### PR TITLE
feat(enrichment SP1): stop the bleeding — retire Haiku guesser, gate spec reader, clean polluted data

### DIFF
--- a/alembic/versions/091_cleanup_vague_descs.py
+++ b/alembic/versions/091_cleanup_vague_descs.py
@@ -1,0 +1,100 @@
+"""SP1 data cleanup — null out hallucinated descriptions and untrustworthy spec stamps.
+
+What: One-off DATA-ONLY backfill that undoes the damage from the now-removed automated
+      Haiku enrichment path. (1) Nulls hallucinated free-text descriptions on never-sourced
+      not_found cards (descriptions containing hedging tokens like "likely"/"possibly"),
+      and (2) clears specs_enriched_at on any card whose status is NOT trustworthy
+      (verified/web_sourced/oem_sourced) so the status-gated spec reader re-evaluates it
+      cleanly. Both affected sets are snapshotted into _sp1_desc_backup so downgrade is exact.
+Called by: alembic (upgrade/downgrade).
+Depends on: material_cards table; SP1 reader status gate in spec_enrichment_service.py.
+
+KNOWN ORDERING DEPENDENCY (intentional, NOT a silent hole): clearing
+``specs_enriched_at`` on the untrustworthy cards does NOT delete the stale
+``material_spec_facets`` rows those cards previously produced. After the stamp is
+cleared the status gate prevents those cards from being re-processed, so the orphaned
+facets are intentionally left in place for SP2 (provenance rework). SP2 adds
+``source``/``tier`` columns to MaterialSpecFacet, which lets it distinguish
+guess-derived ``spec_extraction`` facets from deterministic ``mpn_decode`` ones and
+purge/re-rank them accordingly. We leave them here rather than blind-delete because this
+migration cannot tell which facets came from a guess vs. a deterministic decode.
+
+Revision ID: 091_cleanup_vague_descs
+Revises: 090_add_condition_mc
+Create Date: 2026-06-09
+"""
+
+from loguru import logger
+from sqlalchemy import text
+
+from alembic import op
+
+revision = "091_cleanup_vague_descs"
+down_revision = "090_add_condition_mc"
+branch_labels = None
+depends_on = None
+
+# Hedging tokens that betray a hallucinated/guessed description. A never-sourced
+# (enrichment_source IS NULL) not_found card carrying any of these is junk, not data.
+_VAGUE_DESC_WHERE = (
+    "deleted_at IS NULL "
+    "AND enrichment_status = 'not_found' "
+    "AND enrichment_source IS NULL "
+    "AND description IS NOT NULL "
+    "AND (description ILIKE '%likely%' "
+    "OR description ILIKE '%possibly%' "
+    "OR description ILIKE '%may be%' "
+    "OR description ILIKE '%proprietary%' "
+    "OR description ILIKE '%appears to be%' "
+    "OR description ILIKE '%could be%')"
+)
+
+# Any card stamped as spec-enriched whose status is NOT trustworthy was seeded from a
+# guess/orphan description before the reader gate existed — clear the stamp so it re-evaluates.
+_UNTRUSTWORTHY_STAMP_WHERE = (
+    "deleted_at IS NULL "
+    "AND specs_enriched_at IS NOT NULL "
+    "AND enrichment_status NOT IN ('verified', 'web_sourced', 'oem_sourced')"
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # (a) Snapshot every row this migration will touch (either branch) so downgrade is exact.
+    conn.execute(text("DROP TABLE IF EXISTS _sp1_desc_backup"))
+    conn.execute(
+        text(
+            "CREATE TABLE _sp1_desc_backup AS "
+            "SELECT id, description, specs_enriched_at FROM material_cards "
+            f"WHERE ({_VAGUE_DESC_WHERE}) OR ({_UNTRUSTWORTHY_STAMP_WHERE})"
+        )
+    )
+
+    # (b) Null hallucinated descriptions on never-sourced not_found cards.
+    result = conn.execute(text(f"UPDATE material_cards SET description = NULL WHERE {_VAGUE_DESC_WHERE}"))
+    logger.info("SP1 cleanup: nulled {} hallucinated not_found descriptions", result.rowcount)
+
+    # (c) Clear spec stamps that were set from untrustworthy descriptions.
+    result = conn.execute(
+        text(f"UPDATE material_cards SET specs_enriched_at = NULL WHERE {_UNTRUSTWORTHY_STAMP_WHERE}")
+    )
+    logger.info("SP1 cleanup: cleared {} untrustworthy specs_enriched_at stamps", result.rowcount)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    # There is NO existence guard here by design: this UPDATE ... FROM _sp1_desc_backup
+    # references the snapshot table directly, so if the snapshot is missing the statement
+    # ERRORS LOUD. That is the safe behaviour — without the snapshot we cannot restore the
+    # original descriptions/stamps, and silently swallowing the missing-backup error would
+    # be a quiet data-loss path (downgrade reporting success while restoring nothing). We
+    # deliberately do NOT suppress it.
+    conn.execute(
+        text(
+            "UPDATE material_cards m "
+            "SET description = b.description, specs_enriched_at = b.specs_enriched_at "
+            "FROM _sp1_desc_backup b WHERE m.id = b.id"
+        )
+    )
+    conn.execute(text("DROP TABLE IF EXISTS _sp1_desc_backup"))

--- a/app/config.py
+++ b/app/config.py
@@ -123,10 +123,6 @@ class Settings(BaseSettings):
     customer_enrichment_contacts_per_account: int = 5
 
     # --- Material card AI enrichment ---
-    # Disabled: AI-only enrichment produces hallucinated data. Rebuild with
-    # real connector data (DigiKey, Mouser, Nexar) before re-enabling.
-    material_enrichment_enabled: bool = False
-    material_enrichment_batch_size: int = 300
     # Deterministic MPN→spec decoders (storage/DRAM): zero-network, zero-LLM, regex-gated.
     # Safe to leave on — values are enum-validated by record_spec. See app/services/mpn_decoder.
     mpn_decode_enabled: bool = True

--- a/app/jobs/tagging_jobs.py
+++ b/app/jobs/tagging_jobs.py
@@ -1,8 +1,9 @@
-"""Material tagging background jobs — Claude Haiku AI, prefix, sighting, boost.
+"""Material tagging background jobs — Claude Haiku AI, prefix, sighting, boost, spec
+sweep.
 
 Called by: app/jobs/__init__.py via register_tagging_jobs()
 Depends on: app.database, app.models, app.services.enrichment, app.services.tagging_backfill,
-            app.services.tagging_ai, app.utils.claude_client
+            app.services.tagging_ai, app.services.spec_enrichment_service, app.utils.claude_client
 """
 
 from apscheduler.triggers.interval import IntervalTrigger
@@ -46,13 +47,15 @@ def register_tagging_jobs(scheduler, settings):
         name="Classify untagged cards via Claude Haiku",
     )
 
-    if settings.material_enrichment_enabled:
-        scheduler.add_job(
-            _job_material_enrichment,
-            IntervalTrigger(hours=2),
-            id="material_enrichment",
-            name="Material card AI enrichment (Claude Haiku)",
-        )
+    # Spec extraction backlog sweep. SP1 (2026-06-09): the automated Haiku card-enrichment
+    # path was removed — this job ONLY runs the status-gated structured-spec second pass over
+    # cards already enriched by the authoritative ladder (verified/web_sourced/oem_sourced).
+    scheduler.add_job(
+        _job_spec_enrichment,
+        IntervalTrigger(hours=2),
+        id="spec_enrichment",
+        name="Material card spec extraction (backlog sweep)",
+    )
 
 
 @_traced_job
@@ -203,26 +206,19 @@ async def _job_ai_tagging():
 
 
 @_traced_job
-async def _job_material_enrichment():
-    """Every 2h — AI-enrich material cards missing descriptions/categories via Claude
-    Haiku."""
-    from ..config import settings
+async def _job_spec_enrichment():
+    """Every 2h — structured-spec second pass over the spec backlog.
+
+    SP1 (2026-06-09): the automated Claude Haiku card-enrichment path was removed. This job
+    runs ONLY ``enrich_pending_specs`` (no card-level enrichment), which is status-gated so it
+    seeds facets exclusively from cards with a trustworthy/source-attributed status.
+    """
     from ..database import SessionLocal
+    from ..services.spec_enrichment_service import enrich_pending_specs
 
     db = SessionLocal()
     try:
-        from ..services.material_enrichment_service import enrich_pending_cards
-        from ..services.spec_enrichment_service import enrich_pending_specs
-
-        result = await enrich_pending_cards(db, limit=settings.material_enrichment_batch_size)
-        logger.info(
-            "Material enrichment: enriched={} errors={} pending={}",
-            result["enriched"],
-            result["errors"],
-            result.get("pending", 0),
-        )
-
-        spec_stats = await enrich_pending_specs(db, limit=settings.material_enrichment_batch_size)
+        spec_stats = await enrich_pending_specs(db)
         logger.info(
             "Material spec enrichment: cards={} specs={} errors={} skipped_no_schema={}",
             spec_stats["cards_processed"],
@@ -231,7 +227,7 @@ async def _job_material_enrichment():
             spec_stats["skipped_no_schema"],
         )
     except Exception:
-        logger.exception("Material enrichment job failed")
+        logger.exception("Material spec enrichment job failed")
         db.rollback()
         raise
     finally:

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -8742,18 +8742,37 @@ async def enrich_material(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Trigger AI enrichment for a material card."""
-    from ..models.intelligence import MaterialCard
-    from ..services.material_enrichment_service import enrich_material_cards
+    """Trigger authoritative enrichment for a material card.
 
-    mc = db.query(MaterialCard).filter(MaterialCard.id == material_id).first()
+    Runs the authoritative ladder (verified -> web -> OEM -> flagged inference) with
+    refresh=True so even a terminal card re-enters the ladder, then a status-gated
+    structured-spec pass. The Haiku card-enrichment path was removed in SP1
+    (2026-06-09).
+    """
+    from ..constants import MaterialEnrichmentStatus
+    from ..models.intelligence import MaterialCard
+    from ..services.authoritative_enrichment_service import enrich_cards
+
+    mc = db.get(MaterialCard, material_id)
     if not mc:
         raise HTTPException(404, "Material not found")
 
+    # enrich_cards self-handles ClaudeError / disabled-source outages internally and
+    # returns a counts dict (it does NOT raise on a backend outage). Capture it so we can
+    # tell the user when nothing actually happened instead of reporting false success.
+    enrich_blocked = False
+    counts: dict = {}
     try:
-        await enrich_material_cards([material_id], db)
+        counts = await enrich_cards([material_id], db, refresh=True)
     except Exception as e:
-        logger.warning("Enrichment failed for material {}: {}", material_id, e)
+        logger.exception("Enrichment failed for material {}: {}", material_id, e)
+        enrich_blocked = True
+
+    # A single card produces exactly one status tally on success. If no real status landed,
+    # or a Claude outage / disabled source blocked the run, the card is unchanged.
+    status_tallies = sum(int(counts.get(s, 0)) for s in MaterialEnrichmentStatus)
+    if counts.get("claude_error") or counts.get("disabled_sources") or status_tallies == 0:
+        enrich_blocked = True
 
     try:
         from ..services.spec_enrichment_service import enrich_card_specs
@@ -8764,7 +8783,20 @@ async def enrich_material(
 
     db.refresh(mc)
 
-    return await material_detail_partial(request, material_id, user, db)
+    response = await material_detail_partial(request, material_id, user, db)
+    if enrich_blocked:
+        # Surface a user-facing toast WITHOUT breaking the partial swap, via the existing
+        # showToast HX-Trigger convention bridged to the global $store.toast (htmx_app.js).
+        logger.warning("Enrichment no-op for material {} (counts={}) — surfacing toast", material_id, counts)
+        response.headers["HX-Trigger"] = json.dumps(
+            {
+                "showToast": {
+                    "message": "Enrichment couldn't complete — a data source was unavailable. Try again shortly.",
+                    "type": "error",
+                }
+            }
+        )
+    return response
 
 
 @router.post("/v2/partials/materials/{material_id}/find-crosses", response_class=HTMLResponse)

--- a/app/services/spec_enrichment_service.py
+++ b/app/services/spec_enrichment_service.py
@@ -2,7 +2,7 @@
 
 What: Extracts per-commodity structured specs for material cards via Claude and
       writes them through record_spec (specs_structured JSONB + material_spec_facets).
-Called by: jobs/tagging_jobs.py (_job_material_enrichment), routers/htmx_views.py
+Called by: jobs/tagging_jobs.py (_job_spec_enrichment), routers/htmx_views.py
            (enrich button), app/management/enrich_specs.py (backfill).
 Depends on: commodity_registry.get_batch_spec_schema, spec_write_service.record_spec,
             utils.claude_client.claude_structured.
@@ -13,9 +13,18 @@ from datetime import datetime, timezone
 from loguru import logger
 from sqlalchemy.orm import Session
 
+from app.constants import MaterialEnrichmentStatus
 from app.models.intelligence import MaterialCard
 from app.services.commodity_registry import get_batch_spec_schema
 from app.services.spec_write_service import record_spec
+
+# Only cards whose description/category came from a trustworthy, source-attributed tier may
+# seed structured-spec facets. A guess/orphan description must never produce filter facets.
+_TRUSTWORTHY_STATUSES = (
+    MaterialEnrichmentStatus.VERIFIED,
+    MaterialEnrichmentStatus.WEB_SOURCED,
+    MaterialEnrichmentStatus.OEM_SOURCED,
+)
 
 # {category: {"specs": [{"key","label","type","values"?,"canonical_unit"?,"unit_hint"?}]}}
 COMMODITY_SPECS = get_batch_spec_schema()
@@ -110,9 +119,13 @@ async def enrich_card_specs(
     """Extract and record structured specs for the given cards (second pass).
 
     Eligible cards have a category, a non-empty description, and (unless force) no prior
-    spec pass. Cards are grouped by category; each category uses its own prompt/schema.
-    Specs with confidence >= FACET_MIN_CONF are written via record_spec (JSONB + facet).
-    Every processed card gets specs_enriched_at stamped so it is not reprocessed.
+    spec pass. Only cards with a trustworthy/source-attributed status (verified/web_sourced/
+    oem_sourced) seed specs, so guess/orphan descriptions never produce facets — the status
+    gate is a correctness invariant and applies even when ``force=True`` (force only bypasses
+    the ``specs_enriched_at`` re-process filter). Cards are grouped by category; each category
+    uses its own prompt/schema. Specs with confidence >= FACET_MIN_CONF are written via
+    record_spec (JSONB + facet). Every processed card gets specs_enriched_at stamped so it is
+    not reprocessed.
     """
     from app.utils.claude_client import claude_structured  # lazy: tests patch at source
 
@@ -122,6 +135,9 @@ async def enrich_card_specs(
         MaterialCard.category.isnot(None),
         MaterialCard.description.isnot(None),
         MaterialCard.description != "",
+        # Status gate is OUTSIDE the force branch: force only bypasses re-processing, never
+        # the trustworthy-source invariant.
+        MaterialCard.enrichment_status.in_(_TRUSTWORTHY_STATUSES),
     )
     if not force:
         query = query.filter(MaterialCard.specs_enriched_at.is_(None))
@@ -200,8 +216,12 @@ async def enrich_card_specs(
 
 
 async def enrich_pending_specs(db: Session, *, limit: int = 300, batch_size: int = BATCH_SIZE) -> dict:
-    """Find and enrich cards that need a spec pass (card-level enriched, no specs
-    yet)."""
+    """Find and enrich cards that need a spec pass (card-level enriched, no specs yet).
+
+    Only cards with a trustworthy/source-attributed status
+    (verified/web_sourced/oem_sourced) seed specs, so guess/orphan descriptions never
+    produce facets.
+    """
     rows = (
         db.query(MaterialCard.id)
         .filter(
@@ -210,6 +230,7 @@ async def enrich_pending_specs(db: Session, *, limit: int = 300, batch_size: int
             MaterialCard.description.isnot(None),
             MaterialCard.description != "",
             MaterialCard.deleted_at.is_(None),
+            MaterialCard.enrichment_status.in_(_TRUSTWORTHY_STATUSES),
         )
         .order_by(MaterialCard.search_count.desc().nullslast())
         .limit(limit)

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -172,6 +172,21 @@ htmx.on('htmx:responseError', (evt) => {
     Alpine.store('toast').show = true;
 });
 
+// ── Server-driven toast bridge ───────────────────────────────
+// HTMX dispatches a DOM event named after each HX-Trigger key. Servers emit
+// {"showToast": {"message": "...", "type": "..."}} (see htmx_views.py); bridge
+// it into the global $store.toast the base layout renders (htmx/base.html).
+// Plain string or {message,type} both supported; type defaults to "info".
+document.body.addEventListener('showToast', (evt) => {
+    const d = evt.detail;
+    const msg = typeof d === 'string' ? d : (d && d.message) || '';
+    if (!msg) return;
+    const type = (d && d.type) || 'info';
+    Alpine.store('toast').message = msg;
+    Alpine.store('toast').type = type;
+    Alpine.store('toast').show = true;
+});
+
 // Stale-response guard: HTMX swaps can arrive out of order when the user
 // clicks a new row before the previous /refresh resolves. Correlate via
 // X-Rendered-Req-Id and drop swaps for the wrong row.

--- a/tests/test_email_intelligence_phase6.py
+++ b/tests/test_email_intelligence_phase6.py
@@ -282,7 +282,6 @@ class TestJobEmailHealthUpdate:
                     eight_by_eight_enabled=False,
                     prospecting_enabled=False,
                     customer_enrichment_enabled=False,
-                    material_enrichment_enabled=False,
                 ),
             ),
         ):
@@ -417,7 +416,6 @@ class TestJobCalendarScan:
                     eight_by_eight_enabled=False,
                     prospecting_enabled=False,
                     customer_enrichment_enabled=False,
-                    material_enrichment_enabled=False,
                 ),
             ),
         ):

--- a/tests/test_htmx_views_nightly11.py
+++ b/tests/test_htmx_views_nightly11.py
@@ -13,6 +13,7 @@ import os
 os.environ["TESTING"] = "1"
 
 import io
+import json
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -570,9 +571,59 @@ class TestMaterialsEnrichment:
         db_session: Session,
         test_material_card: MaterialCard,
     ):
-        with patch("app.services.material_enrichment_service.enrich_material_cards", new_callable=AsyncMock):
+        with (
+            patch("app.services.authoritative_enrichment_service.enrich_cards", new_callable=AsyncMock) as auth,
+            patch("app.services.spec_enrichment_service.enrich_card_specs", new_callable=AsyncMock),
+            patch("app.services.material_enrichment_service.enrich_material_cards", new_callable=AsyncMock) as haiku,
+        ):
+            # A single card resolving to a real status returns that status tally = 1.
+            auth.return_value = {"verified": 1}
             resp = client.post(f"/v2/partials/materials/{test_material_card.id}/enrich")
             assert resp.status_code == 200
+        auth.assert_awaited_once()  # routes to the authoritative ladder
+        haiku.assert_not_called()  # never the removed Haiku path
+        # Real completion → no failure toast.
+        assert "HX-Trigger" not in resp.headers
+
+    def test_enrich_noop_surfaces_toast(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_material_card: MaterialCard,
+    ):
+        """enrich_cards self-handles a Claude outage (returns counts, does NOT raise) —
+        the card is unchanged, so the user must get a failure toast, not false
+        success."""
+        with (
+            patch("app.services.authoritative_enrichment_service.enrich_cards", new_callable=AsyncMock) as auth,
+            patch("app.services.spec_enrichment_service.enrich_card_specs", new_callable=AsyncMock),
+        ):
+            auth.return_value = {"claude_error": 1}
+            resp = client.post(f"/v2/partials/materials/{test_material_card.id}/enrich")
+            assert resp.status_code == 200
+        # Still returns the detail partial AND a showToast trigger.
+        assert "HX-Trigger" in resp.headers
+        trigger = json.loads(resp.headers["HX-Trigger"])
+        assert "showToast" in trigger
+        assert trigger["showToast"]["type"] == "error"
+        assert "couldn't complete" in trigger["showToast"]["message"]
+
+    def test_enrich_disabled_source_surfaces_toast(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_material_card: MaterialCard,
+    ):
+        """A disabled source (quota/auth wall) blocks the run → failure toast."""
+        with (
+            patch("app.services.authoritative_enrichment_service.enrich_cards", new_callable=AsyncMock) as auth,
+            patch("app.services.spec_enrichment_service.enrich_card_specs", new_callable=AsyncMock),
+        ):
+            auth.return_value = {"not_found": 1, "disabled_sources": ["digikey"]}
+            resp = client.post(f"/v2/partials/materials/{test_material_card.id}/enrich")
+            assert resp.status_code == 200
+        assert "HX-Trigger" in resp.headers
+        assert "showToast" in json.loads(resp.headers["HX-Trigger"])
 
     def test_enrich_service_error_graceful(
         self,
@@ -580,13 +631,19 @@ class TestMaterialsEnrichment:
         db_session: Session,
         test_material_card: MaterialCard,
     ):
-        with patch(
-            "app.services.material_enrichment_service.enrich_material_cards",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("AI error"),
+        with (
+            patch(
+                "app.services.authoritative_enrichment_service.enrich_cards",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("AI error"),
+            ),
+            patch("app.services.spec_enrichment_service.enrich_card_specs", new_callable=AsyncMock),
         ):
             resp = client.post(f"/v2/partials/materials/{test_material_card.id}/enrich")
             assert resp.status_code == 200
+        # A raised exception is also a blocked run → failure toast.
+        assert "HX-Trigger" in resp.headers
+        assert "showToast" in json.loads(resp.headers["HX-Trigger"])
 
 
 # ── Section 13: Materials find-crosses ────────────────────────────────────

--- a/tests/test_htmx_views_nightly2.py
+++ b/tests/test_htmx_views_nightly2.py
@@ -885,17 +885,26 @@ class TestProactiveRoutes:
         card = _material_card(db_session)
         db_session.commit()
 
-        with patch(
-            "app.services.material_enrichment_service.enrich_material_cards",
-            AsyncMock(return_value=None),
+        with (
+            patch(
+                "app.services.authoritative_enrichment_service.enrich_cards",
+                AsyncMock(return_value={}),
+            ) as auth,
+            patch("app.services.spec_enrichment_service.enrich_card_specs", AsyncMock(return_value={})),
+            patch(
+                "app.services.material_enrichment_service.enrich_material_cards",
+                AsyncMock(return_value=None),
+            ) as haiku,
         ):
             resp = client.post(f"/v2/partials/materials/{card.id}/enrich")
         assert resp.status_code == 200
+        auth.assert_awaited_once()  # routes to the authoritative ladder
+        haiku.assert_not_called()  # never the removed Haiku path
 
     def test_enrich_material_not_found(self, client, db_session: Session):
         with patch(
-            "app.services.material_enrichment_service.enrich_material_cards",
-            AsyncMock(return_value=None),
+            "app.services.authoritative_enrichment_service.enrich_cards",
+            AsyncMock(return_value={}),
         ):
             resp = client.post("/v2/partials/materials/999999/enrich")
         assert resp.status_code == 404

--- a/tests/test_jobs_coverage.py
+++ b/tests/test_jobs_coverage.py
@@ -679,32 +679,27 @@ class TestJobExpireStale:
 
 
 class TestRegisterTaggingJobs:
-    def test_registers_four_jobs_without_enrichment(self):
-        """register_tagging_jobs adds 4 jobs when enrichment is disabled."""
+    def test_registers_all_jobs_unconditionally(self):
+        """register_tagging_jobs adds the 5 tagging/spec jobs unconditionally.
+
+        SP1 (2026-06-09): the gated 'material_enrichment' Haiku job was removed and
+        replaced with an always-on 'spec_enrichment' backlog sweep.
+        """
         from app.jobs.tagging_jobs import register_tagging_jobs
 
         mock_scheduler = MagicMock()
-        mock_settings = MagicMock(material_enrichment_enabled=False)
+        mock_settings = MagicMock()
         register_tagging_jobs(mock_scheduler, mock_settings)
 
-        assert mock_scheduler.add_job.call_count == 4
+        assert mock_scheduler.add_job.call_count == 5
         job_ids = [c.kwargs["id"] for c in mock_scheduler.add_job.call_args_list]
         assert "internal_confidence_boost" in job_ids
         assert "prefix_backfill" in job_ids
         assert "sighting_mining" in job_ids
         assert "ai_tagging" in job_ids
-
-    def test_registers_five_jobs_with_enrichment(self):
-        """register_tagging_jobs adds 5 jobs when enrichment is enabled."""
-        from app.jobs.tagging_jobs import register_tagging_jobs
-
-        mock_scheduler = MagicMock()
-        mock_settings = MagicMock(material_enrichment_enabled=True)
-        register_tagging_jobs(mock_scheduler, mock_settings)
-
-        assert mock_scheduler.add_job.call_count == 5
-        job_ids = [c.kwargs["id"] for c in mock_scheduler.add_job.call_args_list]
-        assert "material_enrichment" in job_ids
+        assert "spec_enrichment" in job_ids
+        # The removed Haiku card-enrichment job must never re-appear.
+        assert "material_enrichment" not in job_ids
 
 
 class TestJobInternalBoost:

--- a/tests/test_jobs_tagging.py
+++ b/tests/test_jobs_tagging.py
@@ -1,13 +1,17 @@
-"""test_jobs_tagging.py — Tests for tagging/material enrichment background jobs.
+"""test_jobs_tagging.py — Tests for tagging/spec-enrichment background jobs.
 
-Covers: _job_material_enrichment.
+Covers: _job_spec_enrichment and register_tagging_jobs registration.
+
+SP1 (2026-06-09): the automated Haiku card-enrichment job (_job_material_enrichment)
+was removed; the spec backlog sweep (_job_spec_enrichment) replaced it and runs the
+status-gated enrich_pending_specs only — never the card-level Haiku path.
 
 All jobs use SessionLocal() internally, so we patch app.database.SessionLocal
 to return the test DB session with close() disabled.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import Session
@@ -37,24 +41,60 @@ def _clear_scheduler_jobs():
         job.remove()
 
 
-# ── _job_material_enrichment() ────────────────────────────────────────
+# ── register_tagging_jobs() ────────────────────────────────────────────
 
 
-def test_material_enrichment_success(scheduler_db):
-    """_job_material_enrichment enriches pending cards."""
-    mock_enrich = AsyncMock(return_value={"enriched": 5, "errors": 1, "pending": 10})
-    with patch("app.services.material_enrichment_service.enrich_pending_cards", mock_enrich):
-        from app.jobs.tagging_jobs import _job_material_enrichment
+def test_registers_spec_enrichment_not_material_enrichment():
+    """The Haiku 'material_enrichment' job is gone; 'spec_enrichment' is registered."""
+    from app.jobs.tagging_jobs import register_tagging_jobs
 
-        asyncio.run(_job_material_enrichment())
-    mock_enrich.assert_called_once()
+    mock_scheduler = MagicMock()
+    register_tagging_jobs(mock_scheduler, MagicMock())
+
+    job_ids = [c.kwargs["id"] for c in mock_scheduler.add_job.call_args_list]
+    assert "spec_enrichment" in job_ids
+    assert "material_enrichment" not in job_ids
 
 
-def test_material_enrichment_error(scheduler_db):
+def test_job_material_enrichment_removed():
+    """The removed Haiku card-enrichment job must no longer exist on the module."""
+    import app.jobs.tagging_jobs as tagging_jobs
+
+    assert not hasattr(tagging_jobs, "_job_material_enrichment")
+
+
+# ── _job_spec_enrichment() ─────────────────────────────────────────────
+
+
+def test_spec_enrichment_success(scheduler_db):
+    """_job_spec_enrichment runs the status-gated spec sweep (no card-level Haiku
+    path)."""
+    mock_specs = AsyncMock(return_value={"cards_processed": 3, "specs_written": 7, "errors": 0, "skipped_no_schema": 1})
+    with patch("app.services.spec_enrichment_service.enrich_pending_specs", mock_specs):
+        from app.jobs.tagging_jobs import _job_spec_enrichment
+
+        asyncio.run(_job_spec_enrichment())
+    mock_specs.assert_called_once()
+
+
+def test_spec_enrichment_does_not_call_card_enrichment(scheduler_db):
+    """The spec sweep must NOT invoke the removed Haiku card-enrichment path."""
+    mock_specs = AsyncMock(return_value={"cards_processed": 0, "specs_written": 0, "errors": 0, "skipped_no_schema": 0})
+    with (
+        patch("app.services.spec_enrichment_service.enrich_pending_specs", mock_specs),
+        patch("app.services.material_enrichment_service.enrich_pending_cards", new_callable=AsyncMock) as mcards,
+    ):
+        from app.jobs.tagging_jobs import _job_spec_enrichment
+
+        asyncio.run(_job_spec_enrichment())
+    mcards.assert_not_called()
+
+
+def test_spec_enrichment_error(scheduler_db):
     """Exception rolls back and re-raises so _traced_job can capture it."""
-    mock_enrich = AsyncMock(side_effect=Exception("Enrichment failed"))
-    with patch("app.services.material_enrichment_service.enrich_pending_cards", mock_enrich):
-        from app.jobs.tagging_jobs import _job_material_enrichment
+    mock_specs = AsyncMock(side_effect=Exception("Spec sweep failed"))
+    with patch("app.services.spec_enrichment_service.enrich_pending_specs", mock_specs):
+        from app.jobs.tagging_jobs import _job_spec_enrichment
 
-        with pytest.raises(Exception, match="Enrichment failed"):
-            asyncio.run(_job_material_enrichment())
+        with pytest.raises(Exception, match="Spec sweep failed"):
+            asyncio.run(_job_spec_enrichment())

--- a/tests/test_migration_091_cleanup.py
+++ b/tests/test_migration_091_cleanup.py
@@ -1,0 +1,69 @@
+"""Structural tests for migration 091 (SP1 vague-description / untrustworthy-stamp
+cleanup).
+
+Asserts the migration's revision metadata and the two WHERE-predicate string constants
+carry the guards SP1 relies on. This is a STRUCTURAL test only — it inspects the module's
+constants and identity, it does NOT execute the upgrade/downgrade.
+
+The 091 data upgrade/downgrade itself is PostgreSQL-only SQL (CREATE TABLE AS ... SELECT,
+UPDATE ... FROM, ILIKE) and so is validated read-only against live Postgres, NOT executed
+on the in-memory SQLite test engine. SQLite tolerates Postgres-invalid SQL and would mask
+real failures (project rule: feedback_sqlite_masks_postgres), so we deliberately keep this
+test to module-level structure and never invoke op.get_bind()-backed code here.
+
+Called by: pytest
+Depends on: alembic/versions/091_cleanup_vague_descs.py
+"""
+
+import importlib.util
+import os
+
+# Load the migration module directly since alembic/versions has no __init__.py.
+_MIGRATION_PATH = os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "091_cleanup_vague_descs.py")
+_spec = importlib.util.spec_from_file_location("migration_091", _MIGRATION_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+class TestRevisionMetadata:
+    """Revision identifiers and chain wiring."""
+
+    def test_revision_id(self):
+        assert _mod.revision == "091_cleanup_vague_descs"
+
+    def test_revision_id_within_pg_version_num_limit(self):
+        # alembic_version.version_num is VARCHAR(32) on Postgres; SQLite ignores the
+        # length so an over-long id would pass tests but crash-loop on deploy.
+        assert len(_mod.revision) <= 32
+
+    def test_down_revision(self):
+        assert _mod.down_revision == "090_add_condition_mc"
+
+
+class TestVagueDescWhere:
+    """The hallucinated-description predicate must stay narrowly scoped."""
+
+    def test_predicate_targets_never_sourced_not_found_cards(self):
+        where = _mod._VAGUE_DESC_WHERE
+        assert "not_found" in where
+        assert "enrichment_source IS NULL" in where
+        assert "deleted_at IS NULL" in where
+        assert "description IS NOT NULL" in where
+
+    def test_predicate_matches_hedging_tokens(self):
+        where = _mod._VAGUE_DESC_WHERE
+        for token in ("likely", "possibly", "may be", "proprietary", "appears to be", "could be"):
+            assert token in where
+
+
+class TestUntrustworthyStampWhere:
+    """The stamp-clearing predicate must stay gated on untrustworthy status."""
+
+    def test_predicate_clears_untrustworthy_specs_enriched_at(self):
+        where = _mod._UNTRUSTWORTHY_STAMP_WHERE
+        assert "specs_enriched_at" in where
+        assert "deleted_at IS NULL" in where
+        assert "verified" in where
+        assert "web_sourced" in where
+        assert "oem_sourced" in where
+        assert "NOT IN" in where

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -54,7 +54,6 @@ def _mock_settings(**overrides):
         eight_by_eight_enabled=False,
         prospecting_enabled=False,
         customer_enrichment_enabled=False,
-        material_enrichment_enabled=False,
     )
     defaults.update(overrides)
     mock = MagicMock()

--- a/tests/test_sp1_spec_input_gate.py
+++ b/tests/test_sp1_spec_input_gate.py
@@ -1,0 +1,165 @@
+"""SP1 trustworthy-status input gate for the structured-spec reader.
+
+What: Asserts enrich_card_specs / enrich_pending_specs only ever seed facets from cards
+      whose enrichment_status is trustworthy/source-attributed (verified/web_sourced/
+      oem_sourced). Guess/orphan descriptions (e.g. not_found cards with a hallucinated
+      "likely a ..." description) must NEVER produce facets, and force=True does NOT bypass
+      the gate (it only bypasses the specs_enriched_at re-process filter).
+Called by: pytest.
+Depends on: app.services.spec_enrichment_service, app.constants.MaterialEnrichmentStatus,
+            app.models (MaterialCard, MaterialSpecFacet), commodity schema seed fixture.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.constants import MaterialEnrichmentStatus
+from app.models.faceted_search import MaterialSpecFacet
+from app.models.intelligence import MaterialCard
+from app.services.commodity_registry import seed_commodity_schemas
+
+_TRUSTWORTHY = {
+    MaterialEnrichmentStatus.VERIFIED,
+    MaterialEnrichmentStatus.WEB_SOURCED,
+    MaterialEnrichmentStatus.OEM_SOURCED,
+}
+
+
+@pytest.fixture
+def db(db_session):
+    return db_session
+
+
+@pytest.fixture()
+def _schemas(db: Session):
+    """Seed commodity_spec_schemas so record_spec validates."""
+    seed_commodity_schemas(db)
+
+
+def _card(
+    db: Session,
+    mpn: str,
+    status: str,
+    *,
+    category: str = "microcontrollers",
+    description: str = "An MCU",
+    enrichment_source: str | None = "verified-distributor",
+) -> MaterialCard:
+    card = MaterialCard(
+        normalized_mpn=mpn.lower().replace("-", ""),
+        display_mpn=mpn,
+        manufacturer="STMicroelectronics",
+        description=description,
+        category=category,
+        search_count=5,
+        enrichment_status=status,
+        enrichment_source=enrichment_source,
+    )
+    db.add(card)
+    db.commit()
+    db.refresh(card)
+    return card
+
+
+def _payload(mpn: str) -> dict:
+    return {"parts": [{"mpn": mpn, "has_usb": True, "has_usb_confidence": 0.95}]}
+
+
+# ── The status gate: selection IFF trustworthy ─────────────────────────
+
+
+@pytest.mark.parametrize("status", list(MaterialEnrichmentStatus))
+@pytest.mark.asyncio
+async def test_enrich_card_specs_selects_only_trustworthy(db: Session, _schemas, status):
+    """A complete card is processed by enrich_card_specs IFF its status is
+    trustworthy."""
+    from app.services.spec_enrichment_service import enrich_card_specs
+
+    card = _card(db, f"GATE{status.replace('_', '')}", status)
+    with patch(
+        "app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_payload(card.display_mpn)
+    ) as mclaude:
+        stats = await enrich_card_specs([card.id], db)
+
+    if status in _TRUSTWORTHY:
+        assert stats["cards_processed"] == 1
+        mclaude.assert_awaited()
+    else:
+        assert stats["cards_processed"] == 0
+        mclaude.assert_not_awaited()
+
+
+@pytest.mark.parametrize("status", list(MaterialEnrichmentStatus))
+@pytest.mark.asyncio
+async def test_enrich_pending_specs_selects_only_trustworthy(db: Session, _schemas, status):
+    """A complete card is swept by enrich_pending_specs IFF its status is
+    trustworthy."""
+    from app.services.spec_enrichment_service import enrich_pending_specs
+
+    card = _card(db, f"PEND{status.replace('_', '')}", status)
+    with patch(
+        "app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_payload(card.display_mpn)
+    ) as mclaude:
+        stats = await enrich_pending_specs(db, limit=10)
+
+    if status in _TRUSTWORTHY:
+        assert stats["cards_processed"] == 1
+        mclaude.assert_awaited()
+    else:
+        assert stats["cards_processed"] == 0
+        mclaude.assert_not_awaited()
+
+
+# ── Regression: the guess -> spec leak ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_not_found_guess_description_never_seeds_specs(db: Session, _schemas):
+    """The original leak: a not_found card with a hallucinated description + a real category
+    must produce ZERO facets and never reach Claude."""
+    from app.services import spec_enrichment_service
+    from app.services.spec_enrichment_service import enrich_pending_specs
+
+    card = _card(
+        db,
+        "GUESS123",
+        MaterialEnrichmentStatus.NOT_FOUND,
+        category="hdd",
+        description="Likely a proprietary hard drive; could be a SAS unit.",
+        enrichment_source=None,
+    )
+
+    with (
+        patch(
+            "app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_payload("GUESS123")
+        ) as mclaude,
+        patch.object(spec_enrichment_service, "record_spec", autospec=True) as mrecord,
+    ):
+        stats = await enrich_pending_specs(db, limit=10)
+
+    assert stats["cards_processed"] == 0
+    mclaude.assert_not_awaited()
+    mrecord.assert_not_called()  # record_spec never reached
+    facets = db.query(MaterialSpecFacet).filter_by(material_card_id=card.id).all()
+    assert facets == []
+
+
+# ── force=True still honors the status gate ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_force_does_not_bypass_status_gate(db: Session, _schemas):
+    """Force=True bypasses the specs_enriched_at re-process filter, NOT the status
+    gate."""
+    from app.services.spec_enrichment_service import enrich_card_specs
+
+    card = _card(db, "FORCED1", MaterialEnrichmentStatus.NOT_FOUND, enrichment_source=None)
+    with patch(
+        "app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=_payload("FORCED1")
+    ) as mclaude:
+        stats = await enrich_card_specs([card.id], db, force=True)
+
+    assert stats["cards_processed"] == 0
+    mclaude.assert_not_awaited()

--- a/tests/test_spec_enrichment_service.py
+++ b/tests/test_spec_enrichment_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from sqlalchemy.orm import Session
 
+from app.constants import MaterialEnrichmentStatus
 from app.models.faceted_search import MaterialSpecFacet
 from app.models.intelligence import MaterialCard
 from app.services.commodity_registry import seed_commodity_schemas
@@ -17,7 +18,15 @@ def db(db_session):
 
 
 def _mc(
-    db: Session, mpn: str, *, category: str | None = "microcontrollers", description="An MCU", specs_enriched_at=None
+    db: Session,
+    mpn: str,
+    *,
+    category: str | None = "microcontrollers",
+    description="An MCU",
+    specs_enriched_at=None,
+    # SP1 (2026-06-09): only trustworthy/source-attributed cards seed specs. Default the
+    # helper to 'verified' so existing happy-path tests still exercise the spec reader.
+    enrichment_status=MaterialEnrichmentStatus.VERIFIED,
 ) -> MaterialCard:
     card = MaterialCard(
         normalized_mpn=mpn.lower().replace("-", ""),
@@ -27,6 +36,7 @@ def _mc(
         category=category,
         search_count=5,
         specs_enriched_at=specs_enriched_at,
+        enrichment_status=enrichment_status,
     )
     db.add(card)
     db.commit()
@@ -137,13 +147,23 @@ async def test_pending_selects_unmarked_cards(db: Session, _schemas):
 
 @pytest.mark.asyncio
 async def test_enrich_button_triggers_spec_pass(client, test_material_card):
+    # SP1 (2026-06-09): the button routes to the authoritative ladder (enrich_cards), then
+    # the status-gated spec pass — never the removed Haiku path (enrich_material_cards).
     with (
-        patch("app.services.material_enrichment_service.enrich_material_cards", new_callable=AsyncMock) as mcard,
+        patch(
+            "app.services.authoritative_enrichment_service.enrich_cards",
+            new_callable=AsyncMock,
+            return_value={"verified": 1},
+        ) as mauth,
         patch("app.services.spec_enrichment_service.enrich_card_specs", new_callable=AsyncMock) as mspec,
+        patch("app.services.material_enrichment_service.enrich_material_cards", new_callable=AsyncMock) as mhaiku,
     ):
         resp = client.post(f"/v2/partials/materials/{test_material_card.id}/enrich")
     assert resp.status_code == 200
-    mcard.assert_awaited_once()
+    mauth.assert_awaited_once()
+    # refresh=True so even a terminal card re-enters the ladder
+    assert mauth.call_args.kwargs.get("refresh") is True
+    mhaiku.assert_not_called()
     mspec.assert_awaited_once()
     # force=True so the just-clicked card re-extracts even if previously marked
     assert mspec.call_args.kwargs.get("force") is True
@@ -152,7 +172,11 @@ async def test_enrich_button_triggers_spec_pass(client, test_material_card):
 @pytest.mark.asyncio
 async def test_enrich_button_survives_spec_failure(client, test_material_card):
     with (
-        patch("app.services.material_enrichment_service.enrich_material_cards", new_callable=AsyncMock),
+        patch(
+            "app.services.authoritative_enrichment_service.enrich_cards",
+            new_callable=AsyncMock,
+            return_value={"verified": 1},
+        ),
         patch(
             "app.services.spec_enrichment_service.enrich_card_specs",
             new_callable=AsyncMock,


### PR DESCRIPTION
**SP1 of the [enrichment-pipeline correctness program](docs/superpowers/specs/2026-06-09-enrichment-pipeline-program-design.md).** Stops the active data pollution that's keeping the materials filters empty/inaccurate.

## Root cause
An ungated legacy **Haiku** path (`material_enrichment_enabled=true` in prod) wrote vague guess descriptions ("Lenovo proprietary component, *likely* a battery…") with no confidence/provenance and without setting status. The guess persisted through `not_found` and was fed into spec extraction → **hallucinated specs**. (298 not_found cards carried fabricated descriptions; 310 had specs seeded from them.)

## Changes
- **Retire the automated Haiku writer** — delete the every-2h `_job_material_enrichment`; replace with a spec-only backlog sweep `_job_spec_enrichment` (`enrich_pending_specs` only, never `enrich_pending_cards`), so the legit spec pass isn't orphaned.
- **Gate the spec reader** — `enrich_card_specs` + `enrich_pending_specs` now only select cards with a trustworthy status (`verified`/`web_sourced`/`oem_sourced`), applied **even under `force=True`** (correctness invariant). A guess/orphan description can never seed a facet again.
- **Repoint the manual enrich button** to the authoritative ladder (`enrich_cards(refresh=True)`) + the gated spec pass, and **surface a toast when enrichment is blocked** (`enrich_cards` self-handles `ClaudeError` and returns counts → the old path silently reported false success). Adds a `showToast` HX-Trigger → `$store.toast` bridge wiring two existing conventions.
- **Remove dead config** (`material_enrichment_enabled`, `material_enrichment_batch_size`).
- **Migration `091_cleanup_vague_descs`** (data-only, backup table + exact downgrade): NULL ~292 vague descriptions on never-sourced `not_found` cards; clear ~700 untrustworthy `specs_enriched_at` stamps so the gated reader re-evaluates cleanly.

## Scope notes
- The underlying Haiku service functions remain **only** for the manual `reenrich.py` CLI (no automated path or UI button calls them) — full CLI retirement is a documented follow-up.
- Stale facets on the 700 cleared cards are intentionally **left for SP2** (provenance rework adds `source`/`tier` columns to distinguish guess-derived `spec_extraction` from deterministic `mpn_decode` facets) — documented in the migration docstring.

## Tests / validation
225 affected tests green: trustworthy-status gate (all 7 statuses), guess→spec leak regression, force-honors-gate, structural migration test; button + job tests repointed. Migration PG-only SQL validated **read-only against live Postgres** (292/700 confirmed). Reviewed by code-reviewer + silent-failure-hunter + simplifier. (Pre-existing unrelated `TestJobRefreshInsights` baseline failure is not touched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)