### PR TITLE
chore(eslint): declare cancelAnimationFrame + confirm as browser globals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,8 @@ export default [
         clearTimeout: 'readonly',
         clearInterval: 'readonly',
         requestAnimationFrame: 'readonly',
+        cancelAnimationFrame: 'readonly',
+        confirm: 'readonly',
         URL: 'readonly',
         URLSearchParams: 'readonly',
         CustomEvent: 'readonly',


### PR DESCRIPTION
## Summary

Two-line fix to the ESLint flat-config: declare `cancelAnimationFrame` and `confirm` as readonly browser globals alongside the existing `requestAnimationFrame`, `window`, `document`, etc.

## Before → After

```
Before:  ✖ 9 problems (2 errors, 7 warnings)
After:   ✖ 7 problems (0 errors, 7 warnings)
```

The 2 errors that got cleared:
```
app/static/htmx_app.js:425:16   error  'cancelAnimationFrame' is not defined  no-undef
app/static/htmx_app.js:1168:12  error  'confirm' is not defined               no-undef
```

Both are standard Web APIs — `cancelAnimationFrame` pairs with the already-declared `requestAnimationFrame`, and `confirm()` is a base-level browser prompt. The code calling them was always correct; the config just didn't know to allow them.

## Remaining 7 warnings

All are `'e' is defined but never used` in `catch (e)` blocks. Cosmetic — they won't block CI (warnings only). Leaving for a separate cleanup pass; the quick fix is `catch { ... }` (no binding) or rename to `_e` per the existing `argsIgnorePattern: '^_'` rule.

## Scope
- 1 file (`eslint.config.mjs`)
- 2 insertions
- No runtime effect — lint-only config change

Generated with [Claude Code](https://claude.com/claude-code)
