### PR TITLE
simplify(connectors): de-duplicate connector request/parse logic

### DIFF
--- a/app/connectors/ai_live_web.py
+++ b/app/connectors/ai_live_web.py
@@ -32,6 +32,8 @@ _STOCK_SIGNAL_WORDS = (
     "quantity",
     "pieces",
 )
+# Evidence must quote a stock/qty-like token to be credible.
+_EVIDENCE_TOKEN_RE = re.compile(r"(in stock|available|qty|quantity|\d+\s*(pcs|pieces|units)?)", re.I)
 _SEARCH_SCHEMA_HINT = {
     "offers": [
         {
@@ -76,10 +78,8 @@ class AIWebSearchConnector(BaseConnector):
 
     @staticmethod
     def _has_current_stock_signal(item: dict, evidence_note: str) -> bool:
-        explicit = item.get("in_stock_explicit")
-        if isinstance(explicit, bool):
-            if explicit:
-                return True
+        if item.get("in_stock_explicit") is True:
+            return True
         evidence_l = (evidence_note or "").lower()
         return any(token in evidence_l for token in _STOCK_SIGNAL_WORDS)
 
@@ -147,12 +147,11 @@ class AIWebSearchConnector(BaseConnector):
             price = safe_float(item.get("unit_price"))
             currency = (item.get("currency") or "USD").strip().upper()[:3] or "USD"
             lead_time = (item.get("lead_time") or "").strip() or None
-            condition = (item.get("condition") or "").strip().lower() or None
+            raw_condition = (item.get("condition") or "").strip().lower()
+            condition = raw_condition if raw_condition in {"new", "used", "refurbished"} else None
             vendor_url = self._normalize_vendor_url(item.get("vendor_url") or "")
             evidence_note = (item.get("evidence_note") or "").strip()
             listing_age_days = safe_int(item.get("listing_age_days"))
-            if condition not in {"new", "used", "refurbished"}:
-                condition = None
 
             # Quality gate — keep only credible current stock postings.
             if qty is None or qty <= 0:
@@ -172,7 +171,7 @@ class AIWebSearchConnector(BaseConnector):
                 continue
 
             # Extra sanity: evidence should include a stock/qty-like token.
-            if not re.search(r"(in stock|available|qty|quantity|\d+\s*(pcs|pieces|units)?)", evidence_note, re.I):
+            if not _EVIDENCE_TOKEN_RE.search(evidence_note):
                 dropped += 1
                 continue
 

--- a/app/connectors/digikey.py
+++ b/app/connectors/digikey.py
@@ -133,9 +133,8 @@ class DigiKeyConnector(BaseConnector):
             url = prod.get("ProductUrl") or prod.get("productUrl") or ""
 
             # Price — use unit price or first price break
-            price = None
             price_breaks = prod.get("StandardPricing") or prod.get("standardPricing") or []
-            if price_breaks and isinstance(price_breaks, list):
+            if isinstance(price_breaks, list) and price_breaks:
                 # Find the smallest qty price break
                 best = min(
                     price_breaks,
@@ -161,6 +160,14 @@ class DigiKeyConnector(BaseConnector):
             )
             rohs = map_rohs(rohs_raw)
 
+            # Normalize the product URL to an absolute DigiKey link
+            if url.startswith("http"):
+                click_url = url
+            elif url:
+                click_url = f"https://www.digikey.com{url}"
+            else:
+                click_url = ""
+
             results.append(
                 {
                     "vendor_name": "DigiKey",
@@ -172,7 +179,7 @@ class DigiKeyConnector(BaseConnector):
                     "source_type": "digikey",
                     "is_authorized": True,
                     "confidence": 5 if qty else 3,
-                    "click_url": url if url.startswith("http") else f"https://www.digikey.com{url}" if url else "",
+                    "click_url": click_url,
                     "vendor_sku": dk_pn,
                     "vendor_url": "https://www.digikey.com",
                     "description": detail_desc,

--- a/app/connectors/ebay.py
+++ b/app/connectors/ebay.py
@@ -65,30 +65,19 @@ class EbayConnector(BaseConnector):
             "fieldgroups": "MATCHING_ITEMS",
         }
 
-        r = await http.get(
-            self.SEARCH_URL,
-            headers={
-                "Authorization": f"Bearer {token}",
+        def headers(bearer: str) -> dict:
+            return {
+                "Authorization": f"Bearer {bearer}",
                 "X-EBAY-C-MARKETPLACE-ID": "EBAY_US",
                 "Content-Type": "application/json",
-            },
-            params=params,
-            timeout=self.timeout,
-        )
+            }
+
+        r = await http.get(self.SEARCH_URL, headers=headers(token), params=params, timeout=self.timeout)
 
         if r.status_code == 401:
             self._token = None
             token = await self._get_token()
-            r = await http.get(
-                self.SEARCH_URL,
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "X-EBAY-C-MARKETPLACE-ID": "EBAY_US",
-                    "Content-Type": "application/json",
-                },
-                params=params,
-                timeout=self.timeout,
-            )
+            r = await http.get(self.SEARCH_URL, headers=headers(token), params=params, timeout=self.timeout)
 
         if r.status_code == 404:
             return []

--- a/app/connectors/email_mining.py
+++ b/app/connectors/email_mining.py
@@ -46,6 +46,55 @@ OFFER_PATTERNS = [
 # Part number pattern — uppercase alphanumeric with dashes/slashes, 4+ chars
 MPN_PATTERN = re.compile(r"\b([A-Z0-9][A-Z0-9\-/\.#]{3,30}[A-Z0-9])\b")
 
+# Uppercase tokens that look like part numbers but are HTML/email boilerplate.
+MPN_FALSE_POSITIVES = {
+    "HTTP",
+    "HTTPS",
+    "HTML",
+    "HREF",
+    "FONT",
+    "SIZE",
+    "COLOR",
+    "TABLE",
+    "STYLE",
+    "CLASS",
+    "WIDTH",
+    "HEIGHT",
+    "ALIGN",
+    "BORDER",
+    "CELLPADDING",
+    "CELLSPACING",
+    "COLSPAN",
+    "ROWSPAN",
+    "VALIGN",
+    "BGCOLOR",
+    "IMAGE",
+    "ARIAL",
+    "VERDANA",
+    "HELVETICA",
+    "SERIF",
+    "SANS",
+    "SPAN",
+    "MAILTO",
+    "SUBJECT",
+    "FROM",
+    "BEST",
+    "REGARDS",
+    "THANK",
+    "THANKS",
+    "PLEASE",
+    "HELLO",
+    "DEAR",
+    "SINCERELY",
+    "KIND",
+    "OFFER",
+    "QUOTE",
+    "PRICE",
+    "STOCK",
+    "AVAILABLE",
+    "QUANTITY",
+}
+
 # Email signature extraction patterns
 PHONE_PATTERN = re.compile(
     r"(?:(?:phone|tel|cell|mobile|fax|ph|direct|office)[\s:.\-]*)?"
@@ -127,13 +176,13 @@ class EmailMiner:
 
     # ── H8: Delta Query helpers ──────────────────────────────────────
 
-    def _get_delta_token(self, folder: str) -> str | None:
-        """Retrieve stored delta token for incremental sync (H8)."""
+    def _get_sync_state(self, folder: str):
+        """Fetch the SyncState row for this user/folder, or None (H8)."""
         if not self.db or not self.user_id:
             return None
         from app.models import SyncState
 
-        sync = (
+        return (
             self.db.query(SyncState)
             .filter(
                 SyncState.user_id == self.user_id,
@@ -141,6 +190,10 @@ class EmailMiner:
             )
             .first()
         )
+
+    def _get_delta_token(self, folder: str) -> str | None:
+        """Retrieve stored delta token for incremental sync (H8)."""
+        sync = self._get_sync_state(folder)
         return sync.delta_token if sync else None
 
     def _save_delta_token(self, folder: str, token: str):
@@ -149,14 +202,7 @@ class EmailMiner:
             return
         from app.models import SyncState
 
-        sync = (
-            self.db.query(SyncState)
-            .filter(
-                SyncState.user_id == self.user_id,
-                SyncState.folder == folder,
-            )
-            .first()
-        )
+        sync = self._get_sync_state(folder)
         if sync:
             sync.delta_token = token
             sync.last_sync_at = datetime.now(timezone.utc)
@@ -173,18 +219,7 @@ class EmailMiner:
 
     def _clear_delta_token(self, folder: str):
         """Discard a stale delta token so the next scan does a full re-sync."""
-        if not self.db or not self.user_id:
-            return
-        from app.models import SyncState
-
-        sync = (
-            self.db.query(SyncState)
-            .filter(
-                SyncState.user_id == self.user_id,
-                SyncState.folder == folder,
-            )
-            .first()
-        )
+        sync = self._get_sync_state(folder)
         if sync:
             sync.delta_token = None
             self.db.flush()
@@ -296,13 +331,14 @@ class EmailMiner:
             c["message_count"] += 1
 
             received = msg.get("receivedDateTime")
+            received_dt = None
             if received:
                 try:
-                    dt = datetime.fromisoformat(received.replace("Z", "+00:00"))
-                    if not c["last_contact"] or dt > c["last_contact"]:
-                        c["last_contact"] = dt
+                    received_dt = datetime.fromisoformat(received.replace("Z", "+00:00"))
                 except Exception:
                     logger.debug("Failed to parse receivedDateTime", exc_info=True)
+            if received_dt and (not c["last_contact"] or received_dt > c["last_contact"]):
+                c["last_contact"] = received_dt
 
             # Check if this is an offer email (regex pre-filter)
             regex_matches = self._count_offer_matches(subject, body)
@@ -326,13 +362,6 @@ class EmailMiner:
                     from app.services.email_intelligence_service import (
                         process_email_intelligence,
                     )
-
-                    received_dt = None
-                    if received:
-                        try:
-                            received_dt = datetime.fromisoformat(received.replace("Z", "+00:00"))
-                        except Exception:
-                            logger.debug("Failed to parse receivedDateTime for classification", exc_info=True)
 
                     await process_email_intelligence(
                         self.db,
@@ -619,58 +648,9 @@ class EmailMiner:
         """Extract likely electronic component part numbers from text."""
         candidates = MPN_PATTERN.findall(text.upper())
 
-        false_positives = {
-            "HTTP",
-            "HTTPS",
-            "HTML",
-            "HREF",
-            "FONT",
-            "SIZE",
-            "COLOR",
-            "TABLE",
-            "STYLE",
-            "CLASS",
-            "WIDTH",
-            "HEIGHT",
-            "ALIGN",
-            "BORDER",
-            "CELLPADDING",
-            "CELLSPACING",
-            "COLSPAN",
-            "ROWSPAN",
-            "VALIGN",
-            "BGCOLOR",
-            "IMAGE",
-            "ARIAL",
-            "VERDANA",
-            "HELVETICA",
-            "SERIF",
-            "SANS",
-            "SPAN",
-            "MAILTO",
-            "SUBJECT",
-            "FROM",
-            "BEST",
-            "REGARDS",
-            "THANK",
-            "THANKS",
-            "PLEASE",
-            "HELLO",
-            "DEAR",
-            "SINCERELY",
-            "KIND",
-            "REGARDS",
-            "OFFER",
-            "QUOTE",
-            "PRICE",
-            "STOCK",
-            "AVAILABLE",
-            "QUANTITY",
-        }
-
         valid = set()
         for c in candidates:
-            if c in false_positives:
+            if c in MPN_FALSE_POSITIVES:
                 continue
             if len(c) < 4:
                 continue

--- a/app/connectors/oemsecrets.py
+++ b/app/connectors/oemsecrets.py
@@ -111,13 +111,8 @@ class OEMSecretsConnector(BaseConnector):
             prices_obj = item.get("prices")
             if isinstance(prices_obj, dict):
                 # Pick USD prices, fall back to first available currency
-                price_list = prices_obj.get("USD", [])
-                if not price_list:
-                    for _cur, plist in prices_obj.items():
-                        if plist:
-                            price_list = plist
-                            break
-                if price_list and isinstance(price_list, list) and len(price_list) > 0:
+                price_list = prices_obj.get("USD") or next((plist for plist in prices_obj.values() if plist), [])
+                if isinstance(price_list, list) and price_list:
                     # Use the lowest unit break price (first entry)
                     price = price_list[0].get("unit_price")
             if price is None:

--- a/app/connectors/sources.py
+++ b/app/connectors/sources.py
@@ -184,6 +184,17 @@ def _parse_retry_after(response: httpx.Response) -> float:
     return 5.0 + random.uniform(0, 2)
 
 
+def _round_price(price) -> float | None:
+    """Coerce a raw price to a float rounded to 4 dp, or None when not numeric."""
+    value = safe_float(price)
+    return round(value, 4) if value is not None else None
+
+
+def _octopart_search_url(pn: str) -> str:
+    """Octopart search-page URL for a part number (fallback when no direct URL)."""
+    return f"https://octopart.com/search?q={quote_plus(pn)}"
+
+
 class NexarConnector(BaseConnector):
     """Nexar/Octopart API — full seller data via GraphQL or REST v4."""
 
@@ -272,20 +283,9 @@ class NexarConnector(BaseConnector):
     async def _run_query(self, query: str, part_number: str) -> dict:
         from ..http_client import http
 
-        token = await self._get_token()
-        r = await http.post(
-            self.API_URL,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json",
-            },
-            json={"query": query, "variables": {"mpn": part_number}},
-            timeout=self.timeout,
-        )
-        if r.status_code == 401:
-            self._token = None
+        async def post() -> httpx.Response:
             token = await self._get_token()
-            r = await http.post(
+            return await http.post(
                 self.API_URL,
                 headers={
                     "Authorization": f"Bearer {token}",
@@ -294,6 +294,11 @@ class NexarConnector(BaseConnector):
                 json={"query": query, "variables": {"mpn": part_number}},
                 timeout=self.timeout,
             )
+
+        r = await post()
+        if r.status_code == 401:
+            self._token = None  # force a fresh token, then retry once
+            r = await post()
         r.raise_for_status()
         return r.json()
 
@@ -339,7 +344,7 @@ class NexarConnector(BaseConnector):
         """Parse Octopart REST v4 /parts/search response (v3-style JSON)."""
         results = []
         seen = set()
-        search_url = f"https://octopart.com/search?q={quote_plus(pn)}"
+        search_url = _octopart_search_url(pn)
 
         for hit in data.get("results", []):
             item = hit.get("item") or hit  # v4 nests under "item"
@@ -383,7 +388,7 @@ class NexarConnector(BaseConnector):
                             "manufacturer": mfr,
                             "mpn_matched": mpn,
                             "qty_available": safe_int(qty),
-                            "unit_price": round(safe_float(price), 4) if safe_float(price) is not None else None,
+                            "unit_price": _round_price(price),
                             "currency": currency,
                             "source_type": "octopart",
                             "is_authorized": auth,
@@ -442,7 +447,7 @@ class NexarConnector(BaseConnector):
     def _parse_full(self, results_data: list, pn: str) -> list[dict]:
         results = []
         seen = set()
-        octopart_url = f"https://octopart.com/search?q={quote_plus(pn)}"
+        octopart_url = _octopart_search_url(pn)
 
         for hit in results_data:
             part = hit.get("part") or {}
@@ -526,7 +531,7 @@ class NexarConnector(BaseConnector):
                             "manufacturer": mfr,
                             "mpn_matched": mpn,
                             "qty_available": safe_int(qty),
-                            "unit_price": round(safe_float(price), 4) if safe_float(price) is not None else None,
+                            "unit_price": _round_price(price),
                             "currency": currency,
                             "source_type": "octopart",
                             "is_authorized": auth,
@@ -545,14 +550,13 @@ class NexarConnector(BaseConnector):
     def _parse_aggregate(self, results_data: list, pn: str) -> list[dict]:
         """Parse Nexar aggregate results (totalAvail + medianPrice + direct URLs)."""
         results = []
-        search_url = f"https://octopart.com/search?q={quote_plus(pn)}"
+        search_url = _octopart_search_url(pn)
 
         for hit in results_data:
             part = hit.get("part") or {}
             mpn = part.get("mpn", pn)
             mfr = (part.get("manufacturer") or {}).get("name", "")
             total_avail = part.get("totalAvail")
-            _ = part.get("avgAvail")
             median_price = part.get("medianPrice1000") or {}
             price = median_price.get("price")
             currency = median_price.get("currency", "USD")
@@ -572,7 +576,7 @@ class NexarConnector(BaseConnector):
                     "manufacturer": mfr,
                     "mpn_matched": mpn,
                     "qty_available": safe_int(total_avail),
-                    "unit_price": round(safe_float(price), 4) if safe_float(price) is not None else None,
+                    "unit_price": _round_price(price),
                     "currency": currency,
                     "source_type": "octopart",
                     "is_authorized": True,


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/connectors`)
6 file(s) changed, 15 simplifications (7 file(s) already clean).

- **`ai_live_web.py`** — Replaced nested isinstance/if with `is True` in _has_current_stock_signal; Folded the condition normalization + allowlist check into one expression; Hoisted the per-iteration evidence-token regex to a module-level compiled constant.
- **`digikey.py`** — Removed dead `price = None` initializer in the price-break block; Replaced a nested ternary for click_url with an explicit if/elif/else.
- **`ebay.py`** — Removed copy-pasted request headers by introducing a local `headers(bearer)` builder.
- **`email_mining.py`** — Extracted shared _get_sync_state() helper for the three delta-token methods; Parse receivedDateTime once per message instead of twice; Hoisted the MPN false-positive set to a module-level constant; Dropped the duplicate "REGARDS" entry from the false-positive set.
- **`oemsecrets.py`** — Collapsed the USD-price fallback loop into a single `next(...)` generator and removed a redundant length check.
- **`sources.py`** — Collapsed the duplicated POST-request block in NexarConnector._run_query into a local post() closure; Added file-local _round_price() helper and applied it at all 3 price-formatting sites; Added file-local _octopart_search_url() helper and applied it at all 3 URL-construction sites; Removed dead `_ = part.get("avgAvail")` no-op lookup in _parse_aggregate.

_Recorded cross-file follow-ups:_
- `sources.py`: ALTITUDE: per-connector concurrency map _CONNECTOR_CONCURRENCY hardcodes sibling connector class names (DigiKeyConnector, MouserConnector, etc.
- `digikey.py`: REUSE (cross-file, not made): the OAuth client_credentials token cache (`_get_token` with `_token`/`_token_expires_at` + 60s safety margin) is duplicated verbatim in digikey.
- `digikey.py`: REUSE (cross-file, not made): the 'lowest-qty price break via min(.
- `ebay.py`: REUSE (cross-file, not made): same duplicated OAuth client_credentials token-cache as digikey.
- `mouser.py`: REUSE (cross-file, not made): shares the same lowest-qty price-break min() pattern noted under digikey.
- `sourcengine.py`: REUSE/ALTITUDE (cross-file): The auth/rate-limit error block in _do_search (lines 46-49: `if r.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)