### PR TITLE
build/deploy/ci hardening: lockfiles, worker deploy, redis CI, dependabot groups, worktree guard

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -12,8 +12,10 @@ sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 libffi-dev shared-mime-info \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install all dev/test dependencies (includes prod deps via -r requirements.txt)
-pip install --no-cache-dir -r requirements-dev.txt
+# Install prod + dev/test dependencies. Since the pip-tools migration these are two
+# separate locks: requirements-dev.txt uses `-c requirements.txt` (constraint), so it
+# no longer pulls in prod packages — both files must be installed (as CI does).
+pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
 
 # Install Chromium for Playwright-based tests
 python3 -m playwright install chromium

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,20 @@ updates:
     labels:
       - dependencies
     groups:
-      minor-and-patch:
+      # All dev/test tooling — batch every update INCLUDING majors into one PR.
+      # Low blast radius (pytest/cov/asyncio/schemathesis/etc. never ship to prod),
+      # and the repo's unbounded `>=` floors make most of these no-op floor raises.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+          - major
+      # Production runtime deps — batch only SAFE minor/patch into one PR.
+      # MAJOR production bumps stay UNGROUPED (one PR each) so they get individual
+      # scrutiny + a smoke test before merge (e.g. redis-py 8.0).
+      production-minor-patch:
+        dependency-type: production
         update-types:
           - minor
           - patch
@@ -21,6 +34,10 @@ updates:
       day: monday
     labels:
       - ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: "/"
@@ -31,7 +48,14 @@ updates:
     labels:
       - dependencies
     groups:
-      minor-and-patch:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+          - major
+      production-minor-patch:
+        dependency-type: production
         update-types:
           - minor
           - patch
@@ -43,3 +67,7 @@ updates:
       day: monday
     labels:
       - dependencies
+    groups:
+      docker-images:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,21 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
+      - name: Verify requirements lockfiles are in sync
+        # requirements*.txt are COMPILED from requirements*.in via pip-tools (pinned
+        # in requirements-dev.txt). Recompile WITHOUT --upgrade — existing pins are
+        # kept, so a fresh PyPI release never counts as drift — and fail if the
+        # committed lock changed, i.e. a .in was edited without recompiling, or a
+        # .txt was hand-edited. Keeps installs reproducible.
+        run: |
+          pip-compile --no-header --no-strip-extras --quiet requirements.in
+          pip-compile --no-header --no-strip-extras --quiet requirements-dev.in
+          if ! git diff --exit-code requirements.txt requirements-dev.txt; then
+            echo "::error::Lockfiles out of sync with their .in sources. Run: pip-compile --no-header --no-strip-extras requirements.in && pip-compile --no-header --no-strip-extras requirements-dev.in (then commit)."
+            exit 1
+          fi
+          echo "Lockfiles in sync with .in sources."
+
       - name: Install frontend dependencies
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v5
@@ -152,6 +161,19 @@ jobs:
             --cov=app --cov-report=term-missing --cov-report=xml:coverage.xml \
             --cov-fail-under=50 \
             --junitxml=test-results.xml
+
+      - name: Redis integration tests
+        # Exercises the REAL redis-py client against the `redis` service above —
+        # coverage the main suite cannot give (it runs under TESTING=1, where
+        # every Redis path short-circuits to None/in-memory). Catches a
+        # redis-py-breaking change (the redis-py 8.0 / #227 scenario) before it
+        # ships. Uses INTEGRATION_REDIS_URL because conftest.py blanks REDIS_URL
+        # for test isolation; -o addopts="" drops the suite-wide xdist/ignore opts.
+        env:
+          INTEGRATION_REDIS_URL: redis://localhost:6379/0
+          PYTHONPATH: ${{ github.workspace }}
+        run: |
+          pytest tests/integration/test_redis_integration.py -v -o addopts=""
 
       - name: Upload test results
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,23 @@ mypy app/                         # Type check
 ```
 Pre-commit hooks: ruff, ruff-format, mypy, docformatter, detect-private-key.
 
+### Dependencies (pip-tools lockfiles)
+
+Python deps are **pinned lockfiles** compiled from hand-authored sources, so every
+install (CI + deploy) is reproducible.
+
+- **Edit** `requirements.in` (prod) / `requirements-dev.in` (dev) — never the `.txt`.
+- **Recompile** the locks, then commit BOTH the `.in` and the regenerated `.txt`:
+  ```bash
+  pip-compile --no-header --no-strip-extras requirements.in
+  pip-compile --no-header --no-strip-extras requirements-dev.in
+  ```
+- `requirements.txt` (prod lock) is what the Docker image + `deploy.sh` install;
+  `requirements-dev.txt` adds the dev/test tools. CI fails if a `.txt` drifts from
+  its `.in` (the "Verify requirements lockfiles are in sync" step).
+- To bump a dep: change the constraint in the `.in`, recompile, run the suite. To
+  refresh transitive pins to newest: `pip-compile --upgrade ...`.
+
 ### Migrations
 ```bash
 alembic upgrade head                              # Apply pending

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,8 +223,10 @@ docker compose down               # Stop everything
 `deploy.sh` must run from `main` unless `--no-commit`. It builds with a unique
 `BUILD_COMMIT` build-arg (consumed before the source COPYs in both Dockerfile stages, so
 templates/static/Vite always rebuild fresh while apt/pip/npm-ci cache — no `--no-cache`),
-recreates only the `app` container, waits for the health check, verifies the deployed
-build tag, and checks that Tailwind classes in templates exist in the built CSS bundle.
+rebuilds + recreates **both** the `app` and `enrichment-worker` containers (they share
+`requirements.txt`, so the worker must not lag the app on a dependency bump), waits for
+the app health check, verifies the deployed build tag on both, and checks that Tailwind
+classes in templates exist in the built CSS bundle.
 Never use bare `docker compose up -d --build` (without `--build-arg BUILD_COMMIT=...`) —
 it ships stale templates.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -138,6 +138,20 @@ if [ "$(docker inspect --format='{{.State.Running}}' "$WORKER_CONTAINER" 2>/dev/
     docker compose logs --tail=50 enrichment-worker
     exit 1
 fi
+# Catch a worker that builds fine but crash-loops at runtime (a bad import / a
+# redis-py or anthropic API break — exactly the #227 scenario). It has no health
+# check and uses restart: always, so a single snapshot can catch it mid-restart
+# looking "running"; confirm RestartCount is stable over a short window.
+RC1=$(docker inspect --format='{{.RestartCount}}' "$WORKER_CONTAINER" 2>/dev/null || echo 0)
+sleep 8
+RC2=$(docker inspect --format='{{.RestartCount}}' "$WORKER_CONTAINER" 2>/dev/null || echo 0)
+if [ "${RC2:-0}" -gt "${RC1:-0}" ] \
+    || [ "$(docker inspect --format='{{.State.Running}}' "$WORKER_CONTAINER" 2>/dev/null)" != "true" ]; then
+    echo "==> ERROR: enrichment-worker is crash-looping (restarts ${RC1} -> ${RC2}) — not a healthy deploy"
+    echo "==> Last 50 log lines:"
+    docker compose logs --tail=50 enrichment-worker
+    exit 1
+fi
 WORKER_COMMIT=$(docker compose exec -T enrichment-worker printenv BUILD_COMMIT 2>/dev/null | tr -d '[:space:]' || echo "UNKNOWN")
 if [ "$WORKER_COMMIT" != "$BUILD_COMMIT" ]; then
     echo "==> MISMATCH: enrichment-worker ($WORKER_COMMIT) does NOT match build ($BUILD_COMMIT)"

--- a/deploy.sh
+++ b/deploy.sh
@@ -75,8 +75,13 @@ fi
 # input-pinned layers (apt, gh, pip, Chromium, `npm ci`) stay cached. ~4x faster deploys
 # with no stale-template risk. The unique timestamp also invalidates --no-commit deploys.
 BUILD_COMMIT="$(git rev-parse --short HEAD)-$(date +%s)"
-echo "==> Rebuilding app container (build tag: $BUILD_COMMIT)..."
-docker compose build --build-arg BUILD_COMMIT="$BUILD_COMMIT" app
+echo "==> Rebuilding app + enrichment-worker images (build tag: $BUILD_COMMIT)..."
+# app and enrichment-worker share `build: .` (same Dockerfile), so building both
+# here reuses every cached layer — the worker image is nearly free. This stops the
+# worker from silently running stale wheels after a dependency bump: it shares
+# requirements.txt with the app (e.g. redis-py, anthropic), and deploy.sh used to
+# rebuild only the app, leaving the worker on the old image until someone noticed.
+docker compose build --build-arg BUILD_COMMIT="$BUILD_COMMIT" app enrichment-worker
 
 # Step 3: Recreate only the app container with the new image
 # Clean up any orphaned rename containers from previous deploys
@@ -117,6 +122,28 @@ if [ "$DEPLOYED_COMMIT" != "$BUILD_COMMIT" ]; then
     exit 1
 fi
 echo "==> MATCH: deployed build tag ($DEPLOYED_COMMIT)"
+
+# Step 5b: Recreate the enrichment-worker on the freshly-built image.
+# The worker has no HTTP health check, so confirm it is running and verify the
+# BUILD_COMMIT baked into its env (same Dockerfile as app). Done after the app is
+# healthy + verified so a broken app build never disrupts a working worker.
+echo ""
+echo "==> Recreating enrichment-worker..."
+docker compose up -d enrichment-worker
+sleep 3
+WORKER_CONTAINER=$(docker compose ps -q enrichment-worker)
+if [ "$(docker inspect --format='{{.State.Running}}' "$WORKER_CONTAINER" 2>/dev/null)" != "true" ]; then
+    echo "==> ERROR: enrichment-worker is not running after recreate"
+    echo "==> Last 50 log lines:"
+    docker compose logs --tail=50 enrichment-worker
+    exit 1
+fi
+WORKER_COMMIT=$(docker compose exec -T enrichment-worker printenv BUILD_COMMIT 2>/dev/null | tr -d '[:space:]' || echo "UNKNOWN")
+if [ "$WORKER_COMMIT" != "$BUILD_COMMIT" ]; then
+    echo "==> MISMATCH: enrichment-worker ($WORKER_COMMIT) does NOT match build ($BUILD_COMMIT)"
+    exit 1
+fi
+echo "==> MATCH: enrichment-worker build tag ($WORKER_COMMIT)"
 
 # Step 6: Verify CSS covers Tailwind color classes used in templates
 echo ""

--- a/docs/BRANCH_AND_CI_WORKFLOW.md
+++ b/docs/BRANCH_AND_CI_WORKFLOW.md
@@ -81,6 +81,16 @@ scripts/branch-cleanup.sh --apply --remote   # also delete stale REMOTE branches
 Do this whenever the local branch list grows past the active set, and after a
 batch of PRs merges.
 
+For **worktrees**, use the companion guard (same dry-run-by-default contract). It
+removes a worktree only when it is BOTH clean and merged into `origin/main`, and
+**HOLDS** any worktree with uncommitted work or unmerged commits — so a name
+collision or a still-active session can never lose WIP to automated cleanup:
+
+```bash
+scripts/worktree-guard.sh              # report SAFE vs HELD (dry run)
+scripts/worktree-guard.sh --apply      # remove only the SAFE (clean + merged) ones
+```
+
 ## 5. Keep the workspace clean
 
 - **Working tree:** commit or quarantine untracked files; `git status` should be

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,0 +1,47 @@
+# Dev/test dependency SOURCE (hand-authored). Edit this file, then regenerate the
+# pinned lock with:  pip-compile --no-header requirements-dev.in
+# Do NOT edit requirements-dev.txt by hand — it is the compiled output.
+# Prod pins constrain dev deps (-c) so shared versions stay consistent; CI installs
+# both requirements.txt and requirements-dev.txt.
+-c requirements.txt
+
+# Testing
+pytest>=9.0.3
+pytest-asyncio>=1.4.0
+pytest-cov>=7.1.0
+pytest-xdist>=3.8.0
+responses>=0.26.1
+freezegun>=1.5.5
+schemathesis>=4.21.1
+nest_asyncio>=1.6.0
+
+# E2E / Playwright
+playwright>=1.60.0
+pytest-playwright>=0.8.0
+pytest-timeout>=2.3.0
+itsdangerous>=2.1.0
+
+# Stability
+pybreaker>=1.4.1
+
+# Linting
+ruff>=0.15.15
+
+# Type checking
+mypy>=2.1.0
+sqlalchemy[mypy]>=2.0.50
+types-redis>=4.6.0.20241004
+
+# Pre-commit
+pre-commit>=4.6.0
+
+# Security scanning
+bandit>=1.9.4
+pip-audit>=2.10.0
+
+# Debugging
+ipdb>=0.13.13
+
+# Lockfile management — compiles requirements*.in -> requirements*.txt.
+# Pinned in the lock so CI's drift-gate uses the same compiler version we do.
+pip-tools>=7.5.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,39 +1,367 @@
-# Dev/test dependencies — install with: pip install -r requirements-dev.txt
--r requirements.txt
+anyio==4.13.0
+    # via
+    #   -c requirements.txt
+    #   httpx
+    #   starlette
+ast-serialize==0.5.0
+    # via mypy
+asttokens==3.0.1
+    # via stack-data
+attrs==26.1.0
+    # via
+    #   jsonschema
+    #   referencing
+bandit==1.9.4
+    # via -r requirements-dev.in
+boolean-py==5.0
+    # via license-expression
+build==1.5.0
+    # via pip-tools
+cachecontrol[filecache]==0.14.4
+    # via
+    #   cachecontrol
+    #   pip-audit
+certifi==2026.5.20
+    # via
+    #   -c requirements.txt
+    #   httpcore
+    #   httpx
+    #   requests
+cffi==2.0.0
+    # via
+    #   -c requirements.txt
+    #   cryptography
+cfgv==3.5.0
+    # via pre-commit
+charset-normalizer==3.4.7
+    # via
+    #   -c requirements.txt
+    #   requests
+click==8.4.1
+    # via
+    #   -c requirements.txt
+    #   pip-tools
+    #   schemathesis
+coverage[toml]==7.14.1
+    # via pytest-cov
+cryptography==48.0.0
+    # via
+    #   -c requirements.txt
+    #   types-pyopenssl
+    #   types-redis
+cyclonedx-python-lib==11.9.0
+    # via pip-audit
+decorator==5.3.1
+    # via
+    #   ipdb
+    #   ipython
+defusedxml==0.7.1
+    # via
+    #   -c requirements.txt
+    #   py-serializable
+distlib==0.4.2
+    # via virtualenv
+execnet==2.1.2
+    # via pytest-xdist
+executing==2.2.1
+    # via stack-data
+filelock==3.29.1
+    # via
+    #   cachecontrol
+    #   python-discovery
+    #   virtualenv
+freezegun==1.5.5
+    # via -r requirements-dev.in
+graphql-core==3.2.11
+    # via hypothesis-graphql
+greenlet==3.5.1
+    # via
+    #   -c requirements.txt
+    #   playwright
+    #   sqlalchemy
+h11==0.16.0
+    # via
+    #   -c requirements.txt
+    #   httpcore
+harfile==0.5.0
+    # via schemathesis
+httpcore==1.0.9
+    # via
+    #   -c requirements.txt
+    #   httpx
+httpx==0.28.1
+    # via
+    #   -c requirements.txt
+    #   schemathesis
+hypothesis==6.155.2
+    # via
+    #   hypothesis-graphql
+    #   hypothesis-jsonschema
+    #   schemathesis
+hypothesis-graphql==0.13.0
+    # via schemathesis
+hypothesis-jsonschema==0.23.1
+    # via schemathesis
+identify==2.6.19
+    # via pre-commit
+idna==3.18
+    # via
+    #   -c requirements.txt
+    #   anyio
+    #   httpx
+    #   requests
+iniconfig==2.3.0
+    # via pytest
+ipdb==0.13.13
+    # via -r requirements-dev.in
+ipython==9.14.1
+    # via ipdb
+ipython-pygments-lexers==1.1.1
+    # via ipython
+itsdangerous==2.2.0
+    # via
+    #   -c requirements.txt
+    #   -r requirements-dev.in
+jedi==0.20.0
+    # via ipython
+jsonschema==4.26.0
+    # via hypothesis-jsonschema
+jsonschema-rs==0.46.5
+    # via schemathesis
+jsonschema-specifications==2025.9.1
+    # via jsonschema
+junit-xml==1.9
+    # via schemathesis
+librt==0.11.0
+    # via mypy
+license-expression==30.4.4
+    # via cyclonedx-python-lib
+markdown-it-py==4.2.0
+    # via rich
+markupsafe==3.0.3
+    # via
+    #   -c requirements.txt
+    #   werkzeug
+matplotlib-inline==0.2.2
+    # via ipython
+mdurl==0.1.2
+    # via markdown-it-py
+msgpack==1.1.2
+    # via cachecontrol
+mypy==2.1.0
+    # via
+    #   -r requirements-dev.in
+    #   sqlalchemy
+mypy-extensions==1.1.0
+    # via mypy
+nest-asyncio==1.6.0
+    # via -r requirements-dev.in
+nodeenv==1.10.0
+    # via pre-commit
+packageurl-python==0.17.6
+    # via cyclonedx-python-lib
+packaging==26.2
+    # via
+    #   -c requirements.txt
+    #   build
+    #   pip-audit
+    #   pip-requirements-parser
+    #   pytest
+    #   wheel
+parso==0.8.7
+    # via jedi
+pathspec==1.1.1
+    # via mypy
+pexpect==4.9.0
+    # via ipython
+pip-api==0.0.34
+    # via pip-audit
+pip-audit==2.10.0
+    # via -r requirements-dev.in
+pip-requirements-parser==32.0.1
+    # via pip-audit
+pip-tools==7.5.3
+    # via -r requirements-dev.in
+platformdirs==4.10.0
+    # via
+    #   pip-audit
+    #   python-discovery
+    #   virtualenv
+playwright==1.60.0
+    # via
+    #   -r requirements-dev.in
+    #   pytest-playwright
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+pre-commit==4.6.0
+    # via -r requirements-dev.in
+prompt-toolkit==3.0.52
+    # via ipython
+psutil==7.2.2
+    # via ipython
+ptyprocess==0.7.0
+    # via pexpect
+pure-eval==0.2.3
+    # via stack-data
+py-serializable==2.1.0
+    # via cyclonedx-python-lib
+pybreaker==1.4.1
+    # via -r requirements-dev.in
+pycparser==3.0
+    # via
+    #   -c requirements.txt
+    #   cffi
+pyee==13.0.1
+    # via
+    #   -c requirements.txt
+    #   playwright
+pygments==2.20.0
+    # via
+    #   ipython
+    #   ipython-pygments-lexers
+    #   pytest
+    #   rich
+pyparsing==3.3.2
+    # via pip-requirements-parser
+pyproject-hooks==1.2.0
+    # via
+    #   build
+    #   pip-tools
+pyrate-limiter==4.2.0
+    # via schemathesis
+pytest==9.0.3
+    # via
+    #   -r requirements-dev.in
+    #   pytest-asyncio
+    #   pytest-base-url
+    #   pytest-cov
+    #   pytest-playwright
+    #   pytest-timeout
+    #   pytest-xdist
+    #   schemathesis
+pytest-asyncio==1.4.0
+    # via -r requirements-dev.in
+pytest-base-url==2.1.0
+    # via pytest-playwright
+pytest-cov==7.1.0
+    # via -r requirements-dev.in
+pytest-playwright==0.8.0
+    # via -r requirements-dev.in
+pytest-timeout==2.4.0
+    # via -r requirements-dev.in
+pytest-xdist==3.8.0
+    # via -r requirements-dev.in
+python-dateutil==2.9.0.post0
+    # via freezegun
+python-discovery==1.4.0
+    # via virtualenv
+python-slugify==8.0.4
+    # via pytest-playwright
+pyyaml==6.0.3
+    # via
+    #   -c requirements.txt
+    #   bandit
+    #   pre-commit
+    #   responses
+    #   schemathesis
+referencing==0.37.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+requests==2.34.2
+    # via
+    #   -c requirements.txt
+    #   cachecontrol
+    #   pip-audit
+    #   pytest-base-url
+    #   responses
+    #   schemathesis
+    #   starlette-testclient
+responses==0.26.1
+    # via -r requirements-dev.in
+rich==15.0.0
+    # via
+    #   bandit
+    #   pip-audit
+    #   schemathesis
+rpds-py==2026.5.1
+    # via
+    #   jsonschema
+    #   referencing
+ruff==0.15.16
+    # via -r requirements-dev.in
+schemathesis==4.21.1
+    # via -r requirements-dev.in
+six==1.17.0
+    # via
+    #   junit-xml
+    #   python-dateutil
+sortedcontainers==2.4.0
+    # via
+    #   cyclonedx-python-lib
+    #   hypothesis
+sqlalchemy[mypy]==2.0.50
+    # via
+    #   -c requirements.txt
+    #   -r requirements-dev.in
+stack-data==0.6.3
+    # via ipython
+starlette==1.2.1
+    # via
+    #   -c requirements.txt
+    #   starlette-testclient
+starlette-testclient==0.4.1
+    # via schemathesis
+stevedore==5.8.0
+    # via bandit
+tenacity==9.1.4
+    # via schemathesis
+text-unidecode==1.3
+    # via python-slugify
+tomli==2.4.1
+    # via pip-audit
+tomli-w==1.2.0
+    # via pip-audit
+traitlets==5.15.1
+    # via
+    #   ipython
+    #   matplotlib-inline
+types-cffi==2.0.0.20260518
+    # via types-pyopenssl
+types-pyopenssl==24.1.0.20240722
+    # via types-redis
+types-redis==4.6.0.20241004
+    # via -r requirements-dev.in
+types-setuptools==82.0.0.20260518
+    # via types-cffi
+typing-extensions==4.15.0
+    # via
+    #   -c requirements.txt
+    #   anyio
+    #   cyclonedx-python-lib
+    #   mypy
+    #   pyee
+    #   pytest-asyncio
+    #   referencing
+    #   schemathesis
+    #   sqlalchemy
+    #   starlette
+urllib3==2.7.0
+    # via
+    #   -c requirements.txt
+    #   requests
+    #   responses
+virtualenv==21.4.2
+    # via pre-commit
+wcwidth==0.8.1
+    # via prompt-toolkit
+werkzeug==3.1.8
+    # via schemathesis
+wheel==0.47.0
+    # via pip-tools
 
-# Testing
-pytest>=9.0.3
-pytest-asyncio>=1.4.0
-pytest-cov>=7.1.0
-pytest-xdist>=3.8.0
-responses>=0.26.1
-freezegun>=1.5.5
-schemathesis>=4.21.1
-nest_asyncio>=1.6.0
-
-# E2E / Playwright
-playwright>=1.60.0
-pytest-playwright>=0.8.0
-pytest-timeout>=2.3.0
-itsdangerous>=2.1.0
-
-# Stability
-pybreaker>=1.4.1
-
-# Linting
-ruff>=0.15.15
-
-# Type checking
-mypy>=2.1.0
-sqlalchemy[mypy]>=2.0.50
-types-redis>=4.6.0.20241004
-
-# Pre-commit
-pre-commit>=4.6.0
-
-# Security scanning
-bandit>=1.9.4
-pip-audit>=2.10.0
-
-# Debugging
-ipdb>=0.13.13
+# The following packages are considered to be unsafe in a requirements file:
+# pip
+# setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -1,0 +1,56 @@
+# Production dependency SOURCE (hand-authored). Edit this file, then regenerate the
+# pinned lock with:  pip-compile --no-header requirements.in
+# Do NOT edit requirements.txt by hand — it is the compiled, fully-pinned output.
+fastapi==0.136.3
+uvicorn[standard]==0.49.0
+sqlalchemy==2.0.50
+psycopg2-binary==2.9.12
+python-multipart==0.0.32
+httpx==0.28.1
+openpyxl==3.1.5
+jinja2==3.1.6
+# Email Mining v2 hardening
+filetype==1.2.0
+charset-normalizer==3.4.7
+# Credential encryption
+cryptography==48.0.0
+# Observability
+loguru==0.7.3
+# Pinned >=1.0.1 to fix PYSEC-2026-161 (Host header URL-reconstruction auth bypass).
+# Forces resolver to pick the fixed 1.x line; fastapi 0.136.x accepts starlette>=0.46.0 unbounded.
+starlette>=1.2.1,<2.0
+# Replaced prometheus-fastapi-instrumentator (hard-pinned starlette<1.0.0) with a small
+# ASGI middleware in app/prometheus_metrics.py that uses prometheus_client directly.
+prometheus_client>=0.25.0,<1.0
+sentry-sdk[fastapi]==2.61.1
+# Rate limiting
+slowapi==0.1.9
+# Fuzzy matching
+rapidfuzz>=3.0.0,<4.0
+# PDF generation
+weasyprint==68.1
+# Scheduling
+apscheduler>=3.11.2,<4.0
+# Migrations
+alembic==1.18.4
+# Caching
+redis[hiredis]==8.0.0
+orjson>=3.11.9,<4.0
+# CSRF protection
+starlette-csrf==3.0.0
+# NetComponents integration
+beautifulsoup4==4.15.0
+patchright==1.60.1
+# Typed settings from env vars (fail-fast validation at startup)
+pydantic-settings==2.14.1
+# SSE streaming for HTMX sourcing progress
+sse-starlette>=3.4.4,<4.0
+# Anthropic Claude API (used by claude_client, enrichment, batch extraction)
+anthropic>=0.107.1,<1.0
+# HTML sanitization for untrusted email content (XSS prevention)
+nh3==0.3.5
+# Safe XML parsing (XXE prevention)
+defusedxml>=0.7.1
+# Azure Communication Services (click-to-call)
+azure-communication-callautomation>=1.5.0,<2.0
+azure-communication-identity>=1.5.0,<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,53 +1,242 @@
-fastapi==0.136.3
-uvicorn[standard]==0.49.0
-sqlalchemy==2.0.50
-psycopg2-binary==2.9.12
-python-multipart==0.0.32
-httpx==0.28.1
-openpyxl==3.1.5
-jinja2==3.1.6
-# Email Mining v2 hardening
-filetype==1.2.0
-charset-normalizer==3.4.7
-# Credential encryption
-cryptography==48.0.0
-# Observability
-loguru==0.7.3
-# Pinned >=1.0.1 to fix PYSEC-2026-161 (Host header URL-reconstruction auth bypass).
-# Forces resolver to pick the fixed 1.x line; fastapi 0.136.x accepts starlette>=0.46.0 unbounded.
-starlette>=1.2.1,<2.0
-# Replaced prometheus-fastapi-instrumentator (hard-pinned starlette<1.0.0) with a small
-# ASGI middleware in app/prometheus_metrics.py that uses prometheus_client directly.
-prometheus_client>=0.25.0,<1.0
-sentry-sdk[fastapi]==2.61.1
-# Rate limiting
-slowapi==0.1.9
-# Fuzzy matching
-rapidfuzz>=3.0.0,<4.0
-# PDF generation
-weasyprint==68.1
-# Scheduling
-apscheduler>=3.11.2,<4.0
-# Migrations
 alembic==1.18.4
-# Caching
-redis[hiredis]==8.0.0
-orjson>=3.11.9,<4.0
-# CSRF protection
-starlette-csrf==3.0.0
-# NetComponents integration
+    # via -r requirements.in
+annotated-doc==0.0.4
+    # via fastapi
+annotated-types==0.7.0
+    # via pydantic
+anthropic==0.107.1
+    # via -r requirements.in
+anyio==4.13.0
+    # via
+    #   anthropic
+    #   httpx
+    #   sse-starlette
+    #   starlette
+    #   watchfiles
+apscheduler==3.11.2
+    # via -r requirements.in
+azure-communication-callautomation==1.5.0
+    # via -r requirements.in
+azure-communication-identity==1.5.0
+    # via -r requirements.in
+azure-core==1.41.0
+    # via
+    #   azure-communication-callautomation
+    #   azure-communication-identity
+    #   msrest
 beautifulsoup4==4.15.0
-patchright==1.60.1
-# Typed settings from env vars (fail-fast validation at startup)
-pydantic-settings==2.14.1
-# SSE streaming for HTMX sourcing progress
-sse-starlette>=3.4.4,<4.0
-# Anthropic Claude API (used by claude_client, enrichment, batch extraction)
-anthropic>=0.107.1,<1.0
-# HTML sanitization for untrusted email content (XSS prevention)
+    # via -r requirements.in
+brotli==1.2.0
+    # via fonttools
+certifi==2026.5.20
+    # via
+    #   httpcore
+    #   httpx
+    #   msrest
+    #   requests
+    #   sentry-sdk
+cffi==2.0.0
+    # via
+    #   cryptography
+    #   weasyprint
+charset-normalizer==3.4.7
+    # via
+    #   -r requirements.in
+    #   requests
+click==8.4.1
+    # via uvicorn
+cryptography==48.0.0
+    # via -r requirements.in
+cssselect2==0.9.0
+    # via weasyprint
+defusedxml==0.7.1
+    # via -r requirements.in
+deprecated==1.3.1
+    # via limits
+distro==1.9.0
+    # via anthropic
+docstring-parser==0.18.0
+    # via anthropic
+et-xmlfile==2.0.0
+    # via openpyxl
+fastapi==0.136.3
+    # via
+    #   -r requirements.in
+    #   sentry-sdk
+filetype==1.2.0
+    # via -r requirements.in
+fonttools[woff]==4.63.0
+    # via weasyprint
+greenlet==3.5.1
+    # via
+    #   patchright
+    #   sqlalchemy
+h11==0.16.0
+    # via
+    #   httpcore
+    #   uvicorn
+hiredis==3.4.0
+    # via redis
+httpcore==1.0.9
+    # via httpx
+httptools==0.8.0
+    # via uvicorn
+httpx==0.28.1
+    # via
+    #   -r requirements.in
+    #   anthropic
+idna==3.18
+    # via
+    #   anyio
+    #   httpx
+    #   requests
+isodate==0.7.2
+    # via
+    #   azure-communication-callautomation
+    #   msrest
+itsdangerous==2.2.0
+    # via starlette-csrf
+jinja2==3.1.6
+    # via -r requirements.in
+jiter==0.15.0
+    # via anthropic
+limits==5.8.0
+    # via slowapi
+loguru==0.7.3
+    # via -r requirements.in
+mako==1.3.12
+    # via alembic
+markupsafe==3.0.3
+    # via
+    #   jinja2
+    #   mako
+msrest==0.7.1
+    # via azure-communication-identity
 nh3==0.3.5
-# Safe XML parsing (XXE prevention)
-defusedxml>=0.7.1
-# Azure Communication Services (click-to-call)
-azure-communication-callautomation>=1.5.0,<2.0
-azure-communication-identity>=1.5.0,<2.0
+    # via -r requirements.in
+oauthlib==3.3.1
+    # via requests-oauthlib
+openpyxl==3.1.5
+    # via -r requirements.in
+orjson==3.11.9
+    # via -r requirements.in
+packaging==26.2
+    # via limits
+patchright==1.60.1
+    # via -r requirements.in
+pillow==12.2.0
+    # via weasyprint
+prometheus-client==0.25.0
+    # via -r requirements.in
+psycopg2-binary==2.9.12
+    # via -r requirements.in
+pycparser==3.0
+    # via cffi
+pydantic==2.13.4
+    # via
+    #   anthropic
+    #   fastapi
+    #   pydantic-settings
+pydantic-core==2.46.4
+    # via pydantic
+pydantic-settings==2.14.1
+    # via -r requirements.in
+pydyf==0.12.1
+    # via weasyprint
+pyee==13.0.1
+    # via patchright
+pyphen==0.17.2
+    # via weasyprint
+python-dotenv==1.2.2
+    # via
+    #   pydantic-settings
+    #   uvicorn
+python-multipart==0.0.32
+    # via -r requirements.in
+pyyaml==6.0.3
+    # via uvicorn
+rapidfuzz==3.14.5
+    # via -r requirements.in
+redis[hiredis]==8.0.0
+    # via -r requirements.in
+requests==2.34.2
+    # via
+    #   azure-core
+    #   msrest
+    #   requests-oauthlib
+requests-oauthlib==2.0.0
+    # via msrest
+sentry-sdk[fastapi]==2.61.1
+    # via -r requirements.in
+slowapi==0.1.9
+    # via -r requirements.in
+sniffio==1.3.1
+    # via anthropic
+soupsieve==2.8.4
+    # via beautifulsoup4
+sqlalchemy==2.0.50
+    # via
+    #   -r requirements.in
+    #   alembic
+sse-starlette==3.4.4
+    # via -r requirements.in
+starlette==1.2.1
+    # via
+    #   -r requirements.in
+    #   fastapi
+    #   sse-starlette
+    #   starlette-csrf
+starlette-csrf==3.0.0
+    # via -r requirements.in
+tinycss2==1.5.1
+    # via
+    #   cssselect2
+    #   weasyprint
+tinyhtml5==2.1.0
+    # via weasyprint
+typing-extensions==4.15.0
+    # via
+    #   alembic
+    #   anthropic
+    #   anyio
+    #   azure-communication-callautomation
+    #   azure-core
+    #   beautifulsoup4
+    #   fastapi
+    #   limits
+    #   pydantic
+    #   pydantic-core
+    #   pyee
+    #   sqlalchemy
+    #   starlette
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via
+    #   fastapi
+    #   pydantic
+    #   pydantic-settings
+tzlocal==5.3.1
+    # via apscheduler
+urllib3==2.7.0
+    # via
+    #   requests
+    #   sentry-sdk
+uvicorn[standard]==0.49.0
+    # via -r requirements.in
+uvloop==0.22.1
+    # via uvicorn
+watchfiles==1.2.0
+    # via uvicorn
+weasyprint==68.1
+    # via -r requirements.in
+webencodings==0.5.1
+    # via
+    #   cssselect2
+    #   tinycss2
+    #   tinyhtml5
+websockets==16.0
+    # via uvicorn
+wrapt==2.2.1
+    # via deprecated
+zopfli==0.4.2
+    # via fonttools

--- a/scripts/worktree-guard.sh
+++ b/scripts/worktree-guard.sh
@@ -15,6 +15,8 @@
 # Guarantees:
 #   - A worktree with uncommitted TRACKED changes is NEVER removed.
 #   - A worktree whose branch has commits not in origin/main is NEVER removed.
+#   - If merge state can't be determined (fetch / origin/main / gh / git error),
+#     the run aborts or HOLDs — a failed check is never read as "safe".
 #   - The primary checkout is never touched.
 #   - Dry-run by default; pass --apply to actually remove the SAFE ones.
 #   - HOLD worktrees print the exact reason; forcing one is a deliberate MANUAL act
@@ -37,11 +39,31 @@ done
 run() { if [ "$APPLY" = 1 ]; then "$@"; else echo "  DRY-RUN: $*"; fi; }
 
 cd "$(git rev-parse --show-toplevel)" || exit 1
-git fetch origin -q --prune || true
 
-# Branches with open PRs are off-limits (mirrors branch-cleanup.sh).
-PROTECTED=$(gh pr list --state open --limit 100 --json headRefName -q '.[].headRefName' 2>/dev/null | sort -u || true)
-protected() { [ -n "$PROTECTED" ] && grep -qxF "$1" <<<"$PROTECTED"; }
+# Merge state is only trustworthy if origin/main is current and resolvable. A
+# swallowed fetch failure or a missing origin/main is the difference between
+# "no unmerged commits" and "couldn't check" — never resolve that toward removal.
+if ! git fetch origin -q --prune; then
+  echo "ERROR: 'git fetch origin' failed — cannot determine merge state. Aborting; nothing removed." >&2
+  exit 1
+fi
+if ! git rev-parse --verify -q origin/main >/dev/null; then
+  echo "ERROR: origin/main is not resolvable — refusing to classify any worktree. Aborting." >&2
+  exit 1
+fi
+
+# Branches with open PRs are off-limits (mirrors branch-cleanup.sh). If gh can't be
+# queried we can't prove a branch is PR-free, so HOLD everything rather than guess.
+if PROTECTED=$(gh pr list --state open --limit 100 --json headRefName -q '.[].headRefName' 2>/dev/null | sort -u); then
+  GH_OK=1
+else
+  GH_OK=0
+  echo "WARNING: could not query open PRs via gh — every branch-attached worktree will be HELD." >&2
+fi
+protected() {
+  [ "$GH_OK" = 0 ] && return 0
+  [ -n "$PROTECTED" ] && grep -qxF "$1" <<<"$PROTECTED"
+}
 
 # Parse `git worktree list --porcelain` into "path<TAB>branch" lines, skipping the
 # first (primary) worktree, which git always lists first.
@@ -65,14 +87,21 @@ for line in "${WORKTREES[@]}"; do
   [ -d "$path" ] || { echo "stale worktree entry (path gone): $path — run 'git worktree prune'"; continue; }
 
   reasons=()
-  # 1) uncommitted TRACKED changes (untracked files like node_modules don't block)
-  if [ -n "$(git -C "$path" status --porcelain --untracked-files=no)" ]; then
+  # 1) uncommitted TRACKED changes (untracked files like node_modules don't block).
+  #    A git error here must NOT be read as "clean".
+  if ! status=$(git -C "$path" status --porcelain --untracked-files=no 2>/dev/null); then
+    reasons+=("git status failed — held")
+  elif [ -n "$status" ]; then
     reasons+=("uncommitted tracked changes")
   fi
-  # 2) commits not in origin/main (squash-merges land here too — held to be safe)
-  if [ "$branch" != "(detached)" ] && [ -n "$(git -C "$path" log --oneline origin/main..HEAD 2>/dev/null)" ]; then
-    n=$(git -C "$path" rev-list --count origin/main..HEAD 2>/dev/null || echo "?")
-    reasons+=("$n commit(s) not in origin/main")
+  # 2) commits not in origin/main (squash-merges land here too — held to be safe).
+  #    A detached HEAD or a failed comparison is "can't tell" -> HOLD, never SAFE.
+  if [ "$branch" = "(detached)" ]; then
+    reasons+=("detached HEAD — held")
+  elif ! ahead=$(git -C "$path" rev-list --count origin/main..HEAD 2>/dev/null); then
+    reasons+=("could not compare against origin/main — held")
+  elif [ "$ahead" -gt 0 ]; then
+    reasons+=("$ahead commit(s) not in origin/main")
   fi
   # 3) open PR on the branch
   if [ "$branch" != "(detached)" ] && protected "$branch"; then
@@ -81,7 +110,8 @@ for line in "${WORKTREES[@]}"; do
 
   if [ "${#reasons[@]}" -gt 0 ]; then
     held=$((held + 1))
-    printf 'HOLD  %s [%s]\n      reason: %s\n' "$path" "$branch" "$(IFS='; '; echo "${reasons[*]}")"
+    echo "HOLD  $path [$branch]"
+    for rr in "${reasons[@]}"; do echo "      - $rr"; done
     echo "      to remove anyway (loses uncommitted work): git worktree remove --force \"$path\""
   else
     safe=$((safe + 1))

--- a/scripts/worktree-guard.sh
+++ b/scripts/worktree-guard.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# worktree-guard.sh — safe pruning of git worktrees (companion to branch-cleanup.sh).
+#
+# Why this exists: with multiple Claude sessions sharing one checkout, feature work
+# is isolated in worktrees under .claude/worktrees/ (and friends). An automated
+# cleanup once *nearly* deleted a worktree holding uncommitted WIP because its branch
+# name collided with an already-merged one (`materials-filter-rework` vs the merged
+# `materials-filter-tree`). This guard makes that impossible: a worktree is only
+# eligible for removal when it is BOTH clean (no uncommitted tracked changes) AND its
+# branch is fully merged into origin/main. Anything else is HELD and reported — never
+# auto-removed. `git branch -d/-D` can't delete a worktree-attached branch anyway, so
+# branch-cleanup.sh skips these; this script is the piece that handles the worktrees.
+#
+# Guarantees:
+#   - A worktree with uncommitted TRACKED changes is NEVER removed.
+#   - A worktree whose branch has commits not in origin/main is NEVER removed.
+#   - The primary checkout is never touched.
+#   - Dry-run by default; pass --apply to actually remove the SAFE ones.
+#   - HOLD worktrees print the exact reason; forcing one is a deliberate MANUAL act
+#     (`git worktree remove --force <path>`), intentionally not automated here.
+#
+# Usage:
+#   scripts/worktree-guard.sh            # report only (default)
+#   scripts/worktree-guard.sh --apply    # remove worktrees that are clean AND merged
+#
+set -uo pipefail
+
+APPLY=0
+for a in "$@"; do
+  case "$a" in
+    --apply) APPLY=1 ;;
+    -h | --help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $a" >&2; exit 2 ;;
+  esac
+done
+run() { if [ "$APPLY" = 1 ]; then "$@"; else echo "  DRY-RUN: $*"; fi; }
+
+cd "$(git rev-parse --show-toplevel)" || exit 1
+git fetch origin -q --prune || true
+
+# Branches with open PRs are off-limits (mirrors branch-cleanup.sh).
+PROTECTED=$(gh pr list --state open --limit 100 --json headRefName -q '.[].headRefName' 2>/dev/null | sort -u || true)
+protected() { [ -n "$PROTECTED" ] && grep -qxF "$1" <<<"$PROTECTED"; }
+
+# Parse `git worktree list --porcelain` into "path<TAB>branch" lines, skipping the
+# first (primary) worktree, which git always lists first.
+mapfile -t WORKTREES < <(
+  git worktree list --porcelain | awk '
+    /^worktree /  { path=substr($0,10) }
+    /^branch /    { sub(/^branch refs\/heads\//,""); print path "\t" $0 }
+    /^detached$/  { print path "\t(detached)" }
+  ' | tail -n +2
+)
+
+if [ "${#WORKTREES[@]}" -eq 0 ]; then
+  echo "No linked worktrees. Nothing to do."
+  exit 0
+fi
+
+held=0 safe=0
+for line in "${WORKTREES[@]}"; do
+  path=${line%%$'\t'*}
+  branch=${line#*$'\t'}
+  [ -d "$path" ] || { echo "stale worktree entry (path gone): $path — run 'git worktree prune'"; continue; }
+
+  reasons=()
+  # 1) uncommitted TRACKED changes (untracked files like node_modules don't block)
+  if [ -n "$(git -C "$path" status --porcelain --untracked-files=no)" ]; then
+    reasons+=("uncommitted tracked changes")
+  fi
+  # 2) commits not in origin/main (squash-merges land here too — held to be safe)
+  if [ "$branch" != "(detached)" ] && [ -n "$(git -C "$path" log --oneline origin/main..HEAD 2>/dev/null)" ]; then
+    n=$(git -C "$path" rev-list --count origin/main..HEAD 2>/dev/null || echo "?")
+    reasons+=("$n commit(s) not in origin/main")
+  fi
+  # 3) open PR on the branch
+  if [ "$branch" != "(detached)" ] && protected "$branch"; then
+    reasons+=("open PR")
+  fi
+
+  if [ "${#reasons[@]}" -gt 0 ]; then
+    held=$((held + 1))
+    printf 'HOLD  %s [%s]\n      reason: %s\n' "$path" "$branch" "$(IFS='; '; echo "${reasons[*]}")"
+    echo "      to remove anyway (loses uncommitted work): git worktree remove --force \"$path\""
+  else
+    safe=$((safe + 1))
+    echo "SAFE  $path [$branch] — clean and merged into origin/main"
+    run git worktree remove "$path"
+    [ "$branch" != "(detached)" ] && run git branch -d "$branch"
+  fi
+done
+
+echo "---"
+echo "SAFE: $safe   HELD: $held   ($([ "$APPLY" = 1 ] && echo 'applied' || echo 'dry-run; pass --apply to remove SAFE ones'))"

--- a/tests/integration/test_redis_integration.py
+++ b/tests/integration/test_redis_integration.py
@@ -1,0 +1,125 @@
+"""Redis integration tests — exercise the REAL redis-py client end-to-end.
+
+What it does: connects to a live Redis (via the REDIS_URL env var) and drives
+exactly the client operations the app relies on — ``from_url(...)`` with the
+app's kwargs, ``ping``, ``get``/``setex``, ``scan``/``delete``, and
+``decode_responses`` — plus the app's own connection code paths
+(``intel_cache._get_redis`` and ``rate_limit._resolve_storage``).
+
+Why it exists: the normal suite runs under ``TESTING=1``, where every Redis path
+short-circuits to ``None`` / in-memory, so a redis-py-breaking change (e.g. a
+future major bump, like redis-py 8.0 in PR #227) would sail through CI green.
+These tests are the missing coverage. They run ONLY when ``INTEGRATION_REDIS_URL``
+is set — the dedicated CI job that spins up a ``redis`` service — and skip
+everywhere else (local dev, the main test run), so they never flake without a
+real server. A dedicated var (not ``REDIS_URL``) is used because
+``tests/conftest.py`` deliberately blanks ``REDIS_URL`` for test isolation.
+
+Called by: ``.github/workflows/ci.yml`` "Redis integration tests" step.
+Depends on: a reachable Redis server, ``app.cache.intel_cache``,
+``app.rate_limit``, ``app.config.settings``.
+"""
+
+import os
+
+import pytest
+
+# Dedicated var: conftest.py blanks REDIS_URL for isolation, so the integration
+# job passes the live server URL via INTEGRATION_REDIS_URL instead. Default to ""
+# (falsy -> skip) so the type stays `str`, not `str | None`.
+REDIS_URL = os.environ.get("INTEGRATION_REDIS_URL") or ""
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not REDIS_URL,
+        reason="INTEGRATION_REDIS_URL not set — redis integration tests skipped",
+    ),
+]
+
+_KEY_PREFIX = "intel:itest:"
+
+
+@pytest.fixture
+def redis_client():
+    """A real redis-py client, or skip if the server is unreachable.
+
+    Cleans up this test namespace before and after so reruns are deterministic.
+    """
+    import redis
+
+    client = redis.from_url(REDIS_URL, decode_responses=True, socket_connect_timeout=3)
+    try:
+        client.ping()
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Redis not reachable at {REDIS_URL}: {exc}")
+
+    def _clear():
+        for key in client.scan_iter(match=f"{_KEY_PREFIX}*"):
+            client.delete(key)
+
+    _clear()
+    yield client
+    _clear()
+
+
+def test_client_ops_app_relies_on(redis_client):
+    """from_url + setex + get + scan + delete with the app's exact usage.
+
+    Mirrors intel_cache.set_cached/get_cached (setex+get) and
+    decorators.invalidate_prefix (scan+delete by pattern).
+    """
+    r = redis_client
+
+    # setex with a TTL, then get — decode_responses=True returns a str, not bytes.
+    r.setex(f"{_KEY_PREFIX}k1", 60, '{"v": 1}')
+    assert r.get(f"{_KEY_PREFIX}k1") == '{"v": 1}'
+    assert r.ttl(f"{_KEY_PREFIX}k1") > 0
+
+    # scan + delete by pattern (the invalidate_prefix cursor loop).
+    r.setex(f"{_KEY_PREFIX}p:a", 60, "1")
+    r.setex(f"{_KEY_PREFIX}p:b", 60, "2")
+    found: list[str] = []
+    cursor = 0
+    while True:
+        cursor, keys = r.scan(cursor=cursor, match=f"{_KEY_PREFIX}p:*", count=100)
+        found.extend(keys)
+        if cursor == 0:
+            break
+    assert set(found) == {f"{_KEY_PREFIX}p:a", f"{_KEY_PREFIX}p:b"}
+    assert r.delete(*found) == 2
+    assert r.get(f"{_KEY_PREFIX}p:a") is None
+
+
+def test_intel_cache_get_redis_connects(monkeypatch):
+    """app.cache.intel_cache._get_redis() connects to a real Redis and round-trips."""
+    from app.cache import intel_cache
+    from app.config import settings
+
+    # Defeat the TESTING short-circuit and point at the live server.
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setattr(settings, "cache_backend", "redis", raising=False)
+    monkeypatch.setattr(settings, "redis_url", REDIS_URL, raising=False)
+    # Reset the lazy-init module globals so it reconnects with our settings.
+    monkeypatch.setattr(intel_cache, "_redis_init_attempted", False, raising=False)
+    monkeypatch.setattr(intel_cache, "_redis_client", None, raising=False)
+
+    client = intel_cache._get_redis()
+    assert client is not None, "intel_cache could not connect to Redis"
+    assert client.ping() is True
+
+    client.setex(f"{_KEY_PREFIX}gr", 30, "ok")
+    assert client.get(f"{_KEY_PREFIX}gr") == "ok"
+    client.delete(f"{_KEY_PREFIX}gr")
+
+
+def test_rate_limiter_picks_redis_storage(monkeypatch):
+    """rate_limit._resolve_storage() returns the Redis URL, not the in-memory
+    fallback."""
+    from app import rate_limit
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "cache_backend", "redis", raising=False)
+    monkeypatch.setattr(settings, "redis_url", REDIS_URL, raising=False)
+
+    assert rate_limit._resolve_storage() == REDIS_URL

--- a/tests/integration/test_redis_integration.py
+++ b/tests/integration/test_redis_integration.py
@@ -48,7 +48,16 @@ def redis_client():
     """
     import redis
 
-    client = redis.from_url(REDIS_URL, decode_responses=True, socket_connect_timeout=3)
+    # Match the app's full from_url kwarg set (intel_cache.py) so a removed/renamed
+    # constructor kwarg — e.g. retry_on_timeout, the canonical redis-py-8.0-style
+    # break — fails here too, not only via the _get_redis path.
+    client = redis.from_url(
+        REDIS_URL,
+        decode_responses=True,
+        socket_connect_timeout=3,
+        socket_timeout=2,
+        retry_on_timeout=True,
+    )
     try:
         client.ping()
     except Exception as exc:  # pragma: no cover - environment guard
@@ -89,6 +98,59 @@ def test_client_ops_app_relies_on(redis_client):
     assert set(found) == {f"{_KEY_PREFIX}p:a", f"{_KEY_PREFIX}p:b"}
     assert r.delete(*found) == 2
     assert r.get(f"{_KEY_PREFIX}p:a") is None
+
+
+def test_distributed_lock_set_nx_ex(redis_client):
+    """Set(key, val, nx=True, ex=N) — the lock primitive used in core_jobs and
+    activity_digest_service (and plain set/get in signature_parser /
+    material_enrichment_service).
+
+    A redis-py change to set()'s nx/ex handling or return contract would silently break
+    both locks; the rest of the file never exercises set().
+    """
+    r = redis_client
+    lock = f"{_KEY_PREFIX}lock"
+
+    assert r.set(lock, "1", nx=True, ex=30)  # first acquire -> truthy
+    assert r.set(lock, "1", nx=True, ex=30) is None  # contended -> None
+    assert r.ttl(lock) > 0
+    r.delete(lock)
+    assert r.set(lock, "1", nx=True, ex=30)  # acquirable again once cleared
+    r.delete(lock)
+
+    # plain set + get (no nx/ex) — signature_parser / material_enrichment_service.
+    r.set(f"{_KEY_PREFIX}plain", "v")
+    assert r.get(f"{_KEY_PREFIX}plain") == "v"
+    r.delete(f"{_KEY_PREFIX}plain")
+
+
+def test_search_service_get_redis_connects(monkeypatch):
+    """app.search_service._get_search_redis() — the app's SECOND redis client.
+
+    Distinct from intel_cache (different from_url kwargs) and references
+    redis.RedisError at module scope, which a redis-py reorg could move. Nothing else in
+    the job imports/executes this path, so without this test a break here ships green.
+    """
+    import redis
+
+    import app.search_service as search_service
+    from app.config import settings
+
+    # The module-level `except redis.RedisError` clauses must keep resolving.
+    assert issubclass(redis.RedisError, Exception)
+
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.setattr(settings, "redis_url", REDIS_URL, raising=False)
+    monkeypatch.setattr(search_service, "_search_redis", None, raising=False)
+    monkeypatch.setattr(search_service, "_search_redis_attempted", False, raising=False)
+
+    client = search_service._get_search_redis()
+    assert client is not None, "search_service could not connect to Redis"
+    assert client.ping() is True
+
+    client.setex(f"{_KEY_PREFIX}ss", 30, "ok")
+    assert client.get(f"{_KEY_PREFIX}ss") == "ok"
+    client.delete(f"{_KEY_PREFIX}ss")
 
 
 def test_intel_cache_get_redis_connects(monkeypatch):


### PR DESCRIPTION
Follow-up hardening from the Dependabot #217–#227 sweep — five independent improvements, one commit each. No app/runtime logic changes (only CI/deploy/deps/tooling + one new test).

### 1. Dependabot grouping (`bfe3aa35`)
The old config grouped only *minor-and-patch*, so dev floor-raises escaped as one-PR-each (how 11 PRs opened at once). Now **dev deps batch into one PR** (incl. majors — they never ship to prod); **prod minor/patch batch**; **prod MAJORS stay separate** for scrutiny + smoke (the redis-py 8.0 pattern). Paired with `deleteBranchOnMerge` (enabled on the repo) to end the stale-branch graveyard.

### 2. `deploy.sh` recreates the enrichment-worker (`9b02b7a9`)
deploy.sh rebuilt only `app`, so after a dep bump the worker kept running **stale wheels** (redis-py/anthropic) until manually recreated — hit during the sweep. Now both rebuild (shared Dockerfile → ~free) and the worker is verified by the same `BUILD_COMMIT`, recreated after the app is healthy.

### 3. Redis in CI + integration tests (`dca10520`)
CI had only Postgres; every redis path mocks under `TESTING=1`, so a redis-py break passes green (why #227 needed a manual smoke). Adds a `redis:7-alpine` service + a dedicated step driving the **real** client — `from_url/ping/get/setex/scan/delete` plus `intel_cache._get_redis` and `rate_limit._resolve_storage`. Gated on `INTEGRATION_REDIS_URL` (conftest blanks `REDIS_URL`). Verified locally (3 passed).

### 4. pip-tools lockfiles (`83e3d662`)
No lockfile + bare `pip install` = non-reproducible builds (redis-py 8 rode in unpinned). Now `requirements*.in` → fully-pinned `requirements*.txt` via pip-tools (prod 242 / dev 353; prod lock carries **zero** dev tools). CI fails on drift (deterministic; pip-tools itself pinned). Verified: clean-venv `pip install -r requirements.txt` + `import app.main` boots on the locked set.

### 5. `scripts/worktree-guard.sh` (`671e60fc`)
Stops automated cleanup from deleting a worktree with WIP — the `materials-filter-rework` vs merged `materials-filter-tree` name-collision near-miss. Removes a worktree only when **clean AND merged**; HOLDS anything else. Dry-run by default; companion to `branch-cleanup.sh`.

## Verification
- pre-commit clean across the full branch diff (ruff/format/mypy/yaml/...).
- Redis integration tests: **3 passed** against a real redis server.
- Lockfiles: deterministic recompile (byte-identical) + clean-venv install + app import smoke.
- `deploy.sh`: `bash -n` clean.
- `worktree-guard.sh`: live-tested — HOLDS this branch's own worktree (unmerged), marks the now-merged one SAFE.

CI on this PR exercises the new redis job, the lockfile-sync gate, and the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
