### PR TITLE
fix(ci): unblock main — starlette ≥1.0.1 + docformatter reflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,9 @@ alembic==1.18.4
 # Caching
 redis[hiredis]==7.4.0
 orjson>=3.9.0,<4.0
+# Pin starlette directly to clear PYSEC-2026-161 (Host-header
+# inconsistency in 0.x). FastAPI allows starlette>=0.46.0, so 1.0.1 is fine.
+starlette>=1.0.1
 # CSRF protection
 starlette-csrf==3.0.0
 # NetComponents integration

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -692,7 +692,8 @@ class TestDeepTestSourceTypedErrors:
 
 class TestRedactBareKeyMasking:
     def test_bare_key_in_query_without_named_prefix(self):
-        """Bare token in URL query string (no named prefix) gets masked by _mask_bare."""
+        """Bare token in URL query string (no named prefix) gets masked by
+        _mask_bare."""
         bare_token = "A" * 25  # 25 chars, well within 20-100 range
         text = f"https://api.example.com/endpoint?data={bare_token}&q=test"
         result = _redact_api_keys(text)


### PR DESCRIPTION
## Summary
Main CI has been red since 2026-05-26 because of two unrelated regressions:

1. **pip-audit:** starlette 0.52.1 has PYSEC-2026-161 (Host-header inconsistency, potential auth bypass). Fix is starlette ≥1.0.1. FastAPI 0.136.1 already allows \`starlette>=0.46.0\`.
2. **docformatter:** \`tests/test_health_monitor.py:692-694\` had a single-line docstring at 90 chars; the hook reflows to 88. Added by the latest nightly-coverage PR.

Together, these block the activity-timeline stack (#120-#154) and the independent fixes (#149, #150, #151).

## Test plan
- [x] \`pre-commit run --all-files\` clean (318 source files)
- [x] Diff stays small: 5 insertions, 1 deletion across 2 files
- [ ] CI green: pip-audit clean, docformatter passes
- [ ] After merge: dependent PRs go green on rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)