### PR TITLE
fix(devops): High-tier dependency + config hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,12 @@ ENCRYPTION_SALT=
 # ── Admin ──
 ADMIN_EMAILS=mkhoury@trioscs.com
 
+# ── Observability ──
+# Token required in the X-Metrics-Token header to access the /metrics
+# endpoint. Leave unset to keep /metrics fully blocked (recommended unless
+# a scraper needs it); set a random secret to allow authenticated scraping.
+METRICS_TOKEN=
+
 # ── NetComponents Worker ──
 NC_USERNAME=your_nc_email@company.com
 NC_PASSWORD=your_nc_password

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,25 @@ updates:
       day: monday
     labels:
       - ci
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build frontend with Vite
-FROM node:20-alpine AS builder
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 WORKDIR /build
 COPY package.json package-lock.json ./
 RUN npm ci
@@ -9,7 +9,7 @@ COPY app/templates/ app/templates/
 RUN npm run build
 
 # Stage 2: Python application
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:9d3abd9fc11d06998ccdbdd93b4dd49b5ad7d67fcbbc11c016eb0eb2c2194891
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,16 +18,16 @@ sentry-sdk[fastapi]==2.60.0
 # Rate limiting
 slowapi==0.1.9
 # Fuzzy matching
-rapidfuzz>=3.0.0
+rapidfuzz>=3.0.0,<4.0
 # PDF generation
 weasyprint==68.1
 # Scheduling
-apscheduler==3.11.2,<4.0
+apscheduler>=3.11.2,<4.0
 # Migrations
 alembic==1.18.4
 # Caching
 redis[hiredis]==7.4.0
-orjson>=3.9.0
+orjson>=3.9.0,<4.0
 # CSRF protection
 starlette-csrf==3.0.0
 # NetComponents integration
@@ -36,13 +36,13 @@ patchright==1.59.1
 # Typed settings from env vars (fail-fast validation at startup)
 pydantic-settings==2.14.1
 # SSE streaming for HTMX sourcing progress
-sse-starlette>=1.6.0
+sse-starlette>=1.6.0,<4.0
 # Anthropic Claude API (used by claude_client, enrichment, batch extraction)
-anthropic>=0.40.0
+anthropic>=0.40.0,<1.0
 # HTML sanitization for untrusted email content (XSS prevention)
-nh3>=0.2.0
+nh3==0.3.3
 # Safe XML parsing (XXE prevention)
 defusedxml>=0.7.0
 # Azure Communication Services (click-to-call)
-azure-communication-callautomation>=1.3.0
-azure-communication-identity>=1.5.0
+azure-communication-callautomation>=1.3.0,<2.0
+azure-communication-identity>=1.5.0,<2.0


### PR DESCRIPTION
Resolves **HIGH-DEVOPS-2/3/4/5/6** and the dependency half of **HIGH-SEC-2** from `CODE_REVIEW_NOTES.md`.

- **HIGH-DEVOPS-3** — `METRICS_TOKEN` added to `.env.example` (the `/metrics` endpoint reads it).
- **HIGH-DEVOPS-4** — invalid `apscheduler==3.11.2,<4.0` specifier fixed → `apscheduler>=3.11.2,<4.0`.
- **HIGH-DEVOPS-5** — loose lower-bound-only pins capped below the next major: `rapidfuzz`, `orjson`, `sse-starlette`, `anthropic` (`<1.0`), `azure-communication-*`.
- **HIGH-SEC-2 (deps)** — `nh3` HTML sanitizer pinned exactly (`==0.3.3`) for reproducibility.
- **HIGH-DEVOPS-6** — `npm` + `docker` ecosystems added to `.github/dependabot.yml`.
- **HIGH-DEVOPS-2** — `node:20-alpine` and `python:3.12-slim` base images digest-pinned in the Dockerfile.

All `requirements.txt` lines verified to parse as valid PEP 508 specifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)