### PR TITLE
feat(enrichment): FRU crosswalk decode pass — FRU cards inherit specs from approved models

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -130,6 +130,11 @@ class Settings(BaseSettings):
     # zero-LLM. Runs between mpn-decode (0.95) and the AI spec reader (0.85). Safe to leave
     # on — values are enum-validated by record_spec. See app/services/desc_extractor.
     desc_parse_enabled: bool = True
+    # Deterministic FRU crosswalk decode (IBM/Lenovo FRU → approved mfg models): zero-network,
+    # zero-LLM — strict-intersects the regex-gated decodes of a FRU's mfg_model links. Runs
+    # between mpn-decode (0.95) and desc-parse (0.90) at 0.93. Safe to leave on — values are
+    # enum-validated by record_spec. See app/services/fru_crosswalk_enrich.
+    fru_crosswalk_enrich_enabled: bool = True
 
     # --- Tagging ---
     min_tag_confidence: float = 0.90

--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -193,6 +193,10 @@ async def run_one_batch(
     batch = select_batch(db, config)
     if not batch:
         return {}
+    # Captured BEFORE the per-card loop: the FRU crosswalk pass below runs over the FULL
+    # batch (not enriched_ids) — FRU spare PNs are precisely the population connectors
+    # miss, so they finish not_found and never reach enriched_ids.
+    batch_ids = [int(c.id) for c in batch]
 
     if disabled is None:
         disabled = set()
@@ -302,6 +306,25 @@ async def run_one_batch(
                 logger.info("ENRICH_WORKER: mpn-decode {}", decode_and_record_specs(db, enriched_ids))
             except Exception:
                 logger.exception("ENRICH_WORKER: mpn-decode failed over {} cards", len(enriched_ids))
+
+    # Deterministic FRU crosswalk decode: FRU spare PNs (IBM/Lenovo) inherit the
+    # strict-intersected decode of their approved mfg_model links, source=
+    # "fru_matrix_decode" at 0.93 — between mpn-decode (0.95, first-party decode is
+    # stronger evidence) and desc-parse (0.90; the crosswalk can also SET a missing
+    # category, letting desc-parse pick the card up in the SAME batch). Scope is the
+    # FULL batch (batch_ids, not enriched_ids): not_found/quarantined cards are safe to
+    # include — the pass is deterministic and free, and it never touches
+    # enrichment_status. Same session, committed together below.
+    if batch_ids:
+        from app.config import settings
+
+        if settings.fru_crosswalk_enrich_enabled:
+            from app.services.fru_crosswalk_enrich import crosswalk_and_record_specs
+
+            try:
+                logger.info("ENRICH_WORKER: fru-crosswalk {}", crosswalk_and_record_specs(db, batch_ids))
+            except Exception:
+                logger.exception("ENRICH_WORKER: fru-crosswalk failed over {} cards", len(batch_ids))
 
     # Deterministic description→spec extraction (storage/DRAM token grammar): zero-LLM,
     # enum-validated by record_spec. Runs AFTER mpn-decode (its 0.95 values outrank this

--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -310,8 +310,10 @@ async def run_one_batch(
     # Deterministic FRU crosswalk decode: FRU spare PNs (IBM/Lenovo) inherit the
     # strict-intersected decode of their approved mfg_model links, source=
     # "fru_matrix_decode" at 0.93 — between mpn-decode (0.95, first-party decode is
-    # stronger evidence) and desc-parse (0.90; the crosswalk can also SET a missing
-    # category, letting desc-parse pick the card up in the SAME batch). Scope is the
+    # stronger evidence) and desc-parse (0.90; for cards in enriched_ids, a missing
+    # category the crosswalk fills lets desc-parse pick them up in the SAME batch —
+    # not_found FRU spares are NOT in enriched_ids, so they only benefit from the
+    # crosswalk itself this batch). Scope is the
     # FULL batch (batch_ids, not enriched_ids): not_found/quarantined cards are safe to
     # include — the pass is deterministic and free, and it never touches
     # enrichment_status. Same session, committed together below.

--- a/app/services/fru_crosswalk_enrich.py
+++ b/app/services/fru_crosswalk_enrich.py
@@ -1,0 +1,191 @@
+"""FRU crosswalk decode enrichment — FRU cards inherit specs from approved models.
+
+What: for each batch card whose key-normalized MPN matches ``fru_links.fru_norm``,
+decodes every linked ``mfg_model`` manufacturer model with the existing pure MPN
+decoders (zero LLM, zero network), STRICT-INTERSECTS the results (only spec keys
+present in every decode with equal values survive; a commodity disagreement skips
+the card entirely), and writes the agreed specs onto the FRU card via
+``record_spec(source="fru_matrix_decode", confidence=0.93)`` — between mpn_decode
+(0.95) and desc_parse (0.90) on the confidence ladder. Category is filled from the
+agreed commodity ONLY when the card has none (an existing category is authoritative
+and a mismatch skips the card); the card's manufacturer is never touched. Reverse
+direction (a card that IS a mfg_model) gains nothing here — its own MPN already
+decodes directly at 0.95. Does not commit — the caller manages the txn.
+
+Called by: app/services/enrichment_worker/worker.py (run_one_batch, second pass,
+           gated by settings.fru_crosswalk_enrich_enabled, over the FULL batch ids).
+Depends on: models.FruLink, constants.FruLinkKind, mpn_decoder.decode_mpn (pure),
+            utils.normalization.normalize_mpn_key, spec_write_service.record_spec.
+"""
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app.constants import FruLinkKind
+from app.models import FruLink, MaterialCard
+from app.services.mpn_decoder import DecodeResult, decode_mpn
+from app.services.spec_write_service import load_schema_cache, record_spec
+from app.utils.normalization import normalize_mpn_key
+
+# Source tag + confidence for everything this pass writes (see record_spec). Sits
+# between mpn_decode (0.95 — first-party decode of the card's own MPN is strictly
+# stronger evidence) and desc_parse (0.90). DecodeResult.confidence (0.95) is
+# deliberately ignored: a one-hop workbook mapping plus decode is weaker than a
+# first-party decode.
+FRU_DECODE_SOURCE = "fru_matrix_decode"
+FRU_DECODE_CONFIDENCE = 0.93
+
+
+def intersect_decodes(results: list[DecodeResult]) -> tuple[str | None, dict, int]:
+    """Strict-intersect the decodes of a FRU's approved substitute models (pure, no DB).
+
+    Returns ``(agreed_commodity_or_None, agreed_specs, dropped_count)``:
+    - ``None`` commodity signals a commodity conflict (or an empty input) — the
+      substitutes can't agree on what they ARE, so nothing may be asserted.
+    - ``agreed_specs`` keeps only keys present in EVERY decode with equal values
+      (``==`` exact — decoders emit canonical enum strings / numbers). A key missing
+      from any one decode is dropped silently (absence is not agreement); a key
+      present everywhere with differing values is dropped AND counted.
+    """
+    if not results:
+        return (None, {}, 0)
+    commodities = {r.commodity for r in results}
+    if len(commodities) > 1:
+        return (None, {}, 0)
+    commodity = results[0].commodity
+    agreed: dict = {}
+    dropped = 0
+    for spec_key, first_value in results[0].specs.items():
+        rest = results[1:]
+        if any(spec_key not in r.specs for r in rest):
+            continue  # absent from a substitute — not agreement, not a value conflict
+        if all(r.specs[spec_key] == first_value for r in rest):
+            agreed[spec_key] = first_value
+        else:
+            dropped += 1
+    return (commodity, agreed, dropped)
+
+
+def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, int]:
+    """Crosswalk-decode the FRU cards among *card_ids* and write the agreed specs.
+
+    Returns {matched, decoded, written, categorized, dropped_conflict,
+    commodity_conflict, category_mismatch}: cards with ≥1 mfg_model link; matched cards
+    with ≥1 successful model decode; specs persisted; NULL-category cards categorized
+    from the agreed commodity; spec keys discarded by the value intersection; cards
+    skipped on commodity disagreement; cards skipped because their existing category
+    contradicts the agreed commodity.
+    """
+    stats = {
+        "matched": 0,
+        "decoded": 0,
+        "written": 0,
+        "categorized": 0,
+        "dropped_conflict": 0,
+        "commodity_conflict": 0,
+        "category_mismatch": 0,
+    }
+
+    # db.get per id is an identity-map hit (the worker loaded the batch on this
+    # session). Distinct normalized_mpns can share one key, hence the list values.
+    key_to_card_ids: dict[str, list[int]] = {}
+    for card_id in card_ids:
+        card = db.get(MaterialCard, card_id)
+        if card is None:
+            continue
+        key = normalize_mpn_key(card.normalized_mpn)
+        if key:
+            key_to_card_ids.setdefault(key, []).append(int(card_id))
+    if not key_to_card_ids:
+        return stats
+
+    # ONE link query for the whole batch (no N+1), grouped by FRU into a set of
+    # (related_raw, manufacturer) so cross-sheet duplicates decode once.
+    links = (
+        db.query(FruLink)
+        .filter(
+            FruLink.fru_norm.in_(key_to_card_ids.keys()),
+            FruLink.rel_kind == FruLinkKind.MFG_MODEL.value,
+        )
+        .all()
+    )
+    models_by_fru: dict[str, set[tuple[str, str | None]]] = {}
+    for link in links:
+        models_by_fru.setdefault(link.fru_norm, set()).add((link.related_raw, link.manufacturer))
+
+    schema_caches: dict[str, dict] = {}  # one schema load per commodity, reused across cards
+    for fru_norm, models in models_by_fru.items():
+        # Decode + intersect once per FRU (pure, no DB); sorted for a deterministic
+        # result order. None results (unrecognized schemes) contribute no evidence.
+        results = [r for raw, mfg in sorted(models, key=lambda m: m[0]) if (r := decode_mpn(raw, mfg)) is not None]
+        commodity, agreed, dropped = intersect_decodes(results)
+
+        for card_id in key_to_card_ids[fru_norm]:
+            stats["matched"] += 1
+            if not results:
+                continue
+            # Per-card isolation: a single bad card must never abort the rest of the batch.
+            try:
+                if commodity is None:
+                    # Substitutes disagree on what they ARE — assert nothing (D2).
+                    stats["decoded"] += 1
+                    stats["commodity_conflict"] += 1
+                    continue
+                card = db.get(MaterialCard, card_id)
+                card_cat = (card.category or "").lower().strip()
+                if card_cat and card_cat != commodity:
+                    # An existing category is authoritative — never overwritten (D3).
+                    stats["decoded"] += 1
+                    stats["category_mismatch"] += 1
+                    continue
+                cache = schema_caches.get(commodity)
+                if cache is None:
+                    cache = schema_caches[commodity] = load_schema_cache(db, commodity)
+                prior_specs = card.specs_structured or {}
+                # SAVEPOINT per card: record_spec flushes, so a DB-level failure would
+                # otherwise poison the shared batch transaction. The nested txn rolls back
+                # ONLY this card (including a categorize-from-null); counters increment
+                # after a clean release so a rolled-back card contributes nothing.
+                with db.begin_nested():
+                    if not card_cat:
+                        # The agreed commodity is regex-gated against strict manufacturer
+                        # schemes AND agreed across ALL decoded substitutes — a safe FILL
+                        # for a missing category, never an overwrite. record_spec requires
+                        # a category, so this precedes the loop.
+                        card.category = commodity
+                    card_written = 0
+                    for spec_key, value in agreed.items():
+                        prior = prior_specs.get(spec_key)
+                        # Pre-SP2 overwrite guard: record_spec's cross-source rule is
+                        # latest-write-wins, so keys already held at STRICTLY higher
+                        # confidence (mpn_decode 0.95, vendor APIs) are skipped here.
+                        if prior and float(prior.get("confidence") or 0.0) > FRU_DECODE_CONFIDENCE:
+                            continue
+                        if record_spec(
+                            db,
+                            card_id,
+                            spec_key,
+                            value,
+                            source=FRU_DECODE_SOURCE,
+                            confidence=FRU_DECODE_CONFIDENCE,
+                            schema_cache=cache,
+                        ):
+                            card_written += 1
+                # Reached only on a clean savepoint release.
+                stats["decoded"] += 1
+                stats["written"] += card_written
+                stats["dropped_conflict"] += dropped
+                if not card_cat:
+                    stats["categorized"] += 1
+            except Exception:
+                logger.exception("fru-crosswalk: failed on card_id={}", card_id)
+
+    if stats["written"] or stats["categorized"]:
+        logger.info(
+            "fru-crosswalk: wrote {} specs across {} cards ({} newly categorized, {} keys dropped by intersection)",
+            stats["written"],
+            stats["decoded"],
+            stats["categorized"],
+            stats["dropped_conflict"],
+        )
+    return stats

--- a/app/services/fru_crosswalk_enrich.py
+++ b/app/services/fru_crosswalk_enrich.py
@@ -6,17 +6,24 @@ decoders (zero LLM, zero network), STRICT-INTERSECTS the results (only spec keys
 present in every decode with equal values survive; a commodity disagreement skips
 the card entirely), and writes the agreed specs onto the FRU card via
 ``record_spec(source="fru_matrix_decode", confidence=0.93)`` — between mpn_decode
-(0.95) and desc_parse (0.90) on the confidence ladder. Category is filled from the
-agreed commodity ONLY when the card has none (an existing category is authoritative
-and a mismatch skips the card); the card's manufacturer is never touched. Reverse
-direction (a card that IS a mfg_model) gains nothing here — its own MPN already
-decodes directly at 0.95. Does not commit — the caller manages the txn.
+(0.95) and desc_parse (0.90) on the confidence ladder. Keys a prior pass already
+holds at STRICTLY higher confidence are pre-gated here, never overwritten — this
+file is one of the three pre-gate sites enumerated in record_spec's ARBITRATION
+MODEL registry (app/services/spec_write_service.py), which the SP2 source-tier
+ladder will consolidate. Category is filled from the agreed commodity ONLY when the
+card has none (an existing category is authoritative and a mismatch skips the
+card); the card's manufacturer is never touched. Reverse direction (a card that IS
+a mfg_model) gains nothing here — its own MPN already decodes directly at 0.95.
+Does not commit — the caller manages the txn.
 
 Called by: app/services/enrichment_worker/worker.py (run_one_batch, second pass,
            gated by settings.fru_crosswalk_enrich_enabled, over the FULL batch ids).
-Depends on: models.FruLink, constants.FruLinkKind, mpn_decoder.decode_mpn (pure),
-            utils.normalization.normalize_mpn_key, spec_write_service.record_spec.
+Depends on: models.FruLink, models.MaterialCard, constants.FruLinkKind,
+            mpn_decoder.decode_mpn (pure), utils.normalization.normalize_mpn_key,
+            spec_write_service.record_spec / load_schema_cache.
 """
+
+from collections import Counter
 
 from loguru import logger
 from sqlalchemy.orm import Session
@@ -36,24 +43,30 @@ FRU_DECODE_SOURCE = "fru_matrix_decode"
 FRU_DECODE_CONFIDENCE = 0.93
 
 
-def intersect_decodes(results: list[DecodeResult]) -> tuple[str | None, dict, int]:
+def intersect_decodes(
+    results: list[DecodeResult],
+) -> tuple[str | None, dict[str, str | int | float | bool], int]:
     """Strict-intersect the decodes of a FRU's approved substitute models (pure, no DB).
 
     Returns ``(agreed_commodity_or_None, agreed_specs, dropped_count)``:
-    - ``None`` commodity signals a commodity conflict (or an empty input) — the
-      substitutes can't agree on what they ARE, so nothing may be asserted.
+    - ``None`` commodity signals a genuine commodity conflict — the substitutes
+      can't agree on what they ARE, so nothing may be asserted.
     - ``agreed_specs`` keeps only keys present in EVERY decode with equal values
       (``==`` exact — decoders emit canonical enum strings / numbers). A key missing
       from any one decode is dropped silently (absence is not agreement); a key
       present everywhere with differing values is dropped AND counted.
+
+    Raises ``ValueError`` on empty *results* — the caller must filter no-evidence
+    FRUs (zero decodable substitutes) BEFORE calling, so a ``None`` commodity here
+    always means contradicting evidence, never missing evidence.
     """
     if not results:
-        return (None, {}, 0)
+        raise ValueError("intersect_decodes requires at least one DecodeResult")
     commodities = {r.commodity for r in results}
     if len(commodities) > 1:
         return (None, {}, 0)
     commodity = results[0].commodity
-    agreed: dict = {}
+    agreed: dict[str, str | int | float | bool] = {}
     dropped = 0
     for spec_key, first_value in results[0].specs.items():
         rest = results[1:]
@@ -69,18 +82,31 @@ def intersect_decodes(results: list[DecodeResult]) -> tuple[str | None, dict, in
 def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, int]:
     """Crosswalk-decode the FRU cards among *card_ids* and write the agreed specs.
 
-    Returns {matched, decoded, written, categorized, dropped_conflict,
-    commodity_conflict, category_mismatch}: cards with ≥1 mfg_model link; matched cards
-    with ≥1 successful model decode; specs persisted; NULL-category cards categorized
-    from the agreed commodity; spec keys discarded by the value intersection; cards
-    skipped on commodity disagreement; cards skipped because their existing category
-    contradicts the agreed commodity.
+    Returns {matched, decoded, written, categorized, failed, dropped_conflict,
+    commodity_conflict, category_mismatch}:
+
+    - matched: cards with ≥1 mfg_model link.
+    - decoded: matched cards whose substitutes produced ≥1 decode AND that were not
+      lost to a failure/rollback (conflict-/mismatch-skipped cards count — their
+      decode reached a verdict; rolled-back cards do not).
+    - written: specs persisted.
+    - categorized: NULL-category cards categorized from the agreed commodity.
+    - failed: cards lost to an exception — a raising decode fails every card on its
+      FRU, a write failure only its own card. Per-failure tracebacks are logged
+      below, but the aggregate must surface failures too, so the worker's one-line
+      stats can distinguish a healthy no-op batch from a crashed one.
+    - dropped_conflict: spec keys discarded by the value intersection, counted ONCE
+      per FRU (not per card sharing the key, and independent of per-card skips).
+    - commodity_conflict: cards skipped on commodity disagreement.
+    - category_mismatch: cards skipped because their existing category contradicts
+      the agreed commodity.
     """
     stats = {
         "matched": 0,
         "decoded": 0,
         "written": 0,
         "categorized": 0,
+        "failed": 0,
         "dropped_conflict": 0,
         "commodity_conflict": 0,
         "category_mismatch": 0,
@@ -114,33 +140,61 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
         models_by_fru.setdefault(link.fru_norm, set()).add((link.related_raw, link.manufacturer))
 
     schema_caches: dict[str, dict] = {}  # one schema load per commodity, reused across cards
+    # record_spec drops BOTH vocabulary-drift cases at DEBUG only (invisible at the
+    # production INFO level), so the discard of crosswalk output is surfaced below as
+    # an aggregate WARNING after the batch, exactly like mpn_decoder/writer.py:
+    #   dropped_no_schema   "commodity.spec_key"       -> value with NO schema row
+    #   dropped_out_of_enum "commodity.spec_key=value" -> enum value outside the LIVE
+    #                       enum_values (the worker decodes against live DB rows,
+    #                       which can lag a deploy's reseed or drift after a
+    #                       failed/manual reseed).
+    dropped_no_schema: Counter = Counter()
+    dropped_out_of_enum: Counter = Counter()
     for fru_norm, models in models_by_fru.items():
-        # Decode + intersect once per FRU (pure, no DB); sorted for a deterministic
-        # result order. None results (unrecognized schemes) contribute no evidence.
-        results = [r for raw, mfg in sorted(models, key=lambda m: m[0]) if (r := decode_mpn(raw, mfg)) is not None]
+        fru_card_ids = key_to_card_ids[fru_norm]
+        stats["matched"] += len(fru_card_ids)
+        # Per-FRU isolation: one raising decoder on a weird workbook string must
+        # fail ONLY this FRU's cards, never abort the remaining FRUs or lose stats.
+        try:
+            # Decode + intersect once per FRU (pure, no DB); sorted for a deterministic
+            # result order. None results (unrecognized schemes) contribute no evidence.
+            results = [r for raw, mfg in sorted(models, key=lambda m: m[0]) if (r := decode_mpn(raw, mfg)) is not None]
+        except Exception:
+            stats["failed"] += len(fru_card_ids)
+            logger.exception("fru-crosswalk: decode failed for fru_norm={}", fru_norm)
+            continue
+        if not results:
+            continue  # zero decodable substitutes — no evidence, nothing asserted
         commodity, agreed, dropped = intersect_decodes(results)
+        stats["dropped_conflict"] += dropped  # once per FRU, independent of card outcomes
+        if commodity is None:
+            # Substitutes disagree on what they ARE — assert nothing.
+            stats["decoded"] += len(fru_card_ids)
+            stats["commodity_conflict"] += len(fru_card_ids)
+            continue
 
-        for card_id in key_to_card_ids[fru_norm]:
-            stats["matched"] += 1
-            if not results:
-                continue
+        for card_id in fru_card_ids:
             # Per-card isolation: a single bad card must never abort the rest of the batch.
             try:
-                if commodity is None:
-                    # Substitutes disagree on what they ARE — assert nothing (D2).
-                    stats["decoded"] += 1
-                    stats["commodity_conflict"] += 1
-                    continue
                 card = db.get(MaterialCard, card_id)
+                if card is None:
+                    continue
                 card_cat = (card.category or "").lower().strip()
                 if card_cat and card_cat != commodity:
-                    # An existing category is authoritative — never overwritten (D3).
+                    # An existing category is authoritative — never overwritten,
+                    # never written-around: the card is skipped entirely.
                     stats["decoded"] += 1
                     stats["category_mismatch"] += 1
                     continue
                 cache = schema_caches.get(commodity)
                 if cache is None:
                     cache = schema_caches[commodity] = load_schema_cache(db, commodity)
+                for spec_key, value in agreed.items():
+                    schema = cache.get((commodity, spec_key))
+                    if schema is None:
+                        dropped_no_schema[f"{commodity}.{spec_key}"] += 1
+                    elif schema.data_type == "enum" and schema.enum_values and str(value) not in schema.enum_values:
+                        dropped_out_of_enum[f"{commodity}.{spec_key}={value}"] += 1
                 prior_specs = card.specs_structured or {}
                 # SAVEPOINT per card: record_spec flushes, so a DB-level failure would
                 # otherwise poison the shared batch transaction. The nested txn rolls back
@@ -159,6 +213,7 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
                         # Pre-SP2 overwrite guard: record_spec's cross-source rule is
                         # latest-write-wins, so keys already held at STRICTLY higher
                         # confidence (mpn_decode 0.95, vendor APIs) are skipped here.
+                        # Registered in record_spec's ARBITRATION MODEL docstring.
                         if prior and float(prior.get("confidence") or 0.0) > FRU_DECODE_CONFIDENCE:
                             continue
                         if record_spec(
@@ -174,18 +229,29 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
                 # Reached only on a clean savepoint release.
                 stats["decoded"] += 1
                 stats["written"] += card_written
-                stats["dropped_conflict"] += dropped
                 if not card_cat:
                     stats["categorized"] += 1
             except Exception:
+                stats["failed"] += 1
                 logger.exception("fru-crosswalk: failed on card_id={}", card_id)
 
-    if stats["written"] or stats["categorized"]:
+    if dropped_no_schema or dropped_out_of_enum:
+        logger.warning(
+            "fru-crosswalk: {} crosswalk spec values dropped — no commodity_spec_schemas row for {}; "
+            "value outside the live enum_values for {} "
+            "(decoder and seeded schemas have drifted; see tests/test_mpn_decoder_seed_sync.py)",
+            sum(dropped_no_schema.values()) + sum(dropped_out_of_enum.values()),
+            dict(dropped_no_schema),
+            dict(dropped_out_of_enum),
+        )
+    if stats["written"] or stats["categorized"] or stats["failed"]:
         logger.info(
-            "fru-crosswalk: wrote {} specs across {} cards ({} newly categorized, {} keys dropped by intersection)",
+            "fru-crosswalk: wrote {} specs across {} decoded cards "
+            "({} newly categorized, {} keys dropped by intersection, {} cards failed)",
             stats["written"],
             stats["decoded"],
             stats["categorized"],
             stats["dropped_conflict"],
+            stats["failed"],
         )
     return stats

--- a/app/services/spec_write_service.py
+++ b/app/services/spec_write_service.py
@@ -47,15 +47,20 @@ def record_spec(
     not found, no category, no schema, enum mismatch, unparseable numeric, vendor-API
     conflict, or same-source lower-confidence).
 
-    ARBITRATION MODEL — currently split across TWO sites. This function is deliberately
-    2-tier: vendor-API sources are authoritative, otherwise latest-write-wins across
-    sources. The desc_extractor writer (app/services/desc_extractor/writer.py, lands
-    from its own branch) adds a third tier ABOVE this call: it pre-gates on the prior
-    entry's confidence so the 0.95 mpn_decode baseline is never overwritten by its 0.90
-    description parse — record_spec alone would let it win via latest-write-wins. Until
-    the SP2 source-tier ladder moves that pre-gate in here (as a per-source
-    {source: min_confidence_to_overwrite} floor map, making the writer's pre-gate
-    redundant and deletable), any change to the arbitration model must update BOTH
+    ARBITRATION MODEL — currently split across THREE sites. This function is
+    deliberately 2-tier: vendor-API sources are authoritative, otherwise
+    latest-write-wins across sources. Two writers add a third tier ABOVE this call by
+    pre-gating on the prior entry's confidence — record_spec alone would let them win
+    via latest-write-wins over the 0.95 mpn_decode baseline:
+
+    - app/services/desc_extractor/writer.py (desc_parse, 0.90) skips keys already
+      held at strictly higher confidence.
+    - app/services/fru_crosswalk_enrich.py (fru_matrix_decode, 0.93) applies the
+      same strictly-higher-confidence skip.
+
+    Until the SP2 source-tier ladder moves that pre-gate in here (as a per-source
+    {source: min_confidence_to_overwrite} floor map, making the writers' pre-gates
+    redundant and deletable), any change to the arbitration model must update ALL
     sites, and any NEW non-vendor-API writer needs the same pre-gate or it will
     overwrite decoded values.
     """
@@ -132,8 +137,9 @@ def record_spec(
         new_entry["original_unit"] = unit
 
     # Conflict resolution: 2-tier — vendor API sources are authoritative, otherwise latest
-    # wins. NOTE: desc_extractor's writer pre-gates on confidence BEFORE calling record_spec
-    # (third tier above this one) — see the ARBITRATION MODEL note in the docstring.
+    # wins. NOTE: the desc_extractor and fru_crosswalk writers pre-gate on confidence BEFORE
+    # calling record_spec (third tier above this one) — see the ARBITRATION MODEL note in
+    # the docstring.
     specs = dict(card.specs_structured or {})
     existing = specs.get(spec_key)
 

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -292,7 +292,7 @@
 | condition | String 20, nullable, indexed | Broker stock condition: `New`\|`Recertified`\|`Refurbished`\|`Used`\|`Pulled`\|`Unknown`. Application-validated (no DB CHECK). Powers the Condition global facet; NULL until a source (offer/sighting provenance) populates it — the facet renders only values with data. Migration 091. |
 | enrichment_status | String 20 | `unenriched` \| `verified` \| `web_sourced` \| `oem_sourced` \| `ai_inferred` \| `not_found` \| `not_catalogued`. Validated on write against `MaterialEnrichmentStatus` (constants.py). `oem_sourced` = single official OEM page; `not_catalogued` = recognised OEM/FRU part with no public specs (retries on 30-day backoff). No migration — varchar column. |
 | cross_references | JSONB | Alternative MPNs; also records OEM FRU→commodity-MPN linkages written by the cross-ref enrichment tier (`[{"mpn": <resolved>, "manufacturer": <mfr>}]`). |
-| specs_structured | JSONB | Parametric data |
+| specs_structured | JSONB | Parametric data — `{spec_key: {value, source, confidence, updated_at}}`. Source vocabulary: vendor APIs (`digikey_api` \| `nexar_api` \| `mouser_api` — authoritative), `mpn_decode` (0.95), `fru_matrix_decode` (0.93, FRU crosswalk intersection), `desc_parse` (0.90), `spec_extraction` (AI, ≥ 0.85) |
 | enriched_at | UTCDateTime, nullable | When the first-pass card enrichment (description/category/lifecycle) ran; NULL = not yet run |
 | specs_enriched_at | UTCDateTime, nullable, indexed | When the second-pass structured-spec extraction ran; NULL = spec pass not yet run |
 | search_vector | TSVECTOR | Trigger-maintained FTS (weighted: MPN=A, manufacturer=B, description/category=C) |

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -776,20 +776,35 @@ ladder lands in record_spec):
 
     1. mpn_decoder/writer.py::decode_and_record_specs   — deterministic MPN→spec
        decode, source="mpn_decode", confidence 0.95 (settings.mpn_decode_enabled).
-    2. desc_extractor/writer.py::extract_and_record_specs — deterministic
+    2. fru_crosswalk_enrich.py::crosswalk_and_record_specs — deterministic FRU
+       crosswalk decode (IBM/Lenovo FRU spare PNs inherit the STRICT-INTERSECTED
+       decode of their fru_links rel_kind='mfg_model' models — only spec keys present
+       in every decode with equal values write; a commodity disagreement skips the
+       card), source="fru_matrix_decode", confidence 0.93
+       (settings.fru_crosswalk_enrich_enabled). Zero LLM/network; ONE fru_links query
+       per batch. Scope is the FULL batch ids, NOT enriched_ids — FRU spares finish
+       not_found, and the pass never touches enrichment_status. Fills a NULL category
+       from the agreed commodity (mirroring mpn_decode; an existing category is
+       authoritative — a mismatch skips the card); never writes manufacturer; never
+       writes the reverse direction (a card that IS a mfg_model already decodes
+       first-party at 0.95). Pre-gates each key on the prior entry's confidence
+       (> 0.93 skipped) like desc_parse, so mpn_decode/vendor-API values stay
+       authoritative.
+    3. desc_extractor/writer.py::extract_and_record_specs — deterministic
        description→spec token grammar (storage + DRAM; TRIO part-master/inventory
        descriptions like `HD, 450GB, 15KRPM, 3.5", Fibre Channel`), source=
        "desc_parse", confidence 0.90 (settings.desc_parse_enabled). Zero LLM/network;
        extraction is suppressed on foreign commodity labels ("Other,"/"Tray,"…) and
        conflicting tokens; only already-categorized hdd/ssd/dram cards are written
        (NEVER categorizes — a description is not a regex-gated commodity proof).
-       The writer skips keys already held at higher confidence, so mpn_decode 0.95
-       and vendor-API values stay authoritative.
-    3. spec_enrichment_service.py::enrich_card_specs    — AI spec reader,
+       The writer skips keys already held at higher confidence, so mpn_decode 0.95,
+       fru_matrix_decode 0.93 and vendor-API values stay authoritative.
+    4. spec_enrichment_service.py::enrich_card_specs    — AI spec reader,
        source="spec_extraction", facets gated at confidence >= 0.85. Applies the
        same strictly-higher-confidence skip guard, so it never clobbers an
-       mpn_decode/desc_parse key it under-claims against (an AI confidence >= the
-       deterministic prior still wins — see the tiering caveat above).
+       mpn_decode/fru_matrix_decode/desc_parse key it under-claims against (an AI
+       confidence >= the deterministic prior still wins — see the tiering caveat
+       above).
 
 After first pass (scheduled job only):
 tagging_jobs.py -> enrich_pending_specs() [spec extraction, second pass]

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -789,7 +789,11 @@ ladder lands in record_spec):
        writes the reverse direction (a card that IS a mfg_model already decodes
        first-party at 0.95). Pre-gates each key on the prior entry's confidence
        (> 0.93 skipped) like desc_parse, so mpn_decode/vendor-API values stay
-       authoritative.
+       authoritative. Isolation is two-level: decode/intersect failures are caught
+       per FRU, write failures per card (SAVEPOINT) — both surface in the returned
+       `failed` count so the worker's stats line distinguishes a no-op batch from a
+       crashed one. Schema-drift drops (no schema row / out-of-enum value) emit the
+       same aggregate WARNING as the mpn-decode writer.
     3. desc_extractor/writer.py::extract_and_record_specs — deterministic
        description→spec token grammar (storage + DRAM; TRIO part-master/inventory
        descriptions like `HD, 450GB, 15KRPM, 3.5", Fibre Channel`), source=

--- a/tests/test_fru_crosswalk_intersect.py
+++ b/tests/test_fru_crosswalk_intersect.py
@@ -1,0 +1,84 @@
+"""Unit — intersect_decodes: the pure D2 strict-intersection rule of the FRU crosswalk
+pass (no DB).
+
+Specs all approved substitutes share are FRU-level truths; anything they differ on (or
+that any one of them omits) is never asserted.
+"""
+
+from app.services.fru_crosswalk_enrich import intersect_decodes
+from app.services.mpn_decoder import DecodeResult
+
+
+def _hdd(specs: dict) -> DecodeResult:
+    return DecodeResult(commodity="hdd", vendor="seagate", specs=specs)
+
+
+def test_full_agreement_keeps_all_specs():
+    a = _hdd({"capacity_gb": 4000, "form_factor": '3.5"', "interface": "SAS"})
+    b = _hdd({"capacity_gb": 4000, "form_factor": '3.5"', "interface": "SAS"})
+
+    commodity, agreed, dropped = intersect_decodes([a, b])
+
+    assert commodity == "hdd"
+    assert agreed == {"capacity_gb": 4000, "form_factor": '3.5"', "interface": "SAS"}
+    assert dropped == 0
+
+
+def test_conflicting_value_dropped_and_counted_shared_keys_kept():
+    a = _hdd({"capacity_gb": 4000, "rpm": 10000})
+    b = _hdd({"capacity_gb": 4000, "rpm": 15000})
+
+    commodity, agreed, dropped = intersect_decodes([a, b])
+
+    assert commodity == "hdd"
+    assert agreed == {"capacity_gb": 4000}  # rpm conflicts → never asserted
+    assert dropped == 1
+
+
+def test_key_present_in_only_one_decode_is_dropped_uncounted():
+    # Absence is not agreement — the key is dropped, but it is NOT a value
+    # conflict, so it does not count toward dropped_conflict.
+    a = _hdd({"capacity_gb": 4000, "rpm": 7200})
+    b = _hdd({"capacity_gb": 4000})
+
+    commodity, agreed, dropped = intersect_decodes([a, b])
+
+    assert commodity == "hdd"
+    assert agreed == {"capacity_gb": 4000}
+    assert dropped == 0
+
+
+def test_commodity_disagreement_returns_none():
+    # A FRU whose substitutes can't agree on what they ARE gets nothing asserted.
+    a = _hdd({"capacity_gb": 4000})
+    b = DecodeResult(commodity="ssd", vendor="samsung", specs={"capacity_gb": 3840})
+
+    assert intersect_decodes([a, b]) == (None, {}, 0)
+
+
+def test_single_decode_is_passthrough():
+    a = _hdd({"capacity_gb": 8000, "form_factor": '3.5"'})
+
+    commodity, agreed, dropped = intersect_decodes([a])
+
+    assert commodity == "hdd"
+    assert agreed == {"capacity_gb": 8000, "form_factor": '3.5"'}
+    assert dropped == 0
+
+
+def test_empty_list_is_noop():
+    assert intersect_decodes([]) == (None, {}, 0)
+
+
+def test_three_way_intersection_requires_all_to_agree():
+    # A key must be present in EVERY decode with an equal value; a key missing
+    # from just one of three decodes is dropped even when the other two agree.
+    a = _hdd({"capacity_gb": 4000, "form_factor": '3.5"', "rpm": 7200})
+    b = _hdd({"capacity_gb": 4000, "form_factor": '3.5"', "rpm": 7200})
+    c = _hdd({"capacity_gb": 4000, "rpm": 10000})
+
+    commodity, agreed, dropped = intersect_decodes([a, b, c])
+
+    assert commodity == "hdd"
+    assert agreed == {"capacity_gb": 4000}  # form_factor absent from c; rpm conflicts
+    assert dropped == 1  # only rpm is a counted value conflict

--- a/tests/test_fru_crosswalk_intersect.py
+++ b/tests/test_fru_crosswalk_intersect.py
@@ -1,9 +1,11 @@
-"""Unit — intersect_decodes: the pure D2 strict-intersection rule of the FRU crosswalk
-pass (no DB).
+"""Unit — intersect_decodes: the pure strict-intersection rule of the FRU crosswalk pass
+(no DB).
 
 Specs all approved substitutes share are FRU-level truths; anything they differ on (or
 that any one of them omits) is never asserted.
 """
+
+import pytest
 
 from app.services.fru_crosswalk_enrich import intersect_decodes
 from app.services.mpn_decoder import DecodeResult
@@ -66,8 +68,12 @@ def test_single_decode_is_passthrough():
     assert dropped == 0
 
 
-def test_empty_list_is_noop():
-    assert intersect_decodes([]) == (None, {}, 0)
+def test_empty_list_raises():
+    # No evidence is the CALLER's case to handle (it filters undecodable links
+    # before calling) — raising here keeps a None commodity unambiguous: it always
+    # means contradicting evidence, never missing evidence.
+    with pytest.raises(ValueError):
+        intersect_decodes([])
 
 
 def test_three_way_intersection_requires_all_to_agree():

--- a/tests/test_fru_crosswalk_worker.py
+++ b/tests/test_fru_crosswalk_worker.py
@@ -1,0 +1,137 @@
+"""run_one_batch wires the FRU crosswalk pass: after mpn-decode, before desc-parse,
+gated by settings.fru_crosswalk_enrich_enabled, over the FULL batch (not enriched_ids),
+and isolated from batch failures."""
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock, patch
+
+from app.constants import MaterialEnrichmentStatus
+from app.models import MaterialCard
+from app.services.enrichment_worker.circuit_breaker import EnrichmentCircuitBreaker
+from app.services.enrichment_worker.config import EnrichmentWorkerConfig
+from app.services.enrichment_worker.worker import run_one_batch
+
+_FRU_ZERO = {
+    "matched": 0,
+    "decoded": 0,
+    "written": 0,
+    "categorized": 0,
+    "dropped_conflict": 0,
+    "commodity_conflict": 0,
+    "category_mismatch": 0,
+}
+
+
+def _seed_card(db, mpn: str) -> MaterialCard:
+    card = MaterialCard(
+        normalized_mpn=mpn.lower(),
+        display_mpn=mpn,
+        enrichment_status="unenriched",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(card)
+    db.flush()
+    return card
+
+
+async def _fake_enrich_verified(card, db, **kw):
+    card.enrichment_status = MaterialEnrichmentStatus.VERIFIED
+    return MaterialEnrichmentStatus.VERIFIED
+
+
+def _run(db_session, fru_mock, enrich=_fake_enrich_verified, decode_mock=None, desc_mock=None, spec_mock=None):
+    cfg = EnrichmentWorkerConfig(batch_size=5, web_daily_cap=80)
+    breaker = EnrichmentCircuitBreaker(cfg)
+    decode_mock = decode_mock or Mock(return_value={"decoded": 0, "written": 0, "categorized": 0})
+    desc_mock = desc_mock or Mock(return_value={"parsed": 0, "written": 0, "failed": 0})
+    spec_mock = spec_mock or AsyncMock(return_value={"cards_processed": 1, "specs_written": 1})
+    with (
+        patch("app.services.enrichment_worker.worker.enrich_card", side_effect=enrich),
+        patch("app.services.enrichment_worker.worker._connectors_in_order", return_value=[]),
+        patch("app.services.enrichment_worker.worker.intel_cache.get_cached", return_value=None),
+        patch("app.services.enrichment_worker.worker.intel_cache.set_cached"),
+        patch("app.services.mpn_decoder.writer.decode_and_record_specs", decode_mock),
+        patch("app.services.fru_crosswalk_enrich.crosswalk_and_record_specs", fru_mock),
+        patch("app.services.desc_extractor.writer.extract_and_record_specs", desc_mock),
+        patch("app.services.spec_enrichment_service.enrich_card_specs", spec_mock),
+    ):
+        return asyncio.run(run_one_batch(db_session, cfg, {}, breaker, set(), {"web_calls": 0}))
+
+
+def test_crosswalk_gated_by_settings_flag(db_session, monkeypatch):
+    from app.config import settings
+
+    _seed_card(db_session, "00AJ141")
+    monkeypatch.setattr(settings, "fru_crosswalk_enrich_enabled", False)
+    fru_mock = Mock(return_value=dict(_FRU_ZERO))
+
+    _run(db_session, fru_mock)
+
+    fru_mock.assert_not_called()
+
+
+def test_not_found_card_still_receives_crosswalk(db_session):
+    # D6: scope is the FULL batch, not enriched_ids — a FRU spare PN that every
+    # connector misses (not_found) is precisely this feature's primary target.
+    card = _seed_card(db_session, "00AJ141")
+
+    async def fake_not_found(c, db, **kw):
+        c.enrichment_status = MaterialEnrichmentStatus.NOT_FOUND
+        return MaterialEnrichmentStatus.NOT_FOUND
+
+    fru_mock = Mock(return_value=dict(_FRU_ZERO))
+    desc_mock = Mock(return_value={"parsed": 0, "written": 0, "failed": 0})
+
+    _run(db_session, fru_mock, enrich=fake_not_found, desc_mock=desc_mock)
+
+    fru_mock.assert_called_once()
+    assert fru_mock.call_args.args[1] == [card.id]
+    assert card.enrichment_status == MaterialEnrichmentStatus.NOT_FOUND  # status untouched by the pass
+    desc_mock.assert_not_called()  # desc-parse still gates on enriched_ids
+
+
+def test_crosswalk_receives_full_batch_ids(db_session):
+    cards = [_seed_card(db_session, f"00AJ14{i}") for i in range(3)]
+    fru_mock = Mock(return_value=dict(_FRU_ZERO))
+
+    _run(db_session, fru_mock)
+
+    # select_batch orders by created_at DESC — compare membership, not order.
+    assert sorted(fru_mock.call_args.args[1]) == sorted(c.id for c in cards)
+
+
+def test_passes_run_decode_then_crosswalk_then_desc_then_ai(db_session):
+    # D6 ordering IS the confidence tiering: 0.95 decode, 0.93 crosswalk, 0.90 desc,
+    # 0.85 AI.
+    _seed_card(db_session, "00AJ141")
+    order: list[str] = []
+    decode_mock = Mock(
+        side_effect=lambda *a, **k: order.append("decode") or {"decoded": 0, "written": 0, "categorized": 0}
+    )
+    fru_mock = Mock(side_effect=lambda *a, **k: order.append("crosswalk") or dict(_FRU_ZERO))
+    desc_mock = Mock(side_effect=lambda *a, **k: order.append("desc") or {"parsed": 0, "written": 0, "failed": 0})
+
+    async def ai(*a, **k):
+        order.append("ai")
+        return {"cards_processed": 0, "specs_written": 0}
+
+    _run(db_session, fru_mock, decode_mock=decode_mock, desc_mock=desc_mock, spec_mock=ai)
+
+    assert order == ["decode", "crosswalk", "desc", "ai"]
+
+
+def test_crosswalk_failure_does_not_crash_batch(db_session):
+    # A crosswalk exception is logged; desc-parse and the AI pass still run, and the
+    # batch still commits.
+    _seed_card(db_session, "00AJ141")
+    fru_mock = Mock(side_effect=RuntimeError("boom"))
+    desc_mock = Mock(return_value={"parsed": 0, "written": 0, "failed": 0})
+    spec_mock = AsyncMock(return_value={"cards_processed": 1, "specs_written": 0})
+
+    counts = _run(db_session, fru_mock, desc_mock=desc_mock, spec_mock=spec_mock)
+
+    fru_mock.assert_called_once()
+    desc_mock.assert_called_once()
+    spec_mock.assert_awaited_once()
+    assert counts.get(MaterialEnrichmentStatus.VERIFIED, 0) == 1

--- a/tests/test_fru_crosswalk_worker.py
+++ b/tests/test_fru_crosswalk_worker.py
@@ -17,6 +17,7 @@ _FRU_ZERO = {
     "decoded": 0,
     "written": 0,
     "categorized": 0,
+    "failed": 0,
     "dropped_conflict": 0,
     "commodity_conflict": 0,
     "category_mismatch": 0,
@@ -72,7 +73,7 @@ def test_crosswalk_gated_by_settings_flag(db_session, monkeypatch):
 
 
 def test_not_found_card_still_receives_crosswalk(db_session):
-    # D6: scope is the FULL batch, not enriched_ids — a FRU spare PN that every
+    # Scope is the FULL batch, not enriched_ids — a FRU spare PN that every
     # connector misses (not_found) is precisely this feature's primary target.
     card = _seed_card(db_session, "00AJ141")
 
@@ -102,8 +103,8 @@ def test_crosswalk_receives_full_batch_ids(db_session):
 
 
 def test_passes_run_decode_then_crosswalk_then_desc_then_ai(db_session):
-    # D6 ordering IS the confidence tiering: 0.95 decode, 0.93 crosswalk, 0.90 desc,
-    # 0.85 AI.
+    # The pass ordering IS the confidence tiering: 0.95 decode, 0.93 crosswalk,
+    # 0.90 desc, 0.85 AI.
     _seed_card(db_session, "00AJ141")
     order: list[str] = []
     decode_mock = Mock(

--- a/tests/test_fru_crosswalk_writer.py
+++ b/tests/test_fru_crosswalk_writer.py
@@ -1,0 +1,312 @@
+"""Writer — crosswalk_and_record_specs: FRU cards inherit the strict-intersected decode
+of their approved mfg_model links via record_spec (source="fru_matrix_decode",
+confidence 0.93), with the category fill / mismatch-skip / savepoint / single-query
+guarantees of the spec (D1–D5, D7, D9–D11)."""
+
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+from app.models import FruLink, MaterialCard, MaterialSpecFacet
+from app.services.commodity_registry import seed_commodity_schemas
+from app.services.fru_crosswalk_enrich import (
+    FRU_DECODE_CONFIDENCE,
+    FRU_DECODE_SOURCE,
+    crosswalk_and_record_specs,
+)
+from app.utils.normalization import normalize_mpn_key
+
+ZERO_STATS = {
+    "matched": 0,
+    "decoded": 0,
+    "written": 0,
+    "categorized": 0,
+    "dropped_conflict": 0,
+    "commodity_conflict": 0,
+    "category_mismatch": 0,
+}
+
+
+def _facets(db: Session, card_id: int) -> dict:
+    rows = db.query(MaterialSpecFacet).filter_by(material_card_id=card_id).all()
+    return {r.spec_key: (r.value_text if r.value_text is not None else r.value_numeric) for r in rows}
+
+
+def _card(db: Session, mpn: str, category: str | None = None, **kw) -> MaterialCard:
+    card = MaterialCard(normalized_mpn=mpn.lower(), display_mpn=mpn, category=category, **kw)
+    db.add(card)
+    db.flush()
+    return card
+
+
+def _link(
+    db: Session, fru: str, related: str, mfg: str | None = "Seagate", kind: str = "mfg_model", sheet: str = "Main"
+) -> FruLink:
+    link = FruLink(
+        fru_raw=fru,
+        fru_norm=normalize_mpn_key(fru),
+        related_raw=related,
+        related_norm=normalize_mpn_key(related),
+        rel_kind=kind,
+        manufacturer=mfg,
+        source_sheet=sheet,
+    )
+    db.add(link)
+    db.flush()
+    return link
+
+
+def test_writer_writes_intersected_specs_with_source_and_confidence(db_session: Session):
+    # Two approved substitutes that agree on form/usage but differ on capacity: the
+    # shared keys write at 0.93/"fru_matrix_decode", the conflicting key is dropped.
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category="hdd")
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    _link(db_session, "00AJ141", "ST8000NM0055")
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+    db_session.commit()
+
+    assert stats == {
+        "matched": 1,
+        "decoded": 1,
+        "written": 2,
+        "categorized": 0,
+        "dropped_conflict": 1,  # capacity_gb 4000 vs 8000
+        "commodity_conflict": 0,
+        "category_mismatch": 0,
+    }
+    f = _facets(db_session, card.id)
+    assert f == {"form_factor": '3.5"', "usage_class": "Enterprise / Datacenter"}
+    entry = card.specs_structured["form_factor"]
+    assert entry["source"] == FRU_DECODE_SOURCE == "fru_matrix_decode"
+    assert entry["confidence"] == FRU_DECODE_CONFIDENCE == 0.93
+
+
+def test_single_model_writes_all_specs_and_categorizes_null_category(db_session: Session):
+    # Intersection of one → all its specs write; a NULL-category FRU card is
+    # categorized from the agreed (regex-gated) commodity before the record_spec loop.
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category=None)
+    _link(db_session, "00AJ141", "ST4000NM0035")
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+    db_session.commit()
+
+    assert stats["matched"] == 1
+    assert stats["decoded"] == 1
+    assert stats["categorized"] == 1
+    assert stats["written"] == 3
+    assert card.category == "hdd"
+    f = _facets(db_session, card.id)
+    assert f["capacity_gb"] == 4000
+    assert f["form_factor"] == '3.5"'
+
+
+def test_category_mismatch_skips_card(db_session: Session):
+    # An existing category is authoritative — a dram card whose FRU links decode hdd
+    # gets NOTHING asserted (never overwritten, never written-around).
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category="dram")
+    _link(db_session, "00AJ141", "ST4000NM0035")
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+
+    assert stats["category_mismatch"] == 1
+    assert stats["written"] == 0
+    assert stats["categorized"] == 0
+    assert card.category == "dram"
+    assert _facets(db_session, card.id) == {}
+
+
+def test_commodity_conflict_skips_card(db_session: Session):
+    # Substitutes that can't agree on what they ARE (hdd vs ssd) → the card is
+    # skipped entirely; a NULL category is NOT filled from a conflicted decode.
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category=None)
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    _link(db_session, "00AJ141", "MZQL21T9HCJR", mfg="Samsung")
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+
+    assert stats["matched"] == 1
+    assert stats["decoded"] == 1
+    assert stats["commodity_conflict"] == 1
+    assert stats["written"] == 0
+    assert stats["categorized"] == 0
+    assert card.category is None
+    assert _facets(db_session, card.id) == {}
+
+
+def test_card_manufacturer_never_written(db_session: Session):
+    # D4: the FRU card keeps its IBM/Lenovo manufacturer context — the drive vendor on
+    # the link (Seagate) is display-only and never copied onto the card.
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category="hdd", manufacturer="IBM")
+    _link(db_session, "00AJ141", "ST4000NM0035", mfg="Seagate")
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+    db_session.commit()
+
+    assert stats["written"] == 3
+    assert card.manufacturer == "IBM"
+
+
+def test_confidence_guard_skips_higher_prior_overwrites_lower(db_session: Session):
+    # D7: a prior key held at confidence > 0.93 (mpn_decode 0.95) is skipped; a prior
+    # held lower (spec_extraction 0.85) is overwritten — record_spec alone is
+    # latest-write-wins, so this pre-gate is what keeps the decode baseline authoritative.
+    seed_commodity_schemas(db_session)
+    card = _card(
+        db_session,
+        "00AJ141",
+        category="hdd",
+        specs_structured={
+            "capacity_gb": {"value": 8000, "source": "mpn_decode", "confidence": 0.95, "updated_at": "x"},
+            "form_factor": {"value": '2.5"', "source": "spec_extraction", "confidence": 0.85, "updated_at": "x"},
+        },
+    )
+    _link(db_session, "00AJ141", "ST4000NM0035")
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+    db_session.commit()
+
+    assert stats["written"] == 2  # form_factor overwritten + usage_class fresh; capacity skipped
+    specs = card.specs_structured
+    assert specs["capacity_gb"] == {"value": 8000, "source": "mpn_decode", "confidence": 0.95, "updated_at": "x"}
+    assert specs["form_factor"]["value"] == '3.5"'
+    assert specs["form_factor"]["source"] == FRU_DECODE_SOURCE
+    assert specs["usage_class"]["source"] == FRU_DECODE_SOURCE
+
+
+def test_duplicate_links_across_sheets_decode_once(db_session: Session, monkeypatch):
+    # Cross-sheet duplicates of the same related model collapse into one decode call
+    # (the per-FRU link set), and the single-model intersection still writes.
+    import app.services.fru_crosswalk_enrich as mod
+
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category="hdd")
+    _link(db_session, "00AJ141", "ST4000NM0035", sheet="Main")
+    _link(db_session, "00AJ141", "ST4000NM0035", sheet="xSeries")
+
+    calls: list[str] = []
+    real_decode = mod.decode_mpn
+
+    def counting(mpn, manufacturer=None):
+        calls.append(mpn)
+        return real_decode(mpn, manufacturer)
+
+    monkeypatch.setattr(mod, "decode_mpn", counting)
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+
+    assert calls == ["ST4000NM0035"]
+    assert stats["written"] == 3
+    assert stats["dropped_conflict"] == 0
+
+
+def test_non_mfg_model_links_excluded(db_session: Session):
+    # D1: drive_pn (and every other rel_kind) is out of scope this wave — a FRU with
+    # only non-mfg_model links is not even "matched".
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category="hdd")
+    _link(db_session, "00AJ141", "ST4000NM0035", kind="drive_pn")
+    _link(db_session, "00AJ141", "00AJ144", mfg=None, kind="option")
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+
+    assert stats == ZERO_STATS
+    assert _facets(db_session, card.id) == {}
+
+
+def test_reverse_only_card_gets_nothing(db_session: Session):
+    # D5: a card whose norm matches only related_norm (it IS a mfg_model) inherits
+    # nothing — its own MPN already decodes directly via the mpn_decode pass.
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "ST4000NM0035", category="hdd")
+    _link(db_session, "00AJ141", "ST4000NM0035")
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+
+    assert stats == ZERO_STATS
+    assert _facets(db_session, card.id) == {}
+
+
+def test_no_link_batch_zero_stats_and_no_decode_calls(db_session: Session, monkeypatch):
+    import app.services.fru_crosswalk_enrich as mod
+
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "593553-001", category="hdd")
+
+    calls: list[str] = []
+    monkeypatch.setattr(mod, "decode_mpn", lambda mpn, manufacturer=None: calls.append(mpn))
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+
+    assert stats == ZERO_STATS
+    assert calls == []
+
+
+def test_savepoint_isolates_a_failing_card(db_session: Session, monkeypatch):
+    # D9: a record_spec failure on card 2 of 3 rolls back ONLY that card (including a
+    # categorize-from-null) without poisoning the shared transaction — siblings persist,
+    # the counters stay honest, and the session still commits.
+    import app.services.fru_crosswalk_enrich as mod
+
+    seed_commodity_schemas(db_session)
+    card1 = _card(db_session, "00AJ141", category=None)
+    bad = _card(db_session, "00AJ142", category=None)
+    card3 = _card(db_session, "00AJ143", category=None)
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    _link(db_session, "00AJ142", "ST8000NM0055")
+    _link(db_session, "00AJ143", "MZQL21T9HCJR", mfg="Samsung")
+
+    real_record_spec = mod.record_spec
+
+    def flaky(db, card_id, *args, **kwargs):
+        if card_id == bad.id:
+            db.flush()  # flush the pending categorize, then fail the way a DB error would
+            raise RuntimeError("simulated flush failure")
+        return real_record_spec(db, card_id, *args, **kwargs)
+
+    monkeypatch.setattr(mod, "record_spec", flaky)
+
+    stats = crosswalk_and_record_specs(db_session, [card1.id, bad.id, card3.id])
+    db_session.commit()  # must NOT raise — the bad card's savepoint kept the transaction clean
+
+    assert stats["matched"] == 3
+    assert stats["decoded"] == 2  # only the clean cards
+    assert stats["categorized"] == 2
+    assert stats["written"] == 6
+    assert _facets(db_session, card1.id)["capacity_gb"] == 4000
+    assert _facets(db_session, card3.id)["capacity_gb"] == 1920
+    assert _facets(db_session, bad.id) == {}  # bad card fully rolled back
+    assert bad.category is None  # categorize-from-null did NOT leak past the rollback
+
+
+def test_links_resolved_via_exactly_one_select(db_session: Session):
+    # D10: the whole batch resolves its links through ONE fru_links SELECT — no N+1.
+    engine = db_session.get_bind()
+
+    seed_commodity_schemas(db_session)
+    cards = []
+    for i, (fru, model) in enumerate(
+        [("00AJ141", "ST4000NM0035"), ("00AJ142", "ST8000NM0055"), ("00AJ143", "MZQL21T9HCJR")]
+    ):
+        cards.append(_card(db_session, fru, category=None))
+        _link(db_session, fru, model, mfg="Samsung" if i == 2 else "Seagate")
+
+    fru_link_selects: list[str] = []
+
+    def counter(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT") and "fru_links" in statement:
+            fru_link_selects.append(statement)
+
+    event.listen(engine, "before_cursor_execute", counter)
+    try:
+        stats = crosswalk_and_record_specs(db_session, [c.id for c in cards])
+    finally:
+        event.remove(engine, "before_cursor_execute", counter)
+
+    assert len(fru_link_selects) == 1, fru_link_selects
+    assert stats["matched"] == 3
+    assert stats["written"] == 9

--- a/tests/test_fru_crosswalk_writer.py
+++ b/tests/test_fru_crosswalk_writer.py
@@ -1,7 +1,7 @@
 """Writer — crosswalk_and_record_specs: FRU cards inherit the strict-intersected decode
 of their approved mfg_model links via record_spec (source="fru_matrix_decode",
-confidence 0.93), with the category fill / mismatch-skip / savepoint / single-query
-guarantees of the spec (D1–D5, D7, D9–D11)."""
+confidence 0.93), with the category fill / mismatch-skip / per-FRU + per-card isolation
+/ single-query guarantees stated inline on each test."""
 
 from sqlalchemy import event
 from sqlalchemy.orm import Session
@@ -20,6 +20,7 @@ ZERO_STATS = {
     "decoded": 0,
     "written": 0,
     "categorized": 0,
+    "failed": 0,
     "dropped_conflict": 0,
     "commodity_conflict": 0,
     "category_mismatch": 0,
@@ -71,6 +72,7 @@ def test_writer_writes_intersected_specs_with_source_and_confidence(db_session: 
         "decoded": 1,
         "written": 2,
         "categorized": 0,
+        "failed": 0,
         "dropped_conflict": 1,  # capacity_gb 4000 vs 8000
         "commodity_conflict": 0,
         "category_mismatch": 0,
@@ -138,7 +140,7 @@ def test_commodity_conflict_skips_card(db_session: Session):
 
 
 def test_card_manufacturer_never_written(db_session: Session):
-    # D4: the FRU card keeps its IBM/Lenovo manufacturer context — the drive vendor on
+    # The FRU card keeps its IBM/Lenovo manufacturer context — the drive vendor on
     # the link (Seagate) is display-only and never copied onto the card.
     seed_commodity_schemas(db_session)
     card = _card(db_session, "00AJ141", category="hdd", manufacturer="IBM")
@@ -152,7 +154,7 @@ def test_card_manufacturer_never_written(db_session: Session):
 
 
 def test_confidence_guard_skips_higher_prior_overwrites_lower(db_session: Session):
-    # D7: a prior key held at confidence > 0.93 (mpn_decode 0.95) is skipped; a prior
+    # A prior key held at confidence > 0.93 (mpn_decode 0.95) is skipped; a prior
     # held lower (spec_extraction 0.85) is overwritten — record_spec alone is
     # latest-write-wins, so this pre-gate is what keeps the decode baseline authoritative.
     seed_commodity_schemas(db_session)
@@ -205,7 +207,7 @@ def test_duplicate_links_across_sheets_decode_once(db_session: Session, monkeypa
 
 
 def test_non_mfg_model_links_excluded(db_session: Session):
-    # D1: drive_pn (and every other rel_kind) is out of scope this wave — a FRU with
+    # drive_pn (and every other rel_kind) is out of scope this wave — a FRU with
     # only non-mfg_model links is not even "matched".
     seed_commodity_schemas(db_session)
     card = _card(db_session, "00AJ141", category="hdd")
@@ -219,7 +221,7 @@ def test_non_mfg_model_links_excluded(db_session: Session):
 
 
 def test_reverse_only_card_gets_nothing(db_session: Session):
-    # D5: a card whose norm matches only related_norm (it IS a mfg_model) inherits
+    # A card whose norm matches only related_norm (it IS a mfg_model) inherits
     # nothing — its own MPN already decodes directly via the mpn_decode pass.
     seed_commodity_schemas(db_session)
     card = _card(db_session, "ST4000NM0035", category="hdd")
@@ -247,7 +249,7 @@ def test_no_link_batch_zero_stats_and_no_decode_calls(db_session: Session, monke
 
 
 def test_savepoint_isolates_a_failing_card(db_session: Session, monkeypatch):
-    # D9: a record_spec failure on card 2 of 3 rolls back ONLY that card (including a
+    # A record_spec failure on card 2 of 3 rolls back ONLY that card (including a
     # categorize-from-null) without poisoning the shared transaction — siblings persist,
     # the counters stay honest, and the session still commits.
     import app.services.fru_crosswalk_enrich as mod
@@ -275,6 +277,7 @@ def test_savepoint_isolates_a_failing_card(db_session: Session, monkeypatch):
 
     assert stats["matched"] == 3
     assert stats["decoded"] == 2  # only the clean cards
+    assert stats["failed"] == 1  # the rolled-back card surfaces in the aggregate
     assert stats["categorized"] == 2
     assert stats["written"] == 6
     assert _facets(db_session, card1.id)["capacity_gb"] == 4000
@@ -284,7 +287,7 @@ def test_savepoint_isolates_a_failing_card(db_session: Session, monkeypatch):
 
 
 def test_links_resolved_via_exactly_one_select(db_session: Session):
-    # D10: the whole batch resolves its links through ONE fru_links SELECT — no N+1.
+    # The whole batch resolves its links through ONE fru_links SELECT — no N+1.
     engine = db_session.get_bind()
 
     seed_commodity_schemas(db_session)
@@ -310,3 +313,178 @@ def test_links_resolved_via_exactly_one_select(db_session: Session):
     assert len(fru_link_selects) == 1, fru_link_selects
     assert stats["matched"] == 3
     assert stats["written"] == 9
+
+
+def test_single_survivor_passthrough_with_undecodable_sibling(db_session: Session):
+    # FRU matrices routinely link models outside the storage/ssd/memory decoder
+    # registry. Undecodable links contribute NO evidence — they are filtered, not
+    # treated as conflicts — so when exactly one link decodes, ALL of its specs pass
+    # through at 0.93: one-of-N agreement is the contract, not all-of-N.
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category="hdd")
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    _link(db_session, "00AJ141", "00AJ144X", mfg="IBM")  # outside the decoder registry
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+    db_session.commit()
+
+    assert stats["matched"] == 1
+    assert stats["decoded"] == 1
+    assert stats["written"] == 3
+    assert stats["commodity_conflict"] == 0
+    assert stats["failed"] == 0
+    f = _facets(db_session, card.id)
+    assert f == {"capacity_gb": 4000, "form_factor": '3.5"', "usage_class": "Enterprise / Datacenter"}
+    assert card.specs_structured["capacity_gb"]["source"] == FRU_DECODE_SOURCE
+
+
+def test_all_links_undecodable_is_a_no_evidence_noop(db_session: Session):
+    # The sibling branch: EVERY link is outside the decoder registry → the card is
+    # matched but never decoded, nothing is asserted, and the no-evidence FRU is NOT
+    # misreported as a commodity conflict.
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category=None)
+    _link(db_session, "00AJ141", "00AJ144X", mfg="IBM")
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+
+    assert stats["matched"] == 1
+    assert stats["decoded"] == 0
+    assert stats["written"] == 0
+    assert stats["commodity_conflict"] == 0
+    assert stats["failed"] == 0
+    assert card.category is None
+    assert _facets(db_session, card.id) == {}
+
+
+def test_cards_sharing_one_normalized_key_all_enriched(db_session: Session, monkeypatch):
+    # key_to_card_ids is a dict of LISTS: dash/spacing MPN variants collapse to one
+    # normalized key, and EVERY card on that key receives the FRU's agreed specs
+    # while each unique model decodes exactly once. The intersection (and its
+    # dropped-keys count) is computed once per FRU — the conflicting capacity key
+    # reports dropped_conflict=1, not once per card sharing the key.
+    import app.services.fru_crosswalk_enrich as mod
+
+    seed_commodity_schemas(db_session)
+    card_a = _card(db_session, "00AJ141", category="hdd")
+    card_b = _card(db_session, "00-AJ-141", category="hdd")
+    assert normalize_mpn_key(card_a.normalized_mpn) == normalize_mpn_key(card_b.normalized_mpn)
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    _link(db_session, "00AJ141", "ST8000NM0055")
+
+    calls: list[str] = []
+    real_decode = mod.decode_mpn
+
+    def counting(mpn, manufacturer=None):
+        calls.append(mpn)
+        return real_decode(mpn, manufacturer)
+
+    monkeypatch.setattr(mod, "decode_mpn", counting)
+
+    stats = crosswalk_and_record_specs(db_session, [card_a.id, card_b.id])
+    db_session.commit()
+
+    assert sorted(calls) == ["ST4000NM0035", "ST8000NM0055"]  # one decode per model, not per card
+    assert stats["matched"] == 2
+    assert stats["decoded"] == 2
+    assert stats["written"] == 4  # 2 agreed keys x 2 cards
+    assert stats["dropped_conflict"] == 1  # capacity conflict counted once per FRU, not per card
+    for card in (card_a, card_b):
+        assert _facets(db_session, card.id) == {"form_factor": '3.5"', "usage_class": "Enterprise / Datacenter"}
+
+
+def test_decode_exception_on_one_fru_does_not_abort_the_rest(db_session: Session, monkeypatch):
+    # decode/intersect runs per FRU OUTSIDE the per-card savepoint — a decoder
+    # exception on one weird workbook string must fail ONLY that FRU's cards
+    # (surfaced in `failed`), never the remaining FRUs or the stats dict.
+    import app.services.fru_crosswalk_enrich as mod
+
+    seed_commodity_schemas(db_session)
+    card1 = _card(db_session, "00AJ141", category="hdd")
+    card2 = _card(db_session, "00AJ142", category="hdd")
+    card3 = _card(db_session, "00AJ143", category="ssd")
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    _link(db_session, "00AJ142", "ST8000NM0055")
+    _link(db_session, "00AJ143", "MZQL21T9HCJR", mfg="Samsung")
+
+    real_decode = mod.decode_mpn
+
+    def exploding(mpn, manufacturer=None):
+        if mpn == "ST8000NM0055":
+            raise RuntimeError("simulated decoder failure")
+        return real_decode(mpn, manufacturer)
+
+    monkeypatch.setattr(mod, "decode_mpn", exploding)
+
+    stats = crosswalk_and_record_specs(db_session, [card1.id, card2.id, card3.id])
+    db_session.commit()  # the failing FRU must not poison the shared transaction
+
+    assert stats["matched"] == 3
+    assert stats["failed"] == 1  # every card on the raising FRU counts as failed
+    assert stats["decoded"] == 2
+    assert stats["written"] == 6
+    assert _facets(db_session, card1.id)["capacity_gb"] == 4000
+    assert _facets(db_session, card3.id)["capacity_gb"] == 1920
+    assert _facets(db_session, card2.id) == {}
+
+
+def test_writer_warns_when_crosswalk_key_has_no_schema(db_session: Session):
+    # record_spec drops a value with no commodity_spec_schemas row at DEBUG only
+    # (invisible at the production INFO level) — the crosswalk writer must surface
+    # the discard as an aggregate WARNING exactly like mpn_decoder's writer, or a
+    # post-deploy schema lag silently zeroes the pass (decoded=N, written=0 with no
+    # production-visible explanation).
+    from loguru import logger as loguru_logger
+
+    from app.models import CommoditySpecSchema
+
+    seed_commodity_schemas(db_session)
+    db_session.query(CommoditySpecSchema).filter_by(commodity="hdd", spec_key="usage_class").delete()
+    db_session.flush()
+    card = _card(db_session, "00AJ141", category="hdd")
+    _link(db_session, "00AJ141", "ST4000NM0035")
+
+    warnings: list[str] = []
+    sink_id = loguru_logger.add(lambda message: warnings.append(str(message)), level="WARNING")
+    try:
+        stats = crosswalk_and_record_specs(db_session, [card.id])
+    finally:
+        loguru_logger.remove(sink_id)
+    db_session.commit()
+
+    assert any("hdd.usage_class" in w and "dropped" in w for w in warnings), warnings
+    f = _facets(db_session, card.id)
+    assert "usage_class" not in f  # dropped (no schema)
+    assert f["capacity_gb"] == 4000  # sibling keys still written
+    assert stats["written"] == 2
+
+
+def test_writer_warns_when_enum_value_outside_live_schema(db_session: Session):
+    # record_spec's OTHER silent vocabulary drop: a schema row exists but the agreed
+    # value is not in its LIVE enum_values (a stale DB row after a failed/lagging
+    # reseed). The writer must surface this drop in the same aggregate WARNING as
+    # the no-schema case, mirroring mpn_decoder's writer.
+    from loguru import logger as loguru_logger
+
+    from app.models import CommoditySpecSchema
+
+    seed_commodity_schemas(db_session)
+    schema = db_session.query(CommoditySpecSchema).filter_by(commodity="hdd", spec_key="form_factor").one()
+    schema.enum_values = ['2.5"']  # simulate live-DB enum drift: 3.5" removed
+    db_session.flush()
+    card = _card(db_session, "00AJ141", category="hdd")
+    _link(db_session, "00AJ141", "ST4000NM0035")
+
+    warnings: list[str] = []
+    sink_id = loguru_logger.add(lambda message: warnings.append(str(message)), level="WARNING")
+    try:
+        stats = crosswalk_and_record_specs(db_session, [card.id])
+    finally:
+        loguru_logger.remove(sink_id)
+    db_session.commit()
+
+    assert any('hdd.form_factor=3.5"' in w and "dropped" in w for w in warnings), warnings
+    f = _facets(db_session, card.id)
+    assert "form_factor" not in f  # dropped (out-of-enum), exactly mirroring record_spec
+    assert f["capacity_gb"] == 4000  # sibling keys still written
+    assert stats["written"] == 2


### PR DESCRIPTION
## FRU crosswalk decode enrichment (wave 2)

New deterministic worker second-pass stage: for each batch card whose key-normalized MPN matches `fru_links.fru_norm`, decode that FRU's `rel_kind='mfg_model'` links with the existing pure MPN decoders (zero LLM, zero network), **strict-intersect** the results, and write the agreed specs onto the FRU card via `record_spec(source="fru_matrix_decode", confidence=0.93)`. An IBM FRU like `00AJ141` that no vendor decode gate matches now inherits the deterministic specs of its approved manufacturer models — TRIO's own ingested IBM/Lenovo crosswalk instead of PartSurfer scraping.

Implements `/root/source_ingest/analysis/SPEC_FRU_CROSSWALK_ENRICHMENT.md` exactly. Depends on #247 (desc_parse stage) and #248 (fru_links + fru_matrix_service), both on main.

### Decision summary (D1–D12)

- **D1 — Link scope: `mfg_model` only.** `drive_pn` (qual-list bare-drive PNs) excluded this wave — OEM-firmware suffix variants risk misreads; widening later is a one-line `rel_kind` filter change.
- **D2 — Strict intersection.** Distinct `related_raw` decode once (set); `None` decodes contribute no evidence. Commodity disagreement → card skipped entirely (`commodity_conflict`). Otherwise only keys present in **every** decode with **equal** values write; a key missing from any decode is dropped (absence ≠ agreement); differing values are dropped and counted (`dropped_conflict`). Single decode = intersection of one → all specs write.
- **D3 — Category fill only when NULL**, exactly mirroring `mpn_decoder/writer.py`: existing category that differs from the agreed commodity → card skipped (`category_mismatch`), never overwritten; empty category → set from the agreed commodity inside the per-card SAVEPOINT (`categorized`).
- **D4 — Manufacturer never written.** The FRU card keeps its IBM/Lenovo context; the drive vendor stays display-only on `fru_links.manufacturer` (test-asserted).
- **D5 — No reverse-direction writes.** A card matching only `related_norm` (it IS a mfg_model) gains nothing — its own MPN already decodes first-party at 0.95; inheriting from the FRU would mean inheriting from sibling models of other manufacturers.
- **D6 — Placement & scope.** Pipeline: `mpn_decode (0.95) → fru_crosswalk (0.93) → desc_parse (0.90) → AI spec pass (0.85)`. Scope is the **full batch ids** captured right after `select_batch` — NOT `enriched_ids` (FRU spares land `not_found` and never reach it). `enrichment_status` untouched.
- **D7 — Pre-SP2 overwrite guard.** Like #247's desc writer: skip any key whose prior `specs_structured` confidence > 0.93, keeping `mpn_decode` 0.95 and vendor-API values authoritative until SP2's ladder lands. `DecodeResult.confidence` (0.95) is deliberately ignored.
- **D8 — Flag.** `fru_crosswalk_enrich_enabled: bool = True` (env `FRU_CROSSWALK_ENRICH_ENABLED`), declared right after `desc_parse_enabled`.
- **D9 — SAVEPOINT per card** (`db.begin_nested()`), mirroring `mpn_decoder/writer.py`; counters increment only after a clean release; no commit — the batch commit persists everything together.
- **D10 — No N+1.** `db.get` per id (identity-map hits), one batched `fru_links` SELECT keyed by `normalize_mpn_key(card.normalized_mpn)`, decode+intersect once per FRU, one schema-cache load per commodity.
- **D11 — Stats/logging.** Returns `{matched, decoded, written, categorized, dropped_conflict, commodity_conflict, category_mismatch}`; writer logs one aggregate INFO when `written or categorized`; worker logs `ENRICH_WORKER: fru-crosswalk {stats}`.

### D12 — `spec_tiers.SOURCE_TIER` merge note (verbatim from the spec, NOT this PR)

> **D12 — `spec_tiers.SOURCE_TIER` merge note (NOT this PR).** The concurrent
> `feat/enrichment-sp2-provenance-ladder` branch replaces confidence-ordering with an
> integer tier ladder (`mpn_decode: 85`, `partsurfer: 80`, `spec_extraction: 60`). The
> prompt's "~93" is the confidence-scale slot; on SP2's integer scale the equivalent slot
> is **`"fru_matrix_decode": 84`** (and `"desc_parse": 83` for #247), preserving
> `mpn_decode > fru_matrix_decode > desc_parse > partsurfer > spec_extraction`. Whichever
> branch merges second adds the missing `SOURCE_TIER` entries plus a `test_spec_tiers.py`
> assertion of that relative order, and may then delete the D7 confidence guard (ladder
> supersedes it). Record this in both PR descriptions.

### Files

- `app/services/fru_crosswalk_enrich.py` — NEW: `FRU_DECODE_SOURCE`/`FRU_DECODE_CONFIDENCE`, pure `intersect_decodes`, `crosswalk_and_record_specs`
- `app/config.py` — `fru_crosswalk_enrich_enabled` flag
- `app/services/enrichment_worker/worker.py` — `batch_ids` capture + gated pass between mpn-decode and desc-parse
- `tests/test_fru_crosswalk_intersect.py` (7), `tests/test_fru_crosswalk_writer.py` (12), `tests/test_fru_crosswalk_worker.py` (5) — 24 new tests
- `docs/APP_MAP_INTERACTIONS.md` — worker second-pass ordering: stage 2 inserted (scoped tightly to that section), ladder renumbered
- `docs/APP_MAP_DATABASE.md` — `specs_structured` source vocabulary: `fru_matrix_decode` added

No model change, no migration, no template change.

### Tests

- 24 new tests (intersection units, writer behavior incl. savepoint isolation + single-SELECT statement-count guard, worker integration incl. flag gate, full-batch scope on a `not_found` card, decode→crosswalk→desc→AI ordering, failure isolation)
- Full suite: **15117 passed, 34 skipped, 1 xfailed** (`TESTING=1 pytest tests/ -q`)
- `pre-commit run --all-files` clean (ruff, ruff-format, mypy, docformatter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
