### PR TITLE
fix(materials): repoint Has-alternates to the FRU crosswalk (2 → 9,400 cards)

### DIFF
--- a/app/services/faceted_search_service.py
+++ b/app/services/faceted_search_service.py
@@ -9,11 +9,11 @@ Depends on: MaterialCard, MaterialSpecFacet, CommoditySpecSchema
 from datetime import datetime, timedelta, timezone
 from typing import NamedTuple
 
-from sqlalchemy import Text, cast, exists, func, or_
+from sqlalchemy import Text, and_, cast, exists, func, or_
 from sqlalchemy.orm import Session
 
 from app.constants import MaterialEnrichmentStatus
-from app.models import CommoditySpecSchema, MaterialCard, MaterialSpecFacet, MaterialVendorHistory
+from app.models import CommoditySpecSchema, FruLink, MaterialCard, MaterialSpecFacet, MaterialVendorHistory
 from app.utils.search_builder import SearchBuilder
 
 # Max distinct values rendered for an open-vocabulary (no enum_values) enum facet.
@@ -38,6 +38,34 @@ _INTERNAL_MODE_PREDICATES = {
 INTERNAL_FILTER_VALUES = ("all", *_INTERNAL_MODE_PREDICATES)  # "all" = no-op sentinel
 SEARCHED_WITHIN_DAYS = {"7d": 7, "30d": 30, "90d": 90}
 SEARCHED_WITHIN_VALUES = ("any", *SEARCHED_WITHIN_DAYS)  # "any" = no-op sentinel
+
+
+def has_crosses_predicate():
+    """The single "Has alternates" predicate — share it across every count/list path.
+
+    A card has alternates when its ``normalized_mpn`` appears in the FRU crosswalk
+    (``fru_links``) in EITHER direction — as the FRU (``fru_norm``) or as the related
+    part (``related_norm``) — OR when its manual ``cross_references`` JSON holds a
+    non-empty list. Both sides of the fru_links join are key-normalized
+    (``normalize_mpn_key``): ``fru_norm``/``related_norm`` by the FRU-matrix ingest and
+    ``normalized_mpn`` by the card ingest, so direct equality is the canonical join
+    (same contract as fru_crosswalk_enrich / fru_matrix_service).
+
+    Two separate ORed EXISTS (not one EXISTS with an OR inside) is deliberate:
+    PostgreSQL turns each into a hashed SubPlan fed by a single index-only scan of
+    ix_fru_links_fru_norm / ix_fru_links_related_norm, instead of a per-row correlated
+    probe. The cross_references branch keeps the portable non-empty-JSON-list test:
+    PG jsonb::text renders an empty array as '[]' and a JSON null as 'null'; SQLite
+    stores json.dumps() output, which matches the same literals.
+    """
+    return or_(
+        exists().where(FruLink.fru_norm == MaterialCard.normalized_mpn),
+        exists().where(FruLink.related_norm == MaterialCard.normalized_mpn),
+        and_(
+            MaterialCard.cross_references.isnot(None),
+            cast(MaterialCard.cross_references, Text).notin_(("[]", "null", "")),
+        ),
+    )
 
 
 def _apply_facet_filters(
@@ -283,8 +311,9 @@ def search_materials_faceted(
             ("has vendor sightings / stock seen").
         has_price: When True, restrict to cards with a vendor-history row carrying a
             recorded last_price.
-        has_crosses: When True, restrict to cards whose cross_references JSON holds a
-            non-empty list (portable across PostgreSQL JSONB and SQLite JSON-as-text).
+        has_crosses: When True, restrict to cards with at least one known alternate —
+            a fru_links crosswalk edge on normalized_mpn (either direction) OR a
+            non-empty cross_references JSON list (see has_crosses_predicate).
         internal: Tri-state — "all" (no-op), "standard" (is_internal_part FALSE/NULL),
             "internal" (is_internal_part TRUE). Unknown values degrade to "all".
         searched_within: Recency bucket on last_searched_at — "7d" | "30d" | "90d" |
@@ -376,14 +405,7 @@ def search_materials_faceted(
             )
         )
     if has_crosses:
-        # Portable non-empty-JSON-list predicate: PG jsonb::text renders an empty array
-        # as '[]' and a JSON null as 'null'; SQLite stores json.dumps() output, which
-        # matches the same literals. Avoids PG-only jsonb_array_length() that SQLite
-        # tests would silently mis-handle.
-        query = query.filter(
-            MaterialCard.cross_references.isnot(None),
-            cast(MaterialCard.cross_references, Text).notin_(("[]", "null", "")),
-        )
+        query = query.filter(has_crosses_predicate())
     internal_predicate = _INTERNAL_MODE_PREDICATES.get(internal)
     if internal_predicate is not None:
         query = query.filter(internal_predicate())

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1876,8 +1876,15 @@ Sidebar facets (workspace.html + materialsFilter Alpine component) — COMMODITY
     |     /v2/partials/materials/faceted → search_materials_faceted():
     |       has_stock   (EXISTS MaterialVendorHistory row)
     |       has_price   (EXISTS row with last_price IS NOT NULL)
-    |       has_crosses (cross_references holds a non-empty list; portable text-cast
-    |                    predicate — identical on PG JSONB and SQLite JSON-as-text)
+    |       has_crosses ("Has alternates" — has_crosses_predicate(), the single
+    |                    shared predicate for every list/count path: EXISTS fru_links
+    |                    on normalized_mpn in EITHER direction (fru_norm OR
+    |                    related_norm; two separate ORed EXISTS so PG plans hashed
+    |                    SubPlans over ix_fru_links_fru_norm/_related_norm — both
+    |                    sides are normalize_mpn_key form, direct equality is the
+    |                    canonical join) OR cross_references holds a non-empty list
+    |                    (portable text-cast predicate — identical on PG JSONB and
+    |                    SQLite JSON-as-text))
     |       internal    (tri-state all|standard|internal on is_internal_part; default
     |                    `all` — deliberately not `standard` — so first load never
     |                    silently drops rows)

--- a/tests/test_faceted_search_service.py
+++ b/tests/test_faceted_search_service.py
@@ -816,3 +816,106 @@ def test_get_commodity_spec_coverage(db_session: Session):
     # Case-insensitive commodity key, and an unknown commodity yields zeros.
     assert get_commodity_spec_coverage(db_session, "  DRAM ") == SpecCoverage(with_specs=1, total=2)
     assert get_commodity_spec_coverage(db_session, "nonexistent_xyz") == SpecCoverage(with_specs=0, total=0)
+
+
+# --- "Has alternates" (has_crosses): fru_links crosswalk OR manual cross_references ---
+
+
+def _cross_card(db, mpn, **kw):
+    card = MaterialCard(
+        normalized_mpn=mpn,
+        display_mpn=mpn.upper(),
+        category=kw.pop("category", "hdd"),
+        created_at=datetime.now(timezone.utc),
+        **kw,
+    )
+    db.add(card)
+    db.flush()
+    return card
+
+
+def _fru_edge(db, fru_norm, related_norm, kind=None):
+    from app.constants import FruLinkKind
+    from app.models import FruLink
+
+    link = FruLink(
+        fru_raw=fru_norm.upper(),
+        fru_norm=fru_norm,
+        related_raw=related_norm.upper(),
+        related_norm=related_norm,
+        rel_kind=(kind or FruLinkKind.MFG_MODEL).value,
+        source_sheet="Main",
+    )
+    db.add(link)
+    db.flush()
+    return link
+
+
+def test_has_crosses_matches_fru_links_both_directions(db_session: Session):
+    """A card matches when its normalized_mpn sits on EITHER side of a fru_links
+    edge."""
+    _cross_card(db_session, "00aj001")  # FRU side (fru_norm)
+    _cross_card(db_session, "st9300603ss")  # related side (related_norm)
+    _cross_card(db_session, "lonely001")  # no edges, no cross_references
+    _fru_edge(db_session, "00aj001", "st9300603ss")
+    db_session.flush()
+
+    results, total = search_materials_faceted(db_session, has_crosses=True)
+    assert total == 2
+    assert {r.normalized_mpn for r in results} == {"00aj001", "st9300603ss"}
+
+
+def test_has_crosses_keeps_manual_cross_references_branch(db_session: Session):
+    """A card with manual cross_references but NO fru_links edge still matches (OR
+    branch)."""
+    _cross_card(db_session, "manualx01", cross_references=[{"mpn": "ALT-1"}])
+    _cross_card(db_session, "emptycross", cross_references=[])  # empty list is NOT an alternate
+    _cross_card(db_session, "nullcross", cross_references=None)
+    db_session.flush()
+
+    results, total = search_materials_faceted(db_session, has_crosses=True)
+    assert total == 1
+    assert results[0].normalized_mpn == "manualx01"
+
+
+def test_has_crosses_excludes_unrelated_and_is_noop_when_false(db_session: Session):
+    """No fru_links edge + no cross_references -> excluded; has_crosses=False filters
+    nothing."""
+    _cross_card(db_session, "plain001")
+    _cross_card(db_session, "plain002")
+    db_session.flush()
+
+    _, total_filtered = search_materials_faceted(db_session, has_crosses=True)
+    assert total_filtered == 0
+
+    _, total_all = search_materials_faceted(db_session, has_crosses=False)
+    assert total_all == 2
+
+
+def test_has_crosses_count_consistent_and_dedups_overlap(db_session: Session):
+    """Total == len(results): a card matched by BOTH fru_links AND cross_references
+    counts once."""
+    _cross_card(db_session, "bothways1", cross_references=[{"mpn": "ALT-9"}])
+    _fru_edge(db_session, "bothways1", "wd4000fyyz")
+    # The edge's related side has no card row -- the EXISTS must not invent results.
+    _cross_card(db_session, "plain003")
+    db_session.flush()
+
+    results, total = search_materials_faceted(db_session, has_crosses=True)
+    assert total == len(results) == 1
+    assert results[0].normalized_mpn == "bothways1"
+
+
+def test_has_crosses_predicate_shared_by_list_and_count(db_session: Session):
+    """The list rows and the total come from the same predicate under combined
+    filters."""
+    fru_card = _cross_card(db_session, "00fruhdd1", category="hdd")
+    _cross_card(db_session, "00fruram1", category="dram")  # crossed, wrong commodity
+    _cross_card(db_session, "nocross01", category="hdd")  # right commodity, no alternates
+    _fru_edge(db_session, "00fruhdd1", "st4000nm0023")
+    _fru_edge(db_session, "00fruram1", "m393a2g40db1")
+    db_session.flush()
+
+    results, total = search_materials_faceted(db_session, commodity="hdd", has_crosses=True)
+    assert total == len(results) == 1
+    assert results[0].id == fru_card.id


### PR DESCRIPTION
## Summary

**OPTIMIZATION_PLAN_2026_06_12 §2 item 1.5 PR-A** (evidence: EVIDENCE_MAP_2026_06_12 `filter_ux`).

The "Has alternates" sourcing filter (`has_crosses`) matched only `MaterialCard.cross_references` — **2 live cards** — while the FRU crosswalk (`fru_links`, 54,456 edges) joins **9,398 live cards** by `normalized_mpn`. A 4,700× understatement: the filter looked dead while the data was live.

## What changed

- **`app/services/faceted_search_service.py`** — new module-level `has_crosses_predicate()`: `EXISTS` against `fru_links` on the card's `normalized_mpn` in **either direction** (`fru_norm` OR `related_norm`), OR-ed with the existing portable non-empty `cross_references` JSON branch (a card with manual cross_references but no fru_links still matches). The `search_materials_faceted` list rows and `total` count share one query object, so list/count consistency holds by construction; the helper is module-level for any future count path.
- **Join correctness (canonical normalization):** both `fru_links.fru_norm`/`related_norm` (FRU-matrix ingest) and `material_cards.normalized_mpn` (card ingest) are `normalize_mpn_key` form — verified live: direct equality, `lower()`, and full key-normalization joins all return exactly **9,398**. Direct equality is the canonical join, same contract as `fru_crosswalk_enrich` / `fru_matrix_service`.
- **`docs/APP_MAP_INTERACTIONS.md`** — sourcing-signals facet predicate note updated.
- **Tests** — 5 new service tests: fru_links match in each direction, manual cross_references OR-branch kept, empty/null cross_references and unlinked cards excluded, `total == len(results)` with overlap dedup, and list/count predicate consistency under combined commodity+has_crosses filters.

## Live before/after (read-only, measured against live PG)

| Predicate | Cards |
|---|---|
| **Before** — `cross_references` non-empty only | **2** |
| **After** — fru_links either direction OR cross_references | **9,400** |
| (fru_links-only component) | 9,398 |

(9,398 via crosswalk + 2 cross_references-only; disjoint sets — matches the plan's expected 2 → ~9,398.)

## Performance / EXPLAIN (exact ORM-emitted SQL, live PG)

Two **separate ORed EXISTS** (not one EXISTS with an OR inside) is deliberate: PostgreSQL plans each as a **hashed SubPlan** fed by a single **Index Only Scan** of the existing `ix_fru_links_fru_norm` / `ix_fru_links_related_norm` — no per-row correlated probes, **no seq scan on fru_links**.

- List page (`ORDER BY search_count DESC, created_at DESC LIMIT 50`): **42 ms** (Index Scan `ix_mc_order_live` + hashed-subplan filter, 50 rows after 442 examined).
- Count query: **~1.1 s** (unavoidable seq scan of the 743k-row `material_cards`, as with the old predicate; both fru_links probes are index-only, executed once each).

**No migration:** the directive's index gate was "seq scan on fru_links for the EXISTS" — the plan shows none; existing ingest-created indexes cover it. (The orchestrator's registry note assigning 106 to this branch was left unconsumed/reverted since no number was claimed.)

## Verification

- Full suite: **16,223 passed**, 35 skipped, 1 xfailed.
- `pre-commit run --all-files` twice (first mutated pre-existing docstring drift in 3 untouched test files — reverted per the changed-files gate, not bundled; second pass clean; changed files independently clean).
- Final SQL verified against **live PostgreSQL**, not just the SQLite suite (`feedback_sqlite_masks_postgres`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)