### PR TITLE
fix(sightings): repair broken "Send RFQ" modal (tojson in double-quoted x-data)

### DIFF
--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -1329,7 +1329,14 @@ async def sightings_send_inquiry(
         if progressed_count:
             msg += f" {progressed_count} requirement{'s' if progressed_count != 1 else ''} advanced to sourcing."
 
-    return _oob_toast(msg, "warning" if failed_vendors else "success")
+    # Machine-readable result so the browser caller (rfqVendorModal.confirmSend) can
+    # report the TRUE outcome: this route intentionally returns 200 even on a partial
+    # or total send failure (the failures are captured above, not raised), so the
+    # client must not infer success from the HTTP status alone.
+    resp = _oob_toast(msg, "warning" if failed_vendors else "success")
+    resp.headers["X-RFQ-Sent"] = str(sent_count)
+    resp.headers["X-RFQ-Total"] = str(total)
+    return resp
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1397,4 +1397,145 @@ Alpine.data('quoteBuilder', (initialLines, reqId, hasCustomerSite, requirementId
   },
 }));
 
+// ── rfqVendorModal: sightings "Send RFQ" vendor-selection + compose modal ──
+// Rendered by app/templates/htmx/partials/sightings/vendor_modal.html. The server
+// passes the pre-selected vendor normalized-names and the requirement ids through a
+// SINGLE-quoted x-data attribute via |tojson — kept out of an inline x-data because
+// |tojson emits double quotes that would close a double-quoted attribute and break
+// Alpine init (see CLAUDE.md Alpine-quoting anti-pattern).
+Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
+  step: 'compose',
+  // Selection state as a plain reactive object keyed by vendor name (NOT a Set) — matches
+  // the sightingSelection store and the project's Alpine-reactivity guidance: Alpine tracks
+  // object key add/delete reliably, Set mutations less so.
+  selectedVendors: Object.fromEntries((suggestedNames || []).map((n) => [n, true])),
+  requirementIds: requirementIds || [],
+  emailBody: '',
+  previewing: false,
+  sending: false,
+
+  get selectedCount() {
+    return Object.keys(this.selectedVendors).length;
+  },
+  isSelected(name) {
+    return !!this.selectedVendors[name];
+  },
+  toggleVendor(name) {
+    if (this.selectedVendors[name]) delete this.selectedVendors[name];
+    else this.selectedVendors[name] = true;
+  },
+
+  // Build a FormData with REPEATED keys for the multi-valued fields. (Object.fromEntries
+  // on a FormData silently collapses duplicate keys to the last value — that would send
+  // only one requirement_id / vendor_name.) htmx.ajax accepts a FormData for `values`
+  // as-is, and fetch sends it directly.
+  _form() {
+    const form = new FormData();
+    this.requirementIds.forEach((id) => form.append('requirement_ids', id));
+    Object.keys(this.selectedVendors).forEach((v) => form.append('vendor_names', v));
+    form.append('email_body', this.emailBody);
+    return form;
+  },
+
+  _toast(message, type) {
+    // Toast store is { message, type, show } — set fields directly; show is a boolean.
+    this.$store.toast.message = message;
+    this.$store.toast.type = type;
+    this.$store.toast.show = true;
+  },
+
+  async loadPreview() {
+    if (this.selectedCount === 0 || !this.emailBody || this.previewing) return;
+    this.previewing = true;
+    try {
+      await htmx.ajax('POST', '/v2/partials/sightings/preview-inquiry', {
+        target: this.$refs.previewContent,
+        swap: 'innerHTML',
+        indicator: this.$refs.previewContent,
+        values: this._form(),
+      });
+      this.step = 'preview';
+    } catch (err) {
+      console.error('[rfqVendorModal] preview failed', err);
+      this._toast('Preview failed — please try again', 'error');
+    } finally {
+      this.previewing = false;
+    }
+  },
+
+  async confirmSend() {
+    if (this.selectedCount === 0 || !this.emailBody || this.sending) return;
+    this.sending = true;
+    const count = this.selectedCount;
+    try {
+      // Raw fetch so we can read the result headers below. starlette_csrf requires the
+      // x-csrftoken header on POST (mirrors quoteBuilder).
+      const csrf = document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '';
+      const resp = await fetch('/v2/partials/sightings/send-inquiry', {
+        method: 'POST',
+        headers: { 'x-csrftoken': csrf },
+        body: this._form(),
+      });
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      // The route returns 200 even on a partial/total send failure, so report the TRUE
+      // outcome from the X-RFQ-* headers rather than assuming success.
+      const sent = parseInt(resp.headers.get('X-RFQ-Sent') || '0', 10);
+      const total = parseInt(resp.headers.get('X-RFQ-Total') || String(count), 10);
+      const outcome = this._sendOutcome(sent, total);
+      this._toast(outcome.message, outcome.type);
+      if (!outcome.delivered) return; // nothing sent — keep the modal open to retry
+      this._refreshSightings();
+      this.$dispatch('close-modal');
+    } catch (err) {
+      console.error('[rfqVendorModal] send failed', err);
+      this._toast('Send failed — please try again', 'error');
+    } finally {
+      this.sending = false;
+    }
+  },
+
+  // Map the server's sent/total counts to a toast. `delivered` is false only when
+  // nothing went out, so the caller can keep the modal open for a retry.
+  _sendOutcome(sent, total) {
+    if (sent === 0) {
+      return { type: 'error', delivered: false, message: 'Send failed — no RFQs were delivered' };
+    }
+    if (sent < total) {
+      return {
+        type: 'warning',
+        delivered: true,
+        message: 'Sent to ' + sent + ' of ' + total + ' vendors — ' + (total - sent) + ' failed',
+      };
+    }
+    return {
+      type: 'success',
+      delivered: true,
+      message: 'RFQ sent to ' + sent + ' vendor' + (sent === 1 ? '' : 's'),
+    };
+  },
+
+  // A successful send can change BOTH the open detail panel (status pill auto-advances
+  // OPEN→SOURCING, new "RFQ sent" activity rows) and the requirements list. Refresh
+  // whichever is on screen.
+  _refreshSightings() {
+    const selectedReqId = Alpine.store('sightingSelection')?.selectedReqId;
+    if (selectedReqId) {
+      htmx.ajax('GET', '/v2/partials/sightings/' + selectedReqId + '/detail', {
+        target: '#sightings-detail',
+        swap: 'innerHTML',
+        indicator: '#sightings-detail-skeleton',
+      });
+    }
+    const table = document.getElementById('sightings-table');
+    const tableUrl = table && table.getAttribute('hx-get');
+    if (tableUrl) {
+      htmx.ajax('GET', tableUrl, {
+        target: '#sightings-table',
+        swap: 'innerHTML',
+        indicator: '#sightings-load-spinner',
+      });
+    }
+  },
+}));
+
 Alpine.start();

--- a/app/templates/htmx/partials/sightings/vendor_modal.html
+++ b/app/templates/htmx/partials/sightings/vendor_modal.html
@@ -4,48 +4,12 @@
    Context: suggested_vendors, requirement_ids, parts
 #}
 
-<div class="p-4" x-data="{
-  step: 'compose',
-  selectedVendors: new Set({{ suggested_vendors|map(attribute='normalized_name')|list|tojson }}),
-  emailBody: '',
-  cleaning: false,
-  previewing: false,
-  sending: false,
-  toggleVendor(name) {
-    if (this.selectedVendors.has(name)) this.selectedVendors.delete(name);
-    else this.selectedVendors.add(name);
-  },
-  async loadPreview() {
-    this.previewing = true;
-    const form = new FormData();
-    {{ requirement_ids|tojson }}.forEach(id => form.append('requirement_ids', id));
-    this.selectedVendors.forEach(v => form.append('vendor_names', v));
-    form.append('email_body', this.emailBody);
-    try {
-      const target = this.$refs.previewContent;
-      await htmx.ajax('POST', '/v2/partials/sightings/preview-inquiry', {
-        target: target, swap: 'innerHTML', values: Object.fromEntries(form)
-      });
-      this.step = 'preview';
-    } catch {
-      $store.toast.show('Preview failed — check your selections', 'error');
-    } finally {
-      this.previewing = false;
-    }
-  },
-  confirmSend() {
-    this.sending = true;
-    const form = new FormData();
-    {{ requirement_ids|tojson }}.forEach(id => form.append('requirement_ids', id));
-    this.selectedVendors.forEach(v => form.append('vendor_names', v));
-    form.append('email_body', this.emailBody);
-    const xhr = new XMLHttpRequest();
-    xhr.open('POST', '/v2/partials/sightings/send-inquiry');
-    xhr.onload = () => { const t = document.getElementById('sightings-table'); if (t) htmx.ajax('GET', t.getAttribute('hx-get') || window.location.pathname, {target: '#sightings-table'}); };
-    xhr.send(form);
-    $dispatch('close-modal');
-  }
-}">
+{# The component logic lives in the rfqVendorModal() factory in app/static/htmx_app.js.
+   The vendor-name list and requirement ids are passed via |tojson inside a SINGLE-quoted
+   x-data attribute — tojson emits double quotes, which would close a double-quoted
+   attribute and break Alpine init (CLAUDE.md Alpine-quoting anti-pattern). #}
+<div class="p-4"
+     x-data='rfqVendorModal({{ suggested_vendors|map(attribute="normalized_name")|list|tojson }}, {{ requirement_ids|tojson }})'>
 
   {# ── Step 1: Compose ─────────────────────────────────────────── #}
   <div x-show="step === 'compose'" x-cloak>
@@ -60,8 +24,8 @@
         {% for v in suggested_vendors %}
         <label class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer">
           <input type="checkbox"
-                 :checked="selectedVendors.has('{{ v.normalized_name }}')"
-                 @change="toggleVendor('{{ v.normalized_name }}')"
+                 :checked='isSelected({{ v.normalized_name|tojson }})'
+                 @change='toggleVendor({{ v.normalized_name|tojson }})'
                  class="rounded border-gray-300">
           <div class="flex-1 min-w-0">
             <span class="text-sm font-medium text-gray-700">{{ v.display_name }}</span>
@@ -103,17 +67,17 @@
         Cancel
       </button>
       <button @click="loadPreview()"
-              :disabled="selectedVendors.size === 0 || !emailBody || previewing"
+              :disabled="selectedCount === 0 || !emailBody || previewing"
               class="px-4 py-2 text-sm font-medium text-brand-600 bg-brand-50 hover:bg-brand-100 border border-brand-200 rounded-lg transition-colors disabled:bg-gray-100 disabled:text-gray-400 disabled:border-gray-200">
         <span x-show="!previewing" x-cloak>
-          Preview <span x-text="selectedVendors.size"></span> Email<span x-show="selectedVendors.size !== 1" x-cloak>s</span>
+          Preview <span x-text="selectedCount"></span> Email<span x-show="selectedCount !== 1" x-cloak>s</span>
         </span>
         <span x-show="previewing" x-cloak>Loading...</span>
       </button>
       <button @click="confirmSend()"
-              :disabled="selectedVendors.size === 0 || !emailBody || sending"
+              :disabled="selectedCount === 0 || !emailBody || sending"
               class="px-4 py-2 text-sm font-medium text-white bg-brand-500 hover:bg-brand-600 rounded-lg transition-colors disabled:bg-gray-300">
-        Send to <span x-text="selectedVendors.size"></span> Vendor<span x-show="selectedVendors.size !== 1" x-cloak>s</span>
+        Send to <span x-text="selectedCount"></span> Vendor<span x-show="selectedCount !== 1" x-cloak>s</span>
       </button>
     </div>
   </div>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1319,6 +1319,32 @@ Component bound to `/requisitions2` `<tr>`. CSS handles hover reveal via
 `@focusin`/`@focusout`/`@keydown.enter` toggle visibility for keyboard
 users. `Escape` dismisses.
 
+### rfqVendorModal  (htmx_app.js, Alpine.data)
+
+Backs `sightings/vendor_modal.html` — the "Send RFQ" batch-inquiry modal opened
+from a sighting's vendor row (`requirement_ids=<id>`) or the table action bar
+(comma-joined ids). Invoked as
+`x-data='rfqVendorModal({{ suggested_vendors|map(attribute="normalized_name")|list|tojson }}, {{ requirement_ids|tojson }})'`.
+The factory lives in JS (not inline) because `|tojson` emits double quotes that
+would close a double-quoted `x-data` attribute and break Alpine init; the data is
+carried through a **single-quoted** attribute (tojson escapes `'`). State:
+`step` (compose|preview), `selectedVendors` (a plain reactive object keyed by vendor
+name — matches the `sightingSelection` store, not a Set; `selectedCount` getter +
+`isSelected(name)` back the bindings), `emailBody`. Methods: `toggleVendor`;
+`loadPreview()` → `POST /v2/partials/sightings/preview-inquiry` (htmx.ajax swap into
+`x-ref="previewContent"`); `confirmSend()` → `fetch POST
+/v2/partials/sightings/send-inquiry` with the `x-csrftoken` header, then on success
+`_refreshSightings()` re-GETs the open `#sightings-detail` (status auto-advances
+OPEN→SOURCING + new activity rows) and the `#sightings-table` list, and dispatches
+`close-modal`. `_form()` builds a `FormData` with **repeated** `requirement_ids`/
+`vendor_names` keys (not `Object.fromEntries`, which collapses duplicates).
+
+The route returns **HTTP 200 even on partial/total send failure** (failures are
+captured, not raised) and exposes the true outcome via `X-RFQ-Sent` / `X-RFQ-Total`
+response headers. `confirmSend` reads them and toasts via `$store.toast`: full
+success, partial-failure (warning), or total-failure (error — modal stays open to
+retry); it never infers success from the HTTP status alone.
+
 ---
 
 ## 8x8 Integration — Operator Enablement

--- a/tests/frontend/rfq-vendor-modal.test.ts
+++ b/tests/frontend/rfq-vendor-modal.test.ts
@@ -1,0 +1,225 @@
+/**
+ * rfq-vendor-modal.test.ts — Vitest unit tests for the rfqVendorModal Alpine component.
+ *
+ * Mirrors the logic of Alpine.data('rfqVendorModal', ...) in app/static/htmx_app.js
+ * (the established convention in alpine-components.test.ts is to re-implement the data
+ * factory's logic and test it directly, rather than booting Alpine).
+ *
+ * Guards the sightings "Send RFQ" modal regressions:
+ *  - selectedVendors seeded from the server-provided pre-selected names
+ *  - toggleVendor add/remove
+ *  - _form() serialises MULTIPLE requirement_ids / vendor_names as REPEATED keys
+ *    (the original used Object.fromEntries(FormData), which silently collapsed
+ *    duplicate keys to a single value)
+ *  - _toast() sets the toast store fields directly (show is a boolean, not a method)
+ *  - confirmSend/loadPreview no-op when nothing is selected or the body is empty
+ *
+ * Called by: npx vitest run
+ * Depends on: vitest, jsdom
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Mirror of the rfqVendorModal() factory's pure logic (network calls stubbed out so
+// we can exercise the guards and serialisation without Alpine/htmx/fetch).
+function createRfqVendorModal(suggestedNames: string[], requirementIds: number[]) {
+  return {
+    step: 'compose',
+    // Plain reactive object keyed by vendor name (mirrors the factory + sightingSelection store).
+    selectedVendors: Object.fromEntries((suggestedNames || []).map((n) => [n, true])) as Record<string, boolean>,
+    requirementIds: requirementIds || [],
+    emailBody: '',
+    previewing: false,
+    sending: false,
+    // test-only spies
+    $store: { toast: { message: '', type: 'info', show: false } },
+    _previewCalled: false,
+    _sendCalled: false,
+
+    get selectedCount() {
+      return Object.keys(this.selectedVendors).length;
+    },
+    isSelected(name: string) {
+      return !!this.selectedVendors[name];
+    },
+    toggleVendor(name: string) {
+      if (this.selectedVendors[name]) delete this.selectedVendors[name];
+      else this.selectedVendors[name] = true;
+    },
+
+    _form(): FormData {
+      const form = new FormData();
+      this.requirementIds.forEach((id) => form.append('requirement_ids', String(id)));
+      Object.keys(this.selectedVendors).forEach((v) => form.append('vendor_names', v));
+      form.append('email_body', this.emailBody);
+      return form;
+    },
+
+    _toast(message: string, type: string) {
+      this.$store.toast.message = message;
+      this.$store.toast.type = type;
+      this.$store.toast.show = true;
+    },
+
+    _sendOutcome(sent: number, total: number) {
+      if (sent === 0) {
+        return { type: 'error', delivered: false, message: 'Send failed — no RFQs were delivered' };
+      }
+      if (sent < total) {
+        return {
+          type: 'warning',
+          delivered: true,
+          message: 'Sent to ' + sent + ' of ' + total + ' vendors — ' + (total - sent) + ' failed',
+        };
+      }
+      return {
+        type: 'success',
+        delivered: true,
+        message: 'RFQ sent to ' + sent + ' vendor' + (sent === 1 ? '' : 's'),
+      };
+    },
+
+    loadPreview() {
+      if (this.selectedCount === 0 || !this.emailBody || this.previewing) return;
+      this._previewCalled = true;
+    },
+
+    confirmSend() {
+      if (this.selectedCount === 0 || !this.emailBody || this.sending) return;
+      this._sendCalled = true;
+    },
+  };
+}
+
+describe('rfqVendorModal', () => {
+  let m: ReturnType<typeof createRfqVendorModal>;
+
+  beforeEach(() => {
+    m = createRfqVendorModal(['arrow electronics', 'mouser'], [10, 11]);
+  });
+
+  describe('initial state', () => {
+    it('seeds selectedVendors from the pre-selected names', () => {
+      expect(m.selectedCount).toBe(2);
+      expect(m.isSelected('arrow electronics')).toBe(true);
+      expect(m.isSelected('mouser')).toBe(true);
+    });
+
+    it('seeds an empty selection when no names are provided', () => {
+      const empty = createRfqVendorModal([], []);
+      expect(empty.selectedCount).toBe(0);
+    });
+
+    it('starts on the compose step', () => {
+      expect(m.step).toBe('compose');
+    });
+  });
+
+  describe('toggleVendor', () => {
+    it('removes a vendor that is selected', () => {
+      m.toggleVendor('mouser');
+      expect(m.isSelected('mouser')).toBe(false);
+      expect(m.selectedCount).toBe(1);
+    });
+
+    it('adds a vendor that is not selected', () => {
+      m.toggleVendor('digikey');
+      expect(m.isSelected('digikey')).toBe(true);
+      expect(m.selectedCount).toBe(3);
+    });
+  });
+
+  describe('_form serialisation', () => {
+    it('emits a repeated key for every requirement id', () => {
+      m.emailBody = 'hi';
+      const form = m._form();
+      expect(form.getAll('requirement_ids')).toEqual(['10', '11']);
+    });
+
+    it('emits a repeated key for every selected vendor (no duplicate-key collapse)', () => {
+      m.emailBody = 'hi';
+      const form = m._form();
+      // The original Object.fromEntries(FormData) bug would have dropped all but one.
+      expect(form.getAll('vendor_names').sort()).toEqual(['arrow electronics', 'mouser']);
+    });
+
+    it('reflects toggles in the serialised vendor list', () => {
+      m.toggleVendor('mouser'); // remove
+      m.toggleVendor('digikey'); // add
+      const form = m._form();
+      expect(form.getAll('vendor_names').sort()).toEqual(['arrow electronics', 'digikey']);
+    });
+
+    it('includes the email body', () => {
+      m.emailBody = 'please quote';
+      expect(m._form().get('email_body')).toBe('please quote');
+    });
+  });
+
+  describe('_toast', () => {
+    it('sets message/type/show directly (show is a boolean, not a method)', () => {
+      m._toast('RFQ sent to 2 vendors', 'success');
+      expect(m.$store.toast.message).toBe('RFQ sent to 2 vendors');
+      expect(m.$store.toast.type).toBe('success');
+      expect(m.$store.toast.show).toBe(true);
+    });
+  });
+
+  describe('_sendOutcome (true outcome from server X-RFQ-* counts)', () => {
+    it('reports full success when all vendors were sent', () => {
+      const o = m._sendOutcome(3, 3);
+      expect(o.type).toBe('success');
+      expect(o.delivered).toBe(true);
+      expect(o.message).toBe('RFQ sent to 3 vendors');
+    });
+
+    it('uses singular wording for one vendor', () => {
+      expect(m._sendOutcome(1, 1).message).toBe('RFQ sent to 1 vendor');
+    });
+
+    it('warns on a PARTIAL failure (the route still returns HTTP 200)', () => {
+      const o = m._sendOutcome(1, 3);
+      expect(o.type).toBe('warning');
+      expect(o.delivered).toBe(true);
+      expect(o.message).toBe('Sent to 1 of 3 vendors — 2 failed');
+    });
+
+    it('errors and keeps the modal open when NOTHING was delivered', () => {
+      const o = m._sendOutcome(0, 3);
+      expect(o.type).toBe('error');
+      expect(o.delivered).toBe(false);
+      expect(o.message).toBe('Send failed — no RFQs were delivered');
+    });
+  });
+
+  describe('guards', () => {
+    it('confirmSend is a no-op with no vendors selected', () => {
+      const empty = createRfqVendorModal([], [10]);
+      empty.emailBody = 'hi';
+      empty.confirmSend();
+      expect(empty._sendCalled).toBe(false);
+    });
+
+    it('confirmSend is a no-op with an empty body', () => {
+      m.confirmSend();
+      expect(m._sendCalled).toBe(false);
+    });
+
+    it('confirmSend proceeds with vendors + body', () => {
+      m.emailBody = 'hi';
+      m.confirmSend();
+      expect(m._sendCalled).toBe(true);
+    });
+
+    it('loadPreview is a no-op with an empty body', () => {
+      m.loadPreview();
+      expect(m._previewCalled).toBe(false);
+    });
+
+    it('loadPreview proceeds with vendors + body', () => {
+      m.emailBody = 'hi';
+      m.loadPreview();
+      expect(m._previewCalled).toBe(true);
+    });
+  });
+});

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -7,6 +7,7 @@ Depends on: conftest.py fixtures, app models, sighting_status service
 import json
 import re
 from datetime import datetime, timedelta, timezone
+from html.parser import HTMLParser
 
 from app.constants import ActivityType
 from app.models.intelligence import ActivityLog, MaterialCard
@@ -14,6 +15,24 @@ from app.models.offers import Offer
 from app.models.sourcing import Requirement, Requisition, Sighting
 from app.models.vendor_sighting_summary import VendorSightingSummary
 from app.models.vendors import VendorCard, VendorContact
+
+
+class _XDataExtractor(HTMLParser):
+    """Collect every x-data attribute value AS THE BROWSER TOKENIZES IT.
+
+    Faithfully reproduces HTML attribute-value termination, so a literal double-quote
+    injected by |tojson into a double-quoted x-data attribute shows up here as a
+    TRUNCATED value — exactly what breaks Alpine init in the browser.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.xdata_values: list[str] = []
+
+    def handle_starttag(self, tag, attrs):
+        for name, value in attrs:
+            if name == "x-data" and value:
+                self.xdata_values.append(value)
 
 
 def _seed_data(db_session):
@@ -327,6 +346,49 @@ class TestSightingsVendorModal:
         resp = client.get("/v2/partials/sightings/vendor-modal?requirement_ids=99999")
         assert resp.status_code == 200
 
+    def test_xdata_not_truncated_with_vendors(self, client, db_session):
+        """Regression for the broken "Send RFQ" modal.
+
+        With at least one suggested vendor, the modal's root x-data must survive HTML
+        attribute tokenization. The original template injected the vendor-name list via
+        |tojson INSIDE a double-quoted x-data attribute; tojson emits literal double
+        quotes (``["good vendor"]``) which close the attribute at the first vendor name,
+        so Alpine fails to init and the whole modal goes inert (the reported bug). The
+        fix routes the data through a single-quoted x-data invoking the rfqVendorModal()
+        factory, so the attribute — and the vendor name inside it — parse intact.
+        """
+        _, r, _ = _seed_data(db_session)
+        # VendorCard whose normalized_name matches lower(trim(vendor_name)) so the
+        # suggested_vendors join returns a non-empty list (the failing scenario).
+        db_session.add(
+            VendorCard(
+                normalized_name="good vendor",
+                display_name="Good Vendor",
+                is_blacklisted=False,
+                engagement_score=50.0,
+            )
+        )
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/sightings/vendor-modal?requirement_ids={r.id}")
+        assert resp.status_code == 200
+        # Sanity: the join matched and the vendor is actually in the modal.
+        assert "Good Vendor" in resp.text
+
+        extractor = _XDataExtractor()
+        extractor.feed(resp.text)
+        modal_xdata = [v for v in extractor.xdata_values if "rfqVendorModal" in v]
+        assert modal_xdata, (
+            "modal root must invoke the rfqVendorModal() factory via a single-quoted "
+            f"x-data; x-data values parsed: {extractor.xdata_values!r}"
+        )
+        # The vendor name must survive intact inside the parsed attribute — proof the
+        # tojson double-quotes did NOT terminate the attribute early.
+        assert any("good vendor" in v for v in modal_xdata), (
+            "vendor name was truncated out of the x-data attribute — tojson double-quotes "
+            "broke attribute tokenization (the original bug)."
+        )
+
 
 class TestSightingsBatchLimit:
     def test_batch_refresh_over_limit_returns_400(self, client, db_session):
@@ -350,6 +412,62 @@ class TestSightingsSendInquiry:
             data={"requirement_ids": str(r.id), "vendor_names": "Acme"},
         )
         assert resp.status_code == 400
+
+
+class TestSightingsSendInquiryResultHeaders:
+    """The route returns HTTP 200 even on a partial/total send failure (failures are
+    captured, not raised).
+
+    The X-RFQ-Sent / X-RFQ-Total headers carry the true outcome so the browser modal
+    (rfqVendorModal.confirmSend) never reports a false success.
+    """
+
+    def _post(self, client, r):
+        return client.post(
+            "/v2/partials/sightings/send-inquiry",
+            data={
+                "requirement_ids": str(r.id),
+                "vendor_names": ["Acme", "Globex"],  # list → repeated form keys
+                "email_body": "Please quote.",
+            },
+        )
+
+    def test_full_success_headers(self, client, db_session, monkeypatch):
+        _, r, _ = _seed_data(db_session)
+
+        async def fake_send(**kwargs):
+            # One result per vendor group => all sent.
+            return [{"vendor": g} for g in kwargs["vendor_groups"]]
+
+        monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
+        resp = self._post(client, r)
+        assert resp.status_code == 200
+        assert resp.headers["X-RFQ-Sent"] == "2"
+        assert resp.headers["X-RFQ-Total"] == "2"
+
+    def test_partial_failure_still_200_with_headers(self, client, db_session, monkeypatch):
+        _, r, _ = _seed_data(db_session)
+
+        async def fake_send(**kwargs):
+            return [{"vendor": kwargs["vendor_groups"][0]}]  # only 1 of 2 delivered
+
+        monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
+        resp = self._post(client, r)
+        assert resp.status_code == 200
+        assert resp.headers["X-RFQ-Sent"] == "1"
+        assert resp.headers["X-RFQ-Total"] == "2"
+
+    def test_total_failure_still_200_with_headers(self, client, db_session, monkeypatch):
+        _, r, _ = _seed_data(db_session)
+
+        async def fake_send(**kwargs):
+            raise RuntimeError("Graph API down")
+
+        monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
+        resp = self._post(client, r)
+        assert resp.status_code == 200
+        assert resp.headers["X-RFQ-Sent"] == "0"
+        assert resp.headers["X-RFQ-Total"] == "2"
 
 
 class TestDashboardCounters:

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -62,8 +62,6 @@ def test_htmx_ajax_calls_have_indicator():
     allowlist: set[tuple[str, int]] = {
         ("app/templates/htmx/base.html", 56),
         ("app/templates/requisitions2/_inline_cell.html", 16),
-        ("app/templates/htmx/partials/sightings/vendor_modal.html", 26),
-        ("app/templates/htmx/partials/sightings/vendor_modal.html", 44),
         ("app/templates/htmx/partials/sourcing/workspace.html", 177),
         ("app/templates/htmx/partials/excess/bid_form.html", 16),
         ("app/templates/htmx/partials/parts/cell_edit.html", 12),


### PR DESCRIPTION
## Problem
Clicking **Send RFQ** on the sightings page opened a blank, inert modal. Root cause: the modal's root `x-data` was a **double-quoted** Alpine attribute injecting `{{ suggested_vendors|...|tojson }}`. Jinja's `tojson` escapes `'` but **not** `"`, so a non-empty vendor list rendered `new Set(["acme",...])` and the first `"` closed the attribute mid-expression → Alpine threw on init, the whole component died, and its `x-cloak` content never showed. (Present since the page was first built.)

## Fix
- Move the component into `Alpine.data('rfqVendorModal', …)` in `htmx_app.js` (matches the `quoteBuilder`/`materialsFilter` factory convention); the template invokes it via a **single-quoted** `x-data` (tojson's double quotes are safe inside single quotes; tojson escapes single quotes).
- Selection is a plain reactive object keyed by vendor name (matches the `sightingSelection` store; avoids Set-reactivity fragility flagged in the project spec).
- Fix secondary bugs that surfaced once Alpine worked: bare `$store`/`$dispatch` → `this.…`; `$store.toast.show(...)` misuse (it's a boolean); `Object.fromEntries(FormData)` collapsing duplicate `requirement_ids`/`vendor_names` → real `FormData`; raw XHR that discarded the response.
- `send-inquiry` returns HTTP 200 even on partial/total send failure, so it now emits `X-RFQ-Sent`/`X-RFQ-Total` headers and `confirmSend` reports the **true** outcome (success / partial-warning / "no RFQs delivered", modal kept open) instead of a false success.

## Tests
- `test_sightings_router.py`: render-integrity (parses `x-data` with `html.parser` — fails on the old truncated attribute) + 3 server result-header tests.
- `tests/frontend/rfq-vendor-modal.test.ts`: factory logic (selection, repeated-key serialization, outcome mapping).
- Drained 2 stale `htmx.ajax` indicator-allowlist entries.

Full suite: 14580 passed, 0 failed. Frontend 78/78. Ruff/ESLint clean.

## Related (NOT in this PR — same bug class, separate features)
`excess/detail.html:31`, `materials/filters/_macros.html:13-14`, `materials/ai_interpret.html:26` have the identical tojson-in-double-quoted-attribute bug. Tracked for a separate change + static guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)