### PR TITLE
docs: design spec for GitHub cleanup & optimization

### DIFF
--- a/docs/superpowers/plans/2026-05-08-github-cleanup-track-0-tooling.md
+++ b/docs/superpowers/plans/2026-05-08-github-cleanup-track-0-tooling.md
@@ -1,0 +1,921 @@
+# Track 0 — Pre-flight Tooling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. These artifacts are LOCAL `.claude/` config, not committed to the repo (`.claude/settings.local.json` and friends are .gitignored). Verification is by execution, not by CI.
+
+**Goal:** Build the four local skills (`/cascade`, `/recommit`, `/smoke-gate`, `/worktree-prune`), add the `main-is-RED` pre-push warn hook, and fix the over-broad `warn-destructive-git` hookify rule — so that Track 1 (the cascade-merge critical path) has the tools it requires before it starts.
+
+**Architecture:** Each skill is a directory `.claude/skills/<name>/` containing a `SKILL.md` (YAML frontmatter: `name`, `description`, `disable-model-invocation: true`) plus optional helper scripts under the same directory. The `/cascade` skill is the most complex and ships an actual bash implementation in `.claude/skills/cascade/cascade.sh` (toposort by `baseRefName`, leaf-first merge, idempotent state at `.claude/state/cascade.json`, pre-rebase comment snapshot via `gh api`). `/recommit` is a one-liner. `/smoke-gate` exercises a throwaway Postgres 16 container against the alembic upgrade/downgrade chain. `/worktree-prune` diffs `ls .claude/worktrees/` against `git worktree list --porcelain` and confirms each removal interactively. The `main-is-RED` hook is a non-blocking PreToolUse hook installed inline in `.claude/settings.local.json` matched on `Bash` tool calls whose `command` matches `git push.*`. The `warn-destructive-git` rule is rewritten so the regex matches the *target ref* (`main`/`master`), not the bare `--force` flag, allowing legitimate force-pushes to feature branches in worktree workflows.
+
+**Tech Stack:** Bash 5 + `gh` CLI + `jq` + `git` + Docker (for `/smoke-gate`'s ephemeral Postgres) + Claude Code skill/hook framework.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-github-cleanup-design.md` §0.1 – §0.6.
+
+**Intentional decision — NO COMMITS:** Every file in this plan lives under `.claude/` which is `.gitignored` for local-only config (`.claude/settings.local.json`, `hookify.*.local.md`, `skills/`, `hooks/`, `state/`). Do not run `git add` against any file produced here. If git accidentally tracks one of them, untrack with `git rm --cached <file>` and add it to `.gitignore`.
+
+---
+
+## File Inventory
+
+| File | Action | Purpose |
+|---|---|---|
+| `.claude/skills/cascade/SKILL.md` | Create | Skill frontmatter + invocation instructions for `/cascade` |
+| `.claude/skills/cascade/cascade.sh` | Create | Toposort + leaf-first merge + idempotent state machine (spec §0.1) |
+| `.claude/skills/recommit/SKILL.md` | Create | One-line `git commit` wrapper that re-stages auto-fixed files (spec §0.2) |
+| `.claude/skills/smoke-gate/SKILL.md` | Create | Skill frontmatter + invocation instructions for `/smoke-gate` |
+| `.claude/skills/smoke-gate/smoke-gate.sh` | Create | Ephemeral Postgres + alembic upgrade/downgrade chain (spec §0.3) |
+| `.claude/skills/worktree-prune/SKILL.md` | Create | Skill frontmatter + invocation instructions for `/worktree-prune` |
+| `.claude/skills/worktree-prune/worktree-prune.sh` | Create | Orphan-detect + interactive prune (spec §0.4) |
+| `.claude/state/.gitkeep` | Create | Reserves the state directory used by `/cascade` |
+| `.claude/settings.local.json` | Modify | Append `main-is-RED` PreToolUse Bash warn hook (spec §0.5) |
+| `.claude/hookify.warn-destructive-git.local.md` | Modify | Rewrite regex to match target-ref (`main`/`master`) instead of bare `--force` (spec §0.6) |
+
+---
+
+## Task 1: `/cascade` skill — directory + SKILL.md scaffold
+
+**Files:**
+- Create: `.claude/skills/cascade/SKILL.md`
+- Create: `.claude/state/.gitkeep`
+
+- [ ] **Step 1: Create the cascade skill directory and the state directory**
+
+```bash
+mkdir -p /root/availai/.claude/skills/cascade
+mkdir -p /root/availai/.claude/state
+touch /root/availai/.claude/state/.gitkeep
+```
+
+Expected: directories exist, no errors.
+
+```bash
+ls -la /root/availai/.claude/skills/cascade /root/availai/.claude/state
+```
+
+Expected output: both directories listed; `.gitkeep` present in `state/`.
+
+- [ ] **Step 2: Write `.claude/skills/cascade/SKILL.md`**
+
+This file is the user-facing entry point — frontmatter follows the format from `.claude/skills/deploy/SKILL.md` (verified). The body tells the model exactly what `cascade.sh` does and when to invoke it, per spec §0.1.
+
+```markdown
+---
+name: cascade
+description: Toposort open PRs, merge ready leaves, rebase descendants, halt on conflict. Idempotent.
+disable-model-invocation: true
+---
+
+Run `/cascade` when you need to merge a stack of feature PRs in dependency order without a human babysitting each step. See `docs/superpowers/specs/2026-05-08-github-cleanup-design.md` §0.1 for the design rationale.
+
+Steps:
+
+1. Run `bash /root/availai/.claude/skills/cascade/cascade.sh`
+2. The script will:
+   - Read state from `.claude/state/cascade.json` if present (resume mode)
+   - Toposort all OPEN PRs by `baseRefName` (PRs targeting `main` or whose base was already merged are leaves)
+   - For each leaf: snapshot unresolved review comments via `gh api repos/.../pulls/<n>/comments --jq '.[] | select(.in_reply_to_id == null)'`, rebase onto current `main`, force-push with lease, wait for green CI, run `gh pr merge --squash`, then update `.claude/state/cascade.json`
+   - Halt on the first conflict and print the exact `next action` (resolve in worktree, push, re-run `/cascade`)
+3. Report which PRs merged, which halted, and the next action.
+
+The state file shape is `{"merged": [<pr-number>...], "halted_at": <pr-number-or-null>, "halt_reason": "<string-or-null>"}`. Re-running `/cascade` re-reads this and resumes from the next leaf.
+
+DO NOT use this for the stacked PR pair #108/#109 — that pair has a hand-executed procedure in spec §1.2 because the leaf (#109) merges into a non-`main` base. `/cascade` only handles PRs whose base is `main`.
+```
+
+- [ ] **Step 3: Verify the SKILL.md is well-formed**
+
+```bash
+head -5 /root/availai/.claude/skills/cascade/SKILL.md
+```
+
+Expected: opening `---`, `name: cascade`, `description:` line, `disable-model-invocation: true`, closing `---`.
+
+- [ ] **Step 4: Local-only — do NOT commit**
+
+These files are under `.claude/` which is gitignored. Skip any `git add` step. If `git status` shows them as untracked, leave them untracked.
+
+```bash
+cd /root/availai && git check-ignore -v .claude/skills/cascade/SKILL.md
+```
+
+Expected: prints the matching `.gitignore` rule (typically `.gitignore:.claude/`). If it does NOT print a match, STOP and confirm `.claude/` is in `.gitignore` before continuing.
+
+---
+
+## Task 2: `/cascade` skill — implementation script
+
+**Files:**
+- Create: `.claude/skills/cascade/cascade.sh`
+- Test: manual smoke run with `--dry-run` flag against current open PRs
+
+- [ ] **Step 1: Write `cascade.sh` with toposort + leaf-merge loop + state file**
+
+```bash
+cat > /root/availai/.claude/skills/cascade/cascade.sh <<'CASCADE_SH'
+#!/usr/bin/env bash
+# cascade.sh — toposort open PRs, merge leaves, rebase descendants, halt on conflict.
+# Called by: /cascade skill (.claude/skills/cascade/SKILL.md)
+# Depends on: gh CLI authenticated, jq, git, working tree clean on main.
+# State: .claude/state/cascade.json
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+STATE_FILE="$REPO_ROOT/.claude/state/cascade.json"
+DRY_RUN="${1:-}"
+
+# Load or initialize state
+if [ -f "$STATE_FILE" ]; then
+  MERGED=$(jq -r '.merged | join(" ")' "$STATE_FILE")
+else
+  MERGED=""
+  echo '{"merged": [], "halted_at": null, "halt_reason": null}' > "$STATE_FILE"
+fi
+
+# Snapshot all open PRs
+PRS_JSON=$(gh pr list --state open --limit 100 \
+  --json number,baseRefName,headRefName,mergeStateStatus,mergeable,title)
+
+echo "$PRS_JSON" | jq -r '.[] | "PR #\(.number): \(.headRefName) → \(.baseRefName) [\(.mergeStateStatus)]"'
+
+# Compute leaves: PRs whose baseRefName is "main" AND not already in MERGED
+LEAVES=$(echo "$PRS_JSON" | jq -r --arg merged "$MERGED" '
+  [.[] | select(.baseRefName == "main")
+       | select((.number | tostring) as $n | ($merged | split(" ") | index($n)) | not)
+       | select(.mergeable == "MERGEABLE" and (.mergeStateStatus == "CLEAN" or .mergeStateStatus == "UNSTABLE"))]
+  | .[] | .number')
+
+if [ -z "$LEAVES" ]; then
+  echo "No mergeable leaves found. Either all merged, all blocked, or all conflicting."
+  echo "Halt reason candidates:"
+  echo "$PRS_JSON" | jq -r '.[] | select(.baseRefName == "main") | "  PR #\(.number): mergeable=\(.mergeable) state=\(.mergeStateStatus)"'
+  exit 0
+fi
+
+for PR_NUMBER in $LEAVES; do
+  echo ""
+  echo "=== Processing PR #$PR_NUMBER ==="
+
+  HEAD_BRANCH=$(echo "$PRS_JSON" | jq -r --arg n "$PR_NUMBER" '.[] | select(.number == ($n | tonumber)) | .headRefName')
+
+  # Step 1: Snapshot unresolved review comments BEFORE rebase (spec §0.1, silent-failure H7)
+  SNAPSHOT_FILE="$REPO_ROOT/.claude/state/cascade-pr${PR_NUMBER}-comments.json"
+  echo "Snapshotting unresolved comments to $SNAPSHOT_FILE"
+  gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" \
+    --jq '[.[] | select(.in_reply_to_id == null)]' > "$SNAPSHOT_FILE" 2>/dev/null || echo "[]" > "$SNAPSHOT_FILE"
+
+  if [ "$DRY_RUN" = "--dry-run" ]; then
+    echo "DRY RUN: would rebase $HEAD_BRANCH onto main, push --force-with-lease, wait for CI, merge"
+    continue
+  fi
+
+  # Step 2: Rebase onto current main
+  git fetch origin main
+  if ! git checkout "$HEAD_BRANCH" 2>/dev/null; then
+    git fetch origin "$HEAD_BRANCH:$HEAD_BRANCH"
+    git checkout "$HEAD_BRANCH"
+  fi
+
+  if ! git rebase origin/main; then
+    git rebase --abort || true
+    jq --arg pr "$PR_NUMBER" --arg reason "rebase conflict" \
+      '.halted_at = ($pr | tonumber) | .halt_reason = $reason' \
+      "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+    echo ""
+    echo "HALT: PR #$PR_NUMBER has rebase conflict on $HEAD_BRANCH."
+    echo "Next action: cd into worktree for $HEAD_BRANCH, run 'git rebase origin/main', resolve, push --force-with-lease, then re-run /cascade."
+    exit 1
+  fi
+
+  # Step 3: Push with lease
+  git push --force-with-lease origin "$HEAD_BRANCH"
+
+  # Step 4: Wait for CI green on the new SHA
+  echo "Waiting for CI to complete on PR #$PR_NUMBER..."
+  for i in $(seq 1 60); do
+    sleep 30
+    STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus,mergeable,statusCheckRollup \
+      --jq '.statusCheckRollup | map(.conclusion) | unique')
+    case "$STATE" in
+      *FAILURE*|*CANCELLED*)
+        jq --arg pr "$PR_NUMBER" --arg reason "CI failed after rebase" \
+          '.halted_at = ($pr | tonumber) | .halt_reason = $reason' \
+          "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+        echo "HALT: PR #$PR_NUMBER CI failed. Investigate at gh pr view $PR_NUMBER --web"
+        exit 1
+        ;;
+      *SUCCESS*)
+        if ! echo "$STATE" | grep -qE 'PENDING|null'; then
+          echo "CI green on PR #$PR_NUMBER"
+          break
+        fi
+        ;;
+    esac
+    if [ "$i" = "60" ]; then
+      echo "TIMEOUT: CI did not complete in 30 minutes for PR #$PR_NUMBER"
+      exit 1
+    fi
+  done
+
+  # Step 5: Re-post unresolved comments to new SHAs (spec §0.1)
+  COUNT=$(jq 'length' "$SNAPSHOT_FILE")
+  if [ "$COUNT" -gt 0 ]; then
+    echo "Re-posting $COUNT snapshotted comments as PR review remarks"
+    BODY=$(jq -r '"Pre-rebase unresolved review comments (auto-restored by /cascade):\n\n" + ([.[] | "- @" + .user.login + " (" + .path + ":" + (.line // .original_line | tostring) + "): " + .body] | join("\n"))' "$SNAPSHOT_FILE")
+    gh pr comment "$PR_NUMBER" --body "$BODY" || echo "WARN: could not re-post comments"
+  fi
+
+  # Step 6: Squash-merge
+  gh pr merge "$PR_NUMBER" --squash --delete-branch=false
+
+  # Step 7: Update state
+  jq --arg pr "$PR_NUMBER" '.merged += [($pr | tonumber)]' \
+    "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+  echo "MERGED: PR #$PR_NUMBER"
+
+  # Step 8: After each merge, refresh PRS_JSON so newly-eligible leaves (descendants whose base just merged) are picked up
+  git checkout main
+  git pull origin main
+  PRS_JSON=$(gh pr list --state open --limit 100 \
+    --json number,baseRefName,headRefName,mergeStateStatus,mergeable,title)
+done
+
+echo ""
+echo "=== /cascade complete ==="
+jq '.' "$STATE_FILE"
+CASCADE_SH
+chmod +x /root/availai/.claude/skills/cascade/cascade.sh
+```
+
+- [ ] **Step 2: Smoke-test the dry-run path**
+
+```bash
+cd /root/availai && bash .claude/skills/cascade/cascade.sh --dry-run
+```
+
+Expected: prints the open-PR list, identifies leaves (PRs whose `baseRefName` is `main`), prints `DRY RUN: would rebase ...` for each. Does NOT push, does NOT call `gh pr merge`. Exits 0.
+
+If output is empty (no leaves), expected for current repo state if all PRs are CONFLICTING — see spec §1.3 pre-flight which says #96 and #103 must have conflicts resolved before `/cascade` runs.
+
+- [ ] **Step 3: Verify the state file shape on first invocation**
+
+```bash
+cat /root/availai/.claude/state/cascade.json
+```
+
+Expected: `{"merged": [], "halted_at": null, "halt_reason": null}` (or similar — JSON with these three keys).
+
+- [ ] **Step 4: Verify the snapshot file is created on first dry run**
+
+```bash
+ls /root/availai/.claude/state/cascade-pr*-comments.json 2>/dev/null | head -3
+```
+
+Expected: at least one snapshot file per leaf PR. Each is valid JSON (verify with `jq '.' <file>`).
+
+- [ ] **Step 5: Local-only — do NOT commit**
+
+`.claude/state/` is gitignored alongside `.claude/`. Verify with `git check-ignore -v .claude/state/cascade.json`. Expected: prints the gitignore rule.
+
+---
+
+## Task 3: `/recommit` skill
+
+**Files:**
+- Create: `.claude/skills/recommit/SKILL.md`
+
+This is the entire skill — no helper script. Per spec §0.2, the implementation is a one-liner: `git commit "$@" || (git add -u && git commit --no-edit)`. The skill exists so the user has a single named entry point that is explicit about WHY auto-restage happens (pre-commit hooks reformat files, the first commit fails, we re-stage and retry).
+
+- [ ] **Step 1: Create directory and write SKILL.md**
+
+```bash
+mkdir -p /root/availai/.claude/skills/recommit
+```
+
+```markdown
+---
+name: recommit
+description: git commit with explicit re-stage on pre-commit auto-fix failure. No hidden state.
+disable-model-invocation: true
+---
+
+Run `/recommit` instead of `git commit` whenever you have pre-commit hooks that auto-fix files (ruff, ruff-format, docformatter). The first `git commit` will fail because the hook modified files; the second invocation re-stages those files via `git add -u` and retries with the same message.
+
+This is the EXPLICIT replacement for the originally-proposed auto-restage hook (spec §0.2, silent-failure H5: an auto-hook would silently scoop up `git add -p` partial-stage hunks the user did not intend to commit). `/recommit` is opt-in per commit.
+
+Run this exact command, passing through any args the user provides (e.g. `-m "msg"`, `--amend`, file paths):
+
+```bash
+git commit "$@" || (git add -u && git commit --no-edit)
+```
+
+If both attempts fail, surface the full git output to the user — do NOT swallow the error.
+```
+
+Write that file:
+
+```bash
+cat > /root/availai/.claude/skills/recommit/SKILL.md <<'RECOMMIT_MD'
+---
+name: recommit
+description: git commit with explicit re-stage on pre-commit auto-fix failure. No hidden state.
+disable-model-invocation: true
+---
+
+Run `/recommit` instead of `git commit` whenever you have pre-commit hooks that auto-fix files (ruff, ruff-format, docformatter). The first `git commit` will fail because the hook modified files; the second invocation re-stages those files via `git add -u` and retries with the same message.
+
+This is the EXPLICIT replacement for the originally-proposed auto-restage hook (spec §0.2, silent-failure H5: an auto-hook would silently scoop up `git add -p` partial-stage hunks the user did not intend to commit). `/recommit` is opt-in per commit.
+
+Run this exact command, passing through any args the user provides (e.g. `-m "msg"`, `--amend`, file paths):
+
+```bash
+git commit "$@" || (git add -u && git commit --no-edit)
+```
+
+If both attempts fail, surface the full git output to the user — do NOT swallow the error.
+RECOMMIT_MD
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+head -5 /root/availai/.claude/skills/recommit/SKILL.md
+```
+
+Expected: opening `---`, `name: recommit`, `description:`, `disable-model-invocation: true`, closing `---`.
+
+- [ ] **Step 3: Local-only — do NOT commit**
+
+Same as Task 1 Step 4 — `.claude/skills/` is gitignored.
+
+---
+
+## Task 4: `/smoke-gate` skill — SKILL.md scaffold
+
+**Files:**
+- Create: `.claude/skills/smoke-gate/SKILL.md`
+
+- [ ] **Step 1: Create directory and write SKILL.md**
+
+```bash
+mkdir -p /root/availai/.claude/skills/smoke-gate
+```
+
+```bash
+cat > /root/availai/.claude/skills/smoke-gate/SKILL.md <<'SMOKE_MD'
+---
+name: smoke-gate
+description: Ephemeral Postgres + alembic upgrade/downgrade/upgrade chain. Catches alembic chicken-and-egg.
+disable-model-invocation: true
+---
+
+Run `/smoke-gate` before merging any PR that touches `alembic/versions/`. See spec §0.3.
+
+The script:
+1. Spins up `postgres:16` on host port 5433 via `docker run -d --rm`
+2. Waits for the DB to accept connections
+3. Runs `alembic upgrade head` → `alembic downgrade base` → `alembic upgrade head`
+4. Tears down the container even on failure (trap EXIT)
+
+This is exactly the chain that exposes the failure mode behind PRs #108/#109 (downgrade missing reverse op causes `alembic downgrade base` to fail).
+
+Run:
+
+```bash
+bash /root/availai/.claude/skills/smoke-gate/smoke-gate.sh
+```
+
+Exit code 0 means the chain passes; non-zero means a migration is broken — surface the alembic stderr to the user.
+SMOKE_MD
+```
+
+- [ ] **Step 2: Verify SKILL.md present and well-formed**
+
+```bash
+head -5 /root/availai/.claude/skills/smoke-gate/SKILL.md
+```
+
+Expected: opening `---`, frontmatter with `name`, `description`, `disable-model-invocation: true`, closing `---`.
+
+---
+
+## Task 5: `/smoke-gate` skill — implementation script
+
+**Files:**
+- Create: `.claude/skills/smoke-gate/smoke-gate.sh`
+- Test: live run against the current `alembic/` state
+
+- [ ] **Step 1: Write `smoke-gate.sh` with strict cleanup trap**
+
+```bash
+cat > /root/availai/.claude/skills/smoke-gate/smoke-gate.sh <<'SMOKE_SH'
+#!/usr/bin/env bash
+# smoke-gate.sh — ephemeral Postgres + alembic upgrade/downgrade/upgrade chain.
+# Called by: /smoke-gate skill (.claude/skills/smoke-gate/SKILL.md)
+# Depends on: docker, alembic available on PATH, repo root with alembic.ini
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+CONTAINER_NAME="smoke-gate-pg-$$"
+HOST_PORT=5433
+DB_USER=smoke
+DB_PASS=smoke
+DB_NAME=smoke
+
+cleanup() {
+  echo "Cleaning up container $CONTAINER_NAME"
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+echo "Starting ephemeral Postgres 16 on host port $HOST_PORT..."
+docker run -d --rm \
+  --name "$CONTAINER_NAME" \
+  -e POSTGRES_USER="$DB_USER" \
+  -e POSTGRES_PASSWORD="$DB_PASS" \
+  -e POSTGRES_DB="$DB_NAME" \
+  -p "$HOST_PORT:5432" \
+  postgres:16 >/dev/null
+
+echo "Waiting for Postgres to accept connections..."
+for i in $(seq 1 30); do
+  if docker exec "$CONTAINER_NAME" pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+  if [ "$i" = "30" ]; then
+    echo "FAIL: Postgres did not become ready in 30s"
+    exit 1
+  fi
+done
+
+export DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@localhost:${HOST_PORT}/${DB_NAME}"
+export TESTING=1
+export PYTHONPATH="$REPO_ROOT"
+
+echo ""
+echo "=== Step 1: alembic upgrade head ==="
+alembic upgrade head
+
+echo ""
+echo "=== Step 2: alembic downgrade base ==="
+alembic downgrade base
+
+echo ""
+echo "=== Step 3: alembic upgrade head (round-trip) ==="
+alembic upgrade head
+
+echo ""
+echo "=== /smoke-gate PASS ==="
+SMOKE_SH
+chmod +x /root/availai/.claude/skills/smoke-gate/smoke-gate.sh
+```
+
+- [ ] **Step 2: Live-test the script**
+
+```bash
+cd /root/availai && bash .claude/skills/smoke-gate/smoke-gate.sh
+```
+
+Expected output (last line): `=== /smoke-gate PASS ===`, exit code 0.
+
+If it fails on `alembic downgrade base`, that is the legitimate finding the skill is designed to catch — record the failing revision and check whether it matches the spec's reference to PR #108/#109's chicken-and-egg.
+
+- [ ] **Step 3: Verify cleanup happens on failure**
+
+Manually break the chain to confirm the trap fires:
+
+```bash
+cd /root/availai && (bash .claude/skills/smoke-gate/smoke-gate.sh; echo "exit=$?") &
+SMOKE_PID=$!
+sleep 5
+kill -INT $SMOKE_PID 2>/dev/null || true
+wait $SMOKE_PID 2>/dev/null || true
+docker ps --filter "name=smoke-gate-pg-" --format '{{.Names}}'
+```
+
+Expected: empty output from the last `docker ps` command — the trap removed the container even though we SIGINT'd the script.
+
+- [ ] **Step 4: Local-only — do NOT commit**
+
+Same as previous tasks.
+
+---
+
+## Task 6: `/worktree-prune` skill — SKILL.md scaffold
+
+**Files:**
+- Create: `.claude/skills/worktree-prune/SKILL.md`
+
+- [ ] **Step 1: Create directory and write SKILL.md**
+
+```bash
+mkdir -p /root/availai/.claude/skills/worktree-prune
+cat > /root/availai/.claude/skills/worktree-prune/SKILL.md <<'PRUNE_MD'
+---
+name: worktree-prune
+description: Detect orphan .claude/worktrees/ dirs, cross-check PR state, interactive remove.
+disable-model-invocation: true
+---
+
+Run `/worktree-prune` to find orphans in `.claude/worktrees/` (dirs that exist on disk but are NOT in `git worktree list`). Per spec §0.4.
+
+The script:
+1. Computes `comm -23 <(ls .claude/worktrees/) <(git worktree list --porcelain | awk '/^worktree/ {print $2}' | sed 's|.*/||')`
+2. For each orphan, prints the dir + the associated branch state (from `gh pr view <branch>` if recoverable from `.git/HEAD` inside the dir)
+3. Asks the user to confirm each removal (`y/n/q`)
+4. Removes confirmed orphans via `git worktree remove --force <path>` if git knows about them, or plain `rm -rf <path>` if it does not
+
+Run:
+
+```bash
+bash /root/availai/.claude/skills/worktree-prune/worktree-prune.sh
+```
+
+Re-run safely — script is idempotent (no-op on dirs already cleaned).
+PRUNE_MD
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+head -5 /root/availai/.claude/skills/worktree-prune/SKILL.md
+```
+
+Expected: well-formed frontmatter.
+
+---
+
+## Task 7: `/worktree-prune` skill — implementation script
+
+**Files:**
+- Create: `.claude/skills/worktree-prune/worktree-prune.sh`
+- Test: live run against the 7 known orphan dirs from spec §1.4
+
+- [ ] **Step 1: Write `worktree-prune.sh`**
+
+```bash
+cat > /root/availai/.claude/skills/worktree-prune/worktree-prune.sh <<'PRUNE_SH'
+#!/usr/bin/env bash
+# worktree-prune.sh — detect orphan .claude/worktrees/ dirs and prompt for removal.
+# Called by: /worktree-prune skill (.claude/skills/worktree-prune/SKILL.md)
+# Depends on: git, gh CLI (optional; for branch state)
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+WORKTREE_DIR="$REPO_ROOT/.claude/worktrees"
+if [ ! -d "$WORKTREE_DIR" ]; then
+  echo "No .claude/worktrees/ directory present. Nothing to prune."
+  exit 0
+fi
+
+# Set of directory names actually present on disk
+ON_DISK=$(ls "$WORKTREE_DIR" 2>/dev/null | sort)
+
+# Set of basenames git tracks
+TRACKED=$(git worktree list --porcelain | awk '/^worktree/ {print $2}' | sed 's|.*/||' | sort)
+
+# Orphans = on-disk minus tracked
+ORPHANS=$(comm -23 <(echo "$ON_DISK") <(echo "$TRACKED"))
+
+if [ -z "$ORPHANS" ]; then
+  echo "No orphan worktree directories found."
+  exit 0
+fi
+
+echo "Found orphan dirs in .claude/worktrees/:"
+echo "$ORPHANS" | sed 's/^/  /'
+echo ""
+
+for dir in $ORPHANS; do
+  full_path="$WORKTREE_DIR/$dir"
+  echo "=== $full_path ==="
+
+  # Try to discover the branch this dir was for
+  if [ -f "$full_path/.git" ]; then
+    head_file=$(grep '^gitdir:' "$full_path/.git" 2>/dev/null | awk '{print $2}')/HEAD
+    branch=$(cat "$head_file" 2>/dev/null | sed 's|ref: refs/heads/||')
+  else
+    branch="(unknown)"
+  fi
+
+  echo "  branch: $branch"
+
+  # Optional gh lookup
+  if [ "$branch" != "(unknown)" ] && command -v gh >/dev/null 2>&1; then
+    pr_state=$(gh pr list --head "$branch" --state all --json number,state --jq '.[0] | "PR #\(.number) \(.state)"' 2>/dev/null || echo "(no PR)")
+    echo "  PR state: $pr_state"
+  fi
+
+  read -r -p "  Remove this orphan? [y/N/q] " ans
+  case "$ans" in
+    y|Y)
+      if git worktree list --porcelain | grep -q "^worktree $full_path\$"; then
+        git worktree remove --force "$full_path"
+      else
+        rm -rf "$full_path"
+      fi
+      echo "  removed."
+      ;;
+    q|Q)
+      echo "  quitting."
+      exit 0
+      ;;
+    *)
+      echo "  skipped."
+      ;;
+  esac
+done
+
+# Final reconciliation
+git worktree prune
+echo ""
+echo "Done. Remaining worktrees:"
+git worktree list
+PRUNE_SH
+chmod +x /root/availai/.claude/skills/worktree-prune/worktree-prune.sh
+```
+
+- [ ] **Step 2: Live-test in dry-mode by piping `n` to all prompts**
+
+```bash
+cd /root/availai && yes n | bash .claude/skills/worktree-prune/worktree-prune.sh | head -40
+```
+
+Expected: lists the 7 known orphan dirs from spec §1.4 (`agent-a034b395`, `agent-a263dee1`, `agent-a37647f7`, `agent-a47a352b`, `agent-a4cf0049`, `agent-a6911920`, `agent-aff7e329`), prompts for each, and skips all (because we answered `n`). Final line: `Done. Remaining worktrees:` followed by `git worktree list` output. Exit code 0.
+
+If the orphan list is different from the spec's 7 (e.g. some were already cleaned manually), record the actual list — do NOT mutate it. Track 1.4 will do the actual removal.
+
+- [ ] **Step 3: Local-only — do NOT commit**
+
+Same as previous tasks.
+
+---
+
+## Task 8: `main-is-RED` pre-push warn hook
+
+**Files:**
+- Modify: `.claude/settings.local.json` — append a new PreToolUse hook entry under the `Bash` matcher
+
+- [ ] **Step 1: Read the current `settings.local.json` and identify the insertion point**
+
+The current file has `permissions` and `hooks.PreToolUse` arrays. The new hook is a `PreToolUse` entry on `Bash` with command-pattern matching. Existing PreToolUse entries use `matcher: "Read|Edit|Write"` etc.; this new one uses `matcher: "Bash"` and inspects `$CLAUDE_TOOL_INPUT` to confirm the command starts with `git push`.
+
+- [ ] **Step 2: Insert the hook block via Edit**
+
+Add this new object to the `PreToolUse` array (alongside the existing three blocks). The hook is non-blocking — it always exits 0; it only writes a warn line to stderr (which Claude Code surfaces to the operator).
+
+The exact command, written single-line for JSON:
+
+```
+case "$CLAUDE_TOOL_INPUT" in *git*push*) c=$(gh run list --branch main --limit 1 --json conclusion -q '.[0].conclusion' 2>/dev/null); [ "$c" = "failure" ] && echo "WARN: main CI is currently RED — your PR's mergeStateStatus will show UNSTABLE due to main, not your PR" >&2 ;; esac; exit 0
+```
+
+Append the following block to the `PreToolUse` array (becomes the fourth entry):
+
+```json
+{
+  "matcher": "Bash",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "case \"$CLAUDE_TOOL_INPUT\" in *git*push*) c=$(gh run list --branch main --limit 1 --json conclusion -q '.[0].conclusion' 2>/dev/null); [ \"$c\" = \"failure\" ] && echo \"WARN: main CI is currently RED — your PR's mergeStateStatus will show UNSTABLE due to main, not your PR\" >&2 ;; esac; exit 0",
+      "statusMessage": "main-is-RED check"
+    }
+  ]
+}
+```
+
+Use the Edit tool to insert this block immediately before the closing `]` of the `PreToolUse` array (after the existing third block ending with `"statusMessage": "Status string guard"`). Be careful to add a trailing comma to the previous block.
+
+- [ ] **Step 3: Verify the JSON is still valid**
+
+```bash
+jq '.' /root/availai/.claude/settings.local.json > /dev/null && echo "JSON OK"
+```
+
+Expected: `JSON OK`. If `jq` errors, fix the trailing-comma / brace placement.
+
+- [ ] **Step 4: Verify the hook fires by simulating `git push`**
+
+```bash
+CLAUDE_TOOL_INPUT="git push origin feature/test-branch" bash -c "$(jq -r '.hooks.PreToolUse | map(select(.matcher == "Bash")) | .[0].hooks[0].command' /root/availai/.claude/settings.local.json)"
+echo "exit=$?"
+```
+
+Expected: `exit=0`. Stderr will contain the WARN line ONLY if `main` CI is currently red at the time of this command.
+
+To force-test the warn path (regardless of real CI state), you can replace the `gh run list` call with `c=failure` for one shot:
+
+```bash
+CLAUDE_TOOL_INPUT="git push origin feature/test-branch" bash -c 'case "$CLAUDE_TOOL_INPUT" in *git*push*) c=failure; [ "$c" = "failure" ] && echo "WARN: main CI is currently RED — your PRs mergeStateStatus will show UNSTABLE due to main, not your PR" >&2 ;; esac; exit 0'
+echo "exit=$?"
+```
+
+Expected: warn line on stderr, `exit=0`. Confirms the conditional branch logic.
+
+- [ ] **Step 5: Local-only — do NOT commit**
+
+`.claude/settings.local.json` is already gitignored per project convention. Verify with `git check-ignore -v .claude/settings.local.json`.
+
+---
+
+## Task 9: Fix `warn-destructive-git` hookify rule (target-ref matching)
+
+**Files:**
+- Modify: `.claude/hookify.warn-destructive-git.local.md`
+
+Current pattern (verified by reading the file):
+
+```
+pattern: git\s+(push\s+--force|reset\s+--hard|checkout\s+\.|clean\s+-f|branch\s+-D)
+```
+
+Per spec §0.6, the change is to make `git push --force` block ONLY when targeting `main` or `master`, while still blocking the other unconditional destructive ops (`reset --hard`, `checkout .`, `clean -f`, `branch -D`). `--force-with-lease` to `main`/`master` must also be blocked.
+
+- [ ] **Step 1: Replace the `pattern:` line with the target-ref version**
+
+The new pattern uses an alternation across five sub-patterns. The first two cover the force-push variants targeting `main`/`master`; the remaining three are unchanged unconditional blocks.
+
+```
+pattern: (git\s+push\b[^\n]*--force\b[^\n]*\b(main|master)\b)|(git\s+push\b[^\n]*--force-with-lease[^\n]*\b(main|master)\b)|(git\s+reset\s+--hard)|(git\s+checkout\s+\.)|(git\s+clean\s+-f)|(git\s+branch\s+-D)
+```
+
+Use Edit to replace the existing `pattern:` line in `.claude/hookify.warn-destructive-git.local.md`:
+
+- old: `pattern: git\s+(push\s+--force|reset\s+--hard|checkout\s+\.|clean\s+-f|branch\s+-D)`
+- new: `pattern: (git\s+push\b[^\n]*--force\b[^\n]*\b(main|master)\b)|(git\s+push\b[^\n]*--force-with-lease[^\n]*\b(main|master)\b)|(git\s+reset\s+--hard)|(git\s+checkout\s+\.)|(git\s+clean\s+-f)|(git\s+branch\s+-D)`
+
+- [ ] **Step 2: Update the message body to reflect the new semantics**
+
+Replace the current message body so it correctly explains that force-push to feature branches is allowed:
+
+- old:
+
+```
+**BLOCKED: Destructive git operation detected**
+
+Force push, hard reset, and clean -f can cause irreversible data loss.
+Ask the user for explicit confirmation before proceeding with destructive git operations.
+```
+
+- new:
+
+```
+**BLOCKED: Destructive git operation against a protected target**
+
+This rule blocks:
+- `git push --force` or `--force-with-lease` to `main`/`master`
+- `git reset --hard`, `git checkout .`, `git clean -f`, `git branch -D` (unconditional)
+
+Force-push to feature branches is allowed (legitimate worktree workflow).
+Ask the user for explicit confirmation before proceeding.
+```
+
+- [ ] **Step 3: Verify the file's frontmatter is still well-formed**
+
+```bash
+head -8 /root/availai/.claude/hookify.warn-destructive-git.local.md
+```
+
+Expected: opening `---`, `name: warn-destructive-git`, `enabled: true`, `event: bash`, `pattern: ...` (the new long pattern on one line), `action: block`, closing `---`.
+
+- [ ] **Step 4: Test the regex against the spec's intent — these MUST match (BLOCK)**
+
+```bash
+PATTERN='(git\s+push\b[^\n]*--force\b[^\n]*\b(main|master)\b)|(git\s+push\b[^\n]*--force-with-lease[^\n]*\b(main|master)\b)|(git\s+reset\s+--hard)|(git\s+checkout\s+\.)|(git\s+clean\s+-f)|(git\s+branch\s+-D)'
+for cmd in \
+  "git push --force origin main" \
+  "git push origin main --force" \
+  "git push --force-with-lease origin main" \
+  "git push origin main --force-with-lease" \
+  "git push --force origin master" \
+  "git reset --hard HEAD~1" \
+  "git checkout ." \
+  "git clean -fd" \
+  "git branch -D feature/foo"; do
+    if echo "$cmd" | grep -Pq "$PATTERN"; then echo "BLOCK: $cmd"; else echo "MISS:  $cmd"; fi
+done
+```
+
+Expected: every line prints `BLOCK: <cmd>`. Any `MISS:` line is a regression — fix the pattern.
+
+- [ ] **Step 5: Test the regex against the ALLOW cases — these MUST NOT match**
+
+```bash
+PATTERN='(git\s+push\b[^\n]*--force\b[^\n]*\b(main|master)\b)|(git\s+push\b[^\n]*--force-with-lease[^\n]*\b(main|master)\b)|(git\s+reset\s+--hard)|(git\s+checkout\s+\.)|(git\s+clean\s+-f)|(git\s+branch\s+-D)'
+for cmd in \
+  "git push --force origin feature/cleanup" \
+  "git push --force-with-lease origin chore/great-purge" \
+  "git push --force origin docs/claude-md-rebuild" \
+  "git push origin main" \
+  "git push origin main --tags"; do
+    if echo "$cmd" | grep -Pq "$PATTERN"; then echo "BLOCK: $cmd (REGRESSION)"; else echo "ALLOW: $cmd"; fi
+done
+```
+
+Expected: every line prints `ALLOW: <cmd>`. Any `BLOCK: ... (REGRESSION)` is a false positive — fix the pattern.
+
+- [ ] **Step 6: Local-only — do NOT commit**
+
+`.claude/hookify.*.local.md` files are gitignored. Verify with `git check-ignore -v .claude/hookify.warn-destructive-git.local.md`.
+
+---
+
+## Task 10: End-to-end validation pass
+
+**Files:** none modified — pure verification.
+
+- [ ] **Step 1: Confirm all four skill directories + scripts exist and are executable**
+
+```bash
+test -f /root/availai/.claude/skills/cascade/SKILL.md \
+  && test -x /root/availai/.claude/skills/cascade/cascade.sh \
+  && test -f /root/availai/.claude/skills/recommit/SKILL.md \
+  && test -f /root/availai/.claude/skills/smoke-gate/SKILL.md \
+  && test -x /root/availai/.claude/skills/smoke-gate/smoke-gate.sh \
+  && test -f /root/availai/.claude/skills/worktree-prune/SKILL.md \
+  && test -x /root/availai/.claude/skills/worktree-prune/worktree-prune.sh \
+  && echo "ALL TRACK 0 ARTIFACTS PRESENT"
+```
+
+Expected: `ALL TRACK 0 ARTIFACTS PRESENT`.
+
+- [ ] **Step 2: Confirm settings.local.json contains the main-is-RED hook**
+
+```bash
+jq '.hooks.PreToolUse | map(select(.matcher == "Bash")) | length' /root/availai/.claude/settings.local.json
+```
+
+Expected: `1` (or higher if other Bash matchers exist; the new entry must be present).
+
+```bash
+jq -r '.hooks.PreToolUse | map(select(.matcher == "Bash")) | .[0].hooks[0].command' /root/availai/.claude/settings.local.json | grep -q "main is currently RED" && echo "HOOK INSTALLED"
+```
+
+Expected: `HOOK INSTALLED`.
+
+- [ ] **Step 3: Confirm the warn-destructive-git pattern is the new target-ref version**
+
+```bash
+grep -Eq 'main\|master' /root/availai/.claude/hookify.warn-destructive-git.local.md && echo "PATTERN UPGRADED"
+```
+
+Expected: `PATTERN UPGRADED`.
+
+- [ ] **Step 4: Confirm none of the Track 0 artifacts are tracked by git**
+
+```bash
+cd /root/availai && git status --porcelain .claude/skills/cascade .claude/skills/recommit .claude/skills/smoke-gate .claude/skills/worktree-prune .claude/state .claude/settings.local.json .claude/hookify.warn-destructive-git.local.md
+```
+
+Expected: empty output (all paths gitignored, nothing tracked, nothing to commit). If any path appears, verify `.gitignore` covers `.claude/`.
+
+- [ ] **Step 5: Run the success-criteria check from spec §10 item 7**
+
+```bash
+test -d /root/availai/.claude/skills/cascade \
+  && test -d /root/availai/.claude/skills/recommit \
+  && test -d /root/availai/.claude/skills/smoke-gate \
+  && test -d /root/availai/.claude/skills/worktree-prune \
+  && echo "SPEC §10 ITEM 7 PASS"
+```
+
+Expected: `SPEC §10 ITEM 7 PASS`.
+
+- [ ] **Step 6: Run the success-criteria check from spec §10 item 8**
+
+```bash
+grep -q "main is currently RED" /root/availai/.claude/settings.local.json \
+  || test -x /root/availai/.claude/hooks/main-is-red-warn.sh \
+  && echo "SPEC §10 ITEM 8 PASS"
+```
+
+Expected: `SPEC §10 ITEM 8 PASS`.
+
+---
+
+## Self-review against the spec
+
+Each spec subsection mapped to the task that implements it:
+
+| Spec § | Subject | Implementing task(s) |
+|---|---|---|
+| §0.1 | `/cascade` skill — toposort, leaf merge, idempotent state, comment snapshot | Task 1 (SKILL.md) + Task 2 (cascade.sh) |
+| §0.2 | `/recommit` skill — explicit re-stage replacement for auto-restage hook | Task 3 |
+| §0.3 | `/smoke-gate` skill — ephemeral Postgres + alembic chain | Task 4 (SKILL.md) + Task 5 (smoke-gate.sh) |
+| §0.4 | `/worktree-prune` skill — orphan detect + interactive prune | Task 6 (SKILL.md) + Task 7 (worktree-prune.sh) |
+| §0.5 | `main-is-RED` pre-push warn hook (PreToolUse Bash, non-blocking) | Task 8 |
+| §0.6 | Fix `warn-destructive-git` hookify rule — target-ref matching | Task 9 |
+| §10 item 7 (success criteria) | All four skill dirs exist | Task 10 Step 5 |
+| §10 item 8 (success criteria) | `main-is-RED` hook installed | Task 10 Step 6 |
+
+Silent-failure protections from §11 specifically addressed by Track 0:
+
+- **H5 / C4 (auto-restage hook bypasses `git add -p`)** → Task 3 ships explicit `/recommit` skill instead of an auto-hook.
+- **H6 / C8 (force-push whitelist by path was a band-aid)** → Task 9 rewrites pattern to match target-ref (`main`/`master`), which is the root-cause fix.
+- **H7 (rebase silently buries unresolved review comments)** → Task 2 Step 1's `cascade.sh` snapshots unresolved comments to `.claude/state/cascade-pr<n>-comments.json` BEFORE rebase and re-posts them after force-push.
+
+Build-order rule preserved: `/cascade`, `/recommit`, `/smoke-gate`, `/worktree-prune` all exist locally before Track 1 begins, so Track 1.1 (stabilize main) can use `/smoke-gate`, Track 1.3 (cascade-merge 11 PRs) can use `/cascade`, and Track 1.4 (worktree consolidation) can use `/worktree-prune`. The `main-is-RED` hook starts firing immediately, surfacing the `mergeStateStatus=UNSTABLE` confusion that Track 1 will encounter.

--- a/docs/superpowers/plans/2026-05-08-github-cleanup-track-1-critical-path.md
+++ b/docs/superpowers/plans/2026-05-08-github-cleanup-track-1-critical-path.md
@@ -1,0 +1,794 @@
+# Track 1 — Critical Path Implementation Plan
+
+> **For agentic workers:** This plan is the sequential critical path of the GitHub Cleanup design (spec: `/root/availai/.claude/worktrees/spec-cleanup/docs/superpowers/specs/2026-05-08-github-cleanup-design.md`, §1.1–§1.4 + §13). Execute tasks IN ORDER — earlier tasks unblock later ones. Each task is bite-sized (2–5 min). Section §-numbers in tasks reference the spec, not this plan. Stop and surface immediately on any unexpected output, conflict, or red CI; do not improvise around the spec.
+
+## Goal
+
+Drive the repo from its current red, blocked, drift-laden state to: `main` green, all 13 open PRs resolved, no orphan worktrees or stale remote branches, CLAUDE.md drift fixed. This unblocks Track 2B (branch protection + `deleteBranchOnMerge`), which the spec explicitly forbids landing until Track 1 is done.
+
+Specifically:
+- §1.1 Stabilize `main` (red CI on `6890dcf5`, direct-to-main hotfix allowed pre-protection).
+- §1.2 Resolve the #109 → #108 → main stack and ship the §13 CLAUDE.md fix-now mini-PR.
+- §1.3 Cascade-merge 11 PRs via the `/cascade` skill (deps → infra → features), with pre-flight conflict resolution on #96 and #103, fast-track on dependabot #100.
+- §1.4 Worktree + remote-branch consolidation (orphan dirs, merged worktrees, merged remote branches, safe local prune).
+
+## Architecture
+
+Track 1 mostly mutates **repo state on GitHub** via `gh` and **local git state** via `git`/`git worktree`. The only files modified inside this track are:
+1. The hotfix file(s) for §1.1 (unknown until diagnosis).
+2. Conflict-resolution edits in #96's and #103's worktrees.
+3. `/root/availai/CLAUDE.md` (and a one-liner in `/root/availai/.env.example`) for the §13 fix-now mini-PR.
+
+The work is **sequential by design** (per spec §1 dependency arrow: 1.1 → 1.2 → 1.3 → 1.4). Do not parallelize across the four subsections — each guards the next from a known silent-failure mode (stack orphaning H2, comment loss H7, branch-deletion-during-cascade H4, etc.).
+
+## Tech Stack
+
+- `gh` CLI (PR/run/api operations) — repo `TRIOSCS/Avail-AI-Test`
+- `git` + `git worktree` — local repo at `/root/availai`, this plan-execution worktree at `/root/availai/.claude/worktrees/spec-cleanup`
+- Track 0 skills (PREREQUISITE, see below): `/cascade`, `/recommit`, `/smoke-gate`, `/worktree-prune`
+- Local pre-commit, pytest, ruff, mypy (per CLAUDE.md "Before pushing big PRs" rule)
+
+## PREREQUISITES
+
+**Track 0 MUST be complete before starting Track 1.** Per spec §0 and the dependency arrow in §Architecture, Track 1 invokes the Track 0 skills directly.
+
+Verify these exist before beginning:
+
+```bash
+test -d /root/availai/.claude/skills/cascade        || echo "MISSING: /cascade — Track 0.1 incomplete"
+test -d /root/availai/.claude/skills/recommit       || echo "MISSING: /recommit — Track 0.2 incomplete"
+test -d /root/availai/.claude/skills/smoke-gate     || echo "MISSING: /smoke-gate — Track 0.3 incomplete"
+test -d /root/availai/.claude/skills/worktree-prune || echo "MISSING: /worktree-prune — Track 0.4 incomplete"
+```
+
+If any are missing, halt and complete Track 0 first. The §1.3 cascade absolutely requires `/cascade` (manual cascade is forbidden — H1, H4, H7 silent-failure modes are specifically what `/cascade` exists to prevent).
+
+Also verify branch protection is OFF on `main` (the §1.1 direct-to-main hotfix depends on this):
+
+```bash
+gh api repos/TRIOSCS/Avail-AI-Test/branches/main/protection 2>&1 | grep -q '"message": "Branch not protected"' \
+  && echo "OK: main is unprotected (Track 2B not yet applied)" \
+  || echo "STOP: main protection appears active — investigate before §1.1 hotfix"
+```
+
+## File Structure
+
+This track mutates repo state more than files. Files actually edited in Track 1:
+
+| Path | Section | Notes |
+|---|---|---|
+| (TBD by §1.1 diagnosis) | §1.1 | Hotfix target unknown until `gh run view 25532626888 --log-failed` is read. Likely candidates: `requirements.txt`, an `alembic/versions/*.py`, an `app/**/*.py` test/source, or a CI workflow. |
+| Files in #96's worktree | §1.3 pre-flight | Whatever conflicts vs. main on `fix/ci-unblock-test-assertions`. |
+| Files in #103's worktree | §1.3 pre-flight | Whatever conflicts vs. main on `docs/claude-md-rebuild`. |
+| `/root/availai/CLAUDE.md` | §1.2 step 6 (per §13) | 7 fix-now items: pre-commit list (line 440), `ANTHROPIC_MODEL` value (line 640), config block (lines 627–668: remove 4 phantom keys, replace `AZURE_REDIRECT_URI`→`APP_URL`, add 3 real keys, add `.env.example` pointer). |
+| `/root/availai/.env.example` | §1.2 step 6 (per §13.5) | One-line `claude-sonnet-4-6` fix on line 9, rides the same mini-PR. |
+
+Worktree-CLAUDE.md drift across 6 worktree copies + `/root/availai-health-fix/CLAUDE.md` is **not** edited per file — those copies vanish when their worktrees are removed in §1.4 (per spec §13 item 4).
+
+---
+
+## Tasks
+
+### §1.1 — Stabilize main
+
+#### Task 1.1.1 — Capture current main CI state
+
+Confirm we are diagnosing the right run, and pin the failing SHA in writing for the worklog.
+
+```bash
+cd /root/availai
+git fetch origin
+git rev-parse origin/main                                 # should be 6890dcf5... (or document the new HEAD if main moved)
+gh run list --branch main --limit 5 \
+  --json databaseId,headSha,name,conclusion,createdAt \
+  --jq '.[] | "\(.databaseId)\t\(.headSha[0:8])\t\(.name)\t\(.conclusion)\t\(.createdAt)"'
+```
+
+Expected: at least one row for run id `25532626888` showing `failure`. If main has moved past `6890dcf5`, re-identify the most recent `failure` run on `main` and use **its** id throughout §1.1 (treat `25532626888` in subsequent commands as a placeholder for "the failing main run").
+
+#### Task 1.1.2 — Diagnose root cause from failing run logs
+
+Pull the failing logs and read carefully.
+
+```bash
+gh run view 25532626888 --log-failed | tee /tmp/main-fail.log
+```
+
+Expected output structure to look for:
+- Failing job name (e.g., `test`, `security`)
+- Failing step (e.g., `Run pytest`, `pip-audit`, `npm audit`)
+- The actual error trace — typically a Python traceback (test name + assertion / exception), an alembic error, a dependency-resolution error, or an audit CVE.
+
+Write down (mentally or in scratch buffer) the **single root cause** before moving to fix. Per CLAUDE.md "No band-aids": you fix the cause, not the symptom.
+
+#### Task 1.1.3 — Apply the §1.1 hotfix (direct to main)
+
+Open-ended by necessity — the fix shape depends on §1.1.2. Reference shapes:
+
+- **If dependency drift / pip-audit CVE:** pin or bump the offending version in `requirements.txt` (or `pyproject.toml`). Verify locally: `pip install -r requirements.txt && pip-audit` (or whichever tool the workflow uses).
+- **If npm audit:** `npm audit fix` (or targeted `npm install <pkg>@<safe>`); commit `package-lock.json`.
+- **If test regression:** fix the underlying code OR update the assertion (only if the assertion is genuinely stale — never tweak a test to mask a real bug). Re-run locally: `TESTING=1 PYTHONPATH=/root/availai pytest tests/<file>::<test> -v`.
+- **If migration / alembic issue:** invoke `/smoke-gate` to verify `upgrade head → downgrade base → upgrade head` chain, then ship the migration fix.
+- **If workflow YAML issue:** edit `.github/workflows/<file>.yml`; confirm syntax with `gh workflow view`.
+
+Commit directly on `main` (per spec §1.1 — this is the **only** direct-to-main exception in the whole design):
+
+```bash
+cd /root/availai
+git checkout main
+git pull --ff-only origin main
+git add <fixed-files>
+git commit -m "fix(ci): stabilize main — <one-line cause>"
+git push origin main
+```
+
+If `git push` is blocked by the `warn-destructive-git` hookify rule, that means Track 0.6 was not yet applied — pause and complete Track 0.6 (the rule should only block force-pushes to `main`, not regular pushes).
+
+#### Task 1.1.4 — Verify main CI returns green
+
+Wait for the new run, then verify.
+
+```bash
+sleep 15  # let GH register the push
+gh run watch --exit-status $(gh run list --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run list --branch main --limit 2 --json conclusion --jq '.[0].conclusion'
+```
+
+Expected: `success`. If `failure`, return to §1.1.2 with the new run id and iterate. Do not proceed to §1.2 with red main.
+
+---
+
+### §1.2 — Resolve stacked PRs (#109 → #108 → main) and ship §13 CLAUDE.md mini-PR
+
+#### Task 1.2.1 — Verify the stack invariant before merging
+
+```bash
+gh pr view 109 --json baseRefName,headRefName,mergeable,mergeStateStatus,commits \
+  --jq '{base: .baseRefName, head: .headRefName, mergeable, state: .mergeStateStatus, latest_sha: .commits[-1].oid[0:8]}'
+gh pr view 108 --json baseRefName,headRefName,mergeable,mergeStateStatus \
+  --jq '{base: .baseRefName, head: .headRefName, mergeable, state: .mergeStateStatus}'
+```
+
+Expected:
+- #109 `base` = `fix/ci-unblock-alembic-and-audit` (NOT `main`), `mergeable` = `MERGEABLE`, latest commit on green CI per spec §1.2 (sha prefix `46ffc97` per spec, but accept whatever HEAD is on the branch).
+- #108 `base` = `main`, `head` = `fix/ci-unblock-alembic-and-audit`.
+
+If #109's base is `main` instead of `fix/ci-unblock-alembic-and-audit`, halt — the stack has been broken and the spec's §1.2 procedure no longer applies; surface for operator decision.
+
+#### Task 1.2.2 — Squash-merge #109 INTO #108's branch
+
+Per spec §1.2 step 1 — this merges into the parent PR's branch, not main, because #109's base IS #108's branch.
+
+```bash
+gh pr merge 109 --squash --delete-branch=false
+```
+
+Note: explicit `--delete-branch=false` because `deleteBranchOnMerge` is OFF at the repo level right now anyway, but being explicit avoids a future-proofing surprise. After this command, #109 is `MERGED` and `fix/ci-unblock-alembic-and-audit` (the #108 branch) has gained #109's squashed commit.
+
+Verify:
+
+```bash
+gh pr view 109 --json state --jq .state                   # MERGED
+gh pr view 108 --json commits --jq '.commits[-1].oid[0:8]'  # should be a NEW sha vs. before
+```
+
+#### Task 1.2.3 — Wait for #108's CI to re-run and turn green
+
+The merge in §1.2.2 pushed a new commit to `fix/ci-unblock-alembic-and-audit`, so a fresh CI run kicks off automatically.
+
+```bash
+sleep 15
+gh run watch --exit-status $(gh run list --branch fix/ci-unblock-alembic-and-audit --limit 1 --json databaseId --jq '.[0].databaseId')
+gh pr view 108 --json mergeStateStatus,statusCheckRollup --jq '{state: .mergeStateStatus, checks: [.statusCheckRollup[] | {name, conclusion}]}'
+```
+
+Expected: every check `SUCCESS`, mergeStateStatus `CLEAN`. If any check fails, halt — the assumption that #109's fixes covered #108 has broken; investigate the failure before continuing.
+
+#### Task 1.2.4 — Squash-merge #108 into main
+
+Per spec §1.2 step 4.
+
+```bash
+gh pr merge 108 --squash --delete-branch=false
+```
+
+Verify:
+
+```bash
+gh pr view 108 --json state --jq .state                   # MERGED
+git -C /root/availai fetch origin
+git -C /root/availai log origin/main -1 --oneline         # should be the squash-merge commit
+```
+
+#### Task 1.2.5 — Verify main CI green post-stack-resolution
+
+```bash
+sleep 15
+gh run watch --exit-status $(gh run list --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run list --branch main --limit 1 --json conclusion --jq '.[0].conclusion'   # success
+```
+
+If failure: halt — the cascade in §1.3 cannot start with a red main (every cascade PR's `mergeStateStatus` would inherit UNSTABLE, which is the exact root cause of the original 8-PR pile-up).
+
+#### Task 1.2.6 — Branch + worktree for the §13 fix-now mini-PR
+
+Per spec §13 — small, direct PR scope = 7 CLAUDE.md edits + 1 `.env.example` line.
+
+```bash
+cd /root/availai
+git checkout main && git pull --ff-only origin main
+git checkout -b chore/claudemd-fix-now
+# Stay in /root/availai for this PR — it's a tiny doc edit; no worktree needed.
+```
+
+#### Task 1.2.7 — Apply §13 item 1 — pre-commit hook list (CLAUDE.md line ~440)
+
+Open `/root/availai/CLAUDE.md`, find the existing line:
+
+```
+Pre-commit hooks: ruff, ruff-format, mypy, docformatter, detect-private-key
+```
+
+Replace with the spec §13.1 verbatim list:
+
+```
+Pre-commit hooks: ruff, ruff-format, mypy, docformatter, detect-private-key, check-yaml, check-added-large-files, check-merge-conflict, end-of-file-fixer, trailing-whitespace; pre-push hook runs full --all-files sweep automatically
+```
+
+#### Task 1.2.8 — Apply §13 item 2 — `ANTHROPIC_MODEL` value (CLAUDE.md line ~640)
+
+Find:
+
+```
+ANTHROPIC_MODEL=claude-3-5-sonnet-20241022
+```
+
+Replace with:
+
+```
+ANTHROPIC_MODEL=claude-sonnet-4-6
+```
+
+(Spec §13.2: matches `app/config.py`.)
+
+#### Task 1.2.9 — Apply §13 item 3 — Configuration block surgery (CLAUDE.md lines 627–668)
+
+Three sub-edits in the `## Configuration` block:
+
+a. **Remove phantom keys** (these are not in `app/config.py`):
+   - `MICROSOFT_GRAPH_ENDPOINT=...`
+   - `SMTP_FROM=...`
+   - `ACTIVITY_TRACKING_ENABLED=...`
+   - `CONTACTS_SYNC_ENABLED=...`
+   Delete the lines (and any now-empty surrounding block / fenced section header that goes with them).
+
+b. **Replace** `AZURE_REDIRECT_URI=https://app.yourdomain.com/auth/callback` with `APP_URL=https://app.yourdomain.com` (spec §13.3 — `app/config.py` uses `APP_URL`, not `AZURE_REDIRECT_URI`).
+
+c. **Add** these three keys to the appropriate subsection (Feature Flags or a new "Other" subsection — match the existing markdown style of fenced bash blocks with `KEY=value`):
+   - `AVAIL_OPP_TABLE_V2=true`
+   - `ENCRYPTION_SALT=<random>`
+   - `EXPLORIUM_API_KEY=...`
+
+d. **Add** a single pointer line at the bottom of the Configuration section (before any horizontal rule):
+
+```
+> See `.env.example` for long-tail keys (`EIGHT_BY_EIGHT_*`, `NC_*`, `BACKUP_*`, `DO_SPACES_*`).
+```
+
+#### Task 1.2.10 — Apply §13 item 5 — `.env.example` line 9
+
+Open `/root/availai/.env.example`. Find line 9 (`ANTHROPIC_MODEL=claude-3-5-sonnet-20241022` per spec §13.5) and update to:
+
+```
+ANTHROPIC_MODEL=claude-sonnet-4-6
+```
+
+#### Task 1.2.11 — Lint, commit, and push the mini-PR
+
+```bash
+cd /root/availai
+pre-commit run --all-files                 # CLAUDE.md spec rule: full sweep before push
+git add CLAUDE.md .env.example
+git commit -m "docs(claude-md): fix-now drift items per design §13
+
+- Pre-commit hook list updated to match actual config
+- ANTHROPIC_MODEL aligned to claude-sonnet-4-6 (CLAUDE.md + .env.example)
+- Configuration block: remove 4 phantom keys, replace AZURE_REDIRECT_URI→APP_URL,
+  add AVAIL_OPP_TABLE_V2 / ENCRYPTION_SALT / EXPLORIUM_API_KEY,
+  add .env.example pointer for long-tail keys
+
+Closes the 7 fix-now items from spec §13."
+git push -u origin chore/claudemd-fix-now
+```
+
+#### Task 1.2.12 — Open the mini-PR and merge once green
+
+```bash
+gh pr create --base main --head chore/claudemd-fix-now \
+  --title "docs(claude-md): fix-now drift items (§13)" \
+  --body "$(cat <<'EOF'
+## Summary
+Fixes the 7 fix-now CLAUDE.md drift items called out in `2026-05-08-github-cleanup-design.md` §13.
+
+## Test plan
+- [x] Pre-commit + ruff clean
+- [x] All edits sourced from spec §13 verbatim
+- [x] APP_MAP docs unaffected (no architecture change)
+
+## Risk & rollback
+Doc-only PR. Revert with `git revert` if any wording is off.
+EOF
+)"
+
+# Wait for CI then merge
+sleep 15
+gh run watch --exit-status $(gh run list --branch chore/claudemd-fix-now --limit 1 --json databaseId --jq '.[0].databaseId')
+gh pr merge --squash --delete-branch=false $(gh pr list --head chore/claudemd-fix-now --json number --jq '.[0].number')
+```
+
+Note on coordination with #103 (per spec §12): #103 (`docs/claude-md-rebuild`) may incorporate or supersede some of these items. That's resolved during the cascade in §1.3 task 1.3.13 (#103 conflict resolution) — at that point this mini-PR is already in main and #103 rebases onto it.
+
+---
+
+### §1.3 — Cascade-merge 11 PRs (`/cascade` skill)
+
+The cascade pool, in spec §1.3 order:
+
+| # | PR | Branch | Notes |
+|---|---|---|---|
+| 1 | #100 | `dependabot/pip/minor-and-patch-ac6984c910` | Fast-track: skip full agent review; verify CI + no major bumps |
+| 2 | #92  | `fix/env-hygiene` | 4 lines, 1 file |
+| 3 | #93  | `fix/deploy-sh-harden` | 35 lines, 1 file. **§8.2 edit required before merge** (pre-pend `git pull --rebase origin main` per design §2B.4) |
+| 4 | #94  | `docs/pre-rollout-checklist` | 336 lines, docs-only |
+| 5 | #96  | `fix/ci-unblock-test-assertions` | **POST conflict resolution (§1.3.5 below)** |
+| 6 | #97  | `fix/eslint-browser-globals` | 2 lines, 1 file |
+| 7 | #101 | `chore/great-purge-tracked-artifacts` | 2747 deletions, 361 files — biggest deletion PR; full review extra-careful |
+| 8 | #102 | `fix/search-bg-session` | 867 lines, 8 files; full review |
+| 9 | #103 | `docs/claude-md-rebuild` | **POST conflict resolution AND post §13 mini-PR (§1.3.13)** |
+| 10 | #106 | `fix/connector-hard-errors` | 13 lines, 2 files |
+| 11 | #107 | `chore/gradient-vestiges-and-docfmt` | 1347 lines, 32 files — biggest feature PR; full review extra-careful |
+
+#### Task 1.3.1 — Cascade procedure template (READ ONCE, REFERENCED BY EVERY 1.3.X TASK BELOW)
+
+This task documents the per-PR procedure that `/cascade` executes (spec §1.3 "Per-PR procedure"). **Do not run this task on its own** — every per-PR task below says "run /cascade procedure on PR #N" and refers back here.
+
+The 10 steps `/cascade` executes for each PR:
+
+1. **Snapshot unresolved review comments** via `gh api repos/TRIOSCS/Avail-AI-Test/pulls/<N>/comments --jq '.[] | select(.in_reply_to_id == null)'` → write to `.claude/state/cascade/<N>-comments.json` (prevents H7 silent loss on rebase).
+2. **Rebase onto current `main`** in the PR's worktree (or check it out if no worktree exists). Halt on conflict and surface to user with explicit "next action" message.
+3. **Run pre-commit + tests + lint locally**: `pre-commit run --all-files && TESTING=1 PYTHONPATH=/root/availai pytest tests/ -v && ruff check app/`. Halt on failure.
+4. **Push** with `git push --force-with-lease origin <branch>` (allowed because force-push is to feature branch, not `main` — Track 0.6 ref-name rule covers this).
+5. **Re-post unresolved comments** to the new SHAs from the snapshot in step 1.
+6. **Dispatch full agent review suite** (per CLAUDE.md "Run ALL pr-review-toolkit agents on every PR"): comment-analyzer, pr-test-analyzer, type-design-analyzer, silent-failure-hunter, code-simplifier, code-reviewer, plus feature-dev:code-reviewer. **Skip this step for #100 only** (dependabot fast-track per spec §1.3 / architecture C7).
+7. **Address review findings as fresh commits** (never amend — CLAUDE.md commit safety rule); push.
+8. **Wait for green CI** on the latest SHA: `gh run watch --exit-status $(gh run list --branch <branch> --limit 1 --json databaseId --jq '.[0].databaseId')`.
+9. **`gh pr merge <N> --squash --delete-branch=false`**. Explicit `--delete-branch=false` because Track 2B's `deleteBranchOnMerge` is not yet on; remote branches are cleaned up in bulk in §1.4 (silent-failure H4 protection).
+10. **Update cascade state**: `/cascade` writes the merged PR number to `.claude/state/cascade.json`. If anything halts mid-flight, restart resumes from the next leaf.
+
+Success criteria for **each** per-PR run: PR shows `state=MERGED`, branch's last CI run is `success`, `main` CI is `success` after the merge, no comments lost (snapshot file matches re-posted set).
+
+#### Task 1.3.2 — Pre-flight: resolve conflicts on #96
+
+Per spec §1.3 pre-flight bullet 1.
+
+```bash
+cd /root/availai
+git fetch origin
+gh pr view 96 --json mergeable,headRefName --jq '{mergeable, branch: .headRefName}'
+# Expected: mergeable = CONFLICTING, branch = fix/ci-unblock-test-assertions
+
+# Get into the PR's worktree if it exists, else check out the branch into a new worktree
+git worktree list | grep -q "fix/ci-unblock-test-assertions" \
+  || git worktree add /root/availai/.claude/worktrees/pr96 fix/ci-unblock-test-assertions
+
+cd /root/availai/.claude/worktrees/pr96
+git pull origin fix/ci-unblock-test-assertions
+git rebase origin/main
+# Resolve conflicts file-by-file. For each conflicted file:
+#   - Open it
+#   - Resolve <<<<<<< / ======= / >>>>>>> markers
+#   - git add <file>
+# Then: git rebase --continue (repeat until done)
+
+# Verify the rebase landed cleanly
+git status                                      # clean
+pre-commit run --all-files                      # green
+TESTING=1 PYTHONPATH=/root/availai pytest tests/ -v   # green
+
+git push --force-with-lease origin fix/ci-unblock-test-assertions
+gh pr view 96 --json mergeable --jq .mergeable  # MERGEABLE
+```
+
+If conflicts cannot be resolved cleanly (semantic conflict that requires test/code changes): halt and surface — do not improvise; this is a signal that #96 needs operator review before cascading.
+
+#### Task 1.3.3 — Pre-flight: resolve conflicts on #103
+
+Same procedure as 1.3.2, branch `docs/claude-md-rebuild`. Per spec §12 + §13 coordination:
+
+```bash
+cd /root/availai
+git worktree list | grep -q "docs/claude-md-rebuild" \
+  || git worktree add /root/availai/.claude/worktrees/pr103 docs/claude-md-rebuild
+
+cd /root/availai/.claude/worktrees/pr103
+git pull origin docs/claude-md-rebuild
+git rebase origin/main                          # main now contains the §13 mini-PR from §1.2.12
+```
+
+When resolving CLAUDE.md conflicts, the rule per spec §12: **prefer the §13 mini-PR's already-merged content** for any of the 7 fix-now items #103 also touches (mini-PR went first; #103 rebases on top). For other CLAUDE.md content #103 introduces (the broader rebuild), keep #103's version.
+
+```bash
+git status                                      # clean
+pre-commit run --all-files                      # green
+git push --force-with-lease origin docs/claude-md-rebuild
+gh pr view 103 --json mergeable --jq .mergeable # MERGEABLE
+```
+
+#### Task 1.3.4 — Confirm no other PR has drifted to CONFLICTING
+
+Per spec §1.3 pre-flight bullet 3.
+
+```bash
+gh pr list --state open --json number,mergeable \
+  --jq '.[] | select(.mergeable == "CONFLICTING") | .number'
+```
+
+Expected output: empty (or only #96 / #103 if their force-pushes haven't propagated yet — re-run after 30s).
+If a different PR appears as CONFLICTING: halt and resolve it via the same template as 1.3.2 before starting the cascade.
+
+#### Task 1.3.5 — Initialize `/cascade` state
+
+```bash
+mkdir -p /root/availai/.claude/state/cascade
+test -f /root/availai/.claude/state/cascade.json && cat /root/availai/.claude/state/cascade.json || echo '{"merged":[]}' > /root/availai/.claude/state/cascade.json
+```
+
+If a stale `cascade.json` from a prior run exists, decide whether to resume or reset. For a fresh run: overwrite with `{"merged":[]}`.
+
+#### Task 1.3.6 — Run /cascade procedure on PR #100
+
+PR-specific notes: **dependabot — FAST-TRACK; skip step 6 of the template (full agent review).** Per spec §1.3 / architecture C7: verify CI passes + no major-version bumps + merge.
+
+Pre-merge sanity check before invoking `/cascade`:
+
+```bash
+gh pr view 100 --json title,body --jq '"\(.title)\n\(.body)"' | grep -iE 'major|breaking' \
+  && echo "STOP: dependabot bump appears to include majors — promote to full review" \
+  || echo "OK: minor/patch only, fast-track approved"
+```
+
+Then invoke `/cascade` for #100 with the `--fast-track` flag (skill argument that disables step 6). Verify success criteria from 1.3.1: #100 MERGED, branch CI success, main CI success.
+
+#### Task 1.3.7 — Run /cascade procedure on PR #92
+
+PR-specific notes: 4 lines, 1 file (`fix/env-hygiene`). Standard procedure — full review applies but it should be quick given size.
+
+Invoke `/cascade` on #92. Verify success criteria from 1.3.1.
+
+#### Task 1.3.8 — Run /cascade procedure on PR #93
+
+PR-specific notes: 35 lines, 1 file (`fix/deploy-sh-harden`). **Mandatory edit before merge per spec §8.2 / §2B.4:** prepend `git pull --rebase origin main` before `deploy.sh`'s existing `git push origin main` (line 21). This rides into #93's existing scope so Track 2B's linear-history protection doesn't reject the next deploy.
+
+In the cascade template's step 7 (address findings as fresh commits), explicitly add this edit if it isn't already in #93:
+
+```bash
+cd <pr93-worktree>
+grep -n "git push origin main" deploy.sh         # find current line
+# Edit deploy.sh to add `git pull --rebase origin main` immediately before it
+git add deploy.sh
+git commit -m "fix(deploy): pull --rebase before push (compat with linear-history protection)"
+git push origin fix/deploy-sh-harden
+```
+
+Then continue cascade template from step 8. Verify success criteria from 1.3.1.
+
+#### Task 1.3.9 — Run /cascade procedure on PR #94
+
+PR-specific notes: 336 lines, 1 file, **docs-only** (`docs/pre-rollout-checklist`). Standard procedure; agent review should be quick (no code/security risk).
+
+Invoke `/cascade` on #94. Verify success criteria from 1.3.1.
+
+#### Task 1.3.10 — Run /cascade procedure on PR #96
+
+PR-specific notes: **post-conflict-resolution from task 1.3.2.** Standard procedure from here.
+
+Re-verify mergeable before invoking:
+
+```bash
+gh pr view 96 --json mergeable --jq .mergeable   # must be MERGEABLE
+```
+
+Invoke `/cascade` on #96. Verify success criteria from 1.3.1.
+
+#### Task 1.3.11 — Run /cascade procedure on PR #97
+
+PR-specific notes: 2 lines, 1 file (`fix/eslint-browser-globals`). Trivial — full review still runs but is quick.
+
+Invoke `/cascade` on #97. Verify success criteria from 1.3.1.
+
+#### Task 1.3.12 — Run /cascade procedure on PR #101
+
+PR-specific notes: **2747 deletions, 361 files — biggest deletion PR (`chore/great-purge-tracked-artifacts`).** Full review **extra-careful** — confirm the deletions don't include load-bearing artifacts (e.g., a tracked migration, a tracked vendored dependency that's not in `requirements.txt`, a tracked build output the deploy depends on). Spend the time on step 6's full agent review — silent-failure-hunter and code-reviewer specifically.
+
+Pre-merge sanity check inside the template's step 3:
+
+```bash
+cd <pr101-worktree>
+git diff --stat origin/main...HEAD | tail -1     # confirm deletion stats
+# Scan deleted files for risky patterns:
+git diff --name-only --diff-filter=D origin/main...HEAD | grep -E '\.(py|yml|yaml|sh|html|jinja2)$' | head -50
+# Each "real code" file in this list deserves a quick "why deleted?" justification.
+```
+
+Invoke `/cascade` on #101. Verify success criteria from 1.3.1.
+
+#### Task 1.3.13 — Run /cascade procedure on PR #102
+
+PR-specific notes: 867 lines, 8 files (`fix/search-bg-session`); full review. Likely touches search service / DB session lifecycle (per branch name) — spec calls this one out for full review specifically, so silent-failure-hunter + type-design-analyzer findings should be addressed thoroughly.
+
+Invoke `/cascade` on #102. Verify success criteria from 1.3.1.
+
+#### Task 1.3.14 — Run /cascade procedure on PR #103
+
+PR-specific notes: **post-conflict-resolution from task 1.3.3 AND post §13 mini-PR from §1.2.12.** During cascade rebase, the §13 fix-now items are already in main; #103 must layer on top — see task 1.3.3's note about preferring main's content for the 7 fix-now items.
+
+Re-verify mergeable before invoking:
+
+```bash
+gh pr view 103 --json mergeable --jq .mergeable  # must be MERGEABLE
+```
+
+Invoke `/cascade` on #103. Verify success criteria from 1.3.1.
+
+#### Task 1.3.15 — Run /cascade procedure on PR #106
+
+PR-specific notes: 13 lines, 2 files (`fix/connector-hard-errors`). Small, but per project memory this is part of the connector hard-errors split-out work — full review applies; scrutinize the error-handling semantics.
+
+Invoke `/cascade` on #106. Verify success criteria from 1.3.1.
+
+#### Task 1.3.16 — Run /cascade procedure on PR #107
+
+PR-specific notes: **1347 lines, 32 files — biggest feature PR (`chore/gradient-vestiges-and-docfmt`).** Full review **extra-careful** — gradient cleanup touches CSS/templates and docfmt touches docs across many files. Per project memory, this PR was previously CI-blocked behind the main red; with main now green it should be unblocked. Code-simplifier and code-reviewer are the agents that matter most here.
+
+Invoke `/cascade` on #107. Verify success criteria from 1.3.1.
+
+#### Task 1.3.17 — Confirm 0 open PRs after cascade
+
+```bash
+gh pr list --state open --json number --jq 'length'
+```
+
+Expected: `0`. If non-zero: list which PRs remain and surface — `/cascade` may have halted on a PR not yet listed in this plan, or new PRs may have been opened during the cascade window.
+
+```bash
+gh pr list --state open --json number,title,headRefName
+```
+
+#### Task 1.3.18 — Confirm main CI is green after final cascade merge
+
+```bash
+gh run watch --exit-status $(gh run list --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run list --branch main --limit 3 --json conclusion --jq 'all(.[]; .conclusion == "success")'
+```
+
+Expected: `true`. Halt and surface if not.
+
+---
+
+### §1.4 — Worktree + remote-branch consolidation
+
+#### Task 1.4.1 — Inventory worktrees and remote branches
+
+Establish baseline before mutation.
+
+```bash
+cd /root/availai
+git worktree list                                                          | tee /tmp/wt-before.txt
+ls /root/availai/.claude/worktrees/                                        | tee /tmp/wt-dirs-before.txt
+git branch -vv                                                             | tee /tmp/local-branches-before.txt
+gh api repos/TRIOSCS/Avail-AI-Test/branches --paginate --jq '.[].name'     | tee /tmp/remote-branches-before.txt
+```
+
+Save these so the §1.4 success-criteria checks have something to diff against.
+
+#### Task 1.4.2 — Remove the 7 orphan `agent-*` directories
+
+Per spec §1.4 — these dirs are not in `git worktree list` (orphaned by previous failed worktree-add or manual rm).
+
+```bash
+for slug in a034b395 a263dee1 a37647f7 a47a352b a4cf0049 a6911920 aff7e329; do
+  d="/root/availai/.claude/worktrees/agent-${slug}"
+  if [ -d "$d" ]; then
+    # Sanity: confirm it's not in `git worktree list`
+    if git worktree list --porcelain | grep -q "$d"; then
+      echo "REFUSE: $d is a real worktree, not an orphan — investigate"
+    else
+      rm -rf "$d" && echo "removed $d"
+    fi
+  else
+    echo "absent (already cleaned): $d"
+  fi
+done
+```
+
+Use `/worktree-prune` (Track 0.4) for the interactive variant if preferred — but the explicit list above matches the spec verbatim and is safer as a one-shot.
+
+#### Task 1.4.3 — Remove worktrees whose branches were merged in §1.3
+
+Iterate `git worktree list` and, for each worktree whose branch shows up in the cascade-merged set, run `git worktree remove`. Use `/worktree-prune` skill which automates this:
+
+```bash
+/worktree-prune
+```
+
+(The skill cross-references `gh pr view <branch>` for state CLOSED/MERGED, prompts to confirm, then runs `git worktree remove --force <path>` + `rm -rf <path>`.)
+
+If running manually instead:
+
+```bash
+cd /root/availai
+git worktree list --porcelain | awk '/^worktree/ {wt=$2} /^branch/ {print wt "\t" $2}' \
+  | while IFS=$'\t' read -r wt branch; do
+      branch="${branch#refs/heads/}"
+      [ "$branch" = "main" ] && continue
+      [ "$wt" = "/root/availai" ] && continue
+      state=$(gh pr list --head "$branch" --state all --json state --jq '.[0].state // ""')
+      if [ "$state" = "MERGED" ] || [ "$state" = "CLOSED" ]; then
+        echo "removing worktree $wt (branch $branch state $state)"
+        git worktree remove --force "$wt" && rm -rf "$wt"
+      fi
+    done
+```
+
+#### Task 1.4.4 — Remove the transient `/tmp/pr109-rebase` worktree
+
+Per spec §1.4 — session artifact from #109 rebase work.
+
+```bash
+if git worktree list | grep -q "/tmp/pr109-rebase"; then
+  git worktree remove --force /tmp/pr109-rebase
+fi
+rm -rf /tmp/pr109-rebase 2>/dev/null || true
+```
+
+#### Task 1.4.5 — Surface `/root/availai-health-fix` for operator decision
+
+Per spec §1.4 + §12 — design does **not** delete this. Operator decides.
+
+```bash
+if [ -d /root/availai-health-fix ]; then
+  cd /root/availai-health-fix
+  echo "=== /root/availai-health-fix ==="
+  git status -sb 2>/dev/null
+  git log -1 --oneline 2>/dev/null
+  cd /root/availai
+fi
+```
+
+Print the output. Do NOT delete. Surface to user with: "operator decision per spec §12 — keep or delete?"
+
+#### Task 1.4.6 — Delete merged remote branches via `gh api`
+
+**CRITICAL** per spec §1.4: `deleteBranchOnMerge` is NOT on during the cascade (Track 2B is gated behind Track 1), so §1.3's merged branches still exist on origin and must be deleted explicitly.
+
+Use the spec's exact bash block (verbatim from spec §1.4):
+
+```bash
+gh pr list --state merged --base main --search "merged:>=2026-05-08" \
+  --json number,headRefName --jq '.[].headRefName' | \
+  while read branch; do
+    [ -n "$branch" ] && gh api -X DELETE \
+      "repos/TRIOSCS/Avail-AI-Test/git/refs/heads/$branch" 2>/dev/null || true
+  done
+```
+
+Note: `2>/dev/null || true` swallows already-deleted (404) errors silently; that's intentional per the spec's idempotency goal. If you want a louder version for verification:
+
+```bash
+gh pr list --state merged --base main --search "merged:>=2026-05-08" \
+  --json number,headRefName --jq '.[] | "\(.number)\t\(.headRefName)"' | \
+  while IFS=$'\t' read num branch; do
+    [ -z "$branch" ] && continue
+    if gh api -X DELETE "repos/TRIOSCS/Avail-AI-Test/git/refs/heads/$branch" 2>&1 \
+       | grep -qE '(204|Not Found)'; then
+      echo "deleted (or already gone): #$num $branch"
+    else
+      echo "FAILED: #$num $branch"
+    fi
+  done
+```
+
+#### Task 1.4.7 — Local prune to reflect remote deletions
+
+```bash
+cd /root/availai
+git fetch --prune origin
+git branch -vv | grep ': gone\]'    # list local branches whose remote is gone
+```
+
+#### Task 1.4.8 — Safe local-branch cleanup with `git cherry` check
+
+**CRITICAL** per spec §1.4 / silent-failure H4: `git branch -D` after squash-merge silently drops un-squashed commits. Verify with `git cherry main <branch>` first — empty output means all commits are squashed in main; non-empty means there's un-squashed work.
+
+Use the spec's exact bash block (verbatim from spec §1.4):
+
+```bash
+for b in $(git branch -vv | grep ': gone\]' | awk '{print $1}'); do
+  if [ -z "$(git cherry main "$b")" ]; then
+    git branch -D "$b"
+  else
+    echo "SKIP $b: has un-squashed commits"
+  fi
+done
+```
+
+For any branch printed as `SKIP`: surface to user — these branches have commits that did not make it into main via squash. Do NOT force-delete them; investigate per branch.
+
+#### Task 1.4.9 — Final-state verification
+
+Per spec §1.4: "only `/root/availai` itself + any actively-used worktree under `.claude/worktrees/`. `git worktree list` and `ls .claude/worktrees/` agree."
+
+```bash
+cd /root/availai
+echo "=== git worktree list ==="
+git worktree list
+echo
+echo "=== ls .claude/worktrees/ ==="
+ls /root/availai/.claude/worktrees/ 2>/dev/null
+echo
+echo "=== orphan check (expected: empty) ==="
+comm -23 \
+  <(ls /root/availai/.claude/worktrees/ 2>/dev/null | sort) \
+  <(git worktree list --porcelain | awk '/^worktree/ {print $2}' | sed 's|.*/||' | sort)
+```
+
+Expected:
+- `git worktree list` shows `/root/availai` + at most a small number of in-use worktrees (e.g., this plan-execution `spec-cleanup` worktree if still active).
+- `ls .claude/worktrees/` matches the worktree list (no orphans).
+- `comm -23` output is empty.
+
+If any check fails: re-run §1.4.2 / §1.4.3 / §1.4.6 / §1.4.7 / §1.4.8 as needed.
+
+---
+
+## Self-review — spec coverage map
+
+Mapping each spec §-number to the task(s) that implement it:
+
+| Spec § | Coverage | Task(s) |
+|---|---|---|
+| §1.1 (stabilize main — pull failing logs) | yes | 1.1.1, 1.1.2 |
+| §1.1 (diagnose + fix as direct-to-main hotfix) | yes | 1.1.3 |
+| §1.1 (verify with /smoke-gate if migration) | yes | 1.1.3 (referenced as fix-shape option) |
+| §1.1 (verify main green) | yes | 1.1.4 |
+| §1.2 step 1 (`gh pr merge 109 --squash`) | yes | 1.2.2 |
+| §1.2 step 2 (wait for #108 CI) | yes | 1.2.3 |
+| §1.2 step 3 (verify #108 fully green) | yes | 1.2.3 |
+| §1.2 step 4 (`gh pr merge 108 --squash`) | yes | 1.2.4 |
+| §1.2 step 5 (verify main CI green) | yes | 1.2.5 |
+| §1.2 step 6 (ship §13 mini-PR) | yes | 1.2.6 → 1.2.12 |
+| §13 item 1 (pre-commit list, line 440) | yes | 1.2.7 |
+| §13 item 2 (`ANTHROPIC_MODEL`, line 640) | yes | 1.2.8 |
+| §13 item 3 (config block lines 627–668: 4 removes, 1 replace, 3 adds, 1 pointer) | yes | 1.2.9 (sub-edits a/b/c/d) |
+| §13 item 4 (worktree CLAUDE.md drift handled by worktree deletion) | yes | 1.4.3 (no per-file edits — confirms spec) |
+| §13 item 5 (`.env.example:9` one-liner rides the PR) | yes | 1.2.10 |
+| §1.3 pre-flight: resolve #96 conflicts | yes | 1.3.2 |
+| §1.3 pre-flight: resolve #103 conflicts | yes | 1.3.3 |
+| §1.3 pre-flight: confirm no other CONFLICTING | yes | 1.3.4 |
+| §1.3 cascade order #100 → #92 → #93 → #94 → #96 → #97 → #101 → #102 → #103 → #106 → #107 | yes | 1.3.6 → 1.3.16 (in order) |
+| §1.3 per-PR procedure (10 steps) | yes | 1.3.1 (template task; referenced by all per-PR tasks) |
+| §1.3 #100 fast-track (skip full review per C7) | yes | 1.3.6 |
+| §1.3 #93 deploy.sh edit per §2B.4 | yes | 1.3.8 |
+| §1.3 #103 coordinates with §13 mini-PR | yes | 1.3.3 + 1.3.14 |
+| §1.3 final state: 0 open PRs, main green | yes | 1.3.17, 1.3.18 |
+| §1.4 rm -rf 7 orphan agent-* dirs | yes | 1.4.2 |
+| §1.4 git worktree remove merged worktrees | yes | 1.4.3 (via `/worktree-prune` or manual) |
+| §1.4 remove `/tmp/pr109-rebase` | yes | 1.4.4 |
+| §1.4 surface `/root/availai-health-fix` (operator decision per §12) | yes | 1.4.5 |
+| §1.4 `gh api DELETE` merged remote branches (deleteBranchOnMerge not on yet) | yes | 1.4.6 |
+| §1.4 `git fetch --prune origin` | yes | 1.4.7 |
+| §1.4 `git cherry` check before `git branch -D` (H4 prevention) | yes | 1.4.8 |
+| §1.4 final-state agreement check | yes | 1.4.9 |
+| §0 prerequisite gating | yes | PREREQUISITES section |
+
+All spec §1.1–§1.4 + §13 items are covered. Items deferred to other tracks (§2B branch protection, §2A templates/labels, §3 automations) are explicitly out of scope for this plan.

--- a/docs/superpowers/plans/2026-05-08-github-cleanup-track-2a-land-now.md
+++ b/docs/superpowers/plans/2026-05-08-github-cleanup-track-2a-land-now.md
@@ -1,0 +1,237 @@
+# Track 2A — Land-Now Policy Implementation Plan
+
+> **For agentic workers:** Two tiny, fully independent repo changes from `2026-05-08-github-cleanup-design.md` §2A. Each artifact ships as its OWN PR. Both can land any time, in parallel with Track 1 — they have NO merge-blocking effect on the cascade. Do not combine them. Do not wait for Track 1. §2A.3 (`deleteBranchOnMerge`) and §2A.4 (Dependabot github-actions ecosystem) are explicitly REMOVED in the spec — do not implement them here.
+
+## Goal
+
+Land the two policy artifacts that are safe to ship at any time:
+1. `.github/PULL_REQUEST_TEMPLATE.md` populating the GitHub PR description box with Summary / Test plan / Risk & rollback / Linked issues sections (spec §2A.1).
+2. Issue label taxonomy (`type:*`, `priority:*`, `scope:*`) applied to the repo via `gh label create --force`, then back-applied to existing issues #88 and #89 (spec §2A.2).
+
+Success = template renders for the next PR opened, `gh label list` returns all 13 names, and `gh issue view 88/89` shows the assigned labels.
+
+## Architecture
+
+- **PR template** is a single Markdown file at `.github/PULL_REQUEST_TEMPLATE.md`. GitHub auto-injects its body into every new PR description. Single-file PR. No code, no tests.
+- **Labels** are repo-level configuration, NOT files. Applied via `gh label create --force` (idempotent — re-run safely). The same script back-applies labels to #88 and #89 via `gh issue edit`. The script is run-once-and-discard; nothing to commit. To keep the work auditable, the script is committed under `scripts/github/apply-labels.sh` so it can be re-run if the taxonomy ever drifts.
+
+## Tech Stack
+
+- GitHub PR template (Markdown)
+- `gh` CLI (label create, issue edit)
+- Bash (idempotent re-runnable script)
+- Repo: `TRIOSCS/Avail-AI-Test`
+
+## File Structure
+
+| Path | Purpose |
+|---|---|
+| `.github/PULL_REQUEST_TEMPLATE.md` | PR description scaffold (spec §2A.1) |
+| `scripts/github/apply-labels.sh` | Idempotent script: creates 13 labels + applies to #88, #89 (spec §2A.2) |
+
+## PR plan
+
+Two independent PRs. Either may land first. Both target `main`.
+
+- **PR-A** — title: `chore(github): add PR template (spec §2A.1)` — Step 1.
+- **PR-B** — title: `chore(github): apply issue label taxonomy (spec §2A.2)` — Step 2.
+
+---
+
+## Step 1 — PR template (PR-A)
+
+### 1.1 Create the PR template file
+
+Create `.github/PULL_REQUEST_TEMPLATE.md` with this EXACT content (copied verbatim from spec §2A.1):
+
+```markdown
+## Summary
+
+<!-- 1-3 sentences on what changed and why -->
+
+## Test plan
+
+- [ ] Tests added/updated
+- [ ] Pre-commit + ruff + mypy clean
+- [ ] APP_MAP doc(s) in `docs/` updated if architecture changed
+
+## Risk & rollback
+
+<!-- Blast radius. How do we revert if this breaks main/staging? -->
+
+## Linked issues
+
+<!-- Closes #N (or N/A) -->
+```
+
+### 1.2 Verify the file path GitHub looks for
+
+GitHub auto-discovers any of: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/pull_request_template.md`, `docs/PULL_REQUEST_TEMPLATE.md`, or repo-root `PULL_REQUEST_TEMPLATE.md`. We use `.github/PULL_REQUEST_TEMPLATE.md` for clarity. Confirm the file is at exactly that path with `git ls-files .github/PULL_REQUEST_TEMPLATE.md`.
+
+### 1.3 Open PR-A
+
+Branch: `chore/pr-template`. Push and open with:
+
+```bash
+gh pr create \
+  --title "chore(github): add PR template (spec §2A.1)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Adds `.github/PULL_REQUEST_TEMPLATE.md` per `docs/superpowers/specs/2026-05-08-github-cleanup-design.md` §2A.1. From now on every new PR opens with Summary / Test plan / Risk & rollback / Linked issues sections pre-filled.
+
+## Test plan
+
+- [ ] After merge, open a throwaway draft PR and confirm the template body appears
+- [ ] Pre-commit clean (Markdown only — no code change)
+
+## Risk & rollback
+
+Zero blast radius — template only affects new PR description scaffolding. Revert by deleting the file.
+
+## Linked issues
+
+N/A (Track 2A.1 of GitHub cleanup design)
+EOF
+)"
+```
+
+### 1.4 Self-verify before requesting review
+
+```bash
+test -f .github/PULL_REQUEST_TEMPLATE.md && \
+  grep -q "## Summary" .github/PULL_REQUEST_TEMPLATE.md && \
+  grep -q "## Test plan" .github/PULL_REQUEST_TEMPLATE.md && \
+  grep -q "## Risk & rollback" .github/PULL_REQUEST_TEMPLATE.md && \
+  grep -q "## Linked issues" .github/PULL_REQUEST_TEMPLATE.md && \
+  echo OK
+```
+
+Expect `OK`. After merge, open a throwaway draft PR (`gh pr create --draft --title test --body ""` then immediately `gh pr close --delete-branch`) and visually confirm the template body rendered into the description.
+
+---
+
+## Step 2 — Label taxonomy (PR-B)
+
+### 2.1 Create `scripts/github/apply-labels.sh`
+
+The script is idempotent — `--force` updates an existing label in place rather than failing. Re-running is safe.
+
+File: `scripts/github/apply-labels.sh`. Mark executable (`chmod +x`).
+
+```bash
+#!/usr/bin/env bash
+# apply-labels.sh — Idempotent label taxonomy for TRIOSCS/Avail-AI-Test
+# Implements docs/superpowers/specs/2026-05-08-github-cleanup-design.md §2A.2.
+# Re-run safely: `gh label create --force` updates existing labels in place.
+# Called by: humans (one-shot) when taxonomy drifts. Depends on: gh CLI.
+set -euo pipefail
+
+# type:*  — what kind of change
+gh label create "type:bug"      --description "Bug fix"                --color "d73a4a" --force
+gh label create "type:feature"  --description "New feature"            --color "0e8a16" --force
+gh label create "type:chore"    --description "Maintenance / cleanup"  --color "c2e0c6" --force
+gh label create "type:security" --description "Security-related"       --color "b60205" --force
+gh label create "type:docs"     --description "Documentation only"     --color "0075ca" --force
+
+# priority:*  — urgency tier
+gh label create "priority:p0" --description "Drop everything"      --color "b60205" --force
+gh label create "priority:p1" --description "Important, this week" --color "d93f0b" --force
+gh label create "priority:p2" --description "Nice to have"         --color "fbca04" --force
+
+# scope:*  — area of the codebase
+gh label create "scope:ci"       --description "CI / GitHub Actions"     --color "ededed" --force
+gh label create "scope:db"       --description "Database / migrations"   --color "5319e7" --force
+gh label create "scope:frontend" --description "HTMX / Alpine / Jinja2"  --color "1d76db" --force
+gh label create "scope:backend"  --description "FastAPI / services"      --color "006b75" --force
+gh label create "scope:infra"    --description "Docker / deploy / hosts" --color "bfdadc" --force
+
+# Back-apply to existing issues per spec §2A.2.
+gh issue edit 88 --add-label "type:chore,scope:frontend"
+gh issue edit 89 --add-label "type:chore,scope:frontend"
+
+echo "Labels applied. Verify with: gh label list"
+```
+
+### 2.2 Run the script against the repo
+
+This is the one-shot apply. Run from repo root:
+
+```bash
+bash scripts/github/apply-labels.sh
+```
+
+Expect 13 lines of `gh label create` output (one per label) + 2 lines from `gh issue edit` + the trailing `Labels applied.` message. Non-zero exit = halt and surface.
+
+### 2.3 Verify
+
+```bash
+gh label list --json name --jq '
+  map(.name)
+  | contains(["type:bug","type:feature","type:chore","type:security","type:docs",
+              "priority:p0","priority:p1","priority:p2",
+              "scope:ci","scope:db","scope:frontend","scope:backend","scope:infra"])
+'
+```
+
+Expect `true`. Then:
+
+```bash
+gh issue view 88 --json labels --jq '[.labels[].name] | contains(["type:chore","scope:frontend"])'
+gh issue view 89 --json labels --jq '[.labels[].name] | contains(["type:chore","scope:frontend"])'
+```
+
+Both expect `true`.
+
+### 2.4 Open PR-B
+
+Branch: `chore/issue-label-taxonomy`. The PR commits ONLY `scripts/github/apply-labels.sh` (the side-effect against the repo has already been applied in 2.2 — labels live on the GitHub side, not in the repo). Open with:
+
+```bash
+gh pr create \
+  --title "chore(github): apply issue label taxonomy (spec §2A.2)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Adds `scripts/github/apply-labels.sh` per `docs/superpowers/specs/2026-05-08-github-cleanup-design.md` §2A.2. Script is idempotent (`gh label create --force`); already executed once to seed the 13 labels and back-apply `type:chore,scope:frontend` to issues #88 and #89. Committed so the taxonomy is reproducible if it ever drifts.
+
+## Test plan
+
+- [ ] `bash scripts/github/apply-labels.sh` runs cleanly on a second invocation (no errors, exit 0)
+- [ ] `gh label list` shows all 13 `type:* / priority:* / scope:*` labels
+- [ ] `gh issue view 88` and `gh issue view 89` show `type:chore` + `scope:frontend`
+
+## Risk & rollback
+
+Zero code blast radius — script-only commit. The label side-effect is reversible by `gh label delete <name>`.
+
+## Linked issues
+
+N/A (Track 2A.2 of GitHub cleanup design)
+EOF
+)"
+```
+
+---
+
+## Self-review — spec coverage
+
+| Spec section | Status | Where in this plan |
+|---|---|---|
+| §2A.1 PR template — exact body | Implemented | Step 1.1 (verbatim copy) |
+| §2A.1 path `.github/PULL_REQUEST_TEMPLATE.md` | Implemented | Step 1.1 / 1.2 |
+| §2A.2 13 labels (`type:*` x5, `priority:*` x3, `scope:*` x5) | Implemented | Step 2.1 |
+| §2A.2 idempotent via `--force` | Implemented | Step 2.1 (every line uses `--force`) |
+| §2A.2 issue #88 → `type:chore scope:frontend` | Implemented | Step 2.1 (`gh issue edit 88`) |
+| §2A.2 issue #89 → `type:chore scope:frontend` | Implemented | Step 2.1 (`gh issue edit 89`) |
+| §2A.3 `deleteBranchOnMerge` — REMOVED, moved to Track 2B | Out of scope | Not implemented (per instructions) |
+| §2A.4 Dependabot github-actions ecosystem — REMOVED (already exists) | Out of scope | Not implemented (per instructions) |
+| Independence from Track 1 | Honored | Plan has no Prerequisites section; both PRs land any time |
+| Each artifact = its own PR | Honored | PR-A (template) and PR-B (label script) are separate |
+
+Done when both PRs are merged AND the §10 success-criteria spot-checks for §2A pass:
+
+```bash
+test -f .github/PULL_REQUEST_TEMPLATE.md \
+  && gh label list --json name --jq 'map(.name) | contains(["type:bug","priority:p0","scope:ci"])'
+```

--- a/docs/superpowers/plans/2026-05-08-github-cleanup-track-2b-after-track-1.md
+++ b/docs/superpowers/plans/2026-05-08-github-cleanup-track-2b-after-track-1.md
@@ -1,0 +1,576 @@
+# Track 2B — After-Track-1 Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Halt and surface IMMEDIATELY if any prerequisite check (§PREREQUISITES) fails — Track 2B must NOT land while Track 1 is in flight, otherwise it will block the 11-PR cascade and orphan stacked PRs.
+
+**Goal:** Lock in the durable repo-policy posture for `TRIOSCS/Avail-AI-Test` after Track 1 finishes: turn on `deleteBranchOnMerge`, restrict to squash + rebase merges, enforce branch protection on `main` with the corrected job-name contexts (`test`, `security`), publish issue templates, and harden `deploy.sh` so the first post-protection deploy still succeeds. This plan executes the §2B subsections of the GitHub Cleanup design.
+
+**Architecture:** Three small PRs land in series. PR-A (Task 1) is a config-only PR — repo settings via `gh repo edit` + branch protection via `gh api -X PUT`. PR-B (Task 2) adds three `.github/ISSUE_TEMPLATE/*.md` files. PR-C (Task 3) is the deploy.sh hardening — a one-line edit (`git pull --rebase origin main` immediately before `git push origin main`). PR-C has a state-dependent landing path: if PR #93 is still open at execution time, the edit is committed onto #93's branch; if #93 is closed/merged-without-the-fix, the edit lands on a fresh branch instead. After each task, an explicit verification command must produce the expected output before the task is marked done. The trial deploy (`./deploy.sh --no-commit`) is the load-bearing real-world check — protection is verified working only when an actual push succeeds under linear-history.
+
+**Tech Stack:** GitHub CLI (`gh`) · GitHub REST API · Bash · Markdown · Git.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-github-cleanup-design.md` (§2B.1 – §2B.4; §2B.5 CODEOWNERS is DROPPED per spec §11/M6).
+
+---
+
+## PREREQUISITES — Track 1 must be 100% complete before any task here runs
+
+Track 2B encodes the design's hard build-order rule (spec §architecture, "Key dependency rule"): premature application orphans the stacked #108/#109 PR, deadlocks the 11-PR cascade behind required-checks, and creates a destructive `deleteBranchOnMerge` × open-worktree interaction. **Verify ALL of the following before opening Task 1.** If any check fails, STOP and resume Track 1.
+
+- [ ] **P1: Zero open PRs**
+  ```bash
+  gh pr list --repo TRIOSCS/Avail-AI-Test --state open --limit 1 --json number --jq 'length == 0'
+  ```
+  Expected: `true`.
+
+- [ ] **P2: `main` CI is green on the latest commit**
+  ```bash
+  gh run list --repo TRIOSCS/Avail-AI-Test --branch main --limit 2 \
+    --json conclusion --jq 'all(.[]; .conclusion == "success")'
+  ```
+  Expected: `true`.
+
+- [ ] **P3: No orphan worktree directories**
+  ```bash
+  comm -23 \
+    <(ls /root/availai/.claude/worktrees/ 2>/dev/null | sort) \
+    <(cd /root/availai && git worktree list --porcelain | awk '/^worktree/ {print $2}' | sed 's|.*/||' | sort)
+  ```
+  Expected: empty output.
+
+- [ ] **P4: All Track 1.3 cascade-merged head branches deleted from origin**
+  ```bash
+  gh api repos/TRIOSCS/Avail-AI-Test/branches \
+    --jq '.[].name' | grep -E '^(fix/|chore/|docs/|feat/|dependabot/)' || echo "no surviving feature branches"
+  ```
+  Expected: `no surviving feature branches` (or only branches the operator has explicitly chosen to retain — see spec §1.4).
+
+- [ ] **P5: PR #93 state captured for Task 3 routing**
+  ```bash
+  gh pr view 93 --repo TRIOSCS/Avail-AI-Test --json state,headRefName,mergeable
+  ```
+  Record `state` (`OPEN` / `MERGED` / `CLOSED`) and `headRefName`. This decides Task 3's branch (see Task 3 Step 0).
+
+If P1–P4 all pass, proceed.
+
+---
+
+## File Structure
+
+| Path | Action | Purpose |
+|---|---|---|
+| (no file — `gh repo edit` API call) | API | Repo merge settings: delete-branch-on-merge ON, merge-commit OFF, squash + rebase ON |
+| (no file — `gh api -X PUT branches/main/protection`) | API | Branch protection on `main` with required `test` + `security` contexts and linear history |
+| `.github/ISSUE_TEMPLATE/bug.md` | Create | Standard bug-report template |
+| `.github/ISSUE_TEMPLATE/feature.md` | Create | Standard feature-request template |
+| `.github/ISSUE_TEMPLATE/security.md` | Create | Security-issue template (private-disclosure friendly) |
+| `deploy.sh` | Modify | Prepend `git pull --rebase origin main` before `git push origin main` so linear-history protection accepts the push |
+
+CODEOWNERS is intentionally NOT created — spec §2B.5 drops it (M6: decorative without `require_code_owner_reviews`, single-user repo).
+
+---
+
+## Execution Order
+
+Three tasks, each its own PR, sequential.
+
+- **Task 1 — Config PR (PR-A).** Repo settings + branch protection in one PR. Verification of branch-protection contexts is the most load-bearing check in this whole plan (silent-failure §11 P0).
+- **Task 2 — Issue templates (PR-B).** Three Markdown files. Mechanical.
+- **Task 3 — deploy.sh hardening (PR-C).** State-dependent: rides into PR #93 if open, else fresh branch. Includes mandatory trial deploy under live branch protection.
+
+Each task ends with a commit and a verification block. Land Task 1 first — if its branch protection is misconfigured, Task 3's trial deploy will surface the problem cleanly rather than under a real outage.
+
+---
+
+## Task 1: Apply repo settings + branch protection (config PR-A)
+
+**Spec:** §2B.1, §2B.2.
+
+**Files:** none — entirely `gh` CLI calls. Open one PR for traceability/audit; the PR body documents the commands run. Use a tiny no-op file (e.g. add a comment line to a config doc) ONLY if the repo requires non-empty PRs; otherwise document the changes in a tracking issue and skip the PR. Default path below uses an issue, since the changes are server-side.
+
+- [ ] **Step 1: Open a tracking issue (audit trail)**
+
+  ```bash
+  gh issue create --repo TRIOSCS/Avail-AI-Test \
+    --title "Track 2B: apply repo settings + branch protection on main" \
+    --body "Tracks application of spec §2B.1 (repo settings) and §2B.2 (branch protection). See docs/superpowers/specs/2026-05-08-github-cleanup-design.md and docs/superpowers/plans/2026-05-08-github-cleanup-track-2b-after-track-1.md. This issue closes when Step 6 verification passes."
+  ```
+
+  Record the issue number returned (referenced as `$ISSUE_NUM` below).
+
+- [ ] **Step 2: Apply repo merge settings (§2B.1)**
+
+  ```bash
+  gh repo edit TRIOSCS/Avail-AI-Test \
+    --delete-branch-on-merge \
+    --enable-merge-commit=false \
+    --enable-squash-merge=true \
+    --enable-rebase-merge=true
+  ```
+
+  Expected: command exits 0 with no error. No stdout on success is normal.
+
+- [ ] **Step 3: Verify repo merge settings landed**
+
+  ```bash
+  gh repo view TRIOSCS/Avail-AI-Test \
+    --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,deleteBranchOnMerge \
+    --jq '.mergeCommitAllowed == false
+          and .squashMergeAllowed == true
+          and .rebaseMergeAllowed == true
+          and .deleteBranchOnMerge == true'
+  ```
+
+  Expected: `true`. If `false`, re-run Step 2 and re-verify; do not proceed to Step 4.
+
+- [ ] **Step 4: Apply branch protection on `main` (§2B.2)**
+
+  Use the EXACT JSON below — every key is justified in spec §2B.2. **DO NOT substitute workflow names (`CI — Tests`, `Security Scanning`) for the contexts.** The contexts MUST be the GitHub-reported check-run job names `test` and `security`, otherwise the protection silently never matches and is a no-op (spec §11 P0).
+
+  ```bash
+  gh api -X PUT repos/TRIOSCS/Avail-AI-Test/branches/main/protection \
+    -H "Accept: application/vnd.github+json" \
+    --input - <<'JSON'
+  {
+    "required_status_checks": {
+      "strict": false,
+      "contexts": ["test", "security"]
+    },
+    "enforce_admins": false,
+    "required_pull_request_reviews": null,
+    "required_signatures": false,
+    "required_linear_history": true,
+    "required_conversation_resolution": false,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "block_creations": false,
+    "restrictions": null
+  }
+  JSON
+  ```
+
+  Expected: command exits 0. Response prints the applied protection JSON.
+
+- [ ] **Step 5: CRITICAL verification — confirm contexts are job names and `strict` is false (spec §10 #4 + §11 P0)**
+
+  This is the silent-failure-prevention check the parallel review caught. If this returns `false`, the protection is misconfigured and Task 3's trial deploy will block. Re-apply Step 4 with the correct JSON before proceeding.
+
+  ```bash
+  gh api repos/TRIOSCS/Avail-AI-Test/branches/main/protection \
+    --jq '.required_status_checks.contexts == ["test","security"] and .required_status_checks.strict == false'
+  ```
+
+  Expected: `true`.
+
+- [ ] **Step 6: Full §10 #4 protection verification (linear history + admin enforcement)**
+
+  ```bash
+  gh api repos/TRIOSCS/Avail-AI-Test/branches/main/protection \
+    --jq '.required_status_checks.contexts == ["test","security"]
+          and .required_status_checks.strict == false
+          and .required_linear_history.enabled == true
+          and .enforce_admins.enabled == false
+          and .allow_force_pushes.enabled == false
+          and .allow_deletions.enabled == false'
+  ```
+
+  Expected: `true`.
+
+- [ ] **Step 7: Cross-check actual GitHub check-run names match the protection contexts**
+
+  This catches the case where a CI workflow rename has shifted the job names without updating protection. Pull the latest check-run names from the most recent commit on `main`:
+
+  ```bash
+  gh api repos/TRIOSCS/Avail-AI-Test/commits/main/check-runs \
+    --jq '[.check_runs[].name] | sort | unique'
+  ```
+
+  Expected: includes both `"test"` and `"security"`. If GitHub reports different names (e.g. `test (3.11)`), STOP — a follow-up plan is needed to either rename the job in `.github/workflows/` or update the protection contexts. Do not paper over this; mismatched contexts are exactly the silent-failure §11 prevented.
+
+- [ ] **Step 8: Close the tracking issue with verification evidence**
+
+  ```bash
+  gh issue close $ISSUE_NUM --repo TRIOSCS/Avail-AI-Test \
+    --comment "Applied. Verified via §10 #4 protection check + §10 #5 repo-settings check + check-run name cross-check (Steps 5/6/7)."
+  ```
+
+**Task 1 done when:** Steps 3, 5, 6, 7 all return `true` / matching output. Issue closed.
+
+---
+
+## Task 2: Publish issue templates (PR-B)
+
+**Spec:** §2B.3.
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/bug.md`
+- Create: `.github/ISSUE_TEMPLATE/feature.md`
+- Create: `.github/ISSUE_TEMPLATE/security.md`
+
+- [ ] **Step 1: Cut a fresh branch from current `main`**
+
+  ```bash
+  cd /root/availai
+  git fetch origin
+  git checkout -b chore/issue-templates origin/main
+  ```
+
+- [ ] **Step 2: Create `.github/ISSUE_TEMPLATE/bug.md`**
+
+  ```markdown
+  ---
+  name: Bug report
+  about: Report a defect in AvailAI
+  title: "[bug] "
+  labels: ["type:bug"]
+  ---
+
+  ## What happened
+
+  <!-- Describe the actual behavior -->
+
+  ## What you expected
+
+  <!-- Describe the expected behavior -->
+
+  ## Reproduction steps
+
+  1.
+  2.
+  3.
+
+  ## Environment
+
+  - Branch / commit:
+  - Browser / OS (if frontend):
+  - Affected route or service:
+
+  ## Logs / screenshots
+
+  <!-- Paste relevant log lines, request_id, stack trace. NO secrets. -->
+
+  ## Suspected blast radius
+
+  <!-- Single user? Specific tenant? main branch? Helps prioritize. -->
+  ```
+
+- [ ] **Step 3: Create `.github/ISSUE_TEMPLATE/feature.md`**
+
+  ```markdown
+  ---
+  name: Feature request
+  about: Propose a new capability or enhancement
+  title: "[feature] "
+  labels: ["type:feature"]
+  ---
+
+  ## Problem
+
+  <!-- The user-visible pain or workflow gap this solves -->
+
+  ## Proposed solution
+
+  <!-- 1-3 paragraphs. UI sketches in plain text are fine. -->
+
+  ## Alternatives considered
+
+  <!-- Other shapes you weighed and why this one wins -->
+
+  ## Out of scope
+
+  <!-- What this explicitly does NOT cover, to keep the PR small -->
+
+  ## Acceptance criteria
+
+  - [ ]
+  - [ ]
+  - [ ]
+  ```
+
+- [ ] **Step 4: Create `.github/ISSUE_TEMPLATE/security.md`**
+
+  ```markdown
+  ---
+  name: Security issue
+  about: Report a security defect (use private disclosure for sensitive issues)
+  title: "[security] "
+  labels: ["type:security", "priority:p0"]
+  ---
+
+  > **If this issue exposes credentials, customer data, or an active exploit, do NOT file it here.**
+  > Email the maintainer directly and request a private channel.
+
+  ## Severity assessment
+
+  - [ ] P0 — exploitable, credentials/data at risk, or `main` compromised
+  - [ ] P1 — exploitable but contained
+  - [ ] P2 — defense-in-depth gap, not directly exploitable
+
+  ## What's vulnerable
+
+  <!-- Component, route, service, or dependency. NO exploit code. -->
+
+  ## Reproduction (high level only)
+
+  <!-- Enough for a maintainer to reproduce. Detailed exploit goes in private disclosure. -->
+
+  ## Suggested mitigation
+
+  <!-- Optional. Patch sketch, config change, dependency bump, etc. -->
+
+  ## Disclosure status
+
+  - [ ] Private disclosure already sent
+  - [ ] Filing publicly because issue is low-severity / informational
+  ```
+
+- [ ] **Step 5: Stage, commit, push**
+
+  ```bash
+  cd /root/availai
+  git add .github/ISSUE_TEMPLATE/bug.md \
+          .github/ISSUE_TEMPLATE/feature.md \
+          .github/ISSUE_TEMPLATE/security.md
+  git commit -m "chore: add bug/feature/security issue templates (Track 2B §2B.3)"
+  git push -u origin chore/issue-templates
+  ```
+
+- [ ] **Step 6: Open PR-B**
+
+  ```bash
+  gh pr create --repo TRIOSCS/Avail-AI-Test \
+    --base main --head chore/issue-templates \
+    --title "chore: add bug/feature/security issue templates" \
+    --body "Implements spec §2B.3 (Track 2B). Three standard templates with type-label defaults. CODEOWNERS is intentionally NOT added (spec §2B.5 dropped — M6 silent-failure: decorative without require_code_owner_reviews on a single-user repo)."
+  ```
+
+- [ ] **Step 7: Wait for CI green and verify protection accepts the merge**
+
+  ```bash
+  gh pr checks $(gh pr view --repo TRIOSCS/Avail-AI-Test --json number --jq .number) \
+    --repo TRIOSCS/Avail-AI-Test --watch
+  ```
+
+  Expected: `test` and `security` check-runs both pass.
+
+- [ ] **Step 8: Squash-merge PR-B**
+
+  ```bash
+  PR_NUM=$(gh pr view --repo TRIOSCS/Avail-AI-Test --json number --jq .number)
+  gh pr merge $PR_NUM --repo TRIOSCS/Avail-AI-Test --squash --delete-branch
+  ```
+
+  `--delete-branch` exercises the new `deleteBranchOnMerge` setting from Task 1.
+
+- [ ] **Step 9: Verify the three files exist on `main`**
+
+  ```bash
+  for f in bug.md feature.md security.md; do
+    gh api "repos/TRIOSCS/Avail-AI-Test/contents/.github/ISSUE_TEMPLATE/$f" \
+      --jq '.path' || echo "MISSING: $f"
+  done
+  ```
+
+  Expected: prints all three paths, no `MISSING` lines.
+
+- [ ] **Step 10: Verify branch was actually deleted on origin**
+
+  ```bash
+  gh api repos/TRIOSCS/Avail-AI-Test/branches/chore/issue-templates 2>&1 | grep -q "Branch not found"
+  ```
+
+  Expected: exit 0 (i.e. branch is gone — `deleteBranchOnMerge` is functioning).
+
+**Task 2 done when:** Steps 9 and 10 both pass.
+
+---
+
+## Task 3: Harden deploy.sh under linear-history protection (PR-C)
+
+**Spec:** §2B.4.
+
+**Files:**
+- Modify: `deploy.sh`
+
+The current `deploy.sh:20` does a bare `git push origin main`. Branch protection from Task 1 (`required_linear_history: true` + `allow_force_pushes: false`) rejects any non-fast-forward push, so any local divergence kills the deploy. Fix: prepend `git pull --rebase origin main` so the local push tip is always a fast-forward of remote `main`.
+
+### Step 0: Decide branch routing based on PR #93's state (KEY DECISION)
+
+The spec (§12 + §2B.4) prefers riding this fix into PR #93's existing scope. Determine #93's state from the PREREQUISITES P5 capture:
+
+- **If PR #93 is OPEN:** open the deploy.sh edit AS A NEW COMMIT on #93's `headRefName` branch, rebased onto then-current `main`. Skip Step 1 below; jump to Step 1-A.
+- **If PR #93 is MERGED-WITHOUT-THE-FIX or CLOSED:** the fix lands on a fresh branch as PR-C (this Track 2B's config-PR companion). Continue with Step 1 below.
+
+Re-confirm state at execution time — it may have changed since prereq capture:
+
+```bash
+gh pr view 93 --repo TRIOSCS/Avail-AI-Test --json state,headRefName,mergeable
+```
+
+- [ ] **Step 1: (FRESH BRANCH path) Cut `fix/deploy-sh-rebase-before-push` from current `main`**
+
+  Skip this step if #93 is OPEN — use Step 1-A instead.
+
+  ```bash
+  cd /root/availai
+  git fetch origin
+  git checkout -b fix/deploy-sh-rebase-before-push origin/main
+  ```
+
+- [ ] **Step 1-A: (RIDE-INTO-#93 path) Check out #93's branch and rebase onto current `main`**
+
+  Skip this step if #93 is closed/merged — use Step 1 instead.
+
+  ```bash
+  cd /root/availai
+  git fetch origin
+  PR93_BRANCH=$(gh pr view 93 --repo TRIOSCS/Avail-AI-Test --json headRefName --jq .headRefName)
+  git checkout "$PR93_BRANCH"
+  git pull --rebase origin "$PR93_BRANCH"
+  git rebase origin/main
+  ```
+
+  If rebase produces conflicts: STOP, surface them, do not auto-resolve. Conflicts on a foreign PR are not in this plan's scope.
+
+- [ ] **Step 2: Inspect the current push line in `deploy.sh`**
+
+  ```bash
+  grep -n "git push origin main" /root/availai/deploy.sh
+  ```
+
+  Expected: a single hit at line 20 (the `if NO_COMMIT == false` block). If multiple hits or different line number, read the file and adapt the edit below — DO NOT blind-edit.
+
+- [ ] **Step 3: Apply the diff to `deploy.sh`**
+
+  Exact transformation — find the unique three-line sequence and add one line:
+
+  **BEFORE** (deploy.sh lines 18–20):
+  ```bash
+          git add -A
+          git commit -m "${1:-deploy}"
+          git push origin main
+  ```
+
+  **AFTER** (deploy.sh lines 18–21):
+  ```bash
+          git add -A
+          git commit -m "${1:-deploy}"
+          git pull --rebase origin main
+          git push origin main
+  ```
+
+  The `git pull --rebase origin main` line goes IMMEDIATELY before `git push origin main`, INSIDE the `if [ "$NO_COMMIT" = false ]` block, at the same 8-space indentation level as the surrounding lines. `set -euo pipefail` (deploy.sh:4) ensures a rebase failure aborts the whole deploy, which is the desired behavior — never push into a divergent state silently.
+
+- [ ] **Step 4: Verify the edit landed correctly**
+
+  ```bash
+  grep -n -B 1 -A 1 "git push origin main" /root/availai/deploy.sh
+  ```
+
+  Expected: shows `git pull --rebase origin main` on the line immediately before `git push origin main`. Both lines indented identically.
+
+- [ ] **Step 5: Lint check (optional but cheap)**
+
+  ```bash
+  bash -n /root/availai/deploy.sh
+  ```
+
+  Expected: no output (script parses).
+
+- [ ] **Step 6: Stage, commit, push**
+
+  Commit message differs by routing path:
+
+  - **FRESH BRANCH path (Step 1):**
+    ```bash
+    cd /root/availai
+    git add deploy.sh
+    git commit -m "fix(deploy): rebase before push so linear-history protection accepts the deploy (Track 2B §2B.4)"
+    git push -u origin fix/deploy-sh-rebase-before-push
+    ```
+
+  - **RIDE-INTO-#93 path (Step 1-A):**
+    ```bash
+    cd /root/availai
+    git add deploy.sh
+    git commit -m "fix(deploy): rebase before push for linear-history protection (rides into #93 per spec §2B.4)"
+    git push --force-with-lease origin "$PR93_BRANCH"
+    ```
+    `--force-with-lease` is allowed against feature branches per the Track 0.6 hookify rule fix (only `--force` against `main` is blocked).
+
+- [ ] **Step 7: Open PR-C (only on FRESH BRANCH path)**
+
+  Skip if riding into #93 — that PR already exists.
+
+  ```bash
+  gh pr create --repo TRIOSCS/Avail-AI-Test \
+    --base main --head fix/deploy-sh-rebase-before-push \
+    --title "fix(deploy): rebase before push under linear-history protection" \
+    --body "Implements spec §2B.4 (Track 2B). Branch protection enabled in Task 1 (required_linear_history: true) rejects non-fast-forward pushes, so deploy.sh now \`git pull --rebase origin main\` before \`git push\`. Verified manually via trial deploy in Step 9."
+  ```
+
+- [ ] **Step 8: Wait for CI green and merge (FRESH BRANCH path) — or wait for #93 to merge (RIDE-INTO-#93 path)**
+
+  ```bash
+  PR_NUM=$(gh pr view --repo TRIOSCS/Avail-AI-Test --json number --jq .number)
+  gh pr checks $PR_NUM --repo TRIOSCS/Avail-AI-Test --watch
+  gh pr merge $PR_NUM --repo TRIOSCS/Avail-AI-Test --squash --delete-branch
+  ```
+
+- [ ] **Step 9: TRIAL DEPLOY — the load-bearing verification (spec §10 #10)**
+
+  This is the only real-world test that branch protection AND deploy.sh hardening agree. Run a no-commit deploy that exercises `git pull --rebase` and `git push origin main` under live linear-history protection:
+
+  ```bash
+  cd /root/availai
+  git checkout main
+  git pull --rebase origin main
+  ./deploy.sh --no-commit
+  ```
+
+  Wait for the script to reach Step 4 ("App is healthy!"). If it does:
+  - Push succeeded under protection → §2B.4 fix is sufficient.
+  - Mark Task 3 done.
+
+  **If `git push origin main` is rejected by GitHub (e.g. `protected branch hook declined`):**
+  - The deploy.sh fix alone is NOT sufficient. Likely cause: a required check transitioned from green to pending mid-deploy, or check-run names drifted (re-run Task 1 Step 7).
+  - DO NOT add a `bypass` actor without operator sign-off — single-user staging policy still requires intentional protection edits, not silent overrides.
+  - DO NOT disable protection. Surface the rejection logs and STOP.
+  - Recovery options to present to the operator (in order of preference):
+    1. Re-verify §10 #4 protection contexts via Task 1 Step 5 — they may have drifted.
+    2. Add the deploy.sh runner as a `bypass_pull_request_allowances` actor on the protection rule (operator decision).
+    3. Move deploys behind a dedicated PR + auto-merge flow instead of direct `git push origin main` (architectural change, separate plan).
+
+- [ ] **Step 10: Final post-deploy verification**
+
+  ```bash
+  gh run list --repo TRIOSCS/Avail-AI-Test --branch main --limit 1 \
+    --json conclusion,headSha --jq '.[0]'
+  ```
+
+  Expected: `conclusion == "success"` on the new SHA. Confirms branch protection accepted the push AND the post-push CI passed.
+
+**Task 3 done when:** Step 9 trial deploy succeeds AND Step 10 confirms green CI on the new tip.
+
+---
+
+## Self-review — spec §-numbers mapped to tasks
+
+| Spec § | Subject | Task | Steps |
+|---|---|---|---|
+| §2B.1 | Repo merge settings (`gh repo edit`) | Task 1 | Steps 2, 3 |
+| §2B.2 | Branch protection on `main` | Task 1 | Steps 4, 5 (CRITICAL job-name verification), 6, 7 |
+| §2B.3 | Issue templates | Task 2 | Steps 2, 3, 4, 9 |
+| §2B.4 | deploy.sh `git pull --rebase` | Task 3 | Steps 0 (#93 routing), 1/1-A, 3, 4 |
+| §2B.5 | CODEOWNERS — DROPPED | (none) | Documented in File Structure + Task 2 PR body |
+| §10 #4 | Branch-protection verification | Task 1 | Step 6 |
+| §10 #5 | Repo-settings verification | Task 1 | Step 3 |
+| §10 #10 | deploy.sh trial deploy | Task 3 | Step 9 |
+| §11 P0 | Job-name vs workflow-name silent failure | Task 1 | Step 5 (must return `true`) + Step 7 (cross-check) |
+| §11 C1 | `strict: false` (avoids cascade deadlock) | Task 1 | Step 4 JSON, Step 5 verification |
+| §11 C2 | `deleteBranchOnMerge` × open-worktree interaction | PREREQUISITES | P3 (no orphans) |
+| §11 C6 | deploy.sh blocked by linear-history | Task 3 | Step 3 (the fix) + Step 9 (real-world proof) |
+| §11 H2 | `deleteBranchOnMerge` orphans stacked PRs | PREREQUISITES | P1 (zero open PRs ⇒ no stacks) |
+| §11 M6 | CODEOWNERS decorative without enforcement | Task 2 PR body | Documented as deliberate non-action |
+| §12 | PR #93 routing decision | Task 3 | Step 0 (KEY DECISION) + PREREQUISITES P5 |
+
+All §2B.1–§2B.4 subsections covered; §2B.5 explicitly documented as dropped. Every spec §11 silent-failure that touches Track 2B has an explicit verification step. Acceptance: spec §10 checks #4, #5, and #10 all pass.

--- a/docs/superpowers/plans/2026-05-08-github-cleanup-track-3-automations.md
+++ b/docs/superpowers/plans/2026-05-08-github-cleanup-track-3-automations.md
@@ -1,0 +1,419 @@
+# Track 3 — Final Automations Implementation Plan
+
+> **For agentic workers:** Two automation upgrades from `2026-05-08-github-cleanup-design.md` §3.1 and §3.2. Run AFTER Track 1 completes (cascade merged, worktrees pruned). §3.3 (`/worktree-switch`) and §3.4 (`claude-md-auditor` subagent) are explicitly DROPPED in the spec — do NOT implement them. The auto-prune hook lands as a local edit to `.claude/settings.local.json` plus a new script — there is NO PR for hook changes (settings.local.json is gitignored / per-machine). The schedule entry is created via the `/schedule` skill against the user's harness, NOT committed to the repo.
+
+## Goal
+
+1. **§3.1** — When `gh pr merge` or `git merge` runs and the merged feature branch has a corresponding `.claude/worktrees/<slug>` directory, automatically run `git worktree remove --force "<slug>"`. Idempotent (no-op on miss / already-pruned).
+2. **§3.2** — Schedule the existing `claude-md-management:claude-md-improver` skill to run weekly (Monday 09:00) via the `/schedule` skill so CLAUDE.md drift never reaches the level it did this session.
+
+Success = (a) merging any feature PR via `gh pr merge` removes its worktree without manual cleanup; (b) `/schedule list` shows the weekly `claude-md-improver` routine.
+
+## Architecture
+
+- **§3.1 hook** is a local Bash script invoked by Claude Code's `PostToolUse` event for `Bash` tool calls. The hook reads JSON from stdin (Claude Code hook protocol) — see `.claude/hooks/status-string-guard.sh` and `.claude/hooks/skill-instructions-hook.sh` for existing examples in this repo. The script greps the tool's command + output for the merged branch name, derives the worktree slug as the final path component of the branch (verified convention: `fix/env-hygiene` → `env-hygiene`, `docs/pre-rollout-checklist` → `pre-rollout-checklist`), and removes the worktree if present. No-op if slug isn't a worktree, the directory was already removed, or the parsed branch is `main`/`master`.
+- **§3.2 schedule** is a routine in the user's Claude Code harness, not a repo artifact. It uses the `/schedule` skill (NOT `/loop` — `/loop` runs in-session at human pace; `/schedule` runs via cron and persists across sessions). The cron expression `0 9 * * 1` fires every Monday at 09:00 local. The action invokes `claude-md-management:claude-md-improver`, which already exists in the user's plugin set and audits + updates CLAUDE.md files.
+
+## Tech Stack
+
+- Bash (POSIX-portable script, reads JSON from stdin via `jq`)
+- Claude Code hooks (`PostToolUse` Bash matcher in `.claude/settings.local.json`)
+- `git worktree remove --force` (idempotent on already-removed dirs because we guard with `[ -d ]`)
+- `/schedule` skill (cron-style routine manager, separate from `/loop` which is in-session)
+- Existing skill: `claude-md-management:claude-md-improver`
+
+## PREREQUISITES
+
+- **Track 1 complete.** Specifically:
+  - 1.2 (stacked #108/#109 merged)
+  - 1.3 (cascade pool of 11 PRs merged or closed)
+  - 1.4 (orphan worktree dirs `rm -rf`'d, merged-branch worktrees `git worktree remove`'d)
+- After 1.4, `git worktree list` and `ls .claude/worktrees/` agree. The auto-prune hook is meant to keep that invariant going forward — installing it before Track 1.4 would just race the manual cleanup.
+- **Track 2B is optional but typical** — once `deleteBranchOnMerge: true` is on (spec §2B.1), the merged branch is gone from origin AND we've cleaned up the local worktree, closing the loop end-to-end. The hook is correct either way.
+
+## File Structure
+
+| Path | Action | Purpose |
+|---|---|---|
+| `.claude/hooks/auto-prune-worktree.sh` | Create | Reads merge-tool stdin, removes matching `.claude/worktrees/<slug>` (spec §3.1) |
+| `.claude/settings.local.json` | Modify | Append PostToolUse Bash matcher entry pointing at the new script (spec §3.1 wiring) |
+
+No repo-tracked file changes — `.claude/settings.local.json` is per-machine local config, not committed. The `/schedule` routine (§3.2) is harness state, also not in the repo. **There is no PR for this Track.**
+
+---
+
+## Task 1 — Build the auto-prune hook script
+
+### 1.1 Verify worktree slug convention
+
+Run once to confirm the convention before coding:
+
+```bash
+git -C /root/availai worktree list | awk '/\.claude\/worktrees\// {print $1, $NF}'
+```
+
+Expected output (current state) maps each worktree dir to its branch — every dir name equals the LAST `/`-segment of the branch:
+
+```
+.claude/worktrees/ci-unblock              [fix/ci-unblock-test-assertions]
+.claude/worktrees/deploy-sh-harden        [fix/deploy-sh-harden]
+.claude/worktrees/env-hygiene             [fix/env-hygiene]
+.claude/worktrees/eslint-browser-globals  [fix/eslint-browser-globals]
+.claude/worktrees/migration-001           [fix/ci-unblock-alembic-and-audit]
+.claude/worktrees/pre-rollout-checklist   [docs/pre-rollout-checklist]
+.claude/worktrees/spec-cleanup            [docs/github-cleanup-spec]
+```
+
+NOTE the `migration-001`/`ci-unblock` cases prove the slug is NOT always `basename(branch)` — operators sometimes pick a custom shortname. The hook therefore canonicalizes by trying BOTH `basename` and the literal full branch (with `/` → `-`), and falls back to listing `git worktree list --porcelain` to find a worktree whose branch line equals the merged ref. This avoids false misses on hand-named worktrees.
+
+### 1.2 Create the script
+
+Path: `/root/availai/.claude/hooks/auto-prune-worktree.sh`. Mark executable (`chmod +x` after writing).
+
+```bash
+#!/usr/bin/env bash
+# auto-prune-worktree.sh — PostToolUse hook: remove .claude/worktrees/<slug>
+# after `gh pr merge` or `git merge` of a feature branch.
+# Implements docs/superpowers/specs/2026-05-08-github-cleanup-design.md §3.1.
+# Called by: Claude Code PostToolUse hook (Bash matcher) wired in
+#   .claude/settings.local.json. Depends on: jq, git, gh (no network calls).
+# Idempotent: any failure path falls through to exit 0 — never blocks the
+# parent tool call, never re-removes an already-gone worktree.
+set -u
+
+# Hook protocol: JSON from stdin with .tool_input.command and .tool_response.output.
+input="$(cat)"
+[ -z "$input" ] && exit 0
+
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+out="$(printf '%s' "$input" | jq -r '.tool_response.output // empty' 2>/dev/null)"
+[ -z "$cmd" ] && exit 0
+
+# Only act on merge-style invocations.
+case "$cmd" in
+  *"gh pr merge"*|*"git merge"*) ;;
+  *) exit 0 ;;
+esac
+
+# Try to extract the merged branch name from the combined cmd+output blob.
+# `gh pr merge` prints lines like:
+#   ✓ Squashed and merged pull request #92 (fix/env-hygiene)
+# `git merge --ff-only fix/env-hygiene` echoes the ref as an arg.
+blob="$cmd"$'\n'"$out"
+branch=""
+
+# Pattern 1: gh pr merge output — branch in parens after PR #N
+branch="$(printf '%s' "$blob" | grep -oE 'pull request #[0-9]+ \([^)]+\)' \
+  | head -n1 | sed -E 's/.*\(([^)]+)\).*/\1/')"
+
+# Pattern 2: explicit branch arg on `git merge` / `gh pr merge <branch>`
+if [ -z "$branch" ]; then
+  branch="$(printf '%s' "$cmd" \
+    | grep -oE '(git merge( --ff-only| --no-ff| --squash)?| gh pr merge)( -[A-Za-z]+)*( [A-Za-z0-9._/-]+)' \
+    | awk '{print $NF}' | tail -n1)"
+fi
+
+# Refuse to touch main/master, empty, or anything non-feature-looking.
+case "$branch" in
+  ""|main|master|HEAD|origin/*) exit 0 ;;
+esac
+
+# Locate repo root from the hook's CWD; bail quietly if not in a git repo.
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+worktrees_dir="$repo_root/.claude/worktrees"
+[ -d "$worktrees_dir" ] || exit 0
+
+# Resolve slug: prefer `git worktree list` mapping (handles hand-named dirs
+# like .claude/worktrees/migration-001 → fix/ci-unblock-alembic-and-audit),
+# fall back to basename(branch), then full-branch-with-slash-replaced.
+slug=""
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) wt_path="${line#worktree }" ;;
+    "branch refs/heads/$branch")
+      case "$wt_path" in
+        "$worktrees_dir"/*) slug="${wt_path#$worktrees_dir/}" ;;
+      esac
+      ;;
+  esac
+done < <(git -C "$repo_root" worktree list --porcelain)
+
+[ -z "$slug" ] && slug="${branch##*/}"
+target="$worktrees_dir/$slug"
+
+# Idempotent: bail if directory already gone.
+[ -d "$target" ] || exit 0
+
+# Use --force so dirty trees don't block cleanup; merge implies the work shipped.
+git -C "$repo_root" worktree remove --force "$target" 2>/dev/null || rm -rf "$target"
+echo "auto-prune-worktree: removed $target (branch $branch)" >&2
+exit 0
+```
+
+### 1.3 Mark executable
+
+```bash
+chmod +x /root/availai/.claude/hooks/auto-prune-worktree.sh
+```
+
+### 1.4 Test the hook in isolation (no merge required)
+
+Simulate the hook protocol JSON via stdin and a fake worktree:
+
+```bash
+# Create a sandbox worktree the hook can prune.
+git -C /root/availai worktree add /root/availai/.claude/worktrees/_hook-smoke -b chore/_hook-smoke
+
+# Feed simulated `gh pr merge` JSON to the hook.
+printf '%s' '{
+  "tool_input": {"command": "gh pr merge 999 --squash"},
+  "tool_response": {"output": "✓ Squashed and merged pull request #999 (chore/_hook-smoke)\n"}
+}' | /root/availai/.claude/hooks/auto-prune-worktree.sh
+
+# Verify removal.
+test ! -d /root/availai/.claude/worktrees/_hook-smoke && echo "PRUNED OK"
+git -C /root/availai branch -D chore/_hook-smoke 2>/dev/null
+```
+
+Expect `PRUNED OK` and a stderr line `auto-prune-worktree: removed ... (branch chore/_hook-smoke)`.
+
+Then run a no-op smoke (already-removed dir): re-feed the same JSON; expect exit 0 and no stderr line.
+
+Then a guard-rail smoke: feed `"command": "git merge main"` (branch = `main`); expect exit 0 with no action. Confirm by re-creating `_hook-smoke` and re-feeding — it should NOT be removed for `main`.
+
+---
+
+## Task 2 — Wire the hook into `.claude/settings.local.json`
+
+### 2.1 Read the current file structure
+
+The file already has a `hooks` object with `PreToolUse` and `PostToolUse` arrays. Each array entry is `{matcher, hooks: [{type, command, statusMessage}]}`. Confirm shape with:
+
+```bash
+jq '.hooks | keys' /root/availai/.claude/settings.local.json
+jq '.hooks.PostToolUse' /root/availai/.claude/settings.local.json
+```
+
+Expected: `["PostToolUse","PreToolUse"]`, and `PostToolUse` is an array containing the existing Ruff-format and related-tests entries.
+
+### 2.2 Append the new hook entry
+
+Add ONE entry to `.hooks.PostToolUse`. Use `jq` so the file stays valid JSON:
+
+```bash
+tmp=$(mktemp)
+jq '.hooks.PostToolUse += [{
+  "matcher": "Bash",
+  "hooks": [{
+    "type": "command",
+    "command": ".claude/hooks/auto-prune-worktree.sh",
+    "statusMessage": "Auto-prune merged worktree"
+  }]
+}]' /root/availai/.claude/settings.local.json > "$tmp" && mv "$tmp" /root/availai/.claude/settings.local.json
+```
+
+`matcher: "Bash"` (NOT a regex like `gh pr merge.*`) — Claude Code hook matchers run against the tool NAME, and the script does its own command-string filtering inside. This is the same pattern used by all existing entries in the file.
+
+### 2.3 Verify JSON validity
+
+```bash
+jq -e . /root/availai/.claude/settings.local.json >/dev/null && echo "JSON OK"
+jq -e '.hooks.PostToolUse | map(.hooks[0].command) | index(".claude/hooks/auto-prune-worktree.sh")' \
+  /root/availai/.claude/settings.local.json
+```
+
+Expect `JSON OK` and a non-null index (the position of the new entry — typically `2` since two PostToolUse Bash entries already exist).
+
+### 2.4 End-to-end smoke
+
+Open a fresh Claude Code session in `/root/availai`. From within Claude, run a Bash tool call like `gh pr merge --squash <some-test-pr>` (or replay 1.4's sandbox worktree + a no-op `git merge --ff-only chore/_hook-smoke main`). Observe the hook fires (transcript shows status message `Auto-prune merged worktree`) and the worktree is gone.
+
+If smoke fails: hook errors in Claude Code never block the parent tool call, but check the harness log at `~/.claude/logs/` for `auto-prune-worktree:` lines and stderr from `jq` / `git`.
+
+---
+
+## Task 3 — Schedule `claude-md-improver` weekly
+
+### 3.1 Confirm the right scheduler skill
+
+The user's harness exposes both `/loop` (in-session recurring at human pace) and `/schedule` (cron-style remote routines that survive session end). For a weekly CLAUDE.md audit we want **`/schedule`** — `/loop` would die the moment the session closes. The `/schedule` skill description: *"Create, update, list, or run scheduled remote agents (routines) that execute on a cron schedule."*
+
+### 3.2 Create the routine
+
+Invoke the skill with this prompt verbatim (the harness parses cron + action from natural language):
+
+```
+/schedule create
+  name: claude-md-weekly-audit
+  cron: 0 9 * * 1
+  action: Invoke the claude-md-management:claude-md-improver skill against /root/availai. Audit and improve all CLAUDE.md files. Apply fixes directly; open a PR titled "chore(docs): weekly CLAUDE.md drift sweep" if any file changed. Skip silently if no drift found.
+```
+
+Cron expression `0 9 * * 1` = Monday at 09:00 (server-local time). Weekly cadence per spec §3.2. The action body explicitly references the existing skill name `claude-md-management:claude-md-improver` so the routine doesn't reinvent the auditor (spec §3.4 explicitly DROPS a custom subagent).
+
+### 3.3 Verify
+
+```
+/schedule list
+```
+
+Expect output containing a routine named `claude-md-weekly-audit` with cron `0 9 * * 1`. Then optionally:
+
+```
+/schedule run claude-md-weekly-audit
+```
+
+…to fire it once on demand. Confirm it invokes the `claude-md-improver` skill (transcript should show that skill's first-line banner) and either reports "no drift" or opens the described PR.
+
+### 3.4 No file artifact
+
+`/schedule` routines live in the harness's state, NOT in the repo. There is nothing to commit for §3.2.
+
+---
+
+## Self-review — spec coverage
+
+| Spec section | Status | Where in this plan |
+|---|---|---|
+| §3.1 hook script at `.claude/hooks/auto-prune-worktree.sh` | Implemented | Task 1.2 |
+| §3.1 PostToolUse Bash matcher | Implemented | Task 2.2 (matcher: "Bash"; command-string filter inside script) |
+| §3.1 parses merged branch from `gh pr merge` output | Implemented | Task 1.2 (Pattern 1: `pull request #N (branch)`) |
+| §3.1 parses merged branch from `git merge ...` arg | Implemented | Task 1.2 (Pattern 2: tail arg of cmd) |
+| §3.1 maps branch → worktree slug | Implemented | Task 1.2 (worktree-list lookup; basename fallback) |
+| §3.1 `git worktree remove --force` | Implemented | Task 1.2 (with `rm -rf` fallback) |
+| §3.1 idempotent (no-op if dir absent) | Implemented | Task 1.2 (`[ -d "$target" ] \|\| exit 0`) |
+| §3.1 idempotent (no-op on `main`/`master`) | Implemented | Task 1.2 (case branch refusal) |
+| §3.1 test simulating stdin | Implemented | Task 1.4 |
+| §3.2 use existing `claude-md-management:claude-md-improver` skill | Implemented | Task 3.2 (action references skill by full name) |
+| §3.2 schedule via `/loop` or `/schedule` skill | Implemented | Task 3.1–3.2 (chose `/schedule` per skill description; rationale in 3.1) |
+| §3.2 NO custom subagent | Honored | Plan only schedules existing skill; no new subagent file |
+| §3.2 weekly cadence | Implemented | Task 3.2 (cron `0 9 * * 1`) |
+| §3.3 `/worktree-switch` skill — DROPPED | Out of scope | Not implemented (per spec) |
+| §3.4 `claude-md-auditor` subagent — DROPPED | Out of scope | Not implemented (per spec) |
+| Track 1 prerequisite | Honored | PREREQUISITES section at top |
+| Track 2B optional/typical | Noted | PREREQUISITES section at top |
+
+Done when:
+
+```bash
+# 1. Hook script present and executable
+test -x /root/availai/.claude/hooks/auto-prune-worktree.sh
+
+# 2. Hook wired into settings.local.json
+jq -e '.hooks.PostToolUse | map(.hooks[0].command) | any(. == ".claude/hooks/auto-prune-worktree.sh")' \
+  /root/availai/.claude/settings.local.json
+
+# 3. Smoke test (Task 1.4) passed: PRUNED OK + no-op replay + main guard
+# 4. /schedule list shows claude-md-weekly-audit (Task 3.3)
+```
+
+…and a real `gh pr merge` of any future cascade-style feature PR removes its `.claude/worktrees/<slug>` automatically.
+
+---
+
+## Task 4: Final §10 Success-Criteria Verification
+
+Closeout for the entire GitHub cleanup initiative. Track 3 is the last track to land, so verifying spec §10's full 10-item success-criteria list belongs here. Each command below is copied verbatim from spec §10 — run each and confirm the expected output before declaring the cleanup done.
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 4.1: Run all 10 success criteria from spec §10**
+
+Run from `/root/availai`:
+
+```bash
+cd /root/availai
+
+# 1. Zero open PRs
+gh pr list --state open --limit 1 --json number | jq 'length == 0'
+# Expected: true
+
+# 2. Zero orphan worktree dirs
+[ -z "$(comm -23 <(ls .claude/worktrees/ 2>/dev/null | sort) <(git worktree list --porcelain | awk '/^worktree/ {print $2}' | sed 's|.*/||' | sort))" ] && echo "ZERO ORPHANS" || echo "ORPHANS PRESENT"
+# Expected: ZERO ORPHANS
+
+# 3. main CI green (last 2 runs)
+gh run list --branch main --limit 2 --json conclusion --jq 'all(.[]; .conclusion == "success")'
+# Expected: true
+
+# 4. Branch protection correctly applied (job names not workflow names; strict false; linear history)
+gh api repos/TRIOSCS/Avail-AI-Test/branches/main/protection \
+  --jq '.required_status_checks.contexts == ["test","security"]
+        and .required_status_checks.strict == false
+        and .required_linear_history.enabled == true
+        and .enforce_admins.enabled == false'
+# Expected: true
+
+# 5. Repo merge settings
+gh repo view TRIOSCS/Avail-AI-Test \
+  --json mergeCommitAllowed,squashMergeAllowed,deleteBranchOnMerge \
+  --jq '.mergeCommitAllowed == false and .squashMergeAllowed == true and .deleteBranchOnMerge == true'
+# Expected: true
+
+# 6. Templates + labels exist
+test -f .github/PULL_REQUEST_TEMPLATE.md \
+  && test -f .github/ISSUE_TEMPLATE/bug.md \
+  && gh label list --json name --jq 'map(.name) | contains(["type:bug","priority:p0","scope:ci"])' \
+  && echo "TEMPLATES+LABELS PASS"
+# Expected: TEMPLATES+LABELS PASS
+
+# 7. Skills exist locally
+test -d .claude/skills/cascade \
+  && test -d .claude/skills/recommit \
+  && test -d .claude/skills/smoke-gate \
+  && test -d .claude/skills/worktree-prune \
+  && echo "SKILLS PASS"
+# Expected: SKILLS PASS
+
+# 8. main-is-RED hook installed
+(grep -q "main is currently RED" .claude/settings.local.json \
+  || test -x .claude/hooks/main-is-red-warn.sh) \
+  && echo "RED-HOOK PASS"
+# Expected: RED-HOOK PASS
+
+# 9. CLAUDE.md drift fixed (spot-checks)
+grep -q "claude-sonnet-4-6" CLAUDE.md \
+  && grep -q "AVAIL_OPP_TABLE_V2" CLAUDE.md \
+  && ! grep -q "MICROSOFT_GRAPH_ENDPOINT" CLAUDE.md \
+  && echo "CLAUDE.MD-DRIFT PASS"
+# Expected: CLAUDE.MD-DRIFT PASS
+
+# 10. deploy.sh works under protection — VERIFIED MANUALLY in Track 2B Task 3 Step 9 (trial deploy)
+echo "Item 10: confirmed by Track 2B trial deploy"
+```
+
+If any check fails, halt the closeout and trace back to the owning track:
+- #1, #2 → Track 1.4
+- #3 → Track 1.1 / Track 1.3
+- #4, #5 → Track 2B Task 1
+- #6 → Track 2A (template + labels) + Track 2B Task 2 (issue templates)
+- #7 → Track 0 Tasks 1–4
+- #8 → Track 0 Task 5
+- #9 → Track 1.2 (§13 mini-PR)
+- #10 → Track 2B Task 3
+
+- [ ] **Step 4.2: Save closeout memory + update MEMORY.md index**
+
+```bash
+cat > /root/.claude/projects/-root/memory/project_github_cleanup_2026_05_08.md <<'EOF'
+---
+name: GitHub Cleanup 2026-05-08 Complete
+description: Umbrella GitHub cleanup landed; success criteria verified; tracks 0/1/2A/2B/3 done
+type: project
+---
+
+GitHub cleanup initiative completed 2026-05-08.
+
+**Why:** 13 open PRs cascade-blocked behind alembic CI; main RED; no branch protection; 7 orphan worktrees; CLAUDE.md drift.
+
+**How to apply:** Treat the umbrella spec at `docs/superpowers/specs/2026-05-08-github-cleanup-design.md` as the canonical record. Don't re-invent /cascade, /smoke-gate, /worktree-prune, /recommit — they live in `.claude/skills/`. Don't disable warn-destructive-git or the main-is-RED hook without good reason.
+
+Success criteria all verified per spec §10 on completion.
+EOF
+
+echo "- [project_github_cleanup_2026_05_08.md](project_github_cleanup_2026_05_08.md) — 2026-05-08: full GitHub cleanup completed; all 10 success criteria verified" \
+  >> /root/.claude/projects/-root/memory/MEMORY.md
+```
+
+**Cleanup done.**

--- a/docs/superpowers/specs/2026-05-08-github-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-08-github-cleanup-design.md
@@ -1,0 +1,465 @@
+# GitHub Cleanup & Optimization — Design
+
+**Date:** 2026-05-08
+**Status:** APPROVED — ready for writing-plans
+**Repo:** TRIOSCS/Avail-AI-Test
+**Context:** Single-user staging (app.availai.net), NOT multi-tenant prod — risk tolerance is higher than enterprise defaults; merge protections sized accordingly.
+
+---
+
+## Problem statement
+
+The repo has accumulated structural drift that compounds friction on every change:
+
+- **13 open PRs**, 8+ blocked behind a chicken-and-egg Alembic CI failure on `main`
+- **2 PRs CONFLICTING** vs. main (#96, #103) — would fail any cascade rebase as-is
+- **9 scattered worktrees** across `/tmp`, `/root/availai-*`, `.claude/worktrees/` — no convention
+- **7 orphan worktree dirs** (`.claude/worktrees/agent-*`) not in `git worktree list`
+- **`main` CI is RED** as of 2026-05-08 on `6890dcf5` — both `CI — Tests` and `Security Scanning` failing
+- **No branch protection on main** (404 — fully open)
+- **`deleteBranchOnMerge: false`** — branches accumulate after merge
+- **No PR template, no issue templates, no issue labels**
+- **CLAUDE.md drift**: 3 fix-now items + 4 NEW drift items vs. reality (pre-commit list, ANTHROPIC_MODEL 3-way mismatch, phantom env keys, missing real env keys)
+- Repeated friction in this and prior sessions: pre-commit auto-fixes force re-stage, force-push hookify rule blocks worktree work, no orchestration for stacked-PR or cascade-merge flows
+
+This design eliminates that drift in four parallelizable tracks, with corrections from a parallel review pass that caught **multiple silent-failure bugs in the original draft** (documented in §11).
+
+---
+
+## Goals & non-goals
+
+### Goals (binary success criteria — see §10)
+1. 0 open PRs (each merged or closed with rationale)
+2. 0 orphan worktree dirs
+3. `main` CI green and stays green
+4. Branch protection on `main` with required `test` + `security` checks (NOT workflow names — see §6)
+5. `deleteBranchOnMerge: true`, `allow_merge_commit: false`
+6. PR template, issue templates, issue label taxonomy in place
+7. `/cascade`, `/recommit`, `/smoke-gate`, `/worktree-prune` skills exist locally
+8. `main-is-RED` pre-push warn hook active
+9. CLAUDE.md drift items resolved
+10. `deploy.sh` works under linear-history protection (verified by trial deploy)
+
+### Non-goals (explicit, prevent scope creep)
+- mypy 2080 errors / ESLint 9 problems / `test_sprint8_proactive` failure — separate code-quality initiative
+- Multi-contributor concerns: CODEOWNERS enforcement, required reviews, signed commits — not relevant to single-user staging
+- `/root/availai-health-fix` decision — flagged in §7, deferred to operator (this design does not delete it)
+- Renaming the workflow from `CI — Tests` (em-dash) to ASCII — not load-bearing once we use job names for protection
+
+---
+
+## Architecture
+
+Four tracks. Track 0 builds tools; Track 1 is the critical path; Tracks 2A/2B handle policy; Track 3 ships final automations.
+
+```
+Track 0 ──→ Track 1.1 ──→ Track 1.2 ──→ Track 1.3 ──→ Track 1.4 ──→ Track 2B ──→ Track 3
+              (stabilize)   (stack)      (cascade)     (worktrees)   (protection)  (auto)
+
+Track 2A ────────────────────────────────────────────→ (anytime; lands now)
+```
+
+**Key dependency rule:** Track 2B (`deleteBranchOnMerge` + branch protection) **must not land before Track 1 completes**. Reasoning:
+- `deleteBranchOnMerge` while #108/#109 stack is open → orphans the dependent PR (silent-failure H2)
+- `deleteBranchOnMerge` while worktrees still exist → destructive interaction (architecture C2)
+- Branch protection with required checks while cascade PRs are red → indefinite block
+
+---
+
+## Track 0 — Pre-flight tooling
+
+Local-only files in `.claude/skills/` and `.claude/hooks/`. No PRs. Run before Track 1 so Track 1 uses the tools.
+
+### 0.1 `/cascade` skill — `.claude/skills/cascade/SKILL.md`
+Toposort PRs by `baseRefName`, identify merge-ready leaves (state CLEAN + green), merge each, auto-rebase descendants, halt on conflict with explicit "next action" message. Snapshots unresolved review comments per `gh api repos/.../pulls/<n>/comments --jq '.[] | select(.in_reply_to_id == null)'` BEFORE rebase to prevent comment loss (silent-failure H7).
+
+Idempotent: tracks last-merged PR in `.claude/state/cascade.json`; restart resumes from the next leaf.
+
+### 0.2 `/recommit` skill — `.claude/skills/recommit/SKILL.md`
+Replaces the originally-proposed auto-restage hook (silent-failure H5: hook would silently scoop up `git add -p` partial-stage hunks user didn't intend to commit).
+
+Implementation: `git commit "$@" || (git add -u && git commit --no-edit)`. Explicit user invocation; no hidden auto-restage.
+
+### 0.3 `/smoke-gate` skill — `.claude/skills/smoke-gate/SKILL.md`
+Spin up ephemeral postgres (`docker run -d --rm -p 5433:5432 postgres:16`), run `alembic upgrade head` → `alembic downgrade base` → `alembic upgrade head` → step-down/step-up chain → teardown. Catches the exact failure mode that gave us the #108/#109 chicken-and-egg.
+
+### 0.4 `/worktree-prune` skill — `.claude/skills/worktree-prune/SKILL.md`
+Detect orphans: `comm -23 <(ls .claude/worktrees/) <(git worktree list --porcelain | awk '/^worktree/ {print $2}' | sed 's|.*/||')`. Cross-check `gh pr view <branch>` for state CLOSED/MERGED. Interactive confirm + `git worktree remove --force` + `rm -rf`.
+
+### 0.5 `main-is-RED` pre-push warn hook
+PreToolUse on Bash, matcher `git push.*` (excluding `--force` cases handled separately):
+```bash
+c=$(gh run list --branch main --limit 1 --json conclusion -q '.[0].conclusion' 2>/dev/null)
+[ "$c" = "failure" ] && echo "WARN: main CI is currently RED — your PR's mergeStateStatus will show UNSTABLE due to main, not your PR" >&2
+exit 0
+```
+Non-blocking. Solves the confusion we hit repeatedly this session.
+
+### 0.6 Fix `warn-destructive-git` hookify rule
+Current pattern blocks ALL `git push --force` (architecture C8 / silent-failure H6: rationalizing whitelist by path is band-aid; root cause is target-ref).
+
+Replace with a target-ref-based pattern (single-line regex):
+
+```
+BLOCK pattern: git\s+push\b[^\n]*--force\b[^\n]*\b(main|master)\b
+              git\s+push\b[^\n]*--force-with-lease[^\n]*\b(main|master)\b
+ALLOW:        all other --force / --force-with-lease usages (i.e. to feature branches)
+```
+
+The two BLOCK alternatives are matched separately so `--force-with-lease` still flags when targeting `main`. Anchor `\b(main|master)\b` matches both `origin main` (space-separated) and `origin/main`.
+
+This keeps the safety rail for the truly destructive case (force-push to main) while removing friction for legitimate worktree work.
+
+---
+
+## Track 1 — Critical path (sequential)
+
+### 1.1 Stabilize main
+- Pull failing run logs: `gh run view 25532626888 --log-failed`
+- Diagnose root cause on `6890dcf5`
+- Fix as direct-to-main hotfix (the ONLY direct-to-main exception in this design — branch protection isn't on yet)
+- Verify with `/smoke-gate` if migration-related
+
+### 1.2 Resolve stacked PRs (#109 → #108 → main)
+PR #109 base = `fix/ci-unblock-alembic-and-audit` (PR #108's branch). PR #109 is currently fully green (test + security passing on `46ffc979`). PR #108 is red because it lacks #109's CI fixes.
+
+Steps:
+1. `gh pr merge 109 --squash` — squash-merges #109 INTO #108's branch
+2. Wait for #108's CI to re-run on the new commits (now contains #109's fixes)
+3. Verify #108 fully green
+4. `gh pr merge 108 --squash` — squash-merges #108 → main
+5. Verify main CI green
+6. Ship CLAUDE.md fix-now mini-PR (small, direct PR — see §13)
+
+### 1.3 Cascade-merge 11 PRs
+
+**Pool:** #92, #93, #94, #96, #97, #100, #101, #102, #103, #106, #107
+
+**Pre-flight (mandatory before /cascade runs):**
+- Resolve conflicts on **#96** (`fix/ci-unblock-test-assertions`, mergeable=CONFLICTING) in its worktree
+- Resolve conflicts on **#103** (`docs/claude-md-rebuild`, mergeable=CONFLICTING)
+- Confirm no other PR has drifted to CONFLICTING since this audit
+
+**Order** (deps → infra → features):
+1. `#100` — dependabot/pip/minor-and-patch-ac6984c910 (FAST-TRACK: skip full agent review; verify CI passes + no major-version bumps + merge — architecture C7)
+2. `#92` — fix/env-hygiene (4 lines, 1 file)
+3. `#93` — fix/deploy-sh-harden (35 lines, 1 file) — **see §8.2 for required edit before merge**
+4. `#94` — docs/pre-rollout-checklist (336 lines, 1 file, docs-only)
+5. `#96` — fix/ci-unblock-test-assertions (post-conflict-resolution)
+6. `#97` — fix/eslint-browser-globals (2 lines, 1 file)
+7. `#101` — chore/great-purge-tracked-artifacts (2747 deletions, 361 files — biggest deletion PR; full review)
+8. `#102` — fix/search-bg-session (867 lines, 8 files; full review)
+9. `#103` — docs/claude-md-rebuild (post-conflict-resolution; coordinate with §13 fix-now PR — likely supersedes some items)
+10. `#106` — fix/connector-hard-errors (13 lines, 2 files)
+11. `#107` — chore/gradient-vestiges-and-docfmt (1347 lines, 32 files — biggest feature PR; full review)
+
+**Per-PR procedure** (executed by `/cascade`):
+1. Snapshot unresolved review comments via `gh api`
+2. Rebase onto current `main`
+3. Run pre-commit + tests + lint locally in worktree
+4. Push (force-with-lease)
+5. Re-post unresolved comments to new SHAs
+6. Dispatch full agent review suite (skip for #100)
+7. Address findings as fresh commits
+8. Wait for green CI on the latest SHA
+9. `gh pr merge --squash`
+10. Move to next PR; if conflict, halt and surface
+
+### 1.4 Worktree + remote-branch consolidation (uses `/worktree-prune`)
+
+**Local worktrees:**
+- `rm -rf` the 7 orphan dirs: `agent-{a034b395, a263dee1, a37647f7, a47a352b, a4cf0049, a6911920, aff7e329}`
+- `git worktree remove` each `.claude/worktrees/<name>` whose branch was merged in 1.3
+- `git worktree remove /tmp/pr109-rebase` (transient artifact from this session)
+- Decide on `/root/availai-health-fix` (separate clone, branch `[origin/main: behind 4]`) — operator decision per §12
+
+**Remote branches** (CRITICAL — Track 2B's `deleteBranchOnMerge` is NOT on during cascade, so 1.3's merged branches still exist on origin):
+```bash
+# Delete each cascade-merged branch from origin
+gh pr list --state merged --base main --search "merged:>=2026-05-08" \
+  --json number,headRefName --jq '.[].headRefName' | \
+  while read branch; do
+    [ -n "$branch" ] && gh api -X DELETE \
+      "repos/TRIOSCS/Avail-AI-Test/git/refs/heads/$branch" 2>/dev/null || true
+  done
+
+# Local prune to reflect deletions
+git fetch --prune origin
+```
+
+**Local branch cleanup** (only branches confirmed merged):
+```bash
+# Use git cherry to verify merge (silent-failure H4: -D after squash skips merge check)
+for b in $(git branch -vv | grep ': gone\]' | awk '{print $1}'); do
+  if [ -z "$(git cherry main "$b")" ]; then
+    git branch -D "$b"
+  else
+    echo "SKIP $b: has un-squashed commits"
+  fi
+done
+```
+
+**Final state:** only `/root/availai` itself + any actively-used worktree under `.claude/worktrees/`. `git worktree list` and `ls .claude/worktrees/` agree.
+
+---
+
+## Track 2A — Land-now policy (parallel with Track 1)
+
+These have no merge-blocking effect and can land any time. Each is its own small PR.
+
+### 2A.1 PR template
+Create `.github/PULL_REQUEST_TEMPLATE.md`:
+```markdown
+## Summary
+
+<!-- 1-3 sentences on what changed and why -->
+
+## Test plan
+
+- [ ] Tests added/updated
+- [ ] Pre-commit + ruff + mypy clean
+- [ ] APP_MAP doc(s) in `docs/` updated if architecture changed
+
+## Risk & rollback
+
+<!-- Blast radius. How do we revert if this breaks main/staging? -->
+
+## Linked issues
+
+<!-- Closes #N (or N/A) -->
+```
+
+### 2A.2 Issue label taxonomy
+Apply via `gh label create` (idempotent if `--force`):
+- `type:bug`, `type:feature`, `type:chore`, `type:security`, `type:docs`
+- `priority:p0`, `priority:p1`, `priority:p2`
+- `scope:ci`, `scope:db`, `scope:frontend`, `scope:backend`, `scope:infra`
+
+Then label existing #88 (`type:chore scope:frontend`), #89 (`type:chore scope:frontend`). Issues #83, #84 will close when their respective PRs merge.
+
+### 2A.3 ~~`deleteBranchOnMerge: true`~~ → MOVED to Track 2B
+Reason: H2 (orphans stacked #108/#109 if applied prematurely) + C2 (destructive worktree interaction).
+
+### 2A.4 ~~Dependabot github-actions ecosystem~~ → REMOVED
+Already exists at `.github/dependabot.yml:17-23`. Architecture C5: implementing as written would create duplicate keys → silent dependabot parse failure.
+
+---
+
+## Track 2B — Land-after-Track-1 policy
+
+Order: Track 1.4 done → 2B starts. All in one configuration PR/script.
+
+### 2B.1 Repo settings
+```bash
+gh repo edit TRIOSCS/Avail-AI-Test \
+  --delete-branch-on-merge \
+  --enable-merge-commit=false \
+  --enable-squash-merge=true \
+  --enable-rebase-merge=true
+```
+
+### 2B.2 Branch protection on `main`
+
+**CRITICAL:** required check `contexts` are JOB names (`test`, `security`), NOT workflow names (`CI — Tests`, `Security Scanning`). Verified via `gh api repos/.../commits/main/check-runs --jq '.check_runs[].name'`. Using workflow names would silently never match anything → P0 silent-failure (parallel review caught this).
+
+```bash
+gh api -X PUT repos/TRIOSCS/Avail-AI-Test/branches/main/protection \
+  -H "Accept: application/vnd.github+json" \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": ["test", "security"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "required_signatures": false,
+  "required_linear_history": true,
+  "required_conversation_resolution": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "restrictions": null
+}
+JSON
+```
+
+**Each setting justified:**
+- `strict: false` — single-user, no concurrent-contributor races; `strict: true` would deadlock the cascade at ~2 hours sequential CI cycles (architecture C1)
+- `contexts: ["test", "security"]` — actual GitHub-reported check-run names (P0 silent-failure prevention)
+- `enforce_admins: false` — preserves emergency hotfix path (Track 1.1's pattern); single-user staging context
+- `required_linear_history: true` — paired with `allow_merge_commit: false` from §2B.1, otherwise UI silently fails
+- `required_pull_request_reviews: null` — single-user
+- `allow_force_pushes: false` + `allow_deletions: false` — prevent main from being clobbered
+
+### 2B.3 Issue templates
+Create `.github/ISSUE_TEMPLATE/{bug.md,feature.md,security.md}` with standard fields.
+
+### 2B.4 deploy.sh hardening
+deploy.sh currently does `git push origin main` directly (line 21). Linear-history protection will reject non-fast-forward pushes. Two options, **pick exactly one**:
+
+**Chosen: prepend `git pull --rebase origin main` before push** in deploy.sh. Rationale: PR #93 already proposes deploy.sh hardening; this addition rides into #93's scope. If #93 is closed/redirected during cascade, this fix lands as part of Track 2B's config PR instead.
+
+Verify post-Track-2B with a trial deploy.
+
+### 2B.5 ~~CODEOWNERS~~ → DROPPED
+Without `require_code_owner_reviews: true`, CODEOWNERS is decorative (silent-failure M6). Single-user repo — drop. Revisit if multi-contributor.
+
+---
+
+## Track 3 — Final automations (after Track 1 done)
+
+### 3.1 Auto-prune worktree on merge hook
+`.claude/hooks/auto-prune-worktree.sh` triggered PostToolUse on Bash matching `gh pr merge.*` or `git merge.*` on a feature branch:
+- Parse merged branch from output
+- If `.claude/worktrees/<slug>` exists where slug derives from branch → `git worktree remove`
+- Idempotent (no-op if already removed)
+
+### 3.2 Schedule existing `claude-md-improver`
+Use `claude-md-management:claude-md-improver` skill (already exists). Schedule via `/loop` or `/schedule` skill on a weekly cadence. **No custom subagent** — upstream covers it (architecture critique caught the duplicate).
+
+### 3.3 ~~/worktree-switch skill~~ → SUBSUMED
+Pruning was the real pain (7 orphans found). Navigation/copy-uncommitted is niche. Build only if proven needed post-Track-1.
+
+### 3.4 ~~claude-md-auditor subagent~~ → DROPPED
+Duplicate of upstream `claude-md-improver`. Use 3.2 instead.
+
+---
+
+## Failure modes & recovery
+
+| Failure | Detection | Recovery |
+|---|---|---|
+| Cascade rebase introduces new conflict | `/cascade` halts on `git rebase` non-zero exit | Resolve in worktree → push → `/cascade` resumes from `state/cascade.json` |
+| Cascade PR's CI fails on its own merits (not main-RED inheritance) | CI report shows failures unrelated to alembic/main-state | Investigate; fix in PR or close with rationale |
+| `/cascade` dies mid-flight | State file shows incomplete | Idempotent restart from last green merge |
+| Branch protection blocks deploy.sh push | First post-Track-2B deploy fails | §2B.4's `git pull --rebase` lands BEFORE protection (build-order rule) |
+| Pre-rebase comment loss (H7) | New SHAs hide outdated comments | `/cascade` snapshots unresolved comments and re-posts after rebase |
+| Stacked PR merge wrong order (silent-failure H2) | #108 merges before #109 → #109 orphaned | `/cascade` enforces leaf-first; 1.2 is hand-executed in spec order |
+| `git worktree remove` fails because branch checked out | Non-zero exit | Halt; commit/stash work; retry |
+| `gh repo edit --delete-branch-on-merge` fires while open stacked PR exists | Dependent PR auto-retargets to main with confused diff | Track 2B is gated on Track 1 done — by that point no stacked PRs exist |
+
+---
+
+## Success criteria — verifiable commands
+
+```bash
+# 1. Zero open PRs
+gh pr list --state open --limit 1 --json number | jq 'length == 0'
+
+# 2. Zero orphan worktree dirs
+[ -z "$(comm -23 <(ls .claude/worktrees/ 2>/dev/null | sort) <(git worktree list --porcelain | awk '/^worktree/ {print $2}' | sed 's|.*/||' | sort))" ]
+
+# 3. main CI green
+gh run list --branch main --limit 2 --json conclusion --jq 'all(.[]; .conclusion == "success")'
+
+# 4. Branch protection correctly applied
+gh api repos/TRIOSCS/Avail-AI-Test/branches/main/protection \
+  --jq '.required_status_checks.contexts == ["test","security"]
+        and .required_status_checks.strict == false
+        and .required_linear_history.enabled == true
+        and .enforce_admins.enabled == false'
+
+# 5. Repo merge settings
+gh repo view TRIOSCS/Avail-AI-Test \
+  --json mergeCommitAllowed,squashMergeAllowed,deleteBranchOnMerge \
+  --jq '.mergeCommitAllowed == false and .squashMergeAllowed == true and .deleteBranchOnMerge == true'
+
+# 6. Templates + labels exist
+test -f .github/PULL_REQUEST_TEMPLATE.md \
+  && test -f .github/ISSUE_TEMPLATE/bug.md \
+  && gh label list --json name --jq 'map(.name) | contains(["type:bug","priority:p0","scope:ci"])'
+
+# 7. Skills exist locally
+test -d .claude/skills/cascade \
+  && test -d .claude/skills/recommit \
+  && test -d .claude/skills/smoke-gate \
+  && test -d .claude/skills/worktree-prune
+
+# 8. main-is-RED hook installed (either inline in settings.local.json OR as a script)
+grep -q "main is currently RED" .claude/settings.local.json \
+  || test -x .claude/hooks/main-is-red-warn.sh
+
+# 9. CLAUDE.md drift fixed (spot-checks)
+grep -q "claude-sonnet-4-6" CLAUDE.md \
+  && grep -q "AVAIL_OPP_TABLE_V2" CLAUDE.md \
+  && ! grep -q "MICROSOFT_GRAPH_ENDPOINT" CLAUDE.md
+
+# 10. deploy.sh works under protection — VERIFY MANUALLY (trial deploy)
+```
+
+A track is "done" only when its block of these checks pass.
+
+---
+
+## Anti-scope
+
+The following items came up in research and are **deliberately excluded**:
+
+- **mypy 2080 errors / 144 files**: pre-existing tech debt; would be a multi-week initiative on its own
+- **ESLint 9 problems**: same
+- **`test_sprint8_proactive::test_badge_with_matches` failure**: unrelated, single test, separate fix
+- **Renaming workflow `name:` from `CI — Tests` to ASCII**: not load-bearing once we use job names for protection (em-dash trap noted in §11)
+- **Multi-contributor enforcement** (signed commits, required reviews, CODEOWNERS w/ enforcement): single-user staging
+- **`/root/availai-health-fix` directory**: separate clone, not a worktree, branch is `[origin/main: behind 4]`. Likely abandoned but not provably so. Operator decides; this design does not delete it.
+- **Auto-merge for dependabot PRs**: post-Track-2B nice-to-have, not in scope
+- **Renaming branch convention**: 9 worktrees use various prefixes (fix/, chore/, docs/, feat/); not standardizing in this pass
+
+---
+
+## §11 — Bugs the parallel review caught in the original draft
+
+This section preserves the silent-failure findings so writing-plans (and future sessions) understand WHY the design looks the way it does.
+
+| ID | Severity | Bug | Fix in this design |
+|---|---|---|---|
+| C1 / M5 | P0 | `strict: true` + 11-PR cascade = 2hr deadlock | §2B uses `strict: false` |
+| C3 | P0 | Required `Security Scanning` would block every PR (pre-existing pip/npm audit failures) | Drop as required; informational only via workflow |
+| C5 | P0 | Dependabot github-actions ecosystem already exists; "add" would duplicate-key parse-fail | §2A.4 removed |
+| C2 | P1 | `deleteBranchOnMerge` before worktree cleanup = destructive interaction | §2B.1 (was Track 2A) |
+| C4 / H5 | P1 | Auto-restage hook bypasses `git add -p` user intent | Replaced by §0.2 `/recommit` skill |
+| C6 | P1 | deploy.sh `git push origin main` blocked by linear-history protection | §2B.4 prepends `git pull --rebase` |
+| C7 | P2 | Full agent review for dependabot #100 is overkill | §1.3 fast-tracks #100 |
+| C8 / H6 | P1 | Force-push whitelist by path is band-aid | §0.6 ref-name based matching |
+| H1 | P0 | Cascade reviews dispatched AFTER merge → tombstone | §1.3 reorders: review → fix → CI green → merge |
+| H2 | P0 | `deleteBranchOnMerge` orphans stacked #108/#109 | §1.2 resolves stack BEFORE §2B fires |
+| H3 | P0 | Workflow `pull_request: branches: [main]` doesn't fire on stacked PRs | Already fixed in PR #109's branch; lands with #108 merge |
+| H4 | P1 | `git branch -D` after squash silently drops un-squashed commits | §1.4 explicit `git cherry` check before `-D`; remote branches deleted via `gh api` (deleteBranchOnMerge isn't on during cascade) |
+| H7 | P1 | Rebase silently buries unresolved review comments | §0.1 `/cascade` snapshots before rebase |
+| P0 (protection) | P0 | Required checks `CI — Tests` / `Security Scanning` are workflow names, not check-run names — would silently never match | §2B.2 uses `test` + `security` (job names) |
+
+---
+
+## §12 — Open operator decisions (informational, not blocking)
+
+These are flagged for operator awareness; the design does not decide them:
+
+- **`/root/availai-health-fix`**: separate clone with branch `[origin/main: behind 4]`. Probably stale; operator decides delete vs. keep.
+- **PR #103 vs. CLAUDE.md fix-now mini-PR**: #103 (docs/claude-md-rebuild) may incorporate or supersede the §8.1 mini-PR. Operator chooses: ship mini-PR first then rebase #103 on top, OR ship #103 first and skip mini-PR if it covers the 7 fix-now items.
+- **PR #93 vs. §2B.4 deploy.sh edit**: prefer riding the fix into #93's existing scope; if #93 closes for any reason, the fix lands in Track 2B's config PR.
+
+---
+
+## §13 — CLAUDE.md fix-now mini-PR scope
+
+(Referenced from Track 1.2.) Scope = 3 fix-now + 4 NEW drift items, all edits to `/root/availai/CLAUDE.md` only:
+
+1. Line 440: pre-commit hook list update (`ruff, ruff-format, mypy, docformatter, detect-private-key, check-yaml, check-added-large-files, check-merge-conflict, end-of-file-fixer, trailing-whitespace; pre-push hook runs full --all-files sweep automatically`)
+2. Line 640: `ANTHROPIC_MODEL=claude-3-5-sonnet-20241022` → `ANTHROPIC_MODEL=claude-sonnet-4-6` (matches `app/config.py`)
+3. Configuration block (lines 627–668):
+   - REMOVE phantom keys: `MICROSOFT_GRAPH_ENDPOINT`, `SMTP_FROM`, `ACTIVITY_TRACKING_ENABLED`, `CONTACTS_SYNC_ENABLED`
+   - REPLACE `AZURE_REDIRECT_URI` with `APP_URL`
+   - ADD: `AVAIL_OPP_TABLE_V2`, `ENCRYPTION_SALT`, `EXPLORIUM_API_KEY`
+   - ADD one-line pointer to `.env.example` for long-tail keys (`EIGHT_BY_EIGHT_*`, `NC_*`, `BACKUP_*`, `DO_SPACES_*`)
+4. Worktree CLAUDE.md drift in 6 worktree copies + `/root/availai-health-fix/CLAUDE.md`: handled by deleting the worktrees in §1.4, not by editing each copy
+5. Separate `.env.example:9` fix to `claude-sonnet-4-6` is a one-liner that can ride this PR
+
+---
+
+## §14 — Implementation handoff
+
+This design is the input to `superpowers:writing-plans`. The plan should generate task lists for Tracks 0, 1, 2A, 2B, 3 in build order, with explicit reference to this spec's §-numbered subsections.
+
+Track 0 tasks should produce concrete `.claude/skills/<name>/SKILL.md` and `.claude/hooks/<name>.sh` files. Track 1 tasks reference `/cascade`, `/recommit`, `/smoke-gate`, `/worktree-prune` invocations. Track 2A tasks each open small PRs. Track 2B is one configuration PR + the trial-deploy verification. Track 3 tasks update `.claude/settings.local.json` and add `.claude/hooks/auto-prune-worktree.sh`.
+
+Acceptance for "design fully implemented" = all 10 success-criteria checks in §10 pass.


### PR DESCRIPTION
## Summary

Adds the umbrella design spec for the GitHub cleanup & optimization initiative. Single docs file at `docs/superpowers/specs/2026-05-08-github-cleanup-design.md`. No code changes.

The spec covers 4 tracks of cleanup work — PR backlog drain, branch+worktree cleanup, CI/workflow + automation hardening, repo policy + metadata + issues — sequenced to avoid the deadlocks and silent failures that an original draft would have hit.

## What's in the spec

- **§3** — Architecture: 4 tracks with build-order dependency graph
- **§4–§7** — Per-track detail (Track 0 tooling, Track 1 critical path, Track 2A/2B policy, Track 3 final automations)
- **§8** — Failure modes & recovery
- **§10** — Verifiable success criteria (each one a runnable command)
- **§11** — Bugs the parallel review caught in the original draft (silent-failure record)
- **§12** — Open operator decisions
- **§13** — CLAUDE.md fix-now mini-PR scope (3 fix-now + 4 NEW drift items)

## Key design decisions captured

- Required check contexts use **job names** (`test`, `security`), NOT workflow names (`CI — Tests`, `Security Scanning`) — workflow names would silently never match
- `strict: false` on branch protection — `strict: true` would deadlock the 11-PR cascade at ~2hr sequential CI cycles
- `deleteBranchOnMerge` lands AFTER stack resolution + worktree consolidation, not before (otherwise orphans #108→#109 and worktrees)
- Auto-restage hook → replaced with explicit `/recommit` skill (auto-restage silently scoops `git add -p` partial-stage hunks)
- Force-push guard uses target-ref matching (`\b(main|master)\b`) not path whitelisting (band-aid)
- CODEOWNERS dropped (decorative without `require_code_owner_reviews`)
- Dependabot github-actions ecosystem already exists — removed from scope

## Test plan

- [x] Spec self-review (placeholder scan, internal consistency, ambiguity check) — 4 issues found and fixed inline
- [x] Parallel review pass (6 agents: cascade-pool audit, architecture critique, silent-failure hunter, branch-protection risk-check, CLAUDE.md drift recheck, automation recommender refresh) — findings folded into the design
- [ ] Operator review of spec contents

## Risk & rollback

Docs-only. No production impact. Revert by closing the PR.

## Linked issues

N/A — spec drives subsequent work that will close #83, #84 and others as it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)