### PR TITLE
No-hallucination OEM/FRU enrichment (cross-ref + OEM-sourced tiers)

### DIFF
--- a/alembic/versions/089_oem_enrichment_status_columns.py
+++ b/alembic/versions/089_oem_enrichment_status_columns.py
@@ -1,0 +1,45 @@
+"""Add OEM-tier daily counters to enrichment_worker_status.
+
+Adds ``oem_sourced_today`` and ``not_catalogued_today`` so the worker's per-tier
+heartbeat/daily-summary observability covers the two OEM tiers (oem_sourced /
+not_catalogued) added alongside the no-hallucination OEM enrichment feature. Also
+documents the expanded MaterialEnrichmentStatus value set on material_cards via a
+Postgres column comment (guarded so it no-ops on SQLite test runs).
+
+Revision ID: 089_oem_enrichment_status_columns
+Revises: 088_enrichment_worker_status
+Create Date: 2026-06-05
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "089_oem_enrichment_status_columns"
+down_revision = "088_enrichment_worker_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "enrichment_worker_status",
+        sa.Column("oem_sourced_today", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "enrichment_worker_status",
+        sa.Column("not_catalogued_today", sa.Integer(), nullable=False, server_default="0"),
+    )
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(
+            "COMMENT ON COLUMN material_cards.enrichment_status IS "
+            "'unenriched|verified|web_sourced|oem_sourced|ai_inferred|not_found|not_catalogued "
+            "(see MaterialEnrichmentStatus)'"
+        )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("COMMENT ON COLUMN material_cards.enrichment_status IS NULL")
+    op.drop_column("enrichment_worker_status", "not_catalogued_today")
+    op.drop_column("enrichment_worker_status", "oem_sourced_today")

--- a/app/constants.py
+++ b/app/constants.py
@@ -452,7 +452,7 @@ class InboxSyncHealth(StrEnum):
 class MaterialEnrichmentStatus(StrEnum):
     """Enrichment tier for MaterialCard.enrichment_status.
 
-    Single source of truth for the five valid enrichment tiers. Enforced at the ORM
+    Single source of truth for the seven valid enrichment tiers. Enforced at the ORM
     layer via @validates on MaterialCard.
     """
 
@@ -461,3 +461,5 @@ class MaterialEnrichmentStatus(StrEnum):
     WEB_SOURCED = "web_sourced"
     AI_INFERRED = "ai_inferred"
     NOT_FOUND = "not_found"
+    OEM_SOURCED = "oem_sourced"
+    NOT_CATALOGUED = "not_catalogued"

--- a/app/models/enrichment_worker_status.py
+++ b/app/models/enrichment_worker_status.py
@@ -7,7 +7,8 @@ is allowed via CHECK constraint.
 Business Rules:
 - Exactly one row exists (id=1), inserted by migration
 - Worker updates this row periodically with heartbeat and stats
-- Tracks daily enrichment counts by tier (web_sourced, ai_inferred, not_found)
+- Tracks daily enrichment counts by tier (web_sourced, oem_sourced, ai_inferred,
+  not_found, not_catalogued)
 - Circuit breaker state is persisted here for observability
 
 Called by: enrichment_worker.worker (heartbeat updates)
@@ -33,6 +34,8 @@ class EnrichmentWorkerStatus(Base):
     web_sourced_today = Column(Integer, default=0, server_default="0", nullable=False)
     ai_inferred_today = Column(Integer, default=0, server_default="0", nullable=False)
     not_found_today = Column(Integer, default=0, server_default="0", nullable=False)
+    oem_sourced_today = Column(Integer, default=0, server_default="0", nullable=False)
+    not_catalogued_today = Column(Integer, default=0, server_default="0", nullable=False)
     circuit_breaker_open = Column(Boolean, default=False, server_default="false", nullable=False)
     circuit_breaker_reason = Column(Text)
     daily_stats_json = Column(JSON)

--- a/app/models/intelligence.py
+++ b/app/models/intelligence.py
@@ -51,7 +51,7 @@ class MaterialCard(Base):
     specs_enriched_at = Column(UTCDateTime, index=True)  # NULL = spec pass not yet run
     # Verification provenance (added 2026-06-04 — verified-enrichment feature)
     # enrichment_status: see constants.MaterialEnrichmentStatus (validated on write):
-    # unenriched | verified | web_sourced | ai_inferred | not_found
+    # unenriched | verified | web_sourced | oem_sourced | ai_inferred | not_found | not_catalogued
     enrichment_status = Column(String(20), nullable=False, server_default="unenriched", index=True)
     # Per-field provenance: {"<field>": {"source": "digikey", "confidence": 1.0,
     #                                    "fetched_at": "2026-06-04T..Z", "matched_mpn": "..."}}

--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -20,6 +20,13 @@ from sqlalchemy.orm import Session
 from app.connectors.errors import ConnectorAuthError, ConnectorQuotaError, ConnectorRateLimitError
 from app.constants import MaterialEnrichmentStatus
 from app.models import MaterialCard
+from app.services.enrichment_worker.oem_classifier import classify_oem_vendor
+from app.services.enrichment_worker.oem_extractor import (
+    CrossRefResult,
+    OemExtractResult,
+    cross_reference_mpn,
+    extract_oem_description,
+)
 from app.services.enrichment_worker.web_extractor import WebExtractResult, extract_part_from_web
 from app.utils.claude_errors import ClaudeError
 from app.utils.normalization import normalize_mpn_key
@@ -200,6 +207,70 @@ def apply_web_sourced(card: MaterialCard, result: WebExtractResult) -> None:
     card.enriched_at = now
 
 
+def apply_cross_ref_verified(
+    card: MaterialCard,
+    merged: dict,
+    provenance: dict,
+    contributors: list[str],
+    xr: CrossRefResult,
+) -> None:
+    """Write the resolved commodity MPN's distributor data onto an OEM/FRU card.
+
+    Status becomes ``verified`` (the resolved MPN was independently confirmed against a
+    distributor). Records the FRU<->MPN linkage in ``cross_references`` and a top-level
+    ``cross_ref`` provenance block so the whole chain is auditable.
+    """
+    now = datetime.now(timezone.utc)
+    for field_name, value in merged.items():
+        setattr(card, field_name, value)
+    xrefs = list(card.cross_references or [])
+    xrefs.append({"mpn": xr.resolved_mpn, "manufacturer": xr.manufacturer})
+    card.cross_references = xrefs
+    prov = dict(provenance)
+    prov["cross_ref"] = {
+        "oem_part": card.display_mpn,
+        "resolved_mpn": xr.resolved_mpn,
+        "linkage_source_url": xr.linkage_source_url,
+        "linkage_source_domain": xr.linkage_source_domain,
+        "confirmed_by": contributors[0] if contributors else None,
+        "confidence": xr.confidence,
+    }
+    card.enrichment_provenance = prov
+    card.enrichment_source = contributors[0] if contributors else "cross_ref"
+    card.enrichment_status = MaterialEnrichmentStatus.VERIFIED
+    card.enriched_at = now
+
+
+def apply_oem_sourced(card: MaterialCard, result: OemExtractResult) -> None:
+    """Write OEM-official description/category onto the card (status ``oem_sourced``).
+
+    Description + category + datasheet only — never structured specs.
+    """
+    now = datetime.now(timezone.utc)
+    iso = now.isoformat()
+    prov: dict = {
+        "oem_sourced": True,
+        "confidence": result.confidence,
+        "source_urls": result.source_urls,
+        "source_domains": result.source_domains,
+        "fetched_at": iso,
+    }
+    fields = {
+        "description": result.description,
+        "category": result.category,
+        "datasheet_url": result.datasheet_url,
+        "manufacturer": result.manufacturer,
+    }
+    for f, v in fields.items():
+        if v:
+            setattr(card, f, v)
+            prov[f] = {"source": "oem_official", "confidence": result.confidence, "fetched_at": iso}
+    card.enrichment_source = "oem_official"
+    card.enrichment_status = MaterialEnrichmentStatus.OEM_SOURCED
+    card.enrichment_provenance = prov
+    card.enriched_at = now
+
+
 async def enrich_card(
     card: MaterialCard,
     db: Session,
@@ -208,6 +279,7 @@ async def enrich_card(
     refresh: bool = False,
     disabled: set[str] | None = None,
     cooldown: dict[str, float] | None = None,
+    web_meter: dict | None = None,
 ) -> str:
     """Enrich one card: authoritative -> flagged AI inference -> not_found.
 
@@ -216,13 +288,21 @@ async def enrich_card(
     ``cooldown`` accumulates sources that hit a transient rate limit (skipped until
     the cooldown window expires, not permanently disabled).
 
+    ``web_meter`` (optional ``{"web_calls": int, "claude_ok": bool}``) is updated in place:
+    ``web_calls`` counts each billable web-search call made (distributor web, cross-ref, OEM
+    description); ``claude_ok`` is set True after ANY Claude call (incl. infer_part) returns
+    without raising. The worker uses ``web_calls`` for the daily budget and ``claude_ok`` to
+    reset its circuit breaker. Default None = no metering.
+
     CONCURRENCY INVARIANT: safe to run over a shared Session via asyncio.gather
     because, after its first ``await``, this function performs NO DB query/flush —
     only in-memory attribute writes on ``card`` — so synchronous session ops never
     interleave across awaits on the single-threaded event loop. Do NOT add a
     db.query()/db.flush() after the await without switching callers to per-card
     sessions, or concurrent runs (import script, enrichment worker) will corrupt
-    the identity map.
+    the identity map. The cross-ref re-verification (``fetch_authoritative`` on the
+    resolved MPN) is pure async connector I/O — no DB query/flush — so the invariant
+    holds.
     """
     if card.enrichment_status == MaterialEnrichmentStatus.VERIFIED and not refresh:
         return MaterialEnrichmentStatus.VERIFIED
@@ -235,20 +315,52 @@ async def enrich_card(
         apply_authoritative(card, merged, provenance, contributors)
         return MaterialEnrichmentStatus.VERIFIED
 
-    # Web-sourced tier: grounded web search on authoritative distributor/manufacturer pages.
-    # Skipped when "web_search" is in the disabled set (e.g. daily budget exhausted).
+    web_enabled = not (disabled and "web_search" in disabled)
+
+    # Distributor / manufacturer web tier.
     # CONCURRENCY INVARIANT: this await is pure async (no DB) — no DB query/flush follows it;
     # see the docstring above for the full invariant.
-    if not (disabled and "web_search" in disabled):
+    if web_enabled:
         web = await extract_part_from_web(card.display_mpn, card.normalized_mpn)
+        if web_meter is not None:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
+            web_meter["claude_ok"] = True
         if web.status == "web_sourced":
             apply_web_sourced(card, web)
             return MaterialEnrichmentStatus.WEB_SOURCED
 
-    # No authoritative hit -> flagged inference
+    # OEM tiers — only for recognised OEM/FRU codes, only when the web budget is live.
+    vendor = classify_oem_vendor(card.display_mpn)
+    oem_attempted = False
+    if vendor and web_enabled:
+        oem_attempted = True
+        # Tier 3: cross-reference, then INDEPENDENTLY re-verify against distributors.
+        xr = await cross_reference_mpn(card.display_mpn, card.normalized_mpn, vendor)
+        if web_meter is not None:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
+            web_meter["claude_ok"] = True
+        if xr.status == "resolved" and xr.resolved_mpn:
+            resolved_key = normalize_mpn_key(xr.resolved_mpn)
+            xr_results = await fetch_authoritative(xr.resolved_mpn, resolved_key, conns, disabled, cooldown)
+            xr_merged, xr_prov, xr_contrib = merge_authoritative(resolved_key, xr_results)
+            if xr_merged:
+                apply_cross_ref_verified(card, xr_merged, xr_prov, xr_contrib, xr)
+                return MaterialEnrichmentStatus.VERIFIED
+        # Tier 4: OEM-official description (single authoritative page).
+        oem = await extract_oem_description(card.display_mpn, card.normalized_mpn, vendor)
+        if web_meter is not None:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
+            web_meter["claude_ok"] = True
+        if oem.status == "oem_sourced":
+            apply_oem_sourced(card, oem)
+            return MaterialEnrichmentStatus.OEM_SOURCED
+
+    # No authoritative hit -> flagged inference.
     from app.services.ai_inference_fallback import infer_part
 
     inf = await infer_part(card.display_mpn)
+    if web_meter is not None:
+        web_meter["claude_ok"] = True
     now = datetime.now(timezone.utc)
     card.enriched_at = now
     if inf.status == "ai_inferred":
@@ -268,11 +380,13 @@ async def enrich_card(
         }
         return MaterialEnrichmentStatus.AI_INFERRED
 
-    # F5: not_found parts get no provenance — they are genuinely unresolved.
-    card.enrichment_status = MaterialEnrichmentStatus.NOT_FOUND
+    # Terminal: not_catalogued only when an OEM pattern matched AND the OEM tiers ran.
+    card.enrichment_status = (
+        MaterialEnrichmentStatus.NOT_CATALOGUED if (vendor and oem_attempted) else MaterialEnrichmentStatus.NOT_FOUND
+    )
     card.enrichment_source = None
     card.enrichment_provenance = None
-    return MaterialEnrichmentStatus.NOT_FOUND
+    return card.enrichment_status
 
 
 async def enrich_cards(card_ids: list[int], db: Session, *, concurrency: int = 5, refresh: bool = False) -> dict:

--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -21,7 +21,7 @@ from app.connectors.errors import ConnectorAuthError, ConnectorQuotaError, Conne
 from app.constants import MaterialEnrichmentStatus
 from app.models import MaterialCard
 from app.services.enrichment_types import WebMeter
-from app.services.enrichment_worker.oem_classifier import classify_oem_vendor
+from app.services.enrichment_worker.oem_classifier import HIGH_PRECISION_VENDORS, classify_oem_vendor
 from app.services.enrichment_worker.oem_extractor import (
     CrossRefResult,
     OemExtractResult,
@@ -227,17 +227,18 @@ def apply_cross_ref_verified(
     xrefs = list(card.cross_references or [])
     xrefs.append({"mpn": xr.resolved_mpn, "manufacturer": xr.manufacturer})
     card.cross_references = xrefs
+    confirmer = contributors[0] if contributors else None
     prov = dict(provenance)
     prov["cross_ref"] = {
         "oem_part": card.display_mpn,
         "resolved_mpn": xr.resolved_mpn,
         "linkage_source_url": xr.linkage_source_url,
         "linkage_source_domain": xr.linkage_source_domain,
-        "confirmed_by": contributors[0] if contributors else None,
+        "confirmed_by": confirmer,
         "confidence": xr.confidence,
     }
     card.enrichment_provenance = prov
-    card.enrichment_source = contributors[0] if contributors else "cross_ref"
+    card.enrichment_source = confirmer or "cross_ref"
     card.enrichment_status = MaterialEnrichmentStatus.VERIFIED
     card.enriched_at = now
 
@@ -307,8 +308,11 @@ async def enrich_card(
     resolved MPN) is pure async connector I/O — no DB query/flush — so the invariant
     holds.
     """
-    if card.enrichment_status == MaterialEnrichmentStatus.VERIFIED and not refresh:
-        return MaterialEnrichmentStatus.VERIFIED
+    if (
+        card.enrichment_status in (MaterialEnrichmentStatus.VERIFIED, MaterialEnrichmentStatus.OEM_SOURCED)
+        and not refresh
+    ):
+        return card.enrichment_status
 
     conns = connectors if connectors is not None else _connectors_in_order(db)
     results = await fetch_authoritative(card.display_mpn, card.normalized_mpn, conns, disabled, cooldown)
@@ -386,9 +390,14 @@ async def enrich_card(
         }
         return MaterialEnrichmentStatus.AI_INFERRED
 
-    # Terminal: not_catalogued only when an OEM pattern matched AND the OEM tiers ran.
+    # Terminal: not_catalogued only when a HIGH-PRECISION OEM pattern matched AND the OEM
+    # tiers ran. The broad Dell 5-char pattern is excluded (see HIGH_PRECISION_VENDORS) so a
+    # generic 5-char part missing every tier stays not_found (22h retry) instead of being
+    # parked for ~30 days. `vendor in HIGH_PRECISION_VENDORS` is False when vendor is None.
     card.enrichment_status = (
-        MaterialEnrichmentStatus.NOT_CATALOGUED if (vendor and oem_attempted) else MaterialEnrichmentStatus.NOT_FOUND
+        MaterialEnrichmentStatus.NOT_CATALOGUED
+        if (vendor in HIGH_PRECISION_VENDORS and oem_attempted)
+        else MaterialEnrichmentStatus.NOT_FOUND
     )
     card.enrichment_source = None
     card.enrichment_provenance = None
@@ -407,8 +416,10 @@ async def enrich_cards(card_ids: list[int], db: Session, *, concurrency: int = 5
     counts: dict[str, int] = {
         MaterialEnrichmentStatus.VERIFIED: 0,
         MaterialEnrichmentStatus.WEB_SOURCED: 0,
+        MaterialEnrichmentStatus.OEM_SOURCED: 0,
         MaterialEnrichmentStatus.AI_INFERRED: 0,
         MaterialEnrichmentStatus.NOT_FOUND: 0,
+        MaterialEnrichmentStatus.NOT_CATALOGUED: 0,
     }
 
     async def _one(cid: int) -> None:

--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from app.connectors.errors import ConnectorAuthError, ConnectorQuotaError, ConnectorRateLimitError
 from app.constants import MaterialEnrichmentStatus
 from app.models import MaterialCard
+from app.services.enrichment_types import WebMeter
 from app.services.enrichment_worker.oem_classifier import classify_oem_vendor
 from app.services.enrichment_worker.oem_extractor import (
     CrossRefResult,
@@ -279,20 +280,22 @@ async def enrich_card(
     refresh: bool = False,
     disabled: set[str] | None = None,
     cooldown: dict[str, float] | None = None,
-    web_meter: dict | None = None,
+    web_meter: WebMeter | None = None,
 ) -> str:
-    """Enrich one card: authoritative -> flagged AI inference -> not_found.
+    """Authoritative -> web -> OEM cross-ref/description -> flagged AI inference ->
+    not_catalogued/not_found.
 
     Returns the resulting enrichment_status. Does not commit (caller controls txn).
     ``disabled`` accumulates sources that hit a quota/auth wall (skipped run-wide).
     ``cooldown`` accumulates sources that hit a transient rate limit (skipped until
     the cooldown window expires, not permanently disabled).
 
-    ``web_meter`` (optional ``{"web_calls": int, "claude_ok": bool}``) is updated in place:
-    ``web_calls`` counts each billable web-search call made (distributor web, cross-ref, OEM
-    description); ``claude_ok`` is set True after ANY Claude call (incl. infer_part) returns
-    without raising. The worker uses ``web_calls`` for the daily budget and ``claude_ok`` to
-    reset its circuit breaker. Default None = no metering.
+    ``web_meter`` (optional :class:`WebMeter`) is updated in place: ``web_calls`` counts each
+    web-search-enabled Claude tier attempt (distributor / cross-ref / OEM-description),
+    reserved before dispatch so a call that bills then raises is still counted; ``claude_ok``
+    is latched True after ANY Claude call (incl. infer_part) returns without raising. The
+    worker uses ``web_calls`` for the daily budget and ``claude_ok`` to reset its circuit
+    breaker. Default None = no metering.
 
     CONCURRENCY INVARIANT: safe to run over a shared Session via asyncio.gather
     because, after its first ``await``, this function performs NO DB query/flush —
@@ -321,10 +324,11 @@ async def enrich_card(
     # CONCURRENCY INVARIANT: this await is pure async (no DB) — no DB query/flush follows it;
     # see the docstring above for the full invariant.
     if web_enabled:
+        if web_meter is not None:
+            web_meter.reserve_web_call()
         web = await extract_part_from_web(card.display_mpn, card.normalized_mpn)
         if web_meter is not None:
-            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
-            web_meter["claude_ok"] = True
+            web_meter.mark_claude_ok()
         if web.status == "web_sourced":
             apply_web_sourced(card, web)
             return MaterialEnrichmentStatus.WEB_SOURCED
@@ -335,10 +339,11 @@ async def enrich_card(
     if vendor and web_enabled:
         oem_attempted = True
         # Tier 3: cross-reference, then INDEPENDENTLY re-verify against distributors.
+        if web_meter is not None:
+            web_meter.reserve_web_call()
         xr = await cross_reference_mpn(card.display_mpn, card.normalized_mpn, vendor)
         if web_meter is not None:
-            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
-            web_meter["claude_ok"] = True
+            web_meter.mark_claude_ok()
         if xr.status == "resolved" and xr.resolved_mpn:
             resolved_key = normalize_mpn_key(xr.resolved_mpn)
             xr_results = await fetch_authoritative(xr.resolved_mpn, resolved_key, conns, disabled, cooldown)
@@ -347,10 +352,11 @@ async def enrich_card(
                 apply_cross_ref_verified(card, xr_merged, xr_prov, xr_contrib, xr)
                 return MaterialEnrichmentStatus.VERIFIED
         # Tier 4: OEM-official description (single authoritative page).
+        if web_meter is not None:
+            web_meter.reserve_web_call()
         oem = await extract_oem_description(card.display_mpn, card.normalized_mpn, vendor)
         if web_meter is not None:
-            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
-            web_meter["claude_ok"] = True
+            web_meter.mark_claude_ok()
         if oem.status == "oem_sourced":
             apply_oem_sourced(card, oem)
             return MaterialEnrichmentStatus.OEM_SOURCED
@@ -360,7 +366,7 @@ async def enrich_card(
 
     inf = await infer_part(card.display_mpn)
     if web_meter is not None:
-        web_meter["claude_ok"] = True
+        web_meter.mark_claude_ok()
     now = datetime.now(timezone.utc)
     card.enriched_at = now
     if inf.status == "ai_inferred":

--- a/app/services/enrichment_types.py
+++ b/app/services/enrichment_types.py
@@ -3,7 +3,36 @@ at the ORM layer; these constrain the producer functions under mypy)."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import NotRequired, TypedDict
+
+
+@dataclass
+class WebMeter:
+    """Mutable per-card budget/health meter threaded through ``enrich_card``.
+
+    ``web_calls`` counts billable web-search-enabled Claude tier attempts; it is
+    RESERVED *before* each dispatch so a call that bills then raises is still counted.
+    ``claude_ok`` latches True after any Claude call returns without raising. The worker
+    uses ``web_calls`` for the daily web budget and ``claude_ok`` to reset its breaker.
+    """
+
+    web_calls: int = 0
+    claude_ok: bool = False
+
+    def reserve_web_call(self) -> None:
+        """Count one billable web-search tier attempt.
+
+        Call BEFORE the await.
+        """
+        self.web_calls += 1
+
+    def mark_claude_ok(self) -> None:
+        """Latch that a Claude call returned without raising.
+
+        Call AFTER the await.
+        """
+        self.claude_ok = True
 
 
 class FieldProvenance(TypedDict):

--- a/app/services/enrichment_worker/config.py
+++ b/app/services/enrichment_worker/config.py
@@ -27,6 +27,7 @@ class EnrichmentWorkerConfig:
     # often is negligible.
     idle_sleep_seconds: int = 60
     not_found_retry_hours: int = 22
+    not_catalogued_retry_days: int = 30
     circuit_breaker_errors: int = 5
 
     @classmethod
@@ -39,5 +40,6 @@ class EnrichmentWorkerConfig:
             loop_sleep_seconds=int(os.environ.get("ENRICHMENT_LOOP_SLEEP_SECONDS", 30)),
             idle_sleep_seconds=int(os.environ.get("ENRICHMENT_IDLE_SLEEP_SECONDS", 60)),
             not_found_retry_hours=int(os.environ.get("ENRICHMENT_NOT_FOUND_RETRY_HOURS", 22)),
+            not_catalogued_retry_days=int(os.environ.get("ENRICHMENT_NOT_CATALOGUED_RETRY_DAYS", 30)),
             circuit_breaker_errors=int(os.environ.get("ENRICHMENT_CIRCUIT_BREAKER_ERRORS", 5)),
         )

--- a/app/services/enrichment_worker/oem_classifier.py
+++ b/app/services/enrichment_worker/oem_classifier.py
@@ -1,0 +1,55 @@
+"""Classify an MPN as an OEM/system-vendor FRU/spare/service part number.
+
+Pure, regex-based vendor detection used to gate the OEM enrichment tiers (cross-ref +
+OEM official description) in ``enrich_card``. Returns the likely OEM vendor or ``None``.
+The label is advisory only — it seeds the search prompt; correctness is enforced
+downstream by the Python gates in ``oem_extractor`` / ``enrich_card``, never here.
+
+Called by: app.services.authoritative_enrichment_service.enrich_card,
+scripts.backfill_oem_enrichment. Depends on: stdlib ``re`` only.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Ordered (priority) (vendor, pattern). First match wins. Anchored, matched against the
+# UPPERCASED stripped display_mpn. Each pattern is justified by a real not_found sample
+# (see spec §1).
+_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    # Lenovo modern FRU/option: 5x + 2 digits + letter + 5 digits (5B20L64949, 5T10Q96500)
+    ("lenovo", re.compile(r"^5[A-Z]\d{2}[A-Z]\d{5}$")),
+    # Lenovo/IBM classic FRU: 2 digits + letter + 4 alnum (38L7669, 46C9040)
+    ("lenovo", re.compile(r"^\d{2}[A-Z][A-Z0-9]{4}$")),
+    # Lenovo/IBM 7-char FRU: 00/01 + 5 alnum (01HW917, 00E2891, 01LV731)
+    ("lenovo", re.compile(r"^0[01][A-Z0-9]{5}$")),
+    # Acer dotted part code: 2 alnum . 5 alnum . 3 alnum (NB.MBC11.003, 33.G55N7.002)
+    ("acer", re.compile(r"^[A-Z0-9]{2}\.[A-Z0-9]{5}\.[A-Z0-9]{3}$")),
+    # ASUS module code: 2 digits NB + 4 alnum - tail (60NB0690-MB1820)
+    ("asus", re.compile(r"^\d{2}NB[A-Z0-9]{4}-[A-Z0-9]+$")),
+    # ASUS 0X###-######## (0B200-00930000)
+    ("asus", re.compile(r"^0[A-Z]\d{3}-\d{8}$")),
+    # HP/HPE spare: 6 digits - 3 digits (918042-601, 619559-001)
+    ("hpe", re.compile(r"^\d{6}-\d{3}$")),
+    # Dell 5-char spare with >=1 letter (HV52W, 66YYK). Broad/low-priority; a false
+    # positive costs only a wasted web call (genuine MPNs resolve at earlier tiers first).
+    ("dell", re.compile(r"^(?=[A-Z0-9]{5}$)[A-Z0-9]*[A-Z][A-Z0-9]*$")),
+]
+
+
+def classify_oem_vendor(display_mpn: str | None) -> str | None:
+    """Return the likely OEM vendor for an OEM/FRU/spare code, or ``None``.
+
+    Never raises on empty/malformed input (returns ``None``). The vendor label only seeds
+    the cross-ref / description search prompt; the Python trust gates downstream enforce
+    correctness.
+    """
+    if not isinstance(display_mpn, str):
+        return None
+    mpn = display_mpn.strip().upper()
+    if not mpn:
+        return None
+    for vendor, pat in _PATTERNS:
+        if pat.match(mpn):
+            return vendor
+    return None

--- a/app/services/enrichment_worker/oem_classifier.py
+++ b/app/services/enrichment_worker/oem_classifier.py
@@ -13,6 +13,12 @@ from __future__ import annotations
 
 import re
 
+# Vendors whose patterns are precise enough that an OEM-tier miss means "genuinely an
+# uncatalogued OEM service part" (-> not_catalogued, 30-day backoff). The broad Dell
+# 5-char pattern is excluded: a miss there is more likely a generic part, so it stays
+# not_found (22h retry) instead of being parked for a month.
+HIGH_PRECISION_VENDORS: frozenset[str] = frozenset({"lenovo", "ibm", "hpe", "acer", "asus"})
+
 # Ordered (priority) (vendor, pattern). First match wins. Anchored, matched against the
 # UPPERCASED stripped display_mpn. Each pattern is justified by a real not_found sample
 # (see spec §1).

--- a/app/services/enrichment_worker/oem_domains.py
+++ b/app/services/enrichment_worker/oem_domains.py
@@ -1,0 +1,65 @@
+"""Security allowlist for OEM-sourced enrichment.
+
+``is_oem_domain``: official system-vendor parts/support hosts (Lenovo, HPE, HP, Dell,
+Acer, ASUS, IBM). A page on one of these may produce an ``oem_sourced`` description.
+
+``is_crossref_domain``: the OEM-official set UNION the existing distributor + manufacturer
+allowlist — a distributor/manufacturer page that lists an OEM FRU next to the commodity
+MPN is acceptable evidence for the *linkage* (the resolved MPN is independently
+re-verified against distributors regardless). Validated in code; the LLM's domain claims
+are never trusted.
+
+Called by: app.services.enrichment_worker.oem_extractor.
+Depends on: app.services.enrichment_worker.trusted_domains.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from .trusted_domains import is_trusted_domain
+
+# Exact-host official OEM/system-vendor parts & support domains.
+OEM_OFFICIAL_HOSTS: frozenset[str] = frozenset(
+    {
+        "support.lenovo.com",
+        "pcsupport.lenovo.com",
+        "partsurfer.hpe.com",
+        "partsurfer.com",
+        "support.hpe.com",
+        "support.hp.com",
+        "parts.hp.com",
+        "www.dell.com",
+        "dell.com",
+        "www.acer.com",
+        "us.acer.com",
+        "www.asus.com",
+    }
+)
+
+# Vendor root domains matched by dot-suffix (foo.lenovo.com matches lenovo.com).
+OEM_VENDOR_ROOTS: frozenset[str] = frozenset(
+    {"lenovo.com", "hpe.com", "hp.com", "dell.com", "acer.com", "asus.com", "ibm.com"}
+)
+
+
+def is_oem_domain(url: str) -> bool:
+    """Return True if *url* is an official OEM/system-vendor parts/support domain."""
+    try:
+        p = urlparse(url)
+    except Exception:
+        return False
+    if p.scheme not in ("http", "https") or not p.hostname:
+        return False
+    host = p.hostname.lower()
+    if host in OEM_OFFICIAL_HOSTS:
+        return True
+    return any(host == r or host.endswith("." + r) for r in OEM_VENDOR_ROOTS)
+
+
+def is_crossref_domain(url: str) -> bool:
+    """Return True if *url* is authoritative for asserting a FRU<->MPN linkage.
+
+    OEM-official set plus the existing distributor / manufacturer allowlist.
+    """
+    return is_oem_domain(url) or is_trusted_domain(url)

--- a/app/services/enrichment_worker/oem_extractor.py
+++ b/app/services/enrichment_worker/oem_extractor.py
@@ -1,0 +1,231 @@
+"""Grounded OEM enrichment: Claude reads authoritative OEM / cross-reference pages and
+either (a) resolves an OEM/FRU code to the commodity MPN it relabels, or (b) extracts an
+OEM-official description. All trust gates enforced in Python — the model's gate claims are
+never trusted.
+
+Called by: app.services.authoritative_enrichment_service.enrich_card.
+Depends on: app.utils.claude_client, app.utils.normalization, .oem_domains.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+from loguru import logger
+
+from app.utils.claude_client import claude_json
+from app.utils.claude_errors import ClaudeError
+from app.utils.normalization import normalize_mpn_key
+
+from .oem_domains import is_crossref_domain, is_oem_domain
+
+_MIN_CROSSREF_CONFIDENCE = 0.90
+_MIN_OEM_CONFIDENCE = 0.90
+
+
+# --------------------------------- cross-reference ---------------------------------
+
+
+@dataclass
+class CrossRefResult:
+    """Candidate OEM->commodity-MPN cross-reference (not yet distributor-confirmed)."""
+
+    status: str  # "resolved" | "failed"
+    resolved_mpn: str | None = None
+    manufacturer: str | None = None
+    linkage_source_url: str | None = None
+    linkage_source_domain: str | None = None
+    confidence: float = 0.0
+
+
+_XR_FAILED = CrossRefResult(status="failed")
+
+_XR_SYSTEM = (
+    "You are an electronics cross-reference assistant. An OEM/system-vendor FRU, spare, or "
+    "service part number relabels a commodity component. Use web search to find an "
+    "AUTHORITATIVE page (the OEM's own site, or an authorized distributor/manufacturer page) "
+    "that shows BOTH the OEM code AND the underlying manufacturer part number together. "
+    "Return ONLY valid JSON. Never invent a part number; use null when unknown."
+)
+_XR_PROMPT = (
+    "OEM/FRU part number: {mpn} (vendor: {vendor}). Find the commodity manufacturer part "
+    'number it corresponds to. Return JSON: {{"resolved_mpn": str|null, "manufacturer": '
+    'str|null, "linkage_quote": str, "confidence": float, "source_urls": [str]}}. '
+    "linkage_quote must be the verbatim text from the page that shows the OEM code and the "
+    "resolved_mpn together."
+)
+
+
+async def cross_reference_mpn(
+    display_mpn: str,
+    normalized_mpn: str,
+    vendor: str,
+    *,
+    timeout: int = 90,
+) -> CrossRefResult:
+    """Resolve an OEM/FRU code to a CANDIDATE commodity MPN via grounded web search.
+
+    Four Python gates: (1) >=1 source URL on a cross-ref allowlist domain; (2) both the OEM
+    code and the resolved MPN appear verbatim (normalized) in the sourced ``linkage_quote``
+    — this is what makes a real-but-wrong guess detectable; (3) resolved != original (no
+    echo); (4) confidence threshold. Returns the candidate only — the caller independently
+    re-verifies the MPN against distributors. Raises ClaudeError on backend failure.
+    """
+    if not normalized_mpn:
+        return _XR_FAILED
+    try:
+        data = await claude_json(
+            _XR_PROMPT.format(mpn=display_mpn, vendor=vendor),
+            system=_XR_SYSTEM,
+            model_tier="smart",
+            max_tokens=1000,
+            tools=[{"type": "web_search_20250305", "name": "web_search", "max_uses": 4}],
+            timeout=timeout,
+        )
+    except ClaudeError:
+        raise
+    except Exception as e:
+        logger.warning("OEM_XREF: unexpected error for {}: {}", display_mpn, type(e).__name__)
+        return _XR_FAILED
+
+    if not isinstance(data, dict):
+        return _XR_FAILED
+
+    urls = [u for u in (data.get("source_urls") or []) if isinstance(u, str) and is_crossref_domain(u)]
+    if not urls:
+        logger.info("OEM_XREF: {} rejected — no trusted source ({})", display_mpn, data.get("source_urls"))
+        return _XR_FAILED
+
+    resolved_raw = (data.get("resolved_mpn") or "").strip()
+    resolved_key = normalize_mpn_key(resolved_raw)
+    if not resolved_key:
+        return _XR_FAILED
+
+    linkage_key = normalize_mpn_key(data.get("linkage_quote"))
+    if normalized_mpn not in linkage_key or resolved_key not in linkage_key:
+        logger.info("OEM_XREF: {} rejected — linkage quote missing a code", display_mpn)
+        return _XR_FAILED
+
+    if resolved_key == normalized_mpn:
+        logger.info("OEM_XREF: {} rejected — resolved == original", display_mpn)
+        return _XR_FAILED
+
+    try:
+        conf = float(data.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        conf = 0.0
+    if conf < _MIN_CROSSREF_CONFIDENCE:
+        logger.info("OEM_XREF: {} rejected — confidence {:.2f} < {:.2f}", display_mpn, conf, _MIN_CROSSREF_CONFIDENCE)
+        return _XR_FAILED
+
+    return CrossRefResult(
+        status="resolved",
+        resolved_mpn=resolved_raw,
+        manufacturer=(data.get("manufacturer") or "").strip() or None,
+        linkage_source_url=urls[0],
+        linkage_source_domain=urlparse(urls[0]).hostname or "",
+        confidence=conf,
+    )
+
+
+# --------------------------------- OEM description ---------------------------------
+
+
+@dataclass
+class OemExtractResult:
+    """Result of an OEM-official description extraction (description/category only)."""
+
+    status: str  # "oem_sourced" | "failed"
+    description: str | None = None
+    manufacturer: str | None = None
+    category: str | None = None
+    datasheet_url: str | None = None
+    confidence: float = 0.0
+    source_urls: list[str] = field(default_factory=list)
+    source_domains: list[str] = field(default_factory=list)
+
+
+_OEM_FAILED = OemExtractResult(status="failed")
+
+_OEM_SYSTEM = (
+    "You are an electronic-component data extraction assistant. Use web search to find the "
+    "OFFICIAL OEM/system-vendor page (Lenovo, HPE, HP, Dell, Acer, ASUS, IBM) for the given "
+    "OEM/FRU/spare part number. Return ONLY valid JSON. Never invent data; use null when unknown."
+)
+_OEM_PROMPT = (
+    "Find the OEM/FRU part number {mpn} (vendor: {vendor}) on the vendor's official parts or "
+    'support page. Return JSON: {{"description": str, "manufacturer": str, "category": str, '
+    '"datasheet_url": str|null, "confidence": float, "exact_mpn_found": str, "source_urls": '
+    "[str]}}. exact_mpn_found must be the OEM code exactly as printed on the page."
+)
+
+
+async def extract_oem_description(
+    display_mpn: str,
+    normalized_mpn: str,
+    vendor: str,
+    *,
+    timeout: int = 90,
+) -> OemExtractResult:
+    """Extract an OEM-official description/category from the vendor's own page.
+
+    Four Python gates (official OEM domain, exact code verbatim, confidence, non-trivial
+    description + manufacturer). Writes description/category/datasheet only — never
+    structured specs. Raises ClaudeError on backend failure.
+    """
+    if not normalized_mpn:
+        return _OEM_FAILED
+    try:
+        data = await claude_json(
+            _OEM_PROMPT.format(mpn=display_mpn, vendor=vendor),
+            system=_OEM_SYSTEM,
+            model_tier="smart",
+            max_tokens=1000,
+            tools=[{"type": "web_search_20250305", "name": "web_search", "max_uses": 4}],
+            timeout=timeout,
+        )
+    except ClaudeError:
+        raise
+    except Exception as e:
+        logger.warning("OEM_DESC: unexpected error for {}: {}", display_mpn, type(e).__name__)
+        return _OEM_FAILED
+
+    if not isinstance(data, dict):
+        return _OEM_FAILED
+
+    urls = [u for u in (data.get("source_urls") or []) if isinstance(u, str) and is_oem_domain(u)]
+    if not urls:
+        logger.info("OEM_DESC: {} rejected — no official OEM source ({})", display_mpn, data.get("source_urls"))
+        return _OEM_FAILED
+
+    if normalize_mpn_key(data.get("exact_mpn_found")) != normalized_mpn:
+        logger.info("OEM_DESC: {} rejected — MPN mismatch (got {})", display_mpn, data.get("exact_mpn_found"))
+        return _OEM_FAILED
+
+    try:
+        conf = float(data.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        conf = 0.0
+    if conf < _MIN_OEM_CONFIDENCE:
+        logger.info("OEM_DESC: {} rejected — confidence {:.2f} < {:.2f}", display_mpn, conf, _MIN_OEM_CONFIDENCE)
+        return _OEM_FAILED
+
+    desc = (data.get("description") or "").strip()
+    mfr = (data.get("manufacturer") or "").strip()
+    if len(desc) < 10 or not mfr:
+        logger.info(
+            "OEM_DESC: {} rejected — description too short ({}) or missing manufacturer", display_mpn, len(desc)
+        )
+        return _OEM_FAILED
+
+    return OemExtractResult(
+        status="oem_sourced",
+        description=desc,
+        manufacturer=mfr,
+        category=(data.get("category") or "").strip() or None,
+        datasheet_url=(data.get("datasheet_url") or "").strip() or None,
+        confidence=conf,
+        source_urls=urls,
+        source_domains=sorted({urlparse(u).hostname or "" for u in urls}),
+    )

--- a/app/services/enrichment_worker/oem_extractor.py
+++ b/app/services/enrichment_worker/oem_extractor.py
@@ -4,12 +4,14 @@ OEM-official description. All trust gates enforced in Python — the model's gat
 never trusted.
 
 Called by: app.services.authoritative_enrichment_service.enrich_card.
-Depends on: app.utils.claude_client, app.utils.normalization, .oem_domains.
+Depends on: app.utils.claude_client, app.utils.claude_errors, app.utils.normalization,
+.oem_domains.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
 from urllib.parse import urlparse
 
 from loguru import logger
@@ -27,11 +29,16 @@ _MIN_OEM_CONFIDENCE = 0.90
 # --------------------------------- cross-reference ---------------------------------
 
 
-@dataclass
+@dataclass(frozen=True)
 class CrossRefResult:
-    """Candidate OEM->commodity-MPN cross-reference (not yet distributor-confirmed)."""
+    """Candidate OEM->commodity-MPN cross-reference (not yet distributor-confirmed).
 
-    status: str  # "resolved" | "failed"
+    Frozen: producers build the full object in one ``return`` and consumers only read, so
+    immutability is safe and lets the ``_XR_FAILED`` module singleton be shared without an
+    aliasing footgun.
+    """
+
+    status: Literal["resolved", "failed"]
     resolved_mpn: str | None = None
     manufacturer: str | None = None
     linkage_source_url: str | None = None
@@ -102,6 +109,12 @@ async def cross_reference_mpn(
     if not resolved_key:
         return _XR_FAILED
 
+    # Linkage gate: the FRU<->MPN association is single-attestation (the model's quoted
+    # text), checked as a normalized-substring containment of BOTH codes. This is the one
+    # place an LLM claim is load-bearing for the *linkage*; it is defended in depth — the
+    # source domain must be allowlisted (gate 1), the resolved MPN is INDEPENDENTLY
+    # re-verified against a distributor by the caller, and confidence must clear 0.90.
+    # A short code embedded in a longer token is an accepted residual (see review notes).
     linkage_key = normalize_mpn_key(data.get("linkage_quote"))
     if normalized_mpn not in linkage_key or resolved_key not in linkage_key:
         logger.info("OEM_XREF: {} rejected — linkage quote missing a code", display_mpn)
@@ -132,11 +145,16 @@ async def cross_reference_mpn(
 # --------------------------------- OEM description ---------------------------------
 
 
-@dataclass
+@dataclass(frozen=True)
 class OemExtractResult:
-    """Result of an OEM-official description extraction (description/category only)."""
+    """Result of an OEM-official description extraction (description/category only).
 
-    status: str  # "oem_sourced" | "failed"
+    Frozen: producers build the full object in one ``return`` and consumers only read, so
+    immutability is safe and lets the ``_OEM_FAILED`` module singleton be shared without an
+    aliasing footgun.
+    """
+
+    status: Literal["oem_sourced", "failed"]
     description: str | None = None
     manufacturer: str | None = None
     category: str | None = None

--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -1,9 +1,9 @@
 """Enrichment worker — paced background loop.
 
 Selects small batches of unenriched/retryable parts, runs each through
-``enrich_card`` (verified → web_sourced → ai_inferred → not_found),
-paces via a daily web-call budget + per-source cooldowns, and heartbeats to
-``enrichment_worker_status``.
+``enrich_card`` (verified → web_sourced → oem_sourced → ai_inferred →
+not_found/not_catalogued), paces via a daily web-call budget + per-source
+cooldowns, and heartbeats to ``enrichment_worker_status``.
 
 Run: python -m app.services.enrichment_worker
 
@@ -63,6 +63,9 @@ def select_batch(db: Session, config: "EnrichmentWorkerConfig") -> list:
     - ``unenriched``: always eligible.
     - ``not_found``: eligible only when ``enriched_at IS NULL`` OR older than
       ``not_found_retry_hours`` (self-heal as quotas reset daily).
+    - ``not_catalogued``: eligible when ``enriched_at IS NULL`` OR older than
+      ``not_catalogued_retry_days`` (long backoff — uncatalogued OEM service parts
+      rarely become catalogued, so re-check infrequently).
     - ``is_internal_part``, ``deleted_at`` are excluded.
     - Ordered by ``search_count DESC, created_at DESC``: demand still wins
       (high-demand parts first); among equal demand — the common case where
@@ -272,8 +275,10 @@ async def main() -> None:
     # Running totals for today
     enriched_today = 0
     web_sourced_today = 0
+    oem_sourced_today = 0
     ai_inferred_today = 0
     not_found_today = 0
+    not_catalogued_today = 0
     last_stats_date = None
 
     logger.info(
@@ -308,11 +313,14 @@ async def main() -> None:
                 if last_stats_date != today_date:
                     if last_stats_date is not None:
                         logger.info(
-                            "ENRICH_WORKER daily summary: enriched={}, web={}, ai={}, not_found={}",
+                            "ENRICH_WORKER daily summary: enriched={}, web={}, oem={}, ai={}, "
+                            "not_found={}, not_catalogued={}",
                             enriched_today,
                             web_sourced_today,
+                            oem_sourced_today,
                             ai_inferred_today,
                             not_found_today,
+                            not_catalogued_today,
                         )
                         db = SessionLocal()
                         try:
@@ -322,20 +330,26 @@ async def main() -> None:
                                     "date": str(last_stats_date),
                                     "enriched": enriched_today,
                                     "web_sourced": web_sourced_today,
+                                    "oem_sourced": oem_sourced_today,
                                     "ai_inferred": ai_inferred_today,
                                     "not_found": not_found_today,
+                                    "not_catalogued": not_catalogued_today,
                                 },
                                 enriched_today=0,
                                 web_sourced_today=0,
+                                oem_sourced_today=0,
                                 ai_inferred_today=0,
                                 not_found_today=0,
+                                not_catalogued_today=0,
                             )
                         finally:
                             db.close()
                     enriched_today = 0
                     web_sourced_today = 0
+                    oem_sourced_today = 0
                     ai_inferred_today = 0
                     not_found_today = 0
+                    not_catalogued_today = 0
                     last_stats_date = today_date
                     # New day: quotas/budgets reset, so re-enable disabled sources and the
                     # web tier, and zero the in-process web tally (the cache counter is
@@ -384,8 +398,10 @@ async def main() -> None:
                         total_this_batch = sum(batch_counts.values())
                         enriched_today += total_this_batch
                         web_sourced_today += batch_counts.get(MaterialEnrichmentStatus.WEB_SOURCED, 0)
+                        oem_sourced_today += batch_counts.get(MaterialEnrichmentStatus.OEM_SOURCED, 0)
                         ai_inferred_today += batch_counts.get(MaterialEnrichmentStatus.AI_INFERRED, 0)
                         not_found_today += batch_counts.get(MaterialEnrichmentStatus.NOT_FOUND, 0)
+                        not_catalogued_today += batch_counts.get(MaterialEnrichmentStatus.NOT_CATALOGUED, 0)
 
                         # Heartbeat + counters
                         update_enrichment_worker_status(
@@ -394,8 +410,10 @@ async def main() -> None:
                             last_enriched_at=datetime.now(timezone.utc),
                             enriched_today=enriched_today,
                             web_sourced_today=web_sourced_today,
+                            oem_sourced_today=oem_sourced_today,
                             ai_inferred_today=ai_inferred_today,
                             not_found_today=not_found_today,
+                            not_catalogued_today=not_catalogued_today,
                             circuit_breaker_open=False,
                             circuit_breaker_reason=None,
                         )
@@ -425,11 +443,13 @@ async def main() -> None:
 
     finally:
         logger.info(
-            "ENRICH_WORKER shutting down: enriched_today={}, web={}, ai={}, not_found={}",
+            "ENRICH_WORKER shutting down: enriched_today={}, web={}, oem={}, ai={}, not_found={}, not_catalogued={}",
             enriched_today,
             web_sourced_today,
+            oem_sourced_today,
             ai_inferred_today,
             not_found_today,
+            not_catalogued_today,
         )
         db = SessionLocal()
         try:

--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -28,6 +28,7 @@ from app.services.authoritative_enrichment_service import (
     _connectors_in_order,
     enrich_card,
 )
+from app.services.enrichment_types import WebMeter
 from app.utils.claude_errors import ClaudeError
 
 if TYPE_CHECKING:
@@ -132,12 +133,14 @@ async def run_one_batch(
     ``enrichment_worker:web_calls:{date}`` in the intel_cache, but defended in depth by an
     in-process tally in ``web_state`` — the cache silently no-ops if Redis AND Postgres are
     both down, which would otherwise let WEB_DAILY_CAP be bypassed entirely. The gate is
-    re-checked BEFORE each card (not once per batch), so it cannot overshoot the cap by up
-    to ``batch_size`` calls. Once the cap is hit, ``"web_search"`` is added to ``disabled``
-    so ``enrich_card`` skips the web tier and falls through to Opus ai_inferred.
+    re-checked BEFORE each card (not once per batch). A single card may fire up to 3 billable
+    web calls, so the per-card gate can overshoot the cap by at most 2; the meter is flushed
+    in a finally so every dispatched call is billed even when a later tier raises. Once the
+    cap is hit, ``"web_search"`` is added to ``disabled`` so ``enrich_card`` skips the web
+    tier and falls through to Opus ai_inferred.
 
-    After each billable web-tier attempt the cache counter and ``web_state`` tally are
-    incremented (TTL = 1 day).
+    After each card the dispatched web-call count is flushed into the cache counter and the
+    ``web_state`` tally (TTL = 1 day).
     """
     batch = select_batch(db, config)
     if not batch:
@@ -170,7 +173,7 @@ async def run_one_batch(
                 config.web_daily_cap,
             )
             disabled.add("web_search")
-        card_meter = {"web_calls": 0, "claude_ok": False}
+        card_meter = WebMeter()
         try:
             status = await enrich_card(
                 card,
@@ -184,12 +187,8 @@ async def run_one_batch(
             counts[status] = counts.get(status, 0) + 1
 
             # A Claude call (web/cross-ref/OEM/infer) returned without raising → backend healthy.
-            if card_meter["claude_ok"]:
+            if card_meter.claude_ok:
                 breaker.record_claude_success()
-            # Each card may fire 1–3 billable web-search calls; meter keeps the cap exact.
-            if card_meter["web_calls"] > 0:
-                web_calls_today += card_meter["web_calls"]
-                intel_cache.set_cached(web_cache_key, {"count": web_calls_today}, ttl_days=1.0)
 
         except ClaudeError as e:
             # Claude backend is failing — feed the circuit breaker so a sustained outage
@@ -218,6 +217,13 @@ async def run_one_batch(
             card.enrichment_status = MaterialEnrichmentStatus.NOT_FOUND
             card.enriched_at = now
             counts[MaterialEnrichmentStatus.NOT_FOUND] = counts.get(MaterialEnrichmentStatus.NOT_FOUND, 0) + 1
+        finally:
+            # Bill every web call that was DISPATCHED, even if a later tier raised — the
+            # meter reserves before each await, so calls that fired then failed are still
+            # counted (otherwise WEB_DAILY_CAP drifts over on a ClaudeError mid-card).
+            if card_meter.web_calls > 0:
+                web_calls_today += card_meter.web_calls
+                intel_cache.set_cached(web_cache_key, {"count": web_calls_today}, ttl_days=1.0)
 
     web_state["web_calls"] = web_calls_today
 

--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -81,6 +81,15 @@ def select_batch(db: Session, config: "EnrichmentWorkerConfig") -> list:
         ),
     )
 
+    not_catalogued_cutoff = now - timedelta(days=config.not_catalogued_retry_days)
+    not_catalogued_eligible = and_(
+        MaterialCard.enrichment_status == MaterialEnrichmentStatus.NOT_CATALOGUED,
+        or_(
+            MaterialCard.enriched_at.is_(None),
+            MaterialCard.enriched_at < not_catalogued_cutoff,
+        ),
+    )
+
     return (
         db.query(MaterialCard)
         .filter(
@@ -89,6 +98,7 @@ def select_batch(db: Session, config: "EnrichmentWorkerConfig") -> list:
             or_(
                 MaterialCard.enrichment_status == MaterialEnrichmentStatus.UNENRICHED,
                 not_found_eligible,
+                not_catalogued_eligible,
             ),
         )
         .order_by(
@@ -160,8 +170,7 @@ async def run_one_batch(
                 config.web_daily_cap,
             )
             disabled.add("web_search")
-        web_enabled = "web_search" not in disabled
-
+        card_meter = {"web_calls": 0, "claude_ok": False}
         try:
             status = await enrich_card(
                 card,
@@ -169,22 +178,18 @@ async def run_one_batch(
                 connectors=conns,
                 disabled=disabled,
                 cooldown=cooldown,
+                web_meter=card_meter,
             )
             card.enriched_at = now
             counts[status] = counts.get(status, 0) + 1
 
-            if status != MaterialEnrichmentStatus.VERIFIED:
-                # A non-verified result means a Claude tier (web and/or infer) completed
-                # WITHOUT raising — reset the breaker's consecutive-error counter. (A
-                # verified hit comes from a connector with no Claude call, so it must not
-                # reset the breaker, or sustained Claude outages would never trip it.)
+            # A Claude call (web/cross-ref/OEM/infer) returned without raising → backend healthy.
+            if card_meter["claude_ok"]:
                 breaker.record_claude_success()
-                if web_enabled:
-                    # A billable web_search call fires on EVERY web-tier attempt (gate-pass
-                    # OR gate-fail-then-fall-through). Count all of them, not just
-                    # web_sourced successes, so WEB_DAILY_CAP is actually respected.
-                    web_calls_today += 1
-                    intel_cache.set_cached(web_cache_key, {"count": web_calls_today}, ttl_days=1.0)
+            # Each card may fire 1–3 billable web-search calls; meter keeps the cap exact.
+            if card_meter["web_calls"] > 0:
+                web_calls_today += card_meter["web_calls"]
+                intel_cache.set_cached(web_cache_key, {"count": web_calls_today}, ttl_days=1.0)
 
         except ClaudeError as e:
             # Claude backend is failing — feed the circuit breaker so a sustained outage

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -556,6 +556,8 @@ Alpine.data('materialsFilter', () => ({
   displayNames: {},
   verifiedOnly: false,
   webSourced: false,
+  oemSourced: false,
+  notCatalogued: false,
   _onPopstate: null,
 
   get commodityDisplayName() {
@@ -593,6 +595,8 @@ Alpine.data('materialsFilter', () => ({
       this.q = params.get('q') || '';
       this.verifiedOnly = params.get('verified_only') === 'true';
       this.webSourced = params.get('web_sourced') === 'true';
+      this.oemSourced = params.get('oem_sourced') === 'true';
+      this.notCatalogued = params.get('not_catalogued') === 'true';
       const pageVal = parseInt(params.get('page') || '0', 10);
       this.page = isNaN(pageVal) ? 0 : pageVal;
       this.subFilters = {};
@@ -623,6 +627,8 @@ Alpine.data('materialsFilter', () => ({
       this.q = '';
       this.verifiedOnly = false;
       this.webSourced = false;
+      this.oemSourced = false;
+      this.notCatalogued = false;
       this.page = 0;
       this.subFilters = {};
     }
@@ -634,6 +640,8 @@ Alpine.data('materialsFilter', () => ({
     if (this.q) params.set('q', this.q);
     if (this.verifiedOnly) params.set('verified_only', 'true'); else params.delete('verified_only');
     if (this.webSourced) params.set('web_sourced', 'true'); else params.delete('web_sourced');
+    if (this.oemSourced) params.set('oem_sourced', 'true'); else params.delete('oem_sourced');
+    if (this.notCatalogued) params.set('not_catalogued', 'true'); else params.delete('not_catalogued');
     if (this.page > 0) params.set('page', this.page);
     for (const [key, val] of Object.entries(this.subFilters)) {
       if (Array.isArray(val) && val.length > 0) {

--- a/app/templates/htmx/partials/materials/list.html
+++ b/app/templates/htmx/partials/materials/list.html
@@ -75,6 +75,13 @@
                title="Web-sourced from {{ (m.enrichment_provenance or {}).get('source_domains', ['authoritative page'])|join(', ') }} — below API-verified">
               WEB-SOURCED
             </a>
+            {% elif es == "oem_sourced" %}
+            {% set _ou = (m.enrichment_provenance or {}).get('source_urls', [None])[0] %}
+            <a href="{{ _ou or '#' }}" target="_blank" rel="noopener"
+               class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-indigo-50 text-indigo-700 border-indigo-200"
+               title="OEM-official source: {{ (m.enrichment_provenance or {}).get('source_domains', ['vendor page'])|join(', ') }} — description from the OEM; specs not distributor-verified">
+              OEM-SOURCED
+            </a>
             {% elif es == "ai_inferred" %}
             <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-amber-50 text-amber-700 border-amber-200"
                   title="AI guess (&ge;95% confidence) — RECONFIRM NEEDED before trusting; not verified">
@@ -84,6 +91,11 @@
             <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-gray-100 text-gray-500 border-gray-200"
                   title="No authoritative source found this part">
               NOT FOUND
+            </span>
+            {% elif es == "not_catalogued" %}
+            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-slate-100 text-slate-600 border-slate-300"
+                  title="Recognised OEM service/FRU part; no public specs published">
+              NOT CATALOGUED
             </span>
             {% else %}
             <span class="text-xs text-gray-400">--</span>

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -53,13 +53,33 @@
         </label>
       </div>
       {# Web-sourced toggle #}
-      <div class="mb-3">
+      <div class="mb-1">
         <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
           <input type="checkbox"
                  :checked="webSourced"
                  @change="webSourced = !webSourced; applyFilters()"
                  class="rounded border-gray-300 text-sky-600 focus:ring-sky-500 h-3.5 w-3.5">
           <span class="text-gray-700 font-medium">Web-sourced</span>
+        </label>
+      </div>
+      {# OEM-sourced toggle #}
+      <div class="mb-1">
+        <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
+          <input type="checkbox"
+                 :checked="oemSourced"
+                 @change="oemSourced = !oemSourced; applyFilters()"
+                 class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 h-3.5 w-3.5">
+          <span class="text-gray-700 font-medium">OEM-sourced</span>
+        </label>
+      </div>
+      {# Not-catalogued toggle #}
+      <div class="mb-3">
+        <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
+          <input type="checkbox"
+                 :checked="notCatalogued"
+                 @change="notCatalogued = !notCatalogued; applyFilters()"
+                 class="rounded border-gray-300 text-slate-600 focus:ring-slate-500 h-3.5 w-3.5">
+          <span class="text-gray-700 font-medium">Not catalogued</span>
         </label>
       </div>
 
@@ -193,9 +213,13 @@
            var ws = document.querySelector("#materials-workspace");
            var verifiedOnly = Alpine.evaluate(ws, "verifiedOnly") || false;
            var webSourced = Alpine.evaluate(ws, "webSourced") || false;
+           var oemSourced = Alpine.evaluate(ws, "oemSourced") || false;
+           var notCatalogued = Alpine.evaluate(ws, "notCatalogued") || false;
            var statusList = [];
            if (verifiedOnly) statusList.push("verified");
            if (webSourced) statusList.push("web_sourced");
+           if (oemSourced) statusList.push("oem_sourced");
+           if (notCatalogued) statusList.push("not_catalogued");
            return {
              "commodity": Alpine.evaluate(ws, "commodity") || "",
              "q": Alpine.evaluate(ws, "q") || "",

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -31,7 +31,7 @@ AvailAI is a production electronic component sourcing platform and CRM. Buyers s
 | **redis** | Cache + coordination | 768 MB |
 | **caddy** | Reverse proxy, HTTPS | 512 MB |
 | **db-backup** | pg_dump every 6 hours | 256 MB |
-| **enrichment-worker** | Paced material-card enrichment — trust chain `verified` (distributor API) → `web_sourced` (Claude web search, authorized domains) → `ai_inferred` (Opus 4.8, ≥0.95, flagged). Fast-lane: newest-added parts head the queue (`select_batch` orders `search_count DESC, created_at DESC`); ~60s idle poll | 512 MB |
+| **enrichment-worker** | Paced material-card enrichment — trust chain `verified` (distributor API) → `web_sourced` (Claude web search, authorized domains) → **OEM cross-ref** (grounded web, double-verify against distributors → `verified`) → **OEM description** (`oem_sourced`, single official OEM page) → `ai_inferred` (Opus 4.8, ≥0.95, flagged) → `not_catalogued` (recognised OEM/FRU, no public specs) / `not_found`. OEM tiers gated by a pure regex classifier (`oem_classifier.py`). `web_meter` tracks per-card billable web calls + Claude health for exact budget accounting and circuit-breaker reset. Fast-lane: newest-added parts head the queue (`select_batch` orders `search_count DESC, created_at DESC`); ~60s idle poll | 512 MB |
 
 ## Request Flow — Browser to Database
 
@@ -177,6 +177,22 @@ authoritative reference. Static-analysis tests in
 |--------|-----------|---------|
 | `reenrich.py` | `python -m app.management.reenrich` | Re-run first-pass card enrichment (description/category/lifecycle) on existing cards |
 | `enrich_specs.py` | `python -m app.management.enrich_specs --limit N` | One-time / on-demand backfill of structured-spec extraction for cards missing `specs_enriched_at` |
+
+## Enrichment Worker Modules (`app/services/enrichment_worker/`)
+
+Key modules added for OEM/FRU enrichment:
+
+| Module | Purpose |
+|--------|---------|
+| `oem_classifier.py` | Pure regex vendor classifier (`classify_oem_vendor`) — detects Lenovo/IBM, HPE/HP, Dell, Acer, ASUS FRU codes to gate the OEM tiers. Non-OEM parts never incur OEM web calls. |
+| `oem_domains.py` | Security allowlists (`is_oem_domain`, `is_crossref_domain`) for OEM-official and distributor/manufacturer pages; mirrors `trusted_domains.py`. All domain checks enforced in Python — LLM claims are never trusted. |
+| `oem_extractor.py` | Grounded-web-search extractors: `cross_reference_mpn` resolves an OEM/FRU code to a candidate commodity MPN (four Python gates); `extract_oem_description` fetches an official OEM description (four Python gates). Both raise `ClaudeError` on backend failure. |
+
+## Scripts (`scripts/`)
+
+| Script | Purpose |
+|--------|---------|
+| `backfill_oem_enrichment.py` | Dry-run-first backfill over `not_found` / `not_catalogued` cards through the OEM tiers. Writes a coverage CSV; rolls back unless `--commit`. Shared `web_meter` budget cap (`--max-web-calls`, default 300) halts mid-run to prevent API overspend. The paced worker drains any remainder. |
 
 ## Key Numbers
 

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -289,7 +289,8 @@
 | lifecycle_status | String 50 | active\|nrfnd\|eol\|obsolete\|ltb |
 | package_type | String 100 | QFP-64\|BGA-256\|0603 |
 | rohs_status | String 50 | compliant\|non-compliant\|exempt |
-| cross_references | JSONB | Alternative MPNs |
+| enrichment_status | String 20 | `unenriched` \| `verified` \| `web_sourced` \| `oem_sourced` \| `ai_inferred` \| `not_found` \| `not_catalogued`. Validated on write against `MaterialEnrichmentStatus` (constants.py). `oem_sourced` = single official OEM page; `not_catalogued` = recognised OEM/FRU part with no public specs (retries on 30-day backoff). No migration — varchar column. |
+| cross_references | JSONB | Alternative MPNs; also records OEM FRU→commodity-MPN linkages written by the cross-ref enrichment tier (`[{"mpn": <resolved>, "manufacturer": <mfr>}]`). |
 | specs_structured | JSONB | Parametric data |
 | enriched_at | UTCDateTime, nullable | When the first-pass card enrichment (description/category/lifecycle) ran; NULL = not yet run |
 | specs_enriched_at | UTCDateTime, nullable, indexed | When the second-pass structured-spec extraction ran; NULL = spec pass not yet run |

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -654,7 +654,64 @@ materials router -> enrich_material_cards() [user-triggered, batch processing]
     |       (ensures MPN list and card list stay in sync)
     |
     v
-Claude Haiku (Anthropic API)  — FIRST PASS
+authoritative_enrichment_service.enrich_card()  — ENRICHMENT TIER SEQUENCE
+    |
+    +---> Tier 1: distributor connector fanout (fetch_authoritative → merge_authoritative)
+    |       HIT  → status=verified; apply_authoritative() writes description/specs/lifecycle.
+    |       MISS → fall through.
+    |
+    +---> Tier 2: distributor/manufacturer web search (extract_part_from_web, web_meter +1)
+    |       HIT (web_sourced)  → apply_web_sourced(); done.
+    |       MISS → fall through.
+    |
+    +---> OEM gate: classify_oem_vendor(display_mpn) — pure regex, no web call.
+    |       Non-OEM parts skip Tiers 3-4 entirely.
+    |
+    +---> Tier 3 (OEM only): cross-reference MPN (cross_reference_mpn, web_meter +1)
+    |       Grounded Claude web search; four Python gates:
+    |         (1) ≥1 source URL on is_crossref_domain allowlist
+    |         (2) both OEM code and resolved MPN appear verbatim in the sourced linkage_quote
+    |         (3) resolved_mpn != original (no echo)
+    |         (4) confidence ≥ 0.90
+    |       RESOLVED → fetch_authoritative(resolved_mpn) double-verify against distributors
+    |         CONFIRMED → apply_cross_ref_verified(): writes distributor data onto card,
+    |                     records FRU→MPN linkage in cross_references JSONB +
+    |                     cross_ref provenance block; status=verified.
+    |         UNCONFIRMED → discard candidate, fall through.
+    |       FAILED → fall through.
+    |
+    +---> Tier 4 (OEM only): OEM-official description (extract_oem_description, web_meter +1)
+    |       Grounded Claude web search on OEM's own page; four Python gates:
+    |         (1) ≥1 source URL on is_oem_domain allowlist (stricter than cross-ref)
+    |         (2) exact_mpn_found matches normalized_mpn verbatim
+    |         (3) confidence ≥ 0.90
+    |         (4) description ≥ 10 chars + manufacturer present
+    |       HIT → apply_oem_sourced(): writes description/category/datasheet + oem_sourced
+    |             provenance; status=oem_sourced.
+    |       MISS → fall through.
+    |
+    +---> Tier 5: AI inference fallback (infer_part via ai_inference_fallback,
+    |       web_meter: claude_ok=True)
+    |       ai_inferred → writes description/category with reconfirm_needed flag.
+    |       not_found → terminal.
+    |
+    +---> Terminal:
+    |       OEM pattern matched AND OEM tiers ran → status=not_catalogued
+    |         (recognised OEM/FRU part; no public specs; retries on 30-day backoff)
+    |       Otherwise → status=not_found (22h backoff)
+
+web_meter contract ({"web_calls": int, "claude_ok": bool}, updated in place):
+    - web_calls: incremented by 1 for each billable web-search call
+      (Tier 2 + Tier 3 + Tier 4 each count as 1; connector fanout is free).
+    - claude_ok: set True after ANY Claude call returns without raising
+      (Tier 2, 3, 4 or infer_part); the worker reads this to reset its
+      circuit breaker. Default None = no metering (call still works).
+    The enrichment worker passes a fresh meter per card and adds
+    card_meter["web_calls"] to the rolling web_calls_today counter for
+    the daily budget gate (ENRICHMENT_WEB_DAILY_CAP, env-configurable).
+
+Claude Haiku (Anthropic API)  — FIRST PASS (legacy path — superseded by
+    authoritative_enrichment_service for new cards; kept for bulk/batch jobs)
     |
     +---> Classify card: description, category, lifecycle_status
     +---> DB: UPDATE material_cards (description, category, lifecycle_status)

--- a/docs/superpowers/plans/2026-06-05-no-hallucination-oem-enrichment.md
+++ b/docs/superpowers/plans/2026-06-05-no-hallucination-oem-enrichment.md
@@ -1,0 +1,1643 @@
+# No-Hallucination OEM/FRU Enrichment — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve OEM/FRU/spare part numbers (Lenovo/IBM, HP/HPE, Dell, Acer, ASUS) with zero fabrication by adding a strict double-verified cross-reference tier and a single-source OEM-description tier to the enrichment pipeline, plus honest UI surfacing and a dry-run-first backfill.
+
+**Architecture:** Two new Claude grounded-web-search tiers slot into `enrich_card` between the distributor web tier and the AI fallback, gated by a pure regex OEM-vendor classifier so non-OEM parts never incur OEM web calls. Cross-ref → `verified` only when the resolved MPN's linkage is sourced on an allowlisted page AND the resolved MPN independently clears the distributor pipeline. OEM description → new `oem_sourced` status from a single official OEM page. Unresolvable OEM parts → new terminal `not_catalogued`. All trust gates enforced in Python, never trusting LLM claims.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2.0, PostgreSQL (varchar status column — no migration), Jinja2 + HTMX + Alpine.js + Tailwind, pytest (`-n auto`, in-memory SQLite, `TESTING=1`).
+
+**Spec:** `docs/superpowers/specs/2026-06-05-no-hallucination-oem-enrichment-design.md`
+
+**Worktree:** `/root/availai/.claude/worktrees/oem-enrichment` (branch `worktree-oem-enrichment`, base `origin/main` 116e3e6d). All commands assume this CWD and `TESTING=1 PYTHONPATH=$(pwd)`.
+
+---
+
+## File Structure
+
+**Create**
+- `app/services/enrichment_worker/oem_classifier.py` — pure regex vendor classifier
+- `app/services/enrichment_worker/oem_domains.py` — OEM/cross-ref domain allowlists + predicates
+- `app/services/enrichment_worker/oem_extractor.py` — `cross_reference_mpn` + `extract_oem_description`
+- `scripts/backfill_oem_enrichment.py` — dry-run-first backfill over not_found/not_catalogued
+- `tests/test_oem_classifier.py`, `tests/test_oem_domains.py`, `tests/test_oem_extractor.py`,
+  `tests/test_backfill_oem_enrichment.py`
+
+**Modify**
+- `app/constants.py` — add `OEM_SOURCED`, `NOT_CATALOGUED`
+- `app/models/intelligence.py` — update status comment (validator is data-driven, no logic change)
+- `app/services/authoritative_enrichment_service.py` — OEM tiers, `web_meter`, 2 appliers, terminal
+- `app/services/enrichment_worker/worker.py` — meter accounting, breaker reset, `not_catalogued` eligibility
+- `app/services/enrichment_worker/config.py` — `not_catalogued_retry_days`
+- `app/templates/htmx/partials/materials/list.html` — `oem_sourced` + `not_catalogued` badges
+- `app/templates/htmx/partials/materials/workspace.html` — two filter toggles
+- `app/static/htmx_app.js` — Alpine state + URL sync for two toggles
+- `docs/APP_MAP_ARCHITECTURE.md`, `docs/APP_MAP_DATABASE.md`, `docs/APP_MAP_INTERACTIONS.md`
+
+**Test (extend existing)**
+- `tests/test_constants.py` / `tests/test_enrichment_status_enum.py`
+- `tests/test_authoritative_enrichment.py`
+- `tests/test_enrichment_worker.py`
+
+**Dependency order:** Task 1 (constants) → Task 2 (classifier) ∥ Task 3 (domains) → Task 4 (extractor) → Task 5 (enrich_card) → Task 6 (worker) → Task 7 (badges) ∥ Task 8 (filter) → Task 9 (backfill) → Task 10 (docs). Tasks 2 & 3 are independent; 7 & 8 are independent.
+
+---
+
+## Task 1: Add `oem_sourced` + `not_catalogued` statuses
+
+**Files:**
+- Modify: `app/constants.py:452-463`
+- Modify: `app/models/intelligence.py:54-56`
+- Test: `tests/test_constants.py`, `tests/test_enrichment_status_enum.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_constants.py`:
+```python
+def test_material_enrichment_status_has_oem_tiers():
+    from app.constants import MaterialEnrichmentStatus
+
+    assert MaterialEnrichmentStatus.OEM_SOURCED == "oem_sourced"
+    assert MaterialEnrichmentStatus.NOT_CATALOGUED == "not_catalogued"
+    # All values fit the String(20) column.
+    assert all(len(s.value) <= 20 for s in MaterialEnrichmentStatus)
+```
+
+Append to `tests/test_enrichment_status_enum.py`:
+```python
+def test_validator_accepts_oem_tiers():
+    from app.constants import MaterialEnrichmentStatus
+    from app.models import MaterialCard
+
+    c = MaterialCard(display_mpn="01HW917", normalized_mpn="01hw917")
+    c.enrichment_status = MaterialEnrichmentStatus.OEM_SOURCED
+    assert c.enrichment_status == "oem_sourced"
+    c.enrichment_status = "not_catalogued"
+    assert c.enrichment_status == "not_catalogued"
+
+
+def test_validator_still_rejects_junk():
+    import pytest
+
+    from app.models import MaterialCard
+
+    c = MaterialCard(display_mpn="X", normalized_mpn="x")
+    with pytest.raises(ValueError):
+        c.enrichment_status = "bogus_status"
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_constants.py::test_material_enrichment_status_has_oem_tiers tests/test_enrichment_status_enum.py::test_validator_accepts_oem_tiers -v`
+Expected: FAIL (`AttributeError: OEM_SOURCED`).
+
+- [ ] **Step 3: Implement**
+
+In `app/constants.py`, in `class MaterialEnrichmentStatus(StrEnum)`, update the docstring line `Single source of truth for the five valid enrichment tiers.` → `...the seven valid enrichment tiers.` and add after `NOT_FOUND = "not_found"`:
+```python
+    OEM_SOURCED = "oem_sourced"
+    NOT_CATALOGUED = "not_catalogued"
+```
+
+In `app/models/intelligence.py`, update the comment block above the column (currently `# unenriched | verified | web_sourced | ai_inferred | not_found`) to:
+```python
+    # enrichment_status: see constants.MaterialEnrichmentStatus (validated on write):
+    # unenriched | verified | web_sourced | oem_sourced | ai_inferred | not_found | not_catalogued
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_constants.py tests/test_enrichment_status_enum.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/constants.py app/models/intelligence.py tests/test_constants.py tests/test_enrichment_status_enum.py
+git commit -m "feat(enrichment): add oem_sourced + not_catalogued status tiers"
+```
+
+---
+
+## Task 2: OEM vendor classifier
+
+**Files:**
+- Create: `app/services/enrichment_worker/oem_classifier.py`
+- Test: `tests/test_oem_classifier.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/test_oem_classifier.py`:
+```python
+"""Truth-table tests for the OEM/FRU vendor classifier (real not_found samples)."""
+
+import pytest
+
+from app.services.enrichment_worker.oem_classifier import classify_oem_vendor
+
+
+@pytest.mark.parametrize(
+    "mpn,vendor",
+    [
+        ("01HW917", "lenovo"), ("00E2891", "lenovo"), ("01LV731", "lenovo"),
+        ("00HW132", "lenovo"),
+        ("38L7669", "lenovo"), ("46C9040", "lenovo"),
+        ("5B20L64949", "lenovo"), ("5C10Q59981", "lenovo"), ("5T10Q96500", "lenovo"),
+        ("918042-601", "hpe"), ("619559-001", "hpe"), ("486301-001", "hpe"),
+        ("628668-001", "hpe"), ("902499-856", "hpe"),
+        ("NB.MBC11.003", "acer"), ("KT.00403.025", "acer"), ("33.G55N7.002", "acer"),
+        ("NB.GKH11.002", "acer"),
+        ("60NB0690-MB1820", "asus"), ("0B200-00930000", "asus"),
+        ("HV52W", "dell"), ("66YYK", "dell"),
+    ],
+)
+def test_classifies_known_oem_codes(mpn, vendor):
+    assert classify_oem_vendor(mpn) == vendor
+
+
+@pytest.mark.parametrize(
+    "mpn",
+    [
+        "M393A2K40EB3-CWEB/C",  # real Samsung DDR4 RDIMM
+        "LM2596S", "ATMEGA328P-PU", "STM32F407VGT6",
+        "", "  ", None, "AB",  # too short / empty
+    ],
+)
+def test_rejects_non_oem(mpn):
+    assert classify_oem_vendor(mpn) is None
+
+
+def test_case_insensitive_and_stripped():
+    assert classify_oem_vendor("  0b200-00930000  ") == "asus"
+    assert classify_oem_vendor("nb.mbc11.003") == "acer"
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_oem_classifier.py -v`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+Create `app/services/enrichment_worker/oem_classifier.py`:
+```python
+"""Classify an MPN as an OEM/system-vendor FRU/spare/service part number.
+
+Pure, regex-based vendor detection used to gate the OEM enrichment tiers (cross-ref +
+OEM official description) in ``enrich_card``. Returns the likely OEM vendor or ``None``.
+The label is advisory only — it seeds the search prompt; correctness is enforced
+downstream by the Python gates in ``oem_extractor`` / ``enrich_card``, never here.
+
+Called by: app.services.authoritative_enrichment_service.enrich_card,
+scripts.backfill_oem_enrichment. Depends on: stdlib ``re`` only.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Ordered (priority) (vendor, pattern). First match wins. Anchored, matched against the
+# UPPERCASED stripped display_mpn. Each pattern is justified by a real not_found sample
+# (see spec §1).
+_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    # Lenovo modern FRU/option: 5x + 2 digits + letter + 5 digits (5B20L64949, 5T10Q96500)
+    ("lenovo", re.compile(r"^5[A-Z]\d{2}[A-Z]\d{5}$")),
+    # Lenovo/IBM classic FRU: 2 digits + letter + 4 alnum (38L7669, 46C9040)
+    ("lenovo", re.compile(r"^\d{2}[A-Z][A-Z0-9]{4}$")),
+    # Lenovo/IBM 7-char FRU: 00/01 + 5 alnum (01HW917, 00E2891, 01LV731)
+    ("lenovo", re.compile(r"^0[01][A-Z0-9]{5}$")),
+    # Acer dotted part code: 2 alnum . 5 alnum . 3 alnum (NB.MBC11.003, 33.G55N7.002)
+    ("acer", re.compile(r"^[A-Z0-9]{2}\.[A-Z0-9]{5}\.[A-Z0-9]{3}$")),
+    # ASUS module code: 2 digits NB + 4 alnum - tail (60NB0690-MB1820)
+    ("asus", re.compile(r"^\d{2}NB[A-Z0-9]{4}-[A-Z0-9]+$")),
+    # ASUS 0X###-######## (0B200-00930000)
+    ("asus", re.compile(r"^0[A-Z]\d{3}-\d{8}$")),
+    # HP/HPE spare: 6 digits - 3 digits (918042-601, 619559-001)
+    ("hpe", re.compile(r"^\d{6}-\d{3}$")),
+    # Dell 5-char spare with >=1 letter (HV52W, 66YYK). Broad/low-priority; a false
+    # positive costs only a wasted web call (genuine MPNs resolve at earlier tiers first).
+    ("dell", re.compile(r"^(?=[A-Z0-9]{5}$)[A-Z0-9]*[A-Z][A-Z0-9]*$")),
+]
+
+
+def classify_oem_vendor(display_mpn: str | None) -> str | None:
+    """Return the likely OEM vendor for an OEM/FRU/spare code, or ``None``.
+
+    Never raises on empty/malformed input (returns ``None``). The vendor label only seeds
+    the cross-ref / description search prompt; the Python trust gates downstream enforce
+    correctness.
+    """
+    if not isinstance(display_mpn, str):
+        return None
+    mpn = display_mpn.strip().upper()
+    if not mpn:
+        return None
+    for vendor, pat in _PATTERNS:
+        if pat.match(mpn):
+            return vendor
+    return None
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_oem_classifier.py -v`
+Expected: PASS (all params). If `STM32F407VGT6` or similar unexpectedly matches, tighten the offending pattern — but with the anchors above it should not.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/enrichment_worker/oem_classifier.py tests/test_oem_classifier.py
+git commit -m "feat(enrichment): OEM/FRU vendor classifier (gates OEM tiers)"
+```
+
+---
+
+## Task 3: OEM domain allowlists
+
+**Files:**
+- Create: `app/services/enrichment_worker/oem_domains.py`
+- Test: `tests/test_oem_domains.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/test_oem_domains.py`:
+```python
+from app.services.enrichment_worker.oem_domains import is_crossref_domain, is_oem_domain
+
+
+def test_official_oem_hosts_accepted():
+    assert is_oem_domain("https://support.lenovo.com/parts/01HW917")
+    assert is_oem_domain("https://partsurfer.hpe.com/Search.aspx?SearchText=918042-601")
+    assert is_oem_domain("http://www.dell.com/support/HV52W")
+    assert is_oem_domain("https://parts.hp.com/x")  # dot-suffix of hp.com root
+
+
+def test_lookalike_and_bad_schemes_rejected():
+    assert not is_oem_domain("https://evil-lenovo.com/x")
+    assert not is_oem_domain("https://lenovo.com.evil.com/x")
+    assert not is_oem_domain("ftp://support.lenovo.com/x")
+    assert not is_oem_domain("not a url")
+    assert not is_oem_domain("")
+
+
+def test_crossref_superset_includes_distributors_and_oem():
+    # OEM official
+    assert is_crossref_domain("https://support.lenovo.com/x")
+    # distributor (from trusted_domains)
+    assert is_crossref_domain("https://www.mouser.com/ProductDetail/x")
+    # manufacturer (from trusted_domains)
+    assert is_crossref_domain("https://www.ti.com/product/x")
+    # junk
+    assert not is_crossref_domain("https://reddit.com/r/x")
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_oem_domains.py -v`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+Create `app/services/enrichment_worker/oem_domains.py`:
+```python
+"""Security allowlist for OEM-sourced enrichment.
+
+``is_oem_domain``: official system-vendor parts/support hosts (Lenovo, HPE, HP, Dell,
+Acer, ASUS, IBM). A page on one of these may produce an ``oem_sourced`` description.
+
+``is_crossref_domain``: the OEM-official set UNION the existing distributor + manufacturer
+allowlist — a distributor/manufacturer page that lists an OEM FRU next to the commodity
+MPN is acceptable evidence for the *linkage* (the resolved MPN is independently
+re-verified against distributors regardless). Validated in code; the LLM's domain claims
+are never trusted.
+
+Called by: app.services.enrichment_worker.oem_extractor.
+Depends on: app.services.enrichment_worker.trusted_domains.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from .trusted_domains import is_trusted_domain
+
+# Exact-host official OEM/system-vendor parts & support domains.
+OEM_OFFICIAL_HOSTS: frozenset[str] = frozenset(
+    {
+        "support.lenovo.com",
+        "pcsupport.lenovo.com",
+        "partsurfer.hpe.com",
+        "partsurfer.com",
+        "support.hpe.com",
+        "support.hp.com",
+        "parts.hp.com",
+        "www.dell.com",
+        "dell.com",
+        "www.acer.com",
+        "us.acer.com",
+        "www.asus.com",
+    }
+)
+
+# Vendor root domains matched by dot-suffix (foo.lenovo.com matches lenovo.com).
+OEM_VENDOR_ROOTS: frozenset[str] = frozenset(
+    {"lenovo.com", "hpe.com", "hp.com", "dell.com", "acer.com", "asus.com", "ibm.com"}
+)
+
+
+def is_oem_domain(url: str) -> bool:
+    """Return True if *url* is an official OEM/system-vendor parts/support domain."""
+    try:
+        p = urlparse(url)
+    except Exception:
+        return False
+    if p.scheme not in ("http", "https") or not p.hostname:
+        return False
+    host = p.hostname.lower()
+    if host in OEM_OFFICIAL_HOSTS:
+        return True
+    return any(host == r or host.endswith("." + r) for r in OEM_VENDOR_ROOTS)
+
+
+def is_crossref_domain(url: str) -> bool:
+    """Return True if *url* is authoritative for asserting a FRU<->MPN linkage.
+
+    OEM-official set plus the existing distributor / manufacturer allowlist.
+    """
+    return is_oem_domain(url) or is_trusted_domain(url)
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_oem_domains.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/enrichment_worker/oem_domains.py tests/test_oem_domains.py
+git commit -m "feat(enrichment): OEM + cross-ref domain allowlists"
+```
+
+---
+
+## Task 4: OEM extractor (cross-ref + description), all gates in Python
+
+**Files:**
+- Create: `app/services/enrichment_worker/oem_extractor.py`
+- Test: `tests/test_oem_extractor.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/test_oem_extractor.py`:
+```python
+"""Gate tests for OEM cross-ref + description extractors (mocked Claude)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.enrichment_worker import oem_extractor
+from app.services.enrichment_worker.oem_extractor import (
+    cross_reference_mpn,
+    extract_oem_description,
+)
+from app.utils.claude_errors import ClaudeError
+
+XR_OK = {
+    "resolved_mpn": "M393A2K40EB3-CWE",
+    "manufacturer": "Samsung",
+    "linkage_quote": "Lenovo FRU 01HW917 = Samsung M393A2K40EB3-CWE 16GB DDR4 RDIMM",
+    "confidence": 0.95,
+    "source_urls": ["https://support.lenovo.com/parts/01HW917"],
+}
+
+
+async def _xr(data):
+    with patch.object(oem_extractor, "claude_json", new=AsyncMock(return_value=data)):
+        return await cross_reference_mpn("01HW917", "01hw917", "lenovo")
+
+
+@pytest.mark.asyncio
+async def test_crossref_accept():
+    r = await _xr(dict(XR_OK))
+    assert r.status == "resolved"
+    assert r.resolved_mpn == "M393A2K40EB3-CWE"
+    assert r.linkage_source_domain == "support.lenovo.com"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_untrusted_domain():
+    r = await _xr({**XR_OK, "source_urls": ["https://reddit.com/r/homelab"]})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_linkage_missing_resolved():
+    # quote lacks the resolved MPN → linkage not sourced
+    r = await _xr({**XR_OK, "linkage_quote": "Lenovo FRU 01HW917 memory module"})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_linkage_missing_oem_code():
+    r = await _xr({**XR_OK, "linkage_quote": "Samsung M393A2K40EB3-CWE 16GB DDR4 RDIMM"})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_echo_mpn():
+    r = await _xr(
+        {
+            **XR_OK,
+            "resolved_mpn": "01HW917",
+            "linkage_quote": "01HW917 01HW917",
+        }
+    )
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_low_confidence():
+    r = await _xr({**XR_OK, "confidence": 0.5})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_claude_error_propagates():
+    with patch.object(oem_extractor, "claude_json", new=AsyncMock(side_effect=ClaudeError("down"))):
+        with pytest.raises(ClaudeError):
+            await cross_reference_mpn("01HW917", "01hw917", "lenovo")
+
+
+DESC_OK = {
+    "description": "ThinkSystem 16GB TruDDR4 2666MHz RDIMM",
+    "manufacturer": "Lenovo",
+    "category": "Memory Module",
+    "datasheet_url": None,
+    "confidence": 0.95,
+    "exact_mpn_found": "01HW917",
+    "source_urls": ["https://support.lenovo.com/parts/01HW917"],
+}
+
+
+async def _desc(data):
+    with patch.object(oem_extractor, "claude_json", new=AsyncMock(return_value=data)):
+        return await extract_oem_description("01HW917", "01hw917", "lenovo")
+
+
+@pytest.mark.asyncio
+async def test_desc_accept():
+    r = await _desc(dict(DESC_OK))
+    assert r.status == "oem_sourced"
+    assert r.description.startswith("ThinkSystem")
+    assert r.source_domains == ["support.lenovo.com"]
+
+
+@pytest.mark.asyncio
+async def test_desc_reject_untrusted_domain():
+    r = await _desc({**DESC_OK, "source_urls": ["https://www.ebay.com/itm/123"]})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_desc_reject_mpn_mismatch():
+    r = await _desc({**DESC_OK, "exact_mpn_found": "01HW918"})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_desc_reject_short_description():
+    r = await _desc({**DESC_OK, "description": "RAM"})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_desc_claude_error_propagates():
+    with patch.object(oem_extractor, "claude_json", new=AsyncMock(side_effect=ClaudeError("down"))):
+        with pytest.raises(ClaudeError):
+            await extract_oem_description("01HW917", "01hw917", "lenovo")
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_oem_extractor.py -v`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+Create `app/services/enrichment_worker/oem_extractor.py`:
+```python
+"""Grounded OEM enrichment: Claude reads authoritative OEM / cross-reference pages and
+either (a) resolves an OEM/FRU code to the commodity MPN it relabels, or (b) extracts an
+OEM-official description. All trust gates enforced in Python — the model's gate claims are
+never trusted.
+
+Called by: app.services.authoritative_enrichment_service.enrich_card.
+Depends on: app.utils.claude_client, app.utils.normalization, .oem_domains.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+from loguru import logger
+
+from app.utils.claude_client import claude_json
+from app.utils.claude_errors import ClaudeError
+from app.utils.normalization import normalize_mpn_key
+
+from .oem_domains import is_crossref_domain, is_oem_domain
+
+_MIN_CROSSREF_CONFIDENCE = 0.90
+_MIN_OEM_CONFIDENCE = 0.90
+
+
+# --------------------------------- cross-reference ---------------------------------
+
+
+@dataclass
+class CrossRefResult:
+    """Candidate OEM->commodity-MPN cross-reference (not yet distributor-confirmed)."""
+
+    status: str  # "resolved" | "failed"
+    resolved_mpn: str | None = None
+    manufacturer: str | None = None
+    linkage_source_url: str | None = None
+    linkage_source_domain: str | None = None
+    confidence: float = 0.0
+
+
+_XR_FAILED = CrossRefResult(status="failed")
+
+_XR_SYSTEM = (
+    "You are an electronics cross-reference assistant. An OEM/system-vendor FRU, spare, or "
+    "service part number relabels a commodity component. Use web search to find an "
+    "AUTHORITATIVE page (the OEM's own site, or an authorized distributor/manufacturer page) "
+    "that shows BOTH the OEM code AND the underlying manufacturer part number together. "
+    "Return ONLY valid JSON. Never invent a part number; use null when unknown."
+)
+_XR_PROMPT = (
+    "OEM/FRU part number: {mpn} (vendor: {vendor}). Find the commodity manufacturer part "
+    'number it corresponds to. Return JSON: {{"resolved_mpn": str|null, "manufacturer": '
+    'str|null, "linkage_quote": str, "confidence": float, "source_urls": [str]}}. '
+    "linkage_quote must be the verbatim text from the page that shows the OEM code and the "
+    "resolved_mpn together."
+)
+
+
+async def cross_reference_mpn(
+    display_mpn: str,
+    normalized_mpn: str,
+    vendor: str,
+    *,
+    timeout: int = 90,
+) -> CrossRefResult:
+    """Resolve an OEM/FRU code to a CANDIDATE commodity MPN via grounded web search.
+
+    Four Python gates: (1) >=1 source URL on a cross-ref allowlist domain; (2) both the OEM
+    code and the resolved MPN appear verbatim (normalized) in the sourced ``linkage_quote``
+    — this is what makes a real-but-wrong guess detectable; (3) resolved != original (no
+    echo); (4) confidence threshold. Returns the candidate only — the caller independently
+    re-verifies the MPN against distributors. Raises ClaudeError on backend failure.
+    """
+    if not normalized_mpn:
+        return _XR_FAILED
+    try:
+        data = await claude_json(
+            _XR_PROMPT.format(mpn=display_mpn, vendor=vendor),
+            system=_XR_SYSTEM,
+            model_tier="smart",
+            max_tokens=1000,
+            tools=[{"type": "web_search_20250305", "name": "web_search", "max_uses": 4}],
+            timeout=timeout,
+        )
+    except ClaudeError:
+        raise
+    except Exception as e:
+        logger.warning("OEM_XREF: unexpected error for {}: {}", display_mpn, type(e).__name__)
+        return _XR_FAILED
+
+    if not isinstance(data, dict):
+        return _XR_FAILED
+
+    urls = [u for u in (data.get("source_urls") or []) if isinstance(u, str) and is_crossref_domain(u)]
+    if not urls:
+        logger.info("OEM_XREF: {} rejected — no trusted source ({})", display_mpn, data.get("source_urls"))
+        return _XR_FAILED
+
+    resolved_raw = (data.get("resolved_mpn") or "").strip()
+    resolved_key = normalize_mpn_key(resolved_raw)
+    if not resolved_key:
+        return _XR_FAILED
+
+    linkage_key = normalize_mpn_key(data.get("linkage_quote"))
+    if normalized_mpn not in linkage_key or resolved_key not in linkage_key:
+        logger.info("OEM_XREF: {} rejected — linkage quote missing a code", display_mpn)
+        return _XR_FAILED
+
+    if resolved_key == normalized_mpn:
+        logger.info("OEM_XREF: {} rejected — resolved == original", display_mpn)
+        return _XR_FAILED
+
+    try:
+        conf = float(data.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        conf = 0.0
+    if conf < _MIN_CROSSREF_CONFIDENCE:
+        logger.info("OEM_XREF: {} rejected — confidence {:.2f} < {:.2f}", display_mpn, conf, _MIN_CROSSREF_CONFIDENCE)
+        return _XR_FAILED
+
+    return CrossRefResult(
+        status="resolved",
+        resolved_mpn=resolved_raw,
+        manufacturer=(data.get("manufacturer") or "").strip() or None,
+        linkage_source_url=urls[0],
+        linkage_source_domain=urlparse(urls[0]).hostname or "",
+        confidence=conf,
+    )
+
+
+# --------------------------------- OEM description ---------------------------------
+
+
+@dataclass
+class OemExtractResult:
+    """Result of an OEM-official description extraction (description/category only)."""
+
+    status: str  # "oem_sourced" | "failed"
+    description: str | None = None
+    manufacturer: str | None = None
+    category: str | None = None
+    datasheet_url: str | None = None
+    confidence: float = 0.0
+    source_urls: list[str] = field(default_factory=list)
+    source_domains: list[str] = field(default_factory=list)
+
+
+_OEM_FAILED = OemExtractResult(status="failed")
+
+_OEM_SYSTEM = (
+    "You are an electronic-component data extraction assistant. Use web search to find the "
+    "OFFICIAL OEM/system-vendor page (Lenovo, HPE, HP, Dell, Acer, ASUS, IBM) for the given "
+    "OEM/FRU/spare part number. Return ONLY valid JSON. Never invent data; use null when unknown."
+)
+_OEM_PROMPT = (
+    "Find the OEM/FRU part number {mpn} (vendor: {vendor}) on the vendor's official parts or "
+    'support page. Return JSON: {{"description": str, "manufacturer": str, "category": str, '
+    '"datasheet_url": str|null, "confidence": float, "exact_mpn_found": str, "source_urls": '
+    '[str]}}. exact_mpn_found must be the OEM code exactly as printed on the page.'
+)
+
+
+async def extract_oem_description(
+    display_mpn: str,
+    normalized_mpn: str,
+    vendor: str,
+    *,
+    timeout: int = 90,
+) -> OemExtractResult:
+    """Extract an OEM-official description/category from the vendor's own page.
+
+    Four Python gates (official OEM domain, exact code verbatim, confidence, non-trivial
+    description + manufacturer). Writes description/category/datasheet only — never
+    structured specs. Raises ClaudeError on backend failure.
+    """
+    if not normalized_mpn:
+        return _OEM_FAILED
+    try:
+        data = await claude_json(
+            _OEM_PROMPT.format(mpn=display_mpn, vendor=vendor),
+            system=_OEM_SYSTEM,
+            model_tier="smart",
+            max_tokens=1000,
+            tools=[{"type": "web_search_20250305", "name": "web_search", "max_uses": 4}],
+            timeout=timeout,
+        )
+    except ClaudeError:
+        raise
+    except Exception as e:
+        logger.warning("OEM_DESC: unexpected error for {}: {}", display_mpn, type(e).__name__)
+        return _OEM_FAILED
+
+    if not isinstance(data, dict):
+        return _OEM_FAILED
+
+    urls = [u for u in (data.get("source_urls") or []) if isinstance(u, str) and is_oem_domain(u)]
+    if not urls:
+        logger.info("OEM_DESC: {} rejected — no official OEM source ({})", display_mpn, data.get("source_urls"))
+        return _OEM_FAILED
+
+    if normalize_mpn_key(data.get("exact_mpn_found")) != normalized_mpn:
+        logger.info("OEM_DESC: {} rejected — MPN mismatch (got {})", display_mpn, data.get("exact_mpn_found"))
+        return _OEM_FAILED
+
+    try:
+        conf = float(data.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        conf = 0.0
+    if conf < _MIN_OEM_CONFIDENCE:
+        logger.info("OEM_DESC: {} rejected — confidence {:.2f} < {:.2f}", display_mpn, conf, _MIN_OEM_CONFIDENCE)
+        return _OEM_FAILED
+
+    desc = (data.get("description") or "").strip()
+    mfr = (data.get("manufacturer") or "").strip()
+    if len(desc) < 10 or not mfr:
+        logger.info("OEM_DESC: {} rejected — description too short ({}) or missing manufacturer", display_mpn, len(desc))
+        return _OEM_FAILED
+
+    return OemExtractResult(
+        status="oem_sourced",
+        description=desc,
+        manufacturer=mfr,
+        category=(data.get("category") or "").strip() or None,
+        datasheet_url=(data.get("datasheet_url") or "").strip() or None,
+        confidence=conf,
+        source_urls=urls,
+        source_domains=sorted({urlparse(u).hostname or "" for u in urls}),
+    )
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_oem_extractor.py -v`
+Expected: PASS (all gate cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/enrichment_worker/oem_extractor.py tests/test_oem_extractor.py
+git commit -m "feat(enrichment): OEM cross-ref + description extractors (Python-gated)"
+```
+
+---
+
+## Task 5: Wire OEM tiers into `enrich_card` + web metering
+
+**Files:**
+- Modify: `app/services/authoritative_enrichment_service.py` (imports; `enrich_card`; 2 new appliers)
+- Test: `tests/test_authoritative_enrichment.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_authoritative_enrichment.py`:
+```python
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.constants import MaterialEnrichmentStatus
+from app.models import MaterialCard
+from app.services import authoritative_enrichment_service as aes
+from app.services.enrichment_worker.oem_extractor import CrossRefResult, OemExtractResult
+
+
+def _card(mpn="01HW917"):
+    return MaterialCard(display_mpn=mpn, normalized_mpn=mpn.lower().replace("-", ""))
+
+
+@pytest.mark.asyncio
+async def test_crossref_double_verify_to_verified(db_session):
+    card = _card()
+    xr = CrossRefResult(
+        status="resolved", resolved_mpn="M393A2K40EB3-CWE", manufacturer="Samsung",
+        linkage_source_url="https://support.lenovo.com/x", linkage_source_domain="support.lenovo.com",
+        confidence=0.95,
+    )
+    # No distributor hit for the FRU; distributor DOES confirm the resolved MPN.
+    async def fake_fetch(display, norm, conns, disabled, cooldown):
+        if norm == "m393a2k40eb3cwe":
+            return {"mouser": [{"mpn_matched": "M393A2K40EB3-CWE", "description": "16GB DDR4 RDIMM", "manufacturer": "Samsung"}]}
+        return {}
+
+    meter = {"web_calls": 0, "claude_ok": False}
+    with patch.object(aes, "classify_oem_vendor", return_value="lenovo"), \
+         patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())), \
+         patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=xr)), \
+         patch.object(aes, "fetch_authoritative", new=AsyncMock(side_effect=fake_fetch)):
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter=meter)
+
+    assert status == MaterialEnrichmentStatus.VERIFIED
+    assert card.description == "16GB DDR4 RDIMM"
+    assert any(x.get("mpn") == "M393A2K40EB3-CWE" for x in (card.cross_references or []))
+    assert card.enrichment_provenance["cross_ref"]["resolved_mpn"] == "M393A2K40EB3-CWE"
+    assert meter["claude_ok"] is True and meter["web_calls"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_crossref_unconfirmed_mpn_falls_through(db_session):
+    card = _card()
+    xr = CrossRefResult(status="resolved", resolved_mpn="BOGUS-NOPART", confidence=0.95,
+                        linkage_source_domain="support.lenovo.com")
+    with patch.object(aes, "classify_oem_vendor", return_value="lenovo"), \
+         patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())), \
+         patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=xr)), \
+         patch.object(aes, "fetch_authoritative", new=AsyncMock(return_value={})), \
+         patch.object(aes, "extract_oem_description", new=AsyncMock(return_value=OemExtractResult(status="failed"))), \
+         patch("app.services.ai_inference_fallback.infer_part",
+               new=AsyncMock(return_value=type("I", (), {"status": "not_found"})())):
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter={"web_calls": 0, "claude_ok": False})
+    # Unconfirmed cross-ref discarded; OEM desc failed; AI declined → not_catalogued (OEM pattern matched).
+    assert status == MaterialEnrichmentStatus.NOT_CATALOGUED
+    assert card.cross_references in (None, [])
+
+
+@pytest.mark.asyncio
+async def test_oem_description_path(db_session):
+    card = _card()
+    oem = OemExtractResult(status="oem_sourced", description="ThinkSystem 16GB RDIMM",
+                           manufacturer="Lenovo", category="Memory Module",
+                           confidence=0.95, source_urls=["https://support.lenovo.com/x"],
+                           source_domains=["support.lenovo.com"])
+    with patch.object(aes, "classify_oem_vendor", return_value="lenovo"), \
+         patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())), \
+         patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=CrossRefResult(status="failed"))), \
+         patch.object(aes, "extract_oem_description", new=AsyncMock(return_value=oem)):
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter={"web_calls": 0, "claude_ok": False})
+    assert status == MaterialEnrichmentStatus.OEM_SOURCED
+    assert card.description == "ThinkSystem 16GB RDIMM"
+    assert card.enrichment_provenance["oem_sourced"] is True
+
+
+@pytest.mark.asyncio
+async def test_non_oem_failure_stays_not_found(db_session):
+    card = _card("LM2596S")
+    with patch.object(aes, "classify_oem_vendor", return_value=None), \
+         patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())), \
+         patch.object(aes, "fetch_authoritative", new=AsyncMock(return_value={})), \
+         patch("app.services.ai_inference_fallback.infer_part",
+               new=AsyncMock(return_value=type("I", (), {"status": "not_found"})())):
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter={"web_calls": 0, "claude_ok": False})
+    assert status == MaterialEnrichmentStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_oem_tiers_skipped_when_web_disabled(db_session):
+    card = _card()
+    xref = AsyncMock()
+    with patch.object(aes, "classify_oem_vendor", return_value="lenovo"), \
+         patch.object(aes, "fetch_authoritative", new=AsyncMock(return_value={})), \
+         patch.object(aes, "cross_reference_mpn", new=xref), \
+         patch("app.services.ai_inference_fallback.infer_part",
+               new=AsyncMock(return_value=type("I", (), {"status": "not_found"})())):
+        status = await aes.enrich_card(card, db_session, connectors=[], disabled={"web_search"},
+                                       web_meter={"web_calls": 0, "claude_ok": False})
+    xref.assert_not_called()  # OEM tiers gated by web budget
+    assert status == MaterialEnrichmentStatus.NOT_FOUND  # not_catalogued requires an actual attempt
+```
+
+> Note: `db_session` is the existing session fixture in `tests/conftest.py` (used by other `test_authoritative_enrichment.py` tests). If those tests use a different fixture name, match it.
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_authoritative_enrichment.py -k "crossref or oem_description or non_oem or web_disabled" -v`
+Expected: FAIL (`enrich_card() got unexpected keyword 'web_meter'`).
+
+- [ ] **Step 3: Implement**
+
+In `app/services/authoritative_enrichment_service.py`, add imports after the existing `from app.services.enrichment_worker.web_extractor import ...` line:
+```python
+from app.services.enrichment_worker.oem_classifier import classify_oem_vendor
+from app.services.enrichment_worker.oem_extractor import (
+    CrossRefResult,
+    OemExtractResult,
+    cross_reference_mpn,
+    extract_oem_description,
+)
+```
+
+Add two appliers after `apply_web_sourced`:
+```python
+def apply_cross_ref_verified(
+    card: MaterialCard,
+    merged: dict,
+    provenance: dict,
+    contributors: list[str],
+    xr: CrossRefResult,
+) -> None:
+    """Write the resolved commodity MPN's distributor data onto an OEM/FRU card.
+
+    Status becomes ``verified`` (the resolved MPN was independently confirmed against a
+    distributor). Records the FRU<->MPN linkage in ``cross_references`` and a top-level
+    ``cross_ref`` provenance block so the whole chain is auditable.
+    """
+    now = datetime.now(timezone.utc)
+    for field_name, value in merged.items():
+        setattr(card, field_name, value)
+    xrefs = list(card.cross_references or [])
+    xrefs.append({"mpn": xr.resolved_mpn, "manufacturer": xr.manufacturer})
+    card.cross_references = xrefs
+    prov = dict(provenance)
+    prov["cross_ref"] = {
+        "oem_part": card.display_mpn,
+        "resolved_mpn": xr.resolved_mpn,
+        "linkage_source_url": xr.linkage_source_url,
+        "linkage_source_domain": xr.linkage_source_domain,
+        "confirmed_by": contributors[0] if contributors else None,
+        "confidence": xr.confidence,
+    }
+    card.enrichment_provenance = prov
+    card.enrichment_source = contributors[0] if contributors else "cross_ref"
+    card.enrichment_status = MaterialEnrichmentStatus.VERIFIED
+    card.enriched_at = now
+
+
+def apply_oem_sourced(card: MaterialCard, result: OemExtractResult) -> None:
+    """Write OEM-official description/category onto the card (status ``oem_sourced``).
+
+    Description + category + datasheet only — never structured specs.
+    """
+    now = datetime.now(timezone.utc)
+    iso = now.isoformat()
+    prov: dict = {
+        "oem_sourced": True,
+        "confidence": result.confidence,
+        "source_urls": result.source_urls,
+        "source_domains": result.source_domains,
+        "fetched_at": iso,
+    }
+    fields = {
+        "description": result.description,
+        "category": result.category,
+        "datasheet_url": result.datasheet_url,
+        "manufacturer": result.manufacturer,
+    }
+    for f, v in fields.items():
+        if v:
+            setattr(card, f, v)
+            prov[f] = {"source": "oem_official", "confidence": result.confidence, "fetched_at": iso}
+    card.enrichment_source = "oem_official"
+    card.enrichment_status = MaterialEnrichmentStatus.OEM_SOURCED
+    card.enrichment_provenance = prov
+    card.enriched_at = now
+```
+
+Replace the body of `enrich_card` from the `web_enabled`/web-tier section through the terminal `return MaterialEnrichmentStatus.NOT_FOUND`. The new signature adds `web_meter`; update the docstring's CONCURRENCY INVARIANT note to add: "the cross-ref re-verification (`fetch_authoritative` on the resolved MPN) is pure async connector I/O — no DB query/flush — so the invariant holds." Body:
+
+```python
+async def enrich_card(
+    card: MaterialCard,
+    db: Session,
+    *,
+    connectors: list | None = None,
+    refresh: bool = False,
+    disabled: set[str] | None = None,
+    cooldown: dict[str, float] | None = None,
+    web_meter: dict | None = None,
+) -> str:
+    """...(keep existing docstring; append:)
+
+    ``web_meter`` (optional ``{"web_calls": int, "claude_ok": bool}``) is updated in place:
+    ``web_calls`` counts each billable web-search call made (distributor web, cross-ref, OEM
+    description); ``claude_ok`` is set True after ANY Claude call (incl. infer_part) returns
+    without raising. The worker uses ``web_calls`` for the daily budget and ``claude_ok`` to
+    reset its circuit breaker. Default None = no metering.
+    """
+    if card.enrichment_status == MaterialEnrichmentStatus.VERIFIED and not refresh:
+        return MaterialEnrichmentStatus.VERIFIED
+
+    conns = connectors if connectors is not None else _connectors_in_order(db)
+    results = await fetch_authoritative(card.display_mpn, card.normalized_mpn, conns, disabled, cooldown)
+    merged, provenance, contributors = merge_authoritative(card.normalized_mpn, results)
+
+    if merged:
+        apply_authoritative(card, merged, provenance, contributors)
+        return MaterialEnrichmentStatus.VERIFIED
+
+    web_enabled = not (disabled and "web_search" in disabled)
+
+    # Distributor / manufacturer web tier.
+    if web_enabled:
+        web = await extract_part_from_web(card.display_mpn, card.normalized_mpn)
+        if web_meter is not None:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
+            web_meter["claude_ok"] = True
+        if web.status == "web_sourced":
+            apply_web_sourced(card, web)
+            return MaterialEnrichmentStatus.WEB_SOURCED
+
+    # OEM tiers — only for recognised OEM/FRU codes, only when the web budget is live.
+    vendor = classify_oem_vendor(card.display_mpn)
+    oem_attempted = False
+    if vendor and web_enabled:
+        oem_attempted = True
+        # Tier 3: cross-reference, then INDEPENDENTLY re-verify against distributors.
+        xr = await cross_reference_mpn(card.display_mpn, card.normalized_mpn, vendor)
+        if web_meter is not None:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
+            web_meter["claude_ok"] = True
+        if xr.status == "resolved" and xr.resolved_mpn:
+            resolved_key = normalize_mpn_key(xr.resolved_mpn)
+            xr_results = await fetch_authoritative(xr.resolved_mpn, resolved_key, conns, disabled, cooldown)
+            xr_merged, xr_prov, xr_contrib = merge_authoritative(resolved_key, xr_results)
+            if xr_merged:
+                apply_cross_ref_verified(card, xr_merged, xr_prov, xr_contrib, xr)
+                return MaterialEnrichmentStatus.VERIFIED
+        # Tier 4: OEM-official description (single authoritative page).
+        oem = await extract_oem_description(card.display_mpn, card.normalized_mpn, vendor)
+        if web_meter is not None:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
+            web_meter["claude_ok"] = True
+        if oem.status == "oem_sourced":
+            apply_oem_sourced(card, oem)
+            return MaterialEnrichmentStatus.OEM_SOURCED
+
+    # No authoritative hit -> flagged inference.
+    from app.services.ai_inference_fallback import infer_part
+
+    inf = await infer_part(card.display_mpn)
+    if web_meter is not None:
+        web_meter["claude_ok"] = True
+    now = datetime.now(timezone.utc)
+    card.enriched_at = now
+    if inf.status == "ai_inferred":
+        card.description = inf.description
+        card.category = inf.category
+        card.enrichment_source = "claude_opus_inferred"
+        card.enrichment_status = MaterialEnrichmentStatus.AI_INFERRED
+        card.enrichment_provenance = {
+            "reconfirm_needed": True,
+            "description": {
+                "source": "claude_opus_inferred",
+                "confidence": inf.confidence,
+                "fetched_at": now.isoformat(),
+            },
+        }
+        return MaterialEnrichmentStatus.AI_INFERRED
+
+    # Terminal: not_catalogued only when an OEM pattern matched AND the OEM tiers ran.
+    card.enrichment_status = (
+        MaterialEnrichmentStatus.NOT_CATALOGUED
+        if (vendor and oem_attempted)
+        else MaterialEnrichmentStatus.NOT_FOUND
+    )
+    card.enrichment_source = None
+    card.enrichment_provenance = None
+    return card.enrichment_status
+```
+
+> `normalize_mpn_key` is already imported at the top of this module. `extract_part_from_web` is already imported. The `import normalize_mpn_key` line is `from app.utils.normalization import normalize_mpn_key` (already present).
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_authoritative_enrichment.py -v`
+Expected: PASS (new + existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/authoritative_enrichment_service.py tests/test_authoritative_enrichment.py
+git commit -m "feat(enrichment): OEM cross-ref + description tiers in enrich_card with web metering"
+```
+
+---
+
+## Task 6: Worker — metered budget, breaker reset, `not_catalogued` retry
+
+**Files:**
+- Modify: `app/services/enrichment_worker/config.py:21-43`
+- Modify: `app/services/enrichment_worker/worker.py` (`select_batch`, `run_one_batch`)
+- Test: `tests/test_enrichment_worker.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_enrichment_worker.py`:
+```python
+from datetime import datetime, timedelta, timezone
+
+from app.constants import MaterialEnrichmentStatus
+from app.services.enrichment_worker.config import EnrichmentWorkerConfig
+
+
+def test_config_has_not_catalogued_retry_days():
+    c = EnrichmentWorkerConfig()
+    assert c.not_catalogued_retry_days == 30
+
+
+def test_select_batch_not_catalogued_eligibility(db_session):
+    from app.models import MaterialCard
+    from app.services.enrichment_worker.worker import select_batch
+
+    now = datetime.now(timezone.utc)
+    cfg = EnrichmentWorkerConfig(batch_size=10, not_catalogued_retry_days=30)
+    fresh = MaterialCard(display_mpn="A1", normalized_mpn="a1",
+                         enrichment_status=MaterialEnrichmentStatus.NOT_CATALOGUED,
+                         enriched_at=now - timedelta(days=1))
+    stale = MaterialCard(display_mpn="A2", normalized_mpn="a2",
+                         enrichment_status=MaterialEnrichmentStatus.NOT_CATALOGUED,
+                         enriched_at=now - timedelta(days=40))
+    db_session.add_all([fresh, stale])
+    db_session.commit()
+    picked = {c.normalized_mpn for c in select_batch(db_session, cfg)}
+    assert "a2" in picked          # past 30-day backoff → eligible
+    assert "a1" not in picked      # within backoff → not yet
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_enrichment_worker.py -k "not_catalogued" -v`
+Expected: FAIL (`AttributeError: not_catalogued_retry_days`).
+
+- [ ] **Step 3: Implement**
+
+In `app/services/enrichment_worker/config.py`, add the field after `not_found_retry_hours`:
+```python
+    not_found_retry_hours: int = 22
+    not_catalogued_retry_days: int = 30
+```
+and in `from_env`, after the `not_found_retry_hours=...` line:
+```python
+            not_catalogued_retry_days=int(os.environ.get("ENRICHMENT_NOT_CATALOGUED_RETRY_DAYS", 30)),
+```
+
+In `app/services/enrichment_worker/worker.py`, in `select_batch`, after the `not_found_eligible = and_(...)` block add:
+```python
+    not_catalogued_cutoff = now - timedelta(days=config.not_catalogued_retry_days)
+    not_catalogued_eligible = and_(
+        MaterialCard.enrichment_status == MaterialEnrichmentStatus.NOT_CATALOGUED,
+        or_(
+            MaterialCard.enriched_at.is_(None),
+            MaterialCard.enriched_at < not_catalogued_cutoff,
+        ),
+    )
+```
+and add `not_catalogued_eligible` to the `or_(...)` in the `.filter(...)`:
+```python
+            or_(
+                MaterialCard.enrichment_status == MaterialEnrichmentStatus.UNENRICHED,
+                not_found_eligible,
+                not_catalogued_eligible,
+            ),
+```
+
+In `run_one_batch`, replace the per-card try block (the `web_enabled = "web_search" not in disabled` line and the success accounting) with metered accounting. Specifically, delete the line `web_enabled = "web_search" not in disabled` and replace:
+```python
+        try:
+            status = await enrich_card(
+                card,
+                db,
+                connectors=conns,
+                disabled=disabled,
+                cooldown=cooldown,
+            )
+            card.enriched_at = now
+            counts[status] = counts.get(status, 0) + 1
+
+            if status != MaterialEnrichmentStatus.VERIFIED:
+                breaker.record_claude_success()
+                if web_enabled:
+                    web_calls_today += 1
+                    intel_cache.set_cached(web_cache_key, {"count": web_calls_today}, ttl_days=1.0)
+```
+with:
+```python
+        card_meter = {"web_calls": 0, "claude_ok": False}
+        try:
+            status = await enrich_card(
+                card,
+                db,
+                connectors=conns,
+                disabled=disabled,
+                cooldown=cooldown,
+                web_meter=card_meter,
+            )
+            card.enriched_at = now
+            counts[status] = counts.get(status, 0) + 1
+
+            # A Claude call (web/cross-ref/OEM/infer) returned without raising → backend healthy.
+            if card_meter["claude_ok"]:
+                breaker.record_claude_success()
+            # Each card may fire 1–3 billable web-search calls; meter keeps the cap exact.
+            if card_meter["web_calls"] > 0:
+                web_calls_today += card_meter["web_calls"]
+                intel_cache.set_cached(web_cache_key, {"count": web_calls_today}, ttl_days=1.0)
+```
+
+> Leave the budget-gate block above the loop (`if web_calls_today >= config.web_daily_cap ...: disabled.add("web_search")`) unchanged — it still trips the persistent `disabled` flag that `enrich_card` reads. Only the post-call accounting changes.
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_enrichment_worker.py -v`
+Expected: PASS (new + existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/enrichment_worker/config.py app/services/enrichment_worker/worker.py tests/test_enrichment_worker.py
+git commit -m "feat(enrichment): metered web budget + breaker reset + not_catalogued retry backoff"
+```
+
+---
+
+## Task 7: UI badges for `oem_sourced` + `not_catalogued`
+
+**Files:**
+- Modify: `app/templates/htmx/partials/materials/list.html:77-87`
+
+- [ ] **Step 1: Add a render assertion test**
+
+Append to `tests/test_materials_router.py` (or `tests/test_routers_materials.py` — whichever exists; pick the one already importing the materials list partial). If neither has a render helper, create `tests/test_oem_badges.py`:
+```python
+"""Badge rendering for oem_sourced + not_catalogued in the materials list partial."""
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+def _render(status, provenance=None):
+    env = Environment(
+        loader=FileSystemLoader("app/templates"),
+        autoescape=select_autoescape(["html"]),
+    )
+    tmpl = env.get_template("htmx/partials/materials/list.html")
+    card = type("C", (), {
+        "enrichment_status": status, "enrichment_provenance": provenance or {},
+        "lifecycle_status": None, "display_mpn": "01HW917", "manufacturer": "Lenovo",
+        "category": "Memory", "description": "x", "_vendor_count": 0, "_best_price": None,
+        "_best_currency": "USD", "id": 1, "normalized_mpn": "01hw917",
+    })()
+    return tmpl.module if False else tmpl.render(materials=[card], lc_colors={})
+
+
+def test_oem_sourced_badge_renders():
+    html = _render("oem_sourced", {"source_urls": ["https://support.lenovo.com/x"],
+                                    "source_domains": ["support.lenovo.com"]})
+    assert "OEM-SOURCED" in html
+
+
+def test_not_catalogued_badge_renders():
+    html = _render("not_catalogued")
+    assert "NOT CATALOGUED" in html
+```
+> If `list.html` requires more context vars to render than the stub provides, add the missing attributes to the stub `C` class until it renders — do not change the template to suit the test.
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_oem_badges.py -v`
+Expected: FAIL (`OEM-SOURCED` not in output).
+
+- [ ] **Step 3: Implement**
+
+In `app/templates/htmx/partials/materials/list.html`, insert between the `web_sourced` `{% elif %}` block (ends at the `</a>` on line 77) and `{% elif es == "ai_inferred" %}` (line 78):
+```jinja
+            {% elif es == "oem_sourced" %}
+            {% set _ou = (m.enrichment_provenance or {}).get('source_urls', [None])[0] %}
+            <a href="{{ _ou or '#' }}" target="_blank" rel="noopener"
+               class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-indigo-50 text-indigo-700 border-indigo-200"
+               title="OEM-official source: {{ (m.enrichment_provenance or {}).get('source_domains', ['vendor page'])|join(', ') }} — description from the OEM; specs not distributor-verified">
+              OEM-SOURCED
+            </a>
+```
+and insert between the `not_found` `{% elif %}` block (ends line 87) and `{% else %}` (line 88):
+```jinja
+            {% elif es == "not_catalogued" %}
+            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-slate-100 text-slate-600 border-slate-300"
+                  title="Recognised OEM service/FRU part; no public specs published">
+              NOT CATALOGUED
+            </span>
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_oem_badges.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/templates/htmx/partials/materials/list.html tests/test_oem_badges.py
+git commit -m "feat(materials-ui): oem_sourced + not_catalogued status badges"
+```
+
+---
+
+## Task 8: Filter toggles for the two new tiers
+
+**Files:**
+- Modify: `app/templates/htmx/partials/materials/workspace.html` (toggle markup `:56`; hx-vals JS `:194-204`)
+- Modify: `app/static/htmx_app.js` (state `:558`; syncFromURL `:595`; reset `:625`; serialize `:636`)
+
+- [ ] **Step 1: Implement state (no unit test — covered by E2E/manual; this is wiring)**
+
+In `app/static/htmx_app.js`, after line 558 (`webSourced: false,`) add:
+```javascript
+  oemSourced: false,
+  notCatalogued: false,
+```
+After the `this.webSourced = params.get('web_sourced') === 'true';` line (~595) add:
+```javascript
+      this.oemSourced = params.get('oem_sourced') === 'true';
+      this.notCatalogued = params.get('not_catalogued') === 'true';
+```
+After the reset `this.webSourced = false;` line (~625) add:
+```javascript
+      this.oemSourced = false;
+      this.notCatalogued = false;
+```
+After the serialize `if (this.webSourced) params.set('web_sourced', 'true'); else params.delete('web_sourced');` line (~636) add:
+```javascript
+    if (this.oemSourced) params.set('oem_sourced', 'true'); else params.delete('oem_sourced');
+    if (this.notCatalogued) params.set('not_catalogued', 'true'); else params.delete('not_catalogued');
+```
+
+In `app/templates/htmx/partials/materials/workspace.html`: change the web-sourced wrapper `<div class="mb-3">` (line 56) to `<div class="mb-1">`, then insert after that toggle's closing `</div>` (line 64):
+```jinja
+      {# OEM-sourced toggle #}
+      <div class="mb-1">
+        <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
+          <input type="checkbox"
+                 :checked="oemSourced"
+                 @change="oemSourced = !oemSourced; applyFilters()"
+                 class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 h-3.5 w-3.5">
+          <span class="text-gray-700 font-medium">OEM-sourced</span>
+        </label>
+      </div>
+      {# Not-catalogued toggle #}
+      <div class="mb-3">
+        <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
+          <input type="checkbox"
+                 :checked="notCatalogued"
+                 @change="notCatalogued = !notCatalogued; applyFilters()"
+                 class="rounded border-gray-300 text-slate-600 focus:ring-slate-500 h-3.5 w-3.5">
+          <span class="text-gray-700 font-medium">Not catalogued</span>
+        </label>
+      </div>
+```
+In the `hx-vals` JS (lines 194-204), after `var webSourced = ...` add:
+```javascript
+           var oemSourced = Alpine.evaluate(ws, "oemSourced") || false;
+           var notCatalogued = Alpine.evaluate(ws, "notCatalogued") || false;
+```
+and after `if (webSourced) statusList.push("web_sourced");` add:
+```javascript
+           if (oemSourced) statusList.push("oem_sourced");
+           if (notCatalogued) statusList.push("not_catalogued");
+```
+
+- [ ] **Step 2: Build the frontend bundle to verify no JS syntax error**
+
+Run: `npm run build 2>&1 | tail -5`
+Expected: build succeeds (bundle smoke test passes).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/templates/htmx/partials/materials/workspace.html app/static/htmx_app.js
+git commit -m "feat(materials-ui): oem_sourced + not_catalogued filter toggles"
+```
+
+---
+
+## Task 9: Dry-run-first backfill script
+
+**Files:**
+- Create: `scripts/backfill_oem_enrichment.py`
+- Test: `tests/test_backfill_oem_enrichment.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/test_backfill_oem_enrichment.py`:
+```python
+"""Backfill: dry-run writes a coverage report and commits nothing; budget cap halts."""
+
+import csv
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.constants import MaterialEnrichmentStatus
+from app.models import MaterialCard
+
+
+@pytest.mark.asyncio
+async def test_dry_run_writes_csv_and_no_commit(db_session, tmp_path):
+    import scripts.backfill_oem_enrichment as bf
+
+    c = MaterialCard(display_mpn="01HW917", normalized_mpn="01hw917",
+                     enrichment_status=MaterialEnrichmentStatus.NOT_FOUND)
+    db_session.add(c)
+    db_session.commit()
+
+    async def fake_enrich(card, db, **kw):
+        card.enrichment_status = MaterialEnrichmentStatus.OEM_SOURCED
+        return MaterialEnrichmentStatus.OEM_SOURCED
+
+    out = tmp_path / "cov.csv"
+    with patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)), \
+         patch.object(bf, "SessionLocal", return_value=db_session):
+        counts = await bf.run(commit=False, limit=None, max_web_calls=100, csv_path=str(out))
+
+    db_session.expire_all()
+    assert db_session.get(MaterialCard, c.id).enrichment_status == MaterialEnrichmentStatus.NOT_FOUND  # rolled back
+    assert counts["oem_sourced"] == 1
+    rows = list(csv.DictReader(out.open()))
+    assert rows[0]["projected_status"] == "oem_sourced"
+
+
+@pytest.mark.asyncio
+async def test_budget_cap_halts(db_session, tmp_path):
+    import scripts.backfill_oem_enrichment as bf
+
+    for i in range(5):
+        db_session.add(MaterialCard(display_mpn=f"01HW{i:03d}", normalized_mpn=f"01hw{i:03d}",
+                                    enrichment_status=MaterialEnrichmentStatus.NOT_FOUND))
+    db_session.commit()
+
+    async def fake_enrich(card, db, *, web_meter=None, **kw):
+        if web_meter is not None:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 2
+        card.enrichment_status = MaterialEnrichmentStatus.NOT_CATALOGUED
+        return MaterialEnrichmentStatus.NOT_CATALOGUED
+
+    with patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)), \
+         patch.object(bf, "SessionLocal", return_value=db_session):
+        counts = await bf.run(commit=False, limit=None, max_web_calls=3, csv_path=str(tmp_path / "c.csv"))
+
+    # 3-call budget, 2 calls per card → stops after the 2nd card (4 calls would exceed).
+    assert counts["processed"] <= 2
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_backfill_oem_enrichment.py -v`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+Create `scripts/backfill_oem_enrichment.py`:
+```python
+"""One-time backfill: re-enrich not_found / not_catalogued MaterialCards through the OEM
+cross-ref + description tiers.
+
+Dry-run by default: runs ``enrich_card`` over the backlog, tallies projected outcomes,
+writes a coverage CSV, and ROLLS BACK (writes nothing). ``--commit`` persists, with a
+shared web-call budget cap so it cannot blow the API spend. The paced worker drains any
+remainder afterward.
+
+Usage:
+  python3 scripts/backfill_oem_enrichment.py --dry-run
+  python3 scripts/backfill_oem_enrichment.py --commit --max-web-calls 300 --limit 500
+
+Called by: operators (manual, under explicit authorization). Depends on:
+app.database.SessionLocal, app.services.authoritative_enrichment_service.
+"""
+
+import argparse
+import asyncio
+import csv
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from loguru import logger  # noqa: E402
+
+from app.constants import MaterialEnrichmentStatus  # noqa: E402
+from app.database import SessionLocal  # noqa: E402
+from app.models import MaterialCard  # noqa: E402
+from app.services.authoritative_enrichment_service import (  # noqa: E402
+    _connectors_in_order,
+    enrich_card,
+)
+from app.services.enrichment_worker.oem_classifier import classify_oem_vendor  # noqa: E402
+
+_TARGET_STATUSES = (MaterialEnrichmentStatus.NOT_FOUND, MaterialEnrichmentStatus.NOT_CATALOGUED)
+
+
+def _select(db, limit):
+    q = (
+        db.query(MaterialCard)
+        .filter(
+            MaterialCard.deleted_at.is_(None),
+            MaterialCard.is_internal_part.is_(False),
+            MaterialCard.enrichment_status.in_([s.value for s in _TARGET_STATUSES]),
+        )
+        .order_by(MaterialCard.search_count.desc(), MaterialCard.created_at.desc())
+    )
+    return q.limit(limit).all() if limit else q.all()
+
+
+async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str) -> dict:
+    """Process the backlog. Returns a counts dict. Writes a coverage CSV. Rolls back unless commit."""
+    db = SessionLocal()
+    counts: dict[str, int] = {"processed": 0, "web_calls": 0}
+    rows: list[dict] = []
+    try:
+        conns = _connectors_in_order(db)
+        cards = _select(db, limit)
+        logger.info("BACKFILL: {} candidate cards (commit={}, budget={})", len(cards), commit, max_web_calls)
+        disabled: set[str] = set()
+        cooldown: dict[str, float] = {}
+        web_total = 0
+        for i, card in enumerate(cards, 1):
+            if web_total >= max_web_calls:
+                logger.info("BACKFILL: web budget {} reached — stopping (remaining drains via worker)", max_web_calls)
+                break
+            meter = {"web_calls": 0, "claude_ok": False}
+            try:
+                status = await enrich_card(card, db, connectors=conns, disabled=disabled,
+                                           cooldown=cooldown, web_meter=meter)
+            except Exception as e:  # noqa: BLE001 — a single bad card must not abort the run
+                logger.warning("BACKFILL: {} failed: {}", card.display_mpn, type(e).__name__)
+                status = "error"
+            web_total += meter["web_calls"]
+            counts["processed"] += 1
+            counts[status] = counts.get(status, 0) + 1
+            resolved = None
+            if card.enrichment_provenance and isinstance(card.enrichment_provenance, dict):
+                resolved = (card.enrichment_provenance.get("cross_ref") or {}).get("resolved_mpn")
+            rows.append({
+                "display_mpn": card.display_mpn,
+                "vendor": classify_oem_vendor(card.display_mpn) or "",
+                "projected_status": status,
+                "resolved_mpn": resolved or "",
+                "source": card.enrichment_source or "",
+            })
+            if i % 25 == 0:
+                logger.info("BACKFILL: {}/{} (web_calls={})", i, len(cards), web_total)
+
+        counts["web_calls"] = web_total
+        if commit:
+            db.commit()
+            logger.info("BACKFILL: committed.")
+        else:
+            db.rollback()
+            logger.info("BACKFILL: DRY RUN — rolled back, no DB writes.")
+
+        with open(csv_path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=["display_mpn", "vendor", "projected_status", "resolved_mpn", "source"])
+            w.writeheader()
+            w.writerows(rows)
+        logger.info("BACKFILL: coverage CSV → {}", csv_path)
+        logger.info("BACKFILL SUMMARY: {}", {k: v for k, v in counts.items()})
+        return counts
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", help="Preview only (default).")
+    ap.add_argument("--commit", action="store_true", help="Persist results (default is dry-run).")
+    ap.add_argument("--limit", type=int, default=None, help="Max cards to process.")
+    ap.add_argument("--max-web-calls", type=int, default=300, help="Web-search call budget cap.")
+    ap.add_argument("--csv", default="backfill_oem_coverage.csv", help="Coverage CSV output path.")
+    args = ap.parse_args()
+    if not args.commit:
+        logger.info("DRY RUN — no DB writes. Use --commit to persist.")
+    asyncio.run(run(commit=args.commit, limit=args.limit, max_web_calls=args.max_web_calls, csv_path=args.csv))
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_backfill_oem_enrichment.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/backfill_oem_enrichment.py tests/test_backfill_oem_enrichment.py
+git commit -m "feat(scripts): dry-run-first OEM enrichment backfill with budget cap"
+```
+
+---
+
+## Task 10: Update APP_MAP docs
+
+**Files:**
+- Modify: `docs/APP_MAP_ARCHITECTURE.md`, `docs/APP_MAP_DATABASE.md`, `docs/APP_MAP_INTERACTIONS.md`
+
+- [ ] **Step 1: Edit docs (no test)**
+  - `APP_MAP_DATABASE.md`: in the `material_cards.enrichment_status` description, add `oem_sourced` and `not_catalogued` to the value list; note `cross_references` now also records FRU→MPN linkages written by cross-ref enrichment.
+  - `APP_MAP_ARCHITECTURE.md`: under the enrichment-worker module list, add `oem_classifier.py`, `oem_domains.py`, `oem_extractor.py`; add `scripts/backfill_oem_enrichment.py`.
+  - `APP_MAP_INTERACTIONS.md`: in the enrichment-tier flow, document the new sequence (verified → web_sourced → OEM cross-ref [double-verify] → OEM description → ai_inferred → not_catalogued/not_found) and the `web_meter` budget/breaker contract.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/APP_MAP_ARCHITECTURE.md docs/APP_MAP_DATABASE.md docs/APP_MAP_INTERACTIONS.md
+git commit -m "docs(app-map): document OEM enrichment tiers + new statuses"
+```
+
+---
+
+## Final Verification (after all tasks)
+
+- [ ] `TESTING=1 PYTHONPATH=$(pwd) pytest tests/ -q` — full suite green (no regressions vs the 57-test baseline + new tests).
+- [ ] `ruff check app/ scripts/ && ruff format --check app/ scripts/` — clean.
+- [ ] `mypy app/` — no new errors.
+- [ ] `pre-commit run --all-files` — all hooks pass.
+- [ ] `npm run build` — bundle smoke test passes (JS toggles).
+- [ ] Backfill dry-run produces a sane coverage CSV (Task 11 in the session task list).
+
+## Self-Review Notes (author check vs spec)
+- Spec §3 tier order, §3.1 dual cross-ref gate, §4.1–4.8 components, §4.4.1 metering+breaker,
+  §4.6 retry backoff, §4.7 UI, §4.8 backfill — each maps to Task 1–10. ✓
+- Type consistency: `CrossRefResult` / `OemExtractResult` fields used in Task 5 match Task 4
+  definitions; `web_meter` keys `{"web_calls","claude_ok"}` consistent across Tasks 5, 6, 9. ✓
+- No migration (varchar status) — Task 1 changes enum only. ✓
+- `not_catalogued` only when `vendor and oem_attempted` (Task 5) ↔ web-disabled stays
+  `not_found` (Task 5 test `test_oem_tiers_skipped_when_web_disabled`). ✓

--- a/docs/superpowers/plans/2026-06-05-oem-enrichment-review-fixes.md
+++ b/docs/superpowers/plans/2026-06-05-oem-enrichment-review-fixes.md
@@ -1,0 +1,300 @@
+# OEM Enrichment — Review-Fix Plan (round 2)
+
+> Executes the consolidated findings from the 7-agent PR review of branch `worktree-oem-enrichment`. TDD where a behavior changes. Worktree: `/root/availai/.claude/worktrees/oem-enrichment`; run tests with `TESTING=1 PYTHONPATH=$(pwd) pytest <paths> -q` (use `pytest` directly). Baseline before round 2: full suite 14503 passed.
+
+**Do the tasks in order (RF1 first — the `WebMeter` type everything else uses).** Commit per task with the given message. After all tasks: full suite + `pre-commit run --files <changed>`.
+
+---
+
+## RF1 — `WebMeter` type + reserve-before-await metering fix
+
+**Why:** 4 reviewers — billable web call that bills then raises `ClaudeError` is never counted (`WEB_DAILY_CAP` drifts over); loose `dict` meter has silent-key-typo risk across 3 modules.
+
+**RF1.1 — Add `WebMeter` to `app/services/enrichment_types.py`** (after the imports, add `from dataclasses import dataclass`):
+```python
+@dataclass
+class WebMeter:
+    """Mutable per-card budget/health meter threaded through ``enrich_card``.
+
+    ``web_calls`` counts billable web-search-enabled Claude tier attempts; it is
+    RESERVED *before* each dispatch so a call that bills then raises is still counted.
+    ``claude_ok`` latches True after any Claude call returns without raising. The worker
+    uses ``web_calls`` for the daily web budget and ``claude_ok`` to reset its breaker.
+    """
+
+    web_calls: int = 0
+    claude_ok: bool = False
+
+    def reserve_web_call(self) -> None:
+        """Count one billable web-search tier attempt. Call BEFORE the await."""
+        self.web_calls += 1
+
+    def mark_claude_ok(self) -> None:
+        """Latch that a Claude call returned without raising. Call AFTER the await."""
+        self.claude_ok = True
+```
+
+**RF1.2 — `app/services/authoritative_enrichment_service.py`**: import `from app.services.enrichment_types import WebMeter`. Change `enrich_card` signature `web_meter: dict | None = None` → `web_meter: WebMeter | None = None`. Replace each of the three metering blocks so the reserve happens BEFORE the await and the ok-latch AFTER:
+
+Distributor web tier:
+```python
+    if web_enabled:
+        if web_meter is not None:
+            web_meter.reserve_web_call()
+        web = await extract_part_from_web(card.display_mpn, card.normalized_mpn)
+        if web_meter is not None:
+            web_meter.mark_claude_ok()
+        if web.status == "web_sourced":
+            apply_web_sourced(card, web)
+            return MaterialEnrichmentStatus.WEB_SOURCED
+```
+Cross-ref tier:
+```python
+        if web_meter is not None:
+            web_meter.reserve_web_call()
+        xr = await cross_reference_mpn(card.display_mpn, card.normalized_mpn, vendor)
+        if web_meter is not None:
+            web_meter.mark_claude_ok()
+        if xr.status == "resolved" and xr.resolved_mpn:
+            ...
+```
+OEM-description tier:
+```python
+        if web_meter is not None:
+            web_meter.reserve_web_call()
+        oem = await extract_oem_description(card.display_mpn, card.normalized_mpn, vendor)
+        if web_meter is not None:
+            web_meter.mark_claude_ok()
+        if oem.status == "oem_sourced":
+            ...
+```
+infer path (no web reserve, only latch):
+```python
+    inf = await infer_part(card.display_mpn)
+    if web_meter is not None:
+        web_meter.mark_claude_ok()
+```
+Update the `web_meter` docstring paragraph: `web_calls` "counts each web-search-enabled Claude tier attempt (distributor / cross-ref / OEM-description), reserved before dispatch."
+
+**RF1.3 — `app/services/enrichment_worker/worker.py` `run_one_batch`**: import `WebMeter`. Replace `card_meter = {"web_calls": 0, "claude_ok": False}` → `card_meter = WebMeter()`. Pass `web_meter=card_meter`. Change `card_meter["claude_ok"]` → `card_meter.claude_ok`, `card_meter["web_calls"]` → `card_meter.web_calls`. **Move the budget flush into a `finally`** on the per-card try so calls that fired before a later-tier raise are still billed:
+```python
+        card_meter = WebMeter()
+        try:
+            status = await enrich_card(card, db, connectors=conns, disabled=disabled, cooldown=cooldown, web_meter=card_meter)
+            card.enriched_at = now
+            counts[status] = counts.get(status, 0) + 1
+            if card_meter.claude_ok:
+                breaker.record_claude_success()
+        except ClaudeError as e:
+            # (unchanged body — record_claude_error, log)
+            ...
+        except Exception as e:
+            # (unchanged body — quarantine not_found)
+            ...
+        finally:
+            if card_meter.web_calls > 0:
+                web_calls_today += card_meter.web_calls
+                intel_cache.set_cached(web_cache_key, {"count": web_calls_today}, ttl_days=1.0)
+```
+Soften the `run_one_batch` docstring line claiming the cap "cannot overshoot ... by up to batch_size" → "a single card may fire up to 3 billable web calls, so the per-card gate can overshoot the cap by at most 2; the meter is flushed in a finally so every dispatched call is billed even when a later tier raises."
+
+**RF1.4 — `scripts/backfill_oem_enrichment.py`**: `from app.services.enrichment_types import WebMeter`; `meter = WebMeter()`; `web_total += meter.web_calls`. (Per-card try already runs after the await in-loop, so flush is fine.)
+
+**RF1.5 — Update existing meter tests** in `tests/test_enrichment_worker.py` and `tests/test_backfill_oem_enrichment.py`: any `fake_enrich_card(..., web_meter=...)` that did `web_meter["web_calls"] += N` / `web_meter["claude_ok"] = True` becomes `web_meter.reserve_web_call()`×N (or `web_meter.web_calls += N`) / `web_meter.mark_claude_ok()`; any literal `{"web_calls": 0, "claude_ok": False}` → `WebMeter()`; any `meter["web_calls"]`/`meter["claude_ok"]` read → attribute.
+
+Run: `pytest tests/test_enrichment_worker.py tests/test_backfill_oem_enrichment.py tests/test_authoritative_enrichment.py -q`. Commit: `fix(enrichment): WebMeter type + reserve-before-dispatch web budget (no undercount on ClaudeError)`.
+
+---
+
+## RF2 — `enrich_card` correctness fixes
+
+**RF2.1 — OEM_SOURCED re-enrichment guard** (`authoritative_enrichment_service.py:307`): a direct `enrich_cards` call on an already-`oem_sourced` card would re-run the OEM tiers (2 web calls). Extend the early-exit:
+```python
+    if card.enrichment_status in (MaterialEnrichmentStatus.VERIFIED, MaterialEnrichmentStatus.OEM_SOURCED) and not refresh:
+        return card.enrichment_status
+```
+
+**RF2.2 — Dell low-precision → `not_found`, not `not_catalogued`** (terminal block ~384). The Dell 5-char pattern is broad; a genuine 5-char MPN that misses earlier tiers must not be parked 30 days. In `app/services/enrichment_worker/oem_classifier.py` add:
+```python
+# Vendors whose patterns are precise enough that an OEM-tier miss means "genuinely an
+# uncatalogued OEM service part" (-> not_catalogued, 30-day backoff). The broad Dell
+# 5-char pattern is excluded: a miss there is more likely a generic part, so it stays
+# not_found (22h retry) instead of being parked for a month.
+HIGH_PRECISION_VENDORS: frozenset[str] = frozenset({"lenovo", "ibm", "hpe", "acer", "asus"})
+```
+Import it in `authoritative_enrichment_service.py` and change the terminal:
+```python
+    card.enrichment_status = (
+        MaterialEnrichmentStatus.NOT_CATALOGUED
+        if (vendor in HIGH_PRECISION_VENDORS and oem_attempted)
+        else MaterialEnrichmentStatus.NOT_FOUND
+    )
+```
+(`vendor in HIGH_PRECISION_VENDORS` is False when `vendor is None`, so the `vendor` truthiness check is subsumed.)
+
+**RF2.3 — `enrich_cards` counts dict** (~401): add the two new tiers so callers reading `counts["oem_sourced"]`/`["not_catalogued"]` don't `KeyError`:
+```python
+    counts: dict[str, int] = {
+        MaterialEnrichmentStatus.VERIFIED: 0,
+        MaterialEnrichmentStatus.WEB_SOURCED: 0,
+        MaterialEnrichmentStatus.OEM_SOURCED: 0,
+        MaterialEnrichmentStatus.AI_INFERRED: 0,
+        MaterialEnrichmentStatus.NOT_FOUND: 0,
+        MaterialEnrichmentStatus.NOT_CATALOGUED: 0,
+    }
+```
+
+**RF2.4 — `apply_cross_ref_verified` confirmer dedupe** (~235): compute once:
+```python
+    confirmer = contributors[0] if contributors else None
+    prov["cross_ref"] = {... "confirmed_by": confirmer ...}
+    card.enrichment_source = confirmer or "cross_ref"
+```
+
+**RF2.5 — Docstring**: `enrich_card` one-line summary → `"authoritative -> web -> OEM cross-ref/description -> flagged AI inference -> not_catalogued/not_found."`
+
+Run: `pytest tests/test_authoritative_enrichment.py -q`. Commit: `fix(enrichment): oem_sourced re-enrich guard, Dell->not_found, enrich_cards counts, confirmer dedupe`.
+
+---
+
+## RF3 — Worker per-tier observability + migration
+
+**Why:** the worker's per-tier heartbeat/daily-summary silently omit `oem_sourced`/`not_catalogued`.
+
+**RF3.1 — Model** `app/models/enrichment_worker_status.py`: add after `not_found_today`:
+```python
+    oem_sourced_today = Column(Integer, default=0, server_default="0", nullable=False)
+    not_catalogued_today = Column(Integer, default=0, server_default="0", nullable=False)
+```
+
+**RF3.2 — Migration** `alembic/versions/089_oem_enrichment_status_columns.py` (down_revision = `088_enrichment_worker_status`):
+- `upgrade`: `op.add_column("enrichment_worker_status", sa.Column("oem_sourced_today", sa.Integer(), nullable=False, server_default="0"))` and same for `not_catalogued_today`; then `op.execute("COMMENT ON COLUMN material_cards.enrichment_status IS 'unenriched|verified|web_sourced|oem_sourced|ai_inferred|not_found|not_catalogued (see MaterialEnrichmentStatus)'")`.
+- `downgrade`: `op.execute("COMMENT ON COLUMN material_cards.enrichment_status IS NULL")`; `op.drop_column(...)` both.
+- Include the standard file-header docstring. Verify single head: `alembic heads` → one. Test upgrade→downgrade→upgrade on the dev DB if available; otherwise rely on the model+migration parity (tests use `Base.metadata.create_all`, so new columns appear automatically).
+
+**RF3.3 — Worker loop** `worker.py main()`: add `oem_sourced_today = 0` and `not_catalogued_today = 0` alongside the other accumulators; in the daily-reset block reset them and include them in the `daily_stats_json` dict + the daily-summary log; accumulate `oem_sourced_today += batch_counts.get(MaterialEnrichmentStatus.OEM_SOURCED, 0)` and `not_catalogued_today += batch_counts.get(MaterialEnrichmentStatus.NOT_CATALOGUED, 0)`; pass both to `update_enrichment_worker_status(...)` in the heartbeat.
+
+**RF3.4 — `select_batch` docstring**: add a bullet — `not_catalogued: eligible when enriched_at IS NULL OR older than not_catalogued_retry_days (long backoff).`
+
+Run: `pytest tests/test_enrichment_worker.py -q`. Commit: `feat(enrichment): worker per-tier counters for oem_sourced/not_catalogued + migration 089`.
+
+---
+
+## RF4 — Backfill robustness
+
+**RF4.1 — Session lifecycle (root-cause, no band-aid)** `scripts/backfill_oem_enrichment.py`: give `run()` an injectable session and close only an owned one:
+```python
+async def run(*, commit, limit, max_web_calls, csv_path, db=None) -> dict:
+    owns_session = db is None
+    if db is None:
+        db = SessionLocal()
+    try:
+        ...  # existing body
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        if owns_session:
+            db.close()
+```
+Keep the existing `except Exception: db.rollback(); raise` (now nested inside, or fold into the same try with both except+finally).
+
+**RF4.2 — `ClaudeError` early-abort**: import `from app.utils.claude_errors import ClaudeError`. In the loop, catch `ClaudeError` separately, count `counts["claude_error"]`, track consecutive count, and `break` after 5 consecutive (an outage — stop burning budget); reset the consecutive counter on any non-Claude outcome:
+```python
+            try:
+                status = await enrich_card(card, db, connectors=conns, disabled=disabled, cooldown=cooldown, web_meter=meter)
+                consecutive_claude_errors = 0
+            except ClaudeError:
+                consecutive_claude_errors += 1
+                counts["claude_error"] = counts.get("claude_error", 0) + 1
+                status = "claude_error"
+                logger.warning("BACKFILL: {} Claude error ({} consecutive)", card.display_mpn, consecutive_claude_errors)
+                web_total += meter.web_calls
+                if consecutive_claude_errors >= 5:
+                    logger.error("BACKFILL: 5 consecutive Claude errors — aborting (backend outage)")
+                    rows.append({...this card...}); break
+            except Exception as e:
+                logger.warning("BACKFILL: {} failed: {}", card.display_mpn, type(e).__name__)
+                status = "error"
+```
+(Initialize `consecutive_claude_errors = 0` before the loop. Keep `web_total += meter.web_calls` once per card on the success/other path as today.)
+
+**RF4.3 — `--dry-run`/`--commit` mutual exclusion** (make `--dry-run` meaningful): use a mutually-exclusive argparse group so passing both errors, and `--dry-run` is an explicit opt-in:
+```python
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--dry-run", action="store_true", help="Preview only; roll back (default).")
+    g.add_argument("--commit", action="store_true", help="Persist results.")
+```
+
+**RF4.4 — Tests** (`tests/test_backfill_oem_enrichment.py`): switch to injecting `db=db_session` (drop the `SessionLocal` patch); tighten `test_budget_cap_halts` to assert `counts["processed"] == 2` and `counts["web_calls"] == 4`; add `test_select_includes_not_catalogued` (a `not_catalogued` seed is picked up); add `test_bad_card_does_not_abort_run` (a card whose `enrich_card` raises a non-Claude `Exception` → row recorded `status="error"`, run continues); add `test_consecutive_claude_errors_abort` (≥5 `ClaudeError` → loop breaks early).
+
+Run: `pytest tests/test_backfill_oem_enrichment.py -q`. Commit: `fix(scripts): backfill session lifecycle + ClaudeError early-abort + dry-run/commit exclusivity`.
+
+---
+
+## RF5 — `oem_extractor` hardening + comments
+
+**RF5.1 — `frozen=True` + `Literal` status** on the result dataclasses (kills the shared-mutable-singleton footgun; moves the closed set into the type). In `app/services/enrichment_worker/oem_extractor.py` add `from typing import Literal`, and:
+```python
+@dataclass(frozen=True)
+class CrossRefResult:
+    status: Literal["resolved", "failed"]
+    ...
+@dataclass(frozen=True)
+class OemExtractResult:
+    status: Literal["oem_sourced", "failed"]
+    ...
+```
+The producers already build the full object in one `return` (no post-construction mutation), and consumers only read — so `frozen=True` is safe. Keep the `_XR_FAILED`/`_OEM_FAILED` module singletons (now immutable). Do NOT touch the pre-existing `web_extractor.py` (out of scope).
+
+**RF5.2 — Linkage single-attestation comment**: above the gate-2 block in `cross_reference_mpn`, add a comment documenting the accepted residual:
+```python
+    # Linkage gate: the FRU<->MPN association is single-attestation (the model's quoted
+    # text), checked as a normalized-substring containment of BOTH codes. This is the one
+    # place an LLM claim is load-bearing for the *linkage*; it is defended in depth — the
+    # source domain must be allowlisted (gate 1), the resolved MPN is INDEPENDENTLY
+    # re-verified against a distributor by the caller, and confidence must clear 0.90.
+    # A short code embedded in a longer token is an accepted residual (see review notes).
+```
+
+**RF5.3 — Module header `Depends on:`** add `app.utils.claude_errors`.
+
+Run: `pytest tests/test_oem_extractor.py tests/test_authoritative_enrichment.py -q`. Commit: `refactor(enrichment): frozen+Literal oem_extractor results + linkage residual comment`.
+
+---
+
+## RF6 — New tests (lock the contracts the review found untested)
+
+In `tests/test_authoritative_enrichment.py`:
+- `test_web_meter_exact_counts_per_tier`: real `enrich_card` (mocks for the extractors/infer) asserting `meter.web_calls == 1` (web_sourced path), `== 2` (cross-ref verified), `== 3` (oem_sourced and not_catalogued paths).
+- `test_web_meter_counts_billed_call_on_claude_error`: cross-ref raises `ClaudeError` after the distributor-web reserve → `meter.web_calls >= 2` and the exception propagates (reserve-before guarantees the billed call is counted).
+- `test_ai_inferred_sets_claude_ok_without_web_call`: web disabled, vendor None, infer→ai_inferred → `meter.web_calls == 0 and meter.claude_ok is True`.
+- `test_dell_miss_is_not_found_not_catalogued`: `classify_oem_vendor` returns `"dell"`, OEM tiers attempted and fail, infer declines → terminal `NOT_FOUND` (not `not_catalogued`).
+
+In `tests/test_enrichment_worker.py`:
+- `test_breaker_resets_on_claude_ok_without_web`: spy/stub breaker; `fake_enrich_card` sets `meter.mark_claude_ok()` and `web_calls==0` → `record_claude_success` called, budget unchanged.
+- `test_verified_only_does_not_reset_breaker`: `fake_enrich_card` returns VERIFIED with `claude_ok False`, `web_calls 0` → `record_claude_success` NOT called.
+
+In `tests/test_oem_domains.py`:
+- `test_ibm_and_uppercase_host`: `is_oem_domain("https://www.ibm.com/support/x")` True; `is_oem_domain("HTTPS://SUPPORT.LENOVO.COM/x")` True (host lowercased); `is_oem_domain("https://notlenovo.com/x")` False.
+
+In `tests/test_oem_classifier.py`:
+- `test_dell_pattern_is_broad_known_tradeoff`: document that a 5-char alnum-with-letter (e.g. `"LM317"`) classifies `"dell"` (accepted false-positive) — pins the breadth so a future change is deliberate.
+
+In `tests/test_oem_badges.py`: remove the dead `tmpl.module if False else` expression → just `tmpl.render(...)`.
+
+Run the full new+touched set, then the whole suite. Commit: `test(enrichment): real-meter, breaker-reset, backfill, domain + classifier edge coverage`.
+
+---
+
+## Final verification (after RF1–RF6)
+- `TESTING=1 PYTHONPATH=$(pwd) pytest tests/ -q` — green (≥ 14503 + new).
+- `ruff check app/ scripts/ && ruff format --check app/ scripts/`.
+- `pre-commit run mypy --files <all changed .py>` — passes.
+- `alembic heads` — single head (089).
+- `npm run build` unaffected (no JS changed in round 2).
+
+## Deliberately NOT changed (documented decisions — surface to user)
+- **Linkage gate substring logic** — kept (token-exact matching would false-reject separator-bearing OEM codes like `60NB0690-MB1820`/`NB.MBC11.003`); residual is accepted + commented + defended in depth (RF5.2). Offer stricter mode if the user wants it.
+- **`web_extractor.py` / `WebExtractResult`** — pre-existing; not frozen/Literal-ized here (drift-bundling discipline).
+- **`fetch_authoritative` broad-except escalation** — pre-existing; out of scope.

--- a/docs/superpowers/specs/2026-06-05-no-hallucination-oem-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-05-no-hallucination-oem-enrichment-design.md
@@ -243,10 +243,14 @@ Two precise edits, both forced by the new tiers:
   web_meter delta`**: pass a fresh `web_meter={"calls":0}` into each `enrich_card`, read
   `web_meter["calls"]` after, add that to the running total, and persist to the cache.
   This stays exact when a single card fires 1–3 web calls.
-- **Circuit-breaker reset.** Reset the breaker when **`web_meter delta > 0`** (a Claude
-  web call returned without raising), replacing the current `status != VERIFIED` proxy.
-  That proxy is now wrong: a **cross-ref result is `verified` yet did call Claude**, while
-  a plain distributor `verified` makes no Claude call. Metering is the correct signal.
+- **Circuit-breaker reset.** The meter is `{"web_calls": int, "claude_ok": bool}`:
+  `web_calls` counts billable web-search calls (budget); `claude_ok` is set True after
+  **any** Claude call (web tier, cross-ref, OEM description, *or* `infer_part`) returns
+  without raising. Worker resets the breaker when `claude_ok` is True, replacing the
+  current `status != VERIFIED` proxy. That proxy is now wrong on both ends: a **cross-ref
+  result is `verified` yet did call Claude** (must reset), while a plain distributor
+  `verified` makes no Claude call (must not). `claude_ok` is the precise signal; budget
+  uses `web_calls` so a non-web Claude success (AI-inferred) never miscounts spend.
 
 ### 4.5 `constants.py` + model validator
 Add to `MaterialEnrichmentStatus`: `OEM_SOURCED = "oem_sourced"`, `NOT_CATALOGUED =

--- a/docs/superpowers/specs/2026-06-05-no-hallucination-oem-enrichment-design.md
+++ b/docs/superpowers/specs/2026-06-05-no-hallucination-oem-enrichment-design.md
@@ -1,0 +1,354 @@
+# No-Hallucination OEM / FRU Enrichment
+
+**Date:** 2026-06-05
+**Status:** Approved (design) — ready for implementation plan
+**Author:** Claude (Opus 4.8) + user
+**Branch:** `worktree-oem-enrichment` (worktree)
+
+---
+
+## 1. Problem
+
+1,029 of 1,859 `material_cards` sit at `enrichment_status = not_found`. Sampling shows
+they are overwhelmingly **OEM / system-vendor FRU / spare / service part numbers**, not
+manufacturer MPNs:
+
+| Pattern | Vendor | Examples (real data) |
+|---|---|---|
+| `00xxxxx`, `01xxxxx`, `xxLxxxx`, `xxCxxxx` | IBM / Lenovo FRU | `01HW917`, `00E2891`, `38L7669`, `46C9040` |
+| `5Bxx…`, `5Cxx…`, `5Txx…` | Lenovo FRU | `5B20L64949`, `5C10Q59981`, `5T10Q96500` |
+| `xxxxxx-xxx` | HP / HPE spare | `918042-601`, `619559-001`, `486301-001` |
+| `NB.xxxxx.xxx`, `KT.xxxxx.xxx`, `33.xxxxx.xxx` | Acer | `NB.MBC11.003`, `KT.00403.025` |
+| `60NB…`, `0Bxxx-…`, `90NB…` | ASUS | `60NB0690-MB1820`, `0b200-00930000` |
+| 5-char alnum | Dell | `HV52W`, `66YYK` |
+
+They are `not_found` because every existing tier structurally cannot reach them — **not
+because of any hallucination risk**:
+
+1. **Verified tier** — DigiKey / Mouser / Element14 / OEMSecrets / Nexar are *component-
+   distributor* catalogs keyed by **manufacturer MPN**. They do not index OEM FRU/spare
+   codes. → no hit.
+2. **Web-sourced tier** — `trusted_domains.py` allowlists only distributors + chip-maker
+   domains (`ti.com`, `st.com`, …). Claude web search *does* find these codes on
+   `support.lenovo.com` / HPE PartSurfer, but Gate 1 (trusted-domain) discards the
+   correct authoritative page. → rejected.
+3. **AI tier** — `ai_inference_fallback` correctly declines obscure FRU codes by design.
+   → `not_found`.
+
+The gap is precise: **these parts have real authoritative sources (the OEM's own parts
+pages and cross-reference data), but the pipeline does not trust those domains.** The
+fix is to *extend authoritative coverage to OEM sources under the same Python-enforced
+gate discipline* — never to loosen the guardrails.
+
+A smaller, separate bucket exists: a few genuine component MPNs the verified/web tiers
+should have caught (e.g. `M393A2K40EB3-CWEB/C`, a real Samsung DDR4 RDIMM). These are
+out of scope here; they are addressed only incidentally by the backfill re-running them.
+
+## 2. Goals / Non-Goals
+
+**Goals**
+- Resolve OEM/FRU codes to real data with **zero fabrication** — every written field
+  traceable to an authoritative source, enforced in Python (never trusting LLM claims).
+- Cover existing 1,029 (one-time backfill) **and** all future OEM/FRU parts (paced worker).
+- Surface the new provenance honestly in the UI.
+
+**Non-Goals**
+- No scraping of OEM sites (brittle/anti-scraping — a band-aid). Grounded web search only.
+- No paid OEM-parts API (none with usable public coverage for FRU codes).
+- No structured spec guessing (lifecycle/package/pins/rohs) from the LLM — ever.
+- Not solving the genuine-MPN "retry miss" bucket beyond what backfill re-runs incidentally.
+
+## 3. Approach (decided)
+
+Extend the proven grounded-web-search pattern (`web_extractor.py`) to OEM sources with
+two new Claude calls, each gated entirely in Python. Two new enrichment tiers slot into
+`enrich_card` between the distributor web tier and the AI fallback, gated by a cheap
+**OEM-vendor classifier** so non-OEM parts never incur OEM web calls.
+
+```
+1. Verified         (distributor connectors)              ── unchanged
+2. Web-sourced      (distributor / mfr web search)        ── unchanged
+3. NEW ▸ OEM cross-ref     (only if classifier matches)   ── strict double-verify → verified
+4. NEW ▸ OEM description   (only if classifier matches)   ── single official page → oem_sourced
+5. AI inference     (Opus, flagged)                       ── unchanged
+6. Terminal: not_catalogued (classifier matched + OEM tiers ran + nothing) ELSE not_found
+```
+
+### 3.1 The no-hallucination guarantees
+
+**Cross-ref (tier 3) — strict, double-verified.** The danger is not a *fake* MPN (the
+distributor pipeline rejects those); it is a **real-but-wrong** MPN the LLM confidently
+asserts. Two independent guarantees, **both required**:
+
+- **(a) Linkage is sourced.** An allowlisted authoritative page (`is_crossref_domain`)
+  must contain *both* the OEM code *and* the candidate MPN verbatim. Verified in Python
+  from the returned `source_urls` + an explicit `linkage_quote` field: the OEM code and
+  candidate MPN, after `normalize_mpn_key`, must both be substrings of the normalized
+  `linkage_quote`, and at least one `source_url` host must be an allowlisted cross-ref
+  domain. The FRU↔MPN link itself is evidence — not the model's say-so.
+- **(b) MPN is real.** The candidate MPN is fed back through the existing
+  `fetch_authoritative` pipeline and must independently clear an exact normalized-MPN
+  match at a distributor.
+
+Only if **both** pass do we write the card — as `verified` — using the resolved MPN's
+distributor data (via the existing `apply_authoritative` merge), with the FRU↔MPN
+linkage recorded in `cross_references` and a `cross_ref` provenance block. Either gate
+fails → write nothing, fall through to tier 4.
+
+**OEM description (tier 4) — lenient, single official source.** Claude grounded web
+search restricted to OEM-official domains (`is_oem_domain`); the **same four Python
+gates** as the distributor web tier (allowlisted OEM domain, exact OEM code verbatim on
+the page via `normalize_mpn_key`, confidence ≥ `_MIN_OEM_CONFIDENCE`, non-trivial
+description + non-empty vendor). One official page is sufficient → `oem_sourced`.
+Writes **description + category only** (+ datasheet_url if present) — never structured
+specs. Provenance records the OEM domain + source URL.
+
+### 3.2 Rejected alternatives
+- **Scrape PartSurfer / PSREF** — brittle, anti-scraping, high upkeep. Violates "no band-aids".
+- **Tiered "unconfirmed cross-ref" badge** — rejected per the chosen trust bar (a wrong
+  MPN is dangerous; show nothing rather than a half-confirmed MPN).
+
+## 4. Components
+
+All new worker modules live under `app/services/enrichment_worker/` and mirror the
+structure / gate discipline of the existing `web_extractor.py` + `trusted_domains.py`.
+
+### 4.1 `oem_classifier.py` (new, pure)
+```python
+def classify_oem_vendor(display_mpn: str) -> str | None
+```
+Returns one of `"lenovo" | "ibm" | "hp" | "hpe" | "dell" | "acer" | "asus"` or `None`,
+by matching ordered, anchored regexes against the **raw display_mpn** (uppercased). Pure
+and fully unit-tested against the real samples in §1. `None` means "not a recognized
+OEM/FRU pattern" → OEM tiers are skipped and a generic failure remains `not_found`.
+
+Patterns (initial; full table fixed in the plan, each justified by a real sample):
+- Lenovo/IBM FRU: `^0[01][A-Z0-9]{5}$`, `^\d{2}[A-Z]\d{4}$`, `^5[BCT]\d{2}[A-Z]\d{5}$`
+- HP/HPE spare: `^\d{6}-\d{3}$`
+- Acer: `^(NB|KT|TC|33|60)\.[A-Z0-9]{5}\.[A-Z0-9]{3}$`
+- ASUS: `^(90|60)NB[A-Z0-9]{4}-[A-Z0-9]+$`, `^0[A-Z]\d{3}-\d{8}$`
+- Dell: `^[0-9A-Z]{5}$` (last, lowest-priority; 5-char alnum)
+
+Ambiguity is acceptable here (the vendor label only seeds the search prompt; the gates,
+not the label, enforce correctness). False positives cost at most a wasted web call;
+false negatives just leave a part `not_found` (unchanged from today).
+
+### 4.2 `oem_domains.py` (new)
+Mirrors `trusted_domains.py`. Two frozensets + two predicates:
+- `OEM_OFFICIAL_DOMAINS` — official vendor parts/support hosts:
+  `support.lenovo.com`, `pcsupport.lenovo.com`, `partsurfer.hpe.com`,
+  `support.hp.com`, `www.dell.com`, `dell.com`, `www.acer.com`, `www.asus.com`, etc.
+  (full list fixed in plan).
+- `CROSS_REF_AUTHORITATIVE_DOMAINS` — `OEM_OFFICIAL_DOMAINS` ∪ the existing distributor +
+  manufacturer allowlist (`trusted_domains`), since a distributor/mfr page that lists the
+  FRU alongside the commodity MPN is also authoritative for the *linkage*.
+- `is_oem_domain(url) -> bool`, `is_crossref_domain(url) -> bool` — exact-host match,
+  dot-suffix for vendor roots, reject non-http(s); identical safety model to
+  `is_trusted_domain` (`evil-lenovo.com` must NOT match `lenovo.com`).
+
+### 4.3 `oem_extractor.py` (new)
+Mirrors `web_extractor.py`. Two dataclasses + two functions; **all gates in Python**,
+never trusting the model's gate claims. Each raises `ClaudeError` on backend failure
+(so the circuit breaker sees outages); a genuine "not found" reply is parsed, not raised.
+
+```python
+@dataclass
+class CrossRefResult:
+    status: str  # "resolved" | "failed"
+    resolved_mpn: str | None = None
+    manufacturer: str | None = None
+    linkage_source_url: str | None = None
+    linkage_source_domain: str | None = None
+    confidence: float = 0.0
+
+async def cross_reference_mpn(display_mpn, normalized_mpn, vendor, *, timeout=90) -> CrossRefResult
+```
+- Claude `web_search_20250305`, `model_tier="smart"`. Prompt asks for the manufacturer
+  MPN the OEM code corresponds to **and** a `linkage_quote` (verbatim text from a page
+  showing both), plus `source_urls`, `confidence`.
+- Gates: (1) ≥1 `source_url` host ∈ cross-ref allowlist; (2) `normalize_mpn_key(oem) in
+  norm(linkage_quote)` AND `normalize_mpn_key(resolved_mpn) in norm(linkage_quote)`;
+  (3) `resolved_mpn` normalizes to something ≠ the OEM code (a real cross-ref, not echo);
+  (4) `confidence ≥ _MIN_CROSSREF_CONFIDENCE` (0.90). Failure → `status="failed"`.
+- Returns only the *candidate*; distributor re-verification (gate b) happens in
+  `enrich_card`, not here (single responsibility).
+
+```python
+@dataclass
+class OemExtractResult:  # same shape as WebExtractResult, minus distributor semantics
+    status: str  # "oem_sourced" | "failed"
+    description / manufacturer / category / datasheet_url / confidence / source_urls / source_domains
+
+async def extract_oem_description(display_mpn, normalized_mpn, vendor, *, timeout=90) -> OemExtractResult
+```
+- Same four gates as `extract_part_from_web`, but Gate 1 uses `is_oem_domain` and
+  `_MIN_OEM_CONFIDENCE` (0.90). Description + category + optional datasheet only.
+
+### 4.4 `authoritative_enrichment_service.py` (modify `enrich_card` + 2 new appliers)
+
+New parameter (backward-compatible): `web_meter: dict[str, int] | None = None`.
+`enrich_card` increments `web_meter["calls"]` by **1 for every billable web-search Claude
+call it makes** (distributor web tier, cross-ref, OEM description). The worker reads the
+delta to keep `web_daily_cap` exact regardless of how many web tiers fire. Default `None`
+→ no metering (tests / `enrich_cards`).
+
+Insertion (after the distributor web tier fails, before AI fallback), only when
+`classify_oem_vendor(card.display_mpn)` is truthy **and** the web tier is enabled
+(`"web_search" not in disabled`):
+
+```
+vendor = classify_oem_vendor(card.display_mpn)
+if vendor and web_enabled:
+    # Tier 3: cross-ref (strict double-verify)
+    meter web call
+    xr = await cross_reference_mpn(display_mpn, normalized_mpn, vendor)
+    if xr.status == "resolved":
+        results2 = await fetch_authoritative(xr.resolved_mpn, normalize_mpn_key(xr.resolved_mpn), conns, disabled, cooldown)
+        merged2, prov2, contrib2 = merge_authoritative(normalize_mpn_key(xr.resolved_mpn), results2)
+        if merged2:                       # gate (b): MPN independently confirmed
+            apply_cross_ref_verified(card, merged2, prov2, contrib2, xr)
+            return VERIFIED
+    # Tier 4: OEM description (single official page)
+    meter web call
+    oem = await extract_oem_description(display_mpn, normalized_mpn, vendor)
+    if oem.status == "oem_sourced":
+        apply_oem_sourced(card, oem)
+        return OEM_SOURCED
+    oem_attempted = True
+```
+
+`apply_cross_ref_verified(card, merged, provenance, contributors, xr)` — writes merged
+distributor fields (as `apply_authoritative`), sets `enrichment_status=verified`,
+`enrichment_source = contributors[0]`, appends `{mpn, manufacturer}` to
+`card.cross_references`, and adds a top-level `cross_ref` provenance block:
+`{"oem_part": display_mpn, "resolved_mpn": xr.resolved_mpn, "linkage_source_url": …,
+"linkage_source_domain": …, "confirmed_by": contributors[0], "confidence": xr.confidence}`.
+
+`apply_oem_sourced(card, oem)` — mirrors `apply_web_sourced`, status `oem_sourced`,
+`enrichment_source="oem_official"`, provenance `{"oem_sourced": True, confidence,
+source_urls, source_domains, fetched_at, <field>: {...}}`.
+
+**Terminal decision.** Replace the final `not_found` assignment with:
+```
+card.enrichment_status = NOT_CATALOGUED if (vendor and oem_attempted) else NOT_FOUND
+```
+`not_catalogued` only when an OEM pattern matched *and* the OEM tiers actually ran and
+found nothing (so web-budget-skipped parts stay `not_found` and get a real attempt
+later). Both terminals keep `enrichment_source=None`, `enrichment_provenance=None`.
+
+### 4.4.1 Worker changes (`worker.py`, `run_one_batch`)
+Two precise edits, both forced by the new tiers:
+- **Budget accounting.** Replace the current "`web_calls_today += 1` per non-verified
+  card" heuristic (which assumed exactly one web call) with **`web_calls_today +=
+  web_meter delta`**: pass a fresh `web_meter={"calls":0}` into each `enrich_card`, read
+  `web_meter["calls"]` after, add that to the running total, and persist to the cache.
+  This stays exact when a single card fires 1–3 web calls.
+- **Circuit-breaker reset.** Reset the breaker when **`web_meter delta > 0`** (a Claude
+  web call returned without raising), replacing the current `status != VERIFIED` proxy.
+  That proxy is now wrong: a **cross-ref result is `verified` yet did call Claude**, while
+  a plain distributor `verified` makes no Claude call. Metering is the correct signal.
+
+### 4.5 `constants.py` + model validator
+Add to `MaterialEnrichmentStatus`: `OEM_SOURCED = "oem_sourced"`, `NOT_CATALOGUED =
+"not_catalogued"`. Both ≤ 20 chars → fit `String(20)`. The `@validates` validator is
+data-driven (`MaterialEnrichmentStatus(value)`) and accepts them automatically. Update
+the inline column comment in `intelligence.py`. **No migration** (varchar column, not a
+native PG enum).
+
+### 4.6 Worker retry backoff for `not_catalogued`
+`config.py`: add `not_catalogued_retry_days: int = 30` (+ env
+`ENRICHMENT_NOT_CATALOGUED_RETRY_DAYS`). `select_batch` gains a third eligibility arm:
+`not_catalogued` cards become eligible only when `enriched_at < now - retry_days` (long
+backoff — terminal-ish, but self-heals as OEM catalogs change). `not_catalogued` parts
+are otherwise treated like the others for ordering/exclusions.
+
+### 4.7 UI
+- **Badge** `partials/materials/list.html` (the `{% elif es == … %}` chain, after
+  `web_sourced`): add `oem_sourced` (indigo badge "OEM-SOURCED", linked to first
+  `source_urls`, title cites OEM domain) and `not_catalogued` (slate badge "OEM SERVICE
+  PART · NOT CATALOGUED", title "Recognised OEM service part; no public specs published").
+- **Filter** `partials/materials/workspace.html`: add an `oemSourced` and a
+  `notCatalogued` toggle following the exact `webSourced` toggle markup (lines 55-64) and
+  the `statusList.push(...)` wiring (JS lines 194-204). New Alpine state keys default
+  `false`. The faceted service already filters on `statuses` — no service change needed.
+
+### 4.8 Backfill script `scripts/backfill_oem_enrichment.py` (new)
+- Selects all `material_cards` with `enrichment_status='not_found'` (optionally
+  `not_catalogued`) and `is_internal_part=False`, `deleted_at IS NULL`.
+- **Dry-run default**: runs `enrich_card` against a **throwaway** flow that does NOT
+  commit, tallies projected outcomes (`verified` / `oem_sourced` / `not_catalogued` /
+  still-`not_found` / `ai_inferred`), and writes a coverage CSV
+  (`backfill_oem_coverage_<runstamp>.csv`: display_mpn, vendor, projected_status,
+  resolved_mpn, source). Prints a summary table. **Writes nothing.**
+- `--commit`: same pass but persists (reusing `enrich_cards`' batched-commit + bounded
+  concurrency), with its own `--max-web-calls` budget cap (default 300) enforced via a
+  shared `web_meter`, and `--limit N`. Stops cleanly when the web budget is exhausted
+  (remaining parts left for the worker).
+- Mirrors `scripts/import_part_numbers.py` CLI conventions (argparse, Loguru, `TESTING`
+  guard off). Run only under explicit user authorization.
+
+## 5. Data flow (cross-ref happy path)
+
+```
+worker.select_batch → enrich_card(01HW917)
+  fetch_authoritative(01HW917) → {} (distributors don't index FRU)
+  distributor web tier → failed (no trusted distributor page for FRU)
+  classify_oem_vendor("01HW917") → "lenovo"   [web_enabled]
+  cross_reference_mpn → resolved_mpn="M393A2K40EB3", linkage_quote contains both, domain ok, conf 0.94
+    fetch_authoritative("M393A2K40EB3") → mouser exact hit  (gate b ✓)
+    apply_cross_ref_verified → status=verified, cross_references=[{mpn:M393…, mfr:Samsung}],
+                               provenance.cross_ref={oem_part:01HW917, resolved_mpn:…, confirmed_by:mouser}
+  return VERIFIED
+```
+Cross-ref miss → OEM description hit → `oem_sourced`. Both miss → `not_catalogued`.
+
+## 6. Error handling
+- `ClaudeError` from any OEM Claude call propagates out of `enrich_card` exactly like the
+  web tier today → worker's circuit breaker counts it; card left unenriched & retried.
+  Never silently marked `not_found`/`not_catalogued` on a backend outage.
+- All OEM web calls are gated by `"web_search" not in disabled` and metered into
+  `web_meter`, so `web_daily_cap` is respected to the call.
+- Connector quota/auth during cross-ref gate (b) reuses the existing `disabled`/`cooldown`
+  semantics of `fetch_authoritative`.
+- Classifier and domain predicates never raise on malformed input (return `None`/`False`).
+
+## 7. Testing (TDD — tests first for every unit)
+- `test_oem_classifier.py` — truth table over every §1 sample + negatives (real MPNs like
+  `LM2596S`, `M393A2K40EB3` must classify `None`).
+- `test_oem_domains.py` — allowlist membership; `evil-lenovo.com`/`lenovo.com.evil.com`
+  rejected; non-http rejected; cross-ref superset includes distributors.
+- `test_oem_extractor.py` — mocked `claude_json`: cross-ref accept; reject on each gate
+  (untrusted domain, linkage_quote missing either code, echo MPN, low confidence);
+  `ClaudeError` re-raised. Same matrix for `extract_oem_description`.
+- `test_authoritative_enrichment.py` (extend) — `enrich_card` tiers: cross-ref double-
+  verify accepted→verified (+cross_references/provenance); resolved-but-unconfirmed MPN
+  rejected→falls through; real-but-wrong MPN that fails distributor re-verify rejected;
+  oem_sourced path; `not_catalogued` vs `not_found` terminal selection (vendor match +
+  oem_attempted vs web-disabled); `web_meter` increments exactly per billable call.
+- `test_enrichment_status_enum.py` / `test_constants.py` (extend) — new members valid;
+  `@validates` accepts `oem_sourced`/`not_catalogued`, rejects junk.
+- `test_enrichment_worker.py` (extend) — `select_batch` `not_catalogued` eligibility
+  (long backoff window); budget accounting with metered multi-call cards.
+- `test_materials_router*.py` / template test — both new badges render; both filter
+  toggles produce the right `statuses`.
+- `test_backfill_oem_enrichment.py` — dry-run writes coverage CSV + commits nothing;
+  `--commit` persists; `--max-web-calls` halts cleanly.
+
+## 8. Rollout
+1. Land worker + tiers (covers all future OEM/FRU parts automatically).
+2. Run backfill **dry-run** over the 1,029 → review coverage CSV with the user.
+3. On explicit authorization, backfill `--commit` (bounded web budget; remainder drains
+   via the worker).
+4. Update `docs/APP_MAP_ARCHITECTURE.md`, `APP_MAP_DATABASE.md` (new statuses,
+   `cross_references` usage), `APP_MAP_INTERACTIONS.md` (new tiers + flow) in the same PR.
+5. Deploy via `./deploy.sh` (only on explicit authorization; verify new Tailwind badge
+   colors — `indigo`/`slate` — appear in built CSS, per the safelist rule).
+
+## 9. Risks & mitigations
+- **Real-but-wrong cross-ref MPN** → the dual gate (sourced linkage + independent
+  distributor confirm) is specifically designed to stop this; tested explicitly.
+- **Web spend** → classifier gate + `web_meter` + `web_daily_cap` + backfill budget cap.
+- **Tailwind new colors not in build** → verify post-deploy per existing rule; add to
+  safelist if purged.
+- **`String(20)` overflow** → longest new value `not_catalogued` = 14 chars. Safe.
+```

--- a/scripts/backfill_oem_enrichment.py
+++ b/scripts/backfill_oem_enrichment.py
@@ -35,6 +35,7 @@ from app.services.authoritative_enrichment_service import (  # noqa: E402
 )
 from app.services.enrichment_types import WebMeter  # noqa: E402
 from app.services.enrichment_worker.oem_classifier import classify_oem_vendor  # noqa: E402
+from app.utils.claude_errors import ClaudeError  # noqa: E402
 
 _TARGET_STATUSES = (MaterialEnrichmentStatus.NOT_FOUND, MaterialEnrichmentStatus.NOT_CATALOGUED)
 
@@ -52,12 +53,18 @@ def _select(db, limit):
     return q.limit(limit).all() if limit else q.all()
 
 
-async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str) -> dict:
+async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str, db=None) -> dict:
     """Process the backlog.
 
     Returns a counts dict. Writes a coverage CSV. Rolls back unless commit.
+
+    ``db`` may be injected (tests own/close it); when omitted a session is created and
+    closed here. ``ClaudeError`` is caught per card and counted under ``"claude_error"``;
+    5 consecutive ones abort the run (a backend outage — stop burning the web budget).
     """
-    db = SessionLocal()
+    owns_session = db is None
+    if db is None:
+        db = SessionLocal()
     counts: dict[str, int] = {"processed": 0, "web_calls": 0}
     rows: list[dict] = []
     try:
@@ -67,6 +74,8 @@ async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str) -> dict
         disabled: set[str] = set()
         cooldown: dict[str, float] = {}
         web_total = 0
+        consecutive_claude_errors = 0
+        aborted = False
         for i, card in enumerate(cards, 1):
             if web_total >= max_web_calls:
                 logger.info("BACKFILL: web budget {} reached — stopping (remaining drains via worker)", max_web_calls)
@@ -76,7 +85,17 @@ async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str) -> dict
                 status = await enrich_card(
                     card, db, connectors=conns, disabled=disabled, cooldown=cooldown, web_meter=meter
                 )
+                consecutive_claude_errors = 0
+            except ClaudeError:
+                consecutive_claude_errors += 1
+                status = "claude_error"
+                logger.warning(
+                    "BACKFILL: {} Claude error ({} consecutive)", card.display_mpn, consecutive_claude_errors
+                )
+                if consecutive_claude_errors >= 5:
+                    aborted = True
             except Exception as e:  # noqa: BLE001 — a single bad card must not abort the run
+                consecutive_claude_errors = 0
                 logger.warning("BACKFILL: {} failed: {}", card.display_mpn, type(e).__name__)
                 status = "error"
             web_total += meter.web_calls
@@ -96,6 +115,9 @@ async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str) -> dict
             )
             if i % 25 == 0:
                 logger.info("BACKFILL: {}/{} (web_calls={})", i, len(cards), web_total)
+            if aborted:
+                logger.error("BACKFILL: 5 consecutive Claude errors — aborting (backend outage)")
+                break
 
         counts["web_calls"] = web_total
         if commit:
@@ -115,12 +137,16 @@ async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str) -> dict
     except Exception:
         db.rollback()
         raise
+    finally:
+        if owns_session:
+            db.close()
 
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
-    ap.add_argument("--dry-run", action="store_true", help="Preview only (default).")
-    ap.add_argument("--commit", action="store_true", help="Persist results (default is dry-run).")
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--dry-run", action="store_true", help="Preview only; roll back (default).")
+    g.add_argument("--commit", action="store_true", help="Persist results.")
     ap.add_argument("--limit", type=int, default=None, help="Max cards to process.")
     ap.add_argument("--max-web-calls", type=int, default=300, help="Web-search call budget cap.")
     ap.add_argument("--csv", default="backfill_oem_coverage.csv", help="Coverage CSV output path.")

--- a/scripts/backfill_oem_enrichment.py
+++ b/scripts/backfill_oem_enrichment.py
@@ -33,6 +33,7 @@ from app.services.authoritative_enrichment_service import (  # noqa: E402
     _connectors_in_order,
     enrich_card,
 )
+from app.services.enrichment_types import WebMeter  # noqa: E402
 from app.services.enrichment_worker.oem_classifier import classify_oem_vendor  # noqa: E402
 
 _TARGET_STATUSES = (MaterialEnrichmentStatus.NOT_FOUND, MaterialEnrichmentStatus.NOT_CATALOGUED)
@@ -70,7 +71,7 @@ async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str) -> dict
             if web_total >= max_web_calls:
                 logger.info("BACKFILL: web budget {} reached — stopping (remaining drains via worker)", max_web_calls)
                 break
-            meter = {"web_calls": 0, "claude_ok": False}
+            meter = WebMeter()
             try:
                 status = await enrich_card(
                     card, db, connectors=conns, disabled=disabled, cooldown=cooldown, web_meter=meter
@@ -78,7 +79,7 @@ async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str) -> dict
             except Exception as e:  # noqa: BLE001 — a single bad card must not abort the run
                 logger.warning("BACKFILL: {} failed: {}", card.display_mpn, type(e).__name__)
                 status = "error"
-            web_total += meter["web_calls"]
+            web_total += meter.web_calls
             counts["processed"] += 1
             counts[status] = counts.get(status, 0) + 1
             resolved = None

--- a/scripts/backfill_oem_enrichment.py
+++ b/scripts/backfill_oem_enrichment.py
@@ -1,0 +1,129 @@
+"""One-time backfill: re-enrich not_found / not_catalogued MaterialCards through the OEM
+cross-ref + description tiers.
+
+Dry-run by default: runs ``enrich_card`` over the backlog, tallies projected outcomes,
+writes a coverage CSV, and ROLLS BACK (writes nothing). ``--commit`` persists, with a
+shared web-call budget cap so it cannot blow the API spend. The paced worker drains any
+remainder afterward.
+
+Usage:
+  python3 scripts/backfill_oem_enrichment.py --dry-run
+  python3 scripts/backfill_oem_enrichment.py --commit --max-web-calls 300 --limit 500
+
+Called by: operators (manual, under explicit authorization). Depends on:
+app.database.SessionLocal, app.services.authoritative_enrichment_service.
+"""
+
+import argparse
+import asyncio
+import csv
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from loguru import logger  # noqa: E402
+
+from app.constants import MaterialEnrichmentStatus  # noqa: E402
+from app.database import SessionLocal  # noqa: E402
+from app.models import MaterialCard  # noqa: E402
+from app.services.authoritative_enrichment_service import (  # noqa: E402
+    _connectors_in_order,
+    enrich_card,
+)
+from app.services.enrichment_worker.oem_classifier import classify_oem_vendor  # noqa: E402
+
+_TARGET_STATUSES = (MaterialEnrichmentStatus.NOT_FOUND, MaterialEnrichmentStatus.NOT_CATALOGUED)
+
+
+def _select(db, limit):
+    q = (
+        db.query(MaterialCard)
+        .filter(
+            MaterialCard.deleted_at.is_(None),
+            MaterialCard.is_internal_part.is_(False),
+            MaterialCard.enrichment_status.in_([s.value for s in _TARGET_STATUSES]),
+        )
+        .order_by(MaterialCard.search_count.desc(), MaterialCard.created_at.desc())
+    )
+    return q.limit(limit).all() if limit else q.all()
+
+
+async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str) -> dict:
+    """Process the backlog.
+
+    Returns a counts dict. Writes a coverage CSV. Rolls back unless commit.
+    """
+    db = SessionLocal()
+    counts: dict[str, int] = {"processed": 0, "web_calls": 0}
+    rows: list[dict] = []
+    try:
+        conns = _connectors_in_order(db)
+        cards = _select(db, limit)
+        logger.info("BACKFILL: {} candidate cards (commit={}, budget={})", len(cards), commit, max_web_calls)
+        disabled: set[str] = set()
+        cooldown: dict[str, float] = {}
+        web_total = 0
+        for i, card in enumerate(cards, 1):
+            if web_total >= max_web_calls:
+                logger.info("BACKFILL: web budget {} reached — stopping (remaining drains via worker)", max_web_calls)
+                break
+            meter = {"web_calls": 0, "claude_ok": False}
+            try:
+                status = await enrich_card(
+                    card, db, connectors=conns, disabled=disabled, cooldown=cooldown, web_meter=meter
+                )
+            except Exception as e:  # noqa: BLE001 — a single bad card must not abort the run
+                logger.warning("BACKFILL: {} failed: {}", card.display_mpn, type(e).__name__)
+                status = "error"
+            web_total += meter["web_calls"]
+            counts["processed"] += 1
+            counts[status] = counts.get(status, 0) + 1
+            resolved = None
+            if card.enrichment_provenance and isinstance(card.enrichment_provenance, dict):
+                resolved = (card.enrichment_provenance.get("cross_ref") or {}).get("resolved_mpn")
+            rows.append(
+                {
+                    "display_mpn": card.display_mpn,
+                    "vendor": classify_oem_vendor(card.display_mpn) or "",
+                    "projected_status": status,
+                    "resolved_mpn": resolved or "",
+                    "source": card.enrichment_source or "",
+                }
+            )
+            if i % 25 == 0:
+                logger.info("BACKFILL: {}/{} (web_calls={})", i, len(cards), web_total)
+
+        counts["web_calls"] = web_total
+        if commit:
+            db.commit()
+            logger.info("BACKFILL: committed.")
+        else:
+            db.rollback()
+            logger.info("BACKFILL: DRY RUN — rolled back, no DB writes.")
+
+        with open(csv_path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=["display_mpn", "vendor", "projected_status", "resolved_mpn", "source"])
+            w.writeheader()
+            w.writerows(rows)
+        logger.info("BACKFILL: coverage CSV → {}", csv_path)
+        logger.info("BACKFILL SUMMARY: {}", {k: v for k, v in counts.items()})
+        return counts
+    except Exception:
+        db.rollback()
+        raise
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", help="Preview only (default).")
+    ap.add_argument("--commit", action="store_true", help="Persist results (default is dry-run).")
+    ap.add_argument("--limit", type=int, default=None, help="Max cards to process.")
+    ap.add_argument("--max-web-calls", type=int, default=300, help="Web-search call budget cap.")
+    ap.add_argument("--csv", default="backfill_oem_coverage.csv", help="Coverage CSV output path.")
+    args = ap.parse_args()
+    if not args.commit:
+        logger.info("DRY RUN — no DB writes. Use --commit to persist.")
+    asyncio.run(run(commit=args.commit, limit=args.limit, max_web_calls=args.max_web_calls, csv_path=args.csv))

--- a/tests/test_authoritative_enrichment.py
+++ b/tests/test_authoritative_enrichment.py
@@ -464,6 +464,7 @@ import pytest
 
 from app.constants import MaterialEnrichmentStatus
 from app.services import authoritative_enrichment_service as aes
+from app.services.enrichment_types import WebMeter
 from app.services.enrichment_worker.oem_extractor import CrossRefResult, OemExtractResult
 
 
@@ -493,7 +494,7 @@ async def test_crossref_double_verify_to_verified(db_session):
             }
         return {}
 
-    meter = {"web_calls": 0, "claude_ok": False}
+    meter = WebMeter()
     with (
         patch.object(aes, "classify_oem_vendor", return_value="lenovo"),
         patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
@@ -506,7 +507,7 @@ async def test_crossref_double_verify_to_verified(db_session):
     assert card.description == "16GB DDR4 RDIMM"
     assert any(x.get("mpn") == "M393A2K40EB3-CWE" for x in (card.cross_references or []))
     assert card.enrichment_provenance["cross_ref"]["resolved_mpn"] == "M393A2K40EB3-CWE"
-    assert meter["claude_ok"] is True and meter["web_calls"] >= 2
+    assert meter.claude_ok is True and meter.web_calls >= 2
 
 
 @pytest.mark.asyncio
@@ -526,7 +527,7 @@ async def test_crossref_unconfirmed_mpn_falls_through(db_session):
             new=AsyncMock(return_value=type("I", (), {"status": "not_found"})()),
         ),
     ):
-        status = await aes.enrich_card(card, db_session, connectors=[], web_meter={"web_calls": 0, "claude_ok": False})
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter=WebMeter())
     # Unconfirmed cross-ref discarded; OEM desc failed; AI declined → not_catalogued (OEM pattern matched).
     assert status == MaterialEnrichmentStatus.NOT_CATALOGUED
     assert card.cross_references in (None, [])
@@ -550,7 +551,7 @@ async def test_oem_description_path(db_session):
         patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=CrossRefResult(status="failed"))),
         patch.object(aes, "extract_oem_description", new=AsyncMock(return_value=oem)),
     ):
-        status = await aes.enrich_card(card, db_session, connectors=[], web_meter={"web_calls": 0, "claude_ok": False})
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter=WebMeter())
     assert status == MaterialEnrichmentStatus.OEM_SOURCED
     assert card.description == "ThinkSystem 16GB RDIMM"
     assert card.enrichment_provenance["oem_sourced"] is True
@@ -568,7 +569,7 @@ async def test_non_oem_failure_stays_not_found(db_session):
             new=AsyncMock(return_value=type("I", (), {"status": "not_found"})()),
         ),
     ):
-        status = await aes.enrich_card(card, db_session, connectors=[], web_meter={"web_calls": 0, "claude_ok": False})
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter=WebMeter())
     assert status == MaterialEnrichmentStatus.NOT_FOUND
 
 
@@ -585,8 +586,6 @@ async def test_oem_tiers_skipped_when_web_disabled(db_session):
             new=AsyncMock(return_value=type("I", (), {"status": "not_found"})()),
         ),
     ):
-        status = await aes.enrich_card(
-            card, db_session, connectors=[], disabled={"web_search"}, web_meter={"web_calls": 0, "claude_ok": False}
-        )
+        status = await aes.enrich_card(card, db_session, connectors=[], disabled={"web_search"}, web_meter=WebMeter())
     xref.assert_not_called()  # OEM tiers gated by web budget
     assert status == MaterialEnrichmentStatus.NOT_FOUND  # not_catalogued requires an actual attempt

--- a/tests/test_authoritative_enrichment.py
+++ b/tests/test_authoritative_enrichment.py
@@ -456,3 +456,137 @@ def test_enrich_cards_already_verified_skipped(mock_conns, db_session):
     counts = asyncio.run(enrich_cards([card.id], db_session, refresh=False))
     assert call_count["n"] == 0
     assert counts.get("verified", 0) == 1
+
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.constants import MaterialEnrichmentStatus
+from app.services import authoritative_enrichment_service as aes
+from app.services.enrichment_worker.oem_extractor import CrossRefResult, OemExtractResult
+
+
+def _oem_card(mpn="01HW917"):
+    return MaterialCard(display_mpn=mpn, normalized_mpn=mpn.lower().replace("-", ""))
+
+
+@pytest.mark.asyncio
+async def test_crossref_double_verify_to_verified(db_session):
+    card = _oem_card()
+    xr = CrossRefResult(
+        status="resolved",
+        resolved_mpn="M393A2K40EB3-CWE",
+        manufacturer="Samsung",
+        linkage_source_url="https://support.lenovo.com/x",
+        linkage_source_domain="support.lenovo.com",
+        confidence=0.95,
+    )
+
+    # No distributor hit for the FRU; distributor DOES confirm the resolved MPN.
+    async def fake_fetch(display, norm, conns, disabled, cooldown):
+        if norm == "m393a2k40eb3cwe":
+            return {
+                "mouser": [
+                    {"mpn_matched": "M393A2K40EB3-CWE", "description": "16GB DDR4 RDIMM", "manufacturer": "Samsung"}
+                ]
+            }
+        return {}
+
+    meter = {"web_calls": 0, "claude_ok": False}
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value="lenovo"),
+        patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
+        patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=xr)),
+        patch.object(aes, "fetch_authoritative", new=AsyncMock(side_effect=fake_fetch)),
+    ):
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter=meter)
+
+    assert status == MaterialEnrichmentStatus.VERIFIED
+    assert card.description == "16GB DDR4 RDIMM"
+    assert any(x.get("mpn") == "M393A2K40EB3-CWE" for x in (card.cross_references or []))
+    assert card.enrichment_provenance["cross_ref"]["resolved_mpn"] == "M393A2K40EB3-CWE"
+    assert meter["claude_ok"] is True and meter["web_calls"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_crossref_unconfirmed_mpn_falls_through(db_session):
+    card = _oem_card()
+    xr = CrossRefResult(
+        status="resolved", resolved_mpn="BOGUS-NOPART", confidence=0.95, linkage_source_domain="support.lenovo.com"
+    )
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value="lenovo"),
+        patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
+        patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=xr)),
+        patch.object(aes, "fetch_authoritative", new=AsyncMock(return_value={})),
+        patch.object(aes, "extract_oem_description", new=AsyncMock(return_value=OemExtractResult(status="failed"))),
+        patch(
+            "app.services.ai_inference_fallback.infer_part",
+            new=AsyncMock(return_value=type("I", (), {"status": "not_found"})()),
+        ),
+    ):
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter={"web_calls": 0, "claude_ok": False})
+    # Unconfirmed cross-ref discarded; OEM desc failed; AI declined → not_catalogued (OEM pattern matched).
+    assert status == MaterialEnrichmentStatus.NOT_CATALOGUED
+    assert card.cross_references in (None, [])
+
+
+@pytest.mark.asyncio
+async def test_oem_description_path(db_session):
+    card = _oem_card()
+    oem = OemExtractResult(
+        status="oem_sourced",
+        description="ThinkSystem 16GB RDIMM",
+        manufacturer="Lenovo",
+        category="Memory Module",
+        confidence=0.95,
+        source_urls=["https://support.lenovo.com/x"],
+        source_domains=["support.lenovo.com"],
+    )
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value="lenovo"),
+        patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
+        patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=CrossRefResult(status="failed"))),
+        patch.object(aes, "extract_oem_description", new=AsyncMock(return_value=oem)),
+    ):
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter={"web_calls": 0, "claude_ok": False})
+    assert status == MaterialEnrichmentStatus.OEM_SOURCED
+    assert card.description == "ThinkSystem 16GB RDIMM"
+    assert card.enrichment_provenance["oem_sourced"] is True
+
+
+@pytest.mark.asyncio
+async def test_non_oem_failure_stays_not_found(db_session):
+    card = _oem_card("LM2596S")
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value=None),
+        patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
+        patch.object(aes, "fetch_authoritative", new=AsyncMock(return_value={})),
+        patch(
+            "app.services.ai_inference_fallback.infer_part",
+            new=AsyncMock(return_value=type("I", (), {"status": "not_found"})()),
+        ),
+    ):
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter={"web_calls": 0, "claude_ok": False})
+    assert status == MaterialEnrichmentStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_oem_tiers_skipped_when_web_disabled(db_session):
+    card = _oem_card()
+    xref = AsyncMock()
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value="lenovo"),
+        patch.object(aes, "fetch_authoritative", new=AsyncMock(return_value={})),
+        patch.object(aes, "cross_reference_mpn", new=xref),
+        patch(
+            "app.services.ai_inference_fallback.infer_part",
+            new=AsyncMock(return_value=type("I", (), {"status": "not_found"})()),
+        ),
+    ):
+        status = await aes.enrich_card(
+            card, db_session, connectors=[], disabled={"web_search"}, web_meter={"web_calls": 0, "claude_ok": False}
+        )
+    xref.assert_not_called()  # OEM tiers gated by web budget
+    assert status == MaterialEnrichmentStatus.NOT_FOUND  # not_catalogued requires an actual attempt

--- a/tests/test_authoritative_enrichment.py
+++ b/tests/test_authoritative_enrichment.py
@@ -466,6 +466,7 @@ from app.constants import MaterialEnrichmentStatus
 from app.services import authoritative_enrichment_service as aes
 from app.services.enrichment_types import WebMeter
 from app.services.enrichment_worker.oem_extractor import CrossRefResult, OemExtractResult
+from app.utils.claude_errors import ClaudeError
 
 
 def _oem_card(mpn="01HW917"):
@@ -589,3 +590,147 @@ async def test_oem_tiers_skipped_when_web_disabled(db_session):
         status = await aes.enrich_card(card, db_session, connectors=[], disabled={"web_search"}, web_meter=WebMeter())
     xref.assert_not_called()  # OEM tiers gated by web budget
     assert status == MaterialEnrichmentStatus.NOT_FOUND  # not_catalogued requires an actual attempt
+
+
+@pytest.mark.asyncio
+async def test_web_meter_exact_counts_per_tier(db_session):
+    """Reserve-before-dispatch billing: each web-search tier attempt is counted exactly once."""
+
+    # 1 call: distributor web tier resolves immediately.
+    card = _oem_card()
+    with patch.object(
+        aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "web_sourced"})())
+    ):
+        # apply_web_sourced needs the result fields; stub apply to a no-op write.
+        with patch.object(aes, "apply_web_sourced", new=lambda c, w: None):
+            meter = WebMeter()
+            status = await aes.enrich_card(card, db_session, connectors=[], web_meter=meter)
+    assert status == MaterialEnrichmentStatus.WEB_SOURCED
+    assert meter.web_calls == 1
+
+    # 2 calls: web fails (1) + cross-ref resolved & distributor-confirmed (1).
+    card = _oem_card()
+    xr = CrossRefResult(
+        status="resolved",
+        resolved_mpn="M393A2K40EB3-CWE",
+        manufacturer="Samsung",
+        linkage_source_url="https://support.lenovo.com/x",
+        linkage_source_domain="support.lenovo.com",
+        confidence=0.95,
+    )
+
+    async def fake_fetch(display, norm, conns, disabled, cooldown):
+        if norm == "m393a2k40eb3cwe":
+            return {"mouser": [{"mpn_matched": "M393A2K40EB3-CWE", "description": "16GB DDR4 RDIMM"}]}
+        return {}
+
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value="lenovo"),
+        patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
+        patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=xr)),
+        patch.object(aes, "fetch_authoritative", new=AsyncMock(side_effect=fake_fetch)),
+    ):
+        meter = WebMeter()
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter=meter)
+    assert status == MaterialEnrichmentStatus.VERIFIED
+    assert meter.web_calls == 2
+
+    # 3 calls: web fails (1) + cross-ref fails (1) + OEM description sourced (1).
+    card = _oem_card()
+    oem = OemExtractResult(
+        status="oem_sourced",
+        description="ThinkSystem 16GB RDIMM",
+        manufacturer="Lenovo",
+        confidence=0.95,
+        source_urls=["https://support.lenovo.com/x"],
+        source_domains=["support.lenovo.com"],
+    )
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value="lenovo"),
+        patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
+        patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=CrossRefResult(status="failed"))),
+        patch.object(aes, "extract_oem_description", new=AsyncMock(return_value=oem)),
+    ):
+        meter = WebMeter()
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter=meter)
+    assert status == MaterialEnrichmentStatus.OEM_SOURCED
+    assert meter.web_calls == 3
+
+    # 3 calls: web fails (1) + cross-ref fails (1) + OEM description fails (1) + infer declines.
+    card = _oem_card()
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value="lenovo"),
+        patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
+        patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=CrossRefResult(status="failed"))),
+        patch.object(aes, "extract_oem_description", new=AsyncMock(return_value=OemExtractResult(status="failed"))),
+        patch(
+            "app.services.ai_inference_fallback.infer_part",
+            new=AsyncMock(return_value=type("I", (), {"status": "not_found"})()),
+        ),
+    ):
+        meter = WebMeter()
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter=meter)
+    assert status == MaterialEnrichmentStatus.NOT_CATALOGUED
+    assert meter.web_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_web_meter_counts_billed_call_on_claude_error(db_session):
+    """A cross-ref ClaudeError after the distributor-web reserve still counts both
+    billed calls."""
+    card = _oem_card()
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value="lenovo"),
+        patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
+        patch.object(aes, "cross_reference_mpn", new=AsyncMock(side_effect=ClaudeError("backend down"))),
+    ):
+        meter = WebMeter()
+        with pytest.raises(ClaudeError):
+            await aes.enrich_card(card, db_session, connectors=[], web_meter=meter)
+    # reserve-before-dispatch: distributor web (1) + cross-ref (1, billed then raised) are counted.
+    assert meter.web_calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_ai_inferred_sets_claude_ok_without_web_call(db_session):
+    """Web disabled + no OEM vendor: infer path latches claude_ok and bills no web
+    call."""
+    card = _oem_card("LM2596S")
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value=None),
+        patch.object(aes, "fetch_authoritative", new=AsyncMock(return_value={})),
+        patch(
+            "app.services.ai_inference_fallback.infer_part",
+            new=AsyncMock(
+                return_value=type(
+                    "I",
+                    (),
+                    {"status": "ai_inferred", "description": "Buck converter", "category": "IC", "confidence": 0.96},
+                )()
+            ),
+        ),
+    ):
+        meter = WebMeter()
+        status = await aes.enrich_card(card, db_session, connectors=[], disabled={"web_search"}, web_meter=meter)
+    assert status == MaterialEnrichmentStatus.AI_INFERRED
+    assert meter.web_calls == 0 and meter.claude_ok is True
+
+
+@pytest.mark.asyncio
+async def test_dell_miss_is_not_found_not_catalogued(db_session):
+    """A Dell (broad 5-char pattern) OEM-tier miss terminates not_found, not
+    not_catalogued."""
+    card = _oem_card("XYZ12")
+    with (
+        patch.object(aes, "classify_oem_vendor", return_value="dell"),
+        patch.object(aes, "extract_part_from_web", new=AsyncMock(return_value=type("W", (), {"status": "failed"})())),
+        patch.object(aes, "cross_reference_mpn", new=AsyncMock(return_value=CrossRefResult(status="failed"))),
+        patch.object(aes, "fetch_authoritative", new=AsyncMock(return_value={})),
+        patch.object(aes, "extract_oem_description", new=AsyncMock(return_value=OemExtractResult(status="failed"))),
+        patch(
+            "app.services.ai_inference_fallback.infer_part",
+            new=AsyncMock(return_value=type("I", (), {"status": "not_found"})()),
+        ),
+    ):
+        status = await aes.enrich_card(card, db_session, connectors=[], web_meter=WebMeter())
+    assert status == MaterialEnrichmentStatus.NOT_FOUND  # dell is excluded from HIGH_PRECISION_VENDORS

--- a/tests/test_backfill_oem_enrichment.py
+++ b/tests/test_backfill_oem_enrichment.py
@@ -53,7 +53,8 @@ async def test_budget_cap_halts(db_session, tmp_path):
 
     async def fake_enrich(card, db, *, web_meter=None, **kw):
         if web_meter is not None:
-            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 2
+            web_meter.reserve_web_call()
+            web_meter.reserve_web_call()
         card.enrichment_status = MaterialEnrichmentStatus.NOT_CATALOGUED
         return MaterialEnrichmentStatus.NOT_CATALOGUED
 

--- a/tests/test_backfill_oem_enrichment.py
+++ b/tests/test_backfill_oem_enrichment.py
@@ -1,0 +1,67 @@
+"""Backfill: dry-run writes a coverage report and commits nothing; budget cap halts."""
+
+import csv
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.constants import MaterialEnrichmentStatus
+from app.models import MaterialCard
+
+
+@pytest.mark.asyncio
+async def test_dry_run_writes_csv_and_no_commit(db_session, tmp_path):
+    import scripts.backfill_oem_enrichment as bf
+
+    c = MaterialCard(
+        display_mpn="01HW917", normalized_mpn="01hw917", enrichment_status=MaterialEnrichmentStatus.NOT_FOUND
+    )
+    db_session.add(c)
+    db_session.commit()
+
+    async def fake_enrich(card, db, **kw):
+        card.enrichment_status = MaterialEnrichmentStatus.OEM_SOURCED
+        return MaterialEnrichmentStatus.OEM_SOURCED
+
+    out = tmp_path / "cov.csv"
+    with (
+        patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)),
+        patch.object(bf, "SessionLocal", return_value=db_session),
+    ):
+        counts = await bf.run(commit=False, limit=None, max_web_calls=100, csv_path=str(out))
+
+    db_session.expire_all()
+    assert db_session.get(MaterialCard, c.id).enrichment_status == MaterialEnrichmentStatus.NOT_FOUND  # rolled back
+    assert counts["oem_sourced"] == 1
+    rows = list(csv.DictReader(out.open()))
+    assert rows[0]["projected_status"] == "oem_sourced"
+
+
+@pytest.mark.asyncio
+async def test_budget_cap_halts(db_session, tmp_path):
+    import scripts.backfill_oem_enrichment as bf
+
+    for i in range(5):
+        db_session.add(
+            MaterialCard(
+                display_mpn=f"01HW{i:03d}",
+                normalized_mpn=f"01hw{i:03d}",
+                enrichment_status=MaterialEnrichmentStatus.NOT_FOUND,
+            )
+        )
+    db_session.commit()
+
+    async def fake_enrich(card, db, *, web_meter=None, **kw):
+        if web_meter is not None:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 2
+        card.enrichment_status = MaterialEnrichmentStatus.NOT_CATALOGUED
+        return MaterialEnrichmentStatus.NOT_CATALOGUED
+
+    with (
+        patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)),
+        patch.object(bf, "SessionLocal", return_value=db_session),
+    ):
+        counts = await bf.run(commit=False, limit=None, max_web_calls=3, csv_path=str(tmp_path / "c.csv"))
+
+    # 3-call budget, 2 calls per card → stops after the 2nd card (4 calls would exceed).
+    assert counts["processed"] <= 2

--- a/tests/test_backfill_oem_enrichment.py
+++ b/tests/test_backfill_oem_enrichment.py
@@ -1,4 +1,5 @@
-"""Backfill: dry-run writes a coverage report and commits nothing; budget cap halts."""
+"""Backfill: dry-run writes a coverage report and commits nothing; budget cap halts;
+a bad card does not abort the run; consecutive Claude errors abort early."""
 
 import csv
 from unittest.mock import AsyncMock, patch
@@ -7,6 +8,7 @@ import pytest
 
 from app.constants import MaterialEnrichmentStatus
 from app.models import MaterialCard
+from app.utils.claude_errors import ClaudeError
 
 
 @pytest.mark.asyncio
@@ -24,11 +26,8 @@ async def test_dry_run_writes_csv_and_no_commit(db_session, tmp_path):
         return MaterialEnrichmentStatus.OEM_SOURCED
 
     out = tmp_path / "cov.csv"
-    with (
-        patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)),
-        patch.object(bf, "SessionLocal", return_value=db_session),
-    ):
-        counts = await bf.run(commit=False, limit=None, max_web_calls=100, csv_path=str(out))
+    with patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)):
+        counts = await bf.run(commit=False, limit=None, max_web_calls=100, csv_path=str(out), db=db_session)
 
     db_session.expire_all()
     assert db_session.get(MaterialCard, c.id).enrichment_status == MaterialEnrichmentStatus.NOT_FOUND  # rolled back
@@ -58,11 +57,95 @@ async def test_budget_cap_halts(db_session, tmp_path):
         card.enrichment_status = MaterialEnrichmentStatus.NOT_CATALOGUED
         return MaterialEnrichmentStatus.NOT_CATALOGUED
 
-    with (
-        patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)),
-        patch.object(bf, "SessionLocal", return_value=db_session),
-    ):
-        counts = await bf.run(commit=False, limit=None, max_web_calls=3, csv_path=str(tmp_path / "c.csv"))
+    with patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)):
+        counts = await bf.run(
+            commit=False, limit=None, max_web_calls=3, csv_path=str(tmp_path / "c.csv"), db=db_session
+        )
 
-    # 3-call budget, 2 calls per card → stops after the 2nd card (4 calls would exceed).
-    assert counts["processed"] <= 2
+    # 3-call budget, 2 calls per card → the gate trips before the 3rd card (web_total=4 >= 3).
+    assert counts["processed"] == 2
+    assert counts["web_calls"] == 4
+
+
+@pytest.mark.asyncio
+async def test_select_includes_not_catalogued(db_session, tmp_path):
+    import scripts.backfill_oem_enrichment as bf
+
+    c = MaterialCard(
+        display_mpn="01HW917", normalized_mpn="01hw917", enrichment_status=MaterialEnrichmentStatus.NOT_CATALOGUED
+    )
+    db_session.add(c)
+    db_session.commit()
+
+    seen: list[str] = []
+
+    async def fake_enrich(card, db, **kw):
+        seen.append(card.display_mpn)
+        return MaterialEnrichmentStatus.OEM_SOURCED
+
+    with patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)):
+        counts = await bf.run(
+            commit=False, limit=None, max_web_calls=100, csv_path=str(tmp_path / "c.csv"), db=db_session
+        )
+
+    assert "01HW917" in seen  # a not_catalogued card is picked up for re-enrichment
+    assert counts["processed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_bad_card_does_not_abort_run(db_session, tmp_path):
+    import scripts.backfill_oem_enrichment as bf
+
+    for i in range(3):
+        db_session.add(
+            MaterialCard(
+                display_mpn=f"01HW{i:03d}",
+                normalized_mpn=f"01hw{i:03d}",
+                enrichment_status=MaterialEnrichmentStatus.NOT_FOUND,
+            )
+        )
+    db_session.commit()
+
+    calls = {"n": 0}
+
+    async def fake_enrich(card, db, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError("boom")  # non-Claude error on the first card
+        return MaterialEnrichmentStatus.OEM_SOURCED
+
+    out = tmp_path / "c.csv"
+    with patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)):
+        counts = await bf.run(commit=False, limit=None, max_web_calls=100, csv_path=str(out), db=db_session)
+
+    assert counts["processed"] == 3  # run continued past the bad card
+    assert counts.get("error") == 1
+    rows = list(csv.DictReader(out.open()))
+    assert rows[0]["projected_status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_consecutive_claude_errors_abort(db_session, tmp_path):
+    import scripts.backfill_oem_enrichment as bf
+
+    for i in range(10):
+        db_session.add(
+            MaterialCard(
+                display_mpn=f"01HW{i:03d}",
+                normalized_mpn=f"01hw{i:03d}",
+                enrichment_status=MaterialEnrichmentStatus.NOT_FOUND,
+            )
+        )
+    db_session.commit()
+
+    async def fake_enrich(card, db, **kw):
+        raise ClaudeError("backend down")
+
+    with patch.object(bf, "enrich_card", new=AsyncMock(side_effect=fake_enrich)):
+        counts = await bf.run(
+            commit=False, limit=None, max_web_calls=100, csv_path=str(tmp_path / "c.csv"), db=db_session
+        )
+
+    # 5 consecutive ClaudeErrors abort the loop early (outage — stop burning budget).
+    assert counts["processed"] == 5
+    assert counts["claude_error"] == 5

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -31,3 +31,12 @@ def test_source_run_status_strenum():
     assert SourceRunStatus.ERROR_SKIPPED == "error_skipped"
     assert SourceRunStatus.SKIPPED == "skipped"
     assert SourceRunStatus.DISABLED == "disabled"
+
+
+def test_material_enrichment_status_has_oem_tiers():
+    from app.constants import MaterialEnrichmentStatus
+
+    assert MaterialEnrichmentStatus.OEM_SOURCED == "oem_sourced"
+    assert MaterialEnrichmentStatus.NOT_CATALOGUED == "not_catalogued"
+    # All values fit the String(20) column.
+    assert all(len(s.value) <= 20 for s in MaterialEnrichmentStatus)

--- a/tests/test_enrichment_status_enum.py
+++ b/tests/test_enrichment_status_enum.py
@@ -29,3 +29,24 @@ def test_validator_accepts_enum_and_literal(db_session):
     assert card.enrichment_status == "web_sourced"
     card.enrichment_status = MaterialEnrichmentStatus.VERIFIED
     assert card.enrichment_status == "verified"
+
+
+def test_validator_accepts_oem_tiers():
+    from app.constants import MaterialEnrichmentStatus
+    from app.models import MaterialCard
+
+    c = MaterialCard(display_mpn="01HW917", normalized_mpn="01hw917")
+    c.enrichment_status = MaterialEnrichmentStatus.OEM_SOURCED
+    assert c.enrichment_status == "oem_sourced"
+    c.enrichment_status = "not_catalogued"
+    assert c.enrichment_status == "not_catalogued"
+
+
+def test_validator_still_rejects_junk():
+    import pytest
+
+    from app.models import MaterialCard
+
+    c = MaterialCard(display_mpn="X", normalized_mpn="x")
+    with pytest.raises(ValueError):
+        c.enrichment_status = "bogus_status"

--- a/tests/test_enrichment_worker.py
+++ b/tests/test_enrichment_worker.py
@@ -656,9 +656,13 @@ def test_run_one_batch_charges_budget_per_billable_attempt(db_session):
 
     idx = [0]
 
-    async def fake_enrich_card(card, db, **kw):
+    async def fake_enrich_card(card, db, web_meter=None, **kw):
         st = returns[idx[0]]
         idx[0] += 1
+        # Simulate real enrich_card: non-verified results make at least one web call.
+        if web_meter is not None and st != MaterialEnrichmentStatus.VERIFIED:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
+            web_meter["claude_ok"] = True
         return st
 
     set_counts: list[int] = []
@@ -872,8 +876,13 @@ def test_run_one_batch_does_not_overshoot_cap_mid_batch(db_session):
 
     web_enabled_seen: list[bool] = []
 
-    async def fake_enrich_card(card, db, disabled=None, **kw):
-        web_enabled_seen.append("web_search" not in (disabled or set()))
+    async def fake_enrich_card(card, db, disabled=None, web_meter=None, **kw):
+        enabled = "web_search" not in (disabled or set())
+        web_enabled_seen.append(enabled)
+        # Simulate real enrich_card: a web call is made only when web is enabled.
+        if web_meter is not None and enabled:
+            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
+            web_meter["claude_ok"] = True
         return MaterialEnrichmentStatus.NOT_FOUND
 
     cfg = EnrichmentWorkerConfig(batch_size=5, web_daily_cap=2)
@@ -891,3 +900,44 @@ def test_run_one_batch_does_not_overshoot_cap_mid_batch(db_session):
     # Exactly the first 2 cards web-enabled (charge); remaining 3 disabled — no overshoot.
     assert web_enabled_seen == [True, True, False, False, False]
     assert web_state["web_calls"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Task 6: not_catalogued config field + select_batch eligibility
+# ---------------------------------------------------------------------------
+
+
+from datetime import datetime, timedelta, timezone
+
+from app.constants import MaterialEnrichmentStatus
+from app.services.enrichment_worker.config import EnrichmentWorkerConfig
+
+
+def test_config_has_not_catalogued_retry_days():
+    c = EnrichmentWorkerConfig()
+    assert c.not_catalogued_retry_days == 30
+
+
+def test_select_batch_not_catalogued_eligibility(db_session):
+    from app.models import MaterialCard
+    from app.services.enrichment_worker.worker import select_batch
+
+    now = datetime.now(timezone.utc)
+    cfg = EnrichmentWorkerConfig(batch_size=10, not_catalogued_retry_days=30)
+    fresh = MaterialCard(
+        display_mpn="A1",
+        normalized_mpn="a1",
+        enrichment_status=MaterialEnrichmentStatus.NOT_CATALOGUED,
+        enriched_at=now - timedelta(days=1),
+    )
+    stale = MaterialCard(
+        display_mpn="A2",
+        normalized_mpn="a2",
+        enrichment_status=MaterialEnrichmentStatus.NOT_CATALOGUED,
+        enriched_at=now - timedelta(days=40),
+    )
+    db_session.add_all([fresh, stale])
+    db_session.commit()
+    picked = {c.normalized_mpn for c in select_batch(db_session, cfg)}
+    assert "a2" in picked  # past 30-day backoff → eligible
+    assert "a1" not in picked  # within backoff → not yet

--- a/tests/test_enrichment_worker.py
+++ b/tests/test_enrichment_worker.py
@@ -661,8 +661,8 @@ def test_run_one_batch_charges_budget_per_billable_attempt(db_session):
         idx[0] += 1
         # Simulate real enrich_card: non-verified results make at least one web call.
         if web_meter is not None and st != MaterialEnrichmentStatus.VERIFIED:
-            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
-            web_meter["claude_ok"] = True
+            web_meter.reserve_web_call()
+            web_meter.mark_claude_ok()
         return st
 
     set_counts: list[int] = []
@@ -881,8 +881,8 @@ def test_run_one_batch_does_not_overshoot_cap_mid_batch(db_session):
         web_enabled_seen.append(enabled)
         # Simulate real enrich_card: a web call is made only when web is enabled.
         if web_meter is not None and enabled:
-            web_meter["web_calls"] = web_meter.get("web_calls", 0) + 1
-            web_meter["claude_ok"] = True
+            web_meter.reserve_web_call()
+            web_meter.mark_claude_ok()
         return MaterialEnrichmentStatus.NOT_FOUND
 
     cfg = EnrichmentWorkerConfig(batch_size=5, web_daily_cap=2)

--- a/tests/test_enrichment_worker.py
+++ b/tests/test_enrichment_worker.py
@@ -941,3 +941,92 @@ def test_select_batch_not_catalogued_eligibility(db_session):
     picked = {c.normalized_mpn for c in select_batch(db_session, cfg)}
     assert "a2" in picked  # past 30-day backoff → eligible
     assert "a1" not in picked  # within backoff → not yet
+
+
+def test_breaker_resets_on_claude_ok_without_web(db_session):
+    """A Claude call that returns OK with zero web calls (e.g. infer_part) still resets
+    the breaker and does NOT charge the web budget."""
+    import asyncio
+    from datetime import datetime, timezone
+    from unittest.mock import patch
+
+    from app.models import MaterialCard
+    from app.services.enrichment_worker.circuit_breaker import EnrichmentCircuitBreaker
+    from app.services.enrichment_worker.config import EnrichmentWorkerConfig
+    from app.services.enrichment_worker.worker import run_one_batch
+
+    now = datetime.now(timezone.utc)
+    db_session.add(MaterialCard(normalized_mpn="e0", display_mpn="E0", enrichment_status="unenriched", created_at=now))
+    db_session.flush()
+
+    successes: list[int] = []
+
+    class SpyBreaker(EnrichmentCircuitBreaker):
+        def record_claude_success(self):
+            successes.append(1)
+            super().record_claude_success()
+
+    async def fake_enrich_card(card, db, web_meter=None, **kw):
+        if web_meter is not None:
+            web_meter.mark_claude_ok()  # infer_part returned OK, no web call
+        return MaterialEnrichmentStatus.AI_INFERRED
+
+    charged: list[int] = []
+    cfg = EnrichmentWorkerConfig(batch_size=10, web_daily_cap=80)
+    web_state = {"web_calls": 0}
+
+    with (
+        patch("app.services.enrichment_worker.worker.enrich_card", side_effect=fake_enrich_card),
+        patch("app.services.enrichment_worker.worker._connectors_in_order", return_value=[]),
+        patch("app.services.enrichment_worker.worker.intel_cache.get_cached", return_value=None),
+        patch(
+            "app.services.enrichment_worker.worker.intel_cache.set_cached",
+            side_effect=lambda *a, **k: charged.append(1),
+        ),
+    ):
+        asyncio.run(run_one_batch(db_session, cfg, {}, SpyBreaker(cfg), set(), web_state))
+
+    assert successes == [1]  # claude_ok latched → breaker reset
+    assert charged == []  # no web call → budget untouched
+    assert web_state["web_calls"] == 0
+
+
+def test_verified_only_does_not_reset_breaker(db_session):
+    """A VERIFIED-via-connector result (no Claude call, claude_ok False, web_calls 0)
+    must NOT reset the breaker — only an actual Claude success should."""
+    import asyncio
+    from datetime import datetime, timezone
+    from unittest.mock import patch
+
+    from app.models import MaterialCard
+    from app.services.enrichment_worker.circuit_breaker import EnrichmentCircuitBreaker
+    from app.services.enrichment_worker.config import EnrichmentWorkerConfig
+    from app.services.enrichment_worker.worker import run_one_batch
+
+    now = datetime.now(timezone.utc)
+    db_session.add(MaterialCard(normalized_mpn="f0", display_mpn="F0", enrichment_status="unenriched", created_at=now))
+    db_session.flush()
+
+    successes: list[int] = []
+
+    class SpyBreaker(EnrichmentCircuitBreaker):
+        def record_claude_success(self):
+            successes.append(1)
+            super().record_claude_success()
+
+    async def fake_enrich_card(card, db, web_meter=None, **kw):
+        return MaterialEnrichmentStatus.VERIFIED  # connector hit; no Claude, no web
+
+    cfg = EnrichmentWorkerConfig(batch_size=10, web_daily_cap=80)
+    web_state = {"web_calls": 0}
+
+    with (
+        patch("app.services.enrichment_worker.worker.enrich_card", side_effect=fake_enrich_card),
+        patch("app.services.enrichment_worker.worker._connectors_in_order", return_value=[]),
+        patch("app.services.enrichment_worker.worker.intel_cache.get_cached", return_value=None),
+        patch("app.services.enrichment_worker.worker.intel_cache.set_cached"),
+    ):
+        asyncio.run(run_one_batch(db_session, cfg, {}, SpyBreaker(cfg), set(), web_state))
+
+    assert successes == []  # claude_ok False → breaker NOT reset
+    assert web_state["web_calls"] == 0

--- a/tests/test_oem_badges.py
+++ b/tests/test_oem_badges.py
@@ -1,0 +1,44 @@
+"""Badge rendering for oem_sourced + not_catalogued in the materials list partial."""
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+def _render(status, provenance=None):
+    env = Environment(
+        loader=FileSystemLoader("app/templates"),
+        autoescape=select_autoescape(["html"]),
+    )
+    tmpl = env.get_template("htmx/partials/materials/list.html")
+    card = type(
+        "C",
+        (),
+        {
+            "enrichment_status": status,
+            "enrichment_provenance": provenance or {},
+            "lifecycle_status": None,
+            "display_mpn": "01HW917",
+            "manufacturer": "Lenovo",
+            "category": "Memory",
+            "description": "x",
+            "_vendor_count": 0,
+            "_best_price": None,
+            "_best_currency": "USD",
+            "id": 1,
+            "normalized_mpn": "01hw917",
+            "_primary_specs": [],
+            "last_searched_at": None,
+        },
+    )()
+    return tmpl.module if False else tmpl.render(materials=[card], lc_colors={}, total=1, limit=50, offset=0)
+
+
+def test_oem_sourced_badge_renders():
+    html = _render(
+        "oem_sourced", {"source_urls": ["https://support.lenovo.com/x"], "source_domains": ["support.lenovo.com"]}
+    )
+    assert "OEM-SOURCED" in html
+
+
+def test_not_catalogued_badge_renders():
+    html = _render("not_catalogued")
+    assert "NOT CATALOGUED" in html

--- a/tests/test_oem_badges.py
+++ b/tests/test_oem_badges.py
@@ -29,7 +29,7 @@ def _render(status, provenance=None):
             "last_searched_at": None,
         },
     )()
-    return tmpl.module if False else tmpl.render(materials=[card], lc_colors={}, total=1, limit=50, offset=0)
+    return tmpl.render(materials=[card], lc_colors={}, total=1, limit=50, offset=0)
 
 
 def test_oem_sourced_badge_renders():

--- a/tests/test_oem_classifier.py
+++ b/tests/test_oem_classifier.py
@@ -1,0 +1,58 @@
+"""Truth-table tests for the OEM/FRU vendor classifier (real not_found samples)."""
+
+import pytest
+
+from app.services.enrichment_worker.oem_classifier import classify_oem_vendor
+
+
+@pytest.mark.parametrize(
+    "mpn,vendor",
+    [
+        ("01HW917", "lenovo"),
+        ("00E2891", "lenovo"),
+        ("01LV731", "lenovo"),
+        ("00HW132", "lenovo"),
+        ("38L7669", "lenovo"),
+        ("46C9040", "lenovo"),
+        ("5B20L64949", "lenovo"),
+        ("5C10Q59981", "lenovo"),
+        ("5T10Q96500", "lenovo"),
+        ("918042-601", "hpe"),
+        ("619559-001", "hpe"),
+        ("486301-001", "hpe"),
+        ("628668-001", "hpe"),
+        ("902499-856", "hpe"),
+        ("NB.MBC11.003", "acer"),
+        ("KT.00403.025", "acer"),
+        ("33.G55N7.002", "acer"),
+        ("NB.GKH11.002", "acer"),
+        ("60NB0690-MB1820", "asus"),
+        ("0B200-00930000", "asus"),
+        ("HV52W", "dell"),
+        ("66YYK", "dell"),
+    ],
+)
+def test_classifies_known_oem_codes(mpn, vendor):
+    assert classify_oem_vendor(mpn) == vendor
+
+
+@pytest.mark.parametrize(
+    "mpn",
+    [
+        "M393A2K40EB3-CWEB/C",  # real Samsung DDR4 RDIMM
+        "LM2596S",
+        "ATMEGA328P-PU",
+        "STM32F407VGT6",
+        "",
+        "  ",
+        None,
+        "AB",  # too short / empty
+    ],
+)
+def test_rejects_non_oem(mpn):
+    assert classify_oem_vendor(mpn) is None
+
+
+def test_case_insensitive_and_stripped():
+    assert classify_oem_vendor("  0b200-00930000  ") == "asus"
+    assert classify_oem_vendor("nb.mbc11.003") == "acer"

--- a/tests/test_oem_classifier.py
+++ b/tests/test_oem_classifier.py
@@ -56,3 +56,11 @@ def test_rejects_non_oem(mpn):
 def test_case_insensitive_and_stripped():
     assert classify_oem_vendor("  0b200-00930000  ") == "asus"
     assert classify_oem_vendor("nb.mbc11.003") == "acer"
+
+
+def test_dell_pattern_is_broad_known_tradeoff():
+    """The Dell 5-char alnum-with-letter pattern is deliberately broad: a generic part like
+    LM317 classifies as 'dell' (accepted false positive — it only costs a wasted web call,
+    and a Dell miss terminates not_found, not not_catalogued). This pins the breadth so any
+    future narrowing is a deliberate change, not an accident."""
+    assert classify_oem_vendor("LM317") == "dell"

--- a/tests/test_oem_domains.py
+++ b/tests/test_oem_domains.py
@@ -25,3 +25,9 @@ def test_crossref_superset_includes_distributors_and_oem():
     assert is_crossref_domain("https://www.ti.com/product/x")
     # junk
     assert not is_crossref_domain("https://reddit.com/r/x")
+
+
+def test_ibm_and_uppercase_host():
+    assert is_oem_domain("https://www.ibm.com/support/x")  # ibm.com vendor root
+    assert is_oem_domain("HTTPS://SUPPORT.LENOVO.COM/x")  # host lowercased before matching
+    assert not is_oem_domain("https://notlenovo.com/x")  # not a vendor root or official host

--- a/tests/test_oem_domains.py
+++ b/tests/test_oem_domains.py
@@ -1,0 +1,27 @@
+from app.services.enrichment_worker.oem_domains import is_crossref_domain, is_oem_domain
+
+
+def test_official_oem_hosts_accepted():
+    assert is_oem_domain("https://support.lenovo.com/parts/01HW917")
+    assert is_oem_domain("https://partsurfer.hpe.com/Search.aspx?SearchText=918042-601")
+    assert is_oem_domain("http://www.dell.com/support/HV52W")
+    assert is_oem_domain("https://parts.hp.com/x")  # dot-suffix of hp.com root
+
+
+def test_lookalike_and_bad_schemes_rejected():
+    assert not is_oem_domain("https://evil-lenovo.com/x")
+    assert not is_oem_domain("https://lenovo.com.evil.com/x")
+    assert not is_oem_domain("ftp://support.lenovo.com/x")
+    assert not is_oem_domain("not a url")
+    assert not is_oem_domain("")
+
+
+def test_crossref_superset_includes_distributors_and_oem():
+    # OEM official
+    assert is_crossref_domain("https://support.lenovo.com/x")
+    # distributor (from trusted_domains)
+    assert is_crossref_domain("https://www.mouser.com/ProductDetail/x")
+    # manufacturer (from trusted_domains)
+    assert is_crossref_domain("https://www.ti.com/product/x")
+    # junk
+    assert not is_crossref_domain("https://reddit.com/r/x")

--- a/tests/test_oem_extractor.py
+++ b/tests/test_oem_extractor.py
@@ -1,0 +1,126 @@
+"""Gate tests for OEM cross-ref + description extractors (mocked Claude)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.enrichment_worker import oem_extractor
+from app.services.enrichment_worker.oem_extractor import (
+    cross_reference_mpn,
+    extract_oem_description,
+)
+from app.utils.claude_errors import ClaudeError
+
+XR_OK = {
+    "resolved_mpn": "M393A2K40EB3-CWE",
+    "manufacturer": "Samsung",
+    "linkage_quote": "Lenovo FRU 01HW917 = Samsung M393A2K40EB3-CWE 16GB DDR4 RDIMM",
+    "confidence": 0.95,
+    "source_urls": ["https://support.lenovo.com/parts/01HW917"],
+}
+
+
+async def _xr(data):
+    with patch.object(oem_extractor, "claude_json", new=AsyncMock(return_value=data)):
+        return await cross_reference_mpn("01HW917", "01hw917", "lenovo")
+
+
+@pytest.mark.asyncio
+async def test_crossref_accept():
+    r = await _xr(dict(XR_OK))
+    assert r.status == "resolved"
+    assert r.resolved_mpn == "M393A2K40EB3-CWE"
+    assert r.linkage_source_domain == "support.lenovo.com"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_untrusted_domain():
+    r = await _xr({**XR_OK, "source_urls": ["https://reddit.com/r/homelab"]})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_linkage_missing_resolved():
+    # quote lacks the resolved MPN → linkage not sourced
+    r = await _xr({**XR_OK, "linkage_quote": "Lenovo FRU 01HW917 memory module"})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_linkage_missing_oem_code():
+    r = await _xr({**XR_OK, "linkage_quote": "Samsung M393A2K40EB3-CWE 16GB DDR4 RDIMM"})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_echo_mpn():
+    r = await _xr(
+        {
+            **XR_OK,
+            "resolved_mpn": "01HW917",
+            "linkage_quote": "01HW917 01HW917",
+        }
+    )
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_reject_low_confidence():
+    r = await _xr({**XR_OK, "confidence": 0.5})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_crossref_claude_error_propagates():
+    with patch.object(oem_extractor, "claude_json", new=AsyncMock(side_effect=ClaudeError("down"))):
+        with pytest.raises(ClaudeError):
+            await cross_reference_mpn("01HW917", "01hw917", "lenovo")
+
+
+DESC_OK = {
+    "description": "ThinkSystem 16GB TruDDR4 2666MHz RDIMM",
+    "manufacturer": "Lenovo",
+    "category": "Memory Module",
+    "datasheet_url": None,
+    "confidence": 0.95,
+    "exact_mpn_found": "01HW917",
+    "source_urls": ["https://support.lenovo.com/parts/01HW917"],
+}
+
+
+async def _desc(data):
+    with patch.object(oem_extractor, "claude_json", new=AsyncMock(return_value=data)):
+        return await extract_oem_description("01HW917", "01hw917", "lenovo")
+
+
+@pytest.mark.asyncio
+async def test_desc_accept():
+    r = await _desc(dict(DESC_OK))
+    assert r.status == "oem_sourced"
+    assert r.description.startswith("ThinkSystem")
+    assert r.source_domains == ["support.lenovo.com"]
+
+
+@pytest.mark.asyncio
+async def test_desc_reject_untrusted_domain():
+    r = await _desc({**DESC_OK, "source_urls": ["https://www.ebay.com/itm/123"]})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_desc_reject_mpn_mismatch():
+    r = await _desc({**DESC_OK, "exact_mpn_found": "01HW918"})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_desc_reject_short_description():
+    r = await _desc({**DESC_OK, "description": "RAM"})
+    assert r.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_desc_claude_error_propagates():
+    with patch.object(oem_extractor, "claude_json", new=AsyncMock(side_effect=ClaudeError("down"))):
+        with pytest.raises(ClaudeError):
+            await extract_oem_description("01HW917", "01hw917", "lenovo")


### PR DESCRIPTION
## Summary

Resolves the ~1,029 `material_cards` stuck at `not_found` that are actually **OEM/system-vendor FRU/spare/service part numbers** (Lenovo/IBM, HP/HPE, Dell, Acer, ASUS) — not manufacturer MPNs, so the distributor-catalog + chip-maker-domain tiers structurally can't reach them. Adds two new grounded-web-search tiers to `enrich_card`, **with every trust gate enforced in Python (never trusting the LLM)**:

- **OEM cross-reference (strict, double-verified)** → resolves an OEM/FRU code to the commodity MPN it relabels, accepted as `verified` **only when** (a) an allowlisted authoritative page links both codes verbatim **and** (b) the resolved MPN *independently* clears the existing distributor pipeline. Records the FRU→MPN linkage in `cross_references` + a `cross_ref` provenance block.
- **OEM official description (lenient, single source)** → pulls description/category from the vendor's own official page → new `oem_sourced` status. Description/category only — never structured specs.
- Unresolvable, recognised OEM parts → new terminal `not_catalogued` (honest "OEM service part, no public specs"; 30-day worker backoff). Generic 5-char (Dell-pattern) misses stay `not_found` (22h).

Gated by a pure regex `classify_oem_vendor` so non-OEM parts never incur OEM web calls. Integrated into the paced enrichment worker (exact web-budget accounting via a `WebMeter`, circuit-breaker reset on any Claude success, per-tier observability). Ships a **dry-run-first backfill** for the existing backlog.

New statuses surface as an indigo **OEM-SOURCED** badge + a slate **NOT CATALOGUED** label, with matching faceted-filter toggles.

## Process
Brainstorm → spec → TDD plan → 10-task TDD build → **7-agent parallel review** → 6-commit round-2 fix pass → verify. Migration `089` adds two worker-status counters + documents the expanded `enrichment_status` domain (varchar column; no structural change).

## Test Plan
- [x] Full suite green: **14,514 passed**, 29 skipped, 1 xfailed
- [x] ruff + ruff-format clean; pre-commit mypy clean (341 files)
- [x] Single alembic head (`089`); migration DDL PG-validated
- [x] New tests: classifier truth-table, domain allowlist (incl. lookalike rejection), every extractor gate + `ClaudeError` propagation, cross-ref double-verify accept/reject, real-`enrich_card` exact web-meter counts, breaker reset-on-`claude_ok`, backfill dry-run/budget/error-isolation, badge render
- [ ] Bounded backfill dry-run reviewed before any `--commit`
- [ ] Deploy via `./deploy.sh` (verify indigo/slate badge classes in built CSS)

## Notes / deliberate decisions
- **Linkage gate** uses normalized-substring containment (not token-exact) — token-exact would false-reject separator-bearing OEM codes (`60NB0690-MB1820`, `NB.MBC11.003`). Defended in depth (allowlisted domain + independent distributor re-verify + 0.90 confidence); residual documented in code.
- Pre-existing `web_extractor.py` / `fetch_authoritative` left untouched (no unrelated drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)