### PR TITLE
simplify(search_worker_base): de-duplicate shared worker base

### DIFF
--- a/app/services/search_worker_base/ai_gate.py
+++ b/app/services/search_worker_base/ai_gate.py
@@ -106,6 +106,11 @@ class AIGate:
         self._classification_cache: dict[tuple[str, str], tuple[str, str, str]] = {}
         self._cache_lock = threading.Lock()
 
+    @staticmethod
+    def _cache_key(item) -> tuple[str, str]:
+        """Classification cache key for a queue item: (normalized_mpn, lowercased manufacturer)."""
+        return (item.normalized_mpn, (item.manufacturer or "").lower())
+
     async def classify_parts_batch(self, parts: list[dict]) -> list[dict] | None:
         """Classify up to 30 parts using Claude Haiku.
 
@@ -153,10 +158,13 @@ class AIGate:
         queue status to 'queued' (search) or 'gated_out' (skip). Respects a 5-minute
         cooldown after API failures.
         """
-        if self._last_api_failure and (time.monotonic() - self._last_api_failure) < _GATE_COOLDOWN_SECONDS:
-            remaining = int(_GATE_COOLDOWN_SECONDS - (time.monotonic() - self._last_api_failure))
-            logger.debug("AI gate: in cooldown after API failure ({}s remaining)", remaining)
-            return
+        if self._last_api_failure:
+            elapsed = time.monotonic() - self._last_api_failure
+            if elapsed < _GATE_COOLDOWN_SECONDS:
+                logger.debug(
+                    "AI gate: in cooldown after API failure ({}s remaining)", int(_GATE_COOLDOWN_SECONDS - elapsed)
+                )
+                return
 
         model = self.queue_model
         pending = db.query(model).filter(model.status == "pending").order_by(model.created_at.asc()).limit(30).all()
@@ -166,7 +174,7 @@ class AIGate:
 
         uncached = []
         for item in pending:
-            cache_key = (item.normalized_mpn, (item.manufacturer or "").lower())
+            cache_key = self._cache_key(item)
             with self._cache_lock:
                 cached = self._classification_cache.get(cache_key)
             if cached:
@@ -181,15 +189,13 @@ class AIGate:
                 uncached.append(item)
 
         if uncached:
-            parts = [
-                {"mpn": item.mpn, "manufacturer": item.manufacturer or "", "description": item.description or ""}
-                for item in uncached
-            ]
-
             # Split into batches of 30
-            for batch_start in range(0, len(parts), 30):
-                batch = parts[batch_start : batch_start + 30]
+            for batch_start in range(0, len(uncached), 30):
                 batch_items = uncached[batch_start : batch_start + 30]
+                batch = [
+                    {"mpn": item.mpn, "manufacturer": item.manufacturer or "", "description": item.description or ""}
+                    for item in batch_items
+                ]
 
                 results = await self.classify_parts_batch(batch)
                 if results is None:
@@ -227,7 +233,7 @@ class AIGate:
                     item.updated_at = datetime.now(timezone.utc)
 
                     # Cache the classification
-                    cache_key = (item.normalized_mpn, (item.manufacturer or "").lower())
+                    cache_key = self._cache_key(item)
                     with self._cache_lock:
                         self._classification_cache[cache_key] = (commodity, decision, reason)
 

--- a/app/services/search_worker_base/config.py
+++ b/app/services/search_worker_base/config.py
@@ -34,14 +34,14 @@ def build_worker_config(prefix: str, defaults: dict | None = None):
 
     Returns a new object with all fields set as attributes.
     """
-    merged_defaults = {f[0]: f[1] for f in _COMMON_FIELDS}
+    merged_defaults = {suffix: default for suffix, default, _typ in _COMMON_FIELDS}
     if defaults:
         merged_defaults.update(defaults)
 
     obj_dict = {}
-    for suffix, default, typ in _COMMON_FIELDS:
+    for suffix, _default, typ in _COMMON_FIELDS:
         env_key = f"{prefix}_{suffix}"
-        raw = os.environ.get(env_key, merged_defaults.get(suffix, default))
+        raw = os.environ.get(env_key, merged_defaults[suffix])
         obj_dict[env_key] = typ(raw)
 
     return obj_dict

--- a/app/services/search_worker_base/monitoring.py
+++ b/app/services/search_worker_base/monitoring.py
@@ -10,6 +10,7 @@ Depends on: sentry_sdk, loguru
 
 import hashlib
 import re
+from contextlib import contextmanager
 from datetime import datetime
 
 from loguru import logger
@@ -27,9 +28,7 @@ _known_html_hashes: dict[str, set[str]] = {}
 
 def _get_hash_set(component_name: str) -> set[str]:
     """Return the hash set for a given component, creating it if needed."""
-    if component_name not in _known_html_hashes:
-        _known_html_hashes[component_name] = set()
-    return _known_html_hashes[component_name]
+    return _known_html_hashes.setdefault(component_name, set())
 
 
 def log_daily_report(
@@ -58,16 +57,26 @@ Circuit breaker:     {circuit_breaker_status}
     logger.info(report)
 
 
+@contextmanager
+def _sentry_scope(component_name: str, context: dict | None):
+    """Yield a Sentry scope tagged with the worker component and extra context.
+
+    Raises ImportError if the Sentry SDK is not installed — callers handle it so the
+    missing-SDK log message can stay specific to what was being sent.
+    """
+    import sentry_sdk
+
+    with sentry_sdk.new_scope() as scope:
+        scope.set_tag("component", f"{component_name.lower()}_worker")
+        for key, value in (context or {}).items():
+            scope.set_extra(key, value)
+        yield sentry_sdk
+
+
 def capture_sentry_error(error: Exception, context: dict | None = None, component_name: str = "worker"):
     """Send an error to Sentry with worker context."""
     try:
-        import sentry_sdk
-
-        with sentry_sdk.new_scope() as scope:
-            scope.set_tag("component", f"{component_name.lower()}_worker")
-            if context:
-                for key, value in context.items():
-                    scope.set_extra(key, value)
+        with _sentry_scope(component_name, context) as sentry_sdk:
             sentry_sdk.capture_exception(error)
     except ImportError:
         logger.warning("Sentry SDK not available, logging error only: {}", error)
@@ -78,13 +87,7 @@ def capture_sentry_message(
 ):
     """Send a message to Sentry with worker context."""
     try:
-        import sentry_sdk
-
-        with sentry_sdk.new_scope() as scope:
-            scope.set_tag("component", f"{component_name.lower()}_worker")
-            if context:
-                for key, value in context.items():
-                    scope.set_extra(key, value)
+        with _sentry_scope(component_name, context) as sentry_sdk:
             sentry_sdk.capture_message(message, level=level)
     except ImportError:
         logger.warning("Sentry SDK not available: {}", message)

--- a/app/services/search_worker_base/scheduler.py
+++ b/app/services/search_worker_base/scheduler.py
@@ -9,6 +9,7 @@ Depends on: config
 """
 
 import math
+import os
 import random
 from datetime import datetime
 
@@ -41,8 +42,6 @@ class SearchScheduler:
         Window: Sunday 6 PM ET through Friday 5 PM ET.
         Off: Friday 5 PM -> Sunday 6 PM (Saturday all day).
         """
-        import os
-
         if os.environ.get("FORCE_BUSINESS_HOURS"):
             return True
         now = datetime.now(EASTERN)


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services/search_worker_base`)
4 file(s) changed, 7 simplifications (5 file(s) already clean).

- **`ai_gate.py`** — Removed the parallel `parts`/`uncached` index-coupled slicing in process_ai_gate; Factored the duplicated classification cache-key derivation into a `_cache_key` staticmethod; Compute the cooldown elapsed time once instead of twice.
- **`config.py`** — Drop dead per-iteration fallback in env-default lookup.
- **`monitoring.py`** — Extracted shared Sentry scope/tag/context boilerplate into a `_sentry_scope` context manager; Collapsed `_get_hash_set` to `dict.setdefault`.
- **`scheduler.py`** — Hoisted `import os` out of the hot-path `is_business_hours` to module scope.

_Recorded cross-file follow-ups:_
- `queue_manager.py`: No shared timezone/now helper exists in app/utils (each worker module defines its own EASTERN); a cross-file consolidation into a shared util would touch other files and is out of scope.
- `human_behavior.py`: Cross-file (cannot edit, out of scope): app/services/ics_worker/human_behavior.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)