### PR TITLE
perf(deploy): drop --no-cache; per-deploy cache-bust keeps templates fresh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@ FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb836
 WORKDIR /build
 COPY package.json package-lock.json ./
 RUN npm ci
+# Per-deploy cache-bust: BUILD_COMMIT is unique each deploy and this RUN consumes it, so
+# every layer below (the source COPYs + the Vite build) ALWAYS re-runs with fresh
+# templates/static — fresh Tailwind CSS guaranteed — while `npm ci` above stays cached.
+# This is what lets deploy.sh build WITHOUT --no-cache (apt/pip/npm ci all cache) yet
+# never ship a stale template.
+ARG BUILD_COMMIT=unknown
+RUN echo "$BUILD_COMMIT" > /build/.build_commit
 COPY vite.config.js tailwind.config.js postcss.config.js ./
 COPY app/static/ app/static/
 COPY app/templates/ app/templates/

--- a/deploy.sh
+++ b/deploy.sh
@@ -68,13 +68,15 @@ if [ "$NO_COMMIT" = false ]; then
     fi
 fi
 
-# Step 2: Rebuild app with unique build arg to bust Docker cache
-# Note: Dockerfile Stage 1 runs npm build inside Docker, scanning
-# app/templates/ for Tailwind classes. --no-cache ensures fresh rebuild.
-# Append timestamp so --no-commit deploys also invalidate COPY layers
+# Step 2: Rebuild app with a unique BUILD_COMMIT each deploy.
+# No --no-cache: the Dockerfile consumes BUILD_COMMIT right before the source COPYs (in
+# BOTH stages), so the template/static COPYs + the Vite build + the app COPY ALWAYS
+# re-run with fresh content (fresh Tailwind CSS guaranteed), while the expensive,
+# input-pinned layers (apt, gh, pip, Chromium, `npm ci`) stay cached. ~4x faster deploys
+# with no stale-template risk. The unique timestamp also invalidates --no-commit deploys.
 BUILD_COMMIT="$(git rev-parse --short HEAD)-$(date +%s)"
 echo "==> Rebuilding app container (build tag: $BUILD_COMMIT)..."
-docker compose build --no-cache --build-arg BUILD_COMMIT="$BUILD_COMMIT" app
+docker compose build --build-arg BUILD_COMMIT="$BUILD_COMMIT" app
 
 # Step 3: Recreate only the app container with the new image
 # Clean up any orphaned rename containers from previous deploys


### PR DESCRIPTION
Drops `--no-cache` from `deploy.sh`. A `BUILD_COMMIT` cache-bust in the builder stage (consumed by a `RUN echo` right after `npm ci`, before the source COPYs) forces the template/static COPY + Vite build to re-run every deploy — fresh Tailwind CSS guaranteed (the reason `--no-cache` existed) — while `apt`/`gh`/`pip`/`Chromium`/`npm ci` (all input-pinned) now cache. ~4x faster deploys, no stale-template risk. Verified by deploying twice and confirming cached layers + fresh `npm run build` + template propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)