### PR TITLE
feat(cdm): split-panel account workspace with click-to-contact outreach logging

### DIFF
--- a/alembic/versions/095_add_wechat_id_to_site_contacts.py
+++ b/alembic/versions/095_add_wechat_id_to_site_contacts.py
@@ -1,8 +1,9 @@
 """Add wechat_id to site_contacts — WeChat handle for click-to-message outreach.
 
 Used by the CDM account workspace contact panel (click-to-WeChat deep link with
-activity logging). Written by the site-contact create form; read by
-app/templates/htmx/partials/customers/tabs/contacts_tab.html.
+activity logging). Written by the site-contact create form; rendered in the
+customer contact panels (app/templates/htmx/partials/customers/tabs/
+contacts_tab.html and site_contacts.html).
 
 Downgrade drops the column (data loss limited to manually entered WeChat IDs).
 

--- a/alembic/versions/095_add_wechat_id_to_site_contacts.py
+++ b/alembic/versions/095_add_wechat_id_to_site_contacts.py
@@ -1,0 +1,29 @@
+"""Add wechat_id to site_contacts — WeChat handle for click-to-message outreach.
+
+Used by the CDM account workspace contact panel (click-to-WeChat deep link with
+activity logging). Written by the site-contact create form; read by
+app/templates/htmx/partials/customers/tabs/contacts_tab.html.
+
+Downgrade drops the column (data loss limited to manually entered WeChat IDs).
+
+Revision ID: 095_wechat_id
+Revises: 094_fru_links
+Create Date: 2026-06-10
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "095_wechat_id"
+down_revision = "094_fru_links"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("site_contacts", sa.Column("wechat_id", sa.String(length=100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("site_contacts", "wechat_id")

--- a/app/constants.py
+++ b/app/constants.py
@@ -387,6 +387,7 @@ class ActivityType(StrEnum):
     PROACTIVE_MATCH = "proactive_match"
     PART_STATUS_CHANGE = "part_status_change"
     TEAMS_MESSAGE = "teams_message"
+    WECHAT_MESSAGE = "wechat_message"
 
 
 class Channel(StrEnum):
@@ -401,6 +402,7 @@ class Channel(StrEnum):
     OUTLOOK = "outlook"
     CALENDAR = "calendar"
     AVAIL_SYSTEM = "avail_system"
+    WECHAT = "wechat"
 
 
 class EventType(StrEnum):

--- a/app/constants.py
+++ b/app/constants.py
@@ -405,6 +405,15 @@ class Channel(StrEnum):
     WECHAT = "wechat"
 
 
+class OutreachChannel(StrEnum):
+    """Click-to-contact outreach channels (CDM contact panel buttons)."""
+
+    PHONE = "phone"
+    EMAIL = "email"
+    TEAMS = "teams"
+    WECHAT = "wechat"
+
+
 class EventType(StrEnum):
     """Canonical activity_log.event_type values (Communication-Intelligence kind)."""
 

--- a/app/models/crm.py
+++ b/app/models/crm.py
@@ -170,6 +170,7 @@ class SiteContact(Base):
     title = Column(String(255))
     email = Column(String(255))
     phone = Column(String(100))
+    wechat_id = Column(String(100))
     notes = Column(Text)
     is_primary = Column(Boolean, default=False)
     is_active = Column(Boolean, default=True)

--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -20,31 +20,62 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
 from sqlalchemy.orm import Session
 
-from ..constants import ActivityType, Channel, Direction, EventType
+from ..constants import ActivityType, Channel, Direction, EventType, OutreachChannel
 from ..database import get_db
 from ..dependencies import require_user
-from ..models import ActivityLog, Company, User, VendorCard
+from ..models import ActivityLog, Company, CustomerSite, SiteContact, User, VendorCard
 from ..schemas.activity import ActivityTimelineResponse, CallInitiatedRequest, OutreachInitiatedRequest
+from ..services.activity_service import bump_company_site_activity, log_outreach_initiated
 from ..utils.phone_utils import format_phone_display, format_phone_e164
 
 router = APIRouter(prefix="/api/activity", tags=["activity"])
 
 # ── In-memory rate limiter ─────────────────────────────────────────────
-_call_log: dict[int, list[float]] = defaultdict(list)
-_RATE_LIMIT = 10  # max calls per user per minute
+# Buckets are keyed per user AND per endpoint family so a rep's heavy phone
+# use never silently blocks their email/Teams outreach logging (and vice
+# versa). Outreach gets a higher budget: the CDM call-list workflow can
+# legitimately produce several logs per contact per minute.
+_call_log: dict[str, list[float]] = defaultdict(list)
+_RATE_LIMIT = 10  # max click-to-call logs per user per minute
+_OUTREACH_RATE_LIMIT = 30  # max outreach logs per user per minute
 
 
-def _check_rate_limit(user_id: int) -> bool:
+def _check_rate_limit(user_id: int, bucket: str = "call", limit: int = _RATE_LIMIT) -> bool:
     """Return True if user is within rate limit, False if exceeded."""
+    key = f"{user_id}:{bucket}"
     now = time.time()
     window = now - 60
-    timestamps = _call_log[user_id]
+    timestamps = _call_log[key]
     # Prune old entries
-    _call_log[user_id] = [t for t in timestamps if t > window]
-    if len(_call_log[user_id]) >= _RATE_LIMIT:
+    _call_log[key] = [t for t in timestamps if t > window]
+    if len(_call_log[key]) >= limit:
         return False
-    _call_log[user_id].append(now)
+    _call_log[key].append(now)
     return True
+
+
+def _validated_entity_ids(
+    db: Session,
+    company_id: int | None,
+    customer_site_id: int | None,
+    site_contact_id: int | None = None,
+) -> tuple[int | None, int | None, int | None]:
+    """Null out entity ids that don't exist (warn, don't reject).
+
+    The DOM can carry stale ids (e.g. a coworker deleted the contact while the panel was
+    open); inserting them raises FK IntegrityError → opaque 500. Keep the activity, drop
+    the dangling link.
+    """
+    if company_id and not db.get(Company, company_id):
+        logger.warning(f"activity log: company_id={company_id} not found — dropping link")
+        company_id = None
+    if customer_site_id and not db.get(CustomerSite, customer_site_id):
+        logger.warning(f"activity log: customer_site_id={customer_site_id} not found — dropping link")
+        customer_site_id = None
+    if site_contact_id and not db.get(SiteContact, site_contact_id):
+        logger.warning(f"activity log: site_contact_id={site_contact_id} not found — dropping link")
+        site_contact_id = None
+    return company_id, customer_site_id, site_contact_id
 
 
 @router.post("/call-initiated", status_code=201)
@@ -70,7 +101,7 @@ def call_initiated(
         phone_display = format_phone_display(body.phone_number)
 
         # Resolve company from vendor if not provided
-        company_id = body.company_id
+        company_id, customer_site_id, _ = _validated_entity_ids(db, body.company_id, body.customer_site_id)
         vendor_card_id = body.vendor_card_id
         vendor_name = None
 
@@ -109,7 +140,7 @@ def call_initiated(
             is_meaningful=True,
             vendor_card_id=vendor_card_id,
             company_id=company_id,
-            customer_site_id=body.customer_site_id,
+            customer_site_id=customer_site_id,
             requisition_id=requisition_id,
             contact_phone=e164,
             subject=subject,
@@ -117,14 +148,16 @@ def call_initiated(
             notes=f"source=click_to_call origin={body.origin or 'unknown'} phone_display={phone_display}",
         )
         db.add(record)
+        # A logged call is a touch — keep the CDM staleness sort honest.
+        bump_company_site_activity(db, company_id, customer_site_id)
         db.commit()
 
         return {"id": record.id}
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"call-initiated error: {e}")
+    except Exception:
+        logger.exception("call-initiated error")
         db.rollback()
         raise HTTPException(500, "Failed to record phone contact")
 
@@ -137,39 +170,40 @@ def outreach_initiated(
 ):
     """Log a click-to-contact event (phone / email / Teams / WeChat).
 
-    Fired from the CDM account workspace contact panel when a user clicks a tel:/
-    mailto:/Teams/WeChat
-    link. Creates an outbound ActivityLog and bumps
-    company/site last_activity_at so the staleness sort updates.
+    Fired from the CDM contact panel on tel:/mailto:/Teams/WeChat link clicks.
+    Creates an outbound ActivityLog and bumps company/site last_activity_at so
+    the staleness sort updates. Re-clicks within the dedup window return the
+    existing record.
     """
     try:
         contact_value = body.contact_value.strip()
-        if body.channel == "phone":
+        if body.channel == OutreachChannel.PHONE:
             e164 = format_phone_e164(contact_value)
             if not e164:
                 raise HTTPException(400, "Invalid phone number")
             contact_value = e164
-        elif body.channel in ("email", "teams") and "@" not in contact_value:
-            raise HTTPException(400, "Invalid email address")
+        elif body.channel in (OutreachChannel.EMAIL, OutreachChannel.TEAMS):
+            local, _, domain = contact_value.partition("@")
+            if not local or "." not in domain:
+                raise HTTPException(400, "Invalid email address")
         elif not contact_value:
             raise HTTPException(400, "Contact value is required")
 
-        if not _check_rate_limit(user.id):
+        if not _check_rate_limit(user.id, bucket="outreach", limit=_OUTREACH_RATE_LIMIT):
             raise HTTPException(429, "Too many outreach logs — try again in a minute")
 
-        if body.company_id and not db.get(Company, body.company_id):
-            logger.warning(f"outreach-initiated: company_id={body.company_id} not found")
-
-        from ..services.activity_service import log_outreach_initiated
+        company_id, customer_site_id, site_contact_id = _validated_entity_ids(
+            db, body.company_id, body.customer_site_id, body.site_contact_id
+        )
 
         record = log_outreach_initiated(
             db,
             user_id=user.id,
             channel=body.channel,
             contact_value=contact_value,
-            company_id=body.company_id,
-            customer_site_id=body.customer_site_id,
-            site_contact_id=body.site_contact_id,
+            company_id=company_id,
+            customer_site_id=customer_site_id,
+            site_contact_id=site_contact_id,
             contact_name=body.contact_name,
             origin=body.origin,
         )
@@ -178,8 +212,8 @@ def outreach_initiated(
 
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"outreach-initiated error: {e}")
+    except Exception:
+        logger.exception("outreach-initiated error")
         db.rollback()
         raise HTTPException(500, "Failed to record outreach")
 

--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -24,7 +24,7 @@ from ..constants import ActivityType, Channel, Direction, EventType
 from ..database import get_db
 from ..dependencies import require_user
 from ..models import ActivityLog, Company, User, VendorCard
-from ..schemas.activity import ActivityTimelineResponse, CallInitiatedRequest
+from ..schemas.activity import ActivityTimelineResponse, CallInitiatedRequest, OutreachInitiatedRequest
 from ..utils.phone_utils import format_phone_display, format_phone_e164
 
 router = APIRouter(prefix="/api/activity", tags=["activity"])
@@ -127,6 +127,61 @@ def call_initiated(
         logger.error(f"call-initiated error: {e}")
         db.rollback()
         raise HTTPException(500, "Failed to record phone contact")
+
+
+@router.post("/outreach-initiated", status_code=201)
+def outreach_initiated(
+    body: OutreachInitiatedRequest,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Log a click-to-contact event (phone / email / Teams / WeChat).
+
+    Fired from the CDM account workspace contact panel when a user clicks a tel:/
+    mailto:/Teams/WeChat
+    link. Creates an outbound ActivityLog and bumps
+    company/site last_activity_at so the staleness sort updates.
+    """
+    try:
+        contact_value = body.contact_value.strip()
+        if body.channel == "phone":
+            e164 = format_phone_e164(contact_value)
+            if not e164:
+                raise HTTPException(400, "Invalid phone number")
+            contact_value = e164
+        elif body.channel in ("email", "teams") and "@" not in contact_value:
+            raise HTTPException(400, "Invalid email address")
+        elif not contact_value:
+            raise HTTPException(400, "Contact value is required")
+
+        if not _check_rate_limit(user.id):
+            raise HTTPException(429, "Too many outreach logs — try again in a minute")
+
+        if body.company_id and not db.get(Company, body.company_id):
+            logger.warning(f"outreach-initiated: company_id={body.company_id} not found")
+
+        from ..services.activity_service import log_outreach_initiated
+
+        record = log_outreach_initiated(
+            db,
+            user_id=user.id,
+            channel=body.channel,
+            contact_value=contact_value,
+            company_id=body.company_id,
+            customer_site_id=body.customer_site_id,
+            site_contact_id=body.site_contact_id,
+            contact_name=body.contact_name,
+            origin=body.origin,
+        )
+        db.commit()
+        return {"id": record.id}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"outreach-initiated error: {e}")
+        db.rollback()
+        raise HTTPException(500, "Failed to record outreach")
 
 
 @router.get("/account/{company_id}", response_model=ActivityTimelineResponse)

--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -59,23 +59,50 @@ def _validated_entity_ids(
     company_id: int | None,
     customer_site_id: int | None,
     site_contact_id: int | None = None,
-) -> tuple[int | None, int | None, int | None]:
-    """Null out entity ids that don't exist (warn, don't reject).
+) -> tuple[int | None, int | None, int | None, list[str]]:
+    """Drop entity links that don't exist or don't belong together (warn, don't reject).
 
-    The DOM can carry stale ids (e.g. a coworker deleted the contact while the panel was
-    open); inserting them raises FK IntegrityError → opaque 500. Keep the activity, drop
-    the dangling link.
+    The DOM can carry stale ids (e.g. a coworker deleted or moved the contact while the
+    panel was open). Nonexistent ids would raise FK IntegrityError → opaque 500, and
+    ActivityLog has no DB constraint tying company/site/contact together, so a
+    mismatched triple would persist an inconsistent link and bump last_activity_at on an
+    unrelated site. Keep the activity, drop the dangling/mismatched links, and report
+    what was dropped so the caller can surface the degradation instead of claiming full
+    success.
+
+    Returns (company_id, customer_site_id, site_contact_id, dropped) — dropped is a
+    subset of ["company", "site", "contact"] naming the links removed.
     """
+    dropped: list[str] = []
     if company_id and not db.get(Company, company_id):
         logger.warning(f"activity log: company_id={company_id} not found — dropping link")
         company_id = None
-    if customer_site_id and not db.get(CustomerSite, customer_site_id):
+        dropped.append("company")
+    site = db.get(CustomerSite, customer_site_id) if customer_site_id else None
+    if customer_site_id and not site:
         logger.warning(f"activity log: customer_site_id={customer_site_id} not found — dropping link")
         customer_site_id = None
-    if site_contact_id and not db.get(SiteContact, site_contact_id):
+        dropped.append("site")
+    elif site and site.company_id != company_id:
+        logger.warning(
+            f"activity log: customer_site_id={customer_site_id} belongs to company "
+            f"{site.company_id}, not {company_id} — dropping link"
+        )
+        customer_site_id = None
+        dropped.append("site")
+    contact = db.get(SiteContact, site_contact_id) if site_contact_id else None
+    if site_contact_id and not contact:
         logger.warning(f"activity log: site_contact_id={site_contact_id} not found — dropping link")
         site_contact_id = None
-    return company_id, customer_site_id, site_contact_id
+        dropped.append("contact")
+    elif contact and contact.customer_site_id != customer_site_id:
+        logger.warning(
+            f"activity log: site_contact_id={site_contact_id} belongs to site "
+            f"{contact.customer_site_id}, not {customer_site_id} — dropping link"
+        )
+        site_contact_id = None
+        dropped.append("contact")
+    return company_id, customer_site_id, site_contact_id, dropped
 
 
 @router.post("/call-initiated", status_code=201)
@@ -101,7 +128,7 @@ def call_initiated(
         phone_display = format_phone_display(body.phone_number)
 
         # Resolve company from vendor if not provided
-        company_id, customer_site_id, _ = _validated_entity_ids(db, body.company_id, body.customer_site_id)
+        company_id, customer_site_id, _, _ = _validated_entity_ids(db, body.company_id, body.customer_site_id)
         vendor_card_id = body.vendor_card_id
         vendor_name = None
 
@@ -192,7 +219,7 @@ def outreach_initiated(
         if not _check_rate_limit(user.id, bucket="outreach", limit=_OUTREACH_RATE_LIMIT):
             raise HTTPException(429, "Too many outreach logs — try again in a minute")
 
-        company_id, customer_site_id, site_contact_id = _validated_entity_ids(
+        company_id, customer_site_id, site_contact_id, dropped = _validated_entity_ids(
             db, body.company_id, body.customer_site_id, body.site_contact_id
         )
 
@@ -208,7 +235,10 @@ def outreach_initiated(
             origin=body.origin,
         )
         db.commit()
-        return {"id": record.id}
+        # dropped_links tells the client which stale entity links were removed —
+        # the touch IS logged, but it won't appear on the account it was clicked
+        # from, so the frontend downgrades its success toast to a warning.
+        return {"id": record.id, "dropped_links": dropped}
 
     except HTTPException:
         raise

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4345,37 +4345,79 @@ def _staleness_tier(last_activity_at: datetime | None) -> str:
     return "recent"
 
 
-@router.get("/v2/partials/customers", response_class=HTMLResponse)
-async def companies_list_partial(
-    request: Request,
-    search: str = "",
-    limit: int = Query(50, ge=1, le=200),
-    offset: int = Query(0, ge=0),
-    hx_target: str = Query("#main-content", alias="hx_target"),
-    push_url_base: str = Query("/v2/customers", alias="push_url_base"),
-    user: User = Depends(require_user),
-    db: Session = Depends(get_db),
+# Sort options for the CDM account workspace left panel. Default "oldest"
+# puts the longest-neglected accounts at the top (call-list order).
+_CDM_SORTS = {
+    "oldest": lambda: Company.last_activity_at.asc().nullsfirst(),
+    "newest": lambda: Company.last_activity_at.desc().nullslast(),
+    "name_asc": lambda: sqlfunc.lower(Company.name).asc(),
+    "name_desc": lambda: sqlfunc.lower(Company.name).desc(),
+}
+
+_CDM_ACCOUNT_TYPES = ("Customer", "Prospect", "Partner", "Competitor")
+
+
+def _cdm_company_query(
+    db: Session, user: User, *, search: str, staleness: str, account_type: str, my_only: str, sort: str
 ):
-    """Return companies list as HTML partial."""
-    hx_target, push_url_base = _sanitize_hx_params(hx_target, push_url_base, "/v2/customers")
+    """Build the filtered + sorted CDM account list query."""
     query = db.query(Company).filter(Company.is_active.is_(True)).options(joinedload(Company.account_owner))
 
     if search.strip():
         sb = SearchBuilder(search.strip())
         query = query.filter(sb.ilike_filter(Company.name))
 
-    total = query.count()
-    companies = query.order_by(Company.last_activity_at.asc().nullsfirst()).offset(offset).limit(limit).all()
+    now = datetime.now(timezone.utc)
+    overdue_cutoff = now - timedelta(days=STALENESS_OVERDUE_DAYS)
+    due_soon_cutoff = now - timedelta(days=STALENESS_DUE_SOON_DAYS)
+    if staleness == "overdue":
+        query = query.filter(Company.last_activity_at < overdue_cutoff)
+    elif staleness == "due_soon":
+        query = query.filter(
+            Company.last_activity_at >= overdue_cutoff,
+            Company.last_activity_at < due_soon_cutoff,
+        )
+    elif staleness == "recent":
+        query = query.filter(Company.last_activity_at >= due_soon_cutoff)
+    elif staleness == "new":
+        query = query.filter(Company.last_activity_at.is_(None))
 
+    if account_type in _CDM_ACCOUNT_TYPES:
+        query = query.filter(Company.account_type == account_type)
+    if my_only:
+        query = query.filter(Company.account_owner_id == user.id)
+
+    sort_fn = _CDM_SORTS.get(sort, _CDM_SORTS["oldest"])
+    return query.order_by(sort_fn())
+
+
+def _cdm_list_ctx(
+    db: Session,
+    user: User,
+    *,
+    search: str,
+    staleness: str,
+    account_type: str,
+    my_only: str,
+    sort: str,
+    limit: int,
+    offset: int,
+) -> dict:
+    """Shared context for the CDM workspace shell and its account-list partial."""
+    query = _cdm_company_query(
+        db, user, search=search, staleness=staleness, account_type=account_type, my_only=my_only, sort=sort
+    )
+    total = query.count()
+    companies = query.offset(offset).limit(limit).all()
     for c in companies:
         c.staleness = _staleness_tier(c.last_activity_at)
 
-    # Today's Calls — overdue accounts owned by this user (sales/trader only)
-    todays_calls: list[Company] = []
+    # Overdue chip — accounts owned by this user needing a call (sales/trader only)
+    overdue_count = 0
     if user.role in ("sales", "trader"):
         call_threshold = datetime.now(timezone.utc) - timedelta(days=STALENESS_OVERDUE_DAYS)
-        todays_calls = (
-            db.query(Company)
+        overdue_count = (
+            db.query(sqlfunc.count(Company.id))
             .filter(
                 Company.is_active.is_(True),
                 Company.account_owner_id == user.id,
@@ -4384,30 +4426,89 @@ async def companies_list_partial(
                     Company.last_activity_at.is_(None),
                 ),
             )
-            .order_by(
-                Company.is_strategic.desc().nullslast(),
-                Company.last_activity_at.asc().nullsfirst(),
-            )
-            .limit(10)
-            .all()
+            .scalar()
+            or 0
         )
-        for c in todays_calls:
-            c.staleness = _staleness_tier(c.last_activity_at)
 
+    return {
+        "companies": companies,
+        "search": search,
+        "staleness": staleness,
+        "account_type": account_type,
+        "my_only": my_only,
+        "sort": sort,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "overdue_count": overdue_count,
+        "account_types": _CDM_ACCOUNT_TYPES,
+    }
+
+
+@router.get("/v2/partials/customers", response_class=HTMLResponse)
+async def companies_list_partial(
+    request: Request,
+    search: str = "",
+    staleness: str = "",
+    account_type: str = "",
+    my_only: str = "",
+    sort: str = "oldest",
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Return the CDM account workspace (split-panel list + detail) as HTML partial.
+
+    Legacy hx_target/push_url_base query params (still sent by the CRM shell) are
+    ignored — the workspace always swaps account detail into #cdm-detail.
+    """
     ctx = _base_ctx(request, user, "customers")
     ctx.update(
-        {
-            "companies": companies,
-            "search": search,
-            "total": total,
-            "limit": limit,
-            "offset": offset,
-            "hx_target": hx_target,
-            "push_url_base": push_url_base,
-            "todays_calls": todays_calls,
-        }
+        _cdm_list_ctx(
+            db,
+            user,
+            search=search,
+            staleness=staleness,
+            account_type=account_type,
+            my_only=my_only,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+        )
     )
     return template_response("htmx/partials/customers/list.html", ctx)
+
+
+@router.get("/v2/partials/customers/account-list", response_class=HTMLResponse)
+async def companies_account_list_partial(
+    request: Request,
+    search: str = "",
+    staleness: str = "",
+    account_type: str = "",
+    my_only: str = "",
+    sort: str = "oldest",
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Return only the CDM left-panel account list (filter/sort/pagination refresh)."""
+    ctx = {"request": request, "user": user}
+    ctx.update(
+        _cdm_list_ctx(
+            db,
+            user,
+            search=search,
+            staleness=staleness,
+            account_type=account_type,
+            my_only=my_only,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    return template_response("htmx/partials/customers/_account_list.html", ctx)
 
 
 # ── Sprint 4: Company CRUD (static routes — must precede {company_id}) ──
@@ -4522,6 +4623,29 @@ async def check_company_duplicate(
     return HTMLResponse("")
 
 
+def _company_contact_rows(db: Session, company_id: int) -> list[dict]:
+    """All contacts for a company across its sites, plus legacy site-level contacts.
+
+    Returns [{"contact": SiteContact|None, "site": CustomerSite|None, "legacy": bool}].
+    Used by the detail panel (contacts shown inline) and the contacts tab.
+    """
+    sites = db.query(CustomerSite).filter(CustomerSite.company_id == company_id).all()
+    site_map = {s.id: s for s in sites}
+    contacts: list[SiteContact] = []
+    if site_map:
+        contacts = (
+            db.query(SiteContact)
+            .filter(SiteContact.customer_site_id.in_(list(site_map)), SiteContact.is_active.is_(True))
+            .order_by(SiteContact.is_primary.desc(), SiteContact.full_name)
+            .all()
+        )
+    rows = [{"contact": c, "site": site_map.get(c.customer_site_id), "legacy": False} for c in contacts]
+    for s in sites:
+        if s.contact_name or s.contact_email:
+            rows.append({"contact": None, "site": s, "legacy": True})
+    return rows
+
+
 @router.get("/v2/partials/customers/{company_id}", response_class=HTMLResponse)
 async def company_detail_partial(
     request: Request,
@@ -4569,6 +4693,7 @@ async def company_detail_partial(
             "company": company,
             "sites": sites,
             "open_req_count": open_req_count,
+            "contact_rows": _company_contact_rows(db, company_id),
             "user": user,
         }
     )
@@ -4609,72 +4734,9 @@ async def company_tab(
         return template_response("htmx/partials/customers/tabs/sites_tab.html", ctx)
 
     elif tab == "contacts":
-        # Get all SiteContact records across all sites for this company
-        site_ids = [s.id for s in db.query(CustomerSite.id).filter(CustomerSite.company_id == company_id).all()]
-        contacts = []
-        if site_ids:
-            contacts = (
-                db.query(SiteContact)
-                .filter(SiteContact.customer_site_id.in_(site_ids), SiteContact.is_active.is_(True))
-                .order_by(SiteContact.is_primary.desc(), SiteContact.full_name)
-                .all()
-            )
-        # Build a table with site name
-        site_map = {s.id: s for s in db.query(CustomerSite).filter(CustomerSite.company_id == company_id).all()}
-        rows = []
-        for c in contacts:
-            site = site_map.get(c.customer_site_id)
-            site_name = site.site_name if site else _DASH
-            phone_html = (
-                f'<a href="tel:{c.phone}" class="text-brand-500 hover:text-brand-600">{c.phone}</a>'
-                if c.phone
-                else f'<span class="text-gray-500">{_DASH}</span>'
-            )
-            primary_badge = (
-                ' <span class="px-1 py-0.5 text-[9px] font-medium rounded bg-emerald-50 text-emerald-700">Primary</span>'
-                if c.is_primary
-                else ""
-            )
-            rows.append(f"""<tr class="hover:bg-brand-50">
-              <td class="px-4 py-2 text-sm font-medium text-gray-900">{c.full_name or _DASH}{primary_badge}</td>
-              <td class="px-4 py-2 text-sm text-gray-500">{c.title or _DASH}</td>
-              <td class="px-4 py-2 text-sm text-gray-500">{site_name}</td>
-              <td class="px-4 py-2 text-sm text-gray-500">{c.email or _DASH}</td>
-              <td class="px-4 py-2 text-sm">{phone_html}</td>
-            </tr>""")
-        # Also include legacy site-level contacts
-        for s in site_map.values():
-            if s.contact_name or s.contact_email:
-                phone_html = (
-                    f'<a href="tel:{s.contact_phone}" class="text-brand-500">{s.contact_phone}</a>'
-                    if s.contact_phone
-                    else f'<span class="text-gray-500">{_DASH}</span>'
-                )
-                rows.append(f"""<tr class="hover:bg-brand-50">
-                  <td class="px-4 py-2 text-sm font-medium text-gray-900">{s.contact_name or _DASH} <span class="text-[9px] text-gray-400">legacy</span></td>
-                  <td class="px-4 py-2 text-sm text-gray-500">{s.contact_title or _DASH}</td>
-                  <td class="px-4 py-2 text-sm text-gray-500">{s.site_name}</td>
-                  <td class="px-4 py-2 text-sm text-gray-500">{s.contact_email or _DASH}</td>
-                  <td class="px-4 py-2 text-sm">{phone_html}</td>
-                </tr>""")
-        if rows:
-            html = f"""<div class="overflow-x-auto">
-              <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                  <tr>
-                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
-                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Title</th>
-                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Site</th>
-                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
-                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Phone</th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-200">{"".join(rows)}</tbody>
-              </table>
-            </div>"""
-        else:
-            html = '<div class="p-8 text-center"><p class="text-sm text-gray-500">No contacts found. Add contacts via the Sites tab.</p></div>'
-        return HTMLResponse(html)
+        ctx = _base_ctx(request, user, "customers")
+        ctx.update({"company": company, "contact_rows": _company_contact_rows(db, company_id)})
+        return template_response("htmx/partials/customers/tabs/contacts_tab.html", ctx)
 
     elif tab == "requisitions":
         from sqlalchemy import or_
@@ -4927,6 +4989,7 @@ async def create_site_contact(
     email: str = Form(""),
     title: str = Form(""),
     phone: str = Form(""),
+    wechat_id: str = Form(""),
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -4960,6 +5023,7 @@ async def create_site_contact(
                 email=email.strip() or None,
                 title=title.strip() or None,
                 phone=phone.strip() or None,
+                wechat_id=wechat_id.strip() or None,
             )
             db.add(contact)
             db.commit()
@@ -4969,6 +5033,7 @@ async def create_site_contact(
             full_name=full_name.strip(),
             title=title.strip() or None,
             phone=phone.strip() or None,
+            wechat_id=wechat_id.strip() or None,
         )
         db.add(contact)
         db.commit()

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4313,10 +4313,12 @@ async def partials_companies_redirect(request: Request, path: str = ""):
     return RedirectResponse(url=new_url, status_code=301)
 
 
-# CDM staleness rules + account-list query building live in the service layer.
-# Re-exported here under their historical names for callers/tests that import
-# them from this module (noqa F401 keeps ruff from stripping the aliases).
-from ..services.crm_service import STALENESS_DUE_SOON_DAYS, STALENESS_OVERDUE_DAYS  # noqa: E402, F401
+# CDM staleness rules + account-list query building live in the service layer
+# (app/services/crm_service.py). _cdm_list_ctx and _company_contact_rows are
+# plain service imports used by the CDM routes below. _staleness_tier is
+# additionally re-exported under its historical name because tests
+# (tests/test_htmx_views_nightly28.py) import it from this module — the F401
+# keeps ruff from stripping that alias.
 from ..services.crm_service import cdm_list_ctx as _cdm_list_ctx  # noqa: E402
 from ..services.crm_service import company_contact_rows as _company_contact_rows  # noqa: E402
 from ..services.crm_service import staleness_tier as _staleness_tier  # noqa: E402, F401
@@ -4560,7 +4562,10 @@ async def company_detail_partial(
             "company": company,
             "sites": sites,
             "open_req_count": open_req_count,
-            "contact_rows": _company_contact_rows(db, company_id, sites=list(company.sites or [])),
+            # Pass the active-only sites list — contacts on deactivated sites must
+            # not be shown (clicking them would log outreach against, and bump,
+            # a deactivated entity).
+            "contact_rows": _company_contact_rows(db, company_id, sites=sites),
             "user": user,
         }
     )
@@ -4867,6 +4872,11 @@ async def create_site_contact(
 
     if not full_name.strip():
         return HTMLResponse('<div class="p-2 text-xs text-rose-600">Name is required.</div>')
+
+    # SiteContact.wechat_id is String(100) — reject over-length input here (the
+    # in-memory SQLite test engine ignores VARCHAR lengths, but Postgres 500s).
+    if len(wechat_id.strip()) > 100:
+        return HTMLResponse('<div class="p-2 text-xs text-rose-600">WeChat ID must be 100 characters or fewer.</div>')
 
     # Dedup by email
     if email:

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4313,9 +4313,13 @@ async def partials_companies_redirect(request: Request, path: str = ""):
     return RedirectResponse(url=new_url, status_code=301)
 
 
-STALENESS_OVERDUE_DAYS = 30
-STALENESS_DUE_SOON_DAYS = 14
-
+# CDM staleness rules + account-list query building live in the service layer.
+# Re-exported here under their historical names for callers/tests that import
+# them from this module (noqa F401 keeps ruff from stripping the aliases).
+from ..services.crm_service import STALENESS_DUE_SOON_DAYS, STALENESS_OVERDUE_DAYS  # noqa: E402, F401
+from ..services.crm_service import cdm_list_ctx as _cdm_list_ctx  # noqa: E402
+from ..services.crm_service import company_contact_rows as _company_contact_rows  # noqa: E402
+from ..services.crm_service import staleness_tier as _staleness_tier  # noqa: E402, F401
 
 _ALLOWED_HX_TARGETS = {"#main-content", "#crm-tab-content"}
 _ALLOWED_PUSH_URL_BASES = {"/v2/vendors", "/v2/customers", "/v2/crm"}
@@ -4330,139 +4334,20 @@ def _sanitize_hx_params(hx_target: str, push_url_base: str, default_push: str) -
     return hx_target, push_url_base
 
 
-def _staleness_tier(last_activity_at: datetime | None) -> str:
-    """Compute staleness tier from last_activity_at timestamp."""
-    if last_activity_at is None:
-        return "new"
-    ts = last_activity_at
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=timezone.utc)
-    days = (datetime.now(timezone.utc) - ts).days
-    if days >= STALENESS_OVERDUE_DAYS:
-        return "overdue"
-    if days >= STALENESS_DUE_SOON_DAYS:
-        return "due_soon"
-    return "recent"
-
-
-# Sort options for the CDM account workspace left panel. Default "oldest"
-# puts the longest-neglected accounts at the top (call-list order).
-_CDM_SORTS = {
-    "oldest": lambda: Company.last_activity_at.asc().nullsfirst(),
-    "newest": lambda: Company.last_activity_at.desc().nullslast(),
-    "name_asc": lambda: sqlfunc.lower(Company.name).asc(),
-    "name_desc": lambda: sqlfunc.lower(Company.name).desc(),
-}
-
-_CDM_ACCOUNT_TYPES = ("Customer", "Prospect", "Partner", "Competitor")
-
-
-def _cdm_company_query(
-    db: Session, user: User, *, search: str, staleness: str, account_type: str, my_only: str, sort: str
-):
-    """Build the filtered + sorted CDM account list query."""
-    query = db.query(Company).filter(Company.is_active.is_(True)).options(joinedload(Company.account_owner))
-
-    if search.strip():
-        sb = SearchBuilder(search.strip())
-        query = query.filter(sb.ilike_filter(Company.name))
-
-    now = datetime.now(timezone.utc)
-    overdue_cutoff = now - timedelta(days=STALENESS_OVERDUE_DAYS)
-    due_soon_cutoff = now - timedelta(days=STALENESS_DUE_SOON_DAYS)
-    if staleness == "overdue":
-        query = query.filter(Company.last_activity_at < overdue_cutoff)
-    elif staleness == "due_soon":
-        query = query.filter(
-            Company.last_activity_at >= overdue_cutoff,
-            Company.last_activity_at < due_soon_cutoff,
-        )
-    elif staleness == "recent":
-        query = query.filter(Company.last_activity_at >= due_soon_cutoff)
-    elif staleness == "new":
-        query = query.filter(Company.last_activity_at.is_(None))
-
-    if account_type in _CDM_ACCOUNT_TYPES:
-        query = query.filter(Company.account_type == account_type)
-    if my_only:
-        query = query.filter(Company.account_owner_id == user.id)
-
-    sort_fn = _CDM_SORTS.get(sort, _CDM_SORTS["oldest"])
-    return query.order_by(sort_fn())
-
-
-def _cdm_list_ctx(
-    db: Session,
-    user: User,
-    *,
-    search: str,
-    staleness: str,
-    account_type: str,
-    my_only: str,
-    sort: str,
-    limit: int,
-    offset: int,
-) -> dict:
-    """Shared context for the CDM workspace shell and its account-list partial."""
-    query = _cdm_company_query(
-        db, user, search=search, staleness=staleness, account_type=account_type, my_only=my_only, sort=sort
-    )
-    total = query.count()
-    companies = query.offset(offset).limit(limit).all()
-    for c in companies:
-        c.staleness = _staleness_tier(c.last_activity_at)
-
-    # Overdue chip — accounts owned by this user needing a call (sales/trader only)
-    overdue_count = 0
-    if user.role in ("sales", "trader"):
-        call_threshold = datetime.now(timezone.utc) - timedelta(days=STALENESS_OVERDUE_DAYS)
-        overdue_count = (
-            db.query(sqlfunc.count(Company.id))
-            .filter(
-                Company.is_active.is_(True),
-                Company.account_owner_id == user.id,
-                or_(
-                    Company.last_activity_at < call_threshold,
-                    Company.last_activity_at.is_(None),
-                ),
-            )
-            .scalar()
-            or 0
-        )
-
-    return {
-        "companies": companies,
-        "search": search,
-        "staleness": staleness,
-        "account_type": account_type,
-        "my_only": my_only,
-        "sort": sort,
-        "total": total,
-        "limit": limit,
-        "offset": offset,
-        "overdue_count": overdue_count,
-        "account_types": _CDM_ACCOUNT_TYPES,
-    }
-
-
 @router.get("/v2/partials/customers", response_class=HTMLResponse)
 async def companies_list_partial(
     request: Request,
     search: str = "",
     staleness: str = "",
     account_type: str = "",
-    my_only: str = "",
+    my_only: bool = False,
     sort: str = "oldest",
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Return the CDM account workspace (split-panel list + detail) as HTML partial.
-
-    Legacy hx_target/push_url_base query params (still sent by the CRM shell) are
-    ignored — the workspace always swaps account detail into #cdm-detail.
-    """
+    """Return the CDM account workspace (split-panel list + detail) as HTML partial."""
     ctx = _base_ctx(request, user, "customers")
     ctx.update(
         _cdm_list_ctx(
@@ -4475,6 +4360,7 @@ async def companies_list_partial(
             sort=sort,
             limit=limit,
             offset=offset,
+            include_overdue=True,
         )
     )
     return template_response("htmx/partials/customers/list.html", ctx)
@@ -4486,14 +4372,18 @@ async def companies_account_list_partial(
     search: str = "",
     staleness: str = "",
     account_type: str = "",
-    my_only: str = "",
+    my_only: bool = False,
     sort: str = "oldest",
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Return only the CDM left-panel account list (filter/sort/pagination refresh)."""
+    """Return only the CDM left-panel account list (filter/sort/pagination refresh).
+
+    The overdue chip lives in the filter bar (not re-rendered here), so this route skips
+    the overdue COUNT query.
+    """
     ctx = {"request": request, "user": user}
     ctx.update(
         _cdm_list_ctx(
@@ -4623,29 +4513,6 @@ async def check_company_duplicate(
     return HTMLResponse("")
 
 
-def _company_contact_rows(db: Session, company_id: int) -> list[dict]:
-    """All contacts for a company across its sites, plus legacy site-level contacts.
-
-    Returns [{"contact": SiteContact|None, "site": CustomerSite|None, "legacy": bool}].
-    Used by the detail panel (contacts shown inline) and the contacts tab.
-    """
-    sites = db.query(CustomerSite).filter(CustomerSite.company_id == company_id).all()
-    site_map = {s.id: s for s in sites}
-    contacts: list[SiteContact] = []
-    if site_map:
-        contacts = (
-            db.query(SiteContact)
-            .filter(SiteContact.customer_site_id.in_(list(site_map)), SiteContact.is_active.is_(True))
-            .order_by(SiteContact.is_primary.desc(), SiteContact.full_name)
-            .all()
-        )
-    rows = [{"contact": c, "site": site_map.get(c.customer_site_id), "legacy": False} for c in contacts]
-    for s in sites:
-        if s.contact_name or s.contact_email:
-            rows.append({"contact": None, "site": s, "legacy": True})
-    return rows
-
-
 @router.get("/v2/partials/customers/{company_id}", response_class=HTMLResponse)
 async def company_detail_partial(
     request: Request,
@@ -4693,7 +4560,7 @@ async def company_detail_partial(
             "company": company,
             "sites": sites,
             "open_req_count": open_req_count,
-            "contact_rows": _company_contact_rows(db, company_id),
+            "contact_rows": _company_contact_rows(db, company_id, sites=list(company.sites or [])),
             "user": user,
         }
     )
@@ -5089,6 +4956,15 @@ async def set_primary_contact(
     db: Session = Depends(get_db),
 ):
     """Set a contact as primary for the site (unsets others)."""
+    # Validate the site belongs to the company BEFORE mutating — a mismatched
+    # URL must not flip the primary flag and then 500 on render.
+    site = db.query(CustomerSite).filter(CustomerSite.id == site_id, CustomerSite.company_id == company_id).first()
+    if not site:
+        raise HTTPException(404, "Site not found")
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
     contact = (
         db.query(SiteContact).filter(SiteContact.id == contact_id, SiteContact.customer_site_id == site_id).first()
     )
@@ -5111,8 +4987,6 @@ async def set_primary_contact(
         .order_by(SiteContact.is_primary.desc(), SiteContact.full_name)
         .all()
     )
-    site = db.query(CustomerSite).filter(CustomerSite.id == site_id).first()
-    company = db.query(Company).filter(Company.id == company_id).first()
     ctx = _base_ctx(request, user, "customers")
     ctx["site"] = site
     ctx["contacts"] = contacts

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -5,6 +5,7 @@ Depends on: pydantic
 """
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -17,6 +18,22 @@ class CallInitiatedRequest(BaseModel):
     company_id: int | None = None
     customer_site_id: int | None = None
     requirement_id: int | None = None
+    origin: str | None = None
+
+
+class OutreachInitiatedRequest(BaseModel):
+    """Request body for POST /api/activity/outreach-initiated.
+
+    Logs a click-to-contact event (phone / email / Teams / WeChat) from the CDM account
+    workspace contact panel.
+    """
+
+    channel: Literal["phone", "email", "teams", "wechat"]
+    contact_value: str  # phone number, email address, or WeChat ID
+    company_id: int | None = None
+    customer_site_id: int | None = None
+    site_contact_id: int | None = None
+    contact_name: str | None = None
     origin: str | None = None
 
 

--- a/app/schemas/activity.py
+++ b/app/schemas/activity.py
@@ -1,13 +1,14 @@
 """Pydantic schemas for activity endpoints (click-to-call logging + timeline).
 
 Called by: app/routers/activity.py, app/routers/v13_features/activity.py
-Depends on: pydantic
+Depends on: pydantic, app/constants (OutreachChannel)
 """
 
 from datetime import datetime
-from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from ..constants import OutreachChannel
 
 
 class CallInitiatedRequest(BaseModel):
@@ -25,16 +26,20 @@ class OutreachInitiatedRequest(BaseModel):
     """Request body for POST /api/activity/outreach-initiated.
 
     Logs a click-to-contact event (phone / email / Teams / WeChat) from the CDM account
-    workspace contact panel.
+    workspace contact panel. channel validates against the OutreachChannel StrEnum (the
+    single source of truth — the service channel maps are keyed by the same enum), and
+    the free-text fields carry max_length bounds matching the ActivityLog snapshot
+    columns (contact_email/contact_name String(255)) so over-length input is a 422 at
+    the boundary instead of a Postgres DataError 500.
     """
 
-    channel: Literal["phone", "email", "teams", "wechat"]
-    contact_value: str  # phone number, email address, or WeChat ID
+    channel: OutreachChannel
+    contact_value: str = Field(max_length=255)  # phone number, email address, or WeChat ID
     company_id: int | None = None
     customer_site_id: int | None = None
     site_contact_id: int | None = None
-    contact_name: str | None = None
-    origin: str | None = None
+    contact_name: str | None = Field(default=None, max_length=255)
+    origin: str | None = Field(default=None, max_length=100)
 
 
 # ── Timeline filter / response schemas ────────────────────────────────

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -563,6 +563,79 @@ def log_company_note(
     return record
 
 
+# Channel → (activity_type, channel, event_type, snapshot column) for
+# click-to-contact outreach logged from the CDM account workspace.
+# WeChat has no dedicated snapshot column — the handle is kept in notes.
+_OUTREACH_CHANNEL_MAP: dict[str, tuple[str, str, str, str | None]] = {
+    "phone": (ActivityType.CALL_LOGGED, Channel.PHONE, EventType.CALL, "contact_phone"),
+    "email": (ActivityType.EMAIL_SENT, Channel.EMAIL, EventType.EMAIL, "contact_email"),
+    "teams": (ActivityType.TEAMS_MESSAGE, Channel.TEAMS, EventType.MESSAGE, "contact_email"),
+    "wechat": (ActivityType.WECHAT_MESSAGE, Channel.WECHAT, EventType.MESSAGE, None),
+}
+
+_OUTREACH_SUBJECT_VERBS: dict[str, str] = {
+    "phone": "Call to",
+    "email": "Email to",
+    "teams": "Teams message to",
+    "wechat": "WeChat message to",
+}
+
+
+def log_outreach_initiated(
+    db: Session,
+    *,
+    user_id: int,
+    channel: str,
+    contact_value: str,
+    company_id: int | None = None,
+    customer_site_id: int | None = None,
+    site_contact_id: int | None = None,
+    contact_name: str | None = None,
+    origin: str | None = None,
+) -> ActivityLog:
+    """Log a click-to-contact outreach event (phone/email/teams/wechat).
+
+    Called by: POST /api/activity/outreach-initiated (CDM contact panel).
+    Creates an outbound, meaningful, auto-logged ActivityLog and bumps
+    last_activity_at on the company and site so staleness sorting reflects
+    the touch immediately. Caller commits.
+    """
+    if channel not in _OUTREACH_CHANNEL_MAP:
+        raise ValueError(f"Unknown outreach channel: {channel}")
+    activity_type, log_channel, event_type, snapshot_col = _OUTREACH_CHANNEL_MAP[channel]
+
+    target = contact_name or contact_value
+    record = ActivityLog(
+        user_id=user_id,
+        activity_type=activity_type,
+        channel=log_channel,
+        direction=Direction.OUTBOUND,
+        event_type=event_type,
+        is_meaningful=True,
+        auto_logged=True,
+        company_id=company_id,
+        customer_site_id=customer_site_id,
+        site_contact_id=site_contact_id,
+        contact_name=contact_name,
+        subject=f"{_OUTREACH_SUBJECT_VERBS[channel]} {target}",
+        notes=f"source=click_to_contact origin={origin or 'unknown'} contact={contact_value}",
+    )
+    if snapshot_col:
+        setattr(record, snapshot_col, contact_value)
+    db.add(record)
+    db.flush()
+
+    now = datetime.now(timezone.utc)
+    if company_id:
+        db.query(Company).filter(Company.id == company_id).update({"last_activity_at": now}, synchronize_session=False)
+    if customer_site_id:
+        db.query(CustomerSite).filter(CustomerSite.id == customer_site_id).update(
+            {"last_activity_at": now}, synchronize_session=False
+        )
+    logger.info(f"Outreach logged: {channel} -> company {company_id} by user {user_id}")
+    return record
+
+
 # ═══════════════════════════════════════════════════════════════════════
 #  SITE-CONTACT NOTE LOGGING
 # ═══════════════════════════════════════════════════════════════════════

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -14,7 +14,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session, selectinload
 
 from app.config import settings
-from app.constants import ActivityType, Channel, Direction, EventType, InboxSyncHealth
+from app.constants import ActivityType, Channel, Direction, EventType, InboxSyncHealth, OutreachChannel
 from app.models import ActivityLog, Company, CustomerSite, SiteContact, VendorCard, VendorContact
 from app.utils.token_manager import _utc
 from app.vendor_utils import GENERIC_EMAIL_DOMAINS as _GENERIC_DOMAINS
@@ -567,18 +567,33 @@ def log_company_note(
 # click-to-contact outreach logged from the CDM account workspace.
 # WeChat has no dedicated snapshot column — the handle is kept in notes.
 _OUTREACH_CHANNEL_MAP: dict[str, tuple[str, str, str, str | None]] = {
-    "phone": (ActivityType.CALL_LOGGED, Channel.PHONE, EventType.CALL, "contact_phone"),
-    "email": (ActivityType.EMAIL_SENT, Channel.EMAIL, EventType.EMAIL, "contact_email"),
-    "teams": (ActivityType.TEAMS_MESSAGE, Channel.TEAMS, EventType.MESSAGE, "contact_email"),
-    "wechat": (ActivityType.WECHAT_MESSAGE, Channel.WECHAT, EventType.MESSAGE, None),
+    OutreachChannel.PHONE: (ActivityType.CALL_LOGGED, Channel.PHONE, EventType.CALL, "contact_phone"),
+    OutreachChannel.EMAIL: (ActivityType.EMAIL_SENT, Channel.EMAIL, EventType.EMAIL, "contact_email"),
+    OutreachChannel.TEAMS: (ActivityType.TEAMS_MESSAGE, Channel.TEAMS, EventType.MESSAGE, "contact_email"),
+    OutreachChannel.WECHAT: (ActivityType.WECHAT_MESSAGE, Channel.WECHAT, EventType.MESSAGE, None),
 }
 
 _OUTREACH_SUBJECT_VERBS: dict[str, str] = {
-    "phone": "Call to",
-    "email": "Email to",
-    "teams": "Teams message to",
-    "wechat": "WeChat message to",
+    OutreachChannel.PHONE: "Call to",
+    OutreachChannel.EMAIL: "Email to",
+    OutreachChannel.TEAMS: "Teams message to",
+    OutreachChannel.WECHAT: "WeChat message to",
 }
+
+# Re-clicking the same contact link within this window returns the existing
+# ActivityLog instead of writing a duplicate (double-clicks, re-opened dialers).
+OUTREACH_DEDUP_SECONDS = 120
+
+
+def bump_company_site_activity(db: Session, company_id: int | None, customer_site_id: int | None) -> None:
+    """Set last_activity_at = now on a company and/or site (staleness sort feed)."""
+    now = datetime.now(timezone.utc)
+    if company_id:
+        db.query(Company).filter(Company.id == company_id).update({"last_activity_at": now}, synchronize_session=False)
+    if customer_site_id:
+        db.query(CustomerSite).filter(CustomerSite.id == customer_site_id).update(
+            {"last_activity_at": now}, synchronize_session=False
+        )
 
 
 def log_outreach_initiated(
@@ -598,13 +613,36 @@ def log_outreach_initiated(
     Called by: POST /api/activity/outreach-initiated (CDM contact panel).
     Creates an outbound, meaningful, auto-logged ActivityLog and bumps
     last_activity_at on the company and site so staleness sorting reflects
-    the touch immediately. Caller commits.
+    the touch immediately. Re-clicks within OUTREACH_DEDUP_SECONDS return the
+    existing record instead of duplicating it. Caller commits.
     """
     if channel not in _OUTREACH_CHANNEL_MAP:
         raise ValueError(f"Unknown outreach channel: {channel}")
     activity_type, log_channel, event_type, snapshot_col = _OUTREACH_CHANNEL_MAP[channel]
 
     target = contact_name or contact_value
+    subject = f"{_OUTREACH_SUBJECT_VERBS[channel]} {target}"
+
+    # Dedup window — same user, channel, target, and entity within the window
+    # is the same click (double-click / retry), not a second touch.
+    dedup_cutoff = datetime.now(timezone.utc) - timedelta(seconds=OUTREACH_DEDUP_SECONDS)
+    existing = (
+        db.query(ActivityLog)
+        .filter(
+            ActivityLog.user_id == user_id,
+            ActivityLog.activity_type == activity_type,
+            ActivityLog.channel == log_channel,
+            ActivityLog.subject == subject,
+            ActivityLog.company_id == company_id,
+            ActivityLog.created_at >= dedup_cutoff,
+        )
+        .order_by(ActivityLog.created_at.desc())
+        .first()
+    )
+    if existing:
+        logger.info(f"Outreach dedup hit: {channel} -> company {company_id} by user {user_id} (id={existing.id})")
+        return existing
+
     record = ActivityLog(
         user_id=user_id,
         activity_type=activity_type,
@@ -617,7 +655,7 @@ def log_outreach_initiated(
         customer_site_id=customer_site_id,
         site_contact_id=site_contact_id,
         contact_name=contact_name,
-        subject=f"{_OUTREACH_SUBJECT_VERBS[channel]} {target}",
+        subject=subject,
         notes=f"source=click_to_contact origin={origin or 'unknown'} contact={contact_value}",
     )
     if snapshot_col:
@@ -625,13 +663,7 @@ def log_outreach_initiated(
     db.add(record)
     db.flush()
 
-    now = datetime.now(timezone.utc)
-    if company_id:
-        db.query(Company).filter(Company.id == company_id).update({"last_activity_at": now}, synchronize_session=False)
-    if customer_site_id:
-        db.query(CustomerSite).filter(CustomerSite.id == customer_site_id).update(
-            {"last_activity_at": now}, synchronize_session=False
-        )
+    bump_company_site_activity(db, company_id, customer_site_id)
     logger.info(f"Outreach logged: {channel} -> company {company_id} by user {user_id}")
     return record
 

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -566,14 +566,14 @@ def log_company_note(
 # Channel → (activity_type, channel, event_type, snapshot column) for
 # click-to-contact outreach logged from the CDM account workspace.
 # WeChat has no dedicated snapshot column — the handle is kept in notes.
-_OUTREACH_CHANNEL_MAP: dict[str, tuple[str, str, str, str | None]] = {
+_OUTREACH_CHANNEL_MAP: dict[OutreachChannel, tuple[str, str, str, str | None]] = {
     OutreachChannel.PHONE: (ActivityType.CALL_LOGGED, Channel.PHONE, EventType.CALL, "contact_phone"),
     OutreachChannel.EMAIL: (ActivityType.EMAIL_SENT, Channel.EMAIL, EventType.EMAIL, "contact_email"),
     OutreachChannel.TEAMS: (ActivityType.TEAMS_MESSAGE, Channel.TEAMS, EventType.MESSAGE, "contact_email"),
     OutreachChannel.WECHAT: (ActivityType.WECHAT_MESSAGE, Channel.WECHAT, EventType.MESSAGE, None),
 }
 
-_OUTREACH_SUBJECT_VERBS: dict[str, str] = {
+_OUTREACH_SUBJECT_VERBS: dict[OutreachChannel, str] = {
     OutreachChannel.PHONE: "Call to",
     OutreachChannel.EMAIL: "Email to",
     OutreachChannel.TEAMS: "Teams message to",
@@ -600,7 +600,7 @@ def log_outreach_initiated(
     db: Session,
     *,
     user_id: int,
-    channel: str,
+    channel: OutreachChannel,
     contact_value: str,
     company_id: int | None = None,
     customer_site_id: int | None = None,
@@ -623,17 +623,29 @@ def log_outreach_initiated(
     target = contact_name or contact_value
     subject = f"{_OUTREACH_SUBJECT_VERBS[channel]} {target}"
 
-    # Dedup window — same user, channel, target, and entity within the window
-    # is the same click (double-click / retry), not a second touch.
+    # Dedup window — the same user re-clicking the same target within the
+    # window is the same click (double-click / retry), not a second touch.
+    # The key is the stable identity of the click: entity links
+    # (company/site/contact, NULL-safe via SQLAlchemy `==`) plus the channel's
+    # snapshot of the contacted value — NOT the display subject, so two
+    # same-named contacts at one company never collapse into one log and the
+    # subject wording can change without altering dedup semantics. WeChat has
+    # no snapshot column; its subject embeds the handle and is deterministic
+    # for an identical re-click, so it stands in as the value match.
     dedup_cutoff = datetime.now(timezone.utc) - timedelta(seconds=OUTREACH_DEDUP_SECONDS)
+    value_match = (
+        getattr(ActivityLog, snapshot_col) == contact_value if snapshot_col else ActivityLog.subject == subject
+    )
     existing = (
         db.query(ActivityLog)
         .filter(
             ActivityLog.user_id == user_id,
             ActivityLog.activity_type == activity_type,
             ActivityLog.channel == log_channel,
-            ActivityLog.subject == subject,
             ActivityLog.company_id == company_id,
+            ActivityLog.customer_site_id == customer_site_id,
+            ActivityLog.site_contact_id == site_contact_id,
+            value_match,
             ActivityLog.created_at >= dedup_cutoff,
         )
         .order_by(ActivityLog.created_at.desc())

--- a/app/services/crm_service.py
+++ b/app/services/crm_service.py
@@ -1,14 +1,24 @@
-"""services/crm_service.py -- Shared CRM helpers (extracted from routers/crm.py).
+"""services/crm_service.py -- Shared CRM helpers (extracted from routers).
 
-Avoids circular imports: proactive_service needs next_quote_number but
-should not import from routers.
+Holds quote numbering (used by proactive_service) and the CDM account-workspace
+business rules: staleness tiers, account-list query building/sorting, and the
+contact-row assembly for the company detail panel.
+
+Called by: app/routers/htmx_views.py (CDM workspace routes), app/services/proactive_service.py
+Depends on: app/models (Company, CustomerSite, SiteContact, Quote), app/utils/search_builder
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
-from sqlalchemy.orm import Session
+from sqlalchemy import func, or_
+from sqlalchemy.orm import Session, joinedload
 
-from ..models import Quote
+from ..models import Company, CustomerSite, Quote, SiteContact
+from ..models.auth import User
+from ..utils.search_builder import SearchBuilder
+
+STALENESS_OVERDUE_DAYS = 30
+STALENESS_DUE_SOON_DAYS = 14
 
 
 def next_quote_number(db: Session) -> str:
@@ -33,3 +43,168 @@ def next_quote_number(db: Session) -> str:
     else:
         seq = 1
     return f"{prefix}{seq:04d}"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  CDM ACCOUNT WORKSPACE — staleness, list query, contact rows
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def staleness_tier(last_activity_at: datetime | None) -> str:
+    """Compute staleness tier (new/overdue/due_soon/recent) from a timestamp."""
+    if last_activity_at is None:
+        return "new"
+    ts = last_activity_at
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    days = (datetime.now(timezone.utc) - ts).days
+    if days >= STALENESS_OVERDUE_DAYS:
+        return "overdue"
+    if days >= STALENESS_DUE_SOON_DAYS:
+        return "due_soon"
+    return "recent"
+
+
+# Sort options for the CDM account workspace left panel. Default "oldest"
+# puts the longest-neglected accounts at the top (call-list order).
+CDM_SORTS = {
+    "oldest": Company.last_activity_at.asc().nullsfirst(),
+    "newest": Company.last_activity_at.desc().nullslast(),
+    "name_asc": func.lower(Company.name).asc(),
+    "name_desc": func.lower(Company.name).desc(),
+}
+
+CDM_ACCOUNT_TYPES = ("Customer", "Prospect", "Partner", "Competitor")
+
+
+def cdm_company_query(
+    db: Session,
+    user: User,
+    *,
+    search: str,
+    staleness: str,
+    account_type: str,
+    my_only: bool,
+    sort: str,
+    now: datetime | None = None,
+):
+    """Build the filtered + sorted CDM account list query."""
+    query = db.query(Company).filter(Company.is_active.is_(True)).options(joinedload(Company.account_owner))
+
+    if search.strip():
+        sb = SearchBuilder(search.strip())
+        query = query.filter(sb.ilike_filter(Company.name))
+
+    now = now or datetime.now(timezone.utc)
+    overdue_cutoff = now - timedelta(days=STALENESS_OVERDUE_DAYS)
+    due_soon_cutoff = now - timedelta(days=STALENESS_DUE_SOON_DAYS)
+    if staleness == "overdue":
+        query = query.filter(Company.last_activity_at < overdue_cutoff)
+    elif staleness == "due_soon":
+        query = query.filter(
+            Company.last_activity_at >= overdue_cutoff,
+            Company.last_activity_at < due_soon_cutoff,
+        )
+    elif staleness == "recent":
+        query = query.filter(Company.last_activity_at >= due_soon_cutoff)
+    elif staleness == "new":
+        query = query.filter(Company.last_activity_at.is_(None))
+
+    if account_type in CDM_ACCOUNT_TYPES:
+        query = query.filter(Company.account_type == account_type)
+    if my_only:
+        query = query.filter(Company.account_owner_id == user.id)
+
+    return query.order_by(CDM_SORTS.get(sort, CDM_SORTS["oldest"]))
+
+
+def cdm_overdue_count(db: Session, user: User, now: datetime | None = None) -> int:
+    """Count this user's accounts needing a call (overdue or never contacted).
+
+    Sales/trader only — others get 0 (no chip rendered).
+    """
+    if user.role not in ("sales", "trader"):
+        return 0
+    now = now or datetime.now(timezone.utc)
+    call_threshold = now - timedelta(days=STALENESS_OVERDUE_DAYS)
+    return (
+        db.query(func.count(Company.id))
+        .filter(
+            Company.is_active.is_(True),
+            Company.account_owner_id == user.id,
+            or_(
+                Company.last_activity_at < call_threshold,
+                Company.last_activity_at.is_(None),
+            ),
+        )
+        .scalar()
+        or 0
+    )
+
+
+def cdm_list_ctx(
+    db: Session,
+    user: User,
+    *,
+    search: str,
+    staleness: str,
+    account_type: str,
+    my_only: bool,
+    sort: str,
+    limit: int,
+    offset: int,
+    include_overdue: bool = False,
+) -> dict:
+    """Shared context for the CDM workspace shell and its account-list partial.
+
+    include_overdue: the overdue chip lives in the filter bar (workspace shell
+    only), so the account-list refresh route skips that COUNT query.
+    """
+    now = datetime.now(timezone.utc)
+    query = cdm_company_query(
+        db, user, search=search, staleness=staleness, account_type=account_type, my_only=my_only, sort=sort, now=now
+    )
+    total = query.count()
+    companies = query.offset(offset).limit(limit).all()
+    for c in companies:
+        c.staleness = staleness_tier(c.last_activity_at)
+
+    ctx = {
+        "companies": companies,
+        "search": search,
+        "staleness": staleness,
+        "account_type": account_type,
+        "my_only": my_only,
+        "sort": sort,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+    if include_overdue:
+        ctx["overdue_count"] = cdm_overdue_count(db, user, now=now)
+        ctx["account_types"] = CDM_ACCOUNT_TYPES
+    return ctx
+
+
+def company_contact_rows(db: Session, company_id: int, sites: list[CustomerSite] | None = None) -> list[dict]:
+    """All contacts for a company across its sites, plus legacy site-level contacts.
+
+    Returns [{"contact": SiteContact|None, "site": CustomerSite|None, "legacy": bool}].
+    Pass pre-loaded sites (e.g. from joinedload) to skip the sites query.
+    """
+    if sites is None:
+        sites = db.query(CustomerSite).filter(CustomerSite.company_id == company_id).all()
+    site_map = {s.id: s for s in sites}
+    contacts: list[SiteContact] = []
+    if site_map:
+        contacts = (
+            db.query(SiteContact)
+            .filter(SiteContact.customer_site_id.in_(list(site_map)), SiteContact.is_active.is_(True))
+            .order_by(SiteContact.is_primary.desc(), SiteContact.full_name)
+            .all()
+        )
+    rows = [{"contact": c, "site": site_map.get(c.customer_site_id), "legacy": False} for c in contacts]
+    for s in sites:
+        if s.contact_name or s.contact_email:
+            rows.append({"contact": None, "site": s, "legacy": True})
+    return rows

--- a/app/services/crm_service.py
+++ b/app/services/crm_service.py
@@ -4,8 +4,11 @@ Holds quote numbering (used by proactive_service) and the CDM account-workspace
 business rules: staleness tiers, account-list query building/sorting, and the
 contact-row assembly for the company detail panel.
 
-Called by: app/routers/htmx_views.py (CDM workspace routes), app/services/proactive_service.py
-Depends on: app/models (Company, CustomerSite, SiteContact, Quote), app/utils/search_builder
+Called by: app/routers/htmx_views.py (CDM workspace routes),
+    app/routers/crm/quotes.py + app/routers/crm/__init__.py (next_quote_number),
+    app/services/proactive_service.py, app/services/quote_builder_service.py
+Depends on: app/models (Company, CustomerSite, SiteContact, Quote),
+    app/models/auth (User), app/utils/search_builder
 """
 
 from datetime import datetime, timedelta, timezone
@@ -77,6 +80,18 @@ CDM_SORTS = {
 CDM_ACCOUNT_TYPES = ("Customer", "Prospect", "Partner", "Competitor")
 
 
+def _needs_call_filter(now: datetime):
+    """Predicate for accounts needing a call: overdue (30d+) OR never contacted.
+
+    Single source of truth shared by the "needs a call" chip COUNT
+    (cdm_overdue_count) and the chip's click-through filter (cdm_company_query
+    staleness="needs_call") — the two must never disagree on NULL
+    last_activity_at semantics, or the chip promises rows the list won't show.
+    """
+    cutoff = now - timedelta(days=STALENESS_OVERDUE_DAYS)
+    return or_(Company.last_activity_at < cutoff, Company.last_activity_at.is_(None))
+
+
 def cdm_company_query(
     db: Session,
     user: User,
@@ -88,7 +103,11 @@ def cdm_company_query(
     sort: str,
     now: datetime | None = None,
 ):
-    """Build the filtered + sorted CDM account list query."""
+    """Build the filtered + sorted CDM account list query.
+
+    staleness: "" (all) | "overdue" | "due_soon" | "recent" | "new" — one band each —
+    or "needs_call" (overdue OR never contacted), the "needs a call" chip's filter.
+    """
     query = db.query(Company).filter(Company.is_active.is_(True)).options(joinedload(Company.account_owner))
 
     if search.strip():
@@ -100,6 +119,9 @@ def cdm_company_query(
     due_soon_cutoff = now - timedelta(days=STALENESS_DUE_SOON_DAYS)
     if staleness == "overdue":
         query = query.filter(Company.last_activity_at < overdue_cutoff)
+    elif staleness == "needs_call":
+        # The "N need a call" chip — must match cdm_overdue_count exactly.
+        query = query.filter(_needs_call_filter(now))
     elif staleness == "due_soon":
         query = query.filter(
             Company.last_activity_at >= overdue_cutoff,
@@ -121,21 +143,19 @@ def cdm_company_query(
 def cdm_overdue_count(db: Session, user: User, now: datetime | None = None) -> int:
     """Count this user's accounts needing a call (overdue or never contacted).
 
-    Sales/trader only — others get 0 (no chip rendered).
+    Sales/trader only — others get 0 (no chip rendered). Uses the same
+    _needs_call_filter predicate as the chip's click-through query
+    (staleness="needs_call") so count and list never diverge.
     """
     if user.role not in ("sales", "trader"):
         return 0
     now = now or datetime.now(timezone.utc)
-    call_threshold = now - timedelta(days=STALENESS_OVERDUE_DAYS)
     return (
         db.query(func.count(Company.id))
         .filter(
             Company.is_active.is_(True),
             Company.account_owner_id == user.id,
-            or_(
-                Company.last_activity_at < call_threshold,
-                Company.last_activity_at.is_(None),
-            ),
+            _needs_call_filter(now),
         )
         .scalar()
         or 0
@@ -157,8 +177,10 @@ def cdm_list_ctx(
 ) -> dict:
     """Shared context for the CDM workspace shell and its account-list partial.
 
-    include_overdue: the overdue chip lives in the filter bar (workspace shell
-    only), so the account-list refresh route skips that COUNT query.
+    include_overdue: adds the filter-bar-only context — overdue_count (the
+    "needs a call" chip, an extra COUNT query) AND account_types (the type
+    dropdown options). The account-list refresh route re-renders neither, so
+    it omits both and skips the COUNT query.
     """
     now = datetime.now(timezone.utc)
     query = cdm_company_query(
@@ -187,13 +209,24 @@ def cdm_list_ctx(
 
 
 def company_contact_rows(db: Session, company_id: int, sites: list[CustomerSite] | None = None) -> list[dict]:
-    """All contacts for a company across its sites, plus legacy site-level contacts.
+    """Active contacts for a company across its ACTIVE sites, plus legacy site-level
+    contacts.
+
+    Both is_active filters apply: deactivated SiteContacts are excluded, and contacts
+    (real or legacy) on deactivated sites are excluded — outreach must never be logged
+    against, or bump last_activity_at on, a deactivated entity. Pass pre-loaded ACTIVE
+    sites (e.g. the filtered list from company_detail_partial) to skip the sites query.
 
     Returns [{"contact": SiteContact|None, "site": CustomerSite|None, "legacy": bool}].
-    Pass pre-loaded sites (e.g. from joinedload) to skip the sites query.
+    Invariant: legacy=True <=> contact is None <=> the contact fields live on
+    site.contact_* (contacts_tab.html branches on row.legacy and relies on this).
+    For legacy rows site is always set; for contact rows site is the contact's site
+    (None only if the lookup misses).
     """
     if sites is None:
-        sites = db.query(CustomerSite).filter(CustomerSite.company_id == company_id).all()
+        sites = (
+            db.query(CustomerSite).filter(CustomerSite.company_id == company_id, CustomerSite.is_active.is_(True)).all()
+        )
     site_map = {s.id: s for s in sites}
     contacts: list[SiteContact] = []
     if site_map:

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -169,7 +169,7 @@ document.body.addEventListener('htmx:configRequest', (evt) => {
 // Any element with [data-outreach-log] (tel:/mailto:/Teams/WeChat links in
 // customer contact panels) fires a fire-and-forget POST to
 // /api/activity/outreach-initiated when clicked, logging the touch and
-// bumping company.last_activity_at. The default link navigation is NOT
+// bumping company/site last_activity_at. The default link navigation is NOT
 // prevented — the native handler (dialer, mail client, Teams) still opens.
 document.body.addEventListener('click', (evt) => {
     const el = evt.target.closest('[data-outreach-log]');
@@ -192,6 +192,26 @@ document.body.addEventListener('click', (evt) => {
         Alpine.store('toast').type = type;
         Alpine.store('toast').show = true;
     };
+    // Refresh the CDM account list (if on the workspace) so the logged touch
+    // is immediately visible in the staleness sort/labels. This refresh is
+    // SYSTEM-initiated mid-workflow: unlike a user filter change it must not
+    // reset pagination, so the current offset/limit (rendered as data-* on
+    // the _account_list.html header — the filter form intentionally carries
+    // no offset field) is passed through explicitly. source: #cdm-filters
+    // includes the current filter values, like the pagination links do.
+    const refreshAccountList = () => {
+        const cdmFilters = document.getElementById('cdm-filters');
+        const cdmList = document.getElementById('cdm-list');
+        if (!cdmFilters || !cdmList) return;
+        const meta = cdmList.querySelector('[data-offset]');
+        const page = meta ? '?offset=' + meta.dataset.offset + '&limit=' + meta.dataset.limit : '';
+        htmx.ajax('GET', '/v2/partials/customers/account-list' + page, {
+            source: '#cdm-filters',
+            target: '#cdm-list',
+            swap: 'innerHTML',
+            indicator: '#cdm-filters .htmx-indicator',
+        });
+    };
     // keepalive lets the request finish even if the click navigates away.
     // The fetch is never awaited before the default link action, so the
     // call/email/Teams handler always opens — but failures must still be
@@ -202,7 +222,7 @@ document.body.addEventListener('click', (evt) => {
         headers: headers,
         body: JSON.stringify(payload),
         keepalive: true,
-    }).then((resp) => {
+    }).then(async (resp) => {
         if (!resp.ok) {
             showOutreachToast(
                 resp.status === 429
@@ -212,19 +232,39 @@ document.body.addEventListener('click', (evt) => {
             );
             return;
         }
-        const labels = { phone: 'Call', email: 'Email', teams: 'Teams message', wechat: 'WeChat message' };
-        showOutreachToast(
-            (labels[d.channel] || 'Outreach') + ' logged' + (d.contactName ? ' — ' + d.contactName : ''),
-            'success'
-        );
-        // Refresh the CDM account list (if on the workspace) so the logged
-        // touch is immediately visible in the staleness sort/labels. Reuses
-        // the filter form's own hx-get (current filters included).
-        const cdmFilters = document.getElementById('cdm-filters');
-        if (cdmFilters && document.getElementById('cdm-list')) {
-            htmx.trigger(cdmFilters, 'change');
+        // The POST committed — from here on any failure is a RENDERING
+        // problem, not a transport one. Contain it so the .catch below (the
+        // rep-facing "NOT logged" message) only ever reports genuine fetch
+        // rejections; a false "NOT logged" toast invites a duplicate re-click.
+        let droppedLinks = [];
+        try {
+            droppedLinks = (await resp.json()).dropped_links || [];
+        } catch (err) {
+            console.error('[outreach-log] could not parse response body', err);
         }
-    }).catch(() => {
+        try {
+            if (droppedLinks.length) {
+                // Logged, but the server dropped stale entity links — the touch
+                // exists yet won't show on this account, so don't claim success
+                // (and skip the list refresh: nothing changed for this view).
+                showOutreachToast(
+                    'Outreach logged, but the ' + droppedLinks.join('/') +
+                    ' link no longer exists — refresh the page',
+                    'warning'
+                );
+                return;
+            }
+            const labels = { phone: 'Call', email: 'Email', teams: 'Teams message', wechat: 'WeChat message' };
+            showOutreachToast(
+                (labels[d.channel] || 'Outreach') + ' logged' + (d.contactName ? ' — ' + d.contactName : ''),
+                'success'
+            );
+            refreshAccountList();
+        } catch (err) {
+            console.error('[outreach-log] post-success UI update failed', err);
+        }
+    }).catch((err) => {
+        console.error('[outreach-log] failed', err);
         showOutreachToast('Outreach NOT logged — network error', 'error');
     });
 });

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -187,19 +187,46 @@ document.body.addEventListener('click', (evt) => {
     const headers = { 'Content-Type': 'application/json' };
     const csrfCookie = document.cookie.match(/csrftoken=([^;]+)/)?.[1];
     if (csrfCookie) headers['x-csrftoken'] = csrfCookie;
-    // keepalive lets the request finish even if the click navigates away
+    const showOutreachToast = (message, type) => {
+        Alpine.store('toast').message = message;
+        Alpine.store('toast').type = type;
+        Alpine.store('toast').show = true;
+    };
+    // keepalive lets the request finish even if the click navigates away.
+    // The fetch is never awaited before the default link action, so the
+    // call/email/Teams handler always opens — but failures must still be
+    // VISIBLE: a silent 429/500 means the rep believes the touch was logged
+    // while the staleness sort quietly stops reflecting their work.
     fetch('/api/activity/outreach-initiated', {
         method: 'POST',
         headers: headers,
         body: JSON.stringify(payload),
         keepalive: true,
     }).then((resp) => {
-        if (!resp.ok) return;
+        if (!resp.ok) {
+            showOutreachToast(
+                resp.status === 429
+                    ? 'Outreach NOT logged — rate limit hit, wait a minute'
+                    : 'Outreach NOT logged (error ' + resp.status + ')',
+                'error'
+            );
+            return;
+        }
         const labels = { phone: 'Call', email: 'Email', teams: 'Teams message', wechat: 'WeChat message' };
-        Alpine.store('toast').message = (labels[d.channel] || 'Outreach') + ' logged' + (d.contactName ? ' — ' + d.contactName : '');
-        Alpine.store('toast').type = 'success';
-        Alpine.store('toast').show = true;
-    }).catch(() => { /* fire-and-forget: never block the call/email itself */ });
+        showOutreachToast(
+            (labels[d.channel] || 'Outreach') + ' logged' + (d.contactName ? ' — ' + d.contactName : ''),
+            'success'
+        );
+        // Refresh the CDM account list (if on the workspace) so the logged
+        // touch is immediately visible in the staleness sort/labels. Reuses
+        // the filter form's own hx-get (current filters included).
+        const cdmFilters = document.getElementById('cdm-filters');
+        if (cdmFilters && document.getElementById('cdm-list')) {
+            htmx.trigger(cdmFilters, 'change');
+        }
+    }).catch(() => {
+        showOutreachToast('Outreach NOT logged — network error', 'error');
+    });
 });
 
 // ── HTMX error handler — show toast on failed requests ──────

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -165,6 +165,43 @@ document.body.addEventListener('htmx:configRequest', (evt) => {
     }
 });
 
+// ── Click-to-contact outreach logger (CDM contact panel) ────
+// Any element with [data-outreach-log] (tel:/mailto:/Teams/WeChat links in
+// customer contact panels) fires a fire-and-forget POST to
+// /api/activity/outreach-initiated when clicked, logging the touch and
+// bumping company.last_activity_at. The default link navigation is NOT
+// prevented — the native handler (dialer, mail client, Teams) still opens.
+document.body.addEventListener('click', (evt) => {
+    const el = evt.target.closest('[data-outreach-log]');
+    if (!el) return;
+    const d = el.dataset;
+    const payload = {
+        channel: d.channel,
+        contact_value: d.value,
+        company_id: d.companyId ? parseInt(d.companyId, 10) : null,
+        customer_site_id: d.siteId ? parseInt(d.siteId, 10) : null,
+        site_contact_id: d.contactId ? parseInt(d.contactId, 10) : null,
+        contact_name: d.contactName || null,
+        origin: 'cdm_workspace',
+    };
+    const headers = { 'Content-Type': 'application/json' };
+    const csrfCookie = document.cookie.match(/csrftoken=([^;]+)/)?.[1];
+    if (csrfCookie) headers['x-csrftoken'] = csrfCookie;
+    // keepalive lets the request finish even if the click navigates away
+    fetch('/api/activity/outreach-initiated', {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(payload),
+        keepalive: true,
+    }).then((resp) => {
+        if (!resp.ok) return;
+        const labels = { phone: 'Call', email: 'Email', teams: 'Teams message', wechat: 'WeChat message' };
+        Alpine.store('toast').message = (labels[d.channel] || 'Outreach') + ' logged' + (d.contactName ? ' — ' + d.contactName : '');
+        Alpine.store('toast').type = 'success';
+        Alpine.store('toast').show = true;
+    }).catch(() => { /* fire-and-forget: never block the call/email itself */ });
+});
+
 // ── HTMX error handler — show toast on failed requests ──────
 htmx.on('htmx:responseError', (evt) => {
     Alpine.store('toast').message = 'Request failed. Please try again.';

--- a/app/templates/htmx/partials/crm/shell.html
+++ b/app/templates/htmx/partials/crm/shell.html
@@ -9,7 +9,7 @@
     <button @click="tab = 'customers'"
             :class="tab === 'customers' ? 'border-b-2 border-brand-500 text-brand-600 bg-brand-50' : 'text-gray-500 hover:text-brand-600 hover:bg-brand-50'"
             class="px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors"
-            hx-get="/v2/partials/customers?hx_target=%23crm-tab-content&push_url_base=/v2/crm"
+            hx-get="/v2/partials/customers"
             hx-target="#crm-tab-content"
             hx-swap="innerHTML"
             hx-trigger="{{ 'load, click' if default_tab == 'customers' else 'click' }}">

--- a/app/templates/htmx/partials/customers/_account_list.html
+++ b/app/templates/htmx/partials/customers/_account_list.html
@@ -1,0 +1,68 @@
+{# _account_list.html — CDM left-panel account list: rows + count + pagination.
+   Each row loads the account detail into #cdm-detail and highlights via the
+   workspace-level Alpine selectedId.
+   Receives: companies, total, limit, offset (filters come from #cdm-filters via hx-include).
+   Called by: list.html (initial include) and companies_account_list_partial route (refresh).
+   Depends on: workspace x-data (selectedId), brand palette, timeago filter.
+#}
+
+<div class="sticky top-0 z-10 px-3 py-1.5 text-[11px] font-medium text-gray-500 bg-gray-50 border-b border-gray-200">
+  {{ total }} account{{ "s" if total != 1 }}
+</div>
+
+{% if companies %}
+{% set dot_colors = {"overdue": "bg-rose-500", "due_soon": "bg-amber-400", "recent": "bg-emerald-400", "new": "bg-brand-300"} %}
+<div class="divide-y divide-gray-100">
+  {% for c in companies %}
+  <div id="cdm-row-{{ c.id }}" role="button" tabindex="0"
+       class="flex items-center gap-2.5 px-3 py-2.5 cursor-pointer hover:bg-gray-50 transition-colors border-l-2"
+       hx-get="/v2/partials/customers/{{ c.id }}"
+       hx-target="#cdm-detail"
+       hx-swap="innerHTML"
+       preload="mouseover"
+       @click="selectedId = {{ c.id }}"
+       @keydown.enter="selectedId = {{ c.id }}"
+       :class="selectedId === {{ c.id }} ? 'bg-brand-50 border-l-brand-500' : 'border-l-transparent'">
+    <span class="w-2.5 h-2.5 rounded-full flex-shrink-0 {{ dot_colors.get(c.staleness, 'bg-gray-300') }}"
+          role="img" aria-label="{{ c.staleness|replace('_', ' ')|title }}"
+          title="{{ c.staleness|replace('_', ' ')|title }}"></span>
+    <div class="flex-1 min-w-0">
+      <p class="text-sm font-medium text-gray-900 truncate">{{ c.name }}</p>
+      <p class="text-[11px] text-gray-500 truncate">
+        {{ c.account_type or "—" }}{% if c.account_owner %} &middot; {{ c.account_owner.name }}{% endif %}
+      </p>
+    </div>
+    <span class="flex-shrink-0 text-[11px] {% if c.staleness == 'overdue' %}text-rose-600 font-medium{% elif c.staleness == 'due_soon' %}text-amber-600{% else %}text-gray-400{% endif %}">
+      {{ c.last_activity_at|timeago if c.last_activity_at else "Never" }}
+    </span>
+  </div>
+  {% endfor %}
+</div>
+
+{# Pagination #}
+{% if total > limit %}
+<div class="flex items-center justify-center gap-1 py-2 border-t border-gray-100">
+  {% if offset > 0 %}
+  <a hx-get="/v2/partials/customers/account-list?offset={{ offset - limit }}"
+     hx-target="#cdm-list"
+     hx-swap="innerHTML"
+     hx-include="#cdm-filters"
+     class="px-2.5 py-1 text-xs bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Prev</a>
+  {% endif %}
+  <span class="px-2 py-1 text-xs text-gray-500">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
+  {% if offset + limit < total %}
+  <a hx-get="/v2/partials/customers/account-list?offset={{ offset + limit }}"
+     hx-target="#cdm-list"
+     hx-swap="innerHTML"
+     hx-include="#cdm-filters"
+     class="px-2.5 py-1 text-xs bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Next</a>
+  {% endif %}
+</div>
+{% endif %}
+
+{% else %}
+<div class="p-8 text-center">
+  <svg class="mx-auto h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+  <p class="mt-2 text-sm text-gray-500">No accounts found</p>
+</div>
+{% endif %}

--- a/app/templates/htmx/partials/customers/_account_list.html
+++ b/app/templates/htmx/partials/customers/_account_list.html
@@ -6,7 +6,11 @@
    Depends on: workspace x-data (selectedId), brand palette, timeago filter.
 #}
 
-<div class="sticky top-0 z-10 px-3 py-1.5 text-[11px] font-medium text-gray-500 bg-gray-50 border-b border-gray-200">
+{# data-offset/data-limit: read by the outreach logger's system-initiated list
+   refresh (htmx_app.js) so logging a touch doesn't snap a paginated list back
+   to page 1 — the filter form itself intentionally carries no offset field. #}
+<div class="sticky top-0 z-10 px-3 py-1.5 text-[11px] font-medium text-gray-500 bg-gray-50 border-b border-gray-200"
+     data-offset="{{ offset }}" data-limit="{{ limit }}">
   {{ total }} account{{ "s" if total != 1 }}
 </div>
 

--- a/app/templates/htmx/partials/customers/_account_list.html
+++ b/app/templates/htmx/partials/customers/_account_list.html
@@ -15,13 +15,16 @@
 <div class="divide-y divide-gray-100">
   {% for c in companies %}
   <div id="cdm-row-{{ c.id }}" role="button" tabindex="0"
-       class="flex items-center gap-2.5 px-3 py-2.5 cursor-pointer hover:bg-gray-50 transition-colors border-l-2"
+       class="flex items-center gap-2.5 px-3 py-2.5 cursor-pointer hover:bg-gray-50 transition-colors border-l-2 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-500"
        hx-get="/v2/partials/customers/{{ c.id }}"
        hx-target="#cdm-detail"
        hx-swap="innerHTML"
+       hx-target-error="#cdm-error"
+       hx-trigger="click, keyup[key=='Enter']"
+       data-loading-class="opacity-60 pointer-events-none"
        preload="mouseover"
        @click="selectedId = {{ c.id }}"
-       @keydown.enter="selectedId = {{ c.id }}"
+       @keyup.enter="selectedId = {{ c.id }}"
        :class="selectedId === {{ c.id }} ? 'bg-brand-50 border-l-brand-500' : 'border-l-transparent'">
     <span class="w-2.5 h-2.5 rounded-full flex-shrink-0 {{ dot_colors.get(c.staleness, 'bg-gray-300') }}"
           role="img" aria-label="{{ c.staleness|replace('_', ' ')|title }}"
@@ -39,23 +42,30 @@
   {% endfor %}
 </div>
 
-{# Pagination #}
+{# Pagination — keyboard-operable; offset clamped at 0; limit pinned so a
+   future page-size control can't desync links from the route default. #}
 {% if total > limit %}
 <div class="flex items-center justify-center gap-1 py-2 border-t border-gray-100">
   {% if offset > 0 %}
-  <a hx-get="/v2/partials/customers/account-list?offset={{ offset - limit }}"
+  <a role="button" tabindex="0"
+     hx-get="/v2/partials/customers/account-list?offset={{ [offset - limit, 0]|max }}&limit={{ limit }}"
      hx-target="#cdm-list"
      hx-swap="innerHTML"
+     hx-target-error="#cdm-error"
      hx-include="#cdm-filters"
-     class="px-2.5 py-1 text-xs bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Prev</a>
+     hx-trigger="click, keyup[key=='Enter']"
+     class="px-2.5 py-1 text-xs bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-500">Prev</a>
   {% endif %}
   <span class="px-2 py-1 text-xs text-gray-500">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
   {% if offset + limit < total %}
-  <a hx-get="/v2/partials/customers/account-list?offset={{ offset + limit }}"
+  <a role="button" tabindex="0"
+     hx-get="/v2/partials/customers/account-list?offset={{ offset + limit }}&limit={{ limit }}"
      hx-target="#cdm-list"
      hx-swap="innerHTML"
+     hx-target-error="#cdm-error"
      hx-include="#cdm-filters"
-     class="px-2.5 py-1 text-xs bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Next</a>
+     hx-trigger="click, keyup[key=='Enter']"
+     class="px-2.5 py-1 text-xs bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-500">Next</a>
   {% endif %}
 </div>
 {% endif %}

--- a/app/templates/htmx/partials/customers/_detail_empty.html
+++ b/app/templates/htmx/partials/customers/_detail_empty.html
@@ -9,5 +9,5 @@
           d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
   </svg>
   <p class="text-lg font-medium text-gray-500">Select an account</p>
-  <p class="text-sm mt-1">Click an account on the left to see contacts and activity</p>
+  <p class="text-sm mt-1">Contacts, phone numbers, and activity will appear here</p>
 </div>

--- a/app/templates/htmx/partials/customers/_detail_empty.html
+++ b/app/templates/htmx/partials/customers/_detail_empty.html
@@ -1,0 +1,13 @@
+{# _detail_empty.html — Empty state for the CDM right detail panel.
+   Shown when no account is selected in the split workspace.
+   Called by: list.html (include).
+   Depends on: Tailwind CSS.
+#}
+<div class="flex flex-col items-center justify-center h-full text-gray-400 select-none">
+  <svg class="h-16 w-16 mb-4 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
+    <path stroke-linecap="round" stroke-linejoin="round"
+          d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+  </svg>
+  <p class="text-lg font-medium text-gray-500">Select an account</p>
+  <p class="text-sm mt-1">Click an account on the left to see contacts and activity</p>
+</div>

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -1,7 +1,10 @@
-{# Company detail partial — tabbed layout with enrich, quick info, stats, and click-to-call.
-   Receives: company, sites, open_req_count, user.
+{# Company detail partial — tabbed layout with enrich, quick info, stats, and click-to-contact.
+   Renders inside the CDM workspace right panel (#cdm-detail) or full-page (#main-content).
+   Contacts tab is default and inlined so phones/emails/Teams/WeChat actions are
+   immediately available for call-list workflows.
+   Receives: company, sites, open_req_count, contact_rows, user.
    Called by: company_detail_partial route in htmx_views.py.
-   Depends on: brand palette, partials/shared/enrich_button.html, partials/shared/empty_state.html.
+   Depends on: brand palette, partials/shared/enrich_button.html, tabs/contacts_tab.html.
 #}
 
 <title hx-swap-oob="true">{{ company.name }} — Companies — AvailAI</title>
@@ -74,7 +77,9 @@
         <p class="text-xs font-medium text-gray-500 uppercase tracking-wider">Phone</p>
         <p class="mt-1 text-sm font-medium">
           {% if company.phone %}
-            <a href="tel:{{ company.phone }}" class="text-brand-500 hover:text-brand-600">{{ company.phone }}</a>
+            <a href="tel:{{ company.phone }}" class="text-brand-500 hover:text-brand-600"
+               data-outreach-log data-channel="phone" data-value="{{ company.phone }}"
+               data-company-id="{{ company.id }}" data-contact-name="{{ company.name }}">{{ company.phone }}</a>
           {% else %}
             <span class="text-gray-400">—</span>
           {% endif %}
@@ -118,13 +123,13 @@
     </div>
   </div>
 
-  {# ── Tabs ────────────────────────────────────────────────── #}
-  <div x-data="{ activeTab: 'sites' }">
+  {# ── Tabs — Contacts first (CDM call-list workflow) ───────── #}
+  <div x-data="{ activeTab: 'contacts' }">
     <div class="border-b border-gray-200">
       <nav class="flex gap-6 -mb-px">
         {% for tab_id, tab_label, tab_count in [
+          ('contacts', 'Contacts', contact_rows|length if contact_rows is defined else none),
           ('sites', 'Sites', sites|length),
-          ('contacts', 'Contacts', none),
           ('requisitions', 'Requisitions', open_req_count),
           ('activity', 'Activity', none)
         ] %}
@@ -144,44 +149,9 @@
       </nav>
     </div>
 
-    {# Tab content — sites loaded inline on first load #}
+    {# Tab content — contacts loaded inline on first load (click-to-contact panel) #}
     <div id="company-tab-content" class="mt-4">
-      {% if sites %}
-      <div class="bg-white rounded-xl shadow-sm border border-brand-200 overflow-hidden">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
-            <tr>
-              <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Site Name</th>
-              <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-              <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">City</th>
-              <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Country</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-gray-200">
-            {% for s in sites %}
-            <tr class="hover:bg-brand-50 cursor-pointer transition-colors"
-                hx-get="/v2/partials/customers/{{ company.id }}/sites/{{ s.id }}"
-                hx-target="#company-tab-content"
-                hx-swap="innerHTML">
-              <td class="px-4 py-2.5 text-sm font-medium text-gray-900">{{ s.site_name }}</td>
-              <td class="px-4 py-2.5 text-sm text-gray-500">
-                {% if s.site_type %}
-                  <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-brand-100 text-brand-600">{{ s.site_type }}</span>
-                {% else %}
-                  —
-                {% endif %}
-              </td>
-              <td class="px-4 py-2.5 text-sm text-gray-500">{{ s.city or "—" }}</td>
-              <td class="px-4 py-2.5 text-sm text-gray-500">{{ s.country or "—" }}</td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-      {% else %}
-      {% set message = "No sites found for this company." %}
-      {% include "htmx/partials/shared/empty_state.html" %}
-      {% endif %}
+      {% include "htmx/partials/customers/tabs/contacts_tab.html" %}
     </div>
   </div>
 

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -9,7 +9,8 @@
 
 <title hx-swap-oob="true">{{ company.name }} — Companies — AvailAI</title>
 
-<div class="max-w-5xl mx-auto space-y-6">
+{# max-w-3xl: must fit the CDM right panel (~60% viewport), not just full-page #}
+<div class="max-w-3xl mx-auto space-y-6">
 
   {# ── Header Card ─────────────────────────────────────────── #}
   <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-6">
@@ -54,8 +55,9 @@
       </div>
     </div>
 
-    {# Quick info grid (4 cols) #}
-    <div class="mt-6 grid grid-cols-2 md:grid-cols-4 gap-4">
+    {# Quick info grid — 2 cols: the md: viewport breakpoint lies inside a
+       split panel (panel is far narrower than the viewport) #}
+    <div class="mt-6 grid grid-cols-2 gap-4">
       <div class="p-3 rounded-lg bg-gray-50">
         <p class="text-xs font-medium text-gray-500 uppercase tracking-wider">Account Owner</p>
         <p class="mt-1 text-sm font-medium text-gray-900">
@@ -126,7 +128,7 @@
   {# ── Tabs — Contacts first (CDM call-list workflow) ───────── #}
   <div x-data="{ activeTab: 'contacts' }">
     <div class="border-b border-gray-200">
-      <nav class="flex gap-6 -mb-px">
+      <nav class="flex gap-6 -mb-px" role="tablist" aria-label="Account detail sections">
         {% for tab_id, tab_label, tab_count in [
           ('contacts', 'Contacts', contact_rows|length if contact_rows is defined else none),
           ('sites', 'Sites', sites|length),
@@ -134,6 +136,9 @@
           ('activity', 'Activity', none)
         ] %}
         <button @click="activeTab = '{{ tab_id }}'"
+                role="tab"
+                :aria-selected="activeTab === '{{ tab_id }}' ? 'true' : 'false'"
+                aria-controls="company-tab-content"
                 hx-get="/v2/partials/customers/{{ company.id }}/tab/{{ tab_id }}"
                 hx-target="#company-tab-content"
                 hx-trigger="click"
@@ -150,7 +155,7 @@
     </div>
 
     {# Tab content — contacts loaded inline on first load (click-to-contact panel) #}
-    <div id="company-tab-content" class="mt-4">
+    <div id="company-tab-content" class="mt-4" role="tabpanel">
       {% include "htmx/partials/customers/tabs/contacts_tab.html" %}
     </div>
   </div>

--- a/app/templates/htmx/partials/customers/list.html
+++ b/app/templates/htmx/partials/customers/list.html
@@ -1,159 +1,97 @@
-{# Companies list partial — searchable company table with brand palette.
-   Receives: companies, search, total, limit, offset.
-   Called by: companies_list_partial route.
-   Depends on: brand palette.
+{# CDM account workspace — split-panel: scrollable account list (left) + account detail (right).
+   Modeled on the requisitions2 split-screen workspace. Default sort puts the
+   longest-neglected accounts at the top (call-list order).
+   Receives: companies, search, staleness, account_type, my_only, sort, total,
+             limit, offset, overdue_count, account_types.
+   Called by: companies_list_partial route (htmx_views.py).
+   Depends on: splitPanel Alpine component (htmx_app.js), _account_list.html,
+               _detail_empty.html, brand palette.
 #}
 
-<div class="max-w-7xl mx-auto">
-  <div class="flex items-center justify-between mb-4">
-    <div>
-      <p class="text-sm text-gray-500 mt-1">{{ total }} compan{{ "ies" if total != 1 else "y" }}</p>
-    </div>
-  </div>
+<div id="cdm-workspace" class="flex flex-col min-h-[420px]"
+     x-data="{ selectedId: null }"
+     x-init="const fit = () => { $el.style.height = Math.max(420, window.innerHeight - $el.getBoundingClientRect().top - 64) + 'px' }; fit(); window.addEventListener('resize', fit)">
 
-  {# Today's Calls — overdue accounts for this salesperson #}
-  {% if todays_calls %}
-  <div class="bg-rose-50 border border-rose-200 rounded-lg p-4 mb-4">
-    <div class="flex items-center justify-between mb-3">
-      <h3 class="text-sm font-semibold text-rose-800">
-        Needs Attention
-        <span class="ml-1 text-xs font-normal text-rose-600">({{ todays_calls|length }} account{{ "s" if todays_calls|length != 1 else "" }} overdue)</span>
-      </h3>
-    </div>
-    <div class="space-y-2">
-      {% for c in todays_calls %}
-      <div class="flex items-center justify-between bg-white rounded-lg px-3 py-2 border border-rose-100 cursor-pointer hover:bg-rose-50 transition-colors"
-           hx-get="/v2/partials/customers/{{ c.id }}"
-           hx-target="{{ hx_target|default('#main-content') }}"
-           hx-push-url="{{ push_url_base|default('/v2/customers') }}/{{ c.id }}">
-        <div class="flex items-center gap-2">
-          {% set dot_colors = {"overdue": "bg-rose-500", "due_soon": "bg-amber-400", "recent": "bg-emerald-400", "new": "bg-brand-300"} %}
-          <span class="w-2.5 h-2.5 rounded-full {{ dot_colors.get(c.staleness, 'bg-rose-500') }} block"></span>
-          <span class="text-sm font-medium text-gray-900">{{ c.name }}</span>
-          {% if c.is_strategic %}
-          <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-violet-50 text-violet-700">Strategic</span>
-          {% endif %}
-        </div>
-        <span class="text-xs text-rose-600">{{ c.last_activity_at|timeago if c.last_activity_at else "Never contacted" }}</span>
-      </div>
+  {# ── Filter / sort bar ─────────────────────────────────────── #}
+  <form id="cdm-filters" class="flex items-center gap-2 flex-wrap pb-3 flex-shrink-0"
+        hx-get="/v2/partials/customers/account-list"
+        hx-target="#cdm-list"
+        hx-swap="innerHTML"
+        hx-trigger="change, keyup changed delay:300ms from:#cdm-search">
+
+    <input id="cdm-search" aria-label="Search accounts" type="text" name="search" value="{{ search }}"
+           placeholder="Search accounts..."
+           class="flex-1 min-w-[160px] px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+
+    <select name="staleness" aria-label="Filter by activity staleness"
+            class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
+      <option value="">All activity</option>
+      <option value="overdue" {{ "selected" if staleness == "overdue" }}>Overdue (30d+)</option>
+      <option value="due_soon" {{ "selected" if staleness == "due_soon" }}>Due soon (14&ndash;30d)</option>
+      <option value="recent" {{ "selected" if staleness == "recent" }}>Recent (&lt;14d)</option>
+      <option value="new" {{ "selected" if staleness == "new" }}>Never contacted</option>
+    </select>
+
+    <select name="account_type" aria-label="Filter by account type"
+            class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
+      <option value="">All types</option>
+      {% for t in account_types %}
+      <option value="{{ t }}" {{ "selected" if account_type == t }}>{{ t }}</option>
       {% endfor %}
-    </div>
-  </div>
-  {% endif %}
+    </select>
 
-  {# Search bar #}
-  <form id="customer-filters" class="bg-white rounded-lg shadow border border-gray-200 p-4 mb-6">
-    <input type="hidden" name="hx_target" value="{{ hx_target|default('#main-content') }}">
-    <input type="hidden" name="push_url_base" value="{{ push_url_base|default('/v2/customers') }}">
-    <input aria-label="Search customers" type="text" name="search" value="{{ search }}" placeholder="Search customers..."
-           hx-get="/v2/partials/customers" hx-target="{{ hx_target|default('#main-content') }}" hx-push-url="{{ push_url_base|default('/v2/customers') }}"
-           hx-swap="morph"
-           hx-include="#customer-filters"
-           hx-trigger="keyup changed delay:300ms"
-           class="w-full px-3 py-1.5 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+    <select name="sort" aria-label="Sort accounts"
+            class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
+      <option value="oldest" {{ "selected" if sort == "oldest" }}>Longest since activity</option>
+      <option value="newest" {{ "selected" if sort == "newest" }}>Most recent activity</option>
+      <option value="name_asc" {{ "selected" if sort == "name_asc" }}>Name A&ndash;Z</option>
+      <option value="name_desc" {{ "selected" if sort == "name_desc" }}>Name Z&ndash;A</option>
+    </select>
+
+    <label class="inline-flex items-center gap-1.5 px-2 py-1.5 text-sm text-gray-600 cursor-pointer">
+      <input type="checkbox" name="my_only" value="1" {{ "checked" if my_only }}
+             class="rounded border-gray-300 text-brand-500 focus:ring-brand-500">
+      My accounts
+    </label>
+
+    {% if overdue_count %}
+    <button type="button"
+            class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-full bg-rose-50 text-rose-700 border border-rose-200 hover:bg-rose-100 transition-colors"
+            title="Show your accounts overdue for a call"
+            @click="const f = document.getElementById('cdm-filters'); f.elements.staleness.value = 'overdue'; f.elements.my_only.checked = true; f.dispatchEvent(new Event('change', { bubbles: true }))">
+      <span class="w-2 h-2 rounded-full bg-rose-500"></span>
+      {{ overdue_count }} need{{ "s" if overdue_count == 1 }} a call
+    </button>
+    {% endif %}
+
+    <span class="htmx-indicator text-gray-400 text-xs">Loading...</span>
   </form>
 
-  {# Table #}
-  {% if companies %}
-  <div class="bg-white rounded-lg shadow border border-gray-200 overflow-hidden">
-    <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
-          <tr>
-            <th class="px-2 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-8"></th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Company</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Industry</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Owner</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Sites</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Contact</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-gray-200">
-          {% for c in companies %}
-          <tr class="hover:bg-brand-50 cursor-pointer"
-              hx-get="/v2/partials/customers/{{ c.id }}"
-              hx-target="{{ hx_target|default('#main-content') }}"
-              hx-push-url="{{ push_url_base|default('/v2/customers') }}/{{ c.id }}"
-              preload="mouseover">
-            <td class="px-2 py-3">
-              {% set dot_colors = {"overdue": "bg-rose-500", "due_soon": "bg-amber-400", "recent": "bg-emerald-400", "new": "bg-brand-300"} %}
-              <span class="w-3 h-3 rounded-full {{ dot_colors.get(c.staleness, 'bg-gray-300') }} block" role="img" aria-label="{{ c.staleness|replace('_', ' ')|title }}" title="{{ c.staleness|replace('_', ' ')|title }}"></span>
-            </td>
-            <td class="px-4 py-3">
-              <div class="flex items-center">
-                <div class="h-8 w-8 rounded-full bg-brand-100 flex items-center justify-center text-xs font-medium text-brand-600">
-                  {{ c.name[0]|upper if c.name else "?" }}
-                </div>
-                <div class="ml-3">
-                  <p class="text-sm font-medium text-brand-500">{{ c.name }}</p>
-                  {% if c.domain %}<p class="text-xs text-gray-500">{{ c.domain }}</p>{% endif %}
-                </div>
-              </div>
-            </td>
-            <td class="px-4 py-3">
-              {% if c.account_type %}
-              {% set type_colors = {
-                "Customer": "bg-emerald-50 text-emerald-700",
-                "Prospect": "bg-brand-100 text-brand-600",
-                "Partner": "bg-brand-100 text-brand-300",
-                "Competitor": "bg-rose-50 text-rose-700"
-              } %}
-              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ type_colors.get(c.account_type, 'bg-gray-100 text-gray-600') }}">
-                {{ c.account_type }}
-              </span>
-              {% else %}
-              <span class="text-xs text-gray-500">&mdash;</span>
-              {% endif %}
-            </td>
-            <td class="px-4 py-3 text-sm text-gray-500">{{ c.industry or "\u2014" }}</td>
-            <td class="px-4 py-3 text-sm text-gray-500">{{ c.account_owner.name if c.account_owner else "\u2014" }}</td>
-            <td class="px-4 py-3 text-sm text-gray-500 text-center">{{ c.site_count or 0 }}</td>
-            <td class="px-4 py-3 text-sm text-gray-500">
-              {% if c.last_activity_at %}
-                <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full
-                  {% if c.staleness == 'overdue' %}bg-rose-50 text-rose-700
-                  {% elif c.staleness == 'due_soon' %}bg-amber-50 text-amber-700
-                  {% elif c.staleness == 'recent' %}bg-emerald-50 text-emerald-700
-                  {% else %}bg-brand-100 text-brand-600{% endif %}">
-                  {{ c.last_activity_at|timeago }}
-                </span>
-              {% else %}
-                <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-brand-100 text-brand-600">Never</span>
-              {% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+  {# ── Split workspace: account list (left) + detail panel (right) ── #}
+  <div id="split-cdm"
+       class="flex flex-1 overflow-hidden min-h-0 bg-white border border-gray-200 rounded-lg"
+       x-data="splitPanel('cdm', 35)">
+
+    {# Left panel: scrollable account list #}
+    <div class="border-r border-gray-200 flex flex-col bg-white flex-shrink-0 overflow-hidden"
+         :style="'width: ' + leftWidth + '%'">
+      <div id="cdm-list" class="flex-1 overflow-y-auto">
+        {% include "htmx/partials/customers/_account_list.html" %}
+      </div>
     </div>
-  </div>
 
-  {# Pagination #}
-  {% if total > limit %}
-  <div class="mt-4 flex justify-center">
-    <nav class="flex gap-1 items-center">
-      {% if offset > 0 %}
-      <a hx-get="/v2/partials/customers?offset={{ offset - limit }}"
-         hx-target="{{ hx_target|default('#main-content') }}"
-         hx-include="#customer-filters"
-         class="px-3 py-1.5 text-sm bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Prev</a>
-      {% endif %}
-      <span class="px-3 py-1.5 text-sm text-gray-500">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
-      {% if offset + limit < total %}
-      <a hx-get="/v2/partials/customers?offset={{ offset + limit }}"
-         hx-target="{{ hx_target|default('#main-content') }}"
-         hx-include="#customer-filters"
-         class="px-3 py-1.5 text-sm bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Next</a>
-      {% endif %}
-    </nav>
-  </div>
-  {% endif %}
+    {# Resizable divider #}
+    <div class="w-1 bg-gray-200 hover:bg-brand-400 cursor-col-resize flex-shrink-0 transition-colors"
+         role="separator" aria-label="Resize panels" tabindex="0"
+         @mousedown="startResize($event)"
+         @touchstart.prevent="startTouchResize($event)"
+         @keydown.left.prevent="leftWidth = Math.max(20, leftWidth - 2); localStorage.setItem('avail_split_cdm', leftWidth)"
+         @keydown.right.prevent="leftWidth = Math.min(70, leftWidth + 2); localStorage.setItem('avail_split_cdm', leftWidth)"></div>
 
-  {% else %}
-  <div class="bg-white rounded-lg shadow border border-gray-200 p-12 text-center">
-    <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
-    <p class="mt-2 text-sm text-gray-500">No customers found</p>
+    {# Right panel: account detail #}
+    <div id="cdm-detail" class="flex-1 overflow-y-auto bg-white min-w-0 p-4">
+      {% include "htmx/partials/customers/_detail_empty.html" %}
+    </div>
+
   </div>
-  {% endif %}
 </div>

--- a/app/templates/htmx/partials/customers/list.html
+++ b/app/templates/htmx/partials/customers/list.html
@@ -8,15 +8,21 @@
                _detail_empty.html, brand palette.
 #}
 
+{# fitHeight: sized to the viewport in both mount contexts (standalone page and
+   CRM shell tab). @resize.window is auto-unbound by Alpine when the element is
+   swapped out — never add window listeners via x-init here (they leak across
+   HTMX navigations). #}
 <div id="cdm-workspace" class="flex flex-col min-h-[420px]"
-     x-data="{ selectedId: null }"
-     x-init="const fit = () => { $el.style.height = Math.max(420, window.innerHeight - $el.getBoundingClientRect().top - 64) + 'px' }; fit(); window.addEventListener('resize', fit)">
+     x-data="{ selectedId: null, fitHeight() { this.$el.style.height = Math.max(420, window.innerHeight - this.$el.getBoundingClientRect().top - 64) + 'px' } }"
+     x-init="$nextTick(() => fitHeight())"
+     @resize.window.debounce.150ms="fitHeight()">
 
   {# ── Filter / sort bar ─────────────────────────────────────── #}
   <form id="cdm-filters" class="flex items-center gap-2 flex-wrap pb-3 flex-shrink-0"
         hx-get="/v2/partials/customers/account-list"
         hx-target="#cdm-list"
         hx-swap="innerHTML"
+        hx-target-error="#cdm-error"
         hx-trigger="change, keyup changed delay:300ms from:#cdm-search">
 
     <input id="cdm-search" aria-label="Search accounts" type="text" name="search" value="{{ search }}"
@@ -66,6 +72,10 @@
 
     <span class="htmx-indicator text-gray-400 text-xs">Loading...</span>
   </form>
+
+  {# Error region — failed list refreshes / row loads land here instead of
+     silently leaving stale rows behind (response-targets extension). #}
+  <div id="cdm-error" class="mb-2 empty:hidden rounded-lg border border-rose-200 bg-rose-50 p-2 text-sm text-rose-700 flex-shrink-0"></div>
 
   {# ── Split workspace: account list (left) + detail panel (right) ── #}
   <div id="split-cdm"

--- a/app/templates/htmx/partials/customers/list.html
+++ b/app/templates/htmx/partials/customers/list.html
@@ -36,6 +36,10 @@
       <option value="due_soon" {{ "selected" if staleness == "due_soon" }}>Due soon (14&ndash;30d)</option>
       <option value="recent" {{ "selected" if staleness == "recent" }}>Recent (&lt;14d)</option>
       <option value="new" {{ "selected" if staleness == "new" }}>Never contacted</option>
+      {# Chip-only value (hidden from the dropdown list): overdue OR never
+         contacted — must exist as an option so the chip's @click can set it
+         and the form round-trips it. Matches cdm_overdue_count exactly. #}
+      <option value="needs_call" {{ "selected" if staleness == "needs_call" }} hidden>Needs a call</option>
     </select>
 
     <select name="account_type" aria-label="Filter by account type"
@@ -63,8 +67,8 @@
     {% if overdue_count %}
     <button type="button"
             class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-full bg-rose-50 text-rose-700 border border-rose-200 hover:bg-rose-100 transition-colors"
-            title="Show your accounts overdue for a call"
-            @click="const f = document.getElementById('cdm-filters'); f.elements.staleness.value = 'overdue'; f.elements.my_only.checked = true; f.dispatchEvent(new Event('change', { bubbles: true }))">
+            title="Show your accounts overdue for a call or never contacted"
+            @click="const f = document.getElementById('cdm-filters'); f.elements.staleness.value = 'needs_call'; f.elements.my_only.checked = true; f.dispatchEvent(new Event('change', { bubbles: true }))">
       <span class="w-2 h-2 rounded-full bg-rose-500"></span>
       {{ overdue_count }} need{{ "s" if overdue_count == 1 }} a call
     </button>

--- a/app/templates/htmx/partials/customers/tabs/contacts_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/contacts_tab.html
@@ -1,0 +1,89 @@
+{# contacts_tab.html — Company contacts with click-to-contact outreach actions.
+   Each Call / Email / Teams / WeChat action opens the native handler (tel:,
+   mailto:, Teams deep link, weixin:) AND logs an outbound ActivityLog via the
+   delegated [data-outreach-log] listener in htmx_app.js (POST
+   /api/activity/outreach-initiated), which bumps company.last_activity_at.
+   Receives: company, contact_rows ([{contact, site, legacy}]).
+   Called by: company_tab route (tab=contacts) and detail.html (inline default tab).
+   Depends on: htmx_app.js outreach logger, brand palette.
+#}
+
+{% macro outreach_btn(label, href, channel, value, company_id, site_id, contact_id, contact_name, icon_path, new_tab=False) %}
+<a href="{{ href }}"
+   {% if new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}
+   class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-lg border border-gray-200 text-gray-700 hover:bg-brand-50 hover:text-brand-600 hover:border-brand-200 transition-colors"
+   data-outreach-log
+   data-channel="{{ channel }}"
+   data-value="{{ value }}"
+   data-company-id="{{ company_id }}"
+   data-site-id="{{ site_id or '' }}"
+   data-contact-id="{{ contact_id or '' }}"
+   data-contact-name="{{ contact_name or '' }}"
+   title="{{ label }} {{ contact_name or value }} (logs activity)">
+  <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="{{ icon_path }}"/>
+  </svg>
+  {{ label }}
+</a>
+{% endmacro %}
+
+{% macro contact_card(company, name, title, site_name, email, phone, wechat, contact_id, site_id, is_primary, legacy) %}
+<div class="bg-white rounded-lg border border-gray-200 p-3 hover:border-brand-200 transition-colors">
+  <div class="flex items-start justify-between gap-3 flex-wrap">
+    <div class="min-w-0">
+      <div class="flex items-center gap-2">
+        <span class="text-sm font-medium text-gray-900">{{ name or "—" }}</span>
+        {% if is_primary %}
+        <span class="px-1 py-0.5 text-[9px] font-medium rounded bg-emerald-50 text-emerald-700">Primary</span>
+        {% endif %}
+        {% if legacy %}
+        <span class="text-[9px] text-gray-400">legacy</span>
+        {% endif %}
+      </div>
+      <p class="text-[11px] text-gray-500">
+        {{ title or "—" }}{% if site_name %} &middot; {{ site_name }}{% endif %}
+      </p>
+      <div class="mt-1 flex items-center gap-3 text-[11px] text-gray-500 flex-wrap">
+        {% if email %}<span class="truncate">{{ email }}</span>{% endif %}
+        {% if phone %}<span>{{ phone }}</span>{% endif %}
+        {% if wechat %}<span>WeChat: {{ wechat }}</span>{% endif %}
+      </div>
+    </div>
+    <div class="flex items-center gap-1.5 flex-wrap flex-shrink-0">
+      {% if phone %}
+      {{ outreach_btn("Call", "tel:" ~ phone, "phone", phone, company.id, site_id, contact_id, name,
+                      "M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z") }}
+      {% endif %}
+      {% if email %}
+      {{ outreach_btn("Email", "mailto:" ~ email, "email", email, company.id, site_id, contact_id, name,
+                      "M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z") }}
+      {{ outreach_btn("Teams", "https://teams.microsoft.com/l/chat/0/0?users=" ~ email|urlencode, "teams", email, company.id, site_id, contact_id, name,
+                      "M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z", new_tab=True) }}
+      {% endif %}
+      {% if wechat %}
+      {{ outreach_btn("WeChat", "weixin://dl/chat?" ~ wechat|urlencode, "wechat", wechat, company.id, site_id, contact_id, name,
+                      "M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z") }}
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endmacro %}
+
+<div class="space-y-2">
+  {% for row in contact_rows %}
+    {% if row.legacy %}
+      {{ contact_card(company, row.site.contact_name, row.site.contact_title, row.site.site_name,
+                      row.site.contact_email, row.site.contact_phone, none,
+                      none, row.site.id, False, True) }}
+    {% else %}
+      {{ contact_card(company, row.contact.full_name, row.contact.title,
+                      row.site.site_name if row.site else none,
+                      row.contact.email, row.contact.phone, row.contact.wechat_id,
+                      row.contact.id, row.contact.customer_site_id, row.contact.is_primary, False) }}
+    {% endif %}
+  {% else %}
+  <div class="p-8 text-center">
+    <p class="text-sm text-gray-500">No contacts found. Add contacts via the Sites tab.</p>
+  </div>
+  {% endfor %}
+</div>

--- a/app/templates/htmx/partials/customers/tabs/contacts_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/contacts_tab.html
@@ -11,7 +11,7 @@
 {% macro outreach_btn(label, href, channel, value, company_id, site_id, contact_id, contact_name, icon_path, new_tab=False) %}
 <a href="{{ href }}"
    {% if new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}
-   class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-lg border border-gray-200 text-gray-700 hover:bg-brand-50 hover:text-brand-600 hover:border-brand-200 transition-colors"
+   class="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-lg border border-gray-200 text-gray-700 hover:bg-brand-50 hover:text-brand-600 hover:border-brand-200 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1"
    data-outreach-log
    data-channel="{{ channel }}"
    data-value="{{ value }}"

--- a/app/templates/htmx/partials/customers/tabs/site_contacts.html
+++ b/app/templates/htmx/partials/customers/tabs/site_contacts.html
@@ -17,7 +17,7 @@
         hx-target="#site-{{ site.id }}-contacts"
         hx-swap="innerHTML"
         data-loading-disable
-        class="grid grid-cols-2 md:grid-cols-5 gap-2 mb-3 p-2 bg-gray-50 rounded border border-gray-200">
+        class="grid grid-cols-2 md:grid-cols-6 gap-2 mb-3 p-2 bg-gray-50 rounded border border-gray-200">
     <input aria-label="Full Name" type="text" name="full_name" required placeholder="Full Name"
            class="px-2 py-1 text-xs border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
     <input aria-label="Email" type="email" name="email" placeholder="Email"
@@ -25,6 +25,8 @@
     <input aria-label="Title" type="text" name="title" placeholder="Title"
            class="px-2 py-1 text-xs border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
     <input aria-label="Phone" type="text" name="phone" placeholder="Phone"
+           class="px-2 py-1 text-xs border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+    <input aria-label="WeChat ID" type="text" name="wechat_id" placeholder="WeChat ID"
            class="px-2 py-1 text-xs border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
     <button type="submit"
             class="px-2 py-1 text-xs font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
@@ -46,8 +48,15 @@
         </div>
         <div class="flex items-center gap-3 text-[11px] text-gray-500">
           {% if c.title %}<span>{{ c.title }}</span>{% endif %}
-          {% if c.email %}<a href="mailto:{{ c.email }}" class="text-brand-500">{{ c.email }}</a>{% endif %}
-          {% if c.phone %}<a href="tel:{{ c.phone }}" class="text-brand-500">{{ c.phone }}</a>{% endif %}
+          {% if c.email %}<a href="mailto:{{ c.email }}" class="text-brand-500"
+              data-outreach-log data-channel="email" data-value="{{ c.email }}"
+              data-company-id="{{ company.id }}" data-site-id="{{ site.id }}" data-contact-id="{{ c.id }}"
+              data-contact-name="{{ c.full_name }}">{{ c.email }}</a>{% endif %}
+          {% if c.phone %}<a href="tel:{{ c.phone }}" class="text-brand-500"
+              data-outreach-log data-channel="phone" data-value="{{ c.phone }}"
+              data-company-id="{{ company.id }}" data-site-id="{{ site.id }}" data-contact-id="{{ c.id }}"
+              data-contact-name="{{ c.full_name }}">{{ c.phone }}</a>{% endif %}
+          {% if c.wechat_id %}<span>WeChat: {{ c.wechat_id }}</span>{% endif %}
         </div>
       </div>
       <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/app/templates/htmx/partials/customers/tabs/site_contacts.html
+++ b/app/templates/htmx/partials/customers/tabs/site_contacts.html
@@ -26,7 +26,7 @@
            class="px-2 py-1 text-xs border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
     <input aria-label="Phone" type="text" name="phone" placeholder="Phone"
            class="px-2 py-1 text-xs border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
-    <input aria-label="WeChat ID" type="text" name="wechat_id" placeholder="WeChat ID"
+    <input aria-label="WeChat ID" type="text" name="wechat_id" placeholder="WeChat ID" maxlength="100"
            class="px-2 py-1 text-xs border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
     <button type="submit"
             class="px-2 py-1 text-xs font-medium text-white bg-brand-500 rounded hover:bg-brand-600">

--- a/app/templates/htmx/partials/customers/tabs/site_contacts.html
+++ b/app/templates/htmx/partials/customers/tabs/site_contacts.html
@@ -59,7 +59,7 @@
           {% if c.wechat_id %}<span>WeChat: {{ c.wechat_id }}</span>{% endif %}
         </div>
       </div>
-      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+      <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
         {% if not c.is_primary %}
         <button hx-post="/v2/partials/customers/{{ company.id }}/sites/{{ site.id }}/contacts/{{ c.id }}/primary"
                 hx-target="#site-{{ site.id }}-contacts"

--- a/app/utils/phone_utils.py
+++ b/app/utils/phone_utils.py
@@ -35,6 +35,11 @@ def format_phone_e164(raw: str) -> str | None:
     if not digits or len(digits) < 7:
         return None
 
+    # E.164 caps phone numbers at 15 digits — anything longer is not a phone
+    # number (and would overflow the String(100) phone snapshot columns).
+    if len(digits) > 15:
+        return None
+
     # US: 10 digits → +1XXXXXXXXXX
     if len(digits) == 10:
         return f"+1{digits}"

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -71,7 +71,7 @@ Response -> Caddy -> Browser -> HTMX swaps into DOM
 ```
 base.html (app shell: topbar, mobile nav, modal, toast, SSE)
 └── base_page.html (spinner -> hx-get lazy load)
-    └── partials/ (167 HTML files across 15 feature dirs)
+    └── partials/ (170 HTML files across 15 feature dirs)
 ```
 
 - **Navigation:** HTMX `hx-get` swaps into `#main-content` (no SPA routing)
@@ -103,7 +103,7 @@ authoritative reference. Static-analysis tests in
 |---------|-------|-----------|
 | Requisitions | 32 | partials/requisitions/ |
 | Vendors | 16 | partials/vendors/ |
-| Customers | 11 | partials/customers/ |
+| Customers | 18 | partials/customers/ |
 | Materials | 13 | partials/materials/ |
 | Excess | 10 | partials/excess/ |
 | Parts | 13 | partials/parts/ |
@@ -124,6 +124,10 @@ authoritative reference. Static-analysis tests in
 |-----------|------|---------|
 | `_mpn_chips.html` | partials/shared/ | Renders all MPNs (primary + substitutes) as equal inline pill chips with overflow toggle; clickable chips open material card modal when a `link_map` entry exists |
 | `status_badge` macro | partials/shared/_macros.html | Unified status badge rendering used by all pages (requisitions, sightings, parts, etc.) |
+| `list.html` | partials/customers/ | CDM account workspace: split-panel layout (left = scrollable account list, right = `#cdm-detail`), resizable divider via the `splitPanel` Alpine component (panel id `cdm`). Modeled on the requisitions2 workspace. |
+| `_account_list.html` | partials/customers/ | Left-panel account list only — swapped in on filter/sort/pagination refreshes by `GET /v2/partials/customers/account-list`. |
+| `_detail_empty.html` | partials/customers/ | Right-panel placeholder shown before any account is selected in the CDM workspace. |
+| `tabs/contacts_tab.html` | partials/customers/tabs/ | Contacts tab partial for company detail — default tab on `company_detail_partial`. Displays `contact_rows` (SiteContacts from all active sites + legacy site-level contacts) and renders click-to-contact links (tel:/mailto:/Teams deep link/weixin://) with `data-outreach-log` attributes. |
 
 ### Inline Editing
 
@@ -214,11 +218,11 @@ reader (>= 0.85) — see APP_MAP_INTERACTIONS "Worker second-pass ordering":
 |--------|-------|
 | Python files | ~315 |
 | Python LOC | ~75,000 |
-| HTML templates | 167 |
+| HTML templates | 170 |
 | Database tables | 50+ |
 | API endpoints | 400+ |
 | Service modules | 120 |
 | Supplier connectors | 12 |
 | Background jobs | 15 modules |
 | Test files | 100+ |
-| Alembic migrations | 81+ |
+| Alembic migrations | 95+ |

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -71,7 +71,7 @@ Response -> Caddy -> Browser -> HTMX swaps into DOM
 ```
 base.html (app shell: topbar, mobile nav, modal, toast, SSE)
 └── base_page.html (spinner -> hx-get lazy load)
-    └── partials/ (170 HTML files across 15 feature dirs)
+    └── partials/ (182 HTML files across 24 feature dirs)
 ```
 
 - **Navigation:** HTMX `hx-get` swaps into `#main-content` (no SPA routing)
@@ -103,7 +103,7 @@ authoritative reference. Static-analysis tests in
 |---------|-------|-----------|
 | Requisitions | 32 | partials/requisitions/ |
 | Vendors | 16 | partials/vendors/ |
-| Customers | 18 | partials/customers/ |
+| Customers | 12 | partials/customers/ |
 | Materials | 13 | partials/materials/ |
 | Excess | 10 | partials/excess/ |
 | Parts | 13 | partials/parts/ |
@@ -127,7 +127,7 @@ authoritative reference. Static-analysis tests in
 | `list.html` | partials/customers/ | CDM account workspace: split-panel layout (left = scrollable account list, right = `#cdm-detail`), resizable divider via the `splitPanel` Alpine component (panel id `cdm`). Modeled on the requisitions2 workspace. |
 | `_account_list.html` | partials/customers/ | Left-panel account list only — swapped in on filter/sort/pagination refreshes by `GET /v2/partials/customers/account-list`. |
 | `_detail_empty.html` | partials/customers/ | Right-panel placeholder shown before any account is selected in the CDM workspace. |
-| `tabs/contacts_tab.html` | partials/customers/tabs/ | Contacts tab partial for company detail — default tab on `company_detail_partial`. Displays `contact_rows` (SiteContacts from all active sites + legacy site-level contacts) and renders click-to-contact links (tel:/mailto:/Teams deep link/weixin://) with `data-outreach-log` attributes. |
+| `tabs/contacts_tab.html` | partials/customers/tabs/ | Contacts tab partial for company detail — default tab on `company_detail_partial`. Displays `contact_rows` (active SiteContacts across the company's active sites + legacy site-level contacts on active sites) and renders click-to-contact links (tel:/mailto:/Teams deep link/weixin://) with `data-outreach-log` attributes. |
 
 ### Inline Editing
 
@@ -218,7 +218,7 @@ reader (>= 0.85) — see APP_MAP_INTERACTIONS "Worker second-pass ordering":
 |--------|-------|
 | Python files | ~315 |
 | Python LOC | ~75,000 |
-| HTML templates | 170 |
+| HTML templates | 197 |
 | Database tables | 50+ |
 | API endpoints | 400+ |
 | Service modules | 120 |

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -6,7 +6,7 @@
 
 - **Engine:** PostgreSQL 16
 - **ORM:** SQLAlchemy 2.0 with async support
-- **Migrations:** Alembic (81+ migration files)
+- **Migrations:** Alembic (95+ migration files)
 - **Connection:** Pool size 20, max overflow 20, pool recycle 1800s
 - **Timeouts:** Statement 30s, lock 5s
 - **Extensions:** pg_stat_statements, Full-Text Search (TSVECTOR), pg_trgm
@@ -214,6 +214,7 @@
 | enrichment_source | String 50 | explorium\|apollo\|manual |
 | is_strategic | Boolean | |
 | sf_account_id | String 255, unique | Salesforce link |
+| last_activity_at | UTCDateTime, nullable | Bumped by `log_outreach_initiated()` on every click-to-contact event; used by the CDM account workspace `staleness` sort (oldest = longest since activity first). |
 
 **`customer_sites`** — Delivery/contact locations for a company
 | Column | Type | Notes |
@@ -226,6 +227,7 @@
 | address fields | line1, line2, city, state, zip, country | |
 | site_type | String 50 | HQ\|Branch\|Warehouse\|Manufacturing |
 | payment_terms / shipping_terms | String 100 | |
+| last_activity_at | UTCDateTime, nullable | Bumped by `log_outreach_initiated()` alongside `companies.last_activity_at`. |
 
 **`site_contacts`** — Individual people at customer sites
 | Column | Type | Notes |
@@ -234,6 +236,8 @@
 | customer_site_id | FK -> customer_sites (CASCADE) | |
 | full_name | String 255 | |
 | email | String 255 | Unique per site |
+| phone | String 100 | |
+| wechat_id | String 100, nullable | WeChat handle for click-to-message outreach (migration 095_wechat_id). Written by the site-contact create form; rendered in `tabs/contacts_tab.html` as a `weixin://` deep link with `data-outreach-log`. |
 | contact_role | String 50 | buyer\|technical\|decision_maker\|operations |
 | email_verified | Boolean | |
 | enrichment_source | String 50 | lusha\|apollo\|hunter\|manual |
@@ -391,6 +395,8 @@
 - Links to: company, vendor_card, vendor_contact, requisition, requirement, quote, customer_site, site_contact, buy_plan
 - direction: inbound\|outbound
 - quality_score, quality_classification
+- New `ActivityType` values (app/constants.py): `WECHAT_MESSAGE` (written by `log_outreach_initiated()` when channel=wechat). Companion `Channel` enum adds `WECHAT` alongside existing phone\|email\|teams values.
+- Click-to-contact events (channel phone\|email\|teams\|wechat) are written by `log_outreach_initiated()` in `app/services/activity_service.py` — maps channel → activity_type (phone→call_logged, email→email_sent, teams→teams_message, wechat→wechat_message), direction=outbound, is_meaningful=True; bumps `companies.last_activity_at` and `customer_sites.last_activity_at`.
 
 **`activity_digest`** — AI-generated digest cache (one row per entity, migration `086_add_activity_digest.py`)
 | Column | Type | Notes |

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -639,6 +639,55 @@ not requisition-scoped.
 
 ---
 
+## 10. Click-to-Contact Outreach Logging (CDM Workspace)
+
+```
+User clicks a contact link (tel:/mailto:/Teams deep link/weixin://) in
+tabs/contacts_tab.html inside the CDM account workspace
+    |
+    v
+Delegated click listener in app/static/htmx_app.js
+    |
+    +---> Reads data-* attributes from the [data-outreach-log] element
+    |       (data-channel phone|email|teams|wechat, data-value,
+    |        data-company-id, data-site-id, data-contact-id, data-contact-name)
+    |
+    +---> Fire-and-forget fetch POST /api/activity/outreach-initiated
+    |       (app/routers/activity.py, schema OutreachInitiatedRequest in
+    |        app/schemas/activity.py)
+    |
+    +---> On success: $store.toast success flash
+    |
+    v
+activity.py router -> log_outreach_initiated(db, user, request)
+    |
+    v
+app/services/activity_service.log_outreach_initiated()
+    |
+    +---> Maps channel to ActivityType:
+    |       phone   -> ActivityType.CALL_LOGGED   (direction=outbound)
+    |       email   -> ActivityType.EMAIL_SENT
+    |       teams   -> ActivityType.TEAMS_MESSAGE
+    |       wechat  -> ActivityType.WECHAT_MESSAGE  (new, constants.py)
+    |
+    +---> DB: INSERT activity_log (is_meaningful=True, direction=outbound,
+    |       linked to company_id + site_contact_id)
+    |
+    +---> DB: UPDATE companies.last_activity_at = now()
+    +---> DB: UPDATE customer_sites.last_activity_at = now()
+    |       (both bumps feed the CDM workspace staleness sort:
+    |        oldest = longest since activity first)
+
+Channel enum (app/constants.py):
+    Channel.PHONE | Channel.EMAIL | Channel.TEAMS | Channel.WECHAT (new)
+```
+
+`company_detail_partial` builds `contact_rows` via the `_company_contact_rows` helper
+(SiteContacts across all active sites + legacy site-level contacts) and passes it to
+`tabs/contacts_tab.html`, which is now the default (first-rendered) tab.
+
+---
+
 ## Enrichment Pipeline
 
 ```
@@ -1427,7 +1476,7 @@ the current implementation.
 | Requisitions | 45 | CRUD, search, bulk archive/assign, claim |
 | Requirements | 23 | Add parts, CSV upload, search, leads, tasks |
 | Vendors | 35 | CRUD, contacts, stock history, reviews, tags |
-| Companies/CRM | 40 | CRUD, sites, contacts, enrichment, import |
+| Companies/CRM | 42 | CRUD, sites, contacts, enrichment, import; CDM workspace (`/v2/partials/customers`, `/v2/partials/customers/account-list`); outreach logging (`POST /api/activity/outreach-initiated`) |
 | Offers | 30 | CRUD, line items, accept/reject, changelog |
 | Quotes | 25 | CRUD, send, PDF, e-signature, pricing history |
 | Buy Plans | 6 | CRUD, external approval via token |

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -656,13 +656,24 @@ Delegated click listener in app/static/htmx_app.js
     |       (app/routers/activity.py, schema OutreachInitiatedRequest in
     |        app/schemas/activity.py)
     |
-    +---> On success: $store.toast success flash
+    +---> On success: $store.toast success flash + #cdm-list refresh
+    |       (re-sorts the account list so the touch is visible immediately)
+    +---> On failure (429/5xx/network): $store.toast ERROR flash — outreach
+    |       logging failures are never silent
     |
     v
 activity.py router -> log_outreach_initiated(db, user, request)
+    |   - rate limit: per-user "outreach" bucket (30/min), separate from the
+    |     click-to-call bucket (10/min) so channels never starve each other
+    |   - nonexistent company/site/contact ids are nulled out with a warning
+    |     (stale DOM ids must not FK-crash the insert)
     |
     v
 app/services/activity_service.log_outreach_initiated()
+    |
+    +---> Dedup: same user+channel+subject+company within 120s
+    |       (OUTREACH_DEDUP_SECONDS) returns the existing row — double-clicks
+    |       do not create duplicate activities or double bumps
     |
     +---> Maps channel to ActivityType:
     |       phone   -> ActivityType.CALL_LOGGED   (direction=outbound)
@@ -682,7 +693,11 @@ Channel enum (app/constants.py):
     Channel.PHONE | Channel.EMAIL | Channel.TEAMS | Channel.WECHAT (new)
 ```
 
-`company_detail_partial` builds `contact_rows` via the `_company_contact_rows` helper
+CDM business rules (staleness tiers, account-list query/sort, contact-row
+assembly) live in `app/services/crm_service.py` (`staleness_tier`,
+`cdm_company_query`, `cdm_list_ctx`, `company_contact_rows`); the
+`htmx_views.py` routes are thin wrappers.
+`company_detail_partial` builds `contact_rows` via the `company_contact_rows` helper
 (SiteContacts across all active sites + legacy site-level contacts) and passes it to
 `tabs/contacts_tab.html`, which is now the default (first-rendered) tab.
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -657,23 +657,33 @@ Delegated click listener in app/static/htmx_app.js
     |        app/schemas/activity.py)
     |
     +---> On success: $store.toast success flash + #cdm-list refresh
-    |       (re-sorts the account list so the touch is visible immediately)
+    |       (re-sorts the account list so the touch is visible immediately;
+    |        the refresh preserves the current pagination offset/limit, read
+    |        from data-* attrs on the _account_list.html header)
+    +---> On success WITH dropped_links (server removed stale entity links):
+    |       $store.toast WARNING flash instead — the touch is logged but
+    |       invisible on this account; the list refresh is skipped
     +---> On failure (429/5xx/network): $store.toast ERROR flash — outreach
     |       logging failures are never silent
     |
     v
-activity.py router -> log_outreach_initiated(db, user, request)
+activity.py router -> log_outreach_initiated(db, user_id=..., channel=...,
+    |                                          contact_value=..., ...)
     |   - rate limit: per-user "outreach" bucket (30/min), separate from the
     |     click-to-call bucket (10/min) so channels never starve each other
-    |   - nonexistent company/site/contact ids are nulled out with a warning
-    |     (stale DOM ids must not FK-crash the insert)
+    |   - nonexistent OR mismatched company/site/contact ids (site not under
+    |     the company, contact not under the site) are nulled out with a
+    |     warning (stale DOM ids must not FK-crash the insert or bump an
+    |     unrelated entity) and reported back as dropped_links in the 201 body
     |
     v
 app/services/activity_service.log_outreach_initiated()
     |
-    +---> Dedup: same user+channel+subject+company within 120s
+    +---> Dedup: same user + channel + company/site/contact links + contacted
+    |       value (channel snapshot column; subject for WeChat) within 120s
     |       (OUTREACH_DEDUP_SECONDS) returns the existing row — double-clicks
-    |       do not create duplicate activities or double bumps
+    |       do not create duplicate activities or double bumps, while distinct
+    |       same-named contacts never collapse into one log
     |
     +---> Maps channel to ActivityType:
     |       phone   -> ActivityType.CALL_LOGGED   (direction=outbound)
@@ -698,7 +708,8 @@ assembly) live in `app/services/crm_service.py` (`staleness_tier`,
 `cdm_company_query`, `cdm_list_ctx`, `company_contact_rows`); the
 `htmx_views.py` routes are thin wrappers.
 `company_detail_partial` builds `contact_rows` via the `company_contact_rows` helper
-(SiteContacts across all active sites + legacy site-level contacts) and passes it to
+(active SiteContacts across the company's active sites + legacy site-level
+contacts on active sites) and passes it to
 `tabs/contacts_tab.html`, which is now the default (first-rendered) tab.
 
 ---

--- a/tests/frontend/outreach-logger.test.ts
+++ b/tests/frontend/outreach-logger.test.ts
@@ -1,0 +1,225 @@
+/**
+ * outreach-logger.test.ts — Vitest unit tests for the REAL [data-outreach-log]
+ * delegated click listener in app/static/htmx_app.js.
+ *
+ * Imports htmx_app.js once (with htmx/Alpine mocked) so the single delegated
+ * body listener is exercised against the shipped code: dataset→payload
+ * coercion (parseInt with empty-string→null fallback), the error-toast paths
+ * for !resp.ok and network failure, the dropped_links warning downgrade, and
+ * the offset-preserving #cdm-list refresh via htmx.ajax.
+ *
+ * Called by: npx vitest run
+ * Depends on: vitest, jsdom, app/static/htmx_app.js
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+// Mock htmx and all Alpine plugins so htmx_app.js imports cleanly in jsdom.
+vi.mock('htmx.org', () => ({
+  default: {
+    on: vi.fn(), off: vi.fn(), ajax: vi.fn(), process: vi.fn(), trigger: vi.fn(),
+    defineExtension: vi.fn(), createExtension: vi.fn(), config: {},
+  },
+}));
+
+const toast = { message: '', type: '', show: false };
+const alpineMock = {
+  data: vi.fn(),
+  store: vi.fn(() => toast),
+  plugin: vi.fn(), start: vi.fn(), directive: vi.fn(), magic: vi.fn(),
+};
+
+vi.mock('alpinejs', () => ({ default: alpineMock }));
+vi.mock('@alpinejs/focus', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/persist', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/intersect', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/collapse', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/morph', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/mask', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/sort', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/anchor', () => ({ default: vi.fn() }));
+vi.mock('@alpinejs/resize', () => ({ default: vi.fn() }));
+vi.mock('htmx-ext-alpine-morph', () => ({}));
+vi.mock('htmx-ext-response-targets', () => ({}));
+vi.mock('htmx-ext-sse', () => ({}));
+vi.mock('htmx-ext-json-enc', () => ({}));
+vi.mock('htmx-ext-preload', () => ({}));
+vi.mock('htmx-ext-loading-states', () => ({}));
+vi.mock('htmx-ext-path-params', () => ({}));
+vi.mock('htmx-ext-remove-me', () => ({}));
+
+import htmx from 'htmx.org';
+
+const fetchMock = vi.fn();
+
+// Import ONCE — the module registers a single delegated click listener on
+// document.body; re-importing per test would stack duplicate listeners.
+beforeAll(async () => {
+  vi.stubGlobal('fetch', fetchMock);
+  await import('../../app/static/htmx_app.js');
+});
+
+function jsonResponse(body: Record<string, unknown>, ok = true, status = 201) {
+  return { ok, status, json: async () => body };
+}
+
+function mountLink(attrs: Record<string, string>) {
+  const a = document.createElement('a');
+  a.setAttribute('data-outreach-log', '');
+  for (const [k, v] of Object.entries(attrs)) a.setAttribute(k, v);
+  // Prevent jsdom's "navigation not implemented" noise; the delegated body
+  // listener still runs (it does not check defaultPrevented).
+  a.addEventListener('click', (e) => e.preventDefault());
+  document.body.appendChild(a);
+  return a;
+}
+
+function click(el: HTMLElement) {
+  el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+async function flush() {
+  // The handler chains fetch().then(async …) — flush a few microtask turns.
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  document.cookie = 'csrftoken=testtoken';
+  toast.message = '';
+  toast.type = '';
+  toast.show = false;
+  fetchMock.mockReset();
+  (htmx.ajax as any).mockReset();
+  (htmx.ajax as any).mockResolvedValue(undefined);
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('[data-outreach-log] delegated click listener', () => {
+  it('POSTs the coerced payload: int ids, null for empty/missing ids', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 1, dropped_links: [] }));
+    const a = mountLink({
+      'data-channel': 'phone',
+      'data-value': '+14155551234',
+      'data-company-id': '7',
+      'data-site-id': '',        // legacy contact rows render empty site/contact ids
+      'data-contact-name': 'Pat Buyer',
+    });
+    click(a);
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/activity/outreach-initiated');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers['x-csrftoken']).toBe('testtoken');
+    expect(JSON.parse(opts.body)).toEqual({
+      channel: 'phone',
+      contact_value: '+14155551234',
+      company_id: 7,
+      customer_site_id: null,
+      site_contact_id: null,
+      contact_name: 'Pat Buyer',
+      origin: 'cdm_workspace',
+    });
+  });
+
+  it('ignores clicks outside [data-outreach-log] elements', async () => {
+    const plain = document.createElement('a');
+    document.body.appendChild(plain);
+    click(plain);
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('shows the rate-limit error toast on 429', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, false, 429));
+    click(mountLink({ 'data-channel': 'email', 'data-value': 'pat@x.com' }));
+    await flush();
+    expect(toast.type).toBe('error');
+    expect(toast.message).toContain('NOT logged');
+    expect(toast.message).toContain('rate limit');
+    expect(toast.show).toBe(true);
+  });
+
+  it('shows a status-bearing error toast on 500', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, false, 500));
+    click(mountLink({ 'data-channel': 'email', 'data-value': 'pat@x.com' }));
+    await flush();
+    expect(toast.type).toBe('error');
+    expect(toast.message).toContain('error 500');
+  });
+
+  it('shows the network-error toast AND logs the error on fetch rejection', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    click(mountLink({ 'data-channel': 'phone', 'data-value': '+14155551234' }));
+    await flush();
+    expect(toast.type).toBe('error');
+    expect(toast.message).toContain('network error');
+    expect(console.error).toHaveBeenCalledWith('[outreach-log] failed', expect.any(TypeError));
+  });
+
+  it('on success: success toast + offset-preserving #cdm-list refresh', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 9, dropped_links: [] }));
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      '<form id="cdm-filters"><span class="htmx-indicator"></span></form>' +
+        '<div id="cdm-list"><div data-offset="50" data-limit="50"></div></div>'
+    );
+    click(mountLink({ 'data-channel': 'phone', 'data-value': '+14155551234', 'data-contact-name': 'Pat Buyer' }));
+    await flush();
+
+    expect(toast.type).toBe('success');
+    expect(toast.message).toBe('Call logged — Pat Buyer');
+    expect(htmx.ajax).toHaveBeenCalledWith(
+      'GET',
+      '/v2/partials/customers/account-list?offset=50&limit=50',
+      expect.objectContaining({ source: '#cdm-filters', target: '#cdm-list' })
+    );
+  });
+
+  it('skips the refresh when not on the CDM workspace', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 9, dropped_links: [] }));
+    click(mountLink({ 'data-channel': 'email', 'data-value': 'pat@x.com' }));
+    await flush();
+    expect(toast.type).toBe('success');
+    expect(htmx.ajax).not.toHaveBeenCalled();
+  });
+
+  it('downgrades to a warning toast (no refresh) when the server dropped links', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 9, dropped_links: ['contact'] }));
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      '<form id="cdm-filters"></form><div id="cdm-list"><div data-offset="0" data-limit="50"></div></div>'
+    );
+    click(mountLink({ 'data-channel': 'phone', 'data-value': '+14155551234' }));
+    await flush();
+
+    expect(toast.type).toBe('warning');
+    expect(toast.message).toContain('contact');
+    expect(toast.message).toContain('no longer exists');
+    expect(htmx.ajax).not.toHaveBeenCalled();
+  });
+
+  it('a post-success rendering error is contained — never a false "NOT logged" toast', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ id: 9, dropped_links: [] }));
+    (htmx.ajax as any).mockImplementation(() => {
+      throw new Error('htmx exploded');
+    });
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      '<form id="cdm-filters"></form><div id="cdm-list"><div data-offset="0" data-limit="50"></div></div>'
+    );
+    click(mountLink({ 'data-channel': 'phone', 'data-value': '+14155551234' }));
+    await flush();
+
+    // The POST succeeded — the success toast stands; the rendering error is
+    // logged for forensics instead of masquerading as a transport failure.
+    expect(toast.type).toBe('success');
+    expect(toast.message).not.toContain('NOT logged');
+    expect(console.error).toHaveBeenCalledWith(
+      '[outreach-log] post-success UI update failed',
+      expect.any(Error)
+    );
+  });
+});

--- a/tests/test_activity_outreach.py
+++ b/tests/test_activity_outreach.py
@@ -186,6 +186,52 @@ class TestOutreachInitiated:
         )
         assert count == 1
 
+    def test_dedup_stops_after_window_expires(self, client, db_session, cdm_company):
+        """The same click AFTER the dedup window is a NEW touch, not a dup.
+
+        Guards the dedup-miss direction: an over-widened window (unit typo,
+        timezone bug, inverted comparison) would silently drop every repeat
+        touch forever while the dedup-hit tests stay green.
+        """
+        from app.services.activity_service import OUTREACH_DEDUP_SECONDS
+
+        first = self._post(client, cdm_company, "phone", "+14155551234")
+        assert first.status_code == 201
+        record = db_session.get(ActivityLog, first.json()["id"])
+        record.created_at = datetime.now(timezone.utc) - timedelta(seconds=OUTREACH_DEDUP_SECONDS + 60)
+        db_session.commit()
+
+        second = self._post(client, cdm_company, "phone", "+14155551234")
+        assert second.status_code == 201
+        assert second.json()["id"] != first.json()["id"]
+        count = (
+            db_session.query(ActivityLog)
+            .filter(ActivityLog.activity_type == "call_logged", ActivityLog.company_id == cdm_company["company"].id)
+            .count()
+        )
+        assert count == 2
+
+    def test_dedup_does_not_collapse_distinct_contacts(self, client, db_session, cdm_company):
+        """Back-to-back calls to two DIFFERENT contacts at one company are two touches.
+
+        Worst case exercised: same display name AND same phone (shared
+        switchboard) — only site_contact_id distinguishes them, so this pins
+        the entity ids (not the display subject) as the dedup identity.
+        """
+        twin = SiteContact(
+            customer_site_id=cdm_company["site"].id,
+            full_name="Pat Buyer",
+            phone="+14155551234",
+        )
+        db_session.add(twin)
+        db_session.commit()
+
+        first = self._post(client, cdm_company, "phone", "+14155551234")
+        second = self._post(client, cdm_company, "phone", "+14155551234", site_contact_id=twin.id)
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert first.json()["id"] != second.json()["id"]
+
     def test_nonexistent_entity_ids_dropped_not_500(self, client, db_session):
         """Stale DOM ids (deleted company/site/contact) must not FK-crash the log."""
         resp = client.post(
@@ -203,6 +249,69 @@ class TestOutreachInitiated:
         assert record.company_id is None
         assert record.customer_site_id is None
         assert record.site_contact_id is None
+        # The degradation is surfaced to the client, not silently swallowed.
+        assert sorted(resp.json()["dropped_links"]) == ["company", "contact", "site"]
+
+    def test_valid_entity_ids_report_no_dropped_links(self, client, cdm_company):
+        """Fully-linked logs report an empty dropped_links (frontend shows success)."""
+        resp = self._post(client, cdm_company, "phone", "+14155551234")
+        assert resp.status_code == 201
+        assert resp.json()["dropped_links"] == []
+
+    def test_site_from_other_company_link_dropped(self, client, db_session, cdm_company):
+        """A site that doesn't belong to the company must not be linked or bumped."""
+        other_co = Company(name="Unrelated Co", is_active=True)
+        db_session.add(other_co)
+        db_session.flush()
+        other_site = CustomerSite(company_id=other_co.id, site_name="Elsewhere", is_active=True)
+        db_session.add(other_site)
+        db_session.commit()
+
+        resp = self._post(
+            client, cdm_company, "phone", "+14155551234", customer_site_id=other_site.id, site_contact_id=None
+        )
+        assert resp.status_code == 201
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record.company_id == cdm_company["company"].id
+        assert record.customer_site_id is None
+        assert "site" in resp.json()["dropped_links"]
+        # The unrelated site's staleness data must stay untouched.
+        db_session.expire_all()
+        assert db_session.get(CustomerSite, other_site.id).last_activity_at is None
+
+    def test_contact_from_other_site_link_dropped(self, client, db_session, cdm_company):
+        """A contact that doesn't belong to the claimed site must not be linked."""
+        other_site = CustomerSite(company_id=cdm_company["company"].id, site_name="Plant 2", is_active=True)
+        db_session.add(other_site)
+        db_session.flush()
+        other_contact = SiteContact(customer_site_id=other_site.id, full_name="Sam Elsewhere")
+        db_session.add(other_contact)
+        db_session.commit()
+
+        # Payload claims the HQ site but the contact lives at Plant 2.
+        resp = self._post(client, cdm_company, "phone", "+14155551234", site_contact_id=other_contact.id)
+        assert resp.status_code == 201
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record.site_contact_id is None
+        assert record.customer_site_id == cdm_company["site"].id
+        assert "contact" in resp.json()["dropped_links"]
+
+    def test_wechat_whitespace_value_returns_400(self, client, cdm_company):
+        """An all-whitespace WeChat handle must 400, not log 'WeChat message to '."""
+        resp = self._post(client, cdm_company, "wechat", "   ")
+        assert resp.status_code == 400
+        assert "error" in resp.json()
+
+    def test_oversized_contact_value_returns_422(self, client, cdm_company):
+        """contact_value beyond the String(255) snapshot columns is a 422 at the
+        boundary (Postgres would DataError-500; SQLite tests mask that)."""
+        resp = self._post(client, cdm_company, "email", "x" * 290 + "@example.com")
+        assert resp.status_code == 422
+
+    def test_oversized_phone_returns_400(self, client, cdm_company):
+        """A digit string beyond the E.164 15-digit cap is rejected as a phone."""
+        resp = self._post(client, cdm_company, "phone", "1" * 60)
+        assert resp.status_code == 400
 
     def test_call_initiated_bumps_last_activity(self, client, db_session, cdm_company):
         """Click-to-call (legacy endpoint) also feeds the staleness sort now."""

--- a/tests/test_activity_outreach.py
+++ b/tests/test_activity_outreach.py
@@ -1,0 +1,181 @@
+"""Tests for POST /api/activity/outreach-initiated (CDM click-to-contact logging).
+
+Covers: all four channels (phone/email/teams/wechat), last_activity_at bumps on
+company and site, validation errors, and the log_outreach_initiated service.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models import ActivityLog
+from app.models.crm import Company, CustomerSite, SiteContact
+
+
+@pytest.fixture(autouse=True)
+def _clear_rate_limit():
+    """Clear in-memory rate limiter between tests."""
+    from app.routers.activity import _call_log
+
+    _call_log.clear()
+    yield
+    _call_log.clear()
+
+
+@pytest.fixture
+def cdm_company(db_session):
+    """Company + site + contact wired together for outreach tests."""
+    company = Company(
+        name="Outreach Test Co",
+        is_active=True,
+        last_activity_at=datetime.now(timezone.utc) - timedelta(days=40),
+    )
+    db_session.add(company)
+    db_session.flush()
+    site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+    db_session.add(site)
+    db_session.flush()
+    contact = SiteContact(
+        customer_site_id=site.id,
+        full_name="Pat Buyer",
+        title="Purchasing Manager",
+        email="pat@outreachtest.com",
+        phone="+14155551234",
+        wechat_id="pat_wechat",
+    )
+    db_session.add(contact)
+    db_session.commit()
+    return {"company": company, "site": site, "contact": contact}
+
+
+class TestOutreachInitiated:
+    def _post(self, client, cdm, channel, value, **extra):
+        payload = {
+            "channel": channel,
+            "contact_value": value,
+            "company_id": cdm["company"].id,
+            "customer_site_id": cdm["site"].id,
+            "site_contact_id": cdm["contact"].id,
+            "contact_name": cdm["contact"].full_name,
+            "origin": "cdm_workspace",
+            **extra,
+        }
+        return client.post("/api/activity/outreach-initiated", json=payload)
+
+    def test_phone_outreach(self, client, db_session, cdm_company):
+        resp = self._post(client, cdm_company, "phone", "(415) 555-1234")
+        assert resp.status_code == 201
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record.activity_type == "call_logged"
+        assert record.channel == "phone"
+        assert record.event_type == "call"
+        assert record.direction == "outbound"
+        assert record.is_meaningful is True
+        assert record.auto_logged is True
+        assert record.contact_phone == "+14155551234"
+        assert record.company_id == cdm_company["company"].id
+        assert record.site_contact_id == cdm_company["contact"].id
+        assert "Call to Pat Buyer" in record.subject
+
+    def test_email_outreach(self, client, db_session, cdm_company):
+        resp = self._post(client, cdm_company, "email", "pat@outreachtest.com")
+        assert resp.status_code == 201
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record.activity_type == "email_sent"
+        assert record.channel == "email"
+        assert record.event_type == "email"
+        assert record.contact_email == "pat@outreachtest.com"
+        assert "Email to Pat Buyer" in record.subject
+
+    def test_teams_outreach(self, client, db_session, cdm_company):
+        resp = self._post(client, cdm_company, "teams", "pat@outreachtest.com")
+        assert resp.status_code == 201
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record.activity_type == "teams_message"
+        assert record.channel == "teams"
+        assert record.event_type == "message"
+        assert record.contact_email == "pat@outreachtest.com"
+
+    def test_wechat_outreach(self, client, db_session, cdm_company):
+        resp = self._post(client, cdm_company, "wechat", "pat_wechat")
+        assert resp.status_code == 201
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record.activity_type == "wechat_message"
+        assert record.channel == "wechat"
+        assert record.event_type == "message"
+        # WeChat handle goes to notes — contact_name keeps the person's name
+        assert record.contact_name == "Pat Buyer"
+        assert "pat_wechat" in record.notes
+
+    def test_bumps_company_and_site_last_activity(self, client, db_session, cdm_company):
+        before = datetime.now(timezone.utc) - timedelta(minutes=1)
+        resp = self._post(client, cdm_company, "phone", "+14155551234")
+        assert resp.status_code == 201
+
+        db_session.expire_all()
+        company = db_session.get(Company, cdm_company["company"].id)
+        site = db_session.get(CustomerSite, cdm_company["site"].id)
+        assert company.last_activity_at is not None
+        assert company.last_activity_at.replace(tzinfo=timezone.utc) > before
+        assert site.last_activity_at is not None
+        assert site.last_activity_at.replace(tzinfo=timezone.utc) > before
+
+    def test_invalid_phone_returns_400(self, client, cdm_company):
+        resp = self._post(client, cdm_company, "phone", "call pat")
+        assert resp.status_code == 400
+        assert "error" in resp.json()
+
+    def test_invalid_email_returns_400(self, client, cdm_company):
+        resp = self._post(client, cdm_company, "email", "not-an-email")
+        assert resp.status_code == 400
+        assert "error" in resp.json()
+
+    def test_invalid_channel_returns_422(self, client, cdm_company):
+        resp = self._post(client, cdm_company, "fax", "+14155551234")
+        assert resp.status_code == 422
+
+    def test_minimal_payload_without_entities(self, client, db_session):
+        resp = client.post(
+            "/api/activity/outreach-initiated",
+            json={"channel": "phone", "contact_value": "4155551234"},
+        )
+        assert resp.status_code == 201
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record.company_id is None
+        assert "Call to +14155551234" in record.subject
+
+    def test_rate_limit_returns_429(self, client, cdm_company):
+        from app.routers import activity as activity_router
+
+        user_buckets = activity_router._call_log
+        # Fill the rate limit window for every user id the override may use
+        for _ in range(activity_router._RATE_LIMIT):
+            resp = self._post(client, cdm_company, "phone", "+14155551234")
+            assert resp.status_code == 201
+        resp = self._post(client, cdm_company, "phone", "+14155551234")
+        assert resp.status_code == 429
+        assert user_buckets  # sanity: limiter actually tracked the user
+
+
+class TestLogOutreachService:
+    def test_unknown_channel_raises(self, db_session, test_user):
+        from app.services.activity_service import log_outreach_initiated
+
+        with pytest.raises(ValueError):
+            log_outreach_initiated(
+                db_session,
+                user_id=test_user.id,
+                channel="carrier_pigeon",
+                contact_value="coop 7",
+            )
+
+    def test_subject_falls_back_to_value(self, db_session, test_user):
+        from app.services.activity_service import log_outreach_initiated
+
+        record = log_outreach_initiated(
+            db_session,
+            user_id=test_user.id,
+            channel="email",
+            contact_value="someone@example.com",
+        )
+        assert record.subject == "Email to someone@example.com"

--- a/tests/test_activity_outreach.py
+++ b/tests/test_activity_outreach.py
@@ -148,13 +148,78 @@ class TestOutreachInitiated:
         from app.routers import activity as activity_router
 
         user_buckets = activity_router._call_log
-        # Fill the rate limit window for every user id the override may use
-        for _ in range(activity_router._RATE_LIMIT):
+        # Outreach has its own (higher) budget, separate from call-initiated
+        for _ in range(activity_router._OUTREACH_RATE_LIMIT):
             resp = self._post(client, cdm_company, "phone", "+14155551234")
             assert resp.status_code == 201
         resp = self._post(client, cdm_company, "phone", "+14155551234")
         assert resp.status_code == 429
         assert user_buckets  # sanity: limiter actually tracked the user
+
+    def test_rate_limit_bucket_separate_from_call_initiated(self, client, cdm_company):
+        """Exhausting the click-to-call budget must not block outreach logging."""
+        from app.routers import activity as activity_router
+
+        for _ in range(activity_router._RATE_LIMIT):
+            resp = client.post("/api/activity/call-initiated", json={"phone_number": "4155551234"})
+            assert resp.status_code == 201
+        resp = client.post("/api/activity/call-initiated", json={"phone_number": "4155551234"})
+        assert resp.status_code == 429
+
+        # Outreach still works — separate bucket
+        resp = self._post(client, cdm_company, "email", "pat@outreachtest.com")
+        assert resp.status_code == 201
+
+    def test_double_click_dedup_returns_same_record(self, client, db_session, cdm_company):
+        """Re-clicking the same contact link within the window must not duplicate."""
+        from app.models import ActivityLog as AL
+
+        first = self._post(client, cdm_company, "phone", "+14155551234")
+        second = self._post(client, cdm_company, "phone", "+14155551234")
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert first.json()["id"] == second.json()["id"]
+        count = (
+            db_session.query(AL)
+            .filter(AL.activity_type == "call_logged", AL.company_id == cdm_company["company"].id)
+            .count()
+        )
+        assert count == 1
+
+    def test_nonexistent_entity_ids_dropped_not_500(self, client, db_session):
+        """Stale DOM ids (deleted company/site/contact) must not FK-crash the log."""
+        resp = client.post(
+            "/api/activity/outreach-initiated",
+            json={
+                "channel": "phone",
+                "contact_value": "4155551234",
+                "company_id": 999999,
+                "customer_site_id": 999999,
+                "site_contact_id": 999999,
+            },
+        )
+        assert resp.status_code == 201
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record.company_id is None
+        assert record.customer_site_id is None
+        assert record.site_contact_id is None
+
+    def test_call_initiated_bumps_last_activity(self, client, db_session, cdm_company):
+        """Click-to-call (legacy endpoint) also feeds the staleness sort now."""
+        before = datetime.now(timezone.utc) - timedelta(minutes=1)
+        resp = client.post(
+            "/api/activity/call-initiated",
+            json={
+                "phone_number": "4155551234",
+                "company_id": cdm_company["company"].id,
+                "customer_site_id": cdm_company["site"].id,
+            },
+        )
+        assert resp.status_code == 201
+        db_session.expire_all()
+        company = db_session.get(Company, cdm_company["company"].id)
+        assert company.last_activity_at is not None
+        assert company.last_activity_at.replace(tzinfo=timezone.utc) > before
 
 
 class TestLogOutreachService:

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -191,6 +191,42 @@ class TestOverdueChip:
         assert "needs a call" in resp.text
         assert "NeverContacted Corp" in resp.text
 
+    def test_chip_click_filter_matches_chip_count(self, client: TestClient, db_session: Session, test_user: User):
+        """The chip's click-through filter (staleness=needs_call) returns every account
+        the chip counted — overdue AND never-contacted share one predicate.
+
+        Consistency guard: counting and filtering used to encode 'needs a call' twice
+        with different NULL semantics, so a rep could see '1 needs a call', click the
+        chip, and get 'No accounts found'.
+        """
+        test_user.role = "sales"
+        db_session.flush()
+
+        never = Company(
+            name="NeverCalled Corp",
+            is_active=True,
+            account_owner_id=test_user.id,
+            last_activity_at=None,
+        )
+        overdue = Company(
+            name="LongOverdue Corp",
+            is_active=True,
+            account_owner_id=test_user.id,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=45),
+        )
+        db_session.add_all([never, overdue])
+        db_session.commit()
+
+        shell = client.get("/v2/partials/customers")
+        assert shell.status_code == 200
+        assert "2 need a call" in shell.text
+        # The chip targets the shared needs_call predicate, not plain overdue.
+        assert "staleness.value = 'needs_call'" in shell.text
+
+        html = client.get("/v2/partials/customers/account-list?staleness=needs_call&my_only=1").text
+        assert "NeverCalled Corp" in html
+        assert "LongOverdue Corp" in html
+
     def test_chip_excludes_other_owners(self, client: TestClient, db_session: Session, test_user: User):
         """Chip only counts accounts owned by the current user."""
         test_user.role = "sales"
@@ -298,6 +334,52 @@ class TestWorkspaceFiltersAndSort:
         html = client.get("/v2/partials/customers/account-list?staleness=new").text
         assert "Never Filter Co" in html
         assert "Touched Filter Co" not in html
+
+    def test_staleness_filter_due_soon_and_recent(self, client: TestClient, db_session: Session, test_user: User):
+        """due_soon is the two-cutoff 14-30d band; recent is <14d.
+
+        Seeds 5d/20d/45d accounts so a swapped-cutoff or sign-flip regression
+        (due_soon_cutoff is the NEWER timestamp) can't slip through.
+        """
+        c5 = Company(
+            name="Band5d Co",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=5),
+        )
+        c20 = Company(
+            name="Band20d Co",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=20),
+        )
+        c45 = Company(
+            name="Band45d Co",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=45),
+        )
+        db_session.add_all([c5, c20, c45])
+        db_session.commit()
+
+        due_soon = client.get("/v2/partials/customers/account-list?staleness=due_soon").text
+        assert "Band20d Co" in due_soon
+        assert "Band5d Co" not in due_soon
+        assert "Band45d Co" not in due_soon
+
+        recent = client.get("/v2/partials/customers/account-list?staleness=recent").text
+        assert "Band5d Co" in recent
+        assert "Band20d Co" not in recent
+        assert "Band45d Co" not in recent
+
+    def test_inactive_companies_excluded(self, client: TestClient, db_session: Session, test_user: User):
+        """Archived/merged (is_active=False) companies never appear in the account
+        list."""
+        active = Company(name="ActiveList Co", is_active=True)
+        archived = Company(name="ArchivedGone Co", is_active=False)
+        db_session.add_all([active, archived])
+        db_session.commit()
+
+        html = client.get("/v2/partials/customers/account-list").text
+        assert "ActiveList Co" in html
+        assert "ArchivedGone Co" not in html
 
     def test_account_type_filter(self, client: TestClient, db_session: Session, test_user: User):
         """account_type filter narrows to that type."""
@@ -460,6 +542,8 @@ class TestContactPanel:
         assert "https://teams.microsoft.com/l/chat/0/0?users=jane%40contactpanel.com" in resp.text
         assert f'data-company-id="{company.id}"' in resp.text
         assert f'data-contact-id="{contact.id}"' in resp.text
+        # The site-level last_activity_at bump depends on this attribute.
+        assert f'data-site-id="{site.id}"' in resp.text
 
     def test_wechat_action_renders_when_handle_set(self, client: TestClient, db_session: Session, test_user: User):
         """WeChat deep link renders only for contacts with a wechat_id."""
@@ -518,6 +602,65 @@ class TestContactPanel:
         contact = db_session.query(SiteContact).filter(SiteContact.customer_site_id == site.id).first()
         assert contact is not None
         assert contact.wechat_id == "wei_chen_88"
+
+    def test_create_site_contact_wechat_too_long_rejected(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """WeChat IDs beyond the String(100) column are rejected server-side (the SQLite
+        test engine ignores VARCHAR lengths; Postgres would 500)."""
+        from app.models.crm import CustomerSite, SiteContact
+
+        company = Company(name="WeChat Long Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+        db_session.add(site)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts",
+            data={"full_name": "Wei Chen", "wechat_id": "x" * 150},
+        )
+        assert resp.status_code == 200
+        assert "100 characters" in resp.text
+        assert db_session.query(SiteContact).filter(SiteContact.customer_site_id == site.id).count() == 0
+
+    def test_inactive_site_contacts_excluded(self, client: TestClient, db_session: Session, test_user: User):
+        """Contacts (real + legacy) on deactivated sites never render — clicking them
+        would log outreach against, and bump, a deactivated entity."""
+        from app.models.crm import CustomerSite, SiteContact
+
+        company, _, _ = self._make_company_with_contact(db_session)
+        dead_site = CustomerSite(
+            company_id=company.id,
+            site_name="Closed Plant",
+            is_active=False,
+            contact_name="Ghost Legacy",
+            contact_email="ghost-legacy@contactpanel.com",
+        )
+        db_session.add(dead_site)
+        db_session.flush()
+        ghost = SiteContact(
+            customer_site_id=dead_site.id,
+            full_name="Ghost Contact",
+            email="ghost-contact@contactpanel.com",
+        )
+        db_session.add(ghost)
+        db_session.commit()
+
+        # Detail panel (inline default tab) — uses the preloaded sites list.
+        detail = client.get(f"/v2/partials/customers/{company.id}")
+        assert detail.status_code == 200
+        assert "Jane Contact" in detail.text
+        assert "Ghost Contact" not in detail.text
+        assert "Ghost Legacy" not in detail.text
+
+        # Contacts tab refresh — uses the service-layer sites query.
+        tab = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert tab.status_code == 200
+        assert "Jane Contact" in tab.text
+        assert "Ghost Contact" not in tab.text
+        assert "Ghost Legacy" not in tab.text
 
 
 class TestEmailIntelligenceInActivity:

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -69,27 +69,56 @@ class TestVendorListEmbedding:
         assert 'hx-target="#main-content"' in resp.text
 
 
-class TestCustomerListEmbedding:
-    """Test customer list can be embedded in CRM shell."""
+class TestCustomerWorkspace:
+    """Test the CDM split-panel account workspace."""
 
-    def test_customer_list_with_custom_target(self, client: TestClient):
-        """Customer list respects hx_target query parameter."""
-        resp = client.get("/v2/partials/customers?hx_target=%23crm-tab-content")
-        assert resp.status_code == 200
-        assert 'hx-target="#crm-tab-content"' in resp.text
-
-    def test_customer_list_default_target(self, client: TestClient):
-        """Customer list defaults to #main-content when no override."""
+    def test_workspace_renders_panels(self, client: TestClient):
+        """Workspace renders the split layout: filter bar, list panel, detail panel."""
         resp = client.get("/v2/partials/customers")
         assert resp.status_code == 200
-        assert 'hx-target="#main-content"' in resp.text
+        assert 'id="cdm-workspace"' in resp.text
+        assert 'id="cdm-filters"' in resp.text
+        assert 'id="cdm-list"' in resp.text
+        assert 'id="cdm-detail"' in resp.text
+
+    def test_workspace_accepts_legacy_shell_params(self, client: TestClient):
+        """Legacy hx_target/push_url_base params (CRM shell URLs) are still accepted."""
+        resp = client.get("/v2/partials/customers?hx_target=%23crm-tab-content&push_url_base=/v2/crm")
+        assert resp.status_code == 200
+        assert 'id="cdm-workspace"' in resp.text
+
+    def test_account_rows_target_detail_panel(self, client: TestClient, db_session: Session, test_user: User):
+        """Clicking an account row loads its detail into the right panel."""
+        c = Company(name="Panel Target Co", is_active=True)
+        db_session.add(c)
+        db_session.commit()
+
+        resp = client.get("/v2/partials/customers")
+        assert resp.status_code == 200
+        assert f'hx-get="/v2/partials/customers/{c.id}"' in resp.text
+        assert 'hx-target="#cdm-detail"' in resp.text
+
+    def test_account_list_partial_returns_rows_only(self, client: TestClient, db_session: Session, test_user: User):
+        """The account-list partial returns the left panel only (no workspace shell)."""
+        c = Company(name="ListOnly Co", is_active=True)
+        db_session.add(c)
+        db_session.commit()
+
+        resp = client.get("/v2/partials/customers/account-list")
+        assert resp.status_code == 200
+        assert "ListOnly Co" in resp.text
+        assert 'id="cdm-workspace"' not in resp.text
 
 
-class TestTodaysCalls:
-    """Test Today's Calls section on customer list."""
+class TestOverdueChip:
+    """Test the overdue 'needs a call' chip on the CDM workspace filter bar.
 
-    def test_todays_calls_shows_overdue_accounts(self, client: TestClient, db_session: Session, test_user: User):
-        """Customer list shows Today's Calls for overdue accounts owned by user."""
+    Replaces the old "Needs Attention" banner — overdue accounts now surface via the
+    default oldest-first sort plus this one-click filter chip.
+    """
+
+    def test_chip_shows_for_overdue_accounts(self, client: TestClient, db_session: Session, test_user: User):
+        """Chip appears for sales users with overdue owned accounts."""
         test_user.role = "sales"
         db_session.flush()
 
@@ -104,11 +133,11 @@ class TestTodaysCalls:
 
         resp = client.get("/v2/partials/customers")
         assert resp.status_code == 200
-        assert "Needs Attention" in resp.text
+        assert "needs a call" in resp.text
         assert "Overdue Corp" in resp.text
 
-    def test_todays_calls_hidden_for_non_sales(self, client: TestClient, db_session: Session, test_user: User):
-        """Today's Calls section is hidden for non-sales users."""
+    def test_chip_hidden_for_non_sales(self, client: TestClient, db_session: Session, test_user: User):
+        """Chip is hidden for non-sales users."""
         # test_user defaults to "buyer" role
         overdue = Company(
             name="Hidden Corp",
@@ -121,10 +150,11 @@ class TestTodaysCalls:
 
         resp = client.get("/v2/partials/customers")
         assert resp.status_code == 200
-        assert "Needs Attention" not in resp.text
+        assert "need a call" not in resp.text
+        assert "needs a call" not in resp.text
 
-    def test_todays_calls_excludes_non_overdue(self, client: TestClient, db_session: Session, test_user: User):
-        """Today's Calls excludes accounts with recent activity."""
+    def test_chip_excludes_non_overdue(self, client: TestClient, db_session: Session, test_user: User):
+        """Chip does not count accounts with recent activity."""
         test_user.role = "sales"
         db_session.flush()
 
@@ -139,10 +169,11 @@ class TestTodaysCalls:
 
         resp = client.get("/v2/partials/customers")
         assert resp.status_code == 200
-        assert "Needs Attention" not in resp.text
+        assert "need a call" not in resp.text
+        assert "needs a call" not in resp.text
 
-    def test_todays_calls_includes_never_contacted(self, client: TestClient, db_session: Session, test_user: User):
-        """Today's Calls includes accounts with no activity (never contacted)."""
+    def test_chip_includes_never_contacted(self, client: TestClient, db_session: Session, test_user: User):
+        """Chip counts accounts with no activity (never contacted)."""
         test_user.role = "sales"
         db_session.flush()
 
@@ -157,12 +188,11 @@ class TestTodaysCalls:
 
         resp = client.get("/v2/partials/customers")
         assert resp.status_code == 200
-        assert "Needs Attention" in resp.text
+        assert "needs a call" in resp.text
         assert "NeverContacted Corp" in resp.text
-        assert "Never contacted" in resp.text
 
-    def test_todays_calls_excludes_other_owners(self, client: TestClient, db_session: Session, test_user: User):
-        """Today's Calls only shows accounts owned by the current user."""
+    def test_chip_excludes_other_owners(self, client: TestClient, db_session: Session, test_user: User):
+        """Chip only counts accounts owned by the current user."""
         test_user.role = "sales"
         db_session.flush()
 
@@ -177,7 +207,119 @@ class TestTodaysCalls:
 
         resp = client.get("/v2/partials/customers")
         assert resp.status_code == 200
-        assert "Needs Attention" not in resp.text
+        assert "need a call" not in resp.text
+        assert "needs a call" not in resp.text
+
+
+class TestWorkspaceFiltersAndSort:
+    """Test CDM workspace sorting and filtering."""
+
+    def test_default_sort_oldest_first(self, client: TestClient, db_session: Session, test_user: User):
+        """Default sort: never-contacted first, then longest since activity."""
+        c_new = Company(name="AAA NeverTouched", is_active=True, last_activity_at=None)
+        c_old = Company(
+            name="ZZZ Oldest",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=60),
+        )
+        c_recent = Company(
+            name="MMM Freshest",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        db_session.add_all([c_new, c_old, c_recent])
+        db_session.commit()
+
+        html = client.get("/v2/partials/customers/account-list").text
+        assert html.index("AAA NeverTouched") < html.index("ZZZ Oldest") < html.index("MMM Freshest")
+
+    def test_sort_newest_first(self, client: TestClient, db_session: Session, test_user: User):
+        """Sort=newest puts most recently touched accounts at the top."""
+        c_old = Company(
+            name="ZZZ Oldest",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=60),
+        )
+        c_recent = Company(
+            name="MMM Freshest",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        db_session.add_all([c_old, c_recent])
+        db_session.commit()
+
+        html = client.get("/v2/partials/customers/account-list?sort=newest").text
+        assert html.index("MMM Freshest") < html.index("ZZZ Oldest")
+
+    def test_sort_by_name(self, client: TestClient, db_session: Session, test_user: User):
+        """sort=name_asc orders alphabetically regardless of activity."""
+        c_b = Company(name="Bravo Co", is_active=True, last_activity_at=None)
+        c_a = Company(
+            name="Alpha Co",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        db_session.add_all([c_b, c_a])
+        db_session.commit()
+
+        html = client.get("/v2/partials/customers/account-list?sort=name_asc").text
+        assert html.index("Alpha Co") < html.index("Bravo Co")
+
+    def test_staleness_filter_overdue(self, client: TestClient, db_session: Session, test_user: User):
+        """Staleness=overdue shows only 30d+ stale accounts."""
+        stale = Company(
+            name="Stale Filter Co",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=45),
+        )
+        fresh = Company(
+            name="Fresh Filter Co",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=2),
+        )
+        db_session.add_all([stale, fresh])
+        db_session.commit()
+
+        html = client.get("/v2/partials/customers/account-list?staleness=overdue").text
+        assert "Stale Filter Co" in html
+        assert "Fresh Filter Co" not in html
+
+    def test_staleness_filter_new(self, client: TestClient, db_session: Session, test_user: User):
+        """Staleness=new shows only never-contacted accounts."""
+        never = Company(name="Never Filter Co", is_active=True, last_activity_at=None)
+        touched = Company(
+            name="Touched Filter Co",
+            is_active=True,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=2),
+        )
+        db_session.add_all([never, touched])
+        db_session.commit()
+
+        html = client.get("/v2/partials/customers/account-list?staleness=new").text
+        assert "Never Filter Co" in html
+        assert "Touched Filter Co" not in html
+
+    def test_account_type_filter(self, client: TestClient, db_session: Session, test_user: User):
+        """account_type filter narrows to that type."""
+        cust = Company(name="TypeCust Co", is_active=True, account_type="Customer")
+        prospect = Company(name="TypeProspect Co", is_active=True, account_type="Prospect")
+        db_session.add_all([cust, prospect])
+        db_session.commit()
+
+        html = client.get("/v2/partials/customers/account-list?account_type=Prospect").text
+        assert "TypeProspect Co" in html
+        assert "TypeCust Co" not in html
+
+    def test_my_only_filter(self, client: TestClient, db_session: Session, test_user: User):
+        """my_only=1 shows only accounts owned by the current user."""
+        mine = Company(name="Mine Co", is_active=True, account_owner_id=test_user.id)
+        other = Company(name="Unowned Co", is_active=True, account_owner_id=None)
+        db_session.add_all([mine, other])
+        db_session.commit()
+
+        html = client.get("/v2/partials/customers/account-list?my_only=1").text
+        assert "Mine Co" in html
+        assert "Unowned Co" not in html
 
 
 class TestCustomerStaleness:
@@ -269,6 +411,113 @@ class TestCustomerStaleness:
         pos_old = html.index("ZZZ Old")
         pos_recent = html.index("MMM Recent")
         assert pos_new < pos_old < pos_recent
+
+
+class TestContactPanel:
+    """Test the contacts panel (default detail tab) with outreach actions."""
+
+    def _make_company_with_contact(self, db_session, **contact_kwargs):
+        from app.models.crm import CustomerSite, SiteContact
+
+        company = Company(name="Contact Panel Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+        db_session.add(site)
+        db_session.flush()
+        contact = SiteContact(
+            customer_site_id=site.id,
+            full_name="Jane Contact",
+            title="Director of Procurement",
+            email="jane@contactpanel.com",
+            phone="+14155550000",
+            **contact_kwargs,
+        )
+        db_session.add(contact)
+        db_session.commit()
+        return company, site, contact
+
+    def test_detail_shows_contacts_inline(self, client: TestClient, db_session: Session, test_user: User):
+        """Account detail renders contacts (name, title, email, phone) without a tab
+        click."""
+        company, _, _ = self._make_company_with_contact(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        assert "Jane Contact" in resp.text
+        assert "Director of Procurement" in resp.text
+        assert "jane@contactpanel.com" in resp.text
+        assert "+14155550000" in resp.text
+
+    def test_contact_actions_log_outreach(self, client: TestClient, db_session: Session, test_user: User):
+        """Call/Email/Teams actions carry data-outreach-log attributes and deep
+        links."""
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert resp.status_code == 200
+        assert "data-outreach-log" in resp.text
+        assert 'href="tel:+14155550000"' in resp.text
+        assert 'href="mailto:jane@contactpanel.com"' in resp.text
+        assert "https://teams.microsoft.com/l/chat/0/0?users=jane%40contactpanel.com" in resp.text
+        assert f'data-company-id="{company.id}"' in resp.text
+        assert f'data-contact-id="{contact.id}"' in resp.text
+
+    def test_wechat_action_renders_when_handle_set(self, client: TestClient, db_session: Session, test_user: User):
+        """WeChat deep link renders only for contacts with a wechat_id."""
+        company, _, _ = self._make_company_with_contact(db_session, wechat_id="jane_wc")
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert resp.status_code == 200
+        assert "weixin://dl/chat?jane_wc" in resp.text
+        assert 'data-channel="wechat"' in resp.text
+
+    def test_no_wechat_action_without_handle(self, client: TestClient, db_session: Session, test_user: User):
+        """No WeChat button when the contact has no wechat_id."""
+        company, _, _ = self._make_company_with_contact(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert resp.status_code == 200
+        assert "weixin://" not in resp.text
+
+    def test_legacy_site_contact_rendered(self, client: TestClient, db_session: Session, test_user: User):
+        """Legacy site-level contacts still appear in the contacts panel."""
+        from app.models.crm import CustomerSite
+
+        company = Company(name="Legacy Contact Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(
+            company_id=company.id,
+            site_name="Plant 2",
+            is_active=True,
+            contact_name="Old Schoolson",
+            contact_email="old@legacyco.com",
+            contact_phone="+14155559999",
+        )
+        db_session.add(site)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert resp.status_code == 200
+        assert "Old Schoolson" in resp.text
+        assert "legacy" in resp.text
+
+    def test_create_site_contact_with_wechat(self, client: TestClient, db_session: Session, test_user: User):
+        """Site contact create form accepts a WeChat ID."""
+        from app.models.crm import CustomerSite, SiteContact
+
+        company = Company(name="WeChat Create Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+        db_session.add(site)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts",
+            data={"full_name": "Wei Chen", "phone": "+8613800138000", "wechat_id": "wei_chen_88"},
+        )
+        assert resp.status_code == 200
+        contact = db_session.query(SiteContact).filter(SiteContact.customer_site_id == site.id).first()
+        assert contact is not None
+        assert contact.wechat_id == "wei_chen_88"
 
 
 class TestEmailIntelligenceInActivity:

--- a/tests/test_htmx_views_nightly9.py
+++ b/tests/test_htmx_views_nightly9.py
@@ -636,6 +636,27 @@ class TestSiteContactCRUD:
         )
         assert resp.status_code == 404
 
+    def test_set_primary_contact_site_from_other_company_404_no_mutation(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_company: Company,
+        test_customer_site: CustomerSite,
+    ):
+        """A mismatched URL (site belonging to a different company) must 404 BEFORE
+        mutating — the primary flag must not flip."""
+        contact = _site_contact(db_session, test_customer_site)
+        other_company = Company(name="Other Primary Co", is_active=True)
+        db_session.add(other_company)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{other_company.id}/sites/{test_customer_site.id}/contacts/{contact.id}/primary"
+        )
+        assert resp.status_code == 404
+        db_session.refresh(contact)
+        assert contact.is_primary is False
+
     def test_add_site_contact_note_success(
         self,
         client: TestClient,

--- a/tests/test_phone_utils.py
+++ b/tests/test_phone_utils.py
@@ -112,6 +112,12 @@ class TestFormatPhoneE164EdgeCases:
         result = format_phone_e164("44207946095800")
         assert result == "+44207946095800"
 
+    def test_more_than_15_digits_returns_none(self):
+        """E.164 caps at 15 digits — longer strings are not phone numbers (and would
+        overflow the String(100) phone snapshot columns downstream)."""
+        assert format_phone_e164("1234567890123456") is None
+        assert format_phone_e164("+" + "9" * 30) is None
+
     def test_11_digits_not_starting_with_1_returns_none(self):
         """11 digits not starting with 1 — falls through to line 58 (return None)."""
         result = format_phone_e164("44207946095")


### PR DESCRIPTION
## Summary

Restores the lost CDM design: the CRM **Customers** tab is rebuilt as a split-panel account workspace modeled on the requisitions page (and on the Phase 1 CRM design spec in `docs/superpowers/specs/2026-03-29-crm-phase1-design.md`).

### Account list panel (left, scrollable, resizable)
- **Default sort: longest since logged activity at top** (never-contacted first), most recent at bottom — reads as a call list.
- Sort options: most recent activity, name A–Z / Z–A.
- Filters: staleness tier (overdue / due soon / recent / never contacted), account type, "My accounts", live search.
- Staleness dots per row + an overdue **"N needs a call"** chip for sales/traders that one-click filters to their overdue accounts (replaces the old "Needs Attention" banner).
- New `GET /v2/partials/customers/account-list` refreshes only the list panel, preserving the open account.

### Account detail panel (right)
- Row click loads the account into `#cdm-detail` (no page navigation), selected row highlighted.
- **Contacts are now the default tab, inline** — name, title, site, email, phone, WeChat — rendered from a new `tabs/contacts_tab.html` template (replaces inline f-string HTML in the router).

### Click-to-contact + auto-logging
- Per contact: **Call** (`tel:`), **Email** (`mailto:`), **Teams** (deep link), **WeChat** (`weixin://`) buttons.
- Each click opens the native handler AND fire-and-forget logs an outbound activity via new `POST /api/activity/outreach-initiated` → `log_outreach_initiated()` (phone→`call_logged`, email→`email_sent`, teams→`teams_message`, wechat→`wechat_message`; `direction=outbound`, `is_meaningful=True`, `auto_logged=True`), bumping `companies.last_activity_at` + `customer_sites.last_activity_at` so the call-list sort updates immediately. Success toast confirms the log.

### Schema / constants
- Migration `095_wechat_id`: adds `site_contacts.wechat_id` (nullable; symmetric downgrade). Single Alembic head verified.
- New `ActivityType.WECHAT_MESSAGE`, `Channel.WECHAT`; WeChat field added to the site-contact create form/route.

## Verification
- Full backend suite: **15,126 passed**, 34 skipped, 1 xfailed.
- Frontend: production build OK, 92 Vitest tests passed, ESLint clean.
- `pre-commit` (ruff, ruff-format, mypy, docformatter, etc.) all pass on changed files.
- New tests: outreach endpoint (all 4 channels, validation, rate limit, `last_activity_at` bumps), workspace rendering, sort/filter behavior, contact panel actions, WeChat create; stale CRM view tests updated.
- APP_MAP docs updated (ARCHITECTURE / DATABASE / INTERACTIONS).

## Notes
- Layout mirrors the req page exactly (list left, detail right). If you wanted the account list on the **right** edge instead, it's a trivial flip of two divs in `customers/list.html` — say the word.
- 8x8/Teams *inbound* auto-tracking (Phase 2a spec) is untouched; this PR covers outbound click-to-contact logging.

https://claude.ai/code/session_016bmdZGiaMR6f5FDkFZ1gBA

---
_Generated by [Claude Code](https://claude.ai/code/session_016bmdZGiaMR6f5FDkFZ1gBA)_