### PR TITLE
fix: material_cards ON CONFLICT match partial unique index

### DIFF
--- a/app/search_service.py
+++ b/app/search_service.py
@@ -1319,7 +1319,10 @@ def resolve_material_card(mpn: str, db: Session) -> MaterialCard | None:
                 display_mpn=display,
                 search_count=0,
             )
-            .on_conflict_do_nothing(index_elements=["normalized_mpn"])
+            .on_conflict_do_nothing(
+                index_elements=["normalized_mpn"],
+                index_where=MaterialCard.deleted_at.is_(None),
+            )
         )
         result = db.execute(stmt)
         db.flush()


### PR DESCRIPTION
## Summary
- Add `index_where=MaterialCard.deleted_at.is_(None)` to the `on_conflict_do_nothing` call in `resolve_material_card()`
- The unique index on `normalized_mpn` is partial (`WHERE deleted_at IS NULL`), so PostgreSQL requires the matching `index_where` clause
- Without this, every 5-minute batch results job fails with `InvalidColumnReference`, cascading into a rolled-back transaction that also blocks `vendor_responses` updates

## Test plan
- [x] Code path is PostgreSQL-only (`if dialect == "postgresql"`) — SQLite tests unaffected
- [x] Passes ruff, mypy, all pre-commit hooks
- [ ] Verify in production: batch results job no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)