### PR TITLE
fix: resolve Docker build failures from dependency conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir -r requirements.txt \
 
 # Install Chromium for Playwright/patchright (self-heal site testing)
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
-RUN patchright install chromium
+RUN python -m patchright install chromium
 
 # Copy app code and Alembic (for migrations at runtime)
 COPY app/ app/

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,3 @@ pydantic-settings==2.13.1
 sse-starlette>=1.6.0
 # HTMX integration helpers for FastAPI
 fasthx>=3.1.0
-fastapi-htmx>=0.5.0


### PR DESCRIPTION
## Summary
- Remove `fastapi-htmx` — requires `fastapi<0.116`, incompatible with our `fastapi==0.135.1`. `fasthx` already provides HTMX integration and is the package actually used in code.
- Fix `patchright install chromium` → `python -m patchright install chromium` since bare `patchright` isn't on PATH during Docker build.

## Test plan
- [x] `docker compose up -d --build` succeeds
- [x] All containers healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)