### PR TITLE
fix(rfq): surface vendors with no contact email instead of silently dropping them

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -86,7 +86,9 @@ async def send_batch_rfq(
     """Send one RFQ email per vendor group.
 
     Each group: {vendor_name, vendor_email, parts, subject, body}.
-    Returns list of created Contact records as dicts.
+    Returns one result dict per requested vendor, each tagged ``status``:
+    ``"sent"``, ``"failed"`` (a send was attempted but errored), or ``"skipped"``
+    (no contact email on file — no email attempted, no Contact created).
     """
     from app.utils.graph_client import GraphClient
 
@@ -101,6 +103,21 @@ async def send_batch_rfq(
     for group in vendor_groups:
         email = group.get("vendor_email")
         if not email:
+            # Don't silently drop: a selected vendor with no contact email must be
+            # visible (logged + a "skipped" result record) so the caller can report it
+            # distinctly rather than miscounting it as a delivery failure.
+            logger.warning(
+                "RFQ skipped — no contact email on file for vendor '{}'",
+                group.get("vendor_name"),
+            )
+            results.append(
+                {
+                    "vendor_name": group.get("vendor_name"),
+                    "vendor_email": "",
+                    "status": "skipped",
+                    "error": "no contact email on file",
+                }
+            )
             continue
 
         html_body = _build_html_body(group["body"])

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -97,6 +97,7 @@ def _oob_toast(msg: str, level: str = "success") -> HTMLResponse:
 # count from these rather than inferring success from the status code.
 RFQ_SENT_HEADER = "X-RFQ-Sent"
 RFQ_TOTAL_HEADER = "X-RFQ-Total"
+RFQ_SKIPPED_HEADER = "X-RFQ-Skipped"  # vendors with no contact email (not a delivery failure)
 
 
 def _render_offers_panel(request: Request, requirement: Requirement, db: Session) -> HTMLResponse:
@@ -1288,7 +1289,8 @@ async def sightings_send_inquiry(
 
     sent_count = 0
     progressed_count = 0
-    failed_vendors = []
+    failed_vendors: list[str] = []
+    no_email_vendors: list[str] = []
     try:
         from ..email_service import send_batch_rfq
 
@@ -1299,31 +1301,39 @@ async def sightings_send_inquiry(
             requisition_id=requisition_id,
             vendor_groups=vendor_groups,
         )
-        # Count only records the email service tagged "sent". send_batch_rfq returns one
-        # record per attempted vendor INCLUDING per-vendor failures (status="failed"), so
-        # len(results) would over-count and report a false success on a partial failure.
+        # send_batch_rfq returns one record per requested vendor tagged "sent" / "failed"
+        # / "skipped" (no contact email). A vendor is delivered only when status=="sent"
+        # — len(results) would over-count, and a "skipped" vendor is not a delivery
+        # failure (the user just needs to add an email), so surface the three distinctly.
         sent_count = sum(1 for r in results if r.get("status") == "sent")
+        sent_vendors = {r.get("vendor_name") for r in results if r.get("status") == "sent"}
+        failed_vendors = [r.get("vendor_name", "") for r in results if r.get("status") == "failed"]
+        no_email_vendors = [r.get("vendor_name", "") for r in results if r.get("status") == "skipped"]
 
+        # Log "RFQ sent" activity only for vendors actually reached.
         for r in requirements:
             for vn in vendor_names:
-                log_rfq_activity(
-                    db=db,
-                    rfq_id=r.requisition_id,
-                    activity_type="rfq_sent",
-                    description=f"RFQ sent to {vn}",
-                    user_id=user.id,
-                    requirement_id=r.id,
-                )
+                if vn in sent_vendors:
+                    log_rfq_activity(
+                        db=db,
+                        rfq_id=r.requisition_id,
+                        activity_type="rfq_sent",
+                        description=f"RFQ sent to {vn}",
+                        user_id=user.id,
+                        requirement_id=r.id,
+                    )
 
-        # Auto-progress sourcing status OPEN → SOURCING on successful send
-        from ..services.sourcing_auto_progress import auto_progress_status
+        # Auto-progress sourcing status OPEN → SOURCING only once at least one RFQ went out.
+        if sent_vendors:
+            from ..services.sourcing_auto_progress import auto_progress_status
 
-        for r in requirements:
-            if auto_progress_status(r, SourcingStatus.SOURCING, db, user.id):
-                progressed_count += 1
+            for r in requirements:
+                if auto_progress_status(r, SourcingStatus.SOURCING, db, user.id):
+                    progressed_count += 1
     except Exception:
         logger.warning("RFQ send failed", exc_info=True)
-        failed_vendors = vendor_names
+        failed_vendors = list(vendor_names)
+        sent_count = 0
 
     db.commit()
 
@@ -1332,20 +1342,29 @@ async def sightings_send_inquiry(
         await _publish_if_user_source(source, user.id, r.id)
 
     total = len(vendor_names)
-    if failed_vendors:
-        msg = f"Sent to {sent_count}/{total} vendors. Failed: {', '.join(failed_vendors)}."
-    else:
+    if sent_count >= total:
         msg = f"RFQ sent to {sent_count} vendor{'s' if sent_count != 1 else ''}."
         if progressed_count:
             msg += f" {progressed_count} requirement{'s' if progressed_count != 1 else ''} advanced to sourcing."
+        level = "success"
+    else:
+        bits = [f"Sent to {sent_count}/{total} vendors."]
+        if failed_vendors:
+            bits.append(f"Failed: {', '.join(v for v in failed_vendors if v)}.")
+        if no_email_vendors:
+            bits.append(f"No email on file: {', '.join(v for v in no_email_vendors if v)}.")
+        msg = " ".join(bits)
+        level = "warning"
 
     # Machine-readable result so the browser caller (rfqVendorModal.confirmSend) can
-    # report the TRUE outcome: this route intentionally returns 200 even on a partial
-    # or total send failure (the failures are captured above, not raised), so the
-    # client must not infer success from the HTTP status alone.
-    resp = _oob_toast(msg, "warning" if failed_vendors else "success")
+    # report the TRUE outcome: this route intentionally returns 200 even on a partial /
+    # total failure (failures are captured above, not raised), so the client must not
+    # infer success from the HTTP status. X-RFQ-Skipped counts no-email vendors so the
+    # client can distinguish "had no email" from "send failed".
+    resp = _oob_toast(msg, level)
     resp.headers[RFQ_SENT_HEADER] = str(sent_count)
     resp.headers[RFQ_TOTAL_HEADER] = str(total)
+    resp.headers[RFQ_SKIPPED_HEADER] = str(len(no_email_vendors))
     return resp
 
 

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1481,7 +1481,8 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
       // outcome from the X-RFQ-* headers rather than assuming success.
       const sent = parseInt(resp.headers.get('X-RFQ-Sent') || '0', 10);
       const total = parseInt(resp.headers.get('X-RFQ-Total') || String(count), 10);
-      const outcome = this._sendOutcome(sent, total);
+      const skipped = parseInt(resp.headers.get('X-RFQ-Skipped') || '0', 10);
+      const outcome = this._sendOutcome(sent, total, skipped);
       this._toast(outcome.message, outcome.type);
       if (!outcome.delivered) return; // nothing sent — keep the modal open to retry
       this._refreshSightings();
@@ -1494,17 +1495,22 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
     }
   },
 
-  // Map the server's sent/total counts to a toast. `delivered` is false only when
-  // nothing went out, so the caller can keep the modal open for a retry.
-  _sendOutcome(sent, total) {
+  // Map the server's sent/total/skipped counts to a toast. `delivered` is false only when
+  // nothing went out, so the caller can keep the modal open for a retry. `skipped` =
+  // vendors with no contact email — reported distinctly from send failures.
+  _sendOutcome(sent, total, skipped = 0) {
     if (sent === 0) {
       return { type: 'error', delivered: false, message: 'Send failed — no RFQs were delivered' };
     }
     if (sent < total) {
+      const failed = total - sent - skipped;
+      const reasons = [];
+      if (failed > 0) reasons.push(failed + ' failed');
+      if (skipped > 0) reasons.push(skipped + ' had no email');
       return {
         type: 'warning',
         delivered: true,
-        message: 'Sent to ' + sent + ' of ' + total + ' vendors — ' + (total - sent) + ' failed',
+        message: 'Sent to ' + sent + ' of ' + total + ' vendors' + (reasons.length ? ' — ' + reasons.join(', ') : ''),
       };
     }
     return {

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1340,10 +1340,14 @@ OPEN→SOURCING + new activity rows) and the `#sightings-table` list, and dispat
 `vendor_names` keys (not `Object.fromEntries`, which collapses duplicates).
 
 The route returns **HTTP 200 even on partial/total send failure** (failures are
-captured, not raised) and exposes the true outcome via `X-RFQ-Sent` / `X-RFQ-Total`
-response headers. `confirmSend` reads them and toasts via `$store.toast`: full
-success, partial-failure (warning), or total-failure (error — modal stays open to
-retry); it never infers success from the HTTP status alone.
+captured, not raised) and exposes the true outcome via `X-RFQ-Sent` / `X-RFQ-Total` /
+`X-RFQ-Skipped` response headers. `send_batch_rfq` tags each result `sent` / `failed` /
+`skipped` (no contact email — logged, not silently dropped); the route counts only
+`sent`, names `failed` vs "No email on file" vendors distinctly in the toast, and logs
+activity + auto-advances status only for actually-sent vendors. `confirmSend` reads the
+headers and toasts via `$store.toast`: full success, partial (warning, distinguishing
+"N failed" from "N had no email"), or total failure (error — modal stays open to retry);
+it never infers success from the HTTP status alone.
 
 ---
 

--- a/tests/frontend/rfq-vendor-modal.test.ts
+++ b/tests/frontend/rfq-vendor-modal.test.ts
@@ -251,5 +251,15 @@ describe('rfqVendorModal (real factory)', () => {
       expect(m._sendOutcome(1, 3)).toMatchObject({ type: 'warning', delivered: true });
       expect(m._sendOutcome(0, 3)).toMatchObject({ type: 'error', delivered: false });
     });
+
+    it('distinguishes no-email (skipped) from failed in the partial message', () => {
+      const m = makeModal(['a'], [1]);
+      // 1 sent of 3: 2 skipped (no email), 0 failed
+      expect(m._sendOutcome(1, 3, 2).message).toBe('Sent to 1 of 3 vendors — 2 had no email');
+      // 1 sent of 3: 1 skipped + 1 failed
+      expect(m._sendOutcome(1, 3, 1).message).toBe('Sent to 1 of 3 vendors — 1 failed, 1 had no email');
+      // 1 sent of 3: 0 skipped, 2 failed (default skipped=0)
+      expect(m._sendOutcome(1, 3).message).toBe('Sent to 1 of 3 vendors — 2 failed');
+    });
   });
 });

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -566,7 +566,11 @@ class TestSendBatchRfq:
                 vendor_groups=vendor_groups,
             )
 
-        assert len(results) == 0
+        # Email-less vendors are recorded as "skipped" (not silently dropped), and no send
+        # is attempted for them.
+        assert len(results) == 2
+        assert all(r["status"] == "skipped" for r in results)
+        assert all("no contact email" in r["error"] for r in results)
         mock_gc.post_json.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/test_sightings_batch_ops_coverage.py
+++ b/tests/test_sightings_batch_ops_coverage.py
@@ -781,7 +781,7 @@ def test_send_inquiry_broker_publish_per_requirement(client, db_session, test_us
         with patch(
             "app.email_service.send_batch_rfq",
             new_callable=AsyncMock,
-            return_value=[{"vendor_name": "Arrow", "sent": True}],
+            return_value=[{"vendor_name": "Arrow", "status": "sent"}],
         ):
             resp = client.post(
                 "/v2/partials/sightings/send-inquiry",
@@ -810,7 +810,7 @@ def test_send_inquiry_auto_progress_increments_count(client, db_session, test_us
         with patch(
             "app.email_service.send_batch_rfq",
             new_callable=AsyncMock,
-            return_value=[{"vendor_name": "Arrow", "sent": True}],
+            return_value=[{"vendor_name": "Arrow", "status": "sent"}],
         ):
             resp = client.post(
                 "/v2/partials/sightings/send-inquiry",
@@ -841,7 +841,7 @@ def test_send_inquiry_success_toast_with_progressed_count(client, db_session, te
         with patch(
             "app.email_service.send_batch_rfq",
             new_callable=AsyncMock,
-            return_value=[{"vendor_name": "Arrow", "sent": True}],
+            return_value=[{"vendor_name": "Arrow", "status": "sent"}],
         ):
             with patch(
                 "app.services.sourcing_auto_progress.auto_progress_status",

--- a/tests/test_sightings_coverage.py
+++ b/tests/test_sightings_coverage.py
@@ -505,7 +505,10 @@ class TestSendInquiryEndpoint:
     def test_send_inquiry_logs_rfq_activity(self, client, db_session):
         """Send-inquiry logs rfq_sent activity for each requirement+vendor."""
         req, r, _ = _seed_active(db_session)
-        with patch("app.email_service.send_batch_rfq", new=AsyncMock(return_value=[{"ok": True}])):
+        with patch(
+            "app.email_service.send_batch_rfq",
+            new=AsyncMock(return_value=[{"vendor_name": "Cover Vendor", "status": "sent"}]),
+        ):
             resp = client.post(
                 "/v2/partials/sightings/send-inquiry",
                 data={

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -477,6 +477,28 @@ class TestSightingsSendInquiryResultHeaders:
         assert resp.headers["X-RFQ-Sent"] == "0"
         assert resp.headers["X-RFQ-Total"] == "2"
 
+    def test_skipped_no_email_reported_distinctly(self, client, db_session, monkeypatch):
+        """A vendor with no contact email is 'skipped' — counted in X-RFQ-Skipped and
+        named in the toast as 'No email on file', NOT folded into a delivery-failure
+        count."""
+        _, r, _ = _seed_data(db_session)
+
+        async def fake_send(**kwargs):
+            groups = kwargs["vendor_groups"]
+            return [
+                {"vendor_name": groups[0]["vendor_name"], "status": "sent"},
+                {"vendor_name": groups[1]["vendor_name"], "status": "skipped", "error": "no contact email on file"},
+            ]
+
+        monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
+        resp = self._post(client, r)
+        assert resp.status_code == 200
+        assert resp.headers["X-RFQ-Sent"] == "1"
+        assert resp.headers["X-RFQ-Total"] == "2"
+        assert resp.headers["X-RFQ-Skipped"] == "1"
+        assert "No email on file" in resp.text  # distinguished from "Failed:"
+        assert "Globex" in resp.text  # the skipped vendor is named
+
 
 class TestDashboardCounters:
     """Phase 2: Smart Priority Dashboard Strip counters in sightings_list context."""

--- a/tests/test_sightings_router_coverage2.py
+++ b/tests/test_sightings_router_coverage2.py
@@ -400,7 +400,10 @@ class TestSendInquiry:
 
     def test_send_rfq_auto_progress(self, client: TestClient, req_with_item: tuple):
         _, item = req_with_item
-        with patch("app.email_service.send_batch_rfq", new=AsyncMock(return_value=[{"vendor": "Arrow"}])):
+        with patch(
+            "app.email_service.send_batch_rfq",
+            new=AsyncMock(return_value=[{"vendor_name": "Arrow Electronics", "status": "sent"}]),
+        ):
             with patch("app.services.sourcing_auto_progress.auto_progress_status", return_value=True):
                 resp = client.post(
                     "/v2/partials/sightings/send-inquiry",

--- a/tests/test_sightings_router_coverage3.py
+++ b/tests/test_sightings_router_coverage3.py
@@ -595,7 +595,7 @@ class TestSendInquiryCoverage:
         db_session.add(contact)
         db_session.commit()
 
-        with patch("app.email_service.send_batch_rfq", new=AsyncMock(return_value=[{}])):
+        with patch("app.email_service.send_batch_rfq", new=AsyncMock(return_value=[{"status": "sent"}])):
             with patch("app.services.sourcing_auto_progress.auto_progress_status", return_value=False):
                 resp = client.post(
                     "/v2/partials/sightings/send-inquiry",
@@ -612,7 +612,10 @@ class TestSendInquiryCoverage:
     def test_send_with_auto_progress_multiple_reqs(self, client: TestClient, two_items):
         """Lines 1215-1217: auto_progress_status returns True for each req → progressed_count."""
         _, items = two_items
-        with patch("app.email_service.send_batch_rfq", new=AsyncMock(return_value=[{}])):
+        with patch(
+            "app.email_service.send_batch_rfq",
+            new=AsyncMock(return_value=[{"vendor_name": "Some Vendor", "status": "sent"}]),
+        ):
             with patch("app.services.sourcing_auto_progress.auto_progress_status", return_value=True):
                 resp = client.post(
                     "/v2/partials/sightings/send-inquiry",


### PR DESCRIPTION
Follow-up surfaced by the 7-agent review. `send_batch_rfq` silently `continue`d on email-less vendors — no log, no result record — so the modal miscounted them as a delivery failure. Now: log + a `status:"skipped"` record; new `X-RFQ-Skipped` header; toast distinguishes **"No email on file: VendorX"** from **"Failed: VendorY"**; activity log + status auto-advance gated on actually-sent vendors. Full suite green (14584).

🤖 Generated with [Claude Code](https://claude.com/claude-code)