### PR TITLE
fix(materials): faceted list never loaded — hx-vals js: must be an object literal

### DIFF
--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -229,28 +229,27 @@
     <div id="materials-results-spinner" class="htmx-indicator px-4 py-2 text-xs text-gray-400">Loading materials…</div>
 
     {# Results container #}
+    {# hx-vals js: MUST be an object-literal expression. htmx wraps any value not starting
+       with "{" in {…} (htmx.js getValuesForElement), so an IIFE becomes invalid
+       `{(function(){…})()}` → Function() throws → the request silently never fires (the
+       results spinner hangs forever). Keep it a pure object literal, inlining the workspace
+       lookups, exactly like the sub-filters container above. #}
     <div id="materials-results"
          hx-target="this"
          hx-get="/v2/partials/materials/faceted"
          hx-trigger="load, filters-changed from:body"
          hx-indicator="#materials-results-spinner"
-         hx-vals='js:(function(){
-           var ws = document.querySelector("#materials-workspace");
-           var statusList = Alpine.evaluate(ws, "statuses") || [];
-           var lifecycleList = Alpine.evaluate(ws, "lifecycle") || [];
-           var rohsList = Alpine.evaluate(ws, "rohs") || [];
-           return {
-             "commodity": Alpine.evaluate(ws, "commodity") || "",
-             "q": Alpine.evaluate(ws, "q") || "",
-             "sub_filters": JSON.stringify(Alpine.evaluate(ws, "subFilters") || {}),
-             "statuses": statusList.join(","),
-             "lifecycle": lifecycleList.join(","),
-             "rohs": rohsList.join(","),
-             "has_datasheet": Alpine.evaluate(ws, "hasDatasheet") || false,
-             "limit": 50,
-             "offset": Alpine.evaluate(ws, "page") * 50 || 0
-           };
-         })()'
+         hx-vals='js:{
+           "commodity": Alpine.evaluate(document.querySelector("#materials-workspace"), "commodity") || "",
+           "q": Alpine.evaluate(document.querySelector("#materials-workspace"), "q") || "",
+           "sub_filters": JSON.stringify(Alpine.evaluate(document.querySelector("#materials-workspace"), "subFilters") || {}),
+           "statuses": (Alpine.evaluate(document.querySelector("#materials-workspace"), "statuses") || []).join(","),
+           "lifecycle": (Alpine.evaluate(document.querySelector("#materials-workspace"), "lifecycle") || []).join(","),
+           "rohs": (Alpine.evaluate(document.querySelector("#materials-workspace"), "rohs") || []).join(","),
+           "has_datasheet": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasDatasheet") || false,
+           "limit": 50,
+           "offset": (Alpine.evaluate(document.querySelector("#materials-workspace"), "page") || 0) * 50
+         }'
          hx-swap="innerHTML"
          hx-sync="this:replace">
       {# Skeleton loading #}

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -158,6 +158,34 @@ def test_no_tojson_in_double_quoted_alpine_attribute():
     )
 
 
+_HX_VALS_JS = re.compile(r"""hx-vals\s*=\s*(['"])js:(.*?)\1""", re.DOTALL)
+
+
+def test_hx_vals_js_is_object_literal():
+    """`hx-vals="js:..."` MUST be a plain object literal (start with `{`).
+
+    htmx wraps any js: expression that does not start with `{` in `{...}`
+    (getValuesForElement), so an IIFE or function call — `js:(function(){...})()`,
+    `js:buildVals()` — becomes invalid `{(function(){...})()}`; `Function()` throws and
+    htmx SILENTLY aborts the request (it never fires, the indicator hangs forever). This
+    is exactly how the materials faceted list stopped loading. Inline the lookups into an
+    object literal instead.
+    """
+    offenders: list[str] = []
+    for path in sorted(Path("app/templates").rglob("*.html")):
+        text = path.read_text()
+        for m in _HX_VALS_JS.finditer(text):
+            body = m.group(2).strip()
+            if not body.startswith("{"):
+                line = text[: m.start()].count("\n") + 1
+                offenders.append(f"{path.relative_to(Path('.'))}:{line}: got {body[:30]!r}")
+    assert not offenders, (
+        "hx-vals='js:...' must be an OBJECT LITERAL (start with '{'). htmx wraps a non-'{' "
+        "expression in {...}, turning an IIFE/function-call into invalid JS, so the request "
+        "silently never fires:\n" + "\n".join(offenders)
+    )
+
+
 def test_sightings_template_responses_set_rendered_req_id():
     """Every template_response() rendering a context-sensitive sightings partial must
     set the X-Rendered-Req-Id header so the client htmx:beforeSwap stale-response guard


### PR DESCRIPTION
**Symptom:** materials page — the part-number results list is stuck on the "Loading materials…" spinner forever; the left filter sidebar loads fine.

**Root cause:** `#materials-results` used an **IIFE** for its `hx-vals` (`js:(function(){...})()`). htmx wraps any `hx-vals js:` expression that doesn't start with `{` in `{...}` (`getValuesForElement`, htmx.js:3937), so the IIFE became invalid `{(function(){...})()}` → `Function()` throws → htmx **silently aborts** the request. So `GET /v2/partials/materials/faceted` never fired. The tree/manufacturers/global sidebars use the object form (`js:{...}`) and worked — which is exactly why only the part-number list hung. Shipped with the `materials-filter-tree` feature (not the recent sightings/tojson work).

**Diagnosis:** confirmed via live logs (on reload, `workspace`/`manufacturers`/`global`/`tree` all fire 200, `/faceted` never appears) and by reproducing htmx's transform in node (IIFE → `Unexpected token '('`; object form → OK).

**Fix:** convert `hx-vals` to a plain object literal (inline the `Alpine.evaluate(document.querySelector('#materials-workspace'), …)` lookups, matching the working sub-filters container). Add `test_hx_vals_js_is_object_literal` to fail CI on any future non-object `hx-vals js:`.

Backend was confirmed healthy throughout (1859 materials; `/faceted` renders 50 MPN rows for the default filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)