### PR TITLE
simplify(services 2/4): de-duplicate service helpers

### DIFF
--- a/app/services/authoritative_enrichment_service.py
+++ b/app/services/authoritative_enrichment_service.py
@@ -217,6 +217,37 @@ def apply_authoritative(
     card.enriched_at = datetime.now(timezone.utc)
 
 
+def _apply_evidence_fields(
+    card: MaterialCard,
+    fields: dict[str, Any],
+    *,
+    source: str,
+    confidence: float,
+    prov: dict,
+    fetched_at: str,
+) -> None:
+    """Write non-empty evidence-sourced *fields* onto *card* under one *source* string.
+
+    category/manufacturer route through the F1 ladder at *source*'s registered tier (the
+    ladder decides whether the write lands and rejects off-vocab categories); every other
+    field is a direct write. *prov* (the caller's top-level provenance block) is mutated in
+    place: each field that was actually written gets a per-field provenance entry; a
+    ladder-rejected write gets NO entry. Shared by the web/OEM evidence tiers.
+    """
+    for f, v in fields.items():
+        if not v:
+            continue
+        if f == "category":
+            if not set_category(card, v, source, confidence):
+                continue
+        elif f == "manufacturer":
+            if not set_manufacturer(card, v, source, confidence):
+                continue
+        else:
+            setattr(card, f, v)
+        prov[f] = {"source": source, "confidence": confidence, "fetched_at": fetched_at}
+
+
 def apply_web_sourced(card: MaterialCard, result: WebExtractResult) -> None:
     """Write web-sourced fields + provenance onto the card.
 
@@ -229,35 +260,27 @@ def apply_web_sourced(card: MaterialCard, result: WebExtractResult) -> None:
     a ladder-rejected write gets NO per-field provenance entry.
     """
     now = datetime.now(timezone.utc)
-    fields = {
-        "description": result.description,
-        "manufacturer": result.manufacturer,
-        "category": result.category,
-        "datasheet_url": result.datasheet_url,
-    }
+    iso = now.isoformat()
     prov: dict = {
         "web_sourced": True,
         "confidence": result.confidence,
         "source_urls": result.source_urls,
         "source_domains": result.source_domains,
-        "fetched_at": now.isoformat(),
+        "fetched_at": iso,
     }
-    for f, v in fields.items():
-        if not v:
-            continue
-        if f == "category":
-            if not set_category(card, v, "web_search", result.confidence):
-                continue
-        elif f == "manufacturer":
-            if not set_manufacturer(card, v, "web_search", result.confidence):
-                continue
-        else:
-            setattr(card, f, v)
-        prov[f] = {
-            "source": "web_search",
-            "confidence": result.confidence,
-            "fetched_at": now.isoformat(),
-        }
+    _apply_evidence_fields(
+        card,
+        {
+            "description": result.description,
+            "manufacturer": result.manufacturer,
+            "category": result.category,
+            "datasheet_url": result.datasheet_url,
+        },
+        source="web_search",
+        confidence=result.confidence,
+        prov=prov,
+        fetched_at=iso,
+    )
     card.enrichment_source = "web_search"
     card.enrichment_status = MaterialEnrichmentStatus.WEB_SOURCED
     card.enrichment_provenance = prov
@@ -321,24 +344,19 @@ def apply_oem_sourced(card: MaterialCard, result: OemExtractResult) -> None:
         "source_domains": result.source_domains,
         "fetched_at": iso,
     }
-    fields = {
-        "description": result.description,
-        "category": result.category,
-        "datasheet_url": result.datasheet_url,
-        "manufacturer": result.manufacturer,
-    }
-    for f, v in fields.items():
-        if not v:
-            continue
-        if f == "category":
-            if not set_category(card, v, "oem_official", result.confidence):
-                continue
-        elif f == "manufacturer":
-            if not set_manufacturer(card, v, "oem_official", result.confidence):
-                continue
-        else:
-            setattr(card, f, v)
-        prov[f] = {"source": "oem_official", "confidence": result.confidence, "fetched_at": iso}
+    _apply_evidence_fields(
+        card,
+        {
+            "description": result.description,
+            "category": result.category,
+            "datasheet_url": result.datasheet_url,
+            "manufacturer": result.manufacturer,
+        },
+        source="oem_official",
+        confidence=result.confidence,
+        prov=prov,
+        fetched_at=iso,
+    )
     card.enrichment_source = "oem_official"
     card.enrichment_status = MaterialEnrichmentStatus.OEM_SOURCED
     card.enrichment_provenance = prov

--- a/app/services/buyplan_scoring.py
+++ b/app/services/buyplan_scoring.py
@@ -181,11 +181,7 @@ def assign_buyer(
             return entered_by, "vendor_ownership"
 
     # Get all active buyers
-    buyers = (
-        db.query(User)
-        .filter(User.role.in_([UserRole.BUYER, UserRole.TRADER]), User.is_active == True)  # noqa: E712
-        .all()
-    )
+    buyers = db.query(User).filter(User.role.in_([UserRole.BUYER, UserRole.TRADER]), User.is_active.is_(True)).all()
     if not buyers:
         return None, "no_buyers"
 
@@ -194,7 +190,7 @@ def assign_buyer(
     maps = _get_routing_maps()
     brand_map = maps.get("brand_commodity_map", {})
     if vendor_card and vendor_card.commodity_tags:
-        vendor_commodities = set(t.lower() for t in (vendor_card.commodity_tags or []))
+        vendor_commodities = {t.lower() for t in vendor_card.commodity_tags}
     if offer.manufacturer:
         mfr_commodity = brand_map.get(offer.manufacturer.strip().lower())
         if mfr_commodity:

--- a/app/services/calendar_intelligence.py
+++ b/app/services/calendar_intelligence.py
@@ -7,6 +7,7 @@ Called by: scheduler.py (_job_calendar_scan)
 Depends on: utils/graph_client.py, models/intelligence.py
 """
 
+import json
 from datetime import datetime, timedelta, timezone
 
 from loguru import logger
@@ -50,8 +51,9 @@ async def scan_calendar_events(token: str, user_id: int, db: Session, lookback_d
 
     gc = GraphClient(token)
 
-    start_time = (datetime.now(timezone.utc) - timedelta(days=lookback_days)).isoformat()
-    end_time = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(timezone.utc)
+    start_time = (now - timedelta(days=lookback_days)).isoformat()
+    end_time = now.isoformat()
 
     try:
         events = await gc.get_all_pages(
@@ -158,8 +160,6 @@ def _log_calendar_activity(
 
     contact_emails = [a["email"] for a in vendor_attendees[:5]]
     contact_names = [a["name"] for a in vendor_attendees[:5] if a["name"]]
-
-    import json
 
     notes_data = json.dumps(
         {

--- a/app/services/commodity_registry.py
+++ b/app/services/commodity_registry.py
@@ -111,10 +111,7 @@ for _group, _subs in COMMODITY_TREE.items():
 
 def get_all_commodities() -> list[str]:
     """Return flat list of all sub-category keys."""
-    result = []
-    for subs in COMMODITY_TREE.values():
-        result.extend(subs)
-    return result
+    return [sub for subs in COMMODITY_TREE.values() for sub in subs]
 
 
 # Frozen canonical vocabulary — the ONLY values material_cards.category may hold

--- a/app/services/credential_service.py
+++ b/app/services/credential_service.py
@@ -71,6 +71,21 @@ def decrypt_value(ciphertext: str) -> str:
     return f.decrypt(ciphertext.encode()).decode()
 
 
+def _try_decrypt(encrypted: str | None, var_name: str) -> str | None:
+    """Decrypt one credential blob, logging and returning None on failure.
+
+    Shared by the batch/bulk readers, which all fall back to env vars on a decrypt error
+    rather than surfacing it.
+    """
+    if not encrypted:
+        return None
+    try:
+        return decrypt_value(encrypted)
+    except Exception:
+        logger.error("Credential decrypt fallback for {}", var_name, exc_info=True)
+        return None
+
+
 def mask_value(plaintext: str) -> str:
     """Mask a credential value for display: show last 4 chars only."""
     if not plaintext:
@@ -114,14 +129,7 @@ def get_all_credentials_for_source(db: Session, source_name: str) -> dict[str, s
 
     result = {}
     for var_name in src.env_vars or []:
-        val = None
-        if src.credentials:
-            encrypted = src.credentials.get(var_name)
-            if encrypted:
-                try:
-                    val = decrypt_value(encrypted)
-                except Exception:
-                    logger.error("Credential decrypt fallback for {}", var_name, exc_info=True)
+        val = _try_decrypt((src.credentials or {}).get(var_name), var_name)
         if not val:
             val = os.getenv(var_name) or ""
         if val:
@@ -151,14 +159,8 @@ def get_credentials_batch(db: Session, requests: list[tuple[str, str]]) -> dict[
     result: dict[tuple[str, str], str | None] = {}
     for source_name, env_var_name in requests:
         src = sources.get(source_name)
-        val = None
-        if src and src.credentials:
-            encrypted = src.credentials.get(env_var_name)
-            if encrypted:
-                try:
-                    val = decrypt_value(encrypted)
-                except Exception:
-                    logger.error("Credential decrypt fallback for {}", env_var_name, exc_info=True)
+        encrypted = src.credentials.get(env_var_name) if src and src.credentials else None
+        val = _try_decrypt(encrypted, env_var_name)
         if not val:
             val = os.getenv(env_var_name) or None
         result[(source_name, env_var_name)] = val

--- a/app/services/customer_analysis_service.py
+++ b/app/services/customer_analysis_service.py
@@ -31,8 +31,19 @@ async def analyze_customer_materials(company_id: int, db_session=None):
         if not site_ids:
             return
 
-        parts_list = []
-        seen_mpns = set()
+        parts_list: list[str] = []
+        seen_mpns: set[str] = set()
+
+        def add_rows(rows: list) -> None:
+            """Append ``"<mpn> — <label>"`` for each new (case-insensitive) MPN,
+            stopping at 200."""
+            for mpn, label in rows:
+                key = (mpn or "").lower()
+                if key and key not in seen_mpns:
+                    seen_mpns.add(key)
+                    parts_list.append(f"{mpn} — {label or 'unknown'}")
+                if len(parts_list) >= 200:
+                    break
 
         # 1. Requirements (brand field) from requisitions linked to company sites
         req_rows = (
@@ -44,11 +55,7 @@ async def analyze_customer_materials(company_id: int, db_session=None):
             .limit(200)
             .all()
         )
-        for mpn, brand in req_rows:
-            key = (mpn or "").lower()
-            if key and key not in seen_mpns:
-                seen_mpns.add(key)
-                parts_list.append(f"{mpn} — {brand or 'unknown'}")
+        add_rows(req_rows)
 
         # 2. Sightings (manufacturer field) from those same requisitions
         sighting_rows = (
@@ -61,13 +68,7 @@ async def analyze_customer_materials(company_id: int, db_session=None):
             .limit(200)
             .all()
         )
-        for mpn, mfr in sighting_rows:
-            key = (mpn or "").lower()
-            if key and key not in seen_mpns:
-                seen_mpns.add(key)
-                parts_list.append(f"{mpn} — {mfr or 'unknown'}")
-            if len(parts_list) >= 200:
-                break
+        add_rows(sighting_rows)
 
         if not parts_list:
             return

--- a/app/services/customer_enrichment_service.py
+++ b/app/services/customer_enrichment_service.py
@@ -97,12 +97,14 @@ async def enrich_customer_account(
     # Cooldown check
     if not force and company.customer_enrichment_at:
         cooldown = timedelta(days=settings.customer_enrichment_cooldown_days)
-        if datetime.now(timezone.utc) - company.customer_enrichment_at < cooldown:
-            days_left = (company.customer_enrichment_at + cooldown - datetime.now(timezone.utc)).days
+        next_enrichment_at = company.customer_enrichment_at + cooldown
+        now = datetime.now(timezone.utc)
+        if now < next_enrichment_at:
+            days_left = (next_enrichment_at - now).days
             return {
                 "error": f"Cooldown active — {days_left} days remaining",
                 "contacts_added": 0,
-                "next_enrichment_at": (company.customer_enrichment_at + cooldown).isoformat(),
+                "next_enrichment_at": next_enrichment_at.isoformat(),
             }
 
     domain = _get_company_domain(company)

--- a/app/services/email_threads.py
+++ b/app/services/email_threads.py
@@ -36,6 +36,9 @@ from ..config import settings as _settings  # noqa: E402
 
 _TRIOSCS_DOMAINS = _settings.own_domains or frozenset({"trioscs.com"})
 
+# Shared Graph $select field list for message queries
+_MESSAGE_SELECT = "id,subject,from,toRecipients,bodyPreview,receivedDateTime,conversationId"
+
 
 def _cache_get(key: str) -> list | None:
     """Return cached data if still valid, else None."""
@@ -166,9 +169,9 @@ def group_by_thread(messages: list[dict]) -> list[dict]:
                     {
                         "id": m.get("id", ""),
                         "subject": m.get("subject", ""),
-                        "from": m.get("from", {}).get("emailAddress", {}).get("address", ""),
+                        "from": _sender_address(m),
                         "date": m.get("receivedDateTime") or m.get("sentDateTime"),
-                        "direction": _extract_direction(m.get("from", {}).get("emailAddress", {}).get("address", "")),
+                        "direction": _extract_direction(_sender_address(m)),
                     }
                     for m in msgs
                 ],
@@ -202,15 +205,26 @@ def _extract_direction(from_email: str) -> str:
     return "sent" if _is_trioscs_domain(from_email) else "received"
 
 
+def _sender_address(msg: dict) -> str:
+    """Extract the sender email address from a Graph API message."""
+    return msg.get("from", {}).get("emailAddress", {}).get("address", "")
+
+
+def _recipient_addresses(msg: dict) -> list[str]:
+    """Extract the recipient email addresses from a Graph API message."""
+    return [r.get("emailAddress", {}).get("address", "") for r in msg.get("toRecipients", [])]
+
+
+def _filter_external(messages: list[dict]) -> list[dict]:
+    """Drop internal TRIOSCS-to-TRIOSCS messages, keeping vendor-facing ones."""
+    return [m for m in messages if not _is_internal_message(_sender_address(m), _recipient_addresses(m))]
+
+
 def _extract_participants(messages: list[dict]) -> list[str]:
     """Extract unique non-TRIOSCS participant emails from messages."""
     participants = set()
     for msg in messages:
-        from_addr = msg.get("from", {}).get("emailAddress", {}).get("address", "")
-        if from_addr and not _is_trioscs_domain(from_addr):
-            participants.add(from_addr.lower())
-        for recip in msg.get("toRecipients", []):
-            addr = recip.get("emailAddress", {}).get("address", "")
+        for addr in [_sender_address(msg), *_recipient_addresses(msg)]:
             if addr and not _is_trioscs_domain(addr):
                 participants.add(addr.lower())
     return sorted(participants)
@@ -233,7 +247,7 @@ def _detect_needs_response(messages: list[dict]) -> bool:
         reverse=True,
     )
     last_msg = sorted_msgs[0]
-    from_email = last_msg.get("from", {}).get("emailAddress", {}).get("address", "")
+    from_email = _sender_address(last_msg)
 
     if _is_trioscs_domain(from_email):
         return False  # We sent the last message — no response needed
@@ -257,7 +271,7 @@ def _message_to_dict(msg: dict) -> dict:
     """Convert a Graph API message to our response format."""
     from_data = msg.get("from", {}).get("emailAddress", {})
     from_email = from_data.get("address", "")
-    to_list = [r.get("emailAddress", {}).get("address", "") for r in msg.get("toRecipients", [])]
+    to_list = _recipient_addresses(msg)
 
     return {
         "id": msg.get("id", ""),
@@ -272,6 +286,42 @@ def _message_to_dict(msg: dict) -> dict:
 
 
 # ── Thread fetching for requirements ───────────────────────────────────
+
+
+def _collect_threads_by_conversation(messages: list[dict], known: dict[str, dict], matched_via: str) -> dict[str, dict]:
+    """Group messages by conversationId, drop internal ones, and summarize.
+
+    Conversations already present in ``known`` are skipped (a higher-priority
+    tier already matched them). Conversations with only internal messages are
+    omitted. Returns a {conversation_id: thread_summary} dict.
+    """
+    by_conv: dict[str, list[dict]] = {}
+    for m in messages:
+        cid = m.get("conversationId", "")
+        if cid and cid not in known:
+            by_conv.setdefault(cid, []).append(m)
+
+    summaries: dict[str, dict] = {}
+    for cid, msgs in by_conv.items():
+        external_msgs = _filter_external(msgs)
+        if external_msgs:
+            summaries[cid] = _build_thread_summary(cid, external_msgs, matched_via)
+    return summaries
+
+
+async def _fetch_conversation(gc: GraphClient, conv_id: str) -> list[dict]:
+    """Fetch all external (vendor-facing) messages in a single conversation."""
+    messages = await gc.get_all_pages(
+        "/me/messages",
+        params={
+            "$filter": f"conversationId eq '{conv_id}'",
+            "$select": _MESSAGE_SELECT,
+            "$orderby": "receivedDateTime desc",
+            "$top": "50",
+        },
+        max_items=50,
+    )
+    return _filter_external(messages)
 
 
 async def fetch_threads_for_requirement(
@@ -319,28 +369,9 @@ async def fetch_threads_for_requirement(
         conv_id = contact.graph_conversation_id
         if conv_id and conv_id not in threads:
             try:
-                messages = await gc.get_all_pages(
-                    "/me/messages",
-                    params={
-                        "$filter": f"conversationId eq '{conv_id}'",
-                        "$select": "id,subject,from,toRecipients,bodyPreview,receivedDateTime,conversationId",
-                        "$orderby": "receivedDateTime desc",
-                        "$top": "50",
-                    },
-                    max_items=50,
-                )
-                if messages:
-                    # Filter out internal messages
-                    external_msgs = [
-                        m
-                        for m in messages
-                        if not _is_internal_message(
-                            m.get("from", {}).get("emailAddress", {}).get("address", ""),
-                            [r.get("emailAddress", {}).get("address", "") for r in m.get("toRecipients", [])],
-                        )
-                    ]
-                    if external_msgs:
-                        threads[conv_id] = _build_thread_summary(conv_id, external_msgs, "conversation_id")
+                external_msgs = await _fetch_conversation(gc, conv_id)
+                if external_msgs:
+                    threads[conv_id] = _build_thread_summary(conv_id, external_msgs, "conversation_id")
             except Exception as e:
                 logger.warning(f"Graph query failed for conversationId {conv_id[:20]}: {e}")
 
@@ -357,27 +388,9 @@ async def fetch_threads_for_requirement(
         conv_id = vr.graph_conversation_id
         if conv_id and conv_id not in threads:
             try:
-                messages = await gc.get_all_pages(
-                    "/me/messages",
-                    params={
-                        "$filter": f"conversationId eq '{conv_id}'",
-                        "$select": "id,subject,from,toRecipients,bodyPreview,receivedDateTime,conversationId",
-                        "$orderby": "receivedDateTime desc",
-                        "$top": "50",
-                    },
-                    max_items=50,
-                )
-                if messages:
-                    external_msgs = [
-                        m
-                        for m in messages
-                        if not _is_internal_message(
-                            m.get("from", {}).get("emailAddress", {}).get("address", ""),
-                            [r.get("emailAddress", {}).get("address", "") for r in m.get("toRecipients", [])],
-                        )
-                    ]
-                    if external_msgs:
-                        threads[conv_id] = _build_thread_summary(conv_id, external_msgs, "conversation_id")
+                external_msgs = await _fetch_conversation(gc, conv_id)
+                if external_msgs:
+                    threads[conv_id] = _build_thread_summary(conv_id, external_msgs, "conversation_id")
             except Exception as e:
                 logger.warning(f"Graph query failed for VR conversationId: {e}")
 
@@ -390,29 +403,12 @@ async def fetch_threads_for_requirement(
                 "/me/messages",
                 params={
                     "$search": f'"subject:{avail_token}"',
-                    "$select": "id,subject,from,toRecipients,bodyPreview,receivedDateTime,conversationId",
+                    "$select": _MESSAGE_SELECT,
                     "$top": "50",
                 },
                 max_items=50,
             )
-            # Group by conversationId
-            by_conv: dict[str, list[dict]] = {}
-            for m in subject_msgs:
-                cid = m.get("conversationId", "")
-                if cid and cid not in threads:
-                    by_conv.setdefault(cid, []).append(m)
-
-            for cid, msgs in by_conv.items():
-                external_msgs = [
-                    m
-                    for m in msgs
-                    if not _is_internal_message(
-                        m.get("from", {}).get("emailAddress", {}).get("address", ""),
-                        [r.get("emailAddress", {}).get("address", "") for r in m.get("toRecipients", [])],
-                    )
-                ]
-                if external_msgs:
-                    threads[cid] = _build_thread_summary(cid, external_msgs, "subject_token")
+            threads.update(_collect_threads_by_conversation(subject_msgs, threads, "subject_token"))
         except Exception as e:
             logger.warning(f"Graph subject search failed for {avail_token}: {e}")
 
@@ -424,28 +420,12 @@ async def fetch_threads_for_requirement(
                 "/me/messages",
                 params={
                     "$search": f'"{part_number}"',
-                    "$select": "id,subject,from,toRecipients,bodyPreview,receivedDateTime,conversationId",
+                    "$select": _MESSAGE_SELECT,
                     "$top": "25",
                 },
                 max_items=25,
             )
-            by_conv: dict[str, list[dict]] = {}
-            for m in pn_msgs:
-                cid = m.get("conversationId", "")
-                if cid and cid not in threads:
-                    by_conv.setdefault(cid, []).append(m)
-
-            for cid, msgs in by_conv.items():
-                external_msgs = [
-                    m
-                    for m in msgs
-                    if not _is_internal_message(
-                        m.get("from", {}).get("emailAddress", {}).get("address", ""),
-                        [r.get("emailAddress", {}).get("address", "") for r in m.get("toRecipients", [])],
-                    )
-                ]
-                if external_msgs:
-                    threads[cid] = _build_thread_summary(cid, external_msgs, "part_number")
+            threads.update(_collect_threads_by_conversation(pn_msgs, threads, "part_number"))
         except Exception as e:
             logger.warning(f"Graph part number search failed for {part_number}: {e}")
 
@@ -478,30 +458,12 @@ async def fetch_threads_for_requirement(
                 "/me/messages",
                 params={
                     "$search": f'"from:{domain}"',
-                    "$select": "id,subject,from,toRecipients,bodyPreview,receivedDateTime,conversationId",
+                    "$select": _MESSAGE_SELECT,
                     "$top": "15",
                 },
                 max_items=15,
             )
-            domain_threads = {}
-            by_conv: dict[str, list[dict]] = {}
-            for m in domain_msgs:
-                cid = m.get("conversationId", "")
-                if cid and cid not in threads:
-                    by_conv.setdefault(cid, []).append(m)
-
-            for cid, msgs in by_conv.items():
-                external_msgs = [
-                    m
-                    for m in msgs
-                    if not _is_internal_message(
-                        m.get("from", {}).get("emailAddress", {}).get("address", ""),
-                        [r.get("emailAddress", {}).get("address", "") for r in m.get("toRecipients", [])],
-                    )
-                ]
-                if external_msgs:
-                    domain_threads[cid] = _build_thread_summary(cid, external_msgs, "vendor_domain")
-            return domain_threads
+            return _collect_threads_by_conversation(domain_msgs, threads, "vendor_domain")
         except Exception as e:
             logger.warning(f"Graph domain search failed for {domain}: {e}")
             return {}
@@ -565,7 +527,7 @@ async def fetch_thread_messages(conversation_id: str, user_token: str) -> list[d
             "/me/messages",
             params={
                 "$filter": f"conversationId eq '{conversation_id}'",
-                "$select": "id,subject,from,toRecipients,bodyPreview,receivedDateTime,conversationId",
+                "$select": _MESSAGE_SELECT,
                 "$orderby": "receivedDateTime asc",
                 "$top": "50",
             },
@@ -578,7 +540,7 @@ async def fetch_thread_messages(conversation_id: str, user_token: str) -> list[d
     result = []
     for msg in messages:
         msg_dict = _message_to_dict(msg)
-        # Skip internal messages
+        # Skip internal messages (compares against the cleaned recipient list)
         if _is_internal_message(msg_dict["from_email"], msg_dict["to"]):
             continue
         result.append(msg_dict)
@@ -662,31 +624,12 @@ async def fetch_threads_for_vendor(
                 "/me/messages",
                 params={
                     "$search": f'"from:{domain}" OR "to:{domain}"',
-                    "$select": "id,subject,from,toRecipients,bodyPreview,receivedDateTime,conversationId",
+                    "$select": _MESSAGE_SELECT,
                     "$top": "25",
                 },
                 max_items=50,
             )
-
-            domain_threads = {}
-            by_conv: dict[str, list[dict]] = {}
-            for m in msgs:
-                cid = m.get("conversationId", "")
-                if cid and cid not in threads:
-                    by_conv.setdefault(cid, []).append(m)
-
-            for cid, conv_msgs in by_conv.items():
-                external_msgs = [
-                    m
-                    for m in conv_msgs
-                    if not _is_internal_message(
-                        m.get("from", {}).get("emailAddress", {}).get("address", ""),
-                        [r.get("emailAddress", {}).get("address", "") for r in m.get("toRecipients", [])],
-                    )
-                ]
-                if external_msgs:
-                    domain_threads[cid] = _build_thread_summary(cid, external_msgs, "vendor_domain")
-            return domain_threads
+            return _collect_threads_by_conversation(msgs, threads, "vendor_domain")
         except Exception as e:
             logger.warning(f"Graph vendor search failed for domain {domain}: {e}")
             return {}

--- a/app/services/engagement_scorer.py
+++ b/app/services/engagement_scorer.py
@@ -41,6 +41,15 @@ RECENCY_IDEAL_DAYS = 7  # Contacted within 7 days = perfect
 RECENCY_MAX_DAYS = 365  # Over a year = zero score
 
 
+def _decay_score(value: float, ideal: float, maximum: float) -> float:
+    """Map a metric to 0-100: 100 at/below ``ideal``, 0 at/above ``maximum``, linear between."""
+    if value <= ideal:
+        return 100.0
+    if value >= maximum:
+        return 0.0
+    return max(0.0, 100 * (1 - (value - ideal) / (maximum - ideal)))
+
+
 def compute_engagement_score(
     total_outreach: int,
     total_responses: int,
@@ -75,12 +84,13 @@ def compute_engagement_score(
         }
 
     # ── 1. Response Rate (0-100) ──
-    response_rate = min(total_responses / total_outreach, 1.0) if total_outreach > 0 else 0
+    # total_outreach >= MIN_OUTREACH_FOR_SCORE here, so it is always positive.
+    response_rate = min(total_responses / total_outreach, 1.0)
     response_score = response_rate * 100
 
     # ── 2. Ghost Rate penalty (0-100, inverted: 0 ghosts = 100) ──
-    ghost_rate = 1.0 - response_rate if total_outreach > 0 else None
-    ghost_score = (1.0 - ghost_rate) * 100 if ghost_rate is not None else 0
+    ghost_rate = 1.0 - response_rate
+    ghost_score = (1.0 - ghost_rate) * 100
 
     # ── 3. Recency (0-100) ──
     recency_score = 0.0
@@ -88,29 +98,12 @@ def compute_engagement_score(
         if last_contact_at.tzinfo is None:
             last_contact_at = last_contact_at.replace(tzinfo=timezone.utc)
         days_since = max((now - last_contact_at).total_seconds() / 86400, 0)
-        if days_since <= RECENCY_IDEAL_DAYS:
-            recency_score = 100.0
-        elif days_since >= RECENCY_MAX_DAYS:
-            recency_score = 0.0
-        else:
-            # Linear decay from ideal to max
-            recency_score = max(
-                0,
-                100 * (1 - (days_since - RECENCY_IDEAL_DAYS) / (RECENCY_MAX_DAYS - RECENCY_IDEAL_DAYS)),
-            )
+        recency_score = _decay_score(days_since, RECENCY_IDEAL_DAYS, RECENCY_MAX_DAYS)
 
     # ── 4. Response Velocity (0-100) ──
     velocity_score = 0.0
     if avg_velocity_hours is not None and avg_velocity_hours >= 0:
-        if avg_velocity_hours <= VELOCITY_IDEAL_HOURS:
-            velocity_score = 100.0
-        elif avg_velocity_hours >= VELOCITY_MAX_HOURS:
-            velocity_score = 0.0
-        else:
-            velocity_score = max(
-                0,
-                100 * (1 - (avg_velocity_hours - VELOCITY_IDEAL_HOURS) / (VELOCITY_MAX_HOURS - VELOCITY_IDEAL_HOURS)),
-            )
+        velocity_score = _decay_score(avg_velocity_hours, VELOCITY_IDEAL_HOURS, VELOCITY_MAX_HOURS)
 
     # ── 5. Win Rate (0-100) ──
     win_rate = min(total_wins / total_responses, 1.0) if total_responses > 0 else 0
@@ -128,7 +121,7 @@ def compute_engagement_score(
     return {
         "engagement_score": round(engagement_score, 1),
         "response_rate": round(response_rate, 3),
-        "ghost_rate": round(ghost_rate, 3) if ghost_rate is not None else None,
+        "ghost_rate": round(ghost_rate, 3),
         "recency_score": round(recency_score, 1),
         "velocity_score": round(velocity_score, 1),
         "win_rate": round(win_rate, 3),
@@ -208,7 +201,6 @@ async def compute_all_engagement_scores(db: Session) -> dict:
     # ── Compute average response velocity per vendor ──
     # Velocity = avg time between outbound Contact.created_at and VendorResponse.received_at
     # Matched via contact_id FK, attributed to vendor card via Contact.vendor_name
-    velocity_map = {}
     matched_pairs = (
         db.query(
             Contact.vendor_name,
@@ -237,9 +229,8 @@ async def compute_all_engagement_scores(db: Session) -> dict:
             if hours < 720:  # Ignore >30 days as outliers
                 vendor_velocities.setdefault(norm, []).append(hours)
 
-    for norm, hours_list in vendor_velocities.items():
-        if hours_list:
-            velocity_map[norm] = sum(hours_list) / len(hours_list)
+    # Every list was built via setdefault().append(), so all are non-empty.
+    velocity_map = {norm: sum(hours_list) / len(hours_list) for norm, hours_list in vendor_velocities.items()}
 
     # ── Gather win counts (won offers) per vendor ──
     win_rows = (

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -111,6 +111,33 @@ def _parse_price(value) -> Decimal | None:
         return None
 
 
+def _parse_import_row(raw_row: dict) -> tuple[dict | None, str | None]:
+    """Normalize and validate one import row.
+
+    Returns (fields, None) for a valid row, where fields holds the canonical parsed
+    values (asking_price as Decimal|None), or (None, reason) when the row should be
+    skipped — reason is "blank part_number" or "invalid quantity".
+    """
+    row = _normalize_row(raw_row)
+    part_number = (row.get("part_number") or "").strip()
+    if not part_number:
+        return None, "blank part_number"
+
+    quantity = _parse_quantity(row.get("quantity"))
+    if quantity is None:
+        return None, "invalid quantity"
+
+    fields = {
+        "part_number": part_number,
+        "manufacturer": (row.get("manufacturer") or "").strip() or None,
+        "quantity": quantity,
+        "date_code": (row.get("date_code") or "").strip() or None,
+        "condition": (row.get("condition") or "").strip() or "New",
+        "asking_price": _parse_price(row.get("asking_price")),
+    }
+    return fields, None
+
+
 # ---------------------------------------------------------------------------
 # CRUD operations
 # ---------------------------------------------------------------------------
@@ -224,33 +251,22 @@ def import_line_items(db: Session, list_id: int, rows: list[dict]) -> dict:
     errors: list[str] = []
 
     for i, raw_row in enumerate(rows, start=1):
-        row = _normalize_row(raw_row)
-        part_number = (row.get("part_number") or "").strip()
-        if not part_number:
+        fields, error_reason = _parse_import_row(raw_row)
+        if fields is None:
             skipped += 1
-            errors.append(f"Row {i}: blank part_number — skipped")
+            errors.append(f"Row {i}: {error_reason} — skipped")
             continue
 
-        quantity = _parse_quantity(row.get("quantity"))
-        if quantity is None:
-            skipped += 1
-            errors.append(f"Row {i}: invalid quantity — skipped")
-            continue
-
-        asking_price = _parse_price(row.get("asking_price"))
-        manufacturer = (row.get("manufacturer") or "").strip() or None
-        date_code = (row.get("date_code") or "").strip() or None
-        condition = (row.get("condition") or "").strip() or "New"
-
+        part_number = fields["part_number"]
         item = ExcessLineItem(
             excess_list_id=list_id,
             part_number=part_number,
             normalized_part_number=normalize_mpn_key(part_number) or None,
-            manufacturer=manufacturer,
-            quantity=quantity,
-            date_code=date_code,
-            condition=condition,
-            asking_price=asking_price,
+            manufacturer=fields["manufacturer"],
+            quantity=fields["quantity"],
+            date_code=fields["date_code"],
+            condition=fields["condition"],
+            asking_price=fields["asking_price"],
         )
         db.add(item)
         imported += 1
@@ -284,29 +300,19 @@ def preview_import(rows: list[dict]) -> dict:
             if canonical and key not in column_mapping:
                 column_mapping[key] = canonical
 
-        row = _normalize_row(raw_row)
-        part_number = (row.get("part_number") or "").strip()
-        if not part_number:
-            errors.append(f"Row {i}: blank part_number — will be skipped")
+        fields, error_reason = _parse_import_row(raw_row)
+        if fields is None:
+            errors.append(f"Row {i}: {error_reason} — will be skipped")
             continue
 
-        quantity = _parse_quantity(row.get("quantity"))
-        if quantity is None:
-            errors.append(f"Row {i}: invalid quantity — will be skipped")
-            continue
-
-        asking_price = _parse_price(row.get("asking_price"))
-        manufacturer = (row.get("manufacturer") or "").strip() or None
-        date_code = (row.get("date_code") or "").strip() or None
-        condition = (row.get("condition") or "").strip() or "New"
-
+        asking_price = fields["asking_price"]
         valid_rows.append(
             {
-                "part_number": part_number,
-                "manufacturer": manufacturer,
-                "quantity": quantity,
-                "date_code": date_code,
-                "condition": condition,
+                "part_number": fields["part_number"],
+                "manufacturer": fields["manufacturer"],
+                "quantity": fields["quantity"],
+                "date_code": fields["date_code"],
+                "condition": fields["condition"],
                 "asking_price": float(asking_price) if asking_price is not None else None,
             }
         )
@@ -352,6 +358,52 @@ def confirm_import(db: Session, list_id: int, validated_rows: list[dict]) -> dic
 # ---------------------------------------------------------------------------
 # Demand matching
 # ---------------------------------------------------------------------------
+
+
+def _create_excess_offer(
+    db: Session,
+    *,
+    item: ExcessLineItem,
+    req: Requirement,
+    vendor_name: str,
+    norm_key: str,
+    user_id: int,
+    notes: str,
+) -> Offer:
+    """Create an Offer from an excess line item / requirement pair, flush it, and log
+    the OFFER_CREATED activity.
+
+    Returns the persisted Offer.
+    """
+    offer = Offer(
+        requisition_id=req.requisition_id,
+        requirement_id=req.id,
+        excess_line_item_id=item.id,
+        vendor_name=vendor_name,
+        mpn=item.part_number,
+        normalized_mpn=norm_key,
+        manufacturer=item.manufacturer,
+        qty_available=item.quantity,
+        unit_price=item.asking_price,
+        source="excess",
+        condition=item.condition,
+        date_code=item.date_code,
+        entered_by_id=user_id,
+        notes=notes,
+    )
+    db.add(offer)
+    db.flush()
+    log_activity(
+        db,
+        activity_type=ActivityType.OFFER_CREATED,
+        requisition_id=offer.requisition_id,
+        requirement_id=offer.requirement_id,
+        user_id=user_id,
+        vendor_card_id=offer.vendor_card_id,
+        description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
+        details={"offer_id": offer.id, "source": offer.source},
+    )
+    return offer
 
 
 def match_excess_demand(db: Session, list_id: int, *, user_id: int) -> dict:
@@ -403,33 +455,14 @@ def match_excess_demand(db: Session, list_id: int, *, user_id: int) -> dict:
             if existing:
                 continue
 
-            offer = Offer(
-                requisition_id=req.requisition_id,
-                requirement_id=req.id,
-                excess_line_item_id=item.id,
-                vendor_name=vendor_name,
-                mpn=item.part_number,
-                normalized_mpn=norm_key,
-                manufacturer=item.manufacturer,
-                qty_available=item.quantity,
-                unit_price=item.asking_price,
-                source="excess",
-                condition=item.condition,
-                date_code=item.date_code,
-                entered_by_id=user_id,
-                notes=f"Auto-matched from excess list: {excess_list.title}",
-            )
-            db.add(offer)
-            db.flush()
-            log_activity(
+            _create_excess_offer(
                 db,
-                activity_type=ActivityType.OFFER_CREATED,
-                requisition_id=offer.requisition_id,
-                requirement_id=offer.requirement_id,
+                item=item,
+                req=req,
+                vendor_name=vendor_name,
+                norm_key=norm_key,
                 user_id=user_id,
-                vendor_card_id=offer.vendor_card_id,
-                description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
-                details={"offer_id": offer.id, "source": offer.source},
+                notes=f"Auto-matched from excess list: {excess_list.title}",
             )
             item_matches += 1
             matches_created += 1
@@ -653,36 +686,16 @@ def create_proactive_matches_for_excess(
         )
 
         # If no offer exists from demand matching, create a standalone one
-        if not offer and requirements:
-            req = requirements[0]
+        if not offer:
             vendor_name = excess_list.company.name if excess_list.company else "Unknown"
-            offer = Offer(
-                requisition_id=req.requisition_id,
-                requirement_id=req.id,
-                excess_line_item_id=item.id,
-                vendor_name=vendor_name,
-                mpn=item.part_number,
-                normalized_mpn=norm_key,
-                manufacturer=item.manufacturer,
-                qty_available=item.quantity,
-                unit_price=item.asking_price,
-                source="excess",
-                condition=item.condition,
-                date_code=item.date_code,
-                entered_by_id=user_id,
-                notes=f"Proactive match from archived excess list: {excess_list.title}",
-            )
-            db.add(offer)
-            db.flush()
-            log_activity(
+            offer = _create_excess_offer(
                 db,
-                activity_type=ActivityType.OFFER_CREATED,
-                requisition_id=offer.requisition_id,
-                requirement_id=offer.requirement_id,
+                item=item,
+                req=requirements[0],
+                vendor_name=vendor_name,
+                norm_key=norm_key,
                 user_id=user_id,
-                vendor_card_id=offer.vendor_card_id,
-                description=f"Offer added: {offer.vendor_name} — {offer.mpn}",
-                details={"offer_id": offer.id, "source": offer.source},
+                notes=f"Proactive match from archived excess list: {excess_list.title}",
             )
 
         if not offer:

--- a/app/services/health_service.py
+++ b/app/services/health_service.py
@@ -4,7 +4,12 @@ Called by: main.py health endpoint
 Depends on: config.py settings
 """
 
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
 from loguru import logger
+
+from ..config import settings
 
 BACKUP_TIMESTAMP_FILE = "/app/uploads/.last_backup"
 
@@ -14,11 +19,6 @@ def check_backup_freshness() -> str:
 
     Returns "ok", "stale", or "unknown".
     """
-    from datetime import datetime, timedelta, timezone
-    from pathlib import Path
-
-    from ..config import settings
-
     ts_path = Path(BACKUP_TIMESTAMP_FILE)
     if not ts_path.exists():
         return "unknown"

--- a/app/services/multiplier_score_service.py
+++ b/app/services/multiplier_score_service.py
@@ -34,6 +34,7 @@ from ..models import (
     User,
 )
 from ..models.performance import AvailScoreSnapshot, MultiplierScoreSnapshot
+from .scoring_helpers import month_range
 
 # ── Point values ─────────────────────────────────────────────────────
 # Buyer offer pipeline (non-stacking — highest tier only)
@@ -67,13 +68,6 @@ MIN_ACTIVITIES_SALES = 20
 # ══════════════════════════════════════════════════════════════════════
 #  HELPERS
 # ══════════════════════════════════════════════════════════════════════
-
-
-def _month_range(month: date):
-    """Return (start_dt, end_dt) as aware datetimes for the given month."""
-    from app.services.scoring_helpers import month_range
-
-    return month_range(month)
 
 
 def _load_quoted_offer_ids(db: Session) -> set[int]:
@@ -125,7 +119,7 @@ def compute_buyer_multiplier(
 
     Pre-loaded lookup sets can be passed to avoid re-querying per user.
     """
-    start_dt, end_dt = _month_range(month)
+    start_dt, end_dt = month_range(month)
 
     # Load global lookups if not provided
     if quoted_ids is None:
@@ -250,7 +244,7 @@ def compute_sales_multiplier(db: Session, user_id: int, month: date) -> dict:
     Quote progression is non-stacking (won replaces sent). Proactive conversion is non-
     stacking (converted replaces sent). New account points are additive.
     """
-    start_dt, end_dt = _month_range(month)
+    start_dt, end_dt = month_range(month)
 
     # ── Quotes: non-stacking (won replaces sent) ──
     quotes_sent = (
@@ -541,44 +535,26 @@ def determine_bonus_winners(db: Session, role_type: str, month: date) -> list[di
         .all()
     )
 
+    # Ranked tiers: each slot requires the next-ranked row to clear its qualify
+    # threshold. A row that fails the current slot's threshold is skipped, not
+    # promoted, so the positional check must use len(winners) as the slot index.
+    tiers = [(QUALIFY_SCORE_1ST, BONUS_1ST), (QUALIFY_SCORE_2ND, BONUS_2ND)]
+
     winners = []
     for snap, user_name in rows:
-        if len(winners) >= 2:
+        if len(winners) >= len(tiers):
             break
 
-        if len(winners) == 0 and snap.avail_score >= QUALIFY_SCORE_1ST:
+        min_score, bonus_amount = tiers[len(winners)]
+        if snap.avail_score >= min_score:
             winners.append(
                 {
                     "user_id": snap.user_id,
                     "user_name": user_name,
-                    "rank": 1,
+                    "rank": len(winners) + 1,
                     "total_points": snap.total_points,
                     "avail_score": snap.avail_score,
-                    "bonus_amount": BONUS_1ST,
-                }
-            )
-        elif len(winners) == 1 and snap.avail_score >= QUALIFY_SCORE_2ND:
-            winners.append(
-                {
-                    "user_id": snap.user_id,
-                    "user_name": user_name,
-                    "rank": 2,
-                    "total_points": snap.total_points,
-                    "avail_score": snap.avail_score,
-                    "bonus_amount": BONUS_2ND,
-                }
-            )
-        elif (
-            len(winners) == 2 and snap.avail_score >= QUALIFY_SCORE_3RD
-        ):  # pragma: no cover — unreachable: break at >=2
-            winners.append(
-                {
-                    "user_id": snap.user_id,
-                    "user_name": user_name,
-                    "rank": 3,
-                    "total_points": snap.total_points,
-                    "avail_score": snap.avail_score,
-                    "bonus_amount": BONUS_3RD,
+                    "bonus_amount": bonus_amount,
                 }
             )
 

--- a/app/services/ownership_service.py
+++ b/app/services/ownership_service.py
@@ -56,23 +56,12 @@ async def run_ownership_sweep(db: Session) -> dict:
     )
 
     for company in owned:
-        inactivity_limit = (
-            settings.strategic_inactivity_days if company.is_strategic else settings.customer_inactivity_days
-        )
-        warning_day = inactivity_limit - 7  # 7 days before expiration
+        inactivity_limit, warning_day = _company_limits(company)
 
         days_inactive = _days_since_activity(company, now)
         if days_inactive is None:
             # No activity ever recorded — use created_at as baseline
-            if company.created_at:
-                created = (
-                    company.created_at.replace(tzinfo=timezone.utc)
-                    if company.created_at.tzinfo is None
-                    else company.created_at
-                )
-                days_inactive = (now - created).days
-            else:
-                days_inactive = 999  # Force clear
+            days_inactive = _days_since_created(company.created_at, now)
 
         # Past limit → clear ownership
         if days_inactive >= inactivity_limit:
@@ -163,10 +152,7 @@ def get_accounts_at_risk(db: Session) -> list[dict]:
 
     at_risk = []
     for company, owner in owned:
-        inactivity_limit = (
-            settings.strategic_inactivity_days if company.is_strategic else settings.customer_inactivity_days
-        )
-        warning_day = inactivity_limit - 7
+        inactivity_limit, warning_day = _company_limits(company)
 
         days_inactive = _days_since_activity(company, now)
         if days_inactive is None:
@@ -232,18 +218,9 @@ def get_my_accounts(user_id: int, db: Session) -> list[dict]:
 
     results = []
     for c in companies:
-        inactivity_limit = settings.strategic_inactivity_days if c.is_strategic else settings.customer_inactivity_days
-        warning_day = inactivity_limit - 7
+        inactivity_limit, warning_day = _company_limits(c)
         days_inactive = _days_since_activity(c, now)
-
-        if days_inactive is None:
-            status = "no_activity"
-        elif days_inactive <= warning_day:
-            status = "green"
-        elif days_inactive <= inactivity_limit:
-            status = "yellow"
-        else:
-            status = "red"
+        status = _health_status(days_inactive, warning_day, inactivity_limit)
 
         results.append(
             {
@@ -342,13 +319,7 @@ def run_site_ownership_sweep(db: Session) -> dict:
     for site in owned:
         days_inactive = _site_days_since_activity(site, now)
         if days_inactive is None:
-            if site.created_at:
-                created = (
-                    site.created_at.replace(tzinfo=timezone.utc) if site.created_at.tzinfo is None else site.created_at
-                )
-                days_inactive = (now - created).days
-            else:
-                days_inactive = 999
+            days_inactive = _days_since_created(site.created_at, now)
 
         if days_inactive >= inactivity_limit:
             site.owner_id = None
@@ -480,14 +451,7 @@ def get_my_sites(user_id: int, db: Session) -> list[dict]:
         co = company_cache[s.company_id]
 
         days_inactive = _site_days_since_activity(s, now)
-        if days_inactive is None:
-            status = "no_activity"
-        elif days_inactive <= warning_day:
-            status = "green"
-        elif days_inactive <= inactivity_limit:
-            status = "yellow"
-        else:
-            status = "red"
+        status = _health_status(days_inactive, warning_day, inactivity_limit)
 
         results.append(
             {
@@ -556,12 +520,7 @@ def get_sites_at_risk(db: Session) -> list[dict]:
 
 def _site_days_since_activity(site: CustomerSite, now: datetime) -> int | None:
     """Calculate days since last activity for a site."""
-    if not site.last_activity_at:
-        return None
-    last = site.last_activity_at
-    if last.tzinfo is None:
-        last = last.replace(tzinfo=timezone.utc)
-    return (now - last).days
+    return _days_since(site.last_activity_at, now)
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -569,17 +528,48 @@ def _site_days_since_activity(site: CustomerSite, now: datetime) -> int | None:
 # ═══════════════════════════════════════════════════════════════════════
 
 
+def _days_since(last_activity_at: datetime | None, now: datetime) -> int | None:
+    """Whole days between a (possibly naive) timestamp and now, or None if unset."""
+    if not last_activity_at:
+        return None
+    last = last_activity_at
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=timezone.utc)
+    return (now - last).days
+
+
+def _days_since_created(created_at: datetime | None, now: datetime) -> int:
+    """Days since creation, used as the inactivity baseline when no activity exists.
+
+    Returns 999 (force-clear) when no creation timestamp is available.
+    """
+    days = _days_since(created_at, now)
+    return days if days is not None else 999
+
+
+def _company_limits(company: Company) -> tuple[int, int]:
+    """Return (inactivity_limit, warning_day) for a company (strategic vs standard)."""
+    inactivity_limit = settings.strategic_inactivity_days if company.is_strategic else settings.customer_inactivity_days
+    return inactivity_limit, inactivity_limit - 7  # warning fires 7 days before expiration
+
+
+def _health_status(days_inactive: int | None, warning_day: int, inactivity_limit: int) -> str:
+    """Map inactivity to a dashboard health color (no_activity/green/yellow/red)."""
+    if days_inactive is None:
+        return "no_activity"
+    if days_inactive <= warning_day:
+        return "green"
+    if days_inactive <= inactivity_limit:
+        return "yellow"
+    return "red"
+
+
 def _days_since_activity(company: Company, now: datetime) -> int | None:
     """Calculate days since last activity for a company.
 
     Uses company.last_activity_at (precomputed field updated on each activity log).
     """
-    if not company.last_activity_at:
-        return None
-    last = company.last_activity_at
-    if last.tzinfo is None:
-        last = last.replace(tzinfo=timezone.utc)
-    return (now - last).days
+    return _days_since(company.last_activity_at, now)
 
 
 def _clear_ownership(company: Company, db: Session):

--- a/app/services/part_offers.py
+++ b/app/services/part_offers.py
@@ -42,20 +42,16 @@ def part_offers_for(requirement: Requirement, db: Session) -> list[Offer]:
     if not mpns:
         return []
 
-    norm_keys: set[str] = set()
+    key_mpns = {normalize_mpn_key(m) for m in mpns}
+
+    norm_keys = set(key_mpns)
     for m in mpns:
-        norm_keys.add(normalize_mpn_key(m))
         disp = normalize_mpn(m)
         if disp:
             norm_keys.add(disp)
     norm_keys.discard("")
 
-    card_ids = {
-        cid
-        for (cid,) in db.query(MaterialCard.id)
-        .filter(MaterialCard.normalized_mpn.in_({normalize_mpn_key(m) for m in mpns}))
-        .all()
-    }
+    card_ids = {cid for (cid,) in db.query(MaterialCard.id).filter(MaterialCard.normalized_mpn.in_(key_mpns)).all()}
 
     conds = [Offer.normalized_mpn.in_(norm_keys)]
     if card_ids:

--- a/app/services/proactive_matching.py
+++ b/app/services/proactive_matching.py
@@ -153,6 +153,9 @@ def _find_matches(
     company_id only (no offer_id filter). requirement_id and requisition_id are nullable
     — matches without historical requisitions are valid.
     """
+    # Lazy import (avoids an import-time cycle with activity_service); resolved once per call.
+    from .activity_service import _update_last_activity
+
     min_margin = settings.proactive_min_margin_pct
     mpn_upper = normalize_mpn(mpn) or mpn.upper().strip()
 
@@ -302,8 +305,6 @@ def _find_matches(
         )
 
         if cph.company_id:
-            from .activity_service import _update_last_activity
-
             _update_last_activity({"type": "company", "id": cph.company_id}, db)
 
     return matches

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -302,13 +302,12 @@ async def send_proactive_offer(
             </tr>"""
 
         contact_names = ", ".join(c.full_name for c in contacts if c.full_name)
-        greeting = (
-            f"Hi {html.escape(str(contacts[0].full_name))},"
-            if len(contacts) == 1 and contacts[0].full_name
-            else f"Hi {html.escape(str(contact_names))},"
-            if contact_names
-            else "Hello,"
-        )
+        if len(contacts) == 1 and contacts[0].full_name:
+            greeting = f"Hi {html.escape(str(contacts[0].full_name))},"
+        elif contact_names:
+            greeting = f"Hi {html.escape(str(contact_names))},"
+        else:
+            greeting = "Hello,"
 
         notes_html = f'<p style="margin-top:12px">{html.escape(str(notes))}</p>' if notes else ""
         salesperson_name = user.name or user.email.split("@")[0]
@@ -382,27 +381,30 @@ async def send_proactive_offer(
     # Upsert throttle entries only if the email was actually sent
     if send_succeeded:
         now = datetime.now(timezone.utc)
-        for m in matches:
-            existing_throttle = (
-                db.query(ProactiveThrottle)
-                .filter(
-                    ProactiveThrottle.mpn == m.mpn,
-                    ProactiveThrottle.customer_site_id == site_id,
-                )
-                .first()
+        # Batch-load existing throttles for these MPNs (one query instead of N).
+        mpns = {m.mpn for m in matches}
+        throttle_by_mpn = {
+            t.mpn: t
+            for t in db.query(ProactiveThrottle).filter(
+                ProactiveThrottle.mpn.in_(mpns),
+                ProactiveThrottle.customer_site_id == site_id,
             )
+        }
+        for m in matches:
+            existing_throttle = throttle_by_mpn.get(m.mpn)
             if existing_throttle:
                 existing_throttle.last_offered_at = now
                 existing_throttle.proactive_offer_id = po.id
             else:
-                db.add(
-                    ProactiveThrottle(
-                        mpn=m.mpn,
-                        customer_site_id=site_id,
-                        last_offered_at=now,
-                        proactive_offer_id=po.id,
-                    )
+                new_throttle = ProactiveThrottle(
+                    mpn=m.mpn,
+                    customer_site_id=site_id,
+                    last_offered_at=now,
+                    proactive_offer_id=po.id,
                 )
+                db.add(new_throttle)
+                # Mirror autoflush: a later match with the same MPN updates this row.
+                throttle_by_mpn[m.mpn] = new_throttle
 
     db.commit()
     return _proactive_offer_to_dict(po)
@@ -590,6 +592,13 @@ def get_scorecard(db: Session, salesperson_id: int | None = None) -> dict:
     def _capped(col):
         return case((col > CAP, 0), else_=col)
 
+    # Capped sum of a column, restricted to rows in a given status.
+    def _summed_when(status, col):
+        return func.coalesce(
+            func.sum(case((ProactiveOffer.status == status, _capped(func.coalesce(col, 0))))),
+            0,
+        )
+
     # Base filter
     base_filter = []
     if salesperson_id:
@@ -600,39 +609,9 @@ def get_scorecard(db: Session, salesperson_id: int | None = None) -> dict:
         db.query(
             func.count(ProactiveOffer.id).label("sent"),
             func.count(case((ProactiveOffer.status == ProactiveOfferStatus.CONVERTED, 1))).label("converted"),
-            func.coalesce(
-                func.sum(
-                    case(
-                        (
-                            ProactiveOffer.status == ProactiveOfferStatus.CONVERTED,
-                            _capped(func.coalesce(ProactiveOffer.total_sell, 0)),
-                        )
-                    )
-                ),
-                0,
-            ).label("converted_revenue"),
-            func.coalesce(
-                func.sum(
-                    case(
-                        (
-                            ProactiveOffer.status == ProactiveOfferStatus.CONVERTED,
-                            _capped(func.coalesce(ProactiveOffer.total_cost, 0)),
-                        )
-                    )
-                ),
-                0,
-            ).label("converted_cost"),
-            func.coalesce(
-                func.sum(
-                    case(
-                        (
-                            ProactiveOffer.status == ProactiveOfferStatus.SENT,
-                            _capped(func.coalesce(ProactiveOffer.total_sell, 0)),
-                        )
-                    )
-                ),
-                0,
-            ).label("pending_revenue"),
+            _summed_when(ProactiveOfferStatus.CONVERTED, ProactiveOffer.total_sell).label("converted_revenue"),
+            _summed_when(ProactiveOfferStatus.CONVERTED, ProactiveOffer.total_cost).label("converted_cost"),
+            _summed_when(ProactiveOfferStatus.SENT, ProactiveOffer.total_sell).label("pending_revenue"),
             func.count(ProactiveOffer.converted_quote_id).label("quoted"),
         )
         .filter(*base_filter)
@@ -680,39 +659,9 @@ def get_scorecard(db: Session, salesperson_id: int | None = None) -> dict:
                 ProactiveOffer.salesperson_id,
                 func.count(ProactiveOffer.id).label("sent"),
                 func.count(case((ProactiveOffer.status == ProactiveOfferStatus.CONVERTED, 1))).label("converted"),
-                func.coalesce(
-                    func.sum(
-                        case(
-                            (
-                                ProactiveOffer.status == ProactiveOfferStatus.CONVERTED,
-                                _capped(func.coalesce(ProactiveOffer.total_sell, 0)),
-                            )
-                        )
-                    ),
-                    0,
-                ).label("rev"),
-                func.coalesce(
-                    func.sum(
-                        case(
-                            (
-                                ProactiveOffer.status == ProactiveOfferStatus.CONVERTED,
-                                _capped(func.coalesce(ProactiveOffer.total_cost, 0)),
-                            )
-                        )
-                    ),
-                    0,
-                ).label("cost"),
-                func.coalesce(
-                    func.sum(
-                        case(
-                            (
-                                ProactiveOffer.status == ProactiveOfferStatus.SENT,
-                                _capped(func.coalesce(ProactiveOffer.total_sell, 0)),
-                            )
-                        )
-                    ),
-                    0,
-                ).label("pending"),
+                _summed_when(ProactiveOfferStatus.CONVERTED, ProactiveOffer.total_sell).label("rev"),
+                _summed_when(ProactiveOfferStatus.CONVERTED, ProactiveOffer.total_cost).label("cost"),
+                _summed_when(ProactiveOfferStatus.SENT, ProactiveOffer.total_sell).label("pending"),
                 func.count(ProactiveOffer.converted_quote_id).label("quoted"),
             )
             .group_by(ProactiveOffer.salesperson_id)

--- a/app/services/prospect_claim.py
+++ b/app/services/prospect_claim.py
@@ -18,6 +18,28 @@ from app.models import Company, User
 from app.models.crm import CustomerSite, SiteContact
 from app.models.prospect_account import ProspectAccount
 
+
+def _split_hq_location(hq_location: str | None) -> tuple[str | None, str | None]:
+    """Split a 'City, State' HQ location into (city, state).
+
+    Returns (None, None) when there's no comma to split on. Mirrors the prior
+    inline logic: the first comma-delimited field is the city and the second is
+    the state (any further fields are ignored).
+    """
+    if not hq_location or "," not in hq_location:
+        return None, None
+    parts = hq_location.split(",")
+    return parts[0].strip(), parts[1].strip()
+
+
+def _format_similar_names(similar: list, limit: int) -> str:
+    """Join the first `limit` similar customers into a comma-separated string.
+
+    Each entry may be a dict (use its ``name``) or a bare string/value.
+    """
+    return ", ".join(s.get("name", s) if isinstance(s, dict) else str(s) for s in similar[:limit])
+
+
 # ── Claim ────────────────────────────────────────────────────────────
 
 
@@ -76,21 +98,14 @@ def claim_prospect(prospect_id: int, user_id: int, db: Session) -> dict:
             )
         else:
             # Create new Company from prospect data
+            hq_city, hq_state = _split_hq_location(prospect.hq_location)
             company = Company(
                 name=prospect.name,
                 domain=prospect.domain,
                 website=prospect.website,
                 industry=prospect.industry,
-                hq_city=(
-                    prospect.hq_location.split(",")[0].strip()
-                    if prospect.hq_location and "," in prospect.hq_location
-                    else None
-                ),
-                hq_state=(
-                    prospect.hq_location.split(",")[1].strip()
-                    if prospect.hq_location and "," in prospect.hq_location
-                    else None
-                ),
+                hq_city=hq_city,
+                hq_state=hq_state,
                 employee_size=prospect.employee_count_range,
                 is_active=True,
                 account_owner_id=user_id,
@@ -99,8 +114,6 @@ def claim_prospect(prospect_id: int, user_id: int, db: Session) -> dict:
             db.add(company)
             db.flush()
             # Auto-create default HQ site so company appears in pickers
-            from app.models.crm import CustomerSite
-
             default_site = CustomerSite(company_id=company.id, site_name="HQ")
             db.add(default_site)
             db.flush()
@@ -166,19 +179,12 @@ def reveal_contacts(prospect: ProspectAccount, db: Session) -> list[dict]:
     # Create or find a CustomerSite for this company (HQ site)
     site = db.query(CustomerSite).filter(CustomerSite.company_id == prospect.company_id).first()
     if not site:
+        hq_city, hq_state = _split_hq_location(prospect.hq_location)
         site = CustomerSite(
             company_id=prospect.company_id,
             site_name=f"{prospect.name} - HQ",
-            city=(
-                prospect.hq_location.split(",")[0].strip()
-                if prospect.hq_location and "," in prospect.hq_location
-                else None
-            ),
-            state=(
-                prospect.hq_location.split(",")[1].strip()
-                if prospect.hq_location and "," in prospect.hq_location and len(prospect.hq_location.split(",")) > 1
-                else None
-            ),
+            city=hq_city,
+            state=hq_state,
             is_active=True,
         )
         db.add(site)
@@ -247,7 +253,7 @@ async def generate_account_briefing(prospect_id: int, db: Session) -> str | None
     similar = prospect.similar_customers or []
 
     # Build context for the AI
-    similar_names = ", ".join(s.get("name", s) if isinstance(s, dict) else str(s) for s in similar[:5])
+    similar_names = _format_similar_names(similar, 5)
 
     prompt = f"""Generate a concise account briefing for a salesperson about to contact this prospect.
 
@@ -314,7 +320,7 @@ def _template_briefing(prospect: ProspectAccount, signals: dict, similar: list) 
         parts.append(f"**Hiring Signal:** Recruiting {hiring['type']} — indicates growth/expansion.")
 
     if similar:
-        names = ", ".join(s.get("name", s) if isinstance(s, dict) else str(s) for s in similar[:3])
+        names = _format_similar_names(similar, 3)
         parts.append(f"\n**Similar Customers:** {names}")
         parts.append("Reference these relationships to build credibility on the first call.")
 

--- a/app/services/prospect_scoring.py
+++ b/app/services/prospect_scoring.py
@@ -91,19 +91,9 @@ ICP_SEGMENTS = {
     },
 }
 
-ALL_NAICS_CODES = []
-for seg in ICP_SEGMENTS.values():
-    ALL_NAICS_CODES.extend(seg["naics_codes"])
-
-ALL_NAICS_4DIGIT = set()
-for seg in ICP_SEGMENTS.values():
-    for code in seg["naics_codes"]:
-        ALL_NAICS_4DIGIT.add(code[:4])
-
-ALL_NAICS_3DIGIT = set()
-for seg in ICP_SEGMENTS.values():
-    for code in seg["naics_codes"]:
-        ALL_NAICS_3DIGIT.add(code[:3])
+ALL_NAICS_CODES = [code for seg in ICP_SEGMENTS.values() for code in seg["naics_codes"]]
+ALL_NAICS_4DIGIT = {code[:4] for code in ALL_NAICS_CODES}
+ALL_NAICS_3DIGIT = {code[:3] for code in ALL_NAICS_CODES}
 
 # ── Fit Score Weights ────────────────────────────────────────────────
 
@@ -357,27 +347,26 @@ def calculate_readiness_score(prospect_data: dict, signals: dict) -> tuple[int, 
     }
 
     # 2. Recent company events (0-25)
+    # No events = no signal (score stays 0, not neutral — absence of events is informative).
     events = signals.get("events", [])
     event_score = 0
     event_details = []
     if isinstance(events, list):
         for ev in events:
-            ev_type = ev.get("type", "") if isinstance(ev, dict) else ""
-            if "funding" in ev_type.lower():
+            ev_type = (ev.get("type", "") if isinstance(ev, dict) else "").lower()
+            if "funding" in ev_type:
                 event_score = max(event_score, 25)
                 event_details.append("funding")
-            elif "product" in ev_type.lower() or "launch" in ev_type.lower():
+            elif "product" in ev_type or "launch" in ev_type:
                 event_score = max(event_score, 20)
                 event_details.append("new_product")
-            elif "expansion" in ev_type.lower() or "office" in ev_type.lower():
+            elif "expansion" in ev_type or "office" in ev_type:
                 event_score = max(event_score, 20)
                 event_details.append("expansion")
-            elif "acquisition" in ev_type.lower() or "m&a" in ev_type.lower() or "merger" in ev_type.lower():
+            elif "acquisition" in ev_type or "m&a" in ev_type or "merger" in ev_type:
                 event_score = max(event_score, 15)
                 event_details.append("m&a")
     event_score = min(event_score, READINESS_WEIGHT_EVENTS)
-    if not events:
-        event_score = 0  # no events = no signal (not neutral — absence of events is informative)
     total += event_score
     breakdown["events"] = {
         "score": event_score,

--- a/app/services/prospect_warm_intros.py
+++ b/app/services/prospect_warm_intros.py
@@ -51,6 +51,13 @@ def detect_warm_intros(prospect: ProspectAccount, db: Session) -> dict:
         "sighting_count": 0,
     }
 
+    def mark_warm() -> None:
+        """Promote a still-cold prospect to a warm intro (never downgrades a hot
+        one)."""
+        if not result["has_warm_intro"]:
+            result["has_warm_intro"] = True
+            result["warmth"] = "warm"
+
     # 1. VendorCard domain match
     vc = db.query(VendorCard).filter(VendorCard.domain == domain).first()
     if vc:
@@ -109,9 +116,8 @@ def detect_warm_intros(prospect: ProspectAccount, db: Session) -> dict:
                 "company": row.company_name,
             }
         )
-        if not result["has_warm_intro"]:
-            result["has_warm_intro"] = True
-            result["warmth"] = "warm"
+    if internal:
+        mark_warm()
 
     # 3. Sighting count from this domain
     try:
@@ -121,9 +127,8 @@ def detect_warm_intros(prospect: ProspectAccount, db: Session) -> dict:
             db.query(func.count(Sighting.id)).filter(Sighting.vendor_email.ilike(domain_pattern)).scalar() or 0
         )
         result["sighting_count"] = sighting_count
-        if sighting_count > 0 and not result["has_warm_intro"]:
-            result["has_warm_intro"] = True
-            result["warmth"] = "warm"
+        if sighting_count > 0:
+            mark_warm()
     except Exception as e:
         logger.warning("Warm intro sighting lookup failed: {}", e)
 

--- a/app/services/quote_builder_service.py
+++ b/app/services/quote_builder_service.py
@@ -20,6 +20,7 @@ def get_builder_data(
     requirement_ids: list[int] | None = None,
 ) -> list[dict]:
     """Load requirements + offers for the quote builder modal."""
+    from app.constants import OfferStatus
     from app.models import Requirement
 
     query = db.query(Requirement).options(joinedload(Requirement.offers)).filter(Requirement.requisition_id == req_id)
@@ -30,27 +31,24 @@ def get_builder_data(
 
     lines = []
     for r in requirements:
-        from app.constants import OfferStatus
-
-        active_offers = [o for o in r.offers if o.status == OfferStatus.ACTIVE]
-        offers_data = []
-        for o in active_offers:
-            offers_data.append(
-                {
-                    "id": o.id,
-                    "vendor_name": o.vendor_name,
-                    "unit_price": float(o.unit_price) if o.unit_price else 0,
-                    "qty_available": o.qty_available or 0,
-                    "lead_time": o.lead_time,
-                    "date_code": o.date_code,
-                    "condition": o.condition,
-                    "packaging": o.packaging,
-                    "moq": o.moq,
-                    "confidence": o.parse_confidence,
-                    "material_card_id": o.material_card_id,
-                    "notes": o.notes,
-                }
-            )
+        offers_data = [
+            {
+                "id": o.id,
+                "vendor_name": o.vendor_name,
+                "unit_price": float(o.unit_price) if o.unit_price else 0,
+                "qty_available": o.qty_available or 0,
+                "lead_time": o.lead_time,
+                "date_code": o.date_code,
+                "condition": o.condition,
+                "packaging": o.packaging,
+                "moq": o.moq,
+                "confidence": o.parse_confidence,
+                "material_card_id": o.material_card_id,
+                "notes": o.notes,
+            }
+            for o in r.offers
+            if o.status == OfferStatus.ACTIVE
+        ]
 
         lines.append(
             {
@@ -220,26 +218,25 @@ def save_quote_from_builder(
     if not req:
         raise ValueError("Requisition not found")
 
-    line_items = []
-    for li in payload.lines:
-        line_items.append(
-            {
-                "mpn": li.mpn,
-                "manufacturer": li.manufacturer,
-                "qty": li.qty,
-                "cost_price": li.cost_price,
-                "sell_price": li.sell_price,
-                "margin_pct": li.margin_pct,
-                "lead_time": li.lead_time,
-                "date_code": li.date_code,
-                "condition": li.condition,
-                "packaging": li.packaging,
-                "moq": li.moq,
-                "offer_id": li.offer_id,
-                "material_card_id": li.material_card_id,
-                "notes": li.notes,
-            }
-        )
+    line_items = [
+        {
+            "mpn": li.mpn,
+            "manufacturer": li.manufacturer,
+            "qty": li.qty,
+            "cost_price": li.cost_price,
+            "sell_price": li.sell_price,
+            "margin_pct": li.margin_pct,
+            "lead_time": li.lead_time,
+            "date_code": li.date_code,
+            "condition": li.condition,
+            "packaging": li.packaging,
+            "moq": li.moq,
+            "offer_id": li.offer_id,
+            "material_card_id": li.material_card_id,
+            "notes": li.notes,
+        }
+        for li in payload.lines
+    ]
 
     total_sell = sum(li["qty"] * li["sell_price"] for li in line_items)
     total_cost = sum(li["qty"] * li["cost_price"] for li in line_items)
@@ -247,16 +244,13 @@ def save_quote_from_builder(
 
     # Rename old quote to Q-XXXX-R{n} so the new revision keeps the canonical number
     revision = 1
-    if payload.quote_id:
-        old_quote = db.get(Quote, payload.quote_id)
-        if old_quote:
-            old_revision = old_quote.revision or 1
-            quote_number = old_quote.quote_number
-            revision = old_revision + 1
-            old_quote.quote_number = f"{quote_number}-R{old_revision}"
-            old_quote.status = QuoteStatus.REVISED
-        else:
-            quote_number = next_quote_number(db)
+    old_quote = db.get(Quote, payload.quote_id) if payload.quote_id else None
+    if old_quote:
+        old_revision = old_quote.revision or 1
+        quote_number = old_quote.quote_number
+        revision = old_revision + 1
+        old_quote.quote_number = f"{quote_number}-R{old_revision}"
+        old_quote.status = QuoteStatus.REVISED
     else:
         quote_number = next_quote_number(db)
 

--- a/app/services/response_analytics.py
+++ b/app/services/response_analytics.py
@@ -15,6 +15,7 @@ Depends on: models (VendorCard, VendorResponse, EmailIntelligence, ActivityLog)
 """
 
 from datetime import datetime, timedelta, timezone
+from statistics import median
 
 from loguru import logger
 from sqlalchemy import func
@@ -108,13 +109,8 @@ def compute_vendor_response_metrics(db: Session, vendor_card_id: int, lookback_d
     avg_hours = None
     median_hours = None
     if response_hours:
-        response_hours.sort()
         avg_hours = sum(response_hours) / len(response_hours)
-        mid = len(response_hours) // 2
-        if len(response_hours) % 2 == 0 and len(response_hours) >= 2:
-            median_hours = (response_hours[mid - 1] + response_hours[mid]) / 2
-        else:
-            median_hours = response_hours[mid]
+        median_hours = median(response_hours)
 
     quote_quality_rate = 0.0
     if response_count > 0:

--- a/app/services/specialty_detector.py
+++ b/app/services/specialty_detector.py
@@ -123,11 +123,7 @@ BRAND_LIST = [
 ]
 
 # Compile brand patterns (case-insensitive, word-boundary)
-_BRAND_PATTERNS = {}
-for brand in BRAND_LIST:
-    # Escape special regex chars and create word-boundary pattern
-    escaped = re.escape(brand)
-    _BRAND_PATTERNS[brand] = re.compile(rf"\b{escaped}\b", re.IGNORECASE)
+_BRAND_PATTERNS = {brand: re.compile(rf"\b{re.escape(brand)}\b", re.IGNORECASE) for brand in BRAND_LIST}
 
 # ── Commodity category mapping ───────────────────────────────────────
 
@@ -268,10 +264,7 @@ def commodity_slug_to_display(slug: str) -> str:
 
 
 # Flatten keywords for quick lookup
-_COMMODITY_KEYWORDS = {}
-for category, keywords in COMMODITY_MAP.items():
-    for kw in keywords:
-        _COMMODITY_KEYWORDS[kw.lower()] = category
+_COMMODITY_KEYWORDS = {kw.lower(): category for category, keywords in COMMODITY_MAP.items() for kw in keywords}
 
 
 def detect_brands_from_text(text: str) -> list[str]:
@@ -282,11 +275,7 @@ def detect_brands_from_text(text: str) -> list[str]:
     if not text:
         return []
 
-    found = []
-    for brand, pattern in _BRAND_PATTERNS.items():
-        if pattern.search(text):
-            found.append(brand)
-    return found
+    return [brand for brand, pattern in _BRAND_PATTERNS.items() if pattern.search(text)]
 
 
 def detect_commodities_from_text(text: str) -> list[str]:
@@ -298,12 +287,7 @@ def detect_commodities_from_text(text: str) -> list[str]:
         return []
 
     text_lower = text.lower()
-    categories = set()
-
-    for keyword, category in _COMMODITY_KEYWORDS.items():
-        if keyword in text_lower:
-            categories.add(category)
-
+    categories = {category for keyword, category in _COMMODITY_KEYWORDS.items() if keyword in text_lower}
     return sorted(categories)
 
 
@@ -330,31 +314,22 @@ def analyze_vendor_specialties(vendor_card_id: int, db) -> dict:
     )
     for s in sightings:
         if s.manufacturer:
-            brands = detect_brands_from_text(s.manufacturer)
-            for b in brands:
-                brand_counter[b] += 1
+            brand_counter.update(detect_brands_from_text(s.manufacturer))
         if s.mpn_matched:
-            commodities = detect_commodities_from_text(s.mpn_matched)
-            for c in commodities:
-                commodity_counter[c] += 1
+            commodity_counter.update(detect_commodities_from_text(s.mpn_matched))
 
     # 2. From offers
     offers = db.query(Offer.manufacturer, Offer.mpn).filter(Offer.vendor_card_id == vendor_card_id).limit(500).all()
     for o in offers:
         if o.manufacturer:
-            brands = detect_brands_from_text(o.manufacturer)
-            for b in brands:
+            for b in detect_brands_from_text(o.manufacturer):
                 brand_counter[b] += 2  # Weight offers more
         if o.mpn:
-            commodities = detect_commodities_from_text(o.mpn)
-            for c in commodities:
-                commodity_counter[c] += 1
+            commodity_counter.update(detect_commodities_from_text(o.mpn))
 
     # 3. From existing vendor card data
     for field in [card.display_name, card.industry or ""]:
-        brands = detect_brands_from_text(field)
-        for b in brands:
-            brand_counter[b] += 1
+        brand_counter.update(detect_brands_from_text(field))
 
     # Top results
     brand_tags = [b for b, _ in brand_counter.most_common(15)]


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services [core 2/4]`)
22 file(s) changed, 53 simplifications (9 file(s) already clean).

- **`authoritative_enrichment_service.py`** — Extracted the duplicated evidence-tier field-writing loop into one shared private helper _apply_evidence_fields, used by both apply_web_sourced and apply_oem_sourced; apply_web_sourced now computes now.isoformat() once (iso) instead of recomputing it per written field.
- **`buyplan_scoring.py`** — Adopted the codebase-dominant `.is_(True)` boolean filter and dropped the E712 noqa; Removed redundant `or []` and used a set comprehension for vendor commodity tags.
- **`calendar_intelligence.py`** — Hoisted the mid-function `import json` to a module-level import; Compute datetime.now(timezone.utc) once in scan_calendar_events instead of twice.
- **`commodity_registry.py`** — Replaced the manual accumulate-and-extend loop in get_all_commodities() with the flatten comprehension already used by its callers.
- **`credential_service.py`** — Extracted the repeated decrypt-one-blob-with-fallback try/except into a private _try_decrypt() helper.
- **`customer_analysis_service.py`** — Collapsed two copy-paste-with-variation dedup loops into a single local add_rows() helper.
- **`customer_enrichment_service.py`** — Removed redundant datetime.now() and next-enrichment-time recomputation in the cooldown branch.
- **`email_threads.py`** — Extracted the 6 copy-pasted 'filter internal messages' comprehensions into a single _filter_external() helper; Collapsed the 4 near-identical 'group by conversationId -> drop internal -> build summary' loops into one _collect_threads_by_conversation() helper; Deduplicated the two identical single-conversation fetch blocks (Tier 1 Contact + Tier 1b VendorResponse) into _fetch_conversation(); Hoisted the repeated Graph $select field list into a module constant _MESSAGE_SELECT; Introduced _sender_address(msg)/_recipient_addresses(msg) accessors to replace ~10 inline deep-get chains.
- **`engagement_scorer.py`** — Removed dead conditional branches unreachable past the MIN_OUTREACH_FOR_SCORE guard; Extracted duplicated linear-decay logic into _decay_score helper; Collapsed velocity-averaging loop into a dict comprehension and dropped dead pre-init.
- **`excess_service.py`** — Extracted _parse_import_row() to remove duplicated row normalization/validation/field-extraction shared by import_line_items and preview_import; Extracted _create_excess_offer() to consolidate the identical Offer construction + flush + OFFER_CREATED activity log duplicated in match_excess_demand and create_proactive_matches_for_excess; Removed dead 'and requirements' sub-condition in create_proactive_matches_for_excess.
- **`health_service.py`** — Hoisted function-local imports (datetime/timedelta/timezone, pathlib.Path, ..config.settings) to module level, removing per-call import work on the health endpoint; Aligned import placement with the sibling-service convention so the function body contains only logic.
- **`multiplier_score_service.py`** — Removed the _month_range wrapper; call shared month_range() directly; Collapsed determine_bonus_winners' three copy-paste branches into a tier-driven loop and deleted the dead third branch.
- **`ownership_service.py`** — Deduplicated the tz-normalize + days-diff logic shared by _days_since_activity and _site_days_since_activity into one private _days_since(last_activity_at, now) helper; both public wrappers now delegate to it (public names/signatures unchanged); Collapsed the duplicated 'no activity ever recorded → use created_at, else 999' fallback block (present in both run_ownership_sweep and run_site_ownership_sweep) into a _days_since_created(created_at, now) helper; Factored the repeated green/yellow/red/no_activity status computation (duplicated in get_my_accounts and get_my_sites) into _health_status(days_inactive, warning_day, inactivity_limit); Factored the strategic-vs-standard (inactivity_limit, warning_day) derivation — repeated in run_ownership_sweep, get_accounts_at_risk, and get_my_accounts — into _company_limits(company).
- **`part_offers.py`** — Compute normalize_mpn_key(m) once per MPN instead of twice; Removed duplicated set-comprehension over the same normalization.
- **`proactive_matching.py`** — Hoisted the lazy `_update_last_activity` import out of the per-row loop.
- **`proactive_service.py`** — Factored the 6x copy-pasted capped-conditional-sum SQL expression in get_scorecard into a local _summed_when(status, col) builder; Replaced the nested ternary computing the email greeting in send_proactive_offer with an explicit if/elif/else chain; Removed the per-match N+1 throttle lookup in send_proactive_offer; batch-load existing throttles for all matched MPNs in one query.
- **`prospect_claim.py`** — Extracted repeated 'City, State' HQ-location parsing into a private _split_hq_location() helper used at all 3 call sites; Removed a redundant local re-import of CustomerSite; Deduplicated the similar-customers name-join into a _format_similar_names(similar, limit) helper.
- **`prospect_scoring.py`** — Collapsed three imperative NAICS index-building loops into derived comprehensions; Removed dead re-zeroing of event_score for empty/missing events; Hoisted ev_type.lower() out of the per-event branch ladder.
- **`prospect_warm_intros.py`** — De-duplicated the repeated warm-intro promotion into a local mark_warm() closure; Moved the warm-promotion out of the internal-contacts per-row loop.
- **`quote_builder_service.py`** — Hoist the per-iteration `from app.constants import OfferStatus` out of the requirements loop in get_builder_data; Build offers_data via a comprehension instead of filter-then-append; Build line_items via a comprehension in save_quote_from_builder; Flatten the nested revision/quote_number branching.
- **`response_analytics.py`** — Replaced the hand-rolled median computation with the stdlib statistics.median; Dropped the now-unnecessary explicit response_hours.sort().
- **`specialty_detector.py`** — Collapse the brand-pattern build loop into a dict comprehension; Collapse the commodity-keyword flattening loop into a dict comprehension; Return list/set comprehensions in detect_brands_from_text and detect_commodities_from_text; Use Counter.update() for the weight-1 accumulation paths in analyze_vendor_specialties.

_Recorded cross-file follow-ups:_
- `excess_service.py`: ALTITUDE (cross-file): the HTML email builders do not HTML-escape interpolated item fields (part_number, manufacturer, etc.
- `proactive_service.py`: REUSE (cross-file, NOT applied): the `else`-branch inline HTML parts-table builder in send_proactive_offer (lines ~293-335) duplicates the table/greeting/notes/signature HTML in proactive_email.
- `ownership_service.py`: REUSE (cross-file): The tz-normalize idiom `dt.
- `email_threads.py`: CROSS-FILE (not applied — outside target): there is no shared email-domain / sender-address utility in app/utils or app/vendor_utils.
- `authoritative_enrichment_service.py`: Cross-file note (NOT changed): _connectors_in_order and the _SOURCE_TYPE_ALIASES connector-name remapping logic is mirrored against enrichment.
- `prospect_scoring.py`: match_industry_segment rebuilds `{p[:4] for p in seg['naics_prefixes']}` on every segment iteration, and p[:4] is a no-op since naics_prefixes already holds 4-digit prefixes.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)