### PR TITLE
simplify(cache): DRY redis-key/ttl helpers + hoist constant set

### DIFF
--- a/app/cache/decorators.py
+++ b/app/cache/decorators.py
@@ -18,6 +18,9 @@ from app.utils import json_helpers as json
 
 from .intel_cache import get_cached, set_cached
 
+# Kwargs never folded into the cache key (request-scoped, non-serializable).
+_KEY_EXCLUDED = frozenset({"db", "user", "request"})
+
 
 def cached_endpoint(prefix: str, ttl_hours: float = 4, key_params: list[str] | None = None):
     """Decorator that caches an endpoint's return value.
@@ -35,11 +38,10 @@ def cached_endpoint(prefix: str, ttl_hours: float = 4, key_params: list[str] | N
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             # Build cache key from specified params
-            excluded = {"db", "user", "request"}
             if key_params is not None:
                 key_dict = {k: kwargs.get(k) for k in key_params}
             else:
-                key_dict = {k: v for k, v in kwargs.items() if k not in excluded}
+                key_dict = {k: v for k, v in kwargs.items() if k not in _KEY_EXCLUDED}
 
             # Include user.id in key for per-user caching
             user = kwargs.get("user")

--- a/app/cache/intel_cache.py
+++ b/app/cache/intel_cache.py
@@ -23,6 +23,16 @@ _redis_init_attempted = False
 _REDIS_PREFIX = "intel:"
 
 
+def _rkey(cache_key: str) -> str:
+    """Namespace a cache key for Redis storage."""
+    return f"{_REDIS_PREFIX}{cache_key}"
+
+
+def _ttl_seconds(ttl_days: float) -> int:
+    """Convert a fractional-day TTL to whole seconds for Redis EXPIRE/SETEX."""
+    return int(ttl_days * 86400)
+
+
 def _get_redis():
     """Lazy-init Redis connection.
 
@@ -72,7 +82,7 @@ def get_cached(cache_key: str) -> dict | None:
     r = _get_redis()
     if r:
         try:
-            data = r.get(f"{_REDIS_PREFIX}{cache_key}")
+            data = r.get(_rkey(cache_key))
             if data:
                 return json.loads(data)
             return None
@@ -100,13 +110,13 @@ def get_cached(cache_key: str) -> dict | None:
 
 def set_cached(cache_key: str, data: dict, ttl_days: float = 7) -> None:
     """Store data in cache with TTL."""
-    ttl_seconds = int(ttl_days * 86400)
+    ttl_seconds = _ttl_seconds(ttl_days)
 
     # Try Redis first
     r = _get_redis()
     if r:
         try:
-            r.setex(f"{_REDIS_PREFIX}{cache_key}", ttl_seconds, json.dumps(data))
+            r.setex(_rkey(cache_key), ttl_seconds, json.dumps(data))
             return  # Success — skip PG write
         except Exception as e:
             logger.warning("Redis write error for {}: {}", cache_key, e)
@@ -173,8 +183,8 @@ def incr_count(cache_key: str, amount: int = 1, ttl_days: float = 1.0) -> int:
     r = _get_redis()
     if r:
         try:
-            new = int(r.incrby(f"{_REDIS_PREFIX}{cache_key}", amount))
-            r.expire(f"{_REDIS_PREFIX}{cache_key}", int(ttl_days * 86400))
+            new = int(r.incrby(_rkey(cache_key), amount))
+            r.expire(_rkey(cache_key), _ttl_seconds(ttl_days))
             return new
         except Exception as e:
             logger.warning("Redis incr error for {}: {} — falling back to read-modify-write", cache_key, e)
@@ -199,8 +209,8 @@ def incr_hash_count(cache_key: str, field: str, amount: int = 1, ttl_days: float
     r = _get_redis()
     if r:
         try:
-            new = int(r.hincrby(f"{_REDIS_PREFIX}{cache_key}", field, amount))
-            r.expire(f"{_REDIS_PREFIX}{cache_key}", int(ttl_days * 86400))
+            new = int(r.hincrby(_rkey(cache_key), field, amount))
+            r.expire(_rkey(cache_key), _ttl_seconds(ttl_days))
             return new
         except Exception as e:
             logger.warning("Redis hash-incr error for {}: {} — falling back to read-modify-write", cache_key, e)


### PR DESCRIPTION
**Pilot** of a codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module; this is the smallest (`app/cache`) to validate the pipeline.

## Changes
- **`app/cache/decorators.py`** — hoist the per-call `{"db","user","request"}` exclusion set to a module-level `frozenset` (`_KEY_EXCLUDED`); drop the redundant local rebuild on the cached-endpoint hot path. *(efficiency + simplification)*
- **`app/cache/intel_cache.py`** — extract the 6× repeated `f"{_REDIS_PREFIX}{cache_key}"` into `_rkey()` and the 3× `int(ttl_days * 86400)` into `_ttl_seconds()`; route all call sites through them. Values are byte-identical. *(simplification)*

## Verification
- `ruff` + `ruff format` + `docformatter` + `mypy` clean (394 files)
- 41/41 cache tests pass (`test_cache_intel`, `test_requisition_cache`)

## Recorded but deliberately NOT done (out of single-file/quality scope)
- A shared `cache_key_hash()` helper in `app/utils` would de-dup the MD5-truncated key idiom shared with `global_search_service._ai_cache_key` (cross-file → follow-up).
- ⚠️ Possible **correctness** smell (not a simplify concern, left untouched): `cached_endpoint.wrapper` is a sync `def` while the decorator is documented for `async def` endpoints — worth a `/code-review` look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)