### PR TITLE
fix(materials): trust hotfix — category @validates guard + bypass-writer closure + GPU/RTX + cleanup command

### DIFF
--- a/app/data/commodity_seeds.json
+++ b/app/data/commodity_seeds.json
@@ -3683,7 +3683,6 @@
       "enum_values": [
         "GeForce",
         "Quadro",
-        "RTX",
         "Radeon",
         "Radeon Pro",
         "Tesla",

--- a/app/management/cleanup_known_bad.py
+++ b/app/management/cleanup_known_bad.py
@@ -1,0 +1,275 @@
+"""Stop-the-bleed trust hotfix — one-shot cleanup of documented-bad catalog data.
+
+What: OPTIMIZATION_PLAN_2026_06_12 §2 item 1.1. Three idempotent passes, dry-run by
+      default (``--apply`` writes):
+        1. Delete the two documented-wrong facet rows, matched by CONTENT (never by
+           row id — ids differ across environments): the fru_matrix_decode
+           capacity_gb=373,455 row (card 413156 in the 2026-06-10 audit; true value
+           36.4 GB) and the hdd capacity_gb=973,452 outlier. The matching
+           specs_structured mirror entry is dropped when its provenance agrees.
+        2. Normalize-or-null every non-canonical material_cards.category (the
+           pre-#267 bypass-writer residue: 61 NULL-provenance junk strings like
+           "IGBT Modules", plus ~139 provenanced cards on ~89 non-canonical
+           strings). Resolvable values (CATEGORY_ALIASES / case-trim) are written
+           through set_category at legacy_backfill when unprovenanced, or
+           normalized IN PLACE preserving the existing source when provenanced;
+           unresolvable values are nulled with provenance cleared. One
+           MaterialCardAudit row per changed card (action=category_cleanup).
+        3. Stamp ``manufacturer_source='legacy_backfill'`` (conf 0.5, tier 50) on
+           every card with a manufacturer but NULL maker provenance — attribution
+           of EXISTING data, deliberately NOT a ladder write (no new evidence);
+           ``manufacturer_updated_at`` stays NULL (true write time unknown), which
+           ranks identically to the runtime NULL-provenance floor.
+Usage: python -m app.management.cleanup_known_bad [--apply]
+Called by: admin manually at deploy time (after the PR carrying it ships).
+Depends on: MaterialCard / MaterialSpecFacet / MaterialCardAudit,
+      category_normalizer.normalize_category, commodity_registry
+      CANONICAL_COMMODITY_KEYS, spec_tiers.set_category (+ the legacy_backfill
+      constants), audit_service.log_audit.
+"""
+
+import argparse
+from collections import Counter
+
+from loguru import logger
+from sqlalchemy import func, update
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard, MaterialSpecFacet
+from app.services.audit_service import log_audit
+from app.services.category_normalizer import normalize_category
+from app.services.commodity_registry import CANONICAL_COMMODITY_KEYS
+from app.services.spec_tiers import (
+    LEGACY_BACKFILL_CONFIDENCE,
+    LEGACY_BACKFILL_SOURCE,
+    LEGACY_BACKFILL_TIER,
+    set_category,
+)
+
+CREATED_BY = "cleanup_known_bad"
+
+# Documented-wrong facet rows (2026-06-10/12 audits), matched by content criteria.
+# Each entry: (spec_key, value_numeric, source-or-None, category-or-None).
+KNOWN_BAD_FACETS: tuple[tuple[str, float, str | None, str | None], ...] = (
+    # Card 413156: FRU-matrix capacity misdecode — 373,455 GB stored, true 36.4 GB.
+    ("capacity_gb", 373455.0, "fru_matrix_decode", None),
+    # The hdd capacity outlier — 973,452 GB (no shipped drive exists at that point);
+    # matched by value+key (+the hdd category cell), source left open by design.
+    ("capacity_gb", 973452.0, None, "hdd"),
+)
+
+
+def delete_known_bad_facets(db: Session, *, apply: bool = False) -> dict:
+    """Pass 1 — delete the documented-wrong facet rows (and their JSONB mirrors)."""
+    tally: Counter = Counter()
+    for spec_key, value_numeric, source, category in KNOWN_BAD_FACETS:
+        q = db.query(MaterialSpecFacet).filter(
+            MaterialSpecFacet.spec_key == spec_key,
+            MaterialSpecFacet.value_numeric == value_numeric,
+        )
+        if source is not None:
+            q = q.filter(MaterialSpecFacet.source == source)
+        if category is not None:
+            q = q.filter(MaterialSpecFacet.category == category)
+        for facet in q.all():
+            card = db.get(MaterialCard, facet.material_card_id)
+            logger.info(
+                "cleanup-known-bad: documented-wrong facet card={} {}={} (source={}, category={}) — {}",
+                facet.material_card_id,
+                facet.spec_key,
+                facet.value_numeric,
+                facet.source,
+                facet.category,
+                "deleting" if apply else "would delete",
+            )
+            if apply:
+                if card is not None:
+                    specs = dict(card.specs_structured or {})
+                    entry = specs.get(facet.spec_key)
+                    # The mirror is popped only when it mirrors THIS facet's source —
+                    # a mismatch means drift (some other source owns the JSONB entry).
+                    if entry is not None and entry.get("source") == facet.source:
+                        specs.pop(facet.spec_key, None)
+                        card.specs_structured = specs
+                        tally["mirrors_dropped"] += 1
+                    log_audit(
+                        db,
+                        material_card_id=card.id,
+                        action="facet_cleanup",
+                        normalized_mpn=card.normalized_mpn,
+                        details={
+                            "spec_key": facet.spec_key,
+                            "value_numeric": facet.value_numeric,
+                            "source": facet.source,
+                            "reason": "documented_wrong_2026_06_12",
+                        },
+                        created_by=CREATED_BY,
+                    )
+                db.delete(facet)
+            tally["facets_deleted"] += 1
+    return dict(tally)
+
+
+def cleanup_junk_categories(db: Session, *, apply: bool = False) -> dict:
+    """Pass 2 — normalize-or-null every non-canonical category, audit per card."""
+    tally: Counter = Counter()
+    transitions: Counter = Counter()
+    cards = (
+        db.query(MaterialCard)
+        .filter(
+            MaterialCard.category.isnot(None),
+            MaterialCard.category.notin_(CANONICAL_COMMODITY_KEYS),
+            MaterialCard.deleted_at.is_(None),
+        )
+        .order_by(MaterialCard.id)
+        .all()
+    )
+    for card in cards:
+        raw = card.category
+        source_before = card.category_source
+        target = normalize_category(raw)
+        if source_before is None:
+            if target is not None:
+                # Unprovenanced junk that resolves to a canonical key: through the
+                # ladder at legacy_backfill (true origin unknown). The existing
+                # NULL-provenance value ranks at the same (50, 0.5) floor with an
+                # empty timestamp, so the re-write always wins the tie-break.
+                wrote = set_category(card, target, LEGACY_BACKFILL_SOURCE, LEGACY_BACKFILL_CONFIDENCE, write=apply)
+                mode = "normalized" if wrote else "skipped_ladder"
+            else:
+                mode = "nulled"
+                if apply:
+                    card.category = None
+                    card.category_source = None
+                    card.category_confidence = None
+                    card.category_tier = None
+                    card.category_updated_at = None
+        else:
+            if target is not None:
+                # Provenanced but non-canonical (e.g. a pre-alias-map vendor string):
+                # canonicalize the VALUE in place, preserving the original source/
+                # confidence/tier/updated_at — the evidence didn't change, only its
+                # spelling. Defensive mirror of set_category's stale-facet purge:
+                # facet rows keyed to the old category cell can no longer match.
+                mode = "normalized_in_place"
+                if apply:
+                    stale = (
+                        db.query(MaterialSpecFacet)
+                        .filter(
+                            MaterialSpecFacet.material_card_id == card.id,
+                            MaterialSpecFacet.category != target,
+                        )
+                        .all()
+                    )
+                    for facet in stale:
+                        db.delete(facet)
+                        tally["stale_facets_purged"] += 1
+                    card.category = target
+            else:
+                # Provenanced junk that resolves nowhere: the provenance attests to a
+                # write of a value the vocabulary rejects — clear both.
+                mode = "nulled"
+                if apply:
+                    card.category = None
+                    card.category_source = None
+                    card.category_confidence = None
+                    card.category_tier = None
+                    card.category_updated_at = None
+        tally[mode] += 1
+        transitions[f"{raw!r} -> {target if mode.startswith('normalized') else None}"] += 1
+        if apply and mode != "skipped_ladder":
+            log_audit(
+                db,
+                material_card_id=card.id,
+                action="category_cleanup",
+                normalized_mpn=card.normalized_mpn,
+                details={
+                    "from": raw,
+                    "to": target if mode.startswith("normalized") else None,
+                    "source_before": source_before,
+                    "source_after": card.category_source,
+                    "mode": mode,
+                },
+                created_by=CREATED_BY,
+            )
+    for transition, n in transitions.most_common():
+        logger.info("cleanup-known-bad: category {:>5}x {}", n, transition)
+    result = dict(tally)
+    result["cards"] = len(cards)
+    return result
+
+
+def stamp_legacy_manufacturer_provenance(db: Session, *, apply: bool = False) -> dict:
+    """Pass 3 — stamp legacy_backfill provenance on unprovenanced manufacturers.
+
+    In-place attribution of existing data (NOT a ladder write — there is no new
+    evidence). A single bulk UPDATE; ``manufacturer_updated_at`` stays NULL so the
+    stamped rows keep ranking exactly like the runtime NULL-provenance floor
+    ((50, 0.5, "") in spec_tiers._set_provenanced_column).
+    """
+    criteria = (
+        MaterialCard.manufacturer.isnot(None),
+        func.trim(MaterialCard.manufacturer) != "",
+        MaterialCard.manufacturer_source.is_(None),
+    )
+    count = db.query(func.count(MaterialCard.id)).filter(*criteria).scalar() or 0
+    logger.info(
+        "cleanup-known-bad: {} cards carry a manufacturer with NULL provenance — {} {}/conf {}/tier {}",
+        count,
+        "stamping" if apply else "would stamp",
+        LEGACY_BACKFILL_SOURCE,
+        LEGACY_BACKFILL_CONFIDENCE,
+        LEGACY_BACKFILL_TIER,
+    )
+    if apply and count:
+        db.execute(
+            update(MaterialCard)
+            .where(*criteria)
+            .values(
+                manufacturer_source=LEGACY_BACKFILL_SOURCE,
+                manufacturer_confidence=LEGACY_BACKFILL_CONFIDENCE,
+                manufacturer_tier=LEGACY_BACKFILL_TIER,
+            )
+            .execution_options(synchronize_session=False)
+        )
+    return {"manufacturers_stamped": count}
+
+
+def run(db: Session, *, apply: bool = False) -> dict:
+    """Run all three passes; returns the combined tally (never commits)."""
+    summary = {
+        "mode": "apply" if apply else "dry-run",
+        "facets": delete_known_bad_facets(db, apply=apply),
+        "categories": cleanup_junk_categories(db, apply=apply),
+        "manufacturers": stamp_legacy_manufacturer_provenance(db, apply=apply),
+    }
+    logger.info("cleanup-known-bad [{}]: {}", summary["mode"], summary)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Stop-the-bleed trust hotfix (plan 1.1) — dry-run by default")
+    parser.add_argument("--apply", action="store_true", help="Write the deletes/normalizations/stamps")
+    args = parser.parse_args()
+
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        if args.apply:
+            logger.warning(
+                "cleanup-known-bad: --apply will DELETE documented-wrong facet rows, rewrite/null "
+                "non-canonical categories, and stamp manufacturer provenance — ensure a recent "
+                "db-backup exists (pg_dump runs every 6h; scripts/restore.sh to roll back)"
+            )
+        run(db, apply=args.apply)
+        if args.apply:
+            db.commit()
+        else:
+            db.rollback()  # belt-and-braces: dry-run leaves no writes behind
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/models/intelligence.py
+++ b/app/models/intelligence.py
@@ -72,8 +72,9 @@ class MaterialCard(Base):
     # ladder). Through set_category, a lower-tier source can never overwrite a category
     # written by a higher-tier source; a category carrying a value but NULL provenance
     # (legacy data) ranks at the legacy_backfill mid-tier (50). All in-tree category
-    # writers route through set_category; SP3 adds an @validates("category") guard so a
-    # future direct assignment cannot bypass the ladder and leave these columns stale.
+    # writers route through set_category; the @validates("category") guard below (SP3)
+    # rejects any off-vocab direct assignment, so a future un-routed writer can no
+    # longer persist junk past the ladder.
     category_source = Column(String(50))  # "mpn_decode", "digikey_api", "claude_opus_inferred", ...
     category_confidence = Column(Float)
     category_tier = Column(Integer)
@@ -150,6 +151,28 @@ class MaterialCard(Base):
             return MaterialEnrichmentStatus.UNENRICHED.value
         return MaterialEnrichmentStatus(value).value  # raises ValueError on unknown
 
+    @validates("category")
+    def _validate_category(self, _key, value):
+        """SP3 ladder hardening: only NULL or a canonical commodity key may be assigned.
+
+        set_category (spec_tiers) is the single routed writer and only ever assigns
+        canonical keys, so it passes untouched; an off-vocab direct assignment (the
+        pre-#267 bypass-writer class that minted 61 junk categories) raises instead of
+        silently persisting junk with stale provenance columns. Lazy import — the
+        registry imports app.models at module level.
+        """
+        if value is None:
+            return None
+        from app.services.commodity_registry import CANONICAL_COMMODITY_KEYS
+
+        if value not in CANONICAL_COMMODITY_KEYS:
+            raise ValueError(
+                f"material_cards.category must be a canonical commodity key or None, got {value!r} — "
+                "route the write through spec_tiers.set_category (which normalizes via "
+                "category_normalizer and arbitrates via the F1 ladder)"
+            )
+        return value
+
 
 class MaterialVendorHistory(Base):
     __tablename__ = "material_vendor_history"
@@ -187,7 +210,9 @@ class MaterialCardAudit(Base):
     __tablename__ = "material_card_audit"
     id = Column(Integer, primary_key=True)
     material_card_id = Column(Integer, index=True)  # No FK — survives card deletion
-    action = Column(String(50), nullable=False)  # created, linked, unlinked, deleted, merged, healed, restored
+    # created, linked, unlinked, deleted, merged, healed, restored,
+    # category_cleanup / facet_cleanup (app/management/cleanup_known_bad.py)
+    action = Column(String(50), nullable=False)
     entity_type = Column(String(50))  # requirement, sighting, offer
     entity_id = Column(Integer)
     old_card_id = Column(Integer)

--- a/app/services/category_normalizer.py
+++ b/app/services/category_normalizer.py
@@ -24,9 +24,7 @@ supplier taxonomies like DigiKey's). The SFDC ingest ladder resolves through
 ``normalize_category`` never consults source-scoped maps.
 """
 
-from app.services.commodity_registry import get_all_commodities
-
-_CANONICAL_KEYS = frozenset(get_all_commodities())
+from app.services.commodity_registry import CANONICAL_COMMODITY_KEYS as _CANONICAL_KEYS
 
 CATEGORY_ALIASES: dict[str, str] = {
     "connectors, interconnects": "connectors",

--- a/app/services/commodity_registry.py
+++ b/app/services/commodity_registry.py
@@ -117,6 +117,13 @@ def get_all_commodities() -> list[str]:
     return result
 
 
+# Frozen canonical vocabulary — the ONLY values material_cards.category may hold
+# (besides NULL). Consumed by category_normalizer.normalize_category and the
+# @validates("category") guard on MaterialCard (models/intelligence.py), so the
+# guard and the normalizer can never drift apart.
+CANONICAL_COMMODITY_KEYS: frozenset[str] = frozenset(get_all_commodities())
+
+
 def get_parent_group(commodity: str) -> str:
     """Return the parent group name for a commodity, or 'Misc' if unknown."""
     return _PARENT_LOOKUP.get(commodity.lower().strip(), "Misc")

--- a/app/services/desc_extractor/gpu.py
+++ b/app/services/desc_extractor/gpu.py
@@ -13,13 +13,17 @@ Depends on: _common (SpecDict alias + unique_or_none helper) — pure functions.
 
 CONSERVATIVE by design (a wrong facet value is worse than a missing one):
 - gpu_family collects all marketing/chip tokens (Quadro, GeForce, GTX⇒GeForce,
-  RTX, Tesla + datacenter chip list incl. T4, Radeon (Pro), A-/H-series) and
+  RTX⇒GeForce-or-omit, Tesla + datacenter chip list incl. T4, Radeon (Pro),
+  A-/H-series) and
   emits a unique member or omits. Subsumption: an explicit GEFORCE token absorbs
   its own GTX/RTX sub-brand tokens ("GeForce RTX/GTX …" is one family, not a
   conflict). An RTX token adjacent to a consumer x050–x090 model ("RTX 3070",
   "RTX3080", comma-tokenized "RTX, 3070") maps to GeForce — RTX is a tier, not
-  the family — while "RTX" itself is reserved for the professional
-  Quadro-successor line (RTX A2000 etc.) and bare context-less RTX tokens. A-/H-series chip tokens reject hyphen-glued silicon steppings
+  the family — while professional Quadro-successor models (RTX A2000, RTX 4000
+  Ada) and bare context-less RTX tokens emit NO family: "RTX" was removed from
+  the seeded gpu_family enum (trust hotfix 2026-06-12 — it re-fragmented one
+  physical family across two facet values), and these shapes have no honest
+  member in the remaining vocabulary. A-/H-series chip tokens reject hyphen-glued silicon steppings
   ("N17M-Q3-A2", "GK104-400-A2") via a lookbehind — those mark a chip revision,
   never an Ampere/Hopper card. Architecture names (PASCAL spans Tesla AND
   Quadro) and bare models ("2080TI") are deliberately unmapped.
@@ -47,8 +51,9 @@ import re
 from app.services.desc_extractor._common import SpecDict, unique_or_none
 
 # Canonical gpu_family enum strings — MUST match the gpu entry in
-# app/data/commodity_seeds.json (drift-guarded).
-GEFORCE, QUADRO, RTX = "GeForce", "Quadro", "RTX"
+# app/data/commodity_seeds.json (drift-guarded). "RTX" is NOT a member: removed
+# from the seeds (trust hotfix 2026-06-12), so the extractor must never emit it.
+GEFORCE, QUADRO = "GeForce", "Quadro"
 RADEON, RADEON_PRO, TESLA = "Radeon", "Radeon Pro", "Tesla"
 A_SERIES, H_SERIES = "A-series", "H-series"
 
@@ -105,14 +110,15 @@ def _family_members(text: str) -> set[str]:
     else:
         if _GTX.search(text):
             members.add(GEFORCE)  # GTX is definitionally GeForce
-        if _RTX.search(text):
-            # The seeded enum carries BOTH "GeForce" and "RTX". Consumer RTX models
-            # (GeForce RTX 2060…5090) ARE the GeForce family — storing them under
-            # "RTX" fragments one physical family across two facet values (audit
-            # cards 583761 vs 560385). "RTX" is reserved for the professional
-            # Quadro-successor line (RTX A2000/A4000, RTX 4000 Ada, Quadro RTX
-            # 8000) and bare context-less RTX tokens.
-            members.add(GEFORCE if _RTX_CONSUMER.search(text) else RTX)
+        if _RTX.search(text) and _RTX_CONSUMER.search(text):
+            # Consumer RTX models (GeForce RTX 2060…5090) ARE the GeForce family —
+            # storing them under "RTX" fragments one physical family across two facet
+            # values (audit cards 583761 vs 560385). Professional Quadro-successor
+            # models (RTX A2000/A4000, RTX 4000 Ada) and bare context-less RTX tokens
+            # add NOTHING: "RTX" left the seeded enum (trust hotfix 2026-06-12) and a
+            # wrong family is worse than a missing one. A co-occurring branded token
+            # (e.g. "QUADRO RTX 8000") still resolves via its own pattern above.
+            members.add(GEFORCE)
     return members
 
 

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -167,21 +167,26 @@ async def enrich_batch(mpns: list[str], db: Session, concurrency: int = 5) -> di
 
 def _apply_enrichment_to_card(card: MaterialCard, enrichment: dict, db: Session) -> None:
     """Apply enrichment result to a material card and tag it."""
+    from app.services.spec_tiers import set_category, set_manufacturer
+
     manufacturer = enrichment["manufacturer"]
     confidence = enrichment["confidence"]
     source_name = enrichment["source"]
 
-    # Update card fields
-    if not card.manufacturer:
-        card.manufacturer = manufacturer
-    if enrichment.get("category"):
-        from app.services.spec_tiers import set_category
+    # Connector name → its registered *_api ladder source (tier 90; brokerbin is
+    # registered as-is at 65). The evidence here is a distributor-API part match, so
+    # both writes below carry the connector's own SOURCE_TIER name.
+    ladder_source = source_name if source_name == "brokerbin" else f"{source_name}_api"
 
-        # Through the F1 ladder (connector name → its registered *_api ladder source,
-        # tier 90; brokerbin is registered as-is at 65): fills an empty category and may
-        # correct a lower-tier one (decode 85, AI guess 40), but never overwrites a
-        # higher-tier value and never persists off-vocab junk.
-        ladder_source = source_name if source_name == "brokerbin" else f"{source_name}_api"
+    # Manufacturer through the F1 ladder (was a direct fill-when-NULL `card.manufacturer
+    # = ...` — the last un-routed maker writer, which left NULL provenance ranking at
+    # the legacy floor). The ladder fills an empty maker, displaces legacy/lower-tier
+    # values (50 < 90), and never overwrites manual (100) or trio_source (95).
+    set_manufacturer(card, manufacturer, ladder_source, confidence)
+    if enrichment.get("category"):
+        # Same ladder: fills an empty category and may correct a lower-tier one (decode
+        # 85, AI guess 40), but never overwrites a higher-tier value and never persists
+        # off-vocab junk.
         set_category(card, enrichment["category"], ladder_source, confidence)
 
     # Classify and tag

--- a/app/services/spec_tiers.py
+++ b/app/services/spec_tiers.py
@@ -515,7 +515,9 @@ def set_category(
             logger.warning("set_category: off-vocab value {!r} (source={}) — not writing", value, source)
         return False
 
-    # value is already canonical here; SP3's @validates("category") hardens other paths.
+    # value is already canonical here; MaterialCard's @validates("category") guard
+    # (models/intelligence.py) hardens every OTHER path — an off-vocab direct
+    # assignment raises instead of bypassing the ladder.
     return _set_provenanced_column(
         card,
         "category",

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1201,8 +1201,11 @@ owns arbitration in one place:
        memory_gb requires a GPU-context token (NVIDIA/GDDR/HBM/family hit) so NIC
        "10GB"/"100GbE" rows emit nothing, gpu_family maps consumer RTX models
        (x050–x090 adjacent to the RTX token, incl. comma-tokenized "RTX, 3070")
-       to GeForce and reserves the seeded "RTX" member for the professional
-       Quadro-successor line (RTX A2000, RTX 4000 Ada), bit-unit tokens
+       to GeForce and emits NO family for the professional Quadro-successor line
+       (RTX A2000, RTX 4000 Ada) or bare context-less RTX — "RTX" was REMOVED
+       from the seeded gpu_family enum (trust hotfix 2026-06-12: it re-fragmented
+       one physical family across two facet values, audit cards 583761 vs 560385),
+       and a wrong family is worse than a missing one, bit-unit tokens
        ("2Gb, 128*16" component densities — uppercase letter + lowercase b) are
        neutralized BEFORE the upper-casing so bits are never recorded as GB
        capacity (skipped, never ÷8-converted), NAND-die context (_common.
@@ -1428,10 +1431,14 @@ web_search:70 — for BOTH category and manufacturer, with ladder-rejected write
 from `enrichment_provenance` — plus the claude_opus_inferred:40 AI fallback). **The
 ladder monopoly is complete: every category/manufacturer writer routes through
 `set_category` / `set_manufacturer` — no direct overwrite of `card.category` or
-`card.manufacturer` remains** (the only direct maker assignments left are
-fill-when-NULL guards (`if not card.manufacturer`), which can never overwrite and rank
-at the legacy floor until a routed writer stamps real provenance; SP3 adds the
-`@validates` hardening). Visibility: a NON-manual rejection logs at INFO for EVERY
+`card.manufacturer` remains** (the last fill-when-NULL maker write — `_apply_enrichment_to_card`
+in `enrichment.py` — now routes through `set_manufacturer` too, so a connector maker
+displaces a legacy NULL-provenance value (50 < 90) instead of only filling an empty one).
+SP3 hardening is LIVE: `MaterialCard` carries an `@validates("category")` guard
+(`app/models/intelligence.py`) that REJECTS any off-vocab direct assignment (raises
+`ValueError`) — a future un-routed writer can no longer persist junk past the ladder; the
+guard's canonical vocabulary is the single frozen `commodity_registry.CANONICAL_COMMODITY_KEYS`,
+shared with `category_normalizer` so the two can never drift. Visibility: a NON-manual rejection logs at INFO for EVERY
 provenanced column — category, brand AND manufacturer (mirrors `record_spec` — a
 systematically losing writer must be visible at production log levels; the W8
 enrichment writers carry no aggregate maker-conflict counter, so DEBUG-only maker
@@ -1675,6 +1682,22 @@ wd_revision_digit/capacity_grid/seagate_envelope/nand_density — the decoder's
 `dropped`/`drop_reasons` channel attributes grid-emptied capacity-only decodes to
 capacity_grid and envelope refusals to seagate_envelope, never to the shape-regex
 fallback buckets); SAVEPOINT per card.
+
+Stop-the-bleed trust hotfix (one-shot, post-deploy): `python -m
+app.management.cleanup_known_bad [--apply]` — dry-run by default. Three idempotent
+passes that remediate documented-bad catalog data the new guards now block at the
+source: (1) DELETE the two documented-wrong facet rows (fru_matrix_decode
+capacity_gb=373,455 and the hdd capacity_gb=973,452 outlier), matched by CONTENT not
+row id, dropping the specs_structured JSONB mirror only when its source agrees; (2)
+normalize-or-null every non-canonical `material_cards.category` (the pre-#267
+bypass-writer residue) — resolvable values route through `set_category` at
+legacy_backfill when unprovenanced or are canonicalized in place (source preserved,
+stale facets purged) when provenanced, unresolvable values are nulled with provenance
+cleared; (3) stamp `manufacturer_source='legacy_backfill'` (conf 0.5, tier 50) on every
+card with a maker but NULL provenance (attribution of existing data, NOT a ladder write;
+`manufacturer_updated_at` stays NULL so it ranks at the runtime NULL-provenance floor).
+One `MaterialCardAudit` row per changed card (action `facet_cleanup` / `category_cleanup`);
+dry-run rolls back, never commits.
 
 ## Cross-Reference Caching
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,21 @@ def db_session():
         session.close()
 
 
+def force_card_category(db: Session, card: MaterialCard, raw_value: str) -> None:
+    """Write an off-vocab/legacy category via Core UPDATE, bypassing the ORM guard.
+
+    MaterialCard's ``@validates("category")`` rejects non-canonical assignment, but
+    live legacy rows (mixed-case "DRAM", free-text vendor taxonomy) pre-date the
+    guard — tests exercising that residue (faceted lower(trim()) bucketing, the
+    startup residue warning, cleanup_known_bad) seed it here, exactly as a
+    pre-guard writer would have. *card* must be flushed (needs an id).
+    """
+    from sqlalchemy import update as _sa_update
+
+    db.execute(_sa_update(MaterialCard).where(MaterialCard.id == card.id).values(category=raw_value))
+    db.expire(card, ["category"])
+
+
 @pytest.fixture()
 def test_user(db_session: Session) -> User:
     """A standard buyer user."""

--- a/tests/test_cleanup_known_bad.py
+++ b/tests/test_cleanup_known_bad.py
@@ -1,0 +1,315 @@
+"""Tests for app/management/cleanup_known_bad.py — the stop-the-bleed trust hotfix.
+
+Covers the three idempotent passes (documented-wrong facet deletes, non-canonical
+category normalize-or-null, legacy manufacturer-provenance stamp) in BOTH dry-run
+(default, writes nothing) and --apply mode, plus the per-card audit trail.
+
+Off-vocab/legacy categories that pre-date the @validates("category") guard are seeded
+through conftest.force_card_category (a Core UPDATE that bypasses the ORM guard), exactly
+as a pre-guard writer would have left them in the live DB — the residue this command exists
+to clean up.
+
+Called by: pytest
+Depends on: app/management/cleanup_known_bad.py, conftest (db_session, force_card_category),
+            MaterialCard / MaterialSpecFacet / MaterialCardAudit.
+"""
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.management.cleanup_known_bad import (
+    cleanup_junk_categories,
+    delete_known_bad_facets,
+    run,
+    stamp_legacy_manufacturer_provenance,
+)
+from app.models import MaterialCard, MaterialCardAudit, MaterialSpecFacet
+from app.services.spec_tiers import LEGACY_BACKFILL_SOURCE, LEGACY_BACKFILL_TIER
+from tests.conftest import engine, force_card_category  # noqa: F401
+
+
+def _card(db: Session, mpn: str, **kw) -> MaterialCard:
+    card = MaterialCard(
+        normalized_mpn=mpn.lower(),
+        display_mpn=mpn.upper(),
+        created_at=datetime.now(timezone.utc),
+        **kw,
+    )
+    db.add(card)
+    db.flush()
+    return card
+
+
+def _audits(db: Session, action: str) -> list[MaterialCardAudit]:
+    return db.query(MaterialCardAudit).filter_by(action=action).all()
+
+
+# ── Pass 1: documented-wrong facet deletes ──────────────────────────────
+
+
+class TestDeleteKnownBadFacets:
+    def _seed_bad_facets(self, db: Session) -> tuple[MaterialCard, MaterialCard]:
+        # Card with the FRU-matrix capacity misdecode (373,455 GB) matched by key+value+source.
+        fru = _card(db, "FRU-BAD", category="hdd")
+        fru.specs_structured = {"capacity_gb": {"value": 373455.0, "source": "fru_matrix_decode"}}
+        db.add(
+            MaterialSpecFacet(
+                material_card_id=fru.id,
+                category="hdd",
+                spec_key="capacity_gb",
+                value_numeric=373455.0,
+                source="fru_matrix_decode",
+            )
+        )
+        # The hdd capacity outlier (973,452 GB) matched by key+value+category.
+        hdd = _card(db, "HDD-BAD", category="hdd")
+        db.add(
+            MaterialSpecFacet(
+                material_card_id=hdd.id,
+                category="hdd",
+                spec_key="capacity_gb",
+                value_numeric=973452.0,
+                source="mpn_decode",
+            )
+        )
+        db.flush()
+        return fru, hdd
+
+    def test_dry_run_counts_but_writes_nothing(self, db_session: Session):
+        self._seed_bad_facets(db_session)
+        result = delete_known_bad_facets(db_session, apply=False)
+
+        assert result["facets_deleted"] == 2
+        # Nothing actually removed.
+        assert db_session.query(MaterialSpecFacet).count() == 2
+        assert _audits(db_session, "facet_cleanup") == []
+
+    def test_apply_deletes_facets_drops_mirror_and_audits(self, db_session: Session):
+        fru, _hdd = self._seed_bad_facets(db_session)
+        result = delete_known_bad_facets(db_session, apply=True)
+        db_session.flush()
+
+        assert result["facets_deleted"] == 2
+        assert result["mirrors_dropped"] == 1  # only the FRU card had a matching JSONB mirror
+        assert db_session.query(MaterialSpecFacet).count() == 0
+        # The FRU card's specs_structured mirror was popped (source matched the facet).
+        db_session.refresh(fru)
+        assert "capacity_gb" not in (fru.specs_structured or {})
+        # One audit row per deleted facet that still had a card.
+        assert len(_audits(db_session, "facet_cleanup")) == 2
+
+    def test_mirror_kept_when_provenance_drifted(self, db_session: Session):
+        # A JSONB mirror owned by a DIFFERENT source must not be dropped with the facet.
+        fru = _card(db_session, "FRU-DRIFT", category="hdd")
+        fru.specs_structured = {"capacity_gb": {"value": 373455.0, "source": "manual"}}
+        db_session.add(
+            MaterialSpecFacet(
+                material_card_id=fru.id,
+                category="hdd",
+                spec_key="capacity_gb",
+                value_numeric=373455.0,
+                source="fru_matrix_decode",
+            )
+        )
+        db_session.flush()
+
+        result = delete_known_bad_facets(db_session, apply=True)
+        assert result["facets_deleted"] == 1
+        assert result.get("mirrors_dropped", 0) == 0
+        db_session.refresh(fru)
+        assert "capacity_gb" in fru.specs_structured  # drift-owned mirror survives
+
+    def test_correct_capacity_untouched(self, db_session: Session):
+        ok = _card(db_session, "OK-CARD", category="hdd")
+        db_session.add(
+            MaterialSpecFacet(
+                material_card_id=ok.id,
+                category="hdd",
+                spec_key="capacity_gb",
+                value_numeric=4000.0,
+                source="mpn_decode",
+            )
+        )
+        db_session.flush()
+
+        result = delete_known_bad_facets(db_session, apply=True)
+        assert result.get("facets_deleted", 0) == 0
+        assert db_session.query(MaterialSpecFacet).count() == 1
+
+
+# ── Pass 2: non-canonical category normalize-or-null ────────────────────
+
+
+class TestCleanupJunkCategories:
+    def test_unprovenanced_alias_normalized_through_ladder(self, db_session: Session):
+        # "Hard Drives" → canonical "hdd" via the alias map; unprovenanced, so it routes
+        # through set_category at legacy_backfill.
+        card = _card(db_session, "ALIAS-1")
+        force_card_category(db_session, card, "Hard Drives")
+        db_session.flush()
+
+        result = cleanup_junk_categories(db_session, apply=True)
+        db_session.flush()
+        db_session.refresh(card)
+        assert card.category == "hdd"
+        assert card.category_source == LEGACY_BACKFILL_SOURCE
+        assert card.category_tier == LEGACY_BACKFILL_TIER
+        assert result["normalized"] == 1
+        assert len(_audits(db_session, "category_cleanup")) == 1
+
+    def test_unprovenanced_unresolvable_nulled(self, db_session: Session):
+        card = _card(db_session, "JUNK-1")
+        force_card_category(db_session, card, "IGBT Modules")  # no canonical mapping
+        db_session.flush()
+
+        result = cleanup_junk_categories(db_session, apply=True)
+        db_session.flush()
+        db_session.refresh(card)
+        assert card.category is None
+        assert card.category_source is None
+        assert result["nulled"] == 1
+        assert len(_audits(db_session, "category_cleanup")) == 1
+
+    def test_provenanced_noncanonical_normalized_in_place(self, db_session: Session):
+        # A provenanced but mixed-case value: canonicalize in place, KEEP the source.
+        card = _card(db_session, "INPLACE-1")
+        card.category_source = "digikey_api"
+        card.category_confidence = 0.9
+        card.category_tier = 90
+        db_session.flush()
+        force_card_category(db_session, card, "Internal Hard Drives")  # alias → hdd
+        # Stale facet keyed to the old category cell must be purged.
+        db_session.add(
+            MaterialSpecFacet(
+                material_card_id=card.id,
+                category="Internal Hard Drives",
+                spec_key="capacity_gb",
+                value_numeric=4000.0,
+                source="digikey_api",
+            )
+        )
+        db_session.flush()
+
+        result = cleanup_junk_categories(db_session, apply=True)
+        db_session.flush()
+        db_session.refresh(card)
+        assert card.category == "hdd"
+        assert card.category_source == "digikey_api"  # source preserved — value only changed
+        assert result["normalized_in_place"] == 1
+        assert result["stale_facets_purged"] == 1
+        # the stale facet (category != "hdd") is gone
+        assert db_session.query(MaterialSpecFacet).filter(MaterialSpecFacet.category != "hdd").count() == 0
+
+    def test_canonical_categories_skipped(self, db_session: Session):
+        _card(db_session, "CANON-1", category="dram")
+        _card(db_session, "CANON-2", category="ssd")
+        result = cleanup_junk_categories(db_session, apply=True)
+        assert result["cards"] == 0  # nothing non-canonical selected
+
+    def test_dry_run_writes_nothing(self, db_session: Session):
+        card = _card(db_session, "DRY-1")
+        force_card_category(db_session, card, "Hard Drives")
+        db_session.flush()
+
+        result = cleanup_junk_categories(db_session, apply=False)
+        db_session.expire(card, ["category"])
+        assert card.category == "Hard Drives"  # untouched
+        assert result["normalized"] == 1  # but tallied as if applied
+        assert _audits(db_session, "category_cleanup") == []
+
+
+# ── Pass 3: legacy manufacturer-provenance stamp ────────────────────────
+
+
+class TestStampLegacyManufacturerProvenance:
+    def test_apply_stamps_only_unprovenanced(self, db_session: Session):
+        unprov = _card(db_session, "MFR-1", manufacturer="Samsung")  # NULL provenance
+        prov = _card(db_session, "MFR-2", manufacturer="Micron")
+        prov.manufacturer_source = "manual"
+        prov.manufacturer_tier = 100
+        _card(db_session, "MFR-3")  # no manufacturer at all
+        db_session.flush()
+
+        result = stamp_legacy_manufacturer_provenance(db_session, apply=True)
+        assert result["manufacturers_stamped"] == 1
+        db_session.refresh(unprov)
+        db_session.refresh(prov)
+        assert unprov.manufacturer_source == LEGACY_BACKFILL_SOURCE
+        assert unprov.manufacturer_tier == LEGACY_BACKFILL_TIER
+        assert unprov.manufacturer_updated_at is None  # true write time unknown
+        assert prov.manufacturer_source == "manual"  # already provenanced — untouched
+
+    def test_dry_run_writes_nothing(self, db_session: Session):
+        unprov = _card(db_session, "MFR-DRY", manufacturer="Samsung")
+        db_session.flush()
+        result = stamp_legacy_manufacturer_provenance(db_session, apply=False)
+        assert result["manufacturers_stamped"] == 1
+        db_session.refresh(unprov)
+        assert unprov.manufacturer_source is None  # untouched
+
+
+# ── run() orchestration + idempotence ───────────────────────────────────
+
+
+class TestRun:
+    def _seed_all(self, db: Session) -> None:
+        bad = _card(db, "RUN-FACET", category="hdd")
+        db.add(
+            MaterialSpecFacet(
+                material_card_id=bad.id,
+                category="hdd",
+                spec_key="capacity_gb",
+                value_numeric=973452.0,
+                source="mpn_decode",
+            )
+        )
+        alias = _card(db, "RUN-ALIAS")
+        force_card_category(db, alias, "Hard Drives")
+        _card(db, "RUN-MFR", manufacturer="Samsung")
+        db.flush()
+
+    def test_run_dry_run_mode_label(self, db_session: Session):
+        self._seed_all(db_session)
+        summary = run(db_session, apply=False)
+        assert summary["mode"] == "dry-run"
+        assert summary["facets"]["facets_deleted"] == 1
+        assert summary["categories"]["normalized"] == 1
+        assert summary["manufacturers"]["manufacturers_stamped"] == 1
+
+    def test_run_apply_is_idempotent(self, db_session: Session):
+        self._seed_all(db_session)
+        first = run(db_session, apply=True)
+        db_session.flush()
+        assert first["mode"] == "apply"
+
+        second = run(db_session, apply=True)
+        assert second["facets"].get("facets_deleted", 0) == 0
+        assert second["categories"]["cards"] == 0
+        assert second["manufacturers"]["manufacturers_stamped"] == 0
+
+
+def test_main_dry_run_rolls_back(db_session: Session, monkeypatch):
+    """Main() without --apply must roll back (belt-and-braces: dry-run leaves no
+    writes)."""
+    import sys
+
+    import app.database
+    from app.management import cleanup_known_bad
+
+    card = _card(db_session, "MAIN-DRY")
+    force_card_category(db_session, card, "Hard Drives")
+    db_session.flush()
+
+    committed = {"value": False}
+    rolled_back = {"value": False}
+    monkeypatch.setattr(db_session, "commit", lambda: committed.__setitem__("value", True))
+    monkeypatch.setattr(db_session, "rollback", lambda: rolled_back.__setitem__("value", True))
+    monkeypatch.setattr(db_session, "close", lambda: None)
+    # main() does `from app.database import SessionLocal` — patch at the source module.
+    monkeypatch.setattr(app.database, "SessionLocal", lambda: db_session)
+    monkeypatch.setattr(sys, "argv", ["cleanup_known_bad"])
+
+    cleanup_known_bad.main()
+    assert rolled_back["value"] is True
+    assert committed["value"] is False

--- a/tests/test_desc_extractor_gpu.py
+++ b/tests/test_desc_extractor_gpu.py
@@ -31,10 +31,12 @@ CASES = [
     # as the catalog's "GeForce RTX 3080" rows (card 560385) — GeForce, never "RTX".
     ("NVIDIA, RTX, 3070", "gpu", {"gpu_family": "GeForce"}),  # audit card 583761
     ("NVIDIA, RTX, 3080", "gpu", {"gpu_family": "GeForce"}),  # audit card 560385's family
-    # The professional Quadro-successor line keeps the seeded "RTX" member: A-prefixed
-    # and x000-shaped models never match the consumer x050–x090 shape.
-    ("NVIDIA RTX A2000 6GB", "gpu", {"gpu_family": "RTX", "memory_gb": 6}),
-    ("SPS-PCA NVIDIA RTX 4000 ADA 20GB", "gpu", {"gpu_family": "RTX", "memory_gb": 20}),
+    # The professional Quadro-successor line emits NO family since "RTX" left the
+    # seeded enum (trust hotfix 2026-06-12): A-prefixed and x000-shaped models never
+    # match the consumer x050–x090 shape, and a wrong family is worse than a missing
+    # one. The NVIDIA context token still unlocks memory_gb.
+    ("NVIDIA RTX A2000 6GB", "gpu", {"memory_gb": 6}),
+    ("SPS-PCA NVIDIA RTX 4000 ADA 20GB", "gpu", {"memory_gb": 20}),
     (
         "GTX1660Super@6G/D6/DP/H/DVI",  # GTX is definitionally GeForce
         "gpu",

--- a/tests/test_desc_extractor_routing.py
+++ b/tests/test_desc_extractor_routing.py
@@ -305,7 +305,9 @@ def test_emittable_vocabulary_matches_commodity_seeds():
     assert {p[0] for p in tape._IFACE_PATTERNS} == enum_values("tape_drives", "interface")
     assert {p[0] for p in tape._FORM_PATTERNS} <= enum_values("tape_drives", "form_factor")
 
-    gpu_members = {p[0] for p in gpu._FAMILY_PATTERNS} | {gpu.GEFORCE, gpu.RTX}
+    # "RTX" left the seeded enum (trust hotfix 2026-06-12) — the extractor maps
+    # consumer RTX shapes to GeForce and emits nothing for the professional line.
+    gpu_members = {p[0] for p in gpu._FAMILY_PATTERNS} | {gpu.GEFORCE}
     assert gpu_members == enum_values("gpu", "gpu_family")
     assert (gpu._MEM_MIN, gpu._MEM_MAX) == numeric_range("gpu", "memory_gb")
 

--- a/tests/test_enrichment_coverage_report.py
+++ b/tests/test_enrichment_coverage_report.py
@@ -33,12 +33,23 @@ from app.management.enrichment_coverage_report import (
 )
 from app.models import MaterialCard, MaterialSpecFacet
 from app.models.fru_link import FruLink
+from app.services.commodity_registry import CANONICAL_COMMODITY_KEYS
+from tests.conftest import force_card_category
 
 
 def _card(db, mpn, **kwargs):
+    # A deliberately non-canonical category (e.g. " Other ") is legacy residue the
+    # coverage report must still bucket; the @validates guard rejects it on assignment,
+    # so seed it post-flush via force_card_category exactly as a pre-guard writer left it.
+    category = kwargs.pop("category", None)
+    residue = category is not None and category not in CANONICAL_COMMODITY_KEYS
     card = MaterialCard(normalized_mpn=mpn, display_mpn=mpn, **kwargs)
+    if not residue and category is not None:
+        card.category = category
     db.add(card)
     db.flush()
+    if residue:
+        force_card_category(db, card, category)
     return card
 
 

--- a/tests/test_enrichment_service.py
+++ b/tests/test_enrichment_service.py
@@ -453,14 +453,24 @@ class TestApplyEnrichmentToCard:
 
         assert card.category is None  # junk rejected, column left NULL
 
-    def test_does_not_overwrite_existing_manufacturer(self, db_session):
-        """Does not overwrite existing manufacturer."""
+    def test_does_not_overwrite_higher_tier_manufacturer(self, db_session):
+        """A higher-tier maker (manual=100) survives an incoming connector write
+        (mouser_api=90).
+
+        Manufacturer now routes through spec_tiers.set_manufacturer, so "don't
+        overwrite" is the ladder's tier arbitration — a manual prior outranks the
+        connector tier and is kept (the legacy fill-when-NULL guard is gone).
+        """
         from app.services.enrichment import _apply_enrichment_to_card
 
         card = _make_card(db_session, manufacturer="Existing Mfr")
+        card.manufacturer_source = "manual"
+        card.manufacturer_confidence = 1.0
+        card.manufacturer_tier = 100
+        db_session.flush()
         enrichment = {
             "manufacturer": "New Mfr",
-            "category": "New Cat",
+            "category": "voltage_regulators",
             "source": "mouser",
             "confidence": 0.95,
         }
@@ -473,14 +483,25 @@ class TestApplyEnrichmentToCard:
 
         assert card.manufacturer == "Existing Mfr"
 
-    def test_does_not_overwrite_existing_category(self, db_session):
-        """Does not overwrite existing category."""
+    def test_does_not_overwrite_higher_tier_category(self, db_session):
+        """A higher-tier category (manual=100) survives an incoming connector write
+        (mouser_api=90).
+
+        Category routes through spec_tiers.set_category; the manual prior outranks the
+        connector tier and is kept. The seeded value must be canonical (the @validates
+        guard rejects off-vocab assignment), so this also exercises the ladder, not the
+        guard.
+        """
         from app.services.enrichment import _apply_enrichment_to_card
 
-        card = _make_card(db_session, category="Existing Cat")
+        card = _make_card(db_session, category="capacitors")
+        card.category_source = "manual"
+        card.category_confidence = 1.0
+        card.category_tier = 100
+        db_session.flush()
         enrichment = {
             "manufacturer": "TI",
-            "category": "New Cat",
+            "category": "voltage_regulators",  # canonical, but lower tier (mouser_api=90)
             "source": "mouser",
             "confidence": 0.95,
         }
@@ -491,7 +512,7 @@ class TestApplyEnrichmentToCard:
         ):
             _apply_enrichment_to_card(card, enrichment, db_session)
 
-        assert card.category == "Existing Cat"
+        assert card.category == "capacitors"
 
     def test_creates_brand_and_commodity_tags(self, db_session):
         """Creates brand and commodity tags from classification."""

--- a/tests/test_faceted_routes.py
+++ b/tests/test_faceted_routes.py
@@ -84,7 +84,7 @@ def test_faceted_results_returns_materials(client, db_session: Session):
         normalized_mpn="test-001",
         display_mpn="TEST-001",
         manufacturer="TestCo",
-        category="DRAM",
+        category="dram",
         created_at=datetime.now(timezone.utc),
     )
     db_session.add(card)
@@ -429,7 +429,7 @@ def test_faceted_endpoint_currency_aggregate(client, db_session):
         normalized_mpn="eur-test-001",
         display_mpn="EUR-TEST-001",
         manufacturer="EuroCo",
-        category="passive",
+        category="capacitors",
         created_at=datetime.now(timezone.utc),
     )
     db_session.add(card_eur)
@@ -457,7 +457,7 @@ def test_faceted_endpoint_currency_aggregate(client, db_session):
         normalized_mpn="mixed-test-001",
         display_mpn="MIXED-TEST-001",
         manufacturer="MixedCo",
-        category="passive",
+        category="capacitors",
         created_at=datetime.now(timezone.utc),
     )
     db_session.add(card_mixed)
@@ -826,10 +826,13 @@ def test_faceted_spec_chips_without_commodity_use_schema_primaries(client, db_se
 
 def test_faceted_spec_chips_without_commodity_fallback_first_scalars(client, db_session: Session):
     """Cards in a schema-less category fall back to the first 3 scalar spec entries."""
+    # "other" is a canonical commodity key (so it passes the @validates guard) that
+    # carries no CommoditySpecSchema rows — exactly the schema-less shape this fallback
+    # path serves.
     _op_card(
         db_session,
         "chip-fallback",
-        category="widgets",
+        category="other",
         specs_structured={
             "speed_mhz": {"value": 3200},
             "rank": "2R",

--- a/tests/test_faceted_search.py
+++ b/tests/test_faceted_search.py
@@ -16,7 +16,7 @@ class TestFacetedSearchFTS:
             display_mpn="STM32F407VGT6",
             manufacturer="STMicroelectronics",
             description="32-bit ARM Cortex-M4 microcontroller with FPU",
-            category="microcontroller",
+            category="microcontrollers",
         )
         db_session.add(card)
         db_session.commit()
@@ -32,7 +32,7 @@ class TestFacetedSearchFTS:
             normalized_mpn="lm7805ct",
             display_mpn="LM7805CT",
             manufacturer="Texas Instruments",
-            category="voltage_regulator",
+            category="voltage_regulators",
         )
         db_session.add(card)
         db_session.commit()
@@ -51,16 +51,16 @@ class TestFacetedSearchFTS:
         card1 = MaterialCard(
             normalized_mpn="stm32f4",
             display_mpn="STM32F4",
-            category="microcontroller",
+            category="microcontrollers",
         )
         card2 = MaterialCard(
             normalized_mpn="lm7805",
             display_mpn="LM7805",
-            category="voltage_regulator",
+            category="voltage_regulators",
         )
         db_session.add_all([card1, card2])
         db_session.commit()
 
-        results, total = search_materials_faceted(db_session, commodity="microcontroller")
+        results, total = search_materials_faceted(db_session, commodity="microcontrollers")
         assert total == 1
         assert results[0].normalized_mpn == "stm32f4"

--- a/tests/test_faceted_search_service.py
+++ b/tests/test_faceted_search_service.py
@@ -17,7 +17,10 @@ from app.services.faceted_search_service import (
     get_subfilter_options,
     search_materials_faceted,
 )
-from tests.conftest import engine  # noqa: F401
+from tests.conftest import (
+    engine,  # noqa: F401
+    force_card_category,
+)
 
 
 def _seed_dram_schema(db: Session) -> None:
@@ -42,7 +45,7 @@ def _make_dram_card(db: Session, mpn: str, ddr: str, capacity: float, ecc: bool 
         normalized_mpn=mpn.lower(),
         display_mpn=mpn,
         manufacturer="TestCo",
-        category="DRAM",
+        category="dram",
         created_at=datetime.now(timezone.utc),
     )
     db.add(card)
@@ -78,7 +81,7 @@ def test_get_commodity_counts(db_session: Session):
         normalized_mpn="cap-001",
         display_mpn="CAP-001",
         manufacturer="TestCo",
-        category="Capacitors",
+        category="capacitors",
         created_at=datetime.now(timezone.utc),
     )
     db_session.add(cap)
@@ -111,18 +114,21 @@ def test_get_commodity_counts_expression_equivalence(db_session: Session):
         ("Capacitors", None),
         ("DDR4", now),  # soft-deleted — must not be counted
     ]
+    # The whole point of this test is non-canonical case/padding residue (legacy
+    # rows the @validates guard would now reject), so seed the raw values through
+    # force_card_category exactly as a pre-guard writer left them in the DB.
     for i, (category, deleted_at) in enumerate(rows):
-        db_session.add(
-            MaterialCard(
-                normalized_mpn=f"eq-{i:03d}",
-                display_mpn=f"EQ-{i:03d}",
-                manufacturer="TestCo",
-                category=category,
-                created_at=now,
-                deleted_at=deleted_at,
-            )
+        card = MaterialCard(
+            normalized_mpn=f"eq-{i:03d}",
+            display_mpn=f"EQ-{i:03d}",
+            manufacturer="TestCo",
+            created_at=now,
+            deleted_at=deleted_at,
         )
-    db_session.flush()
+        db_session.add(card)
+        db_session.flush()
+        if category is not None:
+            force_card_category(db_session, card, category)
 
     assert get_commodity_counts(db_session) == {"ddr4": 2, "capacitors": 1}
 
@@ -152,7 +158,7 @@ def test_search_materials_faceted_by_commodity(db_session: Session):
         normalized_mpn="cap-001",
         display_mpn="CAP-001",
         manufacturer="TestCo",
-        category="Capacitors",
+        category="capacitors",
         created_at=datetime.now(timezone.utc),
     )
     db_session.add(cap)
@@ -791,20 +797,20 @@ def test_get_commodity_spec_coverage(db_session: Session):
     no_specs = MaterialCard(
         normalized_mpn="cov-002",
         display_mpn="COV-002",
-        category="DRAM",
+        category="dram",
         created_at=datetime.now(timezone.utc),
     )
     deleted = MaterialCard(
         normalized_mpn="cov-003",
         display_mpn="COV-003",
-        category="DRAM",
+        category="dram",
         deleted_at=datetime.now(timezone.utc),
         created_at=datetime.now(timezone.utc),
     )
     other_cat = MaterialCard(
         normalized_mpn="cov-004",
         display_mpn="COV-004",
-        category="Capacitors",
+        category="capacitors",
         created_at=datetime.now(timezone.utc),
     )
     db_session.add_all([no_specs, deleted, other_cat])

--- a/tests/test_htmx_views_nightly6.py
+++ b/tests/test_htmx_views_nightly6.py
@@ -70,7 +70,7 @@ def _make_material_card(db: Session, mpn: str = "LM317T", crosses=None) -> Mater
         normalized_mpn=mpn.lower(),
         display_mpn=mpn,
         manufacturer="Texas Instruments",
-        category="Voltage Regulator",
+        category="voltage_regulators",  # canonical (the @validates guard rejects off-vocab)
         cross_references=crosses,
         created_at=datetime.now(timezone.utc),
     )

--- a/tests/test_jobs_coverage_2.py
+++ b/tests/test_jobs_coverage_2.py
@@ -1915,15 +1915,19 @@ class TestApplyEnrichmentToCard:
         assert card.category == "ics_other"
         mock_tag.assert_called_once()
 
-    def test_does_not_overwrite_existing_manufacturer(self):
+    def test_does_not_overwrite_higher_tier_manufacturer_and_category(self):
         from app.services.enrichment import _apply_enrichment_to_card
 
         card = MagicMock()
         card.manufacturer = "Existing MFR"
-        card.category = "Existing Cat"
-        # Real provenance values: the category now routes through spec_tiers.set_category,
-        # whose ladder math needs concrete tier/confidence (a manual=100 prior outranks
-        # the incoming digikey_api=90, so the category is kept).
+        card.category = "ics_other"  # canonical — both maker and category now route
+        # Real provenance values: manufacturer and category both route through the F1
+        # ladder (set_manufacturer / set_category). A manual=100 prior outranks the
+        # incoming digikey_api=90, so both are kept.
+        card.manufacturer_source = "manual"
+        card.manufacturer_confidence = 1.0
+        card.manufacturer_tier = 100
+        card.manufacturer_updated_at = None
         card.category_source = "manual"
         card.category_confidence = 1.0
         card.category_tier = 100
@@ -1938,9 +1942,9 @@ class TestApplyEnrichmentToCard:
         ):
             _apply_enrichment_to_card(card, enrichment, db)
 
-        # Should NOT overwrite
+        # Should NOT overwrite — manual (100) outranks digikey_api (90)
         assert card.manufacturer == "Existing MFR"
-        assert card.category == "Existing Cat"
+        assert card.category == "ics_other"
 
     def test_no_commodity_tag(self):
         from app.services.enrichment import _apply_enrichment_to_card

--- a/tests/test_phase8_materials.py
+++ b/tests/test_phase8_materials.py
@@ -24,11 +24,13 @@ def material_cards(db_session: Session):
     from app.models.intelligence import MaterialCard
 
     cards = []
+    # Canonical commodity keys (the @validates guard rejects off-vocab); the detail
+    # template renders card.category verbatim, so assertions match these exact strings.
     for mpn, mfr, lifecycle, category, searches in [
-        ("LM317T", "TI", "active", "Voltage Regulator", 42),
-        ("NE555P", "TI", "active", "Timer", 30),
-        ("STM32F103", "STMicro", "eol", "Microcontroller", 15),
-        ("MAX232", "Maxim", "obsolete", "Interface", 5),
+        ("LM317T", "TI", "active", "voltage_regulators", 42),
+        ("NE555P", "TI", "active", "ics_other", 30),
+        ("STM32F103", "STMicro", "eol", "microcontrollers", 15),
+        ("MAX232", "Maxim", "obsolete", "ics_other", 5),
     ]:
         card = MaterialCard(
             normalized_mpn=mpn.lower(),
@@ -146,7 +148,7 @@ class TestMaterialDetail:
         assert resp.status_code == 200
         assert "LM317T" in resp.text
         assert "TI" in resp.text
-        assert "Voltage Regulator" in resp.text
+        assert "voltage_regulators" in resp.text
 
     def test_detail_shows_lifecycle_badge(self, client: TestClient, material_cards):
         card = material_cards[2]  # STM32F103 - EOL
@@ -181,10 +183,12 @@ class TestMaterialUpdate:
     """Tests for updating material card fields."""
 
     def test_update_manufacturer(self, client: TestClient, db_session: Session, material_cards):
-        card = material_cards[0]  # LM317T
+        card = material_cards[0]  # LM317T, seeded category "voltage_regulators"
+        # Post a DIFFERENT canonical category so the ladder records a genuine manual edit
+        # (the route no-ops an unchanged value rather than re-stamping it as manual).
         resp = client.put(
             f"/v2/partials/materials/{card.id}",
-            data={"manufacturer": "Texas Instruments", "category": "voltage_regulators"},
+            data={"manufacturer": "Texas Instruments", "category": "analog_ic"},
         )
         assert resp.status_code == 200
         assert "Texas Instruments" in resp.text
@@ -193,7 +197,7 @@ class TestMaterialUpdate:
         assert card.manufacturer == "Texas Instruments"
         # Category routes through the F1 ladder (set_category) — it lands canonical with
         # manual provenance; off-vocab free text like "Linear Regulator" would be rejected.
-        assert card.category == "voltage_regulators"
+        assert card.category == "analog_ic"
         assert card.category_source == "manual"
 
     def test_update_lifecycle(self, client: TestClient, db_session: Session, material_cards):

--- a/tests/test_quotes_material_card.py
+++ b/tests/test_quotes_material_card.py
@@ -34,7 +34,7 @@ def material_card(db_session: Session) -> MaterialCard:
         display_mpn="LM317T",
         manufacturer="Texas Instruments",
         description="Adjustable Voltage Regulator, 1.5A",
-        category="Semiconductors",
+        category="voltage_regulators",  # canonical (the @validates guard rejects off-vocab)
     )
     db_session.add(mc)
     db_session.commit()
@@ -48,7 +48,7 @@ def material_card_2(db_session: Session) -> MaterialCard:
         display_mpn="NE555P",
         manufacturer="Texas Instruments",
         description="Precision Timer IC",
-        category="Semiconductors",
+        category="voltage_regulators",  # canonical (the @validates guard rejects off-vocab)
     )
     db_session.add(mc)
     db_session.commit()
@@ -117,7 +117,7 @@ def test_quote_to_dict_with_db_enriches_items(db_session, material_card):
     d = quote_to_dict(q, db=db_session)
     assert len(d["line_items"]) == 1
     assert d["line_items"][0]["description"] == "Adjustable Voltage Regulator, 1.5A"
-    assert d["line_items"][0]["category"] == "Semiconductors"
+    assert d["line_items"][0]["category"] == "voltage_regulators"
     assert d["line_items"][0]["mpn"] == "LM317T"
     assert d["line_items"][0]["qty"] == 100
 

--- a/tests/test_reconcile_decoded_facets.py
+++ b/tests/test_reconcile_decoded_facets.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.management.reconcile_decoded_facets import _classify, _facet_matches, reconcile
 from app.models import MaterialCard, MaterialSpecFacet
 from app.services.commodity_registry import seed_commodity_schemas
+from app.services.spec_tiers import tier_for
 from app.services.spec_write_service import record_spec
 
 _OLD_TS = "2026-01-01T00:00:00+00:00"
@@ -39,6 +40,41 @@ def _seed_wrong(db: Session, card: MaterialCard, spec_key: str, value, source: s
     specs = dict(card.specs_structured)
     specs[spec_key] = {**specs[spec_key], "updated_at": _OLD_TS}
     card.specs_structured = specs
+    db.flush()
+
+
+def _seed_legacy_offenum_text(db: Session, card: MaterialCard, spec_key: str, value: str, source: str) -> None:
+    """Seed a text facet whose value is no longer a valid enum member, bypassing
+    record_spec.
+
+    record_spec now rejects off-enum values (e.g. ``gpu_family='RTX'`` after "RTX" left the
+    seeded enum in the trust hotfix), so a legacy bad row can no longer be written through it
+    — yet such rows DO exist in the live DB from before the fix, and correcting them is exactly
+    what the reconcile command is for. This mirrors what a pre-fix record_spec produced (JSONB
+    source-of-truth entry + facet projection), backdated like _seed_wrong, with NO enum gate.
+    """
+    confidence = 0.95 if source == "mpn_decode" else 0.90
+    tier = tier_for(source)
+    specs = dict(card.specs_structured or {})
+    specs[spec_key] = {
+        "value": value,
+        "source": source,
+        "confidence": confidence,
+        "tier": tier,
+        "updated_at": _OLD_TS,
+    }
+    card.specs_structured = specs
+    db.add(
+        MaterialSpecFacet(
+            material_card_id=card.id,
+            category=card.category,
+            spec_key=spec_key,
+            value_text=value,
+            source=source,
+            confidence=confidence,
+            tier=tier,
+        )
+    )
     db.flush()
 
 
@@ -71,7 +107,9 @@ def _seed_audit_cards(db: Session) -> dict[str, MaterialCard]:
     _seed_wrong(db, cards["stmicro"], "capacity_gb", 232, "mpn_decode")
     _seed_wrong(db, cards["seagate"], "capacity_gb", 373207, "mpn_decode")
     _seed_wrong(db, cards["dram"], "capacity_gb", 2, "desc_parse")
-    _seed_wrong(db, cards["gpu"], "gpu_family", "RTX", "desc_parse")
+    # "RTX" left the seeded gpu_family enum (trust hotfix) so record_spec now rejects it;
+    # seed the legacy bad row directly — correcting it is what reconcile is FOR.
+    _seed_legacy_offenum_text(db, cards["gpu"], "gpu_family", "RTX", "desc_parse")
     _seed_wrong(db, cards["modern"], "capacity_gb", 4000, "mpn_decode")
     _seed_wrong(db, cards["wd_rev"], "capacity_gb", 10100, "mpn_decode")
     _seed_wrong(db, cards["seagate_trunc"], "capacity_gb", 120, "mpn_decode")
@@ -315,7 +353,7 @@ def test_facet_matches_no_schema_uses_text_fallback():
 
 
 def test_reconcile_limit_restricts_cards_processed(db_session: Session):
-    """limit=1 causes only the first card to be processed."""
+    """Limit=1 causes only the first card to be processed."""
     seed_commodity_schemas(db_session)
     c1 = _card(db_session, "WD800BB", "hdd")
     c2 = _card(db_session, "WD1200BB", "hdd")
@@ -335,7 +373,8 @@ def test_reconcile_limit_restricts_cards_processed(db_session: Session):
 
 
 def test_reconcile_two_cards_different_categories_loads_schema_cache(db_session: Session):
-    """Each new category triggers a schema_cache load — exercises the cache-miss branch."""
+    """Each new category triggers a schema_cache load — exercises the cache-miss
+    branch."""
     seed_commodity_schemas(db_session)
     hdd_card = _card(db_session, "WD800BB", "hdd")
     dram_card = _card(db_session, "K4B2G1646F", "dram", "Mem, DDR3, 2Gb, 128*16, Samsung")
@@ -353,8 +392,8 @@ def test_reconcile_two_cards_different_categories_loads_schema_cache(db_session:
 
 
 def test_reconcile_savepoint_rolls_back_on_record_spec_failure(db_session: Session, monkeypatch):
-    """When record_spec raises inside apply mode the savepoint is rolled back and
-    the card is counted as failed (lines 231-234, 240-242)."""
+    """When record_spec raises inside apply mode the savepoint is rolled back and the
+    card is counted as failed (lines 231-234, 240-242)."""
     seed_commodity_schemas(db_session)
     card = _card(db_session, "WD800BB", "hdd")
     _seed_wrong(db_session, card, "capacity_gb", 80000, "mpn_decode")
@@ -378,7 +417,8 @@ def test_reconcile_savepoint_rolls_back_on_record_spec_failure(db_session: Sessi
 
 
 def test_reconcile_outer_exception_counted_as_failed(db_session: Session, monkeypatch):
-    """When db.get raises for a card_id the outer handler increments totals['failed']."""
+    """When db.get raises for a card_id the outer handler increments
+    totals['failed']."""
     seed_commodity_schemas(db_session)
     card = _card(db_session, "WD800BB", "hdd")
     _seed_wrong(db_session, card, "capacity_gb", 80000, "mpn_decode")
@@ -401,7 +441,7 @@ def test_reconcile_outer_exception_counted_as_failed(db_session: Session, monkey
 
 
 def test_reconcile_main_dry_run(db_session: Session, monkeypatch):
-    """main() with no --apply calls reconcile(apply=False) and then rollback."""
+    """Main() with no --apply calls reconcile(apply=False) and then rollback."""
 
     from app.management import reconcile_decoded_facets as mod
 
@@ -452,7 +492,7 @@ def test_reconcile_main_dry_run(db_session: Session, monkeypatch):
 
 
 def test_reconcile_main_apply(db_session: Session, monkeypatch):
-    """main() with --apply calls reconcile(apply=True) and skips rollback."""
+    """Main() with --apply calls reconcile(apply=True) and skips rollback."""
     from app.management import reconcile_decoded_facets as mod
 
     reconcile_calls: list[dict] = []

--- a/tests/test_routers_materials.py
+++ b/tests/test_routers_materials.py
@@ -227,7 +227,7 @@ def test_material_card_to_dict_enrichment_fields(db_session):
         manufacturer="TI",
         lifecycle_status="active",
         package_type="QFP-64",
-        category="Microcontroller",
+        category="microcontrollers",  # canonical (the @validates guard rejects off-vocab)
         rohs_status="compliant",
         pin_count=64,
         datasheet_url="https://ti.com/ds.pdf",

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -3126,15 +3126,15 @@ class TestUpsertMaterialCardTagClassification:
         now = datetime.now(timezone.utc)
 
         # Commodity tags are pre-seeded (get_or_create_commodity_tag never
-        # creates them) — seed the one "Voltage Regulators" maps to.
-        db_session.add(Tag(name="Power Management ICs", tag_type="commodity", created_at=datetime.now(timezone.utc)))
-        # Pre-create the card with a manufacturer AND a category so the
-        # commodity branch (result["commodity"]) is exercised.
+        # creates them) — seed the one the canonical "dram" category maps to.
+        db_session.add(Tag(name="Memory ICs", tag_type="commodity", created_at=datetime.now(timezone.utc)))
+        # Pre-create the card with a manufacturer AND a canonical category (the @validates
+        # guard rejects off-vocab) so the commodity branch (result["commodity"]) is exercised.
         card = MaterialCard(
             normalized_mpn="lm317t",
             display_mpn="LM317T",
             manufacturer="Texas Instruments",
-            category="Voltage Regulators",
+            category="dram",
             search_count=0,
         )
         db_session.add(card)

--- a/tests/test_services_coverage_2.py
+++ b/tests/test_services_coverage_2.py
@@ -1204,9 +1204,10 @@ class TestReenrich:
 
         mock_enrich.return_value = {"enriched": 1}
 
-        # Set specs_structured and category on the card
+        # Set specs_structured and a canonical category (the @validates guard rejects
+        # off-vocab) on the card.
         test_material_card.specs_structured = {"voltage": {"value": "3.3V"}}
-        test_material_card.category = "semiconductor"
+        test_material_card.category = "ics_other"
         db_session.commit()
 
         with patch("app.database.SessionLocal", return_value=db_session):
@@ -1243,7 +1244,7 @@ class TestReenrich:
         mock_enrich.return_value = {"enriched": 1}
 
         test_material_card.specs_structured = {"voltage": "3.3V"}
-        test_material_card.category = "ic"
+        test_material_card.category = "ics_other"  # canonical (off-vocab is rejected by @validates)
         db_session.commit()
 
         with patch("app.database.SessionLocal", return_value=db_session):

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -1417,7 +1417,7 @@ class TestEnrichmentBar:
             normalized_mpn="test-mpn-001",
             display_mpn="TEST-MPN-001",
             lifecycle_status="active",
-            category="Microcontroller",
+            category="microcontrollers",  # canonical (the @validates guard rejects off-vocab)
             rohs_status="compliant",
         )
         db_session.add(mc)
@@ -1438,7 +1438,7 @@ class TestEnrichmentBar:
             normalized_mpn="test-mpn-001",
             display_mpn="TEST-MPN-001",
             lifecycle_status="eol",
-            category="Memory",
+            category="dram",  # canonical (the @validates guard rejects off-vocab)
         )
         db_session.add(mc)
         db_session.flush()

--- a/tests/test_spec_enrichment_service.py
+++ b/tests/test_spec_enrichment_service.py
@@ -168,7 +168,7 @@ async def test_skips_card_without_description_or_schema(db: Session, _schemas):
     from app.services.spec_enrichment_service import enrich_card_specs
 
     no_desc = _mc(db, "NODESC", description=None)
-    no_schema = _mc(db, "NOSCHEMA", category="not_a_real_commodity")  # absent from commodity_seeds
+    no_schema = _mc(db, "NOSCHEMA", category="ics_other")  # canonical coarse bucket — no spec schema
     with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value={"parts": []}):
         stats = await enrich_card_specs([no_desc.id, no_schema.id], db)
     assert stats["skipped_no_schema"] == 1  # the schema-less card

--- a/tests/test_spec_tiers.py
+++ b/tests/test_spec_tiers.py
@@ -642,3 +642,41 @@ def test_set_category_non_manual_rejection_logs_at_info(db_session: Session):
         assert not card2.has_validation_conflict  # no conflict entry — INFO is the only trace
     finally:
         loguru_logger.remove(sink_id)
+
+
+# --- @validates("category") guard (SP3 ladder hardening) --------------------
+# The guard on MaterialCard.category (app/models/intelligence.py) rejects any off-vocab
+# direct assignment, so a future un-routed writer can no longer persist junk past the F1
+# ladder. set_category (the single routed writer) only ever assigns canonical keys, so it
+# passes the guard untouched; these pin the guard's contract directly.
+
+
+class TestCategoryValidatesGuard:
+    def test_canonical_key_assignment_passes(self, db_session: Session):
+        card = _card(db_session, normalized_mpn="guard-ok", category="dram")
+        assert card.category == "dram"
+
+    def test_none_assignment_passes(self, db_session: Session):
+        card = _card(db_session, normalized_mpn="guard-none", category=None)
+        card.category = None
+        assert card.category is None
+
+    def test_off_vocab_assignment_raises(self, db_session: Session):
+        import pytest
+
+        card = _card(db_session, normalized_mpn="guard-bad", category=None)
+        with pytest.raises(ValueError, match="canonical commodity key or None"):
+            card.category = "IGBT Modules"  # the pre-#267 bypass-writer junk class
+
+    def test_off_vocab_at_construction_raises(self, db_session: Session):
+        import pytest
+
+        with pytest.raises(ValueError, match="canonical commodity key or None"):
+            MaterialCard(normalized_mpn="guard-ctor", display_mpn="GUARD-CTOR", category="Voltage Regulator")
+
+    def test_set_category_canonical_value_passes_the_guard(self, db_session: Session):
+        # The routed writer normalizes "IC" → canonical "ics_other" before assigning, so it
+        # never trips the guard (the guard hardens OTHER paths, never the ladder).
+        card = _card(db_session, normalized_mpn="guard-routed", category=None)
+        assert set_category(card, "IC", "digikey_api", 0.9) is True
+        assert card.category == "ics_other"

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1201,15 +1201,22 @@ class TestWarnNonCanonicalCategories:
     def test_warns_with_count_and_samples(self, db_session):
         from app.models import MaterialCard
         from app.startup import _warn_non_canonical_categories
+        from tests.conftest import force_card_category
 
-        db_session.add_all(
-            [
-                MaterialCard(normalized_mpn="res-1", display_mpn="RES-1", category="Totally Unknown Category"),
-                MaterialCard(normalized_mpn="res-2", display_mpn="RES-2", category="  Totally Unknown Category "),
-                MaterialCard(normalized_mpn="res-3", display_mpn="RES-3", category="ssd"),  # canonical — not residue
-                MaterialCard(normalized_mpn="res-4", display_mpn="RES-4", category=None),  # NULL — not residue
-            ]
-        )
+        # The non-canonical rows are exactly the legacy residue the @validates guard now
+        # rejects on assignment, so seed them through force_card_category (Core UPDATE) as
+        # a pre-guard writer would have left them — this warning's whole job is to surface
+        # them. Canonical + NULL rows go through the normal constructor.
+        canonical = MaterialCard(normalized_mpn="res-3", display_mpn="RES-3", category="ssd")  # not residue
+        null_cat = MaterialCard(normalized_mpn="res-4", display_mpn="RES-4", category=None)  # not residue
+        residue = [
+            MaterialCard(normalized_mpn="res-1", display_mpn="RES-1"),
+            MaterialCard(normalized_mpn="res-2", display_mpn="RES-2"),
+        ]
+        db_session.add_all([canonical, null_cat, *residue])
+        db_session.flush()
+        force_card_category(db_session, residue[0], "Totally Unknown Category")
+        force_card_category(db_session, residue[1], "  Totally Unknown Category ")
         db_session.flush()
 
         warnings = self._capture_warnings(lambda: _warn_non_canonical_categories(db_session))

--- a/tests/test_tagging_backfill.py
+++ b/tests/test_tagging_backfill.py
@@ -71,7 +71,9 @@ def test_seed_skips_empty_manufacturer(db_session):
 
 def test_seed_with_category(db_session):
     _seed_commodity_tags(db_session)
-    _make_card(db_session, "LM317T", manufacturer="TI", category="Voltage Regulator")
+    # Canonical category (the @validates guard rejects off-vocab); "microcontrollers"
+    # maps to the seeded "Microcontrollers (MCU)" commodity tag.
+    _make_card(db_session, "STM32F103", manufacturer="ST", category="microcontrollers")
 
     result = seed_from_existing_manufacturers(db_session)
     assert result["total_seeded"] == 1

--- a/tests/test_vendor_affinity_coverage.py
+++ b/tests/test_vendor_affinity_coverage.py
@@ -28,7 +28,7 @@ def material_card(db_session: Session) -> MaterialCard:
         normalized_mpn="lm317t",
         display_mpn="LM317T",
         manufacturer="Texas Instruments",
-        category="Voltage Regulator",
+        category="voltage_regulators",  # canonical (the @validates guard rejects off-vocab)
         created_at=datetime.now(timezone.utc),
     )
     db_session.add(card)


### PR DESCRIPTION
## What & why

Stop-the-bleeding **data-trust** fixes for the materials enrichment system. The catalog had accumulated off-vocab junk categories (61 NULL-provenance junk strings like "IGBT Modules", plus ~139 provenanced cards on ~89 non-canonical strings) and documented-wrong facet values because some writers bypassed the F1 category/spec ladder. This PR closes the root-cause holes so junk can no longer be written, and ships a one-shot command to remediate what's already there.

## Engineering changes

### `@validates("category")` guard (the root-cause fix) — `app/models/intelligence.py`
Only `NULL` or a **canonical commodity key** may be assigned to `MaterialCard.category`. An off-vocab direct assignment now **raises `ValueError`** instead of silently bypassing `spec_tiers.set_category` and persisting junk with stale provenance columns.

Rationale: `set_category` (in `spec_tiers`) is the single routed writer and only ever assigns canonical keys, so it passes the guard untouched. The guard catches any *future un-routed writer* — the exact class of bug (pre-#267 bypass writers) that minted the 61 junk categories. The guard's vocabulary is the single frozen `commodity_registry.CANONICAL_COMMODITY_KEYS`, **shared** with `category_normalizer`, so the guard and the normalizer can never drift apart.

### Last bypass-writer closed — `app/services/enrichment.py`
`_apply_enrichment_to_card` now routes **manufacturer** through `spec_tiers.set_manufacturer` (was a fill-when-NULL direct write that left NULL provenance ranking at the legacy floor). The ladder monopoly for category **and** manufacturer writers is now complete — a connector maker now displaces a legacy NULL-provenance value (50 < 90) instead of only filling an empty one, and never overwrites a higher-tier (manual/100, trio_source/95) value.

### GPU description-decode — `app/data/commodity_seeds.json` + `app/services/desc_extractor/gpu.py`
Removed `"RTX"` from the seeded `gpu_family` enum — it re-fragmented one physical family across two facet values (audit cards 583761 vs 560385). The extractor now maps consumer RTX models (x050–x090) to **GeForce** and emits **no family** for the professional Quadro-successor line (RTX A2000, RTX 4000 Ada) or bare context-less RTX tokens (a wrong family is worse than a missing one).

### Cleanup command — `app/management/cleanup_known_bad.py` (new)
**Dry-run by default; `--apply` writes.** Three idempotent passes:
1. **Delete** the two documented-wrong facet rows (FRU-matrix `capacity_gb=373,455` and the hdd `capacity_gb=973,452` outlier), matched by **content** not row id, dropping the `specs_structured` JSONB mirror only when its source agrees.
2. **Normalize-or-null** every non-canonical `category`: resolvable values route through `set_category` at `legacy_backfill` when unprovenanced, or are canonicalized in place (source preserved, stale facets purged) when provenanced; unresolvable values are nulled with provenance cleared.
3. **Stamp** `manufacturer_source='legacy_backfill'` (conf 0.5, tier 50) on cards with a maker but NULL provenance (attribution of existing data, NOT a ladder write; `manufacturer_updated_at` stays NULL).

One `MaterialCardAudit` row per changed card (`facet_cleanup` / `category_cleanup`).

**How to run (post-deploy, admin CLI):**
```bash
python -m app.management.cleanup_known_bad            # dry-run — prints what WOULD change, rolls back
python -m app.management.cleanup_known_bad --apply    # writes (ensure a recent db-backup exists)
```

## Tests

- **New** `tests/test_cleanup_known_bad.py` — all three passes, dry-run + apply, mirror-drift handling, audit trail, `main()` rollback.
- **New** `TestCategoryValidatesGuard` in `tests/test_spec_tiers.py` — guard accepts canonical/NULL, rejects off-vocab at assignment AND construction, `set_category` still passes through.
- **New** `conftest.force_card_category` helper — seeds legacy off-vocab categories via a Core `UPDATE` (bypassing the ORM guard) exactly as a pre-guard writer left them. Used by every test that legitimately exercises residue (faceted bucketing, startup residue warning, coverage report, cleanup command, reconcile).
- **Test-fixture updates (root-cause, not masking):** the guard correctly rejected ~18 test files whose fixtures passed non-canonical category strings; those fixtures now use canonical commodity vocabulary. The enrichment-apply tests were updated to the new ladder semantics (manufacturer displaces NULL-provenance; higher-tier priors are kept — not "fill-when-NULL"). The reconcile test seeds the legacy `gpu_family="RTX"` facet directly (since `record_spec` now rejects it) so the command can still be verified correcting it. **No tests were skipped, xfailed, or deleted to reach green.**

Full suite: **16325 passed, 35 skipped, 1 xfailed — 0 failed, 0 errors.** `pre-commit` clean on changed files.

## Docs
`docs/APP_MAP_INTERACTIONS.md` updated for the live `@validates` guard, the completed ladder monopoly, the GPU/RTX enum removal, and the `cleanup_known_bad` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)