### PR TITLE
feat(enrichment): PartSurfer description-enrichment for uncategorized HP/HPE spares

### DIFF
--- a/alembic/versions/096_spec_provenance.py
+++ b/alembic/versions/096_spec_provenance.py
@@ -64,6 +64,7 @@ _SOURCE_TIER_SQL_CASE = (
     "WHEN 'trio_source_ai' THEN 88 "
     "WHEN 'mpn_decode' THEN 85 "
     "WHEN 'fru_matrix_decode' THEN 84 "
+    "WHEN 'partsurfer_desc' THEN 84 "
     "WHEN 'desc_parse' THEN 83 "
     "WHEN 'fru_desc_parse' THEN 82 "
     "WHEN 'partsurfer' THEN 80 "

--- a/app/config.py
+++ b/app/config.py
@@ -130,6 +130,15 @@ class Settings(BaseSettings):
     # zero-LLM. Runs between mpn-decode (0.95) and the AI spec reader (0.85). Safe to leave
     # on — values are enum-validated by record_spec. See app/services/desc_extractor.
     desc_parse_enabled: bool = True
+    # PartSurfer description enrichment: for UNCATEGORIZED HP/HPE cards, fetch the OEM's own
+    # verbatim description live from partsurfer.hpe.com (robots-allowed, 1 GET / 2s) and feed
+    # it into the desc grammar to categorize the card. Default ON — it's the win for the ~70k
+    # uncategorized HP spares; cheap, free, robots-allowed. Values arbitrate through the F1
+    # ladder at partsurfer_desc (tier 84). See app/services/enrichment_worker/partsurfer_resolver.
+    partsurfer_desc_enabled: bool = True
+    # Cap on live PartSurfer fetches per batch (each is a polite 1-req/2s GET — the worker
+    # paces them). Keeps a batch's wall-time bounded; uncategorized HP cards drain over batches.
+    partsurfer_fetch_per_batch: int = 5
     # Deterministic FRU crosswalk decode (IBM/Lenovo FRU → approved mfg models): zero-network,
     # zero-LLM — strict-intersects the regex-gated decodes of a FRU's mfg_model links. Runs
     # between mpn-decode (0.95) and desc-parse (0.90) at 0.93. Safe to leave on — values are

--- a/app/services/desc_extractor/_common.py
+++ b/app/services/desc_extractor/_common.py
@@ -63,6 +63,12 @@ DESC_CONFIDENCE = 0.90  # deterministic token grammar. Arbitration is by the F1 
 # spec reader 60) — record_spec rejects any write that loses the ladder, so this
 # confidence is provenance metadata, not the cross-source conflict rule.
 
+# OEM-authoritative description: the same desc grammar run over HP/HPE's OWN verbatim
+# PartSurfer catalog text (fetched live), not the card's own desc. Outranks desc_parse
+# (spec_tiers.SOURCE_TIER: partsurfer_desc=84 > desc_parse 83).
+PARTSURFER_DESC_SOURCE = "partsurfer_desc"
+PARTSURFER_DESC_CONFIDENCE = 0.90
+
 # The only commodities the extractor fills specs for — single source of truth shared
 # by extract_desc (routing) and writer.py (card eligibility / the spec'd _HANDLED
 # set). The PSU-vs-CPU wattage guard is structural: only extract_psu can emit the

--- a/app/services/enrichment_worker/partsurfer_resolver.py
+++ b/app/services/enrichment_worker/partsurfer_resolver.py
@@ -1,0 +1,81 @@
+"""Polite direct-HTTP PartSurfer description fetcher (HP/HPE spare → verbatim desc).
+
+What: ``fetch_partsurfer_description`` does ONE GET against partsurfer.hpe.com's
+      server-rendered Search.aspx for an HP/HPE spare/option PN and returns the OEM's own
+      verbatim part DESCRIPTION (the ``ctl00_BodyContentPlaceHolder_lblDescription`` span),
+      html-unescaped and stripped — e.g. "726719-B21" → "HPE 16GB (1X16GB) DUAL RANK X4
+      DDR4-2133 CAS-15-15-15 REGISTERED MEMORY KIT". PartSurfer's Product Number just
+      echoes the spare, so the canonical-MPN crosswalk is useless for HP; the rich
+      description is the win — fed into the existing desc-grammar it categorizes the ~70k
+      uncategorized HP cards. Best-effort and resilient: a non-200, a missing/empty
+      description, or ANY httpx/parse error returns ``None`` and is logged — it NEVER
+      raises into the worker.
+Called by: app/services/enrichment_worker/worker.py (the partsurfer_desc batch pass,
+      gated by settings.partsurfer_desc_enabled).
+Depends on: app.http_client.http_redirect (the shared pooled client — no new client),
+      stdlib re / html / urllib. Politeness (1 req / 2s) is paced by the CALLER.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from urllib.parse import quote
+
+import httpx
+from loguru import logger
+
+from app.http_client import http_redirect
+
+# Contact UA so PartSurfer's operators can reach us (robots.txt allows Search.aspx; only
+# /WebResource.axd is disallowed). Keep this honest and reachable.
+_UA = "AvailAI-PartLookup/1.0 (+sourcing enrichment; contact mkhoury@trioscs.com)"
+_BASE_URL = "https://partsurfer.hpe.com/Search.aspx"
+
+# The verbatim part description lives in this ASP.NET label span. Non-greedy to the first
+# '<' so trailing markup is never captured.
+_LBL_DESCRIPTION_RE = re.compile(r'lblDescription"[^>]*>([^<]*)')
+
+
+async def fetch_partsurfer_description(spare_pn: str, *, timeout: int = 30) -> str | None:
+    """Fetch the verbatim PartSurfer description for *spare_pn*, or ``None``.
+
+    Single GET against the shared pooled ``http_redirect`` client with the contact UA.
+    Returns the html-unescaped/stripped ``lblDescription`` text, or ``None`` for a blank
+    spare, a non-200 status, a missing/empty description span, or ANY exception
+    (httpx transport, regex/parse) — the latter logged at WARNING. Never raises: the
+    worker pass must treat a failed lookup as "no description this card", not an error.
+    """
+    spare = (spare_pn or "").strip()
+    if not spare:
+        return None
+
+    url = f"{_BASE_URL}?SearchText={quote(spare)}"
+    try:
+        resp = await http_redirect.get(url, headers={"User-Agent": _UA}, timeout=timeout)
+    except (httpx.HTTPError, httpx.InvalidURL) as exc:
+        logger.warning("partsurfer: fetch failed for {} ({}): {}", spare, type(exc).__name__, exc)
+        return None
+
+    status = getattr(resp, "status_code", None)
+    if status != 200:
+        logger.info("partsurfer: non-200 for {} (status={}) — no description", spare, status)
+        return None
+
+    try:
+        match = _LBL_DESCRIPTION_RE.search(resp.text or "")
+    except Exception as exc:  # defensive: a non-str .text or pathological input
+        logger.warning("partsurfer: parse failed for {} ({}): {}", spare, type(exc).__name__, exc)
+        return None
+
+    if not match:
+        logger.info("partsurfer: no lblDescription for {} — likely no result", spare)
+        return None
+
+    description = html.unescape(match.group(1)).strip()
+    if not description:
+        logger.info("partsurfer: empty lblDescription for {}", spare)
+        return None
+
+    logger.info("partsurfer: {} -> {!r}", spare, description)
+    return description

--- a/app/services/enrichment_worker/partsurfer_resolver.py
+++ b/app/services/enrichment_worker/partsurfer_resolver.py
@@ -7,9 +7,11 @@ What: ``fetch_partsurfer_description`` does ONE GET against partsurfer.hpe.com's
       DDR4-2133 CAS-15-15-15 REGISTERED MEMORY KIT". PartSurfer's Product Number just
       echoes the spare, so the canonical-MPN crosswalk is useless for HP; the rich
       description is the win — fed into the existing desc-grammar it categorizes the ~70k
-      uncategorized HP cards. Best-effort and resilient: a non-200, a missing/empty
-      description, or ANY httpx/parse error returns ``None`` and is logged — it NEVER
-      raises into the worker.
+      uncategorized HP cards. Best-effort: a non-200 that is a genuine no-result (404/3xx),
+      a missing/empty description, or permanently-bad input returns ``None`` and is logged.
+      But a THROTTLE/OUTAGE signal (429, 5xx, or any httpx transport/timeout error) RAISES
+      ``PartSurferTransient`` so the caller backs off this batch instead of mistaking the
+      throttle for "no result" and hammering the host. ``None`` means a genuine no-result.
 Called by: app/services/enrichment_worker/worker.py (the partsurfer_desc batch pass,
       gated by settings.partsurfer_desc_enabled).
 Depends on: app.http_client.http_redirect (the shared pooled client — no new client),
@@ -36,15 +38,29 @@ _BASE_URL = "https://partsurfer.hpe.com/Search.aspx"
 # '<' so trailing markup is never captured.
 _LBL_DESCRIPTION_RE = re.compile(r'lblDescription"[^>]*>([^<]*)')
 
+# Throttle/outage statuses: the host is signalling "back off", not "no such part".
+_TRANSIENT_STATUSES = frozenset({429, 500, 502, 503, 504})
 
-async def fetch_partsurfer_description(spare_pn: str, *, timeout: int = 30) -> str | None:
+
+class PartSurferTransient(Exception):
+    """Throttle/outage signal (429, 5xx, timeout/transport) — caller should back off,
+    NOT treat as 'no result'."""
+
+
+async def fetch_partsurfer_description(spare_pn: str, *, timeout: int = 12) -> str | None:
     """Fetch the verbatim PartSurfer description for *spare_pn*, or ``None``.
 
     Single GET against the shared pooled ``http_redirect`` client with the contact UA.
-    Returns the html-unescaped/stripped ``lblDescription`` text, or ``None`` for a blank
-    spare, a non-200 status, a missing/empty description span, or ANY exception
-    (httpx transport, regex/parse) — the latter logged at WARNING. Never raises: the
-    worker pass must treat a failed lookup as "no description this card", not an error.
+    Returns the html-unescaped/stripped ``lblDescription`` text, or ``None`` for a GENUINE
+    no-result: a blank spare, permanently-bad input (``httpx.InvalidURL``), a non-200 that
+    is not a throttle (e.g. 404/3xx), or a missing/empty description span.
+
+    RAISES ``PartSurferTransient`` on a throttle/outage so the caller can back off this
+    batch instead of mistaking it for a no-result: a 429 / 5xx response, or any
+    ``httpx.HTTPError`` (timeout, transport, transient) — each logged at WARNING first.
+    The best-effort ``timeout`` is short (12s) so a slow host can't pin the single-threaded
+    worker. A non-str/pathological ``.text`` is still swallowed to ``None`` (a parse
+    failure on a 200 is a genuine no-description, not a throttle).
     """
     spare = (spare_pn or "").strip()
     if not spare:
@@ -53,11 +69,20 @@ async def fetch_partsurfer_description(spare_pn: str, *, timeout: int = 30) -> s
     url = f"{_BASE_URL}?SearchText={quote(spare)}"
     try:
         resp = await http_redirect.get(url, headers={"User-Agent": _UA}, timeout=timeout)
-    except (httpx.HTTPError, httpx.InvalidURL) as exc:
-        logger.warning("partsurfer: fetch failed for {} ({}): {}", spare, type(exc).__name__, exc)
+    except httpx.InvalidURL as exc:
+        # Permanently-bad input for this spare — a retry can't help, so it's a no-result.
+        logger.warning("partsurfer: invalid URL for {} ({}): {}", spare, type(exc).__name__, exc)
         return None
+    except httpx.HTTPError as exc:
+        # Timeout / transport / any transient httpx failure → back off, don't no-result.
+        logger.warning("partsurfer: transport error for {} ({}): {}", spare, type(exc).__name__, exc)
+        raise PartSurferTransient(f"partsurfer transport error for {spare}: {type(exc).__name__}") from exc
 
     status = getattr(resp, "status_code", None)
+    if status in _TRANSIENT_STATUSES:
+        # Throttle / outage — signal back-off, do NOT treat as "no result".
+        logger.warning("partsurfer: {} for {} — throttle/outage, backing off", status, spare)
+        raise PartSurferTransient(f"partsurfer {status} for {spare}")
     if status != 200:
         logger.info("partsurfer: non-200 for {} (status={}) — no description", spare, status)
         return None

--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -300,6 +300,71 @@ async def _oem_resolution_pass(
     return web_calls_today
 
 
+async def _partsurfer_desc_pass(db: Session, batch: list) -> dict[str, int]:
+    """PartSurfer description enrichment — categorize UNCATEGORIZED HP/HPE cards
+    (network).
+
+    For batch cards classified ``hpe`` (classify_oem_vendor) that are still UNCATEGORIZED
+    (``not (card.category or "").strip()``), fetch the OEM's own verbatim description live
+    from partsurfer.hpe.com and feed it into the desc grammar via ``categorize_and_record``
+    at ``partsurfer_desc`` / tier 84 — so the ~70k uncategorized HP spares get a category +
+    facets. PartSurfer's Product Number just echoes the spare, so the canonical-MPN
+    crosswalk is useless for HP; the rich DESCRIPTION is the win.
+
+    Placed AFTER the deterministic categorize/decode passes in run_one_batch so a fetch is
+    only spent on cards STILL uncategorized. Candidates are deduped by display_mpn so the
+    same spare is never fetched twice in a batch, and capped at
+    ``settings.partsurfer_fetch_per_batch``. Politeness is 1 request / 2s — paced here with
+    ``asyncio.sleep(2.0)`` BETWEEN fetches. ``categorize_and_record`` is fill-only (it
+    no-ops on an already-categorized card), so a card a prior pass categorized this batch
+    is skipped without a fetch via the NULL-category gate below.
+
+    Best-effort: ``fetch_partsurfer_description`` never raises (returns None on any error),
+    and each card's write is in ``categorize_and_record``'s own per-card SAVEPOINT.
+    Returns an aggregate {fetched, categorized, specs_written} summary for the log line.
+    """
+    from app.config import settings
+    from app.services.desc_extractor._common import PARTSURFER_DESC_CONFIDENCE, PARTSURFER_DESC_SOURCE
+    from app.services.desc_extractor.writer import categorize_and_record
+    from app.services.enrichment_worker.oem_classifier import classify_oem_vendor
+    from app.services.enrichment_worker.partsurfer_resolver import fetch_partsurfer_description
+
+    # Uncategorized HP/HPE cards only, deduped by display_mpn (one fetch covers every card
+    # sharing the spare). dict preserves insertion order → deterministic fetch order.
+    candidates: dict[str, list] = {}
+    for card in batch:
+        if (card.category or "").strip():
+            continue
+        if classify_oem_vendor(card.display_mpn) != "hpe":
+            continue
+        candidates.setdefault(card.display_mpn, []).append(card)
+    if not candidates:
+        return {"fetched": 0, "categorized": 0, "specs_written": 0}
+
+    fetch_cap = settings.partsurfer_fetch_per_batch
+    fetched = categorized = specs_written = 0
+    for i, (spare, cards) in enumerate(candidates.items()):
+        if fetched >= fetch_cap:
+            break
+        if i:
+            # 1 request / 2s politeness — between fetches only (not before the first).
+            await asyncio.sleep(2.0)
+        desc = await fetch_partsurfer_description(spare)
+        fetched += 1
+        if not desc:
+            continue
+        for card in cards:
+            # categorize_and_record is fill-only (no-op on an already-set category) and
+            # wraps category + facets in one SAVEPOINT — already-categorized cards skip.
+            was_categorized, written = categorize_and_record(
+                db, card, description=desc, source=PARTSURFER_DESC_SOURCE, confidence=PARTSURFER_DESC_CONFIDENCE
+            )
+            if was_categorized:
+                categorized += 1
+                specs_written += written
+    return {"fetched": fetched, "categorized": categorized, "specs_written": specs_written}
+
+
 async def run_one_batch(
     db: Session,
     config: "EnrichmentWorkerConfig",
@@ -589,6 +654,21 @@ async def run_one_batch(
                 logger.info("ENRICH_WORKER: desc-parse {}", extract_and_record_specs(db, enriched_ids))
             except Exception:
                 logger.exception("ENRICH_WORKER: desc-parse failed over {} cards", len(enriched_ids))
+
+    # PartSurfer description enrichment (HTTP, paced): for STILL-uncategorized HP/HPE cards
+    # in this batch, fetch the OEM's own verbatim description live from partsurfer.hpe.com
+    # (robots-allowed, 1 GET / 2s) and feed it into the desc grammar to categorize them at
+    # partsurfer_desc / tier 84. Placed AFTER the deterministic categorize/decode passes so
+    # a billable fetch is only spent on cards nothing else could categorize. Gated by the
+    # flag; bounded by partsurfer_fetch_per_batch. Same session, committed with the batch.
+    if batch_ids:
+        from app.config import settings
+
+        if settings.partsurfer_desc_enabled:
+            try:
+                logger.info("ENRICH_WORKER: partsurfer-desc {}", await _partsurfer_desc_pass(db, batch))
+            except Exception:
+                logger.exception("ENRICH_WORKER: partsurfer-desc pass failed over {} cards", len(batch_ids))
 
     # Second pass: parametric spec extraction for cards that landed a real category this
     # batch. Runs ONCE per batch (the extractor groups by category internally) on the same

--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -319,15 +319,23 @@ async def _partsurfer_desc_pass(db: Session, batch: list) -> dict[str, int]:
     no-ops on an already-categorized card), so a card a prior pass categorized this batch
     is skipped without a fetch via the NULL-category gate below.
 
-    Best-effort: ``fetch_partsurfer_description`` never raises (returns None on any error),
-    and each card's write is in ``categorize_and_record``'s own per-card SAVEPOINT.
-    Returns an aggregate {fetched, categorized, specs_written} summary for the log line.
+    Resilient: on a throttle/outage ``fetch_partsurfer_description`` raises
+    ``PartSurferTransient`` — the pass BREAKS (stops hammering the host this batch) rather
+    than burning the remaining candidates against a struggling host; the descriptions
+    already fetched are kept. Each card's ``categorize_and_record`` is wrapped per-card so
+    one bad card (an IntegrityError/DataError on the shared session) can't abort the pass
+    and waste the other fetched descriptions; ``categorize_and_record`` also wraps its own
+    write in a per-card SAVEPOINT. Returns an aggregate
+    {fetched, categorized, specs_written, failed} summary for the log line.
     """
     from app.config import settings
     from app.services.desc_extractor._common import PARTSURFER_DESC_CONFIDENCE, PARTSURFER_DESC_SOURCE
     from app.services.desc_extractor.writer import categorize_and_record
     from app.services.enrichment_worker.oem_classifier import classify_oem_vendor
-    from app.services.enrichment_worker.partsurfer_resolver import fetch_partsurfer_description
+    from app.services.enrichment_worker.partsurfer_resolver import (
+        PartSurferTransient,
+        fetch_partsurfer_description,
+    )
 
     # Uncategorized HP/HPE cards only, deduped by display_mpn (one fetch covers every card
     # sharing the spare). dict preserves insertion order → deterministic fetch order.
@@ -339,30 +347,43 @@ async def _partsurfer_desc_pass(db: Session, batch: list) -> dict[str, int]:
             continue
         candidates.setdefault(card.display_mpn, []).append(card)
     if not candidates:
-        return {"fetched": 0, "categorized": 0, "specs_written": 0}
+        return {"fetched": 0, "categorized": 0, "specs_written": 0, "failed": 0}
 
     fetch_cap = settings.partsurfer_fetch_per_batch
-    fetched = categorized = specs_written = 0
+    fetched = categorized = specs_written = failed = 0
     for i, (spare, cards) in enumerate(candidates.items()):
         if fetched >= fetch_cap:
             break
         if i:
             # 1 request / 2s politeness — between fetches only (not before the first).
             await asyncio.sleep(2.0)
-        desc = await fetch_partsurfer_description(spare)
+        try:
+            desc = await fetch_partsurfer_description(spare)
+        except PartSurferTransient as exc:
+            # The host is throttling / down — stop hammering it for the rest of this batch.
+            # The aborted fetch is NOT counted; descriptions already fetched are kept.
+            logger.warning("partsurfer-desc: backing off this batch — {}", exc)
+            break
         fetched += 1
         if not desc:
             continue
         for card in cards:
             # categorize_and_record is fill-only (no-op on an already-set category) and
-            # wraps category + facets in one SAVEPOINT — already-categorized cards skip.
-            was_categorized, written = categorize_and_record(
-                db, card, description=desc, source=PARTSURFER_DESC_SOURCE, confidence=PARTSURFER_DESC_CONFIDENCE
-            )
+            # wraps category + facets in one SAVEPOINT. Per-card try/except (mirrors
+            # extract_and_record_specs) so one bad card never aborts the pass and wastes the
+            # other fetched descriptions.
+            try:
+                was_categorized, written = categorize_and_record(
+                    db, card, description=desc, source=PARTSURFER_DESC_SOURCE, confidence=PARTSURFER_DESC_CONFIDENCE
+                )
+            except Exception:
+                failed += 1
+                logger.exception("partsurfer-desc: failed on card_id={}", card.id)
+                continue
             if was_categorized:
                 categorized += 1
                 specs_written += written
-    return {"fetched": fetched, "categorized": categorized, "specs_written": specs_written}
+    return {"fetched": fetched, "categorized": categorized, "specs_written": specs_written, "failed": failed}
 
 
 async def run_one_batch(

--- a/app/services/spec_tiers.py
+++ b/app/services/spec_tiers.py
@@ -76,6 +76,11 @@ SOURCE_TIER: dict[str, int] = {
     "trio_source_ai": 88,
     "mpn_decode": 85,
     "fru_matrix_decode": 84,
+    # PartSurfer = the OEM's own authoritative description → outranks the card's own
+    # desc_parse (83); still a description-parse, so it loses to the deterministic
+    # decoders (mpn_decode 85). Ties fru_matrix_decode (84) — different vendors, the tie
+    # is not load-bearing.
+    "partsurfer_desc": 84,
     "desc_parse": 83,
     "fru_desc_parse": 82,
     "partsurfer": 80,
@@ -709,8 +714,8 @@ def _set_brand_or_maker(
     write: bool,
 ) -> bool:
     """Shared body of set_brand/set_manufacturer: reject empties + garbage fragments
-    (is_garbage_brand_value — unbalanced-paren / single-char shapes, logged at WARNING),
-    normalize, ladder.
+    (is_garbage_brand_value — unbalanced-paren / single-char shapes, logged at
+    WARNING), normalize, ladder.
 
     PRECONDITION: *card* should be session-attached — the alias lookup derives its DB
     session via ``Session.object_session(card)``. A detached/transient card cannot be

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1513,10 +1513,16 @@ owns arbitration in one place:
        writer.categorize_and_record(source="partsurfer_desc"). PartSurfer's Product
        Number just echoes the spare (so the canonical-MPN crosswalk is useless for
        HP); the rich DESCRIPTION is the win — it categorizes the ~70k uncategorized
-       HP cards. Best-effort: fetch_partsurfer_description never raises (any
-       non-200 / missing span / httpx error → None); categorize_and_record is
-       fill-only (a card already categorized this batch is skipped via the
-       NULL-category gate). partsurfer_desc (84) outranks the card's own desc_parse
+       HP cards. Resilient: fetch_partsurfer_description returns None on a GENUINE
+       no-result (404/3xx, missing/empty span, invalid input) but RAISES
+       PartSurferTransient on a throttle/outage (429, 5xx, or any httpx
+       transport/timeout error) — the pass then BREAKS for the rest of this batch
+       (stops hammering a struggling host; descriptions already fetched are kept).
+       Each card's categorize_and_record is wrapped per-card (mirrors
+       extract_and_record_specs) so one bad card (IntegrityError/DataError on the
+       shared session) can't abort the pass — failures are tallied into the summary's
+       "failed" key. categorize_and_record is fill-only (a card already categorized
+       this batch is skipped via the NULL-category gate). partsurfer_desc (84) outranks the card's own desc_parse
        (83) — OEM catalog text beats the card's own desc — but loses to the
        deterministic decoders (mpn_decode 85); it ties fru_matrix_decode (84, a
        different vendor — tie not load-bearing).

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1493,10 +1493,33 @@ owns arbitration in one place:
        MaterialCardAudit action="categorized" per card) and at ingest time by
        source_ingest/clean.py (same grammar, fallback when the source carries no
        mappable Commodity_Code__c). The F1 ladder (fru_desc_parse 82 < desc_parse
-       83 < fru_matrix_decode 84 < mpn_decode 85 < vendor 90) keeps decode/vendor
+       83 < partsurfer_desc 84 < fru_matrix_decode 84 < mpn_decode 85 < vendor 90)
+       keeps decode/vendor
        values authoritative and the card's OWN description above its FRU-linked
        prose — no per-writer pre-gate. The phase-2/3 commodities have no MPN
        decoders, so desc_parse is their top non-vendor deterministic source.
+    3.5. enrichment_worker/worker.py::_partsurfer_desc_pass    — PartSurfer
+       description enrichment (HTTP, paced), source="partsurfer_desc" (tier 84),
+       confidence 0.90 (settings.partsurfer_desc_enabled, default ON). Runs AFTER
+       the deterministic categorize/decode passes so a billable fetch is only spent
+       on cards STILL uncategorized. For batch cards classified "hpe"
+       (classify_oem_vendor) that are UNCATEGORIZED, it does ONE polite GET against
+       https://partsurfer.hpe.com/Search.aspx (robots-allowed; UA
+       "AvailAI-PartLookup/1.0 …"; 1 req / 2s paced with asyncio.sleep; capped at
+       settings.partsurfer_fetch_per_batch, deduped by display_mpn) via
+       partsurfer_resolver.fetch_partsurfer_description, extracts the OEM's own
+       verbatim description (the ctl00_BodyContentPlaceHolder_lblDescription span),
+       and feeds it into the SAME desc grammar through
+       writer.categorize_and_record(source="partsurfer_desc"). PartSurfer's Product
+       Number just echoes the spare (so the canonical-MPN crosswalk is useless for
+       HP); the rich DESCRIPTION is the win — it categorizes the ~70k uncategorized
+       HP cards. Best-effort: fetch_partsurfer_description never raises (any
+       non-200 / missing span / httpx error → None); categorize_and_record is
+       fill-only (a card already categorized this batch is skipped via the
+       NULL-category gate). partsurfer_desc (84) outranks the card's own desc_parse
+       (83) — OEM catalog text beats the card's own desc — but loses to the
+       deterministic decoders (mpn_decode 85); it ties fru_matrix_decode (84, a
+       different vendor — tie not load-bearing).
     4. spec_enrichment_service.py::enrich_card_specs    — AI spec reader,
        source="spec_extraction" (tier 60), facets gated at confidence >= 0.85
        (FACET_MIN_CONF — an AI output-quality floor, not cross-source
@@ -1545,7 +1568,12 @@ load-bearing (it replaced `record_spec`'s old vendor-only special-case + "latest
 
 ```
 SOURCE_TIER  manual:100 · trio_source:95 · {digikey,mouser,nexar,element14,oemsecrets}_api:90
-             · trio_source_ai:88 · mpn_decode:85 · fru_matrix_decode:84 · desc_parse:83
+             · trio_source_ai:88 · mpn_decode:85 · fru_matrix_decode:84
+             · partsurfer_desc:84 (HP PartSurfer description channel — the OEM's OWN
+               verbatim description fetched live via partsurfer_resolver and fed to the
+               desc grammar; outranks the card's own desc_parse 83, loses to mpn_decode 85,
+               ties fru_matrix_decode 84 — different vendors, tie not load-bearing)
+             · desc_parse:83
              · fru_desc_parse:82 (FRU-linked qual-sheet descriptions — below the card's
                OWN description, above the OEM scrapers)
              · {partsurfer,psref,oem_official}:80 (partsurfer/psref are written by the

--- a/tests/fixtures/partsurfer/dimm_726719-B21.html
+++ b/tests/fixtures/partsurfer/dimm_726719-B21.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><html><head><title>PartSurfer (trimmed fixture)</title></head>
+<body><form id="aspnetForm">
+<!-- Trimmed from a real partsurfer.hpe.com Search.aspx HTTP 200 response. Only the lblProductNumber/lblDescription spans are kept so the resolver regex still parses it. The ViewState/script bulk is dropped. -->
+<span id="ctl00_BodyContentPlaceHolder_lblProductNumber">726719-B21</span>
+                                                    </span>
+<span id="ctl00_BodyContentPlaceHolder_lblDescription">HPE 16GB (1X16GB) DUAL RANK X4 DDR4-2133 CAS-15-15-15 REGISTERED MEMORY KIT</span>
+                                                    </span>
+</form></body></html>

--- a/tests/fixtures/partsurfer/notfound.html
+++ b/tests/fixtures/partsurfer/notfound.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><html><head><title>PartSurfer</title></head>
+<body><form id="aspnetForm">
+<!-- Fabricated 'no result' Search.aspx page: the lblDescription span is absent (PartSurfer renders the empty results grid with no description label). -->
+<div id="ctl00_BodyContentPlaceHolder_pnlNoResult">No results found for the part number you entered.</div>
+<span id="ctl00_BodyContentPlaceHolder_lblSearchText">ZZZNOTAPART999</span>
+</form></body></html>

--- a/tests/fixtures/partsurfer/ssd_875507-B21.html
+++ b/tests/fixtures/partsurfer/ssd_875507-B21.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><html><head><title>PartSurfer (trimmed fixture)</title></head>
+<body><form id="aspnetForm">
+<!-- Trimmed from a real partsurfer.hpe.com Search.aspx HTTP 200 response. Only the lblProductNumber/lblDescription spans are kept so the resolver regex still parses it. The ViewState/script bulk is dropped. -->
+<span id="ctl00_BodyContentPlaceHolder_lblProductNumber">875507-B21</span>
+                                                    </span>
+<span id="ctl00_BodyContentPlaceHolder_lblDescription">HPE 240GB SATA 6G READ INTENSIVE SFF RW PM883 SSD</span>
+                                                    </span>
+</form></body></html>

--- a/tests/test_partsurfer_enrich.py
+++ b/tests/test_partsurfer_enrich.py
@@ -11,6 +11,8 @@ Depends on: conftest.py (db_session), seed_commodity_schemas, MaterialCard +
 MaterialSpecFacet schema, spec_tiers.SOURCE_TIER (partsurfer_desc=84).
 """
 
+from unittest.mock import AsyncMock, patch
+
 from sqlalchemy.orm import Session
 
 from app.models import MaterialCard, MaterialSpecFacet
@@ -168,7 +170,8 @@ async def test_worker_pass_only_fetches_uncategorized_hp_cards_and_dedupes(db_se
         fetched_spares.append(spare)
         return {"726719-B21": _DIMM_DESC, "875507-B21": _SSD_DESC}.get(spare)
 
-    monkeypatch.setattr(worker, "fetch_partsurfer_description", fake_fetch, raising=False)
+    # The pass imports fetch_partsurfer_description LAZILY from the resolver module, so the
+    # only effective patch is on that module — patch it there.
     import app.services.enrichment_worker.partsurfer_resolver as resolver_mod
 
     monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
@@ -190,6 +193,7 @@ async def test_worker_pass_only_fetches_uncategorized_hp_cards_and_dedupes(db_se
     # Both cards sharing 726719-B21 get categorized + the 875507-B21 card → 3 categorized.
     assert stats["categorized"] == 3
     assert stats["specs_written"] >= 3
+    assert stats["failed"] == 0
     assert hp_a1.category == "dram"
     assert hp_a2.category == "dram"
     assert hp_b.category == "ssd"
@@ -248,5 +252,227 @@ async def test_worker_pass_no_hp_cards_is_a_noop(db_session: Session, monkeypatc
     monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
 
     stats = await worker._partsurfer_desc_pass(db_session, [non_hp])
-    assert stats == {"fetched": 0, "categorized": 0, "specs_written": 0}
+    assert stats == {"fetched": 0, "categorized": 0, "specs_written": 0, "failed": 0}
     assert called is False
+
+
+async def test_worker_pass_paces_one_sleep_between_each_fetch(db_session: Session, monkeypatch):
+    # Politeness pacing: asyncio.sleep(2.0) fires exactly len(candidates)-1 times (between
+    # fetches, never before the first), each with 2.0. Capture the sleeps instead of no-op'ing.
+    from app.config import settings
+    from app.services.enrichment_worker import worker
+
+    seed_commodity_schemas(db_session)
+    cards = [_hp_card(db_session, mpn) for mpn in ("726719-B21", "875507-B21", "918042-601")]
+
+    async def fake_fetch(spare, **_kw):
+        return _DIMM_DESC
+
+    import app.services.enrichment_worker.partsurfer_resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
+    monkeypatch.setattr(settings, "partsurfer_fetch_per_batch", 10)
+
+    sleeps: list[float] = []
+
+    async def rec(s):
+        sleeps.append(s)
+
+    # The pass calls worker.asyncio.sleep(2.0) between fetches — patch that exact symbol.
+    monkeypatch.setattr(worker.asyncio, "sleep", rec)
+
+    await worker._partsurfer_desc_pass(db_session, cards)
+    db_session.commit()
+
+    # 3 candidates → 2 paced sleeps, each 2.0s, none before the first fetch.
+    assert sleeps == [2.0, 2.0]
+
+
+async def test_worker_pass_aborts_on_transient_and_keeps_earlier(db_session: Session, monkeypatch):
+    # A PartSurferTransient on the 2nd of 3 candidates BREAKS the pass (3rd never fetched),
+    # but the 1st card — already fetched + categorized — is kept. The aborted fetch is not
+    # counted in `fetched`.
+    from app.services.enrichment_worker import worker
+    from app.services.enrichment_worker.partsurfer_resolver import PartSurferTransient
+
+    seed_commodity_schemas(db_session)
+    c1 = _hp_card(db_session, "726719-B21")  # DIMM → categorizes
+    c2 = _hp_card(db_session, "875507-B21")  # raises transient
+    c3 = _hp_card(db_session, "918042-601")  # must never be fetched
+
+    fetched_spares: list[str] = []
+
+    async def fake_fetch(spare, **_kw):
+        fetched_spares.append(spare)
+        if spare == "875507-B21":
+            raise PartSurferTransient("partsurfer 503 for 875507-B21")
+        return _DIMM_DESC
+
+    import app.services.enrichment_worker.partsurfer_resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
+
+    async def no_sleep(_s):
+        return None
+
+    monkeypatch.setattr(worker.asyncio, "sleep", no_sleep)
+
+    stats = await worker._partsurfer_desc_pass(db_session, [c1, c2, c3])
+    db_session.commit()
+
+    # The loop BREAKS at the transient: the 3rd spare is never fetched.
+    assert fetched_spares == ["726719-B21", "875507-B21"]
+    # Only the 1st succeeded — the aborted (transient) fetch is NOT counted.
+    assert stats["fetched"] == 1
+    assert stats["categorized"] == 1
+    assert stats["failed"] == 0
+    assert c1.category == "dram"
+    assert c3.category is None
+
+
+async def test_worker_pass_isolates_a_single_failing_card(db_session: Session, monkeypatch):
+    # One card raising IntegrityError in categorize_and_record must not abort the pass —
+    # the other card still categorizes and summary["failed"] == 1.
+    from sqlalchemy.exc import IntegrityError
+
+    from app.services.desc_extractor import writer as desc_writer
+    from app.services.enrichment_worker import worker
+
+    seed_commodity_schemas(db_session)
+    # Two distinct HP spares (so two separate fetches → two categorize_and_record calls).
+    bad = _hp_card(db_session, "726719-B21")
+    good = _hp_card(db_session, "875507-B21")
+
+    async def fake_fetch(spare, **_kw):
+        return {"726719-B21": _DIMM_DESC, "875507-B21": _SSD_DESC}[spare]
+
+    import app.services.enrichment_worker.partsurfer_resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
+
+    async def no_sleep(_s):
+        return None
+
+    monkeypatch.setattr(worker.asyncio, "sleep", no_sleep)
+
+    real_categorize = desc_writer.categorize_and_record
+
+    def flaky_categorize(db, card, **kw):
+        if card.id == bad.id:
+            raise IntegrityError("simulated", {}, Exception("boom"))
+        return real_categorize(db, card, **kw)
+
+    # The pass imports categorize_and_record from the writer module — patch it there.
+    monkeypatch.setattr(desc_writer, "categorize_and_record", flaky_categorize)
+
+    stats = await worker._partsurfer_desc_pass(db_session, [bad, good])
+    db_session.commit()
+
+    # Both fetched; the bad card failed in isolation; the good card still categorized.
+    assert stats["fetched"] == 2
+    assert stats["failed"] == 1
+    assert stats["categorized"] == 1
+    assert good.category == "ssd"
+    assert bad.category is None
+
+
+async def test_worker_pass_grammar_declines_categorize_none(db_session: Session, monkeypatch):
+    # Fetch succeeds but the description is non-categorizable (categorize_and_record →
+    # (False, 0)) over 2 HP candidates → a clean {fetched:2, categorized:0, specs:0, failed:0}.
+    from app.services.desc_extractor import writer as desc_writer
+    from app.services.enrichment_worker import worker
+
+    seed_commodity_schemas(db_session)
+    cards = [_hp_card(db_session, mpn) for mpn in ("726719-B21", "875507-B21")]
+
+    async def fake_fetch(spare, **_kw):
+        return "SOME OPAQUE HP DESCRIPTION THE GRAMMAR DECLINES"
+
+    import app.services.enrichment_worker.partsurfer_resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
+
+    async def no_sleep(_s):
+        return None
+
+    monkeypatch.setattr(worker.asyncio, "sleep", no_sleep)
+    # Grammar declines every description.
+    monkeypatch.setattr(desc_writer, "categorize_and_record", lambda *a, **k: (False, 0))
+
+    stats = await worker._partsurfer_desc_pass(db_session, cards)
+    db_session.commit()
+
+    assert stats == {"fetched": 2, "categorized": 0, "specs_written": 0, "failed": 0}
+
+
+async def test_run_one_batch_gates_partsurfer_pass_on_flag(db_session: Session, monkeypatch):
+    # The run_one_batch gate: a seeded uncategorized HP card is fetched + categorized ONLY
+    # when settings.partsurfer_desc_enabled is True. Flag OFF → no fetch at all.
+    from app.config import settings
+    from app.constants import MaterialEnrichmentStatus
+    from app.services.enrichment_worker import worker
+    from app.services.enrichment_worker.circuit_breaker import EnrichmentCircuitBreaker
+    from app.services.enrichment_worker.config import EnrichmentWorkerConfig
+
+    seed_commodity_schemas(db_session)
+
+    fetched: list[str] = []
+
+    async def fake_fetch(spare, **_kw):
+        fetched.append(spare)
+        return _DIMM_DESC  # the DIMM description → categorizes to dram
+
+    import app.services.enrichment_worker.partsurfer_resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
+
+    async def no_sleep(_s):
+        return None
+
+    monkeypatch.setattr(worker.asyncio, "sleep", no_sleep)
+    # Isolate the partsurfer pass: enrich_card is a no-op miss; the other deterministic
+    # passes are gated off so only the partsurfer flag is under test.
+    monkeypatch.setattr(settings, "oem_crosswalk_enrich_enabled", False)
+    monkeypatch.setattr(settings, "fru_crosswalk_enrich_enabled", False)
+    monkeypatch.setattr(settings, "mpn_decode_enabled", False)
+    monkeypatch.setattr(settings, "desc_parse_enabled", False)
+
+    async def fake_enrich(card, db, **kw):
+        # Leaves the card uncategorized → eligible for the partsurfer pass.
+        return MaterialEnrichmentStatus.NOT_FOUND
+
+    cfg = EnrichmentWorkerConfig(batch_size=5, web_daily_cap=80)
+    breaker = EnrichmentCircuitBreaker(cfg)
+
+    def _seed_card(mpn: str) -> int:
+        card = MaterialCard(
+            normalized_mpn=mpn.lower(),
+            display_mpn=mpn,
+            category=None,
+            enrichment_status=MaterialEnrichmentStatus.UNENRICHED,
+        )
+        db_session.add(card)
+        db_session.flush()
+        return card.id
+
+    async def _drive():
+        return await worker.run_one_batch(db_session, cfg, {}, breaker, set(), {"web_calls": 0})
+
+    with (
+        patch("app.services.enrichment_worker.worker.enrich_card", side_effect=fake_enrich),
+        patch("app.services.enrichment_worker.worker._connectors_in_order", return_value=[]),
+        patch("app.services.spec_enrichment_service.enrich_card_specs", new=AsyncMock(return_value={})),
+    ):
+        # Flag OFF → the pass is never entered, nothing fetched.
+        monkeypatch.setattr(settings, "partsurfer_desc_enabled", False)
+        cid_off = _seed_card("726719-B21")
+        await _drive()
+        assert fetched == []
+        assert db_session.get(MaterialCard, cid_off).category is None
+
+        # Flag ON → the still-uncategorized HP card is fetched + categorized.
+        monkeypatch.setattr(settings, "partsurfer_desc_enabled", True)
+        cid_on = _seed_card("875507-B21")
+        await _drive()
+        assert "875507-B21" in fetched
+        assert db_session.get(MaterialCard, cid_on).category == "dram"

--- a/tests/test_partsurfer_enrich.py
+++ b/tests/test_partsurfer_enrich.py
@@ -1,0 +1,252 @@
+"""tests/test_partsurfer_enrich.py -- PartSurfer description → category + facets, via the
+F1 ladder.
+
+Covers the DB-side contract of the PartSurfer enrichment channel: feeding the OEM's own
+verbatim description into ``categorize_and_record`` with source="partsurfer_desc"
+categorizes an UNCATEGORIZED HP card and records facets at tier 84; an already-categorized
+card is a no-op; and via ``record_spec`` a partsurfer_desc value BEATS a pre-existing
+desc_parse (83) facet but LOSES to an mpn_decode (85) facet (the ladder check).
+
+Depends on: conftest.py (db_session), seed_commodity_schemas, MaterialCard +
+MaterialSpecFacet schema, spec_tiers.SOURCE_TIER (partsurfer_desc=84).
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard, MaterialSpecFacet
+from app.services.commodity_registry import seed_commodity_schemas
+from app.services.desc_extractor._common import PARTSURFER_DESC_CONFIDENCE, PARTSURFER_DESC_SOURCE
+from app.services.desc_extractor.writer import categorize_and_record
+from app.services.spec_tiers import SOURCE_TIER, set_category
+from app.services.spec_write_service import record_spec
+
+# Real PartSurfer descriptions (the captured fixtures' lblDescription text).
+_DIMM_DESC = "HPE 16GB (1X16GB) DUAL RANK X4 DDR4-2133 CAS-15-15-15 REGISTERED MEMORY KIT"
+_SSD_DESC = "HPE 240GB SATA 6G READ INTENSIVE SFF RW PM883 SSD"
+
+
+def _facets(db: Session, card_id: int) -> dict:
+    rows = db.query(MaterialSpecFacet).filter_by(material_card_id=card_id).all()
+    return {r.spec_key: (r.value_text if r.value_text is not None else r.value_numeric) for r in rows}
+
+
+def _hp_card(db: Session, mpn: str = "726719-B21") -> MaterialCard:
+    """An UNCATEGORIZED HP spare card — the real PartSurfer target population."""
+    card = MaterialCard(normalized_mpn=mpn.lower(), display_mpn=mpn, category=None)
+    db.add(card)
+    db.flush()
+    return card
+
+
+def test_partsurfer_source_is_registered_at_tier_84():
+    # The source string MUST be a registered ladder key (tier 84) or every write loses.
+    assert SOURCE_TIER[PARTSURFER_DESC_SOURCE] == 84
+    assert SOURCE_TIER["partsurfer_desc"] > SOURCE_TIER["desc_parse"]  # 84 > 83
+    assert SOURCE_TIER["mpn_decode"] > SOURCE_TIER["partsurfer_desc"]  # 85 > 84
+
+
+def test_dram_description_categorizes_and_writes_facets_at_tier_84(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = _hp_card(db_session)
+
+    categorized, written = categorize_and_record(
+        db_session,
+        card,
+        description=_DIMM_DESC,
+        source=PARTSURFER_DESC_SOURCE,
+        confidence=PARTSURFER_DESC_CONFIDENCE,
+    )
+    db_session.commit()
+
+    assert categorized is True
+    assert card.category == "dram"
+    # Category written THROUGH the ladder at partsurfer_desc / tier 84.
+    assert card.category_source == "partsurfer_desc"
+    assert card.category_tier == 84
+    assert card.category_confidence == PARTSURFER_DESC_CONFIDENCE
+    # At least one facet, also at partsurfer_desc.
+    assert written >= 1
+    f = _facets(db_session, card.id)
+    assert f["capacity_gb"] == 16
+    assert f["ddr_type"] == "DDR4"
+    assert card.specs_structured["capacity_gb"]["source"] == "partsurfer_desc"
+    assert card.specs_structured["capacity_gb"]["tier"] == 84
+
+
+def test_ssd_description_categorizes_to_storage(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = _hp_card(db_session, "875507-B21")
+
+    categorized, written = categorize_and_record(
+        db_session, card, description=_SSD_DESC, source=PARTSURFER_DESC_SOURCE, confidence=PARTSURFER_DESC_CONFIDENCE
+    )
+    db_session.commit()
+
+    assert categorized is True
+    assert card.category == "ssd"
+    assert card.category_source == "partsurfer_desc"
+    assert written >= 1
+    assert _facets(db_session, card.id)["capacity_gb"] == 240
+
+
+def test_already_categorized_card_is_a_noop(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = _hp_card(db_session)
+    # Pre-categorize via the sanctioned ladder path (never hand-set category).
+    assert set_category(card, "ssd", source="mpn_decode", confidence=0.95)
+    db_session.flush()
+
+    categorized, written = categorize_and_record(
+        db_session, card, description=_DIMM_DESC, source=PARTSURFER_DESC_SOURCE, confidence=PARTSURFER_DESC_CONFIDENCE
+    )
+    db_session.commit()
+
+    # categorize_and_record is fill-only — never reclassifies.
+    assert (categorized, written) == (False, 0)
+    assert card.category == "ssd"  # untouched
+    assert card.category_source == "mpn_decode"
+
+
+def test_partsurfer_desc_beats_desc_parse_but_loses_to_mpn_decode(db_session: Session):
+    # The ladder check via record_spec: partsurfer_desc (84) BEATS a pre-existing
+    # desc_parse (83) facet, but LOSES to an mpn_decode (85) facet.
+    seed_commodity_schemas(db_session)
+    card = _hp_card(db_session)
+    # A category is required for record_spec; set it through the ladder.
+    assert set_category(card, "dram", source="partsurfer_desc", confidence=PARTSURFER_DESC_CONFIDENCE)
+    db_session.flush()
+
+    # A pre-existing desc_parse (83) value.
+    assert record_spec(db_session, card.id, "ddr_type", "DDR3", source="desc_parse", confidence=0.90) is True
+    assert card.specs_structured["ddr_type"]["source"] == "desc_parse"
+
+    # partsurfer_desc (84) > desc_parse (83) → wins, overwrites.
+    assert record_spec(db_session, card.id, "ddr_type", "DDR4", source="partsurfer_desc", confidence=0.90) is True
+    assert card.specs_structured["ddr_type"]["value"] == "DDR4"
+    assert card.specs_structured["ddr_type"]["source"] == "partsurfer_desc"
+    assert card.specs_structured["ddr_type"]["tier"] == 84
+
+    # mpn_decode (85) > partsurfer_desc (84) → wins.
+    assert record_spec(db_session, card.id, "ddr_type", "DDR5", source="mpn_decode", confidence=0.95) is True
+    assert card.specs_structured["ddr_type"]["value"] == "DDR5"
+    assert card.specs_structured["ddr_type"]["source"] == "mpn_decode"
+    assert card.specs_structured["ddr_type"]["tier"] == 85
+
+    # partsurfer_desc (84) can no longer downgrade the mpn_decode (85) value.
+    assert record_spec(db_session, card.id, "ddr_type", "DDR4", source="partsurfer_desc", confidence=0.99) is False
+    assert card.specs_structured["ddr_type"]["value"] == "DDR5"
+    db_session.commit()
+
+
+# --- the worker pass (_partsurfer_desc_pass) -------------------------------------------
+
+
+async def test_worker_pass_only_fetches_uncategorized_hp_cards_and_dedupes(db_session: Session, monkeypatch):
+    # The pass: candidates = UNCATEGORIZED + classify_oem_vendor=="hpe", deduped by
+    # display_mpn. A non-HP card and an already-categorized HP card are never fetched.
+    from app.services.enrichment_worker import worker
+
+    seed_commodity_schemas(db_session)
+    # Two cards sharing display_mpn "726719-B21" (the dedup key) but distinct
+    # normalized_mpn (a UNIQUE column) → one fetch must cover both.
+    hp_a1 = MaterialCard(normalized_mpn="726719-b21", display_mpn="726719-B21", category=None)
+    hp_a2 = MaterialCard(normalized_mpn="726719-b21-dup", display_mpn="726719-B21", category=None)
+    db_session.add_all([hp_a1, hp_a2])
+    db_session.flush()
+    hp_b = _hp_card(db_session, "875507-B21")
+    # An already-categorized HP card — skipped (fill-only NULL-category gate).
+    hp_done = _hp_card(db_session, "918042-601")
+    assert set_category(hp_done, "ssd", source="mpn_decode", confidence=0.95)
+    # A non-HP card — classify_oem_vendor != "hpe", never fetched.
+    non_hp = MaterialCard(normalized_mpn="grm155", display_mpn="GRM155R71C104MA88D", category=None)
+    db_session.add(non_hp)
+    db_session.flush()
+
+    fetched_spares: list[str] = []
+
+    async def fake_fetch(spare, **_kw):
+        fetched_spares.append(spare)
+        return {"726719-B21": _DIMM_DESC, "875507-B21": _SSD_DESC}.get(spare)
+
+    monkeypatch.setattr(worker, "fetch_partsurfer_description", fake_fetch, raising=False)
+    import app.services.enrichment_worker.partsurfer_resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
+    # Avoid the real 2s sleep between fetches.
+
+    async def no_sleep(_s):
+        return None
+
+    monkeypatch.setattr(worker.asyncio, "sleep", no_sleep)
+
+    batch = [hp_a1, hp_a2, hp_b, hp_done, non_hp]
+    stats = await worker._partsurfer_desc_pass(db_session, batch)
+    db_session.commit()
+
+    # Deduped by spare: only the two distinct HP spares are fetched (not the dup, not the
+    # categorized card, not the non-HP card).
+    assert sorted(fetched_spares) == ["726719-B21", "875507-B21"]
+    assert stats["fetched"] == 2
+    # Both cards sharing 726719-B21 get categorized + the 875507-B21 card → 3 categorized.
+    assert stats["categorized"] == 3
+    assert stats["specs_written"] >= 3
+    assert hp_a1.category == "dram"
+    assert hp_a2.category == "dram"
+    assert hp_b.category == "ssd"
+    assert hp_a1.category_source == "partsurfer_desc"
+    assert non_hp.category is None  # never touched
+
+
+async def test_worker_pass_respects_fetch_cap(db_session: Session, monkeypatch):
+    from app.config import settings
+    from app.services.enrichment_worker import worker
+
+    seed_commodity_schemas(db_session)
+    # 3 distinct HP spares but a cap of 1 → only one fetch.
+    cards = [_hp_card(db_session, mpn) for mpn in ("726719-B21", "875507-B21", "918042-601")]
+
+    fetched: list[str] = []
+
+    async def fake_fetch(spare, **_kw):
+        fetched.append(spare)
+        return _DIMM_DESC
+
+    import app.services.enrichment_worker.partsurfer_resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
+
+    async def no_sleep(_s):
+        return None
+
+    monkeypatch.setattr(worker.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(settings, "partsurfer_fetch_per_batch", 1)
+
+    stats = await worker._partsurfer_desc_pass(db_session, cards)
+    db_session.commit()
+
+    assert stats["fetched"] == 1
+    assert len(fetched) == 1
+
+
+async def test_worker_pass_no_hp_cards_is_a_noop(db_session: Session, monkeypatch):
+    from app.services.enrichment_worker import worker
+
+    seed_commodity_schemas(db_session)
+    non_hp = MaterialCard(normalized_mpn="grm155", display_mpn="GRM155R71C104MA88D", category=None)
+    db_session.add(non_hp)
+    db_session.flush()
+
+    called = False
+
+    async def fake_fetch(spare, **_kw):
+        nonlocal called
+        called = True
+        return None
+
+    import app.services.enrichment_worker.partsurfer_resolver as resolver_mod
+
+    monkeypatch.setattr(resolver_mod, "fetch_partsurfer_description", fake_fetch)
+
+    stats = await worker._partsurfer_desc_pass(db_session, [non_hp])
+    assert stats == {"fetched": 0, "categorized": 0, "specs_written": 0}
+    assert called is False

--- a/tests/test_partsurfer_resolver.py
+++ b/tests/test_partsurfer_resolver.py
@@ -3,8 +3,10 @@
 Covers: app/services/enrichment_worker/partsurfer_resolver.py. Patches the shared
 ``app.http_client.http_redirect.get`` with an AsyncMock so ZERO live network is touched —
 the two real fixtures (a DIMM + an SSD captured from partsurfer.hpe.com) drive the happy
-path; the fabricated not-found fixture, a non-200 status, and a raised httpx.HTTPError
-drive the resilience contract (every failure → None, never a raise into the worker).
+path; the fabricated not-found fixture and a genuine non-200 (e.g. 404) drive the
+no-result contract (→ None). The throttle/outage contract is separate: a 429/5xx response
+or a raised httpx error must raise ``PartSurferTransient`` so the caller backs off this
+batch instead of mistaking a throttle for "no result".
 Depends on: tests/fixtures/partsurfer/*.html.
 """
 
@@ -15,8 +17,12 @@ import httpx
 import pytest
 
 from app.services.enrichment_worker import partsurfer_resolver
+from app.services.enrichment_worker.partsurfer_resolver import PartSurferTransient
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "partsurfer"
+
+# The honest contact UA the fetcher must send (matches the module constant).
+_EXPECTED_UA = "AvailAI-PartLookup/1.0 (+sourcing enrichment; contact mkhoury@trioscs.com)"
 
 
 def _fixture(name: str) -> str:
@@ -48,6 +54,19 @@ async def test_ssd_fixture_returns_exact_description():
 
 
 @pytest.mark.asyncio
+async def test_outbound_request_uses_exact_url_and_contact_ua():
+    # Outbound contract: the GET targets the Search.aspx URL with the spare as SearchText
+    # and carries the honest contact User-Agent (robots.txt allows Search.aspx).
+    resp = _resp(_fixture("dimm_726719-B21.html"))
+    get = AsyncMock(return_value=resp)
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=get):
+        await partsurfer_resolver.fetch_partsurfer_description("726719-B21")
+    url = get.await_args.args[0]
+    assert url == "https://partsurfer.hpe.com/Search.aspx?SearchText=726719-B21"
+    assert get.await_args.kwargs["headers"]["User-Agent"] == _EXPECTED_UA
+
+
+@pytest.mark.asyncio
 async def test_not_found_fixture_returns_none():
     # A real-shaped Search.aspx page with no lblDescription span → None (no guess).
     resp = _resp(_fixture("notfound.html"))
@@ -56,17 +75,63 @@ async def test_not_found_fixture_returns_none():
 
 
 @pytest.mark.asyncio
-async def test_non_200_returns_none():
-    resp = _resp(_fixture("dimm_726719-B21.html"), status_code=503)
+async def test_genuine_non_200_returns_none():
+    # A 404/3xx is a GENUINE no-result (not a throttle) → None, the spare moves on.
+    resp = _resp(_fixture("dimm_726719-B21.html"), status_code=404)
     with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
         assert await partsurfer_resolver.fetch_partsurfer_description("726719-B21") is None
 
 
 @pytest.mark.asyncio
-async def test_http_error_is_swallowed_to_none():
-    # ANY httpx error must be caught and returned as None — never raised into the worker.
+async def test_503_raises_transient():
+    # A 5xx is a throttle/outage → PartSurferTransient so the caller backs off this batch.
+    resp = _resp(_fixture("dimm_726719-B21.html"), status_code=503)
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
+        with pytest.raises(PartSurferTransient):
+            await partsurfer_resolver.fetch_partsurfer_description("726719-B21")
+
+
+@pytest.mark.asyncio
+async def test_429_raises_transient_and_logs_warning():
+    # A 429 (rate-limited) is the canonical throttle signal → PartSurferTransient + WARNING.
+    resp = _resp(_fixture("dimm_726719-B21.html"), status_code=429)
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
+        with patch.object(partsurfer_resolver.logger, "warning") as warn:
+            with pytest.raises(PartSurferTransient):
+                await partsurfer_resolver.fetch_partsurfer_description("726719-B21")
+    assert warn.called
+
+
+@pytest.mark.asyncio
+async def test_http_error_raises_transient():
+    # ANY httpx transport error (timeout/connect/transient) → PartSurferTransient (back off),
+    # NOT None — a throttle masquerading as a no-result would hammer the host.
     boom = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
     with patch.object(partsurfer_resolver.http_redirect, "get", new=boom):
+        with pytest.raises(PartSurferTransient):
+            await partsurfer_resolver.fetch_partsurfer_description("726719-B21")
+
+
+@pytest.mark.asyncio
+async def test_invalid_url_returns_none():
+    # Permanently-bad input for this spare — a retry can't help → genuine no-result (None).
+    boom = AsyncMock(side_effect=httpx.InvalidURL("bad url"))
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=boom):
+        assert await partsurfer_resolver.fetch_partsurfer_description("726719-B21") is None
+
+
+@pytest.mark.asyncio
+async def test_text_attribute_raises_returns_none():
+    # A pathological 200 whose .text raises → swallowed to None (a parse failure on a 200 is
+    # a genuine no-description, not a throttle — never raises PartSurferTransient).
+    class _BadText:
+        status_code = 200
+
+        @property
+        def text(self):
+            raise ValueError("decode boom")
+
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=_BadText())):
         assert await partsurfer_resolver.fetch_partsurfer_description("726719-B21") is None
 
 

--- a/tests/test_partsurfer_resolver.py
+++ b/tests/test_partsurfer_resolver.py
@@ -1,0 +1,95 @@
+"""tests/test_partsurfer_resolver.py -- fetch_partsurfer_description unit tests.
+
+Covers: app/services/enrichment_worker/partsurfer_resolver.py. Patches the shared
+``app.http_client.http_redirect.get`` with an AsyncMock so ZERO live network is touched —
+the two real fixtures (a DIMM + an SSD captured from partsurfer.hpe.com) drive the happy
+path; the fabricated not-found fixture, a non-200 status, and a raised httpx.HTTPError
+drive the resilience contract (every failure → None, never a raise into the worker).
+Depends on: tests/fixtures/partsurfer/*.html.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.services.enrichment_worker import partsurfer_resolver
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "partsurfer"
+
+
+def _fixture(name: str) -> str:
+    return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _resp(text: str, status_code: int = 200):
+    """A minimal stand-in for httpx.Response: only .status_code + .text are read."""
+    resp = type("Resp", (), {})()
+    resp.status_code = status_code
+    resp.text = text
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_dimm_fixture_returns_exact_description():
+    resp = _resp(_fixture("dimm_726719-B21.html"))
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
+        desc = await partsurfer_resolver.fetch_partsurfer_description("726719-B21")
+    assert desc == "HPE 16GB (1X16GB) DUAL RANK X4 DDR4-2133 CAS-15-15-15 REGISTERED MEMORY KIT"
+
+
+@pytest.mark.asyncio
+async def test_ssd_fixture_returns_exact_description():
+    resp = _resp(_fixture("ssd_875507-B21.html"))
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
+        desc = await partsurfer_resolver.fetch_partsurfer_description("875507-B21")
+    assert desc == "HPE 240GB SATA 6G READ INTENSIVE SFF RW PM883 SSD"
+
+
+@pytest.mark.asyncio
+async def test_not_found_fixture_returns_none():
+    # A real-shaped Search.aspx page with no lblDescription span → None (no guess).
+    resp = _resp(_fixture("notfound.html"))
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
+        assert await partsurfer_resolver.fetch_partsurfer_description("ZZZNOTAPART999") is None
+
+
+@pytest.mark.asyncio
+async def test_non_200_returns_none():
+    resp = _resp(_fixture("dimm_726719-B21.html"), status_code=503)
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
+        assert await partsurfer_resolver.fetch_partsurfer_description("726719-B21") is None
+
+
+@pytest.mark.asyncio
+async def test_http_error_is_swallowed_to_none():
+    # ANY httpx error must be caught and returned as None — never raised into the worker.
+    boom = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=boom):
+        assert await partsurfer_resolver.fetch_partsurfer_description("726719-B21") is None
+
+
+@pytest.mark.asyncio
+async def test_empty_lbldescription_returns_none():
+    # The span is present but empty/whitespace → None (an empty string is not a description).
+    resp = _resp('<span id="ctl00_BodyContentPlaceHolder_lblDescription">   </span>')
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
+        assert await partsurfer_resolver.fetch_partsurfer_description("726719-B21") is None
+
+
+@pytest.mark.asyncio
+async def test_blank_spare_pn_returns_none_without_fetching():
+    # A blank spare can't be looked up — short-circuit, no HTTP call.
+    get = AsyncMock()
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=get):
+        assert await partsurfer_resolver.fetch_partsurfer_description("  ") is None
+    get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unescapes_html_entities_in_description():
+    resp = _resp('<span id="ctl00_BodyContentPlaceHolder_lblDescription">HPE 2.5&quot; SFF &amp; LFF</span>')
+    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
+        desc = await partsurfer_resolver.fetch_partsurfer_description("123456-B21")
+    assert desc == 'HPE 2.5" SFF & LFF'


### PR DESCRIPTION
## What
A polite **direct-HTTP PartSurfer** path that categorizes the ~70k uncategorized HP/HPE spare cards by feeding HPE's own verbatim part **description** into the existing desc-grammar.

## Why this shape (feasibility-driven)
The approved "OEM direct-HTTP option (c)" was scoped to canonical-MPN crosswalk. A live spike showed **PartSurfer's "Product Number" just echoes the spare** (e.g. `726719-B21` → `726719-B21`), so the resolver's no-echo gate would `no_match` nearly every HP spare — canonical crosswalk is a dead end for HP (this is also *why* the old LLM `web_search` resolver scored 0/16). The reliable win is the **description** (`726719-B21` → "HPE 16GB DUAL RANK X4 **DDR4-2133** … REGISTERED MEMORY KIT"), which the `desc_parse` grammar turns into category + facets. Lenovo is **deferred** — its canonical `support.lenovo.com/partslookup` host is network-unreachable from this env (needs an egress fix, then a re-spike).

## How
- **`partsurfer_resolver.py`** — `fetch_partsurfer_description()`: one GET of `Search.aspx?SearchText={spare}` (robots-allowed; only `/WebResource.axd` is disallowed) via the shared `http_redirect` client, honest contact UA, 12s timeout. Returns the verbatim description, `None` on a genuine no-result, or **raises `PartSurferTransient`** on `429`/`5xx`/transport so the caller backs off.
- **Worker pass** (`_partsurfer_desc_pass`, gated by `partsurfer_desc_enabled`, default **on**) — for still-**uncategorized** HP cards (`classify_oem_vendor == "hpe"`), deduped by spare, capped at `partsurfer_fetch_per_batch` (5), **1 req / 2s**, placed after the deterministic passes. Feeds the description into `categorize_and_record(source="partsurfer_desc")` (fill-only, per-card SAVEPOINT). A throttle signal aborts the rest of the batch; a single failing card is isolated (`failed` counter), never aborting the pass.
- **New `partsurfer_desc` SOURCE_TIER = 84** — the OEM's authoritative description outranks the card's own `desc_parse` (83), loses to the deterministic decoders (`mpn_decode` 85). No new migration (096 CASE snapshot synced for its key-for-key test; runtime tier is Python `tier_for()`).

## Tests
26 unit/DB tests from **real captured PartSurfer fixtures** (DIMM + SSD) + the negative/no-result paths, the tier ladder (beats 83 / loses 85), fill-only no-op, dedupe, cap, the **1-req/2s pacing assertion**, the outbound URL+UA contract, transient-abort, per-card isolation, and the `run_one_batch` flag gate. Regression suites green; ruff + pre-commit clean.

## Deferred follow-ups (noted, not blocking)
- Durable negative marker for spares whose description the grammar can't categorize (today bounded by the 22h/N-day retry backoff — re-fetches a free GET on permanently-ungrammatical spares).
- Lenovo PartSurfer/partslookup once egress to `support.lenovo.com` is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)