### PR TITLE
fix(excess): solicit modal breaks on list titles with apostrophes/quotes

### DIFF
--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1552,4 +1552,36 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
   },
 }));
 
+// ── solicitModal: excess bid-solicitation email composer ──
+// Rendered by app/templates/htmx/partials/excess/solicit_modal.html. Only the subject is
+// dynamic (the list title); it's passed via a SINGLE-quoted x-data attribute through
+// |tojson, so a list title containing a quote/apostrophe can't terminate the attribute
+// and break Alpine init (the inline object previously used |e in a double-quoted x-data,
+// which broke on apostrophe titles).
+Alpine.data('solicitModal', (subject) => ({
+  recipientEmail: '',
+  recipientName: '',
+  subject: subject || 'Bid Request',
+  bundled: true,
+  message: 'We have the following parts available and are seeking your best bid. Please reply with unit price, quantity, and lead time.',
+  polishing: false,
+  async polishEmail() {
+    if (!this.message.trim()) return;
+    this.polishing = true;
+    try {
+      const res = await fetch('/api/excess-lists/polish-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: this.message }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        this.message = data.text;
+      }
+    } finally {
+      this.polishing = false;
+    }
+  },
+}));
+
 Alpine.start();

--- a/app/templates/htmx/partials/excess/solicit_modal.html
+++ b/app/templates/htmx/partials/excess/solicit_modal.html
@@ -3,32 +3,11 @@
    Called by: partial_solicit_form route (/v2/partials/excess/{list_id}/solicit-form).
    Depends on: modal shell (#modal-content), brand palette, Alpine.js, HTMX.
 #}
+{# subject (the only dynamic field) is passed via a SINGLE-quoted x-data through |tojson:
+   a list title containing a quote/apostrophe would close a double-quoted x-data and break
+   Alpine init. The component lives in the solicitModal() factory in app/static/htmx_app.js. #}
 <div class="p-6"
-     x-data="{
-       recipientEmail: '',
-       recipientName: '',
-       subject: '{{ ("Bid Request: " ~ list.title)|e if list else "Bid Request" }}',
-       bundled: true,
-       message: 'We have the following parts available and are seeking your best bid. Please reply with unit price, quantity, and lead time.',
-       polishing: false,
-       async polishEmail() {
-         if (!this.message.trim()) return;
-         this.polishing = true;
-         try {
-           const res = await fetch('/api/excess-lists/polish-email', {
-             method: 'POST',
-             headers: {'Content-Type': 'application/json'},
-             body: JSON.stringify({text: this.message})
-           });
-           if (res.ok) {
-             const data = await res.json();
-             this.message = data.text;
-           }
-         } finally {
-           this.polishing = false;
-         }
-       }
-     }">
+     x-data='solicitModal({{ (("Bid Request: " ~ list.title) if list else "Bid Request")|tojson }})'>
 
   {# ── Header ─────────────────────────────────────────────────────────── #}
   <div class="flex items-center justify-between mb-5">

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1349,6 +1349,22 @@ headers and toasts via `$store.toast`: full success, partial (warning, distingui
 "N failed" from "N had no email"), or total failure (error — modal stays open to retry);
 it never infers success from the HTTP status alone.
 
+### solicitModal  (htmx_app.js, Alpine.data)
+
+Backs `excess/solicit_modal.html` — the "Solicit Bids" email composer opened from an
+excess list. Only the email **subject** (derived from the list title) is dynamic, so the
+factory takes that one argument: `x-data='solicitModal({{ (("Bid Request: " ~ list.title)
+if list else "Bid Request")|tojson }})'`. It lives in JS (not inline) for the same reason
+as `rfqVendorModal`: the title may contain `'`/`"`, and the old inline **double-quoted**
+`x-data` interpolated it with `|e` — which HTML-escapes but emits an invalid JS string
+literal, so an apostrophe/quote title broke `Alpine.init()` and left the whole modal inert
+(spinner/"AI Clean Up" never un-cloaked, submit dead). The **single-quoted** `x-data` +
+`|tojson` is immune. State: `recipientEmail`, `recipientName`, `subject`, `bundled`
+(one bundled email vs one per item), `message`, `polishing`. Method: `polishEmail()` →
+`POST /api/excess-lists/polish-email` ({text} in, {text} out) replaces the body with an
+AI-cleaned version. The form itself posts via HTMX to
+`/v2/partials/excess/{list_id}/solicit` and closes the modal on success.
+
 ---
 
 ## 8x8 Integration — Operator Enablement


### PR DESCRIPTION
## Problem

The **Solicit Bids** modal (excess lists) was rendering inert whenever the
list title contained an apostrophe or double-quote (e.g. `Bob's "Q1" Surplus`).

The component was declared as an inline, **double-quoted** `x-data` whose
`subject` field interpolated the list title via Jinja `|e`. `|e` HTML-escapes
`<>&'"` but produces an invalid **JS string literal** — the embedded `'`
closed the JS string (and the `"` could close the attribute), so
`Alpine.init()` threw and the whole modal went dead: the `x-cloak` spinner /
"AI Clean Up" controls never un-cloaked and the form couldn't submit.

This is the same `tojson`-in-a-double-quoted-attribute bug class fixed for the
RFQ vendor modal (#207) and the materials/excess single-quote sweep (#208).

## Fix (root cause, no band-aid)

Mirror the `rfqVendorModal` pattern:

- Move the component into an `Alpine.data('solicitModal', subject => ({...}))`
  factory in `app/static/htmx_app.js`.
- Pass **only** the subject into it via a **single-quoted** `x-data` rendered
  with `|tojson`. `tojson` escapes `'` → `'` and emits a valid JS string;
  the single-quoted attribute is immune to the embedded `"` in the title.

Component behaviour (recipient fields, bundled toggle, `polishEmail()`) is
byte-for-byte unchanged — only the declaration site moved.

## Verification

- `tests/test_static_analysis.py` — 11 passed (incl.
  `test_no_tojson_in_double_quoted_alpine_attribute`, which now also covers
  this template).
- Render check with a hostile title `Bob's "Q1" Surplus` →
  `x-data='solicitModal("Bid Request: Bob's \"Q1\" Surplus")'` (factory
  call intact, attribute not terminated).
- Frontend vitest: 80 passed. Backend excess/email/sightings suites: 269 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
