### PR TITLE
simplify(app): de-duplicate top-level app modules

### DIFF
--- a/app/company_utils.py
+++ b/app/company_utils.py
@@ -3,6 +3,19 @@
 from .vendor_utils import normalize_vendor_name as normalize_company_name
 
 
+def _auto_keep_rank(company: dict) -> tuple[int, int, int, int]:
+    """Sort key for the auto-keep heuristic (higher wins).
+
+    Priority: more sites → has account owner → is strategic → lower id (older record).
+    """
+    return (
+        company["site_count"],
+        int(company["has_owner"]),
+        int(company["is_strategic"]),
+        -company["id"],
+    )
+
+
 def find_company_dedup_candidates(db, threshold: int = 85, limit: int = 50) -> list[dict]:
     """Find potential duplicate companies using fuzzy name matching.
 
@@ -51,24 +64,13 @@ def find_company_dedup_candidates(db, threshold: int = 85, limit: int = 50) -> l
                 }
             )
 
-    seen_pairs: set[tuple] = set()
     candidates = []
 
     for i, a in enumerate(enriched):
         for b in enriched[i + 1 :]:
-            pair_key = (min(a["id"], b["id"]), max(a["id"], b["id"]))
-            if pair_key in seen_pairs:  # pragma: no cover
-                continue
-
             score = fuzz.token_sort_ratio(a["norm"], b["norm"])
             if score >= threshold:
-                seen_pairs.add(pair_key)
-
-                # Auto-keep heuristic
-                def _rank(x):
-                    return (x["site_count"], int(x["has_owner"]), int(x["is_strategic"]), -x["id"])
-
-                auto_keep = a if _rank(a) >= _rank(b) else b
+                auto_keep = a if _auto_keep_rank(a) >= _auto_keep_rank(b) else b
 
                 candidates.append(
                     {

--- a/app/config.py
+++ b/app/config.py
@@ -339,9 +339,7 @@ class Settings(BaseSettings):
         if isinstance(self.stock_sale_notify_emails, str):
             object.__setattr__(self, "stock_sale_notify_emails", _csv_to_list(self.stock_sale_notify_emails))
         if isinstance(self.own_domains, str):
-            object.__setattr__(
-                self, "own_domains", frozenset(d.strip().lower() for d in self.own_domains.split(",") if d.strip())
-            )
+            object.__setattr__(self, "own_domains", frozenset(_csv_to_list(self.own_domains)))
         return self
 
 

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -17,7 +17,7 @@ Depends on: models, database, config
 """
 
 import hmac
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from fastapi import Depends, HTTPException, Request
 from loguru import logger
@@ -26,6 +26,10 @@ from sqlalchemy.orm import Session, selectinload
 from .constants import UserRole
 from .database import get_db
 from .models import Quote, Requisition, User
+
+# Non-interactive service account seeded by startup.py. It authenticates via the
+# x-agent-key header and is barred from admin/settings/buyer (RFQ) endpoints.
+_AGENT_EMAIL = "agent@availai.local"
 
 # ── Authentication ────────────────────────────────────────────────────
 
@@ -53,9 +57,9 @@ def require_user(request: Request, db: Session = Depends(get_db)) -> User:
         agent_key = request.headers.get("x-agent-key")
         if agent_key and settings.agent_api_key and hmac.compare_digest(agent_key, settings.agent_api_key):
             logger.info("Agent API access: method={} path={}", request.method, request.url.path)
-            user = db.query(User).filter_by(email="agent@availai.local").first()
+            user = db.query(User).filter_by(email=_AGENT_EMAIL).first()
             if not user:
-                logger.error("Agent API key valid but agent@availai.local user not found in DB — seed it first")
+                logger.error("Agent API key valid but {} user not found in DB — seed it first", _AGENT_EMAIL)
                 raise HTTPException(503, "Agent user not provisioned")
     if not user:
         raise HTTPException(401, "Not authenticated")
@@ -70,24 +74,38 @@ def is_admin(user: User) -> bool:
     return bool(user.role == UserRole.ADMIN)
 
 
+def _require_admin_user(request: Request, db: Session, *, agent_msg: str, role_msg: str) -> User:
+    """Resolve an admin-only user, blocking the agent service account.
+
+    Raises 403 with *agent_msg* if the caller is the agent account, or *role_msg* if the
+    caller is not an admin.
+    """
+    user = require_user(request, db)
+    if user.email == _AGENT_EMAIL:
+        raise HTTPException(403, agent_msg)
+    if user.role != UserRole.ADMIN:
+        raise HTTPException(403, role_msg)
+    return user
+
+
 def require_admin(request: Request, db: Session = Depends(get_db)) -> User:
     """Dependency: raises 403 if user is not an admin. Blocks agent service account."""
-    user = require_user(request, db)
-    if user.email == "agent@availai.local":
-        raise HTTPException(403, "Agent keys cannot access admin endpoints")
-    if user.role != UserRole.ADMIN:
-        raise HTTPException(403, "Admin access required")
-    return user
+    return _require_admin_user(
+        request,
+        db,
+        agent_msg="Agent keys cannot access admin endpoints",
+        role_msg="Admin access required",
+    )
 
 
 def require_settings_access(request: Request, db: Session = Depends(get_db)) -> User:
     """Dependency: allows admin only. Blocks agent service account."""
-    user = require_user(request, db)
-    if user.email == "agent@availai.local":
-        raise HTTPException(403, "Agent keys cannot access settings")
-    if user.role != UserRole.ADMIN:
-        raise HTTPException(403, "Settings access required")
-    return user
+    return _require_admin_user(
+        request,
+        db,
+        agent_msg="Agent keys cannot access settings",
+        role_msg="Settings access required",
+    )
 
 
 # Roles allowed through require_buyer. Single source of truth — templates that hide
@@ -170,26 +188,18 @@ async def require_fresh_token(request: Request, db: Session = Depends(get_db)) -
     if not token:
         raise HTTPException(401, "No access token — please log in")
 
-    # Check if token needs refresh (15-min buffer)
-    needs_refresh = False
+    # The background scheduler job (_job_token_refresh) refreshes proactively within the
+    # 15-min buffer, so the only failure case to handle inline is a truly-expired token
+    # (background job missed it or no refresh token) — everything else uses the DB token.
     if user.token_expires_at:
         expiry = (
             user.token_expires_at
             if user.token_expires_at.tzinfo
             else user.token_expires_at.replace(tzinfo=timezone.utc)
         )
-        if datetime.now(timezone.utc) > expiry - timedelta(minutes=15):
-            needs_refresh = True
-
-    if needs_refresh:
-        # Background scheduler job refreshes tokens proactively.
-        # If within buffer but not expired, continue with current token.
         if datetime.now(timezone.utc) > expiry:
-            # Truly expired — background job missed it or no refresh token
             user.m365_connected = False
             db.commit()
             raise HTTPException(401, "Session expired — please log in again")
-        # Within buffer, not yet expired — use current token
-        return str(token)
 
     return str(token)

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -213,6 +213,7 @@ async def send_batch_rfq(
             else:
                 err_detail = str(send_result.get("detail", ""))
                 logger.error(f"Send failed to {email}: {send_result}")
+            per_req_parts = _per_req_parts(group)
             failed_contacts: list[Contact] = []
             try:
                 with db.begin_nested():
@@ -229,13 +230,13 @@ async def send_batch_rfq(
                             "failed",
                             err_detail[:500],
                         )
-                        for rid, parts in _per_req_parts(group)
+                        for rid, parts in per_req_parts
                     ]
             except Exception:
                 logger.error(
                     "Contact tracking failed for vendor '{}' (requisitions {}) on the failed-send path",
                     group["vendor_name"],
-                    [rid for rid, _ in _per_req_parts(group)],
+                    [rid for rid, _ in per_req_parts],
                     exc_info=True,
                 )
             results.append(
@@ -249,6 +250,7 @@ async def send_batch_rfq(
             )
             continue
 
+        per_req_parts = _per_req_parts(group)
         try:
             with db.begin_nested():
                 contacts = [
@@ -263,7 +265,7 @@ async def send_batch_rfq(
                         group["body"],
                         "sent",
                     )
-                    for rid, parts in _per_req_parts(group)
+                    for rid, parts in per_req_parts
                 ]
         except Exception:
             # The email WAS delivered — report a tracking error for this vendor
@@ -271,7 +273,7 @@ async def send_batch_rfq(
             logger.error(
                 "Contact tracking failed for vendor '{}' (requisitions {}) — RFQ email was already sent",
                 group["vendor_name"],
-                [rid for rid, _ in _per_req_parts(group)],
+                [rid for rid, _ in per_req_parts],
                 exc_info=True,
             )
             results.append(
@@ -454,12 +456,13 @@ def _scope_thread_contacts_to_sender(thread_contacts: list[Contact], sender_emai
         ]
         if domain_matches:
             return domain_matches
-    if len({(c.vendor_contact or "").lower() for c in thread_contacts}) == 1:
+    distinct_vendor_emails = {(c.vendor_contact or "").lower() for c in thread_contacts}
+    if len(distinct_vendor_emails) == 1:
         return list(thread_contacts)
     logger.warning(
         "Tier-1 thread match dropped: sender {} matches none of the {} vendors on the conversation",
         sender,
-        len({(c.vendor_contact or "").lower() for c in thread_contacts}),
+        len(distinct_vendor_emails),
     )
     return []
 
@@ -1016,7 +1019,7 @@ def _progress_contact_status(contact: Contact, vr: VendorResponse, db: Session):
         contact.status = "quoted"
     elif classification == "no_stock":
         contact.status = "declined"
-    elif classification in ("ooo_bounce",):
+    elif classification == "ooo_bounce":
         contact.status = "pending"  # Will need re-follow-up
     elif classification in (
         "clarification_needed",
@@ -1322,10 +1325,9 @@ def _auto_create_offers_from_parse(vr: VendorResponse, parsed: dict, db: Session
     from .search_service import resolve_material_card
     from .utils.normalization import normalize_mpn_key
 
-    req_obj = db.get(Requisition, vr.requisition_id)
     mpn_to_req_id: dict[str, int] = {}
     mpn_to_card_id: dict[str, int] = {}
-    if req_obj:
+    if req:
         for r in db.query(Requirement).filter(Requirement.requisition_id == vr.requisition_id).all():
             if r.primary_mpn:
                 key = normalize_mpn_key(r.primary_mpn) or r.primary_mpn.upper().strip()
@@ -1471,8 +1473,6 @@ def _auto_create_offers_from_parse(vr: VendorResponse, parsed: dict, db: Session
     # Publish SSE event so sightings page refreshes for affected requirements
     if owner_id:
         try:
-            import asyncio
-
             from .services.sse_broker import broker
 
             affected_req_ids = set(mpn_to_req_id.values())

--- a/app/enrichment_service.py
+++ b/app/enrichment_service.py
@@ -269,14 +269,15 @@ async def _explorium_find_company(domain: str, name: str = "") -> Optional[dict]
 
     Returns normalized company data.
     """
-    if not get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY"):
+    api_key = get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY")
+    if not api_key:
         logger.debug("Explorium API key not configured — skipping")
         return None
     try:
         resp = await http.post(
             f"{EXPLORIUM_BASE}/match/business",
             headers={
-                "Authorization": f"Bearer {get_credential_cached('explorium_enrichment', 'EXPLORIUM_API_KEY')}",
+                "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
             },
             json={"domain": domain, "name": name},
@@ -309,7 +310,8 @@ async def _explorium_find_company(domain: str, name: str = "") -> Optional[dict]
 
 async def _explorium_find_contacts(domain: str, title_filter: str = "") -> list[dict]:
     """Find contacts at a company via Explorium."""
-    if not get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY"):
+    api_key = get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY")
+    if not api_key:
         return []
     try:
         payload = {"company_domain": domain}
@@ -318,7 +320,7 @@ async def _explorium_find_contacts(domain: str, title_filter: str = "") -> list[
         resp = await http.post(
             f"{EXPLORIUM_BASE}/fetch/prospects",
             headers={
-                "Authorization": f"Bearer {get_credential_cached('explorium_enrichment', 'EXPLORIUM_API_KEY')}",
+                "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
             },
             json=payload,
@@ -602,25 +604,23 @@ def apply_enrichment_to_company(company, data: dict) -> list[str]:
     Returns list of fields updated.
     """
     updated = []
-    field_map = {
-        "domain": "domain",
-        "linkedin_url": "linkedin_url",
-        "legal_name": "legal_name",
-        "industry": "industry",
-        "employee_size": "employee_size",
-        "hq_city": "hq_city",
-        "hq_state": "hq_state",
-        "hq_country": "hq_country",
-    }
-    for data_key, model_field in field_map.items():
-        val = data.get(data_key)
-        if val and not getattr(company, model_field, None):
-            setattr(company, model_field, val)
-            updated.append(model_field)
-    # Website: only set if empty
-    if data.get("website") and not company.website:
-        company.website = data["website"]
-        updated.append("website")
+    # Each field is set only when present in `data` and currently empty on the model.
+    fields = (
+        "domain",
+        "linkedin_url",
+        "legal_name",
+        "industry",
+        "employee_size",
+        "hq_city",
+        "hq_state",
+        "hq_country",
+        "website",
+    )
+    for field in fields:
+        val = data.get(field)
+        if val and not getattr(company, field, None):
+            setattr(company, field, val)
+            updated.append(field)
     if updated:
         company.last_enriched_at = datetime.now(timezone.utc)
         company.enrichment_source = data.get("source", "unknown")
@@ -633,27 +633,23 @@ def apply_enrichment_to_vendor(card, data: dict) -> list[str]:
     Returns list of fields updated.
     """
     updated = []
-    field_map = {
-        "linkedin_url": "linkedin_url",
-        "legal_name": "legal_name",
-        "industry": "industry",
-        "employee_size": "employee_size",
-        "hq_city": "hq_city",
-        "hq_state": "hq_state",
-        "hq_country": "hq_country",
-    }
-    for data_key, model_field in field_map.items():
-        val = data.get(data_key)
-        if val and not getattr(card, model_field, None):
-            setattr(card, model_field, val)
-            updated.append(model_field)
-    # Domain: only set if empty
-    if data.get("domain") and not card.domain:
-        card.domain = data["domain"]
-        updated.append("domain")
-    if data.get("website") and not card.website:
-        card.website = data["website"]
-        updated.append("website")
+    # Each field is set only when present in `data` and currently empty on the model.
+    fields = (
+        "linkedin_url",
+        "legal_name",
+        "industry",
+        "employee_size",
+        "hq_city",
+        "hq_state",
+        "hq_country",
+        "domain",
+        "website",
+    )
+    for field in fields:
+        val = data.get(field)
+        if val and not getattr(card, field, None):
+            setattr(card, field, val)
+            updated.append(field)
     if updated:
         card.last_enriched_at = datetime.now(timezone.utc)
         card.enrichment_source = data.get("source", "unknown")

--- a/app/evidence_tiers.py
+++ b/app/evidence_tiers.py
@@ -30,12 +30,9 @@ def tier_for_sighting(source_type: str | None, is_authorized: bool) -> str:
 
     src = (source_type or "").lower().strip()
 
-    if src in _AUTHORIZED_SOURCES:
-        # DigiKey/Mouser/Element14 results that aren't flagged authorized
-        # still come from reliable structured APIs
-        return "T2"
-
-    if src in _API_SOURCES:
+    # DigiKey/Mouser/Element14 results that aren't flagged authorized still come
+    # from reliable structured APIs, same trust level as the direct API connectors.
+    if src in _AUTHORIZED_SOURCES or src in _API_SOURCES:
         return "T2"
 
     if src in _MARKETPLACE_SOURCES:

--- a/app/file_utils.py
+++ b/app/file_utils.py
@@ -217,6 +217,20 @@ LEAD_TIME_HEADERS = {"lead_time", "lead time", "leadtime", "lt", "delivery", "av
 CURRENCY_HEADERS = {"currency", "curr", "ccy"}
 
 
+def _first_header_value(norm: dict, headers: set) -> str | None:
+    """Return the first non-empty value in *norm* whose key is in *headers*."""
+    for h in headers:
+        if h in norm and norm[h]:
+            return norm[h]
+    return None
+
+
+def _first_header_str(norm: dict, headers: set) -> str | None:
+    """Like ``_first_header_value`` but stripped to a string (None if no match)."""
+    raw = _first_header_value(norm, headers)
+    return str(raw).strip() if raw is not None else None
+
+
 def normalize_stock_row(r: dict) -> dict | None:
     """Extract mpn/qty/price/manufacturer/condition/packaging/date_code/lead_time from a
     row.
@@ -228,74 +242,21 @@ def normalize_stock_row(r: dict) -> dict | None:
 
     norm = {k.strip().lower(): v for k, v in r.items() if k}
 
-    mpn = None
-    for h in MPN_HEADERS:
-        if h in norm and norm[h]:
-            mpn = str(norm[h]).strip()
-            break
-
+    mpn = _first_header_str(norm, MPN_HEADERS)
     if not mpn or len(mpn) < 3:
         return None
 
-    qty_raw = None
-    for h in QTY_HEADERS:
-        if h in norm and norm[h]:
-            qty_raw = norm[h]
-            break
-    qty = normalize_quantity(qty_raw)
-
-    price_raw = None
-    for h in PRICE_HEADERS:
-        if h in norm and norm[h]:
-            price_raw = norm[h]
-            break
-    price = normalize_price(price_raw)
-
-    mfr = None
-    for h in MFR_HEADERS:
-        if h in norm and norm[h]:
-            mfr = str(norm[h]).strip()
-            break
-
-    condition = None
-    for h in CONDITION_HEADERS:
-        if h in norm and norm[h]:
-            condition = str(norm[h]).strip()
-            break
-
-    packaging = None
-    for h in PACKAGING_HEADERS:
-        if h in norm and norm[h]:
-            packaging = str(norm[h]).strip()
-            break
-
-    date_code = None
-    for h in DATE_CODE_HEADERS:
-        if h in norm and norm[h]:
-            date_code = str(norm[h]).strip()
-            break
-
-    lead_time = None
-    for h in LEAD_TIME_HEADERS:
-        if h in norm and norm[h]:
-            lead_time = str(norm[h]).strip()
-            break
-
-    currency = None
-    for h in CURRENCY_HEADERS:
-        if h in norm and norm[h]:
-            currency = norm[h]
-            break
-    currency = detect_currency(currency or price_raw)
+    price_raw = _first_header_value(norm, PRICE_HEADERS)
+    currency = _first_header_value(norm, CURRENCY_HEADERS)
 
     return {
         "mpn": mpn,
-        "qty": qty,
-        "price": price,
-        "manufacturer": mfr,
-        "condition": condition,
-        "packaging": packaging,
-        "date_code": date_code,
-        "lead_time": lead_time,
-        "currency": currency,
+        "qty": normalize_quantity(_first_header_value(norm, QTY_HEADERS)),
+        "price": normalize_price(price_raw),
+        "manufacturer": _first_header_str(norm, MFR_HEADERS),
+        "condition": _first_header_str(norm, CONDITION_HEADERS),
+        "packaging": _first_header_str(norm, PACKAGING_HEADERS),
+        "date_code": _first_header_str(norm, DATE_CODE_HEADERS),
+        "lead_time": _first_header_str(norm, LEAD_TIME_HEADERS),
+        "currency": detect_currency(currency or price_raw),
     }

--- a/app/http_client.py
+++ b/app/http_client.py
@@ -39,11 +39,8 @@ async def close_clients():
 
     Call from app lifespan shutdown.
     """
-    try:
-        await http.aclose()
-    except RuntimeError as e:
-        logger.debug("http client close RuntimeError (expected during shutdown): {}", e)
-    try:
-        await http_redirect.aclose()
-    except RuntimeError as e:
-        logger.debug("http_redirect client close RuntimeError (expected during shutdown): {}", e)
+    for name, client in (("http", http), ("http_redirect", http_redirect)):
+        try:
+            await client.aclose()
+        except RuntimeError as e:
+            logger.debug("{} client close RuntimeError (expected during shutdown): {}", name, e)

--- a/app/main.py
+++ b/app/main.py
@@ -31,13 +31,12 @@ async def lifespan(app):
     """App startup/shutdown — launches background scheduler."""
     from .startup import run_startup_migrations
 
-    # S1: Fail-fast on default secret key (skip in test mode)
     if not os.environ.get("TESTING"):
+        # S1: Fail-fast on default secret key (skip in test mode)
         if settings.secret_key == "change-me-in-production":
             raise RuntimeError("SESSION_SECRET or SECRET_KEY must be set. See .env.example for required variables.")
 
-    # S2: Warn about missing critical env vars (don't crash — vendor keys are optional)
-    if not os.environ.get("TESTING"):
+        # S2: Warn about missing critical env vars (don't crash — vendor keys are optional)
         missing = []
         if not settings.azure_client_id:
             missing.append("AZURE_CLIENT_ID")
@@ -421,8 +420,6 @@ async def api_version_middleware(request: Request, call_next):
 @app.get("/sw.js", include_in_schema=False)
 async def root_sw():
     """Serve self-destruct service worker at root scope to kill any old SW."""
-    from fastapi.responses import Response
-
     body = (
         "self.addEventListener('install',function(){self.skipWaiting()});\n"
         "self.addEventListener('activate',function(e){e.waitUntil("
@@ -504,8 +501,6 @@ async def health(
         payload["scheduler"] = scheduler_status
         payload["connectors_enabled"] = connectors_enabled
         payload["backup"] = backup_status
-
-    from fastapi.responses import JSONResponse
 
     return JSONResponse(
         content=payload,

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -36,7 +36,15 @@ from .models import (
     Requirement,
     Sighting,
 )
-from .scoring import classify_lead, explain_lead, is_weak_lead, score_sighting, score_sighting_v2, score_unified
+from .scoring import (
+    classify_lead,
+    confidence_color,
+    explain_lead,
+    is_weak_lead,
+    score_sighting,
+    score_sighting_v2,
+    score_unified,
+)
 from .services.activity_service import log_activity
 from .services.credential_service import get_credential, get_credentials_batch
 from .services.fru_matrix_service import get_search_aliases
@@ -347,7 +355,7 @@ def _affinity_match_to_result(match: dict, mpn: str) -> dict:
         "is_material_history": False,
         "is_affinity": True,
         "confidence_pct": conf_pct,
-        "confidence_color": "green" if conf_pct >= 75 else ("amber" if conf_pct >= 50 else "red"),
+        "confidence_color": confidence_color(conf_pct),
         "reasoning": match.get("reasoning", ""),
         "qty_available": None,
         "unit_price": None,
@@ -390,7 +398,7 @@ async def search_requirement(req: Requirement, db: Session) -> dict:
 
     # 48h per-normalized-MPN cooldown. Split into MPNs that need a connector
     # call vs. ones whose MaterialCard.last_searched_at is recent enough.
-    to_search, cached_card_ids = _mpn_cooldown_partition(db, pns, now=now)
+    to_search, _cached_card_ids = _mpn_cooldown_partition(db, pns, now=now)
 
     searched_keys = {normalize_mpn_key(m) for m in to_search if normalize_mpn_key(m)}
     mpn_results: dict[str, str] = {}
@@ -1572,11 +1580,10 @@ async def _fetch_fresh(pns: list[str], db: Session) -> tuple[list[dict], list[di
                 "status": SourceRunStatus.ERROR.value if error else SourceRunStatus.OK.value,
             }
     # Merge with skipped/disabled entries
-    for name, entry in agg.items():
-        source_stats_map[name] = entry
+    source_stats_map.update(agg)
 
     # Cache results for subsequent searches of the same PNs
-    connector_stats = [v for k, v in agg.items()]
+    connector_stats = list(agg.values())
     _set_search_cache(cache_key, out, connector_stats)
 
     return out, list(source_stats_map.values())

--- a/app/startup.py
+++ b/app/startup.py
@@ -9,22 +9,13 @@ Depends on: database.py (engine), models.py (Base)
 """
 
 import os
-import re as _re
 
 from loguru import logger
 from sqlalchemy import text as sqltext
 from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 
 from .database import SessionLocal, engine
-
-_NONALNUM = _re.compile(r"[^a-z0-9]")
-
-
-def _norm_key(raw):
-    """Normalize a string for dedup comparison: lowercase, strip non-alphanumeric."""
-    if not raw:
-        return ""
-    return _NONALNUM.sub("", str(raw).strip().lower())
+from .utils.normalization import normalize_mpn_key as _norm_key
 
 
 def run_startup_migrations() -> None:
@@ -32,8 +23,6 @@ def run_startup_migrations() -> None:
 
     Safe to call on every app boot.
     """
-    import os
-
     # Warn if password login backdoor is active outside test mode
     if os.getenv("ENABLE_PASSWORD_LOGIN", "false").lower() == "true" and not os.getenv("TESTING"):
         logger.critical(
@@ -83,7 +72,6 @@ def _create_default_user_if_env_set() -> None:
     """
     import base64
     import hashlib
-    import os
 
     email = os.environ.get("DEFAULT_USER_EMAIL")
     password = os.environ.get("DEFAULT_USER_PASSWORD")
@@ -126,8 +114,6 @@ def _seed_admin_user_if_env_set(db=None) -> None:
     Called by: run_startup_migrations
     Depends on: User model, SessionLocal
     """
-    import os
-
     email = os.environ.get("SEED_ADMIN_EMAIL", "vinod@trioscs.com")
     name = os.environ.get("SEED_ADMIN_NAME", "Vinod")
 
@@ -449,7 +435,7 @@ def _backfill_normalized_mpn() -> None:
                 ).fetchall()
                 if not rows:
                     break
-                batch = [{"nk": _norm_key(r[1]), "id": r[0]} for r in rows if _norm_key(r[1])]
+                batch = [{"nk": nk, "id": r[0]} for r in rows if (nk := _norm_key(r[1]))]
                 if batch:
                     conn.execute(
                         sqltext("UPDATE requirements SET normalized_mpn = :nk WHERE id = :id"),
@@ -539,7 +525,7 @@ def _backfill_sighting_offer_normalized_mpn() -> None:
                 ).fetchall()
                 if not rows:
                     break
-                batch = [{"nk": _norm_key(r[1]), "id": r[0]} for r in rows if _norm_key(r[1])]
+                batch = [{"nk": nk, "id": r[0]} for r in rows if (nk := _norm_key(r[1]))]
                 if batch:
                     conn.execute(
                         sqltext("UPDATE sightings SET normalized_mpn = :nk WHERE id = :id"),
@@ -571,7 +557,7 @@ def _backfill_sighting_offer_normalized_mpn() -> None:
                 ).fetchall()
                 if not rows:
                     break
-                batch = [{"nk": _norm_key(r[1]), "id": r[0]} for r in rows if _norm_key(r[1])]
+                batch = [{"nk": nk, "id": r[0]} for r in rows if (nk := _norm_key(r[1]))]
                 if batch:
                     conn.execute(
                         sqltext("UPDATE offers SET normalized_mpn = :nk WHERE id = :id"),

--- a/app/vendor_utils.py
+++ b/app/vendor_utils.py
@@ -103,8 +103,6 @@ def normalize_vendor_name(name: str) -> str:
     if not name:
         return ""
     n = name.strip().lower()
-    # Remove trailing comma before suffix
-    n = re.sub(r",\s*$", "", n)
     # Strip suffixes (may need multiple passes)
     for _ in range(3):
         prev = n
@@ -127,7 +125,7 @@ def merge_emails_into_card(card, new_emails: list[str]) -> int:
     """
     if not new_emails:
         return 0
-    existing = set(e.lower() for e in (card.emails or []))
+    existing = {e.lower() for e in (card.emails or [])}
     added = 0
     merged = list(card.emails or [])
     for email in new_emails:


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app`)
12 file(s) changed, 28 simplifications (11 file(s) already clean).

- **`company_utils.py`** — Removed dead seen_pairs dedup set and its always-false membership guard; Hoisted the per-pair _rank closure to a module-level _auto_keep_rank function.
- **`config.py`** — own_domains branch now delegates to the file's own _csv_to_list helper instead of re-implementing strip/lower/empty-filter inline.
- **`dependencies.py`** — Replaced the 4 literal "agent@availai.local" occurrences with a module-level _AGENT_EMAIL constant; Factored the near-identical require_admin / require_settings_access bodies into a shared _require_admin_user helper; Removed dead refresh-buffer branching in require_fresh_token; it never changed the outcome.
- **`email_service.py`** — Removed redundant local `import asyncio` inside the SSE-publish block of `_auto_create_offers_from_parse`; Hoisted repeated `_per_req_parts(group)` calls to a local in both the failed-send and success paths of `send_batch_rfq`; Computed the distinct-vendor-email set once in `_scope_thread_contacts_to_sender`; Dropped the duplicate `Requisition` fetch (`req_obj`) in `_auto_create_offers_from_parse`; Replaced single-element tuple membership `classification in ("ooo_bounce",)` with `== "ooo_bounce"` in `_progress_contact_status`.
- **`enrichment_service.py`** — Cache the Explorium API key in a local instead of calling get_credential_cached twice per request; Replace identity field_map dicts with plain field tuples in both apply_enrichment_to_* functions and fold the special-cased website/domain blocks into the loop.
- **`evidence_tiers.py`** — Merge two consecutive `if src in ...: return "T2"` branches into one condition.
- **`file_utils.py`** — Collapsed 8 copy-paste header-lookup blocks in normalize_stock_row into two local helpers.
- **`http_client.py`** — Collapse two near-identical try/except shutdown blocks in close_clients() into one loop.
- **`main.py`** — Merged two adjacent `if not os.environ.get("TESTING")` guards (S1 secret-key check + S2 missing-env-var warning) into one block; Removed redundant local `from fastapi.responses import Response` inside root_sw(); Removed redundant local `from fastapi.responses import JSONResponse` inside health().
- **`search_service.py`** — Replaced inline nested ternary for confidence_color with the existing scoring.confidence_color() helper; Collapsed a manual dict-merge loop into source_stats_map.update(agg); Replaced redundant dict comprehension with list(agg.values()); Marked the unused cooldown-partition return value as intentionally unused.
- **`startup.py`** — Replaced duplicated _norm_key function + _NONALNUM regex with aliased import of the canonical normalize_mpn_key helper; Collapsed double per-row _norm_key calls in 3 backfill comprehensions to one call via walrus; Removed 3 redundant function-local `import os` statements.
- **`vendor_utils.py`** — Removed a fully redundant trailing-comma `re.sub(r",\s*$", "", n)` in normalize_vendor_name(); Converted `set(e.lower() for e in (card.emails or []))` to a set comprehension in merge_emails_into_card().

_Recorded cross-file follow-ups:_
- `email_service.py`: Cross-file note (NOT applied — outside the target file): _build_html_body, _is_noise_email, and _scope_thread_contacts_to_sender are imported by app/routers/htmx_views.
- `startup.py`: ALTITUDE/cross-file note: _backfill_company_counts and _create_count_triggers each repeat their COUNT(*) subquery inline within a single raw SQL/PL-pgSQL string.
- `enrichment_service.py`: CROSS-FILE: _clean_domain is the cleanest of several inline domain-stripping variants in the repo (customer_enrichment_service.
- `constants.py`: ALTITUDE: No fragile band-aids or special-cases bolted onto shared infra.
- `template_env.py`: Cross-file: the codebase repeats an 'ensure tz-aware datetime' idiom (`dt.
- `logging_config.py`: The is_production check ("availai.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)