### PR TITLE
fix(styles): unify table line color + readable MPN typography

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -101,8 +101,8 @@
 
 .opp-mpn {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 14px;
+  font-weight: 600;
   color: var(--opp-text-primary);
   font-variant-numeric: tabular-nums;
   display: block;
@@ -275,14 +275,14 @@ hr { border-color: #BFC4CE; }
   text-transform: uppercase;
   color: #6B7280;
   background: #fff;
-  border-bottom: 2px solid #E5E7EB;
+  border-bottom: 2px solid #BFC4CE;
   padding: 12px 16px;
 }
 
 .responsive-table td,
 .data-table td {
   padding: 14px 16px;
-  border-bottom: 1px solid #F0F1F4;
+  border-bottom: 1px solid #BFC4CE;
   color: #1e293b;
   font-size: 13px;
 }
@@ -312,7 +312,7 @@ hr { border-color: #BFC4CE; }
   text-transform: uppercase;
   color: #6B7280;
   background: #fff;
-  border-bottom: 2px solid #E5E7EB;
+  border-bottom: 2px solid #BFC4CE;
   padding: 8px 10px;
   position: sticky;
   top: 0;
@@ -322,7 +322,7 @@ hr { border-color: #BFC4CE; }
 }
 .compact-table td {
   padding: 6px 10px;
-  border-bottom: 1px solid #F0F1F4;
+  border-bottom: 1px solid #BFC4CE;
   color: #1e293b;
   white-space: nowrap;
   font-family: 'JetBrains Mono', ui-monospace, monospace;
@@ -408,7 +408,7 @@ table {
   gap: 8px;
   padding: 10px 14px;
   background: #fff;
-  border-bottom: 1px solid #E5E7EB;
+  border-bottom: 1px solid #BFC4CE;
   flex-shrink: 0;
 }
 .panel-title {

--- a/specs/ui/opportunity-table-aesthetic-v2.md
+++ b/specs/ui/opportunity-table-aesthetic-v2.md
@@ -73,7 +73,7 @@ Do not start coding until I approve the plan.
 
 ### Typography
 
-- MPN: mono, 13px, weight 500, primary color
+- MPN: mono, 14px, weight 600, primary color
 - Description: sans, 11px, weight 400, tertiary color
 - Status label: sans, 12px, weight 400, secondary color
 - Qty, Unit Price: tabular-nums, sans, 12px, secondary color

--- a/tests/test_management_reenrich.py
+++ b/tests/test_management_reenrich.py
@@ -18,7 +18,8 @@ import pytest
 class TestReenrichMain:
     @pytest.mark.asyncio
     async def test_main_empty_cards_list(self):
-        """main() with no cards still runs without error and doesn't call record_spec."""
+        """Main() with no cards still runs without error and doesn't call
+        record_spec."""
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
         mock_db.query.return_value.filter.return_value.all.return_value = []
@@ -44,7 +45,7 @@ class TestReenrichMain:
 
     @pytest.mark.asyncio
     async def test_main_calls_record_spec_for_spec_values(self):
-        """main() calls record_spec for each non-None spec value in specs_structured."""
+        """Main() calls record_spec for each non-None spec value in specs_structured."""
         mock_db = MagicMock()
 
         card = MagicMock()
@@ -88,7 +89,7 @@ class TestReenrichMain:
 
     @pytest.mark.asyncio
     async def test_main_skips_card_without_specs_structured(self):
-        """main() skips record_spec for cards with None specs_structured."""
+        """Main() skips record_spec for cards with None specs_structured."""
         mock_db = MagicMock()
 
         card = MagicMock()
@@ -119,7 +120,7 @@ class TestReenrichMain:
 
     @pytest.mark.asyncio
     async def test_main_skips_card_without_category(self):
-        """main() skips record_spec for cards with None category."""
+        """Main() skips record_spec for cards with None category."""
         mock_db = MagicMock()
 
         card = MagicMock()
@@ -150,7 +151,8 @@ class TestReenrichMain:
 
     @pytest.mark.asyncio
     async def test_main_handles_plain_string_spec_values(self):
-        """main() handles specs_structured where values are plain strings (not dicts)."""
+        """Main() handles specs_structured where values are plain strings (not
+        dicts)."""
         mock_db = MagicMock()
 
         card = MagicMock()
@@ -190,7 +192,7 @@ class TestReenrichMain:
 
     @pytest.mark.asyncio
     async def test_main_db_always_closed(self):
-        """main() closes DB session even if enrichment raises."""
+        """Main() closes DB session even if enrichment raises."""
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
         mock_session_cls = MagicMock(return_value=mock_db)

--- a/tests/test_services_response_parser_coverage.py
+++ b/tests/test_services_response_parser_coverage.py
@@ -1,4 +1,5 @@
-"""test_services_response_parser_coverage_new.py — Coverage tests for missing error paths.
+"""test_services_response_parser_coverage_new.py — Coverage tests for missing error
+paths.
 
 Covers lines 156-161, 170-171, 189-190, 197-198 in app/services/response_parser.py.
 

--- a/tests/test_sourcengine_connector.py
+++ b/tests/test_sourcengine_connector.py
@@ -123,7 +123,7 @@ class TestSourcengineParseEdgeCases:
         assert result[0]["vendor_name"] == "Arrow"
 
     def test_supplier_as_string_not_dict(self):
-        """supplier field is a string → use str() directly."""
+        """Supplier field is a string → use str() directly."""
         connector = self._make_connector()
         data = {
             "offers": [


### PR DESCRIPTION
## Summary
The deployed UI had a half-completed border darkening: utility classes (`.border-gray-200`, `hr`) moved to `#BFC4CE`, but data-table internal separators were left light at `#E5E7EB` / `#F0F1F4`. Result: row separators looked washed out next to the (correctly darkened) outer borders, and part numbers in the v2 opportunity table were hard to read.

This PR finishes the unification and bumps MPN typography:

- `.responsive-table` / `.data-table` th + td borders → `#BFC4CE`
- `.compact-table` th + td borders → `#BFC4CE`
- `.panel-header` bottom border → `#BFC4CE`
- `.opp-mpn`: `13px / weight 500` → `14px / weight 600` (more readable part numbers)
- `specs/ui/opportunity-table-aesthetic-v2.md` synced to match

Second commit (`001e67cf`) is an unrelated docformatter sweep on 3 test files that the pre-push hook auto-fixed — kept separate to keep the styles change clean to review.

## Test plan
- [ ] Verify Reqs list (`/v2`) row separators are visibly defined, not washed out
- [ ] Verify v2 opportunity table (`/requisitions2`) MPNs render clearly at the larger size + heavier weight
- [ ] Verify left/right panel headers (req detail) have a defined bottom rule
- [ ] Verify no regression on parts list, customer detail, vendor detail (same `.compact-table` styles)
- [ ] After merge: run `./deploy.sh` (already does `--no-cache` + Tailwind verify per existing deploy hygiene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)