### PR TITLE
feat(enrich): harvest connector description + structured fields (enrichment Approach A #1)

### DIFF
--- a/alembic/versions/096_spec_provenance.py
+++ b/alembic/versions/096_spec_provenance.py
@@ -65,6 +65,7 @@ _SOURCE_TIER_SQL_CASE = (
     "WHEN 'mpn_decode' THEN 85 "
     "WHEN 'fru_matrix_decode' THEN 84 "
     "WHEN 'partsurfer_desc' THEN 84 "
+    "WHEN 'connector_desc' THEN 84 "
     "WHEN 'desc_parse' THEN 83 "
     "WHEN 'fru_desc_parse' THEN 82 "
     "WHEN 'partsurfer' THEN 80 "

--- a/app/config.py
+++ b/app/config.py
@@ -136,6 +136,7 @@ class Settings(BaseSettings):
     # uncategorized HP spares; cheap, free, robots-allowed. Values arbitrate through the F1
     # ladder at partsurfer_desc (tier 84). See app/services/enrichment_worker/partsurfer_resolver.
     partsurfer_desc_enabled: bool = True
+    connector_desc_harvest_enabled: bool = True
     # Cap on live PartSurfer fetches per batch (each is a polite 1-req/2s GET — the worker
     # paces them). Keeps a batch's wall-time bounded; uncategorized HP cards drain over batches.
     partsurfer_fetch_per_batch: int = 5

--- a/app/services/desc_extractor/_common.py
+++ b/app/services/desc_extractor/_common.py
@@ -69,6 +69,12 @@ DESC_CONFIDENCE = 0.90  # deterministic token grammar. Arbitration is by the F1 
 PARTSURFER_DESC_SOURCE = "partsurfer_desc"
 PARTSURFER_DESC_CONFIDENCE = 0.90
 
+# Distributor-connector description: the same desc grammar run over a DigiKey/Mouser/
+# element14/OEMSecrets/Nexar product description we ALREADY fetch (not the card's own).
+# Outranks desc_parse (spec_tiers.SOURCE_TIER: connector_desc=84 > desc_parse 83).
+CONNECTOR_DESC_SOURCE = "connector_desc"
+CONNECTOR_DESC_CONFIDENCE = 0.90
+
 # The only commodities the extractor fills specs for — single source of truth shared
 # by extract_desc (routing) and writer.py (card eligibility / the spec'd _HANDLED
 # set). The PSU-vs-CPU wattage guard is structural: only extract_psu can emit the

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -107,6 +107,12 @@ async def _try_connector_config(config: dict, mpn: str) -> dict | None:
                     "category": (r.get("category") or r.get("description") or "").strip()[:200] or None,
                     "source": config["name"],
                     "confidence": config["confidence"],
+                    # Harvest fields — previously discarded (see connector-desc-harvest spec).
+                    "description": (r.get("description") or "").strip() or None,
+                    "package_type": (r.get("package_type") or "").strip() or None,
+                    "pin_count": r.get("pin_count"),
+                    "rohs_status": (r.get("rohs_status") or "").strip() or None,
+                    "datasheet_url": (r.get("datasheet_url") or "").strip() or None,
                 }
         return None
     except asyncio.TimeoutError:

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -226,7 +226,15 @@ def _apply_enrichment_to_card(card: MaterialCard, enrichment: dict, db: Session)
     from app.config import settings
 
     if settings.connector_desc_harvest_enabled:
-        _harvest_connector_enrichment(card, enrichment, ladder_source, db)
+        # Best-effort: harvest is bonus (manufacturer/category/tags above are already
+        # applied). A failure here — e.g. record_spec/categorize_and_record raising
+        # IntegrityError/DataError, which re-raise out of their own per-card SAVEPOINTs
+        # (leaving the outer txn usable) — must NOT propagate and abort the caller's
+        # batch loop (enrich_batch._process_one is unguarded). Log this card and move on.
+        try:
+            _harvest_connector_enrichment(card, enrichment, ladder_source, db)
+        except Exception:
+            logger.exception("connector-desc harvest failed for card_id={}", card.id)
 
 
 # Connector structured fields → seeded facet keys. lifecycle_status is intentionally

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -223,6 +223,56 @@ def _apply_enrichment_to_card(card: MaterialCard, enrichment: dict, db: Session)
     if tags_to_apply:
         tag_material_card(card.id, tags_to_apply, db)
 
+    from app.config import settings
+
+    if settings.connector_desc_harvest_enabled:
+        _harvest_connector_enrichment(card, enrichment, ladder_source, db)
+
+
+# Connector structured fields → seeded facet keys. lifecycle_status is intentionally
+# omitted: no commodity schema defines a `lifecycle` facet (confirmed against
+# commodity_seeds.json), so it would only ever no-op.
+_CONNECTOR_FIELD_TO_FACET = {"package_type": "package", "pin_count": "pin_count", "rohs_status": "rohs"}
+
+
+def _harvest_connector_enrichment(card: MaterialCard, enrichment: dict, ladder_source: str, db: Session) -> None:
+    """Record the description + structured fields the connector returned (previously
+    discarded).
+
+    Description → categorize_and_record (categorizes an uncategorized card + fills
+    facets) at connector_desc / tier 84. Structured fields → record_spec at the
+    connector's vendor-API tier (90) — only stick where the commodity schema defines the
+    key. datasheet_url → card column. All writes arbitrated by the F1 ladder; each in a
+    per-card SAVEPOINT.
+    """
+    from app.services.desc_extractor._common import CONNECTOR_DESC_CONFIDENCE, CONNECTOR_DESC_SOURCE
+    from app.services.desc_extractor.writer import categorize_and_record
+    from app.services.spec_write_service import load_schema_cache, record_spec
+
+    datasheet_url = (enrichment.get("datasheet_url") or "").strip()
+    if datasheet_url and not card.datasheet_url:
+        card.datasheet_url = datasheet_url[:1000]
+
+    description = (enrichment.get("description") or "").strip()
+    if description:
+        # Fill-only: categorizes only if still uncategorized; always fills facets via the ladder.
+        categorize_and_record(
+            db, card, description=description, source=CONNECTOR_DESC_SOURCE, confidence=CONNECTOR_DESC_CONFIDENCE
+        )
+
+    category = (card.category or "").lower().strip()
+    if not category:
+        return  # no schema without a category — structured facets can't be validated
+    schema_cache = load_schema_cache(db, category)
+    with db.begin_nested():
+        for field, facet_key in _CONNECTOR_FIELD_TO_FACET.items():
+            value = enrichment.get(field)
+            if value is None or value == "":
+                continue
+            record_spec(
+                db, int(card.id), facet_key, value, source=ladder_source, confidence=0.95, schema_cache=schema_cache
+            )
+
 
 def boost_confidence_internal(db: Session, batch_size: int = 5000) -> dict:
     """Boost confidence for AI tags confirmed by internal data (no API calls).

--- a/app/services/spec_tiers.py
+++ b/app/services/spec_tiers.py
@@ -80,6 +80,8 @@ SOURCE_TIER: dict[str, int] = {
     # desc_parse (83); still a description-parse, so it loses to the deterministic
     # decoders (mpn_decode 85). Ties fru_matrix_decode (84) — different vendors, the tie
     # is not load-bearing.
+    "connector_desc": 84,  # distributor (DigiKey/Mouser/…) description parsed by the desc grammar:
+    # more authoritative than the card's own desc_parse (83), below the deterministic decoders (85).
     "partsurfer_desc": 84,
     "desc_parse": 83,
     "fru_desc_parse": 82,
@@ -714,8 +716,8 @@ def _set_brand_or_maker(
     write: bool,
 ) -> bool:
     """Shared body of set_brand/set_manufacturer: reject empties + garbage fragments
-    (is_garbage_brand_value — unbalanced-paren / single-char shapes, logged at
-    WARNING), normalize, ladder.
+    (is_garbage_brand_value — unbalanced-paren / single-char shapes, logged at WARNING),
+    normalize, ladder.
 
     PRECONDITION: *card* should be session-attached — the alias lookup derives its DB
     session via ``Session.object_session(card)``. A detached/transient card cannot be

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1493,7 +1493,7 @@ owns arbitration in one place:
        MaterialCardAudit action="categorized" per card) and at ingest time by
        source_ingest/clean.py (same grammar, fallback when the source carries no
        mappable Commodity_Code__c). The F1 ladder (fru_desc_parse 82 < desc_parse
-       83 < partsurfer_desc 84 < fru_matrix_decode 84 < mpn_decode 85 < vendor 90)
+       83 < partsurfer_desc 84 = connector_desc 84 < fru_matrix_decode 84 < mpn_decode 85 < vendor 90)
        keeps decode/vendor
        values authoritative and the card's OWN description above its FRU-linked
        prose — no per-writer pre-gate. The phase-2/3 commodities have no MPN
@@ -1526,6 +1526,22 @@ owns arbitration in one place:
        (83) — OEM catalog text beats the card's own desc — but loses to the
        deterministic decoders (mpn_decode 85); it ties fru_matrix_decode (84, a
        different vendor — tie not load-bearing).
+    3.6. enrichment.py::_apply_enrichment_to_card → _harvest_connector_enrichment    —
+       connector-description harvest (no new network — harvests data the connector
+       pipeline ALREADY fetches per call but _try_connector_config previously discarded),
+       gated by settings.connector_desc_harvest_enabled (default ON). Runs after the
+       existing manufacturer/category apply. Three writes: (a) the connector DESCRIPTION
+       → writer.categorize_and_record(source="connector_desc", tier 84, conf 0.90) —
+       categorizes an uncategorized card + fills facets via the SAME desc grammar (serves
+       the dominant server-commodity cohort); (b) STRUCTURED fields package_type→package,
+       pin_count→pin_count, rohs_status→rohs → record_spec at the connector's vendor-API
+       tier (digikey_api/mouser_api/… 90, conf 0.95), schema-gated so they only stick on
+       component-commodity cards whose schema defines the key (no-op elsewhere); (c)
+       datasheet_url → the card.datasheet_url column (feeds the future datasheet sub-project).
+       connector_desc (84) outranks the card's own desc_parse (83) — a distributor's
+       authoritative description beats the card's own prose — and loses to the
+       deterministic decoders (85); structured facets at vendor tier 90 are authoritative.
+       v1 = enrichment path only; the pricing-search path (search_service) is a follow-up.
     4. spec_enrichment_service.py::enrich_card_specs    — AI spec reader,
        source="spec_extraction" (tier 60), facets gated at confidence >= 0.85
        (FACET_MIN_CONF — an AI output-quality floor, not cross-source

--- a/docs/superpowers/plans/2026-06-16-connector-desc-harvest.md
+++ b/docs/superpowers/plans/2026-06-16-connector-desc-harvest.md
@@ -1,0 +1,415 @@
+# Connector-description Harvest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop discarding the structured fields + description the connector pipeline already fetches, and harvest them into the F1 spec ladder (coverage + facet depth).
+
+**Architecture:** In the enrichment path (`enrich_material_card` → `_apply_enrichment_to_card`), after the existing manufacturer/category apply, run a harvest step that (1) feeds the connector `description` through the existing `categorize_and_record` at a new `connector_desc` source (tier 84 — categorizes uncategorized server-commodity cards + fills facets), (2) records the structured fields (`package`/`pin_count`/`rohs`) at the connector's own vendor-API tier (90) for component-commodity cards, and (3) stores `datasheet_url` on the card. All writes go through the ladder; v1 = enrichment path only (search-path harvest is a follow-up). Flag-gated, no migration.
+
+**Tech Stack:** Python 3.13, SQLAlchemy 2.0, pytest (SQLite in tests). Reuses `spec_tiers`, `spec_write_service.record_spec`, `desc_extractor.writer.categorize_and_record`.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-connector-description-harvest-design.md`
+
+**Honest scope note:** `commodity_seeds.json` confirms `package`/`pin_count`/`rohs` are **component-commodity** facets (not in `dram`/`ssd`/`cpu`/…). So the structured-field write helps DigiKey/Mouser **component** cards; the **description** harvest is what serves the dominant uncategorized **server-spare** cohort. `record_spec` schema-gates structured fields, so they safely no-op where the commodity lacks the key.
+
+---
+
+### Task 1: Register `connector_desc` (tier 84 + constants + flag + migration CASE arm)
+
+**Files:**
+- Modify: `app/services/spec_tiers.py` (the `SOURCE_TIER` dict, near `"partsurfer_desc": 84`)
+- Modify: `app/services/desc_extractor/_common.py` (after the `PARTSURFER_DESC_*` constants)
+- Modify: `app/config.py` (near `partsurfer_desc_enabled`, ~line 138)
+- Modify: `alembic/versions/096_spec_provenance.py` (the `_SOURCE_TIER_SQL_CASE`, after the `partsurfer_desc` arm ~line 67)
+- Test: `tests/test_connector_desc_harvest.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_connector_desc_harvest.py`:
+```python
+"""tests/test_connector_desc_harvest.py — harvest the structured fields + description the
+connector pipeline already fetches (previously discarded), into the F1 ladder.
+
+Depends on: conftest.py (db_session), seed_commodity_schemas, MaterialCard +
+MaterialSpecFacet, spec_tiers.SOURCE_TIER (connector_desc=84).
+"""
+
+from app.services.spec_tiers import SOURCE_TIER, tier_for
+
+
+def test_connector_desc_registered_at_tier_84():
+    assert SOURCE_TIER["connector_desc"] == 84
+    assert tier_for("connector_desc") == 84
+    # Above the card's own desc_parse (83), below the deterministic decoders (85).
+    assert SOURCE_TIER["connector_desc"] > SOURCE_TIER["desc_parse"]
+    assert SOURCE_TIER["connector_desc"] < SOURCE_TIER["mpn_decode"]
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=$PWD pytest tests/test_connector_desc_harvest.py::test_connector_desc_registered_at_tier_84 -v --override-ini="addopts="`
+Expected: FAIL with `KeyError: 'connector_desc'`.
+
+- [ ] **Step 3: Register the source in the ladder**
+
+In `app/services/spec_tiers.py`, add to `SOURCE_TIER` immediately above `"partsurfer_desc": 84,`:
+```python
+    "connector_desc": 84,  # distributor (DigiKey/Mouser/…) description parsed by the desc grammar:
+    # more authoritative than the card's own desc_parse (83), below the deterministic decoders (85).
+```
+
+- [ ] **Step 4: Add the constants**
+
+In `app/services/desc_extractor/_common.py`, after the `PARTSURFER_DESC_CONFIDENCE = 0.90` line:
+```python
+# Distributor-connector description: the same desc grammar run over a DigiKey/Mouser/
+# element14/OEMSecrets/Nexar product description we ALREADY fetch (not the card's own).
+# Outranks desc_parse (spec_tiers.SOURCE_TIER: connector_desc=84 > desc_parse 83).
+CONNECTOR_DESC_SOURCE = "connector_desc"
+CONNECTOR_DESC_CONFIDENCE = 0.90
+```
+
+- [ ] **Step 5: Add the config flag**
+
+In `app/config.py`, immediately after `partsurfer_desc_enabled: bool = True`:
+```python
+    connector_desc_harvest_enabled: bool = True
+```
+
+- [ ] **Step 6: Sync the migration-096 CASE snapshot**
+
+In `alembic/versions/096_spec_provenance.py`, in `_SOURCE_TIER_SQL_CASE`, add immediately after the `"WHEN 'partsurfer_desc' THEN 84 "` line:
+```python
+    "WHEN 'connector_desc' THEN 84 "
+```
+(This keeps `test_migration_096_spec_provenance.py`'s key-for-key assertion green. No live-DB effect — runtime tier is Python `tier_for()`; the migration already ran. Same as the `partsurfer_desc` precedent. No new migration.)
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=$PWD pytest tests/test_connector_desc_harvest.py::test_connector_desc_registered_at_tier_84 tests/test_migration_096_spec_provenance.py -v --override-ini="addopts="`
+Expected: PASS (both — the new tier test + the migration sync test).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/services/spec_tiers.py app/services/desc_extractor/_common.py app/config.py alembic/versions/096_spec_provenance.py tests/test_connector_desc_harvest.py
+git commit -m "feat(enrich): register connector_desc source at tier 84"
+```
+
+---
+
+### Task 2: Widen `_try_connector_config` to carry the harvest fields
+
+**Files:**
+- Modify: `app/services/enrichment.py` (`_try_connector_config`, the `return {...}` ~line 107)
+- Test: `tests/test_connector_desc_harvest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_connector_desc_harvest.py`:
+```python
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from app.services import enrichment
+
+
+def test_try_connector_config_carries_harvest_fields():
+    # A connector result shaped like DigiKey's: rich fields beyond manufacturer/category.
+    fake_result = {
+        "manufacturer": "Samsung",
+        "category": "Memory",
+        "description": "16GB DDR4-2666 ECC RDIMM 288-pin",
+        "package_type": "DIMM-288",
+        "pin_count": 288,
+        "rohs_status": "compliant",
+        "datasheet_url": "https://example.com/ds.pdf",
+    }
+    config = {"name": "digikey", "module": "x", "class": "y", "creds": [], "confidence": 0.95}
+
+    class _Conn:
+        def __init__(self, *a):
+            pass
+
+        async def search(self, mpn):
+            return [fake_result]
+
+    with patch.object(enrichment, "get_credential_cached", return_value="cred"), patch(
+        "importlib.import_module"
+    ) as imp:
+        imp.return_value = type("M", (), {"y": _Conn})
+        out = asyncio.run(enrichment._try_connector_config(config, "MEM123"))
+
+    assert out["manufacturer"] == "Samsung"
+    assert out["description"] == "16GB DDR4-2666 ECC RDIMM 288-pin"
+    assert out["package_type"] == "DIMM-288"
+    assert out["pin_count"] == 288
+    assert out["rohs_status"] == "compliant"
+    assert out["datasheet_url"] == "https://example.com/ds.pdf"
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `TESTING=1 PYTHONPATH=$PWD pytest tests/test_connector_desc_harvest.py::test_try_connector_config_carries_harvest_fields -v --override-ini="addopts="`
+Expected: FAIL with `KeyError: 'description'`.
+
+- [ ] **Step 3: Widen the return dict**
+
+In `app/services/enrichment.py::_try_connector_config`, replace the `return {...}` block (the one inside `for r in results:` that returns on a non-ignored manufacturer) with:
+```python
+                return {
+                    "manufacturer": mfr,
+                    "category": (r.get("category") or r.get("description") or "").strip()[:200] or None,
+                    "source": config["name"],
+                    "confidence": config["confidence"],
+                    # Harvest fields — previously discarded (see connector-desc-harvest spec).
+                    "description": (r.get("description") or "").strip() or None,
+                    "package_type": (r.get("package_type") or "").strip() or None,
+                    "pin_count": r.get("pin_count"),
+                    "rohs_status": (r.get("rohs_status") or "").strip() or None,
+                    "datasheet_url": (r.get("datasheet_url") or "").strip() or None,
+                }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `TESTING=1 PYTHONPATH=$PWD pytest tests/test_connector_desc_harvest.py::test_try_connector_config_carries_harvest_fields -v --override-ini="addopts="`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/enrichment.py tests/test_connector_desc_harvest.py
+git commit -m "feat(enrich): carry description + structured fields through _try_connector_config"
+```
+
+---
+
+### Task 3: Harvest step in `_apply_enrichment_to_card`
+
+**Files:**
+- Modify: `app/services/enrichment.py` (new `_harvest_connector_enrichment` helper + a gated call inside `_apply_enrichment_to_card`)
+- Test: `tests/test_connector_desc_harvest.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_connector_desc_harvest.py`:
+```python
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models import MaterialCard, MaterialSpecFacet
+from app.services.commodity_registry import seed_commodity_schemas
+from app.services.spec_write_service import record_spec
+
+
+def _facets(db: Session, card_id: int) -> dict:
+    rows = db.query(MaterialSpecFacet).filter_by(material_card_id=card_id).all()
+    return {r.spec_key: r for r in rows}
+
+
+def _component_commodity_with(*keys: str) -> str:
+    """A seeded commodity whose schema defines all of *keys* (e.g. package/pin_count/rohs)."""
+    import json
+
+    seeds = json.load(open("app/data/commodity_seeds.json"))
+    for commodity, specs in seeds.items():
+        skeys = {s["spec_key"] for s in specs}
+        if set(keys).issubset(skeys):
+            return commodity
+    raise AssertionError(f"no seeded commodity defines all of {keys}")
+
+
+def test_description_categorizes_uncategorized_card_at_connector_desc(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = MaterialCard(normalized_mpn="mem123", display_mpn="MEM123", category=None)
+    db_session.add(card)
+    db_session.flush()
+    enrichment_data = {
+        "manufacturer": "Samsung",
+        "confidence": 0.95,
+        "source": "digikey",
+        "category": None,
+        "description": "16GB (1x16GB) DUAL RANK X4 DDR4-2666 REGISTERED ECC MEMORY",
+        "package_type": None,
+        "pin_count": None,
+        "rohs_status": None,
+        "datasheet_url": "https://example.com/ds.pdf",
+    }
+    enrichment._apply_enrichment_to_card(card, enrichment_data, db_session)
+    db_session.commit()
+    assert card.category == "dram"
+    assert card.category_source == "connector_desc"
+    assert card.category_tier == 84
+    assert card.datasheet_url == "https://example.com/ds.pdf"
+
+
+def test_structured_fields_recorded_at_vendor_tier_for_component_card(db_session: Session):
+    seed_commodity_schemas(db_session)
+    commodity = _component_commodity_with("package", "pin_count", "rohs")
+    card = MaterialCard(normalized_mpn="cmp1", display_mpn="CMP1", category=commodity)
+    db_session.add(card)
+    db_session.flush()
+    enrichment_data = {
+        "manufacturer": "TE", "confidence": 0.95, "source": "digikey", "category": None,
+        "description": None, "package_type": "SMD", "pin_count": 4, "rohs_status": "compliant",
+        "datasheet_url": None,
+    }
+    enrichment._apply_enrichment_to_card(card, enrichment_data, db_session)
+    db_session.commit()
+    facets = _facets(db_session, card.id)
+    assert "pin_count" in facets and facets["pin_count"].source == "digikey_api"
+    assert facets["pin_count"].tier == 90
+
+
+def test_flag_off_skips_harvest(db_session: Session, monkeypatch):
+    seed_commodity_schemas(db_session)
+    monkeypatch.setattr(settings, "connector_desc_harvest_enabled", False)
+    card = MaterialCard(normalized_mpn="mem9", display_mpn="MEM9", category=None)
+    db_session.add(card)
+    db_session.flush()
+    enrichment_data = {
+        "manufacturer": "Samsung", "confidence": 0.95, "source": "digikey", "category": None,
+        "description": "16GB DDR4-2666 REGISTERED ECC MEMORY", "package_type": None,
+        "pin_count": None, "rohs_status": None, "datasheet_url": "https://example.com/x.pdf",
+    }
+    enrichment._apply_enrichment_to_card(card, enrichment_data, db_session)
+    db_session.commit()
+    assert card.category is None
+    assert card.datasheet_url is None
+
+
+def test_connector_desc_loses_to_mpn_decode(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = MaterialCard(normalized_mpn="mem5", display_mpn="MEM5", category="dram")
+    db_session.add(card)
+    db_session.flush()
+    cache = None
+    # A higher-tier decoder value lands first.
+    record_spec(db_session, int(card.id), "ddr_type", "DDR4", source="mpn_decode", confidence=0.95, schema_cache=cache)
+    db_session.commit()
+    enrichment_data = {
+        "manufacturer": "Samsung", "confidence": 0.95, "source": "digikey", "category": None,
+        "description": "8GB DDR3-1600 REGISTERED ECC MEMORY", "package_type": None,
+        "pin_count": None, "rohs_status": None, "datasheet_url": None,
+    }
+    enrichment._apply_enrichment_to_card(card, enrichment_data, db_session)
+    db_session.commit()
+    facets = _facets(db_session, card.id)
+    # mpn_decode (85) is not clobbered by connector_desc (84).
+    assert facets["ddr_type"].value_text == "DDR4"
+    assert facets["ddr_type"].source == "mpn_decode"
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `TESTING=1 PYTHONPATH=$PWD pytest tests/test_connector_desc_harvest.py -k "harvest or categoriz or structured or flag or mpn_decode" -v --override-ini="addopts="`
+Expected: FAIL (no harvest step yet — `card.category` stays None, no facets, `datasheet_url` unset).
+
+- [ ] **Step 3: Add the harvest helper + gated call**
+
+In `app/services/enrichment.py`, add this helper (place it directly after `_apply_enrichment_to_card`):
+```python
+# Connector structured fields → seeded facet keys. lifecycle_status is intentionally
+# omitted: no commodity schema defines a `lifecycle` facet (confirmed against
+# commodity_seeds.json), so it would only ever no-op.
+_CONNECTOR_FIELD_TO_FACET = {"package_type": "package", "pin_count": "pin_count", "rohs_status": "rohs"}
+
+
+def _harvest_connector_enrichment(card: MaterialCard, enrichment: dict, ladder_source: str, db: Session) -> None:
+    """Record the description + structured fields the connector returned (previously discarded).
+
+    Description → categorize_and_record (categorizes an uncategorized card + fills facets) at
+    connector_desc / tier 84. Structured fields → record_spec at the connector's vendor-API tier
+    (90) — only stick where the commodity schema defines the key. datasheet_url → card column.
+    All writes arbitrated by the F1 ladder; each in a per-card SAVEPOINT.
+    """
+    from app.services.desc_extractor._common import CONNECTOR_DESC_CONFIDENCE, CONNECTOR_DESC_SOURCE
+    from app.services.desc_extractor.writer import categorize_and_record
+    from app.services.spec_write_service import load_schema_cache, record_spec
+
+    datasheet_url = (enrichment.get("datasheet_url") or "").strip()
+    if datasheet_url and not card.datasheet_url:
+        card.datasheet_url = datasheet_url[:1000]
+
+    description = (enrichment.get("description") or "").strip()
+    if description:
+        # Fill-only: categorizes only if still uncategorized; always fills facets via the ladder.
+        categorize_and_record(
+            db, card, description=description, source=CONNECTOR_DESC_SOURCE, confidence=CONNECTOR_DESC_CONFIDENCE
+        )
+
+    category = (card.category or "").lower().strip()
+    if not category:
+        return  # no schema without a category — structured facets can't be validated
+    schema_cache = load_schema_cache(db, category)
+    with db.begin_nested():
+        for field, facet_key in _CONNECTOR_FIELD_TO_FACET.items():
+            value = enrichment.get(field)
+            if value is None or value == "":
+                continue
+            record_spec(
+                db, int(card.id), facet_key, value, source=ladder_source, confidence=0.95, schema_cache=schema_cache
+            )
+```
+
+Then in `_apply_enrichment_to_card`, add this at the END of the function (after the `tag_material_card(...)` block), importing `settings` at the top of the call:
+```python
+    from app.config import settings
+
+    if settings.connector_desc_harvest_enabled:
+        _harvest_connector_enrichment(card, enrichment, ladder_source, db)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `TESTING=1 PYTHONPATH=$PWD pytest tests/test_connector_desc_harvest.py -v --override-ini="addopts="`
+Expected: PASS (all tests in the file).
+
+- [ ] **Step 5: Run the existing enrichment regression**
+
+Run: `TESTING=1 PYTHONPATH=$PWD pytest tests/test_enrichment*.py tests/test_partsurfer_enrich.py -q --override-ini="addopts="`
+Expected: PASS (no regression in the existing enrichment apply path).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/enrichment.py tests/test_connector_desc_harvest.py
+git commit -m "feat(enrich): harvest connector description + structured fields into the ladder"
+```
+
+---
+
+### Task 4: APP_MAP doc + final verification
+
+**Files:**
+- Modify: `docs/APP_MAP_INTERACTIONS.md` (enrichment-writers / evidence-source-tier section)
+
+- [ ] **Step 1: Update the APP_MAP**
+
+In `docs/APP_MAP_INTERACTIONS.md`, in the enrichment-writers / evidence-source-tier table, add a row for `connector_desc` (tier 84 — DigiKey/Mouser/element14/OEMSecrets/Nexar description parsed by the desc grammar) and note the new harvest step in `_apply_enrichment_to_card` (structured fields at the vendor-API tier 90; `datasheet_url` stored on the card).
+
+- [ ] **Step 2: Lint + type + format**
+
+Run: `ruff check app/services/enrichment.py && pre-commit run --files app/services/enrichment.py app/services/spec_tiers.py app/services/desc_extractor/_common.py app/config.py alembic/versions/096_spec_provenance.py tests/test_connector_desc_harvest.py docs/APP_MAP_INTERACTIONS.md`
+Run pre-commit a SECOND time (docformatter mutates then verifies).
+Expected: all hooks pass on the second run.
+
+- [ ] **Step 3: Full targeted suite**
+
+Run: `TESTING=1 PYTHONPATH=$PWD pytest tests/test_connector_desc_harvest.py tests/test_migration_096_spec_provenance.py tests/test_spec_tiers*.py tests/test_enrichment*.py tests/test_partsurfer_enrich.py -q --override-ini="addopts="`
+Expected: PASS, zero failures.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/APP_MAP_INTERACTIONS.md
+git commit -m "docs(app-map): connector_desc harvest writer + tier 84"
+```
+
+---
+
+## Follow-ups (out of scope, noted)
+- Search-path harvest (`search_service`) — opportunistic enrichment during pricing search.
+- `datasheet_url` consumption — the datasheet PDF→facet sub-project.
+- Remaining Approach-A sub-projects: eBay-title mining, Nexar-deep fields, Intel/AMD ARK CPU decoder, Lenovo PSREF.

--- a/docs/superpowers/specs/2026-06-16-connector-description-harvest-design.md
+++ b/docs/superpowers/specs/2026-06-16-connector-description-harvest-design.md
@@ -1,0 +1,144 @@
+# Connector-description harvest — design
+
+**Date:** 2026-06-16
+**Status:** approved (brainstorm) — pending written-spec review
+**Author:** Claude (with mkhoury)
+**Program:** Enrichment-source expansion, Approach A ("harvest-first"). This is sub-project #1 of 5
+(others: eBay-title mining, Nexar-deep fields, Intel/AMD ARK CPU decoder, Lenovo PSREF — each its
+own spec → plan → build).
+
+## Problem
+
+The connector pipeline (`app/connectors/*`) already fetches rich enrichment data on every
+connector-enrichment call — DigiKey/Mouser return `description` (DetailedDescription),
+`lifecycle_status`, `package_type`, `pin_count`, `rohs_status`; element14 returns
+`description`/`package_type`/`rohs_status`; OEMSecrets returns `category`/`lifecycle_status`/
+`datasheet_url`; Nexar returns `description`/`category`. But `app/services/enrichment.py::_try_connector_config`
+keeps only `manufacturer` and a crude `category` (the description truncated to `[:200]`) and
+**discards everything else**. We pay for this data and throw the enrichment away.
+
+## Goal & scope
+
+Harvest the already-fetched connector data into the F1 spec ladder so it serves all three program
+goals: **coverage** (categorize uncategorized cards from the description), **facet depth**
+(structured fields + parsed-description facets), and partially **cross-ref** (datasheet_url
+captured for the downstream datasheet sub-project).
+
+**In scope (v1):** the dedicated **enrichment path** — `enrich_material_card` →
+`_apply_enrichment_to_card`, which already writes to the card.
+
+**Out of scope (deliberate follow-ups):**
+- The higher-volume **pricing-search path** (`search_service`) fetches the same data; harvesting
+  there means opportunistic writes during a search — a larger surface, its own sub-project.
+- Net-new external sources (covered by the other Approach-A sub-projects).
+
+## Resolved decisions
+
+1. **`connector_desc` tier = 84** — a distributor's description is more authoritative than the
+   card's own description (`desc_parse` 83) but is still grammar-parsed, so it sits above
+   `desc_parse` and below the deterministic decoders (`mpn_decode` 85). Mirrors `partsurfer_desc`
+   (also 84; ties are not load-bearing per the ladder's run-order-independence).
+2. **v1 = enrichment path only** (see scope).
+
+## Design
+
+### A. Structured fields → vendor-API tier (authoritative, not parsed)
+
+The structured fields are authoritative distributor data, so they record at the **connector's own
+vendor-API tier** (already registered: `digikey_api`/`mouser_api`/`element14_api`/`oemsecrets_api`/
+`nexar_api` = 90), NOT at a description tier.
+
+- Map each connector result field → its canonical facet key, then `record_spec`:
+  - `pin_count` → `pin_count`
+  - `package_type` → `package`
+  - `lifecycle_status` → `lifecycle`
+  - `rohs_status` → `rohs`
+  - (`datasheet_url` is **stored on the card** for the datasheet sub-project, not a facet.)
+- Implementation MUST confirm the canonical facet-key names against the seeded commodity schemas
+  (`app/data/commodity_seeds.json`) — `record_spec` gates on schema membership, so an off-schema key
+  is a silent no-op (acceptable: a key only sticks where the commodity defines it).
+- Source string = the connector's existing `SOURCE_TIER` key (the implementation maps
+  `config["name"]` → the `*_api` source). Confidence = `0.95` (authoritative structured field).
+
+### B. Description prose → `connector_desc` (categorize + fill)
+
+Feed the connector `description` to the existing `categorize_and_record` (the proven
+`partsurfer_desc`/FRU-desc pattern):
+
+- `categorize_and_record(db, card, description=<connector desc>, source="connector_desc",
+  confidence=CONNECTOR_DESC_CONFIDENCE)` — categorizes an **uncategorized** card (coverage) and
+  fills facets (depth) in one per-card `begin_nested()` SAVEPOINT. Fill-only: a no-op on an
+  already-categorized card's category (it still fills facets via the ladder).
+- New constant `CONNECTOR_DESC_CONFIDENCE = 0.90` + `CONNECTOR_DESC_SOURCE = "connector_desc"`
+  in `app/services/desc_extractor/_common.py` (next to the `DESC_*`/`PARTSURFER_DESC_*` constants).
+
+### C. Ladder registration
+
+- `app/services/spec_tiers.py::SOURCE_TIER` — add `"connector_desc": 84` (above `desc_parse` 83).
+- `alembic/versions/096_spec_provenance.py` — add the `connector_desc → 84` arm to the
+  `_SOURCE_TIER_SQL_CASE` snapshot (the `test_migration_096_spec_provenance.py` sync test asserts
+  the CASE matches `SOURCE_TIER` key-for-key). No live-DB effect (runtime tier is Python
+  `tier_for()`; the migration already ran — same as the `partsurfer_desc` precedent). **No new
+  migration.**
+
+### D. Wiring & flag
+
+- Widen `_try_connector_config`'s return to carry the raw structured fields + full `description`
+  (not just the truncated `category`). Backward-compatible: existing `manufacturer`/`category`/
+  `source`/`confidence` keys unchanged.
+- `_apply_enrichment_to_card` gains a harvest step (A + B above), gated by a new
+  `settings.connector_desc_harvest_enabled: bool = True` (mirrors `partsurfer_desc_enabled`).
+- Reuses existing infra only — no new module, no new external calls (the data is already fetched).
+
+### Data flow
+
+`enrich_material_card(mpn)` → `_try_connector_config` (now returns full fields) →
+`_apply_enrichment_to_card`: (1) existing manufacturer/category apply, (2) **NEW** structured-field
+facets at vendor tier 90, (3) **NEW** `categorize_and_record(source="connector_desc")` over the
+description. All writes arbitrated by the F1 ladder.
+
+## Error handling
+
+- Every write inside the existing per-card `begin_nested()` SAVEPOINT (in `categorize_and_record`
+  and around the structured-facet writes) — a constraint/`DataError`/`IntegrityError` on one field
+  rolls back only that write and is logged; never poisons the batch session.
+- Malformed/missing fields are skipped (the connectors already normalize via `_core_attrs`).
+- The ladder rejects anything that loses to a higher prior — a vendor structured field (90) and a
+  `connector_desc` facet (84) can never clobber `manual`/`trio_source`/decoder values.
+
+## Testing
+
+- A connector result with `description` + structured fields → assert: structured facets land at the
+  vendor tier (90), the description categorizes an uncategorized card + fills facets at
+  `connector_desc` (84), the ladder beats the card's own `desc_parse` (83) but loses to
+  `mpn_decode` (85).
+- Off-schema structured field (e.g. `pin_count` on a `dram` card whose schema lacks it) → silent
+  no-op, no error.
+- Ignored-manufacturer / empty-description / no-result → no-op (no facets, no crash).
+- Flag OFF → no harvest; flag ON → harvest runs.
+- `datasheet_url` stored on the card; not written as a facet.
+- Migration-096 snapshot sync test passes with the new `connector_desc` arm.
+
+## Rollback
+
+Flag off (`CONNECTOR_DESC_HARVEST_ENABLED=false`) disables it instantly; revert the commit to
+remove. No migration to downgrade. Recorded facets remain valid (correctly tiered); the ladder
+makes them harmless even if the source is later disabled.
+
+## Files
+
+- `app/services/enrichment.py` — widen `_try_connector_config` return; harvest step in
+  `_apply_enrichment_to_card`.
+- `app/services/desc_extractor/_common.py` — `CONNECTOR_DESC_SOURCE` / `CONNECTOR_DESC_CONFIDENCE`.
+- `app/services/spec_tiers.py` — `SOURCE_TIER["connector_desc"] = 84`.
+- `alembic/versions/096_spec_provenance.py` — `connector_desc → 84` CASE arm (test sync only).
+- `app/config.py` — `connector_desc_harvest_enabled: bool = True`.
+- `tests/test_connector_desc_harvest.py` (new) — the cases above.
+- `docs/APP_MAP_INTERACTIONS.md` — enrichment-writers / tier table + the harvest step.
+
+## Follow-ups (not this sub-project)
+
+- Search-path harvest (`search_service`) — opportunistic enrichment during pricing search.
+- `datasheet_url` consumption — the datasheet PDF→facet sub-project.
+- The remaining Approach-A sub-projects (eBay-title mining, Nexar-deep fields, ARK CPU decoder,
+  Lenovo PSREF).

--- a/tests/test_connector_desc_harvest.py
+++ b/tests/test_connector_desc_harvest.py
@@ -14,3 +14,44 @@ def test_connector_desc_registered_at_tier_84():
     # Above the card's own desc_parse (83), below the deterministic decoders (85).
     assert SOURCE_TIER["connector_desc"] > SOURCE_TIER["desc_parse"]
     assert SOURCE_TIER["connector_desc"] < SOURCE_TIER["mpn_decode"]
+
+
+import asyncio
+from unittest.mock import patch
+
+from app.services import enrichment
+
+
+def test_try_connector_config_carries_harvest_fields():
+    # A connector result shaped like DigiKey's: rich fields beyond manufacturer/category.
+    fake_result = {
+        "manufacturer": "Samsung",
+        "category": "Memory",
+        "description": "16GB DDR4-2666 ECC RDIMM 288-pin",
+        "package_type": "DIMM-288",
+        "pin_count": 288,
+        "rohs_status": "compliant",
+        "datasheet_url": "https://example.com/ds.pdf",
+    }
+    config = {"name": "digikey", "module": "x", "class": "y", "creds": [], "confidence": 0.95}
+
+    class _Conn:
+        def __init__(self, *a):
+            pass
+
+        async def search(self, mpn):
+            return [fake_result]
+
+    with (
+        patch.object(enrichment, "get_credential_cached", return_value="cred"),
+        patch("importlib.import_module") as imp,
+    ):
+        imp.return_value = type("M", (), {"y": _Conn})
+        out = asyncio.run(enrichment._try_connector_config(config, "MEM123"))
+
+    assert out["manufacturer"] == "Samsung"
+    assert out["description"] == "16GB DDR4-2666 ECC RDIMM 288-pin"
+    assert out["package_type"] == "DIMM-288"
+    assert out["pin_count"] == 288
+    assert out["rohs_status"] == "compliant"
+    assert out["datasheet_url"] == "https://example.com/ds.pdf"

--- a/tests/test_connector_desc_harvest.py
+++ b/tests/test_connector_desc_harvest.py
@@ -55,3 +55,130 @@ def test_try_connector_config_carries_harvest_fields():
     assert out["pin_count"] == 288
     assert out["rohs_status"] == "compliant"
     assert out["datasheet_url"] == "https://example.com/ds.pdf"
+
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models import MaterialCard, MaterialSpecFacet
+from app.services.commodity_registry import seed_commodity_schemas
+from app.services.spec_write_service import record_spec
+
+
+def _facets(db: Session, card_id: int) -> dict:
+    rows = db.query(MaterialSpecFacet).filter_by(material_card_id=card_id).all()
+    return {r.spec_key: r for r in rows}
+
+
+def _component_commodity_with(*keys: str) -> str:
+    """A seeded commodity whose schema defines all of *keys* (e.g.
+
+    package/pin_count/rohs).
+    """
+    import json
+
+    seeds = json.load(open("app/data/commodity_seeds.json"))
+    for commodity, specs in seeds.items():
+        skeys = {s["spec_key"] for s in specs}
+        if set(keys).issubset(skeys):
+            return commodity
+    raise AssertionError(f"no seeded commodity defines all of {keys}")
+
+
+def test_description_categorizes_uncategorized_card_at_connector_desc(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = MaterialCard(normalized_mpn="mem123", display_mpn="MEM123", category=None)
+    db_session.add(card)
+    db_session.flush()
+    enrichment_data = {
+        "manufacturer": "Samsung",
+        "confidence": 0.95,
+        "source": "digikey",
+        "category": None,
+        "description": "16GB (1x16GB) DUAL RANK X4 DDR4-2666 REGISTERED ECC MEMORY",
+        "package_type": None,
+        "pin_count": None,
+        "rohs_status": None,
+        "datasheet_url": "https://example.com/ds.pdf",
+    }
+    enrichment._apply_enrichment_to_card(card, enrichment_data, db_session)
+    db_session.commit()
+    assert card.category == "dram"
+    assert card.category_source == "connector_desc"
+    assert card.category_tier == 84
+    assert card.datasheet_url == "https://example.com/ds.pdf"
+
+
+def test_structured_fields_recorded_at_vendor_tier_for_component_card(db_session: Session):
+    seed_commodity_schemas(db_session)
+    commodity = _component_commodity_with("pin_count")
+    card = MaterialCard(normalized_mpn="cmp1", display_mpn="CMP1", category=commodity)
+    db_session.add(card)
+    db_session.flush()
+    enrichment_data = {
+        "manufacturer": "TE",
+        "confidence": 0.95,
+        "source": "digikey",
+        "category": None,
+        "description": None,
+        "package_type": "SMD",
+        "pin_count": 4,
+        "rohs_status": "compliant",
+        "datasheet_url": None,
+    }
+    enrichment._apply_enrichment_to_card(card, enrichment_data, db_session)
+    db_session.commit()
+    facets = _facets(db_session, card.id)
+    assert "pin_count" in facets and facets["pin_count"].source == "digikey_api"
+    assert facets["pin_count"].tier == 90
+
+
+def test_flag_off_skips_harvest(db_session: Session, monkeypatch):
+    seed_commodity_schemas(db_session)
+    monkeypatch.setattr(settings, "connector_desc_harvest_enabled", False)
+    card = MaterialCard(normalized_mpn="mem9", display_mpn="MEM9", category=None)
+    db_session.add(card)
+    db_session.flush()
+    enrichment_data = {
+        "manufacturer": "Samsung",
+        "confidence": 0.95,
+        "source": "digikey",
+        "category": None,
+        "description": "16GB DDR4-2666 REGISTERED ECC MEMORY",
+        "package_type": None,
+        "pin_count": None,
+        "rohs_status": None,
+        "datasheet_url": "https://example.com/x.pdf",
+    }
+    enrichment._apply_enrichment_to_card(card, enrichment_data, db_session)
+    db_session.commit()
+    assert card.category is None
+    assert card.datasheet_url is None
+
+
+def test_connector_desc_loses_to_mpn_decode(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = MaterialCard(normalized_mpn="mem5", display_mpn="MEM5", category="dram")
+    db_session.add(card)
+    db_session.flush()
+    cache = None
+    # A higher-tier decoder value lands first.
+    record_spec(db_session, int(card.id), "ddr_type", "DDR4", source="mpn_decode", confidence=0.95, schema_cache=cache)
+    db_session.commit()
+    enrichment_data = {
+        "manufacturer": "Samsung",
+        "confidence": 0.95,
+        "source": "digikey",
+        "category": None,
+        "description": "8GB DDR3-1600 REGISTERED ECC MEMORY",
+        "package_type": None,
+        "pin_count": None,
+        "rohs_status": None,
+        "datasheet_url": None,
+    }
+    enrichment._apply_enrichment_to_card(card, enrichment_data, db_session)
+    db_session.commit()
+    facets = _facets(db_session, card.id)
+    # mpn_decode (85) is not clobbered by connector_desc (84).
+    assert facets["ddr_type"].value_text == "DDR4"
+    assert facets["ddr_type"].source == "mpn_decode"

--- a/tests/test_connector_desc_harvest.py
+++ b/tests/test_connector_desc_harvest.py
@@ -182,3 +182,38 @@ def test_connector_desc_loses_to_mpn_decode(db_session: Session):
     # mpn_decode (85) is not clobbered by connector_desc (84).
     assert facets["ddr_type"].value_text == "DDR4"
     assert facets["ddr_type"].source == "mpn_decode"
+
+
+def test_harvest_failure_does_not_propagate(db_session: Session, monkeypatch):
+    """A harvest failure is best-effort — caught + logged, never aborts the caller's
+    batch.
+
+    enrich_batch._process_one calls _apply_enrichment_to_card unguarded, so an exception
+    escaping the harvest would abort the whole batch and waste the rest of its work.
+    """
+    seed_commodity_schemas(db_session)
+    card = MaterialCard(normalized_mpn="boom1", display_mpn="BOOM1", category=None)
+    db_session.add(card)
+    db_session.flush()
+
+    def _boom(*a, **k):
+        raise RuntimeError("harvest blew up")
+
+    # categorize_and_record is imported lazily inside _harvest_connector_enrichment from
+    # app.services.desc_extractor.writer — patch it at the source module.
+    monkeypatch.setattr("app.services.desc_extractor.writer.categorize_and_record", _boom)
+    enrichment_data = {
+        "manufacturer": "Samsung",
+        "confidence": 0.95,
+        "source": "digikey",
+        "category": None,
+        "description": "16GB DDR4-2666 REGISTERED ECC MEMORY",
+        "package_type": None,
+        "pin_count": None,
+        "rohs_status": None,
+        "datasheet_url": None,
+    }
+    # Must NOT raise — the failure is swallowed; the pre-harvest manufacturer apply survives.
+    enrichment._apply_enrichment_to_card(card, enrichment_data, db_session)
+    db_session.commit()
+    assert card.manufacturer  # set_manufacturer ran before the harvest blew up

--- a/tests/test_connector_desc_harvest.py
+++ b/tests/test_connector_desc_harvest.py
@@ -1,0 +1,16 @@
+"""tests/test_connector_desc_harvest.py — harvest the structured fields + description
+the connector pipeline already fetches (previously discarded), into the F1 ladder.
+
+Depends on: conftest.py (db_session), seed_commodity_schemas, MaterialCard +
+MaterialSpecFacet, spec_tiers.SOURCE_TIER (connector_desc=84).
+"""
+
+from app.services.spec_tiers import SOURCE_TIER, tier_for
+
+
+def test_connector_desc_registered_at_tier_84():
+    assert SOURCE_TIER["connector_desc"] == 84
+    assert tier_for("connector_desc") == 84
+    # Above the card's own desc_parse (83), below the deterministic decoders (85).
+    assert SOURCE_TIER["connector_desc"] > SOURCE_TIER["desc_parse"]
+    assert SOURCE_TIER["connector_desc"] < SOURCE_TIER["mpn_decode"]


### PR DESCRIPTION
## Summary
Stop discarding the enrichment data the connector pipeline (DigiKey/Mouser/element14/OEMSecrets/Nexar) **already fetches** on every call. `_try_connector_config` previously kept only `manufacturer` + a truncated `category` and threw away the rest.

- **Description** → `categorize_and_record(source="connector_desc")` at a new **tier 84** (above the card's own `desc_parse` 83, below the deterministic decoders 85) — categorizes uncategorized cards + fills facets via the existing grammar. This is the broad win (serves the server-commodity cohort).
- **Structured fields** (`package_type`→`package`, `pin_count`, `rohs_status`→`rohs`) → `record_spec` at the connector's **vendor-API tier (90)**, schema-gated (only stick on component-commodity cards whose schema defines the key).
- **`datasheet_url`** → stored on `card.datasheet_url` (feeds the future datasheet sub-project).
- Gated by `connector_desc_harvest_enabled` (default **on**); **no migration** (096 CASE snapshot synced like `partsurfer_desc`); v1 = enrichment path only (pricing-search path is a noted follow-up).
- **Best-effort isolation:** a harvest failure is caught + logged so it never aborts the `enrich_batch` loop (same per-card-isolation lesson as the PartSurfer pass).

First of 5 Approach-A enrichment-source sub-projects. Spec + plan: `docs/superpowers/specs/2026-06-16-connector-description-harvest-design.md` + `docs/superpowers/plans/`.

## Test Plan
- [x] `tests/test_connector_desc_harvest.py` — 7 tests: tier registration, config widening, description→`connector_desc` categorize+facets, structured fields at vendor tier 90, flag-off no-op, ladder loses to `mpn_decode`, harvest-failure isolation.
- [x] Regression: enrichment + partsurfer + spec_tiers + migration-096 sync (125 passed).
- [x] ruff + mypy + pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)