### PR TITLE
feat(desc extract): phase-2 grammars — PSU, displays, tape, GPU, motherboards + seed extensions

### DIFF
--- a/app/data/commodity_seeds.json
+++ b/app/data/commodity_seeds.json
@@ -1882,6 +1882,10 @@
       "data_type": "numeric",
       "unit": "in",
       "canonical_unit": "in",
+      "numeric_range": {
+        "min": 7,
+        "max": 86
+      },
       "sort_order": 2,
       "is_primary": true
     },
@@ -1900,7 +1904,11 @@
         "800x480",
         "1024x600",
         "1280x800",
-        "1920x1080"
+        "1920x1080",
+        "1366x768",
+        "1920x1200",
+        "2560x1440",
+        "3840x2160"
       ],
       "sort_order": 3
     },
@@ -1943,7 +1951,8 @@
         "LED RGB",
         "EL",
         "None",
-        "Reflective"
+        "Reflective",
+        "LED"
       ],
       "sort_order": 6
     },
@@ -3399,6 +3408,19 @@
         "8"
       ],
       "sort_order": 8
+    },
+    {
+      "spec_key": "board_type",
+      "display_name": "Board Type",
+      "data_type": "enum",
+      "enum_values": [
+        "System Board",
+        "Backplane",
+        "Riser",
+        "Daughter Board"
+      ],
+      "sort_order": 9,
+      "is_primary": true
     }
   ],
   "cpu": [
@@ -3463,6 +3485,10 @@
       "data_type": "numeric",
       "unit": "W",
       "canonical_unit": "W",
+      "numeric_range": {
+        "min": 30,
+        "max": 5000
+      },
       "sort_order": 1,
       "is_primary": true
     },
@@ -3577,6 +3603,10 @@
       "data_type": "numeric",
       "unit": "GB",
       "canonical_unit": "GB",
+      "numeric_range": {
+        "min": 1,
+        "max": 96
+      },
       "sort_order": 1,
       "is_primary": true
     },
@@ -4006,7 +4036,10 @@
         "TS1155",
         "TS1160",
         "DAT",
-        "AIT"
+        "AIT",
+        "LTO-3",
+        "LTO-4",
+        "TS1170"
       ],
       "sort_order": 1,
       "is_primary": true
@@ -4018,7 +4051,8 @@
       "enum_values": [
         "FC",
         "SAS",
-        "SCSI"
+        "SCSI",
+        "USB"
       ],
       "sort_order": 2,
       "is_primary": true

--- a/app/services/desc_extractor/__init__.py
+++ b/app/services/desc_extractor/__init__.py
@@ -27,7 +27,7 @@ are NEUTRAL — they fall through to body-token + hint arbitration instead.
 
 import re
 
-from app.services.desc_extractor._common import DESC_CONFIDENCE, SPEC_COMMODITIES, DescResult
+from app.services.desc_extractor._common import DESC_CONFIDENCE, SPEC_COMMODITIES, DescResult, SpecDict
 from app.services.desc_extractor.board import extract_board
 from app.services.desc_extractor.display import extract_display
 from app.services.desc_extractor.gpu import extract_gpu
@@ -76,6 +76,12 @@ _LEAD_MAP = {
     "AC ADAPTERS": "power_supplies",
     "LCD": "displays",
     "LCD PANEL": "displays",
+    # Packaging-suffixed display labels are mapped EXPLICITLY — _is_neutral_lead
+    # requires every label word to be neutral, so "LCD ASSY,"/"PNL KIT," would
+    # otherwise die foreign ("LCD"/"PNL" are commodity words, not packaging).
+    "LCD ASSY": "displays",
+    "PNL KIT": "displays",
+    "PANEL KIT": "displays",
     "PNL": "displays",
     "PANEL": "displays",
     "DISPLAY": "displays",
@@ -100,9 +106,13 @@ _FOREIGN = "__foreign__"
 # Leads that are packaging words or brand names, NOT commodity labels — treated as
 # *no lead* (fall through to body-token + hint arbitration) instead of FOREIGN.
 # Any "SPS…"-prefixed lead is neutral too ("SPS-PCA, NVIDIA Tesla V100 32GB Module"
-# must not die foreign), and so is a label whose LAST word is neutral ("SUPERMICRO
-# FRU," is brand+packaging). Phase-1 guards still hold behind a neutral lead: a
-# brand-led body mixing HDD+DIMM tokens hard-conflicts to None as before.
+# must not die foreign). A multi-word label is neutral only when EVERY word is
+# neutral ("SUPERMICRO FRU," is brand+packaging); a label mixing a foreign word
+# with packaging ("CBL ASSY,"/"DRIVE TRAY KIT,") stays FOREIGN — an accessory row
+# must never take the facets of the part it fits ("Cable Assy, for LCD 15.6" FHD
+# panel" describes the panel the cable serves, not the cable). Phase-1 guards
+# still hold behind a neutral lead: a brand-led body mixing HDD+DIMM tokens
+# hard-conflicts to None as before.
 _NEUTRAL_LEADS = frozenset(
     {
         # structural / packaging words
@@ -139,6 +149,7 @@ _NEUTRAL_LEADS = frozenset(
         "ZIPPY",
         "CISCO",
         "EMULEX",
+        "SUPERMICRO",
     }
 )
 
@@ -192,7 +203,12 @@ _BODY_TOKENS = (
 
 
 def _is_neutral_lead(label: str) -> bool:
-    return label.startswith("SPS") or label in _NEUTRAL_LEADS or label.rsplit(" ", 1)[-1] in _NEUTRAL_LEADS
+    if label.startswith("SPS"):
+        return True
+    # EVERY word must be neutral — a single-word check would miss "SUPERMICRO FRU",
+    # while any looser rule (e.g. last-word-only) re-opens the foreign-lead guard
+    # for accessory labels like "CBL ASSY,"/"DRIVE TRAY KIT,".
+    return all(word in _NEUTRAL_LEADS for word in label.split())
 
 
 def _lead_commodity(text: str) -> str | None:
@@ -247,9 +263,11 @@ def extract_desc(description: str, commodity_hint: str | None = None) -> DescRes
         # The HARD cross-family conflict is storage×dram only (both read bare-GB
         # capacity) — e.g. "Memory, 256GB, LiteOn SSD, M.2 2280" or a drive
         # description on a DIMM-categorized card. Never pick a side. gpu also reads
-        # GB but is defended inside the gpu module by the GPU-context-token guard,
-        # not here — a gpu-hinted card with body-only dram/hdd tokens routes gpu and
-        # then extracts nothing.
+        # GB but is defended inside the gpu module, not here: memory_gb requires a
+        # GPU-context token, and a DRAM-module body token without a gpu_family hit
+        # disqualifies it (a bare NVIDIA token on a DIMM row is not GB context) —
+        # so a gpu-hinted card with body-only dram/hdd tokens routes gpu and then
+        # extracts nothing.
         return None
 
     if hint:
@@ -269,6 +287,9 @@ def extract_desc(description: str, commodity_hint: str | None = None) -> DescRes
         # body tokens with no lead to arbitrate (e.g. both HDD and SSD).
         return None
 
+    # Every extractor returns the canonical _common.SpecDict (dict is invariant in
+    # its value type — a narrower per-module union would fail this dispatch).
+    specs: SpecDict
     if effective in ("hdd", "ssd"):
         specs = extract_storage(text, effective)
     elif effective == "dram":

--- a/app/services/desc_extractor/__init__.py
+++ b/app/services/desc_extractor/__init__.py
@@ -1,45 +1,60 @@
-"""Deterministic description→spec field extraction (storage + memory).
+"""Deterministic description→spec field extraction (storage, memory, PSU, displays,
+tape, GPU, motherboards).
 
 What: reads parametric specs straight out of TRIO's compact *human description*
       strings (part master + inventory sheets — e.g. ``HD, 450GB, 15KRPM, 3.5",
-      Fibre Channel``, ``Mem, 16GB DDR4 2Rx4 PC4-2400T RDIMM``) with NO network and
-      NO LLM — zero hallucination. Descriptions are the only parametric signal for
-      OEM/FRU cards whose spare numbers no MPN decoder recognizes. Extraction is
-      gated on an explicit commodity signal (the TRIO ``<Label>,`` lead, a
-      whole-word HDD/SSD/DIMM-grammar token, or the caller's commodity hint);
-      anything else returns None (never guessed). Extracted values map to the
-      seeded commodity_spec_schemas facet keys/enum values; record_spec
-      independently re-validates enum members and skips unseeded keys, while
-      numeric ranges are enforced only inside the extractors themselves.
+      Fibre Channel``, ``Mem, 16GB DDR4 2Rx4 PC4-2400T RDIMM``, ``PSU, 1460W
+      240V/200V AC Hot Swap``) with NO network and NO LLM — zero hallucination.
+      Descriptions are the only parametric signal for OEM/FRU cards whose spare
+      numbers no MPN decoder recognizes. Extraction is gated on an explicit
+      commodity signal (the TRIO ``<Label>,`` lead, a whole-word grammar token,
+      or the caller's commodity hint); anything else returns None (never
+      guessed). Extracted values map to the seeded commodity_spec_schemas facet
+      keys/enum values; record_spec independently re-validates enum members and
+      skips unseeded keys, while numeric ranges are enforced only inside the
+      extractors themselves.
 Called by: the enrichment worker's second pass via desc_extractor/writer.py
       (between the mpn-decode pass at 0.95 and the AI spec reader at 0.85).
-Depends on: desc_extractor.{_common,storage,memory} (pure functions).
+Depends on: desc_extractor.{_common,storage,memory,power,display,tape,gpu,board}
+      (pure functions).
 
 Coverage is deliberately CONSERVATIVE: a field is emitted only when the description
 grammar expresses it unambiguously; conflicting signals omit the key, a foreign
-commodity label (``Other,``/``Tray,``/``LCD,``…) suppresses extraction entirely.
+commodity label (``Other,``/``Tray,``/``Card,``/``Library,``…) suppresses extraction
+entirely. Packaging-word and brand leads (``ASSY,``/``FRU,``/``MSI,``/``SPS-…``)
+are NEUTRAL — they fall through to body-token + hint arbitration instead.
 """
 
 import re
 
 from app.services.desc_extractor._common import DESC_CONFIDENCE, SPEC_COMMODITIES, DescResult
+from app.services.desc_extractor.board import extract_board
+from app.services.desc_extractor.display import extract_display
+from app.services.desc_extractor.gpu import extract_gpu
 from app.services.desc_extractor.memory import extract_memory
+from app.services.desc_extractor.power import extract_psu
 from app.services.desc_extractor.storage import extract_storage
+from app.services.desc_extractor.tape import extract_tape
 
 _FAMILY = {
     "hdd": "storage",
     "ssd": "storage",
     "dram": "dram",
-    "motherboards": "other",
-    "power_supplies": "other",
+    "motherboards": "board",
+    "power_supplies": "power",
+    "displays": "display",
+    "tape_drives": "tape",
+    "gpu": "gpu",
     "cpu": "other",
 }
 
 # TRIO part-master grammar is "<Commodity label>, <details>, <OEM>". A leading label
-# we don't handle ("Other", "Tray", "LCD", "Card", …) means TRIO classified the part
-# as something else — extraction is suppressed even if drive tokens appear later
+# we don't handle ("Other", "Tray", "Card", "Library", …) means TRIO classified the
+# part as something else — extraction is suppressed even if drive tokens appear later
 # ("Other, 3.5\" Server HDD Hard Drive tray"). Labels are pure alpha (so "DDR2," or
-# "MC2X3-3.3," fall through to the body scan instead).
+# "MC2X3-3.3," fall through to the body scan instead). "CARD," stays FOREIGN — the
+# corpus GC bucket is heavily contaminated (only ~38% of "Card," rows are real GPUs:
+# "Card, PCI-X Quad Channel Ultra4 Controller", "Card, Adapter Card, ConnectX-6").
 _LEAD = re.compile(r"^([A-Z][A-Z /.&-]{0,30}?)\s*[,<]")
 _LEAD_MAP = {
     "HD": "hdd",
@@ -47,48 +62,152 @@ _LEAD_MAP = {
     "SSD": "ssd",
     "MB": "motherboards",
     "MAIN BOARD": "motherboards",
+    "MAINBOARD": "motherboards",
     "MOTHERBOARD": "motherboards",
+    "BDPLANAR": "motherboards",
+    "BDPLANAR WIN": "motherboards",
     "MEM": "dram",
     "MEMORY": "dram",
     "PSU": "power_supplies",
     "POWER SUPPLY": "power_supplies",
+    "PWR SPLY": "power_supplies",
+    "PWR SUPPLY": "power_supplies",
+    "AC ADAPTER": "power_supplies",
+    "AC ADAPTERS": "power_supplies",
+    "LCD": "displays",
+    "LCD PANEL": "displays",
+    "PNL": "displays",
+    "PANEL": "displays",
+    "DISPLAY": "displays",
+    "DSPLY": "displays",
+    "MONITOR": "displays",
+    "HU": "displays",  # HP display-unit lead: "HU, FHD AG LED UWVA 13 TS"
+    "TAPE": "tape_drives",
+    "TAPE DRIVE": "tape_drives",
+    "TD": "tape_drives",
+    "GPU": "gpu",
+    "GPU CARD": "gpu",
+    "GC": "gpu",
+    "GRAPHICS CARD": "gpu",
+    "GRAPHIC CARD": "gpu",
+    "VIDEO CARD": "gpu",
+    "VIDEO BOARD": "gpu",
     "CPU": "cpu",
     "PROCESSOR": "cpu",
 }
 _FOREIGN = "__foreign__"
 
-# Comma-less descriptions ("SSD 480GB 7mmH …", "MB C 82L3 WIN …"): the bare first
-# token routes only for the unambiguous labels (a bare leading "HD"/"Mem" without
-# the comma is too loose — those require the `<Label>,` form).
+# Leads that are packaging words or brand names, NOT commodity labels — treated as
+# *no lead* (fall through to body-token + hint arbitration) instead of FOREIGN.
+# Any "SPS…"-prefixed lead is neutral too ("SPS-PCA, NVIDIA Tesla V100 32GB Module"
+# must not die foreign), and so is a label whose LAST word is neutral ("SUPERMICRO
+# FRU," is brand+packaging). Phase-1 guards still hold behind a neutral lead: a
+# brand-led body mixing HDD+DIMM tokens hard-conflicts to None as before.
+_NEUTRAL_LEADS = frozenset(
+    {
+        # structural / packaging words
+        "ASSY",
+        "FRU",
+        "KIT",
+        "PCA",
+        "CRD",
+        "MODULE",
+        "SXM",
+        "SXM ASSY",
+        # brand names
+        "IBM",
+        "HP",
+        "HPE",
+        "DELL",
+        "LENOVO",
+        "ACER",
+        "ASUS",
+        "MSI",
+        "NVIDIA",
+        "INTEL",
+        "SAMSUNG",
+        "LG",
+        "SHARP",
+        "INNOLUX",
+        "AUO",
+        "BOE",
+        "TANDBERG",
+        "QUANTUM",
+        "DELTA",
+        "ACBEL",
+        "ASTEC",
+        "ZIPPY",
+        "CISCO",
+        "EMULEX",
+    }
+)
+
+# Comma-less descriptions ("SSD 480GB 7mmH …", "Tape LTO-9, FH" — the digit in
+# "LTO-9" blocks the lead regex): the bare first token routes only for the
+# unambiguous labels (a bare leading "HD"/"Mem" without the comma is too loose —
+# those require the `<Label>,` form).
 _FIRST_TOKEN_MAP = {
     "HDD": "hdd",
     "SSD": "ssd",
     "MB": "motherboards",
+    "BDPLANAR": "motherboards",
+    "MAINBOARD": "motherboards",
     "MEM": "dram",
     "MEMORY": "dram",
     "PSU": "power_supplies",
+    "LCD": "displays",
+    "PNL": "displays",
+    "DISPLAY": "displays",
+    "DSPLY": "displays",
+    "MONITOR": "displays",
+    "TAPE": "tape_drives",
+    "GPU": "gpu",
+    "GC": "gpu",
     "CPU": "cpu",
 }
 
 # Whole-word body tokens (word boundaries make "16MB", "20HD", "SODIMM bracket"-style
-# substrings safe). Order is irrelevant — all matches are collected.
+# substrings safe). Order is irrelevant — all matches are collected. GPU family words
+# (RTX/QUADRO/GTX…) are extractor-level vocabulary, NOT routing tokens — "SPS-MB DSC
+# GTX1050 4GB i7-7700HQ WIN" must stay a motherboard.
 _BODY_TOKENS = (
     ("hdd", re.compile(r"\bHDD\b|\bHARD DRIVE\b|\bHARD DISK\b")),
     ("ssd", re.compile(r"\bSSD\b")),
     ("dram", re.compile(r"\bMEMORY\b|\b(?:R|U|LR)DIMM\b|\bSO-?DIMM\b|\bDIMM\b|\bDDR(?:3L|[2345])?\b")),
-    ("motherboards", re.compile(r"\bMOTHERBOARD\b|\bMAIN BOARD\b|\bMB\b")),
-    ("power_supplies", re.compile(r"\bPOWER SUPPLY\b")),
+    (
+        "motherboards",
+        re.compile(r"\bMOTHERBOARD\b|\bMAIN BOARD\b|\bMB\b|\bMAINBOARD\b|\bBDPLANAR\b|\bPLANAR\b"),
+    ),
+    (
+        "power_supplies",
+        re.compile(r"\bPSU\b|\bP/S\b|POWER SUPPLY|POWERSUPPLY|PWR[ _]SPLY|PWR[ _]?SUPPLY|\bAC ADAPTER\b"),
+    ),
+    # NOT bare "PANEL" — too generic for a body token (lead-position only).
+    ("displays", re.compile(r"\bLCD\b|\bDISPLAY\b|\bDSPLY\b|\bMONITOR\b|\bPNL\b")),
+    # Covers glued "LTO9 CANIS" / "JAG6 DRIVE" generation tokens.
+    ("tape_drives", re.compile(r"\bLTO[- ]?\d\b|\bULTRIUM\b|TAPE DRIVE|\b3592\b|\bJAG ?\d\b")),
+    ("gpu", re.compile(r"\bGPU\b|\bGFX\b|\bGRPHC\b|GRAPHICS? CARD|GRAPHICS? BOARD")),
     ("cpu", re.compile(r"\bCPU\b|\bPROCESSOR\b")),
 )
 
 
+def _is_neutral_lead(label: str) -> bool:
+    return label.startswith("SPS") or label in _NEUTRAL_LEADS or label.rsplit(" ", 1)[-1] in _NEUTRAL_LEADS
+
+
 def _lead_commodity(text: str) -> str | None:
-    """Mapped commodity for a `<Label>,` lead, _FOREIGN for an unhandled label, else the
+    """Mapped commodity for a `<Label>,` lead, _FOREIGN for an unhandled label, None for
+    a NEUTRAL lead (packaging word / brand — body tokens + hint arbitrate), else the
     _FIRST_TOKEN_MAP commodity for an unambiguous comma-less first token (e.g. ``SSD
     480GB 7mmH …``), else None."""
     m = _LEAD.match(text)
     if m:
-        return _LEAD_MAP.get(m.group(1).strip(), _FOREIGN)
+        # Dot-strip normalization: "PSU., 750W TT ITIC, Acbel…" captures "PSU.".
+        label = m.group(1).strip().rstrip(".")
+        commodity = _LEAD_MAP.get(label)
+        if commodity:
+            return commodity
+        return None if _is_neutral_lead(label) else _FOREIGN
     first = re.match(r"([A-Z]+)\b", text)
     if first and first.group(1) in _FIRST_TOKEN_MAP:
         return _FIRST_TOKEN_MAP[first.group(1)]
@@ -100,9 +219,9 @@ def extract_desc(description: str, commodity_hint: str | None = None) -> DescRes
 
     ``commodity_hint`` is the caller's authoritative commodity (typically the card's
     existing category): it routes extraction even when the text carries no commodity
-    token, and a hint outside hdd/ssd/dram returns None (this extractor only speaks
-    storage and memory). The returned ``commodity`` is a HINT for callers — nothing
-    here ever writes a category.
+    token, and a hint outside SPEC_COMMODITIES (hdd/ssd/dram/power_supplies/displays/
+    tape_drives/gpu/motherboards) returns None. The returned ``commodity`` is a HINT
+    for callers — nothing here ever writes a category.
     """
     if not description:
         return None
@@ -125,14 +244,18 @@ def extract_desc(description: str, commodity_hint: str | None = None) -> DescRes
     if hint:
         families.add(_FAMILY[hint])
     if "storage" in families and "dram" in families:
-        # Cross-family conflict — e.g. "Memory, 256GB, LiteOn SSD, M.2 2280" or a
-        # drive description on a DIMM-categorized card. Never pick a side.
+        # The HARD cross-family conflict is storage×dram only (both read bare-GB
+        # capacity) — e.g. "Memory, 256GB, LiteOn SSD, M.2 2280" or a drive
+        # description on a DIMM-categorized card. Never pick a side. gpu also reads
+        # GB but is defended inside the gpu module by the GPU-context-token guard,
+        # not here — a gpu-hinted card with body-only dram/hdd tokens routes gpu and
+        # then extracts nothing.
         return None
 
     if hint:
         if lead and _FAMILY[lead] != _FAMILY[hint]:
-            # TRIO's own label contradicts the card category ("MB," lead on a
-            # dram-hinted card) — never extract from a contradicted description.
+            # TRIO's own label contradicts the card category ("MEMORY," lead on a
+            # gpu-hinted card) — never extract from a contradicted description.
             return None
         # The hint (card category) routes; a same-family lead refines it
         # ("SSD," lead on an hdd-hinted card routes the ssd vocabulary).
@@ -150,8 +273,18 @@ def extract_desc(description: str, commodity_hint: str | None = None) -> DescRes
         specs = extract_storage(text, effective)
     elif effective == "dram":
         specs = extract_memory(text)
+    elif effective == "power_supplies":
+        specs = extract_psu(text)
+    elif effective == "displays":
+        specs = extract_display(text)
+    elif effective == "tape_drives":
+        specs = extract_tape(text)
+    elif effective == "gpu":
+        specs = extract_gpu(text)
+    elif effective == "motherboards":
+        specs = extract_board(text)
     else:
-        specs = {}  # commodity hint only (motherboards / power_supplies / cpu)
+        specs = {}  # cpu — commodity hint only (the wattage-vs-TDP structural guard)
     return DescResult(commodity=effective, specs=specs, confidence=DESC_CONFIDENCE)
 
 

--- a/app/services/desc_extractor/_common.py
+++ b/app/services/desc_extractor/_common.py
@@ -8,7 +8,22 @@ Called by: app/services/desc_extractor/{__init__,storage,memory,power,display,
 Depends on: nothing (pure).
 """
 
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, field
+from typing import TypeVar
+
+_T = TypeVar("_T")
+
+
+def unique_or_none(values: AbstractSet[_T]) -> _T | None:
+    """The single member of *values*, or None when it is empty or holds a conflict.
+
+    The shared "unique-or-omit" rule every extractor applies: a facet is emitted only
+    when exactly one candidate survives, so conflicting signals omit the key rather than
+    guess (a wrong facet value is worse than a missing one).
+    """
+    return next(iter(values)) if len(values) == 1 else None
+
 
 # Canonical specs mapping — EVERY per-commodity extractor returns exactly this type.
 # dict is invariant in its value type, so a module returning a narrower union (e.g.

--- a/app/services/desc_extractor/_common.py
+++ b/app/services/desc_extractor/_common.py
@@ -1,12 +1,20 @@
 """Shared types + constants for the deterministic description→spec extractors.
 
-What: DescResult dataclass plus the source tag / confidence every desc-parsed spec is
-      written with (see record_spec).
-Called by: app/services/desc_extractor/{__init__,storage,memory,writer}.py.
+What: DescResult dataclass, the canonical SpecDict specs type every extractor
+      returns, plus the source tag / confidence every desc-parsed spec is written
+      with (see record_spec).
+Called by: app/services/desc_extractor/{__init__,storage,memory,power,display,
+      tape,gpu,board,writer}.py.
 Depends on: nothing (pure).
 """
 
 from dataclasses import dataclass, field
+
+# Canonical specs mapping — EVERY per-commodity extractor returns exactly this type.
+# dict is invariant in its value type, so a module returning a narrower union (e.g.
+# dict[str, str]) would fail the extract_desc dispatch under mypy; the shared alias
+# keeps all seven extractors and DescResult.specs in lockstep.
+SpecDict = dict[str, str | int | float | bool]
 
 # Source tag + confidence for everything this extractor writes (see record_spec).
 DESC_SOURCE = "desc_parse"
@@ -36,5 +44,5 @@ class DescResult:
     """
 
     commodity: str
-    specs: dict[str, str | int | float | bool] = field(default_factory=dict)
+    specs: SpecDict = field(default_factory=dict)
     confidence: float = DESC_CONFIDENCE

--- a/app/services/desc_extractor/_common.py
+++ b/app/services/desc_extractor/_common.py
@@ -15,9 +15,11 @@ DESC_CONFIDENCE = 0.90  # deterministic token grammar — sits between mpn_decod
 # vendor-API value, and the writer skips keys already held at higher confidence.
 
 # The only commodities the extractor fills specs for — single source of truth shared
-# by extract_desc (routing) and writer.py (card eligibility). Other inferred
-# commodities (motherboards/power_supplies/cpu) come back as a bare hint, empty specs.
-SPEC_COMMODITIES = frozenset({"hdd", "ssd", "dram"})
+# by extract_desc (routing) and writer.py (card eligibility / the spec'd _HANDLED
+# set). cpu stays hint-only (empty specs): keeping it OUT of this set is the
+# PSU-vs-CPU wattage guard — a `wattage` key can only ever be emitted on the
+# power_supplies route, so CPU "135W" TDP text is structurally unreachable.
+SPEC_COMMODITIES = frozenset({"hdd", "ssd", "dram", "power_supplies", "displays", "tape_drives", "gpu", "motherboards"})
 
 
 @dataclass
@@ -25,9 +27,10 @@ class DescResult:
     """Outcome of extracting one description string.
 
     ``commodity`` is the inferred commodity KEY hint (e.g. "hdd", "ssd", "dram",
-    "motherboards", "power_supplies", "cpu") for CALLERS to use — the extractor and
-    its writer never set a card's category from it. It is always set: when no
-    commodity can be established, extract_desc returns None instead of a DescResult.
+    "power_supplies", "displays", "tape_drives", "gpu", "motherboards", "cpu") for
+    CALLERS to use — the extractor and its writer never set a card's category from
+    it. It is always set: when no commodity can be established, extract_desc
+    returns None instead of a DescResult.
     ``specs`` maps seeded spec_key -> value (enum string / int / float / bool — bool
     only for boolean schemas like dram.ecc, exactly like mpn_decoder.DecodeResult).
     """

--- a/app/services/desc_extractor/board.py
+++ b/app/services/desc_extractor/board.py
@@ -7,7 +7,7 @@ What: reads the board type out of compact human board descriptions like
       re-validates enum members and skips unseeded keys. The drift guard in
       tests/test_desc_extractor_routing.py pins the vocabulary against the seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (SpecDict alias only) — pure functions.
+Depends on: _common (SpecDict alias + unique_or_none helper) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - board_type is a closed token→member map; multiple DISTINCT members ⇒ omit
@@ -24,7 +24,7 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 
 import re
 
-from app.services.desc_extractor._common import SpecDict
+from app.services.desc_extractor._common import SpecDict, unique_or_none
 
 # Canonical board_type enum strings — MUST match the motherboards entry in
 # app/data/commodity_seeds.json (drift-guarded).
@@ -47,7 +47,7 @@ _BOARD_PATTERNS = (
 def _board_type(text: str) -> str | None:
     """Seeded board_type member, or None (no token / conflicting members)."""
     members = {member for member, pattern in _BOARD_PATTERNS if pattern.search(text)}
-    return members.pop() if len(members) == 1 else None
+    return unique_or_none(members)
 
 
 def extract_board(text: str) -> SpecDict:

--- a/app/services/desc_extractor/board.py
+++ b/app/services/desc_extractor/board.py
@@ -1,0 +1,58 @@
+"""Deterministic motherboard description→spec extraction (TRIO inventory grammar).
+
+What: reads the board type out of compact human board descriptions like
+      ``MB, B82CD NOK A49120C UMA 4G32G`` or ``BDPLANAR WIN,i5-10210U,16G,9560,
+      yTPM2`` — NO network, NO LLM. Every emitted value is a seeded motherboards
+      enum member per app/data/commodity_seeds.json; record_spec independently
+      re-validates enum members and skips unseeded keys. The drift guard in
+      tests/test_desc_extractor_routing.py pins the vocabulary against the seeds.
+Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
+Depends on: _common (constants only) — pure functions.
+
+CONSERVATIVE by design (a wrong facet value is worse than a missing one):
+- board_type is a closed token→member map; multiple DISTINCT members ⇒ omit
+  ("MB, 7063-CR1 System backplane kit" is a kit, not one board — correct omit).
+- The bare MB token carries a lookbehind that kills spaced megabytes ("512 MB");
+  glued "512MB"/"36MB" never had a boundary. Mis-filed MB-bucket rows without a
+  board token ("Function Board C 82L7 IO", "TOUCHPAD", "HS 2TB 3.5") emit {}.
+- The route has no GB key at all, so dram-looking tokens in laptop-board specs
+  ("ASSY, MB DSC 1050 4GB i7-8750H HM370 WIN") are inert by construction.
+- NOT extracted: onboard_cpu_family (not seeded — phase-3 candidate with its own
+  seed), socket/chipset/ATX form_factor (≤0.4% corpus fill), laptop-vs-desktop
+  split (UMA/DSC/NBK are OEM-specific noise, not deterministic tokens).
+"""
+
+import re
+
+# Canonical board_type enum strings — MUST match the motherboards entry in
+# app/data/commodity_seeds.json (drift-guarded).
+SYSTEM_BOARD, BACKPLANE, RISER, DAUGHTER_BOARD = "System Board", "Backplane", "Riser", "Daughter Board"
+
+_BOARD_PATTERNS = (
+    (
+        SYSTEM_BOARD,
+        re.compile(
+            r"\bBDPLANAR\b|\bPLANAR\b|SYSTEM BOARD|\bMOTHERBOARD\b|\bMAINBOARD\b"
+            r"|\bMAIN BOARD\b|\bBD SYS\b|(?<![\d.] )\bMB\b"
+        ),
+    ),
+    (BACKPLANE, re.compile(r"\bBACKPLANE\b")),
+    (RISER, re.compile(r"\bRISER\b")),
+    (DAUGHTER_BOARD, re.compile(r"DAUGHTER\s?(?:CARD|BOARD)")),
+)
+
+
+def _board_type(text: str) -> str | None:
+    """Seeded board_type member, or None (no token / conflicting members)."""
+    members = {member for member, pattern in _BOARD_PATTERNS if pattern.search(text)}
+    return members.pop() if len(members) == 1 else None
+
+
+def extract_board(text: str) -> dict[str, str]:
+    """Extract motherboards specs from an upper-cased, whitespace-collapsed
+    description."""
+    specs: dict[str, str] = {}
+    board_type = _board_type(text)
+    if board_type is not None:
+        specs["board_type"] = board_type
+    return specs

--- a/app/services/desc_extractor/board.py
+++ b/app/services/desc_extractor/board.py
@@ -7,7 +7,7 @@ What: reads the board type out of compact human board descriptions like
       re-validates enum members and skips unseeded keys. The drift guard in
       tests/test_desc_extractor_routing.py pins the vocabulary against the seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (constants only) — pure functions.
+Depends on: _common (SpecDict alias only) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - board_type is a closed token→member map; multiple DISTINCT members ⇒ omit
@@ -23,6 +23,8 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 """
 
 import re
+
+from app.services.desc_extractor._common import SpecDict
 
 # Canonical board_type enum strings — MUST match the motherboards entry in
 # app/data/commodity_seeds.json (drift-guarded).
@@ -48,10 +50,10 @@ def _board_type(text: str) -> str | None:
     return members.pop() if len(members) == 1 else None
 
 
-def extract_board(text: str) -> dict[str, str]:
+def extract_board(text: str) -> SpecDict:
     """Extract motherboards specs from an upper-cased, whitespace-collapsed
     description."""
-    specs: dict[str, str] = {}
+    specs: SpecDict = {}
     board_type = _board_type(text)
     if board_type is not None:
         specs["board_type"] = board_type

--- a/app/services/desc_extractor/display.py
+++ b/app/services/desc_extractor/display.py
@@ -8,18 +8,25 @@ What: reads resolution / diagonal size / backlight out of compact human panel
       keys, but numeric ranges are enforced ONLY here — the drift guard in
       tests/test_desc_extractor_routing.py pins both against the seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (constants only) — pure functions.
+Depends on: _common (SpecDict alias only) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - resolution from named classes (HD/FHD/QHD/WUXGA/UHD/4K) and explicit WxH pixel
   pairs that are seeded members. ``HD+`` is excluded by ``(?!\\+)`` and ``WXGA``
   is deliberately unmapped (1280x800-vs-1366x768 ambiguity); glued tokens
-  ("FRUDummy14FHD", "FHDI") never match — the boundary kills them. Two DISTINCT
-  pixel values ⇒ omit (the same value from both grammars is fine).
-- diagonal_size only from an explicit inch mark (21.5" / 21.5-IN / 27inch) or a
-  decimal size immediately before a named resolution class ("15.6 FHD"); bare
-  integers ("HU, FHD … 13 TS") and width markers ("15.6W WXGA") are deliberate
-  misses. Candidates filtered to the seeded 7-86 range; unique-or-omit.
+  ("FRUDummy14FHD", "FHDI") never match — the boundary kills them. A named class
+  immediately before a camera word ("PANEL, W/HD CAMERA", "SPS-LCD BEZEL HD
+  WEBCAM", "AIO520 FHD CAM") describes the integrated camera, not the panel —
+  suppressed via lookahead. Two DISTINCT pixel values ⇒ omit (the same value
+  from both grammars is fine).
+- diagonal_size only from an explicit inch unit — quote marks (21.5"/21.5''), a
+  glued or hyphenated IN (23IN / 21.5-IN), or INCH(ES) — or a decimal size
+  immediately before a named resolution class ("15.6 FHD"). A bare SPACED "IN"
+  is the English preposition ("PANEL 15 IN STOCK", "19 IN RACK") and never
+  matches, and "N-IN-1" dock/multiplexer grammar is rejected by a trailing-digit
+  lookahead. Bare integers ("HU, FHD … 13 TS") and width markers ("15.6W WXGA")
+  are deliberate misses. Candidates filtered to the seeded 7-86 range;
+  unique-or-omit.
 - backlight: WLED (white LED) and bare LED on TRIO panels are the same white
   bucket — both map to the generic seeded "LED" member. Never emit the seeded
   "LED White"/"LED RGB" members from descriptions (white-vs-RGB is not
@@ -28,6 +35,8 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 """
 
 import re
+
+from app.services.desc_extractor._common import SpecDict
 
 # Canonical displays enum strings — MUST match the displays entry in
 # app/data/commodity_seeds.json (drift-guarded).
@@ -56,9 +65,15 @@ _RES_SEEDED = {
     "3840x2160",
 }
 
-_RES_NAMED = re.compile(r"\b(WUXGA|UHD|QHD|FHD|HD)(?!\+)\b|\b4K\b")
+# A named class that immediately precedes a camera word modifies the integrated
+# CAMERA, not the panel ("W/HD CAMERA", "HD WEBCAM", "FHD CAM") — suppressed.
+_NO_CAMERA = r"(?!\s?/?\s?(?:CAM(?:ERA)?|WEBCAM)\b)"
+_RES_NAMED = re.compile(r"\b(WUXGA|UHD|QHD|FHD|HD)(?!\+)\b" + _NO_CAMERA + r"|\b4K\b" + _NO_CAMERA)
 _RES_EXPLICIT = re.compile(r"\b(\d{3,4})\s?X\s?(\d{3,4})\b")
-_DIAG_INCH = re.compile(r"\b(\d{1,2}(?:\.\d{1,2})?)\s?(?:\"|''|[- ]?IN(?:CH(?:ES)?)?\b)")
+# Inch unit required: quotes, glued/hyphenated IN, or INCH(ES). A bare spaced "IN"
+# is the English preposition ("15 IN STOCK") — only the CH-suffixed form may be
+# spaced. The (?![- ]?\d) lookahead rejects "8-IN-1" dock/multiplexer grammar.
+_DIAG_INCH = re.compile(r"\b(\d{1,2}(?:\.\d{1,2})?)(?:\s?(?:\"|'')|\s?[- ]?INCH(?:ES)?\b(?![- ]?\d)|-?IN\b(?![- ]?\d))")
 _DIAG_BEFORE_RES = re.compile(r"\b(\d{1,2}\.\d)\s+(?=(?:FHD|UHD|QHD|WUXGA|HD)(?!\+)\b)")
 _BACKLIGHT = re.compile(r"\bW?LED\b")
 
@@ -88,9 +103,9 @@ def _diagonal_size(text: str) -> int | float | None:
     return int(value) if value.is_integer() else value
 
 
-def extract_display(text: str) -> dict[str, str | int | float]:
+def extract_display(text: str) -> SpecDict:
     """Extract displays specs from an upper-cased, whitespace-collapsed description."""
-    specs: dict[str, str | int | float] = {}
+    specs: SpecDict = {}
     resolution = _resolution(text)
     if resolution is not None:
         specs["resolution"] = resolution

--- a/app/services/desc_extractor/display.py
+++ b/app/services/desc_extractor/display.py
@@ -1,0 +1,102 @@
+"""Deterministic display/panel description→spec extraction (TRIO inventory grammar).
+
+What: reads resolution / diagonal size / backlight out of compact human panel
+      descriptions like ``PNL,15.6 FHD AG WLED SVA 45% 220neDP,INX`` or
+      ``LCD, 21.5", LG`` — NO network, NO LLM. Every emitted value is a seeded
+      displays enum member / in-range numeric per app/data/commodity_seeds.json;
+      record_spec independently re-validates enum members and skips unseeded
+      keys, but numeric ranges are enforced ONLY here — the drift guard in
+      tests/test_desc_extractor_routing.py pins both against the seeds.
+Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
+Depends on: _common (constants only) — pure functions.
+
+CONSERVATIVE by design (a wrong facet value is worse than a missing one):
+- resolution from named classes (HD/FHD/QHD/WUXGA/UHD/4K) and explicit WxH pixel
+  pairs that are seeded members. ``HD+`` is excluded by ``(?!\\+)`` and ``WXGA``
+  is deliberately unmapped (1280x800-vs-1366x768 ambiguity); glued tokens
+  ("FRUDummy14FHD", "FHDI") never match — the boundary kills them. Two DISTINCT
+  pixel values ⇒ omit (the same value from both grammars is fine).
+- diagonal_size only from an explicit inch mark (21.5" / 21.5-IN / 27inch) or a
+  decimal size immediately before a named resolution class ("15.6 FHD"); bare
+  integers ("HU, FHD … 13 TS") and width markers ("15.6W WXGA") are deliberate
+  misses. Candidates filtered to the seeded 7-86 range; unique-or-omit.
+- backlight: WLED (white LED) and bare LED on TRIO panels are the same white
+  bucket — both map to the generic seeded "LED" member. Never emit the seeded
+  "LED White"/"LED RGB" members from descriptions (white-vs-RGB is not
+  expressible from TRIO descs: the RGB in "…,WLED,250,RGB,…" is the color
+  interface). OLED never matches (no boundary inside); EL/CCFL unmapped.
+"""
+
+import re
+
+# Canonical displays enum strings — MUST match the displays entry in
+# app/data/commodity_seeds.json (drift-guarded).
+LED = "LED"
+_RES_BY_NAME = {
+    "WUXGA": "1920x1200",
+    "UHD": "3840x2160",
+    "4K": "3840x2160",
+    "QHD": "2560x1440",
+    "FHD": "1920x1080",
+    "HD": "1366x768",
+}
+# Seeded displays.resolution pixel members an explicit WxH token may emit
+# (3-4 digit pairs only — the 16x2/20x4 character formats are unreachable).
+_RES_SEEDED = {
+    "240x320",
+    "320x240",
+    "480x272",
+    "800x480",
+    "1024x600",
+    "1280x800",
+    "1920x1080",
+    "1366x768",
+    "1920x1200",
+    "2560x1440",
+    "3840x2160",
+}
+
+_RES_NAMED = re.compile(r"\b(WUXGA|UHD|QHD|FHD|HD)(?!\+)\b|\b4K\b")
+_RES_EXPLICIT = re.compile(r"\b(\d{3,4})\s?X\s?(\d{3,4})\b")
+_DIAG_INCH = re.compile(r"\b(\d{1,2}(?:\.\d{1,2})?)\s?(?:\"|''|[- ]?IN(?:CH(?:ES)?)?\b)")
+_DIAG_BEFORE_RES = re.compile(r"\b(\d{1,2}\.\d)\s+(?=(?:FHD|UHD|QHD|WUXGA|HD)(?!\+)\b)")
+_BACKLIGHT = re.compile(r"\bW?LED\b")
+
+# Seeded displays.diagonal_size numeric_range — the only range gate (record_spec
+# performs no numeric_range check); pinned against the seeds by the drift guard.
+_DIAG_MIN, _DIAG_MAX = 7, 86
+
+
+def _resolution(text: str) -> str | None:
+    """Distinct surviving seeded resolution member, or None (absent / conflict)."""
+    values = {_RES_BY_NAME[m.group(1) or "4K"] for m in _RES_NAMED.finditer(text)}
+    for m in _RES_EXPLICIT.finditer(text):
+        explicit = f"{m.group(1)}x{m.group(2)}"
+        if explicit in _RES_SEEDED:
+            values.add(explicit)
+    return values.pop() if len(values) == 1 else None
+
+
+def _diagonal_size(text: str) -> int | float | None:
+    """Distinct surviving diagonal-inch candidate in the seeded range, or None."""
+    values = {float(m.group(1)) for m in _DIAG_INCH.finditer(text)}
+    values |= {float(m.group(1)) for m in _DIAG_BEFORE_RES.finditer(text)}
+    values = {v for v in values if _DIAG_MIN <= v <= _DIAG_MAX}
+    if len(values) != 1:
+        return None
+    value = values.pop()
+    return int(value) if value.is_integer() else value
+
+
+def extract_display(text: str) -> dict[str, str | int | float]:
+    """Extract displays specs from an upper-cased, whitespace-collapsed description."""
+    specs: dict[str, str | int | float] = {}
+    resolution = _resolution(text)
+    if resolution is not None:
+        specs["resolution"] = resolution
+    diagonal = _diagonal_size(text)
+    if diagonal is not None:
+        specs["diagonal_size"] = diagonal
+    if _BACKLIGHT.search(text):
+        specs["backlight"] = LED
+    return specs

--- a/app/services/desc_extractor/display.py
+++ b/app/services/desc_extractor/display.py
@@ -8,7 +8,7 @@ What: reads resolution / diagonal size / backlight out of compact human panel
       keys, but numeric ranges are enforced ONLY here — the drift guard in
       tests/test_desc_extractor_routing.py pins both against the seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (SpecDict alias only) — pure functions.
+Depends on: _common (SpecDict alias + unique_or_none helper) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - resolution from named classes (HD/FHD/QHD/WUXGA/UHD/4K) and explicit WxH pixel
@@ -36,7 +36,7 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 
 import re
 
-from app.services.desc_extractor._common import SpecDict
+from app.services.desc_extractor._common import SpecDict, unique_or_none
 
 # Canonical displays enum strings — MUST match the displays entry in
 # app/data/commodity_seeds.json (drift-guarded).
@@ -89,7 +89,7 @@ def _resolution(text: str) -> str | None:
         explicit = f"{m.group(1)}x{m.group(2)}"
         if explicit in _RES_SEEDED:
             values.add(explicit)
-    return values.pop() if len(values) == 1 else None
+    return unique_or_none(values)
 
 
 def _diagonal_size(text: str) -> int | float | None:

--- a/app/services/desc_extractor/gpu.py
+++ b/app/services/desc_extractor/gpu.py
@@ -9,7 +9,7 @@ What: reads GPU family / memory size out of compact human graphics-card
       drift guard in tests/test_desc_extractor_routing.py pins both against the
       seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (SpecDict alias only) — pure functions.
+Depends on: _common (SpecDict alias + unique_or_none helper) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - gpu_family collects all marketing/chip tokens (Quadro, GeForce, GTX⇒GeForce,
@@ -41,7 +41,7 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 
 import re
 
-from app.services.desc_extractor._common import SpecDict
+from app.services.desc_extractor._common import SpecDict, unique_or_none
 
 # Canonical gpu_family enum strings — MUST match the gpu entry in
 # app/data/commodity_seeds.json (drift-guarded).
@@ -108,7 +108,7 @@ def _memory_gb(text: str) -> int | None:
         values.add(int(m.group(1)))
     values |= {int(m.group(1)) for m in _MEM_GLUED.finditer(text)}
     values = {v for v in values if _MEM_MIN <= v <= _MEM_MAX}
-    return values.pop() if len(values) == 1 else None
+    return unique_or_none(values)
 
 
 def extract_gpu(text: str) -> SpecDict:

--- a/app/services/desc_extractor/gpu.py
+++ b/app/services/desc_extractor/gpu.py
@@ -9,26 +9,39 @@ What: reads GPU family / memory size out of compact human graphics-card
       drift guard in tests/test_desc_extractor_routing.py pins both against the
       seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (constants only) — pure functions.
+Depends on: _common (SpecDict alias only) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - gpu_family collects all marketing/chip tokens (Quadro, GeForce, GTX⇒GeForce,
-  RTX, Tesla + datacenter chip list, Radeon (Pro), A-/H-series) and emits a
-  unique member or omits. Subsumption: an explicit GEFORCE token absorbs its own
-  GTX/RTX sub-brand tokens ("GeForce RTX/GTX …" is one family, not a conflict).
-  Architecture names (PASCAL spans Tesla AND Quadro) and bare models ("2080TI")
-  are deliberately unmapped.
+  RTX, Tesla + datacenter chip list incl. T4, Radeon (Pro), A-/H-series) and
+  emits a unique member or omits. Subsumption: an explicit GEFORCE token absorbs
+  its own GTX/RTX sub-brand tokens ("GeForce RTX/GTX …" is one family, not a
+  conflict). A-/H-series chip tokens reject hyphen-glued silicon steppings
+  ("N17M-Q3-A2", "GK104-400-A2") via a lookbehind — those mark a chip revision,
+  never an Ampere/Hopper card. Architecture names (PASCAL spans Tesla AND
+  Quadro) and bare models ("2080TI") are deliberately unmapped.
 - memory_gb REQUIRES a GPU-context token in the text (any family hit, or
   NVIDIA/NVD/GDDRx/HBMx) — this is the cross-commodity GB guard: "Emulex, 10GB,
   SFP+Mezza Card" and RAID flash-module rows inside the GC bucket emit nothing.
-  "100GbE"/"25GbE" NIC speeds never match (no boundary after GB); the glued
-  "…@6G/D6/DP/H" OEM grammar is decoded via its /D5|/D6 (GDDR) lookahead.
-  Candidates filtered to the seeded 1-96 range; unique-or-omit.
+  A bare context token is NOT enough when a DRAM-module token (DIMM/DDRx) is
+  present — "SODIMM 16GB DDR4 for NVIDIA DGX Station" is a DIMM whose GB
+  belongs to the module (an explicit family hit still unlocks memory_gb).
+  Speed/bandwidth defenses: "100GbE"/"25GbE" never match (no boundary after
+  GB); "608GB/S" bandwidth tokens are skipped explicitly via the trailing-"/S"
+  check (mirrors storage.py/memory.py — also kills decimal bandwidths like
+  "14.4GB/S" whose fractional digit would otherwise capture); and a NIC clause
+  (ConnectX/(Q)SFP/Ethernet/dual-port) disqualifies memory_gb outright —
+  NVIDIA-branded Mellanox adapters carry spaced "25Gb" link speeds that
+  uppercase into the GB shape. The glued "…@6G/D6/DP/H" OEM grammar is decoded
+  via its /D5|/D6 (GDDR) lookahead. Candidates filtered to the seeded 1-96
+  range; unique-or-omit.
 - NOT extracted: gpu_model free-text (not seeded), memory_type (phase 3),
   interface PCIe gen, tdp_watts.
 """
 
 import re
+
+from app.services.desc_extractor._common import SpecDict
 
 # Canonical gpu_family enum strings — MUST match the gpu entry in
 # app/data/commodity_seeds.json (drift-guarded).
@@ -38,11 +51,14 @@ A_SERIES, H_SERIES = "A-series", "H-series"
 
 _FAMILY_PATTERNS = (
     (QUADRO, re.compile(r"\bQUADRO\b")),
-    (TESLA, re.compile(r"\bTESLA\b|\b(?:V100|P100|P40|P4|K20X?|K40|K80|M40|M60)\b")),
+    (TESLA, re.compile(r"\bTESLA\b|\b(?:V100|P100|P40|P4|T4|K20X?|K40|K80|M40|M60)\b")),
     (RADEON_PRO, re.compile(r"RADEON PRO|\bFIREPRO\b")),
     (RADEON, re.compile(r"\bRADEON\b(?! PRO)|\bRX\d{3,4}\b")),
-    (A_SERIES, re.compile(r"\b(?:A100|A40|A30|A16|A10|A2)\b")),
-    (H_SERIES, re.compile(r"\b(?:H100|H200|H800)\b")),
+    # (?<![\w-]) rejects hyphen-glued silicon steppings ("N17M-Q3-A2",
+    # "GK104-400-A2") that a plain \b would accept — the corpus carries real
+    # "-A2"-stepped GeForce chip markings that are NOT Ampere cards.
+    (A_SERIES, re.compile(r"(?<![\w-])A(?:100|40|30|16|10|2)\b")),
+    (H_SERIES, re.compile(r"(?<![\w-])H(?:100|200|800)\b")),
 )
 _GEFORCE = re.compile(r"\bGEFORCE\b")
 # GTX/RTX hug their model digits in the corpus ("RTX3080", "GTX1660Super") — the
@@ -53,6 +69,15 @@ _RTX = re.compile(r"\bRTX(?=\d|\b)")
 _CONTEXT = re.compile(r"\bNVIDIA\b|\bNVD\b|\bGDDR\dX?\b|\bHBM\d?\b")
 _MEM_GB = re.compile(r"\b(\d{1,3})\s?GB\b")
 _MEM_GLUED = re.compile(r"\b(\d{1,2})G(?=/D[56])")
+# DRAM-module body tokens (mirrors the dram routing vocabulary in __init__.py):
+# a bare NVIDIA/GDDR context token must not unlock memory_gb on a DIMM row —
+# "SODIMM 16GB DDR4 for NVIDIA DGX Station" — the GB belongs to the module.
+# GDDR never matches (no boundary inside "GDDR4"). An explicit family hit wins.
+_DRAM_BODY = re.compile(r"\b(?:R|U|LR)DIMM\b|\bSO-?DIMM\b|\bDIMM\b|\bDDR(?:3L|[2345])?\b")
+# NIC clause: Mellanox adapters inside the GC bucket are NVIDIA-branded, and their
+# spaced "25Gb"/"56Gb" link speeds uppercase into the \bGB\b shape — any GB hit on
+# a row carrying NIC vocabulary is a link speed, never a VRAM size.
+_NIC_CLAUSE = re.compile(r"\bCONNECTX\b|\bQ?SFP\d*\b|\bETHERNET\b|\b(?:DUAL|SINGLE|QUAD)[- ]PORT\b")
 
 # Seeded gpu.memory_gb numeric_range — the only range gate (record_spec performs
 # no numeric_range check); pinned against the seeds by the drift guard.
@@ -76,21 +101,28 @@ def _family_members(text: str) -> set[str]:
 
 def _memory_gb(text: str) -> int | None:
     """Distinct surviving memory candidate in the seeded range, or None."""
-    values = {int(m.group(1)) for m in _MEM_GB.finditer(text)}
+    values: set[int] = set()
+    for m in _MEM_GB.finditer(text):
+        if text[m.end() : m.end() + 2] == "/S":
+            continue  # "608GB/S" is memory bandwidth, not a size (mirrors storage.py)
+        values.add(int(m.group(1)))
     values |= {int(m.group(1)) for m in _MEM_GLUED.finditer(text)}
     values = {v for v in values if _MEM_MIN <= v <= _MEM_MAX}
     return values.pop() if len(values) == 1 else None
 
 
-def extract_gpu(text: str) -> dict[str, str | int]:
+def extract_gpu(text: str) -> SpecDict:
     """Extract gpu specs from an upper-cased, whitespace-collapsed description."""
-    specs: dict[str, str | int] = {}
+    specs: SpecDict = {}
     members = _family_members(text)
     if len(members) == 1:
         specs["gpu_family"] = next(iter(members))
-    if members or _CONTEXT.search(text):
-        # A family token still counts as GB context when the family KEY was
-        # omitted for conflict — the description is provably about a GPU.
+    # A family token still counts as GB context when the family KEY was omitted
+    # for conflict — the description is provably about a GPU. A bare context
+    # token does NOT count on a DRAM-module row (the GB is the DIMM's), and a
+    # NIC clause disqualifies memory_gb outright (the GB is a link speed).
+    gb_context = bool(members) or bool(_CONTEXT.search(text) and not _DRAM_BODY.search(text))
+    if gb_context and not _NIC_CLAUSE.search(text):
         memory = _memory_gb(text)
         if memory is not None:
             specs["memory_gb"] = memory

--- a/app/services/desc_extractor/gpu.py
+++ b/app/services/desc_extractor/gpu.py
@@ -1,0 +1,97 @@
+"""Deterministic GPU description→spec extraction (TRIO inventory grammar).
+
+What: reads GPU family / memory size out of compact human graphics-card
+      descriptions like ``SPS-PCA, NVIDIA Tesla V100 32GB Module`` or
+      ``MSI, RTX3080, 10G/D6X/3DP/H`` — NO network, NO LLM. Every emitted value
+      is a seeded gpu enum member / in-range numeric per app/data/
+      commodity_seeds.json; record_spec independently re-validates enum members
+      and skips unseeded keys, but numeric ranges are enforced ONLY here — the
+      drift guard in tests/test_desc_extractor_routing.py pins both against the
+      seeds.
+Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
+Depends on: _common (constants only) — pure functions.
+
+CONSERVATIVE by design (a wrong facet value is worse than a missing one):
+- gpu_family collects all marketing/chip tokens (Quadro, GeForce, GTX⇒GeForce,
+  RTX, Tesla + datacenter chip list, Radeon (Pro), A-/H-series) and emits a
+  unique member or omits. Subsumption: an explicit GEFORCE token absorbs its own
+  GTX/RTX sub-brand tokens ("GeForce RTX/GTX …" is one family, not a conflict).
+  Architecture names (PASCAL spans Tesla AND Quadro) and bare models ("2080TI")
+  are deliberately unmapped.
+- memory_gb REQUIRES a GPU-context token in the text (any family hit, or
+  NVIDIA/NVD/GDDRx/HBMx) — this is the cross-commodity GB guard: "Emulex, 10GB,
+  SFP+Mezza Card" and RAID flash-module rows inside the GC bucket emit nothing.
+  "100GbE"/"25GbE" NIC speeds never match (no boundary after GB); the glued
+  "…@6G/D6/DP/H" OEM grammar is decoded via its /D5|/D6 (GDDR) lookahead.
+  Candidates filtered to the seeded 1-96 range; unique-or-omit.
+- NOT extracted: gpu_model free-text (not seeded), memory_type (phase 3),
+  interface PCIe gen, tdp_watts.
+"""
+
+import re
+
+# Canonical gpu_family enum strings — MUST match the gpu entry in
+# app/data/commodity_seeds.json (drift-guarded).
+GEFORCE, QUADRO, RTX = "GeForce", "Quadro", "RTX"
+RADEON, RADEON_PRO, TESLA = "Radeon", "Radeon Pro", "Tesla"
+A_SERIES, H_SERIES = "A-series", "H-series"
+
+_FAMILY_PATTERNS = (
+    (QUADRO, re.compile(r"\bQUADRO\b")),
+    (TESLA, re.compile(r"\bTESLA\b|\b(?:V100|P100|P40|P4|K20X?|K40|K80|M40|M60)\b")),
+    (RADEON_PRO, re.compile(r"RADEON PRO|\bFIREPRO\b")),
+    (RADEON, re.compile(r"\bRADEON\b(?! PRO)|\bRX\d{3,4}\b")),
+    (A_SERIES, re.compile(r"\b(?:A100|A40|A30|A16|A10|A2)\b")),
+    (H_SERIES, re.compile(r"\b(?:H100|H200|H800)\b")),
+)
+_GEFORCE = re.compile(r"\bGEFORCE\b")
+# GTX/RTX hug their model digits in the corpus ("RTX3080", "GTX1660Super") — the
+# lookahead accepts a glued digit OR a plain word boundary.
+_GTX = re.compile(r"\bGTX(?=\d|\b)")
+_RTX = re.compile(r"\bRTX(?=\d|\b)")
+
+_CONTEXT = re.compile(r"\bNVIDIA\b|\bNVD\b|\bGDDR\dX?\b|\bHBM\d?\b")
+_MEM_GB = re.compile(r"\b(\d{1,3})\s?GB\b")
+_MEM_GLUED = re.compile(r"\b(\d{1,2})G(?=/D[56])")
+
+# Seeded gpu.memory_gb numeric_range — the only range gate (record_spec performs
+# no numeric_range check); pinned against the seeds by the drift guard.
+_MEM_MIN, _MEM_MAX = 1, 96
+
+
+def _family_members(text: str) -> set[str]:
+    """All family members whose tokens appear (post-subsumption)."""
+    members = {member for member, pattern in _FAMILY_PATTERNS if pattern.search(text)}
+    if _GEFORCE.search(text):
+        # Explicit GEFORCE absorbs its GTX/RTX sub-brand tokens — "NVIDIA GeForce
+        # GTX"/"GeForce RTX 3080" is one family, not a GeForce-vs-RTX conflict.
+        members.add(GEFORCE)
+    else:
+        if _GTX.search(text):
+            members.add(GEFORCE)  # GTX is definitionally GeForce
+        if _RTX.search(text):
+            members.add(RTX)
+    return members
+
+
+def _memory_gb(text: str) -> int | None:
+    """Distinct surviving memory candidate in the seeded range, or None."""
+    values = {int(m.group(1)) for m in _MEM_GB.finditer(text)}
+    values |= {int(m.group(1)) for m in _MEM_GLUED.finditer(text)}
+    values = {v for v in values if _MEM_MIN <= v <= _MEM_MAX}
+    return values.pop() if len(values) == 1 else None
+
+
+def extract_gpu(text: str) -> dict[str, str | int]:
+    """Extract gpu specs from an upper-cased, whitespace-collapsed description."""
+    specs: dict[str, str | int] = {}
+    members = _family_members(text)
+    if len(members) == 1:
+        specs["gpu_family"] = next(iter(members))
+    if members or _CONTEXT.search(text):
+        # A family token still counts as GB context when the family KEY was
+        # omitted for conflict — the description is provably about a GPU.
+        memory = _memory_gb(text)
+        if memory is not None:
+            specs["memory_gb"] = memory
+    return specs

--- a/app/services/desc_extractor/memory.py
+++ b/app/services/desc_extractor/memory.py
@@ -8,7 +8,7 @@ What: reads capacity / DDR generation / speed / ECC / module form / rank out of
       enforced ONLY here (record_spec performs no numeric_range check) — the drift
       guard in tests/test_desc_extractor_routing.py pins both against the seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (SpecDict alias only) — pure functions.
+Depends on: _common (SpecDict alias + unique_or_none helper) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - capacity_gb requires an explicit GB/G token and the seeded 1-512 range (MB-era
@@ -30,7 +30,7 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 
 import re
 
-from app.services.desc_extractor._common import SpecDict
+from app.services.desc_extractor._common import SpecDict, unique_or_none
 
 # Canonical dram enum strings — MUST match the dram entry in app/data/commodity_seeds.json.
 RDIMM, LRDIMM, UDIMM, SODIMM, DIMM = "RDIMM", "LRDIMM", "UDIMM", "SO-DIMM", "DIMM"
@@ -70,7 +70,7 @@ def _capacity_gb(text: str) -> int | None:
         value = int(m.group(1))
         if _CAP_MIN <= value <= _CAP_MAX:
             values.add(value)
-    return values.pop() if len(values) == 1 else None
+    return unique_or_none(values)
 
 
 def _ddr_type(text: str) -> str | None:
@@ -78,7 +78,7 @@ def _ddr_type(text: str) -> str | None:
     generations |= {_PC_GEN[m.group(1)] for m in _PC_PREFIX.finditer(text)}
     if not generations and _DDR_BARE.search(text):
         generations.add("DDR")  # generation-less legacy "DDR-333MHz" grammar
-    return generations.pop() if len(generations) == 1 else None
+    return unique_or_none(generations)
 
 
 def _speed_mhz(text: str) -> int | None:
@@ -88,7 +88,7 @@ def _speed_mhz(text: str) -> int | None:
         if _SPEED_MIN <= value <= _SPEED_MAX:
             speeds.add(value)
     speeds |= {_PC4_SPEED[m.group(1)] for m in _PC4_SPEED_GRADE.finditer(text)}
-    return speeds.pop() if len(speeds) == 1 else None
+    return unique_or_none(speeds)
 
 
 def _form_factor(text: str) -> str | None:
@@ -108,13 +108,13 @@ def _ecc(text: str, form_factor: str | None) -> bool | None:
         signals.add(True)
     if form_factor in (RDIMM, LRDIMM):
         signals.add(True)  # registered / load-reduced modules are always ECC
-    return signals.pop() if len(signals) == 1 else None
+    return unique_or_none(signals)
 
 
 def _rank(text: str) -> str | None:
     ranks = {f"{m.group(1)}Rx{m.group(2)}" for m in _RANK.finditer(text)}
     ranks &= _RANK_VALID
-    return ranks.pop() if len(ranks) == 1 else None
+    return unique_or_none(ranks)
 
 
 def extract_memory(text: str) -> SpecDict:

--- a/app/services/desc_extractor/memory.py
+++ b/app/services/desc_extractor/memory.py
@@ -8,7 +8,7 @@ What: reads capacity / DDR generation / speed / ECC / module form / rank out of
       enforced ONLY here (record_spec performs no numeric_range check) — the drift
       guard in tests/test_desc_extractor_routing.py pins both against the seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (constants only) — pure functions.
+Depends on: _common (SpecDict alias only) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - capacity_gb requires an explicit GB/G token and the seeded 1-512 range (MB-era
@@ -29,6 +29,8 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 """
 
 import re
+
+from app.services.desc_extractor._common import SpecDict
 
 # Canonical dram enum strings — MUST match the dram entry in app/data/commodity_seeds.json.
 RDIMM, LRDIMM, UDIMM, SODIMM, DIMM = "RDIMM", "LRDIMM", "UDIMM", "SO-DIMM", "DIMM"
@@ -115,9 +117,9 @@ def _rank(text: str) -> str | None:
     return ranks.pop() if len(ranks) == 1 else None
 
 
-def extract_memory(text: str) -> dict[str, str | int | bool]:
+def extract_memory(text: str) -> SpecDict:
     """Extract dram specs from an upper-cased, whitespace-collapsed description."""
-    specs: dict[str, str | int | bool] = {}
+    specs: SpecDict = {}
     capacity = _capacity_gb(text)
     if capacity is not None:
         specs["capacity_gb"] = capacity

--- a/app/services/desc_extractor/power.py
+++ b/app/services/desc_extractor/power.py
@@ -1,0 +1,77 @@
+"""Deterministic power-supply description→spec extraction (TRIO inventory grammar).
+
+What: reads wattage / supply class out of compact human PSU descriptions like
+      ``PSU, 1460W 240V/200V AC Hot Swap for EN 62368-1`` or ``PWR SPLY,180W,BRZ,
+      D8,ACBL`` — NO network, NO LLM. Every emitted value is a seeded
+      power_supplies enum member / in-range numeric per app/data/
+      commodity_seeds.json; record_spec independently re-validates enum members
+      and skips unseeded keys, but numeric ranges are enforced ONLY here — the
+      drift guard in tests/test_desc_extractor_routing.py pins both against the
+      seeds.
+Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
+Depends on: _common (constants only) — pure functions.
+
+CONSERVATIVE by design (a wrong facet value is worse than a missing one):
+- wattage requires an explicit W/WATT(S) unit token with word boundaries, so
+  glued "250WENT17", VA ratings ("240VA"), VAC/VDC voltages and bare numbers
+  inside MPNs ("PA-1300-42") never match. Candidates are filtered to the seeded
+  30-5000 range; two DIFFERENT surviving values ⇒ omit. The wattage key only
+  exists on this route at all — CPU "135W" TDP descriptions are structurally
+  unreachable because extract_desc never dispatches cpu here.
+- psu_class maps explicit tokens to seeded members (hot-swap/redundant/N+1/
+  common-slot ⇒ Server/Redundant, AC adapter/charger ⇒ AC-DC (External/Adapter),
+  ATX, DC-DC). Multiple DISTINCT members ⇒ omit. A generic "Power Supply"
+  description deliberately emits NO psu_class — the commodity already says PSU,
+  so a generic member would carry zero filter information.
+"""
+
+import re
+
+# Canonical psu_class enum strings — MUST match the power_supplies entry in
+# app/data/commodity_seeds.json (drift-guarded).
+SERVER_REDUNDANT = "Server/Redundant"
+AC_DC_ADAPTER = "AC-DC (External/Adapter)"
+ATX_PC = "ATX/PC"
+DC_DC = "DC-DC Converter"
+
+_WATTS = re.compile(r"\b(\d{2,4})\s?(?:W|WATTS?)\b")
+
+# Seeded power_supplies.wattage numeric_range — the only range gate (record_spec
+# performs no numeric_range check); pinned against the seeds by the drift guard.
+_WATT_MIN, _WATT_MAX = 30, 5000
+
+_CLASS_PATTERNS = (
+    (
+        SERVER_REDUNDANT,
+        re.compile(r"HOT[- ]?SWAP|HOT[- ]?PLUG|REDUNDAN(?:T|CY)|\bN\+1\b|COMMON SLOT|SERVER POWER SUPPLY|SERVER PSU"),
+    ),
+    (AC_DC_ADAPTER, re.compile(r"\bAC ADAPTERS?\b|POWER ADAPTER|\bCHARGER\b")),
+    (ATX_PC, re.compile(r"\bATX\b")),
+    (DC_DC, re.compile(r"\bDC[-/ ]DC\b")),
+)
+
+
+def _wattage(text: str) -> int | None:
+    """Distinct surviving wattage candidate in the seeded range, or None."""
+    values = {int(m.group(1)) for m in _WATTS.finditer(text)}
+    values = {v for v in values if _WATT_MIN <= v <= _WATT_MAX}
+    return values.pop() if len(values) == 1 else None
+
+
+def _psu_class(text: str) -> str | None:
+    """Seeded psu_class member, or None (no token / conflicting members)."""
+    members = {member for member, pattern in _CLASS_PATTERNS if pattern.search(text)}
+    return members.pop() if len(members) == 1 else None
+
+
+def extract_psu(text: str) -> dict[str, str | int]:
+    """Extract power_supplies specs from an upper-cased, whitespace-collapsed
+    description."""
+    specs: dict[str, str | int] = {}
+    wattage = _wattage(text)
+    if wattage is not None:
+        specs["wattage"] = wattage
+    psu_class = _psu_class(text)
+    if psu_class is not None:
+        specs["psu_class"] = psu_class
+    return specs

--- a/app/services/desc_extractor/power.py
+++ b/app/services/desc_extractor/power.py
@@ -9,7 +9,7 @@ What: reads wattage / supply class out of compact human PSU descriptions like
       drift guard in tests/test_desc_extractor_routing.py pins both against the
       seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (SpecDict alias only) — pure functions.
+Depends on: _common (SpecDict alias + unique_or_none helper) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - wattage requires an explicit W/WATT(S) unit token with word boundaries, so
@@ -27,7 +27,7 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 
 import re
 
-from app.services.desc_extractor._common import SpecDict
+from app.services.desc_extractor._common import SpecDict, unique_or_none
 
 # Canonical psu_class enum strings — MUST match the power_supplies entry in
 # app/data/commodity_seeds.json (drift-guarded).
@@ -57,13 +57,13 @@ def _wattage(text: str) -> int | None:
     """Distinct surviving wattage candidate in the seeded range, or None."""
     values = {int(m.group(1)) for m in _WATTS.finditer(text)}
     values = {v for v in values if _WATT_MIN <= v <= _WATT_MAX}
-    return values.pop() if len(values) == 1 else None
+    return unique_or_none(values)
 
 
 def _psu_class(text: str) -> str | None:
     """Seeded psu_class member, or None (no token / conflicting members)."""
     members = {member for member, pattern in _CLASS_PATTERNS if pattern.search(text)}
-    return members.pop() if len(members) == 1 else None
+    return unique_or_none(members)
 
 
 def extract_psu(text: str) -> SpecDict:

--- a/app/services/desc_extractor/power.py
+++ b/app/services/desc_extractor/power.py
@@ -9,7 +9,7 @@ What: reads wattage / supply class out of compact human PSU descriptions like
       drift guard in tests/test_desc_extractor_routing.py pins both against the
       seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (constants only) — pure functions.
+Depends on: _common (SpecDict alias only) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - wattage requires an explicit W/WATT(S) unit token with word boundaries, so
@@ -26,6 +26,8 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 """
 
 import re
+
+from app.services.desc_extractor._common import SpecDict
 
 # Canonical psu_class enum strings — MUST match the power_supplies entry in
 # app/data/commodity_seeds.json (drift-guarded).
@@ -64,10 +66,10 @@ def _psu_class(text: str) -> str | None:
     return members.pop() if len(members) == 1 else None
 
 
-def extract_psu(text: str) -> dict[str, str | int]:
+def extract_psu(text: str) -> SpecDict:
     """Extract power_supplies specs from an upper-cased, whitespace-collapsed
     description."""
-    specs: dict[str, str | int] = {}
+    specs: SpecDict = {}
     wattage = _wattage(text)
     if wattage is not None:
         specs["wattage"] = wattage

--- a/app/services/desc_extractor/storage.py
+++ b/app/services/desc_extractor/storage.py
@@ -8,7 +8,7 @@ What: reads capacity / rpm / form factor / interface out of compact human drive
       skips unseeded keys (it performs no numeric_range check — capacity sanity
       lives in the link-speed exclusions here).
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (SpecDict alias only) — pure functions.
+Depends on: _common (SpecDict alias + unique_or_none helper) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - Capacity requires an explicit unit token (GB/G/TB). Link-speed tokens are excluded
@@ -30,7 +30,7 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 
 import re
 
-from app.services.desc_extractor._common import SpecDict
+from app.services.desc_extractor._common import SpecDict, unique_or_none
 
 # Canonical enum strings — MUST match the hdd/ssd entries in app/data/commodity_seeds.json.
 _FF_BY_VALUE = {"2.5": '2.5"', "3.5": '3.5"', "1.8": '1.8"'}
@@ -89,7 +89,7 @@ def _rpm(text: str) -> str | None:
     # Non-seeded values (a "20K" token, a stray numeric) are dropped, never emitted;
     # two DIFFERENT seeded values would be a conflict — omit.
     seeded = {_RPM_VOCAB[c] for c in candidates if c in _RPM_VOCAB}
-    return seeded.pop() if len(seeded) == 1 else None
+    return unique_or_none(seeded)
 
 
 def _form_factor(text: str, commodity: str) -> str | None:

--- a/app/services/desc_extractor/storage.py
+++ b/app/services/desc_extractor/storage.py
@@ -8,7 +8,7 @@ What: reads capacity / rpm / form factor / interface out of compact human drive
       skips unseeded keys (it performs no numeric_range check — capacity sanity
       lives in the link-speed exclusions here).
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (constants only) — pure functions.
+Depends on: _common (SpecDict alias only) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - Capacity requires an explicit unit token (GB/G/TB). Link-speed tokens are excluded
@@ -29,6 +29,8 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 """
 
 import re
+
+from app.services.desc_extractor._common import SpecDict
 
 # Canonical enum strings — MUST match the hdd/ssd entries in app/data/commodity_seeds.json.
 _FF_BY_VALUE = {"2.5": '2.5"', "3.5": '3.5"', "1.8": '1.8"'}
@@ -110,9 +112,9 @@ def _interface(text: str, commodity: str) -> str | None:
     return member if member in _IFACE_VOCAB[commodity] else None
 
 
-def extract_storage(text: str, commodity: str) -> dict[str, str | int | float]:
+def extract_storage(text: str, commodity: str) -> SpecDict:
     """Extract hdd/ssd specs from an upper-cased, whitespace-collapsed description."""
-    specs: dict[str, str | int | float] = {}
+    specs: SpecDict = {}
     capacity = _capacity_gb(text)
     if capacity is not None:
         specs["capacity_gb"] = capacity

--- a/app/services/desc_extractor/tape.py
+++ b/app/services/desc_extractor/tape.py
@@ -1,0 +1,106 @@
+"""Deterministic tape-drive description→spec extraction (TRIO inventory grammar).
+
+What: reads drive type / interface / form factor out of compact human tape-drive
+      descriptions like ``Tape Drive, 400/800gb Ultrium Lto-3 HH SCSI LVD
+      External`` or ``Tape, JAG 7`` — NO network, NO LLM. Every emitted value is
+      a seeded tape_drives enum member per app/data/commodity_seeds.json;
+      record_spec independently re-validates enum members and skips unseeded
+      keys. The drift guard in tests/test_desc_extractor_routing.py pins the
+      vocabularies against the seeds.
+Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
+Depends on: _common (constants only) — pure functions.
+
+CONSERVATIVE by design (a wrong facet value is worse than a missing one):
+- drive_type collects ALL grammar hits (LTO-N / LTO GEN N / Ultrium N, the closed
+  TS11xx + 3592-model + Jaguar maps, DAT/DDS, AIT) and emits only a unique
+  surviving member. "Ultrium 3000" (a product line, not a generation) is rejected
+  by ``(?!\\d)``; TS1080/TS4500 (libraries) match nothing.
+- interface vocab is {SAS, FC, SCSI, USB}; unique-or-omit ("SAS/FC" combos drop).
+- form_factor from HH/FH and the spelled half-/full-height forms; the glued
+  "LTO7HHSAS" grammar is a deliberate miss (no word boundary).
+- NOT extracted: native_capacity_gb ("400/800gb", "2.5 / 6.25TB" are native/
+  compressed pairs — drive_type already implies capacity) and encryption. The
+  ``Library,`` lead stays unrouted upstream (a library is not a drive).
+"""
+
+import re
+
+# Canonical tape_drives enum strings — MUST match the tape_drives entry in
+# app/data/commodity_seeds.json (drift-guarded).
+DAT, AIT = "DAT", "AIT"
+FULL_HEIGHT, HALF_HEIGHT = "Full-Height", "Half-Height"
+
+_LTO = re.compile(r"\bLTO[- ]?([3-9])\b")
+_LTO_GEN = re.compile(r"\bLTO\s?GEN\s?([3-9])\b")
+_ULTRIUM = re.compile(r"\bULTRIUM\s?([3-9])(?!\d)\b")
+_TS11 = re.compile(r"\bTS11(40|50|55|60|70)\b")
+_3592 = re.compile(r"\b3592[- ]?(E07|EH7|E08|EH8|55F|55E|60F|60E)\b")
+_3592_BY_MODEL = {
+    "E07": "TS1140",
+    "EH7": "TS1140",
+    "E08": "TS1150",
+    "EH8": "TS1150",
+    "55F": "TS1155",
+    "55E": "TS1155",
+    "60F": "TS1160",
+    "60E": "TS1160",
+}
+_JAG = re.compile(r"\bJAG\s?([4-7])(A?)\b")
+_JAG_BY_GEN = {"4": "TS1140", "5": "TS1150", "5A": "TS1155", "6": "TS1160", "7": "TS1170"}
+_DAT = re.compile(r"\bDAT\d{0,3}\b|\bDDS\b")
+_AIT = re.compile(r"\bAIT\b")
+
+_IFACE_PATTERNS = (
+    ("SAS", re.compile(r"\bSAS\b")),
+    ("FC", re.compile(r"\bFC\b|\bFIBRE(?: CHANNEL)?\b|\bFIBER CHANNEL\b")),
+    ("SCSI", re.compile(r"\bSCSI\b")),
+    ("USB", re.compile(r"\bUSB\b")),
+)
+_FORM_PATTERNS = (
+    (HALF_HEIGHT, re.compile(r"\bHH\b|\bHALF[- ]HIGH\b|\bHALF[- ]HEIGHT\b")),
+    (FULL_HEIGHT, re.compile(r"\bFH\b|\bFULL[- ]HEIGHT\b|\bFULL[- ]HIGH\b")),
+)
+
+
+def _drive_type(text: str) -> str | None:
+    """Distinct surviving seeded drive_type member, or None (absent / conflict)."""
+    members = {f"LTO-{m.group(1)}" for m in _LTO.finditer(text)}
+    members |= {f"LTO-{m.group(1)}" for m in _LTO_GEN.finditer(text)}
+    members |= {f"LTO-{m.group(1)}" for m in _ULTRIUM.finditer(text)}
+    members |= {f"TS11{m.group(1)}" for m in _TS11.finditer(text)}
+    members |= {_3592_BY_MODEL[m.group(1)] for m in _3592.finditer(text)}
+    for m in _JAG.finditer(text):
+        member = _JAG_BY_GEN.get(m.group(1) + m.group(2))
+        if member:  # unmapped Jaguar revisions (e.g. "JAG 4A") are dropped, never guessed
+            members.add(member)
+    if _DAT.search(text):
+        members.add(DAT)
+    if _AIT.search(text):
+        members.add(AIT)
+    return members.pop() if len(members) == 1 else None
+
+
+def _interface(text: str) -> str | None:
+    hits = {name for name, pattern in _IFACE_PATTERNS if pattern.search(text)}
+    return hits.pop() if len(hits) == 1 else None
+
+
+def _form_factor(text: str) -> str | None:
+    hits = {name for name, pattern in _FORM_PATTERNS if pattern.search(text)}
+    return hits.pop() if len(hits) == 1 else None
+
+
+def extract_tape(text: str) -> dict[str, str]:
+    """Extract tape_drives specs from an upper-cased, whitespace-collapsed
+    description."""
+    specs: dict[str, str] = {}
+    drive_type = _drive_type(text)
+    if drive_type is not None:
+        specs["drive_type"] = drive_type
+    interface = _interface(text)
+    if interface is not None:
+        specs["interface"] = interface
+    form_factor = _form_factor(text)
+    if form_factor is not None:
+        specs["form_factor"] = form_factor
+    return specs

--- a/app/services/desc_extractor/tape.py
+++ b/app/services/desc_extractor/tape.py
@@ -8,7 +8,7 @@ What: reads drive type / interface / form factor out of compact human tape-drive
       keys. The drift guard in tests/test_desc_extractor_routing.py pins the
       vocabularies against the seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (SpecDict alias only) — pure functions.
+Depends on: _common (SpecDict alias + unique_or_none helper) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - Media/supplies rows emit NOTHING: a CARTRIDGE / CLEANING / MEDIA / LABEL / WORM
@@ -30,7 +30,7 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 
 import re
 
-from app.services.desc_extractor._common import SpecDict
+from app.services.desc_extractor._common import SpecDict, unique_or_none
 
 # Canonical tape_drives enum strings — MUST match the tape_drives entry in
 # app/data/commodity_seeds.json (drift-guarded).
@@ -90,17 +90,17 @@ def _drive_type(text: str) -> str | None:
         members.add(DAT)
     if _AIT.search(text):
         members.add(AIT)
-    return members.pop() if len(members) == 1 else None
+    return unique_or_none(members)
 
 
 def _interface(text: str) -> str | None:
     hits = {name for name, pattern in _IFACE_PATTERNS if pattern.search(text)}
-    return hits.pop() if len(hits) == 1 else None
+    return unique_or_none(hits)
 
 
 def _form_factor(text: str) -> str | None:
     hits = {name for name, pattern in _FORM_PATTERNS if pattern.search(text)}
-    return hits.pop() if len(hits) == 1 else None
+    return unique_or_none(hits)
 
 
 def extract_tape(text: str) -> SpecDict:

--- a/app/services/desc_extractor/tape.py
+++ b/app/services/desc_extractor/tape.py
@@ -8,9 +8,14 @@ What: reads drive type / interface / form factor out of compact human tape-drive
       keys. The drift guard in tests/test_desc_extractor_routing.py pins the
       vocabularies against the seeds.
 Called by: app/services/desc_extractor/__init__.py (extract_desc routing).
-Depends on: _common (constants only) — pure functions.
+Depends on: _common (SpecDict alias only) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
+- Media/supplies rows emit NOTHING: a CARTRIDGE / CLEANING / MEDIA / LABEL / WORM
+  token means the row is a cartridge, cleaning kit or barcode-label pack — not a
+  drive — even though the "Tape," lead or a glued LTO body token routes it here
+  ("Tape, Cleaning Cartridge, DAT 320", "LTO6-LABEL"). Same conservative-loss
+  rationale as the ``Library,`` exclusion below.
 - drive_type collects ALL grammar hits (LTO-N / LTO GEN N / Ultrium N, the closed
   TS11xx + 3592-model + Jaguar maps, DAT/DDS, AIT) and emits only a unique
   surviving member. "Ultrium 3000" (a product line, not a generation) is rejected
@@ -25,10 +30,18 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 
 import re
 
+from app.services.desc_extractor._common import SpecDict
+
 # Canonical tape_drives enum strings — MUST match the tape_drives entry in
 # app/data/commodity_seeds.json (drift-guarded).
 DAT, AIT = "DAT", "AIT"
 FULL_HEIGHT, HALF_HEIGHT = "Full-Height", "Half-Height"
+
+# Media/supplies tokens: a cartridge, cleaning cartridge, loose media or barcode
+# label pack is NOT a drive — extraction is suppressed entirely (a mis-bucketed
+# tape_drives card would otherwise take a 0.90 drive_type that outranks the AI
+# reader). Mirrors the upstream "Library," foreign-lead rationale.
+_MEDIA = re.compile(r"\bCARTRIDGES?\b|\bCLEANING\b|\bMEDIA\b|\bLABELS?\b|\bWORM\b")
 
 _LTO = re.compile(r"\bLTO[- ]?([3-9])\b")
 _LTO_GEN = re.compile(r"\bLTO\s?GEN\s?([3-9])\b")
@@ -90,10 +103,12 @@ def _form_factor(text: str) -> str | None:
     return hits.pop() if len(hits) == 1 else None
 
 
-def extract_tape(text: str) -> dict[str, str]:
+def extract_tape(text: str) -> SpecDict:
     """Extract tape_drives specs from an upper-cased, whitespace-collapsed
     description."""
-    specs: dict[str, str] = {}
+    if _MEDIA.search(text):
+        return {}  # cartridge / cleaning / label / WORM media row — not a drive
+    specs: SpecDict = {}
     drive_type = _drive_type(text)
     if drive_type is not None:
         specs["drive_type"] = drive_type

--- a/app/services/desc_extractor/writer.py
+++ b/app/services/desc_extractor/writer.py
@@ -7,9 +7,12 @@ HIGHER confidence (mpn_decode 0.95, vendor APIs) are skipped here — record_spe
 current cross-source rule is latest-write-wins, so this guard is what keeps the
 decode baseline authoritative until the SP2 source-tier ladder lands in record_spec.
 Unlike mpn_decoder/writer.py this NEVER writes a category: descriptions are not a
-regex-gated commodity proof, so only already-categorized hdd/ssd/dram cards are
-processed (record_spec requires a category anyway). Does not commit — the caller
-manages the txn.
+regex-gated commodity proof, so only cards already categorized to a handled
+commodity (SPEC_COMMODITIES: hdd/ssd/dram/power_supplies/displays/tape_drives/gpu/
+motherboards — the spec'd _HANDLED set) are processed (record_spec requires a
+category anyway). The five phase-2 commodities have no MPN decoders, so desc_parse
+is their top non-vendor source by confidence. Does not commit — the caller manages
+the txn.
 
 Called by: app/services/enrichment_worker/worker.py (run_one_batch, second pass,
            gated by settings.desc_parse_enabled).

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -777,14 +777,23 @@ ladder lands in record_spec):
     1. mpn_decoder/writer.py::decode_and_record_specs   — deterministic MPN→spec
        decode, source="mpn_decode", confidence 0.95 (settings.mpn_decode_enabled).
     2. desc_extractor/writer.py::extract_and_record_specs — deterministic
-       description→spec token grammar (storage + DRAM; TRIO part-master/inventory
-       descriptions like `HD, 450GB, 15KRPM, 3.5", Fibre Channel`), source=
+       description→spec token grammar across EIGHT commodities (phase 1: hdd/ssd/
+       dram; phase 2: power_supplies/displays/tape_drives/gpu/motherboards — TRIO
+       part-master/inventory descriptions like `HD, 450GB, 15KRPM, 3.5", Fibre
+       Channel`, `PSU, 1460W 240V/200V AC Hot Swap`, `Tape, JAG 7`), source=
        "desc_parse", confidence 0.90 (settings.desc_parse_enabled). Zero LLM/network;
-       extraction is suppressed on foreign commodity labels ("Other,"/"Tray,"…) and
-       conflicting tokens; only already-categorized hdd/ssd/dram cards are written
+       extraction is suppressed on foreign commodity labels ("Other,"/"Tray,"/
+       "Card,"/"Library,"…) and conflicting tokens, while NEUTRAL leads (packaging
+       words/brands/SPS- prefixes: "ASSY,"/"MSI,"/"SPS-PCA,"…) fall through to
+       body-token + category-hint arbitration instead of dying foreign. Per-module
+       structural guards: wattage exists only on the power_supplies route (CPU "135W"
+       TDP unreachable — cpu stays hint-only) and gpu memory_gb requires a GPU-context
+       token (NVIDIA/GDDR/HBM/family hit), so NIC "10GB"/"100GbE" rows emit nothing.
+       Only cards already categorized to one of the eight commodities are written
        (NEVER categorizes — a description is not a regex-gated commodity proof).
        The writer skips keys already held at higher confidence, so mpn_decode 0.95
-       and vendor-API values stay authoritative.
+       and vendor-API values stay authoritative. The five phase-2 commodities have
+       no MPN decoders, so desc_parse is their top non-vendor source.
     3. spec_enrichment_service.py::enrich_card_specs    — AI spec reader,
        source="spec_extraction", facets gated at confidence >= 0.85. Applies the
        same strictly-higher-confidence skip guard, so it never clobbers an

--- a/tests/test_desc_extract_writer.py
+++ b/tests/test_desc_extract_writer.py
@@ -108,6 +108,65 @@ def test_desc_rerun_is_idempotent_and_rewrites_corrected_descriptions(db_session
     assert _facets(db_session, card.id)["capacity_gb"] == 32
 
 
+def test_desc_writes_facets_for_phase2_commodity(db_session: Session):
+    # A power_supplies card (no MPN decoder exists for PSUs — desc_parse is its top
+    # non-vendor source) writes both the numeric wattage and the enum psu_class
+    # through record_spec, with desc_parse provenance at 0.90.
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "01KL563", "power_supplies", "PSU, 1460W 240V/200V AC Hot Swap for EN 62368-1")
+
+    stats = extract_and_record_specs(db_session, [card.id])
+    db_session.commit()
+
+    assert stats == {"parsed": 1, "written": 2, "failed": 0}
+    f = _facets(db_session, card.id)
+    assert f["wattage"] == 1460
+    assert f["psu_class"] == "Server/Redundant"
+    for key in ("wattage", "psu_class"):
+        entry = card.specs_structured[key]
+        assert entry["source"] == "desc_parse"
+        assert entry["confidence"] == 0.90
+
+
+def test_desc_writes_phase2_seed_extension_members(db_session: Session):
+    # The phase-2 seed APPENDS must actually round-trip through record_spec's enum
+    # validation: tape LTO-3 + USB and the motherboards board_type spec are all new.
+    seed_commodity_schemas(db_session)
+    tape = _card(db_session, "AA928A", "tape_drives", "Tape Drive, 400/800gb Ultrium Lto-3 HH SCSI LVD External")
+    usb_tape = _card(db_session, "Q1581SB", "tape_drives", "DAT160 INTERNAL USB TAPE DRIVE 80/160GB MFG REF")
+    board = _card(db_session, "5B20T04908", "motherboards", "5B20T04908:MB WHL I7 DIS 4G 8G WIN")
+
+    stats = extract_and_record_specs(db_session, [tape.id, usb_tape.id, board.id])
+    db_session.commit()
+
+    assert stats == {"parsed": 3, "written": 6, "failed": 0}
+    assert _facets(db_session, tape.id) == {
+        "drive_type": "LTO-3",
+        "interface": "SCSI",
+        "form_factor": "Half-Height",
+    }
+    assert _facets(db_session, usb_tape.id) == {"drive_type": "DAT", "interface": "USB"}
+    assert _facets(db_session, board.id) == {"board_type": "System Board"}
+
+
+def test_desc_skips_higher_confidence_prior_on_phase2_commodity(db_session: Session):
+    # A vendor-API gpu memory_gb at 0.95 must survive the desc-parse pass — the
+    # writer's strictly-higher-confidence guard applies to the new commodities too.
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "900-2G500-0000-000", "gpu", "SPS-PCA, NVIDIA Tesla V100 32GB Module")
+    assert record_spec(db_session, card.id, "memory_gb", 16, source="vendor_api", confidence=0.95)
+
+    written = extract_and_record(db_session, card)
+    db_session.commit()
+
+    assert written == 1  # gpu_family only; memory_gb skipped
+    f = _facets(db_session, card.id)
+    assert f["memory_gb"] == 16  # the 0.95 prior is untouched (desc said 32)
+    assert card.specs_structured["memory_gb"]["source"] == "vendor_api"
+    assert f["gpu_family"] == "Tesla"
+    assert card.specs_structured["gpu_family"]["source"] == "desc_parse"
+
+
 def test_desc_skips_uncategorized_card(db_session: Session):
     # Unlike the MPN decoder, a description is not a regex-gated commodity proof — the
     # writer never categorizes, and an uncategorized card cannot take facets anyway.

--- a/tests/test_desc_extractor_board.py
+++ b/tests/test_desc_extractor_board.py
@@ -1,0 +1,68 @@
+"""Accuracy guard for the motherboard description extractor — REAL corpus strings →
+exact specs.
+
+Every description below is verbatim from TRIO's part master
+(/root/source_ingest/LSC1__Material__c.csv, Material_Description__c). Expectations are
+FULL equality. The mb route has no GB key at all, so laptop-board dram/gpu tokens
+("…GTX1050 4GB i7…") are inert by construction.
+"""
+
+import pytest
+
+from app.services.desc_extractor import extract_desc
+
+# (real description, commodity_hint or None, exact expected specs)
+CASES = [
+    # ── TRIO part-master "<Label>, …" grammar ────────────────────────────
+    ("MB, B82CD NOK A49120C UMA 4G32G", None, {"board_type": "System Board"}),
+    ("MB, L 80YN, WIN, i-7-7820 HK 8 G - Lenovo", None, {"board_type": "System Board"}),
+    (
+        "MB, Motherboard, Cel 1007U y-TPM, W8p for ThinkPad X131e, Lenovo",
+        None,
+        {"board_type": "System Board"},
+    ),
+    (
+        "BDPLANAR WIN,i5-10210U,16G,9560,yTPM2",  # "BDPLANAR WIN" lead-map rescue
+        None,
+        {"board_type": "System Board"},
+    ),
+    (
+        "SUPERMICRO FRU,DAUGHTER CARD REPLACEMENT KIT",  # brand+packaging lead is neutral
+        "motherboards",
+        {"board_type": "Daughter Board"},
+    ),
+    # ── body-token / first-token routing ─────────────────────────────────
+    ("BDPLANAR Lenovo MB ALC WIN R7-5700U UMA", None, {"board_type": "System Board"}),
+    ("5B20T04908:MB WHL I7 DIS 4G 8G WIN", None, {"board_type": "System Board"}),
+    (
+        "SPS-MB DSC GTX1050 4GB i7-7700HQ WIN",  # stays a motherboard: no GB, no gpu_family
+        None,
+        {"board_type": "System Board"},
+    ),
+    # ── hint-routed grammar without a routing token ──────────────────────
+    ("SPS - BD SYS SL390/SL2x390", "motherboards", {"board_type": "System Board"}),
+    # ── conflicts and mis-filed MB-bucket rows ───────────────────────────
+    ("MB, 7063-CR1 System backplane kit", None, {}),  # MB×Backplane conflict — it IS a kit
+    ("Function Board C 82L7 IO", "motherboards", {}),
+    ("TOUCHPAD", "motherboards", {}),
+    ("HS 2TB 3.5", "motherboards", {}),  # drive-ish text on an mb card — no board token, no GB key
+]
+
+
+@pytest.mark.parametrize("description,hint,expected", CASES)
+def test_board_extract_exact(description, hint, expected):
+    result = extract_desc(description, commodity_hint=hint)
+    assert result is not None, f"{description!r} did not extract"
+    assert result.commodity == "motherboards"
+    assert result.specs == expected
+    assert result.confidence == 0.90
+
+
+def test_spaced_megabytes_never_read_as_a_board_token():
+    # "16 MB" (spaced megabytes — real corpus drive string) is killed by the MB
+    # lookbehind; glued "512MB"/"36MB" never had a boundary. Neither may emit a
+    # System Board. extract_board expects upper-cased, whitespace-collapsed text.
+    from app.services.desc_extractor.board import extract_board
+
+    assert extract_board("HD 500GB 7200RPM CACHE 16 MB SATA 6.0GB/S.") == {}
+    assert extract_board('HDD, 450GB 15000RPM 16MB 3.5" SAS, N-SERIES') == {}

--- a/tests/test_desc_extractor_display.py
+++ b/tests/test_desc_extractor_display.py
@@ -60,6 +60,18 @@ CASES = [
         "displays",
         {"backlight": "LED"},
     ),
+    # ── packaging-suffixed display leads (explicit _LEAD_MAP entries) ────
+    ("LCD ASSY, 15, HD, 1MIC 8.1", None, {"resolution": "1366x768"}),
+    (
+        "PNL KIT, LCD 15.6 FHD UWVA W/BEZEL",
+        None,
+        {"resolution": "1920x1080", "diagonal_size": 15.6},
+    ),
+    # ── camera tokens: HD/FHD before CAM/CAMERA/WEBCAM is the camera, not the panel ──
+    ("PANEL, W/HD CAMERA", None, {}),
+    ("SPS-LCD BEZEL HD WEBCAM LANNISTER", None, {}),  # a bezel, not a panel
+    ("SPS-LCD CABLE TS PANEL HD WEBCAM", None, {}),  # a cable, not a panel
+    ("CAMERA AIO520 FHD CAM BSN", "displays", {}),
     # ── deliberate misses (conservative > wrong) ─────────────────────────
     ("ZB555KL-4A 5.5 HD+LCD MODULE", None, {}),  # HD+ excluded; 5.5 below the 7" floor
 ]
@@ -72,6 +84,40 @@ def test_display_extract_exact(description, hint, expected):
     assert result.commodity == "displays"
     assert result.specs == expected
     assert result.confidence == 0.90
+
+
+def test_bare_spaced_in_is_a_preposition_not_an_inch_mark():
+    # "<number> IN <word>" is English ("IN STOCK", "IN RACK") — only quote marks,
+    # glued/hyphenated IN, or INCH(ES) count as a diagonal unit.
+    for desc in ("PANEL 15 IN STOCK", "CHASSIS 19 IN RACK", "BACKLIGHT 60 IN"):
+        result = extract_desc(desc, commodity_hint="displays")
+        assert result is not None
+        assert result.specs == {}, f"{desc!r} must not emit a diagonal"
+
+
+def test_n_in_1_dock_grammar_is_not_a_diagonal():
+    # "8-IN-1"/"10 IN 1" multiplexer/dock counts are rejected by the trailing-digit
+    # lookahead (the 7-86 range alone would pass N>=7).
+    for desc in ("LCD, 8-IN-1 docking module", "MONITOR, 10 IN 1 KVM"):
+        result = extract_desc(desc)
+        assert result is not None
+        assert result.specs == {}, f"{desc!r} must not emit a diagonal"
+
+
+def test_distinct_named_and_explicit_resolutions_omit_the_key():
+    # Conflict pin: FHD (1920x1080) vs explicit 1366x768 ⇒ resolution omitted;
+    # the diagonal before the named class still extracts.
+    result = extract_desc("LCD, 15.6 FHD 1366x768")
+    assert result is not None
+    assert result.specs == {"diagonal_size": 15.6}
+
+
+def test_unseeded_explicit_pixel_pair_is_dropped():
+    # 1024x768 matches _RES_EXPLICIT but is not a seeded member — the hardcoded
+    # _RES_SEEDED allowlist is the only barrier before record_spec.
+    result = extract_desc("LCD, 1024x768 panel")
+    assert result is not None
+    assert result.specs == {}
 
 
 def test_backlight_is_always_the_generic_led_bucket():

--- a/tests/test_desc_extractor_display.py
+++ b/tests/test_desc_extractor_display.py
@@ -1,0 +1,84 @@
+"""Accuracy guard for the display/panel description extractor — REAL corpus strings →
+exact specs.
+
+Every description below is verbatim from TRIO's part master
+(/root/source_ingest/LSC1__Material__c.csv, Material_Description__c) or the staged
+inventory sheets (Firesale_inventory). Expectations are FULL equality — a new key
+appearing unexpectedly is as much a failure as a missing one.
+"""
+
+import pytest
+
+from app.services.desc_extractor import extract_desc
+
+# (real description, commodity_hint or None, exact expected specs)
+CASES = [
+    # ── TRIO part-master "<Label>, …" grammar ────────────────────────────
+    ('LCD, 21.5", LG', None, {"diagonal_size": 21.5}),
+    (
+        "PNL,15.6 FHD AG WLED SVA 45% 220neDP,INX",
+        None,
+        {"resolution": "1920x1080", "diagonal_size": 15.6, "backlight": "LED"},
+    ),
+    (
+        'LCD, 15.6", FHD 1920x1080, LQ156M1JW43, Dell branded, Sharp',  # named + explicit agree
+        None,
+        {"resolution": "1920x1080", "diagonal_size": 15.6},
+    ),
+    (
+        "HU, FHD AG LED UWVA 13 TS PVCY",  # HP display-unit lead; bare integer 13 — no inch mark
+        None,
+        {"resolution": "1920x1080", "backlight": "LED"},
+    ),
+    (
+        'Innolux, LCD, 21.5"',  # neutral brand lead; body LCD token routes
+        None,
+        {"diagonal_size": 21.5},
+    ),
+    # ── body-token / first-token routing ─────────────────────────────────
+    (
+        "TFD LCD  TOUCH HU 11.6 HD EDP WLAN DUNES3",
+        None,
+        {"resolution": "1366x768", "diagonal_size": 11.6},
+    ),
+    ("SPS-DSPLY HU 17.3 DRM UHD IR", None, {"resolution": "3840x2160"}),  # bare 17.3 missed
+    (
+        "Lenovo 300E Chromebook Lcd Touch Screen w Bezel 11.6 HD 1366x768 5D10Q93993",
+        None,
+        {"resolution": "1366x768", "diagonal_size": 11.6},
+    ),
+    ("HP 22kd 21.5-IN Display-EMEA", None, {"diagonal_size": 21.5}),
+    ("DISPLAY TIO27-Monitor(27inch)", None, {"diagonal_size": 27}),
+    (
+        "LCD LED 15.6W WXGA GLARE AUO B156XTK01.0 LF 200NIT 8MS 500:1 (ULTRA-SLIM) (EDP) OTP LITE",
+        None,
+        {"backlight": "LED"},  # 15.6W = wide (no inch mark); WXGA deliberately unmapped
+    ),
+    # ── hint-routed grammar without any commodity token ──────────────────
+    (
+        "19.5 WVA,AG,WLED,250,RGB,NZBD,INX",  # RGB is the color interface — never "LED RGB"
+        "displays",
+        {"backlight": "LED"},
+    ),
+    # ── deliberate misses (conservative > wrong) ─────────────────────────
+    ("ZB555KL-4A 5.5 HD+LCD MODULE", None, {}),  # HD+ excluded; 5.5 below the 7" floor
+]
+
+
+@pytest.mark.parametrize("description,hint,expected", CASES)
+def test_display_extract_exact(description, hint, expected):
+    result = extract_desc(description, commodity_hint=hint)
+    assert result is not None, f"{description!r} did not extract"
+    assert result.commodity == "displays"
+    assert result.specs == expected
+    assert result.confidence == 0.90
+
+
+def test_backlight_is_always_the_generic_led_bucket():
+    # WLED (white) and bare LED collapse to the generic seeded "LED" member — the
+    # seeded "LED White"/"LED RGB" members are never emitted from descriptions
+    # (white-vs-RGB is not expressible in TRIO desc grammar).
+    for desc in ("PNL,15.6 FHD AG WLED SVA 45% 220neDP,INX", "HU, FHD AG LED UWVA 13 TS PVCY"):
+        result = extract_desc(desc)
+        assert result is not None
+        assert result.specs["backlight"] == "LED"

--- a/tests/test_desc_extractor_gpu.py
+++ b/tests/test_desc_extractor_gpu.py
@@ -36,6 +36,13 @@ CASES = [
         "gpu",
         {"memory_gb": 8},
     ),
+    (
+        # Real bandwidth grammar: 608GB/S is skipped by the trailing-"/S" check and
+        # 320W/9500MHz never match — only the 10GB memory token survives.
+        "VGA CARD.GEFORCE RTX 3080.10GB GDDR6.256B.9500MHz.(BUY-LC).HDMI+DP*3..320W.608GB/S.W/ATX BKT.ASPM.SV11B20562....LEAD-FREE.MSI",
+        "gpu",
+        {"gpu_family": "GeForce", "memory_gb": 10},
+    ),
     # ── body-token routing (no hint needed) ──────────────────────────────
     ("RX550 CMIT FH 4GB GFX card", None, {"gpu_family": "Radeon", "memory_gb": 4}),
     ("SXM ASSY,K20X GPU 20 FINS", None, {"gpu_family": "Tesla"}),  # neutral "SXM ASSY," lead
@@ -48,6 +55,14 @@ CASES = [
     ),
     ("GPU CARD,PASCAL GP100 PASSIVE", None, {}),  # PASCAL spans Tesla/Quadro — unmapped
     ("2080TI Founders edition", "gpu", {}),  # bare model, no family token
+    (
+        # "-A2" is an NVIDIA silicon-stepping suffix (N17M = GeForce MX150-class
+        # laptop chip), NOT an Ampere A2 — the (?<![\w-]) lookbehind rejects it.
+        # 908P/A31 carry no GB token, so nothing else emits either.
+        "S IC N17M-Q3-A2 BGA 908P GPU A31 !",
+        None,
+        {},
+    ),
 ]
 
 
@@ -65,6 +80,15 @@ GUARDED_GB_CASES = [
     "Emulex, 10GB, SFP+Mezza Card",  # NIC mezzanine inside the GC bucket
     "NVIDIA ConnectX-7 Dual-Port 100GbE Ethernet Adapter",  # 100GbE never matches \bGB\b
     "Flash card for Xseries ThinkServer RAID 720i 4GB Modular Flash & Supercapacitor",
+    # NVIDIA-branded Mellanox NIC: the spaced "25Gb" link speed uppercases into the
+    # \bGB\b shape, but the NIC clause (ConnectX/SFP/dual-port) disqualifies memory_gb.
+    "NVIDIA ConnectX-4 Lx 25Gb dual-port SFP28 adapter",
+    # DRAM-module row: NVIDIA context alone must not unlock memory_gb — the 16GB
+    # belongs to the SODIMM, not a GPU (no gpu_family hit to override).
+    "SODIMM 16GB DDR4 for NVIDIA DGX Station",
+    # Decimal memory bandwidth: "14.4GB/S" would capture its fractional digit (4)
+    # without the trailing-"/S" skip — nothing may emit.
+    "GPU CARD, GT710 PASSIVE 14.4GB/S GDDR5",
 ]
 
 
@@ -73,3 +97,22 @@ def test_memory_gb_requires_gpu_context_token(description):
     result = extract_desc(description, commodity_hint="gpu")
     assert result is not None
     assert result.specs == {}, f"{description!r} must not emit GPU specs"
+
+
+def test_t4_emits_tesla_family():
+    # Spec §3.4 maps the T4 datacenter chip to Tesla; the word boundary keeps
+    # workstation "T400"/"T4000" cards unmatched (no boundary before the 0).
+    result = extract_desc("NVIDIA T4 16GB PCIe", commodity_hint="gpu")
+    assert result is not None
+    assert result.specs == {"gpu_family": "Tesla", "memory_gb": 16}
+    result = extract_desc("Nvidia T400 4GB GDDR6", commodity_hint="gpu")
+    assert result is not None
+    assert result.specs == {"memory_gb": 4}  # T400 is NOT T4 — no family
+
+
+def test_two_distinct_gb_values_omit_memory():
+    # The unique-survivor contract: two different in-range GB candidates ⇒ the
+    # memory_gb key is omitted, never max()/first-match picked.
+    result = extract_desc("GPU, NVIDIA 8GB or 16GB configurations", commodity_hint="gpu")
+    assert result is not None
+    assert result.specs == {}

--- a/tests/test_desc_extractor_gpu.py
+++ b/tests/test_desc_extractor_gpu.py
@@ -1,0 +1,75 @@
+"""Accuracy guard for the GPU description extractor — REAL corpus strings → exact specs.
+
+Every description below is verbatim from TRIO's part master
+(/root/source_ingest/LSC1__Material__c.csv, Material_Description__c). Expectations are
+FULL equality. The GC bucket is heavily contaminated (NICs, RAID flash modules), so the
+memory_gb GPU-context-token guard gets its own negative block.
+"""
+
+import pytest
+
+from app.services.desc_extractor import extract_desc
+
+# (real description, commodity_hint or None, exact expected specs)
+CASES = [
+    # ── family + memory ──────────────────────────────────────────────────
+    ("PCA Quadro GP100 16GB HBM2", "gpu", {"gpu_family": "Quadro", "memory_gb": 16}),
+    (
+        "SPS-PCA, NVIDIA Tesla V100 32GB Module",  # SPS- prefixed lead is neutral, not foreign
+        "gpu",
+        {"gpu_family": "Tesla", "memory_gb": 32},
+    ),
+    (
+        "MSI, RTX3080, 10G/D6X/3DP/H",  # neutral brand lead; glued 10G/D6X memory grammar
+        "gpu",
+        {"gpu_family": "RTX", "memory_gb": 10},
+    ),
+    ("BLD RTX3060 12GB G6 3DP+H", "gpu", {"gpu_family": "RTX", "memory_gb": 12}),
+    (
+        "GTX1660Super@6G/D6/DP/H/DVI",  # GTX is definitionally GeForce
+        "gpu",
+        {"gpu_family": "GeForce", "memory_gb": 6},
+    ),
+    ("SPS-GRAPHICS NVIDIA Quadro P4200 8GB", "gpu", {"gpu_family": "Quadro", "memory_gb": 8}),
+    (
+        "SPS-PCA NVIDIA T1000 8GB",  # T1000 unmapped — NVIDIA context still allows memory
+        "gpu",
+        {"memory_gb": 8},
+    ),
+    # ── body-token routing (no hint needed) ──────────────────────────────
+    ("RX550 CMIT FH 4GB GFX card", None, {"gpu_family": "Radeon", "memory_gb": 4}),
+    ("SXM ASSY,K20X GPU 20 FINS", None, {"gpu_family": "Tesla"}),  # neutral "SXM ASSY," lead
+    ("CRD,GRPHC,NV,GTX,1060", None, {"gpu_family": "GeForce"}),  # bare 1060 has no GB token
+    # ── conflicts and unmapped vocabulary ────────────────────────────────
+    (
+        "GPU, NVIDIA GeForce GTX, Quadro P2000, GP106-875, 1024, 1480MHz. 7Gbps. 5GB GD5",
+        None,
+        {"memory_gb": 5},  # GeForce×Quadro conflict omits the family; 5GB still emits
+    ),
+    ("GPU CARD,PASCAL GP100 PASSIVE", None, {}),  # PASCAL spans Tesla/Quadro — unmapped
+    ("2080TI Founders edition", "gpu", {}),  # bare model, no family token
+]
+
+
+@pytest.mark.parametrize("description,hint,expected", CASES)
+def test_gpu_extract_exact(description, hint, expected):
+    result = extract_desc(description, commodity_hint=hint)
+    assert result is not None, f"{description!r} did not extract"
+    assert result.commodity == "gpu"
+    assert result.specs == expected
+    assert result.confidence == 0.90
+
+
+# ── the cross-commodity GB guard: no GPU-context token ⇒ no memory_gb ────
+GUARDED_GB_CASES = [
+    "Emulex, 10GB, SFP+Mezza Card",  # NIC mezzanine inside the GC bucket
+    "NVIDIA ConnectX-7 Dual-Port 100GbE Ethernet Adapter",  # 100GbE never matches \bGB\b
+    "Flash card for Xseries ThinkServer RAID 720i 4GB Modular Flash & Supercapacitor",
+]
+
+
+@pytest.mark.parametrize("description", GUARDED_GB_CASES)
+def test_memory_gb_requires_gpu_context_token(description):
+    result = extract_desc(description, commodity_hint="gpu")
+    assert result is not None
+    assert result.specs == {}, f"{description!r} must not emit GPU specs"

--- a/tests/test_desc_extractor_power.py
+++ b/tests/test_desc_extractor_power.py
@@ -1,0 +1,99 @@
+"""Accuracy guard for the PSU description extractor — REAL corpus strings → exact specs.
+
+Every description below is verbatim from TRIO's part master
+(/root/source_ingest/LSC1__Material__c.csv, Material_Description__c) or the staged
+inventory sheets (Firesale_inventory). Expectations are FULL equality — a new key
+appearing unexpectedly is as much a failure as a missing one.
+"""
+
+import pytest
+
+from app.services.desc_extractor import extract_desc
+
+# (real description, commodity_hint or None, exact expected specs)
+CASES = [
+    # ── TRIO part-master "<Label>, …" grammar ────────────────────────────
+    (
+        "PSU, 1460W 240V/200V AC Hot Swap for EN 62368-1",
+        None,
+        {"wattage": 1460, "psu_class": "Server/Redundant"},
+    ),
+    ("PWR SPLY,180W,BRZ,D8,ACBL", None, {"wattage": 180}),
+    (
+        "AC ADAPTERS, 45Watt, 20V2.25A COO",  # WATT spelling; 20V2.25A is not a wattage
+        None,
+        {"wattage": 45, "psu_class": "AC-DC (External/Adapter)"},
+    ),
+    (
+        "Power Supply, V7000 Gen2 Expansion 800W, IBM",  # V7000/Gen2 glued digits never match
+        None,
+        {"wattage": 800},
+    ),
+    (
+        "PSU., 750W TT ITIC, Acbel PN FSF061-EL1G",  # dot-stripped "PSU." lead
+        None,
+        {"wattage": 750},
+    ),
+    # ── body-token routing (no lead label) ───────────────────────────────
+    ("750W P/S 8871", None, {"wattage": 750}),  # P/S token routes; bare 8871 has no W
+    (
+        "460 watt AC hot-plug power supply",
+        None,
+        {"wattage": 460, "psu_class": "Server/Redundant"},
+    ),
+    (
+        "ZT - 800W power supply, N+1 Redundancy (Delta p/n DPS-800AB-27 A)",
+        None,
+        {"wattage": 800, "psu_class": "Server/Redundant"},  # DPS-800AB agrees with 800W
+    ),
+    (
+        "Dell Model: A670P-00 Server Power Supply 670W",
+        None,
+        {"wattage": 670, "psu_class": "Server/Redundant"},
+    ),
+    ("PWR_SUPPLY 1300W Delta power supply", None, {"wattage": 1300}),
+    ("150W NE0152T/AS4610 Lenovo/Mellanox PSU", None, {"wattage": 150}),
+    (
+        "Hon-Kwang AC Power Supply Charger 7.5VDC 300mA",  # 7.5VDC/300mA are not wattages
+        None,
+        {"psu_class": "AC-DC (External/Adapter)"},
+    ),
+    (
+        "1200W AC Common Slot (CS) hot-plug power supply",
+        None,
+        {"wattage": 1200, "psu_class": "Server/Redundant"},
+    ),
+    (
+        "HPE X311 400W 100 240VAC TO 12VDC POWER SUPPLY",  # VAC/VDC don't match — 400 only
+        None,
+        {"wattage": 400},
+    ),
+    (
+        "AC Adapter;PA-1300-42;20V/1.5A;UL;white",  # 1300 inside the MPN, no W — class only
+        None,
+        {"psu_class": "AC-DC (External/Adapter)"},
+    ),
+    # ── deliberate misses (conservative > wrong) ─────────────────────────
+    ("PS MT 250WENT17 92%EFF 12V2OUT", "power_supplies", {}),  # glued 250WENT17, no boundary
+    ("PCA, PSUPLY BPLN 370, 240VA", "power_supplies", {}),  # VA is not W; PCA lead is neutral
+    ("Aristocrat  MK7-400-1 power supply", None, {}),  # 400 inside the MPN, no W token
+    ("CHANGER WALL FOR MZ220- MZ320", "power_supplies", {}),  # CHANGER ≠ CHARGER
+    ("HP Aruba E3800 48G POE 4SFP SWITCH, one Power Supply", None, {}),  # switch row — nothing
+]
+
+
+@pytest.mark.parametrize("description,hint,expected", CASES)
+def test_psu_extract_exact(description, hint, expected):
+    result = extract_desc(description, commodity_hint=hint)
+    assert result is not None, f"{description!r} did not extract"
+    assert result.commodity == "power_supplies"
+    assert result.specs == expected
+    assert result.confidence == 0.90
+
+
+def test_generic_power_supply_emits_no_psu_class():
+    # Generic "Power Supply" rows (365 in the corpus) deliberately carry NO psu_class —
+    # the commodity already says PSU; a generic member would add zero filter signal.
+    result = extract_desc("Power Supply, V7000 Gen2 Expansion 800W, IBM")
+    assert result is not None
+    assert "psu_class" not in result.specs

--- a/tests/test_desc_extractor_power.py
+++ b/tests/test_desc_extractor_power.py
@@ -44,7 +44,8 @@ CASES = [
     (
         "ZT - 800W power supply, N+1 Redundancy (Delta p/n DPS-800AB-27 A)",
         None,
-        {"wattage": 800, "psu_class": "Server/Redundant"},  # DPS-800AB agrees with 800W
+        # only 800W matches — the 800 inside DPS-800AB has no W unit token
+        {"wattage": 800, "psu_class": "Server/Redundant"},
     ),
     (
         "Dell Model: A670P-00 Server Power Supply 670W",
@@ -89,6 +90,21 @@ def test_psu_extract_exact(description, hint, expected):
     assert result.commodity == "power_supplies"
     assert result.specs == expected
     assert result.confidence == 0.90
+
+
+def test_two_distinct_wattages_omit_the_key():
+    # Conflict pin for the unique-survivor contract: 750W vs 800W ⇒ wattage omitted
+    # (never max()/first-match picked); the hot-plug class still extracts.
+    result = extract_desc("PSU, 750W or 800W hot-plug power supply")
+    assert result is not None
+    assert result.specs == {"psu_class": "Server/Redundant"}
+
+
+def test_two_distinct_psu_classes_omit_the_key():
+    # ATX vs AC-DC adapter ⇒ psu_class omitted; the unambiguous wattage survives.
+    result = extract_desc("PSU, 65W ATX AC adapter")
+    assert result is not None
+    assert result.specs == {"wattage": 65}
 
 
 def test_generic_power_supply_emits_no_psu_class():

--- a/tests/test_desc_extractor_routing.py
+++ b/tests/test_desc_extractor_routing.py
@@ -69,6 +69,10 @@ NONE_CASES = [
     "Card, FRU ThinkSerRSC_1ux16_v1.0",
     "VPD card, VPD CARD S824 52FE, IBM",
     "Library, 3592 Tape Drive, Jag6 Drive",
+    # packaging-SUFFIXED accessory labels stay foreign — "CBL ASSY," mixes a foreign
+    # word with a packaging word, so the all-words-neutral rule never rescues it
+    # (the body MB token must not emit a System Board for a cable assembly)
+    "CBL ASSY,RPS REAR MB, XL",
     # degenerate: the description IS the part number (real rows where desc == Name)
     "BCM84894B0IFSBG",
     "160-10020-01",
@@ -129,10 +133,45 @@ def test_neutral_leads_fall_through_to_body_and_hint():
     assert extract_desc("MSI, RTX3080, 10G/D6X/3DP/H") is None
 
 
+def test_packaging_suffixed_foreign_labels_stay_foreign_even_hinted():
+    # The all-words-neutral boundary: a label whose last word is packaging but whose
+    # other words are foreign ("Drive Tray Kit,"/"Cable Assy,") must NOT fall through
+    # to body/hint arbitration — an accessory row would otherwise take the facets of
+    # the part it fits (wrong facet values are worse than missing ones).
+    assert extract_desc("Drive Tray Kit, 600GB 15K rpm SAS HDD trays", commodity_hint="hdd") is None
+    assert extract_desc('Cable Assy, for LCD 15.6" FHD panel', commodity_hint="displays") is None
+    # All-words-neutral labels still rescue: brand+packaging falls through to the hint.
+    result = extract_desc("SUPERMICRO FRU,DAUGHTER CARD REPLACEMENT KIT", commodity_hint="motherboards")
+    assert result is not None and result.commodity == "motherboards"
+
+
 def test_neutral_lead_keeps_phase1_conflict_guards():
     # Behind a neutral brand lead, a body mixing HDD+DIMM tokens still hard-conflicts
     # to None (constructed string — the guard predates phase 2 and must survive it).
     assert extract_desc("HP, 16GB DDR4 DIMM + 512GB SSD bundle") is None
+
+
+# ── phase-2 lead/first-token map coverage: every new entry routes ─────────
+# (the two-letter "TD,"/"GC," labels carry the highest future-collision risk —
+# a typo or accidental map removal must fail here, not silently lose recall)
+PHASE2_LEAD_CASES = [
+    ("TD, LTO-6 HH SAS", "tape_drives"),
+    ("GC, NVIDIA Quadro P2000 5GB", "gpu"),
+    ("PANEL, 15.6 FHD AG", "displays"),
+    ("VIDEO CARD, NVIDIA Quadro 600 1GB", "gpu"),
+    ("VIDEO BOARD, GeForce GT730 2GB", "gpu"),
+    ("GRAPHIC CARD, Radeon RX550 4GB", "gpu"),
+    ("MONITOR 27INCH HP EliteDisplay", "displays"),  # comma-less first token
+    ("DSPLY 23.8 FHD TOUCH", "displays"),  # comma-less first token
+    ("GC NVIDIA T1000 4GB", "gpu"),  # comma-less first token
+]
+
+
+@pytest.mark.parametrize("description,commodity", PHASE2_LEAD_CASES)
+def test_phase2_lead_and_first_token_routing(description, commodity):
+    result = extract_desc(description)
+    assert result is not None, f"{description!r} did not route"
+    assert result.commodity == commodity
 
 
 def test_lead_label_dot_strip_normalization():

--- a/tests/test_desc_extractor_routing.py
+++ b/tests/test_desc_extractor_routing.py
@@ -1,9 +1,17 @@
 """Routing + safety guards for extract_desc — REAL corpus strings.
 
 Covers: commodity-hint routing, foreign-lead suppression (the "Other,"/"Tray,"
-part-master labels), cross-family conflicts, degenerate MPN-as-description, the
-non-spec commodity hints (motherboards/power_supplies/cpu), and a drift guard that
-re-validates every emittable enum member against app/data/commodity_seeds.json.
+part-master labels), NEUTRAL leads (packaging words / brands / SPS- prefixes fall
+through to body+hint arbitration), lead-label dot-strip normalization, cross-family
+conflicts, degenerate MPN-as-description, the cpu hint-only commodity, and a drift
+guard that re-validates every emittable enum member and numeric-range constant
+against app/data/commodity_seeds.json.
+
+Phase-2 migrations: the motherboards entries and "Power Supply, V7000 …" moved out
+of HINT_ONLY_CASES (they now emit board_type / wattage — see
+test_desc_extractor_board.py / test_desc_extractor_power.py), and 'LCD, 21.5", LG'
+moved out of NONE_CASES (now displays, diagonal_size 21.5 — see
+test_desc_extractor_display.py).
 """
 
 import json
@@ -13,15 +21,11 @@ import pytest
 
 from app.services.desc_extractor import extract_desc
 
-# ── non-spec commodity hints (callers may use the commodity; specs stay empty) ──
+# ── cpu stays hint-only (callers may use the commodity; specs stay empty) ──
 HINT_ONLY_CASES = [
-    ("MB, L 80YN, WIN, i-7-7820 HK 8 G - Lenovo", "motherboards"),
-    ("MB, Motherboard, Cel 1007U y-TPM, W8p for ThinkPad X131e, Lenovo", "motherboards"),
-    ("BDPLANAR Lenovo MB ALC WIN R7-5700U UMA", "motherboards"),  # body "MB" token
     ("CPU 6 Core E5-2640 15M Cache - 2.50 GHZ 00D0017, IBM", "cpu"),
     ("SPS-CPU BDW E5-2673v4 20C 2.3Gz 50M 135W", "cpu"),  # hyphenated body token
     ("CPU, I5-6500T, 6M 3.1G, SR2BZ, CM8066201920600, Intel", "cpu"),
-    ("Power Supply, V7000 Gen2 Expansion 800W, IBM", "power_supplies"),
 ]
 
 
@@ -31,6 +35,18 @@ def test_non_spec_commodity_hint(description, commodity):
     assert result is not None, f"{description!r} did not extract"
     assert result.commodity == commodity
     assert result.specs == {}
+
+
+def test_cpu_wattage_is_structurally_unreachable():
+    # "135W" is a CPU TDP, not a PSU rating: cpu routes to the empty-specs branch and
+    # the wattage key only exists on the power_supplies route — no extractor can leak
+    # it ("SPS-CPU BDW E5-2673v4 20C 2.3Gz 50M 135W" stays specs={}).
+    result = extract_desc("SPS-CPU BDW E5-2673v4 20C 2.3Gz 50M 135W")
+    assert result is not None
+    assert result.commodity == "cpu"
+    assert "wattage" not in result.specs and result.specs == {}
+    # And a cpu HINT never routes anywhere (cpu is outside SPEC_COMMODITIES).
+    assert extract_desc("SPS-CPU BDW E5-2673v4 20C 2.3Gz 50M 135W", commodity_hint="cpu") is None
 
 
 # ── none-of-the-above: foreign labels, prose lines, degenerate descriptions ──
@@ -47,10 +63,12 @@ NONE_CASES = [
     'Other, 3.5" Server HDD Hard Drive tray, IBM',
     "Other,ServerRAID M5110 SAS/SATA Adapter PDA, IBM",
     "Other, DDR4 512Mx64 PC2133 (4GB), Kingston",  # loose module sold under "Other,"
-    # foreign commodity labels
-    'LCD, 21.5", LG',
+    # foreign commodity labels — "Card,"/"Library," stay foreign even with handled
+    # tokens in the body (the GC bucket is contaminated; a library is not a drive)
     "Card, 1.9Ghz, 2-Way POWER5+ DCM, Processor Card, 36MB L3 Cache 53C4, pSeries z7",
+    "Card, FRU ThinkSerRSC_1ux16_v1.0",
     "VPD card, VPD CARD S824 52FE, IBM",
+    "Library, 3592 Tape Drive, Jag6 Drive",
     # degenerate: the description IS the part number (real rows where desc == Name)
     "BCM84894B0IFSBG",
     "160-10020-01",
@@ -71,11 +89,11 @@ def test_empty_and_blank_return_none():
     assert extract_desc(None) is None  # type: ignore[arg-type]
 
 
-def test_hint_outside_storage_and_memory_returns_none():
-    # The extractor only speaks hdd/ssd/dram — a capacitor-categorized card never
-    # gets drive facets, no matter what its description says.
+def test_hint_outside_spec_commodities_returns_none():
+    # The extractor only speaks the eight SPEC_COMMODITIES — a capacitor-categorized
+    # card never gets drive facets, no matter what its description says.
     assert extract_desc('HD, 450GB, 15KRPM, 3.5", Fibre Channel', commodity_hint="capacitors") is None
-    assert extract_desc("Mem, 16GB DDR4 RDIMM", commodity_hint="motherboards") is None
+    assert extract_desc("PSU, 1460W 240V/200V AC Hot Swap for EN 62368-1", commodity_hint="networking") is None
 
 
 def test_hint_contradicted_by_foreign_lead_returns_none():
@@ -89,6 +107,41 @@ def test_hint_contradicted_by_other_family_lead_returns_none():
         extract_desc("MB, ATX server motherboard, LGA 1150 DDR3 1600/1333/1066, SuperMicro", commodity_hint="dram")
         is None
     )
+    # The contradiction rule covers the phase-2 families too: a "MEMORY," lead on a
+    # gpu-hinted card / an "MB," lead on a motherboards-vs-dram mismatch ⇒ None.
+    assert extract_desc("Mem, 16GB DDR4 RDIMM", commodity_hint="gpu") is None
+    assert extract_desc("Mem, 16GB DDR4 RDIMM", commodity_hint="motherboards") is None
+
+
+def test_neutral_leads_fall_through_to_body_and_hint():
+    # Packaging-word / brand / SPS- leads are NEUTRAL — they must not die foreign.
+    # "ASSY," rescued by the body LTO token; "Innolux," by the body LCD token;
+    # "MSI," and "SPS-PCA," by the caller's gpu hint (no routing token in the body).
+    result = extract_desc("ASSY,DR,BAY,FC,LTO8,TL2/4K")
+    assert result is not None and result.commodity == "tape_drives"
+    result = extract_desc('Innolux, LCD, 21.5"')
+    assert result is not None and result.commodity == "displays"
+    result = extract_desc("MSI, RTX3080, 10G/D6X/3DP/H", commodity_hint="gpu")
+    assert result is not None and result.commodity == "gpu"
+    result = extract_desc("SPS-PCA, NVIDIA Tesla V100 32GB Module", commodity_hint="gpu")
+    assert result is not None and result.commodity == "gpu"
+    # Without a body token or hint, a neutral lead still extracts NOTHING.
+    assert extract_desc("MSI, RTX3080, 10G/D6X/3DP/H") is None
+
+
+def test_neutral_lead_keeps_phase1_conflict_guards():
+    # Behind a neutral brand lead, a body mixing HDD+DIMM tokens still hard-conflicts
+    # to None (constructed string — the guard predates phase 2 and must survive it).
+    assert extract_desc("HP, 16GB DDR4 DIMM + 512GB SSD bundle") is None
+
+
+def test_lead_label_dot_strip_normalization():
+    # "PSU., 750W TT ITIC, Acbel…" captures the label "PSU." — the trailing dot is
+    # stripped before the map lookup instead of sending the row foreign.
+    result = extract_desc("PSU., 750W TT ITIC, Acbel PN FSF061-EL1G")
+    assert result is not None
+    assert result.commodity == "power_supplies"
+    assert result.specs == {"wattage": 750}
 
 
 def test_cross_family_conflict_with_storage_hint():
@@ -155,3 +208,31 @@ def test_emittable_vocabulary_matches_commodity_seeds():
     assert _RANK_VALID == enum_values("dram", "rank")
     assert (_CAP_MIN, _CAP_MAX) == numeric_range("dram", "capacity_gb")
     assert (_SPEED_MIN, _SPEED_MAX) == numeric_range("dram", "speed_mhz")
+
+    # ── phase-2 commodities (power / display / tape / gpu / board) ──
+    from app.services.desc_extractor import board, display, gpu, power, tape
+
+    assert {p[0] for p in power._CLASS_PATTERNS} <= enum_values("power_supplies", "psu_class")
+    assert (power._WATT_MIN, power._WATT_MAX) == numeric_range("power_supplies", "wattage")
+
+    assert set(display._RES_BY_NAME.values()) <= enum_values("displays", "resolution")
+    assert display._RES_SEEDED <= enum_values("displays", "resolution")
+    assert display.LED in enum_values("displays", "backlight")
+    assert (display._DIAG_MIN, display._DIAG_MAX) == numeric_range("displays", "diagonal_size")
+
+    emittable_drive_types = (
+        {f"LTO-{g}" for g in range(3, 10)}
+        | {f"TS11{m}" for m in ("40", "50", "55", "60", "70")}
+        | set(tape._3592_BY_MODEL.values())
+        | set(tape._JAG_BY_GEN.values())
+        | {tape.DAT, tape.AIT}
+    )
+    assert emittable_drive_types == enum_values("tape_drives", "drive_type")
+    assert {p[0] for p in tape._IFACE_PATTERNS} == enum_values("tape_drives", "interface")
+    assert {p[0] for p in tape._FORM_PATTERNS} <= enum_values("tape_drives", "form_factor")
+
+    gpu_members = {p[0] for p in gpu._FAMILY_PATTERNS} | {gpu.GEFORCE, gpu.RTX}
+    assert gpu_members == enum_values("gpu", "gpu_family")
+    assert (gpu._MEM_MIN, gpu._MEM_MAX) == numeric_range("gpu", "memory_gb")
+
+    assert {p[0] for p in board._BOARD_PATTERNS} == enum_values("motherboards", "board_type")

--- a/tests/test_desc_extractor_tape.py
+++ b/tests/test_desc_extractor_tape.py
@@ -71,6 +71,11 @@ CASES = [
     # ── hint-routed grammar without a routing token ──────────────────────
     ("LTO GEN5", "tape_drives", {"drive_type": "LTO-5"}),
     ("LTO7HHSAS", "tape_drives", {}),  # fully glued — every boundary dead, deliberate miss
+    # ── media/supplies rows: cartridges and label packs are NOT drives ───
+    ("Tape, Cleaning Cartridge, DAT 320, IBM", None, {}),
+    ("HP Q2078A LTO8 30TB RW DATA CARTRIDGE", None, {}),
+    ("SPS-Data Cartridge, LTO-8 30TB WORM", None, {}),
+    ("LTO6-LABEL", None, {}),  # barcode-label pack — glued LTO6 routes, _MEDIA suppresses
 ]
 
 
@@ -87,3 +92,11 @@ def test_library_lead_is_foreign_even_with_drive_grammar():
     # A library is not a drive: the "Library," lead suppresses extraction entirely —
     # accepted conservative loss, even though Jag6/3592 drive tokens appear.
     assert extract_desc("Library, 3592 Tape Drive, Jag6 Drive") is None
+
+
+def test_conflicting_generations_and_interfaces_omit_both_keys():
+    # Conflict pins for the unique-survivor contract: LTO-5×LTO-6 drops drive_type
+    # and SAS×FC drops interface — never first-match/max picked.
+    result = extract_desc("Tape Drive, LTO-5 / LTO-6, SAS FC")
+    assert result is not None
+    assert result.specs == {}

--- a/tests/test_desc_extractor_tape.py
+++ b/tests/test_desc_extractor_tape.py
@@ -1,0 +1,89 @@
+"""Accuracy guard for the tape-drive description extractor — REAL corpus strings → exact
+specs.
+
+Every description below is verbatim from TRIO's part master
+(/root/source_ingest/LSC1__Material__c.csv, Material_Description__c). Expectations are
+FULL equality — a new key appearing unexpectedly is as much a failure as a missing one.
+"""
+
+import pytest
+
+from app.services.desc_extractor import extract_desc
+
+# (real description, commodity_hint or None, exact expected specs)
+CASES = [
+    # ── TRIO part-master "<Label>, …" grammar ────────────────────────────
+    (
+        "Tape Drive, 400/800gb Ultrium Lto-3 HH SCSI LVD External",  # 400/800gb pair never read
+        None,
+        {"drive_type": "LTO-3", "interface": "SCSI", "form_factor": "Half-Height"},
+    ),
+    (
+        "Tape Drive, Jag 5,TS3500, TS1150, 3592-E08",  # three agreeing Jaguar-gen-5 signals
+        None,
+        {"drive_type": "TS1150"},
+    ),
+    ("Tape, JAG 6, SAS", None, {"drive_type": "TS1160", "interface": "SAS"}),
+    ("Tape, JAG 7", None, {"drive_type": "TS1170"}),
+    (
+        "Tape LTO-9, FH, SAS",  # comma-less first token "Tape" routes (digit blocks the lead)
+        None,
+        {"drive_type": "LTO-9", "interface": "SAS", "form_factor": "Full-Height"},
+    ),
+    (
+        "Tape Drive, IBM 2.5 / 6.25TB Ultrium 6 LTO6 half-high SAS tape drive, 7226-1U3, G6HxServer, SAS",
+        None,
+        {"drive_type": "LTO-6", "interface": "SAS", "form_factor": "Half-Height"},
+    ),
+    # ── body-token routing (no lead label) ───────────────────────────────
+    ("LTO9 CANIS", None, {"drive_type": "LTO-9"}),  # glued generation token
+    (
+        "TS4300 LTO7 HH Fibre Channel Drive",  # TS4300 is a library model — matches nothing
+        None,
+        {"drive_type": "LTO-7", "interface": "FC", "form_factor": "Half-Height"},
+    ),
+    (
+        "DAT160 INTERNAL USB TAPE DRIVE 80/160GB MFG REF",
+        None,
+        {"drive_type": "DAT", "interface": "USB"},
+    ),
+    (
+        "TS1160 Tape drive with caddy for TS4500, 20-40TB SAS 12Gb",
+        None,
+        {"drive_type": "TS1160", "interface": "SAS"},
+    ),
+    (
+        "ASSY,DR,BAY,FC,LTO8,TL2/4K",  # neutral "ASSY," lead — body LTO8 rescues the route
+        None,
+        {"drive_type": "LTO-8", "interface": "FC"},
+    ),
+    ("FIBRE LTO5(ROHS)", None, {"drive_type": "LTO-5", "interface": "FC"}),
+    (
+        "EJ014B Black 3TB 1U Rack mount SAS 6Gb/s Interface LTO-5 Ultrium 3000 Tape Drive",
+        None,
+        {"drive_type": "LTO-5", "interface": "SAS"},  # "Ultrium 3000" rejected; no capacity key
+    ),
+    (
+        "IBM 3588-F8C TS1080 LTO 8 FH FC for TS4500",  # TS1080/TS4500 match nothing — LTO-8
+        None,
+        {"drive_type": "LTO-8", "interface": "FC", "form_factor": "Full-Height"},
+    ),
+    # ── hint-routed grammar without a routing token ──────────────────────
+    ("LTO GEN5", "tape_drives", {"drive_type": "LTO-5"}),
+    ("LTO7HHSAS", "tape_drives", {}),  # fully glued — every boundary dead, deliberate miss
+]
+
+
+@pytest.mark.parametrize("description,hint,expected", CASES)
+def test_tape_extract_exact(description, hint, expected):
+    result = extract_desc(description, commodity_hint=hint)
+    assert result is not None, f"{description!r} did not extract"
+    assert result.commodity == "tape_drives"
+    assert result.specs == expected
+    assert result.confidence == 0.90
+
+
+def test_library_lead_is_foreign_even_with_drive_grammar():
+    # A library is not a drive: the "Library," lead suppresses extraction entirely —
+    # accepted conservative loss, even though Jag6/3592 drive tokens appear.
+    assert extract_desc("Library, 3592 Tape Drive, Jag6 Drive") is None

--- a/tests/test_taxonomy_seed_expansion.py
+++ b/tests/test_taxonomy_seed_expansion.py
@@ -31,14 +31,17 @@ def test_tape_drives_spec_set():
 
     drive_type = _spec("tape_drives", "drive_type")
     assert drive_type["is_primary"] is True
+    # LTO-3/LTO-4/TS1170 are desc-grammar phase-2 extensions, appended at the END
+    # (the sidebar renders enum order).
     assert drive_type["enum_values"] == [
         "LTO-5", "LTO-6", "LTO-7", "LTO-8", "LTO-9",
         "TS1140", "TS1150", "TS1155", "TS1160", "DAT", "AIT",
+        "LTO-3", "LTO-4", "TS1170",
     ]  # fmt: skip
 
     interface = _spec("tape_drives", "interface")
     assert interface["is_primary"] is True
-    assert interface["enum_values"] == ["FC", "SAS", "SCSI"]
+    assert interface["enum_values"] == ["FC", "SAS", "SCSI", "USB"]  # USB: phase-2 append
 
     assert _spec("tape_drives", "form_factor")["enum_values"] == ["Full-Height", "Half-Height", "Library Module"]
 


### PR DESCRIPTION
## What

Wave-2 of the deterministic description→spec extractor (`app/services/desc_extractor/`): five new commodity grammars per `SPEC_DESC_GRAMMAR_PHASE2.md`, taking spec coverage from 3 commodities (hdd/ssd/dram, #247) to 8. Same contract: pure functions, no network/LLM, confidence 0.90, source `desc_parse`, conflict ⇒ omit the key, foreign lead ⇒ suppress entirely.

## Per-commodity grammar coverage (verbatim corpus examples)

**power_supplies — `power.py` → wattage, psu_class**
- `"PSU, 1460W 240V/200V AC Hot Swap for EN 62368-1"` → `{wattage: 1460, psu_class: "Server/Redundant"}`
- `"AC ADAPTERS, 45Watt, 20V2.25A COO"` → `{wattage: 45, psu_class: "AC-DC (External/Adapter)"}`
- `"PWR_SUPPLY 1300W Delta power supply"` → `{wattage: 1300}` (generic PSU deliberately emits no class)
- Misses by design: `"PS MT 250WENT17"` (glued), `"PCA, PSUPLY BPLN 370, 240VA"` (VA ≠ W), `"AC Adapter;PA-1300-42;20V/1.5A"` (1300 inside the MPN ⇒ class only), `"CHANGER WALL…"` (CHANGER ≠ CHARGER).
- **Structural guard:** `wattage` only exists on the psu route; cpu stays hint-only, so `"SPS-CPU … 135W"` TDP is unreachable (pinned in routing tests).

**displays — `display.py` → resolution, diagonal_size, backlight**
- `"PNL,15.6 FHD AG WLED SVA 45% 220neDP,INX"` → `{resolution: "1920x1080", diagonal_size: 15.6, backlight: "LED"}`
- `'LCD, 21.5", LG'` → `{diagonal_size: 21.5}` · `"SPS-DSPLY HU 17.3 DRM UHD IR"` → `{resolution: "3840x2160"}` (bare 17.3 missed by design)
- `HD+` excluded by `(?!\+)`; WXGA unmapped; WLED/LED collapse to the new generic `"LED"` bucket (never the seeded "LED White"/"LED RGB").

**tape_drives — `tape.py` → drive_type, interface, form_factor**
- `"Tape Drive, Jag 5,TS3500, TS1150, 3592-E08"` → `{drive_type: "TS1150"}` (three agreeing closed-map signals)
- `"Tape, JAG 7"` → TS1170 · `"LTO9 CANIS"` → LTO-9 · `"DAT160 INTERNAL USB TAPE DRIVE…"` → `{drive_type: "DAT", interface: "USB"}`
- `"Ultrium 3000"` rejected by `(?!\d)`; `"TS1080"`/`"TS4500"` match nothing; `"Library,"` lead stays foreign; native-capacity pairs (`400/800gb`) never read.

**gpu — `gpu.py` → gpu_family, memory_gb**
- `"SPS-PCA, NVIDIA Tesla V100 32GB Module"` → `{gpu_family: "Tesla", memory_gb: 32}` · `"MSI, RTX3080, 10G/D6X/3DP/H"` → `{gpu_family: "RTX", memory_gb: 10}` (glued `NG/D6` grammar)
- GEFORCE subsumes its own GTX/RTX sub-brand tokens; `"GeForce GTX, Quadro P2000 … 5GB"` ⇒ family conflict omitted, `memory_gb: 5` still emits; PASCAL/bare models unmapped.
- **GPU-context-token guard on memory_gb:** `"Emulex, 10GB, SFP+Mezza Card"`, `"NVIDIA ConnectX-7 … 100GbE"`, RAID-flash `"… 4GB Modular Flash"` all emit `{}`.

**motherboards — `board.py` → board_type**
- `"MB, B82CD NOK A49120C UMA 4G32G"` / `"BDPLANAR WIN,i5-10210U,…"` / `"SPS - BD SYS SL390/SL2x390"` → System Board; `"SUPERMICRO FRU,DAUGHTER CARD REPLACEMENT KIT"` → Daughter Board
- `"MB, 7063-CR1 System backplane kit"` ⇒ MB×Backplane conflict, omitted; spaced-megabyte `"… 16 MB …"` killed by lookbehind; `"SPS-MB DSC GTX1050 4GB i7…"` stays a motherboard with no GB/family leak (route has no GB key).

## Router (`__init__.py`)

- `SPEC_COMMODITIES` → 8 (shared `_common` constant — serves both the spec's `_SPEC_COMMODITIES` and the writer's `_HANDLED`); cpu stays hint-only.
- `_FAMILY`: displays/tape/gpu new; motherboards→board, power_supplies→power (no longer "other"). Hard cross-family conflict stays storage×dram only.
- **NEW `_NEUTRAL_LEADS`**: packaging words + brands + any `SPS`-prefixed lead fall through to body-token/hint arbitration instead of dying foreign (rescues `"ASSY,DR,BAY,FC,LTO8,TL2/4K"`, `'Innolux, LCD, 21.5"'`, `"MSI, RTX3080, …"`). Phase-1 guards still hold behind a neutral lead.
- Lead-label dot-strip (`"PSU., 750W TT ITIC, Acbel…"` no longer foreign); `_LEAD_MAP`/`_FIRST_TOKEN_MAP`/`_BODY_TOKENS` extended per spec (`"CARD,"` stays FOREIGN — GC bucket only ~38% real GPUs).

## The 8 seed edits (`commodity_seeds.json` — append/augment-only, no migration)

1. motherboards: NEW `board_type` enum spec (sort_order 9, primary)
2. displays.resolution: +`1366x768, 1920x1200, 2560x1440, 3840x2160` (at END)
3. displays.backlight: +`LED` (at END)
4. displays.diagonal_size: `numeric_range {7, 86}`
5. power_supplies.wattage: `numeric_range {30, 5000}`
6. tape_drives.drive_type: +`LTO-3, LTO-4, TS1170` (at END)
7. tape_drives.interface: +`USB` (at END)
8. gpu.memory_gb: `numeric_range {1, 96}`

Boot `seed_commodity_schemas()` inserts new pairs; `reseed_changed_schemas()` reconciles changed enum_values/numeric_range.

## Flipped-test migrations (required by spec §5)

- `HINT_ONLY_CASES` lost the 3 motherboards entries and `"Power Supply, V7000 Gen2 Expansion 800W, IBM"` → now spec cases in `test_desc_extractor_board.py` / `_power.py` (board_type / wattage 800). CPU cases stay hint-only.
- `NONE_CASES` lost `'LCD, 21.5", LG'` → now displays, `{diagonal_size: 21.5}`.
- `test_taxonomy_seed_expansion.py` enum pins updated for the end-appends (drive_type +3, interface +USB).

## Tests

- 5 new test files (`tests/test_desc_extractor_{power,display,tape,gpu,board}.py`): **82 tests**, ~80 verbatim corpus strings (all greped against `LSC1__Material__c.csv` / `Firesale_inventory.txt` before use; 3 spec strings corrected to their true corpus forms — double spaces in `"Aristocrat  MK7…"`/`"TFD LCD  TOUCH…"`).
- Routing suite extended: neutral leads, dot-strip, new-family lead-vs-hint contradiction, cpu wattage structural guard, foreign `"Card,"`/`"Library,"`; drift guard now pins every phase-2 enum constant + numeric range against the seeds.
- Writer suite: phase-2 PSU card writes wattage+psu_class through record_spec; LTO-3/USB/board_type seed appends round-trip enum validation; 0.95 vendor-API prior survives the 0.90 desc pass on a gpu card.
- Full suite: **15179 passed, 34 skipped, 1 xfailed**; `pre-commit run --all-files` clean.

## Spec deviations (with reasons)

1. **`_SPEC_COMMODITIES`/`_HANDLED` naming:** the #247 codebase already unified both as the shared `SPEC_COMMODITIES` in `_common.py` (single source of truth imported by router AND writer). Expanded that one constant instead of introducing a duplicate `_HANDLED` set — semantics identical.
2. **Multi-word neutral leads:** the spec's own required case `"SUPERMICRO FRU,DAUGHTER CARD…"` has a lead (`SUPERMICRO FRU`) that is in neither the neutral set nor the lead map. Added a last-word rule (label whose final word is neutral ⇒ neutral) — `"VPD CARD,"` stays foreign (CARD is not a neutral word).
3. **GTX/RTX boundary:** spec prose says `\bGTX\b`/`\bRTX\b`, but its own test cases are glued (`RTX3080`, `GTX1660Super`). Implemented `\b(G|R)TX(?=\d|\b)` so both forms match.
4. **(b)-grammar diagonal lookahead** also carries the `(?!\+)` HD+ exclusion (spec implies it via the `"5.5 HD+LCD"` ⇒ emits-nothing case; the 7" floor would catch that one anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)