### PR TITLE
simplify(services 3/4): de-duplicate service helpers

### DIFF
--- a/app/services/activity_quality_service.py
+++ b/app/services/activity_quality_service.py
@@ -93,6 +93,16 @@ Score quality 0-100:
 """
 
 
+def _mark_no_data(log: ActivityLog, db: Session) -> None:
+    """Stamp an activity as assessed-with-no-data so it is never retried."""
+    log.quality_score = 0.0
+    log.quality_classification = "no_data"
+    log.is_meaningful = False
+    log.summary = "No interaction details available"
+    log.quality_assessed_at = datetime.now(timezone.utc)
+    db.flush()
+
+
 async def score_activity(activity_id: int, db: Session) -> None:
     """Score a single ActivityLog entry with AI quality classification."""
     log = db.get(ActivityLog, activity_id)
@@ -120,12 +130,7 @@ async def score_activity(activity_id: int, db: Session) -> None:
             parts.append(f"Notes: {log.notes[:500]}")
         if not parts:
             # Nothing to analyze — mark as assessed to prevent infinite retry
-            log.quality_score = 0.0
-            log.quality_classification = "no_data"
-            log.is_meaningful = False
-            log.summary = "No interaction details available"
-            log.quality_assessed_at = datetime.now(timezone.utc)
-            db.flush()
+            _mark_no_data(log, db)
             return
         prompt = (
             "A batch of vendor sightings was added from an automated search run "
@@ -153,12 +158,7 @@ async def score_activity(activity_id: int, db: Session) -> None:
 
         if not parts:
             # Nothing to analyze — mark as assessed to prevent infinite retry
-            log.quality_score = 0.0
-            log.quality_classification = "no_data"
-            log.is_meaningful = False
-            log.summary = "No interaction details available"
-            log.quality_assessed_at = datetime.now(timezone.utc)
-            db.flush()
+            _mark_no_data(log, db)
             return
 
         prompt = "Classify this business interaction:\n\n" + "\n".join(parts)

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -94,6 +94,11 @@ def match_email_to_entity(email_addr: str, db: Session) -> dict | None:
     return None
 
 
+def _phone_digits(phone: str | None) -> str:
+    """Return only the digit characters of a phone string ("" if none)."""
+    return "".join(c for c in (phone or "") if c.isdigit())
+
+
 def match_phone_to_entity(phone: str, db: Session) -> dict | None:
     """Match a phone number to a company or vendor card.
 
@@ -102,7 +107,7 @@ def match_phone_to_entity(phone: str, db: Session) -> dict | None:
     """
     if not phone:
         return None
-    digits = "".join(c for c in phone if c.isdigit())
+    digits = _phone_digits(phone)
     if len(digits) < 7:
         return None
     suffix = digits[-10:]  # last 10 digits for matching
@@ -126,7 +131,7 @@ def match_phone_to_entity(phone: str, db: Session) -> dict | None:
             .all()
         )
     for site in sites:
-        site_digits = "".join(c for c in (site.contact_phone or "") if c.isdigit())
+        site_digits = _phone_digits(site.contact_phone)
         if site_digits and site_digits[-10:] == suffix:
             return {"type": "company", "id": site.company_id, "name": site.site_name, "site_id": site.id}
 
@@ -147,7 +152,7 @@ def match_phone_to_entity(phone: str, db: Session) -> dict | None:
         card_ids = [vc.vendor_card_id for vc in vcs if vc.vendor_card_id]
         card_map = {c.id: c for c in db.query(VendorCard).filter(VendorCard.id.in_(card_ids)).all()} if card_ids else {}
         for vc in vcs:
-            vc_digits = "".join(c for c in (vc.phone or "") if c.isdigit())
+            vc_digits = _phone_digits(vc.phone)
             if vc_digits and vc_digits[-10:] == suffix:
                 card = card_map.get(vc.vendor_card_id)
                 if card:
@@ -159,6 +164,29 @@ def match_phone_to_entity(phone: str, db: Session) -> dict | None:
 # ═══════════════════════════════════════════════════════════════════════
 #  ACTIVITY LOGGING
 # ═══════════════════════════════════════════════════════════════════════
+
+
+def _match_entity_links(match: dict | None) -> dict:
+    """Translate a contact-match dict into ActivityLog entity-link kwargs.
+
+    Returns company_id / vendor_card_id / vendor_contact_id / customer_site_id with only
+    the matched side populated (the other side stays None).
+    """
+    if match and match["type"] == "company":
+        return {
+            "company_id": match["id"],
+            "vendor_card_id": None,
+            "vendor_contact_id": None,
+            "customer_site_id": match.get("site_id"),
+        }
+    if match and match["type"] == "vendor":
+        return {
+            "company_id": None,
+            "vendor_card_id": match["id"],
+            "vendor_contact_id": match.get("vendor_contact_id"),
+            "customer_site_id": None,
+        }
+    return {"company_id": None, "vendor_card_id": None, "vendor_contact_id": None, "customer_site_id": None}
 
 
 def log_email_activity(
@@ -190,10 +218,7 @@ def log_email_activity(
         user_id=user_id,
         activity_type=activity_type,
         channel=Channel.EMAIL,
-        company_id=match["id"] if match and match["type"] == "company" else None,
-        vendor_card_id=match["id"] if match and match["type"] == "vendor" else None,
-        vendor_contact_id=match.get("vendor_contact_id") if match and match["type"] == "vendor" else None,
-        customer_site_id=match.get("site_id") if match and match["type"] == "company" else None,
+        **_match_entity_links(match),
         contact_email=email_addr,
         contact_name=contact_name,
         subject=subject,
@@ -265,10 +290,7 @@ def log_call_activity(
         user_id=user_id,
         activity_type=activity_type,
         channel=Channel.PHONE,
-        company_id=match["id"] if match and match["type"] == "company" else None,
-        vendor_card_id=match["id"] if match and match["type"] == "vendor" else None,
-        vendor_contact_id=match.get("vendor_contact_id") if match and match["type"] == "vendor" else None,
-        customer_site_id=match.get("site_id") if match and match["type"] == "company" else None,
+        **_match_entity_links(match),
         contact_phone=phone,
         contact_name=contact_name,
         duration_seconds=duration_seconds,
@@ -299,6 +321,12 @@ def log_call_activity(
 # ═══════════════════════════════════════════════════════════════════════
 
 
+def _is_meaningful_or_unscored():
+    """Filter clause keeping rows the AI quality pass marked meaningful (True) or has
+    not yet scored (None) — i.e. hide only is_meaningful=False."""
+    return ActivityLog.is_meaningful.is_(True) | ActivityLog.is_meaningful.is_(None)
+
+
 def get_company_activities(
     company_id: int, db: Session, limit: int = 50, meaningful_only: bool = False
 ) -> list[ActivityLog]:
@@ -311,7 +339,7 @@ def get_company_activities(
     """
     q = db.query(ActivityLog).filter(ActivityLog.company_id == company_id)
     if meaningful_only:
-        q = q.filter((ActivityLog.is_meaningful.is_(True)) | (ActivityLog.is_meaningful.is_(None)))
+        q = q.filter(_is_meaningful_or_unscored())
     return q.order_by(ActivityLog.created_at.desc()).limit(limit).all()
 
 
@@ -350,7 +378,7 @@ def get_requisition_activities(
     """
     q = db.query(ActivityLog).filter(ActivityLog.requisition_id == requisition_id)
     if meaningful_only:
-        q = q.filter((ActivityLog.is_meaningful.is_(True)) | (ActivityLog.is_meaningful.is_(None)))
+        q = q.filter(_is_meaningful_or_unscored())
     return q.order_by(ActivityLog.created_at.desc()).limit(limit).all()
 
 
@@ -532,8 +560,7 @@ def log_company_call(
     db.add(record)
     db.flush()
 
-    now = datetime.now(timezone.utc)
-    db.query(Company).filter(Company.id == company_id).update({"last_activity_at": now}, synchronize_session=False)
+    bump_company_site_activity(db, company_id, None)
     logger.info(f"Activity logged: {activity_type} -> company {company_id} by user {user_id}")
     return record
 
@@ -557,8 +584,7 @@ def log_company_note(
     db.add(record)
     db.flush()
 
-    now = datetime.now(timezone.utc)
-    db.query(Company).filter(Company.id == company_id).update({"last_activity_at": now}, synchronize_session=False)
+    bump_company_site_activity(db, company_id, None)
     logger.info(f"Activity logged: note -> company {company_id} by user {user_id}")
     return record
 
@@ -708,11 +734,7 @@ def log_site_contact_note(
     db.add(record)
     db.flush()
 
-    now = datetime.now(timezone.utc)
-    db.query(Company).filter(Company.id == company_id).update({"last_activity_at": now}, synchronize_session=False)
-    db.query(CustomerSite).filter(CustomerSite.id == customer_site_id).update(
-        {"last_activity_at": now}, synchronize_session=False
-    )
+    bump_company_site_activity(db, company_id, customer_site_id)
     logger.info(f"Activity logged: note -> site_contact {site_contact_id} by user {user_id}")
     return record
 

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -101,19 +101,21 @@ def _load_config_cache(db: Session) -> dict[str, str]:
     return _config_cache
 
 
-def get_config_value(db: Session, key: str) -> str | None:
-    """Get a single config value with in-memory caching (5-min TTL)."""
-    global _config_cache, _config_cache_ts
+def _ensure_config_cache_fresh(db: Session) -> None:
+    """Reload the config cache if it has gone stale (TTL expired)."""
     if time.time() - _config_cache_ts > _CONFIG_CACHE_TTL:
         _load_config_cache(db)
+
+
+def get_config_value(db: Session, key: str) -> str | None:
+    """Get a single config value with in-memory caching (5-min TTL)."""
+    _ensure_config_cache_fresh(db)
     return _config_cache.get(key)
 
 
 def get_config_values(db: Session, keys: list[str]) -> dict[str, str]:
     """Get multiple config values with in-memory caching."""
-    global _config_cache, _config_cache_ts
-    if time.time() - _config_cache_ts > _CONFIG_CACHE_TTL:
-        _load_config_cache(db)
+    _ensure_config_cache_fresh(db)
     return {k: _config_cache[k] for k in keys if k in _config_cache}
 
 
@@ -181,46 +183,42 @@ def get_system_health(db: Session) -> dict:
         ("offers", Offer),
         ("quotes", Quote),
     ]:
+        label = TABLE_LABELS.get(key, key.replace("_", " ").title())
         try:
-            counts[TABLE_LABELS.get(key, key.replace("_", " ").title())] = (
-                db.query(sqlfunc.count(model.id)).scalar() or 0
-            )
+            counts[label] = db.query(sqlfunc.count(model.id)).scalar() or 0
         except Exception:
-            counts[TABLE_LABELS.get(key, key.replace("_", " ").title())] = -1
+            counts[label] = -1
 
     # Per-user scheduler status
-    users = db.query(User).all()
-    scheduler_status = []
-    for u in users:
-        scheduler_status.append(
-            {
-                "id": u.id,
-                "email": u.email,
-                "m365_connected": u.m365_connected,
-                "has_refresh_token": bool(u.refresh_token),
-                "token_expires_at": u.token_expires_at.isoformat() if u.token_expires_at else None,
-                "last_inbox_scan": u.last_inbox_scan.isoformat() if u.last_inbox_scan else None,
-                "last_contacts_sync": u.last_contacts_sync.isoformat() if u.last_contacts_sync else None,
-            }
-        )
+    scheduler_status = [
+        {
+            "id": u.id,
+            "email": u.email,
+            "m365_connected": u.m365_connected,
+            "has_refresh_token": bool(u.refresh_token),
+            "token_expires_at": u.token_expires_at.isoformat() if u.token_expires_at else None,
+            "last_inbox_scan": u.last_inbox_scan.isoformat() if u.last_inbox_scan else None,
+            "last_contacts_sync": u.last_contacts_sync.isoformat() if u.last_contacts_sync else None,
+        }
+        for u in db.query(User).all()
+    ]
 
     # Connector health from api_sources
     connectors = []
     try:
-        sources = db.query(ApiSource).order_by(ApiSource.name).all()
-        for s in sources:
-            connectors.append(
-                {
-                    "name": s.name,
-                    "display_name": s.display_name,
-                    "status": s.status,
-                    "category": s.category,
-                    "last_success": s.last_success.isoformat() if s.last_success else None,
-                    "last_error": s.last_error,
-                    "total_searches": s.total_searches,
-                    "total_results": s.total_results,
-                }
-            )
+        connectors = [
+            {
+                "name": s.name,
+                "display_name": s.display_name,
+                "status": s.status,
+                "category": s.category,
+                "last_success": s.last_success.isoformat() if s.last_success else None,
+                "last_error": s.last_error,
+                "total_searches": s.total_searches,
+                "total_results": s.total_results,
+            }
+            for s in db.query(ApiSource).order_by(ApiSource.name).all()
+        ]
     except Exception as e:
         logger.warning("Admin health: connector stats query failed: {}", e)
 

--- a/app/services/ai_intake_parser.py
+++ b/app/services/ai_intake_parser.py
@@ -7,6 +7,7 @@ Depends on: app/utils/llm_router.py and normalization helpers
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -170,13 +171,8 @@ def _normalize_top_level(result: dict[str, Any]) -> None:
         result["confidence"] = 0.0
 
     for key in ("summary", "requisition_name", "customer_name", "vendor_name", "notes"):
-        value = result.get(key)
-        if value is None:
-            continue
-        if not isinstance(value, str):
-            value = str(value)
-        value = " ".join(value.split()).strip()
-        result[key] = value or None
+        if result.get(key) is not None:
+            result[key] = _clean_scalar(result.get(key))
 
     if not result.get("summary"):
         req_count = len(result.get("requirements") or [])
@@ -197,7 +193,7 @@ def _normalize_requirements(result: dict[str, Any]) -> None:
     for row in raw_rows:
         if not isinstance(row, dict):
             continue
-        mpn = normalize_mpn((row.get("mpn") or "").strip()) or (row.get("mpn") or "").strip().upper()
+        mpn = _row_mpn(row)
         if not mpn:
             continue
 
@@ -234,7 +230,7 @@ def _normalize_offers(result: dict[str, Any]) -> None:
     for row in raw_rows:
         if not isinstance(row, dict):
             continue
-        mpn = normalize_mpn((row.get("mpn") or "").strip()) or (row.get("mpn") or "").strip().upper()
+        mpn = _row_mpn(row)
         if not mpn:
             continue
 
@@ -346,8 +342,6 @@ def _heuristic_parse(text: str) -> dict[str, Any] | None:
     Scans each line for part-number-like tokens followed by optional quantity and price
     columns. Returns a minimal result dict.
     """
-    import re
-
     mpn_pattern = re.compile(r"^[\s\"']*([A-Z0-9][A-Z0-9\-\.\/\+]{2,30}[A-Z0-9])")
     lines = text.strip().split("\n")
     rows: list[dict[str, Any]] = []
@@ -443,3 +437,9 @@ def _clean_scalar(value: Any) -> str | None:
         return None
     value = " ".join(str(value).split()).strip()
     return value or None
+
+
+def _row_mpn(row: dict[str, Any]) -> str:
+    """Normalize a row's MPN, falling back to the raw uppercased value."""
+    raw = (row.get("mpn") or "").strip()
+    return normalize_mpn(raw) or raw.upper()

--- a/app/services/ai_service.py
+++ b/app/services/ai_service.py
@@ -123,7 +123,7 @@ async def enrich_contacts_websearch(
             try:
                 validated_contact = EnrichedContact.model_validate(item)
                 raw_contacts.append(validated_contact.model_dump())
-            except (ValidationError, Exception):
+            except Exception:
                 if isinstance(item, dict) and item.get("full_name"):
                     raw_contacts.append(item)
 
@@ -132,15 +132,10 @@ async def enrich_contacts_websearch(
             continue
 
         email = (c.get("email") or "").strip().lower() or None
-        confidence = "low"
 
-        # Confidence assessment
-        if email and domain and domain in email:
-            confidence = "medium"  # Email matches company domain
-        elif email:
-            confidence = "medium"
-        elif c.get("linkedin_url"):
-            confidence = "low"
+        # A verified email (whether or not it matches the company domain) earns
+        # "medium"; anything weaker (a LinkedIn URL only, or nothing) stays "low".
+        confidence = "medium" if email else "low"
 
         contacts.append(
             {
@@ -271,18 +266,21 @@ async def draft_rfq(
     Returns:
         Email body string, or None on failure
     """
+
+    def format_parts(items: list[dict]) -> str:
+        return "\n".join(
+            f"- {p.get('mpn', '?')}: {p.get('qty', '?')} pcs"
+            + (f" (target: ${p['target_price']})" if p.get("target_price") else "")
+            for p in items[:20]
+        )
+
     # If buyer provided their own draft, clean it up instead of generating from scratch
     if user_draft:
         user_draft = user_draft[:12000]
-        parts_str = "\n".join(
-            f"- {p.get('mpn', '?')}: {p.get('qty', '?')} pcs"
-            + (f" (target: ${p['target_price']})" if p.get("target_price") else "")
-            for p in parts[:20]
-        )
         cleanup_prompt = (
             f"Clean up this buyer's RFQ email draft. Fix grammar/formatting, "
             f"ensure all parts are referenced, preserve the buyer's tone.\n\n"
-            f"Parts:\n{parts_str}\n\n"
+            f"Parts:\n{format_parts(parts)}\n\n"
             f"Buyer's draft:\n{user_draft}"
         )
         from app.utils.llm_router import routed_text as _routed_text
@@ -300,11 +298,7 @@ async def draft_rfq(
             f"- Best past price for this part: {vendor_history.get('best_price', 'unknown')}\n"
         )
 
-    parts_str = "\n".join(
-        f"- {p.get('mpn', '?')}: {p.get('qty', '?')} pcs"
-        + (f" (target: ${p['target_price']})" if p.get("target_price") else "")
-        for p in parts[:20]
-    )
+    parts_str = format_parts(parts)
 
     prompt = (
         f"Vendor: {vendor_name}\n"

--- a/app/services/auto_dedup_service.py
+++ b/app/services/auto_dedup_service.py
@@ -81,18 +81,15 @@ def _dedup_vendors(db: Session) -> int:
 
     merged = 0
     merged_ids = set()
-    seen_pairs = set()
 
+    # Inner loop walks only cards[i+1:], so every unordered pair is visited exactly
+    # once — no explicit seen-pair guard is needed.
     for i, a in enumerate(cards):
         if a.id in merged_ids:
             continue
         for b in cards[i + 1 :]:
             if b.id in merged_ids:
                 continue
-            pair_key = (min(a.id, b.id), max(a.id, b.id))
-            if pair_key in seen_pairs:  # pragma: no cover — defensive; loop structure prevents repeats
-                continue
-            seen_pairs.add(pair_key)
 
             score = fuzz.token_sort_ratio(a.normalized_name or "", b.normalized_name or "")
             if score < 92:
@@ -100,9 +97,10 @@ def _dedup_vendors(db: Session) -> int:
 
             # Decide which to keep (more sightings wins)
             if (a.sighting_count or 0) >= (b.sighting_count or 0):
-                keep_id, remove_id = a.id, b.id
+                keep, remove = a, b
             else:
-                keep_id, remove_id = b.id, a.id
+                keep, remove = b, a
+            keep_id, remove_id = keep.id, remove.id
 
             should_merge = False
             if score >= 98:
@@ -110,8 +108,8 @@ def _dedup_vendors(db: Session) -> int:
                 logger.info(
                     "Auto-merging vendors (score={}): '{}' into '{}'",
                     score,
-                    b.display_name if remove_id == b.id else a.display_name,
-                    a.display_name if keep_id == a.id else b.display_name,
+                    remove.display_name,
+                    keep.display_name,
                 )
             elif score >= 92:
                 should_merge = _ai_confirm_vendor_merge(a.display_name, b.display_name, score)

--- a/app/services/buyer_leaderboard.py
+++ b/app/services/buyer_leaderboard.py
@@ -173,18 +173,11 @@ def compute_buyer_leaderboard(db: Session, month: date) -> dict:
             snap = BuyerLeaderboardSnapshot(user_id=entry["user_id"], month=month_start)
             db.add(snap)
 
-        snap.offers_logged = entry["offers_logged"]
-        snap.offers_quoted = entry["offers_quoted"]
-        snap.offers_in_buyplan = entry["offers_in_buyplan"]
-        snap.offers_po_confirmed = entry["offers_po_confirmed"]
-        snap.stock_lists_uploaded = entry["stock_lists_uploaded"]
-        snap.points_offers = entry["points_offers"]
-        snap.points_quoted = entry["points_quoted"]
-        snap.points_buyplan = entry["points_buyplan"]
-        snap.points_po = entry["points_po"]
-        snap.points_stock = entry["points_stock"]
-        snap.total_points = entry["total_points"]
-        snap.rank = entry["rank"]
+        # Copy every entry metric onto the snapshot (entry keys mirror snapshot
+        # attributes 1:1, except user_id which is the upsert key set above).
+        for key, value in entry.items():
+            if key != "user_id":
+                setattr(snap, key, value)
         snap.updated_at = datetime.now(timezone.utc)
 
     db.commit()

--- a/app/services/buyplan_notifications.py
+++ b/app/services/buyplan_notifications.py
@@ -106,6 +106,30 @@ def _lines_html(plan: BuyPlan) -> tuple[str, float]:
     return rows, total
 
 
+def _lines_table(plan: BuyPlan) -> tuple[str, float]:
+    """Build the full 6-column plan-lines HTML table (MPN/Vendor/Qty/Unit/Total/Lead).
+
+    Returns (table_html, total_cost). Shared by the submit and stock-sale emails.
+    """
+    rows, total = _lines_html(plan)
+    table = (
+        f'<table style="border-collapse:collapse;width:100%;margin:16px 0">'
+        f'<thead><tr style="background:#f3f4f6">'
+        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">MPN</th>'
+        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Vendor</th>'
+        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Qty</th>'
+        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Unit Cost</th>'
+        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Line Total</th>'
+        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Lead</th>'
+        f"</tr></thead><tbody>{rows}</tbody>"
+        f'<tfoot><tr style="background:#f3f4f6;font-weight:bold">'
+        f'<td colspan="4" style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Total</td>'
+        f'<td style="padding:8px 10px;border:1px solid #e5e7eb">${total:,.2f}</td>'
+        f'<td style="padding:8px 10px;border:1px solid #e5e7eb"></td></tr></tfoot></table>'
+    )
+    return table, total
+
+
 def _wrap_email(title: str, body_inner: str) -> str:
     """Wrap content in the standard AVAIL email template."""
     return (
@@ -192,7 +216,7 @@ def log_buyplan_activity(
 async def notify_submitted(plan: BuyPlan, db: Session):
     """Notify managers that a buy plan needs approval."""
     ctx = _plan_context(plan, db)
-    rows, total = _lines_html(plan)
+    table, total = _lines_table(plan)
 
     notes_html = ""
     if plan.salesperson_notes:
@@ -204,19 +228,7 @@ async def notify_submitted(plan: BuyPlan, db: Session):
         f"Quote: <strong>{html_mod.escape(ctx['quote_number'])}</strong> | "
         f"SO#: <strong>{html_mod.escape(plan.sales_order_number or '')}</strong></p>"
         f"{notes_html}"
-        f'<table style="border-collapse:collapse;width:100%;margin:16px 0">'
-        f'<thead><tr style="background:#f3f4f6">'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">MPN</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Vendor</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Qty</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Unit Cost</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Line Total</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Lead</th>'
-        f"</tr></thead><tbody>{rows}</tbody>"
-        f'<tfoot><tr style="background:#f3f4f6;font-weight:bold">'
-        f'<td colspan="4" style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Total</td>'
-        f'<td style="padding:8px 10px;border:1px solid #e5e7eb">${total:,.2f}</td>'
-        f'<td style="padding:8px 10px;border:1px solid #e5e7eb"></td></tr></tfoot></table>'
+        f"{table}"
     )
     html_body = _wrap_email("Buy Plan — Approval Required", body)
 
@@ -474,7 +486,7 @@ async def notify_stock_sale_approved(plan: BuyPlan, db: Session):
     from ..utils.graph_client import GraphClient
 
     ctx = _plan_context(plan, db)
-    rows, total = _lines_html(plan)
+    table, total = _lines_table(plan)
 
     approver = db.get(User, plan.approved_by_id) if plan.approved_by_id else None
     approver_name = (approver.name or approver.email) if approver else "Manager (email token)"
@@ -486,19 +498,7 @@ async def notify_stock_sale_approved(plan: BuyPlan, db: Session):
         f'<p style="margin:0"><strong>Submitted by:</strong> {html_mod.escape(ctx["submitter_name"])}</p>'
         f'<p style="margin:4px 0 0"><strong>Acctivate SO#:</strong> {html_mod.escape(str(plan.sales_order_number or "N/A"))}</p>'
         f"</div>"
-        f'<table style="border-collapse:collapse;width:100%;margin:16px 0">'
-        f'<thead><tr style="background:#f3f4f6">'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">MPN</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Vendor</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Qty</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Unit Cost</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Line Total</th>'
-        f'<th style="padding:8px 10px;border:1px solid #e5e7eb;text-align:left">Lead</th>'
-        f"</tr></thead><tbody>{rows}</tbody>"
-        f'<tfoot><tr style="background:#f3f4f6;font-weight:bold">'
-        f'<td colspan="4" style="padding:8px 10px;border:1px solid #e5e7eb;text-align:right">Total</td>'
-        f'<td style="padding:8px 10px;border:1px solid #e5e7eb">${total:,.2f}</td>'
-        f'<td style="padding:8px 10px;border:1px solid #e5e7eb"></td></tr></tfoot></table>'
+        f"{table}"
     )
     html_body = _wrap_email("Stock Sale Approved — No PO Required", body)
 

--- a/app/services/company_merge_service.py
+++ b/app/services/company_merge_service.py
@@ -90,17 +90,19 @@ def merge_companies(keep_id: int, remove_id: int, db: Session) -> dict:
             keep.last_activity_at = _tz_safe(remove.last_activity_at)
 
     # 7. Handle sites — move or delete empty HQs
+    def _norm_site_name(site):
+        return (site.site_name or "").strip().upper()
+
     remove_sites = db.query(CustomerSite).filter(CustomerSite.company_id == remove.id).all()
     keep_site_names = {
-        (s.site_name or "").strip().upper()
-        for s in db.query(CustomerSite).filter(CustomerSite.company_id == keep.id).all()
+        _norm_site_name(s) for s in db.query(CustomerSite).filter(CustomerSite.company_id == keep.id).all()
     }
 
     sites_deleted = 0
     sites_moved = 0
     for s in remove_sites:
         is_empty_hq = (
-            (s.site_name or "").strip().upper() == "HQ"
+            _norm_site_name(s) == "HQ"
             and not s.contact_name
             and not s.contact_email
             and not s.address_line1
@@ -111,10 +113,10 @@ def merge_companies(keep_id: int, remove_id: int, db: Session) -> dict:
             db.delete(s)
             sites_deleted += 1
         else:
-            if (s.site_name or "").strip().upper() in keep_site_names:
+            if _norm_site_name(s) in keep_site_names:
                 s.site_name = f"{remove.name} - {s.site_name or ''}"
             s.company_id = keep.id
-            keep_site_names.add((s.site_name or "").strip().upper())
+            keep_site_names.add(_norm_site_name(s))
             sites_moved += 1
 
     # Flush site changes and expire the relationship so ORM cascade doesn't

--- a/app/services/customer_enrichment_batch.py
+++ b/app/services/customer_enrichment_batch.py
@@ -64,14 +64,13 @@ async def run_customer_enrichment_batch(
             logger.info("All credit budgets exhausted — stopping batch early at {}/{}", processed, len(gaps))
             break
 
+        processed += 1
         try:
             result = await enrich_customer_account(gap["company_id"], db, force=False)
-            processed += 1
             if result.get("ok") and result.get("contacts_added", 0) > 0:
                 enriched += 1
             db.flush()
         except Exception as e:
-            processed += 1
             errors.append(f"Company {gap['company_id']}: {str(e)[:100]}")
             logger.warning("Batch enrichment error for company {}: {}", gap["company_id"], e)
 

--- a/app/services/document_service.py
+++ b/app/services/document_service.py
@@ -11,6 +11,19 @@ _jinja_env = Environment(
 )
 
 
+def _render_pdf(template_name: str, **context) -> bytes:
+    """Render a document template to PDF, injecting the shared ``generated_at``
+    stamp."""
+    from weasyprint import HTML
+
+    template = _jinja_env.get_template(template_name)
+    html = template.render(
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        **context,
+    )
+    return HTML(string=html).write_pdf()
+
+
 def generate_rfq_summary_pdf(requisition_id: int, db: Session) -> bytes:
     """Generate a PDF summary of a requisition with its requirements and offers."""
     from app.models import Offer, Requirement, Requisition
@@ -23,17 +36,12 @@ def generate_rfq_summary_pdf(requisition_id: int, db: Session) -> bytes:
 
     offers = db.query(Offer).filter_by(requisition_id=requisition_id).order_by(Offer.created_at.desc()).all()
 
-    template = _jinja_env.get_template("rfq_summary.html")
-    html = template.render(
+    return _render_pdf(
+        "rfq_summary.html",
         requisition=requisition,
         requirements=requirements,
         offers=offers,
-        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
     )
-
-    from weasyprint import HTML
-
-    return HTML(string=html).write_pdf()
 
 
 def generate_quote_report_pdf(quote_id: int, db: Session) -> bytes:
@@ -49,15 +57,10 @@ def generate_quote_report_pdf(quote_id: int, db: Session) -> bytes:
 
     line_items = quote.line_items or []
 
-    template = _jinja_env.get_template("quote_report.html")
-    html = template.render(
+    return _render_pdf(
+        "quote_report.html",
         quote=quote,
         customer_site=customer_site,
         company=company,
         line_items=line_items,
-        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
     )
-
-    from weasyprint import HTML
-
-    return HTML(string=html).write_pdf()

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -68,6 +68,29 @@ _CONNECTOR_CONFIGS = [
 _IGNORED_MANUFACTURERS = {"", "unknown", "n/a", "various", "none", "other", "generic"}
 
 
+def _manufacturers_agree(a: str, b: str) -> bool:
+    """Fuzzy manufacturer-name match: exact, or either name contains the other."""
+    a = (a or "").lower().strip()
+    b = (b or "").lower().strip()
+    return a == b or a in b or b in a
+
+
+def _nexar_manufacturer(data: dict) -> str | None:
+    """Extract the first result's manufacturer name from a Nexar GraphQL payload.
+
+    Returns the trimmed name, or None when there is no result or it is a junk/placeholder
+    manufacturer (per ``_IGNORED_MANUFACTURERS``).
+    """
+    results = (data.get("data") or {}).get("supSearchMpn", {}).get("results", [])
+    if not results:
+        return None
+    part = results[0].get("part", {})
+    mfr = ((part.get("manufacturer") or {}).get("name") or "").strip()
+    if not mfr or mfr.lower() in _IGNORED_MANUFACTURERS:
+        return None
+    return mfr
+
+
 async def enrich_material_card(mpn: str, db: Session) -> dict | None:
     """Query all available connectors for manufacturer data on a single MPN.
 
@@ -218,6 +241,37 @@ def _apply_enrichment_to_card(card: MaterialCard, enrichment: dict, db: Session)
         tag_material_card(card.id, tags_to_apply, db)
 
 
+def _run_boost_loop(db: Session, base_query, confidence: float, source: str, label: str, batch_size: int) -> int:
+    """Page through a tag-id query and bulk-upgrade each batch to (confidence, source).
+
+    ``base_query`` selects ``MaterialTag.id`` with all phase-specific filters EXCEPT the
+    ``MaterialTag.id > last_id`` keyset cursor, which this loop appends per batch. Returns
+    the total number of tags upgraded.
+    """
+    from app.models.tags import MaterialTag
+
+    boosted = 0
+    last_id = 0
+
+    while True:
+        rows = base_query.filter(MaterialTag.id > last_id).order_by(MaterialTag.id).limit(batch_size).all()
+        if not rows:
+            break
+
+        mt_ids = list({r.id for r in rows})
+        last_id = max(mt_ids)
+
+        boosted += (
+            db.query(MaterialTag)
+            .filter(MaterialTag.id.in_(mt_ids))
+            .update({"confidence": confidence, "source": source}, synchronize_session="fetch")
+        )
+        db.commit()
+        logger.info(f"{label}: {boosted} tags upgraded so far")
+
+    return boosted
+
+
 def boost_confidence_internal(db: Session, batch_size: int = 5000) -> dict:
     """Boost confidence for AI tags confirmed by internal data (no API calls).
 
@@ -231,50 +285,37 @@ def boost_confidence_internal(db: Session, batch_size: int = 5000) -> dict:
     """
     from sqlalchemy import func
 
+    from app.models.sourcing import Sighting
     from app.models.tags import MaterialTag, Tag
 
-    total_boosted = 0
-    last_id = 0
+    # A sighting manufacturer confirms a brand tag when the two names match exactly or
+    # one contains the other (the SQL twin of ``_manufacturers_agree``).
+    sighting_confirms_tag = or_(
+        func.lower(Sighting.manufacturer) == func.lower(Tag.name),
+        func.lower(Sighting.manufacturer).contains(func.lower(Tag.name)),
+        func.lower(Tag.name).contains(func.lower(Sighting.manufacturer)),
+    )
 
-    while True:
-        # Find AI-classified brand tags where card manufacturer confirms the tag
-        rows = (
-            db.query(MaterialTag.id)
-            .join(Tag, MaterialTag.tag_id == Tag.id)
-            .join(MaterialCard, MaterialCard.id == MaterialTag.material_card_id)
-            .filter(
-                Tag.tag_type == "brand",
-                MaterialTag.source == "ai_classified",
-                MaterialTag.confidence < 0.9,
-                MaterialTag.confidence > 0.3,  # Skip "Unknown"
-                MaterialCard.manufacturer.isnot(None),
-                MaterialCard.manufacturer != "",
-                func.lower(MaterialCard.manufacturer) == func.lower(Tag.name),
-                MaterialTag.id > last_id,
-            )
-            .order_by(MaterialTag.id)
-            .limit(batch_size)
-            .all()
-        )
-
-        if not rows:
-            break
-
-        mt_ids = [r.id for r in rows]
-        last_id = mt_ids[-1]
-
-        updated = (
-            db.query(MaterialTag)
-            .filter(MaterialTag.id.in_(mt_ids))
-            .update(
-                {"confidence": 0.90, "source": "ai_confirmed_internal"},
-                synchronize_session="fetch",
-            )
-        )
-        db.commit()
-        total_boosted += updated
-        logger.info(f"Confidence boost: {total_boosted} tags upgraded so far (batch ending at id {last_id})")
-
+    # Phase 1: card manufacturer confirms an AI-classified brand tag.
+    total_boosted = _run_boost_loop(
+        db,
+        db.query(MaterialTag.id)
+        .join(Tag, MaterialTag.tag_id == Tag.id)
+        .join(MaterialCard, MaterialCard.id == MaterialTag.material_card_id)
+        .filter(
+            Tag.tag_type == "brand",
+            MaterialTag.source == "ai_classified",
+            MaterialTag.confidence < 0.9,
+            MaterialTag.confidence > 0.3,  # Skip "Unknown"
+            MaterialCard.manufacturer.isnot(None),
+            MaterialCard.manufacturer != "",
+            func.lower(MaterialCard.manufacturer) == func.lower(Tag.name),
+        ),
+        confidence=0.90,
+        source="ai_confirmed_internal",
+        label="Confidence boost",
+        batch_size=batch_size,
+    )
     logger.info(f"Internal confidence boost complete: {total_boosted} tags upgraded to 0.90")
 
     # Phase 2 (fuzzy boost to 0.85) and Phase 3 (commodity boost to 0.85) removed —
@@ -282,108 +323,52 @@ def boost_confidence_internal(db: Session, batch_size: int = 5000) -> dict:
     fuzzy_boosted = 0
     commodity_boosted = 0
 
-    # Phase 4: Sighting-confirmed — sighting manufacturer confirms existing brand tag
-    from app.models.sourcing import Sighting
-
-    sighting_boosted = 0
-    last_id = 0
-
-    while True:
-        # Find brand tags (0.30-0.89) where a sighting manufacturer matches the tag name
-        rows = (
-            db.query(MaterialTag.id)
-            .join(Tag, MaterialTag.tag_id == Tag.id)
-            .join(MaterialCard, MaterialCard.id == MaterialTag.material_card_id)
-            .join(Sighting, Sighting.material_card_id == MaterialCard.id)
-            .filter(
-                Tag.tag_type == "brand",
-                MaterialTag.confidence < 0.9,
-                MaterialTag.confidence > 0.3,
-                Sighting.manufacturer.isnot(None),
-                Sighting.manufacturer != "",
-                or_(
-                    func.lower(Sighting.manufacturer) == func.lower(Tag.name),
-                    func.lower(Sighting.manufacturer).contains(func.lower(Tag.name)),
-                    func.lower(Tag.name).contains(func.lower(Sighting.manufacturer)),
-                ),
-                MaterialTag.id > last_id,
-            )
-            .order_by(MaterialTag.id)
-            .limit(batch_size)
-            .all()
-        )
-
-        if not rows:
-            break
-
-        mt_ids = list({r.id for r in rows})
-        last_id = max(mt_ids)
-
-        updated = (
-            db.query(MaterialTag)
-            .filter(MaterialTag.id.in_(mt_ids))
-            .update(
-                {"confidence": 0.90, "source": "sighting_confirmed"},
-                synchronize_session="fetch",
-            )
-        )
-        db.commit()
-        sighting_boosted += updated
-        logger.info(f"Sighting-confirmed boost: {sighting_boosted} tags upgraded so far")
-
+    # Phase 4: Sighting-confirmed — sighting manufacturer confirms existing brand tag (0.30-0.89).
+    sighting_boosted = _run_boost_loop(
+        db,
+        db.query(MaterialTag.id)
+        .join(Tag, MaterialTag.tag_id == Tag.id)
+        .join(MaterialCard, MaterialCard.id == MaterialTag.material_card_id)
+        .join(Sighting, Sighting.material_card_id == MaterialCard.id)
+        .filter(
+            Tag.tag_type == "brand",
+            MaterialTag.confidence < 0.9,
+            MaterialTag.confidence > 0.3,
+            Sighting.manufacturer.isnot(None),
+            Sighting.manufacturer != "",
+            sighting_confirms_tag,
+        ),
+        confidence=0.90,
+        source="sighting_confirmed",
+        label="Sighting-confirmed boost",
+        batch_size=batch_size,
+    )
     if sighting_boosted:
         logger.info(f"Sighting-confirmed boost: {sighting_boosted} tags upgraded to 0.90")
 
-    # Phase 5: Multi-source agreement — AI + sighting independently agree → 0.95
-    # Find AI-classified tags (any confidence) where sighting also confirms the same manufacturer
-    multi_boosted = 0
-    last_id = 0
-
-    while True:
-        rows = (
-            db.query(MaterialTag.id)
-            .join(Tag, MaterialTag.tag_id == Tag.id)
-            .join(MaterialCard, MaterialCard.id == MaterialTag.material_card_id)
-            .join(Sighting, Sighting.material_card_id == MaterialCard.id)
-            .filter(
-                Tag.tag_type == "brand",
-                MaterialTag.source.in_(
-                    ["ai_classified", "ai_confirmed_internal", "ai_confirmed_fuzzy", "sighting_confirmed"]
-                ),
-                MaterialTag.confidence < 0.95,
-                MaterialTag.confidence >= 0.7,
-                Sighting.manufacturer.isnot(None),
-                Sighting.manufacturer != "",
-                or_(
-                    func.lower(Sighting.manufacturer) == func.lower(Tag.name),
-                    func.lower(Sighting.manufacturer).contains(func.lower(Tag.name)),
-                    func.lower(Tag.name).contains(func.lower(Sighting.manufacturer)),
-                ),
-                MaterialTag.id > last_id,
-            )
-            .order_by(MaterialTag.id)
-            .limit(batch_size)
-            .all()
-        )
-
-        if not rows:
-            break
-
-        mt_ids = list({r.id for r in rows})
-        last_id = max(mt_ids)
-
-        updated = (
-            db.query(MaterialTag)
-            .filter(MaterialTag.id.in_(mt_ids))
-            .update(
-                {"confidence": 0.95, "source": "multi_source_confirmed"},
-                synchronize_session="fetch",
-            )
-        )
-        db.commit()
-        multi_boosted += updated
-        logger.info(f"Multi-source boost: {multi_boosted} tags upgraded so far")
-
+    # Phase 5: Multi-source agreement — AI + sighting independently agree → 0.95.
+    multi_boosted = _run_boost_loop(
+        db,
+        db.query(MaterialTag.id)
+        .join(Tag, MaterialTag.tag_id == Tag.id)
+        .join(MaterialCard, MaterialCard.id == MaterialTag.material_card_id)
+        .join(Sighting, Sighting.material_card_id == MaterialCard.id)
+        .filter(
+            Tag.tag_type == "brand",
+            MaterialTag.source.in_(
+                ["ai_classified", "ai_confirmed_internal", "ai_confirmed_fuzzy", "sighting_confirmed"]
+            ),
+            MaterialTag.confidence < 0.95,
+            MaterialTag.confidence >= 0.7,
+            Sighting.manufacturer.isnot(None),
+            Sighting.manufacturer != "",
+            sighting_confirms_tag,
+        ),
+        confidence=0.95,
+        source="multi_source_confirmed",
+        label="Multi-source boost",
+        batch_size=batch_size,
+    )
     if multi_boosted:
         logger.info(f"Multi-source boost: {multi_boosted} tags upgraded to 0.95")
 
@@ -453,27 +438,17 @@ async def nexar_bulk_validate(db: Session, limit: int = 5000) -> dict:
         for row in batch:
             try:
                 data = await connector._run_query(connector.AGGREGATE_QUERY, row.normalized_mpn)
-                results = (data.get("data") or {}).get("supSearchMpn", {}).get("results", [])
+                nexar_mfr = _nexar_manufacturer(data)
 
-                if not results:
+                if not nexar_mfr:
                     no_result += 1
                     continue
-
-                part = results[0].get("part", {})
-                nexar_mfr = ((part.get("manufacturer") or {}).get("name") or "").strip().lower()
-
-                if not nexar_mfr or nexar_mfr in _IGNORED_MANUFACTURERS:
-                    no_result += 1
-                    continue
-
-                ai_mfr = (row.tag_name or "").lower().strip()
-                is_match = nexar_mfr == ai_mfr or nexar_mfr in ai_mfr or ai_mfr in nexar_mfr
 
                 mt = db.get(MaterialTag, row.mt_id)
                 if not mt:
                     continue
 
-                if is_match:
+                if _manufacturers_agree(nexar_mfr, row.tag_name):
                     mt.confidence = 0.95
                     mt.source = "ai_confirmed_nexar"
                     confirmed += 1
@@ -484,7 +459,7 @@ async def nexar_bulk_validate(db: Session, limit: int = 5000) -> dict:
                         _apply_enrichment_to_card(
                             card,
                             {
-                                "manufacturer": nexar_mfr.title(),
+                                "manufacturer": nexar_mfr.lower().title(),
                                 "source": "nexar",
                                 "confidence": 0.95,
                                 "category": None,
@@ -553,16 +528,9 @@ async def nexar_backfill_untagged(db: Session, limit: int = 5000) -> dict:
     for i, row in enumerate(untagged):
         try:
             data = await connector._run_query(connector.AGGREGATE_QUERY, row.normalized_mpn)
-            results = (data.get("data") or {}).get("supSearchMpn", {}).get("results", [])
+            nexar_mfr = _nexar_manufacturer(data)
 
-            if not results:
-                no_result += 1
-                continue
-
-            part = results[0].get("part", {})
-            nexar_mfr = ((part.get("manufacturer") or {}).get("name") or "").strip()
-
-            if not nexar_mfr or nexar_mfr.lower() in _IGNORED_MANUFACTURERS:
+            if not nexar_mfr:
                 no_result += 1
                 continue
 
@@ -643,14 +611,8 @@ async def cross_validate_batch(db: Session, limit: int = 500, concurrency: int =
             no_result += 1
             continue
 
-        connector_mfr = result["manufacturer"].lower().strip()
-        ai_mfr = (row.tag_name or "").lower().strip()
-
-        # Check if connector confirms the AI classification
-        # Fuzzy match: either one contains the other, or exact match
-        is_confirmed = connector_mfr == ai_mfr or connector_mfr in ai_mfr or ai_mfr in connector_mfr
-
-        if is_confirmed:
+        # Check if connector confirms the AI classification (exact or substring match)
+        if _manufacturers_agree(result["manufacturer"], row.tag_name):
             # Upgrade the existing tag confidence
             mt = db.get(MaterialTag, row.mt_id)
             if mt and mt.confidence < result["confidence"]:

--- a/app/services/health_monitor.py
+++ b/app/services/health_monitor.py
@@ -84,6 +84,62 @@ def _redact_api_keys(text: str | None) -> str | None:
 # Known good MPN for testing — universally available across all distributors
 DEEP_TEST_MPN = "LM317"
 
+# Per-exception failure descriptors: how to format the stored error message and what to
+# write in the warning log. Each entry → (msg_prefix, max chars of str(e) kept, log phrase).
+# Untyped exceptions fall back to _GENERIC_FAILURE (raw text, no prefix).
+_FAILURE_BY_EXC = {
+    ConnectorAuthError: ("Auth error — rotate credentials: ", 380, "auth error"),
+    ConnectorRateLimitError: ("Rate limited — auto-recovers when window expires: ", 340, "rate-limited"),
+    ConnectorQuotaError: ("Quota exhausted — upgrade plan or wait for cycle: ", 340, "quota exhausted"),
+}
+_GENERIC_FAILURE = ("", 500, "failed")
+
+
+def _record_failure(
+    source: ApiSource,
+    db: Session,
+    *,
+    exc: Exception,
+    old_status: str,
+    now: datetime,
+    elapsed_ms: int,
+    endpoint: str,
+    check_type: str,
+    timestamp_field: str,
+    log_prefix: str,
+) -> dict:
+    """Apply the shared 'check failed' mutations and write the usage log.
+
+    Builds the typed error message, sets the source to ERROR, records error +
+    timestamps, bumps the 24h error count, fires the live→error transition alert, logs a
+    warning, and persists an ApiUsageLog row. Returns the {success, elapsed_ms, error}
+    dict callers add their extra keys to.
+    """
+    prefix, limit, log_phrase = _FAILURE_BY_EXC.get(type(exc), _GENERIC_FAILURE)
+    error_msg = f"{prefix}{str(exc)[:limit]}"
+
+    source.status = ApiSourceStatus.ERROR.value
+    source.last_error = error_msg
+    source.last_error_at = now
+    setattr(source, timestamp_field, now)
+    source.error_count_24h = (source.error_count_24h or 0) + 1
+    _check_status_transition(source, old_status, "error", db, error_msg)
+
+    log = ApiUsageLog(
+        source_id=source.id,
+        timestamp=now,
+        endpoint=endpoint,
+        response_ms=elapsed_ms,
+        success=False,
+        error_message=error_msg,
+        check_type=check_type,
+    )
+    db.add(log)
+    db.flush()
+
+    logger.warning("{} {} for {}: {}", log_prefix, log_phrase, source.name, error_msg)
+    return {"success": False, "elapsed_ms": elapsed_ms, "error": error_msg}
+
 
 def _get_connector(source: ApiSource, db: Session):
     """Get a connector instance for the given source.
@@ -188,101 +244,20 @@ async def ping_source(source: ApiSource, db: Session) -> dict:
 
         return {"success": True, "elapsed_ms": elapsed_ms, "error": None}
 
-    except ConnectorAuthError as e:
-        elapsed_ms = int((time.time() - start) * 1000)
-        error_msg = f"Auth error — rotate credentials: {str(e)[:380]}"
-        source.status = ApiSourceStatus.ERROR.value
-        source.last_error = error_msg
-        source.last_error_at = now
-        source.last_ping_at = now
-        source.error_count_24h = (source.error_count_24h or 0) + 1
-        _check_status_transition(source, old_status, "error", db, error_msg)
-        log = ApiUsageLog(
-            source_id=source.id,
-            timestamp=now,
-            endpoint="ping",
-            response_ms=elapsed_ms,
-            success=False,
-            error_message=error_msg,
-            check_type="ping",
-        )
-        db.add(log)
-        db.flush()
-        logger.warning("Health ping auth error for {}: {}", source.name, error_msg)
-        return {"success": False, "elapsed_ms": elapsed_ms, "error": error_msg}
-
-    except ConnectorRateLimitError as e:
-        elapsed_ms = int((time.time() - start) * 1000)
-        error_msg = f"Rate limited — auto-recovers when window expires: {str(e)[:340]}"
-        source.status = ApiSourceStatus.ERROR.value
-        source.last_error = error_msg
-        source.last_error_at = now
-        source.last_ping_at = now
-        source.error_count_24h = (source.error_count_24h or 0) + 1
-        _check_status_transition(source, old_status, "error", db, error_msg)
-        log = ApiUsageLog(
-            source_id=source.id,
-            timestamp=now,
-            endpoint="ping",
-            response_ms=elapsed_ms,
-            success=False,
-            error_message=error_msg,
-            check_type="ping",
-        )
-        db.add(log)
-        db.flush()
-        logger.warning("Health ping rate-limited for {}: {}", source.name, error_msg)
-        return {"success": False, "elapsed_ms": elapsed_ms, "error": error_msg}
-
-    except ConnectorQuotaError as e:
-        elapsed_ms = int((time.time() - start) * 1000)
-        error_msg = f"Quota exhausted — upgrade plan or wait for cycle: {str(e)[:340]}"
-        source.status = ApiSourceStatus.ERROR.value
-        source.last_error = error_msg
-        source.last_error_at = now
-        source.last_ping_at = now
-        source.error_count_24h = (source.error_count_24h or 0) + 1
-        _check_status_transition(source, old_status, "error", db, error_msg)
-        log = ApiUsageLog(
-            source_id=source.id,
-            timestamp=now,
-            endpoint="ping",
-            response_ms=elapsed_ms,
-            success=False,
-            error_message=error_msg,
-            check_type="ping",
-        )
-        db.add(log)
-        db.flush()
-        logger.warning("Health ping quota exhausted for {}: {}", source.name, error_msg)
-        return {"success": False, "elapsed_ms": elapsed_ms, "error": error_msg}
-
     except Exception as e:
         elapsed_ms = int((time.time() - start) * 1000)
-        error_msg = str(e)[:500]
-
-        source.status = ApiSourceStatus.ERROR.value
-        source.last_error = error_msg
-        source.last_error_at = now
-        source.last_ping_at = now
-        source.error_count_24h = (source.error_count_24h or 0) + 1
-        _check_status_transition(source, old_status, "error", db, error_msg)
-
-        # Log failed ping to ApiUsageLog
-        log = ApiUsageLog(
-            source_id=source.id,
-            timestamp=now,
+        return _record_failure(
+            source,
+            db,
+            exc=e,
+            old_status=old_status,
+            now=now,
+            elapsed_ms=elapsed_ms,
             endpoint="ping",
-            response_ms=elapsed_ms,
-            success=False,
-            error_message=error_msg,
             check_type="ping",
+            timestamp_field="last_ping_at",
+            log_prefix="Health ping",
         )
-        db.add(log)
-        db.flush()
-
-        logger.warning("Health ping failed for {}: {}", source.name, error_msg)
-        return {"success": False, "elapsed_ms": elapsed_ms, "error": error_msg}
 
 
 async def deep_test_source(source: ApiSource, db: Session) -> dict:
@@ -337,100 +312,21 @@ async def deep_test_source(source: ApiSource, db: Session) -> dict:
 
         return {"success": True, "results_count": len(results), "elapsed_ms": elapsed_ms, "error": None}
 
-    except ConnectorAuthError as e:
-        elapsed_ms = int((time.time() - start) * 1000)
-        error_msg = f"Auth error — rotate credentials: {str(e)[:380]}"
-        source.status = ApiSourceStatus.ERROR.value
-        source.last_error = error_msg
-        source.last_error_at = now
-        source.last_deep_test_at = now
-        source.error_count_24h = (source.error_count_24h or 0) + 1
-        _check_status_transition(source, old_status, "error", db, error_msg)
-        log = ApiUsageLog(
-            source_id=source.id,
-            timestamp=now,
-            endpoint="deep_test",
-            response_ms=elapsed_ms,
-            success=False,
-            error_message=error_msg,
-            check_type="deep",
-        )
-        db.add(log)
-        db.flush()
-        logger.warning("Deep test auth error for {}: {}", source.name, error_msg)
-        return {"success": False, "results_count": 0, "elapsed_ms": elapsed_ms, "error": error_msg}
-
-    except ConnectorRateLimitError as e:
-        elapsed_ms = int((time.time() - start) * 1000)
-        error_msg = f"Rate limited — auto-recovers when window expires: {str(e)[:340]}"
-        source.status = ApiSourceStatus.ERROR.value
-        source.last_error = error_msg
-        source.last_error_at = now
-        source.last_deep_test_at = now
-        source.error_count_24h = (source.error_count_24h or 0) + 1
-        _check_status_transition(source, old_status, "error", db, error_msg)
-        log = ApiUsageLog(
-            source_id=source.id,
-            timestamp=now,
-            endpoint="deep_test",
-            response_ms=elapsed_ms,
-            success=False,
-            error_message=error_msg,
-            check_type="deep",
-        )
-        db.add(log)
-        db.flush()
-        logger.warning("Deep test rate-limited for {}: {}", source.name, error_msg)
-        return {"success": False, "results_count": 0, "elapsed_ms": elapsed_ms, "error": error_msg}
-
-    except ConnectorQuotaError as e:
-        elapsed_ms = int((time.time() - start) * 1000)
-        error_msg = f"Quota exhausted — upgrade plan or wait for cycle: {str(e)[:340]}"
-        source.status = ApiSourceStatus.ERROR.value
-        source.last_error = error_msg
-        source.last_error_at = now
-        source.last_deep_test_at = now
-        source.error_count_24h = (source.error_count_24h or 0) + 1
-        _check_status_transition(source, old_status, "error", db, error_msg)
-        log = ApiUsageLog(
-            source_id=source.id,
-            timestamp=now,
-            endpoint="deep_test",
-            response_ms=elapsed_ms,
-            success=False,
-            error_message=error_msg,
-            check_type="deep",
-        )
-        db.add(log)
-        db.flush()
-        logger.warning("Deep test quota exhausted for {}: {}", source.name, error_msg)
-        return {"success": False, "results_count": 0, "elapsed_ms": elapsed_ms, "error": error_msg}
-
     except Exception as e:
         elapsed_ms = int((time.time() - start) * 1000)
-        error_msg = str(e)[:500]
-
-        source.status = ApiSourceStatus.ERROR.value
-        source.last_error = error_msg
-        source.last_error_at = now
-        source.last_deep_test_at = now
-        source.error_count_24h = (source.error_count_24h or 0) + 1
-        _check_status_transition(source, old_status, "error", db, error_msg)
-
-        log = ApiUsageLog(
-            source_id=source.id,
-            timestamp=now,
+        result = _record_failure(
+            source,
+            db,
+            exc=e,
+            old_status=old_status,
+            now=now,
+            elapsed_ms=elapsed_ms,
             endpoint="deep_test",
-            response_ms=elapsed_ms,
-            success=False,
-            error_message=error_msg,
             check_type="deep",
+            timestamp_field="last_deep_test_at",
+            log_prefix="Deep test",
         )
-        db.add(log)
-        db.flush()
-
-        logger.warning("Deep test failed for {}: {}", source.name, error_msg)
-        return {"success": False, "results_count": 0, "elapsed_ms": elapsed_ms, "error": error_msg}
+        return {**result, "results_count": 0}
 
 
 async def run_health_checks(check_type: str = "ping") -> dict:

--- a/app/services/integrity_service.py
+++ b/app/services/integrity_service.py
@@ -62,24 +62,35 @@ def check_orphaned_offers(db: Session) -> int:
     ) or 0
 
 
+# Models that carry a material_card_id FK, paired with their report key.
+_LINKED_MODELS = [
+    (Requirement, "requirements"),
+    (Sighting, "sightings"),
+    (Offer, "offers"),
+]
+
+
+def _dangling_query(db: Session, model, select):
+    """Query for ``model`` rows whose material_card_id points at a missing card.
+
+    ``select`` is the column expression to select (e.g. ``func.count(model.id)``
+    for a tally, or ``model`` to load the rows themselves).
+    """
+    return (
+        db.query(select)
+        .outerjoin(MaterialCard, model.material_card_id == MaterialCard.id)
+        .filter(
+            model.material_card_id.isnot(None),
+            MaterialCard.id.is_(None),
+        )
+    )
+
+
 def check_dangling_fks(db: Session) -> dict:
     """Count records pointing to non-existent material cards."""
     results = {}
-    for model, name in [
-        (Requirement, "requirements"),
-        (Sighting, "sightings"),
-        (Offer, "offers"),
-    ]:
-        count = (
-            db.query(func.count(model.id))
-            .outerjoin(MaterialCard, model.material_card_id == MaterialCard.id)
-            .filter(
-                model.material_card_id.isnot(None),
-                MaterialCard.id.is_(None),
-            )
-            .scalar()
-        ) or 0
-        results[name] = count
+    for model, name in _LINKED_MODELS:
+        results[name] = _dangling_query(db, model, func.count(model.id)).scalar() or 0
     return results
 
 
@@ -200,20 +211,8 @@ def clear_dangling_fks(db: Session) -> dict:
     re-linked to the correct (or a new) card.
     """
     cleared = {}
-    for model, name in [
-        (Requirement, "requirements"),
-        (Sighting, "sightings"),
-        (Offer, "offers"),
-    ]:
-        danglers = (
-            db.query(model)
-            .outerjoin(MaterialCard, model.material_card_id == MaterialCard.id)
-            .filter(
-                model.material_card_id.isnot(None),
-                MaterialCard.id.is_(None),
-            )
-            .all()
-        )
+    for model, name in _LINKED_MODELS:
+        danglers = _dangling_query(db, model, model).all()
         for rec in danglers:
             rec.material_card_id = None
         cleared[name] = len(danglers)

--- a/app/services/prefix_lookup.py
+++ b/app/services/prefix_lookup.py
@@ -1,7 +1,9 @@
 """Prefix lookup — maps MPN prefixes to canonical manufacturer names.
 
-Sorted longest-first for most-specific matching. Returns (manufacturer, confidence)
-where confidence is 0.9 for prefixes >= 3 chars and 0.7 for 2-char prefixes.
+Sorted longest-first for most-specific matching. Returns (manufacturer, 0.9) for a
+prefix >= 3 chars; 2-char prefixes are too ambiguous and are skipped (no match).
+2-char entries are kept in PREFIX_TABLE only as longest-first anchors (e.g. "SN"
+after "SN7"/"SN6"), never returned on their own.
 
 Called by: app.services.tagging (classify_material_card)
 Depends on: nothing (pure data + logic)
@@ -298,8 +300,8 @@ def lookup_manufacturer_by_prefix(normalized_mpn: str) -> tuple[str | None, floa
         normalized_mpn: Lowercase MPN string.
 
     Returns:
-        (manufacturer_name, confidence) or (None, 0.0) if no match.
-        Confidence is 0.9 for prefixes >= 3 chars, 0.7 for 2-char prefixes.
+        (manufacturer_name, 0.9) for a prefix >= 3 chars, or (None, 0.0) if no match.
+        2-char prefixes are too ambiguous to return, so they never match.
     """
     upper_mpn = normalized_mpn.upper()
     for prefix, manufacturer in _SORTED_PREFIXES:

--- a/app/services/prospect_scheduler.py
+++ b/app/services/prospect_scheduler.py
@@ -36,6 +36,25 @@ def _ensure_utc(dt: datetime | None) -> datetime | None:
     return dt
 
 
+def _has_strong_intent(signals: dict) -> bool:
+    """True when the readiness signals carry a strong/moderate intent strength."""
+    intent = signals.get("intent", {})
+    return isinstance(intent, dict) and intent.get("strength") in ("strong", "moderate")
+
+
+def _persist_discovery_results(db: Session, batch: DiscoveryBatch, results: list) -> int:
+    """Add discovery results to the session as ProspectAccount rows; return the count.
+
+    Each result may be a Pydantic model (has ``model_dump``) or a plain dict. Caller is
+    responsible for committing.
+    """
+    for r in results:
+        pa = ProspectAccount(**r.model_dump() if hasattr(r, "model_dump") else r)
+        pa.discovery_batch_id = batch.id
+        db.add(pa)
+    return len(results)
+
+
 # ── Discovery Slice Rotation ─────────────────────────────────────────
 
 DISCOVERY_ROTATION = [
@@ -141,11 +160,7 @@ async def job_discover_prospects() -> dict:
 
             existing_domains = {d[0] for d in db.query(ProspectAccount.domain).limit(10000).all() if d[0]}
             results = await run_explorium_discovery_batch(batch_id, existing_domains)
-            for r in results:
-                pa = ProspectAccount(**r.model_dump() if hasattr(r, "model_dump") else r)
-                pa.discovery_batch_id = batch.id
-                db.add(pa)
-            explorium_count = len(results)
+            explorium_count = _persist_discovery_results(db, batch, results)
             db.commit()
         except Exception as e:
             logger.exception("Explorium discovery failed: {}", e)
@@ -158,11 +173,7 @@ async def job_discover_prospects() -> dict:
 
             graph = get_graph_client()
             email_results = await run_email_mining_batch(batch_id, graph, db)
-            for r in email_results:
-                pa = ProspectAccount(**r.model_dump() if hasattr(r, "model_dump") else r)
-                pa.discovery_batch_id = batch.id
-                db.add(pa)
-            email_count = len(email_results)
+            email_count = _persist_discovery_results(db, batch, email_results)
             db.commit()
         except Exception as e:
             logger.exception("Email mining failed: {}", e)
@@ -361,9 +372,7 @@ async def job_expire_and_resurface() -> dict:
             if (p.readiness_score or 0) > 60:
                 continue
             # Don't expire active intent signals
-            signals = p.readiness_signals or {}
-            intent = signals.get("intent", {})
-            if isinstance(intent, dict) and intent.get("strength") in ("strong", "moderate"):
+            if _has_strong_intent(p.readiness_signals or {}):
                 continue
 
             p.status = "expired"
@@ -385,11 +394,8 @@ async def job_expire_and_resurface() -> dict:
         resurfaced_count = 0
         for p in resurface_candidates:
             signals = p.readiness_signals or {}
-            intent = signals.get("intent", {})
             hiring = signals.get("hiring", {})
-            has_fresh_signals = (isinstance(intent, dict) and intent.get("strength") in ("strong", "moderate")) or (
-                isinstance(hiring, dict) and hiring.get("type")
-            )
+            has_fresh_signals = _has_strong_intent(signals) or (isinstance(hiring, dict) and hiring.get("type"))
             if has_fresh_signals and (p.readiness_score or 0) >= 40:
                 p.status = ProspectAccountStatus.SUGGESTED
                 p.dismissed_by = None

--- a/app/services/requisition_list_service.py
+++ b/app/services/requisition_list_service.py
@@ -133,6 +133,19 @@ def _build_pagination(page: int, per_page: int, total: int) -> PaginationContext
     )
 
 
+def _customer_display_for_req(db: Session, req: Requisition) -> str:
+    """Resolve a requisition's customer display label.
+
+    Prefers "Company — Site" from the linked CustomerSite, falling back to the
+    requisition's free-form customer_name (or empty string).
+    """
+    if req.customer_site_id:
+        site = db.query(CustomerSite).filter(CustomerSite.id == req.customer_site_id).first()
+        if site and site.company:
+            return f"{site.company.name} — {site.site_name}"
+    return req.customer_name or ""
+
+
 def list_requisitions(
     db: Session,
     filters: ReqListFilters,
@@ -616,11 +629,7 @@ def get_requisition_detail(
         return None
 
     # Load customer display name
-    customer_display = req.customer_name or ""
-    if req.customer_site_id:
-        site = db.query(CustomerSite).filter(CustomerSite.id == req.customer_site_id).first()
-        if site and site.company:
-            customer_display = f"{site.company.name} — {site.site_name}"
+    customer_display = _customer_display_for_req(db, req)
 
     # Creator name
     creator_name = ""
@@ -702,11 +711,7 @@ def get_row_context(db: Session, req: Requisition, user) -> dict:
     creator = db.query(User).filter(User.id == req.created_by).first()
     creator_name = creator.name or creator.email if creator else ""
     # Customer display
-    customer_display = req.customer_name or ""
-    if req.customer_site_id:
-        site = db.query(CustomerSite).filter(CustomerSite.id == req.customer_site_id).first()
-        if site and site.company:
-            customer_display = f"{site.company.name} — {site.site_name}"
+    customer_display = _customer_display_for_req(db, req)
     return {
         "req": {
             "id": req.id,

--- a/app/services/sighting_aggregation.py
+++ b/app/services/sighting_aggregation.py
@@ -168,43 +168,31 @@ def rebuild_vendor_summaries(
         newest = max((s.created_at for s in group if s.created_at), default=None)
         has_contact = any(s.vendor_email or s.vendor_phone for s in group) or bool(vendor_phones.get(vn))
 
+        fields = {
+            "vendor_phone": vendor_phones.get(vn),
+            "estimated_qty": estimated_qty,
+            "avg_price": round(avg_price, 4) if avg_price else None,
+            "best_price": round(best_price, 4) if best_price else None,
+            "listing_count": len(group),
+            "source_types": sources,
+            "score": round(max_score, 1) if max_score else None,
+            "tier": _score_to_tier(max_score),
+            "updated_at": datetime.now(timezone.utc),
+            "vendor_card_id": vendor_card_ids.get(vn),
+            "newest_sighting_at": newest,
+            "best_lead_time_days": min(lead_times) if lead_times else None,
+            "min_moq": min(moqs) if moqs else None,
+            "has_contact_info": has_contact,
+        }
+
         # Upsert summary
         existing = db.query(VendorSightingSummary).filter_by(requirement_id=requirement_id, vendor_name=vn).first()
         if existing:
-            existing.vendor_phone = vendor_phones.get(vn)
-            existing.estimated_qty = estimated_qty
-            existing.avg_price = round(avg_price, 4) if avg_price else None
-            existing.best_price = round(best_price, 4) if best_price else None
-            existing.listing_count = len(group)
-            existing.source_types = sources
-            existing.score = round(max_score, 1) if max_score else None
-            existing.tier = _score_to_tier(max_score)
-            existing.updated_at = datetime.now(timezone.utc)
-            existing.vendor_card_id = vendor_card_ids.get(vn)
-            existing.newest_sighting_at = newest
-            existing.best_lead_time_days = min(lead_times) if lead_times else None
-            existing.min_moq = min(moqs) if moqs else None
-            existing.has_contact_info = has_contact
+            for key, value in fields.items():
+                setattr(existing, key, value)
             results.append(existing)
         else:
-            summary = VendorSightingSummary(
-                requirement_id=requirement_id,
-                vendor_name=vn,
-                vendor_phone=vendor_phones.get(vn),
-                estimated_qty=estimated_qty,
-                avg_price=round(avg_price, 4) if avg_price else None,
-                best_price=round(best_price, 4) if best_price else None,
-                listing_count=len(group),
-                source_types=sources,
-                score=round(max_score, 1) if max_score else None,
-                tier=_score_to_tier(max_score),
-                updated_at=datetime.now(timezone.utc),
-                vendor_card_id=vendor_card_ids.get(vn),
-                newest_sighting_at=newest,
-                best_lead_time_days=min(lead_times) if lead_times else None,
-                min_moq=min(moqs) if moqs else None,
-                has_contact_info=has_contact,
-            )
+            summary = VendorSightingSummary(requirement_id=requirement_id, vendor_name=vn, **fields)
             db.add(summary)
             results.append(summary)
 

--- a/app/services/sighting_status.py
+++ b/app/services/sighting_status.py
@@ -152,16 +152,20 @@ def compute_vendor_statuses(
     # contacted > sighting. unavailable outranks contacted: contacted is a step
     # and unavailable is its answer — a mark made after contacting must be
     # visible. offer-in still dominates everything but blacklisted.
+    # Normalize the offer/contacted vendor names once (the DB rows carry raw
+    # names) rather than rebuilding the sets on every vendor iteration.
+    offer_norms = {normalize_vendor_name(ov) for ov in offer_vendors}
+    contacted_norms = {normalize_vendor_name(cv) for cv in contacted_vendors}
     result: dict[str, str] = {}
     for vn in vendor_names:
         norm = normalized[vn]
         if norm in bl_cards:
             result[vn] = "blacklisted"
-        elif vn in offer_vendors or norm in {normalize_vendor_name(ov) for ov in offer_vendors}:
+        elif vn in offer_vendors or norm in offer_norms:
             result[vn] = "offer-in"
         elif norm in unavail_norms:
             result[vn] = "unavailable"
-        elif vn in contacted_vendors or norm in {normalize_vendor_name(cv) for cv in contacted_vendors}:
+        elif vn in contacted_vendors or norm in contacted_norms:
             result[vn] = "contacted"
         else:
             result[vn] = "sighting"

--- a/app/services/sourcing_auto_progress.py
+++ b/app/services/sourcing_auto_progress.py
@@ -55,7 +55,6 @@ def auto_progress_status(
         )
         return False
 
-    old_status = requirement.sourcing_status
     requirement.sourcing_status = target_status
 
     # Log status change
@@ -66,14 +65,14 @@ def auto_progress_status(
             user_id=user_id,
             activity_type=ActivityType.STATUS_CHANGED,
             channel=Channel.SYSTEM,
-            notes=f"Auto-progressed from {old_status} to {target_status}",
+            notes=f"Auto-progressed from {current} to {target_status}",
         )
     )
 
     logger.info(
         "Auto-progressed requirement {}: {} → {}",
         requirement.id,
-        old_status,
+        current,
         target_status,
     )
     return True

--- a/app/services/sourcing_leads.py
+++ b/app/services/sourcing_leads.py
@@ -126,11 +126,12 @@ def _freshness_score(created_at: datetime | None) -> float:
 
 def _contactability_score(sighting: Sighting, vendor_card: VendorCard | None) -> float:
     score = 0.0
+    raw = sighting.raw_data or {}
     if sighting.vendor_email:
         score += 45
     if sighting.vendor_phone:
         score += 35
-    if (sighting.raw_data or {}).get("website") or (sighting.raw_data or {}).get("vendor_url"):
+    if raw.get("website") or raw.get("vendor_url"):
         score += 20
     if vendor_card:
         if vendor_card.emails:
@@ -335,13 +336,10 @@ def _signal_type_for_source(source_type: str) -> str:
 def _reliability_band(score: float) -> str:
     """Reliability band for evidence items per evidence.schema.yaml.
 
-    Separate from confidence_band — this rates the source itself, not the lead.
+    Separate from confidence_band semantically — this rates the source itself, not the
+    lead — but shares the same high/medium/low thresholds.
     """
-    if score >= 75:
-        return "high"
-    if score >= 50:
-        return "medium"
-    return "low"
+    return _confidence_band(score)
 
 
 def _match_type_for_parts(requested: str, matched: str, substitutes: list | None = None) -> str:

--- a/app/services/spec_code_resolver.py
+++ b/app/services/spec_code_resolver.py
@@ -70,6 +70,17 @@ class ResolverResult:
     citations: list[dict] = field(default_factory=list)
     source: ResolverSource = "none"
 
+    @classmethod
+    def from_pending(cls, pending: OemSpecCodePending) -> ResolverResult:
+        """Build a ``pending``/``source="llm"`` result from a persisted pending row."""
+        return cls(
+            status="pending",
+            avl=list(pending.proposed_avl or []),
+            confidence=pending.llm_confidence,
+            citations=list(pending.citations or []),
+            source="llm",
+        )
+
 
 _SYSTEM_PROMPT = """You are a parts-engineering expert with deep knowledge of IBM,
 Cisco, HP, and Dell internal spec codes for electronic components. Given an OEM
@@ -189,16 +200,7 @@ class SpecCodeResolver:
         if allow_pending_reuse:
             pending = self._db.query(OemSpecCodePending).filter_by(oem=norm_oem, spec_code=norm_code).one_or_none()
             if pending is not None:
-                return (
-                    ResolverResult(
-                        status="pending",
-                        avl=list(pending.proposed_avl or []),
-                        confidence=pending.llm_confidence,
-                        citations=list(pending.citations or []),
-                        source="llm",
-                    ),
-                    None,
-                )
+                return ResolverResult.from_pending(pending), None
 
         # 3. Blacklist — accumulated rejected MPNs feed into the LLM prompt
         blacklist_mpns = self._load_blacklist(norm_oem, norm_code)
@@ -284,13 +286,7 @@ class SpecCodeResolver:
                 .one_or_none()
             )
             if winner is not None:
-                return ResolverResult(
-                    status="pending",
-                    avl=list(winner.proposed_avl or []),
-                    confidence=winner.llm_confidence,
-                    citations=list(winner.citations or []),
-                    source="llm",
-                )
+                return ResolverResult.from_pending(winner)
         return result
 
     def _load_blacklist(self, oem: str, spec_code: str) -> list[str]:

--- a/app/services/spec_enrichment_service.py
+++ b/app/services/spec_enrichment_service.py
@@ -43,6 +43,11 @@ _SYSTEM = (
 )
 
 
+def _empty_stats() -> dict:
+    """Zeroed spec-enrichment stats dict (single source of truth for the shape)."""
+    return {"cards_processed": 0, "specs_written": 0, "cards_with_specs": 0, "errors": 0, "skipped_no_schema": 0}
+
+
 def build_spec_prompt(category: str, cards: list[dict]) -> str:
     """Build a commodity-specific spec extraction prompt."""
     schema = COMMODITY_SPECS[category]
@@ -149,7 +154,7 @@ async def enrich_card_specs(
         query = query.filter(MaterialCard.specs_enriched_at.is_(None))
     cards = query.all()
 
-    stats = {"cards_processed": 0, "specs_written": 0, "cards_with_specs": 0, "errors": 0, "skipped_no_schema": 0}
+    stats = _empty_stats()
 
     by_cat: dict[str, list[MaterialCard]] = {}
     for c in cards:
@@ -289,5 +294,5 @@ async def enrich_pending_specs(db: Session, *, limit: int = 300, batch_size: int
     )
     card_ids = [r[0] for r in rows]
     if not card_ids:
-        return {"cards_processed": 0, "specs_written": 0, "cards_with_specs": 0, "errors": 0, "skipped_no_schema": 0}
+        return _empty_stats()
     return await enrich_card_specs(card_ids, db, force=False, batch_size=batch_size)

--- a/app/services/tagging_ai_classify.py
+++ b/app/services/tagging_ai_classify.py
@@ -49,6 +49,9 @@ async def classify_parts_with_ai(part_numbers: list[str]) -> list[dict]:
     mpn_list = "\n".join(f"- {mpn}" for mpn in part_numbers)
     prompt = _CLASSIFY_PROMPT.format(mpns=mpn_list)
 
+    def _all_unknown() -> list[dict]:
+        return [{"mpn": mpn, "manufacturer": "Unknown", "category": "Miscellaneous"} for mpn in part_numbers]
+
     try:
         result = await claude_json(
             prompt,
@@ -59,14 +62,14 @@ async def classify_parts_with_ai(part_numbers: list[str]) -> list[dict]:
         )
     except ClaudeUnavailableError:
         logger.info("Claude not configured — skipping AI classification")
-        return [{"mpn": mpn, "manufacturer": "Unknown", "category": "Miscellaneous"} for mpn in part_numbers]
+        return _all_unknown()
     except ClaudeError as e:
         logger.warning("Claude AI failed for classification: {}", e)
-        return [{"mpn": mpn, "manufacturer": "Unknown", "category": "Miscellaneous"} for mpn in part_numbers]
+        return _all_unknown()
 
     if not result or not isinstance(result, list):
         logger.warning("AI classification returned invalid response")
-        return [{"mpn": mpn, "manufacturer": "Unknown", "category": "Miscellaneous"} for mpn in part_numbers]
+        return _all_unknown()
 
     # Validate and normalize response
     classified = []
@@ -128,8 +131,6 @@ def _apply_ai_results(classified: list[dict], batch: list, db: Session) -> tuple
             unknown += 1
         else:
             matched += 1
-
-        if not is_unknown:
             card = db.get(MaterialCard, card_id)
             if card and not card.manufacturer:
                 card.manufacturer = manufacturer

--- a/app/services/vendor_scorecard.py
+++ b/app/services/vendor_scorecard.py
@@ -35,6 +35,32 @@ W_PO_CONVERSION = 0.25
 W_REVIEW_RATING = 0.25
 
 
+def _load_quoted_offer_ids(db: Session) -> set[int]:
+    """Offer ids referenced by sent/won/lost quote line items."""
+    quoted_offer_ids: set[int] = set()
+    for (items,) in db.query(Quote.line_items).filter(Quote.status.in_(["sent", "won", "lost"])).limit(10000).all():
+        for item in items or []:
+            oid = item.get("offer_id")
+            if oid:
+                quoted_offer_ids.add(oid)
+    return quoted_offer_ids
+
+
+def _load_po_offer_ids(db: Session) -> set[int]:
+    """Offer ids tied to completed buy plans."""
+    po_offer_ids: set[int] = set()
+    for (offer_id,) in (
+        db.query(BuyPlanLine.offer_id)
+        .join(BuyPlan, BuyPlanLine.buy_plan_id == BuyPlan.id)
+        .filter(BuyPlan.status.in_(["completed"]))
+        .filter(BuyPlanLine.offer_id.isnot(None))
+        .limit(10000)
+        .all()
+    ):
+        po_offer_ids.add(offer_id)
+    return po_offer_ids
+
+
 def compute_vendor_scorecard(
     db: Session,
     vendor_card_id: int,
@@ -108,14 +134,7 @@ def compute_vendor_scorecard(
     offers_in_quotes = 0
     if total_offers > 0:
         if quoted_offer_ids is None:
-            quoted_offer_ids = set()
-            for (items,) in (
-                db.query(Quote.line_items).filter(Quote.status.in_(["sent", "won", "lost"])).limit(10000).all()
-            ):
-                for item in items or []:
-                    oid = item.get("offer_id")
-                    if oid:
-                        quoted_offer_ids.add(oid)
+            quoted_offer_ids = _load_quoted_offer_ids(db)
 
         for o in offers_in_window:
             if o.id in quoted_offer_ids:
@@ -126,16 +145,7 @@ def compute_vendor_scorecard(
     offers_to_po = 0
     if total_offers > 0:
         if po_offer_ids is None:
-            po_offer_ids = set()
-            for (offer_id,) in (
-                db.query(BuyPlanLine.offer_id)
-                .join(BuyPlan, BuyPlanLine.buy_plan_id == BuyPlan.id)
-                .filter(BuyPlan.status.in_(["completed"]))
-                .filter(BuyPlanLine.offer_id.isnot(None))
-                .limit(10000)
-                .all()
-            ):
-                po_offer_ids.add(offer_id)
+            po_offer_ids = _load_po_offer_ids(db)
 
         for o in offers_in_window:
             if o.id in po_offer_ids:
@@ -220,23 +230,8 @@ def compute_all_vendor_scorecards(db: Session) -> dict:
     skipped = 0
 
     # ── Preload quote and buy-plan offer-id lookups ONCE ──
-    quoted_offer_ids: set[int] = set()
-    for (items,) in db.query(Quote.line_items).filter(Quote.status.in_(["sent", "won", "lost"])).limit(10000).all():
-        for item in items or []:
-            oid = item.get("offer_id")
-            if oid:
-                quoted_offer_ids.add(oid)
-
-    po_offer_ids: set[int] = set()
-    for (offer_id,) in (
-        db.query(BuyPlanLine.offer_id)
-        .join(BuyPlan, BuyPlanLine.buy_plan_id == BuyPlan.id)
-        .filter(BuyPlan.status.in_(["completed"]))
-        .filter(BuyPlanLine.offer_id.isnot(None))
-        .limit(10000)
-        .all()
-    ):
-        po_offer_ids.add(offer_id)
+    quoted_offer_ids = _load_quoted_offer_ids(db)
+    po_offer_ids = _load_po_offer_ids(db)
 
     # Process vendor IDs in chunks of 500 to avoid loading all at once
     CHUNK_SIZE = 500

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -304,10 +304,9 @@ def validate_notifications(payload: dict, db: Session) -> list[dict]:
             continue
 
         # Timing-safe clientState comparison
-        if sub.client_state:
-            if not hmac.compare_digest(sub.client_state, client_state or ""):
-                logger.warning(f"Client state mismatch for {sub_id}, ignoring")
-                continue
+        if sub.client_state and not hmac.compare_digest(sub.client_state, client_state or ""):
+            logger.warning(f"Client state mismatch for {sub_id}, ignoring")
+            continue
 
         # Replay protection
         resource = notif.get("resource", "")
@@ -414,24 +413,24 @@ async def handle_notification(payload: dict, db: Session, validated: list[dict] 
         subject = msg.get("subject", "")
 
         from_addr = _extract_email(msg.get("from"))
-        user_email = user.email.lower()
-
-        if from_addr and from_addr.lower() == user_email:
+        if not from_addr:
             continue
-        else:
-            from_name = _extract_name(msg.get("from"))
-            if from_addr:
-                log_email_activity(
-                    user_id=user.id,
-                    direction="received",
-                    email_addr=from_addr,
-                    subject=subject,
-                    external_id=message_id,
-                    contact_name=from_name,
-                    db=db,
-                )
-                if user.id not in users_with_inbound:
-                    users_with_inbound[user.id] = (user, token)
+
+        # Skip our own outbound messages
+        if from_addr.lower() == user.email.lower():
+            continue
+
+        log_email_activity(
+            user_id=user.id,
+            direction="received",
+            email_addr=from_addr,
+            subject=subject,
+            external_id=message_id,
+            contact_name=_extract_name(msg.get("from")),
+            db=db,
+        )
+        if user.id not in users_with_inbound:
+            users_with_inbound[user.id] = (user, token)
 
     db.commit()
 


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services [core 3/4]`)
26 file(s) changed, 44 simplifications (6 file(s) already clean).

- **`activity_quality_service.py`** — Extract two byte-identical 'no interaction details' marker blocks into _mark_no_data(log, db).
- **`activity_service.py`** — Extracted _match_entity_links() to remove the identical 4-line match->entity-link block duplicated in log_email_activity and log_call_activity; Extracted _phone_digits() to collapse the digit-extraction comprehension repeated 3x in match_phone_to_entity; Extracted _is_meaningful_or_unscored() for the is_meaningful filter clause duplicated in get_company_activities and get_requisition_activities; Reused existing bump_company_site_activity() in log_company_call, log_company_note, log_site_contact_note instead of re-implementing the last_activity_at bump inline.
- **`admin_service.py`** — Extracted the duplicated config-cache staleness check into `_ensure_config_cache_fresh(db)`; Computed the table label once per loop iteration in `get_system_health` instead of twice; Converted the scheduler-status and connector `for ... append` loops to list comprehensions.
- **`ai_intake_parser.py`** — Extracted duplicated MPN-fallback into a _row_mpn() helper; _normalize_top_level now reuses the existing _clean_scalar() instead of re-implementing whitespace collapse; Moved function-local `import re` in _heuristic_parse to module level.
- **`ai_service.py`** — Collapsed dead-branch confidence logic in enrich_contacts_websearch to a single conditional; Reduced redundant except (ValidationError, Exception) to except Exception; Extracted the parts-list formatter duplicated twice in draft_rfq into a local format_parts() helper.
- **`auto_dedup_service.py`** — Remove provably-dead seen_pairs / pair_key state from _dedup_vendors; Use keep/remove object aliases instead of re-deriving names with conditional expressions.
- **`buyer_leaderboard.py`** — Replaced 12 hand-written entry→snapshot field copies with a loop over the entry dict.
- **`buyplan_notifications.py`** — Extracted byte-identical 6-column lines table into a new _lines_table() helper.
- **`company_merge_service.py`** — Extracted a local `_norm_site_name(site)` helper to remove the 4x-repeated `(site.site_name or "").strip().upper()` idiom.
- **`customer_enrichment_batch.py`** — Hoist duplicated `processed += 1` out of try/except.
- **`document_service.py`** — Extracted shared PDF-render logic into a private `_render_pdf(template_name, **context)` helper; Single lazy weasyprint import site instead of two duplicated ones.
- **`enrichment.py`** — Extracted _manufacturers_agree() for the repeated exact-or-substring manufacturer match; Extracted _nexar_manufacturer() for the duplicated Nexar GraphQL result parsing + junk filter; Collapsed three near-identical batched keyset-update loops in boost_confidence_internal into one _run_boost_loop helper.
- **`health_monitor.py`** — Collapsed 8 near-identical except blocks (4 in ping_source + 4 in deep_test_source) into one shared _record_failure helper plus a per-exception _FAILURE_BY_EXC descriptor table.
- **`integrity_service.py`** — Extract duplicated dangling-FK outerjoin+filter into private _dangling_query helper; Hoist repeated linked-models list into module-level _LINKED_MODELS constant.
- **`prefix_lookup.py`** — Corrected two stale docstrings that contradicted the code's actual confidence behavior.
- **`prospect_scheduler.py`** — Extracted the duplicated 'build ProspectAccount rows from discovery results and attach batch id' loop into a _persist_discovery_results helper, used by both the Explorium and email-mining branches of job_discover_prospects; Extracted the repeated strong/moderate-intent predicate into _has_strong_intent(signals), removing duplicate isinstance+strength checks in both the expire and resurface loops of job_expire_and_resurface.
- **`requisition_list_service.py`** — Extracted duplicated customer-display block into a new module-level helper _customer_display_for_req(db, req); both get_requisition_detail and get_row_context now call it.
- **`sighting_aggregation.py`** — Collapsed the duplicated 14-field upsert into a single computed `fields` dict applied to both the update (setattr loop) and insert (`**fields`) branches.
- **`sighting_status.py`** — Hoist normalized offer/contacted vendor sets out of the per-vendor loop.
- **`sourcing_auto_progress.py`** — Removed redundant `old_status` local that duplicated the already-bound `current`.
- **`sourcing_leads.py`** — _reliability_band now delegates to _confidence_band instead of duplicating its identical high/medium/low threshold body; _contactability_score evaluates (sighting.raw_data or {}) once instead of twice.
- **`spec_code_resolver.py`** — Extract duplicated pending-row -> ResolverResult construction into ResolverResult.from_pending classmethod.
- **`spec_enrichment_service.py`** — Extract duplicated zeroed-stats dict literal into a _empty_stats() factory.
- **`tagging_ai_classify.py`** — Collapse three identical 'all unknown' fallback returns into one local helper; Merge duplicated `if not is_unknown:` guard in _apply_ai_results.
- **`vendor_scorecard.py`** — Extracted duplicated quoted/PO offer-id loaders into _load_quoted_offer_ids() and _load_po_offer_ids().
- **`webhook_service.py`** — Flattened the inbound-message branch in handle_notification into guard clauses; Merged nested clientState check in validate_notifications into a single condition.

_Recorded cross-file follow-ups:_
- `activity_service.py`: CROSS-FILE (not done, recorded): the try/except-PostgreSQL-regex-then-Python-fallback pattern for phone suffix matching in match_phone_to_entity is a candidate for a shared SQL helper, but a proper fix would live in app/utils/sql_helpers.
- `sourcing_leads.py`: REUSE (cross-file): _normalize_phone (digits-only dedup key) is duplicated in app/services/activity_service.
- `sourcing_leads.py`: REUSE (cross-file): _clamp, _now_utc, _as_utc have no equivalent in app/utils.
- `requisition_list_service.py`: CROSS-FILE (out of scope, not applied): the 'Company — Site' display string and the 'user.
- `enrichment.py`: _IGNORED_MANUFACTURERS duplicates _JUNK_MANUFACTURERS in app/services/tagging_backfill.
- `buyplan_notifications.py`: REUSE (cross-file, NOT applied): no shared sendMail helper exists on GraphClient or anywhere in app/; email_service.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)