### PR TITLE
simplify(mpn_decoder): de-duplicate decoder helpers

### DIFF
--- a/app/services/mpn_decoder/memory.py
+++ b/app/services/mpn_decoder/memory.py
@@ -291,6 +291,14 @@ _KING_FORM = {
 _KING_RANK_COUNT = {"S": "1", "D": "2", "Q": "4"}
 
 
+def _set_rank(specs: dict, match: re.Match) -> None:
+    # Shared by Kingston/Crucial: their rank tokens both capture [SDQ] then [48].
+    # Emit only ranks the seeded enum allows (record_spec re-validates anyway).
+    value = f"{_KING_RANK_COUNT[match.group(1)]}Rx{match.group(2)}"
+    if value in _ALLOWED_RANKS:
+        specs["rank"] = value
+
+
 def _kingston(mpn: str) -> DecodeResult | None:
     if not _KINGSTON.match(mpn):
         return None
@@ -330,9 +338,7 @@ def _kingston(mpn: str) -> DecodeResult | None:
                 specs["voltage"] = V135 if low_voltage else V15
         rank = _KING_RANK.search(mpn, rank_from)
         if rank:
-            value = f"{_KING_RANK_COUNT[rank.group(1)]}Rx{rank.group(2)}"
-            if value in _ALLOWED_RANKS:
-                specs["rank"] = value
+            _set_rank(specs, rank)
     if gen:
         specs["ddr_type"] = gen
     elif km is None:
@@ -386,9 +392,7 @@ def _crucial(mpn: str) -> DecodeResult | None:
             specs["ecc"] = True
         rank = _CRUCIAL_RANK.match(mpn, m.end())
         if rank:
-            value = f"{_KING_RANK_COUNT[rank.group(1)]}Rx{rank.group(2)}"
-            if value in _ALLOWED_RANKS:
-                specs["rank"] = value
+            _set_rank(specs, rank)
     st = _CRUCIAL_SPEED_TOKEN.search(mpn)
     if st and st.group(1) in _CRUCIAL_SPEED:
         specs["speed_mhz"] = _CRUCIAL_SPEED[st.group(1)]

--- a/app/services/mpn_decoder/ssd.py
+++ b/app/services/mpn_decoder/ssd.py
@@ -256,6 +256,12 @@ _KIOXIA_ENT_CAP = re.compile(r"(1T92|3T84|7T68|15T3|30T7|\d{3}G)")
 _KIOXIA_ENT_TB = {"1T92": 1920, "3T84": 3840, "7T68": 7680, "15T3": 15360, "30T7": 30720}
 
 
+def _kioxia_cap(token: str, tb_table: dict[str, int]) -> int:
+    # Enterprise <x>T<yz> / client xT0z tokens map via the table; a plain <n>G token
+    # drops its trailing G and reads the leading digits as GB.
+    return tb_table[token] if token in tb_table else int(token[:-1])
+
+
 def _kioxia(mpn: str) -> DecodeResult | None:
     m = _KIOXIA_KXG.match(mpn)
     if m:
@@ -265,8 +271,7 @@ def _kioxia(mpn: str) -> DecodeResult | None:
             specs["interface"] = gen
         cap = _KIOXIA_KXG_CAP.search(mpn, m.end())
         if cap:
-            token = cap.group(1)
-            specs["capacity_gb"] = _KIOXIA_KXG_TB[token] if token in _KIOXIA_KXG_TB else int(token[:-1])
+            specs["capacity_gb"] = _kioxia_cap(cap.group(1), _KIOXIA_KXG_TB)
         return DecodeResult(commodity="ssd", vendor="Kioxia", specs=specs)
 
     m = _KIOXIA_ENT.match(mpn)
@@ -281,8 +286,7 @@ def _kioxia(mpn: str) -> DecodeResult | None:
             specs["form_factor"], specs["interface"] = known
     cap = _KIOXIA_ENT_CAP.search(mpn, m.end())
     if cap:
-        token = cap.group(1)
-        specs["capacity_gb"] = _KIOXIA_ENT_TB[token] if token in _KIOXIA_ENT_TB else int(token[:-1])
+        specs["capacity_gb"] = _kioxia_cap(cap.group(1), _KIOXIA_ENT_TB)
     return DecodeResult(commodity="ssd", vendor="Kioxia", specs=specs) if specs else None
 
 

--- a/app/services/mpn_decoder/storage.py
+++ b/app/services/mpn_decoder/storage.py
@@ -254,6 +254,13 @@ _TOSHIBA_PREFIX = {
 _TB_TOKEN = re.compile(r"(\d{1,2})T[A-Z]?(?:\b|$)")
 
 
+def _set_tb_capacity(specs: dict, mpn: str) -> None:
+    # Toshiba/HGST express capacity as an explicit <n>T token (MG08ACA16TE = 16 TB).
+    cap = _TB_TOKEN.search(mpn)
+    if cap:
+        specs["capacity_gb"] = int(cap.group(1)) * 1000  # TB → GB
+
+
 def _toshiba(mpn: str) -> DecodeResult | None:
     m = _TOSHIBA.match(mpn)
     if not m:
@@ -264,9 +271,7 @@ def _toshiba(mpn: str) -> DecodeResult | None:
         specs["form_factor"] = info[0]
         if info[1]:
             specs["usage_class"] = info[1]
-    cap = _TB_TOKEN.search(mpn)
-    if cap:
-        specs["capacity_gb"] = int(cap.group(1)) * 1000  # TB → GB
+    _set_tb_capacity(specs, mpn)
     return DecodeResult(commodity="hdd", vendor="Toshiba", specs=specs) if specs else None
 
 
@@ -297,9 +302,7 @@ def _hgst(mpn: str) -> DecodeResult | None:
     specs: dict = {"form_factor": info[0]}
     if info[1]:
         specs["usage_class"] = info[1]
-    cap = _TB_TOKEN.search(mpn)
-    if cap:
-        specs["capacity_gb"] = int(cap.group(1)) * 1000
+    _set_tb_capacity(specs, mpn)
     return DecodeResult(commodity="hdd", vendor="HGST", specs=specs)
 
 

--- a/app/services/mpn_decoder/writer.py
+++ b/app/services/mpn_decoder/writer.py
@@ -135,6 +135,7 @@ def decode_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, int]:
                 category_agrees = (card.category or "").lower().strip() == result.commodity
                 did_set_maker = False
                 maker_conflict_pair = None
+                card_written = 0
                 if category_agrees:
                     # Dual-brand W4: the decode's vendor IS the actual maker (the regex gate
                     # is manufacturer-scheme-specific), so write it through the maker ladder
@@ -149,9 +150,6 @@ def decode_and_record_specs(db: Session, card_ids: list[int]) -> dict[str, int]:
                         incoming_maker = normalize_brand_name(db, result.vendor)
                         if existing_maker != incoming_maker:
                             maker_conflict_pair = f"{existing_maker}->{incoming_maker}"
-                if not category_agrees:
-                    card_written = 0
-                else:
                     card_written = sum(
                         1
                         for spec_key, value in result.specs.items()


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services/mpn_decoder`)
4 file(s) changed, 4 simplifications (2 file(s) already clean).

- **`memory.py`** — Extracted the duplicated rank-token formatting + _ALLOWED_RANKS gate into a shared _set_rank(specs, match) helper used by both _kingston and _crucial.
- **`ssd.py`** — Extract _kioxia_cap() to remove the duplicated capacity-token decode in both Kioxia branches.
- **`storage.py`** — Extracted the duplicated TB-token capacity-extraction block into a shared _set_tb_capacity(specs, mpn) helper.
- **`writer.py`** — Collapse the duplicate `category_agrees` branching into one block (removes the inverted `if not category_agrees` re-test).

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)