### PR TITLE
feat(materials page): operational sourcing filters, coverage-aware empty states, richer material cards

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -72,7 +72,7 @@ from ..services.activity_service import log_activity as _log_activity
 from ..services.commodity_registry import COMMODITY_TREE, get_display_name
 from ..services.faceted_search_service import (
     INTERNAL_FILTER_VALUES,
-    SEARCHED_WITHIN_DAYS,
+    SEARCHED_WITHIN_VALUES,
     get_commodity_counts,
     get_commodity_spec_coverage,
     get_facet_counts,
@@ -7251,7 +7251,7 @@ async def materials_faceted_partial(
     has_crosses: bool = Query(False),
     internal: str = Query("all"),
     searched_within: str = Query("any"),
-    min_searches: int = Query(0, ge=0),
+    min_searches: str = Query("0"),
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -7273,11 +7273,24 @@ async def materials_faceted_partial(
     parsed_lifecycle = _csv_list(lifecycle)
     parsed_rohs = _csv_list(rohs)
     parsed_condition = _csv_list(condition)
-    # Unknown enum values degrade to the no-op default (hand-edited URLs must not 500).
+    # Unknown/invalid operational values (incl. non-numeric/negative min_searches)
+    # degrade to the no-op default — hand-edited URLs must not 500/422 — but each
+    # degrade is LOGGED so frontend/backend vocabulary drift (e.g. a bucket added to
+    # the UI but not the backend constants) surfaces in logs instead of silently
+    # no-op'ing the filter while the active-filter chip claims it is applied.
     if internal not in INTERNAL_FILTER_VALUES:
+        logger.warning("materials faceted: unknown internal={!r}, degrading to 'all'", internal)
         internal = "all"
-    if searched_within != "any" and searched_within not in SEARCHED_WITHIN_DAYS:
+    if searched_within not in SEARCHED_WITHIN_VALUES:
+        logger.warning("materials faceted: unknown searched_within={!r}, degrading to 'any'", searched_within)
         searched_within = "any"
+    try:
+        min_searches_n = int(min_searches)
+    except ValueError:
+        min_searches_n = -1
+    if min_searches_n < 0:
+        logger.warning("materials faceted: invalid min_searches={!r}, degrading to 0", min_searches)
+        min_searches_n = 0
 
     materials, total = search_materials_faceted(
         db,
@@ -7296,7 +7309,7 @@ async def materials_faceted_partial(
         has_crosses=has_crosses,
         internal=internal,
         searched_within=searched_within,
-        min_searches=min_searches,
+        min_searches=min_searches_n,
         limit=limit,
         offset=offset,
     )
@@ -7321,9 +7334,12 @@ async def materials_faceted_partial(
         vendor_stats = {s[0]: (s[1], s[2], s[4] if s[3] == 1 else None) for s in stats}
 
     # Attach spec chips for display. In commodity context: the selected commodity's
-    # is_primary keys (unchanged). Without a commodity: each card's OWN category's
-    # primary keys when a schema exists (one batched query — no N+1), else the first
-    # 3 scalar specs_structured entries; the template renders "label: value" there.
+    # is_primary keys (same keys as before; non-scalar/missing values are now SKIPPED
+    # instead of rendering dict-reprs or 500ing on raw-scalar entries). Without a
+    # commodity: each card's OWN category's primary keys (one batched query — no N+1);
+    # whenever that yields no chips (schema-less category OR a card lacking values for
+    # every primary key) fall back to the first 3 scalar specs_structured entries; the
+    # template renders "label: value" there.
     def _spec_scalar(raw):
         val = raw.get("value") if isinstance(raw, dict) else raw
         return val if isinstance(val, (str, int, float, bool)) else None

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -71,7 +71,10 @@ from ..services import task_service
 from ..services.activity_service import log_activity as _log_activity
 from ..services.commodity_registry import COMMODITY_TREE, get_display_name
 from ..services.faceted_search_service import (
+    INTERNAL_FILTER_VALUES,
+    SEARCHED_WITHIN_DAYS,
     get_commodity_counts,
+    get_commodity_spec_coverage,
     get_facet_counts,
     get_global_facet_counts,
     get_subfilter_options,
@@ -7199,6 +7202,8 @@ async def materials_filters_sub_partial(
             "subfilter_options": subfilter_options,
             "facet_counts": facet_counts,
             "commodity_selected": True,
+            "spec_coverage": get_commodity_spec_coverage(db, commodity),
+            "commodity_display": get_display_name(commodity),
         }
     )
     return template_response("htmx/partials/materials/filters/subfilters.html", ctx)
@@ -7241,6 +7246,12 @@ async def materials_faceted_partial(
     rohs: str = Query(""),
     condition: str = Query(""),
     has_datasheet: bool = Query(False),
+    has_stock: bool = Query(False),
+    has_price: bool = Query(False),
+    has_crosses: bool = Query(False),
+    internal: str = Query("all"),
+    searched_within: str = Query("any"),
+    min_searches: int = Query(0, ge=0),
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -7262,6 +7273,11 @@ async def materials_faceted_partial(
     parsed_lifecycle = _csv_list(lifecycle)
     parsed_rohs = _csv_list(rohs)
     parsed_condition = _csv_list(condition)
+    # Unknown enum values degrade to the no-op default (hand-edited URLs must not 500).
+    if internal not in INTERNAL_FILTER_VALUES:
+        internal = "all"
+    if searched_within != "any" and searched_within not in SEARCHED_WITHIN_DAYS:
+        searched_within = "any"
 
     materials, total = search_materials_faceted(
         db,
@@ -7275,6 +7291,12 @@ async def materials_faceted_partial(
         rohs=parsed_rohs,
         condition=parsed_condition,
         has_datasheet=has_datasheet,
+        has_stock=has_stock,
+        has_price=has_price,
+        has_crosses=has_crosses,
+        internal=internal,
+        searched_within=searched_within,
+        min_searches=min_searches,
         limit=limit,
         offset=offset,
     )
@@ -7298,13 +7320,30 @@ async def materials_faceted_partial(
         # currency shown only when a card's vendor rows are single-currency; mixed → default $
         vendor_stats = {s[0]: (s[1], s[2], s[4] if s[3] == 1 else None) for s in stats}
 
-    # Attach primary spec chips for display
-    primary_keys = {}
+    # Attach spec chips for display. In commodity context: the selected commodity's
+    # is_primary keys (unchanged). Without a commodity: each card's OWN category's
+    # primary keys when a schema exists (one batched query — no N+1), else the first
+    # 3 scalar specs_structured entries; the template renders "label: value" there.
+    def _spec_scalar(raw):
+        val = raw.get("value") if isinstance(raw, dict) else raw
+        return val if isinstance(val, (str, int, float, bool)) else None
+
+    primary_by_cat: dict[str, dict[str, str]] = {}
     if commodity:
-        primary_keys = {
+        primary_by_cat[commodity.lower().strip()] = {
             s.spec_key: s.display_name
             for s in db.query(CommoditySpecSchema).filter_by(commodity=commodity, is_primary=True).all()
         }
+    else:
+        card_cats = {(m.category or "").lower().strip() for m in materials if m.category}
+        if card_cats:
+            schema_rows = (
+                db.query(CommoditySpecSchema)
+                .filter(CommoditySpecSchema.commodity.in_(card_cats), CommoditySpecSchema.is_primary.is_(True))
+                .all()
+            )
+            for s in schema_rows:
+                primary_by_cat.setdefault(s.commodity, {})[s.spec_key] = s.display_name
 
     for m in materials:
         vc, bp, cur = vendor_stats.get(m.id, (0, None, None))
@@ -7312,9 +7351,32 @@ async def materials_faceted_partial(
         m._best_price = bp
         m._best_currency = cur
         specs = m.specs_structured or {}
-        m._primary_specs = [
-            {"label": primary_keys[k], "value": specs[k].get("value", "")} for k in primary_keys if k in specs
+        card_cat = commodity.lower().strip() if commodity else (m.category or "").lower().strip()
+        primary_keys = primary_by_cat.get(card_cat, {})
+        chips = [
+            {"label": primary_keys[k], "value": _spec_scalar(specs[k])}
+            for k in primary_keys
+            if k in specs and _spec_scalar(specs[k]) is not None
         ]
+        if not commodity and not chips:
+            # No schema-known primary values for this card — first 3 scalar entries,
+            # labelled by their prettified spec key.
+            for k, raw in specs.items():
+                val = _spec_scalar(raw)
+                if val is None:
+                    continue
+                chips.append({"label": k.replace("_", " "), "value": val})
+                if len(chips) >= 3:
+                    break
+        m._primary_specs = chips
+
+    # Coverage-aware empty state: a parametric zero-result inside a commodity usually
+    # means "not yet spec-enriched", not "no such parts". Coverage is computed only when
+    # the nudge could render (zero results + active parametric sub_filters + commodity).
+    parametric_active = bool(commodity and parsed_filters)
+    spec_coverage = None
+    if total == 0 and parametric_active:
+        spec_coverage = get_commodity_spec_coverage(db, commodity)
 
     ctx = _base_ctx(request, user, "materials")
     ctx.update(
@@ -7330,6 +7392,8 @@ async def materials_faceted_partial(
             "top_categories": [],
             "interpreted_query": "",
             "faceted": True,
+            "parametric_active": parametric_active,
+            "spec_coverage": spec_coverage,
         }
     )
     return template_response("htmx/partials/materials/list.html", ctx)

--- a/app/services/faceted_search_service.py
+++ b/app/services/faceted_search_service.py
@@ -6,17 +6,24 @@ Called by: htmx_views.py faceted search routes
 Depends on: MaterialCard, MaterialSpecFacet, CommoditySpecSchema
 """
 
-from sqlalchemy import func
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import Text, cast, exists, func, or_
 from sqlalchemy.orm import Session
 
 from app.constants import MaterialEnrichmentStatus
-from app.models import CommoditySpecSchema, MaterialCard, MaterialSpecFacet
+from app.models import CommoditySpecSchema, MaterialCard, MaterialSpecFacet, MaterialVendorHistory
 from app.utils.search_builder import SearchBuilder
 
 # Max distinct values rendered for an open-vocabulary (no enum_values) enum facet.
 # Such facets get a typeahead search box + this many top-by-count values
 # (see get_subfilter_options); a fixed-vocabulary facet renders its full canonical list.
 TOP_N = 12
+
+# Operational (Layer-3) filter vocabularies — validated in search_materials_faceted;
+# unknown values degrade to the no-op default rather than erroring on hand-edited URLs.
+INTERNAL_FILTER_VALUES = ("all", "standard", "internal")
+SEARCHED_WITHIN_DAYS = {"7d": 7, "30d": 30, "90d": 90}
 
 
 def _apply_facet_filters(
@@ -212,6 +219,12 @@ def search_materials_faceted(
     rohs: list[str] | None = None,
     condition: list[str] | None = None,
     has_datasheet: bool = False,
+    has_stock: bool = False,
+    has_price: bool = False,
+    has_crosses: bool = False,
+    internal: str = "all",
+    searched_within: str = "any",
+    min_searches: int = 0,
     limit: int = 50,
     offset: int = 0,
 ) -> tuple[list[MaterialCard], int]:
@@ -230,6 +243,17 @@ def search_materials_faceted(
             (OR-within, e.g. ``["active", "eol"]``).
         rohs: When provided, restrict to cards whose rohs_status is in this list (OR-within).
         has_datasheet: When True, restrict to cards that have a non-null datasheet_url.
+        has_stock: When True, restrict to cards with at least one vendor-history row
+            ("has vendor sightings / stock seen").
+        has_price: When True, restrict to cards with a vendor-history row carrying a
+            recorded last_price.
+        has_crosses: When True, restrict to cards whose cross_references JSON holds a
+            non-empty list (portable across PostgreSQL JSONB and SQLite JSON-as-text).
+        internal: Tri-state — "all" (no-op), "standard" (is_internal_part FALSE/NULL),
+            "internal" (is_internal_part TRUE). Unknown values degrade to "all".
+        searched_within: Recency bucket on last_searched_at — "7d" | "30d" | "90d" |
+            "any" (no-op). Unknown values degrade to "any".
+        min_searches: Minimum search_count (0 = no-op).
         limit: Max results
         offset: Pagination offset
 
@@ -248,8 +272,6 @@ def search_materials_faceted(
         # Multi-word natural language queries → FTS for relevance ranking
         use_fts = is_pg and " " in q.strip()
         if use_fts:
-            from sqlalchemy import or_
-
             ts_query = func.plainto_tsquery("english", q)
             # Combine FTS with ILIKE on MPN fields (FTS misses partial MPN matches)
             query = query.filter(
@@ -295,6 +317,36 @@ def search_materials_faceted(
         query = query.filter(MaterialCard.condition.in_(condition))
     if has_datasheet:
         query = query.filter(MaterialCard.datasheet_url.isnot(None))
+
+    # Operational (Layer-3) sourcing filters — MaterialCard columns + vendor history.
+    if has_stock:
+        query = query.filter(exists().where(MaterialVendorHistory.material_card_id == MaterialCard.id))
+    if has_price:
+        query = query.filter(
+            exists().where(
+                MaterialVendorHistory.material_card_id == MaterialCard.id,
+                MaterialVendorHistory.last_price.isnot(None),
+            )
+        )
+    if has_crosses:
+        # Portable non-empty-JSON-list predicate: PG jsonb::text renders an empty array
+        # as '[]' and a JSON null as 'null'; SQLite stores json.dumps() output, which
+        # matches the same literals. Avoids PG-only jsonb_array_length() that SQLite
+        # tests would silently mis-handle.
+        query = query.filter(
+            MaterialCard.cross_references.isnot(None),
+            cast(MaterialCard.cross_references, Text).notin_(("[]", "null", "")),
+        )
+    if internal == "standard":
+        query = query.filter(or_(MaterialCard.is_internal_part.is_(False), MaterialCard.is_internal_part.is_(None)))
+    elif internal == "internal":
+        query = query.filter(MaterialCard.is_internal_part.is_(True))
+    days = SEARCHED_WITHIN_DAYS.get(searched_within)
+    if days:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        query = query.filter(MaterialCard.last_searched_at >= cutoff)
+    if min_searches and min_searches > 0:
+        query = query.filter(MaterialCard.search_count >= min_searches)
 
     if sub_filters and commodity:
         commodity_lower = commodity.lower().strip()
@@ -409,3 +461,30 @@ def get_subfilter_options(db: Session, commodity: str) -> list[dict]:
             option["values"] = ["true", "false"]
         result.append(option)
     return result
+
+
+def get_commodity_spec_coverage(db: Session, commodity: str) -> dict[str, int]:
+    """Return parametric-spec coverage for a commodity.
+
+    {"with_specs": N, "total": M} — N = distinct non-deleted cards in the commodity that
+    have at least one MaterialSpecFacet row, M = all non-deleted cards in the commodity.
+    Drives the coverage line in the sub-filters panel and the coverage-aware empty state
+    (a parametric zero-result mostly means "not yet spec-enriched", not "no such
+    parts"). Two cheap aggregates, no N+1.
+    """
+    commodity = commodity.lower().strip()
+    commodity_cards = db.query(MaterialCard.id).filter(
+        MaterialCard.deleted_at.is_(None),
+        func.lower(func.trim(MaterialCard.category)) == commodity,
+    )
+    total = db.query(func.count()).select_from(commodity_cards.subquery()).scalar() or 0
+    with_specs = (
+        db.query(func.count(func.distinct(MaterialSpecFacet.material_card_id)))
+        .filter(
+            MaterialSpecFacet.category == commodity,
+            MaterialSpecFacet.material_card_id.in_(commodity_cards),
+        )
+        .scalar()
+        or 0
+    )
+    return {"with_specs": with_specs, "total": total}

--- a/app/services/faceted_search_service.py
+++ b/app/services/faceted_search_service.py
@@ -7,6 +7,7 @@ Depends on: MaterialCard, MaterialSpecFacet, CommoditySpecSchema
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import NamedTuple
 
 from sqlalchemy import Text, cast, exists, func, or_
 from sqlalchemy.orm import Session
@@ -20,10 +21,23 @@ from app.utils.search_builder import SearchBuilder
 # (see get_subfilter_options); a fixed-vocabulary facet renders its full canonical list.
 TOP_N = 12
 
-# Operational (Layer-3) filter vocabularies — validated in search_materials_faceted;
-# unknown values degrade to the no-op default rather than erroring on hand-edited URLs.
-INTERNAL_FILTER_VALUES = ("all", "standard", "internal")
+# Operational (Layer-3) filter vocabularies. This service OWNS the vocabularies: the
+# maps below drive the query branches in search_materials_faceted, and the *_VALUES
+# tuples (sentinel + map keys) are derived from them — adding a mode/bucket to a map
+# wires the query branch and the route check together. The faceted ROUTE
+# (htmx_views.materials_faceted_partial) validates incoming params against the *_VALUES
+# tuples and degrades unknowns to the no-op sentinel with a WARNING log; inside this
+# service unknown values simply fall through the map lookups as silent no-ops.
+# Front-end twin (must stay in sync): INTERNAL_MODES / SEARCH_BUCKETS on the
+# materialsFilter Alpine component in app/static/htmx_app.js.
+_INTERNAL_MODE_PREDICATES = {
+    # mode -> zero-arg predicate factory on MaterialCard.is_internal_part.
+    "standard": lambda: or_(MaterialCard.is_internal_part.is_(False), MaterialCard.is_internal_part.is_(None)),
+    "internal": lambda: MaterialCard.is_internal_part.is_(True),
+}
+INTERNAL_FILTER_VALUES = ("all", *_INTERNAL_MODE_PREDICATES)  # "all" = no-op sentinel
 SEARCHED_WITHIN_DAYS = {"7d": 7, "30d": 30, "90d": 90}
+SEARCHED_WITHIN_VALUES = ("any", *SEARCHED_WITHIN_DAYS)  # "any" = no-op sentinel
 
 
 def _apply_facet_filters(
@@ -337,10 +351,9 @@ def search_materials_faceted(
             MaterialCard.cross_references.isnot(None),
             cast(MaterialCard.cross_references, Text).notin_(("[]", "null", "")),
         )
-    if internal == "standard":
-        query = query.filter(or_(MaterialCard.is_internal_part.is_(False), MaterialCard.is_internal_part.is_(None)))
-    elif internal == "internal":
-        query = query.filter(MaterialCard.is_internal_part.is_(True))
+    internal_predicate = _INTERNAL_MODE_PREDICATES.get(internal)
+    if internal_predicate is not None:
+        query = query.filter(internal_predicate())
     days = SEARCHED_WITHIN_DAYS.get(searched_within)
     if days:
         cutoff = datetime.now(timezone.utc) - timedelta(days=days)
@@ -463,14 +476,22 @@ def get_subfilter_options(db: Session, commodity: str) -> list[dict]:
     return result
 
 
-def get_commodity_spec_coverage(db: Session, commodity: str) -> dict[str, int]:
+class SpecCoverage(NamedTuple):
+    """Parametric-spec coverage for a commodity (invariant: 0 <= with_specs <=
+    total)."""
+
+    with_specs: int
+    total: int
+
+
+def get_commodity_spec_coverage(db: Session, commodity: str) -> SpecCoverage:
     """Return parametric-spec coverage for a commodity.
 
-    {"with_specs": N, "total": M} — N = distinct non-deleted cards in the commodity that
-    have at least one MaterialSpecFacet row, M = all non-deleted cards in the commodity.
-    Drives the coverage line in the sub-filters panel and the coverage-aware empty state
-    (a parametric zero-result mostly means "not yet spec-enriched", not "no such
-    parts"). Two cheap aggregates, no N+1.
+    SpecCoverage(with_specs=N, total=M) — N = distinct non-deleted cards in the
+    commodity that have at least one MaterialSpecFacet row, M = all non-deleted cards in
+    the commodity. Drives the coverage line in the sub-filters panel and the coverage-
+    aware empty state (a parametric zero-result mostly means "not yet spec-enriched",
+    not "no such parts"). Two cheap aggregates, no N+1.
     """
     commodity = commodity.lower().strip()
     commodity_cards = db.query(MaterialCard.id).filter(
@@ -487,4 +508,4 @@ def get_commodity_spec_coverage(db: Session, commodity: str) -> dict[str, int]:
         .scalar()
         or 0
     )
-    return {"with_specs": with_specs, "total": total}
+    return SpecCoverage(with_specs=with_specs, total=total)

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -582,6 +582,13 @@ Alpine.data('materialsFilter', () => ({
   rohs: [],
   condition: [],
   hasDatasheet: false,
+  // Sourcing signals (Layer-3 operational filters) — MaterialCard + vendor history.
+  hasStock: false,
+  hasPrice: false,
+  hasCrosses: false,
+  internal: 'all',            // 'all' | 'standard' | 'internal'
+  searchedWithin: 'any',      // '7d' | '30d' | '90d' | 'any'
+  minSearches: 0,
   _onPopstate: null,
 
   // ── Direction-B UI state ─────────────────────────────────────────────
@@ -595,6 +602,7 @@ Alpine.data('materialsFilter', () => ({
   // Persisted CHROME only (layout prefs); filter STATE stays URL-bound.
   recentCommodities: persistOr([], 'mat_recent_commodities'),
   moreAttrsOpen: persistOr(false, 'mat_more_attrs_open'),
+  sourcingOpen: persistOr(false, 'mat_sourcing_open'),
   confidenceOpen: persistOr(false, 'mat_confidence_open'),
 
   // 3 user-facing confidence groups, each expanding to a set of enrichment tiers.
@@ -649,6 +657,14 @@ Alpine.data('materialsFilter', () => ({
     this.applyFilters();
   },
 
+  // Active selections inside the "Sourcing signals" section (for its badge + chips).
+  get sourcingActiveCount() {
+    return (this.hasStock ? 1 : 0) + (this.hasPrice ? 1 : 0) + (this.hasCrosses ? 1 : 0)
+      + (this.internal !== 'all' ? 1 : 0)
+      + (this.searchedWithin !== 'any' ? 1 : 0)
+      + (this.minSearches > 0 ? 1 : 0);
+  },
+
   get activeFilterCount() {
     let count = 0;
     for (const [key, val] of Object.entries(this.subFilters)) {
@@ -660,6 +676,7 @@ Alpine.data('materialsFilter', () => ({
     count += this.rohs.length;
     count += this.condition.length;
     if (this.hasDatasheet) count += 1;
+    count += this.sourcingActiveCount;
     return count;
   },
 
@@ -678,6 +695,12 @@ Alpine.data('materialsFilter', () => ({
     this.rohs = [];
     this.condition = [];
     this.hasDatasheet = false;
+    this.hasStock = false;
+    this.hasPrice = false;
+    this.hasCrosses = false;
+    this.internal = 'all';
+    this.searchedWithin = 'any';
+    this.minSearches = 0;
     this.statuses = [...this.DEFAULT_STATUSES];
     this.q = '';
     this.ui.facetSearch = {};
@@ -737,6 +760,15 @@ Alpine.data('materialsFilter', () => ({
       this.rohs = (params.get('rohs') || '').split(',').filter(s => s !== '');
       this.condition = (params.get('condition') || '').split(',').filter(s => s !== '');
       this.hasDatasheet = params.get('has_datasheet') === 'true';
+      this.hasStock = params.get('has_stock') === 'true';
+      this.hasPrice = params.get('has_price') === 'true';
+      this.hasCrosses = params.get('has_crosses') === 'true';
+      const internalParam = params.get('internal');
+      this.internal = ['standard', 'internal'].includes(internalParam) ? internalParam : 'all';
+      const withinParam = params.get('searched_within');
+      this.searchedWithin = ['7d', '30d', '90d'].includes(withinParam) ? withinParam : 'any';
+      const minSearchesVal = parseInt(params.get('min_searches') || '0', 10);
+      this.minSearches = (isNaN(minSearchesVal) || minSearchesVal < 0) ? 0 : minSearchesVal;
       const pageVal = parseInt(params.get('page') || '0', 10);
       this.page = isNaN(pageVal) ? 0 : pageVal;
       this.subFilters = {};
@@ -770,6 +802,12 @@ Alpine.data('materialsFilter', () => ({
       this.rohs = [];
       this.condition = [];
       this.hasDatasheet = false;
+      this.hasStock = false;
+      this.hasPrice = false;
+      this.hasCrosses = false;
+      this.internal = 'all';
+      this.searchedWithin = 'any';
+      this.minSearches = 0;
       this.page = 0;
       this.subFilters = {};
     }
@@ -788,6 +826,12 @@ Alpine.data('materialsFilter', () => ({
     if (this.rohs.length > 0) params.set('rohs', this.rohs.join(','));
     if (this.condition.length > 0) params.set('condition', this.condition.join(','));
     if (this.hasDatasheet) params.set('has_datasheet', 'true');
+    if (this.hasStock) params.set('has_stock', 'true');
+    if (this.hasPrice) params.set('has_price', 'true');
+    if (this.hasCrosses) params.set('has_crosses', 'true');
+    if (this.internal !== 'all') params.set('internal', this.internal);
+    if (this.searchedWithin !== 'any') params.set('searched_within', this.searchedWithin);
+    if (this.minSearches > 0) params.set('min_searches', this.minSearches);
     if (this.page > 0) params.set('page', this.page);
     for (const [key, val] of Object.entries(this.subFilters)) {
       if (Array.isArray(val) && val.length > 0) {
@@ -832,6 +876,34 @@ Alpine.data('materialsFilter', () => ({
 
   toggleDatasheet() {
     this.hasDatasheet = !this.hasDatasheet;
+    if (window.innerWidth >= 1024) this.applyFilters();
+  },
+
+  // Sourcing-signal boolean toggle (hasStock / hasPrice / hasCrosses).
+  toggleSourcingFlag(flag) {
+    if (!['hasStock', 'hasPrice', 'hasCrosses'].includes(flag)) return;
+    this[flag] = !this[flag];
+    if (window.innerWidth >= 1024) this.applyFilters();
+  },
+
+  // Internal-vs-standard segmented control ('all' | 'standard' | 'internal').
+  setInternal(mode) {
+    this.internal = ['standard', 'internal'].includes(mode) ? mode : 'all';
+    if (window.innerWidth >= 1024) this.applyFilters();
+  },
+
+  // Recently-searched chips ('7d' | '30d' | '90d' | 'any'). Re-clicking the active
+  // bucket resets to 'any'.
+  setSearchedWithin(bucket) {
+    const next = ['7d', '30d', '90d'].includes(bucket) ? bucket : 'any';
+    this.searchedWithin = (this.searchedWithin === next) ? 'any' : next;
+    if (window.innerWidth >= 1024) this.applyFilters();
+  },
+
+  // Min-searches numeric input (0 = off).
+  setMinSearches(value) {
+    const num = parseInt(value, 10);
+    this.minSearches = (isNaN(num) || num < 0) ? 0 : num;
     if (window.innerWidth >= 1024) this.applyFilters();
   },
 

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -617,6 +617,15 @@ Alpine.data('materialsFilter', () => ({
     return this.CONFIDENCE_GROUPS.flatMap(g => g.tiers);
   },
 
+  // Sourcing-signal vocabularies — the single front-end source of truth as
+  // [value, label] pairs (incl. the no-op sentinel 'all'/'any'). Rendered by
+  // workspace.html's x-for templates and consulted by syncFromURL + the setters.
+  // Backend twin (must stay in sync): INTERNAL_FILTER_VALUES / SEARCHED_WITHIN_VALUES
+  // in app/services/faceted_search_service.py — the route logs a WARNING and degrades
+  // to the sentinel when the vocabularies drift.
+  INTERNAL_MODES: [['all', 'All'], ['standard', 'Standard MPNs'], ['internal', 'Internal parts']],
+  SEARCH_BUCKETS: [['7d', '7d'], ['30d', '30d'], ['90d', '90d'], ['any', 'Any']],
+
   get commodityDisplayName() {
     if (!this.commodity) return '';
     return this.displayNames[this.commodity]
@@ -764,9 +773,9 @@ Alpine.data('materialsFilter', () => ({
       this.hasPrice = params.get('has_price') === 'true';
       this.hasCrosses = params.get('has_crosses') === 'true';
       const internalParam = params.get('internal');
-      this.internal = ['standard', 'internal'].includes(internalParam) ? internalParam : 'all';
+      this.internal = this.INTERNAL_MODES.some(([v]) => v === internalParam) ? internalParam : 'all';
       const withinParam = params.get('searched_within');
-      this.searchedWithin = ['7d', '30d', '90d'].includes(withinParam) ? withinParam : 'any';
+      this.searchedWithin = this.SEARCH_BUCKETS.some(([v]) => v === withinParam) ? withinParam : 'any';
       const minSearchesVal = parseInt(params.get('min_searches') || '0', 10);
       this.minSearches = (isNaN(minSearchesVal) || minSearchesVal < 0) ? 0 : minSearchesVal;
       const pageVal = parseInt(params.get('page') || '0', 10);
@@ -888,14 +897,14 @@ Alpine.data('materialsFilter', () => ({
 
   // Internal-vs-standard segmented control ('all' | 'standard' | 'internal').
   setInternal(mode) {
-    this.internal = ['standard', 'internal'].includes(mode) ? mode : 'all';
+    this.internal = this.INTERNAL_MODES.some(([v]) => v === mode) ? mode : 'all';
     if (window.innerWidth >= 1024) this.applyFilters();
   },
 
   // Recently-searched chips ('7d' | '30d' | '90d' | 'any'). Re-clicking the active
   // bucket resets to 'any'.
   setSearchedWithin(bucket) {
-    const next = ['7d', '30d', '90d'].includes(bucket) ? bucket : 'any';
+    const next = this.SEARCH_BUCKETS.some(([v]) => v === bucket) ? bucket : 'any';
     this.searchedWithin = (this.searchedWithin === next) ? 'any' : next;
     if (window.innerWidth >= 1024) this.applyFilters();
   },

--- a/app/templates/htmx/partials/materials/filters/subfilters.html
+++ b/app/templates/htmx/partials/materials/filters/subfilters.html
@@ -1,8 +1,20 @@
 {# Dynamic sub-filters for a specific commodity.
    Called by: HTMX request when commodity or filters change
-   Depends on: subfilter_options, facet_counts from route context
+   Depends on: subfilter_options, facet_counts, spec_coverage, commodity_display
+               from route context
 #}
 {% from "htmx/partials/materials/filters/_macros.html" import render_subfilter %}
+
+{# Coverage line — sets expectations before parametric filtering: facets only exist on
+   spec-enriched cards, so a thin N here explains thin parametric results. #}
+{% macro coverage_line() %}
+  {% if spec_coverage and spec_coverage.total > 0 %}
+  <p class="text-[11px] text-gray-400 mb-2">
+    {{ "{:,}".format(spec_coverage.with_specs) }} of {{ "{:,}".format(spec_coverage.total) }} parts in
+    {{ commodity_display }} have filterable specs
+  </p>
+  {% endif %}
+{% endmacro %}
 
 {% if subfilter_options %}
 <div class="border-t border-gray-100 pt-3 mt-3">
@@ -11,6 +23,7 @@
     <button @click="clearSubFilters()" x-show="Object.keys(subFilters).length > 0" x-cloak
             class="text-[11px] text-brand-600 hover:text-brand-700 font-medium">Clear specs</button>
   </div>
+  {{ coverage_line() }}
 
   {# Essential facets (is_primary) render expanded; the rest fold under "More filters". #}
   {% set primary_opts = subfilter_options | selectattr('is_primary') | list %}
@@ -36,6 +49,7 @@
 </div>
 {% elif commodity_selected %}
 <div class="border-t border-gray-100 pt-3 mt-3">
+  {{ coverage_line() }}
   <p class="text-xs text-gray-400 italic">No filters available for this category</p>
 </div>
 {% endif %}

--- a/app/templates/htmx/partials/materials/list.html
+++ b/app/templates/htmx/partials/materials/list.html
@@ -23,6 +23,15 @@
     'nrfnd': 'bg-gray-100 text-gray-600 border-gray-200',
     'ltb': 'bg-amber-50 text-amber-600 border-amber-200',
   } %}
+  {# Stock-condition badge palette — same shape as the lifecycle badges. #}
+  {% set cond_colors = {
+    'New': 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    'Recertified': 'bg-sky-50 text-sky-700 border-sky-200',
+    'Refurbished': 'bg-amber-50 text-amber-700 border-amber-200',
+    'Used': 'bg-amber-50 text-amber-600 border-amber-200',
+    'Pulled': 'bg-rose-50 text-rose-700 border-rose-200',
+    'Unknown': 'bg-gray-100 text-gray-600 border-gray-200',
+  } %}
   {% if materials %}
   <div class="overflow-x-auto">
     <table class="compact-table">
@@ -46,12 +55,31 @@
             hx-push-url="/v2/materials/{{ m.id }}"
             preload="mouseover">
           <td>
-            <span class="font-data font-semibold text-brand-600">{{ m.display_mpn or m.normalized_mpn or "--" }}</span>
+            <div class="flex items-center gap-1.5">
+              <span class="font-data font-semibold text-brand-600">{{ m.display_mpn or m.normalized_mpn or "--" }}</span>
+              {% if m.datasheet_url %}
+              {# target=_blank anchor inside the hx-get row — same pattern as the
+                 web-sourced/OEM status links below. #}
+              <a href="{{ m.datasheet_url }}" target="_blank" rel="noopener"
+                 class="text-gray-400 hover:text-brand-600" title="Open datasheet"
+                 aria-label="Open datasheet for {{ m.display_mpn or m.normalized_mpn }}">
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                </svg>
+              </a>
+              {% endif %}
+              {% if m.cross_references %}
+              <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full border bg-indigo-50 text-indigo-700 border-indigo-200"
+                    title="Known cross-references / substitutes">
+                {{ m.cross_references|length }} alternate{{ '' if m.cross_references|length == 1 else 's' }}
+              </span>
+              {% endif %}
+            </div>
             {% if m._primary_specs %}
             <div class="flex flex-wrap gap-1 mt-0.5">
               {% for spec in m._primary_specs[:3] %}
               <span class="inline-block px-1.5 py-0.5 bg-gray-50 text-[10px] text-gray-500 rounded font-data">
-                {{ spec.value }}
+                {%- if not commodity and spec.label %}{{ spec.label }}: {% endif %}{{ spec.value }}
               </span>
               {% endfor %}
             </div>
@@ -61,13 +89,22 @@
           <td class="td-label text-gray-600">{{ m.manufacturer or "--" }}</td>
           <td class="td-label text-gray-600">{{ m.category or "--" }}</td>
           <td>
-            {% if m.lifecycle_status %}
-            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border {{ lc_colors.get(m.lifecycle_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
-              {{ m.lifecycle_status|upper }}
-            </span>
-            {% else %}
-            <span class="text-xs text-gray-400">--</span>
-            {% endif %}
+            <div class="flex flex-wrap items-center gap-1">
+              {% if m.lifecycle_status %}
+              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border {{ lc_colors.get(m.lifecycle_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
+                {{ m.lifecycle_status|upper }}
+              </span>
+              {% endif %}
+              {% if m.condition %}
+              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border {{ cond_colors.get(m.condition, 'bg-gray-100 text-gray-600 border-gray-200') }}"
+                    title="Stock condition">
+                {{ m.condition|upper }}
+              </span>
+              {% endif %}
+              {% if not m.lifecycle_status and not m.condition %}
+              <span class="text-xs text-gray-400">--</span>
+              {% endif %}
+            </div>
           </td>
           <td>
             {% set es = m.enrichment_status %}
@@ -128,8 +165,18 @@
     <svg class="mx-auto h-10 w-10 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/>
     </svg>
+    {% if parametric_active and spec_coverage and spec_coverage.with_specs < spec_coverage.total %}
+    {# Coverage-aware nudge: parametric facets only exist on spec-enriched cards, so a
+       zero here mostly means "not yet spec-enriched", not "no such parts". #}
+    <p class="text-sm font-medium text-gray-500">No matches — but most parts here haven't been spec-enriched yet. Try clearing parametric filters.</p>
+    <p class="text-xs text-gray-400 mt-1">
+      Only {{ "{:,}".format(spec_coverage.with_specs) }} of {{ "{:,}".format(spec_coverage.total) }}
+      {% if commodity_display %}{{ commodity_display }} {% endif %}parts have filterable specs so far
+    </p>
+    {% else %}
     <p class="text-sm font-medium text-gray-500">No results match your filters</p>
     <p class="text-xs text-gray-400 mt-1">Try removing a filter or broadening your search</p>
+    {% endif %}
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -128,6 +128,68 @@
         </div>
       </div>
 
+      {# ── Sourcing signals (Layer-3 operational filters) ──────────────
+         Stock/price/crosses toggles, internal tri-state, recently-searched chips and
+         min-searches — MaterialCard + vendor-history predicates, no per-value counts,
+         so this section is static (no HTMX reload needed). #}
+      <div class="border-t border-gray-100 pt-3 mt-3">
+        {{ disclosure_header('sourcingOpen', 'sourcing-panel', 'Sourcing signals', 'sourcingActiveCount > 0', 'sourcingActiveCount') }}
+        <div id="sourcing-panel" role="region" aria-label="Sourcing signals" x-show="sourcingOpen" x-collapse x-cloak class="mt-2">
+          <div class="space-y-0.5 mb-3">
+            <label class="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-50 cursor-pointer text-sm">
+              <input aria-label="Only parts with vendor stock seen" type="checkbox"
+                     :checked="hasStock" @change="toggleSourcingFlag('hasStock')"
+                     class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 h-3.5 w-3.5">
+              <span class="text-gray-700 truncate flex-1 text-[13px]">Has stock seen</span>
+            </label>
+            <label class="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-50 cursor-pointer text-sm">
+              <input aria-label="Only parts with a recorded price" type="checkbox"
+                     :checked="hasPrice" @change="toggleSourcingFlag('hasPrice')"
+                     class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 h-3.5 w-3.5">
+              <span class="text-gray-700 truncate flex-1 text-[13px]">Has price</span>
+            </label>
+            <label class="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-50 cursor-pointer text-sm">
+              <input aria-label="Only parts with known alternates" type="checkbox"
+                     :checked="hasCrosses" @change="toggleSourcingFlag('hasCrosses')"
+                     class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 h-3.5 w-3.5">
+              <span class="text-gray-700 truncate flex-1 text-[13px]">Has alternates</span>
+            </label>
+          </div>
+          <div class="mb-3">
+            <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Part type</h4>
+            <div class="flex flex-wrap gap-1">
+              <template x-for="opt in [['all', 'All'], ['standard', 'Standard MPNs'], ['internal', 'Internal parts']]" :key="'int-' + opt[0]">
+                <button @click="setInternal(opt[0])"
+                        :class="internal === opt[0] ? 'bg-brand-50 text-brand-700 border-brand-300' : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300'"
+                        :aria-pressed="internal === opt[0]"
+                        class="px-2 py-0.5 text-[11px] border rounded-full transition-colors"
+                        x-text="opt[1]"></button>
+              </template>
+            </div>
+          </div>
+          <div class="mb-3">
+            <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Searched within</h4>
+            <div class="flex flex-wrap gap-1">
+              <template x-for="opt in [['7d', '7d'], ['30d', '30d'], ['90d', '90d'], ['any', 'Any']]" :key="'sw-' + opt[0]">
+                <button @click="setSearchedWithin(opt[0])"
+                        :class="searchedWithin === opt[0] ? 'bg-brand-50 text-brand-700 border-brand-300' : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300'"
+                        :aria-pressed="searchedWithin === opt[0]"
+                        class="px-2 py-0.5 text-[11px] border rounded-full transition-colors"
+                        x-text="opt[1]"></button>
+              </template>
+            </div>
+          </div>
+          <div class="mb-3">
+            <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Min searches</h4>
+            <input type="number" min="0" step="1" placeholder="0"
+                   :value="minSearches || ''"
+                   @input.debounce.600ms="setMinSearches($event.target.value)"
+                   aria-label="Minimum search count"
+                   class="w-full px-2 py-1.5 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-brand-500 focus:border-brand-500 tabular-nums">
+          </div>
+        </div>
+      </div>
+
       {# ── Data confidence (3 groups, collapsed, bottom) ───────────────
          Lowest-priority filter. Each group checkbox toggles its member enrichment tiers;
          the backend still receives a `statuses` CSV. #}
@@ -204,7 +266,7 @@
       <div id="ai-script-container"></div>
 
       {# Active filter chips #}
-      <template x-if="commodity || q || Object.keys(subFilters).length > 0 || confidenceNarrowed || lifecycle.length > 0 || rohs.length > 0 || condition.length > 0 || hasDatasheet" x-cloak>
+      <template x-if="commodity || q || Object.keys(subFilters).length > 0 || confidenceNarrowed || lifecycle.length > 0 || rohs.length > 0 || condition.length > 0 || hasDatasheet || sourcingActiveCount > 0" x-cloak>
         <div class="flex flex-wrap gap-1.5 mt-2">
           <template x-if="q" x-cloak>
             <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-50 text-blue-700 rounded-full text-xs">
@@ -245,6 +307,43 @@
             <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
               Has datasheet
               <button @click="hasDatasheet = false; applyFilters()" class="hover:text-gray-900" aria-label="Remove filter">&times;</button>
+            </span>
+          </template>
+          {# Sourcing-signal chips #}
+          <template x-if="hasStock" x-cloak>
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
+              Has stock seen
+              <button @click="hasStock = false; applyFilters()" class="hover:text-gray-900" aria-label="Remove filter">&times;</button>
+            </span>
+          </template>
+          <template x-if="hasPrice" x-cloak>
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
+              Has price
+              <button @click="hasPrice = false; applyFilters()" class="hover:text-gray-900" aria-label="Remove filter">&times;</button>
+            </span>
+          </template>
+          <template x-if="hasCrosses" x-cloak>
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
+              Has alternates
+              <button @click="hasCrosses = false; applyFilters()" class="hover:text-gray-900" aria-label="Remove filter">&times;</button>
+            </span>
+          </template>
+          <template x-if="internal !== 'all'" x-cloak>
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
+              <span x-text="internal === 'internal' ? 'Internal parts' : 'Standard MPNs'"></span>
+              <button @click="setInternal('all')" class="hover:text-gray-900" aria-label="Remove filter">&times;</button>
+            </span>
+          </template>
+          <template x-if="searchedWithin !== 'any'" x-cloak>
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
+              <span x-text="'Searched: ' + searchedWithin"></span>
+              <button @click="searchedWithin = 'any'; applyFilters()" class="hover:text-gray-900" aria-label="Remove filter">&times;</button>
+            </span>
+          </template>
+          <template x-if="minSearches > 0" x-cloak>
+            <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-600 rounded-full text-xs">
+              <span x-text="'Min searches: ' + minSearches"></span>
+              <button @click="minSearches = 0; applyFilters()" class="hover:text-gray-900" aria-label="Remove filter">&times;</button>
             </span>
           </template>
           <template x-if="commodity" x-cloak>
@@ -288,6 +387,12 @@
            "rohs": (Alpine.evaluate(document.querySelector("#materials-workspace"), "rohs") || []).join(","),
            "condition": (Alpine.evaluate(document.querySelector("#materials-workspace"), "condition") || []).join(","),
            "has_datasheet": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasDatasheet") || false,
+           "has_stock": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasStock") || false,
+           "has_price": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasPrice") || false,
+           "has_crosses": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasCrosses") || false,
+           "internal": Alpine.evaluate(document.querySelector("#materials-workspace"), "internal") || "all",
+           "searched_within": Alpine.evaluate(document.querySelector("#materials-workspace"), "searchedWithin") || "any",
+           "min_searches": Alpine.evaluate(document.querySelector("#materials-workspace"), "minSearches") || 0,
            "limit": 50,
            "offset": (Alpine.evaluate(document.querySelector("#materials-workspace"), "page") || 0) * 50
          }'

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -158,7 +158,8 @@
           <div class="mb-3">
             <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Part type</h4>
             <div class="flex flex-wrap gap-1">
-              <template x-for="opt in [['all', 'All'], ['standard', 'Standard MPNs'], ['internal', 'Internal parts']]" :key="'int-' + opt[0]">
+              {# Vocabulary lives on the component (INTERNAL_MODES) — single front-end source of truth. #}
+              <template x-for="opt in INTERNAL_MODES" :key="'int-' + opt[0]">
                 <button @click="setInternal(opt[0])"
                         :class="internal === opt[0] ? 'bg-brand-50 text-brand-700 border-brand-300' : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300'"
                         :aria-pressed="internal === opt[0]"
@@ -170,7 +171,8 @@
           <div class="mb-3">
             <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Searched within</h4>
             <div class="flex flex-wrap gap-1">
-              <template x-for="opt in [['7d', '7d'], ['30d', '30d'], ['90d', '90d'], ['any', 'Any']]" :key="'sw-' + opt[0]">
+              {# Vocabulary lives on the component (SEARCH_BUCKETS) — single front-end source of truth. #}
+              <template x-for="opt in SEARCH_BUCKETS" :key="'sw-' + opt[0]">
                 <button @click="setSearchedWithin(opt[0])"
                         :class="searchedWithin === opt[0] ? 'bg-brand-50 text-brand-700 border-brand-300' : 'bg-white text-gray-500 border-gray-200 hover:border-gray-300'"
                         :aria-pressed="searchedWithin === opt[0]"

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -865,6 +865,20 @@ Sidebar facets (workspace.html + materialsFilter Alpine component) — COMMODITY
     +---> "More attributes" (collapsed, $persist moreAttrsOpen; active-count badge):
     |       Manufacturer (search + top-N) + Global facets (lifecycle / rohs / condition /
     |       has_datasheet) via get_global_facet_counts(). Containers load while hidden.
+    +---> "Sourcing signals" (collapsed, $persist sourcingOpen; active-count badge) —
+    |     Layer-3 operational filters, all top-level params on
+    |     /v2/partials/materials/faceted → search_materials_faceted():
+    |       has_stock   (EXISTS MaterialVendorHistory row)
+    |       has_price   (EXISTS row with last_price IS NOT NULL)
+    |       has_crosses (cross_references holds a non-empty list; portable text-cast
+    |                    predicate — identical on PG JSONB and SQLite JSON-as-text)
+    |       internal    (tri-state all|standard|internal on is_internal_part; default
+    |                    `all` — deliberate deviation from the matrix's default=standard
+    |                    so first load never silently drops rows)
+    |       searched_within (7d|30d|90d|any chips on last_searched_at)
+    |       min_searches    (int ≥ 0 on search_count)
+    |     Unknown enum values degrade to the no-op default (no 500 on hand-edited URLs).
+    |     Static section (no per-value counts → no HTMX reload).
     +---> Data confidence (collapsed, bottom, $persist confidenceOpen): 3 groups —
     |     Trusted / AI-inferred / No data; default all-on; `statuses[]` → `?statuses=` CSV
     |     → search_materials_faceted (IN-filters enrichment_status; precedence over the
@@ -872,6 +886,20 @@ Sidebar facets (workspace.html + materialsFilter Alpine component) — COMMODITY
     Live result count "<N> <Commodity> parts" renders at the top of the results pane
     (list.html) every filters-changed cycle, with an sr-only aria-live announcement.
     Mobile drawer: x-trap focus trap + Escape-to-close.
+
+Coverage-aware empty states (get_commodity_spec_coverage(db, commodity) →
+{"with_specs": N, "total": M}; two cheap aggregates, no N+1):
+    +---> Sub-filters panel header shows "N of M parts in <commodity> have filterable
+    |     specs" so thin parametric results are explained before filtering.
+    +---> Zero results + active parametric sub_filters + N < M → list.html renders the
+    |     "not yet spec-enriched" nudge instead of the generic empty state.
+Result-row upgrades (list.html, server-side in materials_faceted_partial):
+    +---> Spec chips also render WITHOUT a commodity: each card's own category's
+    |     is_primary schema keys (one batched CommoditySpecSchema query), else the first
+    |     3 scalar specs_structured entries, formatted "label: value".
+    +---> Datasheet icon-link (new tab, rel=noopener) when datasheet_url is set;
+    |     "N alternates" badge when cross_references is non-empty; condition badge
+    |     styled like the lifecycle palette.
 
 Search coverage:
     +---> global_search_service.py includes substitutes_text.ilike for

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -873,11 +873,16 @@ Sidebar facets (workspace.html + materialsFilter Alpine component) — COMMODITY
     |       has_crosses (cross_references holds a non-empty list; portable text-cast
     |                    predicate — identical on PG JSONB and SQLite JSON-as-text)
     |       internal    (tri-state all|standard|internal on is_internal_part; default
-    |                    `all` — deliberate deviation from the matrix's default=standard
-    |                    so first load never silently drops rows)
+    |                    `all` — deliberately not `standard` — so first load never
+    |                    silently drops rows)
     |       searched_within (7d|30d|90d|any chips on last_searched_at)
     |       min_searches    (int ≥ 0 on search_count)
-    |     Unknown enum values degrade to the no-op default (no 500 on hand-edited URLs).
+    |     Unknown/invalid values (incl. non-numeric or negative min_searches) degrade
+    |     to the no-op default with a WARNING log (hand-edited URLs never 500/422; the
+    |     log surfaces frontend/backend vocabulary drift). Vocabularies are owned by
+    |     faceted_search_service (INTERNAL_FILTER_VALUES / SEARCHED_WITHIN_VALUES,
+    |     derived from the maps that drive the query branches); the JS twin is
+    |     INTERNAL_MODES / SEARCH_BUCKETS on the materialsFilter component.
     |     Static section (no per-value counts → no HTMX reload).
     +---> Data confidence (collapsed, bottom, $persist confidenceOpen): 3 groups —
     |     Trusted / AI-inferred / No data; default all-on; `statuses[]` → `?statuses=` CSV
@@ -888,7 +893,7 @@ Sidebar facets (workspace.html + materialsFilter Alpine component) — COMMODITY
     Mobile drawer: x-trap focus trap + Escape-to-close.
 
 Coverage-aware empty states (get_commodity_spec_coverage(db, commodity) →
-{"with_specs": N, "total": M}; two cheap aggregates, no N+1):
+SpecCoverage(with_specs=N, total=M) NamedTuple; two cheap aggregates, no N+1):
     +---> Sub-filters panel header shows "N of M parts in <commodity> have filterable
     |     specs" so thin parametric results are explained before filtering.
     +---> Zero results + active parametric sub_filters + N < M → list.html renders the

--- a/tests/frontend/materials-filter-sourcing.test.ts
+++ b/tests/frontend/materials-filter-sourcing.test.ts
@@ -1,0 +1,188 @@
+// tests/frontend/materials-filter-sourcing.test.ts — Layer-3 "Sourcing signals"
+// state on the materialsFilter Alpine component: URL sync (read+write), the
+// toggle/segment/chip/numeric setters, the active-count badge and clearAllFilters.
+// Mirrors the mock harness in materials-filter-display-name.test.ts.
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+let registry: Record<string, any> = {}
+
+vi.mock('htmx.org', () => ({
+  default: {
+    on: vi.fn(), off: vi.fn(), ajax: vi.fn(), process: vi.fn(),
+    defineExtension: vi.fn(), createExtension: vi.fn(),
+    config: {},
+  },
+}))
+
+const alpineMock = {
+  data: (n: string, f: any) => { registry[n] = f },
+  store: vi.fn(),
+  plugin: vi.fn(),
+  start: vi.fn(),
+  directive: vi.fn(),
+  magic: vi.fn(),
+}
+
+vi.mock('alpinejs', () => ({ default: alpineMock }))
+vi.mock('@alpinejs/focus', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/persist', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/intersect', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/collapse', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/morph', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/mask', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/sort', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/anchor', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/resize', () => ({ default: vi.fn() }))
+vi.mock('htmx-ext-alpine-morph', () => ({}))
+vi.mock('htmx-ext-response-targets', () => ({}))
+vi.mock('htmx-ext-sse', () => ({}))
+vi.mock('htmx-ext-json-enc', () => ({}))
+vi.mock('htmx-ext-preload', () => ({}))
+vi.mock('htmx-ext-loading-states', () => ({}))
+vi.mock('htmx-ext-path-deps', () => ({}))
+vi.mock('htmx-ext-remove-me', () => ({}))
+
+function makeComponent() {
+  const c = registry['materialsFilter']()
+  c.$el = { dataset: { displayNames: '{}' } }
+  return c
+}
+
+beforeEach(async () => {
+  registry = {}
+  alpineMock.data = (n: string, f: any) => { registry[n] = f }
+  vi.resetModules()
+  history.replaceState({}, '', '/v2/materials')
+  await import('../../app/static/htmx_app.js')
+})
+
+describe('materialsFilter sourcing signals — syncFromURL', () => {
+  it('parses the operational params from the URL', () => {
+    history.replaceState({}, '',
+      '/v2/materials?has_stock=true&has_price=true&has_crosses=true&internal=internal&searched_within=30d&min_searches=4')
+    const c = makeComponent()
+    c.init()
+    expect(c.hasStock).toBe(true)
+    expect(c.hasPrice).toBe(true)
+    expect(c.hasCrosses).toBe(true)
+    expect(c.internal).toBe('internal')
+    expect(c.searchedWithin).toBe('30d')
+    expect(c.minSearches).toBe(4)
+  })
+
+  it('degrades unknown/negative values to the no-op defaults', () => {
+    history.replaceState({}, '', '/v2/materials?internal=bogus&searched_within=last-week&min_searches=-3')
+    const c = makeComponent()
+    c.init()
+    expect(c.internal).toBe('all')
+    expect(c.searchedWithin).toBe('any')
+    expect(c.minSearches).toBe(0)
+  })
+})
+
+describe('materialsFilter sourcing signals — pushURL', () => {
+  it('serializes only non-default operational state', () => {
+    const c = makeComponent()
+    c.init()
+    c.hasStock = true
+    c.internal = 'standard'
+    c.searchedWithin = '7d'
+    c.minSearches = 2
+    c.pushURL()
+    const params = new URLSearchParams(window.location.search)
+    expect(params.get('has_stock')).toBe('true')
+    expect(params.get('has_price')).toBeNull()    // default omitted
+    expect(params.get('has_crosses')).toBeNull()  // default omitted
+    expect(params.get('internal')).toBe('standard')
+    expect(params.get('searched_within')).toBe('7d')
+    expect(params.get('min_searches')).toBe('2')
+  })
+
+  it('writes a clean URL when everything is at its default', () => {
+    const c = makeComponent()
+    c.init()
+    c.pushURL()
+    const search = window.location.search
+    for (const p of ['has_stock', 'has_price', 'has_crosses', 'internal', 'searched_within', 'min_searches']) {
+      expect(search).not.toContain(p)
+    }
+  })
+})
+
+describe('materialsFilter sourcing signals — setters', () => {
+  it('toggleSourcingFlag flips only the whitelisted flags', () => {
+    const c = makeComponent()
+    c.init()
+    c.toggleSourcingFlag('hasStock')
+    expect(c.hasStock).toBe(true)
+    c.toggleSourcingFlag('hasStock')
+    expect(c.hasStock).toBe(false)
+    c.toggleSourcingFlag('commodity')  // not a sourcing flag — ignored
+    expect(c.commodity).toBe('')
+  })
+
+  it('setSearchedWithin toggles off when re-clicking the active bucket', () => {
+    const c = makeComponent()
+    c.init()
+    c.setSearchedWithin('30d')
+    expect(c.searchedWithin).toBe('30d')
+    c.setSearchedWithin('30d')
+    expect(c.searchedWithin).toBe('any')
+    c.setSearchedWithin('whenever')
+    expect(c.searchedWithin).toBe('any')
+  })
+
+  it('setInternal accepts only the known modes', () => {
+    const c = makeComponent()
+    c.init()
+    c.setInternal('internal')
+    expect(c.internal).toBe('internal')
+    c.setInternal('nope')
+    expect(c.internal).toBe('all')
+  })
+
+  it('setMinSearches floors junk and negatives to 0', () => {
+    const c = makeComponent()
+    c.init()
+    c.setMinSearches('7')
+    expect(c.minSearches).toBe(7)
+    c.setMinSearches('-2')
+    expect(c.minSearches).toBe(0)
+    c.setMinSearches('abc')
+    expect(c.minSearches).toBe(0)
+  })
+})
+
+describe('materialsFilter sourcing signals — counts and reset', () => {
+  it('sourcingActiveCount feeds activeFilterCount', () => {
+    const c = makeComponent()
+    c.init()
+    expect(c.sourcingActiveCount).toBe(0)
+    const base = c.activeFilterCount
+    c.hasStock = true
+    c.hasCrosses = true
+    c.internal = 'standard'
+    c.searchedWithin = '90d'
+    c.minSearches = 1
+    expect(c.sourcingActiveCount).toBe(5)
+    expect(c.activeFilterCount).toBe(base + 5)
+  })
+
+  it('clearAllFilters resets every sourcing signal', () => {
+    const c = makeComponent()
+    c.init()
+    c.hasStock = true
+    c.hasPrice = true
+    c.hasCrosses = true
+    c.internal = 'internal'
+    c.searchedWithin = '7d'
+    c.minSearches = 9
+    c.clearAllFilters()
+    expect(c.hasStock).toBe(false)
+    expect(c.hasPrice).toBe(false)
+    expect(c.hasCrosses).toBe(false)
+    expect(c.internal).toBe('all')
+    expect(c.searchedWithin).toBe('any')
+    expect(c.minSearches).toBe(0)
+  })
+})

--- a/tests/test_faceted_routes.py
+++ b/tests/test_faceted_routes.py
@@ -483,3 +483,299 @@ def test_faceted_endpoint_currency_aggregate(client, db_session):
         "Dollar-prefixed price not rendered for mixed-currency card; "
         "_best_currency should be None for mixed currencies (falls back to '$')"
     )
+
+
+# --- Operational (Layer-3) filter params on the faceted route ---
+
+
+def _op_card(db, mpn, **kw):
+    from app.models.intelligence import MaterialCard
+
+    card = MaterialCard(
+        normalized_mpn=mpn.lower(),
+        display_mpn=mpn.upper(),
+        category=kw.pop("category", "resistors"),
+        created_at=datetime.now(timezone.utc),
+        **kw,
+    )
+    db.add(card)
+    db.flush()
+    return card
+
+
+def test_faceted_operational_params_filter(client, db_session: Session):
+    """?has_crosses / ?internal / ?min_searches narrow the result set."""
+    _op_card(
+        db_session,
+        "op-keep",
+        cross_references=[{"mpn": "ALT-1"}],
+        is_internal_part=False,
+        search_count=5,
+    )
+    _op_card(db_session, "op-no-cross", cross_references=[], is_internal_part=False, search_count=5)
+    _op_card(
+        db_session,
+        "op-internal",
+        cross_references=[{"mpn": "ALT-2"}],
+        is_internal_part=True,
+        search_count=5,
+    )
+    _op_card(db_session, "op-cold", cross_references=[{"mpn": "ALT-3"}], is_internal_part=False, search_count=1)
+    db_session.commit()
+
+    resp = client.get("/v2/partials/materials/faceted?has_crosses=true&internal=standard&min_searches=5")
+    assert resp.status_code == 200
+    assert "OP-KEEP" in resp.text
+    assert "OP-NO-CROSS" not in resp.text
+    assert "OP-INTERNAL" not in resp.text
+    assert "OP-COLD" not in resp.text
+
+
+def test_faceted_has_stock_and_price_params(client, db_session: Session):
+    from app.models.intelligence import MaterialVendorHistory
+
+    with_price = _op_card(db_session, "vh-price")
+    db_session.add(MaterialVendorHistory(material_card_id=with_price.id, vendor_name="V", last_price=2.5))
+    no_price = _op_card(db_session, "vh-stock")
+    db_session.add(MaterialVendorHistory(material_card_id=no_price.id, vendor_name="V", last_price=None))
+    _op_card(db_session, "vh-none")
+    db_session.commit()
+
+    resp = client.get("/v2/partials/materials/faceted?has_stock=true")
+    assert "VH-PRICE" in resp.text and "VH-STOCK" in resp.text and "VH-NONE" not in resp.text
+
+    resp = client.get("/v2/partials/materials/faceted?has_price=true")
+    assert "VH-PRICE" in resp.text and "VH-STOCK" not in resp.text and "VH-NONE" not in resp.text
+
+
+def test_faceted_searched_within_param(client, db_session: Session):
+    from datetime import timedelta
+
+    now = datetime.now(timezone.utc)
+    _op_card(db_session, "sw-fresh", last_searched_at=now - timedelta(days=2))
+    _op_card(db_session, "sw-stale", last_searched_at=now - timedelta(days=60))
+    db_session.commit()
+
+    resp = client.get("/v2/partials/materials/faceted?searched_within=7d")
+    assert "SW-FRESH" in resp.text and "SW-STALE" not in resp.text
+
+    resp = client.get("/v2/partials/materials/faceted?searched_within=90d")
+    assert "SW-FRESH" in resp.text and "SW-STALE" in resp.text
+
+
+def test_faceted_bogus_operational_params_degrade(client, db_session: Session):
+    """Unknown enum values on hand-edited URLs degrade to no-ops, never 500."""
+    _op_card(db_session, "deg-1", is_internal_part=True)
+    _op_card(db_session, "deg-2", is_internal_part=False)
+    db_session.commit()
+
+    resp = client.get("/v2/partials/materials/faceted?internal=bogus&searched_within=yesterday")
+    assert resp.status_code == 200
+    assert "DEG-1" in resp.text and "DEG-2" in resp.text
+
+
+def test_workspace_renders_sourcing_signals_section(client):
+    """The rail's Sourcing-signals section renders with all Layer-3 controls wired."""
+    resp = client.get("/v2/partials/materials/workspace")
+    assert resp.status_code == 200
+    assert "Sourcing signals" in resp.text
+    assert "toggleSourcingFlag('hasStock')" in resp.text
+    assert "toggleSourcingFlag('hasPrice')" in resp.text
+    assert "toggleSourcingFlag('hasCrosses')" in resp.text
+    assert "setInternal(" in resp.text
+    assert "setSearchedWithin(" in resp.text
+    assert "setMinSearches(" in resp.text
+
+
+# --- Coverage-aware empty states ---
+
+
+def _dram_with_facet(db, mpn):
+    card = MaterialCard(
+        normalized_mpn=mpn.lower(),
+        display_mpn=mpn.upper(),
+        category="dram",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(card)
+    db.flush()
+    db.add(MaterialSpecFacet(material_card_id=card.id, category="dram", spec_key="ddr_type", value_text="DDR4"))
+    return card
+
+
+def _seed_ddr_schema(db):
+    db.add(
+        CommoditySpecSchema(
+            commodity="dram",
+            spec_key="ddr_type",
+            display_name="DDR Type",
+            data_type="enum",
+            enum_values=["DDR4", "DDR5"],
+            sort_order=1,
+            is_filterable=True,
+            is_primary=False,
+        )
+    )
+    db.flush()
+
+
+def test_subfilters_panel_shows_coverage_line(client, db_session: Session):
+    """'N of M parts in <commodity> have filterable specs' renders in the panel."""
+    _seed_ddr_schema(db_session)
+    _dram_with_facet(db_session, "cov-a")
+    _op_card(db_session, "cov-b", category="dram")  # no facet rows
+    db_session.commit()
+
+    resp = client.get("/v2/partials/materials/filters/sub?commodity=dram")
+    assert resp.status_code == 200
+    assert "1 of 2 parts in" in resp.text
+    assert "have filterable specs" in resp.text
+
+
+def test_faceted_empty_state_coverage_nudge(client, db_session: Session):
+    """Parametric zero-result + partial coverage → the 'not yet spec-enriched' copy."""
+    import json
+
+    _seed_ddr_schema(db_session)
+    _dram_with_facet(db_session, "nudge-a")  # DDR4 — filtered out below
+    _op_card(db_session, "nudge-b", category="dram")  # not spec-enriched
+    db_session.commit()
+
+    filters_json = json.dumps({"ddr_type": ["DDR5"]})
+    resp = client.get(f"/v2/partials/materials/faceted?commodity=dram&sub_filters={filters_json}")
+    assert resp.status_code == 200
+    assert (
+        "No matches &mdash; but most parts here haven&#39;t been spec-enriched yet." in resp.text
+        or "No matches — but most parts here haven't been spec-enriched yet." in resp.text
+    )
+    assert "Try clearing parametric filters." in resp.text
+
+
+def test_faceted_empty_state_generic_when_coverage_full(client, db_session: Session):
+    """Full coverage (every card has facets) → the generic empty state, not the
+    nudge."""
+    import json
+
+    _seed_ddr_schema(db_session)
+    _dram_with_facet(db_session, "full-a")
+    db_session.commit()
+
+    filters_json = json.dumps({"ddr_type": ["DDR5"]})
+    resp = client.get(f"/v2/partials/materials/faceted?commodity=dram&sub_filters={filters_json}")
+    assert resp.status_code == 200
+    assert "No results match your filters" in resp.text
+    assert "spec-enriched" not in resp.text
+
+
+def test_faceted_empty_state_generic_without_parametric_filters(client, db_session: Session):
+    """Zero results WITHOUT parametric filters → generic empty state (no nudge)."""
+    resp = client.get("/v2/partials/materials/faceted?commodity=dram")
+    assert resp.status_code == 200
+    assert "No results match your filters" in resp.text
+    assert "spec-enriched" not in resp.text
+
+
+# --- Material-card (result row) upgrades ---
+
+
+def test_faceted_row_datasheet_and_condition_badges(client, db_session: Session):
+    _op_card(
+        db_session,
+        "row-rich",
+        datasheet_url="https://example.com/ds.pdf",
+        condition="New",
+        cross_references=[{"mpn": "ALT-1"}, {"mpn": "ALT-2"}],
+    )
+    _op_card(db_session, "row-bare", cross_references=[])
+    db_session.commit()
+
+    resp = client.get("/v2/partials/materials/faceted")
+    assert resp.status_code == 200
+    # Datasheet indicator: new-tab link with noopener.
+    assert 'href="https://example.com/ds.pdf" target="_blank" rel="noopener"' in resp.text
+    assert "Open datasheet" in resp.text
+    # Crosses badge with count.
+    assert "2 alternates" in resp.text
+    # Condition badge styled like the lifecycle palette.
+    assert ">NEW<" in resp.text.replace("\n", "").replace("  ", "")
+    # Bare card renders without the datasheet indicator leaking onto it.
+    assert resp.text.count('title="Open datasheet"') == 1
+
+
+def test_faceted_row_crosses_badge_singular(client, db_session: Session):
+    _op_card(db_session, "row-one-alt", cross_references=[{"mpn": "ALT-1"}])
+    db_session.commit()
+    resp = client.get("/v2/partials/materials/faceted")
+    assert "1 alternate" in resp.text
+    assert "1 alternates" not in resp.text
+
+
+def test_faceted_spec_chips_without_commodity_use_schema_primaries(client, db_session: Session):
+    """No-commodity rows chip their own category's is_primary specs as 'label:
+
+    value'.
+    """
+    db_session.add(
+        CommoditySpecSchema(
+            commodity="dram",
+            spec_key="capacity_gb",
+            display_name="Capacity (GB)",
+            data_type="numeric",
+            sort_order=1,
+            is_filterable=True,
+            is_primary=True,
+        )
+    )
+    _op_card(db_session, "chip-known", category="dram", specs_structured={"capacity_gb": {"value": 32}})
+    db_session.commit()
+
+    resp = client.get("/v2/partials/materials/faceted")
+    assert resp.status_code == 200
+    assert "Capacity (GB): 32" in resp.text
+
+
+def test_faceted_spec_chips_without_commodity_fallback_first_scalars(client, db_session: Session):
+    """Cards in a schema-less category fall back to the first 3 scalar spec entries."""
+    _op_card(
+        db_session,
+        "chip-fallback",
+        category="widgets",
+        specs_structured={
+            "speed_mhz": {"value": 3200},
+            "rank": "2R",
+            "nested_junk": {"value": {"a": 1}},  # non-scalar — skipped
+            "voltage": 1.2,
+            "fourth_key": "chip4-overflow-value",  # 4th scalar — beyond the 3-chip cap
+        },
+    )
+    db_session.commit()
+
+    resp = client.get("/v2/partials/materials/faceted")
+    assert resp.status_code == 200
+    assert "speed mhz: 3200" in resp.text
+    assert "rank: 2R" in resp.text
+    assert "voltage: 1.2" in resp.text
+    assert "nested junk:" not in resp.text
+    assert "chip4-overflow-value" not in resp.text
+
+
+def test_faceted_spec_chips_in_commodity_context_unchanged(client, db_session: Session):
+    """With a commodity selected, chips stay value-only (no 'label:' prefix)."""
+    db_session.add(
+        CommoditySpecSchema(
+            commodity="dram",
+            spec_key="capacity_gb",
+            display_name="Capacity (GB)",
+            data_type="numeric",
+            sort_order=1,
+            is_filterable=True,
+            is_primary=True,
+        )
+    )
+    _op_card(db_session, "chip-ctx", category="dram", specs_structured={"capacity_gb": {"value": 64}})
+    db_session.commit()
+
+    resp = client.get("/v2/partials/materials/faceted?commodity=dram")
+    assert resp.status_code == 200
+    assert ">64<" in resp.text.replace("\n", "").replace(" ", "")
+    assert "Capacity (GB): 64" not in resp.text

--- a/tests/test_faceted_routes.py
+++ b/tests/test_faceted_routes.py
@@ -564,7 +564,7 @@ def test_faceted_searched_within_param(client, db_session: Session):
 
 
 def test_faceted_bogus_operational_params_degrade(client, db_session: Session):
-    """Unknown enum values on hand-edited URLs degrade to no-ops, never 500."""
+    """Unknown/invalid values on hand-edited URLs degrade to no-ops, never 500/422."""
     _op_card(db_session, "deg-1", is_internal_part=True)
     _op_card(db_session, "deg-2", is_internal_part=False)
     db_session.commit()
@@ -572,6 +572,13 @@ def test_faceted_bogus_operational_params_degrade(client, db_session: Session):
     resp = client.get("/v2/partials/materials/faceted?internal=bogus&searched_within=yesterday")
     assert resp.status_code == 200
     assert "DEG-1" in resp.text and "DEG-2" in resp.text
+
+    # min_searches follows the same contract: non-numeric and negative values degrade
+    # to the 0 no-op (NOT a FastAPI 422, which htmx would silently refuse to swap).
+    for bad in ("-1", "abc"):
+        resp = client.get(f"/v2/partials/materials/faceted?min_searches={bad}")
+        assert resp.status_code == 200
+        assert "DEG-1" in resp.text and "DEG-2" in resp.text
 
 
 def test_workspace_renders_sourcing_signals_section(client):
@@ -675,6 +682,21 @@ def test_faceted_empty_state_generic_without_parametric_filters(client, db_sessi
     assert "spec-enriched" not in resp.text
 
 
+def test_faceted_empty_state_generic_when_commodity_has_no_cards(client, db_session: Session):
+    """Parametric filters on a commodity with ZERO cards (coverage 0/0) → generic empty
+    state; the nonsensical 'Only 0 of 0 parts' nudge must never render."""
+    import json
+
+    _seed_ddr_schema(db_session)  # schema exists, but no dram cards are seeded
+    db_session.commit()
+
+    filters_json = json.dumps({"ddr_type": ["DDR5"]})
+    resp = client.get(f"/v2/partials/materials/faceted?commodity=dram&sub_filters={filters_json}")
+    assert resp.status_code == 200
+    assert "No results match your filters" in resp.text
+    assert "spec-enriched" not in resp.text
+
+
 # --- Material-card (result row) upgrades ---
 
 
@@ -773,9 +795,15 @@ def test_faceted_spec_chips_in_commodity_context_unchanged(client, db_session: S
         )
     )
     _op_card(db_session, "chip-ctx", category="dram", specs_structured={"capacity_gb": {"value": 64}})
+    # Raw-scalar primary spec (no {"value": ...} wrapper) — the pre-_spec_scalar code
+    # raised AttributeError (HTTP 500) on this shape in commodity context; it must now
+    # render the chip gracefully.
+    _op_card(db_session, "chip-ctx-raw", category="dram", specs_structured={"capacity_gb": 32})
     db_session.commit()
 
     resp = client.get("/v2/partials/materials/faceted?commodity=dram")
     assert resp.status_code == 200
-    assert ">64<" in resp.text.replace("\n", "").replace(" ", "")
+    compact = resp.text.replace("\n", "").replace(" ", "")
+    assert ">64<" in compact
+    assert ">32<" in compact
     assert "Capacity (GB): 64" not in resp.text

--- a/tests/test_faceted_search_service.py
+++ b/tests/test_faceted_search_service.py
@@ -475,3 +475,213 @@ def test_boolean_subfilter_always_exposes_yes_no(db_session):
     db_session.commit()
     opts2 = {o["spec_key"]: o for o in get_subfilter_options(db_session, "microcontrollers")}
     assert opts2["has_usb"]["values"] == ["true", "false"]
+
+
+# --- Operational (Layer-3) sourcing filters ---
+
+
+def _mk_op(
+    db,
+    mpn,
+    *,
+    crosses="unset",
+    internal=None,
+    last_searched=None,
+    searches=0,
+    vendor_price="none",
+):
+    """Card with operational fields.
+
+    crosses: 'unset' keeps the column default ([]).
+    vendor_price: 'none' = no vendor rows, None = row without price, number = row with price.
+    """
+    card = MaterialCard(
+        normalized_mpn=mpn,
+        display_mpn=mpn.upper(),
+        category="resistors",
+        is_internal_part=internal,
+        last_searched_at=last_searched,
+        search_count=searches,
+        created_at=datetime.now(timezone.utc),
+    )
+    if crosses != "unset":
+        card.cross_references = crosses
+    db.add(card)
+    db.flush()
+    if vendor_price != "none":
+        from app.models import MaterialVendorHistory
+
+        db.add(MaterialVendorHistory(material_card_id=card.id, vendor_name="V1", last_price=vendor_price))
+        db.flush()
+    return card
+
+
+def test_search_faceted_has_stock_filter(db_session: Session):
+    _mk_op(db_session, "stock-yes", vendor_price=None)  # row exists, price unknown
+    _mk_op(db_session, "stock-no")
+
+    results, total = search_materials_faceted(db_session, has_stock=True)
+    assert {c.normalized_mpn for c in results} == {"stock-yes"}
+    assert total == 1
+
+    _, total_all = search_materials_faceted(db_session, has_stock=False)
+    assert total_all == 2  # False is a no-op
+
+
+def test_search_faceted_has_price_filter(db_session: Session):
+    _mk_op(db_session, "price-yes", vendor_price=1.25)
+    _mk_op(db_session, "price-null", vendor_price=None)  # sighting without a price
+    _mk_op(db_session, "price-none")  # no vendor rows at all
+
+    results, total = search_materials_faceted(db_session, has_price=True)
+    assert {c.normalized_mpn for c in results} == {"price-yes"}
+    assert total == 1
+
+    # has_stock is the looser predicate: any vendor row counts.
+    _, total_stock = search_materials_faceted(db_session, has_stock=True)
+    assert total_stock == 2
+
+
+def test_search_faceted_has_crosses_filter_portable(db_session: Session):
+    """has_crosses must hold on rows with SQL NULL, JSON null, [] and a real list.
+
+    The predicate is text-cast based so it behaves identically on PostgreSQL JSONB and
+    SQLite JSON-as-text (see feedback_sqlite_masks_postgres).
+    """
+    _mk_op(db_session, "x-null", crosses=None)  # JSON null / SQL NULL
+    _mk_op(db_session, "x-empty", crosses=[])  # empty list
+    _mk_op(db_session, "x-default")  # column default (list)
+    _mk_op(db_session, "x-real", crosses=[{"mpn": "ALT-1", "manufacturer": "TI"}])
+
+    results, total = search_materials_faceted(db_session, has_crosses=True)
+    assert {c.normalized_mpn for c in results} == {"x-real"}
+    assert total == 1
+
+    _, total_all = search_materials_faceted(db_session, has_crosses=False)
+    assert total_all == 4  # False is a no-op
+
+
+def test_search_faceted_internal_tristate(db_session: Session):
+    _mk_op(db_session, "int-true", internal=True)
+    _mk_op(db_session, "int-false", internal=False)
+    _mk_op(db_session, "int-null", internal=None)  # legacy rows: NULL counts as standard
+
+    _, total_all = search_materials_faceted(db_session, internal="all")
+    assert total_all == 3
+
+    results, total = search_materials_faceted(db_session, internal="standard")
+    assert {c.normalized_mpn for c in results} == {"int-false", "int-null"}
+    assert total == 2
+
+    results, total = search_materials_faceted(db_session, internal="internal")
+    assert {c.normalized_mpn for c in results} == {"int-true"}
+    assert total == 1
+
+    # Unknown value degrades to the "all" no-op (hand-edited URLs).
+    _, total_bogus = search_materials_faceted(db_session, internal="bogus")
+    assert total_bogus == 3
+
+
+def test_search_faceted_searched_within_buckets(db_session: Session):
+    from datetime import timedelta
+
+    now = datetime.now(timezone.utc)
+    _mk_op(db_session, "sw-1d", last_searched=now - timedelta(days=1))
+    _mk_op(db_session, "sw-10d", last_searched=now - timedelta(days=10))
+    _mk_op(db_session, "sw-45d", last_searched=now - timedelta(days=45))
+    _mk_op(db_session, "sw-120d", last_searched=now - timedelta(days=120))
+    _mk_op(db_session, "sw-never", last_searched=None)
+
+    cases = {
+        "7d": {"sw-1d"},
+        "30d": {"sw-1d", "sw-10d"},
+        "90d": {"sw-1d", "sw-10d", "sw-45d"},
+    }
+    for bucket, expected in cases.items():
+        results, total = search_materials_faceted(db_session, searched_within=bucket)
+        assert {c.normalized_mpn for c in results} == expected, bucket
+        assert total == len(expected), bucket
+
+    # "any" and unknown values are no-ops — never-searched rows included.
+    for bucket in ("any", "bogus"):
+        _, total_all = search_materials_faceted(db_session, searched_within=bucket)
+        assert total_all == 5, bucket
+
+
+def test_search_faceted_min_searches(db_session: Session):
+    _mk_op(db_session, "ms-0", searches=0)
+    _mk_op(db_session, "ms-3", searches=3)
+    _mk_op(db_session, "ms-9", searches=9)
+
+    results, total = search_materials_faceted(db_session, min_searches=3)
+    assert {c.normalized_mpn for c in results} == {"ms-3", "ms-9"}  # boundary inclusive
+    assert total == 2
+
+    _, total_all = search_materials_faceted(db_session, min_searches=0)
+    assert total_all == 3  # 0 is a no-op
+
+
+def test_search_faceted_operational_filters_combine(db_session: Session):
+    """Operational filters AND together and with global facets."""
+    keep = _mk_op(
+        db_session,
+        "combo-keep",
+        crosses=[{"mpn": "ALT-9"}],
+        internal=False,
+        searches=5,
+        vendor_price=2.0,
+    )
+    keep.lifecycle_status = "active"
+    drop = _mk_op(db_session, "combo-drop", crosses=[{"mpn": "ALT-8"}], internal=True, searches=5, vendor_price=2.0)
+    drop.lifecycle_status = "active"
+    db_session.flush()
+
+    results, total = search_materials_faceted(
+        db_session,
+        lifecycle=["active"],
+        has_stock=True,
+        has_price=True,
+        has_crosses=True,
+        internal="standard",
+        min_searches=5,
+    )
+    assert {c.normalized_mpn for c in results} == {"combo-keep"}
+    assert total == 1
+
+
+# --- Commodity spec coverage ---
+
+
+def test_get_commodity_spec_coverage(db_session: Session):
+    from app.services.faceted_search_service import get_commodity_spec_coverage
+
+    _seed_dram_schema(db_session)
+    _make_dram_card(db_session, "COV-001", "DDR4", 16)  # has facet rows
+    no_specs = MaterialCard(
+        normalized_mpn="cov-002",
+        display_mpn="COV-002",
+        category="DRAM",
+        created_at=datetime.now(timezone.utc),
+    )
+    deleted = MaterialCard(
+        normalized_mpn="cov-003",
+        display_mpn="COV-003",
+        category="DRAM",
+        deleted_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+    )
+    other_cat = MaterialCard(
+        normalized_mpn="cov-004",
+        display_mpn="COV-004",
+        category="Capacitors",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add_all([no_specs, deleted, other_cat])
+    db_session.flush()
+
+    coverage = get_commodity_spec_coverage(db_session, "dram")
+    assert coverage == {"with_specs": 1, "total": 2}  # deleted + other-category excluded
+
+    # Case-insensitive commodity key, and an unknown commodity yields zeros.
+    assert get_commodity_spec_coverage(db_session, "  DRAM ") == {"with_specs": 1, "total": 2}
+    assert get_commodity_spec_coverage(db_session, "nonexistent_xyz") == {"with_specs": 0, "total": 0}

--- a/tests/test_faceted_search_service.py
+++ b/tests/test_faceted_search_service.py
@@ -548,7 +548,13 @@ def test_search_faceted_has_crosses_filter_portable(db_session: Session):
     The predicate is text-cast based so it behaves identically on PostgreSQL JSONB and
     SQLite JSON-as-text (see feedback_sqlite_masks_postgres).
     """
-    _mk_op(db_session, "x-null", crosses=None)  # JSON null / SQL NULL
+    from sqlalchemy import null
+
+    # Python None persists as the JSON 'null' encoding (JSON.none_as_null is False);
+    # a true SQL NULL needs the explicit null() expression. Both shapes are seeded so
+    # both halves of the predicate (isnot(None) + the text-cast notin_) are exercised.
+    _mk_op(db_session, "x-json-null", crosses=None)  # JSON null
+    _mk_op(db_session, "x-sql-null", crosses=null())  # SQL NULL
     _mk_op(db_session, "x-empty", crosses=[])  # empty list
     _mk_op(db_session, "x-default")  # column default (list)
     _mk_op(db_session, "x-real", crosses=[{"mpn": "ALT-1", "manufacturer": "TI"}])
@@ -558,7 +564,7 @@ def test_search_faceted_has_crosses_filter_portable(db_session: Session):
     assert total == 1
 
     _, total_all = search_materials_faceted(db_session, has_crosses=False)
-    assert total_all == 4  # False is a no-op
+    assert total_all == 5  # False is a no-op
 
 
 def test_search_faceted_internal_tristate(db_session: Session):
@@ -653,7 +659,7 @@ def test_search_faceted_operational_filters_combine(db_session: Session):
 
 
 def test_get_commodity_spec_coverage(db_session: Session):
-    from app.services.faceted_search_service import get_commodity_spec_coverage
+    from app.services.faceted_search_service import SpecCoverage, get_commodity_spec_coverage
 
     _seed_dram_schema(db_session)
     _make_dram_card(db_session, "COV-001", "DDR4", 16)  # has facet rows
@@ -680,8 +686,8 @@ def test_get_commodity_spec_coverage(db_session: Session):
     db_session.flush()
 
     coverage = get_commodity_spec_coverage(db_session, "dram")
-    assert coverage == {"with_specs": 1, "total": 2}  # deleted + other-category excluded
+    assert coverage == SpecCoverage(with_specs=1, total=2)  # deleted + other-category excluded
 
     # Case-insensitive commodity key, and an unknown commodity yields zeros.
-    assert get_commodity_spec_coverage(db_session, "  DRAM ") == {"with_specs": 1, "total": 2}
-    assert get_commodity_spec_coverage(db_session, "nonexistent_xyz") == {"with_specs": 0, "total": 0}
+    assert get_commodity_spec_coverage(db_session, "  DRAM ") == SpecCoverage(with_specs=1, total=2)
+    assert get_commodity_spec_coverage(db_session, "nonexistent_xyz") == SpecCoverage(with_specs=0, total=0)


### PR DESCRIPTION
PR C of the materials filter-tree program — implements the Layer-3 operational filters, coverage-aware empty states and material-card upgrades from `docs/MATERIALS_FILTER_TREE_SPEC_MATRIX.md` that PRs #228/#234 did not build. No migration: every backing column already exists.

## Blueprint mapping — matrix item → what shipped

| Matrix item | What shipped |
|---|---|
| L3 · Availability / Stock | `has_stock` (EXISTS `MaterialVendorHistory` row) + `has_price` (EXISTS row with `last_price IS NOT NULL`) toggles — promoted from display-only vendor stats to filterable predicates, honest "stock seen / price recorded" framing per the matrix. |
| L3 · Has Cross-References / Substitutes | `has_crosses` toggle. Portable non-empty-JSON-list predicate (`IS NOT NULL` + text-cast `NOT IN ('[]','null','')`) so PG JSONB and SQLite JSON-as-text behave identically — tested on NULL / JSON-null / `[]` / populated rows. |
| L3 · Internal Part vs Standard MPN | `internal` tri-state segmented control: All / Standard MPNs / Internal parts (`standard` = `is_internal_part` FALSE **or NULL** for legacy rows). |
| L3 · Recently Sourced / Searched | `searched_within` chips 7d / 30d / 90d / Any on `last_searched_at` (re-click resets to Any). |
| L3 · Demand (search count) | `min_searches` numeric input (0 = off, boundary-inclusive) on `search_count`. |
| UI · Coverage banner per commodity | `get_commodity_spec_coverage()` (two cheap aggregates, no N+1) → "N of M parts in <commodity> have filterable specs" line in the sub-filters panel. |
| UI · "not yet spec-enriched" nudge | Zero results + active parametric `sub_filters` + coverage N<M → "No matches — but most parts here haven't been spec-enriched yet. Try clearing parametric filters." Generic empty state otherwise (incl. full-coverage commodities). |
| UI · Primary-spec chips | Now also render WITHOUT a commodity: each card's own category's `is_primary` schema keys (one batched query), else first 3 scalar `specs_structured` entries — server-side, formatted "label: value". Commodity context unchanged (value-only). |
| Card · datasheet indicator | Icon-link when `datasheet_url` set — new tab, `rel=noopener`. |
| Card · crosses badge | "N alternates" (singular-aware) when `cross_references` non-empty. |
| Card · condition badge | Renders next to lifecycle, same pill palette (New/Recertified/Refurbished/Used/Pulled/Unknown). |

All new params flow router → Alpine `materialsFilter` state → `syncFromURL`/`pushURL`/`applyFilters` → `hx-vals` (object literal) → results container, exactly like the existing global facets. Unknown enum values on hand-edited URLs degrade to the no-op default (never 500).

## Deviation from the matrix

**`internal` defaults to `all`, not `standard`.** The matrix recommends default = "Standard MPNs only", but silently dropping internal-part rows on first page load is worse than showing everything — the user gets a tri-state control plus a removable chip instead of invisible filtering.

## Deferred (with reasons)

- `jsonb_array_length` expression index for `has_crosses` (matrix: "if this filter is hot") — needs an Alembic migration; out of scope for this no-migration PR.
- "Hot (top decile)" demand chip — needs a percentile aggregate; min-searches input covers the buyer narrowing need.
- Multi-select OR recency buckets incl. "Older" — shipped single-select cutoff chips (7d/30d/90d/Any), the simpler idiom matching the matrix's `>= now()-interval` implementation note.

## Drive-by fix

`search_materials_faceted()` had a local `from sqlalchemy import or_` inside the FTS branch; with the new module-level import it shadowed the name and the non-FTS path raised `UnboundLocalError`. Removed the local import (caught by the new tri-state test).

## Tests

- Full Python suite: **14,750 passed**, 34 skipped, 1 xfailed (`TESTING=1 pytest tests/ -q`).
- 22 new Python tests: every filter incl. has_crosses portability (NULL / JSON-null / `[]` / populated), recency boundaries (1/10/45/120d/never), internal tri-state incl. NULL-as-standard, min-searches boundary, filter combination, coverage helper (deleted/other-category exclusion, case-insensitivity), route params, degrade-to-no-op, coverage line, both empty-state branches, chips/badges.
- Frontend: **90 vitest passed** (10 new for the sourcing-signal Alpine state); `npm run build` green (bundle smoke test incl.).
- `pre-commit run --all-files` clean (ruff, ruff-format, docformatter, mypy).

## Tailwind

No new classes: every utility used (incl. `bg-indigo-50/text-indigo-700/border-indigo-200` for the crosses badge) already appears in template content scanned by `tailwind.config.js` and is present in the built `app/static/dist` CSS — verified after `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
