### PR TITLE
fix(search): bound _fetch_fresh gather with 12s deadline — no more spinner→504

### DIFF
--- a/STABLE.md
+++ b/STABLE.md
@@ -26,6 +26,11 @@ Do not refactor these without explicit approval. Changes here can break startup,
 
 When changing any listed file, run tests and do a quick smoke check before committing.
 
+## Deploy hygiene
+
+- **Droplet's local `main` must be fast-forward-only with `origin/main` before any deploy.** Before running `./deploy.sh`, resync: `git fetch origin && git checkout main && git merge --ff-only origin/main`. If that merge is not fast-forward-able, stop and investigate — someone's local work has diverged from the remote and pushing will either silently fail (non-fast-forward rejection) or risk rewinding `origin/main`. `deploy.sh` currently swallows non-fast-forward rejections; a follow-up PR will make it fail loudly and/or auto-resync.
+- When working on a feature branch on the droplet, prefer `./deploy.sh --no-commit` (rebuild + push-skipped) so the deploy reflects local code without attempting to push a stale `main`.
+
 ## Known tech debt
 
 - **`app/static/htmx_app.js` — `htmx:afterSwap` Alpine.initTree gate uses a hardcoded ID allowlist** (`lead-drawer-content`, `rq2-table`). When future HTMX-swapped regions contain Alpine directives (`x-*`), they must be added manually to this list or their directives won't re-bind after swap. Fragile. Future refactor idea: trigger `initTree` whenever the swap target subtree contains any element with an `x-*` attribute, so new regions get covered automatically. Not urgent — Alpine's own MutationObserver handles most cases, and the allowlist is a belt-and-suspenders fallback. Captured 2026-04-21 during the opportunity-table v2 merge.

--- a/app/config.py
+++ b/app/config.py
@@ -180,6 +180,10 @@ class Settings(BaseSettings):
 
     # --- Search ---
     search_concurrency_limit: int = 10
+    # Total wall-clock budget for one _fetch_fresh() fan-out. Slower connectors
+    # are cancelled when exceeded so the orchestrator returns partial results
+    # well under Caddy's 30s lb_try_duration.
+    search_total_timeout_s: float = 12.0
 
     # --- Contact intelligence ---
     contact_scoring_enabled: bool = True

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -927,8 +927,45 @@ async def _fetch_fresh(pns: list[str], db: Session) -> tuple[list[dict], list[di
         async with sem:
             return await _run_one(conn, pn)
 
-    tasks = [_throttled(conn, pn) for pn in pns for conn in connectors]
-    results_lists = await asyncio.gather(*tasks, return_exceptions=True)
+    pairs = [(conn, pn) for pn in pns for conn in connectors]
+    task_objs = [asyncio.create_task(_throttled(conn, pn)) for conn, pn in pairs]
+
+    # Bounded deadline: one slow/hung connector must not block the orchestrator.
+    # Tasks still pending when the budget expires are cancelled and recorded as
+    # errored in stats_updates. CancelledError is a BaseException in 3.8+, so
+    # _run_one's except-Exception doesn't swallow it — pending tasks finish
+    # cancelled rather than returning [] and are skipped in results_lists below.
+    if task_objs:
+        _done, pending = await asyncio.wait(task_objs, timeout=settings.search_total_timeout_s)
+    else:
+        pending = set()
+    if pending:
+        logger.warning(
+            "Search budget {:.1f}s exceeded; cancelling {}/{} pending connector tasks",
+            settings.search_total_timeout_s,
+            len(pending),
+            len(task_objs),
+        )
+        for t in pending:
+            t.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        budget_ms = int(settings.search_total_timeout_s * 1000)
+        pending_set = set(pending)
+        for (conn, _pn), t in zip(pairs, task_objs):
+            if t in pending_set:
+                source_name = _CONNECTOR_SOURCE_MAP.get(conn.__class__.__name__)
+                if source_name:
+                    stats_updates.append((source_name, 0, budget_ms, "search budget exceeded"))
+
+    results_lists: list = []
+    for t in task_objs:
+        if t.cancelled():
+            continue
+        exc = t.exception()
+        if exc is not None:
+            results_lists.append(exc)
+        else:
+            results_lists.append(t.result())
 
     # Apply stats to DB in one pass — safe, sequential, after gather completes
     try:

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -62,7 +62,13 @@ search_service.py (orchestrator)
     |
     +---> ai_part_normalizer.py --> Claude API (normalize MPN)
     |
-    +---> asyncio.gather() -- ALL connectors fire in parallel:
+    +---> asyncio.wait(tasks, timeout=settings.search_total_timeout_s)
+    |     -- ALL connectors fire in parallel, bounded by the search budget
+    |     (default 12s, env SEARCH_TOTAL_TIMEOUT_S). Pending tasks when the
+    |     deadline expires are cancelled and recorded in source_stats with
+    |     error="search budget exceeded"; completed connectors' results are
+    |     preserved so the response degrades gracefully rather than 504.
+    |
     |       +---> nexar.py ----------> Octopart/Nexar API
     |       +---> brokerbin.py ------> BrokerBin API
     |       +---> digikey.py --------> DigiKey API

--- a/tests/test_fetch_fresh_timeout.py
+++ b/tests/test_fetch_fresh_timeout.py
@@ -1,15 +1,14 @@
-"""Phase 1 smoke gate — proves _fetch_fresh lacks an outer timeout wrapper.
+"""Regression gate for _fetch_fresh graceful-degradation budget.
 
 What it does: stubs the connector list with one fast connector and one that
-hangs for 45s, then asserts _fetch_fresh(...) returns within a 15s budget.
+hangs for 45s, then asserts _fetch_fresh(...) returns within a 15s budget,
+preserves the fast connector's result, and records the slow connector as
+errored/timed-out in source_stats.
 
 What calls it: pytest regression suite (`TESTING=1 pytest tests/test_fetch_fresh_timeout.py -v`).
 
-What it depends on: app.search_service._fetch_fresh, tests/conftest.py db_session fixture.
-
-Status: xfail(strict=True) until the async gather at app/search_service.py:931 is
-wrapped with an outer asyncio.wait_for (or equivalent per-task deadline). Once
-wrapped, this test will pass and the xfail marker must be removed.
+What it depends on: app.search_service._fetch_fresh, settings.search_total_timeout_s,
+tests/conftest.py db_session fixture.
 """
 
 import asyncio
@@ -23,12 +22,16 @@ class _FastFakeConnector:
     """Stub connector that returns instantly with one synthetic hit."""
 
     async def search(self, pn: str) -> list[dict]:
+        # Key names must match what _fetch_fresh's dedup + junk-vendor filter
+        # expect (vendor_name, vendor_sku) — see app/search_service.py:971-984
+        # and JUNK_VENDORS in app/shared_constants.py ("" is junk).
         return [
             {
                 "mpn": pn,
-                "vendor": "fast-fake",
+                "vendor_name": "Fast Fake Distributor",
+                "vendor_sku": f"FF-{pn}",
                 "qty": 1,
-                "price": 1.00,
+                "unit_price": 1.00,
                 "source": "fast_fake",
             }
         ]
@@ -42,14 +45,6 @@ class _SlowFakeConnector:
         return []
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Known: app/search_service.py:931 uses bare asyncio.gather with no outer "
-        "wait_for. Remove this xfail once the gather is bounded by a deadline "
-        "(e.g. asyncio.wait_for(gather, timeout=settings.search_total_timeout_s))."
-    ),
-)
 async def test_fetch_fresh_returns_within_budget_when_one_connector_hangs(monkeypatch, db_session):
     """A single hung connector must not block the whole orchestrator.
 
@@ -90,7 +85,7 @@ async def test_fetch_fresh_returns_within_budget_when_one_connector_hangs(monkey
 
     # Fast connector's result must be present — graceful degradation works.
     assert len(results) >= 1, "no results from fast connector despite it returning"
-    assert any(r.get("vendor") == "fast-fake" for r in results)
+    assert any(r.get("vendor_name") == "Fast Fake Distributor" for r in results)
 
     # Slow connector must be recorded as error/timeout in source_stats, not silently dropped.
     slow_stat = next((s for s in stats if s.get("source") == "slow_fake"), None)

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -2567,6 +2567,7 @@ class TestSearchThrottling:
             patch("app.config.settings") as mock_settings,
         ):
             mock_settings.search_concurrency_limit = 2
+            mock_settings.search_total_timeout_s = 5.0
 
             mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
             _setup_mock_connectors(mocks)


### PR DESCRIPTION
## Summary
- Wraps `_fetch_fresh`'s `asyncio.gather` with `asyncio.wait(timeout=settings.search_total_timeout_s)` (default 12s). Pending connector tasks at the deadline are cancelled and recorded in `source_stats` with `error="search budget exceeded"`; completed connectors' results are preserved so the response degrades gracefully instead of returning a Caddy 504.
- Adds `SEARCH_TOTAL_TIMEOUT_S` env-overridable setting.
- Updates `docs/APP_MAP_INTERACTIONS.md` to reflect the bounded-`asyncio.wait` hop and deadline semantics.
- Adds `tests/test_fetch_fresh_timeout.py` — a regression gate that stubs one fast + one hung connector and asserts `_fetch_fresh` returns within 15s with the fast connector's hit preserved and the slow one marked failed.
- Adds a `STABLE.md` "Deploy hygiene" rule: droplet's local `main` must be fast-forward-only with `origin/main` before any deploy (uncovered during Phase 3 when we found local `main` was 89 commits behind).

## Phase 1 failure evidence (why this matters)
- **User symptom:** click Search → spinner → HTTP 504 at 30s, no results.
- **Root cause:** `app/search_service.py:931` was a bare `await asyncio.gather(*tasks, return_exceptions=True)` with no outer deadline. Caddy's `lb_try_duration 30s` (see `Caddyfile`) cut the HTTP connection before gather returned, because any single slow connector blocked the whole orchestrator.
- **Amplifiers observed in live logs (last 6h before fix):**
  - `Nexar: exceeded part limit of 2000` (quota exhausted)
  - `BrokerBin: HTTP 401 Unauthenticated` (key rotated upstream)
  - `Mouser: Invalid unique identifier` (key rotated upstream)
  - `OEMSecrets: ConnectTimeout` (intermittent)
  - `ANTHROPIC_API_KEY not configured` (missing from container env despite being in .env — stale image, separate fix)
  - 140+ `psycopg2.errors.LockNotAvailable … api_sources` from the 15-min health-check job contending with search-path writes on the same rows (separate fix #4)
- Each of those would individually have been survivable if the orchestrator had a wall-clock budget — the fix restores that safety net.

## Test plan
- [x] `TESTING=1 pytest tests/test_fetch_fresh_timeout.py -v` — **1 passed in 12.68s** (was `xfail(strict=True)` in 15.64s before the fix; the marker was removed as part of the landing criteria)
- [x] `TESTING=1 pytest tests/test_search_service.py tests/test_quick_search.py tests/test_manual_search.py tests/test_search_affinity.py tests/test_global_search_service.py tests/test_search_presentation.py tests/test_requisition_service.py tests/test_routers_requisitions.py tests/test_fetch_fresh_timeout.py` — **252 passed in 31.20s**, no regressions
- [x] `ruff check` + pre-commit hooks (ruff / ruff-format / mypy / docformatter / trailing-whitespace / detect-private-key / end-of-file-fixer) all pass
- [ ] Post-merge droplet smoke: click Search in the UI, confirm response < 30s with at least one vendor card (DigiKey / Element14 currently healthy; BrokerBin / Mouser / Nexar will still fail auth/quota until fixes #3 land — that's expected and explicitly acceptable for fix-#1 verification)

## Deploy plan
After merging this PR, on the droplet:
```bash
cd /root/availai
git fetch origin
git checkout main
git pull --ff-only origin main
./deploy.sh --no-commit
# verify the fix:
docker compose logs --tail=100 app | grep -iE "search budget|_fetch_fresh"
docker compose exec -T app python -c "from app.config import settings; print('search_total_timeout_s =', settings.search_total_timeout_s)"
```

## Scope note — fix #1 of 5 in the sourcing-engine repair
1. ✅ **This PR** — bounded gather deadline (graceful-degradation safety net).
2. Disk reclaim + `--no-cache` rebuild to surface `ANTHROPIC_API_KEY` / `SESSION_SECRET` / `ENCRYPTION_SALT` into the container env (ops only, no code change).
3. BrokerBin + Mouser key rotation (external, portal-side).
4. Health-monitor session-scope redesign — `run_health_checks` currently holds a single transaction across all sources, causing `api_sources` row-lock contention with the search path.
5. Final deliverable: pre-SFDC-import checklist.

Follow-ups split out of this PR:
- **Fix #1.5:** make `deploy.sh` fail loudly on non-fast-forward push + auto-resync `main` via `git merge --ff-only origin/main` before push. Separate small PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)