### PR TITLE
fix(ci): reformat docstrings to unblock docformatter pre-commit

### DIFF
--- a/tests/test_email_service_coverage.py
+++ b/tests/test_email_service_coverage.py
@@ -1,4 +1,5 @@
-"""tests/test_email_service_coverage.py — Coverage tests for uncovered lines in app/email_service.py.
+"""tests/test_email_service_coverage.py — Coverage tests for uncovered lines in
+app/email_service.py.
 
 Covers:
 - _handle_excess_bid_reply: empty body (921-922), None parse result (958-959),
@@ -107,7 +108,8 @@ def _make_vendor_response(db: Session, user: User, requisition: Requisition, con
 class TestHandleExcessBidReplyEmptyBody:
     @pytest.mark.asyncio
     async def test_empty_body_skipped(self, db_session: Session, test_user: User):
-        """Whitespace-only body returns early without changing status (lines 921-922)."""
+        """Whitespace-only body returns early without changing status (lines
+        921-922)."""
         sol = _make_excess_solicitation(db_session, test_user)
         msg = {"body": {"content": "   "}, "bodyPreview": "   "}
 
@@ -120,7 +122,7 @@ class TestHandleExcessBidReplyEmptyBody:
 
     @pytest.mark.asyncio
     async def test_empty_body_preview_skipped(self, db_session: Session, test_user: User):
-        """msg with no 'body' key but empty bodyPreview also returns early."""
+        """Msg with no 'body' key but empty bodyPreview also returns early."""
         sol = _make_excess_solicitation(db_session, test_user)
         msg = {"bodyPreview": ""}
 
@@ -138,7 +140,8 @@ class TestHandleExcessBidReplyEmptyBody:
 class TestHandleExcessBidReplyNoneResult:
     @pytest.mark.asyncio
     async def test_none_result_leaves_solicitation_unchanged(self, db_session: Session, test_user: User):
-        """claude_structured returning None leaves solicitation status unchanged (lines 958-959)."""
+        """claude_structured returning None leaves solicitation status unchanged (lines
+        958-959)."""
         sol = _make_excess_solicitation(db_session, test_user)
         msg = {"body": {"content": "I have some parts, please advise."}}
 
@@ -170,7 +173,8 @@ class TestHandleExcessBidReplyNoneResult:
 class TestHandleExcessBidReplyIncomplete:
     @pytest.mark.asyncio
     async def test_missing_unit_price_skips_bid_creation(self, db_session: Session, test_user: User):
-        """Parse result with unit_price=None returns early without creating bid (lines 971-972)."""
+        """Parse result with unit_price=None returns early without creating bid (lines
+        971-972)."""
         sol = _make_excess_solicitation(db_session, test_user)
         msg = {"body": {"content": "We can supply 200 units."}}
 
@@ -204,7 +208,8 @@ class TestAutoCreateOffersCardIdPath:
     def test_requirement_with_material_card_id_linked_to_offer(
         self, db_session: Session, test_user: User, test_requisition: Requisition
     ):
-        """Requirement.material_card_id populates mpn_to_card_id; offer inherits it (line 1043)."""
+        """Requirement.material_card_id populates mpn_to_card_id; offer inherits it
+        (line 1043)."""
         from app.models import MaterialCard
 
         mc = MaterialCard(
@@ -244,7 +249,8 @@ class TestAutoCreateOffersDedup:
     def test_existing_offer_for_same_vr_and_mpn_skipped(
         self, db_session: Session, test_user: User, test_requisition: Requisition
     ):
-        """Existing offer with same vendor_response_id + mpn causes continue (line 1059)."""
+        """Existing offer with same vendor_response_id + mpn causes continue (line
+        1059)."""
         vr = _make_vendor_response(db_session, test_user, test_requisition, confidence=0.9)
 
         # Pre-create the duplicate offer
@@ -352,7 +358,8 @@ class TestAutoCreateOffersExceptionHandlers:
         assert offer is not None
 
     def test_offer_loop_exception_swallowed(self, db_session: Session, test_user: User, test_requisition: Requisition):
-        """Exception inside the per-offer loop is caught (lines 1166-1167); no propagation."""
+        """Exception inside the per-offer loop is caught (lines 1166-1167); no
+        propagation."""
         vr = _make_vendor_response(db_session, test_user, test_requisition, confidence=0.9)
         draft = {"mpn": "LM404T", "vendor_name": "BadVendor"}
         parsed = {"confidence": 0.9}
@@ -371,7 +378,8 @@ class TestAutoCreateOffersStrategicVendorClock:
     def test_strategic_vendor_clock_exception_swallowed(
         self, db_session: Session, test_user: User, test_requisition: Requisition
     ):
-        """Exception in sv_record is swallowed (lines 1135-1136) when vendor_card_id is set."""
+        """Exception in sv_record is swallowed (lines 1135-1136) when vendor_card_id is
+        set."""
         from app.models import VendorCard
 
         vc = VendorCard(
@@ -448,7 +456,8 @@ class TestAutoCreateOffersExistingNotification:
     def test_existing_unread_notification_updated_not_duplicated(
         self, db_session: Session, test_user: User, test_requisition: Requisition
     ):
-        """Unread offer_pending_review log is updated in place, not duplicated (lines 1151-1154)."""
+        """Unread offer_pending_review log is updated in place, not duplicated (lines
+        1151-1154)."""
         vr = _make_vendor_response(db_session, test_user, test_requisition, confidence=0.6)
 
         existing_notif = ActivityLog(
@@ -501,7 +510,8 @@ class TestAutoCreateOffersExistingNotification:
 
 class TestAutoCreateOffersSSEException:
     def test_sse_broker_exception_swallowed(self, db_session: Session, test_user: User, test_requisition: Requisition):
-        """Exception from broker.publish is swallowed (lines 1186-1187); no propagation."""
+        """Exception from broker.publish is swallowed (lines 1186-1187); no
+        propagation."""
         vr = _make_vendor_response(db_session, test_user, test_requisition, confidence=0.9)
         draft = {"mpn": "LM317T", "vendor_name": "TestVendor Inc"}
         parsed = {"confidence": 0.9}

--- a/tests/test_nightly_coverage_gaps.py
+++ b/tests/test_nightly_coverage_gaps.py
@@ -1,4 +1,5 @@
-"""test_nightly_coverage_gaps.py — Covers remaining uncovered lines across multiple modules.
+"""test_nightly_coverage_gaps.py — Covers remaining uncovered lines across multiple
+modules.
 
 Targets:
 - app/utils/graph_client.py: patch_json, search_sent_messages, PATCH retry, _parse_retry_after bad value

--- a/tests/test_search_service_stream.py
+++ b/tests/test_search_service_stream.py
@@ -1,4 +1,5 @@
-"""test_search_service_stream.py — Coverage tests for stream_search_mpn in app/search_service.py.
+"""test_search_service_stream.py — Coverage tests for stream_search_mpn in
+app/search_service.py.
 
 Covers lines 1959-2110: streaming search via SSE.
 
@@ -22,7 +23,8 @@ from tests.conftest import engine  # noqa: F401 — ensures SQLite engine is use
 
 class TestStreamSearchMpnNoConnectors:
     async def test_no_connectors_publishes_done(self, db_session: Session):
-        """When _build_connectors returns empty list, broker.publish is called once with 'done'."""
+        """When _build_connectors returns empty list, broker.publish is called once with
+        'done'."""
         mock_broker = MagicMock()
         mock_broker.publish = AsyncMock()
 
@@ -132,7 +134,8 @@ class TestStreamSearchMpnWithResults:
         assert "results" in event_types
 
     async def test_updated_cards_triggers_card_update_event(self, db_session: Session):
-        """When _incremental_dedup returns updated_cards, a 'card-update' event is published."""
+        """When _incremental_dedup returns updated_cards, a 'card-update' event is
+        published."""
         mock_broker = MagicMock()
         mock_broker.publish = AsyncMock()
 
@@ -162,7 +165,8 @@ class TestStreamSearchMpnWithResults:
 
 class TestStreamSearchMpnConnectorException:
     async def test_connector_exception_publishes_error_source_status(self, db_session: Session):
-        """When connector.search raises, source-status error is published and no exception propagates."""
+        """When connector.search raises, source-status error is published and no
+        exception propagates."""
         mock_broker = MagicMock()
         mock_broker.publish = AsyncMock()
 
@@ -204,7 +208,8 @@ class TestStreamSearchMpnConnectorException:
         assert "done" in event_types
 
     async def test_multiple_connectors_one_fails_other_succeeds(self, db_session: Session):
-        """With two connectors, one failing and one succeeding, both source-status events are published."""
+        """With two connectors, one failing and one succeeding, both source-status
+        events are published."""
         mock_broker = MagicMock()
         mock_broker.publish = AsyncMock()
 

--- a/tests/test_signature_parser_batch.py
+++ b/tests/test_signature_parser_batch.py
@@ -1,5 +1,5 @@
-"""Tests for signature_parser batch functions — mobile label branch, batch_parse_signatures,
-and process_signature_batch_results.
+"""Tests for signature_parser batch functions — mobile label branch,
+batch_parse_signatures, and process_signature_batch_results.
 
 Covers lines 146, 402-458, and 474-550 in app/services/signature_parser.py.
 
@@ -25,7 +25,8 @@ class TestMobileLabel:
     """Covers line 146: result["mobile"] = phone when label before match contains 'mobile'/'cell'."""
 
     def test_mobile_prefix_before_phone_keyword_sets_mobile(self):
-        """'Mobile Phone: ...' → 'mobile' appears before 'Phone:' match, sets result['mobile']."""
+        """'Mobile Phone: ...' → 'mobile' appears before 'Phone:' match, sets
+        result['mobile']."""
         body = "--\nJohn Doe\nMobile Phone: +1-555-123-4567"
         result = parse_signature_regex(body)
         assert result["mobile"] == "+1-555-123-4567" or result.get("phone") is not None
@@ -65,7 +66,8 @@ class TestMobileLabel:
         assert result["mobile"] == "555-987-6543"
 
     def test_mobile_label_confidence_counts_mobile_field(self):
-        """When mobile is set via the label branch, confidence calculation includes it."""
+        """When mobile is set via the label branch, confidence calculation includes
+        it."""
         body = "--\nJohn Doe\nMobile Phone: 555-123-4567\njohn@example.com"
         result = parse_signature_regex(body)
         # mobile + name + email = at least 3 fields → confidence > 0.3 + 3*0.1 = 0.6
@@ -338,7 +340,8 @@ class TestProcessSignatureBatchResults:
         assert extract.confidence > 0.5  # Recalculated after applying fields
 
     async def test_batch_result_none_value_counts_as_error(self, db_session):
-        """A result entry with None value (failed parse) → counted as error, not applied."""
+        """A result entry with None value (failed parse) → counted as error, not
+        applied."""
         mock_redis = MagicMock()
         mock_redis.get.return_value = b"batch-err"
 
@@ -479,7 +482,8 @@ class TestProcessSignatureBatchResults:
         mock_redis.delete.assert_called_once()
 
     async def test_commit_failure_returns_stats_without_clearing_redis(self, db_session):
-        """DB commit failure → stats returned but Redis key NOT deleted (retry allowed)."""
+        """DB commit failure → stats returned but Redis key NOT deleted (retry
+        allowed)."""
         extract = EmailSignatureExtract(
             sender_email="commit-fail@example.com",
             extraction_method="regex",

--- a/tests/test_strategic_vendor_coverage.py
+++ b/tests/test_strategic_vendor_coverage.py
@@ -1,4 +1,5 @@
-"""test_strategic_vendor_coverage.py — Coverage gap tests for strategic_vendor_service.py.
+"""test_strategic_vendor_coverage.py — Coverage gap tests for
+strategic_vendor_service.py.
 
 Targets missing lines: 96, 117-119, 170-171, 175-176, 179-181
 - Line 96: claim_vendor returns "already claimed by another buyer"


### PR DESCRIPTION
## Summary

Main's `CI — Tests` job has been red on the **Run pre-commit checks** step (not alembic — the migration-001 fix from #108 resolved that). Five nightly-coverage test files landed on main with docstring summaries exceeding the 88-char `docformatter` wrap, so `pre-commit run --all-files` fails in CI.

This re-wraps them with `docformatter v1.7.7` (the pinned hook version). Docstring text only — no logic change.

## Files

- `tests/test_email_service_coverage.py`
- `tests/test_nightly_coverage_gaps.py`
- `tests/test_search_service_stream.py`
- `tests/test_signature_parser_batch.py`
- `tests/test_strategic_vendor_coverage.py`

## Verification

- [x] `pre-commit run --all-files` green locally (docformatter + mypy + ruff)
- [ ] CI green on this PR

Once merged, main `test` goes green and the stacked Phase 4 PRs stop inheriting this failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)