### PR TITLE
feat(materials): condense search-results table (9→7 cols, clearer count)

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -348,6 +348,18 @@ hr { border-color: #BFC4CE; }
   box-shadow: inset 2px 0 0 #5F6878;
 }
 
+/* ── Dense variant — tighter rows for the materials results table ──
+   Scoped modifier so the shared .compact-table (sightings / parts / quotes) is
+   untouched. Applied via "compact-table compact-table--dense" in materials/list.html. */
+.compact-table--dense th {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+.compact-table--dense td {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
 /* Ensure tables don't collapse columns below readable widths */
 table {
   min-width: 100%;

--- a/app/templates/htmx/partials/materials/list.html
+++ b/app/templates/htmx/partials/materials/list.html
@@ -6,6 +6,10 @@
             section — set when q matches fru_links, see fru_section.html).
   Called by: htmx_views.py materials_faceted_partial endpoint.
   Depends on: HTMX, Tailwind CSS with brand palette, Alpine.js materialsFilter().
+
+  Layout: 7-column condensed table — MPN · Description · Manufacturer (category folded
+  in as a muted sub-line) · Status (enrichment-trust + lifecycle + condition badges,
+  merged) · Vendors · Best Price · Last Seen. Density via .compact-table--dense (scoped).
 #}
 
 {# FRU crosswalk — renders only when q hits fru_links (forward matrix and/or
@@ -16,13 +20,15 @@
 {% include "htmx/partials/materials/fru_section.html" %}
 {% endif %}
 
-{# Live result count — re-renders every filters-changed cycle (the feedback loop). #}
+{# Live result count — re-renders every filters-changed cycle (the feedback loop).
+   Match-framed: "N results [in <commodity>] [· matching "<q>"]" reads clearly as how
+   many parts matched the current search/filters (vs the bare "N parts"). #}
 <div class="flex items-baseline gap-2 mb-2 px-1">
   <span class="text-sm font-semibold text-gray-700 tabular-nums">{{ "{:,}".format(total) }}</span>
-  <span class="text-sm text-gray-500">{% if commodity_display %}{{ commodity_display }} {% endif %}part{{ '' if total == 1 else 's' }}</span>
+  <span class="text-sm text-gray-500">result{{ '' if total == 1 else 's' }}{% if commodity_display %} in {{ commodity_display }}{% endif %}{% if q %} &middot; matching &ldquo;{{ q }}&rdquo;{% endif %}</span>
 </div>
 {# Screen-reader announcement of the new count on each swap. #}
-<div class="sr-only" role="status" aria-live="polite">{{ "{:,}".format(total) }} {% if commodity_display %}{{ commodity_display }} {% endif %}parts match</div>
+<div class="sr-only" role="status" aria-live="polite">{{ "{:,}".format(total) }} result{{ '' if total == 1 else 's' }}{% if commodity_display %} in {{ commodity_display }}{% endif %}{% if q %} matching {{ q }}{% endif %}</div>
 
 {# Table #}
 <div class="bg-white rounded-lg border border-brand-200 overflow-hidden">
@@ -44,20 +50,20 @@
     'Pulled': 'bg-rose-50 text-rose-700 border-rose-200',
     'Unknown': 'bg-gray-100 text-gray-600 border-gray-200',
   } %}
+  {# Enrichment-status values that render a trust badge (everything else → no badge). #}
+  {% set trust_states = ['verified', 'web_sourced', 'oem_sourced', 'ai_inferred', 'not_found', 'not_catalogued'] %}
   {% if materials %}
   <div class="overflow-x-auto">
-    <table class="compact-table">
+    <table class="compact-table compact-table--dense">
       <thead>
         <tr>
           <th class="text-left">MPN</th>
           <th class="text-left">Description</th>
           <th class="text-left">Manufacturer</th>
-          <th class="text-left">Category</th>
-          <th class="text-left">Lifecycle</th>
           <th class="text-left">Status</th>
           <th class="text-right">Vendors</th>
           <th class="text-right">Best Price</th>
-          <th class="text-left">Last Searched</th>
+          <th class="text-left">Last Seen</th>
         </tr>
       </thead>
       <tbody>
@@ -93,8 +99,8 @@
             <div class="flex flex-wrap gap-1 mt-0.5">
               {% for spec in m._primary_specs[:3] %}
               {# title keeps the label visible on hover when the commodity-scoped
-                 rendering shows the value only. #}
-              <span class="inline-block px-1.5 py-0.5 bg-gray-50 text-[10px] text-gray-500 rounded font-data"
+                 rendering shows the value only. leading-none trims pill height. #}
+              <span class="inline-block px-1.5 py-0.5 bg-gray-50 text-[10px] leading-none text-gray-500 rounded font-data"
                     title="{{ spec.label }}: {{ spec.value }}">
                 {%- if not commodity and spec.label %}{{ spec.label }}: {% endif %}{{ spec.value }}
               </span>
@@ -103,19 +109,60 @@
             {% endif %}
           </td>
           <td class="td-label text-gray-500 truncate max-w-[200px]" title="{{ m.description or '' }}">{{ m.description or "--" }}</td>
-          {# Dual-brand cell: "IBM · Seagate Technology" when brand (OEM label) and
-             manufacturer (actual maker) are both set and DIFFERENT COMPANIES
-             (m._show_maker_suffix — the view compares NORMALIZED forms, so an alias
-             pair like "Hewlett Packard Enterprise"/"HP" renders once, never as a
-             tautological "label · maker"); one value when equal or single; "--" when
-             neither. "·" is the existing codebase idiom (workspace.html,
-             sourcing/results.html). #}
-          <td class="td-label text-gray-600 truncate max-w-[160px]"
-              title="{{ m.brand or m.manufacturer or '' }}{% if m._show_maker_suffix %} · {{ m.manufacturer }}{% endif %}">
-            {{ m.brand or m.manufacturer or "--" }}{% if m._show_maker_suffix %} · {{ m.manufacturer }}{% endif %}</td>
-          <td class="td-label text-gray-600">{{ m.category or "--" }}</td>
+          {# Dual-brand cell with category folded in as a muted sub-line (no standalone
+             Category column). Dual-brand: "IBM · Seagate Technology" when brand (OEM
+             label) and manufacturer (actual maker) are both set and DIFFERENT COMPANIES
+             (m._show_maker_suffix — the view compares NORMALIZED forms, so an alias pair
+             like "Hewlett Packard Enterprise"/"HP" renders once, never a tautological
+             "label · maker"); one value when equal or single; "--" when neither. "·" is
+             the existing codebase idiom (workspace.html, sourcing/results.html). #}
+          <td class="td-label text-gray-600 max-w-[160px]">
+            <div class="truncate" title="{{ m.brand or m.manufacturer or '' }}{% if m._show_maker_suffix %} · {{ m.manufacturer }}{% endif %}">
+              {{ m.brand or m.manufacturer or "--" }}{% if m._show_maker_suffix %} · {{ m.manufacturer }}{% endif %}</div>
+            {% if m.category %}
+            <div class="text-[11px] text-gray-400 truncate" title="Category: {{ m.category }}">{{ m.category }}</div>
+            {% endif %}
+          </td>
+          {# Status: enrichment-trust badge + lifecycle + condition, merged into one
+             wrapping badge group (was two separate columns). #}
           <td>
             <div class="flex flex-wrap items-center gap-1">
+              {% set es = m.enrichment_status %}
+              {% if es == "verified" %}
+              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-emerald-50 text-emerald-700 border-emerald-200"
+                    title="Verified from {{ (m.enrichment_provenance or {}).get('description', {}).get('source', 'catalog') }}">
+                VERIFIED
+              </span>
+              {% elif es == "web_sourced" %}
+              {% set _u = (m.enrichment_provenance or {}).get('source_urls', [None])[0] %}
+              <a href="{{ _u or '#' }}" target="_blank" rel="noopener"
+                 class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-sky-50 text-sky-700 border-sky-200"
+                 title="Web-sourced from {{ (m.enrichment_provenance or {}).get('source_domains', ['authoritative page'])|join(', ') }} — below API-verified">
+                WEB-SOURCED
+              </a>
+              {% elif es == "oem_sourced" %}
+              {% set _ou = (m.enrichment_provenance or {}).get('source_urls', [None])[0] %}
+              <a href="{{ _ou or '#' }}" target="_blank" rel="noopener"
+                 class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-indigo-50 text-indigo-700 border-indigo-200"
+                 title="OEM-official source: {{ (m.enrichment_provenance or {}).get('source_domains', ['vendor page'])|join(', ') }} — description from the OEM; specs not distributor-verified">
+                OEM-SOURCED
+              </a>
+              {% elif es == "ai_inferred" %}
+              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-amber-50 text-amber-700 border-amber-200"
+                    title="AI guess (&ge;95% confidence) — RECONFIRM NEEDED before trusting; not verified">
+                AI GUESS · RECONFIRM
+              </span>
+              {% elif es == "not_found" %}
+              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-gray-100 text-gray-500 border-gray-200"
+                    title="No authoritative source found this part">
+                NOT FOUND
+              </span>
+              {% elif es == "not_catalogued" %}
+              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-slate-100 text-slate-600 border-slate-300"
+                    title="Recognised OEM service/FRU part; no public specs published">
+                NOT CATALOGUED
+              </span>
+              {% endif %}
               {% if m.lifecycle_status %}
               <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border {{ lc_colors.get(m.lifecycle_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
                 {{ m.lifecycle_status|upper }}
@@ -127,55 +174,17 @@
                 {{ m.condition|upper }}
               </span>
               {% endif %}
-              {% if not m.lifecycle_status and not m.condition %}
+              {% if es not in trust_states and not m.lifecycle_status and not m.condition %}
               <span class="text-xs text-gray-400">--</span>
               {% endif %}
             </div>
           </td>
-          <td>
-            {% set es = m.enrichment_status %}
-            {% if es == "verified" %}
-            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-emerald-50 text-emerald-700 border-emerald-200"
-                  title="Verified from {{ (m.enrichment_provenance or {}).get('description', {}).get('source', 'catalog') }}">
-              VERIFIED
-            </span>
-            {% elif es == "web_sourced" %}
-            {% set _u = (m.enrichment_provenance or {}).get('source_urls', [None])[0] %}
-            <a href="{{ _u or '#' }}" target="_blank" rel="noopener"
-               class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-sky-50 text-sky-700 border-sky-200"
-               title="Web-sourced from {{ (m.enrichment_provenance or {}).get('source_domains', ['authoritative page'])|join(', ') }} — below API-verified">
-              WEB-SOURCED
-            </a>
-            {% elif es == "oem_sourced" %}
-            {% set _ou = (m.enrichment_provenance or {}).get('source_urls', [None])[0] %}
-            <a href="{{ _ou or '#' }}" target="_blank" rel="noopener"
-               class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-indigo-50 text-indigo-700 border-indigo-200"
-               title="OEM-official source: {{ (m.enrichment_provenance or {}).get('source_domains', ['vendor page'])|join(', ') }} — description from the OEM; specs not distributor-verified">
-              OEM-SOURCED
-            </a>
-            {% elif es == "ai_inferred" %}
-            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-amber-50 text-amber-700 border-amber-200"
-                  title="AI guess (&ge;95% confidence) — RECONFIRM NEEDED before trusting; not verified">
-              AI GUESS · RECONFIRM
-            </span>
-            {% elif es == "not_found" %}
-            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-gray-100 text-gray-500 border-gray-200"
-                  title="No authoritative source found this part">
-              NOT FOUND
-            </span>
-            {% elif es == "not_catalogued" %}
-            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-slate-100 text-slate-600 border-slate-300"
-                  title="Recognised OEM service/FRU part; no public specs published">
-              NOT CATALOGUED
-            </span>
-            {% else %}
-            <span class="text-xs text-gray-400">--</span>
-            {% endif %}
-          </td>
           <td class="text-right font-medium">{{ m._vendor_count or 0 }}</td>
           <td class="text-right">
             {% if m._best_price is not none %}
-            <span class="text-emerald-700 font-medium">{{ '$' if (m._best_currency or 'USD') == 'USD' else m._best_currency ~ ' ' }}{{ "%.4f"|format(m._best_price) }}</span>
+            {# 2 decimals at/above $1; keep 4 for sub-dollar parts (passives) so they
+               don't collapse to $0.00. Matches _vendor_row.html "best price seen". #}
+            <span class="text-emerald-700 font-medium">{{ '$' if (m._best_currency or 'USD') == 'USD' else m._best_currency ~ ' ' }}{{ ("%.2f" if m._best_price >= 1 else "%.4f")|format(m._best_price) }}</span>
             {% else %}
             <span class="text-gray-400 text-xs">--</span>
             {% endif %}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2226,8 +2226,10 @@ Sidebar facets (workspace.html + materialsFilter Alpine component) — COMMODITY
     |     containers now reload on `filters-changed from:body` (not just commodity-changed),
     |     carrying the same wire params (hx-vals object literal) as #materials-results.
     |     Containers load while hidden.
-    Live result count "<N> <Commodity> parts" renders at the top of the results pane
-    (list.html) every filters-changed cycle, with an sr-only aria-live announcement.
+    Live result count "<N> results [in <Commodity>] [· matching "<q>"]" renders at the top
+    of the results pane (list.html) every filters-changed cycle (match-framed so the number
+    reads as "how many matched", not a bare part count; singular "result" when N==1), with a
+    parallel sr-only aria-live announcement.
     Mobile drawer: x-trap focus trap + Escape-to-close.
 
 Count-consistency invariant (count-honesty, OPTIMIZATION_PLAN §3.3 backend):
@@ -2260,6 +2262,13 @@ SpecCoverage(with_specs=N, total=M) NamedTuple; two cheap aggregates, no N+1):
     +---> Zero results + active parametric sub_filters + N < M → list.html renders the
     |     "not yet spec-enriched" nudge instead of the generic empty state.
 Result-row upgrades (list.html, server-side in materials_faceted_partial):
+    +---> Condensed 7-column layout (was 9): MPN · Description · Manufacturer · Status ·
+    |     Vendors · Best Price · Last Seen. Category is folded as a muted sub-line under the
+    |     manufacturer (no standalone column); Lifecycle + Condition are merged into the
+    |     Status cell alongside the enrichment-trust badge (one wrapping badge group). Best
+    |     Price renders 2 decimals at/above $1, 4 below (passive precision). Table carries
+    |     the scoped .compact-table--dense modifier (4px row padding; shared .compact-table
+    |     untouched). No data dropped — only regrouped.
     +---> Spec chips also render WITHOUT a commodity: each card's own category's
     |     is_primary schema keys (one batched CommoditySpecSchema query), else the first
     |     3 scalar specs_structured entries, formatted "label: value". Every chip carries

--- a/docs/superpowers/specs/2026-06-15-materials-results-condense-design.md
+++ b/docs/superpowers/specs/2026-06-15-materials-results-condense-design.md
@@ -1,0 +1,69 @@
+# Materials search results — condense & clarify (design spec)
+
+**Date:** 2026-06-15
+**Surface:** `app/templates/htmx/partials/materials/list.html` (the results table rendered
+by the `/v2/partials/materials/faceted` endpoint when a user searches/filters on
+`/v2/materials`).
+**Goal:** Make the returned results more condensed (less wasted space), cleaner / easier
+to read, and make the result-count label read clearly as a *match count*.
+
+## Problem
+
+The results table renders **9 columns** (`MPN · Description · Manufacturer · Category ·
+Lifecycle · Status · Vendors · Best Price · Last Searched`), forcing horizontal scroll and
+crowding. Best Price shows 4 decimals (`$42.5000`) for every part. The count header reads
+`1,234 parts`, which doesn't make clear it's "how many matched the current search/filters".
+
+## Decisions (all resolved — no options left open)
+
+### 1. Result-count label
+Replace `{{total}} {{commodity_display}} parts` with a match-framed phrase:
+
+- Visible: **`N results[ in <commodity>][ · matching "<q>"]`** (singular `result` when `N == 1`).
+- SR (`aria-live`): **`N result[s][ in <commodity>][ matching <q>]`**.
+- `commodity_display` and `q` are already passed to the template; render server-side.
+
+### 2. Column consolidation: 9 → 7 columns
+New header row: **`MPN · Description · Manufacturer · Status · Vendors · Best Price · Last Seen`**
+
+- **Drop the standalone Category column.** Fold `category` as a muted sub-line
+  (`text-[11px] text-gray-400`, reuse existing arbitrary value) under the manufacturer in
+  the Manufacturer cell. Renders nothing when `category` is empty.
+- **Merge Lifecycle + Status into one "Status" cell.** One `flex flex-wrap` badge group:
+  enrichment-trust badge (VERIFIED / WEB-SOURCED / OEM-SOURCED / AI GUESS / NOT FOUND /
+  NOT CATALOGUED) **then** lifecycle badge **then** condition badge. `--` only when all
+  three are absent. No badge palettes, links, titles, or colors change — only their cell
+  grouping. **No data is removed; nothing in the sidebar filters changes.**
+- "Last Searched" header → **"Last Seen"** (shorter); cell value/format unchanged.
+
+### 3. Best Price formatting
+`$%.2f` when `_best_price >= 1`, else `$%.4f` (keep sub-dollar precision for passives).
+Aligns with the existing `_vendor_row.html` "best price seen" convention. Currency prefix
+logic unchanged.
+
+### 4. Density
+- Spec pills (`_primary_specs`): tighten gap and leading; keep max 3, same data/tooltip.
+- Add a **scoped** `.compact-table--dense` modifier in `app/static/styles.css` (td vertical
+  padding 6px → 4px, th 8px → 6px) and apply `compact-table compact-table--dense` to *this*
+  table only. **Do not modify the shared `.compact-table` class** — sightings/parts/quotes
+  reuse it.
+
+## Out of scope / unchanged
+- HTMX row click-through (`hx-get` → detail), endpoints, `MaterialCard` fields/queries.
+- The detail card (`detail.html`), sidebar filters, FRU section, pagination, empty states.
+- No new arbitrary Tailwind values (reuse `max-w-[160px]`, `text-[10px]`, `text-[11px]`).
+
+## Tests
+- Update `tests/test_filter_ux_live_count.py` to assert the new "results" copy + singular/
+  plural + `aria-live` still present.
+- Add a render test: merged Status cell shows trust + lifecycle + condition together;
+  Category renders as the muted sub-line under Manufacturer; header has **no** standalone
+  `Category`/`Lifecycle` `<th>`; Best Price shows 2 decimals for a ≥$1 price and 4 for a
+  sub-dollar price; count reads `… matching "<q>"` when `q` is present.
+
+## Files
+- `app/templates/htmx/partials/materials/list.html` — edit (count, headers, cells).
+- `app/static/styles.css` — add scoped `.compact-table--dense`.
+- `tests/test_filter_ux_live_count.py` — update count assertions.
+- `tests/test_materials_results_condense.py` — new render tests.
+- `docs/APP_MAP_INTERACTIONS.md` — note the 7-column results layout + merged Status cell.

--- a/tests/test_faceted_routes.py
+++ b/tests/test_faceted_routes.py
@@ -403,7 +403,7 @@ def test_list_renders_zero_price_and_currency():
     assert "$0.0000" in html0  # zero price is shown, not '--'
 
     html_eur = tmpl.render(materials=[_card(1.5, "EUR")], q="", total=1, limit=50, offset=0, faceted=True)
-    assert "EUR 1.5000" in html_eur  # non-USD currency labelled with its code
+    assert "EUR 1.50" in html_eur  # non-USD currency labelled; ≥$1 → 2 decimals
 
 
 def test_workspace_injects_display_names(client):
@@ -419,8 +419,9 @@ def test_faceted_endpoint_currency_aggregate(client, db_session):
     Exercises the real materials_faceted_partial aggregate SQL:
       count(distinct last_currency), max(last_currency), _best_currency derivation.
 
-    Single-currency card → currency label rendered (e.g. "EUR 1.2500").
+    Single-currency card → currency label rendered (e.g. "EUR 1.25").
     Mixed-currency card  → _best_currency is None → falls back to "$" prefix.
+    (Prices ≥ $1 render with 2 decimals per the results-condense change.)
     """
     from app.models.intelligence import MaterialCard, MaterialVendorHistory
 
@@ -485,14 +486,14 @@ def test_faceted_endpoint_currency_aggregate(client, db_session):
     resp = client.get("/v2/partials/materials/faceted")
     assert resp.status_code == 200
 
-    # Single-currency EUR card: best price is 1.2500, labelled "EUR <price>"
-    assert "EUR 1.2500" in resp.text, (
+    # Single-currency EUR card: best price 1.25 (from 1.2500), labelled "EUR <price>"
+    assert "EUR 1.25" in resp.text, (
         "EUR-labelled best price not rendered for single-currency card; "
         "_best_currency derivation (count distinct == 1 → max currency) may be broken"
     )
 
-    # Mixed-currency card: best price is 2.5000 (min), prefix must be "$" not "EUR"
-    assert "$2.5000" in resp.text, (
+    # Mixed-currency card: best price 2.50 (from 2.5000 min), prefix must be "$" not "EUR"
+    assert "$2.50" in resp.text, (
         "Dollar-prefixed price not rendered for mixed-currency card; "
         "_best_currency should be None for mixed currencies (falls back to '$')"
     )

--- a/tests/test_filter_ux_live_count.py
+++ b/tests/test_filter_ux_live_count.py
@@ -1,4 +1,8 @@
-"""Unit 3 — faceted results render a live result count + an aria-live announcement."""
+"""Unit 3 — faceted results render a live result count + an aria-live announcement.
+
+The count is match-framed: "N results [in <commodity>] [· matching "<q>"]" — the word
+"results" (not "parts") makes clear it's how many matched the current search/filters.
+"""
 
 from datetime import datetime, timezone
 
@@ -25,13 +29,12 @@ def test_faceted_renders_live_count_with_commodity(client, db_session: Session):
 
     resp = client.get("/v2/partials/materials/faceted?commodity=dram")
     assert resp.status_code == 200
-    # Count + display name + pluralized noun at the top of the results pane.
+    # Count + display name + match-framed plural noun at the top of the results pane.
     assert "2" in resp.text
     assert "DRAM" in resp.text
-    assert "parts" in resp.text
+    assert "results" in resp.text
     # Screen-reader announcement present.
     assert 'aria-live="polite"' in resp.text
-    assert "parts match" in resp.text
 
 
 def test_faceted_count_singular_no_commodity(client, db_session: Session):
@@ -41,4 +44,6 @@ def test_faceted_count_singular_no_commodity(client, db_session: Session):
     assert resp.status_code == 200
     # Singular noun for a single result, no commodity name.
     assert "1" in resp.text
-    assert "part" in resp.text
+    assert "result" in resp.text
+    # Singular, not pluralized, for exactly one match.
+    assert "results" not in resp.text

--- a/tests/test_materials_results_condense.py
+++ b/tests/test_materials_results_condense.py
@@ -1,0 +1,105 @@
+"""Condensed materials results table (list.html): 7-column layout, merged Status cell,
+category folded under Manufacturer, smart price decimals, match-framed count.
+
+Renders the partial directly via Jinja (mirrors tests/test_oem_badges.py) so the layout
+contract is asserted without seeding vendor-sighting stats.
+"""
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+def _render(*, materials=None, total=1, q="", commodity="", commodity_display="", **card_overrides):
+    env = Environment(
+        loader=FileSystemLoader("app/templates"),
+        autoescape=select_autoescape(["html"]),
+    )
+    tmpl = env.get_template("htmx/partials/materials/list.html")
+    if materials is None:
+        base = {
+            "id": 1,
+            "display_mpn": "M393A2K43DB2-CWE",
+            "normalized_mpn": "m393a2k43db2-cwe",
+            "datasheet_url": None,
+            "cross_references": None,
+            "description": "16GB DDR4 RDIMM",
+            "brand": None,
+            "manufacturer": "Samsung",
+            "_show_maker_suffix": False,
+            "category": "DRAM",
+            "lifecycle_status": None,
+            "condition": None,
+            "enrichment_status": "unenriched",
+            "enrichment_provenance": {},
+            "_vendor_count": 0,
+            "_best_price": None,
+            "_best_currency": "USD",
+            "_primary_specs": [],
+            "last_searched_at": None,
+        }
+        base.update(card_overrides)
+        materials = [type("C", (), base)()]
+    return tmpl.render(
+        materials=materials,
+        total=total,
+        q=q,
+        commodity=commodity,
+        commodity_display=commodity_display,
+        limit=50,
+        offset=0,
+    )
+
+
+def test_seven_column_header_no_category_or_lifecycle_columns():
+    html = _render()
+    # Exactly 7 column headers (was 9): Category + Lifecycle columns are gone.
+    assert html.count("<th ") == 7  # trailing space: doesn't match <thead>
+    assert ">Category</th>" not in html
+    assert ">Lifecycle</th>" not in html
+    # The survivors, including the merged Status column and the renamed Last Seen.
+    for header in (
+        ">MPN</th>",
+        ">Description</th>",
+        ">Manufacturer</th>",
+        ">Status</th>",
+        ">Vendors</th>",
+        ">Best Price</th>",
+        ">Last Seen</th>",
+    ):
+        assert header in html, f"missing header {header}"
+
+
+def test_category_folds_under_manufacturer():
+    html = _render(manufacturer="Samsung", category="DRAM")
+    assert "Samsung" in html
+    # Category still visible, now as a muted sub-line (not its own column).
+    assert "DRAM" in html
+    assert ">Category</th>" not in html
+
+
+def test_status_cell_merges_trust_lifecycle_condition():
+    html = _render(enrichment_status="verified", lifecycle_status="active", condition="Refurbished")
+    # All three badge families render, now grouped in the single Status cell.
+    assert "VERIFIED" in html
+    assert "ACTIVE" in html
+    assert "REFURBISHED" in html
+    # Still only 7 columns — proves lifecycle merged into status rather than adding a col.
+    assert html.count("<th ") == 7  # trailing space: doesn't match <thead>
+
+
+def test_best_price_two_decimals_at_or_above_one_dollar():
+    html = _render(_best_price=42.5, _best_currency="USD")
+    assert "$42.50" in html
+    assert "$42.5000" not in html
+
+
+def test_best_price_four_decimals_below_one_dollar():
+    html = _render(_best_price=0.0123, _best_currency="USD")
+    assert "$0.0123" in html
+
+
+def test_count_is_match_framed_with_query():
+    html = _render(total=3, q="ddr5 ecc", commodity_display="DRAM")
+    assert "results" in html
+    assert "matching" in html
+    assert "ddr5 ecc" in html
+    assert "DRAM" in html


### PR DESCRIPTION
## What
Condenses the materials search-results table from **9 → 7 columns** by regrouping (no data dropped):
- Category folds into a muted sub-line under Manufacturer.
- Lifecycle merges into the Status cell alongside the enrichment-trust badge.

Plus a clearer results count and a `.compact-table--dense` style. Readiness-reviewed: merge-ready, no blocking issues; no new Tailwind safelist entry needed (`.compact-table--dense` is hand-written CSS in `app/static/styles.css`; the only new utilities are already-safelisted arbitrary values).

## Changes
- `app/templates/htmx/partials/materials/list.html` — 9→7 column regroup
- `app/static/styles.css` — `.compact-table--dense`
- `docs/APP_MAP_INTERACTIONS.md` — updated
- `tests/test_materials_results_condense.py` (new) + `tests/test_faceted_routes.py` / `tests/test_filter_ux_live_count.py` tweaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)