### PR TITLE
Sightings vendor-row: pill-style actions + Send RFQ → Build RFQ

### DIFF
--- a/app/templates/htmx/partials/sightings/_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/_vendor_row.html
@@ -132,19 +132,23 @@
           {% endif %}
           {# Actions — always visible on the collapsed row; @click.stop keeps a button press from toggling expand #}
           {% if vs != 'blacklisted' and not is_unavailable %}
-          <span class="flex items-center gap-2">
+          {# Pill-styled action buttons (tiered emphasis): Build RFQ is the solid-brand
+             primary; Mark Unavail + Convert to offer are outline-pill secondaries. The
+             pill base + colors reuse the app's btn_primary/btn_secondary vocabulary so
+             these read as buttons, distinct from the soft-tinted status pills above. #}
+          <span class="flex items-center gap-1.5">
             <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/vendor-modal?requirement_ids={{ requirement.id }}&preselect={{ s.vendor_name|urlencode }}'})"
-                    class="text-[10px] text-brand-600 hover:text-brand-800 font-medium">
-              Send RFQ
+                    class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full transition-colors bg-brand-500 text-white hover:bg-brand-600">
+              Build RFQ
             </button>
             {# Opens the reason modal; on an advisory/restock row this doubles as the
                re-arm (the modal's upsert refreshes the suppression window). #}
             <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/{{ requirement.id }}/unavailable-form?vendor_name={{ s.vendor_name|urlencode }}'})"
-                    class="text-[10px] text-gray-400 hover:text-rose-500">
+                    class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full transition-colors bg-white text-gray-500 border border-gray-200 hover:bg-rose-50 hover:text-rose-600 hover:border-rose-200">
               Mark Unavail
             </button>
             <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/{{ requirement.id }}/offer-form?vendor_name={{ s.vendor_name|urlencode }}&unit_price={{ s.best_price or '' }}&qty={{ s.estimated_qty or '' }}&moq={{ s.min_moq or '' }}&lead_days={{ s.best_lead_time_days or '' }}'})"
-                    class="text-[10px] text-emerald-600 hover:text-emerald-800 font-medium">
+                    class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full transition-colors bg-white text-emerald-700 border border-emerald-200 hover:bg-emerald-50">
               Convert to offer
             </button>
           </span>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -483,7 +483,7 @@ crm.offers functions directly (no logic duplication) and re-render the panel:
   POST .../offers/{id}/mark-sold -> mark_offer_sold
   DELETE .../offers/{id}         -> delete_offer
 
-"Convert to offer" sits on the collapsed vendor row (next to Send RFQ / Mark
+"Convert to offer" sits on the collapsed vendor row (next to Build RFQ / Mark
 Unavail) and opens the modal prefilled from the VendorSightingSummary. The modal
 and the requisitions add-offer form share one field grid
 (offers/_offer_form_fields.html). Offer creation logs OFFER_CREATED, so converted/

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -608,7 +608,7 @@ class TestVendorRowThreeStates:
         assert "What we learned:" in body
         assert 'class="text-rose-600 font-medium"' in body
         # Action trio hidden
-        assert "Send RFQ" not in body
+        assert "Build RFQ" not in body
         assert "Mark Unavail" not in body
         assert "Convert to offer" not in body
 
@@ -650,7 +650,7 @@ class TestVendorRowThreeStates:
         assert "bg-rose-100 text-rose-700" in body  # Unavailable pill, not Contacted
         assert "We bought them" in body  # reason label renders
         assert "Mark available" in body  # state-1 action present
-        assert "Send RFQ" not in body  # action trio hidden
+        assert "Build RFQ" not in body  # action trio hidden
         assert "Mark Unavail" not in body
 
     def test_state2_expired_record_renders_advisory_hint_and_verify(self, client, db_session):
@@ -681,7 +681,7 @@ class TestVendorRowThreeStates:
         # Expanded grid History entry
         assert "History:" in body
         # Full action trio restored (Mark Unavail doubles as the re-arm)
-        assert "Send RFQ" in body
+        assert "Build RFQ" in body
         assert "Mark Unavail" in body
         assert "Convert to offer" in body
 
@@ -716,7 +716,7 @@ class TestVendorRowThreeStates:
         assert "History:" in body
         assert "Changed:" in body
         # Full action trio restored
-        assert "Send RFQ" in body
+        assert "Build RFQ" in body
         assert "Mark Unavail" in body
         assert "Convert to offer" in body
 
@@ -3738,7 +3738,7 @@ class TestSightingsVendorMatchedMpns:
 
 
 class TestSightingsVendorRowActions:
-    """Send RFQ / Mark Unavail actions live on the always-visible collapsed vendor row,
+    """Build RFQ / Mark Unavail actions live on the always-visible collapsed vendor row,
     not tucked inside the expandable detail (x-show="expanded")."""
 
     def _seed_vendor_row(self, db_session, status="open"):
@@ -3772,13 +3772,13 @@ class TestSightingsVendorRowActions:
         resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
         assert resp.status_code == 200
         body = resp.text
-        assert "Send RFQ" in body
+        assert "Build RFQ" in body
         assert "Mark Unavail" in body
         # The expandable detail is marked by x-show="expanded"; the actions must
         # appear earlier in the markup (i.e. on the always-visible row).
         expanded_marker = 'x-show="expanded"'
         assert expanded_marker in body
-        assert body.index("Send RFQ") < body.index(expanded_marker)
+        assert body.index("Build RFQ") < body.index(expanded_marker)
         assert body.index("Mark Unavail") < body.index(expanded_marker)
 
 


### PR DESCRIPTION
## What & why
On the sightings page, each vendor row's three actions (**Send RFQ** / **Mark Unavail** / **Convert to offer**) were rendered as tiny 10px gray text links buried in the row metadata — easy to miss and not obviously clickable. This promotes them to clear **pill buttons** and renames **Send RFQ → Build RFQ**.

## Design (tiered emphasis — matches the app's existing button vocabulary)
Reuses the `btn_primary`/`btn_secondary` color language so the actions read as buttons and stay visually distinct from the soft-tinted *status* pills sitting next to them on the same row:

| Action | Treatment |
|---|---|
| **Build RFQ** | solid-brand **primary** pill (`bg-brand-500 text-white hover:bg-brand-600`) |
| **Mark Unavail** | gray **outline** pill, hover → rose |
| **Convert to offer** | emerald **outline** pill |

Shared pill base: `inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full transition-colors`.

### Why "Build RFQ" (not Send)
The row button **opens the RFQ composer modal** — it doesn't send. The modal's actual send action keeps **"Send RFQ"/"Send Inquiry"**, so the rename is only on the composer-opener.

## Changes
- `app/templates/htmx/partials/sightings/_vendor_row.html` — pill classes + label rename (dispatch/HTMX logic unchanged)
- `tests/test_sightings_router.py` — update row-action assertions for the rename
- `docs/APP_MAP_INTERACTIONS.md` — update row-action label reference

## Verification
- ✅ Full local suite + `test_sightings_router.py`/`test_sightings_offers.py` (237) pass
- ✅ Tailwind build rebuilt; all new hover/color selectors confirmed emitted in the CSS bundle
- ✅ pre-commit clean (ruff, ruff-format, mypy, docformatter)
- ✅ Code-reviewed — no material issues; rename scope correct, Alpine quoting intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)