### PR TITLE
simplify(nc_worker): de-duplicate worker helpers

### DIFF
--- a/app/services/nc_worker/ai_gate.py
+++ b/app/services/nc_worker/ai_gate.py
@@ -126,10 +126,12 @@ async def process_ai_gate(db: Session):
     cooldown after API failures.
     """
     global _last_api_failure
-    if _last_api_failure and (time.monotonic() - _last_api_failure) < _GATE_COOLDOWN_SECONDS:
-        remaining = int(_GATE_COOLDOWN_SECONDS - (time.monotonic() - _last_api_failure))
-        logger.debug("AI gate: in cooldown after API failure ({}s remaining)", remaining)
-        return
+    if _last_api_failure:
+        elapsed = time.monotonic() - _last_api_failure
+        if elapsed < _GATE_COOLDOWN_SECONDS:
+            remaining = int(_GATE_COOLDOWN_SECONDS - elapsed)
+            logger.debug("AI gate: in cooldown after API failure ({}s remaining)", remaining)
+            return
 
     pending = (
         db.query(NcSearchQueue)

--- a/app/services/nc_worker/result_parser.py
+++ b/app/services/nc_worker/result_parser.py
@@ -97,6 +97,49 @@ def parse_price_breaks(element) -> tuple[list[PriceBreak], str | None]:
         return [], None
 
 
+def _cell(cell_texts: list[str], index: int) -> str:
+    """Return the stripped text of cell ``index``, or '' if out of range."""
+    return cell_texts[index] if len(cell_texts) > index else ""
+
+
+def _build_sighting(
+    cell_texts: list[str],
+    *,
+    part_number: str,
+    vendor_name: str,
+    region: str,
+    inventory_type: str,
+    is_sponsor: bool,
+    price_breaks: list[PriceBreak],
+    currency: str | None,
+    supplier_url: str,
+) -> NcSighting:
+    """Assemble an NcSighting from a parsed row's cell texts plus the per-row extras.
+
+    The fixed-position cell mapping (mfr=3, date_code=4, …, qty=8) is shared by both the
+    region-container and flat parsers, so they only differ in how they derive the extras
+    passed in by keyword.
+    """
+    return NcSighting(
+        part_number=part_number,
+        manufacturer=_cell(cell_texts, 3),
+        date_code=_cell(cell_texts, 4),
+        description=_cell(cell_texts, 5),
+        uploaded_date=_cell(cell_texts, 6),
+        country=_cell(cell_texts, 7),
+        quantity=parse_quantity(_cell(cell_texts, 8)),
+        vendor_name=vendor_name,
+        region=region,
+        inventory_type=inventory_type,
+        is_sponsor=is_sponsor,
+        # Authorized distributor heuristic: has price breaks = authorized
+        is_authorized=len(price_breaks) > 0,
+        price_breaks=price_breaks,
+        currency=currency,
+        supplier_product_url=supplier_url,
+    )
+
+
 def parse_results_html(html: str) -> list[NcSighting]:
     """Parse NC results HTML into a list of NcSighting instances.
 
@@ -149,14 +192,6 @@ def parse_results_html(html: str) -> list[NcSighting]:
                     if not part_number or part_number.lower() in ("part number", ""):
                         continue
 
-                    manufacturer = cell_texts[3] if len(cell_texts) > 3 else ""
-                    date_code = cell_texts[4] if len(cell_texts) > 4 else ""
-                    description = cell_texts[5] if len(cell_texts) > 5 else ""
-                    uploaded_date = cell_texts[6] if len(cell_texts) > 6 else ""
-                    country = cell_texts[7] if len(cell_texts) > 7 else ""
-                    qty_text = cell_texts[8] if len(cell_texts) > 8 else ""
-                    vendor_name = cell_texts[12] if len(cell_texts) > 12 else ""
-
                     # Sponsor check (cell 13)
                     is_sponsor = bool(cell_texts[13].strip()) if len(cell_texts) > 13 else False
 
@@ -172,27 +207,19 @@ def parse_results_html(html: str) -> list[NcSighting]:
                         ncprc = row.select_one(".ncprc")
                     price_breaks, currency = parse_price_breaks(ncprc)
 
-                    # Authorized distributor heuristic: has price breaks = authorized
-                    is_authorized = len(price_breaks) > 0
-
-                    sighting = NcSighting(
-                        part_number=part_number,
-                        manufacturer=manufacturer,
-                        date_code=date_code,
-                        description=description,
-                        uploaded_date=uploaded_date,
-                        country=country,
-                        quantity=parse_quantity(qty_text),
-                        vendor_name=vendor_name,
-                        region=region,
-                        inventory_type=inventory_type,
-                        is_sponsor=is_sponsor,
-                        is_authorized=is_authorized,
-                        price_breaks=price_breaks,
-                        currency=currency,
-                        supplier_product_url=supplier_url,
+                    sightings.append(
+                        _build_sighting(
+                            cell_texts,
+                            part_number=part_number,
+                            vendor_name=_cell(cell_texts, 12),
+                            region=region,
+                            inventory_type=inventory_type,
+                            is_sponsor=is_sponsor,
+                            price_breaks=price_breaks,
+                            currency=currency,
+                            supplier_url=supplier_url,
+                        )
                     )
-                    sightings.append(sighting)
 
                 except (IndexError, AttributeError) as e:
                     logger.warning("NC parser: skipping malformed row: {}", e)
@@ -245,24 +272,19 @@ def _parse_flat(soup) -> list[NcSighting]:
             nctd = row.select_one(".nctd")
             supplier_url = nctd.get("data-url", "") if nctd else ""
 
-            sighting = NcSighting(
-                part_number=part_number,
-                manufacturer=cell_texts[3] if len(cell_texts) > 3 else "",
-                date_code=cell_texts[4] if len(cell_texts) > 4 else "",
-                description=cell_texts[5] if len(cell_texts) > 5 else "",
-                uploaded_date=cell_texts[6] if len(cell_texts) > 6 else "",
-                country=cell_texts[7] if len(cell_texts) > 7 else "",
-                quantity=parse_quantity(cell_texts[8] if len(cell_texts) > 8 else ""),
-                vendor_name=cell_texts[12] if len(cell_texts) > 12 else cell_texts[-1],
-                region=current_region,
-                inventory_type=current_inventory_type,
-                is_sponsor=bool(cell_texts[13].strip()) if len(cell_texts) > 13 else False,
-                is_authorized=len(price_breaks) > 0,
-                price_breaks=price_breaks,
-                currency=currency,
-                supplier_product_url=supplier_url,
+            sightings.append(
+                _build_sighting(
+                    cell_texts,
+                    part_number=part_number,
+                    vendor_name=cell_texts[12] if len(cell_texts) > 12 else cell_texts[-1],
+                    region=current_region,
+                    inventory_type=current_inventory_type,
+                    is_sponsor=bool(cell_texts[13].strip()) if len(cell_texts) > 13 else False,
+                    price_breaks=price_breaks,
+                    currency=currency,
+                    supplier_url=supplier_url,
+                )
             )
-            sightings.append(sighting)
         except (IndexError, AttributeError) as e:
             logger.warning("NC parser (flat): skipping row: {}", e)
             continue

--- a/app/services/nc_worker/session_manager.py
+++ b/app/services/nc_worker/session_manager.py
@@ -103,8 +103,7 @@ class NcSessionManager:
                 "https://www.netcomponents.com/client/isauthorized",
                 timeout=15,
             )
-            is_auth = resp.status_code == 200 and "true" in resp.text.lower()
-            return is_auth
+            return resp.status_code == 200 and "true" in resp.text.lower()
         except (requests.RequestException, OSError) as e:
             logger.warning("NC session health check failed: {}", e)
             return False
@@ -164,6 +163,8 @@ class NcSessionManager:
 
     async def login_browser(self) -> bool:
         """Log in via browser (fallback if HTTP login fails)."""
+        import asyncio
+
         from .human_behavior import HumanBehavior
 
         if not self.has_browser:
@@ -171,8 +172,6 @@ class NcSessionManager:
 
         try:
             await self._page.goto("https://www.netcomponents.com/#/account/login")
-            import asyncio
-
             await asyncio.sleep(3)
 
             acct_input = self._page.locator("#AccountNumber")

--- a/app/services/nc_worker/sighting_writer.py
+++ b/app/services/nc_worker/sighting_writer.py
@@ -66,10 +66,7 @@ def save_nc_sightings(
         existing_keys.add(dedup_key)
 
         # Extract best unit price from price breaks (lowest qty tier = unit price)
-        unit_price = None
-        currency = nc.currency
-        if nc.price_breaks:
-            unit_price = nc.price_breaks[0].price
+        unit_price = nc.price_breaks[0].price if nc.price_breaks else None
 
         # Build raw_data with all NC-specific fields
         raw_data = {
@@ -94,7 +91,7 @@ def save_nc_sightings(
             manufacturer=nc.manufacturer,
             qty_available=nc.quantity,
             unit_price=unit_price,
-            currency=currency,
+            currency=nc.currency,
             source_type="netcomponents",
             source_searched_at=now,
             is_authorized=nc.is_authorized,

--- a/app/services/nc_worker/worker.py
+++ b/app/services/nc_worker/worker.py
@@ -16,6 +16,7 @@ import asyncio
 import hashlib
 import signal
 import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 
 from loguru import logger
@@ -39,6 +40,23 @@ def _handle_shutdown(signum, frame):
 
 signal.signal(signal.SIGTERM, _handle_shutdown)
 signal.signal(signal.SIGINT, _handle_shutdown)
+
+
+@contextmanager
+def _db_session():
+    """Yield a short-lived DB session, always closing it on exit.
+
+    Wraps the repeated ``SessionLocal() / try / finally db.close()`` boilerplate used
+    throughout the main loop. Imports ``SessionLocal`` lazily so tests can patch
+    ``app.database.SessionLocal``.
+    """
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 def update_worker_status(db: Session, **kwargs):
@@ -101,12 +119,9 @@ def main():
     logger.info("NC worker starting...")
 
     # Recover stale items from previous crash
-    db = SessionLocal()
-    try:
+    with _db_session() as db:
         recover_stale_searches(db)
         update_worker_status(db, is_running=True, last_heartbeat=datetime.now(timezone.utc))
-    finally:
-        db.close()
 
     # Start HTTP session and login
     session = NcSessionManager(config)
@@ -114,22 +129,16 @@ def main():
         session.start()
     except Exception as e:
         logger.error("NC worker: failed to start session: {}", e)
-        db = SessionLocal()
-        try:
+        with _db_session() as db:
             update_worker_status(db, is_running=False)
-        finally:
-            db.close()
         return
 
     if not session.is_logged_in:
         if not session.login():
             logger.error("NC worker: initial login failed, exiting")
             session.stop()
-            db = SessionLocal()
-            try:
+            with _db_session() as db:
                 update_worker_status(db, is_running=False)
-            finally:
-                db.close()
             return
 
     logger.info("NC worker: session ready")
@@ -143,11 +152,8 @@ def main():
             try:
                 # Refresh liveness heartbeat on EVERY tick, before any branch,
                 # so monitors don't false-alarm during idle/sleep/breaker paths.
-                db = SessionLocal()
-                try:
+                with _db_session() as db:
                     _record_heartbeat(db)
-                finally:
-                    db.close()
 
                 now_eastern = datetime.now(EASTERN)
 
@@ -160,8 +166,7 @@ def main():
                             searches_today,
                             sightings_today,
                         )
-                        db = SessionLocal()
-                        try:
+                        with _db_session() as db:
                             update_worker_status(
                                 db,
                                 daily_stats_json={
@@ -172,8 +177,6 @@ def main():
                                 searches_today=0,
                                 sightings_today=0,
                             )
-                        finally:
-                            db.close()
                     searches_today = 0
                     sightings_today = 0
                     last_stats_date = today_date
@@ -194,15 +197,12 @@ def main():
                 if breaker.should_stop():
                     info = breaker.get_trip_info()
                     logger.error("NC worker: circuit breaker open ({})", info["trip_reason"])
-                    db = SessionLocal()
-                    try:
+                    with _db_session() as db:
                         update_worker_status(
                             db,
                             circuit_breaker_open=True,
                             circuit_breaker_reason=info["trip_reason"],
                         )
-                    finally:
-                        db.close()
                     time.sleep(60 * 60)
                     continue
 
@@ -215,13 +215,11 @@ def main():
                     continue
 
                 # Run AI gate for any pending items
-                db = SessionLocal()
-                try:
-                    asyncio.run(run_ai_gate(db))
-                except Exception as e:
-                    logger.error("NC worker: AI gate error: {}", e)
-                finally:
-                    db.close()
+                with _db_session() as db:
+                    try:
+                        asyncio.run(run_ai_gate(db))
+                    except Exception as e:
+                        logger.error("NC worker: AI gate error: {}", e)
 
                 # Get next queued item
                 db = SessionLocal()
@@ -338,11 +336,8 @@ def main():
         session.stop()
         if session.has_browser:
             asyncio.run(session.stop_browser())
-        db = SessionLocal()
-        try:
+        with _db_session() as db:
             update_worker_status(db, is_running=False)
-        finally:
-            db.close()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services/nc_worker`)
5 file(s) changed, 7 simplifications (10 file(s) already clean).

- **`ai_gate.py`** — Compute the cooldown elapsed time once instead of calling time.monotonic() twice.
- **`result_parser.py`** — Extracted the duplicated NcSighting construction into a shared `_build_sighting()` helper plus a `_cell()` index accessor.
- **`session_manager.py`** — Removed redundant `is_auth` temp var in check_session_health; returns the expression directly; Hoisted the buried `import asyncio` to the top of login_browser.
- **`sighting_writer.py`** — Remove the dead `currency` local and collapse the unit_price assignment to one explicit line.
- **`worker.py`** — Introduced a private `_db_session()` @contextmanager to replace the repeated `db = SessionLocal() / try / finally db.close()` boilerplate; Deliberately left the large search-iteration block on the explicit SessionLocal()/finally pattern.

_Recorded cross-file follow-ups:_
- `worker.py`: No existing shared DB-session context manager exists in app/database.
- `session_manager.py`: REUSE: the module-private `_USER_AGENT` Chrome UA string is hard-coded here and has no shared counterpart (app/utils/vendor_helpers.
- `ai_gate.py`: REUSE (cross-file): app/services/search_worker_base/ai_gate.
- `scheduler.py`: REUSE (cross-file): app/services/search_worker_base/scheduler.
- `human_behavior.py`: REUSE candidate intentionally NOT applied: this file is byte-for-byte identical to app/services/search_worker_base/human_behavior.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)