### PR TITLE
test: nightly coverage improvement — bring modules to 85%+

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4787,7 +4787,7 @@ async def create_site(
         )
         if existing:
             owner_user = db.get(User, parsed_owner_id)
-            owner_name = owner_user.display_name if owner_user else f"User #{parsed_owner_id}"
+            owner_name = owner_user.name if owner_user else f"User #{parsed_owner_id}"
             return HTMLResponse(
                 f'<div class="p-2 text-xs text-rose-600">{owner_name} already owns site "{existing.site_name}". Each user can only own one site.</div>'
             )

--- a/tests/test_ai_router_nightly2.py
+++ b/tests/test_ai_router_nightly2.py
@@ -1,0 +1,172 @@
+"""tests/test_ai_router_nightly2.py — Additional coverage for app/routers/ai.py.
+
+Targets:
+  line  184: field truncation in bulk_save_contacts (value[:max_len])
+  lines 432-433: generate_description with empty MPN → 400
+  lines 471-475: MaterialCard description update path
+  line  503: parse_response where req mismatch → 404
+  lines 662-686: intake_parse validation paths + None result
+  line  727: parse_freeform_offer missing requisition → 404
+  line  784: save_freeform_offers missing requisition → 404
+
+Called by: pytest autodiscovery
+Depends on: conftest.py fixtures (client, db_session, test_user, test_requisition)
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.orm import Session
+
+from app.models import Requisition
+
+# ── generate_description empty MPN → 400 (lines 432-433) ────────────────────
+
+
+class TestGenerateDescriptionValidation:
+    def test_empty_mpn_returns_400(self, client):
+        resp = client.post(
+            "/api/ai/generate-description",
+            json={"mpn": "   ", "manufacturer": "", "existing_description": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_description_calls_service(self, client):
+        with patch(
+            "app.services.description_service.generate_verified_description",
+            new_callable=AsyncMock,
+            return_value={"description": "Test desc", "confidence": 0.9, "source_count": 3},
+        ):
+            resp = client.post(
+                "/api/ai/generate-description",
+                json={"mpn": "LM317T", "manufacturer": "TI", "existing_description": ""},
+            )
+        assert resp.status_code == 200
+
+
+# ── intake-parse validation (lines 662-686) ──────────────────────────────────
+
+
+class TestIntakeParseValidation:
+    def test_short_text_returns_422(self, client):
+        resp = client.post(
+            "/api/ai/intake-parse",
+            json={"text": "hi", "mode": "auto"},
+        )
+        assert resp.status_code == 422
+
+    def test_text_too_long_returns_422(self, client):
+        resp = client.post(
+            "/api/ai/intake-parse",
+            json={"text": "x" * 12001, "mode": "auto"},
+        )
+        assert resp.status_code == 422
+
+    def test_invalid_mode_returns_422(self, client):
+        resp = client.post(
+            "/api/ai/intake-parse",
+            json={"text": "LM317T 1000 pcs $0.50", "mode": "invalid_mode"},
+        )
+        assert resp.status_code == 422
+
+    def test_none_parse_result_returns_not_parsed(self, client):
+        with patch(
+            "app.services.ai_intake_parser.parse_freeform_intake",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            resp = client.post(
+                "/api/ai/intake-parse",
+                json={"text": "some vendor text here", "mode": "auto"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["parsed"] is False
+
+    def test_missing_requisition_returns_404(self, client):
+        resp = client.post(
+            "/api/ai/intake-parse",
+            json={"text": "LM317T 1000 $0.50", "mode": "rfq", "requisition_id": 999999},
+        )
+        assert resp.status_code == 404
+
+
+# ── parse_freeform_offer missing requisition → 404 (line 727) ───────────────
+
+
+class TestParseFreeformOfferValidation:
+    def test_missing_requisition_returns_404(self, client):
+        with patch("app.routers.ai._ai_enabled", return_value=True):
+            resp = client.post(
+                "/api/ai/parse-freeform-offer",
+                json={"raw_text": "LM317T 1000 $0.50", "requisition_id": 999999},
+            )
+        assert resp.status_code == 404
+
+    def test_none_result_returns_not_parsed(self, client):
+        with patch("app.routers.ai._ai_enabled", return_value=True):
+            with patch(
+                "app.services.freeform_parser_service.parse_freeform_offer",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                resp = client.post(
+                    "/api/ai/parse-freeform-offer",
+                    json={"raw_text": "some vendor text here"},
+                )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["parsed"] is False
+
+
+# ── save_freeform_offers missing requisition → 404 (line 784) ───────────────
+
+
+class TestSaveFreeformOffersValidation:
+    def test_missing_requisition_returns_404(self, client):
+        resp = client.post(
+            "/api/ai/save-freeform-offers",
+            json={
+                "requisition_id": 999999,
+                "offers": [{"vendor_name": "Test Vendor", "mpn": "LM317T"}],
+            },
+        )
+        assert resp.status_code == 404
+
+
+# ── MaterialCard description update path (lines 471-475) ────────────────────
+
+
+class TestGenerateDescriptionForRequirement:
+    def test_updates_material_card_description(self, client, db_session: Session, test_requisition: Requisition):
+        from app.models.intelligence import MaterialCard
+
+        card = MaterialCard(
+            normalized_mpn="lm317t-nightly2",
+            display_mpn="LM317T",
+            description=None,
+        )
+        db_session.add(card)
+        db_session.commit()
+        db_session.refresh(card)
+
+        req = test_requisition.requirements[0]
+        req.material_card_id = card.id
+        db_session.commit()
+
+        with patch(
+            "app.services.description_service.generate_verified_description",
+            new_callable=AsyncMock,
+            return_value={
+                "description": "Low dropout voltage regulator",
+                "confidence": 0.95,
+                "source_count": 4,
+            },
+        ):
+            resp = client.post(f"/api/ai/generate-description/{req.id}")
+        assert resp.status_code == 200
+        result = resp.json()
+        assert result["confidence"] >= 0.75

--- a/tests/test_htmx_views_nightly30.py
+++ b/tests/test_htmx_views_nightly30.py
@@ -1,0 +1,354 @@
+"""tests/test_htmx_views_nightly30.py — Coverage for htmx_views.py gaps.
+
+Targets:
+  line  403: SALES role filter in requisitions_list_partial
+  lines 1636-1639: bulk action ValueError (invalid ID format)
+  line  1475: parse_offer returns None
+  lines 3113-3126: search_filter confidence / source / sort paths
+  lines 4778-4791: create_site invalid owner_id + owner already owns site
+
+Called by: pytest autodiscovery
+Depends on: conftest.py fixtures (db_session, test_user, sales_user, client)
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import Session
+from starlette.requests import Request
+from starlette.testclient import TestClient
+
+from app.database import get_db
+from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+from app.models import Company, CustomerSite, Requisition, User
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_request(path: str = "/v2/partials/requisitions") -> MagicMock:
+    req = MagicMock(spec=Request)
+    req.url.path = path
+    req.headers = {"HX-Request": "true"}
+    req.query_params = MagicMock()
+    req.query_params.get = lambda k, d=None: d
+    req.cookies = {}
+    return req
+
+
+def _sales_client(db_session: Session, sales_user: User) -> TestClient:
+    """TestClient with sales_user as the authenticated user."""
+    from app.main import app
+
+    def _override_db():
+        yield db_session
+
+    def _override_user():
+        return sales_user
+
+    async def _override_fresh_token():
+        return "mock-token"
+
+    overridden = [get_db, require_user, require_admin, require_buyer, require_fresh_token]
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[require_user] = _override_user
+    app.dependency_overrides[require_admin] = _override_user
+    app.dependency_overrides[require_buyer] = _override_user
+    app.dependency_overrides[require_fresh_token] = _override_fresh_token
+
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        for dep in overridden:
+            app.dependency_overrides.pop(dep, None)
+
+
+# ── SALES role filter (line 403) ─────────────────────────────────────────────
+
+
+class TestSalesRoleFilter:
+    """SALES users only see their own requisitions (line 403)."""
+
+    def test_sales_user_sees_only_own_requisitions(self, db_session: Session, sales_user: User, test_user: User):
+        req_own = Requisition(name="Sales Own Req", status="active", created_by=sales_user.id)
+        req_other = Requisition(name="Other User Req", status="active", created_by=test_user.id)
+        db_session.add_all([req_own, req_other])
+        db_session.commit()
+
+        for client in _sales_client(db_session, sales_user):
+            resp = client.get("/v2/partials/requisitions")
+            assert resp.status_code == 200
+            text = resp.text
+            assert "Sales Own Req" in text
+            assert "Other User Req" not in text
+
+
+# ── Bulk action invalid ID format (lines 1636-1639) ─────────────────────────
+
+
+class TestBulkActionInvalidIds:
+    """POST /v2/partials/requisitions/bulk/archive with non-integer IDs → 400."""
+
+    def test_invalid_id_format_returns_400(self, client: TestClient):
+        resp = client.post(
+            "/v2/partials/requisitions/bulk/archive",
+            data={"ids": "abc,def"},
+        )
+        assert resp.status_code == 400
+
+    def test_empty_ids_returns_400(self, client: TestClient):
+        resp = client.post(
+            "/v2/partials/requisitions/bulk/archive",
+            data={"ids": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_invalid_action_returns_400(self, client: TestClient, test_requisition: Requisition):
+        resp = client.post(
+            "/v2/partials/requisitions/bulk/delete",
+            data={"ids": str(test_requisition.id)},
+        )
+        assert resp.status_code == 400
+
+
+# ── Parse offer returns None (line 1475) ─────────────────────────────────────
+
+
+class TestParseOfferNoneResult:
+    """When parse_freeform_offer returns None, ctx['offers'] is set to [] (line 1475)."""
+
+    async def test_parse_offer_none_result(self, db_session: Session, test_user: User, test_requisition: Requisition):
+        from app.routers.htmx_views import parse_offer_action
+
+        mock_req = _make_request(f"/v2/partials/requisitions/{test_requisition.id}/parse-offer")
+
+        with patch(
+            "app.services.freeform_parser_service.parse_freeform_offer",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await parse_offer_action(
+                request=mock_req,
+                req_id=test_requisition.id,
+                raw_text="LM317T 100",
+                user=test_user,
+                db=db_session,
+            )
+        assert result is not None
+
+
+# ── Search filter confidence / source / sort (lines 3113-3126) ───────────────
+
+
+class TestSearchFilterPaths:
+    """Direct coroutine calls to cover confidence/source/sort filter branches."""
+
+    async def test_confidence_filter_high(self, db_session: Session, test_user: User):
+        from app.routers.htmx_views import search_filter
+
+        sample_results = [
+            {
+                "confidence_color": "green",
+                "score": 0.9,
+                "confidence_pct": 90,
+                "unit_price": 1.0,
+                "qty_available": 50,
+                "sources_found": ["brokerbin"],
+            },
+            {
+                "confidence_color": "red",
+                "score": 0.3,
+                "confidence_pct": 30,
+                "unit_price": 0.5,
+                "qty_available": 10,
+                "sources_found": [],
+            },
+        ]
+
+        mock_req = _make_request("/v2/partials/search/filter")
+
+        with patch("app.routers.htmx_views._get_cached_search_results", return_value=sample_results):
+            with patch("app.routers.htmx_views.templates") as mock_tpl:
+                mock_tpl.get_template.return_value.render.return_value = "<div>card</div>"
+                result = await search_filter(
+                    request=mock_req,
+                    search_id="test-123",
+                    confidence="high",
+                    source="all",
+                    sort="best",
+                    user=test_user,
+                    db=db_session,
+                )
+        assert isinstance(result, HTMLResponse)
+
+    async def test_source_filter(self, db_session: Session, test_user: User):
+        from app.routers.htmx_views import search_filter
+
+        sample_results = [
+            {
+                "confidence_color": "green",
+                "score": 0.9,
+                "confidence_pct": 90,
+                "unit_price": 1.0,
+                "qty_available": 50,
+                "sources_found": ["brokerbin"],
+            },
+            {
+                "confidence_color": "amber",
+                "score": 0.7,
+                "confidence_pct": 70,
+                "unit_price": 0.8,
+                "qty_available": 20,
+                "sources_found": ["digikey"],
+            },
+        ]
+
+        mock_req = _make_request("/v2/partials/search/filter")
+
+        with patch("app.routers.htmx_views._get_cached_search_results", return_value=sample_results):
+            with patch("app.routers.htmx_views.templates") as mock_tpl:
+                mock_tpl.get_template.return_value.render.return_value = "<div>card</div>"
+                result = await search_filter(
+                    request=mock_req,
+                    search_id="test-123",
+                    confidence="all",
+                    source="brokerbin",
+                    sort="best",
+                    user=test_user,
+                    db=db_session,
+                )
+        assert isinstance(result, HTMLResponse)
+
+    async def test_sort_cheapest(self, db_session: Session, test_user: User):
+        from app.routers.htmx_views import search_filter
+
+        sample_results = [
+            {
+                "confidence_color": "green",
+                "score": 0.9,
+                "confidence_pct": 90,
+                "unit_price": 2.0,
+                "qty_available": 50,
+                "sources_found": [],
+            },
+            {
+                "confidence_color": "amber",
+                "score": 0.7,
+                "confidence_pct": 70,
+                "unit_price": 0.5,
+                "qty_available": 20,
+                "sources_found": [],
+            },
+        ]
+
+        mock_req = _make_request("/v2/partials/search/filter")
+
+        with patch("app.routers.htmx_views._get_cached_search_results", return_value=sample_results):
+            with patch("app.routers.htmx_views.templates") as mock_tpl:
+                mock_tpl.get_template.return_value.render.return_value = "<div>card</div>"
+                result = await search_filter(
+                    request=mock_req,
+                    search_id="test-123",
+                    confidence="all",
+                    source="all",
+                    sort="cheapest",
+                    user=test_user,
+                    db=db_session,
+                )
+        assert isinstance(result, HTMLResponse)
+
+    async def test_sort_stock(self, db_session: Session, test_user: User):
+        from app.routers.htmx_views import search_filter
+
+        sample_results = [
+            {
+                "confidence_color": "green",
+                "score": 0.9,
+                "confidence_pct": 90,
+                "unit_price": 1.0,
+                "qty_available": 100,
+                "sources_found": [],
+            },
+            {
+                "confidence_color": "amber",
+                "score": 0.5,
+                "confidence_pct": 50,
+                "unit_price": 0.8,
+                "qty_available": 5,
+                "sources_found": [],
+            },
+        ]
+
+        mock_req = _make_request("/v2/partials/search/filter")
+
+        with patch("app.routers.htmx_views._get_cached_search_results", return_value=sample_results):
+            with patch("app.routers.htmx_views.templates") as mock_tpl:
+                mock_tpl.get_template.return_value.render.return_value = "<div>card</div>"
+                result = await search_filter(
+                    request=mock_req,
+                    search_id="test-123",
+                    confidence="all",
+                    source="all",
+                    sort="stock",
+                    user=test_user,
+                    db=db_session,
+                )
+        assert isinstance(result, HTMLResponse)
+
+
+# ── Create site: invalid owner_id + existing owner (lines 4778-4791) ─────────
+
+
+class TestCreateSiteOwnerValidation:
+    """POST /v2/partials/customers/{company_id}/sites owner_id edge cases."""
+
+    def test_invalid_owner_id_string_ignored(self, client: TestClient, db_session: Session):
+        """Non-integer owner_id is treated as None (lines 4778-4779)."""
+        company = Company(name="Test Co", is_active=True)
+        db_session.add(company)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites",
+            data={"site_name": "HQ", "owner_id": "not-a-number"},
+        )
+        assert resp.status_code == 200
+        assert "HQ" in resp.text
+
+    def test_owner_already_owns_site_returns_error(self, client: TestClient, db_session: Session, test_user: User):
+        """Owner who already owns a site returns error HTML (lines 4780-4791)."""
+        company = Company(name="Test Co 2", is_active=True)
+        db_session.add(company)
+        db_session.commit()
+
+        existing_site = CustomerSite(
+            company_id=company.id,
+            site_name="Existing Site",
+            owner_id=test_user.id,
+        )
+        db_session.add(existing_site)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites",
+            data={"site_name": "New Site", "owner_id": str(test_user.id)},
+        )
+        assert resp.status_code == 200
+        assert "already owns" in resp.text.lower() or "only own one site" in resp.text.lower()
+
+    def test_missing_site_name_returns_error(self, client: TestClient, db_session: Session):
+        """Empty site_name returns validation error."""
+        company = Company(name="Test Co 3", is_active=True)
+        db_session.add(company)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites",
+            data={"site_name": ""},
+        )
+        assert resp.status_code == 200
+        assert "required" in resp.text.lower()

--- a/tests/test_vendors_crud_coverage2.py
+++ b/tests/test_vendors_crud_coverage2.py
@@ -1,0 +1,111 @@
+"""tests/test_vendors_crud_coverage2.py — Additional coverage for vendors_crud.py.
+
+Targets:
+  lines 177-180: list_vendors with tag filter
+  lines 379-380: typeahead invalid limit → fallback to 8
+  line  480: delete_vendor with active offers → 400
+  lines 213-217: list_vendors FTS fallback path (q with FTS not available)
+
+Called by: pytest autodiscovery
+Depends on: conftest.py fixtures (client, db_session, test_user, test_vendor_card)
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from sqlalchemy.orm import Session
+
+from app.models import Offer, Requisition, VendorCard
+
+# ── list_vendors with tag filter (lines 177-180) ─────────────────────────────
+
+
+class TestListVendorsTagFilter:
+    def test_list_vendors_with_tag_filter(self, client, db_session: Session):
+        """Tag filter applies (lines 177-182)."""
+        card = VendorCard(
+            normalized_name="texas instruments tag",
+            display_name="Texas Instruments Tagged",
+            brand_tags=["linear"],
+            commodity_tags=["analog ic"],
+        )
+        db_session.add(card)
+        db_session.commit()
+
+        resp = client.get("/api/vendors?tag=analog")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "vendors" in data
+
+    def test_list_vendors_with_q_filter(self, client, db_session: Session):
+        """q filter applies name search (lines 184-222)."""
+        resp = client.get("/api/vendors?q=arrow")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "vendors" in data
+
+    def test_list_vendors_with_sort(self, client, db_session: Session):
+        """Sort parameter works."""
+        resp = client.get("/api/vendors?sort=sighting_count&dir=desc")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "vendors" in data
+
+
+# ── delete vendor with active offers → 400 (line 480) ────────────────────────
+
+
+class TestDeleteVendorWithOffers:
+    def test_delete_vendor_with_active_offers_returns_400(
+        self, client, db_session: Session, test_vendor_card: VendorCard, test_user
+    ):
+        req = Requisition(name="Test Req Delete", status="active", created_by=test_user.id)
+        db_session.add(req)
+        db_session.commit()
+
+        offer = Offer(
+            vendor_card_id=test_vendor_card.id,
+            vendor_name="Arrow Electronics",
+            mpn="LM317T",
+            requisition_id=req.id,
+        )
+        db_session.add(offer)
+        db_session.commit()
+
+        resp = client.delete(f"/api/vendors/{test_vendor_card.id}")
+        assert resp.status_code == 400
+        assert "Cannot delete" in resp.json()["error"]
+
+    def test_delete_vendor_not_found_returns_404(self, client):
+        resp = client.delete("/api/vendors/999999")
+        assert resp.status_code == 404
+
+    def test_delete_vendor_success(self, client, db_session: Session):
+        card = VendorCard(
+            normalized_name="deletable vendor test",
+            display_name="Deletable Vendor",
+        )
+        db_session.add(card)
+        db_session.commit()
+
+        resp = client.delete(f"/api/vendors/{card.id}")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+
+# ── typeahead invalid limit fallback (lines 379-380) ─────────────────────────
+
+
+class TestVendorTypeaheadInvalidLimit:
+    def test_invalid_limit_falls_back_to_8(self, client, test_vendor_card: VendorCard):
+        """Invalid limit param falls back to 8 (lines 379-380)."""
+        resp = client.get("/api/autocomplete/names?q=arrow&limit=not_a_number")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_short_query_returns_empty(self, client):
+        """q < 2 chars returns [] (line 376)."""
+        resp = client.get("/api/autocomplete/names?q=a")
+        assert resp.status_code == 200
+        assert resp.json() == []


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `tests/test_ai_router_nightly2.py` (11 tests): covers `generate-description` validation, `intake-parse` validation paths, `parse-freeform-offer`/`save-freeform-offers` missing requisition → 404, and MaterialCard description update path
- Add `tests/test_htmx_views_nightly30.py` (12 tests): covers SALES role filter in requisitions list, bulk action invalid ID format → 400, `parse_offer` None result, `search_filter` confidence/source/sort branches, and `create_site` owner validation edge cases
- Add `tests/test_vendors_crud_coverage2.py` (8 tests): covers `list_vendors` tag/q/sort filters, delete vendor with active offers → 400, and typeahead invalid limit fallback
- Fix bug in `htmx_views.py` line 4790: `owner_user.display_name` → `owner_user.name` (User model has no `display_name` attribute; caused AttributeError when an owner already owns a site)

## Test plan

- [ ] `TESTING=1 PYTHONPATH=. pytest tests/test_ai_router_nightly2.py -v` — 11 tests pass
- [ ] `TESTING=1 PYTHONPATH=. pytest tests/test_htmx_views_nightly30.py -v` — 12 tests pass
- [ ] `TESTING=1 PYTHONPATH=. pytest tests/test_vendors_crud_coverage2.py -v` — 8 tests pass
- [ ] Full suite passes: `TESTING=1 PYTHONPATH=. pytest tests/ -v`
- [ ] Coverage remains at 96%+ overall

https://claude.ai/code/session_011VLkttZBtzWiHnp2CUbgEs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011VLkttZBtzWiHnp2CUbgEs)_