### PR TITLE
simplify(services 4/4): de-duplicate service helpers

### DIFF
--- a/app/services/acs_service.py
+++ b/app/services/acs_service.py
@@ -35,9 +35,8 @@ async def initiate_call(to_phone: str, from_phone: str, callback_url: str, conne
             source_caller_id_number=PhoneNumberIdentifier(from_phone),
         )
 
-        # Run synchronous SDK call in executor to avoid blocking event loop
-        loop = asyncio.get_event_loop()
-        call_result = await loop.run_in_executor(None, lambda: client.create_call(call_invite, callback_url))
+        # Run synchronous SDK call in a worker thread to avoid blocking event loop
+        call_result = await asyncio.to_thread(client.create_call, call_invite, callback_url)
         return {
             "call_connection_id": call_result.call_connection_id,
             "status": "initiated",

--- a/app/services/attachment_parser.py
+++ b/app/services/attachment_parser.py
@@ -154,10 +154,10 @@ async def _get_or_detect_mapping(
     Caching by (vendor_domain, file_fingerprint) so repeat files from the same vendor
     don't re-invoke AI.
     """
+    from app.models import ColumnMappingCache
+
     # Step 1: Check cache
     if db and vendor_domain and file_fingerprint:
-        from app.models import ColumnMappingCache
-
         cached = (
             db.query(ColumnMappingCache)
             .filter_by(
@@ -189,33 +189,23 @@ async def _get_or_detect_mapping(
 
     # Step 4: Cache the result
     if db and vendor_domain and file_fingerprint and mapping:
-        from app.models import ColumnMappingCache
-
-        cache_entry = ColumnMappingCache(
-            vendor_domain=vendor_domain,
-            file_fingerprint=file_fingerprint,
-            mapping={str(k): v for k, v in mapping.items()},  # JSON needs string keys
-            confidence=0.9 if has_mpn else 0.7,
-            created_at=datetime.now(timezone.utc),
-        )
+        json_mapping = {str(k): v for k, v in mapping.items()}  # JSON needs string keys
+        confidence = 0.9 if has_mpn else 0.7
         try:
             from sqlalchemy.dialects.postgresql import insert
 
             stmt = (
                 insert(ColumnMappingCache.__table__)
                 .values(
-                    vendor_domain=cache_entry.vendor_domain,
-                    file_fingerprint=cache_entry.file_fingerprint,
-                    mapping=cache_entry.mapping,
-                    confidence=cache_entry.confidence,
-                    created_at=cache_entry.created_at,
+                    vendor_domain=vendor_domain,
+                    file_fingerprint=file_fingerprint,
+                    mapping=json_mapping,
+                    confidence=confidence,
+                    created_at=datetime.now(timezone.utc),
                 )
                 .on_conflict_do_update(
                     index_elements=["vendor_domain", "file_fingerprint"],
-                    set_={
-                        "mapping": cache_entry.mapping,
-                        "confidence": cache_entry.confidence,
-                    },
+                    set_={"mapping": json_mapping, "confidence": confidence},
                 )
             )
             db.execute(stmt)
@@ -255,10 +245,9 @@ def _parse_csv(file_bytes: bytes, filename: str) -> tuple[list[str], list[list[s
     """Parse CSV/TSV file with encoding detection, return (headers, rows)."""
     import csv
 
-    from app.utils.file_validation import detect_encoding
+    from app.utils.file_validation import decode_text
 
-    encoding = detect_encoding(file_bytes)
-    text = file_bytes.decode(encoding, errors="replace")
+    text = decode_text(file_bytes)
 
     # Auto-detect delimiter
     delimiter = "\t" if filename.lower().endswith(".tsv") else ","

--- a/app/services/avail_score_service.py
+++ b/app/services/avail_score_service.py
@@ -39,6 +39,7 @@ from ..models import (
     User,
 )
 from ..models.performance import AvailScoreSnapshot
+from .scoring_helpers import month_range
 
 # ── Bonus thresholds ─────────────────────────────────────────────────
 BONUS_1ST = 500.0
@@ -64,6 +65,13 @@ def _tier(value, thresholds):
     return 0
 
 
+def _as_utc(dt):
+    """Treat a naive datetime as UTC; pass tz-aware datetimes through unchanged."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 # ══════════════════════════════════════════════════════════════════════
 #  BUYER AVAIL SCORE
 # ══════════════════════════════════════════════════════════════════════
@@ -74,8 +82,6 @@ def compute_buyer_avail_score(db: Session, user_id: int, month: date) -> dict:
 
     Returns dict with b1–b5, o1–o5 scores, labels, raw values, and totals.
     """
-    from app.services.scoring_helpers import month_range
-
     start_dt, end_dt = month_range(month)
 
     # ── Fetch user's reqs for the month ──
@@ -309,12 +315,7 @@ def _buyer_b1_speed_to_source(db, req_ids, user_reqs):
     for req in user_reqs:
         first_at = fc_map.get(req.id)
         if first_at and req.created_at:
-            req_created = req.created_at
-            if req_created.tzinfo is None:
-                req_created = req_created.replace(tzinfo=timezone.utc)
-            if first_at.tzinfo is None:
-                first_at = first_at.replace(tzinfo=timezone.utc)
-            hours = (first_at - req_created).total_seconds() / 3600
+            hours = (_as_utc(first_at) - _as_utc(req.created_at)).total_seconds() / 3600
             if hours >= 0:
                 total_hours += hours
                 counted += 1
@@ -324,7 +325,7 @@ def _buyer_b1_speed_to_source(db, req_ids, user_reqs):
 
     avg_hours = total_hours / counted
     # Lower is better
-    score = _tier(1, [])  # default 0
+    score = 0
     if avg_hours < 4:
         score = 10
     elif avg_hours < 8:
@@ -418,10 +419,7 @@ def _buyer_b4_pipeline_hygiene(db, req_ids, user_reqs):
     for req in user_reqs:
         if not req.created_at:
             continue
-        req_created = req.created_at
-        if req_created.tzinfo is None:
-            req_created = req_created.replace(tzinfo=timezone.utc)
-        deadline = req_created + timedelta(days=5)
+        deadline = _as_utc(req.created_at) + timedelta(days=5)
 
         has_offer = (
             db.query(Offer.id)
@@ -446,8 +444,6 @@ def _buyer_b4_pipeline_hygiene(db, req_ids, user_reqs):
 
 def compute_sales_avail_score(db: Session, user_id: int, month: date) -> dict:
     """Compute all 10 sales metrics for a given month."""
-    from app.services.scoring_helpers import month_range
-
     start_dt, end_dt = month_range(month)
     # Calls + emails, direction-agnostic: the prior tuple held both call
     # directions, so call_logged (canonical, any direction) preserves intent.
@@ -726,9 +722,7 @@ def _sales_b3_quote_followup(db, user_id, start_dt, end_dt):
     for q in sent_quotes:
         if not q.sent_at:  # pragma: no cover
             continue
-        sent_at = q.sent_at
-        if sent_at.tzinfo is None:
-            sent_at = sent_at.replace(tzinfo=timezone.utc)
+        sent_at = _as_utc(q.sent_at)
         followup_deadline = sent_at + timedelta(days=5)
 
         # Look for outbound activity on the same company after quote was sent

--- a/app/services/buyplan_builder.py
+++ b/app/services/buyplan_builder.py
@@ -221,16 +221,15 @@ def generate_ai_summary(plan: BuyPlan) -> str:
         return "Empty buy plan — no lines generated."
 
     line_count = len(lines)
-    vendor_ids = set()
-    for line in lines:
-        if line.offer_id:
-            vendor_ids.add(line.offer_id)  # proxy — unique offers ≈ unique vendors
 
-    # Count unique vendors from offers
+    # Count unique vendors by name, falling back to offer_id (proxy — unique offers ≈ vendors)
     vendor_names = set()
+    vendor_ids = set()
     for line in lines:
         if line.offer and line.offer.vendor_name:
             vendor_names.add(line.offer.vendor_name.lower())
+        if line.offer_id:
+            vendor_ids.add(line.offer_id)
     vendor_count = len(vendor_names) or len(vendor_ids)
 
     # Average margin

--- a/app/services/buyplan_workflow.py
+++ b/app/services/buyplan_workflow.py
@@ -841,7 +841,7 @@ async def verify_po_sent(plan: "BuyPlan", db: "Session") -> list[dict]:
             # Search sent folder for PO number
             messages = await client.search_sent_messages(
                 query=line.po_number,
-                user_id=str(buyer.azure_id) if buyer else None,
+                user_id=str(buyer.azure_id),
             )
 
             found = len(messages) > 0
@@ -858,7 +858,7 @@ async def verify_po_sent(plan: "BuyPlan", db: "Session") -> list[dict]:
                 }
             )
         except Exception as e:
-            logger.error(f"PO verification failed for line {line.id}: {e}")
+            logger.error("PO verification failed for line {}: {}", line.id, e)
             results.append({"line_id": line.id, "po_number": line.po_number, "found": False, "error": str(e)})
 
     # Use centralized completion check (respects SO verification requirement)

--- a/app/services/contact_intelligence.py
+++ b/app/services/contact_intelligence.py
@@ -28,14 +28,11 @@ if TYPE_CHECKING:
 # ── Name splitting ──────────────────────────────────────────────────
 
 
-# Common surname prefixes that should stay with the last name
-_NAME_PREFIXES = {"de", "del", "van", "von", "di", "da", "la", "le", "el", "al", "bin", "ibn"}
-
-
 def split_name(full_name: str | None) -> tuple[str | None, str | None]:
     """Split a full name into (first_name, last_name).
 
-    Handles prefixes (de, van, etc.) and single-word names.
+    Keeps surname prefixes (de, van, etc.) with the last name; handles single-word
+    names.
     """
     if not full_name or not full_name.strip():
         return (None, None)
@@ -44,15 +41,9 @@ def split_name(full_name: str | None) -> tuple[str | None, str | None]:
     if len(parts) == 1:
         return (parts[0], None)
 
-    # Check for surname prefixes: "John van der Berg" → ("John", "van der Berg")
-    first = parts[0]
-    rest = parts[1:]
-
-    # If second word is a prefix, everything after first is last name
-    if rest and rest[0].lower() in _NAME_PREFIXES:
-        return (first, " ".join(rest))
-
-    return (first, " ".join(rest))
+    # First word is the first name; everything after is the last name. This keeps
+    # surname prefixes attached: "John van der Berg" → ("John", "van der Berg").
+    return (parts[0], " ".join(parts[1:]))
 
 
 # ── Contact auto-discovery ──────────────────────────────────────────
@@ -213,6 +204,26 @@ def _run_sync_or_return_empty(async_fn, *args):
         return {}
 
 
+def _run_coro_blocking(coro, *, timeout: float):
+    """Run an async coroutine to completion from sync code, blocking for the result.
+
+    When a loop is already running (scheduler/async context), `asyncio.run` would
+    raise, so the coroutine is executed in a worker thread instead.
+    """
+    import asyncio
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        future = pool.submit(asyncio.run, coro)
+        return future.result(timeout=timeout)
+
+
 # ── Pipeline event logging ──────────────────────────────────────────
 
 
@@ -314,11 +325,7 @@ def compute_contact_relationship_score(
 
     # Recency: 0-7d = 100, decays linearly to 0 at 365d
     if last_interaction_at:
-        lia = (
-            last_interaction_at.replace(tzinfo=last_interaction_at.tzinfo or timezone.utc)
-            if last_interaction_at
-            else last_interaction_at
-        )
+        lia = last_interaction_at.replace(tzinfo=last_interaction_at.tzinfo or timezone.utc)
         days_since = max((now - lia).total_seconds() / 86400, 0)
         if days_since <= RECENCY_IDEAL_DAYS:
             recency = 100.0
@@ -633,8 +640,6 @@ def generate_contact_nudges(db: Session, vendor_card_id: int) -> list[dict]:
 
 def _enrich_nudges_with_ai(db: Session, nudges: list[dict], vendor_card_id: int) -> list[dict]:
     """Enrich nudge messages with AI suggestions via Claude Haiku."""
-    import asyncio
-
     from app.utils.claude_client import claude_json
 
     for nudge in nudges[:5]:  # Limit to 5 to avoid excessive API calls
@@ -647,30 +652,15 @@ def _enrich_nudges_with_ai(db: Session, nudges: list[dict], vendor_card_id: int)
             f'Return JSON: {{"message": "<1-2 sentence suggestion>"}}'
         )
         try:
-            try:
-                asyncio.get_running_loop()
-                import concurrent.futures
-
-                with concurrent.futures.ThreadPoolExecutor() as pool:
-                    future = pool.submit(
-                        asyncio.run,
-                        claude_json(
-                            prompt,
-                            system="You are a B2B relationship advisor. Return ONLY valid JSON.",
-                            model_tier="fast",
-                            timeout=10,
-                        ),
-                    )
-                    result = future.result(timeout=15)
-            except RuntimeError:
-                result = asyncio.run(
-                    claude_json(
-                        prompt,
-                        system="You are a B2B relationship advisor. Return ONLY valid JSON.",
-                        model_tier="fast",
-                        timeout=10,
-                    )
-                )
+            result = _run_coro_blocking(
+                claude_json(
+                    prompt,
+                    system="You are a B2B relationship advisor. Return ONLY valid JSON.",
+                    model_tier="fast",
+                    timeout=10,
+                ),
+                timeout=15,
+            )
             if result and isinstance(result, dict) and result.get("message"):
                 nudge["message"] = result["message"]
         except Exception as e:
@@ -711,33 +701,18 @@ def generate_contact_summary(db: Session, vendor_card_id: int, contact_id: int) 
     )
 
     try:
-        import asyncio
-
         from app.utils.claude_client import claude_text
 
         prompt = (
             f"Write a 2-3 sentence relationship summary for this vendor contact:\n\n{context}\n\n"
             f"Focus on the health of the relationship and any recommended actions."
         )
-        try:
-            asyncio.get_running_loop()
-            # Already in async context — run in thread pool
-            import concurrent.futures
-
-            with concurrent.futures.ThreadPoolExecutor() as pool:
-                future = pool.submit(
-                    asyncio.run,
-                    claude_text(
-                        prompt, system="You are a B2B relationship analyst. Be concise.", model_tier="fast", timeout=15
-                    ),
-                )
-                result = future.result(timeout=20)
-        except RuntimeError:
-            result = asyncio.run(
-                claude_text(
-                    prompt, system="You are a B2B relationship analyst. Be concise.", model_tier="fast", timeout=15
-                )
-            )
+        result = _run_coro_blocking(
+            claude_text(
+                prompt, system="You are a B2B relationship analyst. Be concise.", model_tier="fast", timeout=15
+            ),
+            timeout=20,
+        )
         if result:
             return result
     except Exception as e:

--- a/app/services/description_service.py
+++ b/app/services/description_service.py
@@ -139,22 +139,18 @@ async def generate_verified_description(
             "verified": False,
         }
 
-    # Determine confidence based on distinct source count
+    # Determine confidence based on distinct source count (num_sources >= 1 here)
     if num_sources >= 3:
         base_confidence = 0.98
     elif num_sources == 2:
         base_confidence = 0.90
-    elif num_sources == 1:
-        base_confidence = 0.75
     else:
-        base_confidence = 0.50
+        base_confidence = 0.75
 
     # Build the AI prompt for cross-referencing and standardization
     from app.utils.claude_client import claude_text
 
-    source_block = ""
-    for s in sources:
-        source_block += f"  - [{s['source']}]: {s['description']}\n"
+    source_block = "".join(f"  - [{s['source']}]: {s['description']}\n" for s in sources)
 
     prompt = (
         f"You are verifying an electronic component description by cross-referencing "

--- a/app/services/faceted_search_service.py
+++ b/app/services/faceted_search_service.py
@@ -39,6 +39,12 @@ INTERNAL_FILTER_VALUES = ("all", *_INTERNAL_MODE_PREDICATES)  # "all" = no-op se
 SEARCHED_WITHIN_DAYS = {"7d": 7, "30d": 30, "90d": 90}
 SEARCHED_WITHIN_VALUES = ("any", *SEARCHED_WITHIN_DAYS)  # "any" = no-op sentinel
 
+# Canonical category match expression — lower(trim(category)). Shared so every
+# count/list/scope path keys cards by the same normalized form and PG can serve the
+# GROUP BY / equality from ix_mc_cat_order_live (098_materials_perf_idx) instead of
+# heap-fetching the raw column.
+_CATEGORY_NORM = func.lower(func.trim(MaterialCard.category))
+
 
 def has_crosses_predicate():
     """The single "Has alternates" predicate — share it across every count/list path.
@@ -86,38 +92,26 @@ def _apply_facet_filters(
         id_column = MaterialSpecFacet.material_card_id
 
     for key, values in filters.items():
+        # Each branch narrows to the cards whose facet row for one spec_key satisfies a
+        # value predicate. They share the same EXISTS-via-IN subquery shape — only the
+        # spec_key derivation and the value predicate differ.
         if key.endswith("_min"):
-            spec_key = key[:-4]
-            query = query.filter(
-                id_column.in_(
-                    db.query(MaterialSpecFacet.material_card_id).filter(
-                        MaterialSpecFacet.category == commodity,
-                        MaterialSpecFacet.spec_key == spec_key,
-                        MaterialSpecFacet.value_numeric >= values,
-                    )
-                )
-            )
+            spec_key, value_predicate = key[:-4], MaterialSpecFacet.value_numeric >= values
         elif key.endswith("_max"):
-            spec_key = key[:-4]
-            query = query.filter(
-                id_column.in_(
-                    db.query(MaterialSpecFacet.material_card_id).filter(
-                        MaterialSpecFacet.category == commodity,
-                        MaterialSpecFacet.spec_key == spec_key,
-                        MaterialSpecFacet.value_numeric <= values,
-                    )
-                )
-            )
+            spec_key, value_predicate = key[:-4], MaterialSpecFacet.value_numeric <= values
         elif isinstance(values, list) and values:
-            query = query.filter(
-                id_column.in_(
-                    db.query(MaterialSpecFacet.material_card_id).filter(
-                        MaterialSpecFacet.category == commodity,
-                        MaterialSpecFacet.spec_key == key,
-                        MaterialSpecFacet.value_text.in_(values),
-                    )
+            spec_key, value_predicate = key, MaterialSpecFacet.value_text.in_(values)
+        else:
+            continue
+        query = query.filter(
+            id_column.in_(
+                db.query(MaterialSpecFacet.material_card_id).filter(
+                    MaterialSpecFacet.category == commodity,
+                    MaterialSpecFacet.spec_key == spec_key,
+                    value_predicate,
                 )
             )
+        )
     return query
 
 
@@ -131,7 +125,7 @@ def get_commodity_counts(db: Session) -> dict[str, int]:
     semantics: lower(trim(x)) IS NOT NULL iff x IS NOT NULL (both functions are
     strict), and id is the non-null PK so count(id) == count(*).
     """
-    cat_expr = func.lower(func.trim(MaterialCard.category))
+    cat_expr = _CATEGORY_NORM
     rows = (
         db.query(cat_expr, func.count())
         .filter(MaterialCard.deleted_at.is_(None), cat_expr.isnot(None))
@@ -240,7 +234,7 @@ def get_manufacturer_options(
             column != "",
         )
         if commodity:
-            q = q.filter(func.lower(func.trim(MaterialCard.category)) == commodity.lower().strip())
+            q = q.filter(_CATEGORY_NORM == commodity.lower().strip())
         return q
 
     union = _branch(MaterialCard.brand).union_all(_branch(MaterialCard.manufacturer)).subquery()
@@ -350,7 +344,7 @@ def _apply_card_filters(
     query = query.filter(MaterialCard.deleted_at.is_(None))
 
     if commodity:
-        query = query.filter(func.lower(func.trim(MaterialCard.category)) == commodity.lower().strip())
+        query = query.filter(_CATEGORY_NORM == commodity.lower().strip())
 
     ts_query = None
     if q:
@@ -664,7 +658,7 @@ def get_commodity_spec_coverage(db: Session, commodity: str) -> SpecCoverage:
     commodity = commodity.lower().strip()
     commodity_cards = db.query(MaterialCard.id).filter(
         MaterialCard.deleted_at.is_(None),
-        func.lower(func.trim(MaterialCard.category)) == commodity,
+        _CATEGORY_NORM == commodity,
     )
     total = db.query(func.count()).select_from(commodity_cards.subquery()).scalar() or 0
     with_specs = (

--- a/app/services/fru_crosswalk_enrich.py
+++ b/app/services/fru_crosswalk_enrich.py
@@ -111,6 +111,28 @@ FRU_DESC_CONFIDENCE = 0.88
 FRU_MAKER_CONFIDENCE = 0.9
 
 
+def _tally_schema_drop(
+    commodity: str,
+    spec_key: str,
+    value: object,
+    schema,
+    dropped_no_schema: Counter,
+    dropped_out_of_enum: Counter,
+) -> None:
+    """Tally a crosswalk spec value that record_spec will silently drop (DEBUG-only
+    there).
+
+    Mirrors record_spec's own schema/enum gate so the discard is surfaced as an
+    aggregate WARNING after the batch (see the module docstring). Pure observability —
+    no DB write, no effect on what record_spec persists. Shared by both write channels
+    so the decode-side and desc-side tallies cannot drift.
+    """
+    if schema is None:
+        dropped_no_schema[f"{commodity}.{spec_key}"] += 1
+    elif schema.data_type == "enum" and schema.enum_values and str(value) not in schema.enum_values:
+        dropped_out_of_enum[f"{commodity}.{spec_key}={value}"] += 1
+
+
 def agree_vendor(results: "list[DecodeResult]") -> str | None:
     """Return the single vendor every decode agrees on, else ``None`` (pure, no DB).
 
@@ -372,11 +394,14 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
                     if cache is None:
                         cache = schema_caches[commodity] = load_schema_cache(db, commodity)
                     for spec_key, value in agreed.items():
-                        schema = cache.get((commodity, spec_key))
-                        if schema is None:
-                            dropped_no_schema[f"{commodity}.{spec_key}"] += 1
-                        elif schema.data_type == "enum" and schema.enum_values and str(value) not in schema.enum_values:
-                            dropped_out_of_enum[f"{commodity}.{spec_key}={value}"] += 1
+                        _tally_schema_drop(
+                            commodity,
+                            spec_key,
+                            value,
+                            cache.get((commodity, spec_key)),
+                            dropped_no_schema,
+                            dropped_out_of_enum,
+                        )
                     card_written = 0
                     did_set_maker = False
                     # SAVEPOINT 1 — decode channel: record_spec flushes, so a DB-level
@@ -501,11 +526,14 @@ def crosswalk_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, in
                 # decode writes or category fill with it.
                 with db.begin_nested():
                     for spec_key, value in d_agreed.items():
-                        schema = d_cache.get((desc_cat, spec_key))
-                        if schema is None:
-                            dropped_no_schema[f"{desc_cat}.{spec_key}"] += 1
-                        elif schema.data_type == "enum" and schema.enum_values and str(value) not in schema.enum_values:
-                            dropped_out_of_enum[f"{desc_cat}.{spec_key}={value}"] += 1
+                        _tally_schema_drop(
+                            desc_cat,
+                            spec_key,
+                            value,
+                            d_cache.get((desc_cat, spec_key)),
+                            dropped_no_schema,
+                            dropped_out_of_enum,
+                        )
                         # Same no-pre-gate rule: the ladder rejects any write
                         # losing to a desc_parse 83 / mpn_decode 85 / vendor
                         # 90 prior (fru_desc_parse is tier 82).

--- a/app/services/part_history_service.py
+++ b/app/services/part_history_service.py
@@ -171,6 +171,11 @@ def price_trend_for_card(db: Session, card_id: int) -> PriceTrend | None:
 # ── Resolution + assembly ──
 
 
+def _count(db: Session, model: type, *conditions) -> int:
+    """COUNT(model.id) over the given filter conditions, coalescing NULL → 0."""
+    return db.query(func.count(model.id)).filter(*conditions).scalar() or 0
+
+
 def _resolve_card(db: Session, normalized_key: str) -> MaterialCard | None:
     if not normalized_key:
         return None
@@ -188,7 +193,7 @@ def get_part_history(db: Session, normalized_key: str) -> PartHistory:
         return PartHistory(found=False)
 
     offers = offers_for_card(db, card.id)
-    offers_count = db.query(func.count(Offer.id)).filter(Offer.material_card_id == card.id).scalar() or 0
+    offers_count = _count(db, Offer, Offer.material_card_id == card.id)
     buyers = buyers_for_card(db, card.id)
 
     # "Confirmed / Won" = three independent kinds of evidence the part actually moved:
@@ -196,27 +201,17 @@ def get_part_history(db: Session, normalized_key: str) -> PartHistory:
     # WON requisitions, and customer-purchase rows. The total is their sum.
     won_offers = won_offers_for_card(db, card.id)
     customer_purchases = customer_purchases_for_card(db, card.id)
-    won_offer_count = (
-        db.query(func.count(Offer.id))
-        .filter(Offer.material_card_id == card.id, Offer.status.in_(_WON_OFFER_STATUSES))
-        .scalar()
-    ) or 0
-    won_req_count = (
-        db.query(func.count(Requirement.id))
-        .filter(Requirement.material_card_id == card.id, Requirement.sourcing_status == SourcingStatus.WON)
-        .scalar()
-    ) or 0
-    customer_count = (
-        db.query(func.count(CustomerPartHistory.id)).filter(CustomerPartHistory.material_card_id == card.id).scalar()
-    ) or 0
+    won_offer_count = _count(db, Offer, Offer.material_card_id == card.id, Offer.status.in_(_WON_OFFER_STATUSES))
+    won_req_count = _count(
+        db, Requirement, Requirement.material_card_id == card.id, Requirement.sourcing_status == SourcingStatus.WON
+    )
+    customer_count = _count(db, CustomerPartHistory, CustomerPartHistory.material_card_id == card.id)
     confirmed_count = won_offer_count + won_req_count + customer_count
 
     sightings = sightings_for_card(db, card.id)
-    sightings_count = db.query(func.count(Sighting.id)).filter(Sighting.material_card_id == card.id).scalar() or 0
+    sightings_count = _count(db, Sighting, Sighting.material_card_id == card.id)
     requirements = requirements_for_card(db, card.id)
-    requirements_count = (
-        db.query(func.count(Requirement.id)).filter(Requirement.material_card_id == card.id).scalar() or 0
-    )
+    requirements_count = _count(db, Requirement, Requirement.material_card_id == card.id)
     price_trend = price_trend_for_card(db, card.id)
 
     return PartHistory(

--- a/app/services/prospect_contacts.py
+++ b/app/services/prospect_contacts.py
@@ -145,7 +145,8 @@ def _is_new_hire(started_at: str | None) -> bool:
         return False
     try:
         start_date = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
-        six_months_ago = datetime.now(timezone.utc).replace(month=max(1, datetime.now(timezone.utc).month - 6))
+        now = datetime.now(timezone.utc)
+        six_months_ago = now.replace(month=max(1, now.month - 6))
         return start_date >= six_months_ago
     except (ValueError, TypeError):
         return False

--- a/app/services/prospect_discovery_explorium.py
+++ b/app/services/prospect_discovery_explorium.py
@@ -379,11 +379,7 @@ async def run_explorium_discovery_batch(
                     discovery_source="explorium",
                     enrichment_data={
                         "explorium": r.get("enrichment_raw", {}),
-                        "signals": {
-                            "intent": r.get("intent", {}),
-                            "events": r.get("events", []),
-                            "hiring": r.get("hiring", {}),
-                        },
+                        "signals": signals,
                     },
                 )
                 prospects.append(prospect)

--- a/app/services/prospect_signals.py
+++ b/app/services/prospect_signals.py
@@ -23,6 +23,29 @@ from app.services.prospect_scoring import (
 # ── Signal Enrichment ────────────────────────────────────────────────
 
 
+def _store_signal(prospect_id: int, key: str, value: object, db: Session, *, label: str) -> None:
+    """Store one signal under ``key`` in readiness_signals, recalc, and commit.
+
+    Idempotent: re-storing the same key just overwrites it. Preserves an
+    existing ``source`` and defaults it to "backfill" on first write.
+    """
+    prospect = db.get(ProspectAccount, prospect_id)
+    if not prospect:
+        logger.warning("enrich_with_{}: prospect {} not found", key, prospect_id)
+        return
+
+    signals = dict(prospect.readiness_signals or {})
+    signals[key] = value
+    signals["enriched_at"] = datetime.now(timezone.utc).isoformat()
+    signals["source"] = signals.get("source", "backfill")
+    prospect.readiness_signals = signals
+
+    _recalculate_readiness(prospect)
+    prospect.last_enriched_at = datetime.now(timezone.utc)
+    db.commit()
+    logger.info("{} signals stored for prospect {}", label, prospect_id)
+
+
 def enrich_with_intent(prospect_id: int, intent_data: dict, db: Session) -> None:
     """Store intent topic data in readiness_signals JSONB under 'intent' key.
 
@@ -30,21 +53,7 @@ def enrich_with_intent(prospect_id: int, intent_data: dict, db: Session) -> None
     procurement solutions, supply chain management, component sourcing.
     Recalculates readiness_score after update.
     """
-    prospect = db.get(ProspectAccount, prospect_id)
-    if not prospect:
-        logger.warning("enrich_with_intent: prospect {} not found", prospect_id)
-        return
-
-    signals = dict(prospect.readiness_signals or {})
-    signals["intent"] = intent_data
-    signals["enriched_at"] = datetime.now(timezone.utc).isoformat()
-    signals["source"] = signals.get("source", "backfill")
-    prospect.readiness_signals = signals
-
-    _recalculate_readiness(prospect)
-    prospect.last_enriched_at = datetime.now(timezone.utc)
-    db.commit()
-    logger.info("Intent signals stored for prospect {}", prospect_id)
+    _store_signal(prospect_id, "intent", intent_data, db, label="Intent")
 
 
 def enrich_with_hiring(prospect_id: int, workforce_data: dict, db: Session) -> None:
@@ -52,21 +61,7 @@ def enrich_with_hiring(prospect_id: int, workforce_data: dict, db: Session) -> N
 
     Looks for procurement/engineering department growth, active hiring.
     """
-    prospect = db.get(ProspectAccount, prospect_id)
-    if not prospect:
-        logger.warning("enrich_with_hiring: prospect {} not found", prospect_id)
-        return
-
-    signals = dict(prospect.readiness_signals or {})
-    signals["hiring"] = workforce_data
-    signals["enriched_at"] = datetime.now(timezone.utc).isoformat()
-    signals["source"] = signals.get("source", "backfill")
-    prospect.readiness_signals = signals
-
-    _recalculate_readiness(prospect)
-    prospect.last_enriched_at = datetime.now(timezone.utc)
-    db.commit()
-    logger.info("Hiring signals stored for prospect {}", prospect_id)
+    _store_signal(prospect_id, "hiring", workforce_data, db, label="Hiring")
 
 
 def enrich_with_events(prospect_id: int, events: list[dict], db: Session) -> None:
@@ -74,21 +69,7 @@ def enrich_with_events(prospect_id: int, events: list[dict], db: Session) -> Non
 
     Event types: new_funding_round, new_product, new_office, M&A.
     """
-    prospect = db.get(ProspectAccount, prospect_id)
-    if not prospect:
-        logger.warning("enrich_with_events: prospect {} not found", prospect_id)
-        return
-
-    signals = dict(prospect.readiness_signals or {})
-    signals["events"] = events
-    signals["enriched_at"] = datetime.now(timezone.utc).isoformat()
-    signals["source"] = signals.get("source", "backfill")
-    prospect.readiness_signals = signals
-
-    _recalculate_readiness(prospect)
-    prospect.last_enriched_at = datetime.now(timezone.utc)
-    db.commit()
-    logger.info("Event signals stored for prospect {}", prospect_id)
+    _store_signal(prospect_id, "events", events, db, label="Event")
 
 
 def _recalculate_readiness(prospect: ProspectAccount) -> None:
@@ -197,9 +178,12 @@ async def enrich_missing_signals(prospect_id: int, db: Session) -> bool:
                         ]
                     )
                 ]
-                strength = (
-                    "strong" if len(component_topics) >= 3 else "moderate" if len(component_topics) >= 1 else "weak"
-                )
+                if len(component_topics) >= 3:
+                    strength = "strong"
+                elif component_topics:
+                    strength = "moderate"
+                else:
+                    strength = "weak"
                 new_signals["intent"] = {
                     "strength": strength,
                     "topics": intent_topics,
@@ -257,6 +241,41 @@ async def enrich_missing_signals(prospect_id: int, db: Session) -> bool:
 
 
 # ── Similar Customer Matching ────────────────────────────────────────
+
+# Region → set of recognized HQ country codes/names (all uppercase).
+REGION_COUNTRIES = {
+    "US": {"US", "USA", "UNITED STATES"},
+    "EU": {
+        "DE",
+        "GB",
+        "FR",
+        "NL",
+        "SE",
+        "IT",
+        "ES",
+        "CH",
+        "AT",
+        "BE",
+        "GERMANY",
+        "UNITED KINGDOM",
+        "FRANCE",
+        "NETHERLANDS",
+    },
+    "ASIA": {
+        "CN",
+        "JP",
+        "KR",
+        "TW",
+        "SG",
+        "IN",
+        "CHINA",
+        "JAPAN",
+        "SOUTH KOREA",
+        "TAIWAN",
+        "SINGAPORE",
+        "INDIA",
+    },
+}
 
 
 def find_similar_customers(prospect: ProspectAccount, db: Session) -> list[dict]:
@@ -324,50 +343,8 @@ def find_similar_customers(prospect: ProspectAccount, db: Session) -> list[dict]
 
         # Region match
         if prospect.region and company.hq_country:
-            prospect_region = prospect.region.upper()
-            country = company.hq_country.upper()
-            region_match = (
-                (prospect_region == "US" and country in ("US", "USA", "UNITED STATES"))
-                or (
-                    prospect_region == "EU"
-                    and country
-                    in (
-                        "DE",
-                        "GB",
-                        "FR",
-                        "NL",
-                        "SE",
-                        "IT",
-                        "ES",
-                        "CH",
-                        "AT",
-                        "BE",
-                        "GERMANY",
-                        "UNITED KINGDOM",
-                        "FRANCE",
-                        "NETHERLANDS",
-                    )
-                )
-                or (
-                    prospect_region == "ASIA"
-                    and country
-                    in (
-                        "CN",
-                        "JP",
-                        "KR",
-                        "TW",
-                        "SG",
-                        "IN",
-                        "CHINA",
-                        "JAPAN",
-                        "SOUTH KOREA",
-                        "TAIWAN",
-                        "SINGAPORE",
-                        "INDIA",
-                    )
-                )
-            )
-            if region_match:
+            countries = REGION_COUNTRIES.get(prospect.region.upper(), set())
+            if company.hq_country.upper() in countries:
                 match_reasons.append(f"Same region: {prospect.region}")
                 score += 5
 
@@ -532,13 +509,8 @@ def _template_fallback_writeup(prospect: ProspectAccount) -> str:
     signals = prospect.readiness_signals or {}
     similar = prospect.similar_customers or []
 
-    # Size description
     size = prospect.employee_count_range or "unknown-size"
-
-    # Industry
     industry = prospect.industry or "unknown industry"
-
-    # Location
     location = prospect.hq_location or "undisclosed location"
 
     # Segment reason from fit_reasoning

--- a/app/services/requirement_status.py
+++ b/app/services/requirement_status.py
@@ -78,21 +78,36 @@ def transition_requirement(
     return True
 
 
+def _advance_requirements(
+    requirement_ids: list[int],
+    target: str,
+    from_statuses: tuple[str, ...],
+    db: Session,
+    actor: User | None,
+) -> int:
+    """Advance each requirement currently in *from_statuses* to *target*.
+
+    Returns count of requirements that changed status. Illegal transitions are skipped,
+    not raised.
+    """
+    changed = 0
+    requirements = db.query(Requirement).filter(Requirement.id.in_(requirement_ids)).all()
+    for req in requirements:
+        if (req.sourcing_status or "open") in from_statuses:
+            try:
+                if transition_requirement(req, target, db, actor):
+                    changed += 1
+            except ValueError as e:
+                logger.debug("Skipping requirement {} transition to {}: {}", req.id, target, e)
+    return changed
+
+
 def on_rfq_sent(requirement_ids: list[int], db: Session, actor: User | None = None) -> int:
     """Mark requirements as 'sourcing' when RFQs are sent for them.
 
     Returns count of requirements that changed status.
     """
-    changed = 0
-    requirements = db.query(Requirement).filter(Requirement.id.in_(requirement_ids)).all()
-    for req in requirements:
-        if (req.sourcing_status or "open") == "open":
-            try:
-                if transition_requirement(req, "sourcing", db, actor):
-                    changed += 1
-            except ValueError as e:
-                logger.debug("Skipping requirement {} transition to sourcing: {}", req.id, e)
-    return changed
+    return _advance_requirements(requirement_ids, "sourcing", ("open",), db, actor)
 
 
 def on_offer_created(requirement: Requirement, db: Session, actor: User | None = None) -> bool:
@@ -115,17 +130,7 @@ def on_quote_built(requirement_ids: list[int], db: Session, actor: User | None =
 
     Returns count of requirements that changed status.
     """
-    changed = 0
-    requirements = db.query(Requirement).filter(Requirement.id.in_(requirement_ids)).all()
-    for req in requirements:
-        current = req.sourcing_status or "open"
-        if current in ("open", "sourcing", "offered"):
-            try:
-                if transition_requirement(req, "quoted", db, actor):
-                    changed += 1
-            except ValueError as e:
-                logger.debug("Skipping requirement {} transition to quoted: {}", req.id, e)
-    return changed
+    return _advance_requirements(requirement_ids, "quoted", ("open", "sourcing", "offered"), db, actor)
 
 
 def claim_requisition(requisition: Requisition, buyer: User, db: Session) -> bool:

--- a/app/services/scoring_helpers.py
+++ b/app/services/scoring_helpers.py
@@ -21,6 +21,7 @@ def month_range(month: date) -> tuple[datetime, datetime]:
         month_end = month_start.replace(year=month_start.year + 1, month=1)
     else:
         month_end = month_start.replace(month=month_start.month + 1)
-    start_dt = datetime(month_start.year, month_start.month, month_start.day, tzinfo=timezone.utc)
-    end_dt = datetime(month_end.year, month_end.month, month_end.day, tzinfo=timezone.utc)
+    midnight = datetime.min.time()
+    start_dt = datetime.combine(month_start, midnight, tzinfo=timezone.utc)
+    end_dt = datetime.combine(month_end, midnight, tzinfo=timezone.utc)
     return start_dt, end_dt

--- a/app/services/signature_parser.py
+++ b/app/services/signature_parser.py
@@ -80,6 +80,24 @@ _SIGNATURE_DELIMITERS = [
     re.compile(r"^sent from my", re.IGNORECASE | re.MULTILINE),
 ]
 
+# Contact fields the AI/batch paths read, write, and validate (excludes `email`,
+# which is sourced from the sender address, and the derived `confidence`).
+_AI_FIELDS = (
+    "full_name",
+    "title",
+    "company_name",
+    "phone",
+    "mobile",
+    "website",
+    "address",
+    "linkedin_url",
+)
+
+
+def _ai_confidence(fields_found: int) -> float:
+    """Confidence for an AI/batch extraction, scaling with populated field count."""
+    return min(0.5 + (fields_found * 0.08), 0.95)
+
 
 def _extract_signature_block(body: str) -> str:
     """Extract the signature portion of an email body (last ~15 lines after
@@ -265,7 +283,7 @@ async def parse_signature_ai(body: str, sender_name: str = "", sender_email: str
         }
 
         fields_found = sum(1 for v in result.values() if v)
-        result["confidence"] = min(0.5 + (fields_found * 0.08), 0.95)
+        result["confidence"] = _ai_confidence(fields_found)
         return result
     except Exception as e:
         logger.warning("AI signature parsing failed: {}", e)
@@ -305,16 +323,7 @@ def cache_signature_extract(db, sender_email: str, extract: dict) -> None:
         existing.updated_at = datetime.now(timezone.utc)
         # Only overwrite if new extract has higher confidence
         if extract.get("confidence", 0) > (existing.confidence or 0):
-            for field in (
-                "full_name",
-                "title",
-                "company_name",
-                "phone",
-                "mobile",
-                "website",
-                "address",
-                "linkedin_url",
-            ):
+            for field in _AI_FIELDS:
                 val = extract.get(field)
                 if val:
                     setattr(existing, field, val)
@@ -356,17 +365,8 @@ _BATCH_LIMIT = 200
 
 _SIGNATURE_SCHEMA = {
     "type": "object",
-    "properties": {
-        "full_name": {"type": ["string", "null"]},
-        "title": {"type": ["string", "null"]},
-        "company_name": {"type": ["string", "null"]},
-        "phone": {"type": ["string", "null"]},
-        "mobile": {"type": ["string", "null"]},
-        "website": {"type": ["string", "null"]},
-        "address": {"type": ["string", "null"]},
-        "linkedin_url": {"type": ["string", "null"]},
-    },
-    "required": ["full_name", "title", "company_name", "phone", "mobile", "website", "address", "linkedin_url"],
+    "properties": {field: {"type": ["string", "null"]} for field in _AI_FIELDS},
+    "required": list(_AI_FIELDS),
 }
 
 _BATCH_SYSTEM_PROMPT = "You extract contact information from email signatures. Return ONLY valid JSON."
@@ -493,7 +493,6 @@ async def process_signature_batch_results(db) -> dict | None:
         return None
 
     stats = {"applied": 0, "errors": 0}
-    _FIELDS = ("full_name", "title", "company_name", "phone", "mobile", "website", "address", "linkedin_url")
 
     for custom_id, parsed in results.items():
         if parsed is None:
@@ -518,14 +517,13 @@ async def process_signature_batch_results(db) -> dict | None:
             continue
 
         try:
-            for field in _FIELDS:
+            for field in _AI_FIELDS:
                 val = parsed.get(field)
                 if val:
                     setattr(record, field, val)
 
-            # Calculate confidence — same formula as parse_signature_ai
-            fields_found = sum(1 for f in _FIELDS if getattr(record, f, None))
-            record.confidence = min(0.5 + (fields_found * 0.08), 0.95)
+            fields_found = sum(1 for f in _AI_FIELDS if getattr(record, f, None))
+            record.confidence = _ai_confidence(fields_found)
             record.extraction_method = "batch_api"
             record.updated_at = datetime.now(timezone.utc)
             stats["applied"] += 1

--- a/app/services/tagging_ai_triage.py
+++ b/app/services/tagging_ai_triage.py
@@ -9,6 +9,8 @@ Depends on: app.http_client, app.services.credential_service
 """
 
 import json
+import os
+import re
 import tempfile
 
 from loguru import logger
@@ -44,8 +46,6 @@ def triage_internal_parts(mpns: list[str]) -> list[dict]:
 
     Called by: app.services.tagging_ai_triage.submit_triage_batch
     """
-    import re
-
     results = []
     for mpn in mpns:
         upper = mpn.upper().strip()
@@ -115,8 +115,7 @@ async def submit_triage_batch(db: Session, limit: int = 50000) -> dict:
     remaining = []
 
     for card_id, mpn in candidates:
-        results = triage_internal_parts([mpn])
-        if results and results[0]["is_internal"]:
+        if triage_internal_parts([mpn])[0]["is_internal"]:
             card = db.get(MaterialCard, card_id)
             if card:
                 card.is_internal_part = True
@@ -302,8 +301,6 @@ async def apply_triage_results(batch_id: str) -> dict:
         db.rollback()
     finally:
         db.close()
-        import os
-
         try:
             os.unlink(tmp_path)
         except OSError:

--- a/app/services/tagging_backfill.py
+++ b/app/services/tagging_backfill.py
@@ -27,6 +27,17 @@ from app.services.tagging import (
 )
 
 
+def _untagged_card_filter(db: Session):
+    """SQL filter selecting MaterialCards with no MaterialTag records at all."""
+    tagged_ids = db.query(MaterialTag.material_card_id).distinct().subquery()
+    return ~MaterialCard.id.in_(db.query(tagged_ids.c.material_card_id))
+
+
+def _count_untagged_cards(db: Session) -> int:
+    """Count MaterialCards that carry no MaterialTag records."""
+    return db.query(func.count(MaterialCard.id)).filter(_untagged_card_filter(db)).scalar() or 0
+
+
 def seed_from_existing_manufacturers(db: Session) -> dict:
     """Harvest MaterialCards with manufacturer already populated.
 
@@ -104,12 +115,7 @@ def run_prefix_backfill(db: Session, batch_size: int = 1000) -> dict:
     Returns: {total_processed, total_matched, total_unmatched, new_brands_discovered}
     """
     # Cards with NO MaterialTag records at all
-    tagged_ids = db.query(MaterialTag.material_card_id).distinct().subquery()
-    total_untagged = (
-        db.query(func.count(MaterialCard.id))
-        .filter(~MaterialCard.id.in_(db.query(tagged_ids.c.material_card_id)))
-        .scalar()
-    )
+    total_untagged = _count_untagged_cards(db)
 
     if not total_untagged:
         logger.info("No untagged cards — prefix backfill skipped")
@@ -128,7 +134,7 @@ def run_prefix_backfill(db: Session, batch_size: int = 1000) -> dict:
         batch = (
             db.query(MaterialCard)
             .filter(
-                ~MaterialCard.id.in_(db.query(tagged_ids.c.material_card_id)),
+                _untagged_card_filter(db),
                 MaterialCard.id > last_id,
             )
             .order_by(MaterialCard.id)
@@ -207,12 +213,7 @@ def backfill_manufacturer_from_sightings(db: Session, batch_size: int = 500) -> 
 
     Called by: app.routers.tagging_admin, app.scheduler
     """
-    tagged_ids = db.query(MaterialTag.material_card_id).distinct().subquery()
-    total_untagged = (
-        db.query(func.count(MaterialCard.id))
-        .filter(~MaterialCard.id.in_(db.query(tagged_ids.c.material_card_id)))
-        .scalar()
-    )
+    total_untagged = _count_untagged_cards(db)
 
     if not total_untagged:
         logger.info("Sighting mining: no untagged cards")
@@ -229,7 +230,7 @@ def backfill_manufacturer_from_sightings(db: Session, batch_size: int = 500) -> 
         cards = (
             db.query(MaterialCard)
             .filter(
-                ~MaterialCard.id.in_(db.query(tagged_ids.c.material_card_id)),
+                _untagged_card_filter(db),
                 MaterialCard.id > last_id,
             )
             .order_by(MaterialCard.id)
@@ -376,12 +377,7 @@ def analyze_untagged_prefixes(db: Session, top_n: int = 100) -> list[dict]:
     """
     from app.services.prefix_lookup import PREFIX_TABLE
 
-    tagged_ids = db.query(MaterialTag.material_card_id).distinct().subquery()
-    untagged = (
-        db.query(MaterialCard.normalized_mpn)
-        .filter(~MaterialCard.id.in_(db.query(tagged_ids.c.material_card_id)))
-        .all()
-    )
+    untagged = db.query(MaterialCard.normalized_mpn).filter(_untagged_card_filter(db)).all()
 
     if not untagged:
         return []

--- a/app/services/vendor_affinity_service.py
+++ b/app/services/vendor_affinity_service.py
@@ -23,6 +23,29 @@ from app.models import (
 from app.utils.sql_helpers import escape_like
 
 
+def _vendor_results_from_rows(rows, db: Session, manufacturer: str | None, level: int) -> list[dict]:
+    """Build affinity-match dicts from (vendor_name_normalized, vendor_name, mpn_count)
+    rows.
+
+    Shared by L1 and L3, which produce identical result shapes apart from the level.
+    """
+    results = []
+    for row in rows:
+        vendor_norm = row.vendor_name_normalized or row.vendor_name.lower()
+        vc = db.query(VendorCard).filter(VendorCard.normalized_name == vendor_norm).first()
+        results.append(
+            {
+                "vendor_name": row.vendor_name,
+                "vendor_id": vc.id if vc else None,
+                "mpn_count": row.mpn_count,
+                "manufacturer": manufacturer,
+                "level": level,
+                "confidence": 0.0,
+            }
+        )
+    return results
+
+
 def find_affinity_vendors_l1(mpn: str, db: Session) -> list[dict]:
     """Find vendors who supply other MPNs from the same manufacturer as the target
     MPN."""
@@ -56,20 +79,7 @@ def find_affinity_vendors_l1(mpn: str, db: Session) -> list[dict]:
         .all()
     )
 
-    results = []
-    for row in rows:
-        vendor_norm = row.vendor_name_normalized or row.vendor_name.lower()
-        vc = db.query(VendorCard).filter(VendorCard.normalized_name == vendor_norm).first()
-        results.append(
-            {
-                "vendor_name": row.vendor_name,
-                "vendor_id": vc.id if vc else None,
-                "mpn_count": row.mpn_count,
-                "manufacturer": manufacturer,
-                "level": 1,
-                "confidence": 0.0,
-            }
-        )
+    results = _vendor_results_from_rows(rows, db, manufacturer, level=1)
 
     logger.info("L1: found {} vendors for manufacturer={} (MPN={})", len(results), manufacturer, mpn)
     return results
@@ -182,20 +192,7 @@ def find_affinity_vendors_l3(mpn: str, manufacturer: str | None, db: Session) ->
         .all()
     )
 
-    results = []
-    for row in rows:
-        vendor_norm = row.vendor_name_normalized or row.vendor_name.lower()
-        vc = db.query(VendorCard).filter(VendorCard.normalized_name == vendor_norm).first()
-        results.append(
-            {
-                "vendor_name": row.vendor_name,
-                "vendor_id": vc.id if vc else None,
-                "mpn_count": row.mpn_count,
-                "manufacturer": manufacturer,
-                "level": 3,
-                "confidence": 0.0,
-            }
-        )
+    results = _vendor_results_from_rows(rows, db, manufacturer, level=3)
 
     logger.info("L3: found {} vendors for category={} (MPN={})", len(results), category, mpn)
     return results

--- a/app/services/vendor_score.py
+++ b/app/services/vendor_score.py
@@ -135,10 +135,8 @@ async def compute_all_vendor_scores(db: Session) -> dict:
     card_offer_ids: dict[int, set[int]] = {}
     # Map normalized_name → set of offer_ids (for vendors matched by name)
     name_offer_ids: dict[str, set[int]] = {}
-    all_offer_ids: set[int] = set()
 
     for oid, vcid, vname in offer_rows:
-        all_offer_ids.add(oid)
         if vcid:
             card_offer_ids.setdefault(vcid, set()).add(oid)
         if vname:


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services [core 4/4]`)
20 file(s) changed, 34 simplifications (12 file(s) already clean).

- **`acs_service.py`** — Replace deprecated get_event_loop()+run_in_executor lambda with asyncio.to_thread.
- **`attachment_parser.py`** — _parse_csv now calls the shared decode_text() helper instead of re-implementing encoding-detect-then-decode; Hoisted the duplicated `from app.models import ColumnMappingCache` import to a single import at the top of _get_or_detect_mapping; Removed the throwaway ColumnMappingCache ORM object in the cache-write path.
- **`avail_score_service.py`** — Replace the confusing `score = _tier(1, [])  # default 0` cruft in _buyer_b1_speed_to_source with a plain `score = 0`; Introduce a local `_as_utc(dt)` helper and use it to collapse three copies of the naive-to-UTC normalization block; Hoist the duplicated lazy `from app.services.scoring_helpers import month_range` to a single module-level import.
- **`buyplan_builder.py`** — Merged two consecutive loops over plan.lines in generate_ai_summary into a single pass.
- **`buyplan_workflow.py`** — Removed a provably-dead `if buyer else None` guard in verify_po_sent; Converted an f-string logger.error call to the file's Loguru brace-style convention.
- **`contact_intelligence.py`** — Removed dead surname-prefix branch in split_name and the now-unused _NAME_PREFIXES set; Dropped a redundant always-true ternary guard inside compute_contact_relationship_score; Consolidated two copy-paste thread-pool/asyncio.run blocks into one in-file _run_coro_blocking helper.
- **`description_service.py`** — Removed unreachable else branch in the confidence ladder; Replaced += string accumulation loop with str.join.
- **`faceted_search_service.py`** — Extract repeated lower(trim(category)) SQL expression into a module-level _CATEGORY_NORM constant; Collapse the 3 copy-paste-with-variation branches in _apply_facet_filters into one shared subquery.
- **`fru_crosswalk_enrich.py`** — Extracted duplicated schema-drop tally into a shared helper _tally_schema_drop.
- **`part_history_service.py`** — Extracted a private _count() helper for the six repeated count queries.
- **`prospect_contacts.py`** — Deduplicated three datetime.now(timezone.utc) calls in _is_new_hire into one local 'now'.
- **`prospect_discovery_explorium.py`** — Reused the already-built `signals` variable in enrichment_data instead of rebuilding an identical dict literal inline.
- **`prospect_signals.py`** — Collapsed three copy-paste-with-variation enrich_with_* functions into a shared _store_signal() helper; Replaced a nested ternary for intent 'strength' with an if/elif/else chain; Flattened a deeply nested region-match or-chain into a REGION_COUNTRIES mapping + single set lookup; Removed three restate-the-obvious comments in _template_fallback_writeup.
- **`requirement_status.py`** — Extracted copy-paste-with-variation in on_rfq_sent and on_quote_built into a private _advance_requirements() helper.
- **`scoring_helpers.py`** — Build the two aware datetimes via datetime.combine(date, midnight, tzinfo=utc) instead of re-unpacking .year/.month/.day from dates already in hand.
- **`signature_parser.py`** — Hoisted the duplicated 8-field contact tuple into a single module-level `_AI_FIELDS` constant; Extracted the duplicated AI confidence formula into `_ai_confidence()`.
- **`tagging_ai_triage.py`** — Hoisted inline `import re` and `import os` to module level; Removed dead guard in the heuristic-pass loop of submit_triage_batch.
- **`tagging_backfill.py`** — Extracted the repeated untagged-MaterialCard query idiom into two private helpers, removing four copies of the same subquery boilerplate.
- **`vendor_affinity_service.py`** — Extracted byte-identical L1/L3 result-building copy-paste into _vendor_results_from_rows helper.
- **`vendor_score.py`** — Removed dead state variable all_offer_ids in compute_all_vendor_scores.

_Recorded cross-file follow-ups:_
- `buyplan_workflow.py`: ALTITUDE / cross-file (NOT applied — would require editing other files): the offer-resolution idiom `offer = line.
- `avail_score_service.py`: Cross-file (NOT done): the naive->UTC coercion now captured by the file-local `_as_utc` is duplicated as an inline idiom across many services (company_merge_service, activity_service, ownership_service, task_service, knowledge_service, vendor_unavailability, oem_crosswalk_enrich, contact_intelligence, etc.
- `contact_intelligence.py`: The repeated run-coro-from-possibly-async-context pattern also exists in sibling services (auto_dedup_service.
- `prospect_signals.py`: REUSE (cross-file, not applied): _compare_sizes() reimplements employee-range parsing (strip commas, '+' → int, 'a-b' → midpoint, plain int → int) that overlaps with _parse_employee_range() in app/services/prospect_scoring.
- `faceted_search_service.py`: Cross-file (out of scope): the lower(trim(category)) SQL expression also appears in app/management/enrichment_coverage_report.
- `tagging_backfill.py`: REUSE/ALTITUDE (cross-file, out of scope): the same untagged-card subquery idiom also lives in app/services/tagging_ai_batch.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)