### PR TITLE
fix(tasks): mark_task_done + reopen_task enforce assignee-only

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -9739,14 +9739,18 @@ async def reopen_task(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Reopen a completed task."""
-    task = db.get(RequisitionTask, task_id)
-    if not task:
+    """Reopen a completed task.
+
+    Only the assignee may reopen the task.
+    """
+    try:
+        task = task_service.reopen_task(db, task_id, user.id)
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    if task is None:
         raise HTTPException(404, "Task not found")
 
-    task.status = TaskStatus.TODO
-    task.completed_at = None
-    db.commit()
     logger.info("Task {} reopened by {}", task_id, user.email)
 
     req_id = task.requirement_id

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -64,6 +64,7 @@ from ..models.prospect_account import ProspectAccount
 from ..models.vendor_sighting_summary import VendorSightingSummary
 from ..models.vendors import VendorContact
 from ..scoring import classify_lead, explain_lead, score_unified
+from ..services import task_service
 from ..services.activity_service import log_activity as _log_activity
 from ..services.commodity_registry import COMMODITY_TREE, get_display_name
 from ..services.faceted_search_service import (
@@ -9708,24 +9709,18 @@ async def mark_task_done(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Mark a task as done."""
+    """Mark a task as done.
 
-    task = db.get(RequisitionTask, task_id)
-    if not task:
+    Only the assignee may complete the task.
+    """
+    try:
+        task = task_service.complete_task(db, task_id, user.id)
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    if task is None:
         raise HTTPException(404, "Task not found")
 
-    task.status = TaskStatus.DONE
-    task.completed_at = datetime.now(timezone.utc)
-    _log_activity(
-        db,
-        activity_type=ActivityType.TASK_COMPLETED,
-        requisition_id=task.requisition_id,
-        requirement_id=task.requirement_id,
-        user_id=user.id,
-        description=f"Task completed: {task.title}",
-        details={"task_id": task.id},
-    )
-    db.commit()
     logger.info("Task {} marked done by {}", task_id, user.email)
 
     # Return refreshed comms tab for the requirement
@@ -9734,8 +9729,6 @@ async def mark_task_done(
         return await part_tab_comms(req_id, request, user, db)
 
     # Fallback — return just the updated task row
-    ctx = _base_ctx(request, user, "requisitions")
-    ctx["task"] = task
     return HTMLResponse('<div class="text-sm text-green-600">Task completed</div>')
 
 

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -180,7 +180,7 @@ def complete_task(
     db: Session,
     task_id: int,
     user_id: int,
-    completion_note: str,
+    completion_note: str = "",
 ) -> RequisitionTask | None:
     """Complete a task. Only the assignee can complete it.
 

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -210,6 +210,29 @@ def complete_task(
     return task
 
 
+def reopen_task(
+    db: Session,
+    task_id: int,
+    user_id: int,
+) -> RequisitionTask | None:
+    """Reopen a completed task. Only the assignee can reopen it.
+
+    Returns the updated task, or None if not found. Raises PermissionError if the caller
+    is not the assignee.
+    """
+    task = db.query(RequisitionTask).filter(RequisitionTask.id == task_id).first()
+    if not task:
+        return None
+    if task.assigned_to_id != user_id:
+        raise PermissionError("Only the assignee can reopen this task")
+    task.status = TaskStatus.TODO
+    task.completed_at = None
+    db.commit()
+    db.refresh(task)
+    logger.info("Task {} reopened by user {}", task_id, user_id)
+    return task
+
+
 def get_waiting_on_tasks(db: Session, user_id: int) -> list[RequisitionTask]:
     """Get tasks created by the user but assigned to someone else (not done)."""
     return (

--- a/tests/test_htmx_views_nightly12.py
+++ b/tests/test_htmx_views_nightly12.py
@@ -59,6 +59,7 @@ def _make_task(
         title="Test Task",
         status="todo",
         created_by=user.id,
+        assigned_to_id=user.id,
         source="manual",
         created_at=datetime.now(timezone.utc),
     )

--- a/tests/test_htmx_views_nightly2.py
+++ b/tests/test_htmx_views_nightly2.py
@@ -18,7 +18,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.constants import RequisitionStatus, SourcingStatus, TaskStatus, TicketSource
+from app.constants import RequisitionStatus, SourcingStatus, TaskStatus, TicketSource, UserRole
 from app.models import (
     Company,
     Requirement,
@@ -575,6 +575,7 @@ class TestPartTasks:
             requirement_id=item.id,
             title="Test task",
             created_by=test_user.id,
+            assigned_to_id=test_user.id,
             status=TaskStatus.TODO,
             source="manual",
         )
@@ -605,6 +606,38 @@ class TestPartTasks:
     def test_mark_task_done_not_found(self, client, db_session: Session):
         resp = client.post("/v2/partials/parts/tasks/999999/done")
         assert resp.status_code == 404
+
+    def test_mark_task_done_rejects_non_assignee(self, client, db_session: Session, test_user: User):
+        """A user who is not the assignee must not be able to complete the task."""
+        other = User(
+            email="other-assignee@example.com",
+            password_hash="x",
+            role=UserRole.SALES,
+            is_active=True,
+        )
+        db_session.add(other)
+        db_session.flush()
+
+        req = _req(db_session, test_user)
+        item = _requirement(db_session, req)
+        db_session.flush()
+        task = RequisitionTask(
+            requisition_id=req.id,
+            requirement_id=item.id,
+            title="Other's task",
+            created_by=other.id,
+            assigned_to_id=other.id,
+            status=TaskStatus.TODO,
+            source="manual",
+        )
+        db_session.add(task)
+        db_session.commit()
+
+        resp = client.post(f"/v2/partials/parts/tasks/{task.id}/done")
+        assert resp.status_code == 403
+
+        db_session.refresh(task)
+        assert task.status == TaskStatus.TODO, "Task must not have transitioned"
 
 
 # ── Archive System ────────────────────────────────────────────────────

--- a/tests/test_htmx_views_nightly2.py
+++ b/tests/test_htmx_views_nightly2.py
@@ -594,6 +594,7 @@ class TestPartTasks:
             requirement_id=item.id,
             title="Done task",
             created_by=test_user.id,
+            assigned_to_id=test_user.id,
             status=TaskStatus.DONE,
             source="manual",
         )
@@ -602,6 +603,38 @@ class TestPartTasks:
 
         resp = client.post(f"/v2/partials/parts/tasks/{task.id}/reopen")
         assert resp.status_code == 200
+
+    def test_reopen_task_rejects_non_assignee(self, client, db_session: Session, test_user: User):
+        """A user who is not the assignee must not be able to reopen the task."""
+        other = User(
+            email="other-reopen@example.com",
+            password_hash="x",
+            role=UserRole.SALES,
+            is_active=True,
+        )
+        db_session.add(other)
+        db_session.flush()
+
+        req = _req(db_session, test_user)
+        item = _requirement(db_session, req)
+        db_session.flush()
+        task = RequisitionTask(
+            requisition_id=req.id,
+            requirement_id=item.id,
+            title="Other's done task",
+            created_by=other.id,
+            assigned_to_id=other.id,
+            status=TaskStatus.DONE,
+            source="manual",
+        )
+        db_session.add(task)
+        db_session.commit()
+
+        resp = client.post(f"/v2/partials/parts/tasks/{task.id}/reopen")
+        assert resp.status_code == 403
+
+        db_session.refresh(task)
+        assert task.status == TaskStatus.DONE, "Task must not have transitioned back to TODO"
 
     def test_mark_task_done_not_found(self, client, db_session: Session):
         resp = client.post("/v2/partials/parts/tasks/999999/done")


### PR DESCRIPTION
## Summary
Closes the assignee-only auth gap on **both** task state-mutation HTMX routes:

- `mark_task_done` (`/v2/partials/parts/tasks/{id}/done`) — flagged in #147.
- `reopen_task` (`/v2/partials/parts/tasks/{id}/reopen`) — discovered during code review of this PR (symmetric bug, identical fix).

Both routes were inlining `task.status` mutations without checking that the caller is the assignee, so any authenticated user could complete or reopen any task.

## Changes
- `task_service.complete_task`: `completion_note` made optional (default `""`). Verified zero non-test callers.
- `task_service.reopen_task`: new function, mirrors `complete_task` (query → assignee check → mutate → commit → refresh → return).
- Both HTMX handlers refactored to delegate to the service; `PermissionError` → HTTP 403.
- Tests: added `test_mark_task_done_rejects_non_assignee` and `test_reopen_task_rejects_non_assignee`; updated existing happy-path tests to set `assigned_to_id`.

## Behavior change to note
Tasks with `assigned_to_id IS NULL` are now uncompletable / unreopenable until assigned. Before this PR they could be mutated by any user. Single-user staging means the practical impact is negligible, but flagging for completeness.

## Bundled
`tests/test_health_monitor.py` 1-line docformatter rewrap — pre-existing drift on `main` that the `all-files-on-push` pre-commit hook forces into every PR until merged. Same pattern as #159.

## Test plan
- [x] `test_mark_task_done` passes (assignee path).
- [x] `test_mark_task_done_rejects_non_assignee` → 403, status unchanged.
- [x] `test_mark_task_done_not_found` → 404.
- [x] `test_reopen_task` passes (assignee path).
- [x] `test_reopen_task_rejects_non_assignee` → 403, status unchanged.
- [x] `pytest tests/test_htmx_views_nightly2.py` all green (83 tests).
- [x] `pre-commit run` clean.
- [ ] After deploy: smoke-test as non-assignee in app.availai.net — both buttons return visible failure.