### PR TITLE
fix(requisitions2): shared shell chrome on direct load (#89)

### DIFF
--- a/app/routers/requisitions2.py
+++ b/app/routers/requisitions2.py
@@ -64,7 +64,7 @@ def _parse_filters(request: Request) -> ReqListFilters:
 def _table_context(request: Request, filters: ReqListFilters, db: Session, user: User) -> dict:
     """Build the shared context dict for table rendering."""
     # Import locally to avoid a circular import at module load time.
-    from app.routers.htmx_views import _vite_assets
+    from app.routers.htmx_views import _base_ctx
 
     result = list_requisitions(
         db=db,
@@ -73,15 +73,12 @@ def _table_context(request: Request, filters: ReqListFilters, db: Session, user:
         user_role=getattr(user, "role", "sales"),
     )
     users = get_team_users(db)
-    assets = _vite_assets()
     return {
-        "request": request,
+        **_base_ctx(request, user, "requisitions"),
         **result,
         "user": user,
         "users": users,
         "avail_opp_table_v2_enabled": settings.avail_opp_table_v2,
-        "vite_js": assets["js_file"],
-        "vite_css": assets["css_files"],
     }
 
 

--- a/app/templates/requisitions2/page.html
+++ b/app/templates/requisitions2/page.html
@@ -64,18 +64,10 @@
 <body class="bg-gray-50 text-gray-900">
 
   {# ── Main content area ────────────────────────────────────── #}
-  <div class="h-screen flex flex-col">
+  {# pb-[52px] reserves space for the fixed 52px mobile_nav below. #}
+  <div class="h-screen flex flex-col pb-[52px]">
 
-    {# Topbar #}
-    <header class="flex h-12 items-center justify-between gap-4 border-b border-brand-200 bg-white px-5 flex-shrink-0">
-      <div class="flex items-center gap-2 text-sm text-gray-600">
-        <a href="/requisitions2" class="text-brand-500 hover:text-brand-600">Requisitions</a>
-        <span class="ml-2 inline-block h-2 w-2 rounded-full bg-emerald-500 animate-pulse" title="Live updates active"></span>
-      </div>
-      <div class="text-sm font-medium text-gray-700">
-        {{ user.display_name or 'User' }}
-      </div>
-    </header>
+    {% include "htmx/partials/shared/topbar.html" %}
 
     {# Workspace area — fills remaining height #}
     <div id="rq2all-page"
@@ -93,7 +85,9 @@
         {% include "requisitions2/_bulk_bar.html" %}
       </div>
 
-      {# SSE listener — hidden, triggers table refresh #}
+      {# SSE listener — triggers table refresh; shows a small "live" dot
+         (preserved from the removed inline header) so users have a signal
+         that push updates are active. #}
       <div id="rq2-sse-source"
            sse-connect="/requisitions2/stream"
            hx-trigger="sse:table-refresh"
@@ -101,7 +95,11 @@
            hx-target="#rq2-table"
            hx-include="#rq2-filters"
            hx-swap="innerHTML"
-           class="hidden"></div>
+           class="pointer-events-none fixed bottom-[60px] right-3 z-10"
+           title="Live updates active"
+           aria-label="Live updates active">
+        <span class="inline-block h-2 w-2 rounded-full bg-emerald-500 animate-pulse"></span>
+      </div>
 
       {# ── Split-screen workspace ────────────────────────────── #}
       <div id="split-rq2"
@@ -147,5 +145,7 @@
            x-transition:leave-end="opacity-0"></div>
     </template>
   </div>
+
+  {% include "htmx/partials/shared/mobile_nav.html" %}
 </body>
 </html>

--- a/tests/test_requisitions2_routes.py
+++ b/tests/test_requisitions2_routes.py
@@ -34,6 +34,24 @@ def test_page_load_contains_table(client):
     assert "rq2-rows" in resp.text or "No requisitions found" in resp.text
 
 
+def test_page_load_includes_shell_chrome(client):
+    """Direct page load renders shared topbar and bottom nav."""
+    resp = client.get("/requisitions2")
+    assert resp.status_code == 200
+    # Topbar: global search input is only rendered by topbar.html.
+    assert 'aria-label="Global search"' in resp.text
+    # Mobile nav: the bottom nav <nav> is only rendered by mobile_nav.html.
+    assert 'aria-label="Main navigation"' in resp.text
+
+
+def test_htmx_fragment_excludes_shell_chrome(client):
+    """HTMX fragment response must not wrap the table in the full shell."""
+    resp = client.get("/requisitions2", headers={"HX-Request": "true"})
+    assert resp.status_code == 200
+    assert 'aria-label="Global search"' not in resp.text
+    assert 'aria-label="Main navigation"' not in resp.text
+
+
 # ── HTMX detection ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Direct loads of `/requisitions2` (bookmark or typed URL) rendered a standalone `page.html` with no topbar or bottom nav. In-app HTMX swaps kept the shell; cold landing looked stripped down.
- Include `htmx/partials/shared/topbar.html` + `htmx/partials/shared/mobile_nav.html` in `page.html`; route context through `_base_ctx()` so `user_name`/`user_email`/`current_view`/`is_admin` come from the single source of truth used by every other v2 route.
- Preserve the pulsing live-update indicator that lived in the removed inline header by promoting the hidden SSE listener into a small fixed-position dot (bottom-right, above mobile nav).

Fixes #89.

## Review pipeline signal
All 7 required agents run (comment-analyzer, pr-test-analyzer, type-design-analyzer, silent-failure-hunter, code-simplifier, code-reviewer from pr-review-toolkit + feature-dev:code-reviewer). Convergent finding from simplifier / type-designer / feature-dev: reuse `_base_ctx()` to kill drift risk and implicitly fix the missing-`is_admin` inconsistency feature-dev flagged at 85% confidence. Applied.

## Out of scope / follow-up
- Make `page.html` `{% extends "htmx/base.html" %}` so this kind of drift is structurally impossible. Tracked as the architectural cleanup (one-shell-via-inheritance + canonical URL collapse).
- Silent-failure-hunter flagged nullable `User.name` and partial `or` fallbacks — pre-existing patterns outside this diff; file separately if we want to harden them.

## Test plan
- [x] `pytest tests/test_requisitions2_routes.py tests/test_requisitions2_templates.py tests/test_coverage_boost_requisitions2.py` — 155 passed, 1 pre-existing flaky (`test_inline_save_urgency`, unrelated).
- [x] New regression tests: `test_page_load_includes_shell_chrome` (asserts topbar + mobile_nav markers on direct load) and `test_htmx_fragment_excludes_shell_chrome` (asserts HX-Request fragment does NOT wrap in shell).
- [x] `ruff check` on changed Python files clean; pre-commit mypy pass on 319 source files.
- [ ] Post-merge: rebuild container (`docker compose up -d --build --force-recreate app`) and curl-verify shell markers on https://app.availai.net/requisitions2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)