### PR TITLE
docs(claude): note current APP_VERSION (3.1.0) on Version line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 **AvailAI** — electronic-component sourcing engine and CRM for Trio Supply Chain Solutions.
 **Stack:** FastAPI + SQLAlchemy 2.0 + PostgreSQL 16 + HTMX 2.x + Alpine.js 3.x + Jinja2 + Tailwind CSS 3.x.
 **Deploy:** Docker Compose (app, enrichment-worker, db, redis, caddy, db-backup) on DigitalOcean.
-**Version:** `APP_VERSION` constant in `app/config.py`.
+**Version:** `APP_VERSION` constant in `app/config.py` (currently `3.1.0`).
 
 It searches supplier APIs in parallel (BrokerBin, Nexar, DigiKey, Mouser, OEMSecrets,
 Element14, Sourcengine, eBay, AI web search, email mining), tracks vendor intelligence,


### PR DESCRIPTION
## Summary

`main` already carries the full CLAUDE.md sync (merged via PR #215). This branch was rebased onto current `main` and reduced to the **only non-regressive delta** from the original #202: pinning the current `APP_VERSION` on the Version line.

The rest of #202's original content was dropped because `main` already has it — and in two places `main` is newer (the Deploy section's `BUILD_COMMIT` build-arg flow from PR #211, and the token-gated `/metrics` note), so merging the old branch as-is would have regressed those.

## Change
```diff
-**Version:** `APP_VERSION` constant in `app/config.py`.
+**Version:** `APP_VERSION` constant in `app/config.py` (currently `3.1.0`).
```

Verified: `app/config.py` has `APP_VERSION = "3.1.0"` on `main`. Documentation only.