### PR TITLE
fix(sightings): honest X-RFQ-Sent count + harden send-result handling

### DIFF
--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -92,6 +92,13 @@ def _oob_toast(msg: str, level: str = "success") -> HTMLResponse:
     )
 
 
+# Result headers on POST /v2/partials/sightings/send-inquiry: the route returns HTTP 200
+# even on a partial/total send failure, so the browser modal reads the true delivered
+# count from these rather than inferring success from the status code.
+RFQ_SENT_HEADER = "X-RFQ-Sent"
+RFQ_TOTAL_HEADER = "X-RFQ-Total"
+
+
 def _render_offers_panel(request: Request, requirement: Requirement, db: Session) -> HTMLResponse:
     """Render the part-centric Offers panel for swap into #sightings-offers-panel."""
     ctx = {
@@ -1292,7 +1299,10 @@ async def sightings_send_inquiry(
             requisition_id=requisition_id,
             vendor_groups=vendor_groups,
         )
-        sent_count = len(results)
+        # Count only records the email service tagged "sent". send_batch_rfq returns one
+        # record per attempted vendor INCLUDING per-vendor failures (status="failed"), so
+        # len(results) would over-count and report a false success on a partial failure.
+        sent_count = sum(1 for r in results if r.get("status") == "sent")
 
         for r in requirements:
             for vn in vendor_names:
@@ -1334,8 +1344,8 @@ async def sightings_send_inquiry(
     # or total send failure (the failures are captured above, not raised), so the
     # client must not infer success from the HTTP status alone.
     resp = _oob_toast(msg, "warning" if failed_vendors else "success")
-    resp.headers["X-RFQ-Sent"] = str(sent_count)
-    resp.headers["X-RFQ-Total"] = str(total)
+    resp.headers[RFQ_SENT_HEADER] = str(sent_count)
+    resp.headers[RFQ_TOTAL_HEADER] = str(total)
     return resp
 
 

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1518,13 +1518,19 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
   // OPEN→SOURCING, new "RFQ sent" activity rows) and the requirements list. Refresh
   // whichever is on screen.
   _refreshSightings() {
+    // The send already succeeded; if a panel refresh fails, warn rather than silently
+    // leaving a stale status pill / requirements list on screen.
+    const onRefreshError = (err) => {
+      console.error('[rfqVendorModal] post-send refresh failed', err);
+      this._toast('Sent — refresh the page to see updated status', 'warning');
+    };
     const selectedReqId = Alpine.store('sightingSelection')?.selectedReqId;
     if (selectedReqId) {
       htmx.ajax('GET', '/v2/partials/sightings/' + selectedReqId + '/detail', {
         target: '#sightings-detail',
         swap: 'innerHTML',
         indicator: '#sightings-detail-skeleton',
-      });
+      }).catch(onRefreshError);
     }
     const table = document.getElementById('sightings-table');
     const tableUrl = table && table.getAttribute('hx-get');
@@ -1533,7 +1539,7 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
         target: '#sightings-table',
         swap: 'innerHTML',
         indicator: '#sightings-load-spinner',
-      });
+      }).catch(onRefreshError);
     }
   },
 }));

--- a/tests/frontend/rfq-vendor-modal.test.ts
+++ b/tests/frontend/rfq-vendor-modal.test.ts
@@ -1,225 +1,245 @@
 /**
- * rfq-vendor-modal.test.ts — Vitest unit tests for the rfqVendorModal Alpine component.
+ * rfq-vendor-modal.test.ts — Vitest unit tests for the REAL rfqVendorModal Alpine factory.
  *
- * Mirrors the logic of Alpine.data('rfqVendorModal', ...) in app/static/htmx_app.js
- * (the established convention in alpine-components.test.ts is to re-implement the data
- * factory's logic and test it directly, rather than booting Alpine).
- *
- * Guards the sightings "Send RFQ" modal regressions:
- *  - selectedVendors seeded from the server-provided pre-selected names
- *  - toggleVendor add/remove
- *  - _form() serialises MULTIPLE requirement_ids / vendor_names as REPEATED keys
- *    (the original used Object.fromEntries(FormData), which silently collapsed
- *    duplicate keys to a single value)
- *  - _toast() sets the toast store fields directly (show is a boolean, not a method)
- *  - confirmSend/loadPreview no-op when nothing is selected or the body is empty
+ * Imports app/static/htmx_app.js (with htmx/Alpine mocked) and pulls the actual
+ * Alpine.data('rfqVendorModal', ...) factory out of the captured registry — so the
+ * network/branching logic in confirmSend / loadPreview / _refreshSightings is exercised
+ * against the shipped code, not a hand-copied mirror.
  *
  * Called by: npx vitest run
- * Depends on: vitest, jsdom
+ * Depends on: vitest, jsdom, app/static/htmx_app.js
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// Mirror of the rfqVendorModal() factory's pure logic (network calls stubbed out so
-// we can exercise the guards and serialisation without Alpine/htmx/fetch).
-function createRfqVendorModal(suggestedNames: string[], requirementIds: number[]) {
-  return {
-    step: 'compose',
-    // Plain reactive object keyed by vendor name (mirrors the factory + sightingSelection store).
-    selectedVendors: Object.fromEntries((suggestedNames || []).map((n) => [n, true])) as Record<string, boolean>,
-    requirementIds: requirementIds || [],
-    emailBody: '',
-    previewing: false,
-    sending: false,
-    // test-only spies
-    $store: { toast: { message: '', type: 'info', show: false } },
-    _previewCalled: false,
-    _sendCalled: false,
+let registry: Record<string, any> = {};
 
-    get selectedCount() {
-      return Object.keys(this.selectedVendors).length;
-    },
-    isSelected(name: string) {
-      return !!this.selectedVendors[name];
-    },
-    toggleVendor(name: string) {
-      if (this.selectedVendors[name]) delete this.selectedVendors[name];
-      else this.selectedVendors[name] = true;
-    },
+// Mock htmx and all Alpine plugins so htmx_app.js imports cleanly in jsdom.
+vi.mock('htmx.org', () => ({
+  default: {
+    on: vi.fn(), off: vi.fn(), ajax: vi.fn(), process: vi.fn(),
+    defineExtension: vi.fn(), createExtension: vi.fn(), config: {},
+  },
+}));
 
-    _form(): FormData {
-      const form = new FormData();
-      this.requirementIds.forEach((id) => form.append('requirement_ids', String(id)));
-      Object.keys(this.selectedVendors).forEach((v) => form.append('vendor_names', v));
-      form.append('email_body', this.emailBody);
-      return form;
-    },
+const alpineMock = {
+  data: (n: string, f: any) => { registry[n] = f; },
+  store: vi.fn(),
+  plugin: vi.fn(), start: vi.fn(), directive: vi.fn(), magic: vi.fn(),
+};
 
-    _toast(message: string, type: string) {
-      this.$store.toast.message = message;
-      this.$store.toast.type = type;
-      this.$store.toast.show = true;
-    },
+vi.mock('alpinejs', () => ({ default: alpineMock }));
+vi.mock('@alpinejs/focus', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/persist', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/intersect', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/collapse', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/morph', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/mask', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/sort', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/anchor', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/resize', () => ({ default: vi.fn() }));
+vi.mock('htmx-ext-alpine-morph', () => ({}));
+vi.mock('htmx-ext-response-targets', () => ({}));
+vi.mock('htmx-ext-sse', () => ({}));
+vi.mock('htmx-ext-json-enc', () => ({}));
+vi.mock('htmx-ext-preload', () => ({}));
+vi.mock('htmx-ext-loading-states', () => ({}));
+vi.mock('htmx-ext-path-deps', () => ({}));
+vi.mock('htmx-ext-remove-me', () => ({}));
 
-    _sendOutcome(sent: number, total: number) {
-      if (sent === 0) {
-        return { type: 'error', delivered: false, message: 'Send failed — no RFQs were delivered' };
-      }
-      if (sent < total) {
-        return {
-          type: 'warning',
-          delivered: true,
-          message: 'Sent to ' + sent + ' of ' + total + ' vendors — ' + (total - sent) + ' failed',
-        };
-      }
-      return {
-        type: 'success',
-        delivered: true,
-        message: 'RFQ sent to ' + sent + ' vendor' + (sent === 1 ? '' : 's'),
-      };
-    },
+import htmx from 'htmx.org';
 
-    loadPreview() {
-      if (this.selectedCount === 0 || !this.emailBody || this.previewing) return;
-      this._previewCalled = true;
-    },
-
-    confirmSend() {
-      if (this.selectedCount === 0 || !this.emailBody || this.sending) return;
-      this._sendCalled = true;
-    },
-  };
+// Build a real factory instance with the Alpine magics ($store/$dispatch/$refs) injected.
+function makeModal(names: string[], ids: number[]) {
+  const inst = registry['rfqVendorModal'](names, ids);
+  inst.$store = { toast: { message: '', type: 'info', show: false } };
+  inst.$dispatch = vi.fn();
+  inst.$refs = { previewContent: document.createElement('div') };
+  return inst;
 }
 
-describe('rfqVendorModal', () => {
-  let m: ReturnType<typeof createRfqVendorModal>;
+function fetchResponse(sent: string | null, total: string | null, ok = true, status = 200) {
+  const h: Record<string, string | null> = { 'X-RFQ-Sent': sent, 'X-RFQ-Total': total };
+  return { ok, status, headers: { get: (k: string) => h[k] ?? null } };
+}
 
-  beforeEach(() => {
-    m = createRfqVendorModal(['arrow electronics', 'mouser'], [10, 11]);
-  });
+beforeEach(async () => {
+  registry = {};
+  alpineMock.data = (n: string, f: any) => { registry[n] = f; };
+  alpineMock.store.mockReset();
+  (htmx.ajax as any).mockReset();
+  (htmx.ajax as any).mockResolvedValue(undefined);
+  document.body.innerHTML = '';
+  document.cookie = 'csrftoken=testtoken';
+  vi.stubGlobal('fetch', vi.fn());
+  vi.resetModules();
+  await import('../../app/static/htmx_app.js');
+});
 
-  describe('initial state', () => {
-    it('seeds selectedVendors from the pre-selected names', () => {
+describe('rfqVendorModal (real factory)', () => {
+  describe('initial state + selection', () => {
+    it('seeds selectedVendors from the names and exposes selectedCount/isSelected', () => {
+      const m = makeModal(['arrow electronics', 'mouser'], [10, 11]);
       expect(m.selectedCount).toBe(2);
       expect(m.isSelected('arrow electronics')).toBe(true);
-      expect(m.isSelected('mouser')).toBe(true);
-    });
-
-    it('seeds an empty selection when no names are provided', () => {
-      const empty = createRfqVendorModal([], []);
-      expect(empty.selectedCount).toBe(0);
-    });
-
-    it('starts on the compose step', () => {
       expect(m.step).toBe('compose');
     });
-  });
 
-  describe('toggleVendor', () => {
-    it('removes a vendor that is selected', () => {
+    it('toggleVendor adds and removes', () => {
+      const m = makeModal(['mouser'], [1]);
       m.toggleVendor('mouser');
       expect(m.isSelected('mouser')).toBe(false);
-      expect(m.selectedCount).toBe(1);
-    });
-
-    it('adds a vendor that is not selected', () => {
       m.toggleVendor('digikey');
+      expect(m.selectedCount).toBe(1);
       expect(m.isSelected('digikey')).toBe(true);
-      expect(m.selectedCount).toBe(3);
     });
   });
 
-  describe('_form serialisation', () => {
-    it('emits a repeated key for every requirement id', () => {
+  describe('_form serialisation (repeated keys, no Object.fromEntries collapse)', () => {
+    it('emits repeated requirement_ids and vendor_names', () => {
+      const m = makeModal(['arrow electronics', 'mouser'], [10, 11]);
       m.emailBody = 'hi';
       const form = m._form();
       expect(form.getAll('requirement_ids')).toEqual(['10', '11']);
-    });
-
-    it('emits a repeated key for every selected vendor (no duplicate-key collapse)', () => {
-      m.emailBody = 'hi';
-      const form = m._form();
-      // The original Object.fromEntries(FormData) bug would have dropped all but one.
       expect(form.getAll('vendor_names').sort()).toEqual(['arrow electronics', 'mouser']);
+      expect(form.get('email_body')).toBe('hi');
     });
+  });
 
-    it('reflects toggles in the serialised vendor list', () => {
-      m.toggleVendor('mouser'); // remove
-      m.toggleVendor('digikey'); // add
-      const form = m._form();
-      expect(form.getAll('vendor_names').sort()).toEqual(['arrow electronics', 'digikey']);
-    });
-
-    it('includes the email body', () => {
+  describe('confirmSend (real network branching)', () => {
+    it('full success → success toast, refresh, close', async () => {
+      const m = makeModal(['a', 'b'], [1]);
       m.emailBody = 'please quote';
-      expect(m._form().get('email_body')).toBe('please quote');
-    });
-  });
+      alpineMock.store.mockReturnValue({ selectedReqId: null });
+      (fetch as any).mockResolvedValue(fetchResponse('2', '2'));
 
-  describe('_toast', () => {
-    it('sets message/type/show directly (show is a boolean, not a method)', () => {
-      m._toast('RFQ sent to 2 vendors', 'success');
-      expect(m.$store.toast.message).toBe('RFQ sent to 2 vendors');
+      await m.confirmSend();
+
       expect(m.$store.toast.type).toBe('success');
-      expect(m.$store.toast.show).toBe(true);
+      expect(m.$store.toast.message).toBe('RFQ sent to 2 vendors');
+      expect(m.$dispatch).toHaveBeenCalledWith('close-modal');
+      expect(m.sending).toBe(false);
+    });
+
+    it('partial failure (1 of 2) → warning toast, still refresh + close', async () => {
+      const m = makeModal(['a', 'b'], [1]);
+      m.emailBody = 'q';
+      alpineMock.store.mockReturnValue({ selectedReqId: null });
+      (fetch as any).mockResolvedValue(fetchResponse('1', '2'));
+
+      await m.confirmSend();
+
+      expect(m.$store.toast.type).toBe('warning');
+      expect(m.$store.toast.message).toBe('Sent to 1 of 2 vendors — 1 failed');
+      expect(m.$dispatch).toHaveBeenCalledWith('close-modal');
+    });
+
+    it('nothing delivered (0 sent) → error toast, modal stays OPEN, no refresh', async () => {
+      const m = makeModal(['a', 'b'], [1]);
+      m.emailBody = 'q';
+      (fetch as any).mockResolvedValue(fetchResponse('0', '2'));
+
+      await m.confirmSend();
+
+      expect(m.$store.toast.type).toBe('error');
+      expect(m.$dispatch).not.toHaveBeenCalled();   // modal kept open to retry
+      expect(htmx.ajax).not.toHaveBeenCalled();      // no refresh
+      expect(m.sending).toBe(false);
+    });
+
+    it('network failure (fetch rejects) → error toast, sending reset', async () => {
+      const m = makeModal(['a'], [1]);
+      m.emailBody = 'q';
+      (fetch as any).mockRejectedValue(new Error('offline'));
+
+      await m.confirmSend();
+
+      expect(m.$store.toast.type).toBe('error');
+      expect(m.$store.toast.message).toBe('Send failed — please try again');
+      expect(m.$dispatch).not.toHaveBeenCalled();
+      expect(m.sending).toBe(false);
+    });
+
+    it('non-2xx → error toast (does not infer success)', async () => {
+      const m = makeModal(['a'], [1]);
+      m.emailBody = 'q';
+      (fetch as any).mockResolvedValue(fetchResponse('1', '1', false, 500));
+
+      await m.confirmSend();
+
+      expect(m.$store.toast.type).toBe('error');
+      expect(m.$dispatch).not.toHaveBeenCalled();
+    });
+
+    it('guards: no-op when nothing selected or body empty', async () => {
+      const empty = makeModal([], [1]);
+      empty.emailBody = 'q';
+      await empty.confirmSend();
+      const noBody = makeModal(['a'], [1]);
+      await noBody.confirmSend();
+      expect(fetch).not.toHaveBeenCalled();
     });
   });
 
-  describe('_sendOutcome (true outcome from server X-RFQ-* counts)', () => {
-    it('reports full success when all vendors were sent', () => {
-      const o = m._sendOutcome(3, 3);
-      expect(o.type).toBe('success');
-      expect(o.delivered).toBe(true);
-      expect(o.message).toBe('RFQ sent to 3 vendors');
+  describe('loadPreview (real)', () => {
+    it('success → step becomes preview', async () => {
+      const m = makeModal(['a'], [1]);
+      m.emailBody = 'q';
+      (htmx.ajax as any).mockResolvedValue(undefined);
+      await m.loadPreview();
+      expect(m.step).toBe('preview');
+      expect(htmx.ajax).toHaveBeenCalled();
     });
 
-    it('uses singular wording for one vendor', () => {
+    it('failure → error toast, stays on compose', async () => {
+      const m = makeModal(['a'], [1]);
+      m.emailBody = 'q';
+      (htmx.ajax as any).mockRejectedValue(new Error('500'));
+      await m.loadPreview();
+      expect(m.step).toBe('compose');
+      expect(m.$store.toast.type).toBe('error');
+      expect(m.previewing).toBe(false);
+    });
+  });
+
+  describe('_refreshSightings targeting', () => {
+    it('refreshes the open detail panel when a requirement is selected', () => {
+      const m = makeModal(['a'], [5]);
+      alpineMock.store.mockReturnValue({ selectedReqId: 5 });
+      m._refreshSightings();
+      const detailCall = (htmx.ajax as any).mock.calls.find((c: any[]) => c[2]?.target === '#sightings-detail');
+      expect(detailCall).toBeTruthy();
+      expect(detailCall[1]).toContain('/v2/partials/sightings/5/detail');
+    });
+
+    it('refreshes the requirements table when present', () => {
+      const m = makeModal(['a'], [5]);
+      alpineMock.store.mockReturnValue({ selectedReqId: null });
+      const table = document.createElement('div');
+      table.id = 'sightings-table';
+      table.setAttribute('hx-get', '/v2/partials/sightings');
+      document.body.appendChild(table);
+      m._refreshSightings();
+      const tableCall = (htmx.ajax as any).mock.calls.find((c: any[]) => c[2]?.target === '#sightings-table');
+      expect(tableCall).toBeTruthy();
+      expect(tableCall[1]).toBe('/v2/partials/sightings');
+    });
+
+    it('does nothing when neither a selected req nor a table is present', () => {
+      const m = makeModal(['a'], [5]);
+      alpineMock.store.mockReturnValue({ selectedReqId: null });
+      m._refreshSightings();
+      expect(htmx.ajax).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('_sendOutcome mapping', () => {
+    it('maps full / partial / zero correctly', () => {
+      const m = makeModal(['a'], [1]);
+      expect(m._sendOutcome(3, 3)).toMatchObject({ type: 'success', delivered: true });
       expect(m._sendOutcome(1, 1).message).toBe('RFQ sent to 1 vendor');
-    });
-
-    it('warns on a PARTIAL failure (the route still returns HTTP 200)', () => {
-      const o = m._sendOutcome(1, 3);
-      expect(o.type).toBe('warning');
-      expect(o.delivered).toBe(true);
-      expect(o.message).toBe('Sent to 1 of 3 vendors — 2 failed');
-    });
-
-    it('errors and keeps the modal open when NOTHING was delivered', () => {
-      const o = m._sendOutcome(0, 3);
-      expect(o.type).toBe('error');
-      expect(o.delivered).toBe(false);
-      expect(o.message).toBe('Send failed — no RFQs were delivered');
-    });
-  });
-
-  describe('guards', () => {
-    it('confirmSend is a no-op with no vendors selected', () => {
-      const empty = createRfqVendorModal([], [10]);
-      empty.emailBody = 'hi';
-      empty.confirmSend();
-      expect(empty._sendCalled).toBe(false);
-    });
-
-    it('confirmSend is a no-op with an empty body', () => {
-      m.confirmSend();
-      expect(m._sendCalled).toBe(false);
-    });
-
-    it('confirmSend proceeds with vendors + body', () => {
-      m.emailBody = 'hi';
-      m.confirmSend();
-      expect(m._sendCalled).toBe(true);
-    });
-
-    it('loadPreview is a no-op with an empty body', () => {
-      m.loadPreview();
-      expect(m._previewCalled).toBe(false);
-    });
-
-    it('loadPreview proceeds with vendors + body', () => {
-      m.emailBody = 'hi';
-      m.loadPreview();
-      expect(m._previewCalled).toBe(true);
+      expect(m._sendOutcome(1, 3)).toMatchObject({ type: 'warning', delivered: true });
+      expect(m._sendOutcome(0, 3)).toMatchObject({ type: 'error', delivered: false });
     });
   });
 });

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -436,8 +436,9 @@ class TestSightingsSendInquiryResultHeaders:
         _, r, _ = _seed_data(db_session)
 
         async def fake_send(**kwargs):
-            # One result per vendor group => all sent.
-            return [{"vendor": g} for g in kwargs["vendor_groups"]]
+            # Real send_batch_rfq returns one record per attempted vendor tagged with a
+            # status; all "sent" here.
+            return [{"vendor_name": g["vendor_name"], "status": "sent"} for g in kwargs["vendor_groups"]]
 
         monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
         resp = self._post(client, r)
@@ -449,12 +450,19 @@ class TestSightingsSendInquiryResultHeaders:
         _, r, _ = _seed_data(db_session)
 
         async def fake_send(**kwargs):
-            return [{"vendor": kwargs["vendor_groups"][0]}]  # only 1 of 2 delivered
+            # Mirror the real contract: one record per vendor, the second tagged "failed"
+            # (NOT a shorter list — that never happens in production and would hide the
+            # len(results) over-count bug).
+            groups = kwargs["vendor_groups"]
+            return [
+                {"vendor_name": groups[0]["vendor_name"], "status": "sent"},
+                {"vendor_name": groups[1]["vendor_name"], "status": "failed"},
+            ]
 
         monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
         resp = self._post(client, r)
         assert resp.status_code == 200
-        assert resp.headers["X-RFQ-Sent"] == "1"
+        assert resp.headers["X-RFQ-Sent"] == "1"  # only the "sent" record counts
         assert resp.headers["X-RFQ-Total"] == "2"
 
     def test_total_failure_still_200_with_headers(self, client, db_session, monkeypatch):

--- a/tests/test_sightings_router_coverage3.py
+++ b/tests/test_sightings_router_coverage3.py
@@ -649,7 +649,9 @@ class TestSendInquiryCoverage:
     def test_send_single_vendor_singular_message(self, client: TestClient, req_item):
         """Line 1236: sent_count==1 → 'vendor' (not 'vendors') in message."""
         _, item = req_item
-        with patch("app.email_service.send_batch_rfq", new=AsyncMock(return_value=[{}])):
+        # Realistic send_batch_rfq result: one record tagged "sent" (sent_count counts
+        # status=="sent", not list length).
+        with patch("app.email_service.send_batch_rfq", new=AsyncMock(return_value=[{"status": "sent"}])):
             with patch("app.services.sourcing_auto_progress.auto_progress_status", return_value=False):
                 resp = client.post(
                     "/v2/partials/sightings/send-inquiry",


### PR DESCRIPTION
Post-merge review of #207/#208 found the `X-RFQ-Sent` header (and the modal's success toast) could still report a **false success on a partial send failure**: `sent_count` was `len(results)`, but `send_batch_rfq` returns one record per *attempted* vendor — including per-vendor failures tagged `status="failed"`. So 1-of-2 delivered still reported "RFQ sent to 2 vendors".

- **sightings.py**: `sent_count = sum(1 for r in results if r.get("status") == "sent")`; hoist `X-RFQ-Sent`/`X-RFQ-Total` to module constants.
- **tests**: partial/full-success header mocks now return realistic `{vendor_name, status}` records (the old short-list mock structurally hid the over-count); coverage3 singular-message mock tagged `"sent"`.
- **htmx_app.js**: `_refreshSightings` GETs now `.catch` → warn instead of leaving a silently stale panel on a refresh error.
- **rfq-vendor-modal.test.ts**: rewritten to drive the **real** factory (import + Alpine-registry capture) — `confirmSend` (success/partial/zero-delivered/network-fail/non-2xx), `loadPreview`, and `_refreshSightings` targeting are now genuinely tested.

Full suite green (14581 passed). Addresses the CRITICAL/HIGH/MEDIUM findings from the 7-agent review of #207/#208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)