### PR TITLE
simplify(jobs): de-duplicate scheduled-job helpers

### DIFF
--- a/app/jobs/core_jobs.py
+++ b/app/jobs/core_jobs.py
@@ -172,11 +172,7 @@ async def _job_inbox_scan():
         for user in users:
             if not user.access_token or not user.m365_connected:
                 continue
-            should_scan = False
-            if not user.last_inbox_scan:
-                should_scan = True
-            elif now - _utc(user.last_inbox_scan) > scan_interval:
-                should_scan = True
+            should_scan = not user.last_inbox_scan or now - _utc(user.last_inbox_scan) > scan_interval
             if should_scan:
                 # Detach user data we need so we can close this session
                 users_to_scan.append(user.id)

--- a/app/jobs/eight_by_eight_jobs.py
+++ b/app/jobs/eight_by_eight_jobs.py
@@ -97,13 +97,12 @@ async def _process_cdrs(db, settings) -> dict:
 
     # Load watermark
     watermark_row = db.query(SystemConfig).filter(SystemConfig.key == "8x8_last_poll").first()
+    since = datetime.now(timezone.utc) - timedelta(hours=24)
     if watermark_row:
         try:
             since = datetime.fromisoformat(watermark_row.value)
         except (ValueError, TypeError):
-            since = datetime.now(timezone.utc) - timedelta(hours=24)
-    else:
-        since = datetime.now(timezone.utc) - timedelta(hours=24)
+            pass
 
     until = datetime.now(timezone.utc)
 

--- a/app/jobs/email_jobs.py
+++ b/app/jobs/email_jobs.py
@@ -101,11 +101,7 @@ async def _job_contacts_sync():
         for user in users:
             if not user.access_token or not user.m365_connected:
                 continue
-            should_sync = False
-            if not user.last_contacts_sync:
-                should_sync = True
-            elif now - _utc(user.last_contacts_sync) > timedelta(hours=24):
-                should_sync = True
+            should_sync = not user.last_contacts_sync or now - _utc(user.last_contacts_sync) > timedelta(hours=24)
             if should_sync:
                 user_ids.append(user.id)
     except Exception as e:
@@ -843,14 +839,15 @@ async def scan_sent_folder(user, db):
     sync_state = db.query(SyncState).filter(SyncState.user_id == user.id, SyncState.folder == folder_key).first()
     delta_token = sync_state.delta_token if sync_state else None
 
+    delta_params = {
+        "$select": "id,subject,from,toRecipients,sentDateTime,hasAttachments,internetMessageHeaders",
+        "$top": "100",
+    }
     try:
         messages, new_token = await gc.delta_query(
             "/me/mailFolders/SentItems/messages/delta",
             delta_token=delta_token,
-            params={
-                "$select": "id,subject,from,toRecipients,sentDateTime,hasAttachments,internetMessageHeaders",
-                "$top": "100",
-            },
+            params=delta_params,
             max_items=500,
         )
     except GraphSyncStateExpired:
@@ -861,10 +858,7 @@ async def scan_sent_folder(user, db):
         messages, new_token = await gc.delta_query(
             "/me/mailFolders/SentItems/messages/delta",
             delta_token=None,
-            params={
-                "$select": "id,subject,from,toRecipients,sentDateTime,hasAttachments,internetMessageHeaders",
-                "$top": "100",
-            },
+            params=delta_params,
             max_items=500,
         )
 

--- a/app/jobs/inventory_jobs.py
+++ b/app/jobs/inventory_jobs.py
@@ -223,14 +223,15 @@ async def _download_and_import_stock_list(
     imported_for_matching: list[dict] = []
 
     # Pre-load existing MaterialCards in one query instead of per-row
-    valid_mpns = list(
-        {
-            normalize_mpn_key((row.get("mpn") or "").strip())
-            for row in rows
-            if (row.get("mpn") or "").strip() and len((row.get("mpn") or "").strip()) >= 3
-        }
-    )
-    valid_mpns = [k for k in valid_mpns if k]  # filter empty keys
+    valid_mpn_keys = set()
+    for row in rows:
+        raw_mpn = (row.get("mpn") or "").strip()
+        if len(raw_mpn) < 3:
+            continue
+        key = normalize_mpn_key(raw_mpn)
+        if key:
+            valid_mpn_keys.add(key)
+    valid_mpns = list(valid_mpn_keys)
     card_map = {}
     mvh_map = {}
     if valid_mpns:
@@ -284,20 +285,15 @@ async def _download_and_import_stock_list(
                 continue
 
         # Add/update vendor history (richer fields from Upgrade 2)
+        price = row.get("unit_price") or row.get("price")
         mvh = mvh_map.get(card.id)
         if mvh:
             mvh.last_seen = datetime.now(timezone.utc)
             mvh.times_seen = (mvh.times_seen or 0) + 1
             if row.get("qty"):
                 mvh.last_qty = row["qty"]
-            if row.get("unit_price"):
-                mvh.last_price = row["unit_price"]
-            elif row.get("price"):
-                mvh.last_price = row["price"]
-            price = row.get("unit_price") or row.get("price")
-            record_price_snapshot(
-                db=db, material_card_id=card.id, vendor_name=norm_vendor, price=price, source="email_auto_import"
-            )
+            if price:
+                mvh.last_price = price
             if row.get("manufacturer"):
                 mvh.last_manufacturer = row["manufacturer"]
         else:
@@ -307,17 +303,13 @@ async def _download_and_import_stock_list(
                 vendor_name_normalized=norm_vendor,
                 source_type="excess_list" if is_excess_list else "email_auto_import",
                 last_qty=row.get("qty"),
-                last_price=row.get("unit_price") or row.get("price"),
+                last_price=price,
                 last_manufacturer=row.get("manufacturer", ""),
             )
             db.add(mvh)
-            record_price_snapshot(
-                db=db,
-                material_card_id=card.id,
-                vendor_name=norm_vendor,
-                price=row.get("unit_price") or row.get("price"),
-                source="email_auto_import",
-            )
+        record_price_snapshot(
+            db=db, material_card_id=card.id, vendor_name=norm_vendor, price=price, source="email_auto_import"
+        )
 
         imported += 1
         imported_for_matching.append(

--- a/app/jobs/knowledge_jobs.py
+++ b/app/jobs/knowledge_jobs.py
@@ -15,6 +15,24 @@ from loguru import logger
 from ..scheduler import _traced_job
 
 
+async def _refresh_each(rows, generate, *, noun, warn_template):
+    """Generate insights for each id in ``rows`` (list of 1-tuples), tolerating per-id
+    failures, and log a ``successes/total`` summary.
+
+    ``generate`` is an async callable ``(id) -> entries``; a non-empty result counts as a
+    success. ``warn_template`` is a Loguru ``"... {} ... {}"`` format taking (id, error).
+    """
+    ok = 0
+    for (item_id,) in rows:
+        try:
+            entries = await generate(item_id)
+            if entries:
+                ok += 1
+        except Exception as e:
+            logger.warning(warn_template, item_id, e)
+    logger.info("Refreshed insights for {}/{} active {}", ok, len(rows), noun)
+
+
 def register_knowledge_jobs(scheduler, settings):
     """Register knowledge ledger background jobs."""
     # DISABLED (2026-03-26) — Knowledge insights not active in UI; heavy Anthropic
@@ -58,15 +76,12 @@ async def _job_refresh_insights():
                 .limit(50)
                 .all()
             )
-            req_ok = 0
-            for (req_id,) in active_reqs:
-                try:
-                    entries = await knowledge_service.generate_insights(db, req_id)
-                    if entries:
-                        req_ok += 1
-                except Exception as e:
-                    logger.warning("Insight generation failed for req {}: {}", req_id, e)
-            logger.info("Refreshed insights for {}/{} active reqs", req_ok, len(active_reqs))
+            await _refresh_each(
+                active_reqs,
+                lambda req_id: knowledge_service.generate_insights(db, req_id),
+                noun="reqs",
+                warn_template="Insight generation failed for req {}: {}",
+            )
         except Exception as e:
             logger.error("Requisition insight refresh failed: {}", e)
 
@@ -87,15 +102,12 @@ async def _job_refresh_insights():
                 .limit(20)
                 .all()
             )
-            vendor_ok = 0
-            for (vid,) in top_vendors:
-                try:
-                    entries = await knowledge_service.generate_vendor_insights(db, vid)
-                    if entries:
-                        vendor_ok += 1
-                except Exception as e:
-                    logger.warning("Vendor insight failed for vendor_card {}: {}", vid, e)
-            logger.info("Refreshed insights for {}/{} active vendors", vendor_ok, len(top_vendors))
+            await _refresh_each(
+                top_vendors,
+                lambda vid: knowledge_service.generate_vendor_insights(db, vid),
+                noun="vendors",
+                warn_template="Vendor insight failed for vendor_card {}: {}",
+            )
         except Exception as e:
             logger.error("Vendor insight refresh failed: {}", e)
 
@@ -110,15 +122,12 @@ async def _job_refresh_insights():
                 .limit(20)
                 .all()
             )
-            company_ok = 0
-            for (cid,) in top_companies:
-                try:
-                    entries = await knowledge_service.generate_company_insights(db, cid)
-                    if entries:
-                        company_ok += 1
-                except Exception as e:
-                    logger.warning("Company insight failed for company {}: {}", cid, e)
-            logger.info("Refreshed insights for {}/{} active companies", company_ok, len(top_companies))
+            await _refresh_each(
+                top_companies,
+                lambda cid: knowledge_service.generate_company_insights(db, cid),
+                noun="companies",
+                warn_template="Company insight failed for company {}: {}",
+            )
         except Exception as e:
             logger.error("Company insight refresh failed: {}", e)
 
@@ -132,15 +141,12 @@ async def _job_refresh_insights():
                 .limit(50)
                 .all()
             )
-            mpn_ok = 0
-            for (mpn,) in top_mpns:
-                try:
-                    entries = await knowledge_service.generate_mpn_insights(db, mpn)
-                    if entries:
-                        mpn_ok += 1
-                except Exception as e:
-                    logger.warning("MPN insight failed for {}: {}", mpn, e)
-            logger.info("Refreshed insights for {}/{} active MPNs", mpn_ok, len(top_mpns))
+            await _refresh_each(
+                top_mpns,
+                lambda mpn: knowledge_service.generate_mpn_insights(db, mpn),
+                noun="MPNs",
+                warn_template="MPN insight failed for {}: {}",
+            )
         except Exception as e:
             logger.error("MPN insight refresh failed: {}", e)
 

--- a/app/jobs/maintenance_jobs.py
+++ b/app/jobs/maintenance_jobs.py
@@ -11,6 +11,9 @@ from loguru import logger
 
 from ..scheduler import _traced_job
 
+# Optional contact fields used to pick the most-complete duplicate and back-fill it
+_CONTACT_MERGE_FIELDS = ["full_name", "title", "phone", "notes", "linkedin_url"]
+
 
 def register_maintenance_jobs(scheduler, settings):
     """Register maintenance jobs with the scheduler."""
@@ -146,7 +149,6 @@ async def _job_contact_dedup():
             db.query(
                 SiteContact.customer_site_id,
                 func.lower(SiteContact.email).label("em"),
-                func.count().label("cnt"),
             )
             .filter(SiteContact.email.isnot(None))
             .group_by(SiteContact.customer_site_id, func.lower(SiteContact.email))
@@ -166,14 +168,12 @@ async def _job_contact_dedup():
             )
             best = max(
                 contacts,
-                key=lambda c: sum(
-                    1 for col in ["full_name", "title", "phone", "notes", "linkedin_url"] if getattr(c, col, None)
-                ),
+                key=lambda c: sum(1 for col in _CONTACT_MERGE_FIELDS if getattr(c, col, None)),
             )
             for other in contacts:
                 if other.id == best.id:
                     continue
-                for col in ["full_name", "title", "phone", "notes", "linkedin_url"]:
+                for col in _CONTACT_MERGE_FIELDS:
                     if getattr(best, col, None) is None and getattr(other, col, None) is not None:
                         setattr(best, col, getattr(other, col))
                 db.delete(other)

--- a/app/jobs/offers_jobs.py
+++ b/app/jobs/offers_jobs.py
@@ -115,24 +115,19 @@ async def _job_performance_tracking():
         from ..services.vendor_scorecard import compute_all_vendor_scorecards
 
         loop = asyncio.get_running_loop()
+
+        async def _run(fn, *args, timeout):
+            return await asyncio.wait_for(loop.run_in_executor(None, fn, db, *args), timeout=timeout)
+
         # Vendor scorecards
-        vs_result = await asyncio.wait_for(
-            loop.run_in_executor(None, compute_all_vendor_scorecards, db),
-            timeout=600,
-        )
+        vs_result = await _run(compute_all_vendor_scorecards, timeout=600)
         logger.info(f"Vendor scorecards: {vs_result['updated']} updated, {vs_result['skipped_cold_start']} cold-start")
         current_month = now.date().replace(day=1)
         # Buyer leaderboard
-        bl_result = await asyncio.wait_for(
-            loop.run_in_executor(None, compute_buyer_leaderboard, db, current_month),
-            timeout=300,
-        )
+        bl_result = await _run(compute_buyer_leaderboard, current_month, timeout=300)
         logger.info(f"Buyer leaderboard: {bl_result['entries']} entries for {current_month}")
         # Avail Scores
-        as_result = await asyncio.wait_for(
-            loop.run_in_executor(None, compute_all_avail_scores, db, current_month),
-            timeout=300,
-        )
+        as_result = await _run(compute_all_avail_scores, current_month, timeout=300)
         logger.info(
             f"Avail Scores: {as_result['buyers']} buyers, "
             f"{as_result['sales']} sales, {as_result['saved']} saved for {current_month}"
@@ -140,10 +135,7 @@ async def _job_performance_tracking():
         # Multiplier Scores
         from ..services.multiplier_score_service import compute_all_multiplier_scores
 
-        ms_result = await asyncio.wait_for(
-            loop.run_in_executor(None, compute_all_multiplier_scores, db, current_month),
-            timeout=300,
-        )
+        ms_result = await _run(compute_all_multiplier_scores, current_month, timeout=300)
         logger.info(
             f"Multiplier Scores: {ms_result['buyers']} buyers, "
             f"{ms_result['sales']} sales, {ms_result['saved']} saved for {current_month}"
@@ -151,30 +143,15 @@ async def _job_performance_tracking():
         # Unified Scores (cross-role leaderboard)
         from ..services.unified_score_service import compute_all_unified_scores
 
-        us_result = await asyncio.wait_for(
-            loop.run_in_executor(None, compute_all_unified_scores, db, current_month),
-            timeout=300,
-        )
+        us_result = await _run(compute_all_unified_scores, current_month, timeout=300)
         logger.info(f"Unified Scores: {us_result['computed']} computed, {us_result['saved']} saved for {current_month}")
         # Recompute previous month during grace period (first 7 days)
         if now.day <= 7:
             prev_month = (current_month - timedelta(days=1)).replace(day=1)
-            await asyncio.wait_for(
-                loop.run_in_executor(None, compute_buyer_leaderboard, db, prev_month),
-                timeout=300,
-            )
-            await asyncio.wait_for(
-                loop.run_in_executor(None, compute_all_avail_scores, db, prev_month),
-                timeout=300,
-            )
-            await asyncio.wait_for(
-                loop.run_in_executor(None, compute_all_multiplier_scores, db, prev_month),
-                timeout=300,
-            )
-            await asyncio.wait_for(
-                loop.run_in_executor(None, compute_all_unified_scores, db, prev_month),
-                timeout=300,
-            )
+            await _run(compute_buyer_leaderboard, prev_month, timeout=300)
+            await _run(compute_all_avail_scores, prev_month, timeout=300)
+            await _run(compute_all_multiplier_scores, prev_month, timeout=300)
+            await _run(compute_all_unified_scores, prev_month, timeout=300)
     except asyncio.TimeoutError:
         logger.error("Performance tracking timed out")
         db.rollback()

--- a/app/jobs/tagging_jobs.py
+++ b/app/jobs/tagging_jobs.py
@@ -6,10 +6,31 @@ Depends on: app.database, app.models, app.services.enrichment, app.services.tagg
             app.services.tagging_ai, app.services.spec_enrichment_service, app.utils.claude_client
 """
 
+import asyncio
+
 from apscheduler.triggers.interval import IntervalTrigger
 from loguru import logger
 
 from ..scheduler import _traced_job
+
+
+async def _run_threaded_db_job(label, fn):
+    """Run a synchronous ``fn(db)`` off the event loop with a fresh session.
+
+    Shared body of the prefix/sighting/boost jobs: open a session, call ``fn`` via
+    ``asyncio.to_thread``, log the result, and roll back + re-raise on failure.
+    """
+    from ..database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        result = await asyncio.to_thread(fn, db)
+        logger.info(f"{label}: {result}")
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
 
 
 def register_tagging_jobs(scheduler, settings):
@@ -64,20 +85,9 @@ async def _job_internal_boost():
 
     Every 4h.
     """
-    import asyncio
-
-    from ..database import SessionLocal
     from ..services.enrichment import boost_confidence_internal
 
-    db = SessionLocal()
-    try:
-        result = await asyncio.to_thread(boost_confidence_internal, db)
-        logger.info(f"Internal confidence boost: {result}")
-    except Exception:
-        db.rollback()
-        raise
-    finally:
-        db.close()
+    await _run_threaded_db_job("Internal confidence boost", boost_confidence_internal)
 
 
 @_traced_job
@@ -86,20 +96,9 @@ async def _job_prefix_backfill():
 
     Every 2h.
     """
-    import asyncio
-
-    from ..database import SessionLocal
     from ..services.tagging_backfill import run_prefix_backfill
 
-    db = SessionLocal()
-    try:
-        result = await asyncio.to_thread(run_prefix_backfill, db)
-        logger.info(f"Prefix backfill: {result}")
-    except Exception:
-        db.rollback()
-        raise
-    finally:
-        db.close()
+    await _run_threaded_db_job("Prefix backfill", run_prefix_backfill)
 
 
 @_traced_job
@@ -108,20 +107,9 @@ async def _job_sighting_mining():
 
     Every 2h.
     """
-    import asyncio
-
-    from ..database import SessionLocal
     from ..services.tagging_backfill import backfill_manufacturer_from_sightings
 
-    db = SessionLocal()
-    try:
-        result = await asyncio.to_thread(backfill_manufacturer_from_sightings, db)
-        logger.info(f"Sighting mining: {result}")
-    except Exception:
-        db.rollback()
-        raise
-    finally:
-        db.close()
+    await _run_threaded_db_job("Sighting mining", backfill_manufacturer_from_sightings)
 
 
 @_traced_job
@@ -130,8 +118,6 @@ async def _job_ai_tagging():
 
     Waterfall: prefix_backfill + sighting_mining first (instant), then Claude Haiku for remainder.
     """
-    import asyncio
-
     from ..database import SessionLocal
     from ..models.intelligence import MaterialCard
     from ..models.tags import MaterialTag, Tag


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/jobs`)
8 file(s) changed, 12 simplifications (6 file(s) already clean).

- **`core_jobs.py`** — Flattened the should_scan if/elif (both branches set True) in _job_inbox_scan into one boolean expression.
- **`eight_by_eight_jobs.py`** — Removed duplicated 24h-fallback watermark default in _process_cdrs.
- **`email_jobs.py`** — Collapsed redundant should_sync boolean state in _job_contacts_sync; Deduplicated the copy-paste-with-variation delta_query params in scan_sent_folder.
- **`inventory_jobs.py`** — Deduplicate the MVH update/create branches in _download_and_import_stock_list; Collapse the valid_mpns set comprehension + second-pass filter into one explicit loop.
- **`knowledge_jobs.py`** — Collapsed four copy-pasted per-category insight loops into one _refresh_each helper.
- **`maintenance_jobs.py`** — Hoisted the duplicated contact-field list into a module constant _CONTACT_MERGE_FIELDS; Removed the dead func.count().label("cnt") column from the duplicates-detection query.
- **`offers_jobs.py`** — Extract a local _run() helper for the 9 repeated wait_for(run_in_executor(...)) calls in _job_performance_tracking.
- **`tagging_jobs.py`** — Extracted the copy-paste-with-variation body of the three threaded jobs into a private _run_threaded_db_job(label, fn) helper; Hoisted the redundant per-function `import asyncio` to module level.

_Recorded cross-file follow-ups:_
- `email_jobs.py`: REUSE/cross-file: the `db.
- `email_jobs.py`: REUSE/no-helper: the `await asyncio.
- `inventory_jobs.py`: No shared session-scope/context-manager helper exists in app/utils or app/database; the `db = SessionLocal()` + try/finally `db.
- `teams_call_jobs.py`: The inline SystemConfig watermark read/write re-implements a get/set-config pattern, but the existing app/services/admin_service.
- `health_jobs.py`: REUSE: The db=SessionLocal() + try/except/finally + db.
- `quality_jobs.py`: REUSE: same as health_jobs.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)