### PR TITLE
feat(materials layout): rail fold reorder, confidence default-open, badge palette unification, no-commodity placeholder

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -7185,7 +7185,11 @@ async def materials_filters_sub_partial(
 ):
     """Render sub-filters for a selected commodity with live facet counts."""
     if not commodity.strip():
-        return HTMLResponse("")
+        # No commodity scope — render the placeholder nudge (skip the facet/coverage
+        # service calls; subfilters.html handles the commodity_selected=False branch).
+        ctx = _base_ctx(request, user, "materials")
+        ctx["commodity_selected"] = False
+        return template_response("htmx/partials/materials/filters/subfilters.html", ctx)
 
     # Parse active filters so facet counts reflect current selection
     parsed_filters = _parse_filter_json(sub_filters)

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -603,7 +603,9 @@ Alpine.data('materialsFilter', () => ({
   recentCommodities: persistOr([], 'mat_recent_commodities'),
   moreAttrsOpen: persistOr(false, 'mat_more_attrs_open'),
   sourcingOpen: persistOr(false, 'mat_sourcing_open'),
-  confidenceOpen: persistOr(false, 'mat_confidence_open'),
+  // Confidence fold (first filter fold) opens by default — trust is the headline
+  // filter; the heavy folds (sourcing / more attributes) stay closed until opened.
+  confidenceOpen: persistOr(true, 'mat_confidence_open'),
 
   // 3 user-facing confidence groups, each expanding to a set of enrichment tiers.
   // Array order pins the visual ordering of the Data-confidence section.

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -566,6 +566,13 @@ document.addEventListener('keydown', (e) => {
 // otherwise (vitest mocks / plugin absent) — never throws at factory-call time.
 const persistOr = (def, key) => (typeof Alpine !== 'undefined' && Alpine.$persist) ? Alpine.$persist(def).as(key) : def;
 
+// One-time storage migration: the confidence fold default flipped false→true, but
+// @alpinejs/persist writes the CURRENT value to storage on init — so every browser that
+// ever loaded the page under the old `persistOr(false, 'mat_confidence_open')` carries a
+// persisted `false` that would override the new default. The fold state moved to
+// 'mat_confidence_open2'; drop the dead key so a revert can't resurrect it.
+if (typeof localStorage !== 'undefined') localStorage.removeItem('mat_confidence_open');
+
 Alpine.data('materialsFilter', () => ({
   commodity: '',
   subFilters: {},
@@ -605,7 +612,9 @@ Alpine.data('materialsFilter', () => ({
   sourcingOpen: persistOr(false, 'mat_sourcing_open'),
   // Confidence fold (first filter fold) opens by default — trust is the headline
   // filter; the heavy folds (sourcing / more attributes) stay closed until opened.
-  confidenceOpen: persistOr(true, 'mat_confidence_open'),
+  // Key is the rotated 'mat_confidence_open2' so the new open default actually reaches
+  // returning users (see the legacy-key removal above persistOr's call sites).
+  confidenceOpen: persistOr(true, 'mat_confidence_open2'),
 
   // 3 user-facing confidence groups, each expanding to a set of enrichment tiers.
   // Array order pins the visual ordering of the Data-confidence section.

--- a/app/templates/htmx/partials/materials/filters/subfilters.html
+++ b/app/templates/htmx/partials/materials/filters/subfilters.html
@@ -1,7 +1,8 @@
 {# Dynamic sub-filters for a specific commodity.
    Called by: HTMX request when commodity or filters change
-   Depends on: subfilter_options, facet_counts, spec_coverage, commodity_display
-               from route context
+   Depends on: commodity_selected (always set by the route), plus subfilter_options,
+               facet_counts, spec_coverage, commodity_display when a commodity is
+               selected. With no commodity it renders only the placeholder nudge.
 #}
 {% from "htmx/partials/materials/filters/_macros.html" import render_subfilter %}
 
@@ -16,7 +17,11 @@
   {% endif %}
 {% endmacro %}
 
-{% if subfilter_options %}
+{% if not commodity_selected %}
+{# No commodity scope yet — nudge toward the category tree (spec filters are
+   commodity-scoped, so there is nothing to render until one is picked). #}
+<p class="text-[11px] text-gray-400 italic px-2 mt-2">Select a category to unlock spec filters</p>
+{% elif subfilter_options %}
 <div class="border-t border-gray-100 pt-3 mt-3">
   <div class="flex items-center justify-between mb-2">
     <h3 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest">Filters</h3>
@@ -47,7 +52,7 @@
   </div>
   {% endif %}
 </div>
-{% elif commodity_selected %}
+{% else %}
 <div class="border-t border-gray-100 pt-3 mt-3">
   {{ coverage_line() }}
   <p class="text-xs text-gray-400 italic">No filters available for this category</p>

--- a/app/templates/htmx/partials/materials/list.html
+++ b/app/templates/htmx/partials/materials/list.html
@@ -23,12 +23,14 @@
     'nrfnd': 'bg-gray-100 text-gray-600 border-gray-200',
     'ltb': 'bg-amber-50 text-amber-600 border-amber-200',
   } %}
-  {# Stock-condition badge palette — same shape as the lifecycle badges. #}
+  {# Stock-condition badge palette — same shape as the lifecycle badges.
+     Refurbished/Used share violet (second-life stock family) so amber stays
+     exclusively "caution / reconfirm" (lifecycle EOL/LTB, AI-guess). #}
   {% set cond_colors = {
     'New': 'bg-emerald-50 text-emerald-700 border-emerald-200',
     'Recertified': 'bg-sky-50 text-sky-700 border-sky-200',
-    'Refurbished': 'bg-amber-50 text-amber-700 border-amber-200',
-    'Used': 'bg-amber-50 text-amber-600 border-amber-200',
+    'Refurbished': 'bg-violet-50 text-violet-700 border-violet-200',
+    'Used': 'bg-violet-50 text-violet-700 border-violet-200',
     'Pulled': 'bg-rose-50 text-rose-700 border-rose-200',
     'Unknown': 'bg-gray-100 text-gray-600 border-gray-200',
   } %}
@@ -69,7 +71,9 @@
               </a>
               {% endif %}
               {% if m.cross_references %}
-              <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full border bg-indigo-50 text-indigo-700 border-indigo-200"
+              {# Neutral gray — count metadata, not a status; indigo means exactly
+                 "OEM-official" (the OEM-SOURCED badge below). #}
+              <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full border bg-gray-100 text-gray-600 border-gray-200"
                     title="Known cross-references / substitutes">
                 {{ m.cross_references|length }} alternate{{ '' if m.cross_references|length == 1 else 's' }}
               </span>
@@ -78,7 +82,10 @@
             {% if m._primary_specs %}
             <div class="flex flex-wrap gap-1 mt-0.5">
               {% for spec in m._primary_specs[:3] %}
-              <span class="inline-block px-1.5 py-0.5 bg-gray-50 text-[10px] text-gray-500 rounded font-data">
+              {# title keeps the label visible on hover when the commodity-scoped
+                 rendering shows the value only. #}
+              <span class="inline-block px-1.5 py-0.5 bg-gray-50 text-[10px] text-gray-500 rounded font-data"
+                    title="{{ spec.label }}: {{ spec.value }}">
                 {%- if not commodity and spec.label %}{{ spec.label }}: {% endif %}{{ spec.value }}
               </span>
               {% endfor %}

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -15,7 +15,9 @@
        aria-hidden="true"
        class="fixed inset-0 bg-gray-900/40 z-40 lg:hidden"></div>
 
-  {# -- Sidebar (desktop: static, mobile: slide-over drawer) -- #}
+  {# -- Sidebar (desktop: static, mobile: slide-over drawer) --
+     Mobile drawer offsets top-[52px] bottom-[48px] assume a 52px app header + 48px
+     bottom nav — update them if the app chrome changes. #}
   <div :class="drawerOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'"
        x-trap.noscroll="drawerOpen"
        @keydown.escape.window="drawerOpen = false"
@@ -102,33 +104,30 @@
            hx-sync="this:replace">
       </div>
 
-      {# ── More attributes (manufacturer + lifecycle/RoHS/condition/datasheet) ──
-         Collapsed by default; demoted below the commodity facets. Containers still load
-         while hidden (hx-trigger="load") so counts are ready when expanded. #}
+      {# ── Data confidence (3 groups, first filter fold, EXPANDED by default) ──
+         Trust is the headline filter, so it sits directly under the commodity context
+         and opens by default. Collapse policy: navigation sections open, trust fold
+         open, heavy folds below closed. Each group checkbox toggles its member
+         enrichment tiers; the backend still receives a `statuses` CSV. #}
       <div class="border-t border-gray-100 pt-3 mt-3">
-        {{ disclosure_header('moreAttrsOpen', 'more-attrs-panel', 'More attributes', 'attributesActiveCount > 0', 'attributesActiveCount') }}
-        <div id="more-attrs-panel" role="region" aria-label="More attributes" x-show="moreAttrsOpen" x-collapse x-cloak class="mt-2">
-          {# Manufacturer #}
-          <div id="manufacturer-filter-container"
-               hx-get="/v2/partials/materials/filters/manufacturers"
-               hx-target="this"
-               hx-trigger="load, commodity-changed from:body"
-               hx-indicator="#mfr-filter-spinner"
-               hx-vals='js:{"commodity": Alpine.evaluate(document.querySelector("#materials-workspace"), "commodity") || ""}'
-               hx-swap="innerHTML">
-          </div>
-          {# Global facets — lifecycle / RoHS / condition / has-datasheet #}
-          <div id="global-filter-container"
-               hx-get="/v2/partials/materials/filters/global"
-               hx-target="this"
-               hx-trigger="load, commodity-changed from:body"
-               hx-vals='js:{"commodity": Alpine.evaluate(document.querySelector("#materials-workspace"), "commodity") || ""}'
-               hx-swap="innerHTML">
-          </div>
+        {{ disclosure_header('confidenceOpen', 'confidence-panel', 'Data confidence', 'confidenceNarrowed', 'activeConfidenceGroups.length') }}
+        <div id="confidence-panel" role="region" aria-label="Data confidence" x-show="confidenceOpen" x-collapse x-cloak class="space-y-0.5 mt-2">
+          <template x-for="group in CONFIDENCE_GROUPS" :key="group.key">
+            <label class="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-50 cursor-pointer text-sm">
+              <input type="checkbox"
+                     :checked="confidenceGroupChecked(group.key)"
+                     @change="toggleConfidenceGroup(group.key)"
+                     class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 h-3.5 w-3.5">
+              <span class="inline-block w-2 h-2 rounded-full flex-shrink-0" :class="group.dot"></span>
+              <span class="text-gray-700 truncate flex-1 text-[13px]" x-text="group.label"></span>
+            </label>
+          </template>
         </div>
       </div>
 
-      {# ── Sourcing signals (Layer-3 operational filters) ──────────────
+      {# ── Sourcing signals (Layer-3 operational filters, 2nd fold, collapsed) ──
+         Heavy fold (11 heterogeneous controls) — closed by default per the collapse
+         policy; the active-count badge + persistOr cover discoverability.
          Stock/price/crosses toggles, internal tri-state, recently-searched chips and
          min-searches — MaterialCard + vendor-history predicates, no per-value counts,
          so this section is static (no HTMX reload needed). #}
@@ -192,22 +191,30 @@
         </div>
       </div>
 
-      {# ── Data confidence (3 groups, collapsed, bottom) ───────────────
-         Lowest-priority filter. Each group checkbox toggles its member enrichment tiers;
-         the backend still receives a `statuses` CSV. #}
+      {# ── More attributes (manufacturer + lifecycle/RoHS/condition/datasheet) ──
+         Last fold, collapsed by default per the collapse policy (heavy folds closed).
+         Containers still load while hidden (hx-trigger="load") so counts are ready
+         when expanded. #}
       <div class="border-t border-gray-100 pt-3 mt-3">
-        {{ disclosure_header('confidenceOpen', 'confidence-panel', 'Data confidence', 'confidenceNarrowed', 'activeConfidenceGroups.length') }}
-        <div id="confidence-panel" role="region" aria-label="Data confidence" x-show="confidenceOpen" x-collapse x-cloak class="space-y-0.5 mt-2">
-          <template x-for="group in CONFIDENCE_GROUPS" :key="group.key">
-            <label class="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-50 cursor-pointer text-sm">
-              <input type="checkbox"
-                     :checked="confidenceGroupChecked(group.key)"
-                     @change="toggleConfidenceGroup(group.key)"
-                     class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 h-3.5 w-3.5">
-              <span class="inline-block w-2 h-2 rounded-full flex-shrink-0" :class="group.dot"></span>
-              <span class="text-gray-700 truncate flex-1 text-[13px]" x-text="group.label"></span>
-            </label>
-          </template>
+        {{ disclosure_header('moreAttrsOpen', 'more-attrs-panel', 'More attributes', 'attributesActiveCount > 0', 'attributesActiveCount') }}
+        <div id="more-attrs-panel" role="region" aria-label="More attributes" x-show="moreAttrsOpen" x-collapse x-cloak class="mt-2">
+          {# Manufacturer #}
+          <div id="manufacturer-filter-container"
+               hx-get="/v2/partials/materials/filters/manufacturers"
+               hx-target="this"
+               hx-trigger="load, commodity-changed from:body"
+               hx-indicator="#mfr-filter-spinner"
+               hx-vals='js:{"commodity": Alpine.evaluate(document.querySelector("#materials-workspace"), "commodity") || ""}'
+               hx-swap="innerHTML">
+          </div>
+          {# Global facets — lifecycle / RoHS / condition / has-datasheet #}
+          <div id="global-filter-container"
+               hx-get="/v2/partials/materials/filters/global"
+               hx-target="this"
+               hx-trigger="load, commodity-changed from:body"
+               hx-vals='js:{"commodity": Alpine.evaluate(document.querySelector("#materials-workspace"), "commodity") || ""}'
+               hx-swap="innerHTML">
+          </div>
         </div>
       </div>
 

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -16,8 +16,10 @@
        class="fixed inset-0 bg-gray-900/40 z-40 lg:hidden"></div>
 
   {# -- Sidebar (desktop: static, mobile: slide-over drawer) --
-     Mobile drawer offsets top-[52px] bottom-[48px] assume a 52px app header + 48px
-     bottom nav — update them if the app chrome changes. #}
+     Mobile drawer offsets top-[52px] bottom-[48px] clear the fixed chrome with ~4px
+     slack: the topbar is h-12 = 48px (shared/topbar.html) and the bottom nav computes
+     to ~44px + safe-area inset (shared/mobile_nav.html; #main-content clears it with
+     pb-[52px]) — update these offsets if either changes. #}
   <div :class="drawerOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'"
        x-trap.noscroll="drawerOpen"
        @keydown.escape.window="drawerOpen = false"

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -904,7 +904,11 @@ Sidebar facets (workspace.html + materialsFilter Alpine component) — COMMODITY
     |       filters" (subfilters.html commodity_selected=False branch; no service calls)
     |       instead of an empty response.
     +---> Data confidence (FIRST filter fold, EXPANDED by default — $persist
-    |     confidenceOpen defaults true): 3 groups — Trusted / AI-inferred / No data;
+    |     confidenceOpen defaults true under the ROTATED key mat_confidence_open2;
+    |     the legacy mat_confidence_open key held a persisted `false` for every
+    |     prior visitor — persist writes the current value on init — and is removed
+    |     on load so the new default reaches returning users): 3 groups —
+    |     Trusted / AI-inferred / No data;
     |     default all-on; `statuses[]` → `?statuses=` CSV → search_materials_faceted
     |     (IN-filters enrichment_status; precedence over the legacy verified_only).
     |     Collapse policy: navigation sections open, trust fold open, heavy folds

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -899,11 +899,17 @@ Sidebar facets (workspace.html + materialsFilter Alpine component) — COMMODITY
     |       Fold/typeahead state HOISTED to materialsFilter.ui.* so it survives the
     |       per-filters-changed HTMX reload. Counts via get_facet_counts() — which now
     |       SELF-EXCLUDES each actively-filtered facet (OR-within-facet; selecting one
-    |       value no longer collapses its siblings to 0).
-    +---> "More attributes" (collapsed, $persist moreAttrsOpen; active-count badge):
-    |       Manufacturer (search + top-N) + Global facets (lifecycle / rohs / condition /
-    |       has_datasheet) via get_global_facet_counts(). Containers load while hidden.
-    +---> "Sourcing signals" (collapsed, $persist sourcingOpen; active-count badge) —
+    |       value no longer collapses its siblings to 0). With NO commodity selected the
+    |       route renders the server-side placeholder "Select a category to unlock spec
+    |       filters" (subfilters.html commodity_selected=False branch; no service calls)
+    |       instead of an empty response.
+    +---> Data confidence (FIRST filter fold, EXPANDED by default — $persist
+    |     confidenceOpen defaults true): 3 groups — Trusted / AI-inferred / No data;
+    |     default all-on; `statuses[]` → `?statuses=` CSV → search_materials_faceted
+    |     (IN-filters enrichment_status; precedence over the legacy verified_only).
+    |     Collapse policy: navigation sections open, trust fold open, heavy folds
+    |     below closed.
+    +---> "Sourcing signals" (2nd fold, collapsed, $persist sourcingOpen; active-count badge) —
     |     Layer-3 operational filters, all top-level params on
     |     /v2/partials/materials/faceted → search_materials_faceted():
     |       has_stock   (EXISTS MaterialVendorHistory row)
@@ -922,10 +928,10 @@ Sidebar facets (workspace.html + materialsFilter Alpine component) — COMMODITY
     |     derived from the maps that drive the query branches); the JS twin is
     |     INTERNAL_MODES / SEARCH_BUCKETS on the materialsFilter component.
     |     Static section (no per-value counts → no HTMX reload).
-    +---> Data confidence (collapsed, bottom, $persist confidenceOpen): 3 groups —
-    |     Trusted / AI-inferred / No data; default all-on; `statuses[]` → `?statuses=` CSV
-    |     → search_materials_faceted (IN-filters enrichment_status; precedence over the
-    |     legacy verified_only).
+    +---> "More attributes" (LAST fold, collapsed, $persist moreAttrsOpen; active-count
+    |     badge): Manufacturer (search + top-N) + Global facets (lifecycle / rohs /
+    |     condition / has_datasheet) via get_global_facet_counts(). Containers load
+    |     while hidden.
     Live result count "<N> <Commodity> parts" renders at the top of the results pane
     (list.html) every filters-changed cycle, with an sr-only aria-live announcement.
     Mobile drawer: x-trap focus trap + Escape-to-close.
@@ -939,10 +945,14 @@ SpecCoverage(with_specs=N, total=M) NamedTuple; two cheap aggregates, no N+1):
 Result-row upgrades (list.html, server-side in materials_faceted_partial):
     +---> Spec chips also render WITHOUT a commodity: each card's own category's
     |     is_primary schema keys (one batched CommoditySpecSchema query), else the first
-    |     3 scalar specs_structured entries, formatted "label: value".
+    |     3 scalar specs_structured entries, formatted "label: value". Every chip carries
+    |     title="label: value" so the value-only commodity rendering keeps its label
+    |     on hover.
     +---> Datasheet icon-link (new tab, rel=noopener) when datasheet_url is set;
-    |     "N alternates" badge when cross_references is non-empty; condition badge
-    |     styled like the lifecycle palette.
+    |     "N alternates" chip when cross_references is non-empty (neutral gray — count
+    |     metadata, not a status; indigo is reserved for OEM-SOURCED); condition badge
+    |     styled like the lifecycle palette, with Refurbished/Used sharing violet
+    |     (second-life family) so amber stays exclusively caution/reconfirm.
 
 Search coverage:
     +---> global_search_service.py includes substitutes_text.ilike for

--- a/tests/frontend/materials-filter-fold-state.test.ts
+++ b/tests/frontend/materials-filter-fold-state.test.ts
@@ -1,0 +1,74 @@
+// tests/frontend/materials-filter-fold-state.test.ts — fold-state defaults on the
+// materialsFilter Alpine component: Data confidence (trust) opens by default, the heavy
+// folds (sourcing / more attributes) start closed, and the legacy 'mat_confidence_open'
+// localStorage key (which holds a persisted `false` for every pre-rotation visitor) is
+// removed at module load. Mirrors the mock harness in materials-filter-sourcing.test.ts.
+// Static twin: tests/test_static_analysis.py::test_materials_fold_state_defaults_pinned.
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+let registry: Record<string, any> = {}
+
+vi.mock('htmx.org', () => ({
+  default: {
+    on: vi.fn(), off: vi.fn(), ajax: vi.fn(), process: vi.fn(),
+    defineExtension: vi.fn(), createExtension: vi.fn(),
+    config: {},
+  },
+}))
+
+const alpineMock = {
+  data: (n: string, f: any) => { registry[n] = f },
+  store: vi.fn(),
+  plugin: vi.fn(),
+  start: vi.fn(),
+  directive: vi.fn(),
+  magic: vi.fn(),
+}
+
+vi.mock('alpinejs', () => ({ default: alpineMock }))
+vi.mock('@alpinejs/focus', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/persist', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/intersect', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/collapse', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/morph', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/mask', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/sort', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/anchor', () => ({ default: vi.fn() }))
+vi.mock('@alpinejs/resize', () => ({ default: vi.fn() }))
+vi.mock('htmx-ext-alpine-morph', () => ({}))
+vi.mock('htmx-ext-response-targets', () => ({}))
+vi.mock('htmx-ext-sse', () => ({}))
+vi.mock('htmx-ext-json-enc', () => ({}))
+vi.mock('htmx-ext-preload', () => ({}))
+vi.mock('htmx-ext-loading-states', () => ({}))
+vi.mock('htmx-ext-path-deps', () => ({}))
+vi.mock('htmx-ext-remove-me', () => ({}))
+
+beforeEach(() => {
+  registry = {}
+  alpineMock.data = (n: string, f: any) => { registry[n] = f }
+  vi.resetModules()
+  localStorage.clear()
+  history.replaceState({}, '', '/v2/materials')
+})
+
+describe('materialsFilter fold-state defaults (fresh browser, no persisted state)', () => {
+  it('opens the Data-confidence (trust) fold and keeps the heavy folds closed', async () => {
+    await import('../../app/static/htmx_app.js')
+    const c = registry['materialsFilter']()
+    // The headline change of the layout-polish spec: trust filter expanded by default.
+    expect(c.confidenceOpen).toBe(true)
+    // Collapse policy: the heavy folds stay closed until the user opens them.
+    expect(c.sourcingOpen).toBe(false)
+    expect(c.moreAttrsOpen).toBe(false)
+  })
+
+  it('removes the legacy mat_confidence_open key on load (key rotated to v2)', async () => {
+    // Every browser that loaded the page under the old `persistOr(false, ...)` default
+    // has `false` persisted — @alpinejs/persist writes the current value on init. The
+    // module-load migration must drop it so the key can never override the new default.
+    localStorage.setItem('mat_confidence_open', 'false')
+    await import('../../app/static/htmx_app.js')
+    expect(localStorage.getItem('mat_confidence_open')).toBeNull()
+  })
+})

--- a/tests/test_faceted_routes.py
+++ b/tests/test_faceted_routes.py
@@ -60,10 +60,23 @@ def test_subfilters_renders_for_commodity(client, db_session: Session):
     assert "DDR Type" in resp.text
 
 
-def test_subfilters_empty_for_no_commodity(client):
+def test_subfilters_placeholder_for_no_commodity(client):
+    # No commodity → server-rendered nudge toward the category tree (replaces the
+    # old empty-string response), with no spec-filter sections or coverage line.
     resp = client.get("/v2/partials/materials/filters/sub")
     assert resp.status_code == 200
-    assert resp.text == ""
+    assert "Select a category to unlock spec filters" in resp.text
+    assert 'class="text-[11px] text-gray-400 italic px-2 mt-2"' in resp.text
+    assert "clearSubFilters()" not in resp.text
+    assert "have filterable specs" not in resp.text
+    assert "No filters available for this category" not in resp.text
+
+
+def test_subfilters_no_placeholder_with_commodity(client):
+    # With a commodity scope the placeholder nudge must NOT render.
+    resp = client.get("/v2/partials/materials/filters/sub?commodity=dram")
+    assert resp.status_code == 200
+    assert "Select a category to unlock spec filters" not in resp.text
 
 
 def test_faceted_results_returns_materials(client, db_session: Session):
@@ -732,6 +745,49 @@ def test_faceted_row_crosses_badge_singular(client, db_session: Session):
     assert "1 alternates" not in resp.text
 
 
+def test_faceted_row_second_life_conditions_render_violet(client, db_session: Session):
+    # Refurbished/Used share the violet second-life family; amber stays exclusively
+    # caution/reconfirm (lifecycle EOL/LTB, AI guess).
+    _op_card(db_session, "row-refurb", condition="Refurbished")
+    _op_card(db_session, "row-used", condition="Used")
+    db_session.commit()
+    resp = client.get("/v2/partials/materials/faceted")
+    assert resp.status_code == 200
+    assert resp.text.count("bg-violet-50 text-violet-700 border-violet-200") == 2
+    assert "bg-amber-50" not in resp.text
+
+
+def test_faceted_row_crosses_chip_neutral_not_indigo(client, db_session: Session):
+    # The alternates chip is count metadata, not a status — neutral gray; indigo is
+    # reserved for the OEM-SOURCED badge.
+    _op_card(db_session, "row-cross-neutral", cross_references=[{"mpn": "ALT-1"}])
+    db_session.commit()
+    resp = client.get("/v2/partials/materials/faceted")
+    assert 'title="Known cross-references / substitutes"' in resp.text
+    assert "bg-gray-100 text-gray-600 border-gray-200" in resp.text
+    assert "bg-indigo-50" not in resp.text
+
+
+def test_faceted_spec_chip_title_keeps_label_in_commodity_context(client, db_session: Session):
+    # Commodity-scoped chips render value-only; the title keeps "Label: value" on hover.
+    db_session.add(
+        CommoditySpecSchema(
+            commodity="dram",
+            spec_key="capacity_gb",
+            display_name="Capacity (GB)",
+            data_type="numeric",
+            sort_order=1,
+            is_filterable=True,
+            is_primary=True,
+        )
+    )
+    _op_card(db_session, "chip-hover", category="dram", specs_structured={"capacity_gb": {"value": 32}})
+    db_session.commit()
+    resp = client.get("/v2/partials/materials/faceted?commodity=dram")
+    assert resp.status_code == 200
+    assert 'title="Capacity (GB): 32"' in resp.text
+
+
 def test_faceted_spec_chips_without_commodity_use_schema_primaries(client, db_session: Session):
     """No-commodity rows chip their own category's is_primary specs as 'label:
 
@@ -806,4 +862,7 @@ def test_faceted_spec_chips_in_commodity_context_unchanged(client, db_session: S
     compact = resp.text.replace("\n", "").replace(" ", "")
     assert ">64<" in compact
     assert ">32<" in compact
-    assert "Capacity (GB): 64" not in resp.text
+    # Value-only in the chip body (no "label:" prefix rendered)…
+    assert ">Capacity(GB):64<" not in compact
+    # …but the label survives on hover via the title attribute.
+    assert 'title="Capacity (GB): 64"' in resp.text

--- a/tests/test_filter_ux_layout.py
+++ b/tests/test_filter_ux_layout.py
@@ -12,7 +12,7 @@ def test_workspace_commodity_first_structure(client):
     # Type-to-find + recents wiring.
     assert 'x-model="categorySearch"' in t
     assert "recentCommodities" in t
-    # "More attributes" collapse wraps manufacturer + global; confidence collapses at bottom.
+    # "More attributes" collapse wraps manufacturer + global; confidence is the first fold.
     assert "moreAttrsOpen" in t
     assert "more-attrs-panel" in t
     assert "confidenceOpen" in t
@@ -20,8 +20,9 @@ def test_workspace_commodity_first_structure(client):
     # Drawer a11y.
     assert "x-trap" in t
 
-    # Commodity-first ORDER: Category section → commodity facets → More attributes → Data confidence.
-    assert t.index("Category") < t.index("More attributes") < t.index("Data confidence")
+    # Fold ORDER: Category section → commodity facets → Data confidence (trust, first
+    # fold) → Sourcing signals → More attributes (heavy folds demoted to the bottom).
+    assert t.index("Category") < t.index("Data confidence") < t.index("Sourcing signals") < t.index("More attributes")
     # Category tree moved ABOVE the manufacturer container (was below it pre-reorg)...
     assert t.index("filters/tree") < t.index("manufacturer-filter-container")
     # ...and the commodity sub-filters come before the demoted "More attributes" block.
@@ -29,7 +30,7 @@ def test_workspace_commodity_first_structure(client):
 
 
 def test_workspace_confidence_still_three_groups(client):
-    # The 3-group confidence filter survives the reorg (now inside the collapsed panel).
+    # The 3-group confidence filter survives the reorg (first fold, expanded by default).
     resp = client.get("/v2/partials/materials/workspace")
     assert resp.status_code == 200
     assert "toggleConfidenceGroup(" in resp.text

--- a/tests/test_filter_ux_layout.py
+++ b/tests/test_filter_ux_layout.py
@@ -30,7 +30,9 @@ def test_workspace_commodity_first_structure(client):
 
 
 def test_workspace_confidence_still_three_groups(client):
-    # The 3-group confidence filter survives the reorg (first fold, expanded by default).
+    # The 3-group confidence filter survives the reorg. (Fold order is asserted above;
+    # the expanded-by-default JS default is pinned in
+    # test_static_analysis.py::test_materials_fold_state_defaults_pinned.)
     resp = client.get("/v2/partials/materials/workspace")
     assert resp.status_code == 200
     assert "toggleConfidenceGroup(" in resp.text

--- a/tests/test_htmx_views_nightly.py
+++ b/tests/test_htmx_views_nightly.py
@@ -546,7 +546,8 @@ class TestMaterialsPartials:
     def test_materials_filters_sub_no_commodity(self, client, db_session: Session):
         resp = client.get("/v2/partials/materials/filters/sub")
         assert resp.status_code == 200
-        assert resp.text == ""
+        # Server-rendered placeholder nudge (replaced the old empty-string response).
+        assert "Select a category to unlock spec filters" in resp.text
 
     def test_materials_filters_sub_with_commodity(self, client, db_session: Session):
         resp = client.get("/v2/partials/materials/filters/sub?commodity=ic")

--- a/tests/test_materials_confidence_groups.py
+++ b/tests/test_materials_confidence_groups.py
@@ -1,8 +1,8 @@
 """Unit 7 — data-confidence 3-group filter.
 
 Backend: statuses CSV still filters by enrichment_status (default = all tiers = no narrowing;
-empty = no filter). Render: the workspace sidebar exposes the 3 group checkboxes at the
-bottom and no longer uses the old per-tier handler.
+empty = no filter). Render: the workspace sidebar exposes the 3 group checkboxes in the
+first filter fold (expanded by default) and no longer uses the old per-tier handler.
 """
 
 from sqlalchemy.orm import Session
@@ -44,7 +44,7 @@ def test_statuses_subset_narrows(db_session: Session):
     assert results[0].normalized_mpn == "v"
 
 
-def test_workspace_renders_confidence_groups_at_bottom(client):
+def test_workspace_renders_confidence_groups_first_fold(client):
     resp = client.get("/v2/partials/materials/workspace")
     assert resp.status_code == 200
     assert "Data confidence" in resp.text

--- a/tests/test_materials_confidence_groups.py
+++ b/tests/test_materials_confidence_groups.py
@@ -1,8 +1,10 @@
 """Unit 7 — data-confidence 3-group filter.
 
 Backend: statuses CSV still filters by enrichment_status (default = all tiers = no narrowing;
-empty = no filter). Render: the workspace sidebar exposes the 3 group checkboxes in the
-first filter fold (expanded by default) and no longer uses the old per-tier handler.
+empty = no filter). Render: the workspace sidebar exposes the 3 group checkboxes and no
+longer uses the old per-tier handler. Fold ORDER is pinned in test_filter_ux_layout.py;
+the expanded-by-default JS default is pinned in
+test_static_analysis.py::test_materials_fold_state_defaults_pinned.
 """
 
 from sqlalchemy.orm import Session
@@ -44,7 +46,7 @@ def test_statuses_subset_narrows(db_session: Session):
     assert results[0].normalized_mpn == "v"
 
 
-def test_workspace_renders_confidence_groups_first_fold(client):
+def test_workspace_renders_confidence_group_checkboxes(client):
     resp = client.get("/v2/partials/materials/workspace")
     assert resp.status_code == 200
     assert "Data confidence" in resp.text

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -368,3 +368,34 @@ def test_requisitions2_js_is_published_under_public():
         "Stale copy at app/static/js/requisitions2.js — that path is never published to "
         "the served static tree. Keep a single copy under app/static/public/js/."
     )
+
+
+def test_materials_fold_state_defaults_pinned():
+    """The materials rail collapse policy is a set of JS defaults, not template markup:
+    the Data-confidence (trust) fold opens by default; the heavy folds (sourcing / more
+    attributes) stay closed. The template tests only pin that the folds exist and their
+    order — without this guard a fold-state refactor could flip the booleans back with
+    zero test failure, silently undoing the expanded-by-default trust filter.
+
+    The confidence key is the ROTATED 'mat_confidence_open2': @alpinejs/persist writes
+    the CURRENT value to storage on init, so every browser that loaded the page under
+    the old `persistOr(false, 'mat_confidence_open')` carries a persisted `false` that
+    would override a new `true` default on the same key. htmx_app.js must keep removing
+    the legacy key so a revert can't resurrect those stale values.
+    """
+    src = Path("app/static/htmx_app.js").read_text()
+    assert re.search(r"confidenceOpen:\s*persistOr\(true,\s*'mat_confidence_open2'\)", src), (
+        "Data-confidence fold must default OPEN under the rotated key "
+        "'mat_confidence_open2' — trust is the headline filter, expanded by default."
+    )
+    assert re.search(r"sourcingOpen:\s*persistOr\(false,\s*'mat_sourcing_open'\)", src), (
+        "Sourcing-signals fold must default CLOSED per the collapse policy."
+    )
+    assert re.search(r"moreAttrsOpen:\s*persistOr\(false,\s*'mat_more_attrs_open'\)", src), (
+        "More-attributes fold must default CLOSED per the collapse policy."
+    )
+    assert "localStorage.removeItem('mat_confidence_open')" in src, (
+        "htmx_app.js must drop the legacy 'mat_confidence_open' localStorage key — "
+        "prior visitors carry a persisted `false` under it that would re-collapse the "
+        "trust fold if the key were ever reused."
+    )


### PR DESCRIPTION
## Summary

PR F — conservative materials layout polish, MAIN-branch half of the resolved design spec `MATERIALS_LAYOUT_SPEC.md` (§5 "CHANGE PLAN — MAIN branch", items 1–7). Items 8–11 (detail page + FRU panels) land separately inside the open #248 branch.

## Changes (each mapped to its spec section)

| # | File | Change | Spec |
|---|------|--------|------|
| 1 | `app/templates/htmx/partials/materials/workspace.html` | Data-confidence fold moved from last to FIRST filter fold; final order Confidence → Sourcing signals → More attributes. Three section comments now document the collapse policy (navigation open / trust open / heavy folds closed). Drawer-offset assumption comment added for `top-[52px] bottom-[48px]` (52px header + 48px bottom nav). Section internals untouched. | §1, §5.1 |
| 2 | `app/static/htmx_app.js` | `confidenceOpen: persistOr(true, 'mat_confidence_open')` (was `false`) + adjacent comment. No other state/default changes — statuses default stays all-on (trusted-only default explicitly REJECTED while the catalog is mostly unenriched). | §1, §5.2 |
| 3 | `app/routers/htmx_views.py` (`materials_filters_sub_partial`) | No-commodity early-return now renders `subfilters.html` with `commodity_selected=False` (skips the facet/coverage service calls) instead of returning an empty string. Router stays thin; copy stays server-rendered. | §4, §5.3 |
| 4 | `app/templates/htmx/partials/materials/filters/subfilters.html` | New `{% if not commodity_selected %}` placeholder branch ahead of the `{% elif subfilter_options %}` block — exact spec copy `Select a category to unlock spec filters`, classes `text-[11px] text-gray-400 italic px-2 mt-2`. | §4, §5.4 |
| 5 | `app/templates/htmx/partials/materials/list.html` | (a) `cond_colors` Refurbished + Used → `bg-violet-50 text-violet-700 border-violet-200` (kills the amber lifecycle/condition collision); (b) cross-ref "N alternates" chip → `bg-gray-100 text-gray-600 border-gray-200` (count metadata, not a status — indigo now exclusively means OEM-official); (c) primary-spec chips gain `title="{{ spec.label }}: {{ spec.value }}"` so value-only commodity rendering keeps its label on hover. | §2, §5.5 |
| 6 | Tests | Placeholder-branch template tests (copy + classes, with/without commodity, in `test_faceted_routes.py` + `test_htmx_views_nightly.py`); fold-order assertion updated in `test_filter_ux_layout.py`; new violet-palette / neutral-chip / chip-title row tests; `test_faceted_spec_chips_in_commodity_context_unchanged` retargeted at the chip body (the hover title legitimately carries "label: value" now); confidence-groups test renamed off "at_bottom". | §5.6 |
| 7 | `docs/APP_MAP_INTERACTIONS.md` | Sidebar fold order/defaults, no-commodity placeholder, and result-row palette notes updated per the standing same-PR rule. | §5.7 |

Spec REJECTED items stay rejected — no tier-ladder, no manufacturer promotion, no `sourcingOpen: true`, no always-show fold badges, no CSS-var drawer refactor, no column changes.

## Verification

- `TESTING=1 pytest tests/ -q` — **14910 passed**, 34 skipped, 1 xfailed
- `npm run test:frontend` — 90 passed (4 files)
- `npm run build` — clean; bundle smoke test passed; `bg-violet-50` / `text-violet-700` / `border-violet-200` / gray chip classes all confirmed present in the built CSS
- `pre-commit run --all-files` — all hooks pass (ruff, ruff-format, mypy, docformatter, etc.)

## Out of scope (lands in #248)

Spec §5 items 8–11: detail.html FRU-before-Crosses reorder + insights `mb-6` move, fru_section.html 12/10 item caps with inline expanders, machines `+N` overflow chip, grid density change, and their tests — all belong to the open `feat/fru-crosswalk` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)