### PR TITLE
feat(sightings): bulk cross-requisition RFQ composer + per-requisition tracking fix (Track B)

### DIFF
--- a/app/connectors/email_mining.py
+++ b/app/connectors/email_mining.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta, timezone
 from loguru import logger
 from sqlalchemy.exc import IntegrityError
 
+from app.shared_constants import RFQ_SUBJECT_TAG_RE
 from app.utils.graph_client import GraphSyncStateExpired
 
 # Common stock list file extensions
@@ -57,8 +58,8 @@ WEBSITE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# Subject token pattern: [ref:{req_id}] (new) or [AVAIL-{req_id}] (legacy)
-AVAIL_TOKEN_RE = re.compile(r"\[(?:ref:|AVAIL-)(\d+)\]")
+# Subject token pattern lives in shared_constants.RFQ_SUBJECT_TAG_RE (single
+# source of truth — [ref:{req_id}] current, [AVAIL-{req_id}] legacy).
 
 # Fields requested from Graph API for messages
 MSG_SELECT = "id,subject,from,receivedDateTime,body,hasAttachments,conversationId"
@@ -516,8 +517,9 @@ class EmailMiner:
             msg_id = msg.get("id", "")
             subject = msg.get("subject", "")
 
-            # Only care about AVAIL-tagged RFQs
-            token_match = AVAIL_TOKEN_RE.search(subject)
+            # Only care about AVAIL-tagged RFQs (presence-only check, so a
+            # multi-token cross-requisition subject matches just the same)
+            token_match = RFQ_SUBJECT_TAG_RE.search(subject)
             if not token_match:
                 # Still mark as processed to avoid re-scanning
                 self._mark_processed(msg_id, "sent_scan")

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -40,7 +40,7 @@ def _build_html_body(plain_text: str) -> str:
 
 def _create_contact(
     db: Session,
-    requisition_id: int,
+    requisition_id: int | None,
     user_id: int,
     vendor_name: str,
     vendor_email: str,
@@ -80,8 +80,9 @@ async def send_batch_rfq(
     token: str,
     db: Session,
     user_id: int,
-    requisition_id: int,
-    vendor_groups: list[dict],
+    requisition_id: int | None = None,
+    vendor_groups: list[dict] | None = None,
+    requisition_parts_map: dict[int, list] | None = None,
 ) -> list[dict]:
     """Send one RFQ email per vendor group.
 
@@ -89,14 +90,41 @@ async def send_batch_rfq(
     Returns one result dict per requested vendor, each tagged ``status``:
     ``"sent"``, ``"failed"`` (a send was attempted but errored), or ``"skipped"``
     (no contact email on file — no email attempted, no Contact created).
+
+    Cross-requisition tracking: when ``requisition_parts_map`` ({requisition_id:
+    parts}) is provided, ONE email still goes out per vendor, but one Contact row
+    is written per (requisition, vendor) pair — each scoped to that requisition's
+    parts, all sharing the email's graph_message_id/graph_conversation_id — and
+    the subject carries one ``[ref:{id}]`` token per requisition (ascending id
+    order, so preview and send stay deterministic and identical).
+
+    Legacy shim: without the map, the scalar ``requisition_id`` behaves exactly
+    as before (one Contact per vendor, parts taken from each vendor group) —
+    callers like htmx_views.rfq_send need no change.
     """
     from app.utils.graph_client import GraphClient
+
+    vendor_groups = vendor_groups or []
+    # Legacy scalar shim: a missing/empty map means single-requisition mode where
+    # each Contact's parts come from its vendor group (byte-identical behavior).
+    parts_map: dict[int, list] = requisition_parts_map or {}
+    legacy_mode = not parts_map
+    req_ids: list[int | None] = [requisition_id] if legacy_mode else sorted(parts_map)
+
+    def _per_req_parts(group: dict) -> list[tuple[int | None, list]]:
+        """(requisition_id, parts) pairs to write Contacts for, per vendor."""
+        if legacy_mode:
+            return [(requisition_id, group.get("parts", []))]
+        return [(rid, parts_map[rid]) for rid in req_ids if rid is not None]
 
     gc = GraphClient(token)
     results = []
 
-    # Build payloads and send all emails in parallel
-    avail_token = f"[ref:{requisition_id}]"
+    # Build payloads and send all emails in parallel. One token per involved
+    # requisition, ascending id — identical to the sightings preview. A None
+    # requisition (degenerate legacy call) yields no token at all, matching the
+    # preview's untagged subject.
+    avail_token = " ".join(f"[ref:{rid}]" for rid in req_ids if rid is not None)
     send_tasks = []
     send_groups = []  # Track which groups we're sending for
 
@@ -147,8 +175,9 @@ async def send_batch_rfq(
 
     send_results = await asyncio.gather(*[_throttled_send(task) for task in send_tasks], return_exceptions=True)
 
-    # Process results: create Contact records, then batch-lookup sent message IDs
-    contacts_to_lookup = []  # (contact, tagged_subject) pairs
+    # Process results: create Contact records (one per involved requisition per
+    # vendor), then batch-lookup sent message IDs
+    contacts_to_lookup = []  # (contacts_for_one_vendor, tagged_subject) pairs
     for group, send_result in zip(send_groups, send_results):
         email = group["vendor_email"]
         tagged_subject = group.pop("_tagged_subject")
@@ -156,21 +185,24 @@ async def send_batch_rfq(
         if isinstance(send_result, Exception):
             logger.error(f"Send error to {email}: {send_result}")
             err_msg = str(send_result)[:500]
-            failed_contact = _create_contact(
-                db,
-                requisition_id,
-                user_id,
-                group["vendor_name"],
-                email,
-                group.get("parts", []),
-                tagged_subject,
-                group["body"],
-                "failed",
-                err_msg,
-            )
+            failed_contacts = [
+                _create_contact(
+                    db,
+                    rid,
+                    user_id,
+                    group["vendor_name"],
+                    email,
+                    parts,
+                    tagged_subject,
+                    group["body"],
+                    "failed",
+                    err_msg,
+                )
+                for rid, parts in _per_req_parts(group)
+            ]
             results.append(
                 {
-                    "id": failed_contact.id,
+                    "id": failed_contacts[0].id if failed_contacts else None,
                     "vendor_name": group["vendor_name"],
                     "vendor_email": email,
                     "status": "failed",
@@ -182,21 +214,24 @@ async def send_batch_rfq(
         if "error" in send_result:
             logger.error(f"Send failed to {email}: {send_result}")
             err_msg = str(send_result.get("detail", ""))[:500]
-            failed_contact = _create_contact(
-                db,
-                requisition_id,
-                user_id,
-                group["vendor_name"],
-                email,
-                group.get("parts", []),
-                tagged_subject,
-                group["body"],
-                "failed",
-                err_msg,
-            )
+            failed_contacts = [
+                _create_contact(
+                    db,
+                    rid,
+                    user_id,
+                    group["vendor_name"],
+                    email,
+                    parts,
+                    tagged_subject,
+                    group["body"],
+                    "failed",
+                    err_msg,
+                )
+                for rid, parts in _per_req_parts(group)
+            ]
             results.append(
                 {
-                    "id": failed_contact.id,
+                    "id": failed_contacts[0].id if failed_contacts else None,
                     "vendor_name": group["vendor_name"],
                     "vendor_email": email,
                     "status": "failed",
@@ -205,53 +240,67 @@ async def send_batch_rfq(
             )
             continue
 
-        contact = _create_contact(
-            db,
-            requisition_id,
-            user_id,
-            group["vendor_name"],
-            email,
-            group.get("parts", []),
-            tagged_subject,
-            group["body"],
-            "sent",
-        )
-        contacts_to_lookup.append((contact, tagged_subject))
+        contacts = [
+            _create_contact(
+                db,
+                rid,
+                user_id,
+                group["vendor_name"],
+                email,
+                parts,
+                tagged_subject,
+                group["body"],
+                "sent",
+            )
+            for rid, parts in _per_req_parts(group)
+        ]
+        if contacts:
+            contacts_to_lookup.append((contacts, tagged_subject))
         results.append(
             {
-                "id": contact.id,
-                "vendor_name": contact.vendor_name,
+                "id": contacts[0].id if contacts else None,
+                "vendor_name": group["vendor_name"],
                 "vendor_email": email,
-                "parts_count": len(contact.parts_included),
+                # Per-vendor total across all involved requisitions (legacy
+                # single-requisition: len of the group's parts, unchanged).
+                "parts_count": sum(len(c.parts_included or []) for c in contacts),
                 "status": "sent",
             }
         )
 
-    # Batch-lookup sent message IDs in parallel for reply matching
+    # Batch-lookup sent message IDs in parallel for reply matching. One email per
+    # vendor → all of that vendor's per-requisition Contacts share its graph ids.
     if contacts_to_lookup:
         lookup_results = await asyncio.gather(
             *[_find_sent_message(gc, subj) for _, subj in contacts_to_lookup],
             return_exceptions=True,
         )
-        for (contact, _), sent_msg in zip(contacts_to_lookup, lookup_results):
+        for (contacts, _), sent_msg in zip(contacts_to_lookup, lookup_results):
             if isinstance(sent_msg, dict) and sent_msg:
-                contact.graph_message_id = sent_msg.get("id")
-                contact.graph_conversation_id = sent_msg.get("conversationId")
+                for contact in contacts:
+                    contact.graph_message_id = sent_msg.get("id")
+                    contact.graph_conversation_id = sent_msg.get("conversationId")
 
     db.commit()
 
-    # Tag propagation: propagate tags for RFQ'd parts to vendor entities
+    # Tag propagation: propagate tags for ALL involved requisitions' RFQ'd parts
+    # to vendor entities (one pass per unique vendor)
     try:
         from .services.tagging import propagate_tags_to_entity
 
-        req_obj = db.get(Requisition, requisition_id)
-        if req_obj:
-            reqs = db.query(Requirement).filter(Requirement.requisition_id == requisition_id).all()
+        valid_req_ids = [rid for rid in req_ids if rid is not None]
+        if valid_req_ids:
+            reqs = db.query(Requirement).filter(Requirement.requisition_id.in_(valid_req_ids)).all()
             card_ids = [r.material_card_id for r in reqs if r.material_card_id]
             if card_ids:  # pragma: no cover
-                for contact_obj, _ in contacts_to_lookup:
-                    if contact_obj.vendor_name_normalized:
-                        vc = db.query(VendorCard).filter_by(normalized_name=contact_obj.vendor_name_normalized).first()
+                seen_vendor_norms = set()
+                for contacts, _ in contacts_to_lookup:
+                    for contact_obj in contacts:
+                        norm = contact_obj.vendor_name_normalized
+                        if not norm or norm in seen_vendor_norms:
+                            continue
+                        seen_vendor_norms.add(norm)
+                        vc = db.query(VendorCard).filter_by(normalized_name=norm).first()
                         if vc:
                             for cid in card_ids:
                                 propagate_tags_to_entity("vendor_card", vc.id, cid, 0.5, db)
@@ -324,8 +373,10 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
     """Check inbox for vendor replies. Smart-matches to outbound RFQs.
 
     Matching priority:
-    1. conversationId — same email thread as a sent RFQ (global, exact)
-    2. Subject [AVAIL-{req_id}] token — explicit RFQ tag
+    1. conversationId — same email thread as a sent RFQ (global, exact; matches
+       ALL Contacts sharing the thread — cross-requisition fan-out)
+    2. Subject [ref:{req_id}] / [AVAIL-{req_id}] token(s) — explicit RFQ tags
+       (every token in a multi-requisition subject is resolved)
     3. Vendor email — sender matches a vendor we contacted (USER-SCOPED to avoid data leaks)
     4. Sender domain — vendor domain match (USER-SCOPED)
     5. Unmatched — saved for manual review
@@ -428,7 +479,9 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
         )
         already_processed = {r[0] for r in vr_rows} | {r[0] for r in pm_rows}
 
-    # Pre-load outbound email contacts for matching (last 6 months)
+    # Pre-load outbound email contacts for matching (last 6 months). Ordered by
+    # id (= creation order) so the fan-out lists below are deterministic and the
+    # last-writer-wins maps genuinely keep the MOST RECENT contact.
     cutoff = datetime.now(timezone.utc) - timedelta(days=180)
     all_contacts = (
         db.query(Contact)
@@ -436,19 +489,27 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
             Contact.contact_type == "email",
             Contact.created_at > cutoff,
         )
+        .order_by(Contact.id)
         .all()
     )
 
-    # ConversationId map is GLOBAL — thread-specific, unambiguous
-    conv_id_map = {}
+    # ConversationId map is GLOBAL — thread-specific, unambiguous. Cross-requisition
+    # sends write one Contact per (requisition, vendor) sharing a single
+    # graph_conversation_id, so each conversation maps to a LIST of contacts; a
+    # reply on the thread is attributed to ALL of them.
+    conv_id_map: dict[str, list[Contact]] = {}
     # Email and domain maps are USER-SCOPED to prevent cross-user data leaks
     email_map = {}  # vendor_email -> Contact (only this user's contacts)
     domain_map = {}  # vendor_domain -> Contact (only this user's contacts)
-    # O(1) lookup for Tier 2 subject-token matching: (req_id, email) -> Contact
+    # O(1) lookup for Tier 2 subject-token matching: (req_id, email) -> Contact.
+    # The setdefault is correct under the per-requisition fan-out: send_batch_rfq
+    # writes at most one Contact per (requisition, vendor email) pair per send, so
+    # keys are effectively unique; for historical duplicates (e.g. a re-send) it
+    # keeps the earliest contact, which is the long-standing behavior.
     req_email_map: dict[tuple[int, str], Contact] = {}
     for c in all_contacts:
         if c.graph_conversation_id:
-            conv_id_map[c.graph_conversation_id] = c
+            conv_id_map.setdefault(c.graph_conversation_id, []).append(c)
         # Build req+email map for Tier 2 (all contacts, not just this user's)
         if c.requisition_id and c.vendor_contact:
             req_email_map.setdefault((c.requisition_id, c.vendor_contact.lower()), c)
@@ -456,6 +517,9 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
         if scanned_by_user_id and c.user_id == scanned_by_user_id:
             if c.vendor_contact:
                 email_lower = c.vendor_contact.lower()
+                # Last-writer-wins = most-recent contact BY DESIGN: Tier 3/4 are
+                # user-scoped fallback heuristics for untokenized replies, so they
+                # deliberately stay single-contact (no fan-out).
                 email_map[email_lower] = c
                 # Extract domain for domain-level matching
                 if "@" in email_lower:
@@ -487,46 +551,56 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
             continue
 
         # ── 4-tier reply matching ──
-        matched_contact = None
+        # A cross-requisition RFQ writes one Contact per (requisition, vendor), so
+        # Tiers 1-2 can match SEVERAL contacts for one message. One VendorResponse
+        # is created per message (contact_id = first matched contact); every
+        # matched contact's status progresses below.
+        matched_contacts: list[Contact] = []
         matched_req_id = requisition_id
 
-        # Tier 1: ConversationId (exact thread, global)
+        # Tier 1: ConversationId (exact thread, global) — all contacts on the thread
         if conv_id and conv_id in conv_id_map:
-            matched_contact = conv_id_map[conv_id]
-            matched_req_id = matched_contact.requisition_id
+            matched_contacts = conv_id_map[conv_id]
+            matched_req_id = matched_contacts[0].requisition_id
 
-        # Tier 2: Subject [AVAIL-{id}] token
-        if not matched_contact:
-            token_match = RFQ_SUBJECT_TAG_RE.search(subj)
-            if token_match:
-                avail_req_id = int(token_match.group(1))
-                # O(1) dict lookup instead of O(n) list comprehension
-                req_contact = req_email_map.get((avail_req_id, email_addr))
-                if req_contact:
-                    matched_contact = req_contact
-                    matched_req_id = avail_req_id
+        # Tier 2: Subject [ref:]/[AVAIL-] tokens — iterate ALL tokens (cross-
+        # requisition subjects carry one token per involved requisition)
+        if not matched_contacts:
+            token_req_ids = list(dict.fromkeys(int(t) for t in RFQ_SUBJECT_TAG_RE.findall(subj)))
+            if token_req_ids:
+                # O(1) dict lookups instead of O(n) list comprehensions
+                matched_contacts = [
+                    req_contact
+                    for token_req_id in token_req_ids
+                    if (req_contact := req_email_map.get((token_req_id, email_addr)))
+                ]
+                if matched_contacts:
+                    matched_req_id = matched_contacts[0].requisition_id
                 else:
-                    # Token found but no exact email match — still assign to req
-                    matched_req_id = avail_req_id
+                    # Token(s) found but no exact email match — still assign to
+                    # the first token's requisition
+                    matched_req_id = token_req_ids[0]
 
-        # Tier 3: Exact email match (USER-SCOPED)
-        if not matched_contact and email_addr in email_map:
-            matched_contact = email_map[email_addr]
-            matched_req_id = matched_contact.requisition_id
+        # Tier 3: Exact email match (USER-SCOPED, most-recent contact by design)
+        if not matched_contacts and email_addr in email_map:
+            matched_contacts = [email_map[email_addr]]
+            matched_req_id = matched_contacts[0].requisition_id
 
-        # Tier 4: Domain match (USER-SCOPED)
-        if not matched_contact and "@" in email_addr:
+        # Tier 4: Domain match (USER-SCOPED, most-recent contact by design)
+        if not matched_contacts and "@" in email_addr:
             sender_domain = email_addr.split("@", 1)[1]
             if sender_domain in domain_map:
-                matched_contact = domain_map[sender_domain]
-                matched_req_id = matched_contact.requisition_id
+                matched_contacts = [domain_map[sender_domain]]
+                matched_req_id = matched_contacts[0].requisition_id
 
         try:
             # Use savepoint so a single message failure doesn't poison the session
             nested = db.begin_nested()
+            # ONE VendorResponse per message (it is per-message, not per-
+            # requisition); contact_id anchors to the first matched contact.
             vr = VendorResponse(
                 requisition_id=matched_req_id,
-                contact_id=matched_contact.id if matched_contact else None,
+                contact_id=matched_contacts[0].id if matched_contacts else None,
                 vendor_name=sender.get("name", email_addr),
                 vendor_email=email_addr,
                 subject=subj,
@@ -535,7 +609,7 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
                 graph_conversation_id=conv_id,
                 scanned_by_user_id=scanned_by_user_id,
                 received_at=msg.get("receivedDateTime"),
-                status="matched" if matched_contact else "new",
+                status="matched" if matched_contacts else "new",
                 created_at=datetime.now(timezone.utc),
             )
             db.add(vr)
@@ -568,8 +642,10 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
                 pending_parse.append(vr)
 
             # ── Contact status progression ──
-            if matched_contact:
-                _progress_contact_status(matched_contact, vr, db)
+            # Every matched contact progresses: a cross-requisition reply must
+            # advance the (requisition, vendor) row on EVERY involved requisition.
+            for mc in matched_contacts:
+                _progress_contact_status(mc, vr, db)
 
             nested.commit()
 
@@ -587,7 +663,7 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
                     "confidence": vr.confidence,
                     "received_at": vr.received_at,
                     "message_id": msg_id,
-                    "matched_contact_id": matched_contact.id if matched_contact else None,
+                    "matched_contact_id": matched_contacts[0].id if matched_contacts else None,
                     "matched_requisition_id": matched_req_id,
                 }
             )

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -101,8 +101,23 @@ async def send_batch_rfq(
     Legacy shim: without the map, the scalar ``requisition_id`` behaves exactly
     as before (one Contact per vendor, parts taken from each vendor group) —
     callers like htmx_views.rfq_send need no change.
+
+    ``requisition_id`` and ``requisition_parts_map`` are MUTUALLY EXCLUSIVE modes
+    (single- vs cross-requisition). Passing both raises ``ValueError`` — the scalar
+    would otherwise be silently ignored.
     """
     from app.utils.graph_client import GraphClient
+
+    # The two requisition inputs are a sum type, not independent kwargs: EITHER
+    # single-requisition mode (scalar requisition_id, parts from each vendor group) OR
+    # cross-requisition mode (requisition_parts_map, parts from the map). Passing both is
+    # meaningless — the scalar would be silently ignored (req_ids = sorted(parts_map)).
+    # Fail loudly on the illegal combination instead of silently picking a winner.
+    if requisition_parts_map is not None and requisition_id is not None:
+        raise ValueError(
+            "send_batch_rfq: pass requisition_id (single-req) OR requisition_parts_map "
+            "(cross-req), never both — they are mutually exclusive modes"
+        )
 
     vendor_groups = vendor_groups or []
     # Legacy scalar shim: a missing/empty map means single-requisition mode where
@@ -293,11 +308,30 @@ async def send_batch_rfq(
             *[_find_sent_message(gc, subj, vendor_email) for _, subj, vendor_email in contacts_to_lookup],
             return_exceptions=True,
         )
-        for (contacts, _, _), sent_msg in zip(contacts_to_lookup, lookup_results):
+        for (contacts, subj, vendor_email), sent_msg in zip(contacts_to_lookup, lookup_results):
             if isinstance(sent_msg, dict) and sent_msg:
                 for contact in contacts:
                     contact.graph_message_id = sent_msg.get("id")
                     contact.graph_conversation_id = sent_msg.get("conversationId")
+            else:
+                # The sent message could not be located (None after retries, or the
+                # lookup task raised and was captured by return_exceptions). These
+                # Contacts keep NULL graph ids, which silently downgrades all future
+                # reply matching for this vendor from Tier-1 conversationId (exact
+                # thread) to the weaker Tier-2/3/4 heuristics — make the dropped
+                # association OBSERVABLE rather than silent. Common on large batches:
+                # the vendor's own message can sit below the $top window in Sent Items.
+                detail = f": {sent_msg}" if isinstance(sent_msg, Exception) else ""
+                logger.warning(
+                    "Sent-message lookup found no match for vendor '{}' <{}> "
+                    "(subject '{}', requisitions {}) — Contact graph ids left NULL; "
+                    "reply matching degrades to subject/email heuristics{}",
+                    contacts[0].vendor_name,
+                    vendor_email,
+                    subj,
+                    [c.requisition_id for c in contacts],
+                    detail,
+                )
 
     db.commit()
 
@@ -344,6 +378,8 @@ async def _find_sent_message(gc, subject: str, vendor_email: str) -> dict | None
     """
     wanted = (vendor_email or "").strip().lower()
     delays = [1, 2, 4]
+    api_error = False
+    scanned = 0
     for delay in delays:
         try:
             await asyncio.sleep(delay)
@@ -356,6 +392,7 @@ async def _find_sent_message(gc, subject: str, vendor_email: str) -> dict | None
                 },
             )
             msgs = data.get("value", []) if data else []
+            scanned = len(msgs)
             for m in msgs:
                 if m.get("subject", "").strip() != subject.strip():
                     continue
@@ -365,7 +402,25 @@ async def _find_sent_message(gc, subject: str, vendor_email: str) -> dict | None
                 if wanted in recipients:
                     return m
         except Exception as e:
+            api_error = True
             logger.warning(f"Sent message lookup attempt failed: {e}")
+    # Distinguish a transient API failure from a genuine no-match: the latter means the
+    # recipient never appeared in the $top window (likely pushed below it by a large
+    # batch fan-out), and the caller leaves the Contact's graph ids NULL.
+    if api_error:
+        logger.warning(
+            "Sent-message lookup gave up for <{}> (subject '{}') after API errors on all retries",
+            wanted,
+            subject,
+        )
+    else:
+        logger.warning(
+            "Sent-message lookup found no match for <{}> (subject '{}') within the top {} Sent items "
+            "— recipient may have been pushed below the window by a large batch",
+            wanted,
+            subject,
+            scanned,
+        )
     return None
 
 

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -40,7 +40,7 @@ def _build_html_body(plain_text: str) -> str:
 
 def _create_contact(
     db: Session,
-    requisition_id: int | None,
+    requisition_id: int,
     user_id: int,
     vendor_name: str,
     vendor_email: str,
@@ -111,10 +111,15 @@ async def send_batch_rfq(
     legacy_mode = not parts_map
     req_ids: list[int | None] = [requisition_id] if legacy_mode else sorted(parts_map)
 
-    def _per_req_parts(group: dict) -> list[tuple[int | None, list]]:
-        """(requisition_id, parts) pairs to write Contacts for, per vendor."""
+    def _per_req_parts(group: dict) -> list[tuple[int, list]]:
+        """(requisition_id, parts) pairs to write Contacts for, per vendor.
+
+        Contact.requisition_id is NOT NULL, so a degenerate legacy call with no
+        requisition at all yields no pairs (email sent, nothing tracked) instead of a
+        guaranteed flush crash.
+        """
         if legacy_mode:
-            return [(requisition_id, group.get("parts", []))]
+            return [] if requisition_id is None else [(requisition_id, group.get("parts", []))]
         return [(rid, parts_map[rid]) for rid in req_ids if rid is not None]
 
     gc = GraphClient(token)
@@ -176,86 +181,97 @@ async def send_batch_rfq(
     send_results = await asyncio.gather(*[_throttled_send(task) for task in send_tasks], return_exceptions=True)
 
     # Process results: create Contact records (one per involved requisition per
-    # vendor), then batch-lookup sent message IDs
-    contacts_to_lookup = []  # (contacts_for_one_vendor, tagged_subject) pairs
+    # vendor), then batch-lookup sent message IDs. Each vendor's contact block
+    # runs inside its own SAVEPOINT so one flush failure can't poison the other
+    # vendors' rows or leave the session unusable for the route's commit (the
+    # emails are already out at this point — tracking must be best-effort
+    # per-vendor, and a tracking failure must be VISIBLE in the results).
+    contacts_to_lookup = []  # (contacts_for_one_vendor, tagged_subject, vendor_email)
     for group, send_result in zip(send_groups, send_results):
         email = group["vendor_email"]
         tagged_subject = group.pop("_tagged_subject")
 
-        if isinstance(send_result, Exception):
-            logger.error(f"Send error to {email}: {send_result}")
-            err_msg = str(send_result)[:500]
-            failed_contacts = [
-                _create_contact(
-                    db,
-                    rid,
-                    user_id,
+        if isinstance(send_result, Exception) or (isinstance(send_result, dict) and "error" in send_result):
+            if isinstance(send_result, Exception):
+                err_detail = str(send_result)
+                logger.error(f"Send error to {email}: {send_result}")
+            else:
+                err_detail = str(send_result.get("detail", ""))
+                logger.error(f"Send failed to {email}: {send_result}")
+            failed_contacts: list[Contact] = []
+            try:
+                with db.begin_nested():
+                    failed_contacts = [
+                        _create_contact(
+                            db,
+                            rid,
+                            user_id,
+                            group["vendor_name"],
+                            email,
+                            parts,
+                            tagged_subject,
+                            group["body"],
+                            "failed",
+                            err_detail[:500],
+                        )
+                        for rid, parts in _per_req_parts(group)
+                    ]
+            except Exception:
+                logger.error(
+                    "Contact tracking failed for vendor '{}' (requisitions {}) on the failed-send path",
                     group["vendor_name"],
-                    email,
-                    parts,
-                    tagged_subject,
-                    group["body"],
-                    "failed",
-                    err_msg,
+                    [rid for rid, _ in _per_req_parts(group)],
+                    exc_info=True,
                 )
-                for rid, parts in _per_req_parts(group)
-            ]
             results.append(
                 {
                     "id": failed_contacts[0].id if failed_contacts else None,
                     "vendor_name": group["vendor_name"],
                     "vendor_email": email,
                     "status": "failed",
-                    "error": str(send_result)[:200],
+                    "error": err_detail[:200],
                 }
             )
             continue
 
-        if "error" in send_result:
-            logger.error(f"Send failed to {email}: {send_result}")
-            err_msg = str(send_result.get("detail", ""))[:500]
-            failed_contacts = [
-                _create_contact(
-                    db,
-                    rid,
-                    user_id,
-                    group["vendor_name"],
-                    email,
-                    parts,
-                    tagged_subject,
-                    group["body"],
-                    "failed",
-                    err_msg,
-                )
-                for rid, parts in _per_req_parts(group)
-            ]
-            results.append(
-                {
-                    "id": failed_contacts[0].id if failed_contacts else None,
-                    "vendor_name": group["vendor_name"],
-                    "vendor_email": email,
-                    "status": "failed",
-                    "error": str(send_result.get("detail", ""))[:200],
-                }
-            )
-            continue
-
-        contacts = [
-            _create_contact(
-                db,
-                rid,
-                user_id,
+        try:
+            with db.begin_nested():
+                contacts = [
+                    _create_contact(
+                        db,
+                        rid,
+                        user_id,
+                        group["vendor_name"],
+                        email,
+                        parts,
+                        tagged_subject,
+                        group["body"],
+                        "sent",
+                    )
+                    for rid, parts in _per_req_parts(group)
+                ]
+        except Exception:
+            # The email WAS delivered — report a tracking error for this vendor
+            # only; the rest of the batch keeps its rows.
+            logger.error(
+                "Contact tracking failed for vendor '{}' (requisitions {}) — RFQ email was already sent",
                 group["vendor_name"],
-                email,
-                parts,
-                tagged_subject,
-                group["body"],
-                "sent",
+                [rid for rid, _ in _per_req_parts(group)],
+                exc_info=True,
             )
-            for rid, parts in _per_req_parts(group)
-        ]
+            results.append(
+                {
+                    "id": None,
+                    "vendor_name": group["vendor_name"],
+                    "vendor_email": email,
+                    "status": "failed",
+                    "error": "tracking_error: email sent but Contact rows could not be recorded",
+                }
+            )
+            continue
+
         if contacts:
-            contacts_to_lookup.append((contacts, tagged_subject))
+            contacts_to_lookup.append((contacts, tagged_subject, email))
         results.append(
             {
                 "id": contacts[0].id if contacts else None,
@@ -270,12 +286,14 @@ async def send_batch_rfq(
 
     # Batch-lookup sent message IDs in parallel for reply matching. One email per
     # vendor → all of that vendor's per-requisition Contacts share its graph ids.
+    # Every vendor in a batch shares the SAME tagged subject, so the lookup is
+    # vendor-discriminating (recipient email), never subject-only.
     if contacts_to_lookup:
         lookup_results = await asyncio.gather(
-            *[_find_sent_message(gc, subj) for _, subj in contacts_to_lookup],
+            *[_find_sent_message(gc, subj, vendor_email) for _, subj, vendor_email in contacts_to_lookup],
             return_exceptions=True,
         )
-        for (contacts, _), sent_msg in zip(contacts_to_lookup, lookup_results):
+        for (contacts, _, _), sent_msg in zip(contacts_to_lookup, lookup_results):
             if isinstance(sent_msg, dict) and sent_msg:
                 for contact in contacts:
                     contact.graph_message_id = sent_msg.get("id")
@@ -294,7 +312,7 @@ async def send_batch_rfq(
             card_ids = [r.material_card_id for r in reqs if r.material_card_id]
             if card_ids:  # pragma: no cover
                 seen_vendor_norms = set()
-                for contacts, _ in contacts_to_lookup:
+                for contacts, _, _ in contacts_to_lookup:
                     for contact_obj in contacts:
                         norm = contact_obj.vendor_name_normalized
                         if not norm or norm in seen_vendor_norms:
@@ -311,12 +329,20 @@ async def send_batch_rfq(
     return results
 
 
-async def _find_sent_message(gc, subject: str) -> dict | None:
+async def _find_sent_message(gc, subject: str, vendor_email: str) -> dict | None:
     """Find the just-sent message in Sent Items to get its ID and conversationId.
+
+    Vendor-discriminating (F1): every vendor group in a batch shares an IDENTICAL tagged
+    subject, so a subject-only match would return the newest vendor's message for every
+    vendor — giving all batch Contacts one shared (wrong) conversation id and
+    misattributing replies. The match therefore requires the vendor's email among
+    toRecipients, and $top covers the whole batch fan-out (the vendor's own message can
+    sit well below the top 5 right after a batch).
 
     Retries with exponential backoff (1s, 2s, 4s) to handle Graph API propagation
     delays.
     """
+    wanted = (vendor_email or "").strip().lower()
     delays = [1, 2, 4]
     for delay in delays:
         try:
@@ -324,18 +350,63 @@ async def _find_sent_message(gc, subject: str) -> dict | None:
             data = await gc.get_json(
                 "/me/mailFolders/sentItems/messages",
                 params={
-                    "$top": "5",
+                    "$top": "25",
                     "$orderby": "sentDateTime desc",
-                    "$select": "id,conversationId,subject",
+                    "$select": "id,conversationId,subject,toRecipients",
                 },
             )
             msgs = data.get("value", []) if data else []
             for m in msgs:
-                if m.get("subject", "").strip() == subject.strip():
+                if m.get("subject", "").strip() != subject.strip():
+                    continue
+                recipients = {
+                    (r.get("emailAddress", {}).get("address") or "").lower() for r in m.get("toRecipients", [])
+                }
+                if wanted in recipients:
                     return m
         except Exception as e:
             logger.warning(f"Sent message lookup attempt failed: {e}")
     return None
+
+
+def _scope_thread_contacts_to_sender(thread_contacts: list[Contact], sender_email: str) -> list[Contact]:
+    """Vendor-scope a conversation-id (Tier-1) match to the replying vendor.
+
+    A conversation id can map to contacts of DIFFERENT vendors (legacy rows
+    written by the old subject-only sent-lookup), so a blind fan-out would
+    progress every batch vendor when ONE replies. Scope: contacts whose vendor
+    email equals the sender, falling back to same-domain contacts (a colleague
+    replying from another mailbox), then to the full thread ONLY when it is
+    single-vendor (every contact shares one vendor email). A multi-vendor thread
+    with an unrecognized sender matches nothing — Tiers 2-4 take over.
+
+    Fan out across requisitions for the SAME vendor, never across vendors.
+
+    Called by: poll_inbox (Tier 1), _repair_contact_status_for_ooo_bounce.
+    """
+    sender = (sender_email or "").lower()
+    exact = [c for c in thread_contacts if (c.vendor_contact or "").lower() == sender]
+    if exact:
+        return exact
+    sender_domain = sender.split("@", 1)[1] if "@" in sender else ""
+    if sender_domain and sender_domain not in NOISE_DOMAINS:
+        domain_matches = [
+            c
+            for c in thread_contacts
+            if c.vendor_contact
+            and "@" in c.vendor_contact
+            and c.vendor_contact.lower().split("@", 1)[1] == sender_domain
+        ]
+        if domain_matches:
+            return domain_matches
+    if len({(c.vendor_contact or "").lower() for c in thread_contacts}) == 1:
+        return list(thread_contacts)
+    logger.warning(
+        "Tier-1 thread match dropped: sender {} matches none of the {} vendors on the conversation",
+        sender,
+        len({(c.vendor_contact or "").lower() for c in thread_contacts}),
+    )
+    return []
 
 
 def log_phone_contact(
@@ -558,15 +629,26 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
         matched_contacts: list[Contact] = []
         matched_req_id = requisition_id
 
-        # Tier 1: ConversationId (exact thread, global) — all contacts on the thread
+        # Tier 1: ConversationId (exact thread, global) — all of the REPLYING
+        # vendor's contacts on the thread (vendor-scoped: a reply from vendor A
+        # must never progress vendor B's contacts on a collided conversation).
         if conv_id and conv_id in conv_id_map:
-            matched_contacts = conv_id_map[conv_id]
-            matched_req_id = matched_contacts[0].requisition_id
+            matched_contacts = _scope_thread_contacts_to_sender(conv_id_map[conv_id], email_addr)
+            if matched_contacts:
+                matched_req_id = matched_contacts[0].requisition_id
 
         # Tier 2: Subject [ref:]/[AVAIL-] tokens — iterate ALL tokens (cross-
-        # requisition subjects carry one token per involved requisition)
+        # requisition subjects carry one token per involved requisition). Tokens
+        # can outlive their requisition (deleted reqs, forwarded subjects), so
+        # they are existence-filtered in ONE query before any use — a stale id
+        # must never reach VendorResponse.requisition_id (FK violation on PG).
         if not matched_contacts:
             token_req_ids = list(dict.fromkeys(int(t) for t in RFQ_SUBJECT_TAG_RE.findall(subj)))
+            if token_req_ids:
+                live_ids = {row[0] for row in db.query(Requisition.id).filter(Requisition.id.in_(token_req_ids)).all()}
+                if dropped := [t for t in token_req_ids if t not in live_ids]:
+                    logger.warning("Dropping stale [ref:] token(s) {} from '{}'", dropped, subj[:120])
+                token_req_ids = [t for t in token_req_ids if t in live_ids]
             if token_req_ids:
                 # O(1) dict lookups instead of O(n) list comprehensions
                 matched_contacts = [
@@ -681,19 +763,10 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
             await _parse_sequential_fallback(pending_parse, db)
 
     # ── Post-parse: update contact status for OOO/bounce classifications ──
-    OOO_CLASSIFICATIONS = {"ooo", "out_of_office", "auto_reply"}
-    BOUNCE_CLASSIFICATIONS = {"bounce", "bounced", "delivery_failure"}
+    # Only the sequential fallback sets vr.classification synchronously; batch
+    # results arrive later and are repaired in process_batch_results.
     for vr in pending_parse:
-        if vr.contact_id and vr.classification:
-            cls = vr.classification.lower()
-            parent_contact = db.get(Contact, vr.contact_id)
-            if parent_contact:
-                if cls in OOO_CLASSIFICATIONS:
-                    parent_contact.status = "ooo"
-                    parent_contact.status_updated_at = datetime.now(timezone.utc)
-                elif cls in BOUNCE_CLASSIFICATIONS:
-                    parent_contact.status = "bounced"
-                    parent_contact.status_updated_at = datetime.now(timezone.utc)
+        _repair_contact_status_for_ooo_bounce(vr, db)
 
     # Single commit for all new responses
     try:
@@ -812,6 +885,66 @@ def _classify_response(parsed: dict, body: str, subject: str) -> dict:
         "needs_action": True,
         "action_hint": "Response received \u2014 review and determine next steps",
     }
+
+
+# Bounce sub-signals within the merged "ooo_bounce" classification (the
+# classifiers deliberately fold OOO and bounces into one bucket — see
+# _classify_response's ooo_signals and RESPONSE_PARSE_SCHEMA).
+_BOUNCE_SIGNALS = (
+    "undeliverable",
+    "delivery failure",
+    "delivery has failed",
+    "mailer-daemon",
+    "address not found",
+    "recipient not found",
+)
+
+
+def _repair_contact_status_for_ooo_bounce(vr: VendorResponse, db: Session) -> None:
+    """Correct outbound Contact status when a reply classifies as OOO/bounce.
+
+    The classification vocabulary is exactly ONE value for this family:
+    "ooo_bounce" — emitted by _classify_response (sequential fallback path),
+    RESPONSE_PARSE_SCHEMA's enum (batch path via _apply_parsed_result), and the
+    ai.py reparse endpoint. Anything else here would be dead code (the old
+    {"ooo","out_of_office","auto_reply"} / {"bounce",...} sets never fired).
+
+    Applies to ALL contacts matched for the message — re-derived from the
+    reply's graph_conversation_id with the same vendor-email scoping as Tier-1
+    matching (never across vendors), falling back to the anchored vr.contact_id.
+    Bounce-vs-OOO is sub-classified from the message text; terminal statuses
+    (quoted/declined) are never regressed.
+
+    Called by: poll_inbox (post-parse, sequential fallback), process_batch_results.
+    """
+    if (vr.classification or "").lower() != "ooo_bounce":
+        return
+
+    contacts: list[Contact] = []
+    if vr.graph_conversation_id:
+        thread = (
+            db.query(Contact)
+            .filter(
+                Contact.graph_conversation_id == vr.graph_conversation_id,
+                Contact.contact_type == "email",
+            )
+            .order_by(Contact.id)
+            .all()
+        )
+        contacts = _scope_thread_contacts_to_sender(thread, (vr.vendor_email or "").lower())
+    if not contacts and vr.contact_id:
+        anchored = db.get(Contact, vr.contact_id)
+        if anchored:
+            contacts = [anchored]
+
+    text = f"{vr.subject or ''} {vr.body or ''}".lower()
+    new_status = "bounced" if any(s in text for s in _BOUNCE_SIGNALS) else "ooo"
+    now = datetime.now(timezone.utc)
+    for contact in contacts:
+        if contact.status in ("quoted", "declined"):
+            continue  # never regress a terminal state on a late auto-reply
+        contact.status = new_status
+        contact.status_updated_at = now
 
 
 def _progress_contact_status(contact: Contact, vr: VendorResponse, db: Session):
@@ -1374,6 +1507,10 @@ async def process_batch_results(db: Session) -> int:
                     "confidence": parsed_data.get("confidence", 0),
                 }
                 _apply_parsed_result(vr, legacy_parsed, db)
+                # Batch path of the OOO/bounce contact-status repair: the
+                # classification only exists NOW, so the poll-time block never
+                # sees it — repair here or it never happens.
+                _repair_contact_status_for_ooo_bounce(vr, db)
                 applied += 1
 
         pb.status = PendingBatchStatus.COMPLETED

--- a/app/jobs/email_jobs.py
+++ b/app/jobs/email_jobs.py
@@ -884,66 +884,94 @@ async def scan_sent_folder(user, db):
             )
         db.flush()
 
-    # Process each sent message
+    # [ref:]/[AVAIL-] tokens can outlive their requisition (deleted reqs, stale
+    # forwarded subjects). Filter every message's tokens through ONE existence
+    # query up front — a stale id written to ActivityLog.requisition_id is an FK
+    # violation on PG that would roll back the WHOLE batch plus the delta token.
+    from ..models import Requisition
+
+    all_tokens = sorted({int(t) for m in messages for t in RFQ_SUBJECT_TAG_RE.findall(m.get("subject") or "")})
+    live_req_ids: set[int] = set()
+    if all_tokens:
+        live_req_ids = {row[0] for row in db.query(Requisition.id).filter(Requisition.id.in_(all_tokens)).all()}
+        if stale := sorted(set(all_tokens) - live_req_ids):
+            logger.warning(f"Sent folder scan [{user.email}]: dropping stale [ref:] token(s) {stale}")
+
+    # Process each sent message. Per-message SAVEPOINT: one malformed message
+    # must not roll back the batch (and with it the already-flushed delta token).
     created_logs = []
     attachment_queue = []
     for msg in messages:
         msg_id = msg.get("id", "")
-        subject = msg.get("subject", "")
-        sent_dt = msg.get("sentDateTime")
+        msg_logs: list[ActivityLog] = []
+        try:
+            with db.begin_nested():
+                subject = msg.get("subject", "")
+                sent_dt = msg.get("sentDateTime")
 
-        # Skip if we already logged this message (dedup by external_id)
-        existing = (
-            db.query(ActivityLog)
-            .filter(
-                ActivityLog.external_id == msg_id,
-                ActivityLog.user_id == user.id,
+                # Skip if we already logged this message (dedup by external_id)
+                existing = (
+                    db.query(ActivityLog)
+                    .filter(
+                        ActivityLog.external_id == msg_id,
+                        ActivityLog.user_id == user.id,
+                    )
+                    .first()
+                )
+                if existing:
+                    continue
+
+                # Extract first recipient email
+                recipients = msg.get("toRecipients", [])
+                first_recipient = ""
+                if recipients:
+                    first_recipient = recipients[0].get("emailAddress", {}).get("address", "")
+
+                # Check for [ref:{id}]/[AVAIL-{id}] tags to link to requisitions. A
+                # cross-requisition RFQ carries one token per involved requisition —
+                # attribute the sent email to ALL of them (untagged, or every token
+                # stale → one unlinked row).
+                token_req_ids: list[int | None] = list(
+                    dict.fromkeys(int(t) for t in RFQ_SUBJECT_TAG_RE.findall(subject) if int(t) in live_req_ids)
+                )
+
+                # Parse sentDateTime
+                occurred_at = None
+                if sent_dt:
+                    try:
+                        occurred_at = datetime.fromisoformat(sent_dt.replace("Z", "+00:00"))
+                    except (ValueError, TypeError):
+                        occurred_at = datetime.now(timezone.utc)
+
+                # Create one ActivityLog entry per token requisition (they share the
+                # message's external_id, so the dedup check above still skips re-scans)
+                for requisition_id in token_req_ids or [None]:
+                    log_entry = ActivityLog(
+                        user_id=user.id,
+                        activity_type="email_sent",
+                        channel="email",
+                        direction="outbound",
+                        event_type="email",
+                        subject=subject[:500] if subject else None,
+                        contact_email=first_recipient or None,
+                        external_id=msg_id,
+                        requisition_id=requisition_id,
+                        auto_logged=True,
+                        occurred_at=occurred_at,
+                    )
+                    db.add(log_entry)
+                    msg_logs.append(log_entry)
+        except Exception:
+            logger.error(
+                f"Sent folder scan [{user.email}]: skipping message {msg_id[:20]} after per-message failure",
+                exc_info=True,
             )
-            .first()
-        )
-        if existing:
             continue
+        created_logs.extend(msg_logs)
 
-        # Extract first recipient email
-        recipients = msg.get("toRecipients", [])
-        first_recipient = ""
-        if recipients:
-            first_recipient = recipients[0].get("emailAddress", {}).get("address", "")
-
-        # Check for [ref:{id}]/[AVAIL-{id}] tags to link to requisitions. A
-        # cross-requisition RFQ carries one token per involved requisition —
-        # attribute the sent email to ALL of them (untagged → one unlinked row).
-        token_req_ids: list[int | None] = list(dict.fromkeys(int(t) for t in RFQ_SUBJECT_TAG_RE.findall(subject)))
-
-        # Parse sentDateTime
-        occurred_at = None
-        if sent_dt:
-            try:
-                occurred_at = datetime.fromisoformat(sent_dt.replace("Z", "+00:00"))
-            except (ValueError, TypeError):
-                occurred_at = datetime.now(timezone.utc)
-
-        # Create one ActivityLog entry per token requisition (they share the
-        # message's external_id, so the dedup check above still skips re-scans)
-        for requisition_id in token_req_ids or [None]:
-            log_entry = ActivityLog(
-                user_id=user.id,
-                activity_type="email_sent",
-                channel="email",
-                direction="outbound",
-                event_type="email",
-                subject=subject[:500] if subject else None,
-                contact_email=first_recipient or None,
-                external_id=msg_id,
-                requisition_id=requisition_id,
-                auto_logged=True,
-                occurred_at=occurred_at,
-            )
-            db.add(log_entry)
-            created_logs.append(log_entry)
-
-        # Check for file attachments (exclude inline images)
-        if msg.get("hasAttachments"):
+        # Check for file attachments (exclude inline images) — outside the
+        # savepoint (network I/O only; detect_attachments swallows its own errors)
+        if msg_logs and msg.get("hasAttachments"):
             attachment_info = await detect_attachments(gc, msg_id)
             if attachment_info:
                 attachment_queue.append({"message_id": msg_id, "attachments": attachment_info})

--- a/app/jobs/email_jobs.py
+++ b/app/jobs/email_jobs.py
@@ -910,11 +910,10 @@ async def scan_sent_folder(user, db):
         if recipients:
             first_recipient = recipients[0].get("emailAddress", {}).get("address", "")
 
-        # Check for [AVAIL-{id}] tag to link to requisition
-        requisition_id = None
-        tag_match = RFQ_SUBJECT_TAG_RE.search(subject)
-        if tag_match:
-            requisition_id = int(tag_match.group(1))
+        # Check for [ref:{id}]/[AVAIL-{id}] tags to link to requisitions. A
+        # cross-requisition RFQ carries one token per involved requisition —
+        # attribute the sent email to ALL of them (untagged → one unlinked row).
+        token_req_ids: list[int | None] = list(dict.fromkeys(int(t) for t in RFQ_SUBJECT_TAG_RE.findall(subject)))
 
         # Parse sentDateTime
         occurred_at = None
@@ -924,22 +923,24 @@ async def scan_sent_folder(user, db):
             except (ValueError, TypeError):
                 occurred_at = datetime.now(timezone.utc)
 
-        # Create ActivityLog entry
-        log_entry = ActivityLog(
-            user_id=user.id,
-            activity_type="email_sent",
-            channel="email",
-            direction="outbound",
-            event_type="email",
-            subject=subject[:500] if subject else None,
-            contact_email=first_recipient or None,
-            external_id=msg_id,
-            requisition_id=requisition_id,
-            auto_logged=True,
-            occurred_at=occurred_at,
-        )
-        db.add(log_entry)
-        created_logs.append(log_entry)
+        # Create one ActivityLog entry per token requisition (they share the
+        # message's external_id, so the dedup check above still skips re-scans)
+        for requisition_id in token_req_ids or [None]:
+            log_entry = ActivityLog(
+                user_id=user.id,
+                activity_type="email_sent",
+                channel="email",
+                direction="outbound",
+                event_type="email",
+                subject=subject[:500] if subject else None,
+                contact_email=first_recipient or None,
+                external_id=msg_id,
+                requisition_id=requisition_id,
+                auto_logged=True,
+                occurred_at=occurred_at,
+            )
+            db.add(log_entry)
+            created_logs.append(log_entry)
 
         # Check for file attachments (exclude inline images)
         if msg.get("hasAttachments"):

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -16,7 +16,7 @@ import json
 import re
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Final, Literal
+from typing import Any, Final, Literal, NamedTuple, TypedDict
 from urllib.parse import urlsplit
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
@@ -1324,9 +1324,31 @@ def _vss_vendor_card_join():
     )
 
 
-def _coverage_ranked_vendor_rows(
-    db: Session, req_id_list: list[int], excluded: set[str]
-) -> list[tuple[VendorCard, int, float | None]]:
+class RankedVendor(NamedTuple):
+    """One coverage-ranked vendor row (see _coverage_ranked_vendor_rows).
+
+    Named fields pin the SELECT-column order: a future swap of covered_count and
+    avg_score in the query would otherwise mis-bind silently (both are numeric).
+    """
+
+    card: VendorCard
+    covered_count: int
+    avg_score: float | None
+
+
+class CoverageEntry(TypedDict):
+    """Per-card coverage shape rendered in the vendor modal row.
+
+    ``mpns`` is populated lazily by a second query and stays ``""`` for cards with no
+    MPN rows — ``""`` is a valid terminal value, NOT "not yet computed".
+    """
+
+    count: int
+    avg_score: float | None
+    mpns: str
+
+
+def _coverage_ranked_vendor_rows(db: Session, req_id_list: list[int], excluded: set[str]) -> list[RankedVendor]:
     """Coverage-ranked suggested vendors — the single source shared by the vendor modal
     and the affinity endpoint (which must drop already-suggested vendors computed the
     SAME way, so it stays self-contained).
@@ -1336,8 +1358,8 @@ def _coverage_ranked_vendor_rows(
     lower(trim(vendor_name)) fallback for NULL-FK rows (post-rebuild summaries are now
     INCLUDED via that fallback — only summaries matching no card at all stay out, since
     the modal suggests known vendors). Plain-column aggregates only (SQLite+PG safe).
-    Returns (card, covered_count, avg_score) rows, coverage desc then engagement desc,
-    capped at 20.
+    Returns RankedVendor(card, covered_count, avg_score) rows, coverage desc then
+    engagement desc, capped at 20.
     """
     covered_count = sqlfunc.count(sqlfunc.distinct(VendorSightingSummary.requirement_id))
     vendor_query = (
@@ -1354,7 +1376,7 @@ def _coverage_ranked_vendor_rows(
     )
     if excluded:
         vendor_query = vendor_query.filter(VendorCard.normalized_name.notin_(sorted(excluded)))
-    rows = (
+    raw_rows = (
         vendor_query.group_by(VendorCard.id)
         .order_by(
             covered_count.desc(),
@@ -1364,14 +1386,15 @@ def _coverage_ranked_vendor_rows(
         .limit(20)
         .all()
     )
+    rows = [RankedVendor(card, int(n_covered), avg_score) for card, n_covered, avg_score in raw_rows]
     if excluded:
         # Belt and braces: some legacy cards carry a normalized_name that predates
         # normalize_vendor_name (suffix kept) — re-check through the canonical
         # normalizer so "X, Inc." cards can't slip past the column filter.
         rows = [
-            (card, n_covered, avg_score)
-            for card, n_covered, avg_score in rows
-            if normalize_vendor_name(card.display_name or card.normalized_name or "") not in excluded
+            r
+            for r in rows
+            if normalize_vendor_name(r.card.display_name or r.card.normalized_name or "") not in excluded
         ]
     return rows
 
@@ -1423,17 +1446,17 @@ async def sightings_vendor_modal(
     excluded = excluded_vendor_norms(db, requirements) if requirements else set()
 
     suggested_vendors: list[VendorCard] = []
-    coverage: dict[int, dict[str, Any]] = {}
+    coverage: dict[int, CoverageEntry] = {}
     if req_id_list:
         rows = _coverage_ranked_vendor_rows(db, req_id_list, excluded)
-        suggested_vendors = [card for card, _, _ in rows]
+        suggested_vendors = [r.card for r in rows]
         coverage = {
-            card.id: {
-                "count": int(n_covered),
-                "avg_score": float(avg_score) if avg_score is not None else None,
-                "mpns": "",
-            }
-            for card, n_covered, avg_score in rows
+            r.card.id: CoverageEntry(
+                count=r.covered_count,
+                avg_score=float(r.avg_score) if r.avg_score is not None else None,
+                mpns="",
+            )
+            for r in rows
         }
         if coverage:
             # Covered-MPN list per vendor (rendered in the row's `title`) — a second
@@ -1498,11 +1521,11 @@ async def sightings_vendor_affinity(
     if requirements:
         excluded = excluded_vendor_norms(db, requirements)
         suggested_norms: set[str] = set()
-        for card, _, _ in _coverage_ranked_vendor_rows(db, req_id_list, excluded):
+        for r in _coverage_ranked_vendor_rows(db, req_id_list, excluded):
             # Both spellings: the stored normalized_name (may be legacy-suffixed) and
             # the canonical re-normalization — affinity matches are compared canonically.
-            suggested_norms.add(card.normalized_name or "")
-            suggested_norms.add(normalize_vendor_name(card.display_name or card.normalized_name or ""))
+            suggested_norms.add(r.card.normalized_name or "")
+            suggested_norms.add(normalize_vendor_name(r.card.display_name or r.card.normalized_name or ""))
 
         # One affinity call per UNIQUE primary MPN (order-preserving dedupe — no
         # double L3 spend when requirements share an MPN).
@@ -1610,13 +1633,22 @@ async def sightings_composer_vendor(
     matched_existing = bool(matches) and matches[0]["match"] == "exact"
     contact_added = False
 
+    # TOCTOU: check_vendor_duplicate ran an earlier, separate query, so the matched
+    # card can be deleted between that check and this fetch. A None card here would
+    # AttributeError → generic 500; instead treat it as "no confident duplicate" and
+    # fall through to the create branch (re-resolving the name the user typed).
+    matched_card = db.get(VendorCard, matches[0]["id"]) if matched_existing else None
+    if matched_existing and matched_card is None:
+        matched_existing = False
+
     if matched_existing:
         # Confident duplicate: hand back the existing card — but a typed email /
         # website must NOT be silently discarded (F4): attach the email as a
         # VendorContact (deduped case-insensitively against the card's existing
         # contacts) and backfill a missing domain. The row's notice reports the
         # email attach explicitly.
-        card = db.get(VendorCard, matches[0]["id"])
+        assert matched_card is not None  # narrowed by the TOCTOU guard above
+        card = matched_card
         updated = False
         if email:
             existing_emails = {
@@ -1714,6 +1746,33 @@ async def sightings_composer_vendor(
     return template_response("htmx/partials/sightings/composer_vendor_row.html", ctx)
 
 
+def _best_contacts_by_card(db: Session, card_ids: list[int]) -> list[VendorContact]:
+    """Vendor contacts ordered worst-first so a last-wins ``{card_id: c}`` dict keeps
+    the BEST contact per vendor.
+
+    VendorContact has no is_primary flag, and a vendor can hold several contacts (an
+    rfq_manual row added inline via the composer alongside an Apollo-enriched row). An
+    unordered ``{c.vendor_card_id: c for c in contacts}`` lets an arbitrary (possibly
+    NULL-email) row win, which would silently skip the vendor as "had no email". Ordering
+    non-NULL email LAST (then verified, then higher confidence) makes the real email win.
+
+    Called by: sightings_preview_inquiry, sightings_send_inquiry.
+    """
+    if not card_ids:
+        return []
+    return (
+        db.query(VendorContact)
+        .filter(VendorContact.vendor_card_id.in_(card_ids))
+        .order_by(
+            VendorContact.email.is_(None).desc(),  # NULL-email rows first (lose last-wins)
+            VendorContact.is_verified.asc().nullsfirst(),  # verified rows last
+            VendorContact.confidence.asc().nullsfirst(),  # higher confidence last
+            VendorContact.id.asc(),  # deterministic tiebreak (newest row wins ties)
+        )
+        .all()
+    )
+
+
 @router.post("/v2/partials/sightings/preview-inquiry", response_class=HTMLResponse)
 async def sightings_preview_inquiry(
     request: Request,
@@ -1751,7 +1810,11 @@ async def sightings_preview_inquiry(
     card_map = {c.normalized_name: c for c in cards}
 
     card_ids = [c.id for c in cards]
-    contacts = db.query(VendorContact).filter(VendorContact.vendor_card_id.in_(card_ids)).all() if card_ids else []
+    # Order worst-first so the dict's last-wins keeps the BEST contact per vendor: a
+    # vendor with multiple contacts (e.g. an rfq_manual row added via the composer plus
+    # an Apollo-enriched row) must not pick a NULL-email contact over one that has the
+    # real email — that would silently skip the vendor as "had no email".
+    contacts = _best_contacts_by_card(db, card_ids)
     contact_map = {c.vendor_card_id: c for c in contacts}
 
     from ..email_service import _build_html_body
@@ -1842,7 +1905,9 @@ async def sightings_send_inquiry(
     card_map = {c.normalized_name: c for c in cards}
 
     card_ids = [c.id for c in cards]
-    contacts = db.query(VendorContact).filter(VendorContact.vendor_card_id.in_(card_ids)).all() if card_ids else []
+    # Best-contact-per-vendor (see _best_contacts_by_card): last-wins dict over a
+    # worst-first ordering so a non-NULL email always beats a NULL-email row.
+    contacts = _best_contacts_by_card(db, card_ids)
     contact_map = {c.vendor_card_id: c for c in contacts}
 
     vendor_groups = []

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -13,15 +13,18 @@ Depends on: models (Requirement, Requisition, Sighting, VendorSightingSummary,
 
 import asyncio
 import json
+import re
 import time
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, Final, Literal
+from urllib.parse import urlsplit
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import HTMLResponse, Response
 from loguru import logger
 from pydantic import ValidationError
+from sqlalchemy import and_, or_
 from sqlalchemy import func as sqlfunc
 from sqlalchemy.orm import Session, joinedload
 
@@ -1300,6 +1303,27 @@ async def sightings_log_activity(
     return resp
 
 
+def _vss_vendor_card_join():
+    """Coalesce join VendorSightingSummary → VendorCard (F10).
+
+    The vendor_card_id FK (indexed ix_vss_vendor_card) is the PRIMARY branch; VSS
+    rows with a NULL FK (e.g. summaries rebuilt before the FK backfill ran) fall
+    back to the legacy lower(trim(vendor_name)) == normalized_name match so a
+    known vendor's coverage never silently disappears. The NULL-FK guard on the
+    fallback prevents double-matching FK rows by name. Plain functions only —
+    SQLite + PG safe.
+
+    Called by: _coverage_ranked_vendor_rows, sightings_vendor_modal (MPN titles).
+    """
+    return or_(
+        VendorSightingSummary.vendor_card_id == VendorCard.id,
+        and_(
+            VendorSightingSummary.vendor_card_id.is_(None),
+            sqlfunc.lower(sqlfunc.trim(VendorSightingSummary.vendor_name)) == VendorCard.normalized_name,
+        ),
+    )
+
+
 def _coverage_ranked_vendor_rows(
     db: Session, req_id_list: list[int], excluded: set[str]
 ) -> list[tuple[VendorCard, int, float | None]]:
@@ -1307,13 +1331,13 @@ def _coverage_ranked_vendor_rows(
     and the affinity endpoint (which must drop already-suggested vendors computed the
     SAME way, so it stays self-contained).
 
-    One grouped query over VendorSightingSummary filtered to the selected
-    requirements, joined to VendorCard via the vendor_card_id FK (indexed
-    ix_vss_vendor_card) — NOT the legacy lower(trim(vendor_name)) name join. VSS rows
-    with NULL vendor_card_id are excluded by design: the modal suggests known vendors
-    (cards), never raw sighting names. Plain-column aggregates only (SQLite+PG safe).
-    Returns (card, covered_count, avg_score) rows, coverage desc then engagement
-    desc, capped at 20.
+    One grouped query over VendorSightingSummary filtered to the selected requirements,
+    joined to VendorCard via _vss_vendor_card_join: the vendor_card_id FK first, with a
+    lower(trim(vendor_name)) fallback for NULL-FK rows (post-rebuild summaries are now
+    INCLUDED via that fallback — only summaries matching no card at all stay out, since
+    the modal suggests known vendors). Plain-column aggregates only (SQLite+PG safe).
+    Returns (card, covered_count, avg_score) rows, coverage desc then engagement desc,
+    capped at 20.
     """
     covered_count = sqlfunc.count(sqlfunc.distinct(VendorSightingSummary.requirement_id))
     vendor_query = (
@@ -1322,10 +1346,7 @@ def _coverage_ranked_vendor_rows(
             covered_count.label("covered_count"),
             sqlfunc.avg(VendorSightingSummary.score).label("avg_score"),
         )
-        .join(
-            VendorSightingSummary,
-            VendorSightingSummary.vendor_card_id == VendorCard.id,
-        )
+        .join(VendorSightingSummary, _vss_vendor_card_join())
         .filter(
             VendorSightingSummary.requirement_id.in_(req_id_list),
             VendorCard.is_blacklisted.is_(False),
@@ -1417,12 +1438,16 @@ async def sightings_vendor_modal(
         if coverage:
             # Covered-MPN list per vendor (rendered in the row's `title`) — a second
             # plain query; no string_agg/group_concat (SQLite vs PG divergence).
+            # Same coalesce join as the ranking query, so fallback-joined (NULL-FK)
+            # rows contribute their MPNs too.
             mpn_rows = (
-                db.query(VendorSightingSummary.vendor_card_id, Requirement.primary_mpn)
+                db.query(VendorCard.id, Requirement.primary_mpn)
+                .select_from(VendorSightingSummary)
                 .join(Requirement, VendorSightingSummary.requirement_id == Requirement.id)
+                .join(VendorCard, _vss_vendor_card_join())
                 .filter(
                     VendorSightingSummary.requirement_id.in_(req_id_list),
-                    VendorSightingSummary.vendor_card_id.in_(list(coverage)),
+                    VendorCard.id.in_(list(coverage)),
                 )
                 .distinct()
                 .all()
@@ -1469,6 +1494,7 @@ async def sightings_vendor_affinity(
     requirements = (db.query(Requirement).filter(Requirement.id.in_(req_id_list)).all()) if req_id_list else []
 
     affinity_vendors: list[dict] = []
+    affinity_partial = False
     if requirements:
         excluded = excluded_vendor_norms(db, requirements)
         suggested_norms: set[str] = set()
@@ -1487,7 +1513,17 @@ async def sightings_vendor_affinity(
             async with sem:
                 return await asyncio.to_thread(_find_affinity_in_thread, mpn)
 
-        per_mpn_matches = await asyncio.gather(*(_bounded(m) for m in mpns))
+        # F6: one MPN's failure must not blank the whole panel (or 500 the swap).
+        # Failed MPNs are logged with the MPN in context; survivors render, and
+        # the template shows a quiet "suggestions incomplete" notice.
+        per_mpn_results = await asyncio.gather(*(_bounded(m) for m in mpns), return_exceptions=True)
+        per_mpn_matches: list[list[dict]] = []
+        for mpn, matches in zip(mpns, per_mpn_results):
+            if isinstance(matches, BaseException):
+                affinity_partial = True
+                logger.error("Vendor affinity lookup failed for MPN {}: {}", mpn, matches)
+                continue
+            per_mpn_matches.append(matches)
 
         best: dict[str, dict] = {}
         for matches in per_mpn_matches:
@@ -1499,8 +1535,31 @@ async def sightings_vendor_affinity(
                     best[norm] = {**match, "normalized_name": norm}
         affinity_vendors = sorted(best.values(), key=lambda m: m["confidence"], reverse=True)[:10]
 
-    ctx = {"request": request, "affinity_vendors": affinity_vendors}
+    ctx = {"request": request, "affinity_vendors": affinity_vendors, "affinity_partial": affinity_partial}
     return template_response("htmx/partials/sightings/vendor_affinity_rows.html", ctx)
+
+
+def _parse_website_domain(website: str) -> str:
+    """Extract a usable domain from user-typed website input (F12).
+
+    urlsplit-based (scheme optional), lowercased host, strips ONE leading
+    "www." — never a blanket str.replace that mangles hosts containing the
+    substring. Returns "" when no plausible domain can be extracted; the caller
+    turns that into a visible 400 instead of silently saving a junk domain.
+
+    Called by: sightings_composer_vendor.
+    """
+    raw = website.strip()
+    try:
+        parsed = urlsplit(raw if "://" in raw else f"//{raw}")
+        host = (parsed.hostname or "").strip().lower()
+    except ValueError:
+        return ""
+    if host.startswith("www."):
+        host = host[4:]
+    if "." not in host or not re.fullmatch(r"[a-z0-9.-]+", host):
+        return ""
+    return host
 
 
 @router.post("/v2/partials/sightings/composer-vendor", response_class=HTMLResponse)
@@ -1540,18 +1599,49 @@ async def sightings_composer_vendor(
     email = str(form.get("email") or "").strip()
     if email and "@" not in email:
         raise HTTPException(status_code=400, detail="invalid contact email")
+    domain = ""
+    if website:
+        domain = _parse_website_domain(website)
+        if not domain:
+            raise HTTPException(status_code=400, detail="invalid website — could not extract a domain")
     req_id_list = [int(x) for x in form.getlist("requirement_ids") if str(x).strip().isdigit()]
 
     matches = check_vendor_duplicate(vendor_name, db)
     matched_existing = bool(matches) and matches[0]["match"] == "exact"
+    contact_added = False
 
     if matched_existing:
-        # Confident duplicate: hand back the existing card — no new DB row at all.
+        # Confident duplicate: hand back the existing card — but a typed email /
+        # website must NOT be silently discarded (F4): attach the email as a
+        # VendorContact (deduped case-insensitively against the card's existing
+        # contacts) and backfill a missing domain. The row's notice reports the
+        # email attach explicitly.
         card = db.get(VendorCard, matches[0]["id"])
+        updated = False
+        if email:
+            existing_emails = {
+                (vc.email or "").lower()
+                for vc in db.query(VendorContact).filter(VendorContact.vendor_card_id == card.id).all()
+            }
+            if email.lower() not in existing_emails:
+                db.add(
+                    VendorContact(
+                        vendor_card_id=card.id,
+                        email=email,
+                        contact_type="company",
+                        source="rfq_manual",
+                        confidence=80,
+                        is_verified=False,
+                    )
+                )
+                contact_added = True
+                updated = True
+        if domain and not card.domain:
+            card.domain = domain
+            updated = True
+        if updated:
+            db.commit()
     else:
-        domain = ""
-        if website:
-            domain = website.replace("https://", "").replace("http://", "").replace("www.", "").split("/")[0].lower()
         card = VendorCard(
             normalized_name=norm,
             display_name=vendor_name,
@@ -1577,20 +1667,30 @@ async def sightings_composer_vendor(
         # Post-commit background enrichment when a usable domain came with the
         # website. Lazy imports: tests mock _background_enrich_vendor and
         # get_credential_cached at their SOURCE modules (CLAUDE.md), and the
-        # coroutine opens its own session (never the request session).
-        if card.domain and not card.last_enriched_at:
-            from ..services.credential_service import get_credential_cached
+        # coroutine opens its own session (never the request session). F7: the
+        # card is already committed — a failure ANYWHERE in this block is logged
+        # and the created row is still returned (enrichment is best-effort;
+        # turning it into a 500 would misreport a successful create).
+        try:
+            if card.domain and not card.last_enriched_at:
+                from ..services.credential_service import get_credential_cached
 
-            if get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY") or get_credential_cached(
-                "anthropic_ai", "ANTHROPIC_API_KEY"
-            ):
-                from ..utils.async_helpers import safe_background_task
-                from ..utils.vendor_helpers import _background_enrich_vendor
+                if get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY") or get_credential_cached(
+                    "anthropic_ai", "ANTHROPIC_API_KEY"
+                ):
+                    from ..utils.async_helpers import safe_background_task
+                    from ..utils.vendor_helpers import _background_enrich_vendor
 
-                await safe_background_task(
-                    _background_enrich_vendor(card.id, card.domain, card.display_name),
-                    task_name="enrich_vendor_from_composer",
-                )
+                    await safe_background_task(
+                        _background_enrich_vendor(card.id, card.domain, card.display_name),
+                        task_name="enrich_vendor_from_composer",
+                    )
+        except Exception:
+            logger.error(
+                "Post-create enrichment kickoff failed for vendor card {} — card committed and returned",
+                card.id,
+                exc_info=True,
+            )
 
     # Active-only unavailability re-check for the selected parts: an excluded
     # vendor renders the rose chip with a DISABLED checkbox and never joins the
@@ -1608,6 +1708,7 @@ async def sightings_composer_vendor(
         "request": request,
         "vendor": card,
         "matched_existing": matched_existing,
+        "contact_added": contact_added,
         "is_excluded": is_excluded,
     }
     return template_response("htmx/partials/sightings/composer_vendor_row.html", ctx)
@@ -1716,6 +1817,11 @@ async def sightings_send_inquiry(
         )
 
     requirements = db.query(Requirement).filter(Requirement.id.in_(requirement_ids)).all()
+    if not requirements:
+        # Every posted requirement id is stale (rows deleted under an open modal).
+        # Without this guard the send would proceed with NO requisition at all —
+        # emails out, zero Contact tracking — instead of telling the user.
+        raise HTTPException(status_code=400, detail="selected requirements no longer exist — refresh and retry")
 
     # Send-time re-validation (closes the TOCTOU the modal filter alone leaves open):
     # vendors with an ACTIVE unavailability record on the selected parts are dropped
@@ -1806,6 +1912,10 @@ async def sightings_send_inquiry(
                     progressed_count += 1
     except Exception:
         logger.warning("RFQ send failed", exc_info=True)
+        # A mid-batch crash can leave partial Contact/ActivityLog rows pending on
+        # the session — roll them back BEFORE the commit below, or the commit
+        # would persist tracking for sends in an unknown state.
+        db.rollback()
         failed_vendors = list(sendable_vendors)
         sent_count = 0
 

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -1327,12 +1327,24 @@ async def sightings_vendor_modal(
     excluded = excluded_vendor_norms(db, requirements) if requirements else set()
 
     suggested_vendors: list[VendorCard] = []
+    coverage: dict[int, dict[str, Any]] = {}
     if req_id_list:
+        # Coverage-ranked suggestions: one grouped query over VendorSightingSummary
+        # filtered to the selected requirements, joined to VendorCard via the
+        # vendor_card_id FK (indexed ix_vss_vendor_card) — NOT the legacy
+        # lower(trim(vendor_name)) name join. VSS rows with NULL vendor_card_id are
+        # excluded by design: the modal suggests known vendors (cards), never raw
+        # sighting names. Plain-column aggregates only (SQLite+PG safe).
+        covered_count = sqlfunc.count(sqlfunc.distinct(VendorSightingSummary.requirement_id))
         vendor_query = (
-            db.query(VendorCard)
+            db.query(
+                VendorCard,
+                covered_count.label("covered_count"),
+                sqlfunc.avg(VendorSightingSummary.score).label("avg_score"),
+            )
             .join(
                 VendorSightingSummary,
-                sqlfunc.lower(sqlfunc.trim(VendorSightingSummary.vendor_name)) == VendorCard.normalized_name,
+                VendorSightingSummary.vendor_card_id == VendorCard.id,
             )
             .filter(
                 VendorSightingSummary.requirement_id.in_(req_id_list),
@@ -1341,9 +1353,44 @@ async def sightings_vendor_modal(
         )
         if excluded:
             vendor_query = vendor_query.filter(VendorCard.normalized_name.notin_(sorted(excluded)))
-        suggested_vendors = (
-            vendor_query.order_by(VendorCard.engagement_score.desc().nullslast()).distinct().limit(20).all()
+        rows = (
+            vendor_query.group_by(VendorCard.id)
+            .order_by(
+                covered_count.desc(),
+                VendorCard.engagement_score.desc().nullslast(),
+                VendorCard.id,
+            )
+            .limit(20)
+            .all()
         )
+        suggested_vendors = [card for card, _, _ in rows]
+        coverage = {
+            card.id: {
+                "count": int(n_covered),
+                "avg_score": float(avg_score) if avg_score is not None else None,
+                "mpns": "",
+            }
+            for card, n_covered, avg_score in rows
+        }
+        if coverage:
+            # Covered-MPN list per vendor (rendered in the row's `title`) — a second
+            # plain query; no string_agg/group_concat (SQLite vs PG divergence).
+            mpn_rows = (
+                db.query(VendorSightingSummary.vendor_card_id, Requirement.primary_mpn)
+                .join(Requirement, VendorSightingSummary.requirement_id == Requirement.id)
+                .filter(
+                    VendorSightingSummary.requirement_id.in_(req_id_list),
+                    VendorSightingSummary.vendor_card_id.in_(list(coverage)),
+                )
+                .distinct()
+                .all()
+            )
+            mpns_by_card: dict[int, set[str]] = {}
+            for card_id, mpn in mpn_rows:
+                if mpn:
+                    mpns_by_card.setdefault(card_id, set()).add(mpn)
+            for card_id, mpns in mpns_by_card.items():
+                coverage[card_id]["mpns"] = ", ".join(sorted(mpns))
         if excluded:
             # Belt and braces: some legacy cards carry a normalized_name that predates
             # normalize_vendor_name (suffix kept) — re-check through the canonical
@@ -1353,10 +1400,12 @@ async def sightings_vendor_modal(
                 for v in suggested_vendors
                 if normalize_vendor_name(v.display_name or v.normalized_name or "") not in excluded
             ]
+            coverage = {v.id: coverage[v.id] for v in suggested_vendors}
 
     ctx = {
         "request": request,
         "suggested_vendors": suggested_vendors,
+        "coverage": coverage,
         "requirement_ids": req_id_list,
         "parts": parts,
     }

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -1299,6 +1299,80 @@ async def sightings_log_activity(
     return resp
 
 
+def _coverage_ranked_vendor_rows(
+    db: Session, req_id_list: list[int], excluded: set[str]
+) -> list[tuple[VendorCard, int, float | None]]:
+    """Coverage-ranked suggested vendors — the single source shared by the vendor modal
+    and the affinity endpoint (which must drop already-suggested vendors computed the
+    SAME way, so it stays self-contained).
+
+    One grouped query over VendorSightingSummary filtered to the selected
+    requirements, joined to VendorCard via the vendor_card_id FK (indexed
+    ix_vss_vendor_card) — NOT the legacy lower(trim(vendor_name)) name join. VSS rows
+    with NULL vendor_card_id are excluded by design: the modal suggests known vendors
+    (cards), never raw sighting names. Plain-column aggregates only (SQLite+PG safe).
+    Returns (card, covered_count, avg_score) rows, coverage desc then engagement
+    desc, capped at 20.
+    """
+    covered_count = sqlfunc.count(sqlfunc.distinct(VendorSightingSummary.requirement_id))
+    vendor_query = (
+        db.query(
+            VendorCard,
+            covered_count.label("covered_count"),
+            sqlfunc.avg(VendorSightingSummary.score).label("avg_score"),
+        )
+        .join(
+            VendorSightingSummary,
+            VendorSightingSummary.vendor_card_id == VendorCard.id,
+        )
+        .filter(
+            VendorSightingSummary.requirement_id.in_(req_id_list),
+            VendorCard.is_blacklisted.is_(False),
+        )
+    )
+    if excluded:
+        vendor_query = vendor_query.filter(VendorCard.normalized_name.notin_(sorted(excluded)))
+    rows = (
+        vendor_query.group_by(VendorCard.id)
+        .order_by(
+            covered_count.desc(),
+            VendorCard.engagement_score.desc().nullslast(),
+            VendorCard.id,
+        )
+        .limit(20)
+        .all()
+    )
+    if excluded:
+        # Belt and braces: some legacy cards carry a normalized_name that predates
+        # normalize_vendor_name (suffix kept) — re-check through the canonical
+        # normalizer so "X, Inc." cards can't slip past the column filter.
+        rows = [
+            (card, n_covered, avg_score)
+            for card, n_covered, avg_score in rows
+            if normalize_vendor_name(card.display_name or card.normalized_name or "") not in excluded
+        ]
+    return rows
+
+
+def _find_affinity_in_thread(mpn: str) -> list[dict]:
+    """Run the SYNC find_vendor_affinity on a worker thread with its OWN session.
+
+    SQLAlchemy sessions are not thread-safe, so the request session never crosses the
+    to_thread boundary — each call opens and closes a fresh SessionLocal (the
+    established thread-work pattern: description_service._collect_db_descriptions,
+    jobs/tagging_jobs). find_vendor_affinity is imported lazily so tests mock it at
+    the source module (app.services.vendor_affinity_service), never the import site.
+    """
+    from ..database import SessionLocal
+    from ..services.vendor_affinity_service import find_vendor_affinity
+
+    thread_db = SessionLocal()
+    try:
+        return find_vendor_affinity(mpn, thread_db)
+    finally:
+        thread_db.close()
+
+
 @router.get("/v2/partials/sightings/vendor-modal", response_class=HTMLResponse)
 async def sightings_vendor_modal(
     request: Request,
@@ -1329,40 +1403,7 @@ async def sightings_vendor_modal(
     suggested_vendors: list[VendorCard] = []
     coverage: dict[int, dict[str, Any]] = {}
     if req_id_list:
-        # Coverage-ranked suggestions: one grouped query over VendorSightingSummary
-        # filtered to the selected requirements, joined to VendorCard via the
-        # vendor_card_id FK (indexed ix_vss_vendor_card) — NOT the legacy
-        # lower(trim(vendor_name)) name join. VSS rows with NULL vendor_card_id are
-        # excluded by design: the modal suggests known vendors (cards), never raw
-        # sighting names. Plain-column aggregates only (SQLite+PG safe).
-        covered_count = sqlfunc.count(sqlfunc.distinct(VendorSightingSummary.requirement_id))
-        vendor_query = (
-            db.query(
-                VendorCard,
-                covered_count.label("covered_count"),
-                sqlfunc.avg(VendorSightingSummary.score).label("avg_score"),
-            )
-            .join(
-                VendorSightingSummary,
-                VendorSightingSummary.vendor_card_id == VendorCard.id,
-            )
-            .filter(
-                VendorSightingSummary.requirement_id.in_(req_id_list),
-                VendorCard.is_blacklisted.is_(False),
-            )
-        )
-        if excluded:
-            vendor_query = vendor_query.filter(VendorCard.normalized_name.notin_(sorted(excluded)))
-        rows = (
-            vendor_query.group_by(VendorCard.id)
-            .order_by(
-                covered_count.desc(),
-                VendorCard.engagement_score.desc().nullslast(),
-                VendorCard.id,
-            )
-            .limit(20)
-            .all()
-        )
+        rows = _coverage_ranked_vendor_rows(db, req_id_list, excluded)
         suggested_vendors = [card for card, _, _ in rows]
         coverage = {
             card.id: {
@@ -1391,16 +1432,6 @@ async def sightings_vendor_modal(
                     mpns_by_card.setdefault(card_id, set()).add(mpn)
             for card_id, mpns in mpns_by_card.items():
                 coverage[card_id]["mpns"] = ", ".join(sorted(mpns))
-        if excluded:
-            # Belt and braces: some legacy cards carry a normalized_name that predates
-            # normalize_vendor_name (suffix kept) — re-check through the canonical
-            # normalizer so "X, Inc." cards can't slip past the column filter.
-            suggested_vendors = [
-                v
-                for v in suggested_vendors
-                if normalize_vendor_name(v.display_name or v.normalized_name or "") not in excluded
-            ]
-            coverage = {v.id: coverage[v.id] for v in suggested_vendors}
 
     ctx = {
         "request": request,
@@ -1410,6 +1441,65 @@ async def sightings_vendor_modal(
         "parts": parts,
     }
     return template_response("htmx/partials/sightings/vendor_modal.html", ctx)
+
+
+@router.get("/v2/partials/sightings/vendor-affinity", response_class=HTMLResponse)
+async def sightings_vendor_affinity(
+    request: Request,
+    requirement_ids: str = "",
+    db: Session = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    """On-demand affinity vendor suggestions for the RFQ vendor modal.
+
+    Called by: vendor_modal.html "Suggest more vendors" button (hx-get swaps the
+    rows into #rfq-affinity-section, replacing the button — second click impossible).
+    Runs find_vendor_affinity per selected primary MPN, merges/dedupes by vendor
+    keeping the highest confidence, drops vendors already coverage-suggested (same
+    query as the modal — self-contained) or unavailability-excluded, caps at 10.
+
+    THREADING: find_vendor_affinity is SYNC with a blocking Anthropic L3 call inside
+    (3-12s for 6 parts) — each per-MPN call runs via asyncio.to_thread with its own
+    short-lived session (_find_affinity_in_thread), gathered under a Semaphore(3) so
+    a wide selection can't exhaust the thread pool. Never call it bare from this
+    async route: it would block the uvicorn worker.
+    """
+    req_id_list = [int(x) for x in requirement_ids.split(",") if x.strip().isdigit()]
+    requirements = (db.query(Requirement).filter(Requirement.id.in_(req_id_list)).all()) if req_id_list else []
+
+    affinity_vendors: list[dict] = []
+    if requirements:
+        excluded = excluded_vendor_norms(db, requirements)
+        suggested_norms: set[str] = set()
+        for card, _, _ in _coverage_ranked_vendor_rows(db, req_id_list, excluded):
+            # Both spellings: the stored normalized_name (may be legacy-suffixed) and
+            # the canonical re-normalization — affinity matches are compared canonically.
+            suggested_norms.add(card.normalized_name or "")
+            suggested_norms.add(normalize_vendor_name(card.display_name or card.normalized_name or ""))
+
+        # One affinity call per UNIQUE primary MPN (order-preserving dedupe — no
+        # double L3 spend when requirements share an MPN).
+        mpns = list(dict.fromkeys(r.primary_mpn for r in requirements if r.primary_mpn))
+        sem = asyncio.Semaphore(3)
+
+        async def _bounded(mpn: str) -> list[dict]:
+            async with sem:
+                return await asyncio.to_thread(_find_affinity_in_thread, mpn)
+
+        per_mpn_matches = await asyncio.gather(*(_bounded(m) for m in mpns))
+
+        best: dict[str, dict] = {}
+        for matches in per_mpn_matches:
+            for match in matches:
+                norm = normalize_vendor_name(match.get("vendor_name") or "")
+                if not norm or norm in suggested_norms or norm in excluded:
+                    continue
+                if norm not in best or match["confidence"] > best[norm]["confidence"]:
+                    best[norm] = {**match, "normalized_name": norm}
+        affinity_vendors = sorted(best.values(), key=lambda m: m["confidence"], reverse=True)[:10]
+
+    ctx = {"request": request, "affinity_vendors": affinity_vendors}
+    return template_response("htmx/partials/sightings/vendor_affinity_rows.html", ctx)
 
 
 @router.post("/v2/partials/sightings/preview-inquiry", response_class=HTMLResponse)

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -1390,8 +1390,9 @@ async def sightings_preview_inquiry(
     excluded = excluded_vendor_norms(db, requirements)
     unavailable_vendors, vendor_names = _partition_by_unavailability(vendor_names, excluded)
 
-    requisition_ids = {r.requisition_id for r in requirements}
-    requisition_id = next(iter(requisition_ids)) if requisition_ids else None
+    # LOCKSTEP with send-inquiry: one [ref:{id}] token per involved requisition,
+    # ascending requisition id — exactly what send_batch_rfq will append.
+    requisition_ids = sorted({r.requisition_id for r in requirements})
 
     # Batch-fetch vendor cards + contacts (same logic as send-inquiry)
     normalized_names = [normalize_vendor_name(vn) for vn in vendor_names]
@@ -1404,7 +1405,7 @@ async def sightings_preview_inquiry(
 
     from ..email_service import _build_html_body
 
-    avail_token = f"[ref:{requisition_id}]" if requisition_id else ""
+    avail_token = " ".join(f"[ref:{rid}]" for rid in requisition_ids)
     parts_list = [{"mpn": r.primary_mpn, "qty": r.target_qty} for r in requirements]
 
     previews = []
@@ -1472,8 +1473,12 @@ async def sightings_send_inquiry(
     excluded = excluded_vendor_norms(db, requirements)
     unavailable_vendors, sendable_vendors = _partition_by_unavailability(vendor_names, excluded)
 
-    requisition_ids = {r.requisition_id for r in requirements}
-    requisition_id = next(iter(requisition_ids)) if requisition_ids else None
+    # Per-requisition parts map: NO collapse to one arbitrary requisition. Each
+    # involved requisition gets its own Contact rows (scoped to its parts) and
+    # its own [ref:{id}] subject token inside send_batch_rfq.
+    requisition_parts_map: dict[int, list] = {}
+    for r in requirements:
+        requisition_parts_map.setdefault(r.requisition_id, []).append({"mpn": r.primary_mpn, "qty": r.target_qty})
 
     # Batch-fetch vendor cards + contacts in two queries instead of N+1
     normalized_names = [normalize_vendor_name(vn) for vn in sendable_vendors]
@@ -1515,8 +1520,8 @@ async def sightings_send_inquiry(
                 token=token,
                 db=db,
                 user_id=user.id,
-                requisition_id=requisition_id,
                 vendor_groups=vendor_groups,
+                requisition_parts_map=requisition_parts_map,
             )
         else:
             results = []  # every requested vendor was dropped by the unavailability re-check

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -48,6 +48,7 @@ from ..services.part_offers import part_offers_for
 from ..services.sighting_status import compute_vendor_statuses
 from ..services.sse_broker import broker
 from ..services.status_machine import SOURCING_TRANSITIONS, require_valid_transition
+from ..services.vendor_duplicates import check_vendor_duplicate
 from ..services.vendor_unavailability import (
     clear_unavailability,
     excluded_vendor_norms,
@@ -1500,6 +1501,116 @@ async def sightings_vendor_affinity(
 
     ctx = {"request": request, "affinity_vendors": affinity_vendors}
     return template_response("htmx/partials/sightings/vendor_affinity_rows.html", ctx)
+
+
+@router.post("/v2/partials/sightings/composer-vendor", response_class=HTMLResponse)
+async def sightings_composer_vendor(
+    request: Request,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    """Resolve-or-create a vendor for the RFQ composer's any-vendor picker.
+
+    Called by: vendor_modal.html — both the "Find any vendor" autocomplete pick and
+    the "Add new vendor" inline mini-form POST here (form fields: vendor_name
+    required; website, email, requirement_ids optional); the returned row is
+    appended into the stable-id #rfq-added-vendors sub-container.
+
+    Flow: check_vendor_duplicate (the extracted service — direct call, never
+    loopback HTTP). A confident duplicate is an EXACT normalized-name match (the
+    service's own classification: exact short-circuits at score 100; fuzzy >= 80
+    are suggestions, not dupes) → return the EXISTING vendor as a selected row with
+    a "matched existing vendor" notice, no new DB row. Otherwise create the minimal
+    VendorCard (normalized_name, display_name, optional domain parsed from the
+    website — the crm/offers manual-entry pattern) plus a VendorContact when an
+    email was given, commit, then fire _background_enrich_vendor post-commit
+    (identical to the materials.py / vendor_contacts.py patterns; imports are lazy
+    so tests mock both gates at their source modules).
+
+    If the resolved vendor is unavailability-excluded for the selected
+    requirement_ids, the row renders the rose "marked unavailable" chip with a
+    DISABLED checkbox — send-time re-validation stays the backstop.
+    """
+    form = await request.form()
+    vendor_name = str(form.get("vendor_name") or "").strip()
+    norm = normalize_vendor_name(vendor_name)
+    if not vendor_name or not norm:
+        raise HTTPException(status_code=400, detail="vendor_name required")
+    website = str(form.get("website") or "").strip()
+    email = str(form.get("email") or "").strip()
+    if email and "@" not in email:
+        raise HTTPException(status_code=400, detail="invalid contact email")
+    req_id_list = [int(x) for x in form.getlist("requirement_ids") if str(x).strip().isdigit()]
+
+    matches = check_vendor_duplicate(vendor_name, db)
+    matched_existing = bool(matches) and matches[0]["match"] == "exact"
+
+    if matched_existing:
+        # Confident duplicate: hand back the existing card — no new DB row at all.
+        card = db.get(VendorCard, matches[0]["id"])
+    else:
+        domain = ""
+        if website:
+            domain = website.replace("https://", "").replace("http://", "").replace("www.", "").split("/")[0].lower()
+        card = VendorCard(
+            normalized_name=norm,
+            display_name=vendor_name,
+            domain=domain or None,
+            emails=[],
+            phones=[],
+        )
+        db.add(card)
+        db.flush()
+        if email:
+            db.add(
+                VendorContact(
+                    vendor_card_id=card.id,
+                    email=email,
+                    contact_type="company",
+                    source="rfq_manual",
+                    confidence=80,
+                    is_verified=False,
+                )
+            )
+        db.commit()
+
+        # Post-commit background enrichment when a usable domain came with the
+        # website. Lazy imports: tests mock _background_enrich_vendor and
+        # get_credential_cached at their SOURCE modules (CLAUDE.md), and the
+        # coroutine opens its own session (never the request session).
+        if card.domain and not card.last_enriched_at:
+            from ..services.credential_service import get_credential_cached
+
+            if get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY") or get_credential_cached(
+                "anthropic_ai", "ANTHROPIC_API_KEY"
+            ):
+                from ..utils.async_helpers import safe_background_task
+                from ..utils.vendor_helpers import _background_enrich_vendor
+
+                await safe_background_task(
+                    _background_enrich_vendor(card.id, card.domain, card.display_name),
+                    task_name="enrich_vendor_from_composer",
+                )
+
+    # Active-only unavailability re-check for the selected parts: an excluded
+    # vendor renders the rose chip with a DISABLED checkbox and never joins the
+    # selection. Both norm spellings are checked (stored normalized_name may be
+    # legacy-suffixed), same belt-and-braces as _coverage_ranked_vendor_rows.
+    is_excluded = False
+    if req_id_list:
+        requirements = db.query(Requirement).filter(Requirement.id.in_(req_id_list)).all()
+        if requirements:
+            excluded = excluded_vendor_norms(db, requirements)
+            canonical = normalize_vendor_name(card.display_name or card.normalized_name or "")
+            is_excluded = canonical in excluded or (card.normalized_name or "") in excluded
+
+    ctx = {
+        "request": request,
+        "vendor": card,
+        "matched_existing": matched_existing,
+        "is_excluded": is_excluded,
+    }
+    return template_response("htmx/partials/sightings/composer_vendor_row.html", ctx)
 
 
 @router.post("/v2/partials/sightings/preview-inquiry", response_class=HTMLResponse)

--- a/app/routers/vendors_crud.py
+++ b/app/routers/vendors_crud.py
@@ -8,7 +8,6 @@ Depends on: models, dependencies, vendor_utils, vendor_helpers, cache
 """
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from loguru import logger
 from sqlalchemy import func as sqlfunc
 from sqlalchemy import text as sqltext
 from sqlalchemy.exc import OperationalError, ProgrammingError
@@ -22,62 +21,16 @@ from ..models.strategic import StrategicVendor
 from ..models.vendors import VendorContact
 from ..schemas.responses import VendorDetailResponse, VendorListResponse
 from ..schemas.vendors import VendorBlacklistToggle, VendorCardUpdate, VendorReviewCreate
+
+# The duplicate-check logic lives in the service (shared with the sightings RFQ
+# composer's POST composer-vendor endpoint). _fuzzy_match_python is re-exported
+# for back-compat — existing callers/tests import it from this module.
+from ..services.vendor_duplicates import _fuzzy_match_python  # noqa: F401
+from ..services.vendor_duplicates import check_vendor_duplicate as _check_vendor_duplicate
 from ..utils.search_builder import SearchBuilder
 from ..utils.vendor_helpers import card_to_dict
-from ..vendor_utils import normalize_vendor_name
 
 router = APIRouter(tags=["vendors"])
-
-FUZZY_MATCH_POOL_SIZE = 500  # Max vendors loaded for fuzzy duplicate check
-TRIGRAM_SIMILARITY_THRESHOLD = 0.3  # pg_trgm similarity threshold (0.3 ≈ 80+ rapidfuzz score)
-
-
-def _fuzzy_match_pg_trgm(db: Session, norm: str) -> list[dict]:
-    """Use PostgreSQL pg_trgm similarity() for index-backed fuzzy matching."""
-    sim = sqlfunc.similarity(VendorCard.normalized_name, norm).label("score")
-    rows = (
-        db.query(VendorCard.id, VendorCard.display_name, sim)
-        .filter(sim >= TRIGRAM_SIMILARITY_THRESHOLD)
-        .order_by(sim.desc())
-        .limit(5)
-        .all()
-    )
-    return [
-        {
-            "id": row.id,
-            "name": row.display_name,
-            "match": "fuzzy",
-            "score": round(row.score * 100),
-        }
-        for row in rows
-    ]
-
-
-def _fuzzy_match_python(db: Session, norm: str) -> list[dict]:
-    """Fallback O(n) fuzzy match using rapidfuzz (for SQLite / environments without
-    pg_trgm)."""
-    try:
-        from rapidfuzz import fuzz
-    except ImportError:  # pragma: no cover
-        return []
-
-    existing = (
-        db.query(VendorCard.id, VendorCard.normalized_name, VendorCard.display_name).limit(FUZZY_MATCH_POOL_SIZE).all()
-    )
-    matches = []
-    for row in existing:
-        score = fuzz.token_sort_ratio(norm, row.normalized_name)
-        if score >= 80:
-            matches.append(
-                {
-                    "id": row.id,
-                    "name": row.display_name,
-                    "match": "fuzzy",
-                    "score": round(score),
-                }
-            )
-    matches.sort(key=lambda m: m["score"], reverse=True)
-    return matches[:5]
 
 
 @router.get("/api/vendors/check-duplicate")
@@ -90,37 +43,10 @@ async def check_vendor_duplicate(
 
     Returns exact and fuzzy matches (threshold 80 for suggestions). Used by frontend
     before vendor creation to warn about duplicates. Uses PostgreSQL pg_trgm trigram
-    index when available, falls back to Python-side rapidfuzz matching on SQLite.
+    index when available, falls back to Python-side rapidfuzz matching on SQLite. Thin
+    wrapper over services.vendor_duplicates.check_vendor_duplicate.
     """
-    norm = normalize_vendor_name(name)
-    matches = []
-
-    # Exact match
-    exact = db.query(VendorCard).filter_by(normalized_name=norm).first()
-    if exact:
-        matches.append(
-            {
-                "id": exact.id,
-                "name": exact.display_name,
-                "match": "exact",
-                "score": 100,
-            }
-        )
-        return {"matches": matches}
-
-    # Fuzzy matches — use pg_trgm on PostgreSQL, rapidfuzz fallback on SQLite
-    dialect = db.bind.dialect.name if db.bind else ""
-    if dialect == "postgresql":
-        try:
-            matches = _fuzzy_match_pg_trgm(db, norm)
-        except (OperationalError, ProgrammingError):
-            db.rollback()
-            logger.warning("pg_trgm not available, falling back to Python fuzzy match")
-            matches = _fuzzy_match_python(db, norm)
-    else:
-        matches = _fuzzy_match_python(db, norm)
-
-    return {"matches": matches[:5]}
+    return {"matches": _check_vendor_duplicate(name, db)}
 
 
 @router.get("/api/vendors", response_model=VendorListResponse, response_model_exclude_none=True)

--- a/app/services/vendor_duplicates.py
+++ b/app/services/vendor_duplicates.py
@@ -1,0 +1,112 @@
+"""vendor_duplicates.py — vendor duplicate-check service (exact + fuzzy).
+
+The single importable home for the duplicate logic that previously lived inline
+in the /api/vendors/check-duplicate route: an EXACT normalized-name match
+short-circuits as the one confident duplicate (score 100); otherwise fuzzy
+candidates (suggestions, threshold 80) come from PostgreSQL pg_trgm
+similarity() (index-backed) with a Python-side rapidfuzz fallback for SQLite /
+environments without pg_trgm.
+
+Called by: app/routers/vendors_crud.py (GET /api/vendors/check-duplicate) and
+           app/routers/sightings.py (POST /v2/partials/sightings/composer-vendor)
+           — both call this function directly, never loopback HTTP.
+Depends on: models.VendorCard, vendor_utils.normalize_vendor_name, rapidfuzz
+            (fallback path only).
+"""
+
+from loguru import logger
+from sqlalchemy import func as sqlfunc
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.orm import Session
+
+from ..models import VendorCard
+from ..vendor_utils import normalize_vendor_name
+
+FUZZY_MATCH_POOL_SIZE = 500  # Max vendors loaded for fuzzy duplicate check
+TRIGRAM_SIMILARITY_THRESHOLD = 0.3  # pg_trgm similarity threshold (0.3 ≈ 80+ rapidfuzz score)
+
+
+def _fuzzy_match_pg_trgm(db: Session, norm: str) -> list[dict]:
+    """Use PostgreSQL pg_trgm similarity() for index-backed fuzzy matching."""
+    sim = sqlfunc.similarity(VendorCard.normalized_name, norm).label("score")
+    rows = (
+        db.query(VendorCard.id, VendorCard.display_name, sim)
+        .filter(sim >= TRIGRAM_SIMILARITY_THRESHOLD)
+        .order_by(sim.desc())
+        .limit(5)
+        .all()
+    )
+    return [
+        {
+            "id": row.id,
+            "name": row.display_name,
+            "match": "fuzzy",
+            "score": round(row.score * 100),
+        }
+        for row in rows
+    ]
+
+
+def _fuzzy_match_python(db: Session, norm: str) -> list[dict]:
+    """Fallback O(n) fuzzy match using rapidfuzz (for SQLite / environments without
+    pg_trgm)."""
+    try:
+        from rapidfuzz import fuzz
+    except ImportError:  # pragma: no cover
+        return []
+
+    existing = (
+        db.query(VendorCard.id, VendorCard.normalized_name, VendorCard.display_name).limit(FUZZY_MATCH_POOL_SIZE).all()
+    )
+    matches = []
+    for row in existing:
+        score = fuzz.token_sort_ratio(norm, row.normalized_name)
+        if score >= 80:
+            matches.append(
+                {
+                    "id": row.id,
+                    "name": row.display_name,
+                    "match": "fuzzy",
+                    "score": round(score),
+                }
+            )
+    matches.sort(key=lambda m: m["score"], reverse=True)
+    return matches[:5]
+
+
+def check_vendor_duplicate(name: str, db: Session) -> list[dict]:
+    """Duplicate-check a vendor name: exact + fuzzy matches, capped at 5.
+
+    An exact normalized-name match returns immediately as the single confident
+    duplicate ({"match": "exact", "score": 100}); otherwise fuzzy candidates
+    ({"match": "fuzzy", "score": >= 80}) are merely suggestions for the caller
+    to surface. Uses the pg_trgm trigram index on PostgreSQL, falling back to
+    Python-side rapidfuzz on SQLite or when pg_trgm is unavailable.
+    """
+    norm = normalize_vendor_name(name)
+
+    # Exact match — the one confident duplicate, short-circuits fuzzy entirely
+    exact = db.query(VendorCard).filter_by(normalized_name=norm).first()
+    if exact:
+        return [
+            {
+                "id": exact.id,
+                "name": exact.display_name,
+                "match": "exact",
+                "score": 100,
+            }
+        ]
+
+    # Fuzzy matches — use pg_trgm on PostgreSQL, rapidfuzz fallback on SQLite
+    dialect = db.bind.dialect.name if db.bind else ""
+    if dialect == "postgresql":
+        try:
+            matches = _fuzzy_match_pg_trgm(db, norm)
+        except (OperationalError, ProgrammingError):
+            db.rollback()
+            logger.warning("pg_trgm not available, falling back to Python fuzzy match")
+            matches = _fuzzy_match_python(db, norm)
+    else:
+        matches = _fuzzy_match_python(db, norm)
+
+    return matches[:5]

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1742,6 +1742,16 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
   previewing: false,
   sending: false,
 
+  // ── Any-vendor picker + inline create (bulk composer spec Part 2 §3/§4) ──
+  vendorQuery: '',
+  vendorResults: [],
+  searchOpen: false,
+  addingVendor: false,
+  addingVendorBusy: false,
+  newVendorName: '',
+  newVendorWebsite: '',
+  newVendorEmail: '',
+
   get selectedCount() {
     return Object.keys(this.selectedVendors).length;
   },
@@ -1751,6 +1761,86 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
   toggleVendor(name) {
     if (this.selectedVendors[name]) delete this.selectedVendors[name];
     else this.selectedVendors[name] = true;
+  },
+  // Server-returned composer rows (composer_vendor_row.html) x-init through here so
+  // they arrive CHECKED — runtime-added keys flow into vendor_names via _form().
+  selectVendor(name) {
+    this.selectedVendors[name] = true;
+  },
+
+  // Debounced (template-side @input.debounce.300ms) lookup against the existing
+  // /api/autocomplete/names endpoint. It mixes vendors + customers — filter to
+  // vendors client-side; never fork the endpoint.
+  async searchVendors() {
+    const q = this.vendorQuery.trim();
+    if (q.length < 2) {
+      this.vendorResults = [];
+      this.searchOpen = false;
+      return;
+    }
+    try {
+      const resp = await fetch('/api/autocomplete/names?q=' + encodeURIComponent(q));
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      const items = await resp.json();
+      this.vendorResults = (items || []).filter((it) => it.type === 'vendor');
+      this.searchOpen = true;
+    } catch (err) {
+      console.error('[rfqVendorModal] vendor search failed', err);
+      this.vendorResults = [];
+      this.searchOpen = false;
+    }
+  },
+
+  async pickVendor(name) {
+    this.searchOpen = false;
+    this.vendorQuery = '';
+    this.vendorResults = [];
+    await this._addComposerVendor({ vendor_name: name });
+  },
+
+  async createVendor() {
+    if (!this.newVendorName.trim() || this.addingVendorBusy) return;
+    this.addingVendorBusy = true;
+    try {
+      const ok = await this._addComposerVendor({
+        vendor_name: this.newVendorName.trim(),
+        website: this.newVendorWebsite.trim(),
+        email: this.newVendorEmail.trim(),
+      });
+      if (ok) {
+        this.newVendorName = '';
+        this.newVendorWebsite = '';
+        this.newVendorEmail = '';
+        this.addingVendor = false;
+      }
+    } finally {
+      this.addingVendorBusy = false;
+    }
+  },
+
+  // POST to composer-vendor and append the returned row into the stable-id
+  // #rfq-added-vendors sub-container INSIDE this x-data wrapper (explicit target —
+  // swapping the wrapper would re-init rfqVendorModal and wipe selection state).
+  // The global htmx:configRequest listener adds the x-csrftoken header.
+  async _addComposerVendor(fields) {
+    const form = new FormData();
+    form.append('vendor_name', fields.vendor_name);
+    if (fields.website) form.append('website', fields.website);
+    if (fields.email) form.append('email', fields.email);
+    this.requirementIds.forEach((id) => form.append('requirement_ids', id));
+    try {
+      await htmx.ajax('POST', '/v2/partials/sightings/composer-vendor', {
+        target: '#rfq-added-vendors',
+        swap: 'beforeend',
+        indicator: '#rfq-added-vendors-spinner',
+        values: form,
+      });
+      return true;
+    } catch (err) {
+      console.error('[rfqVendorModal] add vendor failed', err);
+      this._toast('Could not add vendor — please try again', 'error');
+      return false;
+    }
   },
 
   // Build a FormData with REPEATED keys for the multi-valued fields. (Object.fromEntries

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -644,9 +644,12 @@ htmx.on('htmx:afterSwap', function(evt) {
     // HTMX innerHTML swaps do not always auto-run Alpine on new nodes.
     // Explicit initTree for targets known to contain Alpine components/directives
     // (lead drawer close button; rq2-table rows with rowActionRail, x-truncate-tip,
-    // x-chip-overflow — directives that must re-bind after filter/sort/action swaps).
+    // x-chip-overflow — directives that must re-bind after filter/sort/action swaps;
+    // rfq-affinity-section — affinity rows whose :checked/@change checkboxes bind to
+    // the surrounding rfqVendorModal x-data scope, otherwise the checkboxes are inert
+    // and ticked affinity vendors never enter selectedVendors / never get sent).
     if (t && typeof Alpine !== 'undefined' && typeof Alpine.initTree === 'function') {
-        if (t.id === 'lead-drawer-content' || t.id === 'rq2-table') {
+        if (t.id === 'lead-drawer-content' || t.id === 'rq2-table' || t.id === 'rfq-affinity-section') {
             Alpine.initTree(t);
         }
     }
@@ -1931,6 +1934,16 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
       // Server HTML is trusted (same-origin, auth-protected endpoint).
       container.insertAdjacentHTML('beforeend', html);
       htmx.process(container);
+      // The appended row carries Alpine directives (x-init='selectVendor(...)',
+      // :checked, @change) that bind to THIS rfqVendorModal x-data scope. htmx.process
+      // only wires htmx attributes, not Alpine's, and relying on Alpine 3's
+      // MutationObserver is exactly the unreliable path the afterSwap handler warns
+      // about — explicitly initTree the new node so the row arrives CHECKED and its
+      // checkbox is live (matches the lead-drawer / rq2-table workaround).
+      const addedRow = container.lastElementChild;
+      if (addedRow && typeof Alpine !== 'undefined' && typeof Alpine.initTree === 'function') {
+        Alpine.initTree(addedRow);
+      }
       return true;
     } catch (err) {
       console.error('[rfqVendorModal] add vendor failed', err);
@@ -1998,7 +2011,11 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
       const sent = parseInt(resp.headers.get('X-RFQ-Sent') || '0', 10);
       const total = parseInt(resp.headers.get('X-RFQ-Total') || String(count), 10);
       const skipped = parseInt(resp.headers.get('X-RFQ-Skipped') || '0', 10);
-      const outcome = this._sendOutcome(sent, total, skipped);
+      // X-RFQ-Unavailable = vendors dropped by the send-time unavailability re-check.
+      // They are NOT delivery failures — without subtracting them they'd be
+      // misattributed to the 'failed' bucket (total - sent - skipped).
+      const unavailable = parseInt(resp.headers.get('X-RFQ-Unavailable') || '0', 10);
+      const outcome = this._sendOutcome(sent, total, skipped, unavailable);
       this._toast(outcome.message, outcome.type);
       if (!outcome.delivered) return; // nothing sent — keep the modal open to retry
       this._refreshSightings();
@@ -2011,18 +2028,21 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
     }
   },
 
-  // Map the server's sent/total/skipped counts to a toast. `delivered` is false only when
-  // nothing went out, so the caller can keep the modal open for a retry. `skipped` =
-  // vendors with no contact email — reported distinctly from send failures.
-  _sendOutcome(sent, total, skipped = 0) {
+  // Map the server's sent/total/skipped/unavailable counts to a toast. `delivered` is
+  // false only when nothing went out, so the caller can keep the modal open for a retry.
+  // `skipped` = vendors with no contact email; `unavailable` = vendors dropped by the
+  // send-time unavailability re-check — both reported distinctly from send failures so a
+  // correctly-blocked vendor is never miscounted as 'failed'.
+  _sendOutcome(sent, total, skipped = 0, unavailable = 0) {
     if (sent === 0) {
       return { type: 'error', delivered: false, message: 'Send failed — no RFQs were delivered' };
     }
     if (sent < total) {
-      const failed = total - sent - skipped;
+      const failed = total - sent - skipped - unavailable;
       const reasons = [];
       if (failed > 0) reasons.push(failed + ' failed');
       if (skipped > 0) reasons.push(skipped + ' had no email');
+      if (unavailable > 0) reasons.push(unavailable + ' marked unavailable');
       return {
         type: 'warning',
         delivered: true,

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1818,28 +1818,85 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
     }
   },
 
+  // Fast-path dedup: true when `name` matches a selection key case-insensitively.
+  // Keys are server-NORMALIZED names (suffixes stripped) while picker/typed names
+  // are display names, so this only catches exact/case matches — the authoritative
+  // check in _addComposerVendor re-tests the server's normalized name from the row.
+  _isVendorSelected(name) {
+    const q = (name || '').trim().toLowerCase();
+    return Object.keys(this.selectedVendors).some((k) => k.toLowerCase() === q);
+  },
+
+  // Extract the server-normalized vendor name from a composer_vendor_row.html
+  // payload: the selectable row x-inits selectVendor("<normalized>") with a
+  // |tojson-quoted string (json escapes embedded `"`). Excluded rows render no
+  // x-init → null. Parsed detached via DOMParser (no script execution, no insert).
+  _rowVendorName(html) {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const xInit = doc.querySelector('[x-init]')?.getAttribute('x-init') || '';
+    const m = xInit.match(/selectVendor\(("(?:[^"\\]|\\.)*")\)/);
+    if (!m) return null;
+    try {
+      return JSON.parse(m[1]);
+    } catch {
+      return null;
+    }
+  },
+
   // POST to composer-vendor and append the returned row into the stable-id
-  // #rfq-added-vendors sub-container INSIDE this x-data wrapper (explicit target —
+  // #rfq-added-vendors sub-container INSIDE this x-data wrapper (explicit container —
   // swapping the wrapper would re-init rfqVendorModal and wipe selection state).
-  // The global htmx:configRequest listener adds the x-csrftoken header.
+  // Raw fetch + manual insert (mirrors confirmSend / customerPicker.lookupCompany)
+  // so a server 4xx is DETECTED: htmx.ajax resolves on HTTP errors, which used to
+  // clear the inline create form on a 400. Returns true only when the vendor ended
+  // up selected (row appended, or already present — duplicate picks skip the append
+  // so #rfq-added-vendors never shows the same vendor twice); false on any error so
+  // createVendor keeps the typed values.
   async _addComposerVendor(fields) {
+    if (this._isVendorSelected(fields.vendor_name)) {
+      this._toast('Vendor already added', 'info');
+      return true;
+    }
     const form = new FormData();
     form.append('vendor_name', fields.vendor_name);
     if (fields.website) form.append('website', fields.website);
     if (fields.email) form.append('email', fields.email);
     this.requirementIds.forEach((id) => form.append('requirement_ids', id));
+    const spinner = document.querySelector('#rfq-added-vendors-spinner');
+    spinner?.classList.add('htmx-request');
     try {
-      await htmx.ajax('POST', '/v2/partials/sightings/composer-vendor', {
-        target: '#rfq-added-vendors',
-        swap: 'beforeend',
-        indicator: '#rfq-added-vendors-spinner',
-        values: form,
+      // starlette_csrf requires the x-csrftoken header on POST (mirrors confirmSend).
+      const csrf = document.cookie.match(/csrftoken=([^;]+)/)?.[1] || '';
+      const resp = await fetch('/v2/partials/sightings/composer-vendor', {
+        method: 'POST',
+        headers: { 'x-csrftoken': csrf },
+        body: form,
       });
+      if (!resp.ok) {
+        console.error('[rfqVendorModal] add vendor failed: HTTP ' + resp.status);
+        this._toast('Could not add vendor — please try again', 'error');
+        return false;
+      }
+      const html = await resp.text();
+      // Authoritative dedup on the server-normalized name: picking
+      // "Mouser Electronics, Inc." when "mouser electronics" is already selected
+      // would append a duplicate row while selection state stays unchanged.
+      const normalized = this._rowVendorName(html);
+      if (normalized && this.selectedVendors[normalized]) {
+        this._toast('Vendor already added', 'info');
+        return true;
+      }
+      const container = document.querySelector('#rfq-added-vendors');
+      // Server HTML is trusted (same-origin, auth-protected endpoint).
+      container.insertAdjacentHTML('beforeend', html);
+      htmx.process(container);
       return true;
     } catch (err) {
       console.error('[rfqVendorModal] add vendor failed', err);
       this._toast('Could not add vendor — please try again', 'error');
       return false;
+    } finally {
+      spinner?.classList.remove('htmx-request');
     }
   },
 

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1770,7 +1770,10 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
 
   // Debounced (template-side @input.debounce.300ms) lookup against the existing
   // /api/autocomplete/names endpoint. It mixes vendors + customers — filter to
-  // vendors client-side; never fork the endpoint.
+  // vendors client-side; never fork the endpoint. A failure is VISIBLE (toast),
+  // but only once per failure streak — debounced keystrokes would otherwise
+  // stack identical toasts; a success resets the flag.
+  _searchErrorToasted: false,
   async searchVendors() {
     const q = this.vendorQuery.trim();
     if (q.length < 2) {
@@ -1784,10 +1787,15 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
       const items = await resp.json();
       this.vendorResults = (items || []).filter((it) => it.type === 'vendor');
       this.searchOpen = true;
+      this._searchErrorToasted = false;
     } catch (err) {
       console.error('[rfqVendorModal] vendor search failed', err);
       this.vendorResults = [];
       this.searchOpen = false;
+      if (!this._searchErrorToasted) {
+        this._searchErrorToasted = true;
+        this._toast('Vendor search failed — please try again', 'error');
+      }
     }
   },
 
@@ -1828,11 +1836,14 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
   },
 
   // Extract the server-normalized vendor name from a composer_vendor_row.html
-  // payload: the selectable row x-inits selectVendor("<normalized>") with a
-  // |tojson-quoted string (json escapes embedded `"`). Excluded rows render no
-  // x-init → null. Parsed detached via DOMParser (no script execution, no insert).
+  // payload. Both row branches carry a data-vendor-norm attribute (excluded rows
+  // have no x-init, so the attribute is their ONLY carrier); the x-init
+  // selectVendor("<normalized>") parse stays as a fallback for selectable rows.
+  // Parsed detached via DOMParser (no script execution, no insert).
   _rowVendorName(html) {
     const doc = new DOMParser().parseFromString(html, 'text/html');
+    const norm = doc.querySelector('[data-vendor-norm]')?.getAttribute('data-vendor-norm');
+    if (norm) return norm;
     const xInit = doc.querySelector('[x-init]')?.getAttribute('x-init') || '';
     const m = xInit.match(/selectVendor\(("(?:[^"\\]|\\.)*")\)/);
     if (!m) return null;
@@ -1843,17 +1854,33 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
     }
   },
 
+  // True when #rfq-added-vendors already holds a row for this normalized name —
+  // the dedupe for EXCLUDED rows, which never join selectedVendors (disabled
+  // checkbox) and would otherwise stack duplicates on repeated picks.
+  _containerHasVendor(norm) {
+    const container = document.querySelector('#rfq-added-vendors');
+    if (!container) return false;
+    return Array.from(container.querySelectorAll('[data-vendor-norm]')).some(
+      (el) => el.getAttribute('data-vendor-norm') === norm,
+    );
+  },
+
   // POST to composer-vendor and append the returned row into the stable-id
   // #rfq-added-vendors sub-container INSIDE this x-data wrapper (explicit container —
   // swapping the wrapper would re-init rfqVendorModal and wipe selection state).
   // Raw fetch + manual insert (mirrors confirmSend / customerPicker.lookupCompany)
   // so a server 4xx is DETECTED: htmx.ajax resolves on HTTP errors, which used to
   // clear the inline create form on a 400. Returns true only when the vendor ended
-  // up selected (row appended, or already present — duplicate picks skip the append
-  // so #rfq-added-vendors never shows the same vendor twice); false on any error so
-  // createVendor keeps the typed values.
+  // up selected (row appended, or already present — duplicate picks skip the
+  // append, INCLUDING excluded rows via the container check, so #rfq-added-vendors
+  // never shows the same vendor twice); false on any error so createVendor keeps
+  // the typed values.
   async _addComposerVendor(fields) {
-    if (this._isVendorSelected(fields.vendor_name)) {
+    // Bare picks only: a createVendor submission carrying an email/website must
+    // reach the server even when the name matches a selection — the server
+    // attaches the typed email/domain to the existing card; skipping here would
+    // silently discard the input.
+    if (!fields.email && !fields.website && this._isVendorSelected(fields.vendor_name)) {
       this._toast('Vendor already added', 'info');
       return true;
     }
@@ -1873,16 +1900,30 @@ Alpine.data('rfqVendorModal', (suggestedNames, requirementIds) => ({
         body: form,
       });
       if (!resp.ok) {
-        console.error('[rfqVendorModal] add vendor failed: HTTP ' + resp.status);
-        this._toast('Could not add vendor — please try again', 'error');
+        // The server emits the repo JSON error format ({"error": ...}). A 4xx
+        // reason is actionable user input ("invalid website — ...") — surface it
+        // verbatim; 5xx bodies are internals, keep the generic try-again.
+        let reason = '';
+        try {
+          reason = (await resp.json()).error || '';
+        } catch {
+          /* non-JSON / empty body — fall through to the generic message */
+        }
+        console.error('[rfqVendorModal] add vendor failed: HTTP ' + resp.status, reason);
+        const msg = resp.status < 500 && reason
+          ? 'Could not add vendor: ' + reason
+          : 'Could not add vendor — please try again';
+        this._toast(msg, 'error');
         return false;
       }
       const html = await resp.text();
       // Authoritative dedup on the server-normalized name: picking
       // "Mouser Electronics, Inc." when "mouser electronics" is already selected
       // would append a duplicate row while selection state stays unchanged.
+      // Excluded rows never enter selectedVendors, so they dedupe against the
+      // rows already in the container instead.
       const normalized = this._rowVendorName(html);
-      if (normalized && this.selectedVendors[normalized]) {
+      if (normalized && (this.selectedVendors[normalized] || this._containerHasVendor(normalized))) {
         this._toast('Vendor already added', 'info');
         return true;
       }

--- a/app/templates/htmx/partials/sightings/composer_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/composer_vendor_row.html
@@ -1,6 +1,7 @@
 {# composer_vendor_row.html — single vendor row returned by the RFQ composer's
    any-vendor picker / inline "Add new vendor" form (POST composer-vendor).
-   Called by: sightings.py sightings_composer_vendor — appended (hx swap beforeend)
+   Called by: sightings.py sightings_composer_vendor — appended via _addComposerVendor's
+   raw fetch POST + insertAdjacentHTML('beforeend') + htmx.process + Alpine.initTree
    into the stable-id #rfq-added-vendors sub-container in vendor_modal.html, INSIDE
    the rfqVendorModal x-data wrapper (never the wrapper — re-init wipes selection).
    Depends on: the surrounding rfqVendorModal Alpine component (htmx_app.js) — a

--- a/app/templates/htmx/partials/sightings/composer_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/composer_vendor_row.html
@@ -1,0 +1,38 @@
+{# composer_vendor_row.html — single vendor row returned by the RFQ composer's
+   any-vendor picker / inline "Add new vendor" form (POST composer-vendor).
+   Called by: sightings.py sightings_composer_vendor — appended (hx swap beforeend)
+   into the stable-id #rfq-added-vendors sub-container in vendor_modal.html, INSIDE
+   the rfqVendorModal x-data wrapper (never the wrapper — re-init wipes selection).
+   Depends on: the surrounding rfqVendorModal Alpine component (htmx_app.js) — a
+   selectable row x-inits through selectVendor() so it arrives CHECKED and joins the
+   SAME isSelected/toggleVendor selection state as the suggested/affinity rows; an
+   unavailability-excluded row renders the rose chip with a DISABLED checkbox and
+   never touches the selection (send-time re-validation stays the backstop).
+   Context: vendor (VendorCard), matched_existing (bool), is_excluded (bool).
+#}
+{% if is_excluded %}
+<label class="flex items-center gap-3 px-3 py-2 mt-1 border border-rose-100 rounded-lg bg-rose-50/60">
+  <input type="checkbox" disabled class="rounded border-gray-300 cursor-not-allowed">
+  <div class="flex-1 min-w-0">
+    <span class="text-sm font-medium text-gray-500">{{ vendor.display_name }}</span>
+    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-rose-100 text-rose-700">marked unavailable</span>
+    {% if matched_existing %}
+    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor</span>
+    {% endif %}
+  </div>
+</label>
+{% else %}
+<label class="flex items-center gap-3 px-3 py-2 mt-1 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer"
+       x-init='selectVendor({{ vendor.normalized_name|tojson }})'>
+  <input type="checkbox"
+         :checked='isSelected({{ vendor.normalized_name|tojson }})'
+         @change='toggleVendor({{ vendor.normalized_name|tojson }})'
+         class="rounded border-gray-300">
+  <div class="flex-1 min-w-0">
+    <span class="text-sm font-medium text-gray-700">{{ vendor.display_name }}</span>
+    {% if matched_existing %}
+    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor</span>
+    {% endif %}
+  </div>
+</label>
+{% endif %}

--- a/app/templates/htmx/partials/sightings/composer_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/composer_vendor_row.html
@@ -7,22 +7,27 @@
    selectable row x-inits through selectVendor() so it arrives CHECKED and joins the
    SAME isSelected/toggleVendor selection state as the suggested/affinity rows; an
    unavailability-excluded row renders the rose chip with a DISABLED checkbox and
-   never touches the selection (send-time re-validation stays the backstop).
-   Context: vendor (VendorCard), matched_existing (bool), is_excluded (bool).
+   never touches the selection (send-time re-validation stays the backstop). BOTH
+   branches emit data-vendor-norm so _rowVendorName/_containerHasVendor can dedupe
+   excluded rows too (they have no x-init to read the name from).
+   Context: vendor (VendorCard), matched_existing (bool), contact_added (bool —
+   typed email attached to the matched existing card), is_excluded (bool).
 #}
 {% if is_excluded %}
-<label class="flex items-center gap-3 px-3 py-2 mt-1 border border-rose-100 rounded-lg bg-rose-50/60">
+<label class="flex items-center gap-3 px-3 py-2 mt-1 border border-rose-100 rounded-lg bg-rose-50/60"
+       data-vendor-norm="{{ vendor.normalized_name }}">
   <input type="checkbox" disabled class="rounded border-gray-300 cursor-not-allowed">
   <div class="flex-1 min-w-0">
     <span class="text-sm font-medium text-gray-500">{{ vendor.display_name }}</span>
     <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-rose-100 text-rose-700">marked unavailable</span>
     {% if matched_existing %}
-    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor</span>
+    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor{% if contact_added %} — contact email added{% endif %}</span>
     {% endif %}
   </div>
 </label>
 {% else %}
 <label class="flex items-center gap-3 px-3 py-2 mt-1 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer"
+       data-vendor-norm="{{ vendor.normalized_name }}"
        x-init='selectVendor({{ vendor.normalized_name|tojson }})'>
   <input type="checkbox"
          :checked='isSelected({{ vendor.normalized_name|tojson }})'
@@ -31,7 +36,7 @@
   <div class="flex-1 min-w-0">
     <span class="text-sm font-medium text-gray-700">{{ vendor.display_name }}</span>
     {% if matched_existing %}
-    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor</span>
+    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor{% if contact_added %} — contact email added{% endif %}</span>
     {% endif %}
   </div>
 </label>

--- a/app/templates/htmx/partials/sightings/vendor_affinity_rows.html
+++ b/app/templates/htmx/partials/sightings/vendor_affinity_rows.html
@@ -1,0 +1,33 @@
+{# Affinity vendor suggestion rows for the RFQ vendor modal (on demand).
+   Called by: sightings.py sightings_vendor_affinity — swapped by the vendor_modal.html
+   "Suggest more vendors" button into #rfq-affinity-section (innerHTML, replacing the
+   button so a second request can never duplicate rows).
+   Depends on: the surrounding rfqVendorModal Alpine component (htmx_app.js) — the
+   checkboxes join the SAME isSelected/toggleVendor selection state as the suggested
+   rows, keyed by normalized vendor name, so checked rows flow into vendor_names.
+   Context: affinity_vendors (list of dicts: vendor_name, normalized_name, confidence,
+   reasoning), confidence-desc, capped at 10.
+#}
+{% if affinity_vendors %}
+<label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+  More Vendors ({{ affinity_vendors|length }} by affinity)
+</label>
+<div class="max-h-56 overflow-y-auto border border-gray-200 rounded-lg divide-y divide-gray-100">
+  {% for v in affinity_vendors %}
+  <label class="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 cursor-pointer">
+    <input type="checkbox"
+           :checked='isSelected({{ v.normalized_name|tojson }})'
+           @change='toggleVendor({{ v.normalized_name|tojson }})'
+           class="rounded border-gray-300">
+    <div class="flex-1 min-w-0">
+      <span class="text-sm font-medium text-gray-700">{{ v.vendor_name }}</span>
+      <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700"
+            title="{{ v.reasoning }}">affinity</span>
+      <span class="ml-2 text-[10px] text-gray-400">{{ (v.confidence * 100)|round|int }}% match</span>
+    </div>
+  </label>
+  {% endfor %}
+</div>
+{% else %}
+<p class="text-xs text-gray-400 italic">No additional vendors found by affinity.</p>
+{% endif %}

--- a/app/templates/htmx/partials/sightings/vendor_affinity_rows.html
+++ b/app/templates/htmx/partials/sightings/vendor_affinity_rows.html
@@ -6,7 +6,8 @@
    checkboxes join the SAME isSelected/toggleVendor selection state as the suggested
    rows, keyed by normalized vendor name, so checked rows flow into vendor_names.
    Context: affinity_vendors (list of dicts: vendor_name, normalized_name, confidence,
-   reasoning), confidence-desc, capped at 10.
+   reasoning), confidence-desc, capped at 10; affinity_partial (bool — at least one
+   selected MPN's affinity lookup failed, so the list may be missing vendors).
 #}
 {% if affinity_vendors %}
 <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
@@ -30,4 +31,7 @@
 </div>
 {% else %}
 <p class="text-xs text-gray-400 italic">No additional vendors found by affinity.</p>
+{% endif %}
+{% if affinity_partial %}
+<p class="mt-1 text-[10px] text-gray-400 italic">Suggestions incomplete — some parts could not be checked.</p>
 {% endif %}

--- a/app/templates/htmx/partials/sightings/vendor_modal.html
+++ b/app/templates/htmx/partials/sightings/vendor_modal.html
@@ -45,6 +45,30 @@
         </label>
         {% endfor %}
       </div>
+
+      {# Affinity suggestions (on demand): a stable-id sub-container INSIDE the x-data
+         wrapper — the hx-get targets THIS div, never the wrapper (re-initializing
+         rfqVendorModal would wipe the runtime selection state). The button sits inside
+         the target, so the innerHTML swap replaces it with the rows — a second click
+         is impossible (no-duplicate guarantee). #}
+      {% if requirement_ids %}
+      <div id="rfq-affinity-section" class="mt-2">
+        <button type="button"
+                hx-get="/v2/partials/sightings/vendor-affinity?requirement_ids={{ requirement_ids|join(',') }}"
+                hx-target="#rfq-affinity-section"
+                hx-swap="innerHTML"
+                hx-indicator="#rfq-affinity-spinner"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-brand-200 text-brand-700 text-xs font-medium rounded-lg hover:bg-brand-50 transition-colors">
+          <span id="rfq-affinity-spinner" class="htmx-indicator">
+            <svg class="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+            </svg>
+          </span>
+          Suggest more vendors
+        </button>
+      </div>
+      {% endif %}
     </div>
 
     {# Parts reference (read-only) #}

--- a/app/templates/htmx/partials/sightings/vendor_modal.html
+++ b/app/templates/htmx/partials/sightings/vendor_modal.html
@@ -75,8 +75,10 @@
       {% endif %}
 
       {# Added vendors (autocomplete picks + inline creates): stable-id append target
-         for composer_vendor_row.html — htmx.ajax POSTs to composer-vendor target THIS
-         div with swap beforeend (explicit target + indicator; see _addComposerVendor). #}
+         for composer_vendor_row.html — _addComposerVendor does a raw fetch POST to
+         composer-vendor, then insertAdjacentHTML('beforeend') + htmx.process +
+         Alpine.initTree on THIS div (raw fetch chosen over htmx.ajax to detect 4xx;
+         see _addComposerVendor). #}
       <div id="rfq-added-vendors"></div>
       <span id="rfq-added-vendors-spinner" class="htmx-indicator mt-1 inline-flex items-center text-gray-400">
         <svg class="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">

--- a/app/templates/htmx/partials/sightings/vendor_modal.html
+++ b/app/templates/htmx/partials/sightings/vendor_modal.html
@@ -16,8 +16,10 @@
   <div x-show="step === 'compose'" x-cloak>
     <h3 class="text-lg font-semibold text-gray-900 mb-3">Send Inquiry</h3>
 
-    {# Vendor list #}
-    <div class="mb-4">
+    {# Vendor panel — stable container id; every swap below targets a stable-id
+       SUB-container inside the x-data wrapper, never the wrapper itself
+       (re-initializing rfqVendorModal would wipe runtime selection state). #}
+    <div id="rfq-vendor-panel" class="mb-4">
       <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
         Select Vendors ({{ suggested_vendors|length }} suggested)
       </label>
@@ -69,6 +71,68 @@
         </button>
       </div>
       {% endif %}
+
+      {# Added vendors (autocomplete picks + inline creates): stable-id append target
+         for composer_vendor_row.html — htmx.ajax POSTs to composer-vendor target THIS
+         div with swap beforeend (explicit target + indicator; see _addComposerVendor). #}
+      <div id="rfq-added-vendors"></div>
+      <span id="rfq-added-vendors-spinner" class="htmx-indicator mt-1 inline-flex items-center text-gray-400">
+        <svg class="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+        </svg>
+      </span>
+
+      {# Find any vendor: debounced autocomplete against /api/autocomplete/names —
+         vendors only, filtered client-side in searchVendors() (endpoint not forked).
+         Picking a result POSTs to composer-vendor and appends the returned row. #}
+      <div class="mt-2 relative">
+        <input type="text" x-model="vendorQuery"
+               @input.debounce.300ms="searchVendors()"
+               @focus="searchOpen = vendorResults.length > 0"
+               @click.away="searchOpen = false"
+               placeholder="Find any vendor..."
+               autocomplete="off"
+               aria-label="Find any vendor"
+               class="w-full px-3 py-1.5 border border-gray-200 rounded-lg text-sm focus:border-brand-400 focus:ring-1 focus:ring-brand-200 outline-none">
+        <div x-show="searchOpen" x-cloak
+             class="absolute z-50 left-0 right-0 mt-1 max-h-40 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg">
+          <template x-for="v in vendorResults" :key="v.id">
+            <button type="button" @click="pickVendor(v.name)"
+                    class="w-full text-left px-3 py-1.5 text-sm text-gray-700 hover:bg-brand-50 hover:text-brand-700 truncate"
+                    x-text="v.name"></button>
+          </template>
+          <div x-show="vendorResults.length === 0" x-cloak
+               class="px-3 py-1.5 text-xs text-gray-400 italic">No vendors found</div>
+        </div>
+      </div>
+
+      {# Add vendor on the fly: inline mini-form behind a toggle (the unified req
+         modal's "+ New Customer" pattern) — POSTs to the same composer-vendor
+         endpoint via createVendor(). #}
+      <button type="button" @click="addingVendor = !addingVendor"
+              class="mt-2 text-xs font-semibold text-brand-600 hover:text-brand-700">
+        + Add new vendor
+      </button>
+      <div x-show="addingVendor" x-cloak
+           class="mt-2 p-3 bg-gray-50 rounded-lg border border-gray-200 space-y-2">
+        <div class="flex items-center justify-between">
+          <span class="text-xs font-semibold text-gray-700">New Vendor</span>
+          <button type="button" @click="addingVendor = false"
+                  class="text-xs text-gray-400 hover:text-gray-600">Cancel</button>
+        </div>
+        <input aria-label="Vendor name" type="text" x-model="newVendorName" placeholder="Vendor name *"
+               class="w-full px-2 py-1 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-brand-500">
+        <input aria-label="Website" type="url" x-model="newVendorWebsite" placeholder="Website (optional)"
+               class="w-full px-2 py-1 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-brand-500">
+        <input aria-label="Contact email" type="email" x-model="newVendorEmail" placeholder="Contact email (optional)"
+               class="w-full px-2 py-1 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-brand-500">
+        <button type="button" :disabled="!newVendorName.trim() || addingVendorBusy"
+                @click="createVendor()"
+                class="px-3 py-1 text-xs font-semibold bg-brand-500 text-white rounded hover:bg-brand-600 disabled:opacity-50">
+          <span x-text="addingVendorBusy ? 'Adding...' : 'Add Vendor'"></span>
+        </button>
+      </div>
     </div>
 
     {# Parts reference (read-only) #}

--- a/app/templates/htmx/partials/sightings/vendor_modal.html
+++ b/app/templates/htmx/partials/sightings/vendor_modal.html
@@ -1,7 +1,8 @@
 {# Vendor selection + email compose modal for batch RFQ with preview step.
    Called by: "Send to Vendors" action bar button via @open-modal dispatch
    Depends on: modal.html pattern, HTMX, Alpine.js, preview_inquiry.html
-   Context: suggested_vendors, requirement_ids, parts
+   Context: suggested_vendors, coverage (card id → {count, avg_score, mpns}),
+            requirement_ids, parts
 #}
 
 {# The component logic lives in the rfqVendorModal() factory in app/static/htmx_app.js.
@@ -29,6 +30,11 @@
                  class="rounded border-gray-300">
           <div class="flex-1 min-w-0">
             <span class="text-sm font-medium text-gray-700">{{ v.display_name }}</span>
+            {% set cov = coverage.get(v.id) %}
+            {% if cov %}
+            <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700"
+                  title="Covers: {{ cov.mpns }}">{{ cov.count }}/{{ parts|length }} parts</span>
+            {% endif %}
             {% if v.response_rate %}
             <span class="ml-2 text-[10px] text-gray-400">{{ (v.response_rate * 100)|round|int }}% response</span>
             {% endif %}

--- a/app/templates/htmx/partials/sightings/vendor_modal.html
+++ b/app/templates/htmx/partials/sightings/vendor_modal.html
@@ -45,6 +45,8 @@
           <span class="text-[10px] text-gray-400">Score: {{ v.engagement_score|round|int }}</span>
           {% endif %}
         </label>
+        {% else %}
+        <p class="px-3 py-2 text-xs text-gray-400">No vendors with sightings for these parts — search or add one below.</p>
         {% endfor %}
       </div>
 

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -105,17 +105,28 @@
 
 > UNIQUE `uq_vendor_part_unavail_vendor_mpn` (vendor_name_normalized, normalized_mpn) — marking again for an existing pair is an upsert (the re-arm path), never a duplicate. Written and read only via `app/services/vendor_unavailability.py` (record/clear/apply/release/exclude) and `app/services/sighting_status.py` (reader-authority status branch).
 
-**`contacts`** — RFQ emails sent to vendors
+**`contacts`** — outreach to vendors (RFQ emails, logged calls)
 | Column | Type | Notes |
 |--------|------|-------|
 | id | Integer PK | |
 | requisition_id | FK -> requisitions (CASCADE) | |
 | user_id | FK -> users (CASCADE) | |
-| contact_type | String 20 | rfq\|follow_up\|etc |
+| contact_type | String 20 | email (RFQ sends)\|phone (logged calls) |
 | vendor_name | String 255 | |
 | vendor_contact | String 255 | Email address |
+| parts_included | JSON | Parts asked of the vendor — scoped to THIS row's requisition |
 | graph_message_id | String 500 | Microsoft Graph tracking |
+| graph_conversation_id | String 500 | Graph thread id — inbox-monitor Tier-1 reply matching |
 | status | String 50 | sent\|replied\|etc |
+
+> **Row semantics: one row per (requisition, vendor) pair.** A cross-requisition
+> bulk RFQ (sightings composer) still sends ONE email per vendor, but
+> `send_batch_rfq` writes one Contact per involved requisition — each
+> `parts_included` holding only its own requisition's parts, all of a vendor's
+> rows sharing that one email's `graph_message_id` / `graph_conversation_id`.
+> The inbox monitor therefore treats `graph_conversation_id` as one-to-many
+> (a reply on the thread progresses EVERY contact sharing it). No schema change
+> was needed — multiplicity lives in rows, `requisition_id` stays singular.
 
 **`vendor_responses`** — Replies from vendors to RFQs
 | Column | Type | Notes |

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -673,9 +673,13 @@ the `rfqVendorModal` section below) is fed from four sources:
 1. **Coverage-ranked suggestions (default).** `sightings_vendor_modal` runs the
    shared `_coverage_ranked_vendor_rows` query: a grouped query over
    `VendorSightingSummary` filtered to the selected requirements, joined to
-   `VendorCard` via the `vendor_card_id` FK (indexed `ix_vss_vendor_card`) —
-   NOT the legacy `lower(trim(vendor_name))` name join; VSS rows with NULL
-   `vendor_card_id` are excluded by design (the modal suggests known vendors).
+   `VendorCard` via `_vss_vendor_card_join()` — an `or_()` coalesce whose PRIMARY
+   branch is the `vendor_card_id` FK (indexed `ix_vss_vendor_card`), with a
+   `lower(trim(vendor_name)) == normalized_name` FALLBACK for NULL-FK rows (so a
+   known vendor's coverage never silently disappears when a post-rebuild summary
+   hasn't been FK-backfilled yet; the NULL-FK guard on the fallback prevents
+   double-matching FK rows by name). Only VSS summaries matching no card at all —
+   neither by FK nor by name — are excluded.
    Order: covered-part count desc, then engagement desc; cap 20. Each row shows
    an `N/M parts` chip with the covered MPNs in `title` (computed server-side,
    plain-column aggregates — SQLite+PG safe). `excluded_vendor_norms`
@@ -717,6 +721,16 @@ Every HTMX swap for these sections targets a stable-id sub-container INSIDE the
 `x-data='rfqVendorModal(...)'` wrapper (`#rfq-affinity-section`,
 `#rfq-added-vendors`) — never the wrapper itself, which would re-init the
 Alpine component and wipe runtime selection state.
+
+The affinity and composer rows carry Alpine directives (`:checked='isSelected(...)'`,
+`@change='toggleVendor(...)'`, `x-init='selectVendor(...)'`) that bind to the
+surrounding `rfqVendorModal` scope, and **htmx innerHTML swaps do not reliably
+auto-run Alpine on new nodes**. So both swap targets are explicitly
+`Alpine.initTree`-d: `#rfq-affinity-section` is in the `htmx:afterSwap` allowlist
+(`htmx_app.js`, alongside `lead-drawer-content` / `rq2-table`), and the composer row
+is `initTree`-d by `_addComposerVendor` after its `insertAdjacentHTML`. Without this
+the checkboxes are inert and ticked vendors never enter `selectedVendors` / never get
+sent.
 
 ## 4. Inbox Monitoring & Response Parsing (Background Job)
 
@@ -2536,10 +2550,13 @@ inline-create state (`vendorQuery`, `vendorResults`, `searchOpen`, `addingVendor
 `selectVendor(name)` (server-returned composer rows `x-init` through it so they
 arrive CHECKED); `searchVendors()` → `GET /api/autocomplete/names` filtered to
 `type === "vendor"` client-side; `pickVendor`/`createVendor` → `_addComposerVendor()`,
-an `htmx.ajax` POST to `/v2/partials/sightings/composer-vendor` that appends the
-returned row into the stable-id `#rfq-added-vendors` sub-container (swap
-`beforeend`, explicit target + indicator — never the `x-data` wrapper, whose
-re-init would wipe selection state);
+a **raw `fetch` POST** to `/v2/partials/sightings/composer-vendor` (raw fetch, not
+`htmx.ajax`, so a server 4xx is detected and the inline create form keeps its typed
+values) that appends the returned row into the stable-id `#rfq-added-vendors`
+sub-container via `insertAdjacentHTML('beforeend')` + `htmx.process` +
+`Alpine.initTree` on the new node (so the row's `x-init='selectVendor(...)'` /
+`:checked` / `@change` directives bind to this `x-data` scope and the row arrives
+CHECKED — never the `x-data` wrapper, whose re-init would wipe selection state);
 `loadPreview()` → `POST /v2/partials/sightings/preview-inquiry` (htmx.ajax swap into
 `x-ref="previewContent"`); `confirmSend()` → `fetch POST
 /v2/partials/sightings/send-inquiry` with the `x-csrftoken` header, then on success

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -608,23 +608,115 @@ exits are window expiry, offer/email release, or manual clear.
 Browser POST (send RFQ)
     |
     v
-requirements.py (router)
+Two callers, ONE canonical send path:
+  - htmx_views.rfq_send            (requisition page; legacy scalar requisition_id)
+  - sightings.sightings_send_inquiry (bulk composer; requisition_parts_map)
     |
     v
-email_service.py
+email_service.send_batch_rfq
     |
     +---> graph_client.py --> Microsoft Graph API
-    |       +---> POST /me/sendMail (subject tagged [AVAIL-{req_id}])
-    |       +---> Returns graph_message_id
+    |       +---> POST /me/sendMail — ONE email per vendor; subject carries one
+    |       |     [ref:{req_id}] token per involved requisition, ascending id
+    |       |     ([AVAIL-{id}] is the legacy spelling, still matched on replies)
+    |       +---> Sent-folder lookup -> graph_message_id + graph_conversation_id
     |
-    +---> DB: INSERT contacts (type=rfq, status=sent, graph_message_id)
+    +---> DB: INSERT contacts (type=email, status=sent|failed) — ONE row per
+    |     (requisition, vendor) pair; each parts_included scoped to its OWN
+    |     requisition; all of a vendor's rows share that one email's
+    |     graph_message_id / graph_conversation_id
     |
-    +---> activity_service.py --> DB: INSERT activity_log (outbound email)
+    +---> tag propagation: material_card ids collected from ALL involved
+    |     requisitions' requirements (one pass per unique vendor)
     |
-    +---> vendor_card update: total_outreach++, last_contact_at
-    |
-    +---> teams_notifications.py --> Microsoft Teams webhook
+    v
+back in the sightings router:
+    +---> activity_service.log_rfq_activity per requirement (rfq_sent),
+    |     only for vendors actually sent
+    +---> status auto-progress OPEN -> SOURCING per involved requisition
+    +---> X-RFQ-Sent / X-RFQ-Total / X-RFQ-Skipped / X-RFQ-Unavailable headers
 ```
+
+**Per-requisition Contact fan-out (cross-requisition bulk composer).** The
+sightings vendor modal's selection can span requisitions. There is no collapse
+to one arbitrary requisition anywhere in the path (the old
+`next(iter(requisition_ids))` collapse in both preview and send is gone): the
+router builds a `requisition_parts_map` ({requisition_id: parts}) and
+`send_batch_rfq` takes it as an **additive** parameter. One email per vendor
+still covers ALL selected parts (the point of a bulk composer); the
+multiplicity moves to `Contact` rows — one per (requisition, vendor) pair, each
+`parts_included` holding only that requisition's parts, all sharing the email's
+graph ids. No schema change (Contact keeps its singular `requisition_id`).
+A **legacy shim** keeps the scalar-`requisition_id` call shape byte-identical
+(one Contact per vendor, parts from the vendor group) — `htmx_views.rfq_send`
+was not touched.
+
+**Preview/send lockstep.** `sightings_preview_inquiry` renders the exact
+multi-token subject the send will produce — one `[ref:{id}]` per involved
+requisition, ascending requisition id — so preview and send can never diverge.
+
+**Subject-token single source of truth.** `shared_constants.RFQ_SUBJECT_TAG_RE`
+(`[ref:{id}]` current, `[AVAIL-{id}]` legacy) is the ONE pattern; the duplicate
+`AVAIL_TOKEN_RE` in `email_mining.py` was removed (the miner's sent-scan check
+is presence-only and points at the shared pattern). Extractors use
+`re.findall`, never `.search().group(1)`, so a multi-requisition subject
+attributes to ALL token requisitions: the sent-folder scan
+(`email_jobs.scan_sent_folder`) writes one `email_sent` ActivityLog per token
+requisition (rows share the message's `external_id`, so the dedup check still
+skips re-scans), and inbox Tier-2 matching resolves every token (next section).
+Reply attribution to Contacts is Tier-1 fan-out — see section 4.
+
+**Vendor panel — four selection sources.** The modal's vendor checklist
+(`vendor_modal.html`, all rows joining the same Alpine selection state — see
+the `rfqVendorModal` section below) is fed from four sources:
+
+1. **Coverage-ranked suggestions (default).** `sightings_vendor_modal` runs the
+   shared `_coverage_ranked_vendor_rows` query: a grouped query over
+   `VendorSightingSummary` filtered to the selected requirements, joined to
+   `VendorCard` via the `vendor_card_id` FK (indexed `ix_vss_vendor_card`) —
+   NOT the legacy `lower(trim(vendor_name))` name join; VSS rows with NULL
+   `vendor_card_id` are excluded by design (the modal suggests known vendors).
+   Order: covered-part count desc, then engagement desc; cap 20. Each row shows
+   an `N/M parts` chip with the covered MPNs in `title` (computed server-side,
+   plain-column aggregates — SQLite+PG safe). `excluded_vendor_norms`
+   filtering is unchanged.
+2. **Affinity on demand.** A "Suggest more vendors" button hx-gets
+   `GET /v2/partials/sightings/vendor-affinity?requirement_ids=…`, which runs
+   `find_vendor_affinity` once per UNIQUE primary MPN. The service is SYNC with
+   a blocking Anthropic L3 call inside, so each call runs via
+   `asyncio.to_thread` (with its own short-lived `SessionLocal` — sessions
+   never cross the thread boundary) gathered under an `asyncio.Semaphore(3)`;
+   it is never called bare from the async route. Results are merged/deduped by
+   vendor keeping the highest confidence, dropping already-suggested (same
+   coverage query) and unavailability-excluded vendors, capped at 10; rows
+   render a bordered indigo "affinity" chip + confidence % + reasoning in
+   `title`. The button lives INSIDE its own swap target
+   (`#rfq-affinity-section`), so the response replaces it — a second click
+   cannot duplicate rows.
+3. **Any-vendor autocomplete.** A debounced input against the existing
+   `GET /api/autocomplete/names` (vendors filtered client-side from the mixed
+   response; the endpoint is not forked). Picking a result POSTs
+   `composer-vendor` (below) and appends the returned checked row.
+4. **Inline vendor creation.** An "Add new vendor" mini-form (name required;
+   website + email optional) POSTs `POST /v2/partials/sightings/composer-vendor`,
+   which calls `check_vendor_duplicate` from `app/services/vendor_duplicates.py`
+   (direct service call — never loopback HTTP; the same function backs
+   `GET /api/vendors/check-duplicate`). Duplicate semantics are
+   **exact-match-only**: an exact normalized-name match (score 100) is the one
+   confident duplicate → the EXISTING vendor row is returned with a "matched
+   existing vendor" notice and no new DB row; fuzzy hits (pg_trgm with a
+   rapidfuzz fallback, score >= 80) are suggestions, never auto-dedup.
+   Otherwise it creates a minimal `VendorCard` (+ `VendorContact` when an email
+   was given) and fires `_background_enrich_vendor` post-commit (same pattern
+   as materials/vendor_contacts). Empty name → 400 JSON error. If the resolved
+   vendor is unavailability-excluded for the selected parts, the row renders
+   the rose "marked unavailable" chip with a DISABLED checkbox (send-time
+   re-validation stays the backstop).
+
+Every HTMX swap for these sections targets a stable-id sub-container INSIDE the
+`x-data='rfqVendorModal(...)'` wrapper (`#rfq-affinity-section`,
+`#rfq-added-vendors`) — never the wrapper itself, which would re-init the
+Alpine component and wipe runtime selection state.
 
 ## 4. Inbox Monitoring & Response Parsing (Background Job)
 
@@ -635,14 +727,31 @@ APScheduler (every 30 min)
 email_jobs.py -> inbox_monitor()
     |
     v
-email_service.py
+email_service.poll_inbox()
     |
     +---> graph_client.py --> Graph API: GET inbox messages
-    |       Filter: subject contains [AVAIL-*]
+    |       (delta query incremental sync when available; top-50 fallback —
+    |        ALL messages fetched, matching happens locally below)
     |
-    +---> Match reply to original contact via graph_conversation_id
+    +---> 4-tier reply matching (first tier that hits wins):
+    |       Tier 1: graph_conversation_id (global, exact) — matches ALL
+    |               Contacts sharing the thread: a cross-requisition RFQ
+    |               writes one Contact per (requisition, vendor) on ONE
+    |               conversation, so conv_id_map is dict[str, list[Contact]]
+    |               and the reply is attributed to every one of them
+    |       Tier 2: subject [ref:{id}]/[AVAIL-{id}] tokens — re.findall over
+    |               RFQ_SUBJECT_TAG_RE; every token's (req_id, sender email)
+    |               pair is resolved via req_email_map (unique keys under the
+    |               per-requisition fan-out); tokens with no email match still
+    |               assign the first token's requisition
+    |       Tier 3: sender email -> most-recent contact (USER-SCOPED,
+    |               single-contact fallback BY DESIGN — untokenized replies)
+    |       Tier 4: sender domain (USER-SCOPED, same single-contact design)
     |
-    +---> DB: INSERT vendor_responses (raw email)
+    +---> DB: INSERT vendor_responses (raw email) — exactly ONE per message
+    |     (it is per-message, not per-requisition); contact_id anchors to the
+    |     first matched contact; _progress_contact_status then advances EVERY
+    |     matched contact, so all involved requisitions' rows progress
     |       +---> activity_service.py: log_email_activity() --> DB: INSERT activity_log
     |             (event_type='email', direction='inbound', activity_type='email_received';
     |              dedups on external_id=message_id) so inbound vendor replies
@@ -2302,7 +2411,7 @@ the current implementation.
 | Quotes | 25 | CRUD, send, PDF, e-signature, pricing history |
 | Buy Plans | 6 | CRUD, external approval via token |
 | Materials | 20 | CRUD, substitutes, stock levels, price history |
-| Sightings | 25 | CRUD, RFQ send, batch RFQ, inquiry, vendor+part unavailability (mark/clear/reason modal) |
+| Sightings | 27 | CRUD, RFQ send, batch RFQ, inquiry (cross-requisition composer: vendor-affinity GET + composer-vendor POST), vendor+part unavailability (mark/clear/reason modal) |
 | Excess | 30 | Lists, line items, bids, solicitations, import |
 | AI | 18 | Parse email, normalize, find contacts, draft RFQ |
 | Proactive | 12 | Matches, refresh, dismiss, send, scorecard |
@@ -2320,7 +2429,7 @@ the current implementation.
 
 ---
 
-## Service Modules (118 total)
+## Service Modules (123 top-level)
 
 | Category | Count | Key Modules |
 |----------|-------|-------------|
@@ -2329,7 +2438,7 @@ the current implementation.
 | Email & Communication | 10 | email_threads, contact_intelligence, signature_parser |
 | Scoring & Matching | 10+ | unified_score, avail_score, multiplier_score, proactive_matching |
 | CRM & Data | 20+ | company_merge, vendor_merge, auto_dedup, enrichment |
-| Vendor Mgmt | 8 | vendor_analysis, vendor_affinity, vendor_scorecard |
+| Vendor Mgmt | 9 | vendor_analysis, vendor_affinity, vendor_scorecard, vendor_duplicates |
 | Buy Plans | 6 | buyplan_builder, buyplan_workflow, buyplan_scoring |
 | Materials | 7 | material_enrichment, spec_enrichment_service, materials_ai_search, faceted_search_service, excess_service |
 | Admin & Health | 6 | health_monitor, integrity_service, audit_service |
@@ -2414,14 +2523,27 @@ would close a double-quoted `x-data` attribute and break Alpine init; the data i
 carried through a **single-quoted** attribute (tojson escapes `'`). State:
 `step` (compose|preview), `selectedVendors` (a plain reactive object keyed by vendor
 name — matches the `sightingSelection` store, not a Set; `selectedCount` getter +
-`isSelected(name)` back the bindings), `emailBody`. Methods: `toggleVendor`;
+`isSelected(name)` back the bindings), `emailBody`, plus the any-vendor picker /
+inline-create state (`vendorQuery`, `vendorResults`, `searchOpen`, `addingVendor`,
+`addingVendorBusy`, `newVendorName/Website/Email`). Methods: `toggleVendor`;
+`selectVendor(name)` (server-returned composer rows `x-init` through it so they
+arrive CHECKED); `searchVendors()` → `GET /api/autocomplete/names` filtered to
+`type === "vendor"` client-side; `pickVendor`/`createVendor` → `_addComposerVendor()`,
+an `htmx.ajax` POST to `/v2/partials/sightings/composer-vendor` that appends the
+returned row into the stable-id `#rfq-added-vendors` sub-container (swap
+`beforeend`, explicit target + indicator — never the `x-data` wrapper, whose
+re-init would wipe selection state);
 `loadPreview()` → `POST /v2/partials/sightings/preview-inquiry` (htmx.ajax swap into
 `x-ref="previewContent"`); `confirmSend()` → `fetch POST
 /v2/partials/sightings/send-inquiry` with the `x-csrftoken` header, then on success
 `_refreshSightings()` re-GETs the open `#sightings-detail` (status auto-advances
 OPEN→SOURCING + new activity rows) and the `#sightings-table` list, and dispatches
 `close-modal`. `_form()` builds a `FormData` with **repeated** `requirement_ids`/
-`vendor_names` keys (not `Object.fromEntries`, which collapses duplicates).
+`vendor_names` keys (not `Object.fromEntries`, which collapses duplicates) from
+`Object.keys(selectedVendors)` — so rows added at runtime (affinity rows,
+autocomplete picks, inline creates) flow into `vendor_names` with no extra wiring.
+The vendor panel's four selection sources (coverage-ranked, affinity on demand,
+autocomplete, inline create) are documented flow-level in section 3.
 
 The route returns **HTTP 200 even on partial/total send failure** (failures are
 captured, not raised) and exposes the true outcome via `X-RFQ-Sent` / `X-RFQ-Total` /

--- a/docs/superpowers/plans/2026-06-12-bulk-rfq-composer.md
+++ b/docs/superpowers/plans/2026-06-12-bulk-rfq-composer.md
@@ -14,19 +14,21 @@
 
 ### Task 1: Cross-requisition tracking fix (the load-bearing core)
 
-**Files:**
-- Read FIRST: the inbox-monitor / reply-matching parser (grep email_service.py + jobs for `ref:` parsing) — the spec mandates multi-token attribution; extend the parser root-cause if it only handles one token. Also `grep -rn "send_batch_rfq" app/` — every call site must stay behavior-identical for single-requisition use.
-- Modify: `app/routers/sightings.py` `sightings_send_inquiry` (~:1444-1590) — remove the `next(iter(requisition_ids))` collapse; group requirements per requisition; status auto-progress per involved requisition.
-- Modify: `app/email_service.py` `send_batch_rfq` (:79-262) — accept the requisition→parts mapping (additive/compatible signature per spec Risk note); one email per vendor; subject carries one `[ref:{id}]` token per requisition; one Contact per (requisition, vendor) sharing graph_message_id/graph_conversation_id; per-Contact `parts_included` scoped to that requisition.
-- Modify (if parser needs it): the reply-matching code — attribute replies to ALL Contacts matching any token/conversation id.
-- Test: spec "Testing → Tracking" list verbatim (multi-requisition Contact fan-out, shared graph ids, multi-token subject, reply attribution to all, per-requisition status progression, single-requisition byte-identical regression).
+**Files (anchors architect-verified):**
+- Modify: `app/routers/sightings.py` `sightings_send_inquiry` (:1445, collapse at :1476) — remove the `next(iter(requisition_ids))` collapse; group requirements per requisition; status auto-progress per involved requisition.
+- Modify IN LOCKSTEP: `app/routers/sightings.py` `sightings_preview_inquiry` (:1367, same collapse at :1394) — preview subject must render ALL `[ref:]` tokens exactly as the send will.
+- Modify: `app/email_service.py` `send_batch_rfq` (:79-262) — ADDITIVE param (e.g. `requisition_parts_map: dict[int, list] | None = None`) with a shim converting the legacy scalar `requisition_id` to a one-entry map; one email per vendor; subject carries one `[ref:{id}]` token per requisition; one Contact per (requisition, vendor) sharing graph_message_id/graph_conversation_id; per-Contact `parts_included` scoped to that requisition. The second caller `htmx_views.rfq_send` (`app/routers/htmx_views.py:2642-2650`, scalar req_id) stays byte-identical — do not edit it.
+- Modify: `app/email_service.py` tag-propagation block (:243-260) — currently reads only the single `requisition_id`; iterate ALL involved requisitions' requirements for card ids.
+- Modify (BLOCKER, spec Part 1 "Reply-matcher fan-out"): `app/email_service.py` inbox monitor — `conv_id_map` (:443-451) becomes `dict[str, list[Contact]]`; Tier-1 (:494-496) loops ALL contacts sharing the conversation id; ONE `VendorResponse` per message with `contact_id = contacts[0].id`; `_progress_contact_status` (call :572) iterates the full list. Document in code: `req_email_map` (:448/:454 setdefault) is accidentally correct post-fan-out (unique (req, email) pairs); Tier-3 `email_map` (:459) stays most-recent fallback by design.
+- Modify: token regex consolidation — `AVAIL_TOKEN_RE` (`app/connectors/email_mining.py:61`) and `RFQ_SUBJECT_TAG_RE` (`app/shared_constants.py:124`) are duplicates; keep ONE shared pattern in shared_constants. Switch `.search().group(1)` extraction to `re.findall`: `app/jobs/email_jobs.py:915-917` (sent-folder ActivityLog → attribute to ALL token requisitions); `app/connectors/email_mining.py:520` is presence-only — just point it at the shared pattern.
+- Test: spec "Testing → Tracking / Reply matcher / Preview lockstep / Sent-folder scan" lists verbatim (multi-requisition Contact fan-out, shared graph ids, multi-token subject, Tier-1 attribution to ALL contacts sharing a conversation id, preview multi-token subject, sent-folder scan attributing to all token requisitions, per-requisition status progression, single-requisition byte-identical regression incl. the rfq_send legacy call shape).
 
 - [ ] Failing tests first → implement → green → commit `fix(rfq): per-requisition Contact tracking for cross-requisition sends`
 
 ### Task 2: Coverage-ranked suggested vendors
 
 **Files:**
-- Modify: `app/routers/sightings.py` `sightings_vendor_modal` (~:1302-1363) — replace the flat engagement query with the spec's grouped coverage query over VendorSightingSummary (coverage desc, engagement desc, cap 20); compute covered-MPN lists server-side; keep `excluded_vendor_norms` filtering exactly as today.
+- Modify: `app/routers/sightings.py` `sightings_vendor_modal` (:1303-1363) — replace the flat engagement query with the spec's grouped coverage query over VendorSightingSummary (coverage desc, engagement desc, cap 20); join enrichment data via `VendorSightingSummary.vendor_card_id` (existing FK, indexed `ix_vss_vendor_card`) — NOT the legacy `lower(trim(vendor_name)) == normalized_name` join; add a route comment that VSS rows with NULL `vendor_card_id` are excluded by design (modal suggests known vendors); compute covered-MPN lists server-side; keep `excluded_vendor_norms` filtering exactly as today.
 - Modify: `app/templates/htmx/partials/sightings/vendor_modal.html` — `N/M parts` per row + covered-MPN `title`; existing badges kept.
 - Test: ranking order, exclusion, render assertions (spec "Coverage ranking").
 
@@ -35,18 +37,19 @@
 ### Task 3: Affinity suggestions on demand
 
 **Files:**
-- Modify: `app/routers/sightings.py` — new `GET /v2/partials/sightings/vendor-affinity?requirement_ids=…` per spec §2.2 (merge/dedupe by vendor keep-highest-confidence, drop already-suggested + excluded, cap 10).
-- Create: small partial for the affinity rows (or extend vendor_modal.html section) — bordered indigo chip + confidence % + reasoning in `title`; "Suggest more vendors" button with explicit `hx-target` swapping the section.
-- Test: spec "Affinity endpoint" list; mock the L3 Claude path at the source module.
+- Modify: `app/routers/sightings.py` — new `GET /v2/partials/sightings/vendor-affinity?requirement_ids=…` per spec §2.2 (merge/dedupe by vendor keep-highest-confidence, drop already-suggested + excluded, cap 10). THREADING: `find_vendor_affinity` (`app/services/vendor_affinity_service.py:271`) is SYNC with a blocking Anthropic L3 call inside — wrap each per-MPN call in `asyncio.to_thread(...)`, gathered under `asyncio.Semaphore(3)`; NEVER call it bare from the async route (blocks the uvicorn worker 3-12s for 6 parts).
+- Create: small partial for the affinity rows (or extend vendor_modal.html section) — bordered indigo chip + confidence % + reasoning in `title`; "Suggest more vendors" button with explicit `hx-target` swapping a stable-id sub-container INSIDE the `x-data='rfqVendorModal(...)'` wrapper (never the wrapper — re-init wipes runtime selection state); the button sits inside that target so the response swaps it away — second click cannot duplicate rows.
+- Test: spec "Affinity endpoint" list (incl. the no-duplicate-on-second-request pin); mock the L3 Claude path at the source module.
 
 - [ ] Failing tests first → implement → green → commit `feat(rfq): affinity vendor suggestions`
 
 ### Task 4: Any-vendor autocomplete + inline vendor creation
 
 **Files:**
-- Modify: `app/templates/htmx/partials/sightings/vendor_modal.html` — autocomplete input against existing `GET /api/autocomplete/names` (filter type=="vendor" client-side; selected vendor appends a checked row; excluded vendor → rose chip + disabled checkbox); "Add new vendor" inline mini-form (Enter-Offer modal "New Vendor" pattern).
-- Modify: `app/routers/sightings.py` — new `POST /v2/partials/sightings/composer-vendor` per spec §2.4 (shared duplicate-check service path, NOT HTTP; confident duplicate → existing row + notice; else minimal VendorCard + VendorContact when email given; 400 JSON on empty name).
-- Test: spec "Autocomplete add" + "Inline create" lists.
+- Modify: `app/templates/htmx/partials/sightings/vendor_modal.html` — give the vendor panel a stable container id (the template has none today); autocomplete input against existing `GET /api/autocomplete/names` (filter type=="vendor" client-side; selected vendor appends a checked row; excluded vendor → rose chip + disabled checkbox); "Add new vendor" inline mini-form (Enter-Offer modal "New Vendor" pattern). All swaps target stable-id sub-containers INSIDE the `x-data='rfqVendorModal(...)'` wrapper, never the wrapper — `_form()` reads `selectedVendors` keys, so runtime-added rows flow into `vendor_names` automatically.
+- Create: extract `check_vendor_duplicate(name, db)` into an importable function under `app/services/` (per CLAUDE.md thin-routers rule) — the logic currently lives in the route at `app/routers/vendors_crud.py:83-123` with module-private fuzzy helpers (`_fuzzy_match_pg_trgm` :35 / `_fuzzy_match_python` :56); there is NO shared service today. BOTH the existing `/api/vendors/check-duplicate` route AND the new composer endpoint call the extracted function.
+- Modify: `app/routers/sightings.py` — new `POST /v2/partials/sightings/composer-vendor` per spec §2.4 (calls the extracted service function, NOT HTTP; confident duplicate → existing row + notice; else minimal VendorCard + VendorContact when email given; fire `_background_enrich_vendor` (`app/utils/vendor_helpers.py:157`) after commit, identical to `materials.py:889` / `vendor_contacts.py:616`; 400 JSON on empty name).
+- Test: spec "Autocomplete add" + "Inline create" lists; existing check-duplicate route behavior unchanged after extraction.
 
 - [ ] Failing tests first → implement → green → commit `feat(rfq): any-vendor picker + inline vendor creation`
 

--- a/docs/superpowers/plans/2026-06-12-bulk-rfq-composer.md
+++ b/docs/superpowers/plans/2026-06-12-bulk-rfq-composer.md
@@ -1,0 +1,57 @@
+# Bulk Cross-Requisition RFQ Composer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix cross-requisition RFQ tracking at the root (per-requisition Contact rows sharing one email) and upgrade the sightings vendor modal with coverage-ranked, affinity-suggested, searchable, and inline-creatable vendor selection.
+
+**Architecture:** No schema change. Multiplicity moves to Contact rows: one email per vendor, one Contact per (requisition, vendor), shared graph ids, multi-token `[ref:]` subjects with reply attribution to all involved requisitions. Vendor panel becomes four sections over the existing Alpine selection state; all server logic in the sightings router + one shared coverage query; affinity via the existing `find_vendor_affinity` service.
+
+**Tech Stack:** FastAPI thin routers, SQLAlchemy 2.0 plain-column aggregates (SQLite+PG safe), Jinja2 + HTMX partial swaps (explicit hx-target) + Alpine, pytest route-level tests.
+
+**Spec (authoritative):** `docs/superpowers/specs/2026-06-12-bulk-rfq-composer-design.md` — read fully before each task. Also CLAUDE.md (Alpine landmines, JSON errors, response formats, htmx rules).
+
+---
+
+### Task 1: Cross-requisition tracking fix (the load-bearing core)
+
+**Files:**
+- Read FIRST: the inbox-monitor / reply-matching parser (grep email_service.py + jobs for `ref:` parsing) — the spec mandates multi-token attribution; extend the parser root-cause if it only handles one token. Also `grep -rn "send_batch_rfq" app/` — every call site must stay behavior-identical for single-requisition use.
+- Modify: `app/routers/sightings.py` `sightings_send_inquiry` (~:1444-1590) — remove the `next(iter(requisition_ids))` collapse; group requirements per requisition; status auto-progress per involved requisition.
+- Modify: `app/email_service.py` `send_batch_rfq` (:79-262) — accept the requisition→parts mapping (additive/compatible signature per spec Risk note); one email per vendor; subject carries one `[ref:{id}]` token per requisition; one Contact per (requisition, vendor) sharing graph_message_id/graph_conversation_id; per-Contact `parts_included` scoped to that requisition.
+- Modify (if parser needs it): the reply-matching code — attribute replies to ALL Contacts matching any token/conversation id.
+- Test: spec "Testing → Tracking" list verbatim (multi-requisition Contact fan-out, shared graph ids, multi-token subject, reply attribution to all, per-requisition status progression, single-requisition byte-identical regression).
+
+- [ ] Failing tests first → implement → green → commit `fix(rfq): per-requisition Contact tracking for cross-requisition sends`
+
+### Task 2: Coverage-ranked suggested vendors
+
+**Files:**
+- Modify: `app/routers/sightings.py` `sightings_vendor_modal` (~:1302-1363) — replace the flat engagement query with the spec's grouped coverage query over VendorSightingSummary (coverage desc, engagement desc, cap 20); compute covered-MPN lists server-side; keep `excluded_vendor_norms` filtering exactly as today.
+- Modify: `app/templates/htmx/partials/sightings/vendor_modal.html` — `N/M parts` per row + covered-MPN `title`; existing badges kept.
+- Test: ranking order, exclusion, render assertions (spec "Coverage ranking").
+
+- [ ] Failing tests first → implement → green → commit `feat(rfq): coverage-ranked vendor suggestions`
+
+### Task 3: Affinity suggestions on demand
+
+**Files:**
+- Modify: `app/routers/sightings.py` — new `GET /v2/partials/sightings/vendor-affinity?requirement_ids=…` per spec §2.2 (merge/dedupe by vendor keep-highest-confidence, drop already-suggested + excluded, cap 10).
+- Create: small partial for the affinity rows (or extend vendor_modal.html section) — bordered indigo chip + confidence % + reasoning in `title`; "Suggest more vendors" button with explicit `hx-target` swapping the section.
+- Test: spec "Affinity endpoint" list; mock the L3 Claude path at the source module.
+
+- [ ] Failing tests first → implement → green → commit `feat(rfq): affinity vendor suggestions`
+
+### Task 4: Any-vendor autocomplete + inline vendor creation
+
+**Files:**
+- Modify: `app/templates/htmx/partials/sightings/vendor_modal.html` — autocomplete input against existing `GET /api/autocomplete/names` (filter type=="vendor" client-side; selected vendor appends a checked row; excluded vendor → rose chip + disabled checkbox); "Add new vendor" inline mini-form (Enter-Offer modal "New Vendor" pattern).
+- Modify: `app/routers/sightings.py` — new `POST /v2/partials/sightings/composer-vendor` per spec §2.4 (shared duplicate-check service path, NOT HTTP; confident duplicate → existing row + notice; else minimal VendorCard + VendorContact when email given; 400 JSON on empty name).
+- Test: spec "Autocomplete add" + "Inline create" lists.
+
+- [ ] Failing tests first → implement → green → commit `feat(rfq): any-vendor picker + inline vendor creation`
+
+### Task 5: Docs + verification gate
+
+- [ ] `docs/APP_MAP_INTERACTIONS.md` — update the RFQ flow section (per-requisition Contact fan-out, multi-token refs, the four vendor-panel sources); `docs/APP_MAP_DATABASE.md` only if Contact semantics text exists there.
+- [ ] Full suite `TESTING=1 PYTHONPATH=. pytest tests/ -q --tb=line` green; `pre-commit run --all-files` (twice if docformatter mutates).
+- [ ] Commit `docs(rfq): APP_MAP updates for bulk composer + per-requisition tracking`

--- a/docs/superpowers/specs/2026-06-12-bulk-rfq-composer-design.md
+++ b/docs/superpowers/specs/2026-06-12-bulk-rfq-composer-design.md
@@ -1,0 +1,130 @@
+# Bulk Cross-Requisition RFQ Composer (Track B) — Design
+
+**Date:** 2026-06-12
+**Status:** Approved feature (user selected Track B from the next-build options; this spec
+resolves the design). Track A (Offers tab) and durable unavailability (PR #270) are shipped.
+**Origin:** deferred as "separate spec" in `2026-06-05-sightings-offers-tab-design.md` §11.
+
+## Problem
+
+The sightings vendor modal already composes/previews/sends a multi-part RFQ
+(`vendor_modal.html`, `sightings_vendor_modal` / `preview-inquiry` / `send-inquiry`),
+invoked from the table's multi-select. But:
+
+1. **Cross-requisition tracking is broken (load-bearing bug):** `send-inquiry` collapses
+   the selected requirements' requisitions to ONE via
+   `requisition_id = next(iter(requisition_ids))` (undefined set order) and passes it to
+   `send_batch_rfq`, which writes every `Contact` row, every `[ref:{requisition_id}]`
+   subject token, and reply-matching state against that single requisition. Outreach
+   spanning requisitions A+B+C records history only on one of them — silently.
+2. **Vendor selection is dumb:** a flat engagement-ordered top-20 of vendors that have
+   any sighting on the selected parts. No part-coverage ranking, no way to reach a vendor
+   with no sighting (affinity), no picking an arbitrary DB vendor, no adding a new vendor.
+
+## Decision summary
+
+Fix tracking at the root (per-requisition `Contact` rows sharing one email), and upgrade
+the modal's vendor panel: coverage-ranked suggestions, affinity suggestions on demand,
+any-vendor autocomplete, inline vendor creation. Reuse the existing compose→preview→send
+skeleton, `send_batch_rfq`, and the unavailability exclusion. **No new tables; no
+migration** (Contact keeps its singular `requisition_id` — multiplicity moves to rows).
+
+## Part 1 — Cross-requisition tracking fix
+
+**Semantics: one email per vendor covering ALL selected parts** (that is the point of a
+bulk composer), with full per-requisition tracking:
+
+- `sightings_send_inquiry` stops collapsing requisitions. It groups the selected
+  requirements per requisition and passes the full mapping down.
+- `send_batch_rfq` (or a thin evolution of it — keep ONE canonical send path) sends one
+  Graph email per vendor, then writes **one `Contact` row per (requisition, vendor)
+  pair**, all sharing that email's `graph_message_id` / `graph_conversation_id`. Each
+  Contact's `parts_included` holds only that requisition's parts.
+- **Subject ref tokens:** the subject carries one `[ref:{id}]` token per involved
+  requisition (e.g. `RFQ — 6 parts [ref:12] [ref:34]`). The implementation MUST first
+  read the inbox-monitor/reply-matching parser: if it `search()`es a single token,
+  multiple tokens are fine; if it strictly anchors, extend the parser to find all tokens
+  and attribute the reply to every matching Contact (root-cause, not a workaround).
+  Whichever the parser needs, replies must attribute to ALL involved requisitions.
+- Activity logging already iterates per requirement (`log_rfq_activity(rfq_id=
+  r.requisition_id, requirement_id=r.id)`) — keep, now consistent with Contacts.
+- Status auto-progress (OPEN→SOURCING) applies per involved requisition, not just one.
+- `X-RFQ-*` headers unchanged in meaning (per-vendor counts).
+
+## Part 2 — Vendor panel upgrade (`vendor_modal.html` + `sightings_vendor_modal`)
+
+The modal's vendor list becomes four sections in one selectable checklist:
+
+1. **Suggested (coverage-ranked).** One grouped query over `VendorSightingSummary`
+   filtered to the selected requirement ids: per vendor — covered-part count, avg
+   summary score, engagement score. Order: coverage desc, then engagement desc; keep the
+   20-row cap. Each row shows `N/M parts` (M = selected part count) plus the existing
+   response-rate/engagement badges; `title` lists the covered MPNs (computed in the
+   route, template stays dumb). Vendors in `excluded_vendor_norms` stay excluded from
+   this list (as today).
+2. **Affinity (on demand).** A "Suggest more vendors" button (`hx-get`, htmx partial
+   swap into the section — explicit `hx-target`) calls a new
+   `GET /v2/partials/sightings/vendor-affinity?requirement_ids=…` which runs
+   `find_vendor_affinity(mpn, db)` for each selected requirement's primary MPN,
+   merges/dedupes by vendor (keep highest confidence), drops vendors already in the
+   suggested list or excluded by unavailability, and returns rows rendered with a
+   bordered indigo "affinity" chip + confidence % + the service's reasoning string in
+   `title`. L3 (the Claude call) stays enabled inside the service as designed (the
+   button gate makes the latency opt-in). Cap: 10 rows (the service's own cap).
+3. **Find any vendor.** An autocomplete input reusing `GET /api/autocomplete/names`
+   (vendors only — filter `type == "vendor"` client-side from the existing response;
+   do NOT fork the endpoint). Selecting a result appends a checked row to the list. If
+   the picked vendor is unavailability-excluded for the selected parts, the row renders
+   with the rose "marked unavailable" chip and a **disabled** checkbox (the send-time
+   re-validation remains the backstop).
+4. **Add vendor on the fly.** An inline mini-form (name required; website + contact
+   email optional) behind an "Add new vendor" toggle — the Enter-Offer modal's "New
+   Vendor" pattern. POST to a new `POST /v2/partials/sightings/composer-vendor`
+   endpoint that: runs the duplicate check (`/api/vendors/check-duplicate` logic —
+   call the shared service path, not HTTP); on a confident duplicate, returns the
+   existing vendor row instead (with a "matched existing vendor" notice); otherwise
+   creates the minimal `VendorCard` (the crm/offers.py:331 pattern: normalized_name,
+   display_name, optional domain) plus a `VendorContact` when an email was given, and
+   returns the new checked row. Vendors created here without an email show the
+   existing "no contact email" treatment and are reported via `X-RFQ-Skipped` at send
+   (current behavior, unchanged).
+
+Selection state stays in the modal's existing Alpine component; all new rows join the
+same `vendor_names` form field. Tailwind: full literal classes only; follow the modal's
+existing chip/badge vocabulary (indigo = informational chip family, rose = unavailable).
+
+## Out of scope (deliberate)
+
+- No change to email composition itself (plain-text body → `_build_html_body`).
+- No per-vendor part subsetting in the composer (every selected vendor is asked about
+  all selected parts; the per-requisition Contact split is a tracking concern, not a
+  content concern).
+- No affinity persistence/caching beyond the service's own behavior.
+- No vendor-modal redesign outside the vendor panel (steps/preview/send UX unchanged).
+- The requisitions-page RFQ flows (if any exist outside this modal) are untouched.
+
+## Testing
+
+- **Tracking (the core):** send spanning 2 requisitions × 2 vendors → exactly 4
+  `Contact` rows, each with its own requisition_id and only that requisition's
+  `parts_included`, sharing graph ids per vendor; subject contains both ref tokens;
+  reply-matching attributes a simulated reply to both requisitions' contacts; both
+  requisitions auto-progress OPEN→SOURCING; ActivityLog rows per requirement.
+  Single-requisition sends behave byte-identically to today (regression).
+- **Coverage ranking:** vendor with 3/4 parts ranks above 1/4 with higher engagement;
+  excluded vendor absent; `N/M parts` rendered.
+- **Affinity endpoint:** returns merged/deduped rows; drops already-suggested and
+  excluded vendors; renders chip + confidence; L3 path mocked at the source module.
+- **Autocomplete add:** excluded vendor renders disabled + rose chip.
+- **Inline create:** duplicate → existing card returned, no new row in DB; new vendor →
+  card + contact created, row checked; empty name → 400 JSON error format.
+- **Headers/regression:** X-RFQ-Sent/Total/Skipped/Unavailable semantics unchanged.
+
+## Risks
+
+- Reply-matching parser is the one place with unknown behavior — read it FIRST
+  (architect review must verify multi-token attribution is sound before build).
+- `send_batch_rfq` is shared — single-requisition callers elsewhere must be traced and
+  kept behavior-identical (grep all call sites before changing its signature; prefer an
+  additive parameter or a mapping argument with a compatible default).
+- SQLite tests vs PG: the coverage GROUP BY uses plain columns/aggregates only.

--- a/docs/superpowers/specs/2026-06-12-bulk-rfq-composer-design.md
+++ b/docs/superpowers/specs/2026-06-12-bulk-rfq-composer-design.md
@@ -36,16 +36,51 @@ bulk composer), with full per-requisition tracking:
 
 - `sightings_send_inquiry` stops collapsing requisitions. It groups the selected
   requirements per requisition and passes the full mapping down.
+- **Preview in lockstep:** `sightings_preview_inquiry` (`app/routers/sightings.py:1394`)
+  has the SAME `next(iter(requisition_ids))` collapse as send (`:1476`) — fix both in
+  the same change. The preview subject must show ALL `[ref:]` tokens exactly as the
+  send will produce them (no preview/send divergence).
 - `send_batch_rfq` (or a thin evolution of it — keep ONE canonical send path) sends one
   Graph email per vendor, then writes **one `Contact` row per (requisition, vendor)
   pair**, all sharing that email's `graph_message_id` / `graph_conversation_id`. Each
   Contact's `parts_included` holds only that requisition's parts.
+- **Signature compatibility (verified second caller):** `htmx_views.rfq_send`
+  (`app/routers/htmx_views.py:2642-2650`) calls `send_batch_rfq` with a single scalar
+  `requisition_id=req_id` and must stay byte-identical. The new shape is an **additive
+  parameter** (e.g. `requisition_parts_map: dict[int, list] | None = None`) with a shim
+  that converts the legacy single-id form into a one-entry map internally.
 - **Subject ref tokens:** the subject carries one `[ref:{id}]` token per involved
-  requisition (e.g. `RFQ — 6 parts [ref:12] [ref:34]`). The implementation MUST first
-  read the inbox-monitor/reply-matching parser: if it `search()`es a single token,
-  multiple tokens are fine; if it strictly anchors, extend the parser to find all tokens
-  and attribute the reply to every matching Contact (root-cause, not a workaround).
-  Whichever the parser needs, replies must attribute to ALL involved requisitions.
+  requisition (e.g. `RFQ — 6 parts [ref:12] [ref:34]`).
+- **Reply-matcher fan-out (architect-verified, BLOCKER):** the inbox monitor's
+  `conv_id_map` (`app/email_service.py:443-451`) is `dict[conv_id] = contact` —
+  last-writer-wins, so per-(requisition, vendor) Contact rows sharing one
+  `graph_conversation_id` would silently drop all but one. It MUST become
+  `dict[str, list[Contact]]`:
+  - Tier-1 conversation-id matching (`:494-496`) loops ALL contacts sharing the
+    conversation id.
+  - The `VendorResponse` row is still created **once** per message, with
+    `contact_id = contacts[0].id` (the row is per-message, not per-requisition).
+  - `_progress_contact_status` (call site `:572`) iterates the **full list** so every
+    involved Contact progresses.
+  - `req_email_map` (`:448`, populated via `setdefault` at `:454`) is *accidentally
+    correct* after this feature: (requisition_id, email) pairs become unique under the
+    per-requisition fan-out, so `setdefault` never collides. Document this in code; no
+    structural change needed.
+  - Tier-3 `email_map` (`:459`) stays most-recent-contact fallback **by design**
+    (user-scoped heuristic for untokenized replies) — document, don't change.
+- **Token regex consolidation:** the pattern is duplicated — `AVAIL_TOKEN_RE`
+  (`app/connectors/email_mining.py:61`) vs `RFQ_SUBJECT_TAG_RE`
+  (`app/shared_constants.py:124`), byte-identical. Consolidate to the ONE shared
+  pattern in `shared_constants.py`. Consumers that extract the requisition id via
+  `.search().group(1)` switch to `re.findall` so multi-token subjects attribute to ALL
+  requisitions: `app/jobs/email_jobs.py:915-917` (sent-folder ActivityLog scan — one
+  attribution per token requisition). `app/connectors/email_mining.py:520` is
+  presence-only detection (no `.group(1)`) — multi-token safe as-is; just switch it to
+  the shared pattern. Tier-2 inbox matching (`app/email_service.py:500-508`) iterates
+  all found tokens when resolving `(req_id, email)` pairs.
+- **Tag propagation:** the block in `send_batch_rfq` (`app/email_service.py:243-260`)
+  reads only the single `requisition_id` — it must iterate ALL involved requisitions'
+  requirements when collecting `material_card_id`s.
 - Activity logging already iterates per requirement (`log_rfq_activity(rfq_id=
   r.requisition_id, requirement_id=r.id)`) — keep, now consistent with Contacts.
 - Status auto-progress (OPEN→SOURCING) applies per involved requisition, not just one.
@@ -58,10 +93,14 @@ The modal's vendor list becomes four sections in one selectable checklist:
 1. **Suggested (coverage-ranked).** One grouped query over `VendorSightingSummary`
    filtered to the selected requirement ids: per vendor — covered-part count, avg
    summary score, engagement score. Order: coverage desc, then engagement desc; keep the
-   20-row cap. Each row shows `N/M parts` (M = selected part count) plus the existing
-   response-rate/engagement badges; `title` lists the covered MPNs (computed in the
-   route, template stays dumb). Vendors in `excluded_vendor_norms` stay excluded from
-   this list (as today).
+   20-row cap. **Join (architect-verified):** enrichment data joins via
+   `VendorSightingSummary.vendor_card_id` (existing FK, indexed `ix_vss_vendor_card`) —
+   NOT the legacy `lower(trim(vendor_name)) == normalized_name` join. Add a route
+   comment that VSS rows with NULL `vendor_card_id` are excluded by design (the modal
+   suggests known vendors). Each row shows `N/M parts` (M = selected part count) plus
+   the existing response-rate/engagement badges; `title` lists the covered MPNs
+   (computed in the route, template stays dumb). Vendors in `excluded_vendor_norms`
+   stay excluded from this list (as today).
 2. **Affinity (on demand).** A "Suggest more vendors" button (`hx-get`, htmx partial
    swap into the section — explicit `hx-target`) calls a new
    `GET /v2/partials/sightings/vendor-affinity?requirement_ids=…` which runs
@@ -71,6 +110,15 @@ The modal's vendor list becomes four sections in one selectable checklist:
    bordered indigo "affinity" chip + confidence % + the service's reasoning string in
    `title`. L3 (the Claude call) stays enabled inside the service as designed (the
    button gate makes the latency opt-in). Cap: 10 rows (the service's own cap).
+   **Threading (architect-verified, required):** `find_vendor_affinity`
+   (`app/services/vendor_affinity_service.py:271`) is SYNC with a blocking Anthropic
+   call inside (L3, `anthropic.Anthropic(...).messages.create` at `:207-213`). The
+   async endpoint MUST wrap each per-MPN call in `asyncio.to_thread(...)`, gathered
+   under an `asyncio.Semaphore(3)` — never call it bare from the async route (it would
+   block the uvicorn worker 3-12s for 6 parts).
+   **Idempotent UI:** a second click must not duplicate rows — the swap replaces the
+   button with the response (button lives inside the `hx-target` region), so it
+   disappears once results render; a test pins no-duplicate-on-double-request.
 3. **Find any vendor.** An autocomplete input reusing `GET /api/autocomplete/names`
    (vendors only — filter `type == "vendor"` client-side from the existing response;
    do NOT fork the endpoint). Selecting a result appends a checked row to the list. If
@@ -80,18 +128,39 @@ The modal's vendor list becomes four sections in one selectable checklist:
 4. **Add vendor on the fly.** An inline mini-form (name required; website + contact
    email optional) behind an "Add new vendor" toggle — the Enter-Offer modal's "New
    Vendor" pattern. POST to a new `POST /v2/partials/sightings/composer-vendor`
-   endpoint that: runs the duplicate check (`/api/vendors/check-duplicate` logic —
-   call the shared service path, not HTTP); on a confident duplicate, returns the
+   endpoint that: runs the duplicate check; on a confident duplicate, returns the
    existing vendor row instead (with a "matched existing vendor" notice); otherwise
    creates the minimal `VendorCard` (the crm/offers.py:331 pattern: normalized_name,
    display_name, optional domain) plus a `VendorContact` when an email was given, and
-   returns the new checked row. Vendors created here without an email show the
-   existing "no contact email" treatment and are reported via `X-RFQ-Skipped` at send
-   (current behavior, unchanged).
+   returns the new checked row.
+   **Duplicate-check extraction (architect-verified — no shared service exists today):**
+   the duplicate logic currently lives inside the route function
+   (`app/routers/vendors_crud.py:83-123`, with module-private fuzzy helpers
+   `_fuzzy_match_pg_trgm`/`_fuzzy_match_python` at `:35`/`:56`). Extract an importable
+   `check_vendor_duplicate(name, db)` into a module under `app/services/` (the
+   CLAUDE.md thin-routers rule's preferred home) and have BOTH the existing
+   `/api/vendors/check-duplicate` route AND the new composer endpoint call it — never
+   loopback HTTP, never copy-paste.
+   **Post-create enrichment:** new-card creation fires `_background_enrich_vendor`
+   (`app/utils/vendor_helpers.py:157`) after commit, identical to the existing
+   patterns (`app/routers/materials.py:889`, `app/routers/vendor_contacts.py:616`).
+   Vendors created here without an email show the existing "no contact email"
+   treatment and are reported via `X-RFQ-Skipped` at send (current behavior,
+   unchanged).
 
 Selection state stays in the modal's existing Alpine component; all new rows join the
 same `vendor_names` form field. Tailwind: full literal classes only; follow the modal's
 existing chip/badge vocabulary (indigo = informational chip family, rose = unavailable).
+
+**HTMX swap targets (architect-verified constraint):** every HTMX swap for the new
+sections targets a stable-id sub-container INSIDE the
+`x-data='rfqVendorModal(...)'` wrapper — NEVER the wrapper itself. Re-initializing the
+Alpine component (`rfqVendorModal` factory, `app/static/htmx_app.js:1734`) would wipe
+runtime-added vendor selection state. `_form()` reads `Object.keys(this.selectedVendors)`,
+so rows added at runtime (affinity / autocomplete / inline-create) flow into
+`vendor_names` automatically — no extra wiring. The vendor panel gets a stable container
+id (the template currently has none); the affinity section, autocomplete result list,
+and inline-create form each swap into their own stable-id child.
 
 ## Out of scope (deliberate)
 
@@ -110,11 +179,21 @@ existing chip/badge vocabulary (indigo = informational chip family, rose = unava
   `parts_included`, sharing graph ids per vendor; subject contains both ref tokens;
   reply-matching attributes a simulated reply to both requisitions' contacts; both
   requisitions auto-progress OPEN→SOURCING; ActivityLog rows per requirement.
-  Single-requisition sends behave byte-identically to today (regression).
+  Single-requisition sends behave byte-identically to today (regression), including
+  the `htmx_views.rfq_send` legacy scalar-`requisition_id` call shape.
+- **Reply matcher:** Tier-1 attributes a reply to ALL Contacts sharing a conversation
+  id (the `dict[str, list[Contact]]` fan-out); exactly one `VendorResponse` per
+  message; `_progress_contact_status` advanced every contact in the list.
+- **Preview lockstep:** preview of a 2-requisition selection renders BOTH `[ref:]`
+  tokens, identical to the send subject.
+- **Sent-folder scan:** a sent message with two tokens attributes activity records to
+  both token requisitions (`re.findall` path in `app/jobs/email_jobs.py`).
 - **Coverage ranking:** vendor with 3/4 parts ranks above 1/4 with higher engagement;
   excluded vendor absent; `N/M parts` rendered.
 - **Affinity endpoint:** returns merged/deduped rows; drops already-suggested and
-  excluded vendors; renders chip + confidence; L3 path mocked at the source module.
+  excluded vendors; renders chip + confidence; L3 path mocked at the source module;
+  a second request does not duplicate rows already in the panel (button swapped away
+  with the response).
 - **Autocomplete add:** excluded vendor renders disabled + rose chip.
 - **Inline create:** duplicate → existing card returned, no new row in DB; new vendor →
   card + contact created, row checked; empty name → 400 JSON error format.
@@ -122,9 +201,19 @@ existing chip/badge vocabulary (indigo = informational chip family, rose = unava
 
 ## Risks
 
-- Reply-matching parser is the one place with unknown behavior — read it FIRST
-  (architect review must verify multi-token attribution is sound before build).
-- `send_batch_rfq` is shared — single-requisition callers elsewhere must be traced and
-  kept behavior-identical (grep all call sites before changing its signature; prefer an
-  additive parameter or a mapping argument with a compatible default).
+- Reply-matching parser: RESOLVED by architect review — the required changes are now
+  explicit requirements in Part 1 (conv_id_map list semantics, Tier-1 fan-out, token
+  regex consolidation + `re.findall`). No remaining unknowns; build to the spec.
+- `send_batch_rfq` is shared — both call sites are traced (`sightings.py:1514`,
+  `htmx_views.py:2642-2650`); the additive `requisition_parts_map` parameter + legacy
+  shim in Part 1 keeps the scalar-`requisition_id` caller byte-identical.
 - SQLite tests vs PG: the coverage GROUP BY uses plain columns/aggregates only.
+
+## Architect-review notes (verified against code, recorded for the builder)
+
+- `compute_vendor_statuses` (`app/services/sighting_status.py:44`) consumes `Contact`
+  rows requisition-scoped — the per-(requisition, vendor) fan-out is safe for it; no
+  change needed (verified).
+- `htmx_views.rfq_send` independently falls back to a DB-only token mode on send
+  failure (`app/routers/htmx_views.py:2660`) — a pre-existing divergence from the
+  sightings path; deliberately untouched by this feature.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,7 @@ export default [
         CustomEvent: 'readonly',
         Event: 'readonly',
         FormData: 'readonly',
+        DOMParser: 'readonly',
         AbortController: 'readonly',
         EventSource: 'readonly',
         localStorage: 'readonly',

--- a/tests/frontend/rfq-vendor-modal.test.ts
+++ b/tests/frontend/rfq-vendor-modal.test.ts
@@ -243,6 +243,147 @@ describe('rfqVendorModal (real factory)', () => {
     });
   });
 
+  describe('_addComposerVendor / pickVendor (any-vendor picker)', () => {
+    function rowHtml(normalized: string) {
+      // Mirrors composer_vendor_row.html's selectable branch: x-init carries the
+      // server-normalized name as a tojson-quoted string in a single-quoted attr.
+      // Jinja's |tojson escapes ' < > & as \uXXXX so the attr can't break — mirror it.
+      const quoted = JSON.stringify(normalized)
+        .replace(/'/g, '\\u0027').replace(/</g, '\\u003c')
+        .replace(/>/g, '\\u003e').replace(/&/g, '\\u0026');
+      return `<label x-init='selectVendor(${quoted})'><input type="checkbox"><span>row</span></label>`;
+    }
+    function htmlResponse(html: string, ok = true, status = 200) {
+      return { ok, status, text: () => Promise.resolve(html) };
+    }
+    function addContainer() {
+      const div = document.createElement('div');
+      div.id = 'rfq-added-vendors';
+      document.body.appendChild(div);
+      return div;
+    }
+
+    it('pickVendor posts to composer-vendor and appends the returned row', async () => {
+      const container = addContainer();
+      const m = makeModal(['mouser electronics'], [10, 11]);
+      (fetch as any).mockResolvedValue(htmlResponse(rowHtml('new vendor co')));
+
+      await m.pickVendor('New Vendor Co');
+
+      const [url, opts] = (fetch as any).mock.calls[0];
+      expect(url).toBe('/v2/partials/sightings/composer-vendor');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['x-csrftoken']).toBe('testtoken');
+      expect(opts.body.get('vendor_name')).toBe('New Vendor Co');
+      expect(opts.body.getAll('requirement_ids')).toEqual(['10', '11']);
+      expect(container.children.length).toBe(1);
+      expect((htmx as any).process).toHaveBeenCalledWith(container);
+      expect(m.vendorQuery).toBe('');
+      expect(m.searchOpen).toBe(false);
+    });
+
+    it('skips the request entirely when the vendor is already selected (case-insensitive)', async () => {
+      const container = addContainer();
+      const m = makeModal(['mouser electronics'], [1]);
+
+      await m.pickVendor('Mouser Electronics');
+
+      expect(fetch).not.toHaveBeenCalled();
+      expect(container.children.length).toBe(0);
+      expect(m.$store.toast.type).toBe('info');
+      expect(m.$store.toast.message).toBe('Vendor already added');
+    });
+
+    it('skips the APPEND when the returned row resolves to an already-selected vendor', async () => {
+      const container = addContainer();
+      const m = makeModal(['mouser electronics'], [1]);
+      // Display name differs from the normalized key, so the fast path misses and
+      // the request goes out — the server-normalized name in the row must dedupe.
+      (fetch as any).mockResolvedValue(htmlResponse(rowHtml('mouser electronics')));
+
+      const ok = await m._addComposerVendor({ vendor_name: 'Mouser Electronics, Inc.' });
+
+      expect(ok).toBe(true);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(container.children.length).toBe(0); // no duplicate visual row
+      expect(m.$store.toast.type).toBe('info');
+      expect(m.$store.toast.message).toBe('Vendor already added');
+    });
+
+    it('still appends excluded rows (no x-init selection key)', async () => {
+      const container = addContainer();
+      const m = makeModal(['mouser electronics'], [1]);
+      (fetch as any).mockResolvedValue(htmlResponse('<label><input type="checkbox" disabled><span>unavailable co</span></label>'));
+
+      const ok = await m._addComposerVendor({ vendor_name: 'Unavailable Co' });
+
+      expect(ok).toBe(true);
+      expect(container.children.length).toBe(1);
+    });
+
+    it('a 4xx response keeps the inline create-form values and reports an error', async () => {
+      const container = addContainer();
+      const m = makeModal([], [1]);
+      m.addingVendor = true;
+      m.newVendorName = 'Acme Components';
+      m.newVendorWebsite = 'acme.example';
+      m.newVendorEmail = 'not-an-email';
+      (fetch as any).mockResolvedValue(htmlResponse('', false, 400));
+
+      await m.createVendor();
+
+      expect(m.newVendorName).toBe('Acme Components'); // typed values preserved
+      expect(m.newVendorWebsite).toBe('acme.example');
+      expect(m.newVendorEmail).toBe('not-an-email');
+      expect(m.addingVendor).toBe(true); // form stays open
+      expect(m.addingVendorBusy).toBe(false);
+      expect(container.children.length).toBe(0);
+      expect(m.$store.toast.type).toBe('error');
+      expect(m.$store.toast.message).toBe('Could not add vendor — please try again');
+    });
+
+    it('a network failure also keeps the create-form values', async () => {
+      addContainer();
+      const m = makeModal([], [1]);
+      m.addingVendor = true;
+      m.newVendorName = 'Acme Components';
+      (fetch as any).mockRejectedValue(new Error('offline'));
+
+      await m.createVendor();
+
+      expect(m.newVendorName).toBe('Acme Components');
+      expect(m.addingVendor).toBe(true);
+      expect(m.addingVendorBusy).toBe(false);
+      expect(m.$store.toast.type).toBe('error');
+    });
+
+    it('createVendor success appends the row, clears the form, and closes the panel', async () => {
+      const container = addContainer();
+      const m = makeModal([], [1]);
+      m.addingVendor = true;
+      m.newVendorName = 'Acme Components';
+      m.newVendorWebsite = 'https://acme.example';
+      m.newVendorEmail = 'sales@acme.example';
+      (fetch as any).mockResolvedValue(htmlResponse(rowHtml('acme components')));
+
+      await m.createVendor();
+
+      expect(container.children.length).toBe(1);
+      expect(m.newVendorName).toBe('');
+      expect(m.newVendorWebsite).toBe('');
+      expect(m.newVendorEmail).toBe('');
+      expect(m.addingVendor).toBe(false);
+      expect(m.addingVendorBusy).toBe(false);
+    });
+
+    it('_rowVendorName parses the tojson-quoted normalized name (and escapes)', () => {
+      const m = makeModal([], [1]);
+      expect(m._rowVendorName(rowHtml('digi-key'))).toBe('digi-key');
+      expect(m._rowVendorName(rowHtml("o'brien & co"))).toBe("o'brien & co");
+      expect(m._rowVendorName('<label><span>excluded</span></label>')).toBeNull();
+    });
+  });
+
   describe('_sendOutcome mapping', () => {
     it('maps full / partial / zero correctly', () => {
       const m = makeModal(['a'], [1]);

--- a/tests/frontend/rfq-vendor-modal.test.ts
+++ b/tests/frontend/rfq-vendor-modal.test.ts
@@ -58,8 +58,14 @@ function makeModal(names: string[], ids: number[]) {
   return inst;
 }
 
-function fetchResponse(sent: string | null, total: string | null, ok = true, status = 200) {
-  const h: Record<string, string | null> = { 'X-RFQ-Sent': sent, 'X-RFQ-Total': total };
+function fetchResponse(
+  sent: string | null,
+  total: string | null,
+  ok = true,
+  status = 200,
+  extra: Record<string, string> = {},
+) {
+  const h: Record<string, string | null> = { 'X-RFQ-Sent': sent, 'X-RFQ-Total': total, ...extra };
   return { ok, status, headers: { get: (k: string) => h[k] ?? null } };
 }
 
@@ -130,6 +136,23 @@ describe('rfqVendorModal (real factory)', () => {
 
       expect(m.$store.toast.type).toBe('warning');
       expect(m.$store.toast.message).toBe('Sent to 1 of 2 vendors — 1 failed');
+      expect(m.$dispatch).toHaveBeenCalledWith('close-modal');
+    });
+
+    it('unavailable vendors are not counted as failed in the toast', async () => {
+      // F3: server drops 1 of 2 vendors at send time (X-RFQ-Unavailable=1). The blocked
+      // vendor was correctly handled, NOT a delivery failure — the toast must say
+      // "marked unavailable", never "1 failed".
+      const m = makeModal(['a', 'b'], [1]);
+      m.emailBody = 'q';
+      alpineMock.store.mockReturnValue({ selectedReqId: null });
+      (fetch as any).mockResolvedValue(fetchResponse('1', '2', true, 200, { 'X-RFQ-Unavailable': '1' }));
+
+      await m.confirmSend();
+
+      expect(m.$store.toast.type).toBe('warning');
+      expect(m.$store.toast.message).toBe('Sent to 1 of 2 vendors — 1 marked unavailable');
+      expect(m.$store.toast.message).not.toContain('failed');
       expect(m.$dispatch).toHaveBeenCalledWith('close-modal');
     });
 
@@ -501,6 +524,16 @@ describe('rfqVendorModal (real factory)', () => {
       expect(m._sendOutcome(1, 3, 1).message).toBe('Sent to 1 of 3 vendors — 1 failed, 1 had no email');
       // 1 sent of 3: 0 skipped, 2 failed (default skipped=0)
       expect(m._sendOutcome(1, 3).message).toBe('Sent to 1 of 3 vendors — 2 failed');
+    });
+
+    it('subtracts unavailable vendors from the failed bucket (F3)', () => {
+      const m = makeModal(['a'], [1]);
+      // 1 sent of 3: 2 marked unavailable, 0 failed — none are "failed"
+      expect(m._sendOutcome(1, 3, 0, 2).message).toBe('Sent to 1 of 3 vendors — 2 marked unavailable');
+      // 1 sent of 4: 1 skipped, 1 unavailable, 1 genuinely failed — all three reasons
+      expect(m._sendOutcome(1, 4, 1, 1).message).toBe(
+        'Sent to 1 of 4 vendors — 1 failed, 1 had no email, 1 marked unavailable',
+      );
     });
   });
 });

--- a/tests/frontend/rfq-vendor-modal.test.ts
+++ b/tests/frontend/rfq-vendor-modal.test.ts
@@ -382,6 +382,106 @@ describe('rfqVendorModal (real factory)', () => {
       expect(m._rowVendorName(rowHtml("o'brien & co"))).toBe("o'brien & co");
       expect(m._rowVendorName('<label><span>excluded</span></label>')).toBeNull();
     });
+
+    it('_rowVendorName reads data-vendor-norm from excluded rows (no x-init)', () => {
+      // F11: composer_vendor_row.html emits the normalized name on excluded rows
+      // as a data attribute, since they render no x-init to parse it from.
+      const m = makeModal([], [1]);
+      const excluded = '<label data-vendor-norm="dead vendor"><input type="checkbox" disabled><span>Dead Vendor</span></label>';
+      expect(m._rowVendorName(excluded)).toBe('dead vendor');
+    });
+
+    it('dedupes a re-picked EXCLUDED vendor against rows already in the container', async () => {
+      // F11: excluded rows never join selectedVendors (disabled checkbox), so the
+      // selection-state dedupe can't see them — the container check must.
+      const container = addContainer();
+      const m = makeModal([], [1]);
+      const excludedRow = '<label data-vendor-norm="dead vendor"><input type="checkbox" disabled><span>Dead Vendor</span></label>';
+      (fetch as any).mockResolvedValue(htmlResponse(excludedRow));
+
+      const first = await m._addComposerVendor({ vendor_name: 'Dead Vendor' });
+      const second = await m._addComposerVendor({ vendor_name: 'Dead Vendor' });
+
+      expect(first).toBe(true);
+      expect(second).toBe(true);
+      expect(container.children.length).toBe(1); // no duplicate excluded row
+      expect(m.$store.toast.message).toBe('Vendor already added');
+    });
+
+    it('createVendor payloads carrying email/website bypass the already-selected fast-path', async () => {
+      // F4: the server attaches a typed email to the matched existing card —
+      // skipping the request would silently discard it. Bare picks still skip.
+      addContainer();
+      const m = makeModal(['known vendor'], [1]);
+      (fetch as any).mockResolvedValue(htmlResponse(rowHtml('known vendor')));
+
+      await m._addComposerVendor({ vendor_name: 'Known Vendor', email: 'x@known.com' });
+
+      expect(fetch).toHaveBeenCalledTimes(1); // request went out despite the name match
+      expect(m.$store.toast.type).toBe('info'); // row itself still deduped on return
+    });
+
+    it('a 4xx with a JSON error body surfaces the server reason in the toast', async () => {
+      // F8: the server emits {"error": ...} — show the actionable reason, not a
+      // generic try-again.
+      addContainer();
+      const m = makeModal([], [1]);
+      (fetch as any).mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: 'invalid website — could not extract a domain' }),
+        text: () => Promise.resolve(''),
+      });
+
+      const ok = await m._addComposerVendor({ vendor_name: 'Bad Site Co', website: 'no-dot' });
+
+      expect(ok).toBe(false);
+      expect(m.$store.toast.type).toBe('error');
+      expect(m.$store.toast.message).toContain('invalid website — could not extract a domain');
+    });
+
+    it('a 5xx never surfaces body text — generic try-again toast', async () => {
+      addContainer();
+      const m = makeModal([], [1]);
+      (fetch as any).mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'Internal Server Error' }),
+        text: () => Promise.resolve(''),
+      });
+
+      const ok = await m._addComposerVendor({ vendor_name: 'Acme' });
+
+      expect(ok).toBe(false);
+      expect(m.$store.toast.message).toBe('Could not add vendor — please try again');
+    });
+  });
+
+  describe('searchVendors failure visibility (F9)', () => {
+    it('toasts ONCE per failure streak, then again after a success resets the flag', async () => {
+      const m = makeModal([], [1]);
+      const toastSpy = vi.spyOn(m, '_toast');
+      m.vendorQuery = 'arr';
+      (fetch as any).mockRejectedValue(new Error('offline'));
+
+      await m.searchVendors();
+      await m.searchVendors(); // repeated debounce failure — no second toast
+
+      expect(toastSpy).toHaveBeenCalledTimes(1);
+      expect(toastSpy).toHaveBeenCalledWith(expect.stringContaining('search failed'), 'error');
+      expect(m.vendorResults).toEqual([]);
+      expect(m.searchOpen).toBe(false);
+
+      (fetch as any).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ name: 'Arrow', type: 'vendor' }]),
+      });
+      await m.searchVendors(); // success resets the flag
+      (fetch as any).mockRejectedValue(new Error('offline again'));
+      await m.searchVendors();
+
+      expect(toastSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('_sendOutcome mapping', () => {

--- a/tests/test_email_jobs.py
+++ b/tests/test_email_jobs.py
@@ -1061,6 +1061,8 @@ class TestScanSentFolder:
 
         # No existing log
         mock_db.query.return_value.filter.return_value.first.side_effect = [None, None]
+        # Requisition existence filter: token 42 is live
+        mock_db.query.return_value.filter.return_value.all.return_value = [(42,)]
 
         gc_mock = MagicMock()
         gc_mock.delta_query = AsyncMock(
@@ -1157,6 +1159,8 @@ class TestScanSentFolder:
         user.email = "buyer@trioscs.com"
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.first.return_value = None
+        # Requisition existence filter: both tokens are live
+        mock_db.query.return_value.filter.return_value.all.return_value = [(12,), (34,)]
 
         gc_mock = MagicMock()
         gc_mock.delta_query = AsyncMock(
@@ -1185,6 +1189,96 @@ class TestScanSentFolder:
         # Both rows are the SAME message — shared external_id, same recipient
         assert {log.external_id for log in result} == {"msg-multi-001"}
         assert {log.contact_email for log in result} == {"vendor@arrow.com"}
+
+    @pytest.mark.asyncio
+    async def test_scan_stale_token_not_attributed(self, db_session, test_user, test_requisition):
+        """F5: a [ref:] token pointing at a deleted requisition must not be written
+        to ActivityLog.requisition_id (FK violation on PG → whole batch + delta
+        token rolled back). The stale-token message is logged UNLINKED; the live
+        token still attributes."""
+        from app.jobs.email_jobs import scan_sent_folder
+        from app.models import ActivityLog
+
+        gc_mock = MagicMock()
+        gc_mock.delta_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        "id": "msg-live-1",
+                        "subject": f"RFQ [ref:{test_requisition.id}]",
+                        "sentDateTime": "2026-06-01T10:00:00Z",
+                        "toRecipients": [{"emailAddress": {"address": "vendor@arrow.com"}}],
+                        "hasAttachments": False,
+                    },
+                    {
+                        "id": "msg-stale-1",
+                        "subject": "RFQ [ref:99999]",
+                        "sentDateTime": "2026-06-01T10:01:00Z",
+                        "toRecipients": [{"emailAddress": {"address": "vendor@avnet.com"}}],
+                        "hasAttachments": False,
+                    },
+                ],
+                "delta-after-stale",
+            )
+        )
+
+        with (
+            patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch("app.utils.graph_client.GraphClient", return_value=gc_mock),
+        ):
+            result = await scan_sent_folder(test_user, db_session)
+
+        assert len(result) == 2
+        by_msg = {log.external_id: log for log in result}
+        assert by_msg["msg-live-1"].requisition_id == test_requisition.id
+        assert by_msg["msg-stale-1"].requisition_id is None  # stale token dropped, row kept
+        # Everything committed — no FK crash rolled the batch back.
+        assert db_session.query(ActivityLog).filter(ActivityLog.external_id == "msg-stale-1").count() == 1
+
+    @pytest.mark.asyncio
+    async def test_scan_one_bad_message_does_not_poison_batch(self, db_session, test_user, test_requisition):
+        """F5: per-message savepoints — one malformed message is skipped (logged),
+        the rest of the batch and the delta token survive."""
+        from app.jobs.email_jobs import scan_sent_folder
+        from app.models import SyncState
+
+        gc_mock = MagicMock()
+        gc_mock.delta_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        "id": "msg-bad-1",
+                        "subject": "RFQ broken",
+                        "sentDateTime": "2026-06-01T10:00:00Z",
+                        "toRecipients": [None],  # malformed Graph payload → raises in-loop
+                        "hasAttachments": False,
+                    },
+                    {
+                        "id": "msg-good-1",
+                        "subject": f"RFQ [ref:{test_requisition.id}]",
+                        "sentDateTime": "2026-06-01T10:02:00Z",
+                        "toRecipients": [{"emailAddress": {"address": "vendor@arrow.com"}}],
+                        "hasAttachments": False,
+                    },
+                ],
+                "delta-after-bad",
+            )
+        )
+
+        with (
+            patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch("app.utils.graph_client.GraphClient", return_value=gc_mock),
+        ):
+            result = await scan_sent_folder(test_user, db_session)
+
+        assert [log.external_id for log in result] == ["msg-good-1"]
+        assert result[0].requisition_id == test_requisition.id
+        sync = (
+            db_session.query(SyncState)
+            .filter(SyncState.user_id == test_user.id, SyncState.folder == "sent_items_scan")
+            .one()
+        )
+        assert sync.delta_token == "delta-after-bad"
 
 
 # ── detect_attachments ───────────────────────────────────────────────

--- a/tests/test_email_jobs.py
+++ b/tests/test_email_jobs.py
@@ -1146,6 +1146,46 @@ class TestScanSentFolder:
             result = await scan_sent_folder(user, mock_db)
             assert len(result) >= 1
 
+    @pytest.mark.asyncio
+    async def test_scan_multi_token_subject_attributes_all_requisitions(self):
+        """A sent message tagged with TWO [ref:] tokens (cross-requisition RFQ) creates
+        one ActivityLog per token requisition."""
+        from app.jobs.email_jobs import scan_sent_folder
+
+        user = MagicMock()
+        user.id = 1
+        user.email = "buyer@trioscs.com"
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        gc_mock = MagicMock()
+        gc_mock.delta_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        "id": "msg-multi-001",
+                        "subject": "RFQ — 2 parts [ref:12] [ref:34]",
+                        "sentDateTime": "2026-06-01T10:00:00Z",
+                        "toRecipients": [{"emailAddress": {"address": "vendor@arrow.com"}}],
+                        "hasAttachments": False,
+                    }
+                ],
+                None,
+            )
+        )
+
+        with (
+            patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch("app.utils.graph_client.GraphClient", return_value=gc_mock),
+        ):
+            result = await scan_sent_folder(user, mock_db)
+
+        assert len(result) == 2
+        assert sorted(log.requisition_id for log in result) == [12, 34]
+        # Both rows are the SAME message — shared external_id, same recipient
+        assert {log.external_id for log in result} == {"msg-multi-001"}
+        assert {log.contact_email for log in result} == {"vendor@arrow.com"}
+
 
 # ── detect_attachments ───────────────────────────────────────────────
 

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -48,6 +48,8 @@ from app.models import (
     Contact,
     PendingBatch,
     ProcessedMessage,
+    Requirement,
+    Requisition,
     SyncState,
     User,
     VendorResponse,
@@ -945,6 +947,274 @@ class TestSendBatchRfq:
 
         # Both groups sent (no rephrase gating)
         assert mock_gc.post_json.call_count == 2
+
+
+# ── send_batch_rfq: cross-requisition tracking ───────────────────────
+
+
+def _two_requisitions(db_session, test_user):
+    """Two requisitions, one requirement each, for cross-requisition sends."""
+    reqs = []
+    for i, mpn in enumerate(["CROSS-MPN-A", "CROSS-MPN-B"]):
+        req = Requisition(
+            name=f"REQ-CROSS-{i}",
+            customer_name="Acme Electronics",
+            status="active",
+            created_by=test_user.id,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(req)
+        db_session.flush()
+        db_session.add(
+            Requirement(
+                requisition_id=req.id,
+                primary_mpn=mpn,
+                target_qty=100 * (i + 1),
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        reqs.append(req)
+    db_session.commit()
+    return reqs
+
+
+class TestSendBatchRfqCrossRequisition:
+    """Per-requisition Contact fan-out (requisition_parts_map) in send_batch_rfq.
+
+    One email per vendor; one Contact per (requisition, vendor) sharing that email's
+    graph ids; subject carries one [ref:{id}] token per requisition in ascending
+    requisition-id order. The legacy scalar requisition_id shape (htmx_views.rfq_send)
+    stays byte-identical.
+    """
+
+    @pytest.mark.asyncio
+    async def test_multi_requisition_contact_fanout(self, db_session, test_user):
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        parts_map = {
+            req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
+            req_b.id: [{"mpn": "CROSS-MPN-B", "qty": 200}],
+        }
+        expected_tokens = f"[ref:{req_a.id}] [ref:{req_b.id}]"
+        tagged = f"RFQ {expected_tokens}"
+
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        # One sent-message lookup per vendor — distinct graph ids per vendor.
+        mock_gc.get_json.side_effect = [
+            {"value": [{"id": "sent-a", "conversationId": "conv-vendor-a", "subject": tagged}]},
+            {"value": [{"id": "sent-b", "conversationId": "conv-vendor-b", "subject": tagged}]},
+        ]
+
+        vendor_groups = [
+            {"vendor_name": "Vendor A", "vendor_email": "a@vendora.com", "subject": "RFQ", "body": "Quote please"},
+            {"vendor_name": "Vendor B", "vendor_email": "b@vendorb.com", "subject": "RFQ", "body": "Quote please"},
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                vendor_groups=vendor_groups,
+                requisition_parts_map=parts_map,
+            )
+
+        assert [r["status"] for r in results] == ["sent", "sent"]
+
+        contacts = db_session.query(Contact).order_by(Contact.id).all()
+        assert len(contacts) == 4  # 2 requisitions x 2 vendors
+        pairs = {(c.requisition_id, c.vendor_name) for c in contacts}
+        assert pairs == {
+            (req_a.id, "Vendor A"),
+            (req_b.id, "Vendor A"),
+            (req_a.id, "Vendor B"),
+            (req_b.id, "Vendor B"),
+        }
+        for c in contacts:
+            # parts_included scoped to that contact's own requisition
+            assert c.parts_included == parts_map[c.requisition_id]
+            # every row carries the full multi-token subject
+            assert expected_tokens in c.subject
+        # Graph ids shared per vendor (same email), distinct across vendors.
+        by_vendor: dict = {}
+        for c in contacts:
+            by_vendor.setdefault(c.vendor_name, set()).add((c.graph_message_id, c.graph_conversation_id))
+        assert by_vendor["Vendor A"] == {("sent-a", "conv-vendor-a")}
+        assert by_vendor["Vendor B"] == {("sent-b", "conv-vendor-b")}
+
+    @pytest.mark.asyncio
+    async def test_subject_tokens_sorted_by_requisition_id(self, db_session, test_user):
+        """Token order is deterministic (ascending requisition id), regardless of map
+        insertion order."""
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        # Deliberately reversed insertion order.
+        parts_map = {
+            req_b.id: [{"mpn": "CROSS-MPN-B", "qty": 200}],
+            req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
+        }
+
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        mock_gc.get_json.return_value = {"value": []}
+
+        vendor_groups = [
+            {"vendor_name": "Vendor A", "vendor_email": "a@vendora.com", "subject": "RFQ", "body": "Quote"},
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                vendor_groups=vendor_groups,
+                requisition_parts_map=parts_map,
+            )
+
+        payload = mock_gc.post_json.call_args[0][1]
+        assert payload["message"]["subject"] == f"RFQ [ref:{req_a.id}] [ref:{req_b.id}]"
+
+    @pytest.mark.asyncio
+    async def test_legacy_scalar_requisition_id_shape_unchanged(self, db_session, test_user, test_requisition):
+        """Regression: the htmx_views.rfq_send call shape (scalar requisition_id,
+        parts as TEXT) is byte-identical — one Contact, single token, parts passed
+        through untouched, parts_count keeps its historical len() semantics."""
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        mock_gc.get_json.return_value = {"value": []}
+
+        vendor_groups = [
+            {
+                "vendor_name": "Vendor A",
+                "vendor_email": "a@vendora.com",
+                "parts": "LM317T x100",  # rfq_send passes a parts_summary STRING
+                "subject": "RFQ - Req",
+                "body": "Quote please",
+            }
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                requisition_id=test_requisition.id,
+                vendor_groups=vendor_groups,
+            )
+
+        contacts = db_session.query(Contact).all()
+        assert len(contacts) == 1
+        c = contacts[0]
+        assert c.requisition_id == test_requisition.id
+        assert c.parts_included == "LM317T x100"
+        assert c.subject == f"RFQ - Req [ref:{test_requisition.id}]"
+        assert results[0]["status"] == "sent"
+        assert results[0]["parts_count"] == len("LM317T x100")
+
+    @pytest.mark.asyncio
+    async def test_failed_send_creates_contact_per_requisition(self, db_session, test_user):
+        """A failed vendor send still records a Contact on EVERY involved requisition
+        (the failure must be visible on each one's history)."""
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        parts_map = {
+            req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
+            req_b.id: [{"mpn": "CROSS-MPN-B", "qty": 200}],
+        }
+
+        mock_gc = AsyncMock()
+        mock_gc.post_json.side_effect = Exception("SMTP Error")
+
+        vendor_groups = [
+            {"vendor_name": "Vendor A", "vendor_email": "a@vendora.com", "subject": "RFQ", "body": "Quote"},
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                vendor_groups=vendor_groups,
+                requisition_parts_map=parts_map,
+            )
+
+        assert len(results) == 1
+        assert results[0]["status"] == "failed"
+        contacts = db_session.query(Contact).order_by(Contact.id).all()
+        assert len(contacts) == 2
+        assert {c.requisition_id for c in contacts} == {req_a.id, req_b.id}
+        for c in contacts:
+            assert c.status == "failed"
+            assert "SMTP Error" in c.error_message
+            assert c.parts_included == parts_map[c.requisition_id]
+
+    @pytest.mark.asyncio
+    async def test_tag_propagation_covers_all_requisitions(self, db_session, test_user):
+        """The tag-propagation block reads requirements from ALL involved requisitions,
+        not just one."""
+        from app.models import MaterialCard, VendorCard
+
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        cards = []
+        for req in (req_a, req_b):
+            card = MaterialCard(normalized_mpn=f"CARD-{req.id}", display_mpn=f"CARD-{req.id}")
+            db_session.add(card)
+            db_session.flush()
+            requirement = db_session.query(Requirement).filter(Requirement.requisition_id == req.id).one()
+            requirement.material_card_id = card.id
+            cards.append(card)
+        db_session.add(
+            VendorCard(
+                normalized_name="vendor a",
+                display_name="Vendor A",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        db_session.commit()
+
+        parts_map = {
+            req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
+            req_b.id: [{"mpn": "CROSS-MPN-B", "qty": 200}],
+        }
+
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        mock_gc.get_json.return_value = {"value": []}
+        mock_propagate = MagicMock()
+
+        vendor_groups = [
+            {"vendor_name": "Vendor A", "vendor_email": "a@vendora.com", "subject": "RFQ", "body": "Quote"},
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("app.services.tagging.propagate_tags_to_entity", mock_propagate),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                vendor_groups=vendor_groups,
+                requisition_parts_map=parts_map,
+            )
+
+        propagated_card_ids = {call.args[2] for call in mock_propagate.call_args_list}
+        assert propagated_card_ids == {cards[0].id, cards[1].id}
 
 
 # ── parse_response_ai ────────────────────────────────────────────────
@@ -2211,6 +2481,205 @@ class TestPollInbox:
 
         # Should be unmatched (email_exact and domain maps are user-scoped)
         assert len(results) == 1
+
+
+# ── poll_inbox: cross-requisition reply fan-out ──────────────────────
+
+
+class TestPollInboxCrossRequisitionFanout:
+    """Reply matching against per-(requisition, vendor) Contact rows.
+
+    Tier-1: a conversation id maps to a LIST of Contacts — the reply is
+    attributed to ALL of them (one VendorResponse per message, every Contact
+    progressed). Tier-2: every [ref:] token in the subject is resolved.
+    """
+
+    def _make_inbox_message(
+        self,
+        msg_id="msg-1",
+        sender_email="vendor@parts.com",
+        subject="RE: RFQ",
+        conv_id="conv-1",
+    ):
+        return {
+            "id": msg_id,
+            "subject": subject,
+            "from": {"emailAddress": {"address": sender_email, "name": "Vendor"}},
+            "bodyPreview": "Quote attached",
+            "body": {"content": "<p>Quote attached</p>"},
+            "conversationId": conv_id,
+            "receivedDateTime": None,
+        }
+
+    def _fanout_contacts(self, db_session, test_user, conv_id=None):
+        """Two Contacts (one per requisition) for ONE vendor email — the rows a cross-
+        requisition send_batch_rfq writes."""
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        contacts = []
+        for req in (req_a, req_b):
+            c = Contact(
+                requisition_id=req.id,
+                user_id=test_user.id,
+                contact_type="email",
+                vendor_name="Vendor A",
+                vendor_contact="vendor@parts.com",
+                graph_conversation_id=conv_id,
+                status="sent",
+                created_at=datetime.now(timezone.utc),
+            )
+            db_session.add(c)
+            contacts.append(c)
+        db_session.commit()
+        return req_a, req_b, contacts
+
+    @pytest.mark.asyncio
+    async def test_tier1_reply_attributed_to_all_contacts_sharing_conversation(self, db_session, test_user):
+        req_a, req_b, (c1, c2) = self._fanout_contacts(db_session, test_user, conv_id="conv-shared")
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    sender_email="vendor@parts.com",
+                    conv_id="conv-shared",
+                ),
+            ]
+        }
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        # Exactly ONE VendorResponse per message (per-message, not per-requisition)
+        vrs = db_session.query(VendorResponse).all()
+        assert len(vrs) == 1
+        assert vrs[0].contact_id == c1.id  # contacts[0] = earliest Contact
+        assert results[0]["matched_contact_id"] == c1.id
+        assert results[0]["matched_requisition_id"] == req_a.id
+        # BOTH contacts progressed (sent -> responded)
+        db_session.refresh(c1)
+        db_session.refresh(c2)
+        assert c1.status == "responded"
+        assert c2.status == "responded"
+
+    @pytest.mark.asyncio
+    async def test_tier2_multi_token_subject_matches_all_requisitions(self, db_session, test_user):
+        """A reply whose subject carries BOTH [ref:] tokens (no conversation-id match)
+        resolves every (token req, sender email) pair."""
+        req_a, req_b, (c1, c2) = self._fanout_contacts(db_session, test_user, conv_id=None)
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    sender_email="vendor@parts.com",
+                    subject=f"RE: RFQ — 2 parts [ref:{req_a.id}] [ref:{req_b.id}]",
+                    conv_id="unrelated-conv",
+                ),
+            ]
+        }
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        assert len(db_session.query(VendorResponse).all()) == 1
+        assert results[0]["matched_contact_id"] == c1.id
+        db_session.refresh(c1)
+        db_session.refresh(c2)
+        assert c1.status == "responded"
+        assert c2.status == "responded"
+
+    @pytest.mark.asyncio
+    async def test_tier2_multi_token_no_email_match_assigns_first_token_req(self, db_session, test_user):
+        """Tokens found but unknown sender: the VendorResponse is assigned to the
+        first token's requisition (existing single-token behavior preserved)."""
+        req_a, req_b = _two_requisitions(db_session, test_user)
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    sender_email="unknown@vendor.com",
+                    subject=f"RE: RFQ [ref:{req_a.id}] [ref:{req_b.id}]",
+                    conv_id="no-match-conv",
+                ),
+            ]
+        }
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        assert results[0]["matched_contact_id"] is None
+        assert results[0]["matched_requisition_id"] == req_a.id
+
+    @pytest.mark.asyncio
+    async def test_send_then_reply_end_to_end(self, db_session, test_user):
+        """Full loop: cross-requisition send writes fan-out Contacts sharing a
+        conversation id; a reply on that conversation progresses ALL of them."""
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        parts_map = {
+            req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
+            req_b.id: [{"mpn": "CROSS-MPN-B", "qty": 200}],
+        }
+        tagged = f"RFQ [ref:{req_a.id}] [ref:{req_b.id}]"
+
+        send_gc = AsyncMock()
+        send_gc.post_json.return_value = {}
+        send_gc.get_json.return_value = {"value": [{"id": "sent-e2e", "conversationId": "conv-e2e", "subject": tagged}]}
+        vendor_groups = [
+            {"vendor_name": "Vendor A", "vendor_email": "vendor@parts.com", "subject": "RFQ", "body": "Quote"},
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=send_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                vendor_groups=vendor_groups,
+                requisition_parts_map=parts_map,
+            )
+
+        contacts = db_session.query(Contact).order_by(Contact.id).all()
+        assert len(contacts) == 2
+        assert all(c.graph_conversation_id == "conv-e2e" for c in contacts)
+
+        poll_gc = AsyncMock()
+        poll_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    sender_email="vendor@parts.com",
+                    conv_id="conv-e2e",
+                ),
+            ]
+        }
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=poll_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        assert len(db_session.query(VendorResponse).all()) == 1
+        for c in contacts:
+            db_session.refresh(c)
+            assert c.status == "responded"
+        assert {c.requisition_id for c in contacts} == {req_a.id, req_b.id}
 
 
 # ── process_batch_results ────────────────────────────────────────────

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -36,6 +36,7 @@ from app.email_service import (
     _is_noise_email,
     _parse_sequential_fallback,
     _progress_contact_status,
+    _scope_thread_contacts_to_sender,
     _submit_parse_batch,
     log_phone_contact,
     parse_response_ai,
@@ -929,6 +930,70 @@ class TestSendBatchRfq:
         contact_id = results[0]["id"]
         contact = db_session.get(Contact, contact_id)
         assert contact.graph_message_id is None
+
+    @pytest.mark.asyncio
+    async def test_lookup_no_match_logs_and_leaves_graph_ids_null(self, db_session, test_user, test_requisition):
+        """F5: when the sent message is not found in the $top Sent window (e.g. pushed
+        below it by a large batch), the Contact keeps NULL graph ids AND the dropped
+        association is OBSERVABLE (a warning at the call site naming the vendor email),
+        not silent."""
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        # Sent folder returns messages, but none match the recipient → no-match (not an error)
+        mock_gc.get_json.return_value = {
+            "value": [_sent_item("other-msg", "other-conv", "RFQ [ref:999]", recipient="someone-else@x.com")]
+        }
+
+        vendor_groups = [
+            {
+                "vendor_name": "Vendor A",
+                "vendor_email": "sales@vendora.com",
+                "parts": ["LM317T"],
+                "subject": "RFQ",
+                "body": "Quote please",
+            }
+        ]
+
+        # Loguru bypasses stdlib logging propagation, so spy on the module logger directly.
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch("app.email_service.logger.warning") as mock_warn,
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                requisition_id=test_requisition.id,
+                vendor_groups=vendor_groups,
+            )
+
+        assert results[0]["status"] == "sent"
+        contact = db_session.get(Contact, results[0]["id"])
+        assert contact.graph_message_id is None
+        assert contact.graph_conversation_id is None
+        # The dropped graph-id association is logged with the vendor email — observable.
+        # logger.warning(template, *args) → flatten the call args and look for the email.
+        logged = " ".join(
+            str(a) for call in mock_warn.call_args_list for a in (call.args + tuple(call.kwargs.values()))
+        )
+        assert "sales@vendora.com" in logged
+
+    @pytest.mark.asyncio
+    async def test_both_requisition_inputs_raise(self, db_session, test_user, test_requisition):
+        """F11: requisition_id and requisition_parts_map are mutually exclusive modes —
+        passing both must fail loudly instead of silently ignoring the scalar."""
+        with patch("app.utils.graph_client.GraphClient", return_value=AsyncMock()):
+            with pytest.raises(ValueError, match="mutually exclusive"):
+                await send_batch_rfq(
+                    token="fake-token",
+                    db=db_session,
+                    user_id=test_user.id,
+                    requisition_id=test_requisition.id,
+                    requisition_parts_map={test_requisition.id: [{"mpn": "X", "qty": 1}]},
+                    vendor_groups=[],
+                )
 
     @pytest.mark.asyncio
     async def test_group_without_body_still_sends(self, db_session, test_user, test_requisition):
@@ -2681,6 +2746,65 @@ class TestPollInbox:
 # ── poll_inbox: cross-requisition reply fan-out ──────────────────────
 
 
+class TestScopeThreadContactsToSender:
+    """F7/F8: direct unit tests of _scope_thread_contacts_to_sender — the vendor-scoping
+    guard that stops a Tier-1 conversation-id match from progressing the WRONG vendor's
+    contacts on a legacy collided thread.
+
+    Its four paths: (1) exact email, (2) same-domain
+    fallback, (3) full-thread when single-vendor, (4) [] for a multi-vendor thread with an
+    unrecognized sender (the security backstop). The poll_inbox pre-filter drops
+    noise-domain SENDERS before they reach here, so the noise-domain guard on path 2 is
+    only reachable via this direct test.
+    """
+
+    def _contact(self, email, vendor="V"):
+        return Contact(
+            contact_type="email",
+            vendor_name=vendor,
+            vendor_contact=email,
+            status="sent",
+            created_at=datetime.now(timezone.utc),
+        )
+
+    def test_path1_exact_email_match(self):
+        a1 = self._contact("a@vendora.com", "A")
+        a2 = self._contact("a@vendora.com", "A")
+        b1 = self._contact("b@vendorb.com", "B")
+        out = _scope_thread_contacts_to_sender([a1, a2, b1], "a@vendora.com")
+        assert out == [a1, a2]
+
+    def test_path2_same_domain_fallback_scopes_to_one_vendor(self):
+        a1 = self._contact("a@vendora.com", "A")
+        b1 = self._contact("b@vendorb.com", "B")
+        # sales@ is a different mailbox at Vendor A — domain fallback, never path 3.
+        out = _scope_thread_contacts_to_sender([a1, b1], "sales@vendora.com")
+        assert out == [a1]
+
+    def test_path3_single_vendor_thread_full_fanout(self):
+        a1 = self._contact("a@vendora.com", "A")
+        a2 = self._contact("a@vendora.com", "A")
+        # Colleague from a different mailbox, single-vendor thread → full fan-out.
+        out = _scope_thread_contacts_to_sender([a1, a2], "colleague@vendora.com")
+        assert out == [a1, a2]
+
+    def test_path4_multi_vendor_unrecognized_sender_returns_empty(self):
+        a1 = self._contact("a@vendora.com", "A")
+        b1 = self._contact("b@vendorb.com", "B")
+        # Stranger on a non-noise domain matching neither vendor → no fan-out (backstop).
+        out = _scope_thread_contacts_to_sender([a1, b1], "stranger@unknownco.com")
+        assert out == []
+
+    def test_path2_noise_domain_guard_blocks_domain_fanout(self):
+        noise_domain = next(iter(NOISE_DOMAINS))
+        a1 = self._contact(f"alice@{noise_domain}", "A")
+        b1 = self._contact(f"bob@{noise_domain}", "B")
+        # An unrecognized sender on a generic shared domain must NOT match everyone on
+        # that domain (path 2 is skipped for noise domains); two vendors block path 3 → [].
+        out = _scope_thread_contacts_to_sender([a1, b1], f"carol@{noise_domain}")
+        assert out == []
+
+
 class TestPollInboxCrossRequisitionFanout:
     """Reply matching against per-(requisition, vendor) Contact rows.
 
@@ -2959,6 +3083,133 @@ class TestPollInboxCrossRequisitionFanout:
         db_session.refresh(c2)
         assert c1.status == "responded"
         assert c2.status == "responded"
+
+    @pytest.mark.asyncio
+    async def test_tier1_collided_thread_unrecognized_sender_no_cross_vendor_fanout(self, db_session, test_user):
+        """F7: path-4 backstop — a multi-vendor collided conversation with a reply from an
+        UNRECOGNIZED, non-noise sender matching neither vendor must progress NO contact.
+
+        This pins the no-cross-vendor-fan-out invariant: if _scope_thread_contacts_to_sender
+        ever fell through to returning the full thread instead of [], a reply from a stranger
+        would silently progress BOTH vendors' contacts — the exact mis-attribution the
+        function exists to prevent. Tier-1 returns [], so the reply falls through to Tier 2+
+        (no token, no email/domain match here) and is saved unmatched.
+        """
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        contacts = []
+        for req, vendor, email in [
+            (req_a, "Vendor A", "a@vendora.com"),
+            (req_b, "Vendor A", "a@vendora.com"),
+            (req_a, "Vendor B", "b@vendorb.com"),
+        ]:
+            c = Contact(
+                requisition_id=req.id,
+                user_id=test_user.id,
+                contact_type="email",
+                vendor_name=vendor,
+                vendor_contact=email,
+                graph_conversation_id="conv-collided",
+                status="sent",
+                created_at=datetime.now(timezone.utc),
+            )
+            db_session.add(c)
+            contacts.append(c)
+        db_session.commit()
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    # Third party, NON-noise domain, matches neither vendora.com nor vendorb.com
+                    sender_email="stranger@unknownco.com",
+                    conv_id="conv-collided",
+                ),
+            ]
+        }
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        for c in contacts:
+            db_session.refresh(c)
+        # NO contact progressed — the stranger matched nobody on the collided thread.
+        assert all(c.status == "sent" for c in contacts)
+        # The response falls through Tiers 2-4 (no token, no email/domain match) → unmatched.
+        vr = db_session.query(VendorResponse).one()
+        assert vr.contact_id is None
+        assert vr.status == "new"
+
+    @pytest.mark.asyncio
+    async def test_tier1_collided_thread_domain_fallback_scopes_to_one_vendor(self, db_session, test_user):
+        """F8: path-2 (same-domain fallback) on a MULTI-vendor thread — a reply from a
+        DIFFERENT mailbox at Vendor A (sales@vendora.com) must progress only Vendor A's
+        contacts and never leak to Vendor B, even though both share one conversation id.
+
+        The exact-email match (path 1) misses (sales@ != a@), so resolution must come from
+        the domain branch, NOT the single-vendor full-thread branch (path 3 can't fire — the
+        thread holds two distinct vendor emails).
+        """
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        a1 = Contact(
+            requisition_id=req_a.id,
+            user_id=test_user.id,
+            contact_type="email",
+            vendor_name="Vendor A",
+            vendor_contact="a@vendora.com",
+            graph_conversation_id="conv-collided",
+            status="sent",
+            created_at=datetime.now(timezone.utc),
+        )
+        a2 = Contact(
+            requisition_id=req_b.id,
+            user_id=test_user.id,
+            contact_type="email",
+            vendor_name="Vendor A",
+            vendor_contact="a@vendora.com",
+            graph_conversation_id="conv-collided",
+            status="sent",
+            created_at=datetime.now(timezone.utc),
+        )
+        b1 = Contact(
+            requisition_id=req_a.id,
+            user_id=test_user.id,
+            contact_type="email",
+            vendor_name="Vendor B",
+            vendor_contact="b@vendorb.com",
+            graph_conversation_id="conv-collided",
+            status="sent",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add_all([a1, a2, b1])
+        db_session.commit()
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    sender_email="sales@vendora.com",  # different mailbox, same domain as Vendor A
+                    conv_id="conv-collided",
+                ),
+            ]
+        }
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        for c in (a1, a2, b1):
+            db_session.refresh(c)
+        # Only Vendor A's contacts progressed via the domain fallback; Vendor B untouched.
+        assert a1.status == "responded"
+        assert a2.status == "responded"
+        assert b1.status == "sent"
+        vr = db_session.query(VendorResponse).one()
+        assert vr.contact_id in (a1.id, a2.id)
 
     @pytest.mark.asyncio
     async def test_tier2_stale_token_filtered_against_live_requisitions(self, db_session, test_user):

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -337,31 +337,66 @@ class TestLogPhoneContact:
 # ── _find_sent_message ───────────────────────────────────────────────
 
 
+def _sent_item(msg_id, conv_id, subject, recipient="sales@vendora.com"):
+    """A Graph sentItems message shaped like the real API response (toRecipients always
+    present under the $select the service requests)."""
+    return {
+        "id": msg_id,
+        "conversationId": conv_id,
+        "subject": subject,
+        "toRecipients": [{"emailAddress": {"address": recipient}}],
+    }
+
+
 class TestFindSentMessage:
     @pytest.mark.asyncio
     async def test_found_matching_subject(self):
         gc = AsyncMock()
         gc.get_json.return_value = {
             "value": [
-                {"id": "msg-1", "conversationId": "conv-1", "subject": "RFQ Parts [ref:10]"},
-                {"id": "msg-2", "conversationId": "conv-2", "subject": "Something Else"},
+                _sent_item("msg-1", "conv-1", "RFQ Parts [ref:10]"),
+                _sent_item("msg-2", "conv-2", "Something Else"),
             ]
         }
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await _find_sent_message(gc, "RFQ Parts [ref:10]")
+            result = await _find_sent_message(gc, "RFQ Parts [ref:10]", "sales@vendora.com")
         assert result["id"] == "msg-1"
         assert result["conversationId"] == "conv-1"
 
     @pytest.mark.asyncio
-    async def test_no_matching_subject(self):
+    async def test_same_subject_discriminated_by_recipient(self):
+        """The batch-collision case (F1): every vendor in a batch shares ONE tagged
+        subject, so the lookup MUST discriminate on toRecipients — each vendor's lookup
+        returns the message addressed to THAT vendor, never the newest."""
         gc = AsyncMock()
+        shared = "RFQ — 2 parts [ref:1] [ref:2]"
         gc.get_json.return_value = {
             "value": [
-                {"id": "msg-1", "subject": "Not a match"},
+                _sent_item("sent-b", "conv-b", shared, recipient="b@vendorb.com"),
+                _sent_item("sent-a", "conv-a", shared, recipient="a@vendora.com"),
             ]
         }
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await _find_sent_message(gc, "RFQ Parts [ref:10]")
+            result_a = await _find_sent_message(gc, shared, "a@vendora.com")
+            result_b = await _find_sent_message(gc, shared, "B@VendorB.com")  # case-insensitive
+        assert result_a["id"] == "sent-a"
+        assert result_b["id"] == "sent-b"
+
+    @pytest.mark.asyncio
+    async def test_subject_match_wrong_recipient_returns_none(self):
+        """A same-subject message addressed to a DIFFERENT vendor must not match."""
+        gc = AsyncMock()
+        gc.get_json.return_value = {"value": [_sent_item("sent-b", "conv-b", "RFQ [ref:1]", recipient="b@vendorb.com")]}
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await _find_sent_message(gc, "RFQ [ref:1]", "a@vendora.com")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_matching_subject(self):
+        gc = AsyncMock()
+        gc.get_json.return_value = {"value": [_sent_item("msg-1", "conv-1", "Not a match")]}
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await _find_sent_message(gc, "RFQ Parts [ref:10]", "sales@vendora.com")
         assert result is None
 
     @pytest.mark.asyncio
@@ -369,7 +404,7 @@ class TestFindSentMessage:
         gc = AsyncMock()
         gc.get_json.return_value = None
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await _find_sent_message(gc, "Subject")
+            result = await _find_sent_message(gc, "Subject", "sales@vendora.com")
         assert result is None
 
     @pytest.mark.asyncio
@@ -377,7 +412,7 @@ class TestFindSentMessage:
         gc = AsyncMock()
         gc.get_json.return_value = {"value": []}
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await _find_sent_message(gc, "Subject")
+            result = await _find_sent_message(gc, "Subject", "sales@vendora.com")
         assert result is None
 
     @pytest.mark.asyncio
@@ -385,19 +420,15 @@ class TestFindSentMessage:
         gc = AsyncMock()
         gc.get_json.side_effect = Exception("Network error")
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await _find_sent_message(gc, "Subject")
+            result = await _find_sent_message(gc, "Subject", "sales@vendora.com")
         assert result is None
 
     @pytest.mark.asyncio
     async def test_subject_whitespace_matching(self):
         gc = AsyncMock()
-        gc.get_json.return_value = {
-            "value": [
-                {"id": "msg-1", "conversationId": "conv-1", "subject": " RFQ [ref:10] "},
-            ]
-        }
+        gc.get_json.return_value = {"value": [_sent_item("msg-1", "conv-1", " RFQ [ref:10] ")]}
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await _find_sent_message(gc, " RFQ [ref:10] ")
+            result = await _find_sent_message(gc, " RFQ [ref:10] ", "sales@vendora.com")
         assert result["id"] == "msg-1"
 
     @pytest.mark.asyncio
@@ -407,10 +438,10 @@ class TestFindSentMessage:
         gc.get_json.side_effect = [
             {"value": []},
             {"value": []},
-            {"value": [{"id": "msg-1", "conversationId": "conv-1", "subject": "Test Subject"}]},
+            {"value": [_sent_item("msg-1", "conv-1", "Test Subject")]},
         ]
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await _find_sent_message(gc, "Test Subject")
+            result = await _find_sent_message(gc, "Test Subject", "sales@vendora.com")
         assert result["id"] == "msg-1"
         assert gc.get_json.call_count == 3
 
@@ -419,11 +450,9 @@ class TestFindSentMessage:
         """Verify function returns on first successful match without exhausting
         retries."""
         gc = AsyncMock()
-        gc.get_json.return_value = {
-            "value": [{"id": "msg-1", "conversationId": "conv-1", "subject": "Quick Find"}],
-        }
+        gc.get_json.return_value = {"value": [_sent_item("msg-1", "conv-1", "Quick Find")]}
         with patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await _find_sent_message(gc, "Quick Find")
+            result = await _find_sent_message(gc, "Quick Find", "sales@vendora.com")
         assert result["id"] == "msg-1"
         assert gc.get_json.call_count == 1
 
@@ -834,13 +863,7 @@ class TestSendBatchRfq:
         mock_gc.post_json.return_value = {}
         tagged_subject = f"RFQ [ref:{test_requisition.id}]"
         mock_gc.get_json.return_value = {
-            "value": [
-                {
-                    "id": "sent-msg-100",
-                    "conversationId": "conv-100",
-                    "subject": tagged_subject,
-                }
-            ]
+            "value": [_sent_item("sent-msg-100", "conv-100", tagged_subject, recipient="sales@vendora.com")]
         }
 
         vendor_groups = [
@@ -989,6 +1012,11 @@ class TestSendBatchRfqCrossRequisition:
 
     @pytest.mark.asyncio
     async def test_multi_requisition_contact_fanout(self, db_session, test_user):
+        """The REAL Graph collision scenario: every vendor in the batch shares one
+        identical tagged subject, and EVERY sent-items lookup sees the SAME list
+        (both messages). Only the toRecipients discrimination can hand each
+        vendor its own graph ids — a subject-only match would give every contact
+        the newest message's conversation id (the F1 misattribution bug)."""
         req_a, req_b = _two_requisitions(db_session, test_user)
         parts_map = {
             req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
@@ -999,11 +1027,14 @@ class TestSendBatchRfqCrossRequisition:
 
         mock_gc = AsyncMock()
         mock_gc.post_json.return_value = {}
-        # One sent-message lookup per vendor — distinct graph ids per vendor.
-        mock_gc.get_json.side_effect = [
-            {"value": [{"id": "sent-a", "conversationId": "conv-vendor-a", "subject": tagged}]},
-            {"value": [{"id": "sent-b", "conversationId": "conv-vendor-b", "subject": tagged}]},
-        ]
+        # ONE shared sent-items list for every lookup — identical subjects, newest
+        # (Vendor B's) first, exactly as Graph returns after a batch send.
+        mock_gc.get_json.return_value = {
+            "value": [
+                _sent_item("sent-b", "conv-vendor-b", tagged, recipient="b@vendorb.com"),
+                _sent_item("sent-a", "conv-vendor-a", tagged, recipient="a@vendora.com"),
+            ]
+        }
 
         vendor_groups = [
             {"vendor_name": "Vendor A", "vendor_email": "a@vendora.com", "subject": "RFQ", "body": "Quote please"},
@@ -1039,12 +1070,87 @@ class TestSendBatchRfqCrossRequisition:
             assert c.parts_included == parts_map[c.requisition_id]
             # every row carries the full multi-token subject
             assert expected_tokens in c.subject
-        # Graph ids shared per vendor (same email), distinct across vendors.
+        # Graph ids shared per vendor (same email), distinct across vendors —
+        # despite every lookup seeing the same same-subject list.
         by_vendor: dict = {}
         for c in contacts:
             by_vendor.setdefault(c.vendor_name, set()).add((c.graph_message_id, c.graph_conversation_id))
         assert by_vendor["Vendor A"] == {("sent-a", "conv-vendor-a")}
         assert by_vendor["Vendor B"] == {("sent-b", "conv-vendor-b")}
+
+    @pytest.mark.asyncio
+    async def test_same_subject_batch_reply_progresses_only_replying_vendor(self, db_session, test_user):
+        """End-to-end F1 pin: two vendors, same subject, shared sent-lookup → a reply
+        from one vendor progresses ONLY that vendor's contacts (on both
+        requisitions), never the other's. The replier is Vendor B — the NEWEST
+        sent item — whose conversation id the old subject-only lookup stamped on
+        EVERY vendor's contacts (so pre-fix, B's reply progressed A too). The
+        reply subject carries no tokens (vendors often trim them), isolating
+        Tier-1."""
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        parts_map = {
+            req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
+            req_b.id: [{"mpn": "CROSS-MPN-B", "qty": 200}],
+        }
+        tagged = f"RFQ [ref:{req_a.id}] [ref:{req_b.id}]"
+
+        send_gc = AsyncMock()
+        send_gc.post_json.return_value = {}
+        send_gc.get_json.return_value = {
+            "value": [
+                _sent_item("sent-b", "conv-vendor-b", tagged, recipient="b@vendorb.com"),
+                _sent_item("sent-a", "conv-vendor-a", tagged, recipient="a@vendora.com"),
+            ]
+        }
+        vendor_groups = [
+            {"vendor_name": "Vendor A", "vendor_email": "a@vendora.com", "subject": "RFQ", "body": "Quote"},
+            {"vendor_name": "Vendor B", "vendor_email": "b@vendorb.com", "subject": "RFQ", "body": "Quote"},
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=send_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                vendor_groups=vendor_groups,
+                requisition_parts_map=parts_map,
+            )
+
+        poll_gc = AsyncMock()
+        poll_gc.get_json.return_value = {
+            "value": [
+                {
+                    "id": "reply-b",
+                    "subject": "RE: RFQ",  # token-stripped reply: Tier-1 only
+                    "from": {"emailAddress": {"address": "b@vendorb.com", "name": "Vendor B"}},
+                    "bodyPreview": "Quote attached",
+                    "body": {"content": "<p>Quote attached</p>"},
+                    "conversationId": "conv-vendor-b",
+                    "receivedDateTime": None,
+                }
+            ]
+        }
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=poll_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        contacts = db_session.query(Contact).order_by(Contact.id).all()
+        a_contacts = [c for c in contacts if c.vendor_name == "Vendor A"]
+        b_contacts = [c for c in contacts if c.vendor_name == "Vendor B"]
+        # Vendor B progressed on BOTH requisitions; Vendor A untouched on both.
+        assert {c.requisition_id for c in b_contacts} == {req_a.id, req_b.id}
+        assert all(c.status == "responded" for c in b_contacts)
+        assert all(c.status == "sent" for c in a_contacts)
+        # The VendorResponse anchors to one of B's contacts, never A's.
+        vr = db_session.query(VendorResponse).one()
+        assert vr.contact_id in {c.id for c in b_contacts}
 
     @pytest.mark.asyncio
     async def test_subject_tokens_sorted_by_requisition_id(self, db_session, test_user):
@@ -1215,6 +1321,95 @@ class TestSendBatchRfqCrossRequisition:
 
         propagated_card_ids = {call.args[2] for call in mock_propagate.call_args_list}
         assert propagated_card_ids == {cards[0].id, cards[1].id}
+
+    @pytest.mark.asyncio
+    async def test_contact_tracking_failure_isolated_per_vendor(self, db_session, test_user):
+        """F3: a Contact-creation failure for one vendor must not poison the batch —
+        the other vendor's rows persist, and the broken vendor is reported as a
+        visible tracking error (its email DID go out), never an exception."""
+        import app.email_service as es
+
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        parts_map = {
+            req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
+            req_b.id: [{"mpn": "CROSS-MPN-B", "qty": 200}],
+        }
+
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        mock_gc.get_json.return_value = {"value": []}
+
+        vendor_groups = [
+            {"vendor_name": "Vendor A", "vendor_email": "a@vendora.com", "subject": "RFQ", "body": "Quote"},
+            {"vendor_name": "Vendor B", "vendor_email": "b@vendorb.com", "subject": "RFQ", "body": "Quote"},
+        ]
+
+        real_create = es._create_contact
+
+        def exploding_create(db, rid, user_id, vendor_name, *args, **kwargs):
+            if vendor_name == "Vendor B":
+                raise RuntimeError("simulated flush failure")
+            return real_create(db, rid, user_id, vendor_name, *args, **kwargs)
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("app.email_service._create_contact", side_effect=exploding_create),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                vendor_groups=vendor_groups,
+                requisition_parts_map=parts_map,
+            )
+
+        by_vendor = {r["vendor_name"]: r for r in results}
+        assert by_vendor["Vendor A"]["status"] == "sent"
+        assert by_vendor["Vendor B"]["status"] == "failed"
+        assert "tracking_error" in by_vendor["Vendor B"]["error"]
+        # Vendor A's per-requisition rows persisted despite Vendor B's failure.
+        contacts = db_session.query(Contact).order_by(Contact.id).all()
+        assert {(c.requisition_id, c.vendor_name) for c in contacts} == {
+            (req_a.id, "Vendor A"),
+            (req_b.id, "Vendor A"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_legacy_none_requisition_creates_no_contacts(self, db_session, test_user):
+        """F12: Contact.requisition_id is NOT NULL — a degenerate legacy call with
+        neither a scalar requisition_id nor a parts map sends the email but writes
+        no Contact rows (instead of crashing on the NULL flush)."""
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        mock_gc.get_json.return_value = {"value": []}
+
+        vendor_groups = [
+            {
+                "vendor_name": "Vendor A",
+                "vendor_email": "a@vendora.com",
+                "parts": ["LM317T"],
+                "subject": "RFQ",
+                "body": "Quote",
+            },
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                vendor_groups=vendor_groups,
+            )
+
+        assert results[0]["status"] == "sent"
+        assert results[0]["id"] is None
+        assert db_session.query(Contact).count() == 0
 
 
 # ── parse_response_ai ────────────────────────────────────────────────
@@ -2636,7 +2831,9 @@ class TestPollInboxCrossRequisitionFanout:
 
         send_gc = AsyncMock()
         send_gc.post_json.return_value = {}
-        send_gc.get_json.return_value = {"value": [{"id": "sent-e2e", "conversationId": "conv-e2e", "subject": tagged}]}
+        send_gc.get_json.return_value = {
+            "value": [_sent_item("sent-e2e", "conv-e2e", tagged, recipient="vendor@parts.com")]
+        }
         vendor_groups = [
             {"vendor_name": "Vendor A", "vendor_email": "vendor@parts.com", "subject": "RFQ", "body": "Quote"},
         ]
@@ -2680,6 +2877,287 @@ class TestPollInboxCrossRequisitionFanout:
             db_session.refresh(c)
             assert c.status == "responded"
         assert {c.requisition_id for c in contacts} == {req_a.id, req_b.id}
+
+    @pytest.mark.asyncio
+    async def test_tier1_collided_conversation_scoped_to_sender_vendor(self, db_session, test_user):
+        """F1(b): legacy data can hold contacts of DIFFERENT vendors under one
+        conversation id (the old subject-only sent-lookup).
+
+        Tier-1 fan-out must scope to the replying vendor's email — fan out across
+        requisitions for the SAME vendor, never across vendors.
+        """
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        contacts = []
+        for req, vendor, email in [
+            (req_a, "Vendor A", "a@vendora.com"),
+            (req_b, "Vendor A", "a@vendora.com"),
+            (req_a, "Vendor B", "b@vendorb.com"),
+        ]:
+            c = Contact(
+                requisition_id=req.id,
+                user_id=test_user.id,
+                contact_type="email",
+                vendor_name=vendor,
+                vendor_contact=email,
+                graph_conversation_id="conv-collided",
+                status="sent",
+                created_at=datetime.now(timezone.utc),
+            )
+            db_session.add(c)
+            contacts.append(c)
+        db_session.commit()
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    sender_email="a@vendora.com",
+                    conv_id="conv-collided",
+                ),
+            ]
+        }
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        a1, a2, b1 = contacts
+        for c in contacts:
+            db_session.refresh(c)
+        # Vendor A's contacts progressed on BOTH requisitions; Vendor B's untouched.
+        assert a1.status == "responded"
+        assert a2.status == "responded"
+        assert b1.status == "sent"
+        vr = db_session.query(VendorResponse).one()
+        assert vr.contact_id in (a1.id, a2.id)
+
+    @pytest.mark.asyncio
+    async def test_tier1_thread_reply_from_colleague_at_same_vendor_still_matches(self, db_session, test_user):
+        """A reply from a different mailbox at the SAME vendor (single-vendor thread,
+        e.g. a colleague answering) still fans out to the thread's contacts."""
+        req_a, req_b, (c1, c2) = self._fanout_contacts(db_session, test_user, conv_id="conv-shared")
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    sender_email="colleague@parts.com",
+                    conv_id="conv-shared",
+                ),
+            ]
+        }
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        db_session.refresh(c1)
+        db_session.refresh(c2)
+        assert c1.status == "responded"
+        assert c2.status == "responded"
+
+    @pytest.mark.asyncio
+    async def test_tier2_stale_token_filtered_against_live_requisitions(self, db_session, test_user):
+        """F5: a [ref:] token pointing at a deleted requisition is dropped before
+        use — the live token still matches its contact, and nothing crashes."""
+        req_a, req_b, (c1, c2) = self._fanout_contacts(db_session, test_user, conv_id=None)
+        stale_id = req_a.id + req_b.id + 1000  # guaranteed nonexistent
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    sender_email="vendor@parts.com",
+                    subject=f"RE: RFQ [ref:{stale_id}] [ref:{req_a.id}]",
+                    conv_id="unrelated-conv",
+                ),
+            ]
+        }
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        assert results[0]["matched_requisition_id"] == req_a.id
+        db_session.refresh(c1)
+        assert c1.status == "responded"
+
+    @pytest.mark.asyncio
+    async def test_tier2_stale_token_only_saves_unlinked_response(self, db_session, test_user):
+        """F5: a subject whose ONLY token is stale must not be attributed to the
+        dead requisition (FK crash on PG) — the reply is saved unmatched."""
+        _two_requisitions(db_session, test_user)
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message(
+                    sender_email="unknown@vendor.com",
+                    subject="RE: RFQ [ref:99999]",
+                    conv_id="no-match-conv",
+                ),
+            ]
+        }
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session)
+
+        assert len(results) == 1
+        assert results[0]["matched_requisition_id"] is None
+        vr = db_session.query(VendorResponse).one()
+        assert vr.requisition_id is None
+        assert vr.status == "new"
+
+
+# ── OOO / bounce contact-status repair (F2) ──────────────────────────
+
+
+class TestOooBounceContactRepair:
+    """The post-parse OOO/bounce correction must (a) trigger on the vocabulary the
+    classifiers actually emit — exactly "ooo_bounce" (_classify_response,
+    RESPONSE_PARSE_SCHEMA, ai.py reparse) — and (b) apply to ALL contacts matched for
+    the message (conversation-id siblings, vendor-email scoped), on BOTH the sequential-
+    fallback path and the batch path."""
+
+    def _seed(self, db_session, test_user, conv_id="conv-ooo"):
+        req_a, req_b = _two_requisitions(db_session, test_user)
+        contacts = []
+        for req in (req_a, req_b):
+            c = Contact(
+                requisition_id=req.id,
+                user_id=test_user.id,
+                contact_type="email",
+                vendor_name="Vendor A",
+                vendor_contact="vendor@parts.com",
+                graph_conversation_id=conv_id,
+                status="sent",
+                created_at=datetime.now(timezone.utc),
+            )
+            db_session.add(c)
+            contacts.append(c)
+        db_session.commit()
+        return contacts
+
+    def _message(self, body, subject="Automatic reply: RFQ", conv_id="conv-ooo"):
+        return {
+            "id": "msg-ooo-1",
+            "subject": subject,
+            "from": {"emailAddress": {"address": "vendor@parts.com", "name": "Vendor"}},
+            "bodyPreview": body,
+            "body": {"content": body},
+            "conversationId": conv_id,
+            "receivedDateTime": None,
+        }
+
+    async def _poll(self, db_session, message):
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {"value": [message]}
+        parsed = {"sentiment": "neutral", "parts": [], "confidence": 0.9}
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value="fake-key"),
+            patch("app.email_service._submit_parse_batch", side_effect=RuntimeError("batch down")),
+            patch("app.email_service.parse_response_ai", new_callable=AsyncMock, return_value=parsed),
+        ):
+            return await poll_inbox(token="fake-token", db=db_session)
+
+    @pytest.mark.asyncio
+    async def test_ooo_classification_repairs_all_sibling_contacts(self, db_session, test_user):
+        """Sequential-fallback path: an out-of-office reply sets status='ooo' on
+        EVERY contact matched for the message, not just vr.contact_id's."""
+        c1, c2 = self._seed(db_session, test_user)
+        body = "I am currently out of office and will return Monday."
+        results = await self._poll(db_session, self._message(body))
+
+        assert len(results) == 1
+        vr = db_session.query(VendorResponse).one()
+        assert vr.classification == "ooo_bounce"  # the REAL vocabulary
+        db_session.refresh(c1)
+        db_session.refresh(c2)
+        assert c1.status == "ooo"
+        assert c2.status == "ooo"
+
+    @pytest.mark.asyncio
+    async def test_bounce_signals_set_bounced(self, db_session, test_user):
+        c1, c2 = self._seed(db_session, test_user)
+        body = "Undeliverable: delivery failure — recipient address rejected."
+        await self._poll(db_session, self._message(body, subject="Undeliverable: RFQ"))
+
+        db_session.refresh(c1)
+        db_session.refresh(c2)
+        assert c1.status == "bounced"
+        assert c2.status == "bounced"
+
+    @pytest.mark.asyncio
+    async def test_terminal_contact_status_not_regressed(self, db_session, test_user):
+        """A contact already quoted must not be downgraded by a late auto-reply."""
+        c1, c2 = self._seed(db_session, test_user)
+        c1.status = "quoted"
+        db_session.commit()
+        body = "Automatic reply: out of office."
+        await self._poll(db_session, self._message(body))
+
+        db_session.refresh(c1)
+        db_session.refresh(c2)
+        assert c1.status == "quoted"
+        assert c2.status == "ooo"
+
+    @pytest.mark.asyncio
+    async def test_batch_path_repairs_contacts_when_results_arrive(self, db_session, test_user):
+        """Batch path: classification arrives LATER via process_batch_results —
+        the repair must run there too (it was structurally dead before)."""
+        c1, c2 = self._seed(db_session, test_user, conv_id="conv-batch-ooo")
+        vr = VendorResponse(
+            requisition_id=c1.requisition_id,
+            contact_id=c1.id,
+            vendor_name="Vendor A",
+            vendor_email="vendor@parts.com",
+            subject="Automatic reply: RFQ",
+            body="I am out of the office until next week.",
+            message_id="msg-batch-ooo",
+            graph_conversation_id="conv-batch-ooo",
+            status="new",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(vr)
+        db_session.flush()
+        pb = PendingBatch(
+            batch_id="batch-ooo-1",
+            batch_type="inbox_parse",
+            request_map={f"vr-{vr.id}": vr.id},
+            status="processing",
+            submitted_at=datetime.now(timezone.utc),
+        )
+        db_session.add(pb)
+        db_session.commit()
+
+        batch_results = {
+            f"vr-{vr.id}": {
+                "overall_sentiment": "neutral",
+                "overall_classification": "ooo_bounce",
+                "confidence": 0.9,
+                "parts": [],
+            }
+        }
+        with (
+            patch("app.utils.claude_client.claude_batch_results", new_callable=AsyncMock, return_value=batch_results),
+            patch("app.services.response_parser._normalize_parsed_parts"),
+        ):
+            applied = await process_batch_results(db_session)
+
+        assert applied == 1
+        db_session.refresh(c1)
+        db_session.refresh(c2)
+        assert c1.status == "ooo"
+        assert c2.status == "ooo"
 
 
 # ── process_batch_results ────────────────────────────────────────────

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -873,6 +873,182 @@ class TestSendInquiryUnavailableExclusion:
         assert "unavailable" in resp.text.lower()
 
 
+def _seed_two_requisitions(db_session):
+    """Two requisitions, one OPEN requirement each — a cross-requisition selection."""
+    out = []
+    for i, mpn in enumerate(["CROSS-MPN-A", "CROSS-MPN-B"]):
+        req = Requisition(name=f"Cross RFQ {i}", status="active", customer_name="Acme Corp")
+        db_session.add(req)
+        db_session.flush()
+        r = Requirement(
+            requisition_id=req.id,
+            primary_mpn=mpn,
+            target_qty=100 * (i + 1),
+            sourcing_status="open",
+        )
+        db_session.add(r)
+        db_session.flush()
+        out.append((req, r))
+    db_session.commit()
+    return out
+
+
+def _seed_vendor_with_email(db_session, normalized, display, email):
+    """VendorCard + VendorContact so send-inquiry resolves a contact email."""
+    vc = VendorCard(normalized_name=normalized, display_name=display)
+    db_session.add(vc)
+    db_session.flush()
+    db_session.add(VendorContact(vendor_card_id=vc.id, email=email, source="email"))
+    db_session.commit()
+    return vc
+
+
+class TestCrossRequisitionTracking:
+    """Part 1 of the bulk RFQ composer spec: a send spanning requisitions tracks
+    on EVERY involved requisition (per-requisition Contact rows, multi-token
+    subjects, preview/send lockstep)."""
+
+    def test_preview_renders_all_ref_tokens_sorted(self, client, db_session):
+        (req_a, r_a), (req_b, r_b) = _seed_two_requisitions(db_session)
+        resp = client.post(
+            "/v2/partials/sightings/preview-inquiry",
+            data={
+                "requirement_ids": [str(r_a.id), str(r_b.id)],
+                "vendor_names": ["Acme"],
+                "email_body": "Please quote.",
+            },
+        )
+        assert resp.status_code == 200
+        lo, hi = sorted([req_a.id, req_b.id])
+        # The exact subject the send will produce — both tokens, ascending req id.
+        assert f"RFQ — 2 parts [ref:{lo}] [ref:{hi}]" in resp.text
+
+    def test_send_passes_per_requisition_parts_map(self, client, db_session, monkeypatch):
+        (req_a, r_a), (req_b, r_b) = _seed_two_requisitions(db_session)
+        captured = {}
+
+        async def fake_send(**kwargs):
+            captured.update(kwargs)
+            return [{"vendor_name": g["vendor_name"], "status": "sent"} for g in kwargs["vendor_groups"]]
+
+        monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
+        resp = client.post(
+            "/v2/partials/sightings/send-inquiry",
+            data={
+                "requirement_ids": [str(r_a.id), str(r_b.id)],
+                "vendor_names": ["Acme"],
+                "email_body": "Please quote.",
+            },
+        )
+        assert resp.status_code == 200
+        assert captured["requisition_parts_map"] == {
+            req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
+            req_b.id: [{"mpn": "CROSS-MPN-B", "qty": 200}],
+        }
+        # No scalar collapse to a single arbitrary requisition anymore.
+        assert captured.get("requisition_id") is None
+
+    def test_send_single_requisition_call_shape_regression(self, client, db_session, monkeypatch):
+        """Single-requisition sends keep working through the same path: the map
+        carries exactly one entry with all selected parts."""
+        _, r, _ = _seed_data(db_session)
+        captured = {}
+
+        async def fake_send(**kwargs):
+            captured.update(kwargs)
+            return [{"vendor_name": g["vendor_name"], "status": "sent"} for g in kwargs["vendor_groups"]]
+
+        monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
+        resp = client.post(
+            "/v2/partials/sightings/send-inquiry",
+            data={
+                "requirement_ids": str(r.id),
+                "vendor_names": ["Acme"],
+                "email_body": "Please quote.",
+            },
+        )
+        assert resp.status_code == 200
+        assert captured["requisition_parts_map"] == {r.requisition_id: [{"mpn": "TEST-MPN-001", "qty": 100}]}
+        assert resp.headers["X-RFQ-Sent"] == "1"
+        assert resp.headers["X-RFQ-Total"] == "1"
+
+    def test_send_two_requisitions_two_vendors_full_tracking(self, client, db_session):
+        """The core spec scenario: 2 requisitions x 2 vendors through the REAL
+        send_batch_rfq (Graph mocked) → 4 Contacts, shared graph ids per vendor,
+        per-requisition parts, both requirements progressed, activity per
+        requirement, X-RFQ-* headers unchanged."""
+        from unittest.mock import AsyncMock, patch
+
+        from app.models.offers import Contact
+
+        (req_a, r_a), (req_b, r_b) = _seed_two_requisitions(db_session)
+        _seed_vendor_with_email(db_session, "acme", "Acme", "sales@acme.com")
+        _seed_vendor_with_email(db_session, "globex", "Globex", "sales@globex.com")
+
+        lo, hi = sorted([req_a.id, req_b.id])
+        tagged = f"RFQ — 2 parts [ref:{lo}] [ref:{hi}]"
+
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        mock_gc.get_json.side_effect = [
+            {"value": [{"id": "sent-acme", "conversationId": "conv-acme", "subject": tagged}]},
+            {"value": [{"id": "sent-globex", "conversationId": "conv-globex", "subject": tagged}]},
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            resp = client.post(
+                "/v2/partials/sightings/send-inquiry",
+                data={
+                    "requirement_ids": [str(r_a.id), str(r_b.id)],
+                    "vendor_names": ["Acme", "Globex"],
+                    "email_body": "Please quote.",
+                },
+            )
+
+        assert resp.status_code == 200
+        assert resp.headers["X-RFQ-Sent"] == "2"
+        assert resp.headers["X-RFQ-Total"] == "2"
+        assert resp.headers["X-RFQ-Skipped"] == "0"
+        assert resp.headers["X-RFQ-Unavailable"] == "0"
+
+        contacts = db_session.query(Contact).order_by(Contact.id).all()
+        assert len(contacts) == 4  # one per (requisition, vendor)
+        assert {(c.requisition_id, c.vendor_name) for c in contacts} == {
+            (req_a.id, "Acme"),
+            (req_b.id, "Acme"),
+            (req_a.id, "Globex"),
+            (req_b.id, "Globex"),
+        }
+        expected_parts = {
+            req_a.id: [{"mpn": "CROSS-MPN-A", "qty": 100}],
+            req_b.id: [{"mpn": "CROSS-MPN-B", "qty": 200}],
+        }
+        for c in contacts:
+            assert c.subject == tagged  # identical to the preview subject
+            assert c.parts_included == expected_parts[c.requisition_id]
+        graph_ids = {}
+        for c in contacts:
+            graph_ids.setdefault(c.vendor_name, set()).add((c.graph_message_id, c.graph_conversation_id))
+        assert graph_ids["Acme"] == {("sent-acme", "conv-acme")}
+        assert graph_ids["Globex"] == {("sent-globex", "conv-globex")}
+
+        # Both requisitions' requirements auto-progressed OPEN → SOURCING.
+        db_session.refresh(r_a)
+        db_session.refresh(r_b)
+        assert r_a.sourcing_status == "sourcing"
+        assert r_b.sourcing_status == "sourcing"
+
+        # rfq_sent activity logged per requirement per vendor.
+        logs = db_session.query(ActivityLog).filter(ActivityLog.activity_type == "rfq_sent").all()
+        assert sorted((entry.requisition_id, entry.requirement_id) for entry in logs) == sorted(
+            [(req_a.id, r_a.id), (req_a.id, r_a.id), (req_b.id, r_b.id), (req_b.id, r_b.id)]
+        )
+
+
 class TestSightingsVendorRowStatusTreatment:
     """Row-level visual treatment keyed off computed vendor status (spec
     2026-06-10-sightings-status-row-treatment-design.md)."""

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -707,28 +707,33 @@ class TestRfqModalUnavailableExclusion:
     """RFQ vendor modal excludes vendors with an ACTIVE unavailability record on the
     selected requirements' primary MPN keys (alongside the blacklist filter)."""
 
-    def _card(self, db_session, normalized="good vendor", display="Good Vendor"):
-        db_session.add(
-            VendorCard(
-                normalized_name=normalized,
-                display_name=display,
-                is_blacklisted=False,
-                engagement_score=50.0,
-            )
+    def _card(self, db_session, normalized="good vendor", display="Good Vendor", link_summary=None):
+        """Create a card; optionally link an existing summary via the vendor_card_id FK
+        (the coverage query joins on the FK, not the legacy name join)."""
+        card = VendorCard(
+            normalized_name=normalized,
+            display_name=display,
+            is_blacklisted=False,
+            engagement_score=50.0,
         )
+        db_session.add(card)
+        db_session.flush()
+        if link_summary is not None:
+            link_summary.vendor_card_id = card.id
         db_session.commit()
+        return card
 
     def test_excludes_marked_vendor_for_that_requirement(self, client, db_session):
-        _, r, _ = _seed_data(db_session)
-        self._card(db_session)
+        _, r, s = _seed_data(db_session)
+        self._card(db_session, link_summary=s)
         _unav_record(db_session, requirement_id=r.id)
         resp = client.get(f"/v2/partials/sightings/vendor-modal?requirement_ids={r.id}")
         assert resp.status_code == 200
         assert "Good Vendor" not in resp.text
 
     def test_still_suggested_for_unrelated_requirement(self, client, db_session):
-        _, r, _ = _seed_data(db_session)
-        self._card(db_session)
+        _, r, s = _seed_data(db_session)
+        card = self._card(db_session, link_summary=s)
         _unav_record(db_session, requirement_id=r.id)  # key testmpn001 only
         req2 = Requisition(name="Other RFQ", status="active", customer_name="Other Co")
         db_session.add(req2)
@@ -746,6 +751,7 @@ class TestRfqModalUnavailableExclusion:
                 vendor_name="Good Vendor",
                 listing_count=1,
                 score=60.0,
+                vendor_card_id=card.id,
             )
         )
         db_session.commit()
@@ -755,8 +761,8 @@ class TestRfqModalUnavailableExclusion:
 
     def test_expired_record_returns_vendor_to_modal(self, client, db_session):
         """Active-only exclusion: an expired record no longer suppresses suggestions."""
-        _, r, _ = _seed_data(db_session)
-        self._card(db_session)
+        _, r, s = _seed_data(db_session)
+        self._card(db_session, link_summary=s)
         _unav_record(db_session, age_days=45, requirement_id=r.id)  # LOT window is 30d
         resp = client.get(f"/v2/partials/sightings/vendor-modal?requirement_ids={r.id}")
         assert resp.status_code == 200
@@ -771,8 +777,9 @@ class TestRfqModalUnavailableExclusion:
         _, r, _ = _seed_data(db_session)
         # Legacy card: normalized_name kept the suffix, so notin_({'good vendor'})
         # does NOT filter it at the SQL layer.
-        self._card(db_session, normalized="good vendor inc", display="Good Vendor, Inc.")
-        # Summary whose lower(trim(vendor_name)) matches the legacy card's join key.
+        card = self._card(db_session, normalized="good vendor inc", display="Good Vendor, Inc.")
+        # Summary FK-linked to the legacy card (the coverage query joins on
+        # vendor_card_id, not the vendor_name spelling).
         db_session.add(
             VendorSightingSummary(
                 requirement_id=r.id,
@@ -781,6 +788,7 @@ class TestRfqModalUnavailableExclusion:
                 listing_count=1,
                 score=70.0,
                 tier="Good",
+                vendor_card_id=card.id,
             )
         )
         db_session.commit()
@@ -788,6 +796,127 @@ class TestRfqModalUnavailableExclusion:
         resp = client.get(f"/v2/partials/sightings/vendor-modal?requirement_ids={r.id}")
         assert resp.status_code == 200
         assert "Good Vendor, Inc." not in resp.text
+
+
+class TestVendorModalCoverageRanking:
+    """Spec Part 2 §1 (bulk RFQ composer): suggested vendors are coverage-ranked over
+    VendorSightingSummary joined via the vendor_card_id FK — covered-part count desc,
+    then engagement desc.
+
+    Each row renders `N/M parts` with the covered MPNs in title; VSS rows with NULL
+    vendor_card_id are excluded by design (known vendors only).
+    """
+
+    def _requirements(self, db_session, mpns):
+        req = Requisition(name="Coverage RFQ", status="active", customer_name="Cov Co")
+        db_session.add(req)
+        db_session.flush()
+        items = []
+        for mpn in mpns:
+            r = Requirement(
+                requisition_id=req.id,
+                primary_mpn=mpn,
+                target_qty=10,
+                sourcing_status="open",
+            )
+            db_session.add(r)
+            items.append(r)
+        db_session.flush()
+        return items
+
+    def _vendor(self, db_session, display, engagement=0.0):
+        card = VendorCard(
+            normalized_name=display.lower(),  # no legal suffixes in test names
+            display_name=display,
+            is_blacklisted=False,
+            engagement_score=engagement,
+        )
+        db_session.add(card)
+        db_session.flush()
+        return card
+
+    def _summary(self, db_session, requirement, card=None, vendor_name=None, score=50.0):
+        s = VendorSightingSummary(
+            requirement_id=requirement.id,
+            vendor_name=vendor_name or (card.display_name if card else "Mystery Vendor"),
+            listing_count=1,
+            score=score,
+            vendor_card_id=card.id if card else None,
+        )
+        db_session.add(s)
+        return s
+
+    def _modal(self, client, items):
+        ids = ",".join(str(r.id) for r in items)
+        return client.get(f"/v2/partials/sightings/vendor-modal?requirement_ids={ids}")
+
+    def _seed_ranking(self, db_session):
+        """4 parts; Broadline covers 3 with low engagement, Hotshot covers 1 with
+        high."""
+        items = self._requirements(db_session, ["CV-MPN-1", "CV-MPN-2", "CV-MPN-3", "CV-MPN-4"])
+        broad = self._vendor(db_session, "Broadline Parts", engagement=5.0)
+        hot = self._vendor(db_session, "Hotshot Parts", engagement=99.0)
+        for r in items[:3]:
+            self._summary(db_session, r, broad)
+        self._summary(db_session, items[0], hot)
+        db_session.commit()
+        return items
+
+    def test_coverage_outranks_engagement(self, client, db_session):
+        """A vendor covering 3/4 parts ranks above a 1/4 vendor with higher engagement —
+        coverage desc is the primary sort key."""
+        items = self._seed_ranking(db_session)
+        resp = self._modal(client, items)
+        assert resp.status_code == 200
+        assert "Broadline Parts" in resp.text
+        assert "Hotshot Parts" in resp.text
+        assert resp.text.index("Broadline Parts") < resp.text.index("Hotshot Parts")
+
+    def test_n_of_m_parts_rendered_with_mpn_title(self, client, db_session):
+        """Each suggested row shows `N/M parts` (M = selected part count) and lists the
+        covered MPNs in the chip's title attribute."""
+        items = self._seed_ranking(db_session)
+        resp = self._modal(client, items)
+        assert resp.status_code == 200
+        assert "3/4 parts" in resp.text
+        assert "1/4 parts" in resp.text
+        assert 'title="Covers: CV-MPN-1, CV-MPN-2, CV-MPN-3"' in resp.text
+        assert 'title="Covers: CV-MPN-1"' in resp.text
+
+    def test_excluded_vendor_absent(self, client, db_session):
+        """Unavailability exclusion is preserved under the coverage query."""
+        items = self._requirements(db_session, ["CV-MPN-9"])
+        card = self._vendor(db_session, "Dodgy Vendor")
+        self._summary(db_session, items[0], card)
+        db_session.commit()
+        _unav_record(db_session, vendor_norm="dodgy vendor", key="cvmpn9", requirement_id=items[0].id)
+        resp = self._modal(client, items)
+        assert resp.status_code == 200
+        assert "Dodgy Vendor" not in resp.text
+
+    def test_null_vendor_card_id_summary_excluded(self, client, db_session):
+        """A VSS row with NULL vendor_card_id never suggests a vendor — even when a card
+        matches by name (the legacy lower(trim) join is gone by design)."""
+        items = self._requirements(db_session, ["CV-MPN-7"])
+        self._vendor(db_session, "Phantom Vendor")  # card exists, name matches
+        self._summary(db_session, items[0], card=None, vendor_name="Phantom Vendor")
+        db_session.commit()
+        resp = self._modal(client, items)
+        assert resp.status_code == 200
+        assert "Phantom Vendor" not in resp.text
+
+    def test_coverage_counts_distinct_requirements(self, client, db_session):
+        """Two VSS spellings of one vendor on the same requirement count as 1 covered
+        part (count distinct requirement_id), not 2."""
+        items = self._requirements(db_session, ["CV-MPN-5"])
+        card = self._vendor(db_session, "Dupe Vendor")
+        self._summary(db_session, items[0], card, vendor_name="Dupe Vendor")
+        self._summary(db_session, items[0], card, vendor_name="Dupe Vendor LLC")
+        db_session.commit()
+        resp = self._modal(client, items)
+        assert resp.status_code == 200
+        assert "1/1 parts" in resp.text
+        assert "2/1 parts" not in resp.text
 
 
 class TestSendInquiryUnavailableExclusion:
@@ -1198,17 +1327,18 @@ class TestSightingsVendorModal:
         fix routes the data through a single-quoted x-data invoking the rfqVendorModal()
         factory, so the attribute — and the vendor name inside it — parse intact.
         """
-        _, r, _ = _seed_data(db_session)
-        # VendorCard whose normalized_name matches lower(trim(vendor_name)) so the
-        # suggested_vendors join returns a non-empty list (the failing scenario).
-        db_session.add(
-            VendorCard(
-                normalized_name="good vendor",
-                display_name="Good Vendor",
-                is_blacklisted=False,
-                engagement_score=50.0,
-            )
+        _, r, s = _seed_data(db_session)
+        # VendorCard FK-linked to the seeded summary (the coverage query joins on
+        # vendor_card_id) so suggested_vendors is non-empty (the failing scenario).
+        card = VendorCard(
+            normalized_name="good vendor",
+            display_name="Good Vendor",
+            is_blacklisted=False,
+            engagement_score=50.0,
         )
+        db_session.add(card)
+        db_session.flush()
+        s.vendor_card_id = card.id
         db_session.commit()
 
         resp = client.get(f"/v2/partials/sightings/vendor-modal?requirement_ids={r.id}")

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -1130,6 +1130,185 @@ class TestVendorAffinityOnDemand:
         assert 'hx-target="#rfq-affinity-section"' in resp.text
 
 
+class TestComposerVendor:
+    """Spec Part 2 §3/§4 (bulk RFQ composer): `POST /v2/partials/sightings/ composer-
+    vendor` resolves-or-creates a vendor for the any-vendor picker and the inline "Add
+    new vendor" mini-form.
+
+    A confident duplicate (EXACT normalized-name match per the extracted
+    check_vendor_duplicate service — fuzzy >= 80 are suggestions, not dupes) returns the
+    EXISTING vendor as a selected row with a "matched existing vendor" notice and NO new
+    DB row. Otherwise the minimal VendorCard (+ VendorContact when an email is given) is
+    created, committed, and _background_enrich_vendor fires post-commit (mocked at its
+    SOURCE module — the route imports it lazily). An unavailability-excluded vendor
+    renders the rose chip with a DISABLED checkbox.
+    """
+
+    URL = "/v2/partials/sightings/composer-vendor"
+
+    def _requirements(self, db_session, mpns):
+        req = Requisition(name="Composer RFQ", status="active", customer_name="Comp Co")
+        db_session.add(req)
+        db_session.flush()
+        items = []
+        for mpn in mpns:
+            r = Requirement(
+                requisition_id=req.id,
+                primary_mpn=mpn,
+                target_qty=10,
+                sourcing_status="open",
+            )
+            db_session.add(r)
+            items.append(r)
+        db_session.commit()
+        return items
+
+    def _card(self, db_session, display, normalized=None):
+        card = VendorCard(
+            normalized_name=normalized or display.lower(),
+            display_name=display,
+            is_blacklisted=False,
+        )
+        db_session.add(card)
+        db_session.commit()
+        return card
+
+    def test_exact_duplicate_returns_existing_selected_row_no_new_db_row(self, client, db_session):
+        """A name that normalizes to an existing card is a confident duplicate: the
+        EXISTING vendor comes back as a selected row with the 'matched existing
+        vendor' notice — no new VendorCard, no VendorContact."""
+        card = self._card(db_session, "Known Vendor")
+        resp = client.post(self.URL, data={"vendor_name": "Known Vendor, Inc.", "email": "x@known.com"})
+        assert resp.status_code == 200
+        assert "Known Vendor" in resp.text
+        assert "matched existing vendor" in resp.text
+        # Selected row: joins the modal's Alpine selection state checked
+        assert 'selectVendor("known vendor")' in resp.text
+        assert 'isSelected("known vendor")' in resp.text
+        assert 'toggleVendor("known vendor")' in resp.text
+        # No new DB rows — the duplicate path never writes
+        assert db_session.query(VendorCard).filter_by(normalized_name="known vendor").count() == 1
+        assert db_session.query(VendorContact).filter_by(vendor_card_id=card.id).count() == 0
+
+    def test_new_vendor_creates_card_contact_and_fires_enrichment(self, client, db_session):
+        """No duplicate → minimal VendorCard (normalized_name, display_name, domain
+        parsed from website) + VendorContact for the email, committed, then
+        _background_enrich_vendor fires post-commit (source-module mock)."""
+        from unittest.mock import AsyncMock, patch
+
+        with (
+            patch("app.services.credential_service.get_credential_cached", return_value="key"),
+            patch("app.utils.vendor_helpers._background_enrich_vendor", new_callable=AsyncMock) as mock_enrich,
+        ):
+            resp = client.post(
+                self.URL,
+                data={
+                    "vendor_name": "Fresh Vendor",
+                    "website": "https://www.freshvendor.com/about",
+                    "email": "sales@freshvendor.com",
+                },
+            )
+        assert resp.status_code == 200
+        card = db_session.query(VendorCard).filter_by(normalized_name="fresh vendor").one()
+        assert card.display_name == "Fresh Vendor"
+        assert card.domain == "freshvendor.com"
+        contact = db_session.query(VendorContact).filter_by(vendor_card_id=card.id).one()
+        assert contact.email == "sales@freshvendor.com"
+        assert contact.source == "rfq_manual"
+        assert mock_enrich.call_count == 1
+        assert mock_enrich.call_args[0] == (card.id, "freshvendor.com", "Fresh Vendor")
+        # New row comes back selected, wired to the modal's selection state
+        assert "matched existing vendor" not in resp.text
+        assert 'selectVendor("fresh vendor")' in resp.text
+        assert 'toggleVendor("fresh vendor")' in resp.text
+
+    def test_new_vendor_without_email_or_website_creates_bare_card(self, client, db_session):
+        """Optional fields stay optional: a bare name creates the card only — no
+        contact, no domain, no enrichment fired (nothing to enrich from)."""
+        from unittest.mock import AsyncMock, patch
+
+        with (
+            patch("app.services.credential_service.get_credential_cached", return_value="key"),
+            patch("app.utils.vendor_helpers._background_enrich_vendor", new_callable=AsyncMock) as mock_enrich,
+        ):
+            resp = client.post(self.URL, data={"vendor_name": "Bare Vendor"})
+        assert resp.status_code == 200
+        card = db_session.query(VendorCard).filter_by(normalized_name="bare vendor").one()
+        assert card.domain is None
+        assert db_session.query(VendorContact).filter_by(vendor_card_id=card.id).count() == 0
+        mock_enrich.assert_not_called()
+
+    def test_fuzzy_match_is_not_a_confident_duplicate(self, client, db_session):
+        """Pins the threshold semantics: the duplicate-check service classifies only
+        EXACT normalized-name matches as confident; a fuzzy >= 80 candidate (typo) is
+        a suggestion, so the composer still creates the new card."""
+        self._card(db_session, "Arrow Electronics Co")
+        resp = client.post(self.URL, data={"vendor_name": "Arrow Electronisc Co"})
+        assert resp.status_code == 200
+        assert "matched existing vendor" not in resp.text
+        assert db_session.query(VendorCard).filter_by(normalized_name="arrow electronisc co").count() == 1
+
+    def test_empty_name_returns_400_json_error(self, client, db_session):
+        """Empty/whitespace vendor_name → 400 in the repo JSON error format ({"error":
+
+        ...}, not {"detail": ...}); nothing written.
+        """
+        before = db_session.query(VendorCard).count()
+        resp = client.post(self.URL, data={"vendor_name": "   "})
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]
+        assert body["status_code"] == 400
+        assert db_session.query(VendorCard).count() == before
+
+    def test_name_normalizing_to_nothing_returns_400_json_error(self, client, db_session):
+        """A name that is all legal suffix ('Inc.') normalizes to '' — reject with the
+        same 400 JSON error instead of writing a junk empty-norm card."""
+        resp = client.post(self.URL, data={"vendor_name": "Inc."})
+        assert resp.status_code == 400
+        assert resp.json()["error"]
+        assert db_session.query(VendorCard).filter_by(normalized_name="").count() == 0
+
+    def test_excluded_vendor_renders_rose_chip_and_disabled_checkbox(self, client, db_session):
+        """An existing vendor with an ACTIVE unavailability record on the selected parts
+        renders the rose 'marked unavailable' chip and a DISABLED, unchecked checkbox —
+        it never joins the selection (send-time re-validation stays the backstop)."""
+        items = self._requirements(db_session, ["CP-MPN-1"])
+        self._card(db_session, "Dead Vendor")
+        _unav_record(db_session, vendor_norm="dead vendor", key="cpmpn1", requirement_id=items[0].id)
+        resp = client.post(
+            self.URL,
+            data={"vendor_name": "Dead Vendor", "requirement_ids": str(items[0].id)},
+        )
+        assert resp.status_code == 200
+        assert "marked unavailable" in resp.text
+        assert "bg-rose-100 text-rose-700" in resp.text
+        assert "disabled" in resp.text
+        # Never selected, never toggleable
+        assert "selectVendor(" not in resp.text
+        assert "toggleVendor(" not in resp.text
+
+    def test_modal_renders_picker_added_container_and_inline_form(self, client, db_session):
+        """vendor_modal.html: the vendor panel carries a stable id; the any-vendor
+        autocomplete, the #rfq-added-vendors append target, and the 'Add new vendor'
+        toggle all live INSIDE the rfqVendorModal x-data wrapper (appends target the
+        sub-container, never the wrapper — re-init would wipe selection state)."""
+        items = self._requirements(db_session, ["CP-MPN-2"])
+        ids = ",".join(str(r.id) for r in items)
+        resp = client.get(f"/v2/partials/sightings/vendor-modal?requirement_ids={ids}")
+        assert resp.status_code == 200
+        assert 'id="rfq-vendor-panel"' in resp.text
+        assert 'id="rfq-added-vendors"' in resp.text
+        assert "Find any vendor" in resp.text
+        assert "Add new vendor" in resp.text
+        # Inside the x-data wrapper: the wrapper opens before the sub-containers
+        wrapper_at = resp.text.index("rfqVendorModal(")
+        assert wrapper_at < resp.text.index('id="rfq-added-vendors"')
+        assert wrapper_at < resp.text.index("Find any vendor")
+        # Debounced autocomplete input per the established Alpine pattern
+        assert "@input.debounce.300ms" in resp.text
+
+
 class TestSendInquiryUnavailableExclusion:
     """Send/preview re-validate submitted vendor_names against active-only
     excluded_vendor_norms at request time — excluded vendors are dropped and the skip is

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -919,6 +919,217 @@ class TestVendorModalCoverageRanking:
         assert "2/1 parts" not in resp.text
 
 
+class TestVendorAffinityOnDemand:
+    """Spec Part 2 §2 (bulk RFQ composer): `GET /v2/partials/sightings/vendor-affinity`
+    runs find_vendor_affinity per selected MPN (on a worker thread with its own
+    session), merges/dedupes by vendor keeping the highest confidence, drops vendors
+    already coverage-suggested or unavailability-excluded, caps at 10, and renders
+    checkbox rows that join the modal's existing Alpine selection state.
+
+    find_vendor_affinity is mocked at its SOURCE module (the route imports it lazily) so
+    no L1/L2 queries or Anthropic L3 call ever run in tests.
+    """
+
+    URL = "/v2/partials/sightings/vendor-affinity"
+    PATCH_TARGET = "app.services.vendor_affinity_service.find_vendor_affinity"
+
+    def _requirements(self, db_session, mpns):
+        req = Requisition(name="Affinity RFQ", status="active", customer_name="Aff Co")
+        db_session.add(req)
+        db_session.flush()
+        items = []
+        for mpn in mpns:
+            r = Requirement(
+                requisition_id=req.id,
+                primary_mpn=mpn,
+                target_qty=10,
+                sourcing_status="open",
+            )
+            db_session.add(r)
+            items.append(r)
+        db_session.commit()
+        return items
+
+    def _get(self, client, items):
+        ids = ",".join(str(r.id) for r in items)
+        return client.get(f"{self.URL}?requirement_ids={ids}")
+
+    @staticmethod
+    def _match(name, confidence, reasoning="Vendor supplied 3 other MPN(s) from AffMfr"):
+        """Shape returned by find_vendor_affinity (score_affinity_matches output)."""
+        return {
+            "vendor_name": name,
+            "vendor_id": None,
+            "mpn_count": 3,
+            "manufacturer": "AffMfr",
+            "level": 1,
+            "confidence": confidence,
+            "reasoning": reasoning,
+        }
+
+    def test_merges_and_dedupes_keeping_highest_confidence(self, client, db_session):
+        """The same vendor returned for two MPNs renders ONCE, with the higher
+        confidence; rows sort confidence-desc."""
+        from unittest.mock import patch
+
+        items = self._requirements(db_session, ["AF-MPN-1", "AF-MPN-2"])
+        per_mpn = {
+            "AF-MPN-1": [self._match("Acme Components", 0.40)],
+            "AF-MPN-2": [self._match("Acme Components", 0.65), self._match("Beta Parts", 0.50)],
+        }
+        with patch(self.PATCH_TARGET, side_effect=lambda mpn, db: per_mpn[mpn]) as mock_fva:
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert mock_fva.call_count == 2
+        assert resp.text.count("Acme Components") == 1
+        assert "65%" in resp.text
+        assert "40%" not in resp.text
+        # Confidence-desc ordering: Acme (0.65) before Beta (0.50)
+        assert resp.text.index("Acme Components") < resp.text.index("Beta Parts")
+
+    def test_drops_already_suggested_vendors(self, client, db_session):
+        """Vendors the modal already suggests (same coverage query, recomputed server-
+        side) are dropped from the affinity rows."""
+        from unittest.mock import patch
+
+        items = self._requirements(db_session, ["AF-MPN-3"])
+        card = VendorCard(
+            normalized_name="covered vendor",
+            display_name="Covered Vendor",
+            is_blacklisted=False,
+            engagement_score=10.0,
+        )
+        db_session.add(card)
+        db_session.flush()
+        db_session.add(
+            VendorSightingSummary(
+                requirement_id=items[0].id,
+                vendor_name="Covered Vendor",
+                listing_count=1,
+                score=60.0,
+                vendor_card_id=card.id,
+            )
+        )
+        db_session.commit()
+        matches = [self._match("Covered Vendor", 0.70), self._match("Fresh Vendor", 0.45)]
+        with patch(self.PATCH_TARGET, return_value=matches):
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert "Fresh Vendor" in resp.text
+        assert "Covered Vendor" not in resp.text
+
+    def test_drops_excluded_vendors(self, client, db_session):
+        """Vendors with an ACTIVE unavailability record on a selected MPN key are
+        dropped."""
+        from unittest.mock import patch
+
+        items = self._requirements(db_session, ["AF-MPN-4"])
+        _unav_record(db_session, vendor_norm="dead vendor", key="afmpn4", requirement_id=items[0].id)
+        matches = [self._match("Dead Vendor", 0.70), self._match("Live Vendor", 0.45)]
+        with patch(self.PATCH_TARGET, return_value=matches):
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert "Live Vendor" in resp.text
+        assert "Dead Vendor" not in resp.text
+
+    def test_renders_chip_confidence_and_selection_wiring(self, client, db_session):
+        """Each row: bordered indigo 'affinity' chip, confidence %, reasoning in title,
+        and a checkbox wired to the modal's isSelected/toggleVendor Alpine state."""
+        from unittest.mock import patch
+
+        items = self._requirements(db_session, ["AF-MPN-5"])
+        matches = [self._match("Gamma Supply", 0.55, reasoning="Vendor shares commodity tags (3 matching tag(s))")]
+        with patch(self.PATCH_TARGET, return_value=matches):
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert "Gamma Supply" in resp.text
+        assert "border border-indigo-200 bg-indigo-50 text-indigo-700" in resp.text
+        assert ">affinity</span>" in resp.text
+        assert "55%" in resp.text
+        assert 'title="Vendor shares commodity tags (3 matching tag(s))"' in resp.text
+        # Same Alpine selection mechanism as the modal's existing rows (normalized key)
+        assert 'isSelected("gamma supply")' in resp.text
+        assert 'toggleVendor("gamma supply")' in resp.text
+
+    def test_caps_at_ten_rows(self, client, db_session):
+        from unittest.mock import patch
+
+        items = self._requirements(db_session, ["AF-MPN-6", "AF-MPN-7"])
+        per_mpn = {
+            "AF-MPN-6": [self._match(f"Vendor Six {i}", 0.30 + i / 100) for i in range(8)],
+            "AF-MPN-7": [self._match(f"Vendor Seven {i}", 0.30 + i / 100) for i in range(8)],
+        }
+        with patch(self.PATCH_TARGET, side_effect=lambda mpn, db: per_mpn[mpn]):
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert resp.text.count(">affinity</span>") == 10
+
+    def test_response_has_no_suggest_button(self, client, db_session):
+        """No-duplicate pin: the swap replaces the button with the rows, so the
+        response itself must never re-render 'Suggest more vendors'."""
+        from unittest.mock import patch
+
+        items = self._requirements(db_session, ["AF-MPN-8"])
+        with patch(self.PATCH_TARGET, return_value=[self._match("Delta Parts", 0.40)]):
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert "Suggest more vendors" not in resp.text
+
+    def test_empty_requirement_ids_returns_200_empty_state(self, client, db_session):
+        from unittest.mock import patch
+
+        with patch(self.PATCH_TARGET) as mock_fva:
+            resp = client.get(f"{self.URL}?requirement_ids=")
+        assert resp.status_code == 200
+        mock_fva.assert_not_called()
+        assert "No additional vendors" in resp.text
+
+    def test_no_matches_renders_empty_state(self, client, db_session):
+        from unittest.mock import patch
+
+        items = self._requirements(db_session, ["AF-MPN-9"])
+        with patch(self.PATCH_TARGET, return_value=[]):
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert "No additional vendors" in resp.text
+
+    def test_thread_calls_get_their_own_session(self, client, db_session):
+        """SQLAlchemy sessions are not thread-safe: each to_thread call must receive a
+        fresh short-lived SessionLocal, never the request session. Duplicate MPNs
+        across requirements collapse to one call (no double L3 spend)."""
+        from unittest.mock import patch
+
+        from sqlalchemy.orm import Session as SASession
+
+        items = self._requirements(db_session, ["AF-MPN-10", "AF-MPN-10", "AF-MPN-11"])
+        seen_sessions = []
+
+        def _capture(mpn, db):
+            seen_sessions.append(db)
+            return []
+
+        with patch(self.PATCH_TARGET, side_effect=_capture) as mock_fva:
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert mock_fva.call_count == 2  # AF-MPN-10 deduped
+        for sess in seen_sessions:
+            assert isinstance(sess, SASession)
+            assert sess is not db_session
+
+    def test_modal_renders_affinity_section_with_button(self, client, db_session):
+        """vendor_modal.html: 'Suggest more vendors' button lives inside the stable-id
+        #rfq-affinity-section sub-container and targets IT (never the x-data wrapper —
+        re-init would wipe selection state)."""
+        items = self._requirements(db_session, ["AF-MPN-12"])
+        ids = ",".join(str(r.id) for r in items)
+        resp = client.get(f"/v2/partials/sightings/vendor-modal?requirement_ids={ids}")
+        assert resp.status_code == 200
+        assert 'id="rfq-affinity-section"' in resp.text
+        assert "Suggest more vendors" in resp.text
+        assert f'hx-get="/v2/partials/sightings/vendor-affinity?requirement_ids={ids}"' in resp.text
+        assert 'hx-target="#rfq-affinity-section"' in resp.text
+
+
 class TestSendInquiryUnavailableExclusion:
     """Send/preview re-validate submitted vendor_names against active-only
     excluded_vendor_norms at request time — excluded vendors are dropped and the skip is

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -1443,6 +1443,26 @@ class TestComposerVendor:
         # dedupe can see them (no x-init to read it from).
         assert 'data-vendor-norm="dead vendor"' in resp.text
 
+    def test_exact_duplicate_whose_card_vanished_falls_through_to_create(self, client, db_session):
+        """F6 (TOCTOU): check_vendor_duplicate runs a SEPARATE earlier query, so the
+        matched card can be deleted before the endpoint's db.get.
+
+        A None card must NOT AttributeError into a generic 500 — it falls through to the
+        create branch (using the name the user typed) instead.
+        """
+        from unittest.mock import patch
+
+        # The duplicate service reports an EXACT match on an id that no longer exists.
+        stale = {"id": 999999, "match": "exact", "score": 100}
+        with patch("app.routers.sightings.check_vendor_duplicate", return_value=[stale]):
+            resp = client.post(self.URL, data={"vendor_name": "Vanished Vendor"})
+
+        assert resp.status_code == 200
+        # Created fresh (no "matched existing" notice), selectable row
+        assert "matched existing vendor" not in resp.text
+        assert 'selectVendor("vanished vendor")' in resp.text
+        assert db_session.query(VendorCard).filter_by(normalized_name="vanished vendor").count() == 1
+
     def test_modal_renders_picker_added_container_and_inline_form(self, client, db_session):
         """vendor_modal.html: the vendor panel carries a stable id; the any-vendor
         autocomplete, the #rfq-added-vendors append target, and the 'Add new vendor'
@@ -1591,6 +1611,64 @@ class TestSendInquiryUnavailableExclusion:
         assert "1 vendor" in resp.text  # only Acme is previewed
         assert "Globex" in resp.text  # the skip is visibly reported
         assert "unavailable" in resp.text.lower()
+
+
+class TestSendInquiryContactSelection:
+    """F4: a vendor with multiple VendorContact rows (no is_primary flag) must resolve
+    the one carrying a real email — an unordered last-wins map could pick a NULL-email
+    row and silently skip the vendor as 'had no email'."""
+
+    def _post(self, client, r, url="/v2/partials/sightings/send-inquiry"):
+        return client.post(
+            url,
+            data={
+                "requirement_ids": str(r.id),
+                "vendor_names": ["Acme"],
+                "email_body": "Please quote.",
+            },
+        )
+
+    def test_send_prefers_contact_with_email_over_null_email_row(self, client, db_session, monkeypatch):
+        _, r, _ = _seed_data(db_session)
+        vc = VendorCard(normalized_name="acme", display_name="Acme")
+        db_session.add(vc)
+        db_session.flush()
+        # A higher-confidence NULL-email contact (would win a naive last-wins map) plus a
+        # lower-confidence row that actually has the email.
+        db_session.add(VendorContact(vendor_card_id=vc.id, email=None, source="apollo", confidence=95))
+        db_session.add(VendorContact(vendor_card_id=vc.id, email="real@acme.com", source="rfq_manual", confidence=80))
+        db_session.commit()
+
+        captured = {}
+
+        async def fake_send(**kwargs):
+            captured["groups"] = kwargs["vendor_groups"]
+            return [{"vendor_name": g["vendor_name"], "status": "sent"} for g in kwargs["vendor_groups"]]
+
+        monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
+        resp = self._post(client, r)
+        assert resp.status_code == 200
+        assert captured["groups"][0]["vendor_email"] == "real@acme.com"
+
+    def test_preview_prefers_contact_with_email_over_null_email_row(self, client, db_session):
+        _, r, _ = _seed_data(db_session)
+        vc = VendorCard(normalized_name="acme", display_name="Acme")
+        db_session.add(vc)
+        db_session.flush()
+        db_session.add(VendorContact(vendor_card_id=vc.id, email=None, source="apollo", confidence=95))
+        db_session.add(VendorContact(vendor_card_id=vc.id, email="real@acme.com", source="rfq_manual", confidence=80))
+        db_session.commit()
+
+        resp = client.post(
+            "/v2/partials/sightings/preview-inquiry",
+            data={
+                "requirement_ids": str(r.id),
+                "vendor_names": ["Acme"],
+                "email_body": "Please quote.",
+            },
+        )
+        assert resp.status_code == 200
+        assert "real@acme.com" in resp.text
 
 
 def _seed_two_requisitions(db_session):

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -894,16 +894,54 @@ class TestVendorModalCoverageRanking:
         assert resp.status_code == 200
         assert "Dodgy Vendor" not in resp.text
 
-    def test_null_vendor_card_id_summary_excluded(self, client, db_session):
-        """A VSS row with NULL vendor_card_id never suggests a vendor — even when a card
-        matches by name (the legacy lower(trim) join is gone by design)."""
+    def test_null_vendor_card_id_falls_back_to_name_join(self, client, db_session):
+        """F10: a VSS row with NULL vendor_card_id (e.g. a summary rebuilt before
+        the FK backfill ran) still suggests its vendor via the
+        lower(trim(vendor_name)) == normalized_name fallback branch — the FK
+        join stays primary, the name join only catches NULL-FK rows."""
         items = self._requirements(db_session, ["CV-MPN-7"])
         self._vendor(db_session, "Phantom Vendor")  # card exists, name matches
         self._summary(db_session, items[0], card=None, vendor_name="Phantom Vendor")
         db_session.commit()
         resp = self._modal(client, items)
         assert resp.status_code == 200
-        assert "Phantom Vendor" not in resp.text
+        assert "Phantom Vendor" in resp.text
+        assert "1/1 parts" in resp.text
+        assert 'title="Covers: CV-MPN-7"' in resp.text
+
+    def test_null_fk_summary_without_matching_card_still_absent(self, client, db_session):
+        """The fallback is card-gated: a NULL-FK summary whose name matches no
+        VendorCard suggests nothing (the modal suggests known vendors only)."""
+        items = self._requirements(db_session, ["CV-MPN-8"])
+        self._summary(db_session, items[0], card=None, vendor_name="Unknown Rawname")
+        db_session.commit()
+        resp = self._modal(client, items)
+        assert resp.status_code == 200
+        assert "Unknown Rawname" not in resp.text
+
+    def test_fk_and_null_fk_rows_do_not_double_count(self, client, db_session):
+        """One FK row + one NULL-FK name-matching row on the SAME requirement still
+        count 1 covered part (distinct requirement_id; the OR-join's NULL-FK guard
+        prevents cross-matching FK rows by name)."""
+        items = self._requirements(db_session, ["CV-MPN-9X"])
+        card = self._vendor(db_session, "Split Vendor")
+        self._summary(db_session, items[0], card)
+        # Different raw spelling (VSS has a UNIQUE on requirement_id+vendor_name)
+        # that still hits the lower(trim) fallback branch.
+        self._summary(db_session, items[0], card=None, vendor_name="SPLIT VENDOR ")
+        db_session.commit()
+        resp = self._modal(client, items)
+        assert resp.status_code == 200
+        assert "1/1 parts" in resp.text
+        assert "2/1 parts" not in resp.text
+
+    def test_no_suggested_vendors_shows_empty_state_line(self, client, db_session):
+        """F10: an empty suggested list explains itself instead of rendering a
+        bare empty box."""
+        items = self._requirements(db_session, ["CV-MPN-EMPTY"])
+        resp = self._modal(client, items)
+        assert resp.status_code == 200
+        assert "No vendors with sightings for these parts" in resp.text
 
     def test_coverage_counts_distinct_requirements(self, client, db_session):
         """Two VSS spellings of one vendor on the same requirement count as 1 covered
@@ -1116,6 +1154,34 @@ class TestVendorAffinityOnDemand:
             assert isinstance(sess, SASession)
             assert sess is not db_session
 
+    def test_partial_affinity_failure_renders_results_with_notice(self, client, db_session):
+        """F6: one MPN's affinity lookup failing must neither 500 the endpoint nor
+        silently hide the surviving results — partial rows render, the failed MPN
+        is logged, and a quiet 'suggestions incomplete' notice row appears."""
+        from unittest.mock import patch
+
+        items = self._requirements(db_session, ["AF-MPN-20", "AF-MPN-21"])
+
+        def _maybe_fail(mpn, db):
+            if mpn == "AF-MPN-20":
+                raise RuntimeError("affinity backend down")
+            return [self._match("Solo Vendor", 0.50)]
+
+        with patch(self.PATCH_TARGET, side_effect=_maybe_fail):
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert "Solo Vendor" in resp.text
+        assert "Suggestions incomplete" in resp.text
+
+    def test_full_affinity_success_has_no_incomplete_notice(self, client, db_session):
+        from unittest.mock import patch
+
+        items = self._requirements(db_session, ["AF-MPN-22"])
+        with patch(self.PATCH_TARGET, return_value=[self._match("Ok Vendor", 0.50)]):
+            resp = self._get(client, items)
+        assert resp.status_code == 200
+        assert "Suggestions incomplete" not in resp.text
+
     def test_modal_renders_affinity_section_with_button(self, client, db_session):
         """vendor_modal.html: 'Suggest more vendors' button lives inside the stable-id
         #rfq-affinity-section sub-container and targets IT (never the x-data wrapper —
@@ -1173,22 +1239,64 @@ class TestComposerVendor:
         db_session.commit()
         return card
 
-    def test_exact_duplicate_returns_existing_selected_row_no_new_db_row(self, client, db_session):
-        """A name that normalizes to an existing card is a confident duplicate: the
-        EXISTING vendor comes back as a selected row with the 'matched existing
-        vendor' notice — no new VendorCard, no VendorContact."""
+    def test_exact_duplicate_returns_existing_row_and_attaches_typed_email(self, client, db_session):
+        """F4: a name that normalizes to an existing card is a confident duplicate —
+        the EXISTING vendor comes back as a selected row (no new VendorCard), but
+        a typed email must NOT be silently discarded: it is attached to the
+        existing card as a VendorContact and the notice says so."""
         card = self._card(db_session, "Known Vendor")
         resp = client.post(self.URL, data={"vendor_name": "Known Vendor, Inc.", "email": "x@known.com"})
         assert resp.status_code == 200
         assert "Known Vendor" in resp.text
-        assert "matched existing vendor" in resp.text
+        assert "matched existing vendor — contact email added" in resp.text
         # Selected row: joins the modal's Alpine selection state checked
         assert 'selectVendor("known vendor")' in resp.text
         assert 'isSelected("known vendor")' in resp.text
         assert 'toggleVendor("known vendor")' in resp.text
-        # No new DB rows — the duplicate path never writes
+        # No new CARD — but the typed email survives as a contact
         assert db_session.query(VendorCard).filter_by(normalized_name="known vendor").count() == 1
+        contact = db_session.query(VendorContact).filter_by(vendor_card_id=card.id).one()
+        assert contact.email == "x@known.com"
+        assert contact.source == "rfq_manual"
+
+    def test_exact_duplicate_without_email_writes_nothing(self, client, db_session):
+        """A bare duplicate pick stays read-only: plain notice, no contact rows."""
+        card = self._card(db_session, "Known Vendor")
+        resp = client.post(self.URL, data={"vendor_name": "Known Vendor"})
+        assert resp.status_code == 200
+        assert "matched existing vendor" in resp.text
+        assert "contact email added" not in resp.text
         assert db_session.query(VendorContact).filter_by(vendor_card_id=card.id).count() == 0
+
+    def test_exact_duplicate_existing_email_not_duplicated(self, client, db_session):
+        """The attach dedupes case-insensitively against the card's existing contacts —
+        and the notice stays plain (nothing was added)."""
+        card = self._card(db_session, "Known Vendor")
+        db_session.add(VendorContact(vendor_card_id=card.id, email="X@Known.com", source="email"))
+        db_session.commit()
+        resp = client.post(self.URL, data={"vendor_name": "Known Vendor", "email": "x@known.com"})
+        assert resp.status_code == 200
+        assert "matched existing vendor" in resp.text
+        assert "contact email added" not in resp.text
+        assert db_session.query(VendorContact).filter_by(vendor_card_id=card.id).count() == 1
+
+    def test_exact_duplicate_backfills_missing_domain_from_website(self, client, db_session):
+        """F4: a typed website fills the existing card's missing domain."""
+        card = self._card(db_session, "Known Vendor")
+        assert card.domain is None
+        resp = client.post(self.URL, data={"vendor_name": "Known Vendor", "website": "https://www.known.com/contact"})
+        assert resp.status_code == 200
+        db_session.refresh(card)
+        assert card.domain == "known.com"
+
+    def test_exact_duplicate_never_overwrites_existing_domain(self, client, db_session):
+        card = self._card(db_session, "Known Vendor")
+        card.domain = "known.com"
+        db_session.commit()
+        resp = client.post(self.URL, data={"vendor_name": "Known Vendor", "website": "https://other.example.org"})
+        assert resp.status_code == 200
+        db_session.refresh(card)
+        assert card.domain == "known.com"
 
     def test_new_vendor_creates_card_contact_and_fires_enrichment(self, client, db_session):
         """No duplicate → minimal VendorCard (normalized_name, display_name, domain
@@ -1269,6 +1377,50 @@ class TestComposerVendor:
         assert resp.json()["error"]
         assert db_session.query(VendorCard).filter_by(normalized_name="").count() == 0
 
+    def test_website_without_scheme_parses_domain(self, client, db_session):
+        """F12: urlsplit-based parsing handles scheme-less input."""
+        resp = client.post(self.URL, data={"vendor_name": "Scheme Less", "website": "www.schemeless.io/shop"})
+        assert resp.status_code == 200
+        card = db_session.query(VendorCard).filter_by(normalized_name="scheme less").one()
+        assert card.domain == "schemeless.io"
+
+    def test_website_strips_only_leading_www(self, client, db_session):
+        """F12: only a LEADING 'www.' is stripped — the old blanket
+        str.replace("www.", "") mangled hosts containing the substring."""
+        resp = client.post(self.URL, data={"vendor_name": "Www Embedded", "website": "https://shop.mywww.example.com"})
+        assert resp.status_code == 200
+        card = db_session.query(VendorCard).filter_by(normalized_name="www embedded").one()
+        assert card.domain == "shop.mywww.example.com"
+
+    def test_unusable_website_returns_400_json_error(self, client, db_session):
+        """F12: unparseable / domain-less websites are rejected with the visible
+        400 JSON error (surfaced by the modal via F8), never silently saved as a
+        junk domain. Nothing is written."""
+        before = db_session.query(VendorCard).count()
+        for i, bad in enumerate(("https://", "no-dot", "ht!tp://%%%")):
+            resp = client.post(self.URL, data={"vendor_name": f"Bad Site {i}", "website": bad})
+            assert resp.status_code == 400, f"website {bad!r} should be rejected"
+            assert "website" in resp.json()["error"].lower()
+        assert db_session.query(VendorCard).count() == before
+
+    def test_post_commit_enrichment_failure_still_returns_row(self, client, db_session):
+        """F7: the card is committed before enrichment fires — a post-commit
+        failure must be logged, not turned into a 500 (the modal would report a
+        bogus failure for a vendor that EXISTS, and a retry would dupe-check)."""
+        from unittest.mock import AsyncMock, patch
+
+        with (
+            patch("app.services.credential_service.get_credential_cached", return_value="key"),
+            patch("app.utils.vendor_helpers._background_enrich_vendor", new_callable=AsyncMock),
+            patch("app.utils.async_helpers.safe_background_task", side_effect=RuntimeError("event loop down")),
+        ):
+            resp = client.post(
+                self.URL, data={"vendor_name": "Enrich Fail Co", "website": "https://enrichfail.example"}
+            )
+        assert resp.status_code == 200
+        assert 'selectVendor("enrich fail co")' in resp.text
+        assert db_session.query(VendorCard).filter_by(normalized_name="enrich fail co").count() == 1
+
     def test_excluded_vendor_renders_rose_chip_and_disabled_checkbox(self, client, db_session):
         """An existing vendor with an ACTIVE unavailability record on the selected parts
         renders the rose 'marked unavailable' chip and a DISABLED, unchecked checkbox —
@@ -1287,6 +1439,9 @@ class TestComposerVendor:
         # Never selected, never toggleable
         assert "selectVendor(" not in resp.text
         assert "toggleVendor(" not in resp.text
+        # F11: excluded rows still carry the normalized name so the client-side
+        # dedupe can see them (no x-init to read it from).
+        assert 'data-vendor-norm="dead vendor"' in resp.text
 
     def test_modal_renders_picker_added_container_and_inline_form(self, client, db_session):
         """vendor_modal.html: the vendor panel carries a stable id; the any-vendor
@@ -1307,6 +1462,52 @@ class TestComposerVendor:
         assert wrapper_at < resp.text.index("Find any vendor")
         # Debounced autocomplete input per the established Alpine pattern
         assert "@input.debounce.300ms" in resp.text
+
+
+class TestSendInquiryFailureContainment:
+    """F3/F12: a mid-send crash must not commit partial tracking rows, and a selection
+    whose every requirement id is stale 400s up front instead of reaching
+    send_batch_rfq's NOT-NULL crash path with no requisition at all."""
+
+    def test_send_failure_rolls_back_partial_state(self, client, db_session, monkeypatch):
+        from app.models.offers import Contact
+
+        _, r, _ = _seed_data(db_session)
+        req_id = r.requisition_id
+
+        async def fake_send(**kwargs):
+            # Simulate send_batch_rfq dying MID-batch: one Contact row already
+            # flushed on the shared session when the exception escapes.
+            inner_db = kwargs["db"]
+            inner_db.add(
+                Contact(
+                    requisition_id=req_id,
+                    user_id=kwargs["user_id"],
+                    contact_type="email",
+                    vendor_name="Half Written",
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+            inner_db.flush()
+            raise RuntimeError("Graph died mid-batch")
+
+        monkeypatch.setattr("app.email_service.send_batch_rfq", fake_send)
+        resp = client.post(
+            "/v2/partials/sightings/send-inquiry",
+            data={"requirement_ids": str(r.id), "vendor_names": ["Acme"], "email_body": "Quote."},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["X-RFQ-Sent"] == "0"
+        # The partial row was rolled back, not committed by the route's commit.
+        assert db_session.query(Contact).count() == 0
+
+    def test_all_stale_requirement_ids_return_400(self, client, db_session):
+        resp = client.post(
+            "/v2/partials/sightings/send-inquiry",
+            data={"requirement_ids": "99999", "vendor_names": ["Acme"], "email_body": "Quote."},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["error"]
 
 
 class TestSendInquiryUnavailableExclusion:
@@ -1509,10 +1710,25 @@ class TestCrossRequisitionTracking:
 
         mock_gc = AsyncMock()
         mock_gc.post_json.return_value = {}
-        mock_gc.get_json.side_effect = [
-            {"value": [{"id": "sent-acme", "conversationId": "conv-acme", "subject": tagged}]},
-            {"value": [{"id": "sent-globex", "conversationId": "conv-globex", "subject": tagged}]},
-        ]
+        # ONE shared sent-items list per lookup (identical subjects, both vendors'
+        # messages present) — the realistic Graph shape; toRecipients is what
+        # discriminates each vendor's own message (F1).
+        mock_gc.get_json.return_value = {
+            "value": [
+                {
+                    "id": "sent-globex",
+                    "conversationId": "conv-globex",
+                    "subject": tagged,
+                    "toRecipients": [{"emailAddress": {"address": "sales@globex.com"}}],
+                },
+                {
+                    "id": "sent-acme",
+                    "conversationId": "conv-acme",
+                    "subject": tagged,
+                    "toRecipients": [{"emailAddress": {"address": "sales@acme.com"}}],
+                },
+            ]
+        }
 
         with (
             patch("app.utils.graph_client.GraphClient", return_value=mock_gc),


### PR DESCRIPTION
## Summary
Track B of the June-5 sightings work (deferred as a separate spec). Fixes the cross-requisition RFQ tracking bug at the root and upgrades the vendor modal into a real bulk composer. **No schema change, no migration.**

### Part 1 — Cross-requisition tracking fix (load-bearing)
`send-inquiry`/`preview-inquiry` collapsed multiple requisitions to one via `next(iter(requisition_ids))`, so a bulk RFQ spanning requisitions recorded Contact/subject-ref/reply-matching state on only one — silently. Now: one email per vendor covering all selected parts, **one Contact per (requisition, vendor)** sharing graph ids, sorted multi-token `[ref:]` subjects (preview/send byte-identical), reply Tier-1 fan-out across requisitions, per-requisition status progression and activity logging. Legacy single-requisition caller (`htmx_views.rfq_send`) stays byte-identical via an additive `requisition_parts_map` shim.

### Part 2 — Vendor panel upgrade
- **Coverage-ranked suggestions** via `VendorSightingSummary.vendor_card_id` join (coalesce fallback for post-rebuild cards), `N/M parts` per vendor.
- **Affinity on demand** ("Suggest more vendors") via `find_vendor_affinity`, run under `asyncio.to_thread` + `Semaphore(3)` with per-thread sessions, partial-failure tolerant.
- **Any-vendor autocomplete** reusing `/api/autocomplete/names`.
- **Inline vendor creation** via extracted `app/services/vendor_duplicates.py` (exact-match-only confident duplicate; preserves typed email/website; post-commit best-effort enrichment).

## Review trail
Architecture review (10 findings → spec amended; the reply-matcher conv-id collision was the headline) → per-task spec-compliance reviews → silent-failure hunt (12 findings, ALL fixed incl. a CRITICAL batch-wide reply-misattribution that the fan-out amplified) → conservative simplify pass (no changes, reasoned) → 2 UI-polish fixes.

## Testing
- Full suite: **16,289 passed**, 35 skipped, 1 xfailed; Vitest **115 passed**; ESLint 0 errors; pre-commit green
- ~80 new tests: per-requisition fan-out + shared graph ids, vendor-scoped reply attribution (the real same-subject collision, replacing a test that mocked impossible Graph behavior), coverage ranking, affinity threading, inline create/duplicate, batch savepoint isolation, stale-token guards

## Deploy note
The coverage GROUP BY query uses plain aggregates (SQLite+PG safe) but was not verifiable against live PG in-session — worth a one-line smoke on staging PG at deploy per the SQLite-masks-PG lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)