### PR TITLE
fix(connectors): raise on hard auth/quota errors to stop health-ping self-DOS

### DIFF
--- a/app/connectors/mouser.py
+++ b/app/connectors/mouser.py
@@ -90,7 +90,12 @@ class MouserConnector(BaseConnector):
             )
             if is_auth_error:
                 logger.warning(f"Mouser: auth error for {part_number}: {msg}")
-                return []
+                # Raise so health_monitor.ping_source catches and flips status to
+                # 'error' — otherwise the connector keeps getting pinged every
+                # 15min, burning Mouser API quota with bad creds. Search-time
+                # callers (search_service._run_one) catch this exception and
+                # surface it as a per-source error chip in the UI.
+                raise RuntimeError(f"Mouser auth error: {msg}")
             logger.warning(f"Mouser API errors for {part_number}: {errors}")
             raise RuntimeError(f"Mouser API: {msg}")
 

--- a/app/connectors/sources.py
+++ b/app/connectors/sources.py
@@ -408,6 +408,13 @@ class NexarConnector(BaseConnector):
                 data = await self._run_query(self.AGGREGATE_QUERY, part_number)
                 results_data = (data.get("data") or {}).get("supSearchMpn", {}).get("results", [])
                 return self._parse_aggregate(results_data, part_number) if results_data else []
+            # Quota / billing failures are hard errors — raise so the health
+            # monitor catches and flips status to 'error', stopping the
+            # 15-min ping loop from continuing to burn API calls against an
+            # exhausted quota.
+            msg_lower = msg.lower()
+            if "exceed" in msg_lower and ("limit" in msg_lower or "quota" in msg_lower or "plan" in msg_lower):
+                raise RuntimeError(f"Nexar quota exceeded: {msg[:200]}")
             return []
 
         results_data = (data.get("data") or {}).get("supSearchMpn", {}).get("results", [])


### PR DESCRIPTION
## Summary

Mouser and Nexar connectors silently caught hard auth/quota failures and returned `[]`. `health_monitor.ping_source` saw "no exception" and left source status as `live`, so the 15-min ping loop kept hammering the upstream API forever — burning quota with bad creds, no operator signal.

**Observed prod impact** (per session investigation):
- Nexar: ~108 calls/day per connector × 30 days = 3,240 calls/month against a 2,000-part free tier. Quota exhausted from health pings alone.
- Mouser: same pattern — auth error every ping, status stuck `live`, pings continue every 15 min.

## Fix

Classify hard errors (auth-failure, quota-exceeded) vs soft errors (rate-limit, transient). Hard errors raise `RuntimeError`; soft errors continue to return `[]`.

- `app/connectors/mouser.py`: auth-error path raises (was `return []`)
- `app/connectors/sources.py` `NexarConnector`: GraphQL quota error raises (was `return []`); 'not authorized' fallback path unchanged

## Side effects

- `search_service._run_one` already catches per-connector exceptions and surfaces them as error chips in the UI — no user-facing search regression
- `health_monitor.ping_source` now sees the exception, flips `api_sources.status` to `error`, and the connector is excluded from subsequent pings (per the `is_active` filter set on the bad-cred connectors)
- Net: a connector with broken creds stops self-DOSing; a human flips `is_active` back on after rotating creds

## Test plan

- [ ] Local pre-commit suite passes (already verified on push)
- [ ] CI: ruff / mypy / pytest green
- [ ] Manual: simulate Mouser auth error → confirm `RuntimeError` raised, status flips to `error` in `api_sources` after next ping cycle
- [ ] Manual: simulate Nexar quota error → same behavior
- [ ] Manual: confirm soft 429/rate-limit still returns `[]` and does not flip status

🤖 Generated with [Claude Code](https://claude.com/claude-code)
