### PR TITLE
Fix 10 Sentry issues across jobs, services, and routers

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -527,6 +527,8 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
                 match_method = "domain"
 
         try:
+            # Use savepoint so a single message failure doesn't poison the session
+            nested = db.begin_nested()
             vr = VendorResponse(
                 requisition_id=matched_req_id,
                 contact_id=matched_contact.id if matched_contact else None,
@@ -562,6 +564,8 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
             if matched_contact:
                 _progress_contact_status(matched_contact, vr, db)
 
+            nested.commit()
+
             results.append(
                 {
                     "id": vr.id,
@@ -583,7 +587,7 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
             )
         except Exception as e:
             logger.error(f"Failed to save inbox message {msg_id[:20]}: {e}")
-            db.rollback()
+            nested.rollback()
             continue
 
     # ── Submit AI batch or fall back to sequential parsing ──
@@ -849,19 +853,31 @@ async def _parse_sequential_fallback(
     pending: list[VendorResponse],
     db: Session,
 ) -> None:
-    """Fallback: parse emails concurrently (with semaphore) when batch API fails."""
+    """Fallback: parse emails sequentially when batch API fails.
+
+    DB writes are serialized to avoid concurrent access to a single session.
+    AI calls are parallelized, but results are applied one at a time.
+    """
     sem = asyncio.Semaphore(5)
 
     async def _parse_one(vr):
         async with sem:
             try:
-                parsed = await parse_response_ai(vr.body, vr.subject)
-                if parsed:
-                    _apply_parsed_result(vr, parsed, db)
+                return vr, await parse_response_ai(vr.body, vr.subject)
             except Exception as e:
                 logger.warning(f"Sequential AI parse failed for VR {vr.id}: {e}")
+                return vr, None
 
-    await asyncio.gather(*[_parse_one(vr) for vr in pending])
+    results = await asyncio.gather(*[_parse_one(vr) for vr in pending])
+
+    # Apply results serially to avoid concurrent session writes
+    for vr, parsed in results:
+        if parsed:
+            try:
+                _apply_parsed_result(vr, parsed, db)
+            except Exception as e:
+                logger.warning(f"Failed to apply parsed result for VR {vr.id}: {e}")
+                db.rollback()
 
 
 def _apply_parsed_result(vr: VendorResponse, parsed: dict, db: Session = None) -> None:

--- a/app/jobs/core_jobs.py
+++ b/app/jobs/core_jobs.py
@@ -225,11 +225,15 @@ async def _job_batch_results():
             logger.info(f"Batch processing: {batch_applied} results applied")
     except asyncio.TimeoutError:
         logger.error("Batch results processing timed out (120s)")
-        db.rollback()
     except Exception as e:
         logger.error(f"Batch results processing error: {e}")
-        db.rollback()
     finally:
+        # process_batch_results handles its own commit/rollback per batch;
+        # rollback here only cleans up any uncommitted leftovers safely
+        try:
+            db.rollback()
+        except Exception:
+            pass
         db.close()
 
 

--- a/app/jobs/maintenance_jobs.py
+++ b/app/jobs/maintenance_jobs.py
@@ -106,16 +106,21 @@ async def _job_auto_dedup():
 
 @_traced_job
 async def _job_reset_connector_errors():
-    """Reset 24h error counters on all API sources."""
+    """Reset 24h error counters on all API sources (batched to avoid lock timeout)."""
     from ..database import SessionLocal
     from ..models import ApiSource
 
     db = SessionLocal()
     try:
-        db.query(ApiSource).filter(ApiSource.error_count_24h > 0).update(
-            {"error_count_24h": 0}, synchronize_session="fetch"
-        )
-        db.commit()
+        # Fetch IDs first, then update in small batches to avoid lock contention
+        source_ids = [s.id for s in db.query(ApiSource.id).filter(ApiSource.error_count_24h > 0).all()]
+        batch_size = 50
+        for i in range(0, len(source_ids), batch_size):
+            batch = source_ids[i : i + batch_size]
+            db.query(ApiSource).filter(ApiSource.id.in_(batch)).update(
+                {"error_count_24h": 0}, synchronize_session="fetch"
+            )
+            db.commit()
     except Exception:
         logger.exception("Reset connector error counts failed")
         db.rollback()

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -182,6 +182,8 @@ def _password_login_enabled() -> bool:
 
 def _verify_password(stored: str, password: str) -> bool:
     """Verify PBKDF2-HMAC-SHA256 password hash stored as 'salt_b64$hash_b64'."""
+    if not stored or "$" not in stored:
+        return False
     try:
         salt_b64, hash_b64 = stored.split("$", 1)
         salt = base64.b64decode(salt_b64)

--- a/app/routers/requisitions/requirements.py
+++ b/app/routers/requisitions/requirements.py
@@ -399,11 +399,11 @@ async def add_requirements(
             target_qty=parsed.target_qty,
             target_price=parsed.target_price,
             substitutes=deduped_subs[:20],
-            condition=parsed.condition or "",
+            condition=normalize_condition(parsed.condition) if parsed.condition else None,
             date_codes=parsed.date_codes or "",
             firmware=parsed.firmware or "",
             hardware_codes=parsed.hardware_codes or "",
-            packaging=parsed.packaging or "",
+            packaging=normalize_packaging(parsed.packaging) if parsed.packaging else None,
             notes=parsed.notes or "",
         )
         db.add(r)

--- a/app/routers/requisitions2.py
+++ b/app/routers/requisitions2.py
@@ -115,6 +115,8 @@ async def requisitions_stream(request: Request, _user: User = Depends(require_us
                 except asyncio.TimeoutError:
                     # Send keepalive comment to prevent connection timeout
                     yield ": keepalive\n\n"
+                except asyncio.CancelledError:
+                    break
                 except Exception as e:
                     logger.error(f"SSE stream error: {e}")
                     yield "event: error\ndata: Internal error\n\n"

--- a/app/routers/vendor_analytics.py
+++ b/app/routers/vendor_analytics.py
@@ -191,8 +191,29 @@ def _vendor_parts_summary_query(db, norm, display_name, q, limit, offset):
         params["mpn_pattern"] = "%"
         params["has_filter"] = False
 
+    dialect = db.bind.dialect.name if db.bind else ""
+
+    # PostgreSQL supports array_agg(col ORDER BY ...) for "last" value;
+    # SQLite does not, so we fall back to a correlated subquery.
+    if dialect == "postgresql":
+        last_price_expr = "(array_agg(unit_price ORDER BY created_at DESC))[1]"
+        last_qty_expr = "(array_agg(qty_available ORDER BY created_at DESC))[1]"
+    else:
+        last_price_expr = (
+            "(SELECT s2.unit_price FROM sightings s2"
+            " WHERE s2.vendor_name_normalized = sightings.vendor_name_normalized"
+            " AND COALESCE(s2.mpn_matched, '') = COALESCE(sightings.mpn_matched, '')"
+            " ORDER BY s2.created_at DESC LIMIT 1)"
+        )
+        last_qty_expr = (
+            "(SELECT s2.qty_available FROM sightings s2"
+            " WHERE s2.vendor_name_normalized = sightings.vendor_name_normalized"
+            " AND COALESCE(s2.mpn_matched, '') = COALESCE(sightings.mpn_matched, '')"
+            " ORDER BY s2.created_at DESC LIMIT 1)"
+        )
+
     rows = db.execute(
-        sqltext("""
+        sqltext(f"""
         SELECT mpn, manufacturer, sighting_count, first_seen, last_seen, last_price, last_qty
         FROM (
             SELECT
@@ -201,8 +222,8 @@ def _vendor_parts_summary_query(db, norm, display_name, q, limit, offset):
                 COUNT(*) as sighting_count,
                 MIN(created_at) as first_seen,
                 MAX(created_at) as last_seen,
-                (array_agg(unit_price ORDER BY created_at DESC))[1] as last_price,
-                (array_agg(qty_available ORDER BY created_at DESC))[1] as last_qty
+                {last_price_expr} as last_price,
+                {last_qty_expr} as last_qty
             FROM sightings
             WHERE vendor_name_normalized = :norm
               AND mpn_matched IS NOT NULL AND mpn_matched != ''

--- a/app/services/auto_attribution_service.py
+++ b/app/services/auto_attribution_service.py
@@ -11,6 +11,7 @@ Called by: scheduler.py (job_auto_attribute_activities)
 Depends on: activity_service, claude_client, models
 """
 
+import json
 from datetime import datetime, timedelta, timezone
 
 from loguru import logger
@@ -219,7 +220,17 @@ async def _call_claude_for_matching(
         max_tokens=2048,
     )
 
-    if not result or "matches" not in result:
+    if not result:
+        return {}
+
+    # API occasionally returns tool input as JSON string instead of dict
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+
+    if not isinstance(result, dict) or "matches" not in result:
         return {}
 
     return {

--- a/app/services/buyplan_workflow.py
+++ b/app/services/buyplan_workflow.py
@@ -811,7 +811,20 @@ async def verify_po_sent(plan: "BuyPlan", db: "Session") -> list[dict]:
             continue
 
         try:
-            token = await get_valid_token()
+            buyer = db.get(User, line.buyer_id)
+            if not buyer:
+                results.append(
+                    {
+                        "line_id": line.id,
+                        "po_number": line.po_number,
+                        "found": False,
+                        "skipped": True,
+                        "reason": "buyer_not_found",
+                    }
+                )
+                continue
+
+            token = await get_valid_token(buyer, db)
             if not token:
                 results.append(
                     {
@@ -828,7 +841,7 @@ async def verify_po_sent(plan: "BuyPlan", db: "Session") -> list[dict]:
             # Search sent folder for PO number
             messages = await client.search_sent_messages(
                 query=line.po_number,
-                user_id=str(line.buyer.azure_id) if line.buyer else None,
+                user_id=str(buyer.azure_id) if buyer else None,
             )
 
             found = len(messages) > 0
@@ -908,7 +921,7 @@ async def verify_po_sent_v3(plan: "BuyPlan", db: "Session") -> dict:
             continue
 
         try:
-            token = await get_valid_token()
+            token = await get_valid_token(buyer, db)
             if not token:
                 results[line.po_number] = {
                     "verified": False,

--- a/app/services/vendor_affinity_service.py
+++ b/app/services/vendor_affinity_service.py
@@ -208,7 +208,7 @@ def _classify_mpn(mpn: str, manufacturer: str | None, api_key: str) -> str | Non
         client = anthropic.Anthropic(api_key=api_key)
         mfr_hint = f" from {manufacturer}" if manufacturer else ""
         message = client.messages.create(
-            model="claude-haiku-4-20250514",
+            model="claude-haiku-4-5-20251001",
             max_tokens=50,
             messages=[
                 {


### PR DESCRIPTION
## Summary
- **Fix get_valid_token() missing args** in buyplan PO verification — was called without required `user`/`db` params (AVAILAI-AZ, 3016 events)
- **Fix TypeError in auto-attribution** — Claude API can return string instead of dict; now JSON-parses and type-checks (AVAILAI-18/8, super_high actionability)
- **Fix wrong Claude model ID** — `claude-haiku-4-20250514` → `claude-haiku-4-5-20251001` in vendor_affinity_service (AVAILAI-AK)
- **Fix PostgreSQL-only SQL** — `array_agg(ORDER BY)` in vendor parts summary now falls back to correlated subquery on SQLite (AVAILAI-30, 81 events)
- **Fix check constraint violation** — `condition`/`packaging` now normalized with `None` fallback instead of empty string (AVAILAI-16/15, 104 events)
- **Fix password verify crash** — guard against malformed hash missing `$` separator (AVAILAI-59, 131 events)
- **Fix transaction poisoning** — savepoints in poll_inbox loop, serialized DB writes in sequential fallback, safe rollback in batch job caller (AVAILAI-5F/8B/A/K, ~2700 events)
- **Fix SSE stream error** — catch `CancelledError` on client disconnect (AVAILAI-AX/AV/AW)
- **Fix lock timeout** — batched `ApiSource` counter reset to avoid 5s lock timeout (AVAILAI-9X)

## Test plan
- [x] `test_buyplan_po_verify.py` — 23 passed
- [x] `test_auto_attribution_service.py` — 22 passed
- [x] `test_vendor_affinity.py` — 10 passed
- [x] `test_email_service.py` — 130 passed
- [x] `test_jobs_core.py` + `test_maintenance_jobs.py` — 58 passed
- [x] `test_requisitions2_routes.py` — 71 passed
- [x] `test_routers_auth.py` + `test_routers_ai.py` + `test_requirement_entry_fixes.py` — 88 passed
- [x] `test_vendor_analysis_service.py` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)