### PR TITLE
chore: harden #209/#210/#211 per 7-agent review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ change, update the relevant APP_MAP doc(s) in the same PR.**
 - **Quality > speed. Zero ambiguity in designs.** Resolve every decision in the spec; no TBDs, no "options A/B".
 - **Hosted CLI only.** No GUI, no screenshots, no desktop-dependent suggestions, no browser visual companion.
 - **Before pushing big PRs:** run `pre-commit run --all-files` (local git-hook scope is narrower than CI and bites otherwise).
-- **Deploy is `./deploy.sh` only** — uses `--no-cache` and `--force-recreate`. Bare `docker compose up -d --build` ships stale templates. After deploy, verify any new Tailwind classes actually appear in built CSS.
+- **Deploy is `./deploy.sh` only.** It passes a unique `--build-arg BUILD_COMMIT=<sha>-<ts>` that the Dockerfile consumes right before the source COPYs in BOTH stages, so templates/static/Vite always rebuild fresh while apt/pip/npm-ci cache (~30s deploys; PR #211 — no more `--no-cache`). Bare `docker compose up -d --build` (without that build-arg) ships stale templates. After deploy, verify any new Tailwind classes actually appear in built CSS.
 
 - Always write tests with any new code. Don't ask, just include them.
 - Give exact file paths for everything.
@@ -209,10 +209,13 @@ docker compose down               # Stop everything
 ./deploy.sh                       # From main: commit + push + rebuild + health-check + verify
 ./deploy.sh --no-commit           # Rebuild current branch without committing/pushing
 ```
-`deploy.sh` must run from `main` unless `--no-commit`. It builds with `--no-cache`,
+`deploy.sh` must run from `main` unless `--no-commit`. It builds with a unique
+`BUILD_COMMIT` build-arg (consumed before the source COPYs in both Dockerfile stages, so
+templates/static/Vite always rebuild fresh while apt/pip/npm-ci cache — no `--no-cache`),
 recreates only the `app` container, waits for the health check, verifies the deployed
 build tag, and checks that Tailwind classes in templates exist in the built CSS bundle.
-Never use bare `docker compose up -d --build` — it ships stale templates.
+Never use bare `docker compose up -d --build` (without `--build-arg BUILD_COMMIT=...`) —
+it ships stale templates.
 
 ### Python lint / type check
 ```bash

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1518,8 +1518,10 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
   // OPEN→SOURCING, new "RFQ sent" activity rows) and the requirements list. Refresh
   // whichever is on screen.
   _refreshSightings() {
-    // The send already succeeded; if a panel refresh fails, warn rather than silently
-    // leaving a stale status pill / requirements list on screen.
+    // Best-effort refresh of the open panel + list after a successful send. htmx.ajax
+    // rejects only on network/timeout/target errors (HTTP 4xx/5xx are surfaced by the
+    // global htmx:responseError toast registered above), so this .catch covers the
+    // connection-failure case with a clearer "you already sent" message.
     const onRefreshError = (err) => {
       console.error('[rfqVendorModal] post-send refresh failed', err);
       this._toast('Sent — refresh the page to see updated status', 'warning');

--- a/tests/frontend/rfq-vendor-modal.test.ts
+++ b/tests/frontend/rfq-vendor-modal.test.ts
@@ -44,7 +44,7 @@ vi.mock('htmx-ext-sse', () => ({}));
 vi.mock('htmx-ext-json-enc', () => ({}));
 vi.mock('htmx-ext-preload', () => ({}));
 vi.mock('htmx-ext-loading-states', () => ({}));
-vi.mock('htmx-ext-path-deps', () => ({}));
+vi.mock('htmx-ext-path-params', () => ({}));
 vi.mock('htmx-ext-remove-me', () => ({}));
 
 import htmx from 'htmx.org';
@@ -65,7 +65,6 @@ function fetchResponse(sent: string | null, total: string | null, ok = true, sta
 
 beforeEach(async () => {
   registry = {};
-  alpineMock.data = (n: string, f: any) => { registry[n] = f; };
   alpineMock.store.mockReset();
   (htmx.ajax as any).mockReset();
   (htmx.ajax as any).mockResolvedValue(undefined);
@@ -230,6 +229,17 @@ describe('rfqVendorModal (real factory)', () => {
       alpineMock.store.mockReturnValue({ selectedReqId: null });
       m._refreshSightings();
       expect(htmx.ajax).not.toHaveBeenCalled();
+    });
+
+    it('warns when a refresh htmx.ajax rejects (network/timeout)', async () => {
+      const m = makeModal(['a'], [5]);
+      alpineMock.store.mockReturnValue({ selectedReqId: 5 });
+      (htmx.ajax as any).mockRejectedValue(new Error('offline'));
+      m._refreshSightings();
+      await Promise.resolve();
+      await Promise.resolve(); // flush the .catch microtask
+      expect(m.$store.toast.type).toBe('warning');
+      expect(m.$store.toast.message).toContain('refresh the page');
     });
   });
 

--- a/tests/test_sightings_router_coverage3.py
+++ b/tests/test_sightings_router_coverage3.py
@@ -647,7 +647,7 @@ class TestSendInquiryCoverage:
         assert "Failed" in resp.text or "failed" in resp.text.lower()
 
     def test_send_single_vendor_singular_message(self, client: TestClient, req_item):
-        """Line 1236: sent_count==1 → 'vendor' (not 'vendors') in message."""
+        """sent_count==1 → singular 'vendor' (not 'vendors') in the success message."""
         _, item = req_item
         # Realistic send_batch_rfq result: one record tagged "sent" (sent_count counts
         # status=="sent", not list length).

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -175,7 +175,9 @@ def test_hx_vals_js_is_object_literal():
     for path in sorted(Path("app/templates").rglob("*.html")):
         text = path.read_text()
         for m in _HX_VALS_JS.finditer(text):
-            body = m.group(2).strip()
+            # Do NOT strip: htmx slices the `js:` prefix and checks indexOf('{') == 0 WITHOUT
+            # re-trimming, so `js: {...}` (a space/newline after the colon) breaks too.
+            body = m.group(2)
             if not body.startswith("{"):
                 line = text[: m.start()].count("\n") + 1
                 offenders.append(f"{path.relative_to(Path('.'))}:{line}: got {body[:30]!r}")
@@ -183,6 +185,40 @@ def test_hx_vals_js_is_object_literal():
         "hx-vals='js:...' must be an OBJECT LITERAL (start with '{'). htmx wraps a non-'{' "
         "expression in {...}, turning an IIFE/function-call into invalid JS, so the request "
         "silently never fires:\n" + "\n".join(offenders)
+    )
+
+
+def test_dockerfile_cache_bust_precedes_source_copies():
+    """deploy.sh dropped --no-cache (PR #211); template freshness now relies entirely on
+    a per-deploy BUILD_COMMIT cache-bust placed BEFORE the source COPYs in each
+    Dockerfile stage.
+
+    If a future edit moves a `COPY app/...` above the bust, that layer caches on
+    content alone and a deploy can SILENTLY ship stale templates (the build-tag check only
+    verifies the env var, not file content). Enforce the ordering mechanically.
+    """
+    lines = Path("Dockerfile").read_text().splitlines()
+
+    def first(pred) -> int:
+        return next((i for i, ln in enumerate(lines) if pred(ln)), -1)
+
+    # Builder stage: `RUN echo "$BUILD_COMMIT"` must precede the static/template COPYs.
+    builder_bust = first(lambda ln: 'echo "$BUILD_COMMIT"' in ln)
+    static_copy = first(lambda ln: ln.strip().startswith("COPY app/static"))
+    tmpl_copy = first(lambda ln: ln.strip().startswith("COPY app/templates"))
+    assert builder_bust != -1, (
+        'builder-stage BUILD_COMMIT cache-bust (RUN echo "$BUILD_COMMIT") is gone — without '
+        "--no-cache the Vite build can reuse a stale template layer."
+    )
+    assert builder_bust < static_copy, "COPY app/static must come AFTER the builder BUILD_COMMIT cache-bust"
+    assert builder_bust < tmpl_copy, "COPY app/templates must come AFTER the builder BUILD_COMMIT cache-bust"
+
+    # Stage 2: an `ARG BUILD_COMMIT` cache-bust must precede `COPY app/ app/`.
+    arg_idxs = [i for i, ln in enumerate(lines) if ln.strip().startswith("ARG BUILD_COMMIT")]
+    app_copy = first(lambda ln: ln.strip() == "COPY app/ app/")
+    assert arg_idxs and app_copy != -1, "ARG BUILD_COMMIT / COPY app/ app/ structure changed unexpectedly"
+    assert any(a < app_copy for a in arg_idxs), (
+        "COPY app/ app/ must come AFTER an ARG BUILD_COMMIT cache-bust (else stage-2 app code caches stale)"
     )
 
 


### PR DESCRIPTION
Hardening follow-ups from the post-merge review of #209/#210/#211 (no live bugs). Notably: CLAUDE.md no longer contradicts deploy.sh (#211 removed --no-cache); a new static guard enforces the Dockerfile BUILD_COMMIT-before-source-COPY ordering that template freshness now depends on; the hx-vals guard matches htmx's exact check; corrected the _refreshSightings comment; test hygiene fixes. Full suite green (14583).

🤖 Generated with [Claude Code](https://claude.com/claude-code)