### PR TITLE
simplify(models): de-duplicate SQLAlchemy model definitions

### DIFF
--- a/app/models/crm.py
+++ b/app/models/crm.py
@@ -1,5 +1,6 @@
 """CRM models — Companies, Sites, and Site Contacts."""
 
+import re
 from datetime import datetime, timezone
 
 from sqlalchemy import JSON, Boolean, Column, ForeignKey, Index, Integer, String, Text, UniqueConstraint
@@ -80,11 +81,8 @@ class Company(Base):
 
     @validates("currency")
     def _validate_currency(self, _key, value):
-        if value is not None:
-            import re
-
-            if not re.fullmatch(r"[A-Z]{3}", value):
-                raise ValueError(f"Invalid ISO 4217 currency code: {value}")
+        if value is not None and not re.fullmatch(r"[A-Z]{3}", value):
+            raise ValueError(f"Invalid ISO 4217 currency code: {value}")
         return value
 
     __table_args__ = (

--- a/app/models/excess.py
+++ b/app/models/excess.py
@@ -56,7 +56,9 @@ class ExcessList(Base):
     # --- Validators ---
     @validates("status")
     def _validate_status(self, _key, value):
-        valid = {"draft", "active", "bidding", "closed", "expired"}
+        from ..constants import ExcessListStatus
+
+        valid = {e.value for e in ExcessListStatus}
         if value and value not in valid:
             raise ValueError(f"Invalid ExcessList status: {value!r}")
         return value

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -10,9 +10,8 @@ from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Text
 
-from app.models.base import Base
-
 from ..database import UTCDateTime
+from .base import Base
 
 
 class Notification(Base):


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/models`)
3 file(s) changed, 3 simplifications (41 file(s) already clean).

- **`crm.py`** — Hoisted the function-local `import re` in `_validate_currency` to a module-level import.
- **`excess.py`** — Replaced the hardcoded ExcessList status literal set with the existing `ExcessListStatus` StrEnum from app/constants.py.
- **`notification.py`** — Normalized the Base/UTCDateTime imports to the codebase-wide model convention (relative imports, ..database before .base, single import group).

_Recorded cross-file follow-ups:_
- `crm.py`: Cross-file (REUSE): same codebase-wide `lambda: datetime.
- `intelligence.py`: REUSE (cross-file, not applied): the `Column(.
- `sourcing.py`: REUSE (cross-file, not applied): the url-scheme guard in `_validate_citations` (`urlparse(url.
- `sourcing.py`: REUSE/ALTITUDE (cross-file, not applied): `_uppercase_identity` is defined identically in three classes (OemSpecCode, OemSpecCodePending, OemSpecCodeBlacklist) and closely mirrors Requirement.
- `performance.py`: REUSE: every timestamp default uses the inline `lambda: datetime.
- `buy_plan.py`: SIMPLIFICATION: the two `_validate_status` methods (on BuyPlan and BuyPlanLine) are near-identical (differ only by enum + message), but they belong to separate model classes and exactly match the per-model `@validates("status")` + `valid = {e.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)