### PR TITLE
simplify(source_ingest): de-duplicate ingest helpers

### DIFF
--- a/app/services/source_ingest/clean.py
+++ b/app/services/source_ingest/clean.py
@@ -167,10 +167,7 @@ def extract_trailing_oem(description: str | None) -> str | None:
         return None
     candidate = parts[-1]
     # A manufacturer token is short, has no digits-only payload, and isn't a spec phrase.
-    if not candidate or len(candidate) > 40:
-        return None
-    word_count = len(candidate.split())
-    if word_count > 4:
+    if not candidate or len(candidate) > 40 or len(candidate.split()) > 4:
         return None
     # Reject obvious non-OEM trailers (pure measurements/connectors left after a comma).
     if re.fullmatch(r"[\d.\s\"'/-]+", candidate):

--- a/app/services/source_ingest/parsers.py
+++ b/app/services/source_ingest/parsers.py
@@ -97,8 +97,11 @@ def _first_nonempty(row: dict, columns: tuple[str, ...]) -> str | None:
     """Return the first non-empty/non-whitespace value across *columns* in *row*."""
     for col in columns:
         value = row.get(col)
-        if value is not None and str(value).strip():
-            return str(value).strip()
+        if value is None:
+            continue
+        stripped = str(value).strip()
+        if stripped:
+            return stripped
     return None
 
 
@@ -145,7 +148,10 @@ def _row_to_record(cells: list[str], mapping: dict[str, int], source_file: str) 
         if idx is None or idx >= len(cells):
             return None
         value = cells[idx]
-        return str(value).strip() if value is not None and str(value).strip() else None
+        if value is None:
+            return None
+        stripped = str(value).strip()
+        return stripped or None
 
     raw_mpn = cell("mpn")
     if not raw_mpn:


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`app/services/source_ingest`)
2 file(s) changed, 3 simplifications (5 file(s) already clean).

- **`clean.py`** — Inlined the single-use word_count intermediate in extract_trailing_oem into the candidate-size guard.
- **`parsers.py`** — _first_nonempty: strip each candidate value once into a local instead of calling str(value).strip() twice per match; _row_to_record cell() closure: replace the doubled-strip ternary with an explicit None-check plus `stripped or None`.

_Recorded cross-file follow-ups:_
- `ingest.py`: CROSS-FILE (not made): ingest.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)