### PR TITLE
fix(decode): legacy WD/Seagate capacity grammars, STMicro gate, Gb/GB, RTX family — audit-driven

### DIFF
--- a/app/management/reconcile_decoded_facets.py
+++ b/app/management/reconcile_decoded_facets.py
@@ -1,0 +1,260 @@
+"""Reconcile mpn_decode / desc_parse facet rows against the FIXED deterministic
+extractors.
+
+What: facet-accuracy hotfix companion (audit 2026-06-10). Re-runs the corrected MPN
+      decoder and description extractor over every card owning a facet row with
+      source IN (mpn_decode, desc_parse) for the audit-affected spec_keys
+      (capacity_gb / gpu_family / memory_gb) and reconciles the stored value:
+        * fixed extractor yields a DIFFERENT value  -> record_spec the corrected
+          value (same source — the F1 ladder's newest-timestamp tie-break lets the
+          re-run win over the stale same-tier entry);
+        * fixed extractor yields NOTHING for a previously-recorded key -> DELETE the
+          facet row and its specs_structured entry (the old value was a misdecode —
+          wrong is worse than missing, provenance stays honest).
+      Dry-run by default with per-failure-class tallies (legacy_wd / legacy_seagate /
+      stmicro_gate / gb_bit / rtx_family); --apply writes. SAVEPOINT per card so one
+      bad card never poisons the batch.
+Usage: python -m app.management.reconcile_decoded_facets [--apply] [--limit N]
+Called by: admin manually after deploying the facet-accuracy hotfix.
+Depends on: mpn_decoder.decode_mpn, desc_extractor.extract_desc,
+      spec_write_service.record_spec/spec_would_write/load_schema_cache,
+      MaterialCard + MaterialSpecFacet, normalize_mpn.
+"""
+
+import argparse
+import re
+from collections import Counter, defaultdict
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard, MaterialSpecFacet
+from app.services.desc_extractor import extract_desc
+from app.services.desc_extractor._common import DESC_CONFIDENCE, DESC_SOURCE, SPEC_COMMODITIES
+from app.services.mpn_decoder import decode_mpn
+from app.services.mpn_decoder._common import DECODE_CONFIDENCE, DECODE_SOURCE
+from app.services.mpn_decoder.storage import _STMICRO_DENY
+from app.services.spec_write_service import load_schema_cache, record_spec, spec_would_write
+from app.utils.normalization import normalize_mpn
+
+# The audit's wrong rows live in these (source, spec_key) cells: legacy WD/Seagate +
+# STMicro misdecodes (mpn_decode × capacity_gb), Gb-vs-GB bit coercion (desc_parse ×
+# capacity_gb, and the same reader fix touches gpu memory_gb), and RTX family
+# fragmentation (desc_parse × gpu_family).
+TARGET_SOURCES = (DECODE_SOURCE, DESC_SOURCE)
+TARGET_SPEC_KEYS = ("capacity_gb", "gpu_family", "memory_gb")
+
+_CONFIDENCE = {DECODE_SOURCE: DECODE_CONFIDENCE, DESC_SOURCE: DESC_CONFIDENCE}
+
+# Raw-casing bit token ("2Gb", "512Mb") — classification only (the extractor fix
+# neutralizes these before upper-casing; see desc_extractor._BIT_UNITS).
+_BIT_TOKEN = re.compile(r"\b\d+(?:\.\d+)?\s?[KMGT]b(?![A-Za-z])")
+
+
+def _classify(facet: MaterialSpecFacet, card: MaterialCard) -> str:
+    """Audit failure-class bucket for a targeted facet row (tally key, not behavior)."""
+    if facet.source == DECODE_SOURCE:
+        mpn = normalize_mpn(card.display_mpn) or ""
+        if _STMICRO_DENY.match(mpn):
+            return "stmicro_gate"
+        if mpn.startswith("WD"):
+            return "legacy_wd"
+        if mpn.startswith("ST"):
+            return "legacy_seagate"
+        return "other_mpn_decode"
+    if facet.spec_key == "gpu_family":
+        return "rtx_family"
+    if _BIT_TOKEN.search(card.description or ""):
+        return "gb_bit"
+    return "other_desc_parse"
+
+
+def _recompute(card: MaterialCard, sources: set[str]) -> dict[str, dict]:
+    """Fixed-extractor output per source for *card* — {} means "yields nothing now".
+
+    Mirrors the writers' own gates exactly: the decode contributes only when its
+    commodity matches the card's category (mpn_decoder/writer.py's cross-commodity
+    guard), and desc extraction only runs for a non-empty description on a
+    SPEC_COMMODITIES card (desc_extractor/writer.py).
+    """
+    category = (card.category or "").lower().strip()
+    out: dict[str, dict] = {}
+    if DECODE_SOURCE in sources:
+        result = decode_mpn(card.display_mpn, card.manufacturer)
+        out[DECODE_SOURCE] = dict(result.specs) if result is not None and result.commodity == category else {}
+    if DESC_SOURCE in sources:
+        specs: dict = {}
+        description = (card.description or "").strip()
+        if description and category in SPEC_COMMODITIES:
+            desc_result = extract_desc(description, commodity_hint=category)
+            if desc_result is not None:
+                specs = dict(desc_result.specs)
+        out[DESC_SOURCE] = specs
+    return out
+
+
+def _facet_matches(facet: MaterialSpecFacet, schema, new_value) -> bool:
+    """Does the stored facet projection already equal the fixed extractor's value?"""
+    if schema is not None and schema.data_type == "numeric":
+        if facet.value_numeric is None:
+            return False
+        try:
+            return abs(float(new_value) - float(facet.value_numeric)) < 1e-9
+        except (TypeError, ValueError):
+            return False
+    if schema is not None and schema.data_type == "boolean":
+        return facet.value_text == ("true" if new_value else "false")
+    return facet.value_text == str(new_value)
+
+
+def reconcile(db: Session, *, apply: bool = False, limit: int = 0) -> dict:
+    """Reconcile the targeted facet rows; returns the tally dict (see module docstring).
+
+    Dry-run (default) classifies every row through the exact gates apply-mode uses
+    (spec_would_write is record_spec's read-only twin) and writes NOTHING; --apply
+    mutates inside a per-card SAVEPOINT and commits at the end.
+    """
+    rows = (
+        db.query(MaterialSpecFacet)
+        .filter(
+            MaterialSpecFacet.source.in_(TARGET_SOURCES),
+            MaterialSpecFacet.spec_key.in_(TARGET_SPEC_KEYS),
+        )
+        .order_by(MaterialSpecFacet.material_card_id, MaterialSpecFacet.spec_key)
+        .all()
+    )
+    by_card: dict[int, list[MaterialSpecFacet]] = defaultdict(list)
+    for row in rows:
+        by_card[row.material_card_id].append(row)
+
+    card_ids = sorted(by_card)
+    if limit:
+        card_ids = card_ids[:limit]
+
+    tallies: dict[str, Counter] = defaultdict(Counter)
+    totals: Counter = Counter()
+    schema_caches: dict[str, dict] = {}
+
+    for card_id in card_ids:
+        facets = by_card[card_id]
+        try:
+            card = db.get(MaterialCard, card_id)
+            if card is None:
+                totals["skipped"] += len(facets)
+                continue
+            category = (card.category or "").lower().strip()
+            cache = schema_caches.get(category)
+            if cache is None and category:
+                cache = schema_caches[category] = load_schema_cache(db, category)
+            recomputed = _recompute(card, {f.source for f in facets})
+
+            # Per-card SAVEPOINT (apply mode): record_spec flushes, so a DB-level
+            # failure would otherwise poison the shared transaction for every later
+            # card. Dry-run opens none — it never writes.
+            ctx = db.begin_nested() if apply else None
+            try:
+                for facet in facets:
+                    klass = _classify(facet, card)
+                    new_value = recomputed.get(facet.source, {}).get(facet.spec_key)
+                    schema = (cache or {}).get((category, facet.spec_key))
+                    if new_value is None:
+                        # The fixed extractor yields nothing for this key — the stored
+                        # value is a stale misdecode. Delete facet + JSONB entry, but
+                        # only when the JSONB provenance still agrees with the facet's
+                        # (they mirror by construction; a mismatch means drift — skip).
+                        specs = dict(card.specs_structured or {})
+                        entry = specs.get(facet.spec_key)
+                        if entry is not None and entry.get("source") != facet.source:
+                            tallies[klass]["skipped_provenance_mismatch"] += 1
+                            totals["skipped"] += 1
+                            continue
+                        if apply:
+                            specs.pop(facet.spec_key, None)
+                            card.specs_structured = specs
+                            db.delete(facet)
+                        tallies[klass]["deleted"] += 1
+                        totals["deleted"] += 1
+                    elif _facet_matches(facet, schema, new_value):
+                        tallies[klass]["unchanged"] += 1
+                        totals["unchanged"] += 1
+                    else:
+                        confidence = _CONFIDENCE[facet.source]
+                        if apply:
+                            written = record_spec(
+                                db,
+                                card_id,
+                                facet.spec_key,
+                                new_value,
+                                source=facet.source,
+                                confidence=confidence,
+                                schema_cache=cache,
+                            )
+                        else:
+                            written = spec_would_write(
+                                db,
+                                category=category,
+                                existing_specs=card.specs_structured,
+                                spec_key=facet.spec_key,
+                                value=new_value,
+                                source=facet.source,
+                                confidence=confidence,
+                                schema_cache=cache,
+                            )
+                        action = "corrected" if written else "skipped_ladder"
+                        tallies[klass][action] += 1
+                        totals["corrected" if written else "skipped"] += 1
+                if ctx is not None:
+                    ctx.commit()
+            except BaseException:
+                if ctx is not None:
+                    ctx.rollback()
+                raise
+            totals["cards"] += 1
+        except Exception:
+            totals["failed"] += 1
+            logger.exception("reconcile-decoded-facets: failed on card_id={}", card_id)
+
+    if apply:
+        db.commit()
+
+    summary = {
+        "mode": "apply" if apply else "dry-run",
+        "cards": totals["cards"],
+        "facets": sum(len(by_card[c]) for c in card_ids),
+        "corrected": totals["corrected"],
+        "deleted": totals["deleted"],
+        "unchanged": totals["unchanged"],
+        "skipped": totals["skipped"],
+        "failed": totals["failed"],
+        "by_class": {klass: dict(counter) for klass, counter in sorted(tallies.items())},
+    }
+    logger.info("reconcile-decoded-facets [{}]: {}", summary["mode"], summary)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Reconcile mpn_decode/desc_parse facets against the fixed extractors")
+    parser.add_argument("--apply", action="store_true", help="Write the corrections/deletes (default: dry-run)")
+    parser.add_argument("--limit", type=int, default=0, help="Max cards to process (0 = all)")
+    args = parser.parse_args()
+
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        if args.apply:
+            logger.warning(
+                "reconcile-decoded-facets: --apply will rewrite/DELETE mpn_decode/desc_parse facet rows "
+                "for spec_keys {} — ensure a recent db-backup exists (pg_dump runs every 6h; "
+                "scripts/restore.sh to roll back)",
+                TARGET_SPEC_KEYS,
+            )
+        reconcile(db, apply=args.apply, limit=args.limit)
+        if not args.apply:
+            db.rollback()  # belt-and-braces: dry-run leaves no writes behind
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/management/reconcile_decoded_facets.py
+++ b/app/management/reconcile_decoded_facets.py
@@ -150,7 +150,11 @@ def reconcile(db: Session, *, apply: bool = False, limit: int = 0) -> dict:
 
             # Per-card SAVEPOINT (apply mode): record_spec flushes, so a DB-level
             # failure would otherwise poison the shared transaction for every later
-            # card. Dry-run opens none — it never writes.
+            # card. Dry-run opens none — it never writes. Tallies are BUFFERED and
+            # merged only after a clean release, so a mid-card failure (savepoint
+            # rolled back) can never leave the counters claiming work that was
+            # undone — same honesty rule as mpn_decoder/writer.py.
+            pending: list[tuple[str, str]] = []  # (class, action) per facet
             ctx = db.begin_nested() if apply else None
             try:
                 for facet in facets:
@@ -165,18 +169,15 @@ def reconcile(db: Session, *, apply: bool = False, limit: int = 0) -> dict:
                         specs = dict(card.specs_structured or {})
                         entry = specs.get(facet.spec_key)
                         if entry is not None and entry.get("source") != facet.source:
-                            tallies[klass]["skipped_provenance_mismatch"] += 1
-                            totals["skipped"] += 1
+                            pending.append((klass, "skipped_provenance_mismatch"))
                             continue
                         if apply:
                             specs.pop(facet.spec_key, None)
                             card.specs_structured = specs
                             db.delete(facet)
-                        tallies[klass]["deleted"] += 1
-                        totals["deleted"] += 1
+                        pending.append((klass, "deleted"))
                     elif _facet_matches(facet, schema, new_value):
-                        tallies[klass]["unchanged"] += 1
-                        totals["unchanged"] += 1
+                        pending.append((klass, "unchanged"))
                     else:
                         confidence = _CONFIDENCE[facet.source]
                         if apply:
@@ -200,15 +201,17 @@ def reconcile(db: Session, *, apply: bool = False, limit: int = 0) -> dict:
                                 confidence=confidence,
                                 schema_cache=cache,
                             )
-                        action = "corrected" if written else "skipped_ladder"
-                        tallies[klass][action] += 1
-                        totals["corrected" if written else "skipped"] += 1
+                        pending.append((klass, "corrected" if written else "skipped_ladder"))
                 if ctx is not None:
                     ctx.commit()
             except BaseException:
                 if ctx is not None:
                     ctx.rollback()
                 raise
+            # Reached only on a clean savepoint release (or dry-run) — merge the buffer.
+            for klass, action in pending:
+                tallies[klass][action] += 1
+                totals[action if action in ("corrected", "deleted", "unchanged") else "skipped"] += 1
             totals["cards"] += 1
         except Exception:
             totals["failed"] += 1

--- a/app/services/desc_extractor/__init__.py
+++ b/app/services/desc_extractor/__init__.py
@@ -242,6 +242,18 @@ _CPU_WEAK = re.compile(
 _SUBORDINATE_UNDER: dict[str, frozenset[str]] = {"cpu": frozenset({"dram"})}
 
 
+# Bit-unit neutralization (MUST run before the upper-casing below, which destroys the
+# casing signal): "2Gb, 128*16" is a DRAM *component density* in gigaBITS — uppercase
+# letter + lowercase "b" is the SI bit-unit casing — and upper-casing collapses it into
+# the "2GB" gigaBYTE shape, recording an 8× wrong capacity (facet-accuracy audit, card
+# 74143). Bit tokens are rewritten to "<n><K|M|G|T>BIT", which no capacity/memory regex
+# matches: component densities are deliberately NOT a seeded spec, so they are skipped,
+# never ÷8-converted. "Gbps"/"Gbit"/"Gb/s" forms are already inert after upper-casing
+# (no word boundary / the trailing-"/S" checks); all-lowercase "2gb" stays untouched —
+# sloppy lower-case descriptions mean bytes in this corpus.
+_BIT_UNITS = re.compile(r"\b(\d+(?:\.\d+)?)\s?([KMGT])b(?![A-Za-z])")
+
+
 def _is_neutral_lead(label: str) -> bool:
     if label.startswith("SPS"):
         return True
@@ -283,7 +295,8 @@ def extract_desc(description: str, commodity_hint: str | None = None) -> DescRes
     """
     if not description:
         return None
-    text = re.sub(r"\s+", " ", description).strip().upper()
+    text = _BIT_UNITS.sub(r"\1\2BIT", description)  # before .upper() — see _BIT_UNITS
+    text = re.sub(r"\s+", " ", text).strip().upper()
     if not text:
         return None
 

--- a/app/services/desc_extractor/gpu.py
+++ b/app/services/desc_extractor/gpu.py
@@ -16,7 +16,10 @@ CONSERVATIVE by design (a wrong facet value is worse than a missing one):
   RTX, Tesla + datacenter chip list incl. T4, Radeon (Pro), A-/H-series) and
   emits a unique member or omits. Subsumption: an explicit GEFORCE token absorbs
   its own GTX/RTX sub-brand tokens ("GeForce RTX/GTX …" is one family, not a
-  conflict). A-/H-series chip tokens reject hyphen-glued silicon steppings
+  conflict). An RTX token adjacent to a consumer x050–x090 model ("RTX 3070",
+  "RTX3080", comma-tokenized "RTX, 3070") maps to GeForce — RTX is a tier, not
+  the family — while "RTX" itself is reserved for the professional
+  Quadro-successor line (RTX A2000 etc.) and bare context-less RTX tokens. A-/H-series chip tokens reject hyphen-glued silicon steppings
   ("N17M-Q3-A2", "GK104-400-A2") via a lookbehind — those mark a chip revision,
   never an Ampere/Hopper card. Architecture names (PASCAL spans Tesla AND
   Quadro) and bare models ("2080TI") are deliberately unmapped.
@@ -65,6 +68,14 @@ _GEFORCE = re.compile(r"\bGEFORCE\b")
 # lookahead accepts a glued digit OR a plain word boundary.
 _GTX = re.compile(r"\bGTX(?=\d|\b)")
 _RTX = re.compile(r"\bRTX(?=\d|\b)")
+# Consumer GeForce-RTX model adjacent to the RTX token: "RTX 3070", "RTX3080",
+# "NVIDIA, RTX, 3070" (comma-tokenized corpus rows; glued "RTX3080TI" passes via
+# the (?!\d) tail, which only forbids a FOURTH model digit). The x050–x090 shape
+# ([2-5]0[5-9]0) covers the consumer 2060…5090 lines and can never match the
+# professional Quadro-successor models — RTX A2000/A4000/… are "A"-prefixed and
+# RTX 4000/5000/6000 Ada / Quadro RTX 8000 are x000-shaped, so neither fits
+# [5-9] in the third digit.
+_RTX_CONSUMER = re.compile(r"\bRTX[,\s-]{0,2}[2-5]0[5-9]0(?!\d)")
 
 _CONTEXT = re.compile(r"\bNVIDIA\b|\bNVD\b|\bGDDR\dX?\b|\bHBM\d?\b")
 _MEM_GB = re.compile(r"\b(\d{1,3})\s?GB\b")
@@ -95,7 +106,13 @@ def _family_members(text: str) -> set[str]:
         if _GTX.search(text):
             members.add(GEFORCE)  # GTX is definitionally GeForce
         if _RTX.search(text):
-            members.add(RTX)
+            # The seeded enum carries BOTH "GeForce" and "RTX". Consumer RTX models
+            # (GeForce RTX 2060…5090) ARE the GeForce family — storing them under
+            # "RTX" fragments one physical family across two facet values (audit
+            # cards 583761 vs 560385). "RTX" is reserved for the professional
+            # Quadro-successor line (RTX A2000/A4000, RTX 4000 Ada, Quadro RTX
+            # 8000) and bare context-less RTX tokens.
+            members.add(GEFORCE if _RTX_CONSUMER.search(text) else RTX)
     return members
 
 

--- a/app/services/desc_extractor/memory.py
+++ b/app/services/desc_extractor/memory.py
@@ -12,7 +12,9 @@ Depends on: _common (SpecDict alias + unique_or_none helper) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - capacity_gb requires an explicit GB/G token and the seeded 1-512 range (MB-era
-  modules and bandwidth-per-second tokens never match).
+  modules and bandwidth-per-second tokens never match). GigaBIT component-density
+  tokens ("2Gb, 128*16" — lowercase b) are neutralized to "2GBIT" by extract_desc's
+  pre-uppercase _BIT_UNITS rewrite, so bits can never be recorded as bytes.
 - ddr_type from explicit DDR/DDR2/DDR3/DDR3L/DDR4/DDR5 tokens, or the PC3-/PC3L-/
   PC4-<digits> prefixes (PC3→DDR3, PC3L→DDR3L, PC4→DDR4). Mixed generations ⇒ omit.
 - speed_mhz only from an explicit MHz token (seed range 800-8400, so "DDR-333MHz"

--- a/app/services/mpn_decoder/storage.py
+++ b/app/services/mpn_decoder/storage.py
@@ -5,6 +5,12 @@ decoded only where the scheme expresses it unambiguously; usage_class only for w
 family codes. Anything uncertain is omitted, never guessed. RPM/interface are not reliably
 encoded in these MPNs, so they are left to later phases. SSD part-number schemes live in
 the sibling ssd.py (WD WDS…, Samsung MZ…, Kioxia, …); Seagate XA/ZA/Nytro remain undecoded.
+
+Legacy-era grammars (facet-accuracy audit 2026-06-10): the legacy WD decimal-GB scheme
+(WD800BB = 80 GB) IS decoded — its exactly-2-letter suffix is a certain era gate; legacy
+Seagate ST<ff><digits><iface> shapes and STMicroelectronics ST-prefixed order codes return
+None (the Seagate gate now requires the modern 0-led structured tail). A wrong capacity is
+worse than a missing one.
 """
 
 import re
@@ -20,10 +26,30 @@ UC_SURVEILLANCE = "Surveillance"
 UC_DESKTOP = "Desktop / Client"
 
 # ── Seagate ──────────────────────────────────────────────────────────────
-# Modern family-coded scheme: ST<capacityGB><FAMILY><rest>, e.g. ST4000NM0035 (4 TB),
-# ST16000NM001G (16 TB), ST1000DM010 (1 TB), ST500LM030 (500 GB). The OLD scheme
-# (ST3500418AS) has a digit after the capacity digits, so it never matches this gate.
-_SEAGATE = re.compile(r"^ST(\d{3,6})([A-Z]{2})")
+# Modern family-coded scheme ONLY: ST<capacityGB><FAMILY><0-led tail>, e.g.
+# ST4000NM0035 (4 TB), ST16000NM001G (16 TB), ST1000DM010 (1 TB), ST500LM030
+# (500 GB), ST300MM0006 (300 GB 2.5" SAS). The structured tail is the era gate:
+# every modern model ends <2 family letters> + a 3-4 char alphanumeric tail that
+# STARTS WITH "0" ("0035", "010", "001G", "0006"), anchored to end-of-string.
+# Legacy schemes cannot produce that shape:
+#   * old ST<ff-digit><digits><iface letters> models END at the interface letters
+#     (ST39103FC, ST373207LC, ST973402SS; ST3500418AS additionally has a digit
+#     glued to the letters), so they return None — their digit string mixes a
+#     form-factor digit with MB digits, and pre-~1996 models encode UNFORMATTED
+#     MB (ST3600N is a 525 MB drive), so no pattern-only grammar can split those
+#     eras with certainty. A wrong capacity is worse than a missing one.
+#   * STMicroelectronics order codes (ST232BDR, ST3232EBDR, ST485, STM32…) end in
+#     package/reel letters (D/N/P/W/T + R), never a 0-led tail — the ST-prefix
+#     collision that once decoded an RS-232 transceiver as a "232 GB drive" is
+#     structurally excluded, and _STMICRO_DENY below rejects those shapes outright
+#     as defense-in-depth (a future loosening of the accept gate must not silently
+#     re-admit the IC class).
+_SEAGATE = re.compile(r"^ST(\d{3,6})([A-Z]{2})(0[A-Z0-9]{2,3})$")
+# STMicro order-code deny-shapes: STM32/STM8 MCU prefixes, and short ST<digits>
+# codes ending in 0-4 package letters (+ optional reel "R") with no structured
+# tail (ST232BDR, ST485, ST3232EBDR). Real Seagate models never fit: their family
+# letters are always followed by the 0-led tail digits.
+_STMICRO_DENY = re.compile(r"^ST(?:M\d|\d{2,4}[A-Z]{0,4}R?$)")
 _SEAGATE_FAMILY = {
     "NM": (FF_35, UC_ENTERPRISE),  # Exos / Constellation enterprise
     "NE": (FF_35, UC_NAS),  # IronWolf Pro
@@ -38,6 +64,8 @@ _SEAGATE_FAMILY = {
 
 
 def _seagate(mpn: str) -> DecodeResult | None:
+    if _STMICRO_DENY.match(mpn):
+        return None
     m = _SEAGATE.match(mpn)
     if not m:
         return None
@@ -49,14 +77,34 @@ def _seagate(mpn: str) -> DecodeResult | None:
 
 
 # ── Western Digital (HDD) ────────────────────────────────────────────────
-# Modern scheme WD<cap><suffix> where cap is 2-3 digits = TB×10 (WD40 = 4 TB, WD140 = 14 TB).
-# The old 4-digit GB scheme (WD5000AAKX) and SSDs (WDS…) don't match: a 4th digit blocks
-# [A-Z]+, and WDS starts with a letter.
-# form_factor is taken ONLY from a recognized 3.5" family code (every entry in _WD_FAMILY is
-# a 3.5" line). The suffix's first letter is NOT a reliable form-factor signal — 2.5" mobile
-# drives use varied codes (WD10JPLX, WD…LPLX, WD…LPCX) that don't start "S", so the old
-# "S ⇒ 2.5"" rule mislabeled them 3.5". When no family matches we emit capacity only.
-_WD = re.compile(r"^WD(\d{2,3})([A-Z]+)")
+# TWO WD HDD grammars, era-split by the SUFFIX SHAPE (the digits alone are ambiguous):
+#
+# LEGACY decimal-GB scheme — WD<digits><EXACTLY two family letters> (then end or a
+# "-revision"): the digits are GB with an implied decimal before the last digit.
+# WD800BB = 80.0 GB, WD600BB = 60.0 GB, WD2500JB = 250 GB, WD360GD = 36 GB Raptor,
+# WD64AA = 6.4 GB. Every 2-letter WD family code (AA/BA/BB/JB/EB/GD/JD/KS/YR/UE…)
+# belongs to this pre-TB era — the TB era (WD10EACS onward, 2007+) always uses
+# 4-letter codes — so the exactly-2-letter suffix is a certain era gate. The naive
+# "digits × 100" read here was the audit's 1000× class (WD800BB → 80,000 GB).
+# 2-letter codes span 3.5" (BB/JB) and 2.5" (UE) lines, so legacy emits capacity ONLY.
+#
+# MODERN TB×10 scheme — WD<2-3 digits><4+ letter family code>: digits/10 = TB
+# (WD40EFRX = 4 TB, WD140EFGX = 14 TB). Capacity is emitted only when the era is
+# certain: a 2-digit form is always TB-era (the GB era's 4-letter-code parts were all
+# ≥36 GB ⇒ ≥3 digits), and a 3-digit form is TB-era only when the suffix carries a
+# recognized modern family token from _WD_FAMILY — without one, a 3-digit+4-letter
+# shape is ambiguous between eras (WD800AAJS = 80 GB vs WD140EFGX = 14 TB) and
+# returns None. The old 4-digit mixed scheme (WD5000AAKX = 500 GB, WD1002FAEX =
+# 1 TB — same shape, different units) never matches either gate.
+#
+# form_factor is taken ONLY from a recognized 3.5" family code (every entry in
+# _WD_FAMILY is a 3.5" line). The suffix's first letter is NOT a reliable form-factor
+# signal — 2.5" mobile drives use varied codes (WD10JPLX, WD…LPLX, WD…LPCX) that
+# don't start "S", so the old "S ⇒ 2.5"" rule mislabeled them 3.5". When no family
+# matches (but capacity is era-certain) we emit capacity only. SSDs (WDS…) start
+# with a letter and match neither gate.
+_WD_LEGACY = re.compile(r"^WD(\d{2,4})([A-Z]{2})(?![A-Z])")
+_WD_MODERN = re.compile(r"^WD(\d{2,3})([A-Z]{4,})")
 _WD_FAMILY = [  # ordered substring → usage_class (first match wins)
     ("EFR", UC_NAS),
     ("EFA", UC_NAS),
@@ -81,16 +129,29 @@ _WD_FAMILY = [  # ordered substring → usage_class (first match wins)
 
 
 def _wd(mpn: str) -> DecodeResult | None:
-    m = _WD.match(mpn)
+    m = _WD_LEGACY.match(mpn)
+    if m:
+        # Legacy decimal-GB era (see the grammar comment): digits / 10 = GB.
+        value = int(m.group(1)) / 10
+        capacity = int(value) if value == int(value) else value
+        return DecodeResult(commodity="hdd", vendor="Western Digital", specs={"capacity_gb": capacity})
+    m = _WD_MODERN.match(mpn)
     if not m:
         return None
-    specs: dict = {"capacity_gb": int(m.group(1)) * 100}  # TB×10 → GB
-    suffix = m.group(2)
+    digits, suffix = m.group(1), m.group(2)
+    specs: dict = {}
     for token, uc in _WD_FAMILY:
         if token in suffix:
             specs["usage_class"] = uc
             specs["form_factor"] = FF_35  # every family in _WD_FAMILY is a 3.5" line
             break
+    # TB×10 capacity only when the era is certain: any 2-digit form, or a 3-digit
+    # form whose suffix carries a recognized modern family token. An unrecognized
+    # 3-digit+4-letter shape (WD800AAJS = 80 GB legacy) stays ambiguous → no specs.
+    if len(digits) == 2 or "usage_class" in specs:
+        specs["capacity_gb"] = int(digits) * 100  # TB×10 → GB
+    if not specs:
+        return None
     return DecodeResult(commodity="hdd", vendor="Western Digital", specs=specs)
 
 

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -182,6 +182,7 @@ authoritative reference. Static-analysis tests in
 | `reenrich.py` | `python -m app.management.reenrich` | Re-run first-pass card enrichment (description/category/lifecycle) on existing cards |
 | `enrich_specs.py` | `python -m app.management.enrich_specs --limit N` | One-time / on-demand backfill of structured-spec extraction for cards missing `specs_enriched_at` |
 | `ingest_source_data.py` | `python -m app.management.ingest_source_data [--files GLOB] [--ai-correct] [--apply] [--limit N]` | SP-Ingest CLI: parse → clean → consolidate → (ai_correct) → ingest TRIO source files (SFDC part master + inventory sheets) into `material_cards` via the SP2 tier ladder. DRY RUN by default; `--apply` writes. |
+| `reconcile_decoded_facets.py` | `python -m app.management.reconcile_decoded_facets [--apply] [--limit N]` | Facet-accuracy reconcile: re-run the fixed MPN decoder + desc extractor over cards with mpn_decode/desc_parse facet rows for capacity_gb/gpu_family/memory_gb; corrects changed values (same source, newer ladder timestamp) and DELETES keys the fixed extractor no longer yields. DRY RUN by default with per-failure-class tallies; `--apply` writes. |
 
 ## TRIO Source Ingest (`app/services/source_ingest/`)
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -951,7 +951,13 @@ owns arbitration in one place:
        structural guards: wattage exists only on the power_supplies route while the
        cpu route emits tdp_watts (CPU "135W" TDP can never land in wattage), gpu
        memory_gb requires a GPU-context token (NVIDIA/GDDR/HBM/family hit) so NIC
-       "10GB"/"100GbE" rows emit nothing, and cpu bare cores/TDP tokens AND
+       "10GB"/"100GbE" rows emit nothing, gpu_family maps consumer RTX models
+       (x050–x090 adjacent to the RTX token, incl. comma-tokenized "RTX, 3070")
+       to GeForce and reserves the seeded "RTX" member for the professional
+       Quadro-successor line (RTX A2000, RTX 4000 Ada), bit-unit tokens
+       ("2Gb, 128*16" component densities — uppercase letter + lowercase b) are
+       neutralized BEFORE the upper-casing so bits are never recorded as GB
+       capacity (skipped, never ÷8-converted), and cpu bare cores/TDP tokens AND
        codename-only architecture require a CPU-context signal (MPN-echo descs
        and chassis rows emit nothing). Hinted extraction adds a body-token
        contradiction guard (a cpu-hinted motherboard FRU returns None; dram
@@ -1129,8 +1135,8 @@ Vendor/scheme inventory (module → gate → decoded keys):
 
 | Module | Vendor | Scheme gate (examples) | Decodes |
 |---|---|---|---|
-| storage.py | Seagate | `ST<GB><family>` (ST4000NM0035) | capacity, form_factor, usage_class |
-| storage.py | Western Digital | `WD<TB×10><family>` (WD40EFRX) | capacity, usage_class+form for known 3.5" families |
+| storage.py | Seagate | `ST<GB><family><0-led tail>$` (ST4000NM0035, ST300MM0006) — the structured 0-led tail is the era gate; legacy `ST<ff><digits><iface>` shapes (ST39103FC, ST373207LC) and STMicroelectronics order codes (ST232BDR, STM32… — explicit `_STMICRO_DENY`) return None | capacity, form_factor+usage_class for mapped families |
+| storage.py | Western Digital | era split by SUFFIX SHAPE: legacy `WD<digits><exactly 2 letters>` = decimal-GB (WD800BB = 80 GB, WD64AA = 6.4 GB, capacity only); modern `WD<2-3 digits><4+ letters>` = TB×10 (WD40EFRX), 3-digit forms only with a recognized family token (unrecognized 3-digit+4-letter and ALL 4-digit+4-letter shapes are era-ambiguous → None) | capacity, usage_class+form for known 3.5" families |
 | storage.py | Toshiba | `(MG\|MN\|MD\|MQ\|DT)\d{2}[A-Z]{3}` (MG08ACA16TE) | form_factor, usage_class, capacity from `<n>T` token |
 | storage.py | HGST/Hitachi | `HUH\|HUS(?=\d)\|HUC\|HTS\|HDN\|HDS\|HMS` | form_factor, usage_class, capacity from `<n>T` token; HUSMM/HUSSL SAS SSDs excluded |
 | ssd.py | Samsung | retail `MZ-<fam><cap>` (MZ-V8P2T0B/AM) + OEM `MZ<fam><cap>` (MZVL21T0HCLR, MZ7LH1T9HMLT, MZQL21T9HCJR, MZILT3T8HBLS) | capacity, form_factor (2.5"/M.2 2280/M.2 22110/U.2/mSATA), interface (SATA/SAS; NVMe gen only via pinned family tables), nand_type for retail EVO/QVO + V-table only |
@@ -1148,7 +1154,11 @@ Never guessed: NVMe PCIe generation outside the pinned tables (seeded `interface
 no bare "NVMe"), nand_type outside Samsung retail EVO/QVO/V-table, DDR5 voltage (1.1 V is
 deliberately not emitted), Hynix DDR3 voltage, ranks on 3DS/ambiguous org codes, Kingston
 KVR/KSM generation when the speed code is unmapped (DDR2-era parts — the D4 rank token must
-never be misread as DDR4). `rank`/`registered`/`voltage` are seeded `dram` spec schemas in
+never be misread as DDR4), legacy Seagate `ST<ff><digits><iface>` capacities (the digit
+string mixes a form-factor digit with MB digits and the pre-~1996 era encodes UNFORMATTED
+MB — no pattern-only era split exists, so those shapes return None; facet-accuracy audit
+2026-06-10, `tests/test_mpn_decoder_storage.py` pins the audit cards), and era-ambiguous
+WD shapes (3-digit+4-letter without a known modern family token, all 4-digit+4-letter). `rank`/`registered`/`voltage` are seeded `dram` spec schemas in
 `commodity_seeds.json` (the boot seeder inserts them idempotently — no migration needed);
 `tests/test_mpn_decoder_seed_sync.py` pins decoder↔seed sync, and `writer.py` logs an
 aggregate WARNING for BOTH of `record_spec`'s silent vocabulary drops — a decoded key with
@@ -1159,6 +1169,17 @@ their existing category conflicts with the decoded commodity are counted too
 (`skipped_category_conflict` in the per-batch stats, plus a WARNING with the
 `card_category->decoded_commodity` pairs — the number that says whether the
 category-alias map needs another entry).
+
+Reconciliation after a decoder/extractor fix: `python -m app.management.
+reconcile_decoded_facets [--apply] [--limit N]` re-runs the fixed decode + desc
+extraction over every card owning a facet row with source IN (mpn_decode,
+desc_parse) for the audit-affected spec_keys (capacity_gb/gpu_family/memory_gb).
+A DIFFERENT re-run value is re-recorded through `record_spec` under the SAME
+source (the F1 newest-timestamp tie-break lets the re-run win its own stale
+entry); a key the fixed extractor no longer yields is DELETED from both
+material_spec_facets and specs_structured (wrong is worse than missing —
+provenance stays honest). Dry-run by default with per-failure-class tallies
+(legacy_wd/legacy_seagate/stmicro_gate/gb_bit/rtx_family); SAVEPOINT per card.
 
 ## Cross-Reference Caching
 

--- a/tests/test_desc_extractor_gpu.py
+++ b/tests/test_desc_extractor_gpu.py
@@ -20,11 +20,21 @@ CASES = [
         {"gpu_family": "Tesla", "memory_gb": 32},
     ),
     (
+        # Consumer RTX model ⇒ GeForce (audit class 5): "RTX" is a tier, not the family —
+        # storing RTX here fragmented the GeForce RTX 30-series across two facet values.
         "MSI, RTX3080, 10G/D6X/3DP/H",  # neutral brand lead; glued 10G/D6X memory grammar
         "gpu",
-        {"gpu_family": "RTX", "memory_gb": 10},
+        {"gpu_family": "GeForce", "memory_gb": 10},
     ),
-    ("BLD RTX3060 12GB G6 3DP+H", "gpu", {"gpu_family": "RTX", "memory_gb": 12}),
+    ("BLD RTX3060 12GB G6 3DP+H", "gpu", {"gpu_family": "GeForce", "memory_gb": 12}),
+    # Audit card 583761: comma-tokenized consumer RTX row must land in the SAME family
+    # as the catalog's "GeForce RTX 3080" rows (card 560385) — GeForce, never "RTX".
+    ("NVIDIA, RTX, 3070", "gpu", {"gpu_family": "GeForce"}),  # audit card 583761
+    ("NVIDIA, RTX, 3080", "gpu", {"gpu_family": "GeForce"}),  # audit card 560385's family
+    # The professional Quadro-successor line keeps the seeded "RTX" member: A-prefixed
+    # and x000-shaped models never match the consumer x050–x090 shape.
+    ("NVIDIA RTX A2000 6GB", "gpu", {"gpu_family": "RTX", "memory_gb": 6}),
+    ("SPS-PCA NVIDIA RTX 4000 ADA 20GB", "gpu", {"gpu_family": "RTX", "memory_gb": 20}),
     (
         "GTX1660Super@6G/D6/DP/H/DVI",  # GTX is definitionally GeForce
         "gpu",

--- a/tests/test_desc_extractor_memory.py
+++ b/tests/test_desc_extractor_memory.py
@@ -97,6 +97,21 @@ CASES = [
         "Mem, 16GB DDR4 RDIMM 19.2GB/S",  # bandwidth-per-second token is not a 2nd capacity
         {"capacity_gb": 16, "ddr_type": "DDR4", "form_factor": "RDIMM", "ecc": True},
     ),
+    (
+        # Audit card 74143 (Samsung K4B2G1646F): "2Gb, 128*16" is a COMPONENT density in
+        # gigaBITS (lowercase b) — never capacity_gb=2 (an 8× error). Bit tokens are
+        # neutralized before upper-casing; component densities are skipped, not ÷8'd.
+        "Mem, DDR3, 2Gb, 128*16, Samsung",
+        {"ddr_type": "DDR3"},
+    ),
+    (
+        "Mem, 4Gb DDR4 256Mx16 component",  # same bit-unit class, different density
+        {"ddr_type": "DDR4"},
+    ),
+    (
+        "Mem, 2GB DDR3 UDIMM",  # uppercase GB is gigaBYTES — capacity records normally
+        {"capacity_gb": 2, "ddr_type": "DDR3", "form_factor": "UDIMM"},
+    ),
 ]
 
 

--- a/tests/test_mpn_decoder_storage.py
+++ b/tests/test_mpn_decoder_storage.py
@@ -12,10 +12,22 @@ CASES = [
     ("ST1000DM010", {"capacity_gb": 1000, "form_factor": '3.5"', "usage_class": "Desktop / Client"}, "hdd"),
     ("ST500LM030", {"capacity_gb": 500, "form_factor": '2.5"', "usage_class": "Desktop / Client"}, "hdd"),
     ("ST8000VN004", {"capacity_gb": 8000, "form_factor": '3.5"', "usage_class": "NAS"}, "hdd"),
+    # Seagate modern unmapped families: the structured 0-led tail certifies the era,
+    # so capacity still decodes even when the 2-letter family is not in the usage map.
+    ("ST300MM0006", {"capacity_gb": 300}, "hdd"),
+    ("ST1200MM0088", {"capacity_gb": 1200}, "hdd"),
     # Western Digital modern (TB×10 capacity, family from suffix)
     ("WD40EFRX", {"capacity_gb": 4000, "form_factor": '3.5"', "usage_class": "NAS"}, "hdd"),
     ("WD20EZRZ", {"capacity_gb": 2000, "form_factor": '3.5"', "usage_class": "Desktop / Client"}, "hdd"),
     ("WD140EFGX", {"capacity_gb": 14000, "form_factor": '3.5"', "usage_class": "NAS"}, "hdd"),
+    # Western Digital LEGACY decimal-GB scheme (exactly-2-letter family code): digits/10 GB.
+    # WD800BB / WD600BB are the audit's 1000×-error cards (3648, 622981) — 80 GB, not 80,000.
+    ("WD800BB", {"capacity_gb": 80}, "hdd"),  # audit card 3648
+    ("WD600BB", {"capacity_gb": 60}, "hdd"),  # audit card 622981
+    ("WD2500JB", {"capacity_gb": 250}, "hdd"),
+    ("WD360GD", {"capacity_gb": 36}, "hdd"),  # Raptor
+    ("WD64AA", {"capacity_gb": 6.4}, "hdd"),  # very-old Caviar: implied decimal survives
+    ("WD800BB-00JHC0", {"capacity_gb": 80}, "hdd"),  # dash revision after the 2-letter code
     # Toshiba — MG enterprise 3.5" with explicit TB token; MQ 2.5" form only
     ("MG08ACA16TE", {"capacity_gb": 16000, "form_factor": '3.5"', "usage_class": "Enterprise / Datacenter"}, "hdd"),
     ("MQ01ABD100", {"form_factor": '2.5"'}, "hdd"),
@@ -42,6 +54,51 @@ def test_storage_decode(mpn, expected, commodity):
 def test_old_seagate_scheme_not_misdecoded():
     # Old ST<ff><cap><rest> scheme must NOT match the modern gate (would misread capacity).
     assert decode_mpn("ST3500418AS") is None
+
+
+@pytest.mark.parametrize(
+    "mpn",
+    [
+        "ST39103FC",  # audit card 163617: 9.1 GB Cheetah 9LP — was misdecoded as 39,103 GB
+        "ST373207",  # audit card 195043: 73 GB Cheetah 10K.7 — was misdecoded as 373,207 GB
+        "ST373207LC",  # same drive, SCSI 80-pin suffix form
+        "ST373455LW",  # audit card 413156's evidence chain (same naive digit pathology)
+        "ST973402SS",  # legacy 2.5" SAS shape (digits 973402 are NOT a capacity)
+        "ST173404LW",  # ST1 half-height legacy shape
+    ],
+)
+def test_legacy_seagate_shapes_return_none(mpn):
+    # The legacy ST<ff-digit><digits><iface letters> grammar mixes a form-factor digit
+    # with MB digits, and pre-~1996 models encode UNFORMATTED MB — no pattern-only
+    # grammar can split the eras with certainty, so these must return None rather than
+    # ever emitting the raw digit string as GB (audit failure class 1).
+    assert decode_mpn(mpn) is None, f"{mpn} must not decode (legacy Seagate shape)"
+
+
+@pytest.mark.parametrize(
+    "mpn",
+    [
+        "ST232BDR",  # audit card 674852: STMicro RS-232 transceiver — was a "232 GB drive"
+        "ST3232EBDR",  # STMicro ST3232E, SO + reel
+        "ST485",  # STMicro RS-485 transceiver, bare order code
+        "STM32F407VGT6",  # STM32 MCU
+        "STM8S003F3P6",  # STM8 MCU
+    ],
+)
+def test_stmicro_order_codes_never_pass_the_seagate_gate(mpn):
+    # ST-prefix collision (audit failure class 2): STMicroelectronics order codes end in
+    # package/reel letters, never the modern Seagate 0-led structured tail — both the
+    # strengthened accept gate and the explicit deny-shape must reject them.
+    assert decode_mpn(mpn) is None, f"{mpn} is an STMicro part, not a Seagate drive"
+
+
+@pytest.mark.parametrize("mpn", ["WD800AAJS", "WD740ADFD", "WD5000AAKX", "WD1002FAEX"])
+def test_wd_ambiguous_era_shapes_return_none(mpn):
+    # 3-digit + 4-letter WD shapes without a recognized modern family token are ambiguous
+    # between the legacy decimal-GB era (WD800AAJS = 80 GB) and the TB era (WD140EFGX =
+    # 14 TB); the 4-digit + 4-letter scheme even mixes units (WD5000AAKX = 500 GB,
+    # WD1002FAEX = 1 TB). None of these may emit a capacity.
+    assert decode_mpn(mpn) is None, f"{mpn} is era-ambiguous — must not decode"
 
 
 def test_non_drive_mpn_returns_none():

--- a/tests/test_reconcile_decoded_facets.py
+++ b/tests/test_reconcile_decoded_facets.py
@@ -1,0 +1,171 @@
+"""The facet-accuracy reconcile command — dry-run parity, correction, and delete paths.
+
+Seeds cards with the PRE-FIX wrong facet values the 2026-06-10 audit found (written
+through record_spec exactly like production, then backdated so the re-run's newer
+timestamp wins the same-tier ladder), and asserts the reconcile command corrects,
+deletes, or leaves each row per its failure class.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.management.reconcile_decoded_facets import reconcile
+from app.models import MaterialCard, MaterialSpecFacet
+from app.services.commodity_registry import seed_commodity_schemas
+from app.services.spec_write_service import record_spec
+
+_OLD_TS = "2026-01-01T00:00:00+00:00"
+
+
+def _facets(db: Session, card_id: int) -> dict:
+    rows = db.query(MaterialSpecFacet).filter_by(material_card_id=card_id).all()
+    return {r.spec_key: (r.value_text if r.value_text is not None else r.value_numeric) for r in rows}
+
+
+def _card(db: Session, mpn: str, category: str, description: str | None = None) -> MaterialCard:
+    card = MaterialCard(normalized_mpn=mpn.lower(), display_mpn=mpn, category=category, description=description)
+    db.add(card)
+    db.flush()
+    return card
+
+
+def _seed_wrong(db: Session, card: MaterialCard, spec_key: str, value, source: str) -> None:
+    """Write a pre-fix facet value through record_spec, then backdate its timestamp so
+    the reconcile re-run (same source/tier/confidence, newer updated_at) wins the ladder
+    deterministically."""
+    confidence = 0.95 if source == "mpn_decode" else 0.90
+    assert record_spec(db, card.id, spec_key, value, source=source, confidence=confidence)
+    specs = dict(card.specs_structured)
+    specs[spec_key] = {**specs[spec_key], "updated_at": _OLD_TS}
+    card.specs_structured = specs
+    db.flush()
+
+
+def _seed_audit_cards(db: Session) -> dict[str, MaterialCard]:
+    seed_commodity_schemas(db)
+    cards = {
+        # class 1 — legacy WD 1000× error (audit card 3648): corrected 80000 → 80
+        "wd": _card(db, "WD800BB", "hdd"),
+        # class 2/3 — STMicro transceiver behind the old Seagate gate (card 674852): deleted
+        "stmicro": _card(db, "ST232BDR", "hdd"),
+        # class 1 — legacy Seagate digit-swallow (card 195043): now None → deleted
+        "seagate": _card(db, "ST373207LC", "hdd"),
+        # class 4 — Gb bit-density coerced to GB (card 74143): now skipped → deleted
+        "dram": _card(db, "K4B2G1646F", "dram", "Mem, DDR3, 2Gb, 128*16, Samsung"),
+        # class 5 — RTX consumer fragmentation (card 583761): corrected RTX → GeForce
+        "gpu": _card(db, "GPU3070OEM", "gpu", "NVIDIA, RTX, 3070"),
+        # control — modern Seagate decode is already right: must stay untouched
+        "modern": _card(db, "ST4000NM0035", "hdd"),
+    }
+    _seed_wrong(db, cards["wd"], "capacity_gb", 80000, "mpn_decode")
+    _seed_wrong(db, cards["stmicro"], "capacity_gb", 232, "mpn_decode")
+    _seed_wrong(db, cards["seagate"], "capacity_gb", 373207, "mpn_decode")
+    _seed_wrong(db, cards["dram"], "capacity_gb", 2, "desc_parse")
+    _seed_wrong(db, cards["gpu"], "gpu_family", "RTX", "desc_parse")
+    _seed_wrong(db, cards["modern"], "capacity_gb", 4000, "mpn_decode")
+    # The dram card's CORRECT desc-parsed key — outside TARGET_SPEC_KEYS, must survive.
+    assert record_spec(db, cards["dram"].id, "ddr_type", "DDR3", source="desc_parse", confidence=0.90)
+    db.commit()
+    return cards
+
+
+def test_dry_run_tallies_without_writing(db_session: Session):
+    cards = _seed_audit_cards(db_session)
+
+    summary = reconcile(db_session, apply=False)
+
+    assert summary["mode"] == "dry-run"
+    assert summary["corrected"] == 2  # WD capacity + RTX family
+    assert summary["deleted"] == 3  # STMicro + legacy Seagate + Gb-bit dram
+    assert summary["unchanged"] == 1  # modern Seagate control
+    assert summary["failed"] == 0
+    assert summary["by_class"]["legacy_wd"] == {"corrected": 1}
+    assert summary["by_class"]["stmicro_gate"] == {"deleted": 1}
+    assert summary["by_class"]["legacy_seagate"] == {"deleted": 1, "unchanged": 1}
+    assert summary["by_class"]["gb_bit"] == {"deleted": 1}
+    assert summary["by_class"]["rtx_family"] == {"corrected": 1}
+
+    # Dry-run wrote NOTHING: every wrong value and every facet row is still in place.
+    db_session.expire_all()
+    assert _facets(db_session, cards["wd"].id)["capacity_gb"] == 80000
+    assert _facets(db_session, cards["stmicro"].id)["capacity_gb"] == 232
+    assert _facets(db_session, cards["dram"].id)["capacity_gb"] == 2
+    assert _facets(db_session, cards["gpu"].id)["gpu_family"] == "RTX"
+
+
+def test_apply_corrects_deletes_and_matches_dry_run(db_session: Session):
+    cards = _seed_audit_cards(db_session)
+
+    dry = reconcile(db_session, apply=False)
+    applied = reconcile(db_session, apply=True)
+
+    # Dry-run parity: the read-only pass must predict apply mode exactly.
+    for key in ("cards", "facets", "corrected", "deleted", "unchanged", "skipped", "by_class"):
+        assert dry[key] == applied[key], f"dry-run/apply diverged on {key}"
+
+    db_session.expire_all()
+    # class 1 corrected: same source, newer ladder timestamp, right value.
+    assert _facets(db_session, cards["wd"].id)["capacity_gb"] == 80
+    wd_entry = cards["wd"].specs_structured["capacity_gb"]
+    assert wd_entry["value"] == 80
+    assert wd_entry["source"] == "mpn_decode"
+    assert wd_entry["updated_at"] > _OLD_TS
+    # classes 1/3/4 deleted: facet row AND specs_structured entry are gone.
+    for name in ("stmicro", "seagate", "dram"):
+        assert "capacity_gb" not in _facets(db_session, cards[name].id), name
+        assert "capacity_gb" not in (cards[name].specs_structured or {}), name
+    # the dram card's non-targeted desc_parse key survives (only capacity was wrong).
+    assert _facets(db_session, cards["dram"].id)["ddr_type"] == "DDR3"
+    # class 5 corrected: one family, the catalog-canonical one.
+    assert _facets(db_session, cards["gpu"].id)["gpu_family"] == "GeForce"
+    assert cards["gpu"].specs_structured["gpu_family"]["source"] == "desc_parse"
+    # control untouched, timestamp included (no churn on already-correct rows).
+    assert _facets(db_session, cards["modern"].id)["capacity_gb"] == 4000
+    assert cards["modern"].specs_structured["capacity_gb"]["updated_at"] == _OLD_TS
+
+
+def test_apply_is_idempotent(db_session: Session):
+    _seed_audit_cards(db_session)
+    first = reconcile(db_session, apply=True)
+    second = reconcile(db_session, apply=True)
+
+    assert first["corrected"] == 2 and first["deleted"] == 3
+    # Second pass finds the corrected rows already right and the deleted rows gone.
+    assert second["corrected"] == 0
+    assert second["deleted"] == 0
+    assert second["unchanged"] == 3  # wd + gpu (now right) + modern control
+
+
+def test_delete_skipped_when_jsonb_provenance_drifted(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "ST232BDR", "hdd")
+    _seed_wrong(db_session, card, "capacity_gb", 232, "mpn_decode")
+    # Simulate drift: the JSONB winner no longer belongs to the facet's source —
+    # the reconcile must never delete another source's value.
+    specs = dict(card.specs_structured)
+    specs["capacity_gb"] = {**specs["capacity_gb"], "source": "manual", "tier": 100}
+    card.specs_structured = specs
+    db_session.commit()
+
+    summary = reconcile(db_session, apply=True)
+
+    assert summary["deleted"] == 0
+    assert summary["skipped"] == 1
+    assert summary["by_class"]["stmicro_gate"] == {"skipped_provenance_mismatch": 1}
+    db_session.expire_all()
+    assert _facets(db_session, card.id)["capacity_gb"] == 232  # untouched
+    assert card.specs_structured["capacity_gb"]["source"] == "manual"
+
+
+def test_untargeted_sources_and_keys_are_never_selected(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "WD800BB", "hdd")
+    # A manual capacity (higher tier) is outside the source filter entirely.
+    assert record_spec(db_session, card.id, "capacity_gb", 80, source="manual", confidence=1.0)
+    db_session.commit()
+
+    summary = reconcile(db_session, apply=True)
+
+    assert summary["facets"] == 0
+    db_session.expire_all()
+    assert _facets(db_session, card.id)["capacity_gb"] == 80
+    assert card.specs_structured["capacity_gb"]["source"] == "manual"


### PR DESCRIPTION
## Facet-accuracy hotfix (audit 2026-06-10)

The live facet-accuracy audit (165 stratified rows) found **8 wrong rows in 4 deterministic-extraction failure classes**, with the hot cell at `mpn_decode × capacity_gb` (5/16 verified wrong). This PR fixes every class at the root, with **"a wrong facet is worse than a missing one"** as the bar: when a legacy scheme can't be decoded with certainty, the decoder returns `None`.

### The 8 audit rows → outcome under this PR

| Card | MPN / evidence | Key | Source | Was recorded | Now |
|---|---|---|---|---|---|
| 3648 | WD800BB | capacity_gb | mpn_decode | 80,000 GB | **80 GB** (legacy decimal-GB grammar) |
| 622981 | WD600BB | capacity_gb | mpn_decode | 60,000 GB | **60 GB** |
| 163617 | ST39103FC | capacity_gb | mpn_decode | 39,103 GB | **None** (legacy ST shape — see below) |
| 195043 | ST373207(LC) | capacity_gb | mpn_decode | 373,207 GB | **None** |
| 674852 | ST232BDR (STMicro RS-232 IC) | capacity_gb | mpn_decode | 232 GB | **None** (STMicro deny + structured-tail gate) |
| 74143 | Samsung K4B2G1646F, desc "2Gb, 128*16" | capacity_gb | desc_parse | 2 GB | **skipped** (gigaBITS component density, never coerced) |
| 583761 | desc "NVIDIA, RTX, 3070" | gpu_family | desc_parse | RTX | **GeForce** (consistent with card 560385) |
| 413156 | IBM FRU 32P0791 (ST373455-shaped matrix string) | capacity_gb | fru_matrix_decode | 373,455 GB | decoder now returns **None** for that shape (FRU rows reconcile via the crosswalk re-run, outside this command's source list) |

### Per-class fixes

1. **Legacy WD decimal-GB** (`app/services/mpn_decoder/storage.py`) — era split by *suffix shape*: an exactly-2-letter family code is certainly the pre-TB era (`WD800BB` → 80 GB, `WD64AA` → 6.4 GB, digits/10); modern TB×10 stays for 2-digit forms and 3-digit forms with a recognized modern family token. Era-ambiguous shapes (`WD800AAJS`, all 4-digit+4-letter like `WD5000AAKX`/`WD1002FAEX` which even mix units) → `None`.
2. **Legacy Seagate** — the gate now requires the modern structured tail: `ST<GB digits><2 family letters><0-led 3-4 char tail>$` (`ST4000NM0035`, `ST300MM0006`, `ST1200MM0088` — unmapped modern families still decode capacity). Legacy `ST<ff><digits><iface>` shapes return `None`: the digit string mixes a form-factor digit with MB digits and the pre-~1996 era encodes *unformatted* MB (`ST3600N` = 525 MB), so no pattern-only grammar can split the eras with certainty.
3. **ST-prefix collision** — STMicroelectronics order codes can't fit the 0-led tail, and an explicit `_STMICRO_DENY` shape (`STM\d…`, short `ST<digits><pkg letters>[R]$`) rejects them before the accept gate as defense-in-depth.
4. **Gb vs GB** (`app/services/desc_extractor/__init__.py`) — bit-unit tokens (uppercase letter + lowercase `b`: `2Gb`, `512Mb`) are neutralized to `<n>GBIT` **before** the upper-casing destroys the casing signal, so no capacity/memory regex can ever read bits as bytes. Component densities are skipped, never ÷8-converted. Covers memory, storage, and gpu readers in one place.
5. **gpu_family RTX fragmentation** (`app/services/desc_extractor/gpu.py`) — consumer RTX models (x050–x090 adjacent to the RTX token, incl. comma-tokenized `"RTX, 3070"` and glued `RTX3080TI`) map to **GeForce**; the seeded `RTX` member is reserved for the professional Quadro-successor line (`RTX A2000`, `RTX 4000 Ada` — A-prefixed/x000-shaped, structurally disjoint from the consumer shape).
6. **Reconciliation command** (`app/management/reconcile_decoded_facets.py`) — re-runs the fixed decoder + desc extractor over cards owning facet rows with `source IN (mpn_decode, desc_parse)` for `capacity_gb`/`gpu_family`/`memory_gb`. Different value → `record_spec` under the same source (the F1 newest-timestamp tie-break lets the re-run win its own stale entry); now-`None` keys → facet row + `specs_structured` entry **deleted** (provenance honest). Dry-run default with per-class tallies (`legacy_wd`/`legacy_seagate`/`stmicro_gate`/`gb_bit`/`rtx_family`), `--apply` to write, SAVEPOINT per card, provenance-mismatch delete guard. **Not run with `--apply` in this PR.**

### Tests (all 8 audit rows pinned verbatim)

- `tests/test_mpn_decoder_storage.py` — WD800BB→80 / WD600BB→60 / ST39103FC→None / ST373207(+LC)→None / ST232BDR→None / ST373455LW→None; legacy-vs-modern boundary (WD2500JB, WD64AA, WD360GD, dash-revision WD800BB-00JHC0; ambiguous WD800AAJS/WD740ADFD/WD5000AAKX/WD1002FAEX→None; modern keep-green incl. new ST300MM0006/ST1200MM0088); STMicro deny block (ST232BDR, ST3232EBDR, ST485, STM32F407VGT6, STM8S003F3P6).
- `tests/test_desc_extractor_memory.py` — "2Gb, 128*16" (card 74143) skips capacity; "4Gb 256Mx16" skips; uppercase "2GB" still records.
- `tests/test_desc_extractor_gpu.py` — "NVIDIA, RTX, 3070" (583761) and "RTX, 3080" (560385) → GeForce; RTX3080/RTX3060 pins updated to GeForce; RTX A2000 / RTX 4000 Ada keep `RTX` (both directions).
- `tests/test_reconcile_decoded_facets.py` — dry-run tallies with zero writes, dry-run/apply parity, correct/delete/unchanged paths, idempotency, provenance-mismatch delete guard, source/key selection scope.

Full suite: **15,629 passed, 35 skipped, 1 xfailed**. `pre-commit run --all-files` clean. APP_MAP_INTERACTIONS decoder inventory + APP_MAP_ARCHITECTURE management-command table updated.

### Rollout

After merge+deploy: `python -m app.management.reconcile_decoded_facets` (dry-run, review per-class tallies) → `--apply`. Audit recommendation 7 (re-sample the legacy-MPN stratum) applies afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
