### PR TITLE
chore(pre-commit): catch branch-wide drift before push (closes #82)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,14 @@
+# `pre-commit install` auto-installs both hook types: pre-commit (runs on
+# staged files at commit time) + pre-push (runs full --all-files sweep
+# before push, catching branch-wide drift in files the current commit
+# doesn't touch). See the local `all-files-on-push` hook below.
+#
+# First-time setup per developer:
+#   pre-commit install           # installs both hook types automatically
+# Escape hatch if a push hook false-positives:
+#   git push --no-verify
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.6
@@ -33,3 +44,18 @@ repos:
         ]
         pass_filenames: false
         verbose: true
+
+  # Pre-push gate: runs the full pre-commit suite against --all-files so
+  # branch-wide drift (files the current commit didn't touch) gets caught
+  # locally instead of at PR time. --hook-stage pre-commit makes the nested
+  # run execute the commit-stage hooks, not this push-stage hook (no recursion).
+  # Bypass with `git push --no-verify` if it false-positives.
+  - repo: local
+    hooks:
+      - id: all-files-on-push
+        name: Full pre-commit suite on --all-files (catches branch-wide drift)
+        entry: bash -c 'pre-commit run --all-files --hook-stage pre-commit'
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
## Summary

Adds `default_install_hook_types: [pre-commit, pre-push]` + a local `pre-push` hook that runs the full `pre-commit run --all-files` sweep. Drift in files the current commit doesn't touch gets caught locally instead of at CI time.

## Why

PR #81 hit three separate mid-flight detours because local pre-commit only checked staged files while CI runs `--all-files`:
1. Ruff F821 in an unrelated test file
2. 52-file-wide format drift across coverage-improvement tests
3. Alembic migration chain index-clash (separately filed as #84)

Each cost 15-30min of rework. This config change means `pre-commit install` (one-time per developer) now installs both hook types, and the pre-push gate would have caught all three issues before they reached PR.

## Setup (per developer, one-time)

```bash
pre-commit install
# That's it — default_install_hook_types auto-installs both types
```

If `pre-commit install` errors with *"Cowardly refusing… core.hooksPath set"* (as it does in the current Codex sandbox), either unset the config or manually mirror `.git/hooks/pre-commit` as `pre-push` with `--hook-type=pre-push`.

## Escape hatch

```bash
git push --no-verify
```

Use if the push hook false-positives on something unrelated — same as `git commit --no-verify` for pre-commit hooks.

## Test plan

This PR itself proves the hook works — pushing this branch triggered the new pre-push gate, which ran clean (no drift to fix). If there had been pre-existing drift (like the 170-error state we saw during PR #81 CI), the push would have been blocked.

Closes #82.