### PR TITLE
feat(db): migration for OEM spec code resolver

### DIFF
--- a/alembic/versions/9868c839df65_add_oem_spec_code_resolver.py
+++ b/alembic/versions/9868c839df65_add_oem_spec_code_resolver.py
@@ -1,0 +1,144 @@
+"""add_oem_spec_code_resolver.
+
+Adds tables for the IBM spec code resolver (approved, pending,
+blacklist) and lineage columns on requirements/sightings/offers.
+
+Revision ID: 9868c839df65
+Revises: 084_description
+Create Date: 2026-05-27 21:25:21.937771
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "9868c839df65"
+down_revision = "084_description"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "oem_spec_codes",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("oem", sa.String(64), nullable=False),
+        sa.Column("spec_code", sa.String(64), nullable=False),
+        sa.Column("avl", postgresql.JSONB, nullable=False),
+        sa.Column("source", sa.String(32), nullable=False),
+        sa.Column(
+            "approved_by_user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("approved_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("oem", "spec_code", name="uq_oem_spec_code"),
+    )
+    op.create_index("ix_oem_spec_codes_oem", "oem_spec_codes", ["oem"])
+    op.create_index("ix_oem_spec_codes_spec_code", "oem_spec_codes", ["spec_code"])
+
+    op.create_table(
+        "oem_spec_codes_pending",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("oem", sa.String(64), nullable=False),
+        sa.Column("spec_code", sa.String(64), nullable=False),
+        sa.Column("proposed_avl", postgresql.JSONB, nullable=False),
+        sa.Column("llm_confidence", sa.Float, nullable=False),
+        sa.Column("citations", postgresql.JSONB, nullable=False, server_default="[]"),
+        sa.Column(
+            "discovered_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "first_requirement_id",
+            sa.Integer,
+            sa.ForeignKey("requirements.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "used_in_requirement_ids",
+            postgresql.JSONB,
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.UniqueConstraint("oem", "spec_code", name="uq_pending_oem_spec_code"),
+    )
+    op.create_index("ix_oem_spec_codes_pending_oem", "oem_spec_codes_pending", ["oem"])
+    op.create_index(
+        "ix_oem_spec_codes_pending_spec_code",
+        "oem_spec_codes_pending",
+        ["spec_code"],
+    )
+
+    op.create_table(
+        "oem_spec_codes_blacklist",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("oem", sa.String(64), nullable=False),
+        sa.Column("spec_code", sa.String(64), nullable=False),
+        sa.Column("rejected_mpns", postgresql.JSONB, nullable=False),
+        sa.Column(
+            "rejected_by_user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "rejected_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("reason", sa.Text, nullable=True),
+    )
+    op.create_index("ix_oem_spec_codes_blacklist_oem", "oem_spec_codes_blacklist", ["oem"])
+
+    # Lineage columns — all nullable, no schema break for existing rows
+    op.add_column(
+        "requirements",
+        sa.Column("oem_hint", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "sightings",
+        sa.Column("resolved_via_spec_code", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "sightings",
+        sa.Column("source_mpn", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "offers",
+        sa.Column("resolved_via_spec_code", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "offers",
+        sa.Column("source_mpn", sa.String(255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("offers", "source_mpn")
+    op.drop_column("offers", "resolved_via_spec_code")
+    op.drop_column("sightings", "source_mpn")
+    op.drop_column("sightings", "resolved_via_spec_code")
+    op.drop_column("requirements", "oem_hint")
+
+    op.drop_index("ix_oem_spec_codes_blacklist_oem", table_name="oem_spec_codes_blacklist")
+    op.drop_table("oem_spec_codes_blacklist")
+
+    op.drop_index("ix_oem_spec_codes_pending_spec_code", table_name="oem_spec_codes_pending")
+    op.drop_index("ix_oem_spec_codes_pending_oem", table_name="oem_spec_codes_pending")
+    op.drop_table("oem_spec_codes_pending")
+
+    op.drop_index("ix_oem_spec_codes_spec_code", table_name="oem_spec_codes")
+    op.drop_index("ix_oem_spec_codes_oem", table_name="oem_spec_codes")
+    op.drop_table("oem_spec_codes")


### PR DESCRIPTION
## Summary

Adds the schema for the IBM Spec Code Resolver feature per spec §4. Migration only — no model wiring (that comes in the next stacked PR).

**New tables:**
- `oem_spec_codes` — authoritative OEM → approved AVL list (human-approved only). `(oem, spec_code)` unique, indexed on both columns, FK to `users.id ON DELETE SET NULL`.
- `oem_spec_codes_pending` — LLM-discovered mappings awaiting human approval. Same uniqueness/indexes; FK to `requirements.id ON DELETE SET NULL`. JSONB defaults on `citations` and `used_in_requirement_ids`.
- `oem_spec_codes_blacklist` — rejected mappings, fed back to the LLM as exclusions. No uniqueness (each row is one rejection event). Indexed on `oem`. FK to `users.id ON DELETE SET NULL`.

**Lineage columns (all nullable, no backfill):**
- `requirements.oem_hint VARCHAR(64)`
- `sightings.resolved_via_spec_code VARCHAR(64)`, `sightings.source_mpn VARCHAR(255)`
- `offers.resolved_via_spec_code VARCHAR(64)`, `offers.source_mpn VARCHAR(255)`

All JSONB columns use `postgresql.JSONB` per spec; no autogenerate (models don't exist yet — they come in PR 2).

Stacked on PR #167.

## Verification

Upgrade/downgrade/upgrade cycle run against an isolated PostgreSQL 16 instance:

- `alembic upgrade head` — applies the full chain through `9868c839df65` cleanly.
- `alembic downgrade -1` — drops all 3 tables and 5 lineage columns.
- `alembic upgrade head` — re-applies cleanly.
- `alembic heads` — single head: `9868c839df65`.

Table/column/index/FK shapes verified via `\d` introspection on Postgres after upgrade. Static migration tests (`tests/test_alembic.py`) — 8 passed, 1 xfail expected.

Pre-commit ran clean (ruff, ruff-format, docformatter, mypy, all-files hook).

## Test plan

- [ ] CI alembic upgrade/downgrade smoke test passes against Postgres 16
- [ ] CI static migration tests pass
- [ ] CI mypy / ruff pass
- [ ] PR #167 (`docs/ibm-spec-code-resolver-design`) lands first, then this rebases onto `main`