### PR TITLE
Fold host nc/ics workers onto the pinned requirements.txt lockfile

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -183,16 +183,30 @@ else
     fi
 fi
 
-# Step 6b: Restart the HOST nc/ics worker systemd units.
+# Step 6b: Refresh the host worker venv, then restart the HOST nc/ics worker units.
 # nc_worker and ics_worker run on the HOST (systemd units from /root/availai), OUTSIDE
 # docker — so a deploy that changes their code would otherwise leave them on stale code
-# until someone manually restarts them. Best-effort + idempotent: only touches units
-# that exist (a no-op on CI / boxes without them). NOTE: these host workers use
-# host-installed deps, NOT the pinned requirements.txt lockfile — folding them onto the
-# pinned deps is a separate follow-up.
+# until someone manually restarts them. They run from the pinned-lockfile venv
+# (/root/availai/.venv, built from requirements.txt) so they carry the SAME pinned deps
+# as the docker images; this step re-syncs that venv to the current lock before restart.
+# Best-effort + idempotent: only touches the venv/units that exist (a no-op on CI / boxes
+# without them).
+echo ""
+echo "==> Refreshing host worker venv from requirements.txt..."
+HOST_WORKER_WARN=""
+if [ -x .venv/bin/pip ]; then
+    if venv_err=$(.venv/bin/pip install -q -r requirements.txt 2>&1); then
+        echo "==> host venv in sync with pinned lock (patchright $(.venv/bin/pip show patchright 2>/dev/null | awk '/^Version:/{print $2}'))"
+    else
+        echo "==> WARNING: host worker venv refresh FAILED (workers may run stale deps):"
+        echo "${venv_err}" | tail -5
+        HOST_WORKER_WARN="${HOST_WORKER_WARN} venv-refresh"
+    fi
+else
+    echo "==> no host worker venv (.venv) here — skipping refresh"
+fi
 echo ""
 echo "==> Restarting host worker units (nc/ics)..."
-HOST_WORKER_WARN=""
 for unit in avail-nc-worker avail-ics-worker; do
     if ! systemctl cat "${unit}.service" >/dev/null 2>&1; then
         echo "==> ${unit} not installed here — skipping"
@@ -214,12 +228,15 @@ echo ""
 echo "==> Recent app logs:"
 docker compose logs --tail=20 app
 
-# Re-surface any host-worker restart failure AFTER the log dump, so the operator's last
-# line is the actionable warning — a SILENTLY stale host worker is the bug this prevents.
+# Re-surface any host-worker venv/restart failure AFTER the log dump, so the operator's
+# last line is the actionable warning — a SILENTLY stale host worker is the bug this
+# prevents (stale code OR stale deps).
 if [ -n "${HOST_WORKER_WARN}" ]; then
     echo ""
-    echo "==> ⚠️  Deploy OK, but these host worker(s) FAILED to restart and may be running stale code."
-    echo "==>     Restart them manually:${HOST_WORKER_WARN}"
+    echo "==> ⚠️  Deploy OK, but these host worker step(s) FAILED and may leave workers on stale code/deps:"
+    echo "==>    ${HOST_WORKER_WARN}"
+    echo "==>     Fix manually: 'cd /root/availai && .venv/bin/pip install -r requirements.txt' (deps),"
+    echo "==>     then 'sudo systemctl restart avail-nc-worker avail-ics-worker'."
 fi
 
 echo ""

--- a/deploy/avail-ics-worker.service
+++ b/deploy/avail-ics-worker.service
@@ -12,7 +12,10 @@ WorkingDirectory=/root/availai
 EnvironmentFile=/root/availai/.env.ics-worker
 Environment="DISPLAY=:99"
 Environment="PYTHONPATH=/root/availai"
-ExecStart=/usr/bin/python3 -m app.services.ics_worker.worker
+# Runs from the pinned-lockfile venv (requirements.txt), NOT system python, so the
+# host workers carry the same pinned deps as the docker app/enrichment images.
+# deploy.sh refreshes this venv from requirements.txt on every deploy.
+ExecStart=/root/availai/.venv/bin/python -m app.services.ics_worker.worker
 Restart=on-failure
 RestartSec=300
 StandardOutput=journal

--- a/deploy/avail-nc-worker.service
+++ b/deploy/avail-nc-worker.service
@@ -1,18 +1,21 @@
 [Unit]
 Description=AVAIL NetComponents Search Worker
 Documentation=https://github.com/TRIOSCS/Avail-AI-Test
-After=network.target postgresql.service avail-xvfb.service
+After=network.target avail-xvfb.service
 Requires=avail-xvfb.service
 
 [Service]
 Type=simple
-User=avail
-Group=avail
-WorkingDirectory=/home/avail/avail-ai
-EnvironmentFile=/home/avail/avail-ai/.env
+User=root
+Group=root
+WorkingDirectory=/root/availai
+EnvironmentFile=/root/availai/.env.nc-worker
 Environment="DISPLAY=:99"
-Environment="PYTHONPATH=/home/avail/avail-ai"
-ExecStart=/home/avail/avail-ai/.venv/bin/python -m app.services.nc_worker.worker
+Environment="PYTHONPATH=/root/availai"
+# Runs from the pinned-lockfile venv (requirements.txt), NOT system python, so the
+# host workers carry the same pinned deps as the docker app/enrichment images.
+# deploy.sh refreshes this venv from requirements.txt on every deploy.
+ExecStart=/root/availai/.venv/bin/python -m app.services.nc_worker.worker
 Restart=on-failure
 RestartSec=300
 StandardOutput=journal

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1301,8 +1301,25 @@ deploy.sh
     |       +---> Scan templates for Tailwind color classes
     |       +---> Grep CSS bundle for each class
     |       +---> Warn on any MISSING classes (safelist gap)
+    +---> Step 6b: Host worker venv refresh + restart (nc/ics)
+    |       +---> pip install -r requirements.txt into /root/availai/.venv
+    |       +---> systemctl restart avail-nc-worker avail-ics-worker
+    |       +---> WARN (re-surfaced after logs) if venv/restart fails
     +---> Step 7: Tail logs for errors
 ```
+
+**Host worker dependencies (pinned-lockfile venv).** The `avail-nc-worker`
+/ `avail-ics-worker` systemd units run on the HOST (outside docker, from
+`/root/availai`, `User=root`) and execute
+`/root/availai/.venv/bin/python -m app.services.{nc,ics}_worker.worker`.
+That venv is built from the SAME pinned `requirements.txt` as the docker
+app/enrichment images (not ad-hoc `pip install patchright beautifulsoup4`),
+so the host workers carry identical pinned deps — notably `patchright`,
+which they use to drive **system Google Chrome** via `channel="chrome"`
+(the bundled Chromium is unused). `deploy.sh` Step 6b refreshes the venv
+from the lockfile and restarts both units on every deploy;
+`scripts/setup_nc_worker.sh` bootstraps the venv on a fresh host. The
+unit files live in `deploy/avail-{nc,ics}-worker.service`.
 
 ---
 

--- a/scripts/setup_nc_worker.sh
+++ b/scripts/setup_nc_worker.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
-# Setup script for NetComponents search worker on DigitalOcean server.
-# Run once on initial deployment. Installs Xvfb, Chrome, and Python deps.
+# Setup script for NetComponents search worker on the host server.
+# Run once on initial deployment. Installs Xvfb, Chrome, and the pinned Python deps.
+#
+# The host nc/ics workers run from the pinned-lockfile venv at /root/availai/.venv
+# (built from requirements.txt) — the SAME pinned deps as the docker app/enrichment
+# images. deploy.sh refreshes this venv on every deploy; this script bootstraps it.
 #
 # Usage: sudo bash scripts/setup_nc_worker.sh
 
 set -euo pipefail
+
+REPO_DIR=/root/availai
 
 echo "=== AVAIL NC Worker Setup ==="
 
@@ -13,7 +19,7 @@ echo "Installing Xvfb..."
 apt-get update -qq
 apt-get install -y -qq xvfb
 
-# Install Google Chrome (Patchright needs real Chrome, not Chromium)
+# Install Google Chrome (Patchright drives real Chrome via channel="chrome", not Chromium)
 echo "Installing Google Chrome..."
 if ! command -v google-chrome &>/dev/null; then
     wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
@@ -26,26 +32,24 @@ else
     echo "Chrome already installed: $(google-chrome --version)"
 fi
 
-# Python deps (in AVAIL's virtualenv)
-echo "Installing Python dependencies..."
-cd /home/avail/avail-ai
-if [ -d ".venv" ]; then
-    source .venv/bin/activate
-    pip install -q patchright beautifulsoup4
-    patchright install chrome
-else
-    echo "WARNING: No .venv found at /home/avail/avail-ai/.venv"
-    echo "Install patchright and beautifulsoup4 manually in your Python environment."
+# Python deps — pinned-lockfile venv (requirements.txt), NOT ad-hoc pip installs.
+echo "Building pinned-lockfile venv at ${REPO_DIR}/.venv..."
+cd "${REPO_DIR}"
+if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
 fi
+.venv/bin/python -m pip install --quiet --upgrade pip
+.venv/bin/pip install --quiet -r requirements.txt
+# Patchright drives system Google Chrome (channel="chrome"); register it.
+.venv/bin/patchright install chrome
+echo "venv built; patchright $(.venv/bin/pip show patchright | awk '/^Version:/{print $2}')"
 
-# Create browser profile directory
+# Create browser profile directory (worker runs as root from /root/availai)
 echo "Creating browser profile directory..."
-mkdir -p /home/avail/nc_browser_profile
-chown avail:avail /home/avail/nc_browser_profile
+mkdir -p /root/nc_browser_profile
 
 # Create log directory
 mkdir -p /var/log/avail-nc
-chown avail:avail /var/log/avail-nc
 
 # Install systemd services
 echo "Installing systemd services..."
@@ -56,16 +60,15 @@ systemctl enable avail-xvfb
 systemctl enable avail-nc-worker
 
 # Secure .env file permissions (contains NC credentials)
-if [ -f /home/avail/avail-ai/.env ]; then
-    chmod 600 /home/avail/avail-ai/.env
-    chown avail:avail /home/avail/avail-ai/.env
-    echo ".env permissions set to 600 (owner-only read/write)"
+if [ -f "${REPO_DIR}/.env.nc-worker" ]; then
+    chmod 600 "${REPO_DIR}/.env.nc-worker"
+    echo ".env.nc-worker permissions set to 600 (owner-only read/write)"
 fi
 
 echo ""
 echo "=== Setup Complete ==="
 echo "Next steps:"
-echo "  1. Add NC_USERNAME and NC_PASSWORD to your .env file"
+echo "  1. Add NC_USERNAME and NC_PASSWORD to ${REPO_DIR}/.env.nc-worker"
 echo "  2. Start Xvfb:     sudo systemctl start avail-xvfb"
 echo "  3. Start worker:   sudo systemctl start avail-nc-worker"
 echo "  4. Check status:   sudo systemctl status avail-nc-worker"


### PR DESCRIPTION
## What

The host `avail-nc-worker` / `avail-ics-worker` systemd units ran `/usr/bin/python3` against **ad-hoc system site-packages** (`patchright 1.52.5`), diverging from the pinned deps the docker app/enrichment images run (`patchright 1.60.1`). This folds them onto the **same pinned `requirements.txt` lockfile**.

## Changes

- **`deploy/avail-{nc,ics}-worker.service`** — `ExecStart` now runs `/root/availai/.venv/bin/python` (a venv built from `requirements.txt`) instead of system python. `avail-nc-worker.service` also rewritten from the stale `/home/avail` layout to the live `/root/availai` + `User=root` reality (`avail-ics` already matched).
- **`deploy.sh` Step 6b** — refreshes the venv (`pip install -r requirements.txt`) **before** restarting the units on every deploy; loud WARNING (re-surfaced after the log dump) if the venv refresh or a restart fails. No-ops on CI/boxes without the venv.
- **`scripts/setup_nc_worker.sh`** — bootstraps the venv from `requirements.txt` (was ad-hoc `pip install patchright beautifulsoup4`) and corrected to the `/root` layout.
- **`docs/APP_MAP_INTERACTIONS.md`** — documents the host-worker venv + deploy Step 6b.

## Why

The host workers were the last piece running unpinned deps. Now nc/ics carry identical pinned versions to the docker images — reproducible, and `patchright` upgrades to the tested `1.60.1`. They drive **system Google Chrome** via `channel="chrome"` (bundled Chromium unused), so the browser is independent of the venv.

## Verification (already applied to the host)

- venv built from `requirements.txt` on python3.12 → `pip check` clean, `patchright 1.60.1`.
- Both units repointed, `daemon-reload`, restarted → **active**; `lsof` confirms both live PIDs load from `/root/availai/.venv/lib/python3.12/site-packages`.
- **nc**: clean start → NC login success → idle (queue empty, no SFDC demand).
- **ics**: clean start → **"browser session ready"** — launched headed Chrome 149 under the upgraded patchright, proving end-to-end browser automation on the pinned version.
- `pre-commit` (changed files) + `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)