### PR TITLE
fix(security): least-privilege agent account + requisitions2 CSRF

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -153,6 +153,9 @@ class UserRole(StrEnum):
     TRADER = "trader"
     MANAGER = "manager"
     ADMIN = "admin"
+    # Non-interactive service account (x-agent-key auth). Least privilege:
+    # deliberately excluded from require_buyer's allowed set and never admin.
+    AGENT = "agent"
 
 
 class ProactiveOfferStatus(StrEnum):

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -91,7 +91,12 @@ def require_settings_access(request: Request, db: Session = Depends(get_db)) -> 
 
 
 def require_buyer(request: Request, db: Session = Depends(get_db)) -> User:
-    """Dependency: requires buyer role for RFQ actions."""
+    """Dependency: requires a buyer-tier role for RFQ actions.
+
+    UserRole.AGENT is intentionally absent from the allowed set: the agent
+    service account is non-interactive and must reach only non-privileged
+    (require_user-level) endpoints — never RFQ/buyer actions.
+    """
     user = require_user(request, db)
     if user.role not in (UserRole.BUYER, UserRole.SALES, UserRole.TRADER, UserRole.MANAGER, UserRole.ADMIN):
         raise HTTPException(403, "Buyer role required for this action")

--- a/app/startup.py
+++ b/app/startup.py
@@ -164,8 +164,19 @@ def _seed_agent_user() -> None:
     try:
         existing = db.query(User).filter_by(email="agent@availai.local").first()
         if existing:
+            # Correct a legacy agent row seeded with an over-privileged role.
+            # The agent is a non-interactive service account and must hold
+            # only UserRole.AGENT — never admin or buyer (see dependencies.py).
+            if existing.role != UserRole.AGENT:
+                logger.warning(
+                    "Demoting agent service account from role '{}' to '{}'",
+                    existing.role,
+                    UserRole.AGENT.value,
+                )
+                existing.role = UserRole.AGENT
+                db.commit()
             return
-        user = User(email="agent@availai.local", name="Agent", role=UserRole.ADMIN, is_active=True)
+        user = User(email="agent@availai.local", name="Agent", role=UserRole.AGENT, is_active=True)
         db.add(user)
         db.commit()
         logger.info("Seeded agent service account")

--- a/app/static/js/requisitions2.js
+++ b/app/static/js/requisitions2.js
@@ -12,6 +12,18 @@
  * bundle. Keep behavior in sync with htmx_app.js:splitPanel.
  */
 
+// ── CSRF token for all HTMX requests ───────────────────────
+// Mirrors the listener in htmx_app.js. page.html is a standalone template
+// that only conditionally loads the Vite bundle (htmx_app.js), so without
+// this every hx-post/patch/delete from this page would be rejected by the
+// starlette_csrf middleware for lacking the x-csrftoken header.
+document.body.addEventListener('htmx:configRequest', (evt) => {
+  const csrfCookie = document.cookie.match(/csrftoken=([^;]+)/)?.[1];
+  if (csrfCookie) {
+    evt.detail.headers['x-csrftoken'] = csrfCookie;
+  }
+});
+
 document.addEventListener('alpine:init', () => {
   Alpine.data('splitPanel', (panelId, defaultPct) => ({
     leftWidth: parseInt(localStorage.getItem('avail_split_' + panelId) || defaultPct),

--- a/tests/test_auth_deps_unit.py
+++ b/tests/test_auth_deps_unit.py
@@ -260,12 +260,23 @@ class TestRequireBuyer:
 
         assert result.id == user.id
 
+    def test_agent_role_rejected_403(self, db_session: Session):
+        """The agent service account (UserRole.AGENT) is non-interactive and must not
+        pass require_buyer — it may reach only non-privileged endpoints (CRIT-SEC-1)."""
+        user = _create_user(db_session, email="agent@availai.local", role="agent")
+        request = _make_request(session_data={"user_id": user.id})
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_buyer(request, db_session)
+
+        assert exc_info.value.status_code == 403
+
     def test_unauthorized_role_raises_403(self, db_session: Session):
         """A user with no recognized buyer-tier role should be rejected.
 
-        Since all UserRole values are allowed by require_buyer, we test by directly
-        setting a role value not in the allowed set. In practice this can't happen with
-        the StrEnum, but it validates the guard.
+        require_buyer allows only buyer/sales/trader/manager/admin; any other role value
+        (e.g. the agent service account, or an unknown role) is rejected. Here we patch
+        in an unrecognized role to validate the guard.
         """
         # Create user then manually set role to something outside the allowed set
         user = _create_user(db_session, role="buyer")

--- a/tests/test_startup_nightly.py
+++ b/tests/test_startup_nightly.py
@@ -58,16 +58,19 @@ class TestSeedAgentUser:
 
         user = db_session.query(User).filter_by(email="agent@availai.local").first()
         assert user is not None
-        assert user.role == "admin"
+        # Least privilege: the agent service account is seeded as AGENT,
+        # never admin (CRIT-SEC-1).
+        assert user.role == "agent"
         assert user.name == "Agent"
 
     @patch("app.startup.SessionLocal")
-    def test_skips_when_agent_user_already_exists(self, mock_sl, db_session: Session):
-        """Returns early without duplicating the agent user."""
+    def test_demotes_legacy_over_privileged_agent(self, mock_sl, db_session: Session):
+        """A pre-existing agent row with a stale admin role is demoted to agent without
+        creating a duplicate (CRIT-SEC-1)."""
         from app.models.auth import User
         from app.startup import _seed_agent_user
 
-        # Pre-create the agent user
+        # Simulate a legacy agent row seeded before the least-privilege fix.
         existing = User(email="agent@availai.local", name="Agent", role="admin", is_active=True)
         db_session.add(existing)
         db_session.commit()
@@ -75,8 +78,9 @@ class TestSeedAgentUser:
         mock_sl.return_value = db_session
         _seed_agent_user()
 
-        count = db_session.query(User).filter_by(email="agent@availai.local").count()
-        assert count == 1
+        rows = db_session.query(User).filter_by(email="agent@availai.local").all()
+        assert len(rows) == 1
+        assert rows[0].role == "agent"
 
     @patch("app.startup.SessionLocal")
     def test_error_branch_rolls_back_and_reraises(self, mock_sl):

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -139,3 +139,19 @@ def test_sightings_template_responses_set_rendered_req_id():
 # changes that are not part of this hunt PR. Adding the connector enforcement
 # here without those source changes would break CI on main. Ship the test in
 # the same commit as the source changes it locks in.
+
+
+def test_standalone_pages_register_csrf_listener():
+    """Standalone page templates that issue mutating HTMX requests but do not
+    unconditionally load htmx_app.js must register their own htmx:configRequest CSRF
+    listener — otherwise starlette_csrf rejects every hx-post/patch/delete (CRIT-FE-1).
+
+    requisitions2/page.html loads requisitions2.js for exactly this reason.
+    """
+    js = Path("app/static/js/requisitions2.js").read_text()
+    assert "htmx:configRequest" in js, (
+        "requisitions2.js must register an htmx:configRequest listener that "
+        "attaches the x-csrftoken header — page.html does not always load "
+        "htmx_app.js, which carries the shared listener."
+    )
+    assert "x-csrftoken" in js, "requisitions2.js CSRF listener must set the x-csrftoken header"


### PR DESCRIPTION
Resolves **CRIT-SEC-1** and **CRIT-FE-1** from `CODE_REVIEW_NOTES.md`.

## CRIT-SEC-1 — agent service account privilege escalation
The agent account (`x-agent-key` auth, `agent@availai.local`) was seeded `UserRole.ADMIN`. `require_admin`/`require_settings_access` block it by email, but `require_buyer` only checks `role` — so the agent passed every buyer-tier endpoint, and `is_admin()` returned true. A leaked `AGENT_API_KEY` was effectively an admin user.

- New dedicated least-privilege **`UserRole.AGENT`** (the `role` column is `varchar` — **no migration needed**).
- `_seed_agent_user` seeds `AGENT` and **demotes any legacy over-privileged agent row** on startup (existing DBs self-correct).
- `AGENT` is absent from `require_buyer`'s allowed set → the agent is now confined to non-privileged `require_user` endpoints, matching the documented intent (*"It should only access non-privileged endpoints"* — `auth.md`).

## CRIT-FE-1 — requisitions2 missing CSRF listener
`requisitions2/page.html` only conditionally loads the Vite bundle (`htmx_app.js`), which carries the shared `htmx:configRequest` CSRF listener. When the bundle is absent, every `hx-post/patch/delete` from the page lacks `x-csrftoken` and is rejected by `starlette_csrf`. Added the listener to `requisitions2.js` — which the page **always** loads — so CSRF works unconditionally. (When both bundles load, the listener double-registers harmlessly: it sets the same header to the same value.)

## Tests
- `_seed_agent_user` seeds/demotes to `AGENT`; `require_buyer` rejects `AGENT` with 403; static check that `requisitions2.js` registers the CSRF listener.
- Affected auth/startup/role suites: 116 pass locally; full local suite running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)