### PR TITLE
feat: add MVP_MODE flag to toggle full vs MVP feature set

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -228,6 +228,11 @@ class Settings(BaseSettings):
     eight_by_eight_enabled: bool = False
     eight_by_eight_poll_interval_minutes: int = 30
 
+    # --- MVP Mode ---
+    # When True, disables: Dashboard/Analytics, Enrichment, Teams, Task Manager
+    # Set MVP_MODE=false in .env to re-enable all features
+    mvp_mode: bool = True
+
     # --- Prospecting ---
     prospecting_enabled: bool = True
     prospecting_min_fit_for_contacts: int = 60

--- a/app/jobs/__init__.py
+++ b/app/jobs/__init__.py
@@ -8,11 +8,13 @@ from loguru import logger
 
 
 def register_all_jobs(scheduler, settings):
-    """Register all background jobs from domain modules."""
+    """Register all background jobs from domain modules.
+
+    When MVP_MODE is enabled, enrichment and Teams alert jobs are skipped.
+    """
     from .core_jobs import register_core_jobs
     from .eight_by_eight_jobs import register_eight_by_eight_jobs
     from .email_jobs import register_email_jobs
-    from .enrichment_jobs import register_enrichment_jobs
     from .health_jobs import register_health_jobs
     from .inventory_jobs import register_inventory_jobs
     from .knowledge_jobs import register_knowledge_jobs
@@ -21,11 +23,9 @@ def register_all_jobs(scheduler, settings):
     from .prospecting_jobs import register_prospecting_jobs
     from .sourcing_refresh_jobs import register_sourcing_refresh_jobs
     from .tagging_jobs import register_tagging_jobs
-    from .teams_alert_jobs import register_teams_alert_jobs
 
     register_core_jobs(scheduler, settings)
     register_email_jobs(scheduler, settings)
-    register_enrichment_jobs(scheduler, settings)
     register_inventory_jobs(scheduler, settings)
     register_offers_jobs(scheduler, settings)
     register_prospecting_jobs(scheduler, settings)
@@ -34,8 +34,18 @@ def register_all_jobs(scheduler, settings):
     register_maintenance_jobs(scheduler, settings)
     register_health_jobs(scheduler, settings)
     register_eight_by_eight_jobs(scheduler, settings)
-    register_teams_alert_jobs(scheduler, settings)
     register_knowledge_jobs(scheduler, settings)
+
+    # Full-version-only jobs (disabled in MVP mode)
+    if not settings.mvp_mode:
+        from .enrichment_jobs import register_enrichment_jobs
+        from .teams_alert_jobs import register_teams_alert_jobs
+
+        register_enrichment_jobs(scheduler, settings)
+        register_teams_alert_jobs(scheduler, settings)
+        logger.info("Full mode: enrichment + Teams alert jobs registered")
+    else:
+        logger.info("MVP mode: skipping enrichment + Teams alert jobs")
 
     job_count = len(scheduler.get_jobs())
     logger.info(f"APScheduler configured with {job_count} jobs")

--- a/app/main.py
+++ b/app/main.py
@@ -982,7 +982,8 @@ from .routers.proactive import router as proactive_router
 app.include_router(proactive_router)
 from .routers.performance import router as performance_router
 
-app.include_router(performance_router)
+if not settings.mvp_mode:
+    app.include_router(performance_router)
 from .routers.admin import router as admin_router
 
 app.include_router(admin_router)
@@ -991,7 +992,8 @@ from .routers.emails import router as emails_router
 app.include_router(emails_router)
 from .routers.enrichment import router as enrichment_router
 
-app.include_router(enrichment_router)
+if not settings.mvp_mode:
+    app.include_router(enrichment_router)
 from .routers.documents import router as documents_router
 
 app.include_router(documents_router)
@@ -1004,7 +1006,8 @@ from .routers.command_center import router as command_center_router
 app.include_router(command_center_router)
 from .routers.dashboard import router as dashboard_router
 
-app.include_router(dashboard_router)
+if not settings.mvp_mode:
+    app.include_router(dashboard_router)
 from .routers.prospect_pool import router as prospect_pool_router
 from .routers.prospect_suggested import router as prospect_suggested_router
 
@@ -1013,14 +1016,16 @@ app.include_router(prospect_suggested_router)
 
 from .routers.apollo_sync import router as apollo_sync_router
 
-app.include_router(apollo_sync_router)
+if not settings.mvp_mode:
+    app.include_router(apollo_sync_router)
 
-try:
-    from .routers.explorium import router as explorium_router
+if not settings.mvp_mode:
+    try:
+        from .routers.explorium import router as explorium_router
 
-    app.include_router(explorium_router)
-except ModuleNotFoundError:
-    pass  # explorium router not in this branch / optional
+        app.include_router(explorium_router)
+    except ModuleNotFoundError:
+        pass  # explorium router not in this branch / optional
 
 from .routers.nc_admin import router as nc_admin_router
 
@@ -1037,7 +1042,8 @@ app.include_router(notifications_router)
 
 from .routers.teams_actions import router as teams_actions_router
 
-app.include_router(teams_actions_router)
+if not settings.mvp_mode:
+    app.include_router(teams_actions_router)
 
 from .routers.tagging_admin import router as tagging_admin_router
 
@@ -1053,7 +1059,8 @@ app.include_router(activity_router)
 
 from .routers.teams_alerts import router as teams_alerts_router
 
-app.include_router(teams_alerts_router)
+if not settings.mvp_mode:
+    app.include_router(teams_alerts_router)
 
 from .routers.knowledge import insights_router as knowledge_insights_router
 from .routers.knowledge import router as knowledge_router
@@ -1066,8 +1073,9 @@ app.include_router(knowledge_sprinkles_router)
 from .routers.task import my_tasks_router
 from .routers.task import router as task_router
 
-app.include_router(task_router)
-app.include_router(my_tasks_router)
+if not settings.mvp_mode:
+    app.include_router(task_router)
+    app.include_router(my_tasks_router)
 
 # Strategic Vendors (per-buyer assignments with 39-day TTL)
 from .routers.strategic import router as strategic_router

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -60,6 +60,7 @@ async def index(request: Request, db: Session = Depends(get_db)):
             "is_admin": is_admin,
             "is_manager": is_manager,
             "user_role": user_role,
+            "mvp_mode": settings.mvp_mode,
             "app_version": APP_VERSION,
             "vite_css_tags": vite_css_tags(APP_VERSION),
             "vite_js_tags": vite_js_tags(APP_VERSION),

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -180,6 +180,7 @@
     <button type="button" class="sb-scroll-arrow sb-scroll-up" id="sbScrollUp" onclick="document.querySelector('.sidebar-nav').scrollBy({top:-80,behavior:'smooth'})" aria-label="Scroll up"><svg viewBox="0 0 24 24" width="14" height="14"><polyline points="18 15 12 9 6 15"/></svg></button>
     <nav class="sidebar-nav">
         <!-- Command Center -->
+        {% if not mvp_mode %}
         <div class="sb-top-gradient sb-top-gradient-cc" data-section="cc"></div>
         <div class="sb-nav-group sb-cc-group" data-section="cc" style="--section-color:var(--blue);--section-dot:linear-gradient(135deg,#3b6ea8,#1e3a5f);--section-border:rgba(59,110,168,.18)">
             <div class="sb-section-dot"></div>
@@ -193,6 +194,7 @@
                 <button type="button" class="sb-nav-btn" id="navScorecard" data-tip="Scorecard" onclick="sidebarNav('scorecard',this)"><span class="sb-nav-icon"><svg viewBox="0 0 24 24"><rect x="18" y="3" width="4" height="18"/><rect x="10" y="8" width="4" height="13"/><rect x="2" y="13" width="4" height="8"/></svg></span><span class="sb-label"> Scorecard</span></button>
             </div>
         </div>
+        {% endif %}
         <!-- Opportunity -->
         <div class="sb-top-gradient" data-section="sourcing"></div>
         <div class="sb-nav-group" data-section="sourcing" style="--section-color:var(--sourcing-color);--section-dot:var(--sourcing-dot);--section-border:var(--sourcing-border)">
@@ -1300,6 +1302,7 @@
         </div>
     </div>
 
+    {% if not mvp_mode %}
     <!-- VIEW: Dashboard -->
     <div id="view-dashboard" class="hidden">
         <div style="padding:16px 0 8px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px">
@@ -1333,6 +1336,7 @@
         <div id="scPersonalSummary"></div>
         <div id="scContent"><p class="empty">Loading...</p></div>
     </div>
+    {% endif %}
 
 
     <!-- VIEW: Settings (admin only) -->
@@ -1381,7 +1385,7 @@
         <div id="settings-apihealth" class="settings-panel hidden">
             <div class="tabs" id="apiHealthTabs">
                 <button type="button" class="tab on" onclick="switchApiHealthTab('dashboard',this)">API Health</button>
-                <button type="button" class="tab" onclick="switchApiHealthTab('teams',this)">Teams</button>
+                {% if not mvp_mode %}<button type="button" class="tab" onclick="switchApiHealthTab('teams',this)">Teams</button>{% endif %}
             </div>
 
             <!-- API Health Dashboard -->
@@ -1535,7 +1539,7 @@
 <!-- System notification bell — placeholder, wired up when notification service is registered -->
 {% endif %}
 
-<script type="application/json" id="app-config">{"userName":"{{ user_name }}","userEmail":"{{ user_email }}","isAdmin":{{ "true" if is_admin else "false" }},"isManager":{{ "true" if is_manager else "false" }},"userRole":"{{ user_role }}"}</script>
+<script type="application/json" id="app-config">{"userName":"{{ user_name }}","userEmail":"{{ user_email }}","isAdmin":{{ "true" if is_admin else "false" }},"isManager":{{ "true" if is_manager else "false" }},"userRole":"{{ user_role }}","mvpMode":{{ "true" if mvp_mode else "false" }}}</script>
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 {{ vite_js_tags }}
 {% endif %}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,6 +195,25 @@ class TestTypeCoercion:
                 _make()
 
 
+class TestMvpMode:
+    """MVP_MODE flag controls feature availability."""
+
+    def test_mvp_mode_default_true(self):
+        with patch.dict(os.environ, {}, clear=True):
+            s = _make()
+        assert s.mvp_mode is True
+
+    def test_mvp_mode_disabled(self):
+        with patch.dict(os.environ, {"MVP_MODE": "false"}, clear=True):
+            s = _make()
+        assert s.mvp_mode is False
+
+    def test_mvp_mode_enabled_explicitly(self):
+        with patch.dict(os.environ, {"MVP_MODE": "true"}, clear=True):
+            s = _make()
+        assert s.mvp_mode is True
+
+
 class TestSecretKeyFallback:
     """SECRET_KEY env var maps to secret_key field."""
 


### PR DESCRIPTION
Adds MVP_MODE=true (default) to config. When enabled, disables:
- Dashboard & Analytics (command center, scorecard, performance)
- Enrichment (Apollo sync, Explorium, enrichment router/jobs)
- Microsoft Teams integration (actions, alerts, alert jobs)
- Task Manager

Full version preserved as git tag 'all-inclusive-v1'.
Set MVP_MODE=false in .env to re-enable all features.

https://claude.ai/code/session_01W2vMiRiRWnXritbjyrMCiC