### PR TITLE
simplify(templates 1/6): extract macros for requisitions + quote_builder

### DIFF
--- a/app/templates/htmx/partials/quote_builder/_macros.html
+++ b/app/templates/htmx/partials/quote_builder/_macros.html
@@ -1,0 +1,22 @@
+{# quote_builder/_macros.html — Reusable Jinja macros for the quote builder modal.
+   Imported by: htmx/partials/quote_builder/modal.html
+   Depends on: brand palette / compact-table CSS, Alpine.js quoteBuilder component.
+
+   These macros emit byte-identical markup to the inline blocks they replaced; the
+   modal supplies the static x-data / Alpine bindings (treated as opaque values here).
+#}
+
+{# One Customer-Requirements field: a small uppercase label over a mono value.
+   `expr` is the opaque Alpine x-text expression (kept verbatim). When `emphasis`
+   is true the value uses the semibold variant (Qty Needed / Target Price). #}
+{%- macro spec_field(label, expr, emphasis=False) -%}
+<div>
+              <span class="text-[10px] text-gray-400 uppercase tracking-wide">{{ label }}</span>
+              <p class="text-sm font-mono {% if emphasis %}font-semibold {% endif %}text-gray-900" x-text="{{ expr | safe }}"></p>
+            </div>
+{%- endmacro -%}
+
+{# One keyboard <kbd> chip in the nav-hints footer. #}
+{%- macro kbd(key) -%}
+<kbd class="px-1 py-0.5 bg-gray-100 rounded text-[9px] font-mono border border-gray-200">{{ key }}</kbd>
+{%- endmacro -%}

--- a/app/templates/htmx/partials/quote_builder/modal.html
+++ b/app/templates/htmx/partials/quote_builder/modal.html
@@ -4,6 +4,7 @@
    Called by: quote_builder.py quote_builder_modal endpoint.
    Depends on: Alpine.js quoteBuilder component, brand palette, compact-table CSS.
 #}
+{%- import "htmx/partials/quote_builder/_macros.html" as qb %}
 
 <div class="flex flex-col h-full"
      x-data="quoteBuilder([], {{ req.id }}, {{ has_customer_site | tojson }}, '{{ requirement_ids }}', '{{ multi_req_ids | default("", true) }}')"
@@ -129,9 +130,9 @@
 
       {# Keyboard hints #}
       <div class="px-4 py-2 border-t border-brand-100 text-[10px] text-gray-400 flex gap-3 flex-shrink-0">
-        <span><kbd class="px-1 py-0.5 bg-gray-100 rounded text-[9px] font-mono border border-gray-200">j</kbd>/<kbd class="px-1 py-0.5 bg-gray-100 rounded text-[9px] font-mono border border-gray-200">k</kbd> Nav</span>
-        <span><kbd class="px-1 py-0.5 bg-gray-100 rounded text-[9px] font-mono border border-gray-200">1</kbd>-<kbd class="px-1 py-0.5 bg-gray-100 rounded text-[9px] font-mono border border-gray-200">9</kbd> Offer</span>
-        <span><kbd class="px-1 py-0.5 bg-gray-100 rounded text-[9px] font-mono border border-gray-200">Enter</kbd> Confirm</span>
+        <span>{{ qb.kbd("j") }}/{{ qb.kbd("k") }} Nav</span>
+        <span>{{ qb.kbd("1") }}-{{ qb.kbd("9") }} Offer</span>
+        <span>{{ qb.kbd("Enter") }} Confirm</span>
       </div>
     </div>
 
@@ -149,38 +150,14 @@
         <div class="bg-gray-50 rounded-lg border border-brand-100 px-4 py-3">
           <h3 class="text-[10px] font-semibold uppercase tracking-wider text-brand-400 mb-2">Customer Requirements</h3>
           <div class="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-1.5">
-            <div>
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">Qty Needed</span>
-              <p class="text-sm font-mono font-semibold text-gray-900" x-text="activeLine.target_qty?.toLocaleString() || '—'"></p>
-            </div>
-            <div>
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">Target Price</span>
-              <p class="text-sm font-mono font-semibold text-gray-900" x-text="activeLine.target_price ? '$' + activeLine.target_price.toFixed(4) : '—'"></p>
-            </div>
-            <div>
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">Date Codes</span>
-              <p class="text-sm font-mono text-gray-900" x-text="activeLine.date_codes || '—'"></p>
-            </div>
-            <div>
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">Condition</span>
-              <p class="text-sm font-mono text-gray-900" x-text="activeLine.condition || '—'"></p>
-            </div>
-            <div>
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">Packaging</span>
-              <p class="text-sm font-mono text-gray-900" x-text="activeLine.packaging || '—'"></p>
-            </div>
-            <div>
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">Firmware</span>
-              <p class="text-sm font-mono text-gray-900" x-text="activeLine.firmware || '—'"></p>
-            </div>
-            <div>
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">HW Codes</span>
-              <p class="text-sm font-mono text-gray-900" x-text="activeLine.hardware_codes || '—'"></p>
-            </div>
-            <div>
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">Customer PN</span>
-              <p class="text-sm font-mono text-gray-900" x-text="activeLine.customer_pn || '—'"></p>
-            </div>
+            {{ qb.spec_field("Qty Needed", "activeLine.target_qty?.toLocaleString() || '—'", emphasis=True) }}
+            {{ qb.spec_field("Target Price", "activeLine.target_price ? '$' + activeLine.target_price.toFixed(4) : '—'", emphasis=True) }}
+            {{ qb.spec_field("Date Codes", "activeLine.date_codes || '—'") }}
+            {{ qb.spec_field("Condition", "activeLine.condition || '—'") }}
+            {{ qb.spec_field("Packaging", "activeLine.packaging || '—'") }}
+            {{ qb.spec_field("Firmware", "activeLine.firmware || '—'") }}
+            {{ qb.spec_field("HW Codes", "activeLine.hardware_codes || '—'") }}
+            {{ qb.spec_field("Customer PN", "activeLine.customer_pn || '—'") }}
           </div>
           <template x-if="activeLine.sale_notes" x-cloak>
             <div class="mt-2 pt-2 border-t border-brand-100">

--- a/app/templates/htmx/partials/requisitions/_inline_field_form.html
+++ b/app/templates/htmx/partials/requisitions/_inline_field_form.html
@@ -1,0 +1,27 @@
+{# _inline_field_form.html — shared <form> chrome for inline_cell.html field editors.
+   Every inline editor (name/status/urgency/deadline/owner) wraps an identical
+   hx-patch form with the same Escape-restore <template> and field/context hidden
+   inputs; only the control inside differs. This macro renders that common chrome
+   and yields the per-field control via {% call %}.
+
+   Receives:
+     req         the Requisition being edited
+     field       field name (also the hidden "field" value)
+     context     'row' | 'header' | 'tab'
+     target_id   pre-computed target id (used when context != 'tab')
+     swap_style  hx-swap value
+     orig_display rendered original-display fragment for Escape restore
+   Used by: requisitions/inline_cell.html (one {% call %} per field).
+   Keep the form attributes byte-identical to the original inline_cell forms. #}
+{% macro field_form(req, field, context, target_id, swap_style, orig_display) -%}
+<form hx-patch="/v2/partials/requisitions/{{ req.id }}/inline"
+      hx-target="{{ '#' ~ target_id if context != 'tab' else 'this' }}"
+      hx-swap="{{ swap_style }}"
+      data-loading-disable
+      class="inline"
+      x-init="let t = $el.querySelector('template[data-orig]'); $el._origFrag = t.content;">
+  <template data-orig>{{ orig_display }}</template>
+  <input type="hidden" name="field" value="{{ field }}">
+  <input type="hidden" name="context" value="{{ context }}">
+  {{- caller() }}</form>
+{%- endmacro %}

--- a/app/templates/htmx/partials/requisitions/inline_cell.html
+++ b/app/templates/htmx/partials/requisitions/inline_cell.html
@@ -9,7 +9,8 @@
    Escape key: restores original cell content client-side (no network request).
    Uses _cancelled flag on the form to prevent @blur from submitting after Escape.
 #}
-{% from "htmx/partials/shared/_macros.html" import req_status_badge %}
+{% from "htmx/partials/shared/_macros.html" import req_status_badge -%}
+{% from "htmx/partials/requisitions/_inline_field_form.html" import field_form %}
 
 {% if context == "tab" %}
   {% set target_id = "this" %}
@@ -51,15 +52,7 @@
 {% set cancel_edit = "this.form._cancelled = true; this.form.parentElement.replaceChildren(this.form._origFrag.cloneNode(true))" %}
 
 {% if field == 'name' %}
-<form hx-patch="/v2/partials/requisitions/{{ req.id }}/inline"
-      hx-target="{{ '#' ~ target_id if context != 'tab' else 'this' }}"
-      hx-swap="{{ swap_style }}"
-      data-loading-disable
-      class="inline"
-      x-init="let t = $el.querySelector('template[data-orig]'); $el._origFrag = t.content;">
-  <template data-orig>{{ orig_display }}</template>
-  <input type="hidden" name="field" value="name">
-  <input type="hidden" name="context" value="{{ context }}">
+{% call field_form(req, 'name', context, target_id, swap_style, orig_display) %}
   <input aria-label="Requisition name" type="text" name="value" value="{{ req.name }}"
          class="w-full px-2 py-1 border border-brand-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 {{ 'text-2xl font-bold' if context == 'header' else '' }}"
          autofocus
@@ -67,18 +60,10 @@
          @blur="if (!$el.form._cancelled) $el.form.requestSubmit()"
          @keydown.enter.prevent="$el.form.requestSubmit()"
          @keydown.escape.prevent="{{ cancel_edit }}">
-</form>
+{% endcall %}
 
 {% elif field == 'status' %}
-<form hx-patch="/v2/partials/requisitions/{{ req.id }}/inline"
-      hx-target="{{ '#' ~ target_id if context != 'tab' else 'this' }}"
-      hx-swap="{{ swap_style }}"
-      data-loading-disable
-      class="inline"
-      x-init="let t = $el.querySelector('template[data-orig]'); $el._origFrag = t.content;">
-  <template data-orig>{{ orig_display }}</template>
-  <input type="hidden" name="field" value="status">
-  <input type="hidden" name="context" value="{{ context }}">
+{% call field_form(req, 'status', context, target_id, swap_style, orig_display) %}
   <select name="value"
           class="px-2 py-1 border border-brand-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
           autofocus
@@ -90,18 +75,10 @@
     <option value="{{ s }}" {{ 'selected' if req.status == s else '' }}>{{ s|capitalize }}</option>
     {% endfor %}
   </select>
-</form>
+{% endcall %}
 
 {% elif field == 'urgency' %}
-<form hx-patch="/v2/partials/requisitions/{{ req.id }}/inline"
-      hx-target="{{ '#' ~ target_id if context != 'tab' else 'this' }}"
-      hx-swap="{{ swap_style }}"
-      data-loading-disable
-      class="inline"
-      x-init="let t = $el.querySelector('template[data-orig]'); $el._origFrag = t.content;">
-  <template data-orig>{{ orig_display }}</template>
-  <input type="hidden" name="field" value="urgency">
-  <input type="hidden" name="context" value="{{ context }}">
+{% call field_form(req, 'urgency', context, target_id, swap_style, orig_display) %}
   <select name="value"
           class="px-2 py-1 border border-brand-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
           autofocus
@@ -113,18 +90,10 @@
     <option value="{{ u }}" {{ 'selected' if req.urgency == u else '' }}>{{ u|capitalize }}</option>
     {% endfor %}
   </select>
-</form>
+{% endcall %}
 
 {% elif field == 'deadline' %}
-<form hx-patch="/v2/partials/requisitions/{{ req.id }}/inline"
-      hx-target="{{ '#' ~ target_id if context != 'tab' else 'this' }}"
-      hx-swap="{{ swap_style }}"
-      data-loading-disable
-      class="inline"
-      x-init="let t = $el.querySelector('template[data-orig]'); $el._origFrag = t.content;">
-  <template data-orig>{{ orig_display }}</template>
-  <input type="hidden" name="field" value="deadline">
-  <input type="hidden" name="context" value="{{ context }}">
+{% call field_form(req, 'deadline', context, target_id, swap_style, orig_display) %}
   <input aria-label="Deadline date" type="date" name="value"
          value="{{ req.deadline if req.deadline and req.deadline != 'ASAP' else '' }}"
          class="px-2 py-1 border border-brand-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
@@ -133,18 +102,10 @@
          @change="$el.form.requestSubmit()"
          @blur="if (!$el.form._cancelled) $el.form.requestSubmit()"
          @keydown.escape.prevent="{{ cancel_edit }}">
-</form>
+{% endcall %}
 
 {% elif field == 'owner' %}
-<form hx-patch="/v2/partials/requisitions/{{ req.id }}/inline"
-      hx-target="{{ '#' ~ target_id if context != 'tab' else 'this' }}"
-      hx-swap="{{ swap_style }}"
-      data-loading-disable
-      class="inline"
-      x-init="let t = $el.querySelector('template[data-orig]'); $el._origFrag = t.content;">
-  <template data-orig>{{ orig_display }}</template>
-  <input type="hidden" name="field" value="owner">
-  <input type="hidden" name="context" value="{{ context }}">
+{% call field_form(req, 'owner', context, target_id, swap_style, orig_display) %}
   <select name="value"
           class="px-2 py-1 border border-brand-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
           autofocus
@@ -156,5 +117,5 @@
     <option value="{{ u.id }}" {{ 'selected' if req.created_by == u.id else '' }}>{{ u.name or u.email }}</option>
     {% endfor %}
   </select>
-</form>
+{% endcall %}
 {% endif %}

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -119,7 +119,7 @@ _REQ_ID_HEADERED_SIGHTINGS_PARTIALS = (
 # strings) MUST use a single-quoted attribute (or a JS Alpine.data factory). Keyed (file, line
 # of the attribute's opening). Do NOT add a string/array site here — fix the call site instead.
 _TOJSON_IN_DOUBLE_QUOTED_ALPINE_ALLOWLIST: set[tuple[str, int]] = {
-    ("app/templates/htmx/partials/quote_builder/modal.html", 9),  # has_customer_site|tojson -> true/false
+    ("app/templates/htmx/partials/quote_builder/modal.html", 10),  # has_customer_site|tojson -> true/false
     ("app/templates/htmx/partials/requisitions/rfq_compose.html", 44),  # vendors|map(id)|list|tojson -> [1,2,3]
     ("app/templates/requisitions2/_table.html", 65),  # requisitions|map(id)|list|tojson -> [1,2,3]
 }


### PR DESCRIPTION
Part of the codebase-wide simplification program — **templates wave (1/6)**, full structural pass (quality-only; rendered output preserved).

## What changed
- **`requisitions/inline_cell.html`** — 5 near-identical inline-edit `<form>` blocks → one `field_form` macro (new **`_inline_field_form.html`**).
- **`quote_builder/modal.html`** — 8 spec rows + 5 `<kbd>` chips → `qb.spec_field` / `qb.kbd` macros (new **`_macros.html`**).

No HTMX (`hx-*`) / Alpine (`x-data`/`@`/`:`) attribute values were altered; `partials/shared` untouched. The agents verified **byte-identical rendered output** via render-diff against HEAD (45 field×context×fixture combos for inline_cell; 3 context variants for modal).

## One test co-change (necessary, not drift)
- **`tests/test_static_analysis.py`** — the tojson-in-double-quoted-Alpine guard is keyed by `(file, line)`. The new macro `import` shifted `modal.html`'s `x-data` (a **safe bool** `has_customer_site|tojson`, already allowlisted) from line 9 → 10, so I bumped that one allowlist line number. The guard still flags any **new** string/array violation.

## Verification
- Every template parses via the app Jinja2 env
- **Full suite: 16,5xx passed** after the allowlist line bump (the sole failure was this line-shifted static guard, now green)

⚠️ No automated gate covers visual/interactive rendering — recommend a quick visual smoke of the requisition inline-edit cells and the quote-builder modal before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)