### PR TITLE
fix(backend): High-tier correctness — status enum + MPN normalization

### DIFF
--- a/app/routers/crm/companies.py
+++ b/app/routers/crm/companies.py
@@ -134,7 +134,7 @@ async def list_companies(
                 .join(Quote, Quote.requisition_id == Requisition.id)
                 .filter(
                     CustomerSite.company_id.in_(company_ids),
-                    Requisition.status == "won",
+                    Requisition.status == RequisitionStatus.WON,
                     Quote.created_at >= rev_cutoff,
                 )
                 .group_by(CustomerSite.company_id)

--- a/app/services/sourcing_leads.py
+++ b/app/services/sourcing_leads.py
@@ -31,6 +31,7 @@ from app.models.sourcing import Requirement, Sighting
 from app.models.sourcing_lead import LeadEvidence, LeadFeedbackEvent, SourcingLead
 from app.models.vendors import VendorCard
 from app.scoring import explain_lead
+from app.utils.normalization import normalize_mpn_key
 from app.vendor_utils import normalize_vendor_name
 
 BUYER_STATUSES = {
@@ -54,12 +55,6 @@ def _as_utc(dt: datetime | None) -> datetime | None:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
-
-
-def normalize_mpn(mpn: str | None) -> str:
-    if not mpn:
-        return ""
-    return mpn.upper().replace("-", "").replace("_", "").replace(" ", "").replace("/", "").replace(".", "")
 
 
 def _normalize_phone(phone: str | None) -> str:
@@ -356,8 +351,8 @@ def _match_type_for_parts(requested: str, matched: str, substitutes: list | None
     """
     if not requested or not matched:
         return "exact"
-    req_norm = normalize_mpn(requested)
-    match_norm = normalize_mpn(matched)
+    req_norm = normalize_mpn_key(requested)
+    match_norm = normalize_mpn_key(matched)
     if req_norm == match_norm:
         return "exact"
     if req_norm and match_norm and (req_norm in match_norm or match_norm in req_norm):
@@ -367,9 +362,9 @@ def _match_type_for_parts(requested: str, matched: str, substitutes: list | None
         sub_norms = set()
         for sub in substitutes:
             if isinstance(sub, str):
-                sub_norms.add(normalize_mpn(sub))
+                sub_norms.add(normalize_mpn_key(sub))
             elif isinstance(sub, dict):
-                sub_norms.add(normalize_mpn(sub.get("mpn") or sub.get("part_number") or ""))
+                sub_norms.add(normalize_mpn_key(sub.get("mpn") or sub.get("part_number") or ""))
         sub_norms.discard("")
         if match_norm in sub_norms:
             return "cross_ref"
@@ -420,7 +415,7 @@ def upsert_lead_from_sighting(db: Session, requirement: Requirement, sighting: S
     if not matched_part:
         matched_part = requested_part
 
-    matched_part_norm = normalize_mpn(matched_part) or matched_part.upper()
+    matched_part_norm = normalize_mpn_key(matched_part) or matched_part.lower()
     vendor_card = _find_vendor_card(db, vendor_normalized)
     source_reliability = _source_reliability(sighting.source_type, sighting.evidence_tier)
     freshness = _freshness_score(sighting.created_at)
@@ -768,7 +763,7 @@ def attach_lead_metadata_to_results(db: Session, results_by_requirement: dict[in
     for requirement_id, rows in results_by_requirement.items():
         for row in rows:
             vendor_norm = normalize_vendor_name((row.get("vendor_name") or "").strip()) or ""
-            part_norm = normalize_mpn((row.get("mpn_matched") or row.get("mpn") or "").strip()) or ""
+            part_norm = normalize_mpn_key((row.get("mpn_matched") or row.get("mpn") or "").strip()) or ""
             key = _lead_key(requirement_id, vendor_norm, part_norm)
             lead = by_key.get(key)
             if not lead:

--- a/tests/test_routers_crm.py
+++ b/tests/test_routers_crm.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from app.constants import RequisitionStatus
 from app.models import (
     Company,
     CustomerSite,
@@ -629,6 +630,40 @@ class TestCompaniesAdditional:
         match = [i for i in items if i["id"] == test_company.id]
         assert len(match) == 1
         assert match[0]["revenue_90d"] == 5000.0
+
+    def test_list_companies_revenue_90d_uses_status_enum(
+        self, client, db_session, test_company, test_customer_site, test_user
+    ):
+        """revenue_90d filter must use the RequisitionStatus.WON StrEnum constant, not a
+        raw 'won' string.
+
+        Constructing the row with the enum constant guards against the enum value
+        drifting from the literal.
+        """
+        req = Requisition(
+            name="REQ-WON-ENUM",
+            customer_site_id=test_customer_site.id,
+            status=RequisitionStatus.WON,
+            created_by=test_user.id,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(req)
+        db_session.flush()
+        q = Quote(
+            requisition_id=req.id,
+            customer_site_id=test_customer_site.id,
+            quote_number="WON-ENUM-001",
+            subtotal=4200.00,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(q)
+        db_session.commit()
+
+        resp = client.get("/api/companies")
+        assert resp.status_code == 200
+        match = [i for i in resp.json()["items"] if i["id"] == test_company.id]
+        assert len(match) == 1
+        assert match[0]["revenue_90d"] == 4200.0
 
     def test_list_companies_revenue_90d_zero_when_no_won(self, client, db_session, test_company):
         """Companies with no won quotes should have revenue_90d=0."""

--- a/tests/test_sourcing_leads_coverage.py
+++ b/tests/test_sourcing_leads_coverage.py
@@ -90,17 +90,18 @@ def vendor_card(db_session: Session) -> VendorCard:
 
 class TestUtilityFunctions:
     def test_normalize_mpn_basic(self):
-        from app.services.sourcing_leads import normalize_mpn
+        # sourcing_leads now delegates to the canonical normalize_mpn_key.
+        from app.utils.normalization import normalize_mpn_key
 
-        assert normalize_mpn("LM-317T") == "LM317T"
-        assert normalize_mpn("lm317t") == "LM317T"
-        assert normalize_mpn("LM 317T") == "LM317T"
+        assert normalize_mpn_key("LM-317T") == "lm317t"
+        assert normalize_mpn_key("lm317t") == "lm317t"
+        assert normalize_mpn_key("LM 317T") == "lm317t"
 
     def test_normalize_mpn_empty(self):
-        from app.services.sourcing_leads import normalize_mpn
+        from app.utils.normalization import normalize_mpn_key
 
-        assert normalize_mpn("") == ""
-        assert normalize_mpn(None) == ""
+        assert normalize_mpn_key("") == ""
+        assert normalize_mpn_key(None) == ""
 
     def test_clamp_within_bounds(self):
         from app.services.sourcing_leads import _clamp

--- a/tests/test_sourcing_leads_service.py
+++ b/tests/test_sourcing_leads_service.py
@@ -25,11 +25,11 @@ from app.services.sourcing_leads import (
     _source_reliability,
     append_lead_feedback,
     get_requisition_leads,
-    normalize_mpn,
     sync_leads_for_sightings,
     update_lead_status,
     upsert_lead_from_sighting,
 )
+from app.utils.normalization import normalize_mpn_key
 
 # ── Helpers ─────────────────────────────────────────────────────────
 
@@ -111,17 +111,20 @@ def _make_vendor_card(db: Session, name: str = "arrow electronics") -> VendorCar
 
 
 class TestNormalizeMpn:
+    """sourcing_leads now uses the canonical normalize_mpn_key (lowercase, strips all
+    non-alphanumeric) instead of a local re-implementation."""
+
     def test_normalizes_dashes_spaces(self):
-        assert normalize_mpn("LM-317 T") == "LM317T"
+        assert normalize_mpn_key("LM-317 T") == "lm317t"
 
     def test_normalizes_underscores_dots(self):
-        assert normalize_mpn("LM_317.T") == "LM317T"
+        assert normalize_mpn_key("LM_317.T") == "lm317t"
 
     def test_empty_string(self):
-        assert normalize_mpn("") == ""
+        assert normalize_mpn_key("") == ""
 
     def test_none(self):
-        assert normalize_mpn(None) == ""
+        assert normalize_mpn_key(None) == ""
 
 
 class TestClamp:


### PR DESCRIPTION
Resolves **HIGH-BE-6** and **HIGH-BE-8** from `CODE_REVIEW_NOTES.md`.

- **HIGH-BE-6** — `companies.py` compared `Requisition.status` to raw `"won"`; now `RequisitionStatus.WON`. + regression test.
- **HIGH-BE-8** — `sourcing_leads.py` defined its own `normalize_mpn`; replaced with canonical `normalize_mpn_key` at all call sites; tests updated.

**Assessed, not changed:** HIGH-BE-3 (blocking httpx) — real, but the fix also needs `eight_by_eight_jobs.py`; deferred. HIGH-DB-3 — not a bug (the insert loop already batches via one commit; ORM objects are mutated afterward).

286 affected tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)