### PR TITLE
fix(templates): kill remaining tojson-in-double-quoted-Alpine-attr bugs + guard

### DIFF
--- a/app/templates/htmx/partials/excess/detail.html
+++ b/app/templates/htmx/partials/excess/detail.html
@@ -28,7 +28,9 @@
   {# ── Header Card ────────────────────────────────────────────────── #}
   <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-6">
     <div class="flex items-start justify-between">
-      <div class="flex-1 min-w-0" x-data="{ editing: false, title: {{ list.title|tojson }} }">
+      {# Single-quoted x-data: |tojson emits double quotes (and escapes single quotes),
+         so it is safe inside single quotes but would break a double-quoted attribute. #}
+      <div class="flex-1 min-w-0" x-data='{ editing: false, title: {{ list.title|tojson }} }'>
         {# Inline-editable title #}
         <div x-show="!editing" x-cloak @dblclick="editing = true" class="cursor-pointer group/title">
           <h1 class="text-2xl font-bold text-gray-900 inline">

--- a/app/templates/htmx/partials/materials/ai_interpret.html
+++ b/app/templates/htmx/partials/materials/ai_interpret.html
@@ -21,24 +21,28 @@
   </button>
 </div>
 
-{# Inline script to apply AI-suggested filters to the Alpine component #}
+{# Inline script to apply AI-suggested filters to the Alpine component.
+   SINGLE-quoted x-init with double-quoted JS strings: the interpolated values go through
+   |tojson, which emits double quotes (and escapes single quotes) — safe inside single
+   quotes, but it would close a double-quoted attribute and break Alpine init. tojson output
+   is already a valid JS literal, so assign it directly (no JSON.parse). #}
 <div id="ai-apply-trigger" hx-swap-oob="true:#ai-script-container"
-     x-data x-init="
-       const ws = document.querySelector('#materials-workspace');
+     x-data x-init='
+       const ws = document.querySelector("#materials-workspace");
        if (ws) {
-         const d = Alpine.evaluate(ws, '$data');
+         const d = Alpine.evaluate(ws, "$data");
          {% if ai_result.commodity %}
-         d.commodity = '{{ ai_result.commodity }}';
+         d.commodity = {{ ai_result.commodity | tojson }};
          {% endif %}
          {% if ai_result.filters %}
-         d.subFilters = JSON.parse('{{ ai_result.filters | tojson }}');
+         d.subFilters = {{ ai_result.filters | tojson }};
          {% endif %}
          d.page = 0;
          d.pushURL();
-         document.body.dispatchEvent(new CustomEvent('commodity-changed'));
-         document.body.dispatchEvent(new CustomEvent('filters-changed'));
+         document.body.dispatchEvent(new CustomEvent("commodity-changed"));
+         document.body.dispatchEvent(new CustomEvent("filters-changed"));
        }
-     ">
+     '>
 </div>
 {% else %}
 {# No result / error — show empty #}

--- a/app/templates/htmx/partials/materials/filters/_macros.html
+++ b/app/templates/htmx/partials/materials/filters/_macros.html
@@ -9,9 +9,11 @@
   <div class="space-y-0.5" :class="!expanded && {{ values|length }} > 6 ? 'max-h-[168px] overflow-hidden' : 'max-h-[320px] overflow-y-auto'">
     {% for val in values %}
     <label class="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-50 cursor-pointer text-sm group">
+      {# Single-quoted attributes: |tojson emits double quotes (and escapes single quotes),
+         so spec_key/val are safe inside single quotes — a double-quoted attribute breaks. #}
       <input type="checkbox" value="{{ val }}"
-             :checked="(subFilters['{{ spec_key }}'] || []).includes({{ val|tojson }})"
-             @change="toggleFilter('{{ spec_key }}', {{ val|tojson }})"
+             :checked='(subFilters[{{ spec_key|tojson }}] || []).includes({{ val|tojson }})'
+             @change='toggleFilter({{ spec_key|tojson }}, {{ val|tojson }})'
              class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 h-3.5 w-3.5">
       <span class="text-gray-700 truncate flex-1 text-[13px]">{{ val }}</span>
       {% if counts and val in counts %}

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -113,6 +113,51 @@ _REQ_ID_HEADERED_SIGHTINGS_PARTIALS = (
 )
 
 
+# Sites where |tojson sits inside a DOUBLE-quoted Alpine attribute but is SAFE because the
+# value it serialises is an int/bool — tojson renders true/false or [1, 2, 3], which contain
+# no double quote, so the attribute cannot be broken. Anything else (a string or list of
+# strings) MUST use a single-quoted attribute (or a JS Alpine.data factory). Keyed (file, line
+# of the attribute's opening). Do NOT add a string/array site here — fix the call site instead.
+_TOJSON_IN_DOUBLE_QUOTED_ALPINE_ALLOWLIST: set[tuple[str, int]] = {
+    ("app/templates/htmx/partials/quote_builder/modal.html", 9),  # has_customer_site|tojson -> true/false
+    ("app/templates/htmx/partials/requisitions/rfq_compose.html", 44),  # vendors|map(id)|list|tojson -> [1,2,3]
+    ("app/templates/requisitions2/_table.html", 65),  # requisitions|map(id)|list|tojson -> [1,2,3]
+}
+
+# Alpine directive attributes: x-data, x-init, x-bind:x / :x, x-on:x / @x.
+_ALPINE_ATTR_TOJSON = re.compile(r'(?:x-data|x-init|x-bind:[\w.:-]+|x-on:[\w.:-]+|@[\w.:-]+|:[\w.-]+)\s*=\s*"([^"]*)"')
+
+
+def test_no_tojson_in_double_quoted_alpine_attribute():
+    """|tojson emits UNESCAPED double quotes (it escapes ', <, >, & — but never ").
+
+    Inside a DOUBLE-quoted Alpine attribute (x-data / x-init / @event / :bind / x-on:)
+    the first such double quote closes the attribute early, so Alpine fails to parse the
+    expression and the whole component goes inert — a bug class that has shipped
+    silently more than once (e.g. the sightings "Send RFQ" modal opened blank). The fix
+    is a SINGLE-quoted attribute (tojson escapes ', so single quotes are safe) or a JS
+    Alpine.data() factory invoked with the tojson args. See CLAUDE.md.
+
+    Allowlisted sites serialise only an int/bool and therefore cannot emit a double
+    quote.
+    """
+    offenders: list[str] = []
+    for path in sorted(Path("app/templates").rglob("*.html")):
+        text = path.read_text()
+        for m in _ALPINE_ATTR_TOJSON.finditer(text):
+            if "tojson" not in m.group(1):
+                continue
+            line = text[: m.start()].count("\n") + 1
+            rel = str(path.relative_to(Path(".")))
+            if (rel, line) in _TOJSON_IN_DOUBLE_QUOTED_ALPINE_ALLOWLIST:
+                continue
+            offenders.append(f"{rel}:{line}: {m.group(0)[:90].strip()}")
+    assert not offenders, (
+        "|tojson inside a DOUBLE-quoted Alpine attribute breaks Alpine init (tojson emits "
+        "unescaped double quotes). Use a SINGLE-quoted attribute or a JS Alpine.data factory:\n" + "\n".join(offenders)
+    )
+
+
 def test_sightings_template_responses_set_rendered_req_id():
     """Every template_response() rendering a context-sensitive sightings partial must
     set the X-Rendered-Req-Id header so the client htmx:beforeSwap stale-response guard


### PR DESCRIPTION
Follow-up to #207. Same root cause as the sightings "Send RFQ" modal — `|tojson` emits unescaped double quotes, so inside a **double-quoted** Alpine attribute the first quote closes the attribute and breaks Alpine init for the whole component. Three more live instances, each switched to a **single-quoted** attribute:

- **excess/detail.html** — inline title-edit `x-data` (broke whenever a list had a title).
- **materials/filters/_macros.html** — facet checkbox `:checked`/`@change` (broke for any string spec value).
- **materials/ai_interpret.html** — AI-apply `x-init` (broke whenever the AI returned filters; drops the now-unnecessary `JSON.parse`).

Adds `test_no_tojson_in_double_quoted_alpine_attribute`: scans every template for `|tojson` in a double-quoted Alpine attribute and fails, with a documented `(file,line)` allowlist for the only safe cases (int/bool values whose tojson can't emit a double quote). Verified non-vacuous: it matches exactly the 3 allowlisted int/bool sites and none of the fixed ones.

Render-verified each fix parses intact even with pathological values (`Bob's "Big" List`, `SOP "X"`). Full suite green (14581 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)