### PR TITLE
chore(caddy): enable JSON access logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .env
 .env.*
 !.env.example
-Caddyfile
 __pycache__/
 *.pyc
 *.pyo

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,88 @@
+(backend) {
+	reverse_proxy app:8000 {
+		lb_try_duration 30s
+		lb_try_interval 1s
+		health_uri /health
+		health_interval 5s
+		health_timeout 3s
+		transport http {
+			keepalive 30s
+			keepalive_idle_conns 10
+		}
+	}
+}
+
+app.availai.net {
+	encode gzip zstd
+
+	# Access logging — visible via `docker compose logs caddy`. Diagnoses
+	# client-side issues (which assets the browser fetches, 200 vs 404, what
+	# hash is requested, what HTMX endpoints fire on UI clicks).
+	log {
+		output stdout
+		format json
+		level INFO
+	}
+
+	header {
+		Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+		X-Frame-Options "SAMEORIGIN"
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Permissions-Policy "camera=(), microphone=(), geolocation=()"
+		# CSP moved to FastAPI middleware (app/main.py) for per-request nonce support
+	}
+
+	@blocked path /metrics
+	handle @blocked {
+		respond 403
+	}
+
+	# Service worker — never cache
+	@sw path /static/sw.js
+	handle @sw {
+		header Cache-Control "no-cache, must-revalidate"
+		root * /srv
+		file_server
+	}
+
+	# Vite-hashed assets (fingerprinted filenames) — immutable long cache
+	@hashed path /static/assets/*
+	handle @hashed {
+		header Cache-Control "public, max-age=31536000, immutable"
+		root * /srv
+		file_server
+	}
+
+	# All other static files — short cache so updates propagate
+	@static path /static/*
+	handle @static {
+		header Cache-Control "public, max-age=3600"
+		root * /srv
+		file_server
+	}
+
+	# Safe read-only GET endpoints — 30s browser cache reduces redundant
+	# API calls when switching tabs rapidly
+	@safe_api {
+		method GET
+		path /api/companies /api/users/list /api/vendors
+	}
+	handle @safe_api {
+		header Cache-Control "private, max-age=30"
+		import backend
+	}
+
+	@api path /api/* /auth/*
+	handle @api {
+		header Cache-Control "no-cache, no-store, must-revalidate"
+		import backend
+	}
+
+	# Everything else (HTML pages, etc.) — never cache
+	handle {
+		header Cache-Control "no-store, must-revalidate"
+		header Pragma "no-cache"
+		import backend
+	}
+}

--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -3,6 +3,13 @@
 app.yourdomain.com {
     encode gzip
 
+    # Access logging — emits JSON to stdout; visible via `docker compose logs caddy`.
+    log {
+        output stdout
+        format json
+        level INFO
+    }
+
     header {
         Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
         X-Frame-Options "SAMEORIGIN"

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -692,7 +692,8 @@ class TestDeepTestSourceTypedErrors:
 
 class TestRedactBareKeyMasking:
     def test_bare_key_in_query_without_named_prefix(self):
-        """Bare token in URL query string (no named prefix) gets masked by _mask_bare."""
+        """Bare token in URL query string (no named prefix) gets masked by
+        _mask_bare."""
         bare_token = "A" * 25  # 25 chars, well within 20-100 range
         text = f"https://api.example.com/endpoint?data={bare_token}&q=test"
         result = _redact_api_keys(text)


### PR DESCRIPTION
## Summary
- Adds JSON access logging on the `app.availai.net` site block, emitted to stdout at INFO. Visible via `docker compose logs caddy`; correlates HTMX requests with UI events.
- Removes `Caddyfile` from `.gitignore` (prerequisite — `Caddyfile` was previously untracked, gitignored as production-only; tracking it now lets the access-log config live in source control).
- Syncs the same `log { ... }` block into `Caddyfile.example` so the install template stays current.
- Includes a 1-line docformatter wrap on `tests/test_health_monitor.py` — pre-existing drift on `main` surfaced by the `all-files-on-push` pre-commit hook. Cannot be unbundled without disabling the hook.

## ⚠️ Pre-merge operator check
Removing `Caddyfile` from `.gitignore` means the next `git pull` / `./deploy.sh` on the droplet will overwrite any in-place edits. **Before merging**, SSH to the droplet and run `git status Caddyfile && git diff HEAD -- Caddyfile` — if anything diverges from the committed version, fold those edits in first so they aren't clobbered.

## Notes
- `/static/*` requests are logged at INFO and will dominate the stream — intentional (lets us see which asset hashes the browser fetches), but expect grep-heavy log reading. Can add `log_skip /static/*` later if it gets noisy.
- Caddy v2 auto-redacts `Cookie` and `Authorization` headers, so no session-cookie leakage via `docker compose logs`.

## Test plan
- [x] `caddy validate` passes locally (`docker run --rm caddy:2 caddy validate`).
- [x] Pre-push pre-commit `--all-files` clean.
- [ ] Pre-merge: droplet `Caddyfile` diff check (see above).
- [ ] After merge + deploy, verify `docker compose logs caddy --tail=5` shows JSON access lines on app load.