### PR TITLE
refactor(requisitions): bulk archive/assign use UPDATE...RETURNING

### DIFF
--- a/app/routers/requisitions/core.py
+++ b/app/routers/requisitions/core.py
@@ -604,11 +604,11 @@ async def bulk_archive(user: User = Depends(require_admin), db: Session = Depend
                 ]
             ),
         )
-        .values(status="archived")
+        .values(status=RequisitionStatus.ARCHIVED)
         .returning(Requisition.id)
-        .execution_options(synchronize_session="fetch")
+        .execution_options(synchronize_session=False)
     )
-    archived_ids = [row[0] for row in db.execute(stmt).all()]
+    archived_ids = list(db.execute(stmt).scalars().all())
     for rid in archived_ids:
         log_activity(
             db,
@@ -649,11 +649,11 @@ async def batch_archive_by_ids(
     stmt = (
         update(Requisition)
         .where(*conditions)
-        .values(status="archived")
+        .values(status=RequisitionStatus.ARCHIVED)
         .returning(Requisition.id)
-        .execution_options(synchronize_session="fetch")
+        .execution_options(synchronize_session=False)
     )
-    archived_ids = [row[0] for row in db.execute(stmt).all()]
+    archived_ids = list(db.execute(stmt).scalars().all())
     for rid in archived_ids:
         log_activity(
             db,
@@ -688,9 +688,9 @@ async def batch_assign(
         .where(Requisition.id.in_(payload.ids))
         .values(claimed_by_id=payload.owner_id)
         .returning(Requisition.id)
-        .execution_options(synchronize_session="fetch")
+        .execution_options(synchronize_session=False)
     )
-    assigned_ids = [row[0] for row in db.execute(stmt).all()]
+    assigned_ids = list(db.execute(stmt).scalars().all())
     for rid in assigned_ids:
         log_activity(
             db,


### PR DESCRIPTION
## Summary

- Replaces query-then-update Python loop in `bulk_archive` / `batch_archive_by_ids` / `batch_assign` with a single `update(Requisition).returning(Requisition.id)` statement. Surfaces the affected IDs in the response (`archived_ids` / `assigned_ids`) alongside the existing counts so callers can reconcile against their requested IDs.
- Includes 92-line test coverage in `tests/test_requisitions_core_coverage.py` asserting the new contract by **set equality** (order-independent), plus boundary cases (already-archived, SALES-role narrowing, 404 on missing target user).
- Applies `pr-review-toolkit` no-brainers in a follow-up commit: `RequisitionStatus.ARCHIVED` instead of raw `"archived"` (CLAUDE.md StrEnum rule), `synchronize_session=False` instead of `"fetch"` (correct idiom for fire-and-forget bulk updates — eliminates an unnecessary post-UPDATE SELECT on Postgres), and `.scalars().all()` instead of `[row[0] for row in .all()]` (cleaner typed result, no `Any` leak).

## Commits

- `9e51f700` — `refactor(requisitions): bulk archive/assign use UPDATE...RETURNING`
- `b60affc7` — `refactor(requisitions): apply pr-review no-brainers on bulk archive/assign`

## Test plan

- [x] `pytest tests/test_requisitions_core_coverage.py` — 46 passed
- [x] Full suite (`TESTING=1 PYTHONPATH=/root/availai pytest tests/ --ignore=tests/e2e/`) — 13918 passed, 0 failed, 29 skipped, 1 xfailed
- [x] `ruff check`, `ruff format --check`, `pip-audit` — all clean
- [x] `pre-commit run --all-files` — all hooks pass
- [x] `pr-review-toolkit` fan-out (6 agents): code-reviewer, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, feature-dev:code-reviewer — no Critical findings; applied no-brainers in `b60affc7`

## Review punch-list intentionally deferred (worth tracking)

- Loguru info logs on bulk ops — when payload IDs get auth-filtered to zero, support can't answer "why didn't my action work" without a DB query. RETURNING gives the IDs free.
- Pydantic `response_model=` for the three endpoints to encode `count == len(ids)` as a typed invariant.
- Move SQL into `app/services/requisition_service.py` per CLAUDE.md "routers thin" rule.
- Atomicity-claim wording in `9e51f700`'s body slightly overstated the race-fix (old `Query.update()` did the UPDATE atomically server-side; the real win is the exposed IDs).
- `tests/test_health_monitor.py` (+2/-1) inside `9e51f700` was unrelated docstring rewrap drift — flag if reviewer wants it split out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)