### PR TITLE
feat(models): models and schemas for OEM spec code resolver

### DIFF
--- a/app/models/offers.py
+++ b/app/models/offers.py
@@ -64,6 +64,11 @@ class Offer(Base):
     promoted_by_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"))
     promoted_at = Column(DateTime)
 
+    # Spec-code resolver lineage — populated when this offer was sourced
+    # against an AVL MPN resolved from an OEM spec code (see SpecCodeResolver).
+    resolved_via_spec_code = Column(String(64), nullable=True)
+    source_mpn = Column(String(255), nullable=True)
+
     excess_line_item_id = Column(Integer, ForeignKey("excess_line_items.id", ondelete="SET NULL"))
 
     notes = Column(Text)

--- a/app/models/sourcing.py
+++ b/app/models/sourcing.py
@@ -16,7 +16,9 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, validates
 
 from ..database import UTCDateTime
@@ -115,6 +117,7 @@ class Requirement(Base):
     package_type = Column(String(100))  # Physical package (QFP, BGA, SOIC, DIP, etc.)
     revision = Column(String(100))  # Part revision / version level
     customer_pn = Column(String(255))  # Customer's internal part number
+    oem_hint = Column(String(64), nullable=True)  # which OEM's spec-code vocabulary applies; null → "IBM"
     need_by_date = Column(Date)  # When customer needs the parts
     sale_notes = Column(Text)
     sourcing_status = Column(String(20), default="open")  # open | sourcing | offered | quoted | won | lost
@@ -215,6 +218,11 @@ class Sighting(Base):
     # Multi-factor score breakdown (JSON: {trust, price, qty, freshness, completeness})
     score_components = Column(JSON)
 
+    # Spec-code resolver lineage — populated when this sighting was sourced
+    # against an AVL MPN resolved from an OEM spec code (see SpecCodeResolver).
+    resolved_via_spec_code = Column(String(64), nullable=True)
+    source_mpn = Column(String(255), nullable=True)
+
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     requirement = relationship("Requirement", back_populates="sightings")
@@ -303,3 +311,77 @@ class RequirementAttachment(Base):
 
     requirement = relationship("Requirement", back_populates="attachments")
     uploaded_by = relationship("User", foreign_keys=[uploaded_by_id])
+
+
+class OemSpecCode(Base):
+    """Authoritative OEM spec code → approved MPN list.
+
+    Only human-approved mappings live here. LLM proposals start in
+    OemSpecCodePending and get promoted on approval.
+
+    Called by: app/services/spec_code_resolver.py
+    Depends on: User (foreign key)
+    """
+
+    __tablename__ = "oem_spec_codes"
+
+    id = Column(Integer, primary_key=True)
+    oem = Column(String(64), nullable=False, index=True)
+    spec_code = Column(String(64), nullable=False, index=True)
+    avl = Column(JSONB, nullable=False)
+    source = Column(String(32), nullable=False)
+    approved_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    approved_at = Column(UTCDateTime, nullable=False)
+    created_at = Column(UTCDateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (UniqueConstraint("oem", "spec_code", name="uq_oem_spec_code"),)
+
+
+class OemSpecCodePending(Base):
+    """LLM-discovered mappings awaiting human approval.
+
+    Speculatively used for sourcing while pending; promoted to OemSpecCode on
+    approve; deleted on reject (with rejected MPNs copied into
+    OemSpecCodeBlacklist).
+
+    Called by: app/services/spec_code_resolver.py,
+               app/routers/admin/spec_codes.py
+    Depends on: Requirement (foreign key)
+    """
+
+    __tablename__ = "oem_spec_codes_pending"
+
+    id = Column(Integer, primary_key=True)
+    oem = Column(String(64), nullable=False, index=True)
+    spec_code = Column(String(64), nullable=False, index=True)
+    proposed_avl = Column(JSONB, nullable=False)
+    llm_confidence = Column(Float, nullable=False)
+    citations = Column(JSONB, nullable=False, default=list)
+    discovered_at = Column(UTCDateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    first_requirement_id = Column(Integer, ForeignKey("requirements.id", ondelete="SET NULL"), nullable=True)
+    used_in_requirement_ids = Column(JSONB, nullable=False, default=list)
+
+    __table_args__ = (UniqueConstraint("oem", "spec_code", name="uq_pending_oem_spec_code"),)
+
+
+class OemSpecCodeBlacklist(Base):
+    """Rejected mappings — the resolver passes these to the LLM as an exclusion list so
+    the same wrong MPNs aren't proposed again.
+
+    Multiple rows per (oem, spec_code) are allowed; each row represents one
+    rejection event with its own reason.
+
+    Called by: app/services/spec_code_resolver.py,
+               app/routers/admin/spec_codes.py
+    Depends on: User (foreign key)
+    """
+
+    __tablename__ = "oem_spec_codes_blacklist"
+
+    id = Column(Integer, primary_key=True)
+    oem = Column(String(64), nullable=False, index=True)
+    spec_code = Column(String(64), nullable=False)
+    rejected_mpns = Column(JSONB, nullable=False)
+    rejected_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    rejected_at = Column(UTCDateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    reason = Column(Text, nullable=True)

--- a/app/models/sourcing.py
+++ b/app/models/sourcing.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    func,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship, validates
@@ -150,7 +151,7 @@ class Requirement(Base):
             raise ValueError("priority_score must be 0-100")
         return value
 
-    @validates("primary_mpn", "customer_pn", "oem_pn")
+    @validates("primary_mpn", "customer_pn", "oem_pn", "oem_hint")
     def _uppercase_mpn_fields(self, _key, value):
         return value.upper().strip() if value else value
 
@@ -332,9 +333,20 @@ class OemSpecCode(Base):
     source = Column(String(32), nullable=False)
     approved_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     approved_at = Column(UTCDateTime, nullable=False)
-    created_at = Column(UTCDateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    created_at = Column(
+        UTCDateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
 
     __table_args__ = (UniqueConstraint("oem", "spec_code", name="uq_oem_spec_code"),)
+
+    @validates("oem", "spec_code")
+    def _uppercase_identity(self, _key, value):
+        if value is None:
+            return None
+        return value.upper().strip()
 
 
 class OemSpecCodePending(Base):
@@ -356,12 +368,23 @@ class OemSpecCodePending(Base):
     spec_code = Column(String(64), nullable=False, index=True)
     proposed_avl = Column(JSONB, nullable=False)
     llm_confidence = Column(Float, nullable=False)
-    citations = Column(JSONB, nullable=False, default=list)
-    discovered_at = Column(UTCDateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    citations = Column(JSONB, nullable=False, default=list, server_default="[]")
+    discovered_at = Column(
+        UTCDateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
     first_requirement_id = Column(Integer, ForeignKey("requirements.id", ondelete="SET NULL"), nullable=True)
-    used_in_requirement_ids = Column(JSONB, nullable=False, default=list)
+    used_in_requirement_ids = Column(JSONB, nullable=False, default=list, server_default="[]")
 
     __table_args__ = (UniqueConstraint("oem", "spec_code", name="uq_pending_oem_spec_code"),)
+
+    @validates("oem", "spec_code")
+    def _uppercase_identity(self, _key, value):
+        if value is None:
+            return None
+        return value.upper().strip()
 
 
 class OemSpecCodeBlacklist(Base):
@@ -383,5 +406,16 @@ class OemSpecCodeBlacklist(Base):
     spec_code = Column(String(64), nullable=False)
     rejected_mpns = Column(JSONB, nullable=False)
     rejected_by_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
-    rejected_at = Column(UTCDateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    rejected_at = Column(
+        UTCDateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
     reason = Column(Text, nullable=True)
+
+    @validates("oem", "spec_code")
+    def _uppercase_identity(self, _key, value):
+        if value is None:
+            return None
+        return value.upper().strip()

--- a/app/schemas/spec_codes.py
+++ b/app/schemas/spec_codes.py
@@ -1,0 +1,61 @@
+"""Pydantic schemas for the OEM spec code resolver.
+
+Used by: app/services/spec_code_resolver.py (LLM response validation),
+         app/routers/admin/spec_codes.py (admin action payloads)
+Depends on: pydantic v2
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AvlEntry(BaseModel):
+    """One row of an Approved Vendor List — a single MPN with rank and notes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mpn: str = Field(..., min_length=1, max_length=255)
+    manufacturer: str = Field(..., min_length=1, max_length=255)
+    rank: int = Field(..., ge=1)
+    notes: str | None = Field(default=None, max_length=1000)
+
+
+class ResolverLlmResponse(BaseModel):
+    """Strict schema for what the LLM must return when resolving a spec code."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    avl: list[AvlEntry]
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    citations: list[dict] = Field(default_factory=list)
+    reasoning: str = Field(default="")
+
+
+class ApproveActionBody(BaseModel):
+    """Admin approve-pending action; edited_avl=None means approve as-is."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    edited_avl: list[AvlEntry] | None = None
+
+
+class RejectActionBody(BaseModel):
+    """Admin reject-pending action; empty rejected_mpns means reject all proposed."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reason: str = Field(..., min_length=1, max_length=1000)
+    rejected_mpns: list[str] = Field(default_factory=list)
+
+
+class ReResolveActionBody(BaseModel):
+    """Admin re-resolve action; no body fields — presence of the POST is enough."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+ResolverStatus = Literal["approved", "pending", "unresolved"]
+ResolverSource = Literal["table", "llm", "none"]

--- a/tests/test_oem_spec_code_models.py
+++ b/tests/test_oem_spec_code_models.py
@@ -1,0 +1,175 @@
+"""Model invariants for the IBM spec code resolver tables.
+
+Called by: pytest collection
+Depends on: app.models.sourcing (OemSpecCode, OemSpecCodePending, OemSpecCodeBlacklist,
+            Requirement, Requisition), app.models.offers (Offer), app.schemas.spec_codes,
+            tests.conftest (db_session fixture)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.sourcing import (
+    OemSpecCode,
+    OemSpecCodeBlacklist,
+    OemSpecCodePending,
+    Requirement,
+    Requisition,
+)
+
+
+def _new_requisition(db) -> Requisition:
+    req_set = Requisition(name="test")
+    db.add(req_set)
+    db.commit()
+    db.refresh(req_set)
+    return req_set
+
+
+def test_oem_spec_code_unique_constraint(db_session):
+    db_session.add(
+        OemSpecCode(
+            oem="IBM",
+            spec_code="SPREJ",
+            avl=[{"mpn": "X", "manufacturer": "M", "rank": 1, "notes": None}],
+            source="manual",
+            approved_at=datetime.now(timezone.utc),
+        )
+    )
+    db_session.commit()
+
+    db_session.add(
+        OemSpecCode(
+            oem="IBM",
+            spec_code="SPREJ",
+            avl=[{"mpn": "Y", "manufacturer": "M", "rank": 1, "notes": None}],
+            source="manual",
+            approved_at=datetime.now(timezone.utc),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+
+
+def test_oem_spec_code_pending_unique_constraint(db_session):
+    db_session.add(
+        OemSpecCodePending(
+            oem="IBM",
+            spec_code="SPREJ",
+            proposed_avl=[{"mpn": "X", "manufacturer": "M", "rank": 1, "notes": None}],
+            llm_confidence=0.8,
+        )
+    )
+    db_session.commit()
+
+    db_session.add(
+        OemSpecCodePending(
+            oem="IBM",
+            spec_code="SPREJ",
+            proposed_avl=[{"mpn": "Y", "manufacturer": "M", "rank": 1, "notes": None}],
+            llm_confidence=0.6,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+
+
+def test_blacklist_no_unique_constraint(db_session):
+    """Multiple blacklist entries for the same spec code are allowed (each entry
+    represents one rejection event)."""
+    for mpn in ["A", "B"]:
+        db_session.add(
+            OemSpecCodeBlacklist(
+                oem="IBM",
+                spec_code="SPREJ",
+                rejected_mpns=[mpn],
+                reason="incorrect",
+            )
+        )
+    db_session.commit()
+    rows = db_session.query(OemSpecCodeBlacklist).filter_by(spec_code="SPREJ").all()
+    assert len(rows) == 2
+
+
+def test_requirement_oem_hint_defaults_to_none(db_session):
+    rset = _new_requisition(db_session)
+    req = Requirement(requisition_id=rset.id, primary_mpn="ABC123", manufacturer="TI")
+    db_session.add(req)
+    db_session.commit()
+    db_session.refresh(req)
+    assert req.oem_hint is None
+
+
+def test_sighting_lineage_columns_nullable(db_session):
+    from app.models.sourcing import Requirement, Sighting
+
+    rset = _new_requisition(db_session)
+    req = Requirement(requisition_id=rset.id, primary_mpn="ABC123", manufacturer="TI")
+    db_session.add(req)
+    db_session.commit()
+
+    s = Sighting(
+        requirement_id=req.id,
+        vendor_name="Mouser",
+        manufacturer="TI",
+        normalized_mpn="ABC123",
+        # lineage columns left null
+    )
+    db_session.add(s)
+    db_session.commit()
+    db_session.refresh(s)
+    assert s.resolved_via_spec_code is None
+    assert s.source_mpn is None
+
+
+def test_sighting_lineage_columns_populated(db_session):
+    from app.models.sourcing import Requirement, Sighting
+
+    rset = _new_requisition(db_session)
+    req = Requirement(requisition_id=rset.id, primary_mpn="SPREJ", manufacturer="")
+    db_session.add(req)
+    db_session.commit()
+
+    s = Sighting(
+        requirement_id=req.id,
+        vendor_name="Broker",
+        manufacturer="Murata",
+        normalized_mpn="GRM188R71H103KA01D",
+        resolved_via_spec_code="SPREJ",
+        source_mpn="GRM188R71H103KA01D",
+    )
+    db_session.add(s)
+    db_session.commit()
+    db_session.refresh(s)
+    assert s.resolved_via_spec_code == "SPREJ"
+    assert s.source_mpn == "GRM188R71H103KA01D"
+
+
+def test_resolver_llm_response_rejects_extra_fields():
+    from pydantic import ValidationError
+
+    from app.schemas.spec_codes import ResolverLlmResponse
+
+    with pytest.raises(ValidationError):
+        ResolverLlmResponse.model_validate(
+            {
+                "avl": [],
+                "confidence": 0.0,
+                "citations": [],
+                "reasoning": "",
+                "extra_field": "should fail",
+            }
+        )
+
+
+def test_resolver_llm_response_rejects_invalid_confidence():
+    from pydantic import ValidationError
+
+    from app.schemas.spec_codes import ResolverLlmResponse
+
+    with pytest.raises(ValidationError):
+        ResolverLlmResponse.model_validate({"avl": [], "confidence": 1.5, "citations": [], "reasoning": ""})

--- a/tests/test_oem_spec_code_models.py
+++ b/tests/test_oem_spec_code_models.py
@@ -173,3 +173,77 @@ def test_resolver_llm_response_rejects_invalid_confidence():
 
     with pytest.raises(ValidationError):
         ResolverLlmResponse.model_validate({"avl": [], "confidence": 1.5, "citations": [], "reasoning": ""})
+
+
+def test_oem_spec_code_normalizes_oem_and_spec_code_case(db_session):
+    """Unique constraint must be enforced regardless of input casing/whitespace."""
+    db_session.add(
+        OemSpecCode(
+            oem="ibm",
+            spec_code="sprej ",
+            avl=[{"mpn": "X", "manufacturer": "M", "rank": 1, "notes": None}],
+            source="manual",
+            approved_at=datetime.now(timezone.utc),
+        )
+    )
+    db_session.commit()
+    row = db_session.query(OemSpecCode).one()
+    assert row.oem == "IBM"
+    assert row.spec_code == "SPREJ"
+
+    # Second insert with different casing must collide on the unique constraint
+    db_session.add(
+        OemSpecCode(
+            oem="IBM",
+            spec_code="SPREJ",
+            avl=[{"mpn": "Y", "manufacturer": "M", "rank": 1, "notes": None}],
+            source="manual",
+            approved_at=datetime.now(timezone.utc),
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+
+
+def test_pending_normalizes_oem_and_spec_code_case(db_session):
+    db_session.add(
+        OemSpecCodePending(
+            oem="ibm",
+            spec_code=" sprej",
+            proposed_avl=[{"mpn": "X", "manufacturer": "M", "rank": 1, "notes": None}],
+            llm_confidence=0.7,
+        )
+    )
+    db_session.commit()
+    row = db_session.query(OemSpecCodePending).one()
+    assert row.oem == "IBM"
+    assert row.spec_code == "SPREJ"
+
+
+def test_blacklist_normalizes_oem_and_spec_code_case(db_session):
+    db_session.add(
+        OemSpecCodeBlacklist(
+            oem="ibm",
+            spec_code="sprej",
+            rejected_mpns=["X"],
+            reason="test",
+        )
+    )
+    db_session.commit()
+    row = db_session.query(OemSpecCodeBlacklist).one()
+    assert row.oem == "IBM"
+    assert row.spec_code == "SPREJ"
+
+
+def test_requirement_oem_hint_normalizes_case(db_session):
+    rset = _new_requisition(db_session)
+    req = Requirement(
+        requisition_id=rset.id,
+        primary_mpn="ABC123",
+        manufacturer="TI",
+        oem_hint=" ibm ",
+    )
+    db_session.add(req)
+    db_session.commit()
+    db_session.refresh(req)
+    assert req.oem_hint == "IBM"


### PR DESCRIPTION
## Summary

Adds models matching the migration in PR #170 + Pydantic schemas for resolver IO and admin actions. Per spec §4 and §5.1. Stacked on #170.

### Models (`app/models/sourcing.py`)
- `OemSpecCode` — authoritative OEM spec code → AVL mapping (human-approved only)
- `OemSpecCodePending` — LLM-discovered mappings awaiting human approval
- `OemSpecCodeBlacklist` — rejected mappings, fed back into LLM prompts as an exclusion list
- `Requirement.oem_hint` — optional column for multi-OEM future-proofing (null → "IBM" default)
- `Sighting.resolved_via_spec_code` / `Sighting.source_mpn` — lineage columns

### Models (`app/models/offers.py`)
- `Offer.resolved_via_spec_code` / `Offer.source_mpn` — lineage columns

### Schemas (`app/schemas/spec_codes.py`)
- Pydantic v2 strict schemas: `AvlEntry`, `ResolverLlmResponse`, `ApproveActionBody`, `RejectActionBody`, `ReResolveActionBody`
- `ResolverStatus` / `ResolverSource` literal types
- All schemas use `ConfigDict(extra="forbid")` to reject malformed LLM output

## Test plan

- [x] 8 model + schema invariant tests in `tests/test_oem_spec_code_models.py`, all passing locally:
  - `oem_spec_codes` unique constraint on (oem, spec_code)
  - `oem_spec_codes_pending` unique constraint on (oem, spec_code)
  - `oem_spec_codes_blacklist` allows multiple rows per (oem, spec_code)
  - `Requirement.oem_hint` defaults to null
  - `Sighting` lineage columns nullable + populatable
  - `ResolverLlmResponse` rejects extra fields
  - `ResolverLlmResponse` rejects out-of-range confidence
- [x] `ruff check`, `ruff format`, `docformatter`, `mypy` all clean
- [x] No new alembic migrations (all schema captured in PR #170)