### PR TITLE
fix(workers): per-tick liveness heartbeat across enrichment/nc/ics workers

### DIFF
--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -56,6 +56,35 @@ signal.signal(signal.SIGINT, _handle_shutdown)
 # ---------------------------------------------------------------------------
 
 
+def _record_heartbeat(db: Session, breaker: "EnrichmentCircuitBreaker") -> bool:
+    """Refresh the liveness heartbeat on the status singleton — EVERY loop tick.
+
+    Called at the top of the main loop (before any branch returns/sleeps) so
+    ``last_heartbeat`` advances on idle, daily-cap, breaker-open and business-hours
+    ticks too — not only after a non-empty batch. Without this, a perfectly alive
+    worker can go ~1h between writes and a liveness monitor false-alarms "DOWN".
+
+    Also keeps the persisted breaker flag honest: ``breaker.should_stop()`` is
+    idempotent (auto-resets after cooldown), so writing it every tick clears a stale
+    ``circuit_breaker_open=True`` even when the queue is empty (the non-empty-batch
+    write that previously reset it never runs in that case).
+
+    Returns the current ``breaker_open`` state so the caller can reuse it without a
+    second ``should_stop()`` call.
+    """
+    from app.models.enrichment_worker_status import update_enrichment_worker_status
+
+    breaker_open = breaker.should_stop()
+    update_enrichment_worker_status(
+        db,
+        is_running=True,
+        last_heartbeat=datetime.now(timezone.utc),
+        circuit_breaker_open=breaker_open,
+        circuit_breaker_reason=(breaker.get_trip_info()["trip_reason"] if breaker_open else None),
+    )
+    return breaker_open
+
+
 def select_batch(db: Session, config: "EnrichmentWorkerConfig") -> list:
     """Return the next batch of cards eligible for enrichment.
 
@@ -75,6 +104,8 @@ def select_batch(db: Session, config: "EnrichmentWorkerConfig") -> list:
     """
     from app.models import MaterialCard
 
+    # NOTE: eligibility is read from material_cards.enrichment_status — NOT the (unused)
+    # enrichment_queue table. material_cards is the single source of enrichment state.
     now = datetime.now(timezone.utc)
     retry_cutoff = now - timedelta(hours=config.not_found_retry_hours)
 
@@ -361,6 +392,15 @@ async def main() -> None:
                 break
 
             try:
+                # Liveness heartbeat — EVERY tick, before any branch sleeps/continues, so
+                # last_heartbeat never goes stale on idle/cap/breaker/business-hours paths.
+                # Also reused below as the breaker-open gate (no second should_stop() call).
+                db = SessionLocal()
+                try:
+                    breaker_open = _record_heartbeat(db, breaker)
+                finally:
+                    db.close()
+
                 now_utc = datetime.now(timezone.utc)
                 today_date = now_utc.date()
 
@@ -422,22 +462,14 @@ async def main() -> None:
                     await asyncio.sleep(3600)
                     continue
 
-                # Circuit breaker check — long sleep when open
-                if breaker.should_stop():
-                    info = breaker.get_trip_info()
+                # Circuit breaker check — long sleep when open. Reuses the breaker_open
+                # value already persisted by _record_heartbeat at the top of this tick, so
+                # the status write is not duplicated here.
+                if breaker_open:
                     logger.error(
                         "ENRICH_WORKER: circuit breaker open ({}), sleeping 1h",
-                        info["trip_reason"],
+                        breaker.get_trip_info()["trip_reason"],
                     )
-                    db = SessionLocal()
-                    try:
-                        update_enrichment_worker_status(
-                            db,
-                            circuit_breaker_open=True,
-                            circuit_breaker_reason=info["trip_reason"],
-                        )
-                    finally:
-                        db.close()
                     await asyncio.sleep(3600)
                     continue
 

--- a/app/services/ics_worker/worker.py
+++ b/app/services/ics_worker/worker.py
@@ -57,6 +57,16 @@ def update_worker_status(db: Session, **kwargs):
     db.commit()
 
 
+def _record_heartbeat(db: Session):
+    """Refresh the worker liveness heartbeat to now.
+
+    Called at the top of every main-loop tick so last_heartbeat stays fresh on EVERY
+    path (idle, cap-sleep, breaker-open, off-hours) — not just after a completed search.
+    Keeps liveness monitors from false-alarming "worker DOWN".
+    """
+    update_worker_status(db, is_running=True, last_heartbeat=datetime.now(timezone.utc))
+
+
 async def main():
     """Main worker loop."""
     from app.database import SessionLocal
@@ -127,6 +137,14 @@ async def main():
                 break
 
             try:
+                # Refresh liveness heartbeat every tick — runs on ALL paths
+                # (idle, cap-sleep, breaker-open, off-hours), not just searches.
+                db = SessionLocal()
+                try:
+                    _record_heartbeat(db)
+                finally:
+                    db.close()
+
                 now_eastern = datetime.now(EASTERN)
 
                 # Reset daily stats at midnight

--- a/app/services/nc_worker/worker.py
+++ b/app/services/nc_worker/worker.py
@@ -55,6 +55,16 @@ def update_worker_status(db: Session, **kwargs):
     db.commit()
 
 
+def _record_heartbeat(db: Session):
+    """Refresh the worker liveness heartbeat for the current loop tick.
+
+    Called at the top of every main-loop iteration so last_heartbeat stays fresh on
+    EVERY path (idle, cap-sleep, breaker-open, business-hours), not just after
+    completing work. Returns early if the singleton row is absent.
+    """
+    update_worker_status(db, is_running=True, last_heartbeat=datetime.now(timezone.utc))
+
+
 async def run_ai_gate(db: Session):
     """Run the AI gate (async wrapper since claude_structured is async)."""
     from .ai_gate import process_ai_gate
@@ -131,6 +141,14 @@ def main():
                 break
 
             try:
+                # Refresh liveness heartbeat on EVERY tick, before any branch,
+                # so monitors don't false-alarm during idle/sleep/breaker paths.
+                db = SessionLocal()
+                try:
+                    _record_heartbeat(db)
+                finally:
+                    db.close()
+
                 now_eastern = datetime.now(EASTERN)
 
                 # Reset daily stats at midnight

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -357,7 +357,12 @@ once at startup by `seed_browser_worker_sources` (see `app/startup.py`)
 and the seed survives because the ping loop never touches them. Their
 actual health is tracked via `IcsWorkerStatus` / `NcWorkerStatus`
 heartbeats; both singletons are seeded at startup so
-`update_worker_status()` writes are not silently dropped.
+`update_worker_status()` writes are not silently dropped. Each worker
+(ics, nc, and enrichment) refreshes `last_heartbeat` on **every** loop
+tick via `_record_heartbeat()` at the top of the loop — so the heartbeat
+reflects process liveness independent of work, and stays fresh on idle /
+cap-sleep / breaker-open / off-hours paths (a liveness monitor reading
+`last_heartbeat` won't false-alarm "DOWN" while a worker is merely paused).
 
 ### Removed (2026-05-14)
 

--- a/tests/test_enrichment_worker.py
+++ b/tests/test_enrichment_worker.py
@@ -88,6 +88,79 @@ def test_update_helper_sets_fields(db_session):
 
 
 # ---------------------------------------------------------------------------
+# _record_heartbeat — top-of-loop liveness write (every tick)
+# ---------------------------------------------------------------------------
+
+
+def test_record_heartbeat_advances_with_closed_breaker(db_session):
+    """_record_heartbeat refreshes last_heartbeat, marks is_running, and clears the
+    breaker flag when the breaker is CLOSED — and returns False."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.enrichment_worker_status import EnrichmentWorkerStatus
+    from app.services.enrichment_worker.circuit_breaker import EnrichmentCircuitBreaker
+    from app.services.enrichment_worker.config import EnrichmentWorkerConfig
+    from app.services.enrichment_worker.worker import _record_heartbeat
+
+    # Seed the singleton with a stale heartbeat + a stale-open breaker flag.
+    stale = datetime.now(timezone.utc) - timedelta(hours=2)
+    db_session.add(
+        EnrichmentWorkerStatus(
+            id=1,
+            is_running=False,
+            last_heartbeat=stale,
+            circuit_breaker_open=True,
+            circuit_breaker_reason="old reason",
+        )
+    )
+    db_session.commit()
+
+    before = datetime.now(timezone.utc) - timedelta(seconds=5)
+    breaker = EnrichmentCircuitBreaker(EnrichmentWorkerConfig(circuit_breaker_errors=3))
+
+    result = _record_heartbeat(db_session, breaker)
+
+    assert result is False
+    db_session.expire_all()
+    row = db_session.get(EnrichmentWorkerStatus, 1)
+    assert row.is_running is True
+    assert row.last_heartbeat >= before  # advanced to ~now
+    assert row.circuit_breaker_open is False  # stale True cleared
+    assert row.circuit_breaker_reason is None
+
+
+def test_record_heartbeat_persists_open_breaker_and_reason(db_session):
+    """With a TRIPPED breaker, _record_heartbeat persists circuit_breaker_open=True with
+    the trip reason — and returns True."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.enrichment_worker_status import EnrichmentWorkerStatus
+    from app.services.enrichment_worker.circuit_breaker import EnrichmentCircuitBreaker
+    from app.services.enrichment_worker.config import EnrichmentWorkerConfig
+    from app.services.enrichment_worker.worker import _record_heartbeat
+
+    db_session.add(EnrichmentWorkerStatus(id=1))
+    db_session.commit()
+
+    cfg = EnrichmentWorkerConfig(circuit_breaker_errors=2)
+    breaker = EnrichmentCircuitBreaker(cfg)
+    for _ in range(cfg.circuit_breaker_errors):
+        breaker.record_claude_error()
+    assert breaker.should_stop()  # tripped
+
+    before = datetime.now(timezone.utc) - timedelta(seconds=5)
+    result = _record_heartbeat(db_session, breaker)
+
+    assert result is True
+    db_session.expire_all()
+    row = db_session.get(EnrichmentWorkerStatus, 1)
+    assert row.is_running is True
+    assert row.last_heartbeat >= before
+    assert row.circuit_breaker_open is True
+    assert row.circuit_breaker_reason  # non-empty trip reason set
+
+
+# ---------------------------------------------------------------------------
 # Task 8: EnrichmentWorkerConfig
 # ---------------------------------------------------------------------------
 

--- a/tests/test_ics_worker.py
+++ b/tests/test_ics_worker.py
@@ -15,6 +15,7 @@ from app.models.ics_worker_status import IcsWorkerStatus
 from app.services.ics_worker.worker import (
     EASTERN,
     _handle_shutdown,
+    _record_heartbeat,
     update_worker_status,
 )
 
@@ -73,6 +74,32 @@ class TestUpdateWorkerStatus:
         update_worker_status(db_session, searches_today=1)
         db_session.refresh(ws)
         assert ws.updated_at is not None
+
+
+# ── Tests: _record_heartbeat ────────────────────────────────────
+
+
+class TestRecordHeartbeat:
+    def test_advances_heartbeat_and_marks_running(self, db_session):
+        """_record_heartbeat refreshes last_heartbeat to ~now and sets is_running."""
+        status = _seed_worker_status(db_session)
+        # Seed a stale heartbeat well in the past.
+        stale = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        status.last_heartbeat = stale
+        status.is_running = False
+        db_session.commit()
+
+        before = datetime.now(timezone.utc)
+        _record_heartbeat(db_session)
+        after = datetime.now(timezone.utc)
+
+        refreshed = db_session.query(IcsWorkerStatus).filter_by(id=1).first()
+        assert refreshed.is_running is True
+        hb = refreshed.last_heartbeat
+        if hb.tzinfo is None:
+            hb = hb.replace(tzinfo=timezone.utc)
+        assert hb > stale
+        assert before <= hb <= after
 
 
 # ── Tests: _handle_shutdown ──────────────────────────────────────

--- a/tests/test_nc_worker_full.py
+++ b/tests/test_nc_worker_full.py
@@ -1397,6 +1397,25 @@ class TestWorker:
         assert ws.is_running is True
         assert ws.searches_today == 5
 
+    def test_record_heartbeat_advances_timestamp(self, db_session):
+        """_record_heartbeat refreshes last_heartbeat to ~now and sets is_running."""
+        from datetime import datetime, timedelta, timezone
+
+        from app.services.nc_worker.worker import _record_heartbeat
+
+        stale = datetime.now(timezone.utc) - timedelta(hours=1)
+        ws = NcWorkerStatus(id=1, is_running=False, last_heartbeat=stale)
+        db_session.add(ws)
+        db_session.commit()
+
+        _record_heartbeat(db_session)
+        db_session.refresh(ws)
+
+        assert ws.is_running is True
+        assert ws.last_heartbeat is not None
+        assert ws.last_heartbeat > stale
+        assert datetime.now(timezone.utc) - ws.last_heartbeat < timedelta(seconds=30)
+
     def test_update_worker_status_no_row(self, db_session):
         """update_worker_status does nothing when no singleton row exists."""
         from app.services.nc_worker.worker import update_worker_status


### PR DESCRIPTION
## Problem (found in the 3-worker health review)

All three background workers (`enrichment_worker`, `nc_worker`, `ics_worker`) wrote `last_heartbeat` **only after completing work** — never on the idle / daily-cap / breaker-open / off-hours paths. So `last_heartbeat` goes stale (up to **~1h** for enrichment's cap-sleep) while the process is perfectly alive. Any liveness monitor on `*_worker_status.last_heartbeat` would **false-alarm "worker DOWN."** Observed live: enrichment's heartbeat read ~5 min stale *while actively processing a batch*.

## Fix (consistent across all 3)

Each worker gains a module-level **`_record_heartbeat(...)`** called at the **top of its main loop**, so `last_heartbeat` refreshes on **every tick** regardless of which branch runs (idle, cap, breaker, business-hours).

- **enrichment**: `_record_heartbeat(db, breaker) -> bool` also persists the **breaker flag every tick** — it was only reset to `False` after a *non-empty* batch, so it went stale-`True` if the breaker recovered while the queue was empty. The breaker check now **reuses** the returned value (no second `should_stop()`), and the redundant in-branch status write is dropped. Plus a `select_batch` comment noting it reads `material_cards`, not the unused `enrichment_queue` table.
- **nc / ics**: identical `_record_heartbeat(db)` (`is_running=True, last_heartbeat=now`).

## Tests
Direct unit tests per worker (seed the status singleton, call `_record_heartbeat`, assert `last_heartbeat` advances past a stale value + `is_running=True`; enrichment: breaker-closed **clears** the stale flag, breaker-tripped **persists** it + reason). **311 worker-suite tests pass**; ruff + mypy clean. `APP_MAP_INTERACTIONS` updated.

Note: `monitoring.py` has no heartbeat consumer yet — this is forward-prep for the liveness monitor those `*_worker_status` tables are built for. The host `nc`/`ics` systemd units must be restarted to pick this up (separate from the docker deploy) — I'll handle that at deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
