### PR TITLE
feat(materials): categorize uncategorized cards from descriptions (desc_parse/83)

### DIFF
--- a/app/management/categorize_from_desc.py
+++ b/app/management/categorize_from_desc.py
@@ -1,0 +1,247 @@
+"""One-shot categorize-from-description channel (OPTIMIZATION_PLAN §2.4).
+
+What: Categorizes UNCATEGORIZED material cards from their human descriptions using the
+      shared lead-token grammar (desc_extractor.categorizer.categorize_from_desc), then
+      immediately fills the freshly-categorized card's desc_parse facets — each becomes
+      food for the existing extractor by definition (real descriptions). Two channels:
+        * OWN-DESC: cards with a REAL description (alphanumeric-normalized description !=
+          display_mpn, length >= 15) — categorized + faceted at desc_parse / tier 83.
+        * FRU-DESC: cards still uncategorized AND with no usable own description, but whose
+          linked fru_links row carries a usable description — categorized + faceted at
+          fru_desc_parse / tier 82 (a one-hop FRU prose, ranks just below the own-desc
+          channel, per spec_tiers.SOURCE_TIER).
+      Every category write goes through the F1 ladder (spec_tiers.set_category) and ONLY
+      when card.category IS NULL (the ladder + the IS NULL pre-filter both enforce
+      fill-only — never reclassify). One MaterialCardAudit row per categorized card.
+Usage: python -m app.management.categorize_from_desc [--apply] [--limit N]
+      Dry-run by default: prints a yield report (cards that WOULD categorize, broken down
+      by resulting category, per channel) and writes NOTHING. --apply commits.
+Called by: admin manually (the orchestrator runs --apply during the deploy phase).
+Depends on: desc_extractor.writer.categorize_and_record, desc_extractor.categorizer
+      (dry-run yield), spec_tiers (tier constants), audit_service.log_audit,
+      MaterialCard + FruLink, app.database.SessionLocal.
+"""
+
+import argparse
+import re
+from collections import Counter
+
+from loguru import logger
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard
+from app.models.fru_link import FruLink
+from app.services.audit_service import log_audit
+from app.services.desc_extractor._common import DESC_CONFIDENCE, DESC_SOURCE
+from app.services.desc_extractor.categorizer import categorize_from_desc
+from app.services.desc_extractor.writer import categorize_and_record
+from app.services.spec_tiers import SOURCE_TIER
+
+# FRU-linked descriptions are a ONE-HOP prose (the FRU's row, not the card's own
+# description), so they write at fru_desc_parse / tier 82 — strictly below the own-desc
+# channel (desc_parse / 83), exactly the ranking spec_tiers.SOURCE_TIER assigns.
+FRU_DESC_SOURCE = "fru_desc_parse"
+FRU_DESC_CONFIDENCE = DESC_CONFIDENCE
+
+# A "REAL" description (the spec's gate): its alphanumeric-normalized form differs from
+# the alphanumeric-normalized display_mpn AND is at least this long. The ~39k cards whose
+# description IS just the MPN carry zero extractable signal and are excluded.
+MIN_REAL_DESC_LEN = 15
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def _alnum_norm(text: str | None) -> str:
+    """Lower-cased, alphanumeric-only form — for the desc-vs-MPN comparison + length
+    gate (so "00AR327" == "00AR327 " == "00-AR-327" and a description that is just the
+    MPN with punctuation/spacing noise is recognized as NOT a real description)."""
+    if not text:
+        return ""
+    return _NON_ALNUM.sub("", text.lower())
+
+
+def _has_real_own_desc(card: MaterialCard) -> bool:
+    """True iff *card*'s OWN description is a real description (not the MPN, len >=
+    15)."""
+    norm = _alnum_norm(card.description)
+    return len(norm) >= MIN_REAL_DESC_LEN and norm != _alnum_norm(card.display_mpn)
+
+
+def _fru_description_for(db: Session, card: MaterialCard) -> str | None:
+    """A usable linked-FRU description for *card*, or None.
+
+    The card's ``normalized_mpn`` matches a FRU edge as either the FRU or the related part;
+    return the first non-empty FRU description that is itself "real" (len >= 15, != the
+    card's MPN — a FRU row echoing the bare PN is no signal). Deterministic order (by id)
+    so the run is reproducible.
+    """
+    mpn_norm = card.normalized_mpn
+    rows = (
+        db.execute(
+            select(FruLink.description)
+            .where(
+                or_(FruLink.fru_norm == mpn_norm, FruLink.related_norm == mpn_norm),
+                FruLink.description.isnot(None),
+            )
+            .order_by(FruLink.id)
+            .limit(50)
+        )
+        .scalars()
+        .all()
+    )
+    mpn_alnum = _alnum_norm(card.display_mpn)
+    for desc in rows:
+        norm = _alnum_norm(desc)
+        if len(norm) >= MIN_REAL_DESC_LEN and norm != mpn_alnum:
+            return desc
+    return None
+
+
+def _select_uncategorized(db: Session, limit: int) -> list[MaterialCard]:
+    """Active, uncategorized cards — ordered by id for a reproducible run.
+
+    The own-desc / fru-desc split is decided per card below (the own-desc gate needs the
+    alphanumeric comparison, and the fru-desc lookup is a join), so this returns ALL
+    uncategorized cards and the channel routing happens in ``run``.
+    """
+    query = (
+        db.query(MaterialCard)
+        .filter(MaterialCard.category.is_(None), MaterialCard.deleted_at.is_(None))
+        .order_by(MaterialCard.id)
+    )
+    if limit:
+        query = query.limit(limit)
+    return query.all()
+
+
+def run(db: Session, *, apply: bool = False, limit: int = 0) -> dict:
+    """Categorize uncategorized cards from their (own or linked-FRU) descriptions.
+
+    Dry-run (default) computes the same channel routing + grammar verdict apply-mode uses
+    and writes NOTHING — the yield is what WOULD categorize. --apply runs
+    categorize_and_record (own-desc at desc_parse/83, fru-desc at fru_desc_parse/82) inside
+    its per-card SAVEPOINT, logs a MaterialCardAudit row per categorized card, and commits.
+
+    Returns a tally dict: per-channel counts, per-resulting-category breakdown, specs
+    written, and skip/fail counts.
+    """
+    cards = _select_uncategorized(db, limit)
+
+    by_category: Counter = Counter()
+    by_channel: Counter = Counter()
+    totals: Counter = Counter()
+    specs_written = 0
+
+    for card in cards:
+        try:
+            if _has_real_own_desc(card):
+                channel, source, confidence, description = "own_desc", DESC_SOURCE, DESC_CONFIDENCE, card.description
+            else:
+                fru_desc = _fru_description_for(db, card)
+                if fru_desc is None:
+                    totals["skipped_no_desc"] += 1
+                    continue
+                channel, source, confidence, description = "fru_desc", FRU_DESC_SOURCE, FRU_DESC_CONFIDENCE, fru_desc
+
+            if apply:
+                categorized, written = categorize_and_record(
+                    db, card, description=description, source=source, confidence=confidence
+                )
+                if categorized:
+                    log_audit(
+                        db,
+                        material_card_id=card.id,
+                        action="categorized",
+                        normalized_mpn=card.normalized_mpn,
+                        details={
+                            "category": card.category,
+                            "source": source,
+                            "tier": SOURCE_TIER[source],
+                            "channel": channel,
+                            "specs_written": written,
+                        },
+                        created_by="categorize_from_desc",
+                    )
+            else:
+                # Read-only twin: the grammar verdict is the same set_category WOULD attempt
+                # (existing category IS NULL, so the ladder always lets a canonical key win).
+                commodity = categorize_from_desc(description)
+                categorized, written = (commodity is not None), 0
+                if categorized:
+                    card.category = commodity  # transient only — db.rollback() in main()
+
+            if categorized:
+                by_category[card.category] += 1
+                by_channel[channel] += 1
+                totals["categorized"] += 1
+                specs_written += written
+            else:
+                totals["no_grammar_match"] += 1
+        except Exception:
+            totals["failed"] += 1
+            logger.exception("categorize-from-desc: failed on card_id={}", card.id)
+
+    if apply:
+        db.commit()
+
+    summary = {
+        "mode": "apply" if apply else "dry-run",
+        "cards_examined": len(cards),
+        "categorized": totals["categorized"],
+        "specs_written": specs_written,
+        "no_grammar_match": totals["no_grammar_match"],
+        "skipped_no_desc": totals["skipped_no_desc"],
+        "failed": totals["failed"],
+        "by_channel": dict(by_channel),
+        "by_category": dict(by_category.most_common()),
+    }
+    logger.info("categorize-from-desc [{}]: {}", summary["mode"], summary)
+    return summary
+
+
+def _print_report(summary: dict) -> None:
+    """Human-readable yield report (dry-run) / outcome report (apply)."""
+    logger.info("=" * 60)
+    logger.info("categorize-from-desc [{}]", summary["mode"])
+    logger.info("  cards examined .... {}", summary["cards_examined"])
+    logger.info("  categorized ....... {}", summary["categorized"])
+    logger.info("  specs written ..... {}", summary["specs_written"])
+    logger.info("  no grammar match .. {}", summary["no_grammar_match"])
+    logger.info("  skipped (no desc).. {}", summary["skipped_no_desc"])
+    logger.info("  failed ............ {}", summary["failed"])
+    logger.info("  by channel: {}", summary["by_channel"])
+    logger.info("  by resulting category:")
+    for category, count in summary["by_category"].items():
+        logger.info("    {:<18} {}", category, count)
+    logger.info("=" * 60)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Categorize uncategorized material cards from their descriptions (desc_parse/83 + fru_desc_parse/82)"
+    )
+    parser.add_argument("--apply", action="store_true", help="Write the categories + facets (default: dry-run)")
+    parser.add_argument("--limit", type=int, default=0, help="Max uncategorized cards to examine (0 = all)")
+    args = parser.parse_args()
+
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        if args.apply:
+            logger.warning(
+                "categorize-from-desc: --apply writes categories + facets for uncategorized cards "
+                "(desc_parse/83 + fru_desc_parse/82) — ensure a recent db-backup exists "
+                "(pg_dump runs every 6h; scripts/restore.sh to roll back)"
+            )
+        summary = run(db, apply=args.apply, limit=args.limit)
+        if not args.apply:
+            db.rollback()  # belt-and-braces: dry-run leaves no writes behind
+        _print_report(summary)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/services/desc_extractor/categorizer.py
+++ b/app/services/desc_extractor/categorizer.py
@@ -1,0 +1,144 @@
+"""Grammar-gated category inference from a human description (the CATEGORIZE stage).
+
+What: ``categorize_from_desc`` reads a strict commodity *lead/body grammar* out of a
+      TRIO description and returns the canonical commodity KEY it unambiguously names
+      (``hdd``/``ssd``/``dram``/``cpu``/``power_supplies``/``displays``/``tape_drives``/
+      ``gpu``/``motherboards``/``cables``/``batteries``/``fans_cooling``) — or ``None``
+      when nothing is safe to say. It exists so an UNCATEGORIZED card can be categorized
+      from its own description before the spec extractors run (they require a category).
+      Same discipline as the spec extractors (desc_extractor/__init__.py): a foreign
+      lead suppresses, conflicting signals return None, "a wrong facet is worse than a
+      missing one" — here, "a wrong CATEGORY is worse than a missing one".
+
+      The nine SPEC_COMMODITIES are routed by reusing ``extract_desc``'s own lead/body/
+      contradiction machinery (no second grammar to drift): ``extract_desc(description)``
+      with NO hint returns a DescResult whose ``commodity`` IS the routing verdict, and
+      it already encodes every foreign-lead / packaging-lead / storage×dram-conflict /
+      CPU-pollution rule. For ``cpu`` we additionally require an explicit CPU-identity
+      token (Xeon / Core iN / Ryzen / EPYC / model string / "PROCESSOR" lead — the plan's
+      ``CPU + Xeon/Core/Ryzen`` gate) so a bare ``CPU,`` lead on a non-CPU spare never
+      mints the heavily-polluted cpu category.
+
+      The three categories ``extract_desc`` does NOT handle (cables / batteries /
+      fans_cooling) have their own conservative ANCHORED lead grammars with explicit
+      pollution suppression (e.g. "BATTERY MANAGEMENT" ICs are NOT batteries). They are
+      checked first and only fire on a start-of-string lead, so an "…ANTENNA CABLE"
+      buried inside another commodity's row never routes here.
+
+Called by: app/services/desc_extractor/writer.py (categorize_and_record — the CATEGORIZE
+      stage), app/management/categorize_from_desc.py (the one-shot CLI),
+      app/services/source_ingest/clean.py (ingest-time fallback when the source carries
+      no mappable category — single source of truth for the grammar).
+Depends on: desc_extractor.extract_desc (the spec-commodity router) only. Pure — no DB,
+      no network, no LLM.
+"""
+
+import re
+
+from app.services.desc_extractor import extract_desc
+
+# Whitespace / Excel-CR normalization mirrors extract_desc so the lead anchors line up
+# ("CABLE,\n…", "BATTERY_x000D_…"). Upper-cased once; the new-category grammars below are
+# all anchored, case-folded shapes.
+_WS = re.compile(r"\s+")
+_X000D = re.compile(r"_x000[dD]_")
+
+# CPU-IDENTITY gate (the plan's ``CPU/PROCESSOR + Xeon/Core/Ryzen`` rule): a bare
+# ``CPU,``/``PROCESSOR,`` lead is NOT enough to mint the ~14%-polluted cpu category — the
+# description must carry an explicit CPU family word or model string (Intel Core iN /
+# Xeon / AMD Ryzen / EPYC / Threadripper / Atom / Itanium / Opteron / Pentium / Celeron /
+# Athlon, an E3/E5/E7 or Core-iN model number, or a Scalable Gold/Silver/Platinum/Bronze
+# 3-9xxx). The bare word "PROCESSOR" alone qualifies (TRIO's own commodity label), but
+# "CPU"/"PROC" alone do NOT — those are the polluted leads. extract_desc has already
+# applied its own is_cpu_pollution deny-list, so this is the second, stricter gate.
+# NB: the model-number alternatives carry NO trailing ``\b`` — Xeon V-suffix shapes
+# ("E5-2650L", "E5-2650 V4") and trailing-letter Core SKUs ("I7-7700HQ") would fail a
+# closing word boundary. This mirrors ``__init__._CPU_WEAK`` exactly.
+_CPU_IDENTITY = re.compile(
+    r"\bPROCESSOR\b|\bXEON\b|\bEPYC\b|\bRYZEN\b|\bTHREADRIPPER\b|\bATOM\b"
+    r"|\bITANIUM ?2?\b|\bOPTERON\b|\bPENTIUM\b|\bCELERON\b|\bATHLON\b"
+    r"|\bCORE ?I[3579]\b|\bI[3579]-\d{4,5}|\bE[357]-?\d{4}"
+    r"|\b(?:GOLD|SILVER|PLATINUM|BRONZE)[ -]?[3-9]\d{3}[A-VX-Z]?\b"
+)
+
+# ── cables ───────────────────────────────────────────────────────────────────
+# Lead "CABLE,"/"CABLE "/"CBL," is the TRIO commodity label and is unambiguous: the
+# corpus's CABLE-led rows are genuine cables (LVDS / USB / QSFP / power cords). Anchored
+# at the start ONLY — a trailing "…ANTENNA CABLE" inside another commodity's row leads
+# with its own commodity, so it never routes here.
+_CABLE_LEAD = re.compile(r"^(?:CABLE|CBL)\b")
+
+# ── fans / cooling ─────────────────────────────────────────────────────────────
+# Lead FAN/HEATSINK/HEAT SINK/HSF/BLOWER → fans_cooling. The corpus's FAN-/HEATSINK-led
+# rows are blowers, heatsink-fan assemblies, thermal modules — all fans_cooling. A bare
+# "HEAT SINK," with no fan is still thermal-cooling hardware in this bucket.
+_FAN_LEAD = re.compile(r"^(?:FAN|HEATSINK|HEAT SINK|HSF|BLOWER)\b")
+
+# ── batteries ──────────────────────────────────────────────────────────────────
+# Lead BATTERY/BATT/BTRY → batteries, EXCEPT the "BATTERY MANAGEMENT"/gas-gauge IC class
+# (BQ40Z50 / LTC6803 fuel-gauge / stack-monitor ICs describe themselves as "BATTERY
+# MANAGEMENT …" — a chip, not a battery). Suppress that shape; everything else
+# BATTERY-led (cells, UPS lead-acid, NVRAM cache batteries, laptop packs) categorizes.
+_BATTERY_LEAD = re.compile(r"^(?:BATTERY|BATT|BTRY)\b")
+_BATTERY_POLLUTION = re.compile(r"\bBATTERY MANAGEMENT\b|\bGAS GAUGE\b|\bFUEL GAUGE\b|\bSTACK MONITOR\b")
+
+# New categories not handled by extract_desc, in suppression-aware match order. cables is
+# checked before fans/batteries so the rare "CABLE … FAN" lead row stays a cable.
+_NEW_CATEGORY_LEADS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("cables", _CABLE_LEAD),
+    ("fans_cooling", _FAN_LEAD),
+    ("batteries", _BATTERY_LEAD),
+)
+
+
+def _norm(description: str) -> str:
+    """Upper-cased, Excel-CR-scrubbed, whitespace-collapsed text — the shape the
+    anchored new-category lead grammars match against (mirrors extract_desc's own
+    normalization so a lead lines up identically in both stages)."""
+    text = _X000D.sub(" ", description)
+    return _WS.sub(" ", text).strip().upper()
+
+
+def categorize_from_desc(description: str | None) -> str | None:
+    """Return the canonical commodity key a description unambiguously names, or None.
+
+    Routing order:
+      1. The three categories ``extract_desc`` does not cover (cables / batteries /
+         fans_cooling) via their own ANCHORED lead grammars + pollution suppression.
+      2. Everything else delegates to ``extract_desc(description)`` (NO hint) and uses the
+         returned ``commodity`` — which already encodes the foreign-lead, packaging-lead,
+         storage×dram-conflict and CPU-pollution rules. For ``cpu`` the result is gated a
+         SECOND time on an explicit CPU-identity token so a bare ``CPU,`` spare row is not
+         categorized.
+
+    Conservative by construction: anything that does not anchor a known lead and does not
+    yield an extract_desc commodity returns None (the card stays uncategorized — a wrong
+    category is worse than a missing one). The returned key is always a canonical
+    commodity_seeds key, so set_category's normalize_category never drops it as off-vocab.
+    """
+    if not description:
+        return None
+    text = _norm(description)
+    if not text:
+        return None
+
+    # 1. New-category anchored leads (extract_desc has no grammar for these).
+    for commodity, lead in _NEW_CATEGORY_LEADS:
+        if lead.match(text):
+            if commodity == "batteries" and _BATTERY_POLLUTION.search(text):
+                return None  # "BATTERY MANAGEMENT" IC, not a battery — never categorize
+            return commodity
+
+    # 2. The nine SPEC_COMMODITIES via extract_desc's own router (no hint → pure routing).
+    result = extract_desc(description)
+    if result is None:
+        return None
+    if result.commodity == "cpu" and not _CPU_IDENTITY.search(text):
+        # extract_desc routed cpu (a CPU/PROC body token or _CPU_WEAK family word), but
+        # the stricter categorize gate needs explicit CPU identity — a bare "CPU," spare
+        # with no Xeon/Core/Ryzen/model string is not safe to mint as cpu.
+        return None
+    return result.commodity
+
+
+__all__ = ["categorize_from_desc"]

--- a/app/services/desc_extractor/writer.py
+++ b/app/services/desc_extractor/writer.py
@@ -6,17 +6,27 @@ F1 tier ladder (app/services/spec_tiers.py) arbitrates every write — desc_pars
 tier 83, so it can never overwrite an mpn_decode (85) / vendor-API (90) / trio_source
 (95) value and always beats AI spec_extraction (60), regardless of which pass ran
 first. (The old per-writer confidence pre-gate is gone — the ladder owns arbitration.)
-Unlike mpn_decoder/writer.py this NEVER writes a category: descriptions are not a
-regex-gated commodity proof, so only cards already categorized to a handled
-commodity (SPEC_COMMODITIES: hdd/ssd/dram/power_supplies/displays/tape_drives/gpu/
-motherboards/cpu — the spec'd _HANDLED set) are processed (record_spec requires a
-category anyway). The phase-2/3 commodities have no MPN decoders, so desc_parse
-is their top non-vendor source by confidence. Does not commit — the caller manages
-the txn.
 
-Called by: app/services/enrichment_worker/worker.py (run_one_batch, second pass,
-           gated by settings.desc_parse_enabled).
-Depends on: desc_extractor.extract_desc (pure), spec_write_service.record_spec.
+The SPEC stage (``extract_and_record`` / ``extract_and_record_specs``) only fills facets
+for cards ALREADY categorized to a handled commodity (SPEC_COMMODITIES: hdd/ssd/dram/
+power_supplies/displays/tape_drives/gpu/motherboards/cpu — record_spec requires a
+category). The phase-2/3 commodities have no MPN decoders, so desc_parse is their top
+non-vendor source by confidence.
+
+The CATEGORIZE stage (``categorize_and_record`` — opt-in; only the one-shot CLI / ingest
+call it, the worker still runs spec-only) closes the gap for UNCATEGORIZED cards: a strict
+lead/body grammar (desc_extractor/categorizer.py) infers the commodity KEY from the
+description and, ONLY when ``card.category IS NULL``, fills it via ``set_category`` at
+``desc_parse``/tier 83 (no new source name — reuse the desc_parse identity) before the same
+spec extraction runs for the freshly-set category. Grammar discipline is "a wrong category
+is worse than a missing one": ambiguous / foreign / conflicting descriptions return None
+and the card stays uncategorized. Does not commit — the caller manages the txn.
+
+Called by: app/services/enrichment_worker/worker.py (run_one_batch, second pass, SPEC
+           stage only, gated by settings.desc_parse_enabled);
+           app/management/categorize_from_desc.py (the one-shot CATEGORIZE run).
+Depends on: desc_extractor.extract_desc + categorizer.categorize_from_desc (pure),
+           spec_tiers.set_category, spec_write_service.record_spec.
 """
 
 from loguru import logger
@@ -24,7 +34,9 @@ from sqlalchemy.orm import Session
 
 from app.models import MaterialCard
 from app.services.desc_extractor import extract_desc
-from app.services.desc_extractor._common import DESC_SOURCE, SPEC_COMMODITIES
+from app.services.desc_extractor._common import DESC_CONFIDENCE, DESC_SOURCE, SPEC_COMMODITIES
+from app.services.desc_extractor.categorizer import categorize_from_desc
+from app.services.spec_tiers import set_category
 from app.services.spec_write_service import load_schema_cache, record_spec
 
 
@@ -61,6 +73,74 @@ def extract_and_record(db: Session, card: MaterialCard, schema_cache: dict | Non
             ):
                 written += 1
     return written
+
+
+def categorize_and_record(
+    db: Session,
+    card: MaterialCard,
+    *,
+    description: str | None = None,
+    source: str = DESC_SOURCE,
+    confidence: float = DESC_CONFIDENCE,
+    schema_cache: dict | None = None,
+) -> tuple[bool, int]:
+    """CATEGORIZE an UNCATEGORIZED card from a description, then fill its facets.
+
+    Returns ``(categorized, specs_written)``. No-op (``(False, 0)``) when the card already
+    has a category (categorization is fill-only — never reclassifies), when *description*
+    is empty, or when the grammar declines to name a commodity.
+
+    *description* defaults to ``card.description``; the FRU-desc channel passes a linked
+    ``fru_links.description`` with ``source="fru_desc_parse"`` (tier 82) so a card with no
+    own description still categorizes from its FRU's prose. ``set_category`` writes the
+    canonical commodity at *source*/*confidence* via the F1 ladder (existing=None always
+    loses, so the fill wins; we gate on NULL first regardless). After a successful set, the
+    SAME spec extraction runs for the new category.
+
+    All writes are wrapped in a per-card ``begin_nested()`` SAVEPOINT: a DB-level failure
+    rolls back ONLY this card (category + facets together — a facet failure must not strand
+    a category with no facets, and vice versa) and re-raises, keeping the caller's shared
+    transaction usable for the rest of the batch.
+    """
+    if (card.category or "").strip():
+        return (False, 0)  # already categorized — fill-only, never reclassify
+    text = (description if description is not None else card.description or "").strip()
+    if not text:
+        return (False, 0)
+    commodity = categorize_from_desc(text)
+    if commodity is None:
+        return (False, 0)
+
+    with db.begin_nested():
+        if not set_category(card, commodity, source=source, confidence=confidence):
+            # The canonical commodity lost the ladder or normalized to None. Off-vocab is
+            # impossible (categorize_from_desc only returns canonical keys), so this is a
+            # category that appeared concurrently — nothing else to do (no facets without
+            # a category). Roll back the empty savepoint.
+            return (False, 0)
+        # record_spec needs the now-set category. category + facets are one atomic unit
+        # under this savepoint; the freshly-categorized commodity gets desc_parse facets
+        # immediately, in the SAME transaction.
+        if schema_cache is None:
+            schema_cache = load_schema_cache(db, commodity)
+        written = 0
+        result = extract_desc(text, commodity_hint=commodity)
+        if result is not None and result.specs:
+            for spec_key, value in result.specs.items():
+                # Facets carry the SAME provenance as the category they were unlocked by
+                # (desc_parse/83 for the own description, fru_desc_parse/82 for a linked
+                # FRU description). The ladder arbitrates — a higher prior is never clobbered.
+                if record_spec(
+                    db,
+                    int(card.id),
+                    spec_key,
+                    value,
+                    source=source,
+                    confidence=confidence,
+                    schema_cache=schema_cache,
+                ):
+                    written += 1
+    return (True, written)
 
 
 def extract_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, int]:

--- a/app/services/source_ingest/clean.py
+++ b/app/services/source_ingest/clean.py
@@ -6,8 +6,11 @@ What: ``clean_record`` strips MPN suffixes (` - Pull` / ` - New` / `-x`) and nor
       free-text fields; canonicalizes ``condition`` to the MaterialCondition vocabulary
       (constants.py — None when the source carries none); maps the source commodity
       to an app-canonical category (None if unmappable) with a CPU-bucket pollution deny-list
-      (the SFDC master's 'CPU' code is ~14% non-CPU parts — see _CPU_POLLUTION_RE); and DROPS
-      the record when the MPN is too short / falsy or the description says "DO NOT USE".
+      (the SFDC master's 'CPU' code is ~14% non-CPU parts — see _CPU_POLLUTION_RE), and when
+      the source carries no mappable category falls back to the SHARED lead-token grammar
+      (categorize_from_desc — the same grammar the categorize CLI/worker use) over the
+      description; and DROPS the record when the MPN is too short / falsy or the description
+      says "DO NOT USE".
       ``extract_trailing_oem`` pulls the embedded ", IBM"/", EMC"/", HP" trailing token out
       of a sheet description. Dual-brand routing (SPEC_DUAL_BRAND_FILTERS §2 W6): a trailing
       token matching OEM_TRAILING_RE (IBM/Dell/HP/HPE/Lenovo — an OEM LABEL, not a maker)
@@ -27,6 +30,7 @@ import re
 
 from app.constants import MaterialCondition
 from app.services.category_normalizer import normalize_trio_category
+from app.services.desc_extractor.categorizer import categorize_from_desc
 from app.services.manufacturer_normalizer import OEM_TRAILING_RE
 from app.services.source_ingest.models import SourceRecord
 from app.utils.normalization import normalize_mpn, normalize_mpn_key
@@ -183,6 +187,14 @@ def clean_record(rec: SourceRecord) -> SourceRecord | None:
         # facet-curation analysis identified (HDD trays, CPUs, SSDs, …). Blank it: the card
         # stays in the no-commodity bucket, open to real categorization.
         category = None
+    if category is None and description:
+        # The source carried no mappable Commodity_Code__c (blank / 'Other' / polluted-CPU
+        # blanked above) but the description may unambiguously name a commodity. Fall back
+        # to the SHARED lead-token grammar (categorize_from_desc — the same one the one-shot
+        # categorize CLI and the worker's categorize stage use) so future imports categorize
+        # real-desc rows at ingest. Conservative by construction (ambiguous → None), and the
+        # returned key is canonical so it survives the consolidate ladder downstream.
+        category = categorize_from_desc(description)
 
     return SourceRecord(
         raw_mpn=normalize_mpn(display_mpn) or display_mpn,

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -317,7 +317,7 @@
 | enrichment_status | String 20 | `unenriched` \| `verified` \| `web_sourced` \| `oem_sourced` \| `ai_inferred` \| `not_found` \| `not_catalogued`. Validated on write against `MaterialEnrichmentStatus` (constants.py). `oem_sourced` = single official OEM page; `not_catalogued` = recognised OEM/FRU part with no public specs (retries on 30-day backoff). No migration — varchar column. |
 | cross_references | JSONB | Alternative MPNs; also records OEM FRU→commodity-MPN linkages written by the cross-ref enrichment tier (`[{"mpn": <resolved>, "manufacturer": <mfr>}]`). |
 | specs_structured | JSONB | Parametric data — `{spec_key: {value, source, confidence, tier, updated_at}}`. `tier` (SP2/F2, migration 096) is the F1 ladder rank of the writing source so `record_spec` can rank conflicting writes without re-deriving; legacy entries lacking `tier` are backfilled in-memory from `source` before comparison. Source vocabulary (ladder tier): `manual` (100) · `trio_source` (95) · vendor APIs `digikey_api`\|`nexar_api`\|`mouser_api`\|… (90) · `trio_source_ai` (88) · `mpn_decode` (85) · `fru_matrix_decode` (84, FRU crosswalk intersection) · `desc_parse` (83) · `fru_desc_parse` (82, FRU-linked qual-sheet description intersection — below the card's OWN description, above the OEM scrapers) · `spec_extraction` (60, AI quality-floored at ≥ 0.85) · `legacy_backfill` (50) · `{ai_guess,claude_opus_inferred,claude_haiku}` (40); unknown sources rank 0 (once-per-source WARNING). |
-| category_source | String 50, nullable | SP2/F2 (migration 096). Which source set `category` (e.g. `mpn_decode`, `digikey_api`, `claude_opus_inferred`, `legacy_backfill`). Written only via `spec_tiers.set_category`. |
+| category_source | String 50, nullable | SP2/F2 (migration 096). Which source set `category` (e.g. `mpn_decode`, `digikey_api`, `claude_opus_inferred`, `legacy_backfill`; `desc_parse`/83 + `fru_desc_parse`/82 when set by the categorize-from-description channel — see APP_MAP_INTERACTIONS §desc-parse). Written only via `spec_tiers.set_category`. |
 | category_confidence | Float, nullable | SP2/F2. Confidence of the source that set `category`. |
 | category_tier | Integer, nullable | SP2/F2. F1 ladder rank of `category_source`. A lower-tier source can never overwrite a higher-tier category (the ladder, not write order, decides). Legacy valued-but-unprovenanced rows are backfilled to mid-tier 50 (`legacy_backfill`/0.5); `set_category` applies the SAME floor at runtime to a valued category with NULL provenance, so pre- and post-migration data rank identically. |
 | category_updated_at | UTCDateTime, nullable | SP2/F2 (migration 096). When the category was last (re)written through the ladder — the tie-break timestamp for `set_category` (never borrowed from the card-wide `updated_at`). NULL for legacy rows (ranks as ""). |
@@ -348,7 +348,7 @@
 
 **`material_vendor_history`** — Which vendors sell which parts (deduplicated)
 
-**`material_card_audit`** — Audit trail for card lifecycle events
+**`material_card_audit`** — Audit trail for card lifecycle events (actions: created, linked, unlinked, deleted, merged, healed, restored, soft_deleted, plus `categorized` — written by `app/management/categorize_from_desc.py` when the categorize-from-description channel sets a previously-NULL category, `details` carrying the resulting category/source/tier/channel)
 
 **`material_price_snapshots`** — Historical pricing data points
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1225,13 +1225,28 @@ owns arbitration in one place:
        and a curated model→spec table (app/data/cpu_model_specs.json) merged
        UNDER desc tokens (skipped when the desc names two models, incl. dangling
        slash-alternates like "GOLD 6230R/6240R").
-       Only cards already categorized to one of the nine commodities are written
-       (NEVER categorizes — a description is not a regex-gated commodity proof).
-       The F1 ladder (fru_desc_parse 82 < desc_parse 83 < fru_matrix_decode 84 <
-       mpn_decode 85 < vendor 90) keeps decode/vendor values authoritative and the
-       card's OWN description above its FRU-linked prose — no per-writer
-       pre-gate. The phase-2/3 commodities have no MPN decoders, so
-       desc_parse is their top non-vendor deterministic source.
+       In the worker SPEC stage only cards ALREADY categorized to one of the nine
+       commodities are written (this stage NEVER categorizes). A separate,
+       opt-in CATEGORIZE stage (writer.categorize_and_record, NOT run by the
+       worker — only the one-shot CLI + ingest call it) closes that gap for
+       UNCATEGORIZED cards: a strict lead/body grammar
+       (desc_extractor/categorizer.py — the nine SPEC commodities via the reused
+       extract_desc router with a stricter CPU-identity gate, plus anchored
+       cables/batteries/fans_cooling leads with pollution suppression) infers the
+       commodity KEY and, ONLY when card.category IS NULL, writes it via
+       set_category at desc_parse/83 (own description) or fru_desc_parse/82
+       (a linked fru_links description), then runs the SAME spec extraction for the
+       fresh category in the same SAVEPOINT. Reuses the desc_parse identity — no new
+       tier-83 source. Driven by app/management/categorize_from_desc.py (one-shot,
+       dry-run default, --apply; own-desc + FRU-desc channels, real-desc gate
+       alphanumeric-norm(desc) != alphanumeric-norm(display_mpn) and len >= 15,
+       MaterialCardAudit action="categorized" per card) and at ingest time by
+       source_ingest/clean.py (same grammar, fallback when the source carries no
+       mappable Commodity_Code__c). The F1 ladder (fru_desc_parse 82 < desc_parse
+       83 < fru_matrix_decode 84 < mpn_decode 85 < vendor 90) keeps decode/vendor
+       values authoritative and the card's OWN description above its FRU-linked
+       prose — no per-writer pre-gate. The phase-2/3 commodities have no MPN
+       decoders, so desc_parse is their top non-vendor deterministic source.
     4. spec_enrichment_service.py::enrich_card_specs    — AI spec reader,
        source="spec_extraction" (tier 60), facets gated at confidence >= 0.85
        (FACET_MIN_CONF — an AI output-quality floor, not cross-source
@@ -1675,6 +1690,24 @@ wd_revision_digit/capacity_grid/seagate_envelope/nand_density — the decoder's
 `dropped`/`drop_reasons` channel attributes grid-emptied capacity-only decodes to
 capacity_grid and envelope refusals to seagate_envelope, never to the shape-regex
 fallback buckets); SAVEPOINT per card.
+
+Categorize-from-description backfill (OPTIMIZATION_PLAN §2.4): `python -m
+app.management.categorize_from_desc [--apply] [--limit N]` categorizes UNCATEGORIZED
+cards from their descriptions via the shared lead-token grammar
+(`desc_extractor/categorizer.py::categorize_from_desc`), then fills each freshly
+categorized card's desc_parse facets in the same SAVEPOINT (the new category is
+immediately food for the existing extractor). Two channels: OWN-DESC (a REAL
+description — alphanumeric-norm(desc) != alphanumeric-norm(display_mpn) and len >= 15
+— at `desc_parse`/83) and FRU-DESC (the card has no usable own description but a linked
+`fru_links` row carries one — at `fru_desc_parse`/82). Category writes go through
+`set_category` and ONLY when `card.category IS NULL` (fill-only — never reclassifies);
+the grammar is conservative (foreign/ambiguous/conflicting/pollution → no write).
+Dry-run by default (prints a yield report broken down by resulting category + channel,
+writes nothing); `--apply` commits and logs a `MaterialCardAudit` (action
+`categorized`, `created_by="categorize_from_desc"`) per card. The SAME grammar runs at
+ingest time in `source_ingest/clean.py` (fallback when the source carries no mappable
+`Commodity_Code__c`) so future imports categorize real-desc rows — single source of
+truth, no duplicated grammar.
 
 ## Cross-Reference Caching
 

--- a/tests/test_categorize_from_desc_cli.py
+++ b/tests/test_categorize_from_desc_cli.py
@@ -1,0 +1,140 @@
+"""The categorize-from-desc one-shot CLI: dry-run yield, real-desc gate, channels, --apply.
+
+Dry-run must write NOTHING while reporting the would-categorize yield (per channel + per
+resulting category). --apply categorizes through the ladder, fills facets, and logs an
+audit row per card. Fixtures use category=None — never hand-set an off-vocab category.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.management.categorize_from_desc import _alnum_norm, _has_real_own_desc, run
+from app.models import MaterialCard, MaterialCardAudit, MaterialSpecFacet
+from app.models.fru_link import FruLink
+from app.services.commodity_registry import seed_commodity_schemas
+
+
+def _card(db: Session, mpn: str, description: str | None, category=None) -> MaterialCard:
+    card = MaterialCard(normalized_mpn=mpn.lower(), display_mpn=mpn, category=category, description=description)
+    db.add(card)
+    db.flush()
+    return card
+
+
+def _facets(db: Session, card_id: int) -> dict:
+    rows = db.query(MaterialSpecFacet).filter_by(material_card_id=card_id).all()
+    return {r.spec_key: (r.value_text if r.value_text is not None else r.value_numeric) for r in rows}
+
+
+def test_real_desc_gate():
+    # The MPN-as-description rows (desc == display_mpn, alphanumeric) are NOT real.
+    assert _alnum_norm("00-AR-327 ") == "00ar327"
+    real = MaterialCard(normalized_mpn="x", display_mpn="00AR327", description='HD, 450GB, 15KRPM, 3.5", FC')
+    mpn_echo = MaterialCard(normalized_mpn="y", display_mpn="00AR327", description="00AR327")
+    short = MaterialCard(normalized_mpn="z", display_mpn="ABC", description="HDD")
+    assert _has_real_own_desc(real) is True
+    assert _has_real_own_desc(mpn_echo) is False
+    assert _has_real_own_desc(short) is False
+
+
+def test_dry_run_writes_nothing_but_reports_yield(db_session: Session):
+    seed_commodity_schemas(db_session)
+    _card(db_session, "00AR327", 'HD, 450GB, 15KRPM, 3.5", Fibre Channel')  # -> hdd
+    _card(db_session, "01KL563", "PSU, 1460W 240V/200V AC Hot Swap")  # -> power_supplies
+    _card(db_session, "CBL55", "CABLE, LVDS 40-pin display harness 500mm")  # -> cables
+    _card(db_session, "JUNK1", "JUNK1")  # MPN-as-desc -> skipped_no_desc
+    _card(db_session, "ALREADY", "HDD, 1TB drive", category="hdd")  # already categorized -> not selected
+    db_session.commit()
+
+    summary = run(db_session, apply=False)
+
+    # Dry-run reports the yield but writes nothing.
+    assert summary["mode"] == "dry-run"
+    assert summary["categorized"] == 3
+    assert summary["by_category"] == {"hdd": 1, "power_supplies": 1, "cables": 1}
+    assert summary["by_channel"] == {"own_desc": 3}
+    assert summary["skipped_no_desc"] == 1
+    # NOTHING persisted: no facets, no category mutations survived the rollback.
+    db_session.rollback()
+    assert db_session.query(MaterialSpecFacet).count() == 0
+    for mpn in ("00ar327", "01kl563", "cbl55"):
+        card = db_session.query(MaterialCard).filter_by(normalized_mpn=mpn).one()
+        assert card.category is None
+
+
+def test_apply_categorizes_through_ladder_and_audits(db_session: Session):
+    seed_commodity_schemas(db_session)
+    _card(db_session, "00AR327", 'HD, 450GB, 15KRPM, 3.5", Fibre Channel')
+    db_session.commit()
+
+    summary = run(db_session, apply=True)
+
+    assert summary["mode"] == "apply"
+    assert summary["categorized"] == 1
+    assert summary["specs_written"] >= 1
+    card = db_session.query(MaterialCard).filter_by(normalized_mpn="00ar327").one()
+    assert card.category == "hdd"
+    assert card.category_source == "desc_parse"
+    assert card.category_tier == 83
+    assert _facets(db_session, card.id)["capacity_gb"] == 450
+    # One audit row per categorized card.
+    audit = db_session.query(MaterialCardAudit).filter_by(material_card_id=card.id, action="categorized").one()
+    assert audit.created_by == "categorize_from_desc"
+    assert audit.details["category"] == "hdd"
+    assert audit.details["channel"] == "own_desc"
+    assert audit.details["tier"] == 83
+
+
+def test_fru_desc_channel_when_own_desc_is_unusable(db_session: Session):
+    # A card whose own description is just the MPN, but with a linked fru_links row that
+    # carries a real description, categorizes via the fru_desc channel (tier 82).
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "FRU100", "FRU100")  # own desc == MPN
+    db_session.add(
+        FruLink(
+            fru_raw="FRU100",
+            fru_norm="fru100",
+            related_raw="ST1200MM0017",
+            related_norm="st1200mm0017",
+            rel_kind="mfg_model",
+            description="HDD, 6Gbps 1.2TB 10K 2.5 Inch HDD, IBM",
+            source_sheet="test",
+        )
+    )
+    db_session.commit()
+
+    summary = run(db_session, apply=True)
+
+    assert summary["categorized"] == 1
+    assert summary["by_channel"] == {"fru_desc": 1}
+    db_session.refresh(card)
+    assert card.category == "hdd"
+    assert card.category_source == "fru_desc_parse"
+    assert card.category_tier == 82
+
+
+def test_limit_caps_examined_cards(db_session: Session):
+    seed_commodity_schemas(db_session)
+    for i in range(5):
+        _card(db_session, f"LIM{i}", 'HD, 450GB, 15KRPM, 3.5", Fibre Channel')
+    db_session.commit()
+
+    summary = run(db_session, apply=False, limit=2)
+    assert summary["cards_examined"] == 2
+    db_session.rollback()
+
+
+def test_soft_deleted_cards_excluded(db_session: Session):
+    from datetime import datetime, timezone
+
+    seed_commodity_schemas(db_session)
+    live = _card(db_session, "LIVE1", 'HD, 450GB, 15KRPM, 3.5", Fibre Channel')
+    dead = _card(db_session, "DEAD1", 'HD, 600GB, 10KRPM, 2.5", SAS')
+    dead.deleted_at = datetime.now(timezone.utc)
+    db_session.commit()
+
+    summary = run(db_session, apply=True)
+    assert summary["categorized"] == 1
+    db_session.refresh(live)
+    db_session.refresh(dead)
+    assert live.category == "hdd"
+    assert dead.category is None

--- a/tests/test_desc_categorize_writer.py
+++ b/tests/test_desc_categorize_writer.py
@@ -1,0 +1,157 @@
+"""The categorize stage (writer.categorize_and_record): NULL-only fill + tier-83 ladder.
+
+Fixtures create cards with category=None (NULL) and assert the categorizer SETS the right
+category via the F1 ladder — NEVER hand-set an off-vocab category string (the ladder /
+@validates guard reject off-vocab direct assignment).
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard, MaterialSpecFacet
+from app.services.commodity_registry import seed_commodity_schemas
+from app.services.desc_extractor.writer import categorize_and_record
+from app.services.spec_tiers import set_category
+
+
+def _facets(db: Session, card_id: int) -> dict:
+    rows = db.query(MaterialSpecFacet).filter_by(material_card_id=card_id).all()
+    return {r.spec_key: (r.value_text if r.value_text is not None else r.value_numeric) for r in rows}
+
+
+def _uncategorized_card(db: Session, mpn: str, description: str) -> MaterialCard:
+    """A NULL-category card (the real target population).
+
+    Never hand-set category.
+    """
+    card = MaterialCard(normalized_mpn=mpn.lower(), display_mpn=mpn, category=None, description=description)
+    db.add(card)
+    db.flush()
+    return card
+
+
+def test_categorizes_null_card_and_fills_facets(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = _uncategorized_card(db_session, "00AR327", 'HD, 450GB, 15KRPM, 3.5", Fibre Channel')
+
+    categorized, written = categorize_and_record(db_session, card)
+    db_session.commit()
+
+    assert categorized is True
+    assert card.category == "hdd"
+    # Category written THROUGH the ladder at desc_parse / tier 83 — not assigned directly.
+    assert card.category_source == "desc_parse"
+    assert card.category_tier == 83
+    assert card.category_confidence == 0.90
+    # Facets follow in the SAME transaction, also at desc_parse.
+    assert written >= 1
+    f = _facets(db_session, card.id)
+    assert f["capacity_gb"] == 450
+    assert card.specs_structured["capacity_gb"]["source"] == "desc_parse"
+
+
+def test_never_overwrites_existing_category(db_session: Session):
+    # NULL-only guard: a card already categorized (even via the ladder) is left untouched —
+    # categorization is fill-only, never a reclassifier.
+    seed_commodity_schemas(db_session)
+    card = _uncategorized_card(db_session, "X1", 'HD, 450GB, 15KRPM, 3.5", Fibre Channel')
+    # Pre-categorize as ssd through the ladder (the sanctioned path), THEN try categorize.
+    assert set_category(card, "ssd", source="mpn_decode", confidence=0.95)
+    db_session.flush()
+
+    categorized, written = categorize_and_record(db_session, card)
+    db_session.commit()
+
+    assert categorized is False
+    assert written == 0
+    assert card.category == "ssd"  # untouched
+    assert card.category_source == "mpn_decode"
+
+
+def test_no_grammar_match_leaves_card_uncategorized(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # MPN-as-description / no commodity signal — the grammar declines.
+    card = _uncategorized_card(db_session, "GRM155R71C104MA88D", "GRM155R71C104MA88D")
+
+    categorized, written = categorize_and_record(db_session, card)
+    db_session.commit()
+
+    assert (categorized, written) == (False, 0)
+    assert card.category is None
+    assert _facets(db_session, card.id) == {}
+
+
+def test_empty_description_is_noop(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = _uncategorized_card(db_session, "EMPTY1", "")
+    assert categorize_and_record(db_session, card) == (False, 0)
+    assert card.category is None
+
+
+def test_fru_desc_channel_writes_at_tier_82(db_session: Session):
+    # A card with no usable OWN description categorizes from a passed FRU description at
+    # fru_desc_parse / tier 82 (the one-hop prose ranks below own-desc 83).
+    seed_commodity_schemas(db_session)
+    card = _uncategorized_card(db_session, "FRU100", "FRU100")  # own desc == MPN, unusable
+    fru_desc = "HDD, 6Gbps 1.2TB 10K 2.5 Inch HDD, IBM"
+
+    categorized, written = categorize_and_record(
+        db_session, card, description=fru_desc, source="fru_desc_parse", confidence=0.90
+    )
+    db_session.commit()
+
+    assert categorized is True
+    assert card.category == "hdd"
+    assert card.category_source == "fru_desc_parse"
+    assert card.category_tier == 82
+    assert written >= 1
+    assert card.specs_structured["capacity_gb"]["source"] == "fru_desc_parse"
+
+
+def test_categorizes_phase2_commodity_with_no_extractor(db_session: Session):
+    # A cables card (no spec extractor exists) still CATEGORIZES — written=0 facets is
+    # correct and expected, the category fill is the value.
+    seed_commodity_schemas(db_session)
+    card = _uncategorized_card(db_session, "CBL55", "CABLE, LVDS 40-pin display harness 500mm")
+
+    categorized, written = categorize_and_record(db_session, card)
+    db_session.commit()
+
+    assert categorized is True
+    assert card.category == "cables"
+    assert card.category_tier == 83
+    assert written == 0  # no cables extractor; facets follow only where one exists
+
+
+def test_savepoint_rolls_back_card_on_facet_failure(db_session: Session, monkeypatch):
+    # A DB-level failure while writing facets must roll back the WHOLE card (category +
+    # facets are one atomic unit) via the per-card SAVEPOINT and re-raise — never strand a
+    # category with no facets, and keep the OUTER transaction usable.
+    seed_commodity_schemas(db_session)
+    card = _uncategorized_card(db_session, "BAD1", 'HD, 450GB, 15KRPM, 3.5", Fibre Channel')
+    db_session.commit()  # persist the card so the savepoint rollback can't expunge it
+
+    import app.services.desc_extractor.writer as writer_mod
+
+    def boom(*_a, **_k):
+        raise RuntimeError("simulated facet failure")
+
+    monkeypatch.setattr(writer_mod, "record_spec", boom)
+
+    try:
+        categorize_and_record(db_session, card)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("expected the facet failure to propagate")
+
+    # The SAVEPOINT rolled back the category set + the empty facet write; the outer
+    # transaction is still usable (no full rollback needed).
+    db_session.expire(card)
+    assert card.category is None
+    assert _facets(db_session, card.id) == {}
+    # Outer txn still works: a fresh card categorizes normally.
+    good = _uncategorized_card(db_session, "GOOD1", "CABLE, LVDS 40-pin harness 500mm")
+    monkeypatch.undo()
+    assert categorize_and_record(db_session, good) == (True, 0)
+    db_session.commit()
+    assert good.category == "cables"

--- a/tests/test_desc_categorizer.py
+++ b/tests/test_desc_categorizer.py
@@ -1,0 +1,96 @@
+"""Grammar tests for desc_extractor.categorizer.categorize_from_desc.
+
+Per-grammar positive + negative/ambiguous coverage. The categorizer is the SHARED
+single-source-of-truth grammar used by the categorize stage (writer.categorize_and_record),
+the one-shot CLI, and ingest (source_ingest.clean). It must:
+  * categorize each handled commodity from an unambiguous lead/body description;
+  * return None for ambiguous / foreign / conflicting / pollution descriptions;
+  * NEVER return an off-vocab key (every return value is a canonical commodity_seeds key,
+    so set_category's normalize_category never drops it).
+"""
+
+import pytest
+
+from app.services.category_normalizer import normalize_category
+from app.services.commodity_registry import get_all_commodities
+from app.services.desc_extractor.categorizer import categorize_from_desc
+
+# Positive cases: (description, expected canonical commodity key).
+_POSITIVE = [
+    # SPEC_COMMODITIES via the reused extract_desc router.
+    ("HDD, 6Gbps 1.2TB 10K 2.5 Inch HDD, IBM", "hdd"),
+    ('HD, 450GB, 15KRPM, 3.5", Fibre Channel', "hdd"),
+    ("SSD 480GB 7mmH 6Gb SATA", "ssd"),
+    ("Mem, 16GB DDR4 2Rx4 PC4-2400T RDIMM", "dram"),
+    ("Memory, 8GB DDR3 1600MHz Non-ECC UDIMM, Kingston", "dram"),
+    ("PSU, 1460W 240V/200V AC Hot Swap for EN 62368-1", "power_supplies"),
+    ("LCD, FHD AG LED UWVA 15.6 panel", "displays"),
+    ("Tape Drive, 400/800gb Ultrium Lto-3 HH SCSI LVD External", "tape_drives"),
+    ("MB, WHL I7 DIS 4G 8G WIN", "motherboards"),
+    ("SPS-MB DSC GTX1050 4GB i7-7700HQ WIN", "motherboards"),  # GPU/CPU words subordinate
+    ("GPU, NVIDIA Tesla V100 32GB Module", "gpu"),
+    # CPU requires explicit CPU identity (the CPU + Xeon/Core/Ryzen gate).
+    ("SPS-CPU BDW E5-2650L V4 14C 1_7GHZ 65W", "cpu"),
+    ("SPS-PROC HSW E5-1630v3 4C 3.7GHz 140W", "cpu"),
+    ("Xeon GOLD 6134 3.2G 8C 130W", "cpu"),
+    ("Intel Core i7-7700HQ 2.8GHz Processor", "cpu"),
+    # New-category anchored leads (extract_desc has no grammar for these).
+    ("CABLE, LVDS 40-pin display harness", "cables"),
+    ("CBL, USB 3.0 internal 500mm", "cables"),
+    ("FAN, 80mm hot-swap blower assembly", "fans_cooling"),
+    ("HEATSINK, CPU thermal module with fan", "fans_cooling"),
+    ("HEAT SINK, passive aluminum for DIMM", "fans_cooling"),
+    ("BATTERY, 3.6V NVRAM cache lithium pack", "batteries"),
+    ("BTRY, UPS sealed lead-acid 12V 9Ah", "batteries"),
+]
+
+# Negative / ambiguous cases: the grammar must decline (None) — a wrong category is worse
+# than a missing one.
+_NEGATIVE = [
+    # Bare CPU/PROC lead with NO CPU identity — the polluted-bucket trap.
+    "CPU, spare module for system board",
+    "PROC, replacement part",
+    # Foreign lead suppresses (TRIO classified it as something else).
+    'Other, 3.5" Server HDD Hard Drive tray',
+    "Tray, 2.5 inch drive carrier",
+    "Card, PCI-X Quad Channel Ultra4 Controller",
+    # Hard storage x dram conflict — never pick a side.
+    "Memory, 256GB, LiteOn SSD, M.2 2280",
+    # Battery-management IC is NOT a battery.
+    "BATTERY MANAGEMENT IC BQ40Z50 fuel gauge stack monitor",
+    "BATT GAS GAUGE LTC6803 monitor",
+    # MPN-as-description / no commodity signal at all.
+    "00AR327",
+    "GRM155R71C104MA88D",
+    # Empty / None.
+    "",
+    "   ",
+    None,
+]
+
+
+@pytest.mark.parametrize("description,expected", _POSITIVE)
+def test_categorizes_unambiguous_description(description, expected):
+    assert categorize_from_desc(description) == expected
+
+
+@pytest.mark.parametrize("description", _NEGATIVE)
+def test_declines_ambiguous_or_foreign_description(description):
+    assert categorize_from_desc(description) is None
+
+
+def test_every_returned_key_is_canonical_vocab():
+    # Discipline: the categorizer must never emit a key set_category would drop as
+    # off-vocab. Assert every positive expectation is a canonical commodity_seeds key
+    # AND round-trips through normalize_category unchanged.
+    canonical = set(get_all_commodities())
+    for _description, expected in _POSITIVE:
+        assert expected in canonical, f"{expected!r} is not a canonical commodity key"
+        assert normalize_category(expected) == expected
+
+
+def test_cable_lead_is_anchored_not_substring():
+    # The CABLE lead is start-anchored: "ANTENNA CABLE" inside a display row stays a
+    # display (routed by extract_desc), never a cable.
+    assert categorize_from_desc("LCD, 15.6 FHD panel with ANTENNA CABLE") == "displays"
+    assert categorize_from_desc("CABLE, antenna coax for LCD") == "cables"

--- a/tests/test_source_ingest_clean.py
+++ b/tests/test_source_ingest_clean.py
@@ -145,6 +145,35 @@ def test_clean_blanks_other_commodity_code():
     assert clean_record(_rec(raw_mpn="REAL123", category="OEM ASSY")).category == "oem_assemblies"
 
 
+def test_clean_categorizes_from_description_when_code_unmappable():
+    # Ingest-time categorize fallback (OPTIMIZATION_PLAN §2.4): when the source carries no
+    # mappable Commodity_Code__c but the description unambiguously names a commodity, the
+    # SHARED lead-token grammar (categorize_from_desc) fills it — same grammar the CLI uses.
+    assert (
+        clean_record(_rec(raw_mpn="00AR327", category=None, description='HD, 450GB, 15KRPM, 3.5", FC')).category
+        == "hdd"
+    )
+    # 'Other' code blanked above, THEN the description fallback recovers it.
+    assert (
+        clean_record(_rec(raw_mpn="01KL563", category="Other", description="PSU, 1460W AC Hot Swap")).category
+        == "power_supplies"
+    )
+    # A new-category lead (cables) that has no Commodity_Code__c equivalent.
+    assert (
+        clean_record(_rec(raw_mpn="CBL55", category=None, description="CABLE, LVDS 40-pin harness")).category
+        == "cables"
+    )
+
+
+def test_clean_description_fallback_is_conservative():
+    # Ambiguous / MPN-as-desc / no-signal descriptions do NOT categorize (a wrong category
+    # is worse than a missing one); a mappable source code is never overridden by the desc.
+    assert clean_record(_rec(raw_mpn="00AR327", category=None, description="00AR327")).category is None
+    assert clean_record(_rec(raw_mpn="REAL123", category=None, description="VPD Card spare")).category is None
+    # A real source code wins; the desc fallback only runs when the code is unmappable.
+    assert clean_record(_rec(raw_mpn="REAL123", category="HDD", description="PSU, 1460W AC Hot Swap")).category == "hdd"
+
+
 def test_clean_blanks_cpu_category_for_polluted_mpn_shapes():
     # CATALOG.md ingest warning: ~14% of the SFDC 'CPU' bucket is passives/connectors/logic.
     # Known non-CPU MPN shapes must get their category BLANKED (None — never a tier-95 'cpu'),


### PR DESCRIPTION
## What & why

Implements **OPTIMIZATION_PLAN §2.4** — a grammar-gated *categorize-from-description* channel. The materials filter tree is data-starved because ~92% of cards are uncategorized and therefore invisible to every facet. This is the best cards-per-effort, zero-budget lever: each card categorized from its description immediately becomes food for the existing `desc_parse` facet extractor (real descriptions by definition).

No DB migration — no schema change.

## The grammar (single source of truth)

New `app/services/desc_extractor/categorizer.py::categorize_from_desc` — the **shared** grammar used by the categorize stage, the CLI, *and* ingest (no duplicated grammar):

- The 9 SPEC_COMMODITIES (`hdd`, `ssd`, `dram`, `power_supplies`, `displays`, `tape_drives`, `gpu`, `motherboards`, `cpu`) route by **reusing `extract_desc`'s own router** — inheriting every foreign-lead / packaging-lead / `storage×dram` conflict / CPU-pollution rule, no second grammar to drift.
- `cpu` is gated a second, stricter time on explicit **CPU identity** (`CPU/PROCESSOR` + Xeon / Core iN / Ryzen / EPYC / model string) so a bare `CPU,` spare in the ~14%-polluted bucket is never minted.
- Three categories `extract_desc` does not handle get their own **anchored** lead grammars with pollution suppression: `cables` (`CABLE,`/`CBL,`), `fans_cooling` (`FAN`/`HEATSINK`/`HSF`/`BLOWER`), `batteries` (`BATTERY`/`BATT`/`BTRY`, minus `BATTERY MANAGEMENT`/gas-gauge ICs).
- Conservative by construction: foreign / ambiguous / conflicting → `None` (a wrong category is worse than a missing one). Every returned key is canonical, so `set_category` never drops it.

> KEYBOARD (a §2.4 example) has no canonical `commodity_seeds` key yet, so it is intentionally **not** emitted — `set_category` would reject it as off-vocab. Adding that seed is Phase 2.5 (`keyword_reclass`), out of scope here.

## Ladder discipline

- Category written **ONLY when `card.category IS NULL`** (fill-only — never reclassifies), via the **F1 ladder** `set_category`.
- Source `desc_parse` / **tier 83** for the card's own description; `fru_desc_parse` / **tier 82** for a linked `fru_links` description. **No new source name; no second tier-83 source** — reuses the existing identity.
- Never assigns `card.category =` directly. Facets follow in the **same SAVEPOINT** at the same provenance.
- The worker SPEC pass is unchanged (still never categorizes).

## The CLI

`python -m app.management.categorize_from_desc [--apply] [--limit N]` — dry-run default.

- Targets uncategorized cards with a REAL description (`alnum-norm(desc) != alnum-norm(display_mpn)` and `len >= 15`), plus the FRU-desc channel for cards with no usable own description but a usable linked `fru_links.description`.
- Dry-run prints a yield report by resulting category + channel and writes nothing (rollback). `--apply` commits and logs a `MaterialCardAudit` (`action=categorized`, `created_by=categorize_from_desc`) per card.

## Dry-run yield (live DB, first 20,000 uncategorized cards)

```
categorized ....... 991   (own_desc 986 / fru_desc 5)
no grammar match .. 1,076
skipped (no desc).. 17,933   (MPN-as-description rows, no signal)
by category: hdd 330 · motherboards 237 · displays 154 · cpu 74 · dram 68 ·
             ssd 62 · power_supplies 31 · cables 10 · tape_drives 9 ·
             fans_cooling 7 · batteries 6 · gpu 3
```

~5% yield on the early-id slice; on the cards that actually have a usable description the hit rate is ~48%. Projects to the plan's **+~4–6k categorized cards** over the full real-desc + FRU population. `--apply` is left for the orchestrator's deploy phase.

## Ingest-time rule

`source_ingest/clean.py` calls the **same** `categorize_from_desc` as a fallback when the source carries no mappable `Commodity_Code__c` (blank / 'Other' / polluted-CPU-blanked), so future imports categorize real-desc rows at ingest.

## Tests

- `test_desc_categorizer.py` — per-grammar positive + negative/ambiguous; every returned key is canonical vocab; anchored-lead-not-substring.
- `test_desc_categorize_writer.py` — NULL-only never-overwrite guard, ladder tier 82/83 + provenance, facets-follow, phase-2-commodity-with-no-extractor, savepoint isolation.
- `test_categorize_from_desc_cli.py` — real-desc gate, dry-run-writes-nothing, --apply through ladder + audit row, FRU-desc channel, --limit, soft-deleted exclusion.
- `test_source_ingest_clean.py` — ingest fallback (categorizes / stays conservative / source code wins).

**Full suite: 16275 passed, 35 skipped, 1 xfailed, 0 failed.** `pre-commit run` clean. APP_MAP_INTERACTIONS + APP_MAP_DATABASE updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)