### PR TITLE
fix(requisitions2): load Vite-built assets — unblocks broken /requisitions2 page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -278,8 +278,18 @@ if not os.environ.get("TESTING"):
         ],
     )
 
-_static_dir = "app/static/dist" if os.path.isdir("app/static/dist") else "app/static"
-app.mount("/static", StaticFiles(directory=_static_dir), name="static")
+# Static mount order matters — most specific paths first. Mount the Vite-built
+# hashed bundles at /static/assets/ so hash-named files resolve directly, then
+# mount the source directory at /static/ for everything else (source CSS/JS,
+# public/ images, js/ helpers that aren't bundled). Previously we toggled
+# between source and dist, which made source files 404 whenever a build existed.
+if os.path.isdir("app/static/dist/assets"):
+    app.mount(
+        "/static/assets",
+        StaticFiles(directory="app/static/dist/assets"),
+        name="static-assets",
+    )
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 # Prometheus metrics
 from prometheus_fastapi_instrumentator import Instrumentator

--- a/app/routers/requisitions2.py
+++ b/app/routers/requisitions2.py
@@ -63,6 +63,9 @@ def _parse_filters(request: Request) -> ReqListFilters:
 
 def _table_context(request: Request, filters: ReqListFilters, db: Session, user: User) -> dict:
     """Build the shared context dict for table rendering."""
+    # Import locally to avoid a circular import at module load time.
+    from app.routers.htmx_views import _vite_assets
+
     result = list_requisitions(
         db=db,
         filters=filters,
@@ -70,12 +73,15 @@ def _table_context(request: Request, filters: ReqListFilters, db: Session, user:
         user_role=getattr(user, "role", "sales"),
     )
     users = get_team_users(db)
+    assets = _vite_assets()
     return {
         "request": request,
         **result,
         "user": user,
         "users": users,
         "avail_opp_table_v2_enabled": settings.avail_opp_table_v2,
+        "vite_js": assets["js_file"],
+        "vite_css": assets["css_files"],
     }
 
 

--- a/app/templates/requisitions2/page.html
+++ b/app/templates/requisitions2/page.html
@@ -11,8 +11,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Requisitions — AvailAI</title>
-  <link rel="stylesheet" href="/static/styles.css">
-  <link rel="stylesheet" href="/static/htmx_mobile.css">
+  {# Vite-built CSS bundles — hash-named so cache-busting is automatic.
+     Falls back to source files if Vite manifest isn't loaded. #}
+  {% if vite_css %}
+    {% for css_file in vite_css %}
+    <link rel="stylesheet" href="/static/{{ css_file }}">
+    {% endfor %}
+  {% else %}
+    <link rel="stylesheet" href="/static/styles.css">
+    <link rel="stylesheet" href="/static/htmx_mobile.css">
+  {% endif %}
   <style>
     /* Inline editing — keeps HTMX swap responsive */
     .rq2-editable:hover { background: #f0f4f8; cursor: cell; }
@@ -46,6 +54,11 @@
   <script defer src="https://unpkg.com/@alpinejs/collapse@3.14.8/dist/cdn.min.js"></script>
   <script defer src="https://unpkg.com/@alpinejs/persist@3.14.8/dist/cdn.min.js"></script>
   <script defer src="https://unpkg.com/alpinejs@3.14.8/dist/cdn.min.js"></script>
+  {# Vite-built JS bundle (htmx_app: htmx + alpine + our stores + directives).
+     Falls back to the un-bundled path if Vite manifest isn't loaded. #}
+  {% if vite_js %}
+    <script type="module" src="/static/{{ vite_js }}"></script>
+  {% endif %}
   <script src="/static/js/requisitions2.js" defer></script>
 </head>
 <body class="bg-gray-50 text-gray-900">


### PR DESCRIPTION
## Summary

/requisitions2 was rendering completely unstyled for users: giant unstyled SVG icons, no Tailwind classes, no Alpine directives active. Root cause was three pre-existing issues in the static-asset pipeline that compounded together (dormant until users actually loaded the page after a fresh image build).

## Fixes

**1. `app/templates/requisitions2/page.html`** — hardcoded `/static/styles.css` + `/static/htmx_app.js` now use the Vite manifest like `base.html` does, with a source-file fallback for environments without a build.

**2. `app/routers/requisitions2.py`** — `_table_context()` now calls `_vite_assets()` and injects `vite_css` + `vite_js` so the template actually receives them.

**3. `app/main.py`** — `_static_dir` toggle replaced with dual mount: `/static/assets/*` → `app/static/dist/assets/` (when present), `/static/*` → `app/static/`. Hashed bundles and source files coexist cleanly. Previously the toggle meant either hashed OR source resolved but never both.

## Verification

After rebuild, all 5 asset paths on `/requisitions2` return 200:

```
200  /static/assets/styles-BxOHMow4.css
200  /static/assets/htmx_mobile-Bfcq2ZW3.css
200  /static/assets/htmx_app-CSULb1bc.js
200  /static/js/requisitions2.js
200  /static/styles.css
```

Page HTML correctly references the hashed bundles via the manifest.

## Context

Discovered immediately after #81 shipped. Users loading /requisitions2 got 404s on all the asset paths, masking v2 (and making legacy look broken too). Not a regression from #81 — the bug was dormant because the page.html hardcoded paths happened to work in some deployment states (when dist/ didn't exist). Once `npm run build` produced dist/, the hardcoded paths 404ed.

## Test plan
- [ ] Deploy
- [ ] Load /requisitions2, force-refresh browser
- [ ] Verify v2 visible: colored status dots, coverage meter, deal column, hover action rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)