### PR TITLE
fix(sightings): guard NULL VendorSightingSummary.score in detail row render (live 500)

### DIFF
--- a/app/templates/htmx/partials/sightings/_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/_vendor_row.html
@@ -154,8 +154,8 @@
 
       <div class="flex items-center gap-3 shrink-0">
         <span class="font-mono text-xs {{ 'text-gray-400' if is_unavailable else 'text-gray-600' }}">{{ s.estimated_qty or '—' }} pcs</span>
-        {% set score_color = 'text-gray-400' if is_unavailable else ('text-emerald-600' if s.score >= 70 else ('text-amber-600' if s.score >= 40 else 'text-gray-500')) %}
-        <span class="font-mono text-xs {{ score_color }}">{{ s.score|round|int }}%</span>
+        {% set score_color = 'text-gray-400' if (is_unavailable or s.score is none) else ('text-emerald-600' if s.score >= 70 else ('text-amber-600' if s.score >= 40 else 'text-gray-500')) %}
+        <span class="font-mono text-xs {{ score_color }}">{{ (s.score|round|int ~ '%') if s.score is not none else '—' }}</span>
         <svg :class="expanded ? 'rotate-180' : ''" class="h-3.5 w-3.5 text-gray-300 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
         </svg>

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -128,6 +128,32 @@ class TestSightingsDetailPartial:
         resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
         assert "Good Vendor" in resp.text
 
+    def test_renders_vendor_with_null_score(self, client, db_session):
+        """A VendorSightingSummary with score=None must not 500 the detail panel.
+
+        score is nullable; the row template's score-color/display compared None to an
+        int (TypeError) — caught only against live Postgres, since seeds set a numeric
+        score. Reproduces the live 500 and pins the None-guard.
+        """
+        _, r, _ = _seed_data(db_session)
+        db_session.add(
+            VendorSightingSummary(
+                requirement_id=r.id,
+                vendor_name="NullScore Vendor",
+                estimated_qty=50,
+                listing_count=1,
+                score=None,
+                tier="Unknown",
+            )
+        )
+        db_session.commit()
+        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
+        assert resp.status_code == 200
+        assert "NullScore Vendor" in resp.text  # null-score vendor rendered, no crash
+        assert "75%" in resp.text  # the non-null sibling still renders its numeric score
+        assert "None%" not in resp.text  # null score never reaches the |round|int path
+        assert "—" in resp.text  # score renders as em-dash, not a crash
+
     def test_404_for_missing(self, client, db_session):
         resp = client.get("/v2/partials/sightings/99999/detail")
         assert resp.status_code == 404


### PR DESCRIPTION
## Problem (found by live verification)
The sightings detail panel returned **HTTP 500** whenever it re-rendered for a requirement containing a vendor with a NULL score — i.e. on **mark-unavailable**, **mark-available**, and **opening the requirement's detail**. The mutation succeeded (DB committed); only the response render crashed, so the user saw an error for an action that actually worked.

Root cause: `app/templates/htmx/partials/sightings/_vendor_row.html:157-158` compared `s.score` to an int (`s.score >= 70`) and rendered it via `|round|int`, but `VendorSightingSummary.score` is `Column(Float, nullable=True)` — 5/396 live rows are NULL → `TypeError: '>=' not supported between instances of 'NoneType' and 'int'`.

**Why 16,306 tests missed it:** every test seeds a numeric score (`score=75.0`). SQLite + seeded data masked a NULL that only exists in live Postgres — the SQLite-masks-Postgres class.

## Fix
Guard both lines to match the `{% if score %}` pattern the sibling templates already use (`vendor_modal.html:44`, `table.html:180`): NULL score → neutral gray + em-dash. A null score now renders `—` instead of crashing.

## Verification
- Reproduced live (curl mark-unavailable on real PG → 500, traceback at `_vendor_row.html:157`)
- Regression test reproduces it red, passes green (`TestSightingsDetailPartial::test_renders_vendor_with_null_score`)
- code-reviewer scanned the full detail render path (4 partials) → `s.score` is the **only** unguarded None-comparison; no second latent 500
- Full suite green; ruff/mypy/pre-commit clean; no new Tailwind classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)