### PR TITLE
feat(ops): daily enrichment-coverage report command

### DIFF
--- a/app/management/enrichment_coverage_report.py
+++ b/app/management/enrichment_coverage_report.py
@@ -7,9 +7,12 @@ What: Aggregates material-card enrichment coverage into one compact human-readab
       appends a JSONL history line ({ts, metrics}) and prints run-over-run deltas
       for the headline numbers.
 Usage: python -m app.management.enrichment_coverage_report [--json] [--log-file PATH]
-Called by: ops cron (daily) or admin manually.
+Called by: admin manually; intended for a daily ops cron (host-side — not yet
+      registered anywhere in this repo).
 Depends on: MaterialCard, MaterialSpecFacet, FruLink models; app.database.SessionLocal
-      (single read-only session — performs no writes).
+      (single read-only session — performs no writes; on PostgreSQL all queries share
+      one REPEATABLE READ snapshot so concurrent enrichment-worker writes cannot skew
+      cross-metric ratios).
 """
 
 import argparse
@@ -43,7 +46,12 @@ HEADLINES: tuple[tuple[str, str], ...] = (
 # specs_structured source counting. PG iterates the JSONB in SQL (one query);
 # SQLite uses the equivalent json_each; any other dialect falls back to one
 # streamed Python pass. The jsonb_typeof/json_type guards skip legacy non-object
-# payloads, and non-dict entry values count under "(none)".
+# payloads, and non-dict entry values count under "(none)". Keep all three
+# branches aligned: only a MISSING or JSON-null source maps to "(none)" — a
+# present-but-empty source ("") is its own bucket. Non-string scalar sources
+# render as JSON text in PG (->>) and the Python fallback ('true' / '0');
+# SQLite's json_extract renders booleans as 1/0 — sources are strings in
+# practice, so that residual difference is accepted.
 _PG_SOURCES_SQL = text(
     """
     SELECT COALESCE(e.value ->> 'source', '(none)') AS src, count(*) AS n
@@ -96,13 +104,39 @@ def _spec_source_counts(db: Session) -> dict[str, int]:
                 continue
             for entry in specs.values():
                 source = entry.get("source") if isinstance(entry, dict) else None
-                counts[str(source) if source else "(none)"] += 1
+                if source is None:
+                    key = "(none)"
+                elif isinstance(source, str):
+                    key = source
+                else:
+                    key = json.dumps(source)  # JSON text, like PG's ->> ('true', '0')
+                counts[key] += 1
         rows = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
     return {str(src): int(n) for src, n in rows}
 
 
+def _pin_snapshot(db: Session) -> None:
+    """Pin one consistent snapshot for the whole metric collection (PostgreSQL).
+
+    At PG's default READ COMMITTED every statement sees its own snapshot, so a
+    concurrently writing enrichment worker could skew derived ratios (e.g. a faceted-
+    cards numerator over a cards total taken statements earlier). REPEATABLE READ makes
+    all queries in this transaction read one snapshot; the session stays read-only. Must
+    run before the transaction's first statement, so callers should pass a fresh session
+    (main() does). SQLite is already snapshot-consistent per transaction; other dialects
+    keep their default.
+    """
+    if db.get_bind().dialect.name == "postgresql" and not db.in_transaction():
+        db.connection(execution_options={"isolation_level": "REPEATABLE READ"})
+
+
 def collect_metrics(db: Session) -> dict[str, Any]:
-    """Gather all coverage metrics with a handful of read-only aggregate queries."""
+    """Gather all coverage metrics with a handful of read-only aggregate queries.
+
+    On PostgreSQL the queries share one REPEATABLE READ snapshot (see _pin_snapshot) so
+    the figures are mutually consistent even while the enrichment worker writes.
+    """
+    _pin_snapshot(db)
     active = MaterialCard.deleted_at.is_(None)
     category_norm = func.lower(func.trim(MaterialCard.category))
     has_category = and_(MaterialCard.category.isnot(None), func.trim(MaterialCard.category) != "")
@@ -165,9 +199,11 @@ def collect_metrics(db: Session) -> dict[str, Any]:
         .all()
     )
 
-    # 5. fru_links totals — only if the table exists in this database.
+    # 5. fru_links totals — only if the table exists in this database. Inspect the
+    # session's own connection (NOT the engine, which would check on a second
+    # pooled connection outside this transaction's snapshot).
     fru_links: dict[str, int] | None = None
-    if sa_inspect(db.get_bind()).has_table(FruLink.__tablename__):
+    if sa_inspect(db.connection()).has_table(FruLink.__tablename__):
         fru_rows, fru_distinct = db.query(func.count(FruLink.id), func.count(FruLink.fru_norm.distinct())).one()
         fru_links = {"rows": int(fru_rows), "distinct_frus": int(fru_distinct)}
 
@@ -217,33 +253,51 @@ def compute_deltas(prev: dict[str, Any], curr: dict[str, Any]) -> dict[str, int]
 
 
 def read_last_metrics(path: Path) -> dict[str, Any] | None:
-    """Return the metrics dict from the last well-formed JSONL line, if any."""
+    """Return the metrics dict from the last well-formed JSONL line, if any.
+
+    Scans backwards past unusable trailing lines — malformed JSON (e.g. a torn write
+    from a crash mid-append) or a line without a dict "metrics" key (e.g. a hand edit) —
+    logging a warning for each skipped line, so one bad line costs only its own
+    datapoint, never the delta computation itself.
+    """
     if not path.exists():
         return None
-    last = None
     with path.open(encoding="utf-8") as fh:
-        for line in fh:
-            if line.strip():
-                last = line.strip()
-    if last is None:
-        return None
-    try:
-        entry = json.loads(last)
-    except json.JSONDecodeError:
-        logger.warning("Could not parse last line of {} — skipping delta computation", path)
-        return None
-    metrics = entry.get("metrics") if isinstance(entry, dict) else None
-    return metrics if isinstance(metrics, dict) else None
+        lines = [line.strip() for line in fh if line.strip()]
+    for raw in reversed(lines):
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Skipping malformed line in {} while reading last metrics entry", path)
+            continue
+        metrics = entry.get("metrics") if isinstance(entry, dict) else None
+        if isinstance(metrics, dict):
+            return metrics
+        logger.warning("Skipping line without a 'metrics' dict in {} while reading last metrics entry", path)
+    return None
 
 
 def append_metrics(path: Path, metrics: dict[str, Any]) -> None:
+    """Append one ``{ts, metrics}`` JSONL line.
+
+    If a previous run crashed mid-write the file can end in a torn line with no trailing
+    newline — heal that first so the new entry never merges into (and gets destroyed by)
+    the corrupt line.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps({"ts": metrics["generated_at"], "metrics": metrics}, default=str) + "\n")
+    line = json.dumps({"ts": metrics["generated_at"], "metrics": metrics}, default=str)
+    with path.open("a+b") as fh:
+        fh.seek(0, 2)
+        if fh.tell() > 0:
+            fh.seek(-1, 2)
+            if fh.read(1) != b"\n":
+                fh.write(b"\n")
+        fh.write((line + "\n").encode("utf-8"))
 
 
 def _join(pairs: list[tuple[str, str]]) -> str:
-    return " · ".join(f"{k} {v}" for k, v in pairs) if pairs else "(none)"
+    # Blank labels (e.g. an empty-string spec source) render quoted so they stay visible.
+    return " · ".join(f"{k if k.strip() else repr(k)} {v}" for k, v in pairs) if pairs else "(none)"
 
 
 def format_report(metrics: dict[str, Any], deltas: dict[str, int] | None = None, prev_ts: str | None = None) -> str:

--- a/app/management/enrichment_coverage_report.py
+++ b/app/management/enrichment_coverage_report.py
@@ -1,0 +1,321 @@
+"""Daily enrichment-coverage telemetry report (read-only).
+
+What: Aggregates material-card enrichment coverage into one compact human-readable
+      block (or a structured dict with --json): card/category coverage, facet-table
+      coverage per commodity, specs_structured source mix, enrichment_status
+      distribution, description coverage, and fru_links totals. With --log-file it
+      appends a JSONL history line ({ts, metrics}) and prints run-over-run deltas
+      for the headline numbers.
+Usage: python -m app.management.enrichment_coverage_report [--json] [--log-file PATH]
+Called by: ops cron (daily) or admin manually.
+Depends on: MaterialCard, MaterialSpecFacet, FruLink models; app.database.SessionLocal
+      (single read-only session — performs no writes).
+"""
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+from sqlalchemy import and_, case, func, text
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard, MaterialSpecFacet
+from app.models.fru_link import FruLink
+
+TOP_N = 15
+
+# Headline numbers for run-over-run deltas: (dotted path into metrics, display label).
+HEADLINES: tuple[tuple[str, str], ...] = (
+    ("cards.total", "cards"),
+    ("cards.with_category", "with-category"),
+    ("cards.with_description", "with-description"),
+    ("facets.cards_with_facets", "faceted-cards"),
+    ("facets.rows_total", "facet-rows"),
+    ("spec_entries_total", "spec-entries"),
+    ("fru_links.rows", "fru-rows"),
+)
+
+# specs_structured source counting. PG iterates the JSONB in SQL (one query);
+# SQLite uses the equivalent json_each; any other dialect falls back to one
+# streamed Python pass. The jsonb_typeof/json_type guards skip legacy non-object
+# payloads, and non-dict entry values count under "(none)".
+_PG_SOURCES_SQL = text(
+    """
+    SELECT COALESCE(e.value ->> 'source', '(none)') AS src, count(*) AS n
+    FROM (
+        SELECT specs_structured FROM material_cards
+        WHERE deleted_at IS NULL
+          AND specs_structured IS NOT NULL
+          AND jsonb_typeof(specs_structured) = 'object'
+    ) c
+    CROSS JOIN LATERAL jsonb_each(c.specs_structured) AS e
+    GROUP BY src
+    ORDER BY n DESC, src
+    """
+)
+_SQLITE_SOURCES_SQL = text(
+    """
+    SELECT COALESCE(
+               CASE WHEN j.type = 'object' THEN json_extract(j.value, '$.source') END,
+               '(none)'
+           ) AS src,
+           count(*) AS n
+    FROM material_cards c, json_each(c.specs_structured) AS j
+    WHERE c.deleted_at IS NULL
+      AND c.specs_structured IS NOT NULL
+      AND json_type(c.specs_structured) = 'object'
+    GROUP BY src
+    ORDER BY n DESC, src
+    """
+)
+
+
+def _pct(part: int, total: int) -> float:
+    return round(100.0 * part / total, 1) if total else 0.0
+
+
+def _spec_source_counts(db: Session) -> dict[str, int]:
+    """Count specs_structured entries per recorded source, descending."""
+    dialect = db.get_bind().dialect.name
+    if dialect == "postgresql":
+        rows = db.execute(_PG_SOURCES_SQL).all()
+    elif dialect == "sqlite":
+        rows = db.execute(_SQLITE_SOURCES_SQL).all()
+    else:  # portable fallback — one streamed query, counted in Python
+        counts: Counter[str] = Counter()
+        query = db.query(MaterialCard.specs_structured).filter(
+            MaterialCard.deleted_at.is_(None), MaterialCard.specs_structured.isnot(None)
+        )
+        for (specs,) in query.yield_per(1000):
+            if not isinstance(specs, dict):
+                continue
+            for entry in specs.values():
+                source = entry.get("source") if isinstance(entry, dict) else None
+                counts[str(source) if source else "(none)"] += 1
+        rows = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    return {str(src): int(n) for src, n in rows}
+
+
+def collect_metrics(db: Session) -> dict[str, Any]:
+    """Gather all coverage metrics with a handful of read-only aggregate queries."""
+    active = MaterialCard.deleted_at.is_(None)
+    category_norm = func.lower(func.trim(MaterialCard.category))
+    has_category = and_(MaterialCard.category.isnot(None), func.trim(MaterialCard.category) != "")
+    has_description = and_(MaterialCard.description.isnot(None), func.trim(MaterialCard.description) != "")
+
+    # 1. Cards: totals + category/description coverage in one aggregate query.
+    total, with_category, category_other, with_description = (
+        db.query(
+            func.count(MaterialCard.id),
+            func.count(case((has_category, 1))),
+            func.count(case((category_norm == "other", 1))),
+            func.count(case((has_description, 1))),
+        )
+        .filter(active)
+        .one()
+    )
+    top_categories = (
+        db.query(category_norm, func.count(MaterialCard.id))
+        .filter(active, has_category)
+        .group_by(category_norm)
+        .order_by(func.count(MaterialCard.id).desc(), category_norm)
+        .limit(TOP_N)
+        .all()
+    )
+
+    # 2. Facets: coverage + per-commodity rows/spec-keys (facet.category = commodity).
+    facet_join = MaterialCard.id == MaterialSpecFacet.material_card_id
+    rows_total, cards_with_facets = (
+        db.query(
+            func.count(MaterialSpecFacet.id),
+            func.count(MaterialSpecFacet.material_card_id.distinct()),
+        )
+        .join(MaterialCard, facet_join)
+        .filter(active)
+        .one()
+    )
+    by_commodity = (
+        db.query(
+            MaterialSpecFacet.category,
+            func.count(MaterialSpecFacet.id),
+            func.count(MaterialSpecFacet.spec_key.distinct()),
+        )
+        .join(MaterialCard, facet_join)
+        .filter(active)
+        .group_by(MaterialSpecFacet.category)
+        .order_by(func.count(MaterialSpecFacet.id).desc(), MaterialSpecFacet.category)
+        .limit(TOP_N)
+        .all()
+    )
+
+    # 3. Sources: specs_structured entries per recorded source.
+    spec_sources = _spec_source_counts(db)
+
+    # 4. enrichment_status distribution.
+    status_rows = (
+        db.query(MaterialCard.enrichment_status, func.count(MaterialCard.id))
+        .filter(active)
+        .group_by(MaterialCard.enrichment_status)
+        .order_by(func.count(MaterialCard.id).desc(), MaterialCard.enrichment_status)
+        .all()
+    )
+
+    # 5. fru_links totals — only if the table exists in this database.
+    fru_links: dict[str, int] | None = None
+    if sa_inspect(db.get_bind()).has_table(FruLink.__tablename__):
+        fru_rows, fru_distinct = db.query(func.count(FruLink.id), func.count(FruLink.fru_norm.distinct())).one()
+        fru_links = {"rows": int(fru_rows), "distinct_frus": int(fru_distinct)}
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "cards": {
+            "total": int(total),
+            "with_category": int(with_category),
+            "with_category_pct": _pct(int(with_category), int(total)),
+            "category_other": int(category_other),
+            "with_description": int(with_description),
+            "top_categories": [{"category": str(cat), "count": int(n)} for cat, n in top_categories],
+        },
+        "facets": {
+            "cards_with_facets": int(cards_with_facets),
+            "cards_with_facets_pct": _pct(int(cards_with_facets), int(total)),
+            "rows_total": int(rows_total),
+            "by_commodity": [
+                {"commodity": str(commodity), "rows": int(rows), "spec_keys": int(keys)}
+                for commodity, rows, keys in by_commodity
+            ],
+        },
+        "spec_sources": spec_sources,
+        "spec_entries_total": sum(spec_sources.values()),
+        "enrichment_status": {str(status): int(n) for status, n in status_rows},
+        "fru_links": fru_links,
+    }
+
+
+def _dig(metrics: dict[str, Any], path: str) -> Any:
+    current: Any = metrics
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def compute_deltas(prev: dict[str, Any], curr: dict[str, Any]) -> dict[str, int]:
+    """Headline-number deltas (curr - prev); keys missing on either side are skipped."""
+    deltas: dict[str, int] = {}
+    for path, _label in HEADLINES:
+        a, b = _dig(prev, path), _dig(curr, path)
+        if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+            deltas[path] = int(b) - int(a)
+    return deltas
+
+
+def read_last_metrics(path: Path) -> dict[str, Any] | None:
+    """Return the metrics dict from the last well-formed JSONL line, if any."""
+    if not path.exists():
+        return None
+    last = None
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            if line.strip():
+                last = line.strip()
+    if last is None:
+        return None
+    try:
+        entry = json.loads(last)
+    except json.JSONDecodeError:
+        logger.warning("Could not parse last line of {} — skipping delta computation", path)
+        return None
+    metrics = entry.get("metrics") if isinstance(entry, dict) else None
+    return metrics if isinstance(metrics, dict) else None
+
+
+def append_metrics(path: Path, metrics: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"ts": metrics["generated_at"], "metrics": metrics}, default=str) + "\n")
+
+
+def _join(pairs: list[tuple[str, str]]) -> str:
+    return " · ".join(f"{k} {v}" for k, v in pairs) if pairs else "(none)"
+
+
+def format_report(metrics: dict[str, Any], deltas: dict[str, int] | None = None, prev_ts: str | None = None) -> str:
+    """One compact human-readable block."""
+    cards, facets = metrics["cards"], metrics["facets"]
+    lines = [
+        f"Enrichment coverage — {metrics['generated_at']}",
+        (
+            f"Cards: {cards['total']} total · category {cards['with_category']}"
+            f" ({cards['with_category_pct']}%) · 'other' {cards['category_other']}"
+            f" · description {cards['with_description']}"
+        ),
+        "  Top categories: " + _join([(t["category"], str(t["count"])) for t in cards["top_categories"]]),
+        (
+            f"Facets: {facets['cards_with_facets']} cards covered ({facets['cards_with_facets_pct']}%)"
+            f" · {facets['rows_total']} rows"
+        ),
+        "  By commodity: "
+        + _join([(c["commodity"], f"{c['rows']} rows/{c['spec_keys']} keys") for c in facets["by_commodity"]]),
+        f"Spec sources ({metrics['spec_entries_total']} entries): "
+        + _join([(k, str(v)) for k, v in metrics["spec_sources"].items()]),
+        "Status: " + _join([(k, str(v)) for k, v in metrics["enrichment_status"].items()]),
+    ]
+    fru = metrics["fru_links"]
+    if fru is not None:
+        lines.append(f"FRU links: {fru['rows']} rows · {fru['distinct_frus']} distinct FRUs")
+    else:
+        lines.append("FRU links: (table absent)")
+    if deltas is not None:
+        labels = dict(HEADLINES)
+        parts = [f"{labels[path]} {delta:+d}" for path, delta in deltas.items()]
+        suffix = f" (vs {prev_ts})" if prev_ts else ""
+        lines.append(f"Δ since last run{suffix}: " + (" · ".join(parts) if parts else "(no comparable numbers)"))
+    return "\n".join(lines)
+
+
+def main(json_output: bool = False, log_file: str | None = None) -> dict[str, Any]:
+    """Collect, optionally log + delta, and print the report.
+
+    Returns the output dict.
+    """
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        metrics = collect_metrics(db)
+    finally:
+        db.close()
+
+    deltas: dict[str, int] | None = None
+    prev_ts: str | None = None
+    if log_file:
+        path = Path(log_file)
+        prev = read_last_metrics(path)
+        if prev is not None:
+            deltas = compute_deltas(prev, metrics)
+            prev_ts = prev.get("generated_at")
+        append_metrics(path, metrics)
+
+    output = dict(metrics)
+    if deltas is not None:
+        output["deltas"] = deltas
+    if json_output:
+        print(json.dumps(output, indent=2, default=str))  # noqa: T201 — CLI report output
+    else:
+        print(format_report(metrics, deltas, prev_ts))  # noqa: T201 — CLI report output
+    return output
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Daily enrichment-coverage report (read-only)")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="Emit machine-readable JSON")
+    parser.add_argument("--log-file", default=None, help="JSONL history file; enables run-over-run deltas")
+    args = parser.parse_args()
+    main(json_output=args.json_output, log_file=args.log_file)

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -978,6 +978,43 @@ htmx/partials/materials/fru_section.html
 
 ---
 
+## Enrichment Coverage Telemetry (Ops / Observability)
+
+```
+python -m app.management.enrichment_coverage_report [--json] [--log-file PATH]
+    |   (read-only — single session, no writes; intended as a daily ops cron)
+    v
+collect_metrics(db) — a handful of aggregate queries over active cards
+    |   (deleted_at IS NULL everywhere, incl. the facet joins)
+    |
+    +---> Cards: total, category coverage (non-blank %, 'other' count,
+    |       top-15 lower(trim(category)) by count), description coverage
+    +---> Facets: distinct cards with >=1 material_spec_facets row (+% of cards),
+    |       facet rows total, per-commodity rows + distinct spec_keys (top-15;
+    |       facet.category IS the commodity)
+    +---> Sources: specs_structured entries grouped by each entry's recorded
+    |       "source" (mpn_decode / desc_parse / fru_matrix_decode /
+    |       spec_extraction / vendor APIs / "(none)" for legacy non-dict entries).
+    |       ONE query: PG iterates the JSONB in SQL (CROSS JOIN LATERAL
+    |       jsonb_each), SQLite uses json_each (tests), other dialects fall back
+    |       to one streamed Python pass — keep both SQL branches in sync and
+    |       verify the PG one against live PG when changing it
+    +---> enrichment_status distribution; fru_links totals (rows + distinct
+            fru_norm) only if the table exists
+    |
+    v
+Output: one compact human-readable block, or the structured metrics dict with
+--json. With --log-file it appends one JSONL line {ts, metrics} per run and, when
+a previous line exists, prints "Δ since last run" for the headline numbers
+(cards / with-category / with-description / faceted-cards / facet-rows /
+spec-entries / fru-rows).
+
+Tests: tests/test_enrichment_coverage_report.py (seeded fixture set; metrics,
+delta math, --json shape, log-file behavior).
+```
+
+---
+
 ## Faceted Search (Full-Text Search)
 
 ```

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -982,7 +982,10 @@ htmx/partials/materials/fru_section.html
 
 ```
 python -m app.management.enrichment_coverage_report [--json] [--log-file PATH]
-    |   (read-only — single session, no writes; intended as a daily ops cron)
+    |   (read-only — single session, no writes; on PG all queries share one
+    |    REPEATABLE READ snapshot so concurrent enrichment-worker writes can't
+    |    skew cross-metric ratios; intended as a daily ops cron — host-side,
+    |    not yet registered anywhere in this repo)
     v
 collect_metrics(db) — a handful of aggregate queries over active cards
     |   (deleted_at IS NULL everywhere, incl. the facet joins)
@@ -994,11 +997,13 @@ collect_metrics(db) — a handful of aggregate queries over active cards
     |       facet.category IS the commodity)
     +---> Sources: specs_structured entries grouped by each entry's recorded
     |       "source" (mpn_decode / desc_parse / fru_matrix_decode /
-    |       spec_extraction / vendor APIs / "(none)" for legacy non-dict entries).
+    |       spec_extraction / vendor APIs / "(none)" for legacy non-dict entries
+    |       or entries with a missing/null source).
     |       ONE query: PG iterates the JSONB in SQL (CROSS JOIN LATERAL
     |       jsonb_each), SQLite uses json_each (tests), other dialects fall back
-    |       to one streamed Python pass — keep both SQL branches in sync and
-    |       verify the PG one against live PG when changing it
+    |       to one streamed Python pass — keep all three branches in sync; when
+    |       changing the PG SQL, run the opt-in parity test (set PG_TEST_DSN to
+    |       a Postgres DSN) or verify against live PG
     +---> enrichment_status distribution; fru_links totals (rows + distinct
             fru_norm) only if the table exists
     |
@@ -1007,7 +1012,10 @@ Output: one compact human-readable block, or the structured metrics dict with
 --json. With --log-file it appends one JSONL line {ts, metrics} per run and, when
 a previous line exists, prints "Δ since last run" for the headline numbers
 (cards / with-category / with-description / faceted-cards / facet-rows /
-spec-entries / fru-rows).
+spec-entries / fru-rows). The history reader scans backwards past corrupt or
+wrong-shape trailing lines (each logged as a warning), and appends heal a
+missing trailing newline first, so a torn write from a crashed run never merges
+with — or suppresses deltas beyond — its own entry.
 
 Tests: tests/test_enrichment_coverage_report.py (seeded fixture set; metrics,
 delta math, --json shape, log-file behavior).

--- a/tests/test_enrichment_coverage_report.py
+++ b/tests/test_enrichment_coverage_report.py
@@ -3,20 +3,27 @@
 Seeds a small material-card/facet/fru_links fixture set and asserts the collected
 metrics, the run-over-run delta math, the --json output shape, and the log-file
 behavior. Runs against the shared in-memory SQLite engine, so it exercises the
-sqlite json_each branch of the spec-source counter (the PG jsonb_each branch is
-the same shape; verify it against live PG when changing the SQL).
+sqlite json_each branch of the spec-source counter; the PG jsonb_each branch has
+an opt-in parity test (set PG_TEST_DSN to a Postgres DSN), otherwise verify it
+against live PG when changing the SQL.
 
 Called by: pytest
 Depends on: app/management/enrichment_coverage_report.py, conftest db_session
 """
 
 import json
+import os
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+from loguru import logger
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session as PlainSession
 
 from app.management.enrichment_coverage_report import (
+    _pin_snapshot,
+    _spec_source_counts,
     append_metrics,
     collect_metrics,
     compute_deltas,
@@ -196,6 +203,93 @@ class TestCollectMetrics:
         assert "FRU links: (table absent)" in format_report(m)
 
 
+class TestSpecSourceBranches:
+    """The three dialect branches of _spec_source_counts must bucket identically."""
+
+    def test_python_fallback_matches_sqlite_branch(self, db_session):
+        _card(
+            db_session,
+            "MPN-EDGE",
+            specs_structured={
+                "a": {"value": 1, "source": "mpn_decode"},
+                "b": {"value": 2, "source": ""},  # present-but-empty → its own bucket
+                "c": {"value": 3},  # missing source → "(none)"
+                "d": "legacy",  # non-dict entry → "(none)"
+            },
+        )
+        db_session.commit()
+        expected = {"(none)": 2, "": 1, "mpn_decode": 1}
+        assert _spec_source_counts(db_session) == expected  # sqlite json_each branch
+        with patch.object(db_session.get_bind().dialect, "name", "duckdb"):
+            assert _spec_source_counts(db_session) == expected  # streamed Python fallback
+        # An empty-string source stays visible (quoted) in the human report.
+        m = collect_metrics(db_session)
+        assert "'' 1" in format_report(m)
+
+    @pytest.mark.skipif(not os.environ.get("PG_TEST_DSN"), reason="set PG_TEST_DSN to verify the PG jsonb_each branch")
+    def test_pg_jsonb_each_branch_matches_sqlite(self):
+        """Opt-in parity check for _PG_SOURCES_SQL (CI runs SQLite only)."""
+        engine = create_engine(os.environ["PG_TEST_DSN"])
+        try:
+            with engine.connect() as conn:
+                conn.execute(text("CREATE TEMP TABLE material_cards (specs_structured jsonb, deleted_at timestamptz)"))
+                conn.execute(
+                    text(
+                        "INSERT INTO material_cards (specs_structured, deleted_at) VALUES "
+                        "(CAST(:s AS jsonb), CAST(:d AS timestamptz))"
+                    ),
+                    [
+                        {  # object entries with sources, incl. missing and empty-string
+                            "s": json.dumps(
+                                {
+                                    "ddr_type": {"value": "DDR4", "source": "mpn_decode"},
+                                    "capacity": {"value": 16, "source": "mpn_decode"},
+                                    "ecc": {"value": True, "source": "desc_parse"},
+                                    "rank": {"value": 2, "source": ""},
+                                    "voltage": {"value": 1.2},
+                                }
+                            ),
+                            "d": None,
+                        },
+                        {"s": json.dumps({"legacy": "DDR4"}), "d": None},  # scalar entry → "(none)"
+                        {"s": json.dumps("not an object"), "d": None},  # non-object payload → skipped
+                        {"s": None, "d": None},  # NULL payload → skipped
+                        {  # soft-deleted → excluded entirely
+                            "s": json.dumps({"x": {"value": 1, "source": "mpn_decode"}}),
+                            "d": "2026-01-01T00:00:00Z",
+                        },
+                    ],
+                )
+                counts = _spec_source_counts(PlainSession(bind=conn))
+        finally:
+            engine.dispose()
+        # Same buckets the SQLite branch produces for this data: missing/null source
+        # and scalar entries → "(none)"; empty-string source is its own bucket.
+        assert counts == {"mpn_decode": 2, "(none)": 2, "desc_parse": 1, "": 1}
+
+
+class TestSnapshotPinning:
+    def test_pin_snapshot_sets_repeatable_read_on_fresh_pg_session(self):
+        db = MagicMock()
+        db.get_bind.return_value.dialect.name = "postgresql"
+        db.in_transaction.return_value = False
+        _pin_snapshot(db)
+        db.connection.assert_called_once_with(execution_options={"isolation_level": "REPEATABLE READ"})
+
+    def test_pin_snapshot_noop_mid_transaction_and_on_other_dialects(self):
+        mid_tx = MagicMock()
+        mid_tx.get_bind.return_value.dialect.name = "postgresql"
+        mid_tx.in_transaction.return_value = True
+        _pin_snapshot(mid_tx)
+        mid_tx.connection.assert_not_called()  # isolation can't change mid-transaction
+
+        sqlite = MagicMock()
+        sqlite.get_bind.return_value.dialect.name = "sqlite"
+        sqlite.in_transaction.return_value = False
+        _pin_snapshot(sqlite)
+        sqlite.connection.assert_not_called()  # already snapshot-consistent per transaction
+
+
 class TestDeltas:
     def test_delta_math(self, seeded, tmp_path):
         log = tmp_path / "coverage.jsonl"
@@ -232,7 +326,39 @@ class TestDeltas:
         assert read_last_metrics(tmp_path / "absent.jsonl") is None
         bad = tmp_path / "bad.jsonl"
         bad.write_text('{"ts": "x", "metrics": {"cards": {"total": 1}}}\nnot json\n')
-        assert read_last_metrics(bad) is None  # malformed last line → no deltas
+        # Corrupt trailing line (torn write) → scan back to the last well-formed line.
+        assert read_last_metrics(bad) == {"cards": {"total": 1}}
+        only_junk = tmp_path / "junk.jsonl"
+        only_junk.write_text("not json\nstill not json\n")
+        assert read_last_metrics(only_junk) is None  # no well-formed line at all
+
+    def test_read_last_metrics_wrong_shape_warns_and_falls_back(self, tmp_path):
+        log = tmp_path / "log.jsonl"
+        log.write_text(
+            '{"ts": "t1", "metrics": {"cards": {"total": 1}}}\n["not", "a", "dict"]\n{"ts": "t2", "metrics": "oops"}\n'
+        )
+        warnings: list[str] = []
+        sink = logger.add(lambda msg: warnings.append(str(msg)), level="WARNING")
+        try:
+            assert read_last_metrics(log) == {"cards": {"total": 1}}
+        finally:
+            logger.remove(sink)
+        # Both wrong-shape variants are surfaced, not silently skipped.
+        assert len(warnings) == 2
+        assert all("metrics" in w for w in warnings)
+
+    def test_append_after_truncated_line_heals_history(self, seeded, tmp_path):
+        log = tmp_path / "coverage.jsonl"
+        metrics = collect_metrics(seeded)
+        append_metrics(log, metrics)
+        # Simulate a torn write: a partial line with no trailing newline.
+        with log.open("a", encoding="utf-8") as fh:
+            fh.write('{"ts": "t2", "metr')
+        append_metrics(log, metrics)
+        lines = log.read_text().splitlines()
+        assert len(lines) == 3  # healed: new entry on its own line, never merged
+        assert json.loads(lines[2])["metrics"] == json.loads(json.dumps(metrics))
+        assert read_last_metrics(log) == json.loads(json.dumps(metrics))
 
 
 class TestMain:

--- a/tests/test_enrichment_coverage_report.py
+++ b/tests/test_enrichment_coverage_report.py
@@ -1,0 +1,319 @@
+"""Tests for app/management/enrichment_coverage_report.py — coverage telemetry.
+
+Seeds a small material-card/facet/fru_links fixture set and asserts the collected
+metrics, the run-over-run delta math, the --json output shape, and the log-file
+behavior. Runs against the shared in-memory SQLite engine, so it exercises the
+sqlite json_each branch of the spec-source counter (the PG jsonb_each branch is
+the same shape; verify it against live PG when changing the SQL).
+
+Called by: pytest
+Depends on: app/management/enrichment_coverage_report.py, conftest db_session
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.management.enrichment_coverage_report import (
+    append_metrics,
+    collect_metrics,
+    compute_deltas,
+    format_report,
+    main,
+    read_last_metrics,
+)
+from app.models import MaterialCard, MaterialSpecFacet
+from app.models.fru_link import FruLink
+
+
+def _card(db, mpn, **kwargs):
+    card = MaterialCard(normalized_mpn=mpn, display_mpn=mpn, **kwargs)
+    db.add(card)
+    db.flush()
+    return card
+
+
+@pytest.fixture()
+def seeded(db_session):
+    """Fixture set covering every metric branch.
+
+    Active cards: A (dram, desc, 3 spec entries), B (ssd, 1 entry), C (' Other ',
+    blank desc), D (no category, desc), F (dram, legacy non-dict spec entry).
+    E is soft-deleted and must be excluded everywhere (cards, facets, sources).
+    """
+    a = _card(
+        db_session,
+        "MPN-A",
+        category="dram",
+        description="16GB DDR4 RDIMM",
+        enrichment_status="verified",
+        specs_structured={
+            "ddr_type": {"value": "DDR4", "source": "mpn_decode"},
+            "capacity": {"value": 16, "source": "mpn_decode"},
+            "ecc": {"value": True, "source": "desc_parse"},
+        },
+    )
+    b = _card(
+        db_session,
+        "MPN-B",
+        category="ssd",
+        enrichment_status="web_sourced",
+        specs_structured={"capacity": {"value": 960, "source": "spec_extraction"}},
+    )
+    _card(db_session, "MPN-C", category=" Other ", description="", enrichment_status="unenriched")
+    _card(db_session, "MPN-D", description="mystery part", enrichment_status="unenriched")
+    e = _card(
+        db_session,
+        "MPN-E",
+        category="dram",
+        enrichment_status="verified",
+        deleted_at=datetime.now(timezone.utc),
+        specs_structured={"ddr_type": {"value": "DDR4", "source": "mpn_decode"}},
+    )
+    _card(
+        db_session,
+        "MPN-F",
+        category="dram",
+        enrichment_status="ai_inferred",
+        specs_structured={"ddr_type": "DDR4"},  # legacy non-dict entry → source "(none)"
+    )
+
+    db_session.add_all(
+        [
+            MaterialSpecFacet(material_card_id=a.id, category="dram", spec_key="ddr_type", value_text="DDR4"),
+            MaterialSpecFacet(
+                material_card_id=a.id, category="dram", spec_key="capacity", value_numeric=16, value_unit="GB"
+            ),
+            MaterialSpecFacet(
+                material_card_id=b.id, category="ssd", spec_key="capacity", value_numeric=960, value_unit="GB"
+            ),
+            # Facet row on the soft-deleted card — must be excluded from facet metrics.
+            MaterialSpecFacet(material_card_id=e.id, category="dram", spec_key="ddr_type", value_text="DDR4"),
+        ]
+    )
+    db_session.add_all(
+        [
+            FruLink(
+                fru_raw="00NV340",
+                fru_norm="00nv340",
+                related_raw="ST1000NX0313",
+                related_norm="st1000nx0313",
+                rel_kind="mfg_model",
+                source_sheet="Main",
+            ),
+            FruLink(
+                fru_raw="00NV340",
+                fru_norm="00nv340",
+                related_raw="00NV341",
+                related_norm="00nv341",
+                rel_kind="ibm_11s",
+                source_sheet="Main",
+            ),
+            FruLink(
+                fru_raw="01AB123",
+                fru_norm="01ab123",
+                related_raw="X1",
+                related_norm="x1",
+                rel_kind="tray",
+                source_sheet="Main",
+            ),
+        ]
+    )
+    db_session.commit()
+    return db_session
+
+
+class TestCollectMetrics:
+    def test_card_metrics(self, seeded):
+        m = collect_metrics(seeded)
+        assert m["cards"]["total"] == 5  # soft-deleted E excluded
+        assert m["cards"]["with_category"] == 4
+        assert m["cards"]["with_category_pct"] == 80.0
+        assert m["cards"]["category_other"] == 1  # ' Other ' normalized
+        assert m["cards"]["with_description"] == 2  # blank-string desc excluded
+        assert m["cards"]["top_categories"] == [
+            {"category": "dram", "count": 2},
+            {"category": "other", "count": 1},
+            {"category": "ssd", "count": 1},
+        ]
+
+    def test_facet_metrics(self, seeded):
+        m = collect_metrics(seeded)
+        assert m["facets"]["cards_with_facets"] == 2
+        assert m["facets"]["cards_with_facets_pct"] == 40.0
+        assert m["facets"]["rows_total"] == 3  # deleted card's facet row excluded
+        assert m["facets"]["by_commodity"] == [
+            {"commodity": "dram", "rows": 2, "spec_keys": 2},
+            {"commodity": "ssd", "rows": 1, "spec_keys": 1},
+        ]
+
+    def test_spec_sources(self, seeded):
+        m = collect_metrics(seeded)
+        assert m["spec_sources"] == {
+            "mpn_decode": 2,
+            "(none)": 1,  # legacy non-dict entry on card F
+            "desc_parse": 1,
+            "spec_extraction": 1,
+        }
+        # Ordered by count desc, then name — dict preserves insertion order.
+        assert list(m["spec_sources"]) == ["mpn_decode", "(none)", "desc_parse", "spec_extraction"]
+        assert m["spec_entries_total"] == 5
+
+    def test_status_and_fru(self, seeded):
+        m = collect_metrics(seeded)
+        assert m["enrichment_status"] == {
+            "unenriched": 2,
+            "ai_inferred": 1,
+            "verified": 1,
+            "web_sourced": 1,
+        }
+        assert m["fru_links"] == {"rows": 3, "distinct_frus": 2}
+
+    def test_empty_database(self, db_session):
+        m = collect_metrics(db_session)
+        assert m["cards"]["total"] == 0
+        assert m["cards"]["with_category_pct"] == 0.0  # no ZeroDivisionError
+        assert m["cards"]["top_categories"] == []
+        assert m["facets"] == {
+            "cards_with_facets": 0,
+            "cards_with_facets_pct": 0.0,
+            "rows_total": 0,
+            "by_commodity": [],
+        }
+        assert m["spec_sources"] == {}
+        assert m["spec_entries_total"] == 0
+        assert m["enrichment_status"] == {}
+        assert m["fru_links"] == {"rows": 0, "distinct_frus": 0}
+
+    def test_fru_table_absent(self, seeded):
+        fake_inspector = MagicMock()
+        fake_inspector.has_table.return_value = False
+        with patch("app.management.enrichment_coverage_report.sa_inspect", return_value=fake_inspector):
+            m = collect_metrics(seeded)
+        assert m["fru_links"] is None
+        assert "FRU links: (table absent)" in format_report(m)
+
+
+class TestDeltas:
+    def test_delta_math(self, seeded, tmp_path):
+        log = tmp_path / "coverage.jsonl"
+        first = collect_metrics(seeded)
+        append_metrics(log, first)
+
+        card = _card(seeded, "MPN-NEW", category="hdd", enrichment_status="verified", description="2TB SATA")
+        seeded.add(MaterialSpecFacet(material_card_id=card.id, category="hdd", spec_key="capacity", value_numeric=2))
+        seeded.commit()
+
+        second = collect_metrics(seeded)
+        prev = read_last_metrics(log)
+        assert prev is not None
+        deltas = compute_deltas(prev, second)
+        assert deltas == {
+            "cards.total": 1,
+            "cards.with_category": 1,
+            "cards.with_description": 1,
+            "facets.cards_with_facets": 1,
+            "facets.rows_total": 1,
+            "spec_entries_total": 0,
+            "fru_links.rows": 0,
+        }
+
+    def test_delta_skips_keys_missing_on_either_side(self, seeded):
+        m = collect_metrics(seeded)
+        prev = json.loads(json.dumps(m))
+        prev["fru_links"] = None  # e.g. previous run on a DB without the table
+        deltas = compute_deltas(prev, m)
+        assert "fru_links.rows" not in deltas
+        assert deltas["cards.total"] == 0
+
+    def test_read_last_metrics_missing_and_malformed(self, tmp_path):
+        assert read_last_metrics(tmp_path / "absent.jsonl") is None
+        bad = tmp_path / "bad.jsonl"
+        bad.write_text('{"ts": "x", "metrics": {"cards": {"total": 1}}}\nnot json\n')
+        assert read_last_metrics(bad) is None  # malformed last line → no deltas
+
+
+class TestMain:
+    def test_json_output_shape(self, seeded, capsys):
+        with patch("app.database.SessionLocal", MagicMock(return_value=seeded)):
+            returned = main(json_output=True)
+        printed = json.loads(capsys.readouterr().out)
+        assert printed == json.loads(json.dumps(returned))  # stdout is the returned dict
+        assert set(printed) == {
+            "generated_at",
+            "cards",
+            "facets",
+            "spec_sources",
+            "spec_entries_total",
+            "enrichment_status",
+            "fru_links",
+        }
+        assert set(printed["cards"]) == {
+            "total",
+            "with_category",
+            "with_category_pct",
+            "category_other",
+            "with_description",
+            "top_categories",
+        }
+        assert set(printed["facets"]) == {
+            "cards_with_facets",
+            "cards_with_facets_pct",
+            "rows_total",
+            "by_commodity",
+        }
+        assert "deltas" not in printed  # no --log-file → no deltas key
+
+    def test_human_report_block(self, seeded, capsys):
+        with patch("app.database.SessionLocal", MagicMock(return_value=seeded)):
+            main()
+        out = capsys.readouterr().out
+        assert "Enrichment coverage —" in out
+        assert "Cards: 5 total · category 4 (80.0%) · 'other' 1 · description 2" in out
+        assert "Top categories: dram 2 · other 1 · ssd 1" in out
+        assert "Facets: 2 cards covered (40.0%) · 3 rows" in out
+        assert "By commodity: dram 2 rows/2 keys · ssd 1 rows/1 keys" in out
+        assert "Spec sources (5 entries): mpn_decode 2 · (none) 1 · desc_parse 1 · spec_extraction 1" in out
+        assert "Status: unenriched 2 · ai_inferred 1 · verified 1 · web_sourced 1" in out
+        assert "FRU links: 3 rows · 2 distinct FRUs" in out
+        assert "Δ" not in out  # no log file → no delta line
+
+    def test_log_file_first_then_delta_run(self, seeded, tmp_path, capsys):
+        log = tmp_path / "coverage.jsonl"
+        with patch("app.database.SessionLocal", MagicMock(return_value=seeded)):
+            main(log_file=str(log))
+            first_out = capsys.readouterr().out
+            assert "Δ" not in first_out  # first run has no previous line
+
+            second = main(json_output=True, log_file=str(log))
+            capsys.readouterr()
+
+        assert second["deltas"] == {
+            "cards.total": 0,
+            "cards.with_category": 0,
+            "cards.with_description": 0,
+            "facets.cards_with_facets": 0,
+            "facets.rows_total": 0,
+            "spec_entries_total": 0,
+            "fru_links.rows": 0,
+        }
+        lines = [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+        assert len(lines) == 2  # one JSONL line appended per run
+        assert all(set(entry) == {"ts", "metrics"} for entry in lines)
+        assert lines[1]["ts"] == lines[1]["metrics"]["generated_at"]
+
+    def test_delta_line_in_human_output(self, seeded, tmp_path, capsys):
+        log = tmp_path / "coverage.jsonl"
+        with patch("app.database.SessionLocal", MagicMock(return_value=seeded)):
+            main(log_file=str(log))
+            capsys.readouterr()
+            _card(seeded, "MPN-NEW2", category="hdd", enrichment_status="verified")
+            seeded.commit()
+            main(log_file=str(log))
+        out = capsys.readouterr().out
+        assert "Δ since last run (vs " in out
+        assert "cards +1" in out
+        assert "with-category +1" in out
+        assert "facet-rows +0" in out


### PR DESCRIPTION
## Summary

Adds `app/management/enrichment_coverage_report.py` — a **read-only** daily ops telemetry command:

```
python -m app.management.enrichment_coverage_report [--json] [--log-file PATH]
```

One compact human-readable block (structured dict with `--json`):

1. **Cards** — total active cards, category coverage (non-blank %, `'other'` count, top-15 categories by count), description coverage.
2. **Facets** — distinct cards with ≥1 `material_spec_facets` row (count + % of cards), facet rows total, per-commodity rows + distinct spec_keys (top-15). All facet metrics join to active cards (soft-deleted excluded).
3. **Sources** — `specs_structured` entries grouped by each entry's recorded `source` (mpn_decode / desc_parse / fru_matrix_decode / spec_extraction / vendor APIs / "(none)" for legacy non-dict entries). ONE query: PG iterates JSONB in SQL (`CROSS JOIN LATERAL jsonb_each`), SQLite uses `json_each` (what the test suite exercises), any other dialect falls back to one streamed Python pass.
4. **Status / FRU** — `enrichment_status` distribution; `fru_links` totals (rows + distinct `fru_norm`) only if the table exists.
5. **Deltas** — `--log-file` appends one JSONL line `{ts, metrics}` per run; when a previous line exists, prints `Δ since last run` for the headline numbers (cards / with-category / with-description / faceted-cards / facet-rows / spec-entries / fru-rows).

Single read-only session, no writes anywhere.

## SQLite-masks-Postgres mitigation

The PG-only `jsonb_each` branch was **verified read-only against the live Postgres** (returns the real source mix: spec_extraction 701 · mpn_decode 58 · desc_parse 22 · fru_matrix_decode 12), and the full command was run end-to-end in the app container against live data. The SQLite branch guards legacy non-object entry values with `json_each`'s `type` column (bare `json_extract` on a scalar raises "malformed JSON").

## Sample output (live DB)

```
Enrichment coverage — 2026-06-10T08:02:45.773178+00:00
Cards: 1859 total · category 872 (46.9%) · 'other' 241 · description 552
  Top categories: other 241 · batteries 108 · cables 78 · power_supplies 57 · ...
Facets: 250 cards covered (13.4%) · 793 rows
  By commodity: batteries 228 rows/6 keys · dram 100 rows/8 keys · ...
Spec sources (793 entries): spec_extraction 701 · mpn_decode 58 · desc_parse 22 · fru_matrix_decode 12
Status: not_found 1614 · verified 136 · not_catalogued 86 · oem_sourced 12 · ai_inferred 10 · web_sourced 1
FRU links: 54456 rows · 31335 distinct FRUs
```

## Tests

`tests/test_enrichment_coverage_report.py` — 13 tests: seeded fixture set (incl. soft-deleted card, blank-string category/description, legacy non-dict spec entry), metrics assertions, delta math, `--json` shape, JSONL log-file behavior, fru-table-absent path, empty-DB path.

- Full suite: 15257 passed, 34 skipped, 1 xfailed
- `pre-commit run --all-files` green (with new files staged)
- `docs/APP_MAP_INTERACTIONS.md` — new "Enrichment Coverage Telemetry (Ops / Observability)" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)