### PR TITLE
fix(tasks): reopen_task writes TASK_REOPENED activity log

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -337,6 +337,7 @@ class ActivityType(StrEnum):
     SIGHTING_ADDED = "sighting_added"
     SALES_NOTE = "sales_note"
     TASK_COMPLETED = "task_completed"
+    TASK_REOPENED = "task_reopened"
     ASSIGNMENT_CHANGED = "assignment_changed"
     REQ_ARCHIVED = "req_archived"
     REQ_UNARCHIVED = "req_unarchived"

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -227,6 +227,15 @@ def reopen_task(
         raise PermissionError("Only the assignee can reopen this task")
     task.status = TaskStatus.TODO
     task.completed_at = None
+    log_activity(
+        db,
+        activity_type=ActivityType.TASK_REOPENED,
+        requisition_id=task.requisition_id,
+        requirement_id=task.requirement_id,
+        user_id=user_id,
+        description=f"Task reopened: {task.title}",
+        details={"task_id": task.id},
+    )
     db.commit()
     db.refresh(task)
     logger.info("Task {} reopened by user {}", task_id, user_id)

--- a/tests/test_lifecycle_activity_logging.py
+++ b/tests/test_lifecycle_activity_logging.py
@@ -159,6 +159,35 @@ def test_update_requirement_sales_note_logs(client, db_session, test_requisition
     assert len(rows) == 1
 
 
+def test_reopen_task_logs_task_reopened(db_session, test_requisition, test_user):
+    """Reopening a task writes a task_reopened activity row on its requisition."""
+    from app.constants import TaskStatus
+    from app.models import RequisitionTask
+    from app.services.task_service import reopen_task
+
+    task = RequisitionTask(
+        requisition_id=test_requisition.id,
+        title="Follow up with vendor",
+        created_by=test_user.id,
+        assigned_to_id=test_user.id,
+        status=TaskStatus.DONE,
+    )
+    db_session.add(task)
+    db_session.flush()
+
+    reopen_task(
+        db=db_session,
+        task_id=task.id,
+        user_id=test_user.id,
+    )
+    db_session.commit()
+
+    rows = _activity_rows(db_session, test_requisition.id, ActivityType.TASK_REOPENED)
+    assert len(rows) == 1
+    assert rows[0].user_id == test_user.id
+    assert rows[0].details["task_id"] == task.id
+
+
 def test_mark_task_done_logs_task_completed(client, db_session, test_requisition, test_user):
     """Marking a task done via the htmx route writes a task_completed row."""
     from app.models import RequisitionTask


### PR DESCRIPTION
## Summary
- `task_service.reopen_task` now writes a `TASK_REOPENED` row to `activity_log`, mirroring `complete_task`'s `TASK_COMPLETED` write.
- Closes a visible asymmetry that appeared after PR #162 routed both endpoints through the service layer: completing a task showed up in the activity timeline, reopening didn't.
- Pure additive change — no behavior change for any caller of `reopen_task`.

## Test plan
- [x] New test `test_reopen_task_logs_task_reopened` asserts a single `TASK_REOPENED` row written with correct `user_id`, `requisition_id`, `task_id`.
- [x] 231 tests passed (lifecycle_activity_logging + task_service + task_service_coverage + nightly2 + nightly12).
- [x] pre-commit clean including full --all-files on push.