### PR TITLE
fix(deploy.sh): fail loudly + auto-resync main before push

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,14 +10,46 @@ if [ "${1:-}" = "--no-commit" ]; then
     shift
 fi
 
-# Step 1: Commit & push (unless --no-commit)
+# Step 1: Commit & push (unless --no-commit). Hardened against the silent-
+# failure mode where a stale local main (behind origin/main) caused every
+# `git push origin main` to be rejected as non-fast-forward — the rebuild
+# steps still ran from whatever branch was checked out, so deploys appeared
+# to succeed while origin/main drifted days out of sync.
 if [ "$NO_COMMIT" = false ]; then
+    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+    if [ "$CURRENT_BRANCH" != "main" ]; then
+        echo "ERROR: ./deploy.sh (without --no-commit) must run from main." >&2
+        echo "Current branch: $CURRENT_BRANCH" >&2
+        echo "Either: git checkout main && git pull --ff-only origin main" >&2
+        echo "Or deploy the current branch without pushing: ./deploy.sh --no-commit" >&2
+        exit 1
+    fi
+
+    echo "==> Syncing local main with origin/main..."
+    git fetch origin
+    if ! git merge --ff-only origin/main; then
+        echo "ERROR: local main diverged from origin/main — cannot fast-forward." >&2
+        echo "Resolve with 'git pull --rebase origin main' or investigate before re-running." >&2
+        exit 2
+    fi
+
     if git diff --quiet && git diff --cached --quiet; then
-        echo "No changes to commit — skipping git steps"
+        echo "No changes to commit — skipping commit step"
     else
         git add -A
         git commit -m "${1:-deploy}"
-        git push origin main
+    fi
+
+    AHEAD=$(git rev-list --count origin/main..HEAD)
+    if [ "$AHEAD" -gt 0 ]; then
+        echo "==> Pushing $AHEAD commit(s) to origin/main..."
+        if ! git push origin main; then
+            echo "ERROR: git push origin main failed." >&2
+            echo "Likely causes: non-fast-forward rejection, auth failure, or branch protection." >&2
+            exit 3
+        fi
+    else
+        echo "Local main already matches origin/main — nothing to push."
     fi
 fi
 


### PR DESCRIPTION
## Summary

Fixes the silent-failure mode in `deploy.sh` that let origin/main drift 89 commits behind the droplet's working tree for 8 days unnoticed (Phase 3 finding from the sourcing-engine repair).

## The bug

`deploy.sh` did `git push origin main` with:
- No branch check — callers on feature branches would push their local `main` ref (often stale) instead of the code actually being deployed.
- No exit check — non-fast-forward rejections exited the git block silently; rebuild steps still ran; deploys appeared to succeed.

Result: the droplet successfully rebuilt feature-branch code while origin/main fossilized.

## The fix

- Refuse to run on a non-main branch without `--no-commit`; print a clear instruction telling the caller to either switch to main or use `--no-commit` for a feature-branch-local rebuild.
- `git fetch origin` + `git merge --ff-only origin/main` before anything else; non-ff merge aborts with exit code 2 and a resolver instruction.
- Explicit exit check on `git push origin main`; non-zero aborts with exit code 3 and a diagnostic.
- Skip the push when local has no commits ahead of origin/main (avoids useless no-op pushes).

`--no-commit` mode is unchanged — the droplet's feature-branch-rebuild workflow still works exactly as before.

## Exit codes

| Code | Meaning |
|---|---|
| 1 | Not on main and no `--no-commit` |
| 2 | Local main diverged from origin/main (cannot fast-forward) |
| 3 | `git push origin main` failed (non-ff, auth, branch protection) |

## Test plan

- [x] `bash -n deploy.sh` — syntax OK
- [x] Pre-commit hooks pass on the change
- [ ] **Manual verification** (run on droplet once merged):
  1. **Happy path** — from main with no local diverge: `./deploy.sh` should fetch, ff-merge (likely no-op), skip commit (nothing staged), skip push (no commits ahead), rebuild, and verify.
  2. **Non-main branch** — `git checkout <any-feature-branch> && ./deploy.sh` (no `--no-commit`) should abort immediately with exit code 1 and the switch-to-main instruction.
  3. **Stale main** — with local main deliberately behind origin/main, `./deploy.sh` should ff-sync and continue. Deliberately-diverged case (create a divergent commit on local main) should abort with exit code 2.
  4. **`--no-commit` unchanged** — from any branch: `./deploy.sh --no-commit` should skip the entire git block and just rebuild from the current working tree.

## Context

This is **fix #1.5 of 5** in the sourcing-engine repair — a follow-up to fix #1 (PR #85, merged) that addresses the deploy-hygiene tech debt STABLE.md already documents under the "Deploy hygiene" section.

Generated with [Claude Code](https://claude.com/claude-code)
