### PR TITLE
chore(claude): optimize Claude CLI config for AvailAI development

### DIFF
--- a/.claude/agents/migration-safety-reviewer.md
+++ b/.claude/agents/migration-safety-reviewer.md
@@ -1,0 +1,82 @@
+---
+name: migration-safety-reviewer
+description: |
+  Reviews new Alembic migration files in PR diffs against AvailAI conventions established by the migration 001 rewrite (canonical: alembic/versions/001_initial_schema.py on branch fix/ci-unblock-alembic-and-audit, with rules encoded in tests/test_alembic.py). Prevents regressions to Base.metadata.create_all() / drop_all() patterns and catches asymmetric downgrades.
+  Use when: a PR adds or modifies files under alembic/versions/. Invoke from PR review with the migration file paths.
+tools: Read, Grep, Glob
+model: inherit
+---
+
+You are a database migration safety auditor for AvailAI. Stack: PostgreSQL 16 + SQLAlchemy 2.0 + Alembic.
+
+## Authoritative reference
+
+The canonical "good" pattern is established by:
+- `alembic/versions/001_initial_schema.py` on branch `fix/ci-unblock-alembic-and-audit` (SHA b7cc24b8) — explicit DDL via `op.create_table()` / `op.create_index()` / `op.create_foreign_key()` (3769 lines, 87 tables / 285 indexes / 158 FKs)
+- `tests/test_alembic.py` — encodes the structural rules as test assertions with floor counts
+
+**If `tests/test_alembic.py` passes for 001, the conventions are intact.** Your job is to grade NEW migrations (002+ added in current PR) against the same conventions, not 001 itself.
+
+## Scope
+
+Grade ONLY migration files added or modified in the current PR. Do NOT grade existing migrations 002 through current chain tip — those are immutable history with mixed conventions for legitimate reasons (idempotency wrappers, in-place upgrades, etc.).
+
+The caller passes specific file paths under `alembic/versions/`. Review only those.
+
+## Rules
+
+**R1 — Required attributes.** Module exports `revision`, `down_revision`, `upgrade()`, `downgrade()`. For non-initial migrations, `down_revision` must reference a real prior revision string (not None).
+
+**R2 — Explicit DDL only.** `upgrade()` and `downgrade()` must NOT call `Base.metadata.create_all()` / `Base.metadata.drop_all()`. Use `op.create_table()`, `op.add_column()`, `op.create_index()`, `op.create_foreign_key()` — explicit, named, schema-tracked.
+
+**R3 — Symmetric downgrade.** Every `op.create_table()` in upgrade has a matching `op.drop_table()` in downgrade. Same for `add_column ↔ drop_column`, `create_index ↔ drop_index`, `create_foreign_key ↔ drop_constraint`. A `pass`-only `downgrade()` is acceptable ONLY for data-only migrations (no schema change in upgrade); call this out explicitly in the verdict if so. **Scope: structural symmetry only.** Every `op.X` in upgrade has matching `op.un-X` in downgrade. Idempotency wrappers (`IF EXISTS`, `sa.inspect()` checks) are NOT required by R3 — that's a separate concern not graded here.
+
+**R4 — Cross-table FKs as separate ops.** Foreign keys that reference tables not yet created in this migration must use a separate `op.create_foreign_key()` call AFTER all `op.create_table()` calls in the same migration. Inlining cross-table FKs causes "relation does not exist" errors during fresh-DB upgrade. (Per test_initial_migration_emits_explicit_ddl rationale in tests/test_alembic.py.)
+
+**R5 — Drop order in downgrade.** `op.drop_constraint()` (FK) calls must come BEFORE the `op.drop_table()` of the table they pin. Otherwise drop fails with "cannot drop table because other objects depend on it."
+
+**R6 — No destructive ops without justification.** `op.drop_column()`, `op.drop_table()`, `op.execute("DELETE ...")`, `op.execute("TRUNCATE ...")` in upgrade must have either: (a) a comment explaining data disposition, or (b) a preceding backfill op in the same migration. Otherwise FAIL. **Scope: upgrade ONLY.** Downgrade destructive ops are expected (downgrades exist to undo schema changes) and are NOT subject to this rule.
+
+**R7 — No raw DDL via op.execute for table/column structural operations.** Specifically forbidden in upgrade or downgrade: `op.execute("CREATE TABLE ...")`, `op.execute("ALTER TABLE ... ADD COLUMN ...")`, `op.execute("ALTER TABLE ... DROP COLUMN ...")`, `op.execute("ALTER TABLE ... RENAME COLUMN ...")`, `op.execute("ALTER TABLE ... ALTER COLUMN ...")`. These must use `op.create_table()`, `op.add_column()`, `op.drop_column()`, `op.alter_column()` so alembic's autogenerate diff stays accurate. Idempotency wrappers via `sa.inspect()` are fine (see migration 048's `_col_exists` / `_idx_exists` helper pattern). **All other DDL via execute IS allowed**: CREATE INDEX, DROP INDEX, REINDEX, CREATE/DROP CONSTRAINT, CREATE EXTENSION, CREATE TYPE, CREATE FUNCTION, CREATE TRIGGER, CREATE/DROP VIEW, etc. — these have legitimate cases where the alembic op equivalents are awkward or don't exist (e.g., partial indexes via `WHERE`, GIN/GiST options, complex check constraints, PostgreSQL-specific features). Raw DML/maintenance via execute is also allowed (DELETE, UPDATE, INSERT, ANALYZE).
+
+**R8 — File naming.** New migration files match `NNN_description.py` where NNN is the next sequential 3-digit prefix. Filename prefix must match the `revision = "NNN..."` value. Multiple migrations sharing the same NNN prefix indicate parallel branches that need merging via `alembic merge heads`.
+
+**R9 — Single head expected.** Check that the new migration's `down_revision` points to what was the sole head before this PR. If the PR introduces multiple new migrations, they must form a single linear chain (not parallel branches with the same `down_revision`). You cannot run `alembic heads` yourself — flag NEEDS_VERIFY if you can't tell from the file content alone.
+
+## Output discipline
+
+- Each rule line contains ONE final verdict (PASS / FAIL / N/A / NEEDS_VERIFY) and ONE-line justification.
+- Do NOT emit reasoning iterations, walk-backs, or "actually..." reconsiderations in the output.
+- Do all reasoning before producing the output. The output is a finished judgment, not a thought process.
+
+## Output format
+
+```
+MIGRATION SAFETY REVIEW
+
+File: <path>
+Revision: <rev id>
+Down revision: <down_rev>
+
+R1 Required attributes:        PASS | FAIL — <detail>
+R2 Explicit DDL only:          PASS | FAIL — <detail>
+R3 Symmetric downgrade:        PASS | FAIL — <detail>
+R4 Cross-table FKs separate:   PASS | FAIL | N/A — <detail>
+R5 Drop order in downgrade:    PASS | FAIL | N/A — <detail>
+R6 No destructive ops:         PASS | FAIL | N/A — <detail>
+R7 No raw DDL via execute:     PASS | FAIL | N/A — <detail>
+R8 File naming:                PASS | FAIL — <detail>
+R9 Single head:                PASS | FAIL | NEEDS_VERIFY — <detail>
+
+VERDICT: PASS | FAIL
+
+Concrete fixes (if FAIL):
+- R<n>: <one-line fix referencing specific line in file>
+```
+
+## What you do NOT do
+
+- Modify migration files (read-only review)
+- Run `alembic` or `pytest` (caller's CI / pre-commit handles execution)
+- Grade migrations 002 through current chain tip
+- Recommend stylistic changes (formatting, comment wording, variable names)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,19 @@
 # CLAUDE.md — AvailAI Documentation
 
 **PROJECT:** AvailAI — Electronic component sourcing platform and CRM for Trio Supply Chain Solutions
-**VERSION:** See `app/config.py` → `APP_VERSION`
+**VERSION:** See `app/config.py` (module-level constant `APP_VERSION`)
 **STACK:** FastAPI + SQLAlchemy 2.0 + PostgreSQL 16 + HTMX 2.x + Alpine.js 3.x + Jinja2 + Tailwind CSS
 **DEPLOY:** Docker Compose (app, db, redis, caddy, enrichment-worker [disabled], db-backup) on DigitalOcean
 **LEVEL:** Intermediate
+
+---
+
+## Authoritative Maps (read these before exploring code)
+- `docs/APP_MAP_ARCHITECTURE.md` — stack, infra, project structure
+- `docs/APP_MAP_DATABASE.md` — models, tables, relationships
+- `docs/APP_MAP_INTERACTIONS.md` — service interactions, data flows, integration patterns
+
+**After any code change**, update the relevant APP_MAP doc(s) in the same PR. They are the canonical reference; CLAUDE.md just points at them.
 
 ---
 
@@ -88,6 +97,14 @@ docker compose up app
 
 ## CODE RULES
 
+### Non-Negotiables
+- **Stack is HTMX + Alpine.js + Jinja2 — NOT React.** Reject React/SPA patterns; if a problem seems to need React, you're modeling it wrong. Server-render + HTMX swap.
+- **No band-aids, no half-measures.** Root-cause fixes only, even if interim breakage shows. Workarounds get the PR closed.
+- **Quality > speed. Zero ambiguity in designs.** Resolve every decision in the spec; no TBDs, no "options A/B".
+- **Hosted CLI only.** No GUI, no screenshots, no desktop-dependent suggestions, no browser visual companion.
+- **Before pushing big PRs:** run `pre-commit run --all-files` (local git-hook scope is narrower than CI and bites otherwise).
+- **Deploy is `./deploy.sh` only** — uses `--no-cache` and `--force-recreate`. Bare `docker compose up -d --build` ships stale templates. After deploy, verify any new Tailwind classes actually appear in built CSS.
+
 - Always write tests with any new code. Don't ask, just include them.
 - Give exact file paths for everything.
 - Never use placeholder comments like "# rest of code here" — give complete code.
@@ -167,8 +184,8 @@ app/
 │
 ├── connectors/                # External API integrations (DigiKey, Mouser, Nexar, etc.)
 ├── jobs/                      # APScheduler job definitions
-│   ├── inbox_monitor.py       # Check for RFQ replies every 30min
-│   ├── requirement_refresh.py # Re-search stale requirements
+│   ├── email_jobs.py          # RFQ inbox monitoring + reply parsing
+│   ├── sourcing_refresh_jobs.py # Re-search stale requirements
 │   └── ...
 │
 ├── cache/                     # Redis caching utilities
@@ -192,8 +209,9 @@ app/
 │   ├── htmx_mobile.css        # Mobile-specific overrides
 │   └── dist/                  # Vite build output (minified, content-hashed)
 │
-├── migrations/                # Alembic migration files
 └── logs/                      # Loguru output (structured, request_id context)
+
+# Note: Alembic migrations live at repo-root `alembic/versions/`, NOT under app/.
 
 tests/
 ├── test_models.py             # ORM model tests
@@ -238,7 +256,7 @@ APScheduler fires at interval → Job function → Service layer → Database/Ex
 **RFQ Workflow** (`email_service.py`):
 1. User selects vendors → Click "Send RFQ"
 2. `send_batch_rfq()` sends via Microsoft Graph API, tagged with `[AVAIL-{id}]`
-3. APScheduler polls inbox every 30 minutes (`inbox_monitor.py`)
+3. APScheduler polls inbox every 30 minutes (`email_jobs.py`)
 4. New replies forwarded to Claude via `response_parser.py`
 5. Claude extracts: price, quantity, lead time, condition, date code
 6. Confidence ≥0.8 → auto-create Offer, 0.5-0.8 → flag for manual review
@@ -662,7 +680,7 @@ Check `.env` for API keys (Octopart, BrokerBin, etc.). No keys = no results. You
 **"Check Inbox" finds nothing?**
 - Verify replies are in the same email thread as the RFQ you sent
 - Check that `Mail.Read` permission is granted in Azure
-- Look at `app/jobs/inbox_monitor.py` logs
+- Look at `app/jobs/email_jobs.py` logs
 
 **Tests fail with "TESTING not set"?**
 Run with: `TESTING=1 PYTHONPATH=/root/availai pytest tests/ -v`
@@ -700,26 +718,22 @@ docker compose up -d --build     # Rebuild from scratch
 
 ## Skill Usage Guide
 
-When working on tasks involving these technologies, invoke the corresponding skill:
+Invoke skills proactively — don't ask. Triggers:
 
-| Skill | Invoke When |
-|-------|-------------|
-| fastapi | Builds FastAPI routes, dependency injection, and middleware |
-| htmx | Implements HTMX attributes for server-driven UI updates |
-| jinja2 | Renders server-side templates with Jinja2 syntax and inheritance |
-| vite | Configures Vite build system, asset bundling, and dev server |
-| frontend-design | Designs UI with HTMX, Alpine.js, and Tailwind CSS styling |
-| pytest | Writes pytest tests with fixtures and async support |
-| redis | Configures Redis caching with decorators and TTL |
-| mypy | Enforces mypy strict type checking on Python code |
-| playwright | Implements end-to-end tests with Playwright |
-| mapping-user-journeys | Maps in-app journeys and identifies friction points in code |
-| clarifying-market-fit | Aligns ICP, positioning, and value narrative for on-page messaging |
-| designing-onboarding-paths | Designs onboarding paths, checklists, and first-run UI |
-| instrumenting-product-metrics | Defines product events, funnels, and activation metrics |
-| crafting-page-messaging | Writes conversion-focused messaging for pages and key CTAs |
-| tuning-landing-journeys | Improves landing page flow, hierarchy, and conversion paths |
-| mapping-conversion-events | Defines funnel events, tracking, and success signals |
-| structuring-offer-ladders | Frames plan tiers, value ladders, and upgrade logic |
-| inspecting-search-coverage | Audits technical and on-page search coverage |
-| adding-structured-signals | Adds structured data for rich results |
+| Trigger | Skill |
+|---|---|
+| Adding/modifying FastAPI routes, deps, middleware | `fastapi` |
+| Writing SQLAlchemy 2.0 models, queries, relationships, fixtures | `sqlalchemy` |
+| Adding HTMX attributes, partials, inline edits, lazy-loads, modals | `htmx` |
+| Editing Jinja2 templates, macros, custom filters, partials | `jinja2` |
+| Touching `vite.config.js`, JS/CSS entry points, Vitest specs | `vite` |
+| Building/styling UI (HTMX + Alpine + Tailwind) | `frontend-design` |
+| Writing/fixing pytest tests, fixtures, mocks | `pytest` |
+| Adding/invalidating Redis cache, `@cached_endpoint` | `redis` |
+| Fixing pre-commit lint errors, ruff rules, noqa | `ruff` |
+| Fixing mypy errors, adding type annotations | `mypy` |
+| Writing/extending Playwright E2E specs | `playwright` |
+| Empty states, first-run flows, onboarding nudges | `designing-onboarding-paths`, `orchestrating-feature-adoption` |
+| Funnel events, activity tracking, activation metrics | `mapping-conversion-events`, `instrumenting-product-metrics` |
+| Page copy, CTAs, microcopy | `crafting-page-messaging`, `tuning-landing-journeys` |
+| SEO/meta/structured data on public pages | `inspecting-search-coverage`, `adding-structured-signals` |

--- a/tests/test_database_coverage.py
+++ b/tests/test_database_coverage.py
@@ -180,10 +180,10 @@ class TestDatabaseModule:
 class TestDatabaseNonSQLite:
     """Tests for the PostgreSQL engine creation path (database.py lines 37-50).
 
-    These tests verify the PostgreSQL configuration constants and connect_args
-    without reloading app.database via sys.modules.pop + importlib.import_module,
-    which corrupts the shared in-memory SQLite engine used by other tests in the
-    same xdist worker process.
+    These tests verify the PostgreSQL configuration constants and connect_args without
+    reloading app.database via sys.modules.pop + importlib.import_module, which corrupts
+    the shared in-memory SQLite engine used by other tests in the same xdist worker
+    process.
     """
 
     def test_postgresql_branch_creates_engine_with_pool_args(self):


### PR DESCRIPTION
## Summary
- Patches `CLAUDE.md` to surface load-bearing rules + fix stale file refs (no behavior change)
- Adds `migration-safety-reviewer` subagent for Alembic PR review
- One follow-up commit: docformatter auto-fix on a pre-existing unformatted docstring (was blocking pre-commit on push)

## CLAUDE.md changes
- 6 Non-Negotiables now explicit at top of CODE RULES (HTMX-not-React, no band-aids, quality > speed, hosted CLI, pre-commit before push, deploy --no-cache)
- Authoritative Maps block points at docs/APP_MAP_*.md as canonical reference
- 5 stale file refs fixed (inbox_monitor.py x3, requirement_refresh.py, app/migrations/)
- Skill Usage Guide converted from name list to trigger-based table; adds ruff and sqlalchemy

## migration-safety-reviewer agent
- 9 rules covering required attributes, explicit DDL, symmetric downgrade, cross-table FK separation, drop order, destructive ops in upgrade, structural DDL via execute (with index/extension carve-outs), file naming, single head
- Calibrated against canonical 001 rewrite (fix/ci-unblock-alembic-and-audit at b7cc24b8)
- 3-iteration smoke test against ground-truth corpus: A (good), B (regression form), C (mixed) — all final verdicts correct
- v1 to v2 fixed scope drift on R3 and R6 plus output discipline
- v2 to v3 fixed R7 over-strictness on partial index ops (B-broad rewrite — see agent file for full rule wording)

## Test plan
- [x] Pre-commit --all-files passes on push
- [ ] CLAUDE.md still renders correctly in GitHub web view
- [ ] migration-safety-reviewer agent appears in agents list after Claude Code session restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)