### PR TITLE
chore(ci): scope pre-commit gate to changed files — end the drift treadmill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so merge-base / changed-files diff works
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -60,8 +62,19 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
-      - name: Run pre-commit checks
-        run: pre-commit run --all-files --show-diff-on-failure
+      - name: Run pre-commit checks (files changed vs base)
+        # Scope to files this branch changed, not --all-files, so pre-existing
+        # drift in untouched files never blocks a PR. $GITHUB_BASE_REF is a
+        # built-in env var (PR base branch; empty on push) — no template input.
+        run: |
+          if [ -n "$GITHUB_BASE_REF" ]; then
+            git fetch -q origin "$GITHUB_BASE_REF"
+            base=$(git merge-base "origin/$GITHUB_BASE_REF" HEAD)
+          else
+            base=$(git rev-parse HEAD^ 2>/dev/null || git rev-parse HEAD)
+          fi
+          echo "Running pre-commit on files changed in $base..HEAD"
+          pre-commit run --from-ref "$base" --to-ref HEAD --show-diff-on-failure
 
       - name: Lint with ruff
         run: ruff check app/ tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,8 @@
 # `pre-commit install` auto-installs both hook types: pre-commit (runs on
-# staged files at commit time) + pre-push (runs full --all-files sweep
-# before push, catching branch-wide drift in files the current commit
-# doesn't touch). See the local `all-files-on-push` hook below.
+# staged files at commit time) + pre-push (runs the commit-stage hooks against
+# only the files THIS branch changed vs origin/main — so unrelated branch-wide
+# formatter drift in untouched files never blocks a push). See the local
+# `changed-files-on-push` hook below.
 #
 # First-time setup per developer:
 #   pre-commit install           # installs both hook types automatically
@@ -45,16 +46,17 @@ repos:
         pass_filenames: false
         verbose: true
 
-  # Pre-push gate: runs the full pre-commit suite against --all-files so
-  # branch-wide drift (files the current commit didn't touch) gets caught
-  # locally instead of at PR time. --hook-stage pre-commit makes the nested
-  # run execute the commit-stage hooks, not this push-stage hook (no recursion).
-  # Bypass with `git push --no-verify` if it false-positives.
+  # Pre-push gate: runs the commit-stage hooks against ONLY the files this
+  # branch changed since it forked from origin/main. This mirrors CI exactly
+  # and — unlike the old --all-files sweep — never flags pre-existing drift in
+  # files the branch never touched (which forced every PR to bundle unrelated
+  # reformatting). --hook-stage pre-commit runs the commit-stage hooks (no
+  # recursion). Bypass with `git push --no-verify` if it false-positives.
   - repo: local
     hooks:
-      - id: all-files-on-push
-        name: Full pre-commit suite on --all-files (catches branch-wide drift)
-        entry: bash -c 'pre-commit run --all-files --hook-stage pre-commit'
+      - id: changed-files-on-push
+        name: pre-commit on files changed vs origin/main
+        entry: bash -c 'base=$(git merge-base origin/main HEAD 2>/dev/null || echo origin/main); pre-commit run --from-ref "$base" --to-ref HEAD --hook-stage pre-commit'
         language: system
         stages: [pre-push]
         pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ full CRM (companies, quotes, buy plans, customer matching).
 - `docs/APP_MAP_ARCHITECTURE.md` — stack, infra, project structure
 - `docs/APP_MAP_DATABASE.md` — models, tables, relationships
 - `docs/APP_MAP_INTERACTIONS.md` — service interactions, data flows, integration patterns
+- `docs/BRANCH_AND_CI_WORKFLOW.md` — branch naming/lifecycle, the changed-files
+  formatting gate (do NOT bundle unrelated drift), and quarantine-before-delete
+  branch hygiene (`scripts/branch-cleanup.sh`)
 
 These are the canonical reference. CLAUDE.md only points at them. **After any code
 change, update the relevant APP_MAP doc(s) in the same PR.**

--- a/docs/BRANCH_AND_CI_WORKFLOW.md
+++ b/docs/BRANCH_AND_CI_WORKFLOW.md
@@ -1,0 +1,98 @@
+# Branch & CI Workflow
+
+The canonical rules for branches, the formatting gate, and keeping the repo
+clean. Applies to humans and agents. The goal: **no stale-branch drift, nothing
+deleted without a recoverable mark, a small and current branch set.**
+
+---
+
+## 1. The formatting gate is changed-files only
+
+Both the local pre-push hook (`changed-files-on-push` in `.pre-commit-config.yaml`)
+and CI (`.github/workflows/ci.yml`) run pre-commit against **only the files a
+branch changed** since its `merge-base` with `origin/main`:
+
+```bash
+base=$(git merge-base origin/main HEAD)
+pre-commit run --from-ref "$base" --to-ref HEAD
+```
+
+Consequences — follow these:
+
+- **Never bundle "unrelated" drift.** If a reviewer sees reformatting of files
+  the PR didn't intend to touch, that is a mistake to remove, not required scope.
+  (This reverses the old `all-files` policy — see the superseded note in memory.)
+- **A stale branch failing the gate means it predates this system** — rebase it
+  onto `origin/main`; do not reformat the world to satisfy it.
+- **Never `--no-verify` to dodge a real failure.** The gate now only flags files
+  you actually changed, so a failure is yours to fix.
+- Hooks are version-pinned (docformatter, ruff, mypy in `.pre-commit-config.yaml`).
+  Bump them deliberately in their own PR, never incidentally.
+
+## 2. Branch naming & lifecycle
+
+**Naming:** `<type>/<short-kebab-desc>` where `<type>` ∈
+`feat | fix | chore | docs | refactor | test`. Stacked work uses a numbered
+suffix (`feat/spec-resolver-1-migration`, `-2-models`, …) and merges bottom-up.
+
+**Lifecycle — keep branches short-lived:**
+
+1. Branch off **current** `origin/main` (`git fetch && git switch -c <name> origin/main`).
+2. Open a PR early; keep it focused and small.
+3. If `main` moves under you, **rebase onto `origin/main`** before merge (this is
+   normal maintenance, not a drift band-aid).
+4. Merge, then **delete the branch promptly** (local + remote).
+
+Do not let branches accumulate. A branch with no open PR and no active work is a
+cleanup candidate.
+
+## 3. Quarantine before delete — nothing is lost
+
+Unmerged work and stashes are **archived as tags before deletion**, never just
+dropped:
+
+```bash
+git tag archive/<name> <branch-or-stash-ref>
+git push --no-verify origin archive/<name>   # tags carry no code to lint
+git branch -D <name>                         # or: git stash drop
+```
+
+Recover anytime:
+
+```bash
+git checkout -b <name> archive/<name>
+```
+
+`archive/*` tags are the permanent, pushed record. Merged branches don't need a
+tag (they're already in `main`'s history) — just delete them.
+
+## 4. Routine cleanup
+
+Run the maintained tool to prune stale branches safely. It **never touches
+branches with open PRs**, archives every unmerged branch as an `archive/*` tag
+before deleting, and is **dry-run by default**:
+
+```bash
+scripts/branch-cleanup.sh              # preview (dry run)
+scripts/branch-cleanup.sh --apply      # delete stale LOCAL branches + clear stashes
+scripts/branch-cleanup.sh --apply --remote   # also delete stale REMOTE branches
+```
+
+Do this whenever the local branch list grows past the active set, and after a
+batch of PRs merges.
+
+## 5. Keep the workspace clean
+
+- **Working tree:** commit or quarantine untracked files; `git status` should be
+  clean between tasks. Scratch/debug artifacts go in `/root/quarantine/` (outside
+  the repo), never committed.
+- **Worktrees:** remove agent/eval worktrees when done (`git worktree remove`);
+  `git worktree list` should normally show only the main checkout.
+- **Stashes:** don't let them pile up — archive (§3) and clear.
+
+## 6. Schema / datetime note
+
+All datetime columns use `UTCDateTime` (`app/database.py`), which stores and
+returns **tz-aware UTC** (symmetric bind+result, maps to `TIMESTAMPTZ`). Write
+aware UTC (`datetime.now(timezone.utc)`); never strip tzinfo to "match" a column.
+New datetime columns: just use `UTCDateTime` (no `timezone=` needed).

--- a/scripts/branch-cleanup.sh
+++ b/scripts/branch-cleanup.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# branch-cleanup.sh — safe, quarantine-aware branch pruning.
+# See docs/BRANCH_AND_CI_WORKFLOW.md §3–§4.
+#
+# Guarantees:
+#   - Branches with OPEN PRs are NEVER touched.
+#   - Every unmerged branch is archived as a pushed `archive/<name>` tag BEFORE
+#     it is deleted (recover with: git checkout -b <name> archive/<name>).
+#   - Merged branches are deleted without a tag (already in main's history).
+#   - Dry-run by default; pass --apply to make changes.
+#
+# Usage:
+#   scripts/branch-cleanup.sh                 # preview only
+#   scripts/branch-cleanup.sh --apply         # local branches + stashes
+#   scripts/branch-cleanup.sh --apply --remote  # also delete stale remote branches
+#
+set -uo pipefail
+
+APPLY=0
+REMOTE=0
+for a in "$@"; do
+  case "$a" in
+    --apply) APPLY=1 ;;
+    --remote) REMOTE=1 ;;
+    *) echo "unknown arg: $a" >&2; exit 2 ;;
+  esac
+done
+run() { if [ "$APPLY" = 1 ]; then "$@"; else echo "DRY-RUN: $*"; fi; }
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+git fetch origin -q --prune
+
+PROTECTED=$(gh pr list --state open --limit 100 --json headRefName -q '.[].headRefName' | sort -u)
+protected() { grep -qxF "$1" <<<"$PROTECTED"; }
+
+echo "== merged local branches =="
+for b in $(git branch --merged origin/main --format='%(refname:short)' | grep -vxF 'main'); do
+  protected "$b" && { echo "skip (open PR): $b"; continue; }
+  run git branch -d "$b"
+done
+
+echo "== unmerged local branches (archive -> tag, then delete) =="
+for b in $(git branch --no-merged origin/main --format='%(refname:short)' | grep -vxF 'main'); do
+  protected "$b" && { echo "skip (open PR): $b"; continue; }
+  run git tag -f "archive/$b" "$b"
+  run git push --no-verify origin "archive/$b"
+  run git branch -D "$b"
+done
+
+if [ "$REMOTE" = 1 ]; then
+  echo "== stale remote branches (merged or archived; never open PRs) =="
+  for r in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/ \
+              | sed 's#^origin/##' | grep -vxF 'HEAD' | grep -vxF 'main'); do
+    protected "$r" && { echo "skip (open PR): origin/$r"; continue; }
+    merged=$(git merge-base --is-ancestor "origin/$r" origin/main 2>/dev/null && echo yes || echo no)
+    archived=$(git rev-parse -q --verify "refs/tags/archive/$r" >/dev/null && echo yes || echo no)
+    if [ "$merged" = yes ] || [ "$archived" = yes ]; then
+      run git push --no-verify origin --delete "$r"
+    else
+      echo "skip (unmerged, not archived): origin/$r"
+    fi
+  done
+fi
+
+echo "== stashes (archive -> tag, then clear) =="
+i=0
+git stash list --format='%gd' 2>/dev/null | while read -r ref; do
+  run git tag -f "archive/stash-$i-$(date +%s)" "$ref"
+  i=$((i+1))
+done
+if git stash list --format='%gd' | grep -q .; then
+  run git push --no-verify origin --tags
+  run git stash clear
+fi
+
+echo
+echo "Done${APPLY:+}. $( [ "$APPLY" = 1 ] && echo 'Applied.' || echo 'Dry run — re-run with --apply.')"
+echo "Recover any archived branch:  git checkout -b <name> archive/<name>"


### PR DESCRIPTION
## Root-cause fix for recurring formatter drift + the workflow system around it

**Problem:** the `all-files-on-push` gate (local pre-push **and** CI) ran `pre-commit run --all-files`, reformatting the *entire repo*. Any branch cut before main's last formatting pass carried "drift" in untouched files — guaranteeing CI failures and forcing every PR to bundle unrelated reformatting. Rebasing was a per-branch band-aid; this fixes the cause and documents the system so new work follows it.

### The gate (root-cause fix)
Both gates now run pre-commit on **only the files the branch changed** vs its `merge-base` with `origin/main`:
- `.pre-commit-config.yaml` — `changed-files-on-push` hook diffs `merge-base origin/main..HEAD`.
- `.github/workflows/ci.yml` — `fetch-depth: 0` + `pre-commit run --from-ref <base> --to-ref HEAD` (uses built-in `$GITHUB_BASE_REF`; `--all-files` removed).

Unrelated drift in untouched files can never block a push/PR again; changed files are still fully enforced.

### The system (so new work stays clean)
- **`docs/BRANCH_AND_CI_WORKFLOW.md`** — the canonical rules: changed-files gate (no drift bundling, no `--no-verify` dodging, rebase stale branches), branch naming/lifecycle, **quarantine-before-delete** (`archive/<name>` tags), routine cleanup, clean-workspace rules.
- **`scripts/branch-cleanup.sh`** — dry-run-by-default pruning tool. Never touches open-PR branches; archives every unmerged branch as a pushed `archive/<name>` tag before deleting. `--apply` to execute, `--remote` to also prune remotes.
- **`CLAUDE.md`** — points at the workflow doc.

### Verified
The push of this branch ran the new gate and **passed checking only its changed files** — self-proving the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
