### PR TITLE
feat(search): inject FRU-crosswalk aliases into supplier search (item 2.7)

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -530,6 +530,13 @@ class FruLinkKind(StrEnum):
 # it as the amber "CDC pending" pill — keep ingest and display on this constant.
 CDC_PENDING = "cdc_pending"
 
+# Provenance value in a Requirement.substitutes entry's optional "source" key:
+# the substitute was system-derived from the FRU crosswalk by search_service's
+# alias expansion (vs entered by a user). Written by
+# search_service._persist_fru_aliases, preserved by parse_substitute_mpns, read
+# by template_env's |fru_alias_mpns filter for the "via FRU crosswalk" tooltip.
+FRU_ALIAS_SOURCE = "fru_crosswalk"
+
 
 class UnavailabilityReason(StrEnum):
     """Why a (vendor, part) pair is durably unavailable.

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -27,7 +27,7 @@ from .connectors.mouser import MouserConnector
 from .connectors.oemsecrets import OEMSecretsConnector
 from .connectors.sourcengine import SourcengineConnector
 from .connectors.sources import BrokerBinConnector, NexarConnector
-from .constants import ActivityType, ApiSourceStatus, SourceRunStatus
+from .constants import FRU_ALIAS_SOURCE, ActivityType, ApiSourceStatus, SourceRunStatus
 from .database import SessionLocal
 from .models import (
     ApiSource,
@@ -39,6 +39,7 @@ from .models import (
 from .scoring import classify_lead, explain_lead, is_weak_lead, score_sighting, score_sighting_v2, score_unified
 from .services.activity_service import log_activity
 from .services.credential_service import get_credential, get_credentials_batch
+from .services.fru_matrix_service import get_search_aliases
 from .services.ics_worker.queue_manager import enqueue_for_ics_search
 from .services.nc_worker.queue_manager import enqueue_for_nc_search
 from .services.price_snapshot_service import record_price_snapshot
@@ -47,6 +48,7 @@ from .services.vendor_affinity_service import find_vendor_affinity
 from .services.vendor_unavailability import apply_to_fresh_sightings
 from .utils.async_helpers import safe_background_task
 from .utils.normalization import (
+    MAX_SUBSTITUTES,
     detect_currency,
     normalize_condition,
     normalize_date_code,
@@ -184,6 +186,90 @@ def get_all_pns(req: Requirement) -> list[str]:
     return pns
 
 
+# Cap on FRU-crosswalk aliases injected per requirement as system-derived
+# substitutes (optimization plan 2026-06-12 item 2.7). Priority order is
+# fru_matrix_service.SEARCH_ALIAS_KINDS: mfg_model, drive_pn, option, ibm_11s.
+MAX_FRU_ALIASES: Final[int] = 8
+
+
+def _expand_fru_aliases(db: Session, req: Requirement) -> list[dict]:
+    """New system-derived substitutes from the FRU crosswalk for req's primary MPN.
+
+    Looks up fru_links in both directions (the primary may be the FRU side OR
+    the related side — get_search_aliases handles both with one indexed query)
+    and returns canonical substitute dicts
+    ``{"mpn": ..., "manufacturer": ..., "source": FRU_ALIAS_SOURCE}`` deduped
+    against the primary and the existing substitutes, capped at
+    MAX_FRU_ALIASES without ever pushing the stored list past MAX_SUBSTITUTES.
+
+    Read-only (safe on the caller's session); durable persistence happens in
+    _persist_fru_aliases through its own write session.
+    """
+    primary = (req.primary_mpn or "").strip()
+    if not primary:
+        return []
+    try:
+        candidates = get_search_aliases(db, primary)
+    except Exception as e:
+        logger.warning("FRU alias lookup failed for {}: {}", primary, e)
+        return []
+    if not candidates:
+        return []
+    room = min(MAX_FRU_ALIASES, MAX_SUBSTITUTES - len(req.substitutes or []))
+    if room <= 0:
+        return []
+    taken = {k for k in (normalize_mpn_key(pn) for pn in get_all_pns(req)) if k}
+    aliases: list[dict] = []
+    for cand in candidates:
+        if len(aliases) >= room:
+            break
+        if not cand.norm or cand.norm in taken:
+            continue
+        taken.add(cand.norm)
+        display = normalize_mpn(cand.mpn) or cand.mpn
+        aliases.append({"mpn": display, "manufacturer": cand.manufacturer, "source": FRU_ALIAS_SOURCE})
+    return aliases
+
+
+def _persist_fru_aliases(db: Session, req_id: int, aliases: list[dict]) -> None:
+    """Durably append crosswalk aliases to requirements.substitutes.
+
+    Uses its own short-lived write session (same pattern as search_requirement's main
+    write path) so it works on BOTH search paths — including the all-cached short-
+    circuit, which never opens the main write session — and never dirties the caller's
+    session. Re-deduplicates against the freshly loaded row so concurrent searches of
+    the same requirement stay idempotent. Best-effort: a failure here must not break the
+    search itself.
+    """
+    from sqlalchemy.orm import sessionmaker
+
+    _WriteSession = sessionmaker(bind=db.get_bind(), autocommit=False, autoflush=False, expire_on_commit=False)
+    session = _WriteSession()
+    try:
+        row = session.get(Requirement, req_id)
+        if row is None:
+            return
+        current = list(row.substitutes or [])
+        current_keys = {normalize_mpn_key(row.primary_mpn or "")}
+        for sub in current:
+            raw = (sub.get("mpn") if isinstance(sub, dict) else str(sub or "")) or ""
+            key = normalize_mpn_key(raw)
+            if key:
+                current_keys.add(key)
+        fresh = [a for a in aliases if normalize_mpn_key(a["mpn"]) not in current_keys]
+        if not fresh:
+            return
+        # New list object → SQLAlchemy detects the JSON column change.
+        row.substitutes = current + fresh
+        session.commit()
+        logger.info("Req {}: persisted {} FRU crosswalk substitute(s)", req_id, len(fresh))
+    except Exception:
+        session.rollback()
+        logger.warning("FRU alias persistence failed for requirement {}", req_id, exc_info=True)
+    finally:
+        session.close()
+
+
 # How long a MaterialCard.last_searched_at "shields" its MPN from being
 # re-queried at supplier APIs. Per-MPN, not per-requirement, so two
 # requirements that share an MPN don't each burn quota.
@@ -285,6 +371,20 @@ async def search_requirement(req: Requirement, db: Session) -> dict:
     pns = get_all_pns(req)
     if not pns:
         return {"sightings": [], "source_stats": [], "mpn_results": {}}
+
+    # FRU crosswalk alias expansion (item 2.7): brokers list canonical
+    # mfg_model/drive_pn numbers, not OEM spare numbers, so a FRU-shaped
+    # primary fans out to its crosswalk equivalents (and vice versa — the
+    # lookup is bidirectional). Aliases are persisted as system-derived
+    # substitutes (source="fru_crosswalk") via a dedicated write session so
+    # existing substitutes rendering and future searches carry them; this
+    # call's fan-out includes them immediately. Appended after the explicit
+    # pns so pns[0] stays the primary MPN.
+    fru_aliases = _expand_fru_aliases(db, req)
+    if fru_aliases:
+        _persist_fru_aliases(db, req.id, fru_aliases)
+        pns = pns + [a["mpn"] for a in fru_aliases]
+        logger.info("Req {} ({}): injected {} FRU crosswalk alias(es) into search", req.id, pns[0], len(fru_aliases))
 
     now = datetime.now(timezone.utc)
 

--- a/app/services/fru_matrix_service.py
+++ b/app/services/fru_matrix_service.py
@@ -8,11 +8,14 @@ capped at REVERSE_VIEW_LIMIT usages (shared hardware PNs like screws can sit und
 thousands of FRUs); ReverseView.total carries the uncapped count for display.
 get_reverse_context is the lightweight companion for the search page's compact
 card: a COUNT(DISTINCT fru_norm) aggregate + column-tuple fetch, no FruLink
-entity hydration.
+entity hydration. get_search_aliases is the supplier-search expansion hook:
+both-direction crosswalk equivalents of one MPN as a flat candidate list
+(no entity hydration — it runs on every requirement search).
 
 Called by: app/routers/htmx_views.py (material detail + fru-lookup + faceted-list
            partials, and the search-page "What we know" panel's compact
-           FRU-crosswalk context)
+           FRU-crosswalk context), app/search_service.py (get_search_aliases —
+           FRU alias expansion into supplier queries)
 Depends on: app/models/fru_link.FruLink, app/constants.FruLinkKind/CDC_PENDING,
             app/utils/normalization.normalize_mpn_key
 """
@@ -20,7 +23,7 @@ Depends on: app/models/fru_link.FruLink, app/constants.FruLinkKind/CDC_PENDING,
 from dataclasses import dataclass
 from datetime import date
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from ..constants import CDC_PENDING, FruLinkKind
@@ -403,3 +406,90 @@ def get_reverse_context(db: Session, mpn: str) -> ReverseContext:
         if current is None or (len(fru_raw), fru_raw) < (len(current), current):
             best_raw[fru_norm] = fru_raw
     return ReverseContext(distinct_frus=distinct, top_frus=tuple(sorted(best_raw.values())[:3]))
+
+
+# Crosswalk kinds eligible for supplier-search expansion, in priority order —
+# search_service caps the injected alias count, so higher-sourcing-value kinds
+# (canonical broker-listed models first) must come before weaker identifiers.
+SEARCH_ALIAS_KINDS: tuple[FruLinkKind, ...] = (
+    FruLinkKind.MFG_MODEL,
+    FruLinkKind.DRIVE_PN,
+    FruLinkKind.OPTION,
+    FruLinkKind.IBM_11S,
+)
+
+
+@dataclass(frozen=True)
+class SearchAlias:
+    """One crosswalk-derived MPN candidate for supplier-search expansion."""
+
+    mpn: str  # display spelling (shortest raw form across sheets — canonical de-padded)
+    norm: str  # normalize_mpn_key dedup key
+    rel_kind: str  # FruLinkKind value of the strongest (highest-priority) edge
+    manufacturer: str  # maker of the alias part when known ("" on reverse hits)
+
+
+def get_search_aliases(db: Session, mpn: str) -> list[SearchAlias]:
+    """Both-direction crosswalk equivalents of ``mpn`` for supplier-search expansion.
+
+    Forward hit (``mpn`` is the FRU side): aliases are its linked
+    mfg_model/drive_pn/option/ibm_11s parts — the canonical numbers brokers
+    actually list. Reverse hit (``mpn`` is the related side): the alias is the
+    FRU itself, so canonical-model searches also reach OEM spare listings.
+
+    One indexed query (ix_fru_links_fru_norm / ix_fru_links_related_norm OR'd,
+    column tuples only — no entity hydration) because this runs on every
+    requirement search. Deduped per alias norm: strongest SEARCH_ALIAS_KINDS
+    kind wins, display spelling is the shortest raw form (sheets disagree on
+    SAP zero-padding), manufacturer is the first non-empty forward value.
+    Ordered by kind priority then display string for deterministic capping.
+    """
+    norm = normalize_mpn_key(mpn)
+    if not norm:
+        return []
+    kind_values = [k.value for k in SEARCH_ALIAS_KINDS]
+    # Defensive fetch cap: real FRUs carry well under 100 alias-kind edges; the
+    # cap bounds the Python dedup work if a pathological key accumulates more.
+    rows = db.execute(
+        select(
+            FruLink.fru_norm,
+            FruLink.fru_raw,
+            FruLink.related_norm,
+            FruLink.related_raw,
+            FruLink.rel_kind,
+            FruLink.manufacturer,
+        )
+        .where(
+            FruLink.rel_kind.in_(kind_values),
+            or_(FruLink.fru_norm == norm, FruLink.related_norm == norm),
+        )
+        .order_by(FruLink.id)
+        .limit(2000)
+    ).all()
+    priority = {value: rank for rank, value in enumerate(kind_values)}
+    best: dict[str, dict] = {}
+    for fru_norm, fru_raw, related_norm, related_raw, rel_kind, manufacturer in rows:
+        if fru_norm == norm:
+            alias_norm, alias_raw, alias_mfr = related_norm, related_raw, (manufacturer or "").strip()
+        else:
+            # Reverse hit: the alias is the FRU. FruLink.manufacturer describes
+            # the related (searched) part, not the FRU — leave it blank.
+            alias_norm, alias_raw, alias_mfr = fru_norm, fru_raw, ""
+        if alias_norm == norm:  # self-edge — nothing new to search
+            continue
+        entry = best.get(alias_norm)
+        if entry is None:
+            best[alias_norm] = {"raw": alias_raw, "kind": rel_kind, "mfr": alias_mfr}
+            continue
+        if priority[rel_kind] < priority[entry["kind"]]:
+            entry["kind"] = rel_kind
+        if (len(alias_raw), alias_raw) < (len(entry["raw"]), entry["raw"]):
+            entry["raw"] = alias_raw
+        if not entry["mfr"] and alias_mfr:
+            entry["mfr"] = alias_mfr
+    aliases = [
+        SearchAlias(mpn=entry["raw"], norm=alias_norm, rel_kind=entry["kind"], manufacturer=entry["mfr"])
+        for alias_norm, entry in best.items()
+    ]
+    aliases.sort(key=lambda a: (priority[a.rel_kind], a.mpn))
+    return aliases

--- a/app/template_env.py
+++ b/app/template_env.py
@@ -197,6 +197,29 @@ def _sub_mpns_filter(subs: list | None) -> list[str]:
 templates.env.filters["sub_mpns"] = _sub_mpns_filter
 
 
+def _fru_alias_mpns_filter(subs: list | None) -> set[str]:
+    """Normalized MPNs of substitutes that were system-derived from the FRU crosswalk.
+
+    Companion to |sub_mpns (same normalize_mpn display form, so membership tests against
+    its output match) letting templates flag crosswalk-derived substitutes with a "via
+    FRU crosswalk" tooltip — no new UI elements. Provenance is the optional "source" key
+    written by search_service's alias expansion.
+    """
+    from .constants import FRU_ALIAS_SOURCE
+    from .utils.normalization import normalize_mpn
+
+    result: set[str] = set()
+    for s in subs or []:
+        if isinstance(s, dict) and s.get("source") == FRU_ALIAS_SOURCE:
+            mpn = normalize_mpn(s.get("mpn") or "")
+            if mpn:
+                result.add(mpn)
+    return result
+
+
+templates.env.filters["fru_alias_mpns"] = _fru_alias_mpns_filter
+
+
 def _part_description(obj) -> str:
     """Return part description from MaterialCard (source of truth) with fallback.
 

--- a/app/templates/htmx/partials/shared/_mpn_chips.html
+++ b/app/templates/htmx/partials/shared/_mpn_chips.html
@@ -2,22 +2,28 @@
    Called by: parts/list.html, parts/header.html, requisitions/tabs/req_row.html,
               sightings/table.html, sightings/detail.html, sourcing/workspace.html,
               sourcing/results.html, parts/tabs/req_details.html
-   Depends on: |sub_mpns Jinja2 filter (template_env.py), Alpine.js 3.x
+   Depends on: |sub_mpns + |fru_alias_mpns Jinja2 filters (template_env.py),
+               Alpine.js 3.x. Substitutes carrying FRU-crosswalk provenance
+               (source="fru_crosswalk", written by search_service's alias
+               expansion) get a title= tooltip only — no layout change.
 #}
 
-{%- macro _chip(mpn, link_map) -%}
+{%- macro _chip(mpn, link_map, fru_mpns=none) -%}
   {%- set cls = "px-1.5 py-0.5 font-mono text-slate-800 bg-white rounded border border-slate-300" -%}
+  {%- set via_fru = fru_mpns and mpn in fru_mpns -%}
   {%- if link_map and link_map.get(mpn) -%}
     <button type="button"
        @click.stop="$dispatch('open-modal', {wide: true, url: '/v2/partials/materials/{{ link_map[mpn] }}'})"
        class="{{ cls }} hover:bg-slate-200 cursor-pointer"
+       {% if via_fru %}title="Substitute via FRU crosswalk" {% endif -%}
        aria-label="View material card for {{ mpn }}">{{ mpn }}</button>
   {%- else -%}
-    <span class="{{ cls }}">{{ mpn }}</span>
+    <span class="{{ cls }}"{% if via_fru %} title="Substitute via FRU crosswalk"{% endif %}>{{ mpn }}</span>
   {%- endif -%}
 {%- endmacro -%}
 
 {% macro mpn_chips(requirement, link_map=none, max_visible=2) %}
+{% set fru_mpns = requirement.substitutes|fru_alias_mpns %}
 {% set all_mpns = [] %}
 {% if requirement.primary_mpn %}
   {% set _ = all_mpns.append(requirement.primary_mpn) %}
@@ -33,11 +39,11 @@
 {% if all_mpns|length > max_visible %}
 <span class="inline-flex items-center gap-1 whitespace-nowrap" x-data="{ open: false }">
   {%- for mpn in all_mpns[:max_visible] -%}
-    {{ _chip(mpn, link_map) }}
+    {{ _chip(mpn, link_map, fru_mpns) }}
   {%- endfor -%}
   <span x-show="open" x-cloak class="inline-flex items-center gap-1 flex-wrap">
     {%- for mpn in all_mpns[max_visible:] -%}
-      {{ _chip(mpn, link_map) }}
+      {{ _chip(mpn, link_map, fru_mpns) }}
     {%- endfor -%}
   </span>
   <button type="button" @click.stop="open = !open"
@@ -48,7 +54,7 @@
 {% elif all_mpns %}
 <span class="inline-flex items-center gap-1 whitespace-nowrap">
   {%- for mpn in all_mpns -%}
-    {{ _chip(mpn, link_map) }}
+    {{ _chip(mpn, link_map, fru_mpns) }}
   {%- endfor -%}
 </span>
 {% else %}

--- a/app/utils/normalization.py
+++ b/app/utils/normalization.py
@@ -408,7 +408,9 @@ MAX_SUBSTITUTES = 20
 def parse_substitute_mpns(subs: list[dict], primary_mpn: str, *, limit: int = MAX_SUBSTITUTES) -> list[dict]:
     """Parse structured substitute list, normalize MPNs, and deduplicate.
 
-    Each sub is a dict with 'mpn' and 'manufacturer' keys.
+    Each sub is a dict with 'mpn' and 'manufacturer' keys, plus an optional
+    'source' provenance key (e.g. constants.FRU_ALIAS_SOURCE for system-derived
+    FRU-crosswalk aliases) which is preserved when present.
     Returns normalized, deduped list capped at limit.
 
     Called by: htmx_views.py (add/update/header-save endpoints)
@@ -426,10 +428,12 @@ def parse_substitute_mpns(subs: list[dict], primary_mpn: str, *, limit: int = MA
         key = normalize_mpn_key(ns)
         if key and key not in seen_keys:
             seen_keys.add(key)
-            result.append(
-                {
-                    "mpn": ns,
-                    "manufacturer": sub.get("manufacturer", "").strip(),
-                }
-            )
+            entry = {
+                "mpn": ns,
+                "manufacturer": sub.get("manufacturer", "").strip(),
+            }
+            source = sub.get("source")
+            if isinstance(source, str) and source.strip():
+                entry["source"] = source.strip()
+            result.append(entry)
     return result[:limit]

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -183,6 +183,22 @@ Browser POST /v2/partials/sightings/{requirement_id}/refresh?source=user
     v
 sightings.py (router) → search_requirement(req, db)
     |
+    +---> _expand_fru_aliases(db, req) → fru_matrix_service.get_search_aliases
+    |     FRU-crosswalk alias injection (item 2.7). The primary MPN is looked
+    |     up in fru_links BOTH directions; its mfg_model/drive_pn/option/ibm_11s
+    |     equivalents (the canonical numbers brokers actually list) are deduped
+    |     against the primary + existing substitutes, capped at 8 in that kind
+    |     priority order, and appended to the search MPN set so they fan out to
+    |     every connector. Each alias is durably persisted as a system-derived
+    |     substitute {"mpn", "manufacturer", "source": "fru_crosswalk"} via a
+    |     dedicated write session (_persist_fru_aliases) — so it survives through
+    |     the existing primary+substitutes contract and future searches, AND on
+    |     the all-cached short-circuit path that never opens the main write
+    |     session. Best-effort: a lookup/persist failure logs and the search
+    |     proceeds with the explicit MPNs. Display flags crosswalk-derived subs
+    |     with a "via FRU crosswalk" tooltip via the |fru_alias_mpns filter in
+    |     _mpn_chips.html (no new UI elements).
+    |
     +---> _mpn_cooldown_partition(pns) → (to_search, cached_card_ids)
     |     Per-MPN 48h cooldown. Cards inside the window are partitioned
     |     out; their material_card_id is returned for the detail-panel

--- a/tests/test_fru_search_aliases.py
+++ b/tests/test_fru_search_aliases.py
@@ -1,0 +1,330 @@
+"""FRU alias expansion into supplier search (optimization plan 2026-06-12 item 2.7).
+
+What: get_search_aliases (both lookup directions, alias-kind filter, per-norm
+      dedup with shortest-raw display + manufacturer coalescing, priority
+      ordering), search_service._expand_fru_aliases (cap 8, dedup vs primary +
+      explicit substitutes, MAX_SUBSTITUTES room, provenance tag),
+      search_requirement integration (aliases reach the connector fan-out and
+      persist as system-derived substitutes on both the full path and the
+      all-cached short-circuit; no-links path unchanged),
+      parse_substitute_mpns source-key preservation, and the |fru_alias_mpns
+      template filter behind the "via FRU crosswalk" tooltip.
+Called by: pytest
+Depends on: app.search_service, app.services.fru_matrix_service,
+            app.models.FruLink/Requirement/Requisition/MaterialCard,
+            app.utils.normalization, app.template_env
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.constants import FRU_ALIAS_SOURCE, FruLinkKind
+from app.models import FruLink, MaterialCard, Requirement, Requisition
+from app.search_service import (
+    MAX_FRU_ALIASES,
+    _expand_fru_aliases,
+    get_all_pns,
+    search_requirement,
+)
+from app.services.fru_matrix_service import SEARCH_ALIAS_KINDS, get_search_aliases
+from app.template_env import _fru_alias_mpns_filter
+from app.utils.normalization import MAX_SUBSTITUTES, normalize_mpn_key, parse_substitute_mpns
+
+
+def _link(db: Session, fru: str, related: str, kind: FruLinkKind, sheet: str = "Main", **attrs) -> FruLink:
+    link = FruLink(
+        fru_raw=fru,
+        fru_norm=normalize_mpn_key(fru),
+        related_raw=related,
+        related_norm=normalize_mpn_key(related),
+        rel_kind=kind.value,
+        source_sheet=sheet,
+        **attrs,
+    )
+    db.add(link)
+    db.flush()
+    return link
+
+
+def _make_requirement(db: Session, user, primary_mpn: str, substitutes=None) -> Requirement:
+    requisition = Requisition(
+        name="REQ-FRU-1",
+        customer_name="Test Co",
+        status="active",
+        created_by=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(requisition)
+    db.flush()
+    req = Requirement(
+        requisition_id=requisition.id,
+        primary_mpn=primary_mpn,
+        substitutes=substitutes or [],
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(req)
+    db.commit()
+    return req
+
+
+class TestGetSearchAliases:
+    def test_blank_input_returns_empty(self, db_session):
+        assert get_search_aliases(db_session, "") == []
+        assert get_search_aliases(db_session, "  ") == []
+
+    def test_no_links_returns_empty(self, db_session):
+        assert get_search_aliases(db_session, "00AJ001") == []
+
+    def test_forward_direction_alias_kinds_only(self, db_session):
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL, manufacturer="Seagate")
+        _link(db_session, "00AJ001", "9RZ268-039", FruLinkKind.DRIVE_PN)
+        _link(db_session, "00AJ001", "00AJ004", FruLinkKind.OPTION)
+        _link(db_session, "00AJ001", "11S00AJ001", FruLinkKind.IBM_11S)
+        # Non-alias kinds must NOT expand into supplier queries.
+        _link(db_session, "00AJ001", "TRAY9999", FruLinkKind.TRAY)
+        _link(db_session, "00AJ001", "PPN12345", FruLinkKind.LENOVO_PPN)
+        db_session.commit()
+
+        aliases = get_search_aliases(db_session, "00AJ001")
+
+        assert [a.mpn for a in aliases] == ["ST91000640NS", "9RZ268-039", "00AJ004", "11S00AJ001"]
+        assert aliases[0].manufacturer == "Seagate"
+        assert {a.rel_kind for a in aliases} == {k.value for k in SEARCH_ALIAS_KINDS}
+
+    def test_reverse_direction_returns_fru(self, db_session):
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL, manufacturer="Seagate")
+        db_session.commit()
+
+        aliases = get_search_aliases(db_session, "ST91000640NS")
+
+        assert [a.mpn for a in aliases] == ["00AJ001"]
+        # FruLink.manufacturer describes the related part (the searched MPN
+        # here), not the FRU — reverse hits carry no manufacturer claim.
+        assert aliases[0].manufacturer == ""
+
+    def test_input_is_normalized(self, db_session):
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL)
+        db_session.commit()
+
+        assert [a.mpn for a in get_search_aliases(db_session, " 00aj-001 ")] == ["ST91000640NS"]
+
+    def test_priority_ordering_across_kinds(self, db_session):
+        # Inserted in reverse priority order — output must still rank
+        # mfg_model, drive_pn, option, ibm_11s.
+        _link(db_session, "00AJ001", "11S00AJ001", FruLinkKind.IBM_11S)
+        _link(db_session, "00AJ001", "00AJ004", FruLinkKind.OPTION)
+        _link(db_session, "00AJ001", "9RZ268-039", FruLinkKind.DRIVE_PN)
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL)
+        db_session.commit()
+
+        kinds = [a.rel_kind for a in get_search_aliases(db_session, "00AJ001")]
+
+        assert kinds == [
+            FruLinkKind.MFG_MODEL.value,
+            FruLinkKind.DRIVE_PN.value,
+            FruLinkKind.OPTION.value,
+            FruLinkKind.IBM_11S.value,
+        ]
+
+    def test_dedup_per_norm_prefers_shortest_raw_and_coalesces_manufacturer(self, db_session):
+        # Same alias under two sheets with raw spellings sharing one norm key;
+        # the shortest spelling wins, manufacturer fills from the richer row.
+        _link(db_session, "00AJ001", "68Y-7789", FruLinkKind.MFG_MODEL, sheet="A")
+        _link(db_session, "00AJ001", "68Y7789", FruLinkKind.MFG_MODEL, sheet="B", manufacturer="IBM")
+        db_session.commit()
+
+        aliases = get_search_aliases(db_session, "00AJ001")
+
+        assert len(aliases) == 1
+        assert aliases[0].mpn == "68Y7789"
+        assert aliases[0].manufacturer == "IBM"
+
+
+class TestExpandFruAliases:
+    def test_no_links_returns_empty(self, db_session, test_user):
+        req = _make_requirement(db_session, test_user, "00AJ001")
+        assert _expand_fru_aliases(db_session, req) == []
+
+    def test_alias_dict_format_and_provenance(self, db_session, test_user):
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL, manufacturer="Seagate")
+        req = _make_requirement(db_session, test_user, "00AJ001")
+
+        aliases = _expand_fru_aliases(db_session, req)
+
+        assert aliases == [{"mpn": "ST91000640NS", "manufacturer": "Seagate", "source": FRU_ALIAS_SOURCE}]
+
+    def test_caps_at_eight_in_priority_order(self, db_session, test_user):
+        for i in range(6):
+            _link(db_session, "00AJ001", f"MODEL-{i}00", FruLinkKind.MFG_MODEL)
+        for i in range(4):
+            _link(db_session, "00AJ001", f"DRIVE-{i}00", FruLinkKind.DRIVE_PN)
+        req = _make_requirement(db_session, test_user, "00AJ001")
+
+        aliases = _expand_fru_aliases(db_session, req)
+
+        assert len(aliases) == MAX_FRU_ALIASES == 8
+        # All 6 mfg_model aliases survive the cap; drive_pn fills the rest.
+        assert [a["mpn"] for a in aliases[:6]] == [f"MODEL-{i}00" for i in range(6)]
+        assert all(a["source"] == FRU_ALIAS_SOURCE for a in aliases)
+
+    def test_dedup_against_primary_and_explicit_substitutes(self, db_session, test_user):
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL)
+        _link(db_session, "00AJ001", "9RZ268-039", FruLinkKind.DRIVE_PN)
+        # Explicit substitute matches the first alias by canonical key
+        # (case + dash variations must not escape the dedup).
+        req = _make_requirement(
+            db_session,
+            test_user,
+            "00AJ001",
+            substitutes=[{"mpn": "st9-1000640ns", "manufacturer": ""}],
+        )
+
+        aliases = _expand_fru_aliases(db_session, req)
+
+        assert [a["mpn"] for a in aliases] == ["9RZ268-039"]
+
+    def test_no_room_when_substitutes_at_global_cap(self, db_session, test_user):
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL)
+        subs = [{"mpn": f"SUB-{i:03d}", "manufacturer": ""} for i in range(MAX_SUBSTITUTES)]
+        req = _make_requirement(db_session, test_user, "00AJ001", substitutes=subs)
+
+        assert _expand_fru_aliases(db_session, req) == []
+
+    def test_blank_primary_returns_empty(self, db_session, test_user):
+        req = _make_requirement(db_session, test_user, "")
+        assert _expand_fru_aliases(db_session, req) == []
+
+
+class TestSearchRequirementFruAliases:
+    """Integration: aliases flow into the connector fan-out and persist as
+    system-derived substitutes."""
+
+    async def test_forward_alias_injected_and_persisted(self, db_session, test_user, monkeypatch):
+        monkeypatch.setattr(settings, "spec_resolver_enabled", False)
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL, manufacturer="Seagate")
+        req = _make_requirement(db_session, test_user, "00AJ001")
+
+        with patch("app.search_service._fetch_fresh", new=AsyncMock(return_value=([], []))) as fetch_mock:
+            result = await search_requirement(req, db_session)
+
+        # Alias reaches the supplier fan-out alongside the primary.
+        assert fetch_mock.call_args[0][0] == ["00AJ001", "ST91000640NS"]
+        assert result["mpn_results"] == {"00AJ001": "searched", "ST91000640NS": "searched"}
+
+        # Alias persisted as a system-derived substitute with provenance.
+        db_session.expire(req)
+        assert req.substitutes == [{"mpn": "ST91000640NS", "manufacturer": "Seagate", "source": FRU_ALIAS_SOURCE}]
+        # Future searches pick it up through the normal primary+subs contract.
+        assert get_all_pns(req) == ["00AJ001", "ST91000640NS"]
+
+    async def test_reverse_alias_injected(self, db_session, test_user, monkeypatch):
+        monkeypatch.setattr(settings, "spec_resolver_enabled", False)
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL, manufacturer="Seagate")
+        req = _make_requirement(db_session, test_user, "ST91000640NS")
+
+        with patch("app.search_service._fetch_fresh", new=AsyncMock(return_value=([], []))) as fetch_mock:
+            await search_requirement(req, db_session)
+
+        assert fetch_mock.call_args[0][0] == ["ST91000640NS", "00AJ001"]
+        db_session.expire(req)
+        assert req.substitutes == [{"mpn": "00AJ001", "manufacturer": "", "source": FRU_ALIAS_SOURCE}]
+
+    async def test_no_links_path_unchanged(self, db_session, test_user, monkeypatch):
+        monkeypatch.setattr(settings, "spec_resolver_enabled", False)
+        req = _make_requirement(db_session, test_user, "LM317T")
+
+        with patch("app.search_service._fetch_fresh", new=AsyncMock(return_value=([], []))) as fetch_mock:
+            result = await search_requirement(req, db_session)
+
+        assert fetch_mock.call_args[0][0] == ["LM317T"]
+        assert result["mpn_results"] == {"LM317T": "searched"}
+        db_session.expire(req)
+        assert req.substitutes == []
+
+    async def test_alias_matching_explicit_substitute_not_duplicated(self, db_session, test_user, monkeypatch):
+        monkeypatch.setattr(settings, "spec_resolver_enabled", False)
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL)
+        req = _make_requirement(
+            db_session,
+            test_user,
+            "00AJ001",
+            substitutes=[{"mpn": "ST91000640NS", "manufacturer": "Seagate"}],
+        )
+
+        with patch("app.search_service._fetch_fresh", new=AsyncMock(return_value=([], []))) as fetch_mock:
+            await search_requirement(req, db_session)
+
+        assert fetch_mock.call_args[0][0] == ["00AJ001", "ST91000640NS"]
+        db_session.expire(req)
+        # Explicit substitute untouched — no duplicate, no provenance rewrite.
+        assert req.substitutes == [{"mpn": "ST91000640NS", "manufacturer": "Seagate"}]
+
+    async def test_short_circuit_path_still_persists_aliases(self, db_session, test_user, monkeypatch):
+        """Every MPN within cooldown including the alias → no connector calls, but the
+        system-derived substitute still lands on the requirement."""
+        monkeypatch.setattr(settings, "spec_resolver_enabled", False)
+        now = datetime.now(timezone.utc)
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL, manufacturer="Seagate")
+        for mpn in ("00AJ001", "ST91000640NS"):
+            db_session.add(
+                MaterialCard(
+                    normalized_mpn=normalize_mpn_key(mpn),
+                    display_mpn=mpn,
+                    last_searched_at=now - timedelta(hours=12),
+                )
+            )
+        req = _make_requirement(db_session, test_user, "00AJ001")
+
+        with patch("app.search_service._fetch_fresh", new=AsyncMock(return_value=([], []))) as fetch_mock:
+            result = await search_requirement(req, db_session)
+
+        assert fetch_mock.call_count == 0
+        assert result["mpn_results"] == {"00AJ001": "cached", "ST91000640NS": "cached"}
+        db_session.expire(req)
+        assert req.substitutes == [{"mpn": "ST91000640NS", "manufacturer": "Seagate", "source": FRU_ALIAS_SOURCE}]
+
+    async def test_second_search_does_not_duplicate_aliases(self, db_session, test_user, monkeypatch):
+        monkeypatch.setattr(settings, "spec_resolver_enabled", False)
+        _link(db_session, "00AJ001", "ST91000640NS", FruLinkKind.MFG_MODEL)
+        req = _make_requirement(db_session, test_user, "00AJ001")
+
+        with patch("app.search_service._fetch_fresh", new=AsyncMock(return_value=([], []))):
+            await search_requirement(req, db_session)
+            db_session.expire(req)
+            await search_requirement(req, db_session)
+
+        db_session.expire(req)
+        assert [s["mpn"] for s in req.substitutes] == ["ST91000640NS"]
+
+
+class TestParseSubstituteMpnsSourcePreservation:
+    def test_source_key_preserved(self):
+        subs = [{"mpn": "ST91000640NS", "manufacturer": "Seagate", "source": FRU_ALIAS_SOURCE}]
+        result = parse_substitute_mpns(subs, "00AJ001")
+        assert result == [{"mpn": "ST91000640NS", "manufacturer": "Seagate", "source": FRU_ALIAS_SOURCE}]
+
+    def test_no_source_key_added_when_absent(self):
+        result = parse_substitute_mpns([{"mpn": "LM317T", "manufacturer": "TI"}], "PRIMARY")
+        assert result == [{"mpn": "LM317T", "manufacturer": "TI"}]
+
+    def test_blank_source_dropped(self):
+        result = parse_substitute_mpns([{"mpn": "LM317T", "manufacturer": "", "source": "  "}], "PRIMARY")
+        assert "source" not in result[0]
+
+
+class TestFruAliasMpnsFilter:
+    def test_returns_normalized_crosswalk_mpns_only(self):
+        subs = [
+            {"mpn": "st91000640ns", "manufacturer": "Seagate", "source": FRU_ALIAS_SOURCE},
+            {"mpn": "LM317T", "manufacturer": "TI"},  # explicit sub — no tooltip
+            "PLAINSTRING1",  # legacy string form — no provenance possible
+            {"mpn": "OTHER123", "source": "something_else"},
+        ]
+        assert _fru_alias_mpns_filter(subs) == {"ST91000640NS"}
+
+    def test_empty_and_none(self):
+        assert _fru_alias_mpns_filter(None) == set()
+        assert _fru_alias_mpns_filter([]) == set()


### PR DESCRIPTION
## What

In `app/search_service.py` `search_requirement()`, expand the requirement's primary MPN through the FRU crosswalk and inject the equivalents as **system-derived substitutes** so they fan out to every supplier connector.

## Why

Brokers list canonical `mfg_model`/`drive_pn` numbers, not OEM spare/FRU numbers. A FRU-shaped primary MPN previously reached few supplier listings. Crosswalk expansion bridges that gap in both directions (a FRU primary reaches its model numbers; a model-number primary also reaches OEM spare listings).

## Alias injection contract

- **Both-direction lookup** — `fru_matrix_service.get_search_aliases(db, mpn)` runs one indexed query over `fru_norm`/`related_norm` OR'd (column tuples only, no entity hydration — it runs on every search). Forward hit: aliases are the linked parts; reverse hit: the alias is the FRU itself.
- **Eligible kinds, ordered** — `SEARCH_ALIAS_KINDS = (mfg_model, drive_pn, option, ibm_11s)`. Non-sourcing kinds (tray, lenovo_ppn, …) are excluded. Output is ordered by kind priority then display string for deterministic capping.
- **Cap 8** — `_expand_fru_aliases` caps injected aliases at `MAX_FRU_ALIASES = 8` in that priority order.
- **Dedup** — deduped per canonical norm key against the primary MPN **and** the existing substitutes (case/dash variations don't escape). Never pushes the stored list past `MAX_SUBSTITUTES`.
- **Persistence** — `_persist_fru_aliases` durably appends `{"mpn", "manufacturer", "source": "fru_crosswalk"}` via its own short-lived write session, so aliases land on **both** the full search path **and** the all-cached short-circuit (which never opens the main write session). Re-dedups against the freshly loaded row → idempotent across repeat searches. Best-effort: a lookup/persist failure logs and the search proceeds with the explicit MPNs.
- Aliases flow through the existing primary+substitutes contract — the connector fan-out includes them immediately, future searches pick them up automatically.

## Provenance — "via FRU crosswalk"

`parse_substitute_mpns` preserves the optional `source` key. The new `|fru_alias_mpns` Jinja filter (`app/template_env.py`) flags crosswalk-derived chips with a `title="Substitute via FRU crosswalk"` tooltip in `_mpn_chips.html`. **No new UI elements** — results render through the existing substitutes rendering.

## Tests — `tests/test_fru_search_aliases.py` (24 tests)

- `get_search_aliases`: blank/no-links empty, forward direction (alias-kinds only), reverse direction (FRU returned, no manufacturer claim), input normalization, priority ordering across kinds, per-norm dedup (shortest raw + manufacturer coalesce).
- `_expand_fru_aliases`: **no-links path**, dict-format + provenance, cap-at-8 in priority order, **dedup vs primary + explicit substitutes**, no-room at global cap, blank primary.
- `search_requirement` integration: forward **alias injection** + persistence, reverse injection, **no-links path unchanged**, alias matching explicit substitute not duplicated, short-circuit-path persistence, idempotent repeat search.
- `parse_substitute_mpns` source-key preservation; `|fru_alias_mpns` filter.

Covers all three spec-required paths: alias injection, dedup vs explicit substitutes, no-links.

## Files

`app/constants.py`, `app/search_service.py`, `app/services/fru_matrix_service.py`, `app/template_env.py`, `app/templates/htmx/partials/shared/_mpn_chips.html`, `app/utils/normalization.py`, `tests/test_fru_search_aliases.py`, `docs/APP_MAP_INTERACTIONS.md`.

## Verification

- Full suite: **16247 passed, 35 skipped, 1 xfailed, 0 failed, 0 errors**.
- `pre-commit` clean on changed files (ruff, ruff-format, docformatter, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)