### PR TITLE
fix(oem-drain): newest spare norms first within each demand bucket

### DIFF
--- a/app/management/backfill_oem_crosswalk.py
+++ b/app/management/backfill_oem_crosswalk.py
@@ -8,6 +8,7 @@ display_mpn classifies as *vendor*, ordered demand-first:
   (1) CPU-commodity cards with search_count > 0,
   (2) remaining CPU-commodity cards,
   (3) other commodities,
+newest spare numbers first within each bucket (see select_candidates),
 then resolves each via the Claude-grounded resolver and UPSERTS oem_crosswalk rows only
 (resolved or 90-day-negative no_match) — NO spec writes: the enrichment worker's Pass B
 back-fills cards deterministically as batches cycle. Designed to run ALONGSIDE the live
@@ -60,9 +61,13 @@ def select_candidates(db, vendor: str) -> list[tuple[str, str]]:
 
     Demand-first ordering per spec §5: (1) CPU-commodity cards with search_count > 0,
     (2) remaining CPU-commodity cards, (3) other commodities; search_count DESC then
-    norm within each bucket for determinism. Distinct by norm (a norm keeps its best
-    bucket across the cards sharing it). Does NOT filter by cache freshness — the
-    caller intersects with ``pending_resolution``.
+    norm DESCENDING within each bucket. Descending because OEM spare numbering grows
+    monotonically — L/P-series and high six-digit spares (modern, PartSurfer-covered,
+    tradeable) sort lexicographically AFTER 1990s Compaq-era numbers, which resolve to
+    near-universal no_match; ascending order front-loads the daily resolve budget with
+    dead stock for weeks. Distinct by norm (a norm keeps its best bucket across the
+    cards sharing it). Does NOT filter by cache freshness — the caller intersects with
+    ``pending_resolution``.
     """
     rows = (
         db.query(MaterialCard.display_mpn, MaterialCard.category, MaterialCard.search_count)
@@ -82,7 +87,11 @@ def select_candidates(db, vendor: str) -> list[tuple[str, str]]:
         key = (bucket, -searches, norm, str(display_mpn))
         if norm not in best or key < best[norm]:
             best[norm] = key
-    return [(norm, display) for _b, _s, norm, display in sorted(best.values())]
+    # Newest spares first within each bucket: norm DESC, then a stable re-sort on
+    # (bucket, -search_count) so bucket priority still dominates.
+    ordered = sorted(best.values(), key=lambda k: k[2], reverse=True)
+    ordered.sort(key=lambda k: (k[0], k[1]))
+    return [(norm, display) for _b, _s, norm, display in ordered]
 
 
 async def run(vendor: str, limit: int | None, dry_run: bool) -> int:

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -917,7 +917,9 @@ migration 100, spec: SPEC_OEM_WEB_RESOLUTION):
     (our code never opens an HTTP connection to the OEM; the only failure surface is
     the Claude API). The paced drain CLI `python -m
     app.management.backfill_oem_crosswalk --vendor hpe [--limit N] [--dry-run]`
-    resolves+upserts rows only (demand-first: cpu+searched, cpu, rest), billing the
+    resolves+upserts rows only (demand-first: cpu+searched, cpu, rest; newest spare
+    norms first within each bucket — Compaq-era numbers are near-universal no_match
+    and must not front-load the daily budget), billing the
     SAME two counters the same atomic way, re-checking pending_resolution per item
     (a norm the worker cached mid-run is skipped, not re-billed), tolerating
     IntegrityError at its per-row commit (rollback + continue), >=2s between calls,

--- a/tests/test_backfill_oem_crosswalk.py
+++ b/tests/test_backfill_oem_crosswalk.py
@@ -138,6 +138,19 @@ def test_select_candidates_demand_first_ordering(db_session: Session):
     assert [norm for norm, _ in ordered] == ["444444001", "333333001", "222222001", "111111001"]
 
 
+def test_select_candidates_newest_spares_first_within_bucket(db_session: Session):
+    # Equal bucket + search_count → norm DESCENDING: L-series before high six-digit
+    # before Compaq-era numbers (modern spares resolve; 1990s ones are near-universal
+    # no_match and must not front-load the daily budget).
+    _card(db_session, "013218-001", category="cpu", search_count=0)
+    _card(db_session, "873647-001", category="cpu", search_count=0)
+    _card(db_session, "L99783-001", category="cpu", search_count=0)
+
+    ordered = select_candidates(db_session, "hpe")
+
+    assert [norm for norm, _ in ordered] == ["l99783001", "873647001", "013218001"]
+
+
 def test_select_candidates_dedupes_norms_keeping_best_bucket(db_session: Session):
     # Two cards sharing a spare norm (display variants) collapse to ONE candidate in
     # the best (lowest) bucket.
@@ -283,12 +296,14 @@ def test_run_recheck_skips_norm_cached_by_concurrent_worker(db_session: Session)
     b = _hpe_card(db_session, "875941-001")
     assert a and b
 
+    # Norms drain newest-first, so 875941001 resolves first; the worker races in a
+    # row for the still-pending 875940001.
     async def racing_resolve(display, norm, vendor):
-        if norm == "875940001":
+        if norm == "875941001":
             db_session.add(
                 OemCrosswalk(
-                    spare_raw="875941-001",
-                    spare_norm="875941001",
+                    spare_raw="875940-001",
+                    spare_norm="875940001",
                     vendor="hpe",
                     status=OemCrosswalkStatus.NO_MATCH,
                     looked_up_at=datetime.now(timezone.utc),
@@ -303,7 +318,7 @@ def test_run_recheck_skips_norm_cached_by_concurrent_worker(db_session: Session)
 
     assert attempted == 1  # the second norm was skipped before billing
     assert resolve_mock.await_count == 1
-    assert db_session.query(OemCrosswalk).filter_by(spare_norm="875941001").count() == 1
+    assert db_session.query(OemCrosswalk).filter_by(spare_norm="875940001").count() == 1
     assert counters == {"web_calls": 1, "oem_resolves": 1}
 
 
@@ -317,12 +332,14 @@ def test_run_integrity_error_at_commit_rolls_back_and_continues(db_session: Sess
     _hpe_card(db_session, "875941-001")
 
     async def racing_resolve(display, norm, vendor):
-        if norm == "875940001":
+        # Norms drain newest-first: the collision hits the FIRST item (875941001) so
+        # the run's continuation to the next item is what gets exercised.
+        if norm == "875941001":
             # Same edge (spare_norm, vendor, source_domain) the CLI is about to write.
             db_session.execute(
                 text(
                     "INSERT INTO oem_crosswalk (spare_raw, spare_norm, vendor, status, canonical_mpn_raw, "
-                    "canonical_mpn_norm, source_domain, looked_up_at) VALUES ('875940-001', '875940001', 'hpe', "
+                    "canonical_mpn_norm, source_domain, looked_up_at) VALUES ('875941-001', '875941001', 'hpe', "
                     "'resolved', 'ST4000NM0035', 'st4000nm0035', 'partsurfer.hp.com', '2026-06-10')"
                 )
             )
@@ -337,5 +354,5 @@ def test_run_integrity_error_at_commit_rolls_back_and_continues(db_session: Sess
     # In this single-session simulation the rollback discards the racing row too (in
     # prod the worker committed it from its own session, so it survives); the pinned
     # contracts are: no duplicate edge, and the NEXT item still committed.
-    assert db_session.query(OemCrosswalk).filter_by(spare_norm="875940001").count() == 0
-    assert db_session.query(OemCrosswalk).filter_by(spare_norm="875941001").count() == 1
+    assert db_session.query(OemCrosswalk).filter_by(spare_norm="875941001").count() == 0
+    assert db_session.query(OemCrosswalk).filter_by(spare_norm="875940001").count() == 1


### PR DESCRIPTION
## Why
First live smoke of the PartSurfer drain (post-#268 deploy) resolved its 5 candidates from the head of the queue — all 1990s Compaq-era CPU spares (013218-001, 094603-000, 100613-xxx) — and went 5/5 no_match. The cpu bucket drains in ascending norm order, so the 40/day budget would burn for weeks on dead stock before reaching modern, resolvable, tradeable spares.

## What
- `select_candidates` within-bucket tiebreak flipped to norm **descending** (stable two-pass sort; bucket priority and search_count DESC still dominate). L/P-series and high six-digit spares now drain first.
- Ordering pin test added; the two race-simulation tests re-targeted to the new processing order (they encoded ascending order in their fixtures).
- Docstrings + APP_MAP_INTERACTIONS updated.

## Verification
- `tests/test_backfill_oem_crosswalk.py` 14/14; full suite 15,951 passed / 35 skipped / 1 xfailed; pre-commit clean ×2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)