### PR TITLE
fix(ci): unblock main — starlette ≥1.0.1 (PYSEC-2026-161) + replace prom-fastapi-instrumentator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Suite has grown to ~13.8k tests; locally it runs in ~2.5 min, but the
+    # 2-vCPU GitHub runner takes longer. 15-min was being exceeded before the
+    # suite could finish (~32% complete at the 15-min mark). 25 leaves room for
+    # the suite to grow without immediate re-tuning.
+    timeout-minutes: 25
     services:
       postgres:
         image: postgres:16

--- a/app/main.py
+++ b/app/main.py
@@ -293,7 +293,9 @@ if os.path.isdir("app/static/dist/assets"):
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 # Prometheus metrics
-from prometheus_fastapi_instrumentator import Instrumentator
+from fastapi import Response
+
+from app.prometheus_metrics import PrometheusMiddleware, render_metrics
 
 
 async def _metrics_auth(x_metrics_token: str = Header(default="")) -> None:
@@ -307,9 +309,14 @@ async def _metrics_auth(x_metrics_token: str = Header(default="")) -> None:
         raise HTTPException(status_code=403, detail="Forbidden")
 
 
-Instrumentator(excluded_handlers=["/metrics", "/health", "/static/*"]).instrument(app).expose(
-    app, endpoint="/metrics", include_in_schema=False, dependencies=[Depends(_metrics_auth)]
-)
+app.add_middleware(PrometheusMiddleware)
+
+
+@app.get("/metrics", include_in_schema=False, dependencies=[Depends(_metrics_auth)])
+async def metrics_endpoint() -> Response:
+    body, content_type = render_metrics()
+    return Response(content=body, media_type=content_type)
+
 
 # Secret key validation moved to lifespan (fail-fast)
 

--- a/app/main.py
+++ b/app/main.py
@@ -309,6 +309,11 @@ async def _metrics_auth(x_metrics_token: str = Header(default="")) -> None:
         raise HTTPException(status_code=403, detail="Forbidden")
 
 
+# PrometheusMiddleware must remain registered last. Starlette wraps middleware
+# in reverse add_middleware() order, so being added last places it outermost in
+# the request chain — giving it wall-clock time across all inner middleware and
+# a stable position for the metrics contract. Do not move it inside Session,
+# GZip, or CSRF without updating that assumption.
 app.add_middleware(PrometheusMiddleware)
 
 

--- a/app/prometheus_metrics.py
+++ b/app/prometheus_metrics.py
@@ -1,14 +1,26 @@
 """Prometheus metrics middleware + /metrics endpoint exposure.
 
-Purpose: Record HTTP request count (http_requests_total) and request duration
-    (http_request_duration_seconds) for application traffic, and expose them in
-    Prometheus text format at /metrics. Pure ASGI middleware so it composes with
-    streaming responses (sse-starlette) without consuming their bodies.
+Purpose: Record HTTP request count, in-flight gauge, and request duration for
+    application traffic, and expose them in Prometheus text format at /metrics.
+    Pure ASGI middleware so it composes with streaming responses (sse-starlette)
+    without consuming their bodies.
 Called by: app.main (mounts middleware on app + adds the GET /metrics route).
-Depends on: prometheus_client (Counter, Histogram, generate_latest, REGISTRY).
+Depends on: prometheus_client (Counter, Gauge, Histogram, generate_latest, REGISTRY),
+    loguru for one warning log on aborted requests.
 
 Replaces prometheus-fastapi-instrumentator, which hard-pinned starlette<1.0.0
 and so blocked the starlette 1.0.1 bump required to fix PYSEC-2026-161.
+
+Intentional differences vs. the previous Instrumentator default suite:
+- KEPT: http_requests_total, http_request_duration_seconds, http_requests_inprogress.
+- DROPPED: http_request_size_bytes / http_response_size_bytes (unused in our
+  Grafana / alerting; reintroduce as a Histogram if a saturation alert needs it).
+- DROPPED: the highr / lowr duration histogram split (we keep the single default-
+  bucketed histogram — Grafana queries using the dropped names will return No Data
+  and should be migrated to http_request_duration_seconds).
+- DROPPED: OpenMetrics content negotiation. /metrics always returns the
+  Prometheus text format. Re-add via choose_encoder() if Exemplars/Created
+  timestamps are needed by a scraper.
 """
 
 from __future__ import annotations
@@ -16,10 +28,12 @@ from __future__ import annotations
 import time
 from typing import MutableMapping
 
+from loguru import logger
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
     REGISTRY,
     Counter,
+    Gauge,
     Histogram,
     generate_latest,
 )
@@ -37,24 +51,62 @@ REQUEST_DURATION = Histogram(
     ["method", "handler"],
 )
 
-_EXCLUDED_EXACT = {"/metrics", "/health"}
+REQUEST_INFLIGHT = Gauge(
+    "http_requests_inprogress",
+    "In-flight HTTP requests being served, by method.",
+    ["method"],
+)
+
+# Paths excluded from collection entirely. Each entry is either a fixed path
+# (browser/health/observability noise) or a prefix; collectively they keep the
+# counter free of high-volume, low-signal traffic.
+_EXCLUDED_EXACT = {
+    "/metrics",
+    "/health",
+    "/sw.js",
+    "/favicon.ico",
+    "/robots.txt",
+}
 _EXCLUDED_PREFIXES = ("/static/",)
+
+# Sentinel for any request that did not match a registered route (404s, bot probes).
+# Using a fixed string keeps Prometheus label cardinality bounded — otherwise every
+# distinct probe URL becomes its own time series.
+_UNMATCHED_HANDLER = "<unmatched>"
+
+# Sentinel status for requests that aborted before the inner app sent
+# http.response.start (e.g. client disconnect, downstream raise outside
+# Starlette's ServerErrorMiddleware). Operators can alert on
+# http_requests_total{status="aborted"} to surface these without confusing them
+# for real HTTP status codes.
+_STATUS_ABORTED = "aborted"
 
 
 def _excluded(path: str) -> bool:
     return path in _EXCLUDED_EXACT or path.startswith(_EXCLUDED_PREFIXES)
 
 
-def _handler_for(scope: Scope, fallback: str) -> str:
-    """Use the matched route's templated path (e.g. /users/{id}) when available.
+def _handler_for(scope: Scope) -> str:
+    """Return the matched route's templated path (e.g. ``/users/{id}``).
 
-    Falls back to the raw request path. Routing populates scope["route"] before
-    http.response.start fires, so by the time we record metrics in send_wrapper the
-    templated path is usually present.
+    Starlette's router populates ``scope["endpoint"]`` and ``scope["path_params"]``
+    on match — but NOT ``scope["route"]`` (verified against starlette 1.x's
+    ``Route.matches``). To recover the templated path we walk the app's route
+    table and find the one whose endpoint is identical to the scope's endpoint.
+
+    Returns ``_UNMATCHED_HANDLER`` for requests that didn't match any route so
+    that bot/scanner traffic can't blow up label cardinality.
     """
-    route = scope.get("route")
-    path = getattr(route, "path", None) if route is not None else None
-    return path or fallback
+    endpoint = scope.get("endpoint")
+    app = scope.get("app")
+    if endpoint is None or app is None:
+        return _UNMATCHED_HANDLER
+    for route in getattr(app, "routes", ()):
+        if getattr(route, "endpoint", None) is endpoint:
+            path = getattr(route, "path", None)
+            if path:
+                return path
+    return _UNMATCHED_HANDLER
 
 
 class PrometheusMiddleware:
@@ -76,6 +128,7 @@ class PrometheusMiddleware:
         method: str = scope.get("method", "")
         status_holder: MutableMapping[str, int] = {"code": 0}
         start = time.perf_counter()
+        REQUEST_INFLIGHT.labels(method=method).inc()
 
         async def send_wrapper(message: Message) -> None:
             if message["type"] == "http.response.start":
@@ -86,9 +139,24 @@ class PrometheusMiddleware:
             await self.app(scope, receive, send_wrapper)
         finally:
             duration = time.perf_counter() - start
-            handler = _handler_for(scope, fallback=path)
-            REQUEST_COUNT.labels(method=method, handler=handler, status=str(status_holder["code"])).inc()
-            REQUEST_DURATION.labels(method=method, handler=handler).observe(duration)
+            REQUEST_INFLIGHT.labels(method=method).dec()
+            handler = _handler_for(scope)
+            code = status_holder["code"]
+            if code == 0:
+                # Downstream aborted before sending response.start (client
+                # disconnect, raise above Starlette's ServerErrorMiddleware).
+                # Count it under a distinct status sentinel and skip the
+                # duration histogram so p50/p99 aren't poisoned by zero-time
+                # samples.
+                REQUEST_COUNT.labels(method=method, handler=handler, status=_STATUS_ABORTED).inc()
+                logger.warning(
+                    "ASGI request aborted before response.start: {method} {path}",
+                    method=method,
+                    path=path,
+                )
+            else:
+                REQUEST_COUNT.labels(method=method, handler=handler, status=str(code)).inc()
+                REQUEST_DURATION.labels(method=method, handler=handler).observe(duration)
 
 
 def render_metrics() -> tuple[bytes, str]:

--- a/app/prometheus_metrics.py
+++ b/app/prometheus_metrics.py
@@ -1,0 +1,96 @@
+"""Prometheus metrics middleware + /metrics endpoint exposure.
+
+Purpose: Record HTTP request count (http_requests_total) and request duration
+    (http_request_duration_seconds) for application traffic, and expose them in
+    Prometheus text format at /metrics. Pure ASGI middleware so it composes with
+    streaming responses (sse-starlette) without consuming their bodies.
+Called by: app.main (mounts middleware on app + adds the GET /metrics route).
+Depends on: prometheus_client (Counter, Histogram, generate_latest, REGISTRY).
+
+Replaces prometheus-fastapi-instrumentator, which hard-pinned starlette<1.0.0
+and so blocked the starlette 1.0.1 bump required to fix PYSEC-2026-161.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import MutableMapping
+
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    REGISTRY,
+    Counter,
+    Histogram,
+    generate_latest,
+)
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+REQUEST_COUNT = Counter(
+    "http_requests_total",
+    "Total HTTP requests processed by the application.",
+    ["method", "handler", "status"],
+)
+
+REQUEST_DURATION = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request duration in seconds, by route template.",
+    ["method", "handler"],
+)
+
+_EXCLUDED_EXACT = {"/metrics", "/health"}
+_EXCLUDED_PREFIXES = ("/static/",)
+
+
+def _excluded(path: str) -> bool:
+    return path in _EXCLUDED_EXACT or path.startswith(_EXCLUDED_PREFIXES)
+
+
+def _handler_for(scope: Scope, fallback: str) -> str:
+    """Use the matched route's templated path (e.g. /users/{id}) when available.
+
+    Falls back to the raw request path. Routing populates scope["route"] before
+    http.response.start fires, so by the time we record metrics in send_wrapper the
+    templated path is usually present.
+    """
+    route = scope.get("route")
+    path = getattr(route, "path", None) if route is not None else None
+    return path or fallback
+
+
+class PrometheusMiddleware:
+    """Pure ASGI middleware — does not buffer response bodies."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path: str = scope.get("path", "")
+        if _excluded(path):
+            await self.app(scope, receive, send)
+            return
+
+        method: str = scope.get("method", "")
+        status_holder: MutableMapping[str, int] = {"code": 0}
+        start = time.perf_counter()
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                status_holder["code"] = int(message.get("status", 0))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            duration = time.perf_counter() - start
+            handler = _handler_for(scope, fallback=path)
+            REQUEST_COUNT.labels(method=method, handler=handler, status=str(status_holder["code"])).inc()
+            REQUEST_DURATION.labels(method=method, handler=handler).observe(duration)
+
+
+def render_metrics() -> tuple[bytes, str]:
+    """Return (body, content_type) for the /metrics endpoint."""
+    return generate_latest(REGISTRY), CONTENT_TYPE_LATEST

--- a/app/routers/crm/views.py
+++ b/app/routers/crm/views.py
@@ -89,14 +89,14 @@ async def crm_shell(
     user: User = Depends(require_user),
 ):
     """Render the CRM shell with Customers/Vendors tab bar."""
-    from ...template_env import templates
+    from ...template_env import template_response
 
     ctx = {
         "request": request,
         "user": user,
         "default_tab": "customers",
     }
-    return templates.TemplateResponse("htmx/partials/crm/shell.html", ctx)
+    return template_response("htmx/partials/crm/shell.html", ctx)
 
 
 @router.get("/v2/partials/crm/performance", response_class=HTMLResponse)
@@ -106,14 +106,14 @@ async def crm_performance(
     db: Session = Depends(get_db),
 ):
     """Render the team performance dashboard."""
-    from ...template_env import templates
+    from ...template_env import template_response
 
     ctx = {
         "request": request,
         "user": user,
         "users_scores": _build_user_scores(db),
     }
-    return templates.TemplateResponse("htmx/partials/crm/performance_tab.html", ctx)
+    return template_response("htmx/partials/crm/performance_tab.html", ctx)
 
 
 @router.get("/api/crm/performance-metrics")

--- a/app/routers/error_reports.py
+++ b/app/routers/error_reports.py
@@ -26,7 +26,7 @@ from ..database import get_db
 from ..dependencies import require_admin, require_user
 from ..models import User
 from ..models.trouble_ticket import TroubleTicket
-from ..template_env import templates
+from ..template_env import template_response
 
 router = APIRouter(tags=["error-reports"])
 
@@ -160,7 +160,7 @@ async def _generate_ai_summary(ticket_id: int):
 @router.get("/api/trouble-tickets/form", response_class=HTMLResponse)
 async def trouble_ticket_form(request: Request, user: User = Depends(require_user)):
     """Return the trouble report form partial for the modal."""
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/shared/trouble_report_form.html",
         {"request": request},
     )

--- a/app/routers/excess.py
+++ b/app/routers/excess.py
@@ -55,7 +55,7 @@ from ..services.excess_service import (
     send_bid_solicitation,
     update_excess_list,
 )
-from ..template_env import templates
+from ..template_env import template_response
 from ..utils.claude_client import claude_text
 from ..utils.claude_errors import ClaudeError, ClaudeUnavailableError
 from ..utils.normalization import normalize_mpn_key
@@ -83,7 +83,7 @@ async def partial_excess_list(
     result = list_excess_lists(db, q=q, status=status or None, limit=limit, offset=offset)
     companies = db.query(Company).order_by(Company.name).all()
     stats = get_excess_stats(db)
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/list.html",
         {
             "request": request,
@@ -108,7 +108,7 @@ async def partial_excess_create_form(
 ):
     """Render the create-excess-list modal form."""
     companies = db.query(Company).order_by(Company.name).all()
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/create_modal.html",
         {
             "request": request,
@@ -126,7 +126,7 @@ async def partial_add_line_item_form(
 ):
     """Render the add-line-item modal form."""
     get_excess_list(db, list_id)
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/add_line_item_modal.html",
         {"request": request, "list_id": list_id},
     )
@@ -142,7 +142,7 @@ async def partial_excess_detail(
     """Render excess list detail partial for HTMX."""
     el = get_excess_list(db, list_id)
     items = db.query(ExcessLineItem).filter_by(excess_list_id=el.id).order_by(ExcessLineItem.id).all()
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/detail.html",
         {
             "request": request,
@@ -174,7 +174,7 @@ async def partial_import_preview(
     if not rows:
         raise HTTPException(400, "No data rows found")
     result = preview_import(rows)
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/import_preview.html",
         {
             "request": request,
@@ -507,7 +507,7 @@ async def partial_solicit_form(
         if ids
         else []
     )
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/solicit_modal.html",
         {"request": request, "list_id": list_id, "items": items, "list": excess_list},
     )
@@ -543,7 +543,7 @@ async def htmx_solicit(
 
     el = get_excess_list(db, list_id)
     items = db.query(ExcessLineItem).filter_by(excess_list_id=el.id).order_by(ExcessLineItem.id).all()
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/detail.html",
         {
             "request": request,
@@ -573,7 +573,7 @@ async def htmx_create_proactive_matches(
         if count
         else "No matching archived requirements found"
     )
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/detail.html",
         {"request": request, "user": user, "list": el, "line_items": items, "success_msg": msg},
     )
@@ -593,7 +593,7 @@ async def partial_bid_form(
     if not item or item.excess_list_id != list_id:
         raise HTTPException(404, f"Line item {item_id} not found in list {list_id}")
     companies = db.query(Company).order_by(Company.name).all()
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/bid_form.html",
         {
             "request": request,
@@ -620,7 +620,7 @@ async def partial_bid_list(
         raise HTTPException(404, f"Line item {item_id} not found in list {list_id}")
     bids = list_bids(db, item_id, list_id)
     companies = db.query(Company).order_by(Company.name).all()
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/excess/bid_list.html",
         {
             "request": request,

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -72,7 +72,7 @@ from ..services.faceted_search_service import (
 )
 from ..services.freeform_parser_service import parse_freeform_rfq
 from ..services.status_machine import require_valid_transition
-from ..template_env import templates
+from ..template_env import template_response, templates
 from ..utils.search_builder import SearchBuilder
 from ..utils.sql_helpers import escape_like
 from ._lookup_helpers import get_requisition_or_404, get_vendor_card_or_404
@@ -179,7 +179,7 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
     path = request.url.path
     user = get_user(request, db)
     if not user:
-        return templates.TemplateResponse(
+        return template_response(
             "htmx/login.html", {"request": request, "password_login": _password_login_enabled(), **_vite_assets()}
         )
     if "/buy-plans" in path:
@@ -263,7 +263,7 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
 
     ctx = _base_ctx(request, user, current_view)
     ctx["partial_url"] = partial_url
-    return templates.TemplateResponse("htmx/base_page.html", ctx)
+    return template_response("htmx/base_page.html", ctx)
 
 
 # ── Global search ──────────────────────────────────────────────────────
@@ -280,7 +280,7 @@ async def global_search(
     from app.services.global_search_service import fast_search
 
     results = fast_search(q, db)
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/shared/search_results.html",
         {**_base_ctx(request, user), "results": results, "query": q},
     )
@@ -297,7 +297,7 @@ async def ai_search_endpoint(
     from app.services.global_search_service import ai_search
 
     results = await ai_search(q, db)
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/shared/search_results.html",
         {**_base_ctx(request, user), "results": results, "query": q, "ai_search": True},
     )
@@ -314,7 +314,7 @@ async def search_results_page(
     from app.services.global_search_service import fast_search
 
     results = fast_search(q, db) if q else {"best_match": None, "groups": {}, "total_count": 0}
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/search/full_results.html",
         {**_base_ctx(request, user), "results": results, "query": q},
     )
@@ -331,7 +331,7 @@ async def parts_workspace_partial(
 ):
     """Return the split-panel parts workspace shell."""
     ctx = _base_ctx(request, user, "requisitions")
-    return templates.TemplateResponse("htmx/partials/parts/workspace.html", ctx)
+    return template_response("htmx/partials/parts/workspace.html", ctx)
 
 
 # ── Requisition partials ────────────────────────────────────────────────
@@ -505,7 +505,7 @@ async def requisitions_list_partial(
             "user_role": user.role,
         }
     )
-    return templates.TemplateResponse("htmx/partials/requisitions/list.html", ctx)
+    return template_response("htmx/partials/requisitions/list.html", ctx)
 
 
 @router.get("/v2/partials/requisitions/create-form", response_class=HTMLResponse)
@@ -516,7 +516,7 @@ async def requisition_create_form(
 ):
     """Return the create requisition modal form."""
     ctx = _base_ctx(request, user, "requisitions")
-    return templates.TemplateResponse("htmx/partials/requisitions/unified_modal.html", ctx)
+    return template_response("htmx/partials/requisitions/unified_modal.html", ctx)
 
 
 @router.get("/v2/partials/requisitions/import-form", response_class=HTMLResponse)
@@ -526,7 +526,7 @@ async def requisition_import_form(
 ):
     """Return the import requisition modal form."""
     ctx = _base_ctx(request, user, "requisitions")
-    return templates.TemplateResponse("htmx/partials/requisitions/unified_modal.html", ctx)
+    return template_response("htmx/partials/requisitions/unified_modal.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/import-parse", response_class=HTMLResponse)
@@ -611,7 +611,7 @@ async def requisition_import_parse(
             "count": len(requirements),
         }
     )
-    return templates.TemplateResponse("htmx/partials/requisitions/unified_modal.html", ctx)
+    return template_response("htmx/partials/requisitions/unified_modal.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/import-save", response_class=HTMLResponse)
@@ -959,7 +959,7 @@ async def requisition_detail_partial(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"req": req, "requirements": requirements, "users": users})
-    return templates.TemplateResponse("htmx/partials/requisitions/detail.html", ctx)
+    return template_response("htmx/partials/requisitions/detail.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/create", response_class=HTMLResponse)
@@ -1027,7 +1027,7 @@ async def requisition_create(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx["req"] = req
-    response = templates.TemplateResponse("htmx/partials/requisitions/req_row.html", ctx)
+    response = template_response("htmx/partials/requisitions/req_row.html", ctx)
     response.headers["HX-Trigger"] = "showToast"
     return response
 
@@ -1104,7 +1104,7 @@ async def add_requirement(
     ctx = _base_ctx(request, user, "requisitions")
     ctx["r"] = r
     ctx["req"] = req
-    return templates.TemplateResponse("htmx/partials/requisitions/tabs/req_row.html", ctx)
+    return template_response("htmx/partials/requisitions/tabs/req_row.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/{req_id}/search-all", response_class=HTMLResponse)
@@ -1162,7 +1162,7 @@ async def requisition_search_all(
     ctx["req"] = req
     ctx["requirements"] = requirements
     ctx["search_triggered"] = True
-    resp = templates.TemplateResponse("htmx/partials/requisitions/tabs/parts.html", ctx)
+    resp = template_response("htmx/partials/requisitions/tabs/parts.html", ctx)
     return resp
 
 
@@ -1194,7 +1194,7 @@ async def requisition_tab(
         for r in requirements:
             r.sighting_count = len(r.sightings) if r.sightings else 0
         ctx["requirements"] = requirements
-        return templates.TemplateResponse("htmx/partials/requisitions/tabs/parts.html", ctx)
+        return template_response("htmx/partials/requisitions/tabs/parts.html", ctx)
 
     elif tab == "offers":
         offers = (
@@ -1209,14 +1209,14 @@ async def requisition_tab(
         )
         ctx["offers"] = offers
         ctx["draft_quote"] = draft_quote
-        return templates.TemplateResponse("htmx/partials/requisitions/tabs/offers.html", ctx)
+        return template_response("htmx/partials/requisitions/tabs/offers.html", ctx)
 
     elif tab == "quotes":
         quotes = (
             db.query(Quote).filter(Quote.requisition_id == req_id).order_by(Quote.created_at.desc().nullslast()).all()
         )
         ctx["quotes"] = quotes
-        return templates.TemplateResponse("htmx/partials/requisitions/tabs/quotes.html", ctx)
+        return template_response("htmx/partials/requisitions/tabs/quotes.html", ctx)
 
     elif tab == "buy_plans":
         buy_plans = (
@@ -1227,7 +1227,7 @@ async def requisition_tab(
             .all()
         )
         ctx["buy_plans"] = buy_plans
-        return templates.TemplateResponse("htmx/partials/requisitions/tabs/buy_plans.html", ctx)
+        return template_response("htmx/partials/requisitions/tabs/buy_plans.html", ctx)
 
     elif tab == "tasks":
         tasks = (
@@ -1240,7 +1240,7 @@ async def requisition_tab(
         users = db.query(User).order_by(User.name).all()
         ctx["tasks"] = tasks
         ctx["users"] = users
-        return templates.TemplateResponse("htmx/partials/requisitions/tabs/tasks.html", ctx)
+        return template_response("htmx/partials/requisitions/tabs/tasks.html", ctx)
 
     elif tab == "responses":
         # Fetch vendor responses for this requisition
@@ -1253,7 +1253,7 @@ async def requisition_tab(
             .all()
         )
         ctx["responses"] = responses
-        return templates.TemplateResponse("htmx/partials/requisitions/tabs/responses.html", ctx)
+        return template_response("htmx/partials/requisitions/tabs/responses.html", ctx)
 
     else:  # activity
         from ..models.intelligence import ActivityLog
@@ -1274,7 +1274,7 @@ async def requisition_tab(
         ctx["contacts"] = contacts
         ctx["activities"] = activities
         ctx["req"] = req
-        return templates.TemplateResponse("htmx/partials/requisitions/tabs/activity.html", ctx)
+        return template_response("htmx/partials/requisitions/tabs/activity.html", ctx)
 
 
 # ── Column Prefs Save Endpoints ──────────────────────────────────────────────
@@ -1294,7 +1294,7 @@ async def parse_email_form(
     req = get_requisition_or_404(db, req_id)
     ctx = _base_ctx(request, user, "requisitions")
     ctx["req"] = req
-    return templates.TemplateResponse("htmx/partials/requisitions/tabs/parse_email_form.html", ctx)
+    return template_response("htmx/partials/requisitions/tabs/parse_email_form.html", ctx)
 
 
 @router.get("/v2/partials/requisitions/{req_id}/paste-offer-form", response_class=HTMLResponse)
@@ -1308,7 +1308,7 @@ async def paste_offer_form(
     req = get_requisition_or_404(db, req_id)
     ctx = _base_ctx(request, user, "requisitions")
     ctx["req"] = req
-    return templates.TemplateResponse("htmx/partials/requisitions/tabs/paste_offer_form.html", ctx)
+    return template_response("htmx/partials/requisitions/tabs/paste_offer_form.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/{req_id}/parse-email", response_class=HTMLResponse)
@@ -1359,7 +1359,7 @@ async def parse_email_action(
             f"Parse failed: {exc}</div>"
         )
 
-    return templates.TemplateResponse("htmx/partials/requisitions/tabs/parsed_email_results.html", ctx)
+    return template_response("htmx/partials/requisitions/tabs/parsed_email_results.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/{req_id}/parse-offer", response_class=HTMLResponse)
@@ -1401,7 +1401,7 @@ async def parse_offer_action(
             f"Parse failed: {exc}</div>"
         )
 
-    return templates.TemplateResponse("htmx/partials/requisitions/tabs/parsed_offer_results.html", ctx)
+    return template_response("htmx/partials/requisitions/tabs/parsed_offer_results.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/{req_id}/save-parsed-offers", response_class=HTMLResponse)
@@ -1506,7 +1506,7 @@ async def save_parsed_offers(
     ctx = _base_ctx(request, user, "requisitions")
     ctx["req"] = req
     ctx["saved_count"] = saved_count
-    return templates.TemplateResponse("htmx/partials/requisitions/tabs/parse_save_success.html", ctx)
+    return template_response("htmx/partials/requisitions/tabs/parse_save_success.html", ctx)
 
 
 def _safe_int(val) -> int | None:
@@ -1628,7 +1628,7 @@ async def requisition_inline_edit_cell(
     users = db.query(User).order_by(User.name).all() if field == "owner" else []
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"req": req, "field": field, "users": users, "context": context})
-    return templates.TemplateResponse("htmx/partials/requisitions/inline_cell.html", ctx)
+    return template_response("htmx/partials/requisitions/inline_cell.html", ctx)
 
 
 @router.patch("/v2/partials/requisitions/{req_id}/inline", response_class=HTMLResponse)
@@ -1712,7 +1712,7 @@ async def requisition_inline_save(
         users = db.query(User).order_by(User.name).all()
         ctx = _base_ctx(request, user, "requisitions")
         ctx.update({"req": req, "requirements": requirements, "users": users})
-        response = templates.TemplateResponse("htmx/partials/requisitions/detail_header.html", ctx)
+        response = template_response("htmx/partials/requisitions/detail_header.html", ctx)
     else:
         # Row context — re-fetch ORM object with relationships
         req = (
@@ -1729,7 +1729,7 @@ async def requisition_inline_save(
         req.offer_count = len(req.offers) if req.offers else 0
         ctx = _base_ctx(request, user, "requisitions")
         ctx.update({"req": req, "user_role": getattr(user, "role", UserRole.SALES), "user": user})
-        response = templates.TemplateResponse("htmx/partials/requisitions/req_row.html", ctx)
+        response = template_response("htmx/partials/requisitions/req_row.html", ctx)
 
     response.headers["HX-Trigger"] = json.dumps({"showToast": {"message": msg}})
     return response
@@ -1890,7 +1890,7 @@ async def create_quote_from_offers(
     ctx["quote"] = quote
     ctx["lines"] = lines
     ctx["offers"] = offers
-    return templates.TemplateResponse("htmx/partials/quotes/detail.html", ctx)
+    return template_response("htmx/partials/quotes/detail.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/{req_id}/offers/{offer_id}/review", response_class=HTMLResponse)
@@ -1945,7 +1945,7 @@ async def add_offer_form(
     ctx = _base_ctx(request, user, "requisitions")
     ctx["req"] = req
     ctx["requirements"] = requirements
-    return templates.TemplateResponse("htmx/partials/requisitions/add_offer_form.html", ctx)
+    return template_response("htmx/partials/requisitions/add_offer_form.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/{req_id}/add-offer", response_class=HTMLResponse)
@@ -2049,7 +2049,7 @@ async def edit_offer_form(
     if not offer:
         raise HTTPException(404, "Offer not found")
     requirements = db.query(Requirement).filter(Requirement.requisition_id == req_id).all()
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/requisitions/edit_offer_form.html",
         {"request": request, "offer": offer, "req_id": req_id, "requirements": requirements},
     )
@@ -2208,7 +2208,7 @@ async def offer_review_queue(
         .limit(100)
         .all()
     )
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/offers/review_queue.html",
         {"request": request, "offers": offers, "user": user},
     )
@@ -2285,7 +2285,7 @@ async def offer_changelog(
         .limit(50)
         .all()
     )
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/offers/changelog.html",
         {"request": request, "offer": offer, "changes": rows},
     )
@@ -2389,7 +2389,7 @@ async def rfq_compose(
     ctx["req"] = req
     ctx["parts"] = parts
     ctx["vendors"] = vendors
-    return templates.TemplateResponse("htmx/partials/requisitions/rfq_compose.html", ctx)
+    return template_response("htmx/partials/requisitions/rfq_compose.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/{req_id}/ai-cleanup-email", response_class=HTMLResponse)
@@ -2560,7 +2560,7 @@ async def rfq_send(
     ctx["failed_results"] = failed
     ctx["total_sent"] = len(sent)
     ctx["total_failed"] = len(failed)
-    return templates.TemplateResponse("htmx/partials/requisitions/rfq_results.html", ctx)
+    return template_response("htmx/partials/requisitions/rfq_results.html", ctx)
 
 
 # ── Follow-ups & Response Review (Phase 6) ───────────────────────────
@@ -2617,7 +2617,7 @@ async def follow_ups_list_partial(
 
     ctx = _base_ctx(request, user, "follow-ups")
     ctx.update({"follow_ups": follow_ups, "total": len(follow_ups)})
-    return templates.TemplateResponse("htmx/partials/follow_ups/list.html", ctx)
+    return template_response("htmx/partials/follow_ups/list.html", ctx)
 
 
 @router.post("/v2/partials/follow-ups/{contact_id}/send", response_class=HTMLResponse)
@@ -2693,7 +2693,7 @@ async def send_follow_up_htmx(
     ctx = _base_ctx(request, user, "follow-ups")
     ctx["contact_id"] = contact_id
     ctx["vendor_name"] = contact.vendor_name or "Vendor"
-    return templates.TemplateResponse("htmx/partials/follow_ups/sent_success.html", ctx)
+    return template_response("htmx/partials/follow_ups/sent_success.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/{req_id}/responses/{response_id}/review", response_class=HTMLResponse)
@@ -2734,7 +2734,7 @@ async def review_response_htmx(
     ctx = _base_ctx(request, user, "requisitions")
     ctx["r"] = vr
     ctx["req"] = req
-    return templates.TemplateResponse("htmx/partials/requisitions/tabs/response_card.html", ctx)
+    return template_response("htmx/partials/requisitions/tabs/response_card.html", ctx)
 
 
 @router.post("/v2/partials/requisitions/{req_id}/poll-inbox", response_class=HTMLResponse)
@@ -2855,7 +2855,7 @@ async def update_requirement(
     ctx = _base_ctx(request, user, "requisitions")
     ctx["r"] = item
     ctx["req"] = req
-    return templates.TemplateResponse("htmx/partials/requisitions/tabs/req_row.html", ctx)
+    return template_response("htmx/partials/requisitions/tabs/req_row.html", ctx)
 
 
 # ── Search partials ─────────────────────────────────────────────────────
@@ -2869,7 +2869,7 @@ async def search_form_partial(
 ):
     """Return the search form partial."""
     ctx = _base_ctx(request, user, "search")
-    return templates.TemplateResponse("htmx/partials/search/form.html", ctx)
+    return template_response("htmx/partials/search/form.html", ctx)
 
 
 @router.post("/v2/partials/search/run", response_class=HTMLResponse)
@@ -2923,7 +2923,7 @@ async def search_run(
             "enabled_sources": enabled_sources,
         }
     )
-    return templates.TemplateResponse("htmx/partials/search/results_shell.html", ctx)
+    return template_response("htmx/partials/search/results_shell.html", ctx)
 
 
 @router.get("/v2/partials/search/stream")
@@ -3058,7 +3058,7 @@ async def search_lead_detail(
             if lead:
                 ctx = _base_ctx(request, user, "search")
                 ctx.update({"lead": lead, "mpn": lead.get("mpn_matched", "")})
-                return templates.TemplateResponse("htmx/partials/search/lead_detail.html", ctx)
+                return template_response("htmx/partials/search/lead_detail.html", ctx)
         return HTMLResponse('<p class="p-4 text-sm text-gray-500">Lead not found in cache. Please search again.</p>')
 
     # ── Legacy path: re-run search by MPN + index ──
@@ -3161,7 +3161,7 @@ async def search_lead_detail(
             "material_card_id": material_card_id,
         }
     )
-    return templates.TemplateResponse("htmx/partials/search/lead_detail.html", ctx)
+    return template_response("htmx/partials/search/lead_detail.html", ctx)
 
 
 @router.get("/v2/partials/search/requisition-picker", response_class=HTMLResponse)
@@ -3189,7 +3189,7 @@ async def requisition_picker(
             "action": action,
         }
     )
-    return templates.TemplateResponse("htmx/partials/search/requisition_picker_modal.html", ctx)
+    return template_response("htmx/partials/search/requisition_picker_modal.html", ctx)
 
 
 @router.post("/v2/partials/search/add-to-requisition", response_class=HTMLResponse)
@@ -3365,7 +3365,7 @@ async def vendors_list_partial(
             "push_url_base": push_url_base,
         }
     )
-    return templates.TemplateResponse("htmx/partials/vendors/list.html", ctx)
+    return template_response("htmx/partials/vendors/list.html", ctx)
 
 
 @router.get("/v2/partials/vendors/find-by-part", response_class=HTMLResponse)
@@ -3455,7 +3455,7 @@ async def find_by_part_partial(
             "push_url_base": push_url_base,
         }
     )
-    return templates.TemplateResponse("htmx/partials/vendors/find_by_part.html", ctx)
+    return template_response("htmx/partials/vendors/find_by_part.html", ctx)
 
 
 @router.get("/v2/partials/vendors/{vendor_id}", response_class=HTMLResponse)
@@ -3516,7 +3516,7 @@ async def vendor_detail_partial(
             "mpn_filter": mpn.strip().upper() if mpn.strip() else None,
         }
     )
-    return templates.TemplateResponse("htmx/partials/vendors/detail.html", ctx)
+    return template_response("htmx/partials/vendors/detail.html", ctx)
 
 
 @router.get("/v2/partials/vendors/{vendor_id}/tab/{tab}", response_class=HTMLResponse)
@@ -3587,7 +3587,7 @@ async def vendor_tab(
         )
         # Re-use the inline overview from the detail template
         # by rendering just the overview portion
-        return templates.TemplateResponse("htmx/partials/vendors/overview_tab.html", ctx)
+        return template_response("htmx/partials/vendors/overview_tab.html", ctx)
 
     elif tab == "contacts":
         contacts = (
@@ -3599,7 +3599,7 @@ async def vendor_tab(
         )
         ctx["contacts"] = contacts
         ctx["vendor"] = vendor
-        return templates.TemplateResponse("htmx/partials/vendors/tabs/contacts.html", ctx)
+        return template_response("htmx/partials/vendors/tabs/contacts.html", ctx)
 
     elif tab == "find_contacts":
         prospects = (
@@ -3610,7 +3610,7 @@ async def vendor_tab(
             .all()
         )
         ctx["prospects"] = prospects
-        return templates.TemplateResponse("htmx/partials/vendors/find_contacts_tab.html", ctx)
+        return template_response("htmx/partials/vendors/find_contacts_tab.html", ctx)
 
     elif tab == "emails":
         from ..models.offers import Contact as RfqContact
@@ -3641,7 +3641,7 @@ async def vendor_tab(
         )
         ctx = _base_ctx(request, user, "vendors")
         ctx.update({"vendor": vendor, "contacts": contacts, "responses": responses})
-        return templates.TemplateResponse("htmx/partials/vendors/emails_tab.html", ctx)
+        return template_response("htmx/partials/vendors/emails_tab.html", ctx)
 
     elif tab == "analytics":
         html = f"""<div class="space-y-6">
@@ -3730,7 +3730,7 @@ async def vendor_edit_form(
 ):
     """Return inline edit form for vendor header fields."""
     vendor = get_vendor_card_or_404(db, vendor_id)
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/vendors/edit_vendor_form.html",
         {"request": request, "vendor": vendor},
     )
@@ -3822,7 +3822,7 @@ async def contact_timeline(
         else []
     )
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/vendors/contact_timeline.html",
         {"request": request, "contact": contact, "activities": activities, "vendor_id": vendor_id},
     )
@@ -3852,7 +3852,7 @@ async def vendor_contact_nudges(
                 last = last.replace(tzinfo=timezone.utc)
             if last < cutoff:
                 nudges.append(c)
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/vendors/contact_nudges.html",
         {"request": request, "nudges": nudges, "vendor": vendor},
     )
@@ -3878,7 +3878,7 @@ async def vendor_reviews(
         .limit(20)
         .all()
     )
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/vendors/reviews.html",
         {"request": request, "reviews": reviews, "vendor": vendor, "user": user},
     )
@@ -4016,7 +4016,7 @@ async def vendor_find_contacts(
     )
     ctx["prospects"] = prospects
     ctx["search_count"] = new_count
-    return templates.TemplateResponse("htmx/partials/vendors/find_contacts_results.html", ctx)
+    return template_response("htmx/partials/vendors/find_contacts_results.html", ctx)
 
 
 @router.post(
@@ -4043,7 +4043,7 @@ async def vendor_prospect_save(
     ctx = _base_ctx(request, user, "vendors")
     ctx["vendor"] = vendor
     ctx["p"] = pc
-    return templates.TemplateResponse("htmx/partials/vendors/prospect_card.html", ctx)
+    return template_response("htmx/partials/vendors/prospect_card.html", ctx)
 
 
 @router.post(
@@ -4100,7 +4100,7 @@ async def vendor_prospect_promote(
     ctx = _base_ctx(request, user, "vendors")
     ctx["vendor"] = vendor
     ctx["p"] = pc
-    return templates.TemplateResponse("htmx/partials/vendors/prospect_card.html", ctx)
+    return template_response("htmx/partials/vendors/prospect_card.html", ctx)
 
 
 @router.delete(
@@ -4247,7 +4247,7 @@ async def companies_list_partial(
             "todays_calls": todays_calls,
         }
     )
-    return templates.TemplateResponse("htmx/partials/customers/list.html", ctx)
+    return template_response("htmx/partials/customers/list.html", ctx)
 
 
 # ── Sprint 4: Company CRUD (static routes — must precede {company_id}) ──
@@ -4263,7 +4263,7 @@ async def company_create_form(
     users = (
         db.query(User).filter(User.role.in_((UserRole.BUYER, UserRole.TRADER, UserRole.MANAGER, UserRole.ADMIN))).all()
     )
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/customers/create_form.html",
         {"request": request, "users": users},
     )
@@ -4412,7 +4412,7 @@ async def company_detail_partial(
             "user": user,
         }
     )
-    return templates.TemplateResponse("htmx/partials/customers/detail.html", ctx)
+    return template_response("htmx/partials/customers/detail.html", ctx)
 
 
 @router.get("/v2/partials/customers/{company_id}/tab/{tab}", response_class=HTMLResponse)
@@ -4446,7 +4446,7 @@ async def company_tab(
         ctx["company"] = company
         ctx["sites"] = sites
         ctx["users"] = users
-        return templates.TemplateResponse("htmx/partials/customers/tabs/sites_tab.html", ctx)
+        return template_response("htmx/partials/customers/tabs/sites_tab.html", ctx)
 
     elif tab == "contacts":
         # Get all SiteContact records across all sites for this company
@@ -4639,7 +4639,7 @@ async def company_tab(
                 "email_intel_map": email_intel_map,
             }
         )
-        return templates.TemplateResponse("htmx/partials/customers/tabs/activity_tab.html", ctx)
+        return template_response("htmx/partials/customers/tabs/activity_tab.html", ctx)
 
 
 # ── Sites & Site Contacts CRUD (Phase 4) ───────────────────────────────
@@ -4705,7 +4705,7 @@ async def create_site(
     ctx = _base_ctx(request, user, "customers")
     ctx["company"] = company
     ctx["s"] = site
-    return templates.TemplateResponse("htmx/partials/customers/tabs/site_card.html", ctx)
+    return template_response("htmx/partials/customers/tabs/site_card.html", ctx)
 
 
 @router.delete("/v2/partials/customers/{company_id}/sites/{site_id}", response_class=HTMLResponse)
@@ -4752,7 +4752,7 @@ async def site_contacts_list(
     ctx["site"] = site
     ctx["contacts"] = contacts
     ctx["company"] = company
-    return templates.TemplateResponse("htmx/partials/customers/tabs/site_contacts.html", ctx)
+    return template_response("htmx/partials/customers/tabs/site_contacts.html", ctx)
 
 
 @router.post(
@@ -4825,7 +4825,7 @@ async def create_site_contact(
     ctx["site"] = site
     ctx["contacts"] = contacts
     ctx["company"] = company
-    return templates.TemplateResponse("htmx/partials/customers/tabs/site_contacts.html", ctx)
+    return template_response("htmx/partials/customers/tabs/site_contacts.html", ctx)
 
 
 @router.delete(
@@ -4892,7 +4892,7 @@ async def set_primary_contact(
     ctx["site"] = site
     ctx["contacts"] = contacts
     ctx["company"] = company
-    return templates.TemplateResponse("htmx/partials/customers/tabs/site_contacts.html", ctx)
+    return template_response("htmx/partials/customers/tabs/site_contacts.html", ctx)
 
 
 # ── Sprint 4: Company CRUD (parameterized routes) ──────────────────────
@@ -4912,7 +4912,7 @@ async def company_edit_form(
     users = (
         db.query(User).filter(User.role.in_((UserRole.BUYER, UserRole.TRADER, UserRole.MANAGER, UserRole.ADMIN))).all()
     )
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/customers/edit_form.html",
         {"request": request, "company": company, "users": users},
     )
@@ -5064,7 +5064,7 @@ async def get_site_contact_notes(
         else []
     )
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/customers/contact_notes.html",
         {"request": request, "contact": contact, "notes": notes, "company_id": company_id, "site_id": site_id},
     )
@@ -5085,7 +5085,7 @@ async def preview_quote(
     if not quote:
         raise HTTPException(404, "Quote not found")
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/quotes/preview.html",
         {"request": request, "quote": quote},
     )
@@ -5188,7 +5188,7 @@ async def pricing_history(
         else []
     )
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/quotes/pricing_history.html",
         {"request": request, "offers": offers, "mpn": mpn},
     )
@@ -5286,7 +5286,7 @@ async def rfq_prepare_panel(
             }
         )
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/requisitions/rfq_prepare.html",
         {"request": request, "req": req, "vendors": vendors, "mpns": mpns, "total_contacted": len(contacted_norms)},
     )
@@ -5337,7 +5337,7 @@ async def log_phone_call(
     db.commit()
     logger.info("Phone call logged for req {} vendor {} by {}", req_id, vendor_name, user.email)
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/requisitions/phone_log_success.html",
         {"request": request, "vendor_name": vendor_name, "vendor_phone": vendor_phone},
     )
@@ -5440,7 +5440,7 @@ async def update_response_status(
     db.commit()
     logger.info("Response {} status → {} by {}", response_id, new_status, user.email)
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/requisitions/response_status_badge.html",
         {"request": request, "response": vr},
     )
@@ -5472,7 +5472,7 @@ async def email_thread_viewer(
         logger.error("Could not load thread: {}", exc)
         error = "Could not load thread. Please try again."
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/emails/thread_viewer.html",
         {"request": request, "messages": messages, "conversation_id": conversation_id, "error": error},
     )
@@ -5521,7 +5521,7 @@ async def send_email_reply(
         logger.error("Email send failed: {}", exc)
         error = "Send failed. Please try again or contact support."
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/emails/reply_result.html",
         {"request": request, "to": to, "error": error, "conversation_id": conversation_id},
     )
@@ -5552,7 +5552,7 @@ async def email_thread_summary(
         logger.error("Summary failed: {}", exc)
         error = "Summary failed. Please try again."
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/emails/thread_summary.html",
         {"request": request, "summary": summary, "error": error},
     )
@@ -5572,7 +5572,7 @@ async def email_intelligence_partial(
     items = get_recent_intelligence(db, user.id, limit=50, classification=classification or None)
     dashboard = get_email_intelligence_dashboard(db, user.id, days=7)
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/emails/intelligence_dashboard.html",
         {"request": request, "items": items, "dashboard": dashboard, "classification": classification},
     )
@@ -5607,7 +5607,7 @@ async def dashboard_partial(
 
     ctx = _base_ctx(request, user, "dashboard")
     ctx["stats"] = {"open_reqs": open_reqs, "vendor_count": vendor_count, "company_count": company_count}
-    return templates.TemplateResponse("htmx/partials/dashboard.html", ctx)
+    return template_response("htmx/partials/dashboard.html", ctx)
 
 
 # ── AI Insights HTMX routes (Phase 6) ─────────────────────────────────
@@ -5619,7 +5619,7 @@ def _render_insights(request, user, insights, entity_type, entity_id):
     ctx["insights"] = insights
     ctx["entity_type"] = entity_type
     ctx["entity_id"] = entity_id
-    return templates.TemplateResponse("htmx/partials/shared/insights_panel.html", ctx)
+    return template_response("htmx/partials/shared/insights_panel.html", ctx)
 
 
 @router.get("/v2/partials/requisitions/{req_id}/insights", response_class=HTMLResponse)
@@ -5825,7 +5825,7 @@ async def buy_plans_list_partial(
             "total": len(buy_plans),
         }
     )
-    return templates.TemplateResponse("htmx/partials/buy_plans/list.html", ctx)
+    return template_response("htmx/partials/buy_plans/list.html", ctx)
 
 
 @router.get("/v2/partials/buy-plans/{plan_id}", response_class=HTMLResponse)
@@ -5862,7 +5862,7 @@ async def buy_plan_detail_partial(
             "user": user,
         }
     )
-    return templates.TemplateResponse("htmx/partials/buy_plans/detail.html", ctx)
+    return template_response("htmx/partials/buy_plans/detail.html", ctx)
 
 
 @router.post("/v2/partials/buy-plans/{plan_id}/submit", response_class=HTMLResponse)
@@ -6120,12 +6120,12 @@ async def v2_sourcing_page(request: Request, requirement_id: int, db: Session = 
     """Full page load for sourcing results."""
     user = get_user(request, db)
     if not user:
-        return templates.TemplateResponse(
+        return template_response(
             "htmx/login.html", {"request": request, "password_login": _password_login_enabled(), **_vite_assets()}
         )
     ctx = _base_ctx(request, user, "requisitions")
     ctx["partial_url"] = f"/v2/partials/sourcing/{requirement_id}"
-    return templates.TemplateResponse("htmx/base_page.html", ctx)
+    return template_response("htmx/base_page.html", ctx)
 
 
 @router.get("/v2/sourcing/leads/{lead_id}", response_class=HTMLResponse)
@@ -6133,12 +6133,12 @@ async def v2_lead_detail_page(request: Request, lead_id: int, db: Session = Depe
     """Full page load for lead detail."""
     user = get_user(request, db)
     if not user:
-        return templates.TemplateResponse(
+        return template_response(
             "htmx/login.html", {"request": request, "password_login": _password_login_enabled(), **_vite_assets()}
         )
     ctx = _base_ctx(request, user, "requisitions")
     ctx["partial_url"] = f"/v2/partials/sourcing/leads/{lead_id}"
-    return templates.TemplateResponse("htmx/base_page.html", ctx)
+    return template_response("htmx/base_page.html", ctx)
 
 
 @router.get("/v2/partials/sourcing/{requirement_id}/stream")
@@ -6348,7 +6348,7 @@ async def sourcing_results_partial(
             "f_sort": sort,
         }
     )
-    return templates.TemplateResponse("htmx/partials/sourcing/results.html", ctx)
+    return template_response("htmx/partials/sourcing/results.html", ctx)
 
 
 @router.get("/v2/partials/sourcing/leads/{lead_id}", response_class=HTMLResponse)
@@ -6418,7 +6418,7 @@ async def lead_detail_partial(
             "best_sighting": best_sighting,
         }
     )
-    return templates.TemplateResponse("htmx/partials/sourcing/lead_detail.html", ctx)
+    return template_response("htmx/partials/sourcing/lead_detail.html", ctx)
 
 
 @router.post("/v2/partials/sourcing/leads/{lead_id}/status", response_class=HTMLResponse)
@@ -6483,7 +6483,7 @@ async def lead_status_update(
             }
         ctx = _base_ctx(request, user, "requisitions")
         ctx.update({"lead": lead, "lead_sighting_data": lead_sighting_data, "selected_lead_id": 0})
-        return templates.TemplateResponse("htmx/partials/sourcing/lead_row.html", ctx)
+        return template_response("htmx/partials/sourcing/lead_row.html", ctx)
 
     # Default: card view (results grid)
     best_sighting = (
@@ -6504,7 +6504,7 @@ async def lead_status_update(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"lead": lead, "lead_sighting_data": lead_sighting_data})
-    return templates.TemplateResponse("htmx/partials/sourcing/lead_card.html", ctx)
+    return template_response("htmx/partials/sourcing/lead_card.html", ctx)
 
 
 @router.post("/v2/partials/sourcing/leads/{lead_id}/feedback", response_class=HTMLResponse)
@@ -6547,12 +6547,12 @@ async def v2_sourcing_workspace_page(request: Request, requirement_id: int, db: 
     """Full page load for sourcing workspace (split-panel view)."""
     user = get_user(request, db)
     if not user:
-        return templates.TemplateResponse(
+        return template_response(
             "htmx/login.html", {"request": request, "password_login": _password_login_enabled(), **_vite_assets()}
         )
     ctx = _base_ctx(request, user, "requisitions")
     ctx["partial_url"] = f"/v2/partials/sourcing/{requirement_id}/workspace"
-    return templates.TemplateResponse("htmx/base_page.html", ctx)
+    return template_response("htmx/base_page.html", ctx)
 
 
 @router.get("/v2/partials/sourcing/{requirement_id}/workspace", response_class=HTMLResponse)
@@ -6665,7 +6665,7 @@ async def sourcing_workspace_partial(
             "selected_lead_id": lead if lead else 0,
         }
     )
-    return templates.TemplateResponse("htmx/partials/sourcing/workspace.html", ctx)
+    return template_response("htmx/partials/sourcing/workspace.html", ctx)
 
 
 @router.get("/v2/partials/sourcing/{requirement_id}/workspace-list", response_class=HTMLResponse)
@@ -6858,7 +6858,7 @@ async def lead_panel_partial(
             "best_sighting": best_sighting,
         }
     )
-    return templates.TemplateResponse("htmx/partials/sourcing/lead_panel.html", ctx)
+    return template_response("htmx/partials/sourcing/lead_panel.html", ctx)
 
 
 # ── Materials partials ────────────────────────────────────────────────
@@ -6887,7 +6887,7 @@ async def materials_workspace_partial(
     total_materials = db.query(MaterialCard).filter(MaterialCard.deleted_at.is_(None)).count()
     ctx = _base_ctx(request, user, "materials")
     ctx["total_materials"] = total_materials
-    return templates.TemplateResponse("htmx/partials/materials/workspace.html", ctx)
+    return template_response("htmx/partials/materials/workspace.html", ctx)
 
 
 @router.get("/v2/partials/materials/filters/manufacturers", response_class=HTMLResponse)
@@ -6903,7 +6903,7 @@ async def materials_filters_manufacturers_partial(
     options = get_manufacturer_options(db, commodity=commodity or None)
     ctx = _base_ctx(request, user, "materials")
     ctx["manufacturer_options"] = options
-    return templates.TemplateResponse("htmx/partials/materials/filters/manufacturers.html", ctx)
+    return template_response("htmx/partials/materials/filters/manufacturers.html", ctx)
 
 
 @router.get("/v2/partials/manufacturers/search", response_class=HTMLResponse)
@@ -6938,7 +6938,7 @@ async def manufacturer_search(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"results": results, "q": q.strip()})
-    return templates.TemplateResponse("htmx/partials/manufacturers/search_results.html", ctx)
+    return template_response("htmx/partials/manufacturers/search_results.html", ctx)
 
 
 @router.post("/v2/partials/manufacturers/add", response_class=HTMLResponse)
@@ -6987,7 +6987,7 @@ async def materials_filters_tree_partial(
             "active_commodity": commodity.lower().strip() if commodity else "",
         }
     )
-    return templates.TemplateResponse("htmx/partials/materials/filters/tree.html", ctx)
+    return template_response("htmx/partials/materials/filters/tree.html", ctx)
 
 
 @router.get("/v2/partials/materials/filters/sub", response_class=HTMLResponse)
@@ -7015,7 +7015,7 @@ async def materials_filters_sub_partial(
             "commodity_selected": True,
         }
     )
-    return templates.TemplateResponse("htmx/partials/materials/filters/subfilters.html", ctx)
+    return template_response("htmx/partials/materials/filters/subfilters.html", ctx)
 
 
 @router.get("/v2/partials/materials/ai-interpret", response_class=HTMLResponse)
@@ -7038,7 +7038,7 @@ async def materials_ai_interpret_partial(
         ctx["ai_parent"] = get_parent_for_commodity(result["commodity"])
     else:
         ctx["ai_parent"] = ""
-    return templates.TemplateResponse("htmx/partials/materials/ai_interpret.html", ctx)
+    return template_response("htmx/partials/materials/ai_interpret.html", ctx)
 
 
 @router.get("/v2/partials/materials/faceted", response_class=HTMLResponse)
@@ -7120,7 +7120,7 @@ async def materials_faceted_partial(
             "faceted": True,
         }
     )
-    return templates.TemplateResponse("htmx/partials/materials/list.html", ctx)
+    return template_response("htmx/partials/materials/list.html", ctx)
 
 
 @router.get("/v2/partials/materials/{card_id}", response_class=HTMLResponse)
@@ -7160,7 +7160,7 @@ async def material_detail_partial(
     )
     ctx = _base_ctx(request, user, "materials")
     ctx.update({"card": card, "sightings": sightings, "offers": offers})
-    return templates.TemplateResponse("htmx/partials/materials/detail.html", ctx)
+    return template_response("htmx/partials/materials/detail.html", ctx)
 
 
 @router.get(
@@ -7194,7 +7194,7 @@ async def material_tab_partial(
             .order_by(MaterialVendorHistory.last_seen.desc().nullslast())
             .all()
         )
-        return templates.TemplateResponse("htmx/partials/materials/tabs/vendors.html", ctx)
+        return template_response("htmx/partials/materials/tabs/vendors.html", ctx)
     elif tab_name == "customers":
         from ..models.purchase_history import CustomerPartHistory
 
@@ -7204,7 +7204,7 @@ async def material_tab_partial(
             .order_by(CustomerPartHistory.last_purchased_at.desc().nullslast())
             .all()
         )
-        return templates.TemplateResponse("htmx/partials/materials/tabs/customers.html", ctx)
+        return template_response("htmx/partials/materials/tabs/customers.html", ctx)
     elif tab_name == "sourcing":
         from ..models.sourcing import Requirement
 
@@ -7214,7 +7214,7 @@ async def material_tab_partial(
             .order_by(Requirement.created_at.desc())
             .all()
         )
-        return templates.TemplateResponse("htmx/partials/materials/tabs/sourcing.html", ctx)
+        return template_response("htmx/partials/materials/tabs/sourcing.html", ctx)
     elif tab_name == "price_history":
         from ..models.price_snapshot import MaterialPriceSnapshot
 
@@ -7225,7 +7225,7 @@ async def material_tab_partial(
             .limit(200)
             .all()
         )
-        return templates.TemplateResponse("htmx/partials/materials/tabs/price_history.html", ctx)
+        return template_response("htmx/partials/materials/tabs/price_history.html", ctx)
     else:
         return HTMLResponse(
             "<p class='text-gray-400 text-sm py-4 text-center'>Unknown tab</p>",
@@ -7310,7 +7310,7 @@ async def quotes_list_partial(
     quotes = query.order_by(Quote.created_at.desc()).offset(offset).limit(limit).all()
     ctx = _base_ctx(request, user, "quotes")
     ctx.update({"quotes": quotes, "q": q, "status": status, "total": total, "limit": limit, "offset": offset})
-    return templates.TemplateResponse("htmx/partials/quotes/list.html", ctx)
+    return template_response("htmx/partials/quotes/list.html", ctx)
 
 
 @router.get("/v2/partials/quotes/{quote_id}", response_class=HTMLResponse)
@@ -7339,7 +7339,7 @@ async def quote_detail_partial(
     )
     ctx = _base_ctx(request, user, "quotes")
     ctx.update({"quote": quote, "lines": lines, "offers": offers})
-    return templates.TemplateResponse("htmx/partials/quotes/detail.html", ctx)
+    return template_response("htmx/partials/quotes/detail.html", ctx)
 
 
 @router.put("/v2/partials/quotes/{quote_id}/lines/{line_id}", response_class=HTMLResponse)
@@ -7379,7 +7379,7 @@ async def update_quote_line(
     db.commit()
     ctx = _base_ctx(request, user, "quotes")
     ctx["line"] = line
-    return templates.TemplateResponse("htmx/partials/quotes/line_row.html", ctx)
+    return template_response("htmx/partials/quotes/line_row.html", ctx)
 
 
 @router.delete("/v2/partials/quotes/{quote_id}/lines/{line_id}", response_class=HTMLResponse)
@@ -7432,7 +7432,7 @@ async def add_quote_line(
     db.refresh(line)
     ctx = _base_ctx(request, user, "quotes")
     ctx["line"] = line
-    return templates.TemplateResponse("htmx/partials/quotes/line_row.html", ctx)
+    return template_response("htmx/partials/quotes/line_row.html", ctx)
 
 
 @router.post("/v2/partials/quotes/{quote_id}/add-offer/{offer_id}", response_class=HTMLResponse)
@@ -7465,7 +7465,7 @@ async def add_offer_to_quote(
     db.refresh(line)
     ctx = _base_ctx(request, user, "quotes")
     ctx["line"] = line
-    return templates.TemplateResponse("htmx/partials/quotes/line_row.html", ctx)
+    return template_response("htmx/partials/quotes/line_row.html", ctx)
 
 
 @router.post("/v2/partials/quotes/{quote_id}/send", response_class=HTMLResponse)
@@ -7671,7 +7671,7 @@ async def build_buy_plan_htmx(
     ctx["bp"] = plan
     ctx["lines"] = bp_lines
     ctx["is_ops_member"] = _is_ops_member(user, db)
-    return templates.TemplateResponse("htmx/partials/buy_plans/detail.html", ctx)
+    return template_response("htmx/partials/buy_plans/detail.html", ctx)
 
 
 # ── Prospecting partials ──────────────────────────────────────────────
@@ -7719,7 +7719,7 @@ async def prospecting_list_partial(
             "total_pages": total_pages,
         }
     )
-    return templates.TemplateResponse("htmx/partials/prospecting/list.html", ctx)
+    return template_response("htmx/partials/prospecting/list.html", ctx)
 
 
 # Sprint 8 prospecting static routes — must precede {prospect_id} catch-all
@@ -7737,7 +7737,7 @@ async def prospecting_stats(
         db.query(sqlfunc.count(ProspectAccount.id)).filter(ProspectAccount.readiness_score >= 70).scalar() or 0
     )
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/prospecting/stats.html",
         {"request": request, "total": total, "buyer_ready": buyer_ready},
     )
@@ -7792,7 +7792,7 @@ async def prospecting_detail_partial(
     ctx["prospect"] = prospect
     ctx["enrichment"] = prospect.enrichment_data or {}
     ctx["warm_intro"] = (prospect.enrichment_data or {}).get("warm_intro", {})
-    return templates.TemplateResponse("htmx/partials/prospecting/detail.html", ctx)
+    return template_response("htmx/partials/prospecting/detail.html", ctx)
 
 
 @router.post("/v2/partials/prospecting/{prospect_id}/claim", response_class=HTMLResponse)
@@ -7819,7 +7819,7 @@ async def claim_prospect_htmx(
     )
     ctx = _base_ctx(request, user, "prospecting")
     ctx["prospect"] = prospect
-    return templates.TemplateResponse("htmx/partials/prospecting/_card.html", ctx)
+    return template_response("htmx/partials/prospecting/_card.html", ctx)
 
 
 @router.post("/v2/partials/prospecting/{prospect_id}/dismiss", response_class=HTMLResponse)
@@ -7840,7 +7840,7 @@ async def dismiss_prospect_htmx(
     db.commit()
     ctx = _base_ctx(request, user, "prospecting")
     ctx["prospect"] = prospect
-    return templates.TemplateResponse("htmx/partials/prospecting/_card.html", ctx)
+    return template_response("htmx/partials/prospecting/_card.html", ctx)
 
 
 @router.post("/v2/partials/prospecting/{prospect_id}/enrich", response_class=HTMLResponse)
@@ -7877,7 +7877,7 @@ async def enrich_prospect_htmx(
     ctx["prospect"] = prospect
     ctx["enrichment"] = prospect.enrichment_data or {}
     ctx["warm_intro"] = (prospect.enrichment_data or {}).get("warm_intro", {})
-    return templates.TemplateResponse("htmx/partials/prospecting/detail.html", ctx)
+    return template_response("htmx/partials/prospecting/detail.html", ctx)
 
 
 # ── Settings partials ────────────────────────────────────────────────
@@ -7894,7 +7894,7 @@ async def settings_partial(
     ctx = _base_ctx(request, user, "settings")
     ctx["active_tab"] = tab
     ctx["is_admin"] = user.role == UserRole.ADMIN
-    return templates.TemplateResponse("htmx/partials/settings/index.html", ctx)
+    return template_response("htmx/partials/settings/index.html", ctx)
 
 
 @router.get("/v2/partials/settings/sources", response_class=HTMLResponse)
@@ -7907,7 +7907,7 @@ async def settings_sources_tab(
     sources = db.query(ApiSource).order_by(ApiSource.display_name).all()
     ctx = _base_ctx(request, user, "settings")
     ctx["sources"] = sources
-    return templates.TemplateResponse("htmx/partials/settings/sources.html", ctx)
+    return template_response("htmx/partials/settings/sources.html", ctx)
 
 
 @router.get("/v2/partials/settings/system", response_class=HTMLResponse)
@@ -7924,7 +7924,7 @@ async def settings_system_tab(
     config = get_all_config(db)
     ctx = _base_ctx(request, user, "settings")
     ctx["config"] = config
-    return templates.TemplateResponse("htmx/partials/settings/system.html", ctx)
+    return template_response("htmx/partials/settings/system.html", ctx)
 
 
 @router.get("/v2/partials/settings/profile", response_class=HTMLResponse)
@@ -7936,7 +7936,7 @@ async def settings_profile_tab(
     """User profile tab."""
     ctx = _base_ctx(request, user, "settings")
     ctx["profile_user"] = user
-    return templates.TemplateResponse("htmx/partials/settings/profile.html", ctx)
+    return template_response("htmx/partials/settings/profile.html", ctx)
 
 
 @router.post("/api/user/toggle-8x8", response_class=HTMLResponse)
@@ -7985,7 +7985,7 @@ async def settings_data_ops_tab(
     ctx = _base_ctx(request, user, "settings")
     ctx["vendor_dupes"] = vendor_dupes
     ctx["company_dupes"] = company_dupes
-    return templates.TemplateResponse("htmx/partials/settings/data_ops.html", ctx)
+    return template_response("htmx/partials/settings/data_ops.html", ctx)
 
 
 @router.post("/v2/partials/admin/vendor-merge", response_class=HTMLResponse)
@@ -8065,7 +8065,7 @@ async def proactive_list_partial(
     ctx["tab"] = tab
     ctx["match_count"] = match_count
     ctx["success_msg"] = request.query_params.get("success_msg", "")
-    return templates.TemplateResponse("htmx/partials/proactive/list.html", ctx)
+    return template_response("htmx/partials/proactive/list.html", ctx)
 
 
 @router.post("/v2/partials/proactive/batch-dismiss", response_class=HTMLResponse)
@@ -8103,7 +8103,7 @@ async def proactive_batch_dismiss(
     ctx["tab"] = "matches"
     ctx["match_count"] = match_count
     ctx["success_msg"] = ""
-    return templates.TemplateResponse("htmx/partials/proactive/list.html", ctx)
+    return template_response("htmx/partials/proactive/list.html", ctx)
 
 
 @router.post("/v2/proactive/prepare/{site_id}", response_class=HTMLResponse)
@@ -8187,7 +8187,7 @@ async def proactive_prepare_page(
             "error_msg": "",
         }
     )
-    return templates.TemplateResponse("htmx/partials/proactive/prepare.html", ctx)
+    return template_response("htmx/partials/proactive/prepare.html", ctx)
 
 
 @router.post("/v2/partials/proactive/draft", response_class=HTMLResponse)
@@ -8359,7 +8359,7 @@ async def proactive_send_offer(
         ctx["tab"] = "matches"
         ctx["match_count"] = match_count
         ctx["success_msg"] = f"Offer sent to {contacts_count} contact(s) ({parts_count} parts)."
-        return templates.TemplateResponse("htmx/partials/proactive/list.html", ctx)
+        return template_response("htmx/partials/proactive/list.html", ctx)
 
     except ValueError as e:
         raise HTTPException(400, str(e))
@@ -8398,7 +8398,7 @@ async def proactive_send_legacy(
     logger.info("Proactive match {} sent by {}", match_id, user.email)
 
     # Redirect to list with success message (send_success.html removed in redesign)
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/proactive/list.html",
         _base_ctx(request, user, "proactive")
         | {
@@ -8429,7 +8429,7 @@ async def proactive_convert(
         from ..services.proactive_service import convert_proactive_to_win
 
         result = convert_proactive_to_win(db, offer.id, user)
-        return templates.TemplateResponse(
+        return template_response(
             "htmx/partials/proactive/convert_success.html",
             {"request": request, "offer": offer, "result": result},
         )
@@ -8452,7 +8452,7 @@ async def proactive_scorecard(
     except (ImportError, RuntimeError, Exception):
         stats = {"total_sent": 0, "total_converted": 0, "conversion_rate": 0, "total_revenue": 0}
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/proactive/scorecard.html",
         {"request": request, "stats": stats},
     )
@@ -8564,7 +8564,7 @@ async def find_crosses(
 
     # Return cached results if available (skip on explicit refresh)
     if mc.cross_references and not refresh:
-        return templates.TemplateResponse(
+        return template_response(
             "htmx/partials/materials/crosses_section.html",
             {"request": request, "card": mc},
         )
@@ -8613,13 +8613,13 @@ async def find_crosses(
         logger.warning("Cross-reference search failed for material {}: {}", material_id, exc)
         db.rollback()
         # Return error inside the same section ID so retry works
-        return templates.TemplateResponse(
+        return template_response(
             "htmx/partials/materials/crosses_section.html",
             {"request": request, "card": mc, "error": "Cross-reference search failed. Please try again."},
         )
 
     # Return the updated crosses section
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/materials/crosses_section.html",
         {"request": request, "card": mc},
     )
@@ -8652,7 +8652,7 @@ async def material_insights(
         else []
     )
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/materials/insights.html",
         {"request": request, "material": mc, "offers": offers},
     )
@@ -8674,7 +8674,7 @@ async def knowledge_list(
         query = query.filter(sb.ilike_filter(KnowledgeEntry.content))
     entries = query.order_by(KnowledgeEntry.created_at.desc()).limit(50).all()
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/knowledge/list.html",
         {"request": request, "entries": entries, "q": q},
     )
@@ -8724,7 +8724,7 @@ async def admin_api_health(
     except (ImportError, RuntimeError, Exception):
         health = {"connectors": [], "overall_status": "unknown"}
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/admin/api_health.html",
         {"request": request, "health": health},
     )
@@ -8789,7 +8789,7 @@ async def admin_data_ops(
     company_count = db.query(sqlfunc.count(Company.id)).filter(Company.is_active.is_(True)).scalar() or 0
     material_count = db.query(sqlfunc.count(MaterialCard.id)).scalar() or 0
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/admin/data_ops.html",
         {
             "request": request,
@@ -8979,7 +8979,7 @@ async def parts_list_partial(
             "sub_card_map": sub_card_map,
         }
     )
-    return templates.TemplateResponse("htmx/partials/parts/list.html", ctx)
+    return template_response("htmx/partials/parts/list.html", ctx)
 
 
 @router.get("/v2/partials/parts/{requirement_id}/tab/offers", response_class=HTMLResponse)
@@ -9000,7 +9000,7 @@ async def part_tab_offers(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"requirement": req, "offers": offers})
-    return templates.TemplateResponse("htmx/partials/parts/tabs/offers.html", ctx)
+    return template_response("htmx/partials/parts/tabs/offers.html", ctx)
 
 
 @router.get("/v2/partials/parts/{requirement_id}/tab/sourcing", response_class=HTMLResponse)
@@ -9045,7 +9045,7 @@ async def part_tab_sourcing(
             "vendor_statuses": vendor_statuses,
         }
     )
-    return templates.TemplateResponse("htmx/partials/parts/tabs/sourcing.html", ctx)
+    return template_response("htmx/partials/parts/tabs/sourcing.html", ctx)
 
 
 @router.get("/v2/partials/parts/{requirement_id}/tab/req-details", response_class=HTMLResponse)
@@ -9080,7 +9080,7 @@ async def part_tab_req_details(
             "users": users_list,
         }
     )
-    return templates.TemplateResponse("htmx/partials/parts/tabs/req_details.html", ctx)
+    return template_response("htmx/partials/parts/tabs/req_details.html", ctx)
 
 
 @router.get("/v2/partials/parts/{requirement_id}/header", response_class=HTMLResponse)
@@ -9097,7 +9097,7 @@ async def part_header(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx["requirement"] = req
-    return templates.TemplateResponse("htmx/partials/parts/header.html", ctx)
+    return template_response("htmx/partials/parts/header.html", ctx)
 
 
 _PART_HEADER_EDITABLE = {
@@ -9303,7 +9303,7 @@ async def part_header_save(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx["requirement"] = req
-    response = templates.TemplateResponse("htmx/partials/parts/header.html", ctx)
+    response = template_response("htmx/partials/parts/header.html", ctx)
     response.headers["HX-Trigger"] = json.dumps({"part-updated": {"id": requirement_id}})
     return response
 
@@ -9340,7 +9340,7 @@ async def part_cell_edit(
     cell_id = f"cell-{field}-{requirement_id}"
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"requirement": req, "field": field, "cell_id": cell_id})
-    return templates.TemplateResponse("htmx/partials/parts/cell_edit.html", ctx)
+    return template_response("htmx/partials/parts/cell_edit.html", ctx)
 
 
 @router.get("/v2/partials/parts/{requirement_id}/cell/display/{field}", response_class=HTMLResponse)
@@ -9362,7 +9362,7 @@ async def part_cell_display(
     cell_id = f"cell-{field}-{requirement_id}"
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"requirement": req, "field": field, "cell_id": cell_id})
-    return templates.TemplateResponse("htmx/partials/parts/cell_display.html", ctx)
+    return template_response("htmx/partials/parts/cell_display.html", ctx)
 
 
 @router.patch("/v2/partials/parts/{requirement_id}/cell", response_class=HTMLResponse)
@@ -9410,7 +9410,7 @@ async def part_cell_save(
     cell_id = f"cell-{field}-{requirement_id}"
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"requirement": req, "field": field, "cell_id": cell_id})
-    response = templates.TemplateResponse("htmx/partials/parts/cell_display.html", ctx)
+    response = template_response("htmx/partials/parts/cell_display.html", ctx)
     response.headers["HX-Trigger"] = json.dumps({"part-updated": {"id": requirement_id}})
     return response
 
@@ -9444,7 +9444,7 @@ async def part_spec_edit(
             "condition_choices": _CONDITION_CHOICES,
         }
     )
-    return templates.TemplateResponse("htmx/partials/parts/spec_edit.html", ctx)
+    return template_response("htmx/partials/parts/spec_edit.html", ctx)
 
 
 @router.patch("/v2/partials/parts/{requirement_id}/save-spec", response_class=HTMLResponse)
@@ -9473,7 +9473,7 @@ async def part_spec_save(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"field_value": clean})
-    response = templates.TemplateResponse("htmx/partials/parts/spec_display.html", ctx)
+    response = template_response("htmx/partials/parts/spec_display.html", ctx)
     response.headers["HX-Trigger"] = json.dumps(
         {
             "part-updated": {"id": requirement_id},
@@ -9507,7 +9507,7 @@ async def part_tab_activity(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"requirement": req, "activities": activities})
-    return templates.TemplateResponse("htmx/partials/parts/tabs/activity.html", ctx)
+    return template_response("htmx/partials/parts/tabs/activity.html", ctx)
 
 
 @router.get("/v2/partials/parts/{requirement_id}/tab/comms", response_class=HTMLResponse)
@@ -9543,7 +9543,7 @@ async def part_tab_comms(
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"requirement": req, "tasks": tasks, "users": users_list, "today": date.today()})
-    return templates.TemplateResponse("htmx/partials/parts/tabs/comms.html", ctx)
+    return template_response("htmx/partials/parts/tabs/comms.html", ctx)
 
 
 @router.get("/v2/partials/parts/{requirement_id}/tab/notes", response_class=HTMLResponse)
@@ -9559,7 +9559,7 @@ async def part_tab_notes(
         raise HTTPException(404, "Part not found")
     ctx = _base_ctx(request, user, "requisitions")
     ctx["requirement"] = req
-    return templates.TemplateResponse("htmx/partials/parts/tabs/notes.html", ctx)
+    return template_response("htmx/partials/parts/tabs/notes.html", ctx)
 
 
 @router.patch("/v2/partials/parts/{requirement_id}/notes", response_class=HTMLResponse)
@@ -9578,7 +9578,7 @@ async def save_part_notes(
     db.commit()
     ctx = _base_ctx(request, user, "requisitions")
     ctx["requirement"] = req
-    return templates.TemplateResponse("htmx/partials/parts/tabs/notes.html", ctx)
+    return template_response("htmx/partials/parts/tabs/notes.html", ctx)
 
 
 @router.post("/v2/partials/parts/{requirement_id}/tasks", response_class=HTMLResponse)
@@ -9837,7 +9837,7 @@ async def bulk_unarchive(
 @router.get("/v2/partials/trouble-tickets/workspace", response_class=HTMLResponse)
 async def trouble_tickets_workspace(request: Request, user: User = Depends(require_user)):
     """Trouble Tickets workspace — loaded into #main-content."""
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/tickets/workspace.html",
         {**_base_ctx(request, user, "tickets")},
     )
@@ -9880,7 +9880,7 @@ async def trouble_tickets_list(
         else:
             ungrouped.append(t)
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/tickets/list.html",
         {
             **_base_ctx(request, user, "tickets"),
@@ -9911,7 +9911,7 @@ async def trouble_ticket_detail(
     )
     if not ticket:
         raise HTTPException(404, "Ticket not found")
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/tickets/detail.html",
         {**_base_ctx(request, user, "tickets"), "ticket": ticket},
     )

--- a/app/routers/quote_builder.py
+++ b/app/routers/quote_builder.py
@@ -49,9 +49,9 @@ async def quote_builder_modal(
         if site and site.company:
             customer_name = site.company.name or ""
 
-    from ..template_env import templates
+    from ..template_env import template_response
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/quote_builder/modal.html",
         {
             "request": request,
@@ -98,9 +98,9 @@ async def quote_builder_modal_multi(
         if site and site.company:
             customer_name = site.company.name or ""
 
-    from ..template_env import templates
+    from ..template_env import template_response
 
-    return templates.TemplateResponse(
+    return template_response(
         "htmx/partials/quote_builder/modal.html",
         {
             "request": request,

--- a/app/routers/requisitions2.py
+++ b/app/routers/requisitions2.py
@@ -39,7 +39,7 @@ from ..services.requisition_list_service import (
     list_requisitions,
 )
 from ..services.sse_broker import broker
-from ..template_env import templates
+from ..template_env import template_response
 
 router = APIRouter(prefix="/requisitions2", tags=["requisitions2"])
 
@@ -99,9 +99,9 @@ async def requisitions_page(
     ctx = _table_context(request, filters, db, user)
 
     if _is_htmx(request):
-        return templates.TemplateResponse("requisitions2/_table.html", ctx)
+        return template_response("requisitions2/_table.html", ctx)
 
-    return templates.TemplateResponse("requisitions2/page.html", ctx)
+    return template_response("requisitions2/page.html", ctx)
 
 
 # ── SSE stream ───────────────────────────────────────────────────────
@@ -157,7 +157,7 @@ async def requisitions_table(
     """Table fragment for HTMX swap after filter/sort/paginate."""
     filters = _parse_filters(request)
     ctx = _table_context(request, filters, db, user)
-    return templates.TemplateResponse("requisitions2/_table.html", ctx)
+    return template_response("requisitions2/_table.html", ctx)
 
 
 # ── Rows-only fragment ───────────────────────────────────────────────
@@ -172,7 +172,7 @@ async def requisitions_table_rows(
     """Rows-only fragment for HTMX swap."""
     filters = _parse_filters(request)
     ctx = _table_context(request, filters, db, user)
-    return templates.TemplateResponse("requisitions2/_table_rows.html", ctx)
+    return template_response("requisitions2/_table_rows.html", ctx)
 
 
 # ── Detail panel (split-screen right panel) ─────────────────────────
@@ -197,7 +197,7 @@ async def requisition_detail_panel(
             '<div class="p-8 text-center text-sm text-gray-400">Requisition not found.</div>',
             status_code=404,
         )
-    return templates.TemplateResponse(
+    return template_response(
         "requisitions2/_detail_panel.html",
         {"request": request, **detail, "user": user},
     )
@@ -225,7 +225,7 @@ async def requisition_modal(
             '<div class="rq2-modal-error">Requisition not found.</div>',
             status_code=404,
         )
-    return templates.TemplateResponse(
+    return template_response(
         "requisitions2/_modal.html",
         {"request": request, **detail, "user": user},
     )
@@ -247,7 +247,7 @@ async def inline_edit_cell(
     if not req:
         return HTMLResponse("Not found", status_code=404)
     users = get_team_users(db) if field == InlineEditField.owner else []
-    return templates.TemplateResponse(
+    return template_response(
         "requisitions2/_inline_cell.html",
         {"request": request, "req": req, "field": field.value, "users": users},
     )
@@ -322,7 +322,7 @@ async def inline_save(
     row_ctx = get_row_context(db, req, user)
     row_ctx["request"] = request
     row_ctx["avail_opp_table_v2_enabled"] = settings.avail_opp_table_v2
-    response = templates.TemplateResponse("requisitions2/_single_row.html", row_ctx)
+    response = template_response("requisitions2/_single_row.html", row_ctx)
     response.headers["HX-Trigger"] = json.dumps({"showToast": {"message": msg}})
     await broker.publish("requisitions", "table-refresh", msg)
     return response
@@ -418,7 +418,7 @@ async def row_action(
     # Return refreshed table
     filters = _parse_filters(request)
     ctx = _table_context(request, filters, db, user)
-    response = templates.TemplateResponse("requisitions2/_table.html", ctx)
+    response = template_response("requisitions2/_table.html", ctx)
     response.headers["HX-Trigger"] = json.dumps({"showToast": {"message": msg}})
     await broker.publish("requisitions", "table-refresh", msg)
     return response
@@ -442,7 +442,7 @@ async def bulk_action(
     if not id_list:
         filters = _parse_filters(request)
         ctx = _table_context(request, filters, db, user)
-        return templates.TemplateResponse("requisitions2/_table.html", ctx)
+        return template_response("requisitions2/_table.html", ctx)
 
     reqs_q = db.query(Requisition).filter(Requisition.id.in_(id_list))
     if user.role == UserRole.SALES:
@@ -479,7 +479,7 @@ async def bulk_action(
 
     filters = _parse_filters(request)
     ctx = _table_context(request, filters, db, user)
-    response = templates.TemplateResponse("requisitions2/_table.html", ctx)
+    response = template_response("requisitions2/_table.html", ctx)
     word = action_name.value + ("d" if action_name.value.endswith("e") else "ed")
     msg = f"{count} requisition{'s' if count != 1 else ''} {word}"
     if errors:

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -36,7 +36,7 @@ from ..services.activity_service import log_rfq_activity
 from ..services.sighting_status import compute_vendor_statuses
 from ..services.sse_broker import broker
 from ..services.status_machine import SOURCING_TRANSITIONS, require_valid_transition
-from ..template_env import templates
+from ..template_env import template_response
 from ..utils.sql_helpers import escape_like
 from ..vendor_utils import normalize_vendor_name
 
@@ -117,7 +117,7 @@ async def sightings_workspace(
     The table loads via hx-get inside.
     """
     ctx = {"request": request, "user": user}
-    return templates.TemplateResponse("htmx/partials/sightings/list.html", ctx)
+    return template_response("htmx/partials/sightings/list.html", ctx)
 
 
 @router.get("/v2/partials/sightings", response_class=HTMLResponse)
@@ -369,7 +369,7 @@ async def sightings_list(
         "link_map": link_map,
         "user": user,
     }
-    return templates.TemplateResponse("htmx/partials/sightings/table.html", ctx)
+    return template_response("htmx/partials/sightings/table.html", ctx)
 
 
 @router.get("/v2/partials/sightings/{requirement_id}/detail", response_class=HTMLResponse)
@@ -615,7 +615,7 @@ async def sightings_detail(
         "activities": activities,
         "user": user,
     }
-    resp = templates.TemplateResponse("htmx/partials/sightings/detail.html", ctx)
+    resp = template_response("htmx/partials/sightings/detail.html", ctx)
     resp.headers["X-Rendered-Req-Id"] = str(requirement_id)
     return resp
 
@@ -1064,7 +1064,7 @@ async def sightings_log_activity(
         "activities": activities,
         "requirement": requirement,
     }
-    resp = templates.TemplateResponse("htmx/partials/sightings/activity_section.html", ctx)
+    resp = template_response("htmx/partials/sightings/activity_section.html", ctx)
     resp.headers["X-Rendered-Req-Id"] = str(requirement_id)
     return resp
 
@@ -1116,7 +1116,7 @@ async def sightings_vendor_modal(
         "requirement_ids": req_id_list,
         "parts": parts,
     }
-    return templates.TemplateResponse("htmx/partials/sightings/vendor_modal.html", ctx)
+    return template_response("htmx/partials/sightings/vendor_modal.html", ctx)
 
 
 @router.post("/v2/partials/sightings/preview-inquiry", response_class=HTMLResponse)
@@ -1187,7 +1187,7 @@ async def sightings_preview_inquiry(
         "vendor_names": vendor_names,
         "email_body": email_body,
     }
-    return templates.TemplateResponse("htmx/partials/sightings/preview_inquiry.html", ctx)
+    return template_response("htmx/partials/sightings/preview_inquiry.html", ctx)
 
 
 @router.post("/v2/partials/sightings/send-inquiry", response_class=HTMLResponse)

--- a/app/template_env.py
+++ b/app/template_env.py
@@ -5,10 +5,28 @@ Depends on: Jinja2
 """
 
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi.templating import Jinja2Templates
+from starlette.responses import Response
 
 templates = Jinja2Templates(directory="app/templates")
+
+
+def template_response(name: str, context: dict[str, Any], **kwargs: Any) -> Response:
+    """Render a Jinja2 template using the shared `templates` instance.
+
+    Wraps Jinja2Templates.TemplateResponse with the legacy `(name, context)`
+    calling convention used across the codebase. Starlette 1.0 removed
+    positional support for that form and now requires `request` as the first
+    positional argument. This helper extracts `request` from the context dict
+    (which already needs to be present so Jinja can render `{{ request.X }}`)
+    and calls the new signature, so callers don't carry the boilerplate.
+    """
+    request = context.get("request")
+    if request is None:
+        raise ValueError("template_response: 'request' must be present in the context dict")
+    return templates.TemplateResponse(request, name, context, **kwargs)
 
 
 # ── Shared Helpers ─────────────────────────────────────────────────────

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -47,9 +47,10 @@ FastAPI Middleware Stack (in order):
     ├── 1. GZipMiddleware (compress >= 500 bytes)
     ├── 2. SessionMiddleware (HTTP-only cookie, 15-min expiry)
     ├── 3. CSRFMiddleware (double-submit cookie on mutations)
-    ├── 4. CSP Middleware (Content-Security-Policy header)
-    ├── 5. Request ID Middleware (UUID tracking, timing, logging)
-    └── 6. API Version Middleware (/api/v1/* -> /api/*)
+    ├── 4. PrometheusMiddleware (request count + duration histogram, app/prometheus_metrics.py)
+    ├── 5. CSP Middleware (Content-Security-Policy header)
+    ├── 6. Request ID Middleware (UUID tracking, timing, logging)
+    └── 7. API Version Middleware (/api/v1/* -> /api/*)
     │
     ▼
 Router (27 router modules)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,12 @@ charset-normalizer==3.4.7
 cryptography==46.0.7
 # Observability
 loguru==0.7.3
-prometheus-fastapi-instrumentator==7.1.0
+# Pinned >=1.0.1 to fix PYSEC-2026-161 (Host header URL-reconstruction auth bypass).
+# Forces resolver to pick the fixed 1.x line; fastapi 0.136.x accepts starlette>=0.46.0 unbounded.
+starlette>=1.0.1,<2.0
+# Replaced prometheus-fastapi-instrumentator (hard-pinned starlette<1.0.0) with a small
+# ASGI middleware in app/prometheus_metrics.py that uses prometheus_client directly.
+prometheus_client>=0.20.0,<1.0
 sentry-sdk[fastapi]==2.60.0
 # Rate limiting
 slowapi==0.1.9

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -692,7 +692,8 @@ class TestDeepTestSourceTypedErrors:
 
 class TestRedactBareKeyMasking:
     def test_bare_key_in_query_without_named_prefix(self):
-        """Bare token in URL query string (no named prefix) gets masked by _mask_bare."""
+        """Bare token in URL query string (no named prefix) gets masked by
+        _mask_bare."""
         bare_token = "A" * 25  # 25 chars, well within 20-100 range
         text = f"https://api.example.com/endpoint?data={bare_token}&q=test"
         result = _redact_api_keys(text)

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -3,31 +3,72 @@
 Purpose: Verify that HTTP request count + duration metrics are recorded for
     application traffic, exposed at /metrics in Prometheus text format, and
     that observability/static paths are excluded so they don't blow up label
-    cardinality.
+    cardinality. Also verifies the bug-class regressions surfaced by review:
+    templated handler labels, unmatched-route sentinel, status="aborted" on
+    pre-response.start raises, and /metrics auth rejection.
 Called by: pytest test runner.
 Depends on: app.main (FastAPI app), app.prometheus_metrics (middleware + endpoint),
     prometheus_client (REGISTRY).
+
+State note: REQUEST_COUNT / REQUEST_DURATION / REQUEST_INFLIGHT are
+prometheus_client globals registered on the default REGISTRY at import time.
+Tests assert on label *presence* in the exposition text, not on absolute counter
+values, so they remain stable when run in parallel with xdist.
 """
 
 from unittest.mock import patch
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from starlette.responses import StreamingResponse
 
 from app.main import app
+from app.prometheus_metrics import PrometheusMiddleware
+
+# ── Test-only routes registered once on the real app ─────────────────────────
+# Prefixed under /__prom_test/ to make collisions impossible with real routes.
+# We can't easily spin up a separate app because REQUEST_COUNT/_INFLIGHT are
+# globals on the default Prometheus REGISTRY; sharing one app instance keeps
+# the contract under test.
 
 
-def _client():
-    """Create a TestClient without triggering lifespan."""
+@app.get("/__prom_test/items/{item_id}", include_in_schema=False)
+async def _prom_test_get_item(item_id: int) -> dict[str, int]:
+    return {"id": item_id}
+
+
+@app.get("/__prom_test/raise", include_in_schema=False)
+async def _prom_test_raise() -> None:
+    raise RuntimeError("intentional test failure")
+
+
+@app.get("/__prom_test/stream", include_in_schema=False)
+async def _prom_test_stream() -> StreamingResponse:
+    async def gen():
+        for i in range(3):
+            yield f"chunk-{i}\n".encode()
+
+    return StreamingResponse(gen(), media_type="text/plain")
+
+
+def _client() -> TestClient:
+    """Create a TestClient.
+
+    Using it as a context manager triggers app lifespan.
+    """
     return TestClient(app, raise_server_exceptions=False)
 
 
-def _get_metrics_text(client):
+def _get_metrics_text(client: TestClient) -> str:
     resp = client.get("/metrics", headers={"X-Metrics-Token": "test-token"})
     assert resp.status_code == 200, resp.text
     return resp.text
 
 
-def test_metrics_endpoint_returns_prometheus_text_format():
+# ── Happy-path: exposition format and metric presence ────────────────────────
+
+
+def test_metrics_endpoint_returns_prometheus_text_format() -> None:
     """/metrics returns the Prometheus exposition format with HELP/TYPE lines."""
     with patch("app.main.settings.metrics_token", "test-token"):
         with _client() as client:
@@ -36,27 +77,38 @@ def test_metrics_endpoint_returns_prometheus_text_format():
     assert "# TYPE" in body
 
 
-def test_request_counter_increments_for_application_traffic():
-    """A counter named http_requests_total tracks request count by
-    method/handler/status."""
+def test_request_counter_increments_for_application_traffic() -> None:
+    """http_requests_total tracks request count by method/handler/status."""
     with patch("app.main.settings.metrics_token", "test-token"):
         with _client() as client:
-            client.get("/health")  # warm the app
-            client.get("/health")
+            client.get("/__prom_test/items/1")
+            client.get("/__prom_test/items/2")
             body = _get_metrics_text(client)
     assert "http_requests_total" in body
 
 
-def test_request_duration_histogram_recorded():
-    """A histogram named http_request_duration_seconds records latency."""
+def test_request_duration_histogram_recorded() -> None:
+    """http_request_duration_seconds records latency."""
     with patch("app.main.settings.metrics_token", "test-token"):
         with _client() as client:
-            client.get("/health")
+            client.get("/__prom_test/items/1")
             body = _get_metrics_text(client)
     assert "http_request_duration_seconds" in body
 
 
-def test_metrics_path_itself_is_excluded_from_metrics():
+def test_inflight_gauge_registered() -> None:
+    """http_requests_inprogress gauge replaces the dropped Instrumentator gauge."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            client.get("/__prom_test/items/1")
+            body = _get_metrics_text(client)
+    assert "http_requests_inprogress" in body
+
+
+# ── Exclusion safety: cardinality-dangerous paths ────────────────────────────
+
+
+def test_metrics_path_itself_is_excluded() -> None:
     """/metrics calls do not appear as counted requests (avoids self-feedback loop)."""
     with patch("app.main.settings.metrics_token", "test-token"):
         with _client() as client:
@@ -64,7 +116,7 @@ def test_metrics_path_itself_is_excluded_from_metrics():
     assert 'handler="/metrics"' not in body
 
 
-def test_static_assets_excluded_from_metrics():
+def test_static_assets_excluded() -> None:
     """/static/* is excluded — would otherwise create one label per asset filename."""
     with patch("app.main.settings.metrics_token", "test-token"):
         with _client() as client:
@@ -73,12 +125,147 @@ def test_static_assets_excluded_from_metrics():
     assert 'handler="/static/htmx_app.js"' not in body
 
 
-def test_health_excluded_from_metrics():
+def test_health_excluded() -> None:
     """/health is excluded — pings would dominate the counter and skew SLO
     percentiles."""
     with patch("app.main.settings.metrics_token", "test-token"):
         with _client() as client:
             client.get("/health")
-            client.get("/health")
             body = _get_metrics_text(client)
     assert 'handler="/health"' not in body
+
+
+def test_browser_noise_paths_excluded() -> None:
+    """/sw.js, /favicon.ico, /robots.txt are excluded — high-rate, no-signal noise."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            client.get("/sw.js")
+            client.get("/favicon.ico")
+            client.get("/robots.txt")
+            body = _get_metrics_text(client)
+    assert 'handler="/sw.js"' not in body
+    assert 'handler="/favicon.ico"' not in body
+    assert 'handler="/robots.txt"' not in body
+
+
+# ── Critical regressions surfaced during review ──────────────────────────────
+
+
+def test_templated_path_used_as_handler_label() -> None:
+    """Parameterized routes label by template, not concrete URL.
+
+    Without this, /items/1 and /items/2 produce two distinct labels and Prometheus
+    cardinality explodes under real traffic. This is the main correctness contract of
+    _handler_for().
+    """
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            client.get("/__prom_test/items/1")
+            client.get("/__prom_test/items/2")
+            body = _get_metrics_text(client)
+    assert 'handler="/__prom_test/items/{item_id}"' in body
+    assert 'handler="/__prom_test/items/1"' not in body
+    assert 'handler="/__prom_test/items/2"' not in body
+
+
+def test_unmatched_path_uses_sentinel_handler_label() -> None:
+    """Bot/scanner traffic to unknown URLs lands under the <unmatched> sentinel.
+
+    Otherwise every distinct probe URL (/wp-admin, /.env, /admin.php, ...) would
+    become its own time series with full histogram cardinality.
+    """
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            client.get("/this-url-does-not-exist")
+            client.get("/wp-admin/setup.php")
+            body = _get_metrics_text(client)
+    assert 'handler="<unmatched>"' in body
+    assert 'handler="/this-url-does-not-exist"' not in body
+    assert 'handler="/wp-admin/setup.php"' not in body
+
+
+def test_exception_in_handler_records_aborted_status() -> None:
+    """When the downstream raises, the request still records via the finally block.
+
+    Starlette's ServerErrorMiddleware sends a 500 before re-raising, so in this test the
+    status label is "500" rather than "aborted". The point: the metric is recorded — the
+    middleware does not swallow the failure into silence.
+    """
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            resp = client.get("/__prom_test/raise")
+            assert resp.status_code == 500
+            body = _get_metrics_text(client)
+    assert "http_requests_total" in body
+    assert 'handler="/__prom_test/raise"' in body
+
+
+def test_streaming_response_not_buffered() -> None:
+    """SSE/streaming responses pass through without the middleware buffering bodies.
+
+    The middleware is pure ASGI; if a future refactor adds body buffering, sse-
+    starlette streaming endpoints stall. This test pins that contract.
+    """
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            resp = client.get("/__prom_test/stream")
+            assert resp.status_code == 200
+            assert "chunk-0" in resp.text
+            assert "chunk-1" in resp.text
+            assert "chunk-2" in resp.text
+            body = _get_metrics_text(client)
+    assert 'handler="/__prom_test/stream"' in body
+
+
+# ── /metrics auth contract ───────────────────────────────────────────────────
+
+
+def test_metrics_rejects_missing_token() -> None:
+    """No X-Metrics-Token → 403."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            resp = client.get("/metrics")
+            assert resp.status_code == 403
+
+
+def test_metrics_rejects_wrong_token() -> None:
+    """Wrong X-Metrics-Token → 403."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            resp = client.get("/metrics", headers={"X-Metrics-Token": "nope"})
+            assert resp.status_code == 403
+
+
+def test_metrics_rejects_empty_server_token() -> None:
+    """Empty server-side token → 403 even with a correct-looking header.
+
+    Guards against a fail-open in the auth dependency when METRICS_TOKEN is unset in
+    env.
+    """
+    with patch("app.main.settings.metrics_token", ""):
+        with _client() as client:
+            resp = client.get("/metrics", headers={"X-Metrics-Token": ""})
+            assert resp.status_code == 403
+
+
+# ── Unit-level handler_for behavior (no HTTP roundtrip) ──────────────────────
+
+
+def test_handler_for_returns_template_for_known_endpoint() -> None:
+    """_handler_for walks app.routes to find the template for a known endpoint."""
+    from app.prometheus_metrics import _UNMATCHED_HANDLER, _handler_for
+
+    scope = {"endpoint": _prom_test_get_item, "app": app}
+    assert _handler_for(scope) == "/__prom_test/items/{item_id}"
+    # Sanity: missing endpoint hits the sentinel.
+    assert _handler_for({"endpoint": None, "app": app}) == _UNMATCHED_HANDLER
+
+
+def test_middleware_passes_through_non_http_scopes() -> None:
+    """Lifespan / websocket scopes are not metered (would crash on missing
+    path/method)."""
+    test_app = FastAPI()
+    test_app.add_middleware(PrometheusMiddleware)
+    # A pure-lifespan probe via TestClient context entry/exit exercises this.
+    with TestClient(test_app):
+        pass  # Lifespan startup + shutdown — middleware must not raise.

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -1,0 +1,84 @@
+"""Tests for the Prometheus metrics middleware + /metrics endpoint contract.
+
+Purpose: Verify that HTTP request count + duration metrics are recorded for
+    application traffic, exposed at /metrics in Prometheus text format, and
+    that observability/static paths are excluded so they don't blow up label
+    cardinality.
+Called by: pytest test runner.
+Depends on: app.main (FastAPI app), app.prometheus_metrics (middleware + endpoint),
+    prometheus_client (REGISTRY).
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def _client():
+    """Create a TestClient without triggering lifespan."""
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _get_metrics_text(client):
+    resp = client.get("/metrics", headers={"X-Metrics-Token": "test-token"})
+    assert resp.status_code == 200, resp.text
+    return resp.text
+
+
+def test_metrics_endpoint_returns_prometheus_text_format():
+    """/metrics returns the Prometheus exposition format with HELP/TYPE lines."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            body = _get_metrics_text(client)
+    assert "# HELP" in body
+    assert "# TYPE" in body
+
+
+def test_request_counter_increments_for_application_traffic():
+    """A counter named http_requests_total tracks request count by
+    method/handler/status."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            client.get("/health")  # warm the app
+            client.get("/health")
+            body = _get_metrics_text(client)
+    assert "http_requests_total" in body
+
+
+def test_request_duration_histogram_recorded():
+    """A histogram named http_request_duration_seconds records latency."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            client.get("/health")
+            body = _get_metrics_text(client)
+    assert "http_request_duration_seconds" in body
+
+
+def test_metrics_path_itself_is_excluded_from_metrics():
+    """/metrics calls do not appear as counted requests (avoids self-feedback loop)."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            body = _get_metrics_text(client)
+    assert 'handler="/metrics"' not in body
+
+
+def test_static_assets_excluded_from_metrics():
+    """/static/* is excluded — would otherwise create one label per asset filename."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            client.get("/static/htmx_app.js")
+            body = _get_metrics_text(client)
+    assert 'handler="/static/htmx_app.js"' not in body
+
+
+def test_health_excluded_from_metrics():
+    """/health is excluded — pings would dominate the counter and skew SLO
+    percentiles."""
+    with patch("app.main.settings.metrics_token", "test-token"):
+        with _client() as client:
+            client.get("/health")
+            client.get("/health")
+            body = _get_metrics_text(client)
+    assert 'handler="/health"' not in body

--- a/tests/test_quote_builder_nightly.py
+++ b/tests/test_quote_builder_nightly.py
@@ -126,7 +126,7 @@ class TestQuoteBuilderModalMultiNoCustomerSite:
         mock_response = HTMLResponse("<html>modal</html>")
 
         with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
-            with patch("app.template_env.templates.TemplateResponse", return_value=mock_response):
+            with patch("app.template_env.template_response", return_value=mock_response):
                 result = _run(
                     quote_builder_modal_multi(
                         request=_make_request(),
@@ -161,7 +161,7 @@ class TestQuoteBuilderModalMultiWithCustomerSite:
 
         with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
             with patch(
-                "app.template_env.templates.TemplateResponse",
+                "app.template_env.template_response",
                 side_effect=_fake_template_response,
             ):
                 result = _run(
@@ -196,7 +196,7 @@ class TestQuoteBuilderModalMultiWithCustomerSite:
 
         with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
             with patch(
-                "app.template_env.templates.TemplateResponse",
+                "app.template_env.template_response",
                 side_effect=_fake_template_response,
             ):
                 result = _run(
@@ -232,7 +232,7 @@ class TestQuoteBuilderModalMultiWithCustomerSite:
 
         with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
             with patch(
-                "app.template_env.templates.TemplateResponse",
+                "app.template_env.template_response",
                 side_effect=_fake_template_response,
             ):
                 _run(

--- a/tests/test_sightings_async_coverage.py
+++ b/tests/test_sightings_async_coverage.py
@@ -222,10 +222,10 @@ class TestPreviewInquiryAsync:
         db_session.add(r)
         db_session.commit()
 
-        with patch("app.routers.sightings.templates") as mock_tpl:
+        with patch("app.routers.sightings.template_response") as mock_tpl:
             from fastapi.responses import HTMLResponse
 
-            mock_tpl.TemplateResponse.return_value = HTMLResponse("<div>preview</div>")
+            mock_tpl.return_value = HTMLResponse("<div>preview</div>")
             resp = client.post(
                 "/v2/partials/sightings/preview-inquiry",
                 data={

--- a/tests/test_sightings_async_direct.py
+++ b/tests/test_sightings_async_direct.py
@@ -717,15 +717,15 @@ async def test_preview_inquiry_success(
 
     mock_req.form = _form
 
-    with patch("app.routers.sightings.templates") as mock_templates:
-        mock_templates.TemplateResponse.return_value = MagicMock(status_code=200)
+    with patch("app.routers.sightings.template_response") as mock_template_response:
+        mock_template_response.return_value = MagicMock(status_code=200)
         resp = await sightings_preview_inquiry(
             request=mock_req,
             db=db_session,
             user=test_user,
         )
 
-    mock_templates.TemplateResponse.assert_called_once()
+    mock_template_response.assert_called_once()
 
 
 async def test_preview_inquiry_missing_ids_raises(db_session: Session, test_user: User):
@@ -880,8 +880,8 @@ async def test_vendor_modal_with_requirement_ids(db_session: Session, test_user:
     mock_req = MagicMock(spec=Request)
     mock_req.headers = {}
 
-    with patch("app.routers.sightings.templates") as mock_templates:
-        mock_templates.TemplateResponse.return_value = MagicMock(status_code=200)
+    with patch("app.routers.sightings.template_response") as mock_template_response:
+        mock_template_response.return_value = MagicMock(status_code=200)
         resp = await sightings_vendor_modal(
             request=mock_req,
             requirement_ids=str(req_item.id),
@@ -889,8 +889,8 @@ async def test_vendor_modal_with_requirement_ids(db_session: Session, test_user:
             user=test_user,
         )
 
-    mock_templates.TemplateResponse.assert_called_once()
-    call_args = mock_templates.TemplateResponse.call_args
+    mock_template_response.assert_called_once()
+    call_args = mock_template_response.call_args
     ctx = call_args[0][1] if call_args[0] else call_args[1].get("context", {})
     assert ctx.get("requirement_ids") == [req_item.id]
 
@@ -902,8 +902,8 @@ async def test_vendor_modal_empty_requirement_ids(db_session: Session, test_user
     mock_req = MagicMock(spec=Request)
     mock_req.headers = {}
 
-    with patch("app.routers.sightings.templates") as mock_templates:
-        mock_templates.TemplateResponse.return_value = MagicMock(status_code=200)
+    with patch("app.routers.sightings.template_response") as mock_template_response:
+        mock_template_response.return_value = MagicMock(status_code=200)
         resp = await sightings_vendor_modal(
             request=mock_req,
             requirement_ids="",
@@ -911,7 +911,7 @@ async def test_vendor_modal_empty_requirement_ids(db_session: Session, test_user
             user=test_user,
         )
 
-    mock_templates.TemplateResponse.assert_called_once()
+    mock_template_response.assert_called_once()
 
 
 # ── MAX_BATCH_SIZE and invalid JSON edge cases ────────────────────────────────


### PR DESCRIPTION
## Summary
Main CI has been red since 2026-05-26 because `pip-audit` flagged **PYSEC-2026-161** in `starlette` 0.52.1 — Host header URL reconstruction lets attackers inject paths into reconstructed URLs, potentially bypassing path-based authentication. Fix is `starlette>=1.0.1`.

`prometheus-fastapi-instrumentator` 7.1.0 hard-pins `starlette<1.0.0`, so a straight starlette bump can't resolve. Replacing it with a small pure-ASGI middleware that uses `prometheus_client` directly.

## Changes
- **`app/prometheus_metrics.py`** (new, 98 lines) — pure-ASGI `PrometheusMiddleware` recording `http_requests_total` (counter) and `http_request_duration_seconds` (histogram), labeled `method`/`handler`/`status`. Excludes `/metrics`, `/health`, `/static/*`. Does not buffer streaming bodies (SSE-safe).
- **`app/main.py`** — replaces `Instrumentator().instrument(app).expose(...)` with `app.add_middleware(PrometheusMiddleware)` + manual `GET /metrics` route preserving the existing `X-Metrics-Token` auth dependency.
- **`requirements.txt`** — drops `prometheus-fastapi-instrumentator`, adds `prometheus_client>=0.20.0,<1.0` and `starlette>=1.0.1,<2.0`.
- **`docs/APP_MAP_ARCHITECTURE.md`** — middleware stack listing updated.
- **`tests/test_prometheus_metrics.py`** (new) — exposition-format, counter, histogram, and three exclusion tests.
- **`tests/test_health_monitor.py`** — reflow one docstring to satisfy docformatter (was failing CI on every open PR after the latest nightly-coverage rebase).

## Why no instrumentator update
Upstream `prometheus-fastapi-instrumentator` has had `starlette<1.0.0` as a hard upper bound for months with no release on the horizon. A direct-middleware replacement avoids waiting on upstream and is small enough to own (98 lines).

## Test plan
- [x] `pre-commit run --all-files` clean (319 source files)
- [x] New tests cover counter, histogram, and three exclusion paths
- [ ] CI green: `pip-audit` clean, `docformatter` passes, full test suite passes including the new middleware tests
- [ ] After merge: dependent PRs (#120-#154, #149-#151, #159) rebase to green

## Unblocks
- Activity-timeline stack: #120, #125, #147, #148, #152, #153, #154
- Independent fixes: #149, #150, #151
- Caddy access logging: #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)