### PR TITLE
deploy: restart host nc/ics worker systemd units after deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,8 +225,10 @@ docker compose down               # Stop everything
 templates/static/Vite always rebuild fresh while apt/pip/npm-ci cache — no `--no-cache`),
 rebuilds + recreates **both** the `app` and `enrichment-worker` containers (they share
 `requirements.txt`, so the worker must not lag the app on a dependency bump), waits for
-the app health check, verifies the deployed build tag on both, and checks that Tailwind
-classes in templates exist in the built CSS bundle.
+the app health check, verifies the deployed build tag on both, checks that Tailwind
+classes in templates exist in the built CSS bundle, and restarts the host `nc`/`ics`
+worker systemd units (they run from `/root/availai` outside docker, so they'd otherwise
+keep running stale code after a deploy).
 Never use bare `docker compose up -d --build` (without `--build-arg BUILD_COMMIT=...`) —
 it ships stale templates.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -192,15 +192,20 @@ fi
 # pinned deps is a separate follow-up.
 echo ""
 echo "==> Restarting host worker units (nc/ics)..."
+HOST_WORKER_WARN=""
 for unit in avail-nc-worker avail-ics-worker; do
-    if systemctl cat "${unit}.service" >/dev/null 2>&1; then
-        if systemctl restart "${unit}.service" 2>/dev/null || sudo systemctl restart "${unit}.service" 2>/dev/null; then
-            echo "==> restarted ${unit} ($(systemctl is-active "${unit}.service" 2>/dev/null || true))"
-        else
-            echo "==> WARNING: could not restart ${unit} — restart it manually if its code changed"
-        fi
-    else
+    if ! systemctl cat "${unit}.service" >/dev/null 2>&1; then
         echo "==> ${unit} not installed here — skipping"
+        continue
+    fi
+    # Capture stderr so a failed restart reports WHY (needs-root vs broken new code vs transient),
+    # instead of a generic "could not restart". Try unprivileged, then escalate to sudo.
+    if restart_err=$(systemctl restart "${unit}.service" 2>&1) \
+        || restart_err=$(sudo systemctl restart "${unit}.service" 2>&1); then
+        echo "==> restarted ${unit} ($(systemctl is-active "${unit}.service" 2>/dev/null || true))"
+    else
+        echo "==> WARNING: could not restart ${unit}: ${restart_err}"
+        HOST_WORKER_WARN="${HOST_WORKER_WARN} ${unit}"
     fi
 done
 
@@ -208,5 +213,14 @@ done
 echo ""
 echo "==> Recent app logs:"
 docker compose logs --tail=20 app
+
+# Re-surface any host-worker restart failure AFTER the log dump, so the operator's last
+# line is the actionable warning — a SILENTLY stale host worker is the bug this prevents.
+if [ -n "${HOST_WORKER_WARN}" ]; then
+    echo ""
+    echo "==> ⚠️  Deploy OK, but these host worker(s) FAILED to restart and may be running stale code."
+    echo "==>     Restart them manually:${HOST_WORKER_WARN}"
+fi
+
 echo ""
 echo "==> Deploy complete."

--- a/deploy.sh
+++ b/deploy.sh
@@ -183,6 +183,27 @@ else
     fi
 fi
 
+# Step 6b: Restart the HOST nc/ics worker systemd units.
+# nc_worker and ics_worker run on the HOST (systemd units from /root/availai), OUTSIDE
+# docker — so a deploy that changes their code would otherwise leave them on stale code
+# until someone manually restarts them. Best-effort + idempotent: only touches units
+# that exist (a no-op on CI / boxes without them). NOTE: these host workers use
+# host-installed deps, NOT the pinned requirements.txt lockfile — folding them onto the
+# pinned deps is a separate follow-up.
+echo ""
+echo "==> Restarting host worker units (nc/ics)..."
+for unit in avail-nc-worker avail-ics-worker; do
+    if systemctl cat "${unit}.service" >/dev/null 2>&1; then
+        if systemctl restart "${unit}.service" 2>/dev/null || sudo systemctl restart "${unit}.service" 2>/dev/null; then
+            echo "==> restarted ${unit} ($(systemctl is-active "${unit}.service" 2>/dev/null || true))"
+        else
+            echo "==> WARNING: could not restart ${unit} — restart it manually if its code changed"
+        fi
+    else
+        echo "==> ${unit} not installed here — skipping"
+    fi
+done
+
 # Step 7: Show recent logs to confirm the right code is running
 echo ""
 echo "==> Recent app logs:"


### PR DESCRIPTION
Closes the host-worker deploy gap from the 3-worker review: `nc_worker`/`ics_worker` run as **host** systemd units (from `/root/availai`, outside docker), so `deploy.sh` — which only rebuilds the docker app+worker — left them on **stale code** until a manual `systemctl restart` (observed: they ran ~7h-old pre-#229 code until I restarted them by hand for #238).

`deploy.sh` now restarts `avail-nc-worker` / `avail-ics-worker` after the docker recreate. Best-effort + idempotent: gated on `systemctl cat` (no-op on CI/boxes without the units), sudo fallback, and a clear WARNING if a restart fails. Verified `bash -n` clean; the `systemctl restart` of these units was already validated live during the #238 deploy.

Separate follow-up (not here): the host workers use **host-installed deps**, not the pinned `requirements.txt` lockfile — folding them onto the pinned deps is a bigger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)