### PR TITLE
fix(deps): bump cryptography 48→49 + starlette 1.2.1→1.3.1 (clears security CVE red)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -339,15 +339,10 @@ types-setuptools==82.0.0.20260518
 typing-extensions==4.15.0
     # via
     #   -c requirements.txt
-    #   anyio
-    #   cyclonedx-python-lib
     #   mypy
     #   pyee
-    #   pytest-asyncio
-    #   referencing
     #   schemathesis
     #   sqlalchemy
-    #   starlette
 urllib3==2.7.0
     # via
     #   -c requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -44,7 +44,7 @@ click==8.4.1
     #   schemathesis
 coverage[toml]==7.14.1
     # via pytest-cov
-cryptography==48.0.0
+cryptography==49.0.0
     # via
     #   -c requirements.txt
     #   types-pyopenssl
@@ -308,7 +308,7 @@ sqlalchemy[mypy]==2.0.50
     #   -r requirements-dev.in
 stack-data==0.6.3
     # via ipython
-starlette==1.2.1
+starlette==1.3.1
     # via
     #   -c requirements.txt
     #   starlette-testclient
@@ -339,10 +339,15 @@ types-setuptools==82.0.0.20260518
 typing-extensions==4.15.0
     # via
     #   -c requirements.txt
+    #   anyio
+    #   cyclonedx-python-lib
     #   mypy
     #   pyee
+    #   pytest-asyncio
+    #   referencing
     #   schemathesis
     #   sqlalchemy
+    #   starlette
 urllib3==2.7.0
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -13,12 +13,14 @@ jinja2==3.1.6
 filetype==1.2.0
 charset-normalizer==3.4.7
 # Credential encryption
-cryptography==48.0.0
+cryptography==49.0.0
 # Observability
 loguru==0.7.3
-# Pinned >=1.0.1 to fix PYSEC-2026-161 (Host header URL-reconstruction auth bypass).
-# Forces resolver to pick the fixed 1.x line; fastapi 0.136.x accepts starlette>=0.46.0 unbounded.
-starlette>=1.2.1,<2.0
+# Pinned >=1.3.1 to fix CVE-2026-54283 (urlencoded form DoS) + CVE-2026-54282
+# (request.url Host-header spoof) on top of PYSEC-2026-161 (Host header URL-reconstruction
+# auth bypass). Forces resolver to pick the fixed 1.x line; fastapi 0.136.x accepts
+# starlette>=0.46.0 unbounded, so 0.136.3 stays pinned (no fastapi bump needed).
+starlette>=1.3.1,<2.0
 # Replaced prometheus-fastapi-instrumentator (hard-pinned starlette<1.0.0) with a small
 # ASGI middleware in app/prometheus_metrics.py that uses prometheus_client directly.
 prometheus_client>=0.25.0,<1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ charset-normalizer==3.4.7
     #   requests
 click==8.4.1
     # via uvicorn
-cryptography==48.0.0
+cryptography==49.0.0
     # via -r requirements.in
 cssselect2==0.9.0
     # via weasyprint
@@ -180,7 +180,7 @@ sqlalchemy==2.0.50
     #   alembic
 sse-starlette==3.4.4
     # via -r requirements.in
-starlette==1.2.1
+starlette==1.3.1
     # via
     #   -r requirements.in
     #   fastapi
@@ -198,6 +198,7 @@ typing-extensions==4.15.0
     # via
     #   alembic
     #   anthropic
+    #   anyio
     #   azure-communication-callautomation
     #   azure-core
     #   beautifulsoup4
@@ -207,6 +208,7 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   pyee
     #   sqlalchemy
+    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -198,7 +198,6 @@ typing-extensions==4.15.0
     # via
     #   alembic
     #   anthropic
-    #   anyio
     #   azure-communication-callautomation
     #   azure-core
     #   beautifulsoup4
@@ -208,7 +207,6 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   pyee
     #   sqlalchemy
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via


### PR DESCRIPTION
## What
Clears the `security` (pip-audit) CI failure now red on **all** branches (incl. main on re-run) — 3 newly-disclosed CVEs in the current pins:

- **cryptography 48.0.0 → 49.0.0** — GHSA-537c-gmf6-5ccf (statically-linked OpenSSL in wheels).
- **starlette 1.2.1 → 1.3.1** — CVE-2026-54283 (urlencoded form DoS) + CVE-2026-54282 (request.url host-spoof).

## Why it's safe (vetted)
- **cryptography:** app uses only `Fernet` + `PBKDF2HMAC`/`SHA256` (`encrypted_type.py`, `credential_service.py`). None of the 49.0.0 breaking changes (dropped platforms, removed type aliases, ChaCha20 nonce, x509 NULL params) touch that surface.
- **starlette:** file uploads use `UploadFile` (bypass `max_part_size`); no `>1MB` text field or `>1000`-field form flow; **zero** `request.url.hostname/.netloc` usage → CVE-54282 behavior change is inert here. `fastapi 0.136.3` pins `starlette>=0.46.0`, so **no fastapi bump needed**.
- Template wrapper (`app/template_env.py`) already uses the modern `TemplateResponse(request, ...)` signature — unchanged in 1.3.1.

## Notes
- Lockfiles recompiled in place (pip-tools); only the two functional pins change (+ transitive comment churn). Recompile gate verified locally.
- **Supersedes dependabot #279** (cryptography) and the **starlette portion of #278** (the rest of #278 — fastapi 0.137 — is separately blocked by a route-tree test incompat and excluded here on purpose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)