### PR TITLE
simplify(routers): de-duplicate route handlers (excl. htmx_views)

### DIFF
--- a/app/routers/_lookup_helpers.py
+++ b/app/routers/_lookup_helpers.py
@@ -7,10 +7,11 @@ Depends on: SQLAlchemy Session, HTTPException
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from ..models.sourcing import Requisition
+from ..models.vendors import VendorCard
+
 
 def get_requisition_or_404(db: Session, req_id: int):
-    from ..models.sourcing import Requisition
-
     req = db.get(Requisition, req_id)
     if not req:
         raise HTTPException(404, "Requisition not found")
@@ -18,8 +19,6 @@ def get_requisition_or_404(db: Session, req_id: int):
 
 
 def get_vendor_card_or_404(db: Session, card_id: int):
-    from ..models.vendors import VendorCard
-
     card = db.get(VendorCard, card_id)
     if not card:
         raise HTTPException(404, "Vendor not found")

--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -15,6 +15,7 @@ Depends on: app/utils/phone_utils.py, app/services/activity_service.py
 
 import time
 from collections import defaultdict
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from loguru import logger
@@ -266,16 +267,9 @@ def get_account_timeline_endpoint(
     if not company:
         raise HTTPException(404, "Company not found")
 
-    from datetime import datetime as dt
-
     from ..services.activity_service import get_account_timeline
 
-    try:
-        df = dt.fromisoformat(date_from) if date_from else None
-        dto = dt.fromisoformat(date_to) if date_to else None
-    except (ValueError, TypeError):
-        raise HTTPException(400, "Invalid date format — expected ISO 8601")
-
+    df, dto = _parse_date_range(date_from, date_to)
     items, total = get_account_timeline(
         db,
         company_id,
@@ -287,12 +281,7 @@ def get_account_timeline_endpoint(
         limit=limit,
         offset=offset,
     )
-    return {
-        "items": [_timeline_item(a) for a in items],
-        "total": total,
-        "limit": limit,
-        "offset": offset,
-    }
+    return _timeline_response(items, total, limit, offset)
 
 
 @router.get("/contact/{site_contact_id}", response_model=ActivityTimelineResponse)
@@ -309,21 +298,13 @@ def get_contact_timeline_endpoint(
     db: Session = Depends(get_db),
 ):
     """Get paginated activity timeline for a site contact."""
-    from ..models import SiteContact
     from ..services.activity_service import get_contact_timeline
 
     contact = db.get(SiteContact, site_contact_id)
     if not contact:
         raise HTTPException(404, "Contact not found")
 
-    from datetime import datetime as dt
-
-    try:
-        df = dt.fromisoformat(date_from) if date_from else None
-        dto = dt.fromisoformat(date_to) if date_to else None
-    except (ValueError, TypeError):
-        raise HTTPException(400, "Invalid date format — expected ISO 8601")
-
+    df, dto = _parse_date_range(date_from, date_to)
     items, total = get_contact_timeline(
         db,
         site_contact_id,
@@ -335,6 +316,21 @@ def get_contact_timeline_endpoint(
         limit=limit,
         offset=offset,
     )
+    return _timeline_response(items, total, limit, offset)
+
+
+def _parse_date_range(date_from: str | None, date_to: str | None) -> tuple[datetime | None, datetime | None]:
+    """Parse ISO 8601 date_from/date_to query params, or raise HTTP 400."""
+    try:
+        df = datetime.fromisoformat(date_from) if date_from else None
+        dto = datetime.fromisoformat(date_to) if date_to else None
+    except (ValueError, TypeError):
+        raise HTTPException(400, "Invalid date format — expected ISO 8601")
+    return df, dto
+
+
+def _timeline_response(items: list[ActivityLog], total: int, limit: int, offset: int) -> dict:
+    """Build the paginated timeline response payload."""
     return {
         "items": [_timeline_item(a) for a in items],
         "total": total,

--- a/app/routers/admin/spec_codes.py
+++ b/app/routers/admin/spec_codes.py
@@ -186,6 +186,12 @@ async def re_resolve(
     spec_code = row.spec_code
     oem = row.oem
 
+    def unresolved(error: bool) -> HTMLResponse:
+        return template_response(
+            "htmx/partials/admin/spec_codes_reresolve_unresolved.html",
+            {"request": request, "spec_code": spec_code, "error": error},
+        )
+
     resolver = SpecCodeResolver(db)
     try:
         # Force a fresh attempt (don't reuse the row we're trying to replace). No
@@ -197,18 +203,12 @@ async def re_resolve(
             "spec_codes: re-resolve failed for pending_id={}",
             pending_id,
         )
-        return template_response(
-            "htmx/partials/admin/spec_codes_reresolve_unresolved.html",
-            {"request": request, "spec_code": spec_code, "error": True},
-        )
+        return unresolved(error=True)
 
     if result.status == "unresolved":
         # Fresh attempt found nothing — leave the original pending row intact. No
         # overwrite, no data loss; the admin can still reject to blacklist it.
-        return template_response(
-            "htmx/partials/admin/spec_codes_reresolve_unresolved.html",
-            {"request": request, "spec_code": spec_code, "error": False},
-        )
+        return unresolved(error=False)
 
     # Fresh resolution succeeded — atomically swap the old row for the new one. The
     # LLM call is already done, so this transaction is short.
@@ -225,9 +225,6 @@ async def re_resolve(
             "spec_codes: re-resolve swap failed for pending_id={}",
             pending_id,
         )
-        return template_response(
-            "htmx/partials/admin/spec_codes_reresolve_unresolved.html",
-            {"request": request, "spec_code": spec_code, "error": True},
-        )
+        return unresolved(error=True)
 
     return HTMLResponse("", status_code=200)

--- a/app/routers/admin/system.py
+++ b/app/routers/admin/system.py
@@ -30,6 +30,11 @@ from ...services.admin_service import get_all_config, get_system_health, set_con
 router = APIRouter(tags=["admin"])
 
 
+def _iso(dt):
+    """Return a datetime as an ISO string, or None if unset."""
+    return dt.isoformat() if dt else None
+
+
 # -- Schemas ---------------------------------------------------------------
 
 
@@ -111,9 +116,9 @@ def api_connector_health(
                 "avg_response_ms": src.avg_response_ms or 0,
                 "total_searches": total,
                 "total_results": total_results,
-                "last_success": src.last_success.isoformat() if src.last_success else None,
+                "last_success": _iso(src.last_success),
                 "last_error": src.last_error,
-                "last_error_at": src.last_error_at.isoformat() if src.last_error_at else None,
+                "last_error_at": _iso(src.last_error_at),
                 "error_count_24h": errors_24h,
             }
         )
@@ -160,17 +165,17 @@ def api_health_dashboard(
                 "source_type": src.source_type,
                 "status": src.status,
                 "is_active": src.is_active,
-                "last_success": src.last_success.isoformat() if src.last_success else None,
+                "last_success": _iso(src.last_success),
                 "last_error": src.last_error,
-                "last_error_at": src.last_error_at.isoformat() if src.last_error_at else None,
+                "last_error_at": _iso(src.last_error_at),
                 "error_count_24h": src.error_count_24h or 0,
                 "avg_response_ms": src.avg_response_ms or 0,
                 "total_searches": src.total_searches or 0,
                 "monthly_quota": quota,
                 "calls_this_month": calls,
                 "usage_pct": usage_pct,
-                "last_ping_at": src.last_ping_at.isoformat() if src.last_ping_at else None,
-                "last_deep_test_at": src.last_deep_test_at.isoformat() if src.last_deep_test_at else None,
+                "last_ping_at": _iso(src.last_ping_at),
+                "last_deep_test_at": _iso(src.last_deep_test_at),
                 "recent_checks": checks["total"],
                 "recent_failures": checks["failures"],
             }
@@ -250,10 +255,9 @@ def api_set_credentials(
         value = (value or "").strip()
         if value:
             creds[var_name] = encrypt_value(value)
-            updated.append(var_name)
         else:
             creds.pop(var_name, None)
-            updated.append(var_name)
+        updated.append(var_name)
     src.credentials = creds
     db.commit()
     logger.info(f"Credentials updated for {src.name} by {user.email}: {updated}")
@@ -349,7 +353,7 @@ def api_material_audit(
                 "new_card_id": e.new_card_id,
                 "normalized_mpn": e.normalized_mpn,
                 "details": e.details,
-                "created_at": e.created_at.isoformat() if e.created_at else None,
+                "created_at": _iso(e.created_at),
                 "created_by": e.created_by,
             }
             for e in entries

--- a/app/routers/ai.py
+++ b/app/routers/ai.py
@@ -89,7 +89,6 @@ def _build_vendor_history(vendor_name: str, db: Session) -> dict:
 
     from sqlalchemy import func
 
-    # Single combined query for rfq count, offer count, and last contact date
     safe_vendor = escape_like(vendor_name)
     total_rfqs = (
         db.query(func.count(Contact.id))
@@ -100,7 +99,6 @@ def _build_vendor_history(vendor_name: str, db: Session) -> dict:
         .scalar()
     ) or 0
 
-    # Combine offer count + last contact into parallel-style queries
     total_offers = (db.query(func.count(Offer.id)).filter(Offer.vendor_name.ilike(f"%{safe_vendor}%")).scalar()) or 0
 
     last_contact_date = (
@@ -114,6 +112,15 @@ def _build_vendor_history(vendor_name: str, db: Session) -> dict:
         "avg_response_hours": card.response_velocity_hours,
         "engagement_score": card.engagement_score,
     }
+
+
+def _rfq_context_for_requisition(db: Session, user: User, requisition_id: int) -> list[dict]:
+    """Build {mpn, qty} RFQ context for a requisition, or 404 if not visible to user."""
+    req = get_req_for_user(db, user, requisition_id, options=[])
+    if not req:
+        raise HTTPException(404, "Requisition not found")
+    reqs = db.query(Requirement).filter(Requirement.requisition_id == requisition_id).all()
+    return [{"mpn": r.primary_mpn, "qty": r.target_qty or 1} for r in reqs if r.primary_mpn]
 
 
 # ── Feature 1: Contact Enrichment ────────────────────────────────────────
@@ -157,10 +164,6 @@ async def ai_find_contacts(
             vendor_card_id = card.id
 
     if not company_name:
-        # No company resolved from entity_type/entity_id — will fail below
-        pass
-
-    if not company_name:
         raise HTTPException(400, "company_name or entity_id required")
 
     from app.services.ai_service import enrich_contacts_websearch
@@ -180,7 +183,7 @@ async def ai_find_contacts(
     for c in merged:
         for field, max_len in _MAX_LEN.items():
             val = c.get(field)
-            if val and isinstance(val, str) and len(val) > max_len:
+            if isinstance(val, str) and len(val) > max_len:
                 c[field] = val[:max_len]
 
     saved_ids = []
@@ -451,7 +454,6 @@ async def ai_generate_description_for_requirement(
     db: Session = Depends(get_db),
 ):
     """Generate and save a verified description for an existing requirement."""
-    from ..models import Requirement
     from ..services.description_service import generate_verified_description
 
     req = db.get(Requirement, requirement_id)
@@ -672,11 +674,7 @@ async def ai_intake_parse(
 
     rfq_context = None
     if requisition_id:
-        req = get_req_for_user(db, user, requisition_id, options=[])
-        if not req:
-            raise HTTPException(404, "Requisition not found")
-        reqs = db.query(Requirement).filter(Requirement.requisition_id == requisition_id).all()
-        rfq_context = [{"mpn": r.primary_mpn, "qty": r.target_qty or 1} for r in reqs if r.primary_mpn]
+        rfq_context = _rfq_context_for_requisition(db, user, requisition_id)
 
     from app.services.ai_intake_parser import parse_freeform_intake
 
@@ -722,11 +720,7 @@ async def ai_parse_freeform_offer(
 
     rfq_context = None
     if payload.requisition_id:
-        req = get_req_for_user(db, user, payload.requisition_id, options=[])
-        if not req:
-            raise HTTPException(404, "Requisition not found")
-        reqs = db.query(Requirement).filter(Requirement.requisition_id == payload.requisition_id).all()
-        rfq_context = [{"mpn": r.primary_mpn, "qty": r.target_qty or 1} for r in reqs if r.primary_mpn]
+        rfq_context = _rfq_context_for_requisition(db, user, payload.requisition_id)
 
     from app.services.freeform_parser_service import parse_freeform_offer
 

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -34,6 +34,7 @@ from ..database import get_db
 from ..dependencies import get_user
 from ..http_client import http
 from ..models import User
+from ..rate_limit import limiter
 
 router = APIRouter()
 
@@ -44,8 +45,6 @@ SCOPES = GRAPH_SCOPES
 @router.get("/", response_class=HTMLResponse)
 async def index(request: Request):
     """Redirect root to the HTMX frontend."""
-    from fastapi.responses import RedirectResponse
-
     return RedirectResponse(url="/v2/requisitions", status_code=302)
 
 
@@ -64,9 +63,6 @@ async def login(request: Request):
         }
     )
     return RedirectResponse(f"{AZURE_AUTH}/authorize?{params}")
-
-
-from ..rate_limit import limiter
 
 
 @router.get("/auth/callback")

--- a/app/routers/crm/_helpers.py
+++ b/app/routers/crm/_helpers.py
@@ -13,10 +13,19 @@ from ...services.crm_service import next_quote_number  # noqa: F401
 _PRICED_STATUSES = ["sent", "won", "lost"]
 
 
+def _iso(dt) -> str | None:
+    """Return a datetime as an ISO string, or None if unset."""
+    return dt.isoformat() if dt else None
+
+
+def _float(v) -> float | None:
+    """Return a numeric value as a float, or None if falsy."""
+    return float(v) if v else None
+
+
 def _quote_date_iso(q: Quote) -> str | None:
     """Return the best available date for a quote as an ISO string."""
-    dt = q.sent_at or q.created_at
-    return dt.isoformat() if dt else None
+    return _iso(q.sent_at or q.created_at)
 
 
 def record_changes(
@@ -133,23 +142,23 @@ def quote_to_dict(q: Quote, db=None) -> dict:
         "quote_number": q.quote_number,
         "revision": q.revision,
         "line_items": enriched_items,
-        "subtotal": float(q.subtotal) if q.subtotal else None,
-        "total_cost": float(q.total_cost) if q.total_cost else None,
-        "total_margin_pct": float(q.total_margin_pct) if q.total_margin_pct else None,
+        "subtotal": _float(q.subtotal),
+        "total_cost": _float(q.total_cost),
+        "total_margin_pct": _float(q.total_margin_pct),
         "payment_terms": q.payment_terms,
         "shipping_terms": q.shipping_terms,
         "validity_days": q.validity_days,
         "notes": q.notes,
         "status": q.status,
-        "sent_at": q.sent_at.isoformat() if q.sent_at else None,
+        "sent_at": _iso(q.sent_at),
         "result": q.result,
         "result_reason": q.result_reason,
         "result_notes": q.result_notes,
-        "result_at": q.result_at.isoformat() if q.result_at else None,
-        "won_revenue": float(q.won_revenue) if q.won_revenue else None,
+        "result_at": _iso(q.result_at),
+        "won_revenue": _float(q.won_revenue),
         "created_by": q.created_by.name if q.created_by else None,
-        "created_at": q.created_at.isoformat() if q.created_at else None,
-        "updated_at": q.updated_at.isoformat() if q.updated_at else None,
+        "created_at": _iso(q.created_at),
+        "updated_at": _iso(q.updated_at),
         "is_expired": is_expired,
         "days_until_expiry": days_until_expiry,
     }
@@ -158,7 +167,6 @@ def quote_to_dict(q: Quote, db=None) -> dict:
 def _build_quote_email_html(quote: Quote, to_name: str, company_name: str, user: User) -> str:
     """Build a professional HTML quote email with Trio branding."""
     import html as _html
-    from datetime import timedelta
 
     _esc = _html.escape
 

--- a/app/routers/crm/clone.py
+++ b/app/routers/crm/clone.py
@@ -36,6 +36,7 @@ async def clone_requisition(req_id: int, user: User = Depends(require_user), db:
     )
     db.add(new_req)
     db.flush()
+    cloned_pairs = []  # (old_requirement, new_requirement) for offer remapping after flush
     for r in req.requirements:
         cloned_mpn = normalize_mpn(r.primary_mpn) or r.primary_mpn
         # Dedup substitutes by canonical key
@@ -62,12 +63,13 @@ async def clone_requisition(req_id: int, user: User = Depends(require_user), db:
             notes=r.notes,
         )
         db.add(new_r)
+        cloned_pairs.append((r, new_r))
     db.flush()
-    # Map old requirement IDs → new for offer cloning (batch query)
-    new_reqs = db.query(Requirement).filter(Requirement.requisition_id == new_req.id).all()
-    mpn_to_new_id = {r.primary_mpn: r.id for r in new_reqs}
+    # Map old requirement IDs → new for offer cloning. Keyed on the new (cloned) MPN so
+    # that later requirements sharing an MPN win, matching the prior re-query behavior.
+    mpn_to_new_id = {new_r.primary_mpn: new_r.id for _, new_r in cloned_pairs}
     req_map = {
-        old_r.id: mpn_to_new_id[old_r.primary_mpn] for old_r in req.requirements if old_r.primary_mpn in mpn_to_new_id
+        old_r.id: mpn_to_new_id[old_r.primary_mpn] for old_r, _ in cloned_pairs if old_r.primary_mpn in mpn_to_new_id
     }
     for o in req.offers:
         if o.status in ("active", "selected"):

--- a/app/routers/crm/companies.py
+++ b/app/routers/crm/companies.py
@@ -21,6 +21,45 @@ from ...utils.search_builder import SearchBuilder
 
 router = APIRouter()
 
+_COMPANY_SUFFIXES = re.compile(
+    r"\b(inc\.?|llc\.?|ltd\.?|corp\.?|co\.?|plc\.?|gmbh|ag|sa|s\.?a\.?|"
+    r"s\.?r\.?l\.?|pty\.?|b\.?v\.?|n\.?v\.?|a\.?s\.?|oy|ab|limited|"
+    r"corporation|incorporated|company)\s*$",
+    re.IGNORECASE,
+)
+
+
+def _normalize_company_name(n: str) -> str:
+    """Normalize a company name for duplicate comparison.
+
+    Lowercases, replaces punctuation with spaces, strips legal suffixes (Inc, LLC, Ltd,
+    Corp, etc.), and collapses whitespace.
+    """
+    n = n.strip().lower()
+    n = re.sub(r"[^\w\s]", " ", n)  # punctuation -> space
+    n = _COMPANY_SUFFIXES.sub("", n).strip()
+    return re.sub(r"\s+", " ", n)
+
+
+def _find_company_duplicates(clean: str, db: Session) -> list[dict]:
+    """Return up to 5 active companies whose normalized name matches `clean`."""
+    companies = db.query(Company.id, Company.name).filter(Company.is_active.is_(True)).limit(2000).all()
+    matches = []
+    for c in companies:
+        cn = _normalize_company_name(c.name)
+        if not cn:
+            continue
+        # Exact normalized match
+        if cn == clean:
+            matches.append({"id": c.id, "name": c.name, "match": "exact"})
+        # Containment (one is substring of the other)
+        elif cn in clean or clean in cn:
+            matches.append({"id": c.id, "name": c.name, "match": "similar"})
+        # Prefix match (first 6+ chars match)
+        elif len(clean) >= 6 and len(cn) >= 6 and cn[:6] == clean[:6]:
+            matches.append({"id": c.id, "name": c.name, "match": "similar"})
+    return matches[:5]
+
 
 def _load_company_tags(company_id: int, db: Session) -> list[dict]:
     """Load visible entity tags for a company."""
@@ -244,41 +283,12 @@ async def check_company_duplicate(
     Normalizes to lowercase, strips suffixes (Inc, LLC, Ltd, Corp, etc.), and compares
     for matches.
     """
-    _suffixes = re.compile(
-        r"\b(inc\.?|llc\.?|ltd\.?|corp\.?|co\.?|plc\.?|gmbh|ag|sa|s\.?a\.?|"
-        r"s\.?r\.?l\.?|pty\.?|b\.?v\.?|n\.?v\.?|a\.?s\.?|oy|ab|limited|"
-        r"corporation|incorporated|company)\s*$",
-        re.IGNORECASE,
-    )
-
-    def _normalize(n: str) -> str:
-        n = n.strip().lower()
-        n = re.sub(r"[^\w\s]", " ", n)  # punctuation -> space
-        n = _suffixes.sub("", n).strip()
-        n = re.sub(r"\s+", " ", n)
-        return n
-
-    clean = _normalize(name)
+    clean = _normalize_company_name(name)
     if not clean:
         return {"matches": []}
 
     # Pull all company names (cached at 500 limit, same as list_companies)
-    companies = db.query(Company.id, Company.name).filter(Company.is_active.is_(True)).limit(2000).all()
-    matches = []
-    for c in companies:
-        cn = _normalize(c.name)
-        if not cn:
-            continue
-        # Exact normalized match
-        if cn == clean:
-            matches.append({"id": c.id, "name": c.name, "match": "exact"})
-        # Containment (one is substring of the other)
-        elif cn in clean or clean in cn:
-            matches.append({"id": c.id, "name": c.name, "match": "similar"})
-        # Prefix match (first 6+ chars match)
-        elif len(clean) >= 6 and len(cn) >= 6 and cn[:6] == clean[:6]:
-            matches.append({"id": c.id, "name": c.name, "match": "similar"})
-    return {"matches": matches[:5]}
+    return {"matches": _find_company_duplicates(clean, db)}
 
 
 @router.get("/api/companies/{company_id}")
@@ -417,37 +427,13 @@ async def create_company(
 
     # Duplicate check (unless force=True)
     if not force:
-        _suffixes = re.compile(
-            r"\b(inc\.?|llc\.?|ltd\.?|corp\.?|co\.?|plc\.?|gmbh|ag|sa|s\.?a\.?|"
-            r"s\.?r\.?l\.?|pty\.?|b\.?v\.?|n\.?v\.?|a\.?s\.?|oy|ab|limited|"
-            r"corporation|incorporated|company)\s*$",
-            re.IGNORECASE,
-        )
-
-        def _norm(n: str) -> str:
-            n = n.strip().lower()
-            n = re.sub(r"[^\w\s]", " ", n)
-            n = _suffixes.sub("", n).strip()
-            return re.sub(r"\s+", " ", n)
-
-        query_clean = _norm(clean_name)
+        query_clean = _normalize_company_name(clean_name)
         if query_clean:
-            companies = db.query(Company.id, Company.name).filter(Company.is_active.is_(True)).limit(2000).all()
-            duplicates = []
-            for c in companies:
-                cn = _norm(c.name)
-                if not cn:
-                    continue
-                if cn == query_clean:
-                    duplicates.append({"id": c.id, "name": c.name, "match": "exact"})
-                elif cn in query_clean or query_clean in cn:  # pragma: no cover
-                    duplicates.append({"id": c.id, "name": c.name, "match": "similar"})
-                elif len(query_clean) >= 6 and len(cn) >= 6 and cn[:6] == query_clean[:6]:  # pragma: no cover
-                    duplicates.append({"id": c.id, "name": c.name, "match": "similar"})
+            duplicates = _find_company_duplicates(query_clean, db)
             if duplicates:
                 return JSONResponse(
                     status_code=409,
-                    content={"duplicates": duplicates[:5]},
+                    content={"duplicates": duplicates},
                 )
     # Extract domain from website if no explicit domain
     if not clean_domain and payload.website:

--- a/app/routers/crm/enrichment.py
+++ b/app/routers/crm/enrichment.py
@@ -15,6 +15,22 @@ from ...services.credential_service import get_credential_cached
 router = APIRouter()
 
 
+def _normalize_domain(value: str) -> str:
+    """Strip scheme, www, and any path from a domain/website string."""
+    return value.replace("https://", "").replace("http://", "").replace("www.", "").split("/")[0]
+
+
+def _require_enrichment_provider() -> None:
+    """Raise 503 unless at least one enrichment provider credential is configured."""
+    if not get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY") and not get_credential_cached(
+        "anthropic_ai", "ANTHROPIC_API_KEY"
+    ):
+        raise HTTPException(
+            503,
+            "No enrichment providers configured — set EXPLORIUM_API_KEY or ANTHROPIC_API_KEY in .env",
+        )
+
+
 # ── Enrichment (shared for vendors + customers) ─────────────────────────
 
 
@@ -26,13 +42,7 @@ async def enrich_company(
     db: Session = Depends(get_db),
 ):
     """Enrich a customer company with external data."""
-    if not get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY") and not get_credential_cached(
-        "anthropic_ai", "ANTHROPIC_API_KEY"
-    ):
-        raise HTTPException(
-            503,
-            "No enrichment providers configured — set EXPLORIUM_API_KEY or ANTHROPIC_API_KEY in .env",
-        )
+    _require_enrichment_provider()
     from ...enrichment_service import apply_enrichment_to_company, enrich_entity
 
     company = db.get(Company, company_id)
@@ -40,7 +50,7 @@ async def enrich_company(
         raise HTTPException(404, "Company not found")
     domain = company.domain or company.website or ""
     if domain:
-        domain = domain.replace("https://", "").replace("http://", "").replace("www.", "").split("/")[0]
+        domain = _normalize_domain(domain)
     if payload.domain:
         domain = payload.domain
     if not domain:
@@ -73,13 +83,7 @@ async def enrich_vendor_card(
     db: Session = Depends(get_db),
 ):
     """Enrich a vendor card with external data."""
-    if not get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY") and not get_credential_cached(
-        "anthropic_ai", "ANTHROPIC_API_KEY"
-    ):
-        raise HTTPException(
-            503,
-            "No enrichment providers configured — set EXPLORIUM_API_KEY or ANTHROPIC_API_KEY in .env",
-        )
+    _require_enrichment_provider()
     from ...enrichment_service import apply_enrichment_to_vendor, enrich_entity
 
     card = db.get(VendorCard, card_id)
@@ -87,7 +91,7 @@ async def enrich_vendor_card(
         raise HTTPException(404, "Vendor card not found")
     domain = card.domain or card.website or ""
     if domain:
-        domain = domain.replace("https://", "").replace("http://", "").replace("www.", "").split("/")[0]
+        domain = _normalize_domain(domain)
     if payload.domain:
         domain = payload.domain
     if not domain:
@@ -107,18 +111,12 @@ async def get_suggested_contacts(
     db: Session = Depends(get_db),
 ):
     """Find suggested contacts at a company from enrichment providers."""
-    if not get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY") and not get_credential_cached(
-        "anthropic_ai", "ANTHROPIC_API_KEY"
-    ):
-        raise HTTPException(
-            503,
-            "No enrichment providers configured — set EXPLORIUM_API_KEY or ANTHROPIC_API_KEY in .env",
-        )
+    _require_enrichment_provider()
     from ...enrichment_service import find_suggested_contacts
 
     if not domain:
         raise HTTPException(400, "domain parameter is required")
-    domain = domain.replace("https://", "").replace("http://", "").replace("www.", "").split("/")[0]
+    domain = _normalize_domain(domain)
     contacts = await find_suggested_contacts(domain, name, title)
     return {"domain": domain, "contacts": contacts, "count": len(contacts)}
 

--- a/app/routers/crm/offers.py
+++ b/app/routers/crm/offers.py
@@ -51,6 +51,23 @@ ALLOWED_OFFER_EXTENSIONS = {
 }
 
 
+def _log_offer_status_change(db: Session, offer: Offer, old_status, user: User) -> None:
+    """Emit the standard OFFER_STATUS_CHANGED activity log for an offer transition."""
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_STATUS_CHANGED,
+        requisition_id=offer.requisition_id,
+        user_id=user.id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
+        details={
+            "offer_id": offer.id,
+            "old_status": str(old_status),
+            "new_status": str(offer.status),
+        },
+    )
+
+
 # ── Offers ───────────────────────────────────────────────────────────────
 
 
@@ -129,8 +146,6 @@ async def list_offers(req_id: int, user: User = Depends(require_user), db: Sessi
     groups: dict[int, list] = {}
     for o in offers:
         key = o.requirement_id or 0
-        if key not in groups:
-            groups[key] = []
         atts = [
             {
                 "id": a.id,
@@ -141,7 +156,7 @@ async def list_offers(req_id: int, user: User = Depends(require_user), db: Sessi
             }
             for a in (o.attachments or [])
         ]
-        groups[key].append(
+        groups.setdefault(key, []).append(
             {
                 "id": o.id,
                 "requirement_id": o.requirement_id,
@@ -221,10 +236,8 @@ async def list_offers(req_id: int, user: User = Depends(require_user), db: Sessi
         for ho in hist_query:  # pragma: no cover
             for r in req.requirements:
                 if ho.material_card_id in req_card_map.get(r.id, set()):
-                    if r.id not in hist_by_req:
-                        hist_by_req[r.id] = []
                     is_sub = ho.material_card_id != primary_card_ids.get(r.id)
-                    hist_by_req[r.id].append(
+                    hist_by_req.setdefault(r.id, []).append(
                         {
                             "id": ho.id,
                             "vendor_name": ho.vendor_name,
@@ -344,7 +357,6 @@ async def create_offer(
             _enrich_new_card = (card.id, domain, card.display_name)
     # Resolve material card for this MPN
     from ...search_service import resolve_material_card
-    from ...utils.normalization import normalize_mpn_key
 
     mat_card = resolve_material_card(payload.mpn, db)
 
@@ -650,19 +662,7 @@ async def approve_offer(
     # Offer hook: user approval of a pending offer is user-initiated proof of
     # availability — release the vendor's matching active unavailability records.
     maybe_release_on_offer(db, offer.requirement_id, offer.vendor_name, user)
-    log_activity(
-        db,
-        activity_type=ActivityType.OFFER_STATUS_CHANGED,
-        requisition_id=offer.requisition_id,
-        user_id=user.id,
-        vendor_card_id=offer.vendor_card_id,
-        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
-        details={
-            "offer_id": offer.id,
-            "old_status": str(old_status),
-            "new_status": str(offer.status),
-        },
-    )
+    _log_offer_status_change(db, offer, old_status, user)
     db.commit()
     return {"ok": True, "status": "active"}
 
@@ -688,19 +688,7 @@ async def reject_offer(
     if reason:
         offer.notes = f"{offer.notes or ''}\n[Rejected: {reason}]".strip()
     record_changes(db, "offer", offer_id, user.id, {"status": old_status}, {"status": "rejected"}, ["status"])
-    log_activity(
-        db,
-        activity_type=ActivityType.OFFER_STATUS_CHANGED,
-        requisition_id=offer.requisition_id,
-        user_id=user.id,
-        vendor_card_id=offer.vendor_card_id,
-        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
-        details={
-            "offer_id": offer.id,
-            "old_status": str(old_status),
-            "new_status": str(offer.status),
-        },
-    )
+    _log_offer_status_change(db, offer, old_status, user)
     db.commit()
     return {"ok": True, "status": "rejected"}
 
@@ -728,19 +716,7 @@ async def mark_offer_sold(
     offer.updated_at = datetime.now(timezone.utc)
     offer.updated_by_id = user.id
     record_changes(db, "offer", offer_id, user.id, {"status": old_status}, {"status": "sold"}, ["status"])
-    log_activity(
-        db,
-        activity_type=ActivityType.OFFER_STATUS_CHANGED,
-        requisition_id=offer.requisition_id,
-        user_id=user.id,
-        vendor_card_id=offer.vendor_card_id,
-        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
-        details={
-            "offer_id": offer.id,
-            "old_status": str(old_status),
-            "new_status": str(offer.status),
-        },
-    )
+    _log_offer_status_change(db, offer, old_status, user)
     db.commit()
     return {"ok": True, "status": "sold"}
 
@@ -891,9 +867,6 @@ async def delete_offer_attachment(
         raise HTTPException(404, "Attachment not found")
     # Delete from OneDrive if we have the item ID
     if att.onedrive_item_id and user.access_token:
-        from ...utils.graph_client import GraphClient
-
-        GraphClient(user.access_token)
         try:
             from ...http_client import http
 
@@ -920,22 +893,14 @@ async def browse_onedrive(
     from ...utils.graph_client import GraphClient
 
     gc = GraphClient(user.access_token)
-    if path:
-        data = await gc.get_json(
-            f"/me/drive/root:/{path}:/children",
-            params={
-                "$top": "50",
-                "$select": "id,name,size,file,folder,webUrl,lastModifiedDateTime",
-            },
-        )
-    else:
-        data = await gc.get_json(
-            "/me/drive/root/children",
-            params={
-                "$top": "50",
-                "$select": "id,name,size,file,folder,webUrl,lastModifiedDateTime",
-            },
-        )
+    endpoint = f"/me/drive/root:/{path}:/children" if path else "/me/drive/root/children"
+    data = await gc.get_json(
+        endpoint,
+        params={
+            "$top": "50",
+            "$select": "id,name,size,file,folder,webUrl,lastModifiedDateTime",
+        },
+    )
     if "error" in data:
         raise HTTPException(502, "Failed to browse OneDrive")
     items = data.get("value", [])
@@ -1051,19 +1016,7 @@ async def promote_offer(
     # Offer hook: user promotion of a pending offer is user-initiated proof of
     # availability — release the vendor's matching active unavailability records.
     maybe_release_on_offer(db, offer.requirement_id, offer.vendor_name, user)
-    log_activity(
-        db,
-        activity_type=ActivityType.OFFER_STATUS_CHANGED,
-        requisition_id=offer.requisition_id,
-        user_id=user.id,
-        vendor_card_id=offer.vendor_card_id,
-        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
-        details={
-            "offer_id": offer.id,
-            "old_status": str(old_status),
-            "new_status": str(offer.status),
-        },
-    )
+    _log_offer_status_change(db, offer, old_status, user)
     db.commit()
 
     logger.info(f"Offer {offer_id} promoted T4→T5 by user {user.id}")
@@ -1084,7 +1037,7 @@ async def reject_offer_t4_review(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
-    if offer.status not in ("pending_review",):
+    if offer.status != "pending_review":
         raise HTTPException(400, "Only pending_review offers can be rejected")
 
     require_valid_transition("offer", offer.status, OfferStatus.REJECTED)
@@ -1092,19 +1045,7 @@ async def reject_offer_t4_review(
     offer.status = OfferStatus.REJECTED
     offer.updated_by_id = user.id
     offer.updated_at = datetime.now(timezone.utc)
-    log_activity(
-        db,
-        activity_type=ActivityType.OFFER_STATUS_CHANGED,
-        requisition_id=offer.requisition_id,
-        user_id=user.id,
-        vendor_card_id=offer.vendor_card_id,
-        description=f"Offer {offer.vendor_name} status: {old_status} → {offer.status}",
-        details={
-            "offer_id": offer.id,
-            "old_status": str(old_status),
-            "new_status": str(offer.status),
-        },
-    )
+    _log_offer_status_change(db, offer, old_status, user)
     db.commit()
 
     logger.info(f"Offer {offer_id} rejected by user {user.id}")

--- a/app/routers/crm/quotes.py
+++ b/app/routers/crm/quotes.py
@@ -29,6 +29,45 @@ from ._helpers import (
 router = APIRouter()
 
 
+def _quote_load_options():
+    """Eager-load options for serializing a Quote (customer site, company, site
+    contacts, creator)."""
+    return (
+        joinedload(Quote.customer_site).joinedload(CustomerSite.company),
+        joinedload(Quote.customer_site).joinedload(CustomerSite.site_contacts),
+        joinedload(Quote.created_by),
+    )
+
+
+def _compute_quote_totals(line_items: list[dict]) -> tuple[float, float, float]:
+    """Compute (subtotal, total_cost, total_margin_pct) from quote line items."""
+    total_sell = sum((item.get("qty") or 0) * (item.get("sell_price") or 0) for item in line_items)
+    total_cost = sum((item.get("qty") or 0) * (item.get("cost_price") or 0) for item in line_items)
+    margin_pct = round((total_sell - total_cost) / total_sell * 100, 2) if total_sell > 0 else 0
+    return total_sell, total_cost, margin_pct
+
+
+def _build_revision(old: Quote, user: User) -> Quote:
+    """Mark ``old`` as revised and return a fresh Quote carrying its line items and
+    terms forward at the next revision number."""
+    require_valid_transition("quote", old.status, QuoteStatus.REVISED)
+    old.status = QuoteStatus.REVISED
+    base_number = old.quote_number
+    old.quote_number = f"{base_number}-R{old.revision}"
+    return Quote(
+        requisition_id=old.requisition_id,
+        customer_site_id=old.customer_site_id,
+        quote_number=base_number,
+        revision=old.revision + 1,
+        line_items=old.line_items,
+        payment_terms=old.payment_terms,
+        shipping_terms=old.shipping_terms,
+        validity_days=old.validity_days,
+        notes=old.notes,
+        created_by_id=user.id,
+    )
+
+
 # ── Quotes ───────────────────────────────────────────────────────────────
 
 
@@ -43,11 +82,7 @@ async def get_quote(req_id: int, user: User = Depends(require_user), db: Session
         raise HTTPException(404, "Requisition not found")
     quote = (
         db.query(Quote)
-        .options(
-            joinedload(Quote.customer_site).joinedload(CustomerSite.company),
-            joinedload(Quote.customer_site).joinedload(CustomerSite.site_contacts),
-            joinedload(Quote.created_by),
-        )
+        .options(*_quote_load_options())
         .filter(Quote.requisition_id == req_id)
         .order_by(Quote.revision.desc())
         .first()
@@ -97,11 +132,7 @@ async def list_quotes(req_id: int, user: User = Depends(require_user), db: Sessi
         raise HTTPException(404, "Requisition not found")
     quotes = (
         db.query(Quote)
-        .options(
-            joinedload(Quote.customer_site).joinedload(CustomerSite.company),
-            joinedload(Quote.customer_site).joinedload(CustomerSite.site_contacts),
-            joinedload(Quote.created_by),
-        )
+        .options(*_quote_load_options())
         .filter(Quote.requisition_id == req_id)
         .order_by(Quote.revision.desc())
         .all()
@@ -181,8 +212,7 @@ async def create_quote(
                 )
 
     site = db.get(CustomerSite, req.customer_site_id)
-    total_sell = sum((item.get("qty") or 0) * (item.get("sell_price") or 0) for item in line_items)
-    total_cost = sum((item.get("qty") or 0) * (item.get("cost_price") or 0) for item in line_items)
+    total_sell, total_cost, margin_pct = _compute_quote_totals(line_items)
     from sqlalchemy.exc import IntegrityError
 
     old_status = req.status
@@ -194,7 +224,7 @@ async def create_quote(
             line_items=line_items,
             subtotal=total_sell,
             total_cost=total_cost,
-            total_margin_pct=(round((total_sell - total_cost) / total_sell * 100, 2) if total_sell > 0 else 0),
+            total_margin_pct=margin_pct,
             payment_terms=site.payment_terms if site else None,
             shipping_terms=site.shipping_terms if site else None,
             created_by_id=user.id,
@@ -281,25 +311,12 @@ async def update_quote(
     updates = payload.model_dump(exclude_unset=True)
     if "line_items" in updates:
         quote.line_items = updates.pop("line_items")
-        total_sell = sum((item.get("qty") or 0) * (item.get("sell_price") or 0) for item in (quote.line_items or []))
-        total_cost = sum((item.get("qty") or 0) * (item.get("cost_price") or 0) for item in (quote.line_items or []))
-        quote.subtotal = total_sell
-        quote.total_cost = total_cost
-        quote.total_margin_pct = round((total_sell - total_cost) / total_sell * 100, 2) if total_sell > 0 else 0
+        quote.subtotal, quote.total_cost, quote.total_margin_pct = _compute_quote_totals(quote.line_items or [])
     for field, value in updates.items():
         setattr(quote, field, value)
     db.commit()
     # Eager-load relations for serialization
-    quote = (
-        db.query(Quote)
-        .options(
-            joinedload(Quote.customer_site).joinedload(CustomerSite.company),
-            joinedload(Quote.customer_site).joinedload(CustomerSite.site_contacts),
-            joinedload(Quote.created_by),
-        )
-        .filter(Quote.id == quote.id)
-        .first()
-    )
+    quote = db.query(Quote).options(*_quote_load_options()).filter(Quote.id == quote.id).first()
     return quote_to_dict(quote, db)
 
 
@@ -496,22 +513,7 @@ async def revise_quote(quote_id: int, user: User = Depends(require_user), db: Se
     old = get_quote_for_user(db, user, quote_id)
     if not old:
         raise HTTPException(404, "Quote not found")
-    require_valid_transition("quote", old.status, QuoteStatus.REVISED)
-    old.status = QuoteStatus.REVISED
-    old_number = old.quote_number
-    old.quote_number = f"{old_number}-R{old.revision}"
-    new_quote = Quote(
-        requisition_id=old.requisition_id,
-        customer_site_id=old.customer_site_id,
-        quote_number=old_number,
-        revision=old.revision + 1,
-        line_items=old.line_items,
-        payment_terms=old.payment_terms,
-        shipping_terms=old.shipping_terms,
-        validity_days=old.validity_days,
-        notes=old.notes,
-        created_by_id=user.id,
-    )
+    new_quote = _build_revision(old, user)
     db.add(new_quote)
     db.commit()
     return quote_to_dict(new_quote, db)
@@ -533,22 +535,7 @@ async def reopen_quote(
     if req:
         req.status = RequisitionStatus.REOPENED
     if payload.revise:
-        require_valid_transition("quote", quote.status, QuoteStatus.REVISED)
-        quote.status = QuoteStatus.REVISED
-        old_number = quote.quote_number
-        quote.quote_number = f"{old_number}-R{quote.revision}"
-        new_quote = Quote(
-            requisition_id=quote.requisition_id,
-            customer_site_id=quote.customer_site_id,
-            quote_number=old_number,
-            revision=quote.revision + 1,
-            line_items=quote.line_items,
-            payment_terms=quote.payment_terms,
-            shipping_terms=quote.shipping_terms,
-            validity_days=quote.validity_days,
-            notes=quote.notes,
-            created_by_id=user.id,
-        )
+        new_quote = _build_revision(quote, user)
         db.add(new_quote)
         db.commit()
         return quote_to_dict(new_quote, db)

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -1,6 +1,7 @@
 """Documents API — PDF generation for requisitions and quotes."""
 
 import asyncio
+from collections.abc import Callable
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
@@ -13,6 +14,21 @@ from ..models import User
 from ..rate_limit import limiter
 
 router = APIRouter(tags=["documents"])
+
+
+async def _render_pdf(generator: Callable[[int, Session], bytes], obj_id: int, db: Session, log_label: str) -> bytes:
+    """Run a blocking PDF generator off the event loop, mapping failures to HTTP errors.
+
+    ValueError → 404 (caller passed a known not-found message); anything else → 500.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, generator, obj_id, db)
+    except ValueError as e:
+        raise HTTPException(404, str(e))
+    except Exception as e:
+        logger.error("PDF generation failed for {} {}: {}", log_label, obj_id, e)
+        raise HTTPException(500, "PDF generation failed")
 
 
 @router.get("/api/requisitions/{requisition_id}/pdf")
@@ -30,14 +46,7 @@ async def download_rfq_pdf(
     if not req:
         raise HTTPException(404, "Requisition not found")
 
-    try:
-        loop = asyncio.get_running_loop()
-        pdf_bytes = await loop.run_in_executor(None, generate_rfq_summary_pdf, req.id, db)
-    except ValueError as e:
-        raise HTTPException(404, str(e))
-    except Exception as e:
-        logger.error("PDF generation failed for requisition {}: {}", requisition_id, e)
-        raise HTTPException(500, "PDF generation failed")
+    pdf_bytes = await _render_pdf(generate_rfq_summary_pdf, req.id, db, "requisition")
 
     return Response(
         content=pdf_bytes,
@@ -61,14 +70,7 @@ async def download_quote_pdf(
     if not quote:
         raise HTTPException(404, "Quote not found")
 
-    try:
-        loop = asyncio.get_running_loop()
-        pdf_bytes = await loop.run_in_executor(None, generate_quote_report_pdf, quote.id, db)
-    except ValueError as e:
-        raise HTTPException(404, str(e))
-    except Exception as e:
-        logger.error("PDF generation failed for quote {}: {}", quote_id, e)
-        raise HTTPException(500, "PDF generation failed")
+    pdf_bytes = await _render_pdf(generate_quote_report_pdf, quote.id, db, "quote")
 
     return Response(
         content=pdf_bytes,

--- a/app/routers/error_reports.py
+++ b/app/routers/error_reports.py
@@ -175,6 +175,7 @@ async def submit_trouble_ticket(
 ):
     """Handle submission from trouble ticket form — accepts JSON or form data."""
     content_type = request.headers.get("content-type", "")
+    screenshot_b64 = ua = viewport = error_log = network_log_raw = None
 
     if "application/json" in content_type:
         try:
@@ -196,11 +197,6 @@ async def submit_trouble_ticket(
         form = await request.form()
         description = (form.get("message") or "").strip()
         page_url = form.get("current_url")
-        screenshot_b64 = None
-        ua = None
-        viewport = None
-        error_log = None
-        network_log_raw = None
 
     if not description:
         return HTMLResponse(

--- a/app/routers/excess.py
+++ b/app/routers/excess.py
@@ -57,13 +57,29 @@ from ..services.excess_service import (
 )
 from ..template_env import template_response
 from ..utils.claude_client import claude_text
-from ..utils.claude_errors import ClaudeError, ClaudeUnavailableError
+from ..utils.claude_errors import ClaudeError
 from ..utils.normalization import normalize_mpn_key
 
 router = APIRouter(tags=["excess"])
 
 MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB
 ALLOWED_EXTENSIONS = {".csv", ".tsv", ".xlsx", ".xls"}
+
+
+def _file_extension(filename: str) -> str:
+    """Return the lowercase extension (with dot) of a filename, or '' if none."""
+    if "." not in filename:
+        return ""
+    return "." + filename.rsplit(".", 1)[-1].lower()
+
+
+def _get_line_item_or_404(db: Session, list_id: int, item_id: int) -> ExcessLineItem:
+    """Fetch a line item, verifying it belongs to the given list (404 otherwise)."""
+    get_excess_list(db, list_id)
+    item = db.get(ExcessLineItem, item_id)
+    if not item or item.excess_list_id != list_id:
+        raise HTTPException(404, f"Line item {item_id} not found in list {list_id}")
+    return item
 
 
 # ── HTMX Partials ────────────────────────────────────────────────────
@@ -164,7 +180,7 @@ async def partial_import_preview(
     """Parse uploaded file and render an import preview partial for HTMX."""
     get_excess_list(db, list_id)
     filename = file.filename or ""
-    ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    ext = _file_extension(filename)
     if ext not in ALLOWED_EXTENSIONS:
         raise HTTPException(400, f"Unsupported file type '{ext}'")
     content = await file.read()
@@ -272,9 +288,7 @@ async def api_import_file(
 ):
     """Upload a CSV/TSV/Excel file to bulk-import line items."""
     filename = file.filename or ""
-    ext = ""
-    if "." in filename:
-        ext = "." + filename.rsplit(".", 1)[-1].lower()
+    ext = _file_extension(filename)
 
     if ext not in ALLOWED_EXTENSIONS:
         raise HTTPException(400, f"Unsupported file type '{ext}'. Allowed: {', '.join(sorted(ALLOWED_EXTENSIONS))}")
@@ -304,7 +318,7 @@ async def api_preview_import(
     """Upload a file and return a validation preview (no DB writes)."""
     get_excess_list(db, list_id)
     filename = file.filename or ""
-    ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    ext = _file_extension(filename)
     if ext not in ALLOWED_EXTENSIONS:
         raise HTTPException(400, f"Unsupported file type '{ext}'")
     content = await file.read()
@@ -469,11 +483,7 @@ async def api_update_bid(
         bid = accept_bid(db, bid_id, item_id, list_id)
         return BidResponse.model_validate(bid)
 
-    # Verify ownership chain
-    get_excess_list(db, list_id)
-    item = db.get(ExcessLineItem, item_id)
-    if not item or item.excess_list_id != list_id:
-        raise HTTPException(404, f"Line item {item_id} not found in list {list_id}")
+    _get_line_item_or_404(db, list_id, item_id)
 
     bid = db.get(Bid, bid_id)
     if not bid or bid.excess_line_item_id != item_id:
@@ -588,10 +598,7 @@ async def partial_bid_form(
     db: Session = Depends(get_db),
 ):
     """Render the bid recording form modal."""
-    get_excess_list(db, list_id)
-    item = db.get(ExcessLineItem, item_id)
-    if not item or item.excess_list_id != list_id:
-        raise HTTPException(404, f"Line item {item_id} not found in list {list_id}")
+    item = _get_line_item_or_404(db, list_id, item_id)
     companies = db.query(Company).order_by(Company.name).all()
     return template_response(
         "htmx/partials/excess/bid_form.html",
@@ -614,10 +621,7 @@ async def partial_bid_list(
     db: Session = Depends(get_db),
 ):
     """Render the bid list modal for a line item."""
-    get_excess_list(db, list_id)
-    item = db.get(ExcessLineItem, item_id)
-    if not item or item.excess_list_id != list_id:
-        raise HTTPException(404, f"Line item {item_id} not found in list {list_id}")
+    item = _get_line_item_or_404(db, list_id, item_id)
     bids = list_bids(db, item_id, list_id)
     companies = db.query(Company).order_by(Company.name).all()
     return template_response(
@@ -726,8 +730,6 @@ async def api_polish_email(
             system="You are a professional email editor. Return only the polished email text.",
             max_tokens=1024,
         )
-    except ClaudeUnavailableError:
-        return PolishEmailResponse(text=payload.text)
     except ClaudeError:
         return PolishEmailResponse(text=payload.text)
     return PolishEmailResponse(text=polished.strip() if polished else payload.text)

--- a/app/routers/materials.py
+++ b/app/routers/materials.py
@@ -67,6 +67,27 @@ def _stamp_manual_provenance(card: MaterialCard, fields: list[str]) -> None:
     card.enrichment_provenance = prov
 
 
+def _actor_email(user: User) -> str:
+    """Audit/merge actor label — the user's email, or ``"admin"`` if it's unset."""
+    return user.email if hasattr(user, "email") else "admin"
+
+
+def _backfill_manufacturer(card: MaterialCard, db: Session) -> None:
+    """Fill a card's missing manufacturer from its MPN prefix, committing on a hit.
+
+    Shared by the two single-card read endpoints (by-id and by-mpn) so a card surfaced
+    without a manufacturer gets one inferred lazily on first view.
+    """
+    if card.manufacturer:
+        return
+    inferred = _infer_manufacturer_from_prefix(db, card.normalized_mpn)
+    if inferred:
+        card.manufacturer = inferred
+        db.add(card)
+        db.commit()
+        invalidate_prefix("material_list")
+
+
 def render_add_modal(
     request: Request, *, errors: dict | None = None, values: dict | None = None, status_code: int = 200
 ):
@@ -135,14 +156,14 @@ async def add_material(
             condition = MaterialCondition(condition).value
         except ValueError:
             errors["condition"] = f'"{condition}" is not a valid condition.'
+    values = {
+        "mpn": mpn,
+        "manufacturer": manufacturer,
+        "description": description,
+        "category": category,
+        "condition": condition,
+    }
     if errors:
-        values = {
-            "mpn": mpn,
-            "manufacturer": manufacturer,
-            "description": description,
-            "category": category,
-            "condition": condition,
-        }
         return render_add_modal(request, errors=errors, values=values, status_code=422)
 
     norm = normalize_mpn_key(mpn)
@@ -157,18 +178,7 @@ async def add_material(
         # punctuation-only "MPN" like "---". Re-render the modal like every other 422;
         # a raw HTTPException body would be swapped into #modal-content as JSON text
         # (htmx_app.js force-allows 422 swaps targeted there).
-        return render_add_modal(
-            request,
-            errors={"mpn": "Enter a valid MPN."},
-            values={
-                "mpn": mpn,
-                "manufacturer": manufacturer,
-                "description": description,
-                "category": category,
-                "condition": condition,
-            },
-            status_code=422,
-        )
+        return render_add_modal(request, errors={"mpn": "Enter a valid MPN."}, values=values, status_code=422)
 
     # Manual/100 writes — blank = blank (never default, suggest, or copy values).
     written: list[str] = []
@@ -339,13 +349,7 @@ async def get_material(card_id: int, user: User = Depends(require_user), db: Ses
     card = db.get(MaterialCard, card_id)
     if not card or card.deleted_at is not None:
         raise HTTPException(404, "Material not found")
-    if not card.manufacturer:
-        inferred = _infer_manufacturer_from_prefix(db, card.normalized_mpn)
-        if inferred:
-            card.manufacturer = inferred
-            db.add(card)
-            db.commit()
-            invalidate_prefix("material_list")
+    _backfill_manufacturer(card, db)
     return material_card_to_dict(card, db)
 
 
@@ -381,13 +385,7 @@ async def get_material_by_mpn(mpn: str, user: User = Depends(require_user), db: 
     card = db.query(MaterialCard).filter_by(normalized_mpn=norm).filter(MaterialCard.deleted_at.is_(None)).first()
     if not card:
         raise HTTPException(404, "No material card found for this MPN")
-    if not card.manufacturer:
-        inferred = _infer_manufacturer_from_prefix(db, card.normalized_mpn)
-        if inferred:
-            card.manufacturer = inferred
-            db.add(card)
-            db.commit()
-            invalidate_prefix("material_list")
+    _backfill_manufacturer(card, db)
     return material_card_to_dict(card, db)
 
 
@@ -583,7 +581,7 @@ async def delete_material(card_id: int, user: User = Depends(require_admin), db:
         material_card_id=card.id,
         action="soft_deleted",
         normalized_mpn=card.normalized_mpn,
-        created_by=user.email if hasattr(user, "email") else "admin",
+        created_by=_actor_email(user),
     )
     db.commit()
     invalidate_prefix("material_list")
@@ -606,7 +604,7 @@ async def restore_material(card_id: int, user: User = Depends(require_admin), db
         material_card_id=card.id,
         action="restored",
         normalized_mpn=card.normalized_mpn,
-        created_by=user.email if hasattr(user, "email") else "admin",
+        created_by=_actor_email(user),
     )
     db.commit()
     invalidate_prefix("material_list")
@@ -628,9 +626,7 @@ async def merge_material_cards(
         raise HTTPException(400, "source_card_id and target_card_id are required")
 
     try:
-        result = _merge_material_cards_service(
-            db, source_id, target_id, user.email if hasattr(user, "email") else "admin"
-        )
+        result = _merge_material_cards_service(db, source_id, target_id, _actor_email(user))
     except ValueError as e:
         raise HTTPException(400 if "itself" in str(e) else 404, str(e))
 

--- a/app/routers/proactive.py
+++ b/app/routers/proactive.py
@@ -47,8 +47,7 @@ async def refresh_proactive_matches(
     """Trigger a proactive matching scan."""
     from ..services.proactive_matching import run_proactive_scan
 
-    result = run_proactive_scan(db)
-    return result
+    return run_proactive_scan(db)
 
 
 @router.get("/api/proactive/count")
@@ -278,8 +277,7 @@ async def convert_to_win(
     try:
         from ..services.proactive_service import convert_proactive_to_win
 
-        result = convert_proactive_to_win(db, offer_id, user)
-        return result
+        return convert_proactive_to_win(db, offer_id, user)
     except ValueError as e:
         raise HTTPException(400, str(e))
 
@@ -297,11 +295,8 @@ async def proactive_scorecard(
     from ..dependencies import is_admin as _is_admin
     from ..services.proactive_service import get_scorecard
 
-    is_admin = _is_admin(user)
-    if salesperson_id and not is_admin:
+    if not _is_admin(user):
         salesperson_id = user.id  # Non-admin can only see own
-    if not is_admin and not salesperson_id:
-        salesperson_id = user.id
 
     @cached_endpoint(prefix="proactive_scorecard", ttl_hours=1, key_params=["salesperson_id"])
     def _fetch(salesperson_id, db):

--- a/app/routers/prospect_suggested.py
+++ b/app/routers/prospect_suggested.py
@@ -24,6 +24,7 @@ from ..services.prospect_claim import (
     trigger_deep_enrichment_bg,
 )
 from ..services.prospect_priority import build_priority_snapshot
+from ..services.prospect_scoring import classify_readiness
 from ..utils.async_helpers import safe_background_task
 from ..utils.sql_helpers import escape_like
 
@@ -426,13 +427,7 @@ def _serialize_prospect(p: ProspectAccount) -> dict:
     similar = p.similar_customers or []
     priority = build_priority_snapshot(p)
 
-    # Readiness tier
-    if p.readiness_score >= 70:
-        readiness_tier = "call_now"
-    elif p.readiness_score >= 40:
-        readiness_tier = "nurture"
-    else:
-        readiness_tier = "monitor"
+    readiness_tier = classify_readiness(p.readiness_score or 0)
 
     # Signal summary for card display
     signal_tags = []

--- a/app/routers/quote_builder.py
+++ b/app/routers/quote_builder.py
@@ -20,6 +20,33 @@ from ..schemas.quote_builder import QuoteBuilderSaveRequest
 router = APIRouter(tags=["quote-builder"])
 
 
+def _parse_req_ids(requisition_ids: str) -> list[int]:
+    """Parse a comma-separated requisition-id string into ints.
+
+    Raises HTTP 400 on a malformed value or an empty selection.
+    """
+    try:
+        ids = [int(x.strip()) for x in requisition_ids.split(",") if x.strip()]
+    except ValueError:
+        raise HTTPException(400, "Invalid requisition IDs")
+    if not ids:
+        raise HTTPException(400, "No requisitions selected")
+    return ids
+
+
+def _customer_name_for_site(db: Session, customer_site_id: int | None) -> str:
+    """Resolve the customer company name for a requisition's customer site ("" if
+    none)."""
+    if not customer_site_id:
+        return ""
+    from ..models import CustomerSite
+
+    site = db.get(CustomerSite, customer_site_id)
+    if site and site.company:
+        return site.company.name or ""
+    return ""
+
+
 @router.get("/v2/partials/quote-builder/{req_id}")
 async def quote_builder_modal(
     req_id: int,
@@ -40,15 +67,6 @@ async def quote_builder_modal(
     if not req:
         raise HTTPException(404, "Requisition not found")
 
-    customer_name = ""
-    has_customer_site = bool(req.customer_site_id)
-    if has_customer_site:
-        from ..models import CustomerSite
-
-        site = db.get(CustomerSite, req.customer_site_id)
-        if site and site.company:
-            customer_name = site.company.name or ""
-
     from ..template_env import template_response
 
     return template_response(
@@ -56,8 +74,8 @@ async def quote_builder_modal(
         {
             "request": request,
             "req": req,
-            "customer_name": customer_name,
-            "has_customer_site": has_customer_site,
+            "customer_name": _customer_name_for_site(db, req.customer_site_id),
+            "has_customer_site": bool(req.customer_site_id),
             "requirement_ids": requirement_ids or "",
         },
     )
@@ -77,26 +95,12 @@ async def quote_builder_modal_multi(
     """
     from ..dependencies import get_req_for_user
 
-    try:
-        req_id_list = [int(x.strip()) for x in requisition_ids.split(",") if x.strip()]
-    except ValueError:
-        raise HTTPException(400, "Invalid requisition IDs")
-    if not req_id_list:
-        raise HTTPException(400, "No requisitions selected")
+    req_id_list = _parse_req_ids(requisition_ids)
 
     # Use the first requisition as primary
     primary_req = get_req_for_user(db, user, req_id_list[0])
     if not primary_req:
         raise HTTPException(404, "Requisition not found")
-
-    customer_name = ""
-    has_customer_site = bool(primary_req.customer_site_id)
-    if has_customer_site:
-        from ..models import CustomerSite
-
-        site = db.get(CustomerSite, primary_req.customer_site_id)
-        if site and site.company:
-            customer_name = site.company.name or ""
 
     from ..template_env import template_response
 
@@ -105,8 +109,8 @@ async def quote_builder_modal_multi(
         {
             "request": request,
             "req": primary_req,
-            "customer_name": customer_name,
-            "has_customer_site": has_customer_site,
+            "customer_name": _customer_name_for_site(db, primary_req.customer_site_id),
+            "has_customer_site": bool(primary_req.customer_site_id),
             "requirement_ids": "",
             "multi_req_ids": requisition_ids,
         },
@@ -123,12 +127,7 @@ async def quote_builder_data_multi(
     from ..dependencies import get_req_for_user
     from ..services.quote_builder_service import apply_smart_defaults, get_builder_data
 
-    try:
-        req_id_list = [int(x.strip()) for x in requisition_ids.split(",") if x.strip()]
-    except ValueError:
-        raise HTTPException(400, "Invalid requisition IDs")
-    if not req_id_list:
-        raise HTTPException(400, "No requisitions selected")
+    req_id_list = _parse_req_ids(requisition_ids)
 
     all_lines = []
     for rid in req_id_list:
@@ -249,8 +248,6 @@ async def quote_builder_export_pdf(
 ):
     """Stream a PDF export of a saved quote (reuses existing PDF generator)."""
     import asyncio
-
-    from fastapi.responses import Response
 
     from ..models import Quote
 

--- a/app/routers/requisitions/attachments.py
+++ b/app/routers/requisitions/attachments.py
@@ -26,6 +26,47 @@ from ...models import (
 
 router = APIRouter(tags=["requisitions"])
 
+MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _serialize_attachment(a) -> dict:
+    """Full JSON shape for an attachment list entry."""
+    return {
+        "id": a.id,
+        "file_name": a.file_name,
+        "onedrive_url": a.onedrive_url,
+        "content_type": a.content_type,
+        "size_bytes": a.size_bytes,
+        "uploaded_by": a.uploaded_by.name if a.uploaded_by else None,
+        "created_at": a.created_at.isoformat() if a.created_at else None,
+    }
+
+
+def _attachment_created_response(att) -> dict:
+    """Compact JSON shape returned after creating/linking an attachment."""
+    return {
+        "id": att.id,
+        "file_name": att.file_name,
+        "onedrive_url": att.onedrive_url,
+        "content_type": att.content_type,
+    }
+
+
+async def _delete_onedrive_item(item_id: str, token: str) -> None:
+    """Best-effort DELETE of a OneDrive item; raises HTTPException only on auth
+    errors."""
+    from ...http_client import http
+
+    resp = await http.delete(
+        f"https://graph.microsoft.com/v1.0/me/drive/items/{item_id}",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+    if resp.status_code == 401:
+        raise HTTPException(401, "Microsoft token expired — please re-authenticate")
+    if resp.status_code == 403:
+        raise HTTPException(403, "Access denied to OneDrive item")
+
 
 @router.get("/api/requisitions/{req_id}/attachments")
 async def list_requisition_attachments(
@@ -37,18 +78,7 @@ async def list_requisition_attachments(
     req = get_req_for_user(db, user, req_id)
     if not req:
         raise HTTPException(404, "Requisition not found")
-    return [
-        {
-            "id": a.id,
-            "file_name": a.file_name,
-            "onedrive_url": a.onedrive_url,
-            "content_type": a.content_type,
-            "size_bytes": a.size_bytes,
-            "uploaded_by": a.uploaded_by.name if a.uploaded_by else None,
-            "created_at": a.created_at.isoformat() if a.created_at else None,
-        }
-        for a in req.attachments
-    ]
+    return [_serialize_attachment(a) for a in req.attachments]
 
 
 @router.post("/api/requisitions/{req_id}/attachments")
@@ -63,7 +93,7 @@ async def upload_requisition_attachment(
     if not req:
         raise HTTPException(404, "Requisition not found")
     content = await file.read()
-    if len(content) > 10 * 1024 * 1024:
+    if len(content) > MAX_ATTACHMENT_BYTES:
         raise HTTPException(400, "File too large (max 10 MB)")
     from ...scheduler import get_valid_token
 
@@ -102,12 +132,7 @@ async def upload_requisition_attachment(
     )
     db.add(att)
     db.commit()
-    return {
-        "id": att.id,
-        "file_name": att.file_name,
-        "onedrive_url": att.onedrive_url,
-        "content_type": att.content_type,
-    }
+    return _attachment_created_response(att)
 
 
 @router.post("/api/requisitions/{req_id}/attachments/onedrive")
@@ -152,12 +177,7 @@ async def attach_requisition_from_onedrive(
     )
     db.add(att)
     db.commit()
-    return {
-        "id": att.id,
-        "file_name": att.file_name,
-        "onedrive_url": att.onedrive_url,
-        "content_type": att.content_type,
-    }
+    return _attachment_created_response(att)
 
 
 @router.delete("/api/requisition-attachments/{att_id}")
@@ -177,17 +197,7 @@ async def delete_requisition_attachment(
         if not token:
             raise HTTPException(401, "Microsoft token expired — please re-authenticate")
         try:
-            from ...http_client import http
-
-            resp = await http.delete(
-                f"https://graph.microsoft.com/v1.0/me/drive/items/{att.onedrive_item_id}",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=15,
-            )
-            if resp.status_code == 401:
-                raise HTTPException(401, "Microsoft token expired — please re-authenticate")
-            if resp.status_code == 403:
-                raise HTTPException(403, "Access denied to OneDrive item")
+            await _delete_onedrive_item(att.onedrive_item_id, token)
         except HTTPException:
             raise
         except (ConnectionError, TimeoutError, OSError) as e:
@@ -213,18 +223,7 @@ async def list_requirement_attachments(
     parent_req = get_req_for_user(db, user, requirement.requisition_id)
     if not parent_req:
         raise HTTPException(403, "Not authorized")
-    return [
-        {
-            "id": a.id,
-            "file_name": a.file_name,
-            "onedrive_url": a.onedrive_url,
-            "content_type": a.content_type,
-            "size_bytes": a.size_bytes,
-            "uploaded_by": a.uploaded_by.name if a.uploaded_by else None,
-            "created_at": a.created_at.isoformat() if a.created_at else None,
-        }
-        for a in requirement.attachments
-    ]
+    return [_serialize_attachment(a) for a in requirement.attachments]
 
 
 @router.post("/api/requirements/{req_id}/attachments")
@@ -242,7 +241,7 @@ async def upload_requirement_attachment(
     if not parent_req:
         raise HTTPException(403, "Not authorized")
     content = await file.read()
-    if len(content) > 10 * 1024 * 1024:
+    if len(content) > MAX_ATTACHMENT_BYTES:
         raise HTTPException(400, "File too large (max 10 MB)")
     from ...scheduler import get_valid_token
 
@@ -283,12 +282,7 @@ async def upload_requirement_attachment(
     )
     db.add(att)
     db.commit()
-    return {
-        "id": att.id,
-        "file_name": att.file_name,
-        "onedrive_url": att.onedrive_url,
-        "content_type": att.content_type,
-    }
+    return _attachment_created_response(att)
 
 
 @router.delete("/api/requirement-attachments/{att_id}")
@@ -308,17 +302,7 @@ async def delete_requirement_attachment(
         if not token:
             raise HTTPException(401, "Microsoft token expired — please re-authenticate")
         try:
-            from ...http_client import http
-
-            resp = await http.delete(
-                f"https://graph.microsoft.com/v1.0/me/drive/items/{att.onedrive_item_id}",
-                headers={"Authorization": f"Bearer {token}"},
-                timeout=15,
-            )
-            if resp.status_code == 401:
-                raise HTTPException(401, "Microsoft token expired — please re-authenticate")
-            if resp.status_code == 403:
-                raise HTTPException(403, "Access denied to OneDrive item")
+            await _delete_onedrive_item(att.onedrive_item_id, token)
         except HTTPException:
             raise
         except (ConnectionError, TimeoutError, OSError) as e:

--- a/app/routers/requisitions/core.py
+++ b/app/routers/requisitions/core.py
@@ -387,60 +387,85 @@ def _build_requisition_list(q, status, sort, order, limit, offset, user, db):
         creators = db.query(User.id, User.name, User.email).filter(User.id.in_(creator_ids)).all()
         creator_names = {u.id: u.name or u.email.split("@")[0] for u in creators}
     return {
-        "requisitions": [
-            {
-                "id": r.id,
-                "name": r.name,
-                "status": r.status,
-                "customer_site_id": r.customer_site_id,
-                "company_id": (r.customer_site.company_id if r.customer_site else None),
-                "customer_display": (
-                    f"{r.customer_site.company.name} — {r.customer_site.site_name}"
-                    if r.customer_site and r.customer_site.company
-                    else r.customer_name or ""
-                ),
-                "requirement_count": req_cnt,
-                "contact_count": con_cnt,
-                "reply_count": reply_cnt or 0,
-                "latest_reply_at": latest_reply.isoformat() if latest_reply else None,
-                "has_new_offers": bool(has_new),
-                "latest_offer_at": latest_offer.isoformat() if latest_offer else None,
-                "created_by": r.created_by,
-                "created_by_name": creator_names.get(r.created_by, ""),
-                "created_at": r.created_at.isoformat() if r.created_at else None,
-                "last_searched_at": r.last_searched_at.isoformat() if r.last_searched_at else None,
-                "sourced_count": sourced_cnt or 0,
-                "rfq_sent_count": rfq_sent or 0,
-                "latest_rfq_sent_at": latest_rfq_sent.isoformat() if latest_rfq_sent else None,
-                "cloned_from_id": r.cloned_from_id,
-                "deadline": r.deadline,
-                "needs_review_count": needs_rev or 0,
-                "total_target_value": float(ttv or 0),
-                "quote_status": q_status,
-                "quote_sent_at": q_sent.isoformat() if q_sent else None,
-                "quote_total": float(q_total) if q_total else None,
-                "quote_won_value": float(q_won) if q_won else None,
-                "offer_count": offer_cnt or 0,
-                "best_offer_price": float(best_price) if best_price else None,
-                "awaiting_reply_count": await_cnt or 0,
-                "proactive_match_count": pm_cnt or 0,
-                "claimed_by_id": r.claimed_by_id,
-                "urgency": r.urgency or "normal",
-                "opportunity_value": float(r.opportunity_value) if r.opportunity_value else None,
-                "sourcing_score": _sc,
-                "sourcing_color": _sc_color,
-                "sourcing_signals": _sc_signals,
-            }
-            for r, req_cnt, con_cnt, reply_cnt, latest_reply, has_new, latest_offer, sourced_cnt, rfq_sent, needs_rev, ttv, q_status, q_sent, q_total, q_won, offer_cnt, best_price, await_cnt, pm_cnt, call_cnt, email_act_cnt, latest_rfq_sent in rows
-            for _sc, _sc_color, _sc_signals in [
-                compute_sourcing_score_safe(
-                    req_cnt, sourced_cnt, rfq_sent, reply_cnt, offer_cnt, call_cnt, email_act_cnt
-                )
-            ]
-        ],
+        "requisitions": [_serialize_req_row(row, creator_names) for row in rows],
         "total": total,
         "limit": limit,
         "offset": offset,
+    }
+
+
+def _serialize_req_row(row, creator_names):
+    """Serialize one query row (Requisition + subquery aggregates) into a list-view
+    dict."""
+    (
+        r,
+        req_cnt,
+        con_cnt,
+        reply_cnt,
+        latest_reply,
+        has_new,
+        latest_offer,
+        sourced_cnt,
+        rfq_sent,
+        needs_rev,
+        ttv,
+        q_status,
+        q_sent,
+        q_total,
+        q_won,
+        offer_cnt,
+        best_price,
+        await_cnt,
+        pm_cnt,
+        call_cnt,
+        email_act_cnt,
+        latest_rfq_sent,
+    ) = row
+    score, score_color, score_signals = compute_sourcing_score_safe(
+        req_cnt, sourced_cnt, rfq_sent, reply_cnt, offer_cnt, call_cnt, email_act_cnt
+    )
+    return {
+        "id": r.id,
+        "name": r.name,
+        "status": r.status,
+        "customer_site_id": r.customer_site_id,
+        "company_id": (r.customer_site.company_id if r.customer_site else None),
+        "customer_display": (
+            f"{r.customer_site.company.name} — {r.customer_site.site_name}"
+            if r.customer_site and r.customer_site.company
+            else r.customer_name or ""
+        ),
+        "requirement_count": req_cnt,
+        "contact_count": con_cnt,
+        "reply_count": reply_cnt or 0,
+        "latest_reply_at": latest_reply.isoformat() if latest_reply else None,
+        "has_new_offers": bool(has_new),
+        "latest_offer_at": latest_offer.isoformat() if latest_offer else None,
+        "created_by": r.created_by,
+        "created_by_name": creator_names.get(r.created_by, ""),
+        "created_at": r.created_at.isoformat() if r.created_at else None,
+        "last_searched_at": r.last_searched_at.isoformat() if r.last_searched_at else None,
+        "sourced_count": sourced_cnt or 0,
+        "rfq_sent_count": rfq_sent or 0,
+        "latest_rfq_sent_at": latest_rfq_sent.isoformat() if latest_rfq_sent else None,
+        "cloned_from_id": r.cloned_from_id,
+        "deadline": r.deadline,
+        "needs_review_count": needs_rev or 0,
+        "total_target_value": float(ttv or 0),
+        "quote_status": q_status,
+        "quote_sent_at": q_sent.isoformat() if q_sent else None,
+        "quote_total": float(q_total) if q_total else None,
+        "quote_won_value": float(q_won) if q_won else None,
+        "offer_count": offer_cnt or 0,
+        "best_offer_price": float(best_price) if best_price else None,
+        "awaiting_reply_count": await_cnt or 0,
+        "proactive_match_count": pm_cnt or 0,
+        "claimed_by_id": r.claimed_by_id,
+        "urgency": r.urgency or "normal",
+        "opportunity_value": float(r.opportunity_value) if r.opportunity_value else None,
+        "sourcing_score": score,
+        "sourcing_color": score_color,
+        "sourcing_signals": score_signals,
     }
 
 

--- a/app/routers/requisitions/requirements.py
+++ b/app/routers/requisitions/requirements.py
@@ -85,6 +85,19 @@ def _dedupe_substitutes(subs: list[str], primary_mpn: str) -> list[dict]:
     return deduped
 
 
+def _substitute_keys(requirement: Requirement) -> list[str]:
+    """Return normalized MPN keys for a requirement's substitutes (string or dict
+    form)."""
+    keys = []
+    for sub in requirement.substitutes or []:
+        sub_str = (sub if isinstance(sub, str) else "").strip()
+        if sub_str:
+            sub_key = normalize_mpn_key(sub_str)
+            if sub_key:
+                keys.append(sub_key)
+    return keys
+
+
 def _annotate_buyer_outcomes(req: Requisition, results: dict, db: Session) -> None:
     """Annotate each lead with buyer outcome for quick triage progress.
 
@@ -740,15 +753,9 @@ async def get_saved_sightings(
     req_sub_keys: dict[int, list[str]] = {}
     for r in req.requirements:
         primary_card_ids[r.id] = r.material_card_id
-        sub_keys = []
-        for sub in r.substitutes or []:
-            sub_str = (sub if isinstance(sub, str) else "").strip()
-            if sub_str:
-                sub_key = normalize_mpn_key(sub_str)
-                if sub_key:
-                    sub_keys.append(sub_key)
-                    all_sub_keys.add(sub_key)
+        sub_keys = _substitute_keys(r)
         req_sub_keys[r.id] = sub_keys
+        all_sub_keys.update(sub_keys)
 
     sub_card_lookup: dict[str, int] = {}
     if all_sub_keys:
@@ -1139,13 +1146,7 @@ async def list_requirement_sightings(
     card_ids: set[int] = set()
     if req_item.material_card_id:
         card_ids.add(req_item.material_card_id)
-    sub_keys = []
-    for sub in req_item.substitutes or []:
-        sub_str = (sub if isinstance(sub, str) else "").strip()
-        if sub_str:
-            sub_key = normalize_mpn_key(sub_str)
-            if sub_key:
-                sub_keys.append(sub_key)
+    sub_keys = _substitute_keys(req_item)
     if sub_keys:
         sub_rows = db.query(MaterialCard.id).filter(MaterialCard.normalized_mpn.in_(sub_keys)).all()
         card_ids |= {row[0] for row in sub_rows}
@@ -1236,16 +1237,10 @@ async def list_requirement_offers(
     if req_item.material_card_id:
         card_ids.add(req_item.material_card_id)
     # Also check substitute material cards
-    from ...utils.normalization import normalize_mpn_key
-
-    for sub in req_item.substitutes or []:
-        sub_str = (sub if isinstance(sub, str) else "").strip()
-        if sub_str:
-            sub_key = normalize_mpn_key(sub_str)
-            if sub_key:
-                mc = db.query(MaterialCard.id).filter(MaterialCard.normalized_mpn == sub_key).first()
-                if mc:
-                    card_ids.add(mc[0])
+    sub_keys = _substitute_keys(req_item)
+    if sub_keys:
+        sub_rows = db.query(MaterialCard.id).filter(MaterialCard.normalized_mpn.in_(sub_keys)).all()
+        card_ids |= {row[0] for row in sub_rows}
 
     if card_ids:
         hist_offers = (

--- a/app/routers/requisitions2.py
+++ b/app/routers/requisitions2.py
@@ -347,21 +347,21 @@ async def row_action(
 
     msg = "Action completed"
 
-    if action_name == RowActionName.archive:
+    # State transitions differ only by target state + message verb.
+    transition_actions = {
+        RowActionName.archive: ("archived", f"'{req.name}' archived"),
+        RowActionName.activate: ("active", f"'{req.name}' activated"),
+        RowActionName.won: ("won", f"'{req.name}' marked won"),
+        RowActionName.lost: ("lost", f"'{req.name}' marked lost"),
+    }
+
+    if action_name in transition_actions:
         from ..services.requisition_state import transition
 
+        target_state, success_msg = transition_actions[action_name]
         try:
-            transition(req, "archived", user, db)
-            msg = f"'{req.name}' archived"
-        except ValueError as e:
-            msg = str(e)
-
-    elif action_name == RowActionName.activate:
-        from ..services.requisition_state import transition
-
-        try:
-            transition(req, "active", user, db)
-            msg = f"'{req.name}' activated"
+            transition(req, target_state, user, db)
+            msg = success_msg
         except ValueError as e:
             msg = str(e)
 
@@ -380,24 +380,6 @@ async def row_action(
         try:
             unclaim_requisition(req, db, actor=user)
             msg = f"Unclaimed '{req.name}'"
-        except ValueError as e:
-            msg = str(e)
-
-    elif action_name == RowActionName.won:
-        from ..services.requisition_state import transition
-
-        try:
-            transition(req, "won", user, db)
-            msg = f"'{req.name}' marked won"
-        except ValueError as e:
-            msg = str(e)
-
-    elif action_name == RowActionName.lost:
-        from ..services.requisition_state import transition
-
-        try:
-            transition(req, "lost", user, db)
-            msg = f"'{req.name}' marked lost"
         except ValueError as e:
             msg = str(e)
 
@@ -451,20 +433,17 @@ async def bulk_action(
     count = 0
     errors = []
 
+    bulk_target_state = {
+        BulkActionName.archive: "archived",
+        BulkActionName.activate: "active",
+    }.get(action_name)
+
     for req in reqs:
-        if action_name == BulkActionName.archive:
+        if bulk_target_state is not None:
             from ..services.requisition_state import transition
 
             try:
-                transition(req, "archived", user, db)
-                count += 1
-            except ValueError as e:
-                errors.append(f"REQ-{req.id}: {e}")
-        elif action_name == BulkActionName.activate:
-            from ..services.requisition_state import transition
-
-            try:
-                transition(req, "active", user, db)
+                transition(req, bulk_target_state, user, db)
                 count += 1
             except ValueError as e:
                 errors.append(f"REQ-{req.id}: {e}")

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -225,6 +225,48 @@ def _partition_by_unavailability(vendor_names: list[str], excluded_norms: set[st
     return unavailable, sendable
 
 
+def _mpn_link_map(db: Session, requirements) -> dict[str, int]:
+    """Build a display-MPN → MaterialCard.id map for the given requirements.
+
+    Collects each requirement's primary_mpn plus substitute MPNs (string or dict form),
+    normalizes them, and resolves live (non-deleted) MaterialCards in one query. Shared
+    by sightings_list (table) and sightings_detail (header). Empty input → empty map.
+    """
+    from ..utils.normalization import normalize_mpn_key
+
+    all_mpns: set[str] = set()
+    for r in requirements:
+        if r.primary_mpn:
+            all_mpns.add(r.primary_mpn.upper())
+        for sub in r.substitutes or []:
+            mpn = sub.get("mpn") if isinstance(sub, dict) else sub
+            if mpn:
+                all_mpns.add(str(mpn).upper())
+    if not all_mpns:
+        return {}
+
+    norm_to_display: dict[str, str] = {}
+    for mpn in all_mpns:
+        n = normalize_mpn_key(mpn)
+        if n:
+            norm_to_display[n] = mpn
+
+    cards = (
+        db.query(MaterialCard.id, MaterialCard.normalized_mpn)
+        .filter(
+            MaterialCard.normalized_mpn.in_(list(norm_to_display.keys())),
+            MaterialCard.deleted_at.is_(None),
+        )
+        .all()
+    )
+    link_map: dict[str, int] = {}
+    for card_id, norm in cards:
+        display = norm_to_display.get(norm)
+        if display:
+            link_map[display] = card_id
+    return link_map
+
+
 @router.get("/v2/partials/sightings/workspace", response_class=HTMLResponse)
 async def sightings_workspace(
     request: Request,
@@ -343,8 +385,6 @@ async def sightings_list(
         coverage_map = {c.requirement_id: c.total_qty or 0 for c in coverage_rows}
 
     # ── Dashboard Strip Counters (Phase 2) ──────────────────────────
-    from datetime import date
-
     deadline_48h = date.today() + timedelta(days=2)
 
     # Active requirement IDs for dashboard (not just current page)
@@ -426,36 +466,7 @@ async def sightings_list(
                 heatmap_req_ids.add(r.id)
 
     # ── MPN → MaterialCard link map ─────────────────────────────
-    link_map: dict[str, int] = {}
-    if requirements:
-        from ..utils.normalization import normalize_mpn_key
-
-        all_mpns: set[str] = set()
-        for r in requirements:
-            if r.primary_mpn:
-                all_mpns.add(r.primary_mpn.upper())
-            for sub in r.substitutes or []:
-                mpn = sub.get("mpn") if isinstance(sub, dict) else sub
-                if mpn:
-                    all_mpns.add(str(mpn).upper())
-        if all_mpns:
-            norm_to_display: dict[str, str] = {}
-            for mpn in all_mpns:
-                n = normalize_mpn_key(mpn)
-                if n:
-                    norm_to_display[n] = mpn
-            cards = (
-                db.query(MaterialCard.id, MaterialCard.normalized_mpn)
-                .filter(
-                    MaterialCard.normalized_mpn.in_(list(norm_to_display.keys())),
-                    MaterialCard.deleted_at.is_(None),
-                )
-                .all()
-            )
-            for card_id, norm in cards:
-                display = norm_to_display.get(norm)
-                if display:
-                    link_map[display] = card_id
+    link_map = _mpn_link_map(db, requirements) if requirements else {}
 
     groups = None
     if filters.group_by in ("brand", "manufacturer"):
@@ -647,34 +658,7 @@ async def sightings_detail(
         material_card = db.get(MaterialCard, requirement.material_card_id)
 
     # ── MPN → MaterialCard link map for detail header ────────────
-    from ..utils.normalization import normalize_mpn_key as _norm_key
-
-    detail_link_map: dict[str, int] = {}
-    detail_mpns: set[str] = set()
-    if requirement.primary_mpn:
-        detail_mpns.add(requirement.primary_mpn.upper())
-    for sub in requirement.substitutes or []:
-        mpn = sub.get("mpn") if isinstance(sub, dict) else sub
-        if mpn:
-            detail_mpns.add(str(mpn).upper())
-    if detail_mpns:
-        norm_to_display: dict[str, str] = {}
-        for mpn in detail_mpns:
-            n = _norm_key(mpn)
-            if n:
-                norm_to_display[n] = mpn
-        detail_cards = (
-            db.query(MaterialCard.id, MaterialCard.normalized_mpn)
-            .filter(
-                MaterialCard.normalized_mpn.in_(list(norm_to_display.keys())),
-                MaterialCard.deleted_at.is_(None),
-            )
-            .all()
-        )
-        for card_id, norm in detail_cards:
-            display = norm_to_display.get(norm)
-            if display:
-                detail_link_map[display] = card_id
+    detail_link_map = _mpn_link_map(db, [requirement])
 
     # ── Cross-Requirement Vendor Overlap (Phase 4.7) ────────────
     overlap_counts: dict[str, int] = dict(
@@ -877,16 +861,11 @@ async def sightings_batch_refresh(
     for rid in requirement_ids:
         await _publish_if_user_source(source, user.id, int(rid))
 
-    parts = []
     total = success + failed
-    parts.append(f"Searched {success}/{total} requirements.")
+    msg = f"Searched {success}/{total} requirements."
     if failed:
-        parts.append(f"{failed} failed.")
-    msg = " ".join(parts)
-    if failed:
-        level = "warning"
-    else:
-        level = "success"
+        msg += f" {failed} failed."
+    level = "warning" if failed else "success"
     if _toast_suppressed_for_sse(source):
         return HTMLResponse("")
     return _oob_toast(msg, level)

--- a/app/routers/sources.py
+++ b/app/routers/sources.py
@@ -119,18 +119,16 @@ def _get_connector_for_source(name: str, db: Session = None):
     if name == "email_mining" and settings.email_mining_enabled:
         return _EmailMiningTestConnector()
 
-    if name == "anthropic_ai":
-        return _AnthropicTestConnector()
-    if name == "teams_notifications":
-        return _TeamsTestConnector()
-    if name == "apollo_enrichment":
-        return _ApolloTestConnector()
-    if name == "lusha_enrichment":
-        return _LushaTestConnector()
-    if name == "explorium_enrichment":
-        return _ExploriumTestConnector()
-    if name == "azure_oauth":
-        return _AzureOAuthTestConnector()
+    test_connector = {
+        "anthropic_ai": _AnthropicTestConnector,
+        "teams_notifications": _TeamsTestConnector,
+        "apollo_enrichment": _ApolloTestConnector,
+        "lusha_enrichment": _LushaTestConnector,
+        "explorium_enrichment": _ExploriumTestConnector,
+        "azure_oauth": _AzureOAuthTestConnector,
+    }.get(name)
+    if test_connector:
+        return test_connector()
 
     return None
 
@@ -282,6 +280,18 @@ class _AzureOAuthTestConnector:
         return [{"vendor_name": "Azure OAuth", "mpn_matched": "Tenant verified", "status": "ok"}]
 
 
+async def _parse_mining_options(request: Request) -> MiningOptions:
+    """Parse MiningOptions from a JSON request body, falling back to defaults."""
+    try:
+        if request.headers.get("content-type", "").startswith("application/json"):
+            body = await request.body()
+            if body and body.strip():
+                return MiningOptions.model_validate_json(body)
+    except (ValueError, TypeError):
+        logger.warning("Mining options parse failed, using defaults", exc_info=True)
+    return MiningOptions()
+
+
 def _create_sightings_from_attachment(
     db: Session,
     vr: VendorResponse,
@@ -356,13 +366,11 @@ def _create_sightings_from_attachment(
 
         mat_card = resolve_material_card(mpn, db)
 
-        from ..vendor_utils import normalize_vendor_name as _nvn
-
         sighting = Sighting(
             requirement_id=matched_req.id,
             material_card_id=mat_card.id if mat_card else None,
             vendor_name=vr.vendor_name or "",
-            vendor_name_normalized=_nvn(vr.vendor_name or ""),
+            vendor_name_normalized=normalize_vendor_name(vr.vendor_name or ""),
             vendor_email=vr.vendor_email,
             mpn_matched=normalize_mpn(mpn) or mpn,
             manufacturer=row.get("manufacturer", ""),
@@ -475,7 +483,7 @@ async def test_api_source(
     results = []
     error = None
 
-    has_env_vars = bool(src.env_vars and len(src.env_vars))
+    has_env_vars = bool(src.env_vars)
 
     try:
         connector = _get_connector_for_source(src.name, db)
@@ -499,10 +507,17 @@ async def test_api_source(
 
     db.commit()
 
+    if results:
+        status = "ok"
+    elif not error:
+        status = "no_results"
+    else:
+        status = "error"
+
     return {
         "source": src.display_name,
         "test_mpn": test_mpn,
-        "status": "ok" if results else "no_results" if not error else "error",
+        "status": status,
         "results_count": len(results),
         "elapsed_ms": elapsed_ms,
         "error": error,
@@ -625,14 +640,7 @@ async def scan_inbox_for_vendors(request: Request, user: User = Depends(require_
     """Run email intelligence scan — mines inbox for vendor contacts and offers."""
     token = await require_fresh_token(request, db)
 
-    opts = MiningOptions()
-    try:
-        if request.headers.get("content-type", "").startswith("application/json"):
-            body = await request.body()
-            if body and body.strip():
-                opts = MiningOptions.model_validate_json(body)
-    except (ValueError, TypeError):
-        logger.warning("Mining options parse failed, using defaults", exc_info=True)
+    opts = await _parse_mining_options(request)
     lookback_days = opts.lookback_days
 
     from ..connectors.email_mining import EmailMiner
@@ -712,14 +720,7 @@ async def email_mining_scan_outbound(
     from ..scheduler import get_valid_token
 
     token = await get_valid_token(user, db) or user.access_token
-    opts = MiningOptions()
-    try:
-        if request.headers.get("content-type", "").startswith("application/json"):
-            raw = await request.body()
-            if raw and raw.strip():
-                opts = MiningOptions.model_validate_json(raw)
-    except (ValueError, TypeError):
-        logger.warning("Mining options parse failed, using defaults", exc_info=True)
+    opts = await _parse_mining_options(request)
     lookback = opts.lookback_days
 
     miner = EmailMiner(token, db=db, user_id=user.id)

--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -16,6 +16,11 @@ from app.utils.sql_helpers import escape_like
 router = APIRouter(prefix="/api/tags", tags=["tags"])
 
 
+def _tag_response(tag: Tag) -> TagResponse:
+    """Build a TagResponse from a Tag ORM row."""
+    return TagResponse(id=tag.id, name=tag.name, tag_type=tag.tag_type, parent_id=tag.parent_id)
+
+
 @router.get("/")
 async def list_tags(
     tag_type: str | None = Query(None, description="Filter by 'brand' or 'commodity'"),
@@ -36,9 +41,7 @@ async def list_tags(
     tags = query.order_by(Tag.name).offset(offset).limit(limit).all()
 
     return {
-        "items": [
-            TagResponse(id=t.id, name=t.name, tag_type=t.tag_type, parent_id=t.parent_id).model_dump() for t in tags
-        ],
+        "items": [_tag_response(t).model_dump() for t in tags],
         "total": total,
         "limit": limit,
         "offset": offset,
@@ -65,7 +68,7 @@ async def get_tag_entities(
     return {
         "items": [
             EntityTagResponse(
-                tag=TagResponse(id=et.tag.id, name=et.tag.name, tag_type=et.tag.tag_type, parent_id=et.tag.parent_id),
+                tag=_tag_response(et.tag),
                 interaction_count=et.interaction_count,
                 total_entity_interactions=et.total_entity_interactions,
                 is_visible=et.is_visible,
@@ -103,7 +106,7 @@ async def get_entity_tags(
 
     return [
         EntityTagResponse(
-            tag=TagResponse(id=et.tag.id, name=et.tag.name, tag_type=et.tag.tag_type, parent_id=et.tag.parent_id),
+            tag=_tag_response(et.tag),
             interaction_count=et.interaction_count,
             total_entity_interactions=et.total_entity_interactions,
             is_visible=et.is_visible,
@@ -129,7 +132,7 @@ async def get_material_card_tags(
 
     return [
         MaterialTagResponse(
-            tag=TagResponse(id=mt.tag.id, name=mt.tag.name, tag_type=mt.tag.tag_type, parent_id=mt.tag.parent_id),
+            tag=_tag_response(mt.tag),
             confidence=mt.confidence,
             source=mt.source,
             classified_at=mt.classified_at,

--- a/app/routers/v13_features/__init__.py
+++ b/app/routers/v13_features/__init__.py
@@ -1,18 +1,15 @@
 """v13_features — v1.3.0 Feature Routes (package)
 
-Graph webhooks, activity logging, sales dashboard (account ownership & open pool),
-and prospecting pool (site-level ownership).
+Graph webhooks and activity logging.
 
-Re-exports a single `router` that merges activity, sales, and prospecting sub-routers.
+Re-exports a single `router` from the activity sub-router.
 
 Called by: main.py (router mount)
-Depends on: activity, sales, prospecting sub-modules
+Depends on: activity sub-module
 """
 
 from fastapi import APIRouter
-from sqlalchemy.orm import Session  # noqa: F401 — test patches app.routers.v13_features.Session
 
-from ...config import settings  # noqa: F401 — test patches app.routers.v13_features.settings
 from .activity import _activity_to_dict  # noqa: F401 — tests import this
 from .activity import router as _activity_router
 

--- a/app/routers/v13_features/activity.py
+++ b/app/routers/v13_features/activity.py
@@ -550,7 +550,6 @@ async def vendor_activity_status(
 @router.get("/api/companies/{company_id}/activity-status")
 async def company_activity_status(company_id: int, user: User = Depends(require_user), db: Session = Depends(get_db)):
     """Get activity health status for a company (for dashboard indicators)."""
-    from app.config import settings as cfg
     from app.services.activity_service import days_since_last_activity
 
     company = db.get(Company, company_id)
@@ -558,11 +557,11 @@ async def company_activity_status(company_id: int, user: User = Depends(require_
         raise HTTPException(404, "Company not found")
 
     days = days_since_last_activity(company_id, db)
-    inactivity_limit = cfg.strategic_inactivity_days if company.is_strategic else cfg.customer_inactivity_days
+    inactivity_limit = settings.strategic_inactivity_days if company.is_strategic else settings.customer_inactivity_days
 
     if days is None:
         status = "no_activity"
-    elif days <= cfg.customer_warning_days:
+    elif days <= settings.customer_warning_days:
         status = "green"
     elif days <= inactivity_limit:
         status = "yellow"

--- a/app/routers/vendor_contacts.py
+++ b/app/routers/vendor_contacts.py
@@ -39,6 +39,31 @@ from ..vendor_utils import normalize_vendor_name
 router = APIRouter(tags=["vendors"])
 
 
+def _lookup_response(card, vendor_name, source, tier, **extra):
+    """Build the standard vendor-contact lookup payload from a card."""
+    return {
+        "vendor_name": vendor_name,
+        "emails": card.emails or [],
+        "phones": card.phones or [],
+        "website": card.website,
+        "card_id": card.id,
+        "source": source,
+        "tier": tier,
+        **extra,
+    }
+
+
+def _coalesce_contact_list(values, single):
+    """Normalize an AI-returned list field, prepending an optional single value."""
+    if isinstance(values, str):
+        values = [values]
+    else:
+        values = list(values or [])
+    if single and single not in values:
+        values.insert(0, single)
+    return values
+
+
 # -- 3-Tier Vendor Contact Lookup ---------------------------------------------
 
 
@@ -64,15 +89,7 @@ async def lookup_vendor_contact(
 
     # TIER 1: Cache check (free, instant)
     if card.emails:
-        return {
-            "vendor_name": card.display_name,
-            "emails": card.emails or [],
-            "phones": card.phones or [],
-            "website": card.website,
-            "card_id": card.id,
-            "source": "cached",
-            "tier": 1,
-        }
+        return _lookup_response(card, card.display_name, "cached", 1)
 
     # TIER 2: Website scrape (free, ~1-2 sec)
     if card.website:
@@ -83,30 +100,13 @@ async def lookup_vendor_contact(
                 merge_contact_into_card(card, scraped["emails"], scraped["phones"], source="website_scrape")
                 db.commit()
                 if card.emails:
-                    return {
-                        "vendor_name": card.display_name,
-                        "emails": card.emails or [],
-                        "phones": card.phones or [],
-                        "website": card.website,
-                        "card_id": card.id,
-                        "source": "website_scrape",
-                        "tier": 2,
-                    }
+                    return _lookup_response(card, card.display_name, "website_scrape", 2)
         except Exception as e:
             logger.warning(f"Tier 2 scrape failed for {vendor_name}: {e}")
 
     # TIER 3: AI lookup (expensive, last resort)
     if not get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY"):
-        return {
-            "vendor_name": vendor_name,
-            "emails": card.emails or [],
-            "phones": card.phones or [],
-            "website": card.website,
-            "card_id": card.id,
-            "source": None,
-            "tier": 0,
-            "error": "No API key configured",
-        }
+        return _lookup_response(card, vendor_name, None, 0, error="No API key configured")
 
     logger.info(f"Tier 3: AI lookup for {vendor_name}")
     try:
@@ -141,49 +141,18 @@ async def lookup_vendor_contact(
         if not info or not isinstance(info, dict):
             info = {}
 
-        ai_emails = info.get("emails") or []
-        if isinstance(ai_emails, str):
-            ai_emails = [ai_emails]
-        single_email = info.get("email")
-        if single_email and single_email not in ai_emails:
-            ai_emails.insert(0, single_email)
-        ai_emails = clean_emails(ai_emails)
-
-        ai_phones = info.get("phones") or []
-        if isinstance(ai_phones, str):
-            ai_phones = [ai_phones]
-        single_phone = info.get("phone")
-        if single_phone and single_phone not in ai_phones:
-            ai_phones.insert(0, single_phone)
-        ai_phones = clean_phones(ai_phones)
-
+        ai_emails = clean_emails(_coalesce_contact_list(info.get("emails"), info.get("email")))
+        ai_phones = clean_phones(_coalesce_contact_list(info.get("phones"), info.get("phone")))
         website = info.get("website")
 
         merge_contact_into_card(card, ai_emails, ai_phones, website, source="ai_lookup")
         db.commit()
 
-        return {
-            "vendor_name": card.display_name,
-            "emails": card.emails or [],
-            "phones": card.phones or [],
-            "website": card.website,
-            "card_id": card.id,
-            "source": "ai_lookup",
-            "tier": 3,
-        }
+        return _lookup_response(card, card.display_name, "ai_lookup", 3)
 
     except Exception as e:
         logger.warning(f"Tier 3 AI lookup failed for {vendor_name}: {e}")
-        return {
-            "vendor_name": vendor_name,
-            "emails": card.emails or [],
-            "phones": card.phones or [],
-            "website": card.website,
-            "card_id": card.id,
-            "source": None,
-            "tier": 0,
-            "error": str(e)[:200],
-        }
+        return _lookup_response(card, vendor_name, None, 0, error=str(e)[:200])
 
 
 # -- Structured Vendor Contact CRUD -------------------------------------------

--- a/app/routers/vendors_crud.py
+++ b/app/routers/vendors_crud.py
@@ -167,58 +167,56 @@ async def list_vendors(
         cards = query.limit(limit).offset(offset).all()
         if not cards:
             return {"vendors": [], "total": 0, "limit": limit, "offset": offset}
-        # Batch fetch review stats -- single query instead of N+1
+        # card_ids is non-empty here -- the empty-cards case returned above.
         card_ids = [c.id for c in cards]
+        # Batch fetch review stats -- single query instead of N+1
         review_stats = {}
-        if card_ids:
-            for cid, avg, cnt in (
-                db.query(
-                    VendorReview.vendor_card_id,
-                    sqlfunc.avg(VendorReview.rating),
-                    sqlfunc.count(VendorReview.id),
-                )
-                .filter(VendorReview.vendor_card_id.in_(card_ids))
-                .group_by(VendorReview.vendor_card_id)
-                .all()
-            ):
-                review_stats[cid] = (avg, cnt)
+        for cid, avg, cnt in (
+            db.query(
+                VendorReview.vendor_card_id,
+                sqlfunc.avg(VendorReview.rating),
+                sqlfunc.count(VendorReview.id),
+            )
+            .filter(VendorReview.vendor_card_id.in_(card_ids))
+            .group_by(VendorReview.vendor_card_id)
+            .all()
+        ):
+            review_stats[cid] = (avg, cnt)
         # Batch fetch strategic claim info -- single query instead of N+1
         claim_map = {}
-        if card_ids:
-            for sv in (
-                db.query(StrategicVendor)
-                .filter(
-                    StrategicVendor.vendor_card_id.in_(card_ids),
-                    StrategicVendor.released_at.is_(None),
-                )
-                .all()
-            ):
-                owner_name = sv.user.name if sv.user else None
-                claim_map[sv.vendor_card_id] = {
-                    "claimed_by_user_id": sv.user_id,
-                    "claimed_by_name": owner_name,
-                }
+        for sv in (
+            db.query(StrategicVendor)
+            .filter(
+                StrategicVendor.vendor_card_id.in_(card_ids),
+                StrategicVendor.released_at.is_(None),
+            )
+            .all()
+        ):
+            owner_name = sv.user.name if sv.user else None
+            claim_map[sv.vendor_card_id] = {
+                "claimed_by_user_id": sv.user_id,
+                "claimed_by_name": owner_name,
+            }
 
         # Batch fetch top contact per vendor -- single query, dedup in Python
         top_contact_map = {}
-        if card_ids:
-            contacts = (
-                db.query(VendorContact)
-                .filter(VendorContact.vendor_card_id.in_(card_ids))
-                .order_by(
-                    VendorContact.relationship_score.desc().nullslast(),
-                    VendorContact.interaction_count.desc().nullslast(),
-                    VendorContact.last_seen_at.desc().nullslast(),
-                )
-                .all()
+        contacts = (
+            db.query(VendorContact)
+            .filter(VendorContact.vendor_card_id.in_(card_ids))
+            .order_by(
+                VendorContact.relationship_score.desc().nullslast(),
+                VendorContact.interaction_count.desc().nullslast(),
+                VendorContact.last_seen_at.desc().nullslast(),
             )
-            for vc in contacts:
-                if vc.vendor_card_id not in top_contact_map:
-                    top_contact_map[vc.vendor_card_id] = {
-                        "name": vc.full_name,
-                        "email": vc.email,
-                        "phone": vc.phone,
-                    }
+            .all()
+        )
+        for vc in contacts:
+            if vc.vendor_card_id not in top_contact_map:
+                top_contact_map[vc.vendor_card_id] = {
+                    "name": vc.full_name,
+                    "email": vc.email,
+                    "phone": vc.phone,
+                }
 
         results = []
         for c in cards:


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/routers`)
30 file(s) changed, 71 simplifications (7 file(s) already clean).

- **`_lookup_helpers.py`** — Hoisted the two function-level lazy model imports (Requisition, VendorCard) to module top-level.
- **`activity.py`** — Extracted the duplicated ISO-date parsing and the timeline response-dict construction shared by both timeline endpoints into `_parse_date_range` and `_timeline_response` helpers; Removed redundant local `from ..models import SiteContact` in get_contact_timeline_endpoint; Hoisted the per-call lazy `from datetime import datetime as dt` to a single module-top `from datetime import datetime`.
- **`spec_codes.py`** — Collapsed three identical template_response calls to the spec_codes_reresolve_unresolved.html partial into a single local helper `unresolved(error: bool)` inside re_resolve.
- **`system.py`** — Added a module-private `_iso(dt)` helper and replaced the 7 repeated `x.isoformat() if x else None` inline expressions (across api_connector_health, api_health_dashboard, and api_material_audit) with `_iso(...)` calls; Collapsed the duplicated `updated.append(var_name)` that appeared in both branches of the credential set if/else into a single call after the branch in api_set_credentials.
- **`ai.py`** — Removed dead `if not company_name: pass` block in ai_find_contacts; Removed inaccurate/misleading comments in _build_vendor_history; Tightened the field-truncation guard in ai_find_contacts; Removed redundant mid-function `from ..models import Requirement` in ai_generate_description_for_requirement; Extracted duplicated RFQ-context builder into _rfq_context_for_requisition helper.
- **`auth.py`** — Removed redundant local `from fastapi.responses import RedirectResponse` inside index(); Moved the stray mid-file `from ..rate_limit import limiter` into the top import block.
- **`_helpers.py`** — Added module-private `_iso(dt)` and `_float(v)` helpers and applied them across quote_to_dict to replace 5 repeated `x.isoformat() if x else None` and 5 repeated `float(x) if x else None` inline expressions; also routed _quote_date_iso through `_iso`; Removed the redundant function-local `from datetime import timedelta` inside _build_quote_email_html.
- **`clone.py`** — Removed the redundant `db.query(Requirement).filter(...).all()` re-fetch of the just-created requirements; build the old->new id map from in-memory objects after the existing single flush.
- **`companies.py`** — Extracted duplicated company-name dedup logic into shared module-level helpers; Stopped recompiling the suffix regex on every request; Removed redundant [:5] slice at the create_company call site.
- **`enrichment.py`** — Extracted `_require_enrichment_provider()` for the 3x-duplicated 503 credential guard; Extracted `_normalize_domain()` for the 3x-duplicated scheme/www/path stripping.
- **`offers.py`** — Deduplicated five identical OFFER_STATUS_CHANGED log_activity blocks into a module-level _log_offer_status_change(db, offer, old_status, user) helper; Removed a redundant local re-import of normalize_mpn_key in create_offer; Removed a dead GraphClient instantiation in delete_offer_attachment; Replaced two `if key not in d: d[key] = []` patterns with dict.setdefault; Collapsed the duplicated two-branch gc.get_json call in browse_onedrive; Changed `offer.status not in ("pending_review",)` to `offer.status != "pending_review"` in reject_offer_t4_review.
- **`quotes.py`** — Extracted the repeated 3-option joinedload eager-load block into a module-level _quote_load_options() helper, called via .options(*_quote_load_options()); Extracted duplicated subtotal/total_cost/total_margin_pct computation into _compute_quote_totals(line_items); Extracted the duplicated revision-creation logic into _build_revision(old, user).
- **`documents.py`** — Extracted the duplicated PDF generate-off-event-loop + error-mapping block into a `_render_pdf(generator, obj_id, db, log_label)` helper shared by both endpoints; Cross-file note (NOT applied): the same get_running_loop().run_in_executor(generate_quote_report_pdf, ...) + ValueError->404 / Exception->500 pattern also lives in app/routers/quote_builder.py (~line 280).
- **`error_reports.py`** — Removed the redundant five-line None-initialization block in the legacy form-encoded branch of submit_trouble_ticket by hoisting the defaults above the content-type branch.
- **`excess.py`** — Extracted repeated filename-extension parsing into a private `_file_extension` helper; Extracted the duplicated line-item ownership-chain 404 check into `_get_line_item_or_404`; Merged two identical Claude exception handlers in api_polish_email into one.
- **`materials.py`** — De-duplicated the Add-part 422 re-render context dict in add_material; Extracted duplicated 'infer missing manufacturer on read' block into _backfill_manufacturer helper; Extracted the repeated `user.email if hasattr(user, 'email') else 'admin'` actor expression into _actor_email helper.
- **`proactive.py`** — Collapsed two `result = ...; return result` pairs into direct returns; Reduced scorecard salesperson_id resolution from three lines + temp var to one branch.
- **`prospect_suggested.py`** — Replace inline readiness-tier if/elif/else in _serialize_prospect with the existing classify_readiness() helper.
- **`quote_builder.py`** — Extracted `_parse_req_ids()` to de-duplicate the comma-separated-id parse + 400 validation; Extracted `_customer_name_for_site()` to collapse the repeated site→company.name lookup; Removed redundant local `from fastapi.responses import Response` in quote_builder_export_pdf.
- **`attachments.py`** — Extracted `_serialize_attachment()` for the duplicated 7-field list serialization; Extracted `_attachment_created_response()` for the 4-field create/link response; Extracted `_delete_onedrive_item()` for the duplicated OneDrive DELETE + 401/403 handling; Named the 10 MB size cap as `MAX_ATTACHMENT_BYTES` constant.
- **`core.py`** — Extracted the dense list-comprehension row builder into a named _serialize_req_row helper.
- **`requirements.py`** — Removed a redundant function-local re-import of normalize_mpn_key inside list_requirement_offers; Extracted repeated substitute-key collection into a module-level _substitute_keys(requirement) helper; Collapsed an N+1 per-substitute MaterialCard query in list_requirement_offers into a single batched IN query.
- **`requisitions2.py`** — Collapsed the four copy-paste-with-variation state-transition branches in row_action (archive/activate/won/lost) into one data-driven branch keyed by a transition_actions dict (target_state, success_msg); De-duplicated the archive/activate transition branches in bulk_action by mapping the action to its target state once and sharing the loop body.
- **`sightings.py`** — Removed redundant function-local `from datetime import date` in sightings_list; Collapsed the verbose toast-message/level construction in sightings_batch_refresh; Extracted duplicated MPN -> MaterialCard link-map logic into a shared `_mpn_link_map(db, requirements)` helper.
- **`sources.py`** — Collapsed 6-branch if-chain for simple test connectors into a dict lookup; Extracted verbatim-duplicated MiningOptions request-body parse into _parse_mining_options helper; Removed redundant in-loop re-import of normalize_vendor_name; Replaced nested ternary for test status with explicit if/elif/else; Simplified bool(src.env_vars and len(src.env_vars)) to bool(src.env_vars).
- **`tags.py`** — Added a `_tag_response(tag)` helper and replaced four copy-paste TagResponse(id=..., name=..., tag_type=..., parent_id=...) constructions with it.
- **`__init__.py`** — Removed two dead imports (`Session`, `settings`) whose noqa justifications were provably false; Corrected the now-inaccurate module docstring to match the actual single (activity) sub-module.
- **`activity.py`** — Remove redundant local `from app.config import settings as cfg` import in company_activity_status and use the module-level `settings` (already imported at line 15).
- **`vendor_contacts.py`** — Collapsed 6 copy-paste-with-variation lookup-response dicts into one local _lookup_response(card, vendor_name, source, tier, **extra) helper; Deduplicated the AI emails-vs-phones list-normalization into _coalesce_contact_list(values, single).
- **`vendors_crud.py`** — Removed three redundant `if card_ids:` guards in list_vendors' batch-fetch section.

_Recorded cross-file follow-ups:_
- `requirements.py`: Cross-file note: the saved-sightings vs requirement-sightings endpoints (get_saved_sightings / list_requirement_sightings) share a large material-history + sighting-dict assembly flow that could be unified into a shared service helper, but a proper fix would live in app/services or the requisitions package __init__ (which already re-exports the _get_material_history/_history_to_result/sighting_to_dict helpers) — out of scope for this single target file.
- `materials.py`: Manual-write + clear_validation_conflicts pattern (set_manufacturer/set_category at 'manual',1.
- `materials.py`: File-extension allowlist `{'.
- `ai.py`: htmx_views.
- `excess.py`: app/utils/file_validation.
- `quotes.py`: _compute_quote_totals and the revision logic ideally belong in app/services/crm_service.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)