### PR TITLE
simplify(management): de-duplicate management-command helpers

### DIFF
--- a/app/management/backfill_dual_brand.py
+++ b/app/management/backfill_dual_brand.py
@@ -98,12 +98,17 @@ def _ladder_set(
     apply: bool,
     overlay: _Overlay,
 ) -> bool:
-    """Apply (or, dry-run, simulate) one ladder-gated brand/manufacturer write."""
+    """Apply (or, dry-run, simulate) one ladder-gated brand/manufacturer write.
+
+    In apply mode the setter flushes inside a per-card SAVEPOINT, so a DB-level failure
+    rolls back only this card (the exception propagates to the pass's per-card tally).
+    """
     if value is None or not str(value).strip():
         return False
     setter = set_brand if attr == "brand" else set_manufacturer
     if apply:
-        return setter(card, value, source, confidence)
+        with db.begin_nested():
+            return setter(card, value, source, confidence)
 
     key = (card.id, attr)
     incoming = {
@@ -146,15 +151,9 @@ def _pass_b1(db: Session, *, apply: bool, overlay: _Overlay) -> dict:
     for card in cards:
         tally["scanned"] += 1
         try:
-            if apply:
-                with db.begin_nested():
-                    won = _ladder_set(
-                        db, card, "brand", card.manufacturer, "legacy_backfill", 0.5, apply=True, overlay=overlay
-                    )
-            else:
-                won = _ladder_set(
-                    db, card, "brand", card.manufacturer, "legacy_backfill", 0.5, apply=False, overlay=overlay
-                )
+            won = _ladder_set(
+                db, card, "brand", card.manufacturer, "legacy_backfill", 0.5, apply=apply, overlay=overlay
+            )
         except Exception:
             tally["failed"] += 1
             logger.exception("backfill_dual_brand B1: failed on card id={} — skipping", card.id)
@@ -192,15 +191,9 @@ def _pass_b2(db: Session, *, apply: bool, overlay: _Overlay) -> dict:
     for link, card in rows:
         tally["links_scanned"] += 1
         try:
-            if apply:
-                with db.begin_nested():
-                    won = _ladder_set(
-                        db, card, "manufacturer", link.manufacturer, "trio_source", 0.9, apply=True, overlay=overlay
-                    )
-            else:
-                won = _ladder_set(
-                    db, card, "manufacturer", link.manufacturer, "trio_source", 0.9, apply=False, overlay=overlay
-                )
+            won = _ladder_set(
+                db, card, "manufacturer", link.manufacturer, "trio_source", 0.9, apply=apply, overlay=overlay
+            )
         except Exception:
             tally["failed"] += 1
             logger.exception("backfill_dual_brand B2: failed on card id={} (fru_link id={})", card.id, link.id)
@@ -258,11 +251,7 @@ def _pass_b3(db: Session, *, apply: bool, overlay: _Overlay) -> dict:
             tally["missing_cards"] += 1
             continue
         try:
-            if apply:
-                with db.begin_nested():
-                    won = _ladder_set(db, card, attr, token, "desc_parse", 0.85, apply=True, overlay=overlay)
-            else:
-                won = _ladder_set(db, card, attr, token, "desc_parse", 0.85, apply=False, overlay=overlay)
+            won = _ladder_set(db, card, attr, token, "desc_parse", 0.85, apply=apply, overlay=overlay)
         except Exception:
             tally["failed"] += 1
             logger.exception("backfill_dual_brand B3: failed on card id={} — skipping", card_id)

--- a/app/management/categorize_from_desc.py
+++ b/app/management/categorize_from_desc.py
@@ -23,7 +23,6 @@ Depends on: desc_extractor.writer.categorize_and_record, desc_extractor.categori
 """
 
 import argparse
-import re
 from collections import Counter
 
 from loguru import logger
@@ -37,6 +36,7 @@ from app.services.desc_extractor._common import DESC_CONFIDENCE, DESC_SOURCE
 from app.services.desc_extractor.categorizer import categorize_from_desc
 from app.services.desc_extractor.writer import categorize_and_record
 from app.services.spec_tiers import SOURCE_TIER
+from app.utils.normalization import normalize_mpn_key
 
 # FRU-linked descriptions are a ONE-HOP prose (the FRU's row, not the card's own
 # description), so they write at fru_desc_parse / tier 82 — strictly below the own-desc
@@ -49,16 +49,10 @@ FRU_DESC_CONFIDENCE = DESC_CONFIDENCE
 # description IS just the MPN carry zero extractable signal and are excluded.
 MIN_REAL_DESC_LEN = 15
 
-_NON_ALNUM = re.compile(r"[^a-z0-9]+")
-
-
-def _alnum_norm(text: str | None) -> str:
-    """Lower-cased, alphanumeric-only form — for the desc-vs-MPN comparison + length
-    gate (so "00AR327" == "00AR327 " == "00-AR-327" and a description that is just the
-    MPN with punctuation/spacing noise is recognized as NOT a real description)."""
-    if not text:
-        return ""
-    return _NON_ALNUM.sub("", text.lower())
+# Lower-cased, alphanumeric-only form — the shared dedup-key normalizer (so "00AR327" ==
+# "00AR327 " == "00-AR-327" and a description that is just the MPN with punctuation/
+# spacing noise is recognized as NOT a real description).
+_alnum_norm = normalize_mpn_key
 
 
 def _has_real_own_desc(card: MaterialCard) -> bool:

--- a/app/management/cleanup_known_bad.py
+++ b/app/management/cleanup_known_bad.py
@@ -124,6 +124,16 @@ def cleanup_junk_categories(db: Session, *, apply: bool = False) -> dict:
         .order_by(MaterialCard.id)
         .all()
     )
+
+    def _null_category(card: MaterialCard) -> None:
+        """Clear the category cell and all four provenance columns (junk that resolves
+        nowhere — the value the vocabulary rejects, and any attestation of it)."""
+        card.category = None
+        card.category_source = None
+        card.category_confidence = None
+        card.category_tier = None
+        card.category_updated_at = None
+
     for card in cards:
         raw = card.category
         source_before = card.category_source
@@ -139,11 +149,7 @@ def cleanup_junk_categories(db: Session, *, apply: bool = False) -> dict:
             else:
                 mode = "nulled"
                 if apply:
-                    card.category = None
-                    card.category_source = None
-                    card.category_confidence = None
-                    card.category_tier = None
-                    card.category_updated_at = None
+                    _null_category(card)
         else:
             if target is not None:
                 # Provenanced but non-canonical (e.g. a pre-alias-map vendor string):
@@ -170,11 +176,7 @@ def cleanup_junk_categories(db: Session, *, apply: bool = False) -> dict:
                 # write of a value the vocabulary rejects — clear both.
                 mode = "nulled"
                 if apply:
-                    card.category = None
-                    card.category_source = None
-                    card.category_confidence = None
-                    card.category_tier = None
-                    card.category_updated_at = None
+                    _null_category(card)
         tally[mode] += 1
         transitions[f"{raw!r} -> {target if mode.startswith('normalized') else None}"] += 1
         if apply and mode != "skipped_ladder":

--- a/app/management/enrichment_coverage_report.py
+++ b/app/management/enrichment_coverage_report.py
@@ -350,6 +350,12 @@ def _join(pairs: list[tuple[str, str]]) -> str:
     return " · ".join(f"{k if k.strip() else repr(k)} {v}" for k, v in pairs) if pairs else "(none)"
 
 
+def _join_counts(counts: dict[str, int]) -> str:
+    """``_join`` for the common label→count mapping (spec/category/facet sources,
+    status)."""
+    return _join([(k, str(v)) for k, v in counts.items()])
+
+
 def format_report(metrics: dict[str, Any], deltas: dict[str, int] | None = None, prev_ts: str | None = None) -> str:
     """One compact human-readable block."""
     cards, facets = metrics["cards"], metrics["facets"]
@@ -367,11 +373,10 @@ def format_report(metrics: dict[str, Any], deltas: dict[str, int] | None = None,
         ),
         "  By commodity: "
         + _join([(c["commodity"], f"{c['rows']} rows/{c['spec_keys']} keys") for c in facets["by_commodity"]]),
-        f"Spec sources ({metrics['spec_entries_total']} entries): "
-        + _join([(k, str(v)) for k, v in metrics["spec_sources"].items()]),
-        "Category sources: " + _join([(k, str(v)) for k, v in metrics["category_sources"].items()]),
-        "Facet sources: " + _join([(k, str(v)) for k, v in metrics["facet_sources"].items()]),
-        "Status: " + _join([(k, str(v)) for k, v in metrics["enrichment_status"].items()]),
+        f"Spec sources ({metrics['spec_entries_total']} entries): " + _join_counts(metrics["spec_sources"]),
+        "Category sources: " + _join_counts(metrics["category_sources"]),
+        "Facet sources: " + _join_counts(metrics["facet_sources"]),
+        "Status: " + _join_counts(metrics["enrichment_status"]),
     ]
     if metrics["unregistered_sources"]:
         lines.append(

--- a/app/management/import_demand_telemetry.py
+++ b/app/management/import_demand_telemetry.py
@@ -81,6 +81,16 @@ def _parse_ts(raw: str | None) -> datetime | None:
     return None
 
 
+def _max_present(a, b):
+    """Column-wise max that treats None as "no value": the other operand wins, or the
+    larger of the two when both are present."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return max(a, b)
+
+
 def read_telemetry(csv_path: str | Path) -> tuple[dict[str, tuple[int | None, datetime | None]], dict]:
     """Stream the export and aggregate (qty, ts) per normalized MPN key.
 
@@ -115,8 +125,8 @@ def read_telemetry(csv_path: str | Path) -> tuple[dict[str, tuple[int | None, da
             prev = telemetry.get(key)
             if prev is not None:
                 prev_qty, prev_ts = prev
-                qty = prev_qty if qty is None else (qty if prev_qty is None else max(qty, prev_qty))
-                ts = prev_ts if ts is None else (ts if prev_ts is None else max(ts, prev_ts))
+                qty = _max_present(qty, prev_qty)
+                ts = _max_present(ts, prev_ts)
             telemetry[key] = (qty, ts)
     return telemetry, stats
 

--- a/app/management/ingest_fru_matrix.py
+++ b/app/management/ingest_fru_matrix.py
@@ -45,7 +45,7 @@ Depends on: openpyxl, app.models.FruLink, app.constants.FruLinkKind/CDC_PENDING,
 import argparse
 import re
 from collections import Counter
-from dataclasses import dataclass, field, fields, replace
+from dataclasses import asdict, dataclass, field, fields, replace
 from datetime import date, datetime
 from functools import lru_cache
 from typing import Callable, Iterable
@@ -811,23 +811,9 @@ def upsert_links(db, links: Iterable[ParsedLink], chunk_size: int = 1000) -> tup
         for link in chunk:
             row = existing.get(link.key)
             if row is None:
-                to_insert.append(
-                    {
-                        "fru_raw": link.fru_raw,
-                        "fru_norm": link.fru_norm,
-                        "related_raw": link.related_raw,
-                        "related_norm": link.related_norm,
-                        "rel_kind": FruLinkKind(link.rel_kind).value,  # Core insert skips @validates
-                        "source_sheet": link.source_sheet,
-                        "manufacturer": link.manufacturer,
-                        "description": link.description,
-                        "series": link.series,
-                        "machine": link.machine,
-                        "qual_status": link.qual_status,
-                        "qual_date": link.qual_date,
-                        "note": link.note,
-                    }
-                )
+                values = asdict(link)  # ParsedLink fields == FruLink insertable columns
+                values["rel_kind"] = FruLinkKind(link.rel_kind).value  # Core insert skips @validates
+                to_insert.append(values)
             else:
                 changed = False
                 for attr in _UPDATABLE:

--- a/app/management/ingest_source_data.py
+++ b/app/management/ingest_source_data.py
@@ -53,11 +53,12 @@ def _discover_files(pattern: str) -> tuple[list[Path], Path | None]:
         p = Path(raw)
         if not p.is_file():
             continue
-        if _is_manufacturers_lookup(p) and p.suffix.lower() == ".csv":
+        suffix = p.suffix.lower()
+        if _is_manufacturers_lookup(p) and suffix == ".csv":
             manufacturers = p
-        elif _is_sfdc_master(p) and p.suffix.lower() == ".csv":
+        elif _is_sfdc_master(p) and suffix == ".csv":
             paths.append(p)
-        elif p.suffix.lower() in _SHEET_SUFFIXES and not p.name.lower().endswith(".md"):
+        elif suffix in _SHEET_SUFFIXES and not p.name.lower().endswith(".md"):
             paths.append(p)
     return paths, manufacturers
 

--- a/app/management/reconcile_decoded_facets.py
+++ b/app/management/reconcile_decoded_facets.py
@@ -174,13 +174,10 @@ def _gate_fru_facet(
     gaps stay visible in the persisted run report instead of silently passing.
     """
     if facet.spec_key == "capacity_gb" and category == "hdd":
-        value = facet.value_numeric
-        on_grid = False
-        if value is not None:
-            try:
-                on_grid = float(value) in HDD_SHIPPED_CAPACITY_GB
-            except (TypeError, ValueError):
-                on_grid = False
+        try:
+            on_grid = float(facet.value_numeric) in HDD_SHIPPED_CAPACITY_GB
+        except (TypeError, ValueError):
+            on_grid = False
         if on_grid:
             return "fru_capacity_grid", "unchanged"
         return "fru_capacity_grid", _delete_facet_row(db, card, facet, apply=apply)

--- a/app/management/run_fru_crosswalk.py
+++ b/app/management/run_fru_crosswalk.py
@@ -110,20 +110,22 @@ def select_drain_card_ids(db: Session, *, limit: int = 0) -> list[int]:
     )
     if not fru_norms:
         return []
+    # SQL filters to active, non-internal, unfaceted-OR-uncategorized cards; the fru_norm
+    # membership test stays in Python (fru_norm is a normalize_mpn_key output, not
+    # reproducible in SQL). Stream like _existing_card_keys — this can be a full-table scan.
     has_facet = select(MaterialSpecFacet.id).where(MaterialSpecFacet.material_card_id == MaterialCard.id).exists()
     has_category = func.coalesce(func.trim(MaterialCard.category), "") != ""
-    rows = db.execute(
-        select(MaterialCard.id, MaterialCard.normalized_mpn, ~has_facet, ~has_category).where(
-            MaterialCard.deleted_at.is_(None),
-            MaterialCard.is_internal_part.is_(False),
-        )
-    ).all()
-    card_ids: list[int] = []
-    for card_id, normalized_mpn, unfaceted, uncategorized in rows:
-        if not (unfaceted or uncategorized):
-            continue
-        if normalize_mpn_key(normalized_mpn) in fru_norms:
-            card_ids.append(int(card_id))
+    card_ids = [
+        int(card_id)
+        for card_id, normalized_mpn in db.execute(
+            select(MaterialCard.id, MaterialCard.normalized_mpn).where(
+                MaterialCard.deleted_at.is_(None),
+                MaterialCard.is_internal_part.is_(False),
+                ~has_facet | ~has_category,
+            )
+        ).yield_per(5000)
+        if normalize_mpn_key(normalized_mpn) in fru_norms
+    ]
     card_ids.sort()
     return card_ids[:limit] if limit else card_ids
 


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/management`)
9 file(s) changed, 10 simplifications (5 file(s) already clean).

- **`backfill_dual_brand.py`** — Folded the apply-mode SAVEPOINT wrapper into _ladder_set, collapsing 3 duplicated apply/dry-run call-site blocks.
- **`categorize_from_desc.py`** — Replaced the private _NON_ALNUM regex + _alnum_norm body with a delegate to the shared normalize_mpn_key.
- **`cleanup_known_bad.py`** — Extracted the duplicated 5-line category null-out into a local _null_category helper.
- **`enrichment_coverage_report.py`** — Collapsed four identical label->count join calls in format_report into a new _join_counts(dict) helper.
- **`import_demand_telemetry.py`** — Replaced two nested-ternary 'column-wise max of optionals' lines with a shared private helper _max_present(a, b).
- **`ingest_fru_matrix.py`** — Replace the 16-line hand-listed to_insert dict with dataclasses.asdict(link).
- **`ingest_source_data.py`** — Hoisted the repeated p.suffix.lower() computation to a single `suffix` local in _discover_files.
- **`reconcile_decoded_facets.py`** — Removed redundant on_grid state in _gate_fru_facet (redundant init + duplicate False assignment + subsumed None guard).
- **`run_fru_crosswalk.py`** — select_drain_card_ids now filters unfaceted-OR-uncategorized in SQL and streams the scan with yield_per(5000) instead of materializing all rows with .all(); Removed the dead per-row `if not (unfaceted or uncategorized): continue` and the unused selected flag columns now that SQL does that filtering.

_Recorded cross-file follow-ups:_
- `ingest_fru_matrix.py`: No cross-file reuse opportunity found: searched app/utils, app/services, app/cache and adjacent app/management for a shared chunking/batched helper or an asdict-to-insert helper — none exists; normalize_mpn_key (the one shared helper this file needs) is already imported and used.
- `backfill_oem_crosswalk.py`: CROSS-FILE ALTITUDE: the date-keyed counter-key construction (`enrichment_worker:web_calls:{today_str}` and `enrichment_worker:oem_resolves:{today_str}` built from datetime.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)