### PR TITLE
simplify(desc_extractor): de-duplicate extractor helpers

### DIFF
--- a/app/services/desc_extractor/cpu.py
+++ b/app/services/desc_extractor/cpu.py
@@ -224,13 +224,22 @@ def is_cpu_pollution(text: str) -> bool:
     return any(p.search(cleaned) for p in _POLLUTION)
 
 
+def _add_alt_num(found: set[str], text: str, pos: int, prefix: str) -> None:
+    """Add a dangling slash-alternate model string (``prefix`` + the alternate's number)
+    to *found* when one starts at *pos* — e.g. "GOLD 6230R/6240R" adds ``GOLD
+    6240R``."""
+    alt = _ALT_NUM.match(text, pos)
+    if alt:
+        found.add(f"{prefix}{alt.group(1)}")
+
+
 def _models(text: str) -> set[str]:
     """All normalized model strings found (any class).
 
     A dangling slash-alternate right after a model token ("E5-2620 V3/V4", "GOLD
-    6230R/6240R") expands to a SECOND model string — the row names two CPUs, so
-    unique- or-omit skips the table merge exactly as it does when both tokens are
-    lexically complete.
+    6230R/6240R") expands to a SECOND model string — the row names two CPUs, so unique-
+    or-omit skips the table merge exactly as it does when both tokens are lexically
+    complete.
     """
     found: set[str] = set()
     for m in _XEON_E.finditer(text):
@@ -240,27 +249,19 @@ def _models(text: str) -> set[str]:
         alt_vn = _ALT_VN.match(text, m.end())
         if alt_vn:
             found.add(f"{base} V{alt_vn.group(1)}")
-        alt_num = _ALT_NUM.match(text, m.end())
-        if alt_num:
-            found.add(f"E{series}-{alt_num.group(1)}")
+        _add_alt_num(found, text, m.end(), f"E{series}-")
     if not _METAL_BRAND.search(text):  # Pentium/Athlon Gold-Silver never read as Scalable
         for m in _XEON_SCALABLE.finditer(text):
             found.add(f"{m.group(1)} {m.group(2)}")
-            alt_num = _ALT_NUM.match(text, m.end())
-            if alt_num:
-                found.add(f"{m.group(1)} {alt_num.group(1)}")
+            _add_alt_num(found, text, m.end(), f"{m.group(1)} ")
     for m in _XEON_SCALABLE_HP.finditer(text):
         found.add(f"{_HP_SCALABLE_LETTER[m.group(1)]} {m.group(2)}")
     for m in _CORE_I_MODEL.finditer(text):
         found.add(f"I{m.group(1)}-{m.group(2)}{m.group(3)}")
-        alt_num = _ALT_NUM.match(text, m.end())
-        if alt_num:
-            found.add(f"I{m.group(1)}-{alt_num.group(1)}")
+        _add_alt_num(found, text, m.end(), f"I{m.group(1)}-")
     for m in _EPYC_MODEL.finditer(text):
         found.add(f"EPYC {m.group(1)}")
-        alt_num = _ALT_NUM.match(text, m.end())
-        if alt_num:
-            found.add(f"EPYC {alt_num.group(1)}")
+        _add_alt_num(found, text, m.end(), "EPYC ")
     for m in _RYZEN_MODEL.finditer(text):
         found.add(f"RYZEN {m.group(1)} {m.group(2)}")
     return found

--- a/app/services/desc_extractor/storage.py
+++ b/app/services/desc_extractor/storage.py
@@ -58,6 +58,9 @@ _RPM_K = re.compile(r"\b(\d{1,2}(?:[.,]\d)?)\s?K(?:\s?RPM)?\b")
 _RPM_FULL = re.compile(r"\b(\d{1,2},?\d{3})\s?RPM\b")
 _RPM_R = re.compile(r"\b(\d{4,5})R\b")
 _FORM_INCH = re.compile(r"\b(\d\.\d)\s?(?:\"|''|[- ]?IN(?:CH(?:ES)?)?\b)")
+# Small-/large-form-factor bay shorthand: SFF → 2.5", LFF → 3.5".
+_SFF = re.compile(r"\bSFF\b")
+_LFF = re.compile(r"\bLFF\b")
 _IFACE_PATTERNS = (
     ("SAS", re.compile(r"\bSAS\b")),
     ("SATA", re.compile(r"\bSATA(?:[- ]?(?:6G|3G|III|II))?\b")),
@@ -107,9 +110,9 @@ def _rpm(text: str) -> str | None:
 
 def _form_factor(text: str, commodity: str) -> str | None:
     sizes = {m.group(1) for m in _FORM_INCH.finditer(text) if m.group(1) in _FF_BY_VALUE}
-    if re.search(r"\bSFF\b", text):
+    if _SFF.search(text):
         sizes.add("2.5")
-    if re.search(r"\bLFF\b", text):
+    if _LFF.search(text):
         sizes.add("3.5")
     if len(sizes) != 1:
         return None  # absent or conflicting (e.g. drive "2.5"" sold with a 3.5" kit)

--- a/app/services/desc_extractor/writer.py
+++ b/app/services/desc_extractor/writer.py
@@ -34,10 +34,32 @@ from sqlalchemy.orm import Session
 
 from app.models import MaterialCard
 from app.services.desc_extractor import extract_desc
-from app.services.desc_extractor._common import DESC_CONFIDENCE, DESC_SOURCE, SPEC_COMMODITIES
+from app.services.desc_extractor._common import DESC_CONFIDENCE, DESC_SOURCE, SPEC_COMMODITIES, SpecDict
 from app.services.desc_extractor.categorizer import categorize_from_desc
 from app.services.spec_tiers import set_category
 from app.services.spec_write_service import load_schema_cache, record_spec
+
+
+def _write_specs(db: Session, card_id: int, specs: SpecDict, source: str, confidence: float, schema_cache: dict) -> int:
+    """Record every (key, value) in *specs* via record_spec; return the count written.
+
+    No pre-gate here: record_spec's F1 tier ladder rejects any write that loses to a
+    higher-(tier, confidence, updated_at) prior (e.g. mpn_decode at tier 85 > 83). The
+    caller owns the surrounding ``begin_nested()`` SAVEPOINT.
+    """
+    written = 0
+    for spec_key, value in specs.items():
+        if record_spec(
+            db,
+            card_id,
+            spec_key,
+            value,
+            source=source,
+            confidence=confidence,
+            schema_cache=schema_cache,
+        ):
+            written += 1
+    return written
 
 
 def extract_and_record(db: Session, card: MaterialCard, schema_cache: dict | None = None) -> int:
@@ -57,22 +79,8 @@ def extract_and_record(db: Session, card: MaterialCard, schema_cache: dict | Non
         return 0
     if schema_cache is None:
         schema_cache = load_schema_cache(db, category)
-    written = 0
     with db.begin_nested():
-        # No pre-gate here: record_spec's F1 tier ladder rejects any write that loses to a
-        # higher-(tier, confidence, updated_at) prior (e.g. mpn_decode at tier 85 > 83).
-        for spec_key, value in result.specs.items():
-            if record_spec(
-                db,
-                int(card.id),
-                spec_key,
-                value,
-                source=DESC_SOURCE,
-                confidence=result.confidence,
-                schema_cache=schema_cache,
-            ):
-                written += 1
-    return written
+        return _write_specs(db, int(card.id), result.specs, DESC_SOURCE, result.confidence, schema_cache)
 
 
 def categorize_and_record(
@@ -120,26 +128,15 @@ def categorize_and_record(
             return (False, 0)
         # record_spec needs the now-set category. category + facets are one atomic unit
         # under this savepoint; the freshly-categorized commodity gets desc_parse facets
-        # immediately, in the SAME transaction.
+        # immediately, in the SAME transaction. Facets carry the SAME provenance as the
+        # category they were unlocked by (desc_parse/83 for the own description,
+        # fru_desc_parse/82 for a linked FRU description) — the ladder arbitrates.
         if schema_cache is None:
             schema_cache = load_schema_cache(db, commodity)
         written = 0
         result = extract_desc(text, commodity_hint=commodity)
         if result is not None and result.specs:
-            for spec_key, value in result.specs.items():
-                # Facets carry the SAME provenance as the category they were unlocked by
-                # (desc_parse/83 for the own description, fru_desc_parse/82 for a linked
-                # FRU description). The ladder arbitrates — a higher prior is never clobbered.
-                if record_spec(
-                    db,
-                    int(card.id),
-                    spec_key,
-                    value,
-                    source=source,
-                    confidence=confidence,
-                    schema_cache=schema_cache,
-                ):
-                    written += 1
+            written = _write_specs(db, int(card.id), result.specs, source, confidence, schema_cache)
     return (True, written)
 
 


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services/desc_extractor`)
3 file(s) changed, 4 simplifications (9 file(s) already clean).

- **`cpu.py`** — Consolidated the 4x-duplicated dangling slash-alternate expansion into one helper.
- **`storage.py`** — Hoisted the only two inline re.search(...) calls in the package to module-level precompiled constants, matching the file's own convention.
- **`writer.py`** — Extracted the duplicated record_spec write loop shared by both public writer functions; Imported the canonical SpecDict alias for the new helper's signature.

_Recorded cross-file follow-ups:_
- `cpu.py`: REUSE (cross-file): `_clean`/`_HTML_TAG` strip-tags+collapse is specific to this extractor (it handles truncated trailing tags `<[^>]*$` on already-uppercased input); app/utils/text_utils.
- `cpu.py`: SIMPLIFICATION (cross-file): the `{v for v in values if MIN <= v <= MAX}` + `unique_or_none` range-clamp tail in `_clock_ghz`/`_core_count`/`_tdp_watts` is the SAME idiom repeated across all 7 sibling extractors (gpu/power/display/memory).
- `writer.py`: ALTITUDE (cross-file): the `with db.
- `storage.py`: REUSE (cross-file): '/S' bandwidth skip in _capacity_gb mirrors gpu.
- `storage.py`: ALTITUDE (cross-file): the `{name for name,pattern in PATTERNS if pattern.
- `memory.py`: REUSE (cross-file): the per-key `x = _f(text); if x is not None: specs[key] = x` boilerplate in extract_memory is identical across all sibling extractors (storage/gpu/tape/board/power/display).

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)