### PR TITLE
feat(services): SpecCodeResolver service

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -100,6 +100,15 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     anthropic_model: str = "claude-sonnet-4-6"
 
+    # --- OEM Spec Code Resolver ---
+    # Feature flag; resolver only fires when enabled. Min confidence is the
+    # absolute floor (post web-search penalty) below which results are dropped
+    # rather than written to oem_spec_codes_pending. Model is the Claude model
+    # ID used for the grounded web-search call.
+    spec_resolver_enabled: bool = False
+    spec_resolver_min_confidence: float = 0.3
+    spec_resolver_model: str = "claude-opus-4-7"
+
     # --- Agent service-to-service auth ---
     agent_api_key: str = ""
 

--- a/app/config.py
+++ b/app/config.py
@@ -103,11 +103,12 @@ class Settings(BaseSettings):
     # --- OEM Spec Code Resolver ---
     # Feature flag; resolver only fires when enabled. Min confidence is the
     # absolute floor (post web-search penalty) below which results are dropped
-    # rather than written to oem_spec_codes_pending. Model is the Claude model
-    # ID used for the grounded web-search call.
+    # rather than written to oem_spec_codes_pending. Model tier selects which
+    # claude_client.MODELS entry the resolver routes through — "opus" is the
+    # default for hallucination-resistance on a low-volume grounded call.
     spec_resolver_enabled: bool = False
     spec_resolver_min_confidence: float = 0.3
-    spec_resolver_model: str = "claude-opus-4-7"
+    spec_resolver_model_tier: str = "opus"
 
     # --- Agent service-to-service auth ---
     agent_api_key: str = ""

--- a/app/services/spec_code_resolver.py
+++ b/app/services/spec_code_resolver.py
@@ -1,0 +1,275 @@
+"""SpecCodeResolver — translate OEM spec codes (e.g. IBM SPREJ) to approved MPNs.
+
+Called by: app/search_service.py:search_requirement() when the synchronous
+    connector fanout returns zero sightings (wired in a later PR).
+
+Depends on: app/models/sourcing.py (OemSpecCode, OemSpecCodePending,
+    OemSpecCodeBlacklist), app/utils/claude_client.claude_json, and
+    app/schemas/spec_codes (ResolverLlmResponse).
+
+The resolver is read-mostly: it short-circuits at any cached layer before
+issuing an LLM call. When it does call the LLM, it writes a row to
+``oem_spec_codes_pending``; that row is consumed by the admin UI for human
+approval before being promoted to ``oem_spec_codes``.
+
+Resolution order (from spec §5):
+    1. ``OemSpecCode`` hit                  -> ``approved`` / ``source="table"``
+    2. ``OemSpecCodePending`` hit           -> ``pending``  / ``source="llm"``
+    3. Load ``OemSpecCodeBlacklist`` rejected_mpns as LLM exclusion set
+    4. Call Claude (web_search grounded), validate against ``ResolverLlmResponse``
+    5. Apply confidence floor + no-citations penalty
+    6. Persist ``OemSpecCodePending`` row (idempotent under UNIQUE collisions)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from loguru import logger
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.sourcing import (
+    OemSpecCode,
+    OemSpecCodeBlacklist,
+    OemSpecCodePending,
+)
+from app.schemas.spec_codes import ResolverLlmResponse, ResolverSource, ResolverStatus
+
+
+@dataclass
+class ResolverResult:
+    """Outcome of a single ``resolve()`` call.
+
+    Attributes:
+        status: ``approved`` (table hit), ``pending`` (LLM proposal in queue),
+            or ``unresolved`` (no usable mapping).
+        avl: Approved Vendor List entries; empty when unresolved.
+        confidence: 1.0 for table hits, LLM-rated for pending, 0.0 unresolved.
+        citations: Grounding citations from the LLM web-search call; empty for
+            table hits.
+        source: ``table``, ``llm``, or ``none``.
+    """
+
+    status: ResolverStatus
+    avl: list[dict] = field(default_factory=list)
+    confidence: float = 0.0
+    citations: list[dict] = field(default_factory=list)
+    source: ResolverSource = "none"
+
+
+_SYSTEM_PROMPT = """You are a parts-engineering expert with deep knowledge of IBM,
+Cisco, HP, and Dell internal spec codes for electronic components. Given an OEM
+spec code, return the Approved Vendor List (AVL) — the set of manufacturer part
+numbers approved by that OEM for parts matching the spec.
+
+Return STRICT JSON matching this schema:
+{
+  "avl": [{"mpn": "<MPN>", "manufacturer": "<Name>", "rank": <int>, "notes": "<str|null>"}],
+  "confidence": <float 0..1>,
+  "citations": [{"url": "<url>", "snippet": "<short verbatim quote>"}],
+  "reasoning": "<one-paragraph explanation>"
+}
+
+Rules:
+- If you are not reasonably confident, return {"avl": [], "confidence": 0.0, ...}.
+- Lower `rank` = higher preference (1 is primary AVL).
+- Use web_search to ground your answer in IBM redbooks, datasheets, or broker catalogs.
+- NEVER propose an MPN from the user-provided blacklist.
+- Do NOT include any field other than the four above. Extra fields cause rejection.
+"""
+
+
+def _build_user_prompt(spec_code: str, oem: str, blacklist_mpns: list[str]) -> str:
+    """Assemble the per-request user prompt for the LLM."""
+    return (
+        f"OEM: {oem}\n"
+        f"Spec code: {spec_code}\n"
+        f"Blacklisted MPNs (do NOT propose): {json.dumps(blacklist_mpns)}\n"
+        f"Return the AVL as strict JSON per the system prompt."
+    )
+
+
+async def _default_claude_call(
+    *,
+    system: str,
+    user: str,
+    tools: list[dict],
+    max_tokens: int,
+) -> dict | list | None:
+    """Default LLM adapter — bridges the resolver's keyword call shape to
+    ``claude_json``'s positional ``prompt`` parameter.
+
+    Kept module-level (rather than nested in ``__init__``) so it stays
+    importable for tests that want to assert on the wrapper itself, and so the
+    constructor remains free of imports at instance-construction time.
+    """
+    from app.utils.claude_client import claude_json
+
+    return await claude_json(
+        user,
+        system=system,
+        model_tier="smart",
+        max_tokens=max_tokens,
+        tools=tools,
+        timeout=60,
+    )
+
+
+class SpecCodeResolver:
+    """Resolution pipeline: table → pending → blacklist → LLM → pending row.
+
+    The class is a thin coordinator; all state lives in the DB. Construct one
+    per request — it holds a reference to the caller's ``Session``.
+    """
+
+    def __init__(
+        self,
+        db: Session,
+        claude_call: Callable[..., Any] | None = None,
+    ) -> None:
+        self._db = db
+        # Dependency-injected for tests; defaults to the project's claude_json
+        # via a thin adapter that normalizes keyword args.
+        self._claude_call = claude_call if claude_call is not None else _default_claude_call
+
+    async def resolve(self, spec_code: str, oem: str = "IBM") -> ResolverResult:
+        """Resolve a single (oem, spec_code) pair to an AVL.
+
+        Normalizes input (strip + uppercase), walks the table → pending → LLM ladder,
+        and writes a pending row on a fresh LLM-derived hit.
+        """
+        norm_code = (spec_code or "").strip().upper()
+        norm_oem = (oem or "IBM").strip().upper()
+        if not norm_code:
+            return ResolverResult(status="unresolved")
+
+        # 1. Authoritative table
+        approved = self._db.query(OemSpecCode).filter_by(oem=norm_oem, spec_code=norm_code).one_or_none()
+        if approved is not None:
+            return ResolverResult(
+                status="approved",
+                avl=list(approved.avl or []),
+                confidence=1.0,
+                source="table",
+            )
+
+        # 2. Pending — reuse prior LLM result
+        pending = self._db.query(OemSpecCodePending).filter_by(oem=norm_oem, spec_code=norm_code).one_or_none()
+        if pending is not None:
+            return ResolverResult(
+                status="pending",
+                avl=list(pending.proposed_avl or []),
+                confidence=pending.llm_confidence,
+                citations=list(pending.citations or []),
+                source="llm",
+            )
+
+        # 3. Blacklist — accumulated rejected MPNs feed into the LLM prompt
+        blacklist_mpns = self._load_blacklist(norm_oem, norm_code)
+
+        # 4. LLM call (validated against ResolverLlmResponse)
+        llm_result = await self._call_llm(norm_code, norm_oem, blacklist_mpns)
+        if llm_result is None:
+            return ResolverResult(status="unresolved")
+
+        # 5. Confidence floor — apply no-citations penalty first, then compare
+        adjusted_confidence = llm_result.confidence
+        if not llm_result.citations:
+            adjusted_confidence *= 0.7
+        if adjusted_confidence < settings.spec_resolver_min_confidence or not llm_result.avl:
+            logger.info(
+                "spec_resolver: below floor or empty avl; oem={} code={} conf={}",
+                norm_oem,
+                norm_code,
+                adjusted_confidence,
+            )
+            return ResolverResult(status="unresolved")
+
+        # 6. Persist pending row (idempotent under concurrency)
+        avl_payload = [entry.model_dump() for entry in llm_result.avl]
+        row = OemSpecCodePending(
+            oem=norm_oem,
+            spec_code=norm_code,
+            proposed_avl=avl_payload,
+            llm_confidence=adjusted_confidence,
+            citations=list(llm_result.citations),
+        )
+        self._db.add(row)
+        try:
+            self._db.commit()
+        except IntegrityError:
+            # Concurrent resolver wrote first; re-read the winning row.
+            self._db.rollback()
+            winner = self._db.query(OemSpecCodePending).filter_by(oem=norm_oem, spec_code=norm_code).one()
+            logger.info(
+                "spec_resolver: lost insert race; reusing winner row id={}",
+                winner.id,
+            )
+            return ResolverResult(
+                status="pending",
+                avl=list(winner.proposed_avl or []),
+                confidence=winner.llm_confidence,
+                citations=list(winner.citations or []),
+                source="llm",
+            )
+
+        return ResolverResult(
+            status="pending",
+            avl=avl_payload,
+            confidence=adjusted_confidence,
+            citations=list(llm_result.citations),
+            source="llm",
+        )
+
+    def _load_blacklist(self, oem: str, spec_code: str) -> list[str]:
+        """Flatten every rejected MPN for this (oem, spec_code) pair."""
+        rows = self._db.query(OemSpecCodeBlacklist).filter_by(oem=oem, spec_code=spec_code).all()
+        flat: list[str] = []
+        for r in rows:
+            flat.extend(r.rejected_mpns or [])
+        return flat
+
+    async def _call_llm(
+        self,
+        spec_code: str,
+        oem: str,
+        blacklist_mpns: list[str],
+    ) -> ResolverLlmResponse | None:
+        """Call the LLM, validate the response against ``ResolverLlmResponse``.
+
+        Returns ``None`` on any failure (network error, ``None`` response,
+        schema violation) — the caller treats that as ``unresolved``.
+        """
+        try:
+            raw = await self._claude_call(
+                system=_SYSTEM_PROMPT,
+                user=_build_user_prompt(spec_code, oem, blacklist_mpns),
+                tools=[{"type": "web_search_20250305", "name": "web_search", "max_uses": 6}],
+                max_tokens=2000,
+            )
+        except Exception:
+            logger.exception(
+                "spec_resolver: LLM call failed; oem={} code={}",
+                oem,
+                spec_code,
+            )
+            return None
+
+        if raw is None:
+            return None
+
+        try:
+            return ResolverLlmResponse.model_validate(raw)
+        except ValidationError:
+            logger.exception(
+                "spec_resolver: LLM response failed schema validation; oem={} code={} raw={}",
+                oem,
+                spec_code,
+                raw,
+            )
+            return None

--- a/app/services/spec_code_resolver.py
+++ b/app/services/spec_code_resolver.py
@@ -19,6 +19,14 @@ Resolution order (from spec §5):
     4. Call Claude (web_search grounded), validate against ``ResolverLlmResponse``
     5. Apply confidence floor + no-citations penalty
     6. Persist ``OemSpecCodePending`` row (idempotent under UNIQUE collisions)
+
+Note on the feature flag:
+    ``settings.spec_resolver_enabled`` is checked by CALLERS, not by this
+    service. The resolver itself will always run when called. This keeps
+    the service testable without flag plumbing; callers (e.g.
+    ``app/search_service.py``) are responsible for gating invocation. Do
+    not call this service in production code without first checking the
+    flag.
 """
 
 from __future__ import annotations
@@ -113,7 +121,7 @@ async def _default_claude_call(
     return await claude_json(
         user,
         system=system,
-        model_tier="smart",
+        model_tier=settings.spec_resolver_model_tier,
         max_tokens=max_tokens,
         tools=tools,
         timeout=60,
@@ -264,7 +272,7 @@ class SpecCodeResolver:
             return None
 
         try:
-            return ResolverLlmResponse.model_validate(raw)
+            llm_result = ResolverLlmResponse.model_validate(raw)
         except ValidationError:
             logger.exception(
                 "spec_resolver: LLM response failed schema validation; oem={} code={} raw={}",
@@ -273,3 +281,20 @@ class SpecCodeResolver:
                 raw,
             )
             return None
+
+        # Defense in depth: even though the system prompt instructs the LLM
+        # not to propose blacklisted MPNs, filter them out post-hoc in case
+        # the model leaks. Normalize case for the comparison.
+        blacklist_set = {m.upper().strip() for m in blacklist_mpns}
+        filtered_avl = [entry for entry in llm_result.avl if entry.mpn.upper().strip() not in blacklist_set]
+        if not filtered_avl:
+            logger.info(
+                "spec_resolver: LLM proposed only blacklisted MPNs; treating as unresolved; oem={} code={}",
+                oem,
+                spec_code,
+            )
+            return None  # caller's None check will route to unresolved
+
+        # Replace the AVL on the validated response so the rest of resolve()
+        # sees the filtered list.
+        return llm_result.model_copy(update={"avl": filtered_avl})

--- a/app/utils/claude_client.py
+++ b/app/utils/claude_client.py
@@ -42,6 +42,7 @@ API_VERSION = "2023-06-01"
 MODELS = {
     "fast": "claude-haiku-4-5-20251001",
     "smart": settings.anthropic_model or "claude-sonnet-4-6",
+    "opus": "claude-opus-4-7",
 }
 
 

--- a/tests/test_spec_code_resolver.py
+++ b/tests/test_spec_code_resolver.py
@@ -233,6 +233,95 @@ async def test_llm_schema_invalid_returns_unresolved(resolver):
 # ── Concurrent insert collision (Task 3.10) ──────────────────────────
 
 
+async def test_default_claude_call_uses_configured_model_tier(monkeypatch):
+    """Verify the resolver's default claude call routes through the configured model
+    tier, not a hardcoded one."""
+    from app.config import settings
+    from app.services import spec_code_resolver as resolver_module
+
+    monkeypatch.setattr(settings, "spec_resolver_model_tier", "opus")
+
+    captured: dict = {}
+
+    async def fake_claude_json(prompt, **kwargs):
+        captured.update(kwargs)
+        return None  # don't care about the return shape
+
+    # _default_claude_call lazy-imports claude_json from app.utils.claude_client,
+    # so patch it at the source module.
+    import app.utils.claude_client as claude_client_module
+
+    monkeypatch.setattr(claude_client_module, "claude_json", fake_claude_json)
+
+    await resolver_module._default_claude_call(system="sys", user="usr", tools=[], max_tokens=100)
+    assert captured["model_tier"] == "opus"
+
+
+# ── Blacklist leak filter (defense in depth) ─────────────────────────
+
+
+async def test_llm_proposing_blacklisted_mpn_is_filtered(resolver, db_session):
+    """Defense in depth: if LLM leaks a blacklisted MPN, the resolver
+    filters it before persisting."""
+    db_session.add(
+        OemSpecCodeBlacklist(
+            oem="IBM",
+            spec_code="SPREJ",
+            rejected_mpns=["BAD_MPN"],
+            reason="known bad",
+        )
+    )
+    db_session.commit()
+
+    async def fake_claude(**kwargs):
+        return {
+            "avl": [
+                {"mpn": "BAD_MPN", "manufacturer": "Bad", "rank": 1, "notes": None},
+                {"mpn": "GOOD_MPN", "manufacturer": "Good", "rank": 2, "notes": None},
+            ],
+            "confidence": 0.9,
+            "citations": [{"url": "https://example.com", "snippet": "..."}],
+            "reasoning": "ok",
+        }
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("SPREJ")
+
+    assert result.status == "pending"
+    mpns = [e["mpn"] for e in result.avl]
+    assert "BAD_MPN" not in mpns
+    assert "GOOD_MPN" in mpns
+
+
+async def test_llm_proposing_only_blacklisted_mpns_returns_unresolved(resolver, db_session):
+    db_session.add(
+        OemSpecCodeBlacklist(
+            oem="IBM",
+            spec_code="SPREJ",
+            rejected_mpns=["BAD_MPN_1", "BAD_MPN_2"],
+            reason="all bad",
+        )
+    )
+    db_session.commit()
+
+    async def fake_claude(**kwargs):
+        return {
+            "avl": [
+                {"mpn": "BAD_MPN_1", "manufacturer": "X", "rank": 1, "notes": None},
+                {"mpn": "BAD_MPN_2", "manufacturer": "Y", "rank": 2, "notes": None},
+            ],
+            "confidence": 0.95,
+            "citations": [{"url": "https://example.com", "snippet": "..."}],
+            "reasoning": "all blacklisted",
+        }
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("SPREJ")
+
+    assert result.status == "unresolved"
+    assert resolver._db.query(OemSpecCodePending).count() == 0
+
+
 async def test_concurrent_pending_insert_recovers_via_reread(resolver, db_session):
     """Simulate a second resolver running for the same spec code by inserting a pending
     row out-of-band right before the LLM commit.

--- a/tests/test_spec_code_resolver.py
+++ b/tests/test_spec_code_resolver.py
@@ -1,0 +1,269 @@
+"""Unit tests for the SpecCodeResolver service.
+
+Covers every branch of resolve(): table hit, pending hit, blacklist propagation, LLM
+empty AVL, confidence floor + web-search penalty, LLM failure modes, and concurrent-
+insert recovery via UNIQUE-constraint collision.
+
+Mocks the LLM call (claude_json) via the constructor's claude_call injection point. The
+DB session comes from the autouse db_session fixture in tests/conftest.py — the resolver
+and the test share the same session, which is what makes the concurrent-insert
+simulation work (committing a competing row in the same session still triggers the
+UNIQUE constraint at resolver-commit time).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.models.sourcing import (
+    OemSpecCode,
+    OemSpecCodeBlacklist,
+    OemSpecCodePending,
+)
+from app.services.spec_code_resolver import ResolverResult, SpecCodeResolver
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def resolver(db_session):
+    """Resolver bound to the test session; LLM is unset until a test wires it."""
+    return SpecCodeResolver(db_session, claude_call=AsyncMock())
+
+
+@pytest.fixture
+def approved_mapping(db_session):
+    row = OemSpecCode(
+        oem="IBM",
+        spec_code="SPREJ",
+        avl=[{"mpn": "GRM188R71H103KA01D", "manufacturer": "Murata", "rank": 1, "notes": None}],
+        source="manual",
+        approved_at=datetime.now(timezone.utc),
+    )
+    db_session.add(row)
+    db_session.commit()
+    return row
+
+
+@pytest.fixture
+def pending_mapping(db_session):
+    row = OemSpecCodePending(
+        oem="IBM",
+        spec_code="SPREJ",
+        proposed_avl=[{"mpn": "GRM188R71H103KA01D", "manufacturer": "Murata", "rank": 1, "notes": None}],
+        llm_confidence=0.7,
+        citations=[],
+    )
+    db_session.add(row)
+    db_session.commit()
+    return row
+
+
+# ── Table-hit branch (Task 3.4) ──────────────────────────────────────
+
+
+async def test_resolves_from_table_without_llm_call(resolver, approved_mapping):
+    claude_mock = AsyncMock()
+    resolver._claude_call = claude_mock
+
+    result = await resolver.resolve("SPREJ")
+
+    assert isinstance(result, ResolverResult)
+    assert result.status == "approved"
+    assert result.source == "table"
+    assert result.confidence == 1.0
+    assert result.avl[0]["mpn"] == "GRM188R71H103KA01D"
+    claude_mock.assert_not_called()
+
+
+async def test_normalizes_case_and_whitespace(resolver, approved_mapping):
+    result = await resolver.resolve("  sprej  ", oem="ibm")
+    assert result.status == "approved"
+
+
+# ── Pending-hit branch (Task 3.5) ────────────────────────────────────
+
+
+async def test_reuses_pending_row_without_llm_call(resolver, pending_mapping):
+    claude_mock = AsyncMock()
+    resolver._claude_call = claude_mock
+
+    result = await resolver.resolve("SPREJ")
+
+    assert result.status == "pending"
+    assert result.source == "llm"
+    assert result.confidence == 0.7
+    assert result.avl[0]["mpn"] == "GRM188R71H103KA01D"
+    claude_mock.assert_not_called()
+
+
+# ── Blacklist propagation (Task 3.6) ─────────────────────────────────
+
+
+async def test_blacklist_passes_into_llm_prompt(resolver, db_session):
+    db_session.add(
+        OemSpecCodeBlacklist(
+            oem="IBM",
+            spec_code="SPREJ",
+            rejected_mpns=["BAD_MPN_1", "BAD_MPN_2"],
+            reason="wrong package",
+        )
+    )
+    db_session.commit()
+
+    captured: dict = {}
+
+    async def fake_claude(**kwargs):
+        captured.update(kwargs)
+        return {
+            "avl": [{"mpn": "GOOD_MPN", "manufacturer": "Murata", "rank": 1, "notes": None}],
+            "confidence": 0.9,
+            "citations": [{"url": "https://example.com", "snippet": "..."}],
+            "reasoning": "ok",
+        }
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("SPREJ")
+
+    assert "BAD_MPN_1" in captured["user"]
+    assert "BAD_MPN_2" in captured["user"]
+    assert result.status == "pending"
+    assert result.source == "llm"
+    assert result.avl[0]["mpn"] == "GOOD_MPN"
+
+
+# ── LLM empty AVL → unresolved (Task 3.7) ────────────────────────────
+
+
+async def test_empty_avl_treated_as_unresolved(resolver):
+    async def fake_claude(**kwargs):
+        return {"avl": [], "confidence": 0.0, "citations": [], "reasoning": ""}
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("UNKNOWN")
+    assert result.status == "unresolved"
+
+    # And no pending row should have been written
+    assert resolver._db.query(OemSpecCodePending).count() == 0
+
+
+# ── Confidence floor + WebSearch penalty (Task 3.8) ──────────────────
+
+
+async def test_confidence_below_floor_unresolved(resolver):
+    async def fake_claude(**kwargs):
+        return {
+            "avl": [{"mpn": "X", "manufacturer": "M", "rank": 1, "notes": None}],
+            "confidence": 0.2,  # below default floor 0.3
+            "citations": [{"url": "https://example.com", "snippet": "..."}],
+            "reasoning": "low",
+        }
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("FOO")
+    assert result.status == "unresolved"
+
+
+async def test_no_citations_applies_penalty(resolver):
+    """Confidence 0.5 with no citations → 0.5 * 0.7 = 0.35 ≥ floor 0.3."""
+
+    async def fake_claude(**kwargs):
+        return {
+            "avl": [{"mpn": "X", "manufacturer": "M", "rank": 1, "notes": None}],
+            "confidence": 0.5,
+            "citations": [],
+            "reasoning": "no citations",
+        }
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("FOO")
+    assert result.status == "pending"
+    assert result.confidence == pytest.approx(0.35)
+
+
+async def test_no_citations_below_penalized_floor_unresolved(resolver):
+    """Confidence 0.4 with no citations → 0.4 * 0.7 = 0.28 < floor 0.3."""
+
+    async def fake_claude(**kwargs):
+        return {
+            "avl": [{"mpn": "X", "manufacturer": "M", "rank": 1, "notes": None}],
+            "confidence": 0.4,
+            "citations": [],
+            "reasoning": "no citations, just below penalized floor",
+        }
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("FOO")
+    assert result.status == "unresolved"
+
+
+# ── LLM failure modes (Task 3.9) ─────────────────────────────────────
+
+
+async def test_llm_exception_returns_unresolved(resolver):
+    async def fake_claude(**kwargs):
+        raise RuntimeError("api down")
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("FOO")
+    assert result.status == "unresolved"
+
+
+async def test_llm_none_returns_unresolved(resolver):
+    async def fake_claude(**kwargs):
+        return None
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("FOO")
+    assert result.status == "unresolved"
+
+
+async def test_llm_schema_invalid_returns_unresolved(resolver):
+    async def fake_claude(**kwargs):
+        return {"avl": "not a list", "confidence": 0.9}  # invalid
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("FOO")
+    assert result.status == "unresolved"
+
+
+# ── Concurrent insert collision (Task 3.10) ──────────────────────────
+
+
+async def test_concurrent_pending_insert_recovers_via_reread(resolver, db_session):
+    """Simulate a second resolver running for the same spec code by inserting a pending
+    row out-of-band right before the LLM commit.
+
+    The resolver and the test share `db_session`, but the UNIQUE constraint on
+    (oem, spec_code) fires at commit time regardless — the resolver's commit
+    raises IntegrityError, and it must recover by re-reading the winning row.
+    """
+
+    async def fake_claude(**kwargs):
+        # Sneak a competing row in just before the resolver commits its own
+        db_session.add(
+            OemSpecCodePending(
+                oem="IBM",
+                spec_code="FOO",
+                proposed_avl=[{"mpn": "WINNER", "manufacturer": "M", "rank": 1, "notes": None}],
+                llm_confidence=0.8,
+                citations=[],
+            )
+        )
+        db_session.commit()
+        return {
+            "avl": [{"mpn": "LOSER", "manufacturer": "M", "rank": 1, "notes": None}],
+            "confidence": 0.9,
+            "citations": [{"url": "https://example.com", "snippet": "..."}],
+            "reasoning": "would have lost",
+        }
+
+    resolver._claude_call = fake_claude
+    result = await resolver.resolve("FOO")
+
+    assert result.status == "pending"
+    assert result.source == "llm"
+    assert result.avl[0]["mpn"] == "WINNER"  # the resolver re-read the winning row


### PR DESCRIPTION
## Summary

PR 3 of the IBM Spec Code Resolver stack. Implements the resolver pipeline per [spec §5](docs/superpowers/specs/2026-05-27-ibm-spec-code-resolver-design.md):

```
table → pending → blacklist → LLM (Claude + web_search) → pending row
```

The resolver short-circuits at each cached layer before issuing an LLM call. On a fresh LLM-derived hit it writes a row to `oem_spec_codes_pending` for human approval. Idempotent under UNIQUE collisions — if a competing resolver wins the insert race, we recover via re-read.

Adds three settings (off by default):
- `spec_resolver_enabled: bool = False`
- `spec_resolver_min_confidence: float = 0.3`
- `spec_resolver_model: str = "claude-opus-4-7"`

Stacked on #171 (PR 2 — models). **Not wired into `search_service` yet** — that lands in PR 4.

## What's in

- `app/services/spec_code_resolver.py` — `SpecCodeResolver` class + `ResolverResult` dataclass, ~265 LOC.
- `app/config.py` — three new settings adjacent to `anthropic_model`.
- `tests/test_spec_code_resolver.py` — 12 unit tests, every branch covered.

## Test plan

- [x] `env TESTING=1 PYTHONPATH=. pytest tests/test_spec_code_resolver.py -v --override-ini="addopts="` → 12 PASSED
- [x] Pre-commit clean (ruff, ruff-format, docformatter, mypy)
- [x] Settings load: `False 0.3 claude-opus-4-7`

Test coverage:
1. Table-hit short-circuits LLM call
2. Case + whitespace normalization
3. Pending-hit reuses prior LLM result
4. Blacklist MPNs propagate into LLM prompt
5. Empty AVL → unresolved (no pending row written)
6. Confidence below floor → unresolved
7. No-citations × 0.7 penalty: 0.5 → 0.35 ≥ floor → pending
8. No-citations × 0.7 penalty: 0.4 → 0.28 < floor → unresolved
9. LLM exception → unresolved
10. LLM returns `None` → unresolved
11. LLM schema-invalid → unresolved
12. Concurrent insert collision → recover via re-read

## Divergences from plan

- **`claude_json` call shape:** the plan's example used `model=...` and `user=...` kwargs that don't exist in the real `app.utils.claude_client.claude_json` signature (which takes `prompt` positional + `system=`, `model_tier=`, `tools=`, `max_tokens=`, `timeout=`). I wrote a thin module-level adapter `_default_claude_call(system, user, tools, max_tokens)` that bridges the keyword-based call shape (which the tests verify against) to the real positional `claude_json(prompt, ...)`. The `spec_resolver_model` setting is stored but currently routes via `model_tier="smart"`; we can wire it through directly when/if `claude_json` grows a `model=` parameter.
- **Concurrent insert test:** the autouse `db_session` fixture is shared between the test and the resolver, but SQLite's UNIQUE constraint on `(oem, spec_code)` still fires at commit time even within the same session, so the simulated collision works without needing a second `SessionLocal()`. Kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)