### PR TITLE
simplify(schemas): de-duplicate schema/validator definitions

### DIFF
--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -8,7 +8,7 @@ Depends on: pydantic
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class SourceCredentialsUpdate(BaseModel):
@@ -18,7 +18,7 @@ class SourceCredentialsUpdate(BaseModel):
     credential keys.
     """
 
-    model_config = {"extra": "allow"}
+    model_config = ConfigDict(extra="allow")
 
 
 class TeamsChannelRouting(BaseModel):
@@ -29,4 +29,4 @@ class TeamsChannelRouting(BaseModel):
     Uses extra="allow" to accept dynamic channel keys.
     """
 
-    model_config = {"extra": "allow"}
+    model_config = ConfigDict(extra="allow")

--- a/app/schemas/ai.py
+++ b/app/schemas/ai.py
@@ -20,6 +20,14 @@ from pydantic import BaseModel, Field, field_validator
 from app.utils.normalization import normalize_condition, normalize_mpn, normalize_packaging
 
 
+def _normalize_optional(v: str | None, normalizer) -> str | None:
+    """Apply a normalizer to an optional field, passing through None and falling back to
+    the original value when the normalizer returns None."""
+    if v is None:
+        return v
+    return normalizer(v) or v
+
+
 class ProspectFinderRequest(BaseModel):
     entity_type: Literal["company", "site", "vendor"] = "company"
     entity_id: int | None = None
@@ -57,16 +65,12 @@ class DraftOfferItem(BaseModel):
     @field_validator("condition")
     @classmethod
     def normalize_condition_field(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        return normalize_condition(v) or v
+        return _normalize_optional(v, normalize_condition)
 
     @field_validator("packaging")
     @classmethod
     def normalize_packaging_field(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        return normalize_packaging(v) or v
+        return _normalize_optional(v, normalize_packaging)
 
 
 class SaveDraftOffersRequest(BaseModel):

--- a/app/schemas/buy_plan.py
+++ b/app/schemas/buy_plan.py
@@ -21,6 +21,21 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+
+def _require_and_strip_note(note: str | None, *, required: bool, message: str) -> str | None:
+    """Enforce a conditionally-required note and strip surrounding whitespace.
+
+    Raises ``ValueError`` with ``message`` when ``required`` is set but the note
+    is missing or blank. A present note is returned stripped; ``None`` passes
+    through unchanged.
+    """
+    if required and not (note and note.strip()):
+        raise ValueError(message)
+    if note:
+        return note.strip()
+    return note
+
+
 # ── Request Schemas ──────────────────────────────────────────────────
 
 
@@ -50,10 +65,11 @@ class SOVerificationRequest(BaseModel):
 
     @model_validator(mode="after")
     def note_required_on_reject(self):
-        if self.action in ("reject", "halt") and not (self.rejection_note and self.rejection_note.strip()):
-            raise ValueError("A note is required when rejecting or halting")
-        if self.rejection_note:
-            self.rejection_note = self.rejection_note.strip()
+        self.rejection_note = _require_and_strip_note(
+            self.rejection_note,
+            required=self.action in ("reject", "halt"),
+            message="A note is required when rejecting or halting",
+        )
         return self
 
 
@@ -80,10 +96,11 @@ class POVerificationRequest(BaseModel):
 
     @model_validator(mode="after")
     def note_required_on_reject(self):
-        if self.action == "reject" and not (self.rejection_note and self.rejection_note.strip()):
-            raise ValueError("A note is required when rejecting a PO")
-        if self.rejection_note:
-            self.rejection_note = self.rejection_note.strip()
+        self.rejection_note = _require_and_strip_note(
+            self.rejection_note,
+            required=self.action == "reject",
+            message="A note is required when rejecting a PO",
+        )
         return self
 
 
@@ -95,10 +112,11 @@ class BuyPlanLineIssue(BaseModel):
 
     @model_validator(mode="after")
     def note_required_for_other(self):
-        if self.issue_type == "other" and not (self.note and self.note.strip()):
-            raise ValueError("A note is required for 'other' issue type")
-        if self.note:
-            self.note = self.note.strip()
+        self.note = _require_and_strip_note(
+            self.note,
+            required=self.issue_type == "other",
+            message="A note is required for 'other' issue type",
+        )
         return self
 
 

--- a/app/schemas/crm.py
+++ b/app/schemas/crm.py
@@ -14,6 +14,7 @@ Depends on: pydantic
 
 from __future__ import annotations
 
+import re
 from datetime import date
 from typing import Literal
 
@@ -30,6 +31,8 @@ from app.utils.normalization_helpers import (
     normalize_phone_e164,
     normalize_us_state,
 )
+
+_WEBSITE_RE = re.compile(r"^https?://[a-zA-Z0-9][-a-zA-Z0-9.]*\.[a-zA-Z]{2,}")
 
 # ── Companies ────────────────────────────────────────────────────────
 
@@ -64,9 +67,7 @@ class CompanyCreate(BaseModel):
         v = v.strip()
         if not v.startswith(("http://", "https://")):
             v = "https://" + v
-        import re
-
-        if not re.match(r"^https?://[a-zA-Z0-9][-a-zA-Z0-9.]*\.[a-zA-Z]{2,}", v):
+        if not _WEBSITE_RE.match(v):
             raise ValueError("Please enter a valid website URL")
         return v
 

--- a/app/schemas/requisitions.py
+++ b/app/schemas/requisitions.py
@@ -36,6 +36,22 @@ def _validate_deadline(v: str | None) -> str | None:
     raise ValueError(f"Invalid date: '{v}'. Use YYYY-MM-DD format and ensure the date is valid.")
 
 
+def _normalize_optional(v: str | None, normalizer) -> str | None:
+    """Apply a normalizer to an optional field, passing through None and falling back to
+    the original value when the normalizer returns None."""
+    if v is None:
+        return v
+    return normalizer(v) or v
+
+
+def _normalize_mpn_list(v):
+    """Normalize each MPN in a list, dropping falsy entries; pass non-lists through
+    unchanged."""
+    if isinstance(v, list):
+        return [normalize_mpn(s) or s for s in v if s]
+    return v
+
+
 # ── Batch Operations ─────────────────────────────────────────────────
 
 
@@ -128,23 +144,17 @@ class RequirementCreate(BaseModel):
     def parse_substitutes(cls, v):
         if isinstance(v, str):
             v = [s.strip() for s in v.replace("\n", ",").split(",") if s.strip()]
-        if isinstance(v, list):
-            return [normalize_mpn(s) or s for s in v if s]
-        return v
+        return _normalize_mpn_list(v)
 
     @field_validator("condition")
     @classmethod
     def normalize_condition_field(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        return normalize_condition(v) or v
+        return _normalize_optional(v, normalize_condition)
 
     @field_validator("packaging")
     @classmethod
     def normalize_packaging_field(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        return normalize_packaging(v) or v
+        return _normalize_optional(v, normalize_packaging)
 
 
 class RequirementUpdate(BaseModel):
@@ -180,23 +190,17 @@ class RequirementUpdate(BaseModel):
     @field_validator("substitutes", mode="before")
     @classmethod
     def normalize_substitutes(cls, v):
-        if isinstance(v, list):
-            return [normalize_mpn(s) or s for s in v if s]
-        return v
+        return _normalize_mpn_list(v)
 
     @field_validator("condition")
     @classmethod
     def normalize_condition_field(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        return normalize_condition(v) or v
+        return _normalize_optional(v, normalize_condition)
 
     @field_validator("packaging")
     @classmethod
     def normalize_packaging_field(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        return normalize_packaging(v) or v
+        return _normalize_optional(v, normalize_packaging)
 
 
 class SightingUnavailableIn(BaseModel):

--- a/app/schemas/requisitions2.py
+++ b/app/schemas/requisitions2.py
@@ -9,7 +9,6 @@ Depends on: pydantic
 
 from datetime import date
 from enum import Enum
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -53,10 +52,10 @@ class ReqListFilters(BaseModel):
 
     q: str = ""
     status: ReqStatus = ReqStatus.active
-    owner: Optional[int] = None
-    urgency: Optional[Urgency] = None
-    date_from: Optional[date] = None
-    date_to: Optional[date] = None
+    owner: int | None = None
+    urgency: Urgency | None = None
+    date_from: date | None = None
+    date_to: date | None = None
     sort: SortColumn = SortColumn.created_at
     order: SortOrder = SortOrder.desc
     page: int = Field(default=1, ge=1)

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -199,6 +199,12 @@ class SimpleOkIdResponse(BaseModel):
 # ── Bulk Requisition Endpoints ─────────────────────────────────────────
 
 
+def _assert_count_matches(count_label: str, count: int, ids_label: str, ids: list[int]) -> None:
+    """Raise ValueError if a `*_count` field disagrees with its `*_ids` list length."""
+    if count != len(ids):
+        raise ValueError(f"{count_label} ({count}) != len({ids_label}) ({len(ids)})")
+
+
 class BulkArchiveResponse(BaseModel):
     """Response shape for `/api/requisitions/bulk-archive` and `/batch-archive`.
 
@@ -215,8 +221,7 @@ class BulkArchiveResponse(BaseModel):
 
     @model_validator(mode="after")
     def _count_matches_ids(self) -> Self:
-        if self.archived_count != len(self.archived_ids):
-            raise ValueError(f"archived_count ({self.archived_count}) != len(archived_ids) ({len(self.archived_ids)})")
+        _assert_count_matches("archived_count", self.archived_count, "archived_ids", self.archived_ids)
         return self
 
 
@@ -230,8 +235,7 @@ class BatchAssignResponse(BaseModel):
 
     @model_validator(mode="after")
     def _count_matches_ids(self) -> Self:
-        if self.assigned_count != len(self.assigned_ids):
-            raise ValueError(f"assigned_count ({self.assigned_count}) != len(assigned_ids) ({len(self.assigned_ids)})")
+        _assert_count_matches("assigned_count", self.assigned_count, "assigned_ids", self.assigned_ids)
         return self
 
 

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -11,6 +11,16 @@ from datetime import datetime, timedelta, timezone
 from pydantic import BaseModel, Field, field_validator
 
 
+def _require_due_at_24h(v: datetime) -> datetime:
+    """Reject due dates less than 24 hours out; returns ``v`` unchanged if valid."""
+    now = datetime.now(timezone.utc)
+    # Make naive datetimes UTC for comparison
+    check = v.replace(tzinfo=timezone.utc) if v.tzinfo is None else v
+    if check < now + timedelta(hours=24):
+        raise ValueError("Due date must be at least 24 hours from now")
+    return v
+
+
 class TaskCreate(BaseModel):
     title: str = Field(..., min_length=1, max_length=255)
     description: str | None = None
@@ -20,12 +30,7 @@ class TaskCreate(BaseModel):
     @field_validator("due_at")
     @classmethod
     def due_at_min_24h(cls, v: datetime) -> datetime:
-        now = datetime.now(timezone.utc)
-        # Make naive datetimes UTC for comparison
-        check = v.replace(tzinfo=timezone.utc) if v.tzinfo is None else v
-        if check < now + timedelta(hours=24):
-            raise ValueError("Due date must be at least 24 hours from now")
-        return v
+        return _require_due_at_24h(v)
 
 
 class TaskUpdate(BaseModel):
@@ -39,11 +44,7 @@ class TaskUpdate(BaseModel):
     def due_at_min_24h(cls, v: datetime | None) -> datetime | None:
         if v is None:
             return v
-        now = datetime.now(timezone.utc)
-        check = v.replace(tzinfo=timezone.utc) if v.tzinfo is None else v
-        if check < now + timedelta(hours=24):
-            raise ValueError("Due date must be at least 24 hours from now")
-        return v
+        return _require_due_at_24h(v)
 
 
 class TaskComplete(BaseModel):

--- a/app/schemas/vendors.py
+++ b/app/schemas/vendors.py
@@ -14,7 +14,35 @@ Depends on: pydantic
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from pydantic import BaseModel, field_validator
+
+
+def _require_vendor_name(v: str) -> str:
+    """Strip and reject a blank vendor_name."""
+    v = v.strip()
+    if not v:
+        raise ValueError("vendor_name required")
+    return v
+
+
+def _dedupe_cleaned(v: list[str] | None, cleaner: Callable[[str], str | None]) -> list[str] | None:
+    """Apply ``cleaner`` to each item, dropping ``None`` results, preserving order, and
+    de-duplicating.
+
+    Passes ``None`` through unchanged.
+    """
+    if v is None:
+        return None
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in v:
+        cleaned = cleaner(item)
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            result.append(cleaned)
+    return result
 
 
 class VendorCardUpdate(BaseModel):
@@ -27,34 +55,17 @@ class VendorCardUpdate(BaseModel):
     @field_validator("emails", mode="before")
     @classmethod
     def clean_emails(cls, v: list[str] | None) -> list[str] | None:
-        if v is None:
-            return None
-        seen: set[str] = set()
-        result: list[str] = []
-        for e in v:
+        def clean(e: str) -> str | None:
             if not e or "@" not in str(e):
-                continue
-            cleaned = str(e).strip().lower()
-            if cleaned not in seen:
-                seen.add(cleaned)
-                result.append(cleaned)
-        return result
+                return None
+            return str(e).strip().lower()
+
+        return _dedupe_cleaned(v, clean)
 
     @field_validator("phones", mode="before")
     @classmethod
     def clean_phones(cls, v: list[str] | None) -> list[str] | None:
-        if v is None:
-            return None
-        seen: set[str] = set()
-        result: list[str] = []
-        for p in v:
-            if not p or not str(p).strip():
-                continue
-            cleaned = str(p).strip()
-            if cleaned not in seen:
-                seen.add(cleaned)
-                result.append(cleaned)
-        return result
+        return _dedupe_cleaned(v, lambda p: str(p).strip() if p and str(p).strip() else None)
 
 
 class VendorBlacklistToggle(BaseModel):
@@ -82,10 +93,7 @@ class VendorContactLookup(BaseModel):
     @field_validator("vendor_name")
     @classmethod
     def name_required(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("vendor_name required")
-        return v
+        return _require_vendor_name(v)
 
 
 class VendorContactCreate(BaseModel):
@@ -129,10 +137,7 @@ class VendorEmailAdd(BaseModel):
     @field_validator("vendor_name")
     @classmethod
     def name_required(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise ValueError("vendor_name required")
-        return v
+        return _require_vendor_name(v)
 
     @field_validator("email")
     @classmethod


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/schemas`)
9 file(s) changed, 11 simplifications (17 file(s) already clean).

- **`admin.py`** — Replace bare-dict model_config with ConfigDict to match the codebase convention.
- **`ai.py`** — Added file-local _normalize_optional helper to collapse the two duplicated optional-field normalizer bodies in DraftOfferItem.
- **`buy_plan.py`** — Extracted thrice-duplicated conditionally-required-note + strip logic into a module-level _require_and_strip_note() helper.
- **`crm.py`** — Hoisted the per-call `import re` out of CompanyCreate.validate_website to a module-level import; Precompiled the website-validation regex into a module constant _WEBSITE_RE instead of re.match-ing a raw pattern string on every call.
- **`requisitions.py`** — Hoisted two module-level helpers (_normalize_optional, _normalize_mpn_list) to remove four near-identical copy-paste validator bodies.
- **`requisitions2.py`** — Switched Optional[X] field annotations to X | None union syntax and removed the now-unused typing.Optional import.
- **`responses.py`** — Extracted copy-paste-with-variation count/ids cross-check into one module-level helper _assert_count_matches().
- **`task.py`** — Extracted duplicated due-date validation into a shared module-level helper.
- **`vendors.py`** — Extracted _dedupe_cleaned helper to collapse the two duplicated seen-set dedup loops in clean_emails/clean_phones; Extracted _require_vendor_name to remove the byte-identical name_required validator duplicated across VendorContactLookup and VendorEmailAdd.

_Recorded cross-file follow-ups:_
- `crm.py`: REUSE (cross-file): the inline website-URL normalization (add https:// scheme + validate) is not factored into any shared helper.
- `buy_plan.py`: Cross-file (out of scope): the blank-strip/required-note pattern now lives in three places — _strip_not_blank in excess.
- `task.py`: REUSE (cross-file, not applied): app/utils/token_manager.
- `sources.py`: REUSE (cross-file, NOT applied): SourceStatusToggle.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)