### PR TITLE
Verified material enrichment + part-number import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ scripts/ux-repair-state/history.jsonl
 scripts/ux-repair-state/failed_patches.json
 coverage-report.txt
 docs/superpowers/specs/2026-03-28-coverage-report.txt
+reports/

--- a/alembic/versions/a1f7c2d9e4b8_add_material_enrichment_status_provenance.py
+++ b/alembic/versions/a1f7c2d9e4b8_add_material_enrichment_status_provenance.py
@@ -44,6 +44,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index("ix_material_cards_enrichment_status", table_name="material_cards")
+    op.drop_index("ix_material_cards_enrichment_status", table_name="material_cards", if_exists=True)
     op.execute("ALTER TABLE IF EXISTS material_cards DROP COLUMN IF EXISTS enrichment_provenance")
     op.execute("ALTER TABLE IF EXISTS material_cards DROP COLUMN IF EXISTS enrichment_status")

--- a/alembic/versions/a1f7c2d9e4b8_add_material_enrichment_status_provenance.py
+++ b/alembic/versions/a1f7c2d9e4b8_add_material_enrichment_status_provenance.py
@@ -1,0 +1,49 @@
+"""Add material_cards.enrichment_status and enrichment_provenance.
+
+enrichment_status (VARCHAR 20, NOT NULL, server_default 'unenriched', indexed)
+marks a card as unenriched | verified | ai_inferred | not_found.
+enrichment_provenance (JSONB, nullable) records per-field source attribution.
+
+Revision ID: a1f7c2d9e4b8
+Revises: 086_add_activity_digest
+Create Date: 2026-06-04 22:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a1f7c2d9e4b8"
+down_revision: Union[str, None] = "086_add_activity_digest"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "material_cards",
+        sa.Column(
+            "enrichment_status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="unenriched",
+        ),
+    )
+    op.add_column(
+        "material_cards",
+        sa.Column("enrichment_provenance", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.create_index(
+        "ix_material_cards_enrichment_status",
+        "material_cards",
+        ["enrichment_status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_material_cards_enrichment_status", table_name="material_cards")
+    op.execute("ALTER TABLE IF EXISTS material_cards DROP COLUMN IF EXISTS enrichment_provenance")
+    op.execute("ALTER TABLE IF EXISTS material_cards DROP COLUMN IF EXISTS enrichment_status")

--- a/app/connectors/_core_attrs.py
+++ b/app/connectors/_core_attrs.py
@@ -1,0 +1,91 @@
+"""Shared helpers to normalize connector core attributes into MaterialCard vocab.
+
+Core attributes: category, lifecycle_status, package_type, pin_count, rohs_status.
+All helpers return None when the input is missing/unmappable — never a guess.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# DigiKey ProductStatus / generic distributor lifecycle text -> MaterialCard lifecycle_status
+_LIFECYCLE_MAP = {
+    "active": "active",
+    "obsolete": "obsolete",
+    "discontinued": "obsolete",
+    "not for new designs": "nrfnd",
+    "nrnd": "nrfnd",
+    "last time buy": "ltb",
+    "end of life": "eol",
+    "eol": "eol",
+}
+
+_ROHS_MAP = {
+    "rohs compliant": "compliant",
+    "compliant": "compliant",
+    "rohs3 compliant": "compliant",
+    "non-compliant": "non-compliant",
+    "not compliant": "non-compliant",
+    "rohs exempt": "exempt",
+    "exempt": "exempt",
+}
+
+
+def map_lifecycle(raw: Any) -> str | None:
+    if not raw:
+        return None
+    return _LIFECYCLE_MAP.get(str(raw).strip().lower())
+
+
+def map_rohs(raw: Any) -> str | None:
+    if not raw:
+        return None
+    return _ROHS_MAP.get(str(raw).strip().lower())
+
+
+def clean_str(raw: Any, *, maxlen: int) -> str | None:
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s[:maxlen] if s else None
+
+
+def safe_pin_count(raw: Any) -> int | None:
+    try:
+        v = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    return v if v > 0 else None
+
+
+def digikey_parameter(params: Any, names: tuple[str, ...]) -> str | None:
+    """Extract a ValueText from DigiKey Parameters[] by ParameterText match."""
+    if not isinstance(params, list):
+        return None
+    wanted = {n.lower() for n in names}
+    for p in params:
+        if isinstance(p, dict) and str(p.get("ParameterText", "")).strip().lower() in wanted:
+            val = str(p.get("ValueText", "")).strip()
+            if val and val != "-":
+                return val
+    return None
+
+
+def generic_attribute(attrs: Any, name_key: str, value_key: str, names: tuple[str, ...]) -> str | None:
+    """Extract a value from a generic attribute list by label/name match.
+
+    Works for Mouser ProductAttributes ({AttributeName, AttributeValue}) and Element14
+    attributes ({attributeLabel, attributeValue}) by passing the appropriate key names.
+    """
+    if not isinstance(attrs, list):
+        return None
+    wanted = {n.lower() for n in names}
+    for attr in attrs:
+        if not isinstance(attr, dict):
+            continue
+        label = str(attr.get(name_key, "")).strip().lower()
+        if label in wanted:
+            val = str(attr.get(value_key, "")).strip()
+            if val and val != "-":
+                return val
+    return None

--- a/app/connectors/digikey.py
+++ b/app/connectors/digikey.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from ..http_client import http
 from ..utils import safe_float, safe_int
+from ._core_attrs import clean_str, digikey_parameter, map_lifecycle, map_rohs, safe_pin_count
 from .errors import ConnectorRateLimitError
 from .sources import BaseConnector, _parse_retry_after
 
@@ -144,6 +145,22 @@ class DigiKeyConnector(BaseConnector):
             else:
                 price = prod.get("UnitPrice") or prod.get("unitPrice")
 
+            # Core attributes (optional — None when absent)
+            cat = prod.get("Category") or {}
+            category = clean_str(cat.get("Name") if isinstance(cat, dict) else cat, maxlen=255)
+            status = prod.get("ProductStatus") or {}
+            lifecycle = map_lifecycle(status.get("Status") if isinstance(status, dict) else status)
+            params = prod.get("Parameters")
+            package = clean_str(digikey_parameter(params, ("Package / Case", "Supplier Device Package")), maxlen=100)
+            pin_count = safe_pin_count(
+                digikey_parameter(params, ("Number of Terminations", "Number of I/O", "Number of Pins"))
+            )
+            classifications = prod.get("Classifications")
+            rohs_raw = (
+                classifications.get("RohsStatus") if isinstance(classifications, dict) else prod.get("RohsStatus")
+            )
+            rohs = map_rohs(rohs_raw)
+
             results.append(
                 {
                     "vendor_name": "DigiKey",
@@ -159,6 +176,11 @@ class DigiKeyConnector(BaseConnector):
                     "vendor_sku": dk_pn,
                     "vendor_url": "https://www.digikey.com",
                     "description": detail_desc,
+                    "category": category,
+                    "lifecycle_status": lifecycle,
+                    "package_type": package,
+                    "pin_count": pin_count,
+                    "rohs_status": rohs,
                 }
             )
 

--- a/app/connectors/element14.py
+++ b/app/connectors/element14.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from ..http_client import http
 from ..utils import safe_float, safe_int
+from ._core_attrs import clean_str, generic_attribute, map_rohs
 from .errors import ConnectorAuthError, ConnectorRateLimitError
 from .sources import BaseConnector
 
@@ -100,6 +101,18 @@ class Element14Connector(BaseConnector):
 
             click_url = f"https://www.newark.com/search?st={quote_plus(mpn)}"
 
+            # Core attributes (optional — None when absent)
+            attrs = prod.get("attributes")
+            rohs = map_rohs(
+                generic_attribute(attrs, "attributeLabel", "attributeValue", ("RoHS", "RoHS Status", "ROHS"))
+            )
+            package = clean_str(
+                generic_attribute(
+                    attrs, "attributeLabel", "attributeValue", ("Package", "Case / Package", "Package / Case")
+                ),
+                maxlen=100,
+            )
+
             results.append(
                 {
                     "vendor_name": "element14",
@@ -115,6 +128,8 @@ class Element14Connector(BaseConnector):
                     "vendor_sku": sku,
                     "vendor_url": "https://www.newark.com",
                     "description": desc[:500] if desc else "",
+                    "rohs_status": rohs,
+                    "package_type": package,
                 }
             )
 

--- a/app/connectors/mouser.py
+++ b/app/connectors/mouser.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 from ..http_client import http
 from ..utils import safe_float
+from ._core_attrs import clean_str, generic_attribute, map_lifecycle, safe_pin_count
 from .errors import ConnectorAuthError, ConnectorRateLimitError
 from .sources import BaseConnector
 
@@ -122,6 +123,28 @@ class MouserConnector(BaseConnector):
                 if price_str:
                     price = safe_float(price_str.replace("$", "").replace(",", ""))
 
+            # Core attributes (optional — None when absent)
+            product_attrs = part.get("ProductAttributes")
+            category = clean_str(part.get("Category"), maxlen=255)
+            lifecycle = map_lifecycle(part.get("LifecycleStatus"))
+            package = clean_str(
+                generic_attribute(
+                    product_attrs,
+                    "AttributeName",
+                    "AttributeValue",
+                    ("Package / Case", "Package", "Case / Package"),
+                ),
+                maxlen=100,
+            )
+            pin_count = safe_pin_count(
+                generic_attribute(
+                    product_attrs,
+                    "AttributeName",
+                    "AttributeValue",
+                    ("Number of Pins", "Number of Terminations", "Pin Count"),
+                )
+            )
+
             results.append(
                 {
                     "vendor_name": "Mouser",
@@ -137,6 +160,10 @@ class MouserConnector(BaseConnector):
                     "vendor_sku": mouser_pn,
                     "vendor_url": "https://www.mouser.com",
                     "description": desc,
+                    "category": category,
+                    "lifecycle_status": lifecycle,
+                    "package_type": package,
+                    "pin_count": pin_count,
                 }
             )
 

--- a/app/connectors/oemsecrets.py
+++ b/app/connectors/oemsecrets.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 from ..http_client import http
 from ..utils import safe_float, safe_int
+from ._core_attrs import clean_str, map_lifecycle
 from .errors import ConnectorAuthError, ConnectorRateLimitError
 from .sources import BaseConnector
 
@@ -139,6 +140,10 @@ class OEMSecretsConnector(BaseConnector):
                 auth_status == "authorised" if auth_status else item.get("authorized", item.get("is_authorized", True))
             )
 
+            # Core attributes (optional — None when absent)
+            category = clean_str(item.get("category"), maxlen=255)
+            lifecycle = map_lifecycle(item.get("lifecycle_status"))
+
             results.append(
                 {
                     "vendor_name": dist_name,
@@ -154,6 +159,8 @@ class OEMSecretsConnector(BaseConnector):
                     "vendor_sku": sku,
                     "moq": safe_int(moq) or None,
                     "datasheet_url": datasheet,
+                    "category": category,
+                    "lifecycle_status": lifecycle,
                 }
             )
 

--- a/app/connectors/sources.py
+++ b/app/connectors/sources.py
@@ -11,6 +11,7 @@ import httpx
 from loguru import logger
 
 from ..utils import safe_float, safe_int
+from ._core_attrs import clean_str
 from .errors import ConnectorAuthError, ConnectorError, ConnectorQuotaError, ConnectorRateLimitError
 
 # ── Async-compatible circuit breaker ─────────────────────────────────
@@ -198,6 +199,7 @@ class NexarConnector(BaseConnector):
         results { part {
           mpn
           manufacturer { name }
+          category { name }
           sellers {
             company { name homepageUrl }
             isAuthorized
@@ -447,6 +449,8 @@ class NexarConnector(BaseConnector):
             mpn = part.get("mpn", pn)
             mfr = (part.get("manufacturer") or {}).get("name", "")
             sellers = part.get("sellers") or []
+            # Core attribute: category (optional)
+            category = clean_str((part.get("category") or {}).get("name"), maxlen=255)
 
             if not sellers:
                 key = f"_ref_{mpn}_{mfr}"
@@ -464,6 +468,7 @@ class NexarConnector(BaseConnector):
                             "is_authorized": False,
                             "confidence": 2,
                             "octopart_url": octopart_url,
+                            "category": category,
                         }
                     )
                 continue
@@ -493,6 +498,7 @@ class NexarConnector(BaseConnector):
                                 "confidence": 3 if auth else 2,
                                 "octopart_url": octopart_url,
                                 "vendor_url": homepage,
+                                "category": category,
                             }
                         )
                     continue
@@ -529,6 +535,7 @@ class NexarConnector(BaseConnector):
                             "click_url": click_url,
                             "vendor_url": homepage,
                             "vendor_sku": sku,
+                            "category": category,
                         }
                     )
 

--- a/app/file_utils.py
+++ b/app/file_utils.py
@@ -11,6 +11,59 @@ import io
 from loguru import logger
 
 
+def _looks_like_html(content: bytes) -> bool:
+    """Return True when the byte payload looks like an HTML document."""
+    head = content[:512].lstrip().lower()
+    return head.startswith((b"<head", b"<html", b"<table", b"<!doctype", b"<meta"))
+
+
+def _parse_html_table(content: bytes) -> list[dict]:
+    """Parse an HTML <table> export (e.g. ERP 'Excel' that is really HTML)."""
+    from html.parser import HTMLParser
+
+    class _T(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.rows: list[list[str]] = []
+            self._cur: list[str] | None = None
+            self._cell: list[str] | None = None
+
+        def handle_starttag(self, tag, attrs):
+            if tag == "tr":
+                self._cur = []
+            elif tag in ("td", "th"):
+                self._cell = []
+
+        def handle_endtag(self, tag):
+            if tag == "tr" and self._cur is not None:
+                self.rows.append(self._cur)
+                self._cur = None
+            elif tag in ("td", "th") and self._cell is not None and self._cur is not None:
+                self._cur.append("".join(self._cell).strip())
+                self._cell = None
+
+        def handle_data(self, data):
+            if self._cell is not None:
+                self._cell.append(data)
+
+    try:
+        text = content.decode("iso-8859-1")
+    except Exception:
+        text = content.decode("utf-8", errors="replace")
+    p = _T()
+    p.feed(text)
+    table = [r for r in p.rows if any(c.strip() for c in r)]
+    if not table:
+        return []
+    headers = [str(c or "").strip().lower() for c in table[0]]
+    out = []
+    for row in table[1:]:
+        if not any(c.strip() for c in row):
+            continue
+        out.append(dict(zip(headers, [str(v or "").strip() for v in row])))
+    return out
+
+
 def parse_tabular_file(content: bytes, filename: str) -> list[dict]:
     """Parse CSV/TSV/Excel file bytes into a list of row dicts.
 
@@ -22,7 +75,12 @@ def parse_tabular_file(content: bytes, filename: str) -> list[dict]:
 
     try:
         if fname.endswith((".xlsx", ".xls")):
-            rows = _parse_excel(content)
+            if _looks_like_html(content):
+                rows = _parse_html_table(content)
+            else:
+                rows = _parse_excel(content)
+        elif _looks_like_html(content):
+            rows = _parse_html_table(content)
         else:
             delimiter = "\t" if fname.endswith(".tsv") else ","
             rows = _parse_csv(content, delimiter)
@@ -59,6 +117,40 @@ def _parse_csv(content: bytes, delimiter: str = ",") -> list[dict]:
     for row in reader:
         rows.append({k.strip().lower(): v.strip() for k, v in row.items() if k})
     return rows
+
+
+_MPN_COLUMN_NAMES = (
+    "material: material name",
+    "material name",
+    "mpn",
+    "part number",
+    "part_number",
+    "partnumber",
+    "pn",
+    "part#",
+)
+
+
+def extract_mpns(rows: list[dict]) -> list[str]:
+    """Pull part numbers from parsed rows.
+
+    Prefers a recognized column name; otherwise uses the single column present.
+    Preserves order, drops blanks.
+    """
+    if not rows:
+        return []
+    keys = list(rows[0].keys())
+    col = next((k for k in keys if k in _MPN_COLUMN_NAMES), None)
+    if col is None and len(keys) == 1:
+        col = keys[0]
+    if col is None:
+        return []
+    out = []
+    for r in rows:
+        v = (r.get(col) or "").strip()
+        if v:
+            out.append(v)
+    return out
 
 
 # ── Stock list row normalization ────────────────────────────────────────

--- a/app/models/intelligence.py
+++ b/app/models/intelligence.py
@@ -48,6 +48,12 @@ class MaterialCard(Base):
     )  # Structured specs: {"ddr_type": {"value": "DDR4", "source": "...", "confidence": 0.99, "updated_at": "..."}}
     enrichment_source = Column(String(50))  # "claude_ai", "manual", etc.
     enriched_at = Column(UTCDateTime)
+    # Verification provenance (added 2026-06-04 — verified-enrichment feature)
+    # enrichment_status: "unenriched" | "verified" | "ai_inferred" | "not_found"
+    enrichment_status = Column(String(20), nullable=False, server_default="unenriched", index=True)
+    # Per-field provenance: {"<field>": {"source": "digikey", "confidence": 1.0,
+    #                                    "fetched_at": "2026-06-04T..Z", "matched_mpn": "..."}}
+    enrichment_provenance = Column(JSONB)
 
     is_internal_part = Column(Boolean, default=False, server_default="false")  # Internal/custom PN (not a standard MPN)
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -7202,6 +7202,7 @@ async def materials_faceted_partial(
     sub_filters: str = "{}",
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
+    verified_only: bool = Query(False),
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -7221,6 +7222,7 @@ async def materials_faceted_partial(
         q=q or None,
         sub_filters=parsed_filters or None,
         manufacturers=manufacturers,
+        verified_only=verified_only,
         limit=limit,
         offset=offset,
     )

--- a/app/routers/materials.py
+++ b/app/routers/materials.py
@@ -382,6 +382,57 @@ async def backfill_manufacturers(user: User = Depends(require_admin), db: Sessio
     return {"enriched_records": count}
 
 
+# -- Part Number Import -------------------------------------------------------
+
+
+@router.post("/api/materials/import-part-numbers")
+async def import_part_numbers(request: Request, user: User = Depends(require_buyer), db: Session = Depends(get_db)):
+    """Import a bare list of part numbers (one MPN per row) as MaterialCards.
+
+    Accepts CSV/XLSX/TSV and HTML-table-as-.xls. Creates bare cards
+    (enrichment_status='unenriched'); enrichment runs separately.
+    """
+    import os as _os
+
+    from ..file_utils import extract_mpns, parse_tabular_file
+    from ..search_service import resolve_material_card
+
+    form = await request.form()
+    file = form.get("file")
+    if not file:
+        raise HTTPException(400, "No file uploaded")
+    ext = _os.path.splitext(file.filename or "")[1].lower()
+    if ext not in {".csv", ".xlsx", ".xls", ".tsv"}:
+        raise HTTPException(400, f"Invalid file type '{ext}'")
+    content = await file.read()
+    if len(content) > 10_000_000:
+        raise HTTPException(413, "File too large -- 10MB maximum")
+
+    rows = parse_tabular_file(content, file.filename or "")
+    mpns = extract_mpns(rows)
+    if not mpns:
+        raise HTTPException(400, "No part numbers found in file")
+
+    created = existing = skipped = 0
+    for mpn in mpns:
+        card = resolve_material_card(mpn, db)
+        if card is None:
+            skipped += 1
+            continue
+        # resolve_material_card logs created vs resolved; detect new by enrichment_status default
+        if card.enrichment_status == "unenriched" and card.enriched_at is None and card.search_count == 0:
+            created += 1
+        else:
+            existing += 1
+    db.commit()
+    return {
+        "created": created,
+        "existing": existing,
+        "skipped": skipped,
+        "total_rows": len(mpns),
+    }
+
+
 # -- Standalone Stock Import ---------------------------------------------------
 
 

--- a/app/services/ai_inference_fallback.py
+++ b/app/services/ai_inference_fallback.py
@@ -1,0 +1,82 @@
+"""Flagged best-effort inference for parts no authoritative source resolves.
+
+Uses Claude Opus 4.8 (model_tier="opus") with a strict refusal rule. Produces ONLY
+description + category — never structured specs (lifecycle/package/pins/rohs), because
+guessing those is the dangerous kind of hallucination. Confidence below threshold or
+empty description => not_found (no guess kept).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loguru import logger
+
+from app.utils.claude_client import claude_structured
+
+_MIN_CONFIDENCE = 0.5
+
+_SYSTEM = (
+    "You are an expert electronic-component engineer. You are given a single "
+    "manufacturer or OEM part number with NO other context. Identify the part ONLY "
+    "if you genuinely recognize it. It is correct and expected to decline for "
+    "obscure OEM/FRU/service part numbers you do not actually know.\n"
+    "Rules:\n"
+    "- description: 1 concise sentence of what the part is. Empty string if not confident.\n"
+    "- category: a short commodity category (e.g. 'Capacitor', 'Connector', 'Memory Module'). "
+    "Empty string if not confident.\n"
+    "- confidence: 0.0-1.0, your honest probability that this description is correct.\n"
+    "- NEVER invent a plausible-sounding description. When unsure, return empty strings and low confidence."
+)
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "description": {"type": "string"},
+        "category": {"type": "string"},
+        "confidence": {"type": "number"},
+    },
+    "required": ["description", "category", "confidence"],
+}
+
+
+@dataclass
+class InferenceResult:
+    status: str  # "ai_inferred" | "not_found"
+    description: str | None
+    category: str | None
+    confidence: float
+
+
+async def infer_part(display_mpn: str) -> InferenceResult:
+    """Infer part description and category from a part number using Claude Opus.
+
+    Args:
+        display_mpn: The manufacturer part number to look up.
+
+    Returns:
+        InferenceResult with status "ai_inferred" if confident, "not_found" otherwise.
+    """
+    prompt = f"Part number: {display_mpn}"
+    try:
+        data = await claude_structured(
+            prompt,
+            _SCHEMA,
+            system=_SYSTEM,
+            model_tier="opus",
+            max_tokens=300,
+        )
+    except Exception as e:
+        logger.warning("AI_INFER: claude error for {}: {}", display_mpn, type(e).__name__)
+        data = None
+
+    if not data:
+        return InferenceResult("not_found", None, None, 0.0)
+
+    desc = (data.get("description") or "").strip()
+    cat = (data.get("category") or "").strip()
+    conf = float(data.get("confidence") or 0.0)
+
+    if not desc or conf < _MIN_CONFIDENCE:
+        return InferenceResult("not_found", None, None, conf)
+    return InferenceResult("ai_inferred", desc, cat or None, conf)

--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -37,11 +37,6 @@ CORE_FIELDS = [
 _ADEQUATE = ("description", "manufacturer", "category")
 
 
-def _source_of(hit: dict) -> str:
-    st = str(hit.get("source_type", "")).lower()
-    return _SOURCE_TYPE_ALIASES.get(st, st)
-
-
 def merge_authoritative(
     normalized_mpn: str, results_by_source: dict[str, list[dict]]
 ) -> tuple[dict[str, Any], dict[str, Any], list[str]]:

--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -1,0 +1,127 @@
+"""Verified, source-attributed enrichment for MaterialCards.
+
+Queries existing connectors in cost-optimized priority order, accepts a source's data
+ONLY on an exact normalized-MPN match, and merges core attributes first-non-null-by-
+priority while recording per-field provenance. Parts with no authoritative hit fall
+through to a flagged Opus 4.8 inference (see ai_inference_fallback) — never a silent
+guess.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard
+from app.utils.normalization import normalize_mpn_key
+
+# Cost-optimized: free distributor APIs first, paid Nexar last (gaps only).
+SOURCE_ORDER = ["digikey", "mouser", "element14", "oemsecrets", "nexar"]
+# Nexar source_type is reported as "octopart" by its connector.
+_SOURCE_TYPE_ALIASES = {"octopart": "nexar"}
+
+CORE_FIELDS = [
+    "description",
+    "manufacturer",
+    "category",
+    "lifecycle_status",
+    "package_type",
+    "rohs_status",
+    "pin_count",
+    "datasheet_url",
+]
+# A part is "adequately resolved" (skip paid Nexar) once these are present.
+_ADEQUATE = ("description", "manufacturer", "category")
+
+
+def _source_of(hit: dict) -> str:
+    st = str(hit.get("source_type", "")).lower()
+    return _SOURCE_TYPE_ALIASES.get(st, st)
+
+
+def merge_authoritative(
+    normalized_mpn: str, results_by_source: dict[str, list[dict]]
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    """Merge connector results into (fields, provenance, contributors).
+
+    Only exact normalized-MPN matches are considered. For each CORE_FIELD, the first
+    source (in SOURCE_ORDER) with a non-null value wins.
+    """
+    merged: dict[str, Any] = {}
+    provenance: dict[str, Any] = {}
+    contributors: list[str] = []
+    now = datetime.now(timezone.utc).isoformat()
+
+    for source in SOURCE_ORDER:
+        hits = results_by_source.get(source) or []
+        exact = [h for h in hits if normalize_mpn_key(h.get("mpn_matched")) == normalized_mpn]
+        if not exact:
+            continue
+        contributed = False
+        for hit in exact:
+            for field in CORE_FIELDS:
+                if field in merged:
+                    continue
+                val = hit.get(field)
+                if val is None or (isinstance(val, str) and not val.strip()):
+                    continue
+                merged[field] = val
+                provenance[field] = {
+                    "source": source,
+                    "confidence": 1.0,
+                    "fetched_at": now,
+                    "matched_mpn": hit.get("mpn_matched"),
+                }
+                contributed = True
+        if contributed and source not in contributors:
+            contributors.append(source)
+    return merged, provenance, contributors
+
+
+def _connectors_in_order(db: Session) -> list:
+    """Return enabled connectors filtered + ordered to SOURCE_ORDER."""
+    from app.search_service import _build_connectors
+
+    conns, _, _ = _build_connectors(db)
+    by_name = {}
+    for c in conns:
+        name = _SOURCE_TYPE_ALIASES.get(c.source_name, c.source_name)
+        by_name.setdefault(name, c)
+    return [by_name[n] for n in SOURCE_ORDER if n in by_name]
+
+
+async def fetch_authoritative(display_mpn: str, normalized_mpn: str, connectors: list) -> dict[str, list[dict]]:
+    """Query connectors in priority order; short-circuit before paid Nexar once
+    adequate."""
+    results: dict[str, list[dict]] = {}
+    for conn in connectors:
+        name = _SOURCE_TYPE_ALIASES.get(conn.source_name, conn.source_name)
+        if name == "nexar":
+            merged, _, _ = merge_authoritative(normalized_mpn, results)
+            if all(f in merged for f in _ADEQUATE):
+                logger.debug("AUTH_ENRICH: {} adequately resolved, skipping nexar", normalized_mpn)
+                break
+        try:
+            results[name] = await conn.search(display_mpn)
+        except Exception as e:  # connector-level failure is non-fatal for this MPN
+            logger.warning("AUTH_ENRICH: {} failed for {}: {}", name, normalized_mpn, type(e).__name__)
+            results[name] = []
+    return results
+
+
+def apply_authoritative(
+    card: MaterialCard,
+    merged: dict,
+    provenance: dict,
+    contributors: list[str],
+) -> None:
+    """Write merged authoritative fields + provenance onto the card."""
+    for field, value in merged.items():
+        setattr(card, field, value)
+    card.enrichment_provenance = provenance
+    card.enrichment_source = contributors[0] if contributors else card.enrichment_source
+    card.enrichment_status = "verified"
+    card.enriched_at = datetime.now(timezone.utc)

--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -16,6 +16,7 @@ from typing import Any
 from loguru import logger
 from sqlalchemy.orm import Session
 
+from app.connectors.errors import ConnectorAuthError, ConnectorQuotaError
 from app.models import MaterialCard
 from app.utils.normalization import normalize_mpn_key
 
@@ -89,12 +90,24 @@ def _connectors_in_order(db: Session) -> list:
     return [by_name[n] for n in SOURCE_ORDER if n in by_name]
 
 
-async def fetch_authoritative(display_mpn: str, normalized_mpn: str, connectors: list) -> dict[str, list[dict]]:
+async def fetch_authoritative(
+    display_mpn: str,
+    normalized_mpn: str,
+    connectors: list,
+    disabled: set[str] | None = None,
+) -> dict[str, list[dict]]:
     """Query connectors in priority order; short-circuit before paid Nexar once
-    adequate."""
+    adequate.
+
+    A source that hits a quota or auth wall is added to ``disabled`` and skipped
+    for the rest of the run (so we don't keep burning failed calls), and surfaced
+    loudly. Transient per-MPN failures are logged and treated as no result.
+    """
     results: dict[str, list[dict]] = {}
     for conn in connectors:
         name = _SOURCE_TYPE_ALIASES.get(conn.source_name, conn.source_name)
+        if disabled is not None and name in disabled:
+            continue
         if name == "nexar":
             merged, _, _ = merge_authoritative(normalized_mpn, results)
             if all(f in merged for f in _ADEQUATE):
@@ -102,7 +115,13 @@ async def fetch_authoritative(display_mpn: str, normalized_mpn: str, connectors:
                 break
         try:
             results[name] = await conn.search(display_mpn)
-        except Exception as e:  # connector-level failure is non-fatal for this MPN
+        except (ConnectorQuotaError, ConnectorAuthError) as e:
+            # Source is unusable for the rest of the run — disable + surface loudly.
+            if disabled is not None:
+                disabled.add(name)
+            logger.error("AUTH_ENRICH: {} DISABLED for run ({}): {}", name, type(e).__name__, e)
+            results[name] = []
+        except Exception as e:  # transient connector failure — non-fatal for this MPN
             logger.warning("AUTH_ENRICH: {} failed for {}: {}", name, normalized_mpn, type(e).__name__)
             results[name] = []
     return results
@@ -123,16 +142,24 @@ def apply_authoritative(
     card.enriched_at = datetime.now(timezone.utc)
 
 
-async def enrich_card(card: MaterialCard, db: Session, *, connectors: list | None = None, refresh: bool = False) -> str:
+async def enrich_card(
+    card: MaterialCard,
+    db: Session,
+    *,
+    connectors: list | None = None,
+    refresh: bool = False,
+    disabled: set[str] | None = None,
+) -> str:
     """Enrich one card: authoritative -> flagged AI inference -> not_found.
 
     Returns the resulting enrichment_status. Does not commit (caller controls txn).
+    ``disabled`` accumulates sources that hit a quota/auth wall (skipped run-wide).
     """
     if card.enrichment_status == "verified" and not refresh:
         return "verified"
 
     conns = connectors if connectors is not None else _connectors_in_order(db)
-    results = await fetch_authoritative(card.display_mpn, card.normalized_mpn, conns)
+    results = await fetch_authoritative(card.display_mpn, card.normalized_mpn, conns, disabled)
     merged, provenance, contributors = merge_authoritative(card.normalized_mpn, results)
 
     if merged:
@@ -170,6 +197,7 @@ async def enrich_cards(card_ids: list[int], db: Session, *, concurrency: int = 5
     Commits in batches of 50.
     """
     conns = _connectors_in_order(db)
+    disabled: set[str] = set()
     sem = asyncio.Semaphore(concurrency)
     counts = {"verified": 0, "ai_inferred": 0, "not_found": 0}
 
@@ -178,7 +206,7 @@ async def enrich_cards(card_ids: list[int], db: Session, *, concurrency: int = 5
         if card is None:
             return
         async with sem:
-            status = await enrich_card(card, db, connectors=conns, refresh=refresh)
+            status = await enrich_card(card, db, connectors=conns, refresh=refresh, disabled=disabled)
         counts[status] = counts.get(status, 0) + 1
 
     for i in range(0, len(card_ids), 50):
@@ -186,4 +214,7 @@ async def enrich_cards(card_ids: list[int], db: Session, *, concurrency: int = 5
         await asyncio.gather(*(_one(c) for c in batch))
         db.commit()
         logger.info("AUTH_ENRICH: committed {}/{} cards", min(i + 50, len(card_ids)), len(card_ids))
+    if disabled:
+        counts["disabled_sources"] = sorted(disabled)
+        logger.error("AUTH_ENRICH: sources disabled this run (quota/auth): {}", sorted(disabled))
     return counts

--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -9,6 +9,7 @@ guess.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from typing import Any
 
@@ -120,3 +121,69 @@ def apply_authoritative(
     card.enrichment_source = contributors[0] if contributors else card.enrichment_source
     card.enrichment_status = "verified"
     card.enriched_at = datetime.now(timezone.utc)
+
+
+async def enrich_card(card: MaterialCard, db: Session, *, connectors: list | None = None, refresh: bool = False) -> str:
+    """Enrich one card: authoritative -> flagged AI inference -> not_found.
+
+    Returns the resulting enrichment_status. Does not commit (caller controls txn).
+    """
+    if card.enrichment_status == "verified" and not refresh:
+        return "verified"
+
+    conns = connectors if connectors is not None else _connectors_in_order(db)
+    results = await fetch_authoritative(card.display_mpn, card.normalized_mpn, conns)
+    merged, provenance, contributors = merge_authoritative(card.normalized_mpn, results)
+
+    if merged:
+        apply_authoritative(card, merged, provenance, contributors)
+        return "verified"
+
+    # No authoritative hit -> flagged inference
+    from app.services.ai_inference_fallback import infer_part
+
+    inf = await infer_part(card.display_mpn)
+    now = datetime.now(timezone.utc)
+    card.enriched_at = now
+    if inf.status == "ai_inferred":
+        card.description = inf.description
+        card.category = inf.category
+        card.enrichment_source = "claude_opus_inferred"
+        card.enrichment_status = "ai_inferred"
+        card.enrichment_provenance = {
+            "description": {
+                "source": "claude_opus_inferred",
+                "confidence": inf.confidence,
+                "fetched_at": now.isoformat(),
+            }
+        }
+        return "ai_inferred"
+
+    card.enrichment_status = "not_found"
+    card.enrichment_source = card.enrichment_source or "claude_opus_inferred"
+    return "not_found"
+
+
+async def enrich_cards(card_ids: list[int], db: Session, *, concurrency: int = 5, refresh: bool = False) -> dict:
+    """Enrich many cards with bounded concurrency.
+
+    Commits in batches of 50.
+    """
+    conns = _connectors_in_order(db)
+    sem = asyncio.Semaphore(concurrency)
+    counts = {"verified": 0, "ai_inferred": 0, "not_found": 0}
+
+    async def _one(cid: int) -> None:
+        card = db.get(MaterialCard, cid)
+        if card is None:
+            return
+        async with sem:
+            status = await enrich_card(card, db, connectors=conns, refresh=refresh)
+        counts[status] = counts.get(status, 0) + 1
+
+    for i in range(0, len(card_ids), 50):
+        batch = card_ids[i : i + 50]
+        await asyncio.gather(*(_one(c) for c in batch))
+        db.commit()
+        logger.info("AUTH_ENRICH: committed {}/{} cards", min(i + 50, len(card_ids)), len(card_ids))
+    return counts

--- a/app/services/faceted_search_service.py
+++ b/app/services/faceted_search_service.py
@@ -159,6 +159,7 @@ def search_materials_faceted(
     q: str | None = None,
     sub_filters: dict | None = None,
     manufacturers: list[str] | None = None,
+    verified_only: bool = False,
     limit: int = 50,
     offset: int = 0,
 ) -> tuple[list[MaterialCard], int]:
@@ -168,6 +169,8 @@ def search_materials_faceted(
         commodity: Filter by commodity category (lowercased)
         q: Text search on MPN/manufacturer/description
         sub_filters: {spec_key: [values]} for enums, {spec_key_min: val} for ranges
+        manufacturers: Restrict to these manufacturer names
+        verified_only: When True, return only cards with enrichment_status == "verified"
         limit: Max results
         offset: Pagination offset
 
@@ -215,6 +218,9 @@ def search_materials_faceted(
 
     if manufacturers:
         query = query.filter(MaterialCard.manufacturer.in_(manufacturers))
+
+    if verified_only:
+        query = query.filter(MaterialCard.enrichment_status == "verified")
 
     if sub_filters and commodity:
         commodity_lower = commodity.lower().strip()

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -553,6 +553,7 @@ Alpine.data('materialsFilter', () => ({
   q: '',
   page: 0,
   drawerOpen: false,
+  verifiedOnly: false,
   _onPopstate: null,
 
   get commodityDisplayName() {
@@ -585,6 +586,7 @@ Alpine.data('materialsFilter', () => ({
       const params = new URLSearchParams(window.location.search);
       this.commodity = params.get('commodity') || '';
       this.q = params.get('q') || '';
+      this.verifiedOnly = params.get('verified_only') === 'true';
       const pageVal = parseInt(params.get('page') || '0', 10);
       this.page = isNaN(pageVal) ? 0 : pageVal;
       this.subFilters = {};
@@ -613,6 +615,7 @@ Alpine.data('materialsFilter', () => ({
       // Broken URL — reset to defaults
       this.commodity = '';
       this.q = '';
+      this.verifiedOnly = false;
       this.page = 0;
       this.subFilters = {};
     }
@@ -622,6 +625,7 @@ Alpine.data('materialsFilter', () => ({
     const params = new URLSearchParams();
     if (this.commodity) params.set('commodity', this.commodity);
     if (this.q) params.set('q', this.q);
+    if (this.verifiedOnly) params.set('verified_only', 'true'); else params.delete('verified_only');
     if (this.page > 0) params.set('page', this.page);
     for (const [key, val] of Object.entries(this.subFilters)) {
       if (Array.isArray(val) && val.length > 0) {

--- a/app/templates/htmx/partials/materials/list.html
+++ b/app/templates/htmx/partials/materials/list.html
@@ -25,6 +25,7 @@
           <th class="text-left">Manufacturer</th>
           <th class="text-left">Category</th>
           <th class="text-left">Lifecycle</th>
+          <th class="text-left">Status</th>
           <th class="text-right">Vendors</th>
           <th class="text-right">Best Price</th>
           <th class="text-left">Last Searched</th>
@@ -55,6 +56,27 @@
             {% if m.lifecycle_status %}
             <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border {{ lc_colors.get(m.lifecycle_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
               {{ m.lifecycle_status|upper }}
+            </span>
+            {% else %}
+            <span class="text-xs text-gray-400">--</span>
+            {% endif %}
+          </td>
+          <td>
+            {% set es = m.enrichment_status %}
+            {% if es == "verified" %}
+            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-emerald-50 text-emerald-700 border-emerald-200"
+                  title="Verified from {{ (m.enrichment_provenance or {}).get('description', {}).get('source', 'catalog') }}">
+              VERIFIED
+            </span>
+            {% elif es == "ai_inferred" %}
+            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-amber-50 text-amber-700 border-amber-200"
+                  title="AI-inferred — unverified, best-effort guess">
+              AI-INFERRED
+            </span>
+            {% elif es == "not_found" %}
+            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-gray-100 text-gray-500 border-gray-200"
+                  title="No authoritative source found this part">
+              NOT FOUND
             </span>
             {% else %}
             <span class="text-xs text-gray-400">--</span>

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -41,6 +41,17 @@
            hx-swap="innerHTML">
       </div>
 
+      {# Verified only toggle #}
+      <div class="mb-3">
+        <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
+          <input type="checkbox"
+                 :checked="verifiedOnly"
+                 @change="verifiedOnly = !verifiedOnly; applyFilters()"
+                 class="rounded border-gray-300 text-emerald-600 focus:ring-emerald-500 h-3.5 w-3.5">
+          <span class="text-gray-700 font-medium">Verified only</span>
+        </label>
+      </div>
+
       {# "All Materials" button #}
       <button @click="selectCommodity(null)"
               :class="!commodity ? 'bg-brand-50 text-brand-700 font-medium border-l-2 border-brand-500' : 'text-gray-600 hover:bg-gray-50 border-l-2 border-transparent'"
@@ -171,6 +182,7 @@
            "commodity": Alpine.evaluate(document.querySelector("#materials-workspace"), "commodity") || "",
            "q": Alpine.evaluate(document.querySelector("#materials-workspace"), "q") || "",
            "sub_filters": JSON.stringify(Alpine.evaluate(document.querySelector("#materials-workspace"), "subFilters") || {}),
+           "verified_only": Alpine.evaluate(document.querySelector("#materials-workspace"), "verifiedOnly") || false,
            "limit": 50,
            "offset": Alpine.evaluate(document.querySelector("#materials-workspace"), "page") * 50 || 0
          }'

--- a/app/utils/claude_client.py
+++ b/app/utils/claude_client.py
@@ -42,7 +42,7 @@ API_VERSION = "2023-06-01"
 MODELS = {
     "fast": "claude-haiku-4-5-20251001",
     "smart": settings.anthropic_model or "claude-sonnet-4-6",
-    "opus": "claude-opus-4-7",
+    "opus": "claude-opus-4-8",
 }
 
 

--- a/docs/superpowers/plans/2026-06-04-verified-material-enrichment.md
+++ b/docs/superpowers/plans/2026-06-04-verified-material-enrichment.md
@@ -1,0 +1,1551 @@
+# Verified Material Enrichment + Part-Number Import — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Import a bare list of part numbers into availai `material_cards` and enrich each with core attributes from authoritative catalog sources (with per-field provenance), flagging anything we can't verify as AI-inferred or not-found — so nothing is ever a silent guess.
+
+**Architecture:** A new `authoritative_enrichment_service` queries existing connectors (DigiKey → Mouser → Element14 → OEMSecrets → Nexar, gaps only) via `BaseConnector.search()`, accepts a source's data only on an exact normalized-MPN match, merges core fields first-non-null-by-priority while recording provenance, and falls back to a flagged Claude Opus 4.8 inference (`description`+`category` only) for parts no source resolves. Two new `material_cards` columns (`enrichment_status`, `enrichment_provenance`) make verified/inferred a first-class, filterable property. A new import endpoint + script (handling the HTML-table-as-`.xls` format) creates bare cards and runs the pipeline dry-run-first.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 (sync), PostgreSQL (SQLite in tests), Alembic, Jinja2 + HTMX + Alpine.js + Tailwind, pytest, the house Anthropic wrapper `app/utils/claude_client.py`.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-verified-material-enrichment-design.md`
+
+**Branch:** `feat/verified-material-enrichment` (already created off `main`; spec already committed as `91e54784`).
+
+**Conventions for every task:**
+- Run tests with `python3 -m pytest` (the bare `python` is not on PATH).
+- Before each commit: `pre-commit run --files <changed files>` must pass (ruff, ruff-format, mypy, docformatter).
+- Commit after each task with a `type(scope): summary` message + the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer.
+
+---
+
+## File Structure
+
+**Create:**
+- `alembic/versions/a1f7c2d9e4b8_add_material_enrichment_status_provenance.py` — migration for the two new columns.
+- `app/services/authoritative_enrichment_service.py` — source-priority merge + provenance + exact-match guard + orchestration.
+- `app/services/ai_inference_fallback.py` — flagged Opus 4.8 inference (description+category only).
+- `scripts/import_part_numbers.py` — one-time/ops importer with dry-run coverage report.
+- `tests/test_authoritative_enrichment.py`, `tests/test_ai_inference_fallback.py`, `tests/test_part_number_import.py`, `tests/test_material_enrichment_status_filter.py`, `tests/test_html_table_parse.py`.
+
+**Modify:**
+- `app/models/intelligence.py` — add `enrichment_status`, `enrichment_provenance` to `MaterialCard`.
+- `app/utils/claude_client.py:45` — bump `MODELS["opus"]` to `claude-opus-4-8`.
+- `app/connectors/digikey.py`, `mouser.py`, `element14.py`, `oemsecrets.py`, `app/connectors/sources.py` (NexarConnector) — add optional core-attribute keys to result dicts.
+- `app/file_utils.py` — add `_parse_html_table()` + HTML sniff in `parse_tabular_file()` + `extract_mpns()`.
+- `app/routers/materials.py` — new `POST /api/materials/import-part-numbers` endpoint.
+- `app/services/faceted_search_service.py:155` — add `verified_only` param.
+- `app/routers/htmx_views.py:7197` — add `verified_only` query param to `materials_faceted_partial`.
+- `app/templates/htmx/partials/materials/list.html`, `workspace.html`, `app/static/htmx_app.js` — status badge + "Verified only" toggle.
+- `docs/APP_MAP_DATABASE.md`, `docs/APP_MAP_ARCHITECTURE.md`, `docs/APP_MAP_INTERACTIONS.md` — document the changes.
+
+---
+
+## Task 1: DB migration + model columns
+
+**Files:**
+- Modify: `app/models/intelligence.py` (after `enriched_at`, ~line 50)
+- Create: `alembic/versions/a1f7c2d9e4b8_add_material_enrichment_status_provenance.py`
+- Test: `tests/test_authoritative_enrichment.py` (first test only)
+
+- [ ] **Step 1: Add columns to the model**
+
+In `app/models/intelligence.py`, immediately after the `enriched_at = Column(UTCDateTime)` line, add:
+
+```python
+    # Verification provenance (added 2026-06-04 — verified-enrichment feature)
+    # enrichment_status: "unenriched" | "verified" | "ai_inferred" | "not_found"
+    enrichment_status = Column(String(20), nullable=False, server_default="unenriched", index=True)
+    # Per-field provenance: {"<field>": {"source": "digikey", "confidence": 1.0,
+    #                                    "fetched_at": "2026-06-04T..Z", "matched_mpn": "..."}}
+    enrichment_provenance = Column(JSONB)
+```
+
+(`String`, `Column`, `JSONB` are already imported in this file.)
+
+- [ ] **Step 2: Write the failing model test**
+
+Create `tests/test_authoritative_enrichment.py`:
+
+```python
+from datetime import datetime, timezone
+
+from app.models import MaterialCard
+
+
+def test_new_card_defaults_to_unenriched(db_session):
+    card = MaterialCard(
+        normalized_mpn="teststatusdefault",
+        display_mpn="TEST-STATUS-DEFAULT",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(card)
+    db_session.flush()
+    db_session.refresh(card)
+    assert card.enrichment_status == "unenriched"
+    assert card.enrichment_provenance is None
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `python3 -m pytest tests/test_authoritative_enrichment.py::test_new_card_defaults_to_unenriched -v`
+Expected: FAIL — `AttributeError`/`no such column enrichment_status` (model/test DB not yet updated). (Test DB is created from models, so this passes only once Step 1 is in; if it already passes after Step 1, that confirms the model change.)
+
+- [ ] **Step 4: Create the migration**
+
+Create `alembic/versions/a1f7c2d9e4b8_add_material_enrichment_status_provenance.py`:
+
+```python
+"""Add material_cards.enrichment_status and enrichment_provenance.
+
+enrichment_status (VARCHAR 20, NOT NULL, server_default 'unenriched', indexed)
+marks a card as unenriched | verified | ai_inferred | not_found.
+enrichment_provenance (JSONB, nullable) records per-field source attribution.
+
+Revision ID: a1f7c2d9e4b8
+Revises: 086_add_activity_digest
+Create Date: 2026-06-04 22:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a1f7c2d9e4b8"
+down_revision: Union[str, None] = "086_add_activity_digest"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "material_cards",
+        sa.Column(
+            "enrichment_status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="unenriched",
+        ),
+    )
+    op.add_column(
+        "material_cards",
+        sa.Column("enrichment_provenance", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.create_index(
+        "ix_material_cards_enrichment_status",
+        "material_cards",
+        ["enrichment_status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_material_cards_enrichment_status", table_name="material_cards")
+    op.execute("ALTER TABLE IF EXISTS material_cards DROP COLUMN IF EXISTS enrichment_provenance")
+    op.execute("ALTER TABLE IF EXISTS material_cards DROP COLUMN IF EXISTS enrichment_status")
+```
+
+- [ ] **Step 5: Verify the model test passes + migration round-trips**
+
+Run: `python3 -m pytest tests/test_authoritative_enrichment.py::test_new_card_defaults_to_unenriched -v`
+Expected: PASS.
+
+Run (migration round-trip against a Postgres dev DB if available; skip if tests use SQLite only):
+`PYTHONPATH=/root/availai alembic upgrade head && PYTHONPATH=/root/availai alembic downgrade -1 && PYTHONPATH=/root/availai alembic upgrade head`
+Expected: no errors; `alembic heads` now shows `a1f7c2d9e4b8`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+pre-commit run --files app/models/intelligence.py alembic/versions/a1f7c2d9e4b8_add_material_enrichment_status_provenance.py tests/test_authoritative_enrichment.py
+git add app/models/intelligence.py alembic/versions/a1f7c2d9e4b8_add_material_enrichment_status_provenance.py tests/test_authoritative_enrichment.py
+git commit -m "feat(materials): add enrichment_status + enrichment_provenance columns
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Connector core-attribute extraction
+
+Connectors today return only `manufacturer`/`description`/`datasheet_url` (+ price/stock). Extend each to *additionally* surface `category`, `lifecycle_status`, `package_type`, `pin_count`, `rohs_status` as **optional** keys (None when absent) — additive, so existing search behavior is untouched.
+
+> ⚠️ The exact raw API field names below are from API docs, not a captured response. Step 1 verifies them against real responses before relying on them.
+
+**Files:**
+- Modify: `app/connectors/digikey.py`, `mouser.py`, `element14.py`, `oemsecrets.py`, `app/connectors/sources.py`
+- Create: `app/connectors/_core_attrs.py` (shared normalization helpers)
+- Test: `tests/test_connector_core_attrs.py`
+
+- [ ] **Step 1: Probe real responses to confirm field names**
+
+Run a one-off probe (delete after) for a known catalog MPN to capture the raw JSON keys for DigiKey and Nexar:
+
+```bash
+cd /root/availai && PYTHONPATH=/root/availai python3 - <<'PY'
+import asyncio, json
+from app.database import SessionLocal
+from app.search_service import _build_connectors
+db = SessionLocal()
+conns, _, _ = _build_connectors(db)
+async def main():
+    for c in conns:
+        if c.source_name in ("digikey", "nexar"):
+            hits = await c.search("STM32F407VGT6")
+            print(c.source_name, "->", len(hits), "hits")
+            if hits:
+                print(json.dumps(hits[0], indent=2, default=str)[:1500])
+asyncio.run(main())
+db.close()
+PY
+```
+
+Record the actual key names (e.g. DigiKey `ProductStatus.Status`, `Category.Name`, `Parameters[].ParameterText/ValueText`). If they differ from the mapping in Step 3, adjust Step 3 accordingly. **Do not commit this probe.**
+
+- [ ] **Step 2: Write the shared normalizer + failing test**
+
+Create `app/connectors/_core_attrs.py`:
+
+```python
+"""Shared helpers to normalize connector core attributes into MaterialCard vocab.
+
+Core attributes: category, lifecycle_status, package_type, pin_count, rohs_status.
+All helpers return None when the input is missing/unmappable — never a guess.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# DigiKey ProductStatus / generic distributor lifecycle text -> MaterialCard lifecycle_status
+_LIFECYCLE_MAP = {
+    "active": "active",
+    "obsolete": "obsolete",
+    "discontinued": "obsolete",
+    "not for new designs": "nrfnd",
+    "nrnd": "nrfnd",
+    "last time buy": "ltb",
+    "end of life": "eol",
+    "eol": "eol",
+}
+
+_ROHS_MAP = {
+    "rohs compliant": "compliant",
+    "compliant": "compliant",
+    "rohs3 compliant": "compliant",
+    "non-compliant": "non-compliant",
+    "not compliant": "non-compliant",
+    "rohs exempt": "exempt",
+    "exempt": "exempt",
+}
+
+
+def map_lifecycle(raw: Any) -> str | None:
+    if not raw:
+        return None
+    return _LIFECYCLE_MAP.get(str(raw).strip().lower())
+
+
+def map_rohs(raw: Any) -> str | None:
+    if not raw:
+        return None
+    return _ROHS_MAP.get(str(raw).strip().lower())
+
+
+def clean_str(raw: Any, *, maxlen: int) -> str | None:
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s[:maxlen] if s else None
+
+
+def safe_pin_count(raw: Any) -> int | None:
+    try:
+        v = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    return v if v > 0 else None
+
+
+def digikey_parameter(params: Any, names: tuple[str, ...]) -> str | None:
+    """Extract a ValueText from DigiKey Parameters[] by ParameterText match."""
+    if not isinstance(params, list):
+        return None
+    wanted = {n.lower() for n in names}
+    for p in params:
+        if isinstance(p, dict) and str(p.get("ParameterText", "")).strip().lower() in wanted:
+            val = str(p.get("ValueText", "")).strip()
+            if val and val != "-":
+                return val
+    return None
+```
+
+Create `tests/test_connector_core_attrs.py`:
+
+```python
+from app.connectors._core_attrs import (
+    digikey_parameter,
+    map_lifecycle,
+    map_rohs,
+    safe_pin_count,
+)
+
+
+def test_lifecycle_mapping():
+    assert map_lifecycle("Active") == "active"
+    assert map_lifecycle("Not For New Designs") == "nrfnd"
+    assert map_lifecycle("Obsolete") == "obsolete"
+    assert map_lifecycle("totally unknown status") is None
+    assert map_lifecycle(None) is None
+
+
+def test_rohs_mapping():
+    assert map_rohs("ROHS Compliant") == "compliant"
+    assert map_rohs("Non-Compliant") == "non-compliant"
+    assert map_rohs("weird") is None
+
+
+def test_pin_count():
+    assert safe_pin_count("64") == 64
+    assert safe_pin_count("0") is None
+    assert safe_pin_count("abc") is None
+
+
+def test_digikey_parameter():
+    params = [
+        {"ParameterText": "Package / Case", "ValueText": "100-LQFP"},
+        {"ParameterText": "Number of I/O", "ValueText": "82"},
+    ]
+    assert digikey_parameter(params, ("Package / Case",)) == "100-LQFP"
+    assert digikey_parameter(params, ("Mounting Type",)) is None
+    assert digikey_parameter([], ("Package / Case",)) is None
+```
+
+- [ ] **Step 3: Run test to verify it fails, then it passes**
+
+Run: `python3 -m pytest tests/test_connector_core_attrs.py -v`
+Expected: PASS once `_core_attrs.py` exists (this module is pure logic; it should go green immediately).
+
+- [ ] **Step 4: Wire DigiKey extraction**
+
+In `app/connectors/digikey.py`, in the parse loop (where `results.append({...})` is built, ~line 147), before the append add:
+
+```python
+        from ._core_attrs import (
+            clean_str,
+            digikey_parameter,
+            map_lifecycle,
+            map_rohs,
+            safe_pin_count,
+        )
+
+        cat = prod.get("Category") or {}
+        category = clean_str(cat.get("Name") if isinstance(cat, dict) else cat, maxlen=255)
+        status = prod.get("ProductStatus") or {}
+        lifecycle = map_lifecycle(status.get("Status") if isinstance(status, dict) else status)
+        params = prod.get("Parameters")
+        package = clean_str(digikey_parameter(params, ("Package / Case", "Supplier Device Package")), maxlen=100)
+        pin_count = safe_pin_count(digikey_parameter(params, ("Number of Terminations", "Number of I/O", "Number of Pins")))
+        rohs = map_rohs((prod.get("Classifications") or {}).get("RohsStatus") if isinstance(prod.get("Classifications"), dict) else prod.get("RohsStatus"))
+```
+
+Then add these keys inside the result dict (after `"description": detail_desc,`):
+
+```python
+                    "category": category,
+                    "lifecycle_status": lifecycle,
+                    "package_type": package,
+                    "pin_count": pin_count,
+                    "rohs_status": rohs,
+```
+
+- [ ] **Step 5: Wire Mouser, Element14, OEMSecrets, Nexar**
+
+Apply the same additive pattern using each connector's raw fields (confirm names via Step 1 where uncertain). Add to each result dict, defaulting to `None`:
+
+- **`mouser.py`** (after `"description": desc,`): use `part.get("Category")`, `part.get("LifecycleStatus")`, `part.get("DataSheetUrl")` and `part.get("ProductAttributes")` (a list of `{AttributeName, AttributeValue}` — mirror `digikey_parameter` but for these keys).
+- **`element14.py`** (after the description key): `prod.get("attributes")` (Newark returns `[{attributeLabel, attributeValue}]`); map `RoHS`/`Package` labels; `prod.get("datasheets")`.
+- **`oemsecrets.py`** (after `"datasheet_url": datasheet,`): `item.get("category")`, `item.get("lifecycle_status")` (often absent — leave None).
+- **`sources.py` `NexarConnector`**: add `category { name }` to `FULL_QUERY`'s `part { ... }` selection (it is already in `AGGREGATE_QUERY`), and extract `category` in the full-query parse. Lifecycle/package/pin are not reliably in the Nexar schema — leave None unless Step 1 shows otherwise.
+
+Each new key is optional; downstream uses `.get()`, so missing keys are safe.
+
+- [ ] **Step 6: Test connector extraction with recorded responses**
+
+Add to `tests/test_connector_core_attrs.py` a test that feeds a recorded raw DigiKey `prod` dict (built from Step 1's capture) through the connector's parse path and asserts the new keys appear. Since `_do_search` performs HTTP, test the **pure extraction** by factoring the per-product mapping into a small module function if needed, or assert via a monkeypatched `httpx` response (see Task 3 mocking pattern). Minimum: assert `map_lifecycle`/`digikey_parameter` produce the expected values for the captured payload.
+
+Run: `python3 -m pytest tests/test_connector_core_attrs.py -v` → PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+pre-commit run --files app/connectors/_core_attrs.py app/connectors/digikey.py app/connectors/mouser.py app/connectors/element14.py app/connectors/oemsecrets.py app/connectors/sources.py tests/test_connector_core_attrs.py
+git add app/connectors/_core_attrs.py app/connectors/digikey.py app/connectors/mouser.py app/connectors/element14.py app/connectors/oemsecrets.py app/connectors/sources.py tests/test_connector_core_attrs.py
+git commit -m "feat(connectors): capture core attributes (category/lifecycle/package/pins/rohs)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Authoritative enrichment service (merge + provenance + exact-match guard)
+
+**Files:**
+- Create: `app/services/authoritative_enrichment_service.py`
+- Test: `tests/test_authoritative_enrichment.py` (add tests)
+
+- [ ] **Step 1: Write failing tests for the merge + guard**
+
+Add to `tests/test_authoritative_enrichment.py`:
+
+```python
+import pytest
+
+from app.services.authoritative_enrichment_service import (
+    CORE_FIELDS,
+    merge_authoritative,
+)
+
+
+def _hit(source, mpn="LM317T", **over):
+    base = {
+        "source_type": source,
+        "mpn_matched": mpn,
+        "manufacturer": "TI",
+        "description": f"desc from {source}",
+        "category": None,
+        "lifecycle_status": None,
+        "package_type": None,
+        "pin_count": None,
+        "rohs_status": None,
+        "datasheet_url": None,
+    }
+    base.update(over)
+    return base
+
+
+def test_exact_match_guard_rejects_mismatch():
+    # connector returned a DIFFERENT part — must be ignored
+    results = {"digikey": [_hit("digikey", mpn="LM317MT")]}
+    merged, prov, contributors = merge_authoritative("lm317t", results)
+    assert merged == {}
+    assert contributors == []
+
+
+def test_first_non_null_by_priority():
+    results = {
+        "mouser": [_hit("mouser", description="mouser desc", category="Linear")],
+        "digikey": [_hit("digikey", description="digikey desc", lifecycle_status="active")],
+    }
+    merged, prov, contributors = merge_authoritative("lm317t", results)
+    # digikey has higher priority -> its description wins
+    assert merged["description"] == "digikey desc"
+    assert prov["description"]["source"] == "digikey"
+    # category only present from mouser -> taken from mouser
+    assert merged["category"] == "Linear"
+    assert prov["category"]["source"] == "mouser"
+    assert merged["lifecycle_status"] == "active"
+    assert "digikey" in contributors and "mouser" in contributors
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_authoritative_enrichment.py -v`
+Expected: FAIL — `ModuleNotFoundError: authoritative_enrichment_service`.
+
+- [ ] **Step 3: Implement the service**
+
+Create `app/services/authoritative_enrichment_service.py`:
+
+```python
+"""Verified, source-attributed enrichment for MaterialCards.
+
+Queries existing connectors in cost-optimized priority order, accepts a source's
+data ONLY on an exact normalized-MPN match, and merges core attributes
+first-non-null-by-priority while recording per-field provenance. Parts with no
+authoritative hit fall through to a flagged Opus 4.8 inference (see
+ai_inference_fallback) — never a silent guess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard
+from app.utils.normalization import normalize_mpn_key
+
+# Cost-optimized: free distributor APIs first, paid Nexar last (gaps only).
+SOURCE_ORDER = ["digikey", "mouser", "element14", "oemsecrets", "nexar"]
+# Nexar source_type is reported as "octopart" by its connector.
+_SOURCE_TYPE_ALIASES = {"octopart": "nexar"}
+
+CORE_FIELDS = [
+    "description",
+    "manufacturer",
+    "category",
+    "lifecycle_status",
+    "package_type",
+    "rohs_status",
+    "pin_count",
+    "datasheet_url",
+]
+# A part is "adequately resolved" (skip paid Nexar) once these are present.
+_ADEQUATE = ("description", "manufacturer", "category")
+
+
+def _source_of(hit: dict) -> str:
+    st = str(hit.get("source_type", "")).lower()
+    return _SOURCE_TYPE_ALIASES.get(st, st)
+
+
+def merge_authoritative(
+    normalized_mpn: str, results_by_source: dict[str, list[dict]]
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    """Merge connector results into (fields, provenance, contributors).
+
+    Only exact normalized-MPN matches are considered. For each CORE_FIELD, the
+    first source (in SOURCE_ORDER) with a non-null value wins.
+    """
+    merged: dict[str, Any] = {}
+    provenance: dict[str, Any] = {}
+    contributors: list[str] = []
+    now = datetime.now(timezone.utc).isoformat()
+
+    for source in SOURCE_ORDER:
+        hits = results_by_source.get(source) or []
+        exact = [h for h in hits if normalize_mpn_key(h.get("mpn_matched")) == normalized_mpn]
+        if not exact:
+            continue
+        contributed = False
+        for hit in exact:
+            for field in CORE_FIELDS:
+                if field in merged:
+                    continue
+                val = hit.get(field)
+                if val is None or (isinstance(val, str) and not val.strip()):
+                    continue
+                merged[field] = val
+                provenance[field] = {
+                    "source": source,
+                    "confidence": 1.0,
+                    "fetched_at": now,
+                    "matched_mpn": hit.get("mpn_matched"),
+                }
+                contributed = True
+        if contributed and source not in contributors:
+            contributors.append(source)
+    return merged, provenance, contributors
+
+
+def _connectors_in_order(db: Session) -> list:
+    """Return enabled connectors filtered + ordered to SOURCE_ORDER."""
+    from app.search_service import _build_connectors
+
+    conns, _, _ = _build_connectors(db)
+    by_name = {}
+    for c in conns:
+        name = _SOURCE_TYPE_ALIASES.get(c.source_name, c.source_name)
+        by_name.setdefault(name, c)
+    return [by_name[n] for n in SOURCE_ORDER if n in by_name]
+
+
+async def fetch_authoritative(
+    display_mpn: str, normalized_mpn: str, connectors: list
+) -> dict[str, list[dict]]:
+    """Query connectors in priority order; short-circuit before paid Nexar once adequate."""
+    results: dict[str, list[dict]] = {}
+    for conn in connectors:
+        name = _SOURCE_TYPE_ALIASES.get(conn.source_name, conn.source_name)
+        if name == "nexar":
+            merged, _, _ = merge_authoritative(normalized_mpn, results)
+            if all(f in merged for f in _ADEQUATE):
+                logger.debug("AUTH_ENRICH: {} adequately resolved, skipping nexar", normalized_mpn)
+                break
+        try:
+            results[name] = await conn.search(display_mpn)
+        except Exception as e:  # connector-level failure is non-fatal for this MPN
+            logger.warning("AUTH_ENRICH: {} failed for {}: {}", name, normalized_mpn, type(e).__name__)
+            results[name] = []
+    return results
+
+
+def apply_authoritative(card: MaterialCard, merged: dict, provenance: dict, contributors: list[str]) -> None:
+    """Write merged authoritative fields + provenance onto the card."""
+    for field, value in merged.items():
+        setattr(card, field, value)
+    card.enrichment_provenance = provenance
+    card.enrichment_source = contributors[0] if contributors else card.enrichment_source
+    card.enrichment_status = "verified"
+    card.enriched_at = datetime.now(timezone.utc)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/test_authoritative_enrichment.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+pre-commit run --files app/services/authoritative_enrichment_service.py tests/test_authoritative_enrichment.py
+git add app/services/authoritative_enrichment_service.py tests/test_authoritative_enrichment.py
+git commit -m "feat(materials): authoritative enrichment merge with exact-match guard + provenance
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: AI inference fallback (Opus 4.8, flagged)
+
+**Files:**
+- Modify: `app/utils/claude_client.py:45`
+- Create: `app/services/ai_inference_fallback.py`
+- Test: `tests/test_ai_inference_fallback.py`
+
+- [ ] **Step 1: Bump the opus model tier to the best version**
+
+In `app/utils/claude_client.py`, change line 45:
+
+```python
+    "opus": "claude-opus-4-8",
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Create `tests/test_ai_inference_fallback.py`:
+
+```python
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.ai_inference_fallback import infer_part
+
+
+@pytest.mark.asyncio
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+async def test_confident_inference_returns_ai_inferred(mock_claude):
+    mock_claude.return_value = {
+        "description": "Linear voltage regulator, adjustable, TO-220",
+        "category": "Voltage Regulator",
+        "confidence": 0.8,
+    }
+    result = await infer_part("LM317T")
+    assert result.status == "ai_inferred"
+    assert result.description.startswith("Linear voltage regulator")
+    assert result.category == "Voltage Regulator"
+    # Opus must be requested
+    assert mock_claude.call_args.kwargs["model_tier"] == "opus"
+
+
+@pytest.mark.asyncio
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+async def test_declined_inference_returns_not_found(mock_claude):
+    mock_claude.return_value = {"description": "", "category": "", "confidence": 0.0}
+    result = await infer_part("04M3HJ")
+    assert result.status == "not_found"
+    assert result.description is None
+
+
+@pytest.mark.asyncio
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+async def test_null_response_returns_not_found(mock_claude):
+    mock_claude.return_value = None
+    result = await infer_part("ZZZ999")
+    assert result.status == "not_found"
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_ai_inference_fallback.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement the fallback**
+
+Create `app/services/ai_inference_fallback.py`:
+
+```python
+"""Flagged best-effort inference for parts no authoritative source resolves.
+
+Uses Claude Opus 4.8 (model_tier="opus") with a strict refusal rule. Produces
+ONLY description + category — never structured specs (lifecycle/package/pins/rohs),
+because guessing those is the dangerous kind of hallucination. Confidence below
+threshold or empty description => not_found (no guess kept).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loguru import logger
+
+from app.utils.claude_client import claude_structured
+
+_MIN_CONFIDENCE = 0.5
+
+_SYSTEM = (
+    "You are an expert electronic-component engineer. You are given a single "
+    "manufacturer or OEM part number with NO other context. Identify the part ONLY "
+    "if you genuinely recognize it. It is correct and expected to decline for "
+    "obscure OEM/FRU/service part numbers you do not actually know.\n"
+    "Rules:\n"
+    "- description: 1 concise sentence of what the part is. Empty string if not confident.\n"
+    "- category: a short commodity category (e.g. 'Capacitor', 'Connector', 'Memory Module'). "
+    "Empty string if not confident.\n"
+    "- confidence: 0.0-1.0, your honest probability that this description is correct.\n"
+    "- NEVER invent a plausible-sounding description. When unsure, return empty strings and low confidence."
+)
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "description": {"type": "string"},
+        "category": {"type": "string"},
+        "confidence": {"type": "number"},
+    },
+    "required": ["description", "category", "confidence"],
+}
+
+
+@dataclass
+class InferenceResult:
+    status: str  # "ai_inferred" | "not_found"
+    description: str | None
+    category: str | None
+    confidence: float
+
+
+async def infer_part(display_mpn: str) -> InferenceResult:
+    prompt = f"Part number: {display_mpn}"
+    try:
+        data = await claude_structured(
+            prompt,
+            _SCHEMA,
+            system=_SYSTEM,
+            model_tier="opus",
+            max_tokens=300,
+        )
+    except Exception as e:
+        logger.warning("AI_INFER: claude error for {}: {}", display_mpn, type(e).__name__)
+        data = None
+
+    if not data:
+        return InferenceResult("not_found", None, None, 0.0)
+
+    desc = (data.get("description") or "").strip()
+    cat = (data.get("category") or "").strip()
+    conf = float(data.get("confidence") or 0.0)
+
+    if not desc or conf < _MIN_CONFIDENCE:
+        return InferenceResult("not_found", None, None, conf)
+    return InferenceResult("ai_inferred", desc, cat or None, conf)
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `python3 -m pytest tests/test_ai_inference_fallback.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+pre-commit run --files app/utils/claude_client.py app/services/ai_inference_fallback.py tests/test_ai_inference_fallback.py
+git add app/utils/claude_client.py app/services/ai_inference_fallback.py tests/test_ai_inference_fallback.py
+git commit -m "feat(materials): Opus 4.8 flagged AI inference fallback (description+category only)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Orchestration — enrich one card end-to-end
+
+**Files:**
+- Modify: `app/services/authoritative_enrichment_service.py`
+- Test: `tests/test_authoritative_enrichment.py` (add)
+
+- [ ] **Step 1: Write failing orchestration tests**
+
+Add to `tests/test_authoritative_enrichment.py`:
+
+```python
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+from app.models import MaterialCard
+from app.services.authoritative_enrichment_service import enrich_card
+
+
+def _card(db_session, mpn="LM317T"):
+    from app.utils.normalization import normalize_mpn_key
+
+    c = MaterialCard(
+        normalized_mpn=normalize_mpn_key(mpn),
+        display_mpn=mpn,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(c)
+    db_session.flush()
+    return c
+
+
+class _FakeConn:
+    def __init__(self, source_name, hits):
+        self.source_name = source_name
+        self._hits = hits
+
+    async def search(self, pn):
+        return self._hits
+
+
+@patch("app.services.authoritative_enrichment_service._connectors_in_order")
+def test_enrich_card_verified(mock_conns, db_session):
+    card = _card(db_session)
+    mock_conns.return_value = [
+        _FakeConn("digikey", [{
+            "source_type": "digikey", "mpn_matched": "LM317T",
+            "manufacturer": "TI", "description": "Adjustable regulator",
+            "category": "Voltage Regulator", "lifecycle_status": "active",
+        }])
+    ]
+    import asyncio
+    asyncio.run(enrich_card(card, db_session))
+    assert card.enrichment_status == "verified"
+    assert card.manufacturer == "TI"
+    assert card.enrichment_provenance["description"]["source"] == "digikey"
+
+
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+@patch("app.services.authoritative_enrichment_service._connectors_in_order")
+def test_enrich_card_ai_inferred_when_no_authoritative(mock_conns, mock_claude, db_session):
+    card = _card(db_session, "04M3HJ")
+    mock_conns.return_value = [_FakeConn("digikey", [])]  # no hits anywhere
+    mock_claude.return_value = {"description": "Dell laptop bezel", "category": "Mechanical", "confidence": 0.7}
+    import asyncio
+    asyncio.run(enrich_card(card, db_session))
+    assert card.enrichment_status == "ai_inferred"
+    assert card.description == "Dell laptop bezel"
+    assert card.lifecycle_status is None  # never guessed
+
+
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+@patch("app.services.authoritative_enrichment_service._connectors_in_order")
+def test_enrich_card_not_found(mock_conns, mock_claude, db_session):
+    card = _card(db_session, "ZZ9PLURAL")
+    mock_conns.return_value = [_FakeConn("digikey", [])]
+    mock_claude.return_value = {"description": "", "category": "", "confidence": 0.0}
+    import asyncio
+    asyncio.run(enrich_card(card, db_session))
+    assert card.enrichment_status == "not_found"
+    assert card.description is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_authoritative_enrichment.py -v`
+Expected: FAIL — `enrich_card` not defined.
+
+- [ ] **Step 3: Implement `enrich_card` + batch driver**
+
+Append to `app/services/authoritative_enrichment_service.py`:
+
+```python
+async def enrich_card(card: MaterialCard, db: Session, *, connectors: list | None = None, refresh: bool = False) -> str:
+    """Enrich one card: authoritative -> flagged AI inference -> not_found.
+
+    Returns the resulting enrichment_status. Does not commit (caller controls txn).
+    """
+    if card.enrichment_status == "verified" and not refresh:
+        return "verified"
+
+    conns = connectors if connectors is not None else _connectors_in_order(db)
+    results = await fetch_authoritative(card.display_mpn, card.normalized_mpn, conns)
+    merged, provenance, contributors = merge_authoritative(card.normalized_mpn, results)
+
+    if merged:
+        apply_authoritative(card, merged, provenance, contributors)
+        return "verified"
+
+    # No authoritative hit -> flagged inference
+    from app.services.ai_inference_fallback import infer_part
+
+    inf = await infer_part(card.display_mpn)
+    now = datetime.now(timezone.utc)
+    card.enriched_at = now
+    if inf.status == "ai_inferred":
+        card.description = inf.description
+        card.category = inf.category
+        card.enrichment_source = "claude_opus_inferred"
+        card.enrichment_status = "ai_inferred"
+        card.enrichment_provenance = {
+            "description": {"source": "claude_opus_inferred", "confidence": inf.confidence, "fetched_at": now.isoformat()}
+        }
+        return "ai_inferred"
+
+    card.enrichment_status = "not_found"
+    card.enrichment_source = card.enrichment_source or "claude_opus_inferred"
+    return "not_found"
+
+
+async def enrich_cards(card_ids: list[int], db: Session, *, concurrency: int = 5, refresh: bool = False) -> dict:
+    """Enrich many cards with bounded concurrency. Commits in batches of 50."""
+    conns = _connectors_in_order(db)
+    sem = asyncio.Semaphore(concurrency)
+    counts = {"verified": 0, "ai_inferred": 0, "not_found": 0}
+
+    async def _one(cid: int) -> None:
+        card = db.query(MaterialCard).get(cid)
+        if card is None:
+            return
+        async with sem:
+            status = await enrich_card(card, db, connectors=conns, refresh=refresh)
+        counts[status] = counts.get(status, 0) + 1
+
+    for i in range(0, len(card_ids), 50):
+        batch = card_ids[i : i + 50]
+        await asyncio.gather(*(_one(c) for c in batch))
+        db.commit()
+        logger.info("AUTH_ENRICH: committed {}/{} cards", min(i + 50, len(card_ids)), len(card_ids))
+    return counts
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/test_authoritative_enrichment.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pre-commit run --files app/services/authoritative_enrichment_service.py tests/test_authoritative_enrichment.py
+git add app/services/authoritative_enrichment_service.py tests/test_authoritative_enrichment.py
+git commit -m "feat(materials): orchestrate per-card enrich (verified -> ai_inferred -> not_found)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: HTML-table parser + `parse_tabular_file` sniff + MPN extraction
+
+The input file is `text/html` with an `.xls` extension; `openpyxl` will fail on it. Add an HTML branch and a single-column MPN extractor.
+
+**Files:**
+- Modify: `app/file_utils.py`
+- Test: `tests/test_html_table_parse.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_html_table_parse.py`:
+
+```python
+from app.file_utils import extract_mpns, parse_tabular_file
+
+_HTML = (
+    b"<head><META http-equiv=\"Content-Type\" content=\"text/html; charset=ISO-8859-1\"></head>"
+    b"<table><tr><td>Material: Material Name</td></tr>"
+    b"<tr><td>M393A2K43EB3-CWEB/C</td></tr>"
+    b"<tr><td>04M3HJ</td></tr>"
+    b"<tr><td></td></tr>"
+    b"<tr><td>LTM8053IY#PBF</td></tr></table>"
+)
+
+
+def test_parse_html_disguised_as_xls():
+    rows = parse_tabular_file(_HTML, "report1780605266325.xls")
+    # header lowercased+stripped becomes the dict key
+    assert len(rows) == 3  # blank row dropped
+    assert rows[0]["material: material name"] == "M393A2K43EB3-CWEB/C"
+
+
+def test_extract_mpns_single_column():
+    rows = parse_tabular_file(_HTML, "report.xls")
+    mpns = extract_mpns(rows)
+    assert mpns == ["M393A2K43EB3-CWEB/C", "04M3HJ", "LTM8053IY#PBF"]
+
+
+def test_extract_mpns_named_column():
+    rows = [{"part number": "ABC123"}, {"part number": "DEF456"}]
+    assert extract_mpns(rows) == ["ABC123", "DEF456"]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_html_table_parse.py -v`
+Expected: FAIL — HTML not handled / `extract_mpns` undefined.
+
+- [ ] **Step 3: Implement HTML sniff + parser + extractor**
+
+In `app/file_utils.py`, add an HTML parser and route to it. Add near the other parsers:
+
+```python
+def _looks_like_html(content: bytes) -> bool:
+    head = content[:512].lstrip().lower()
+    return head.startswith((b"<head", b"<html", b"<table", b"<!doctype", b"<meta"))
+
+
+def _parse_html_table(content: bytes) -> list[dict]:
+    """Parse an HTML <table> export (e.g. ERP 'Excel' that is really HTML)."""
+    from html.parser import HTMLParser
+
+    class _T(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.rows: list[list[str]] = []
+            self._cur: list[str] | None = None
+            self._cell: list[str] | None = None
+
+        def handle_starttag(self, tag, attrs):
+            if tag == "tr":
+                self._cur = []
+            elif tag in ("td", "th"):
+                self._cell = []
+
+        def handle_endtag(self, tag):
+            if tag == "tr" and self._cur is not None:
+                self.rows.append(self._cur)
+                self._cur = None
+            elif tag in ("td", "th") and self._cell is not None and self._cur is not None:
+                self._cur.append("".join(self._cell).strip())
+                self._cell = None
+
+        def handle_data(self, data):
+            if self._cell is not None:
+                self._cell.append(data)
+
+    try:
+        text = content.decode("iso-8859-1")
+    except Exception:
+        text = content.decode("utf-8", errors="replace")
+    p = _T()
+    p.feed(text)
+    table = [r for r in p.rows if any(c.strip() for c in r)]
+    if not table:
+        return []
+    headers = [str(c or "").strip().lower() for c in table[0]]
+    out = []
+    for row in table[1:]:
+        if not any(c.strip() for c in row):
+            continue
+        out.append(dict(zip(headers, [str(v or "").strip() for v in row])))
+    return out
+```
+
+Then update `parse_tabular_file` so the `.xls`/`.xlsx` branch falls back to HTML when the bytes are HTML:
+
+```python
+    try:
+        if fname.endswith((".xlsx", ".xls")):
+            if _looks_like_html(content):
+                rows = _parse_html_table(content)
+            else:
+                rows = _parse_excel(content)
+        elif _looks_like_html(content):
+            rows = _parse_html_table(content)
+        else:
+            delimiter = "\t" if fname.endswith(".tsv") else ","
+            rows = _parse_csv(content, delimiter)
+    except Exception as e:
+        logger.warning(f"File parse error ({filename}): {e}")
+```
+
+Add the MPN extractor:
+
+```python
+_MPN_COLUMN_NAMES = (
+    "material: material name",
+    "material name",
+    "mpn",
+    "part number",
+    "part_number",
+    "partnumber",
+    "pn",
+    "part#",
+)
+
+
+def extract_mpns(rows: list[dict]) -> list[str]:
+    """Pull part numbers from parsed rows.
+
+    Prefers a recognized column name; otherwise uses the single column present.
+    Preserves order, drops blanks.
+    """
+    if not rows:
+        return []
+    keys = list(rows[0].keys())
+    col = next((k for k in keys if k in _MPN_COLUMN_NAMES), None)
+    if col is None and len(keys) == 1:
+        col = keys[0]
+    if col is None:
+        return []
+    out = []
+    for r in rows:
+        v = (r.get(col) or "").strip()
+        if v:
+            out.append(v)
+    return out
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/test_html_table_parse.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pre-commit run --files app/file_utils.py tests/test_html_table_parse.py
+git add app/file_utils.py tests/test_html_table_parse.py
+git commit -m "feat(import): parse HTML-table-as-xls + extract_mpns helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Import endpoint + script with dry-run coverage report
+
+**Files:**
+- Modify: `app/routers/materials.py`
+- Create: `scripts/import_part_numbers.py`
+- Test: `tests/test_part_number_import.py`
+
+- [ ] **Step 1: Write failing endpoint test**
+
+Create `tests/test_part_number_import.py`:
+
+```python
+import io
+
+
+def test_import_part_numbers_creates_bare_cards(client, db_session):
+    from app.models import MaterialCard
+
+    html = (
+        b"<table><tr><td>Material: Material Name</td></tr>"
+        b"<tr><td>NEWPART-001</td></tr><tr><td>NEWPART-002</td></tr></table>"
+    )
+    resp = client.post(
+        "/api/materials/import-part-numbers",
+        files={"file": ("report.xls", io.BytesIO(html), "application/vnd.ms-excel")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created"] == 2
+    cards = db_session.query(MaterialCard).filter(
+        MaterialCard.normalized_mpn.in_(["newpart001", "newpart002"])
+    ).all()
+    assert len(cards) == 2
+    assert all(c.enrichment_status == "unenriched" for c in cards)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_part_number_import.py -v`
+Expected: FAIL — 404 (endpoint not defined).
+
+- [ ] **Step 3: Implement the endpoint**
+
+In `app/routers/materials.py`, add (near the existing `import_stock_list_standalone`):
+
+```python
+@router.post("/api/materials/import-part-numbers")
+async def import_part_numbers(
+    request: Request, user: User = Depends(require_buyer), db: Session = Depends(get_db)
+):
+    """Import a bare list of part numbers (one MPN per row) as MaterialCards.
+
+    Accepts CSV/XLSX/TSV and HTML-table-as-.xls. Creates bare cards
+    (enrichment_status='unenriched'); enrichment runs separately.
+    """
+    import os as _os
+
+    from ..file_utils import extract_mpns, parse_tabular_file
+    from ..search_service import resolve_material_card
+
+    form = await request.form()
+    file = form.get("file")
+    if not file:
+        raise HTTPException(400, "No file uploaded")
+    ext = _os.path.splitext(file.filename or "")[1].lower()
+    if ext not in {".csv", ".xlsx", ".xls", ".tsv"}:
+        raise HTTPException(400, f"Invalid file type '{ext}'")
+    content = await file.read()
+    if len(content) > 10_000_000:
+        raise HTTPException(413, "File too large -- 10MB maximum")
+
+    rows = parse_tabular_file(content, file.filename or "")
+    mpns = extract_mpns(rows)
+    if not mpns:
+        raise HTTPException(400, "No part numbers found in file")
+
+    created = existing = skipped = 0
+    for mpn in mpns:
+        card = resolve_material_card(mpn, db)
+        if card is None:
+            skipped += 1
+            continue
+        # resolve_material_card logs created vs resolved; detect new by enrichment_status default
+        if card.enrichment_status == "unenriched" and card.enriched_at is None and card.search_count == 0:
+            created += 1
+        else:
+            existing += 1
+    db.commit()
+    return {
+        "created": created,
+        "existing": existing,
+        "skipped": skipped,
+        "total_rows": len(mpns),
+    }
+```
+
+> Note: `created` vs `existing` is approximate (relies on default state); the dry-run report in the script is the source of truth for coverage. If exact created-count matters, have `resolve_material_card` return a created flag — out of scope here.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/test_part_number_import.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the importer/enricher script with dry-run report**
+
+Create `scripts/import_part_numbers.py`:
+
+```python
+"""Import a bare part-number file and run verified enrichment.
+
+Usage:
+  python3 scripts/import_part_numbers.py --file "/path/report.xls" --dry-run
+  python3 scripts/import_part_numbers.py --file "/path/report.xls" --commit
+"""
+
+import argparse
+import asyncio
+import csv
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, "/root/availai")
+
+from loguru import logger  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.file_utils import extract_mpns, parse_tabular_file  # noqa: E402
+from app.models import MaterialCard  # noqa: E402
+from app.services.authoritative_enrichment_service import (  # noqa: E402
+    _connectors_in_order,
+    enrich_card,
+)
+from app.utils.normalization import normalize_mpn_key  # noqa: E402
+
+_REPORT_COLS = [
+    "input_mpn", "normalized_mpn", "status", "source",
+    "manufacturer", "category", "lifecycle_status", "package_type",
+    "pin_count", "rohs_status", "description", "datasheet_url", "notes",
+]
+
+
+async def _run(file_path: str, commit: bool, report_path: str, refresh: bool) -> None:
+    db = SessionLocal()
+    try:
+        content = open(file_path, "rb").read()
+        mpns = extract_mpns(parse_tabular_file(content, file_path))
+        logger.info("Parsed {} part numbers from {}", len(mpns), file_path)
+
+        conns = _connectors_in_order(db)
+        rows = []
+        counts = {"verified": 0, "ai_inferred": 0, "not_found": 0}
+
+        for i, raw in enumerate(mpns):
+            norm = normalize_mpn_key(raw)
+            if not norm:
+                rows.append({"input_mpn": raw, "normalized_mpn": "", "status": "skipped", "notes": "unparseable mpn"})
+                continue
+            # In dry-run, use a transient card not added to the session.
+            card = db.query(MaterialCard).filter_by(normalized_mpn=norm).first()
+            transient = card is None
+            if transient:
+                card = MaterialCard(normalized_mpn=norm, display_mpn=raw.strip(),
+                                    created_at=datetime.now(timezone.utc))
+            status = await enrich_card(card, db, connectors=conns, refresh=refresh)
+            counts[status] = counts.get(status, 0) + 1
+            prov = card.enrichment_provenance or {}
+            rows.append({
+                "input_mpn": raw, "normalized_mpn": norm, "status": status,
+                "source": (prov.get("description") or {}).get("source", ""),
+                "manufacturer": card.manufacturer or "", "category": card.category or "",
+                "lifecycle_status": card.lifecycle_status or "", "package_type": card.package_type or "",
+                "pin_count": card.pin_count or "", "rohs_status": card.rohs_status or "",
+                "description": card.description or "", "datasheet_url": card.datasheet_url or "",
+                "notes": "" if not transient else "new card",
+            })
+            if commit:
+                if transient:
+                    db.add(card)
+                if (i + 1) % 50 == 0:
+                    db.commit()
+                    logger.info("Committed {}/{}", i + 1, len(mpns))
+            if (i + 1) % 25 == 0:
+                logger.info("Processed {}/{} ({})", i + 1, len(mpns), counts)
+
+        if commit:
+            db.commit()
+        else:
+            db.rollback()
+
+        with open(report_path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=_REPORT_COLS, extrasaction="ignore")
+            w.writeheader()
+            w.writerows(rows)
+        logger.info("Wrote report -> {}", report_path)
+        logger.info("SUMMARY: {} (committed={})", counts, commit)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--file", required=True)
+    ap.add_argument("--commit", action="store_true", help="Write to DB (default is dry-run)")
+    ap.add_argument("--refresh", action="store_true", help="Re-enrich already-verified cards")
+    ap.add_argument("--report", default=None)
+    args = ap.parse_args()
+    report = args.report or f"reports/part_import_report_{datetime.now(timezone.utc):%Y%m%dT%H%M%SZ}.csv"
+    import os
+    os.makedirs(os.path.dirname(report) or ".", exist_ok=True)
+    if not args.commit:
+        logger.info("DRY RUN — no DB writes. Use --commit to persist.")
+    asyncio.run(_run(args.file, args.commit, report, args.refresh))
+```
+
+Add `reports/` to `.gitignore` if not already ignored.
+
+- [ ] **Step 6: Commit**
+
+```bash
+pre-commit run --files app/routers/materials.py scripts/import_part_numbers.py tests/test_part_number_import.py .gitignore
+git add app/routers/materials.py scripts/import_part_numbers.py tests/test_part_number_import.py .gitignore
+git commit -m "feat(import): part-number import endpoint + dry-run enrichment script
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `verified_only` filter in faceted search
+
+**Files:**
+- Modify: `app/services/faceted_search_service.py:155`, `app/routers/htmx_views.py:7197`
+- Test: `tests/test_material_enrichment_status_filter.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/test_material_enrichment_status_filter.py`:
+
+```python
+from datetime import datetime, timezone
+
+from app.models import MaterialCard
+from app.services.faceted_search_service import search_materials_faceted
+
+
+def _mk(db, mpn, status):
+    c = MaterialCard(
+        normalized_mpn=mpn, display_mpn=mpn.upper(), enrichment_status=status,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(c)
+    return c
+
+
+def test_verified_only_filter(db_session):
+    _mk(db_session, "verifiedone", "verified")
+    _mk(db_session, "guessedone", "ai_inferred")
+    _mk(db_session, "missingone", "not_found")
+    db_session.flush()
+
+    all_cards, total_all = search_materials_faceted(db_session)
+    assert total_all >= 3
+
+    verified, total_v = search_materials_faceted(db_session, verified_only=True)
+    assert {c.normalized_mpn for c in verified} == {"verifiedone"}
+    assert total_v == 1
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/test_material_enrichment_status_filter.py -v`
+Expected: FAIL — `verified_only` is an unexpected kwarg.
+
+- [ ] **Step 3: Add the param + WHERE clause**
+
+In `app/services/faceted_search_service.py`, add `verified_only: bool = False` to the `search_materials_faceted` keyword args, and after the `manufacturers` filter block add:
+
+```python
+    if verified_only:
+        query = query.filter(MaterialCard.enrichment_status == "verified")
+```
+
+- [ ] **Step 4: Add the query param to the GET handler**
+
+In `app/routers/htmx_views.py`, in `materials_faceted_partial` add the param:
+
+```python
+    verified_only: bool = Query(False),
+```
+
+and pass `verified_only=verified_only` into the `search_materials_faceted(...)` call.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `python3 -m pytest tests/test_material_enrichment_status_filter.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+pre-commit run --files app/services/faceted_search_service.py app/routers/htmx_views.py tests/test_material_enrichment_status_filter.py
+git add app/services/faceted_search_service.py app/routers/htmx_views.py tests/test_material_enrichment_status_filter.py
+git commit -m "feat(materials): verified-only filter in faceted search
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: UI — status badge + "Verified only" toggle
+
+**Files:**
+- Modify: `app/templates/htmx/partials/materials/list.html`, `workspace.html`, `app/static/htmx_app.js`
+
+- [ ] **Step 1: Add the status badge column**
+
+In `app/templates/htmx/partials/materials/list.html`, after the lifecycle `<td>` (around line 61), insert a new cell keyed on `enrichment_status`:
+
+```html
+          <td>
+            {% set es = m.enrichment_status %}
+            {% if es == "verified" %}
+            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-emerald-50 text-emerald-700 border-emerald-200"
+                  title="Verified from {{ (m.enrichment_provenance or {}).get('description', {}).get('source', 'catalog') }}">
+              VERIFIED
+            </span>
+            {% elif es == "ai_inferred" %}
+            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-amber-50 text-amber-700 border-amber-200"
+                  title="AI-inferred — unverified, best-effort guess">
+              AI-INFERRED
+            </span>
+            {% elif es == "not_found" %}
+            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-gray-100 text-gray-500 border-gray-200"
+                  title="No authoritative source found this part">
+              NOT FOUND
+            </span>
+            {% else %}
+            <span class="text-xs text-gray-400">--</span>
+            {% endif %}
+          </td>
+```
+
+Also add a matching `<th>` header cell (e.g. `Status`) wherever the table header row is defined in this partial.
+
+- [ ] **Step 2: Add the "Verified only" toggle**
+
+In `app/templates/htmx/partials/materials/workspace.html`, after the manufacturer filter container (around line 42), insert:
+
+```html
+      {# Verified only toggle #}
+      <div class="mb-3">
+        <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
+          <input type="checkbox"
+                 :checked="verifiedOnly"
+                 @change="verifiedOnly = !verifiedOnly; applyFilters()"
+                 class="rounded border-gray-300 text-emerald-600 focus:ring-emerald-500 h-3.5 w-3.5">
+          <span class="text-gray-700 font-medium">Verified only</span>
+        </label>
+      </div>
+```
+
+Add `"verified_only": verifiedOnly` to the `#materials-results` `hx-vals` object in this template (matching the existing `commodity`/`q`/`sub_filters` entries).
+
+- [ ] **Step 3: Add Alpine state + URL sync**
+
+In `app/static/htmx_app.js`, in the `materialsFilter` Alpine component (around lines 550–663):
+- add state: `verifiedOnly: false,`
+- in `syncFromURL()`: `this.verifiedOnly = params.get('verified_only') === 'true';`
+- in `pushURL()`: `if (this.verifiedOnly) params.set('verified_only', 'true'); else params.delete('verified_only');`
+
+- [ ] **Step 4: Build + smoke check**
+
+Run: `npm run build`
+Expected: build succeeds; new Tailwind classes (`bg-emerald-50`, `bg-amber-50`, etc. — all already used by `lc_colors`) are present. If any class is missing, check the Tailwind safelist (per project deploy notes).
+
+Optional console-error check (authenticated) per the e2e harness in `tests/e2e/conftest.py`: load the materials page, toggle "Verified only", assert no console errors and the list refreshes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+pre-commit run --files app/templates/htmx/partials/materials/list.html app/templates/htmx/partials/materials/workspace.html app/static/htmx_app.js
+git add app/templates/htmx/partials/materials/list.html app/templates/htmx/partials/materials/workspace.html app/static/htmx_app.js
+git commit -m "feat(materials-ui): enrichment-status badge + verified-only toggle
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Full verification, dry-run, docs, deploy
+
+- [ ] **Step 1: Whole-suite + all-files gate**
+
+Run: `pre-commit run --all-files`
+Run: `python3 -m pytest tests/ -q`
+Expected: all green. Fix any regressions before proceeding.
+
+- [ ] **Step 2: Dry-run the real list and review coverage**
+
+Run: `python3 scripts/import_part_numbers.py --file "/root/Material Items/report1780605266325.xls"`
+Expected: a `reports/part_import_report_*.csv` with 1,827 data rows and a SUMMARY line of `verified / ai_inferred / not_found` counts. **Review with the user** (esp. the verified vs inferred split and the Nexar call volume) before committing anything to the DB.
+
+- [ ] **Step 3: Commit to the DB (after user approval of the report)**
+
+First create the cards via the endpoint or directly, then enrich:
+Run: `python3 scripts/import_part_numbers.py --file "/root/Material Items/report1780605266325.xls" --commit`
+Expected: cards created + enriched; SUMMARY logged.
+
+- [ ] **Step 4: Update APP_MAP docs**
+
+- `docs/APP_MAP_DATABASE.md`: document `material_cards.enrichment_status` + `enrichment_provenance`.
+- `docs/APP_MAP_ARCHITECTURE.md`: document `authoritative_enrichment_service` + `ai_inference_fallback` + connector core-attribute extension.
+- `docs/APP_MAP_INTERACTIONS.md`: document `POST /api/materials/import-part-numbers` + the verified-only filter.
+
+Commit the docs.
+
+- [ ] **Step 5: Deploy (UI changes need a fresh build)**
+
+Run: `./deploy.sh --no-cache` (per the project deploy rule — Docker has cached stale templates before).
+Verify the badge + "Verified only" toggle render on the live materials page; confirm no DNS `could not translate host name "db"` crash-loop (if it occurs: `docker compose down && up`).
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git push -u origin feat/verified-material-enrichment
+```
+Open a PR summarizing the verified-enrichment capability + import; run the PR-review agents.
+
+---
+
+## Self-Review Checklist (completed by plan author)
+
+- **Spec coverage:** §2 decisions → Tasks 1–9; §3 columns → Task 1; §4.1 connectors → Task 2; §4.2 service → Tasks 3/5; §4.3 fallback → Task 4; §4.4 import → Tasks 6/7; §4.5 filter/UI → Tasks 8/9; §6 report → Task 7; §7 errors → Task 3 (`fetch_authoritative` try/except) + §quota handled as empty results; §8 tests → each task; §9 rollout → Task 10. ✅
+- **Exact-match guard** (spec's primary accuracy lever) → Task 3 `merge_authoritative` + test. ✅
+- **Opus 4.8 "best version"** → Task 4 Step 1 bump + `model_tier="opus"`. ✅
+- **AI never fabricates structured specs** → Task 4 (description+category only) + Task 5 `test_enrich_card_ai_inferred` asserts `lifecycle_status is None`. ✅
+- **Known follow-up (not a blocker):** `import_part_numbers` created-count is approximate; the dry-run report is the authoritative coverage source (noted inline in Task 7).
+- **Type consistency:** `enrich_card`/`enrich_cards`, `merge_authoritative`, `fetch_authoritative`, `apply_authoritative`, `infer_part`/`InferenceResult`, `extract_mpns`, `parse_tabular_file` used consistently across tasks. ✅

--- a/docs/superpowers/specs/2026-06-04-verified-material-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-04-verified-material-enrichment-design.md
@@ -1,0 +1,190 @@
+# Verified Material Enrichment + Part-Number Import — Design Spec
+
+**Date:** 2026-06-04
+**Status:** Approved design, pending implementation plan
+**Branch:** `feat/verified-material-enrichment`
+
+## 1. Problem & Goal
+
+A buyer-supplied report (`report1780605266325.xls` — actually an HTML-table export) contains **1,827 unique part numbers** ("every part we've ever been asked for"), single column, no manufacturer/description/specs. We need to add all of them to availai's `material_cards` with **core-attribute** enrichment that is **accurate and source-attributed**, so they are usefully filterable.
+
+The hard requirement is **"no unlabeled hallucination."** Every value shown must either be:
+- **Verified** — pulled from an authoritative catalog source, attributed to that source per field; or
+- **AI-inferred** — a best-effort guess, **structurally and visually flagged as unverified**; or
+- **Not found** — MPN only, explicitly marked.
+
+A value must never appear *as if* verified when it was guessed.
+
+### 1.1 Why this is non-trivial (the root problem)
+availai's existing material enrichment (`app/services/material_enrichment_service.py`) generates descriptions/specs by asking **Claude Haiku to infer them from the MPN string alone** — no authoritative lookup. That is itself the hallucination vector. availai's authorized-distributor connectors exist only for **supplier search** (sightings), and they currently parse only `manufacturer`, `description`, `datasheet_url` (+ price/stock) — discarding the catalog category/lifecycle/package/parameter data the APIs actually return.
+
+This design fixes the root cause: it introduces a **verified, source-attributed enrichment path** that becomes the canonical accurate enrichment for *any* future list, not just this one.
+
+### 1.2 The input list (characterized)
+- 1,827 rows, **0 duplicates, 0 blanks**, single column, header `Material: Material Name`.
+- ~1,133 longer MPNs (e.g. `M393A2K43EB3-CWEB/C`, `LTM8053IY#PBF`, `BCN31ABL253G13`) — mostly resolvable in electronic-component catalogs.
+- ~676 short alphanumeric codes (e.g. `04M3HJ`, `5B20N02284`, `93Y0050`) — almost all **OEM/FRU service part numbers** (Dell/Lenovo/IBM/HP) that will **not** be in DigiKey/Mouser/Nexar. These are the expected `ai_inferred` / `not_found` population.
+- File is a mislabeled `text/html` table (ISO-8859-1), cleanly parseable as a single-column table.
+
+## 2. Approved Decisions
+
+| Decision | Choice |
+|---|---|
+| Coverage policy | **Max coverage.** Verified where possible; AI-inferred (flagged) for gaps; `not_found` for the rest. Nothing is dropped. |
+| Spec depth | **Core attributes + verified descriptions** (no parametric facet sliders). Fields: description, manufacturer, category, lifecycle_status, package_type, rohs_status, pin_count, datasheet_url. Filtering via FTS + category/manufacturer/lifecycle + a verified-only toggle. |
+| Build approach | **Reusable capability** (not a throwaway script): import path + authoritative enrichment service + flagged AI fallback. Run once for this list. |
+| Source order | Cost-optimized: **DigiKey → Mouser → Element14 → OEMSecrets → Nexar (gaps only)**. All authoritative; Nexar last to limit paid credits while still capturing its unique coverage on hard parts. |
+| Match guard | **Exact normalized-MPN match required** before accepting any source's data. Partial/fuzzy hits are rejected, never attached. (Primary defense against verified-but-wrong.) |
+| AI fallback model | **Claude Opus 4.8** (`claude-opus-4-8`) — most capable for both knowledge and *calibrated refusal*. Used only for gap parts; produces description + category only; strict "return null if not confident". |
+| Run safety | **Dry-run → coverage report → review → commit.** No DB writes until the report is reviewed. |
+
+## 3. Data Model Changes (Alembic migration)
+
+Two new columns on `material_cards` (model: `app/models/intelligence.py:26-69`):
+
+```python
+# First-class verification status. Indexed (drives the "Verified only" filter).
+enrichment_status = Column(String(20), nullable=False, server_default="unenriched", index=True)
+#   one of: "unenriched" | "verified" | "ai_inferred" | "not_found"
+
+# Per-field provenance, auditable to source.
+enrichment_provenance = Column(JSONB, nullable=True)
+#   { "<field>": {"source": "digikey", "confidence": 1.0, "fetched_at": "2026-06-04T..Z",
+#                 "matched_mpn": "..."}, ... }
+#   fields tracked: description, manufacturer, category, lifecycle_status,
+#                   package_type, rohs_status, pin_count, datasheet_url
+```
+
+Reused as-is: `normalized_mpn` (unique dedup key), `display_mpn`, `description`, `manufacturer`, `category`, `lifecycle_status`, `package_type`, `rohs_status`, `pin_count`, `datasheet_url`, `enrichment_source`, `enriched_at`, `search_vector`, `deleted_at`.
+
+**`enrichment_source` semantics:** set to the highest-priority source that contributed any field (e.g. `"digikey"`), or `"claude_opus_inferred"` for AI-inferred rows. Detailed per-field attribution lives in `enrichment_provenance`.
+
+**Migration:** Alembic autogenerate, reviewed, `upgrade head` → `downgrade -1` → `upgrade head` tested. `enrichment_status` backfills to `"unenriched"` for existing rows via `server_default`. Add index on `enrichment_status` (mirrors the `deleted_at` index pattern in `079_add_index_material_cards_deleted_at.py`).
+
+## 4. Components
+
+### 4.1 Connector extensions — capture core attributes
+Today connectors return only `manufacturer`/`description`/`datasheet_url`. Extend the *parse* step of each to also surface the core attributes the API already returns. Scope is limited to core attributes — **not** full parametric specs.
+
+- **`app/connectors/digikey.py`** (DigiKey Product Search v4): add `category` (from `Category`/`CategoryName`), `lifecycle_status` (from `ProductStatus` → mapped to availai's `active|nrfnd|eol|obsolete|ltb`), `package_type` (from `Parameters` "Package / Case"), `pin_count` (from `Parameters` "Number of Terminations"/"Number of Pins"), `rohs_status` (from `Classifications`/`RohsStatus`). DigiKey is the richest free source for these.
+- **`app/connectors/sources.py` `NexarConnector`**: add `category` (`Part.category.name`), `lifecycle_status` (from specs/attributes if present), `package_type`, `pin_count` from `Part.specs`, `bestDatasheet.url`. Used only on gap parts.
+- **`app/connectors/mouser.py`**, **`element14.py`**, **`oemsecrets.py`**: add `category` and `datasheet_url` where present; these mainly contribute description/manufacturer/datasheet for coverage.
+
+Each connector's per-result dict gains optional keys: `category`, `lifecycle_status`, `package_type`, `pin_count`, `rohs_status` (in addition to existing `manufacturer`, `mpn_matched`/`mpn`, `description`, `datasheet_url`). All existing search behavior (sightings) is unchanged — these are additive keys.
+
+A unit-level **lifecycle mapping table** lives next to the DigiKey connector (e.g. `{"Active":"active","Obsolete":"obsolete","Not For New Designs":"nrfnd","Last Time Buy":"ltb","End of Life":"eol"}`) and is the single source of truth for status normalization. Unknown statuses → leave `lifecycle_status` null (never guess).
+
+### 4.2 Authoritative enrichment service (new)
+**`app/services/authoritative_enrichment_service.py`**
+
+```python
+SOURCE_ORDER = ["digikey", "mouser", "element14", "oemsecrets", "nexar"]
+CORE_FIELDS = ["description", "manufacturer", "category",
+               "lifecycle_status", "package_type", "rohs_status",
+               "pin_count", "datasheet_url"]
+
+async def enrich_card_authoritative(card, db, *, refresh=False) -> EnrichmentResult
+async def enrich_cards_authoritative(card_ids, db, *, concurrency=5, refresh=False) -> dict
+```
+
+Per card:
+1. Skip if `enrichment_status == "verified"` and not `refresh`.
+2. For each source in `SOURCE_ORDER`: call `connector.search(display_mpn)` (existing `BaseConnector.search`, which already provides retry / circuit-breaker / per-connector semaphore).
+3. **Exact-match guard:** keep only results where `normalize_mpn_key(result["mpn_matched"]) == card.normalized_mpn`. Drop everything else.
+4. **Merge — first non-null per field by source priority.** For each `CORE_FIELDS` field, take the first source (in order) that supplied a non-null value; record `{source, confidence, fetched_at, matched_mpn}` in `enrichment_provenance[field]`. Confidence = `1.0` for an exact-match authoritative hit.
+5. Stop early once all fields are filled OR once the next source is `nexar` and the part already has description+manufacturer+category (avoids spending Nexar credits when the part is already adequately resolved).
+6. If ≥1 field was filled from an authoritative source → `enrichment_status = "verified"`, `enrichment_source = <highest-priority contributor>`, `enriched_at = now`.
+7. If **no** authoritative source returned an exact match → hand to the AI fallback (§4.3).
+
+Concurrency is bounded (`concurrency=5` default) on top of the connectors' own semaphores; rate-limit/quota errors (`ConnectorRateLimitError`, `ConnectorQuotaError` from `app/connectors/errors.py`) are caught per-source and treated as "source unavailable for this MPN" (logged), not fatal.
+
+### 4.3 AI-inference fallback (flagged) — new
+**`app/services/ai_inference_fallback.py`** (a dedicated module, imported by the authoritative enrichment service).
+
+- Model: **`claude-opus-4-8`**.
+- Input: the MPN string only.
+- Output (structured/tool-forced): `{ "description": str|null, "category": str|null, "confidence": float }`.
+- **Strict prompt rule:** "If you are not confident this is a real, specific part, return null for description and category. Do NOT invent a plausible description. It is correct and expected to return null for unknown OEM/service part numbers."
+- It produces **description + category only**. It must **never** populate lifecycle/package/pin/RoHS (guessing structured fields is the dangerous hallucination) — those stay null.
+- Apply:
+  - Non-null description → `enrichment_status = "ai_inferred"`, `enrichment_source = "claude_opus_inferred"`, provenance `{source:"claude_opus_inferred", confidence:<model conf>}`, `enriched_at = now`.
+  - Null (model declined) → `enrichment_status = "not_found"`, MPN only, no description.
+
+### 4.4 Import path — new
+- **Parser:** extend `app/file_utils.py` to detect and parse the **HTML-table-as-`.xls`** format (sniff leading `<head>`/`<table>` / `text/html`), plus existing CSV/XLSX/TSV. Auto-detect a single-column MPN file (or a column literally named `Material: Material Name` / `mpn` / `part number`). Normalize each value via `normalize_mpn_key()`; drop blanks; dedup.
+- **Endpoint:** `POST /api/materials/import-part-numbers` in `app/routers/materials.py` (buyer-gated via `require_buyer`, matching the existing `import-stock-list` endpoint at `app/routers/materials.py:389`). Body: uploaded file. Action: UPSERT bare `MaterialCard` (set `display_mpn`, `normalized_mpn`, `enrichment_status="unenriched"`) deduped on `normalized_mpn`; do **not** create `MaterialVendorHistory` (no vendor in this file — that's the key difference from the stock-list importer). Returns a summary (created / already-existing / skipped-blank). Enrichment is enqueued, not run inline.
+- **Script:** `scripts/import_part_numbers.py` wrapping the same service for this one-time load and ops use. Flags: `--file PATH`, `--dry-run` (default), `--commit`, `--refresh`, `--report PATH`.
+- **Idempotency:** re-import upserts by `normalized_mpn`; re-enrichment skips `verified` rows unless `--refresh`.
+
+### 4.5 Filtering & UI
+- **Service:** add an optional `verified_only: bool` (and/or `enrichment_status` filter) to `search_materials_faceted()` (`app/services/faceted_search_service.py:155`). When set, filter `MaterialCard.enrichment_status == "verified"`.
+- **Materials list + detail templates** (`app/templates/partials/materials/…`, e.g. `workspace.html`): status badge per card — **"Verified · {source}"** (green), **"AI-inferred"** (amber, with tooltip "unverified — best-effort guess"), **"Not found"** (gray). Follow existing status-pill styling.
+- **Filter bar:** a **"Verified only"** toggle (HTMX, posts to the existing filter endpoint). Default off (show everything); on → verified rows only. This is what lets a guessed value never silently pollute a filtered result set.
+- Datasheet URL rendered as a link when present.
+
+## 5. Data Flow
+
+```
+report1780605266325.xls
+  └─ parse_part_number_file()  → [normalized MPNs]
+       └─ UPSERT MaterialCard (enrichment_status="unenriched")
+            └─ enrich_cards_authoritative()
+                 ├─ for source in [digikey, mouser, element14, oemsecrets, nexar(gap)]:
+                 │     connector.search(mpn) → exact-MPN-match filter → merge fields + provenance
+                 ├─ any authoritative field?  → status="verified"
+                 └─ none?                     → Opus fallback
+                                                  ├─ description?  → status="ai_inferred"
+                                                  └─ declined      → status="not_found"
+  └─ (dry-run) coverage report CSV   ──review──▶  (commit) write to DB
+                                                      └─ faceted search + UI badges + "Verified only"
+```
+
+## 6. Coverage Report (dry-run artifact)
+
+`--dry-run` writes a CSV (default `reports/part_import_report_<UTC-timestamp>.csv`, gitignored; override with `--report PATH`) with one row per input MPN:
+
+`input_mpn, normalized_mpn, status, source, manufacturer, category, lifecycle_status, package_type, pin_count, rohs_status, description, datasheet_url, notes`
+
+Plus a summary footer: counts of `verified` / `ai_inferred` / `not_found`, and per-source contribution counts. **No DB writes occur in dry-run.** The user reviews this before `--commit`.
+
+## 7. Error Handling
+
+- Connector failures (network, 5xx) per source → logged, treated as "no result from this source", continue to next source. Never abort the run.
+- `ConnectorRateLimitError` → respected via the connector's existing backoff; if persistent, that source is skipped for that MPN and noted in `notes`.
+- `ConnectorQuotaError` (e.g. Nexar credits exhausted) → that source is disabled for the remainder of the run, logged loudly, surfaced in the report summary (so coverage isn't silently capped).
+- Opus fallback error/timeout → row left `not_found` with a `notes` flag; never blocks other rows.
+- Partial/ambiguous connector match (MPN mismatch) → discarded; counts toward "no authoritative hit". Logged at debug.
+- All DB writes for `--commit` run in batched transactions; a failure rolls back the batch, not the whole run.
+
+## 8. Testing (pytest, mocked external APIs)
+
+- `parse_part_number_file`: HTML-`.xls` format, plain CSV, single-column, the `Material: Material Name` header, blanks/dupes.
+- Exact-MPN-match guard: a connector returning a near-but-different MPN is rejected; an exact match is accepted.
+- Merge/provenance: first-non-null-by-priority; provenance records correct source per field; `enrichment_status` transitions (`verified` / `ai_inferred` / `not_found`).
+- Source-order short-circuit: Nexar is **not** called when cheaper sources already resolved description+manufacturer+category.
+- DigiKey `ProductStatus` → lifecycle mapping (incl. unknown → null).
+- Opus fallback: confident → `ai_inferred`; declined (null) → `not_found`; structured fields never populated by fallback.
+- `verified_only` filter returns only `verified` rows.
+- Quota/rate-limit handling: a quota error disables the source and is reported, run completes.
+- Representative-MPN fixtures: a passive (`BCN31ABL253G13`), a memory module (`M393A2K43EB3-CWEB/C`), an IC/module (`LTM8053IY#PBF`), and an OEM FRU (`5B20N02284`).
+
+## 9. Rollout
+
+1. Branch `feat/verified-material-enrichment` (done).
+2. Implement; run `pre-commit run --all-files`; full pytest suite green.
+3. `python scripts/import_part_numbers.py --file "/root/Material Items/report1780605266325.xls" --dry-run` → review coverage report with the user.
+4. On approval: `--commit` to the staging DB.
+5. Deploy (`deploy.sh` with `--no-cache`) for the UI/filter changes; verify badges + "Verified only" filter render (check Tailwind classes built).
+6. Update `docs/APP_MAP_DATABASE.md` (new columns), `docs/APP_MAP_ARCHITECTURE.md` (new service + connector extensions), `docs/APP_MAP_INTERACTIONS.md` (import endpoint + verified-only filter).
+7. PR → review (PR-review agents) → merge.
+
+## 10. Out of Scope (YAGNI)
+
+- Full parametric spec facets / range sliders (capacitance, voltage, etc.).
+- OEM-specific lookup integrations (Dell/Lenovo/HP parts portals) for the FRU codes — those remain `ai_inferred`/`not_found` for now.
+- Scheduled/automatic re-enrichment cron (re-enrichment is on-demand via `--refresh` / the existing job can adopt the new path later).
+- Replacing the existing Haiku enrichment everywhere — this adds the verified path and routes the import through it; broader migration of the legacy path is a follow-up.
+
+## 11. Cost Note
+
+DigiKey/Mouser/Element14/OEMSecrets are effectively free per-call (rate-limited). Nexar/Octopart consumes paid credits — bounded here because Nexar runs **only** on parts unresolved by the four free sources (expected to be a minority of the ~1,133 catalog MPNs plus a portion of the ~676 OEM codes, most of which Nexar also won't have). The dry-run report surfaces actual Nexar call count before any credits are spent on a committed run.

--- a/scripts/import_part_numbers.py
+++ b/scripts/import_part_numbers.py
@@ -1,0 +1,135 @@
+"""Import a bare part-number file and run verified enrichment.
+
+Usage:
+  python3 scripts/import_part_numbers.py --file "/path/report.xls" --dry-run
+  python3 scripts/import_part_numbers.py --file "/path/report.xls" --commit
+"""
+
+import argparse
+import asyncio
+import csv
+import os
+import sys
+from datetime import datetime, timezone
+
+# Allow running from the scripts/ directory or from the repo root.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from loguru import logger  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.file_utils import extract_mpns, parse_tabular_file  # noqa: E402
+from app.models import MaterialCard  # noqa: E402
+from app.services.authoritative_enrichment_service import (  # noqa: E402
+    _connectors_in_order,
+    enrich_card,
+)
+from app.utils.normalization import normalize_mpn_key  # noqa: E402
+
+_REPORT_COLS = [
+    "input_mpn",
+    "normalized_mpn",
+    "status",
+    "source",
+    "manufacturer",
+    "category",
+    "lifecycle_status",
+    "package_type",
+    "pin_count",
+    "rohs_status",
+    "description",
+    "datasheet_url",
+    "notes",
+]
+
+
+async def _run(file_path: str, commit: bool, report_path: str, refresh: bool) -> None:
+    db = SessionLocal()
+    try:
+        content = open(file_path, "rb").read()
+        mpns = extract_mpns(parse_tabular_file(content, file_path))
+        logger.info("Parsed {} part numbers from {}", len(mpns), file_path)
+
+        conns = _connectors_in_order(db)
+        rows = []
+        counts = {"verified": 0, "ai_inferred": 0, "not_found": 0}
+
+        for i, raw in enumerate(mpns):
+            norm = normalize_mpn_key(raw)
+            if not norm:
+                rows.append(
+                    {
+                        "input_mpn": raw,
+                        "normalized_mpn": "",
+                        "status": "skipped",
+                        "notes": "unparseable mpn",
+                    }
+                )
+                continue
+            # In dry-run, use a transient card not added to the session.
+            card = db.query(MaterialCard).filter_by(normalized_mpn=norm).first()
+            transient = card is None
+            if transient:
+                card = MaterialCard(
+                    normalized_mpn=norm,
+                    display_mpn=raw.strip(),
+                    created_at=datetime.now(timezone.utc),
+                )
+            status = await enrich_card(card, db, connectors=conns, refresh=refresh)
+            counts[status] = counts.get(status, 0) + 1
+            prov = card.enrichment_provenance or {}
+            rows.append(
+                {
+                    "input_mpn": raw,
+                    "normalized_mpn": norm,
+                    "status": status,
+                    "source": (prov.get("description") or {}).get("source", ""),
+                    "manufacturer": card.manufacturer or "",
+                    "category": card.category or "",
+                    "lifecycle_status": card.lifecycle_status or "",
+                    "package_type": card.package_type or "",
+                    "pin_count": card.pin_count or "",
+                    "rohs_status": card.rohs_status or "",
+                    "description": card.description or "",
+                    "datasheet_url": card.datasheet_url or "",
+                    "notes": "" if not transient else "new card",
+                }
+            )
+            if commit:
+                if transient:
+                    db.add(card)
+                if (i + 1) % 50 == 0:
+                    db.commit()
+                    logger.info("Committed {}/{}", i + 1, len(mpns))
+            if (i + 1) % 25 == 0:
+                logger.info("Processed {}/{} ({})", i + 1, len(mpns), counts)
+
+        if commit:
+            db.commit()
+        else:
+            db.rollback()
+
+        with open(report_path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=_REPORT_COLS, extrasaction="ignore")
+            w.writeheader()
+            w.writerows(rows)
+        logger.info("Wrote report -> {}", report_path)
+        logger.info("SUMMARY: {} (committed={})", counts, commit)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--file", required=True)
+    ap.add_argument("--commit", action="store_true", help="Write to DB (default is dry-run)")
+    ap.add_argument("--refresh", action="store_true", help="Re-enrich already-verified cards")
+    ap.add_argument("--report", default=None)
+    args = ap.parse_args()
+    report = args.report or f"reports/part_import_report_{datetime.now(timezone.utc):%Y%m%dT%H%M%SZ}.csv"
+    os.makedirs(os.path.dirname(report) or ".", exist_ok=True)
+    if not args.commit:
+        logger.info("DRY RUN — no DB writes. Use --commit to persist.")
+    asyncio.run(_run(args.file, args.commit, report, args.refresh))

--- a/scripts/import_part_numbers.py
+++ b/scripts/import_part_numbers.py
@@ -53,6 +53,7 @@ async def _run(file_path: str, commit: bool, report_path: str, refresh: bool) ->
         logger.info("Parsed {} part numbers from {}", len(mpns), file_path)
 
         conns = _connectors_in_order(db)
+        disabled: set[str] = set()
         rows = []
         counts = {"verified": 0, "ai_inferred": 0, "not_found": 0}
 
@@ -77,7 +78,7 @@ async def _run(file_path: str, commit: bool, report_path: str, refresh: bool) ->
                     display_mpn=raw.strip(),
                     created_at=datetime.now(timezone.utc),
                 )
-            status = await enrich_card(card, db, connectors=conns, refresh=refresh)
+            status = await enrich_card(card, db, connectors=conns, refresh=refresh, disabled=disabled)
             counts[status] = counts.get(status, 0) + 1
             prov = card.enrichment_provenance or {}
             rows.append(
@@ -116,7 +117,9 @@ async def _run(file_path: str, commit: bool, report_path: str, refresh: bool) ->
             w.writeheader()
             w.writerows(rows)
         logger.info("Wrote report -> {}", report_path)
-        logger.info("SUMMARY: {} (committed={})", counts, commit)
+        if disabled:
+            logger.error("Sources DISABLED this run (quota/auth): {}", sorted(disabled))
+        logger.info("SUMMARY: {} disabled_sources={} (committed={})", counts, sorted(disabled), commit)
     finally:
         db.close()
 
@@ -124,6 +127,11 @@ async def _run(file_path: str, commit: bool, report_path: str, refresh: bool) ->
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--file", required=True)
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview only, no DB writes (this is the default; flag accepted explicitly)",
+    )
     ap.add_argument("--commit", action="store_true", help="Write to DB (default is dry-run)")
     ap.add_argument("--refresh", action="store_true", help="Re-enrich already-verified cards")
     ap.add_argument("--report", default=None)

--- a/tests/test_ai_inference_fallback.py
+++ b/tests/test_ai_inference_fallback.py
@@ -1,0 +1,38 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.ai_inference_fallback import infer_part
+
+
+@pytest.mark.asyncio
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+async def test_confident_inference_returns_ai_inferred(mock_claude):
+    mock_claude.return_value = {
+        "description": "Linear voltage regulator, adjustable, TO-220",
+        "category": "Voltage Regulator",
+        "confidence": 0.8,
+    }
+    result = await infer_part("LM317T")
+    assert result.status == "ai_inferred"
+    assert result.description.startswith("Linear voltage regulator")
+    assert result.category == "Voltage Regulator"
+    # Opus must be requested
+    assert mock_claude.call_args.kwargs["model_tier"] == "opus"
+
+
+@pytest.mark.asyncio
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+async def test_declined_inference_returns_not_found(mock_claude):
+    mock_claude.return_value = {"description": "", "category": "", "confidence": 0.0}
+    result = await infer_part("04M3HJ")
+    assert result.status == "not_found"
+    assert result.description is None
+
+
+@pytest.mark.asyncio
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+async def test_null_response_returns_not_found(mock_claude):
+    mock_claude.return_value = None
+    result = await infer_part("ZZZ999")
+    assert result.status == "not_found"

--- a/tests/test_authoritative_enrichment.py
+++ b/tests/test_authoritative_enrichment.py
@@ -69,3 +69,83 @@ def test_first_non_null_by_priority():
     assert prov["category"]["source"] == "mouser"
     assert merged["lifecycle_status"] == "active"
     assert "digikey" in contributors and "mouser" in contributors
+
+
+from unittest.mock import AsyncMock, patch
+
+from app.services.authoritative_enrichment_service import enrich_card
+
+
+def _card(db_session, mpn="LM317T"):
+    from app.utils.normalization import normalize_mpn_key
+
+    c = MaterialCard(
+        normalized_mpn=normalize_mpn_key(mpn),
+        display_mpn=mpn,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(c)
+    db_session.flush()
+    return c
+
+
+class _FakeConn:
+    def __init__(self, source_name, hits):
+        self.source_name = source_name
+        self._hits = hits
+
+    async def search(self, pn):
+        return self._hits
+
+
+@patch("app.services.authoritative_enrichment_service._connectors_in_order")
+def test_enrich_card_verified(mock_conns, db_session):
+    card = _card(db_session)
+    mock_conns.return_value = [
+        _FakeConn(
+            "digikey",
+            [
+                {
+                    "source_type": "digikey",
+                    "mpn_matched": "LM317T",
+                    "manufacturer": "TI",
+                    "description": "Adjustable regulator",
+                    "category": "Voltage Regulator",
+                    "lifecycle_status": "active",
+                }
+            ],
+        )
+    ]
+    import asyncio
+
+    asyncio.run(enrich_card(card, db_session))
+    assert card.enrichment_status == "verified"
+    assert card.manufacturer == "TI"
+    assert card.enrichment_provenance["description"]["source"] == "digikey"
+
+
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+@patch("app.services.authoritative_enrichment_service._connectors_in_order")
+def test_enrich_card_ai_inferred_when_no_authoritative(mock_conns, mock_claude, db_session):
+    card = _card(db_session, "04M3HJ")
+    mock_conns.return_value = [_FakeConn("digikey", [])]  # no hits anywhere
+    mock_claude.return_value = {"description": "Dell laptop bezel", "category": "Mechanical", "confidence": 0.7}
+    import asyncio
+
+    asyncio.run(enrich_card(card, db_session))
+    assert card.enrichment_status == "ai_inferred"
+    assert card.description == "Dell laptop bezel"
+    assert card.lifecycle_status is None  # never guessed
+
+
+@patch("app.services.ai_inference_fallback.claude_structured", new_callable=AsyncMock)
+@patch("app.services.authoritative_enrichment_service._connectors_in_order")
+def test_enrich_card_not_found(mock_conns, mock_claude, db_session):
+    card = _card(db_session, "ZZ9PLURAL")
+    mock_conns.return_value = [_FakeConn("digikey", [])]
+    mock_claude.return_value = {"description": "", "category": "", "confidence": 0.0}
+    import asyncio
+
+    asyncio.run(enrich_card(card, db_session))
+    assert card.enrichment_status == "not_found"
+    assert card.description is None

--- a/tests/test_authoritative_enrichment.py
+++ b/tests/test_authoritative_enrichment.py
@@ -23,3 +23,49 @@ def test_new_card_defaults_to_unenriched(db_session):
     db_session.refresh(card)
     assert card.enrichment_status == "unenriched"
     assert card.enrichment_provenance is None
+
+
+from app.services.authoritative_enrichment_service import (
+    merge_authoritative,
+)
+
+
+def _hit(source, mpn="LM317T", **over):
+    base = {
+        "source_type": source,
+        "mpn_matched": mpn,
+        "manufacturer": "TI",
+        "description": f"desc from {source}",
+        "category": None,
+        "lifecycle_status": None,
+        "package_type": None,
+        "pin_count": None,
+        "rohs_status": None,
+        "datasheet_url": None,
+    }
+    base.update(over)
+    return base
+
+
+def test_exact_match_guard_rejects_mismatch():
+    # connector returned a DIFFERENT part — must be ignored
+    results = {"digikey": [_hit("digikey", mpn="LM317MT")]}
+    merged, prov, contributors = merge_authoritative("lm317t", results)
+    assert merged == {}
+    assert contributors == []
+
+
+def test_first_non_null_by_priority():
+    results = {
+        "mouser": [_hit("mouser", description="mouser desc", category="Linear")],
+        "digikey": [_hit("digikey", description="digikey desc", lifecycle_status="active")],
+    }
+    merged, prov, contributors = merge_authoritative("lm317t", results)
+    # digikey has higher priority -> its description wins
+    assert merged["description"] == "digikey desc"
+    assert prov["description"]["source"] == "digikey"
+    # category only present from mouser -> taken from mouser
+    assert merged["category"] == "Linear"
+    assert prov["category"]["source"] == "mouser"
+    assert merged["lifecycle_status"] == "active"
+    assert "digikey" in contributors and "mouser" in contributors

--- a/tests/test_authoritative_enrichment.py
+++ b/tests/test_authoritative_enrichment.py
@@ -149,3 +149,29 @@ def test_enrich_card_not_found(mock_conns, mock_claude, db_session):
     asyncio.run(enrich_card(card, db_session))
     assert card.enrichment_status == "not_found"
     assert card.description is None
+
+
+def test_quota_error_disables_source_for_run():
+    """A ConnectorQuotaError disables that source for the rest of the run."""
+    import asyncio
+
+    from app.connectors.errors import ConnectorQuotaError
+    from app.services.authoritative_enrichment_service import fetch_authoritative
+
+    calls = {"n": 0}
+
+    class _QuotaConn:
+        source_name = "digikey"
+
+        async def search(self, pn):
+            calls["n"] += 1
+            raise ConnectorQuotaError("quota exceeded")
+
+    disabled: set[str] = set()
+    conn = _QuotaConn()
+    asyncio.run(fetch_authoritative("X1", "x1", [conn], disabled))
+    assert "digikey" in disabled
+    assert calls["n"] == 1
+    # Second MPN: source already disabled -> not retried.
+    asyncio.run(fetch_authoritative("X2", "x2", [conn], disabled))
+    assert calls["n"] == 1

--- a/tests/test_authoritative_enrichment.py
+++ b/tests/test_authoritative_enrichment.py
@@ -1,0 +1,25 @@
+"""Tests for the verified-material-enrichment feature.
+
+Covers: enrichment_status / enrichment_provenance model columns (Task 1),
+and (future tasks) authoritative-enrichment service logic.
+
+Called by: pytest
+Depends on: app/models/intelligence.py, tests/conftest.py (db_session fixture)
+"""
+
+from datetime import datetime, timezone
+
+from app.models import MaterialCard
+
+
+def test_new_card_defaults_to_unenriched(db_session):
+    card = MaterialCard(
+        normalized_mpn="teststatusdefault",
+        display_mpn="TEST-STATUS-DEFAULT",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(card)
+    db_session.flush()
+    db_session.refresh(card)
+    assert card.enrichment_status == "unenriched"
+    assert card.enrichment_provenance is None

--- a/tests/test_connector_core_attrs.py
+++ b/tests/test_connector_core_attrs.py
@@ -1,0 +1,447 @@
+"""Tests for app/connectors/_core_attrs.py shared helpers and connector wiring.
+
+All tests use synthetic raw-response dicts matching the documented API shapes. No live
+network or DB required.
+"""
+
+from app.connectors._core_attrs import (
+    clean_str,
+    digikey_parameter,
+    generic_attribute,
+    map_lifecycle,
+    map_rohs,
+    safe_pin_count,
+)
+
+# ── _core_attrs helpers ───────────────────────────────────────────────
+
+
+def test_lifecycle_mapping():
+    assert map_lifecycle("Active") == "active"
+    assert map_lifecycle("Not For New Designs") == "nrfnd"
+    assert map_lifecycle("Obsolete") == "obsolete"
+    assert map_lifecycle("totally unknown status") is None
+    assert map_lifecycle(None) is None
+
+
+def test_lifecycle_mapping_extra():
+    assert map_lifecycle("NRND") == "nrfnd"
+    assert map_lifecycle("Discontinued") == "obsolete"
+    assert map_lifecycle("Last Time Buy") == "ltb"
+    assert map_lifecycle("End Of Life") == "eol"
+    assert map_lifecycle("EOL") == "eol"
+    assert map_lifecycle("") is None
+
+
+def test_rohs_mapping():
+    assert map_rohs("ROHS Compliant") == "compliant"
+    assert map_rohs("Non-Compliant") == "non-compliant"
+    assert map_rohs("weird") is None
+
+
+def test_rohs_mapping_extra():
+    assert map_rohs("compliant") == "compliant"
+    assert map_rohs("RoHS3 Compliant") == "compliant"
+    assert map_rohs("Not Compliant") == "non-compliant"
+    assert map_rohs("RoHS Exempt") == "exempt"
+    assert map_rohs("Exempt") == "exempt"
+    assert map_rohs(None) is None
+    assert map_rohs("") is None
+
+
+def test_pin_count():
+    assert safe_pin_count("64") == 64
+    assert safe_pin_count("0") is None
+    assert safe_pin_count("abc") is None
+
+
+def test_pin_count_extra():
+    assert safe_pin_count(32) == 32
+    assert safe_pin_count(-1) is None
+    assert safe_pin_count(None) is None
+    assert safe_pin_count("  128  ") == 128
+
+
+def test_clean_str():
+    assert clean_str("  hello  ", maxlen=100) == "hello"
+    assert clean_str("toolongstring", maxlen=5) == "toolo"
+    assert clean_str(None, maxlen=100) is None
+    assert clean_str("  ", maxlen=100) is None
+    assert clean_str(42, maxlen=100) == "42"
+
+
+def test_digikey_parameter():
+    params = [
+        {"ParameterText": "Package / Case", "ValueText": "100-LQFP"},
+        {"ParameterText": "Number of I/O", "ValueText": "82"},
+    ]
+    assert digikey_parameter(params, ("Package / Case",)) == "100-LQFP"
+    assert digikey_parameter(params, ("Mounting Type",)) is None
+    assert digikey_parameter([], ("Package / Case",)) is None
+
+
+def test_digikey_parameter_dash_value():
+    """A '-' ValueText should be treated as missing."""
+    params = [{"ParameterText": "Package / Case", "ValueText": "-"}]
+    assert digikey_parameter(params, ("Package / Case",)) is None
+
+
+def test_digikey_parameter_case_insensitive():
+    params = [{"ParameterText": "number of terminations", "ValueText": "64"}]
+    assert digikey_parameter(params, ("Number of Terminations",)) == "64"
+
+
+def test_digikey_parameter_not_list():
+    assert digikey_parameter(None, ("Package / Case",)) is None
+    assert digikey_parameter("not a list", ("Package / Case",)) is None
+
+
+def test_generic_attribute_mouser_style():
+    """Mouser ProductAttributes use AttributeName / AttributeValue."""
+    attrs = [
+        {"AttributeName": "Package", "AttributeValue": "SOIC-8"},
+        {"AttributeName": "Number of Pins", "AttributeValue": "8"},
+    ]
+    assert generic_attribute(attrs, "AttributeName", "AttributeValue", ("Package",)) == "SOIC-8"
+    assert generic_attribute(attrs, "AttributeName", "AttributeValue", ("Number of Pins",)) == "8"
+    assert generic_attribute(attrs, "AttributeName", "AttributeValue", ("Missing",)) is None
+
+
+def test_generic_attribute_element14_style():
+    """Element14 attributes use attributeLabel / attributeValue."""
+    attrs = [
+        {"attributeLabel": "RoHS", "attributeValue": "Compliant"},
+        {"attributeLabel": "Package", "attributeValue": "DIP-8"},
+    ]
+    assert generic_attribute(attrs, "attributeLabel", "attributeValue", ("RoHS",)) == "Compliant"
+    assert generic_attribute(attrs, "attributeLabel", "attributeValue", ("Package",)) == "DIP-8"
+
+
+def test_generic_attribute_case_insensitive():
+    attrs = [{"AttributeName": "PACKAGE", "AttributeValue": "QFN-32"}]
+    assert generic_attribute(attrs, "AttributeName", "AttributeValue", ("package",)) == "QFN-32"
+
+
+def test_generic_attribute_not_list():
+    assert generic_attribute(None, "AttributeName", "AttributeValue", ("Package",)) is None
+    assert generic_attribute("not a list", "AttributeName", "AttributeValue", ("Package",)) is None
+
+
+def test_generic_attribute_dash_value():
+    attrs = [{"AttributeName": "Package", "AttributeValue": "-"}]
+    assert generic_attribute(attrs, "AttributeName", "AttributeValue", ("Package",)) is None
+
+
+# ── DigiKey connector wiring ──────────────────────────────────────────
+
+
+def _make_digikey_prod(**overrides):
+    """Build a synthetic DigiKey product dict with core-attribute fields."""
+    base = {
+        "ManufacturerPartNumber": "STM32F407VGT6",
+        "Manufacturer": {"Name": "STMicroelectronics"},
+        "DigiKeyPartNumber": "497-11802-ND",
+        "QuantityAvailable": 1000,
+        "StandardPricing": [{"BreakQuantity": 1, "UnitPrice": 12.50}],
+        "ProductUrl": "https://www.digikey.com/product/497-11802-ND",
+        "Description": {"DetailedDescription": "IC MCU 32BIT 1MB FLASH 100LQFP"},
+        "Category": {"Name": "Embedded - Microcontrollers"},
+        "ProductStatus": {"Status": "Active"},
+        "Parameters": [
+            {"ParameterText": "Package / Case", "ValueText": "100-LQFP"},
+            {"ParameterText": "Number of I/O", "ValueText": "82"},
+        ],
+        "Classifications": {"RohsStatus": "ROHS Compliant"},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_digikey_core_attrs_extracted():
+    from app.connectors.digikey import DigiKeyConnector
+
+    c = DigiKeyConnector(client_id="x", client_secret="y")
+    data = {"Products": [_make_digikey_prod()]}
+    results = c._parse(data, "STM32F407VGT6")
+    assert len(results) == 1
+    r = results[0]
+    assert r["category"] == "Embedded - Microcontrollers"
+    assert r["lifecycle_status"] == "active"
+    assert r["package_type"] == "100-LQFP"
+    assert r["pin_count"] == 82
+    assert r["rohs_status"] == "compliant"
+
+
+def test_digikey_core_attrs_missing_fields():
+    """Missing optional fields should yield None — not crash."""
+    from app.connectors.digikey import DigiKeyConnector
+
+    c = DigiKeyConnector(client_id="x", client_secret="y")
+    prod = {
+        "ManufacturerPartNumber": "X",
+        "Manufacturer": {"Name": "M"},
+        "DigiKeyPartNumber": "D1",
+        "QuantityAvailable": 10,
+        "ProductUrl": "https://digikey.com/x",
+        "Description": {"DetailedDescription": "Test"},
+        # No Category, ProductStatus, Parameters, Classifications
+    }
+    results = c._parse({"Products": [prod]}, "X")
+    r = results[0]
+    assert r["category"] is None
+    assert r["lifecycle_status"] is None
+    assert r["package_type"] is None
+    assert r["pin_count"] is None
+    assert r["rohs_status"] is None
+
+
+def test_digikey_unknown_lifecycle_yields_none():
+    from app.connectors.digikey import DigiKeyConnector
+
+    c = DigiKeyConnector(client_id="x", client_secret="y")
+    prod = _make_digikey_prod(ProductStatus={"Status": "Some Exotic Status"})
+    results = c._parse({"Products": [prod]}, "STM32F407VGT6")
+    assert results[0]["lifecycle_status"] is None
+
+
+# ── Mouser connector wiring ───────────────────────────────────────────
+
+
+def _make_mouser_part(**overrides):
+    base = {
+        "ManufacturerPartNumber": "STM32F407VGT6",
+        "Manufacturer": "STMicroelectronics",
+        "MouserPartNumber": "511-STM32F407VGT6",
+        "Availability": "500 In Stock",
+        "PriceBreaks": [{"Quantity": 1, "Price": "$12.50"}],
+        "ProductDetailUrl": "https://mouser.com/ProductDetail/STM32F407VGT6",
+        "Description": "MCU ARM Cortex-M4",
+        "Category": "Microcontrollers",
+        "LifecycleStatus": "Active",
+        "ProductAttributes": [
+            {"AttributeName": "Package / Case", "AttributeValue": "100-LQFP"},
+            {"AttributeName": "Number of Pins", "AttributeValue": "100"},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_mouser_core_attrs_extracted():
+    from app.connectors.mouser import MouserConnector
+
+    c = MouserConnector(api_key="key")
+    data = {"SearchResults": {"Parts": [_make_mouser_part()]}}
+    results = c._parse(data, "STM32F407VGT6")
+    assert len(results) == 1
+    r = results[0]
+    assert r["category"] == "Microcontrollers"
+    assert r["lifecycle_status"] == "active"
+    assert r["package_type"] == "100-LQFP"
+    assert r["pin_count"] == 100
+
+
+def test_mouser_core_attrs_missing():
+    from app.connectors.mouser import MouserConnector
+
+    c = MouserConnector(api_key="key")
+    part = {
+        "ManufacturerPartNumber": "X",
+        "Manufacturer": "M",
+        "MouserPartNumber": "M-X",
+        "Availability": "10 In Stock",
+        "PriceBreaks": [],
+        "ProductDetailUrl": "",
+        "Description": "",
+        # No Category, LifecycleStatus, ProductAttributes
+    }
+    results = c._parse({"SearchResults": {"Parts": [part]}}, "X")
+    r = results[0]
+    assert r["category"] is None
+    assert r["lifecycle_status"] is None
+    assert r["package_type"] is None
+    assert r["pin_count"] is None
+
+
+# ── Element14 connector wiring ────────────────────────────────────────
+
+
+def _make_element14_prod(**overrides):
+    base = {
+        "translatedManufacturerPartNumber": "LM317T",
+        "brandName": "Texas Instruments",
+        "displayName": "IC REG LINEAR 1.2V",
+        "sku": "12345",
+        "stock": {"level": 500},
+        "prices": [{"cost": "0.65"}],
+        "attributes": [
+            {"attributeLabel": "RoHS", "attributeValue": "Compliant"},
+            {"attributeLabel": "Package", "attributeValue": "TO-220-3"},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_element14_core_attrs_extracted():
+    from app.connectors.element14 import Element14Connector
+
+    c = Element14Connector(api_key="key")
+    data = {"manufacturerPartNumberSearchReturn": {"products": [_make_element14_prod()]}}
+    results = c._parse(data, "LM317T")
+    assert len(results) == 1
+    r = results[0]
+    assert r["rohs_status"] == "compliant"
+    assert r["package_type"] == "TO-220-3"
+
+
+def test_element14_core_attrs_missing():
+    from app.connectors.element14 import Element14Connector
+
+    c = Element14Connector(api_key="key")
+    prod = {
+        "translatedManufacturerPartNumber": "X",
+        "brandName": "M",
+        "displayName": "D",
+        "sku": "S",
+        "stock": {},
+        "prices": [],
+        # No attributes
+    }
+    data = {"manufacturerPartNumberSearchReturn": {"products": [prod]}}
+    results = c._parse(data, "X")
+    r = results[0]
+    assert r["rohs_status"] is None
+    assert r["package_type"] is None
+
+
+# ── OEMSecrets connector wiring ───────────────────────────────────────
+
+
+def _make_oemsecrets_item(**overrides):
+    base = {
+        "distributor": {"distributor_name": "Arrow"},
+        "manufacturer": "TI",
+        "source_part_number": "LM317T/NOPB",
+        "quantity_in_stock": 5000,
+        "prices": {"USD": [{"unit_break": 1, "unit_price": "0.89"}]},
+        "buy_now_url": "https://arrow.com/buy",
+        "datasheet_url": "https://ti.com/ds.pdf",
+        "distributor_authorisation_status": "authorised",
+        "category": "Linear Regulators",
+        "lifecycle_status": "Active",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_oemsecrets_core_attrs_extracted():
+    from app.connectors.oemsecrets import OEMSecretsConnector
+
+    c = OEMSecretsConnector(api_key="key")
+    data = {"stock": [_make_oemsecrets_item()]}
+    results = c._parse(data, "LM317T")
+    assert len(results) == 1
+    r = results[0]
+    assert r["category"] == "Linear Regulators"
+    assert r["lifecycle_status"] == "active"
+
+
+def test_oemsecrets_core_attrs_missing():
+    from app.connectors.oemsecrets import OEMSecretsConnector
+
+    c = OEMSecretsConnector(api_key="key")
+    item = {
+        "distributor": {"distributor_name": "Broker X"},
+        "source_part_number": "X",
+        "quantity_in_stock": 100,
+        "prices": {"USD": [{"unit_break": 1, "unit_price": "1.50"}]},
+        # No category or lifecycle_status
+    }
+    results = c._parse({"stock": [item]}, "X")
+    r = results[0]
+    assert r["category"] is None
+    assert r["lifecycle_status"] is None
+
+
+def test_oemsecrets_unknown_lifecycle_yields_none():
+    from app.connectors.oemsecrets import OEMSecretsConnector
+
+    c = OEMSecretsConnector(api_key="key")
+    item = _make_oemsecrets_item(lifecycle_status="Exotic Status")
+    results = c._parse({"stock": [item]}, "LM317T")
+    assert results[0]["lifecycle_status"] is None
+
+
+# ── Nexar connector wiring ────────────────────────────────────────────
+
+
+def _make_nexar_full_hit(category_name: str | None = "Microcontrollers"):
+    """Build a synthetic Nexar FULL_QUERY result hit."""
+    part: dict = {
+        "mpn": "STM32F407VGT6",
+        "manufacturer": {"name": "STMicroelectronics"},
+        "sellers": [
+            {
+                "company": {"name": "Arrow", "homepageUrl": "https://arrow.com"},
+                "isAuthorized": True,
+                "offers": [
+                    {
+                        "inventoryLevel": 500,
+                        "prices": [{"price": "12.50", "currency": "USD", "quantity": 1}],
+                        "clickUrl": "https://arrow.com/buy",
+                        "sku": "ARW-STM32",
+                    }
+                ],
+            }
+        ],
+    }
+    if category_name is not None:
+        part["category"] = {"name": category_name}
+    return {"part": part}
+
+
+def test_nexar_full_query_category_extracted():
+    from app.connectors.sources import NexarConnector
+
+    c = NexarConnector(client_id="x", client_secret="y")
+    hits = [_make_nexar_full_hit("Microcontrollers")]
+    results = c._parse_full(hits, "STM32F407VGT6")
+    assert len(results) >= 1
+    # All results from the same part share the same category
+    for r in results:
+        assert r["category"] == "Microcontrollers"
+
+
+def test_nexar_full_query_no_category_yields_none():
+    from app.connectors.sources import NexarConnector
+
+    c = NexarConnector(client_id="x", client_secret="y")
+    hits = [_make_nexar_full_hit(category_name=None)]
+    results = c._parse_full(hits, "STM32F407VGT6")
+    assert len(results) >= 1
+    for r in results:
+        assert r["category"] is None
+
+
+def test_nexar_aggregate_query_category_extracted():
+    from app.connectors.sources import NexarConnector
+
+    c = NexarConnector(client_id="x", client_secret="y")
+    hits = [
+        {
+            "part": {
+                "mpn": "LM317T",
+                "manufacturer": {"name": "TI"},
+                "totalAvail": 5000,
+                "medianPrice1000": {"price": "0.89", "currency": "USD"},
+                "shortDescription": "Voltage Regulator",
+                "category": {"name": "Linear Regulators"},
+                "octopartUrl": "https://octopart.com/lm317t",
+                "manufacturerUrl": "",
+            }
+        }
+    ]
+    results = c._parse_aggregate(hits, "LM317T")
+    assert len(results) == 1
+    assert results[0]["category"] == "Linear Regulators"

--- a/tests/test_html_table_parse.py
+++ b/tests/test_html_table_parse.py
@@ -1,0 +1,28 @@
+from app.file_utils import extract_mpns, parse_tabular_file
+
+_HTML = (
+    b'<head><META http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"></head>'
+    b"<table><tr><td>Material: Material Name</td></tr>"
+    b"<tr><td>M393A2K43EB3-CWEB/C</td></tr>"
+    b"<tr><td>04M3HJ</td></tr>"
+    b"<tr><td></td></tr>"
+    b"<tr><td>LTM8053IY#PBF</td></tr></table>"
+)
+
+
+def test_parse_html_disguised_as_xls():
+    rows = parse_tabular_file(_HTML, "report1780605266325.xls")
+    # header lowercased+stripped becomes the dict key
+    assert len(rows) == 3  # blank row dropped
+    assert rows[0]["material: material name"] == "M393A2K43EB3-CWEB/C"
+
+
+def test_extract_mpns_single_column():
+    rows = parse_tabular_file(_HTML, "report.xls")
+    mpns = extract_mpns(rows)
+    assert mpns == ["M393A2K43EB3-CWEB/C", "04M3HJ", "LTM8053IY#PBF"]
+
+
+def test_extract_mpns_named_column():
+    rows = [{"part number": "ABC123"}, {"part number": "DEF456"}]
+    assert extract_mpns(rows) == ["ABC123", "DEF456"]

--- a/tests/test_material_enrichment_status_filter.py
+++ b/tests/test_material_enrichment_status_filter.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timezone
+
+from app.models import MaterialCard
+from app.services.faceted_search_service import search_materials_faceted
+
+
+def _mk(db, mpn, status):
+    c = MaterialCard(
+        normalized_mpn=mpn,
+        display_mpn=mpn.upper(),
+        enrichment_status=status,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(c)
+    return c
+
+
+def test_verified_only_filter(db_session):
+    _mk(db_session, "verifiedone", "verified")
+    _mk(db_session, "guessedone", "ai_inferred")
+    _mk(db_session, "missingone", "not_found")
+    db_session.flush()
+
+    all_cards, total_all = search_materials_faceted(db_session)
+    assert total_all >= 3
+
+    verified, total_v = search_materials_faceted(db_session, verified_only=True)
+    assert {c.normalized_mpn for c in verified} == {"verifiedone"}
+    assert total_v == 1

--- a/tests/test_part_number_import.py
+++ b/tests/test_part_number_import.py
@@ -1,0 +1,22 @@
+"""Tests for POST /api/materials/import-part-numbers endpoint."""
+
+import io
+
+
+def test_import_part_numbers_creates_bare_cards(client, db_session):
+    from app.models import MaterialCard
+
+    html = (
+        b"<table><tr><td>Material: Material Name</td></tr>"
+        b"<tr><td>NEWPART-001</td></tr><tr><td>NEWPART-002</td></tr></table>"
+    )
+    resp = client.post(
+        "/api/materials/import-part-numbers",
+        files={"file": ("report.xls", io.BytesIO(html), "application/vnd.ms-excel")},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["created"] == 2
+    cards = db_session.query(MaterialCard).filter(MaterialCard.normalized_mpn.in_(["newpart001", "newpart002"])).all()
+    assert len(cards) == 2
+    assert all(c.enrichment_status == "unenriched" for c in cards)


### PR DESCRIPTION
## Summary
Adds a **verified, source-attributed** material-enrichment path plus a bare part-number importer. Enrichment now pulls real catalog data from existing connectors (DigiKey → Mouser → Element14 → OEMSecrets → Nexar) with **per-field provenance**, and only falls back to a **clearly-flagged** Opus 4.8 guess when no authoritative source resolves a part. Nothing is ever a silent guess.

Motivated by a 1,827-row SFTP report of "every part we've ever been asked for" (bare MPNs, ~37% OEM/FRU codes) that needed accurate, filterable descriptions/specs without hallucination.

## What's included (TDD, 9 tasks)
- **Model + migration** `a1f7c2d9e4b8`: `material_cards.enrichment_status` (`unenriched|verified|ai_inferred|not_found`, indexed) + `enrichment_provenance` (JSONB).
- **Connector core-attribute extraction** (additive): category / lifecycle / package / pin_count / rohs via shared `app/connectors/_core_attrs.py`. Existing search behavior unchanged.
- **`authoritative_enrichment_service`**: exact-normalized-MPN-match guard (the accuracy core), first-non-null-by-priority merge with provenance, cost-optimized source order (paid Nexar last/gap-only), `enrich_card`/`enrich_cards`.
- **`ai_inference_fallback`** (Opus 4.8): description+category only, declines → `not_found` when unsure, NEVER fabricates structured specs. (`MODELS["opus"]` bumped to `claude-opus-4-8`.)
- **Importer**: `POST /api/materials/import-part-numbers` (buyer-gated) + `scripts/import_part_numbers.py` (dry-run coverage report); handles the HTML-table-as-`.xls` export format.
- **Filtering/UI**: `verified_only` faceted filter + status badge (`list.html`) + "Verified only" toggle (`workspace.html` / `htmx_app.js`), so a guessed value never silently pollutes a filtered result.

## Testing
- Full suite: **14331 passed, 29 skipped, 1 xfailed** (0 failures).
- Vite build ✅ · pre-commit (ruff/ruff-format/mypy/docformatter) ✅.
- 43 feature tests incl. exact-match-guard rejection, merge precedence, flagged-fallback transitions, HTML-`.xls` parsing.

## ⚠️ Three-way merge coordination
This branch overlaps two sibling branches the team is merging together:
- **#203 `feat/materials-spec-enrichment`** — overlaps on `intelligence.py`, `faceted_search_service.py`, `htmx_views.py`, `list.html`, `workspace.html`, `htmx_app.js`, APP_MAP docs. **Both migrations branch off `086_add_activity_digest` → two Alembic heads.**
- **`feat/activity-audit-repairs`** — overlaps on `htmx_views.py`.

**Recommended order: activity → #203 → this PR.** Rebase this branch last and re-chain its migration `down_revision` `086 → 087_add_specs_enriched_at` for a linear history (avoids `alembic merge heads`). On the `MaterialCard` conflict, **keep ALL columns** (specs_enriched_at + enrichment_status + enrichment_provenance).

## Held until explicitly approved (runtime, not code)
1. `scripts/import_part_numbers.py --file "…report1780605266325.xls"` **dry-run** → review verified/ai_inferred/not_found split (expect a large not_found share — the OEM/FRU codes).
2. `--commit` to the DB, then deploy (`--no-cache`) + backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)