### PR TITLE
Rfq frontend modularity

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,3 +1,12 @@
+import {
+    _updateBulkFollowUpBtn,
+    cancelFollowUpsRequests,
+    configureRfqFollowups,
+    loadFollowUpsPanel,
+    sendBulkFollowUp,
+    sendFollowUp,
+} from './rfq/followups.js';
+
 /* AVAIL v1.2.0 — CRM, offers, quotes, target pricing */
 
 // ── Bootstrap: read server-rendered config from JSON block ────────────
@@ -3135,6 +3144,19 @@ let _serverSearchActive = false; // True when server-side search returned filter
 let _currentMainView = localStorage.getItem('avail_main_view') || 'sales';  // 'sales' | 'purchasing' | 'archive'
 if (_currentMainView === 'sourcing') _currentMainView = 'purchasing';  // migrate legacy stored value
 let _archiveGroupsOpen = new Set();  // company_id or customer_display keys that are expanded
+
+configureRfqFollowups({
+    apiFetch,
+    confirmAction,
+    showToast,
+    esc,
+    escAttr,
+    guardBtn,
+    getCurrentMainView: () => _currentMainView,
+    refreshActivity: () => {
+        if (typeof loadActivity === 'function') loadActivity();
+    },
+});
 
 
 
@@ -10236,13 +10258,12 @@ function applyDropdownFilters(data) {
 
 // ── v7 Main View Switcher ───────────────────────────────────────────────
 let _archiveAbort = null;   // AbortController for archive fetch
-let _followUpsAbort = null; // AbortController for follow-ups fetch
 let _pollAbort = null;      // AbortController for auto-poll replies
 
 function _cancelTabInflight() {
     // Cancel in-flight requests from previous tab
     if (_archiveAbort) { try { _archiveAbort.abort(); } catch(e){} _archiveAbort = null; }
-    if (_followUpsAbort) { try { _followUpsAbort.abort(); } catch(e){} _followUpsAbort = null; }
+    cancelFollowUpsRequests();
     if (_pollAbort) { try { _pollAbort.abort(); } catch(e){} _pollAbort = null; }
     if (_reqAbort) { try { _reqAbort.abort(); } catch(e){} _reqAbort = null; }
     // Cancel in-flight score fetches
@@ -10514,19 +10535,6 @@ function setMainPill(view) {
 
 const searchRequisitions = debounce(query => loadRequisitions(query), 300);
 
-async function sendFollowUp(contactId, vendorName) {
-    confirmAction('Send Follow-Up', 'Send follow-up email to ' + vendorName + '?', async function() {
-        if (sendFollowUp._busy) return; sendFollowUp._busy = true;
-        try {
-            const data = await apiFetch(`/api/follow-ups/${contactId}/send`, { method: 'POST', body: {} });
-            showToast(data.message || `Follow-up sent to ${vendorName}`, 'success');
-            if (typeof loadActivity === 'function') loadActivity();
-            loadFollowUpsPanel();
-        } catch (e) { showToast('Failed to send follow-up', 'error'); }
-        finally { sendFollowUp._busy = false; }
-    });
-}
-
 // ── Deal Board ─────────────────────────────────────────────────────────
 // Renders a kanban-style board grouping requisitions by deal stage.
 // Called by: setMainView('deals')
@@ -10633,72 +10641,6 @@ async function _dealCardClick(reqId) {
     }
 }
 
-// ── Follow-Ups Dashboard Panel ───────────────────────────────────────────
-async function loadFollowUpsPanel() {
-    const panel = document.getElementById('followUpsPanel');
-    if (!panel) return;
-    if (_currentMainView === 'archive') { panel.style.display = 'none'; return; }
-    if (_followUpsAbort) try { _followUpsAbort.abort(); } catch(e){}
-    _followUpsAbort = new AbortController();
-    try {
-        const data = await apiFetch('/api/follow-ups', { signal: _followUpsAbort.signal });
-        if (_currentMainView === 'archive') return; // stale — user switched tabs
-        const followUps = data.follow_ups || [];
-        if (!followUps.length) { panel.style.display = 'none'; return; }
-        // Group by requisition
-        const groups = {};
-        for (const fu of followUps) {
-            const key = fu.requisition_id || 0;
-            if (!groups[key]) groups[key] = { name: fu.requisition_name || 'Unknown Requirement', items: [] };
-            groups[key].items.push(fu);
-        }
-        let html = `<div class="card" style="margin:0 16px 12px;padding:12px;border-left:3px solid var(--amber)">
-            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
-                <span style="font-weight:700;font-size:13px;color:var(--amber)">Awaiting Vendor Replies (${followUps.length})</span>
-                <button class="btn btn-warning btn-sm" id="bulkFollowUpBtn" onclick="sendBulkFollowUp()" style="font-size:10px;display:none">Send Selected</button>
-            </div>`;
-        for (const [rfqId, g] of Object.entries(groups)) {
-            html += `<div style="margin-bottom:6px"><span style="font-weight:600;font-size:12px">${esc(g.name)}</span></div>`;
-            for (const fu of g.items) {
-                const dayColor = fu.days_waiting > 5 ? 'var(--red)' : fu.days_waiting > 2 ? 'var(--amber)' : 'var(--green)';
-                html += `<div style="display:flex;align-items:center;gap:8px;padding:3px 0;font-size:11px">
-                    ${fu.contact_id ? `<input type="checkbox" class="fu-cb" data-contact-id="${fu.contact_id}" onchange="_updateBulkFollowUpBtn()">` : ''}
-                    <span style="color:var(--text2)">${esc(fu.vendor_name)}</span>
-                    <span style="color:var(--muted)">${esc(fu.vendor_email || '')}</span>
-                    <span style="color:${dayColor};font-weight:600">${fu.days_waiting}d</span>
-                    ${fu.parts && fu.parts.length ? `<span style="color:var(--muted)">${esc(Array.isArray(fu.parts) ? fu.parts.join(', ') : String(fu.parts))}</span>` : ''}
-                    ${fu.contact_id ? `<button class="btn btn-ghost btn-sm" onclick="sendFollowUp(${fu.contact_id},'${escAttr(fu.vendor_name)}')" style="padding:1px 6px;font-size:10px">Send Now</button>` : ''}
-                </div>`;
-            }
-        }
-        html += '</div>';
-        panel.innerHTML = html;
-        panel.style.display = '';
-    } catch(e) { if (e.name !== 'AbortError') panel.style.display = 'none'; }
-}
-
-function _updateBulkFollowUpBtn() {
-    const checked = document.querySelectorAll('.fu-cb:checked').length;
-    const btn = document.getElementById('bulkFollowUpBtn');
-    if (btn) {
-        btn.style.display = checked > 0 ? '' : 'none';
-        btn.textContent = `Send ${checked} Follow-up${checked > 1 ? 's' : ''}`;
-    }
-}
-
-async function sendBulkFollowUp() {
-    const checked = [...document.querySelectorAll('.fu-cb:checked')];
-    const contactIds = checked.map(cb => parseInt(cb.dataset.contactId)).filter(Boolean);
-    if (!contactIds.length) return;
-    const btn = document.getElementById('bulkFollowUpBtn');
-    await guardBtn(btn, 'Sending…', async () => {
-        const data = await apiFetch('/api/follow-ups/send-batch', {
-            method: 'POST', body: { contact_ids: contactIds }
-        });
-        showToast(`Sent ${data.sent} of ${data.total} follow-ups`, data.sent > 0 ? 'success' : 'error');
-        loadFollowUps();
-    });
-}
 
 async function createRequisition() {
     const name = document.getElementById('nrName')?.value?.trim() || '';

--- a/app/static/rfq/followups.js
+++ b/app/static/rfq/followups.js
@@ -1,0 +1,147 @@
+/**
+ * rfq/followups.js
+ *
+ * Purpose:
+ * Encapsulates RFQ follow-up panel loading and follow-up send actions so the
+ * main frontend bundle does not keep RFQ follow-up behavior inline.
+ *
+ * Business rules enforced:
+ * - Follow-ups are hidden in archive view.
+ * - Bulk follow-up sends must refresh the same follow-up panel they came from.
+ * - Follow-up UI keeps existing inline handler names and DOM contracts.
+ *
+ * Called by:
+ * - app/static/app.js
+ * - inline RFQ follow-up buttons rendered into index.html/app.js templates
+ *
+ * Depends on:
+ * - app/static/app.js to inject shared helpers via configureRfqFollowups()
+ * - DOM elements #followUpsPanel and #bulkFollowUpBtn
+ * - RFQ follow-up API endpoints under /api/follow-ups
+ */
+
+let _followUpsAbort = null;
+
+let _deps = {
+    apiFetch: null,
+    confirmAction: null,
+    showToast: null,
+    esc: null,
+    escAttr: null,
+    guardBtn: null,
+    getCurrentMainView: () => 'sales',
+    refreshActivity: null,
+};
+
+export function configureRfqFollowups(deps) {
+    _deps = { ..._deps, ...(deps || {}) };
+}
+
+export function cancelFollowUpsRequests() {
+    if (_followUpsAbort) {
+        try { _followUpsAbort.abort(); } catch (e) {}
+        _followUpsAbort = null;
+    }
+}
+
+export async function sendFollowUp(contactId, vendorName) {
+    _deps.confirmAction('Send Follow-Up', 'Send follow-up email to ' + vendorName + '?', async function() {
+        if (sendFollowUp._busy) return;
+        sendFollowUp._busy = true;
+        try {
+            const data = await _deps.apiFetch(`/api/follow-ups/${contactId}/send`, { method: 'POST', body: {} });
+            _deps.showToast(data.message || `Follow-up sent to ${vendorName}`, 'success');
+            if (typeof _deps.refreshActivity === 'function') _deps.refreshActivity();
+            await loadFollowUpsPanel();
+        } catch (e) {
+            _deps.showToast('Failed to send follow-up', 'error');
+        } finally {
+            sendFollowUp._busy = false;
+        }
+    });
+}
+
+export async function loadFollowUpsPanel() {
+    const panel = document.getElementById('followUpsPanel');
+    if (!panel) return;
+    if (_deps.getCurrentMainView() === 'archive') {
+        panel.style.display = 'none';
+        return;
+    }
+
+    cancelFollowUpsRequests();
+    _followUpsAbort = new AbortController();
+
+    try {
+        const data = await _deps.apiFetch('/api/follow-ups', { signal: _followUpsAbort.signal });
+        if (_deps.getCurrentMainView() === 'archive') return;
+
+        const followUps = data.follow_ups || [];
+        if (!followUps.length) {
+            panel.style.display = 'none';
+            panel.innerHTML = '';
+            return;
+        }
+
+        const groups = {};
+        for (const fu of followUps) {
+            const key = fu.requisition_id || 0;
+            if (!groups[key]) groups[key] = { name: fu.requisition_name || 'Unknown Requirement', items: [] };
+            groups[key].items.push(fu);
+        }
+
+        let html = `<div class="card" style="margin:0 16px 12px;padding:12px;border-left:3px solid var(--amber)">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
+                <span style="font-weight:700;font-size:13px;color:var(--amber)">Awaiting Vendor Replies (${followUps.length})</span>
+                <button class="btn btn-warning btn-sm" id="bulkFollowUpBtn" onclick="sendBulkFollowUp()" style="font-size:10px;display:none">Send Selected</button>
+            </div>`;
+
+        for (const g of Object.values(groups)) {
+            html += `<div style="margin-bottom:6px"><span style="font-weight:600;font-size:12px">${_deps.esc(g.name)}</span></div>`;
+            for (const fu of g.items) {
+                const dayColor = fu.days_waiting > 5 ? 'var(--red)' : fu.days_waiting > 2 ? 'var(--amber)' : 'var(--green)';
+                html += `<div style="display:flex;align-items:center;gap:8px;padding:3px 0;font-size:11px">
+                    ${fu.contact_id ? `<input type="checkbox" class="fu-cb" data-contact-id="${fu.contact_id}" onchange="_updateBulkFollowUpBtn()">` : ''}
+                    <span style="color:var(--text2)">${_deps.esc(fu.vendor_name)}</span>
+                    <span style="color:var(--muted)">${_deps.esc(fu.vendor_email || '')}</span>
+                    <span style="color:${dayColor};font-weight:600">${fu.days_waiting}d</span>
+                    ${fu.parts && fu.parts.length ? `<span style="color:var(--muted)">${_deps.esc(Array.isArray(fu.parts) ? fu.parts.join(', ') : String(fu.parts))}</span>` : ''}
+                    ${fu.contact_id ? `<button class="btn btn-ghost btn-sm" onclick="sendFollowUp(${fu.contact_id},'${_deps.escAttr(fu.vendor_name)}')" style="padding:1px 6px;font-size:10px">Send Now</button>` : ''}
+                </div>`;
+            }
+        }
+
+        html += '</div>';
+        panel.innerHTML = html;
+        panel.style.display = '';
+    } catch (e) {
+        if (e.name !== 'AbortError') {
+            panel.style.display = 'none';
+        }
+    }
+}
+
+export function _updateBulkFollowUpBtn() {
+    const checked = document.querySelectorAll('.fu-cb:checked').length;
+    const btn = document.getElementById('bulkFollowUpBtn');
+    if (btn) {
+        btn.style.display = checked > 0 ? '' : 'none';
+        btn.textContent = `Send ${checked} Follow-up${checked > 1 ? 's' : ''}`;
+    }
+}
+
+export async function sendBulkFollowUp() {
+    const checked = [...document.querySelectorAll('.fu-cb:checked')];
+    const contactIds = checked.map(cb => parseInt(cb.dataset.contactId)).filter(Boolean);
+    if (!contactIds.length) return;
+
+    const btn = document.getElementById('bulkFollowUpBtn');
+    await _deps.guardBtn(btn, 'Sending…', async () => {
+        const data = await _deps.apiFetch('/api/follow-ups/send-batch', {
+            method: 'POST',
+            body: { contact_ids: contactIds },
+        });
+        _deps.showToast(`Sent ${data.sent} of ${data.total} follow-ups`, data.sent > 0 ? 'success' : 'error');
+        await loadFollowUpsPanel();
+    });
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -345,6 +345,7 @@
             <button type="button" class="m-tab-pill" data-view="purchasing" onclick="mobileReqPillTap('purchasing',this)">Purchasing</button>
             <button type="button" class="m-tab-pill" data-view="archive" onclick="mobileReqPillTap('archive',this)">Archive</button>
         </div>
+        <div id="followUpsPanel" aria-live="polite"></div>
         <div id="reqList" aria-live="polite"><p class="empty">Loading…</p></div>
     </div>
     <!-- Mobile FAB — floating action button for new requisition -->

--- a/tests/test_rfq_frontend_validation.py
+++ b/tests/test_rfq_frontend_validation.py
@@ -32,6 +32,13 @@ def app_js():
 
 
 @pytest.fixture(scope="module")
+def followups_js():
+    """Read RFQ follow-up module raw content."""
+    with open("app/static/rfq/followups.js", "r") as f:
+        return f.read()
+
+
+@pytest.fixture(scope="module")
 def styles_css():
     """Read styles.css raw content."""
     with open("app/static/styles.css", "r") as f:
@@ -45,6 +52,13 @@ class TestJSSyntax:
     def test_app_js_parses(self):
         """app.js passes Node.js syntax check."""
         result = subprocess.run(["node", "-c", "app/static/app.js"], capture_output=True, text=True, timeout=10)
+        assert result.returncode == 0, f"JS syntax error: {result.stderr}"
+
+    def test_followups_js_parses(self):
+        """RFQ follow-up module passes Node.js syntax check."""
+        result = subprocess.run(
+            ["node", "-c", "app/static/rfq/followups.js"], capture_output=True, text=True, timeout=10
+        )
         assert result.returncode == 0, f"JS syntax error: {result.stderr}"
 
     def test_crm_js_parses(self):
@@ -352,6 +366,21 @@ class TestTasksSidebarRight:
         """loadMyTasks uses Promise.allSettled for resilience."""
         assert "Promise.allSettled" in app_js
         assert "Array.isArray(tasksRes.value)" in app_js
+
+
+class TestRfqFollowupsModule:
+    """Verify RFQ follow-up UI has a mount point and dedicated helper module."""
+
+    def test_followups_panel_mount_exists(self, index_html):
+        assert 'id="followUpsPanel"' in index_html
+
+    def test_app_imports_followups_module(self, app_js):
+        assert "from './rfq/followups.js'" in app_js
+        assert "configureRfqFollowups({" in app_js
+
+    def test_bulk_followup_refreshes_panel(self, followups_js):
+        assert "await loadFollowUpsPanel()" in followups_js
+        assert "loadFollowUps()" not in followups_js
 
 
 # ── Scroll-End Detection ────────────────────────────────────────────────


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Modularize RFQ follow-up frontend, restore the follow-up panel mount, and fix the bulk follow-up refresh bug to improve maintainability and user experience.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The RFQ follow-up logic was previously embedded in a large `app.js` file, leading to a runtime error when sending bulk follow-ups due to a call to a non-existent function (`loadFollowUps()`). Additionally, the HTML element for the follow-up panel was missing, preventing the UI from rendering correctly. This PR addresses these issues by extracting the follow-up logic into a dedicated module, fixing the refresh call, and restoring the necessary HTML structure.

<div><a href="https://cursor.com/agents/bc-294fbedb-fd1d-4a37-b1e0-bc380cda6ddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-294fbedb-fd1d-4a37-b1e0-bc380cda6ddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->