### PR TITLE
simplify(enrichment_worker): de-duplicate worker helpers

### DIFF
--- a/app/services/enrichment_worker/config.py
+++ b/app/services/enrichment_worker/config.py
@@ -38,15 +38,19 @@ class EnrichmentWorkerConfig:
     @classmethod
     def from_env(cls) -> "EnrichmentWorkerConfig":
         """Build config from environment variables, falling back to defaults."""
+
+        def env_int(key: str, default: int) -> int:
+            return int(os.environ.get(key, default))
+
         return cls(
-            batch_size=int(os.environ.get("ENRICHMENT_BATCH_SIZE", 5)),
-            daily_cap=int(os.environ.get("ENRICHMENT_DAILY_CAP", 200)),
-            web_daily_cap=int(os.environ.get("ENRICHMENT_WEB_DAILY_CAP", 80)),
-            loop_sleep_seconds=int(os.environ.get("ENRICHMENT_LOOP_SLEEP_SECONDS", 30)),
-            idle_sleep_seconds=int(os.environ.get("ENRICHMENT_IDLE_SLEEP_SECONDS", 60)),
-            not_found_retry_hours=int(os.environ.get("ENRICHMENT_NOT_FOUND_RETRY_HOURS", 22)),
-            not_catalogued_retry_days=int(os.environ.get("ENRICHMENT_NOT_CATALOGUED_RETRY_DAYS", 30)),
-            circuit_breaker_errors=int(os.environ.get("ENRICHMENT_CIRCUIT_BREAKER_ERRORS", 5)),
-            oem_resolve_per_batch=int(os.environ.get("ENRICHMENT_OEM_RESOLVE_PER_BATCH", 2)),
-            oem_resolve_daily_cap=int(os.environ.get("ENRICHMENT_OEM_RESOLVE_DAILY_CAP", 40)),
+            batch_size=env_int("ENRICHMENT_BATCH_SIZE", 5),
+            daily_cap=env_int("ENRICHMENT_DAILY_CAP", 200),
+            web_daily_cap=env_int("ENRICHMENT_WEB_DAILY_CAP", 80),
+            loop_sleep_seconds=env_int("ENRICHMENT_LOOP_SLEEP_SECONDS", 30),
+            idle_sleep_seconds=env_int("ENRICHMENT_IDLE_SLEEP_SECONDS", 60),
+            not_found_retry_hours=env_int("ENRICHMENT_NOT_FOUND_RETRY_HOURS", 22),
+            not_catalogued_retry_days=env_int("ENRICHMENT_NOT_CATALOGUED_RETRY_DAYS", 30),
+            circuit_breaker_errors=env_int("ENRICHMENT_CIRCUIT_BREAKER_ERRORS", 5),
+            oem_resolve_per_batch=env_int("ENRICHMENT_OEM_RESOLVE_PER_BATCH", 2),
+            oem_resolve_daily_cap=env_int("ENRICHMENT_OEM_RESOLVE_DAILY_CAP", 40),
         )

--- a/app/services/enrichment_worker/oem_domains.py
+++ b/app/services/enrichment_worker/oem_domains.py
@@ -15,9 +15,7 @@ Depends on: app.services.enrichment_worker.trusted_domains.
 
 from __future__ import annotations
 
-from urllib.parse import urlparse
-
-from .trusted_domains import is_trusted_domain
+from .trusted_domains import _host_allowed, is_trusted_domain
 
 # Exact-host official OEM/system-vendor parts & support domains.
 OEM_OFFICIAL_HOSTS: frozenset[str] = frozenset(
@@ -46,16 +44,7 @@ OEM_VENDOR_ROOTS: frozenset[str] = frozenset(
 
 def is_oem_domain(url: str) -> bool:
     """Return True if *url* is an official OEM/system-vendor parts/support domain."""
-    try:
-        p = urlparse(url)
-    except Exception:
-        return False
-    if p.scheme not in ("http", "https") or not p.hostname:
-        return False
-    host = p.hostname.lower()
-    if host in OEM_OFFICIAL_HOSTS:
-        return True
-    return any(host == r or host.endswith("." + r) for r in OEM_VENDOR_ROOTS)
+    return _host_allowed(url, OEM_OFFICIAL_HOSTS, OEM_VENDOR_ROOTS)
 
 
 def is_crossref_domain(url: str) -> bool:

--- a/app/services/enrichment_worker/oem_extractor.py
+++ b/app/services/enrichment_worker/oem_extractor.py
@@ -32,6 +32,15 @@ _MIN_OEM_CONFIDENCE = 0.90
 _CATEGORY_VOCAB = ", ".join(sorted(get_all_commodities()))
 
 
+def _confidence(data: dict) -> float:
+    """Parse the model's ``confidence`` field, defaulting a missing/malformed value to
+    0.0."""
+    try:
+        return float(data.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 # --------------------------------- cross-reference ---------------------------------
 
 
@@ -130,10 +139,7 @@ async def cross_reference_mpn(
         logger.info("OEM_XREF: {} rejected — resolved == original", display_mpn)
         return _XR_FAILED
 
-    try:
-        conf = float(data.get("confidence") or 0.0)
-    except (TypeError, ValueError):
-        conf = 0.0
+    conf = _confidence(data)
     if conf < _MIN_CROSSREF_CONFIDENCE:
         logger.info("OEM_XREF: {} rejected — confidence {:.2f} < {:.2f}", display_mpn, conf, _MIN_CROSSREF_CONFIDENCE)
         return _XR_FAILED
@@ -228,10 +234,7 @@ async def extract_oem_description(
         logger.info("OEM_DESC: {} rejected — MPN mismatch (got {})", display_mpn, data.get("exact_mpn_found"))
         return _OEM_FAILED
 
-    try:
-        conf = float(data.get("confidence") or 0.0)
-    except (TypeError, ValueError):
-        conf = 0.0
+    conf = _confidence(data)
     if conf < _MIN_OEM_CONFIDENCE:
         logger.info("OEM_DESC: {} rejected — confidence {:.2f} < {:.2f}", display_mpn, conf, _MIN_OEM_CONFIDENCE)
         return _OEM_FAILED

--- a/app/services/enrichment_worker/trusted_domains.py
+++ b/app/services/enrichment_worker/trusted_domains.py
@@ -3,7 +3,28 @@ manufacturer-official domains may produce web_sourced data. Validated in code.""
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from urllib.parse import urlparse
+
+
+def _host_allowed(url: str, exact_hosts: Iterable[str], suffix_roots: Iterable[str]) -> bool:
+    """Return True if *url*'s host exactly matches ``exact_hosts`` or is a dot-suffix of
+    a ``suffix_roots`` entry (e.g. ``www.ti.com`` matches root ``ti.com`` but ``evil-
+    ti.com`` does not).
+
+    Rejects non-http/https schemes and unparseable URLs.
+    """
+    try:
+        p = urlparse(url)
+    except Exception:
+        return False
+    if p.scheme not in ("http", "https") or not p.hostname:
+        return False
+    host = p.hostname.lower()
+    if host in exact_hosts:
+        return True
+    return any(host == root or host.endswith("." + root) for root in suffix_roots)
+
 
 AUTHORIZED_DISTRIBUTORS: frozenset[str] = frozenset(
     {
@@ -51,13 +72,4 @@ def is_trusted_domain(url: str) -> bool:
     ``evil-ti.com`` does not).  Rejects non-http/https schemes and unparseable
     URLs.
     """
-    try:
-        p = urlparse(url)
-    except Exception:
-        return False
-    if p.scheme not in ("http", "https") or not p.hostname:
-        return False
-    host = p.hostname.lower()
-    if host in AUTHORIZED_DISTRIBUTORS:
-        return True
-    return any(host == k or host.endswith("." + k) for k in MANUFACTURER_DOMAINS)
+    return _host_allowed(url, AUTHORIZED_DISTRIBUTORS, MANUFACTURER_DOMAINS)

--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -369,14 +369,18 @@ async def run_one_batch(
     # arbitrates every write).
     priority_ids = {int(c.id) for c in batch if c.enrich_requested_at is not None}
 
-    # Clear the priority-lane stamp on EVERY batch card immediately — attribute writes
-    # on already-loaded ORM objects, BEFORE the first await (the worker's
-    # no-query-after-await discipline) — so a card that finishes terminal (not_found)
-    # cannot keep its stamp and pin the lane forever. Persisted by the batch-final
-    # commit below, together with the enrichment results.
-    for card in batch:
-        if card.enrich_requested_at is not None:
-            card.enrich_requested_at = None
+    def _clear_priority_stamps() -> None:
+        # Clear the priority-lane stamp on EVERY batch card — attribute writes on
+        # already-loaded ORM objects — so a card that finishes terminal (not_found)
+        # cannot keep its stamp and pin the lane forever. Persisted by the batch-final
+        # commit below, together with the enrichment results.
+        for card in batch:
+            if card.enrich_requested_at is not None:
+                card.enrich_requested_at = None
+
+    # Done immediately, BEFORE the first await (the worker's no-query-after-await
+    # discipline). Re-applied after any rollback that discards the stamp clears.
+    _clear_priority_stamps()
 
     if disabled is None:
         disabled = set()
@@ -389,6 +393,11 @@ async def run_one_batch(
     # and the in-process tally so the cap holds even when the cache is unavailable and
     # silently no-ops.
     web_calls_today = max(intel_cache.get_count(web_cache_key), web_state.get("web_calls", 0))
+
+    # One lazy import of the settings singleton (cheap Pydantic object), reused by every
+    # feature-flag gate below — the import stays lazy to keep worker import-time light
+    # and patchable, but is hoisted here so it isn't re-imported per pass.
+    from app.config import settings
 
     # OEM web-resolution crosswalk (Pass A + Pass B) — BEFORE the per-card core loop,
     # per the crosswalk-pass pattern (worker-level queries between awaits are fine;
@@ -406,8 +415,6 @@ async def run_one_batch(
     # oem_sourced — which short-circuits enrich_card's early-return below and saves
     # up to 3 web calls per card. Same session, committed with the batch below.
     if batch_ids:
-        from app.config import settings
-
         if settings.oem_crosswalk_enrich_enabled:
             try:
                 web_calls_today = await _oem_resolution_pass(
@@ -421,9 +428,7 @@ async def run_one_batch(
                     # core loop don't die on PendingRollbackError and abort the whole
                     # batch; then re-apply the stamp clears the rollback discarded.
                     db.rollback()
-                    for card in batch:
-                        if card.enrich_requested_at is not None:
-                            card.enrich_requested_at = None
+                    _clear_priority_stamps()
             # The pass bills the counters into web_state BEFORE each await — re-sync
             # the local tally so a swallowed pass exception can't clobber the OEM
             # increments at the per-card flushes / the web_state reconciliation below
@@ -437,9 +442,7 @@ async def run_one_batch(
             except Exception:
                 logger.exception("ENRICH_WORKER: oem-crosswalk failed over {} cards", len(batch_ids))
 
-    from app.config import settings as _settings
-
-    lane_split = _settings.enrichment_lane_split_enabled
+    lane_split = settings.enrichment_lane_split_enabled
     conns = _connectors_in_order(db)
     counts: dict[str, int] = {}
     # Cards that landed a real category this batch (verified / web_sourced / ai_inferred) —
@@ -536,8 +539,6 @@ async def run_one_batch(
     # per-writer "skip keys already held at higher confidence" pre-gates are gone — the
     # ladder owns arbitration in one place. Same session, committed together below.
     if enriched_ids:
-        from app.config import settings
-
         if settings.mpn_decode_enabled:
             from app.services.mpn_decoder.writer import decode_and_record_specs
 
@@ -562,8 +563,6 @@ async def run_one_batch(
     # deterministic and free, and it never touches enrichment_status. Same session,
     # committed together below.
     if batch_ids:
-        from app.config import settings
-
         if settings.fru_crosswalk_enrich_enabled:
             from app.services.fru_crosswalk_enrich import crosswalk_and_record_specs
 
@@ -580,8 +579,6 @@ async def run_one_batch(
     # the AI spec pass (spec_extraction, 60) regardless of the confidence either claims.
     # Same shared post-await session, committed together below.
     if enriched_ids:
-        from app.config import settings
-
         if settings.desc_parse_enabled:
             from app.services.desc_extractor.writer import extract_and_record_specs
 
@@ -786,10 +783,11 @@ async def main() -> None:
                         not_catalogued_today += batch_counts.get(MaterialEnrichmentStatus.NOT_CATALOGUED, 0)
 
                         # Heartbeat + counters
+                        now_ts = datetime.now(timezone.utc)
                         update_enrichment_worker_status(
                             db,
-                            last_heartbeat=datetime.now(timezone.utc),
-                            last_enriched_at=datetime.now(timezone.utc),
+                            last_heartbeat=now_ts,
+                            last_enriched_at=now_ts,
                             enriched_today=enriched_today,
                             web_sourced_today=web_sourced_today,
                             oem_sourced_today=oem_sourced_today,


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services/enrichment_worker`)
5 file(s) changed, 7 simplifications (6 file(s) already clean).

- **`config.py`** — Replace ten repeated int(os.environ.get(KEY, default)) calls in from_env with a small local env_int closure.
- **`oem_domains.py`** — Delegate is_oem_domain to the shared _host_allowed helper instead of re-implementing URL parse + scheme/host validation + suffix match.
- **`oem_extractor.py`** — Deduplicated the confidence-parse try/except (identical in both functions) into a module-private _confidence(data) helper.
- **`trusted_domains.py`** — Extract the URL-host validation/matching logic into a private _host_allowed helper; is_trusted_domain now delegates to it.
- **`worker.py`** — Extracted the duplicated priority-stamp-clearing loop into a local _clear_priority_stamps() helper; Consolidated five lazy `from app.config import settings` imports (incl. one `_settings` alias) into one hoisted lazy import reused by every feature-flag gate; Read the current timestamp once for the per-batch heartbeat status write instead of twice.

_Recorded cross-file follow-ups:_
- `oem_crosswalk_resolver.py`: CROSS-FILE (reuse): the confidence-parse block here (lines ~209-212) is identical to the one in web_extractor.
- `web_extractor.py`: CROSS-FILE (reuse): the confidence-parse block (lines ~118-121) is the same 4-line pattern shared with oem_extractor.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)