### PR TITLE
fix(sourcing): spec-resolver review follow-ups — 5 confirmed fixes

### DIFF
--- a/alembic/versions/cf06dcdb7839_add_resolved_via_spec_code_to_queue_tables.py
+++ b/alembic/versions/cf06dcdb7839_add_resolved_via_spec_code_to_queue_tables.py
@@ -3,9 +3,11 @@
 Adds ``resolved_via_spec_code`` lineage column to ``ics_search_queue`` and
 ``nc_search_queue`` to record spec-code provenance on each queue row. Also
 drops the legacy ``requirement_id`` UNIQUE
-constraints on both queue tables — dedup is now keyed on
-``(requirement_id, normalized_mpn)`` at the application layer so the
-spec-code resolver can enqueue multiple AVL MPNs per requirement.
+constraints on both queue tables and replaces them with a composite
+``(requirement_id, normalized_mpn)`` UNIQUE — dedup is keyed on that pair so
+the spec-code resolver can enqueue multiple AVL MPNs per requirement while a
+DB constraint still rejects true duplicates (the in-Python check in
+``QueueManager.enqueue_search`` loses to concurrent enqueues otherwise).
 
 Revision ID: cf06dcdb7839
 Revises: 9868c839df65
@@ -40,8 +42,26 @@ def upgrade() -> None:
     op.execute("ALTER TABLE ics_search_queue DROP CONSTRAINT IF EXISTS ics_search_queue_requirement_id_key")
     op.execute("ALTER TABLE nc_search_queue DROP CONSTRAINT IF EXISTS nc_search_queue_requirement_id_key")
 
+    # Replace it with the composite (requirement_id, normalized_mpn) UNIQUE so
+    # the multi-AVL enqueue is allowed but true duplicates are still rejected
+    # at the DB layer (matches the model __table_args__).
+    op.create_unique_constraint(
+        "uq_ics_queue_requirement_mpn",
+        "ics_search_queue",
+        ["requirement_id", "normalized_mpn"],
+    )
+    op.create_unique_constraint(
+        "uq_nc_queue_requirement_mpn",
+        "nc_search_queue",
+        ["requirement_id", "normalized_mpn"],
+    )
+
 
 def downgrade() -> None:
+    # Drop the composite UNIQUE first.
+    op.drop_constraint("uq_nc_queue_requirement_mpn", "nc_search_queue", type_="unique")
+    op.drop_constraint("uq_ics_queue_requirement_mpn", "ics_search_queue", type_="unique")
+
     # Restore the per-requirement UNIQUE constraint. If duplicate rows now
     # exist (because the resolver enqueued multiple AVL MPNs for the same
     # requirement), this will fail — operator must clean up duplicates

--- a/app/models/ics_search_queue.py
+++ b/app/models/ics_search_queue.py
@@ -10,7 +10,7 @@ Depends on: requirements, requisitions tables
 
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, ForeignKey, Index, Integer, SmallInteger, String, Text
+from sqlalchemy import Column, ForeignKey, Index, Integer, SmallInteger, String, Text, UniqueConstraint
 
 from ..database import UTCDateTime
 from .base import Base
@@ -46,6 +46,11 @@ class IcsSearchQueue(Base):
     updated_at = Column(UTCDateTime, default=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (
+        # DB-level backing for the (requirement_id, normalized_mpn) dedup that
+        # QueueManager.enqueue_search checks in Python. The app check loses to a
+        # concurrent enqueue race; this constraint makes the duplicate insert
+        # fail loudly (caught as IntegrityError) instead of silently doubling.
+        UniqueConstraint("requirement_id", "normalized_mpn", name="uq_ics_queue_requirement_mpn"),
         Index(
             "ix_ics_queue_poll",
             "status",

--- a/app/models/nc_search_queue.py
+++ b/app/models/nc_search_queue.py
@@ -10,7 +10,7 @@ Depends on: requirements, requisitions tables
 
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, ForeignKey, Index, Integer, SmallInteger, String, Text
+from sqlalchemy import Column, ForeignKey, Index, Integer, SmallInteger, String, Text, UniqueConstraint
 
 from ..database import UTCDateTime
 from .base import Base
@@ -46,6 +46,11 @@ class NcSearchQueue(Base):
     updated_at = Column(UTCDateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (
+        # DB-level backing for the (requirement_id, normalized_mpn) dedup that
+        # QueueManager.enqueue_search checks in Python. The app check loses to a
+        # concurrent enqueue race; this constraint makes the duplicate insert
+        # fail loudly (caught as IntegrityError) instead of silently doubling.
+        UniqueConstraint("requirement_id", "normalized_mpn", name="uq_nc_queue_requirement_mpn"),
         Index(
             "ix_nc_queue_poll",
             "status",

--- a/app/routers/admin/spec_codes.py
+++ b/app/routers/admin/spec_codes.py
@@ -165,15 +165,17 @@ async def re_resolve(
     user: User = Depends(require_settings_access),
     db: Session = Depends(get_db),
 ):
-    """Delete the existing pending row and re-invoke the resolver.
+    """Re-invoke the resolver for an existing pending row, replacing it only on success.
 
-    Returns empty body on a fresh resolution (row replaced); a warning fragment if the
-    resolver returned unresolved.
+    Returns empty body on a fresh resolution (row swapped); a warning fragment if the
+    resolver returned unresolved or raised.
 
-    The delete + resolve happens inside a SAVEPOINT so that if the resolver raises (LLM
-    API down, network blip), the original pending row is preserved — never destroyed by
-    a transient failure. (Schema-validation failures don't raise: the resolver catches
-    them and returns ``unresolved`` rather than propagating.)
+    The fresh resolution runs FIRST (``propose`` forces a new LLM attempt instead of
+    reusing the existing pending row) and the original row is swapped out only once we
+    have a better result. A miss or a transient failure therefore leaves the buyer audit
+    trail (citations, confidence, MPNs) completely intact — overwrite-on-success, never
+    delete-then-hope. ``propose`` also runs the ~60s LLM call without holding a DB
+    transaction, so the connection isn't pinned for its duration.
     """
     from ...services.spec_code_resolver import SpecCodeResolver
 
@@ -184,22 +186,12 @@ async def re_resolve(
     spec_code = row.spec_code
     oem = row.oem
 
-    # Atomic swap: delete inside a SAVEPOINT, flush (so the resolver's
-    # pending-lookup query can't see it), then run the resolver. On any
-    # exception the SAVEPOINT auto-rolls back and the original row is
-    # restored — buyer audit trail (citations, confidence, MPNs) is
-    # never lost to a transient failure.
+    resolver = SpecCodeResolver(db)
     try:
-        with db.begin_nested():  # SAVEPOINT
-            db.delete(row)
-            db.flush()
-            resolver = SpecCodeResolver(db)
-            result = await resolver.resolve(spec_code, oem=oem)
-        db.commit()
+        # Force a fresh attempt (don't reuse the row we're trying to replace). No
+        # writes happen here, so the original row is untouched whatever the outcome.
+        result, persist_payload = await resolver.propose(spec_code, oem=oem, allow_pending_reuse=False)
     except Exception:
-        # SAVEPOINT was auto-rolled back; outer transaction may still
-        # hold the original row. Rollback to clear any pending state
-        # and ensure the row is visible to subsequent reads.
         db.rollback()
         logger.exception(
             "spec_codes: re-resolve failed for pending_id={}",
@@ -211,11 +203,31 @@ async def re_resolve(
         )
 
     if result.status == "unresolved":
-        # Resolver legitimately returned no result. The original pending
-        # row has been deleted (admin explicitly requested re-resolve);
-        # if the admin wants to blacklist, they should use reject.
+        # Fresh attempt found nothing — leave the original pending row intact. No
+        # overwrite, no data loss; the admin can still reject to blacklist it.
         return template_response(
             "htmx/partials/admin/spec_codes_reresolve_unresolved.html",
             {"request": request, "spec_code": spec_code, "error": False},
         )
+
+    # Fresh resolution succeeded — atomically swap the old row for the new one. The
+    # LLM call is already done, so this transaction is short.
+    try:
+        with db.begin_nested():
+            db.delete(row)
+            db.flush()
+            if persist_payload is not None:
+                resolver.persist(persist_payload)
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception(
+            "spec_codes: re-resolve swap failed for pending_id={}",
+            pending_id,
+        )
+        return template_response(
+            "htmx/partials/admin/spec_codes_reresolve_unresolved.html",
+            {"request": request, "spec_code": spec_code, "error": True},
+        )
+
     return HTMLResponse("", status_code=200)

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -400,32 +400,20 @@ async def search_requirement(req: Requirement, db: Session) -> dict:
         from .config import settings as _settings
 
         if _settings.spec_resolver_enabled and len(sightings) == 0 and write_req.primary_mpn:
-            from sqlalchemy.exc import IntegrityError
-
             try:
                 from app.services.spec_code_resolver import SpecCodeResolver
 
-                # Caller-owned transaction: the resolver flushes (not commits)
-                # its pending-row insert. Wrap it in a SAVEPOINT so a concurrent-
-                # insert race (UNIQUE on oem+spec_code) rolls back ONLY the
-                # resolver insert — never the sightings already committed above.
+                # resolve() owns its own persistence SAVEPOINT and releases the DB
+                # connection during the grounded LLM call, so we do NOT wrap it in a
+                # transaction here — doing so would pin a pooled connection for the
+                # call's ~60s duration. The sightings committed just above are durable
+                # and unaffected, and a concurrent-insert race is recovered inside
+                # resolve() (it reuses the winning row).
                 resolver = SpecCodeResolver(write_db)
-                with write_db.begin_nested():
-                    resolution = await resolver.resolve(
-                        write_req.primary_mpn,
-                        oem=write_req.oem_hint or "IBM",
-                    )
-            except IntegrityError:
-                # Lost the insert race; the savepoint already rolled back the
-                # resolver insert. Treat as unresolved — saved sightings stay
-                # intact. ``rollback()`` here unwinds to the savepoint only.
-                write_db.rollback()
-                logger.info(
-                    "spec_resolver: lost pending-insert race for req {} mpn {}; treating as unresolved",
-                    req_id,
+                resolution = await resolver.resolve(
                     write_req.primary_mpn,
+                    oem=write_req.oem_hint or "IBM",
                 )
-                resolution = None
             except Exception:
                 logger.warning(
                     "spec_resolver: resolve() failed for req {} mpn {}",
@@ -488,6 +476,25 @@ async def search_requirement(req: Requirement, db: Session) -> dict:
                         req_id,
                         spec_code_tag,
                     )
+
+                    # Stamp the cooldown clock on every AVL MPN we actually
+                    # searched. Without this, ``_mpn_cooldown_partition`` keeps
+                    # returning the full AVL set as stale on every subsequent
+                    # zero-hit click and re-burns connector quota — the bug the
+                    # partition gate above is meant to prevent. Mirror the
+                    # primary path: upsert a card from the AVL sightings, fall
+                    # back to ``resolve_material_card`` when the fanout was empty
+                    # so a card always exists to carry ``last_searched_at``.
+                    for avl_pn in to_fetch_avl:
+                        try:
+                            avl_card = _upsert_material_card(avl_pn, resolved_sightings, write_db, now)
+                            if avl_card is None:
+                                avl_card = resolve_material_card(avl_pn, write_db)
+                            if avl_card:
+                                avl_card.last_searched_at = now
+                        except Exception as e:
+                            logger.error("AVL_MATERIAL_CARD_STAMP_FAIL: mpn={} error={}", avl_pn, e)
+                            write_db.rollback()
 
                     # Enqueue each AVL MPN to ICS and NC workers in addition
                     # to the primary-MPN enqueue below.

--- a/app/services/search_worker_base/queue_manager.py
+++ b/app/services/search_worker_base/queue_manager.py
@@ -13,6 +13,7 @@ from typing import Any, Callable
 
 from loguru import logger
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models import Requirement, Sighting
@@ -192,7 +193,23 @@ class QueueManager:
             resolved_via_spec_code=resolved_via_spec_code,
         )
         db.add(item)
-        db.commit()
+        try:
+            db.commit()
+        except IntegrityError:
+            # Lost the insert race against a concurrent enqueue for the same
+            # (requirement_id, normalized_mpn): the uq_*_queue_requirement_mpn
+            # constraint rejected our row. Roll back and return the row the
+            # winner committed — identical to the in-Python ``existing`` path.
+            db.rollback()
+            winner = db.query(model).filter_by(requirement_id=requirement_id, normalized_mpn=norm_mpn).first()
+            logger.debug(
+                "{} enqueue race: requirement {} mpn {} already inserted concurrently (id={})",
+                self.log_prefix,
+                requirement_id,
+                norm_mpn,
+                getattr(winner, "id", None),
+            )
+            return winner
         db.refresh(item)
         logger.info(
             "{} enqueue: requirement {} queued as item {} (mpn={})", self.log_prefix, requirement_id, item.id, norm_mpn

--- a/app/services/spec_code_resolver.py
+++ b/app/services/spec_code_resolver.py
@@ -38,6 +38,7 @@ from urllib.parse import urlparse
 
 from loguru import logger
 from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.config import settings
@@ -145,45 +146,73 @@ class SpecCodeResolver:
         # via a thin adapter that normalizes keyword args.
         self._claude_call = claude_call if claude_call is not None else _default_claude_call
 
-    async def resolve(self, spec_code: str, oem: str = "IBM") -> ResolverResult:
-        """Resolve a single (oem, spec_code) pair to an AVL.
+    async def propose(
+        self,
+        spec_code: str,
+        oem: str = "IBM",
+        *,
+        allow_pending_reuse: bool = True,
+    ) -> tuple[ResolverResult, dict | None]:
+        """Resolve a (oem, spec_code) pair WITHOUT holding a DB connection across the
+        LLM call.
 
-        Normalizes input (strip + uppercase), walks the table → pending → LLM ladder,
-        and writes a pending row on a fresh LLM-derived hit.
+        Walks the table → pending → LLM ladder and returns ``(result, persist_payload)``.
+        ``persist_payload`` is non-None ONLY for a fresh LLM-derived hit the caller
+        should write via ``persist()`` inside a short, LLM-free SAVEPOINT; it is
+        ``None`` for table hits, pending reuse, and unresolved outcomes.
+
+        The read-only table/pending/blacklist queries are rolled back before the
+        grounded LLM call so a pooled connection isn't pinned for the call's ~60s
+        duration — callers MUST therefore have no uncommitted writes when they call
+        propose(). Pass ``allow_pending_reuse=False`` to force a fresh LLM attempt
+        (admin re-resolve) instead of returning an existing pending row.
         """
         norm_code = (spec_code or "").strip().upper()
         norm_oem = (oem or "IBM").strip().upper()
         if not norm_code:
-            return ResolverResult(status="unresolved")
+            return ResolverResult(status="unresolved"), None
 
         # 1. Authoritative table
         approved = self._db.query(OemSpecCode).filter_by(oem=norm_oem, spec_code=norm_code).one_or_none()
         if approved is not None:
-            return ResolverResult(
-                status="approved",
-                avl=list(approved.avl or []),
-                confidence=1.0,
-                source="table",
+            return (
+                ResolverResult(
+                    status="approved",
+                    avl=list(approved.avl or []),
+                    confidence=1.0,
+                    source="table",
+                ),
+                None,
             )
 
-        # 2. Pending — reuse prior LLM result
-        pending = self._db.query(OemSpecCodePending).filter_by(oem=norm_oem, spec_code=norm_code).one_or_none()
-        if pending is not None:
-            return ResolverResult(
-                status="pending",
-                avl=list(pending.proposed_avl or []),
-                confidence=pending.llm_confidence,
-                citations=list(pending.citations or []),
-                source="llm",
-            )
+        # 2. Pending — reuse prior LLM result unless the caller forces a fresh attempt
+        if allow_pending_reuse:
+            pending = self._db.query(OemSpecCodePending).filter_by(oem=norm_oem, spec_code=norm_code).one_or_none()
+            if pending is not None:
+                return (
+                    ResolverResult(
+                        status="pending",
+                        avl=list(pending.proposed_avl or []),
+                        confidence=pending.llm_confidence,
+                        citations=list(pending.citations or []),
+                        source="llm",
+                    ),
+                    None,
+                )
 
         # 3. Blacklist — accumulated rejected MPNs feed into the LLM prompt
         blacklist_mpns = self._load_blacklist(norm_oem, norm_code)
 
+        # Release the read-only transaction before the slow grounded LLM call so a
+        # pooled connection isn't pinned for its duration. Everything queried above
+        # is read-only and the caller guarantees no uncommitted writes here, so the
+        # rollback discards nothing of value.
+        self._db.rollback()
+
         # 4. LLM call (validated against ResolverLlmResponse)
         llm_result = await self._call_llm(norm_code, norm_oem, blacklist_mpns)
         if llm_result is None:
-            return ResolverResult(status="unresolved")
+            return ResolverResult(status="unresolved"), None
 
         # 5. Confidence floor — apply no-citations penalty first, then compare
         adjusted_confidence = llm_result.confidence
@@ -196,34 +225,73 @@ class SpecCodeResolver:
                 norm_code,
                 adjusted_confidence,
             )
-            return ResolverResult(status="unresolved")
+            return ResolverResult(status="unresolved"), None
 
-        # 6. Persist pending row (idempotent under concurrency)
+        # 6. Build the fresh result + the payload the caller persists.
         avl_payload = [entry.model_dump() for entry in llm_result.avl]
-        row = OemSpecCodePending(
-            oem=norm_oem,
-            spec_code=norm_code,
-            proposed_avl=avl_payload,
-            llm_confidence=adjusted_confidence,
-            citations=[c.model_dump() for c in llm_result.citations],
-        )
-        self._db.add(row)
-        # Caller-owned transaction: flush (not commit) so the surrounding
-        # write session keeps ownership of the outer transaction. The caller
-        # (search_service / re_resolve) wraps this resolve() in a SAVEPOINT
-        # via ``write_db.begin_nested()`` and catches IntegrityError, rolling
-        # back ONLY the savepoint so a concurrent-insert race can't abort the
-        # caller's already-saved sightings. We deliberately let IntegrityError
-        # propagate here rather than swallowing it.
-        self._db.flush()
-
-        return ResolverResult(
+        citations_payload = [c.model_dump() for c in llm_result.citations]
+        result = ResolverResult(
             status="pending",
             avl=avl_payload,
             confidence=adjusted_confidence,
-            citations=[c.model_dump() for c in llm_result.citations],
+            citations=citations_payload,
             source="llm",
         )
+        persist_payload = {
+            "oem": norm_oem,
+            "spec_code": norm_code,
+            "proposed_avl": avl_payload,
+            "llm_confidence": adjusted_confidence,
+            "citations": citations_payload,
+        }
+        return result, persist_payload
+
+    def persist(self, persist_payload: dict) -> None:
+        """Insert the proposed pending row from ``propose()``.
+
+        The caller owns the transaction and wraps this in a SAVEPOINT so a
+        concurrent-insert race (UNIQUE on oem+spec_code) rolls back only this insert.
+        We deliberately let ``IntegrityError`` propagate to the caller's race handler.
+        """
+        row = OemSpecCodePending(**persist_payload)
+        self._db.add(row)
+        self._db.flush()
+
+    async def resolve(self, spec_code: str, oem: str = "IBM") -> ResolverResult:
+        """Convenience wrapper: ``propose()`` then ``persist()`` a fresh hit in a SAVEPOINT.
+
+        Owns its own persistence transaction, so (via ``propose``) no DB connection is
+        held during the LLM call. On a concurrent-insert race it reuses the winning
+        row's data rather than failing. Callers that must bundle the persist with other
+        writes (e.g. admin re-resolve's atomic delete+insert swap) should call
+        ``propose``/``persist`` directly instead of this wrapper.
+        """
+        result, persist_payload = await self.propose(spec_code, oem)
+        if persist_payload is None:
+            return result
+
+        try:
+            with self._db.begin_nested():
+                self.persist(persist_payload)
+        except IntegrityError:
+            # Lost the insert race: a concurrent resolve persisted the same
+            # (oem, spec_code). The SAVEPOINT already rolled our insert back; reuse
+            # the winner's row so both callers converge on one mapping.
+            self._db.rollback()
+            winner = (
+                self._db.query(OemSpecCodePending)
+                .filter_by(oem=persist_payload["oem"], spec_code=persist_payload["spec_code"])
+                .one_or_none()
+            )
+            if winner is not None:
+                return ResolverResult(
+                    status="pending",
+                    avl=list(winner.proposed_avl or []),
+                    confidence=winner.llm_confidence,
+                    citations=list(winner.citations or []),
+                    source="llm",
+                )
+        return result
 
     def _load_blacklist(self, oem: str, spec_code: str) -> list[str]:
         """Flatten every rejected MPN for this (oem, spec_code) pair."""
@@ -260,6 +328,18 @@ class SpecCodeResolver:
             return None
 
         if raw is None:
+            # The adapter collapses two distinct failures to ``None``: an empty
+            # LLM response, and a non-empty response whose JSON ``safe_json_parse``
+            # could not parse (logged only at DEBUG, below Sentry's capture floor).
+            # Either way a hallucinated/truncated answer is otherwise
+            # indistinguishable from a legitimate "no match" — warn so it's
+            # observable instead of vanishing into a silent ``unresolved``.
+            logger.warning(
+                "spec_resolver: LLM returned no usable JSON (empty or unparseable); "
+                "treating as unresolved; oem={} code={}",
+                oem,
+                spec_code,
+            )
             return None
 
         # Pre-filter citations: drop any with non-http(s) URL schemes (or

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -424,15 +424,15 @@
 
 ### Search Queues
 
-**`ics_search_queue`** — ICS browser automation queue (priority, status, gate_decision). Dedup keyed on `(requirement_id, normalized_mpn)` at the app layer (legacy per-requirement UNIQUE dropped) so the spec-code resolver can enqueue multiple AVL MPNs per requirement; carries `resolved_via_spec_code` lineage.
-**`nc_search_queue`** — NetComponents browser automation queue (same structure + same dedup/lineage change)
+**`ics_search_queue`** — ICS browser automation queue (priority, status, gate_decision). Dedup keyed on `(requirement_id, normalized_mpn)` — backed by a composite UNIQUE (`uq_ics_queue_requirement_mpn`) that replaced the legacy per-requirement UNIQUE — so the spec-code resolver can enqueue multiple AVL MPNs per requirement while concurrent enqueues still can't double-insert (the app-layer check in `QueueManager.enqueue_search` catches the resulting `IntegrityError` and returns the winning row); carries `resolved_via_spec_code` lineage.
+**`nc_search_queue`** — NetComponents browser automation queue (same structure + same composite-UNIQUE dedup `uq_nc_queue_requirement_mpn` / lineage change)
 
 ### OEM Spec-Code Resolver
 
 Translates an OEM spec code (e.g. IBM `SPREJ`) to approved MPNs when the normal connector fanout returns universal zero. See `app/services/spec_code_resolver.py` and `app/routers/admin/spec_codes.py`.
 
 **`oem_spec_codes`** — Authoritative, human-approved spec-code → AVL mappings. `source` (validated against `SpecCodeSource`: manual/llm_approved/csv_import), `avl` (JSONB), `approved_at` (TIMESTAMPTZ), UNIQUE `(oem, spec_code)`.
-**`oem_spec_codes_pending`** — LLM-discovered mappings awaiting approval. `llm_confidence` (0–1, model-validated), `citations` (JSONB, structural http(s) URL check at model layer), `used_in_requirement_ids` (JSONB), UNIQUE `(oem, spec_code)`. Resolver flushes (not commits) its insert; caller owns the transaction via a SAVEPOINT.
+**`oem_spec_codes_pending`** — LLM-discovered mappings awaiting approval. `llm_confidence` (0–1, model-validated), `citations` (JSONB, structural http(s) URL check at model layer), `used_in_requirement_ids` (JSONB), UNIQUE `(oem, spec_code)`. The resolver splits read+LLM (`propose()`) from the write (`persist()`): the read transaction is released before the grounded LLM call so no connection is pinned for its ~60s duration, and the pending-row insert happens in a short SAVEPOINT afterward (concurrent-insert races recover to the winning row rather than erroring).
 **`oem_spec_codes_blacklist`** — Rejected MPNs fed back into the LLM exclusion prompt; multiple rows per `(oem, spec_code)` allowed.
 
 Lineage columns added to existing tables: `requirements.oem_hint`; `sightings.resolved_via_spec_code` / `sightings.source_mpn`; `offers.resolved_via_spec_code` / `offers.source_mpn`. (Today only the synchronous fanout tags sightings; the async ICS/NC workers record the tag on the queue row but do not yet copy it onto worker-created sightings.)

--- a/tests/routers/admin/test_spec_codes_pending.py
+++ b/tests/routers/admin/test_spec_codes_pending.py
@@ -183,10 +183,10 @@ def test_re_resolve_escapes_html_in_unresolved_response(client_with_settings_use
         db_session.query(OemSpecCodePending).filter(OemSpecCodePending.spec_code == "<script>alert(1)</script>").one()
     )
 
-    async def fake_resolve(self, spec_code, oem="IBM"):
-        return ResolverResult(status="unresolved")
+    async def fake_propose(self, spec_code, oem="IBM", *, allow_pending_reuse=True):
+        return ResolverResult(status="unresolved"), None
 
-    monkeypatch.setattr(resolver_mod.SpecCodeResolver, "resolve", fake_resolve)
+    monkeypatch.setattr(resolver_mod.SpecCodeResolver, "propose", fake_propose)
 
     resp = client_with_settings_user.post(f"/admin/spec-codes/pending/{pending.id}/re-resolve")
     assert resp.status_code == 200
@@ -195,6 +195,93 @@ def test_re_resolve_escapes_html_in_unresolved_response(client_with_settings_use
     # an executable tag.
     assert b"<script>" not in resp.content
     assert b"&lt;script&gt;" in resp.content
+
+
+def test_re_resolve_preserves_row_when_resolver_returns_unresolved(
+    client_with_settings_user,
+    pending_row,
+    db_session,
+    monkeypatch,
+):
+    """A re-resolve that legitimately comes back ``unresolved`` must NOT throw away the
+    original pending row.
+
+    Today the buyer audit trail (citations, confidence, proposed AVL) is the only record
+    of what the LLM previously proposed; silently deleting it on a fresh miss is
+    irreversible data loss. The endpoint must preserve the row and tell the admin
+    nothing new was found.
+    """
+
+    async def fake_propose(self, spec_code, oem="IBM", *, allow_pending_reuse=True):
+        from app.services.spec_code_resolver import ResolverResult
+
+        return ResolverResult(status="unresolved"), None
+
+    monkeypatch.setattr(
+        "app.services.spec_code_resolver.SpecCodeResolver.propose",
+        fake_propose,
+    )
+
+    pending_id = pending_row.id
+    resp = client_with_settings_user.post(f"/admin/spec-codes/pending/{pending_id}/re-resolve")
+    assert resp.status_code == 200
+
+    # The original pending row and its full audit trail must survive.
+    db_session.expire_all()
+    still_there = db_session.get(OemSpecCodePending, pending_id)
+    assert still_there is not None, "unresolved re-resolve must not delete the audit trail"
+    assert still_there.spec_code == "SPREJ"
+    assert still_there.proposed_avl[0]["mpn"] == "GRM188R71H103KA01D"
+    assert still_there.citations[0]["url"] == "https://example.com"
+    assert still_there.llm_confidence == 0.8
+
+
+def test_re_resolve_swaps_row_on_fresh_success(
+    client_with_settings_user,
+    pending_row,
+    db_session,
+    monkeypatch,
+):
+    """A successful fresh re-resolve replaces the old pending row with the new proposal
+    (old gone, new persisted) — the success path the original code never covered."""
+
+    async def fake_propose(self, spec_code, oem="IBM", *, allow_pending_reuse=True):
+        from app.services.spec_code_resolver import ResolverResult
+
+        result = ResolverResult(
+            status="pending",
+            avl=[{"mpn": "NEW_MPN", "manufacturer": "Vishay", "rank": 1, "notes": None}],
+            confidence=0.91,
+            citations=[{"url": "https://new.example.com", "snippet": "fresh"}],
+            source="llm",
+        )
+        payload = {
+            "oem": oem,
+            "spec_code": spec_code,
+            "proposed_avl": result.avl,
+            "llm_confidence": result.confidence,
+            "citations": result.citations,
+        }
+        return result, payload
+
+    monkeypatch.setattr(
+        "app.services.spec_code_resolver.SpecCodeResolver.propose",
+        fake_propose,
+    )
+
+    resp = client_with_settings_user.post(f"/admin/spec-codes/pending/{pending_row.id}/re-resolve")
+    assert resp.status_code == 200
+
+    db_session.expire_all()
+    # Exactly one pending row remains, carrying the FRESH proposal — the old
+    # GRM188R71H103KA01D proposal has been swapped out for NEW_MPN. (We assert by
+    # data, not row id: SQLite reuses the deleted rowid for the replacement insert.)
+    rows = db_session.query(OemSpecCodePending).filter_by(oem="IBM", spec_code="SPREJ").all()
+    assert len(rows) == 1
+    assert rows[0].proposed_avl[0]["mpn"] == "NEW_MPN"
+    assert rows[0].llm_confidence == 0.91
+    assert all(r.proposed_avl[0]["mpn"] != "GRM188R71H103KA01D" for r in rows)
+    assert rows[0].llm_confidence == 0.91
 
 
 def test_re_resolve_preserves_row_on_resolver_exception(
@@ -209,12 +296,12 @@ def test_re_resolve_preserves_row_on_resolver_exception(
     The route must return a friendly error fragment, not a 500.
     """
 
-    async def fake_resolve(self, spec_code, oem="IBM"):
+    async def fake_propose(self, spec_code, oem="IBM", *, allow_pending_reuse=True):
         raise RuntimeError("LLM API down")
 
     monkeypatch.setattr(
-        "app.services.spec_code_resolver.SpecCodeResolver.resolve",
-        fake_resolve,
+        "app.services.spec_code_resolver.SpecCodeResolver.propose",
+        fake_propose,
     )
 
     pending_id = pending_row.id

--- a/tests/test_queue_manager_override_mpn.py
+++ b/tests/test_queue_manager_override_mpn.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from app.models import IcsSearchQueue, NcSearchQueue, Requirement
 from app.models.sourcing import Requisition
@@ -123,3 +124,31 @@ def test_nc_wrapper_propagates_kwargs(db_session, requirement):
     # And NC table row is independent from ICS rows
     nc_rows = db_session.query(NcSearchQueue).filter_by(requirement_id=requirement.id).all()
     assert len(nc_rows) == 1
+
+
+@pytest.mark.parametrize("model", [IcsSearchQueue, NcSearchQueue])
+def test_duplicate_requirement_mpn_pair_is_rejected_at_db_level(db_session, requirement, model):
+    """The (requirement_id, normalized_mpn) dedup is backed by a DB UNIQUE constraint,
+    not just an application-level check — two concurrent enqueues that both pass the in-
+    Python lookup still cannot create duplicate rows."""
+    first = model(
+        requirement_id=requirement.id,
+        requisition_id=requirement.requisition_id,
+        mpn="SPREJ",
+        normalized_mpn="SPREJ",
+        status="pending",
+    )
+    db_session.add(first)
+    db_session.commit()
+
+    dup = model(
+        requirement_id=requirement.id,
+        requisition_id=requirement.requisition_id,
+        mpn="SPREJ",
+        normalized_mpn="SPREJ",
+        status="pending",
+    )
+    db_session.add(dup)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()

--- a/tests/test_search_service_with_spec_resolver.py
+++ b/tests/test_search_service_with_spec_resolver.py
@@ -321,6 +321,44 @@ async def test_avl_cooldown_skips_fetch_within_window(db_session, enable_flag, s
     assert ["GRM188R71H103KA01D"] not in fetch_calls
 
 
+async def test_avl_refanout_stamps_material_card_so_cooldown_engages(
+    db_session, enable_flag, spec_code_requirement, monkeypatch
+):
+    """Regression: the AVL re-fanout must stamp a MaterialCard.last_searched_at for
+    each searched AVL MPN. Without it ``_mpn_cooldown_partition`` always re-returns the
+    AVL set as stale and every zero-hit click re-burns connector quota. Uses the REAL
+    partition (no monkeypatch) and a zero-hit AVL fanout so the resolve_material_card
+    fallback path is exercised."""
+
+    async def fake_fetch_fresh(mpns, db):
+        # Both the primary and the AVL fanout return zero hits.
+        return ([], [_ok_stat("oemsecrets")])
+
+    async def fake_resolve(self, spec_code, oem="IBM"):
+        return ResolverResult(
+            status="pending",
+            avl=[{"mpn": "GRM188R71H103KA01D", "manufacturer": "Murata", "rank": 1, "notes": None}],
+            confidence=0.8,
+            citations=[{"url": "https://example.com", "snippet": "..."}],
+            source="llm",
+        )
+
+    monkeypatch.setattr(search_service, "_fetch_fresh", fake_fetch_fresh)
+    monkeypatch.setattr(
+        "app.services.spec_code_resolver.SpecCodeResolver.resolve",
+        fake_resolve,
+    )
+
+    await search_service.search_requirement(spec_code_requirement, db_session)
+
+    from app.models import MaterialCard
+
+    norm = search_service.normalize_mpn_key("GRM188R71H103KA01D")
+    card = db_session.query(MaterialCard).filter_by(normalized_mpn=norm).one_or_none()
+    assert card is not None, "AVL MPN must get a MaterialCard so the per-MPN cooldown can engage"
+    assert card.last_searched_at is not None, "cooldown clock must be stamped on the searched AVL MPN's card"
+
+
 async def test_avl_fetch_fresh_exception_logged_and_continues(
     db_session, enable_flag, spec_code_requirement, monkeypatch
 ):

--- a/tests/test_spec_code_resolver.py
+++ b/tests/test_spec_code_resolver.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 import pytest
+from loguru import logger
 
 from app.models.sourcing import (
     OemSpecCode,
@@ -32,6 +33,19 @@ from app.services.spec_code_resolver import ResolverResult, SpecCodeResolver
 def resolver(db_session):
     """Resolver bound to the test session; LLM is unset until a test wires it."""
     return SpecCodeResolver(db_session, claude_call=AsyncMock())
+
+
+@pytest.fixture
+def loguru_warnings():
+    """Capture loguru WARNING+ messages into a list.
+
+    Loguru isn't bridged to
+    stdlib logging here, so pytest's caplog won't see logger.warning(...).
+    """
+    captured: list[str] = []
+    sink_id = logger.add(lambda msg: captured.append(str(msg)), level="WARNING")
+    yield captured
+    logger.remove(sink_id)
 
 
 @pytest.fixture
@@ -221,6 +235,26 @@ async def test_llm_none_returns_unresolved(resolver):
     assert result.status == "unresolved"
 
 
+async def test_llm_none_emits_sentry_visible_warning(resolver, loguru_warnings):
+    """A ``None`` from the LLM adapter (empty response OR malformed JSON that
+    ``safe_json_parse`` dropped) must surface as a WARNING — not vanish silently into an
+    indistinguishable 'unresolved'.
+
+    WARNING is the Sentry capture floor, so this is what makes a hallucinated/truncated
+    response observable.
+    """
+
+    async def fake_claude(**kwargs):
+        return None
+
+    resolver._claude_call = fake_claude
+    await resolver.resolve("SPREJ", oem="IBM")
+
+    assert any("SPREJ" in m and "IBM" in m for m in loguru_warnings), (
+        f"expected a WARNING naming the oem/spec_code on the None path; got {loguru_warnings!r}"
+    )
+
+
 async def test_llm_schema_invalid_returns_unresolved(resolver):
     async def fake_claude(**kwargs):
         return {"avl": "not a list", "confidence": 0.9}  # invalid
@@ -228,6 +262,33 @@ async def test_llm_schema_invalid_returns_unresolved(resolver):
     resolver._claude_call = fake_claude
     result = await resolver.resolve("FOO")
     assert result.status == "unresolved"
+
+
+async def test_no_db_transaction_held_during_llm_call(resolver, db_session):
+    """The ~60s grounded LLM call must NOT pin a DB connection inside an open
+    transaction — under concurrency that exhausts the pool.
+
+    The read-only table/pending/blacklist queries are released (rolled back) before the
+    network call, so the session holds no transaction while the LLM is in flight.
+    """
+    observed: dict = {}
+
+    async def fake_claude(**kwargs):
+        observed["in_transaction"] = db_session.in_transaction()
+        return {
+            "avl": [{"mpn": "X", "manufacturer": "M", "rank": 1, "notes": None}],
+            "confidence": 0.9,
+            "citations": [{"url": "https://example.com", "snippet": "s"}],
+            "reasoning": "r",
+        }
+
+    resolver._claude_call = fake_claude
+    await resolver.resolve("FOO", oem="IBM")
+
+    assert observed.get("in_transaction") is False, (
+        "the DB transaction must be released before the LLM network call so the "
+        "connection isn't pinned for the call's duration"
+    )
 
 
 # ── Concurrent insert collision (Task 3.10) ──────────────────────────
@@ -402,18 +463,17 @@ async def test_resolve_uses_flush_not_commit(resolver, db_session, monkeypatch):
     assert result.avl[0]["mpn"] == "GOOD_MPN"
 
 
-async def test_concurrent_pending_insert_propagates_integrity_error(resolver, db_session):
-    """Simulate a second resolver winning the same (oem, spec_code) first.
+async def test_concurrent_pending_insert_recovers_to_winner(resolver, db_session):
+    """If a concurrent resolver commits the same (oem, spec_code) first, resolve() must
+    NOT raise.
 
-    With the caller-owned-transaction design, resolve() flushes its insert and lets the
-    UNIQUE-constraint IntegrityError propagate. The CALLER (search_service / re_resolve)
-    wraps resolve() in a SAVEPOINT and treats the race as unresolved — the resolver
-    itself no longer swallows the error.
+    ``resolve()`` owns its persistence SAVEPOINT and, on the UNIQUE
+    collision, recovers by reusing the winner's row so both callers converge on a
+    single mapping — the race no longer surfaces as an error every caller must catch.
     """
-    from sqlalchemy.exc import IntegrityError
 
     async def fake_claude(**kwargs):
-        # Sneak a competing row in just before the resolver flushes its own.
+        # A competing resolver commits the same (oem, spec_code) first.
         db_session.add(
             OemSpecCodePending(
                 oem="IBM",
@@ -423,7 +483,7 @@ async def test_concurrent_pending_insert_propagates_integrity_error(resolver, db
                 citations=[],
             )
         )
-        db_session.flush()
+        db_session.commit()
         return {
             "avl": [{"mpn": "LOSER", "manufacturer": "M", "rank": 1, "notes": None}],
             "confidence": 0.9,
@@ -432,5 +492,10 @@ async def test_concurrent_pending_insert_propagates_integrity_error(resolver, db
         }
 
     resolver._claude_call = fake_claude
-    with pytest.raises(IntegrityError):
-        await resolver.resolve("FOO")
+    result = await resolver.resolve("FOO")
+
+    # Recovered to the winner's data — not the LOSER we computed — without raising.
+    assert result.status == "pending"
+    assert result.avl[0]["mpn"] == "WINNER"
+    # Exactly one row survives the race.
+    assert db_session.query(OemSpecCodePending).filter_by(oem="IBM", spec_code="FOO").count() == 1


### PR DESCRIPTION
Follow-up to **#186** (OEM spec-code resolver, now merged to `main`). An adversarial multi-agent review of the merged feature surfaced 5 **confirmed** findings (survived adversarial verification); this PR lands root-cause fixes for all five, each with a regression test written test-first.

## Fixes

| # | Problem | Fix |
|---|---------|-----|
| **1** | AVL re-fanout never stamped a `MaterialCard`, so `_mpn_cooldown_partition` re-returned the whole AVL set every time → every zero-hit click re-burned connector quota. The passing test only worked because it mocked the partition. | Stamp `MaterialCard.last_searched_at` per searched AVL MPN (mirrors the primary path). New test uses the **real** partition. |
| **2** | Resolver `None` from the LLM (empty response **or** unparseable JSON that `safe_json_parse` dropped at DEBUG) vanished into an indistinguishable `unresolved`. | Log a Sentry-visible `WARNING` on the `None` path with oem/spec_code. |
| **3** | Admin re-resolve deleted the pending row, re-ran the resolver, then committed unconditionally — a legitimate `unresolved` destroyed the buyer audit trail (citations/confidence/AVL) forever. | Resolve **first**, swap the row only on success. A miss or transient failure leaves the original row untouched. |
| **4** | The `(requirement_id, normalized_mpn)` dedup was app-level only; concurrent enqueues could double-insert, and the lookup was unindexed. | Composite `UNIQUE(requirement_id, normalized_mpn)` on both queue tables (model + migration); `enqueue_search` catches `IntegrityError` and returns the winning row. |
| **5** | The ~60s grounded LLM call ran inside an open transaction (`begin_nested` / a held read txn), pinning a pooled connection for its duration → pool-exhaustion risk under concurrency. | Split the resolver into `propose()` (reads + LLM, releases the read transaction **before** the call) and `persist()` (short SAVEPOINT write afterward). `resolve()` is a back-compat wrapper; concurrent-insert races now recover to the winning row instead of erroring. |

Fix #5 also closed two review nits for free: the re-resolve **success path** is now tested, and the delete-then-hope pattern is gone.

## Verification
- **84/84** affected tests pass; broader **434-test** sweep clean.
- `ruff` ✓ · `ruff-format` ✓ · `mypy` ✓ · `docformatter` ✓ · full `pre-commit` (changed-files) ✓.
- Single alembic head (`cf06dcdb7839`); migration up+down updated.
- `docs/APP_MAP_DATABASE.md` updated for the new constraint and the resolver transaction model.

## Notes
- TDD throughout: each fix is RED → GREEN with the failing test verified first.
- Scoped to the 5 confirmed findings + directly-related docs/tests; no unrelated drift bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)