### PR TITLE
test: nightly coverage improvement — 5 modules to 100%

### DIFF
--- a/tests/test_material_enrichment_service_coverage.py
+++ b/tests/test_material_enrichment_service_coverage.py
@@ -503,3 +503,169 @@ async def test_process_batch_handles_empty_parts_list(db):
         stats = await process_material_batch_results(db)
 
     assert stats["errors"] >= 1
+
+
+# ── Missing line coverage ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enrich_batch_wrong_part_count_skips_batch(db):
+    """Lines 153-155: AI returns wrong number of parts → batch skipped, errors incremented."""
+    from app.services.material_enrichment_service import _enrich_batch
+
+    c1 = _make_card(db, "PARTA")
+    c2 = _make_card(db, "PARTB")
+    stats = {"enriched": 0, "skipped": 0, "errors": 0}
+
+    # Return 3 parts for 2 cards — count mismatch triggers the skip path
+    mock_result = {
+        "parts": [
+            {"mpn": "PARTA", "description": "Part A", "category": "other", "lifecycle_status": "active"},
+            {"mpn": "PARTB", "description": "Part B", "category": "other", "lifecycle_status": "active"},
+            {"mpn": "PARTC", "description": "Extra", "category": "other", "lifecycle_status": "active"},
+        ]
+    }
+
+    with patch(
+        "app.utils.claude_client.claude_structured",
+        new_callable=AsyncMock,
+        return_value=mock_result,
+    ):
+        await _enrich_batch([c1, c2], db, stats)
+
+    assert stats["enriched"] == 0
+    assert stats["errors"] == 2
+
+
+@pytest.mark.asyncio
+async def test_batch_enrich_empty_batch_queue_returns_none(db):
+    """Line 295: bq.build_batch() returns empty list → return None before calling claude."""
+    from app.services.batch_queue import BatchQueue
+    from app.services.material_enrichment_service import batch_enrich_materials
+
+    _make_card(db, "QUEUED-CARD")
+
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = None
+
+    with (
+        patch("app.services.material_enrichment_service._get_redis", return_value=mock_redis),
+        patch.object(BatchQueue, "build_batch", return_value=[]),
+    ):
+        result = await batch_enrich_materials(db)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_process_batch_card_id_parse_value_error(db):
+    """Lines 360-362: custom_id part after '-' is not an integer → error counted."""
+    from app.services.material_enrichment_service import process_material_batch_results
+
+    batch_results = {
+        "mat_enrich-xyz": {
+            "parts": [{"mpn": "X", "description": "x", "category": "other", "lifecycle_status": "active"}]
+        }
+    }
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = b"batch-valueerr"
+    with (
+        patch("app.services.material_enrichment_service._get_redis", return_value=mock_redis),
+        patch(
+            "app.services.material_enrichment_service.claude_batch_results",
+            new_callable=AsyncMock,
+            return_value=batch_results,
+        ),
+    ):
+        stats = await process_material_batch_results(db)
+
+    assert stats is not None
+    assert stats["errors"] >= 1
+    assert stats["applied"] == 0
+
+
+@pytest.mark.asyncio
+async def test_process_batch_apply_enrichment_raises_exception(db):
+    """Lines 379-381: _apply_enrichment_result raises → error counted, apply continues."""
+    from app.services.material_enrichment_service import process_material_batch_results
+
+    card = _make_card(db, "RAISE-CARD")
+    batch_results = {
+        f"mat_enrich-{card.id}": {
+            "parts": [
+                {
+                    "mpn": "RAISE-CARD",
+                    "description": "A part",
+                    "category": "other",
+                    "lifecycle_status": "active",
+                }
+            ]
+        }
+    }
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = b"batch-raise"
+    with (
+        patch("app.services.material_enrichment_service._get_redis", return_value=mock_redis),
+        patch(
+            "app.services.material_enrichment_service.claude_batch_results",
+            new_callable=AsyncMock,
+            return_value=batch_results,
+        ),
+        patch(
+            "app.services.material_enrichment_service._apply_enrichment_result",
+            side_effect=RuntimeError("apply failed"),
+        ),
+    ):
+        stats = await process_material_batch_results(db)
+
+    assert stats is not None
+    assert stats["errors"] >= 1
+    assert stats["applied"] == 0
+
+
+@pytest.mark.asyncio
+async def test_process_batch_commit_exception_returns_stats(db):
+    """Lines 385-388: db.commit() raises after processing → stats returned, rollback called."""
+    from app.services.material_enrichment_service import process_material_batch_results
+
+    card = _make_card(db, "COMMIT-FAIL-CARD")
+    batch_results = {
+        f"mat_enrich-{card.id}": {
+            "parts": [
+                {
+                    "mpn": "COMMIT-FAIL-CARD",
+                    "description": "A part",
+                    "category": "other",
+                    "lifecycle_status": "active",
+                }
+            ]
+        }
+    }
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = b"batch-commitfail"
+
+    original_commit = db.commit
+    call_count = [0]
+
+    def bad_commit():
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise Exception("Simulated commit failure")
+        return original_commit()
+
+    db.commit = bad_commit
+    try:
+        with (
+            patch("app.services.material_enrichment_service._get_redis", return_value=mock_redis),
+            patch(
+                "app.services.material_enrichment_service.claude_batch_results",
+                new_callable=AsyncMock,
+                return_value=batch_results,
+            ),
+        ):
+            stats = await process_material_batch_results(db)
+    finally:
+        db.commit = original_commit
+
+    assert stats is not None
+    assert "applied" in stats

--- a/tests/test_proactive_matching.py
+++ b/tests/test_proactive_matching.py
@@ -16,12 +16,16 @@ from app.models import (
     Requisition,
     User,
 )
+from app.models.config import SystemConfig
 from app.models.intelligence import ProactiveDoNotOffer, ProactiveThrottle
 from app.models.purchase_history import CustomerPartHistory
 from app.services.proactive_matching import (
+    _find_matches,
+    _get_watermark,
     _score_frequency,
     _score_margin,
     _score_recency,
+    _set_watermark,
     compute_match_score,
     dismiss_match,
     expire_old_matches,
@@ -989,3 +993,119 @@ class TestScoringBoundaries:
         dt = datetime.now(timezone.utc) - timedelta(days=90)  # recency=100
         score, margin = compute_match_score(dt, 5, 100.0, 70.0)
         assert score == 100  # 100*0.4 + 100*0.3 + 100*0.3 = 100
+
+
+# ── Watermark helper tests ──────────────────────────────────────────────────
+
+
+class TestWatermarkHelpers:
+    """Tests for _get_watermark and _set_watermark (lines 124-138)."""
+
+    def test_get_watermark_naive_timestamp_gets_utc(self, db_session):
+        """Naive ISO timestamp stored in SystemConfig gets UTC tzinfo attached."""
+        naive_iso = "2025-01-15T10:00:00"  # no tzinfo
+        db_session.add(SystemConfig(key="proactive_last_scan", value=naive_iso, description="test"))
+        db_session.commit()
+
+        result = _get_watermark(db_session)
+        assert result.tzinfo is not None
+
+    def test_get_watermark_invalid_value_returns_default(self, db_session):
+        """Corrupt watermark value falls back to default lookback window."""
+        db_session.add(SystemConfig(key="proactive_last_scan", value="not-a-date", description="test"))
+        db_session.commit()
+
+        result = _get_watermark(db_session)
+        assert result.tzinfo is not None
+        assert result < datetime.now(timezone.utc)
+
+    def test_set_watermark_creates_new_row_when_missing(self, db_session):
+        """_set_watermark creates a new SystemConfig row if none exists."""
+        ts = datetime.now(timezone.utc) - timedelta(hours=1)
+        _set_watermark(db_session, ts)
+        db_session.commit()
+
+        row = db_session.query(SystemConfig).filter(SystemConfig.key == "proactive_last_scan").first()
+        assert row is not None
+        assert ts.isoformat() in row.value
+
+
+# ── _find_matches with source_offer=None ──────────────────────────────────
+
+
+class TestFindMatchesSourceOfferNone:
+    """Tests for _find_matches when source_offer is None (lines 214-224)."""
+
+    def test_find_matches_no_source_offer_uses_fallback(self, db_session):
+        """_find_matches with source_offer=None queries fallback offer from DB."""
+        data = _setup_scenario(db_session)
+
+        offer = Offer(
+            requisition_id=data["requisition"].id,
+            requirement_id=data["requirement"].id,
+            material_card_id=data["card"].id,
+            vendor_name="Arrow",
+            mpn="STM32F407",
+            unit_price=Decimal("8.00"),
+            status="active",
+        )
+        db_session.add(offer)
+        db_session.commit()
+
+        matches = _find_matches(
+            db_session,
+            material_card_id=data["card"].id,
+            mpn="STM32F407",
+            our_cost=8.0,
+            source_offer=None,
+        )
+        assert isinstance(matches, list)
+
+    def test_find_matches_no_source_offer_no_fallback_returns_empty(self, db_session):
+        """_find_matches with source_offer=None and no existing offer returns []."""
+        data = _setup_scenario(db_session)
+
+        matches = _find_matches(
+            db_session,
+            material_card_id=data["card"].id,
+            mpn="STM32F407",
+            our_cost=8.0,
+            source_offer=None,
+        )
+        assert matches == []
+
+
+# ── run_proactive_scan cap warning ─────────────────────────────────────────
+
+
+class TestProactiveScanCapWarning:
+    """Test the 5000-offer cap warning in run_proactive_scan (line 336)."""
+
+    def test_scan_logs_warning_at_5000_cap(self, db_session):
+        """run_proactive_scan warns when 5000 offers are returned (cap hit)."""
+        import unittest.mock as um
+
+        fake_offers = [
+            um.MagicMock(material_card_id=i, id=i, created_at=datetime.now(timezone.utc)) for i in range(5000)
+        ]
+
+        mock_chain = um.MagicMock()
+        mock_chain.filter.return_value = mock_chain
+        mock_chain.order_by.return_value = mock_chain
+        mock_chain.limit.return_value = mock_chain
+        mock_chain.all.return_value = fake_offers
+
+        with (
+            patch(
+                "app.services.proactive_matching._get_watermark",
+                return_value=datetime.now(timezone.utc) - timedelta(hours=1),
+            ),
+            patch("app.services.proactive_matching._set_watermark"),
+            patch("app.services.proactive_matching.find_matches_for_offer", return_value=[]),
+            patch("app.services.proactive_matching.logger") as mock_logger,
+        ):
+            with patch.object(db_session, "query", return_value=mock_chain):
+                run_proactive_scan(db_session)
+
+        mock_logger.warning.assert_called_once()
+        assert "5000" in mock_logger.warning.call_args[0][0]

--- a/tests/test_services_coverage_2.py
+++ b/tests/test_services_coverage_2.py
@@ -24,6 +24,7 @@ import asyncio
 from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models import (
@@ -854,6 +855,138 @@ class TestStrategicVendorService:
 
         vendors2, total2 = get_open_pool(db_session, search="NONEXISTENT_XYZZY")
         assert total2 == 0
+
+    # ── New tests for uncovered lines ─────────────────────────────────
+
+    def test_claim_vendor_already_claimed_by_different_user(
+        self, db_session: Session, test_user: User, test_vendor_card: VendorCard
+    ):
+        """Line 96: another buyer already owns the vendor → returns 'claimed by another buyer'."""
+        from app.services.strategic_vendor_service import claim_vendor
+
+        # user1 claims the vendor
+        record, err = claim_vendor(db_session, test_user.id, test_vendor_card.id)
+        assert err is None
+        assert record is not None
+
+        # Create a second user
+        second_user = User(
+            email="buyer2@trioscs.com",
+            name="Buyer Two",
+            role="buyer",
+            azure_id="test-azure-id-svs-002",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(second_user)
+        db_session.flush()
+
+        # Second user tries to claim the same vendor
+        record2, err2 = claim_vendor(db_session, second_user.id, test_vendor_card.id)
+        assert record2 is None
+        assert err2 is not None
+        assert "another buyer" in err2.lower()
+
+    def test_claim_vendor_integrity_error_on_commit(
+        self, db_session: Session, test_user: User, test_vendor_card: VendorCard
+    ):
+        """Lines 117-119: IntegrityError during commit → rollback, return error message."""
+        from sqlalchemy.exc import IntegrityError
+
+        from app.services.strategic_vendor_service import claim_vendor
+
+        original_commit = db_session.commit
+        call_count = [0]
+
+        def _fail_commit():
+            call_count[0] += 1
+            # Raise on the first commit inside claim_vendor
+            if call_count[0] == 1:
+                raise IntegrityError("UNIQUE constraint failed", params={}, orig=Exception("unique"))
+            return original_commit()
+
+        db_session.commit = _fail_commit
+        try:
+            record, err = claim_vendor(db_session, test_user.id, test_vendor_card.id)
+        finally:
+            db_session.commit = original_commit
+
+        assert record is None
+        assert err is not None
+        assert "just claimed" in err.lower()
+
+    def test_replace_vendor_drop_fails(self, db_session: Session, test_user: User):
+        """Lines 170-171: drop_vendor fails inside replace_vendor → rollback, return error."""
+        from app.services.strategic_vendor_service import replace_vendor
+
+        vc1 = VendorCard(
+            normalized_name="replace_fail_a",
+            display_name="Replace Fail A",
+            sighting_count=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        vc2 = VendorCard(
+            normalized_name="replace_fail_b",
+            display_name="Replace Fail B",
+            sighting_count=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([vc1, vc2])
+        db_session.flush()
+
+        # vc1 is NOT claimed — so drop_vendor will return (False, error)
+        record, err = replace_vendor(db_session, test_user.id, vc1.id, vc2.id)
+        assert record is None
+        assert err is not None
+        assert "not in your" in err.lower()
+
+    def test_replace_vendor_claim_fails(self, db_session: Session, test_user: User):
+        """Lines 175-176: claim_vendor returns no record inside replace_vendor → rollback, return error."""
+        from app.services.strategic_vendor_service import claim_vendor, replace_vendor
+
+        vc1 = VendorCard(
+            normalized_name="replace_claim_fail_a",
+            display_name="Replace Claim Fail A",
+            sighting_count=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        # vc2 does not exist — claim will fail with "not found"
+        db_session.add(vc1)
+        db_session.flush()
+        claim_vendor(db_session, test_user.id, vc1.id)
+
+        record, err = replace_vendor(db_session, test_user.id, vc1.id, 99999)
+        assert record is None
+        assert err is not None
+
+    def test_replace_vendor_exception_reraises(self, db_session: Session, test_user: User):
+        """Lines 179-181: exception inside replace_vendor transaction → rollback then re-raise."""
+        from unittest.mock import patch
+
+        from app.services.strategic_vendor_service import claim_vendor, replace_vendor
+
+        vc1 = VendorCard(
+            normalized_name="replace_exc_a",
+            display_name="Replace Exc A",
+            sighting_count=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        vc2 = VendorCard(
+            normalized_name="replace_exc_b",
+            display_name="Replace Exc B",
+            sighting_count=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([vc1, vc2])
+        db_session.flush()
+        claim_vendor(db_session, test_user.id, vc1.id)
+
+        # Patch claim_vendor inside the service module to raise after drop succeeds
+        with patch(
+            "app.services.strategic_vendor_service.claim_vendor",
+            side_effect=RuntimeError("unexpected failure"),
+        ):
+            with pytest.raises(RuntimeError, match="unexpected failure"):
+                replace_vendor(db_session, test_user.id, vc1.id, vc2.id)
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_services_engagement.py
+++ b/tests/test_services_engagement.py
@@ -624,3 +624,170 @@ class TestComputeAllEngagementErrorPaths:
 
         result = await compute_all_engagement_scores(db_session)
         assert result["updated"] == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  New coverage tests for missing lines
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestEngagementScorerMissingLines:
+    """Tests targeting specific uncovered lines in engagement_scorer.py."""
+
+    # ── Line 65: now=None default path ───────────────────────────────
+
+    def test_compute_engagement_score_uses_utc_when_now_none(self):
+        """Line 65: when now=None (default), datetime.now(timezone.utc) is called."""
+        # Omit the now= kwarg entirely — exercises the 'if now is None: now = ...' branch
+        result = compute_engagement_score(0, 0, 0, None, None)
+        # Cold start path still returns COLD_START_SCORE regardless
+        assert result["engagement_score"] == 50
+
+    # ── Lines 180-181: domain_aliases loop in compute_all_engagement_scores ──
+
+    @pytest.mark.asyncio
+    async def test_domain_aliases_included_in_response_map(self, db_session):
+        """Lines 180-181: domain_aliases on VendorCard are also added to domain_to_norm map."""
+        card = _make_vendor_card(
+            db_session,
+            "aliased vendor",
+            "Aliased Vendor",
+            domain="aliased.com",
+            domain_aliases=["alt.aliased.com", "alias2.com"],
+        )
+        db_session.commit()
+
+        # Send a response from the alias domain
+        _make_vendor_response(db_session, "Rep", "rep@alt.aliased.com")
+        db_session.commit()
+
+        result = await compute_all_engagement_scores(db_session)
+        assert result["updated"] >= 1
+        db_session.refresh(card)
+        # Response via alias domain should be matched
+        assert card.total_responses >= 1
+
+    # ── Line 199: email with no '@' in it → continue ─────────────────
+
+    @pytest.mark.asyncio
+    async def test_invalid_email_without_at_sign_skipped(self, db_session):
+        """Line 199: VendorResponse with vendor_email lacking '@' → skipped in response_map."""
+        from app.models import VendorResponse
+
+        # Add a response with an invalid email (no '@')
+        bad_resp = VendorResponse(
+            vendor_name="NoAt Vendor",
+            vendor_email="invalidemail",  # no @ → line 199 continue
+            received_at=datetime.now(timezone.utc),
+            status="new",
+        )
+        db_session.add(bad_resp)
+
+        _make_vendor_card(db_session, "noat vendor", "NoAt Vendor", domain="noat.com")
+        db_session.commit()
+
+        # Should not crash; the invalid email is simply ignored
+        result = await compute_all_engagement_scores(db_session)
+        assert "updated" in result
+
+    # ── Line 204: fallback norm via normalize_vendor_name when domain not found ──
+
+    @pytest.mark.asyncio
+    async def test_response_domain_fallback_normalization(self, db_session):
+        """Line 204: when email domain not in domain_to_norm, fallback normalize is used."""
+        from app.models import VendorResponse
+
+        # Card has NO domain set — so its domain won't be in domain_to_norm
+        _make_vendor_card(db_session, "fallback vendor", "Fallback Vendor", domain=None)
+
+        # Response from a domain not in domain_to_norm → fallback normalize_vendor_name("fallback")
+        resp = VendorResponse(
+            vendor_name="someone",
+            vendor_email="someone@fallback.com",  # domain "fallback.com" not in map
+            received_at=datetime.now(timezone.utc),
+            status="new",
+        )
+        db_session.add(resp)
+        db_session.commit()
+
+        result = await compute_all_engagement_scores(db_session)
+        assert "updated" in result
+
+    # ── Lines 257-258: win_map building (Offer with status=WON) ──────
+
+    @pytest.mark.asyncio
+    async def test_won_offers_counted_in_win_map(self, db_session, test_user):
+        """Lines 257-258: Offer with status='won' increments win_map for the vendor."""
+        from app.constants import OfferStatus
+        from app.models import Offer
+
+        card = _make_vendor_card(db_session, "winning vendor", "Winning Vendor", domain="winner.com")
+        req = _make_requisition(db_session, test_user.id)
+        # Outreach so score is computed beyond cold start
+        for _ in range(3):
+            _make_contact(db_session, req.id, test_user.id, "Winning Vendor")
+
+        # Create a won offer for this vendor
+        offer = Offer(
+            requisition_id=req.id,
+            vendor_name="Winning Vendor",
+            vendor_name_normalized="winning vendor",
+            mpn="LM317T",
+            status=OfferStatus.WON,
+        )
+        db_session.add(offer)
+        db_session.commit()
+
+        result = await compute_all_engagement_scores(db_session)
+        assert result["updated"] >= 1
+        db_session.refresh(card)
+        # Win count should be at least 1
+        assert card.total_wins >= 1
+
+    # ── Lines 307-308: db.flush() exception in batch loop ─────────────
+
+    @pytest.mark.asyncio
+    async def test_flush_exception_in_batch_loop_is_logged(self, db_session, monkeypatch):
+        """Lines 307-308: db.flush() raises in the batch update loop → error is logged, no crash."""
+        _make_vendor_card(db_session, "flushfail vendor", "FlushFail Vendor", domain="flushfail.com")
+        db_session.commit()
+
+        original_flush = db_session.flush
+        call_count = [0]
+
+        def bad_flush(*args, **kwargs):
+            call_count[0] += 1
+            # Fail on the first batch flush call (inside the BATCH_SIZE loop)
+            if call_count[0] == 1:
+                raise RuntimeError("Simulated flush failure in batch loop")
+            return original_flush(*args, **kwargs)
+
+        monkeypatch.setattr(db_session, "flush", bad_flush)
+        # Should not raise — the exception is caught and logged
+        result = await compute_all_engagement_scores(db_session)
+        assert "updated" in result
+
+    # ── Lines 406-408: db.flush() exception in apply_outbound_stats ───
+
+    def test_apply_outbound_stats_flush_exception_rollback(self, db_session):
+        """Lines 406-408: flush() exception in apply_outbound_stats → rollback, no crash."""
+        card = _make_vendor_card(db_session, "rollback vendor", "Rollback Vendor", domain="rollback.com")
+        card.total_outreach = 0
+        db_session.commit()
+
+        original_flush = db_session.flush
+        call_count = [0]
+
+        def bad_flush(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] >= 1:
+                raise RuntimeError("Simulated flush failure")
+            return original_flush(*args, **kwargs)
+
+        db_session.flush = bad_flush
+        try:
+            # Should not raise — the exception is caught, rollback called
+            updated = apply_outbound_stats(db_session, {"rollback.com": 5})
+            assert isinstance(updated, int)
+        finally:
+            db_session.flush = original_flush

--- a/tests/test_tagging_ai_batch.py
+++ b/tests/test_tagging_ai_batch.py
@@ -10,6 +10,7 @@ import tempfile
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models.intelligence import MaterialCard
@@ -645,3 +646,350 @@ class TestApplyBatchResultsChunked:
         assert result["total_lines"] == 2
         assert result["errors"] == 2
         assert result["matched"] == 0
+
+    @patch("app.database.SessionLocal")
+    @patch("app.http_client.http")
+    @patch("app.services.credential_service.get_credential_cached", return_value="sk-test-key")
+    def test_blank_lines_skipped(self, mock_cred, mock_http, mock_session_local, db_session: Session):
+        """Line 481: blank lines in JSONL are silently skipped (not counted as errors)."""
+        mock_session_local.return_value = db_session
+
+        valid_line = json.dumps(
+            {
+                "custom_id": "backfill_0",
+                "result": {
+                    "type": "succeeded",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "structured_output",
+                                "input": {"classifications": []},
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
+        # blank lines around valid line — only the valid line counts as total_lines
+        tmp.write("\n")
+        tmp.write("   \n")
+        tmp.write(valid_line + "\n")
+        tmp.write("\n")
+        tmp.close()
+        tmp_path = tmp.name
+
+        status_resp = MagicMock()
+        status_resp.status_code = 200
+        status_resp.json.return_value = {
+            "processing_status": "ended",
+            "results_url": "https://api.anthropic.com/results/batch_blank",
+        }
+        mock_http.get = AsyncMock(return_value=status_resp)
+        mock_http.stream = _make_fake_stream(tmp_path)
+
+        try:
+            result = _run(apply_batch_results_chunked("batch_blank"))
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+        # Only the non-blank line is counted
+        assert result["total_lines"] == 1
+        assert result["errors"] == 0
+
+    @patch("app.database.SessionLocal")
+    @patch("app.http_client.http")
+    @patch("app.services.credential_service.get_credential_cached", return_value="sk-test-key")
+    def test_classifications_as_list_used_directly(self, mock_cred, mock_http, mock_session_local, db_session: Session):
+        """Line 507: when classifications is a list subclass (with .get() returning []),
+        isinstance check triggers and items = classifications is used instead."""
+        _make_card(db_session, "xyz001", manufacturer=None)
+        db_session.commit()
+        mock_session_local.return_value = db_session
+
+        # Build a list subclass that has a .get() method — satisfies both
+        # classifications.get("classifications", []) (returns []) AND isinstance(classifications, list).
+        class _ListWithGet(list):
+            def get(self, key, default=None):
+                return default  # returns [] for get("classifications", [])
+
+        classification_item = {"mpn": "XYZ001", "manufacturer": "Acme Corp", "category": "Logic ICs"}
+        list_classifications = _ListWithGet([classification_item])
+
+        # Patch json.loads so entry["result"]["message"]["content"][0]["input"] is list_classifications
+        import json as _json
+
+        _original_loads = _json.loads
+
+        def _patched_loads(s, **kw):
+            data = _original_loads(s, **kw)
+            try:
+                data["result"]["message"]["content"][0]["input"] = list_classifications
+            except (KeyError, IndexError, TypeError):
+                pass
+            return data
+
+        result_line = json.dumps(
+            {
+                "custom_id": "backfill_0",
+                "result": {
+                    "type": "succeeded",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "structured_output",
+                                "input": {"classifications": []},
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
+        tmp.write(result_line + "\n")
+        tmp.close()
+        tmp_path = tmp.name
+
+        status_resp = MagicMock()
+        status_resp.status_code = 200
+        status_resp.json.return_value = {
+            "processing_status": "ended",
+            "results_url": "https://api.anthropic.com/results/batch_list",
+        }
+        mock_http.get = AsyncMock(return_value=status_resp)
+        mock_http.stream = _make_fake_stream(tmp_path)
+
+        with patch("json.loads", side_effect=_patched_loads):
+            try:
+                result = _run(apply_batch_results_chunked("batch_list"))
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+        # The list path was exercised; 1 line processed with 1 item matched
+        assert result["total_lines"] == 1
+
+    @patch("app.database.SessionLocal")
+    @patch("app.http_client.http")
+    @patch("app.services.credential_service.get_credential_cached", return_value="sk-test-key")
+    def test_batch_flush_triggered_at_100_items(self, mock_cred, mock_http, mock_session_local, db_session: Session):
+        """Lines 516-520: when batch_classifications reaches 100, _apply_chunked_batch is called."""
+        # Create 101 cards so we can generate 101 valid classification lines
+        for i in range(101):
+            _make_card(db_session, f"mpn{i:04d}", manufacturer=None)
+        db_session.commit()
+        mock_session_local.return_value = db_session
+
+        lines = []
+        for i in range(101):
+            lines.append(
+                json.dumps(
+                    {
+                        "custom_id": f"backfill_{i}",
+                        "result": {
+                            "type": "succeeded",
+                            "message": {
+                                "content": [
+                                    {
+                                        "type": "tool_use",
+                                        "name": "structured_output",
+                                        "input": {
+                                            "classifications": [
+                                                {
+                                                    "mpn": f"MPN{i:04d}",
+                                                    "manufacturer": "TestCorp",
+                                                    "category": "Logic ICs",
+                                                }
+                                            ]
+                                        },
+                                    }
+                                ]
+                            },
+                        },
+                    }
+                )
+            )
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
+        tmp.write("\n".join(lines) + "\n")
+        tmp.close()
+        tmp_path = tmp.name
+
+        status_resp = MagicMock()
+        status_resp.status_code = 200
+        status_resp.json.return_value = {
+            "processing_status": "ended",
+            "results_url": "https://api.anthropic.com/results/batch_100",
+        }
+        mock_http.get = AsyncMock(return_value=status_resp)
+        mock_http.stream = _make_fake_stream(tmp_path)
+
+        try:
+            result = _run(apply_batch_results_chunked("batch_100"))
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+        # All 101 lines processed; the >=100 flush path was exercised
+        assert result["total_lines"] == 101
+
+    @patch("app.database.SessionLocal")
+    @patch("app.http_client.http")
+    @patch("app.services.credential_service.get_credential_cached", return_value="sk-test-key")
+    def test_progress_log_at_500_lines(self, mock_cred, mock_http, mock_session_local, db_session: Session):
+        """Line 523: progress logging fires when total_lines % 500 == 0.
+
+        Requires 500 lines that reach line 522 (i.e. type=succeeded with valid classifications).
+        Each such line increments total_lines; at total_lines==500 the log fires.
+        """
+        mock_session_local.return_value = db_session
+
+        # Each line must be type=succeeded with a valid tool_use block so it reaches line 522.
+        # Empty classifications list is fine — it won't match any cards (no DB cards needed).
+        succeeded_line = {
+            "result": {
+                "type": "succeeded",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "structured_output",
+                            "input": {"classifications": []},
+                        }
+                    ]
+                },
+            }
+        }
+        lines = []
+        for i in range(500):
+            entry = dict(succeeded_line)
+            entry["custom_id"] = f"backfill_{i}"
+            lines.append(json.dumps(entry))
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
+        tmp.write("\n".join(lines) + "\n")
+        tmp.close()
+        tmp_path = tmp.name
+
+        status_resp = MagicMock()
+        status_resp.status_code = 200
+        status_resp.json.return_value = {
+            "processing_status": "ended",
+            "results_url": "https://api.anthropic.com/results/batch_500",
+        }
+        mock_http.get = AsyncMock(return_value=status_resp)
+        mock_http.stream = _make_fake_stream(tmp_path)
+
+        try:
+            result = _run(apply_batch_results_chunked("batch_500"))
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+        # 500 lines processed; the % 500 == 0 progress log was triggered at line 523
+        assert result["total_lines"] == 500
+
+    @patch("app.services.tagging_ai_batch._apply_chunked_batch")
+    @patch("app.database.SessionLocal")
+    @patch("app.http_client.http")
+    @patch("app.services.credential_service.get_credential_cached", return_value="sk-test-key")
+    def test_outer_exception_handler_reraises(self, mock_cred, mock_http, mock_session_local, mock_apply_chunked):
+        """Lines 535-538: exception inside the processing loop → logged, rollback, re-raise."""
+        mock_session_local.return_value = MagicMock()
+
+        # Make _apply_chunked_batch raise to trigger the outer exception handler
+        mock_apply_chunked.side_effect = RuntimeError("unexpected error in apply")
+
+        result_line = json.dumps(
+            {
+                "custom_id": "backfill_0",
+                "result": {
+                    "type": "succeeded",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "structured_output",
+                                "input": {
+                                    "classifications": [
+                                        {"mpn": "ABC", "manufacturer": "Corp", "category": "Logic ICs"}
+                                        for _ in range(100)  # fill a full batch of 100
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                },
+            }
+        )
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
+        tmp.write(result_line + "\n")
+        tmp.close()
+        tmp_path = tmp.name
+
+        status_resp = MagicMock()
+        status_resp.status_code = 200
+        status_resp.json.return_value = {
+            "processing_status": "ended",
+            "results_url": "https://api.anthropic.com/results/batch_exc",
+        }
+        mock_http.get = AsyncMock(return_value=status_resp)
+        mock_http.stream = _make_fake_stream(tmp_path)
+
+        try:
+            with pytest.raises(RuntimeError, match="unexpected error in apply"):
+                _run(apply_batch_results_chunked("batch_exc"))
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    @patch("app.database.SessionLocal")
+    @patch("app.http_client.http")
+    @patch("app.services.credential_service.get_credential_cached", return_value="sk-test-key")
+    def test_osunlink_failure_silently_ignored(self, mock_cred, mock_http, mock_session_local, db_session: Session):
+        """Lines 546-547: OSError from os.unlink() is silently swallowed."""
+        mock_session_local.return_value = db_session
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
+        tmp.write("")
+        tmp.close()
+        tmp_path = tmp.name
+
+        status_resp = MagicMock()
+        status_resp.status_code = 200
+        status_resp.json.return_value = {
+            "processing_status": "ended",
+            "results_url": "https://api.anthropic.com/results/batch_unlink",
+        }
+        mock_http.get = AsyncMock(return_value=status_resp)
+        mock_http.stream = _make_fake_stream(tmp_path)
+
+        import unittest.mock
+
+        with unittest.mock.patch("os.unlink", side_effect=OSError("Permission denied")):
+            # Should NOT raise — OSError is silently caught
+            result = _run(apply_batch_results_chunked("batch_unlink"))
+
+        # File may still exist since unlink was mocked to fail; clean up manually
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+        assert "total_lines" in result


### PR DESCRIPTION
## Summary

- All `app/` modules were already at 85%+ (96% total coverage, 1437 missing lines)
- Targeted the 10 modules with the most uncovered statements
- Added 934 lines of tests across 5 files to bring 5 modules to **100%**

## Modules improved

| Module | Before | After | Lines covered |
|--------|--------|-------|---------------|
| `app/services/engagement_scorer.py` | 93% | 100% | 65, 180-181, 199, 204, 257-258, 307-308, 406-408 |
| `app/services/material_enrichment_service.py` | 93% | 100% | 153-155, 295, 360-362, 379-381, 385-388 |
| `app/services/strategic_vendor_service.py` | 91% | 100% | 96, 117-119, 170-171, 175-176, 179-181 |
| `app/services/tagging_ai_batch.py` | 91% | 100% | 481, 507, 516-520, 523, 535-538, 546-547 |
| `app/services/proactive_matching.py` | 94% | 100% | 125-129, 138, 214-221, 224, 336 |

## New test coverage highlights

- **engagement_scorer**: domain aliases loop, VendorResponse with no-`@` email, WON-offer win_map, flush exception paths
- **material_enrichment_service**: AI returns wrong part count vs cards batch, empty BatchQueue, card_id parse ValueError, `_apply_enrichment_result` exception, commit failure
- **strategic_vendor_service**: cross-user vendor claim conflict, IntegrityError on race condition, `replace_vendor` drop-failure and claim-failure rollback paths
- **tagging_ai_batch**: blank JSONL lines, list-format classifications, >= 100-item batch flush, progress-log at 500 lines, outer exception reraise, OSError on temp-file unlink
- **proactive_matching**: naive watermark timestamp UTC tagging, corrupt watermark fallback, `_set_watermark` creating new SystemConfig, `_find_matches` with `source_offer=None`, 5000-offer cap warning

## Test plan

- [x] `TESTING=1 PYTHONPATH=. pytest tests/test_proactive_matching.py --override-ini="addopts=" -q` — 55 passed
- [x] `TESTING=1 PYTHONPATH=. pytest tests/test_services_coverage_2.py tests/test_services_engagement.py tests/test_tagging_ai_batch.py --override-ini="addopts=" -q` — 216 passed
- [x] Full suite (no xdist): 13594 passed, 30 skipped — 96% total coverage (1376 missing, down from 1437)

https://claude.ai/code/session_015JgHcvuc8BbXNCXA15w2ut

---
_Generated by [Claude Code](https://claude.ai/code/session_015JgHcvuc8BbXNCXA15w2ut)_