### PR TITLE
Activity timeline — Plan 2a: offer events

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from loguru import logger
 from sqlalchemy.orm import Session
 
-from .constants import PendingBatchStatus, VendorResponseStatus
+from .constants import ActivityType, PendingBatchStatus, VendorResponseStatus
 from .models import (
     ActivityLog,
     Contact,
@@ -20,6 +20,7 @@ from .models import (
     VendorCard,
     VendorResponse,
 )
+from .services.activity_service import log_activity
 from .services.credential_service import get_credential_cached
 from .shared_constants import JUNK_DOMAINS as NOISE_DOMAINS
 from .shared_constants import JUNK_EMAIL_PREFIXES as NOISE_PREFIXES
@@ -1088,6 +1089,17 @@ def _auto_create_offers_from_parse(vr: VendorResponse, parsed: dict, db: Session
             )
             db.add(offer)
             db.flush()
+
+            log_activity(
+                db,
+                activity_type=ActivityType.OFFER_CREATED,
+                requisition_id=offer.requisition_id,
+                requirement_id=offer.requirement_id,
+                user_id=None,
+                vendor_card_id=offer.vendor_card_id,
+                description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+                details={"offer_id": offer.id, "source": offer.source},
+            )
 
             # Auto-generate task for email-parsed offer
             try:

--- a/app/routers/crm/clone.py
+++ b/app/routers/crm/clone.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from ...constants import RequisitionStatus
+from ...constants import ActivityType, RequisitionStatus
 from ...database import get_db
 from ...dependencies import require_user
 from ...models import Offer, Requirement, Requisition, User
+from ...services.activity_service import log_activity
 from ...utils.normalization import (
     normalize_condition,
     normalize_mpn,
@@ -91,5 +92,16 @@ async def clone_requisition(req_id: int, user: User = Depends(require_user), db:
                 status="reference",
             )
             db.add(new_o)
+            db.flush()
+            log_activity(
+                db,
+                activity_type=ActivityType.OFFER_CREATED,
+                requisition_id=new_o.requisition_id,
+                requirement_id=new_o.requirement_id,
+                user_id=user.id,
+                vendor_card_id=new_o.vendor_card_id,
+                description=f"Offer added: {new_o.vendor_name} — {new_o.mpn}",
+                details={"offer_id": new_o.id, "source": new_o.source},
+            )
     db.commit()
     return {"ok": True, "id": new_req.id, "name": new_req.name}

--- a/app/routers/crm/offers.py
+++ b/app/routers/crm/offers.py
@@ -395,7 +395,7 @@ async def create_offer(
         except Exception as e:
             logger.warning("Requirement status update failed: {}", e)
 
-    db.commit()
+    db.flush()  # offer.id populated; activity row + offer committed together below
 
     log_activity(
         db,

--- a/app/routers/crm/offers.py
+++ b/app/routers/crm/offers.py
@@ -6,7 +6,7 @@ from loguru import logger
 from sqlalchemy import func as sqlfunc
 from sqlalchemy.orm import Session, joinedload, selectinload
 
-from ...constants import OfferStatus, RequisitionStatus, UserRole
+from ...constants import ActivityType, OfferStatus, RequisitionStatus, UserRole
 from ...database import get_db
 from ...dependencies import is_admin as _is_admin
 from ...dependencies import require_buyer, require_user
@@ -25,6 +25,7 @@ from ...models import (
 )
 from ...schemas.crm import OfferCreate, OfferUpdate, OneDriveAttach
 from ...schemas.responses import OfferListResponse
+from ...services.activity_service import log_activity
 from ...services.credential_service import get_credential_cached
 from ...services.status_machine import require_valid_transition
 from ...utils.async_helpers import safe_background_task
@@ -394,6 +395,18 @@ async def create_offer(
         except Exception as e:
             logger.warning("Requirement status update failed: {}", e)
 
+    db.commit()
+
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_CREATED,
+        requisition_id=offer.requisition_id,
+        requirement_id=offer.requirement_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+        details={"offer_id": offer.id, "source": offer.source},
+    )
     db.commit()
 
     # Auto-generate review task for new offer

--- a/app/routers/crm/offers.py
+++ b/app/routers/crm/offers.py
@@ -639,6 +639,19 @@ async def approve_offer(
     offer.updated_at = datetime.now(timezone.utc)
     offer.updated_by_id = user.id
     record_changes(db, "offer", offer_id, user.id, {"status": old_status}, {"status": "active"}, ["status"])
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
     db.commit()
     return {"ok": True, "status": "active"}
 
@@ -664,6 +677,19 @@ async def reject_offer(
     if reason:
         offer.notes = f"{offer.notes or ''}\n[Rejected: {reason}]".strip()
     record_changes(db, "offer", offer_id, user.id, {"status": old_status}, {"status": "rejected"}, ["status"])
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
     db.commit()
     return {"ok": True, "status": "rejected"}
 
@@ -691,6 +717,19 @@ async def mark_offer_sold(
     offer.updated_at = datetime.now(timezone.utc)
     offer.updated_by_id = user.id
     record_changes(db, "offer", offer_id, user.id, {"status": old_status}, {"status": "sold"}, ["status"])
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
     db.commit()
     return {"ok": True, "status": "sold"}
 
@@ -994,9 +1033,23 @@ async def promote_offer(
 
     offer.evidence_tier = "T5"
     require_valid_transition("offer", offer.status, OfferStatus.ACTIVE)
+    old_status = offer.status
     offer.status = OfferStatus.ACTIVE
     offer.promoted_by_id = user.id
     offer.promoted_at = datetime.now(timezone.utc)
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
     db.commit()
 
     logger.info(f"Offer {offer_id} promoted T4→T5 by user {user.id}")
@@ -1021,9 +1074,23 @@ async def reject_offer_t4_review(
         raise HTTPException(400, "Only pending_review offers can be rejected")
 
     require_valid_transition("offer", offer.status, OfferStatus.REJECTED)
+    old_status = offer.status
     offer.status = OfferStatus.REJECTED
     offer.updated_by_id = user.id
     offer.updated_at = datetime.now(timezone.utc)
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
     db.commit()
 
     logger.info(f"Offer {offer_id} rejected by user {user.id}")

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -64,6 +64,7 @@ from ..models.prospect_account import ProspectAccount
 from ..models.vendor_sighting_summary import VendorSightingSummary
 from ..models.vendors import VendorContact
 from ..scoring import classify_lead, explain_lead, score_unified
+from ..services.activity_service import log_activity as _log_activity
 from ..services.commodity_registry import COMMODITY_TREE, get_display_name
 from ..services.faceted_search_service import (
     get_commodity_counts,
@@ -1923,8 +1924,6 @@ async def review_offer(
         require_valid_transition("offer", offer.status, OfferStatus.REJECTED)
         offer.status = OfferStatus.REJECTED
 
-    from ..services.activity_service import log_activity as _log_activity
-
     _log_activity(
         db,
         activity_type=ActivityType.OFFER_STATUS_CHANGED,
@@ -2014,10 +2013,8 @@ async def add_offer(
         created_at=datetime.now(timezone.utc),
     )
     db.add(offer)
-    db.commit()
+    db.flush()  # offer.id populated; activity row + offer committed together below
     logger.info("Manual offer created: {} on req {} by {}", mpn, req_id, user.email)
-
-    from ..services.activity_service import log_activity as _log_activity
 
     _log_activity(
         db,
@@ -2217,8 +2214,6 @@ async def mark_offer_sold_htmx(
         )
     )
 
-    from ..services.activity_service import log_activity as _log_activity
-
     _log_activity(
         db,
         activity_type=ActivityType.OFFER_STATUS_CHANGED,
@@ -2281,8 +2276,6 @@ async def promote_offer_htmx(
     offer.updated_at = datetime.now(timezone.utc)
     offer.updated_by_id = user.id
 
-    from ..services.activity_service import log_activity as _log_activity
-
     _log_activity(
         db,
         activity_type=ActivityType.OFFER_STATUS_CHANGED,
@@ -2322,8 +2315,6 @@ async def reject_offer_htmx(
     offer.status = OfferStatus.REJECTED
     offer.updated_at = datetime.now(timezone.utc)
     offer.updated_by_id = user.id
-
-    from ..services.activity_service import log_activity as _log_activity
 
     _log_activity(
         db,

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -1911,6 +1911,8 @@ async def review_offer(
     if not offer:
         raise HTTPException(404, "Offer not found")
 
+    old_status = offer.status
+
     if action == "approve":
         require_valid_transition("offer", offer.status, OfferStatus.APPROVED)
         offer.status = OfferStatus.APPROVED
@@ -1920,6 +1922,22 @@ async def review_offer(
     else:
         require_valid_transition("offer", offer.status, OfferStatus.REJECTED)
         offer.status = OfferStatus.REJECTED
+
+    from ..services.activity_service import log_activity as _log_activity
+
+    _log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
 
     db.commit()
     logger.info("Offer {} {} by {}", offer_id, action, user.email)
@@ -2198,6 +2216,23 @@ async def mark_offer_sold_htmx(
             new_value="sold",
         )
     )
+
+    from ..services.activity_service import log_activity as _log_activity
+
+    _log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
+
     db.commit()
     logger.info("Offer {} marked sold by {}", offer_id, user.email)
 
@@ -2238,12 +2273,30 @@ async def promote_offer_htmx(
     if offer.status != "pending_review":
         raise HTTPException(400, "Only pending_review offers can be promoted")
 
+    old_status = offer.status
     require_valid_transition("offer", offer.status, OfferStatus.ACTIVE)
     offer.status = OfferStatus.ACTIVE
     offer.approved_by_id = user.id
     offer.approved_at = datetime.now(timezone.utc)
     offer.updated_at = datetime.now(timezone.utc)
     offer.updated_by_id = user.id
+
+    from ..services.activity_service import log_activity as _log_activity
+
+    _log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
+
     db.commit()
     logger.info("Offer {} promoted by {}", offer_id, user.email)
 
@@ -2264,10 +2317,28 @@ async def reject_offer_htmx(
     if offer.status != "pending_review":
         raise HTTPException(400, "Only pending_review offers can be rejected")
 
+    old_status = offer.status
     require_valid_transition("offer", offer.status, OfferStatus.REJECTED)
     offer.status = OfferStatus.REJECTED
     offer.updated_at = datetime.now(timezone.utc)
     offer.updated_by_id = user.id
+
+    from ..services.activity_service import log_activity as _log_activity
+
+    _log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
+
     db.commit()
     logger.info("Offer {} rejected by {}", offer_id, user.email)
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -23,6 +23,7 @@ from sqlalchemy import func as sqlfunc
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..constants import (
+    ActivityType,
     AttributionStatus,
     BuyPlanStatus,
     ContactStatus,
@@ -1997,6 +1998,20 @@ async def add_offer(
     db.add(offer)
     db.commit()
     logger.info("Manual offer created: {} on req {} by {}", mpn, req_id, user.email)
+
+    from ..services.activity_service import log_activity as _log_activity
+
+    _log_activity(
+        db,
+        activity_type=ActivityType.OFFER_CREATED,
+        requisition_id=offer.requisition_id,
+        requirement_id=offer.requirement_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+        details={"offer_id": offer.id, "source": offer.source},
+    )
+    db.commit()
 
     return await requisition_tab(request=request, req_id=req_id, tab="offers", user=user, db=db)
 

--- a/app/services/ai_offer_service.py
+++ b/app/services/ai_offer_service.py
@@ -13,7 +13,7 @@ Depends on: models (Offer, Requirement, Requisition, VendorCard, VendorContact,
 from loguru import logger
 from sqlalchemy.orm import Session
 
-from ..constants import OfferStatus
+from ..constants import ActivityType, OfferStatus
 from ..models import (
     CustomerSite,
     Offer,
@@ -26,6 +26,7 @@ from ..models import (
 )
 from ..utils.normalization import fuzzy_mpn_match, normalize_mpn_key
 from ..vendor_utils import normalize_vendor_name
+from .activity_service import log_activity
 
 # -- Prospect Contact Promotion -----------------------------------------------
 
@@ -184,6 +185,16 @@ def save_parsed_offers(db: Session, requisition_id: int, response_id: int | None
         )
         db.add(offer)
         db.flush()
+        log_activity(
+            db,
+            activity_type=ActivityType.OFFER_CREATED,
+            requisition_id=offer.requisition_id,
+            requirement_id=offer.requirement_id,
+            user_id=user_id,
+            vendor_card_id=offer.vendor_card_id,
+            description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+            details={"offer_id": offer.id, "source": offer.source},
+        )
         created.append(offer.id)
 
     logger.info(
@@ -321,6 +332,16 @@ def save_freeform_offers(
         )
         db.add(offer)
         db.flush()
+        log_activity(
+            db,
+            activity_type=ActivityType.OFFER_CREATED,
+            requisition_id=offer.requisition_id,
+            requirement_id=offer.requirement_id,
+            user_id=user_id,
+            vendor_card_id=offer.vendor_card_id,
+            description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+            details={"offer_id": offer.id, "source": offer.source},
+        )
         created.append(offer.id)
 
     logger.info(

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -17,13 +17,14 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ..constants import BidSolicitationStatus, BidStatus, ExcessLineItemStatus
+from ..constants import ActivityType, BidSolicitationStatus, BidStatus, ExcessLineItemStatus
 from ..models import Company, CustomerSite
 from ..models.excess import Bid, BidSolicitation, ExcessLineItem, ExcessList
 from ..models.intelligence import ProactiveMatch
 from ..models.offers import Offer
 from ..models.sourcing import Requirement, Requisition
 from ..utils.normalization import normalize_mpn_key
+from .activity_service import log_activity
 
 _ACTIVE_REQ_STATUSES = {"active", "open", "sourcing"}
 
@@ -419,6 +420,17 @@ def match_excess_demand(db: Session, list_id: int, *, user_id: int) -> dict:
                 notes=f"Auto-matched from excess list: {excess_list.title}",
             )
             db.add(offer)
+            db.flush()
+            log_activity(
+                db,
+                activity_type=ActivityType.OFFER_CREATED,
+                requisition_id=offer.requisition_id,
+                requirement_id=offer.requirement_id,
+                user_id=user_id,
+                vendor_card_id=offer.vendor_card_id,
+                description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+                details={"offer_id": offer.id, "source": offer.source},
+            )
             item_matches += 1
             matches_created += 1
 
@@ -662,6 +674,16 @@ def create_proactive_matches_for_excess(
             )
             db.add(offer)
             db.flush()
+            log_activity(
+                db,
+                activity_type=ActivityType.OFFER_CREATED,
+                requisition_id=offer.requisition_id,
+                requirement_id=offer.requirement_id,
+                user_id=user_id,
+                vendor_card_id=offer.vendor_card_id,
+                description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+                details={"offer_id": offer.id, "source": offer.source},
+            )
 
         if not offer:
             continue

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -17,6 +17,7 @@ from sqlalchemy import case, func
 from sqlalchemy.orm import Session, joinedload
 
 from ..constants import (
+    ActivityType,
     OfferStatus,
     ProactiveMatchStatus,
     ProactiveOfferStatus,
@@ -38,6 +39,7 @@ from ..models import (
     User,
 )
 from ..vendor_utils import normalize_vendor_name
+from .activity_service import log_activity
 
 # ── Match Retrieval ──────────────────────────────────────────────────────
 
@@ -474,6 +476,17 @@ def convert_proactive_to_win(db: Session, proactive_offer_id: int, user: User) -
         db.add(new_offer)
         db.flush()
         offer_ids.append(new_offer.id)
+
+        log_activity(
+            db,
+            activity_type=ActivityType.OFFER_CREATED,
+            requisition_id=new_offer.requisition_id,
+            requirement_id=new_offer.requirement_id,
+            user_id=user.id,
+            vendor_card_id=new_offer.vendor_card_id,
+            description=f"Offer added: {new_offer.vendor_name} — {new_offer.mpn}",
+            details={"offer_id": new_offer.id, "source": new_offer.source},
+        )
 
         cost = float(item.get("unit_price") or 0)
         sell = float(item.get("sell_price") or cost)

--- a/app/services/requisition_service.py
+++ b/app/services/requisition_service.py
@@ -14,7 +14,7 @@ from loguru import logger
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ..constants import RequisitionStatus
+from ..constants import ActivityType, RequisitionStatus
 from ..models import Offer, Requirement, Requisition
 from ..utils.normalization import (
     normalize_condition,
@@ -22,6 +22,7 @@ from ..utils.normalization import (
     normalize_mpn_key,
     normalize_packaging,
 )
+from .activity_service import log_activity
 
 # ---------------------------------------------------------------------------
 # Datetime helpers
@@ -154,6 +155,17 @@ def clone_requisition(
                 status="reference",
             )
             db.add(new_o)
+            db.flush()
+            log_activity(
+                db,
+                activity_type=ActivityType.OFFER_CREATED,
+                requisition_id=new_o.requisition_id,
+                requirement_id=new_o.requirement_id,
+                user_id=user_id,
+                vendor_card_id=new_o.vendor_card_id,
+                description=f"Offer added: {new_o.vendor_name} — {new_o.mpn}",
+                details={"offer_id": new_o.id, "source": new_o.source},
+            )
 
     safe_commit(db, entity="requisition clone")
     logger.info("Cloned requisition {} → {} for user {}", source_req.id, new_req.id, user_id)

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -54,7 +54,10 @@ the canonical writer (`log_rfq_activity()` is kept as a thin delegating alias).
 Email and call events are written by `log_email_activity()`/`log_call_activity()`,
 which run their own contact-matching. The requisition Activity tab reads its
 timeline back via `activity_service.get_requisition_activities()` rather than an
-inlined query.
+inlined query. Offer creation and offer status changes now also route through
+`activity_service.log_activity()` (`ActivityType.OFFER_CREATED` /
+`ActivityType.OFFER_STATUS_CHANGED`) so offer events appear on the requisition
+Activity tab.
 
 ## 2. Search (User-Initiated Only)
 

--- a/docs/superpowers/plans/2026-05-21-activity-timeline-plan-2a-offer-events.md
+++ b/docs/superpowers/plans/2026-05-21-activity-timeline-plan-2a-offer-events.md
@@ -1,0 +1,636 @@
+# Activity Timeline — Plan 2a: Offer Events
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every offer creation and offer status change writes an `activity_log` row through the canonical `log_activity()` writer, so offer events appear on the requisition Activity tab.
+
+**Architecture:** Plan 1 shipped `log_activity()` (canonical writer) and the `ActivityType` enum. This plan adds a `log_activity()` call at all 10 offer-creation sites and all 10 offer-status-change sites. Every offer status transition logs `ActivityType.OFFER_STATUS_CHANGED` (the specific transition lives in `description`/`details`) — there is no per-transition enum member. No schema migration.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy 2.0, pytest (in-memory SQLite), Loguru.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-activity-timeline-design.md` (build step 2, offers portion).
+
+**Branch:** Create `feat/activity-timeline-2a` off `feat/activity-timeline` (Plan 1, PR #120) — Plan 2a depends on `log_activity()` and `ActivityType` from Plan 1. If #120 has merged to `main`, branch off `main` instead.
+
+---
+
+## Conventions for every task
+
+**Canonical call shape — offer creation:**
+
+```python
+log_activity(
+    db,
+    activity_type=ActivityType.OFFER_CREATED,
+    requisition_id=<req id in scope>,
+    requirement_id=<requirement id in scope, or None>,
+    user_id=<user id in scope, or None>,
+    vendor_card_id=<vendor_card id in scope, or None>,
+    description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+    details={"offer_id": offer.id, "source": offer.source},
+)
+```
+
+**Canonical call shape — offer status change:**
+
+```python
+log_activity(
+    db,
+    activity_type=ActivityType.OFFER_STATUS_CHANGED,
+    requisition_id=offer.requisition_id,
+    user_id=user.id,
+    vendor_card_id=offer.vendor_card_id,
+    description=f"Offer {offer.vendor_name} status: {old_status} → {new_status}",
+    details={"offer_id": offer.id, "old_status": str(old_status), "new_status": str(new_status)},
+)
+```
+
+**Rules for every task:**
+- The `log_activity` call goes **after** the offer row has an `id` (after `db.add` + `db.flush`, or after the existing `db.commit`) and **before** the function returns.
+- In loops, the call goes **inside** the loop, once per offer (Plan 2a does not aggregate — offer events are individually meaningful).
+- If a creation site has no per-iteration `db.flush()`, add `db.flush()` after `db.add(...)` so `offer.id` is populated before `log_activity`.
+- Imports: add `from app.constants import ActivityType` and `from app.services.activity_service import log_activity` — **match each file's existing import style** (relative vs absolute, and depth). Verify whether the file already imports either name before adding.
+- **Verify every line number against the current file before editing** — this plan was written against a specific revision and the numbers will drift as tasks land commits. Use the quoted anchor code (function name + the `Offer(` / `offer.status =` line) to locate the site, not the raw line number.
+- TDD: write the failing test first, run it, confirm it fails for the expected reason, then implement.
+- Tests run: `TESTING=1 PYTHONPATH=/root/availai pytest <file> -v --override-ini="addopts="`
+- Loguru not print; Ruff clean; follow existing patterns.
+- Each task ends in its own commit. Do not push or open a PR until the plan owner approves.
+
+**Helper used by every test** — assert an activity row exists:
+
+```python
+from app.models import ActivityLog
+
+
+def _activity_rows(db, requisition_id, activity_type):
+    return (
+        db.query(ActivityLog)
+        .filter(
+            ActivityLog.requisition_id == requisition_id,
+            ActivityLog.activity_type == activity_type,
+        )
+        .all()
+    )
+```
+
+Put this helper at the top of the new test file (Task 1 creates it; later tasks import or reuse it).
+
+---
+
+### Task 1: `offer_created` — router paths (`crm/offers.py`, `htmx_views.py add_offer`)
+
+Instrument the two single-offer router creation paths.
+
+**Sites:**
+- `app/routers/crm/offers.py` — `create_offer()`. `Offer(...)` ~line 349, `db.add` ~376, `db.commit` ~397. Scope: `db` (param), `user.id`, `req_id`, `payload.requirement_id`, `card.id` (vendor_card). Insert after the `db.commit()`.
+- `app/routers/htmx_views.py` — `add_offer()`. `Offer(...)` ~line 1970, `db.add` ~1997, `db.commit` ~1998. Scope: `db`, `user.id`, `req_id`, requirement id via `_safe_int(form.get("requirement_id"))`, no vendor_card. Insert after the `db.commit()`.
+
+**Files:**
+- Modify: `app/routers/crm/offers.py`
+- Modify: `app/routers/htmx_views.py`
+- Test: `tests/test_offer_activity_logging.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_offer_activity_logging.py`:
+
+```python
+"""test_offer_activity_logging.py — offer events write activity_log rows.
+
+Covers Plan 2a: offer_created at all 10 creation sites and offer_status_changed
+at all 10 status-change sites route through activity_service.log_activity().
+
+Called by: pytest
+Depends on: app/services/activity_service.py, app/constants.py, conftest.py
+"""
+
+from app.constants import ActivityType
+from app.models import ActivityLog
+
+
+def _activity_rows(db, requisition_id, activity_type):
+    return (
+        db.query(ActivityLog)
+        .filter(
+            ActivityLog.requisition_id == requisition_id,
+            ActivityLog.activity_type == activity_type,
+        )
+        .all()
+    )
+
+
+def test_create_offer_route_logs_offer_created(client, db_session, test_requisition, test_vendor_card):
+    """POST to the offer-create API writes an offer_created activity row."""
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED))
+    resp = client.post(
+        f"/api/requisitions/{test_requisition.id}/offers",
+        json={
+            "requirement_id": None,
+            "vendor_card_id": test_vendor_card.id,
+            "mpn": "LM317T",
+            "vendor_name": test_vendor_card.display_name,
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
+    assert len(rows) == before + 1
+```
+
+Before writing this test, **verify the offer-create API route and payload schema** in `app/routers/crm/offers.py` (`create_offer()` decorator + its Pydantic body model). Adjust the URL and JSON body to match the actual route and required fields. If `create_offer()` requires fields not shown, add the minimum to make the request valid. If the route cannot be driven cleanly via `client`, instead call `create_offer()`'s logic through the lower-level path and assert the row — but prefer the route.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py -v --override-ini="addopts="`
+Expected: FAIL — `assert len(rows) == before + 1` fails (no offer_created row written yet).
+
+- [ ] **Step 3: Instrument `create_offer()` in `app/routers/crm/offers.py`**
+
+Add the imports (match the file's style — it is `app/routers/crm/offers.py`, so 3-dot relative: `from ...constants import ActivityType`, `from ...services.activity_service import log_activity`). Then, immediately after the `db.commit()` near line 397 and before the function's return / side-effects, insert:
+
+```python
+        log_activity(
+            db,
+            activity_type=ActivityType.OFFER_CREATED,
+            requisition_id=offer.requisition_id,
+            requirement_id=offer.requirement_id,
+            user_id=user.id,
+            vendor_card_id=offer.vendor_card_id,
+            description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+            details={"offer_id": offer.id, "source": offer.source},
+        )
+        db.commit()
+```
+
+(The extra `db.commit()` persists the activity row; `log_activity` only flushes.)
+
+- [ ] **Step 4: Instrument `add_offer()` in `app/routers/htmx_views.py`**
+
+Add the imports (match `app/routers/htmx_views.py` style — 2-dot relative: `from ..constants import ActivityType`, `from ..services.activity_service import log_activity`; check whether `log_activity` is already imported from Plan 1's change to this file and reuse it). Immediately after the `db.commit()` near line 1998, insert:
+
+```python
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_CREATED,
+        requisition_id=offer.requisition_id,
+        requirement_id=offer.requirement_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+        details={"offer_id": offer.id, "source": offer.source},
+    )
+    db.commit()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py tests/test_offers_overhaul.py -v --override-ini="addopts="`
+Expected: PASS — new test passes; existing offer tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/routers/crm/offers.py app/routers/htmx_views.py tests/test_offer_activity_logging.py
+git commit -m "feat: log offer_created activity from offer-create router paths"
+```
+
+---
+
+### Task 2: `offer_created` — email-parsed and proactive-win offers
+
+Instrument the two service paths that create offers from parsed vendor email and proactive-match conversion. Both create offers **in a loop** — log once per offer, inside the loop, after `db.flush()`.
+
+**Sites:**
+- `app/email_service.py` — `_auto_create_offers_from_parse(vr, parsed, db)`. `Offer(...)` ~line 1066 inside a loop over draft offers, `db.add` ~1089, `db.flush` ~1090. Scope: `db`, `vr.requisition_id`, requirement id via `mpn_to_req_id.get(mpn_key)`, **no `user_id`** (function has no user param → pass `user_id=None`), no vendor_card on the offer.
+- `app/services/proactive_service.py` — `convert_proactive_to_win()`. `Offer(...)` ~line 457 inside a loop, `db.add` ~474, `db.flush` ~475. Scope: `db`, `user.id`, `req.id`, `requirement.id`, vendor_card via the cloned offer.
+
+**Files:**
+- Modify: `app/email_service.py`
+- Modify: `app/services/proactive_service.py`
+- Test: `tests/test_offer_activity_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_offer_activity_logging.py`:
+
+```python
+from app.services.activity_service import log_activity  # noqa: F401  (ensures import path valid)
+
+
+def test_email_parsed_offer_logs_offer_created(db_session, test_requisition, test_user):
+    """An offer auto-created from a parsed vendor email writes offer_created."""
+    from app.email_service import _auto_create_offers_from_parse
+    from app.models.offers import VendorResponse
+
+    vr = VendorResponse(
+        requisition_id=test_requisition.id,
+        from_email="vendor@example.com",
+        subject="RE: RFQ",
+        body_text="We can supply.",
+    )
+    db_session.add(vr)
+    db_session.flush()
+
+    parsed = {
+        "offers": [
+            {"vendor_name": "Vendor X", "mpn": "LM317T", "unit_price": 0.5, "qty_available": 100}
+        ]
+    }
+    _auto_create_offers_from_parse(vr, parsed, db_session)
+    db_session.commit()
+
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
+    assert len(rows) >= 1
+```
+
+Before writing, **verify**: the exact name and signature of the email-parsed offer-creation function in `app/email_service.py` (the dossier calls it `_auto_create_offers_from_parse(vr, parsed, db)` — confirm), the `VendorResponse` model's required non-nullable fields (adjust the constructor to satisfy them), and the shape of the `parsed` dict the function expects (read the function body). Fix the test to match reality. If the function cannot be unit-tested directly because of heavy dependencies, STOP and report NEEDS_CONTEXT.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py -k email_parsed -v --override-ini="addopts="`
+Expected: FAIL — no `offer_created` row.
+
+- [ ] **Step 3: Instrument the email-parsed loop in `app/email_service.py`**
+
+Add imports (file is `app/email_service.py`: `from .constants import ActivityType`, `from .services.activity_service import log_activity`). Inside the offer-creation loop, immediately after `db.flush()` (~line 1090) and still inside the loop, insert:
+
+```python
+            log_activity(
+                db,
+                activity_type=ActivityType.OFFER_CREATED,
+                requisition_id=offer.requisition_id,
+                requirement_id=offer.requirement_id,
+                user_id=None,
+                vendor_card_id=offer.vendor_card_id,
+                description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+                details={"offer_id": offer.id, "source": offer.source},
+            )
+```
+
+- [ ] **Step 4: Instrument the proactive-win loop in `app/services/proactive_service.py`**
+
+Add imports (file is `app/services/proactive_service.py`: `from ..constants import ActivityType`, `from .activity_service import log_activity`). Inside the loop, immediately after `db.flush()` (~line 475), insert (note the offer variable here is `new_offer`):
+
+```python
+            log_activity(
+                db,
+                activity_type=ActivityType.OFFER_CREATED,
+                requisition_id=new_offer.requisition_id,
+                requirement_id=new_offer.requirement_id,
+                user_id=user.id,
+                vendor_card_id=new_offer.vendor_card_id,
+                description=f"Offer added: {new_offer.vendor_name} — {new_offer.mpn}",
+                details={"offer_id": new_offer.id, "source": new_offer.source},
+            )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py tests/ -k "proactive or email_parse" -v --override-ini="addopts="`
+Expected: PASS — new test passes; existing proactive/email tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/email_service.py app/services/proactive_service.py tests/test_offer_activity_logging.py
+git commit -m "feat: log offer_created for email-parsed and proactive-win offers"
+```
+
+---
+
+### Task 3: `offer_created` — AI offer service (`save_parsed_offers`, `save_freeform_offers`)
+
+Both functions in `app/services/ai_offer_service.py` create offers in a loop. Same pattern as Task 2.
+
+**Sites:**
+- `save_parsed_offers()` — `Offer(...)` ~line 162 in a loop, `db.add` ~185, `db.flush` ~186. Scope: `db`, `user_id` (param), `requisition_id` (param), `req_id` (matched requirement), no vendor_card.
+- `save_freeform_offers()` — `Offer(...)` ~line 299 in a loop, `db.add` ~322, `db.flush` ~323. Scope: `db`, `user_id` (param), `requisition_id` (param), `req_id`, `card.id` (vendor_card).
+
+**Files:**
+- Modify: `app/services/ai_offer_service.py`
+- Test: `tests/test_offer_activity_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_offer_activity_logging.py`:
+
+```python
+def test_save_parsed_offers_logs_offer_created(db_session, test_requisition, test_user):
+    """save_parsed_offers writes one offer_created row per saved offer."""
+    from app.services.ai_offer_service import save_parsed_offers
+
+    save_parsed_offers(
+        db=db_session,
+        requisition_id=test_requisition.id,
+        user_id=test_user.id,
+        offers=_one_parsed_offer(),
+    )
+    db_session.commit()
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
+    assert len(rows) >= 1
+```
+
+Before writing, **verify** the exact signature of `save_parsed_offers` (param names and order — the dossier says `db, requisition_id, user_id, offers`; confirm) and the exact type each parsed offer must be (a Pydantic model? a dict? read the function — it iterates `offers` and reads `o.mpn`, `o.vendor_name`). Write a small `_one_parsed_offer()` helper in the test file that builds one valid parsed-offer object of the correct type. If `save_parsed_offers` needs a material-card lookup or other setup, provide the minimum. Adjust the test to the real signature.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py -k save_parsed -v --override-ini="addopts="`
+Expected: FAIL — no `offer_created` row.
+
+- [ ] **Step 3: Instrument both loops in `app/services/ai_offer_service.py`**
+
+Add imports (`from ..constants import ActivityType`, `from .activity_service import log_activity`). In **both** `save_parsed_offers()` and `save_freeform_offers()`, immediately after the per-offer `db.flush()` and still inside the loop, insert:
+
+```python
+            log_activity(
+                db,
+                activity_type=ActivityType.OFFER_CREATED,
+                requisition_id=offer.requisition_id,
+                requirement_id=offer.requirement_id,
+                user_id=user_id,
+                vendor_card_id=offer.vendor_card_id,
+                description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+                details={"offer_id": offer.id, "source": offer.source},
+            )
+```
+
+(`offer` is the loop variable in both functions; `user_id` is a parameter of both.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py tests/ -k "ai_offer or save_parsed or save_freeform" -v --override-ini="addopts="`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/ai_offer_service.py tests/test_offer_activity_logging.py
+git commit -m "feat: log offer_created from AI offer service (parsed + freeform)"
+```
+
+---
+
+### Task 4: `offer_created` — excess matching and requisition clone/duplicate
+
+Four loop-based service sites. Each creates offers without a per-iteration `db.flush()` — **add `db.flush()` after `db.add(...)`** so `offer.id` is set before `log_activity`.
+
+**Sites:**
+- `app/services/excess_service.py` — `apply_excess_list_to_requirements()`: `Offer(...)` ~line 405, `db.add` ~421 (nested loop). Scope: `db`, `user_id` (param), `req.requisition_id`, `req.id`, no vendor_card.
+- `app/services/excess_service.py` — `create_proactive_matches_for_excess()`: `Offer(...)` ~line 647, `db.add` ~663, `db.flush` ~664 (has flush). Scope: `db`, `user_id` (param), `req.requisition_id`, `req.id`, no vendor_card.
+- `app/routers/crm/clone.py` — `clone_requisition()`: `Offer(...)` ~line 73 (var `new_o`), `db.add` ~93, `db.commit` ~94. Scope: `db`, `user.id`, `new_req.id`, requirement id via `req_map.get(...)`, `o.vendor_card_id`.
+- `app/services/requisition_service.py` — `duplicate_requisition()`: `Offer(...)` ~line 136 (var `new_o`), `db.add` ~156, `safe_commit` ~158. Scope: `db`, `user_id` (param), `new_req.id`, requirement via `req_map.get(...)`, `o.vendor_card_id`.
+
+**Files:**
+- Modify: `app/services/excess_service.py`
+- Modify: `app/routers/crm/clone.py`
+- Modify: `app/services/requisition_service.py`
+- Test: `tests/test_offer_activity_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_offer_activity_logging.py`:
+
+```python
+def test_clone_requisition_logs_offer_created(db_session, test_requisition, test_user, test_offer):
+    """Cloning a requisition that has offers logs offer_created for each cloned offer."""
+    from app.services.requisition_service import duplicate_requisition
+
+    before = db_session.query(ActivityLog).filter(
+        ActivityLog.activity_type == ActivityType.OFFER_CREATED
+    ).count()
+    new_req = duplicate_requisition(db=db_session, source_req_id=test_requisition.id, user_id=test_user.id)
+    db_session.commit()
+    after = db_session.query(ActivityLog).filter(
+        ActivityLog.activity_type == ActivityType.OFFER_CREATED
+    ).count()
+    assert after > before
+    rows = _activity_rows(db_session, new_req.id, ActivityType.OFFER_CREATED)
+    assert len(rows) >= 1
+```
+
+Before writing, **verify**: the `duplicate_requisition` signature (the dossier says `db, source_req_id, user_id` — confirm param names), that the `test_offer` fixture's offer is attached to `test_requisition` (check `tests/conftest.py` ~line 384), and that cloning copies offers. Adjust the test to reality. If `duplicate_requisition` does not copy offers when none match, ensure `test_offer` is wired so the clone path runs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py -k clone_requisition -v --override-ini="addopts="`
+Expected: FAIL — no `offer_created` row for the cloned requisition.
+
+- [ ] **Step 3: Instrument the four sites**
+
+For each site, add the file's imports (`ActivityType` from constants, `log_activity` from activity_service — match each file's relative-import style). At each creation loop, ensure `db.flush()` runs after `db.add(...)` (add it where missing — sites in `excess_service.apply_excess_list_to_requirements`, `clone.py`, `requisition_service.py` lack a per-offer flush), then insert immediately after the flush, inside the loop:
+
+```python
+            db.flush()  # ensure offer.id is set (add only where no per-offer flush exists)
+            log_activity(
+                db,
+                activity_type=ActivityType.OFFER_CREATED,
+                requisition_id=<offer var>.requisition_id,
+                requirement_id=<offer var>.requirement_id,
+                user_id=<user.id or user_id>,
+                vendor_card_id=<offer var>.vendor_card_id,
+                description=f"Offer added: {<offer var>.vendor_name} — {<offer var>.mpn}",
+                details={"offer_id": <offer var>.id, "source": <offer var>.source},
+            )
+```
+
+Substitute the real loop variable per site: `offer` in `excess_service.py` (both functions), `new_o` in `clone.py` and `requisition_service.py`. Use `user_id` (the param) in the service functions and `user.id` in `clone.py`. Do **not** add a redundant `db.flush()` in `create_proactive_matches_for_excess()` — it already flushes per offer.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py tests/ -k "excess or clone or duplicate or requisition_service" -v --override-ini="addopts="`
+Expected: PASS — new test passes; existing excess/clone tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/excess_service.py app/routers/crm/clone.py app/services/requisition_service.py tests/test_offer_activity_logging.py
+git commit -m "feat: log offer_created from excess-match and requisition-clone paths"
+```
+
+---
+
+### Task 5: `offer_status_changed` — `crm/offers.py` (5 sites)
+
+Instrument the five offer-status mutations in `app/routers/crm/offers.py`. Every transition logs `ActivityType.OFFER_STATUS_CHANGED`.
+
+**Sites (all in `app/routers/crm/offers.py`):**
+- `approve_offer()` — `offer.status = OfferStatus.ACTIVE` ~line 623; `old_status` already captured ~621.
+- `reject_offer()` — `offer.status = OfferStatus.REJECTED` ~line 648; `old_status` already captured ~646.
+- `mark_offer_sold()` — `offer.status = OfferStatus.SOLD` ~line 677; `old_status` already captured ~675.
+- `promote_offer()` — `offer.status = OfferStatus.ACTIVE` ~line 984; **no `old_status` captured — add one** before the status line.
+- `reject_offer_t4_review()` — `offer.status = OfferStatus.REJECTED` ~line 1011; **no `old_status` — add one** before the status line.
+
+**Files:**
+- Modify: `app/routers/crm/offers.py`
+- Test: `tests/test_offer_activity_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_offer_activity_logging.py`:
+
+```python
+def test_approve_offer_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """Approving an offer writes an offer_status_changed activity row."""
+    # test_offer must be in pending_review for approve to be allowed
+    test_offer.status = "pending_review"
+    db_session.commit()
+    resp = client.post(f"/api/offers/{test_offer.id}/approve")
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == 1
+    assert "status:" in (rows[0].notes or "")
+```
+
+Before writing, **verify** the approve route path and method in `app/routers/crm/offers.py` (`approve_offer()` decorator), and that the `test_offer` fixture (`tests/conftest.py` ~line 384) belongs to `test_requisition`. Adjust URL/body to match. Confirm `record_changes`/transition validation will accept the `pending_review → active` move for the fixture offer.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py -k approve_offer -v --override-ini="addopts="`
+Expected: FAIL — no `offer_status_changed` row.
+
+- [ ] **Step 3: Instrument the five functions**
+
+Add imports if not already present (`from ...constants import ActivityType`, `from ...services.activity_service import log_activity`).
+
+For `promote_offer()` and `reject_offer_t4_review()`, **first add `old_status` capture** immediately before the `offer.status = ...` line:
+
+```python
+    old_status = offer.status
+```
+
+Then in **all five** functions, immediately after the `offer.status = <new>` assignment and before the function's `db.commit()`, insert:
+
+```python
+        log_activity(
+            db,
+            activity_type=ActivityType.OFFER_STATUS_CHANGED,
+            requisition_id=offer.requisition_id,
+            user_id=user.id,
+            vendor_card_id=offer.vendor_card_id,
+            description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+            details={
+                "offer_id": offer.id,
+                "old_status": str(old_status),
+                "new_status": str(offer.status),
+            },
+        )
+```
+
+(`offer.status` is the new value, already assigned. Indentation: match each function's body.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py tests/test_offers_overhaul.py tests/test_sprint2_offer_mgmt.py -v --override-ini="addopts="`
+Expected: PASS — new test passes; existing offer tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/routers/crm/offers.py tests/test_offer_activity_logging.py
+git commit -m "feat: log offer_status_changed from crm/offers.py status mutations"
+```
+
+---
+
+### Task 6: `offer_status_changed` — `htmx_views.py` (5 sites) + APP_MAP doc
+
+Instrument the five offer-status mutations in `app/routers/htmx_views.py`, then update the APP_MAP doc.
+
+**Sites (all in `app/routers/htmx_views.py`):**
+- `review_offer()` — one if/else: `offer.status = OfferStatus.APPROVED` (~1915) / `OfferStatus.REJECTED` (~1921), shared `db.commit()` ~1923. **No `old_status` — capture once before the if/else.** Log once after the if/else.
+- `mark_offer_sold_htmx()` — `offer.status = OfferStatus.SOLD` ~line 2173; `old_status` already captured ~2171.
+- `promote_offer_htmx()` — `offer.status = OfferStatus.ACTIVE` ~line 2227; **no `old_status` — add one.**
+- `reject_offer_htmx()` — `offer.status = OfferStatus.REJECTED` ~line 2253; **no `old_status` — add one.**
+
+Note: these are separate UI handlers; the `crm/offers.py` set (Task 5) are the JSON-API equivalents. Both code paths exist; instrument both — an action taken through either path must appear on the timeline. Do not attempt to consolidate the two implementations in this plan.
+
+**Files:**
+- Modify: `app/routers/htmx_views.py`
+- Modify: `docs/APP_MAP_INTERACTIONS.md`
+- Test: `tests/test_offer_activity_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_offer_activity_logging.py`:
+
+```python
+def test_review_offer_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """Approving an offer through the HTMX review handler logs offer_status_changed."""
+    test_offer.status = "pending_review"
+    db_session.commit()
+    resp = client.post(
+        f"/v2/partials/requisitions/{test_requisition.id}/offers/{test_offer.id}/review",
+        data={"action": "approve"},
+    )
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == 1
+```
+
+Before writing, **verify** the `review_offer()` route path, method, and form/query param name for the approve/reject action in `app/routers/htmx_views.py` (the dossier shows it branches on an `action` variable — confirm whether `action` comes from a form field, query param, or path). Adjust the request to match.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py -k review_offer_htmx -v --override-ini="addopts="`
+Expected: FAIL — no `offer_status_changed` row.
+
+- [ ] **Step 3: Instrument the four htmx handlers**
+
+Add imports if not already present (`from ..constants import ActivityType`, `from ..services.activity_service import log_activity` — reuse if Plan 1 already imported `log_activity` here).
+
+For `review_offer()`: add `old_status = offer.status` before the `if action == "approve":` branch; after the if/else block and before the shared `db.commit()`, insert one call:
+
+```python
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
+```
+
+For `mark_offer_sold_htmx()`, `promote_offer_htmx()`, `reject_offer_htmx()`: capture `old_status = offer.status` before the status assignment where it is missing (promote, reject; sold already has it), then insert the same `log_activity(...)` block (above) after the status assignment and before that handler's `db.commit()`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_offer_activity_logging.py -v --override-ini="addopts="`
+Expected: PASS — all tests in the file pass.
+
+- [ ] **Step 5: Update the APP_MAP doc**
+
+In `docs/APP_MAP_INTERACTIONS.md`, find the activity-logging section (the Plan 1 note about `log_activity()` / `get_requisition_activities()`). Add a sentence: offer creation and offer status changes now route through `activity_service.log_activity()` (`ActivityType.OFFER_CREATED` / `ActivityType.OFFER_STATUS_CHANGED`) so offer events appear on the requisition Activity tab. Match the doc's existing prose style; do not restructure.
+
+- [ ] **Step 6: Run the full offer + activity suite + lint, then commit**
+
+```bash
+TESTING=1 PYTHONPATH=/root/availai pytest tests/ -k "offer or activity" -v --override-ini="addopts="
+ruff check app/routers/crm/offers.py app/routers/htmx_views.py app/email_service.py app/services/proactive_service.py app/services/ai_offer_service.py app/services/excess_service.py app/routers/crm/clone.py app/services/requisition_service.py
+git add app/routers/htmx_views.py docs/APP_MAP_INTERACTIONS.md tests/test_offer_activity_logging.py
+git commit -m "feat: log offer_status_changed from htmx offer handlers"
+```
+
+Expected: all offer/activity-tagged tests pass; ruff reports no errors.
+
+---
+
+## Self-Review
+
+**Spec coverage (build step 2 — offers portion):**
+- `offer_created` at every creation site → Tasks 1-4 cover all 10 sites (the spec's 11th, `import_ai_offers`, does not exist in the codebase) ✓
+- `offer_status_changed` at every status mutation → Tasks 5-6 cover all 10 sites ✓
+- All writes route through the canonical `log_activity()` ✓
+- Tests alongside each task ✓
+
+**Placeholder scan:** Task 4's Step 3 uses `<offer var>` / `<user.id or user_id>` placeholders deliberately — the per-site substitution is spelled out in the sentence immediately after the code block (loop var: `offer` for excess, `new_o` for clone/duplicate; actor: `user_id` param in services, `user.id` in `clone.py`). Every other code step is complete.
+
+**Type consistency:** `log_activity()` is called with the exact keyword args from its Plan 1 signature (`db` positional; `activity_type`, `requisition_id`, `requirement_id`, `user_id`, `vendor_card_id`, `description`, `details` keyword). `ActivityType.OFFER_CREATED` / `ActivityType.OFFER_STATUS_CHANGED` are the Plan 1 enum members. `details` is a plain `dict` as the signature expects.
+
+**Scope:** Plan 2a is offers only. Tasks/assignment/archive/notes are Plan 2b. Sightings (with batch aggregation) are deferred to Plan 4 per the design decision of 2026-05-21. The `OfferStatus.APPROVED` vs `ACTIVE` inconsistency between the two approve paths is pre-existing and out of scope — `offer_status_changed` logs whatever transition actually occurred.
+
+**No migration:** confirmed — reuses existing `activity_log` columns.

--- a/docs/superpowers/plans/2026-05-21-activity-timeline-plan-2b-lifecycle-events.md
+++ b/docs/superpowers/plans/2026-05-21-activity-timeline-plan-2b-lifecycle-events.md
@@ -1,0 +1,493 @@
+# Activity Timeline — Plan 2b: Lifecycle Events
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Task completion, requisition assignment, requisition archive/unarchive, and sales-note edits each write an `activity_log` row through the canonical `log_activity()` writer, so these lifecycle events appear on the requisition Activity tab.
+
+**Architecture:** Continues build step 2 (the non-offer half; offers are Plan 2a). Adds `log_activity()` calls at task/assignment/archive/note mutation points. The two existing **manual** `ActivityLog` writes in `claim_requisition()` / `unclaim_requisition()` (raw `activity_type` strings, not enum) are migrated onto `log_activity()` + the `ActivityType` enum. One additive enum member, `REQ_UNARCHIVED`, is added (archive and unarchive are distinct timeline events). No schema migration.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLAlchemy 2.0, pytest (in-memory SQLite), Loguru.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-activity-timeline-design.md` (build step 2, non-offer portion). Sightings are deferred to Plan 4 (batch aggregation belongs with the curation layer) per the design decision of 2026-05-21.
+
+**Branch:** Create `feat/activity-timeline-2b` off `feat/activity-timeline-2a` (Plan 2a) — or off `main` if Plan 1 + 2a have merged.
+
+---
+
+## Conventions for every task
+
+**The canonical writer** — `log_activity()` in `app/services/activity_service.py`:
+`log_activity(db, *, activity_type, channel="system", requisition_id=None, requirement_id=None, user_id=None, company_id=None, vendor_card_id=None, vendor_contact_id=None, description=None, summary=None, occurred_at=None, details=None) -> ActivityLog`. It calls `db.flush()`, not `db.commit()` — the caller commits.
+
+**Rules for every task:**
+- Imports: add `from <...>constants import ActivityType` and `from <...>services.activity_service import log_activity` — **match each file's existing import style and depth**. Check whether either name is already imported before adding. **`app/routers/htmx_views.py` defines a route function literally named `log_activity`** — in that file, import the service as `from ..services.activity_service import log_activity as _log_activity` and call `_log_activity(...)`, OR use a function-local import; do NOT shadow the route function. Verify with `grep -n "def log_activity" app/routers/htmx_views.py`.
+- **Verify every function name, line number, and variable name against the current file before editing.** This plan's site list came from an automated survey that proved partly inaccurate during Plan 2a (wrong function names). Treat the names below as starting points: confirm with `grep`, and if a named function does not exist, find the real mutation point by searching for the field assignment (`task.status =`, `claimed_by_id`, `.status = RequisitionStatus.ARCHIVED`, `sale_notes =`). If a site genuinely cannot be found, report NEEDS_CONTEXT.
+- The `log_activity()` call goes **after** the mutation, and the enclosing handler's existing `db.commit()` persists it (`log_activity` only flushes). For bulk-`.update()` sites, see Task 4's pattern.
+- TDD: write the failing test first, run it, confirm it fails for the expected reason, then implement.
+- Tests run: `TESTING=1 PYTHONPATH=/root/availai pytest <file> -v --override-ini="addopts="`. A widespread failure set that also appears on a `git stash` baseline is pre-existing xdist test-pollution — report it, don't try to fix it.
+- Loguru not print; Ruff clean; follow existing patterns. Each task ends in its own commit. Do not push or open a PR until the plan owner approves.
+
+**Shared test helper** — Task 1 creates `tests/test_lifecycle_activity_logging.py` with this header + helper; later tasks append to the same file:
+
+```python
+"""test_lifecycle_activity_logging.py — lifecycle events write activity_log rows.
+
+Covers Plan 2b: task_completed, assignment_changed, req_archived/req_unarchived,
+and sales_note events route through activity_service.log_activity().
+
+Called by: pytest
+Depends on: app/services/activity_service.py, app/constants.py, conftest.py
+"""
+
+from app.constants import ActivityType
+from app.models import ActivityLog
+
+
+def _activity_rows(db, requisition_id, activity_type):
+    return (
+        db.query(ActivityLog)
+        .filter(
+            ActivityLog.requisition_id == requisition_id,
+            ActivityLog.activity_type == activity_type,
+        )
+        .all()
+    )
+```
+
+---
+
+### Task 1: `task_completed`
+
+When a requisition task is marked done, log a `task_completed` activity. There are two independent code paths (the route handler does **not** delegate to the service) — instrument both.
+
+**Sites (verify names/lines with `grep -n "def mark_task_done\|def complete_task\|TaskStatus.DONE\|status = .*DONE" app/routers/htmx_views.py app/services/task_service.py`):**
+- `app/routers/htmx_views.py` — `mark_task_done()`: sets `task.status = TaskStatus.DONE` (~line 9628). In scope: `db`, `user.id`, `task.requisition_id`, `task.requirement_id`.
+- `app/services/task_service.py` — `complete_task()`: sets the same (~line 194). In scope: `db`, `user_id` (param — verify), `task.requisition_id`, `task.requirement_id`.
+
+Do **not** instrument `reopen_task()` — reopening is not a completion event.
+
+**Files:**
+- Modify: `app/routers/htmx_views.py`
+- Modify: `app/services/task_service.py`
+- Test: `tests/test_lifecycle_activity_logging.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_lifecycle_activity_logging.py` with the header + `_activity_rows` helper shown in the Conventions section, then append:
+
+```python
+def test_complete_task_logs_task_completed(db_session, test_requisition, test_user):
+    """Completing a task writes a task_completed activity row on its requisition."""
+    from app.models import RequisitionTask  # verify the model name/location
+    from app.services.task_service import complete_task
+
+    task = RequisitionTask(
+        requisition_id=test_requisition.id,
+        title="Follow up with vendor",
+        created_by=test_user.id,
+    )
+    db_session.add(task)
+    db_session.flush()
+
+    complete_task(db=db_session, task_id=task.id, user_id=test_user.id)
+    db_session.commit()
+
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.TASK_COMPLETED)
+    assert len(rows) == 1
+```
+
+Before writing, **verify**: the task model's real class name and module (`grep -rn "class .*Task" app/models/`), its required non-nullable fields (adjust the constructor), and the real signature of `complete_task()` (param names/order). Rewrite the test to match. If `complete_task` requires the user to be the task assignee, set `assigned_to_id=test_user.id` on the task.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py -v --override-ini="addopts="`
+Expected: FAIL — `assert len(rows) == 1` fails (no `task_completed` row).
+
+- [ ] **Step 3: Instrument `complete_task()` in `app/services/task_service.py`**
+
+Add imports (`from ..constants import ActivityType`, `from .activity_service import log_activity` — match file style). Immediately after the `task.status = ...DONE` assignment (and `completed_at` set), before the function's commit/return, insert:
+
+```python
+    log_activity(
+        db,
+        activity_type=ActivityType.TASK_COMPLETED,
+        requisition_id=task.requisition_id,
+        requirement_id=task.requirement_id,
+        user_id=user_id,
+        description=f"Task completed: {task.title}",
+        details={"task_id": task.id},
+    )
+```
+
+Match indentation; use the real actor variable (`user_id` or `user.id`) and the real title attribute.
+
+- [ ] **Step 4: Instrument `mark_task_done()` in `app/routers/htmx_views.py`**
+
+Add imports — use the `log_activity as _log_activity` alias (or a function-local import) because `htmx_views.py` has a route named `log_activity`. After `task.status = ...DONE`, before `db.commit()`, insert the same call (using `_log_activity`, `user.id`):
+
+```python
+    _log_activity(
+        db,
+        activity_type=ActivityType.TASK_COMPLETED,
+        requisition_id=task.requisition_id,
+        requirement_id=task.requirement_id,
+        user_id=user.id,
+        description=f"Task completed: {task.title}",
+        details={"task_id": task.id},
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py tests/test_task_service.py -v --override-ini="addopts="`
+Expected: PASS — new test passes; existing task tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/routers/htmx_views.py app/services/task_service.py tests/test_lifecycle_activity_logging.py
+git commit -m "feat: log task_completed activity on task completion"
+```
+
+---
+
+### Task 2: `assignment_changed` — migrate claim/unclaim + add batch assign
+
+`claim_requisition()` and `unclaim_requisition()` in `app/services/requirement_status.py` already write `ActivityLog` rows **directly**, with raw `activity_type` strings (`"requisition_claimed"` / `"requisition_unclaimed"`) that are not in the `ActivityType` enum. Migrate both onto `log_activity()` + `ActivityType.ASSIGNMENT_CHANGED`, with the claim/unclaim direction in `description`/`details`. Then add coverage to `batch_assign()`.
+
+**Sites (verify with `grep -n "def claim_requisition\|def unclaim_requisition\|def batch_assign\|claimed_by_id\|activity_type=" app/services/requirement_status.py app/routers/requisitions/core.py`):**
+- `app/services/requirement_status.py` — `claim_requisition()`: sets `claimed_by_id`; has a manual `ActivityLog(...)` block (~lines 150-157). **Replace** that block with a `log_activity()` call.
+- `app/services/requirement_status.py` — `unclaim_requisition()`: sets `claimed_by_id=None`; has a manual `ActivityLog(...)` block (~lines 175-182). **Replace** it.
+- `app/routers/requisitions/core.py` — `batch_assign()`: does a bulk `.update({"claimed_by_id": ...})`. **No rows are loaded.** Before the `.update()`, capture the affected requisition ids with a lightweight `SELECT` (`ids = [r.id for r in q.with_entities(Requisition.id).all()]` — adapt to the query variable in scope), run the existing `.update()`, then loop `log_activity()` per id.
+
+**Files:**
+- Modify: `app/services/requirement_status.py`
+- Modify: `app/routers/requisitions/core.py`
+- Test: `tests/test_lifecycle_activity_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_lifecycle_activity_logging.py`:
+
+```python
+def test_claim_requisition_logs_assignment_changed(db_session, test_requisition, test_user):
+    """Claiming a requisition writes an assignment_changed activity row."""
+    from app.services.requirement_status import claim_requisition
+
+    claim_requisition(test_requisition, test_user, db_session)
+    db_session.commit()
+
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.ASSIGNMENT_CHANGED)
+    assert len(rows) == 1
+    # the legacy raw-string activity_type must no longer be written
+    legacy = (
+        db_session.query(ActivityLog)
+        .filter(ActivityLog.activity_type == "requisition_claimed")
+        .all()
+    )
+    assert legacy == []
+```
+
+Before writing, **verify** the `claim_requisition()` signature (the survey says `claim_requisition(requisition, buyer, db)` — confirm param order/names) and adjust the call.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py -k assignment -v --override-ini="addopts="`
+Expected: FAIL — the row exists but with `activity_type="requisition_claimed"`, so the `ActivityType.ASSIGNMENT_CHANGED` query returns 0 and/or the `legacy == []` assertion fails.
+
+- [ ] **Step 3: Migrate `claim_requisition()` and `unclaim_requisition()`**
+
+Add imports (`from ..constants import ActivityType`, `from .activity_service import log_activity` — match file style). In `claim_requisition()`, **delete** the manual `ActivityLog(...)` + `db.add(...)` block and replace it with:
+
+```python
+    log_activity(
+        db,
+        activity_type=ActivityType.ASSIGNMENT_CHANGED,
+        requisition_id=locked.id,
+        user_id=buyer.id,
+        description=f"Requisition claimed by {buyer.name or buyer.email}",
+        details={"action": "claimed", "claimed_by_id": buyer.id},
+    )
+```
+
+(Use the real requisition variable — the survey shows `locked` — and the real actor param `buyer`.) In `unclaim_requisition()`, replace its manual block with:
+
+```python
+    log_activity(
+        db,
+        activity_type=ActivityType.ASSIGNMENT_CHANGED,
+        requisition_id=requisition.id,
+        user_id=<actor id in scope, or None>,
+        description="Requisition unclaimed",
+        details={"action": "unclaimed"},
+    )
+```
+
+Verify what actor variable `unclaim_requisition()` has in scope; if none, pass `user_id=None`.
+
+- [ ] **Step 4: Instrument `batch_assign()` in `app/routers/requisitions/core.py`**
+
+Add imports (`from ...constants import ActivityType`, `from ...services.activity_service import log_activity` — match style). Locate the bulk `.update({"claimed_by_id": ...})`. Immediately **before** the `.update()`, capture the target ids; **after** the `.update()`, loop:
+
+```python
+    target_ids = [row.id for row in q.with_entities(Requisition.id).all()]
+    count = q.update({"claimed_by_id": payload.owner_id}, synchronize_session=False)
+    for rid in target_ids:
+        log_activity(
+            db,
+            activity_type=ActivityType.ASSIGNMENT_CHANGED,
+            requisition_id=rid,
+            user_id=user.id,
+            description=f"Requisition assignment changed (batch) — owner {payload.owner_id}",
+            details={"action": "batch_assigned", "claimed_by_id": payload.owner_id},
+        )
+```
+
+Adapt `q`, `payload.owner_id`, and `user.id` to the real variable names in that handler. Keep the existing `.update()` call and its return value.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py tests/test_requisitions_core_coverage.py -v --override-ini="addopts="`
+Expected: PASS — new test passes; existing requisition tests still pass. If an existing test asserted the old `"requisition_claimed"` string, update that test to expect `ActivityType.ASSIGNMENT_CHANGED` (the migration intentionally changes the value — `grep -rn "requisition_claimed\|requisition_unclaimed" tests/` and fix any such assertions, listing them in the commit).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/requirement_status.py app/routers/requisitions/core.py tests/test_lifecycle_activity_logging.py
+git commit -m "feat: route claim/unclaim/batch-assign through log_activity (assignment_changed)"
+```
+
+---
+
+### Task 3: `req_archived` / `req_unarchived` — single-row + loop sites + enum member
+
+Add an additive `REQ_UNARCHIVED` enum member, then instrument the archive/unarchive sites that operate on loaded ORM rows.
+
+**Files:**
+- Modify: `app/constants.py`
+- Modify: `app/routers/requisitions/core.py`
+- Modify: `app/routers/htmx_views.py`
+- Test: `tests/test_lifecycle_activity_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_lifecycle_activity_logging.py`:
+
+```python
+def test_toggle_archive_logs_req_archived(client, db_session, test_requisition):
+    """Archiving a requisition writes a req_archived activity row."""
+    resp = client.put(f"/api/requisitions/{test_requisition.id}/archive")
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.REQ_ARCHIVED)
+    assert len(rows) == 1
+```
+
+Before writing, **verify** the archive route path/method (`grep -n "def toggle_archive" -B3 app/routers/requisitions/core.py`) and whether it is a true toggle (archives if active, unarchives if archived). Adjust the request. If a second request would unarchive, optionally add a follow-up assertion for `ActivityType.REQ_UNARCHIVED`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py -k archive -v --override-ini="addopts="`
+Expected: FAIL — `ImportError` for `ActivityType.REQ_UNARCHIVED` (not defined yet) or `assert len(rows) == 1` fails.
+
+- [ ] **Step 3: Add the `REQ_UNARCHIVED` enum member**
+
+In `app/constants.py`, in the `ActivityType` StrEnum, add after `REQ_ARCHIVED`:
+
+```python
+    REQ_UNARCHIVED = "req_unarchived"
+```
+
+(`req_unarchived` is 14 chars — fits the `activity_type` `String(20)` column.)
+
+- [ ] **Step 4: Instrument the loaded-row archive sites**
+
+For each site below, add imports (match file style; use the `_log_activity` alias in `htmx_views.py`). After the status mutation, before the handler's `db.commit()`, insert a `log_activity()` / `_log_activity()` call with `activity_type=ActivityType.REQ_ARCHIVED` when archiving and `ActivityType.REQ_UNARCHIVED` when unarchiving:
+
+```python
+        log_activity(
+            db,
+            activity_type=ActivityType.REQ_ARCHIVED,  # or REQ_UNARCHIVED
+            requisition_id=<req>.id,
+            user_id=user.id,
+            description="Requisition archived",  # or "Requisition unarchived"
+        )
+```
+
+Sites (verify each with grep):
+- `app/routers/requisitions/core.py` — `toggle_archive()`: it sets `RequisitionStatus.ARCHIVED` (and, if a toggle, `ACTIVE` on the other branch). Log `REQ_ARCHIVED` on the archive branch and `REQ_UNARCHIVED` on the unarchive branch.
+- `app/routers/htmx_views.py` — `archive_part()` (~line 9722, sets parent req to ARCHIVED): log `REQ_ARCHIVED`.
+- `app/routers/htmx_views.py` — the unarchive handler (~line 9743, sets `RequisitionStatus.ACTIVE`): log `REQ_UNARCHIVED`.
+- `app/routers/htmx_views.py` — `bulk_part_actions()` (~line 1567): this loops over loaded `reqs`. For each requisition whose status is set to `ARCHIVED` in the loop, add a `_log_activity(... REQ_ARCHIVED ...)` call inside the loop.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py tests/test_requisitions_core_coverage.py -v --override-ini="addopts="`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/constants.py app/routers/requisitions/core.py app/routers/htmx_views.py tests/test_lifecycle_activity_logging.py
+git commit -m "feat: log req_archived/req_unarchived from loaded-row archive paths"
+```
+
+---
+
+### Task 4: `req_archived` — bulk-update archive sites
+
+`bulk_archive()` and `batch_archive_by_ids()` in `app/routers/requisitions/core.py` archive via a bare `.update({"status": "archived"})` with no rows loaded. Capture the affected ids before the update, then log per id — same pattern as Task 2's `batch_assign`.
+
+**Files:**
+- Modify: `app/routers/requisitions/core.py`
+- Test: `tests/test_lifecycle_activity_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_lifecycle_activity_logging.py`:
+
+```python
+def test_batch_archive_logs_req_archived(client, db_session, test_requisition):
+    """Batch-archiving requisitions by id writes a req_archived row for each."""
+    resp = client.post("/api/requisitions/batch-archive", json={"ids": [test_requisition.id]})
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.REQ_ARCHIVED)
+    assert len(rows) == 1
+```
+
+Before writing, **verify** the batch-archive route — exact path, method, and request body shape (`grep -n "def batch_archive_by_ids\|def bulk_archive" -B3 app/routers/requisitions/core.py`). Pick whichever of the two endpoints is cleanly drivable via the test client and adjust the request to its real contract. (Both get instrumented in Step 3 regardless of which the test drives.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py -k batch_archive -v --override-ini="addopts="`
+Expected: FAIL — no `req_archived` row.
+
+- [ ] **Step 3: Instrument both bulk-archive handlers**
+
+In `bulk_archive()` and `batch_archive_by_ids()`, immediately before the bulk `.update()`, capture the ids being archived; after the `.update()`, loop `log_activity()`:
+
+```python
+    target_ids = [row.id for row in q.with_entities(Requisition.id).all()]
+    count = q.update({"status": RequisitionStatus.ARCHIVED}, synchronize_session=False)
+    for rid in target_ids:
+        log_activity(
+            db,
+            activity_type=ActivityType.REQ_ARCHIVED,
+            requisition_id=rid,
+            user_id=user.id,
+            description="Requisition archived (bulk)",
+        )
+```
+
+Adapt `q` and `user.id` to each handler's real variable names. Keep the existing `.update()` and its return value. (Imports were added to this file in Task 2/3; reuse them.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py tests/test_requisitions_core_coverage.py -v --override-ini="addopts="`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/routers/requisitions/core.py tests/test_lifecycle_activity_logging.py
+git commit -m "feat: log req_archived from bulk-archive endpoints"
+```
+
+---
+
+### Task 5: `sales_note` + APP_MAP doc
+
+When a requirement's `sale_notes` field is edited, log a `sales_note` activity. Two sites.
+
+**Sites (verify with `grep -n "def update_requirement\|def save_part_notes\|sale_notes" app/routers/requisitions/requirements.py app/routers/htmx_views.py`):**
+- `app/routers/requisitions/requirements.py` — `update_requirement()`: sets `r.sale_notes = ...` (~line 654). In scope: `db`, `user.id`, the requirement `r`, the requisition (resolved earlier in the handler). Log only when `sale_notes` actually changed.
+- `app/routers/htmx_views.py` — `save_part_notes()`: sets `req.sale_notes = ...` (~line 9572). `requisition_id` may need to be read off the requirement object — verify.
+
+**Files:**
+- Modify: `app/routers/requisitions/requirements.py`
+- Modify: `app/routers/htmx_views.py`
+- Modify: `docs/APP_MAP_INTERACTIONS.md`
+- Test: `tests/test_lifecycle_activity_logging.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_lifecycle_activity_logging.py`:
+
+```python
+def test_save_part_notes_logs_sales_note(client, db_session, test_requisition):
+    """Editing a requirement's sale notes writes a sales_note activity row."""
+    requirement = test_requisition.requirements[0]
+    resp = client.patch(
+        f"/v2/partials/parts/{requirement.id}/notes",
+        data={"sale_notes": "Customer wants expedited quote"},
+    )
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.SALES_NOTE)
+    assert len(rows) == 1
+```
+
+Before writing, **verify** the `save_part_notes()` route path/method and form field name, and how the `test_requisition` fixture exposes its requirement(s). Adjust to match.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py -k sales_note -v --override-ini="addopts="`
+Expected: FAIL — no `sales_note` row.
+
+- [ ] **Step 3: Instrument both note-edit handlers**
+
+In each handler, after the `sale_notes` assignment and before `db.commit()`, insert (guarding so it only logs when the note actually changed — capture the prior value first):
+
+```python
+        log_activity(
+            db,
+            activity_type=ActivityType.SALES_NOTE,
+            requisition_id=<requisition id in scope>,
+            requirement_id=<requirement id>,
+            user_id=user.id,
+            description="Sales note updated",
+            details={"requirement_id": <requirement id>},
+        )
+```
+
+In `htmx_views.py`, use the `_log_activity` alias. Resolve `requisition_id` from the requirement object where it is not directly in scope. Only log when the new `sale_notes` value differs from the old one (skip no-op saves).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_lifecycle_activity_logging.py -v --override-ini="addopts="`
+Expected: PASS — all tests in the file pass.
+
+- [ ] **Step 5: Update the APP_MAP doc**
+
+In `docs/APP_MAP_INTERACTIONS.md`, extend the activity-logging note: task completion, requisition assignment (claim/unclaim/batch), archive/unarchive, and sales-note edits now route through `activity_service.log_activity()` (`ActivityType.TASK_COMPLETED`, `ASSIGNMENT_CHANGED`, `REQ_ARCHIVED`/`REQ_UNARCHIVED`, `SALES_NOTE`). Match the doc's existing style.
+
+- [ ] **Step 6: Run the full lifecycle + activity suite + lint, then commit**
+
+```bash
+TESTING=1 PYTHONPATH=/root/availai pytest tests/ -k "activity or lifecycle or task or archive" -v --override-ini="addopts="
+ruff check app/constants.py app/routers/requisitions/core.py app/routers/requisitions/requirements.py app/routers/htmx_views.py app/services/task_service.py app/services/requirement_status.py
+git add app/routers/requisitions/requirements.py app/routers/htmx_views.py docs/APP_MAP_INTERACTIONS.md tests/test_lifecycle_activity_logging.py
+git commit -m "feat: log sales_note activity on requirement note edits"
+```
+
+Expected: lifecycle/activity-tagged tests pass; ruff clean. (Pre-existing xdist pollution failures, if any, are out of scope — confirm against a baseline.)
+
+---
+
+## Self-Review
+
+**Spec coverage (build step 2 — non-offer portion):**
+- `task_completed` → Task 1 (both the route and service paths) ✓
+- `assignment_changed` → Task 2 (claim + unclaim migrated off raw strings; batch_assign added) ✓
+- `req_archived` / `req_unarchived` → Tasks 3-4 (loaded-row sites + bulk-update sites) ✓
+- `sales_note` → Task 5 ✓
+- `sighting_added` → intentionally deferred to Plan 4 (batch aggregation belongs with the curation layer) ✓
+- `offer_created` / `offer_status_changed` → Plan 2a ✓
+
+**Enum extension:** This plan adds one member, `REQ_UNARCHIVED`, to the `ActivityType` enum (Task 3). The spec's canonical list named only `req_archived`; archive and unarchive are genuinely distinct timeline events, so this is a deliberate additive extension (a new string member, no schema change — `req_unarchived` fits the existing `String(20)` column). Flagged here so it is a recorded decision, not silent drift.
+
+**Placeholder scan:** Task 2's `batch_assign` and Task 4's bulk-archive code blocks, and Task 3's archive snippet, use `<...>` placeholders for per-site variable names — each is resolved in the sentence immediately after the block (real query variable, real actor, real id attribute). Every other code step is complete.
+
+**Type consistency:** All calls use the Plan 1 `log_activity()` keyword signature. `ActivityType` members referenced: `TASK_COMPLETED`, `ASSIGNMENT_CHANGED`, `REQ_ARCHIVED`, `SALES_NOTE` (existing) and `REQ_UNARCHIVED` (added in Task 3 before first use in Task 3 Step 4).
+
+**Migration risk:** Task 2 changes the `activity_type` value written by claim/unclaim from `"requisition_claimed"`/`"requisition_unclaimed"` to `"assignment_changed"`. Any existing test or display code keyed on the old strings must be updated — Task 2 Step 5 explicitly greps for and fixes such tests. The DB is intentionally empty (no historical rows to migrate).
+
+**No schema migration:** confirmed — reuses existing `activity_log` columns; the only schema-adjacent change is an additive StrEnum member.

--- a/tests/test_offer_activity_logging.py
+++ b/tests/test_offer_activity_logging.py
@@ -116,3 +116,16 @@ def test_save_freeform_offers_logs_offer_created(db_session, test_requisition, t
     db_session.commit()
     rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
     assert len(rows) >= 1
+
+
+def test_clone_requisition_logs_offer_created(db_session, test_requisition, test_user, test_offer):
+    """Cloning a requisition that has offers logs offer_created per cloned offer."""
+    from app.services.requisition_service import clone_requisition
+
+    before = db_session.query(ActivityLog).filter(ActivityLog.activity_type == ActivityType.OFFER_CREATED).count()
+    new_req = clone_requisition(db=db_session, source_req=test_requisition, user_id=test_user.id)
+    db_session.commit()
+    after = db_session.query(ActivityLog).filter(ActivityLog.activity_type == ActivityType.OFFER_CREATED).count()
+    assert after > before
+    rows = _activity_rows(db_session, new_req.id, ActivityType.OFFER_CREATED)
+    assert len(rows) >= 1

--- a/tests/test_offer_activity_logging.py
+++ b/tests/test_offer_activity_logging.py
@@ -140,6 +140,118 @@ def test_approve_offer_logs_status_changed(client, db_session, test_requisition,
     rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
     assert len(rows) == 1
     assert "status:" in (rows[0].notes or "")
+    assert rows[0].details["old_status"] == "pending_review"
+    assert rows[0].details["new_status"] == "active"
+    assert rows[0].details["offer_id"] == test_offer.id
+
+
+def test_add_offer_htmx_logs_offer_created(client, db_session, test_requisition):
+    """The add-offer HTMX route writes exactly one offer_created activity row."""
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED))
+    resp = client.post(
+        f"/v2/partials/requisitions/{test_requisition.id}/add-offer",
+        data={"vendor_name": "Arrow Electronics", "mpn": "LM317T"},
+    )
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
+    assert len(rows) == before + 1
+
+
+def test_reject_offer_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """PUT /api/offers/{id}/reject writes one offer_status_changed activity row."""
+    test_offer.status = "pending_review"
+    db_session.commit()
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
+    resp = client.put(f"/api/offers/{test_offer.id}/reject")
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == before + 1
+
+
+def test_mark_offer_sold_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """PATCH /api/offers/{id}/mark-sold writes one offer_status_changed activity row."""
+    test_offer.status = "active"
+    db_session.commit()
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
+    resp = client.patch(f"/api/offers/{test_offer.id}/mark-sold")
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == before + 1
+
+
+def test_promote_offer_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """POST /api/offers/{id}/promote writes one offer_status_changed row with a real
+    status change."""
+    test_offer.status = "pending_review"
+    test_offer.evidence_tier = "T4"
+    db_session.commit()
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
+    resp = client.post(f"/api/offers/{test_offer.id}/promote")
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == before + 1
+    assert rows[0].details["old_status"] != rows[0].details["new_status"]
+
+
+def test_reject_offer_t4_review_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """POST /api/offers/{id}/reject (T4 review) writes one offer_status_changed activity
+    row."""
+    test_offer.status = "pending_review"
+    db_session.commit()
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
+    resp = client.post(f"/api/offers/{test_offer.id}/reject")
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == before + 1
+
+
+def test_review_offer_htmx_reject_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """The HTMX review handler with action=reject logs one offer_status_changed row."""
+    test_offer.status = "pending_review"
+    db_session.commit()
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
+    resp = client.post(
+        f"/v2/partials/requisitions/{test_requisition.id}/offers/{test_offer.id}/review",
+        data={"action": "reject"},
+    )
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == before + 1
+
+
+def test_mark_offer_sold_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """The mark-sold HTMX handler logs one offer_status_changed row."""
+    test_offer.status = "active"
+    db_session.commit()
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
+    resp = client.post(
+        f"/v2/partials/requisitions/{test_requisition.id}/offers/{test_offer.id}/mark-sold",
+    )
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == before + 1
+
+
+def test_promote_offer_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """The promote-offer HTMX handler logs one offer_status_changed row."""
+    test_offer.status = "pending_review"
+    db_session.commit()
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
+    resp = client.post(f"/v2/partials/offers/{test_offer.id}/promote")
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == before + 1
+
+
+def test_reject_offer_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """The reject-offer HTMX handler logs one offer_status_changed row."""
+    test_offer.status = "pending_review"
+    db_session.commit()
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
+    resp = client.post(f"/v2/partials/offers/{test_offer.id}/reject")
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == before + 1
 
 
 def test_review_offer_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):

--- a/tests/test_offer_activity_logging.py
+++ b/tests/test_offer_activity_logging.py
@@ -129,3 +129,14 @@ def test_clone_requisition_logs_offer_created(db_session, test_requisition, test
     assert after > before
     rows = _activity_rows(db_session, new_req.id, ActivityType.OFFER_CREATED)
     assert len(rows) >= 1
+
+
+def test_approve_offer_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """Approving an offer via the API writes an offer_status_changed activity row."""
+    test_offer.status = "pending_review"
+    db_session.commit()
+    resp = client.put(f"/api/offers/{test_offer.id}/approve")
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) == 1
+    assert "status:" in (rows[0].notes or "")

--- a/tests/test_offer_activity_logging.py
+++ b/tests/test_offer_activity_logging.py
@@ -1,0 +1,39 @@
+"""test_offer_activity_logging.py — offer events write activity_log rows.
+
+Covers Plan 2a: offer_created at all 10 creation sites and offer_status_changed
+at all 10 status-change sites route through activity_service.log_activity().
+
+Called by: pytest
+Depends on: app/services/activity_service.py, app/constants.py, conftest.py
+"""
+
+from app.constants import ActivityType
+from app.models import ActivityLog
+
+
+def _activity_rows(db, requisition_id, activity_type):
+    return (
+        db.query(ActivityLog)
+        .filter(
+            ActivityLog.requisition_id == requisition_id,
+            ActivityLog.activity_type == activity_type,
+        )
+        .all()
+    )
+
+
+def test_create_offer_route_logs_offer_created(client, db_session, test_requisition, test_vendor_card):
+    """POST to the offer-create API writes an offer_created activity row."""
+    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED))
+    resp = client.post(
+        f"/api/requisitions/{test_requisition.id}/offers",
+        json={
+            "requirement_id": None,
+            "vendor_card_id": test_vendor_card.id,
+            "mpn": "LM317T",
+            "vendor_name": test_vendor_card.display_name,
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
+    assert len(rows) == before + 1

--- a/tests/test_offer_activity_logging.py
+++ b/tests/test_offer_activity_logging.py
@@ -70,3 +70,49 @@ def test_email_parsed_offer_logs_offer_created(db_session, test_requisition):
 
     rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
     assert len(rows) >= 1
+
+
+def _one_parsed_offer():
+    """Return an offers list with one valid DraftOfferItem for the AI offer services."""
+    from app.schemas.ai import DraftOfferItem
+
+    return [
+        DraftOfferItem(
+            vendor_name="Arrow Electronics",
+            mpn="LM317T",
+            manufacturer="Texas Instruments",
+            qty_available=500,
+            unit_price=0.42,
+        )
+    ]
+
+
+def test_save_parsed_offers_logs_offer_created(db_session, test_requisition):
+    """save_parsed_offers writes one offer_created row per saved offer."""
+    from app.services.ai_offer_service import save_parsed_offers
+
+    save_parsed_offers(
+        db=db_session,
+        requisition_id=test_requisition.id,
+        response_id=None,
+        offers=_one_parsed_offer(),
+        user_id=None,
+    )
+    db_session.commit()
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
+    assert len(rows) >= 1
+
+
+def test_save_freeform_offers_logs_offer_created(db_session, test_requisition, test_user):
+    """save_freeform_offers writes one offer_created row per saved offer."""
+    from app.services.ai_offer_service import save_freeform_offers
+
+    save_freeform_offers(
+        db=db_session,
+        requisition_id=test_requisition.id,
+        offers=_one_parsed_offer(),
+        user_id=test_user.id,
+    )
+    db_session.commit()
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
+    assert len(rows) >= 1

--- a/tests/test_offer_activity_logging.py
+++ b/tests/test_offer_activity_logging.py
@@ -140,3 +140,16 @@ def test_approve_offer_logs_status_changed(client, db_session, test_requisition,
     rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
     assert len(rows) == 1
     assert "status:" in (rows[0].notes or "")
+
+
+def test_review_offer_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):
+    """Approving an offer through the HTMX review handler logs offer_status_changed."""
+    test_offer.status = "pending_review"
+    db_session.commit()
+    resp = client.post(
+        f"/v2/partials/requisitions/{test_requisition.id}/offers/{test_offer.id}/review",
+        data={"action": "approve"},
+    )
+    assert resp.status_code == 200, resp.text
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
+    assert len(rows) >= 1

--- a/tests/test_offer_activity_logging.py
+++ b/tests/test_offer_activity_logging.py
@@ -37,3 +37,36 @@ def test_create_offer_route_logs_offer_created(client, db_session, test_requisit
     assert resp.status_code in (200, 201), resp.text
     rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
     assert len(rows) == before + 1
+
+
+def test_email_parsed_offer_logs_offer_created(db_session, test_requisition):
+    """An offer auto-created from a parsed vendor email writes offer_created."""
+    from app.email_service import _auto_create_offers_from_parse
+    from app.models.offers import VendorResponse
+
+    vr = VendorResponse(
+        requisition_id=test_requisition.id,
+        vendor_name="Vendor X",
+        vendor_email="vendor@example.com",
+        subject="RE: RFQ",
+        body="We can supply.",
+        confidence=0.95,
+    )
+    db_session.add(vr)
+    db_session.flush()
+
+    parsed = {
+        "parts": [
+            {
+                "mpn": "LM317T",
+                "status": "quoted",
+                "unit_price": 0.5,
+                "qty_available": 100,
+            }
+        ]
+    }
+    _auto_create_offers_from_parse(vr, parsed, db_session)
+    db_session.commit()
+
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_CREATED)
+    assert len(rows) >= 1


### PR DESCRIPTION
## What & why

Plan 2a of the Activity-timeline rework (build step 2, offer portion). Wires every offer creation and offer status change through the canonical `log_activity()` writer so offer events appear on the requisition Activity tab.

**Stacked on #120** (Plan 1 — write path). Base is `feat/activity-timeline`; retarget to `main` once #120 merges. Merge order: #120 → this.

Plan: `docs/superpowers/plans/2026-05-21-activity-timeline-plan-2a-offer-events.md`.

## Changes (6 TDD tasks + review fixes, no schema migration)

- **`offer_created`** at all 10 creation sites — offer-create API, HTMX `add_offer`, email-parsed offers, proactive-to-win, AI offer service (parsed + freeform), excess matching (×2), requisition clone + duplicate.
- **`offer_status_changed`** at all 10 status-change sites — `crm/offers.py` (approve/reject/mark-sold/promote/reject-T4) and the 5 HTMX handlers. Every transition logs `OFFER_STATUS_CHANGED` with the `old → new` transition in `description`/`details`.
- Offer creation + activity logging are **atomic** — single transaction per site (flush → log → one commit); a logging failure rolls back the offer, no orphans.
- `htmx_views.py` imports the service as `_log_activity` (the file has a route function named `log_activity`).

## Testing

- `tests/test_offer_activity_logging.py` — **16 tests** covering creation and status-change paths, with precise `before + 1` row-count assertions and `details` payload checks.
- 30 offer+activity tests pass; `pre-commit run --all-files` clean.
- Reviewed by the pr-review-toolkit agents; the one real finding (a split-commit in the two offer-create router paths) was fixed before this PR.

## Scope / follow-ups

Plan 2b (task completion, assignment, archive/unarchive, sales notes) is written (`...-plan-2b-lifecycle-events.md`) and is the next PR. Sightings → Plan 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)