### PR TITLE
Hide Command Center and Scorecard from all users

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1235,15 +1235,17 @@ function applyRoleGating() {
         navProspecting.style.display = canProspect ? '' : 'none';
     }
 
-    // ── Dashboard: hide Command Center from buyers ──
+    // ── Dashboard: hide Command Center and Scorecard from all users ──
     const navDashboard = document.getElementById('navDashboard');
     if (navDashboard) {
-        navDashboard.style.display = role === 'buyer' ? 'none' : '';
+        navDashboard.style.display = 'none';
     }
     const ccGroup = document.querySelector('.sb-cc-group');
-    if (ccGroup) ccGroup.style.display = role === 'buyer' ? 'none' : '';
+    if (ccGroup) ccGroup.style.display = 'none';
+    const ccGradient = document.querySelector('.sb-top-gradient-cc');
+    if (ccGradient) ccGradient.style.display = 'none';
     const perfNav = document.getElementById('navScorecard');
-    if (perfNav) perfNav.style.display = '';
+    if (perfNav) perfNav.style.display = 'none';
 
     // ── Settings: admin only ──
     const navSettings = document.getElementById('navSettings');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -151,9 +151,9 @@
 <aside class="sidebar" id="sidebar" role="navigation" aria-label="Main navigation">
     <button type="button" class="sb-scroll-arrow sb-scroll-up" id="sbScrollUp" onclick="document.querySelector('.sidebar-nav').scrollBy({top:-80,behavior:'smooth'})" aria-label="Scroll up"><svg viewBox="0 0 24 24" width="14" height="14"><polyline points="18 15 12 9 6 15"/></svg></button>
     <nav class="sidebar-nav">
-        <!-- Command Center -->
-        <div class="sb-top-gradient sb-top-gradient-cc" data-section="cc"></div>
-        <div class="sb-nav-group sb-cc-group" data-section="cc" style="--section-color:var(--blue);--section-dot:linear-gradient(135deg,#3b6ea8,#1e3a5f);--section-border:rgba(59,110,168,.18)">
+        <!-- Command Center (hidden) -->
+        <div class="sb-top-gradient sb-top-gradient-cc" data-section="cc" style="display:none"></div>
+        <div class="sb-nav-group sb-cc-group" data-section="cc" style="display:none;--section-color:var(--blue);--section-dot:linear-gradient(135deg,#3b6ea8,#1e3a5f);--section-border:rgba(59,110,168,.18)">
             <div class="sb-section-dot"></div>
             <div class="sb-group-header sb-cc-header" id="navCmdCenter" onclick="toggleSidebarGroup(this)" data-tip="Command Center" role="button" tabindex="0">
                 <span class="sb-group-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1" stroke-linejoin="round"><polygon points="7.5,1 12.5,3.8 12.5,9.4 7.5,12.2 2.5,9.4 2.5,3.8"/><polygon points="16.5,1 21.5,3.8 21.5,9.4 16.5,12.2 11.5,9.4 11.5,3.8"/><polygon points="12,10.8 17,13.6 17,19.2 12,22 7,19.2 7,13.6"/></svg></span>
@@ -1439,7 +1439,7 @@
     <button type="button" class="m-more-item" onclick="mobileMoreNav('vendors')"><svg viewBox="0 0 24 24"><path d="M6 2L3 7v13a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V7l-3-5z"/><line x1="3" y1="7" x2="21" y2="7"/><path d="M16 11a4 4 0 0 1-8 0"/></svg> Vendors</button>
     <button type="button" class="m-more-item" onclick="mobileMoreNav('materials')"><svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg> Materials</button>
     <button type="button" class="m-more-item" onclick="mobileMoreNav('buyplans')"><svg viewBox="0 0 24 24"><path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/><path d="M9 14l2 2 4-4"/></svg> Buy Plans</button>
-    <button type="button" class="m-more-item" onclick="mobileMoreNav('scorecard')"><svg viewBox="0 0 24 24"><rect x="18" y="3" width="4" height="18"/><rect x="10" y="8" width="4" height="13"/><rect x="2" y="13" width="4" height="8"/></svg> Scorecard</button>
+    <button type="button" class="m-more-item" onclick="mobileMoreNav('scorecard')" style="display:none"><svg viewBox="0 0 24 24"><rect x="18" y="3" width="4" height="18"/><rect x="10" y="8" width="4" height="13"/><rect x="2" y="13" width="4" height="8"/></svg> Scorecard</button>
     <button type="button" class="m-more-item" onclick="mobileMoreNav('contacts')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg> Contacts</button>
     <button type="button" class="m-more-item" onclick="mobileMoreNav('settings')"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg> Settings</button>
 </div>


### PR DESCRIPTION
## Summary
This PR hides the Command Center and Scorecard sections from all users by updating the role-based gating logic and adding inline display styles to the HTML templates.

## Key Changes
- **Role-based gating logic**: Updated `applyRoleGating()` in `app.js` to hide the Dashboard/Command Center and Scorecard for all users instead of just buyers
  - Changed `navDashboard` display from role-based (`role === 'buyer' ? 'none' : ''`) to always hidden (`'none'`)
  - Changed `.sb-cc-group` display from role-based to always hidden
  - Added hiding of `.sb-top-gradient-cc` gradient element
  - Changed `navScorecard` display from always visible (`''`) to always hidden (`'none'`)

- **HTML template updates**: Added inline `style="display:none"` attributes to prevent flash of content
  - Command Center group section in sidebar
  - Command Center gradient element
  - Scorecard button in mobile navigation menu
  - Updated HTML comments to reflect that these sections are now hidden

## Implementation Details
The changes ensure consistent hiding across both desktop (sidebar navigation) and mobile (more menu) interfaces. The inline styles in the HTML provide immediate hiding before JavaScript executes, preventing visual flicker.

https://claude.ai/code/session_01K5zdycxvnc2r4YBtiC8FGP