### PR TITLE
fix(security): clear remaining Critical review findings (SEC-2/FE-2/TEST-2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,18 @@ AZURE_CLIENT_SECRET=
 AZURE_TENANT_ID=
 APP_URL=https://app.availai.net
 
+# ── Local Password Login (development / non-Azure environments) ──
+# Enables the /auth/login password form as an alternative to Azure SSO.
+# SECURITY: relative to SSO this is an authentication bypass. Keep it
+# `false` on any internet-reachable environment unless you accept that
+# risk. When true, startup also creates DEFAULT_USER_EMAIL from
+# DEFAULT_USER_PASSWORD with role DEFAULT_USER_ROLE — which defaults to
+# `buyer`; only set a higher tier (e.g. admin) if genuinely needed.
+ENABLE_PASSWORD_LOGIN=false
+DEFAULT_USER_EMAIL=
+DEFAULT_USER_PASSWORD=
+DEFAULT_USER_ROLE=buyer
+
 # ── AI ──
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=claude-sonnet-4-20250514

--- a/app/database.py
+++ b/app/database.py
@@ -24,30 +24,38 @@ class UTCDateTime(TypeDecorator):
         return value
 
 
-_is_sqlite = settings.database_url.startswith("sqlite")
+def _make_engine(database_url: str):
+    """Build the SQLAlchemy engine for ``database_url``.
 
-if _is_sqlite:
-    from sqlalchemy.pool import StaticPool
+    Split out from module scope so the PostgreSQL configuration branch is unit-testable
+    directly — re-importing this module to exercise it would rebuild the shared engine
+    and corrupt parallel (xdist) tests.
+    """
+    if database_url.startswith("sqlite"):
+        from sqlalchemy.pool import StaticPool
 
-    engine = create_engine(
-        settings.database_url,
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-else:
-    _connect_args: dict[str, object] = {"connect_timeout": 10}
-    if settings.database_url.startswith("postgresql"):
-        _connect_args["options"] = "-c statement_timeout=30000 -c lock_timeout=5000"
+        return create_engine(
+            database_url,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
 
-    engine = create_engine(
-        settings.database_url,
+    connect_args: dict[str, object] = {"connect_timeout": 10}
+    if database_url.startswith("postgresql"):
+        connect_args["options"] = "-c statement_timeout=30000 -c lock_timeout=5000"
+
+    return create_engine(
+        database_url,
         pool_size=20,
         max_overflow=20,
         pool_timeout=10,
         pool_pre_ping=True,
         pool_recycle=1800,
-        connect_args=_connect_args,
+        connect_args=connect_args,
     )
+
+
+engine = _make_engine(settings.database_url)
 
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
 

--- a/app/startup.py
+++ b/app/startup.py
@@ -86,7 +86,9 @@ def _create_default_user_if_env_set() -> None:
 
     email = os.environ.get("DEFAULT_USER_EMAIL")
     password = os.environ.get("DEFAULT_USER_PASSWORD")
-    role = os.environ.get("DEFAULT_USER_ROLE", "admin")
+    # Least privilege: an unspecified role yields a buyer, never an admin.
+    # Set DEFAULT_USER_ROLE explicitly to grant a higher tier (CRIT-SEC-2).
+    role = os.environ.get("DEFAULT_USER_ROLE", "buyer")
     if not email or not password:
         return
 

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -243,7 +243,12 @@ document.body.addEventListener('htmx:beforeSwap', (evt) => {
  *
  * Called by: partials/shared/split_panel.html
  * Depends on: Alpine.js
+ *
+ * Sets window.__availSplitPanelRegistered so the standalone
+ * requisitions2.js fallback skips its duplicate registration when this
+ * bundle is loaded (CRIT-FE-2).
  */
+window.__availSplitPanelRegistered = true;
 Alpine.data('splitPanel', (panelId, defaultPct) => ({
     leftWidth: parseInt(localStorage.getItem('avail_split_' + panelId) || defaultPct),
     _resizing: false,

--- a/app/static/js/requisitions2.js
+++ b/app/static/js/requisitions2.js
@@ -25,70 +25,76 @@ document.body.addEventListener('htmx:configRequest', (evt) => {
 });
 
 document.addEventListener('alpine:init', () => {
-  Alpine.data('splitPanel', (panelId, defaultPct) => ({
-    leftWidth: parseInt(localStorage.getItem('avail_split_' + panelId) || defaultPct),
-    _resizing: false,
-    _startX: 0,
-    _startWidth: 0,
+  // splitPanel is also registered by htmx_app.js (the Vite bundle). When the
+  // bundle is loaded it sets window.__availSplitPanelRegistered and wins;
+  // this standalone copy registers only as the no-bundle fallback so the
+  // component is never registered twice (CRIT-FE-2).
+  if (!window.__availSplitPanelRegistered) {
+    Alpine.data('splitPanel', (panelId, defaultPct) => ({
+      leftWidth: parseInt(localStorage.getItem('avail_split_' + panelId) || defaultPct),
+      _resizing: false,
+      _startX: 0,
+      _startWidth: 0,
 
-    startResize(e) {
-      this._resizing = true;
-      this._startX = e.clientX;
-      this._startWidth = this.leftWidth;
-      document.body.style.cursor = 'col-resize';
-      document.body.style.userSelect = 'none';
+      startResize(e) {
+        this._resizing = true;
+        this._startX = e.clientX;
+        this._startWidth = this.leftWidth;
+        document.body.style.cursor = 'col-resize';
+        document.body.style.userSelect = 'none';
 
-      const onMove = (ev) => {
-        if (!this._resizing) return;
-        const container = document.getElementById('split-' + panelId);
-        if (!container) return;
-        const dx = ev.clientX - this._startX;
-        const containerW = container.offsetWidth;
-        const newPct = this._startWidth + (dx / containerW) * 100;
-        this.leftWidth = Math.max(20, Math.min(70, Math.round(newPct)));
-      };
+        const onMove = (ev) => {
+          if (!this._resizing) return;
+          const container = document.getElementById('split-' + panelId);
+          if (!container) return;
+          const dx = ev.clientX - this._startX;
+          const containerW = container.offsetWidth;
+          const newPct = this._startWidth + (dx / containerW) * 100;
+          this.leftWidth = Math.max(20, Math.min(70, Math.round(newPct)));
+        };
 
-      const onUp = () => {
-        this._resizing = false;
-        document.body.style.cursor = '';
-        document.body.style.userSelect = '';
-        localStorage.setItem('avail_split_' + panelId, this.leftWidth);
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', onUp);
-      };
+        const onUp = () => {
+          this._resizing = false;
+          document.body.style.cursor = '';
+          document.body.style.userSelect = '';
+          localStorage.setItem('avail_split_' + panelId, this.leftWidth);
+          document.removeEventListener('mousemove', onMove);
+          document.removeEventListener('mouseup', onUp);
+        };
 
-      document.addEventListener('mousemove', onMove);
-      document.addEventListener('mouseup', onUp);
-    },
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+      },
 
-    startTouchResize(e) {
-      const touch = e.touches[0];
-      this._resizing = true;
-      this._startX = touch.clientX;
-      this._startWidth = this.leftWidth;
+      startTouchResize(e) {
+        const touch = e.touches[0];
+        this._resizing = true;
+        this._startX = touch.clientX;
+        this._startWidth = this.leftWidth;
 
-      const onTouchMove = (ev) => {
-        if (!this._resizing) return;
-        const t = ev.touches[0];
-        const container = document.getElementById('split-' + panelId);
-        if (!container) return;
-        const dx = t.clientX - this._startX;
-        const containerW = container.offsetWidth;
-        const newPct = this._startWidth + (dx / containerW) * 100;
-        this.leftWidth = Math.max(20, Math.min(70, Math.round(newPct)));
-      };
+        const onTouchMove = (ev) => {
+          if (!this._resizing) return;
+          const t = ev.touches[0];
+          const container = document.getElementById('split-' + panelId);
+          if (!container) return;
+          const dx = t.clientX - this._startX;
+          const containerW = container.offsetWidth;
+          const newPct = this._startWidth + (dx / containerW) * 100;
+          this.leftWidth = Math.max(20, Math.min(70, Math.round(newPct)));
+        };
 
-      const onTouchEnd = () => {
-        this._resizing = false;
-        localStorage.setItem('avail_split_' + panelId, this.leftWidth);
-        document.removeEventListener('touchmove', onTouchMove);
-        document.removeEventListener('touchend', onTouchEnd);
-      };
+        const onTouchEnd = () => {
+          this._resizing = false;
+          localStorage.setItem('avail_split_' + panelId, this.leftWidth);
+          document.removeEventListener('touchmove', onTouchMove);
+          document.removeEventListener('touchend', onTouchEnd);
+        };
 
-      document.addEventListener('touchmove', onTouchMove);
-      document.addEventListener('touchend', onTouchEnd);
-    },
-  }));
+        document.addEventListener('touchmove', onTouchMove);
+        document.addEventListener('touchend', onTouchEnd);
+      },
+    }));
+  }
 
   Alpine.data('rq2Page', () => ({
     selectedIds: new Set(),

--- a/tests/test_database_coverage.py
+++ b/tests/test_database_coverage.py
@@ -177,47 +177,69 @@ class TestDatabaseModule:
         assert isinstance(SessionLocal, sessionmaker)
 
 
-class TestDatabaseNonSQLite:
-    """Tests for the PostgreSQL engine creation path (database.py lines 37-50).
+class TestMakeEngine:
+    """Exercises the real engine-construction branches in app/database.py via the
+    extracted _make_engine() factory.
 
-    These tests verify the PostgreSQL configuration constants and connect_args without
-    reloading app.database via sys.modules.pop + importlib.import_module, which corrupts
-    the shared in-memory SQLite engine used by other tests in the same xdist worker
-    process.
+    Earlier tests here reconstructed the kwargs inline and never touched app.database,
+    so the production branch was effectively untested (CRIT-TEST-2). These call
+    _make_engine() directly — with create_engine patched so the branch logic is asserted
+    without a real connection and without rebuilding the shared engine.
     """
 
-    def test_postgresql_branch_creates_engine_with_pool_args(self):
-        """PostgreSQL branch uses pool_size=20, max_overflow=20, pool_pre_ping=True."""
-        import sqlalchemy
+    def test_postgresql_branch_passes_pool_and_timeout_args(self):
+        """A postgresql:// URL gets the production pool settings and the
+        statement_timeout / lock_timeout connect option."""
+        import app.database as database
 
-        mock_engine = MagicMock()
-        _connect_args: dict = {"connect_timeout": 10, "options": "-c statement_timeout=30000"}
+        with patch.object(database, "create_engine") as mock_create:
+            database._make_engine("postgresql://user:pass@localhost/testdb")
 
-        with patch("sqlalchemy.create_engine", return_value=mock_engine) as mock_create:
-            sqlalchemy.create_engine(
-                "postgresql://user:pass@localhost/testdb",
-                pool_size=20,
-                max_overflow=20,
-                pool_timeout=10,
-                pool_pre_ping=True,
-                pool_recycle=1800,
-                connect_args=_connect_args,
-            )
+        assert mock_create.call_count == 1
+        args, kwargs = mock_create.call_args
+        assert args[0] == "postgresql://user:pass@localhost/testdb"
+        assert kwargs["pool_size"] == 20
+        assert kwargs["max_overflow"] == 20
+        assert kwargs["pool_timeout"] == 10
+        assert kwargs["pool_pre_ping"] is True
+        assert kwargs["pool_recycle"] == 1800
+        assert "statement_timeout" in kwargs["connect_args"]["options"]
+        assert "lock_timeout" in kwargs["connect_args"]["options"]
 
-        assert mock_create.called
-        call_kwargs = mock_create.call_args[1]
-        assert "pool_size" in call_kwargs
-        assert call_kwargs["pool_size"] == 20
-        assert call_kwargs["max_overflow"] == 20
-        assert call_kwargs["pool_pre_ping"] is True
+    def test_sqlite_branch_uses_static_pool(self):
+        """A sqlite:// URL builds a StaticPool engine with check_same_thread off."""
+        import app.database as database
 
-    def test_postgresql_options_added_for_postgresql_url(self):
-        """PostgreSQL URL gets statement_timeout and lock_timeout in connect_args."""
-        url = "postgresql://user:pass@localhost/testdb"
-        _connect_args: dict = {"connect_timeout": 10}
-        if url.startswith("postgresql"):
-            _connect_args["options"] = "-c statement_timeout=30000 -c lock_timeout=5000"
+        with patch.object(database, "create_engine") as mock_create:
+            database._make_engine("sqlite:///tmp/test.db")
 
-        assert "options" in _connect_args
-        assert "statement_timeout" in _connect_args["options"]
-        assert "lock_timeout" in _connect_args["options"]
+        assert mock_create.call_count == 1
+        _, kwargs = mock_create.call_args
+        assert kwargs["poolclass"].__name__ == "StaticPool"
+        assert kwargs["connect_args"] == {"check_same_thread": False}
+
+    def test_non_postgresql_url_omits_timeout_options(self):
+        """A non-sqlite, non-postgresql URL keeps the pool args but gets no
+        statement_timeout options in connect_args."""
+        import app.database as database
+
+        with patch.object(database, "create_engine") as mock_create:
+            database._make_engine("mysql://user:pass@localhost/db")
+
+        assert mock_create.call_count == 1
+        _, kwargs = mock_create.call_args
+        assert kwargs["pool_size"] == 20
+        assert "options" not in kwargs["connect_args"]
+
+    def test_make_engine_postgresql_builds_real_queue_pool(self):
+        """Sanity check with create_engine un-patched: a postgresql:// URL
+        yields a real QueuePool engine (no connection is opened)."""
+        from app.database import _make_engine
+
+        eng = _make_engine("postgresql://user:pass@localhost:5432/testdb")
+        try:
+            assert eng.pool.__class__.__name__ == "QueuePool"
+            assert eng.pool.size() == 20
+            assert eng.dialect.name == "postgresql"
+        finally:
+            eng.dispose()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -98,6 +98,28 @@ class TestCreateDefaultUser:
         assert "$" in u.password_hash
 
     @patch("app.startup.SessionLocal")
+    def test_default_role_is_buyer_when_role_unset(self, mock_sl, db_session):
+        """With DEFAULT_USER_ROLE unset, the created user is a buyer — never an admin
+        (CRIT-SEC-2: least privilege)."""
+        from app.startup import _create_default_user_if_env_set
+
+        mock_sl.return_value = db_session
+
+        env = {
+            "DEFAULT_USER_EMAIL": "defaultrole@test.com",
+            "DEFAULT_USER_PASSWORD": "secret123",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("DEFAULT_USER_ROLE", None)
+            _create_default_user_if_env_set()
+
+        from app.models.auth import User
+
+        u = db_session.query(User).filter_by(email="defaultrole@test.com").first()
+        assert u is not None
+        assert u.role == "buyer"
+
+    @patch("app.startup.SessionLocal")
     def test_skips_if_user_already_exists(self, mock_sl, db_session, admin_user):
         """Does not create duplicate user."""
         from app.startup import _create_default_user_if_env_set

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -447,15 +447,16 @@ class TestBackfillProactiveOfferQty:
 class TestCreateDefaultUserDefaultRole:
     """Additional _create_default_user_if_env_set coverage."""
 
-    def test_default_role_is_admin(self):
-        """Without DEFAULT_USER_ROLE, role defaults to 'admin'."""
+    def test_default_role_is_buyer(self):
+        """Without DEFAULT_USER_ROLE, role defaults to least-privilege 'buyer', never
+        'admin' (CRIT-SEC-2)."""
         from app.startup import _create_default_user_if_env_set
 
         mock_session = MagicMock()
         mock_session.query.return_value.filter_by.return_value.first.return_value = None
 
         env = {
-            "DEFAULT_USER_EMAIL": "admin@example.com",
+            "DEFAULT_USER_EMAIL": "default@example.com",
             "DEFAULT_USER_PASSWORD": "secret",
         }
         with (
@@ -466,7 +467,7 @@ class TestCreateDefaultUserDefaultRole:
             _create_default_user_if_env_set()
 
         created_user = mock_session.add.call_args[0][0]
-        assert created_user.role == "admin"
+        assert created_user.role == "buyer"
 
 
 class TestExecAdditional:


### PR DESCRIPTION
Clears the **last 3 open Critical findings** in `CODE_REVIEW_NOTES.md` — the Critical tier is now fully resolved.

## CRIT-SEC-2 — `ENABLE_PASSWORD_LOGIN` auth bypass / admin default
- `ENABLE_PASSWORD_LOGIN`, `DEFAULT_USER_EMAIL/PASSWORD/ROLE` added to `.env.example` with a security note.
- `_create_default_user_if_env_set` — `DEFAULT_USER_ROLE` fallback changed **`admin` → `buyer`**: an unspecified role now yields least privilege.
- *Deliberately not done:* hard-failing startup when the flag is set. Password login is the legitimate login path for non-Azure / staging environments; the existing `logger.critical` startup warning is kept. Disabling it outright would break staging access.

## CRIT-FE-2 — duplicate `splitPanel` Alpine registration
`splitPanel` was registered twice when `requisitions2/page.html` loaded both `requisitions2.js` and the Vite bundle. `htmx_app.js` now sets `window.__availSplitPanelRegistered`; `requisitions2.js` registers its fallback copy only when that flag is unset.

## CRIT-TEST-2 — `app/database.py` PostgreSQL branch untested
Engine construction is extracted into a testable `_make_engine(database_url)` factory (behavior unchanged — `engine = _make_engine(settings.database_url)`). `TestDatabaseNonSQLite` (which reconstructed kwargs inline and never touched the module) is replaced with `TestMakeEngine`, which calls the real factory and asserts the sqlite / postgresql / other branches.

## Validation
- pre-commit clean; affected database/startup suites pass; full local suite running.
- `requisitions2.js` / `htmx_app.js` ESLint-clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)