### PR TITLE
fix(devops): harden deploy pipeline — 4 CRIT-DEVOPS findings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,44 @@ on:
     types: [published]
 
 jobs:
+  # Gate: never deploy a release commit whose CI is not green.
+  verify-ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Require green CI on the release commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          # Echo a check's status (if running) or conclusion (if completed),
+          # or empty if it has not reported for this commit yet.
+          check_state() {
+            gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
+              --jq ".check_runs[] | select(.name==\"$1\") | (if .status!=\"completed\" then .status else .conclusion end)" \
+              2>/dev/null | head -1
+          }
+          for attempt in $(seq 1 40); do
+            T=$(check_state "CI — Tests")
+            S=$(check_state "Security Scanning")
+            echo "attempt $attempt — CI — Tests=${T:-missing}  Security Scanning=${S:-missing}"
+            case "$T" in failure|cancelled|timed_out|action_required|stale)
+              echo "ERROR: 'CI — Tests' for $SHA = $T — refusing to deploy." >&2; exit 1;; esac
+            case "$S" in failure|cancelled|timed_out|action_required|stale)
+              echo "ERROR: 'Security Scanning' for $SHA = $S — refusing to deploy." >&2; exit 1;; esac
+            if [ "$T" = success ] && [ "$S" = success ]; then
+              echo "All required checks green for $SHA — deploy may proceed."
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "ERROR: required CI checks did not all complete green within the wait window." >&2
+          exit 1
+
   deploy:
+    needs: verify-ci
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,7 @@ RUN useradd -r -u 1000 -m appuser \
     && mkdir -p /app/fix_queue && chown appuser:appuser /app/fix_queue
 
 ENTRYPOINT ["tini", "--", "./docker-entrypoint.sh"]
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]
+# No --forwarded-allow-ips here: uvicorn safe-defaults to 127.0.0.1 when the
+# image is run standalone. docker-compose.yml overrides `command:` to trust
+# the compose network where Caddy fronts the app.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,6 +37,21 @@ if [ "$NO_COMMIT" = false ]; then
         echo "No changes to commit — skipping commit step"
     else
         git add -A
+        # Last line of defence before `git add -A` lands something in history.
+        # .gitignore should already exclude these, but the moment it misses a
+        # new untracked file (a secret, an SSH key, a DB dump) `git add -A`
+        # stages it. Abort the deploy rather than commit it.
+        DANGER=$(git diff --cached --name-only | grep -iE \
+            '(^|/)\.env($|\.)|\.(pem|key|p12|pfx|sql|sqlite3?|dump)$|(^|/)(credentials|service-account|id_rsa|id_ed25519)[^/]*$' \
+            || true)
+        if [ -n "$DANGER" ]; then
+            echo "ERROR: deploy aborted — refusing to commit sensitive/data files:" >&2
+            echo "$DANGER" | sed 's/^/  /' >&2
+            echo "Add them to .gitignore or commit deliberately outside ./deploy.sh." >&2
+            echo "The working tree is unchanged; nothing was committed." >&2
+            git reset -q
+            exit 4
+        fi
         git commit -m "${1:-deploy}"
     fi
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -12,7 +12,7 @@ services:
       - ./app:/app/app
       - /app/app/static/dist    # preserve Vite-built assets from image
       - ./scripts:/app/scripts
-    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*", "--reload", "--reload-dir", "/app/app"]
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "172.28.0.0/24", "--reload", "--reload-dir", "/app/app"]
 
   redis:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,10 @@ services:
   app:
     build: .
     restart: always
+    # Trust X-Forwarded-* headers only from the compose network (where Caddy
+    # is the sole HTTP client) — never "*", which would trust a spoofed
+    # X-Forwarded-For from any client that reached uvicorn directly.
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "172.28.0.0/24"]
     env_file: .env
     stop_grace_period: 60s
     depends_on:
@@ -206,3 +210,14 @@ volumes:
   caddy_config:
   static_files:
   applogs:
+
+# Pin the default network to a fixed subnet so the app's --forwarded-allow-ips
+# can name it. All services already share the implicit `default` network;
+# this only fixes its address range. If 172.28.0.0/24 collides with an
+# existing Docker network on the host, change it here and in the app
+# `command:` (and docker-compose.local.yml) to a free range.
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,12 +26,19 @@ if [ -d /srv/static ]; then
     cp -r app/static/dist/* /srv/static/
 fi
 
-# Run database migrations before starting the app (DB is healthy via depends_on)
+# Run database migrations before starting the app (DB is healthy via depends_on).
+# A failed migration is fatal: starting the app against an un-migrated schema
+# risks data corruption and masks the real problem. `alembic upgrade head` is
+# idempotent — it is a no-op when the schema is already current, so a non-zero
+# exit always means a genuine failure.
 echo "Running alembic upgrade head..."
 if ! runuser -u appuser -- alembic upgrade head 2>&1; then
-    echo "WARNING: alembic upgrade head failed — skipping (schema may already be current)."
+    echo "ERROR: alembic upgrade head failed — refusing to start the app." >&2
+    echo "The database schema is not at head. Investigate the migration failure" >&2
+    echo "before restarting; do not start the app against a stale schema." >&2
+    exit 1
 fi
-echo "Alembic: migrations check done."
+echo "Alembic: migrations complete."
 
 # Drop to non-root user and start the app
 exec runuser -u appuser -- "$@"


### PR DESCRIPTION
Resolves the 4 open Critical DevOps findings from `CODE_REVIEW_NOTES.md`.

## CRIT-DEVOPS-1 — failed migrations no longer swallowed
`docker-entrypoint.sh` caught a failed `alembic upgrade head` with a `WARNING` and started the app anyway, against a possibly un-migrated schema. Now exits 1 — the app refuses to start. `alembic upgrade head` is idempotent, so a non-zero exit is always a real failure.

## CRIT-DEVOPS-2 — deploy.sh secret-staging guard
`git add -A` would stage a secret/data file the moment `.gitignore` missed it. Added a guard that aborts (exit 4, working tree untouched) if any staged path matches `.env*` / `*.pem` / `*.key` / `*.p12` / `*.pfx` / `*.sql` / `*.sqlite` / `*.dump` or a `credentials`/`service-account`/`id_rsa`/`id_ed25519` filename. `git add -A` is kept — the deploy workflow depends on it — with this as the backstop. (The review suggested explicit paths; that doesn't fit a generic deploy script, so the guard achieves the same safety goal.)

## CRIT-DEVOPS-3 — `--forwarded-allow-ips` no longer `"*"`
uvicorn trusted `X-Forwarded-*` from any client. The compose `default` network is now pinned to `172.28.0.0/24`; the app trusts only that CIDR (Caddy — its sole HTTP client — lives there). `Dockerfile` CMD drops the flag so a standalone run safe-defaults to `127.0.0.1`; `docker-compose.yml` overrides `command:` with the CIDR; `docker-compose.local.yml` matched. uvicorn 0.42's `_TrustedHosts` supports CIDR.

⚠️ **Caveat:** if `172.28.0.0/24` collides with an existing Docker network on the droplet, change it in `docker-compose.yml` (network block + app `command:`) and `docker-compose.local.yml`. On the next `docker compose up` the `default` network is recreated with the fixed subnet.

## CRIT-DEVOPS-4 — deploy gated on CI
`deploy.yml` deployed on `release: published` with no check that CI passed. Added a `verify-ci` job that polls the release commit's `CI — Tests` and `Security Scanning` check-runs and fails unless both are green; `deploy` now `needs: verify-ci`.

## Validation
- `sh -n` / `bash -n` on both scripts; all 3 YAML files parse; `docker compose config` renders the CIDR + command correctly.
- Not auto-merged — deploy-infra changes; please review. Merging does not trigger a deploy (deploy runs only on `release: published`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)