### PR TITLE
fix(materials): tab partials 500 on non-null qty — bad Jinja2 format filter

### DIFF
--- a/app/templates/htmx/partials/materials/tabs/customers.html
+++ b/app/templates/htmx/partials/materials/tabs/customers.html
@@ -17,7 +17,7 @@
     <tr class="border-b border-gray-100 hover:bg-brand-50/50 transition-colors">
       <td class="py-2 px-3 font-semibold text-gray-900">{{ c.company.name if c.company else '--' }}</td>
       <td class="py-2 px-3 text-right">{{ c.purchase_count or 0 }}</td>
-      <td class="py-2 px-3 text-right">{{ "{:,}"|format(c.total_quantity) if c.total_quantity else '-' }}</td>
+      <td class="py-2 px-3 text-right">{{ "{:,}".format(c.total_quantity) if c.total_quantity else '-' }}</td>
       <td class="py-2 px-3 text-right">{% if c.avg_unit_price %}<span class="text-emerald-700 font-medium">${{ "%.4f"|format(c.avg_unit_price) }}</span>{% else %}<span class="text-gray-400">-</span>{% endif %}</td>
       <td class="py-2 px-3">{{ c.last_purchased_at.strftime('%Y-%m-%d') if c.last_purchased_at else '-' }}</td>
       <td class="py-2 px-3">{{ c.source or '-' }}</td>

--- a/app/templates/htmx/partials/materials/tabs/price_history.html
+++ b/app/templates/htmx/partials/materials/tabs/price_history.html
@@ -18,7 +18,7 @@
       <td class="py-2 px-3">{{ s.recorded_at.strftime('%Y-%m-%d %H:%M') if s.recorded_at else '-' }}</td>
       <td class="py-2 px-3 font-semibold text-gray-900">{{ s.vendor_name }}</td>
       <td class="py-2 px-3 text-right"><span class="text-emerald-700 font-medium">${{ "%.4f"|format(s.price) }}</span></td>
-      <td class="py-2 px-3 text-right">{{ "{:,}"|format(s.quantity) if s.quantity else '-' }}</td>
+      <td class="py-2 px-3 text-right">{{ "{:,}".format(s.quantity) if s.quantity else '-' }}</td>
       <td class="py-2 px-3">{{ s.currency or 'USD' }}</td>
       <td class="py-2 px-3">{{ s.source or '-' }}</td>
     </tr>

--- a/app/templates/htmx/partials/materials/tabs/sourcing.html
+++ b/app/templates/htmx/partials/materials/tabs/sourcing.html
@@ -33,7 +33,7 @@
           {{ (r.sourcing_status or 'open')|capitalize }}
         </span>
       </td>
-      <td class="py-2 px-3 text-right">{{ "{:,}"|format(r.target_qty) if r.target_qty else '-' }}</td>
+      <td class="py-2 px-3 text-right">{{ "{:,}".format(r.target_qty) if r.target_qty else '-' }}</td>
       <td class="py-2 px-3 text-right">{% if r.target_price %}<span class="text-emerald-700">${{ "%.4f"|format(r.target_price) }}</span>{% else %}<span class="text-gray-400">-</span>{% endif %}</td>
       <td class="py-2 px-3">{{ r.created_at.strftime('%Y-%m-%d') if r.created_at else '-' }}</td>
     </tr>

--- a/app/templates/htmx/partials/materials/tabs/vendors.html
+++ b/app/templates/htmx/partials/materials/tabs/vendors.html
@@ -21,7 +21,7 @@
       <td class="py-2 px-3 font-semibold text-gray-900">{{ v.vendor_name }}</td>
       <td class="py-2 px-3">{% if v.is_authorized %}<span class="text-emerald-600 font-medium">Yes</span>{% else %}<span class="text-gray-400">-</span>{% endif %}</td>
       <td class="py-2 px-3 text-right">{% if v.last_price %}<span class="text-emerald-700 font-medium">${{ "%.4f"|format(v.last_price) }}</span>{% else %}<span class="text-gray-400">-</span>{% endif %}</td>
-      <td class="py-2 px-3 text-right">{{ "{:,}"|format(v.last_qty) if v.last_qty else '-' }}</td>
+      <td class="py-2 px-3 text-right">{{ "{:,}".format(v.last_qty) if v.last_qty else '-' }}</td>
       <td class="py-2 px-3">{{ v.last_currency or 'USD' }}</td>
       <td class="py-2 px-3">{{ v.first_seen.strftime('%Y-%m-%d') if v.first_seen else '-' }}</td>
       <td class="py-2 px-3">{{ v.last_seen.strftime('%Y-%m-%d') if v.last_seen else '-' }}</td>

--- a/tests/ux_mega/test_materials_tab_render.py
+++ b/tests/ux_mega/test_materials_tab_render.py
@@ -93,14 +93,14 @@ def _ns(**kw):
         (
             "htmx/partials/materials/tabs/price_history.html",
             {
-                "sightings": [
+                "snapshots": [
                     _ns(
                         vendor_name="ACME",
                         price=9.8765,
                         quantity=1_000,
                         currency="USD",
                         source="bb",
-                        seen_at=None,
+                        recorded_at=None,
                     )
                 ],
                 "card": _ns(id=1),

--- a/tests/ux_mega/test_materials_tab_render.py
+++ b/tests/ux_mega/test_materials_tab_render.py
@@ -1,0 +1,125 @@
+"""test_materials_tab_render.py — Render each materials-tab partial with a concrete row
+so the quantity/price format filters actually execute.
+
+Purpose: catch printf-vs-str.format mismatches in templates that the empty-list
+    coverage in test_template_compilation cannot reach (because `{% for %}`
+    over an empty list never runs the loop body where the buggy filter lives).
+Called by: pytest.
+Depends on: jinja2, the shared template_env.
+
+Regression background: 2026-05-27 prod 500 on /v2/partials/materials/1/tab/vendors
+caused by `"{:,}"|format(qty)` — Jinja2's `format` filter is printf-style, so
+`"{:,}"` has zero `%s`/`%d` placeholders, raising `TypeError: not all arguments
+converted during string formatting`. The fix swaps the filter for a direct
+`.format()` method call. These tests pin that contract.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+@pytest.fixture(scope="module")
+def jinja_env() -> Environment:
+    """A Jinja2 env pointed at app/templates with the same autoescape policy."""
+    return Environment(
+        loader=FileSystemLoader("app/templates"),
+        autoescape=select_autoescape(["html"]),
+    )
+
+
+def _ns(**kw):
+    return SimpleNamespace(**kw)
+
+
+@pytest.mark.parametrize(
+    "template,ctx",
+    [
+        (
+            "htmx/partials/materials/tabs/vendors.html",
+            {
+                "vendors": [
+                    _ns(
+                        vendor_name="ACME",
+                        is_authorized=True,
+                        last_price=1.2345,
+                        last_qty=12_345,
+                        last_currency="USD",
+                        first_seen=None,
+                        last_seen=None,
+                        times_seen=3,
+                        vendor_sku="SKU-1",
+                    )
+                ],
+                "card": _ns(id=1),
+            },
+        ),
+        (
+            "htmx/partials/materials/tabs/customers.html",
+            {
+                "customers": [
+                    _ns(
+                        company=_ns(name="BigCo"),
+                        purchase_count=4,
+                        total_quantity=99_999,
+                        avg_unit_price=2.5678,
+                        last_purchased_at=None,
+                    )
+                ],
+                "card": _ns(id=1),
+            },
+        ),
+        (
+            "htmx/partials/materials/tabs/sourcing.html",
+            {
+                "requirements": [
+                    _ns(
+                        id=1,
+                        requisition_id=10,
+                        primary_mpn="MPN-1",
+                        target_qty=5_000,
+                        target_price=0.4321,
+                        created_at=None,
+                        # sourcing_status is used as a dict key (st_colors.get)
+                        # so it must be hashable — a plain string is fine.
+                        sourcing_status="open",
+                        requisition=_ns(id=10, title="Req 10"),
+                    )
+                ],
+                "card": _ns(id=1),
+            },
+        ),
+        (
+            "htmx/partials/materials/tabs/price_history.html",
+            {
+                "sightings": [
+                    _ns(
+                        vendor_name="ACME",
+                        price=9.8765,
+                        quantity=1_000,
+                        currency="USD",
+                        source="bb",
+                        seen_at=None,
+                    )
+                ],
+                "card": _ns(id=1),
+            },
+        ),
+    ],
+    ids=["vendors", "customers", "sourcing", "price_history"],
+)
+def test_materials_tab_renders_with_concrete_row(jinja_env, template, ctx):
+    """Renders the tab partial with a row carrying non-null qty + price.
+
+    If a future template change re-introduces `"{:,}"|format(X)` (printf filter
+    over a str.format string), `X` truthy will raise TypeError here.
+    """
+    try:
+        jinja_env.get_template(template).render(**ctx)
+    except TypeError as e:
+        pytest.fail(
+            f"TypeError rendering {template} with a non-null qty/price row: {e}. "
+            f'Check the template for `"{{:,}}"|format(...)` (printf filter over a '
+            f'str.format string) — use `"{{:,}}".format(...)` instead.'
+        )


### PR DESCRIPTION
## Summary
Found via 5-min post-deploy log tail on 2026-05-27. `/v2/partials/materials/{id}/tab/vendors` was returning **500** in prod with `TypeError: not all arguments converted during string formatting`.

**Root cause**: 4 materials-tab templates used `"{:,}"|format(X)`. Jinja2's `format` filter is printf-style, so `"{:,}"` has zero `%s`/`%d` placeholders. Any truthy quantity value raises the TypeError.

**Why it slipped through `tests/ux_mega/test_template_compilation.py`**: that test renders templates with empty lists, so the `{% for %}` loop where the buggy filter lives never executes.

## Changes
- **`app/templates/htmx/partials/materials/tabs/{vendors,customers,sourcing,price_history}.html`** — one-character fix per file: `"{:,}"|format(X)` → `"{:,}".format(X)` (call `.format()` directly on the string — Jinja2 supports method calls on strings, preserves the thousands-separator UI).
- **`tests/ux_mega/test_materials_tab_render.py`** (new) — renders each tab with a concrete row carrying non-null qty + price so the format filter actually runs. Verified bidirectionally: passes on the fix, fails with the exact prod error message when the buggy filter is reinstated.

## Test plan
- [x] New regression test passes on all 4 templates
- [x] New regression test fails (reproducing prod error) when the buggy filter is reinstated — verified locally
- [x] \`pre-commit run --all-files\` clean
- [ ] CI green
- [ ] After merge + deploy: re-curl \`/v2/partials/materials/1/tab/vendors\` confirms 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)