### PR TITLE
Default /v2 to requisitions view instead of dashboard after login

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -177,7 +177,7 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
     elif "/requisitions" in path:
         current_view = "requisitions"
     else:
-        current_view = "dashboard"
+        current_view = "requisitions"
 
     # Determine the correct partial URL for initial content load
     partial_url = f"/v2/partials/{current_view}"

--- a/tests/test_htmx_views.py
+++ b/tests/test_htmx_views.py
@@ -44,6 +44,23 @@ class TestFullPageLoads:
         assert "AvailAI" in resp.text
 
 
+class TestDefaultViewIsRequisitions:
+    """Test that /v2 root defaults to requisitions view, not dashboard."""
+
+    def test_v2_root_default_view_is_requisitions(self):
+        """The view-detection logic should default to 'requisitions' for bare /v2."""
+        # Simulate the path-matching logic from v2_page handler
+        path = "/v2"
+        if "/requisitions" in path:
+            current_view = "requisitions"
+        elif "/search" in path:
+            current_view = "search"
+        else:
+            current_view = "requisitions"  # Should NOT be "dashboard"
+        assert current_view == "requisitions"
+        assert f"/v2/partials/{current_view}" == "/v2/partials/requisitions"
+
+
 class TestLoginPage:
     """Test that unauthenticated users see the login page."""
 


### PR DESCRIPTION
The dashboard partial was failing to load, leaving a blank page with just
the logo after login. Changed the default view from "dashboard" to
"requisitions" so users land on the requisitions screen immediately.

https://claude.ai/code/session_018uWLAm9akwdY8dR5SzNoGB