### PR TITLE
fix(health-monitor): commit per source to release api_sources locks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,8 +44,17 @@ EMAIL_MINING_ENABLED=false
 # Set to false + restart container to revert to legacy rendering.
 AVAIL_OPP_TABLE_V2=true
 
-# ── Session ──
+# ── Session & Encryption ──
 SESSION_SECRET=change-me-to-random-string
+# Optional — extra salt used in Fernet key derivation for EncryptedType columns
+# (users.refresh_token, users.access_token, users.password_hash).
+# Leave unset for dev; the code falls back to a legacy static salt. Set a
+# unique value per deployment for defense-in-depth. Rotation note: changing
+# this value after data has been encrypted makes existing encrypted rows
+# unreadable (Fernet InvalidToken — process_result_value returns None).
+# Jointly load-bearing with SESSION_SECRET — both are inputs to the derived
+# Fernet key. See app/utils/encrypted_type.py.
+ENCRYPTION_SALT=
 
 # ── Admin ──
 ADMIN_EMAILS=mkhoury@trioscs.com

--- a/app/services/health_monitor.py
+++ b/app/services/health_monitor.py
@@ -312,20 +312,24 @@ async def run_health_checks(check_type: str = "ping") -> dict:
 
         check_fn = deep_test_source if check_type == "deep" else ping_source
 
+        # Per-source commit: release api_sources row locks immediately after each
+        # check so the search path (which UPDATEs the same rows after asyncio.gather)
+        # doesn't hit LockNotAvailable while a 15-min health run iterates.
         for source in sources:
             try:
                 result = await check_fn(source, db)
+                db.commit()
                 results["sources"][source.name] = result
                 if result["success"]:
                     results["passed"] += 1
                 else:
                     results["failed"] += 1
             except Exception as e:
+                db.rollback()
                 logger.error("Health check crashed for {}: {}", source.name, e)
                 results["sources"][source.name] = {"success": False, "error": str(e)}
                 results["failed"] += 1
 
-        db.commit()
         logger.info(
             "Health check ({}) complete: {}/{} passed",
             check_type,

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -413,6 +413,84 @@ class TestRunHealthChecks:
         mock_session.rollback.assert_called_once()
         mock_session.close.assert_called_once()
 
+    def test_commits_per_source_not_once_at_end(self):
+        """Each source commits independently so api_sources row locks release between
+        iterations — otherwise the search path hits LockNotAvailable (see Phase 3 root-
+        cause analysis)."""
+        sources = []
+        for i in range(1, 4):
+            s = MagicMock()
+            s.name = f"source_{i}"
+            sources.append(s)
+
+        mock_session = MagicMock(spec=Session)
+        mock_session.query.return_value.filter.return_value.all.return_value = sources
+        mock_session.close = MagicMock()
+
+        commit_count = 0
+
+        def _count_commits():
+            nonlocal commit_count
+            commit_count += 1
+
+        mock_session.commit.side_effect = _count_commits
+
+        with patch("app.database.SessionLocal", return_value=mock_session):
+            with patch("app.services.health_monitor.ping_source", new_callable=AsyncMock) as mock_ping:
+                mock_ping.return_value = {"success": True, "elapsed_ms": 50, "error": None}
+                asyncio.get_event_loop().run_until_complete(run_health_checks("ping"))
+
+        assert commit_count == 3, (
+            f"expected one commit per source (3), got {commit_count} — locks on api_sources "
+            f"would be held for the whole run instead of released between iterations"
+        )
+
+    def test_source_failure_does_not_rollback_siblings(self):
+        """When one source's check raises, earlier-committed sources persist and later
+        sources still run.
+
+        Under the old single-transaction design, a mid-loop exception rolled back every
+        source's changes.
+        """
+        s1 = MagicMock()
+        s1.name = "source_1"
+        s2 = MagicMock()
+        s2.name = "source_2"
+        s3 = MagicMock()
+        s3.name = "source_3"
+
+        mock_session = MagicMock(spec=Session)
+        mock_session.query.return_value.filter.return_value.all.return_value = [s1, s2, s3]
+        mock_session.close = MagicMock()
+
+        commit_count = 0
+        rollback_count = 0
+
+        def _count_commits():
+            nonlocal commit_count
+            commit_count += 1
+
+        def _count_rollbacks():
+            nonlocal rollback_count
+            rollback_count += 1
+
+        mock_session.commit.side_effect = _count_commits
+        mock_session.rollback.side_effect = _count_rollbacks
+
+        with patch("app.database.SessionLocal", return_value=mock_session):
+            with patch("app.services.health_monitor.ping_source", new_callable=AsyncMock) as mock_ping:
+                mock_ping.side_effect = [
+                    {"success": True, "elapsed_ms": 50, "error": None},
+                    Exception("connector blew up"),
+                    {"success": True, "elapsed_ms": 60, "error": None},
+                ]
+                result = asyncio.get_event_loop().run_until_complete(run_health_checks("ping"))
+
+        assert result["passed"] == 2
+        assert result["failed"] == 1
+        assert commit_count == 2, f"sources 1 and 3 should have committed independently; got {commit_count} commits"
+        assert rollback_count == 1, f"source 2's failure should trigger exactly one rollback; got {rollback_count}"
+
 
 # ── _get_connector tests ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `run_health_checks` now commits after each source's check (success path) and rolls back per-source on failure, instead of holding a single transaction across the entire 15-min loop and committing only at the end.
- Adds two regression tests in `tests/test_health_monitor.py::TestRunHealthChecks`:
  - `test_commits_per_source_not_once_at_end` — asserts one `commit()` call per source (failed on old code: 1 commit total).
  - `test_source_failure_does_not_rollback_siblings` — asserts a mid-loop exception triggers exactly one `rollback()` and doesn't undo earlier-committed sources.
- Bonus: documents `ENCRYPTION_SALT` in `.env.example` (Phase 3 uncovered that the setting was implemented but never surfaced in the stub file, so it was silently falling through to the legacy static-salt code path — see `app/utils/encrypted_type.py`). This change rode into the same commit with the health-monitor fix due to a pre-commit auto-fix quirk; keeping it in this PR rather than rewriting history for a cosmetic split.

## Phase 3 failure evidence (why this matters)

Live log excerpt from 2026-04-22 15:09 UTC (before fix #1 deployed):

```
ERROR | app.services.health_monitor | run_health_checks | Health check run failed:
    This Session's transaction has been rolled back due to a previous exception during flush.
    ...psycopg2.errors.LockNotAvailable: canceling statement due to lock timeout
    CONTEXT: while updating tuple (0,9) in relation "api_sources"
```

- Old design: single session, flush per-source, single `commit()` at end of 15-min loop.
- Contention path: while `run_health_checks` held row locks, a concurrent search hit `app/search_service.py:937-957`'s `UPDATE api_sources` and was cancelled by Postgres's `lock_timeout=5000ms`.
- Count: 140+ `LockNotAvailable` occurrences in a rolling 24h window.
- Cascade: once the search session's next write failed, SQLAlchemy marked it as `PendingRollbackError` — subsequent queries in that session also failed, poisoning the request.

With per-source commit, each source's row locks release in ~50ms-2s instead of whole-loop duration. The search path's concurrent `UPDATE` is no longer blocked.

## Test plan
- [x] `TESTING=1 pytest tests/test_health_monitor.py -q` — **41/41 passed** (35 pre-existing + 2 new + 4 other TestRunHealthChecks tests, all passing).
- [x] `TESTING=1 pytest tests/test_search_service.py tests/test_connectors.py tests/test_quick_search.py tests/test_requisition_service.py -q` — **311/311 passed**, no collateral damage in neighbor modules.
- [x] `ruff check` + pre-commit hooks (ruff / ruff-format / docformatter / mypy / detect-private-key / trailing-whitespace) all pass.
- [ ] Post-merge droplet verification: after deploy, tail logs for 20+ minutes and confirm zero new `psycopg2.errors.LockNotAvailable` entries matching `"api_sources"`. Command:
      `docker compose logs --since=20m app 2>&1 | grep -c 'LockNotAvailable.*api_sources'  # expect 0`
- [ ] Health check fires every 15 min — wait for at least one full cycle post-deploy and confirm the `Health check (ping) complete: N/N passed` log line shows success counts unchanged from pre-deploy (behaviour-preserving change, just transaction scope shrinks).

## Deploy plan

After merge:
```bash
cd /root/availai
git fetch origin
git checkout main
git pull --ff-only origin main
./deploy.sh --no-commit
docker compose logs --tail=100 --since=20m app 2>&1 | grep -iE "LockNotAvailable|PendingRollbackError|Health check.*complete" | tail
```

## Scope + risk
- **Scope:** 1 service function (`run_health_checks` in `app/services/health_monitor.py`), 1 test class extension, 1 `.env.example` doc-stub.
- **Destructive ops:** none. No schema change, no data migration. Behaviour-preserving transaction-scope shrink.
- **Rollback:** single `git revert`.
- **Risk of regression on fix #1:** zero — doesn't touch `_fetch_fresh`. The xfail→pass Smoke B regression gate from fix #1 stays green.

## Fix sequence context
This is **fix #4 of 5** in the sourcing-engine repair:
1. ✅ #1 — bounded gather deadline in `_fetch_fresh` (PR #85, awaiting merge).
2. ⏸ #2 — container env gap for `ANTHROPIC_API_KEY` (ops-side; user reapplying `.env` edit).
3. ⏸ #3 — BrokerBin/Mouser key rotation (external portal, user-side).
4. ✅ **This PR** — health-monitor per-source commit.
5. ⏸ #5 — pre-rollout checklist (tracked as a deliverable, not a PR).

Bonus follow-up also queued:
- #1.5 — harden `deploy.sh` to fail loudly on non-fast-forward push + auto-resync `main` (tracked, separate small PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)