### PR TITLE
simplify(utils): de-duplicate shared utility helpers

### DIFF
--- a/app/utils/claude_client.py
+++ b/app/utils/claude_client.py
@@ -61,6 +61,63 @@ def _headers(*, cache: bool = False) -> dict:
     return h
 
 
+# Tool definition that pins the model to a JSON Schema (H9: Structured Outputs).
+_STRUCTURED_OUTPUT_TOOL_NAME = "structured_output"
+
+
+def _structured_output_tool(schema: dict) -> dict:
+    """Tool definition that forces schema-conforming JSON output."""
+    return {
+        "name": _STRUCTURED_OUTPUT_TOOL_NAME,
+        "description": "Return structured data matching the required schema.",
+        "input_schema": schema,
+    }
+
+
+def _system_blocks(system: str, *, cache: bool) -> list[dict]:
+    """Build the `system` field, optionally marking it cacheable (H10)."""
+    if not system:
+        return []
+    block: dict[str, Any] = {"type": "text", "text": system}
+    if cache:
+        block["cache_control"] = {"type": "ephemeral"}
+    return [block]
+
+
+_MISSING = object()
+
+
+def _extract_tool_input(content: list[dict]) -> Any:
+    """Return the structured_output tool input, or `_MISSING` if no such block."""
+    for block in content:
+        if block.get("type") == "tool_use" and block.get("name") == _STRUCTURED_OUTPUT_TOOL_NAME:
+            return block.get("input")
+    return _MISSING
+
+
+def _raise_for_status(resp: httpx.Response, *, context: str) -> None:
+    """Map a non-200 Claude API response to the matching ClaudeError subclass."""
+    if resp.status_code in (401, 403):
+        raise ClaudeAuthError(f"Claude API auth failed: {resp.status_code}")
+    if resp.status_code == 429:
+        raise ClaudeRateLimitError("Rate limit exceeded after retries")
+    if resp.status_code >= 500:
+        raise ClaudeServerError(f"Claude API error: {resp.status_code}")
+    raise ClaudeError(f"{context}: {resp.status_code}")
+
+
+def _record_usage(span: Any, usage: dict) -> None:
+    """Copy token-usage counters from a response into the Sentry span."""
+    span.set_data("ai.prompt_tokens.used", usage.get("input_tokens", 0))
+    span.set_data("ai.completion_tokens.used", usage.get("output_tokens", 0))
+    span.set_data(
+        "ai.total_tokens.used",
+        usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
+    )
+    if usage.get("cache_read_input_tokens"):
+        span.set_data("ai.cache_read_tokens", usage["cache_read_input_tokens"])
+
+
 async def claude_structured(
     prompt: str,
     schema: dict,
@@ -104,20 +161,13 @@ async def claude_structured(
     else:
         model = MODELS.get(model_tier, MODELS["fast"])
 
-    # Build system with optional cache control (H10)
-    system_blocks = []
-    if system:
-        block = {"type": "text", "text": system}
-        if cache_system:
-            block["cache_control"] = {"type": "ephemeral"}
-        system_blocks.append(block)
-
     body: dict[str, Any] = {
         "model": model,
         "max_tokens": max_tokens,
         "messages": [{"role": "user", "content": prompt}],
     }
 
+    system_blocks = _system_blocks(system, cache=cache_system)
     if system_blocks:
         body["system"] = system_blocks
 
@@ -127,16 +177,9 @@ async def claude_structured(
         # Ensure max_tokens covers both thinking and output
         body["max_tokens"] = max(max_tokens, thinking_budget + 1024)
 
-    # H9: Structured Outputs — guaranteed valid JSON
-    # Use tool-based approach for schema enforcement
-    body["tools"] = [
-        {
-            "name": "structured_output",
-            "description": "Return structured data matching the required schema.",
-            "input_schema": schema,
-        }
-    ]
-    body["tool_choice"] = {"type": "tool", "name": "structured_output"}
+    # H9: Structured Outputs — guaranteed valid JSON via tool-based schema enforcement
+    body["tools"] = [_structured_output_tool(schema)]
+    body["tool_choice"] = {"type": "tool", "name": _STRUCTURED_OUTPUT_TOOL_NAME}
 
     max_attempts = 3
     for attempt in range(1, max_attempts + 1):
@@ -168,32 +211,17 @@ async def claude_structured(
                 if resp.status_code != 200:
                     span.set_data("ai.response.status_code", resp.status_code)
                     logger.warning(f"Claude API {resp.status_code}: {resp.text[:200]}")
-                    if resp.status_code in (401, 403):
-                        raise ClaudeAuthError(f"Claude API auth failed: {resp.status_code}")
-                    if resp.status_code == 429:
-                        raise ClaudeRateLimitError("Rate limit exceeded after retries")
-                    if resp.status_code >= 500:
-                        raise ClaudeServerError(f"Claude API error: {resp.status_code}")
-                    raise ClaudeError(f"Claude API error: {resp.status_code}")
+                    _raise_for_status(resp, context="Claude API error")
 
                 data = resp.json()
-                usage = data.get("usage", {})
-                span.set_data("ai.prompt_tokens.used", usage.get("input_tokens", 0))
-                span.set_data("ai.completion_tokens.used", usage.get("output_tokens", 0))
-                span.set_data(
-                    "ai.total_tokens.used",
-                    usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
-                )
-                if usage.get("cache_read_input_tokens"):
-                    span.set_data("ai.cache_read_tokens", usage["cache_read_input_tokens"])
+                _record_usage(span, data.get("usage", {}))
 
                 # Tool use response — extract the tool input (guaranteed valid JSON)
-                for block in data.get("content", []):
-                    if block.get("type") == "tool_use" and block.get("name") == "structured_output":
-                        return block.get("input")
-
-                logger.warning("Claude structured output: no tool_use block in response")
-                return None
+                tool_input = _extract_tool_input(data.get("content", []))
+                if tool_input is _MISSING:
+                    logger.warning("Claude structured output: no tool_use block in response")
+                    return None
+                return tool_input
 
         except (ClaudeError,):
             raise
@@ -252,19 +280,13 @@ async def claude_text(
 
     model = MODELS.get(model_tier, MODELS["fast"])
 
-    system_blocks = []
-    if system:
-        block = {"type": "text", "text": system}
-        if cache_system:
-            block["cache_control"] = {"type": "ephemeral"}
-        system_blocks.append(block)
-
     body: dict[str, Any] = {
         "model": model,
         "max_tokens": max_tokens,
         "messages": [{"role": "user", "content": prompt}],
     }
 
+    system_blocks = _system_blocks(system, cache=cache_system)
     if system_blocks:
         body["system"] = system_blocks
     if tools:
@@ -300,24 +322,10 @@ async def claude_text(
                 if resp.status_code != 200:
                     span.set_data("ai.response.status_code", resp.status_code)
                     logger.warning(f"Claude API {resp.status_code}: {resp.text[:200]}")
-                    if resp.status_code in (401, 403):
-                        raise ClaudeAuthError(f"Claude API auth failed: {resp.status_code}")
-                    if resp.status_code == 429:
-                        raise ClaudeRateLimitError("Rate limit exceeded after retries")
-                    if resp.status_code >= 500:
-                        raise ClaudeServerError(f"Claude API error: {resp.status_code}")
-                    raise ClaudeError(f"Claude API error: {resp.status_code}")
+                    _raise_for_status(resp, context="Claude API error")
 
                 data = resp.json()
-                usage = data.get("usage", {})
-                span.set_data("ai.prompt_tokens.used", usage.get("input_tokens", 0))
-                span.set_data("ai.completion_tokens.used", usage.get("output_tokens", 0))
-                span.set_data(
-                    "ai.total_tokens.used",
-                    usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
-                )
-                if usage.get("cache_read_input_tokens"):
-                    span.set_data("ai.cache_read_tokens", usage["cache_read_input_tokens"])
+                _record_usage(span, data.get("usage", {}))
 
                 # Extract text from response (may be interleaved with tool use)
                 texts = [b["text"] for b in data.get("content", []) if b.get("type") == "text"]
@@ -418,24 +426,15 @@ def _build_batch_request(
     """Build a single request entry for the Batch API."""
     model = MODELS.get(model_tier, MODELS["fast"])
 
-    system_blocks = []
-    if system:
-        system_blocks.append({"type": "text", "text": system})
-
     params: dict[str, Any] = {
         "model": model,
         "max_tokens": max_tokens,
         "messages": [{"role": "user", "content": prompt}],
-        "tools": [
-            {
-                "name": "structured_output",
-                "description": "Return structured data matching the required schema.",
-                "input_schema": schema,
-            }
-        ],
-        "tool_choice": {"type": "tool", "name": "structured_output"},
+        "tools": [_structured_output_tool(schema)],
+        "tool_choice": {"type": "tool", "name": _STRUCTURED_OUTPUT_TOOL_NAME},
     }
 
+    system_blocks = _system_blocks(system, cache=False)
     if system_blocks:
         params["system"] = system_blocks
 
@@ -570,19 +569,17 @@ async def claude_batch_results(
                 if result.get("type") == "succeeded":
                     message = result.get("message", {})
                     # Extract tool_use input (same as claude_structured)
-                    for block in message.get("content", []):
-                        if block.get("type") == "tool_use" and block.get("name") == "structured_output":
-                            raw_input = block.get("input")
-                            # API occasionally returns tool input as JSON string
-                            if isinstance(raw_input, str):
-                                try:
-                                    raw_input = json.loads(raw_input)
-                                except (json.JSONDecodeError, TypeError):
-                                    raw_input = None
-                            parsed[cid] = raw_input
-                            break
-                    else:
+                    raw_input = _extract_tool_input(message.get("content", []))
+                    if raw_input is _MISSING:
                         parsed[cid] = None
+                    else:
+                        # API occasionally returns tool input as JSON string
+                        if isinstance(raw_input, str):
+                            try:
+                                raw_input = json.loads(raw_input)
+                            except (json.JSONDecodeError, TypeError):
+                                raw_input = None
+                        parsed[cid] = raw_input
                 else:
                     error = result.get("error", {})
                     logger.warning(f"Batch item {cid} failed: {error.get('type', 'unknown')}")

--- a/app/utils/claude_errors.py
+++ b/app/utils/claude_errors.py
@@ -8,28 +8,18 @@ Depends on: nothing
 class ClaudeError(Exception):
     """Base exception for Claude API failures."""
 
-    pass
-
 
 class ClaudeAuthError(ClaudeError):
     """API key missing or invalid (401/403)."""
-
-    pass
 
 
 class ClaudeRateLimitError(ClaudeError):
     """Rate limited (429) — caller should back off."""
 
-    pass
-
 
 class ClaudeServerError(ClaudeError):
     """Claude API returned 5xx — transient, may retry."""
 
-    pass
-
 
 class ClaudeUnavailableError(ClaudeError):
     """API key not configured — feature should degrade gracefully."""
-
-    pass

--- a/app/utils/graph_client.py
+++ b/app/utils/graph_client.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import asyncio
+import os
 
 from loguru import logger
 
@@ -22,17 +23,14 @@ class GraphSyncStateExpired(Exception):
     """Raised when Graph API returns 410 — the delta token is stale and must be
     discarded."""
 
-    pass
-
 
 # H1: Immutable IDs — prevents ID changes when messages are moved between folders
 IMMUTABLE_ID_HEADER = {"Prefer": 'IdType="ImmutableId"'}
 
 # H6: Retry config — in TESTING mode, fail fast (no retries, no sleep)
-import os as _os
-
-MAX_RETRIES = 0 if _os.environ.get("TESTING") else 3
-BACKOFF_BASE = 0 if _os.environ.get("TESTING") else 2  # seconds — exponential: 2, 4, 8
+_TESTING = bool(os.environ.get("TESTING"))
+MAX_RETRIES = 0 if _TESTING else 3
+BACKOFF_BASE = 0 if _TESTING else 2  # seconds — exponential: 2, 4, 8
 
 
 class GraphClient:
@@ -210,21 +208,13 @@ class GraphClient:
                     logger.warning("Graph 410 SyncStateNotFound — delta token expired")
                     raise GraphSyncStateExpired(resp.text[:300])
 
-                # Throttled — respect Retry-After, use max of backoff and header
-                if resp.status_code == 429:
+                # Throttled (429) / Service Unavailable (503) — respect Retry-After,
+                # using the max of backoff and header so we never wait less than asked.
+                if resp.status_code in (429, 503):
                     backoff_wait = BACKOFF_BASE ** (attempt + 1)
                     retry_after = _parse_retry_after(resp)
                     wait = max(backoff_wait, retry_after) if retry_after else backoff_wait
-                    logger.warning(f"Graph 429 — retry in {wait}s (attempt {attempt + 1})")
-                    await asyncio.sleep(wait)
-                    continue
-
-                # 503 Service Unavailable — retry with Retry-After if present
-                if resp.status_code == 503:
-                    backoff_wait = BACKOFF_BASE ** (attempt + 1)
-                    retry_after = _parse_retry_after(resp)
-                    wait = max(backoff_wait, retry_after) if retry_after else backoff_wait
-                    logger.warning(f"Graph 503 — retry in {wait}s (attempt {attempt + 1})")
+                    logger.warning(f"Graph {resp.status_code} — retry in {wait}s (attempt {attempt + 1})")
                     await asyncio.sleep(wait)
                     continue
 

--- a/app/utils/json_helpers.py
+++ b/app/utils/json_helpers.py
@@ -16,10 +16,8 @@ def dumps(obj, *, sort_keys: bool = False, default=None) -> str:
     Mirrors json.dumps() signature for the params we use. Returns str (not bytes) for
     compatibility with Redis and SQL.
     """
-    opts = 0
-    if sort_keys:
-        opts |= orjson.OPT_SORT_KEYS
-    return orjson.dumps(obj, option=opts or None, default=default).decode()
+    option = orjson.OPT_SORT_KEYS if sort_keys else 0
+    return orjson.dumps(obj, option=option, default=default).decode()
 
 
 def loads(s):

--- a/app/utils/normalization.py
+++ b/app/utils/normalization.py
@@ -53,6 +53,14 @@ _CURRENCY_CODE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# K/M shorthand multipliers, shared by price and quantity parsing.
+_KM_MULTIPLIERS = {
+    "k": 1_000,
+    "K": 1_000,
+    "m": 1_000_000,
+    "M": 1_000_000,
+}
+
 
 def normalize_price(raw: Any) -> float | None:
     """Parse price string to float.
@@ -97,8 +105,7 @@ def normalize_price(raw: Any) -> float | None:
     m = re.match(r"^([\d.]+)\s*([kKmM])$", s)
     if m:
         num = float(m.group(1))
-        mult = {"k": 1_000, "K": 1_000, "m": 1_000_000, "M": 1_000_000}
-        return num * mult.get(m.group(2), 1)
+        return num * _KM_MULTIPLIERS.get(m.group(2), 1)
 
     try:
         val = float(s)
@@ -131,12 +138,7 @@ def detect_currency(raw: Any) -> str:
 
 # ── Quantity normalization ────────────────────────────────────────────
 
-_QTY_MULTIPLIERS = {
-    "k": 1_000,
-    "K": 1_000,
-    "m": 1_000_000,
-    "M": 1_000_000,
-}
+_QTY_MULTIPLIERS = _KM_MULTIPLIERS
 
 
 def normalize_quantity(raw: Any) -> int | None:

--- a/app/utils/normalization_helpers.py
+++ b/app/utils/normalization_helpers.py
@@ -217,7 +217,7 @@ _COUNTRY_MAP = {
 }
 
 # Valid ISO 3166-1 alpha-2 codes (for pass-through)
-_VALID_ISO2 = {v for v in _COUNTRY_MAP.values()}
+_VALID_ISO2 = set(_COUNTRY_MAP.values())
 
 
 def normalize_country(raw: str | None) -> str | None:
@@ -314,7 +314,7 @@ _US_STATE_MAP = {
     "american samoa": "AS",
 }
 
-_VALID_STATE_CODES = {v for v in _US_STATE_MAP.values()}
+_VALID_STATE_CODES = set(_US_STATE_MAP.values())
 
 
 def normalize_us_state(raw: str | None) -> str | None:

--- a/app/utils/phone_utils.py
+++ b/app/utils/phone_utils.py
@@ -90,10 +90,7 @@ def format_phone_display(raw: str) -> str:
     cc = digits[:cc_len]
     rest = digits[cc_len:]
     # Split rest into groups of 4
-    groups = []
-    while rest:
-        groups.append(rest[:4])
-        rest = rest[4:]
+    groups = [rest[i : i + 4] for i in range(0, len(rest), 4)]
     return f"+{cc} {' '.join(groups)}"
 
 

--- a/app/utils/search_builder.py
+++ b/app/utils/search_builder.py
@@ -70,7 +70,6 @@ class SearchBuilder:
                     model.search_vector.isnot(None),
                     sqltext("search_vector @@ plainto_tsquery('english', :q)"),
                 )
-                .params(q=self.q)
                 .order_by(sqltext("ts_rank(search_vector, plainto_tsquery('english', :q)) DESC"))
                 .params(q=self.q)
             )

--- a/app/utils/text_utils.py
+++ b/app/utils/text_utils.py
@@ -6,6 +6,20 @@ Depends on: re (stdlib)
 
 import re
 
+# Block-level tags that become line breaks; remaining tags collapse to spaces.
+_BLOCK_TAG_RE = re.compile(r"<br\s*/?>|</p>|</tr>|</li>", re.IGNORECASE)
+_TAG_RE = re.compile(r"<[^>]+>")
+_INLINE_WS_RE = re.compile(r"[^\S\n]+")
+_BLANK_LINES_RE = re.compile(r"\n{3,}")
+_DISCLAIMER_RES = [
+    re.compile(pat, re.IGNORECASE | re.DOTALL)
+    for pat in (
+        r"this email and any attachments.*?(?=\n\n|\Z)",
+        r"confidentiality notice.*?(?=\n\n|\Z)",
+        r"disclaimer.*?(?=\n\n|\Z)",
+    )
+]
+
 
 def clean_email_body(body: str) -> str:
     """Strip HTML, excessive whitespace, and email disclaimers.
@@ -14,15 +28,10 @@ def clean_email_body(body: str) -> str:
     """
     if not body:
         return ""
-    text = re.sub(r"<br\s*/?>|</p>|</tr>|</li>", "\n", body, flags=re.IGNORECASE)
-    text = re.sub(r"<[^>]+>", " ", text)
-    text = re.sub(r"[^\S\n]+", " ", text)
-    text = re.sub(r"\n{3,}", "\n\n", text)
-    disclaimer_patterns = [
-        r"(?i)this email and any attachments.*?(?=\n\n|\Z)",
-        r"(?i)confidentiality notice.*?(?=\n\n|\Z)",
-        r"(?i)DISCLAIMER.*?(?=\n\n|\Z)",
-    ]
-    for pat in disclaimer_patterns:
-        text = re.sub(pat, "", text, flags=re.DOTALL)
+    text = _BLOCK_TAG_RE.sub("\n", body)
+    text = _TAG_RE.sub(" ", text)
+    text = _INLINE_WS_RE.sub(" ", text)
+    text = _BLANK_LINES_RE.sub("\n\n", text)
+    for disclaimer_re in _DISCLAIMER_RES:
+        text = disclaimer_re.sub("", text)
     return text.strip()

--- a/app/utils/vendor_helpers.py
+++ b/app/utils/vendor_helpers.py
@@ -37,6 +37,25 @@ _EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
 # ── Helper Functions ─────────────────────────────────────────────────────
 
 
+def _record_alternate_name(card: VendorCard, vendor_name: str, db: Session, *, context: str) -> None:
+    """Append vendor_name to a matched card's alternate_names and commit.
+
+    No-op if the name already appears (as an alternate or as the display name). Rolls
+    back and logs on commit failure rather than propagating, since the matched card is
+    still usable without the alternate-name update.
+    """
+    alts = list(card.alternate_names or [])
+    if vendor_name in alts or vendor_name == card.display_name:
+        return
+    alts.append(vendor_name)
+    card.alternate_names = alts
+    try:
+        db.commit()
+    except Exception:
+        logger.exception("Failed to commit {} vendor alt name for '{}'", context, vendor_name)
+        db.rollback()
+
+
 def get_or_create_card(vendor_name: str, db: Session, domain: str | None = None) -> VendorCard:
     """Find existing VendorCard by normalized name, domain, or fuzzy match, or create
     new.
@@ -58,15 +77,7 @@ def get_or_create_card(vendor_name: str, db: Session, domain: str | None = None)
         domain_lower = domain.strip().lower()
         card = db.query(VendorCard).filter(sqlfunc.lower(VendorCard.domain) == domain_lower).first()
         if card:
-            alts = list(card.alternate_names or [])
-            if vendor_name not in alts and vendor_name != card.display_name:
-                alts.append(vendor_name)
-                card.alternate_names = alts
-                try:
-                    db.commit()
-                except Exception:
-                    logger.exception("Failed to commit domain-matched vendor alt name for '{}'", vendor_name)
-                    db.rollback()
+            _record_alternate_name(card, vendor_name, db, context="domain-matched")
             logger.info(
                 "Domain-matched vendor '{}' to '{}' (domain={})",
                 vendor_name,
@@ -89,15 +100,7 @@ def get_or_create_card(vendor_name: str, db: Session, domain: str | None = None)
             if trgm_rows and trgm_rows[0].sim >= 0.6:
                 card = db.get(VendorCard, trgm_rows[0].id)
                 if card:
-                    alts = list(card.alternate_names or [])
-                    if vendor_name not in alts and vendor_name != card.display_name:
-                        alts.append(vendor_name)
-                        card.alternate_names = alts
-                        try:
-                            db.commit()
-                        except Exception:
-                            logger.exception("Failed to commit pg_trgm matched vendor alt name for '{}'", vendor_name)
-                            db.rollback()
+                    _record_alternate_name(card, vendor_name, db, context="pg_trgm matched")
                     logger.info(
                         "pg_trgm matched vendor '{}' to '{}' (sim={:.2f})",
                         vendor_name,
@@ -124,15 +127,7 @@ def get_or_create_card(vendor_name: str, db: Session, domain: str | None = None)
         if best_score >= 82 and best_card_id:
             card = db.get(VendorCard, best_card_id)
             if card:
-                alts = list(card.alternate_names or [])
-                if vendor_name not in alts and vendor_name != card.display_name:
-                    alts.append(vendor_name)
-                    card.alternate_names = alts
-                    try:
-                        db.commit()
-                    except Exception:
-                        logger.exception("Failed to commit fuzzy-matched vendor alt name for '{}'", vendor_name)
-                        db.rollback()
+                _record_alternate_name(card, vendor_name, db, context="fuzzy-matched")
                 logger.info(
                     "Fuzzy-matched vendor '{}' to '{}' (score={})",
                     vendor_name,


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/utils`, 10 files)
- **`claude_client.py`** — extract repeated *system-block construction*, *structured-output tool definition*, *tool_use input extraction*, *status→exception mapping*, and *usage→span accounting* into private helpers. Applied **only** where call sites were byte-identical; the divergent batch-API paths (different log/exception wording) were deliberately left intact.
- **`vendor_helpers.py`** — collapse the 3×-duplicated alternate-name merge/commit block into one `_record_alternate_name()` helper; per-branch log wording reconstructed exactly.
- **`normalization.py`** — single shared `_KM_MULTIPLIERS` constant for price + quantity; stop allocating the multiplier dict on every call.
- Surgical dedup across `claude_errors`, `graph_client`, `json_helpers`, `normalization_helpers`, `phone_utils`, `search_builder`, `text_utils`.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

## Recorded, not done (cross-file → follow-up)
- `llm_router.py` re-declares all of `claude_*`'s params with duplicated defaults — dedup belongs there, not here.
- `card_to_dict` / `vendor_helpers` use Redis directly rather than `intel_cache.get_cached/set_cached` (those add an `intel:` prefix + PG fallback = observable change; would need a new unprefixed accessor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)