### PR TITLE
chore(gitignore): catch-all for .env.* variants, whitelist .env.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-# Never commit these
+# Never commit these — exact .env and any `.env.*` variant (backups, workers,
+# timestamped edit snapshots). `!.env.example` re-allows the committed template.
 .env
-.env.backup.*
+.env.*
+!.env.example
 Caddyfile
 __pycache__/
 *.pyc
@@ -43,8 +45,6 @@ scripts/deep_test.py
 # server-local backups (do not commit)
 availai_backup.sql
 app/static/public/*_backup.png
-.env.ics-worker
-.env.nc-worker
 .worktrees/
 fix_queue/
 scripts/ux-repair-reports/


### PR DESCRIPTION
## Summary
Replaces three narrow `.env` patterns (`.env.backup.*`, `.env.ics-worker`, `.env.nc-worker`) with a single catch-all `.env.*` + `!.env.example` whitelist so any future `.env.<suffix>` naming scheme is covered by default.

## Why
During the Phase 3 environment audit, a timestamped backup `.env.before-anthropic-restore-20260422T224021Z` was sitting in the droplet's repo root — untracked AND unignored. `git add .` on the droplet would have staged it, leaking every secret the app uses (Azure OAuth, DB creds, connector keys, Anthropic key). Three narrow patterns left a blast-radius gap every time someone coined a new backup naming convention.

## Test evidence (`git check-ignore -v`)

```
.gitignore:4:.env.*	.env.before-anthropic-restore-20260422T224021Z   ✓ ignored
.gitignore:4:.env.*	.env.ics-worker                                  ✓ ignored
.gitignore:4:.env.*	.env.nc-worker                                  ✓ ignored
.gitignore:4:.env.*	.env.backup.2026-04-22                          ✓ ignored
.env.example                                                        ✓ NOT ignored (tracked template)
```

## Scope
- 1 file changed (`.gitignore`)
- 4 insertions, 4 deletions
- No code changes, no behaviour changes, no runtime impact.
- Does not untrack any currently-tracked files (`.env.example` is tracked and the whitelist preserves that).

## Related tech debt captured (not in this PR)

- Droplet's current `.env` has **duplicate `ENABLE_PASSWORD_LOGIN`** lines (108 + 114). Can't fix via git (`.env` is gitignored); needs a manual de-dup on the droplet. Tracked in pre-rollout checklist (task #6).
- `.env.example` has drifted: 35 extras in real `.env` aren't documented; 7 keys in `.env.example` don't exist in real `.env`. Also tracked for pre-rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)