### PR TITLE
simplify(ics_worker): de-duplicate worker helpers

### DIFF
--- a/app/services/ics_worker/ai_gate.py
+++ b/app/services/ics_worker/ai_gate.py
@@ -126,10 +126,12 @@ async def process_ai_gate(db: Session):
     cooldown after API failures.
     """
     global _last_api_failure
-    if _last_api_failure and (time.monotonic() - _last_api_failure) < _GATE_COOLDOWN_SECONDS:
-        remaining = int(_GATE_COOLDOWN_SECONDS - (time.monotonic() - _last_api_failure))
-        logger.debug("AI gate: in cooldown after API failure ({}s remaining)", remaining)
-        return
+    if _last_api_failure:
+        elapsed = time.monotonic() - _last_api_failure
+        if elapsed < _GATE_COOLDOWN_SECONDS:
+            remaining = int(_GATE_COOLDOWN_SECONDS - elapsed)
+            logger.debug("AI gate: in cooldown after API failure ({}s remaining)", remaining)
+            return
 
     pending = (
         db.query(IcsSearchQueue)

--- a/app/services/ics_worker/circuit_breaker.py
+++ b/app/services/ics_worker/circuit_breaker.py
@@ -38,7 +38,8 @@ class CircuitBreaker(CircuitBreakerBase):
             return "UNEXPECTED_REDIRECT"
 
         # Login page = session expired (normal, handled by session_manager)
-        if "login.aspx" in url.lower() or "login" in url.lower().split("/")[-1]:
+        url_lower = url.lower()
+        if "login.aspx" in url_lower or "login" in url_lower.split("/")[-1]:
             return "SESSION_EXPIRED"
 
         # Captcha detection

--- a/app/services/ics_worker/result_parser.py
+++ b/app/services/ics_worker/result_parser.py
@@ -52,12 +52,17 @@ def parse_quantity(text: str) -> int | None:
         return None
 
 
+def _empty_company() -> dict:
+    """Empty company-info dict (keys: name, email, phone, company_id)."""
+    return {"name": "", "email": "", "phone": "", "company_id": ""}
+
+
 def _extract_company_info(block) -> dict:
     """Extract company info from a .flex or company info block.
 
     Returns dict with keys: name, email, phone, company_id.
     """
-    info = {"name": "", "email": "", "phone": "", "company_id": ""}
+    info = _empty_company()
 
     # Company name — usually in a bold/link element
     name_el = block.find("a", href=re.compile(r"OpenProfile", re.I))
@@ -101,7 +106,7 @@ def parse_results_html(html: str) -> list[IcsSighting]:
     soup = BeautifulSoup(html, "html.parser")
     sightings = []
     current_date = ""
-    current_company = {"name": "", "email": "", "phone": "", "company_id": ""}
+    current_company = _empty_company()
 
     # Strategy: iterate through all elements, tracking context
     # Look for date groups, company blocks, and result rows
@@ -130,12 +135,13 @@ def parse_results_html(html: str) -> list[IcsSighting]:
                 # Extract cell texts
                 cell_texts = [c.get_text(strip=True) for c in cells]
 
-                # ICsource columns: Part#, Comments, Qty, Price, MFG, D/C, Stock
-                part_number = cell_texts[0] if len(cell_texts) > 0 else ""
-                description = cell_texts[1] if len(cell_texts) > 1 else ""
-                qty_text = cell_texts[2] if len(cell_texts) > 2 else ""
-                price = cell_texts[3] if len(cell_texts) > 3 else ""
-                manufacturer = cell_texts[4] if len(cell_texts) > 4 else ""
+                # ICsource columns: Part#, Comments, Qty, Price, MFG, D/C, Stock.
+                # The `< 5` guard above guarantees indices 0-4 exist.
+                part_number = cell_texts[0]
+                description = cell_texts[1]
+                qty_text = cell_texts[2]
+                price = cell_texts[3]
+                manufacturer = cell_texts[4]
                 date_code = cell_texts[5] if len(cell_texts) > 5 else ""
 
                 # Stock column — check for checkmark image or text

--- a/app/services/ics_worker/worker.py
+++ b/app/services/ics_worker/worker.py
@@ -15,6 +15,7 @@ Depends on: all ics_worker modules, database
 import asyncio
 import hashlib
 import signal
+from contextlib import contextmanager
 from datetime import datetime, timezone
 
 from loguru import logger
@@ -38,6 +39,22 @@ def _handle_shutdown(signum, frame):
 
 signal.signal(signal.SIGTERM, _handle_shutdown)
 signal.signal(signal.SIGINT, _handle_shutdown)
+
+
+@contextmanager
+def _db_session():
+    """Open a short-lived DB session and guarantee it is closed.
+
+    Wraps the ``db = SessionLocal(); try: ... finally: db.close()`` boilerplate the
+    main loop repeats on every status/heartbeat write.
+    """
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 def update_worker_status(db: Session, **kwargs):
@@ -97,12 +114,9 @@ async def main():
     logger.info("ICS worker starting...")
 
     # Recover stale items from previous crash
-    db = SessionLocal()
-    try:
+    with _db_session() as db:
         recover_stale_searches(db)
         update_worker_status(db, is_running=True, last_heartbeat=datetime.now(timezone.utc))
-    finally:
-        db.close()
 
     # Start browser session
     session = IcsSessionManager(config)
@@ -110,22 +124,16 @@ async def main():
         await session.start()
     except Exception as e:
         logger.error("ICS worker: failed to start browser session: {}", e)
-        db = SessionLocal()
-        try:
+        with _db_session() as db:
             update_worker_status(db, is_running=False)
-        finally:
-            db.close()
         return
 
     if not session.is_logged_in:
         if not await session.login():
             logger.error("ICS worker: initial login failed, exiting")
             await session.stop()
-            db = SessionLocal()
-            try:
+            with _db_session() as db:
                 update_worker_status(db, is_running=False)
-            finally:
-                db.close()
             return
 
     logger.info("ICS worker: browser session ready")
@@ -139,11 +147,8 @@ async def main():
             try:
                 # Refresh liveness heartbeat every tick — runs on ALL paths
                 # (idle, cap-sleep, breaker-open, off-hours), not just searches.
-                db = SessionLocal()
-                try:
+                with _db_session() as db:
                     _record_heartbeat(db)
-                finally:
-                    db.close()
 
                 now_eastern = datetime.now(EASTERN)
 
@@ -157,8 +162,7 @@ async def main():
                             sightings_today,
                         )
                         # Update daily stats in worker status
-                        db = SessionLocal()
-                        try:
+                        with _db_session() as db:
                             update_worker_status(
                                 db,
                                 daily_stats_json={
@@ -169,8 +173,6 @@ async def main():
                                 searches_today=0,
                                 sightings_today=0,
                             )
-                        finally:
-                            db.close()
                     searches_today = 0
                     sightings_today = 0
                     last_stats_date = today_date
@@ -191,15 +193,12 @@ async def main():
                 if breaker.should_stop():
                     info = breaker.get_trip_info()
                     logger.error("ICS worker: circuit breaker open ({}), sleeping 1hr", info["trip_reason"])
-                    db = SessionLocal()
-                    try:
+                    with _db_session() as db:
                         update_worker_status(
                             db,
                             circuit_breaker_open=True,
                             circuit_breaker_reason=info["trip_reason"],
                         )
-                    finally:
-                        db.close()
                     await asyncio.sleep(60 * 60)
                     continue
 
@@ -212,13 +211,11 @@ async def main():
                     continue
 
                 # Run AI gate for any pending items
-                db = SessionLocal()
-                try:
-                    await process_ai_gate(db)
-                except Exception as e:
-                    logger.error("ICS worker: AI gate error: {}", e)
-                finally:
-                    db.close()
+                with _db_session() as db:
+                    try:
+                        await process_ai_gate(db)
+                    except Exception as e:
+                        logger.error("ICS worker: AI gate error: {}", e)
 
                 # Get next queued item
                 db = SessionLocal()
@@ -329,11 +326,8 @@ async def main():
             sightings_today,
         )
         await session.stop()
-        db = SessionLocal()
-        try:
+        with _db_session() as db:
             update_worker_status(db, is_running=False)
-        finally:
-            db.close()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services/ics_worker`)
4 file(s) changed, 5 simplifications (11 file(s) already clean).

- **`ai_gate.py`** — Compute the cooldown elapsed time once instead of calling time.monotonic() twice.
- **`circuit_breaker.py`** — Compute url.lower() once for the login-page check instead of twice.
- **`result_parser.py`** — Removed dead defensive index guards in the result-row parse; De-duplicated the empty-company dict literal via an _empty_company() factory.
- **`worker.py`** — Added a `_db_session()` @contextmanager and applied it to 7 repeated `db = SessionLocal(); try: ... finally: db.close()` sites.

_Recorded cross-file follow-ups:_
- `ai_gate.py`: REUSE (cross-file, blocked): Replace this module's inline duplication with the shared `AIGate` class from app/services/search_worker_base/ai_gate.
- `ai_gate.py`: REUSE (cross-file, blocked): Use the shared `_build_system_prompt('ICsource','search_ics')` builder instead of the inline `_GATE_SYSTEM_PROMPT`.
- `result_parser.py`: parse_quantity is byte-identical to nc_worker/result_parser.
- `circuit_breaker.py`: captcha_signals list (["captcha", "verify you are human", "are you a robot", "recaptcha"]) is duplicated verbatim in nc_worker/circuit_breaker.
- `scheduler.py`: Strong REUSE/ALTITUDE opportunity NOT applied: this file is ~60 lines of copy-paste-with-variation against app/services/search_worker_base/scheduler.
- `human_behavior.py`: REUSE (cross-file, cannot apply): this module is byte-for-byte identical to app/services/search_worker_base/human_behavior.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)