### PR TITLE
fix: route requisitions through v2 shell instead of standalone /requi…

### DIFF
--- a/app/routers/htmx/core.py
+++ b/app/routers/htmx/core.py
@@ -38,13 +38,6 @@ from ._helpers import _base_ctx, _vite_assets, escape_like, router, templates
 @router.get("/strategic", response_class=HTMLResponse)
 async def htmx_page(request: Request, db: Session = Depends(get_db)):
     """Full page load — serves base.html with initial content via HTMX."""
-    from fastapi.responses import RedirectResponse
-
-    # Redirect /requisitions to the redesigned standalone page
-    path = request.url.path
-    if path in ("/requisitions", "/requisitions/"):
-        return RedirectResponse(url="/requisitions2", status_code=302)
-
     user = get_user(request, db)
     if not user:
         return templates.TemplateResponse("htmx/login.html", {"request": request, **_vite_assets()})

--- a/app/templates/htmx/base.html
+++ b/app/templates/htmx/base.html
@@ -55,9 +55,12 @@
            x-show="!$store.sidebar.collapsed">Opportunity</p>
         <div x-show="$store.sidebar.collapsed" class="border-t border-brand-800 my-2 mx-2"></div>
 
-        {# Requisitions — full page nav to /requisitions2 (standalone redesigned page) #}
-        <a href="/requisitions2"
-           hx-boost="false"
+        {# Requisitions — HTMX partial swap inside v2 shell #}
+        <a href="/v2/requisitions"
+           hx-get="/v2/partials/requisitions"
+           hx-target="#main-content"
+           hx-push-url="/v2/requisitions"
+           preload="mouseover"
            @click="currentView = 'requisitions'"
            :class="currentView === 'requisitions' ? 'bg-brand-900 text-white' : 'text-brand-200 hover:bg-brand-800 hover:text-white'"
            class="group flex items-center px-3 py-2 text-sm font-medium rounded-md transition-colors">
@@ -161,8 +164,11 @@
           </button>
         </div>
         <nav class="px-3 py-4 space-y-1">
-          {# Requisitions — full page nav #}
-          <a href="/requisitions2" hx-boost="false"
+          {# Requisitions — HTMX partial swap inside v2 shell #}
+          <a href="/v2/requisitions"
+             hx-get="/v2/partials/requisitions"
+             hx-target="#main-content"
+             hx-push-url="/v2/requisitions"
              @click="currentView = 'requisitions'; sidebarOpen = false"
              :class="currentView === 'requisitions' ? 'bg-brand-900 text-white' : 'text-brand-200 hover:bg-brand-800 hover:text-white'"
              class="flex items-center px-3 py-2 text-sm font-medium rounded-md">Requisitions</a>
@@ -260,8 +266,11 @@
   {# ── Mobile bottom nav (5 items) ──────────────────────────── #}
   <nav class="lg:hidden fixed bottom-0 inset-x-0 bg-white border-t border-brand-200 z-40 flex justify-around items-center"
        style="padding-bottom: calc(4px + env(safe-area-inset-bottom, 0px));">
-    {# Requisitions — full page nav #}
-    <a href="/requisitions2" hx-boost="false"
+    {# Requisitions — HTMX partial swap inside v2 shell #}
+    <a href="/v2/requisitions"
+       hx-get="/v2/partials/requisitions"
+       hx-target="#main-content"
+       hx-push-url="/v2/requisitions"
        @click="currentView = 'requisitions'"
        :class="currentView === 'requisitions' ? 'text-brand-500' : 'text-gray-400'"
        class="flex flex-col items-center justify-center py-2 px-1 min-h-[44px] min-w-[44px] text-xs font-medium">


### PR DESCRIPTION
…sitions2

Remove the redirect from /v2/requisitions to /requisitions2 in htmx/core.py. Update all 3 nav links (desktop sidebar, mobile drawer, bottom nav) in base.html to use HTMX partial swaps into #main-content instead of full-page navigation with hx-boost=false.

Requisitions now loads inside the v2 shell like every other page, using the more complete System B partials (712-line router with all 7 tabs).

https://claude.ai/code/session_01ME2jh1GBqn9zk9Y2JRvZvK