### PR TITLE
docs: CLAUDE.md — tier-ladder arbitration, review-fleet workflow, git discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,23 @@ change, update the relevant APP_MAP doc(s) in the same PR.**
 - Always read the actual codebase before making changes — never rely on cached assumptions
 
 ### PR Reviews
-- Run ALL pr-review-toolkit agents on every PR: comment-analyzer, pr-test-analyzer, type-design-analyzer, silent-failure-hunter, code-simplifier, code-reviewer
-- Also run feature-dev:code-reviewer
+- Saved fleet: `Workflow({name: "pr-review-fleet", args: {pr, branch, worktree, title}})`
+  (`.claude/workflows/pr-review-fleet.js`) — all 6 pr-review-toolkit + feature-dev
+  reviewers in parallel → adversarial verify per finding → fix-all → simplify, with the
+  git constraints below baked in.
+- Caveat: invoking via scriptPath+args has misfired twice — for a one-off fleet, bake the
+  pr/branch/worktree/title values inline instead of passing args.
+
+### Git Discipline
+- **Merge, don't rebase, on pushed branches** — force-push is hook-blocked, so a rebase
+  strands the branch. `git fetch origin && git merge origin/main`; resolve conflicts root-cause.
+- Already-rebased branch? Append-only recovery: (1) snapshot the rebased state to a temp
+  branch, (2) `git checkout -B <branch> origin/<branch>`, (3) merge origin/main, (4) apply
+  the snapshot as a tree diff (`git diff HEAD <temp> | git apply`, commit), (5) plain push.
+- `gh pr edit` is broken (deprecated Projects-classic GraphQL, fails silently) — use
+  `gh api -X PATCH /repos/<owner>/<repo>/pulls/<n> --input -`.
+- When docformatter rewraps a docstring, run `pre-commit` twice — the first run mutates,
+  the second verifies clean.
 
 ---
 
@@ -131,6 +146,13 @@ Permission dependencies: `require_user` (any login), `require_buyer` (search/RFQ
 - Status values: always use `StrEnum` constants from `app/constants.py`, never raw strings
   (e.g. `RequisitionStatus.OPEN`, `RequirementStatus.FOUND`).
 - Keep routers thin (HTTP only); put business logic in `app/services/`.
+- **MaterialCard category/spec writes: the F1 tier ladder (`app/services/spec_tiers.py`)
+  is the single arbitration point.** ALL such writes go through `set_category()` /
+  `record_spec()` — never assign `card.category` or facets directly. Writers MUST register
+  their source string in `SOURCE_TIER` (unknown source → tier 0 → loses every conflict).
+  Never add per-writer confidence pre-gates — the ladder owns arbitration; run order is
+  not load-bearing. Enrichment writers + evidence-source tiers table:
+  `docs/APP_MAP_INTERACTIONS.md`.
 
 ### Search & Matching
 - Vendor matching: `fuzzy_score_vendor()` from `app/vendor_utils.py` (rapidfuzz wrapper). Never inline fuzzy logic.

--- a/docs/BRANCH_AND_CI_WORKFLOW.md
+++ b/docs/BRANCH_AND_CI_WORKFLOW.md
@@ -39,8 +39,10 @@ suffix (`feat/spec-resolver-1-migration`, `-2-models`, …) and merges bottom-up
 
 1. Branch off **current** `origin/main` (`git fetch && git switch -c <name> origin/main`).
 2. Open a PR early; keep it focused and small.
-3. If `main` moves under you, **rebase onto `origin/main`** before merge (this is
-   normal maintenance, not a drift band-aid).
+3. If `main` moves under you, **merge `origin/main` into the branch** before merging
+   (normal maintenance, not a drift band-aid). Do NOT rebase a pushed branch — the
+   resulting force-push is hook-blocked; see CLAUDE.md "Git Discipline" for the
+   append-only recovery recipe if a branch was already rebased.
 4. Merge, then **delete the branch promptly** (local + remote).
 
 Do not let branches accumulate. A branch with no open PR and no active work is a


### PR DESCRIPTION
Refreshes CLAUDE.md with this session's contracts (net +22 lines, terse pointers — detail stays in the APP_MAP docs):

**Coding Conventions › Database**
- The F1 tier ladder (`app/services/spec_tiers.py`) is the single arbitration point for ALL MaterialCard category/spec writes — `set_category()` / `record_spec()` only, sources MUST be registered in `SOURCE_TIER` (unknown → tier 0, loses everything), never add per-writer confidence pre-gates.
- One-line pointer: enrichment writers + evidence-source tiers table lives in `docs/APP_MAP_INTERACTIONS.md`.

**Standing Workflow Rules › PR Reviews** (replaces the stale agent-list bullets — the fleet runs exactly those agents)
- Saved fleet invocation per the file's own header: `Workflow({name: "pr-review-fleet", args: {pr, branch, worktree, title}})` (`.claude/workflows/pr-review-fleet.js`).
- Caveat: scriptPath+args invocation has misfired twice — bake values inline for one-off fleets.

**Standing Workflow Rules › Git Discipline** (new)
- Merge-don't-rebase on pushed branches (force-push hook-blocked).
- 5-step append-only recovery for an already-rebased branch (snapshot → `checkout -B` to origin tip → merge main → tree-diff apply → plain push).
- `gh pr edit` broken → `gh api -X PATCH`.
- Run pre-commit twice when docformatter rewraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)