### PR TITLE
test(simplify 4/8): parametrize + dedup test setup

### DIFF
--- a/tests/scripts/test_check_schema_matches_models.py
+++ b/tests/scripts/test_check_schema_matches_models.py
@@ -5,27 +5,30 @@ Called by: pytest
 Depends on: scripts.check_schema_matches_models
 """
 
+import pytest
+
 from scripts.check_schema_matches_models import filter_allowlist, format_diffs
 
 
-def test_filter_allowlist_drops_numeric_precision_noise():
-    """alembic.compare_metadata sometimes reports Numeric(10,2) vs NUMERIC(10,2) drift
-    that is semantically a no-op.
-
-    Allowlist must drop these.
-    """
-    raw = [
-        ("modify_type", None, "table_x", "col_y", {}, "NUMERIC(10, 2)", "Numeric(precision=10, scale=2)"),
-    ]
-    assert filter_allowlist(raw) == []
-
-
-def test_filter_allowlist_keeps_real_drift():
-    """A genuinely added column must NOT be filtered."""
-    raw = [
-        ("add_column", None, "table_x", "new_col"),
-    ]
-    assert filter_allowlist(raw) == raw
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Numeric(10,2) vs NUMERIC(10,2) is semantic no-op drift the allowlist must drop.
+        pytest.param(
+            [("modify_type", None, "table_x", "col_y", {}, "NUMERIC(10, 2)", "Numeric(precision=10, scale=2)")],
+            [],
+            id="drops-numeric-precision-noise",
+        ),
+        # A genuinely added column must NOT be filtered.
+        pytest.param(
+            [("add_column", None, "table_x", "new_col")],
+            [("add_column", None, "table_x", "new_col")],
+            id="keeps-real-drift",
+        ),
+    ],
+)
+def test_filter_allowlist(raw, expected):
+    assert filter_allowlist(raw) == expected
 
 
 def test_format_diffs_renders_human_readable():

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -14,6 +14,12 @@ from pathlib import Path
 import pytest
 
 MIGRATION_DIR = Path(__file__).parent.parent / "alembic" / "versions"
+ENV_PY = Path(__file__).parent.parent / "alembic" / "env.py"
+
+
+def _env_py_source():
+    """Read the alembic env.py source for static-analysis assertions."""
+    return ENV_PY.read_text()
 
 
 def _load_migration():
@@ -102,9 +108,7 @@ def test_initial_migration_downgrade_is_symmetric():
 
 def test_env_py_imports_all_models():
     """env.py must import Base so autogenerate sees all tables."""
-    env_path = Path(__file__).parent.parent / "alembic" / "env.py"
-    content = env_path.read_text()
-    assert "from app.models import Base" in content
+    assert "from app.models import Base" in _env_py_source()
 
 
 def test_env_py_installs_idempotent_op_wrappers():
@@ -116,8 +120,7 @@ def test_env_py_installs_idempotent_op_wrappers():
     well-documented purpose; removing one silently is the failure mode this
     test prevents.
     """
-    env_path = Path(__file__).parent.parent / "alembic" / "env.py"
-    content = env_path.read_text()
+    content = _env_py_source()
     expected_assignments = [
         "op.add_column = _idempotent_add_column",
         "op.alter_column = _idempotent_alter_column",
@@ -142,8 +145,7 @@ def test_env_py_alembic_version_widened_to_128():
     (which retroactively widens the column) gets a chance to run. Pre-creating the table
     at env-setup avoids the bootstrap race.
     """
-    env_path = Path(__file__).parent.parent / "alembic" / "env.py"
-    content = env_path.read_text()
+    content = _env_py_source()
     assert "VARCHAR(128)" in content, "env.py must widen alembic_version.version_num"
     assert "CREATE TABLE IF NOT EXISTS alembic_version" in content
 
@@ -156,8 +158,7 @@ def test_drop_table_cascade_is_env_var_gated():
     caller passes ``cascade=True`` or ``ALEMBIC_ALLOW_CASCADE=1`` is set
     (the latter is what CI uses for chain-replay smoke tests).
     """
-    env_path = Path(__file__).parent.parent / "alembic" / "env.py"
-    content = env_path.read_text()
+    content = _env_py_source()
     assert "ALEMBIC_ALLOW_CASCADE" in content, "Cascade gate env var missing — drop_table must opt into CASCADE."
     # Sanity: the default-False kwarg must be present in the wrapper signature.
     assert "cascade: bool = False" in content

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -21,15 +21,14 @@ from app.models import (
 )
 
 
-@pytest.fixture()
-def att_client(db_session: Session, test_user: User) -> TestClient:
-    """TestClient with auth overrides and access_token set."""
+def _client_with_token(db_session: Session, test_user: User, access_token: str | None):
+    """Yield a TestClient with auth overrides and the given access_token on
+    test_user."""
     from app.database import get_db
     from app.dependencies import require_buyer, require_user
     from app.main import app
 
-    # Set access_token on test user for OneDrive operations
-    test_user.access_token = "fake-token-for-testing"
+    test_user.access_token = access_token
     db_session.commit()
 
     def _override_db():
@@ -48,6 +47,18 @@ def att_client(db_session: Session, test_user: User) -> TestClient:
     finally:
         for dep in [get_db, require_user, require_buyer]:
             app.dependency_overrides.pop(dep, None)
+
+
+@pytest.fixture()
+def att_client(db_session: Session, test_user: User) -> TestClient:
+    """TestClient with auth overrides and access_token set."""
+    yield from _client_with_token(db_session, test_user, "fake-token-for-testing")
+
+
+def _first_requirement(db_session: Session, test_requisition) -> Requirement:
+    """The first Requirement of test_requisition (created by the requisition
+    fixture)."""
+    return db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -176,7 +187,7 @@ def test_delete_requisition_attachment_not_found(att_client):
 
 def test_list_requirement_attachments_empty(att_client, test_requisition, db_session):
     """GET /api/requirements/{id}/attachments returns empty list when no files."""
-    req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     resp = att_client.get(f"/api/requirements/{req.id}/attachments")
     assert resp.status_code == 200
     assert resp.json() == []
@@ -184,7 +195,7 @@ def test_list_requirement_attachments_empty(att_client, test_requisition, db_ses
 
 def test_list_requirement_attachments_with_data(att_client, db_session, test_requisition, test_user):
     """Attachments appear in the requirement list response."""
-    req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     att = RequirementAttachment(
         requirement_id=req.id,
         file_name="spec.pdf",
@@ -212,7 +223,7 @@ def test_list_requirement_attachments_not_found(att_client):
 @patch("app.http_client.http")
 def test_upload_requirement_attachment(mock_http, _mock_token, att_client, test_requisition, db_session):
     """POST /api/requirements/{id}/attachments uploads to OneDrive."""
-    req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     mock_resp = MagicMock()
     mock_resp.status_code = 201
     mock_resp.json.return_value = {"id": "od-req-456", "webUrl": "https://onedrive.example.com/spec"}
@@ -238,7 +249,7 @@ def test_upload_requirement_attachment_not_found(att_client):
 
 def test_delete_requirement_attachment(att_client, db_session, test_requisition, test_user):
     """DELETE /api/requirement-attachments/{id} removes the record."""
-    req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     att = RequirementAttachment(
         requirement_id=req.id,
         file_name="remove-me.pdf",
@@ -268,29 +279,7 @@ def test_delete_requirement_attachment_not_found(att_client):
 @pytest.fixture()
 def notoken_client(db_session: Session, test_user: User) -> TestClient:
     """TestClient with auth overrides but NO access_token."""
-    from app.database import get_db
-    from app.dependencies import require_buyer, require_user
-    from app.main import app
-
-    test_user.access_token = None
-    db_session.commit()
-
-    def _override_db():
-        yield db_session
-
-    def _override_user():
-        return test_user
-
-    app.dependency_overrides[get_db] = _override_db
-    app.dependency_overrides[require_user] = _override_user
-    app.dependency_overrides[require_buyer] = _override_user
-
-    try:
-        with TestClient(app) as c:
-            yield c
-    finally:
-        for dep in [get_db, require_user, require_buyer]:
-            app.dependency_overrides.pop(dep, None)
+    yield from _client_with_token(db_session, test_user, None)
 
 
 # ── Requisition: no access_token → 401 (line 1251) ──────────────────
@@ -431,7 +420,7 @@ def test_delete_requisition_onedrive_failure(
 @patch("app.http_client.http")
 def test_upload_requirement_too_large(mock_http, att_client, test_requisition, db_session):
     """requisitions.py line 1393: requirement upload > 10 MB → 400."""
-    req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     big_content = b"x" * (10 * 1024 * 1024 + 1)
     resp = att_client.post(
         f"/api/requirements/{req.id}/attachments",
@@ -442,7 +431,7 @@ def test_upload_requirement_too_large(mock_http, att_client, test_requisition, d
 
 def test_upload_requirement_no_token(notoken_client, test_requisition, db_session):
     """requisitions.py line 1395: no access_token → 401."""
-    req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     resp = notoken_client.post(
         f"/api/requirements/{req.id}/attachments",
         files={"file": ("test.pdf", BytesIO(b"data"), "application/pdf")},
@@ -457,7 +446,7 @@ def test_upload_requirement_no_token(notoken_client, test_requisition, db_sessio
 @patch("app.http_client.http")
 def test_upload_requirement_onedrive_error(mock_http, _mock_token, att_client, test_requisition, db_session):
     """requisitions.py lines 1410-1411: OneDrive upload failure → 502."""
-    req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     mock_resp = MagicMock()
     mock_resp.status_code = 500
     mock_resp.text = "Internal Server Error"
@@ -479,7 +468,7 @@ def test_delete_requirement_with_onedrive(mock_http, mock_token, att_client, db_
     """requisitions.py lines 1443-1450: delete attachment + OneDrive item."""
     mock_http.delete = AsyncMock(return_value=MagicMock(status_code=204))
 
-    req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     att = RequirementAttachment(
         requirement_id=req.id,
         file_name="onedrive-req-file.pdf",
@@ -504,7 +493,7 @@ def test_delete_requirement_onedrive_failure(
     """requisitions.py lines 1451-1452: OneDrive delete fails → still succeeds."""
     mock_http.delete = AsyncMock(side_effect=TimeoutError("timed out"))
 
-    req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     att = RequirementAttachment(
         requirement_id=req.id,
         file_name="fail-req-delete.pdf",

--- a/tests/test_attachments_coverage2.py
+++ b/tests/test_attachments_coverage2.py
@@ -166,55 +166,21 @@ class TestAttachRequisitionFromOneDriveLine123:
         assert data["onedrive_url"] == "https://od.example.com/component_spec.pdf"
         assert data["content_type"] == "application/pdf"
 
-    def test_token_expired_error_code_returns_401(self, client, test_requisition):
-        """Graph returns TokenExpired → 401."""
-        gc_mock = MagicMock()
-        gc_mock.get_json = AsyncMock(return_value={"error": {"code": "TokenExpired"}})
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="tok",
-            ),
-            patch(
-                "app.utils.graph_client.GraphClient",
-                return_value=gc_mock,
-            ),
-        ):
-            resp = client.post(
-                f"/api/requisitions/{test_requisition.id}/attachments/onedrive",
-                json={"item_id": "od-item-001"},
-            )
-        assert resp.status_code == 401
+    @pytest.mark.parametrize(
+        ("graph_error", "expected_status"),
+        [
+            pytest.param({"error": {"code": "TokenExpired"}}, 401, id="token_expired_401"),
+            pytest.param({"error": {"code": "AccessDenied"}}, 403, id="access_denied_uppercase_403"),
+            pytest.param({"error": "string-error-not-dict"}, 404, id="non_dict_error_404"),
+        ],
+    )
+    def test_graph_error_code_maps_to_status(self, client, test_requisition, graph_error, expected_status):
+        """Graph error codes map to HTTP status (incl.
 
-    def test_access_denied_uppercase_returns_403(self, client, test_requisition):
-        """Graph returns AccessDenied (uppercase) → 403."""
-        gc_mock = MagicMock()
-        gc_mock.get_json = AsyncMock(return_value={"error": {"code": "AccessDenied"}})
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="tok",
-            ),
-            patch(
-                "app.utils.graph_client.GraphClient",
-                return_value=gc_mock,
-            ),
-        ):
-            resp = client.post(
-                f"/api/requisitions/{test_requisition.id}/attachments/onedrive",
-                json={"item_id": "od-item-001"},
-            )
-        assert resp.status_code == 403
-
-    def test_non_dict_error_value_returns_404(self, client, test_requisition):
-        """Graph returns error as a non-dict string → falls through to 404.
-
-        Covers the `else ""` branch of the isinstance check on line 138.
+        the non-dict `else ""` branch).
         """
         gc_mock = MagicMock()
-        gc_mock.get_json = AsyncMock(return_value={"error": "string-error-not-dict"})
+        gc_mock.get_json = AsyncMock(return_value=graph_error)
         with (
             patch(
                 "app.scheduler.get_valid_token",
@@ -230,7 +196,7 @@ class TestAttachRequisitionFromOneDriveLine123:
                 f"/api/requisitions/{test_requisition.id}/attachments/onedrive",
                 json={"item_id": "od-item-001"},
             )
-        assert resp.status_code == 404
+        assert resp.status_code == expected_status
 
 
 # ── Lines 125-155 via direct async handler call ──────────────────────────────
@@ -313,14 +279,24 @@ class TestAttachOneDriveDirectHandler:
 
         assert exc_info.value.status_code == 401
 
-    async def test_direct_graph_auth_error_raises_401(self, db_session, test_requisition, test_user):
-        """Direct handler: Graph auth error → 401 — lines 137-140."""
+    @pytest.mark.parametrize(
+        ("error_code", "expected_status"),
+        [
+            pytest.param("InvalidAuthenticationToken", 401, id="auth_error_401"),
+            pytest.param("accessDenied", 403, id="access_denied_403"),
+            pytest.param("someOtherError", 404, id="unknown_error_404"),
+        ],
+    )
+    async def test_direct_graph_error_code_raises(
+        self, db_session, test_requisition, test_user, error_code, expected_status
+    ):
+        """Direct handler: Graph error codes raise the mapped HTTPException status."""
         from fastapi import HTTPException, Request
 
         from app.routers.requisitions.attachments import attach_requisition_from_onedrive
 
         gc_mock = MagicMock()
-        gc_mock.get_json = AsyncMock(return_value={"error": {"code": "InvalidAuthenticationToken"}})
+        gc_mock.get_json = AsyncMock(return_value={"error": {"code": error_code}})
 
         mock_request = MagicMock(spec=Request)
         mock_request.json = AsyncMock(return_value={"item_id": "od-001"})
@@ -344,73 +320,7 @@ class TestAttachOneDriveDirectHandler:
                 db=db_session,
             )
 
-        assert exc_info.value.status_code == 401
-
-    async def test_direct_graph_access_denied_raises_403(self, db_session, test_requisition, test_user):
-        """Direct handler: Graph accessDenied → 403 — line 141-143."""
-        from fastapi import HTTPException, Request
-
-        from app.routers.requisitions.attachments import attach_requisition_from_onedrive
-
-        gc_mock = MagicMock()
-        gc_mock.get_json = AsyncMock(return_value={"error": {"code": "accessDenied"}})
-
-        mock_request = MagicMock(spec=Request)
-        mock_request.json = AsyncMock(return_value={"item_id": "od-001"})
-
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="tok",
-            ),
-            patch(
-                "app.utils.graph_client.GraphClient",
-                return_value=gc_mock,
-            ),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await attach_requisition_from_onedrive(
-                req_id=test_requisition.id,
-                request=mock_request,
-                user=test_user,
-                db=db_session,
-            )
-
-        assert exc_info.value.status_code == 403
-
-    async def test_direct_item_not_found_raises_404(self, db_session, test_requisition, test_user):
-        """Direct handler: unknown error code → 404 — line 143."""
-        from fastapi import HTTPException, Request
-
-        from app.routers.requisitions.attachments import attach_requisition_from_onedrive
-
-        gc_mock = MagicMock()
-        gc_mock.get_json = AsyncMock(return_value={"error": {"code": "someOtherError"}})
-
-        mock_request = MagicMock(spec=Request)
-        mock_request.json = AsyncMock(return_value={"item_id": "od-001"})
-
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="tok",
-            ),
-            patch(
-                "app.utils.graph_client.GraphClient",
-                return_value=gc_mock,
-            ),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await attach_requisition_from_onedrive(
-                req_id=test_requisition.id,
-                request=mock_request,
-                user=test_user,
-                db=db_session,
-            )
-
-        assert exc_info.value.status_code == 404
+        assert exc_info.value.status_code == expected_status
 
     async def test_direct_missing_item_id_raises_400(self, db_session, test_requisition, test_user):
         """Direct handler: item_id missing → 400 — lines 125-127."""
@@ -447,8 +357,9 @@ class TestDeleteRequisitionAttachmentLine178:
             resp = client.delete(f"/api/requisition-attachments/{att.id}")
         assert resp.status_code == 401
 
-    def test_onedrive_delete_returns_401(self, client, db_session, test_requisition, test_user):
-        """OneDrive returns 401 during delete → 401 re-raised — line 187-188."""
+    @pytest.mark.parametrize("status", [401, 403], ids=["onedrive_401", "onedrive_403"])
+    def test_onedrive_delete_reraises_status(self, client, db_session, test_requisition, test_user, status):
+        """OneDrive 401/403 during delete is re-raised — lines 187-190."""
         att = _make_req_att(db_session, test_requisition.id, test_user.id)
         with (
             patch(
@@ -459,29 +370,11 @@ class TestDeleteRequisitionAttachmentLine178:
             patch(
                 "app.http_client.http.delete",
                 new_callable=AsyncMock,
-                return_value=_mock_resp(401),
+                return_value=_mock_resp(status),
             ),
         ):
             resp = client.delete(f"/api/requisition-attachments/{att.id}")
-        assert resp.status_code == 401
-
-    def test_onedrive_delete_returns_403(self, client, db_session, test_requisition, test_user):
-        """OneDrive returns 403 during delete → 403 re-raised — lines 189-190."""
-        att = _make_req_att(db_session, test_requisition.id, test_user.id)
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="tok",
-            ),
-            patch(
-                "app.http_client.http.delete",
-                new_callable=AsyncMock,
-                return_value=_mock_resp(403),
-            ),
-        ):
-            resp = client.delete(f"/api/requisition-attachments/{att.id}")
-        assert resp.status_code == 403
+        assert resp.status_code == status
 
 
 # ── Line 215: list_requirement_attachments — get_req_for_user returns None ───
@@ -572,9 +465,10 @@ class TestDeleteRequirementAttachmentLines309And319:
             resp = client.delete(f"/api/requirement-attachments/{att.id}")
         assert resp.status_code == 401
 
-    def test_onedrive_delete_returns_401(self, client, db_session, test_requisition, test_user):
-        """OneDrive returns 401 during requirement attachment delete → 401 — line
-        309."""
+    @pytest.mark.parametrize("status", [401, 403], ids=["onedrive_401", "onedrive_403"])
+    def test_onedrive_delete_reraises_status(self, client, db_session, test_requisition, test_user, status):
+        """OneDrive 401/403 during requirement attachment delete is re-raised — lines
+        309, 319."""
         requirement = _make_requirement(db_session, test_requisition.id)
         att = _make_reqmt_att(db_session, requirement.id, test_user.id)
         with (
@@ -586,28 +480,8 @@ class TestDeleteRequirementAttachmentLines309And319:
             patch(
                 "app.http_client.http.delete",
                 new_callable=AsyncMock,
-                return_value=_mock_resp(401),
+                return_value=_mock_resp(status),
             ),
         ):
             resp = client.delete(f"/api/requirement-attachments/{att.id}")
-        assert resp.status_code == 401
-
-    def test_onedrive_delete_returns_403(self, client, db_session, test_requisition, test_user):
-        """OneDrive returns 403 during requirement attachment delete → 403 — line
-        319."""
-        requirement = _make_requirement(db_session, test_requisition.id)
-        att = _make_reqmt_att(db_session, requirement.id, test_user.id)
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="tok",
-            ),
-            patch(
-                "app.http_client.http.delete",
-                new_callable=AsyncMock,
-                return_value=_mock_resp(403),
-            ),
-        ):
-            resp = client.delete(f"/api/requirement-attachments/{att.id}")
-        assert resp.status_code == 403
+        assert resp.status_code == status

--- a/tests/test_auto_dedup_service.py
+++ b/tests/test_auto_dedup_service.py
@@ -62,6 +62,19 @@ def _make_company(db: Session, name: str, **kw) -> Company:
     return co
 
 
+def _candidate(keep_id: int, remove_id: int, score: int = 99, *, auto_keep_id: int = None) -> dict:
+    """Build a company dedup candidate.
+
+    company_a is the keeper unless auto_keep_id overrides.
+    """
+    return {
+        "company_a": {"id": keep_id},
+        "company_b": {"id": remove_id},
+        "auto_keep_id": keep_id if auto_keep_id is None else auto_keep_id,
+        "score": score,
+    }
+
+
 # ══════════════════════════════════════════════════════════════════════
 # run_auto_dedup (top-level)
 # ══════════════════════════════════════════════════════════════════════
@@ -240,14 +253,7 @@ class TestDedupCompanies:
         remove = _make_company(db_session, "Acme Corp Dup")
         db_session.commit()
 
-        candidates = [
-            {
-                "company_a": {"id": keep.id},
-                "company_b": {"id": remove.id},
-                "auto_keep_id": keep.id,
-                "score": 99,
-            }
-        ]
+        candidates = [_candidate(keep.id, remove.id, score=99)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.company_merge_service.merge_companies") as mock_merge:
@@ -264,14 +270,7 @@ class TestDedupCompanies:
         remove = _make_company(db_session, "Acme Corporation")
         db_session.commit()
 
-        candidates = [
-            {
-                "company_a": {"id": keep.id},
-                "company_b": {"id": remove.id},
-                "auto_keep_id": keep.id,
-                "score": 95,
-            }
-        ]
+        candidates = [_candidate(keep.id, remove.id, score=95)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.auto_dedup_service._ai_confirm_company_merge", return_value=True) as mock_ai:
@@ -292,14 +291,7 @@ class TestDedupCompanies:
         remove = _make_company(db_session, "Acme Dup", account_owner_id=user2.id)
         db_session.commit()
 
-        candidates = [
-            {
-                "company_a": {"id": keep.id},
-                "company_b": {"id": remove.id},
-                "auto_keep_id": keep.id,
-                "score": 99,
-            }
-        ]
+        candidates = [_candidate(keep.id, remove.id, score=99)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.company_merge_service.merge_companies") as mock_merge:
@@ -317,14 +309,7 @@ class TestDedupCompanies:
         remove = _make_company(db_session, "Acme Dup", account_owner_id=user.id)
         db_session.commit()
 
-        candidates = [
-            {
-                "company_a": {"id": keep.id},
-                "company_b": {"id": remove.id},
-                "auto_keep_id": keep.id,
-                "score": 99,
-            }
-        ]
+        candidates = [_candidate(keep.id, remove.id, score=99)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.company_merge_service.merge_companies"):
@@ -340,14 +325,7 @@ class TestDedupCompanies:
         remove = _make_company(db_session, "Acme Dup", account_owner_id=None)
         db_session.commit()
 
-        candidates = [
-            {
-                "company_a": {"id": keep.id},
-                "company_b": {"id": remove.id},
-                "auto_keep_id": keep.id,
-                "score": 99,
-            }
-        ]
+        candidates = [_candidate(keep.id, remove.id, score=99)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.company_merge_service.merge_companies"):
@@ -365,16 +343,7 @@ class TestDedupCompanies:
             companies.append(co)
         db_session.commit()
 
-        candidates = []
-        for i in range(0, 24, 2):
-            candidates.append(
-                {
-                    "company_a": {"id": companies[i].id},
-                    "company_b": {"id": companies[i + 1].id},
-                    "auto_keep_id": companies[i].id,
-                    "score": 99,
-                }
-            )
+        candidates = [_candidate(companies[i].id, companies[i + 1].id, score=99) for i in range(0, 24, 2)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.company_merge_service.merge_companies"):
@@ -393,8 +362,8 @@ class TestDedupCompanies:
         db_session.commit()
 
         candidates = [
-            {"company_a": {"id": keep1.id}, "company_b": {"id": rem1.id}, "auto_keep_id": keep1.id, "score": 99},
-            {"company_a": {"id": keep2.id}, "company_b": {"id": rem2.id}, "auto_keep_id": keep2.id, "score": 99},
+            _candidate(keep1.id, rem1.id, score=99),
+            _candidate(keep2.id, rem2.id, score=99),
         ]
 
         call_count = 0
@@ -418,14 +387,7 @@ class TestDedupCompanies:
         keep = _make_company(db_session, "Real Co")
         db_session.commit()
 
-        candidates = [
-            {
-                "company_a": {"id": keep.id},
-                "company_b": {"id": 99999},
-                "auto_keep_id": keep.id,
-                "score": 99,
-            }
-        ]
+        candidates = [_candidate(keep.id, 99999, score=99)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.company_merge_service.merge_companies") as mock_merge:
@@ -442,14 +404,7 @@ class TestDedupCompanies:
         remove = _make_company(db_session, "Acme Corporation")
         db_session.commit()
 
-        candidates = [
-            {
-                "company_a": {"id": keep.id},
-                "company_b": {"id": remove.id},
-                "auto_keep_id": keep.id,
-                "score": 94,
-            }
-        ]
+        candidates = [_candidate(keep.id, remove.id, score=94)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.auto_dedup_service._ai_confirm_company_merge", return_value=False):
@@ -467,14 +422,7 @@ class TestDedupCompanies:
         remove = _make_company(db_session, "Remove")
         db_session.commit()
 
-        candidates = [
-            {
-                "company_a": {"id": keep.id},
-                "company_b": {"id": remove.id},
-                "auto_keep_id": keep.id,
-                "score": 99,
-            }
-        ]
+        candidates = [_candidate(keep.id, remove.id, score=99, auto_keep_id=keep.id)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.company_merge_service.merge_companies") as mock_merge:
@@ -490,14 +438,7 @@ class TestDedupCompanies:
         co_b = _make_company(db_session, "CoB")
         db_session.commit()
 
-        candidates = [
-            {
-                "company_a": {"id": co_a.id},
-                "company_b": {"id": co_b.id},
-                "auto_keep_id": co_b.id,
-                "score": 99,
-            }
-        ]
+        candidates = [_candidate(co_a.id, co_b.id, score=99, auto_keep_id=co_b.id)]
 
         with patch("app.company_utils.find_company_dedup_candidates", return_value=candidates):
             with patch("app.services.company_merge_service.merge_companies") as mock_merge:
@@ -512,67 +453,50 @@ class TestDedupCompanies:
 
 
 class TestAIConfirmation:
-    def test_ai_confirm_vendor_merge_true(self):
-        """Should return True when Claude says same entity."""
+    @pytest.mark.parametrize(
+        ("claude_return", "claude_side_effect", "expected"),
+        [
+            pytest.param(True, None, True, id="true"),
+            pytest.param(False, None, False, id="false"),
+            pytest.param(None, RuntimeError("API error"), False, id="exception"),
+        ],
+    )
+    def test_ai_confirm_vendor_merge(self, claude_return, claude_side_effect, expected):
+        """Mirrors _ask_claude_merge; exception falls back to False (safe default)."""
         from app.services.auto_dedup_service import _ai_confirm_vendor_merge
 
-        with patch("app.services.auto_dedup_service._ask_claude_merge", new_callable=AsyncMock, return_value=True):
+        with patch(
+            "app.services.auto_dedup_service._ask_claude_merge",
+            new_callable=AsyncMock,
+            return_value=claude_return,
+            side_effect=claude_side_effect,
+        ):
             result = _ai_confirm_vendor_merge("Arrow Electronics", "Arrow Elec", 95)
 
-        assert result is True
+        assert result is expected
 
-    def test_ai_confirm_vendor_merge_false(self):
-        """Should return False when Claude says different entity."""
-        from app.services.auto_dedup_service import _ai_confirm_vendor_merge
-
-        with patch("app.services.auto_dedup_service._ask_claude_merge", new_callable=AsyncMock, return_value=False):
-            result = _ai_confirm_vendor_merge("Arrow Electronics", "Digi-Key", 92)
-
-        assert result is False
-
-    def test_ai_confirm_vendor_merge_exception(self):
-        """Should return False on exception (safe default)."""
-        from app.services.auto_dedup_service import _ai_confirm_vendor_merge
-
-        with patch(
-            "app.services.auto_dedup_service._ask_claude_merge",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("API error"),
-        ):
-            result = _ai_confirm_vendor_merge("A", "B", 95)
-
-        assert result is False
-
-    def test_ai_confirm_company_merge_true(self):
-        """Should return True when Claude confirms company match."""
-        from app.services.auto_dedup_service import _ai_confirm_company_merge
-
-        with patch("app.services.auto_dedup_service._ask_claude_merge", new_callable=AsyncMock, return_value=True):
-            result = _ai_confirm_company_merge("Acme Corp", "ACME Corporation", "acme.com", "acme.com", 95)
-
-        assert result is True
-
-    def test_ai_confirm_company_merge_no_domains(self):
-        """Should handle None domains gracefully."""
-        from app.services.auto_dedup_service import _ai_confirm_company_merge
-
-        with patch("app.services.auto_dedup_service._ask_claude_merge", new_callable=AsyncMock, return_value=False):
-            result = _ai_confirm_company_merge("A", "B", None, None, 93)
-
-        assert result is False
-
-    def test_ai_confirm_company_merge_exception(self):
-        """Should return False on exception."""
+    @pytest.mark.parametrize(
+        ("domain_a", "domain_b", "claude_return", "claude_side_effect", "expected"),
+        [
+            pytest.param("acme.com", "acme.com", True, None, True, id="true"),
+            pytest.param(None, None, False, None, False, id="no_domains"),
+            pytest.param(None, None, None, RuntimeError("boom"), False, id="exception"),
+        ],
+    )
+    def test_ai_confirm_company_merge(self, domain_a, domain_b, claude_return, claude_side_effect, expected):
+        """Mirrors _ask_claude_merge; None domains handled gracefully; exception →
+        False."""
         from app.services.auto_dedup_service import _ai_confirm_company_merge
 
         with patch(
             "app.services.auto_dedup_service._ask_claude_merge",
             new_callable=AsyncMock,
-            side_effect=RuntimeError("boom"),
+            return_value=claude_return,
+            side_effect=claude_side_effect,
         ):
-            result = _ai_confirm_company_merge("A", "B", None, None, 95)
+            result = _ai_confirm_company_merge("Acme Corp", "ACME Corporation", domain_a, domain_b, 95)
 
-        assert result is False
+        assert result is expected
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -581,63 +505,26 @@ class TestAIConfirmation:
 
 
 class TestAskClaudeMerge:
-    def test_returns_true_high_confidence(self):
-        """Should return True when same_entity=True and confidence >= 0.85."""
+    @pytest.mark.parametrize(
+        ("claude_response", "expected"),
+        [
+            pytest.param({"same_entity": True, "confidence": 0.95}, True, id="high_confidence"),
+            pytest.param({"same_entity": True, "confidence": 0.60}, False, id="low_confidence"),
+            pytest.param({"same_entity": False, "confidence": 0.99}, False, id="not_same"),
+            pytest.param(None, False, id="none"),
+            pytest.param({}, False, id="missing_keys"),
+            pytest.param({"same_entity": True, "confidence": 0.85}, True, id="boundary_confidence_085"),
+        ],
+    )
+    def test_decision(self, claude_response, expected):
+        """same_entity=True AND confidence >= 0.85 (inclusive) returns True; otherwise
+        False."""
         from app.services.auto_dedup_service import _ask_claude_merge
 
-        mock_result = {"same_entity": True, "confidence": 0.95}
-        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=mock_result):
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=claude_response):
             result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("Are A and B the same?"))
 
-        assert result is True
-
-    def test_returns_false_low_confidence(self):
-        """Should return False when confidence < 0.85."""
-        from app.services.auto_dedup_service import _ask_claude_merge
-
-        mock_result = {"same_entity": True, "confidence": 0.60}
-        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=mock_result):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("Are A and B the same?"))
-
-        assert result is False
-
-    def test_returns_false_not_same(self):
-        """Should return False when same_entity=False."""
-        from app.services.auto_dedup_service import _ask_claude_merge
-
-        mock_result = {"same_entity": False, "confidence": 0.99}
-        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=mock_result):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("Are A and B the same?"))
-
-        assert result is False
-
-    def test_returns_false_on_none(self):
-        """Should return False when Claude returns None."""
-        from app.services.auto_dedup_service import _ask_claude_merge
-
-        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=None):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("Are A and B the same?"))
-
-        assert result is False
-
-    def test_returns_false_missing_keys(self):
-        """Should return False when response is missing keys."""
-        from app.services.auto_dedup_service import _ask_claude_merge
-
-        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value={}):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("Are A and B the same?"))
-
-        assert result is False
-
-    def test_boundary_confidence_085(self):
-        """Confidence exactly at 0.85 should return True."""
-        from app.services.auto_dedup_service import _ask_claude_merge
-
-        mock_result = {"same_entity": True, "confidence": 0.85}
-        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=mock_result):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("Are A and B the same?"))
-
-        assert result is True
+        assert result is expected
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/test_avail_score.py
+++ b/tests/test_avail_score.py
@@ -9,6 +9,7 @@ import os
 os.environ["TESTING"] = "1"
 os.environ["RATE_LIMIT_ENABLED"] = "false"
 
+from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 from unittest.mock import patch
 
@@ -131,20 +132,20 @@ def _make_quote(
 
 
 class TestTier:
-    def test_tier_highest(self):
-        assert _tier(100, [(90, 10), (80, 8), (70, 6)]) == 10
+    TIERS = [(90, 10), (80, 8), (70, 6)]
 
-    def test_tier_middle(self):
-        assert _tier(85, [(90, 10), (80, 8), (70, 6)]) == 8
-
-    def test_tier_lowest(self):
-        assert _tier(50, [(90, 10), (80, 8), (70, 6)]) == 0
-
-    def test_tier_exact_boundary(self):
-        assert _tier(80, [(90, 10), (80, 8), (70, 6)]) == 8
-
-    def test_tier_empty(self):
-        assert _tier(100, []) == 0
+    @pytest.mark.parametrize(
+        "value, tiers, expected",
+        [
+            pytest.param(100, TIERS, 10, id="highest"),
+            pytest.param(85, TIERS, 8, id="middle"),
+            pytest.param(50, TIERS, 0, id="lowest"),
+            pytest.param(80, TIERS, 8, id="exact_boundary"),
+            pytest.param(100, [], 0, id="empty"),
+        ],
+    )
+    def test_tier(self, value, tiers, expected):
+        assert _tier(value, tiers) == expected
 
 
 # ── Unit tests: _rank_and_bonus ─────────────────────────────────────
@@ -595,6 +596,24 @@ class TestGetAvailScores:
 # ── API Endpoint Tests ──────────────────────────────────────────────
 
 
+@contextmanager
+def _api_client(db_session, current_user):
+    """Build a TestClient with get_db + require_user overridden, cleaning up after."""
+    from fastapi.testclient import TestClient
+
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: current_user
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(require_user, None)
+
+
 @pytest.mark.skipif(
     os.environ.get("MVP_MODE", "true").lower() == "true",
     reason="Performance router disabled in MVP mode",
@@ -602,99 +621,47 @@ class TestGetAvailScores:
 class TestAvailScoreAPI:
     def test_get_avail_scores_buyer(self, db_session):
         """GET /api/performance/avail-scores?role=buyer returns data."""
-        from app.dependencies import require_user
-        from app.main import app
-
         buyer = _make_user(db_session, "API Buyer", "buyer", "apibuyer")
         db_session.commit()
         compute_all_avail_scores(db_session, MONTH)
 
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-
-        app.dependency_overrides[get_db] = lambda: db_session
-        app.dependency_overrides[require_user] = lambda: buyer
-        client = TestClient(app)
-
-        resp = client.get("/api/performance/avail-scores?role=buyer&month=2026-02")
+        with _api_client(db_session, buyer) as client:
+            resp = client.get("/api/performance/avail-scores?role=buyer&month=2026-02")
         assert resp.status_code == 200
         data = resp.json()
         assert data["role"] == "buyer"
         assert len(data["entries"]) == 1
 
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(require_user, None)
-
     def test_get_avail_scores_sales(self, db_session):
         """GET /api/performance/avail-scores?role=sales returns data."""
-        from app.dependencies import require_user
-        from app.main import app
-
         sales = _make_user(db_session, "API Sales", "sales", "apisales")
         db_session.commit()
         compute_all_avail_scores(db_session, MONTH)
 
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-
-        app.dependency_overrides[get_db] = lambda: db_session
-        app.dependency_overrides[require_user] = lambda: sales
-        client = TestClient(app)
-
-        resp = client.get("/api/performance/avail-scores?role=sales&month=2026-02")
+        with _api_client(db_session, sales) as client:
+            resp = client.get("/api/performance/avail-scores?role=sales&month=2026-02")
         assert resp.status_code == 200
         data = resp.json()
         assert data["role"] == "sales"
         assert len(data["entries"]) >= 1
 
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(require_user, None)
-
     def test_invalid_role_rejected(self, db_session):
         """Invalid role returns 422."""
-        from app.dependencies import require_user
-        from app.main import app
-
         user = _make_user(db_session, "Bad Role", "buyer", "badrole")
         db_session.commit()
 
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-
-        app.dependency_overrides[get_db] = lambda: db_session
-        app.dependency_overrides[require_user] = lambda: user
-        client = TestClient(app)
-
-        resp = client.get("/api/performance/avail-scores?role=invalid")
+        with _api_client(db_session, user) as client:
+            resp = client.get("/api/performance/avail-scores?role=invalid")
         assert resp.status_code == 422
-
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(require_user, None)
 
     def test_refresh_requires_admin(self, db_session):
         """POST refresh requires admin role."""
-        from app.dependencies import require_user
-        from app.main import app
-
         buyer = _make_user(db_session, "NonAdmin", "buyer", "nonadmin")
         db_session.commit()
 
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-
-        app.dependency_overrides[get_db] = lambda: db_session
-        app.dependency_overrides[require_user] = lambda: buyer
-        client = TestClient(app)
-
-        resp = client.post("/api/performance/avail-scores/refresh")
+        with _api_client(db_session, buyer) as client:
+            resp = client.post("/api/performance/avail-scores/refresh")
         assert resp.status_code == 403
-
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(require_user, None)
 
 
 # ── Edge cases ──────────────────────────────────────────────────────

--- a/tests/test_connector_status.py
+++ b/tests/test_connector_status.py
@@ -5,6 +5,33 @@ Covers uncovered line 35: when all connectors are disabled.
 
 from unittest.mock import patch
 
+# Every credential attribute log_connector_status() inspects, defaulted to empty
+# (disabled). Individual tests override only the credentials they want set.
+_ALL_CREDENTIALS = (
+    "nexar_client_id",
+    "nexar_client_secret",
+    "brokerbin_api_key",
+    "brokerbin_api_secret",
+    "ebay_client_id",
+    "ebay_client_secret",
+    "digikey_client_id",
+    "digikey_client_secret",
+    "mouser_api_key",
+    "oemsecrets_api_key",
+    "sourcengine_api_key",
+    "element14_api_key",
+    "anthropic_api_key",
+    "azure_client_id",
+    "azure_client_secret",
+    "azure_tenant_id",
+)
+
+
+def _configure_settings(mock_settings, **overrides):
+    """Set all credentials to empty (disabled), then apply the given overrides."""
+    for name in _ALL_CREDENTIALS:
+        setattr(mock_settings, name, overrides.get(name, ""))
+
 
 class TestLogConnectorStatus:
     def test_all_disabled_returns_dict(self):
@@ -12,23 +39,7 @@ class TestLogConnectorStatus:
         from app.connector_status import log_connector_status
 
         with patch("app.connector_status.settings") as mock_settings:
-            # Set all credentials to empty strings
-            mock_settings.nexar_client_id = ""
-            mock_settings.nexar_client_secret = ""
-            mock_settings.brokerbin_api_key = ""
-            mock_settings.brokerbin_api_secret = ""
-            mock_settings.ebay_client_id = ""
-            mock_settings.ebay_client_secret = ""
-            mock_settings.digikey_client_id = ""
-            mock_settings.digikey_client_secret = ""
-            mock_settings.mouser_api_key = ""
-            mock_settings.oemsecrets_api_key = ""
-            mock_settings.sourcengine_api_key = ""
-            mock_settings.element14_api_key = ""
-            mock_settings.anthropic_api_key = ""
-            mock_settings.azure_client_id = ""
-            mock_settings.azure_client_secret = ""
-            mock_settings.azure_tenant_id = ""
+            _configure_settings(mock_settings)
 
             result = log_connector_status()
 
@@ -40,22 +51,12 @@ class TestLogConnectorStatus:
         from app.connector_status import log_connector_status
 
         with patch("app.connector_status.settings") as mock_settings:
-            mock_settings.nexar_client_id = "id"
-            mock_settings.nexar_client_secret = "secret"
-            mock_settings.brokerbin_api_key = ""
-            mock_settings.brokerbin_api_secret = ""
-            mock_settings.ebay_client_id = ""
-            mock_settings.ebay_client_secret = ""
-            mock_settings.digikey_client_id = ""
-            mock_settings.digikey_client_secret = ""
-            mock_settings.mouser_api_key = "key"
-            mock_settings.oemsecrets_api_key = ""
-            mock_settings.sourcengine_api_key = ""
-            mock_settings.element14_api_key = ""
-            mock_settings.anthropic_api_key = ""
-            mock_settings.azure_client_id = ""
-            mock_settings.azure_client_secret = ""
-            mock_settings.azure_tenant_id = ""
+            _configure_settings(
+                mock_settings,
+                nexar_client_id="id",
+                nexar_client_secret="secret",
+                mouser_api_key="key",
+            )
 
             result = log_connector_status()
 

--- a/tests/test_credential_service.py
+++ b/tests/test_credential_service.py
@@ -23,6 +23,25 @@ from app.services.credential_service import (
     mask_value,
 )
 
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _add_api_source(db_session, name, key, plaintext):
+    """Persist an ApiSource holding one encrypted credential under ``key``."""
+    src = ApiSource(
+        name=name,
+        display_name=f"{name} display",
+        category="api",
+        source_type="aggregator",
+        status="active",
+        env_vars=[key],
+        credentials={key: encrypt_value(plaintext)},
+    )
+    db_session.add(src)
+    db_session.commit()
+    return src
+
+
 # ── encrypt / decrypt ────────────────────────────────────────────────
 
 
@@ -34,16 +53,16 @@ class TestEncryptDecrypt:
         encrypted = encrypt_value(plaintext)
         assert encrypted != plaintext
 
-    def test_round_trip(self):
-        plaintext = "sk-ant-api03-XXXXXX"
+    @pytest.mark.parametrize(
+        "plaintext",
+        [
+            pytest.param("sk-ant-api03-XXXXXX", id="ascii"),
+            pytest.param("pässwörd-with-üñíçödé", id="unicode"),
+            pytest.param("", id="empty_string"),
+        ],
+    )
+    def test_round_trip(self, plaintext):
         assert decrypt_value(encrypt_value(plaintext)) == plaintext
-
-    def test_round_trip_unicode(self):
-        plaintext = "pässwörd-with-üñíçödé"
-        assert decrypt_value(encrypt_value(plaintext)) == plaintext
-
-    def test_round_trip_empty_string(self):
-        assert decrypt_value(encrypt_value("")) == ""
 
     def test_decrypt_corrupted_token_raises(self):
         with pytest.raises((InvalidToken, Exception)):
@@ -95,18 +114,7 @@ class TestGetCredential:
     """DB-first, env-fallback credential retrieval."""
 
     def test_returns_decrypted_db_value(self, db_session):
-        encrypted = encrypt_value("db-secret-value")
-        src = ApiSource(
-            name="test_src",
-            display_name="Test Source",
-            category="api",
-            source_type="aggregator",
-            status="active",
-            env_vars=["MY_KEY"],
-            credentials={"MY_KEY": encrypted},
-        )
-        db_session.add(src)
-        db_session.commit()
+        _add_api_source(db_session, "test_src", "MY_KEY", "db-secret-value")
 
         result = get_credential(db_session, "test_src", "MY_KEY")
         assert result == "db-secret-value"
@@ -123,18 +131,7 @@ class TestGetCredential:
 
     def test_db_takes_priority_over_env(self, db_session, monkeypatch):
         monkeypatch.setenv("MY_KEY", "env-value")
-        encrypted = encrypt_value("db-value")
-        src = ApiSource(
-            name="priority_src",
-            display_name="Priority Source",
-            category="api",
-            source_type="aggregator",
-            status="active",
-            env_vars=["MY_KEY"],
-            credentials={"MY_KEY": encrypted},
-        )
-        db_session.add(src)
-        db_session.commit()
+        _add_api_source(db_session, "priority_src", "MY_KEY", "db-value")
 
         result = get_credential(db_session, "priority_src", "MY_KEY")
         assert result == "db-value"
@@ -147,18 +144,7 @@ class TestCredentialIsSet:
     """Boolean check for credential existence."""
 
     def test_true_when_db_credential_exists(self, db_session):
-        encrypted = encrypt_value("some-value")
-        src = ApiSource(
-            name="check_src",
-            display_name="Check Source",
-            category="api",
-            source_type="aggregator",
-            status="active",
-            env_vars=["CHECK_KEY"],
-            credentials={"CHECK_KEY": encrypted},
-        )
-        db_session.add(src)
-        db_session.commit()
+        _add_api_source(db_session, "check_src", "CHECK_KEY", "some-value")
 
         assert credential_is_set(db_session, "check_src", "CHECK_KEY") is True
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -103,8 +103,6 @@ class TestRequireFreshToken:
 
     async def test_raises_401_when_truly_expired(self, db_session, test_user):
         """Token past expiry → 401, m365_connected set to False."""
-        from fastapi import HTTPException
-
         test_user.access_token = "expired-token"
         test_user.token_expires_at = datetime.now(timezone.utc) - timedelta(minutes=5)
         test_user.m365_connected = True
@@ -119,8 +117,6 @@ class TestRequireFreshToken:
 
     async def test_raises_401_when_no_access_token(self, db_session, test_user):
         """User with no access_token → 401."""
-        from fastapi import HTTPException
-
         test_user.access_token = None
         db_session.commit()
 
@@ -131,8 +127,6 @@ class TestRequireFreshToken:
 
     async def test_raises_401_when_no_session(self, db_session):
         """No session → 401."""
-        from fastapi import HTTPException
-
         request = _mock_request({})
         with pytest.raises(HTTPException) as exc_info:
             await require_fresh_token(request, db_session)

--- a/tests/test_description_service_coverage.py
+++ b/tests/test_description_service_coverage.py
@@ -11,11 +11,24 @@ import os
 
 os.environ["TESTING"] = "1"
 
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests.conftest import TestSessionLocal
+
+
+@contextmanager
+def _testing_disabled():
+    """Temporarily remove TESTING so real function bodies run, then restore it."""
+    saved = os.environ.pop("TESTING", None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            os.environ["TESTING"] = saved
+
 
 # ── _collect_db_descriptions via patched SessionLocal ─────────────
 
@@ -296,8 +309,7 @@ def test_collect_db_descriptions_limits_to_five_sources():
 
 def test_backfill_descriptions_runs_when_not_testing():
     """backfill_descriptions processes requirements when TESTING is unset."""
-    import os
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import AsyncMock
 
     from app.services.description_service import backfill_descriptions
 
@@ -318,6 +330,7 @@ def test_backfill_descriptions_runs_when_not_testing():
     }
 
     with (
+        _testing_disabled(),
         patch.dict(os.environ, {}, clear=False),
         patch("app.services.description_service.SessionLocal", return_value=mock_db),
         patch(
@@ -326,13 +339,7 @@ def test_backfill_descriptions_runs_when_not_testing():
             return_value=mock_result,
         ),
     ):
-        # Temporarily remove TESTING to test the real function body
-        saved = os.environ.pop("TESTING", None)
-        try:
-            backfill_descriptions([1])
-        finally:
-            if saved is not None:
-                os.environ["TESTING"] = saved
+        backfill_descriptions([1])
 
     mock_db.commit.assert_called_once()
     assert mock_req.description == "IC VOLT REG ADJ 1.5A TO-220"
@@ -340,8 +347,7 @@ def test_backfill_descriptions_runs_when_not_testing():
 
 def test_backfill_descriptions_skips_existing_description():
     """backfill_descriptions skips requirements that already have a description."""
-    import os
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import AsyncMock
 
     from app.services.description_service import backfill_descriptions
 
@@ -355,18 +361,14 @@ def test_backfill_descriptions_skips_existing_description():
     mock_db.get.return_value = mock_req
 
     with (
+        _testing_disabled(),
         patch("app.services.description_service.SessionLocal", return_value=mock_db),
         patch(
             "app.services.description_service.generate_verified_description",
             new_callable=AsyncMock,
         ) as mock_gen,
     ):
-        saved = os.environ.pop("TESTING", None)
-        try:
-            backfill_descriptions([1])
-        finally:
-            if saved is not None:
-                os.environ["TESTING"] = saved
+        backfill_descriptions([1])
 
     # generate_verified_description should NOT be called since description exists
     mock_gen.assert_not_called()
@@ -374,8 +376,7 @@ def test_backfill_descriptions_skips_existing_description():
 
 def test_backfill_descriptions_skips_missing_requirement():
     """backfill_descriptions skips non-existent requirement IDs gracefully."""
-    import os
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import AsyncMock
 
     from app.services.description_service import backfill_descriptions
 
@@ -383,26 +384,21 @@ def test_backfill_descriptions_skips_missing_requirement():
     mock_db.get.return_value = None  # Requirement not found
 
     with (
+        _testing_disabled(),
         patch("app.services.description_service.SessionLocal", return_value=mock_db),
         patch(
             "app.services.description_service.generate_verified_description",
             new_callable=AsyncMock,
         ) as mock_gen,
     ):
-        saved = os.environ.pop("TESTING", None)
-        try:
-            backfill_descriptions([999])
-        finally:
-            if saved is not None:
-                os.environ["TESTING"] = saved
+        backfill_descriptions([999])
 
     mock_gen.assert_not_called()
 
 
 def test_backfill_descriptions_handles_exception_gracefully():
     """backfill_descriptions catches exceptions and continues."""
-    import os
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import AsyncMock
 
     from app.services.description_service import backfill_descriptions
 
@@ -416,6 +412,7 @@ def test_backfill_descriptions_handles_exception_gracefully():
     mock_db.get.return_value = mock_req
 
     with (
+        _testing_disabled(),
         patch("app.services.description_service.SessionLocal", return_value=mock_db),
         patch(
             "app.services.description_service.generate_verified_description",
@@ -423,20 +420,14 @@ def test_backfill_descriptions_handles_exception_gracefully():
             side_effect=Exception("AI service unavailable"),
         ),
     ):
-        saved = os.environ.pop("TESTING", None)
-        try:
-            # Should not raise even when generate_verified_description fails
-            backfill_descriptions([1])
-        finally:
-            if saved is not None:
-                os.environ["TESTING"] = saved
+        # Should not raise even when generate_verified_description fails
+        backfill_descriptions([1])
 
 
 def test_backfill_descriptions_updates_material_card():
     """backfill_descriptions updates linked MaterialCard when card has no
     description."""
-    import os
-    from unittest.mock import AsyncMock, MagicMock
+    from unittest.mock import AsyncMock
 
     from app.services.description_service import backfill_descriptions
 
@@ -455,6 +446,7 @@ def test_backfill_descriptions_updates_material_card():
     mock_result = {"description": "IC MCU 32-BIT", "confidence": 0.90, "sources_used": 2}
 
     with (
+        _testing_disabled(),
         patch("app.services.description_service.SessionLocal", return_value=mock_db),
         patch(
             "app.services.description_service.generate_verified_description",
@@ -462,12 +454,7 @@ def test_backfill_descriptions_updates_material_card():
             return_value=mock_result,
         ),
     ):
-        saved = os.environ.pop("TESTING", None)
-        try:
-            backfill_descriptions([1])
-        finally:
-            if saved is not None:
-                os.environ["TESTING"] = saved
+        backfill_descriptions([1])
 
     assert mock_card.description == "IC MCU 32-BIT"
 

--- a/tests/test_email_intelligence_service_coverage.py
+++ b/tests/test_email_intelligence_service_coverage.py
@@ -24,6 +24,8 @@ os.environ["TESTING"] = "1"
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from app.services.email_intelligence_service import (
     classify_email_ai,
     detect_specialties_ai,
@@ -34,6 +36,22 @@ from app.services.email_intelligence_service import (
     summarize_thread,
 )
 from app.utils.claude_errors import ClaudeError, ClaudeUnavailableError
+
+
+def _graph_client_with_messages(messages):
+    """MagicMock GraphClient whose get_all_pages returns the given messages."""
+    gc_mock = MagicMock()
+    gc_mock.get_all_pages = AsyncMock(return_value=messages)
+    return gc_mock
+
+
+def _one_message(content="Body"):
+    return {
+        "from": {"emailAddress": {"address": "v@v.com"}},
+        "body": {"content": content},
+        "receivedDateTime": "2025-01-01T00:00:00Z",
+    }
+
 
 # ── classify_email_ai ─────────────────────────────────────────────────
 
@@ -60,56 +78,39 @@ class TestClassifyEmailAi:
             result = await classify_email_ai("Subject", "Body")
         assert result is None
 
-    async def test_non_dict_result_returns_none(self):
-        """None or non-dict result → returns None (lines 85-86)."""
-        with patch("app.utils.claude_client.claude_json", new=AsyncMock(return_value=None)):
-            result = await classify_email_ai("Subject", "Body")
-        assert result is None
-
-    async def test_invalid_classification_defaults_to_general(self):
-        """Unknown classification → 'general' (lines 91-93)."""
-        with patch(
-            "app.utils.claude_client.claude_json",
-            new=AsyncMock(
-                return_value={
-                    "classification": "banana",
-                    "confidence": 0.9,
-                    "has_pricing": False,
-                }
+    @pytest.mark.parametrize(
+        ("claude_return", "expected_field", "expected_value"),
+        [
+            pytest.param(None, None, None, id="non_dict_result_returns_none"),
+            pytest.param(
+                {"classification": "banana", "confidence": 0.9, "has_pricing": False},
+                "classification",
+                "general",
+                id="invalid_classification_defaults_to_general",
             ),
-        ):
-            result = await classify_email_ai("Subject", "Body")
-        assert result["classification"] == "general"
-
-    async def test_confidence_clamped_to_zero_one(self):
-        """Confidence outside [0,1] is clamped (lines 96-99)."""
-        with patch(
-            "app.utils.claude_client.claude_json",
-            new=AsyncMock(
-                return_value={
-                    "classification": "offer",
-                    "confidence": 2.5,  # > 1.0
-                    "has_pricing": True,
-                }
+            pytest.param(
+                {"classification": "offer", "confidence": 2.5, "has_pricing": True},
+                "confidence",
+                1.0,
+                id="confidence_clamped_to_zero_one",
             ),
-        ):
-            result = await classify_email_ai("Subject", "Body")
-        assert result["confidence"] == 1.0
-
-    async def test_invalid_confidence_type_defaults_to_half(self):
-        """Non-numeric confidence → 0.5 (lines 97-99)."""
-        with patch(
-            "app.utils.claude_client.claude_json",
-            new=AsyncMock(
-                return_value={
-                    "classification": "offer",
-                    "confidence": "high",  # invalid type
-                    "has_pricing": True,
-                }
+            pytest.param(
+                {"classification": "offer", "confidence": "high", "has_pricing": True},
+                "confidence",
+                0.5,
+                id="invalid_confidence_type_defaults_to_half",
             ),
-        ):
+        ],
+    )
+    async def test_result_normalization(self, claude_return, expected_field, expected_value):
+        """None/non-dict → None; unknown classification → 'general'; confidence clamped
+        to [0,1]; non-numeric confidence → 0.5 (lines 85-99)."""
+        with patch("app.utils.claude_client.claude_json", new=AsyncMock(return_value=claude_return)):
             result = await classify_email_ai("Subject", "Body")
-        assert result["confidence"] == 0.5
+        if expected_field is None:
+            assert result is None
+        else:
+            assert result[expected_field] == expected_value
 
 
 # ── extract_pricing_intelligence ─────────────────────────────────────
@@ -561,7 +562,7 @@ class TestSummarizeThread:
 
     async def test_graph_fetch_failure_returns_none(self, db_session, test_user):
         """Graph API fetch raises → returns None (lines 451-453)."""
-        gc_mock = MagicMock()
+        gc_mock = _graph_client_with_messages([])
         gc_mock.get_all_pages = AsyncMock(side_effect=Exception("network error"))
 
         with patch("app.utils.graph_client.GraphClient", return_value=gc_mock):
@@ -570,80 +571,42 @@ class TestSummarizeThread:
 
     async def test_empty_messages_returns_none(self, db_session, test_user):
         """No messages fetched → returns None (lines 455-456)."""
-        gc_mock = MagicMock()
-        gc_mock.get_all_pages = AsyncMock(return_value=[])
+        gc_mock = _graph_client_with_messages([])
 
         with patch("app.utils.graph_client.GraphClient", return_value=gc_mock):
             result = await summarize_thread("tok", "conv-empty", db_session, test_user.id)
         assert result is None
 
-    async def test_claude_unavailable_returns_none(self, db_session, test_user):
-        """ClaudeUnavailableError → returns None (lines 477-479)."""
-        gc_mock = MagicMock()
-        gc_mock.get_all_pages = AsyncMock(
-            return_value=[
-                {
-                    "from": {"emailAddress": {"address": "v@v.com"}},
-                    "body": {"content": "Some email body"},
-                    "receivedDateTime": "2025-01-01T00:00:00Z",
-                }
-            ]
-        )
+    @pytest.mark.parametrize(
+        ("claude_mock", "conv_id"),
+        [
+            pytest.param(
+                AsyncMock(side_effect=ClaudeUnavailableError("not configured")),
+                "conv-unavail",
+                id="claude_unavailable",
+            ),
+            pytest.param(
+                AsyncMock(side_effect=ClaudeError("fail")),
+                "conv-error",
+                id="claude_error",
+            ),
+            pytest.param(
+                AsyncMock(return_value=None),
+                "conv-null",
+                id="non_dict_result",
+            ),
+        ],
+    )
+    async def test_claude_summary_failure_returns_none(self, db_session, test_user, claude_mock, conv_id):
+        """ClaudeUnavailableError / ClaudeError / non-dict summary → returns None (lines
+        477-485)."""
+        gc_mock = _graph_client_with_messages([_one_message()])
 
         with (
             patch("app.utils.graph_client.GraphClient", return_value=gc_mock),
-            patch(
-                "app.utils.claude_client.claude_json",
-                new=AsyncMock(side_effect=ClaudeUnavailableError("not configured")),
-            ),
+            patch("app.utils.claude_client.claude_json", new=claude_mock),
         ):
-            result = await summarize_thread("tok", "conv-unavail", db_session, test_user.id)
-        assert result is None
-
-    async def test_claude_error_returns_none(self, db_session, test_user):
-        """ClaudeError → returns None (lines 480-482)."""
-        gc_mock = MagicMock()
-        gc_mock.get_all_pages = AsyncMock(
-            return_value=[
-                {
-                    "from": {"emailAddress": {"address": "v@v.com"}},
-                    "body": {"content": "Body"},
-                    "receivedDateTime": "2025-01-01T00:00:00Z",
-                }
-            ]
-        )
-
-        with (
-            patch("app.utils.graph_client.GraphClient", return_value=gc_mock),
-            patch(
-                "app.utils.claude_client.claude_json",
-                new=AsyncMock(side_effect=ClaudeError("fail")),
-            ),
-        ):
-            result = await summarize_thread("tok", "conv-error", db_session, test_user.id)
-        assert result is None
-
-    async def test_non_dict_result_returns_none(self, db_session, test_user):
-        """Non-dict summary result → returns None (lines 484-485)."""
-        gc_mock = MagicMock()
-        gc_mock.get_all_pages = AsyncMock(
-            return_value=[
-                {
-                    "from": {"emailAddress": {"address": "v@v.com"}},
-                    "body": {"content": "Body"},
-                    "receivedDateTime": "2025-01-01T00:00:00Z",
-                }
-            ]
-        )
-
-        with (
-            patch("app.utils.graph_client.GraphClient", return_value=gc_mock),
-            patch(
-                "app.utils.claude_client.claude_json",
-                new=AsyncMock(return_value=None),
-            ),
-        ):
-            result = await summarize_thread("tok", "conv-null", db_session, test_user.id)
+            result = await summarize_thread("tok", conv_id, db_session, test_user.id)
         assert result is None
 
 

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -9,6 +9,8 @@ Depends on: app/file_utils.py
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.file_utils import (
     normalize_stock_row,
     parse_tabular_file,
@@ -17,6 +19,17 @@ from app.file_utils import (
 # ═══════════════════════════════════════════════════════════════════════
 #  parse_tabular_file
 # ═══════════════════════════════════════════════════════════════════════
+
+
+def _stub_openpyxl_rows(rows):
+    """Wire the patched openpyxl stub so load_workbook().active.iter_rows() yields
+    rows."""
+    mock_openpyxl = sys.modules["openpyxl"]
+    mock_wb = MagicMock()
+    mock_ws = MagicMock()
+    mock_ws.iter_rows.return_value = rows
+    mock_wb.active = mock_ws
+    mock_openpyxl.load_workbook.return_value = mock_wb
 
 
 class TestParseTabularFile:
@@ -42,17 +55,13 @@ class TestParseTabularFile:
 
     @patch.dict("sys.modules", {"openpyxl": MagicMock()})
     def test_excel_parsed(self):
-        mock_openpyxl = sys.modules["openpyxl"]
-        mock_wb = MagicMock()
-        mock_ws = MagicMock()
-        mock_ws.iter_rows.return_value = [
-            ("MPN", "Qty", "Price"),
-            ("LM317T", 1000, 0.50),
-            ("NE555P", 500, 0.25),
-        ]
-        mock_wb.active = mock_ws
-        mock_openpyxl.load_workbook.return_value = mock_wb
-
+        _stub_openpyxl_rows(
+            [
+                ("MPN", "Qty", "Price"),
+                ("LM317T", 1000, 0.50),
+                ("NE555P", 500, 0.25),
+            ]
+        )
         rows = parse_tabular_file(b"fake-excel", "stock.xlsx")
         assert len(rows) == 2
         assert rows[0]["mpn"] == "LM317T"
@@ -60,29 +69,19 @@ class TestParseTabularFile:
 
     @patch.dict("sys.modules", {"openpyxl": MagicMock()})
     def test_excel_xls_extension(self):
-        mock_openpyxl = sys.modules["openpyxl"]
-        mock_wb = MagicMock()
-        mock_ws = MagicMock()
-        mock_ws.iter_rows.return_value = [("MPN",), ("ABC123",)]
-        mock_wb.active = mock_ws
-        mock_openpyxl.load_workbook.return_value = mock_wb
-
+        _stub_openpyxl_rows([("MPN",), ("ABC123",)])
         rows = parse_tabular_file(b"fake", "file.xls")
         assert len(rows) == 1
 
     @patch.dict("sys.modules", {"openpyxl": MagicMock()})
     def test_excel_empty_rows_skipped(self):
-        mock_openpyxl = sys.modules["openpyxl"]
-        mock_wb = MagicMock()
-        mock_ws = MagicMock()
-        mock_ws.iter_rows.return_value = [
-            ("MPN", "Qty"),
-            (None, None),  # empty row
-            ("LM317T", 100),
-        ]
-        mock_wb.active = mock_ws
-        mock_openpyxl.load_workbook.return_value = mock_wb
-
+        _stub_openpyxl_rows(
+            [
+                ("MPN", "Qty"),
+                (None, None),  # empty row
+                ("LM317T", 100),
+            ]
+        )
         rows = parse_tabular_file(b"fake", "stock.xlsx")
         assert len(rows) == 1
 
@@ -126,92 +125,78 @@ class TestNormalizeStockRow:
         assert result["qty"] == 1000
         assert result["price"] == 0.50
 
-    def test_alternate_mpn_header_pn(self):
-        row = {"pn": "NE555P", "quantity": "500"}
+    @pytest.mark.parametrize(
+        ("row", "expected_mpn"),
+        [
+            ({"pn": "NE555P", "quantity": "500"}, "NE555P"),
+            ({"part number": "ABC123XY", "avail": "200"}, "ABC123XY"),
+            ({" MPN ": "LM317T", " QTY ": "100"}, "LM317T"),
+            ({"sku": "SKU12345", "qty": "50"}, "SKU12345"),
+        ],
+        ids=["pn", "part_number", "stripped_lowered_keys", "sku"],
+    )
+    def test_alternate_mpn_headers(self, row, expected_mpn):
         result = normalize_stock_row(row)
         assert result is not None
-        assert result["mpn"] == "NE555P"
+        assert result["mpn"] == expected_mpn
 
-    def test_alternate_mpn_header_part_number(self):
-        row = {"part number": "ABC123XY", "avail": "200"}
+    @pytest.mark.parametrize(
+        ("row", "expected_qty"),
+        [
+            ({"mpn": "LM317T", "available": "500"}, 500),
+            ({"mpn": "LM317T", "stock": "750"}, 750),
+        ],
+        ids=["available", "stock"],
+    )
+    def test_alternate_qty_headers(self, row, expected_qty):
         result = normalize_stock_row(row)
-        assert result is not None
-        assert result["mpn"] == "ABC123XY"
-
-    def test_alternate_qty_header(self):
-        row = {"mpn": "LM317T", "available": "500"}
-        result = normalize_stock_row(row)
-        assert result["qty"] == 500
-
-    def test_alternate_qty_stock(self):
-        row = {"mpn": "LM317T", "stock": "750"}
-        result = normalize_stock_row(row)
-        assert result["qty"] == 750
+        assert result["qty"] == expected_qty
 
     def test_alternate_price_header(self):
         row = {"mpn": "LM317T", "unit price": "1.25"}
         result = normalize_stock_row(row)
         assert result["price"] == 1.25
 
-    def test_no_mpn_returns_none(self):
-        row = {"qty": "1000", "price": "0.50"}
-        result = normalize_stock_row(row)
-        assert result is None
+    @pytest.mark.parametrize(
+        "row",
+        [
+            {"qty": "1000", "price": "0.50"},  # no mpn
+            {"mpn": "AB"},  # < 3 chars
+            {"mpn": ""},  # empty mpn
+        ],
+        ids=["no_mpn", "short_mpn", "empty_mpn"],
+    )
+    def test_invalid_mpn_returns_none(self, row):
+        assert normalize_stock_row(row) is None
 
-    def test_short_mpn_returns_none(self):
-        row = {"mpn": "AB"}  # < 3 chars
+    @pytest.mark.parametrize(
+        ("row", "field", "expected"),
+        [
+            ({"mpn": "LM317T", "manufacturer": "Texas Instruments"}, "manufacturer", "Texas Instruments"),
+            ({"mpn": "LM317T", "mfr": "TI"}, "manufacturer", "TI"),
+            ({"mpn": "LM317T", "condition": "New"}, "condition", "New"),
+            ({"mpn": "LM317T", "packaging": "Tape & Reel"}, "packaging", "Tape & Reel"),
+            ({"mpn": "LM317T", "date_code": "2024+"}, "date_code", "2024+"),
+            ({"mpn": "LM317T", "lead_time": "4-6 weeks"}, "lead_time", "4-6 weeks"),
+        ],
+        ids=["manufacturer", "mfr_alias", "condition", "packaging", "date_code", "lead_time"],
+    )
+    def test_optional_fields(self, row, field, expected):
         result = normalize_stock_row(row)
-        assert result is None
+        assert result[field] == expected
 
-    def test_empty_mpn_returns_none(self):
-        row = {"mpn": ""}
+    @pytest.mark.parametrize(
+        ("row", "expected_currency"),
+        [
+            ({"mpn": "LM317T", "price": "€1.25"}, "EUR"),
+            ({"mpn": "LM317T", "price": "1.25", "currency": "GBP"}, "GBP"),
+            ({"mpn": "LM317T", "price": "1.25"}, "USD"),
+        ],
+        ids=["from_price_symbol", "from_currency_field", "default_usd"],
+    )
+    def test_currency_detection(self, row, expected_currency):
         result = normalize_stock_row(row)
-        assert result is None
-
-    def test_optional_fields_manufacturer(self):
-        row = {"mpn": "LM317T", "manufacturer": "Texas Instruments"}
-        result = normalize_stock_row(row)
-        assert result["manufacturer"] == "Texas Instruments"
-
-    def test_optional_fields_mfr_alias(self):
-        row = {"mpn": "LM317T", "mfr": "TI"}
-        result = normalize_stock_row(row)
-        assert result["manufacturer"] == "TI"
-
-    def test_optional_fields_condition(self):
-        row = {"mpn": "LM317T", "condition": "New"}
-        result = normalize_stock_row(row)
-        assert result["condition"] == "New"
-
-    def test_optional_fields_packaging(self):
-        row = {"mpn": "LM317T", "packaging": "Tape & Reel"}
-        result = normalize_stock_row(row)
-        assert result["packaging"] == "Tape & Reel"
-
-    def test_optional_fields_date_code(self):
-        row = {"mpn": "LM317T", "date_code": "2024+"}
-        result = normalize_stock_row(row)
-        assert result["date_code"] == "2024+"
-
-    def test_optional_fields_lead_time(self):
-        row = {"mpn": "LM317T", "lead_time": "4-6 weeks"}
-        result = normalize_stock_row(row)
-        assert result["lead_time"] == "4-6 weeks"
-
-    def test_currency_detection_from_price(self):
-        row = {"mpn": "LM317T", "price": "€1.25"}
-        result = normalize_stock_row(row)
-        assert result["currency"] == "EUR"
-
-    def test_currency_detection_from_currency_field(self):
-        row = {"mpn": "LM317T", "price": "1.25", "currency": "GBP"}
-        result = normalize_stock_row(row)
-        assert result["currency"] == "GBP"
-
-    def test_default_currency_usd(self):
-        row = {"mpn": "LM317T", "price": "1.25"}
-        result = normalize_stock_row(row)
-        assert result["currency"] == "USD"
+        assert result["currency"] == expected_currency
 
     def test_no_qty_or_price_still_returns(self):
         row = {"mpn": "LM317T"}
@@ -219,15 +204,3 @@ class TestNormalizeStockRow:
         assert result is not None
         assert result["qty"] is None
         assert result["price"] is None
-
-    def test_header_keys_stripped_and_lowered(self):
-        row = {" MPN ": "LM317T", " QTY ": "100"}
-        result = normalize_stock_row(row)
-        assert result is not None
-        assert result["mpn"] == "LM317T"
-
-    def test_sku_header_as_mpn(self):
-        row = {"sku": "SKU12345", "qty": "50"}
-        result = normalize_stock_row(row)
-        assert result is not None
-        assert result["mpn"] == "SKU12345"

--- a/tests/test_htmx_views_nightly11.py
+++ b/tests/test_htmx_views_nightly11.py
@@ -15,9 +15,11 @@ os.environ["TESTING"] = "1"
 import io
 import json
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -93,35 +95,53 @@ def make_knowledge_entry(db_session: Session, user: User, **kw) -> KnowledgeEntr
     return e
 
 
+@contextmanager
+def admin_client(db_session: Session, admin_user: User):
+    """Yield a TestClient with every auth dependency overridden to act as admin_user."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    def _override_db():
+        yield db_session
+
+    def _override_admin():
+        return admin_user
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[require_user] = _override_admin
+    app.dependency_overrides[require_admin] = _override_admin
+    app.dependency_overrides[require_buyer] = _override_admin
+    app.dependency_overrides[require_fresh_token] = AsyncMock(return_value="mock-token")
+
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
+            app.dependency_overrides.pop(dep, None)
+
+
 # ── Section 1: Prospecting list partial ───────────────────────────────────
 
 
 class TestProspectingListPartial:
     """Covers GET /v2/partials/prospecting."""
 
-    def test_prospecting_list_returns_200(self, client: TestClient, db_session: Session):
-        make_prospect(db_session)
-        resp = client.get("/v2/partials/prospecting")
-        assert resp.status_code == 200
-
-    def test_prospecting_list_with_query(self, client: TestClient, db_session: Session):
-        make_prospect(db_session, name="SearchableProspect Corp")
-        resp = client.get("/v2/partials/prospecting?q=SearchableProspect")
-        assert resp.status_code == 200
-
-    def test_prospecting_list_with_status_filter(self, client: TestClient, db_session: Session):
-        make_prospect(db_session, status="claimed")
-        resp = client.get("/v2/partials/prospecting?status=claimed")
-        assert resp.status_code == 200
-
-    def test_prospecting_list_sort_fit_desc(self, client: TestClient, db_session: Session):
-        make_prospect(db_session)
-        resp = client.get("/v2/partials/prospecting?sort=fit_desc")
-        assert resp.status_code == 200
-
-    def test_prospecting_list_sort_recent_desc(self, client: TestClient, db_session: Session):
-        make_prospect(db_session)
-        resp = client.get("/v2/partials/prospecting?sort=recent_desc")
+    @pytest.mark.parametrize(
+        ("prospect_kwargs", "query"),
+        [
+            ({}, ""),
+            ({"name": "SearchableProspect Corp"}, "?q=SearchableProspect"),
+            ({"status": "claimed"}, "?status=claimed"),
+            ({}, "?sort=fit_desc"),
+            ({}, "?sort=recent_desc"),
+        ],
+        ids=["plain", "with_query", "with_status_filter", "sort_fit_desc", "sort_recent_desc"],
+    )
+    def test_prospecting_list_returns_200(self, client: TestClient, db_session: Session, prospect_kwargs, query):
+        make_prospect(db_session, **prospect_kwargs)
+        resp = client.get(f"/v2/partials/prospecting{query}")
         assert resp.status_code == 200
 
     def test_prospecting_list_pagination(self, client: TestClient, db_session: Session):
@@ -242,20 +262,18 @@ class TestSettingsPartials:
     """Covers GET /v2/partials/settings, /settings/sources, /settings/profile,
     /settings/system."""
 
-    def test_settings_index(self, client: TestClient):
-        resp = client.get("/v2/partials/settings")
-        assert resp.status_code == 200
-
-    def test_settings_with_tab_param(self, client: TestClient):
-        resp = client.get("/v2/partials/settings?tab=sources")
-        assert resp.status_code == 200
-
-    def test_settings_sources_tab(self, client: TestClient):
-        resp = client.get("/v2/partials/settings/sources")
-        assert resp.status_code == 200
-
-    def test_settings_profile_tab(self, client: TestClient):
-        resp = client.get("/v2/partials/settings/profile")
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/settings",
+            "/v2/partials/settings?tab=sources",
+            "/v2/partials/settings/sources",
+            "/v2/partials/settings/profile",
+        ],
+        ids=["index", "with_tab_param", "sources_tab", "profile_tab"],
+    )
+    def test_settings_tab_returns_200(self, client: TestClient, path):
+        resp = client.get(path)
         assert resp.status_code == 200
 
     def test_settings_system_tab_non_admin_returns_403(self, client: TestClient, db_session: Session, test_user: User):
@@ -296,20 +314,17 @@ class TestProactiveListAndDismiss:
     """Covers GET /v2/partials/proactive and POST /v2/partials/proactive/batch-
     dismiss."""
 
-    def test_proactive_list_matches_tab(self, client: TestClient, db_session: Session):
+    @pytest.mark.parametrize(
+        "path",
+        ["/v2/partials/proactive", "/v2/partials/proactive?tab=sent"],
+        ids=["matches_tab", "sent_tab"],
+    )
+    def test_proactive_list_tab(self, client: TestClient, db_session: Session, path):
         with patch(
             "app.services.proactive_service.get_matches_for_user", return_value={"groups": [], "stats": {"total": 0}}
         ):
             with patch("app.services.proactive_service.get_sent_offers", return_value=[]):
-                resp = client.get("/v2/partials/proactive")
-                assert resp.status_code == 200
-
-    def test_proactive_list_sent_tab(self, client: TestClient, db_session: Session):
-        with patch(
-            "app.services.proactive_service.get_matches_for_user", return_value={"groups": [], "stats": {"total": 0}}
-        ):
-            with patch("app.services.proactive_service.get_sent_offers", return_value=[]):
-                resp = client.get("/v2/partials/proactive?tab=sent")
+                resp = client.get(path)
                 assert resp.status_code == 200
 
     def test_proactive_list_returns_list_when_service_returns_list(self, client: TestClient):
@@ -796,145 +811,45 @@ class TestAdminImportVendors:
     def test_import_vendors_no_file_returns_400(
         self, client: TestClient, db_session: Session, test_user: User, admin_user: User
     ):
-        from app.database import get_db
-        from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        def _override_admin():
-            return admin_user
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = _override_admin
-        app.dependency_overrides[require_admin] = _override_admin
-        app.dependency_overrides[require_buyer] = _override_admin
-        app.dependency_overrides[require_fresh_token] = AsyncMock(return_value="mock-token")
-
-        try:
-            with TestClient(app) as admin_client:
-                resp = admin_client.post("/v2/partials/admin/import/vendors")
-                assert resp.status_code == 400
-        finally:
-            for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
-                app.dependency_overrides.pop(dep, None)
+        with admin_client(db_session, admin_user) as admin:
+            resp = admin.post("/v2/partials/admin/import/vendors")
+            assert resp.status_code == 400
 
     def test_import_vendors_csv_success(self, client: TestClient, db_session: Session, admin_user: User):
-        from app.database import get_db
-        from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        def _override_admin():
-            return admin_user
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = _override_admin
-        app.dependency_overrides[require_admin] = _override_admin
-        app.dependency_overrides[require_buyer] = _override_admin
-        app.dependency_overrides[require_fresh_token] = AsyncMock(return_value="mock-token")
-
         csv_content = b"name,email,phone,website\nNewVendorCSV Inc,sales@newvendor.com,555-1234,https://newvendor.com\n"
 
-        try:
-            with TestClient(app) as admin_client:
-                resp = admin_client.post(
-                    "/v2/partials/admin/import/vendors",
-                    files={"file": ("vendors.csv", io.BytesIO(csv_content), "text/csv")},
-                )
-                assert resp.status_code == 200
-                assert "Imported" in resp.text
-        finally:
-            for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
-                app.dependency_overrides.pop(dep, None)
+        with admin_client(db_session, admin_user) as admin:
+            resp = admin.post(
+                "/v2/partials/admin/import/vendors",
+                files={"file": ("vendors.csv", io.BytesIO(csv_content), "text/csv")},
+            )
+            assert resp.status_code == 200
+            assert "Imported" in resp.text
 
     def test_import_vendors_skips_duplicates(
         self, client: TestClient, db_session: Session, admin_user: User, test_vendor_card: VendorCard
     ):
-        from app.database import get_db
-        from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        def _override_admin():
-            return admin_user
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = _override_admin
-        app.dependency_overrides[require_admin] = _override_admin
-        app.dependency_overrides[require_buyer] = _override_admin
-        app.dependency_overrides[require_fresh_token] = AsyncMock(return_value="mock-token")
-
         # Use normalized name that already exists ("arrow electronics")
         csv_content = b"name,email\nArrow Electronics,sales@arrow.com\n"
 
-        try:
-            with TestClient(app) as admin_client:
-                resp = admin_client.post(
-                    "/v2/partials/admin/import/vendors",
-                    files={"file": ("vendors.csv", io.BytesIO(csv_content), "text/csv")},
-                )
-                assert resp.status_code == 200
-                assert "Imported 0" in resp.text
-        finally:
-            for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
-                app.dependency_overrides.pop(dep, None)
+        with admin_client(db_session, admin_user) as admin:
+            resp = admin.post(
+                "/v2/partials/admin/import/vendors",
+                files={"file": ("vendors.csv", io.BytesIO(csv_content), "text/csv")},
+            )
+            assert resp.status_code == 200
+            assert "Imported 0" in resp.text
 
     def test_admin_data_ops_returns_200_for_admin(self, client: TestClient, db_session: Session, admin_user: User):
         """Admin users can access data-ops panel."""
-        from app.database import get_db
-        from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        def _override_admin():
-            return admin_user
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = _override_admin
-        app.dependency_overrides[require_admin] = _override_admin
-        app.dependency_overrides[require_buyer] = _override_admin
-        app.dependency_overrides[require_fresh_token] = AsyncMock(return_value="mock-token")
-
-        try:
-            with TestClient(app) as admin_client:
-                resp = admin_client.get("/v2/partials/admin/data-ops")
-                assert resp.status_code == 200
-        finally:
-            for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
-                app.dependency_overrides.pop(dep, None)
+        with admin_client(db_session, admin_user) as admin:
+            resp = admin.get("/v2/partials/admin/data-ops")
+            assert resp.status_code == 200
 
     def test_admin_api_health(self, client: TestClient, db_session: Session, admin_user: User):
-        from app.database import get_db
-        from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        def _override_admin():
-            return admin_user
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = _override_admin
-        app.dependency_overrides[require_admin] = _override_admin
-        app.dependency_overrides[require_buyer] = _override_admin
-        app.dependency_overrides[require_fresh_token] = AsyncMock(return_value="mock-token")
-
-        try:
-            with TestClient(app) as admin_client:
-                resp = admin_client.get("/v2/partials/admin/api-health")
-                assert resp.status_code == 200
-        finally:
-            for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
-                app.dependency_overrides.pop(dep, None)
+        with admin_client(db_session, admin_user) as admin:
+            resp = admin.get("/v2/partials/admin/api-health")
+            assert resp.status_code == 200
 
 
 # ── Section 17: Admin vendor/company merge ────────────────────────────────

--- a/tests/test_htmx_views_nightly15.py
+++ b/tests/test_htmx_views_nightly15.py
@@ -20,6 +20,7 @@ os.environ["TESTING"] = "1"
 
 from datetime import datetime, timezone
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -257,25 +258,16 @@ class TestSendFollowUp:
 
 
 class TestReviewResponse:
-    def test_mark_reviewed(self, client: TestClient, db_session: Session, test_requisition: Requisition):
+    @pytest.mark.parametrize("status", ["reviewed", "rejected"])
+    def test_mark_status(self, client: TestClient, db_session: Session, test_requisition: Requisition, status: str):
         vr = _make_vendor_response(db_session, test_requisition)
         resp = client.post(
             f"/v2/partials/requisitions/{test_requisition.id}/responses/{vr.id}/review",
-            data={"status": "reviewed"},
+            data={"status": status},
         )
         assert resp.status_code == 200
         db_session.refresh(vr)
-        assert vr.status == "reviewed"
-
-    def test_mark_rejected(self, client: TestClient, db_session: Session, test_requisition: Requisition):
-        vr = _make_vendor_response(db_session, test_requisition)
-        resp = client.post(
-            f"/v2/partials/requisitions/{test_requisition.id}/responses/{vr.id}/review",
-            data={"status": "rejected"},
-        )
-        assert resp.status_code == 200
-        db_session.refresh(vr)
-        assert vr.status == "rejected"
+        assert vr.status == status
 
     def test_invalid_status(self, client: TestClient, db_session: Session, test_requisition: Requisition):
         vr = _make_vendor_response(db_session, test_requisition)

--- a/tests/test_htmx_views_nightly16.py
+++ b/tests/test_htmx_views_nightly16.py
@@ -20,6 +20,7 @@ os.environ["TESTING"] = "1"
 
 from datetime import datetime, timezone
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -103,7 +104,16 @@ class TestUpdateRequirement:
         )
         assert resp.status_code == 404
 
-    def test_update_with_need_by_date(self, client: TestClient, db_session: Session, test_requisition: Requisition):
+    @pytest.mark.parametrize(
+        "need_by_date",
+        [
+            pytest.param("2026-12-31", id="valid_date"),
+            pytest.param("not-a-date", id="invalid_date"),
+        ],
+    )
+    def test_update_need_by_date(
+        self, client: TestClient, db_session: Session, test_requisition: Requisition, need_by_date: str
+    ):
         item = _make_requirement(db_session, test_requisition)
         resp = client.put(
             f"/v2/partials/requisitions/{test_requisition.id}/requirements/{item.id}",
@@ -111,20 +121,7 @@ class TestUpdateRequirement:
                 "primary_mpn": "LM317T",
                 "manufacturer": "TI",
                 "target_qty": "5",
-                "need_by_date": "2026-12-31",
-            },
-        )
-        assert resp.status_code == 200
-
-    def test_update_with_invalid_date(self, client: TestClient, db_session: Session, test_requisition: Requisition):
-        item = _make_requirement(db_session, test_requisition)
-        resp = client.put(
-            f"/v2/partials/requisitions/{test_requisition.id}/requirements/{item.id}",
-            data={
-                "primary_mpn": "LM317T",
-                "manufacturer": "TI",
-                "target_qty": "5",
-                "need_by_date": "not-a-date",
+                "need_by_date": need_by_date,
             },
         )
         assert resp.status_code == 200

--- a/tests/test_htmx_views_nightly27.py
+++ b/tests/test_htmx_views_nightly27.py
@@ -192,13 +192,14 @@ class TestEditOfferValueErrorBranchesDirect:
 
 
 class TestReviewResponseHtmxDirect:
-    async def test_mark_reviewed_success(self, db_session: Session, test_user: User):
-        """Lines 2803–2815: POST status=reviewed → vr.status = 'reviewed'."""
+    @pytest.mark.parametrize("status", ["reviewed", "rejected"])
+    async def test_mark_status_success(self, db_session: Session, test_user: User, status: str):
+        """Lines 2803–2815: POST status=reviewed/rejected → vr.status updated."""
         from app.routers.htmx_views import review_response_htmx
 
         req = _make_req(db_session, test_user)
         vr = _make_vendor_response(db_session, req)
-        mock_req = _mock_form_request(fields={"status": "reviewed"})
+        mock_req = _mock_form_request(fields={"status": status})
         with patch("app.routers.htmx_views.template_response") as mock_tpl:
             mock_tpl.return_value = HTMLResponse("response card")
             result = await review_response_htmx(
@@ -210,27 +211,7 @@ class TestReviewResponseHtmxDirect:
             )
         assert result.status_code == 200
         db_session.refresh(vr)
-        assert vr.status == "reviewed"
-
-    async def test_mark_rejected_success(self, db_session: Session, test_user: User):
-        """POST status=rejected → vr.status = 'rejected'."""
-        from app.routers.htmx_views import review_response_htmx
-
-        req = _make_req(db_session, test_user)
-        vr = _make_vendor_response(db_session, req)
-        mock_req = _mock_form_request(fields={"status": "rejected"})
-        with patch("app.routers.htmx_views.template_response") as mock_tpl:
-            mock_tpl.return_value = HTMLResponse("response card")
-            result = await review_response_htmx(
-                request=mock_req,
-                req_id=req.id,
-                response_id=vr.id,
-                user=test_user,
-                db=db_session,
-            )
-        assert result.status_code == 200
-        db_session.refresh(vr)
-        assert vr.status == "rejected"
+        assert vr.status == status
 
     async def test_invalid_status_raises_400(self, db_session: Session, test_user: User):
         """Invalid status → 400."""

--- a/tests/test_htmx_views_nightly6.py
+++ b/tests/test_htmx_views_nightly6.py
@@ -143,6 +143,14 @@ def _make_proactive_match(
     return pm
 
 
+def _seed_proactive_match(db: Session, req: Requisition, user: User) -> ProactiveMatch:
+    """Build the full company → site → offer → ProactiveMatch chain for `user`."""
+    company = _make_company(db)
+    site = _make_site(db, company)
+    offer = _make_offer(db, req, user)
+    return _make_proactive_match(db, offer, user, site)
+
+
 # ── Section 1: Find Crosses ───────────────────────────────────────────
 
 
@@ -229,13 +237,10 @@ class TestProactivePrepare:
 
     def test_valid_matches_renders_prepare_template(self, client, db_session, test_requisition, test_user):
         """Valid match_ids for the current user → renders prepare template."""
-        company = _make_company(db_session)
-        site = _make_site(db_session, company)
-        offer = _make_offer(db_session, test_requisition, test_user)
-        pm = _make_proactive_match(db_session, offer, test_user, site)
+        pm = _seed_proactive_match(db_session, test_requisition, test_user)
 
         resp = client.post(
-            f"/v2/proactive/prepare/{site.id}",
+            f"/v2/proactive/prepare/{pm.customer_site_id}",
             data={"match_ids": str(pm.id)},
             follow_redirects=False,
         )
@@ -263,10 +268,7 @@ class TestProactiveDraft:
 
     def test_ai_draft_success_returns_js_html(self, client, db_session, test_requisition, test_user):
         """AI draft succeeds → HTML contains script to populate form."""
-        company = _make_company(db_session)
-        site = _make_site(db_session, company)
-        offer = _make_offer(db_session, test_requisition, test_user)
-        pm = _make_proactive_match(db_session, offer, test_user, site)
+        pm = _seed_proactive_match(db_session, test_requisition, test_user)
 
         ai_response = {
             "subject": "Parts Available — Acme Corp",
@@ -288,10 +290,7 @@ class TestProactiveDraft:
 
     def test_ai_draft_failure_returns_retry_html(self, client, db_session, test_requisition, test_user):
         """AI draft exception → retry HTML returned, no 500."""
-        company = _make_company(db_session)
-        site = _make_site(db_session, company)
-        offer = _make_offer(db_session, test_requisition, test_user)
-        pm = _make_proactive_match(db_session, offer, test_user, site)
+        pm = _seed_proactive_match(db_session, test_requisition, test_user)
 
         with patch(
             "app.services.proactive_email.draft_proactive_email",
@@ -519,10 +518,7 @@ class TestProactiveScorecardBadge:
 
     def test_badge_with_new_matches_returns_count_span(self, client, db_session, test_requisition, test_user):
         """With new ProactiveMatches → response contains the count badge."""
-        company = _make_company(db_session)
-        site = _make_site(db_session, company)
-        offer = _make_offer(db_session, test_requisition, test_user)
-        _make_proactive_match(db_session, offer, test_user, site)
+        _seed_proactive_match(db_session, test_requisition, test_user)
 
         resp = client.get("/v2/partials/proactive/badge")
         assert resp.status_code == 200

--- a/tests/test_ics_worker_full.py
+++ b/tests/test_ics_worker_full.py
@@ -49,59 +49,31 @@ pytestmark = pytest.mark.slow
 
 
 class TestMpnNormalizer:
-    def test_empty_string(self):
-        assert normalize_mpn("") == ""
-
-    def test_none_input(self):
-        assert normalize_mpn(None) == ""
-
-    def test_whitespace_only(self):
-        assert normalize_mpn("   ") == ""
-
-    def test_basic_uppercase(self):
-        assert normalize_mpn("stm32f103c8t6") == "STM32F103C8T6"
-
-    def test_strip_whitespace_internal(self):
-        assert normalize_mpn("LM 317 T") == "LM317T"
-
-    def test_strip_tape_and_reel_slash(self):
-        assert normalize_mpn("STM32F103C8T6/TR") == "STM32F103C8T6"
-
-    def test_strip_tape_and_reel_dash(self):
-        assert normalize_mpn("STM32F103C8T6-TR") == "STM32F103C8T6"
-
-    def test_strip_cut_tape_slash(self):
-        assert normalize_mpn("LM317T/CT") == "LM317T"
-
-    def test_strip_cut_tape_dash(self):
-        assert normalize_mpn("LM317T-CT") == "LM317T"
-
-    def test_strip_nd_suffix(self):
-        assert normalize_mpn("LM358DR-ND") == "LM358DR"
-
-    def test_strip_dkr_suffix(self):
-        assert normalize_mpn("AD8232ACPZ-DKR") == "AD8232ACPZ"
-
-    def test_strip_pbf_hash(self):
-        assert normalize_mpn("IRF3205#PBF") == "IRF3205"
-
-    def test_strip_pbf_dash(self):
-        assert normalize_mpn("IRF3205-PBF") == "IRF3205"
-
-    def test_strip_nopb_slash(self):
-        assert normalize_mpn("TPS54302DDCR/NOPB") == "TPS54302DDCR"
-
-    def test_strip_nopb_dash(self):
-        assert normalize_mpn("TPS54302DDCR-NOPB") == "TPS54302DDCR"
-
-    def test_strip_reel_suffix(self):
-        assert normalize_mpn("ADP3338AKCZ-3.3-RL") == "ADP3338AKCZ-3.3"
-
-    def test_strip_reel_with_number(self):
-        assert normalize_mpn("ADP3338AKCZ-RL7") == "ADP3338AKCZ"
-
-    def test_case_insensitive_suffix(self):
-        assert normalize_mpn("lm317t/tr") == "LM317T"
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            pytest.param("", "", id="empty_string"),
+            pytest.param(None, "", id="none_input"),
+            pytest.param("   ", "", id="whitespace_only"),
+            pytest.param("stm32f103c8t6", "STM32F103C8T6", id="basic_uppercase"),
+            pytest.param("LM 317 T", "LM317T", id="strip_whitespace_internal"),
+            pytest.param("STM32F103C8T6/TR", "STM32F103C8T6", id="strip_tape_and_reel_slash"),
+            pytest.param("STM32F103C8T6-TR", "STM32F103C8T6", id="strip_tape_and_reel_dash"),
+            pytest.param("LM317T/CT", "LM317T", id="strip_cut_tape_slash"),
+            pytest.param("LM317T-CT", "LM317T", id="strip_cut_tape_dash"),
+            pytest.param("LM358DR-ND", "LM358DR", id="strip_nd_suffix"),
+            pytest.param("AD8232ACPZ-DKR", "AD8232ACPZ", id="strip_dkr_suffix"),
+            pytest.param("IRF3205#PBF", "IRF3205", id="strip_pbf_hash"),
+            pytest.param("IRF3205-PBF", "IRF3205", id="strip_pbf_dash"),
+            pytest.param("TPS54302DDCR/NOPB", "TPS54302DDCR", id="strip_nopb_slash"),
+            pytest.param("TPS54302DDCR-NOPB", "TPS54302DDCR", id="strip_nopb_dash"),
+            pytest.param("ADP3338AKCZ-3.3-RL", "ADP3338AKCZ-3.3", id="strip_reel_suffix"),
+            pytest.param("ADP3338AKCZ-RL7", "ADP3338AKCZ", id="strip_reel_with_number"),
+            pytest.param("lm317t/tr", "LM317T", id="case_insensitive_suffix"),
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert normalize_mpn(raw) == expected
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -134,33 +106,30 @@ class TestIcsConfig:
 
 
 class TestResultParser:
-    def test_none_html(self):
-        assert parse_results_html(None) == []
-
-    def test_empty_html(self):
-        assert parse_results_html("") == []
-
-    def test_whitespace_html(self):
-        assert parse_results_html("   ") == []
-
-    def test_no_results(self):
-        html = "<div>No results found</div>"
+    @pytest.mark.parametrize(
+        "html",
+        [
+            pytest.param(None, id="none_html"),
+            pytest.param("", id="empty_html"),
+            pytest.param("   ", id="whitespace_html"),
+            pytest.param("<div>No results found</div>", id="no_results"),
+        ],
+    )
+    def test_empty_result(self, html):
         assert parse_results_html(html) == []
 
-    def test_parse_quantity_normal(self):
-        assert parse_quantity("1,000") == 1000
-
-    def test_parse_quantity_plus(self):
-        assert parse_quantity("500+") == 500
-
-    def test_parse_quantity_empty(self):
-        assert parse_quantity("") is None
-
-    def test_parse_quantity_invalid(self):
-        assert parse_quantity("N/A") is None
-
-    def test_parse_quantity_none(self):
-        assert parse_quantity(None) is None
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            pytest.param("1,000", 1000, id="normal"),
+            pytest.param("500+", 500, id="plus"),
+            pytest.param("", None, id="empty"),
+            pytest.param("N/A", None, id="invalid"),
+            pytest.param(None, None, id="none"),
+        ],
+    )
+    def test_parse_quantity(self, raw, expected):
+        assert parse_quantity(raw) == expected
 
     def test_browse_match_item_parsing(self):
         """Parse a typical ICsource results page structure."""
@@ -425,38 +394,63 @@ class TestSearchEngine:
 
 
 class TestCircuitBreaker:
+    @pytest.mark.parametrize(
+        ("url", "content", "expected_result", "expected_open"),
+        [
+            pytest.param(
+                "https://www.icsource.com/members/Search/Results.aspx",
+                "search results page content here",
+                "HEALTHY",
+                False,
+                id="healthy_page",
+            ),
+            pytest.param(
+                "https://www.google.com",
+                "google page",
+                "UNEXPECTED_REDIRECT",
+                True,
+                id="unexpected_redirect",
+            ),
+            pytest.param(
+                "https://www.icsource.com/home/LogIn.aspx",
+                "login page",
+                "SESSION_EXPIRED",
+                False,
+                id="session_expired_login_url",
+            ),
+            pytest.param(
+                "https://www.icsource.com/error",
+                "too many requests please slow down",
+                "RATE_LIMITED",
+                True,
+                id="rate_limited",
+            ),
+            pytest.param(
+                "https://www.icsource.com/error",
+                "access denied - your account has been blocked",
+                "ACCESS_DENIED",
+                True,
+                id="access_denied",
+            ),
+            pytest.param(
+                "https://www.icsource.com/warning",
+                "we detected unusual activity on your account",
+                "ACCESS_DENIED",
+                True,
+                id="unusual_activity",
+            ),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_healthy_page(self):
+    async def test_single_health_check(self, url, content, expected_result, expected_open):
         breaker = CircuitBreaker()
         page = AsyncMock()
-        page.url = "https://www.icsource.com/members/Search/Results.aspx"
-        page.evaluate = AsyncMock(return_value="search results page content here")
+        page.url = url
+        page.evaluate = AsyncMock(return_value=content)
 
         result = await breaker.check_page_health(page)
-        assert result == "HEALTHY"
-        assert not breaker.is_open
-
-    @pytest.mark.asyncio
-    async def test_unexpected_redirect(self):
-        breaker = CircuitBreaker()
-        page = AsyncMock()
-        page.url = "https://www.google.com"
-        page.evaluate = AsyncMock(return_value="google page")
-
-        result = await breaker.check_page_health(page)
-        assert result == "UNEXPECTED_REDIRECT"
-        assert breaker.is_open
-
-    @pytest.mark.asyncio
-    async def test_session_expired_login_url(self):
-        breaker = CircuitBreaker()
-        page = AsyncMock()
-        page.url = "https://www.icsource.com/home/LogIn.aspx"
-        page.evaluate = AsyncMock(return_value="login page")
-
-        result = await breaker.check_page_health(page)
-        assert result == "SESSION_EXPIRED"
-        assert not breaker.is_open
+        assert result == expected_result
+        assert breaker.is_open is expected_open
 
     @pytest.mark.asyncio
     async def test_captcha_warning(self):
@@ -482,39 +476,6 @@ class TestCircuitBreaker:
         assert result == "CAPTCHA_WARNING"
         assert breaker.is_open
         assert "Captcha" in breaker.trip_reason
-
-    @pytest.mark.asyncio
-    async def test_rate_limited(self):
-        breaker = CircuitBreaker()
-        page = AsyncMock()
-        page.url = "https://www.icsource.com/error"
-        page.evaluate = AsyncMock(return_value="too many requests please slow down")
-
-        result = await breaker.check_page_health(page)
-        assert result == "RATE_LIMITED"
-        assert breaker.is_open
-
-    @pytest.mark.asyncio
-    async def test_access_denied(self):
-        breaker = CircuitBreaker()
-        page = AsyncMock()
-        page.url = "https://www.icsource.com/error"
-        page.evaluate = AsyncMock(return_value="access denied - your account has been blocked")
-
-        result = await breaker.check_page_health(page)
-        assert result == "ACCESS_DENIED"
-        assert breaker.is_open
-
-    @pytest.mark.asyncio
-    async def test_unusual_activity(self):
-        breaker = CircuitBreaker()
-        page = AsyncMock()
-        page.url = "https://www.icsource.com/warning"
-        page.evaluate = AsyncMock(return_value="we detected unusual activity on your account")
-
-        result = await breaker.check_page_health(page)
-        assert result == "ACCESS_DENIED"
-        assert breaker.is_open
 
     @pytest.mark.asyncio
     async def test_consecutive_failures_trip(self):
@@ -2579,84 +2540,28 @@ class TestSchedulerBranches:
         with patch.dict(os.environ, {"FORCE_BUSINESS_HOURS": "1"}):
             assert sched.is_business_hours() is True
 
-    def test_business_hours_saturday(self):
-        """Saturday always returns False (line 48)."""
-        cfg = IcsConfig()
-        sched = SearchScheduler(cfg)
-        # Saturday: weekday() == 5
-        with patch("app.services.ics_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 5
-            mock_now.hour = 12
-            mock_dt.now.return_value = mock_now
-            with patch.dict(os.environ, {}, clear=False):
-                os.environ.pop("FORCE_BUSINESS_HOURS", None)
-                assert sched.is_business_hours() is False
-
-    def test_business_hours_sunday_before_6pm(self):
-        """Sunday before 6 PM returns False (line 51)."""
+    @pytest.mark.parametrize(
+        ("weekday", "hour", "expected"),
+        [
+            pytest.param(5, 12, False, id="saturday"),  # line 48
+            pytest.param(6, 10, False, id="sunday_before_6pm"),  # line 51
+            pytest.param(6, 18, True, id="sunday_after_6pm"),
+            pytest.param(4, 12, True, id="friday_before_5pm"),  # line 54
+            pytest.param(4, 17, False, id="friday_after_5pm"),
+            pytest.param(2, 3, True, id="weekday"),  # Wednesday, line 56
+        ],
+    )
+    def test_business_hours_by_day(self, weekday, hour, expected):
         cfg = IcsConfig()
         sched = SearchScheduler(cfg)
         with patch("app.services.ics_worker.scheduler.datetime") as mock_dt:
             mock_now = MagicMock()
-            mock_now.weekday.return_value = 6
-            mock_now.hour = 10
+            mock_now.weekday.return_value = weekday
+            mock_now.hour = hour
             mock_dt.now.return_value = mock_now
             with patch.dict(os.environ, {}, clear=False):
                 os.environ.pop("FORCE_BUSINESS_HOURS", None)
-                assert sched.is_business_hours() is False
-
-    def test_business_hours_sunday_after_6pm(self):
-        """Sunday at 6 PM+ returns True."""
-        cfg = IcsConfig()
-        sched = SearchScheduler(cfg)
-        with patch("app.services.ics_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 6
-            mock_now.hour = 18
-            mock_dt.now.return_value = mock_now
-            with patch.dict(os.environ, {}, clear=False):
-                os.environ.pop("FORCE_BUSINESS_HOURS", None)
-                assert sched.is_business_hours() is True
-
-    def test_business_hours_friday_before_5pm(self):
-        """Friday before 5 PM returns True (line 54)."""
-        cfg = IcsConfig()
-        sched = SearchScheduler(cfg)
-        with patch("app.services.ics_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 4
-            mock_now.hour = 12
-            mock_dt.now.return_value = mock_now
-            with patch.dict(os.environ, {}, clear=False):
-                os.environ.pop("FORCE_BUSINESS_HOURS", None)
-                assert sched.is_business_hours() is True
-
-    def test_business_hours_friday_after_5pm(self):
-        """Friday at 5 PM+ returns False."""
-        cfg = IcsConfig()
-        sched = SearchScheduler(cfg)
-        with patch("app.services.ics_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 4
-            mock_now.hour = 17
-            mock_dt.now.return_value = mock_now
-            with patch.dict(os.environ, {}, clear=False):
-                os.environ.pop("FORCE_BUSINESS_HOURS", None)
-                assert sched.is_business_hours() is False
-
-    def test_business_hours_weekday(self):
-        """Monday-Thursday always returns True (line 56)."""
-        cfg = IcsConfig()
-        sched = SearchScheduler(cfg)
-        with patch("app.services.ics_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 2  # Wednesday
-            mock_now.hour = 3
-            mock_dt.now.return_value = mock_now
-            with patch.dict(os.environ, {}, clear=False):
-                os.environ.pop("FORCE_BUSINESS_HOURS", None)
-                assert sched.is_business_hours() is True
+                assert sched.is_business_hours() is expected
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_jobs_core.py
+++ b/tests/test_jobs_core.py
@@ -45,61 +45,46 @@ def _clear_scheduler_jobs():
 # ── _job_auto_archive() ───────────────────────────────────────────────
 
 
-def test_auto_archive_archives_stale(scheduler_db, test_user):
-    """Requisitions last searched >30 days ago get archived."""
-    old = Requisition(
-        name="OLD-001",
+@pytest.mark.parametrize(
+    ("name", "last_searched_at", "expected_status"),
+    [
+        pytest.param(
+            "OLD-001",
+            datetime.now(timezone.utc) - timedelta(days=45),
+            "archived",
+            id="stale_gets_archived",
+        ),
+        pytest.param(
+            "RECENT-001",
+            datetime.now(timezone.utc) - timedelta(days=5),
+            "active",
+            id="recent_skipped",
+        ),
+        pytest.param(
+            "UNSEARCHED-001",
+            None,
+            "active",
+            id="never_searched_skipped",
+        ),
+    ],
+)
+def test_auto_archive_by_last_searched(scheduler_db, test_user, name, last_searched_at, expected_status):
+    """Active requisitions are archived only when last searched >30 days ago."""
+    req = Requisition(
+        name=name,
         status="active",
         created_by=test_user.id,
-        last_searched_at=datetime.now(timezone.utc) - timedelta(days=45),
+        last_searched_at=last_searched_at,
     )
-    scheduler_db.add(old)
+    scheduler_db.add(req)
     scheduler_db.commit()
 
     from app.jobs.core_jobs import _job_auto_archive
 
     asyncio.run(_job_auto_archive())
 
-    scheduler_db.refresh(old)
-    assert old.status == "archived"
-
-
-def test_auto_archive_skips_recent(scheduler_db, test_user):
-    """Requisitions searched recently are not archived."""
-    recent = Requisition(
-        name="RECENT-001",
-        status="active",
-        created_by=test_user.id,
-        last_searched_at=datetime.now(timezone.utc) - timedelta(days=5),
-    )
-    scheduler_db.add(recent)
-    scheduler_db.commit()
-
-    from app.jobs.core_jobs import _job_auto_archive
-
-    asyncio.run(_job_auto_archive())
-
-    scheduler_db.refresh(recent)
-    assert recent.status == "active"
-
-
-def test_auto_archive_skips_never_searched(scheduler_db, test_user):
-    """Requisitions that have never been searched are not archived."""
-    unsearched = Requisition(
-        name="UNSEARCHED-001",
-        status="active",
-        created_by=test_user.id,
-        last_searched_at=None,
-    )
-    scheduler_db.add(unsearched)
-    scheduler_db.commit()
-
-    from app.jobs.core_jobs import _job_auto_archive
-
-    asyncio.run(_job_auto_archive())
-
-    scheduler_db.refresh(unsearched)
-    assert unsearched.status == "active"
+    scheduler_db.refresh(req)
+    assert req.status == expected_status
 
 
 def test_auto_archive_only_archives_active_status(scheduler_db, test_user):
@@ -150,11 +135,39 @@ def test_auto_archive_error_handling(scheduler_db):
 # ── _job_token_refresh() ──────────────────────────────────────────────
 
 
-def test_token_refresh_refreshes_expired(scheduler_db, test_user):
-    """Users with expired tokens get refreshed."""
-    test_user.refresh_token = "rt_test_123"
-    test_user.token_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
-    test_user.access_token = "old_token"
+@pytest.mark.parametrize(
+    ("refresh_token", "access_token", "token_expires_at", "should_refresh"),
+    [
+        pytest.param(
+            "rt_test_123",
+            "old_token",
+            datetime.now(timezone.utc) - timedelta(hours=1),
+            True,
+            id="expired_gets_refreshed",
+        ),
+        pytest.param(
+            "rt_test_123",
+            "still_valid",
+            datetime.now(timezone.utc) + timedelta(hours=1),
+            False,
+            id="valid_skipped",
+        ),
+        pytest.param(
+            "rt_test_789",
+            None,
+            None,
+            True,
+            id="no_access_token_gets_refreshed",
+        ),
+    ],
+)
+def test_token_refresh_by_token_state(
+    scheduler_db, test_user, refresh_token, access_token, token_expires_at, should_refresh
+):
+    """Users are refreshed only when their access token is expired or missing."""
+    test_user.refresh_token = refresh_token
+    test_user.access_token = access_token
+    test_user.token_expires_at = token_expires_at
     scheduler_db.commit()
 
     with patch("app.utils.token_manager.refresh_user_token", new_callable=AsyncMock) as mock_refresh:
@@ -162,36 +175,10 @@ def test_token_refresh_refreshes_expired(scheduler_db, test_user):
         from app.jobs.core_jobs import _job_token_refresh
 
         asyncio.run(_job_token_refresh())
-        mock_refresh.assert_called_once()
-
-
-def test_token_refresh_skips_valid(scheduler_db, test_user):
-    """Users with valid tokens are not refreshed."""
-    test_user.refresh_token = "rt_test_123"
-    test_user.token_expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
-    test_user.access_token = "still_valid"
-    scheduler_db.commit()
-
-    with patch("app.utils.token_manager.refresh_user_token", new_callable=AsyncMock) as mock_refresh:
-        from app.jobs.core_jobs import _job_token_refresh
-
-        asyncio.run(_job_token_refresh())
-        mock_refresh.assert_not_called()
-
-
-def test_token_refresh_refreshes_user_without_access_token(scheduler_db, test_user):
-    """Users with a refresh token but no access token get refreshed."""
-    test_user.refresh_token = "rt_test_789"
-    test_user.access_token = None
-    test_user.token_expires_at = None
-    scheduler_db.commit()
-
-    with patch("app.utils.token_manager.refresh_user_token", new_callable=AsyncMock) as mock_refresh:
-        mock_refresh.return_value = "new_token"
-        from app.jobs.core_jobs import _job_token_refresh
-
-        asyncio.run(_job_token_refresh())
-        mock_refresh.assert_called_once()
+        if should_refresh:
+            mock_refresh.assert_called_once()
+        else:
+            mock_refresh.assert_not_called()
 
 
 def test_token_refresh_handles_error_per_user(scheduler_db, test_user):
@@ -443,24 +430,27 @@ def test_refresh_access_token_success():
         assert result == ("at_new", "rt_new")
 
 
-def test_refresh_access_token_failure_returns_none():
-    """Non-200 response from Azure AD returns None."""
+def _non_200_post():
     mock_response = MagicMock()
     mock_response.status_code = 400
     mock_response.text = "invalid_grant: The refresh token has expired"
+    return AsyncMock(return_value=mock_response)
 
+
+@pytest.mark.parametrize(
+    "post_mock_factory",
+    [
+        pytest.param(_non_200_post, id="non_200_response"),
+        pytest.param(
+            lambda: AsyncMock(side_effect=Exception("Connection refused")),
+            id="network_error",
+        ),
+    ],
+)
+def test_refresh_access_token_returns_none(post_mock_factory):
+    """Azure AD non-200 responses and network errors both return None."""
     with patch("app.utils.token_manager.http") as mock_http:
-        mock_http.post = AsyncMock(return_value=mock_response)
-        from app.utils.token_manager import _refresh_access_token
-
-        result = asyncio.run(_refresh_access_token("rt_bad", "cid", "cs", "tid"))
-        assert result is None
-
-
-def test_refresh_access_token_exception_returns_none():
-    """Network error during refresh returns None."""
-    with patch("app.utils.token_manager.http") as mock_http:
-        mock_http.post = AsyncMock(side_effect=Exception("Connection refused"))
+        mock_http.post = post_mock_factory()
         from app.utils.token_manager import _refresh_access_token
 
         result = asyncio.run(_refresh_access_token("rt", "cid", "cs", "tid"))
@@ -515,12 +505,53 @@ def test_batch_results_handles_error(scheduler_db):
 # ── _job_inbox_scan() ──────────────────────────────────────────────────
 
 
-def test_inbox_scan_scans_connected_user(scheduler_db, test_user):
-    """Connected users with stale last_inbox_scan are scanned."""
+@pytest.mark.parametrize(
+    ("access_token", "m365_connected", "last_inbox_scan", "should_scan"),
+    [
+        pytest.param(
+            "at_inbox",
+            True,
+            datetime.now(timezone.utc) - timedelta(hours=2),
+            True,
+            id="connected_stale_scanned",
+        ),
+        pytest.param(
+            "at_inbox",
+            False,
+            None,
+            False,
+            id="disconnected_skipped",
+        ),
+        pytest.param(
+            None,
+            True,
+            None,
+            False,
+            id="no_access_token_skipped",
+        ),
+        pytest.param(
+            "at_inbox",
+            True,
+            None,
+            True,
+            id="never_scanned_scanned",
+        ),
+        pytest.param(
+            "at_inbox",
+            True,
+            datetime.now(timezone.utc) - timedelta(minutes=5),
+            False,
+            id="recently_scanned_skipped",
+        ),
+    ],
+)
+def test_inbox_scan_eligibility(scheduler_db, test_user, access_token, m365_connected, last_inbox_scan, should_scan):
+    """A user is scanned only when connected, has an access token, and is past the
+    interval."""
     test_user.refresh_token = "rt_inbox"
-    test_user.access_token = "at_inbox"
-    test_user.m365_connected = True
-    test_user.last_inbox_scan = datetime.now(timezone.utc) - timedelta(hours=2)
+    test_user.access_token = access_token
+    test_user.m365_connected = m365_connected
+    test_user.last_inbox_scan = last_inbox_scan
     scheduler_db.commit()
 
     with (
@@ -531,83 +562,10 @@ def test_inbox_scan_scans_connected_user(scheduler_db, test_user):
         from app.jobs.core_jobs import _job_inbox_scan
 
         asyncio.run(_job_inbox_scan())
-        mock_scan.assert_called_once()
-
-
-def test_inbox_scan_skips_disconnected_user(scheduler_db, test_user):
-    """Users without m365_connected=True are skipped."""
-    test_user.refresh_token = "rt_inbox"
-    test_user.access_token = "at_inbox"
-    test_user.m365_connected = False
-    test_user.last_inbox_scan = None
-    scheduler_db.commit()
-
-    with (
-        patch("app.jobs.email_jobs._scan_user_inbox", new_callable=AsyncMock) as mock_scan,
-        patch("app.config.settings") as mock_settings,
-    ):
-        mock_settings.inbox_scan_interval_min = 30
-        from app.jobs.core_jobs import _job_inbox_scan
-
-        asyncio.run(_job_inbox_scan())
-        mock_scan.assert_not_called()
-
-
-def test_inbox_scan_skips_user_without_access_token(scheduler_db, test_user):
-    """Users without an access_token are skipped even if connected."""
-    test_user.refresh_token = "rt_inbox"
-    test_user.access_token = None
-    test_user.m365_connected = True
-    test_user.last_inbox_scan = None
-    scheduler_db.commit()
-
-    with (
-        patch("app.jobs.email_jobs._scan_user_inbox", new_callable=AsyncMock) as mock_scan,
-        patch("app.config.settings") as mock_settings,
-    ):
-        mock_settings.inbox_scan_interval_min = 30
-        from app.jobs.core_jobs import _job_inbox_scan
-
-        asyncio.run(_job_inbox_scan())
-        mock_scan.assert_not_called()
-
-
-def test_inbox_scan_scans_user_with_no_previous_scan(scheduler_db, test_user):
-    """Users who have never been scanned (last_inbox_scan=None) are scanned."""
-    test_user.refresh_token = "rt_inbox"
-    test_user.access_token = "at_inbox"
-    test_user.m365_connected = True
-    test_user.last_inbox_scan = None
-    scheduler_db.commit()
-
-    with (
-        patch("app.jobs.email_jobs._scan_user_inbox", new_callable=AsyncMock) as mock_scan,
-        patch("app.config.settings") as mock_settings,
-    ):
-        mock_settings.inbox_scan_interval_min = 30
-        from app.jobs.core_jobs import _job_inbox_scan
-
-        asyncio.run(_job_inbox_scan())
-        mock_scan.assert_called_once()
-
-
-def test_inbox_scan_skips_recently_scanned_user(scheduler_db, test_user):
-    """Users scanned within the interval are skipped."""
-    test_user.refresh_token = "rt_inbox"
-    test_user.access_token = "at_inbox"
-    test_user.m365_connected = True
-    test_user.last_inbox_scan = datetime.now(timezone.utc) - timedelta(minutes=5)
-    scheduler_db.commit()
-
-    with (
-        patch("app.jobs.email_jobs._scan_user_inbox", new_callable=AsyncMock) as mock_scan,
-        patch("app.config.settings") as mock_settings,
-    ):
-        mock_settings.inbox_scan_interval_min = 30
-        from app.jobs.core_jobs import _job_inbox_scan
-
-        asyncio.run(_job_inbox_scan())
-        mock_scan.assert_not_called()
+        if should_scan:
+            mock_scan.assert_called_once()
+        else:
+            mock_scan.assert_not_called()
 
 
 def test_inbox_scan_handles_timeout(scheduler_db, test_user):

--- a/tests/test_load_test_fixes.py
+++ b/tests/test_load_test_fixes.py
@@ -86,38 +86,32 @@ def _make_quote(db, req, site, user, offer_ids, quote_number="Q-TEST-001"):
 # ── Fix 1: Migration file exists ────────────────────────────────────────
 
 
+def _load_migration_015():
+    import importlib.util
+
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "alembic",
+        "versions",
+        "015_performance_indexes.py",
+    )
+    assert os.path.exists(path)
+    spec = importlib.util.spec_from_file_location("migration_015", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 class TestPerformanceIndexes:
     def test_migration_file_exists(self):
         """Migration 015 should exist with is_stale column."""
-        import importlib.util
-
-        path = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "alembic",
-            "versions",
-            "015_performance_indexes.py",
-        )
-        assert os.path.exists(path)
-        spec = importlib.util.spec_from_file_location("migration_015", path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+        mod = _load_migration_015()
         assert mod.revision == "015_performance_indexes"
         assert mod.down_revision == "014_multiplier_score_snapshot"
 
     def test_migration_has_upgrade_and_downgrade(self):
-        import importlib.util
-
-        path = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "alembic",
-            "versions",
-            "015_performance_indexes.py",
-        )
-        spec = importlib.util.spec_from_file_location("migration_015", path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+        mod = _load_migration_015()
         assert callable(mod.upgrade)
         assert callable(mod.downgrade)
 
@@ -400,6 +394,3 @@ class TestProactiveOfferExpiry:
         from app.jobs.offers_jobs import _job_proactive_offer_expiry
 
         assert callable(_job_proactive_offer_expiry)
-
-
-# ── Fix 5: Buyer-brief optimized ────────────────────────────────────────

--- a/tests/test_m9_m10_audit_fixes.py
+++ b/tests/test_m9_m10_audit_fixes.py
@@ -20,36 +20,30 @@ from app.utils.sql_helpers import escape_like
 class TestLikeEscapeIntegration:
     """Verify escape_like is applied to user-facing search inputs."""
 
-    def test_percent_in_sales_person_escaped(self):
-        """Percent wildcards in sales_person filter must be escaped."""
-        raw = "100%match"
-        escaped = escape_like(raw)
-        assert "%" not in escaped or r"\%" in escaped
-        assert escaped == r"100\%match"
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("100%match", r"100\%match"),
+            ("LM_358", r"LM\_358"),
+            ("100%_test", r"100\%\_test"),
+        ],
+        ids=[
+            "percent_in_sales_person",
+            "underscore_in_search_query",
+            "combined_wildcards_in_tag_search",
+        ],
+    )
+    def test_wildcards_escaped(self, raw, expected):
+        """User-facing search inputs must have LIKE wildcards escaped."""
+        assert escape_like(raw) == expected
 
-    def test_underscore_in_search_query_escaped(self):
-        """Underscore wildcards in q filter must be escaped."""
-        raw = "LM_358"
-        escaped = escape_like(raw)
-        assert escaped == r"LM\_358"
+    @pytest.mark.parametrize("module_name", ["sightings", "tags"])
+    def test_router_imports_escape_like(self, module_name):
+        """sightings.py and tags.py must import escape_like."""
+        import importlib
 
-    def test_combined_wildcards_in_tag_search(self):
-        """Combined wildcards in tag search must all be escaped."""
-        raw = "100%_test"
-        escaped = escape_like(raw)
-        assert escaped == r"100\%\_test"
-
-    def test_sightings_router_imports_escape_like(self):
-        """sightings.py must import escape_like."""
-        from app.routers import sightings
-
-        assert hasattr(sightings, "escape_like")
-
-    def test_tags_router_imports_escape_like(self):
-        """tags.py must import escape_like."""
-        from app.routers import tags
-
-        assert hasattr(tags, "escape_like")
+        router_module = importlib.import_module(f"app.routers.{module_name}")
+        assert hasattr(router_module, "escape_like")
 
 
 # ── M10: Enrichment Connector Error Classification ─────────────────────
@@ -96,9 +90,18 @@ class TestEnrichmentErrorClassification:
         mock_logger.warning.assert_called_once()
         assert "timed out" in mock_logger.warning.call_args[0][0]
 
+    @pytest.mark.parametrize(
+        ("exc_message", "log_level", "expected_substr"),
+        [
+            ("HTTP 401 Unauthorized", "error", "auth failure"),
+            ("HTTP 403 Forbidden", "error", "auth failure"),
+            ("HTTP 429 Too Many Requests", "warning", "rate limited"),
+        ],
+        ids=["auth_401", "auth_403", "rate_limit_429"],
+    )
     @pytest.mark.asyncio()
-    async def test_auth_401_logs_error(self):
-        """401 errors should log at ERROR level with auth failure message."""
+    async def test_classified_error_log_level_and_message(self, exc_message, log_level, expected_substr):
+        """401/403 log at ERROR (auth failure); 429 logs a rate-limited WARNING."""
         import app.services.enrichment as mod
 
         config = _make_config()
@@ -108,62 +111,16 @@ class TestEnrichmentErrorClassification:
             patch.object(mod, "get_credential_cached", return_value="fake-key"),
             patch.object(mod, "importlib") as mock_importlib,
             patch.object(mod, "logger", mock_logger),
-            patch.object(mod.asyncio, "wait_for", side_effect=Exception("HTTP 401 Unauthorized")),
+            patch.object(mod.asyncio, "wait_for", side_effect=Exception(exc_message)),
         ):
-            mock_module = MagicMock()
-            mock_importlib.import_module.return_value = mock_module
+            mock_importlib.import_module.return_value = MagicMock()
 
             result = await mod._try_connector_config(config, "LM358N")
 
         assert result is None
-        mock_logger.error.assert_called_once()
-        assert "auth failure" in mock_logger.error.call_args[0][0]
-
-    @pytest.mark.asyncio()
-    async def test_auth_403_logs_error(self):
-        """403 Forbidden should also be classified as auth failure."""
-        import app.services.enrichment as mod
-
-        config = _make_config()
-        mock_logger = MagicMock()
-
-        with (
-            patch.object(mod, "get_credential_cached", return_value="fake-key"),
-            patch.object(mod, "importlib") as mock_importlib,
-            patch.object(mod, "logger", mock_logger),
-            patch.object(mod.asyncio, "wait_for", side_effect=Exception("HTTP 403 Forbidden")),
-        ):
-            mock_module = MagicMock()
-            mock_importlib.import_module.return_value = mock_module
-
-            result = await mod._try_connector_config(config, "LM358N")
-
-        assert result is None
-        mock_logger.error.assert_called_once()
-        assert "auth failure" in mock_logger.error.call_args[0][0]
-
-    @pytest.mark.asyncio()
-    async def test_rate_limit_logs_warning(self):
-        """429 rate-limit errors should log a warning with rate-limited message."""
-        import app.services.enrichment as mod
-
-        config = _make_config()
-        mock_logger = MagicMock()
-
-        with (
-            patch.object(mod, "get_credential_cached", return_value="fake-key"),
-            patch.object(mod, "importlib") as mock_importlib,
-            patch.object(mod, "logger", mock_logger),
-            patch.object(mod.asyncio, "wait_for", side_effect=Exception("HTTP 429 Too Many Requests")),
-        ):
-            mock_module = MagicMock()
-            mock_importlib.import_module.return_value = mock_module
-
-            result = await mod._try_connector_config(config, "LM358N")
-
-        assert result is None
-        mock_logger.warning.assert_called_once()
-        assert "rate limited" in mock_logger.warning.call_args[0][0]
+        log_method = getattr(mock_logger, log_level)
+        log_method.assert_called_once()
+        assert expected_substr in log_method.call_args[0][0]
 
     @pytest.mark.asyncio()
     async def test_generic_error_logs_warning_with_exc_info(self):
@@ -179,12 +136,10 @@ class TestEnrichmentErrorClassification:
             patch.object(mod, "logger", mock_logger),
             patch.object(mod.asyncio, "wait_for", side_effect=Exception("Connection refused")),
         ):
-            mock_module = MagicMock()
-            mock_importlib.import_module.return_value = mock_module
+            mock_importlib.import_module.return_value = MagicMock()
 
             result = await mod._try_connector_config(config, "LM358N")
 
         assert result is None
         mock_logger.warning.assert_called_once()
-        call_kwargs = mock_logger.warning.call_args
-        assert call_kwargs[1].get("exc_info") is True
+        assert mock_logger.warning.call_args[1].get("exc_info") is True

--- a/tests/test_manufacturer_typeahead.py
+++ b/tests/test_manufacturer_typeahead.py
@@ -6,21 +6,22 @@ Called by: pytest
 Depends on: conftest.py (client, db_session fixtures), app.models.sourcing.Manufacturer
 """
 
+import pytest
+
 from app.models.sourcing import Manufacturer
 
 
-def test_search_by_canonical_name(client, db_session):
+@pytest.mark.parametrize(
+    "query",
+    [
+        pytest.param("texas", id="by_canonical_name"),
+        pytest.param("TI", id="by_alias"),
+    ],
+)
+def test_search_matches_manufacturer(client, db_session, query):
     db_session.add(Manufacturer(canonical_name="Texas Instruments", aliases=["TI"]))
     db_session.commit()
-    resp = client.get("/v2/partials/manufacturers/search?q=texas")
-    assert resp.status_code == 200
-    assert "Texas Instruments" in resp.text
-
-
-def test_search_by_alias(client, db_session):
-    db_session.add(Manufacturer(canonical_name="Texas Instruments", aliases=["TI"]))
-    db_session.commit()
-    resp = client.get("/v2/partials/manufacturers/search?q=TI")
+    resp = client.get(f"/v2/partials/manufacturers/search?q={query}")
     assert resp.status_code == 200
     assert "Texas Instruments" in resp.text
 

--- a/tests/test_material_card_category_edit.py
+++ b/tests/test_material_card_category_edit.py
@@ -50,6 +50,15 @@ def _toast(resp) -> dict | None:
     return json.loads(raw).get("showToast")
 
 
+def _seed_ti_alias(db: Session) -> None:
+    """Seed a real TI alias row so normalize_brand_name exercises the production (non-
+    pass-through) canonicalization path."""
+    from app.models import Manufacturer
+
+    db.add(Manufacturer(canonical_name="Texas Instruments", aliases=["TI"]))
+    db.commit()
+
+
 def test_manual_category_change_stamps_manual_provenance(client, db_session: Session):
     """A deliberate category change lands canonical with manual/100/1.0 provenance — not
     a raw write that leaves the old provenance attached to the new value."""
@@ -326,10 +335,7 @@ def test_unchanged_alias_manufacturer_not_restamped_with_seeded_alias_table(clie
     manufacturers table makes normalize_brand_name a pass-through, so this test seeds
     a real alias row to exercise the production path.)
     """
-    from app.models import Manufacturer
-
-    db_session.add(Manufacturer(canonical_name="Texas Instruments", aliases=["TI"]))
-    db_session.commit()
+    _seed_ti_alias(db_session)
     card = _card(db_session, "LM317T-ALIAS", manufacturer="TI")  # NULL provenance — legacy
 
     resp = client.put(
@@ -348,10 +354,7 @@ def test_canonical_resubmit_of_stored_alias_not_restamped(client, db_session: Se
     """Canonical-to-canonical equality: re-submitting the CANONICAL form of a stored
     alias ("Texas Instruments" over stored "TI") is the same maker, not an edit — it
     must not be re-stamped manual/100 either."""
-    from app.models import Manufacturer
-
-    db_session.add(Manufacturer(canonical_name="Texas Instruments", aliases=["TI"]))
-    db_session.commit()
+    _seed_ti_alias(db_session)
     card = _card(db_session, "LM317T-CANON", manufacturer="TI")
 
     resp = client.put(
@@ -368,10 +371,7 @@ def test_canonical_resubmit_of_stored_alias_not_restamped(client, db_session: Se
 def test_alias_manufacturer_change_still_lands_with_seeded_alias_table(client, db_session: Session):
     """A GENUINE maker change on an alias-stored card still routes through the ladder at
     manual/100 (the canonical-to-canonical guard must not eat real edits)."""
-    from app.models import Manufacturer
-
-    db_session.add(Manufacturer(canonical_name="Texas Instruments", aliases=["TI"]))
-    db_session.commit()
+    _seed_ti_alias(db_session)
     card = _card(db_session, "LM317T-EDIT", manufacturer="TI")
 
     resp = client.put(f"/v2/partials/materials/{card.id}", data={"manufacturer": "STMicroelectronics"})

--- a/tests/test_materials_results_condense.py
+++ b/tests/test_materials_results_condense.py
@@ -5,6 +5,7 @@ Renders the partial directly via Jinja (mirrors tests/test_oem_badges.py) so the
 contract is asserted without seeding vendor-sighting stats.
 """
 
+import pytest
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 
@@ -86,15 +87,18 @@ def test_status_cell_merges_trust_lifecycle_condition():
     assert html.count("<th ") == 7  # trailing space: doesn't match <thead>
 
 
-def test_best_price_two_decimals_at_or_above_one_dollar():
-    html = _render(_best_price=42.5, _best_currency="USD")
-    assert "$42.50" in html
-    assert "$42.5000" not in html
-
-
-def test_best_price_four_decimals_below_one_dollar():
-    html = _render(_best_price=0.0123, _best_currency="USD")
-    assert "$0.0123" in html
+@pytest.mark.parametrize(
+    ("price", "expected", "forbidden"),
+    [
+        pytest.param(42.5, "$42.50", "$42.5000", id="two_decimals_at_or_above_one_dollar"),
+        pytest.param(0.0123, "$0.0123", None, id="four_decimals_below_one_dollar"),
+    ],
+)
+def test_best_price_decimal_precision(price, expected, forbidden):
+    html = _render(_best_price=price, _best_currency="USD")
+    assert expected in html
+    if forbidden is not None:
+        assert forbidden not in html
 
 
 def test_count_is_match_framed_with_query():

--- a/tests/test_migration_055.py
+++ b/tests/test_migration_055.py
@@ -194,27 +194,21 @@ class TestNormalizePhones:
         update_calls = _calls_matching(conn.execute.call_args_list, "UPDATE")
         assert len(update_calls) == 0
 
-    def test_skips_when_normalized_equals_raw(self):
-        """If format_phone_e164 returns the same value as input, no UPDATE issued."""
-        row = _ns(id=1, phone="5551234567")
+    @pytest.mark.parametrize(
+        "raw,normalized",
+        [
+            pytest.param("5551234567", "5551234567", id="normalized_equals_raw"),
+            pytest.param("not-a-phone", None, id="normalized_is_none"),
+        ],
+    )
+    def test_skips_when_no_change(self, raw, normalized):
+        """No UPDATE when normalization yields the same value or None (unparseable)."""
+        row = _ns(id=1, phone=raw)
         conn = MagicMock()
         results = [[row]] + [[] for _ in range(5)]
         conn.execute.return_value.fetchall.side_effect = results
 
-        with patch("app.utils.phone_utils.format_phone_e164", return_value="5551234567"):
-            _normalize_phones(conn)
-
-        update_calls = _calls_matching(conn.execute.call_args_list, "UPDATE")
-        assert len(update_calls) == 0
-
-    def test_skips_when_normalized_is_none(self):
-        """If format_phone_e164 returns None (unparseable), no UPDATE issued."""
-        row = _ns(id=1, phone="not-a-phone")
-        conn = MagicMock()
-        results = [[row]] + [[] for _ in range(5)]
-        conn.execute.return_value.fetchall.side_effect = results
-
-        with patch("app.utils.phone_utils.format_phone_e164", return_value=None):
+        with patch("app.utils.phone_utils.format_phone_e164", return_value=normalized):
             _normalize_phones(conn)
 
         update_calls = _calls_matching(conn.execute.call_args_list, "UPDATE")

--- a/tests/test_migration_091_cleanup.py
+++ b/tests/test_migration_091_cleanup.py
@@ -18,6 +18,8 @@ Depends on: alembic/versions/091_cleanup_vague_descs.py
 import importlib.util
 import os
 
+import pytest
+
 # Load the migration module directly since alembic/versions has no __init__.py.
 _MIGRATION_PATH = os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "091_cleanup_vague_descs.py")
 _spec = importlib.util.spec_from_file_location("migration_091", _MIGRATION_PATH)
@@ -43,27 +45,39 @@ class TestRevisionMetadata:
 class TestVagueDescWhere:
     """The hallucinated-description predicate must stay narrowly scoped."""
 
-    def test_predicate_targets_never_sourced_not_found_cards(self):
-        where = _mod._VAGUE_DESC_WHERE
-        assert "not_found" in where
-        assert "enrichment_source IS NULL" in where
-        assert "deleted_at IS NULL" in where
-        assert "description IS NOT NULL" in where
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "not_found",
+            "enrichment_source IS NULL",
+            "deleted_at IS NULL",
+            "description IS NOT NULL",
+        ],
+    )
+    def test_predicate_targets_never_sourced_not_found_cards(self, token):
+        assert token in _mod._VAGUE_DESC_WHERE
 
-    def test_predicate_matches_hedging_tokens(self):
-        where = _mod._VAGUE_DESC_WHERE
-        for token in ("likely", "possibly", "may be", "proprietary", "appears to be", "could be"):
-            assert token in where
+    @pytest.mark.parametrize(
+        "token",
+        ["likely", "possibly", "may be", "proprietary", "appears to be", "could be"],
+    )
+    def test_predicate_matches_hedging_tokens(self, token):
+        assert token in _mod._VAGUE_DESC_WHERE
 
 
 class TestUntrustworthyStampWhere:
     """The stamp-clearing predicate must stay gated on untrustworthy status."""
 
-    def test_predicate_clears_untrustworthy_specs_enriched_at(self):
-        where = _mod._UNTRUSTWORTHY_STAMP_WHERE
-        assert "specs_enriched_at" in where
-        assert "deleted_at IS NULL" in where
-        assert "verified" in where
-        assert "web_sourced" in where
-        assert "oem_sourced" in where
-        assert "NOT IN" in where
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "specs_enriched_at",
+            "deleted_at IS NULL",
+            "verified",
+            "web_sourced",
+            "oem_sourced",
+            "NOT IN",
+        ],
+    )
+    def test_predicate_clears_untrustworthy_specs_enriched_at(self, token):
+        assert token in _mod._UNTRUSTWORTHY_STAMP_WHERE

--- a/tests/test_migration_094_fru_links.py
+++ b/tests/test_migration_094_fru_links.py
@@ -11,9 +11,11 @@ Depends on: alembic/versions/094_fru_links.py
 import importlib.util
 import os
 
+import pytest
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.pool import StaticPool
 
 # Load the migration module directly since alembic/versions has no __init__.py.
@@ -74,24 +76,15 @@ class TestExecution:
         assert {"ix_fru_links_fru_norm", "ix_fru_links_related_norm"} <= index_names
 
         # The unique key must reject duplicate edges.
+        insert_edge = text(
+            "INSERT INTO fru_links (fru_raw, fru_norm, related_raw, related_norm, rel_kind, source_sheet) "
+            "VALUES ('00AJ001', '00aj001', '68Y7789', '68y7789', 'ibm_11s', 'Main')"
+        )
         with engine.begin() as conn:
-            conn.execute(
-                text(
-                    "INSERT INTO fru_links (fru_raw, fru_norm, related_raw, related_norm, rel_kind, source_sheet) "
-                    "VALUES ('00AJ001', '00aj001', '68Y7789', '68y7789', 'ibm_11s', 'Main')"
-                )
-            )
-        import pytest
-        from sqlalchemy.exc import IntegrityError
-
+            conn.execute(insert_edge)
         with pytest.raises(IntegrityError):
             with engine.begin() as conn:
-                conn.execute(
-                    text(
-                        "INSERT INTO fru_links (fru_raw, fru_norm, related_raw, related_norm, rel_kind, source_sheet) "
-                        "VALUES ('00AJ001', '00aj001', '68Y7789', '68y7789', 'ibm_11s', 'Main')"
-                    )
-                )
+                conn.execute(insert_edge)
 
         self._run(engine, _mod.downgrade)
         assert not inspect(engine).has_table("fru_links")

--- a/tests/test_nc_phase4.py
+++ b/tests/test_nc_phase4.py
@@ -12,6 +12,16 @@ from app.services.nc_worker.config import NcConfig
 from app.services.nc_worker.human_behavior import HumanBehavior
 from app.services.nc_worker.session_manager import NcSessionManager
 
+
+def _run(coro):
+    """Run a coroutine to completion on a fresh, immediately-closed event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
 # ── HumanBehavior Tests ─────────────────────────────────────────────
 
 
@@ -43,15 +53,13 @@ def test_random_delay_gaussian_distribution():
 
 def test_human_type_calls_keyboard(db_session):
     """human_type types each character individually."""
-    loop = asyncio.new_event_loop()
     page = MagicMock()
     page.keyboard = MagicMock()
     page.keyboard.type = AsyncMock()
     locator = MagicMock()
     locator.click = AsyncMock()
 
-    loop.run_until_complete(HumanBehavior.human_type(page, locator, "ABC"))
-    loop.close()
+    _run(HumanBehavior.human_type(page, locator, "ABC"))
 
     locator.click.assert_called_once()
     assert page.keyboard.type.call_count == 3  # One per character
@@ -59,15 +67,13 @@ def test_human_type_calls_keyboard(db_session):
 
 def test_human_click_random_position():
     """human_click clicks within the bounding box, not dead center."""
-    loop = asyncio.new_event_loop()
     page = MagicMock()
     page.mouse = MagicMock()
     page.mouse.click = AsyncMock()
     locator = MagicMock()
     locator.bounding_box = AsyncMock(return_value={"x": 100, "y": 200, "width": 80, "height": 30})
 
-    loop.run_until_complete(HumanBehavior.human_click(page, locator))
-    loop.close()
+    _run(HumanBehavior.human_click(page, locator))
 
     page.mouse.click.assert_called_once()
     call_args = page.mouse.click.call_args[0]
@@ -79,14 +85,12 @@ def test_human_click_random_position():
 
 def test_human_click_fallback_no_bbox():
     """human_click falls back to locator.click() if bounding_box returns None."""
-    loop = asyncio.new_event_loop()
     page = MagicMock()
     locator = MagicMock()
     locator.bounding_box = AsyncMock(return_value=None)
     locator.click = AsyncMock()
 
-    loop.run_until_complete(HumanBehavior.human_click(page, locator))
-    loop.close()
+    _run(HumanBehavior.human_click(page, locator))
 
     locator.click.assert_called_once()
 

--- a/tests/test_nc_phase6.py
+++ b/tests/test_nc_phase6.py
@@ -6,6 +6,8 @@ Depends on: conftest.py, nc_worker modules
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.services.nc_worker.circuit_breaker import CircuitBreaker
 from app.services.nc_worker.config import NcConfig
 from app.services.nc_worker.scheduler import SearchScheduler
@@ -13,44 +15,24 @@ from app.services.nc_worker.scheduler import SearchScheduler
 # ── Scheduler Tests ──────────────────────────────────────────────────
 
 
-def test_scheduler_is_business_hours_weekday():
-    """Business hours check works for weekday within range."""
-    cfg = NcConfig()
-    sched = SearchScheduler(cfg)
-
-    # Mock a Tuesday at 10 AM Eastern
-    with patch("app.services.nc_worker.scheduler.datetime") as mock_dt:
-        mock_now = MagicMock()
-        mock_now.weekday.return_value = 1  # Tuesday
-        mock_now.hour = 10
-        mock_dt.now.return_value = mock_now
-        assert sched.is_business_hours() is True
-
-
-def test_scheduler_is_business_hours_weekend():
-    """Business hours are False on weekends."""
-    cfg = NcConfig()
-    sched = SearchScheduler(cfg)
+@pytest.mark.parametrize(
+    ("weekday", "hour", "expected"),
+    [
+        pytest.param(1, 10, True, id="weekday_within_range"),  # Tuesday 10 AM
+        pytest.param(5, 10, False, id="weekend"),  # Saturday 10 AM
+        pytest.param(4, 22, False, id="outside_hours"),  # Friday 10 PM (after 5 PM cutoff)
+    ],
+)
+def test_scheduler_is_business_hours(weekday, hour, expected):
+    """Business hours check honors weekday and configured hour range."""
+    sched = SearchScheduler(NcConfig())
 
     with patch("app.services.nc_worker.scheduler.datetime") as mock_dt:
         mock_now = MagicMock()
-        mock_now.weekday.return_value = 5  # Saturday
-        mock_now.hour = 10
+        mock_now.weekday.return_value = weekday
+        mock_now.hour = hour
         mock_dt.now.return_value = mock_now
-        assert sched.is_business_hours() is False
-
-
-def test_scheduler_is_business_hours_outside():
-    """Business hours are False outside the configured range (Friday 10 PM)."""
-    cfg = NcConfig()
-    sched = SearchScheduler(cfg)
-
-    with patch("app.services.nc_worker.scheduler.datetime") as mock_dt:
-        mock_now = MagicMock()
-        mock_now.weekday.return_value = 4  # Friday
-        mock_now.hour = 22  # 10 PM (after 5 PM cutoff)
-        mock_dt.now.return_value = mock_now
-        assert sched.is_business_hours() is False
+        assert sched.is_business_hours() is expected
 
 
 def test_scheduler_next_delay_within_bounds():
@@ -145,32 +127,34 @@ def test_breaker_captcha_detection():
     assert breaker.is_open  # Second time, tripped
 
 
-def test_breaker_rate_limited():
-    """Rate limiting message trips the breaker."""
+@pytest.mark.parametrize(
+    ("body", "url", "expected_result", "expected_open"),
+    [
+        pytest.param(
+            "too many requests. please try again later.",
+            "https://www.netcomponents.com/error",
+            "RATE_LIMITED",
+            True,
+            id="rate_limited_trips",
+        ),
+        pytest.param(
+            "please log in",
+            "https://www.netcomponents.com/account/login",
+            "SESSION_EXPIRED",
+            False,
+            id="session_expired_no_trip",
+        ),
+    ],
+)
+def test_breaker_check_response_health(body, url, expected_result, expected_open):
+    """Rate limiting trips the breaker; a login page is a normal session expiry (no
+    trip)."""
     breaker = CircuitBreaker()
 
-    result = breaker.check_response_health(
-        200,
-        "too many requests. please try again later.",
-        "https://www.netcomponents.com/error",
-    )
+    result = breaker.check_response_health(200, body, url)
 
-    assert result == "RATE_LIMITED"
-    assert breaker.is_open
-
-
-def test_breaker_session_expired():
-    """Login page URL = SESSION_EXPIRED (normal, not a trip)."""
-    breaker = CircuitBreaker()
-
-    result = breaker.check_response_health(
-        200,
-        "please log in",
-        "https://www.netcomponents.com/account/login",
-    )
-
-    assert result == "SESSION_EXPIRED"
-    assert not breaker.is_open  # Not a trip
+    assert result == expected_result
+    assert bool(breaker.is_open) is expected_open
 
 
 def test_breaker_empty_results_streak():

--- a/tests/test_nightly_coverage_boost.py
+++ b/tests/test_nightly_coverage_boost.py
@@ -87,7 +87,6 @@ class TestActivityDigestEdgeCases:
                 "status_signal": "on_track",
             }
 
-        monkeypatch_svc = svc
         with (
             patch.object(svc, "_get_redis", return_value=None),
             patch("app.utils.claude_client.claude_structured", fake_cs),

--- a/tests/test_nightly_nc_worker.py
+++ b/tests/test_nightly_nc_worker.py
@@ -541,59 +541,25 @@ class TestNcScheduler:
         finally:
             del os.environ["FORCE_BUSINESS_HOURS"]
 
-    def test_is_business_hours_saturday(self):
+    @pytest.mark.parametrize(
+        ("weekday", "hour", "expected"),
+        [
+            pytest.param(5, 10, False, id="saturday"),
+            pytest.param(6, 10, False, id="sunday_morning"),
+            pytest.param(6, 20, True, id="sunday_evening"),
+            pytest.param(4, 10, True, id="friday_on"),
+            pytest.param(4, 18, False, id="friday_off"),
+            pytest.param(2, 14, True, id="wednesday"),
+        ],
+    )
+    def test_is_business_hours(self, weekday, hour, expected):
         scheduler = self._make_scheduler()
         with patch("app.services.nc_worker.scheduler.datetime") as mock_dt:
             mock_now = MagicMock()
-            mock_now.weekday.return_value = 5
-            mock_now.hour = 10
+            mock_now.weekday.return_value = weekday
+            mock_now.hour = hour
             mock_dt.now.return_value = mock_now
-            assert scheduler.is_business_hours() is False
-
-    def test_is_business_hours_sunday_morning(self):
-        scheduler = self._make_scheduler()
-        with patch("app.services.nc_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 6
-            mock_now.hour = 10
-            mock_dt.now.return_value = mock_now
-            assert scheduler.is_business_hours() is False
-
-    def test_is_business_hours_sunday_evening(self):
-        scheduler = self._make_scheduler()
-        with patch("app.services.nc_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 6
-            mock_now.hour = 20
-            mock_dt.now.return_value = mock_now
-            assert scheduler.is_business_hours() is True
-
-    def test_is_business_hours_friday_on(self):
-        scheduler = self._make_scheduler()
-        with patch("app.services.nc_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 4
-            mock_now.hour = 10
-            mock_dt.now.return_value = mock_now
-            assert scheduler.is_business_hours() is True
-
-    def test_is_business_hours_friday_off(self):
-        scheduler = self._make_scheduler()
-        with patch("app.services.nc_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 4
-            mock_now.hour = 18
-            mock_dt.now.return_value = mock_now
-            assert scheduler.is_business_hours() is False
-
-    def test_is_business_hours_wednesday(self):
-        scheduler = self._make_scheduler()
-        with patch("app.services.nc_worker.scheduler.datetime") as mock_dt:
-            mock_now = MagicMock()
-            mock_now.weekday.return_value = 2
-            mock_now.hour = 14
-            mock_dt.now.return_value = mock_now
-            assert scheduler.is_business_hours() is True
+            assert scheduler.is_business_hours() is expected
 
     def test_next_delay_increments_count(self):
         scheduler = self._make_scheduler()
@@ -695,6 +661,28 @@ class TestNcSightingWriter:
             yield session
             session.rollback()
 
+    @staticmethod
+    def _make_requirement(db, *, req_name, mpn, normalized_mpn, target_qty):
+        from app.models import MaterialCard, Requirement, Requisition
+
+        req = Requisition(name=req_name, status="active")
+        db.add(req)
+        db.flush()
+
+        mc = MaterialCard(display_mpn=mpn, normalized_mpn=normalized_mpn)
+        db.add(mc)
+        db.flush()
+
+        requirement = Requirement(
+            requisition_id=req.id,
+            primary_mpn=mpn,
+            target_qty=target_qty,
+            material_card_id=mc.id,
+        )
+        db.add(requirement)
+        db.flush()
+        return requirement
+
     @patch("app.services.sighting_aggregation.rebuild_vendor_summaries_from_sightings")
     def test_save_nc_sightings_no_requirement(self, mock_rebuild, db):
         from app.services.nc_worker.sighting_writer import save_nc_sightings
@@ -706,25 +694,11 @@ class TestNcSightingWriter:
 
     @patch("app.services.sighting_aggregation.rebuild_vendor_summaries_from_sightings")
     def test_save_nc_sightings_empty_list(self, mock_rebuild, db):
-        from app.models import MaterialCard, Requirement, Requisition
         from app.services.nc_worker.sighting_writer import save_nc_sightings
 
-        req = Requisition(name="NC Test1", status="active")
-        db.add(req)
-        db.flush()
-
-        mc = MaterialCard(display_mpn="LM324", normalized_mpn="lm324_nc_empty")
-        db.add(mc)
-        db.flush()
-
-        requirement = Requirement(
-            requisition_id=req.id,
-            primary_mpn="LM324",
-            target_qty=50,
-            material_card_id=mc.id,
+        requirement = self._make_requirement(
+            db, req_name="NC Test1", mpn="LM324", normalized_mpn="lm324_nc_empty", target_qty=50
         )
-        db.add(requirement)
-        db.flush()
 
         queue_item = MagicMock(requirement_id=requirement.id)
         result = save_nc_sightings(db, queue_item, [])
@@ -733,26 +707,12 @@ class TestNcSightingWriter:
 
     @patch("app.services.sighting_aggregation.rebuild_vendor_summaries_from_sightings")
     def test_save_nc_sightings_skips_no_vendor(self, mock_rebuild, db):
-        from app.models import MaterialCard, Requirement, Requisition
         from app.services.nc_worker.result_parser import NcSighting
         from app.services.nc_worker.sighting_writer import save_nc_sightings
 
-        req = Requisition(name="NC Test2", status="active")
-        db.add(req)
-        db.flush()
-
-        mc = MaterialCard(display_mpn="AB456", normalized_mpn="ab456_nc_skip")
-        db.add(mc)
-        db.flush()
-
-        requirement = Requirement(
-            requisition_id=req.id,
-            primary_mpn="AB456",
-            target_qty=10,
-            material_card_id=mc.id,
+        requirement = self._make_requirement(
+            db, req_name="NC Test2", mpn="AB456", normalized_mpn="ab456_nc_skip", target_qty=10
         )
-        db.add(requirement)
-        db.flush()
 
         sighting = NcSighting(part_number="AB456", vendor_name="", quantity=100)
         queue_item = MagicMock(requirement_id=requirement.id)
@@ -761,26 +721,12 @@ class TestNcSightingWriter:
 
     @patch("app.services.sighting_aggregation.rebuild_vendor_summaries_from_sightings")
     def test_save_nc_sightings_creates_sighting_with_price_breaks(self, mock_rebuild, db):
-        from app.models import MaterialCard, Requirement, Requisition
         from app.services.nc_worker.result_parser import NcSighting, PriceBreak
         from app.services.nc_worker.sighting_writer import save_nc_sightings
 
-        req = Requisition(name="NC Test3", status="active")
-        db.add(req)
-        db.flush()
-
-        mc = MaterialCard(display_mpn="TDA2030", normalized_mpn="tda2030_nc_create")
-        db.add(mc)
-        db.flush()
-
-        requirement = Requirement(
-            requisition_id=req.id,
-            primary_mpn="TDA2030",
-            target_qty=200,
-            material_card_id=mc.id,
+        requirement = self._make_requirement(
+            db, req_name="NC Test3", mpn="TDA2030", normalized_mpn="tda2030_nc_create", target_qty=200
         )
-        db.add(requirement)
-        db.flush()
 
         sighting = NcSighting(
             part_number="TDA2030",
@@ -802,26 +748,12 @@ class TestNcSightingWriter:
 
     @patch("app.services.sighting_aggregation.rebuild_vendor_summaries_from_sightings")
     def test_save_nc_sightings_deduplicates(self, mock_rebuild, db):
-        from app.models import MaterialCard, Requirement, Requisition
         from app.services.nc_worker.result_parser import NcSighting
         from app.services.nc_worker.sighting_writer import save_nc_sightings
 
-        req = Requisition(name="NC Test4", status="active")
-        db.add(req)
-        db.flush()
-
-        mc = MaterialCard(display_mpn="DUP002", normalized_mpn="dup002_nc")
-        db.add(mc)
-        db.flush()
-
-        requirement = Requirement(
-            requisition_id=req.id,
-            primary_mpn="DUP002",
-            target_qty=5,
-            material_card_id=mc.id,
+        requirement = self._make_requirement(
+            db, req_name="NC Test4", mpn="DUP002", normalized_mpn="dup002_nc", target_qty=5
         )
-        db.add(requirement)
-        db.flush()
 
         s1 = NcSighting(part_number="DUP002", vendor_name="VendorDup", quantity=50)
         s2 = NcSighting(part_number="DUP002", vendor_name="VendorDup", quantity=50)
@@ -831,26 +763,12 @@ class TestNcSightingWriter:
 
     @patch("app.services.sighting_aggregation.rebuild_vendor_summaries_from_sightings")
     def test_save_nc_sightings_no_price_breaks(self, mock_rebuild, db):
-        from app.models import MaterialCard, Requirement, Requisition
         from app.services.nc_worker.result_parser import NcSighting
         from app.services.nc_worker.sighting_writer import save_nc_sightings
 
-        req = Requisition(name="NC Test5", status="active")
-        db.add(req)
-        db.flush()
-
-        mc = MaterialCard(display_mpn="TMP36", normalized_mpn="tmp36_nc_noprice")
-        db.add(mc)
-        db.flush()
-
-        requirement = Requirement(
-            requisition_id=req.id,
-            primary_mpn="TMP36",
-            target_qty=10,
-            material_card_id=mc.id,
+        requirement = self._make_requirement(
+            db, req_name="NC Test5", mpn="TMP36", normalized_mpn="tmp36_nc_noprice", target_qty=10
         )
-        db.add(requirement)
-        db.flush()
 
         sighting = NcSighting(
             part_number="TMP36",

--- a/tests/test_oem_extractor.py
+++ b/tests/test_oem_extractor.py
@@ -33,40 +33,23 @@ async def test_crossref_accept():
     assert r.linkage_source_domain == "support.lenovo.com"
 
 
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"source_urls": ["https://reddit.com/r/homelab"]}, id="untrusted_domain"),
+        # quote lacks the resolved MPN → linkage not sourced
+        pytest.param({"linkage_quote": "Lenovo FRU 01HW917 memory module"}, id="linkage_missing_resolved"),
+        pytest.param(
+            {"linkage_quote": "Samsung M393A2K40EB3-CWE 16GB DDR4 RDIMM"},
+            id="linkage_missing_oem_code",
+        ),
+        pytest.param({"resolved_mpn": "01HW917", "linkage_quote": "01HW917 01HW917"}, id="echo_mpn"),
+        pytest.param({"confidence": 0.5}, id="low_confidence"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_crossref_reject_untrusted_domain():
-    r = await _xr({**XR_OK, "source_urls": ["https://reddit.com/r/homelab"]})
-    assert r.status == "failed"
-
-
-@pytest.mark.asyncio
-async def test_crossref_reject_linkage_missing_resolved():
-    # quote lacks the resolved MPN → linkage not sourced
-    r = await _xr({**XR_OK, "linkage_quote": "Lenovo FRU 01HW917 memory module"})
-    assert r.status == "failed"
-
-
-@pytest.mark.asyncio
-async def test_crossref_reject_linkage_missing_oem_code():
-    r = await _xr({**XR_OK, "linkage_quote": "Samsung M393A2K40EB3-CWE 16GB DDR4 RDIMM"})
-    assert r.status == "failed"
-
-
-@pytest.mark.asyncio
-async def test_crossref_reject_echo_mpn():
-    r = await _xr(
-        {
-            **XR_OK,
-            "resolved_mpn": "01HW917",
-            "linkage_quote": "01HW917 01HW917",
-        }
-    )
-    assert r.status == "failed"
-
-
-@pytest.mark.asyncio
-async def test_crossref_reject_low_confidence():
-    r = await _xr({**XR_OK, "confidence": 0.5})
+async def test_crossref_reject(overrides):
+    r = await _xr({**XR_OK, **overrides})
     assert r.status == "failed"
 
 
@@ -101,21 +84,17 @@ async def test_desc_accept():
     assert r.source_domains == ["support.lenovo.com"]
 
 
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"source_urls": ["https://www.ebay.com/itm/123"]}, id="untrusted_domain"),
+        pytest.param({"exact_mpn_found": "01HW918"}, id="mpn_mismatch"),
+        pytest.param({"description": "RAM"}, id="short_description"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_desc_reject_untrusted_domain():
-    r = await _desc({**DESC_OK, "source_urls": ["https://www.ebay.com/itm/123"]})
-    assert r.status == "failed"
-
-
-@pytest.mark.asyncio
-async def test_desc_reject_mpn_mismatch():
-    r = await _desc({**DESC_OK, "exact_mpn_found": "01HW918"})
-    assert r.status == "failed"
-
-
-@pytest.mark.asyncio
-async def test_desc_reject_short_description():
-    r = await _desc({**DESC_OK, "description": "RAM"})
+async def test_desc_reject(overrides):
+    r = await _desc({**DESC_OK, **overrides})
     assert r.status == "failed"
 
 

--- a/tests/test_offers_overhaul.py
+++ b/tests/test_offers_overhaul.py
@@ -19,6 +19,32 @@ from app.models import (
     VendorResponse,
 )
 
+
+def _find_offer_in_groups(data, offer_id):
+    """Locate an offer by id within the grouped /offers response."""
+    for group in data["groups"]:
+        for offer in group.get("offers", []):
+            if offer["id"] == offer_id:
+                return offer
+    return None
+
+
+def _make_vendor_response(db, requisition_id, user_id, *, vendor_name, vendor_email, subject, body):
+    """Create and flush a VendorResponse for auto-parse tests."""
+    vr = VendorResponse(
+        requisition_id=requisition_id,
+        vendor_name=vendor_name,
+        vendor_email=vendor_email,
+        subject=subject,
+        body=body,
+        scanned_by_user_id=user_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(vr)
+    db.flush()
+    return vr
+
+
 # ── Changelog / Audit Trail ──────────────────────────────────────────
 
 
@@ -167,24 +193,16 @@ class TestOfferApproval:
         assert pending_offer.status == "rejected"
         assert "Too expensive" in (pending_offer.notes or "")
 
-    def test_approve_non_pending_fails(self, client, test_offer):
-        """Cannot approve an already active offer."""
-        resp = client.put(f"/api/offers/{test_offer.id}/approve")
+    @pytest.mark.parametrize("action", ["approve", "reject"])
+    def test_non_pending_fails(self, client, test_offer, action):
+        """Cannot approve or reject an already active offer."""
+        resp = client.put(f"/api/offers/{test_offer.id}/{action}")
         assert resp.status_code == 400
 
-    def test_reject_non_pending_fails(self, client, test_offer):
-        """Cannot reject an already active offer."""
-        resp = client.put(f"/api/offers/{test_offer.id}/reject")
-        assert resp.status_code == 400
-
-    def test_approve_not_found(self, client):
+    @pytest.mark.parametrize("action", ["approve", "reject"])
+    def test_not_found(self, client, action):
         """404 for nonexistent offer."""
-        resp = client.put("/api/offers/99999/approve")
-        assert resp.status_code == 404
-
-    def test_reject_not_found(self, client):
-        """404 for nonexistent offer."""
-        resp = client.put("/api/offers/99999/reject")
+        resp = client.put(f"/api/offers/99999/{action}")
         assert resp.status_code == 404
 
 
@@ -238,15 +256,7 @@ class TestQuotedOfferBadge:
 
         resp = client.get(f"/api/requisitions/{test_requisition.id}/offers")
         assert resp.status_code == 200
-        data = resp.json()
-        groups = data["groups"]
-        # Find the offer in the groups
-        found = None
-        for g in groups:
-            for o in g.get("offers", []):
-                if o["id"] == offer.id:
-                    found = o
-                    break
+        found = _find_offer_in_groups(resp.json(), offer.id)
         assert found is not None
         assert found["quoted_on"] == "Q-2026-0099"
 
@@ -269,14 +279,7 @@ class TestQuotedOfferBadge:
 
         resp = client.get(f"/api/requisitions/{test_requisition.id}/offers")
         assert resp.status_code == 200
-        data = resp.json()
-        groups = data["groups"]
-        found = None
-        for g in groups:
-            for o in g.get("offers", []):
-                if o["id"] == offer.id:
-                    found = o
-                    break
+        found = _find_offer_in_groups(resp.json(), offer.id)
         assert found is not None
         assert found.get("quoted_on") is None
 
@@ -287,68 +290,71 @@ class TestQuotedOfferBadge:
 class TestBuyPlanQuoteLineItems:
     """V1 buy plan submission is deprecated and always returns 404."""
 
-    def test_buy_plan_submit_returns_404(self, client, test_requisition, test_offer, db_session, test_user):
-        """V1 submit_buy_plan always returns 404."""
-        from app.models import Company, CustomerSite
-
-        co = Company(name="BP Test Co", is_active=True, created_at=datetime.now(timezone.utc))
-        db_session.add(co)
-        db_session.flush()
-        site = CustomerSite(company_id=co.id, site_name="HQ", contact_name="X", contact_email="x@bp.com")
-        db_session.add(site)
-        db_session.flush()
-
-        q = Quote(
-            requisition_id=test_requisition.id,
-            customer_site_id=site.id,
-            quote_number="Q-2026-0100",
-            status="sent",
-            line_items=[
-                {
-                    "offer_id": test_offer.id,
-                    "mpn": "LM317T",
-                    "vendor_name": "Arrow Electronics",
-                    "qty": 1000,
-                    "cost_price": 0.50,
-                    "lead_time": "2-3 weeks (includes transit)",
-                    "condition": "New Surplus",
-                }
-            ],
-            subtotal=1000.00,
-            total_cost=500.00,
-            total_margin_pct=50.00,
-            created_by_id=test_user.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(q)
-        db_session.commit()
-
-        resp = client.post(
-            f"/api/quotes/{q.id}/buy-plan",
-            json={
-                "offer_ids": [test_offer.id],
-                "salesperson_notes": "Rush order",
-            },
-        )
-        assert resp.status_code == 404
-
-    def test_buy_plan_fallback_returns_404(self, client, test_requisition, test_offer, db_session, test_user):
+    @pytest.mark.parametrize(
+        ("company_name", "contact_email", "quote_number", "line_items", "salesperson_notes"),
+        [
+            pytest.param(
+                "BP Test Co",
+                "x@bp.com",
+                "Q-2026-0100",
+                [
+                    {
+                        "offer_id": "TEST_OFFER_ID",
+                        "mpn": "LM317T",
+                        "vendor_name": "Arrow Electronics",
+                        "qty": 1000,
+                        "cost_price": 0.50,
+                        "lead_time": "2-3 weeks (includes transit)",
+                        "condition": "New Surplus",
+                    }
+                ],
+                "Rush order",
+                id="with_line_items",
+            ),
+            pytest.param(
+                "BP Fallback Co",
+                "x@fb.com",
+                "Q-2026-0101",
+                [],
+                "",
+                id="empty_line_items",
+            ),
+        ],
+    )
+    def test_buy_plan_returns_404(
+        self,
+        client,
+        test_requisition,
+        test_offer,
+        db_session,
+        test_user,
+        company_name,
+        contact_email,
+        quote_number,
+        line_items,
+        salesperson_notes,
+    ):
         """V1 submit_buy_plan always returns 404 regardless of quote line_items."""
         from app.models import Company, CustomerSite
 
-        co = Company(name="BP Fallback Co", is_active=True, created_at=datetime.now(timezone.utc))
+        co = Company(name=company_name, is_active=True, created_at=datetime.now(timezone.utc))
         db_session.add(co)
         db_session.flush()
-        site = CustomerSite(company_id=co.id, site_name="HQ", contact_name="X", contact_email="x@fb.com")
+        site = CustomerSite(company_id=co.id, site_name="HQ", contact_name="X", contact_email=contact_email)
         db_session.add(site)
         db_session.flush()
+
+        # Resolve the offer-id placeholder now that the fixture offer exists.
+        line_items = [
+            {**li, "offer_id": test_offer.id} if li.get("offer_id") == "TEST_OFFER_ID" else li for li in line_items
+        ]
 
         q = Quote(
             requisition_id=test_requisition.id,
             customer_site_id=site.id,
-            quote_number="Q-2026-0101",
+            quote_number=quote_number,
             status="sent",
-            line_items=[],
+            line_items=line_items,
             subtotal=1000.00,
             total_cost=500.00,
             total_margin_pct=50.00,
@@ -360,7 +366,7 @@ class TestBuyPlanQuoteLineItems:
 
         resp = client.post(
             f"/api/quotes/{q.id}/buy-plan",
-            json={"offer_ids": [test_offer.id], "salesperson_notes": ""},
+            json={"offer_ids": [test_offer.id], "salesperson_notes": salesperson_notes},
         )
         assert resp.status_code == 404
 
@@ -375,17 +381,15 @@ class TestAutoParseOffers:
         """_apply_parsed_result creates Offer records from parsed email."""
         req_item = test_requisition.requirements[0]
 
-        vr = VendorResponse(
-            requisition_id=test_requisition.id,
+        vr = _make_vendor_response(
+            db_session,
+            test_requisition.id,
+            test_user.id,
             vendor_name="Vendor XYZ",
             vendor_email="sales@xyz.com",
             subject="RE: RFQ LM317T",
             body="We can offer LM317T at $0.55",
-            scanned_by_user_id=test_user.id,
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(vr)
-        db_session.flush()
 
         parsed = {
             "confidence": 0.85,
@@ -420,17 +424,15 @@ class TestAutoParseOffers:
 
     def test_dedup_prevents_duplicate_offers(self, db_session, test_requisition, test_user):
         """Re-parsing same email doesn't create duplicate offers."""
-        vr = VendorResponse(
-            requisition_id=test_requisition.id,
+        vr = _make_vendor_response(
+            db_session,
+            test_requisition.id,
+            test_user.id,
             vendor_name="Vendor ABC",
             vendor_email="sales@abc.com",
             subject="RE: RFQ",
             body="Offer: LM317T $0.50",
-            scanned_by_user_id=test_user.id,
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(vr)
-        db_session.flush()
 
         parsed = {
             "confidence": 0.9,
@@ -454,17 +456,15 @@ class TestAutoParseOffers:
 
     def test_low_confidence_skips_offer_creation(self, db_session, test_requisition, test_user):
         """Confidence < 0.5 doesn't create offers."""
-        vr = VendorResponse(
-            requisition_id=test_requisition.id,
+        vr = _make_vendor_response(
+            db_session,
+            test_requisition.id,
+            test_user.id,
             vendor_name="Low Conf",
             vendor_email="sales@low.com",
             subject="RE: RFQ",
             body="Maybe?",
-            scanned_by_user_id=test_user.id,
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(vr)
-        db_session.flush()
 
         parsed = {
             "confidence": 0.3,
@@ -483,17 +483,15 @@ class TestAutoParseOffers:
 
     def test_creates_notification_for_pending_offer(self, db_session, test_requisition, test_user):
         """Auto-parse creates an offer_pending_review ActivityLog entry."""
-        vr = VendorResponse(
-            requisition_id=test_requisition.id,
+        vr = _make_vendor_response(
+            db_session,
+            test_requisition.id,
+            test_user.id,
             vendor_name="Notif Vendor",
             vendor_email="sales@notif.com",
             subject="RE: RFQ",
             body="Offer for LM317T",
-            scanned_by_user_id=test_user.id,
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(vr)
-        db_session.flush()
 
         parsed = {
             "confidence": 0.8,
@@ -545,13 +543,7 @@ class TestOffersListFields:
 
         resp = client.get(f"/api/requisitions/{test_requisition.id}/offers")
         assert resp.status_code == 200
-        data = resp.json()
-        found = None
-        for g in data["groups"]:
-            for o in g.get("offers", []):
-                if o["id"] == offer.id:
-                    found = o
-                    break
+        found = _find_offer_in_groups(resp.json(), offer.id)
         assert found is not None
         assert "updated_at" in found
         assert "updated_by" in found

--- a/tests/test_phase7_email_integration.py
+++ b/tests/test_phase7_email_integration.py
@@ -82,30 +82,20 @@ def vendor_with_emails(db_session: Session, test_user: User) -> VendorCard:
 class TestVendorEmailsTab:
     """Tests for the vendor emails tab."""
 
-    def test_emails_tab_loads(self, client: TestClient, vendor_with_emails: VendorCard):
+    @pytest.mark.parametrize(
+        "expected",
+        [
+            pytest.param(["Outbound RFQs", "Vendor Responses"], id="loads"),
+            pytest.param(["RFQ - LM317T", "sales@emailtest.com"], id="shows_contacts"),
+            pytest.param(["Re: RFQ - LM317T", "Quote", "90%"], id="shows_responses"),
+            pytest.param(["RFQs Sent", "Response Rate"], id="shows_stats"),
+        ],
+    )
+    def test_emails_tab_renders(self, client: TestClient, vendor_with_emails: VendorCard, expected: list[str]):
         resp = client.get(f"/v2/partials/vendors/{vendor_with_emails.id}/tab/emails")
         assert resp.status_code == 200
-        assert "Outbound RFQs" in resp.text
-        assert "Vendor Responses" in resp.text
-
-    def test_emails_tab_shows_contacts(self, client: TestClient, vendor_with_emails: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{vendor_with_emails.id}/tab/emails")
-        assert resp.status_code == 200
-        assert "RFQ - LM317T" in resp.text
-        assert "sales@emailtest.com" in resp.text
-
-    def test_emails_tab_shows_responses(self, client: TestClient, vendor_with_emails: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{vendor_with_emails.id}/tab/emails")
-        assert resp.status_code == 200
-        assert "Re: RFQ - LM317T" in resp.text
-        assert "Quote" in resp.text
-        assert "90%" in resp.text
-
-    def test_emails_tab_shows_stats(self, client: TestClient, vendor_with_emails: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{vendor_with_emails.id}/tab/emails")
-        assert resp.status_code == 200
-        assert "RFQs Sent" in resp.text
-        assert "Response Rate" in resp.text
+        for fragment in expected:
+            assert fragment in resp.text
 
     def test_emails_tab_empty_state(self, client: TestClient, db_session: Session):
         """Vendor with no email history shows empty state."""

--- a/tests/test_phone_utils.py
+++ b/tests/test_phone_utils.py
@@ -5,112 +5,114 @@ letters, empty strings, too-short numbers, 7-9 digit ambiguous,
 12+ digit international, _guess_country_code_len branches.
 """
 
+import pytest
+
 from app.utils.phone_utils import _guess_country_code_len, format_phone_display, format_phone_e164
 
 
 class TestFormatPhoneE164:
-    def test_us_10_digit(self):
-        assert format_phone_e164("4155551234") == "+14155551234"
-
-    def test_us_already_e164(self):
-        assert format_phone_e164("+14155551234") == "+14155551234"
-
-    def test_us_formatted(self):
-        assert format_phone_e164("(415) 555-1234") == "+14155551234"
-
-    def test_us_11_digit(self):
-        assert format_phone_e164("14155551234") == "+14155551234"
-
-    def test_international_hk(self):
-        assert format_phone_e164("+852 9876 5432") == "+85298765432"
-
-    def test_international_uk(self):
-        assert format_phone_e164("+44 20 7946 0958") == "+442079460958"
-
-    def test_too_short(self):
-        assert format_phone_e164("12345") is None
-
-    def test_letters(self):
-        assert format_phone_e164("call john") is None
-
-    def test_empty(self):
-        assert format_phone_e164("") is None
-
-    def test_none(self):
-        assert format_phone_e164(None) is None
-
-    def test_with_extension(self):
-        assert format_phone_e164("(415) 555-1234 ext 100") == "+14155551234"
-
-    def test_with_x_extension(self):
-        assert format_phone_e164("4155551234 x200") == "+14155551234"
-
-    def test_dashes_and_dots(self):
-        assert format_phone_e164("415.555.1234") == "+14155551234"
-
-    def test_spaces(self):
-        assert format_phone_e164("415 555 1234") == "+14155551234"
-
-    def test_mixed_formatting(self):
-        assert format_phone_e164("  +1 (415) 555-1234  ") == "+14155551234"
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("4155551234", "+14155551234"),
+            ("+14155551234", "+14155551234"),
+            ("(415) 555-1234", "+14155551234"),
+            ("14155551234", "+14155551234"),
+            ("+852 9876 5432", "+85298765432"),
+            ("+44 20 7946 0958", "+442079460958"),
+            ("12345", None),
+            ("call john", None),
+            ("", None),
+            (None, None),
+            ("(415) 555-1234 ext 100", "+14155551234"),
+            ("4155551234 x200", "+14155551234"),
+            ("415.555.1234", "+14155551234"),
+            ("415 555 1234", "+14155551234"),
+            ("  +1 (415) 555-1234  ", "+14155551234"),
+        ],
+        ids=[
+            "us_10_digit",
+            "us_already_e164",
+            "us_formatted",
+            "us_11_digit",
+            "international_hk",
+            "international_uk",
+            "too_short",
+            "letters",
+            "empty",
+            "none",
+            "with_extension",
+            "with_x_extension",
+            "dashes_and_dots",
+            "spaces",
+            "mixed_formatting",
+        ],
+    )
+    def test_format_phone_e164(self, raw, expected):
+        assert format_phone_e164(raw) == expected
 
 
 class TestFormatPhoneDisplay:
-    def test_us_raw(self):
-        assert format_phone_display("4155551234") == "(415) 555-1234"
-
-    def test_us_e164(self):
-        assert format_phone_display("+14155551234") == "(415) 555-1234"
-
-    def test_us_formatted_input(self):
-        assert format_phone_display("(415) 555-1234") == "(415) 555-1234"
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("4155551234", "(415) 555-1234"),
+            ("+14155551234", "(415) 555-1234"),
+            ("(415) 555-1234", "(415) 555-1234"),
+            ("12345", "12345"),
+            ("call john", "call john"),
+            ("", ""),
+            (None, ""),
+        ],
+        ids=[
+            "us_raw",
+            "us_e164",
+            "us_formatted_input",
+            "unparseable_returns_raw",
+            "letters_returns_raw",
+            "empty",
+            "none",
+        ],
+    )
+    def test_format_phone_display(self, raw, expected):
+        assert format_phone_display(raw) == expected
 
     def test_international_hk(self):
         result = format_phone_display("+852 9876 5432")
         assert result.startswith("+852")
         assert "9876" in result
 
-    def test_unparseable_returns_raw(self):
-        assert format_phone_display("12345") == "12345"
-
-    def test_letters_returns_raw(self):
-        assert format_phone_display("call john") == "call john"
-
-    def test_empty(self):
-        assert format_phone_display("") == ""
-
-    def test_none(self):
-        assert format_phone_display(None) == ""
-
 
 class TestFormatPhoneE164EdgeCases:
     """Cover lines 51-58: 7-9 digits without + returns None, 12+ digits returns +digits."""
 
-    def test_7_digits_no_plus_returns_none(self):
-        assert format_phone_e164("5551234") is None
-
-    def test_8_digits_no_plus_returns_none(self):
-        assert format_phone_e164("55512345") is None
-
-    def test_9_digits_no_plus_returns_none(self):
-        assert format_phone_e164("555123456") is None
-
-    def test_7_digits_with_plus_returns_e164(self):
-        """7 digits WITH a + prefix should work (international short number)."""
-        result = format_phone_e164("+5551234")
-        assert result == "+5551234"
-
-    def test_12_digits_no_plus_returns_international(self):
-        result = format_phone_e164("861012345678")
-        assert result == "+861012345678"
-
-    def test_13_digits_no_plus_returns_international(self):
-        result = format_phone_e164("8521234567890")
-        assert result == "+8521234567890"
-
-    def test_14_digits_no_plus_returns_international(self):
-        result = format_phone_e164("44207946095800")
-        assert result == "+44207946095800"
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("5551234", None),
+            ("55512345", None),
+            ("555123456", None),
+            # 7 digits WITH a + prefix should work (international short number).
+            ("+5551234", "+5551234"),
+            ("861012345678", "+861012345678"),
+            ("8521234567890", "+8521234567890"),
+            ("44207946095800", "+44207946095800"),
+            # 11 digits not starting with 1 — falls through to line 58 (return None).
+            ("44207946095", None),
+        ],
+        ids=[
+            "7_digits_no_plus_returns_none",
+            "8_digits_no_plus_returns_none",
+            "9_digits_no_plus_returns_none",
+            "7_digits_with_plus_returns_e164",
+            "12_digits_no_plus_returns_international",
+            "13_digits_no_plus_returns_international",
+            "14_digits_no_plus_returns_international",
+            "11_digits_not_starting_with_1_returns_none",
+        ],
+    )
+    def test_format_phone_e164_edge_cases(self, raw, expected):
+        assert format_phone_e164(raw) == expected
 
     def test_more_than_15_digits_returns_none(self):
         """E.164 caps at 15 digits — longer strings are not phone numbers (and would
@@ -118,66 +120,59 @@ class TestFormatPhoneE164EdgeCases:
         assert format_phone_e164("1234567890123456") is None
         assert format_phone_e164("+" + "9" * 30) is None
 
-    def test_11_digits_not_starting_with_1_returns_none(self):
-        """11 digits not starting with 1 — falls through to line 58 (return None)."""
-        result = format_phone_e164("44207946095")
-        assert result is None
-
 
 class TestGuessCountryCodeLen:
     """Cover lines 99, 103, 109: the three branch returns in _guess_country_code_len."""
 
-    def test_1_digit_us_canada(self):
-        assert _guess_country_code_len("14155551234") == 1
-
-    def test_2_digit_uk(self):
-        assert _guess_country_code_len("442079460958") == 2
-
-    def test_2_digit_germany(self):
-        assert _guess_country_code_len("4930123456") == 2
-
-    def test_2_digit_china(self):
-        assert _guess_country_code_len("861012345678") == 2
-
-    def test_2_digit_india(self):
-        assert _guess_country_code_len("919876543210") == 2
-
-    def test_2_digit_singapore(self):
-        assert _guess_country_code_len("6598765432") == 2
-
-    def test_3_digit_hong_kong(self):
-        assert _guess_country_code_len("85298765432") == 3
-
-    def test_3_digit_ireland(self):
-        assert _guess_country_code_len("353861234567") == 3
-
-    def test_3_digit_israel(self):
-        assert _guess_country_code_len("972501234567") == 3
-
-    def test_3_digit_uae(self):
-        assert _guess_country_code_len("971501234567") == 3
-
-    def test_default_2_digit_for_unknown_prefix(self):
-        """Number not matching any known prefix -> default return 2."""
-        assert _guess_country_code_len("7912345678") == 2
-
-    def test_default_2_digit_nigeria(self):
-        assert _guess_country_code_len("2341234567") == 2
+    @pytest.mark.parametrize(
+        ("digits", "expected"),
+        [
+            ("14155551234", 1),
+            ("442079460958", 2),
+            ("4930123456", 2),
+            ("861012345678", 2),
+            ("919876543210", 2),
+            ("6598765432", 2),
+            ("85298765432", 3),
+            ("353861234567", 3),
+            ("972501234567", 3),
+            ("971501234567", 3),
+            # Number not matching any known prefix -> default return 2.
+            ("7912345678", 2),
+            ("2341234567", 2),
+        ],
+        ids=[
+            "1_digit_us_canada",
+            "2_digit_uk",
+            "2_digit_germany",
+            "2_digit_china",
+            "2_digit_india",
+            "2_digit_singapore",
+            "3_digit_hong_kong",
+            "3_digit_ireland",
+            "3_digit_israel",
+            "3_digit_uae",
+            "default_2_digit_for_unknown_prefix",
+            "default_2_digit_nigeria",
+        ],
+    )
+    def test_guess_country_code_len(self, digits, expected):
+        assert _guess_country_code_len(digits) == expected
 
 
 class TestFormatPhoneDisplayInternational:
     """Integration: format_phone_display with various CC lengths."""
 
-    def test_display_hong_kong(self):
-        result = format_phone_display("+85298765432")
-        assert result == "+852 9876 5432"
-
-    def test_display_uk(self):
-        result = format_phone_display("+442079460958")
-        assert result == "+44 2079 4609 58"
-
-    def test_display_unknown_country_code(self):
-        # 12+ digits with + prefix to avoid US 10-digit path
-        result = format_phone_display("+79123456789")
-        # CC default 2 ("79"), rest="123456789" -> "1234 5678 9"
-        assert result == "+79 1234 5678 9"
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("+85298765432", "+852 9876 5432"),
+            ("+442079460958", "+44 2079 4609 58"),
+            # 12+ digits with + prefix to avoid US 10-digit path.
+            # CC default 2 ("79"), rest="123456789" -> "1234 5678 9"
+            ("+79123456789", "+79 1234 5678 9"),
+        ],
+        ids=["hong_kong", "uk", "unknown_country_code"],
+    )
+    def test_format_phone_display_international(self, raw, expected):
+        assert format_phone_display(raw) == expected

--- a/tests/test_pipeline_scoring_fixes.py
+++ b/tests/test_pipeline_scoring_fixes.py
@@ -10,10 +10,6 @@ Called by: pytest
 Depends on: app/routers/dashboard/, app/services/proactive_service.py
 """
 
-# ---- Bug 1: avail_rank recomputed in team-leaderboard ----
-
-
-# ---- Bug 3: Proactive scorecard outlier cap ----
 # Tests for _cap_outlier removed — capping is now done inline via SQL case()
 # expressions in get_scorecard(). Behavior is covered by scorecard integration
 # tests in test_proactive_service.py.

--- a/tests/test_proactive_matching.py
+++ b/tests/test_proactive_matching.py
@@ -109,6 +109,28 @@ def _setup_scenario(db):
     }
 
 
+def _make_offer(db, data, **overrides):
+    """Add the standard Arrow/STM32F407 offer for `data`'s scenario and return it.
+
+    Any field can be overridden via kwargs (e.g. vendor_name, unit_price,
+    material_card_id).
+    """
+    fields = {
+        "requisition_id": data["requisition"].id,
+        "requirement_id": data["requirement"].id,
+        "material_card_id": data["card"].id,
+        "vendor_name": "Arrow",
+        "mpn": "STM32F407",
+        "unit_price": Decimal("8.00"),
+        "status": "active",
+    }
+    fields.update(overrides)
+    offer = Offer(**fields)
+    db.add(offer)
+    db.commit()
+    return offer
+
+
 # ── Scoring tests ────────────────────────────────────────────────────────
 
 
@@ -169,18 +191,7 @@ def test_find_matches_for_offer(db_session):
     data = _setup_scenario(db_session)
 
     # Create an offer for the same part
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow Electronics",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        qty_available=200,
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data, vendor_name="Arrow Electronics", qty_available=200)
 
     matches = find_matches_for_offer(offer.id, db_session)
     db_session.commit()
@@ -205,17 +216,14 @@ def test_find_matches_no_cph(db_session):
     db_session.add(card2)
     db_session.flush()
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
+    offer = _make_offer(
+        db_session,
+        data,
         material_card_id=card2.id,
         vendor_name="Mouser",
         mpn="LM358N",
         unit_price=Decimal("0.50"),
-        status="active",
     )
-    db_session.add(offer)
-    db_session.commit()
 
     matches = find_matches_for_offer(offer.id, db_session)
     assert len(matches) == 0
@@ -227,17 +235,7 @@ def test_find_matches_no_owner(db_session):
     data["company"].account_owner_id = None
     db_session.commit()
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     matches = find_matches_for_offer(offer.id, db_session)
     assert len(matches) == 0
@@ -247,17 +245,7 @@ def test_find_matches_dedup(db_session):
     """Duplicate matches for same card+company are not created."""
     data = _setup_scenario(db_session)
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     # First call creates match
     matches1 = find_matches_for_offer(offer.id, db_session)
@@ -277,18 +265,7 @@ def test_run_proactive_scan(db_session):
     """Batch scan picks up new offers and creates matches."""
     data = _setup_scenario(db_session)
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-        created_at=datetime.now(timezone.utc),
-    )
-    db_session.add(offer)
-    db_session.commit()
+    _make_offer(db_session, data, created_at=datetime.now(timezone.utc))
 
     # Set watermark so it picks up the offer
     from app.models.config import SystemConfig
@@ -313,17 +290,7 @@ def test_dismiss_match(db_session):
     """Dismissing a match sets status and reason."""
     data = _setup_scenario(db_session)
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     matches = find_matches_for_offer(offer.id, db_session)
     db_session.commit()
@@ -340,17 +307,7 @@ def test_mark_match_sent(db_session):
     """Marking a match as sent updates status."""
     data = _setup_scenario(db_session)
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     matches = find_matches_for_offer(offer.id, db_session)
     db_session.commit()
@@ -368,17 +325,7 @@ def test_expire_old_matches(db_session):
     """Old 'new' matches get expired."""
     data = _setup_scenario(db_session)
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     matches = find_matches_for_offer(offer.id, db_session)
     db_session.commit()
@@ -446,17 +393,7 @@ def test_find_matches_offer_no_material_card(db_session):
     """Offer with no material_card_id returns [] early (line 100)."""
     data = _setup_scenario(db_session)
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=None,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data, material_card_id=None)
 
     matches = find_matches_for_offer(offer.id, db_session)
     assert matches == []
@@ -473,17 +410,7 @@ def test_find_matches_no_active_site(db_session):
     data["site"].is_active = False
     db_session.commit()
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     matches = find_matches_for_offer(offer.id, db_session)
     assert len(matches) == 0
@@ -506,17 +433,7 @@ def test_find_matches_do_not_offer_suppression(db_session):
     db_session.add(dno)
     db_session.commit()
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     matches = find_matches_for_offer(offer.id, db_session)
     assert len(matches) == 0
@@ -538,17 +455,7 @@ def test_find_matches_throttled(db_session):
     db_session.add(throttle)
     db_session.commit()
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     matches = find_matches_for_offer(offer.id, db_session)
     assert len(matches) == 0
@@ -565,17 +472,7 @@ def test_find_matches_below_min_margin(db_session):
     data["cph"].avg_unit_price = Decimal("8.10")
     db_session.commit()
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     # margin = (8.10 - 8.00) / 8.10 * 100 = 1.23% < 5% (mock min_margin)
     with patch("app.services.proactive_matching.settings") as mock_settings:
@@ -785,17 +682,7 @@ def test_run_proactive_scan_commit_failure(db_session):
 
     data = _setup_scenario(db_session)
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-        created_at=datetime.now(timezone.utc),
-    )
-    db_session.add(offer)
+    _make_offer(db_session, data, created_at=datetime.now(timezone.utc))
     db_session.add(
         SystemConfig(
             key="proactive_last_scan",
@@ -825,17 +712,7 @@ def test_dismiss_match_wrong_user(db_session):
     """Dismissing someone else's match raises ValueError."""
     data = _setup_scenario(db_session)
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     matches = find_matches_for_offer(offer.id, db_session)
     db_session.commit()
@@ -870,17 +747,7 @@ def test_mark_match_sent_wrong_user(db_session):
     """Marking someone else's match as sent raises ValueError."""
     data = _setup_scenario(db_session)
 
-    offer = Offer(
-        requisition_id=data["requisition"].id,
-        requirement_id=data["requirement"].id,
-        material_card_id=data["card"].id,
-        vendor_name="Arrow",
-        mpn="STM32F407",
-        unit_price=Decimal("8.00"),
-        status="active",
-    )
-    db_session.add(offer)
-    db_session.commit()
+    offer = _make_offer(db_session, data)
 
     matches = find_matches_for_offer(offer.id, db_session)
     db_session.commit()

--- a/tests/test_proactive_service.py
+++ b/tests/test_proactive_service.py
@@ -125,6 +125,39 @@ def _make_site_contact(db: Session, site: CustomerSite) -> SiteContact:
     return sc
 
 
+def _make_match(
+    db: Session,
+    *,
+    offer: Offer,
+    requirement: Requirement,
+    requisition: Requisition,
+    site: CustomerSite,
+    user: User,
+    mpn: str,
+    **kwargs,
+) -> ProactiveMatch:
+    """Create a ProactiveMatch linking an offer to an archived requirement."""
+    match = ProactiveMatch(
+        offer_id=offer.id,
+        requirement_id=requirement.id,
+        requisition_id=requisition.id,
+        customer_site_id=site.id,
+        salesperson_id=user.id,
+        mpn=mpn,
+        **kwargs,
+    )
+    db.add(match)
+    db.flush()
+    return match
+
+
+def _mock_graph_client(*, side_effect=None):
+    """Return a MagicMock GraphClient whose post_json is an AsyncMock."""
+    mock_gc = MagicMock()
+    mock_gc.post_json = AsyncMock(return_value=None, side_effect=side_effect)
+    return mock_gc
+
+
 # ── send_proactive_offer ───────────────────────────────────────────────
 
 
@@ -149,15 +182,15 @@ class TestSendProactiveOffer:
         """Valid matches but empty contact_ids raises ValueError."""
         # Create a match for the test_offer
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="LM317T")
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="LM317T",
         )
-        db_session.add(match)
         db_session.commit()
 
         with pytest.raises(ValueError, match="No valid contacts"):
@@ -176,22 +209,19 @@ class TestSendProactiveOffer:
     async def test_send_success(self, db_session, test_user, test_company, test_customer_site, test_offer):
         """Mocked GraphClient.post_json -> creates ProactiveOffer and returns data."""
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="LM317T")
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="LM317T",
         )
-        db_session.add(match)
         contact = _make_site_contact(db_session, test_customer_site)
         db_session.commit()
 
-        mock_gc = MagicMock()
-        mock_gc.post_json = AsyncMock(return_value=None)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with patch("app.utils.graph_client.GraphClient", return_value=_mock_graph_client()):
             result = await send_proactive_offer(
                 db=db_session,
                 user=test_user,
@@ -243,22 +273,19 @@ class TestSendProactiveOffer:
         db_session.flush()
 
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="TOTAL100")
-        match = ProactiveMatch(
-            offer_id=offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="TOTAL100",
         )
-        db_session.add(match)
         contact = _make_site_contact(db_session, test_customer_site)
         db_session.commit()
 
-        mock_gc = MagicMock()
-        mock_gc.post_json = AsyncMock(return_value=None)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with patch("app.utils.graph_client.GraphClient", return_value=_mock_graph_client()):
             result = await send_proactive_offer(
                 db=db_session,
                 user=test_user,
@@ -279,20 +306,19 @@ class TestSendProactiveOffer:
     ):
         """GraphClient raises exception -> ProactiveOffer is still saved."""
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="LM317T")
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="LM317T",
         )
-        db_session.add(match)
         contact = _make_site_contact(db_session, test_customer_site)
         db_session.commit()
 
-        mock_gc = MagicMock()
-        mock_gc.post_json = AsyncMock(side_effect=Exception("Graph API down"))
+        mock_gc = _mock_graph_client(side_effect=Exception("Graph API down"))
 
         with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
             result = await send_proactive_offer(
@@ -460,17 +486,16 @@ class TestConvertProactiveToWin:
         """ProactiveMatch.status is updated to 'converted' after conversion."""
         # Create a match first
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="LM317T")
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="LM317T",
             status="sent",
         )
-        db_session.add(match)
-        db_session.flush()
 
         po = ProactiveOffer(
             customer_site_id=test_customer_site.id,
@@ -670,16 +695,16 @@ class TestGetMatchesForUser:
         from app.services.proactive_service import get_matches_for_user
 
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="LM317T")
-        m1 = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="LM317T",
             status="new",
         )
-        db_session.add(m1)
         db_session.commit()
 
         result = get_matches_for_user(db_session, test_user.id, status="new")
@@ -695,16 +720,16 @@ class TestGetMatchesForUser:
         from app.services.proactive_service import get_matches_for_user
 
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="LM317T")
-        m = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="LM317T",
             status="sent",
         )
-        db_session.add(m)
         db_session.commit()
 
         result = get_matches_for_user(db_session, test_user.id, status="")
@@ -718,19 +743,19 @@ class TestGetMatchesForUser:
         from app.services.proactive_service import get_matches_for_user
 
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="DETAILS")
-        m = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="DETAILS",
             status="new",
             match_score=75,
             margin_pct=22.5,
             customer_purchase_count=3,
         )
-        db_session.add(m)
         db_session.commit()
 
         result = get_matches_for_user(db_session, test_user.id, status="new")
@@ -759,22 +784,19 @@ class TestSendProactiveOfferGreetings:
     ):
         """Single named contact gets 'Hi {name},' greeting."""
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="LM317T")
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="LM317T",
         )
-        db_session.add(match)
         contact = _make_site_contact(db_session, test_customer_site)
         db_session.commit()
 
-        mock_gc = MagicMock()
-        mock_gc.post_json = AsyncMock(return_value=None)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with patch("app.utils.graph_client.GraphClient", return_value=_mock_graph_client()):
             result = await send_proactive_offer(
                 db=db_session,
                 user=test_user,
@@ -794,15 +816,15 @@ class TestSendProactiveOfferGreetings:
     ):
         """Multiple named contacts get comma-separated names greeting."""
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="LM317T")
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="LM317T",
         )
-        db_session.add(match)
         contact1 = SiteContact(
             customer_site_id=test_customer_site.id,
             full_name="Alice",
@@ -816,10 +838,7 @@ class TestSendProactiveOfferGreetings:
         db_session.add_all([contact1, contact2])
         db_session.commit()
 
-        mock_gc = MagicMock()
-        mock_gc.post_json = AsyncMock(return_value=None)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with patch("app.utils.graph_client.GraphClient", return_value=_mock_graph_client()):
             result = await send_proactive_offer(
                 db=db_session,
                 user=test_user,
@@ -837,15 +856,15 @@ class TestSendProactiveOfferGreetings:
     async def test_greeting_no_name_contact(self, db_session, test_user, test_company, test_customer_site, test_offer):
         """Contact with no full_name gets 'Hello,' greeting."""
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="LM317T")
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="LM317T",
         )
-        db_session.add(match)
         contact = SiteContact(
             customer_site_id=test_customer_site.id,
             full_name="",
@@ -854,10 +873,7 @@ class TestSendProactiveOfferGreetings:
         db_session.add(contact)
         db_session.commit()
 
-        mock_gc = MagicMock()
-        mock_gc.post_json = AsyncMock(return_value=None)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with patch("app.utils.graph_client.GraphClient", return_value=_mock_graph_client()):
             result = await send_proactive_offer(
                 db=db_session,
                 user=test_user,
@@ -981,22 +997,19 @@ class TestQtyCapping:
         archived_req, req_item = _make_archived_requisition(
             db_session, test_user, test_customer_site, mpn="CAP-QTY-TEST", target_qty=50
         )
-        match = ProactiveMatch(
-            offer_id=offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="CAP-QTY-TEST",
         )
-        db_session.add(match)
         contact = _make_site_contact(db_session, test_customer_site)
         db_session.commit()
 
-        mock_gc = MagicMock()
-        mock_gc.post_json = AsyncMock(return_value=None)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with patch("app.utils.graph_client.GraphClient", return_value=_mock_graph_client()):
             result = await send_proactive_offer(
                 db=db_session,
                 user=test_user,
@@ -1042,22 +1055,19 @@ class TestQtyCapping:
         archived_req, req_item = _make_archived_requisition(
             db_session, test_user, test_customer_site, mpn="AVAIL-QTY-TEST", target_qty=500
         )
-        match = ProactiveMatch(
-            offer_id=offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        match = _make_match(
+            db_session,
+            offer=offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="AVAIL-QTY-TEST",
         )
-        db_session.add(match)
         contact = _make_site_contact(db_session, test_customer_site)
         db_session.commit()
 
-        mock_gc = MagicMock()
-        mock_gc.post_json = AsyncMock(return_value=None)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with patch("app.utils.graph_client.GraphClient", return_value=_mock_graph_client()):
             result = await send_proactive_offer(
                 db=db_session,
                 user=test_user,
@@ -1080,16 +1090,16 @@ class TestQtyCapping:
         archived_req, req_item = _make_archived_requisition(
             db_session, test_user, test_customer_site, mpn="TARGET-QTY-TEST", target_qty=250
         )
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="TARGET-QTY-TEST",
             status="new",
         )
-        db_session.add(match)
         db_session.commit()
 
         result = get_matches_for_user(db_session, test_user.id)
@@ -1108,16 +1118,16 @@ class TestGetMatchCount:
         from app.services.proactive_service import get_match_count
 
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="COUNT1")
-        m = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="COUNT1",
             status="new",
         )
-        db_session.add(m)
         db_session.commit()
 
         count = get_match_count(db_session, test_user.id)
@@ -1127,16 +1137,16 @@ class TestGetMatchCount:
         from app.services.proactive_service import get_match_count
 
         archived_req, req_item = _make_archived_requisition(db_session, test_user, test_customer_site, mpn="COUNT2")
-        m = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=req_item.id,
-            requisition_id=archived_req.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
+        _make_match(
+            db_session,
+            offer=test_offer,
+            requirement=req_item,
+            requisition=archived_req,
+            site=test_customer_site,
+            user=test_user,
             mpn="COUNT2",
             status="sent",
         )
-        db_session.add(m)
         db_session.commit()
 
         count = get_match_count(db_session, test_user.id)

--- a/tests/test_prospect_priority_coverage.py
+++ b/tests/test_prospect_priority_coverage.py
@@ -27,6 +27,8 @@ os.environ["TESTING"] = "1"
 
 from types import SimpleNamespace
 
+import pytest
+
 from app.services.prospect_priority import build_priority_snapshot
 
 
@@ -192,27 +194,22 @@ class TestBuildPrioritySnapshotAllBranches:
         # Should not crash
         assert isinstance(snapshot, dict)
 
-    def test_procurement_hiring_signal(self):
-        """Hiring type='procurement' → +4, 'Procurement hiring signal' (lines
-        104-106)."""
+    @pytest.mark.parametrize(
+        ("hiring_type", "expected_reason"),
+        [
+            ("procurement", "Procurement hiring signal"),  # +4, lines 104-106
+            ("engineering", "Engineering growth signal"),  # +2, lines 108-110
+        ],
+        ids=["procurement", "engineering"],
+    )
+    def test_hiring_signal(self, hiring_type, expected_reason):
+        """Hiring type maps to its growth-signal reason."""
         snapshot = build_priority_snapshot(
             _prospect(
-                readiness_signals={"hiring": {"type": "procurement"}},
+                readiness_signals={"hiring": {"type": hiring_type}},
             )
         )
-        reasons = snapshot["priority_reasons"]
-        assert "Procurement hiring signal" in reasons
-
-    def test_engineering_hiring_signal(self):
-        """Hiring type='engineering' → +2, 'Engineering growth signal' (lines
-        108-110)."""
-        snapshot = build_priority_snapshot(
-            _prospect(
-                readiness_signals={"hiring": {"type": "engineering"}},
-            )
-        )
-        reasons = snapshot["priority_reasons"]
-        assert "Engineering growth signal" in reasons
+        assert expected_reason in snapshot["priority_reasons"]
 
     def test_new_procurement_hire_signal(self):
         """new_procurement_hire=True → +3, reason added (lines 113-115)."""
@@ -234,38 +231,24 @@ class TestBuildPrioritySnapshotAllBranches:
         reasons = snapshot["priority_reasons"]
         assert "Marked priority" in reasons
 
-    def test_strong_fit_readiness_baseline(self):
-        """Fit>=75 and readiness>=55 → 'Strong fit/readiness baseline' (line 124)."""
+    @pytest.mark.parametrize(
+        ("fit_score", "readiness_score", "expected_reason"),
+        [
+            (78, 58, "Strong fit/readiness baseline"),  # fit>=75 and readiness>=55, line 124
+            (72, 40, "Strong ICP fit"),  # fit>=70 but readiness<55, line 126
+            (55, 65, "Strong near-term timing"),  # readiness>=60 but fit<70, line 128
+        ],
+        ids=["fit_readiness_baseline", "icp_fit_only", "near_term_timing_only"],
+    )
+    def test_baseline_reasons(self, fit_score, readiness_score, expected_reason):
+        """Fit/readiness combinations each yield their baseline reason."""
         snapshot = build_priority_snapshot(
             _prospect(
-                fit_score=78,
-                readiness_score=58,
+                fit_score=fit_score,
+                readiness_score=readiness_score,
             )
         )
-        reasons = snapshot["priority_reasons"]
-        assert "Strong fit/readiness baseline" in reasons
-
-    def test_strong_icp_fit_only(self):
-        """Fit>=70 but readiness<55 → 'Strong ICP fit' (line 126)."""
-        snapshot = build_priority_snapshot(
-            _prospect(
-                fit_score=72,
-                readiness_score=40,
-            )
-        )
-        reasons = snapshot["priority_reasons"]
-        assert "Strong ICP fit" in reasons
-
-    def test_strong_near_term_timing_only(self):
-        """Readiness>=60 but fit<70 → 'Strong near-term timing' (line 128)."""
-        snapshot = build_priority_snapshot(
-            _prospect(
-                fit_score=55,
-                readiness_score=65,
-            )
-        )
-        reasons = snapshot["priority_reasons"]
-        assert "Strong near-term timing" in reasons
+        assert expected_reason in snapshot["priority_reasons"]
 
     def test_no_reasons_gets_default_message(self):
         """All zeros → 'Needs stronger buyer signals' (line 132)."""

--- a/tests/test_purchase_history.py
+++ b/tests/test_purchase_history.py
@@ -7,15 +7,19 @@ from app.models.purchase_history import CustomerPartHistory
 from app.services.purchase_history_service import upsert_purchase
 
 
-def test_model_creation(db_session):
-    """CustomerPartHistory record can be created with all fields."""
-    co = Company(name="Test Co", is_active=True)
+def _make_company_and_card(db_session, normalized_mpn, display_mpn, company_name="Test Co"):
+    """Create and flush a Company + MaterialCard, returning both."""
+    co = Company(name=company_name, is_active=True)
     db_session.add(co)
-    db_session.flush()
-
-    card = MaterialCard(normalized_mpn="abc123", display_mpn="ABC-123", search_count=0)
+    card = MaterialCard(normalized_mpn=normalized_mpn, display_mpn=display_mpn, search_count=0)
     db_session.add(card)
     db_session.flush()
+    return co, card
+
+
+def test_model_creation(db_session):
+    """CustomerPartHistory record can be created with all fields."""
+    co, card = _make_company_and_card(db_session, "abc123", "ABC-123")
 
     cph = CustomerPartHistory(
         company_id=co.id,
@@ -39,11 +43,7 @@ def test_unique_constraint(db_session):
     """Duplicate (company, material_card, source) raises IntegrityError."""
     from sqlalchemy.exc import IntegrityError
 
-    co = Company(name="Test Co", is_active=True)
-    db_session.add(co)
-    card = MaterialCard(normalized_mpn="xyz789", display_mpn="XYZ-789", search_count=0)
-    db_session.add(card)
-    db_session.flush()
+    co, card = _make_company_and_card(db_session, "xyz789", "XYZ-789")
 
     db_session.add(
         CustomerPartHistory(
@@ -72,11 +72,7 @@ def test_unique_constraint(db_session):
 
 def test_different_sources_allowed(db_session):
     """Same company+card with different sources creates separate records."""
-    co = Company(name="Test Co", is_active=True)
-    db_session.add(co)
-    card = MaterialCard(normalized_mpn="def456", display_mpn="DEF-456", search_count=0)
-    db_session.add(card)
-    db_session.flush()
+    co, card = _make_company_and_card(db_session, "def456", "DEF-456")
 
     db_session.add(
         CustomerPartHistory(
@@ -102,11 +98,7 @@ def test_different_sources_allowed(db_session):
 
 def test_upsert_creates_new(db_session):
     """upsert_purchase creates a new record when none exists."""
-    co = Company(name="Test Co", is_active=True)
-    db_session.add(co)
-    card = MaterialCard(normalized_mpn="new001", display_mpn="NEW-001", search_count=0)
-    db_session.add(card)
-    db_session.flush()
+    co, card = _make_company_and_card(db_session, "new001", "NEW-001")
 
     result = upsert_purchase(
         db_session,
@@ -130,11 +122,7 @@ def test_upsert_creates_new(db_session):
 
 def test_upsert_updates_existing(db_session):
     """upsert_purchase increments count and updates rolling average on second call."""
-    co = Company(name="Test Co", is_active=True)
-    db_session.add(co)
-    card = MaterialCard(normalized_mpn="upd001", display_mpn="UPD-001", search_count=0)
-    db_session.add(card)
-    db_session.flush()
+    co, card = _make_company_and_card(db_session, "upd001", "UPD-001")
 
     # First purchase: $10, qty 100
     upsert_purchase(
@@ -168,11 +156,7 @@ def test_upsert_updates_existing(db_session):
 
 def test_upsert_no_price(db_session):
     """upsert_purchase handles None price gracefully."""
-    co = Company(name="Test Co", is_active=True)
-    db_session.add(co)
-    card = MaterialCard(normalized_mpn="nop001", display_mpn="NOP-001", search_count=0)
-    db_session.add(card)
-    db_session.flush()
+    co, card = _make_company_and_card(db_session, "nop001", "NOP-001")
 
     result = upsert_purchase(
         db_session,
@@ -190,11 +174,7 @@ def test_upsert_no_price(db_session):
 
 def test_upsert_updates_source_ref(db_session):
     """Second upsert overwrites source_ref with latest reference."""
-    co = Company(name="Test Co", is_active=True)
-    db_session.add(co)
-    card = MaterialCard(normalized_mpn="ref001", display_mpn="REF-001", search_count=0)
-    db_session.add(card)
-    db_session.flush()
+    co, card = _make_company_and_card(db_session, "ref001", "REF-001")
 
     upsert_purchase(
         db_session,
@@ -219,11 +199,7 @@ def test_upsert_updates_source_ref(db_session):
 
 def test_cascade_delete_company(db_session):
     """Deleting a company cascades to its purchase history."""
-    co = Company(name="Cascade Co", is_active=True)
-    db_session.add(co)
-    card = MaterialCard(normalized_mpn="cas001", display_mpn="CAS-001", search_count=0)
-    db_session.add(card)
-    db_session.flush()
+    co, card = _make_company_and_card(db_session, "cas001", "CAS-001", company_name="Cascade Co")
 
     db_session.add(
         CustomerPartHistory(
@@ -244,11 +220,7 @@ def test_cascade_delete_company(db_session):
 
 def test_cascade_delete_material_card(db_session):
     """Deleting a material card cascades to its purchase history."""
-    co = Company(name="Cascade Co", is_active=True)
-    db_session.add(co)
-    card = MaterialCard(normalized_mpn="cas002", display_mpn="CAS-002", search_count=0)
-    db_session.add(card)
-    db_session.flush()
+    co, card = _make_company_and_card(db_session, "cas002", "CAS-002", company_name="Cascade Co")
 
     db_session.add(
         CustomerPartHistory(

--- a/tests/test_quote_builder_router.py
+++ b/tests/test_quote_builder_router.py
@@ -4,20 +4,35 @@ Called by: pytest
 Depends on: conftest fixtures (client, test_requisition, test_user, test_customer_site, test_quote)
 """
 
+from contextlib import ExitStack, contextmanager
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.models import Quote, Requisition
 
 
+@contextmanager
+def _patched_builder(requisition, builder_data=None):
+    """Patch the three collaborators used by the data-fetch endpoints.
+
+    Yields the get_builder_data mock so callers can assert on it.
+    """
+    with ExitStack() as stack:
+        stack.enter_context(patch("app.dependencies.get_req_for_user", return_value=requisition))
+        mock_data = stack.enter_context(
+            patch("app.services.quote_builder_service.get_builder_data", return_value=builder_data or [])
+        )
+        stack.enter_context(patch("app.services.quote_builder_service.apply_smart_defaults"))
+        yield mock_data
+
+
 class TestQuoteBuilderData:
     def test_get_data_valid_req(self, client: TestClient, test_requisition: Requisition):
-        with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
-            with patch("app.services.quote_builder_service.get_builder_data", return_value=[]):
-                with patch("app.services.quote_builder_service.apply_smart_defaults"):
-                    resp = client.get(f"/v2/partials/quote-builder/{test_requisition.id}/data")
+        with _patched_builder(test_requisition):
+            resp = client.get(f"/v2/partials/quote-builder/{test_requisition.id}/data")
         assert resp.status_code == 200
         assert "lines" in resp.json()
 
@@ -27,37 +42,32 @@ class TestQuoteBuilderData:
         assert resp.status_code == 404
 
     def test_get_data_with_requirement_ids(self, client: TestClient, test_requisition: Requisition):
-        with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
-            with patch("app.services.quote_builder_service.get_builder_data", return_value=[]) as mock_data:
-                with patch("app.services.quote_builder_service.apply_smart_defaults"):
-                    resp = client.get(
-                        f"/v2/partials/quote-builder/{test_requisition.id}/data",
-                        params={"requirement_ids": "1,2,3"},
-                    )
+        with _patched_builder(test_requisition) as mock_data:
+            resp = client.get(
+                f"/v2/partials/quote-builder/{test_requisition.id}/data",
+                params={"requirement_ids": "1,2,3"},
+            )
         assert resp.status_code == 200
         mock_data.assert_called_once()
-        call_kwargs = mock_data.call_args
-        assert call_kwargs[1]["requirement_ids"] == [1, 2, 3]
+        assert mock_data.call_args[1]["requirement_ids"] == [1, 2, 3]
 
 
 class TestQuoteBuilderMultiData:
     def test_multi_data_valid(self, client: TestClient, test_requisition: Requisition):
-        with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
-            with patch("app.services.quote_builder_service.get_builder_data", return_value=[]):
-                with patch("app.services.quote_builder_service.apply_smart_defaults"):
-                    resp = client.get(
-                        "/v2/partials/quote-builder/multi/data",
-                        params={"requisition_ids": str(test_requisition.id)},
-                    )
+        with _patched_builder(test_requisition):
+            resp = client.get(
+                "/v2/partials/quote-builder/multi/data",
+                params={"requisition_ids": str(test_requisition.id)},
+            )
         assert resp.status_code == 200
         assert "lines" in resp.json()
 
-    def test_multi_data_empty_ids(self, client: TestClient):
-        resp = client.get("/v2/partials/quote-builder/multi/data", params={"requisition_ids": ""})
-        assert resp.status_code == 400
-
-    def test_multi_data_invalid_ids(self, client: TestClient):
-        resp = client.get("/v2/partials/quote-builder/multi/data", params={"requisition_ids": "abc"})
+    @pytest.mark.parametrize(
+        "requisition_ids",
+        [pytest.param("", id="empty_ids"), pytest.param("abc", id="invalid_ids")],
+    )
+    def test_multi_data_bad_ids(self, client: TestClient, requisition_ids):
+        resp = client.get("/v2/partials/quote-builder/multi/data", params={"requisition_ids": requisition_ids})
         assert resp.status_code == 400
 
 

--- a/tests/test_requirements_router_coverage2.py
+++ b/tests/test_requirements_router_coverage2.py
@@ -26,29 +26,11 @@ from app.models import (
     Requisition,
     Sighting,
     SourcingLead,
-    User,
 )
 
 # ── Helpers ───────────────────────────────────────────────────────────────
 
 _VALID_REQ_PAYLOAD = {"primary_mpn": "LM317T", "manufacturer": "ST Micro", "target_qty": 100}
-
-
-def _make_requirement(db: Session, req: Requisition, **kw) -> Requirement:
-    defaults = dict(
-        requisition_id=req.id,
-        primary_mpn="LM317T",
-        normalized_mpn="lm317t",
-        target_qty=100,
-        target_price=0.50,
-        created_at=datetime.now(timezone.utc),
-    )
-    defaults.update(kw)
-    r = Requirement(**defaults)
-    db.add(r)
-    db.commit()
-    db.refresh(r)
-    return r
 
 
 def _make_sighting(db: Session, req_item: Requirement, **kw) -> Sighting:
@@ -84,22 +66,6 @@ def _make_material_card(db: Session, mpn: str = "LM317T") -> MaterialCard:
     db.commit()
     db.refresh(card)
     return card
-
-
-def _make_requisition(db: Session, user: User, **kw) -> Requisition:
-    defaults = dict(
-        name="Test Req",
-        customer_name="Acme",
-        status="active",
-        created_by=user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    defaults.update(kw)
-    req = Requisition(**defaults)
-    db.add(req)
-    db.commit()
-    db.refresh(req)
-    return req
 
 
 def _make_sourcing_lead(db: Session, req: Requisition, req_item: Requirement, **kw) -> SourcingLead:

--- a/tests/test_requisitions_core_coverage.py
+++ b/tests/test_requisitions_core_coverage.py
@@ -18,11 +18,57 @@ import os
 
 os.environ["TESTING"] = "1"
 
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import pytest
+
 from app.constants import RequisitionStatus
 from app.models import Requisition, User
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_req(db_session, created_by, *, name="Req", status=RequisitionStatus.ACTIVE, **kw) -> Requisition:
+    req = Requisition(
+        name=name,
+        customer_name="Test Co",
+        status=status,
+        created_by=created_by,
+        created_at=datetime.now(timezone.utc),
+        **kw,
+    )
+    db_session.add(req)
+    return req
+
+
+@contextmanager
+def _client_as(db_session, user):
+    """Yield a TestClient whose auth/role dependencies all resolve to ``user``."""
+    from fastapi.testclient import TestClient
+
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_user
+    from app.main import app
+
+    def override_db():
+        yield db_session
+
+    def override_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[require_user] = override_user
+    app.dependency_overrides[require_admin] = override_user
+    app.dependency_overrides[require_buyer] = override_user
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        for dep in [get_db, require_user, require_admin, require_buyer]:
+            app.dependency_overrides.pop(dep, None)
+
 
 # ── Requisition Counts ───────────────────────────────────────────────
 
@@ -39,10 +85,6 @@ class TestRequisitionCounts:
 
     def test_counts_as_sales_user(self, db_session):
         """Sales user only counts own requisitions."""
-        from app.database import get_db
-        from app.dependencies import require_admin, require_buyer, require_user
-        from app.main import app
-
         sales = User(
             email="salescounts@test.com",
             name="Sales Counts",
@@ -53,39 +95,13 @@ class TestRequisitionCounts:
         db_session.add(sales)
         db_session.commit()
 
-        # Create req by sales user
-        req = Requisition(
-            name="Sales Req",
-            customer_name="Test Co",
-            status="active",
-            created_by=sales.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
+        _make_req(db_session, sales.id, name="Sales Req", status="active")
         db_session.commit()
 
-        def override_db():
-            yield db_session
-
-        def override_sales():
-            return sales
-
-        app.dependency_overrides[get_db] = override_db
-        app.dependency_overrides[require_user] = override_sales
-        app.dependency_overrides[require_admin] = override_sales
-        app.dependency_overrides[require_buyer] = override_sales
-
-        from fastapi.testclient import TestClient
-
-        try:
-            with TestClient(app) as c:
-                resp = c.get("/api/requisitions/counts")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert data["total"] >= 1
-        finally:
-            for dep in [get_db, require_user, require_admin, require_buyer]:
-                app.dependency_overrides.pop(dep, None)
+        with _client_as(db_session, sales) as c:
+            resp = c.get("/api/requisitions/counts")
+        assert resp.status_code == 200
+        assert resp.json()["total"] >= 1
 
 
 # ── List Requisitions ────────────────────────────────────────────────
@@ -99,49 +115,28 @@ class TestListRequisitions:
         data = resp.json()
         assert "requisitions" in data or "items" in data
 
-    def test_list_with_search_query(self, client, test_requisition):
-        """GET /api/requisitions?q=test searches by name."""
-        resp = client.get("/api/requisitions?q=REQ-TEST")
+    @pytest.mark.parametrize(
+        "query",
+        [
+            pytest.param("?q=REQ-TEST", id="search_query"),
+            pytest.param("?status=active", id="single_status"),
+            pytest.param("?status=active,draft", id="multiple_statuses"),
+            pytest.param("?sort=name&order=asc", id="sort_asc"),
+            pytest.param("?sort=invalid_col", id="sort_invalid_defaults_to_created_at"),
+            pytest.param("?limit=10&offset=0", id="limit_offset"),
+        ],
+    )
+    def test_list_with_query_params(self, client, test_requisition, query):
+        """Filtering/sorting/pagination query params all return 200."""
+        resp = client.get(f"/api/requisitions{query}")
         assert resp.status_code == 200
 
     def test_list_with_archive_status(self, client, db_session, test_user):
         """GET /api/requisitions?status=archive returns archived reqs."""
-        archived = Requisition(
-            name="Archived Req",
-            customer_name="Test Co",
-            status=RequisitionStatus.ARCHIVED,
-            created_by=test_user.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(archived)
+        _make_req(db_session, test_user.id, name="Archived Req", status=RequisitionStatus.ARCHIVED)
         db_session.commit()
 
         resp = client.get("/api/requisitions?status=archive")
-        assert resp.status_code == 200
-
-    def test_list_with_single_status(self, client, test_requisition):
-        """GET /api/requisitions?status=active filters to single status."""
-        resp = client.get("/api/requisitions?status=active")
-        assert resp.status_code == 200
-
-    def test_list_with_multiple_statuses(self, client, test_requisition):
-        """GET /api/requisitions?status=active,draft filters to multiple statuses."""
-        resp = client.get("/api/requisitions?status=active,draft")
-        assert resp.status_code == 200
-
-    def test_list_sort_asc(self, client, test_requisition):
-        """GET /api/requisitions with sort=name&order=asc works."""
-        resp = client.get("/api/requisitions?sort=name&order=asc")
-        assert resp.status_code == 200
-
-    def test_list_sort_invalid_defaults_to_created_at(self, client, test_requisition):
-        """Invalid sort column falls back to created_at."""
-        resp = client.get("/api/requisitions?sort=invalid_col")
-        assert resp.status_code == 200
-
-    def test_list_with_limit_offset(self, client, test_requisition):
-        """GET /api/requisitions with limit/offset returns paginated results."""
-        resp = client.get("/api/requisitions?limit=10&offset=0")
         assert resp.status_code == 200
 
 
@@ -237,20 +232,18 @@ class TestUpdateRequisition:
         )
         assert resp.status_code == 400
 
-    def test_update_valid_urgency(self, client, test_requisition):
-        """Update with valid urgency works."""
-        resp = client.put(
-            f"/api/requisitions/{test_requisition.id}",
-            json={"urgency": "hot"},
-        )
-        assert resp.status_code == 200
-
-    def test_update_opportunity_value(self, client, test_requisition):
-        """Update opportunity_value field works."""
-        resp = client.put(
-            f"/api/requisitions/{test_requisition.id}",
-            json={"opportunity_value": 5000.00},
-        )
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param({"urgency": "hot"}, id="valid_urgency"),
+            pytest.param({"opportunity_value": 5000.00}, id="opportunity_value"),
+            pytest.param({"deadline": "2026-12-31"}, id="deadline"),
+            pytest.param({"deadline": ""}, id="empty_deadline_sets_null"),
+        ],
+    )
+    def test_update_field_succeeds(self, client, test_requisition, body):
+        """Valid single-field updates return 200."""
+        resp = client.put(f"/api/requisitions/{test_requisition.id}", json=body)
         assert resp.status_code == 200
 
     def test_update_customer_site_id(self, client, test_requisition, test_customer_site):
@@ -258,22 +251,6 @@ class TestUpdateRequisition:
         resp = client.put(
             f"/api/requisitions/{test_requisition.id}",
             json={"customer_site_id": test_customer_site.id},
-        )
-        assert resp.status_code == 200
-
-    def test_update_deadline(self, client, test_requisition):
-        """Update deadline works."""
-        resp = client.put(
-            f"/api/requisitions/{test_requisition.id}",
-            json={"deadline": "2026-12-31"},
-        )
-        assert resp.status_code == 200
-
-    def test_update_empty_deadline_sets_null(self, client, test_requisition):
-        """Update with empty deadline sets it to None."""
-        resp = client.put(
-            f"/api/requisitions/{test_requisition.id}",
-            json={"deadline": ""},
         )
         assert resp.status_code == 200
 
@@ -295,14 +272,7 @@ class TestToggleArchive:
 
     def test_unarchive_archived_req(self, client, db_session, test_user):
         """Unarchiving an archived req sets status back to active."""
-        req = Requisition(
-            name="Archived to Restore",
-            customer_name="Test Co",
-            status=RequisitionStatus.ARCHIVED,
-            created_by=test_user.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
+        req = _make_req(db_session, test_user.id, name="Archived to Restore", status=RequisitionStatus.ARCHIVED)
         db_session.commit()
 
         resp = client.put(f"/api/requisitions/{req.id}/archive")
@@ -326,14 +296,7 @@ class TestBulkArchive:
         db_session.add(other_user)
         db_session.flush()
 
-        req = Requisition(
-            name="Other Bulk Req",
-            customer_name="Test Co",
-            status=RequisitionStatus.ACTIVE,
-            created_by=other_user.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
+        _make_req(db_session, other_user.id, name="Other Bulk Req")
         db_session.commit()
 
         resp = client.put("/api/requisitions/bulk-archive")
@@ -354,17 +317,7 @@ class TestBulkArchive:
         db_session.add(other)
         db_session.flush()
 
-        reqs = []
-        for i in range(3):
-            r = Requisition(
-                name=f"Bulk IDs Req {i}",
-                customer_name="Test Co",
-                status=RequisitionStatus.ACTIVE,
-                created_by=other.id,
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(r)
-            reqs.append(r)
+        reqs = [_make_req(db_session, other.id, name=f"Bulk IDs Req {i}") for i in range(3)]
         db_session.commit()
 
         resp = client.put("/api/requisitions/bulk-archive")
@@ -392,14 +345,7 @@ class TestBatchArchive:
 
     def test_batch_archive_already_archived_ids(self, client, db_session, test_user):
         """Batch archive of already-archived req returns 0 archived."""
-        req = Requisition(
-            name="Already Archived",
-            customer_name="Test Co",
-            status=RequisitionStatus.ARCHIVED,
-            created_by=test_user.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
+        req = _make_req(db_session, test_user.id, name="Already Archived", status=RequisitionStatus.ARCHIVED)
         db_session.commit()
         resp = client.put(
             "/api/requisitions/batch-archive",
@@ -410,10 +356,6 @@ class TestBatchArchive:
 
     def test_batch_archive_sales_role_own_reqs(self, db_session):
         """Sales user can only batch-archive own reqs."""
-        from app.database import get_db
-        from app.dependencies import require_admin, require_buyer, require_user
-        from app.main import app
-
         sales = User(
             email="salesbatch@test.com",
             name="Sales Batch",
@@ -424,51 +366,17 @@ class TestBatchArchive:
         db_session.add(sales)
         db_session.flush()
 
-        req = Requisition(
-            name="Sales Batch Req",
-            customer_name="Test Co",
-            status=RequisitionStatus.ACTIVE,
-            created_by=sales.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
+        req = _make_req(db_session, sales.id, name="Sales Batch Req")
         db_session.commit()
 
-        def override_db():
-            yield db_session
-
-        def override_sales():
-            return sales
-
-        app.dependency_overrides[get_db] = override_db
-        app.dependency_overrides[require_user] = override_sales
-        app.dependency_overrides[require_admin] = override_sales
-        app.dependency_overrides[require_buyer] = override_sales
-
-        from fastapi.testclient import TestClient
-
-        try:
-            with TestClient(app) as c:
-                resp = c.put("/api/requisitions/batch-archive", json={"ids": [req.id]})
-            assert resp.status_code == 200
-            assert resp.json()["archived_count"] >= 1
-        finally:
-            for dep in [get_db, require_user, require_admin, require_buyer]:
-                app.dependency_overrides.pop(dep, None)
+        with _client_as(db_session, sales) as c:
+            resp = c.put("/api/requisitions/batch-archive", json={"ids": [req.id]})
+        assert resp.status_code == 200
+        assert resp.json()["archived_count"] >= 1
 
     def test_batch_archive_returns_ids(self, client, db_session, test_user):
         """Batch-archive response includes archived_ids matching the requested IDs."""
-        reqs = []
-        for i in range(3):
-            r = Requisition(
-                name=f"Batch IDs Req {i}",
-                customer_name="Test Co",
-                status=RequisitionStatus.ACTIVE,
-                created_by=test_user.id,
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(r)
-            reqs.append(r)
+        reqs = [_make_req(db_session, test_user.id, name=f"Batch IDs Req {i}") for i in range(3)]
         db_session.commit()
         ids = [r.id for r in reqs]
 
@@ -515,17 +423,7 @@ class TestBatchAssign:
         db_session.add(target)
         db_session.flush()
 
-        reqs = []
-        for i in range(3):
-            r = Requisition(
-                name=f"Assign IDs Req {i}",
-                customer_name="Test Co",
-                status=RequisitionStatus.ACTIVE,
-                created_by=test_user.id,
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(r)
-            reqs.append(r)
+        reqs = [_make_req(db_session, test_user.id, name=f"Assign IDs Req {i}") for i in range(3)]
         db_session.commit()
         ids = [r.id for r in reqs]
 
@@ -562,10 +460,6 @@ class TestDismissNewOffers:
 class TestClaimRequisition:
     def test_claim_wrong_role_returns_403(self, db_session):
         """Non-buyer role cannot claim requisition."""
-        from app.database import get_db
-        from app.dependencies import require_admin, require_buyer, require_user
-        from app.main import app
-
         sales = User(
             email="salesnoclaim@test.com",
             name="Sales No Claim",
@@ -576,36 +470,12 @@ class TestClaimRequisition:
         db_session.add(sales)
         db_session.flush()
 
-        req = Requisition(
-            name="Claim Test Req",
-            customer_name="Test Co",
-            status=RequisitionStatus.ACTIVE,
-            created_by=sales.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
+        req = _make_req(db_session, sales.id, name="Claim Test Req")
         db_session.commit()
 
-        def override_db():
-            yield db_session
-
-        def override_sales():
-            return sales
-
-        app.dependency_overrides[get_db] = override_db
-        app.dependency_overrides[require_user] = override_sales
-        app.dependency_overrides[require_admin] = override_sales
-        app.dependency_overrides[require_buyer] = override_sales
-
-        from fastapi.testclient import TestClient
-
-        try:
-            with TestClient(app) as c:
-                resp = c.post(f"/api/requisitions/{req.id}/claim")
-            assert resp.status_code == 403
-        finally:
-            for dep in [get_db, require_user, require_admin, require_buyer]:
-                app.dependency_overrides.pop(dep, None)
+        with _client_as(db_session, sales) as c:
+            resp = c.post(f"/api/requisitions/{req.id}/claim")
+        assert resp.status_code == 403
 
     def test_claim_req_not_found(self, client):
         """Claim non-existent requisition returns 404."""

--- a/tests/test_routers_attachments.py
+++ b/tests/test_routers_attachments.py
@@ -77,6 +77,25 @@ def _mock_http_response(status_code: int = 204, json_data: dict | None = None):
     return resp
 
 
+def _patch_valid_token(token: str | None):
+    """Patch get_valid_token (at its source module) to return the given token."""
+    return patch(
+        "app.scheduler.get_valid_token",
+        new_callable=AsyncMock,
+        return_value=token,
+    )
+
+
+def _patch_graph_delete(status_code: int):
+    """Patch the shared http client's delete to return a response with the given
+    status."""
+    return patch(
+        "app.http_client.http.delete",
+        new_callable=AsyncMock,
+        return_value=_mock_http_response(status_code),
+    )
+
+
 # ── Delete Requisition Attachment ────────────────────────────────────
 
 
@@ -90,18 +109,9 @@ class TestDeleteRequisitionAttachment:
 
     def test_uses_refreshed_token(self, client, req_att, db_session):
         """Delete endpoint must call get_valid_token and use the refreshed token."""
-        mock_resp = _mock_http_response(204)
         with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="refreshed-token-abc",
-            ) as mock_gvt,
-            patch(
-                "app.http_client.http.delete",
-                new_callable=AsyncMock,
-                return_value=mock_resp,
-            ) as mock_delete,
+            _patch_valid_token("refreshed-token-abc") as mock_gvt,
+            _patch_graph_delete(204) as mock_delete,
         ):
             resp = client.delete(f"/api/requisition-attachments/{req_att.id}")
             assert resp.status_code == 200
@@ -113,69 +123,29 @@ class TestDeleteRequisitionAttachment:
 
     def test_expired_token_returns_401(self, client, req_att):
         """When get_valid_token returns None, endpoint must return 401."""
-        with patch(
-            "app.scheduler.get_valid_token",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
+        with _patch_valid_token(None):
             resp = client.delete(f"/api/requisition-attachments/{req_att.id}")
             assert resp.status_code == 401
             assert "token expired" in resp.json()["error"].lower()
 
-    def test_graph_401_returns_401(self, client, req_att):
-        """When Graph API returns 401, endpoint must surface 401 to caller."""
-        mock_resp = _mock_http_response(401)
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="some-token",
-            ),
-            patch(
-                "app.http_client.http.delete",
-                new_callable=AsyncMock,
-                return_value=mock_resp,
-            ),
-        ):
+    @pytest.mark.parametrize(
+        "graph_status,expected_status,error_substr",
+        [
+            pytest.param(401, 401, "token expired", id="graph_401"),
+            pytest.param(403, 403, "access denied", id="graph_403"),
+        ],
+    )
+    def test_graph_auth_error_surfaced(self, client, req_att, graph_status, expected_status, error_substr):
+        """Graph API 401/403 responses must be surfaced to the caller."""
+        with _patch_valid_token("some-token"), _patch_graph_delete(graph_status):
             resp = client.delete(f"/api/requisition-attachments/{req_att.id}")
-            assert resp.status_code == 401
-            assert "token expired" in resp.json()["error"].lower()
-
-    def test_graph_403_returns_403(self, client, req_att):
-        """When Graph API returns 403, endpoint must surface 403 to caller."""
-        mock_resp = _mock_http_response(403)
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="some-token",
-            ),
-            patch(
-                "app.http_client.http.delete",
-                new_callable=AsyncMock,
-                return_value=mock_resp,
-            ),
-        ):
-            resp = client.delete(f"/api/requisition-attachments/{req_att.id}")
-            assert resp.status_code == 403
-            assert "access denied" in resp.json()["error"].lower()
+            assert resp.status_code == expected_status
+            assert error_substr in resp.json()["error"].lower()
 
     def test_db_record_not_deleted_on_auth_failure(self, client, req_att, db_session):
         """On 401/403 from Graph, the DB record must NOT be deleted (prevent data
         leak)."""
-        mock_resp = _mock_http_response(401)
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="some-token",
-            ),
-            patch(
-                "app.http_client.http.delete",
-                new_callable=AsyncMock,
-                return_value=mock_resp,
-            ),
-        ):
+        with _patch_valid_token("some-token"), _patch_graph_delete(401):
             client.delete(f"/api/requisition-attachments/{req_att.id}")
             # Record should still exist
             att = db_session.get(RequisitionAttachment, req_att.id)
@@ -196,18 +166,9 @@ class TestDeleteRequirementAttachment:
 
     def test_uses_refreshed_token(self, client, reqmt_att, db_session):
         """Delete endpoint must call get_valid_token and use the refreshed token."""
-        mock_resp = _mock_http_response(204)
         with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="refreshed-token-xyz",
-            ) as mock_gvt,
-            patch(
-                "app.http_client.http.delete",
-                new_callable=AsyncMock,
-                return_value=mock_resp,
-            ) as mock_delete,
+            _patch_valid_token("refreshed-token-xyz") as mock_gvt,
+            _patch_graph_delete(204) as mock_delete,
         ):
             resp = client.delete(f"/api/requirement-attachments/{reqmt_att.id}")
             assert resp.status_code == 200
@@ -218,30 +179,14 @@ class TestDeleteRequirementAttachment:
 
     def test_expired_token_returns_401(self, client, reqmt_att):
         """When get_valid_token returns None, endpoint must return 401."""
-        with patch(
-            "app.scheduler.get_valid_token",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
+        with _patch_valid_token(None):
             resp = client.delete(f"/api/requirement-attachments/{reqmt_att.id}")
             assert resp.status_code == 401
             assert "token expired" in resp.json()["error"].lower()
 
     def test_graph_401_returns_401(self, client, reqmt_att):
         """When Graph API returns 401, endpoint must surface 401 to caller."""
-        mock_resp = _mock_http_response(401)
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="some-token",
-            ),
-            patch(
-                "app.http_client.http.delete",
-                new_callable=AsyncMock,
-                return_value=mock_resp,
-            ),
-        ):
+        with _patch_valid_token("some-token"), _patch_graph_delete(401):
             resp = client.delete(f"/api/requirement-attachments/{reqmt_att.id}")
             assert resp.status_code == 401
 
@@ -262,11 +207,7 @@ class TestAttachFromOneDrive:
             "size": 4096,
         }
         with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="refreshed-link-token",
-            ) as mock_gvt,
+            _patch_valid_token("refreshed-link-token") as mock_gvt,
             patch(
                 "app.utils.graph_client.GraphClient",
             ) as MockGC,
@@ -285,11 +226,7 @@ class TestAttachFromOneDrive:
 
     def test_expired_token_returns_401(self, client, test_requisition):
         """When get_valid_token returns None, endpoint must return 401."""
-        with patch(
-            "app.scheduler.get_valid_token",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
+        with _patch_valid_token(None):
             resp = client.post(
                 f"/api/requisitions/{test_requisition.id}/attachments/onedrive",
                 json={"item_id": "od-123"},
@@ -297,16 +234,18 @@ class TestAttachFromOneDrive:
             assert resp.status_code == 401
             assert "token expired" in resp.json()["error"].lower()
 
-    def test_graph_auth_error_returns_401(self, client, test_requisition):
-        """When Graph returns InvalidAuthenticationToken error, endpoint must return
-        401."""
-        error_response = {"error": {"code": "InvalidAuthenticationToken", "message": "Token expired"}}
+    @pytest.mark.parametrize(
+        "error_code,expected_status",
+        [
+            pytest.param("InvalidAuthenticationToken", 401, id="auth_error"),
+            pytest.param("accessDenied", 403, id="access_denied"),
+        ],
+    )
+    def test_graph_error_surfaced(self, client, test_requisition, error_code, expected_status):
+        """Graph error codes (auth/access-denied) must map to the right HTTP status."""
+        error_response = {"error": {"code": error_code, "message": "denied"}}
         with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="some-token",
-            ),
+            _patch_valid_token("some-token"),
             patch(
                 "app.utils.graph_client.GraphClient",
             ) as MockGC,
@@ -317,25 +256,4 @@ class TestAttachFromOneDrive:
                 f"/api/requisitions/{test_requisition.id}/attachments/onedrive",
                 json={"item_id": "od-123"},
             )
-            assert resp.status_code == 401
-
-    def test_graph_access_denied_returns_403(self, client, test_requisition):
-        """When Graph returns accessDenied error, endpoint must return 403."""
-        error_response = {"error": {"code": "accessDenied", "message": "Forbidden"}}
-        with (
-            patch(
-                "app.scheduler.get_valid_token",
-                new_callable=AsyncMock,
-                return_value="some-token",
-            ),
-            patch(
-                "app.utils.graph_client.GraphClient",
-            ) as MockGC,
-        ):
-            gc_instance = MockGC.return_value
-            gc_instance.get_json = AsyncMock(return_value=error_response)
-            resp = client.post(
-                f"/api/requisitions/{test_requisition.id}/attachments/onedrive",
-                json={"item_id": "od-123"},
-            )
-            assert resp.status_code == 403
+            assert resp.status_code == expected_status

--- a/tests/test_routers_proactive.py
+++ b/tests/test_routers_proactive.py
@@ -44,6 +44,23 @@ def sales_client(db_session: Session, sales_user: User) -> TestClient:
             app.dependency_overrides.pop(dep, None)
 
 
+def _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site, *, company_id=None):
+    """Create, persist, and return a 'new' ProactiveMatch for LM317T."""
+    match = ProactiveMatch(
+        offer_id=test_offer.id,
+        requirement_id=test_requisition.id,
+        requisition_id=test_requisition.id,
+        customer_site_id=test_customer_site.id,
+        salesperson_id=test_user.id,
+        mpn="LM317T",
+        status="new",
+        **({"company_id": company_id} if company_id is not None else {}),
+    )
+    db_session.add(match)
+    db_session.commit()
+    return match
+
+
 # ── Matches ──────────────────────────────────────────────────────────
 
 
@@ -93,17 +110,7 @@ def test_count_badge(mock_fn, client):
 
 def test_dismiss_success(client, db_session, test_user, test_requisition, test_offer, test_customer_site):
     """Dismiss match IDs -> 200."""
-    match = ProactiveMatch(
-        offer_id=test_offer.id,
-        requirement_id=test_requisition.id,
-        requisition_id=test_requisition.id,
-        customer_site_id=test_customer_site.id,
-        salesperson_id=test_user.id,
-        mpn="LM317T",
-        status="new",
-    )
-    db_session.add(match)
-    db_session.commit()
+    match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
 
     resp = client.post("/api/proactive/dismiss", json={"match_ids": [match.id]})
     assert resp.status_code == 200
@@ -235,24 +242,20 @@ def test_contacts_site_empty(client):
 
 
 class TestSendValidation:
-    def test_send_empty_match_ids(self, client):
-        """Send with empty match_ids -> 400."""
+    @pytest.mark.parametrize(
+        ("match_ids", "contact_ids"),
+        [
+            pytest.param([], [1], id="empty_match_ids"),
+            pytest.param([1], [], id="empty_contact_ids"),
+        ],
+    )
+    def test_send_empty_ids(self, client, match_ids, contact_ids):
+        """Empty match_ids or contact_ids -> 400."""
         resp = client.post(
             "/api/proactive/send",
             json={
-                "match_ids": [],
-                "contact_ids": [1],
-            },
-        )
-        assert resp.status_code == 400
-
-    def test_send_empty_contact_ids(self, client):
-        """Send with empty contact_ids -> 400."""
-        resp = client.post(
-            "/api/proactive/send",
-            json={
-                "match_ids": [1],
-                "contact_ids": [],
+                "match_ids": match_ids,
+                "contact_ids": contact_ids,
             },
         )
         assert resp.status_code == 400
@@ -365,17 +368,7 @@ class TestDraftEndpoint:
         self, mock_draft, client, db_session, test_user, test_requisition, test_offer, test_customer_site
     ):
         """AI draft returns subject + body + html."""
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=test_requisition.id,
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
-            mpn="LM317T",
-            status="new",
-        )
-        db_session.add(match)
-        db_session.commit()
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
         resp = client.post(
             "/api/proactive/draft",
             json={
@@ -397,17 +390,7 @@ class TestDraftEndpoint:
         self, mock_draft, client, db_session, test_user, test_requisition, test_offer, test_customer_site
     ):
         """AI returns None -> 500."""
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=test_requisition.id,
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
-            mpn="LM317T",
-            status="new",
-        )
-        db_session.add(match)
-        db_session.commit()
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
         resp = client.post(
             "/api/proactive/draft",
             json={
@@ -524,18 +507,9 @@ class TestDoNotOffer:
         self, client, db_session, test_company, test_user, test_requisition, test_offer, test_customer_site
     ):
         """Suppression auto-dismisses open proactive matches."""
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=test_requisition.id,
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
-            company_id=test_company.id,
-            salesperson_id=test_user.id,
-            mpn="LM317T",
-            status="new",
+        match = _make_match(
+            db_session, test_user, test_requisition, test_offer, test_customer_site, company_id=test_company.id
         )
-        db_session.add(match)
-        db_session.commit()
 
         resp = client.post(
             "/api/proactive/do-not-offer",
@@ -569,17 +543,7 @@ class TestDraftWithContactIds:
         db_session.add(contact)
         db_session.flush()
 
-        match = ProactiveMatch(
-            offer_id=test_offer.id,
-            requirement_id=test_requisition.id,
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
-            salesperson_id=test_user.id,
-            mpn="LM317T",
-            status="new",
-        )
-        db_session.add(match)
-        db_session.commit()
+        match = _make_match(db_session, test_user, test_requisition, test_offer, test_customer_site)
 
         resp = client.post(
             "/api/proactive/draft",

--- a/tests/test_routers_prospect_suggested.py
+++ b/tests/test_routers_prospect_suggested.py
@@ -115,31 +115,23 @@ class TestListSuggested:
         assert data["total"] == 1
         assert data["items"][0]["name"] == "High"
 
-    def test_filter_readiness_call_now(self, client, db_session):
+    @pytest.mark.parametrize(
+        ("readiness_level", "expected_name"),
+        [
+            ("call_now", "Hot"),
+            ("nurture", "Warm"),
+            ("monitor", "Cold"),
+        ],
+        ids=["call_now", "nurture", "monitor"],
+    )
+    def test_filter_readiness_level(self, client, db_session, readiness_level, expected_name):
         _make_prospect(db_session, name="Hot", domain="hot.com", readiness_score=80)
         _make_prospect(db_session, name="Warm", domain="warm.com", readiness_score=50)
         _make_prospect(db_session, name="Cold", domain="cold.com", readiness_score=20)
-        resp = client.get("/api/prospects/suggested?readiness_level=call_now")
+        resp = client.get(f"/api/prospects/suggested?readiness_level={readiness_level}")
         data = resp.json()
         assert data["total"] == 1
-        assert data["items"][0]["name"] == "Hot"
-
-    def test_filter_readiness_nurture(self, client, db_session):
-        _make_prospect(db_session, name="Hot", domain="hot.com", readiness_score=80)
-        _make_prospect(db_session, name="Warm", domain="warm.com", readiness_score=50)
-        _make_prospect(db_session, name="Cold", domain="cold.com", readiness_score=20)
-        resp = client.get("/api/prospects/suggested?readiness_level=nurture")
-        data = resp.json()
-        assert data["total"] == 1
-        assert data["items"][0]["name"] == "Warm"
-
-    def test_filter_readiness_monitor(self, client, db_session):
-        _make_prospect(db_session, name="Hot", domain="hot.com", readiness_score=80)
-        _make_prospect(db_session, name="Cold", domain="cold.com", readiness_score=20)
-        resp = client.get("/api/prospects/suggested?readiness_level=monitor")
-        data = resp.json()
-        assert data["total"] == 1
-        assert data["items"][0]["name"] == "Cold"
+        assert data["items"][0]["name"] == expected_name
 
     def test_sort_readiness_desc(self, client, db_session):
         _make_prospect(db_session, name="Low", domain="low.com", readiness_score=20)
@@ -1009,13 +1001,10 @@ class TestAddProspectManuallyService:
         result = add_prospect_manually("dupetest.com", test_user.id, db_session)
         assert result["is_new"] is False
 
-    def test_empty_domain_raises(self, db_session, test_user):
+    @pytest.mark.parametrize("domain", ["", "   "], ids=["empty", "whitespace_only"])
+    def test_blank_domain_raises(self, db_session, test_user, domain):
         with pytest.raises(ValueError, match="Domain is required"):
-            add_prospect_manually("", test_user.id, db_session)
-
-    def test_whitespace_only_raises(self, db_session, test_user):
-        with pytest.raises(ValueError, match="Domain is required"):
-            add_prospect_manually("   ", test_user.id, db_session)
+            add_prospect_manually(domain, test_user.id, db_session)
 
 
 # ── list_batches endpoint ────────────────────────────────────────────

--- a/tests/test_schemas_crm.py
+++ b/tests/test_schemas_crm.py
@@ -8,10 +8,17 @@ from app.schemas.crm import (
     AddContactToSite,
     CompanyCreate,
     CompanyUpdate,
+    CustomerImportRow,
     EnrichDomainRequest,
     OfferCreate,
+    OfferUpdate,
+    OneDriveAttach,
+    QuoteCreate,
+    QuoteLineItem,
     QuoteReopen,
     QuoteResult,
+    QuoteSendOverride,
+    QuoteUpdate,
     SuggestedContactItem,
     SuggestedSiteContact,
 )
@@ -150,18 +157,6 @@ class TestAddContactToSite:
         assert payload.contact.full_name == "Jane"
 
 
-# ── Additional coverage for missing lines ───────────────────────────
-
-from app.schemas.crm import (
-    CustomerImportRow,
-    OfferUpdate,
-    OneDriveAttach,
-    QuoteCreate,
-    QuoteLineItem,
-    QuoteSendOverride,
-    QuoteUpdate,
-)
-
 # ── CompanyCreate phone normalization ───────────────────────────────
 
 
@@ -180,25 +175,19 @@ class TestCompanyCreatePhone:
 
 
 class TestCompanyUpdateValidators:
-    def test_normalize_hq_country_none(self) -> None:
-        u = CompanyUpdate(hq_country=None)
-        assert u.hq_country is None
-
-    def test_normalize_hq_country_value(self) -> None:
-        u = CompanyUpdate(hq_country="United States")
-        assert u.hq_country == "US"
-
-    def test_normalize_hq_state_none(self) -> None:
-        u = CompanyUpdate(hq_state=None)
-        assert u.hq_state is None
-
-    def test_normalize_hq_state_value(self) -> None:
-        u = CompanyUpdate(hq_state="California")
-        assert u.hq_state == "CA"
-
-    def test_normalize_phone_none(self) -> None:
-        u = CompanyUpdate(phone=None)
-        assert u.phone is None
+    @pytest.mark.parametrize(
+        "field,value,expected",
+        [
+            pytest.param("hq_country", None, None, id="hq_country_none"),
+            pytest.param("hq_country", "United States", "US", id="hq_country_value"),
+            pytest.param("hq_state", None, None, id="hq_state_none"),
+            pytest.param("hq_state", "California", "CA", id="hq_state_value"),
+            pytest.param("phone", None, None, id="phone_none"),
+        ],
+    )
+    def test_normalize(self, field, value, expected) -> None:
+        u = CompanyUpdate(**{field: value})
+        assert getattr(u, field) == expected
 
     def test_normalize_phone_value(self) -> None:
         u = CompanyUpdate(phone="(555) 123-4567")
@@ -210,29 +199,20 @@ class TestCompanyUpdateValidators:
 
 
 class TestOfferCreateValidators:
-    def test_packaging_none(self) -> None:
-        o = OfferCreate(mpn="LM317T", vendor_name="Arrow")
-        assert o.packaging is None
-
-    def test_packaging_normalized(self) -> None:
-        o = OfferCreate(mpn="LM317T", vendor_name="Arrow", packaging="Tape & Reel")
-        assert o.packaging == "reel"
-
-    def test_date_code_none(self) -> None:
-        o = OfferCreate(mpn="LM317T", vendor_name="Arrow")
-        assert o.date_code is None
-
-    def test_date_code_normalized(self) -> None:
-        o = OfferCreate(mpn="LM317T", vendor_name="Arrow", date_code="DC 2024")
-        assert o.date_code == "2024"
-
-    def test_condition_normalized(self) -> None:
-        o = OfferCreate(mpn="LM317T", vendor_name="Arrow", condition="Factory New")
-        assert o.condition == "new"
-
-    def test_mpn_normalized(self) -> None:
-        o = OfferCreate(mpn="lm317t", vendor_name="Arrow")
-        assert o.mpn == "LM317T"
+    @pytest.mark.parametrize(
+        "overrides,field,expected",
+        [
+            pytest.param({}, "packaging", None, id="packaging_none"),
+            pytest.param({"packaging": "Tape & Reel"}, "packaging", "reel", id="packaging_normalized"),
+            pytest.param({}, "date_code", None, id="date_code_none"),
+            pytest.param({"date_code": "DC 2024"}, "date_code", "2024", id="date_code_normalized"),
+            pytest.param({"condition": "Factory New"}, "condition", "new", id="condition_normalized"),
+            pytest.param({"mpn": "lm317t"}, "mpn", "LM317T", id="mpn_normalized"),
+        ],
+    )
+    def test_field_normalized(self, overrides, field, expected) -> None:
+        o = OfferCreate(**{"mpn": "LM317T", "vendor_name": "Arrow", **overrides})
+        assert getattr(o, field) == expected
 
 
 # ── OfferUpdate validators ─────────────────────────────────────────
@@ -243,29 +223,20 @@ class TestOfferUpdate:
         u = OfferUpdate()
         assert u.mpn is None
 
-    def test_mpn_none(self) -> None:
-        u = OfferUpdate(mpn=None)
-        assert u.mpn is None
-
-    def test_mpn_normalized(self) -> None:
-        u = OfferUpdate(mpn="lm317t")
-        assert u.mpn == "LM317T"
-
-    def test_condition_none(self) -> None:
-        u = OfferUpdate(condition=None)
-        assert u.condition is None
-
-    def test_condition_normalized(self) -> None:
-        u = OfferUpdate(condition="refurbished")
-        assert u.condition == "refurb"
-
-    def test_packaging_none(self) -> None:
-        u = OfferUpdate(packaging=None)
-        assert u.packaging is None
-
-    def test_packaging_normalized(self) -> None:
-        u = OfferUpdate(packaging="Tube")
-        assert u.packaging == "tube"
+    @pytest.mark.parametrize(
+        "field,value,expected",
+        [
+            pytest.param("mpn", None, None, id="mpn_none"),
+            pytest.param("mpn", "lm317t", "LM317T", id="mpn_normalized"),
+            pytest.param("condition", None, None, id="condition_none"),
+            pytest.param("condition", "refurbished", "refurb", id="condition_normalized"),
+            pytest.param("packaging", None, None, id="packaging_none"),
+            pytest.param("packaging", "Tube", "tube", id="packaging_normalized"),
+        ],
+    )
+    def test_field_normalized(self, field, value, expected) -> None:
+        u = OfferUpdate(**{field: value})
+        assert getattr(u, field) == expected
 
 
 # ── QuoteLineItem ──────────────────────────────────────────────────

--- a/tests/test_search_builder.py
+++ b/tests/test_search_builder.py
@@ -10,6 +10,7 @@ Depends on: app/utils/search_builder.py, conftest.py
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from sqlalchemy import Column, String
 from sqlalchemy.exc import OperationalError, ProgrammingError
 
@@ -180,8 +181,17 @@ def test_fts_with_results_returns_fts_query():
     assert result is mock_fts_query
 
 
-def test_fts_programming_error_fallback():
-    """ProgrammingError in FTS path falls back to ILIKE (line 80-81)."""
+@pytest.mark.parametrize(
+    ("exc", "orig_msg"),
+    [
+        (ProgrammingError, "pg error"),
+        (OperationalError, "sqlite error"),
+    ],
+    ids=["programming_error", "operational_error"],
+)
+def test_fts_db_error_falls_back_to_ilike(exc, orig_msg):
+    """ProgrammingError/OperationalError in FTS path falls back to ILIKE (line
+    80-81)."""
     sb = SearchBuilder("resistor query long enough")
 
     mock_model = MagicMock()
@@ -193,31 +203,7 @@ def test_fts_programming_error_fallback():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            raise ProgrammingError("test", {}, Exception("pg error"))
-        return MagicMock()
-
-    mock_query = MagicMock()
-    mock_query.filter.side_effect = _filter_side_effect
-
-    with patch.object(sb, "ilike_filter", return_value=MagicMock()):
-        result = sb.fts_or_fallback(mock_query, mock_model, [MagicMock()])
-    assert result is not None
-
-
-def test_fts_operational_error_fallback():
-    """OperationalError in FTS path falls back to ILIKE (line 80-81)."""
-    sb = SearchBuilder("resistor query long enough")
-
-    mock_model = MagicMock()
-    mock_model.search_vector = MagicMock()
-
-    call_count = 0
-
-    def _filter_side_effect(*args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            raise OperationalError("test", {}, Exception("sqlite error"))
+            raise exc("test", {}, Exception(orig_msg))
         return MagicMock()
 
     mock_query = MagicMock()

--- a/tests/test_search_worker_utils.py
+++ b/tests/test_search_worker_utils.py
@@ -14,6 +14,8 @@ os.environ["TESTING"] = "1"
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 
 class TestSearchSchedulerIsBusinessHours:
     """SearchScheduler.is_business_hours() covers all weekday branches (lines 48-61)."""
@@ -28,79 +30,27 @@ class TestSearchSchedulerIsBusinessHours:
         config = SimpleNamespace(**config_dict)
         return SearchScheduler(config, "ICS")
 
-    def test_saturday_always_off(self):
-        """Saturday (weekday 5) is always outside business hours."""
-        scheduler = self._make_scheduler()
-
-        # Saturday at noon
-        with patch("app.services.search_worker_base.scheduler.datetime") as mock_dt:
-            mock_dt.now.return_value = MagicMock(weekday=lambda: 5, hour=12)
-            result = scheduler.is_business_hours()
-        assert result is False
-
-    def test_sunday_before_6pm_off(self):
-        """Sunday before 6 PM is outside business hours."""
-        scheduler = self._make_scheduler()
-        with patch("app.services.search_worker_base.scheduler.datetime") as mock_dt:
-            mock_dt.now.return_value = MagicMock(weekday=lambda: 6, hour=10)
-            result = scheduler.is_business_hours()
-        assert result is False
-
-    def test_sunday_after_6pm_on(self):
-        """Sunday at or after 6 PM is inside business hours."""
+    @pytest.mark.parametrize(
+        ("weekday", "hour", "expected"),
+        [
+            pytest.param(5, 12, False, id="saturday_always_off"),
+            pytest.param(6, 10, False, id="sunday_before_6pm_off"),
+            pytest.param(6, 18, True, id="sunday_after_6pm_on"),
+            pytest.param(4, 16, True, id="friday_before_5pm_on"),
+            pytest.param(4, 17, False, id="friday_at_5pm_off"),
+            pytest.param(0, 9, True, id="monday_always_on"),
+            pytest.param(1, 14, True, id="tuesday_always_on"),
+            pytest.param(2, 11, True, id="wednesday_always_on"),
+            pytest.param(3, 15, True, id="thursday_always_on"),
+        ],
+    )
+    def test_is_business_hours_by_weekday(self, weekday, hour, expected):
+        """is_business_hours() resolves each weekday/hour combination correctly."""
         scheduler = self._make_scheduler()
         with patch("app.services.search_worker_base.scheduler.datetime") as mock_dt:
-            mock_dt.now.return_value = MagicMock(weekday=lambda: 6, hour=18)
+            mock_dt.now.return_value = MagicMock(weekday=lambda: weekday, hour=hour)
             result = scheduler.is_business_hours()
-        assert result is True
-
-    def test_friday_before_5pm_on(self):
-        """Friday before 5 PM is inside business hours."""
-        scheduler = self._make_scheduler()
-        with patch("app.services.search_worker_base.scheduler.datetime") as mock_dt:
-            mock_dt.now.return_value = MagicMock(weekday=lambda: 4, hour=16)
-            result = scheduler.is_business_hours()
-        assert result is True
-
-    def test_friday_at_5pm_off(self):
-        """Friday at or after 5 PM is outside business hours."""
-        scheduler = self._make_scheduler()
-        with patch("app.services.search_worker_base.scheduler.datetime") as mock_dt:
-            mock_dt.now.return_value = MagicMock(weekday=lambda: 4, hour=17)
-            result = scheduler.is_business_hours()
-        assert result is False
-
-    def test_monday_always_on(self):
-        """Monday (weekday 0) is always inside business hours."""
-        scheduler = self._make_scheduler()
-        with patch("app.services.search_worker_base.scheduler.datetime") as mock_dt:
-            mock_dt.now.return_value = MagicMock(weekday=lambda: 0, hour=9)
-            result = scheduler.is_business_hours()
-        assert result is True
-
-    def test_tuesday_always_on(self):
-        """Tuesday (weekday 1) is always inside business hours."""
-        scheduler = self._make_scheduler()
-        with patch("app.services.search_worker_base.scheduler.datetime") as mock_dt:
-            mock_dt.now.return_value = MagicMock(weekday=lambda: 1, hour=14)
-            result = scheduler.is_business_hours()
-        assert result is True
-
-    def test_wednesday_always_on(self):
-        """Wednesday (weekday 2) is always inside business hours."""
-        scheduler = self._make_scheduler()
-        with patch("app.services.search_worker_base.scheduler.datetime") as mock_dt:
-            mock_dt.now.return_value = MagicMock(weekday=lambda: 2, hour=11)
-            result = scheduler.is_business_hours()
-        assert result is True
-
-    def test_thursday_always_on(self):
-        """Thursday (weekday 3) is always inside business hours."""
-        scheduler = self._make_scheduler()
-        with patch("app.services.search_worker_base.scheduler.datetime") as mock_dt:
-            mock_dt.now.return_value = MagicMock(weekday=lambda: 3, hour=15)
-            result = scheduler.is_business_hours()
-        assert result is True
+        assert result is expected
 
     def test_force_business_hours_env_var(self):
         """FORCE_BUSINESS_HOURS=1 always returns True."""
@@ -146,8 +96,16 @@ class TestSearchSchedulerIsBusinessHours:
 class TestHumanBehaviorHumanType:
     """HumanBehavior.human_type() typing loop (line 41)."""
 
-    async def test_human_type_types_each_character(self):
-        """human_type() calls page.keyboard.type for each character."""
+    @pytest.mark.parametrize(
+        ("text", "expected_calls"),
+        [
+            pytest.param("AB", 2, id="types_each_character"),
+            pytest.param("", 0, id="empty_string"),
+            pytest.param("X", 1, id="single_char"),
+        ],
+    )
+    async def test_human_type_calls_keyboard_per_character(self, text, expected_calls):
+        """human_type() calls page.keyboard.type once per character."""
         from app.services.search_worker_base.human_behavior import HumanBehavior
 
         page = MagicMock()
@@ -158,41 +116,9 @@ class TestHumanBehaviorHumanType:
         locator.click = AsyncMock()
 
         with patch("asyncio.sleep", new=AsyncMock()):
-            await HumanBehavior.human_type(page, locator, "AB")
+            await HumanBehavior.human_type(page, locator, text)
 
-        assert page.keyboard.type.call_count == 2
-
-    async def test_human_type_empty_string(self):
-        """human_type() with empty string doesn't call keyboard.type."""
-        from app.services.search_worker_base.human_behavior import HumanBehavior
-
-        page = MagicMock()
-        page.keyboard = MagicMock()
-        page.keyboard.type = AsyncMock()
-
-        locator = MagicMock()
-        locator.click = AsyncMock()
-
-        with patch("asyncio.sleep", new=AsyncMock()):
-            await HumanBehavior.human_type(page, locator, "")
-
-        page.keyboard.type.assert_not_called()
-
-    async def test_human_type_single_char(self):
-        """human_type() with single character calls keyboard.type once."""
-        from app.services.search_worker_base.human_behavior import HumanBehavior
-
-        page = MagicMock()
-        page.keyboard = MagicMock()
-        page.keyboard.type = AsyncMock()
-
-        locator = MagicMock()
-        locator.click = AsyncMock()
-
-        with patch("asyncio.sleep", new=AsyncMock()):
-            await HumanBehavior.human_type(page, locator, "X")
-
-        assert page.keyboard.type.call_count == 1
+        assert page.keyboard.type.call_count == expected_calls
 
 
 class TestHumanBehaviorHumanClick:

--- a/tests/test_services_admin.py
+++ b/tests/test_services_admin.py
@@ -124,9 +124,6 @@ class TestConfig:
         assert result["status"] == 404
 
 
-# ── Scoring Weights ─────────────────────────────────────────────────
-
-
 # ── System Health ───────────────────────────────────────────────────
 
 
@@ -178,22 +175,10 @@ class TestSystemHealth:
         assert conn["display_name"] == "Test Source"
         assert conn["total_searches"] == 100
 
-    def test_count_exception_returns_neg1(self, db_session, monkeypatch):
-        """If a count query fails, the count is -1."""
-        # Make one of the count queries fail
-
-        original_query = db_session.query
-
-        def patched_query(*args, **kwargs):
-            # Make Quote count fail
-            result = original_query(*args, **kwargs)
-            return result
-
-        # Patch at a finer level: make the Quote model's id attribute throw
-        # Instead, just verify the structure handles errors gracefully
+    def test_count_exception_returns_neg1(self, db_session):
+        """get_system_health returns an int for every db_stats count."""
         result = get_system_health(db_session)
-        # All counts should be >= 0 (no exception thrown in our test)
-        for key, val in result["db_stats"].items():
+        for val in result["db_stats"].values():
             assert isinstance(val, int)
 
 

--- a/tests/test_services_coverage_2.py
+++ b/tests/test_services_coverage_2.py
@@ -24,6 +24,7 @@ import asyncio
 from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models import (
@@ -42,6 +43,13 @@ from app.models import (
 )
 from app.models.notification import Notification
 from app.models.strategic import StrategicVendor
+from app.utils.claude_errors import ClaudeUnavailableError
+
+
+def _run(coro):
+    """Run an async coroutine to completion on the current event loop."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # 1. Buyer Leaderboard
@@ -203,9 +211,7 @@ class TestProspectDiscoveryEmail:
             ]
         )
 
-        result = asyncio.get_event_loop().run_until_complete(
-            mine_unknown_domains(graph_client, db_session, days_back=90)
-        )
+        result = _run(mine_unknown_domains(graph_client, db_session, days_back=90))
         # newcompany.com has 2 emails (passes threshold), lonely.com has 1 (filtered out)
         assert len(result) == 1
         assert result[0]["domain"] == "newcompany.com"
@@ -223,9 +229,7 @@ class TestProspectDiscoveryEmail:
             ]
         )
 
-        result = asyncio.get_event_loop().run_until_complete(
-            mine_unknown_domains(graph_client, db_session, days_back=90)
-        )
+        result = _run(mine_unknown_domains(graph_client, db_session, days_back=90))
         assert len(result) == 0
 
     def test_mine_unknown_domains_api_error(self, db_session: Session):
@@ -235,9 +239,7 @@ class TestProspectDiscoveryEmail:
         graph_client = AsyncMock()
         graph_client.list_messages = AsyncMock(side_effect=Exception("API down"))
 
-        result = asyncio.get_event_loop().run_until_complete(
-            mine_unknown_domains(graph_client, db_session, days_back=90)
-        )
+        result = _run(mine_unknown_domains(graph_client, db_session, days_back=90))
         assert result == []
 
     def test_enrich_email_domains_with_data(self):
@@ -250,7 +252,7 @@ class TestProspectDiscoveryEmail:
         async def mock_enrich(domain):
             return {"name": "NewCo Inc", "industry": "Electronics", "website": "https://newco.com"}
 
-        result = asyncio.get_event_loop().run_until_complete(enrich_email_domains(domains, enrich_fn=mock_enrich))
+        result = _run(enrich_email_domains(domains, enrich_fn=mock_enrich))
         assert len(result) == 1
         assert result[0].name == "NewCo Inc"
         assert result[0].discovery_source == "email_history"
@@ -267,9 +269,7 @@ class TestProspectDiscoveryEmail:
         async def apollo_enrich(domain):
             return {"name": "Fallback Corp", "industry": "Tech"}
 
-        result = asyncio.get_event_loop().run_until_complete(
-            enrich_email_domains(domains, enrich_fn=fail_enrich, apollo_enrich_fn=apollo_enrich)
-        )
+        result = _run(enrich_email_domains(domains, enrich_fn=fail_enrich, apollo_enrich_fn=apollo_enrich))
         assert len(result) == 1
         assert result[0].name == "Fallback Corp"
 
@@ -278,9 +278,7 @@ class TestProspectDiscoveryEmail:
         from app.services.prospect_discovery_email import enrich_email_domains
 
         domains = [{"domain": "nope.com", "email_count": 2, "sample_senders": []}]
-        result = asyncio.get_event_loop().run_until_complete(
-            enrich_email_domains(domains, enrich_fn=None, apollo_enrich_fn=None)
-        )
+        result = _run(enrich_email_domains(domains, enrich_fn=None, apollo_enrich_fn=None))
         assert len(result) == 0
 
     def test_run_email_mining_batch_no_domains(self, db_session: Session):
@@ -290,9 +288,7 @@ class TestProspectDiscoveryEmail:
         graph_client = AsyncMock()
         graph_client.list_messages = AsyncMock(return_value=[])
 
-        result = asyncio.get_event_loop().run_until_complete(
-            run_email_mining_batch("batch-1", graph_client, db_session)
-        )
+        result = _run(run_email_mining_batch("batch-1", graph_client, db_session))
         assert result == []
 
 
@@ -431,9 +427,7 @@ class TestAutoAttribution:
         mock_result = {"matches": [{"activity_id": 1, "entity_type": "company", "entity_id": 10, "confidence": 0.95}]}
 
         with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=mock_result):
-            result = asyncio.get_event_loop().run_until_complete(
-                _call_claude_for_matching(activities, companies, vendors)
-            )
+            result = _run(_call_claude_for_matching(activities, companies, vendors))
 
         assert 1 in result
         assert result[1]["entity_type"] == "company"
@@ -451,7 +445,7 @@ class TestAutoAttribution:
         )
 
         with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=json_str):
-            result = asyncio.get_event_loop().run_until_complete(_call_claude_for_matching(activities, [], []))
+            result = _run(_call_claude_for_matching(activities, [], []))
 
         assert 1 in result
 
@@ -467,7 +461,7 @@ class TestAutoAttribution:
             new_callable=AsyncMock,
             side_effect=ClaudeUnavailableError("no key"),
         ):
-            result = asyncio.get_event_loop().run_until_complete(_call_claude_for_matching(activities, [], []))
+            result = _run(_call_claude_for_matching(activities, [], []))
 
         assert result == {}
 
@@ -484,7 +478,7 @@ class TestAiGate:
         """Empty parts list returns empty list."""
         from app.services.ics_worker.ai_gate import classify_parts_batch
 
-        result = asyncio.get_event_loop().run_until_complete(classify_parts_batch([]))
+        result = _run(classify_parts_batch([]))
         assert result == []
 
     def test_classify_parts_batch_success(self):
@@ -500,7 +494,7 @@ class TestAiGate:
         }
 
         with patch("app.utils.llm_router.routed_structured", new_callable=AsyncMock, return_value=mock_result):
-            result = asyncio.get_event_loop().run_until_complete(classify_parts_batch(parts))
+            result = _run(classify_parts_batch(parts))
 
         assert len(result) == 1
         assert result[0]["search_ics"] is True
@@ -512,7 +506,7 @@ class TestAiGate:
         parts = [{"mpn": "TEST123", "manufacturer": "Test", "description": "Part"}]
 
         with patch("app.utils.llm_router.routed_structured", new_callable=AsyncMock, side_effect=Exception("API down")):
-            result = asyncio.get_event_loop().run_until_complete(classify_parts_batch(parts))
+            result = _run(classify_parts_batch(parts))
 
         assert result is None
 
@@ -520,7 +514,7 @@ class TestAiGate:
         """No pending items -> returns immediately."""
         from app.services.ics_worker.ai_gate import process_ai_gate
 
-        asyncio.get_event_loop().run_until_complete(process_ai_gate(db_session))
+        _run(process_ai_gate(db_session))
         # No error = success
 
     def test_process_ai_gate_cached_item(self, db_session: Session, test_user: User):
@@ -569,7 +563,7 @@ class TestAiGate:
         with _cache_lock:
             _classification_cache[("stm32f407vg", "stmicro")] = ("semiconductor", "search", "MCU chip")
 
-        asyncio.get_event_loop().run_until_complete(process_ai_gate(db_session))
+        _run(process_ai_gate(db_session))
 
         db_session.refresh(item)
         assert item.status == "queued"
@@ -616,7 +610,7 @@ class TestAiGate:
         db_session.commit()
 
         with patch("app.services.ics_worker.ai_gate.classify_parts_batch", new_callable=AsyncMock, return_value=None):
-            asyncio.get_event_loop().run_until_complete(process_ai_gate(db_session))
+            _run(process_ai_gate(db_session))
 
         db_session.refresh(item)
         assert item.status == "queued"
@@ -928,50 +922,24 @@ class TestAutoDedup:
         with patch("app.services.auto_dedup_service._run_coro_sync", return_value=False):
             assert _ai_confirm_company_merge("A", "B", "a.com", "b.com", 94) is False
 
-    def test_ask_claude_merge_true(self):
-        """_ask_claude_merge returns True when same_entity=True and confidence>=0.85."""
+    @pytest.mark.parametrize(
+        ("patch_kwargs", "expected"),
+        [
+            ({"return_value": {"same_entity": True, "confidence": 0.9}}, True),
+            ({"return_value": {"same_entity": True, "confidence": 0.5}}, False),
+            ({"side_effect": ClaudeUnavailableError("no key")}, False),
+            ({"return_value": None}, False),
+        ],
+        ids=["true", "low_confidence", "unavailable", "none_result"],
+    )
+    def test_ask_claude_merge(self, patch_kwargs, expected):
+        """_ask_claude_merge returns True only when same_entity and confidence>=0.85;
+        otherwise False (low confidence, None result, or ClaudeUnavailableError)."""
         from app.services.auto_dedup_service import _ask_claude_merge
 
-        with patch(
-            "app.utils.claude_client.claude_structured",
-            new_callable=AsyncMock,
-            return_value={"same_entity": True, "confidence": 0.9},
-        ):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("test"))
-        assert result is True
-
-    def test_ask_claude_merge_low_confidence(self):
-        """_ask_claude_merge returns False when confidence < 0.85."""
-        from app.services.auto_dedup_service import _ask_claude_merge
-
-        with patch(
-            "app.utils.claude_client.claude_structured",
-            new_callable=AsyncMock,
-            return_value={"same_entity": True, "confidence": 0.5},
-        ):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("test"))
-        assert result is False
-
-    def test_ask_claude_merge_unavailable(self):
-        """_ask_claude_merge returns False on ClaudeUnavailableError."""
-        from app.services.auto_dedup_service import _ask_claude_merge
-        from app.utils.claude_errors import ClaudeUnavailableError
-
-        with patch(
-            "app.utils.claude_client.claude_structured",
-            new_callable=AsyncMock,
-            side_effect=ClaudeUnavailableError("no key"),
-        ):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("test"))
-        assert result is False
-
-    def test_ask_claude_merge_none_result(self):
-        """_ask_claude_merge returns False when result is None."""
-        from app.services.auto_dedup_service import _ask_claude_merge
-
-        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=None):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("test"))
-        assert result is False
+        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, **patch_kwargs):
+            result = _run(_ask_claude_merge("test"))
+        assert result is expected
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -1192,7 +1160,7 @@ class TestReenrich:
         mock_enrich.return_value = {"enriched": 0}
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            asyncio.get_event_loop().run_until_complete(main(limit=10, batch_size=5))
+            _run(main(limit=10, batch_size=5))
 
         mock_enrich.assert_called_once()
 
@@ -1211,7 +1179,7 @@ class TestReenrich:
         db_session.commit()
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            asyncio.get_event_loop().run_until_complete(main(limit=10, batch_size=5))
+            _run(main(limit=10, batch_size=5))
 
         mock_enrich.assert_called_once()
         # record_spec should be called for the voltage spec
@@ -1229,7 +1197,7 @@ class TestReenrich:
         # specs_structured is None by default
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            asyncio.get_event_loop().run_until_complete(main(limit=10, batch_size=5))
+            _run(main(limit=10, batch_size=5))
 
         mock_record_spec.assert_not_called()
 
@@ -1248,7 +1216,7 @@ class TestReenrich:
         db_session.commit()
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            asyncio.get_event_loop().run_until_complete(main(limit=10, batch_size=5))
+            _run(main(limit=10, batch_size=5))
 
         # Plain string "3.3V" is not a dict, so spec_data.get("value") won't work
         # The code handles this: value = spec_data if not isinstance(spec_data, dict)
@@ -1425,7 +1393,7 @@ class TestAutoAttributionExtra:
 
         activities = [{"id": 1, "email": "a@b.com", "phone": "", "name": "X", "subject": "Y"}]
         with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value=None):
-            result = asyncio.get_event_loop().run_until_complete(_call_claude_for_matching(activities, [], []))
+            result = _run(_call_claude_for_matching(activities, [], []))
         assert result == {}
 
     def test_call_claude_invalid_json_string(self):
@@ -1434,7 +1402,7 @@ class TestAutoAttributionExtra:
 
         activities = [{"id": 1, "email": "a@b.com", "phone": "", "name": "X", "subject": "Y"}]
         with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value="not json{"):
-            result = asyncio.get_event_loop().run_until_complete(_call_claude_for_matching(activities, [], []))
+            result = _run(_call_claude_for_matching(activities, [], []))
         assert result == {}
 
     def test_call_claude_wrong_format(self):
@@ -1443,7 +1411,7 @@ class TestAutoAttributionExtra:
 
         activities = [{"id": 1, "email": "a@b.com", "phone": "", "name": "X", "subject": "Y"}]
         with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock, return_value={"wrong": True}):
-            result = asyncio.get_event_loop().run_until_complete(_call_claude_for_matching(activities, [], []))
+            result = _run(_call_claude_for_matching(activities, [], []))
         assert result == {}
 
     def test_call_claude_error(self):
@@ -1455,7 +1423,7 @@ class TestAutoAttributionExtra:
         with patch(
             "app.utils.claude_client.claude_structured", new_callable=AsyncMock, side_effect=ClaudeError("fail")
         ):
-            result = asyncio.get_event_loop().run_until_complete(_call_claude_for_matching(activities, [], []))
+            result = _run(_call_claude_for_matching(activities, [], []))
         assert result == {}
 
 
@@ -1671,7 +1639,7 @@ class TestAutoDedupExtra:
         with patch(
             "app.utils.claude_client.claude_structured", new_callable=AsyncMock, side_effect=ClaudeError("fail")
         ):
-            result = asyncio.get_event_loop().run_until_complete(_ask_claude_merge("test"))
+            result = _run(_ask_claude_merge("test"))
         assert result is False
 
 
@@ -1725,7 +1693,7 @@ class TestAiGateExtra:
             new_callable=AsyncMock,
             return_value=classifications,
         ):
-            asyncio.get_event_loop().run_until_complete(process_ai_gate(db_session))
+            _run(process_ai_gate(db_session))
 
         db_session.refresh(item)
         assert item.status == "queued"
@@ -1787,7 +1755,7 @@ class TestAiGateExtra:
             new_callable=AsyncMock,
             return_value=classifications,
         ):
-            asyncio.get_event_loop().run_until_complete(process_ai_gate(db_session))
+            _run(process_ai_gate(db_session))
 
         db_session.refresh(item)
         assert item.status == "gated_out"
@@ -1839,7 +1807,7 @@ class TestAiGateExtra:
             new_callable=AsyncMock,
             return_value=[],
         ):
-            asyncio.get_event_loop().run_until_complete(process_ai_gate(db_session))
+            _run(process_ai_gate(db_session))
 
         db_session.refresh(item)
         # Item stays pending since no classification was returned for it
@@ -1859,7 +1827,7 @@ class TestAiGateExtra:
         ai_gate_mod._last_api_failure = time.monotonic()
 
         # Should return early without processing
-        asyncio.get_event_loop().run_until_complete(process_ai_gate(db_session))
+        _run(process_ai_gate(db_session))
 
         # Reset
         ai_gate_mod._last_api_failure = 0.0
@@ -1871,7 +1839,7 @@ class TestAiGateExtra:
         parts = [{"mpn": "TEST", "manufacturer": "X", "description": "Part"}]
 
         with patch("app.utils.llm_router.routed_structured", new_callable=AsyncMock, return_value={"unexpected": True}):
-            result = asyncio.get_event_loop().run_until_complete(classify_parts_batch(parts))
+            result = _run(classify_parts_batch(parts))
         assert result is None
 
 

--- a/tests/test_services_prospect_scheduler.py
+++ b/tests/test_services_prospect_scheduler.py
@@ -73,70 +73,67 @@ class TestDiscoveryRotation:
         assert result["segment"] == "Aerospace & Defense"
         assert result["regions"] == ["US"]
 
-    def test_after_aerospace_us_picks_aerospace_eu_asia(self, db_session):
-        _make_batch(
-            db_session,
-            batch_id="b1",
-            segment="Aerospace & Defense",
-            regions=["US"],
-        )
+    @pytest.mark.parametrize(
+        ("batch_id", "prev_segment", "prev_regions", "next_segment", "next_regions"),
+        [
+            pytest.param(
+                "b1",
+                "Aerospace & Defense",
+                ["US"],
+                "Aerospace & Defense",
+                ["EU", "Asia"],
+                id="aerospace_us-to-aerospace_eu_asia",
+            ),
+            pytest.param(
+                "b2",
+                "Aerospace & Defense",
+                ["EU", "Asia"],
+                "Service Supply Chain",
+                ["US"],
+                id="aerospace_eu-to-service_us",
+            ),
+            pytest.param(
+                "b3",
+                "Service Supply Chain",
+                ["US"],
+                "Service Supply Chain",
+                ["EU", "Asia"],
+                id="service_us-to-service_eu",
+            ),
+            pytest.param(
+                "b4",
+                "Service Supply Chain",
+                ["EU", "Asia"],
+                "EMS / Electronics Mfg",
+                None,
+                id="service_eu-to-ems",
+            ),
+            pytest.param(
+                "b5",
+                "EMS / Electronics Mfg",
+                ["US", "EU", "Asia"],
+                "Automotive + catch-all",
+                None,
+                id="ems-to-automotive",
+            ),
+            pytest.param(
+                "b6",
+                "Automotive + catch-all",
+                ["US", "EU", "Asia"],
+                "Aerospace & Defense",
+                ["US"],
+                id="automotive-wraps-to-aerospace_us",
+            ),
+        ],
+    )
+    def test_rotation_advances(self, db_session, batch_id, prev_segment, prev_regions, next_segment, next_regions):
+        """Each completed slice advances to the next slice; month 6 wraps to the
+        start."""
+        _make_batch(db_session, batch_id=batch_id, segment=prev_segment, regions=prev_regions)
         result = get_next_discovery_slice(db_session)
-        assert result["segment"] == "Aerospace & Defense"
-        assert result["regions"] == ["EU", "Asia"]
-
-    def test_after_aerospace_eu_picks_service_us(self, db_session):
-        _make_batch(
-            db_session,
-            batch_id="b2",
-            segment="Aerospace & Defense",
-            regions=["EU", "Asia"],
-        )
-        result = get_next_discovery_slice(db_session)
-        assert result["segment"] == "Service Supply Chain"
-        assert result["regions"] == ["US"]
-
-    def test_after_service_us_picks_service_eu(self, db_session):
-        _make_batch(
-            db_session,
-            batch_id="b3",
-            segment="Service Supply Chain",
-            regions=["US"],
-        )
-        result = get_next_discovery_slice(db_session)
-        assert result["segment"] == "Service Supply Chain"
-        assert result["regions"] == ["EU", "Asia"]
-
-    def test_after_service_eu_picks_ems(self, db_session):
-        _make_batch(
-            db_session,
-            batch_id="b4",
-            segment="Service Supply Chain",
-            regions=["EU", "Asia"],
-        )
-        result = get_next_discovery_slice(db_session)
-        assert result["segment"] == "EMS / Electronics Mfg"
-
-    def test_after_ems_picks_automotive(self, db_session):
-        _make_batch(
-            db_session,
-            batch_id="b5",
-            segment="EMS / Electronics Mfg",
-            regions=["US", "EU", "Asia"],
-        )
-        result = get_next_discovery_slice(db_session)
-        assert result["segment"] == "Automotive + catch-all"
-
-    def test_wraps_around_after_month_6(self, db_session):
-        """After automotive → back to Aerospace US."""
-        _make_batch(
-            db_session,
-            batch_id="b6",
-            segment="Automotive + catch-all",
-            regions=["US", "EU", "Asia"],
-        )
-        result = get_next_discovery_slice(db_session)
-        assert result["segment"] == "Aerospace & Defense"
-        assert result["regions"] == ["US"]
+        assert result["segment"] == next_segment
+        if next_regions is not None:
+            assert result["regions"] == next_regions
 
     def test_uses_most_recent_batch(self, db_session):
         """Multiple batches — picks based on most recent."""
@@ -200,38 +197,20 @@ class TestDiscoveryRotation:
 
 class TestKillSwitch:
     @pytest.mark.asyncio
-    async def test_discover_skips_when_disabled(self):
+    @pytest.mark.parametrize(
+        "job",
+        [
+            pytest.param(job_discover_prospects, id="discover"),
+            pytest.param(job_enrich_pool, id="enrich"),
+            pytest.param(job_find_contacts, id="contacts"),
+            pytest.param(job_refresh_scores, id="refresh"),
+            pytest.param(job_expire_and_resurface, id="expire"),
+        ],
+    )
+    async def test_job_skips_when_disabled(self, job):
         with patch("app.services.prospect_scheduler.settings") as mock_s:
             mock_s.prospecting_enabled = False
-            result = await job_discover_prospects()
-        assert result["skipped"] is True
-
-    @pytest.mark.asyncio
-    async def test_enrich_skips_when_disabled(self):
-        with patch("app.services.prospect_scheduler.settings") as mock_s:
-            mock_s.prospecting_enabled = False
-            result = await job_enrich_pool()
-        assert result["skipped"] is True
-
-    @pytest.mark.asyncio
-    async def test_contacts_skips_when_disabled(self):
-        with patch("app.services.prospect_scheduler.settings") as mock_s:
-            mock_s.prospecting_enabled = False
-            result = await job_find_contacts()
-        assert result["skipped"] is True
-
-    @pytest.mark.asyncio
-    async def test_refresh_skips_when_disabled(self):
-        with patch("app.services.prospect_scheduler.settings") as mock_s:
-            mock_s.prospecting_enabled = False
-            result = await job_refresh_scores()
-        assert result["skipped"] is True
-
-    @pytest.mark.asyncio
-    async def test_expire_skips_when_disabled(self):
-        with patch("app.services.prospect_scheduler.settings") as mock_s:
-            mock_s.prospecting_enabled = False
-            result = await job_expire_and_resurface()
+            result = await job()
         assert result["skipped"] is True
 
 
@@ -240,95 +219,85 @@ class TestKillSwitch:
 
 class TestExpireLogic:
     @pytest.mark.asyncio
-    async def test_expires_old_low_readiness(self, db_session):
-        p = _make_prospect(
-            db_session,
-            name="Old Low",
-            domain="oldlow.com",
-            readiness_score=30,
-            created_at=datetime.now(timezone.utc) - timedelta(days=100),
-            last_enriched_at=datetime.now(timezone.utc) - timedelta(days=70),
-        )
+    @pytest.mark.parametrize(
+        ("overrides", "expected_status"),
+        [
+            pytest.param(
+                {
+                    "name": "Old Low",
+                    "domain": "oldlow.com",
+                    "readiness_score": 30,
+                    "created_at": datetime.now(timezone.utc) - timedelta(days=100),
+                    "last_enriched_at": datetime.now(timezone.utc) - timedelta(days=70),
+                },
+                "expired",
+                id="expires_old_low_readiness",
+            ),
+            pytest.param(
+                {
+                    "name": "Old High",
+                    "domain": "oldhigh.com",
+                    "readiness_score": 70,
+                    "created_at": datetime.now(timezone.utc) - timedelta(days=100),
+                    "last_enriched_at": datetime.now(timezone.utc) - timedelta(days=70),
+                },
+                "suggested",
+                id="does_not_expire_high_readiness",
+            ),
+            pytest.param(
+                {
+                    "name": "Recent",
+                    "domain": "recent.com",
+                    "readiness_score": 30,
+                    "created_at": datetime.now(timezone.utc) - timedelta(days=100),
+                    "last_enriched_at": datetime.now(timezone.utc) - timedelta(days=10),
+                },
+                "suggested",
+                id="does_not_expire_recently_enriched",
+            ),
+            pytest.param(
+                {
+                    "name": "Intent",
+                    "domain": "intent.com",
+                    "readiness_score": 30,
+                    "readiness_signals": {"intent": {"strength": "strong"}},
+                    "created_at": datetime.now(timezone.utc) - timedelta(days=100),
+                    "last_enriched_at": datetime.now(timezone.utc) - timedelta(days=70),
+                },
+                "suggested",
+                id="does_not_expire_strong_intent",
+            ),
+            pytest.param(
+                {
+                    "name": "Young",
+                    "domain": "young.com",
+                    "readiness_score": 20,
+                    "created_at": datetime.now(timezone.utc) - timedelta(days=30),
+                },
+                "suggested",
+                id="does_not_expire_young_prospect",
+            ),
+            pytest.param(
+                {
+                    "name": "Boundary",
+                    "domain": "boundary.com",
+                    "readiness_score": 20,
+                    "created_at": datetime.now(timezone.utc) - timedelta(days=89),
+                    "last_enriched_at": datetime.now(timezone.utc) - timedelta(days=70),
+                },
+                "suggested",
+                id="within_90_day_boundary",
+            ),
+        ],
+    )
+    async def test_expire_status(self, db_session, overrides, expected_status):
+        """Old low-readiness prospects expire; high-readiness / fresh / strong-intent /
+        young / within-90-day-boundary prospects stay suggested."""
+        p = _make_prospect(db_session, **overrides)
         with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
             await job_expire_and_resurface()
         db_session.refresh(p)
-        assert p.status == "expired"
-
-    @pytest.mark.asyncio
-    async def test_does_not_expire_high_readiness(self, db_session):
-        p = _make_prospect(
-            db_session,
-            name="Old High",
-            domain="oldhigh.com",
-            readiness_score=70,
-            created_at=datetime.now(timezone.utc) - timedelta(days=100),
-            last_enriched_at=datetime.now(timezone.utc) - timedelta(days=70),
-        )
-        with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
-            await job_expire_and_resurface()
-        db_session.refresh(p)
-        assert p.status == "suggested"
-
-    @pytest.mark.asyncio
-    async def test_does_not_expire_recently_enriched(self, db_session):
-        p = _make_prospect(
-            db_session,
-            name="Recent",
-            domain="recent.com",
-            readiness_score=30,
-            created_at=datetime.now(timezone.utc) - timedelta(days=100),
-            last_enriched_at=datetime.now(timezone.utc) - timedelta(days=10),
-        )
-        with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
-            await job_expire_and_resurface()
-        db_session.refresh(p)
-        assert p.status == "suggested"
-
-    @pytest.mark.asyncio
-    async def test_does_not_expire_strong_intent(self, db_session):
-        p = _make_prospect(
-            db_session,
-            name="Intent",
-            domain="intent.com",
-            readiness_score=30,
-            readiness_signals={"intent": {"strength": "strong"}},
-            created_at=datetime.now(timezone.utc) - timedelta(days=100),
-            last_enriched_at=datetime.now(timezone.utc) - timedelta(days=70),
-        )
-        with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
-            await job_expire_and_resurface()
-        db_session.refresh(p)
-        assert p.status == "suggested"
-
-    @pytest.mark.asyncio
-    async def test_does_not_expire_young_prospect(self, db_session):
-        p = _make_prospect(
-            db_session,
-            name="Young",
-            domain="young.com",
-            readiness_score=20,
-            created_at=datetime.now(timezone.utc) - timedelta(days=30),
-        )
-        with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
-            await job_expire_and_resurface()
-        db_session.refresh(p)
-        assert p.status == "suggested"
-
-    @pytest.mark.asyncio
-    async def test_within_90_day_boundary(self, db_session):
-        """Prospect created 89 days ago should NOT be expired (cutoff is 90)."""
-        p = _make_prospect(
-            db_session,
-            name="Boundary",
-            domain="boundary.com",
-            readiness_score=20,
-            created_at=datetime.now(timezone.utc) - timedelta(days=89),
-            last_enriched_at=datetime.now(timezone.utc) - timedelta(days=70),
-        )
-        with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
-            await job_expire_and_resurface()
-        db_session.refresh(p)
-        assert p.status == "suggested"
+        assert p.status == expected_status
 
 
 # ── Resurface Logic ─────────────────────────────────────────────────
@@ -355,70 +324,67 @@ class TestResurfaceLogic:
         assert p.dismiss_reason is None
 
     @pytest.mark.asyncio
-    async def test_resurfaces_expired_with_hiring_signals(self, db_session):
-        p = _make_prospect(
-            db_session,
-            name="Expired",
-            domain="expired.com",
-            status="expired",
-            readiness_score=45,
-            readiness_signals={"hiring": {"type": "procurement"}},
-            last_enriched_at=datetime.now(timezone.utc) - timedelta(days=10),
-        )
+    @pytest.mark.parametrize(
+        ("overrides", "expected_status"),
+        [
+            pytest.param(
+                {
+                    "name": "Expired",
+                    "domain": "expired.com",
+                    "status": "expired",
+                    "readiness_score": 45,
+                    "readiness_signals": {"hiring": {"type": "procurement"}},
+                    "last_enriched_at": datetime.now(timezone.utc) - timedelta(days=10),
+                },
+                "suggested",
+                id="resurfaces_expired_with_hiring_signals",
+            ),
+            pytest.param(
+                {
+                    "name": "NoSignals",
+                    "domain": "nosignals.com",
+                    "status": "dismissed",
+                    "readiness_score": 50,
+                    "readiness_signals": {},
+                    "last_enriched_at": datetime.now(timezone.utc) - timedelta(days=5),
+                },
+                "dismissed",
+                id="does_not_resurface_without_signals",
+            ),
+            pytest.param(
+                {
+                    "name": "LowRead",
+                    "domain": "lowread.com",
+                    "status": "dismissed",
+                    "readiness_score": 20,
+                    "readiness_signals": {"intent": {"strength": "strong"}},
+                    "last_enriched_at": datetime.now(timezone.utc) - timedelta(days=5),
+                },
+                "dismissed",
+                id="does_not_resurface_low_readiness",
+            ),
+            pytest.param(
+                {
+                    "name": "OldEnrich",
+                    "domain": "oldenrich.com",
+                    "status": "dismissed",
+                    "readiness_score": 60,
+                    "readiness_signals": {"intent": {"strength": "strong"}},
+                    "last_enriched_at": datetime.now(timezone.utc) - timedelta(days=45),
+                },
+                "dismissed",
+                id="does_not_resurface_old_enrichment",
+            ),
+        ],
+    )
+    async def test_resurface_status(self, db_session, overrides, expected_status):
+        """Expired/dismissed prospects resurface only with fresh signals AND readiness
+        >= 40; low readiness, no signals, or stale enrichment do not."""
+        p = _make_prospect(db_session, **overrides)
         with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
             await job_expire_and_resurface()
         db_session.refresh(p)
-        assert p.status == "suggested"
-
-    @pytest.mark.asyncio
-    async def test_does_not_resurface_without_signals(self, db_session):
-        p = _make_prospect(
-            db_session,
-            name="NoSignals",
-            domain="nosignals.com",
-            status="dismissed",
-            readiness_score=50,
-            readiness_signals={},
-            last_enriched_at=datetime.now(timezone.utc) - timedelta(days=5),
-        )
-        with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
-            await job_expire_and_resurface()
-        db_session.refresh(p)
-        assert p.status == "dismissed"
-
-    @pytest.mark.asyncio
-    async def test_does_not_resurface_low_readiness(self, db_session):
-        """Even with signals, readiness < 40 shouldn't resurface."""
-        p = _make_prospect(
-            db_session,
-            name="LowRead",
-            domain="lowread.com",
-            status="dismissed",
-            readiness_score=20,
-            readiness_signals={"intent": {"strength": "strong"}},
-            last_enriched_at=datetime.now(timezone.utc) - timedelta(days=5),
-        )
-        with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
-            await job_expire_and_resurface()
-        db_session.refresh(p)
-        assert p.status == "dismissed"
-
-    @pytest.mark.asyncio
-    async def test_does_not_resurface_old_enrichment(self, db_session):
-        """Enrichment older than 30 days shouldn't trigger resurface."""
-        p = _make_prospect(
-            db_session,
-            name="OldEnrich",
-            domain="oldenrich.com",
-            status="dismissed",
-            readiness_score=60,
-            readiness_signals={"intent": {"strength": "strong"}},
-            last_enriched_at=datetime.now(timezone.utc) - timedelta(days=45),
-        )
-        with patch("app.database.SessionLocal", return_value=db_session), patch.object(db_session, "close"):
-            await job_expire_and_resurface()
-        db_session.refresh(p)
-        assert p.status == "dismissed"
+        assert p.status == expected_status
 
 
 # ── Score Refresh ───────────────────────────────────────────────────
@@ -717,25 +683,20 @@ class TestSchedulerCoverageGaps:
         assert result["email_count"] == 0
 
     @pytest.mark.asyncio
-    async def test_refresh_scores_exception_path(self):
-        """Lines 313-317: job_refresh_scores returns error on exception."""
+    @pytest.mark.parametrize(
+        ("job", "boom"),
+        [
+            pytest.param(job_refresh_scores, "Score refresh exploded", id="refresh_scores"),
+            pytest.param(job_expire_and_resurface, "Expire job exploded", id="expire_and_resurface"),
+        ],
+    )
+    async def test_job_returns_error_on_exception(self, job, boom):
+        """job_refresh_scores / job_expire_and_resurface return error on exception."""
         with patch("app.database.SessionLocal") as mock_sl:
             mock_db = MagicMock()
             mock_sl.return_value = mock_db
-            mock_db.query.side_effect = RuntimeError("Score refresh exploded")
+            mock_db.query.side_effect = RuntimeError(boom)
 
-            result = await job_refresh_scores()
-
-        assert "error" in result
-
-    @pytest.mark.asyncio
-    async def test_expire_and_resurface_exception_path(self):
-        """Lines 403-407: job_expire_and_resurface returns error on exception."""
-        with patch("app.database.SessionLocal") as mock_sl:
-            mock_db = MagicMock()
-            mock_sl.return_value = mock_db
-            mock_db.query.side_effect = RuntimeError("Expire job exploded")
-
-            result = await job_expire_and_resurface()
+            result = await job()
 
         assert "error" in result

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -152,38 +152,25 @@ class TestStart:
 
 
 class TestCheckSessionHealth:
-    def test_healthy_session(self, manager, mock_page):
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("https://www.icsource.com/members/Search/NewSearch.aspx", True),  # healthy session
+            ("https://www.icsource.com/home/Login.aspx", False),  # redirected to login
+            ("https://www.icsource.com/home/default.aspx", False),  # redirected to public home
+        ],
+        ids=["healthy_session", "redirected_to_login", "redirected_to_public_home"],
+    )
+    def test_health_by_landing_url(self, manager, mock_page, url, expected):
         manager._page = mock_page
-        mock_page.url = "https://www.icsource.com/members/Search/NewSearch.aspx"
+        mock_page.url = url
 
         async def _run():
             with patch("app.services.ics_worker.session_manager.asyncio.sleep", new_callable=AsyncMock):
                 return await manager.check_session_health()
 
         result = asyncio.get_event_loop().run_until_complete(_run())
-        assert result is True
-
-    def test_redirected_to_login(self, manager, mock_page):
-        manager._page = mock_page
-        mock_page.url = "https://www.icsource.com/home/Login.aspx"
-
-        async def _run():
-            with patch("app.services.ics_worker.session_manager.asyncio.sleep", new_callable=AsyncMock):
-                return await manager.check_session_health()
-
-        result = asyncio.get_event_loop().run_until_complete(_run())
-        assert result is False
-
-    def test_redirected_to_public_home(self, manager, mock_page):
-        manager._page = mock_page
-        mock_page.url = "https://www.icsource.com/home/default.aspx"
-
-        async def _run():
-            with patch("app.services.ics_worker.session_manager.asyncio.sleep", new_callable=AsyncMock):
-                return await manager.check_session_health()
-
-        result = asyncio.get_event_loop().run_until_complete(_run())
-        assert result is False
+        assert result is expected
 
     def test_exception_returns_false(self, manager, mock_page):
         manager._page = mock_page

--- a/tests/test_sightings_sse.py
+++ b/tests/test_sightings_sse.py
@@ -7,6 +7,8 @@ Depends on: conftest.py fixtures, app.services.sse_broker, app.routers.sightings
 import json
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from app.models.sourcing import Requirement, Requisition, Sighting
 from app.models.vendor_sighting_summary import VendorSightingSummary
 
@@ -38,99 +40,58 @@ def _seed_data(db_session):
     return req, r, s
 
 
-class TestSSEPublishOnAdvanceStatus:
-    """Verify advance-status endpoint publishes sighting-updated SSE event."""
+def _seed_sighting(db_session, requirement_id):
+    """Create an actual sighting to mark unavailable."""
+    s = Sighting(
+        requirement_id=requirement_id,
+        vendor_name="SSE Vendor",
+        mpn_matched="SSE-TEST-001",
+    )
+    db_session.add(s)
+    db_session.commit()
 
-    def test_publishes_on_status_change(self, client, db_session):
+
+class TestSSEPublishOnMutation:
+    """Each sightings mutation endpoint publishes a sighting-updated SSE event carrying
+    the requirement_id."""
+
+    @pytest.mark.parametrize(
+        ("method", "path_suffix", "data", "extra_setup", "asserts_event_name"),
+        [
+            ("patch", "advance-status", {"status": "sourcing"}, None, True),
+            ("post", "log-activity", {"notes": "Test note", "channel": "note", "vendor_name": ""}, None, True),
+            (
+                "post",
+                "mark-unavailable",
+                {"vendor_name": "SSE Vendor", "reason": "sold_elsewhere"},
+                _seed_sighting,
+                False,
+            ),
+            ("patch", "assign", {"assigned_buyer_id": "1"}, None, False),
+            ("post", "refresh", None, None, False),
+        ],
+        ids=["advance_status", "log_activity", "mark_unavailable", "assign_buyer", "refresh"],
+    )
+    def test_publishes_sighting_updated(
+        self, client, db_session, method, path_suffix, data, extra_setup, asserts_event_name
+    ):
         _, r, _ = _seed_data(db_session)
+        if extra_setup is not None:
+            extra_setup(db_session, r.id)
+
         with patch("app.routers.sightings.broker") as mock_broker:
             mock_broker.publish = AsyncMock()
-            resp = client.patch(
-                f"/v2/partials/sightings/{r.id}/advance-status",
-                data={"status": "sourcing"},
-            )
+            request = getattr(client, method)
+            url = f"/v2/partials/sightings/{r.id}/{path_suffix}"
+            resp = request(url, data=data) if data is not None else request(url)
+
             assert resp.status_code == 200
             mock_broker.publish.assert_called_once()
             call_args = mock_broker.publish.call_args
-            assert call_args[0][1] == "sighting-updated"
-            data = json.loads(call_args[0][2])
-            assert data["requirement_id"] == r.id
-
-
-class TestSSEPublishOnLogActivity:
-    """Verify log-activity endpoint publishes sighting-updated SSE event."""
-
-    def test_publishes_on_activity_log(self, client, db_session):
-        _, r, _ = _seed_data(db_session)
-        with patch("app.routers.sightings.broker") as mock_broker:
-            mock_broker.publish = AsyncMock()
-            resp = client.post(
-                f"/v2/partials/sightings/{r.id}/log-activity",
-                data={"notes": "Test note", "channel": "note", "vendor_name": ""},
-            )
-            assert resp.status_code == 200
-            mock_broker.publish.assert_called_once()
-            call_args = mock_broker.publish.call_args
-            assert call_args[0][1] == "sighting-updated"
-            data = json.loads(call_args[0][2])
-            assert data["requirement_id"] == r.id
-
-
-class TestSSEPublishOnMarkUnavailable:
-    """Verify mark-unavailable endpoint publishes sighting-updated SSE event."""
-
-    def test_publishes_on_mark_unavailable(self, client, db_session):
-        _, r, _ = _seed_data(db_session)
-        # Create an actual sighting to mark
-        s = Sighting(
-            requirement_id=r.id,
-            vendor_name="SSE Vendor",
-            mpn_matched="SSE-TEST-001",
-        )
-        db_session.add(s)
-        db_session.commit()
-
-        with patch("app.routers.sightings.broker") as mock_broker:
-            mock_broker.publish = AsyncMock()
-            resp = client.post(
-                f"/v2/partials/sightings/{r.id}/mark-unavailable",
-                data={"vendor_name": "SSE Vendor", "reason": "sold_elsewhere"},
-            )
-            assert resp.status_code == 200
-            mock_broker.publish.assert_called_once()
-            data = json.loads(mock_broker.publish.call_args[0][2])
-            assert data["requirement_id"] == r.id
-
-
-class TestSSEPublishOnAssignBuyer:
-    """Verify assign-buyer endpoint publishes sighting-updated SSE event."""
-
-    def test_publishes_on_assign(self, client, db_session):
-        _, r, _ = _seed_data(db_session)
-        with patch("app.routers.sightings.broker") as mock_broker:
-            mock_broker.publish = AsyncMock()
-            resp = client.patch(
-                f"/v2/partials/sightings/{r.id}/assign",
-                data={"assigned_buyer_id": "1"},
-            )
-            assert resp.status_code == 200
-            mock_broker.publish.assert_called_once()
-            data = json.loads(mock_broker.publish.call_args[0][2])
-            assert data["requirement_id"] == r.id
-
-
-class TestSSEPublishOnRefresh:
-    """Verify single refresh endpoint publishes sighting-updated SSE event."""
-
-    def test_publishes_on_refresh(self, client, db_session):
-        _, r, _ = _seed_data(db_session)
-        with patch("app.routers.sightings.broker") as mock_broker:
-            mock_broker.publish = AsyncMock()
-            resp = client.post(f"/v2/partials/sightings/{r.id}/refresh")
-            assert resp.status_code == 200
-            mock_broker.publish.assert_called_once()
-            data = json.loads(mock_broker.publish.call_args[0][2])
-            assert data["requirement_id"] == r.id
+            if asserts_event_name:
+                assert call_args[0][1] == "sighting-updated"
+            data_published = json.loads(call_args[0][2])
+            assert data_published["requirement_id"] == r.id
 
 
 class TestSSEPublishOnBatchRefresh:

--- a/tests/test_sourcing_leads_coverage.py
+++ b/tests/test_sourcing_leads_coverage.py
@@ -69,6 +69,14 @@ def basic_sighting(db_session: Session, req_pair: tuple) -> Sighting:
     return s
 
 
+def _sync_one_lead(db_session: Session, item: Requirement, sighting: Sighting) -> SourcingLead:
+    """Sync a single sighting into a lead and return the persisted lead."""
+    from app.services.sourcing_leads import sync_leads_for_sightings
+
+    sync_leads_for_sightings(db_session, item, [sighting])
+    return db_session.query(SourcingLead).first()
+
+
 @pytest.fixture()
 def vendor_card(db_session: Session) -> VendorCard:
     vc = VendorCard(
@@ -155,45 +163,35 @@ class TestUtilityFunctions:
 
         assert _freshness_score(None) == 45.0
 
-    def test_match_type_exact(self):
+    @pytest.mark.parametrize(
+        ("requested", "matched", "substitutes", "expected"),
+        [
+            pytest.param("LM317T", "LM317T", None, "exact", id="exact"),
+            # "ABCDE" contains "ABC" so it's a normalized prefix match
+            pytest.param("ABC", "ABCDE", None, "normalized", id="normalized"),
+            pytest.param("LM317T", "LM7805", [{"mpn": "LM7805"}], "cross_ref", id="cross_ref"),
+            pytest.param("LM317T", "XYZ999", None, "fuzzy", id="fuzzy"),
+        ],
+    )
+    def test_match_type(self, requested, matched, substitutes, expected):
         from app.services.sourcing_leads import _match_type_for_parts
 
-        assert _match_type_for_parts("LM317T", "LM317T") == "exact"
+        assert _match_type_for_parts(requested, matched, substitutes=substitutes) == expected
 
-    def test_match_type_normalized(self):
-        from app.services.sourcing_leads import _match_type_for_parts
-
-        # "ABCDE" contains "ABC" so it's a normalized prefix match
-        assert _match_type_for_parts("ABC", "ABCDE") == "normalized"
-
-    def test_match_type_cross_ref(self):
-        from app.services.sourcing_leads import _match_type_for_parts
-
-        subs = [{"mpn": "LM7805"}]
-        assert _match_type_for_parts("LM317T", "LM7805", substitutes=subs) == "cross_ref"
-
-    def test_match_type_fuzzy(self):
-        from app.services.sourcing_leads import _match_type_for_parts
-
-        assert _match_type_for_parts("LM317T", "XYZ999") == "fuzzy"
-
-    def test_suggested_next_action_low_safety(self):
+    @pytest.mark.parametrize(
+        ("confidence", "safety", "contactability", "expected_substr", "case_insensitive"),
+        [
+            pytest.param(80.0, 40.0, 80.0, "Verify", False, id="low_safety"),
+            pytest.param(80.0, 80.0, 20.0, "contact", True, id="low_contactability"),
+            pytest.param(80.0, 80.0, 80.0, "Contact now", False, id="high_confidence"),
+        ],
+    )
+    def test_suggested_next_action(self, confidence, safety, contactability, expected_substr, case_insensitive):
         from app.services.sourcing_leads import _suggested_next_action
 
-        result = _suggested_next_action(80.0, 40.0, 80.0)
-        assert "Verify" in result
-
-    def test_suggested_next_action_low_contactability(self):
-        from app.services.sourcing_leads import _suggested_next_action
-
-        result = _suggested_next_action(80.0, 80.0, 20.0)
-        assert "contact" in result.lower()
-
-    def test_suggested_next_action_high_confidence(self):
-        from app.services.sourcing_leads import _suggested_next_action
-
-        result = _suggested_next_action(80.0, 80.0, 80.0)
-        assert "Contact now" in result
+        result = _suggested_next_action(confidence, safety, contactability)
+        haystack = result.lower() if case_insensitive else result
+        assert expected_substr in haystack
 
     def test_source_category_mapping(self):
         from app.services.sourcing_leads import _source_category
@@ -490,20 +488,18 @@ class TestGetRequisitionLeads:
 
 class TestUpdateLeadStatus:
     def test_invalid_status_raises(self, db_session: Session, req_pair: tuple, basic_sighting: Sighting):
-        from app.services.sourcing_leads import sync_leads_for_sightings, update_lead_status
+        from app.services.sourcing_leads import update_lead_status
 
         _, item = req_pair
-        sync_leads_for_sightings(db_session, item, [basic_sighting])
-        lead = db_session.query(SourcingLead).first()
+        lead = _sync_one_lead(db_session, item, basic_sighting)
         with pytest.raises(ValueError):
             update_lead_status(db_session, lead.id, "INVALID_STATUS")
 
     def test_valid_status_update(self, db_session: Session, req_pair: tuple, basic_sighting: Sighting):
-        from app.services.sourcing_leads import sync_leads_for_sightings, update_lead_status
+        from app.services.sourcing_leads import update_lead_status
 
         _, item = req_pair
-        sync_leads_for_sightings(db_session, item, [basic_sighting])
-        lead = db_session.query(SourcingLead).first()
+        lead = _sync_one_lead(db_session, item, basic_sighting)
         updated = update_lead_status(db_session, lead.id, "contacted")
         assert updated.buyer_status == "contacted"
 
@@ -516,11 +512,10 @@ class TestUpdateLeadStatus:
     def test_has_stock_propagates_to_vendor_card(
         self, db_session: Session, req_pair: tuple, basic_sighting: Sighting, vendor_card: VendorCard
     ):
-        from app.services.sourcing_leads import sync_leads_for_sightings, update_lead_status
+        from app.services.sourcing_leads import update_lead_status
 
         _, item = req_pair
-        sync_leads_for_sightings(db_session, item, [basic_sighting])
-        lead = db_session.query(SourcingLead).first()
+        lead = _sync_one_lead(db_session, item, basic_sighting)
         original_wins = vendor_card.total_wins or 0
         update_lead_status(db_session, lead.id, "has_stock")
         db_session.refresh(vendor_card)

--- a/tests/test_specialty_detector.py
+++ b/tests/test_specialty_detector.py
@@ -10,6 +10,8 @@ Depends on: app/services/specialty_detector.py, conftest.py
 
 from datetime import datetime, timezone
 
+import pytest
+
 from app.models import Offer, Requirement, Requisition, Sighting, User, VendorCard
 from app.services.specialty_detector import (
     analyze_vendor_specialties,
@@ -21,58 +23,61 @@ from app.services.specialty_detector import (
 
 
 class TestDetectBrandsFromText:
-    def test_empty_text(self):
-        assert detect_brands_from_text("") == []
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            pytest.param("", [], id="empty_text"),
+            pytest.param(None, [], id="none_text"),
+            pytest.param("This text has no brand names whatsoever", [], id="no_match"),
+        ],
+    )
+    def test_returns_empty(self, text, expected):
+        assert detect_brands_from_text(text) == expected
 
-    def test_none_text(self):
-        assert detect_brands_from_text(None) == []
-
-    def test_single_brand(self):
-        result = detect_brands_from_text("We have Intel processors in stock")
-        assert "Intel" in result
-
-    def test_multiple_brands(self):
-        result = detect_brands_from_text("Intel and AMD compete in the CPU market")
-        assert "Intel" in result
-        assert "AMD" in result
-
-    def test_case_insensitive(self):
-        result = detect_brands_from_text("texas instruments makes great chips")
-        assert "Texas Instruments" in result
-
-    def test_no_match(self):
-        result = detect_brands_from_text("This text has no brand names whatsoever")
-        assert result == []
-
-    def test_word_boundary_respected(self):
-        """'NXP' should match, but should not match inside 'UNEXPECTED'."""
-        result = detect_brands_from_text("NXP semiconductors")
-        assert "NXP" in result
-
-    def test_special_chars_escaped(self):
-        """3M has special regex implications but should still match."""
-        result = detect_brands_from_text("3M connectors are reliable")
-        assert "3M" in result
+    @pytest.mark.parametrize(
+        "text,expected_brands",
+        [
+            pytest.param("We have Intel processors in stock", ["Intel"], id="single_brand"),
+            pytest.param("Intel and AMD compete in the CPU market", ["Intel", "AMD"], id="multiple_brands"),
+            pytest.param("texas instruments makes great chips", ["Texas Instruments"], id="case_insensitive"),
+            # 'NXP' should match, but should not match inside 'UNEXPECTED'.
+            pytest.param("NXP semiconductors", ["NXP"], id="word_boundary_respected"),
+            # 3M has special regex implications but should still match.
+            pytest.param("3M connectors are reliable", ["3M"], id="special_chars_escaped"),
+        ],
+    )
+    def test_detects_brands(self, text, expected_brands):
+        result = detect_brands_from_text(text)
+        for brand in expected_brands:
+            assert brand in result
 
 
 # ── detect_commodities_from_text ─────────────────────────────────────
 
 
 class TestDetectCommoditiesFromText:
-    def test_empty_text(self):
-        assert detect_commodities_from_text("") == []
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            pytest.param("", [], id="empty_text"),
+            pytest.param(None, [], id="none_text"),
+            pytest.param("hello world foo bar", [], id="no_match"),
+        ],
+    )
+    def test_returns_empty(self, text, expected):
+        assert detect_commodities_from_text(text) == expected
 
-    def test_none_text(self):
-        assert detect_commodities_from_text(None) == []
-
-    def test_single_commodity(self):
-        result = detect_commodities_from_text("DDR4 SDRAM module 16GB")
-        assert "dram" in result
-
-    def test_multiple_commodities(self):
-        result = detect_commodities_from_text("SSD and DDR SDRAM module")
-        assert "dram" in result
-        assert "ssd" in result
+    @pytest.mark.parametrize(
+        "text,expected_commodities",
+        [
+            pytest.param("DDR4 SDRAM module 16GB", ["dram"], id="single_commodity"),
+            pytest.param("SSD and DDR SDRAM module", ["dram", "ssd"], id="multiple_commodities"),
+        ],
+    )
+    def test_detects_commodities(self, text, expected_commodities):
+        result = detect_commodities_from_text(text)
+        for commodity in expected_commodities:
+            assert commodity in result
 
     def test_sorted_output(self):
         result = detect_commodities_from_text("resistor and capacitor and inductor")
@@ -82,10 +87,6 @@ class TestDetectCommoditiesFromText:
         """Multiple keywords mapping to same category should not duplicate."""
         result = detect_commodities_from_text("ddr sdram dimm rdimm")
         assert result.count("dram") == 1
-
-    def test_no_match(self):
-        result = detect_commodities_from_text("hello world foo bar")
-        assert result == []
 
 
 # ── analyze_vendor_specialties (DB tests) ────────────────────────────

--- a/tests/test_sprint7_email_integration.py
+++ b/tests/test_sprint7_email_integration.py
@@ -8,6 +8,7 @@ Called by: pytest
 Depends on: conftest.py fixtures, app.routers.htmx_views
 """
 
+import pytest
 from fastapi.testclient import TestClient
 
 # ── Email Thread Viewer ──────────────────────────────────────────────
@@ -28,18 +29,17 @@ class TestThreadViewer:
 
 
 class TestEmailReply:
-    def test_reply_missing_fields(self, client: TestClient):
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({"to": "", "body": ""}, id="missing_fields"),
+            pytest.param({"to": "john@arrow.com", "body": ""}, id="missing_body"),
+        ],
+    )
+    def test_reply_rejects_incomplete(self, client: TestClient, data):
         resp = client.post(
             "/v2/partials/emails/reply",
-            data={"to": "", "body": ""},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 400
-
-    def test_reply_missing_body(self, client: TestClient):
-        resp = client.post(
-            "/v2/partials/emails/reply",
-            data={"to": "john@arrow.com", "body": ""},
+            data=data,
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 400

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -32,6 +32,50 @@ def _make_sqlite_engine():
     )
 
 
+_CREATE_REQUIREMENTS = "CREATE TABLE requirements (id INTEGER PRIMARY KEY, primary_mpn TEXT, normalized_mpn TEXT)"
+_CREATE_MATERIAL_CARDS = "CREATE TABLE material_cards (id INTEGER PRIMARY KEY, display_mpn TEXT, normalized_mpn TEXT)"
+_CREATE_MPN_SIGHTINGS = "CREATE TABLE sightings (id INTEGER PRIMARY KEY, mpn_matched TEXT, normalized_mpn TEXT)"
+_CREATE_OFFERS = "CREATE TABLE offers (id INTEGER PRIMARY KEY, mpn TEXT, normalized_mpn TEXT)"
+_CREATE_VENDOR_SIGHTINGS = (
+    "CREATE TABLE sightings (id INTEGER PRIMARY KEY, vendor_name TEXT, vendor_name_normalized TEXT)"
+)
+
+
+def _mock_engine_conn(mock_engine):
+    """Wire a mock engine so ``engine.connect()`` yields a context-manager conn."""
+    mock_conn = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_engine.connect.return_value = mock_conn
+    return mock_conn
+
+
+def _make_proactive_offer_engine(offer_insert_sql, offer_params=None):
+    """SQLite engine with proactive_matches/requirements/proactive_offers seeded.
+
+    Requirement id=1 has target_qty=50 and proactive_match id=10. The single
+    proactive_offers row is inserted via the caller-supplied statement/params.
+    """
+    eng = _make_sqlite_engine()
+    with eng.connect() as conn:
+        conn.execute(sqltext("CREATE TABLE proactive_matches (id INTEGER PRIMARY KEY, requirement_id INTEGER)"))
+        conn.execute(sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, target_qty INTEGER)"))
+        conn.execute(
+            sqltext(
+                "CREATE TABLE proactive_offers "
+                "(id INTEGER PRIMARY KEY, line_items TEXT, total_sell REAL, total_cost REAL)"
+            )
+        )
+        conn.execute(sqltext("INSERT INTO requirements (id, target_qty) VALUES (1, 50)"))
+        conn.execute(sqltext("INSERT INTO proactive_matches (id, requirement_id) VALUES (10, 1)"))
+        if offer_params is None:
+            conn.execute(sqltext(offer_insert_sql))
+        else:
+            conn.execute(sqltext(offer_insert_sql), offer_params)
+        conn.commit()
+    return eng
+
+
 class TestStartupGuard:
     def test_testing_mode_skips_migrations(self):
         """TESTING=1 -> run_startup_migrations does nothing."""
@@ -40,26 +84,23 @@ class TestStartupGuard:
 
 
 class TestExec:
-    def test_pg_ddl_fails_on_sqlite_gracefully(self, db_session):
-        """PG-specific DDL fails on SQLite but _exec swallows the error."""
+    @pytest.mark.parametrize(
+        ("sql", "params"),
+        [
+            pytest.param("CREATE EXTENSION IF NOT EXISTS pg_trgm", None, id="pg_ddl_fails_gracefully"),
+            pytest.param("SELECT 1", None, id="success"),
+            pytest.param("SELECT :val", {"val": 42}, id="with_params"),
+        ],
+    )
+    def test_exec_handles_statement(self, db_session, sql, params):
+        """_exec runs valid SQLite statements and swallows PG-only DDL errors."""
         from tests.conftest import engine
 
         with engine.connect() as conn:
-            _exec(conn, "CREATE EXTENSION IF NOT EXISTS pg_trgm")
-
-    def test_exec_success(self, db_session):
-        """_exec succeeds with a valid SQLite statement."""
-        from tests.conftest import engine
-
-        with engine.connect() as conn:
-            _exec(conn, "SELECT 1")
-
-    def test_exec_with_params(self, db_session):
-        """_exec passes params correctly."""
-        from tests.conftest import engine
-
-        with engine.connect() as conn:
-            _exec(conn, "SELECT :val", {"val": 42})
+            if params is None:
+                _exec(conn, sql)
+            else:
+                _exec(conn, sql, params)
 
 
 class TestCreateDefaultUser:
@@ -265,10 +306,7 @@ class TestBackfillProactiveOfferQty:
         """When no matches have target_qty, returns early."""
         from app.startup import _backfill_proactive_offer_qty
 
-        mock_conn = MagicMock()
-        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
-        mock_conn.__exit__ = MagicMock(return_value=False)
-        mock_engine.connect.return_value = mock_conn
+        mock_conn = _mock_engine_conn(mock_engine)
         mock_conn.execute.return_value.fetchall.return_value = []
 
         _backfill_proactive_offer_qty()
@@ -277,14 +315,9 @@ class TestBackfillProactiveOfferQty:
     @patch("app.startup.engine")
     def test_fixes_offer_quantities(self, mock_engine, db_session):
         """Recalculates offer totals when target_qty < qty_available."""
-        import json
-
         from app.startup import _backfill_proactive_offer_qty
 
-        mock_conn = MagicMock()
-        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
-        mock_conn.__exit__ = MagicMock(return_value=False)
-        mock_engine.connect.return_value = mock_conn
+        mock_conn = _mock_engine_conn(mock_engine)
 
         match_rows = [(10, 50)]
         line_items = json.dumps([{"match_id": 10, "qty": 100, "sell_price": 1.0, "unit_price": 0.5}])
@@ -298,14 +331,9 @@ class TestBackfillProactiveOfferQty:
     @patch("app.startup.engine")
     def test_no_change_when_qty_matches(self, mock_engine, db_session):
         """No UPDATE when qty already <= target_qty."""
-        import json
-
         from app.startup import _backfill_proactive_offer_qty
 
-        mock_conn = MagicMock()
-        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
-        mock_conn.__exit__ = MagicMock(return_value=False)
-        mock_engine.connect.return_value = mock_conn
+        mock_conn = _mock_engine_conn(mock_engine)
 
         match_rows = [(10, 100)]
         line_items = json.dumps([{"match_id": 10, "qty": 50, "sell_price": 1.0, "unit_price": 0.5}])
@@ -324,10 +352,7 @@ class TestBackfillProactiveOfferQty:
 
         from app.startup import _backfill_proactive_offer_qty
 
-        mock_conn = MagicMock()
-        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
-        mock_conn.__exit__ = MagicMock(return_value=False)
-        mock_engine.connect.return_value = mock_conn
+        mock_conn = _mock_engine_conn(mock_engine)
         mock_conn.execute.side_effect = OperationalError("select", {}, Exception("DB gone"))
         mock_conn.rollback = MagicMock()
 
@@ -337,22 +362,9 @@ class TestBackfillProactiveOfferQty:
         """Offers with null line_items are skipped."""
         from app.startup import _backfill_proactive_offer_qty
 
-        eng = _make_sqlite_engine()
-        with eng.connect() as conn:
-            conn.execute(sqltext("CREATE TABLE proactive_matches (id INTEGER PRIMARY KEY, requirement_id INTEGER)"))
-            conn.execute(sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, target_qty INTEGER)"))
-            conn.execute(
-                sqltext(
-                    "CREATE TABLE proactive_offers "
-                    "(id INTEGER PRIMARY KEY, line_items TEXT, total_sell REAL, total_cost REAL)"
-                )
-            )
-            conn.execute(sqltext("INSERT INTO requirements (id, target_qty) VALUES (1, 50)"))
-            conn.execute(sqltext("INSERT INTO proactive_matches (id, requirement_id) VALUES (10, 1)"))
-            conn.execute(
-                sqltext("INSERT INTO proactive_offers (id, line_items, total_sell, total_cost) VALUES (1, NULL, 0, 0)")
-            )
-            conn.commit()
+        eng = _make_proactive_offer_engine(
+            "INSERT INTO proactive_offers (id, line_items, total_sell, total_cost) VALUES (1, NULL, 0, 0)"
+        )
 
         with patch("app.startup.engine", eng):
             _backfill_proactive_offer_qty()
@@ -361,34 +373,19 @@ class TestBackfillProactiveOfferQty:
         """Line items with match_id not in target_map use original qty."""
         from app.startup import _backfill_proactive_offer_qty
 
-        eng = _make_sqlite_engine()
-        with eng.connect() as conn:
-            conn.execute(sqltext("CREATE TABLE proactive_matches (id INTEGER PRIMARY KEY, requirement_id INTEGER)"))
-            conn.execute(sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, target_qty INTEGER)"))
-            conn.execute(
-                sqltext(
-                    "CREATE TABLE proactive_offers "
-                    "(id INTEGER PRIMARY KEY, line_items TEXT, total_sell REAL, total_cost REAL)"
-                )
-            )
-            conn.execute(sqltext("INSERT INTO requirements (id, target_qty) VALUES (1, 50)"))
-            conn.execute(sqltext("INSERT INTO proactive_matches (id, requirement_id) VALUES (10, 1)"))
-            items = json.dumps(
-                [
-                    {
-                        "match_id": 999,
-                        "qty": 200,
-                        "unit_price": 5.0,
-                    }
-                ]
-            )
-            conn.execute(
-                sqltext(
-                    "INSERT INTO proactive_offers (id, line_items, total_sell, total_cost) VALUES (1, :items, 1000, 1000)"
-                ),
-                {"items": items},
-            )
-            conn.commit()
+        items = json.dumps(
+            [
+                {
+                    "match_id": 999,
+                    "qty": 200,
+                    "unit_price": 5.0,
+                }
+            ]
+        )
+        eng = _make_proactive_offer_engine(
+            "INSERT INTO proactive_offers (id, line_items, total_sell, total_cost) VALUES (1, :items, 1000, 1000)",
+            {"items": items},
+        )
 
         with patch("app.startup.engine", eng):
             _backfill_proactive_offer_qty()
@@ -401,35 +398,20 @@ class TestBackfillProactiveOfferQty:
         """Offers with qty > target_qty get corrected (real SQLite tables)."""
         from app.startup import _backfill_proactive_offer_qty
 
-        eng = _make_sqlite_engine()
-        with eng.connect() as conn:
-            conn.execute(sqltext("CREATE TABLE proactive_matches (id INTEGER PRIMARY KEY, requirement_id INTEGER)"))
-            conn.execute(sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, target_qty INTEGER)"))
-            conn.execute(
-                sqltext(
-                    "CREATE TABLE proactive_offers "
-                    "(id INTEGER PRIMARY KEY, line_items TEXT, total_sell REAL, total_cost REAL)"
-                )
-            )
-            conn.execute(sqltext("INSERT INTO requirements (id, target_qty) VALUES (1, 50)"))
-            conn.execute(sqltext("INSERT INTO proactive_matches (id, requirement_id) VALUES (10, 1)"))
-            items = json.dumps(
-                [
-                    {
-                        "match_id": 10,
-                        "qty": 200,
-                        "unit_price": 5.0,
-                        "sell_price": 7.0,
-                    }
-                ]
-            )
-            conn.execute(
-                sqltext(
-                    "INSERT INTO proactive_offers (id, line_items, total_sell, total_cost) VALUES (1, :items, 1400, 1000)"
-                ),
-                {"items": items},
-            )
-            conn.commit()
+        items = json.dumps(
+            [
+                {
+                    "match_id": 10,
+                    "qty": 200,
+                    "unit_price": 5.0,
+                    "sell_price": 7.0,
+                }
+            ]
+        )
+        eng = _make_proactive_offer_engine(
+            "INSERT INTO proactive_offers (id, line_items, total_sell, total_cost) VALUES (1, :items, 1400, 1000)",
+            {"items": items},
+        )
 
         with patch("app.startup.engine", eng):
             _backfill_proactive_offer_qty()
@@ -601,12 +583,8 @@ class TestBackfillNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, primary_mpn TEXT, normalized_mpn TEXT)")
-            )
-            conn.execute(
-                sqltext("CREATE TABLE material_cards (id INTEGER PRIMARY KEY, display_mpn TEXT, normalized_mpn TEXT)")
-            )
+            conn.execute(sqltext(_CREATE_REQUIREMENTS))
+            conn.execute(sqltext(_CREATE_MATERIAL_CARDS))
             conn.execute(
                 sqltext("INSERT INTO requirements (id, primary_mpn, normalized_mpn) VALUES (1, 'LM-317T', NULL)")
             )
@@ -627,9 +605,7 @@ class TestBackfillNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE material_cards (id INTEGER PRIMARY KEY, display_mpn TEXT, normalized_mpn TEXT)")
-            )
+            conn.execute(sqltext(_CREATE_MATERIAL_CARDS))
             conn.commit()
         with patch("app.startup.engine", eng):
             _backfill_normalized_mpn()
@@ -639,9 +615,7 @@ class TestBackfillNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, primary_mpn TEXT, normalized_mpn TEXT)")
-            )
+            conn.execute(sqltext(_CREATE_REQUIREMENTS))
             conn.commit()
         with patch("app.startup.engine", eng):
             _backfill_normalized_mpn()
@@ -651,12 +625,8 @@ class TestBackfillNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, primary_mpn TEXT, normalized_mpn TEXT)")
-            )
-            conn.execute(
-                sqltext("CREATE TABLE material_cards (id INTEGER PRIMARY KEY, display_mpn TEXT, normalized_mpn TEXT)")
-            )
+            conn.execute(sqltext(_CREATE_REQUIREMENTS))
+            conn.execute(sqltext(_CREATE_MATERIAL_CARDS))
             conn.execute(sqltext("INSERT INTO requirements (id, primary_mpn, normalized_mpn) VALUES (1, '---', NULL)"))
             conn.execute(
                 sqltext("INSERT INTO material_cards (id, display_mpn, normalized_mpn) VALUES (1, '---', NULL)")
@@ -673,12 +643,8 @@ class TestBackfillNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, primary_mpn TEXT, normalized_mpn TEXT)")
-            )
-            conn.execute(
-                sqltext("CREATE TABLE material_cards (id INTEGER PRIMARY KEY, display_mpn TEXT, normalized_mpn TEXT)")
-            )
+            conn.execute(sqltext(_CREATE_REQUIREMENTS))
+            conn.execute(sqltext(_CREATE_MATERIAL_CARDS))
             conn.execute(
                 sqltext("INSERT INTO material_cards (id, display_mpn, normalized_mpn) VALUES (1, 'LM317T', 'lm317t')")
             )
@@ -697,12 +663,8 @@ class TestBackfillNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, primary_mpn TEXT, normalized_mpn TEXT)")
-            )
-            conn.execute(
-                sqltext("CREATE TABLE material_cards (id INTEGER PRIMARY KEY, display_mpn TEXT, normalized_mpn TEXT)")
-            )
+            conn.execute(sqltext(_CREATE_REQUIREMENTS))
+            conn.execute(sqltext(_CREATE_MATERIAL_CARDS))
             conn.execute(
                 sqltext("INSERT INTO requirements (id, primary_mpn, normalized_mpn) VALUES (1, 'LM317T', 'lm317t')")
             )
@@ -716,12 +678,8 @@ class TestBackfillNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE requirements (id INTEGER PRIMARY KEY, primary_mpn TEXT, normalized_mpn TEXT)")
-            )
-            conn.execute(
-                sqltext("CREATE TABLE material_cards (id INTEGER PRIMARY KEY, display_mpn TEXT, normalized_mpn TEXT)")
-            )
+            conn.execute(sqltext(_CREATE_REQUIREMENTS))
+            conn.execute(sqltext(_CREATE_MATERIAL_CARDS))
             conn.execute(sqltext("INSERT INTO requirements (id, primary_mpn, normalized_mpn) VALUES (1, '', NULL)"))
             conn.execute(sqltext("INSERT INTO material_cards (id, display_mpn, normalized_mpn) VALUES (1, '', NULL)"))
             conn.commit()
@@ -788,10 +746,8 @@ class TestBackfillSightingOfferNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE sightings (id INTEGER PRIMARY KEY, mpn_matched TEXT, normalized_mpn TEXT)")
-            )
-            conn.execute(sqltext("CREATE TABLE offers (id INTEGER PRIMARY KEY, mpn TEXT, normalized_mpn TEXT)"))
+            conn.execute(sqltext(_CREATE_MPN_SIGHTINGS))
+            conn.execute(sqltext(_CREATE_OFFERS))
             conn.execute(sqltext("INSERT INTO sightings (id, mpn_matched, normalized_mpn) VALUES (1, 'LM-317T', NULL)"))
             conn.execute(
                 sqltext("INSERT INTO sightings (id, mpn_matched, normalized_mpn) VALUES (2, 'RC-0805 FR', NULL)")
@@ -819,10 +775,8 @@ class TestBackfillSightingOfferNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE sightings (id INTEGER PRIMARY KEY, mpn_matched TEXT, normalized_mpn TEXT)")
-            )
-            conn.execute(sqltext("CREATE TABLE offers (id INTEGER PRIMARY KEY, mpn TEXT, normalized_mpn TEXT)"))
+            conn.execute(sqltext(_CREATE_MPN_SIGHTINGS))
+            conn.execute(sqltext(_CREATE_OFFERS))
             conn.execute(sqltext("INSERT INTO sightings (id, mpn_matched, normalized_mpn) VALUES (1, '  ', NULL)"))
             conn.execute(sqltext("INSERT INTO offers (id, mpn, normalized_mpn) VALUES (1, '---', NULL)"))
             conn.commit()
@@ -842,10 +796,8 @@ class TestBackfillSightingOfferNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE sightings (id INTEGER PRIMARY KEY, mpn_matched TEXT, normalized_mpn TEXT)")
-            )
-            conn.execute(sqltext("CREATE TABLE offers (id INTEGER PRIMARY KEY, mpn TEXT, normalized_mpn TEXT)"))
+            conn.execute(sqltext(_CREATE_MPN_SIGHTINGS))
+            conn.execute(sqltext(_CREATE_OFFERS))
             conn.execute(sqltext("INSERT INTO sightings (id, mpn_matched, normalized_mpn) VALUES (1, '!!!', NULL)"))
             conn.execute(sqltext("INSERT INTO offers (id, mpn, normalized_mpn) VALUES (1, '!!!', NULL)"))
             conn.commit()
@@ -865,10 +817,8 @@ class TestBackfillSightingOfferNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE sightings (id INTEGER PRIMARY KEY, mpn_matched TEXT, normalized_mpn TEXT)")
-            )
-            conn.execute(sqltext("CREATE TABLE offers (id INTEGER PRIMARY KEY, mpn TEXT, normalized_mpn TEXT)"))
+            conn.execute(sqltext(_CREATE_MPN_SIGHTINGS))
+            conn.execute(sqltext(_CREATE_OFFERS))
             conn.execute(
                 sqltext("INSERT INTO sightings (id, mpn_matched, normalized_mpn) VALUES (1, 'LM317', 'lm317')")
             )
@@ -884,7 +834,7 @@ class TestBackfillSightingOfferNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(sqltext("CREATE TABLE offers (id INTEGER PRIMARY KEY, mpn TEXT, normalized_mpn TEXT)"))
+            conn.execute(sqltext(_CREATE_OFFERS))
             conn.execute(sqltext("INSERT INTO offers (id, mpn, normalized_mpn) VALUES (1, 'LM317', NULL)"))
             conn.commit()
 
@@ -901,9 +851,7 @@ class TestBackfillSightingOfferNormalizedMpn:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext("CREATE TABLE sightings (id INTEGER PRIMARY KEY, mpn_matched TEXT, normalized_mpn TEXT)")
-            )
+            conn.execute(sqltext(_CREATE_MPN_SIGHTINGS))
             conn.execute(sqltext("INSERT INTO sightings (id, mpn_matched, normalized_mpn) VALUES (1, 'LM317', NULL)"))
             conn.commit()
 
@@ -924,11 +872,7 @@ class TestBackfillSightingVendorNormalized:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext(
-                    "CREATE TABLE sightings (id INTEGER PRIMARY KEY, vendor_name TEXT, vendor_name_normalized TEXT)"
-                )
-            )
+            conn.execute(sqltext(_CREATE_VENDOR_SIGHTINGS))
             conn.execute(
                 sqltext("INSERT INTO sightings (id, vendor_name, vendor_name_normalized) VALUES (1, 'Acme Inc.', NULL)")
             )
@@ -970,11 +914,7 @@ class TestBackfillSightingVendorNormalized:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext(
-                    "CREATE TABLE sightings (id INTEGER PRIMARY KEY, vendor_name TEXT, vendor_name_normalized TEXT)"
-                )
-            )
+            conn.execute(sqltext(_CREATE_VENDOR_SIGHTINGS))
             conn.execute(
                 sqltext("INSERT INTO sightings (id, vendor_name, vendor_name_normalized) VALUES (1, 'Acme', 'acme')")
             )
@@ -992,11 +932,7 @@ class TestBackfillSightingVendorNormalized:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext(
-                    "CREATE TABLE sightings (id INTEGER PRIMARY KEY, vendor_name TEXT, vendor_name_normalized TEXT)"
-                )
-            )
+            conn.execute(sqltext(_CREATE_VENDOR_SIGHTINGS))
             conn.execute(
                 sqltext("INSERT INTO sightings (id, vendor_name, vendor_name_normalized) VALUES (1, '???', NULL)")
             )
@@ -1027,11 +963,7 @@ class TestBackfillSightingVendorNormalized:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext(
-                    "CREATE TABLE sightings (id INTEGER PRIMARY KEY, vendor_name TEXT, vendor_name_normalized TEXT)"
-                )
-            )
+            conn.execute(sqltext(_CREATE_VENDOR_SIGHTINGS))
             conn.execute(
                 sqltext("INSERT INTO sightings (id, vendor_name, vendor_name_normalized) VALUES (1, 'Acme', NULL)")
             )
@@ -1056,11 +988,7 @@ class TestBackfillSightingVendorNormalized:
 
         eng = _make_sqlite_engine()
         with eng.connect() as conn:
-            conn.execute(
-                sqltext(
-                    "CREATE TABLE sightings (id INTEGER PRIMARY KEY, vendor_name TEXT, vendor_name_normalized TEXT)"
-                )
-            )
+            conn.execute(sqltext(_CREATE_VENDOR_SIGHTINGS))
             conn.execute(
                 sqltext("INSERT INTO sightings (id, vendor_name, vendor_name_normalized) VALUES (1, 'Acme', NULL)")
             )

--- a/tests/test_teams_notifications.py
+++ b/tests/test_teams_notifications.py
@@ -7,11 +7,24 @@ Called by: pytest
 Depends on: app.services.teams_notifications, unittest.mock
 """
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from loguru import logger
+
+
+@contextmanager
+def _capture_logs(level):
+    """Capture loguru messages at the given level into a list yielded to the caller."""
+    captured = []
+    sink_id = logger.add(lambda msg: captured.append(str(msg)), level=level)
+    try:
+        yield captured
+    finally:
+        logger.remove(sink_id)
+
 
 # ---------------------------------------------------------------------------
 # post_teams_channel
@@ -21,9 +34,7 @@ from loguru import logger
 @pytest.mark.asyncio
 async def test_post_teams_channel_skips_when_no_webhook():
     """Silently returns when TEAMS_WEBHOOK_URL is not configured."""
-    captured = []
-    sink_id = logger.add(lambda msg: captured.append(str(msg)), level="DEBUG")
-    try:
+    with _capture_logs("DEBUG") as captured:
         with patch(
             "app.services.teams_notifications.get_credential_cached",
             return_value=None,
@@ -32,8 +43,6 @@ async def test_post_teams_channel_skips_when_no_webhook():
 
             await post_teams_channel("hello")
         assert any("not configured" in m for m in captured)
-    finally:
-        logger.remove(sink_id)
 
 
 @pytest.mark.asyncio
@@ -70,9 +79,7 @@ async def test_post_teams_channel_accepts_202():
     """202 Accepted is also treated as success (no warning logged)."""
     mock_resp = MagicMock(status_code=202, text="accepted")
     mock_http_post = AsyncMock(return_value=mock_resp)
-    captured = []
-    sink_id = logger.add(lambda msg: captured.append(str(msg)), level="WARNING")
-    try:
+    with _capture_logs("WARNING") as captured:
         with (
             patch(
                 "app.services.teams_notifications.get_credential_cached",
@@ -86,8 +93,6 @@ async def test_post_teams_channel_accepts_202():
             await post_teams_channel("test 202")
 
         assert not any("webhook returned" in m for m in captured)
-    finally:
-        logger.remove(sink_id)
 
 
 @pytest.mark.asyncio
@@ -95,9 +100,7 @@ async def test_post_teams_channel_logs_warning_on_bad_status():
     """Non-200/202 status codes are logged as warnings."""
     mock_resp = MagicMock(status_code=400, text="Bad Request")
     mock_http_post = AsyncMock(return_value=mock_resp)
-    captured = []
-    sink_id = logger.add(lambda msg: captured.append(str(msg)), level="WARNING")
-    try:
+    with _capture_logs("WARNING") as captured:
         with (
             patch(
                 "app.services.teams_notifications.get_credential_cached",
@@ -111,17 +114,13 @@ async def test_post_teams_channel_logs_warning_on_bad_status():
             await post_teams_channel("fail")
 
         assert any("webhook returned" in m for m in captured)
-    finally:
-        logger.remove(sink_id)
 
 
 @pytest.mark.asyncio
 async def test_post_teams_channel_catches_exception():
     """Network errors are caught and logged, not raised."""
     mock_http_post = AsyncMock(side_effect=ConnectionError("network down"))
-    captured = []
-    sink_id = logger.add(lambda msg: captured.append(str(msg)), level="ERROR")
-    try:
+    with _capture_logs("ERROR") as captured:
         with (
             patch(
                 "app.services.teams_notifications.get_credential_cached",
@@ -135,8 +134,6 @@ async def test_post_teams_channel_catches_exception():
             await post_teams_channel("boom")
 
         assert any("channel post failed" in m for m in captured)
-    finally:
-        logger.remove(sink_id)
 
 
 # ---------------------------------------------------------------------------
@@ -153,15 +150,11 @@ def _make_user(email="buyer@trioscs.com", access_token="tok-123"):
 async def test_send_teams_dm_skips_no_token_no_db():
     """Skips DM when user has no access_token and no db session provided."""
     user = _make_user(access_token=None)
-    captured = []
-    sink_id = logger.add(lambda msg: captured.append(str(msg)), level="DEBUG")
-    try:
+    with _capture_logs("DEBUG") as captured:
         from app.services.teams_notifications import send_teams_dm
 
         await send_teams_dm(user, "hello")
         assert any("No token" in m for m in captured)
-    finally:
-        logger.remove(sink_id)
 
 
 @pytest.mark.asyncio
@@ -169,9 +162,7 @@ async def test_send_teams_dm_skips_when_token_refresh_returns_none():
     """Skips DM when get_valid_token returns None (expired, no refresh)."""
     user = _make_user(access_token=None)
     mock_db = MagicMock()
-    captured = []
-    sink_id = logger.add(lambda msg: captured.append(str(msg)), level="DEBUG")
-    try:
+    with _capture_logs("DEBUG") as captured:
         with (
             patch(
                 "app.services.teams_notifications.GraphClient",
@@ -187,8 +178,6 @@ async def test_send_teams_dm_skips_when_token_refresh_returns_none():
 
             await send_teams_dm(user, "hello", db=mock_db)
         assert any("No valid token" in m for m in captured)
-    finally:
-        logger.remove(sink_id)
 
 
 @pytest.mark.asyncio
@@ -285,9 +274,7 @@ async def test_send_teams_dm_skips_message_when_no_chat_id():
 async def test_send_teams_dm_catches_exception():
     """Graph API errors are caught and logged as warnings."""
     user = _make_user()
-    captured = []
-    sink_id = logger.add(lambda msg: captured.append(str(msg)), level="WARNING")
-    try:
+    with _capture_logs("WARNING") as captured:
         with patch(
             "app.utils.graph_client.GraphClient",
             side_effect=RuntimeError("graph unavailable"),
@@ -297,5 +284,3 @@ async def test_send_teams_dm_catches_exception():
             await send_teams_dm(user, "boom")
 
         assert any("failed" in m and "Chat permissions" in m for m in captured)
-    finally:
-        logger.remove(sink_id)

--- a/tests/test_ticket_coordination.py
+++ b/tests/test_ticket_coordination.py
@@ -40,6 +40,24 @@ def admin_client(db_session: Session, admin_user: User) -> TestClient:
             app.dependency_overrides.pop(dep, None)
 
 
+def _add_report_button_ticket(
+    db_session: Session, *, ticket_number: str, title: str, description: str
+) -> TroubleTicket:
+    """Persist a report-button trouble ticket and return it."""
+    ticket = TroubleTicket(
+        ticket_number=ticket_number,
+        submitted_by=1,
+        title=title,
+        description=description,
+        source="report_button",
+        status="submitted",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(ticket)
+    db_session.commit()
+    return ticket
+
+
 def test_create_ticket(admin_client):
     """Submit a trouble ticket via POST."""
     resp = admin_client.post(
@@ -61,17 +79,12 @@ def test_list_tickets_empty(admin_client):
 
 def test_list_tickets_with_data(admin_client, db_session):
     """List returns tickets created via the report button."""
-    t = TroubleTicket(
+    _add_report_button_ticket(
+        db_session,
         ticket_number="TT-COORD-001",
-        submitted_by=1,
         title="Test ticket",
         description="Test description",
-        source="report_button",
-        status="submitted",
-        created_at=datetime.now(timezone.utc),
     )
-    db_session.add(t)
-    db_session.commit()
     resp = admin_client.get("/api/trouble-tickets")
     assert resp.status_code == 200
     assert len(resp.json()["items"]) >= 1
@@ -79,17 +92,12 @@ def test_list_tickets_with_data(admin_client, db_session):
 
 def test_get_ticket_by_id(admin_client, db_session):
     """Get a single ticket by ID."""
-    t = TroubleTicket(
+    t = _add_report_button_ticket(
+        db_session,
         ticket_number="TT-COORD-002",
-        submitted_by=1,
         title="Detail test",
         description="Detail description",
-        source="report_button",
-        status="submitted",
-        created_at=datetime.now(timezone.utc),
     )
-    db_session.add(t)
-    db_session.commit()
     db_session.refresh(t)
 
     resp = admin_client.get(f"/api/trouble-tickets/{t.id}")

--- a/tests/test_trusted_domains.py
+++ b/tests/test_trusted_domains.py
@@ -1,18 +1,29 @@
+import pytest
+
 from app.services.enrichment_worker.trusted_domains import is_trusted_domain
 
 
-def test_authorized_distributor():
-    assert is_trusted_domain("https://www.digikey.com/en/products/detail/x")
-    assert is_trusted_domain("https://www.mouser.com/ProductDetail/x")
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param("https://www.digikey.com/en/products/detail/x", id="distributor-digikey"),
+        pytest.param("https://www.mouser.com/ProductDetail/x", id="distributor-mouser"),
+        pytest.param("https://www.ti.com/product/LM317", id="manufacturer-suffix-www"),
+        pytest.param("https://st.com/foo", id="manufacturer-apex"),
+    ],
+)
+def test_trusted_urls_accepted(url):
+    assert is_trusted_domain(url)
 
 
-def test_manufacturer_suffix():
-    assert is_trusted_domain("https://www.ti.com/product/LM317")
-    assert is_trusted_domain("https://st.com/foo")
-
-
-def test_rejects_lookalike_and_untrusted():
-    assert not is_trusted_domain("https://evil-st.com/foo")  # suffix spoof
-    assert not is_trusted_domain("https://www.ebay.com/itm/123")
-    assert not is_trusted_domain("ftp://www.ti.com/x")  # non-http
-    assert not is_trusted_domain("not a url")
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param("https://evil-st.com/foo", id="suffix-spoof"),
+        pytest.param("https://www.ebay.com/itm/123", id="untrusted-marketplace"),
+        pytest.param("ftp://www.ti.com/x", id="non-http-scheme"),
+        pytest.param("not a url", id="unparseable"),
+    ],
+)
+def test_untrusted_urls_rejected(url):
+    assert not is_trusted_domain(url)

--- a/tests/test_unmatched_activities.py
+++ b/tests/test_unmatched_activities.py
@@ -298,6 +298,18 @@ class TestUnmatchedEndpoints:
             )
         db_session.commit()
 
+    def _make_unmatched(self, db_session, user_id, email, ext_id):
+        a = ActivityLog(
+            user_id=user_id,
+            activity_type="email_received",
+            channel="email",
+            contact_email=email,
+            external_id=ext_id,
+        )
+        db_session.add(a)
+        db_session.commit()
+        return a
+
     def test_list_unmatched_admin(self, admin_client, db_session, admin_user):
         self._seed_unmatched(db_session, admin_user.id)
 
@@ -314,15 +326,7 @@ class TestUnmatchedEndpoints:
         assert resp.status_code == 403
 
     def test_attribute_endpoint(self, admin_client, db_session, admin_user, test_company):
-        a = ActivityLog(
-            user_id=admin_user.id,
-            activity_type="email_received",
-            channel="email",
-            contact_email="x@y.com",
-            external_id="attr-api-1",
-        )
-        db_session.add(a)
-        db_session.commit()
+        a = self._make_unmatched(db_session, admin_user.id, "x@y.com", "attr-api-1")
 
         resp = admin_client.post(
             f"/api/activities/{a.id}/attribute",
@@ -341,15 +345,7 @@ class TestUnmatchedEndpoints:
         assert resp.status_code == 404
 
     def test_attribute_nonexistent_company(self, admin_client, db_session, admin_user):
-        a = ActivityLog(
-            user_id=admin_user.id,
-            activity_type="email_received",
-            channel="email",
-            contact_email="x@y.com",
-            external_id="attr-api-2",
-        )
-        db_session.add(a)
-        db_session.commit()
+        a = self._make_unmatched(db_session, admin_user.id, "x@y.com", "attr-api-2")
 
         resp = admin_client.post(
             f"/api/activities/{a.id}/attribute",
@@ -358,15 +354,7 @@ class TestUnmatchedEndpoints:
         assert resp.status_code == 404
 
     def test_dismiss_endpoint(self, admin_client, db_session, admin_user):
-        a = ActivityLog(
-            user_id=admin_user.id,
-            activity_type="email_received",
-            channel="email",
-            contact_email="dismiss@y.com",
-            external_id="dis-api-1",
-        )
-        db_session.add(a)
-        db_session.commit()
+        a = self._make_unmatched(db_session, admin_user.id, "dismiss@y.com", "dis-api-1")
 
         resp = admin_client.post(f"/api/activities/{a.id}/dismiss")
         assert resp.status_code == 200
@@ -381,29 +369,13 @@ class TestUnmatchedEndpoints:
         assert resp.status_code == 404
 
     def test_dismiss_non_admin_forbidden(self, buyer_client, db_session, test_user):
-        a = ActivityLog(
-            user_id=test_user.id,
-            activity_type="email_received",
-            channel="email",
-            contact_email="x@y.com",
-            external_id="dis-api-buyer",
-        )
-        db_session.add(a)
-        db_session.commit()
+        a = self._make_unmatched(db_session, test_user.id, "x@y.com", "dis-api-buyer")
 
         resp = buyer_client.post(f"/api/activities/{a.id}/dismiss")
         assert resp.status_code == 403
 
     def test_activity_to_dict_includes_dismissed_at(self, admin_client, db_session, admin_user):
-        a = ActivityLog(
-            user_id=admin_user.id,
-            activity_type="email_received",
-            channel="email",
-            contact_email="dict@y.com",
-            external_id="dict-1",
-        )
-        db_session.add(a)
-        db_session.commit()
+        self._make_unmatched(db_session, admin_user.id, "dict@y.com", "dict-1")
 
         resp = admin_client.get("/api/activities/unmatched")
         item = resp.json()["items"][0]

--- a/tests/test_vendor_name_normalized.py
+++ b/tests/test_vendor_name_normalized.py
@@ -9,6 +9,7 @@ Verifies:
 from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.models import (
@@ -205,8 +206,6 @@ def test_contact_query_by_normalized(db_session: Session, requisition, user):
     db_session.add(contact)
     db_session.commit()
 
-    from sqlalchemy import func
-
     # New pattern: direct equality on normalized column
     count = (
         db_session.query(func.count(Contact.id))
@@ -278,8 +277,6 @@ def test_engagement_scorer_uses_normalized(db_session: Session, requisition, use
             )
         )
     db_session.commit()
-
-    from sqlalchemy import func
 
     outreach = (
         db_session.query(func.count(Contact.id))


### PR DESCRIPTION
Part of the codebase-wide simplification program — **tests wave (4/8)**, full simplify (within-file only).

## What changed
- Copy-paste test functions differing only in data → `@pytest.mark.parametrize` (one case per original; IDs preserved).
- Repeated arrange/setup blocks → local helper functions / module-level fixtures **defined in the same file**.
- Removed exact-duplicate test functions and dead/commented tests.

`conftest.py` and all shared fixtures untouched; no assertion weakened; mock/patch targets unchanged.

## Verification (coverage preserved)
- ruff clean
- **Full suite: 16608 passed, 0 failed** (baseline 16,563). The collected/passed count *rises* where multi-assert tests were split into discrete parametrized cases — no test case was dropped (exact-duplicate removals are 1-for-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)