### PR TITLE
feat(fru): targeted FRU-graph drain CLI + gated drive_pn widening + deterministic maker propagation (§2.6)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -135,6 +135,16 @@ class Settings(BaseSettings):
     # between mpn-decode (0.95) and desc-parse (0.90) at 0.93. Safe to leave on — values are
     # enum-validated by record_spec. See app/services/fru_crosswalk_enrich.
     fru_crosswalk_enrich_enabled: bool = True
+    # Widen the FRU crosswalk DECODE channel to also decode the drive_pn rel_kind's related
+    # parts (today the decode channel reads mfg_model links only; drive_pn rows still feed the
+    # DESC channel regardless of this flag). GATED on a measured misread rate: a 100-row dry-run
+    # (app.management.run_fru_crosswalk --measure-drive-pn) found 0/3328 drive_pn related parts
+    # decode at all (they are IBM/Lenovo FRU numbers, not canonical manufacturer MPNs), so the
+    # OEM-firmware-suffix misread rate is 0% (≤2% gate) — safe to default ON. The regex gate in
+    # decode_mpn is the source of truth, so a non-canonical drive_pn never misdecodes; record_spec
+    # re-validates every value. Flip OFF only if a future drive_pn ingest carries canonical models
+    # whose firmware suffixes are re-measured above the 2% gate. See app/services/fru_crosswalk_enrich.
+    fru_crosswalk_drive_pn_decode_enabled: bool = True
     # OEM web-resolution crosswalk (PartSurfer/PSREF spare → canonical MPN cache): gates BOTH
     # worker passes — Pass B (the deterministic tier-80 writer over cached oem_crosswalk rows:
     # zero-network, zero-LLM, safe-on) and Pass A (the paced Claude-grounded resolution, which

--- a/app/management/run_fru_crosswalk.py
+++ b/app/management/run_fru_crosswalk.py
@@ -1,0 +1,412 @@
+"""Targeted FRU-graph drain CLI (OPTIMIZATION_PLAN §2.6 — zero-network, zero-LLM).
+
+What: exploits the existing FRU-links graph (mfg_model + drive_pn edges) to categorize/
+      facet/maker-stamp more cards through the F1 ladder, all deterministically. Two
+      phases, each dry-run by DEFAULT (``--apply`` writes):
+
+  PHASE A — targeted drain (``drain``): runs ``crosswalk_and_record_specs`` over the
+    EXISTING cards that have a mfg_model/drive_pn FRU link but are still UNFACETED
+    (no MaterialSpecFacet rows) or UNCATEGORIZED (category NULL/blank). No targeted
+    runner existed before this — the worker only crosswalks whatever happens to be in
+    its current batch. Dry-run wraps the writer in a SAVEPOINT and rolls it back, so the
+    returned stats are a REAL yield report (the writer's own ladder/savepoint logic runs
+    unchanged) with nothing persisted.
+
+  PHASE B — dangling-card creation (``create``): creates MaterialCards (category=None,
+    enrichment_status=unenriched) for two dangling populations so the worker's existing
+    tier-84 crosswalk / tier-85 mpn_decode passes FIRE on them on the next loop:
+      (b1) dangling enrichable FRUs — distinct ``fru_norm`` (mfg_model/drive_pn links)
+           with NO card whose linked models DECODE or whose link descriptions EXTRACT;
+      (b2) dangling canonical models — distinct ``related_norm`` (mfg_model/drive_pn,
+           NEVER lenovo_ppn) with NO card whose ``related_raw`` DECODES to a recognized
+           vendor (Seagate/WD/Samsung/Micron/… via the regex-gated decoders).
+    The ~30,985 lenovo_ppn danglers are EXPLICITLY OUT OF SCOPE (display-only value;
+    OPTIMIZATION_PLAN §5 kill-list) and are never created.
+
+  ``--measure-drive-pn``: the §2.6(c) GATE. Decodes a sample of drive_pn related parts
+    and reports the OEM-firmware-suffix MISREAD rate (a decode whose commodity/specs
+    contradict the linked qual-sheet description — the description is ground truth for a
+    drive_pn row). Widening the decode channel to drive_pn is enabled by default
+    (settings.fru_crosswalk_drive_pn_decode_enabled) iff that rate is ≤2%.
+
+Usage:
+  python -m app.management.run_fru_crosswalk                      # dry-run BOTH phases
+  python -m app.management.run_fru_crosswalk --apply              # write BOTH phases
+  python -m app.management.run_fru_crosswalk drain --apply        # drain only
+  python -m app.management.run_fru_crosswalk create --apply       # create only
+  python -m app.management.run_fru_crosswalk --measure-drive-pn   # §2.6(c) gate report
+Called by: admin manually; the deploy orchestrator runs ``--apply`` post-deploy.
+Depends on: fru_crosswalk_enrich.crosswalk_and_record_specs (drain), mpn_decoder.decode_mpn
+      + desc_extractor.extract_desc (enrichability + the drive_pn misread gate),
+      MaterialCard / MaterialSpecFacet / FruLink models, normalize_mpn(_key),
+      app.database.SessionLocal.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+
+from loguru import logger
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.constants import FruLinkKind, MaterialEnrichmentStatus
+from app.models import FruLink, MaterialCard, MaterialSpecFacet
+from app.services.desc_extractor import extract_desc
+from app.services.fru_crosswalk_enrich import crosswalk_and_record_specs
+from app.services.mpn_decoder import decode_mpn
+from app.utils.normalization import normalize_mpn, normalize_mpn_key
+
+# Card-creation phase scopes the FRU-graph edges that point at real, enrichable parts:
+# mfg_model = manufacturer model / MPN, drive_pn = bare drive PN (qual lists). lenovo_ppn
+# is EXPLICITLY excluded (§2.6(b) / §5 kill-list) — its danglers are display-only.
+CARD_CREATE_REL_KINDS = (FruLinkKind.MFG_MODEL.value, FruLinkKind.DRIVE_PN.value)
+
+# §2.6(c) gate threshold: drive_pn decode widening stays default-ON iff the measured
+# OEM-firmware-suffix misread rate is at or below this.
+DRIVE_PN_MISREAD_GATE_PCT = 2.0
+DRIVE_PN_MEASURE_SAMPLE = 100
+
+
+# ──────────────────────────────────────────────────────────────────────────────────
+# Shared helpers
+# ──────────────────────────────────────────────────────────────────────────────────
+
+
+def _existing_card_keys(db: Session) -> set[str]:
+    """normalize_mpn_key of every active card's normalized_mpn — the "has a card" set.
+
+    The FRU norms (fru_norm / related_norm) are themselves normalize_mpn_key outputs
+    (see ingest_fru_matrix), so comparing on this key matches a dangling part to its
+    card 1:1 even across raw-vs-canonical spelling.
+    """
+    keys: set[str] = set()
+    for (normalized_mpn,) in db.execute(
+        select(MaterialCard.normalized_mpn).where(MaterialCard.deleted_at.is_(None))
+    ).yield_per(5000):
+        key = normalize_mpn_key(normalized_mpn)
+        if key:
+            keys.add(key)
+    return keys
+
+
+# ──────────────────────────────────────────────────────────────────────────────────
+# Phase A — targeted drain
+# ──────────────────────────────────────────────────────────────────────────────────
+
+
+def select_drain_card_ids(db: Session, *, limit: int = 0) -> list[int]:
+    """Active cards with a mfg_model/drive_pn FRU link that are UNFACETED or
+    UNCATEGORIZED.
+
+    A card is in scope when its key-normalized MPN equals a ``fru_links.fru_norm`` of an
+    in-scope rel_kind AND (it has no MaterialSpecFacet row OR its category is NULL/blank).
+    Ordered by id for a deterministic, resumable run. ``limit`` 0 = all.
+    """
+    fru_norms = set(
+        db.execute(select(FruLink.fru_norm.distinct()).where(FruLink.rel_kind.in_(CARD_CREATE_REL_KINDS))).scalars()
+    )
+    if not fru_norms:
+        return []
+    has_facet = select(MaterialSpecFacet.id).where(MaterialSpecFacet.material_card_id == MaterialCard.id).exists()
+    has_category = func.coalesce(func.trim(MaterialCard.category), "") != ""
+    rows = db.execute(
+        select(MaterialCard.id, MaterialCard.normalized_mpn, ~has_facet, ~has_category).where(
+            MaterialCard.deleted_at.is_(None),
+            MaterialCard.is_internal_part.is_(False),
+        )
+    ).all()
+    card_ids: list[int] = []
+    for card_id, normalized_mpn, unfaceted, uncategorized in rows:
+        if not (unfaceted or uncategorized):
+            continue
+        if normalize_mpn_key(normalized_mpn) in fru_norms:
+            card_ids.append(int(card_id))
+    card_ids.sort()
+    return card_ids[:limit] if limit else card_ids
+
+
+def run_drain(db: Session, *, apply: bool = False, limit: int = 0) -> dict:
+    """Run the FRU crosswalk over the linked-but-unfaceted/uncategorized cards.
+
+    Dry-run (default) wraps the writer in a SAVEPOINT and rolls it back so the returned
+    stats are a REAL yield report (the writer's ladder + per-card savepoints all run) with
+    nothing persisted. ``--apply`` keeps the writes and commits. Returns a summary dict.
+    """
+    card_ids = select_drain_card_ids(db, limit=limit)
+    if not card_ids:
+        summary: dict[str, object] = {"mode": "apply" if apply else "dry-run", "candidates": 0, "stats": {}}
+        logger.info("run-fru-crosswalk drain [{}]: no linked-but-unfaceted/uncategorized cards", summary["mode"])
+        return summary
+
+    if apply:
+        stats = crosswalk_and_record_specs(db, card_ids)
+        db.commit()
+    else:
+        # Dry-run: the writer flushes via record_spec, so isolate every write in ONE
+        # savepoint and roll it back — the returned stats are the true yield, persisted
+        # nothing. (begin_nested needs an active transaction; SessionLocal/tests provide one.)
+        savepoint = db.begin_nested()
+        try:
+            stats = crosswalk_and_record_specs(db, card_ids)
+        finally:
+            savepoint.rollback()
+
+    summary = {"mode": "apply" if apply else "dry-run", "candidates": len(card_ids), "stats": dict(stats)}
+    logger.info("run-fru-crosswalk drain [{}]: {}", summary["mode"], summary)
+    return summary
+
+
+# ──────────────────────────────────────────────────────────────────────────────────
+# Phase B — dangling-card creation
+# ──────────────────────────────────────────────────────────────────────────────────
+
+
+def _decodes(raw: str | None, manufacturer: str | None) -> bool:
+    """True iff ``raw`` decodes to non-empty specs (the part is mpn_decode-
+    enrichable)."""
+    result = decode_mpn(raw, manufacturer)
+    return result is not None and bool(result.specs)
+
+
+def collect_creatable_cards(db: Session) -> dict[str, dict]:
+    """Plan the dangling cards to create, keyed by normalize_mpn_key (deduped, no card
+    yet).
+
+    Returns ``{key: {"display_mpn", "manufacturer", "kinds": set, "reason": str}}`` for:
+      (b1) dangling ENRICHABLE FRUs — a fru_norm with no card whose linked models DECODE
+           or whose link descriptions EXTRACT (so the tier-84 crosswalk pass will fire);
+      (b2) dangling CANONICAL models — a related_norm (mfg_model/drive_pn, NOT lenovo_ppn)
+           with no card whose related_raw DECODES (so the tier-85 mpn_decode pass fires).
+    lenovo_ppn danglers are never collected (the query is scoped to CARD_CREATE_REL_KINDS,
+    which excludes it). A part that is both keeps the first reason seen and unions its kinds.
+    """
+    existing = _existing_card_keys(db)
+    links = db.execute(
+        select(
+            FruLink.fru_norm,
+            FruLink.fru_raw,
+            FruLink.related_norm,
+            FruLink.related_raw,
+            FruLink.rel_kind,
+            FruLink.manufacturer,
+            FruLink.description,
+        ).where(FruLink.rel_kind.in_(CARD_CREATE_REL_KINDS))
+    ).all()
+
+    # FRU side (b1): gather each fru_norm's decodable models + extractable descriptions.
+    fru_raw_by_norm: dict[str, str] = {}
+    fru_models: dict[str, list[tuple[str, str | None]]] = {}
+    fru_descs: dict[str, list[str]] = {}
+    # Related side (b2): the canonical model parts.
+    related: dict[str, tuple[str, str | None]] = {}  # related_norm -> (related_raw, manufacturer)
+    for fru_norm, fru_raw, related_norm, related_raw, rel_kind, manufacturer, description in links:
+        if fru_norm:
+            fru_raw_by_norm.setdefault(fru_norm, fru_raw)
+            if rel_kind == FruLinkKind.MFG_MODEL.value:
+                fru_models.setdefault(fru_norm, []).append((related_raw, manufacturer))
+            if description and description.strip():
+                fru_descs.setdefault(fru_norm, []).append(description.strip())
+        if related_norm and related_norm not in related:
+            related[related_norm] = (related_raw, manufacturer)
+
+    plan: dict[str, dict] = {}
+
+    # (b1) dangling enrichable FRUs
+    for fru_norm in sorted(set(fru_models) | set(fru_descs)):
+        if fru_norm in existing:
+            continue
+        enrichable = any(_decodes(raw, mfg) for raw, mfg in fru_models.get(fru_norm, [])) or any(
+            extract_desc(d) is not None for d in fru_descs.get(fru_norm, [])
+        )
+        if not enrichable:
+            continue
+        display = normalize_mpn(fru_raw_by_norm[fru_norm]) or fru_raw_by_norm[fru_norm]
+        plan[fru_norm] = {
+            "display_mpn": display,
+            "manufacturer": None,  # FRU side: maker is set deterministically by the crosswalk pass
+            "kinds": {"fru"},
+            "reason": "enrichable_fru",
+        }
+
+    # (b2) dangling canonical models (decode-enrichable)
+    for related_norm in sorted(related):
+        if related_norm in existing or related_norm in plan:
+            continue
+        related_raw, manufacturer = related[related_norm]
+        if not _decodes(related_raw, manufacturer):
+            continue
+        display = normalize_mpn(related_raw) or related_raw
+        plan[related_norm] = {
+            "display_mpn": display,
+            "manufacturer": None,  # mpn_decode writes the deterministic maker on the next loop
+            "kinds": {"canonical_model"},
+            "reason": "canonical_model",
+        }
+
+    return plan
+
+
+def run_create(db: Session, *, apply: bool = False, limit: int = 0) -> dict:
+    """Create cards for the dangling enrichable FRUs + canonical models (skip
+    lenovo_ppn).
+
+    Dry-run (default) only counts. ``--apply`` inserts each card (category=None,
+    unenriched) with a per-card flush guarded against the unique-MPN race (a concurrent
+    ingest may have just created it). Returns a summary dict with per-reason counts.
+    """
+    plan = collect_creatable_cards(db)
+    keys = sorted(plan)
+    if limit:
+        keys = keys[:limit]
+
+    by_reason: Counter = Counter()
+    for key in keys:
+        by_reason[plan[key]["reason"]] += 1
+
+    created = 0
+    skipped_existing = 0
+    if apply:
+        for key in keys:
+            spec = plan[key]
+            card = MaterialCard(
+                normalized_mpn=key,
+                display_mpn=spec["display_mpn"],
+                category=None,
+                enrichment_status=MaterialEnrichmentStatus.UNENRICHED.value,
+            )
+            db.add(card)
+            try:
+                db.flush()
+                created += 1
+            except IntegrityError:
+                # A concurrent ingest created the same normalized_mpn between the plan and
+                # the insert — not an error, just nothing to create.
+                db.rollback()
+                skipped_existing += 1
+        db.commit()
+
+    summary = {
+        "mode": "apply" if apply else "dry-run",
+        "creatable": len(keys),
+        "by_reason": dict(by_reason),
+        "created": created,
+        "skipped_existing": skipped_existing,
+    }
+    logger.info("run-fru-crosswalk create [{}]: {}", summary["mode"], summary)
+    return summary
+
+
+# ──────────────────────────────────────────────────────────────────────────────────
+# §2.6(c) — drive_pn decode-widening misread gate
+# ──────────────────────────────────────────────────────────────────────────────────
+
+
+def measure_drive_pn_misreads(db: Session, *, sample: int = DRIVE_PN_MEASURE_SAMPLE) -> dict:
+    """Measure the OEM-firmware-suffix MISREAD rate of decoding drive_pn related parts.
+
+    For up to *sample* drive_pn links that DECODE (deterministic id order, resumable), a
+    decode is a MISREAD when it contradicts the linked qual-sheet description — the
+    description is the ground truth for a drive_pn row, which carries rich prose like
+    ``18TB 3.5 HDD 7.2K 12 Gb/s SAS``. A contradiction is a different commodity, or a
+    shared spec key whose decoded value differs from the description's extracted value.
+    A decode with no description to check against is counted as ``unverifiable`` (neither
+    pass nor misread — it cannot be a false read either way). The gate is misread / decoded.
+
+    Returns {decoded, misread, unverifiable, misread_pct, gate_pct, passes, sample, scanned}.
+    """
+    links = db.execute(
+        select(FruLink.related_raw, FruLink.manufacturer, FruLink.description)
+        .where(FruLink.rel_kind == FruLinkKind.DRIVE_PN.value)
+        .order_by(FruLink.id)
+    ).all()
+
+    decoded = 0
+    misread = 0
+    unverifiable = 0
+    scanned = 0
+    for related_raw, manufacturer, description in links:
+        if decoded >= sample:
+            break
+        scanned += 1
+        result = decode_mpn(related_raw, manufacturer)
+        if result is None or not result.specs:
+            continue
+        decoded += 1
+        prose = (description or "").strip()
+        truth = extract_desc(prose) if prose else None
+        if truth is None:
+            unverifiable += 1
+            continue
+        contradicts = result.commodity != truth.commodity or any(
+            key in truth.specs and str(truth.specs[key]) != str(value) for key, value in result.specs.items()
+        )
+        if contradicts:
+            misread += 1
+
+    misread_pct = round(100.0 * misread / decoded, 2) if decoded else 0.0
+    summary = {
+        "decoded": decoded,
+        "misread": misread,
+        "unverifiable": unverifiable,
+        "misread_pct": misread_pct,
+        "gate_pct": DRIVE_PN_MISREAD_GATE_PCT,
+        "passes": misread_pct <= DRIVE_PN_MISREAD_GATE_PCT,
+        "sample": sample,
+        "scanned": scanned,
+    }
+    logger.info("run-fru-crosswalk measure-drive-pn: {}", summary)
+    return summary
+
+
+# ──────────────────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Targeted FRU-graph drain + dangling-card creation (§2.6)")
+    parser.add_argument(
+        "phase",
+        nargs="?",
+        choices=("drain", "create", "all"),
+        default="all",
+        help="Which phase to run (default: all)",
+    )
+    parser.add_argument("--apply", action="store_true", help="Persist the writes/creations (default: dry-run)")
+    parser.add_argument("--limit", type=int, default=0, help="Max cards per phase (0 = all)")
+    parser.add_argument(
+        "--measure-drive-pn",
+        action="store_true",
+        help="Only report the §2.6(c) drive_pn decode-widening misread rate; no writes",
+    )
+    args = parser.parse_args()
+
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        if args.measure_drive_pn:
+            measure_drive_pn_misreads(db)
+            db.rollback()
+            return
+        if args.apply:
+            logger.warning(
+                "run-fru-crosswalk: --apply will write specs/categories/manufacturers via the F1 ladder "
+                "and CREATE dangling cards — ensure a recent db-backup exists (pg_dump every 6h; "
+                "scripts/restore.sh to roll back)"
+            )
+        if args.phase in ("drain", "all"):
+            run_drain(db, apply=args.apply, limit=args.limit)
+        if args.phase in ("create", "all"):
+            run_create(db, apply=args.apply, limit=args.limit)
+        if not args.apply:
+            db.rollback()  # belt-and-braces: dry-run leaves no writes behind
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/services/fru_crosswalk_enrich.py
+++ b/app/services/fru_crosswalk_enrich.py
@@ -7,13 +7,18 @@ settings.fru_crosswalk_enrich_enabled:
 
 1. **Model decode** (``fru_matrix_decode``, tier 84, confidence 0.93): for each batch
    card whose key-normalized MPN matches ``fru_links.fru_norm``, decodes every linked
-   ``mfg_model`` manufacturer model with the existing pure MPN decoders (zero LLM,
-   zero network), STRICT-INTERSECTS the results (only spec keys present in every
-   decode with equal values survive; a commodity disagreement skips the card
-   entirely), and writes the agreed specs via record_spec. Category is filled from
-   the agreed commodity ONLY when the card has none (via ``spec_tiers.set_category``,
-   stamping tier-84 provenance; an existing DIFFERENT category skips the card before
-   any write).
+   ``mfg_model`` manufacturer model (and ``drive_pn`` links when
+   ``settings.fru_crosswalk_drive_pn_decode_enabled`` — the gated widening, measured 0%
+   misread) with the existing pure MPN decoders (zero LLM, zero network),
+   STRICT-INTERSECTS the results (only spec keys present in every decode with equal
+   values survive; a commodity disagreement skips the card entirely), and writes the
+   agreed specs via record_spec. Category is filled from the agreed commodity ONLY when
+   the card has none (via ``spec_tiers.set_category``, stamping tier-84 provenance; an
+   existing DIFFERENT category skips the card before any write). The card's MANUFACTURER
+   is filled (via ``spec_tiers.set_manufacturer`` at tier 84) ONLY when every decoded
+   substitute identifies the SAME maker — the decoder's regex gate is
+   manufacturer-scheme-specific, so a unanimous vendor is a DETERMINISTIC maker, never a
+   prose inference (D4: the prohibition was on prose inference, not deterministic decode).
 2. **Linked-description parse** (``fru_desc_parse``, tier 82, confidence 0.88): the
    FRU matrix qual sheets stored prose on fru_links rows (drive_pn rows carry strings
    like ``18TB 3.5 HDD 7.2K 12 Gb/s SAS``, mfg_model rows carry bare-drive prose like
@@ -50,7 +55,9 @@ fru_desc_parse 82 sits between desc_parse (83 — the card's OWN description out
 a linked row's prose) and partsurfer (80). Neither channel can overwrite an
 mpn_decode/desc_parse/vendor-API/trio_source prior and both always beat AI
 spec_extraction (60), so there is NO per-writer confidence pre-gate here. The card's
-manufacturer is never touched. Reverse direction (a card that IS a mfg_model) gains
+manufacturer is written ONLY by the decode channel's deterministic maker propagation
+(unanimous decoded vendor; the desc channel never writes a maker). Reverse direction
+(a card that IS a mfg_model) gains
 nothing here — its own MPN already decodes directly at tier 85 and its own
 description already desc-parses at tier 83. Does not commit — the caller manages
 the txn.
@@ -68,12 +75,13 @@ from collections import Counter
 from loguru import logger
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.constants import FruLinkKind
 from app.models import FruLink, MaterialCard
 from app.services.desc_extractor import DescResult, extract_desc
 from app.services.desc_extractor._common import SPEC_COMMODITIES
 from app.services.mpn_decoder import DecodeResult, decode_mpn
-from app.services.spec_tiers import set_category
+from app.services.spec_tiers import set_category, set_manufacturer
 from app.services.spec_write_service import load_schema_cache, record_spec
 from app.utils.normalization import normalize_mpn_key
 
@@ -91,6 +99,30 @@ FRU_DECODE_CONFIDENCE = 0.93
 # deliberately ignored for the same one-hop reason as above; the ladder arbitrates.
 FRU_DESC_SOURCE = "fru_desc_parse"
 FRU_DESC_CONFIDENCE = 0.88
+
+# Confidence for the FRU-side MAKER write (D4 maker propagation). The decode's vendor IS a
+# DETERMINISTIC maker claim — every decoder's regex gate is manufacturer-scheme-specific
+# (an ``M393A…`` part is unambiguously Samsung, an ``ST…`` part unambiguously Seagate), so a
+# unanimous vendor across a FRU's decoded canonical models is a deterministic maker, never a
+# prose inference (the D4 prohibition was about prose inference, not deterministic decode).
+# One notch below the per-spec decode confidence (0.93), exactly like mpn_decoder/writer.py's
+# MAKER_CONFIDENCE sits below DECODE_CONFIDENCE; the F1 ladder (set_manufacturer at tier 84)
+# arbitrates, never this confidence.
+FRU_MAKER_CONFIDENCE = 0.9
+
+
+def agree_vendor(results: "list[DecodeResult]") -> str | None:
+    """Return the single vendor every decode agrees on, else ``None`` (pure, no DB).
+
+    Maker propagation (D4) is deterministic-only: a maker is written for the FRU-side card
+    ONLY when EVERY decoded canonical model identifies the SAME maker via its regex-gated
+    scheme. A vendor disagreement (Seagate vs Western Digital among a FRU's substitutes) or
+    an empty *results* list yields ``None`` — assert no maker rather than guess one. Callers
+    must filter spec-less / unrecognized decodes before calling (same contract as
+    ``intersect_decodes``: the caller already drops ``decode_mpn`` results without specs).
+    """
+    vendors = {r.vendor for r in results if r.vendor}
+    return next(iter(vendors)) if len(vendors) == 1 else None
 
 
 def intersect_decodes(
@@ -149,8 +181,8 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
     """Crosswalk-enrich the FRU cards among *card_ids*: decode their mfg_model links AND
     parse their linked qual-sheet descriptions; write the agreed specs.
 
-    Returns {matched, decoded, written, categorized, desc_parsed, desc_written,
-    failed, desc_failed, dropped_conflict, desc_dropped_conflict,
+    Returns {matched, decoded, written, categorized, manufacturers_set, desc_parsed,
+    desc_written, failed, desc_failed, dropped_conflict, desc_dropped_conflict,
     commodity_conflict, desc_commodity_conflict, category_mismatch,
     desc_category_mismatch}:
 
@@ -164,6 +196,13 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
     - written: fru_matrix_decode specs persisted.
     - categorized: NULL-category cards categorized from the agreed decode commodity
       (the desc channel never categorizes).
+    - manufacturers_set: cards whose manufacturer was written from the FRU's UNANIMOUS
+      decoded vendor (D4 deterministic maker propagation — set_manufacturer at
+      fru_matrix_decode/84). Only counted on a clean savepoint release, only when the
+      decode commodity agrees with the card's category (shared cross-commodity guard),
+      and only when every decoded substitute identifies the SAME maker (agree_vendor).
+      The desc channel never writes a maker (linked prose is not a deterministic maker
+      proof).
     - desc_parsed: cards that landed ≥1 fru_desc_parse spec from their linked
       descriptions.
     - desc_written: fru_desc_parse specs persisted.
@@ -202,6 +241,7 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
         "decoded": 0,
         "written": 0,
         "categorized": 0,
+        "manufacturers_set": 0,
         "desc_parsed": 0,
         "desc_written": 0,
         "failed": 0,
@@ -239,12 +279,20 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
         )
         .all()
     )
+    # (c) drive_pn DECODE widening (gated). The decode channel reads mfg_model links
+    # always; drive_pn links join the decode set ONLY under the flag (measured 0% misread —
+    # drive_pn related parts are IBM/Lenovo FRU numbers that the regex gates reject, so the
+    # widening writes nothing today but catches a future canonical drive_pn entry). The DESC
+    # channel reads drive_pn descriptions regardless of this flag (unchanged below).
+    decode_rel_kinds = {FruLinkKind.MFG_MODEL.value}
+    if settings.fru_crosswalk_drive_pn_decode_enabled:
+        decode_rel_kinds.add(FruLinkKind.DRIVE_PN.value)
     linked_frus: set[str] = set()  # every FRU with an in-scope link — the "matched" universe
     models_by_fru: dict[str, set[tuple[str, str | None]]] = {}
     descs_by_fru: dict[str, set[str]] = {}
     for link in links:
         linked_frus.add(link.fru_norm)
-        if link.rel_kind == FruLinkKind.MFG_MODEL.value:
+        if link.rel_kind in decode_rel_kinds:
             models_by_fru.setdefault(link.fru_norm, set()).add((link.related_raw, link.manufacturer))
         description = (link.description or "").strip()
         if description:
@@ -286,6 +334,11 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
             continue
         commodity: str | None = None
         agreed: dict[str, str | int | float | bool] = {}
+        # (d) D4 maker propagation: the UNANIMOUS maker across the FRU's decoded canonical
+        # models (every decoder's regex gate is manufacturer-scheme-specific, so a single
+        # agreed vendor is a deterministic maker, never a prose inference). None when the
+        # substitutes disagree on the maker or none decoded — assert no maker then.
+        vendor: str | None = agree_vendor(results)
         if results:
             commodity, agreed, dropped = intersect_decodes(results)
             stats["dropped_conflict"] += dropped  # once per FRU, independent of card outcomes
@@ -325,11 +378,12 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
                         elif schema.data_type == "enum" and schema.enum_values and str(value) not in schema.enum_values:
                             dropped_out_of_enum[f"{commodity}.{spec_key}={value}"] += 1
                     card_written = 0
+                    did_set_maker = False
                     # SAVEPOINT 1 — decode channel: record_spec flushes, so a DB-level
                     # failure would otherwise poison the shared batch transaction. The
                     # nested txn rolls back ONLY this card's decode writes (including a
-                    # categorize-from-null); counters increment after a clean release
-                    # so a rolled-back card contributes nothing.
+                    # categorize-from-null AND the maker write); counters increment after a
+                    # clean release so a rolled-back card contributes nothing.
                     with db.begin_nested():
                         if not card_cat:
                             # The agreed commodity is regex-gated against strict manufacturer
@@ -338,6 +392,16 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
                             # existing=None always loses to the incoming write). record_spec
                             # requires a category, so this precedes the loop.
                             set_category(card, commodity, FRU_DECODE_SOURCE, FRU_DECODE_CONFIDENCE)
+                        # (d) D4 maker propagation: the card reached here only because its
+                        # category agrees with the decoded commodity (the cross-commodity
+                        # guard above), so the unanimous decoded vendor is a SAFE deterministic
+                        # maker for this card. set_manufacturer (tier 84) corrects a legacy OEM
+                        # label sitting in `manufacturer` (unprovenanced, tier 50) but never
+                        # overwrites a vendor-API (90) / trio_source (95) / manual (100) value —
+                        # the F1 ladder, not run order, arbitrates. None vendor (substitutes
+                        # disagree on the maker) writes nothing — never infer a maker.
+                        if vendor is not None:
+                            did_set_maker = set_manufacturer(card, vendor, FRU_DECODE_SOURCE, FRU_MAKER_CONFIDENCE)
                         # No pre-gate: record_spec's F1 tier ladder rejects any write that
                         # loses to a higher-(tier, confidence, updated_at) prior (mpn_decode
                         # 85 / vendor 90 / trio_source 95 all outrank tier 84).
@@ -357,6 +421,8 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
                     stats["written"] += card_written
                     if not card_cat:
                         stats["categorized"] += 1
+                    if did_set_maker:
+                        stats["manufacturers_set"] += 1
             except Exception:
                 stats["failed"] += 1
                 logger.exception("fru-crosswalk: failed on card_id={}", card_id)
@@ -475,6 +541,7 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
     if (
         stats["written"]
         or stats["categorized"]
+        or stats["manufacturers_set"]
         or stats["desc_written"]
         or stats["failed"]
         or stats["desc_failed"]
@@ -483,12 +550,13 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
     ):
         logger.info(
             "fru-crosswalk: wrote {} decode specs across {} decoded cards "
-            "({} newly categorized) + {} linked-desc specs across {} desc-parsed cards "
+            "({} newly categorized, {} makers set) + {} linked-desc specs across {} desc-parsed cards "
             "({}/{} decode/desc keys dropped by intersection, {} desc commodity conflicts, "
             "{} desc category mismatches, {} cards failed, {} desc channels failed)",
             stats["written"],
             stats["decoded"],
             stats["categorized"],
+            stats["manufacturers_set"],
             stats["desc_written"],
             stats["desc_parsed"],
             stats["dropped_conflict"],

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -318,7 +318,7 @@
 | manufacturer | String 255, indexed | Dual-brand semantics (migration 097): the ACTUAL MAKER (`Seagate Technology`, `Kingston Technology`, composite `Hitachi/IBM` verbatim). Written ONLY via `spec_tiers.set_manufacturer` (F1 ladder + `normalize_brand_name`); legacy direct writes rank at the `legacy_backfill` floor (50) on the next arbitration. |
 | brand | String 255, nullable, indexed (`ix_material_cards_brand`) | Migration 097. The OEM LABEL on the part (`IBM`, `Dell Technologies`, `Hewlett Packard Enterprise`, `Lenovo`) — most cards never get one. Written ONLY via `spec_tiers.set_brand`, gated to source-backed evidence (`OEM_TRAILING_RE` description token, explicit ingest column, B1 legacy reclassify) — never guessed. The materials "Brand" facet ORs across `brand` + `manufacturer` (one combined facet; wire param stays `manufacturers`). |
 | brand_source / brand_confidence / brand_tier / brand_updated_at | String 50 / Float / Integer / UTCDateTime — all nullable | Migration 097. Provenance for `brand`, same F1 contract as `category_*` (valued-but-NULL-provenance ranks at the legacy floor 50; `brand_updated_at` is the ladder tie-break stamp). |
-| manufacturer_source / manufacturer_confidence / manufacturer_tier / manufacturer_updated_at | String 50 / Float / Integer / UTCDateTime — all nullable | Migration 097. Provenance for `manufacturer` — required so trio_source (95) maker evidence (fru_links `mfg_model`) can displace an OEM name sitting in `manufacturer` from legacy data via the ladder. All pre-097 rows are NULL → legacy floor 50 at runtime (no in-migration backfill; the data backfill is `python -m app.management.backfill_dual_brand`, dry-run by default, run post-deploy). |
+| manufacturer_source / manufacturer_confidence / manufacturer_tier / manufacturer_updated_at | String 50 / Float / Integer / UTCDateTime — all nullable | Migration 097. Provenance for `manufacturer` — required so trio_source (95) maker evidence (fru_links `mfg_model`) can displace an OEM name sitting in `manufacturer` from legacy data via the ladder. Maker writers: `mpn_decode` (85, decoder's own vendor), `fru_matrix_decode` (84, §2.6(d) — the UNANIMOUS deterministic vendor across a FRU's decoded canonical models, conf 0.9), vendor APIs (90), trio_source (95), manual (100). All pre-097 rows are NULL → legacy floor 50 at runtime (no in-migration backfill; the data backfill is `python -m app.management.backfill_dual_brand`, dry-run by default, run post-deploy). |
 | description | Text | AI-enriched part description |
 | category | String 255 | AI-enriched commodity category |
 | lifecycle_status | String 50 | active\|nrfnd\|eol\|obsolete\|ltb |
@@ -382,6 +382,12 @@
 > UNIQUE `uq_fru_links_edge` (fru_norm, related_norm, rel_kind, source_sheet). Populated by
 > `python -m app.management.ingest_fru_matrix <xlsx> [--apply]`; read by
 > `app/services/fru_matrix_service.py` for the materials detail "FRU matrix" / "Used in FRUs" panels.
+> The `mfg_model` (always) and `drive_pn` (gated by `settings.fru_crosswalk_drive_pn_decode_enabled`)
+> edges feed the FRU crosswalk DECODE channel (`fru_crosswalk_enrich.py` → tier-84 category +
+> deterministic-maker + specs); `mfg_model`/`drive_pn` descriptions feed the DESC channel
+> (tier-82 specs). The targeted drain + dangling-card creation over these edges is
+> `python -m app.management.run_fru_crosswalk [drain|create|all] [--apply]` (dry-run default;
+> lenovo_ppn danglers are explicitly skipped). See APP_MAP_INTERACTIONS "FRU Crosswalk".
 
 **`oem_crosswalk`** — permanent OEM spare→canonical-MPN web-resolution cache, incl. negative rows (migration 101)
 | Column | Type | Notes |

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1263,9 +1263,17 @@ owns arbitration in one place:
        fru_links query (rel_kind IN mfg_model + drive_pn), both gated by
        settings.fru_crosswalk_enrich_enabled. (a) DECODE channel: IBM/Lenovo FRU
        spare PNs inherit the STRICT-INTERSECTED decode of their rel_kind='mfg_model'
-       models — only spec keys present in every decode with equal values write; a
-       commodity disagreement skips the card (BOTH channels) — source=
-       "fru_matrix_decode" (tier 84), confidence 0.93. (b) LINKED-DESCRIPTION channel
+       models (PLUS rel_kind='drive_pn' when settings.fru_crosswalk_drive_pn_decode_enabled
+       — the §2.6(c) GATED widening; measured 0% OEM-firmware-suffix misread so default ON,
+       since drive_pn related parts are IBM/Lenovo FRU numbers the regex gates reject, but
+       the desc channel reads drive_pn descriptions regardless of the flag) — only spec keys
+       present in every decode with equal values write; a commodity disagreement skips the
+       card (BOTH channels) — source="fru_matrix_decode" (tier 84), confidence 0.93. The
+       card's MANUFACTURER is filled via spec_tiers.set_manufacturer (tier 84, conf 0.9)
+       ONLY when EVERY decoded substitute identifies the SAME maker (DecodeResult.vendor;
+       the decoder's regex gate is manufacturer-scheme-specific, so a unanimous vendor is a
+       DETERMINISTIC maker — §2.6(d)/D4: never a prose inference) and the decode commodity
+       agrees with the card's category — counted in manufacturers_set. (b) LINKED-DESCRIPTION channel
        (wave 3A): the qual-sheet prose stored on the FRU's mfg_model + drive_pn rows
        (e.g. drive_pn `18TB 3.5 HDD 7.2K 12 Gb/s SAS`, mfg_model `SSD; 2.5; 1.92 TB
        Samsung PM1733`) runs through desc_extractor.extract_desc(description,
@@ -1292,7 +1300,8 @@ owns arbitration in one place:
        NOT enriched_ids — FRU spares finish not_found, and the pass never touches
        enrichment_status. Fills a NULL category from the agreed DECODE commodity via
        spec_tiers.set_category (an existing DIFFERENT category skips the card before
-       any write); never writes manufacturer; never writes the reverse direction (a
+       any write); writes manufacturer ONLY via the deterministic-maker propagation
+       above (the desc channel never writes a maker); never writes the reverse direction (a
        card that IS a mfg_model already decodes first-party at tier 85 and
        desc-parses its own description at tier 83). The ladder (82 < 83 desc_parse <
        84 < 85, < vendor 90) guarantees neither channel overwrites
@@ -1798,6 +1807,26 @@ wd_revision_digit/capacity_grid/seagate_envelope/nand_density — the decoder's
 `dropped`/`drop_reasons` channel attributes grid-emptied capacity-only decodes to
 capacity_grid and envelope refusals to seagate_envelope, never to the shape-regex
 fallback buckets); SAVEPOINT per card.
+
+Targeted FRU-graph drain (§2.6): `python -m app.management.run_fru_crosswalk
+[drain|create|all] [--apply] [--limit N] [--measure-drive-pn]` — dry-run by
+default, two phases. PHASE A (`drain`) runs `crosswalk_and_record_specs` over the
+EXISTING cards that have a mfg_model/drive_pn FRU link but are still UNFACETED (no
+material_spec_facets row) or UNCATEGORIZED (category NULL/blank) — the worker only
+crosswalks whatever lands in its current batch, so this is the targeted runner;
+dry-run wraps the writer in a SAVEPOINT and rolls it back, so the returned stats are
+a REAL yield report with nothing persisted. PHASE B (`create`) creates MaterialCards
+(category=None, unenriched) for two dangling populations so the worker's tier-84
+crosswalk / tier-85 mpn_decode passes fire on the next loop: (b1) dangling enrichable
+FRUs — a fru_norm with NO card whose linked models decode or whose link descriptions
+extract; (b2) dangling canonical models — a related_norm (mfg_model/drive_pn, NEVER
+lenovo_ppn) with NO card whose related_raw decodes to a recognized vendor. The ~31k
+lenovo_ppn danglers are EXPLICITLY out of scope (display-only; §5 kill-list).
+`--measure-drive-pn` reports the §2.6(c) gate: the OEM-firmware-suffix MISREAD rate of
+decoding drive_pn related parts (a decode whose commodity/specs contradict the linked
+qual-sheet description) — drive_pn decode widening defaults ON iff that rate ≤2%
+(measured 0/3328 decode → 0%). All writes go through the F1 ladder (set_category /
+set_manufacturer / record_spec); the orchestrator runs `--apply` post-deploy.
 
 ## Cross-Reference Caching
 

--- a/tests/test_fru_crosswalk_writer.py
+++ b/tests/test_fru_crosswalk_writer.py
@@ -28,6 +28,7 @@ ZERO_STATS = {
     "decoded": 0,
     "written": 0,
     "categorized": 0,
+    "manufacturers_set": 0,
     "desc_parsed": 0,
     "desc_written": 0,
     "failed": 0,
@@ -93,6 +94,7 @@ def test_writer_writes_intersected_specs_with_source_and_confidence(db_session: 
         matched=1,
         decoded=1,
         written=2,
+        manufacturers_set=1,  # both substitutes decode to Seagate — unanimous maker (D4)
         dropped_conflict=1,  # capacity_gb 4000 vs 8000
     )
     f = _facets(db_session, card.id)
@@ -100,6 +102,9 @@ def test_writer_writes_intersected_specs_with_source_and_confidence(db_session: 
     entry = card.specs_structured["form_factor"]
     assert entry["source"] == FRU_DECODE_SOURCE == "fru_matrix_decode"
     assert entry["confidence"] == FRU_DECODE_CONFIDENCE == 0.93
+    # (d) D4: the unanimous decoded vendor is the deterministic maker, written at tier 84.
+    assert card.manufacturer == "Seagate"
+    assert card.manufacturer_source == FRU_DECODE_SOURCE
 
 
 def test_single_model_writes_all_specs_and_categorizes_null_category(db_session: Session):
@@ -159,9 +164,11 @@ def test_commodity_conflict_skips_card(db_session: Session):
     assert _facets(db_session, card.id) == {}
 
 
-def test_card_manufacturer_never_written(db_session: Session):
-    # The FRU card keeps its IBM/Lenovo manufacturer context — the drive vendor on
-    # the link (Seagate) is display-only and never copied onto the card.
+def test_deterministic_maker_upgrades_legacy_oem_label(db_session: Session):
+    # (d) D4 maker propagation: a legacy IBM/Lenovo OEM label (unprovenanced → ranks at
+    # the legacy_backfill tier 50) is UPGRADED to the DETERMINISTIC maker the decoder
+    # identifies (Seagate, tier 84) — never inferred from prose, always from the
+    # regex-gated decode of the linked canonical model.
     seed_commodity_schemas(db_session)
     card = _card(db_session, "00AJ141", category="hdd", manufacturer="IBM")
     _link(db_session, "00AJ141", "ST4000NM0035", mfg="Seagate")
@@ -170,7 +177,10 @@ def test_card_manufacturer_never_written(db_session: Session):
     db_session.commit()
 
     assert stats["written"] == 3
-    assert card.manufacturer == "IBM"
+    assert stats["manufacturers_set"] == 1
+    assert card.manufacturer == "Seagate"
+    assert card.manufacturer_source == FRU_DECODE_SOURCE
+    assert card.manufacturer_tier == 84
 
 
 def test_ladder_skips_higher_tier_prior_overwrites_lower(db_session: Session):
@@ -661,11 +671,13 @@ def test_decode_filled_category_routes_desc_channel_same_pass(db_session: Sessio
         decoded=1,
         written=3,
         categorized=1,
+        manufacturers_set=1,  # the lone decoding model (ST…) is Seagate — unanimous maker
         desc_parsed=1,
         desc_written=2,  # rpm + interface; capacity_gb lost 82 < 84
     )
     assert card.category == "hdd"
     assert card.category_source == FRU_DECODE_SOURCE  # the desc channel NEVER categorizes
+    assert card.manufacturer == "Seagate"  # the drive_pn IBM FRU (00FJ069) does not decode
     f = _facets(db_session, card.id)
     assert f["capacity_gb"] == 4000  # decode (84) kept over desc prose (82)
     assert f["rpm"] == "10000"

--- a/tests/test_run_fru_crosswalk.py
+++ b/tests/test_run_fru_crosswalk.py
@@ -1,0 +1,372 @@
+"""Targeted FRU-graph drain CLI (app.management.run_fru_crosswalk, §2.6).
+
+Covers:
+  - PHASE A drain: selects linked-but-unfaceted/uncategorized cards only; dry-run reports
+    a real yield WITHOUT persisting; --apply persists.
+  - PHASE B card creation: dangling enrichable FRUs + dangling canonical models become
+    cards; the lenovo_ppn danglers are SKIPPED; dry-run counts without inserting.
+  - §2.6(c) drive_pn decode-widening misread gate logic (pass / fail / unverifiable).
+  - §2.6(d) deterministic maker propagation: positive (unanimous vendor → maker set) and
+    the negative (vendor disagreement → specs write but NO maker).
+
+Real decoding MPNs used: ST4000NM0035 / ST8000NM0055 (Seagate hdd), HUS726040ALE610
+(HGST hdd), MZ7LH960HAJR (Samsung ssd). drive_pn related parts are IBM FRU numbers
+(00VN…) that do NOT decode — exactly the live-data shape.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.constants import FruLinkKind, MaterialEnrichmentStatus
+from app.management.run_fru_crosswalk import (
+    collect_creatable_cards,
+    measure_drive_pn_misreads,
+    run_create,
+    run_drain,
+    select_drain_card_ids,
+)
+from app.models import FruLink, MaterialCard, MaterialSpecFacet
+from app.services.commodity_registry import seed_commodity_schemas
+from app.services.fru_crosswalk_enrich import crosswalk_and_record_specs
+from app.utils.normalization import normalize_mpn_key
+
+
+def _card(db: Session, mpn: str, category: str | None = None, **kw) -> MaterialCard:
+    card = MaterialCard(normalized_mpn=normalize_mpn_key(mpn), display_mpn=mpn, category=category, **kw)
+    db.add(card)
+    db.flush()
+    return card
+
+
+def _link(
+    db: Session,
+    fru: str,
+    related: str,
+    *,
+    mfg: str | None = "Seagate",
+    kind: str = FruLinkKind.MFG_MODEL.value,
+    sheet: str = "Main",
+    description: str | None = None,
+) -> FruLink:
+    link = FruLink(
+        fru_raw=fru,
+        fru_norm=normalize_mpn_key(fru),
+        related_raw=related,
+        related_norm=normalize_mpn_key(related),
+        rel_kind=kind,
+        manufacturer=mfg,
+        description=description,
+        source_sheet=sheet,
+    )
+    db.add(link)
+    db.flush()
+    return link
+
+
+# ── PHASE A: targeted drain ─────────────────────────────────────────────────────────
+
+
+def test_drain_selects_only_linked_unfaceted_or_uncategorized(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # In scope: linked + uncategorized.
+    linked_uncat = _card(db_session, "00AJ141", category=None)
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    # In scope: linked + categorized but unfaceted.
+    linked_unfaceted = _card(db_session, "00AJ200", category="hdd")
+    _link(db_session, "00AJ200", "ST8000NM0055")
+    # OUT of scope: linked but already faceted AND categorized.
+    faceted = _card(db_session, "00AJ300", category="hdd")
+    _link(db_session, "00AJ300", "ST4000NM0035")
+    db_session.add(
+        MaterialSpecFacet(material_card_id=faceted.id, category="hdd", spec_key="form_factor", value_text='3.5"')
+    )
+    # OUT of scope: unfaceted+uncategorized but NO FRU link.
+    _card(db_session, "ZZZ999", category=None)
+    db_session.flush()
+
+    ids = set(select_drain_card_ids(db_session))
+    assert ids == {linked_uncat.id, linked_unfaceted.id}
+
+
+def test_drain_dry_run_reports_yield_without_persisting(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category=None)
+    _link(db_session, "00AJ141", "ST4000NM0035")  # decodes hdd, Seagate
+    db_session.flush()
+
+    summary = run_drain(db_session, apply=False)
+    assert summary["mode"] == "dry-run"
+    assert summary["candidates"] == 1
+    assert summary["stats"]["decoded"] == 1
+    assert summary["stats"]["categorized"] == 1
+    assert summary["stats"]["manufacturers_set"] == 1
+    # Nothing persisted — the savepoint rolled back.
+    db_session.expire_all()
+    assert db_session.get(MaterialCard, card.id).category is None
+    assert db_session.query(MaterialSpecFacet).count() == 0
+
+
+def test_drain_apply_persists_specs_category_and_maker(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = _card(db_session, "00AJ141", category=None)
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    db_session.flush()
+
+    summary = run_drain(db_session, apply=True)
+    assert summary["mode"] == "apply"
+    assert summary["stats"]["written"] >= 1
+
+    db_session.expire_all()
+    refreshed = db_session.get(MaterialCard, card.id)
+    assert refreshed.category == "hdd"
+    assert refreshed.manufacturer == "Seagate"  # §2.6(d) deterministic maker
+    assert db_session.query(MaterialSpecFacet).filter_by(material_card_id=card.id).count() >= 1
+
+
+def test_drain_no_candidates(db_session: Session):
+    seed_commodity_schemas(db_session)
+    summary = run_drain(db_session, apply=False)
+    assert summary == {"mode": "dry-run", "candidates": 0, "stats": {}}
+
+
+# ── PHASE B: dangling-card creation ─────────────────────────────────────────────────
+
+
+def test_create_skips_lenovo_ppn_danglers(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # A FRU that already has a card, with a dangling lenovo_ppn (out of scope) and a
+    # dangling canonical model (in scope).
+    _card(db_session, "00AJ141", category="hdd")
+    _link(db_session, "00AJ141", "ST4000NM0035")  # dangling canonical model — creatable
+    _link(db_session, "00AJ141", "0000000NV340_E00", kind=FruLinkKind.LENOVO_PPN.value, mfg=None)
+    db_session.flush()
+
+    plan = collect_creatable_cards(db_session)
+    keys = set(plan)
+    assert normalize_mpn_key("ST4000NM0035") in keys
+    # The lenovo_ppn dangler is NEVER collected.
+    assert normalize_mpn_key("0000000NV340_E00") not in keys
+    assert all(plan[k]["reason"] == "canonical_model" for k in keys)
+
+
+def test_create_collects_dangling_canonical_models_and_enrichable_frus(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # Dangling FRU (no card) with an enrichable mfg_model link → both the FRU (b1) and the
+    # canonical model (b2) are creatable.
+    _link(db_session, "00AAA01", "ST4000NM0035")
+    db_session.flush()
+
+    plan = collect_creatable_cards(db_session)
+    assert plan[normalize_mpn_key("00AAA01")]["reason"] == "enrichable_fru"
+    assert plan[normalize_mpn_key("ST4000NM0035")]["reason"] == "canonical_model"
+
+
+def test_create_skips_non_enrichable_dangling_fru(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # A dangling FRU whose only link is a non-decoding IBM FRU drive_pn with no description
+    # → not enrichable → no FRU card, no canonical card.
+    _link(db_session, "49Y9999", "00VN528", kind=FruLinkKind.DRIVE_PN.value, mfg=None, description=None)
+    db_session.flush()
+
+    plan = collect_creatable_cards(db_session)
+    assert plan == {}
+
+
+def test_create_skips_parts_that_already_have_cards(db_session: Session):
+    seed_commodity_schemas(db_session)
+    _card(db_session, "ST4000NM0035", category="hdd")  # canonical model already a card
+    _card(db_session, "00AJ141", category="hdd")  # FRU already a card
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    db_session.flush()
+
+    plan = collect_creatable_cards(db_session)
+    assert plan == {}
+
+
+def test_create_apply_inserts_unenriched_null_category_cards(db_session: Session):
+    seed_commodity_schemas(db_session)
+    _link(db_session, "00AAA01", "ST4000NM0035")
+    db_session.flush()
+
+    summary = run_create(db_session, apply=True)
+    assert summary["mode"] == "apply"
+    assert summary["created"] == 2  # the FRU + the canonical model
+    db_session.expire_all()
+
+    created = db_session.execute(
+        select(MaterialCard).where(MaterialCard.normalized_mpn == normalize_mpn_key("ST4000NM0035"))
+    ).scalar_one()
+    assert created.category is None
+    assert created.enrichment_status == MaterialEnrichmentStatus.UNENRICHED.value
+
+
+def test_create_dry_run_does_not_insert(db_session: Session):
+    seed_commodity_schemas(db_session)
+    _link(db_session, "00AAA01", "ST4000NM0035")
+    db_session.flush()
+    before = db_session.query(MaterialCard).count()
+
+    summary = run_create(db_session, apply=False)
+    assert summary["mode"] == "dry-run"
+    assert summary["creatable"] == 2
+    assert summary["created"] == 0
+    assert db_session.query(MaterialCard).count() == before
+
+
+# ── §2.6(c): drive_pn decode-widening misread gate ──────────────────────────────────
+
+
+def test_measure_drive_pn_gate_passes_when_nothing_decodes(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # Live shape: drive_pn related parts are IBM FRU numbers that never decode.
+    _link(
+        db_session,
+        "49Y7443",
+        "00VN528",
+        kind=FruLinkKind.DRIVE_PN.value,
+        mfg=None,
+        description="HDD; Seagate; 14000GB; 3.5; 7200 RPM; SAS",
+    )
+    db_session.flush()
+
+    result = measure_drive_pn_misreads(db_session, sample=100)
+    assert result["decoded"] == 0
+    assert result["misread"] == 0
+    assert result["misread_pct"] == 0.0
+    assert result["passes"] is True  # 0% <= 2% gate
+
+
+def test_measure_drive_pn_gate_counts_misread_on_contradiction(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # A drive_pn whose related part DECODES (a real Seagate MPN) but whose qual-sheet
+    # description contradicts the decode → a misread. The decode is hdd/Seagate/4000GB;
+    # the prose says SSD → commodity contradiction.
+    _link(
+        db_session,
+        "49Y7443",
+        "ST4000NM0035",
+        kind=FruLinkKind.DRIVE_PN.value,
+        mfg="Seagate",
+        description="SSD; Samsung; 960GB; 2.5; SATA",
+    )
+    db_session.flush()
+
+    result = measure_drive_pn_misreads(db_session, sample=100)
+    assert result["decoded"] == 1
+    assert result["misread"] == 1
+    assert result["misread_pct"] == 100.0
+    assert result["passes"] is False  # 100% > 2% gate
+
+
+def test_measure_drive_pn_unverifiable_when_no_description(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # Decodes but has no description to check against → unverifiable (not pass, not misread).
+    _link(
+        db_session,
+        "49Y7443",
+        "ST4000NM0035",
+        kind=FruLinkKind.DRIVE_PN.value,
+        mfg="Seagate",
+        description=None,
+    )
+    db_session.flush()
+
+    result = measure_drive_pn_misreads(db_session, sample=100)
+    assert result["decoded"] == 1
+    assert result["misread"] == 0
+    assert result["unverifiable"] == 1
+    assert result["passes"] is True
+
+
+def test_measure_drive_pn_no_misread_when_decode_agrees_with_prose(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # Decodes hdd/4000GB and the prose agrees (hdd, 4000GB) → not a misread.
+    _link(
+        db_session,
+        "49Y7443",
+        "ST4000NM0035",
+        kind=FruLinkKind.DRIVE_PN.value,
+        mfg="Seagate",
+        description="HDD; Seagate; 4000GB; 3.5; 7200 RPM; SAS",
+    )
+    db_session.flush()
+
+    result = measure_drive_pn_misreads(db_session, sample=100)
+    assert result["decoded"] == 1
+    assert result["misread"] == 0
+    assert result["passes"] is True
+
+
+# ── §2.6(c): drive_pn decode-WIDENING flag gates the decode channel ─────────────────
+
+
+def test_drive_pn_decode_widening_flag_includes_decoding_drive_pn(db_session: Session, monkeypatch):
+    # Flag ON (default): a drive_pn link whose related part DECODES feeds the decode
+    # channel → the card is decoded + categorized from it.
+    seed_commodity_schemas(db_session)
+    monkeypatch.setattr(settings, "fru_crosswalk_drive_pn_decode_enabled", True)
+    card = _card(db_session, "00AJ141", category=None)
+    _link(db_session, "00AJ141", "ST4000NM0035", kind=FruLinkKind.DRIVE_PN.value, mfg="Seagate")
+    db_session.flush()
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+    db_session.commit()
+    assert stats["decoded"] == 1
+    assert stats["categorized"] == 1
+    assert db_session.get(MaterialCard, card.id).category == "hdd"
+
+
+def test_drive_pn_decode_widening_flag_off_excludes_drive_pn_from_decode(db_session: Session, monkeypatch):
+    # Flag OFF: the SAME decoding drive_pn link is NOT decoded (only mfg_model feeds the
+    # decode channel). With no decodable model and no description, the card gets nothing.
+    seed_commodity_schemas(db_session)
+    monkeypatch.setattr(settings, "fru_crosswalk_drive_pn_decode_enabled", False)
+    card = _card(db_session, "00AJ141", category=None)
+    _link(db_session, "00AJ141", "ST4000NM0035", kind=FruLinkKind.DRIVE_PN.value, mfg="Seagate")
+    db_session.flush()
+
+    stats = crosswalk_and_record_specs(db_session, [card.id])
+    db_session.commit()
+    assert stats["decoded"] == 0
+    assert stats["categorized"] == 0
+    assert db_session.get(MaterialCard, card.id).category is None
+
+
+# ── §2.6(d): deterministic maker propagation (positive + negative) ───────────────────
+
+
+def test_maker_propagated_when_all_substitutes_agree(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # Two Seagate models → unanimous vendor → maker set deterministically at tier 84.
+    card = _card(db_session, "00AJ141", category=None)
+    _link(db_session, "00AJ141", "ST4000NM0035")
+    _link(db_session, "00AJ141", "ST8000NM0055")
+    db_session.flush()
+
+    summary = run_drain(db_session, apply=True)
+    assert summary["stats"]["manufacturers_set"] == 1
+    db_session.expire_all()
+    refreshed = db_session.get(MaterialCard, card.id)
+    assert refreshed.manufacturer == "Seagate"
+    assert refreshed.manufacturer_source == "fru_matrix_decode"
+    assert refreshed.manufacturer_tier == 84
+
+
+def test_maker_not_propagated_when_vendors_disagree(db_session: Session):
+    seed_commodity_schemas(db_session)
+    # Two HDDs that AGREE on commodity (hdd, form_factor, usage_class) but DISAGREE on
+    # vendor (Seagate vs HGST) → specs still write, but NO maker is inferred (D4: never
+    # guess a maker when the deterministic decoders disagree).
+    card = _card(db_session, "00AJ141", category=None, manufacturer="IBM")
+    _link(db_session, "00AJ141", "ST4000NM0035", mfg="Seagate")
+    _link(db_session, "00AJ141", "HUS726040ALE610", mfg="HGST")
+    db_session.flush()
+
+    summary = run_drain(db_session, apply=True)
+    assert summary["stats"]["written"] >= 1  # shared specs still land
+    assert summary["stats"]["manufacturers_set"] == 0
+    db_session.expire_all()
+    refreshed = db_session.get(MaterialCard, card.id)
+    # The legacy IBM label is untouched — no deterministic maker to upgrade it with.
+    assert refreshed.manufacturer == "IBM"


### PR DESCRIPTION
## What & why

Exploits the existing 54k-edge FRU-links graph to categorize / facet / maker-stamp more cards — all **deterministic, zero-network, zero-LLM**, all through the F1 ladder (OPTIMIZATION_PLAN §2.6). The graph has produced very few enriched cards so far; these are HP/IBM/Lenovo spares — TRIO's bread and butter.

**No DB migration** (creating cards = data, not schema). **No new tiers/sources** — reuses `fru_matrix_decode` (84) and the existing `set_category` / `set_manufacturer` / `record_spec` ladder.

## The four sub-parts

**(a) Targeted drain CLI** — new `app/management/run_fru_crosswalk.py` (dry-run default, `--apply`):
- `drain`: runs `crosswalk_and_record_specs` over the EXISTING cards that have a mfg_model/drive_pn FRU link but are still **unfaceted or uncategorized** (no targeted runner existed — the worker only crosswalks whatever lands in its current batch). Dry-run wraps the writer in a SAVEPOINT + rollback → a **real yield report** with nothing persisted.
- `create`: see (b).
- `--measure-drive-pn`: the (c) gate report.

**(b) Card creation for dangling canonical FRUs** — `create` phase (dry-run default, own counts):
- (b1) dangling **enrichable FRUs** — a `fru_norm` with no card whose linked models decode or whose link descriptions extract;
- (b2) dangling **canonical Seagate/WD/Samsung models** — a `related_norm` (mfg_model/drive_pn) with no card whose `related_raw` decodes to a recognized vendor.
- The ~31k **lenovo_ppn danglers are explicitly SKIPPED** (display-only; §5 kill-list).
- New cards are `category=None`, `enrichment_status=unenriched`, so the worker's existing tier-84 crosswalk / tier-85 mpn_decode passes fire on them on the next loop.

**(c) Gated drive_pn DECODE widening** — new flag `settings.fru_crosswalk_drive_pn_decode_enabled`. The decode channel (today mfg_model-only at `fru_crosswalk_enrich.py`) now also reads `drive_pn` links. **GATE: measured 0 / 3328 drive_pn related parts decode** (they are IBM/Lenovo FRU numbers the regex gates reject) → **0% OEM-firmware-suffix misread (≤2% gate) → enabled by default**. The desc channel reads drive_pn descriptions regardless of the flag (unchanged). DECISION: enable by default.

**(d) Deterministic maker propagation (resolves D4)** — the FRU-side card's `manufacturer` is written via `set_manufacturer` at `fru_matrix_decode`/84 **ONLY when every decoded canonical model identifies the SAME maker** (`DecodeResult.vendor` — the decoder's regex gate is manufacturer-scheme-specific, so a unanimous vendor is a *deterministic* maker, never a prose inference). Vendor disagreement (e.g. Seagate vs HGST among substitutes) → no maker. New `manufacturers_set` stat.

## Ladder discipline
Every category / manufacturer / spec write goes through `set_category` / `set_manufacturer` / `record_spec` — never a direct `card.category =` / `card.manufacturer =`. No new tiers/sources invented. Compatible with the `@validates("category")` guard that just landed on main (PR #283): all test fixtures use `category=None`/`manufacturer=None` and assert the **ladder** sets them.

## (c) gate decision + measured misread rate
- `--measure-drive-pn` over all 3,328 live drive_pn rows: **0 decoded → 0% misread → gate PASSES** → drive_pn decode widening **default ON**.

## Tests (all green)
New `tests/test_run_fru_crosswalk.py` (18 tests) + updated `tests/test_fru_crosswalk_writer.py`:
- drain selection (only linked + unfaceted/uncategorized), dry-run yields-without-persisting, `--apply` persists, no-candidates path;
- card creation: dangling canonical models + enrichable FRUs collected, **lenovo_ppn SKIP**, non-enrichable skip, already-has-card skip, `--apply` inserts unenriched/null-category, dry-run inserts nothing;
- drive_pn widening flag gate (on includes / off excludes the decode), misread-gate logic (pass / fail-on-contradiction / unverifiable / agrees);
- deterministic maker propagation **positive** (unanimous vendor → maker set at tier 84) **and negative** (vendor disagreement → specs write, NO maker).
- Full suite: **16419 passed, 35 skipped, 1 xfailed, 0 failed**.

## Live dry-run yields (read-only, against the live DB)
- **drain** (dry-run): 586 candidates (unfaceted∪uncategorized; the 325 uncategorized are a subset of the 586 unfaceted), 117 decoded, 65 specs written, 2 newly categorized, **34 makers set**, 76 category-mismatch skips (existing categories authoritative).
- **create** (dry-run): **347 creatable** = 243 enrichable FRUs + 104 canonical models; **0 lenovo_ppn** (excluded).
- **(c) misread**: 0 / 3328 decode → **0% → default ON**.

(`--apply` is left to the deploy orchestrator; this PR ran dry-run only.)

Docs: `APP_MAP_INTERACTIONS.md` + `APP_MAP_DATABASE.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)