### PR TITLE
simplify(scripts): de-duplicate CLI/maintenance helpers

### DIFF
--- a/scripts/backfill_material_card_ids.py
+++ b/scripts/backfill_material_card_ids.py
@@ -39,13 +39,43 @@ def _resolve_or_create(norm_key: str, display_mpn: str, db, card_cache: dict) ->
     return None
 
 
+def _backfill_table(db, card_cache: dict, *, label: str, model, mpn_of, norm_key_of, dry_run: bool) -> dict:
+    """Link one table's rows to material cards via offset-paginated batches.
+
+    ``mpn_of(row)`` returns the raw MPN string; ``norm_key_of(row, mpn)`` returns the
+    normalization key (Requirements reuse their precomputed ``normalized_mpn`` column).
+    """
+    counts = {"linked": 0, "created": 0, "skipped": 0}
+    logger.info(f"Backfilling {label}...")
+    offset = 0
+    while True:
+        batch = db.query(model).filter(model.material_card_id.is_(None)).limit(BATCH_SIZE).offset(offset).all()
+        if not batch:
+            break
+        for row in batch:
+            mpn = mpn_of(row)
+            norm_key = norm_key_of(row, mpn) if mpn else None
+            if not norm_key:
+                counts["skipped"] += 1
+                continue
+            display = normalize_mpn(mpn) or mpn.strip()
+            was_new = norm_key not in card_cache
+            card_id = _resolve_or_create(norm_key, display, db, card_cache)
+            if card_id:
+                if not dry_run:
+                    row.material_card_id = card_id
+                counts["linked"] += 1
+                if was_new:
+                    counts["created"] += 1
+        if not dry_run:
+            db.commit()
+        offset += BATCH_SIZE
+        logger.info(f"  {label.capitalize()}: {offset} processed...")
+    return counts
+
+
 def backfill(dry_run: bool = False) -> dict:
     db = SessionLocal()
-    stats = {
-        "requirements": {"linked": 0, "created": 0, "skipped": 0},
-        "sightings": {"linked": 0, "created": 0, "skipped": 0},
-        "offers": {"linked": 0, "created": 0, "skipped": 0},
-    }
     card_cache: dict[str, int] = {}
 
     try:
@@ -55,103 +85,35 @@ def backfill(dry_run: bool = False) -> dict:
             card_cache[norm] = card_id
         logger.info(f"Loaded {len(card_cache)} material cards into cache")
 
-        # --- Requirements ---
-        logger.info("Backfilling requirements...")
-        offset = 0
-        while True:
-            batch = (
-                db.query(Requirement)
-                .filter(Requirement.material_card_id.is_(None))
-                .limit(BATCH_SIZE)
-                .offset(offset)
-                .all()
-            )
-            if not batch:
-                break
-            for r in batch:
-                mpn = r.primary_mpn
-                if not mpn:
-                    stats["requirements"]["skipped"] += 1
-                    continue
-                norm_key = r.normalized_mpn or normalize_mpn_key(mpn)
-                if not norm_key:
-                    stats["requirements"]["skipped"] += 1
-                    continue
-                display = normalize_mpn(mpn) or mpn.strip()
-                was_new = norm_key not in card_cache
-                card_id = _resolve_or_create(norm_key, display, db, card_cache)
-                if card_id:
-                    if not dry_run:
-                        r.material_card_id = card_id
-                    stats["requirements"]["linked"] += 1
-                    if was_new:
-                        stats["requirements"]["created"] += 1
-            if not dry_run:
-                db.commit()
-            offset += BATCH_SIZE
-            logger.info(f"  Requirements: {offset} processed...")
-
-        # --- Sightings ---
-        logger.info("Backfilling sightings...")
-        offset = 0
-        while True:
-            batch = (
-                db.query(Sighting).filter(Sighting.material_card_id.is_(None)).limit(BATCH_SIZE).offset(offset).all()
-            )
-            if not batch:
-                break
-            for s in batch:
-                mpn = s.mpn_matched
-                if not mpn:
-                    stats["sightings"]["skipped"] += 1
-                    continue
-                norm_key = normalize_mpn_key(mpn)
-                if not norm_key:
-                    stats["sightings"]["skipped"] += 1
-                    continue
-                display = normalize_mpn(mpn) or mpn.strip()
-                was_new = norm_key not in card_cache
-                card_id = _resolve_or_create(norm_key, display, db, card_cache)
-                if card_id:
-                    if not dry_run:
-                        s.material_card_id = card_id
-                    stats["sightings"]["linked"] += 1
-                    if was_new:
-                        stats["sightings"]["created"] += 1
-            if not dry_run:
-                db.commit()
-            offset += BATCH_SIZE
-            logger.info(f"  Sightings: {offset} processed...")
-
-        # --- Offers (batched) ---
-        logger.info("Backfilling offers...")
-        offset = 0
-        while True:
-            batch = db.query(Offer).filter(Offer.material_card_id.is_(None)).limit(BATCH_SIZE).offset(offset).all()
-            if not batch:
-                break
-            for o in batch:
-                mpn = o.mpn
-                if not mpn:
-                    stats["offers"]["skipped"] += 1
-                    continue
-                norm_key = normalize_mpn_key(mpn)
-                if not norm_key:
-                    stats["offers"]["skipped"] += 1
-                    continue
-                display = normalize_mpn(mpn) or mpn.strip()
-                was_new = norm_key not in card_cache
-                card_id = _resolve_or_create(norm_key, display, db, card_cache)
-                if card_id:
-                    if not dry_run:
-                        o.material_card_id = card_id
-                    stats["offers"]["linked"] += 1
-                    if was_new:
-                        stats["offers"]["created"] += 1
-            if not dry_run:
-                db.commit()
-            offset += BATCH_SIZE
-            logger.info(f"  Offers: {offset} processed...")
+        stats = {
+            "requirements": _backfill_table(
+                db,
+                card_cache,
+                label="requirements",
+                model=Requirement,
+                mpn_of=lambda r: r.primary_mpn,
+                norm_key_of=lambda r, mpn: r.normalized_mpn or normalize_mpn_key(mpn),
+                dry_run=dry_run,
+            ),
+            "sightings": _backfill_table(
+                db,
+                card_cache,
+                label="sightings",
+                model=Sighting,
+                mpn_of=lambda s: s.mpn_matched,
+                norm_key_of=lambda s, mpn: normalize_mpn_key(mpn),
+                dry_run=dry_run,
+            ),
+            "offers": _backfill_table(
+                db,
+                card_cache,
+                label="offers",
+                model=Offer,
+                mpn_of=lambda o: o.mpn,
+                norm_key_of=lambda o, mpn: normalize_mpn_key(mpn),
+                dry_run=dry_run,
+            ),
+        }
 
         logger.info("Backfill complete!")
         for table, s in stats.items():

--- a/scripts/backfill_oem_enrichment.py
+++ b/scripts/backfill_oem_enrichment.py
@@ -132,7 +132,7 @@ async def run(*, commit: bool, limit, max_web_calls: int, csv_path: str, db=None
             w.writeheader()
             w.writerows(rows)
         logger.info("BACKFILL: coverage CSV → {}", csv_path)
-        logger.info("BACKFILL SUMMARY: {}", {k: v for k, v in counts.items()})
+        logger.info("BACKFILL SUMMARY: {}", counts)
         return counts
     except Exception:
         db.rollback()

--- a/scripts/check_schema_matches_models.py
+++ b/scripts/check_schema_matches_models.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Callable
-from typing import Iterable
+from collections.abc import Callable, Iterable
 
 from alembic.autogenerate import compare_metadata
 from alembic.runtime.migration import MigrationContext
@@ -46,21 +45,15 @@ def filter_allowlist(diffs: Iterable[tuple]) -> list[tuple]:
     out: list[tuple] = []
     for d in diffs:
         kind = d[0] if d else None
-        skip = False
-        for allow_kind, predicate in _ALLOWLIST:
-            if kind == allow_kind and predicate(d):
-                skip = True
-                break
-        if not skip:
+        allowed = any(kind == allow_kind and predicate(d) for allow_kind, predicate in _ALLOWLIST)
+        if not allowed:
             out.append(d)
     return out
 
 
 def format_diffs(diffs: Iterable[tuple]) -> str:
     """Human-readable rendering of remaining diffs, one per line."""
-    lines = []
-    for d in diffs:
-        lines.append("  " + " | ".join(repr(part) for part in d))
+    lines = ["  " + " | ".join(repr(part) for part in d) for d in diffs]
     return "\n".join(lines) if lines else "(no diffs)"
 
 

--- a/scripts/data_cleanup.py
+++ b/scripts/data_cleanup.py
@@ -86,6 +86,18 @@ def audit(phase: int, action: str, entity: str, details: dict):
     log.info(f"  [{action}] {entity}: {json.dumps(details, default=str)[:200]}")
 
 
+def _reassign_fk(db: Session, model, column: str, loser_id, winner_id):
+    """Bulk-repoint a foreign-key column from loser_id to winner_id."""
+    db.query(model).filter_by(**{column: loser_id}).update({column: winner_id}, synchronize_session=False)
+
+
+def _copy_missing_fields(winner, loser, fields):
+    """Fill blank winner fields from the loser."""
+    for field in fields:
+        if not getattr(winner, field) and getattr(loser, field):
+            setattr(winner, field, getattr(loser, field))
+
+
 # ── Backup ──────────────────────────────────────────────────────────
 
 
@@ -214,81 +226,36 @@ def _merge_vendor_cards(db: Session, winner: VendorCard, loser: VendorCard):
     winner.total_pos = (winner.total_pos or 0) + (loser.total_pos or 0)
 
     # Copy enrichment fields if winner is missing them
-    for field in [
-        "website",
-        "linkedin_url",
-        "legal_name",
-        "employee_size",
-        "hq_city",
-        "hq_state",
-        "hq_country",
-        "industry",
-    ]:
-        if not getattr(winner, field) and getattr(loser, field):
-            setattr(winner, field, getattr(loser, field))
+    _copy_missing_fields(
+        winner,
+        loser,
+        ["website", "linkedin_url", "legal_name", "employee_size", "hq_city", "hq_state", "hq_country", "industry"],
+    )
 
     # Update FK tables
     loser_id = loser.id
     winner_id = winner.id
 
-    # Offers
-    db.query(Offer).filter_by(vendor_card_id=loser_id).update({"vendor_card_id": winner_id}, synchronize_session=False)
+    # Move a child whose unique key (keyed by `unique_attr`) doesn't already
+    # exist on the winner; delete it when the winner already holds that key.
+    # A falsy key (None/"") is always moved, never treated as a collision.
+    def _move_or_delete(model, unique_attr):
+        existing = {getattr(row, unique_attr) for row in db.query(model).filter_by(vendor_card_id=winner_id).all()}
+        for child in db.query(model).filter_by(vendor_card_id=loser_id).all():
+            key = getattr(child, unique_attr)
+            if key and key in existing:
+                db.delete(child)
+            else:
+                child.vendor_card_id = winner_id
 
-    # VendorMetricsSnapshot — check unique on vendor_card_id+snapshot_date
-    existing_dates = {
-        r[0] for r in db.query(VendorMetricsSnapshot.snapshot_date).filter_by(vendor_card_id=winner_id).all()
-    }
-    for vms in db.query(VendorMetricsSnapshot).filter_by(vendor_card_id=loser_id).all():
-        if vms.snapshot_date in existing_dates:
-            db.delete(vms)
-        else:
-            vms.vendor_card_id = winner_id
+    # Simple repoint (no unique constraint to honor)
+    for model in (Offer, StockListHash, VendorReview, ProspectContact, ActivityLog, RoutingAssignment, EnrichmentQueue):
+        _reassign_fk(db, model, "vendor_card_id", loser_id, winner_id)
 
-    # StockListHashes
-    db.query(StockListHash).filter_by(vendor_card_id=loser_id).update(
-        {"vendor_card_id": winner_id}, synchronize_session=False
-    )
-
-    # VendorContacts — check unique on vendor_card_id+email
-    existing_emails = {r[0] for r in db.query(VendorContact.email).filter_by(vendor_card_id=winner_id).all()}
-    for vc in db.query(VendorContact).filter_by(vendor_card_id=loser_id).all():
-        if vc.email and vc.email in existing_emails:
-            db.delete(vc)
-        else:
-            vc.vendor_card_id = winner_id
-
-    # VendorReviews
-    db.query(VendorReview).filter_by(vendor_card_id=loser_id).update(
-        {"vendor_card_id": winner_id}, synchronize_session=False
-    )
-
-    # ProspectContacts
-    db.query(ProspectContact).filter_by(vendor_card_id=loser_id).update(
-        {"vendor_card_id": winner_id}, synchronize_session=False
-    )
-
-    # ActivityLog
-    db.query(ActivityLog).filter_by(vendor_card_id=loser_id).update(
-        {"vendor_card_id": winner_id}, synchronize_session=False
-    )
-
-    # BuyerVendorStats — check unique on user_id+vendor_card_id
-    existing_bvs_users = {r[0] for r in db.query(BuyerVendorStats.user_id).filter_by(vendor_card_id=winner_id).all()}
-    for bvs in db.query(BuyerVendorStats).filter_by(vendor_card_id=loser_id).all():
-        if bvs.user_id in existing_bvs_users:
-            db.delete(bvs)
-        else:
-            bvs.vendor_card_id = winner_id
-
-    # RoutingAssignments
-    db.query(RoutingAssignment).filter_by(vendor_card_id=loser_id).update(
-        {"vendor_card_id": winner_id}, synchronize_session=False
-    )
-
-    # EnrichmentQueue
-    db.query(EnrichmentQueue).filter_by(vendor_card_id=loser_id).update(
-        {"vendor_card_id": winner_id}, synchronize_session=False
-    )
+    # Constrained repoint — move or delete on the winner's existing unique key
+    _move_or_delete(VendorMetricsSnapshot, "snapshot_date")  # unique: vendor_card_id+snapshot_date
+    _move_or_delete(VendorContact, "email")  # unique: vendor_card_id+email
+    _move_or_delete(BuyerVendorStats, "user_id")  # unique: user_id+vendor_card_id
 
     db.flush()
     db.delete(loser)
@@ -348,33 +315,31 @@ def phase2_company_dedup(db: Session, dry_run: bool):
 def _merge_companies(db: Session, winner: Company, loser: Company):
     """Merge loser company into winner."""
     # Copy missing fields
-    for field in [
-        "domain",
-        "website",
-        "industry",
-        "linkedin_url",
-        "legal_name",
-        "employee_size",
-        "hq_city",
-        "hq_state",
-        "hq_country",
-        "account_type",
-        "phone",
-        "credit_terms",
-        "tax_id",
-    ]:
-        if not getattr(winner, field) and getattr(loser, field):
-            setattr(winner, field, getattr(loser, field))
+    _copy_missing_fields(
+        winner,
+        loser,
+        [
+            "domain",
+            "website",
+            "industry",
+            "linkedin_url",
+            "legal_name",
+            "employee_size",
+            "hq_city",
+            "hq_state",
+            "hq_country",
+            "account_type",
+            "phone",
+            "credit_terms",
+            "tax_id",
+        ],
+    )
 
     # Update FK tables
-    db.query(CustomerSite).filter_by(company_id=loser.id).update({"company_id": winner.id}, synchronize_session=False)
-    db.query(Sighting).filter_by(source_company_id=loser.id).update(
-        {"source_company_id": winner.id}, synchronize_session=False
-    )
-    db.query(ActivityLog).filter_by(company_id=loser.id).update({"company_id": winner.id}, synchronize_session=False)
-    db.query(EnrichmentQueue).filter_by(company_id=loser.id).update(
-        {"company_id": winner.id}, synchronize_session=False
-    )
+    _reassign_fk(db, CustomerSite, "company_id", loser.id, winner.id)
+    _reassign_fk(db, Sighting, "source_company_id", loser.id, winner.id)
+    _reassign_fk(db, ActivityLog, "company_id", loser.id, winner.id)
+    _reassign_fk(db, EnrichmentQueue, "company_id", loser.id, winner.id)
 
     db.flush()
     db.delete(loser)
@@ -392,62 +357,22 @@ def phase3_contact_cleanup(db: Session, dry_run: bool):
     log.info("--- Phase 3a: Phone Normalization ---")
     phone_updates = 0
 
-    # VendorContacts
-    contacts = db.query(VendorContact).filter(VendorContact.phone.isnot(None)).all()
-    for c in contacts:
-        new_phone = normalize_phone_e164(c.phone)
-        if new_phone and new_phone != c.phone:
-            audit(
-                3,
-                "normalize_phone",
-                "vendor_contact",
-                {
-                    "id": c.id,
-                    "old": c.phone,
-                    "new": new_phone,
-                },
-            )
-            if not dry_run:
-                c.phone = new_phone
-            phone_updates += 1
-
-    # CustomerSites
-    sites = db.query(CustomerSite).filter(CustomerSite.contact_phone.isnot(None)).all()
-    for s in sites:
-        new_phone = normalize_phone_e164(s.contact_phone)
-        if new_phone and new_phone != s.contact_phone:
-            audit(
-                3,
-                "normalize_phone",
-                "customer_site",
-                {
-                    "id": s.id,
-                    "old": s.contact_phone,
-                    "new": new_phone,
-                },
-            )
-            if not dry_run:
-                s.contact_phone = new_phone
-            phone_updates += 1
-
-    # Companies
-    cos = db.query(Company).filter(Company.phone.isnot(None)).all()
-    for co in cos:
-        new_phone = normalize_phone_e164(co.phone)
-        if new_phone and new_phone != co.phone:
-            audit(
-                3,
-                "normalize_phone",
-                "company",
-                {
-                    "id": co.id,
-                    "old": co.phone,
-                    "new": new_phone,
-                },
-            )
-            if not dry_run:
-                co.phone = new_phone
-            phone_updates += 1
+    # (model, phone column, audit entity) for the scalar phone fields
+    phone_columns = [
+        (VendorContact, "phone", "vendor_contact"),
+        (CustomerSite, "contact_phone", "customer_site"),
+        (Company, "phone", "company"),
+    ]
+    for model, column, entity in phone_columns:
+        col = getattr(model, column)
+        for row in db.query(model).filter(col.isnot(None)).all():
+            old = getattr(row, column)
+            new_phone = normalize_phone_e164(old)
+            if new_phone and new_phone != old:
+                audit(3, "normalize_phone", entity, {"id": row.id, "old": old, "new": new_phone})
+                if not dry_run:
+                    setattr(row, column, new_phone)
+                phone_updates += 1
 
     # VendorCard.phones (JSON array)
     cards = db.query(VendorCard).filter(VendorCard.phones.isnot(None)).all()
@@ -483,48 +408,23 @@ def phase3_contact_cleanup(db: Session, dry_run: bool):
     log.info("--- Phase 3b: Contact Name Cleanup ---")
     name_updates = 0
 
-    contacts = db.query(VendorContact).filter(VendorContact.full_name.isnot(None)).all()
-    for c in contacts:
-        if not c.full_name:
-            continue
-        cleaned, is_person = clean_contact_name(c.full_name)
-        if cleaned != c.full_name:
-            audit(
-                3,
-                "clean_name",
-                "vendor_contact",
-                {
-                    "id": c.id,
-                    "old": c.full_name,
-                    "new": cleaned,
-                    "is_person": is_person,
-                },
-            )
-            if not dry_run:
-                c.full_name = cleaned
-            name_updates += 1
-
-    # ProspectContacts
-    prospects = db.query(ProspectContact).filter(ProspectContact.full_name.isnot(None)).all()
-    for p in prospects:
-        if not p.full_name:
-            continue
-        cleaned, is_person = clean_contact_name(p.full_name)
-        if cleaned != p.full_name:
-            audit(
-                3,
-                "clean_name",
-                "prospect_contact",
-                {
-                    "id": p.id,
-                    "old": p.full_name,
-                    "new": cleaned,
-                    "is_person": is_person,
-                },
-            )
-            if not dry_run:
-                p.full_name = cleaned
-            name_updates += 1
+    # (model, audit entity) for the full_name fields
+    name_models = [(VendorContact, "vendor_contact"), (ProspectContact, "prospect_contact")]
+    for model, entity in name_models:
+        for row in db.query(model).filter(model.full_name.isnot(None)).all():
+            if not row.full_name:
+                continue
+            cleaned, is_person = clean_contact_name(row.full_name)
+            if cleaned != row.full_name:
+                audit(
+                    3,
+                    "clean_name",
+                    entity,
+                    {"id": row.id, "old": row.full_name, "new": cleaned, "is_person": is_person},
+                )
+                if not dry_run:
+                    setattr(row, "full_name", cleaned)
+                name_updates += 1
 
     log.info(f"Name cleanups: {name_updates}")
 
@@ -595,114 +495,29 @@ def phase5_field_standardization(db: Session, dry_run: bool):
     country_fixes = 0
     state_fixes = 0
 
-    # Companies
-    for co in db.query(Company).all():
-        if co.hq_country:
-            new_country = normalize_country(co.hq_country)
-            if new_country and new_country != co.hq_country:
-                audit(
-                    5,
-                    "normalize_country",
-                    "company",
-                    {
-                        "id": co.id,
-                        "old": co.hq_country,
-                        "new": new_country,
-                    },
-                )
-                if not dry_run:
-                    co.hq_country = new_country
+    def normalize_field(row, column, normalizer, action, entity):
+        old = getattr(row, column, None)
+        if not old:
+            return False
+        new = normalizer(old)
+        if not new or new == old:
+            return False
+        audit(5, action, entity, {"id": row.id, "old": old, "new": new})
+        if not dry_run:
+            setattr(row, column, new)
+        return True
+
+    # (model, country column, state column, audit entity)
+    targets = [
+        (Company, "hq_country", "hq_state", "company"),
+        (CustomerSite, "country", "state", "customer_site"),
+        (VendorCard, "hq_country", "hq_state", "vendor_card"),
+    ]
+    for model, country_col, state_col, entity in targets:
+        for row in db.query(model).all():
+            if normalize_field(row, country_col, normalize_country, "normalize_country", entity):
                 country_fixes += 1
-
-        if co.hq_state:
-            new_state = normalize_us_state(co.hq_state)
-            if new_state and new_state != co.hq_state:
-                audit(
-                    5,
-                    "normalize_state",
-                    "company",
-                    {
-                        "id": co.id,
-                        "old": co.hq_state,
-                        "new": new_state,
-                    },
-                )
-                if not dry_run:
-                    co.hq_state = new_state
-                state_fixes += 1
-
-    # CustomerSites
-    for site in db.query(CustomerSite).all():
-        country = getattr(site, "country", None)
-        if country:
-            new_country = normalize_country(country)
-            if new_country and new_country != country:
-                audit(
-                    5,
-                    "normalize_country",
-                    "customer_site",
-                    {
-                        "id": site.id,
-                        "old": country,
-                        "new": new_country,
-                    },
-                )
-                if not dry_run:
-                    site.country = new_country
-                country_fixes += 1
-
-        state = getattr(site, "state", None)
-        if state:
-            new_state = normalize_us_state(state)
-            if new_state and new_state != state:
-                audit(
-                    5,
-                    "normalize_state",
-                    "customer_site",
-                    {
-                        "id": site.id,
-                        "old": state,
-                        "new": new_state,
-                    },
-                )
-                if not dry_run:
-                    site.state = new_state
-                state_fixes += 1
-
-    # VendorCards
-    for card in db.query(VendorCard).all():
-        if card.hq_country:
-            new_country = normalize_country(card.hq_country)
-            if new_country and new_country != card.hq_country:
-                audit(
-                    5,
-                    "normalize_country",
-                    "vendor_card",
-                    {
-                        "id": card.id,
-                        "old": card.hq_country,
-                        "new": new_country,
-                    },
-                )
-                if not dry_run:
-                    card.hq_country = new_country
-                country_fixes += 1
-
-        if card.hq_state:
-            new_state = normalize_us_state(card.hq_state)
-            if new_state and new_state != card.hq_state:
-                audit(
-                    5,
-                    "normalize_state",
-                    "vendor_card",
-                    {
-                        "id": card.id,
-                        "old": card.hq_state,
-                        "new": new_state,
-                    },
-                )
-                if not dry_run:
-                    card.hq_state = new_state
+            if normalize_field(row, state_col, normalize_us_state, "normalize_state", entity):
                 state_fixes += 1
 
     if not dry_run and (country_fixes or state_fixes):

--- a/scripts/enrich_from_sightings.py
+++ b/scripts/enrich_from_sightings.py
@@ -111,9 +111,14 @@ def enrich_card_from_sightings(
                     needs_description = False  # Got from authorized, stop looking
 
         # Manufacturer
-        if needs_manufacturer and "manufacturer" not in updates:
-            if manufacturer and isinstance(manufacturer, str) and manufacturer.strip():
-                updates["manufacturer"] = manufacturer.strip()
+        if (
+            needs_manufacturer
+            and "manufacturer" not in updates
+            and manufacturer
+            and isinstance(manufacturer, str)
+            and manufacturer.strip()
+        ):
+            updates["manufacturer"] = manufacturer.strip()
 
         # Datasheet URL
         if needs_datasheet and "datasheet_url" not in updates:

--- a/scripts/enrich_orchestrator.py
+++ b/scripts/enrich_orchestrator.py
@@ -19,6 +19,7 @@ import json
 import os
 import sys
 import uuid
+from collections import defaultdict
 from datetime import datetime, timezone
 
 from loguru import logger
@@ -49,8 +50,14 @@ from scripts.enrich_specs_batch import (
 )
 
 
-def _parse_parts(result_data: dict) -> list | None:
-    """Extract and parse 'parts' from batch result, handling JSON string edge case."""
+def _parse_parts(result_data) -> list | None:
+    """Extract a 'parts' list from a batch result entry.
+
+    Returns None if the entry is missing/malformed (not a dict, or 'parts' is neither a
+    list nor a JSON-encoded list), so callers can treat None as an error.
+    """
+    if not isinstance(result_data, dict):
+        return None
     parts = result_data.get("parts", [])
     if isinstance(parts, str):
         try:
@@ -99,6 +106,23 @@ def _fail_run(db, run: EnrichmentRun, error: str):
     run.status = "failed"
     run.error_message = error
     db.commit()
+
+
+def _resumable_run(db, phase: str) -> EnrichmentRun | None:
+    """Return an in-flight run for this phase (running/submitted), or None."""
+    return (
+        db.query(EnrichmentRun)
+        .filter(EnrichmentRun.phase == phase, EnrichmentRun.status.in_(["running", "submitted"]))
+        .first()
+    )
+
+
+def _phase_completed(db, phase: str) -> bool:
+    """Whether a completed run exists for this phase (used to skip on resume)."""
+    return (
+        db.query(EnrichmentRun).filter(EnrichmentRun.phase == phase, EnrichmentRun.status == "completed").first()
+        is not None
+    )
 
 
 # ── Phase 0: Reclassify coarse categories ────────────────────────────
@@ -201,12 +225,9 @@ async def phase_1_mine_sightings(db, dry_run: bool) -> dict:
             .all()
         )
 
-        card_sightings: dict[int, list] = {}
+        card_sightings: dict[int, list] = defaultdict(list)
         for s in sightings:
-            cid = s.material_card_id
-            if cid not in card_sightings:
-                card_sightings[cid] = []
-            card_sightings[cid].append((s.source_type, s.manufacturer, s.is_authorized, s.raw_data))
+            card_sightings[s.material_card_id].append((s.source_type, s.manufacturer, s.is_authorized, s.raw_data))
 
         for cid in card_sightings:
             card_sightings[cid].sort(key=lambda x: SOURCE_PRIORITY.get(x[0] or "", 0), reverse=True)
@@ -254,11 +275,7 @@ async def phase_2_batch_enrichment(db, dry_run: bool) -> dict:
     logger.info("═══ Phase 2: AI batch enrichment (Sonnet) ═══")
 
     # Check for resumable run
-    existing = (
-        db.query(EnrichmentRun)
-        .filter(EnrichmentRun.phase == "phase_2_batch", EnrichmentRun.status.in_(["running", "submitted"]))
-        .first()
-    )
+    existing = _resumable_run(db, "phase_2_batch")
 
     if existing and existing.batch_ids:
         logger.info(f"Resuming Phase 2 run {existing.run_id} — polling batch results")
@@ -347,16 +364,12 @@ async def _poll_and_apply_phase2(db, run: EnrichmentRun, dry_run: bool) -> dict:
 
             # Apply results
             for custom_id, result_data in results.items():
-                if result_data is None or not isinstance(result_data, dict):
-                    stats["errors"] += 1
-                    continue
-
-                card_meta_list = run.request_map.get(custom_id, [])
                 parts = _parse_parts(result_data)
                 if parts is None:
                     stats["errors"] += 1
                     continue
 
+                card_meta_list = run.request_map.get(custom_id, [])
                 for card_info, ai_part in zip(card_meta_list, parts):
                     stats["processed"] += 1
                     cat = ai_part.get("category", "other")
@@ -434,14 +447,7 @@ async def phase_3_spec_extraction(db, dry_run: bool) -> dict:
 
     for category in COMMODITY_SPECS:
         # Check for resumable run
-        existing = (
-            db.query(EnrichmentRun)
-            .filter(
-                EnrichmentRun.phase == f"phase_3_specs_{category}",
-                EnrichmentRun.status.in_(["running", "submitted"]),
-            )
-            .first()
-        )
+        existing = _resumable_run(db, f"phase_3_specs_{category}")
 
         if existing and existing.batch_ids:
             logger.info(f"  Resuming {category} spec extraction")
@@ -539,16 +545,12 @@ async def _poll_and_apply_specs(db, run: EnrichmentRun, category: str, dry_run: 
                 continue
 
             for custom_id, result_data in results.items():
-                if result_data is None or not isinstance(result_data, dict):
-                    stats["errors"] += 1
-                    continue
-
-                card_meta_list = run.request_map.get(custom_id, [])
                 parts = _parse_parts(result_data)
                 if parts is None:
                     stats["errors"] += 1
                     continue
 
+                card_meta_list = run.request_map.get(custom_id, [])
                 for card_info, ai_part in zip(card_meta_list, parts):
                     stats["processed"] += 1
                     summary = _specs_to_summary(category, ai_part)
@@ -589,11 +591,7 @@ async def phase_4_premium_descriptions(db, dry_run: bool) -> dict:
 
     logger.info("═══ Phase 4: Premium descriptions (Sonnet) ═══")
 
-    existing = (
-        db.query(EnrichmentRun)
-        .filter(EnrichmentRun.phase == "phase_4_descriptions", EnrichmentRun.status.in_(["running", "submitted"]))
-        .first()
-    )
+    existing = _resumable_run(db, "phase_4_descriptions")
 
     if existing and existing.batch_ids:
         logger.info("Resuming Phase 4")
@@ -738,16 +736,12 @@ async def _poll_and_apply_descriptions(db, run: EnrichmentRun, dry_run: bool) ->
                 continue
 
             for custom_id, result_data in results.items():
-                if result_data is None or not isinstance(result_data, dict):
-                    stats["errors"] += 1
-                    continue
-
-                card_meta = run.request_map.get(custom_id, [])
                 parts = _parse_parts(result_data)
                 if parts is None:
                     stats["errors"] += 1
                     continue
 
+                card_meta = run.request_map.get(custom_id, [])
                 for card_info, ai_part in zip(card_meta, parts):
                     stats["processed"] += 1
                     desc = ai_part.get("description")
@@ -803,34 +797,19 @@ async def run_pipeline(dry_run: bool = True, resume: bool = False):
         logger.info(f"{'═' * 60}")
 
         # Phase 0: Reclassify coarse categories
-        if (
-            not resume
-            or not db.query(EnrichmentRun)
-            .filter(EnrichmentRun.phase == "phase_0_reclassify", EnrichmentRun.status == "completed")
-            .first()
-        ):
+        if not resume or not _phase_completed(db, "phase_0_reclassify"):
             await phase_0_reclassify(db, dry_run)
         else:
             logger.info("Phase 0 already complete — skipping")
 
         # Phase 1: Mine sighting data
-        if (
-            not resume
-            or not db.query(EnrichmentRun)
-            .filter(EnrichmentRun.phase == "phase_1_sightings", EnrichmentRun.status == "completed")
-            .first()
-        ):
+        if not resume or not _phase_completed(db, "phase_1_sightings"):
             await phase_1_mine_sightings(db, dry_run)
         else:
             logger.info("Phase 1 already complete — skipping")
 
         # Phase 2: AI batch enrichment (Sonnet)
-        if (
-            not resume
-            or not db.query(EnrichmentRun)
-            .filter(EnrichmentRun.phase == "phase_2_batch", EnrichmentRun.status == "completed")
-            .first()
-        ):
+        if not resume or not _phase_completed(db, "phase_2_batch"):
             await phase_2_batch_enrichment(db, dry_run)
         else:
             logger.info("Phase 2 already complete — skipping")
@@ -839,24 +818,14 @@ async def run_pipeline(dry_run: bool = True, resume: bool = False):
         await phase_3_spec_extraction(db, dry_run)
 
         # Phase 4: Premium descriptions
-        if (
-            not resume
-            or not db.query(EnrichmentRun)
-            .filter(EnrichmentRun.phase == "phase_4_descriptions", EnrichmentRun.status == "completed")
-            .first()
-        ):
+        if not resume or not _phase_completed(db, "phase_4_descriptions"):
             await phase_4_premium_descriptions(db, dry_run)
         else:
             logger.info("Phase 4 already complete — skipping")
 
         # Phase 5: Web search enrichment (lifecycle, RoHS, cross-refs)
         if not dry_run:
-            if (
-                not resume
-                or not db.query(EnrichmentRun)
-                .filter(EnrichmentRun.phase == "phase_5_web", EnrichmentRun.status == "completed")
-                .first()
-            ):
+            if not resume or not _phase_completed(db, "phase_5_web"):
                 from scripts.enrich_web_verified import run_web_enrichment
 
                 await run_web_enrichment(db, limit=5000, dry_run=False)

--- a/scripts/enrich_specs_batch.py
+++ b/scripts/enrich_specs_batch.py
@@ -213,38 +213,28 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    async def with_session(run):
+        """Open a session for the duration of one CLI command, then close it."""
+        db = SessionLocal()
+        try:
+            await run(db)
+        finally:
+            db.close()
+
+    async def run_submit_all(db):
+        for cat in COMMODITY_SPECS:
+            result = await submit_spec_extraction(db, cat, limit=args.limit)
+            logger.info(f"[{cat}] {result}")
+
+    async def run_submit_one(db):
+        result = await submit_spec_extraction(db, args.category, limit=args.limit)
+        logger.info(result)
+
+    async def run_apply(db):
+        result = await apply_spec_results(args.meta_path, db, dry_run=not args.apply)
+        logger.info(result)
+
     if args.command == "submit":
-        if args.all:
-
-            async def submit_all():
-                db = SessionLocal()
-                try:
-                    for cat in COMMODITY_SPECS:
-                        result = await submit_spec_extraction(db, cat, limit=args.limit)
-                        logger.info(f"[{cat}] {result}")
-                finally:
-                    db.close()
-
-            asyncio.run(submit_all())
-        else:
-
-            async def submit_one():
-                db = SessionLocal()
-                try:
-                    result = await submit_spec_extraction(db, args.category, limit=args.limit)
-                    logger.info(result)
-                finally:
-                    db.close()
-
-            asyncio.run(submit_one())
+        asyncio.run(with_session(run_submit_all if args.all else run_submit_one))
     elif args.command == "apply":
-
-        async def apply():
-            db = SessionLocal()
-            try:
-                result = await apply_spec_results(args.meta_path, db, dry_run=not args.apply)
-                logger.info(result)
-            finally:
-                db.close()
-
-        asyncio.run(apply())
+        asyncio.run(with_session(run_apply))

--- a/scripts/frprp.py
+++ b/scripts/frprp.py
@@ -288,7 +288,8 @@ def scan_security_patterns() -> list[dict]:
     for rf in ROUTERS_DIR.rglob("*.py"):
         content = rf.read_text(errors="replace")
         rel = str(rf.relative_to(PROJECT_ROOT))
-        for i, line in enumerate(content.splitlines(), 1):
+        lines = content.splitlines()
+        for i, line in enumerate(lines, 1):
             if "HTMLResponse" in line and ("f'" in line or 'f"' in line):
                 # Skip if already escaped or marked safe
                 if "html.escape" in line or "html_mod.escape" in line:
@@ -305,7 +306,7 @@ def scan_security_patterns() -> list[dict]:
                 if "json.dumps" in line or "json_dumps" in line:
                     continue
                 # Check surrounding lines for json.dumps too
-                ctx = "\n".join(content.splitlines()[max(0, i - 3) : i + 3])
+                ctx = "\n".join(lines[max(0, i - 3) : i + 3])
                 if "json.dumps" in ctx and ".replace(" in ctx:
                     continue
                 findings.append(
@@ -387,10 +388,11 @@ def scan_template_consistency() -> list[dict]:
     for tf in TEMPLATES_DIR.rglob("*.html"):
         content = tf.read_text(errors="replace")
         rel = str(tf.relative_to(PROJECT_ROOT))
+        lines = content.splitlines()
 
         # Raw status strings that should use status_badge macro
         for status in raw_statuses:
-            for i, line in enumerate(content.splitlines(), 1):
+            for i, line in enumerate(lines, 1):
                 stripped = line.strip()
                 # Skip Jinja2 comments and comparisons
                 if (
@@ -422,7 +424,7 @@ def scan_template_consistency() -> list[dict]:
                         )
 
         # Inline styles (should use Tailwind) — skip dynamic/unfixable ones
-        for i, line in enumerate(content.splitlines(), 1):
+        for i, line in enumerate(lines, 1):
             if 'style="' in line and "hx-" not in line:
                 # Skip dynamic styles that can't be converted
                 if any(
@@ -517,8 +519,9 @@ def scan_loading_states() -> list[dict]:
     for tf in TEMPLATES_DIR.rglob("*.html"):
         content = tf.read_text(errors="replace")
         rel = str(tf.relative_to(PROJECT_ROOT))
+        lines = content.splitlines()
 
-        for i, line in enumerate(content.splitlines(), 1):
+        for i, line in enumerate(lines, 1):
             # Only flag forms/buttons with mutations, or lazy-load triggers
             is_mutation = re.search(r"hx-(post|put|delete|patch)", line)
             is_lazy = re.search(r'hx-trigger="(load|revealed|intersect)', line)
@@ -526,18 +529,11 @@ def scan_loading_states() -> list[dict]:
             if not (is_mutation or is_lazy):
                 continue
 
+            # Check wider context (15 lines) — loading attrs may be on child
+            # elements; this window includes the current line itself.
+            context = "\n".join(lines[max(0, i - 3) : i + 12])
             has_indicator = (
-                "hx-indicator" in line
-                or "data-loading" in line
-                or "data-loading-disable" in line
-                or "data-loading-aria-busy" in line
-            )
-            # Check wider context (15 lines) — loading attrs may be on child elements
-            context_lines = content.splitlines()[max(0, i - 3) : min(len(content.splitlines()), i + 12)]
-            context = "\n".join(context_lines)
-            has_indicator = (
-                has_indicator
-                or "hx-indicator" in context
+                "hx-indicator" in context
                 or "htmx-indicator" in context
                 or "data-loading" in context
                 or "data-loading-disable" in context
@@ -619,8 +615,9 @@ def scan_accessibility_static() -> list[dict]:
     for tf in TEMPLATES_DIR.rglob("*.html"):
         content = tf.read_text(errors="replace")
         rel = str(tf.relative_to(PROJECT_ROOT))
+        lines = content.splitlines()
 
-        for i, line in enumerate(content.splitlines(), 1):
+        for i, line in enumerate(lines, 1):
             # Images without alt
             if "<img" in line and "alt=" not in line:
                 findings.append(
@@ -638,7 +635,7 @@ def scan_accessibility_static() -> list[dict]:
 
             # Inputs without label or aria-label
             if "<input" in line and 'type="hidden"' not in line:
-                ctx = "\n".join(content.splitlines()[max(0, i - 3) : i + 3])
+                ctx = "\n".join(lines[max(0, i - 3) : i + 3])
                 if "aria-label" not in ctx and "<label" not in ctx and "aria-labelledby" not in ctx:
                     findings.append(
                         {
@@ -857,6 +854,34 @@ def run_phase2_classify(scan_report: dict) -> dict:
 # ── Phase 3: FIX (auto-patterns) ─────────────────────────────────────
 
 
+def _rewrite_line(content: str, line_num: int, transform) -> str:
+    """Apply ``transform`` to the 1-based ``line_num`` of ``content``.
+
+    Returns ``content`` unchanged if ``line_num`` is out of range, so callers can
+    rely on an out-of-bounds finding being a no-op.
+    """
+    lines = content.splitlines()
+    if not (0 < line_num <= len(lines)):
+        return content
+    lines[line_num - 1] = transform(lines[line_num - 1])
+    return "\n".join(lines)
+
+
+def _add_input_label(line: str) -> str:
+    """Add an ``aria-label`` to a bare ``<input>``, derived from placeholder/name."""
+    if "<input" not in line or "aria-label" in line:
+        return line
+    placeholder = re.search(r'placeholder="([^"]*)"', line)
+    name = re.search(r'name="([^"]*)"', line)
+    if placeholder:
+        label = placeholder.group(1)
+    elif name:
+        label = name.group(1).replace("_", " ").title()
+    else:
+        label = "Input"
+    return line.replace("<input", f'<input aria-label="{label}"', 1)
+
+
 def apply_auto_fix(finding: dict, all_findings: list[dict]) -> bool:
     """Apply a deterministic auto-fix pattern.
 
@@ -875,34 +900,39 @@ def apply_auto_fix(finding: dict, all_findings: list[dict]) -> bool:
     original = content
     line_num = finding.get("line", 0)
 
+    def add_x_cloak(line: str) -> str:
+        # Add x-cloak after x-show or x-if
+        if "x-cloak" in line:
+            return line
+        line = re.sub(r'(x-show="[^"]*")', r"\1 x-cloak", line)
+        return re.sub(r'(x-if="[^"]*")', r"\1 x-cloak", line)
+
+    def add_alt(line: str) -> str:
+        if "<img" in line and "alt=" not in line:
+            return line.replace("<img", '<img alt=""', 1)
+        return line
+
+    def add_role_button(line: str) -> str:
+        if "@click" in line and "role=" not in line:
+            return re.sub(r"(@click)", r'role="button" tabindex="0" \1', line)
+        return line
+
     if pattern == "missing_rel_noopener":
-        lines = content.splitlines()
-        if 0 < line_num <= len(lines):
-            lines[line_num - 1] = lines[line_num - 1].replace(
-                'target="_blank"', 'target="_blank" rel="noopener noreferrer"'
-            )
-            content = "\n".join(lines)
+        content = _rewrite_line(
+            content,
+            line_num,
+            lambda line: line.replace('target="_blank"', 'target="_blank" rel="noopener noreferrer"'),
+        )
 
     elif pattern == "missing_x_cloak":
-        lines = content.splitlines()
-        if 0 < line_num <= len(lines):
-            line = lines[line_num - 1]
-            # Add x-cloak after x-show or x-if
-            if "x-cloak" not in line:
-                line = re.sub(r'(x-show="[^"]*")', r"\1 x-cloak", line)
-                line = re.sub(r'(x-if="[^"]*")', r"\1 x-cloak", line)
-                lines[line_num - 1] = line
-            content = "\n".join(lines)
+        content = _rewrite_line(content, line_num, add_x_cloak)
 
     elif pattern == "deprecated_db_query_get":
-        lines = content.splitlines()
-        if 0 < line_num <= len(lines):
-            lines[line_num - 1] = re.sub(
-                r"db\.query\((\w+)\)\.get\((\w+)\)",
-                r"db.get(\1, \2)",
-                lines[line_num - 1],
-            )
-            content = "\n".join(lines)
+        content = _rewrite_line(
+            content,
+            line_num,
+            lambda line: re.sub(r"db\.query\((\w+)\)\.get\((\w+)\)", r"db.get(\1, \2)", line),
+        )
 
     elif pattern == "unescaped_html_response":
         # Add html import and escape the f-string content
@@ -918,39 +948,13 @@ def apply_auto_fix(finding: dict, all_findings: list[dict]) -> bool:
         content = "\n".join(lines)
 
     elif pattern == "missing_alt":
-        lines = content.splitlines()
-        if 0 < line_num <= len(lines):
-            line = lines[line_num - 1]
-            if "<img" in line and "alt=" not in line:
-                line = line.replace("<img", '<img alt=""', 1)
-                lines[line_num - 1] = line
-            content = "\n".join(lines)
+        content = _rewrite_line(content, line_num, add_alt)
 
     elif pattern == "missing_role_button":
-        lines = content.splitlines()
-        if 0 < line_num <= len(lines):
-            line = lines[line_num - 1]
-            if "@click" in line and "role=" not in line:
-                line = re.sub(r"(@click)", r'role="button" tabindex="0" \1', line)
-                lines[line_num - 1] = line
-            content = "\n".join(lines)
+        content = _rewrite_line(content, line_num, add_role_button)
 
     elif pattern == "missing_input_label":
-        lines = content.splitlines()
-        if 0 < line_num <= len(lines):
-            line = lines[line_num - 1]
-            if "<input" in line and "aria-label" not in line:
-                # Try to use placeholder or name as label
-                placeholder = re.search(r'placeholder="([^"]*)"', line)
-                name = re.search(r'name="([^"]*)"', line)
-                label = (
-                    placeholder.group(1)
-                    if placeholder
-                    else (name.group(1).replace("_", " ").title() if name else "Input")
-                )
-                line = line.replace("<input", f'<input aria-label="{label}"', 1)
-                lines[line_num - 1] = line
-            content = "\n".join(lines)
+        content = _rewrite_line(content, line_num, _add_input_label)
 
     if content != original:
         full_path.write_text(content)

--- a/scripts/import_part_numbers.py
+++ b/scripts/import_part_numbers.py
@@ -44,7 +44,8 @@ def _run(file_path: str, commit: bool) -> dict[str, int]:
     db = SessionLocal()
     created = existing = skipped = 0
     try:
-        content = open(file_path, "rb").read()
+        with open(file_path, "rb") as f:
+            content = f.read()
         mpns = extract_mpns(parse_tabular_file(content, file_path))
         logger.info("Parsed {} part numbers from {}", len(mpns), file_path)
 

--- a/scripts/merge_suffix_material_cards.py
+++ b/scripts/merge_suffix_material_cards.py
@@ -66,6 +66,17 @@ def find_merge_candidates(db) -> list[tuple[int, str, int, str]]:
     return candidates
 
 
+def _move_rows(db, model, suffix_id: int, base_id: int, dry_run: bool) -> int:
+    """Re-point ``model`` rows from the suffix card to the base card.
+
+    Returns the number of rows moved (in dry-run, the number that *would* move).
+    """
+    if dry_run:
+        return db.query(model).filter(model.material_card_id == suffix_id).count()
+    result = db.execute(update(model).where(model.material_card_id == suffix_id).values(material_card_id=base_id))
+    return result.rowcount
+
+
 def merge(dry_run: bool = False) -> dict:
     """Execute the merge of suffix MaterialCards into their base cards."""
     db = SessionLocal()
@@ -87,34 +98,9 @@ def merge(dry_run: bool = False) -> dict:
                 f"[{i}/{len(candidates)}] Merging '{suffix_mpn}' (id={suffix_id}) → '{base_mpn}' (id={base_id})"
             )
 
-            if not dry_run:
-                # Move sightings
-                result = db.execute(
-                    update(Sighting).where(Sighting.material_card_id == suffix_id).values(material_card_id=base_id)
-                )
-                sightings_count = result.rowcount
-            else:
-                sightings_count = db.query(Sighting).filter(Sighting.material_card_id == suffix_id).count()
-
-            if not dry_run:
-                # Move offers
-                result = db.execute(
-                    update(Offer).where(Offer.material_card_id == suffix_id).values(material_card_id=base_id)
-                )
-                offers_count = result.rowcount
-            else:
-                offers_count = db.query(Offer).filter(Offer.material_card_id == suffix_id).count()
-
-            if not dry_run:
-                # Move requirements
-                result = db.execute(
-                    update(Requirement)
-                    .where(Requirement.material_card_id == suffix_id)
-                    .values(material_card_id=base_id)
-                )
-                requirements_count = result.rowcount
-            else:
-                requirements_count = db.query(Requirement).filter(Requirement.material_card_id == suffix_id).count()
+            sightings_count = _move_rows(db, Sighting, suffix_id, base_id, dry_run)
+            offers_count = _move_rows(db, Offer, suffix_id, base_id, dry_run)
+            requirements_count = _move_rows(db, Requirement, suffix_id, base_id, dry_run)
 
             if not dry_run:
                 # Soft-delete the suffix card

--- a/scripts/migrate_sf_pool.py
+++ b/scripts/migrate_sf_pool.py
@@ -108,7 +108,7 @@ def migrate(dry_run: bool = True) -> dict:
                     discovery_source="salesforce_import",
                     discovery_batch_id=batch.id if batch else None,
                     import_priority=co.import_priority,
-                    historical_context=historical if historical else None,
+                    historical_context=historical or None,
                 )
                 db.add(pa)
 

--- a/scripts/reconstruct_001_baseline.py
+++ b/scripts/reconstruct_001_baseline.py
@@ -314,6 +314,20 @@ def parse_pg_dump(sql: str) -> ParseResult:
 # ── Python source emitters ─────────────────────────────────────────────
 
 
+def _cascade_kwargs(fk: ForeignKey) -> str:
+    """Render the trailing ``, ondelete=…, onupdate=…`` kwargs for an FK.
+
+    Cascade kwargs are emitted only when the parsed FK has them; default
+    ``NO ACTION`` is left implicit (no kwarg) to match alembic's convention.
+    """
+    extras = ""
+    if fk.ondelete:
+        extras += f", ondelete='{fk.ondelete}'"
+    if fk.onupdate:
+        extras += f", onupdate='{fk.onupdate}'"
+    return extras
+
+
 def render_op_create_table(t: Table) -> str:
     """Render op.create_table for a single table.
 
@@ -343,10 +357,7 @@ def render_op_create_table(t: Table) -> str:
         local = "[" + ", ".join(f"'{c}'" for c in fk.local_columns) + "]"
         ref = "[" + ", ".join(f"'{fk.referenced_table}.{c}'" for c in fk.referenced_columns) + "]"
         extras = f", name='{fk.name}'" if fk.name else ""
-        if fk.ondelete:
-            extras += f", ondelete='{fk.ondelete}'"
-        if fk.onupdate:
-            extras += f", onupdate='{fk.onupdate}'"
+        extras += _cascade_kwargs(fk)
         lines.append(f"    sa.ForeignKeyConstraint({local}, {ref}{extras}),")
     lines.append(")")
     return "\n".join(lines)
@@ -366,9 +377,7 @@ def render_op_create_index(ix: Index) -> str:
       reconstructed from the parsed parts. Alembic's create_index can't
       express partial indexes or per-column ordering, so we emit raw DDL.
     """
-    has_orderings = any(o is not None for o in ix.column_orderings)
-    has_where = ix.where_clause is not None
-    if not has_orderings and not has_where:
+    if not _is_complex_index(ix):
         cols = "[" + ", ".join(f"'{c}'" for c in ix.columns) + "]"
         return f"op.create_index('{ix.name}', '{ix.table}', {cols}, unique={ix.unique})"
 
@@ -407,11 +416,7 @@ def render_op_create_foreign_key(src_table: str, fk: ForeignKey) -> str:
     local = "[" + ", ".join(f"'{c}'" for c in fk.local_columns) + "]"
     remote = "[" + ", ".join(f"'{c}'" for c in fk.referenced_columns) + "]"
     name = f"'{fk.name}'" if fk.name else "None"
-    extras = ""
-    if fk.ondelete:
-        extras += f", ondelete='{fk.ondelete}'"
-    if fk.onupdate:
-        extras += f", onupdate='{fk.onupdate}'"
+    extras = _cascade_kwargs(fk)
     return f"op.create_foreign_key({name}, '{src_table}', '{fk.referenced_table}', {local}, {remote}{extras})"
 
 
@@ -526,7 +531,7 @@ engine = create_engine({dsn!r})
 Base.metadata.create_all(bind=engine)
 """
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(REPO_ROOT) + (os.pathsep + env.get("PYTHONPATH", "") if env.get("PYTHONPATH") else "")
+    env["PYTHONPATH"] = os.pathsep.join(p for p in (str(REPO_ROOT), env.get("PYTHONPATH")) if p)
     subprocess.run([sys.executable, "-c", script], check=True, env=env)
 
 

--- a/scripts/seed_test_data.py
+++ b/scripts/seed_test_data.py
@@ -415,7 +415,7 @@ def seed_requisitions(db, user, companies, sites, material_cards, vendor_cards):
     return requisitions, all_requirements, all_offers
 
 
-def seed_quotes(db, user, requisitions, requirements, offers, sites, *, now):
+def seed_quotes(db, user, requisitions, offers, sites, *, now):
     """Create quotes in every status."""
     quote_configs = [
         {"status": QuoteStatus.DRAFT, "req_idx": 5},
@@ -482,7 +482,7 @@ def seed_quotes(db, user, requisitions, requirements, offers, sites, *, now):
     return quotes
 
 
-def seed_buy_plans(db, user, quotes, requisitions, requirements, offers, *, now):
+def seed_buy_plans(db, user, quotes, offers, *, now):
     """Create buy plans in every status."""
     bp_configs = [
         {"status": BuyPlanStatus.DRAFT, "so_status": SOVerificationStatus.PENDING, "quote_idx": 0},
@@ -650,8 +650,8 @@ def main():
         vendor_cards = seed_vendor_cards(db)
         material_cards = seed_material_cards(db)
         requisitions, requirements, offers = seed_requisitions(db, user, companies, sites, material_cards, vendor_cards)
-        quotes = seed_quotes(db, user, requisitions, requirements, offers, sites, now=now)
-        seed_buy_plans(db, user, quotes, requisitions, requirements, offers, now=now)
+        quotes = seed_quotes(db, user, requisitions, offers, sites, now=now)
+        seed_buy_plans(db, user, quotes, offers, now=now)
         seed_excess_lists(db, user, companies, sites, vendor_cards)
 
         db.commit()

--- a/scripts/validate_001_against_chain.py
+++ b/scripts/validate_001_against_chain.py
@@ -201,16 +201,14 @@ def walk_migration_ops(model: SchemaModel, migration_paths: list[Path]) -> list[
                 col_name = _string_arg(col_node, 0) if isinstance(col_node, ast.Call) else None
                 if col_name:
                     model.add_column(table, col_name)
-            elif op_name == "drop_column":
+            elif op_name in ("drop_column", "alter_column"):
                 col = _string_arg(node, 1)
-                if col and not model.has_column(table, col):
+                if not col:
+                    continue
+                if not model.has_column(table, col):
                     gaps.append(Gap(path.name, op_name, f"{table}.{col}", f"column {col!r} not in {table!r}"))
-                elif col:
+                elif op_name == "drop_column":
                     model.drop_column(table, col)
-            elif op_name == "alter_column":
-                col = _string_arg(node, 1)
-                if col and not model.has_column(table, col):
-                    gaps.append(Gap(path.name, op_name, f"{table}.{col}", f"column {col!r} not in {table!r}"))
             # create_index / drop_index / create_foreign_key etc. only checked for table existence
     return gaps
 


### PR DESCRIPTION
Part of the codebase-wide simplification program (quality-only — no behavior changes, public APIs unchanged). One PR per module.

## Changes (`scripts`)
14 file(s) changed, 25 simplifications (6 file(s) already clean).

- **`backfill_material_card_ids.py`** — Replaced three copy-paste-with-variation backfill loops (Requirements/Sightings/Offers) with one parametrized _backfill_table helper invoked three times.
- **`backfill_oem_enrichment.py`** — Removed a pointless dict comprehension that copied `counts` before logging it.
- **`check_schema_matches_models.py`** — Consolidate Iterable import into the existing collections.abc line; Replace skip-flag + nested for/break in filter_allowlist with any(); Turn append-in-loop into a list comprehension in format_diffs.
- **`data_cleanup.py`** — Extracted module-level _reassign_fk() and _copy_missing_fields() helpers; Unified three near-identical 'unique-constraint move-or-delete' blocks in _merge_vendor_cards into one nested _move_or_delete(model, unique_attr); Made Phase 3 phone + name normalization and Phase 5 country/state normalization table-driven.
- **`enrich_from_sightings.py`** — Flattened a nested if in the manufacturer branch of enrich_card_from_sightings into a single combined guard.
- **`enrich_orchestrator.py`** — Folded the repeated `result_data is None or not isinstance(result_data, dict)` guard into `_parse_parts`, removing 3 copy-pasted validation branches; Extracted `_resumable_run(db, phase)` helper, replacing 3 duplicated in-flight-run lookups; Extracted `_phase_completed(db, phase)` helper, collapsing 5 multi-line phase-skip checks in run_pipeline to one-liners; Replaced manual dict-of-lists construction with `collections.defaultdict(list)` in phase_1_mine_sightings.
- **`enrich_specs_batch.py`** — Collapsed three near-identical __main__ async wrappers (submit_all/submit_one/apply) into one with_session helper plus three thin command bodies, removing 3x copy-pasted SessionLocal()/try/finally session boilerplate.
- **`frprp.py`** — Hoisted repeated content.splitlines() to one call per file in 5 scan functions; Removed redundant double has_indicator assignment in scan_loading_states; Extracted _rewrite_line helper to remove copy-paste-with-variation in apply_auto_fix.
- **`import_part_numbers.py`** — Wrapped the bare open(file_path, 'rb').read() in a `with` context manager to avoid leaking the file handle.
- **`merge_suffix_material_cards.py`** — Extracted the repeated update-or-count-per-table pattern into a _move_rows helper, replacing three ~9-line if/else dry-run blocks with three one-line calls.
- **`migrate_sf_pool.py`** — Simplified `historical if historical else None` to the equivalent `historical or None`.
- **`reconstruct_001_baseline.py`** — render_op_create_index now calls the existing _is_complex_index predicate instead of re-inlining the has_orderings/has_where check; Extracted duplicated ondelete/onupdate kwarg-building into a single _cascade_kwargs(fk) helper; Replaced convoluted nested-ternary PYTHONPATH build with a pathsep.join comprehension.
- **`seed_test_data.py`** — Removed 3 dead parameters threaded through internal seed helpers.
- **`validate_001_against_chain.py`** — Merged the near-identical drop_column and alter_column branches in walk_migration_ops.

_Recorded cross-file follow-ups:_
- `frprp.py`: Cross-file (noted, NOT changed): log() and run_cmd() in this script are duplicated privately in scripts/data_cleanup.
- `enrich_orchestrator.py`: CROSS-FILE: `_build_batch_requests`/`BATCH_SIZE`/`VALID_CATEGORIES` (enrich_batch.
- `data_cleanup.py`: Cross-file note (NOT applied, out of scope): the script's _merge_vendor_cards/_merge_companies duplicate FK-reassignment logic that ideally would live as reusable helpers in app/services or app/utils alongside the existing merge services, so admin endpoints, auto-dedup, and this script share one merge implementation.
- `migrate_sf_pool.py`: REUSE (cross-file, NOT applied): normalize_domain duplicates the private _clean_domain in app/enrichment_service.
- `enrich_from_sightings.py`: SIMPLIFICATION (not applied, exported-symbol rule): AUTHORIZED_SOURCES is module-level dead code — it is never referenced inside the file (sorting uses the per-sighting is_authorized boolean s[2], not a source-name lookup) and a repo-wide grep shows no importer.
- `enrich_from_sightings.py`: ALTITUDE (cross-file note, not applied): scripts/enrich_orchestrator.

## Verification
- ruff + ruff-format + docformatter + mypy clean (394 files)
- **Full suite: 16,563 passed, 35 skipped** (xdist, `TESTING=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)