### PR TITLE
fix(security): High-tier escaping — XSS, LIKE wildcards, asyncio.run

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -74,6 +74,7 @@ from ..services.freeform_parser_service import parse_freeform_rfq
 from ..services.status_machine import require_valid_transition
 from ..template_env import templates
 from ..utils.search_builder import SearchBuilder
+from ..utils.sql_helpers import escape_like
 from ._lookup_helpers import get_requisition_or_404, get_vendor_card_or_404
 from .auth import _password_login_enabled
 
@@ -367,9 +368,9 @@ async def requisitions_list_partial(
             select(Requirement.id).where(
                 Requirement.requisition_id == Requisition.id,
                 or_(
-                    Requirement.primary_mpn.ilike(safe),
-                    Requirement.customer_pn.ilike(safe),
-                    Requirement.substitutes_text.ilike(safe),
+                    Requirement.primary_mpn.ilike(safe, escape="\\"),
+                    Requirement.customer_pn.ilike(safe, escape="\\"),
+                    Requirement.substitutes_text.ilike(safe, escape="\\"),
                 ),
             )
         )
@@ -1129,9 +1130,7 @@ async def requisition_search_all(
     if not os.environ.get("TESTING"):
         requirement_ids = [r.id for r in requirements]
 
-        def _bg_search(req_ids: list[int]):
-            import asyncio
-
+        async def _bg_search(req_ids: list[int]):
             from app.database import SessionLocal
             from app.search_service import search_requirement as do_search
 
@@ -1141,7 +1140,7 @@ async def requisition_search_all(
                     try:
                         req_obj = bg_db.get(Requirement, rid)
                         if req_obj:
-                            asyncio.run(do_search(req_obj, bg_db))
+                            await do_search(req_obj, bg_db)
                     except Exception:
                         logger.warning("Manual search failed for requirement {}", rid, exc_info=True)
             finally:
@@ -3327,12 +3326,12 @@ async def vendors_list_partial(
         from sqlalchemy import Text, cast
 
         sb = SearchBuilder(q.strip())
-        term = f"%{q.strip()}%"
+        term = f"%{escape_like(q.strip())}%"
         query = query.filter(
             or_(
                 sb.ilike_filter(VendorCard.display_name, VendorCard.domain),
-                cast(VendorCard.brand_tags, Text).ilike(term),
-                cast(VendorCard.commodity_tags, Text).ilike(term),
+                cast(VendorCard.brand_tags, Text).ilike(term, escape="\\"),
+                cast(VendorCard.commodity_tags, Text).ilike(term, escape="\\"),
             )
         )
 
@@ -6921,8 +6920,8 @@ async def manufacturer_search(
 
     results = []
     if q.strip():
-        pattern = f"%{q.strip()}%"
-        by_name = db.query(Manufacturer).filter(Manufacturer.canonical_name.ilike(pattern)).limit(10).all()
+        pattern = f"%{escape_like(q.strip())}%"
+        by_name = db.query(Manufacturer).filter(Manufacturer.canonical_name.ilike(pattern, escape="\\")).limit(10).all()
         results = list(by_name)
         if len(results) < 10:
             seen_ids = {r.id for r in results}
@@ -6930,7 +6929,7 @@ async def manufacturer_search(
                 db.query(Manufacturer)
                 .filter(
                     Manufacturer.id.notin_(seen_ids),
-                    cast(Manufacturer.aliases, Text).ilike(pattern),
+                    cast(Manufacturer.aliases, Text).ilike(pattern, escape="\\"),
                 )
                 .limit(10 - len(results))
                 .all()

--- a/app/template_env.py
+++ b/app/template_env.py
@@ -137,7 +137,6 @@ def _sanitize_html_filter(value: str) -> str:
             "hr",
         },
         attributes={
-            "*": {"class"},
             "a": {"href", "title", "target"},
             "td": {"colspan", "rowspan", "width", "height"},
             "th": {"colspan", "rowspan", "width", "height"},

--- a/app/templates/htmx/partials/shared/_macros.html
+++ b/app/templates/htmx/partials/shared/_macros.html
@@ -147,15 +147,15 @@ Usage:
   {%- set italic_cls = ' opp-deal--computed' if source in ('computed', 'partial') else '' -%}
   {%- set partial_cls = ' opp-deal--partial' if source == 'partial' else '' -%}
   {%- if source == 'partial' -%}
-    {%- set title_attr = ' title="Floor estimate — ' ~ priced_count ~ ' of ' ~ requirement_count ~ ' parts priced"' -%}
+    {%- set title_text = 'Floor estimate — ' ~ priced_count ~ ' of ' ~ requirement_count ~ ' parts priced' -%}
   {%- elif source == 'computed' -%}
-    {%- set title_attr = ' title="Computed from target prices (all parts priced)"' -%}
+    {%- set title_text = 'Computed from target prices (all parts priced)' -%}
   {%- elif source == 'entered' -%}
-    {%- set title_attr = ' title="Entered by broker"' -%}
+    {%- set title_text = 'Entered by broker' -%}
   {%- else -%}
-    {%- set title_attr = '' -%}
+    {%- set title_text = '' -%}
   {%- endif -%}
-<span class="opp-deal opp-deal--tier-{{ tier }}{{ italic_cls }}{{ partial_cls }}"{{ title_attr|safe }}>{{ prefix }}${{ '{:,.0f}'.format(amount) }}</span>
+<span class="opp-deal opp-deal--tier-{{ tier }}{{ italic_cls }}{{ partial_cls }}"{% if title_text %} title="{{ title_text }}"{% endif %}>{{ prefix }}${{ '{:,.0f}'.format(amount) }}</span>
 {%- endif -%}
 {%- endmacro %}
 

--- a/tests/test_manufacturer_typeahead.py
+++ b/tests/test_manufacturer_typeahead.py
@@ -57,3 +57,37 @@ def test_add_empty_name_returns_error(client, db_session):
     resp = client.post("/v2/partials/manufacturers/add", data={"name": "   "})
     assert resp.status_code == 200
     assert "required" in resp.text.lower()
+
+
+def test_search_wildcard_percent_is_escaped(client, db_session):
+    """HIGH-SEC-3: a bare '%' in the search term must be treated as a
+    literal, not a SQL LIKE wildcard. Without escaping, q='%' would match
+    every manufacturer."""
+    db_session.add(Manufacturer(canonical_name="Texas Instruments"))
+    db_session.add(Manufacturer(canonical_name="Analog Devices"))
+    db_session.commit()
+    resp = client.get("/v2/partials/manufacturers/search?q=%25")  # %25 == '%'
+    assert resp.status_code == 200
+    # '%' is now literal — it matches neither manufacturer name.
+    assert "Texas Instruments" not in resp.text
+    assert "Analog Devices" not in resp.text
+
+
+def test_search_wildcard_underscore_is_escaped(client, db_session):
+    """HIGH-SEC-3: a bare '_' must be a literal, not a single-char wildcard."""
+    db_session.add(Manufacturer(canonical_name="ABC"))
+    db_session.commit()
+    resp = client.get("/v2/partials/manufacturers/search?q=A_C")
+    assert resp.status_code == 200
+    # '_' is literal — 'A_C' does not match 'ABC'.
+    assert "ABC" not in resp.text
+
+
+def test_search_literal_percent_in_name_matches(client, db_session):
+    """A manufacturer whose name actually contains '%' is still found when the user
+    searches for that literal '%'."""
+    db_session.add(Manufacturer(canonical_name="Discount 50% Co"))
+    db_session.commit()
+    resp = client.get("/v2/partials/manufacturers/search?q=50%25")  # '50%'
+    assert resp.status_code == 200
+    assert "Discount 50% Co" in resp.text

--- a/tests/test_opp_macros.py
+++ b/tests/test_opp_macros.py
@@ -67,6 +67,27 @@ def test_deal_value_partial_has_tilde_and_italic_and_tooltip():
     assert "3 of 5 parts priced" in html
 
 
+def test_deal_value_title_attr_is_escaped_not_safe():
+    """HIGH-SEC-1: the title tooltip must be rendered through Jinja2
+    autoescaping in the attribute context. A value containing HTML/quote
+    metacharacters (priced_count/requirement_count are normally ints, but
+    the macro must not trust them) must come out escaped — never raw.
+    """
+    html = render_macro(
+        '{{ deal_value(30000, "partial", priced_count=\'"><script>x</script>\', requirement_count=5) }}'
+    )
+    # The raw payload must not appear; the escaped form must.
+    assert "<script>x</script>" not in html
+    assert "&lt;script&gt;" in html
+    # The title attribute must still be present and well-formed.
+    assert 'title="Floor estimate' in html
+
+
+def test_deal_value_no_title_attr_for_unknown_source():
+    html = render_macro('{{ deal_value(500, "mystery") }}')
+    assert "title=" not in html
+
+
 # ── coverage_meter ────────────────────────────────────────────────────
 
 

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -265,12 +265,18 @@ class TestSanitizeHtmlNoStyle:
         assert "style=" not in result
         assert "text" in result
 
-    def test_class_attribute_preserved(self):
+    def test_class_attribute_stripped(self):
+        """Class is no longer allowed on arbitrary tags (HIGH-SEC-2): on sanitized
+        external email HTML it would let an attacker apply the app's own CSS classes.
+
+        The element text is still preserved.
+        """
         from app.template_env import _sanitize_html_filter
 
         html = '<span class="text-red-500">warning</span>'
         result = _sanitize_html_filter(html)
-        assert 'class="text-red-500"' in result
+        assert "class=" not in result
+        assert "warning" in result
 
     def test_empty_input(self):
         from app.template_env import _sanitize_html_filter

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -141,6 +141,59 @@ def test_sightings_template_responses_set_rendered_req_id():
 # the same commit as the source changes it locks in.
 
 
+def test_htmx_views_like_patterns_are_escaped():
+    """HIGH-SEC-3: every ILIKE/LIKE pattern built from a user-supplied
+    search term in htmx_views.py must escape LIKE wildcards.
+
+    Two enforced invariants:
+      1. No f-string that interpolates a bare `.strip()` term into a
+         `%...%` pattern (must go through escape_like / SearchBuilder.safe).
+      2. Every `.ilike(...)` / `.like(...)` call that takes a `%`-wrapped
+         pattern variable must pass an explicit `escape=` character so the
+         backslash escaping done by escape_like is actually honoured.
+    """
+    src = Path("app/routers/htmx_views.py").read_text()
+    lines = src.splitlines()
+    failures: list[str] = []
+
+    # Rule 1: forbid `f"%{<term>.strip()}%"` — unescaped wildcard injection.
+    bad_fstring = re.compile(r'f"%\{[^}]*\.strip\(\)\}%"')
+    for i, line in enumerate(lines, 1):
+        if bad_fstring.search(line):
+            failures.append(
+                f"htmx_views.py:{i} — f-string builds a LIKE pattern from a raw "
+                f".strip() term; wrap it in escape_like()."
+            )
+
+    # Rule 2: an .ilike(<var>) / .like(<var>) on a %-wrapped pattern must
+    # carry escape=. We only flag calls whose argument is a known
+    # escaped-pattern variable name.
+    escaped_pattern_vars = ("term", "pattern", "safe")
+    call_re = re.compile(r"\.i?like\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*([,)])")
+    for i, line in enumerate(lines, 1):
+        for m in call_re.finditer(line):
+            varname, after = m.group(1), m.group(2)
+            if varname not in escaped_pattern_vars:
+                continue
+            if after == ")":  # no further args → no escape= present
+                failures.append(
+                    f"htmx_views.py:{i} — .ilike({varname}) has no escape= argument; "
+                    f'use .ilike({varname}, escape="\\\\").'
+                )
+
+    assert not failures, "\n".join(failures)
+
+
+def test_no_asyncio_run_in_htmx_views():
+    """HIGH-BE-4: asyncio.run() must never appear in htmx_views.py — it
+    creates a fresh event loop and fails/blocks inside request or
+    background-task contexts. Use `await` on the coroutine instead.
+    """
+    src = Path("app/routers/htmx_views.py").read_text()
+    offenders = [i for i, line in enumerate(src.splitlines(), 1) if "asyncio.run(" in line]
+    assert not offenders, f"asyncio.run( found in htmx_views.py at line(s): {offenders}"
+
+
 def test_standalone_pages_register_csrf_listener():
     """Standalone page templates that issue mutating HTMX requests but do not
     unconditionally load htmx_app.js must register their own htmx:configRequest CSRF


### PR DESCRIPTION
Resolves **HIGH-SEC-1/2/3** and **HIGH-BE-4** from `CODE_REVIEW_NOTES.md`.

- **HIGH-SEC-1** — the `deal_value` macro built a `title=""` attribute via `{{ title_attr|safe }}`, bypassing autoescaping (XSS vector). Rebuilt to render a `title_text` value through normal Jinja2 escaping.
- **HIGH-SEC-2** — removed `class` from the nh3 sanitizer's wildcard (`*`) attribute allowlist; `class` on arbitrary tags is an abuse vector and no `sanitize_html` caller needs it.
- **HIGH-SEC-3** — `htmx_views.py` built ILIKE patterns as `f"%{q}%"` with no LIKE-wildcard escaping. All pattern sites now use the canonical `escape_like()` helper with `escape="\\"`; the missing `escape="\\"` was also added to three `SearchBuilder`-derived `.ilike()` calls.
- **HIGH-BE-4** — the last `asyncio.run()` in `htmx_views.py`: `_bg_search` is now `async` and awaits the coroutine directly.

Tests: title-escaping macro cases, LIKE-escaping behavior tests, and two `test_static_analysis` grep invariants. 120 affected tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)