### PR TITLE
ci: bump checkout@v4→v5 and setup-python@v5→v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # full history so merge-base / changed-files diff works
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,10 +14,10 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
## Why
GitHub Actions deprecation: Node-20 JS actions are **forced to Node 24 on 2026-06-16** and Node 20 is removed from runners 2026-09-16. CI currently warns on `actions/checkout@v4` and `actions/setup-python@v5`.

## Change
- `actions/checkout@v4` → `@v5` (ci.yml, security.yml)
- `actions/setup-python@v5` → `@v6` (ci.yml, security.yml)

`actions/setup-node@v6` and `actions/upload-artifact@v7` are already on Node 24 — left unchanged. The project build Node (`setup-node node-version: "20"`) is a separate toolchain concern and intentionally untouched here.

## Risk
None expected — version-only bumps; no inputs/permissions changed. CI on this PR validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)