### PR TITLE
test: nightly coverage improvement — bring all modules to 85%+

### DIFF
--- a/tests/test_crm_service_nightly_coverage.py
+++ b/tests/test_crm_service_nightly_coverage.py
@@ -1,0 +1,82 @@
+"""test_crm_service_nightly_coverage.py — Tests for app/services/crm_service.py.
+
+Covers: next_quote_number (first number, sequential increment, ValueError on bad suffix).
+
+Called by: pytest
+Depends on: app/services/crm_service.py, conftest.py
+"""
+
+import os
+from datetime import datetime, timezone
+
+from freezegun import freeze_time
+
+os.environ["TESTING"] = "1"
+
+from app.models import Quote
+from app.services.crm_service import next_quote_number
+
+
+class TestNextQuoteNumber:
+    def test_first_quote_in_year(self, db_session):
+        """No existing quotes → Q-YYYY-0001."""
+        result = next_quote_number(db_session)
+        year = datetime.now(timezone.utc).year
+        assert result == f"Q-{year}-0001"
+
+    def test_increments_from_last(self, db_session, test_user, test_requisition):
+        """Existing quote → next number is last + 1."""
+        year = datetime.now(timezone.utc).year
+        q = Quote(
+            requisition_id=test_requisition.id,
+            quote_number=f"Q-{year}-0005",
+            created_by_id=test_user.id,
+        )
+        db_session.add(q)
+        db_session.commit()
+
+        result = next_quote_number(db_session)
+        assert result == f"Q-{year}-0006"
+
+    def test_zero_pads_to_4_digits(self, db_session, test_user, test_requisition):
+        """Zero-pads sequence to 4 digits."""
+        year = datetime.now(timezone.utc).year
+        q = Quote(
+            requisition_id=test_requisition.id,
+            quote_number=f"Q-{year}-0099",
+            created_by_id=test_user.id,
+        )
+        db_session.add(q)
+        db_session.commit()
+
+        result = next_quote_number(db_session)
+        assert result == f"Q-{year}-0100"
+
+    def test_bad_suffix_falls_back_to_1(self, db_session, test_user, test_requisition):
+        """When last quote_number suffix is non-numeric, falls back to seq=1."""
+        year = datetime.now(timezone.utc).year
+        q = Quote(
+            requisition_id=test_requisition.id,
+            quote_number=f"Q-{year}-XXXX",
+            created_by_id=test_user.id,
+        )
+        db_session.add(q)
+        db_session.commit()
+
+        result = next_quote_number(db_session)
+        assert result == f"Q-{year}-0001"
+
+    def test_ignores_other_year_quotes(self, db_session, test_user, test_requisition):
+        """Quotes from a different year don't affect this year's numbering."""
+        with freeze_time("2023-06-15"):
+            old = Quote(
+                requisition_id=test_requisition.id,
+                quote_number="Q-2023-0099",
+                created_by_id=test_user.id,
+            )
+            db_session.add(old)
+            db_session.commit()
+
+        result = next_quote_number(db_session)
+        year = datetime.now(timezone.utc).year
+        assert result == f"Q-{year}-0001"

--- a/tests/test_dependencies_nightly_coverage.py
+++ b/tests/test_dependencies_nightly_coverage.py
@@ -1,0 +1,321 @@
+"""test_dependencies_nightly_coverage.py — Extra coverage for app/dependencies.py.
+
+Covers: require_user (agent key, deactivated user), require_admin, require_settings_access,
+require_buyer (non-buyer role), get_req_for_user (sales filter), get_quote_for_user.
+
+Called by: pytest
+Depends on: app/dependencies.py, conftest.py
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+os.environ["TESTING"] = "1"
+
+from app.dependencies import (
+    get_quote_for_user,
+    get_req_for_user,
+    get_user,
+    require_admin,
+    require_buyer,
+    require_settings_access,
+    require_user,
+)
+from app.models import Quote, Requisition, User
+
+
+def _mock_request(session_data=None, headers=None):
+    req = MagicMock()
+    # Use a MagicMock for session so .clear() is trackable
+    mock_session = MagicMock()
+    mock_session.get = (session_data or {}).get
+    req.session = mock_session
+    req.headers = headers or {}
+    req.method = "GET"
+    req.url = MagicMock()
+    req.url.path = "/test"
+    return req
+
+
+# ── get_user exception branch ─────────────────────────────────────────
+
+
+class TestGetUserExceptionBranch:
+    def test_clears_session_on_db_exception(self, db_session):
+        """When db.get raises, session is cleared and None returned."""
+        request = _mock_request({"user_id": 999})
+        bad_db = MagicMock(spec=Session)
+        bad_db.get.side_effect = Exception("DB connection lost")
+        result = get_user(request, bad_db)
+        assert result is None
+        request.session.clear.assert_called_once()
+
+
+# ── require_user branches ─────────────────────────────────────────────
+
+
+class TestRequireUserBranches:
+    def test_raises_401_when_no_user_no_agent_key(self, db_session):
+        request = _mock_request({})
+        with pytest.raises(HTTPException) as exc:
+            require_user(request, db_session)
+        assert exc.value.status_code == 401
+
+    def test_agent_key_with_no_agent_user_raises_503(self, db_session):
+        """Valid agent key but no agent user in DB → 503."""
+        request = _mock_request({}, headers={"x-agent-key": "test-agent-key-secret"})
+        with patch("app.config.settings") as mock_settings:
+            mock_settings.agent_api_key = "test-agent-key-secret"
+            with pytest.raises(HTTPException) as exc:
+                require_user(request, db_session)
+        assert exc.value.status_code == 503
+
+    def test_agent_key_with_agent_user_in_db(self, db_session):
+        """Valid agent key + agent user in DB → returns agent user."""
+        agent_user = User(
+            email="agent@availai.local",
+            name="Agent",
+            role="agent",
+            azure_id="agent-azure-id",
+        )
+        db_session.add(agent_user)
+        db_session.commit()
+
+        request = _mock_request({}, headers={"x-agent-key": "test-agent-key-secret"})
+        with patch("app.config.settings") as mock_settings:
+            mock_settings.agent_api_key = "test-agent-key-secret"
+            user = require_user(request, db_session)
+        assert user.email == "agent@availai.local"
+
+    def test_wrong_agent_key_raises_401(self, db_session):
+        """Wrong agent key → 401, not authenticated."""
+        request = _mock_request({}, headers={"x-agent-key": "wrong-key"})
+        with patch("app.config.settings") as mock_settings:
+            mock_settings.agent_api_key = "correct-key"
+            with pytest.raises(HTTPException) as exc:
+                require_user(request, db_session)
+        assert exc.value.status_code == 401
+
+    def test_deactivated_user_raises_403(self, db_session):
+        """Deactivated user → 403."""
+        user = User(
+            email="inactive@trioscs.com",
+            name="Inactive",
+            role="buyer",
+            azure_id="inactive-azure-id",
+            is_active=False,
+        )
+        db_session.add(user)
+        db_session.commit()
+
+        request = _mock_request({"user_id": user.id})
+        with pytest.raises(HTTPException) as exc:
+            require_user(request, db_session)
+        assert exc.value.status_code == 403
+        assert "deactivated" in str(exc.value.detail).lower()
+
+
+# ── require_admin branches ────────────────────────────────────────────
+
+
+class TestRequireAdminBranches:
+    def test_agent_email_blocked(self, db_session):
+        """agent@availai.local cannot access admin endpoints."""
+        agent_user = User(
+            email="agent@availai.local",
+            name="Agent",
+            role="admin",
+            azure_id="agent-azure-id-2",
+        )
+        db_session.add(agent_user)
+        db_session.commit()
+
+        request = _mock_request({"user_id": agent_user.id})
+        with pytest.raises(HTTPException) as exc:
+            require_admin(request, db_session)
+        assert exc.value.status_code == 403
+        assert "Agent keys" in str(exc.value.detail)
+
+    def test_non_admin_role_raises_403(self, db_session, test_user):
+        """Buyer role cannot access admin endpoints."""
+        request = _mock_request({"user_id": test_user.id})
+        with pytest.raises(HTTPException) as exc:
+            require_admin(request, db_session)
+        assert exc.value.status_code == 403
+        assert "Admin access required" in str(exc.value.detail)
+
+    def test_admin_role_passes(self, db_session, admin_user):
+        """Admin role gets through."""
+        request = _mock_request({"user_id": admin_user.id})
+        user = require_admin(request, db_session)
+        assert user.id == admin_user.id
+
+
+# ── require_settings_access branches ─────────────────────────────────
+
+
+class TestRequireSettingsAccessBranches:
+    def test_agent_email_blocked(self, db_session):
+        """agent@availai.local cannot access settings."""
+        agent_user = User(
+            email="agent@availai.local",
+            name="Agent",
+            role="admin",
+            azure_id="agent-azure-id-3",
+        )
+        db_session.add(agent_user)
+        db_session.commit()
+
+        request = _mock_request({"user_id": agent_user.id})
+        with pytest.raises(HTTPException) as exc:
+            require_settings_access(request, db_session)
+        assert exc.value.status_code == 403
+        assert "Agent keys" in str(exc.value.detail)
+
+    def test_non_admin_raises_403(self, db_session, test_user):
+        request = _mock_request({"user_id": test_user.id})
+        with pytest.raises(HTTPException) as exc:
+            require_settings_access(request, db_session)
+        assert exc.value.status_code == 403
+        assert "Settings access required" in str(exc.value.detail)
+
+    def test_admin_passes(self, db_session, admin_user):
+        request = _mock_request({"user_id": admin_user.id})
+        user = require_settings_access(request, db_session)
+        assert user.id == admin_user.id
+
+
+# ── require_buyer branches ────────────────────────────────────────────
+
+
+class TestRequireBuyerBranches:
+    def test_non_buyer_role_raises_403(self, db_session):
+        """User with viewer role cannot access buyer endpoints."""
+        user = User(
+            email="viewer@trioscs.com",
+            name="Viewer",
+            role="viewer",
+            azure_id="viewer-azure-id",
+        )
+        db_session.add(user)
+        db_session.commit()
+
+        request = _mock_request({"user_id": user.id})
+        with pytest.raises(HTTPException) as exc:
+            require_buyer(request, db_session)
+        assert exc.value.status_code == 403
+        assert "Buyer role required" in str(exc.value.detail)
+
+    def test_buyer_role_passes(self, db_session, test_user):
+        request = _mock_request({"user_id": test_user.id})
+        user = require_buyer(request, db_session)
+        assert user.id == test_user.id
+
+    def test_sales_role_passes(self, db_session, sales_user):
+        request = _mock_request({"user_id": sales_user.id})
+        user = require_buyer(request, db_session)
+        assert user.id == sales_user.id
+
+    def test_admin_role_passes(self, db_session, admin_user):
+        request = _mock_request({"user_id": admin_user.id})
+        user = require_buyer(request, db_session)
+        assert user.id == admin_user.id
+
+
+# ── get_req_for_user sales filter ────────────────────────────────────
+
+
+class TestGetReqForUserSalesFilter:
+    def test_sales_user_cannot_see_others_requisitions(self, db_session, sales_user, test_user):
+        """Sales user cannot see requisitions created by others."""
+        req = Requisition(
+            name="REQ-OTHER",
+            customer_name="Other",
+            status="active",
+            created_by=test_user.id,
+        )
+        db_session.add(req)
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            get_req_for_user(db_session, sales_user, req.id)
+        assert exc.value.status_code == 404
+
+    def test_sales_user_can_see_own_requisition(self, db_session, sales_user):
+        """Sales user can see their own requisitions."""
+        req = Requisition(
+            name="REQ-OWN",
+            customer_name="Mine",
+            status="active",
+            created_by=sales_user.id,
+        )
+        db_session.add(req)
+        db_session.commit()
+
+        result = get_req_for_user(db_session, sales_user, req.id)
+        assert result.id == req.id
+
+    def test_custom_load_options(self, db_session, test_user, test_requisition):
+        """Custom load options are accepted."""
+        from sqlalchemy.orm import joinedload
+
+        result = get_req_for_user(
+            db_session, test_user, test_requisition.id, options=[joinedload(Requisition.requirements)]
+        )
+        assert result.id == test_requisition.id
+
+
+# ── get_quote_for_user ────────────────────────────────────────────────
+
+
+class TestGetQuoteForUser:
+    def _make_quote(self, db_session, user, requisition, quote_number="Q-2024-0001"):
+
+        quote = Quote(
+            requisition_id=requisition.id,
+            quote_number=quote_number,
+            created_by_id=user.id,
+        )
+        db_session.add(quote)
+        db_session.commit()
+        db_session.refresh(quote)
+        return quote
+
+    def test_buyer_can_get_any_quote(self, db_session, test_user, test_requisition):
+        quote = self._make_quote(db_session, test_user, test_requisition)
+        result = get_quote_for_user(db_session, test_user, quote.id)
+        assert result.id == quote.id
+
+    def test_nonexistent_quote_raises_404(self, db_session, test_user):
+        with pytest.raises(HTTPException) as exc:
+            get_quote_for_user(db_session, test_user, 99999)
+        assert exc.value.status_code == 404
+
+    def test_sales_user_can_get_own_quote(self, db_session, sales_user, test_requisition):
+        """Sales user can get quotes for their own requisitions."""
+        test_requisition.created_by = sales_user.id
+        db_session.commit()
+
+        quote = self._make_quote(db_session, sales_user, test_requisition, "Q-2024-S01")
+        result = get_quote_for_user(db_session, sales_user, quote.id)
+        assert result.id == quote.id
+
+    def test_sales_user_cannot_get_others_quote(self, db_session, sales_user, test_user, test_requisition):
+        """Sales user cannot get quotes for other users' requisitions."""
+        test_requisition.created_by = test_user.id
+        db_session.commit()
+
+        quote = self._make_quote(db_session, test_user, test_requisition, "Q-2024-O01")
+        with pytest.raises(HTTPException) as exc:
+            get_quote_for_user(db_session, sales_user, quote.id)
+        assert exc.value.status_code == 404
+
+    def test_custom_load_options(self, db_session, test_user, test_requisition):
+        """Custom load options are accepted."""
+        quote = self._make_quote(db_session, test_user, test_requisition, "Q-2024-C01")
+        result = get_quote_for_user(db_session, test_user, quote.id, options=[])
+        assert result.id == quote.id

--- a/tests/test_error_reports_nightly_coverage.py
+++ b/tests/test_error_reports_nightly_coverage.py
@@ -1,0 +1,421 @@
+"""test_error_reports_nightly_coverage.py — Targets remaining uncovered branches.
+
+Covers line 384 (analyze_tickets empty-tickets early return) and verifies
+the submit_trouble_ticket JSON path and form-encoded path reach their
+success branches without relying on parallel test state.
+
+Called by: pytest (nightly coverage job)
+Depends on: app/routers/error_reports.py, tests/conftest.py
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+import base64
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+from app.constants import TicketSource, TicketStatus
+from app.models.trouble_ticket import TroubleTicket
+
+# ── analyze_tickets: empty-tickets early return (line 384) ───────────
+
+
+class TestAnalyzeNoOpenTickets:
+    """Line 384: analyze_tickets returns early when no submitted/in_progress
+    report_button tickets exist."""
+
+    def test_analyze_returns_no_open_tickets_html_when_db_is_empty(self, client):
+        """With a clean DB session containing no tickets, the analyze endpoint
+        returns the 'No open tickets' partial immediately."""
+        resp = client.post("/api/trouble-tickets/analyze")
+        assert resp.status_code == 200
+        assert "No open tickets" in resp.text
+
+    def test_analyze_ignores_resolved_tickets(self, client, db_session, test_user):
+        """Resolved tickets are excluded from analysis — should still hit line 384."""
+        ticket = TroubleTicket(
+            ticket_number="TT-RES-NIGHTLY-001",
+            submitted_by=test_user.id,
+            title="Already resolved",
+            description="This one is resolved, should be excluded",
+            status=TicketStatus.RESOLVED,
+            source=TicketSource.REPORT_BUTTON,
+            risk_tier="low",
+            category="other",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ticket)
+        db_session.commit()
+
+        resp = client.post("/api/trouble-tickets/analyze")
+        assert resp.status_code == 200
+        assert "No open tickets" in resp.text
+
+    def test_analyze_ignores_wont_fix_tickets(self, client, db_session, test_user):
+        """wont_fix tickets are excluded from analysis — still triggers early return."""
+        ticket = TroubleTicket(
+            ticket_number="TT-WNT-NIGHTLY-001",
+            submitted_by=test_user.id,
+            title="Wont fix ticket",
+            description="This wont be fixed",
+            status=TicketStatus.WONT_FIX,
+            source=TicketSource.REPORT_BUTTON,
+            risk_tier="low",
+            category="other",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ticket)
+        db_session.commit()
+
+        resp = client.post("/api/trouble-tickets/analyze")
+        assert resp.status_code == 200
+        assert "No open tickets" in resp.text
+
+    def test_analyze_ignores_non_report_button_submitted_tickets(self, client, db_session, test_user):
+        """Submitted ticket_form tickets are excluded; returns no-open-tickets message."""
+        ticket = TroubleTicket(
+            ticket_number="TT-TF-NIGHTLY-001",
+            submitted_by=test_user.id,
+            title="Ticket form ticket",
+            description="Submitted via ticket form, not report button",
+            status=TicketStatus.SUBMITTED,
+            source=TicketSource.TICKET_FORM,
+            risk_tier="low",
+            category="other",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ticket)
+        db_session.commit()
+
+        resp = client.post("/api/trouble-tickets/analyze")
+        assert resp.status_code == 200
+        assert "No open tickets" in resp.text
+
+
+# ── submit_trouble_ticket: JSON path success (lines 187-193, 253-262) ──
+
+
+class TestSubmitJsonPathSuccess:
+    """Verify the JSON branch of submit_trouble_ticket executes the complete
+    success path including background task scheduling."""
+
+    def test_json_submit_returns_success_html(self, client):
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            json={"description": "Nightly coverage: JSON path success"},
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        assert "Report submitted" in resp.text
+        assert "TT-" in resp.text
+
+    def test_json_submit_all_optional_fields(self, client):
+        """All optional JSON fields parsed correctly (lines 188-193)."""
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            json={
+                "description": "Full JSON payload",
+                "page_url": "/v2/sourcing",
+                "user_agent": "Mozilla/5.0 (X11; Linux x86_64)",
+                "viewport": "1440x900",
+                "error_log": "TypeError: Cannot read property 'id' of undefined",
+                "network_log": '[{"url": "/api/search", "status": 500}]',
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        assert "Report submitted" in resp.text
+
+    def test_json_submit_only_viewport_sets_browser_info(self, client, db_session):
+        """viewport alone (no user_agent) still sets browser_info."""
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            json={
+                "description": "Viewport only test",
+                "viewport": "1280x800",
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+
+    def test_json_submit_only_user_agent_sets_browser_info(self, client, db_session):
+        """user_agent alone (no viewport) sets browser_info JSON."""
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            json={
+                "description": "User agent only test",
+                "user_agent": "curl/7.68.0",
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+
+    def test_json_submit_network_log_as_list_not_string(self, client):
+        """network_log provided as a list (not string) bypasses json.loads."""
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            json={
+                "description": "Network log as list",
+                "network_log": [{"url": "/api/vendors", "status": 404}],
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+
+    def test_json_submit_with_screenshot_b64(self, client, tmp_path, monkeypatch):
+        """Screenshot in JSON body triggers _save_screenshot path."""
+        from app.routers import error_reports
+
+        monkeypatch.setattr(error_reports, "UPLOAD_DIR", str(tmp_path))
+        monkeypatch.setattr(error_reports, "_upload_dir_ready", False)
+
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+        b64 = base64.b64encode(png_bytes).decode()
+
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            json={
+                "description": "Bug with screenshot attached",
+                "screenshot": b64,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        assert "Report submitted" in resp.text
+
+
+# ── submit_trouble_ticket: form-encoded path success (lines 197-255) ──
+
+
+class TestSubmitFormEncodedPathSuccess:
+    """Verify the form-encoded branch executes the complete success path."""
+
+    def test_form_submit_with_message_only(self, client):
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            data={"message": "Nightly coverage: form path success"},
+        )
+        assert resp.status_code == 200
+        assert "Report submitted" in resp.text
+        assert "TT-" in resp.text
+
+    def test_form_submit_with_current_url(self, client):
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            data={
+                "message": "Form with URL",
+                "current_url": "/v2/requisitions",
+            },
+        )
+        assert resp.status_code == 200
+        assert "Report submitted" in resp.text
+
+    def test_form_submit_stores_ticket_in_db(self, client, db_session):
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            data={"message": "Stored form ticket nightly"},
+        )
+        assert resp.status_code == 200
+        ticket = (
+            db_session.query(TroubleTicket).filter(TroubleTicket.description == "Stored form ticket nightly").first()
+        )
+        assert ticket is not None
+        assert ticket.source == TicketSource.REPORT_BUTTON
+        assert ticket.status == TicketStatus.SUBMITTED
+
+    def test_form_submit_whitespace_message_rejected(self, client):
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            data={"message": "   \t  "},
+        )
+        assert resp.status_code == 422
+        assert "describe" in resp.text.lower() or "problem" in resp.text.lower()
+
+    def test_form_submit_message_at_max_length_accepted(self, client):
+        """Message exactly at MAX_MESSAGE_LEN (5000) is accepted."""
+        from app.routers.error_reports import MAX_MESSAGE_LEN
+
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            data={"message": "X" * MAX_MESSAGE_LEN},
+        )
+        assert resp.status_code == 200
+
+    def test_form_submit_message_over_max_length_rejected(self, client):
+        """Message over MAX_MESSAGE_LEN (5001+) is rejected with 422."""
+        from app.routers.error_reports import MAX_MESSAGE_LEN
+
+        resp = client.post(
+            "/api/trouble-tickets/submit",
+            data={"message": "X" * (MAX_MESSAGE_LEN + 1)},
+        )
+        assert resp.status_code == 422
+        assert "too long" in resp.text.lower() or "max" in resp.text.lower()
+
+
+# ── analyze_tickets: ClaudeUnavailableError path ─────────────────────
+
+
+class TestAnalyzeClaudeErrors:
+    """Verify analyze_tickets catches ClaudeUnavailableError and ClaudeError."""
+
+    @patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock)
+    def test_claude_unavailable_error_returns_fallback_html(self, mock_claude, client, db_session, test_user):
+        from app.utils.claude_errors import ClaudeUnavailableError
+
+        ticket = TroubleTicket(
+            ticket_number="TT-CLU-NIGHTLY-001",
+            submitted_by=test_user.id,
+            title="Unavailable error test",
+            description="Triggers ClaudeUnavailableError",
+            status=TicketStatus.SUBMITTED,
+            source=TicketSource.REPORT_BUTTON,
+            risk_tier="low",
+            category="other",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ticket)
+        db_session.commit()
+
+        mock_claude.side_effect = ClaudeUnavailableError("service down")
+        resp = client.post("/api/trouble-tickets/analyze")
+        assert resp.status_code == 200
+        assert "no results" in resp.text.lower() or "Try again" in resp.text
+
+    @patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock)
+    def test_claude_error_returns_fallback_html(self, mock_claude, client, db_session, test_user):
+        from app.utils.claude_errors import ClaudeError
+
+        ticket = TroubleTicket(
+            ticket_number="TT-CLE-NIGHTLY-001",
+            submitted_by=test_user.id,
+            title="ClaudeError test",
+            description="Triggers ClaudeError",
+            status=TicketStatus.IN_PROGRESS,
+            source=TicketSource.REPORT_BUTTON,
+            risk_tier="low",
+            category="other",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ticket)
+        db_session.commit()
+
+        mock_claude.side_effect = ClaudeError("quota exceeded")
+        resp = client.post("/api/trouble-tickets/analyze")
+        assert resp.status_code == 200
+        assert "no results" in resp.text.lower() or "Try again" in resp.text
+
+    @patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock)
+    def test_claude_returns_result_without_groups_key(self, mock_claude, client, db_session, test_user):
+        """Result missing 'groups' key triggers the same fallback as None."""
+        ticket = TroubleTicket(
+            ticket_number="TT-NOG-NIGHTLY-001",
+            submitted_by=test_user.id,
+            title="No groups key test",
+            description="Claude returns result without groups",
+            status=TicketStatus.SUBMITTED,
+            source=TicketSource.REPORT_BUTTON,
+            risk_tier="low",
+            category="other",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ticket)
+        db_session.commit()
+
+        mock_claude.return_value = {"unexpected_key": "value"}
+        resp = client.post("/api/trouble-tickets/analyze")
+        assert resp.status_code == 200
+        assert "no results" in resp.text.lower()
+
+    @patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock)
+    def test_analyze_success_with_existing_group_updates_fix(self, mock_claude, client, db_session, test_user):
+        """Existing RootCauseGroup without suggested_fix gets fix updated."""
+        from app.models.root_cause_group import RootCauseGroup
+
+        ticket = TroubleTicket(
+            ticket_number="TT-GRP-NIGHTLY-001",
+            submitted_by=test_user.id,
+            title="Group update test",
+            description="Testing existing group update path",
+            status=TicketStatus.SUBMITTED,
+            source=TicketSource.REPORT_BUTTON,
+            risk_tier="low",
+            category="other",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ticket)
+        db_session.commit()
+        db_session.refresh(ticket)
+
+        existing_group = RootCauseGroup(title="Nightly Search Bug", suggested_fix=None)
+        db_session.add(existing_group)
+        db_session.commit()
+
+        mock_claude.return_value = {
+            "groups": [
+                {
+                    "title": "Nightly Search Bug",
+                    "suggested_fix": "Fix the query builder logic",
+                    "ticket_ids": [ticket.id],
+                }
+            ]
+        }
+
+        resp = client.post("/api/trouble-tickets/analyze")
+        assert resp.status_code == 200
+        # HX-Trigger header is set on success
+        assert resp.headers.get("HX-Trigger") == "ticketsUpdated"
+
+
+# ── list_error_reports: pagination parameters ─────────────────────────
+
+
+class TestListPagination:
+    def test_list_with_limit_and_offset(self, client, db_session, test_user):
+        """limit and offset query params are accepted and applied."""
+        for i in range(3):
+            db_session.add(
+                TroubleTicket(
+                    ticket_number=f"TT-PAG-NIGHTLY-{i:03d}",
+                    submitted_by=test_user.id,
+                    title=f"Pagination ticket {i}",
+                    description=f"Ticket number {i}",
+                    status=TicketStatus.SUBMITTED,
+                    source=TicketSource.REPORT_BUTTON,
+                    risk_tier="low",
+                    category="other",
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+        db_session.commit()
+
+        resp = client.get("/api/error-reports?limit=2&offset=0")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["items"]) <= 2
+        assert data["total"] >= 3
+
+    def test_list_offset_beyond_total_returns_empty_items(self, client, db_session, test_user):
+        """offset beyond total returns empty items list with correct total."""
+        db_session.add(
+            TroubleTicket(
+                ticket_number="TT-OFST-NIGHTLY-001",
+                submitted_by=test_user.id,
+                title="Offset test",
+                description="Testing large offset",
+                status=TicketStatus.SUBMITTED,
+                source=TicketSource.REPORT_BUTTON,
+                risk_tier="low",
+                category="other",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        db_session.commit()
+
+        resp = client.get("/api/error-reports?limit=10&offset=9999")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"] == []
+        assert data["total"] >= 1

--- a/tests/test_health_monitor_nightly_coverage.py
+++ b/tests/test_health_monitor_nightly_coverage.py
@@ -1,0 +1,149 @@
+"""test_health_monitor_nightly_coverage.py — Extra coverage for health_monitor.py.
+
+Covers: deep_test_source typed-error branches (auth, rate-limit, quota),
+and _redact_api_keys closure edge cases.
+
+Called by: pytest
+Depends on: tests/test_health_monitor.py (existing coverage), conftest.py
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+os.environ["TESTING"] = "1"
+
+from app.connectors.errors import ConnectorAuthError, ConnectorQuotaError, ConnectorRateLimitError
+from app.models.config import ApiSource, ApiUsageLog
+from app.services.health_monitor import _redact_api_keys, deep_test_source
+
+
+def _make_source(db, **overrides):
+    defaults = {
+        "name": "test_hm_nightly",
+        "display_name": "Test HM Nightly",
+        "category": "distributor",
+        "source_type": "api",
+        "status": "live",
+        "is_active": True,
+        "calls_this_month": 0,
+        "monthly_quota": None,
+        "error_count_24h": 0,
+    }
+    defaults.update(overrides)
+    source = ApiSource(**defaults)
+    db.add(source)
+    db.flush()
+    return source
+
+
+class TestDeepTestSourceTypedErrors:
+    """deep_test_source produces distinct error messages for each ConnectorError subtype
+    (lines 341-407 in health_monitor.py).
+    """
+
+    def test_auth_error_message(self, db_session):
+        """ConnectorAuthError in deep_test → error mentions 'rotate credentials'."""
+        source = _make_source(db_session, status="live", error_count_24h=0)
+        mock_connector = MagicMock()
+        mock_connector.search = AsyncMock(side_effect=ConnectorAuthError("bad creds"))
+
+        with patch("app.services.health_monitor._get_connector", return_value=mock_connector):
+            with patch("app.services.health_monitor._check_status_transition"):
+                result = asyncio.get_event_loop().run_until_complete(deep_test_source(source, db_session))
+
+        assert result["success"] is False
+        assert result["results_count"] == 0
+        assert source.status == "error"
+        msg = (source.last_error or "").lower()
+        assert "rotate credentials" in msg or "auth error" in msg
+
+        logs = db_session.query(ApiUsageLog).filter_by(source_id=source.id, endpoint="deep_test").all()
+        assert len(logs) == 1
+        assert logs[0].success is False
+
+    def test_rate_limit_error_message(self, db_session):
+        """ConnectorRateLimitError in deep_test → error mentions 'rate limited' or 'auto-recover'."""
+        source = _make_source(db_session, status="live", error_count_24h=0)
+        mock_connector = MagicMock()
+        mock_connector.search = AsyncMock(side_effect=ConnectorRateLimitError("hit window"))
+
+        with patch("app.services.health_monitor._get_connector", return_value=mock_connector):
+            with patch("app.services.health_monitor._check_status_transition"):
+                result = asyncio.get_event_loop().run_until_complete(deep_test_source(source, db_session))
+
+        assert result["success"] is False
+        assert source.status == "error"
+        msg = (source.last_error or "").lower()
+        assert "rate limited" in msg or "auto-recover" in msg or "auto recovers" in msg
+
+        logs = db_session.query(ApiUsageLog).filter_by(source_id=source.id, endpoint="deep_test").all()
+        assert logs[0].success is False
+
+    def test_quota_error_message(self, db_session):
+        """ConnectorQuotaError in deep_test → error mentions 'quota' or 'upgrade plan'."""
+        source = _make_source(db_session, status="live", error_count_24h=0)
+        mock_connector = MagicMock()
+        mock_connector.search = AsyncMock(side_effect=ConnectorQuotaError("plan limit"))
+
+        with patch("app.services.health_monitor._get_connector", return_value=mock_connector):
+            with patch("app.services.health_monitor._check_status_transition"):
+                result = asyncio.get_event_loop().run_until_complete(deep_test_source(source, db_session))
+
+        assert result["success"] is False
+        assert source.status == "error"
+        msg = (source.last_error or "").lower()
+        assert "quota" in msg or "upgrade" in msg
+
+        logs = db_session.query(ApiUsageLog).filter_by(source_id=source.id, endpoint="deep_test").all()
+        assert logs[0].success is False
+
+    def test_typed_error_increments_error_count(self, db_session):
+        """Each typed error increments error_count_24h."""
+        source = _make_source(db_session, status="live", error_count_24h=5)
+        mock_connector = MagicMock()
+        mock_connector.search = AsyncMock(side_effect=ConnectorAuthError("expired"))
+
+        with patch("app.services.health_monitor._get_connector", return_value=mock_connector):
+            with patch("app.services.health_monitor._check_status_transition"):
+                asyncio.get_event_loop().run_until_complete(deep_test_source(source, db_session))
+
+        assert source.error_count_24h == 6
+
+
+class TestRedactApiKeysClosureBranches:
+    """Tests to cover the closure branches in _redact_api_keys."""
+
+    def test_named_key_eight_char_minimum_is_masked(self):
+        """The regex requires 8+ chars; this key has exactly 8 and gets masked."""
+        text = "api_key=ABCDEFGH"
+        result = _redact_api_keys(text)
+        assert "ABCDEFGH" not in result
+        assert "***" in result
+
+    def test_bare_key_over_100_chars_not_masked_in_url(self):
+        """Keys >100 chars in query strings with non-named param are left unmasked (line 73).
+
+        Uses 'data=' prefix which is NOT in _API_KEY_RE's prefix list, so the bare-key
+        masking path applies. The key is 105 A's (>100), triggering the early return.
+        """
+        long_key = "A" * 105
+        text = f"https://api.com/search?data={long_key}&other=val"
+        result = _redact_api_keys(text)
+        # Long bare key should NOT be masked (>100 char guard, line 73)
+        assert long_key in result
+
+    def test_bare_key_20_to_100_chars_is_masked_in_url(self):
+        """Keys 20-100 chars in URL query strings ARE masked."""
+        medium_key = "B" * 30
+        text = f"https://api.example.com/v1?apikey={medium_key}"
+        result = _redact_api_keys(text)
+        assert medium_key not in result or "***" in result
+
+    def test_ampersand_triggers_url_masking(self):
+        """URLs with & (no ?) also trigger bare key masking."""
+        key = "C" * 25
+        text = f"search?q=hello&key={key}"
+        result = _redact_api_keys(text)
+        # The bare key should be masked since it's in a query string
+        assert key not in result

--- a/tests/test_materials_nightly_coverage.py
+++ b/tests/test_materials_nightly_coverage.py
@@ -1,0 +1,335 @@
+"""tests/test_materials_nightly_coverage.py — Covers remaining branches in app/routers/materials.py.
+
+Targets the three uncovered code paths (lines 447-449, 462-463, 476-481):
+- IntegrityError race condition when creating a new VendorCard (lines 447-449)
+- normalize_mpn_key returns empty string for symbol-only MPNs (lines 462-463)
+- IntegrityError race condition when creating a new MaterialCard (lines 476-481)
+
+Called by: pytest
+Depends on: conftest.py fixtures (client, db_session), app models
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+
+from sqlalchemy.exc import IntegrityError
+
+from app.models import MaterialCard, VendorCard
+
+
+class TestImportStockNullMpnKey:
+    """Lines 462-463: normalize_mpn_key returns empty string for symbol-only MPNs.
+
+    '---' passes normalize_stock_row (length >= 3) but normalize_mpn_key('---')
+    returns '' which is falsy, so those rows are skipped (lines 462-463).
+
+    Direct handler calls are used so coverage registers in the main thread.
+    """
+
+    def _invoke(self, db_session, vendor_name: str, csv_content: bytes, monkeypatch):
+        """Run the handler directly and return the response dict."""
+        import asyncio
+
+        from app.models import User
+        from app.routers.materials import import_stock_list_standalone
+
+        monkeypatch.setattr("app.routers.materials.get_credential_cached", lambda *a, **kw: None)
+        monkeypatch.setattr("app.routers.materials.safe_background_task", lambda *a, **kw: None)
+        monkeypatch.setattr("app.routers.materials.record_price_snapshot", lambda **kw: None)
+
+        async def _run():
+            class _File:
+                filename = "stock.csv"
+
+                async def read(inner_self):  # noqa: N805
+                    return csv_content
+
+            class _Form:
+                def get(inner_self, key):  # noqa: N805
+                    if key == "file":
+                        return _File()
+                    if key == "vendor_name":
+                        return vendor_name
+                    if key == "vendor_website":
+                        return ""
+                    return None
+
+            class FakeRequest:
+                async def form(inner_self):  # noqa: N805
+                    return _Form()
+
+                state = type("state", (), {"request_id": "test"})()
+
+            user = User(
+                email=f"sym_{vendor_name[:6]}@t.com",
+                name="SBuyer",
+                role="buyer",
+                azure_id=f"sym_{vendor_name[:6]}",
+            )
+            return await import_stock_list_standalone(
+                request=FakeRequest(),  # type: ignore[arg-type]
+                user=user,
+                db=db_session,
+            )
+
+        return asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_symbol_only_mpn_is_skipped(self, db_session, monkeypatch):
+        """Rows whose MPN normalises to empty string are counted as skipped (lines 462-463)."""
+        # '---' has length 3 (passes normalize_stock_row) but normalize_mpn_key returns ''
+        content = b"mpn,qty,price\n---,100,0.50\n"
+        result = self._invoke(db_session, "Symbol Vendor A", content, monkeypatch)
+        assert result["skipped_rows"] >= 1
+        assert result["imported_rows"] == 0
+
+    def test_mixed_good_and_symbol_rows(self, db_session, monkeypatch):
+        """Valid MPN rows import; symbol-only rows hit lines 462-463 and skip."""
+        # LM317T → imported; '...' → normalize_mpn_key('...') = '' → skipped
+        content = b"mpn,qty,price\nLM317T,100,0.50\n...,200,0.25\n"
+        result = self._invoke(db_session, "Mixed MPN Vendor B", content, monkeypatch)
+        assert result["imported_rows"] == 1
+        assert result["skipped_rows"] == 1
+
+
+class TestImportStockVendorCardIntegrityError:
+    """Lines 447-449: IntegrityError when flushing a new VendorCard.
+
+    Simulates a race condition: initial query finds nothing (so the router
+    creates a new VendorCard), flush raises IntegrityError, rollback, then
+    re-query finds the concurrently-inserted vendor.
+    """
+
+    def test_integrity_error_on_vendor_flush_falls_back_to_existing(self, db_session, monkeypatch):
+        """IntegrityError on VendorCard flush triggers rollback + re-query (lines 447-449).
+
+        Strategy: patch rollback to insert the vendor after rollback so the
+        re-query at line 449 finds it.
+        """
+        import asyncio
+
+        from app.models import User
+        from app.routers.materials import import_stock_list_standalone
+        from app.vendor_utils import normalize_vendor_name
+
+        vendor_name = "Race Condition Vendor IE"
+        norm = normalize_vendor_name(vendor_name)
+
+        monkeypatch.setattr("app.routers.materials.get_credential_cached", lambda *a, **kw: None)
+        monkeypatch.setattr("app.routers.materials.safe_background_task", lambda *a, **kw: None)
+        monkeypatch.setattr("app.routers.materials.record_price_snapshot", lambda **kw: None)
+
+        original_flush = db_session.flush
+        original_rollback = db_session.rollback
+
+        # On the first flush (VendorCard at line 445), raise IntegrityError.
+        # On the subsequent rollback, insert the vendor so line 449 re-query finds it.
+        raise_on_next = [True]
+        rollback_calls = [0]
+
+        def patched_flush(*args, **kwargs):
+            if raise_on_next[0]:
+                raise_on_next[0] = False
+                raise IntegrityError("duplicate normalized_name", {}, None)
+            return original_flush(*args, **kwargs)
+
+        def patched_rollback():
+            rollback_calls[0] += 1
+            original_rollback()
+            if rollback_calls[0] == 1:
+                # Simulate concurrent insert after rollback so re-query finds the vendor
+                concurrent_vc = VendorCard(
+                    normalized_name=norm,
+                    display_name=vendor_name,
+                    sighting_count=0,
+                    emails=[],
+                    phones=[],
+                )
+                db_session.add(concurrent_vc)
+                db_session.commit()
+
+        monkeypatch.setattr(db_session, "flush", patched_flush)
+        monkeypatch.setattr(db_session, "rollback", patched_rollback)
+
+        csv_content = b"mpn,qty,price\nLM317T,100,0.50\n"
+
+        async def _run():
+            class _File:
+                filename = "stock.csv"
+
+                async def read(self):
+                    return csv_content
+
+            class _Form:
+                def get(self, key):
+                    if key == "file":
+                        return _File()
+                    if key == "vendor_name":
+                        return vendor_name
+                    if key == "vendor_website":
+                        return ""
+                    return None
+
+            class FakeRequest:
+                async def form(self):
+                    return _Form()
+
+                state = type("state", (), {"request_id": "test"})()
+
+            user = User(email="buyer@trioscs.com", name="Buyer", role="buyer", azure_id="xyz")
+            return await import_stock_list_standalone(
+                request=FakeRequest(),  # type: ignore[arg-type]
+                user=user,
+                db=db_session,
+            )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        # After IntegrityError + rollback + re-query finds the vendor → import proceeds
+        assert "imported_rows" in result
+
+
+class TestImportStockMaterialCardIntegrityError:
+    """Lines 476-481: IntegrityError when flushing a new MaterialCard.
+
+    Uses a mock session to precisely control what happens on each flush call
+    so the router hits the try/except IntegrityError around db.flush() for
+    new MaterialCard creation.
+    """
+
+    def _make_fake_request(self, vendor_name: str, csv_content: bytes):
+        """Build a minimal fake Request that returns a form with file + vendor_name."""
+
+        class _File:
+            filename = "stock.csv"
+
+            async def read(inner_self):  # noqa: N805
+                return csv_content
+
+        class _Form:
+            def get(inner_self, key):  # noqa: N805
+                if key == "file":
+                    return _File()
+                if key == "vendor_name":
+                    return vendor_name
+                if key == "vendor_website":
+                    return ""
+                return None
+
+        class FakeRequest:
+            async def form(inner_self):  # noqa: N805
+                return _Form()
+
+            state = type("state", (), {"request_id": "test"})()
+
+        return FakeRequest()
+
+    def test_integrity_error_on_material_card_flush_skips_row_when_not_found(self, db_session, monkeypatch):
+        """IntegrityError on MaterialCard flush causes that row to be skipped.
+
+        Covers lines 476-481: after IntegrityError + rollback, re-query returns
+        None so the row is skipped (imported_rows stays 0).
+        """
+        import asyncio
+
+        from app.models import User
+        from app.routers.materials import import_stock_list_standalone
+
+        vendor_name = "IE MaterialCard Skip Vendor"
+        csv_content = b"mpn,qty,price\nUNIQUE_IE_SKIP_XYZ,100,1.00\n"
+
+        monkeypatch.setattr("app.routers.materials.get_credential_cached", lambda *a, **kw: None)
+        monkeypatch.setattr("app.routers.materials.safe_background_task", lambda *a, **kw: None)
+        monkeypatch.setattr("app.routers.materials.record_price_snapshot", lambda **kw: None)
+
+        original_flush = db_session.flush
+        # MaterialCard flush is the 2nd call (after VendorCard flush at line 445).
+        # After the IntegrityError at line 476, rollback is called, and the
+        # re-query at line 478 must return None (simulated by the card not
+        # existing in DB + rollback clearing the new card object).
+        # We need flush to raise on the MaterialCard add but NOT on VendorCard.
+        # Strategy: first flush (VendorCard) succeeds; second flush (line 475
+        # for MaterialCard) raises; all subsequent succeed.
+        flush_count = [0]
+
+        def controlled_flush(*args, **kwargs):
+            flush_count[0] += 1
+            if flush_count[0] == 2:
+                raise IntegrityError("duplicate key normalized_mpn", {}, None)
+            return original_flush(*args, **kwargs)
+
+        monkeypatch.setattr(db_session, "flush", controlled_flush)
+
+        async def _run():
+            user = User(email="buyer_skip@trioscs.com", name="BuyerSkip", role="buyer", azure_id="skip1")
+            return await import_stock_list_standalone(
+                request=self._make_fake_request(vendor_name, csv_content),  # type: ignore[arg-type]
+                user=user,
+                db=db_session,
+            )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        # Re-query returns None after rollback → row skipped
+        assert result["skipped_rows"] >= 1
+        assert result["imported_rows"] == 0
+
+    def test_integrity_error_on_material_card_flush_uses_existing_card(self, db_session, monkeypatch):
+        """IntegrityError on MaterialCard flush recovers when re-query finds existing.
+
+        Covers lines 476-478: IntegrityError → rollback → re-query finds the card
+        (inserted by a concurrent request) → row is imported.
+        """
+        import asyncio
+
+        from app.models import User
+        from app.routers.materials import import_stock_list_standalone
+        from app.utils.normalization import normalize_mpn_key
+
+        vendor_name = "IE MaterialCard Found Vendor"
+        mpn = "LM741CN_FOUND"
+        norm = normalize_mpn_key(mpn)
+        csv_content = f"mpn,qty,price\n{mpn},50,0.75\n".encode()
+
+        monkeypatch.setattr("app.routers.materials.get_credential_cached", lambda *a, **kw: None)
+        monkeypatch.setattr("app.routers.materials.safe_background_task", lambda *a, **kw: None)
+        monkeypatch.setattr("app.routers.materials.record_price_snapshot", lambda **kw: None)
+
+        # The card does NOT exist initially. After IntegrityError + rollback,
+        # we simulate a concurrent insert by inserting the card in the rollback
+        # side-effect so the re-query at line 478 finds it.
+        original_rollback = db_session.rollback
+        rollback_calls = [0]
+
+        def side_effect_rollback():
+            rollback_calls[0] += 1
+            original_rollback()
+            if rollback_calls[0] == 1:
+                # Simulate concurrent insert: insert the card directly after rollback
+                concurrent_mc = MaterialCard(normalized_mpn=norm, display_mpn=mpn, manufacturer="")
+                db_session.add(concurrent_mc)
+                db_session.commit()
+
+        monkeypatch.setattr(db_session, "rollback", side_effect_rollback)
+
+        original_flush = db_session.flush
+        flush_count = [0]
+
+        def controlled_flush(*args, **kwargs):
+            flush_count[0] += 1
+            if flush_count[0] == 2:
+                raise IntegrityError("duplicate key normalized_mpn", {}, None)
+            return original_flush(*args, **kwargs)
+
+        monkeypatch.setattr(db_session, "flush", controlled_flush)
+
+        async def _run():
+            user = User(email="buyer_found@trioscs.com", name="BuyerFound", role="buyer", azure_id="found1")
+            return await import_stock_list_standalone(
+                request=self._make_fake_request(vendor_name, csv_content),  # type: ignore[arg-type]
+                user=user,
+                db=db_session,
+            )
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        # Re-query after rollback finds the concurrently inserted card → row imported
+        assert "imported_rows" in result

--- a/tests/test_requirements_nightly_coverage.py
+++ b/tests/test_requirements_nightly_coverage.py
@@ -1,0 +1,1114 @@
+"""test_requirements_nightly_coverage.py — Coverage booster for requirements.py.
+
+Targets lines 163, 179, 184, 188, 236, 307-308, 363, 365-437, 439-457,
+463-465, 478, 511, 521, 704, 733-748, 755, 815, 820, 843, 917-918, 920,
+991, 997, 1002-1071, 1118, 1132, 1221-1225 in requirements.py.
+
+Called by: pytest
+Depends on: conftest fixtures (client, db_session, test_user, test_requisition)
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from sqlalchemy.orm import Session
+
+from app.models import (
+    ChangeLog,
+    Contact,
+    MaterialCard,
+    Offer,
+    Requirement,
+    Requisition,
+    Sighting,
+    SourcingLead,
+    User,
+    VendorCard,
+)
+from app.models.task import RequisitionTask
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _req(db: Session, user: User, **kw) -> Requisition:
+    defaults = dict(
+        name="NC-REQ",
+        customer_name="Acme",
+        status="active",
+        created_by=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    defaults.update(kw)
+    r = Requisition(**defaults)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _item(db: Session, req: Requisition, **kw) -> Requirement:
+    defaults = dict(
+        requisition_id=req.id,
+        primary_mpn="LM317T",
+        normalized_mpn="lm317t",
+        target_qty=100,
+        target_price=0.50,
+        created_at=datetime.now(timezone.utc),
+    )
+    defaults.update(kw)
+    r = Requirement(**defaults)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _sighting(db: Session, req_item: Requirement, **kw) -> Sighting:
+    defaults = dict(
+        requirement_id=req_item.id,
+        vendor_name="Arrow",
+        vendor_name_normalized="arrow",
+        mpn_matched="LM317T",
+        source_type="brokerbin",
+        qty_available=500,
+        unit_price=0.45,
+        confidence=80,
+        score=50,
+        created_at=datetime.now(timezone.utc),
+    )
+    defaults.update(kw)
+    s = Sighting(**defaults)
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+def _offer(db: Session, req: Requisition, req_item: Requirement, user: User, **kw) -> Offer:
+    defaults = dict(
+        requisition_id=req.id,
+        requirement_id=req_item.id,
+        vendor_name="Arrow Electronics",
+        vendor_name_normalized="arrow electronics",
+        mpn="LM317T",
+        normalized_mpn="lm317t",
+        qty_available=1000,
+        unit_price=0.50,
+        entered_by_id=user.id,
+        status="active",
+        created_at=datetime.now(timezone.utc),
+    )
+    defaults.update(kw)
+    o = Offer(**defaults)
+    db.add(o)
+    db.commit()
+    db.refresh(o)
+    return o
+
+
+def _card(db: Session, mpn: str = "LM317T") -> MaterialCard:
+    from app.utils.normalization import normalize_mpn_key
+
+    mc = MaterialCard(
+        display_mpn=mpn,
+        normalized_mpn=normalize_mpn_key(mpn),
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(mc)
+    db.commit()
+    db.refresh(mc)
+    return mc
+
+
+def _lead(db: Session, req: Requisition, req_item: Requirement, **kw) -> SourcingLead:
+    import uuid
+
+    defaults = dict(
+        lead_id=f"lead-{uuid.uuid4().hex[:10]}",
+        requisition_id=req.id,
+        requirement_id=req_item.id,
+        part_number_requested="LM317T",
+        part_number_matched="LM317T",
+        match_type="exact",
+        vendor_name="Arrow",
+        vendor_name_normalized="arrow",
+        primary_source_type="brokerbin",
+        primary_source_name="brokerbin",
+        buyer_status="open",
+        created_at=datetime.now(timezone.utc),
+    )
+    defaults.update(kw)
+    lead = SourcingLead(**defaults)
+    db.add(lead)
+    db.commit()
+    db.refresh(lead)
+    return lead
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# list_requirements — lines 236-350 (with sightings, offers, tasks, steps)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestListRequirementsBody:
+    def test_with_sighting_count_shows_sourced_step(self, client, db_session, test_user, test_requisition):
+        """Sighting present → step = 'sourced'."""
+        req_item = test_requisition.requirements[0]
+        _sighting(db_session, req_item)
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/requirements")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 1
+        assert data[0]["step"] == "sourced"
+        assert data[0]["sighting_count"] >= 1
+
+    def test_with_active_offer_shows_offers_step(self, client, db_session, test_user, test_requisition):
+        """Active offer present → step = 'offers'."""
+        req_item = test_requisition.requirements[0]
+        _offer(db_session, test_requisition, req_item, test_user, status="active")
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/requirements")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["step"] == "offers"
+        assert data[0]["offer_count"] >= 1
+
+    def test_with_selected_offer_shows_selected_step(self, client, db_session, test_user, test_requisition):
+        """Selected offer → step = 'selected'."""
+        req_item = test_requisition.requirements[0]
+        _offer(
+            db_session,
+            test_requisition,
+            req_item,
+            test_user,
+            status="active",
+            selected_for_quote=True,
+        )
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/requirements")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["step"] == "selected"
+        assert data[0]["selected_count"] >= 1
+
+    def test_no_requirements_returns_empty(self, client, db_session, test_user):
+        """Requisition with no requirements returns an empty list."""
+        req = _req(db_session, test_user, name="EMPTY-REQ")
+        resp = client.get(f"/api/requisitions/{req.id}/requirements")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_step_new_when_no_sightings_or_offers(self, client, db_session, test_user, test_requisition):
+        """No sightings, no offers → step = 'new'."""
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/requirements")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["step"] == "new"
+
+    def test_task_count_included(self, client, db_session, test_user, test_requisition):
+        """Open tasks for requirement reflected in task_count."""
+        req_item = test_requisition.requirements[0]
+        task = RequisitionTask(
+            requisition_id=test_requisition.id,
+            title="Send RFQ",
+            task_type="sourcing",
+            status="todo",
+            source="manual",
+            source_ref=f"requirement:{req_item.id}",
+            created_by=test_user.id,
+        )
+        db_session.add(task)
+        db_session.commit()
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/requirements")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["task_count"] >= 1
+
+    def test_contact_count_included(self, client, db_session, test_user, test_requisition):
+        """Contacts linked to requisition are counted."""
+        ct = Contact(
+            requisition_id=test_requisition.id,
+            user_id=test_user.id,
+            contact_type="rfq",
+            vendor_name="Arrow",
+            parts_included=["LM317T"],
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ct)
+        db_session.commit()
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/requirements")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["contact_count"] >= 1
+        assert data[0]["hours_since_activity"] is not None
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# add_requirements — lines 363-465 (core path, batch, dup detection)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestAddRequirementsCore:
+    def test_add_single_returns_created(self, client, db_session, test_user, test_requisition):
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            with patch("app.services.task_service.on_requirement_added"):
+                resp = client.post(
+                    f"/api/requisitions/{test_requisition.id}/requirements",
+                    json={"primary_mpn": "NE555", "manufacturer": "TI", "target_qty": 100},
+                )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["created"]) == 1
+        assert data["created"][0]["primary_mpn"] == "NE555"
+
+    def test_add_with_all_optional_fields(self, client, db_session, test_user, test_requisition):
+        """Exercises condition, packaging, firmware, date_codes, notes, description."""
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            with patch("app.services.task_service.on_requirement_added"):
+                resp = client.post(
+                    f"/api/requisitions/{test_requisition.id}/requirements",
+                    json={
+                        "primary_mpn": "LM7805",
+                        "manufacturer": "Fairchild",
+                        "target_qty": 50,
+                        "condition": "new",
+                        "packaging": "Tape and Reel",
+                        "firmware": "v1.0",
+                        "date_codes": "2023+",
+                        "hardware_codes": "REV-C",
+                        "notes": "Urgent",
+                        "description": "5V regulator",
+                    },
+                )
+        assert resp.status_code == 200
+
+    def test_add_batch_all_valid(self, client, db_session, test_user, test_requisition):
+        """Batch with two valid items → created count matches."""
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            with patch("app.services.task_service.on_requirement_added"):
+                resp = client.post(
+                    f"/api/requisitions/{test_requisition.id}/requirements",
+                    json=[
+                        {"primary_mpn": "BC547", "manufacturer": "ST", "target_qty": 200},
+                        {"primary_mpn": "2N2222", "manufacturer": "ON Semi", "target_qty": 300},
+                    ],
+                )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["created"]) == 2
+
+    def test_add_batch_with_invalid_skips_item(self, client, db_session, test_user, test_requisition):
+        """Batch where one item is invalid → skipped list returned."""
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/requirements",
+                json=[
+                    {"primary_mpn": "BC547", "manufacturer": "ST", "target_qty": 100},
+                    {"primary_mpn": "X", "manufacturer": "", "target_qty": -1},
+                ],
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "skipped" in data
+        assert len(data["skipped"]) >= 1
+
+    def test_add_single_invalid_mpn_raises_422(self, client, db_session, test_user, test_requisition):
+        """Single item with blank primary_mpn → 422 (not batch mode)."""
+        resp = client.post(
+            f"/api/requisitions/{test_requisition.id}/requirements",
+            json={"primary_mpn": "", "manufacturer": "TI", "target_qty": 100},
+        )
+        assert resp.status_code == 422
+
+    def test_add_with_substitutes(self, client, db_session, test_user, test_requisition):
+        """Substitutes deduplication exercised."""
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            with patch("app.services.task_service.on_requirement_added"):
+                resp = client.post(
+                    f"/api/requisitions/{test_requisition.id}/requirements",
+                    json={
+                        "primary_mpn": "LM7812",
+                        "manufacturer": "TI",
+                        "target_qty": 100,
+                        "substitutes": ["LM7808", "LM7808", "LM7812"],
+                    },
+                )
+        assert resp.status_code == 200
+
+    def test_add_with_duplicate_detection(self, client, db_session, test_user):
+        """Duplicate detection runs when customer_site_id is set + card_ids exist."""
+        from app.models import Company, CustomerSite
+
+        co = Company(name="DupCo", is_active=True, created_at=datetime.now(timezone.utc))
+        db_session.add(co)
+        db_session.flush()
+        site = CustomerSite(company_id=co.id, site_name="Main")
+        db_session.add(site)
+        db_session.flush()
+
+        req = _req(db_session, test_user, customer_site_id=site.id)
+
+        # Prior requisition for same site
+        prior_req = _req(db_session, test_user, name="PRIOR-REQ", customer_site_id=site.id)
+        mc = _card(db_session, "BC557")
+        prior_item = _item(db_session, prior_req, primary_mpn="BC557", material_card_id=mc.id)
+        assert prior_item.id is not None
+
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=mc):
+            with patch("app.services.task_service.on_requirement_added"):
+                resp = client.post(
+                    f"/api/requisitions/{req.id}/requirements",
+                    json={"primary_mpn": "BC557", "manufacturer": "Philips", "target_qty": 100},
+                )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "duplicates" in data
+        # The prior req has same site_id and same material_card_id → duplicate flagged
+        assert len(data["duplicates"]) >= 1
+
+    def test_add_task_autoassign_runs(self, client, db_session, test_user, test_requisition):
+        """on_requirement_added is called (patched to verify invocation)."""
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            with patch("app.services.task_service.on_requirement_added") as mock_task:
+                resp = client.post(
+                    f"/api/requisitions/{test_requisition.id}/requirements",
+                    json={"primary_mpn": "LM393", "manufacturer": "TI", "target_qty": 10},
+                )
+        assert resp.status_code == 200
+        mock_task.assert_called_once()
+
+    def test_add_tag_propagation_with_site(self, client, db_session, test_user):
+        """propagate_tags_to_entity is called when material_card_id + customer_site_id set."""
+        from app.models import Company, CustomerSite
+
+        co = Company(name="TagCo", is_active=True, created_at=datetime.now(timezone.utc))
+        db_session.add(co)
+        db_session.flush()
+        site = CustomerSite(company_id=co.id, site_name="HQ")
+        db_session.add(site)
+        db_session.flush()
+
+        req = _req(db_session, test_user, customer_site_id=site.id)
+        mc = _card(db_session, "TL431")
+
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=mc):
+            with patch("app.services.tagging.propagate_tags_to_entity") as mock_tag:
+                with patch("app.services.task_service.on_requirement_added"):
+                    resp = client.post(
+                        f"/api/requisitions/{req.id}/requirements",
+                        json={"primary_mpn": "TL431", "manufacturer": "TI", "target_qty": 10},
+                    )
+        assert resp.status_code == 200
+        assert mock_tag.call_count >= 1
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# upload_requirements — lines 478, 511, 521 (body, condition/packaging branch)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestUploadRequirementsBody:
+    def test_upload_with_price_and_condition(self, client, db_session, test_user, test_requisition):
+        """Exercises normalize_price, normalize_condition, normalize_packaging branches."""
+        csv_content = (
+            b"mpn,qty,price,condition,packaging,manufacturer,date_codes,notes\n"
+            b"LM7805,50,1.25,New,Tape and Reel,TI,2023+,Urgent\n"
+        )
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/upload",
+                files={"file": ("parts.csv", csv_content, "text/csv")},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["created"] >= 1
+
+    def test_upload_with_subs_comma_separated(self, client, db_session, test_user, test_requisition):
+        """substitutes column parsed from comma-separated string."""
+        csv_content = b"mpn,qty,substitutes\nLM317T,100,NE555,LM7805\n"
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/upload",
+                files={"file": ("parts.csv", csv_content, "text/csv")},
+            )
+        assert resp.status_code == 200
+
+    def test_upload_empty_mpn_row_skipped(self, client, db_session, test_user, test_requisition):
+        """Rows where MPN normalizes to None are skipped."""
+        # Use a column name that maps to no MPN field
+        csv_content = b"part,qty\n,100\nAB,50\n"
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/upload",
+                files={"file": ("parts.csv", csv_content, "text/csv")},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["created"] == 0
+
+    def test_upload_parse_error_returns_400(self, client, db_session, test_user, test_requisition):
+        """Unparseable file raises 400."""
+        with patch(
+            "app.file_utils.parse_tabular_file",
+            side_effect=ValueError("bad file"),
+        ):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/upload",
+                files={"file": ("bad.csv", b"garbage", "text/csv")},
+            )
+        assert resp.status_code == 400
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# get_saved_sightings — lines 704, 733-748, 755, 815, 820, 843
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetSavedSightingsBody:
+    def test_with_sightings_enriches_vendor_cards(self, client, db_session, test_user, test_requisition):
+        """Sightings present and _enrich_with_vendor_cards called."""
+        req_item = test_requisition.requirements[0]
+        _sighting(db_session, req_item)
+
+        vc = VendorCard(
+            normalized_name="arrow",
+            display_name="Arrow Electronics",
+            emails=["sales@arrow.com"],
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(vc)
+        db_session.commit()
+
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/sightings")
+        assert resp.status_code == 200
+
+    def test_sightings_with_material_card_on_requirement(self, client, db_session, test_user, test_requisition):
+        """material_card_id on requirement triggers sub_card_lookup path."""
+        mc = _card(db_session, "LM317T")
+        req_item = test_requisition.requirements[0]
+        req_item.material_card_id = mc.id
+        db_session.commit()
+        _sighting(db_session, req_item)
+
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/sightings")
+        assert resp.status_code == 200
+
+    def test_sightings_with_substitute_mpn_string(self, client, db_session, test_user, test_requisition):
+        """String substitute on requirement triggers sub-key lookup path."""
+        req_item = test_requisition.requirements[0]
+        req_item.substitutes = ["NE555P"]
+        db_session.commit()
+        _sighting(db_session, req_item)
+
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/sightings")
+        assert resp.status_code == 200
+
+    def test_sightings_include_lead_data(self, client, db_session, test_user, test_requisition):
+        """_attach_lead_data populates lead_cards for each group."""
+        req_item = test_requisition.requirements[0]
+        _sighting(db_session, req_item)
+        lead = _lead(db_session, test_requisition, req_item, confidence_score=85)
+        assert lead.id is not None
+
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/sightings")
+        assert resp.status_code == 200
+        data = resp.json()
+        key = str(req_item.id)
+        if key in data:
+            assert "lead_cards" in data[key]
+
+    def test_sightings_with_unavailable_sighting_annotated(self, client, db_session, test_user, test_requisition):
+        """Unavailable sighting → buyer_outcome = 'unavailable_confirmed'."""
+        req_item = test_requisition.requirements[0]
+        _sighting(db_session, req_item, is_unavailable=True)
+
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/sightings")
+        assert resp.status_code == 200
+
+    def test_sightings_offer_logged_buyer_outcome(self, client, db_session, test_user, test_requisition):
+        """Sighting whose vendor/MPN matches an active offer → 'offer_logged'."""
+        req_item = test_requisition.requirements[0]
+        _sighting(
+            db_session,
+            req_item,
+            vendor_name="Arrow",
+            vendor_name_normalized="arrow",
+            mpn_matched="LM317T",
+        )
+        _offer(
+            db_session,
+            test_requisition,
+            req_item,
+            test_user,
+            vendor_name="Arrow",
+            vendor_name_normalized="arrow",
+            mpn="LM317T",
+            normalized_mpn="lm317t",
+            status="active",
+        )
+        resp = client.get(f"/api/requisitions/{test_requisition.id}/sightings")
+        assert resp.status_code == 200
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# leads_queue — lines 917-920 (status filter branch)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestLeadsQueue:
+    def test_queue_no_filter(self, client, db_session, test_user, test_requisition):
+        """GET /api/leads/queue with no filter returns all leads."""
+        req_item = test_requisition.requirements[0]
+        _lead(db_session, test_requisition, req_item, buyer_status="open")
+        resp = client.get("/api/leads/queue")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_queue_status_all_skips_filter(self, client, db_session, test_user, test_requisition):
+        """status=all → filter not applied (line 920 branch)."""
+        req_item = test_requisition.requirements[0]
+        _lead(db_session, test_requisition, req_item, buyer_status="open")
+        resp = client.get("/api/leads/queue?status=all")
+        assert resp.status_code == 200
+
+    def test_queue_status_filter_applied(self, client, db_session, test_user, test_requisition):
+        """status=open → only open leads returned (line 918 branch)."""
+        req_item = test_requisition.requirements[0]
+        # Use different vendor names to avoid unique constraint violation
+        _lead(
+            db_session,
+            test_requisition,
+            req_item,
+            buyer_status="open",
+            vendor_name="Arrow",
+            vendor_name_normalized="arrow",
+        )
+        _lead(
+            db_session,
+            test_requisition,
+            req_item,
+            buyer_status="no_stock",
+            vendor_name="Mouser",
+            vendor_name_normalized="mouser",
+        )
+        resp = client.get("/api/leads/queue?status=open")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert all(lx["buyer_status"] == "open" for lx in data)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# get_lead_detail — lines 991, 997 (404 and 403 paths)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetLeadDetail:
+    def test_lead_not_found_returns_404(self, client, db_session, test_user):
+        resp = client.get("/api/leads/999999")
+        assert resp.status_code == 404
+
+    def test_lead_unauthorized_returns_403(self, client, db_session, test_user, test_requisition):
+        """Lead exists but get_req_for_user returns None → 403."""
+        req_item = test_requisition.requirements[0]
+        lead = _lead(db_session, test_requisition, req_item)
+        with patch(
+            "app.routers.requisitions.requirements.get_req_for_user",
+            return_value=None,
+        ):
+            resp = client.get(f"/api/leads/{lead.id}")
+        assert resp.status_code == 403
+
+    def test_lead_found_returns_data(self, client, db_session, test_user, test_requisition):
+        """Lead exists and authorized → 200."""
+        req_item = test_requisition.requirements[0]
+        lead = _lead(db_session, test_requisition, req_item)
+        resp = client.get(f"/api/leads/{lead.id}")
+        assert resp.status_code == 200
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# patch_lead_status — 400 (ValueError), 404 (not found after update)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPatchLeadStatus:
+    _VALID_STATUS = "contacted"  # one of the allowed Literal values
+
+    def test_status_not_found_returns_404(self, client, db_session, test_user):
+        resp = client.patch("/api/leads/999999/status", json={"status": self._VALID_STATUS})
+        assert resp.status_code == 404
+
+    def test_status_unauthorized_returns_403(self, client, db_session, test_user, test_requisition):
+        req_item = test_requisition.requirements[0]
+        lead = _lead(db_session, test_requisition, req_item)
+        with patch(
+            "app.routers.requisitions.requirements.get_req_for_user",
+            return_value=None,
+        ):
+            resp = client.patch(f"/api/leads/{lead.id}/status", json={"status": self._VALID_STATUS})
+        assert resp.status_code == 403
+
+    def test_status_value_error_returns_400(self, client, db_session, test_user, test_requisition):
+        req_item = test_requisition.requirements[0]
+        lead = _lead(db_session, test_requisition, req_item)
+        with patch(
+            "app.routers.requisitions.requirements.update_lead_status",
+            side_effect=ValueError("invalid transition"),
+        ):
+            resp = client.patch(f"/api/leads/{lead.id}/status", json={"status": self._VALID_STATUS})
+        assert resp.status_code == 400
+
+    def test_status_update_returns_none_returns_404(self, client, db_session, test_user, test_requisition):
+        req_item = test_requisition.requirements[0]
+        lead = _lead(db_session, test_requisition, req_item)
+        with patch(
+            "app.routers.requisitions.requirements.update_lead_status",
+            return_value=None,
+        ):
+            resp = client.patch(f"/api/leads/{lead.id}/status", json={"status": self._VALID_STATUS})
+        assert resp.status_code == 404
+
+    def test_status_success(self, client, db_session, test_user, test_requisition):
+        """Successful status update returns ok=True."""
+        from unittest.mock import MagicMock
+
+        req_item = test_requisition.requirements[0]
+        lead = _lead(db_session, test_requisition, req_item)
+        mock_lead = MagicMock()
+        mock_lead.id = lead.id
+        mock_lead.buyer_status = "contacted"
+        mock_lead.confidence_score = 80
+        mock_lead.confidence_band = "high"
+        mock_lead.vendor_safety_score = 70
+        mock_lead.vendor_safety_band = "medium"
+        mock_lead.buyer_feedback_summary = None
+        with patch(
+            "app.routers.requisitions.requirements.update_lead_status",
+            return_value=mock_lead,
+        ):
+            resp = client.patch(f"/api/leads/{lead.id}/status", json={"status": self._VALID_STATUS})
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# import_stock_list — lines 1002-1071 (main body, match/no-match/exception)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestImportStockListBody:
+    def test_import_stock_matching_mpn_creates_sighting(self, client, db_session, test_user, test_requisition):
+        """CSV with MPN matching a requirement creates a sighting."""
+        csv_content = b"mpn,qty,price,condition\nLM317T,500,0.45,new\n"
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/import-stock",
+                data={"vendor_name": "Arrow"},
+                files={"file": ("stock.csv", csv_content, "text/csv")},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["matched_sightings"] >= 1
+
+    def test_import_stock_with_material_card(self, client, db_session, test_user, test_requisition):
+        """resolve_material_card returning a card sets material_card_id on sighting."""
+        mc = _card(db_session, "LM317T")
+        csv_content = b"mpn,qty\nLM317T,200\n"
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=mc):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/import-stock",
+                data={"vendor_name": "DigiKey"},
+                files={"file": ("stock.csv", csv_content, "text/csv")},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["matched_sightings"] >= 1
+
+    def test_import_stock_no_match_skips_sighting(self, client, db_session, test_user, test_requisition):
+        """CSV MPN not in req_mpns → no sightings created."""
+        csv_content = b"mpn,qty\nXYZ999,100\n"
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/import-stock",
+                data={"vendor_name": "Arrow"},
+                files={"file": ("stock.csv", csv_content, "text/csv")},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["matched_sightings"] == 0
+
+    def test_import_stock_exception_returns_500(self, client, db_session, test_user, test_requisition):
+        """Exception during sighting creation → rollback + 500."""
+        csv_content = b"mpn,qty\nLM317T,100\n"
+        with patch(
+            "app.routers.requisitions.requirements.resolve_material_card",
+            side_effect=Exception("db failure"),
+        ):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/import-stock",
+                data={"vendor_name": "Arrow"},
+                files={"file": ("stock.csv", csv_content, "text/csv")},
+            )
+        assert resp.status_code == 500
+
+    def test_import_stock_file_too_large_returns_413(self, client, db_session, test_user, test_requisition):
+        """File > 10MB via import-stock endpoint → 413."""
+        big = b"x" * (10_000_001)
+        resp = client.post(
+            f"/api/requisitions/{test_requisition.id}/import-stock",
+            data={"vendor_name": "Arrow"},
+            files={"file": ("big.csv", big, "text/csv")},
+        )
+        assert resp.status_code == 413
+
+    def test_import_stock_substitute_matching(self, client, db_session, test_user, test_requisition):
+        """Substitute MPN on a requirement matches imported row."""
+        req_item = test_requisition.requirements[0]
+        req_item.substitutes = ["NE555P"]
+        db_session.commit()
+        csv_content = b"mpn,qty\nNE555P,100\n"
+        with patch("app.routers.requisitions.requirements.resolve_material_card", return_value=None):
+            resp = client.post(
+                f"/api/requisitions/{test_requisition.id}/import-stock",
+                data={"vendor_name": "Arrow"},
+                files={"file": ("stock.csv", csv_content, "text/csv")},
+            )
+        assert resp.status_code == 200
+        # substitute match creates sighting
+        assert resp.json()["matched_sightings"] >= 1
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# list_requirement_sightings — lines 1118, 1132 (substitute card lookup)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestListRequirementSightingsSubstitutes:
+    def test_substitute_string_with_material_card(self, client, db_session, test_user, test_requisition):
+        """String substitute MPN that has a material card → sub_rows path exercised."""
+        req_item = test_requisition.requirements[0]
+        req_item.substitutes = ["TL431A"]
+        db_session.commit()
+        _card(db_session, "TL431A")
+        _sighting(db_session, req_item)
+
+        resp = client.get(f"/api/requirements/{req_item.id}/sightings")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "sightings" in data
+
+    def test_requirement_not_found_returns_404(self, client, db_session, test_user):
+        resp = client.get("/api/requirements/999999/sightings")
+        assert resp.status_code == 404
+
+    def test_unauthorized_returns_403(self, client, db_session, test_user, test_requisition):
+        req_item = test_requisition.requirements[0]
+        with patch(
+            "app.routers.requisitions.requirements.get_req_for_user",
+            return_value=None,
+        ):
+            resp = client.get(f"/api/requirements/{req_item.id}/sightings")
+        assert resp.status_code == 403
+
+    def test_sightings_returned_with_lead_data(self, client, db_session, test_user, test_requisition):
+        """_attach_lead_data executed for single-requirement sightings view."""
+        req_item = test_requisition.requirements[0]
+        _sighting(db_session, req_item)
+        lead = _lead(db_session, test_requisition, req_item, confidence_score=90)
+        assert lead.id is not None
+
+        resp = client.get(f"/api/requirements/{req_item.id}/sightings")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "lead_cards" in data
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# list_requirement_offers — lines 1221-1225 (substitute material card path)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestListRequirementOffersSubstitutes:
+    def test_offers_not_found_returns_404(self, client, db_session, test_user):
+        resp = client.get("/api/requirements/999999/offers")
+        assert resp.status_code == 404
+
+    def test_offers_returns_current_offers(self, client, db_session, test_user, test_requisition):
+        req_item = test_requisition.requirements[0]
+        _offer(db_session, test_requisition, req_item, test_user, status="active")
+        resp = client.get(f"/api/requirements/{req_item.id}/offers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 1
+        assert data[0]["is_historical"] is False
+
+    def test_offers_with_string_substitute_card(self, client, db_session, test_user, test_requisition):
+        """String substitute with material card → card_ids lookup exercised (line 1221-1225)."""
+        req_item = test_requisition.requirements[0]
+        req_item.substitutes = ["TL431A"]
+        db_session.commit()
+        sub_mc = _card(db_session, "TL431A")
+
+        # Create a historical offer for the substitute card
+        other_req = _req(db_session, test_user, name="OTHER-REQ")
+        _offer(
+            db_session,
+            other_req,
+            req_item,
+            test_user,
+            material_card_id=sub_mc.id,
+            status="active",
+        )
+
+        resp = client.get(f"/api/requirements/{req_item.id}/offers")
+        assert resp.status_code == 200
+
+    def test_offers_historical_flag_set(self, client, db_session, test_user, test_requisition):
+        """Historical offers from other requisitions via material card have is_historical=True."""
+        req_item = test_requisition.requirements[0]
+        mc = _card(db_session, "LM317T")
+        req_item.material_card_id = mc.id
+        db_session.commit()
+
+        # Create another requisition and offer on same material card
+        other_req = _req(db_session, test_user, name="HIST-REQ")
+        other_item = _item(db_session, other_req, primary_mpn="LM317T", material_card_id=mc.id)
+        _offer(db_session, other_req, other_item, test_user, material_card_id=mc.id, status="active")
+
+        resp = client.get(f"/api/requirements/{req_item.id}/offers")
+        assert resp.status_code == 200
+        data = resp.json()
+        hist = [o for o in data if o.get("is_historical")]
+        assert len(hist) >= 1
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# toggle_quote_selection — line 1273-1283 (403 path)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestToggleQuoteSelectionAuth:
+    def test_toggle_unauthorized_returns_403(self, client, db_session, test_user, test_requisition):
+        req_item = test_requisition.requirements[0]
+        offer = _offer(db_session, test_requisition, req_item, test_user)
+        with patch(
+            "app.routers.requisitions.requirements.get_req_for_user",
+            return_value=None,
+        ):
+            resp = client.post(f"/api/offers/{offer.id}/toggle-quote-selection")
+        assert resp.status_code == 403
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# list_requirement_notes / add_requirement_note — lines 1305-1313, 1327-1359
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestRequirementNotesBody:
+    def test_list_notes_with_offer_notes(self, client, db_session, test_user, test_requisition):
+        """Offer with notes included in response."""
+        req_item = test_requisition.requirements[0]
+        _offer(db_session, test_requisition, req_item, test_user, notes="Priority vendor")
+        resp = client.get(f"/api/requirements/{req_item.id}/notes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(n["note"] == "Priority vendor" for n in data["notes"])
+
+    def test_add_note_creates_timestamp_entry(self, client, db_session, test_user, test_requisition):
+        """Note append includes timestamp and user email."""
+        req_item = test_requisition.requirements[0]
+        resp = client.post(
+            f"/api/requirements/{req_item.id}/notes",
+            json={"text": "Check lead times"},
+        )
+        assert resp.status_code == 200
+        notes = resp.json()["notes"]
+        assert "Check lead times" in notes
+        assert "testbuyer@trioscs.com" in notes
+
+    def test_add_note_appends_to_existing(self, client, db_session, test_user, test_requisition):
+        req_item = test_requisition.requirements[0]
+        req_item.notes = "Initial note"
+        db_session.commit()
+        resp = client.post(
+            f"/api/requirements/{req_item.id}/notes",
+            json={"text": "Follow-up"},
+        )
+        assert resp.status_code == 200
+        result = resp.json()["notes"]
+        assert "Initial note" in result
+        assert "Follow-up" in result
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# list_requirement_tasks — line 1392 (with offer-level tasks)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestListRequirementTasksWithOffers:
+    def test_offer_level_tasks_included(self, client, db_session, test_user, test_requisition):
+        """Tasks whose source_ref = 'offer:{id}' are included in the result."""
+        req_item = test_requisition.requirements[0]
+        offer = _offer(db_session, test_requisition, req_item, test_user)
+        task = RequisitionTask(
+            requisition_id=test_requisition.id,
+            title="Send quote",
+            task_type="quote",
+            status="todo",
+            source="manual",
+            source_ref=f"offer:{offer.id}",
+            created_by=test_user.id,
+            assigned_to_id=test_user.id,
+        )
+        db_session.add(task)
+        db_session.commit()
+
+        resp = client.get(f"/api/requirements/{req_item.id}/tasks")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(t["source_ref"] == f"offer:{offer.id}" for t in data)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# list_requirement_history — lines 1430, 1462, 1510-1512, 1536 (offer changes,
+# rfq_sent, task_done)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestListRequirementHistoryBody:
+    def test_history_not_found_returns_404(self, client, db_session, test_user):
+        resp = client.get("/api/requirements/999999/history")
+        assert resp.status_code == 404
+
+    def test_history_with_offer_changelog(self, client, db_session, test_user, test_requisition):
+        """Change log on an offer for this requirement appears in history."""
+        req_item = test_requisition.requirements[0]
+        offer = _offer(db_session, test_requisition, req_item, test_user)
+        cl = ChangeLog(
+            entity_type="offer",
+            entity_id=offer.id,
+            user_id=test_user.id,
+            field_name="unit_price",
+            old_value="0.50",
+            new_value="0.45",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(cl)
+        db_session.commit()
+
+        resp = client.get(f"/api/requirements/{req_item.id}/history")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(e["type"] == "change" and e["entity"] == "offer" for e in data)
+
+    def test_history_rfq_sent_only_when_mpn_in_parts(self, client, db_session, test_user, test_requisition):
+        """Contact with parts_included matching MPN → rfq_sent event."""
+        req_item = test_requisition.requirements[0]
+        ct = Contact(
+            requisition_id=test_requisition.id,
+            user_id=test_user.id,
+            contact_type="rfq",
+            vendor_name="Mouser",
+            parts_included=[req_item.primary_mpn],
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ct)
+        db_session.commit()
+
+        resp = client.get(f"/api/requirements/{req_item.id}/history")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(e["type"] == "rfq_sent" for e in data)
+
+    def test_history_rfq_not_included_when_mpn_not_in_parts(self, client, db_session, test_user, test_requisition):
+        """Contact with different parts_included → no rfq_sent event."""
+        req_item = test_requisition.requirements[0]
+        ct = Contact(
+            requisition_id=test_requisition.id,
+            user_id=test_user.id,
+            contact_type="rfq",
+            vendor_name="Mouser",
+            parts_included=["DIFFERENT_MPN"],
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(ct)
+        db_session.commit()
+
+        resp = client.get(f"/api/requirements/{req_item.id}/history")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert not any(e["type"] == "rfq_sent" for e in data)
+
+    def test_history_done_task_via_offer_ref(self, client, db_session, test_user, test_requisition):
+        """Task with source_ref=offer:{id} that is 'done' → task_done in history."""
+        req_item = test_requisition.requirements[0]
+        offer = _offer(db_session, test_requisition, req_item, test_user)
+        task = RequisitionTask(
+            requisition_id=test_requisition.id,
+            title="Completed offer task",
+            task_type="general",
+            status="done",
+            source="manual",
+            source_ref=f"offer:{offer.id}",
+            created_by=test_user.id,
+            completed_at=datetime.now(timezone.utc),
+        )
+        db_session.add(task)
+        db_session.commit()
+
+        resp = client.get(f"/api/requirements/{req_item.id}/history")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(e["type"] == "task_done" for e in data)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# _annotate_buyer_outcomes and _attach_lead_data helper coverage (lines 163, 179, 184, 188)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+class TestAnnotateBuyerOutcomesHelpers:
+    def test_annotate_empty_req_ids_no_op(self, db_session, test_user):
+        """_annotate_buyer_outcomes with empty requirements → no-op."""
+        from app.routers.requisitions.requirements import _annotate_buyer_outcomes
+
+        req = _req(db_session, test_user)
+        _annotate_buyer_outcomes(req, {}, db_session)
+        # No exception = pass
+
+    def test_annotate_with_no_results_no_op(self, db_session, test_user):
+        """_annotate_buyer_outcomes with results=None → no-op."""
+        from app.routers.requisitions.requirements import _annotate_buyer_outcomes
+
+        req = _req(db_session, test_user)
+        _item(db_session, req)
+        db_session.refresh(req)
+        _annotate_buyer_outcomes(req, None, db_session)
+
+    def test_attach_lead_data_empty_req_ids_no_op(self, db_session):
+        """_attach_lead_data with requirements having no id → no-op."""
+        from app.routers.requisitions.requirements import _attach_lead_data
+
+        r = Requirement(requisition_id=None, primary_mpn="X")
+        r.id = None
+        _attach_lead_data([r], {}, db_session)
+
+    def test_attach_lead_data_builds_lead_summary(self, db_session, test_user, test_requisition):
+        """_attach_lead_data populates lead_summary for a group with a lead."""
+        from app.routers.requisitions.requirements import _attach_lead_data
+
+        req_item = test_requisition.requirements[0]
+        lead = _lead(
+            db_session,
+            test_requisition,
+            req_item,
+            confidence_score=80,
+            vendor_safety_score=85,
+        )
+        assert lead.id is not None
+
+        results = {str(req_item.id): {"sightings": [], "label": "LM317T"}}
+        _attach_lead_data(test_requisition.requirements, results, db_session)
+
+        grp = results[str(req_item.id)]
+        assert "lead_summary" in grp
+        assert grp["lead_summary"]["total_leads"] >= 1

--- a/tests/test_schemas_nightly_coverage.py
+++ b/tests/test_schemas_nightly_coverage.py
@@ -1,0 +1,123 @@
+"""test_schemas_nightly_coverage.py — Tests for app/schemas/proactive.py and app/schemas/admin.py.
+
+Covers Pydantic model instantiation and field validation.
+
+Called by: pytest
+Depends on: app/schemas/proactive.py, app/schemas/admin.py
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from app.schemas.admin import SourceCredentialsUpdate, TeamsChannelRouting
+from app.schemas.proactive import (
+    DismissMatches,
+    DoNotOfferItem,
+    DoNotOfferRequest,
+    DraftProactive,
+    SendProactive,
+)
+
+
+class TestDismissMatches:
+    def test_basic(self):
+        obj = DismissMatches(match_ids=[1, 2, 3])
+        assert obj.match_ids == [1, 2, 3]
+
+    def test_empty_list(self):
+        obj = DismissMatches(match_ids=[])
+        assert obj.match_ids == []
+
+
+class TestDraftProactive:
+    def test_defaults(self):
+        obj = DraftProactive(match_ids=[1])
+        assert obj.match_ids == [1]
+        assert obj.contact_ids == []
+        assert obj.sell_prices == {}
+        assert obj.notes is None
+
+    def test_full(self):
+        obj = DraftProactive(
+            match_ids=[1, 2],
+            contact_ids=[10],
+            sell_prices={"LM317T": 0.55},
+            notes="Draft note",
+        )
+        assert obj.notes == "Draft note"
+        assert obj.sell_prices["LM317T"] == 0.55
+
+
+class TestSendProactive:
+    def test_required_fields(self):
+        obj = SendProactive(match_ids=[1], contact_ids=[10])
+        assert obj.match_ids == [1]
+        assert obj.contact_ids == [10]
+        assert obj.sell_prices == {}
+        assert obj.subject is None
+        assert obj.notes is None
+        assert obj.email_html is None
+
+    def test_full(self):
+        obj = SendProactive(
+            match_ids=[1, 2],
+            contact_ids=[10, 11],
+            sell_prices={"ABC": 1.25},
+            subject="RFQ for ABC",
+            notes="Please respond",
+            email_html="<p>Hello</p>",
+        )
+        assert obj.subject == "RFQ for ABC"
+        assert obj.email_html == "<p>Hello</p>"
+
+
+class TestDoNotOfferItem:
+    def test_required(self):
+        obj = DoNotOfferItem(mpn="LM317T", company_id=42)
+        assert obj.mpn == "LM317T"
+        assert obj.company_id == 42
+        assert obj.reason is None
+
+    def test_with_reason(self):
+        obj = DoNotOfferItem(mpn="LM317T", company_id=42, reason="Competitor")
+        assert obj.reason == "Competitor"
+
+
+class TestDoNotOfferRequest:
+    def test_empty(self):
+        obj = DoNotOfferRequest(items=[])
+        assert obj.items == []
+
+    def test_with_items(self):
+        obj = DoNotOfferRequest(
+            items=[
+                DoNotOfferItem(mpn="LM317T", company_id=1),
+                DoNotOfferItem(mpn="TL071", company_id=2, reason="Price"),
+            ]
+        )
+        assert len(obj.items) == 2
+
+
+class TestSourceCredentialsUpdate:
+    def test_accepts_dynamic_keys(self):
+        obj = SourceCredentialsUpdate(**{"API_KEY": "secret123", "API_SECRET": "xyz"})
+        assert obj.model_extra["API_KEY"] == "secret123"
+        assert obj.model_extra["API_SECRET"] == "xyz"
+
+    def test_empty(self):
+        obj = SourceCredentialsUpdate()
+        assert obj.model_extra == {}
+
+
+class TestTeamsChannelRouting:
+    def test_accepts_dynamic_keys(self):
+        obj = TeamsChannelRouting(
+            teams_channel_hot="https://webhook.office.com/hot",
+            teams_channel_quotes="https://webhook.office.com/quotes",
+        )
+        assert "teams_channel_hot" in obj.model_extra
+
+    def test_empty(self):
+        obj = TeamsChannelRouting()
+        assert obj.model_extra == {}

--- a/tests/test_sightings_nightly_coverage.py
+++ b/tests/test_sightings_nightly_coverage.py
@@ -1,0 +1,1115 @@
+"""tests/test_sightings_nightly_coverage.py — Coverage gap tests for sightings router.
+
+Targets the lines uncovered by existing sightings test files when they run in
+the pytest-xdist parallel harness. This file is designed to run serially so
+coverage is collected correctly.
+
+Called by: pytest (target: tests/test_sightings_nightly_coverage.py)
+Depends on: conftest.py fixtures, app/routers/sightings.py
+"""
+
+import json
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+from fastapi.responses import HTMLResponse as _HTMLResponse
+from sqlalchemy.orm import Session
+
+from app.models import ActivityLog, Requirement, Requisition, User, VendorCard, VendorContact
+from app.models.sourcing import Sighting
+
+
+def _make_req(db, user):
+    req = Requisition(
+        name="REQ-SIGHTINGS-01",
+        customer_name="Test Corp",
+        status="active",
+        created_by=user.id,
+    )
+    db.add(req)
+    db.flush()
+    return req
+
+
+def _make_item(db, req, mpn="LM317T"):
+    item = Requirement(
+        requisition_id=req.id,
+        primary_mpn=mpn,
+        target_qty=100,
+        target_price=0.50,
+        sourcing_status="open",
+    )
+    db.add(item)
+    db.flush()
+    return item
+
+
+def _make_sighting(db, item, vendor="Arrow Electronics"):
+    sighting = Sighting(
+        requirement_id=item.id,
+        vendor_name=vendor,
+        qty_available=1000,
+        unit_price=0.55,
+        currency="USD",
+        is_unavailable=False,
+    )
+    db.add(sighting)
+    db.flush()
+    return sighting
+
+
+def _make_req_and_item(db: Session, user: User, mpn: str = "LM317T") -> tuple:
+    req = Requisition(name=f"NC-REQ-{mpn}", status="active", created_by=user.id)
+    db.add(req)
+    db.flush()
+    item = Requirement(
+        requisition_id=req.id,
+        primary_mpn=mpn,
+        target_qty=100,
+        sourcing_status="open",
+    )
+    db.add(item)
+    db.flush()
+    db.commit()
+    db.refresh(item)
+    return req, item
+
+
+# ── batch-assign ──────────────────────────────────────────────────────
+
+
+class TestBatchAssign:
+    def test_assign_buyer_to_requirements(self, client, db_session, test_user, test_requisition):
+        """Batch assign buyer to requirements returns 200 HTML."""
+        item = test_requisition.requirements[0]
+        payload = {"requirement_ids": json.dumps([item.id]), "buyer_id": str(test_user.id)}
+        resp = client.post("/v2/partials/sightings/batch-assign", data=payload)
+        assert resp.status_code == 200
+        db_session.refresh(item)
+        assert item.assigned_buyer_id == test_user.id
+
+    def test_assign_no_buyer_id(self, client, db_session, test_user, test_requisition):
+        """Batch assign with no buyer_id unassigns."""
+        item = test_requisition.requirements[0]
+        item.assigned_buyer_id = test_user.id
+        db_session.commit()
+
+        payload = {"requirement_ids": json.dumps([item.id]), "buyer_id": ""}
+        resp = client.post("/v2/partials/sightings/batch-assign", data=payload)
+        assert resp.status_code == 200
+        db_session.refresh(item)
+        assert item.assigned_buyer_id is None
+
+    def test_assign_empty_selection_returns_toast(self, client):
+        """No requirements selected returns a warning toast."""
+        payload = {"requirement_ids": "[]", "buyer_id": ""}
+        resp = client.post("/v2/partials/sightings/batch-assign", data=payload)
+        assert resp.status_code == 200
+        assert b"No requirements selected" in resp.content
+
+    def test_assign_known_buyer_name_shown(self, client, db_session, test_user, test_requisition):
+        """Buyer name shown in toast when buyer_id resolves to existing user (line 793)."""
+        item = test_requisition.requirements[0]
+        payload = {"requirement_ids": json.dumps([item.id]), "buyer_id": str(test_user.id)}
+        resp = client.post("/v2/partials/sightings/batch-assign", data=payload)
+        assert resp.status_code == 200
+        assert test_user.name in resp.text or "assigned" in resp.text.lower()
+
+
+# ── batch-status ──────────────────────────────────────────────────────
+
+
+class TestBatchStatus:
+    def test_update_status_valid_transition(self, client, db_session, test_user, test_requisition):
+        """Valid status transition open → sourcing updates requirements."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "open"
+        db_session.commit()
+
+        payload = {"requirement_ids": json.dumps([item.id]), "status": "sourcing"}
+        resp = client.post("/v2/partials/sightings/batch-status", data=payload)
+        assert resp.status_code == 200
+
+    def test_empty_selection_returns_toast(self, client):
+        """No requirements selected returns warning toast."""
+        payload = {"requirement_ids": "[]", "status": "sourcing"}
+        resp = client.post("/v2/partials/sightings/batch-status", data=payload)
+        assert resp.status_code == 200
+        assert b"No requirements selected" in resp.content
+
+    def test_invalid_status_returns_400(self, client):
+        """Completely invalid status value returns 400."""
+        payload = {"requirement_ids": "[1]", "status": "not_a_real_status"}
+        resp = client.post("/v2/partials/sightings/batch-status", data=payload)
+        assert resp.status_code == 400
+
+    def test_invalid_transition_skipped(self, client, db_session, test_user, test_requisition):
+        """Requirements in archived state (no allowed transitions) are skipped."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "archived"
+        db_session.commit()
+
+        payload = {"requirement_ids": json.dumps([item.id]), "status": "sourcing"}
+        resp = client.post("/v2/partials/sightings/batch-status", data=payload)
+        assert resp.status_code == 200
+        assert b"skipped" in resp.content.lower()
+
+
+# ── batch-notes ───────────────────────────────────────────────────────
+
+
+class TestBatchNotes:
+    def test_add_note_to_requirements(self, client, db_session, test_user, test_requisition):
+        """Batch notes logs an activity."""
+        item = test_requisition.requirements[0]
+        payload = {"requirement_ids": json.dumps([item.id]), "notes": "Test batch note"}
+        resp = client.post("/v2/partials/sightings/batch-notes", data=payload)
+        assert resp.status_code == 200
+
+    def test_empty_selection_returns_toast(self, client):
+        """No requirements selected returns warning toast."""
+        payload = {"requirement_ids": "[]", "notes": "Some note"}
+        resp = client.post("/v2/partials/sightings/batch-notes", data=payload)
+        assert resp.status_code == 200
+        assert b"No requirements selected" in resp.content
+
+
+# ── mark-unavailable ──────────────────────────────────────────────────
+
+
+class TestMarkUnavailable:
+    def test_marks_sightings_unavailable(self, client, db_session, test_user, test_requisition):
+        """Marks all sightings for a vendor as unavailable."""
+        item = test_requisition.requirements[0]
+        sighting = _make_sighting(db_session, item, "Arrow Electronics")
+        db_session.commit()
+
+        payload = {"vendor_name": "Arrow Electronics"}
+        resp = client.post(
+            f"/v2/partials/sightings/{item.id}/mark-unavailable",
+            data=payload,
+        )
+        assert resp.status_code == 200
+        db_session.refresh(sighting)
+        assert sighting.is_unavailable is True
+
+    def test_missing_vendor_name_returns_400(self, client, test_requisition):
+        """Missing vendor_name returns 400."""
+        item = test_requisition.requirements[0]
+        resp = client.post(f"/v2/partials/sightings/{item.id}/mark-unavailable", data={})
+        assert resp.status_code == 400
+
+
+# ── assign-buyer ──────────────────────────────────────────────────────
+
+
+class TestAssignBuyer:
+    def test_assigns_buyer(self, client, db_session, test_user, test_requisition):
+        """Assigns a buyer to a requirement."""
+        item = test_requisition.requirements[0]
+        payload = {"assigned_buyer_id": str(test_user.id)}
+        resp = client.patch(f"/v2/partials/sightings/{item.id}/assign", data=payload)
+        assert resp.status_code == 200
+        db_session.refresh(item)
+        assert item.assigned_buyer_id == test_user.id
+
+    def test_unassigns_buyer(self, client, db_session, test_user, test_requisition):
+        """Empty buyer_id unassigns."""
+        item = test_requisition.requirements[0]
+        item.assigned_buyer_id = test_user.id
+        db_session.commit()
+
+        payload = {"assigned_buyer_id": ""}
+        resp = client.patch(f"/v2/partials/sightings/{item.id}/assign", data=payload)
+        assert resp.status_code == 200
+        db_session.refresh(item)
+        assert item.assigned_buyer_id is None
+
+    def test_nonexistent_requirement_returns_404(self, client):
+        """404 for unknown requirement."""
+        payload = {"assigned_buyer_id": "1"}
+        resp = client.patch("/v2/partials/sightings/99999/assign", data=payload)
+        assert resp.status_code == 404
+
+
+# ── advance-status ────────────────────────────────────────────────────
+
+
+class TestAdvanceStatus:
+    def test_advances_valid_status(self, client, db_session, test_user, test_requisition):
+        """Valid transition updates sourcing_status."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "open"
+        db_session.commit()
+
+        payload = {"status": "searching"}
+        resp = client.patch(f"/v2/partials/sightings/{item.id}/advance-status", data=payload)
+        assert resp.status_code in (200, 409)
+
+    def test_missing_status_returns_400(self, client, test_requisition):
+        """No status provided → 400."""
+        item = test_requisition.requirements[0]
+        resp = client.patch(f"/v2/partials/sightings/{item.id}/advance-status", data={})
+        assert resp.status_code == 400
+
+    def test_nonexistent_requirement_returns_404(self, client):
+        """404 for unknown requirement."""
+        resp = client.patch("/v2/partials/sightings/99999/advance-status", data={"status": "searching"})
+        assert resp.status_code == 404
+
+
+# ── log-activity ──────────────────────────────────────────────────────
+
+
+class TestLogActivity:
+    def test_logs_note_activity(self, client, db_session, test_user, test_requisition):
+        """POST log-activity creates an ActivityLog record."""
+        item = test_requisition.requirements[0]
+        payload = {"notes": "Test note entry", "channel": "note", "vendor_name": ""}
+        resp = client.post(f"/v2/partials/sightings/{item.id}/log-activity", data=payload)
+        assert resp.status_code == 200
+
+        activity = db_session.query(ActivityLog).filter(ActivityLog.requirement_id == item.id).first()
+        assert activity is not None
+        assert "Test note entry" in activity.notes
+
+    def test_logs_call_activity(self, client, db_session, test_user, test_requisition):
+        """Call channel sets activity_type to call_outbound."""
+        item = test_requisition.requirements[0]
+        payload = {"notes": "Called vendor", "channel": "call", "vendor_name": "Arrow"}
+        resp = client.post(f"/v2/partials/sightings/{item.id}/log-activity", data=payload)
+        assert resp.status_code == 200
+
+        activity = (
+            db_session.query(ActivityLog)
+            .filter(ActivityLog.requirement_id == item.id, ActivityLog.activity_type == "call_outbound")
+            .first()
+        )
+        assert activity is not None
+
+    def test_empty_notes_returns_400(self, client, test_requisition):
+        """Empty notes → 400."""
+        item = test_requisition.requirements[0]
+        payload = {"notes": "   ", "channel": "note"}
+        resp = client.post(f"/v2/partials/sightings/{item.id}/log-activity", data=payload)
+        assert resp.status_code == 400
+
+    def test_invalid_channel_returns_400(self, client, test_requisition):
+        """Invalid channel → 400."""
+        item = test_requisition.requirements[0]
+        payload = {"notes": "Some note", "channel": "fax"}
+        resp = client.post(f"/v2/partials/sightings/{item.id}/log-activity", data=payload)
+        assert resp.status_code == 400
+
+    def test_nonexistent_requirement_returns_404(self, client):
+        """404 for unknown requirement."""
+        payload = {"notes": "Some note", "channel": "note"}
+        resp = client.post("/v2/partials/sightings/99999/log-activity", data=payload)
+        assert resp.status_code == 404
+
+
+# ── sightings_refresh ─────────────────────────────────────────────────
+
+
+class TestSightingsRefresh:
+    def test_refresh_unknown_requirement(self, client):
+        """404 for unknown requirement."""
+        resp = client.post("/v2/partials/sightings/99999/refresh")
+        assert resp.status_code == 404
+
+    def test_refresh_success(self, client, db_session, test_user, test_requisition):
+        """Refresh succeeds and returns detail panel."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            return_value={"mpn_results": {"LM317T": "found"}},
+        ):
+            resp = client.post(f"/v2/partials/sightings/{item.id}/refresh")
+        assert resp.status_code == 200
+
+    def test_refresh_handles_search_exception(self, client, db_session, test_user, test_requisition):
+        """Search exception doesn't crash the endpoint — returns refresh_failed toast."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("API unavailable"),
+        ):
+            resp = client.post(f"/v2/partials/sightings/{item.id}/refresh")
+        assert resp.status_code == 200
+
+
+# ── batch-refresh ─────────────────────────────────────────────────────
+
+
+class TestBatchRefresh:
+    def test_batch_refresh_empty_ids(self, client):
+        """No requirement_ids → warning toast."""
+        payload = {"requirement_ids": "[]"}
+        resp = client.post("/v2/partials/sightings/batch-refresh", data=payload)
+        assert resp.status_code == 200
+
+    def test_batch_refresh_runs(self, client, db_session, test_user, test_requisition):
+        """Batch refresh with valid IDs returns 200."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            return_value={"mpn_results": {"LM317T": "found"}},
+        ):
+            payload = {"requirement_ids": json.dumps([item.id])}
+            resp = client.post("/v2/partials/sightings/batch-refresh", data=payload)
+        assert resp.status_code == 200
+
+    def test_batch_refresh_sse_source_returns_empty(self, client, test_requisition):
+        """source=sse suppresses the OOB toast (returns empty HTML)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            return_value={"mpn_results": {}},
+        ):
+            payload = {"requirement_ids": json.dumps([item.id])}
+            resp = client.post("/v2/partials/sightings/batch-refresh?source=sse", data=payload)
+        assert resp.status_code == 200
+        assert resp.content == b""
+
+
+# ── _build_mpn_toast unit tests ───────────────────────────────────────
+
+
+class TestBuildMpnToast:
+    def test_searched_and_cached_mixed(self):
+        """Both searched and cached MPNs → combined message (line 677)."""
+        from app.routers.sightings import _build_mpn_toast
+
+        result = _build_mpn_toast({"A": "searched", "B": "cached"}, False)
+        assert "1" in result and "cached" in result
+
+    def test_all_cached(self):
+        """Only cached MPNs → 'All MPNs searched within 48h'."""
+        from app.routers.sightings import _build_mpn_toast
+
+        result = _build_mpn_toast({"A": "cached", "B": "cached"}, False)
+        assert "48h" in result
+
+
+# ── _build_mpn_toast via refresh endpoint (lines 677, 679, 680) ──────────────
+# Direct HTTP endpoint tests that fire the toast branches
+
+
+class TestBuildMpnToastViaRefresh:
+    """Tests _build_mpn_toast indirectly by checking refresh HX-Trigger headers."""
+
+    def test_searched_and_cached_mix_fires_line_677(self, client, db_session, test_user, test_requisition):
+        """searched > 0 AND cached > 0 → line 677 branch (mixed message)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            return_value={"mpn_results": {"MPN1": "searched", "MPN2": "cached"}},
+        ):
+            resp = client.post(f"/v2/partials/sightings/{item.id}/refresh")
+        assert resp.status_code == 200
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "cached" in trigger
+
+    def test_all_cached_fires_line_680(self, client, db_session, test_user, test_requisition):
+        """All cached → line 680 branch (all-cached message with 48h)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            return_value={"mpn_results": {"MPN1": "cached", "MPN2": "cached"}},
+        ):
+            resp = client.post(f"/v2/partials/sightings/{item.id}/refresh")
+        assert resp.status_code == 200
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "48h" in trigger
+
+    def test_only_searched_fires_line_679(self, client, db_session, test_user, test_requisition):
+        """Only searched → line 679 branch (Searched N MPNs)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            return_value={"mpn_results": {"MPN1": "searched"}},
+        ):
+            resp = client.post(f"/v2/partials/sightings/{item.id}/refresh")
+        assert resp.status_code == 200
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "Searched" in trigger
+
+    def test_empty_results_no_hx_trigger(self, client, db_session, test_user, test_requisition):
+        """Empty mpn_results → no HX-Trigger (line 673 false branch)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            return_value={"mpn_results": {}},
+        ):
+            resp = client.post(f"/v2/partials/sightings/{item.id}/refresh")
+        assert resp.status_code == 200
+        assert "HX-Trigger" not in resp.headers
+
+
+# ── batch-refresh missing branches (lines 699-764) ───────────────────────────
+
+
+class TestBatchRefreshMissingBranches:
+    def test_invalid_json_returns_400(self, client):
+        """Malformed JSON returns 400 (lines 704-705)."""
+        resp = client.post(
+            "/v2/partials/sightings/batch-refresh",
+            data={"requirement_ids": "not-json!!!"},
+        )
+        assert resp.status_code == 400
+
+    def test_non_list_json_treated_as_empty(self, client):
+        """Non-list JSON (dict) is coerced to empty list (line 703)."""
+        resp = client.post(
+            "/v2/partials/sightings/batch-refresh",
+            data={"requirement_ids": '{"key": "value"}'},
+        )
+        assert resp.status_code == 200
+
+    def test_too_many_ids_returns_400(self, client):
+        """More than MAX_BATCH_SIZE IDs returns 400 (lines 707-708)."""
+        resp = client.post(
+            "/v2/partials/sightings/batch-refresh",
+            data={"requirement_ids": json.dumps(list(range(51)))},
+        )
+        assert resp.status_code == 400
+
+    def test_nonexistent_id_counts_as_failed(self, client):
+        """Non-existent requirement ID increments failed (lines 724-727)."""
+        resp = client.post(
+            "/v2/partials/sightings/batch-refresh",
+            data={"requirement_ids": "[88888]"},
+        )
+        assert resp.status_code == 200
+        assert "1" in resp.text
+
+    def test_valid_requirement_triggers_search(self, client, db_session, test_user, test_requisition):
+        """Valid ID fires search_requirement (lines 737-747)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_search:
+            resp = client.post(
+                "/v2/partials/sightings/batch-refresh",
+                data={"requirement_ids": json.dumps([item.id])},
+            )
+        assert resp.status_code == 200
+        mock_search.assert_awaited_once()
+
+    def test_search_exception_increments_failed(self, client, db_session, test_user, test_requisition):
+        """Search exception increments failed count (lines 743-745)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("connector error"),
+        ):
+            resp = client.post(
+                "/v2/partials/sightings/batch-refresh",
+                data={"requirement_ids": json.dumps([item.id])},
+            )
+        assert resp.status_code == 200
+        assert "warning" in resp.text or "1" in resp.text
+
+    def test_sse_source_suppresses_toast_returns_empty(self, client, db_session, test_user, test_requisition):
+        """source=sse returns empty HTMLResponse (line 764)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            resp = client.post(
+                "/v2/partials/sightings/batch-refresh?source=sse",
+                data={"requirement_ids": json.dumps([item.id])},
+            )
+        assert resp.status_code == 200
+        assert resp.text == ""
+
+    def test_failed_toast_warning_level(self, client, db_session, test_user, test_requisition):
+        """When failed > 0, toast level is warning (lines 759-762)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.search_service.search_requirement",
+            new_callable=AsyncMock,
+            side_effect=Exception("fail"),
+        ):
+            resp = client.post(
+                "/v2/partials/sightings/batch-refresh",
+                data={"requirement_ids": json.dumps([item.id])},
+            )
+        assert resp.status_code == 200
+        assert "warning" in resp.text
+
+
+# ── batch-assign missing branches (lines 776-801) ────────────────────────────
+
+
+class TestBatchAssignMissingBranches:
+    def test_too_many_returns_400(self, client):
+        """Over MAX_BATCH_SIZE returns 400 (lines 781-782)."""
+        resp = client.post(
+            "/v2/partials/sightings/batch-assign",
+            data={"requirement_ids": json.dumps(list(range(51))), "buyer_id": "1"},
+        )
+        assert resp.status_code == 400
+
+    def test_buyer_name_shown_in_toast(self, client, db_session, test_user, test_requisition):
+        """Buyer name displayed in toast when buyer_id resolves to a user (line 793)."""
+        item = test_requisition.requirements[0]
+        resp = client.post(
+            "/v2/partials/sightings/batch-assign",
+            data={"requirement_ids": json.dumps([item.id]), "buyer_id": str(test_user.id)},
+        )
+        assert resp.status_code == 200
+        assert test_user.name in resp.text or "assigned" in resp.text.lower()
+
+    def test_plural_requirements_text(self, client, db_session, test_user, test_requisition):
+        """2 requirements → plural 'requirements' (line 800)."""
+        item = test_requisition.requirements[0]
+        # Need a second requirement in the same/different requisition
+        req2, item2 = _make_req_and_item(db_session, test_user, mpn="BASSN-EXTRA")
+        resp = client.post(
+            "/v2/partials/sightings/batch-assign",
+            data={"requirement_ids": json.dumps([item.id, item2.id]), "buyer_id": ""},
+        )
+        assert resp.status_code == 200
+        assert "requirements" in resp.text
+
+
+# ── batch-status missing branches (lines 815-861) ────────────────────────────
+
+
+class TestBatchStatusMissingBranches:
+    def test_too_many_returns_400(self, client):
+        """Over MAX_BATCH_SIZE returns 400 (lines 819-820)."""
+        resp = client.post(
+            "/v2/partials/sightings/batch-status",
+            data={"requirement_ids": json.dumps(list(range(51))), "status": "sourcing"},
+        )
+        assert resp.status_code == 400
+
+    def test_valid_transition_creates_activity_log(self, client, db_session, test_user, test_requisition):
+        """Valid transition creates ActivityLog (lines 831-852)."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "open"
+        db_session.commit()
+        resp = client.post(
+            "/v2/partials/sightings/batch-status",
+            data={"requirement_ids": json.dumps([item.id]), "status": "sourcing"},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(item)
+        assert item.sourcing_status == "sourcing"
+        log = db_session.query(ActivityLog).filter_by(requirement_id=item.id).first()
+        assert log is not None
+
+    def test_skipped_increments_causes_warning_level(self, client, db_session, test_user, test_requisition):
+        """Skipped > 0 → warning level toast (lines 856-860)."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "won"
+        db_session.commit()
+        resp = client.post(
+            "/v2/partials/sightings/batch-status",
+            data={"requirement_ids": json.dumps([item.id]), "status": "open"},
+        )
+        assert resp.status_code == 200
+        assert "skipped" in resp.text.lower() or "warning" in resp.text.lower()
+
+    def test_all_valid_success_level(self, client, db_session, test_user, test_requisition):
+        """All valid → success level (line 856)."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "open"
+        db_session.commit()
+        resp = client.post(
+            "/v2/partials/sightings/batch-status",
+            data={"requirement_ids": json.dumps([item.id]), "status": "sourcing"},
+        )
+        assert resp.status_code == 200
+        assert "success" in resp.text
+
+
+# ── batch-notes missing branches (lines 872-903) ─────────────────────────────
+
+
+class TestBatchNotesMissingBranches:
+    def test_too_many_returns_400(self, client):
+        """Over MAX_BATCH_SIZE returns 400 (lines 877-878)."""
+        resp = client.post(
+            "/v2/partials/sightings/batch-notes",
+            data={"requirement_ids": json.dumps(list(range(51))), "notes": "note"},
+        )
+        assert resp.status_code == 400
+
+    def test_empty_notes_warning(self, client, db_session, test_user, test_requisition):
+        """Empty notes returns warning (lines 883-884)."""
+        item = test_requisition.requirements[0]
+        resp = client.post(
+            "/v2/partials/sightings/batch-notes",
+            data={"requirement_ids": json.dumps([item.id]), "notes": ""},
+        )
+        assert resp.status_code == 200
+        assert "required" in resp.text.lower() or "warning" in resp.text.lower()
+
+    def test_singular_message(self, client, db_session, test_user, test_requisition):
+        """1 requirement → singular form (line 902)."""
+        item = test_requisition.requirements[0]
+        resp = client.post(
+            "/v2/partials/sightings/batch-notes",
+            data={"requirement_ids": json.dumps([item.id]), "notes": "Test note singular"},
+        )
+        assert resp.status_code == 200
+        assert "requirement" in resp.text
+
+    def test_multiple_creates_multiple_logs(self, client, db_session, test_user, test_requisition):
+        """Multiple requirements each get an ActivityLog (lines 888-896)."""
+        item = test_requisition.requirements[0]
+        req2, item2 = _make_req_and_item(db_session, test_user, mpn="BNOTE-EXTRA2")
+        resp = client.post(
+            "/v2/partials/sightings/batch-notes",
+            data={"requirement_ids": json.dumps([item.id, item2.id]), "notes": "Bulk note"},
+        )
+        assert resp.status_code == 200
+        logs = db_session.query(ActivityLog).filter(ActivityLog.requirement_id.in_([item.id, item2.id])).all()
+        assert len(logs) >= 1
+
+
+# ── mark-unavailable mocked sightings_detail (lines 920-935) ─────────────────
+
+
+class TestMarkUnavailableMocked:
+    """Use mocked sightings_detail to ensure lines 920-935 are covered."""
+
+    def test_marks_sightings_with_mocked_detail(self, client, db_session, test_user, test_requisition):
+        """Lines 920-935 covered: normalize, query, mark, commit, publish, return."""
+        item = test_requisition.requirements[0]
+        sighting = _make_sighting(db_session, item, "Mouser Electronics")
+        db_session.commit()
+        with patch(
+            "app.routers.sightings.sightings_detail",
+            new_callable=AsyncMock,
+            return_value=_HTMLResponse("<div>detail</div>"),
+        ):
+            resp = client.post(
+                f"/v2/partials/sightings/{item.id}/mark-unavailable",
+                data={"vendor_name": "Mouser Electronics"},
+            )
+        assert resp.status_code == 200
+        db_session.refresh(sighting)
+        assert sighting.is_unavailable is True
+
+    def test_no_matching_sightings_still_returns_detail(self, client, db_session, test_user, test_requisition):
+        """No matching sightings → commit no-op, still calls sightings_detail."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.routers.sightings.sightings_detail",
+            new_callable=AsyncMock,
+            return_value=_HTMLResponse("<div>no vendor</div>"),
+        ):
+            resp = client.post(
+                f"/v2/partials/sightings/{item.id}/mark-unavailable",
+                data={"vendor_name": "Ghost Vendor XYZ"},
+            )
+        assert resp.status_code == 200
+
+    def test_sse_source_skips_publish(self, client, db_session, test_user, test_requisition):
+        """source=sse skips broker.publish (line 933)."""
+        item = test_requisition.requirements[0]
+        with patch("app.routers.sightings.broker") as mock_broker:
+            mock_broker.publish = AsyncMock()
+            with patch(
+                "app.routers.sightings.sightings_detail",
+                new_callable=AsyncMock,
+                return_value=_HTMLResponse("<div>ok</div>"),
+            ):
+                resp = client.post(
+                    f"/v2/partials/sightings/{item.id}/mark-unavailable?source=sse",
+                    data={"vendor_name": "Any Vendor"},
+                )
+        assert resp.status_code == 200
+        mock_broker.publish.assert_not_awaited()
+
+
+# ── assign-buyer mocked sightings_detail (lines 948-960) ─────────────────────
+
+
+class TestAssignBuyerMocked:
+    """Explicit coverage of lines 948-960 with mocked sightings_detail."""
+
+    def test_assigns_buyer_and_returns_detail(self, client, db_session, test_user, test_requisition):
+        """Lines 948-960: form parse, assign, commit, publish, return."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.routers.sightings.sightings_detail",
+            new_callable=AsyncMock,
+            return_value=_HTMLResponse("<div>assigned</div>"),
+        ):
+            resp = client.patch(
+                f"/v2/partials/sightings/{item.id}/assign",
+                data={"assigned_buyer_id": str(test_user.id)},
+            )
+        assert resp.status_code == 200
+        db_session.refresh(item)
+        assert item.assigned_buyer_id == test_user.id
+
+    def test_clears_buyer_with_empty_string(self, client, db_session, test_user, test_requisition):
+        """Empty assigned_buyer_id → None (line 949)."""
+        item = test_requisition.requirements[0]
+        item.assigned_buyer_id = test_user.id
+        db_session.commit()
+        with patch(
+            "app.routers.sightings.sightings_detail",
+            new_callable=AsyncMock,
+            return_value=_HTMLResponse("<div>cleared</div>"),
+        ):
+            resp = client.patch(
+                f"/v2/partials/sightings/{item.id}/assign",
+                data={"assigned_buyer_id": ""},
+            )
+        assert resp.status_code == 200
+        db_session.refresh(item)
+        assert item.assigned_buyer_id is None
+
+    def test_sse_source_skips_publish(self, client, db_session, test_user, test_requisition):
+        """source=sse skips broker.publish (line 958)."""
+        item = test_requisition.requirements[0]
+        with patch("app.routers.sightings.broker") as mock_broker:
+            mock_broker.publish = AsyncMock()
+            with patch(
+                "app.routers.sightings.sightings_detail",
+                new_callable=AsyncMock,
+                return_value=_HTMLResponse("<div>ok</div>"),
+            ):
+                resp = client.patch(
+                    f"/v2/partials/sightings/{item.id}/assign?source=sse",
+                    data={"assigned_buyer_id": ""},
+                )
+        assert resp.status_code == 200
+        mock_broker.publish.assert_not_awaited()
+
+
+# ── advance-status mocked sightings_detail (lines 977-1002) ──────────────────
+
+
+class TestAdvanceStatusMocked:
+    """Explicit coverage of lines 977-1002 with mocked sightings_detail."""
+
+    def test_invalid_transition_returns_409(self, client, db_session, test_user, test_requisition):
+        """Invalid transition raises 409 (line 984)."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "won"
+        db_session.commit()
+        resp = client.patch(
+            f"/v2/partials/sightings/{item.id}/advance-status",
+            data={"status": "open"},
+        )
+        assert resp.status_code in (409, 400)
+
+    def test_valid_transition_updates_and_logs(self, client, db_session, test_user, test_requisition):
+        """Lines 981-1002: fetch req, validate, update status, log, commit, publish, return."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "open"
+        db_session.commit()
+        with patch(
+            "app.routers.sightings.sightings_detail",
+            new_callable=AsyncMock,
+            return_value=_HTMLResponse("<div>advanced</div>"),
+        ):
+            resp = client.patch(
+                f"/v2/partials/sightings/{item.id}/advance-status",
+                data={"status": "sourcing"},
+            )
+        assert resp.status_code == 200
+        db_session.refresh(item)
+        assert item.sourcing_status == "sourcing"
+        log = db_session.query(ActivityLog).filter_by(requirement_id=item.id).first()
+        assert log is not None
+        assert "sourcing" in log.notes
+
+    def test_sse_source_skips_publish(self, client, db_session, test_user, test_requisition):
+        """source=sse skips broker.publish (line 1000)."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "open"
+        db_session.commit()
+        with patch("app.routers.sightings.broker") as mock_broker:
+            mock_broker.publish = AsyncMock()
+            with patch(
+                "app.routers.sightings.sightings_detail",
+                new_callable=AsyncMock,
+                return_value=_HTMLResponse("<div>ok</div>"),
+            ):
+                resp = client.patch(
+                    f"/v2/partials/sightings/{item.id}/advance-status?source=sse",
+                    data={"status": "sourcing"},
+                )
+        assert resp.status_code == 200
+        mock_broker.publish.assert_not_awaited()
+
+
+# ── preview-inquiry (lines 1135-1190) ────────────────────────────────────────
+
+
+class TestPreviewInquiryMissingBranches:
+    def test_missing_params_returns_400(self, client):
+        """No params → 400 (lines 1138-1139)."""
+        resp = client.post("/v2/partials/sightings/preview-inquiry", data={})
+        assert resp.status_code == 400
+
+    def test_success_with_valid_params(self, client, db_session, test_user, test_requisition):
+        """Valid params → rendered preview (lines 1141-1190)."""
+        item = test_requisition.requirements[0]
+        with patch("app.email_service._build_html_body", return_value="<p>Preview</p>"):
+            resp = client.post(
+                "/v2/partials/sightings/preview-inquiry",
+                data={
+                    "requirement_ids": [str(item.id)],
+                    "vendor_names": ["Arrow Electronics"],
+                    "email_body": "Quote please.",
+                },
+            )
+        assert resp.status_code == 200
+
+    def test_resolves_vendor_email_from_card_and_contact(self, client, db_session, test_user, test_requisition):
+        """Vendor email resolved from VendorCard+VendorContact (lines 1148-1167)."""
+        item = test_requisition.requirements[0]
+        card = VendorCard(
+            normalized_name="previewvendor",
+            display_name="Preview Vendor",
+            emails=["sales@preview.com"],
+            phones=[],
+            sighting_count=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(card)
+        db_session.flush()
+        contact = VendorContact(
+            vendor_card_id=card.id,
+            full_name="Preview Contact",
+            email="contact@preview.com",
+            source="manual",
+            is_verified=True,
+            confidence=90,
+        )
+        db_session.add(contact)
+        db_session.commit()
+        with patch("app.email_service._build_html_body", return_value="<p>Preview</p>"):
+            resp = client.post(
+                "/v2/partials/sightings/preview-inquiry",
+                data={
+                    "requirement_ids": [str(item.id)],
+                    "vendor_names": ["Preview Vendor"],
+                    "email_body": "Quote please.",
+                },
+            )
+        assert resp.status_code == 200
+
+    def test_multiple_vendors_each_previewed(self, client, db_session, test_user, test_requisition):
+        """Multiple vendors each get a preview (line 1161 loop)."""
+        item = test_requisition.requirements[0]
+        with patch("app.email_service._build_html_body", return_value="<p>Preview</p>"):
+            resp = client.post(
+                "/v2/partials/sightings/preview-inquiry",
+                data={
+                    "requirement_ids": [str(item.id)],
+                    "vendor_names": ["Vendor A", "Vendor B"],
+                    "email_body": "RFQ body",
+                },
+            )
+        assert resp.status_code == 200
+
+    def test_avail_token_uses_requisition_id(self, client, db_session, test_user, test_requisition):
+        """avail_token set from requisition_id (line 1157)."""
+        item = test_requisition.requirements[0]
+        with patch("app.email_service._build_html_body", return_value="<p>Preview</p>") as mock_build:
+            resp = client.post(
+                "/v2/partials/sightings/preview-inquiry",
+                data={
+                    "requirement_ids": [str(item.id)],
+                    "vendor_names": ["Any Vendor"],
+                    "email_body": "body text",
+                },
+            )
+        assert resp.status_code == 200
+        mock_build.assert_called_once_with("body text")
+
+
+# ── send-inquiry (lines 1216-1299) ────────────────────────────────────────────
+
+
+class TestSendInquiryMissingBranches:
+    def test_missing_params_returns_400(self, client):
+        """No params → 400 (lines 1210-1214)."""
+        resp = client.post("/v2/partials/sightings/send-inquiry", data={})
+        assert resp.status_code == 400
+
+    def test_missing_email_body_returns_400(self, client, db_session, test_user, test_requisition):
+        """Empty email_body → 400 (line 1210)."""
+        item = test_requisition.requirements[0]
+        resp = client.post(
+            "/v2/partials/sightings/send-inquiry",
+            data={
+                "requirement_ids": [str(item.id)],
+                "vendor_names": ["Arrow"],
+                "email_body": "",
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_success_calls_send_batch_rfq(self, client, db_session, test_user, test_requisition):
+        """Successful send calls send_batch_rfq (lines 1216-1262)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.email_service.send_batch_rfq",
+            new_callable=AsyncMock,
+            return_value=[{"vendor_name": "Arrow", "sent": True}],
+        ):
+            resp = client.post(
+                "/v2/partials/sightings/send-inquiry",
+                data={
+                    "requirement_ids": [str(item.id)],
+                    "vendor_names": ["Arrow"],
+                    "email_body": "Please quote.",
+                },
+            )
+        assert resp.status_code == 200
+        assert "rfq" in resp.text.lower() or "sent" in resp.text.lower()
+
+    def test_resolves_vendor_email_from_card_contact(self, client, db_session, test_user, test_requisition):
+        """Vendor email resolved from VendorCard+VendorContact (lines 1227-1237)."""
+        item = test_requisition.requirements[0]
+        card = VendorCard(
+            normalized_name="sendco",
+            display_name="Send Co",
+            emails=["sales@sendco.com"],
+            phones=[],
+            sighting_count=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(card)
+        db_session.flush()
+        contact = VendorContact(
+            vendor_card_id=card.id,
+            full_name="Send Contact",
+            email="contact@sendco.com",
+            source="manual",
+            is_verified=True,
+            confidence=90,
+        )
+        db_session.add(contact)
+        db_session.commit()
+        with patch(
+            "app.email_service.send_batch_rfq",
+            new_callable=AsyncMock,
+            return_value=[{"vendor_name": "Send Co", "sent": True}],
+        ):
+            resp = client.post(
+                "/v2/partials/sightings/send-inquiry",
+                data={
+                    "requirement_ids": [str(item.id)],
+                    "vendor_names": ["Send Co"],
+                    "email_body": "Quote urgently.",
+                },
+            )
+        assert resp.status_code == 200
+
+    def test_exception_sets_failed_vendors_warning(self, client, db_session, test_user, test_requisition):
+        """send_batch_rfq exception → warning toast with failed vendor names (lines 1281-1295)."""
+        item = test_requisition.requirements[0]
+        with patch(
+            "app.email_service.send_batch_rfq",
+            new_callable=AsyncMock,
+            side_effect=Exception("Graph API down"),
+        ):
+            resp = client.post(
+                "/v2/partials/sightings/send-inquiry",
+                data={
+                    "requirement_ids": [str(item.id)],
+                    "vendor_names": ["FailVendor"],
+                    "email_body": "Quote please.",
+                },
+            )
+        assert resp.status_code == 200
+        assert "warning" in resp.text.lower() or "failed" in resp.text.lower()
+        assert "FailVendor" in resp.text
+
+    def test_auto_progress_increments_progressed_count(self, client, db_session, test_user, test_requisition):
+        """auto_progress_status=True increments progressed_count (lines 1278-1280)."""
+        item = test_requisition.requirements[0]
+        item.sourcing_status = "open"
+        db_session.commit()
+        with patch(
+            "app.email_service.send_batch_rfq",
+            new_callable=AsyncMock,
+            return_value=[{"vendor_name": "Arrow", "sent": True}],
+        ):
+            with patch(
+                "app.services.sourcing_auto_progress.auto_progress_status",
+                return_value=True,
+            ):
+                resp = client.post(
+                    "/v2/partials/sightings/send-inquiry",
+                    data={
+                        "requirement_ids": [str(item.id)],
+                        "vendor_names": ["Arrow"],
+                        "email_body": "Quote please.",
+                    },
+                )
+        assert resp.status_code == 200
+        assert "sourcing" in resp.text.lower() or "advanced" in resp.text.lower() or "rfq" in resp.text.lower()
+
+    def test_publishes_sse_per_requirement(self, client, db_session, test_user, test_requisition):
+        """broker.publish called once per requirement (lines 1287-1289)."""
+        item = test_requisition.requirements[0]
+        req2, item2 = _make_req_and_item(db_session, test_user, mpn="SEND-SSE-EXTRA")
+        with patch("app.routers.sightings.broker") as mock_broker:
+            mock_broker.publish = AsyncMock()
+            with patch(
+                "app.email_service.send_batch_rfq",
+                new_callable=AsyncMock,
+                return_value=[{"vendor_name": "Arrow", "sent": True}],
+            ):
+                resp = client.post(
+                    "/v2/partials/sightings/send-inquiry",
+                    data={
+                        "requirement_ids": [str(item.id), str(item2.id)],
+                        "vendor_names": ["Arrow"],
+                        "email_body": "Quote please.",
+                    },
+                )
+        assert resp.status_code == 200
+        assert mock_broker.publish.await_count == 2
+
+    def test_sse_source_skips_broker_publish(self, client, db_session, test_user, test_requisition):
+        """source=sse skips broker.publish for each requirement."""
+        item = test_requisition.requirements[0]
+        with patch("app.routers.sightings.broker") as mock_broker:
+            mock_broker.publish = AsyncMock()
+            with patch(
+                "app.email_service.send_batch_rfq",
+                new_callable=AsyncMock,
+                return_value=[{"vendor_name": "Arrow", "sent": True}],
+            ):
+                resp = client.post(
+                    "/v2/partials/sightings/send-inquiry?source=sse",
+                    data={
+                        "requirement_ids": [str(item.id)],
+                        "vendor_names": ["Arrow"],
+                        "email_body": "Quote.",
+                    },
+                )
+        assert resp.status_code == 200
+        mock_broker.publish.assert_not_awaited()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Overall single-thread coverage jumped from **74% → 97%** (well above the 85% target)
- 8 new test files added, 219 new passing tests, 0 failures
- Every previously sub-85% module is now at 99–100%

## Modules covered

| Module | Before | After |
|---|---|---|
| `app/services/crm_service.py` | 71% | 100% |
| `app/dependencies.py` | 84% | 100% |
| `app/rate_limit.py` | 12% | 100% |
| `app/schemas/proactive.py` | 0% | 100% |
| `app/schemas/admin.py` | 0% | 100% |
| `app/routers/sightings.py` | 58% | 100% |
| `app/routers/materials.py` | 63% | 100% |
| `app/routers/error_reports.py` | 68% | 100% |
| `app/routers/requisitions/requirements.py` | 55% | 99% |
| `app/services/health_monitor.py` | 81% | 99% |

## Test plan

- [x] All 219 new tests pass: `TESTING=1 PYTHONPATH=. python3 -m pytest tests/test_*_nightly_coverage.py -q`
- [x] Ruff lint clean: `ruff check tests/test_*_nightly_coverage.py`
- [x] Full suite: 14,002 passed, 30 skipped, 1 xfailed
- [x] Single-thread coverage report confirms 97% TOTAL

https://claude.ai/code/session_01S8HWWbMC89VVGbX8swKRZs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8HWWbMC89VVGbX8swKRZs)_