### PR TITLE
fix: cross-PR wave-2/3 seam repairs — oem_official tier, 'other' lock-in guard, telemetry provenance, scoped FRU degradation

### DIFF
--- a/MIGRATION_NUMBERS_IN_FLIGHT.txt
+++ b/MIGRATION_NUMBERS_IN_FLIGHT.txt
@@ -1,0 +1,25 @@
+# MIGRATION_NUMBERS_IN_FLIGHT — alembic migration-number coordination log.
+#
+# Why: numbered migrations are claimed manually, and two open branches that both pick
+# the next free number (each chaining onto the same parent) create two alembic heads
+# the moment the second one merges — `alembic upgrade head` then fails at deploy time.
+# tests/test_migration_chain.py turns that into a CI failure on whichever branch lands
+# second, but only AFTER the collision exists; this file is the discovery path that
+# prevents it (a branch author cannot otherwise know which numbers are in flight
+# without trawling every open PR).
+#
+# Protocol (checked by tests/test_migration_numbers_in_flight.py):
+#   1. Before creating alembic/versions/NNN_*.py, take the lowest 3-digit number not
+#      listed below and not already present in alembic/versions/.
+#   2. Append a claim line in the SAME PR/commit that adds the migration:
+#         NNN  <branch-name>  <one-line description>
+#   3. Claim lines are append-only and permanent — never renumber or delete one. If
+#      the later-merging branch finds its parent superseded (a newer migration landed
+#      on main first), re-chain its down_revision onto the new head (or add an
+#      `alembic merge heads` revision); the claimed number stays the same.
+#   Two branches claiming the same number now collide HERE (a git conflict on the same
+#   appended line, or the duplicate-number test) instead of at deploy time.
+#
+# Format: <3-digit number> <branch> <notes...>  — lines starting with '#' are ignored.
+097 feat/dual-brand-filters dual-brand columns (PR #263, open — must re-chain down_revision onto 098 before merge: both currently chain off 096)
+098 perf/materials-post-ingest materials perf indexes (PR #262, MERGED to main)

--- a/alembic/versions/096_spec_provenance.py
+++ b/alembic/versions/096_spec_provenance.py
@@ -68,6 +68,7 @@ _SOURCE_TIER_SQL_CASE = (
     "WHEN 'fru_desc_parse' THEN 82 "
     "WHEN 'partsurfer' THEN 80 "
     "WHEN 'psref' THEN 80 "
+    "WHEN 'oem_official' THEN 80 "
     "WHEN 'web_search' THEN 70 "
     "WHEN 'brokerbin' THEN 65 "
     "WHEN 'spec_extraction' THEN 60 "

--- a/app/management/enrichment_coverage_report.py
+++ b/app/management/enrichment_coverage_report.py
@@ -2,14 +2,19 @@
 
 What: Aggregates material-card enrichment coverage into one compact human-readable
       block (or a structured dict with --json): card/category coverage, facet-table
-      coverage per commodity, specs_structured source mix, enrichment_status
-      distribution, description coverage, and fru_links totals. With --log-file it
-      appends a JSONL history line ({ts, metrics}) and prints run-over-run deltas
-      for the headline numbers.
+      coverage per commodity, specs_structured source mix, category provenance
+      (category_source counts incl. the "(none)" no-provenance bucket), facet
+      provenance (facet source counts incl. "(none)" for rows the 096 backfill
+      could not match), an unregistered-source callout (any observed source string
+      missing from spec_tiers.SOURCE_TIER ranks at tier 0 and loses every conflict),
+      enrichment_status distribution, description coverage, and fru_links totals.
+      With --log-file it appends a JSONL history line ({ts, metrics}) and prints
+      run-over-run deltas for the headline numbers.
 Usage: python -m app.management.enrichment_coverage_report [--json] [--log-file PATH]
-Called by: admin manually; intended for a daily ops cron (host-side — not yet
-      registered anywhere in this repo).
-Depends on: MaterialCard, MaterialSpecFacet, FruLink models; app.database.SessionLocal
+Called by: admin manually; daily ops cron via scripts/enrichment_coverage_cron.sh
+      (host crontab — see that script's header for the install line).
+Depends on: MaterialCard, MaterialSpecFacet, FruLink models; spec_tiers.SOURCE_TIER
+      (the unregistered-source cross-check); app.database.SessionLocal
       (single read-only session — performs no writes; on PostgreSQL all queries share
       one REPEATABLE READ snapshot so concurrent enrichment-worker writes cannot skew
       cross-metric ratios).
@@ -29,6 +34,7 @@ from sqlalchemy.orm import Session
 
 from app.models import MaterialCard, MaterialSpecFacet
 from app.models.fru_link import FruLink
+from app.services.spec_tiers import SOURCE_TIER
 
 TOP_N = 15
 
@@ -85,6 +91,12 @@ _SQLITE_SOURCES_SQL = text(
 
 def _pct(part: int, total: int) -> float:
     return round(100.0 * part / total, 1) if total else 0.0
+
+
+def _source_bucket(src: object) -> str:
+    """NULL provenance buckets as "(none)" — same convention as the spec-source
+    counter."""
+    return str(src) if src is not None else "(none)"
 
 
 def _spec_source_counts(db: Session) -> dict[str, int]:
@@ -190,6 +202,41 @@ def collect_metrics(db: Session) -> dict[str, Any]:
     # 3. Sources: specs_structured entries per recorded source.
     spec_sources = _spec_source_counts(db)
 
+    # 3b. Category provenance: categorized cards per category_source. Spec-entry counts
+    # alone are WINS-only and spec-only — a card categorized by an ingest that wrote no
+    # specs (or whose spec writes all lost the ladder) is invisible in spec_sources, so
+    # "trio_source: 0 spec entries" after an ingest does NOT mean the ingest wrote
+    # nothing. "(none)" = categorized rows with NULL category_source (a writer
+    # bypassing set_category, or pre-096 data the backfill should have stamped).
+    category_source_rows = (
+        db.query(MaterialCard.category_source, func.count(MaterialCard.id))
+        .filter(active, has_category)
+        .group_by(MaterialCard.category_source)
+        .order_by(func.count(MaterialCard.id).desc())
+        .all()
+    )
+    category_sources = {_source_bucket(src): int(n) for src, n in category_source_rows}
+
+    # 3c. Facet provenance: facet rows per source. "(none)" = rows with NULL provenance —
+    # the 096 backfill only stamped rows whose spec_key still existed in the card's
+    # specs_structured JSONB, so orphans stay NULL and would otherwise be invisible.
+    facet_source_rows = (
+        db.query(MaterialSpecFacet.source, func.count(MaterialSpecFacet.id))
+        .join(MaterialCard, facet_join)
+        .filter(active)
+        .group_by(MaterialSpecFacet.source)
+        .order_by(func.count(MaterialSpecFacet.id).desc())
+        .all()
+    )
+    facet_sources = {_source_bucket(src): int(n) for src, n in facet_source_rows}
+
+    # 3d. Unregistered-source callout: any observed source string missing from the F1
+    # ladder maps to tier 0 (spec_tiers.tier_for) and loses EVERY conflict — a
+    # misregistered writer is otherwise visible only as a once-per-process WARNING
+    # plus DEBUG per-row logs. Surfacing it here makes it trend in the daily report.
+    observed = set(spec_sources) | set(category_sources) | set(facet_sources)
+    unregistered_sources = sorted(observed - set(SOURCE_TIER) - {"(none)"})
+
     # 4. enrichment_status distribution.
     status_rows = (
         db.query(MaterialCard.enrichment_status, func.count(MaterialCard.id))
@@ -228,6 +275,9 @@ def collect_metrics(db: Session) -> dict[str, Any]:
         },
         "spec_sources": spec_sources,
         "spec_entries_total": sum(spec_sources.values()),
+        "category_sources": category_sources,
+        "facet_sources": facet_sources,
+        "unregistered_sources": unregistered_sources,
         "enrichment_status": {str(status): int(n) for status, n in status_rows},
         "fru_links": fru_links,
     }
@@ -319,8 +369,15 @@ def format_report(metrics: dict[str, Any], deltas: dict[str, int] | None = None,
         + _join([(c["commodity"], f"{c['rows']} rows/{c['spec_keys']} keys") for c in facets["by_commodity"]]),
         f"Spec sources ({metrics['spec_entries_total']} entries): "
         + _join([(k, str(v)) for k, v in metrics["spec_sources"].items()]),
+        "Category sources: " + _join([(k, str(v)) for k, v in metrics["category_sources"].items()]),
+        "Facet sources: " + _join([(k, str(v)) for k, v in metrics["facet_sources"].items()]),
         "Status: " + _join([(k, str(v)) for k, v in metrics["enrichment_status"].items()]),
     ]
+    if metrics["unregistered_sources"]:
+        lines.append(
+            "WARNING unregistered sources (tier 0 — every write loses conflicts): "
+            + ", ".join(metrics["unregistered_sources"])
+        )
     fru = metrics["fru_links"]
     if fru is not None:
         lines.append(f"FRU links: {fru['rows']} rows · {fru['distinct_frus']} distinct FRUs")

--- a/app/management/reenrich.py
+++ b/app/management/reenrich.py
@@ -44,6 +44,7 @@ async def main(limit: int = 500, batch_size: int = 30):
 
         enriched_cards = db.query(MaterialCard).filter(MaterialCard.id.in_(card_ids)).all()
         facet_count = 0
+        skipped_count = 0
         for card in enriched_cards:
             if not card.specs_structured or not card.category:
                 continue
@@ -64,17 +65,28 @@ async def main(limit: int = 500, batch_size: int = 30):
                     entry_source = "spec_extraction"
                     entry_confidence = 0.85
                 if value is not None:
-                    record_spec(
+                    # Count only PERSISTED writes — record_spec returns False on
+                    # no-schema (entries written under a category the card no longer
+                    # has), enum drift, unparseable numerics, and F1 ladder rejection.
+                    # Counting attempts would let "Backfilled N facet rows" claim
+                    # writes the gates silently skipped.
+                    if record_spec(
                         db,
                         int(card.id),
                         spec_key,
                         value,
                         source=entry_source,
                         confidence=entry_confidence,
-                    )
-                    facet_count += 1
+                    ):
+                        facet_count += 1
+                    else:
+                        skipped_count += 1
         db.commit()
-        logger.info("Backfilled {} facet rows", facet_count)
+        logger.info(
+            "Backfilled {} facet rows ({} entries skipped by schema/enum/ladder gates)",
+            facet_count,
+            skipped_count,
+        )
     finally:
         db.close()
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -7399,13 +7399,21 @@ async def materials_faceted_partial(
     # a crosswalk-only PN matches no material card, so the section must not depend
     # on card results. Both lookups are indexed point reads; non-MPN text queries
     # simply miss and render nothing.
+    # The section is ADDITIVE, so the lookups get the same scoped try/except
+    # search_history_panel uses — a crosswalk failure degrades to "no FRU section"
+    # and must never 500 the whole materials list (the primary surface).
     fru_view = None
     fru_reverse = None
     if q:
         from ..services.fru_matrix_service import get_fru_view, get_reverse_view
 
-        fru_view = get_fru_view(db, q)
-        fru_reverse = get_reverse_view(db, q)
+        try:
+            fru_view = get_fru_view(db, q)
+            fru_reverse = get_reverse_view(db, q)
+        except Exception:
+            logger.exception("materials faceted FRU section failed q={} user={}", q, user.id)
+            fru_view = None
+            fru_reverse = None
 
     ctx = _base_ctx(request, user, "materials")
     ctx.update(

--- a/app/services/source_ingest/ai_correct.py
+++ b/app/services/source_ingest/ai_correct.py
@@ -92,8 +92,14 @@ def _apply_result(part: ConsolidatedPart, result: dict) -> None:
         part.ai_description = desc.strip()
 
     # Only accept an AI category when the source had none (don't override real category).
+    # 'other' is rejected outright (defense in depth — ai_correct() also withholds it from
+    # the schema enum): it is the ABSENCE of classification, not a classification, and
+    # writing it at trio_source_ai (88) would permanently lock the card out of every
+    # deterministic re-homing lane below it — mpn_decode (85), fru_matrix_decode (84),
+    # desc_parse (83), fru_desc_parse (82), partsurfer/oem (80) — exactly the rows
+    # clean.py blanks TRIO's 'Other' code to keep open.
     cat = result.get("category")
-    if not part.category and isinstance(cat, str) and cat.strip():
+    if not part.category and isinstance(cat, str) and cat.strip() and cat.strip().lower() != "other":
         part.ai_category = cat.strip()
         conf = result.get("category_confidence")
         part.ai_category_confidence = float(conf) if isinstance(conf, (int, float)) else 0.5
@@ -139,7 +145,12 @@ async def ai_correct(parts: list[ConsolidatedPart]) -> dict:
     everything" from "AI failed on 100% of parts". ``corrected`` counts only parts where a
     structured result was actually applied.
     """
-    canonical_keys = sorted(get_all_commodities())
+    # 'other' is withheld from the model's vocabulary: clean.py deliberately blanks TRIO's
+    # 'Other' code so the no-category rows stay open to real categorization, and those are
+    # precisely the rows this lane categorizes (ai_category applies only when part.category
+    # is falsy). Offering 'other' would re-lock them at tier 88, above every deterministic
+    # decode/desc-parse lane. The model returns null when no real commodity fits.
+    canonical_keys = sorted(k for k in get_all_commodities() if k != "other")
     schema = _schema(canonical_keys)
     vocab_line = "Canonical category keys (choose exactly one or null): " + ", ".join(canonical_keys)
 

--- a/app/services/source_ingest/ingest.py
+++ b/app/services/source_ingest/ingest.py
@@ -132,11 +132,14 @@ def _ingest_part(db: Session, part: ConsolidatedPart, schema_caches: dict, stats
 
         # Description: fill ONLY when empty — there is no description-tier yet, so we must not
         # clobber an existing description (documented design choice; see module docstring).
+        # Credit the fill to AI_SOURCE when the text is the AI-standardized description
+        # (_description_for prefers ai_description) — the by-source report must not claim
+        # Claude-standardized text as raw trio_source ground truth.
         desc = _description_for(part)
         if desc and not (card.description or "").strip():
             card.description = desc[:1000]
             tally["descriptions_filled"] += 1
-            by_source[RAW_SOURCE] += 1
+            by_source[AI_SOURCE if part.ai_description else RAW_SOURCE] += 1
 
         # Condition: fill only with a real value, never "Unknown" (see _condition_fillable).
         if _condition_fillable(part.condition, card.condition):
@@ -243,7 +246,8 @@ def _tally_dry_run(
         stats["fields_by_source"][cat_source] += 1
     if desc_would:
         stats["descriptions_filled"] += 1
-        stats["fields_by_source"][RAW_SOURCE] += 1
+        # Mirror apply-mode's attribution: an AI-standardized description credits AI_SOURCE.
+        stats["fields_by_source"][AI_SOURCE if part.ai_description else RAW_SOURCE] += 1
     if cond_would:
         stats["conditions_filled"] += 1
         stats["fields_by_source"][RAW_SOURCE] += 1

--- a/app/services/spec_tiers.py
+++ b/app/services/spec_tiers.py
@@ -42,7 +42,9 @@ if TYPE_CHECKING:
 # spec_extraction the worker's run-order + writer pre-gates used to enforce by hand; the
 # same grammar run over a FRU's LINKED qual-sheet descriptions (``fru_desc_parse`` — a
 # one-hop fru_links row's prose, weaker than the card's OWN description) is 82; OEM
-# scrapers (PartSurfer/PSREF) map to 80; ``legacy_backfill`` (50) marks pre-ladder data
+# pages map to 80 — the named scrapers (``partsurfer``/``psref``) and the broader
+# ``oem_official`` umbrella (authoritative_enrichment_service's OEM-domain extractor)
+# are the same evidence class; ``legacy_backfill`` (50) marks pre-ladder data
 # whose true source is unknown — above the AI guesses (a stray guess can't flip legacy
 # data) but below every real source; AI free-text mining sits at the bottom (Haiku batch
 # categorization ``claude_haiku`` ranks with the other AI guesses). ``manual`` (a human
@@ -66,6 +68,7 @@ SOURCE_TIER: dict[str, int] = {
     "fru_desc_parse": 82,
     "partsurfer": 80,
     "psref": 80,
+    "oem_official": 80,
     "web_search": 70,
     "brokerbin": 65,
     "spec_extraction": 60,

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1018,7 +1018,9 @@ SOURCE_TIER  manual:100 · trio_source:95 · {digikey,mouser,nexar,element14,oem
              · trio_source_ai:88 · mpn_decode:85 · fru_matrix_decode:84 · desc_parse:83
              · fru_desc_parse:82 (FRU-linked qual-sheet descriptions — below the card's
                OWN description, above the OEM scrapers)
-             · {partsurfer,psref}→oem_scrape:80 · web_search:70 · brokerbin:65
+             · {partsurfer,psref,oem_official}:80 (the named OEM scrapers and the broader
+               oem_official umbrella — authoritative_enrichment_service's OEM-domain
+               extractor — are the same evidence class) · web_search:70 · brokerbin:65
              · spec_extraction:60 · legacy_backfill:50 (pre-ladder data; also the runtime
                floor for a valued category with NULL provenance) ·
                {ai_guess,claude_opus_inferred,claude_haiku}:40
@@ -1251,8 +1253,9 @@ htmx/partials/materials/fru_section.html
 python -m app.management.enrichment_coverage_report [--json] [--log-file PATH]
     |   (read-only — single session, no writes; on PG all queries share one
     |    REPEATABLE READ snapshot so concurrent enrichment-worker writes can't
-    |    skew cross-metric ratios; intended as a daily ops cron — host-side,
-    |    not yet registered anywhere in this repo)
+    |    skew cross-metric ratios; daily ops cron via
+    |    scripts/enrichment_coverage_cron.sh — host crontab runs it inside the
+    |    app container, JSONL history persisted in the applogs volume)
     v
 collect_metrics(db) — a handful of aggregate queries over active cards
     |   (deleted_at IS NULL everywhere, incl. the facet joins)
@@ -1271,6 +1274,15 @@ collect_metrics(db) — a handful of aggregate queries over active cards
     |       to one streamed Python pass — keep all three branches in sync; when
     |       changing the PG SQL, run the opt-in parity test (set PG_TEST_DSN to
     |       a Postgres DSN) or verify against live PG
+    +---> Category provenance: categorized cards grouped by category_source
+    |       ("(none)" = NULL provenance — a writer bypassing set_category or
+    |       unbackfilled pre-096 data); spec-entry counts alone are WINS-only and
+    |       spec-only, so a category-only ingest is visible ONLY here
+    +---> Facet provenance: facet rows grouped by source ("(none)" = NULL rows
+    |       the guarded 096 backfill could not match to a JSONB entry)
+    +---> Unregistered-source callout: any observed source string (spec, category,
+    |       or facet) missing from spec_tiers.SOURCE_TIER — such a writer ranks at
+    |       tier 0 and silently loses every conflict; the report makes it trend
     +---> enrichment_status distribution; fru_links totals (rows + distinct
             fru_norm) only if the table exists
     |

--- a/docs/BRANCH_AND_CI_WORKFLOW.md
+++ b/docs/BRANCH_AND_CI_WORKFLOW.md
@@ -48,6 +48,13 @@ suffix (`feat/spec-resolver-1-migration`, `-2-models`, …) and merges bottom-up
 Do not let branches accumulate. A branch with no open PR and no active work is a
 cleanup candidate.
 
+**Alembic migration numbers:** numbered migrations are claimed manually, so a branch
+adding one MUST follow the protocol in `MIGRATION_NUMBERS_IN_FLIGHT.txt` (repo root):
+take the lowest number neither listed there nor present in `alembic/versions/`, and
+append a claim line in the same PR. `tests/test_migration_numbers_in_flight.py`
+enforces uniqueness + registry completeness; `tests/test_migration_chain.py` still
+guards the single-head invariant when chains collide anyway.
+
 ## 3. Quarantine before delete — nothing is lost
 
 Unmerged work and stashes are **archived as tags before deletion**, never just

--- a/scripts/enrichment_coverage_cron.sh
+++ b/scripts/enrichment_coverage_cron.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Daily enrichment-coverage telemetry for AvailAI
+# Runs daily at 06:10 UTC via cron
+# Called by: crontab (10 6 * * *) — install once with:
+#   (crontab -l 2>/dev/null; echo "10 6 * * * /root/availai/scripts/enrichment_coverage_cron.sh") | crontab -
+# Depends on: docker compose (app container), app/management/enrichment_coverage_report.py
+#
+# The JSONL history lives at /var/log/avail/enrichment_coverage_history.jsonl INSIDE
+# the app container — that path is the `applogs` named volume (docker-compose.yml),
+# so run-over-run deltas survive container recreation. The human-readable block is
+# appended host-side to /var/log/avail/enrichment_coverage.log.
+set -euo pipefail
+
+cd /root/availai
+LOG="/var/log/avail/enrichment_coverage.log"
+mkdir -p /var/log/avail
+{
+    echo "=== Enrichment coverage $(date -u +%FT%TZ) ==="
+    docker compose exec -T app python -m app.management.enrichment_coverage_report \
+        --log-file /var/log/avail/enrichment_coverage_history.jsonl
+} >> "$LOG" 2>&1

--- a/tests/test_desc_extractor_routing.py
+++ b/tests/test_desc_extractor_routing.py
@@ -150,6 +150,36 @@ def test_packaging_suffixed_foreign_labels_stay_foreign_even_hinted():
     assert result is not None and result.commodity == "motherboards"
 
 
+# ── _NEUTRAL_LEADS growth tripwire (wave-6 guard) ─────────────────────────
+# _is_neutral_lead admits a multi-word label only when EVERY word is neutral, so
+# the foreign-lead guard for these accessory/system rows hinges on specific words
+# ("SERVER", "TRAY", "CBL", "EXPANSION", …) staying OUT of _NEUTRAL_LEADS. Each
+# case pairs a foreign multi-word label with body tokens AND a matching hint —
+# the strongest possible pull toward extraction — so a wave-6 brand/packaging
+# addition that re-admits one of these labels turns red HERE instead of silently
+# writing the served part's facets onto its accessory/chassis row. Bare and
+# hinted forms must BOTH stay None.
+FOREIGN_MULTIWORD_LEAD_CASES = [
+    # accessory labels mixing a foreign word with packaging words
+    ("CBL ASSY,RPS REAR MB, XL", "motherboards"),
+    ("Drive Tray Kit, 600GB 15K rpm SAS HDD trays", "hdd"),
+    ('Cable Assy, for LCD 15.6" FHD panel', "displays"),
+    ('Server Tray, 2.5" Hot-Swap SAS HDD caddy', "hdd"),
+    # brand + system words — adding the system word as "neutral" would flip these
+    ("HP SERVER, 16GB DDR4 RDIMM 2x Xeon Gold 6134", "dram"),
+    ('IBM STORAGE EXPANSION, 12x 3.5" SAS HDD bays', "hdd"),
+]
+
+
+@pytest.mark.parametrize("description,hint", FOREIGN_MULTIWORD_LEAD_CASES)
+def test_foreign_multiword_leads_stay_foreign(description, hint):
+    assert extract_desc(description) is None, f"{description!r} must stay FOREIGN unhinted"
+    assert extract_desc(description, commodity_hint=hint) is None, (
+        f"{description!r} must stay FOREIGN under a {hint!r} hint — a _NEUTRAL_LEADS "
+        "addition re-admitted an accessory/system label"
+    )
+
+
 def test_neutral_lead_keeps_phase1_conflict_guards():
     # Behind a neutral brand lead, a body mixing HDD+DIMM tokens still hard-conflicts
     # to None (constructed string — the guard predates phase 2 and must survive it).

--- a/tests/test_enrichment_coverage_report.py
+++ b/tests/test_enrichment_coverage_report.py
@@ -168,6 +168,38 @@ class TestCollectMetrics:
         assert list(m["spec_sources"]) == ["mpn_decode", "(none)", "desc_parse", "spec_extraction"]
         assert m["spec_entries_total"] == 5
 
+    def test_provenance_defaults_to_none_buckets(self, seeded):
+        # Fixture has no provenance anywhere: every categorized card / facet row lands
+        # in "(none)", and nothing is unregistered.
+        m = collect_metrics(seeded)
+        assert m["category_sources"] == {"(none)": 4}
+        assert m["facet_sources"] == {"(none)": 3}  # deleted card's facet row excluded
+        assert m["unregistered_sources"] == []
+
+    def test_provenance_sources_and_unregistered_callout(self, seeded):
+        a = seeded.query(MaterialCard).filter_by(normalized_mpn="MPN-A").one()
+        b = seeded.query(MaterialCard).filter_by(normalized_mpn="MPN-B").one()
+        a.category_source, a.category_tier = "mpn_decode", 85
+        b.category_source, b.category_tier = "typo_writer", 0  # NOT in SOURCE_TIER
+        facet = (
+            seeded.query(MaterialSpecFacet)
+            .filter(MaterialSpecFacet.material_card_id == a.id, MaterialSpecFacet.spec_key == "ddr_type")
+            .one()
+        )
+        facet.source = "mpn_decode"
+        seeded.commit()
+
+        m = collect_metrics(seeded)
+        assert m["category_sources"] == {"(none)": 2, "mpn_decode": 1, "typo_writer": 1}
+        assert m["facet_sources"] == {"(none)": 2, "mpn_decode": 1}
+        # Observed in category provenance but absent from SOURCE_TIER → tier-0 callout.
+        assert m["unregistered_sources"] == ["typo_writer"]
+
+        report = format_report(m)
+        assert "Category sources: " in report
+        assert "Facet sources: " in report
+        assert "WARNING unregistered sources (tier 0 — every write loses conflicts): typo_writer" in report
+
     def test_status_and_fru(self, seeded):
         m = collect_metrics(seeded)
         assert m["enrichment_status"] == {
@@ -191,6 +223,9 @@ class TestCollectMetrics:
         }
         assert m["spec_sources"] == {}
         assert m["spec_entries_total"] == 0
+        assert m["category_sources"] == {}
+        assert m["facet_sources"] == {}
+        assert m["unregistered_sources"] == []
         assert m["enrichment_status"] == {}
         assert m["fru_links"] == {"rows": 0, "distinct_frus": 0}
 
@@ -373,6 +408,9 @@ class TestMain:
             "facets",
             "spec_sources",
             "spec_entries_total",
+            "category_sources",
+            "facet_sources",
+            "unregistered_sources",
             "enrichment_status",
             "fru_links",
         }

--- a/tests/test_management_reenrich.py
+++ b/tests/test_management_reenrich.py
@@ -95,6 +95,53 @@ class TestReenrichMain:
         assert "voltage" in spec_keys
 
     @pytest.mark.asyncio
+    async def test_backfill_counts_only_persisted_writes(self):
+        """A record_spec rejection (no-schema / enum drift / ladder loss) counts as
+        skipped, never as backfilled — the closing log must not overstate what the facet
+        projection actually holds."""
+        mock_db = MagicMock()
+        card = MagicMock()
+        card.id = 42
+        card.category = "dram"
+        card.specs_structured = {
+            "ddr_type": {"value": "DDR4"},  # persists
+            "bogus_key": {"value": "x"},  # rejected by the gates → skipped
+            "speed_mhz": {"value": "junk"},  # rejected → skipped
+        }
+        mock_db.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [
+            (42,)
+        ]
+        mock_db.query.return_value.filter.return_value.all.return_value = [card]
+
+        from loguru import logger
+
+        messages: list[str] = []
+        sink_id = logger.add(lambda m: messages.append(str(m)), level="INFO")
+        try:
+            with (
+                patch("app.database.SessionLocal", MagicMock(return_value=mock_db)),
+                patch(
+                    "app.services.material_enrichment_service.enrich_material_cards",
+                    new_callable=AsyncMock,
+                    return_value={"enriched": 1},
+                ),
+                patch(
+                    "app.services.spec_write_service.record_spec",
+                    side_effect=[True, False, False],
+                ) as mock_record,
+            ):
+                from app.management.reenrich import main
+
+                await main(limit=10, batch_size=5)
+        finally:
+            logger.remove(sink_id)
+
+        assert mock_record.call_count == 3
+        assert any("Backfilled 1 facet rows (2 entries skipped by schema/enum/ladder gates)" in m for m in messages), (
+            messages
+        )
+
+    @pytest.mark.asyncio
     async def test_main_skips_card_without_specs_structured(self):
         """Main() skips record_spec for cards with None specs_structured."""
         mock_db = MagicMock()

--- a/tests/test_migration_numbers_in_flight.py
+++ b/tests/test_migration_numbers_in_flight.py
@@ -1,0 +1,71 @@
+"""Guard: the migration-number coordination log stays unique and complete.
+
+MIGRATION_NUMBERS_IN_FLIGHT.txt (repo root) is the discovery path for alembic
+migration numbers claimed by open branches — without it, two branches pick the same
+next number, chain onto the same parent, and `alembic upgrade head` fails at deploy
+time with two heads (tests/test_migration_chain.py only catches that AFTER the
+collision exists, on whichever branch lands second). This test enforces the log's two
+invariants:
+
+1. No number is claimed twice (a duplicate claim IS the collision — fail before merge).
+2. Every numbered migration file from the registry's start onward has a claim line
+   (the log rots the first time a branch lands a migration without appending; making
+   that a CI failure keeps the protocol self-sustaining).
+
+Called by: pytest. Depends on: MIGRATION_NUMBERS_IN_FLIGHT.txt + alembic/versions/
+filenames only (no DB).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from collections import Counter
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_LOG = _REPO_ROOT / "MIGRATION_NUMBERS_IN_FLIGHT.txt"
+_VERSIONS = _REPO_ROOT / "alembic" / "versions"
+
+# Claim line: "<3-digit number> <branch> <notes...>" ('#' lines are comments).
+_CLAIM = re.compile(r"^(\d{3})\s+(\S+)")
+
+# The registry starts at 097 — the first number claimed after the log was introduced.
+# Earlier numbered migrations (090-096) pre-date it and are deliberately unlisted.
+_REGISTRY_START = 97
+
+
+def _claims() -> list[tuple[int, str]]:
+    claims = []
+    for line in _LOG.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _CLAIM.match(line)
+        assert m, f"Unparseable claim line in {_LOG.name}: {line!r} — expected '<3-digit number> <branch> <notes...>'"
+        claims.append((int(m.group(1)), m.group(2)))
+    return claims
+
+
+def test_no_duplicate_number_claims():
+    counts = Counter(num for num, _branch in _claims())
+    dupes = sorted(num for num, n in counts.items() if n > 1)
+    assert not dupes, (
+        f"Migration number(s) {dupes} claimed more than once in {_LOG.name} — two "
+        "branches picked the same number; the later one must renumber BEFORE merging "
+        "or alembic ends up with two heads at deploy time."
+    )
+
+
+def test_every_landed_numbered_migration_is_claimed():
+    claimed = {num for num, _branch in _claims()}
+    landed = {
+        int(m.group(1))
+        for f in _VERSIONS.glob("*.py")
+        if (m := re.match(r"(\d{3})_", f.name)) and int(m.group(1)) >= _REGISTRY_START
+    }
+    missing = sorted(landed - claimed)
+    assert not missing, (
+        f"Numbered migration(s) {missing} exist in alembic/versions/ without a claim "
+        f"line in {_LOG.name} — append '<number> <branch> <notes>' in the same PR that "
+        "adds a migration (see the protocol in the file header)."
+    )

--- a/tests/test_source_ingest_ai_correct.py
+++ b/tests/test_source_ingest_ai_correct.py
@@ -56,6 +56,39 @@ async def test_ai_correct_standardizes_and_extracts(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_other_category_is_withheld_and_rejected(monkeypatch):
+    # clean.py blanks TRIO's 'Other' commodity code precisely so those rows stay open to
+    # the deterministic decode (85) / desc-parse (83) lanes — and the AI lane categorizes
+    # exactly those blanked rows (ai_category applies only when part.category is falsy).
+    # Re-admitting 'other' at trio_source_ai (88) would lock them out permanently, so it
+    # must be (a) withheld from the model's vocabulary AND (b) rejected if returned anyway
+    # (mirrors test_source_ingest_clean.test_clean_blanks_other_commodity_code).
+    seen: dict = {}
+
+    async def fake(prompt, schema, **kw):
+        seen["prompt"] = prompt
+        seen["schema"] = schema
+        return {
+            "normalized_mpn": "x",
+            "standardized_description": None,
+            "category": "other",  # off-vocab reply — must be dropped, not applied
+            "category_confidence": 0.9,
+            "specs": [],
+        }
+
+    monkeypatch.setattr(ai_mod, "claude_structured", fake)
+    part = _part(category=None)
+    stats = await ai_correct([part])
+
+    enum = seen["schema"]["properties"]["category"]["enum"]
+    assert "other" not in enum and None in enum and "hdd" in enum
+    vocab_line = seen["prompt"].splitlines()[0]
+    assert "other" not in vocab_line.split(": ", 1)[1].split(", ")
+    assert part.ai_category is None and part.ai_category_confidence is None
+    assert stats == {"corrected": 1, "failed": 0}  # the rest of the result still applies
+
+
+@pytest.mark.asyncio
 async def test_ai_correct_does_not_override_existing_category(monkeypatch):
     async def fake(prompt, schema, **kw):
         return {

--- a/tests/test_source_ingest_ingest.py
+++ b/tests/test_source_ingest_ingest.py
@@ -135,6 +135,22 @@ def test_ai_inferred_category_uses_trio_source_ai_tier(db_session: Session):
     assert card.category_tier == 88
 
 
+def test_ai_description_fill_credits_trio_source_ai(db_session: Session):
+    # A Claude-standardized description filling an empty card must be credited to
+    # trio_source_ai in the by-source report — not claimed as raw trio_source ground
+    # truth. Apply mode and dry run must attribute identically.
+    seed_commodity_schemas(db_session)
+    part = _part(category=None, description="raw text", ai_description="AI standardized text")
+    dry = ingest(db_session, [part], apply=False)
+    stats = ingest(db_session, [part], apply=True)
+
+    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    assert card.description == "AI standardized text"
+    for s in (dry, stats):
+        assert s["descriptions_filled"] == 1
+        assert s["fields_by_source"] == {"trio_source_ai": 1}  # nothing credited to trio_source
+
+
 def test_ai_specs_written_at_trio_source_ai(db_session: Session):
     seed_commodity_schemas(db_session)
     part = _part(ai_specs={"rpm": {"value": "7200", "confidence": 0.9}})


### PR DESCRIPTION
Applies 9 confirmed cross-PR findings (root-cause only) plus a conservative simplify pass.

## Findings fixed

| # | Sev | Fix |
|---|-----|-----|
| 1 | major | `'oem_official': 80` registered in `spec_tiers.SOURCE_TIER` (co-resident with partsurfer/psref — same evidence class) + `WHEN 'oem_official' THEN 80` in migration 096's `_SOURCE_TIER_SQL_CASE`; the sync test (`test_source_tier_sql_case_matches_live_ladder`) pins both. `apply_oem_sourced` provenance no longer ranks at tier 0. |
| 2 | minor | Parametric `FOREIGN_MULTIWORD_LEAD_CASES` tripwire in `test_desc_extractor_routing.py` — foreign multi-word labels paired with body tokens AND matching hints must stay `None`; a wave-6 `_NEUTRAL_LEADS` addition that re-admits an accessory/system label now turns CI red. |
| 3 | minor | `MIGRATION_NUMBERS_IN_FLIGHT.txt` coordination log at repo root + `tests/test_migration_numbers_in_flight.py` (no duplicate claims; every landed `>=097` migration must be claimed) + protocol note in `docs/BRANCH_AND_CI_WORKFLOW.md`. Seeded with the live claims: 097 (`feat/dual-brand-filters`, PR #263 open) and 098 (merged) — **both currently chain off 096; #263 must re-chain its `down_revision` onto 098 before merging.** The 096 single-head test already asserts mainline reachability (no per-merge rot), so no change needed there. |
| 4+7 | nit+major | `enrichment_coverage_report`: new `category_sources` + `facet_sources` sections (incl. `"(none)"` NULL-provenance buckets — unbackfilled facet orphans and set_category-bypassing writers are now visible) and an `unregistered_sources` tier-0 callout cross-checked against `SOURCE_TIER` (a systematically-losing writer now trends in the daily report, with a WARNING line in the human block). Daily run registered via `scripts/enrichment_coverage_cron.sh` (host crontab pattern as `weekly_cleanup.sh`; JSONL history persisted in the `applogs` volume so deltas survive container recreation). |
| 5 | nit | `source_ingest/ingest.py`: description fills credit `trio_source_ai` when the text is the AI-standardized description — in BOTH `_ingest_part` and `_tally_dry_run` (dry-run/apply parity). Report attribution only; no write-path change. |
| 6 | major | `source_ingest/ai_correct.py`: `'other'` is withheld from the model's schema enum + prompt vocab AND rejected in `_apply_result` (defense in depth) — an AI `'other'` at tier 88 would permanently lock clean.py's deliberately-blanked rows out of every deterministic re-homing lane (decode 85 / fru 84 / desc 83 / fru-desc 82 / oem 80). Test mirrors `test_source_ingest_clean`'s 'Other' case. |
| 8 | minor | `reenrich.py` facet backfill counts only truthy `record_spec` returns; closing log now reports `Backfilled N facet rows (M entries skipped by schema/enum/ladder gates)`. |
| 9 | minor | `materials_faceted_partial` wraps `get_fru_view`/`get_reverse_view` in the same scoped try/except + `logger.exception` pattern `search_history_panel` uses — a crosswalk failure degrades to "no FRU section" instead of 500ing the whole materials list. |

## Simplify pass (conservative)
- Deduped the `"(none)"` source-bucketing into `_source_bucket()` in the coverage report (used by both new GROUP BYs).
- Open-branch-owned files (`spec_tiers.py`, `source_ingest/ingest.py`) received ONLY the minimal confirmed-fix edits — zero extra churn, to keep merge surface small for `feat/dual-brand-filters` / `feat/on-add-enrichment`.

## Docs
- `docs/APP_MAP_INTERACTIONS.md`: SOURCE_TIER ladder line (+oem_official) and the coverage-telemetry section (new provenance sections + cron registration).
- `docs/BRANCH_AND_CI_WORKFLOW.md`: migration-number claim protocol.

## Validation
- Full suite green: **15592 passed, 35 skipped, 1 xfailed** (a first run showed 2 migration-round-trip failures, traced to me running `pre-commit run --all-files` concurrently — ruff-format rewrote a test file mid-run; the clean rerun on the final tree passed everything).
- `pre-commit run --all-files` clean (two passes per docformatter convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)