### PR TITLE
chore: upgrade to Python 3.13

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "AvailAI Dev",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "workspaceFolder": "/workspace",
   "features": {
     "ghcr.io/devcontainers/features/node:1": { "version": "20" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,10 @@ jobs:
         with:
           fetch-depth: 0  # full history so merge-base / changed-files diff works
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
 
       - name: Set up Node.js

--- a/.github/workflows/dependabot-lockfile-sync.yml
+++ b/.github/workflows/dependabot-lockfile-sync.yml
@@ -51,10 +51,10 @@ jobs:
           # but the PR's earlier failing check stays stale-red until a manual re-run.
           token: ${{ secrets.DEPENDABOT_LOCKFILE_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Recompile pip-tools lockfiles
         # Pinned pip-tools + identical flags to ci.yml's drift gate, so the output is

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
 
       - name: Set up Node.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY app/templates/ app/templates/
 RUN npm run build
 
 # Stage 2: Python application
-FROM python:3.12-slim@sha256:9d3abd9fc11d06998ccdbdd93b4dd49b5ad7d67fcbbc11c016eb0eb2c2194891
+FROM python:3.13-slim@sha256:b04b5d7233d2ad9c379e22ea8927cd1378cd15c60d4ef876c065b25ea8fb3bf3
 
 WORKDIR /app
 

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -11,7 +11,7 @@ only (no code imports it) and depends on the main repo files like
 ## 1. Prerequisites
 
 - **Docker + Docker Compose** (recommended way to run everything locally)
-- **Python 3.12** (for running the app directly or tests without Docker)
+- **Python 3.13** (for running the app directly or tests without Docker)
 - **Node 20 + npm** (only if you are rebuilding the frontend)
 
 You should also have a **`.env`** file at the project root. For local dev you

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -10,7 +10,7 @@ AvailAI is a production electronic component sourcing platform and CRM. Buyers s
 
 | Layer | Technology |
 |-------|-----------|
-| **Backend** | Python 3.12, FastAPI, Uvicorn |
+| **Backend** | Python 3.13, FastAPI, Uvicorn |
 | **Database** | PostgreSQL 16, SQLAlchemy 2.0, Alembic |
 | **Cache** | Redis 7 (fallback: PG JSONB) |
 | **Frontend** | Jinja2 + HTMX 2.0 + Alpine.js 3.15 + Tailwind CSS |

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.12
+python_version = 3.13
 warn_return_any = true
 warn_unused_configs = true
 check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ exclude_dirs = ["tests", "alembic"]
 skips = ["B101"]  # allow assert in non-test code (used in type narrowing)
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 ignore_missing_imports = true
 no_strict_optional = true
 warn_unused_ignores = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -339,15 +339,10 @@ types-setuptools==82.0.0.20260518
 typing-extensions==4.15.0
     # via
     #   -c requirements.txt
-    #   anyio
-    #   cyclonedx-python-lib
     #   mypy
     #   pyee
-    #   pytest-asyncio
-    #   referencing
     #   schemathesis
     #   sqlalchemy
-    #   starlette
 urllib3==2.7.0
     # via
     #   -c requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -198,7 +198,6 @@ typing-extensions==4.15.0
     # via
     #   alembic
     #   anthropic
-    #   anyio
     #   azure-communication-callautomation
     #   azure-core
     #   beautifulsoup4
@@ -208,7 +207,6 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   pyee
     #   sqlalchemy
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py312"
+target-version = "py313"
 line-length = 120
 
 [lint]


### PR DESCRIPTION
## What

Upgrades the runtime from **Python 3.12 → 3.13** — the deliberate, validated upgrade we chose over the bleeding-edge **3.14** that #231 proposed (and we declined: 3.14 is too new and `patchright` had no cp314 wheel).

## Why 3.13 is safe (wheel-checked first)
Full wheel coverage across the tree — `patchright` ships a `py3-none` wheel; `psycopg2-binary`/`orjson`/`hiredis`/`pydantic-core` have cp313, `nh3`/`cryptography` are abi3, `weasyprint` is pure-python. No build-from-source anywhere.

## Changes
- `Dockerfile`: base `python:3.12-slim` → `python:3.13-slim` (digest-pinned).
- `ci.yml` + `security.yml` + `dependabot-lockfile-sync.yml`: `setup-python` 3.12 → 3.13.
- `ruff.toml` `target-version` py312→py313; `mypy` `python_version` 3.12→3.13 (`mypy.ini` + `pyproject.toml`).
- `requirements*.txt`: **recompiled under 3.13** — same package versions, only a few `# via` annotation lines shift with the 3.12→3.13 markers (so CI's lockfile-sync gate, now on 3.13, matches).
- `docs/APP_MAP_ARCHITECTURE.md`: backend row → 3.13.

## Validation (local, before this PR)
- ✅ App image **builds on 3.13** — all 242 pinned deps install, no wheel gaps.
- ✅ `pip check`: no broken requirements.
- ✅ `import app.main` on **Python 3.13.13**.
- ✅ weasyprint 69 renders a PDF on 3.13.
- CI here runs the **full suite on 3.13** + the lockfile-sync gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
