### PR TITLE
simplify(templates 5/6): extract macros (sightings/parts/prospecting/offers)

### DIFF
--- a/app/templates/htmx/partials/offers/_field_macros.html
+++ b/app/templates/htmx/partials/offers/_field_macros.html
@@ -1,0 +1,14 @@
+{# _field_macros.html — shared input widgets for the offer field grid.
+   Called by: offers/_offer_form_fields.html.
+   The macros emit the exact same markup the grid used to repeat inline; keep the
+   input name= attributes stable — both offer POST handlers read inputs by name. #}
+
+{# Plain optional text input (label + text box pre-filled from prefill dict `p`). #}
+{%- macro text_field(label, name, placeholder, p) -%}
+<div>
+    <label class="block text-xs text-gray-500 mb-1">{{ label }}</label>
+    <input type="text" name="{{ name }}" value="{{ p.get(name, '') }}"
+           class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
+           placeholder="{{ placeholder }}">
+  </div>
+{%- endmacro -%}

--- a/app/templates/htmx/partials/offers/_offer_form_fields.html
+++ b/app/templates/htmx/partials/offers/_offer_form_fields.html
@@ -4,6 +4,7 @@
      mpn_default  fallback MPN when prefill has none (used by the sightings modal)
    Used by: requisitions/add_offer_form.html, sightings/offer_form_modal.html.
    Keep the input name= attributes stable — both POST handlers read them by name. #}
+{% from "htmx/partials/offers/_field_macros.html" import text_field -%}
 {% set p = prefill or {} %}
 
 {# Row 1: Vendor Name, MPN, Qty Available, Unit Price #}
@@ -36,24 +37,9 @@
 
 {# Row 2: Manufacturer, Lead Time, Date Code, Condition #}
 <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-  <div>
-    <label class="block text-xs text-gray-500 mb-1">Manufacturer</label>
-    <input type="text" name="manufacturer" value="{{ p.get('manufacturer', '') }}"
-           class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
-           placeholder="e.g. Texas Instruments">
-  </div>
-  <div>
-    <label class="block text-xs text-gray-500 mb-1">Lead Time</label>
-    <input type="text" name="lead_time" value="{{ p.get('lead_time', '') }}"
-           class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
-           placeholder="2-3 weeks">
-  </div>
-  <div>
-    <label class="block text-xs text-gray-500 mb-1">Date Code</label>
-    <input type="text" name="date_code" value="{{ p.get('date_code', '') }}"
-           class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
-           placeholder="2025+">
-  </div>
+  {{ text_field('Manufacturer', 'manufacturer', 'e.g. Texas Instruments', p) }}
+  {{ text_field('Lead Time', 'lead_time', '2-3 weeks', p) }}
+  {{ text_field('Date Code', 'date_code', '2025+', p) }}
   <div>
     <label class="block text-xs text-gray-500 mb-1">Condition</label>
     <select name="condition" class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
@@ -86,34 +72,14 @@
            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
            placeholder="e.g. Tape & Reel">
   </div>
-  <div>
-    <label class="block text-xs text-gray-500 mb-1">Firmware</label>
-    <input type="text" name="firmware" value="{{ p.get('firmware', '') }}"
-           class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
-           placeholder="Rev / version">
-  </div>
+  {{ text_field('Firmware', 'firmware', 'Rev / version', p) }}
 </div>
 
 {# Row 4: Hardware Code, Warranty, Country of Origin, Valid Until #}
 <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-  <div>
-    <label class="block text-xs text-gray-500 mb-1">Hardware Code</label>
-    <input type="text" name="hardware_code" value="{{ p.get('hardware_code', '') }}"
-           class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
-           placeholder="HW rev">
-  </div>
-  <div>
-    <label class="block text-xs text-gray-500 mb-1">Warranty</label>
-    <input type="text" name="warranty" value="{{ p.get('warranty', '') }}"
-           class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
-           placeholder="e.g. 1 year">
-  </div>
-  <div>
-    <label class="block text-xs text-gray-500 mb-1">Country of Origin</label>
-    <input type="text" name="country_of_origin" value="{{ p.get('country_of_origin', '') }}"
-           class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
-           placeholder="e.g. US, CN">
-  </div>
+  {{ text_field('Hardware Code', 'hardware_code', 'HW rev', p) }}
+  {{ text_field('Warranty', 'warranty', 'e.g. 1 year', p) }}
+  {{ text_field('Country of Origin', 'country_of_origin', 'e.g. US, CN', p) }}
   <div>
     <label class="block text-xs text-gray-500 mb-1">Valid Until</label>
     <input type="date" name="valid_until" value="{{ p.get('valid_until', '') }}"

--- a/app/templates/htmx/partials/parts/_macros.html
+++ b/app/templates/htmx/partials/parts/_macros.html
@@ -1,0 +1,15 @@
+{# parts/_macros.html — Macros local to the parts split-workspace cluster.
+   Called by: parts/list.html (and other parts/* partials that share these patterns).
+   Depends on: HTMX (inline click-to-edit cell contract).
+#}
+
+{# Inline-editable table cell: clicking swaps in the matching cell/edit fragment.
+   `field` drives the stable id (cell-{field}-{req_id}) and the edit endpoint;
+   the cell's rendered value is supplied by the {% call %} body. #}
+{% macro edit_cell(req_id, field, title) %}<td id="cell-{{ field }}-{{ req_id }}" @click.stop
+                    hx-get="/v2/partials/parts/{{ req_id }}/cell/edit/{{ field }}"
+                    hx-target="#cell-{{ field }}-{{ req_id }}" hx-swap="outerHTML"
+                    class="cursor-pointer hover:bg-brand-50 transition-colors"
+                    title="{{ title }}">
+                  {{ caller() }}
+                </td>{% endmacro %}

--- a/app/templates/htmx/partials/parts/list.html
+++ b/app/templates/htmx/partials/parts/list.html
@@ -82,7 +82,7 @@
   </div>
 
   {% if requirements %}
-  {% from "htmx/partials/shared/_mpn_chips.html" import mpn_chips %}
+  {% from "htmx/partials/shared/_mpn_chips.html" import mpn_chips %}{% from "htmx/partials/parts/_macros.html" import edit_cell %}
   <div class="top-scroll-content flex-1 min-h-0" id="left-table-content">
       <table class="compact-table">
         <thead>
@@ -145,29 +145,11 @@
               {% if col_key == 'status' %}
                 {# Editable cell — own <td> with inline edit attributes #}
                 {% from "htmx/partials/shared/_macros.html" import status_badge %}
-                <td id="cell-sourcing_status-{{ req.id }}" @click.stop
-                    hx-get="/v2/partials/parts/{{ req.id }}/cell/edit/sourcing_status"
-                    hx-target="#cell-sourcing_status-{{ req.id }}" hx-swap="outerHTML"
-                    class="cursor-pointer hover:bg-brand-50 transition-colors"
-                    title="Click to edit status">
-                  {{ status_badge(req.sourcing_status or 'open') }}
-                </td>
+                {% call edit_cell(req.id, 'sourcing_status', 'Click to edit status') %}{{ status_badge(req.sourcing_status or 'open') }}{% endcall %}
               {% elif col_key == 'qty' %}
-                <td id="cell-target_qty-{{ req.id }}" @click.stop
-                    hx-get="/v2/partials/parts/{{ req.id }}/cell/edit/target_qty"
-                    hx-target="#cell-target_qty-{{ req.id }}" hx-swap="outerHTML"
-                    class="cursor-pointer hover:bg-brand-50 transition-colors"
-                    title="Click to edit qty">
-                  {{ '{:,}'.format(req.target_qty) if req.target_qty else '—' }}
-                </td>
+                {% call edit_cell(req.id, 'target_qty', 'Click to edit qty') %}{{ '{:,}'.format(req.target_qty) if req.target_qty else '—' }}{% endcall %}
               {% elif col_key == 'target_price' %}
-                <td id="cell-target_price-{{ req.id }}" @click.stop
-                    hx-get="/v2/partials/parts/{{ req.id }}/cell/edit/target_price"
-                    hx-target="#cell-target_price-{{ req.id }}" hx-swap="outerHTML"
-                    class="cursor-pointer hover:bg-brand-50 transition-colors"
-                    title="Click to edit price">
-                  {{ '${:,.4f}'.format(req.target_price) if req.target_price else '—' }}
-                </td>
+                {% call edit_cell(req.id, 'target_price', 'Click to edit price') %}{{ '${:,.4f}'.format(req.target_price) if req.target_price else '—' }}{% endcall %}
               {% else %}
                 {# Non-editable cells #}
                 <td{% if col_key in ('requisition', 'customer', 'owner') %} class="td-label"{% endif %}>

--- a/app/templates/htmx/partials/prospecting/_card.html
+++ b/app/templates/htmx/partials/prospecting/_card.html
@@ -3,7 +3,7 @@
   Receives: prospect (ProspectAccount ORM object).
   Called by: prospecting/list.html (loop include), claim/dismiss endpoints (OOB swap).
   Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette.
-#}
+#}{% import "htmx/partials/prospecting/_macros.html" as score %}
 {% set prospect_status_colors = {
   'suggested': 'bg-brand-100 text-brand-600',
   'claimed': 'bg-emerald-50 text-emerald-700',
@@ -36,10 +36,10 @@
       {% set fit = prospect.fit_score or 0 %}
       <div class="flex items-center justify-between text-xs mb-0.5">
         <span class="text-gray-500">Fit</span>
-        <span class="font-medium {% if fit >= 70 %}text-emerald-600{% elif fit >= 40 %}text-amber-600{% else %}text-rose-600{% endif %}">{{ fit }}%</span>
+        <span class="font-medium {{ score.score_text_color(fit) }}">{{ fit }}%</span>
       </div>
       <div class="w-full h-1.5 bg-gray-200 rounded-full overflow-hidden">
-        <div class="h-full rounded-full transition-all {% if fit >= 70 %}bg-emerald-500{% elif fit >= 40 %}bg-amber-500{% else %}bg-rose-500{% endif %}"
+        <div class="h-full rounded-full transition-all {{ score.score_bar_color(fit) }}"
              style="width: {{ fit }}%"></div>
       </div>
     </div>
@@ -49,10 +49,10 @@
       {% set ready = prospect.readiness_score or 0 %}
       <div class="flex items-center justify-between text-xs mb-0.5">
         <span class="text-gray-500">Readiness</span>
-        <span class="font-medium {% if ready >= 70 %}text-emerald-600{% elif ready >= 40 %}text-amber-600{% else %}text-rose-600{% endif %}">{{ ready }}%</span>
+        <span class="font-medium {{ score.score_text_color(ready) }}">{{ ready }}%</span>
       </div>
       <div class="w-full h-1.5 bg-gray-200 rounded-full overflow-hidden">
-        <div class="h-full rounded-full transition-all {% if ready >= 70 %}bg-emerald-500{% elif ready >= 40 %}bg-amber-500{% else %}bg-rose-500{% endif %}"
+        <div class="h-full rounded-full transition-all {{ score.score_bar_color(ready) }}"
              style="width: {{ ready }}%"></div>
       </div>
     </div>

--- a/app/templates/htmx/partials/prospecting/_macros.html
+++ b/app/templates/htmx/partials/prospecting/_macros.html
@@ -1,0 +1,19 @@
+{#
+  prospecting/_macros.html — Shared Jinja macros for the prospecting cluster.
+  Called by: prospecting/_card.html, prospecting/detail.html (import).
+  Depends on: Tailwind CSS with brand palette.
+
+  These macros encapsulate copy-pasted score/threshold markup so the card and
+  detail templates stay in sync. Each macro emits output byte-identical to the
+  inline markup it replaced.
+#}
+
+{# Tailwind text-color class for a 0-100 score (>=70 good, >=40 warn, else bad). #}
+{%- macro score_text_color(score) -%}
+{% if score >= 70 %}text-emerald-600{% elif score >= 40 %}text-amber-600{% else %}text-rose-600{% endif %}
+{%- endmacro -%}
+
+{# Tailwind bg-color class for a 0-100 score progress-bar fill. #}
+{%- macro score_bar_color(score) -%}
+{% if score >= 70 %}bg-emerald-500{% elif score >= 40 %}bg-amber-500{% else %}bg-rose-500{% endif %}
+{%- endmacro -%}

--- a/app/templates/htmx/partials/prospecting/detail.html
+++ b/app/templates/htmx/partials/prospecting/detail.html
@@ -3,7 +3,7 @@
   Receives: prospect (ProspectAccount ORM), enrichment (dict), warm_intro (dict).
   Called by: htmx_views.py prospecting_detail_partial endpoint.
   Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette.
-#}
+#}{% import "htmx/partials/prospecting/_macros.html" as score %}
 
 <div class="max-w-7xl mx-auto">
 
@@ -91,11 +91,11 @@
     <div class="bg-white border border-brand-200 rounded-lg p-6">
       <div class="text-sm font-medium text-gray-500 mb-2">Fit Score</div>
       {% set fit = prospect.fit_score or 0 %}
-      <div class="text-3xl font-bold {% if fit >= 70 %}text-emerald-600{% elif fit >= 40 %}text-amber-600{% else %}text-rose-600{% endif %}">
+      <div class="text-3xl font-bold {{ score.score_text_color(fit) }}">
         {{ fit }}%
       </div>
       <div class="mt-3 w-full h-2.5 bg-gray-200 rounded-full overflow-hidden">
-        <div class="h-full rounded-full transition-all {% if fit >= 70 %}bg-emerald-500{% elif fit >= 40 %}bg-amber-500{% else %}bg-rose-500{% endif %}"
+        <div class="h-full rounded-full transition-all {{ score.score_bar_color(fit) }}"
              style="width: {{ fit }}%"></div>
       </div>
       {% if prospect.fit_reasoning %}
@@ -107,11 +107,11 @@
     <div class="bg-white border border-brand-200 rounded-lg p-6">
       <div class="text-sm font-medium text-gray-500 mb-2">Readiness Score</div>
       {% set ready = prospect.readiness_score or 0 %}
-      <div class="text-3xl font-bold {% if ready >= 70 %}text-emerald-600{% elif ready >= 40 %}text-amber-600{% else %}text-rose-600{% endif %}">
+      <div class="text-3xl font-bold {{ score.score_text_color(ready) }}">
         {{ ready }}%
       </div>
       <div class="mt-3 w-full h-2.5 bg-gray-200 rounded-full overflow-hidden">
-        <div class="h-full rounded-full transition-all {% if ready >= 70 %}bg-emerald-500{% elif ready >= 40 %}bg-amber-500{% else %}bg-rose-500{% endif %}"
+        <div class="h-full rounded-full transition-all {{ score.score_bar_color(ready) }}"
              style="width: {{ ready }}%"></div>
       </div>
       {% if prospect.readiness_signals %}

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -72,8 +72,8 @@ def test_htmx_ajax_calls_have_indicator():
         ("app/templates/htmx/partials/parts/list.html", 11),
         ("app/templates/htmx/partials/parts/list.html", 12),
         ("app/templates/htmx/partials/parts/list.html", 138),
-        ("app/templates/htmx/partials/parts/list.html", 295),
-        ("app/templates/htmx/partials/parts/list.html", 342),
+        ("app/templates/htmx/partials/parts/list.html", 277),
+        ("app/templates/htmx/partials/parts/list.html", 324),
         ("app/templates/htmx/partials/parts/tabs/req_details.html", 209),
     }
 


### PR DESCRIPTION
Part of the codebase-wide simplification program — **templates wave (5/6)**, full structural pass (quality-only; rendered output preserved).

## What changed
Extracted repeated markup into Jinja macros/partials within the sightings, parts, prospecting, and offers clusters. **No HTMX/Alpine attribute values altered**; `partials/shared` untouched.

New partials:
- `app/templates/htmx/partials/offers/_field_macros.html`
- `app/templates/htmx/partials/parts/_macros.html`
- `app/templates/htmx/partials/prospecting/_macros.html`

## One test co-change (necessary, not drift)
- **`tests/test_static_analysis.py`** — bumped the line-keyed *htmx-ajax-indicator* allowlist for `parts/list.html` (295→277, 342→324). The macro extraction removed ~18 lines above two **already-allowlisted** imperative `htmx.ajax` call sites, shifting them up. The guard still flags any new indicator-less call.

## Verification
- Every template parses via the app Jinja2 env
- **Full suite green** after the allowlist line bumps (sole failure was the line-shifted static guard)

⚠️ No automated gate covers visual/interactive rendering — recommend a visual smoke of sightings/parts pages before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)