### PR TITLE
test(simplify 5/8): parametrize + dedup test setup

### DIFF
--- a/tests/routers/admin/test_spec_codes_pending.py
+++ b/tests/routers/admin/test_spec_codes_pending.py
@@ -281,7 +281,6 @@ def test_re_resolve_swaps_row_on_fresh_success(
     assert rows[0].proposed_avl[0]["mpn"] == "NEW_MPN"
     assert rows[0].llm_confidence == 0.91
     assert all(r.proposed_avl[0]["mpn"] != "GRM188R71H103KA01D" for r in rows)
-    assert rows[0].llm_confidence == 0.91
 
 
 def test_re_resolve_preserves_row_on_resolver_exception(

--- a/tests/test_acs_service_coverage.py
+++ b/tests/test_acs_service_coverage.py
@@ -10,22 +10,24 @@ os.environ["TESTING"] = "1"
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # ---------------------------------------------------------------------------
 # initiate_call
 # ---------------------------------------------------------------------------
 
 
-async def test_initiate_call_no_connection_string():
+@pytest.mark.parametrize(
+    ("from_phone", "connection_string"),
+    [
+        pytest.param("+15550009999", "", id="no_connection_string"),
+        pytest.param("", "endpoint=abc", id="no_from_phone"),
+    ],
+)
+async def test_initiate_call_missing_config(from_phone, connection_string):
     from app.services.acs_service import initiate_call
 
-    result = await initiate_call("+15550001234", "+15550009999", "https://cb.example.com/hook", "")
-    assert result is None
-
-
-async def test_initiate_call_no_from_phone():
-    from app.services.acs_service import initiate_call
-
-    result = await initiate_call("+15550001234", "", "https://cb.example.com/hook", "endpoint=abc")
+    result = await initiate_call("+15550001234", from_phone, "https://cb.example.com/hook", connection_string)
     assert result is None
 
 

--- a/tests/test_ai_service_extra_coverage.py
+++ b/tests/test_ai_service_extra_coverage.py
@@ -13,6 +13,8 @@ os.environ["TESTING"] = "1"
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from app.services.ai_service import (
     company_intel,
     draft_rfq,
@@ -24,22 +26,21 @@ from app.utils.claude_errors import ClaudeError, ClaudeUnavailableError
 class TestEnrichContactsWebsearchErrorPaths:
     """Cover lines 103-107, 126-128 — error handlers in enrich_contacts_websearch."""
 
-    async def test_claude_unavailable_returns_empty_list(self):
-        """ClaudeUnavailableError → returns [] (line 103-104)."""
+    @pytest.mark.parametrize(
+        ("exc", "kwargs"),
+        [
+            (ClaudeUnavailableError("not configured"), {}),
+            (ClaudeError("api error"), {"domain": "widget.com"}),
+        ],
+        ids=["claude_unavailable", "claude_error"],
+    )
+    async def test_claude_failure_returns_empty_list(self, exc, kwargs):
+        """ClaudeUnavailableError / ClaudeError → returns [] (lines 103-107)."""
         with patch(
             "app.services.ai_service.claude_json",
-            new=AsyncMock(side_effect=ClaudeUnavailableError("not configured")),
+            new=AsyncMock(side_effect=exc),
         ):
-            result = await enrich_contacts_websearch("Acme Corp")
-        assert result == []
-
-    async def test_claude_error_returns_empty_list(self):
-        """ClaudeError → returns [] (line 106-107)."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new=AsyncMock(side_effect=ClaudeError("api error")),
-        ):
-            result = await enrich_contacts_websearch("Widget Co", domain="widget.com")
+            result = await enrich_contacts_websearch("Acme Corp", **kwargs)
         assert result == []
 
     async def test_validation_error_falls_back_to_raw_contacts(self):
@@ -75,70 +76,64 @@ class TestEnrichContactsWebsearchErrorPaths:
         assert "Alice Chen" in names
         assert "Charlie" in names
 
-    async def test_domain_match_sets_medium_confidence(self):
-        """Email matching domain → confidence=medium (line 138-139)."""
-        raw_result = {"contacts": [{"full_name": "Jane Doe", "email": "jane@acme.com"}]}
+    @pytest.mark.parametrize(
+        ("contact", "kwargs", "expected_confidence"),
+        [
+            (
+                {"full_name": "Jane Doe", "email": "jane@acme.com"},
+                {"domain": "acme.com"},
+                "medium",
+            ),
+            (
+                {"full_name": "Jane Doe", "email": "jane@other.com"},
+                {"domain": "acme.com"},
+                "medium",
+            ),
+            (
+                {"full_name": "Tom Smith", "linkedin_url": "https://linkedin.com/in/tom"},
+                {},
+                "low",
+            ),
+        ],
+        ids=[
+            "domain_match_medium",
+            "email_without_domain_medium",
+            "linkedin_without_email_low",
+        ],
+    )
+    async def test_confidence_assignment(self, contact, kwargs, expected_confidence):
+        """Confidence is derived from email/domain/linkedin presence (lines 138-144)."""
+        raw_result = {"contacts": [contact]}
         with patch(
             "app.services.ai_service.claude_json",
             new=AsyncMock(return_value=raw_result),
         ):
-            result = await enrich_contacts_websearch("Acme", domain="acme.com")
-        assert result[0]["confidence"] == "medium"
-
-    async def test_email_without_domain_sets_medium_confidence(self):
-        """Email present but not matching domain → confidence=medium (line 141)."""
-        raw_result = {"contacts": [{"full_name": "Jane Doe", "email": "jane@other.com"}]}
-        with patch(
-            "app.services.ai_service.claude_json",
-            new=AsyncMock(return_value=raw_result),
-        ):
-            result = await enrich_contacts_websearch("Acme", domain="acme.com")
-        assert result[0]["confidence"] == "medium"
-
-    async def test_linkedin_without_email_stays_low_confidence(self):
-        """No email but linkedin → confidence=low (line 143-144)."""
-        raw_result = {
-            "contacts": [
-                {
-                    "full_name": "Tom Smith",
-                    "linkedin_url": "https://linkedin.com/in/tom",
-                }
-            ]
-        }
-        with patch(
-            "app.services.ai_service.claude_json",
-            new=AsyncMock(return_value=raw_result),
-        ):
-            result = await enrich_contacts_websearch("Parts Inc")
-        assert result[0]["confidence"] == "low"
+            result = await enrich_contacts_websearch("Acme", **kwargs)
+        assert result[0]["confidence"] == expected_confidence
 
 
 class TestCompanyIntelErrorPaths:
     """Cover lines 231-235, 242-243 — error handlers and validation failure in
     company_intel."""
 
-    async def test_claude_unavailable_returns_none(self):
-        """ClaudeUnavailableError → returns None (lines 231-232)."""
+    @pytest.mark.parametrize(
+        ("exc", "kwargs"),
+        [
+            (ClaudeUnavailableError("not configured"), {}),
+            (ClaudeError("api failure"), {"domain": "widget.com"}),
+        ],
+        ids=["claude_unavailable", "claude_error"],
+    )
+    async def test_claude_failure_returns_none(self, exc, kwargs):
+        """ClaudeUnavailableError / ClaudeError → returns None (lines 231-235)."""
         with (
             patch("app.cache.intel_cache.get_cached", return_value=None),
             patch(
                 "app.services.ai_service.claude_json",
-                new=AsyncMock(side_effect=ClaudeUnavailableError("not configured")),
+                new=AsyncMock(side_effect=exc),
             ),
         ):
-            result = await company_intel("Acme Corp")
-        assert result is None
-
-    async def test_claude_error_returns_none(self):
-        """ClaudeError → returns None (lines 234-235)."""
-        with (
-            patch("app.cache.intel_cache.get_cached", return_value=None),
-            patch(
-                "app.services.ai_service.claude_json",
-                new=AsyncMock(side_effect=ClaudeError("api failure")),
-            ),
-        ):
-            result = await company_intel("Widget Co", domain="widget.com")
+            result = await company_intel("Acme Corp", **kwargs)
         assert result is None
 
     async def test_validation_failure_falls_through_to_raw_dict(self):

--- a/tests/test_attachment_parser.py
+++ b/tests/test_attachment_parser.py
@@ -26,19 +26,15 @@ from app.services.attachment_parser import (
 class TestMatchHeadersDeterministic:
     """Tests for _match_headers_deterministic -- regex-based column mapping."""
 
-    def test_match_headers_standard(self):
-        """Standard headers map to the correct fields."""
-        headers = ["Part Number", "Manufacturer", "Qty", "Price"]
-        mapping = _match_headers_deterministic(headers)
-
-        assert mapping[0] == "mpn"
-        assert mapping[1] == "manufacturer"
-        assert mapping[2] == "qty"
-        assert mapping[3] == "unit_price"
-
-    def test_match_headers_alternates(self):
-        """Alternate header forms still resolve correctly."""
-        headers = ["MPN", "Mfg", "Quantity", "Unit Price"]
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            pytest.param(["Part Number", "Manufacturer", "Qty", "Price"], id="standard"),
+            pytest.param(["MPN", "Mfg", "Quantity", "Unit Price"], id="alternates"),
+        ],
+    )
+    def test_match_headers_resolves_standard_fields(self, headers):
+        """Standard and alternate header forms map to the correct fields."""
         mapping = _match_headers_deterministic(headers)
 
         assert mapping[0] == "mpn"

--- a/tests/test_buyplan_workflow.py
+++ b/tests/test_buyplan_workflow.py
@@ -11,7 +11,9 @@ Depends on: conftest fixtures, buyplan_workflow module
 """
 
 import asyncio
+from collections.abc import Awaitable
 from datetime import datetime, timedelta, timezone
+from typing import TypeVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -43,6 +45,17 @@ from app.services.buyplan_workflow import (
 )
 
 # ── Helpers ──────────────────────────────────────────────────────────
+
+_T = TypeVar("_T")
+
+
+def _run(coro: Awaitable[_T]) -> _T:
+    """Run an async coroutine to completion on a fresh event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _make_plan(db: Session, user: User, quote: Quote, requisition: Requisition, **overrides) -> BuyPlan:
@@ -1125,11 +1138,7 @@ class TestVerifyPOSent:
         _make_line(db_session, plan, po_number=None)
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent(plan, db_session))
 
         assert len(results) == 1
         assert results[0]["skipped"] is True
@@ -1141,11 +1150,7 @@ class TestVerifyPOSent:
         _make_line(db_session, plan, po_number="PO-TEST", buyer_id=None)
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent(plan, db_session))
 
         assert results[0]["reason"] == "no_buyer"
 
@@ -1157,11 +1162,7 @@ class TestVerifyPOSent:
         _make_line(db_session, plan, po_number="PO-TEST", buyer_id=test_user.id)
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent(plan, db_session))
 
         assert results[0]["reason"] == "no_token"
 
@@ -1187,11 +1188,7 @@ class TestVerifyPOSent:
         )
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent(plan, db_session))
 
         assert results[0]["found"] is True
         assert results[0]["message_count"] == 1
@@ -1215,11 +1212,7 @@ class TestVerifyPOSent:
         )
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent(plan, db_session))
 
         assert results[0]["found"] is False
 
@@ -1231,11 +1224,7 @@ class TestVerifyPOSent:
         _make_line(db_session, plan, po_number="PO-ERR", buyer_id=test_user.id)
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent(plan, db_session))
 
         assert results[0]["found"] is False
         assert "error" in results[0]
@@ -1251,11 +1240,7 @@ class TestVerifyPOSentV3:
         _make_line(db_session, plan, po_number=None, status=BuyPlanLineStatus.PENDING_VERIFY.value)
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent_v3(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent_v3(plan, db_session))
 
         assert results == {}
 
@@ -1266,11 +1251,7 @@ class TestVerifyPOSentV3:
         _make_line(db_session, plan, po_number="PO-1", status=BuyPlanLineStatus.AWAITING_PO.value)
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent_v3(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent_v3(plan, db_session))
 
         assert results == {}
 
@@ -1281,11 +1262,7 @@ class TestVerifyPOSentV3:
         _make_line(db_session, plan, po_number="PO-NB", buyer_id=None, status=BuyPlanLineStatus.PENDING_VERIFY.value)
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent_v3(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent_v3(plan, db_session))
 
         assert results["PO-NB"]["reason"] == "no_buyer"
 
@@ -1325,13 +1302,9 @@ class TestVerifyPOSentV3:
         )
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            # Patch at the v3 import location
-            with patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="mock-token"):
-                results = loop.run_until_complete(verify_po_sent_v3(plan, db_session))
-        finally:
-            loop.close()
+        # Patch at the v3 import location
+        with patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="mock-token"):
+            results = _run(verify_po_sent_v3(plan, db_session))
 
         assert results["PO-V3"]["verified"] is True
         assert results["PO-V3"]["recipient"] == "vendor@test.com"
@@ -1357,12 +1330,8 @@ class TestVerifyPOSentV3:
         )
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            with patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="mock-token"):
-                results = loop.run_until_complete(verify_po_sent_v3(plan, db_session))
-        finally:
-            loop.close()
+        with patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="mock-token"):
+            results = _run(verify_po_sent_v3(plan, db_session))
 
         assert results["PO-V3NF"]["verified"] is False
         assert results["PO-V3NF"]["reason"] == "not_found_in_sent"
@@ -1384,12 +1353,8 @@ class TestVerifyPOSentV3:
                 return None
             return original_get(model, ident, **kwargs)
 
-        loop = asyncio.new_event_loop()
-        try:
-            with patch.object(db_session, "get", side_effect=mock_get):
-                results = loop.run_until_complete(verify_po_sent_v3(plan, db_session))
-        finally:
-            loop.close()
+        with patch.object(db_session, "get", side_effect=mock_get):
+            results = _run(verify_po_sent_v3(plan, db_session))
 
         assert results["PO-BNF"]["reason"] == "buyer_not_found"
 
@@ -1414,11 +1379,7 @@ class TestVerifyPOSentV3:
         )
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent_v3(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent_v3(plan, db_session))
 
         assert results["PO-GE"]["verified"] is False
         assert "graph_error" in results["PO-GE"]["reason"]
@@ -1433,10 +1394,6 @@ class TestVerifyPOSentV3:
         )
         db_session.refresh(plan)
 
-        loop = asyncio.new_event_loop()
-        try:
-            results = loop.run_until_complete(verify_po_sent_v3(plan, db_session))
-        finally:
-            loop.close()
+        results = _run(verify_po_sent_v3(plan, db_session))
 
         assert results["PO-NT"]["reason"] == "no_token"

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -40,6 +40,15 @@ def _clean_breakers():
     _breakers.pop("_FakeConnector", None)
 
 
+def _trip_breaker(conn: "_FakeConnector", times: int = 5) -> None:
+    """Drive `times` failing searches so the connector's breaker opens."""
+    for _ in range(times):
+        try:
+            asyncio.run(conn.search("LM317T"))
+        except ConnectionError:
+            pass
+
+
 # ── CircuitBreaker unit tests ─────────────────────────────────────────
 
 
@@ -113,11 +122,7 @@ def test_connector_success_keeps_breaker_closed():
 def test_connector_opens_breaker_after_failures():
     """After 5 consecutive failures, connector breaker opens."""
     conn = _FakeConnector(fail=True)
-    for _ in range(5):
-        try:
-            asyncio.run(conn.search("LM317T"))
-        except ConnectionError:
-            pass
+    _trip_breaker(conn)
     assert conn._breaker.current_state == "open"
 
 
@@ -132,11 +137,7 @@ def test_open_breaker_raises_without_calling():
 
     conn = _FakeConnector(fail=True)
     # Trip the breaker (fail_max=5, max_retries=0 → 5 search calls)
-    for _ in range(5):
-        try:
-            asyncio.run(conn.search("LM317T"))
-        except ConnectionError:
-            pass
+    _trip_breaker(conn)
     assert conn._breaker.current_state == "open"
 
     # Reset call count and stop failing

--- a/tests/test_data_integrity_h8_h10_h11_h12.py
+++ b/tests/test_data_integrity_h8_h10_h11_h12.py
@@ -13,6 +13,8 @@ Depends on: conftest fixtures, app.services.sighting_aggregation,
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 # ── H8: AI Contact Field Truncation ────────────────────────────────
 
 
@@ -76,8 +78,7 @@ class TestH8ContactTruncation:
 class TestH10RefreshWarning:
     """Verify HX-Trigger header is set when search refresh fails."""
 
-    def test_refresh_failure_sets_hx_trigger(self, client, db_session):
-        """When search_requirement raises, response should have HX-Trigger header."""
+    def _make_requirement(self, db_session, primary_mpn):
         from app.models.sourcing import Requirement, Requisition
 
         req = Requisition(name="Test RFQ", status="active", customer_name="Test Co")
@@ -85,13 +86,18 @@ class TestH10RefreshWarning:
         db_session.flush()
         r = Requirement(
             requisition_id=req.id,
-            primary_mpn="TEST-001",
+            primary_mpn=primary_mpn,
             manufacturer="TestMfr",
             target_qty=100,
             sourcing_status="open",
         )
         db_session.add(r)
         db_session.commit()
+        return r
+
+    def test_refresh_failure_sets_hx_trigger(self, client, db_session):
+        """When search_requirement raises, response should have HX-Trigger header."""
+        r = self._make_requirement(db_session, "TEST-001")
 
         with (
             patch("app.search_service.search_requirement", side_effect=RuntimeError("API down")),
@@ -107,20 +113,7 @@ class TestH10RefreshWarning:
 
     def test_successful_refresh_no_warning(self, client, db_session):
         """When search_requirement succeeds, no warning in HX-Trigger."""
-        from app.models.sourcing import Requirement, Requisition
-
-        req = Requisition(name="Test RFQ", status="active", customer_name="Test Co")
-        db_session.add(req)
-        db_session.flush()
-        r = Requirement(
-            requisition_id=req.id,
-            primary_mpn="TEST-002",
-            manufacturer="TestMfr",
-            target_qty=100,
-            sourcing_status="open",
-        )
-        db_session.add(r)
-        db_session.commit()
+        r = self._make_requirement(db_session, "TEST-002")
 
         with (
             patch(
@@ -143,29 +136,20 @@ class TestH10RefreshWarning:
 class TestH11QtyEstimation:
     """Verify _estimate_qty_with_ai returns dict with approximate flag."""
 
-    def test_empty_list_returns_none_not_approximate(self):
+    @pytest.mark.parametrize(
+        ("qtys", "expected"),
+        [
+            pytest.param([], {"qty": None, "approximate": False}, id="empty_list_none_not_approximate"),
+            pytest.param([None, None], {"qty": None, "approximate": False}, id="all_none_not_approximate"),
+            pytest.param([42], {"qty": 42, "approximate": False}, id="single_value_exact"),
+            pytest.param([100, 200], {"qty": 300, "approximate": False}, id="two_values_sum_exact"),
+        ],
+    )
+    def test_no_ai_needed_returns_exact(self, qtys, expected):
+        """0-2 values resolve deterministically without invoking the AI fallback."""
         from app.services.sighting_aggregation import _estimate_qty_with_ai
 
-        result = _estimate_qty_with_ai([])
-        assert result == {"qty": None, "approximate": False}
-
-    def test_all_none_returns_none_not_approximate(self):
-        from app.services.sighting_aggregation import _estimate_qty_with_ai
-
-        result = _estimate_qty_with_ai([None, None])
-        assert result == {"qty": None, "approximate": False}
-
-    def test_single_value_returns_exact(self):
-        from app.services.sighting_aggregation import _estimate_qty_with_ai
-
-        result = _estimate_qty_with_ai([42])
-        assert result == {"qty": 42, "approximate": False}
-
-    def test_two_values_returns_sum_exact(self):
-        from app.services.sighting_aggregation import _estimate_qty_with_ai
-
-        result = _estimate_qty_with_ai([100, 200])
-        assert result == {"qty": 300, "approximate": False}
+        assert _estimate_qty_with_ai(qtys) == expected
 
     def test_three_values_no_api_key_returns_max_approximate(self):
         """Without ANTHROPIC_API_KEY, fallback uses max and marks approximate."""
@@ -226,10 +210,8 @@ class TestH11QtyEstimation:
 class TestH12CredentialDecryptionFallback:
     """Verify credential decryption failure logs and falls back to env var."""
 
-    def test_decrypt_failure_falls_back_to_env(self, db_session):
-        """When decryption fails, get_credential returns env var value."""
+    def _make_source(self, db_session, credentials):
         from app.models import ApiSource
-        from app.services.credential_service import get_credential
 
         src = ApiSource(
             name="test_src",
@@ -238,10 +220,17 @@ class TestH12CredentialDecryptionFallback:
             source_type="aggregator",
             status="active",
             env_vars=["MY_API_KEY"],
-            credentials={"MY_API_KEY": "corrupted-not-valid-fernet-token"},
+            credentials=credentials,
         )
         db_session.add(src)
         db_session.commit()
+        return src
+
+    def test_decrypt_failure_falls_back_to_env(self, db_session):
+        """When decryption fails, get_credential returns env var value."""
+        from app.services.credential_service import get_credential
+
+        self._make_source(db_session, {"MY_API_KEY": "corrupted-not-valid-fernet-token"})
 
         with patch.dict(os.environ, {"MY_API_KEY": "fallback-value"}):
             result = get_credential(db_session, "test_src", "MY_API_KEY")
@@ -252,20 +241,9 @@ class TestH12CredentialDecryptionFallback:
         """When decryption fails, warning is logged about env var fallback."""
         from loguru import logger
 
-        from app.models import ApiSource
         from app.services.credential_service import get_credential
 
-        src = ApiSource(
-            name="test_src",
-            display_name="Test Source",
-            category="api",
-            source_type="aggregator",
-            status="active",
-            env_vars=["MY_API_KEY"],
-            credentials={"MY_API_KEY": "corrupted-not-valid-fernet-token"},
-        )
-        db_session.add(src)
-        db_session.commit()
+        self._make_source(db_session, {"MY_API_KEY": "corrupted-not-valid-fernet-token"})
 
         messages = []
         handler_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
@@ -280,20 +258,9 @@ class TestH12CredentialDecryptionFallback:
 
     def test_no_credentials_returns_env_var(self, db_session):
         """When source has no credentials, env var is returned."""
-        from app.models import ApiSource
         from app.services.credential_service import get_credential
 
-        src = ApiSource(
-            name="test_src",
-            display_name="Test Source",
-            category="api",
-            source_type="aggregator",
-            status="active",
-            env_vars=["MY_API_KEY"],
-            credentials={},
-        )
-        db_session.add(src)
-        db_session.commit()
+        self._make_source(db_session, {})
 
         with patch.dict(os.environ, {"MY_API_KEY": "env-value"}):
             result = get_credential(db_session, "test_src", "MY_API_KEY")
@@ -302,21 +269,10 @@ class TestH12CredentialDecryptionFallback:
 
     def test_successful_decrypt_returns_db_value(self, db_session):
         """When decryption succeeds, DB credential is returned (not env var)."""
-        from app.models import ApiSource
         from app.services.credential_service import encrypt_value, get_credential
 
         encrypted = encrypt_value("my-secret-key")
-        src = ApiSource(
-            name="test_src",
-            display_name="Test Source",
-            category="api",
-            source_type="aggregator",
-            status="active",
-            env_vars=["MY_API_KEY"],
-            credentials={"MY_API_KEY": encrypted},
-        )
-        db_session.add(src)
-        db_session.commit()
+        self._make_source(db_session, {"MY_API_KEY": encrypted})
 
         with patch.dict(os.environ, {"MY_API_KEY": "should-not-use-this"}):
             result = get_credential(db_session, "test_src", "MY_API_KEY")
@@ -325,20 +281,9 @@ class TestH12CredentialDecryptionFallback:
 
     def test_decrypt_failure_no_env_returns_none(self, db_session):
         """When decryption fails and no env var, returns None."""
-        from app.models import ApiSource
         from app.services.credential_service import get_credential
 
-        src = ApiSource(
-            name="test_src",
-            display_name="Test Source",
-            category="api",
-            source_type="aggregator",
-            status="active",
-            env_vars=["MY_API_KEY"],
-            credentials={"MY_API_KEY": "corrupted-token"},
-        )
-        db_session.add(src)
-        db_session.commit()
+        self._make_source(db_session, {"MY_API_KEY": "corrupted-token"})
 
         env_backup = os.environ.pop("MY_API_KEY", None)
         try:

--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -21,9 +21,7 @@ _fake_weasyprint.HTML = _mock_html_cls
 # Insert into sys.modules so `from weasyprint import HTML` resolves
 sys.modules.setdefault("weasyprint", _fake_weasyprint)
 
-from app.models import (  # noqa: E402
-    Quote,
-)
+from app.models import Quote  # noqa: E402
 from app.services.document_service import (  # noqa: E402
     generate_quote_report_pdf,
     generate_rfq_summary_pdf,
@@ -37,6 +35,23 @@ def _reset_html_mock():
     _mock_html_cls.return_value.write_pdf.reset_mock()
     _mock_html_cls.return_value.write_pdf.return_value = b"%PDF-1.4 fake"
     _mock_html_cls.return_value.write_pdf.side_effect = None
+
+
+def _make_quote(db, requisition, customer_site, user, *, quote_number, **fields):
+    """Persist and return a draft Quote with the common FKs/boilerplate filled in;
+    `fields` overrides/adds quote-specific columns (line_items, notes, terms, …)."""
+    quote = Quote(
+        requisition_id=requisition.id,
+        customer_site_id=customer_site.id,
+        quote_number=quote_number,
+        status="draft",
+        created_by_id=user.id,
+        created_at=datetime.now(timezone.utc),
+        **fields,
+    )
+    db.add(quote)
+    db.commit()
+    return quote
 
 
 # ── generate_rfq_summary_pdf ────────────────────────────────────────
@@ -104,11 +119,12 @@ class TestGenerateQuoteReportPdf:
 
     def test_renders_line_items(self, db_session, test_customer_site, test_company, test_user, test_requisition):
         """Quote with line items should include them in the HTML."""
-        quote = Quote(
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
+        quote = _make_quote(
+            db_session,
+            test_requisition,
+            test_customer_site,
+            test_user,
             quote_number="Q-2026-LI-01",
-            status="draft",
             line_items=[
                 {
                     "mpn": "LM317T",
@@ -130,11 +146,7 @@ class TestGenerateQuoteReportPdf:
             subtotal=975.0,
             total_cost=550.0,
             total_margin_pct=43.6,
-            created_by_id=test_user.id,
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(quote)
-        db_session.commit()
 
         generate_quote_report_pdf(quote.id, db_session)
 
@@ -144,34 +156,28 @@ class TestGenerateQuoteReportPdf:
 
     def test_quote_with_empty_line_items(self, db_session, test_customer_site, test_user, test_requisition):
         """Quote with empty line_items list should still render cleanly."""
-        quote = Quote(
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
+        quote = _make_quote(
+            db_session,
+            test_requisition,
+            test_customer_site,
+            test_user,
             quote_number="Q-2026-EMPTY",
-            status="draft",
             line_items=[],
-            created_by_id=test_user.id,
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(quote)
-        db_session.commit()
 
         result = generate_quote_report_pdf(quote.id, db_session)
         assert result == b"%PDF-1.4 fake"
 
     def test_includes_notes_when_present(self, db_session, test_customer_site, test_user, test_requisition):
-        quote = Quote(
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
+        quote = _make_quote(
+            db_session,
+            test_requisition,
+            test_customer_site,
+            test_user,
             quote_number="Q-2026-NOTES",
-            status="draft",
             line_items=[],
             notes="Special pricing for bulk order",
-            created_by_id=test_user.id,
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(quote)
-        db_session.commit()
 
         generate_quote_report_pdf(quote.id, db_session)
 
@@ -179,19 +185,16 @@ class TestGenerateQuoteReportPdf:
         assert "Special pricing for bulk order" in html_string
 
     def test_includes_payment_and_shipping_terms(self, db_session, test_customer_site, test_user, test_requisition):
-        quote = Quote(
-            requisition_id=test_requisition.id,
-            customer_site_id=test_customer_site.id,
+        quote = _make_quote(
+            db_session,
+            test_requisition,
+            test_customer_site,
+            test_user,
             quote_number="Q-2026-TERMS",
-            status="draft",
             line_items=[],
             payment_terms="Net 30",
             shipping_terms="FOB Origin",
-            created_by_id=test_user.id,
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(quote)
-        db_session.commit()
 
         generate_quote_report_pdf(quote.id, db_session)
 

--- a/tests/test_eight_by_eight_coverage.py
+++ b/tests/test_eight_by_eight_coverage.py
@@ -76,28 +76,19 @@ def _mock_async_client(*, get=None, post=None):
 
 
 class TestNormalizePhone:
-    def test_empty_string_returns_empty(self):
-        assert normalize_phone("") == ""
-
-    def test_strips_formatting(self):
-        assert normalize_phone("+1 (555) 123-4567") == "5551234567"
-
-    def test_strips_leading_1(self):
-        assert normalize_phone("15551234567") == "5551234567"
-
-    def test_10_digit_number_unchanged(self):
-        assert normalize_phone("5551234567") == "5551234567"
-
-    def test_short_number_returned_as_is(self):
-        result = normalize_phone("+1234")
-        assert result == "1234"
-
-    def test_dots_removed(self):
-        assert normalize_phone("555.123.4567") == "5551234567"
-
-    def test_none_like_empty_string(self):
-        # Edge: None passed — shouldn't crash
-        assert normalize_phone("") == ""
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            pytest.param("", "", id="empty_string_returns_empty"),
+            pytest.param("+1 (555) 123-4567", "5551234567", id="strips_formatting"),
+            pytest.param("15551234567", "5551234567", id="strips_leading_1"),
+            pytest.param("5551234567", "5551234567", id="10_digit_number_unchanged"),
+            pytest.param("+1234", "1234", id="short_number_returned_as_is"),
+            pytest.param("555.123.4567", "5551234567", id="dots_removed"),
+        ],
+    )
+    def test_normalize_phone(self, raw, expected):
+        assert normalize_phone(raw) == expected
 
 
 # ── get_access_token ───────────────────────────────────────────────────
@@ -306,12 +297,14 @@ class TestReverseLookupPhone:
 
 
 class TestProcessCdrsEdgeCases:
-    def _make_mock_db(self, watermark=None, users=None):
+    def _make_mock_db(self, watermark=None, users=None, requisition=None):
         db = MagicMock()
         wm_query = MagicMock()
         wm_query.filter.return_value.first.return_value = watermark
         user_query = MagicMock()
         user_query.filter.return_value.all.return_value = users or []
+        req_query = MagicMock()
+        req_query.join.return_value.filter.return_value.first.return_value = requisition
 
         def query_router(model):
             name = getattr(model, "__tablename__", "")
@@ -319,10 +312,19 @@ class TestProcessCdrsEdgeCases:
                 return wm_query
             if name == "users":
                 return user_query
+            if name == "requisitions":
+                return req_query
             return MagicMock()
 
         db.query.side_effect = query_router
         return db
+
+    @staticmethod
+    def _make_user(extension="1001", user_id=1):
+        user = MagicMock()
+        user.id = user_id
+        user.eight_by_eight_extension = extension
+        return user
 
     @patch("app.services.eight_by_eight_service.get_access_token", new_callable=AsyncMock)
     async def test_auth_failure_returns_zeros(self, mock_auth):
@@ -402,29 +404,7 @@ class TestProcessCdrsEdgeCases:
         mock_log.return_value = record
         mock_reverse.return_value = None
 
-        mock_user = MagicMock()
-        mock_user.id = 1
-        mock_user.eight_by_eight_extension = "1001"
-
-        db = MagicMock()
-        wm_query = MagicMock()
-        wm_query.filter.return_value.first.return_value = None
-        user_query = MagicMock()
-        user_query.filter.return_value.all.return_value = [mock_user]
-        req_join = MagicMock()
-        req_join.join.return_value.filter.return_value.first.return_value = None
-
-        def query_router(model):
-            name = getattr(model, "__tablename__", "")
-            if name == "system_config":
-                return wm_query
-            if name == "users":
-                return user_query
-            if name == "requisitions":
-                return req_join
-            return MagicMock()
-
-        db.query.side_effect = query_router
+        db = self._make_mock_db(users=[self._make_user()], requisition=None)
         result = await _process_cdrs(db, FAKE_SETTINGS)
         assert result["processed"] == 1
 
@@ -455,25 +435,7 @@ class TestProcessCdrsEdgeCases:
         mock_log.return_value = None
         mock_reverse.return_value = None
 
-        mock_user = MagicMock()
-        mock_user.id = 1
-        mock_user.eight_by_eight_extension = "1001"
-
-        db = MagicMock()
-        wm_query = MagicMock()
-        wm_query.filter.return_value.first.return_value = None
-        user_query = MagicMock()
-        user_query.filter.return_value.all.return_value = [mock_user]
-
-        def query_router(model):
-            name = getattr(model, "__tablename__", "")
-            if name == "system_config":
-                return wm_query
-            if name == "users":
-                return user_query
-            return MagicMock()
-
-        db.query.side_effect = query_router
+        db = self._make_mock_db(users=[self._make_user()])
         result = await _process_cdrs(db, FAKE_SETTINGS)
         assert result["skipped"] == 1
 
@@ -513,25 +475,7 @@ class TestProcessCdrsEdgeCases:
             "vendor_card_id": 99,
         }
 
-        mock_user = MagicMock()
-        mock_user.id = 1
-        mock_user.eight_by_eight_extension = "1001"
-
-        db = MagicMock()
-        wm_query = MagicMock()
-        wm_query.filter.return_value.first.return_value = None
-        user_query = MagicMock()
-        user_query.filter.return_value.all.return_value = [mock_user]
-
-        def query_router(model):
-            name = getattr(model, "__tablename__", "")
-            if name == "system_config":
-                return wm_query
-            if name == "users":
-                return user_query
-            return MagicMock()
-
-        db.query.side_effect = query_router
+        db = self._make_mock_db(users=[self._make_user()])
         result = await _process_cdrs(db, FAKE_SETTINGS)
         assert result["matched"] == 1
         assert record.vendor_card_id == 99

--- a/tests/test_element14_connector.py
+++ b/tests/test_element14_connector.py
@@ -1,13 +1,24 @@
 """Tests for element14/Newark connector — parse logic and error handling."""
 
+import httpx
 import pytest
 
 from app.connectors.element14 import Element14Connector
+
+ELEMENT14_URL = "https://api.element14.com/catalog/products"
 
 
 @pytest.fixture
 def connector():
     return Element14Connector(api_key="test-key")
+
+
+def install_mock_get(monkeypatch, handler):
+    """Patch the connector's shared http client so `http.get` calls `handler`."""
+    monkeypatch.setattr(
+        "app.connectors.element14.http",
+        type("FakeHTTP", (), {"get": handler})(),
+    )
 
 
 SAMPLE_RESPONSE = {
@@ -106,14 +117,12 @@ async def test_no_api_key_returns_empty():
 @pytest.mark.asyncio
 async def test_api_search_400_returns_empty(connector, monkeypatch):
     """400 Bad Request from element14 should return [] instead of raising."""
-    import httpx
-
-    fake_request = httpx.Request("GET", "https://api.element14.com/catalog/products")
+    fake_request = httpx.Request("GET", ELEMENT14_URL)
 
     async def mock_get(*args, **kwargs):
         return httpx.Response(400, request=fake_request, json={"error": {"code": 400, "message": "Bad Request"}})
 
-    monkeypatch.setattr("app.connectors.element14.http", type("FakeHTTP", (), {"get": mock_get})())
+    install_mock_get(monkeypatch, mock_get)
     results = await connector._api_search("TPS65217CRSLR", "TPS65217CRSLR")
     assert results == []
 
@@ -121,10 +130,8 @@ async def test_api_search_400_returns_empty(connector, monkeypatch):
 @pytest.mark.asyncio
 async def test_keyword_fallback_survives_400(connector, monkeypatch):
     """If exact MPN returns 0 and keyword fallback gets 400, return [] gracefully."""
-    import httpx
-
     call_count = 0
-    fake_request = httpx.Request("GET", "https://api.element14.com/catalog/products")
+    fake_request = httpx.Request("GET", ELEMENT14_URL)
 
     async def mock_get(*args, **kwargs):
         nonlocal call_count
@@ -137,44 +144,39 @@ async def test_keyword_fallback_survives_400(connector, monkeypatch):
             )
         return httpx.Response(400, request=fake_request, json={"error": {"code": 400, "message": "Bad Request"}})
 
-    monkeypatch.setattr("app.connectors.element14.http", type("FakeHTTP", (), {"get": mock_get})())
+    install_mock_get(monkeypatch, mock_get)
     results = await connector._do_search("TPS65217CRSLR")
     assert results == []
     assert call_count == 2
 
 
 @pytest.mark.asyncio
-async def test_403_qps_body_raises_rate_limit(connector, monkeypatch):
-    """403 with a 'queries per second' body (no auth marker) is a transient QPS cap →
-    ConnectorRateLimitError so fetch_authoritative applies a cooldown instead of
-    disabling the source."""
-    import httpx
+@pytest.mark.parametrize(
+    ("body", "expected_error_attr"),
+    [
+        # 403 with a 'queries per second' body (no auth marker) is a transient QPS cap →
+        # ConnectorRateLimitError so fetch_authoritative applies a cooldown instead of
+        # disabling the source.
+        ("Account Over Queries Per Second Limit", "ConnectorRateLimitError"),
+        # 403 whose body contains BOTH 'queries per second' AND an auth marker is a
+        # credential rejection → ConnectorAuthError (auth wins over rate limit).
+        ("Invalid API key - queries per second", "ConnectorAuthError"),
+    ],
+    ids=["qps_only_rate_limit", "qps_with_auth_marker_auth"],
+)
+async def test_403_body_classification(connector, monkeypatch, body, expected_error_attr):
+    """A 403 body is classified as a rate-limit vs.
 
-    from app.connectors.errors import ConnectorRateLimitError
+    an auth rejection by its content.
+    """
+    from app.connectors import errors
 
-    fake_request = httpx.Request("GET", "https://api.element14.com/catalog/products")
-
-    async def mock_get(*args, **kwargs):
-        return httpx.Response(403, request=fake_request, text="Account Over Queries Per Second Limit")
-
-    monkeypatch.setattr("app.connectors.element14.http", type("FakeHTTP", (), {"get": mock_get})())
-    with pytest.raises(ConnectorRateLimitError):
-        await connector._api_search("LM358N", "LM358N")
-
-
-@pytest.mark.asyncio
-async def test_403_qps_with_auth_marker_raises_auth(connector, monkeypatch):
-    """403 whose body contains BOTH 'queries per second' AND an auth marker is a
-    credential rejection → ConnectorAuthError (auth wins over rate limit)."""
-    import httpx
-
-    from app.connectors.errors import ConnectorAuthError
-
-    fake_request = httpx.Request("GET", "https://api.element14.com/catalog/products")
+    expected_error = getattr(errors, expected_error_attr)
+    fake_request = httpx.Request("GET", ELEMENT14_URL)
 
     async def mock_get(*args, **kwargs):
-        return httpx.Response(403, request=fake_request, text="Invalid API key - queries per second")
+        return httpx.Response(403, request=fake_request, text=body)
 
-    monkeypatch.setattr("app.connectors.element14.http", type("FakeHTTP", (), {"get": mock_get})())
-    with pytest.raises(ConnectorAuthError):
+    install_mock_get(monkeypatch, mock_get)
+    with pytest.raises(expected_error):
         await connector._api_search("LM358N", "LM358N")

--- a/tests/test_email_intelligence_phase5.py
+++ b/tests/test_email_intelligence_phase5.py
@@ -13,7 +13,47 @@ Depends on: conftest fixtures
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
+
 from tests.conftest import engine  # noqa: F401
+
+
+def _make_vendor_with_response(db, *, slug, response_delay_hours):
+    """Create a VendorCard plus one VendorResponse with a known response time.
+
+    Returns the persisted VendorCard.
+    """
+    from app.models import VendorCard
+    from app.models.offers import VendorResponse
+
+    now = datetime.now(timezone.utc)
+    domain = f"{slug}.com"
+    vendor = VendorCard(
+        normalized_name=f"{slug} vendor",
+        display_name=f"{slug.title()} Vendor",
+        domain=domain,
+        emails=[f"sales@{domain}"],
+        sighting_count=1,
+        total_outreach=2,
+        created_at=now,
+    )
+    db.add(vendor)
+    db.flush()
+
+    db.add(
+        VendorResponse(
+            vendor_name=vendor.display_name,
+            vendor_email=f"sales@{domain}",
+            subject="RE: RFQ 1",
+            received_at=now,
+            created_at=now - timedelta(hours=response_delay_hours),
+            classification="offer",
+            confidence=0.9,
+        )
+    )
+    db.commit()
+    return vendor
+
 
 # ═══════════════════════════════════════════════════════════════════════
 #  5A: Response Time Metrics
@@ -392,79 +432,21 @@ class TestResponseTimeInterpolation:
         # Verify it's between 0 and 100 (interpolated, not at boundaries)
         assert 0 < result["response_time_score"] < 100
 
-    def test_response_time_at_or_below_ideal(self, db_session):
-        """Response time <= 4h gives perfect 100.0 score (line 184)."""
-        from app.models import VendorCard
-        from app.models.offers import VendorResponse
+    @pytest.mark.parametrize(
+        ("slug", "response_delay_hours", "expected_score"),
+        [
+            pytest.param("fast", 2, 100.0, id="at_or_below_ideal_line184"),
+            pytest.param("slow", 200, 0.0, id="at_or_above_max_line186"),
+        ],
+    )
+    def test_response_time_boundary(self, db_session, slug, response_delay_hours, expected_score):
+        """Response time <= 4h scores 100.0; >= 168h scores 0.0 (lines 184, 186)."""
         from app.services.response_analytics import compute_email_health_score
 
-        now = datetime.now(timezone.utc)
-
-        vendor = VendorCard(
-            normalized_name="fast vendor",
-            display_name="Fast Vendor",
-            domain="fast.com",
-            emails=["sales@fast.com"],
-            sighting_count=1,
-            total_outreach=2,
-            created_at=now,
-        )
-        db_session.add(vendor)
-        db_session.flush()
-
-        # Response with 2h response time (<= 4h ideal)
-        db_session.add(
-            VendorResponse(
-                vendor_name="Fast Vendor",
-                vendor_email="sales@fast.com",
-                subject="RE: RFQ 1",
-                received_at=now,
-                created_at=now - timedelta(hours=2),
-                classification="offer",
-                confidence=0.9,
-            )
-        )
-        db_session.commit()
+        vendor = _make_vendor_with_response(db_session, slug=slug, response_delay_hours=response_delay_hours)
 
         result = compute_email_health_score(db_session, vendor.id)
-        assert result["response_time_score"] == 100.0
-
-    def test_response_time_at_or_above_max(self, db_session):
-        """Response time >= 168h gives 0.0 score (line 186)."""
-        from app.models import VendorCard
-        from app.models.offers import VendorResponse
-        from app.services.response_analytics import compute_email_health_score
-
-        now = datetime.now(timezone.utc)
-
-        vendor = VendorCard(
-            normalized_name="slow vendor",
-            display_name="Slow Vendor",
-            domain="slow.com",
-            emails=["sales@slow.com"],
-            sighting_count=1,
-            total_outreach=2,
-            created_at=now,
-        )
-        db_session.add(vendor)
-        db_session.flush()
-
-        # Response with 200h response time (>= 168h max)
-        db_session.add(
-            VendorResponse(
-                vendor_name="Slow Vendor",
-                vendor_email="sales@slow.com",
-                subject="RE: RFQ 1",
-                received_at=now,
-                created_at=now - timedelta(hours=200),
-                classification="offer",
-                confidence=0.9,
-            )
-        )
-        db_session.commit()
-
-        result = compute_email_health_score(db_session, vendor.id)
-        assert result["response_time_score"] == 0.0
+        assert result["response_time_score"] == expected_score
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_evidence_tiers.py
+++ b/tests/test_evidence_tiers.py
@@ -5,52 +5,68 @@ Covers:
 - tier_for_parsed_offer: maps confidence → T4 or T5
 """
 
+import pytest
+
 from app.evidence_tiers import tier_for_parsed_offer, tier_for_sighting
 
 
 class TestTierForSighting:
-    def test_authorized_always_t1(self):
-        assert tier_for_sighting("digikey", True) == "T1"
-        assert tier_for_sighting("brokerbin", True) == "T1"
-        assert tier_for_sighting(None, True) == "T1"
-
-    def test_authorized_api_sources_t2(self):
-        for src in ("digikey", "mouser", "element14", "nexar", "octopart", "brokerbin", "sourcengine"):
-            assert tier_for_sighting(src, False) == "T2", f"{src} should be T2"
-
-    def test_marketplace_sources_t3(self):
-        for src in ("ebay", "oemsecrets", "ics", "ics_scrape"):
-            assert tier_for_sighting(src, False) == "T3", f"{src} should be T3"
-
-    def test_email_sources_t5(self):
-        for src in ("email_parse", "email_auto_import", "email"):
-            assert tier_for_sighting(src, False) == "T5", f"{src} should be T5"
-
-    def test_manual_t6(self):
-        assert tier_for_sighting("manual", False) == "T6"
-        assert tier_for_sighting("", False) == "T6"
-
-    def test_history_sources_t7(self):
-        for src in ("material_history", "stock_list", "excess_list"):
-            assert tier_for_sighting(src, False) == "T7", f"{src} should be T7"
-
-    def test_unknown_source_defaults_t3(self):
-        assert tier_for_sighting("some_new_connector", False) == "T3"
-
-    def test_none_source_not_authorized_t6(self):
-        assert tier_for_sighting(None, False) == "T6"
+    @pytest.mark.parametrize(
+        ("source", "authorized", "expected"),
+        [
+            # Authorized always wins → T1, regardless of source.
+            ("digikey", True, "T1"),
+            ("brokerbin", True, "T1"),
+            (None, True, "T1"),
+            # Authorized API sources (not authorized flag) → T2.
+            ("digikey", False, "T2"),
+            ("mouser", False, "T2"),
+            ("element14", False, "T2"),
+            ("nexar", False, "T2"),
+            ("octopart", False, "T2"),
+            ("brokerbin", False, "T2"),
+            ("sourcengine", False, "T2"),
+            # Marketplace sources → T3.
+            ("ebay", False, "T3"),
+            ("oemsecrets", False, "T3"),
+            ("ics", False, "T3"),
+            ("ics_scrape", False, "T3"),
+            # Email sources → T5.
+            ("email_parse", False, "T5"),
+            ("email_auto_import", False, "T5"),
+            ("email", False, "T5"),
+            # Manual / empty → T6.
+            ("manual", False, "T6"),
+            ("", False, "T6"),
+            # History sources → T7.
+            ("material_history", False, "T7"),
+            ("stock_list", False, "T7"),
+            ("excess_list", False, "T7"),
+            # Unknown source defaults to T3.
+            ("some_new_connector", False, "T3"),
+            # None source, not authorized → T6.
+            (None, False, "T6"),
+        ],
+    )
+    def test_tier_for_sighting(self, source, authorized, expected):
+        assert tier_for_sighting(source, authorized) == expected
 
 
 class TestTierForParsedOffer:
-    def test_high_confidence_t5(self):
-        assert tier_for_parsed_offer(0.9) == "T5"
-        assert tier_for_parsed_offer(0.8) == "T5"
-        assert tier_for_parsed_offer(1.0) == "T5"
-
-    def test_medium_confidence_t4(self):
-        assert tier_for_parsed_offer(0.7) == "T4"
-        assert tier_for_parsed_offer(0.5) == "T4"
-        assert tier_for_parsed_offer(0.0) == "T4"
-
-    def test_none_confidence_t4(self):
-        assert tier_for_parsed_offer(None) == "T4"
+    @pytest.mark.parametrize(
+        ("confidence", "expected"),
+        [
+            # High confidence (>= 0.8) → T5.
+            (0.9, "T5"),
+            (0.8, "T5"),
+            (1.0, "T5"),
+            # Medium / low confidence → T4.
+            (0.7, "T4"),
+            (0.5, "T4"),
+            (0.0, "T4"),
+            # None confidence → T4.
+            (None, "T4"),
+        ],
+    )
+    def test_tier_for_parsed_offer(self, confidence, expected):
+        assert tier_for_parsed_offer(confidence) == expected

--- a/tests/test_faceted_routes.py
+++ b/tests/test_faceted_routes.py
@@ -34,18 +34,7 @@ def test_subfilters_renders_for_commodity(client, db_session: Session):
     )
     db_session.add(card)
     db_session.flush()
-    db_session.add(
-        CommoditySpecSchema(
-            commodity="dram",
-            spec_key="ddr_type",
-            display_name="DDR Type",
-            data_type="enum",
-            enum_values=["DDR4", "DDR5"],
-            sort_order=1,
-            is_filterable=True,
-            is_primary=False,
-        )
-    )
+    _seed_ddr_schema(db_session)
     db_session.add(
         MaterialSpecFacet(
             material_card_id=card.id,
@@ -113,19 +102,7 @@ def test_faceted_results_sub_filters_actually_filter(client, db_session: Session
     import json
 
     # Create schema
-    db_session.add(
-        CommoditySpecSchema(
-            commodity="dram",
-            spec_key="ddr_type",
-            display_name="DDR Type",
-            data_type="enum",
-            enum_values=["DDR4", "DDR5"],
-            sort_order=1,
-            is_filterable=True,
-            is_primary=False,
-        )
-    )
-    db_session.flush()
+    _seed_ddr_schema(db_session)
 
     # Create two cards with different spec values
     card_ddr4 = MaterialCard(
@@ -652,6 +629,20 @@ def _seed_ddr_schema(db):
     db.flush()
 
 
+def _seed_capacity_schema(db):
+    db.add(
+        CommoditySpecSchema(
+            commodity="dram",
+            spec_key="capacity_gb",
+            display_name="Capacity (GB)",
+            data_type="numeric",
+            sort_order=1,
+            is_filterable=True,
+            is_primary=True,
+        )
+    )
+
+
 def test_subfilters_panel_shows_coverage_line(client, db_session: Session):
     """'N of M parts in <commodity> have filterable specs' renders in the panel."""
     _seed_ddr_schema(db_session)
@@ -783,17 +774,7 @@ def test_faceted_row_crosses_chip_neutral_not_indigo(client, db_session: Session
 
 def test_faceted_spec_chip_title_keeps_label_in_commodity_context(client, db_session: Session):
     # Commodity-scoped chips render value-only; the title keeps "Label: value" on hover.
-    db_session.add(
-        CommoditySpecSchema(
-            commodity="dram",
-            spec_key="capacity_gb",
-            display_name="Capacity (GB)",
-            data_type="numeric",
-            sort_order=1,
-            is_filterable=True,
-            is_primary=True,
-        )
-    )
+    _seed_capacity_schema(db_session)
     _op_card(db_session, "chip-hover", category="dram", specs_structured={"capacity_gb": {"value": 32}})
     db_session.commit()
     resp = client.get("/v2/partials/materials/faceted?commodity=dram")
@@ -806,17 +787,7 @@ def test_faceted_spec_chips_without_commodity_use_schema_primaries(client, db_se
 
     value'.
     """
-    db_session.add(
-        CommoditySpecSchema(
-            commodity="dram",
-            spec_key="capacity_gb",
-            display_name="Capacity (GB)",
-            data_type="numeric",
-            sort_order=1,
-            is_filterable=True,
-            is_primary=True,
-        )
-    )
+    _seed_capacity_schema(db_session)
     _op_card(db_session, "chip-known", category="dram", specs_structured={"capacity_gb": {"value": 32}})
     db_session.commit()
 
@@ -855,17 +826,7 @@ def test_faceted_spec_chips_without_commodity_fallback_first_scalars(client, db_
 
 def test_faceted_spec_chips_in_commodity_context_unchanged(client, db_session: Session):
     """With a commodity selected, chips stay value-only (no 'label:' prefix)."""
-    db_session.add(
-        CommoditySpecSchema(
-            commodity="dram",
-            spec_key="capacity_gb",
-            display_name="Capacity (GB)",
-            data_type="numeric",
-            sort_order=1,
-            is_filterable=True,
-            is_primary=True,
-        )
-    )
+    _seed_capacity_schema(db_session)
     _op_card(db_session, "chip-ctx", category="dram", specs_structured={"capacity_gb": {"value": 64}})
     # Raw-scalar primary spec (no {"value": ...} wrapper) — the pre-_spec_scalar code
     # raised AttributeError (HTTP 500) on this shape in commodity context; it must now

--- a/tests/test_freeform_parser_coverage.py
+++ b/tests/test_freeform_parser_coverage.py
@@ -12,7 +12,34 @@ os.environ["TESTING"] = "1"
 
 from unittest.mock import patch
 
+import pytest
+
 from app.services.freeform_parser_service import parse_freeform_offer, parse_freeform_rfq
+
+# Sentinel for parametrized cases that only assert the field is populated (not None),
+# as opposed to checking an exact normalized value.
+NOT_NONE = object()
+
+
+def _patch_routed(result, captured=None):
+    """Patch routed_structured with an async stub returning ``result``.
+
+    If ``captured`` (a list) is given, each call's prompt is appended to it.
+    """
+
+    async def _stub(prompt=None, *a, **kw):
+        if captured is not None:
+            captured.append(prompt)
+        return result
+
+    return patch("app.services.freeform_parser_service.routed_structured", new=_stub)
+
+
+def _assert_field(actual, expected):
+    if expected is NOT_NONE:
+        assert actual is not None
+    else:
+        assert actual == expected
 
 
 class TestParseFreeformRfq:
@@ -30,123 +57,36 @@ class TestParseFreeformRfq:
             "customer_name": "Acme",
             "requirements": [{"primary_mpn": "LM317T", "target_qty": 500, "condition": "new"}],
         }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
+        with _patch_routed(mock_result):
             result = await parse_freeform_rfq("Please quote 500 pcs LM317T")
 
         assert result is not None
         assert result["name"] == "Test RFQ"
         assert result["requirements"][0]["primary_mpn"] == "LM317T"
 
-    async def test_normalizes_qty_default_to_1(self):
-        mock_result = {
-            "name": "RFQ",
-            "requirements": [{"primary_mpn": "STM32F4", "target_qty": None}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_rfq("Quote STM32F4")
-
-        assert result["requirements"][0]["target_qty"] == 1
-
-    async def test_normalizes_price(self):
-        mock_result = {
-            "name": "RFQ",
-            "requirements": [{"primary_mpn": "LM317T", "target_price": "1.50"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_rfq("Quote LM317T at $1.50")
-
-        assert result["requirements"][0]["target_price"] is not None
-
-    async def test_normalizes_condition(self):
-        mock_result = {
-            "name": "RFQ",
-            "requirements": [{"primary_mpn": "LM317T", "condition": "NEW"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_rfq("Quote LM317T new condition")
-
-        # condition should be normalized (lowercased etc.)
-        assert result["requirements"][0]["condition"] is not None
-
-    async def test_normalizes_condition_default_new(self):
-        mock_result = {
-            "name": "RFQ",
-            "requirements": [
-                {"primary_mpn": "LM317T"}  # No condition
-            ],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
+    @pytest.mark.parametrize(
+        ("requirement", "field", "expected"),
+        [
+            pytest.param({"primary_mpn": "STM32F4", "target_qty": None}, "target_qty", 1, id="qty_default_to_1"),
+            pytest.param({"primary_mpn": "LM317T", "target_price": "1.50"}, "target_price", NOT_NONE, id="price"),
+            pytest.param({"primary_mpn": "LM317T", "condition": "NEW"}, "condition", NOT_NONE, id="condition"),
+            pytest.param({"primary_mpn": "LM317T"}, "condition", "new", id="condition_default_new"),
+            pytest.param(
+                {"primary_mpn": "LM317T", "packaging": "Tape and Reel"}, "packaging", NOT_NONE, id="packaging"
+            ),
+            pytest.param({"primary_mpn": "LM317T", "date_codes": "2024+"}, "date_codes", NOT_NONE, id="date_codes"),
+            pytest.param({"primary_mpn": "LM317T", "substitutes": None}, "substitutes", [], id="empty_substitutes"),
+        ],
+    )
+    async def test_normalizes_requirement_field(self, requirement, field, expected):
+        mock_result = {"name": "RFQ", "requirements": [requirement]}
+        with _patch_routed(mock_result):
             result = await parse_freeform_rfq("Quote LM317T")
 
-        assert result["requirements"][0]["condition"] == "new"
-
-    async def test_normalizes_packaging(self):
-        mock_result = {
-            "name": "RFQ",
-            "requirements": [{"primary_mpn": "LM317T", "packaging": "Tape and Reel"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_rfq("Quote LM317T T&R")
-
-        assert result["requirements"][0]["packaging"] is not None
-
-    async def test_normalizes_date_codes(self):
-        mock_result = {
-            "name": "RFQ",
-            "requirements": [{"primary_mpn": "LM317T", "date_codes": "2024+"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_rfq("Quote LM317T 2024+")
-
-        assert result["requirements"][0]["date_codes"] is not None
-
-    async def test_sets_empty_substitutes_when_none(self):
-        mock_result = {
-            "name": "RFQ",
-            "requirements": [{"primary_mpn": "LM317T", "substitutes": None}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_rfq("Quote LM317T")
-
-        assert result["requirements"][0]["substitutes"] == []
+        _assert_field(result["requirements"][0][field], expected)
 
     async def test_api_returns_none_propagates_none(self):
-        async def _none(*a, **kw):
-            return None
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_none):
+        with _patch_routed(None):
             result = await parse_freeform_rfq("Quote LM317T")
 
         assert result is None
@@ -155,11 +95,7 @@ class TestParseFreeformRfq:
         long_text = "A" * 10000
         called_with = []
 
-        async def _capture(prompt, **kw):
-            called_with.append(prompt)
-            return {"name": "RFQ", "requirements": []}
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_capture):
+        with _patch_routed({"name": "RFQ", "requirements": []}, captured=called_with):
             await parse_freeform_rfq(long_text)
 
         assert len(called_with) == 1
@@ -185,114 +121,31 @@ class TestParseFreeformOffer:
                 }
             ],
         }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
+        with _patch_routed(mock_result):
             result = await parse_freeform_offer("We have 1000 LM317T at $0.50 each")
 
         assert result is not None
         assert result["vendor_name"] == "Arrow Electronics"
         assert result["offers"][0]["mpn"] == "LM317T"
 
-    async def test_normalizes_price(self):
-        mock_result = {
-            "vendor_name": "Arrow",
-            "offers": [{"mpn": "LM317T", "unit_price": "0.75"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_offer("Arrow: LM317T $0.75")
-
-        assert result["offers"][0]["unit_price"] is not None
-
-    async def test_normalizes_quantity(self):
-        mock_result = {
-            "vendor_name": "Arrow",
-            "offers": [{"mpn": "LM317T", "qty_available": "1,000"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_offer("Arrow: LM317T 1000 pcs")
-
-        assert result["offers"][0]["qty_available"] is not None
-
-    async def test_normalizes_condition(self):
-        mock_result = {
-            "vendor_name": "Arrow",
-            "offers": [{"mpn": "LM317T", "condition": "NEW ORIGINAL"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_offer("Arrow: LM317T new")
-
-        assert result["offers"][0]["condition"] is not None
-
-    async def test_normalizes_date_code(self):
-        mock_result = {
-            "vendor_name": "Arrow",
-            "offers": [{"mpn": "LM317T", "date_code": "2339"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_offer("Arrow: LM317T DC2339")
-
-        assert result["offers"][0]["date_code"] is not None
-
-    async def test_normalizes_moq(self):
-        mock_result = {
-            "vendor_name": "Arrow",
-            "offers": [{"mpn": "LM317T", "moq": "100"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_offer("Arrow: LM317T MOQ 100")
-
-        assert result["offers"][0]["moq"] is not None
-
-    async def test_normalizes_packaging(self):
-        mock_result = {
-            "vendor_name": "Arrow",
-            "offers": [{"mpn": "LM317T", "packaging": "TR"}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
-            result = await parse_freeform_offer("Arrow: LM317T T&R")
-
-        assert result["offers"][0]["packaging"] is not None
-
-    async def test_defaults_currency_to_usd(self):
-        mock_result = {
-            "vendor_name": "Arrow",
-            "offers": [{"mpn": "LM317T", "currency": None}],
-        }
-
-        async def _mock(*a, **kw):
-            return mock_result
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_mock):
+    @pytest.mark.parametrize(
+        ("offer", "field", "expected"),
+        [
+            pytest.param({"mpn": "LM317T", "unit_price": "0.75"}, "unit_price", NOT_NONE, id="price"),
+            pytest.param({"mpn": "LM317T", "qty_available": "1,000"}, "qty_available", NOT_NONE, id="quantity"),
+            pytest.param({"mpn": "LM317T", "condition": "NEW ORIGINAL"}, "condition", NOT_NONE, id="condition"),
+            pytest.param({"mpn": "LM317T", "date_code": "2339"}, "date_code", NOT_NONE, id="date_code"),
+            pytest.param({"mpn": "LM317T", "moq": "100"}, "moq", NOT_NONE, id="moq"),
+            pytest.param({"mpn": "LM317T", "packaging": "TR"}, "packaging", NOT_NONE, id="packaging"),
+            pytest.param({"mpn": "LM317T", "currency": None}, "currency", "USD", id="currency_default_usd"),
+        ],
+    )
+    async def test_normalizes_offer_field(self, offer, field, expected):
+        mock_result = {"vendor_name": "Arrow", "offers": [offer]}
+        with _patch_routed(mock_result):
             result = await parse_freeform_offer("Arrow: LM317T")
 
-        assert result["offers"][0]["currency"] == "USD"
+        _assert_field(result["offers"][0][field], expected)
 
     async def test_with_rfq_context(self):
         mock_result = {
@@ -301,12 +154,8 @@ class TestParseFreeformOffer:
         }
         called_prompt = []
 
-        async def _capture(prompt, **kw):
-            called_prompt.append(prompt)
-            return mock_result
-
         rfq_context = [{"mpn": "LM317T", "qty": 500}]
-        with patch("app.services.freeform_parser_service.routed_structured", new=_capture):
+        with _patch_routed(mock_result, captured=called_prompt):
             result = await parse_freeform_offer("Arrow offer", rfq_context=rfq_context)
 
         assert result is not None
@@ -314,10 +163,7 @@ class TestParseFreeformOffer:
         assert "LM317T" in called_prompt[0]
 
     async def test_api_returns_none_propagates_none(self):
-        async def _none(*a, **kw):
-            return None
-
-        with patch("app.services.freeform_parser_service.routed_structured", new=_none):
+        with _patch_routed(None):
             result = await parse_freeform_offer("Arrow offer")
 
         assert result is None
@@ -325,12 +171,8 @@ class TestParseFreeformOffer:
     async def test_rfq_context_capped_at_10_parts(self):
         called_prompt = []
 
-        async def _capture(prompt, **kw):
-            called_prompt.append(prompt)
-            return {"vendor_name": "A", "offers": []}
-
         rfq_context = [{"mpn": f"PART{i}", "qty": 10} for i in range(15)]
-        with patch("app.services.freeform_parser_service.routed_structured", new=_capture):
+        with _patch_routed({"vendor_name": "A", "offers": []}, captured=called_prompt):
             await parse_freeform_offer("Offer text", rfq_context=rfq_context)
 
         # First 10 parts included, but the 11th-15th are cut off

--- a/tests/test_fru_crosswalk_writer.py
+++ b/tests/test_fru_crosswalk_writer.py
@@ -9,6 +9,8 @@ Description corpus strings are REAL fru_links rows from the live FRU matrix inge
 (Qlot/Gabor/CZ sheets).
 """
 
+import contextlib
+
 from sqlalchemy import event
 from sqlalchemy.orm import Session
 
@@ -76,6 +78,55 @@ def _link(
     db.add(link)
     db.flush()
     return link
+
+
+def _spy_decode(monkeypatch) -> list[str]:
+    """Patch decode_mpn to record (and still delegate) each MPN it is called with."""
+    import app.services.fru_crosswalk_enrich as mod
+
+    calls: list[str] = []
+    real_decode = mod.decode_mpn
+
+    def counting(mpn, manufacturer=None):
+        calls.append(mpn)
+        return real_decode(mpn, manufacturer)
+
+    monkeypatch.setattr(mod, "decode_mpn", counting)
+    return calls
+
+
+def _count_fru_link_selects(db: Session):
+    """Context manager yielding the list of fru_links SELECT statements executed inside
+    it."""
+    engine = db.get_bind()
+    selects: list[str] = []
+
+    def counter(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT") and "fru_links" in statement:
+            selects.append(statement)
+
+    @contextlib.contextmanager
+    def _cm():
+        event.listen(engine, "before_cursor_execute", counter)
+        try:
+            yield selects
+        finally:
+            event.remove(engine, "before_cursor_execute", counter)
+
+    return _cm()
+
+
+@contextlib.contextmanager
+def _capture_warnings():
+    """Capture loguru WARNING-level messages emitted inside the block."""
+    from loguru import logger as loguru_logger
+
+    warnings: list[str] = []
+    sink_id = loguru_logger.add(lambda message: warnings.append(str(message)), level="WARNING")
+    try:
+        yield warnings
+    finally:
+        loguru_logger.remove(sink_id)
 
 
 def test_writer_writes_intersected_specs_with_source_and_confidence(db_session: Session):
@@ -221,21 +272,12 @@ def test_ladder_skips_higher_tier_prior_overwrites_lower(db_session: Session):
 def test_duplicate_links_across_sheets_decode_once(db_session: Session, monkeypatch):
     # Cross-sheet duplicates of the same related model collapse into one decode call
     # (the per-FRU link set), and the single-model intersection still writes.
-    import app.services.fru_crosswalk_enrich as mod
-
     seed_commodity_schemas(db_session)
     card = _card(db_session, "00AJ141", category="hdd")
     _link(db_session, "00AJ141", "ST4000NM0035", sheet="Main")
     _link(db_session, "00AJ141", "ST4000NM0035", sheet="xSeries")
 
-    calls: list[str] = []
-    real_decode = mod.decode_mpn
-
-    def counting(mpn, manufacturer=None):
-        calls.append(mpn)
-        return real_decode(mpn, manufacturer)
-
-    monkeypatch.setattr(mod, "decode_mpn", counting)
+    calls = _spy_decode(monkeypatch)
 
     stats = crosswalk_and_record_specs(db_session, [card.id])
 
@@ -341,8 +383,6 @@ def test_savepoint_isolates_a_failing_card(db_session: Session, monkeypatch):
 
 def test_links_resolved_via_exactly_one_select(db_session: Session):
     # The whole batch resolves its links through ONE fru_links SELECT — no N+1.
-    engine = db_session.get_bind()
-
     seed_commodity_schemas(db_session)
     cards = []
     for i, (fru, model) in enumerate(
@@ -351,17 +391,8 @@ def test_links_resolved_via_exactly_one_select(db_session: Session):
         cards.append(_card(db_session, fru, category=None))
         _link(db_session, fru, model, mfg="Samsung" if i == 2 else "Seagate")
 
-    fru_link_selects: list[str] = []
-
-    def counter(conn, cursor, statement, parameters, context, executemany):
-        if statement.lstrip().upper().startswith("SELECT") and "fru_links" in statement:
-            fru_link_selects.append(statement)
-
-    event.listen(engine, "before_cursor_execute", counter)
-    try:
+    with _count_fru_link_selects(db_session) as fru_link_selects:
         stats = crosswalk_and_record_specs(db_session, [c.id for c in cards])
-    finally:
-        event.remove(engine, "before_cursor_execute", counter)
 
     assert len(fru_link_selects) == 1, fru_link_selects
     assert stats["matched"] == 3
@@ -416,8 +447,6 @@ def test_cards_sharing_one_normalized_key_all_enriched(db_session: Session, monk
     # while each unique model decodes exactly once. The intersection (and its
     # dropped-keys count) is computed once per FRU — the conflicting capacity key
     # reports dropped_conflict=1, not once per card sharing the key.
-    import app.services.fru_crosswalk_enrich as mod
-
     seed_commodity_schemas(db_session)
     card_a = _card(db_session, "00AJ141", category="hdd")
     card_b = _card(db_session, "00-AJ-141", category="hdd")
@@ -425,14 +454,7 @@ def test_cards_sharing_one_normalized_key_all_enriched(db_session: Session, monk
     _link(db_session, "00AJ141", "ST4000NM0035")
     _link(db_session, "00AJ141", "ST8000NM0055")
 
-    calls: list[str] = []
-    real_decode = mod.decode_mpn
-
-    def counting(mpn, manufacturer=None):
-        calls.append(mpn)
-        return real_decode(mpn, manufacturer)
-
-    monkeypatch.setattr(mod, "decode_mpn", counting)
+    calls = _spy_decode(monkeypatch)
 
     stats = crosswalk_and_record_specs(db_session, [card_a.id, card_b.id])
     db_session.commit()
@@ -487,8 +509,6 @@ def test_writer_warns_when_crosswalk_key_has_no_schema(db_session: Session):
     # the discard as an aggregate WARNING exactly like mpn_decoder's writer, or a
     # post-deploy schema lag silently zeroes the pass (decoded=N, written=0 with no
     # production-visible explanation).
-    from loguru import logger as loguru_logger
-
     from app.models import CommoditySpecSchema
 
     seed_commodity_schemas(db_session)
@@ -497,12 +517,8 @@ def test_writer_warns_when_crosswalk_key_has_no_schema(db_session: Session):
     card = _card(db_session, "00AJ141", category="hdd")
     _link(db_session, "00AJ141", "ST4000NM0035")
 
-    warnings: list[str] = []
-    sink_id = loguru_logger.add(lambda message: warnings.append(str(message)), level="WARNING")
-    try:
+    with _capture_warnings() as warnings:
         stats = crosswalk_and_record_specs(db_session, [card.id])
-    finally:
-        loguru_logger.remove(sink_id)
     db_session.commit()
 
     assert any("hdd.usage_class" in w and "dropped" in w for w in warnings), warnings
@@ -517,8 +533,6 @@ def test_writer_warns_when_enum_value_outside_live_schema(db_session: Session):
     # value is not in its LIVE enum_values (a stale DB row after a failed/lagging
     # reseed). The writer must surface this drop in the same aggregate WARNING as
     # the no-schema case, mirroring mpn_decoder's writer.
-    from loguru import logger as loguru_logger
-
     from app.models import CommoditySpecSchema
 
     seed_commodity_schemas(db_session)
@@ -528,12 +542,8 @@ def test_writer_warns_when_enum_value_outside_live_schema(db_session: Session):
     card = _card(db_session, "00AJ141", category="hdd")
     _link(db_session, "00AJ141", "ST4000NM0035")
 
-    warnings: list[str] = []
-    sink_id = loguru_logger.add(lambda message: warnings.append(str(message)), level="WARNING")
-    try:
+    with _capture_warnings() as warnings:
         stats = crosswalk_and_record_specs(db_session, [card.id])
-    finally:
-        loguru_logger.remove(sink_id)
     db_session.commit()
 
     assert any('hdd.form_factor=3.5"' in w and "dropped" in w for w in warnings), warnings
@@ -777,24 +787,13 @@ def test_duplicate_descriptions_across_sheets_extract_once(db_session: Session, 
 def test_desc_channel_links_resolved_in_the_same_single_select(db_session: Session):
     # The desc channel rides the decode channel's ONE fru_links SELECT — extending
     # the rel_kind filter must not add a second query.
-    engine = db_session.get_bind()
-
     seed_commodity_schemas(db_session)
     card = _card(db_session, "01LJ787", category=None)
     _link(db_session, "01LJ787", "ST4000NM0035")
     _link(db_session, "01LJ787", "00FJ069", mfg=None, kind="drive_pn", description=_DESC_HDD_1_2TB)
 
-    fru_link_selects: list[str] = []
-
-    def counter(conn, cursor, statement, parameters, context, executemany):
-        if statement.lstrip().upper().startswith("SELECT") and "fru_links" in statement:
-            fru_link_selects.append(statement)
-
-    event.listen(engine, "before_cursor_execute", counter)
-    try:
+    with _count_fru_link_selects(db_session) as fru_link_selects:
         stats = crosswalk_and_record_specs(db_session, [card.id])
-    finally:
-        event.remove(engine, "before_cursor_execute", counter)
 
     assert len(fru_link_selects) == 1, fru_link_selects
     assert stats["written"] == 3
@@ -931,8 +930,6 @@ def test_desc_drop_counts_per_card_on_a_multi_card_fru(db_session: Session):
 def test_desc_channel_surfaces_schema_drift_in_the_aggregate_warning(db_session: Session):
     # A desc-extracted key with no live schema row must surface in the same aggregate
     # WARNING the decode channel uses — record_spec alone drops it at DEBUG only.
-    from loguru import logger as loguru_logger
-
     from app.models import CommoditySpecSchema
 
     seed_commodity_schemas(db_session)
@@ -941,12 +938,8 @@ def test_desc_channel_surfaces_schema_drift_in_the_aggregate_warning(db_session:
     card = _card(db_session, "01LJ065", category="hdd")
     _link(db_session, "01LJ065", "00VN423", mfg=None, kind="drive_pn", description=_DESC_HDD_8TB)
 
-    warnings: list[str] = []
-    sink_id = loguru_logger.add(lambda message: warnings.append(str(message)), level="WARNING")
-    try:
+    with _capture_warnings() as warnings:
         stats = crosswalk_and_record_specs(db_session, [card.id])
-    finally:
-        loguru_logger.remove(sink_id)
     db_session.commit()
 
     assert any("hdd.rpm" in w and "dropped" in w for w in warnings), warnings

--- a/tests/test_htmx_views_deep.py
+++ b/tests/test_htmx_views_deep.py
@@ -14,6 +14,7 @@ os.environ["TESTING"] = "1"
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -133,41 +134,31 @@ class TestV2PagePathVariants:
             resp = client.get(path)
         return resp.status_code
 
-    def test_v2_buy_plans(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/buy-plans", test_user) == 200
-
-    def test_v2_excess(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/excess", test_user) == 200
-
-    def test_v2_quotes(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/quotes", test_user) == 200
-
-    def test_v2_prospecting(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/prospecting", test_user) == 200
-
-    def test_v2_proactive(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/proactive", test_user) == 200
-
-    def test_v2_settings(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/settings", test_user) == 200
-
-    def test_v2_materials(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/materials", test_user) == 200
-
-    def test_v2_follow_ups(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/follow-ups", test_user) == 200
-
-    def test_v2_trouble_tickets(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/trouble-tickets", test_user) == 200
-
-    def test_v2_search(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/search", test_user) == 200
-
-    def test_v2_crm(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/crm", test_user) == 200
-
-    def test_v2_sightings(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/sightings", test_user) == 200
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/buy-plans",
+            "/v2/excess",
+            "/v2/quotes",
+            "/v2/prospecting",
+            "/v2/proactive",
+            "/v2/settings",
+            "/v2/materials",
+            "/v2/follow-ups",
+            "/v2/trouble-tickets",
+            "/v2/search",
+            "/v2/crm",
+            "/v2/sightings",
+            "/v2/materials/1",
+            "/v2/prospecting/1",
+            "/v2/trouble-tickets/1",
+            "/v2/excess/1",
+            "/v2/prospecting/5",
+            "/v2/sourcing/leads/1",
+        ],
+    )
+    def test_v2_static_paths_ok(self, client: TestClient, test_user: User, path: str):
+        assert self._get(client, path, test_user) == 200
 
     def test_v2_vendors_id(self, client: TestClient, db_session: Session, test_user: User):
         vc = _vendor_card(db_session)
@@ -179,15 +170,6 @@ class TestV2PagePathVariants:
         db_session.commit()
         assert self._get(client, f"/v2/customers/{co.id}", test_user) == 200
 
-    def test_v2_materials_id(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/materials/1", test_user) == 200
-
-    def test_v2_prospecting_id(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/prospecting/1", test_user) == 200
-
-    def test_v2_trouble_tickets_id(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/trouble-tickets/1", test_user) == 200
-
     def test_v2_buy_plans_id(self, client: TestClient, db_session: Session, test_user: User):
         req = _requisition(db_session, test_user)
         q = _quote(db_session, req, test_user)
@@ -196,17 +178,11 @@ class TestV2PagePathVariants:
         db_session.commit()
         assert self._get(client, f"/v2/buy-plans/{bp.id}", test_user) == 200
 
-    def test_v2_excess_id(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/excess/1", test_user) == 200
-
     def test_v2_quotes_id(self, client: TestClient, db_session: Session, test_user: User):
         req = _requisition(db_session, test_user)
         q = _quote(db_session, req, test_user)
         db_session.commit()
         assert self._get(client, f"/v2/quotes/{q.id}", test_user) == 200
-
-    def test_v2_prospecting_id_param(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/prospecting/5", test_user) == 200
 
     def test_v2_sourcing_page(self, client: TestClient, db_session: Session, test_user: User):
         req = _requisition(db_session, test_user)
@@ -220,9 +196,6 @@ class TestV2PagePathVariants:
         db_session.commit()
         assert self._get(client, f"/v2/sourcing/{r.id}/workspace", test_user) == 200
 
-    def test_v2_sourcing_lead_page(self, client: TestClient, test_user: User):
-        assert self._get(client, "/v2/sourcing/leads/1", test_user) == 200
-
     def test_v2_unauthenticated_returns_login(self, unauthenticated_client: TestClient):
         with patch("app.routers.htmx_views.get_user", return_value=None):
             resp = unauthenticated_client.get("/v2/buy-plans")
@@ -235,17 +208,16 @@ class TestV2PagePathVariants:
 
 
 class TestBuyPlansRoutes:
-    def test_buy_plans_list(self, client: TestClient):
-        resp = client.get("/v2/partials/buy-plans")
-        assert resp.status_code == 200
-
-    def test_buy_plans_list_with_filter(self, client: TestClient):
-        resp = client.get("/v2/partials/buy-plans?q=test&status=pending")
-        assert resp.status_code == 200
-
-    def test_buy_plans_list_mine(self, client: TestClient):
-        resp = client.get("/v2/partials/buy-plans?mine=true")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/buy-plans",
+            "/v2/partials/buy-plans?q=test&status=pending",
+            "/v2/partials/buy-plans?mine=true",
+        ],
+    )
+    def test_buy_plans_list_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
     def test_buy_plan_detail_404(self, client: TestClient):
         resp = client.get("/v2/partials/buy-plans/99999")
@@ -269,12 +241,9 @@ class TestBuyPlansRoutes:
         resp = client.post(f"/v2/partials/buy-plans/{bp.id}/submit", data={})
         assert resp.status_code == 400
 
-    def test_buy_plan_cancel_404(self, client: TestClient):
-        resp = client.post("/v2/partials/buy-plans/99999/cancel", data={})
-        assert resp.status_code in (404, 400, 422)
-
-    def test_buy_plan_reset_404(self, client: TestClient):
-        resp = client.post("/v2/partials/buy-plans/99999/reset", data={})
+    @pytest.mark.parametrize("action", ["cancel", "reset"])
+    def test_buy_plan_post_missing_404(self, client: TestClient, action: str):
+        resp = client.post(f"/v2/partials/buy-plans/99999/{action}", data={})
         assert resp.status_code in (404, 400, 422)
 
 
@@ -284,9 +253,17 @@ class TestBuyPlansRoutes:
 
 
 class TestSourcingRoutes:
-    def test_sourcing_results_404(self, client: TestClient):
-        resp = client.get("/v2/partials/sourcing/99999")
-        assert resp.status_code == 404
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/sourcing/99999",
+            "/v2/partials/sourcing/99999/workspace",
+            "/v2/partials/sourcing/99999/workspace-list",
+            "/v2/partials/sourcing/leads/99999/panel",
+        ],
+    )
+    def test_sourcing_get_404(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 404
 
     def test_sourcing_results_exists(self, client: TestClient, db_session: Session, test_user: User):
         req = _requisition(db_session, test_user)
@@ -302,24 +279,12 @@ class TestSourcingRoutes:
         resp = client.get(f"/v2/partials/sourcing/{r.id}?confidence=high&sort=freshest")
         assert resp.status_code == 200
 
-    def test_sourcing_workspace_404(self, client: TestClient):
-        resp = client.get("/v2/partials/sourcing/99999/workspace")
-        assert resp.status_code == 404
-
     def test_sourcing_workspace_exists(self, client: TestClient, db_session: Session, test_user: User):
         req = _requisition(db_session, test_user)
         r = _requirement(db_session, req)
         db_session.commit()
         resp = client.get(f"/v2/partials/sourcing/{r.id}/workspace")
         assert resp.status_code == 200
-
-    def test_sourcing_workspace_list_404(self, client: TestClient):
-        resp = client.get("/v2/partials/sourcing/99999/workspace-list")
-        assert resp.status_code == 404
-
-    def test_sourcing_lead_panel_404(self, client: TestClient):
-        resp = client.get("/v2/partials/sourcing/leads/99999/panel")
-        assert resp.status_code == 404
 
     def test_sourcing_search_post_404(self, client: TestClient):
         resp = client.post("/v2/partials/sourcing/99999/search", data={})
@@ -332,53 +297,33 @@ class TestSourcingRoutes:
 
 
 class TestMaterialsRoutes:
-    def test_materials_list(self, client: TestClient):
-        resp = client.get("/v2/partials/materials")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/materials",
+            "/v2/partials/materials/workspace",
+            "/v2/partials/materials/filters/manufacturers",
+            "/v2/partials/materials/filters/manufacturers?commodity=resistors",
+            "/v2/partials/manufacturers/search",
+            "/v2/partials/manufacturers/search?q=Texas",
+            "/v2/partials/materials/filters/tree",
+            "/v2/partials/materials/filters/sub",
+            "/v2/partials/materials/ai-interpret",
+            "/v2/partials/materials/faceted",
+        ],
+    )
+    def test_materials_get_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
-    def test_materials_workspace(self, client: TestClient):
-        resp = client.get("/v2/partials/materials/workspace")
-        assert resp.status_code == 200
-
-    def test_materials_filters_manufacturers(self, client: TestClient):
-        resp = client.get("/v2/partials/materials/filters/manufacturers")
-        assert resp.status_code == 200
-
-    def test_materials_filters_manufacturers_with_commodity(self, client: TestClient):
-        resp = client.get("/v2/partials/materials/filters/manufacturers?commodity=resistors")
-        assert resp.status_code == 200
-
-    def test_manufacturer_search_empty(self, client: TestClient):
-        resp = client.get("/v2/partials/manufacturers/search")
-        assert resp.status_code == 200
-
-    def test_manufacturer_search_with_query(self, client: TestClient):
-        resp = client.get("/v2/partials/manufacturers/search?q=Texas")
-        assert resp.status_code == 200
-
-    def test_materials_filters_tree(self, client: TestClient):
-        resp = client.get("/v2/partials/materials/filters/tree")
-        assert resp.status_code == 200
-
-    def test_materials_filters_sub(self, client: TestClient):
-        resp = client.get("/v2/partials/materials/filters/sub")
-        assert resp.status_code == 200
-
-    def test_materials_ai_interpret(self, client: TestClient):
-        resp = client.get("/v2/partials/materials/ai-interpret")
-        assert resp.status_code == 200
-
-    def test_materials_faceted(self, client: TestClient):
-        resp = client.get("/v2/partials/materials/faceted")
-        assert resp.status_code == 200
-
-    def test_materials_detail_404(self, client: TestClient):
-        resp = client.get("/v2/partials/materials/99999")
-        assert resp.status_code == 404
-
-    def test_materials_insights_404(self, client: TestClient):
-        resp = client.get("/v2/partials/materials/99999/insights")
-        assert resp.status_code == 404
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/materials/99999",
+            "/v2/partials/materials/99999/insights",
+        ],
+    )
+    def test_materials_get_404(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 404
 
     def test_manufacturer_add_empty(self, client: TestClient):
         resp = client.post("/v2/partials/manufacturers/add", data={})
@@ -391,13 +336,17 @@ class TestMaterialsRoutes:
 
 
 class TestQuotesRoutes:
-    def test_quotes_list(self, client: TestClient):
-        resp = client.get("/v2/partials/quotes")
-        assert resp.status_code == 200
-
-    def test_quotes_list_with_filter(self, client: TestClient):
-        resp = client.get("/v2/partials/quotes?q=Q-001&status=draft")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/quotes",
+            "/v2/partials/quotes?q=Q-001&status=draft",
+            "/v2/partials/quotes/recent-terms",
+            "/v2/partials/pricing-history/LM317T",
+        ],
+    )
+    def test_quotes_get_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
     def test_quote_detail_404(self, client: TestClient):
         resp = client.get("/v2/partials/quotes/99999")
@@ -410,29 +359,20 @@ class TestQuotesRoutes:
         resp = client.get(f"/v2/partials/quotes/{q.id}")
         assert resp.status_code == 200
 
-    def test_quote_recent_terms(self, client: TestClient):
-        resp = client.get("/v2/partials/quotes/recent-terms")
-        assert resp.status_code == 200
-
-    def test_pricing_history(self, client: TestClient):
-        resp = client.get("/v2/partials/pricing-history/LM317T")
-        assert resp.status_code == 200
-
     def test_quote_delete_404(self, client: TestClient):
         resp = client.delete("/v2/partials/quotes/99999")
         assert resp.status_code == 404
 
-    def test_quote_reopen_404(self, client: TestClient):
-        resp = client.post("/v2/partials/quotes/99999/reopen")
-        assert resp.status_code == 404
-
-    def test_quote_preview_404(self, client: TestClient):
-        resp = client.post("/v2/partials/quotes/99999/preview")
-        assert resp.status_code == 404
-
-    def test_quote_send_404(self, client: TestClient):
-        resp = client.post("/v2/partials/quotes/99999/send", data={})
-        assert resp.status_code == 404
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/quotes/99999/reopen",
+            "/v2/partials/quotes/99999/preview",
+            "/v2/partials/quotes/99999/send",
+        ],
+    )
+    def test_quote_post_404(self, client: TestClient, path: str):
+        assert client.post(path, data={}).status_code == 404
 
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -441,21 +381,17 @@ class TestQuotesRoutes:
 
 
 class TestProspectingRoutes:
-    def test_prospecting_list(self, client: TestClient):
-        resp = client.get("/v2/partials/prospecting")
-        assert resp.status_code == 200
-
-    def test_prospecting_list_with_filter(self, client: TestClient):
-        resp = client.get("/v2/partials/prospecting?q=acme&sort=fit_desc")
-        assert resp.status_code == 200
-
-    def test_prospecting_list_recent_sort(self, client: TestClient):
-        resp = client.get("/v2/partials/prospecting?sort=recent_desc")
-        assert resp.status_code == 200
-
-    def test_prospecting_stats(self, client: TestClient):
-        resp = client.get("/v2/partials/prospecting/stats")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/prospecting",
+            "/v2/partials/prospecting?q=acme&sort=fit_desc",
+            "/v2/partials/prospecting?sort=recent_desc",
+            "/v2/partials/prospecting/stats",
+        ],
+    )
+    def test_prospecting_get_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
     def test_prospecting_add_domain_empty(self, client: TestClient):
         resp = client.post("/v2/partials/prospecting/add-domain", data={})
@@ -478,12 +414,9 @@ class TestProspectingRoutes:
         resp = client.post("/v2/partials/prospecting/99999/claim")
         assert resp.status_code == 400
 
-    def test_prospecting_dismiss_404(self, client: TestClient):
-        resp = client.post("/v2/partials/prospecting/99999/dismiss")
-        assert resp.status_code == 404
-
-    def test_prospecting_enrich_404(self, client: TestClient):
-        resp = client.post("/v2/partials/prospecting/99999/enrich")
+    @pytest.mark.parametrize("action", ["dismiss", "enrich"])
+    def test_prospecting_post_404(self, client: TestClient, action: str):
+        resp = client.post(f"/v2/partials/prospecting/99999/{action}")
         assert resp.status_code == 404
 
 
@@ -493,21 +426,17 @@ class TestProspectingRoutes:
 
 
 class TestSettingsRoutes:
-    def test_settings_partial(self, client: TestClient):
-        resp = client.get("/v2/partials/settings")
-        assert resp.status_code == 200
-
-    def test_settings_partial_with_tab(self, client: TestClient):
-        resp = client.get("/v2/partials/settings?tab=profile")
-        assert resp.status_code == 200
-
-    def test_settings_sources(self, client: TestClient):
-        resp = client.get("/v2/partials/settings/sources")
-        assert resp.status_code == 200
-
-    def test_settings_profile(self, client: TestClient):
-        resp = client.get("/v2/partials/settings/profile")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/settings",
+            "/v2/partials/settings?tab=profile",
+            "/v2/partials/settings/sources",
+            "/v2/partials/settings/profile",
+        ],
+    )
+    def test_settings_get_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
     def test_settings_system_non_admin(self, client: TestClient):
         # test_user is a 'buyer' — should get 403
@@ -630,13 +559,9 @@ class TestProactiveRoutes:
         resp = client.post("/v2/partials/proactive/draft", data={})
         assert resp.status_code == 200
 
-    def test_proactive_knowledge_list(self, client: TestClient):
-        resp = client.get("/v2/partials/knowledge")
-        assert resp.status_code == 200
-
-    def test_proactive_knowledge_search(self, client: TestClient):
-        resp = client.get("/v2/partials/knowledge?q=resistor")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize("path", ["/v2/partials/knowledge", "/v2/partials/knowledge?q=resistor"])
+    def test_proactive_knowledge_get_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -645,13 +570,13 @@ class TestProactiveRoutes:
 
 
 class TestAdminMergeRoutes:
-    def test_vendor_merge_non_admin(self, client: TestClient):
-        resp = client.post("/v2/partials/admin/vendor-merge", data={"keep_id": "1", "remove_id": "2"})
+    @pytest.mark.parametrize(
+        "path",
+        ["/v2/partials/admin/vendor-merge", "/v2/partials/admin/company-merge"],
+    )
+    def test_merge_non_admin_403(self, client: TestClient, path: str):
         # buyer user → 403
-        assert resp.status_code == 403
-
-    def test_company_merge_non_admin(self, client: TestClient):
-        resp = client.post("/v2/partials/admin/company-merge", data={"keep_id": "1", "remove_id": "2"})
+        resp = client.post(path, data={"keep_id": "1", "remove_id": "2"})
         assert resp.status_code == 403
 
 
@@ -661,10 +586,17 @@ class TestAdminMergeRoutes:
 
 
 class TestInsightsRoutes:
-    def test_requisition_insights_any_id(self, client: TestClient):
-        # Returns 200 even for non-existent IDs (renders "no insights" state)
-        resp = client.get("/v2/partials/requisitions/99999/insights")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # Returns 200 even for non-existent IDs (renders "no insights" state)
+            "/v2/partials/requisitions/99999/insights",
+            "/v2/partials/vendors/99999/insights",
+            "/v2/partials/customers/99999/insights",
+        ],
+    )
+    def test_insights_any_id_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
     def test_requisition_insights_exists(self, client: TestClient, db_session: Session, test_user: User):
         req = _requisition(db_session, test_user)
@@ -672,18 +604,10 @@ class TestInsightsRoutes:
         resp = client.get(f"/v2/partials/requisitions/{req.id}/insights")
         assert resp.status_code == 200
 
-    def test_vendor_insights_any_id(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors/99999/insights")
-        assert resp.status_code == 200
-
     def test_vendor_insights_exists(self, client: TestClient, db_session: Session):
         vc = _vendor_card(db_session)
         db_session.commit()
         resp = client.get(f"/v2/partials/vendors/{vc.id}/insights")
-        assert resp.status_code == 200
-
-    def test_customer_insights_any_id(self, client: TestClient):
-        resp = client.get("/v2/partials/customers/99999/insights")
         assert resp.status_code == 200
 
     def test_customer_insights_exists(self, client: TestClient, db_session: Session):
@@ -734,46 +658,14 @@ class TestDashboardRoutes:
 
 
 class TestRequisitionTabs:
-    def test_tab_parts(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize(
+        "tab",
+        ["parts", "offers", "quotes", "buy_plans", "tasks", "activity", "responses"],
+    )
+    def test_tab_ok(self, client: TestClient, db_session: Session, test_user: User, tab: str):
         req = _requisition(db_session, test_user)
         db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/parts")
-        assert resp.status_code == 200
-
-    def test_tab_offers(self, client: TestClient, db_session: Session, test_user: User):
-        req = _requisition(db_session, test_user)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/offers")
-        assert resp.status_code == 200
-
-    def test_tab_quotes(self, client: TestClient, db_session: Session, test_user: User):
-        req = _requisition(db_session, test_user)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/quotes")
-        assert resp.status_code == 200
-
-    def test_tab_buy_plans(self, client: TestClient, db_session: Session, test_user: User):
-        req = _requisition(db_session, test_user)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/buy_plans")
-        assert resp.status_code == 200
-
-    def test_tab_tasks(self, client: TestClient, db_session: Session, test_user: User):
-        req = _requisition(db_session, test_user)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/tasks")
-        assert resp.status_code == 200
-
-    def test_tab_activity(self, client: TestClient, db_session: Session, test_user: User):
-        req = _requisition(db_session, test_user)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/activity")
-        assert resp.status_code == 200
-
-    def test_tab_responses(self, client: TestClient, db_session: Session, test_user: User):
-        req = _requisition(db_session, test_user)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/responses")
+        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/{tab}")
         assert resp.status_code == 200
 
     def test_tab_unknown_404(self, client: TestClient, db_session: Session, test_user: User):
@@ -793,16 +685,11 @@ class TestRequisitionTabs:
 
 
 class TestParseForms:
-    def test_parse_email_form(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("form", ["parse-email-form", "paste-offer-form"])
+    def test_form_ok(self, client: TestClient, db_session: Session, test_user: User, form: str):
         req = _requisition(db_session, test_user)
         db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/parse-email-form")
-        assert resp.status_code == 200
-
-    def test_paste_offer_form(self, client: TestClient, db_session: Session, test_user: User):
-        req = _requisition(db_session, test_user)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/paste-offer-form")
+        resp = client.get(f"/v2/partials/requisitions/{req.id}/{form}")
         assert resp.status_code == 200
 
     def test_parse_email_form_404(self, client: TestClient):
@@ -909,13 +796,9 @@ class TestRfqRoutes:
 
 
 class TestFollowUpRoutes:
-    def test_follow_ups_list(self, client: TestClient):
-        resp = client.get("/v2/partials/follow-ups")
-        assert resp.status_code == 200
-
-    def test_follow_ups_list_with_filter(self, client: TestClient):
-        resp = client.get("/v2/partials/follow-ups?q=test")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize("path", ["/v2/partials/follow-ups", "/v2/partials/follow-ups?q=test"])
+    def test_follow_ups_list_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
     def test_follow_ups_send_batch_empty(self, client: TestClient):
         resp = client.post("/v2/partials/follow-ups/send-batch", data={})
@@ -932,26 +815,22 @@ class TestFollowUpRoutes:
 
 
 class TestSearchRoutes:
-    def test_search_partial(self, client: TestClient):
-        resp = client.get("/v2/partials/search")
-        assert resp.status_code == 200
-
-    def test_search_filter_with_id(self, client: TestClient):
-        # search_id is required; missing results → returns "expired" message
-        resp = client.get("/v2/partials/search/filter?search_id=nonexistent")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/search",
+            # search_id is required; missing results → returns "expired" message
+            "/v2/partials/search/filter?search_id=nonexistent",
+            "/v2/partials/search/requisition-picker",
+            "/v2/partials/search/requisition-picker?q=REQ",
+        ],
+    )
+    def test_search_get_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
     def test_search_lead_detail_missing(self, client: TestClient):
         resp = client.get("/v2/partials/search/lead-detail?lead_id=99999")
         assert resp.status_code in (200, 404)
-
-    def test_search_requisition_picker(self, client: TestClient):
-        resp = client.get("/v2/partials/search/requisition-picker")
-        assert resp.status_code == 200
-
-    def test_search_requisition_picker_with_q(self, client: TestClient):
-        resp = client.get("/v2/partials/search/requisition-picker?q=REQ")
-        assert resp.status_code == 200
 
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -960,34 +839,30 @@ class TestSearchRoutes:
 
 
 class TestVendorDetailRoutes:
-    def test_vendor_edit_form_404(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors/99999/edit-form")
+    @pytest.mark.parametrize(
+        "suffix",
+        ["edit-form", "reviews", "contact-nudges"],
+    )
+    def test_vendor_get_404(self, client: TestClient, suffix: str):
+        resp = client.get(f"/v2/partials/vendors/99999/{suffix}")
         assert resp.status_code == 404
 
-    def test_vendor_edit_form_exists(self, client: TestClient, db_session: Session):
+    @pytest.mark.parametrize(
+        "suffix",
+        [
+            "edit-form",
+            "reviews",
+            "contact-nudges",
+            "tab/contacts",
+            "tab/overview",
+            "tab/offers",
+            "tab/emails",
+        ],
+    )
+    def test_vendor_get_exists_ok(self, client: TestClient, db_session: Session, suffix: str):
         vc = _vendor_card(db_session)
         db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/edit-form")
-        assert resp.status_code == 200
-
-    def test_vendor_reviews_404(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors/99999/reviews")
-        assert resp.status_code == 404
-
-    def test_vendor_reviews_exists(self, client: TestClient, db_session: Session):
-        vc = _vendor_card(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/reviews")
-        assert resp.status_code == 200
-
-    def test_vendor_contact_nudges_404(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors/99999/contact-nudges")
-        assert resp.status_code == 404
-
-    def test_vendor_contact_nudges_exists(self, client: TestClient, db_session: Session):
-        vc = _vendor_card(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/contact-nudges")
+        resp = client.get(f"/v2/partials/vendors/{vc.id}/{suffix}")
         assert resp.status_code == 200
 
     def test_vendor_tab_rfq_invalid(self, client: TestClient, db_session: Session):
@@ -996,30 +871,6 @@ class TestVendorDetailRoutes:
         # "rfq" not in valid_tabs → 404
         resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/rfq")
         assert resp.status_code == 404
-
-    def test_vendor_tab_contacts(self, client: TestClient, db_session: Session):
-        vc = _vendor_card(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/contacts")
-        assert resp.status_code == 200
-
-    def test_vendor_tab_overview(self, client: TestClient, db_session: Session):
-        vc = _vendor_card(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/overview")
-        assert resp.status_code == 200
-
-    def test_vendor_tab_offers(self, client: TestClient, db_session: Session):
-        vc = _vendor_card(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/offers")
-        assert resp.status_code == 200
-
-    def test_vendor_tab_emails(self, client: TestClient, db_session: Session):
-        vc = _vendor_card(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/emails")
-        assert resp.status_code == 200
 
     def test_vendor_toggle_blacklist_404(self, client: TestClient):
         resp = client.post("/v2/partials/vendors/99999/toggle-blacklist")
@@ -1032,48 +883,30 @@ class TestVendorDetailRoutes:
 
 
 class TestCustomerRoutes:
-    def test_customers_list(self, client: TestClient):
-        resp = client.get("/v2/partials/customers")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v2/partials/customers",
+            "/v2/partials/customers?q=acme",
+            "/v2/partials/customers/create-form",
+            "/v2/partials/customers/typeahead",
+            "/v2/partials/customers/typeahead?q=acme",
+            "/v2/partials/customers/check-duplicate?name=TestCo",
+        ],
+    )
+    def test_customers_get_ok(self, client: TestClient, path: str):
+        assert client.get(path).status_code == 200
 
-    def test_customers_list_with_filter(self, client: TestClient):
-        resp = client.get("/v2/partials/customers?q=acme")
-        assert resp.status_code == 200
-
-    def test_create_form(self, client: TestClient):
-        resp = client.get("/v2/partials/customers/create-form")
-        assert resp.status_code == 200
-
-    def test_typeahead_empty(self, client: TestClient):
-        resp = client.get("/v2/partials/customers/typeahead")
-        assert resp.status_code == 200
-
-    def test_typeahead_with_q(self, client: TestClient):
-        resp = client.get("/v2/partials/customers/typeahead?q=acme")
-        assert resp.status_code == 200
-
-    def test_check_duplicate(self, client: TestClient):
-        resp = client.get("/v2/partials/customers/check-duplicate?name=TestCo")
-        assert resp.status_code == 200
-
-    def test_customer_detail_404(self, client: TestClient):
-        resp = client.get("/v2/partials/customers/99999")
+    @pytest.mark.parametrize("suffix", ["", "/edit-form"])
+    def test_customer_get_404(self, client: TestClient, suffix: str):
+        resp = client.get(f"/v2/partials/customers/99999{suffix}")
         assert resp.status_code == 404
 
-    def test_customer_detail_exists(self, client: TestClient, db_session: Session):
+    @pytest.mark.parametrize("suffix", ["", "/edit-form"])
+    def test_customer_get_exists_ok(self, client: TestClient, db_session: Session, suffix: str):
         co = _company(db_session)
         db_session.commit()
-        resp = client.get(f"/v2/partials/customers/{co.id}")
-        assert resp.status_code == 200
-
-    def test_customer_edit_form_404(self, client: TestClient):
-        resp = client.get("/v2/partials/customers/99999/edit-form")
-        assert resp.status_code == 404
-
-    def test_customer_edit_form_exists(self, client: TestClient, db_session: Session):
-        co = _company(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/customers/{co.id}/edit-form")
+        resp = client.get(f"/v2/partials/customers/{co.id}{suffix}")
         assert resp.status_code == 200
 
 
@@ -1083,10 +916,11 @@ class TestCustomerRoutes:
 
 
 class TestRequisitionEditRoutes:
-    def test_edit_field_name(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("field", ["name", "status"])
+    def test_edit_field_ok(self, client: TestClient, db_session: Session, test_user: User, field: str):
         req = _requisition(db_session, test_user)
         db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/edit/name")
+        resp = client.get(f"/v2/partials/requisitions/{req.id}/edit/{field}")
         assert resp.status_code == 200
 
     def test_edit_field_invalid_returns_400(self, client: TestClient, db_session: Session, test_user: User):
@@ -1095,12 +929,6 @@ class TestRequisitionEditRoutes:
         # "customer_name" not in valid_fields → 400
         resp = client.get(f"/v2/partials/requisitions/{req.id}/edit/customer_name")
         assert resp.status_code == 400
-
-    def test_edit_field_status(self, client: TestClient, db_session: Session, test_user: User):
-        req = _requisition(db_session, test_user)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/edit/status")
-        assert resp.status_code == 200
 
     def test_edit_field_404(self, client: TestClient):
         resp = client.get("/v2/partials/requisitions/99999/edit/name")
@@ -1113,10 +941,7 @@ class TestRequisitionEditRoutes:
 
 
 class TestBulkActions:
-    def test_bulk_close_empty(self, client: TestClient):
-        resp = client.post("/v2/partials/requisitions/bulk/close", data={})
-        assert resp.status_code in (200, 400)
-
-    def test_bulk_archive_empty(self, client: TestClient):
-        resp = client.post("/v2/partials/requisitions/bulk/archive", data={})
+    @pytest.mark.parametrize("action", ["close", "archive"])
+    def test_bulk_action_empty(self, client: TestClient, action: str):
+        resp = client.post(f"/v2/partials/requisitions/bulk/{action}", data={})
         assert resp.status_code in (200, 400)

--- a/tests/test_htmx_views_nightly19.py
+++ b/tests/test_htmx_views_nightly19.py
@@ -15,6 +15,7 @@ import os
 
 os.environ["TESTING"] = "1"
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -22,6 +23,15 @@ from app.models import Requisition, VendorCard
 from app.models.buy_plan import BuyPlan
 
 # ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _make_company(db: Session, name: str):
+    from app.models import Company
+
+    company = Company(name=name, is_active=True)
+    db.add(company)
+    db.commit()
+    return company
 
 
 def _make_buy_plan(db: Session, req: Requisition, **kw) -> BuyPlan:
@@ -82,20 +92,12 @@ class TestInsights:
         assert resp.status_code == 200
 
     def test_company_insights_panel(self, client: TestClient, db_session: Session):
-        from app.models import Company
-
-        company = Company(name="InsightCo", is_active=True)
-        db_session.add(company)
-        db_session.commit()
+        company = _make_company(db_session, "InsightCo")
         resp = client.get(f"/v2/partials/customers/{company.id}/insights")
         assert resp.status_code == 200
 
     def test_company_insights_refresh(self, client: TestClient, db_session: Session):
-        from app.models import Company
-
-        company = Company(name="InsightCo2", is_active=True)
-        db_session.add(company)
-        db_session.commit()
+        company = _make_company(db_session, "InsightCo2")
         resp = client.post(f"/v2/partials/customers/{company.id}/insights/refresh")
         assert resp.status_code == 200
 
@@ -112,23 +114,20 @@ class TestInsights:
 
 
 class TestBuyPlansListPartial:
-    def test_list_empty(self, client: TestClient):
-        resp = client.get("/v2/partials/buy-plans")
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param("/v2/partials/buy-plans", id="empty"),
+            pytest.param("/v2/partials/buy-plans?status=draft", id="filter_status"),
+            pytest.param("/v2/partials/buy-plans?mine=true", id="mine_only"),
+            pytest.param("/v2/partials/buy-plans?q=SO-12345", id="search"),
+        ],
+    )
+    def test_list_loads(self, client: TestClient, url: str):
+        resp = client.get(url)
         assert resp.status_code == 200
 
     def test_list_with_plan(self, client: TestClient, db_session: Session, test_requisition: Requisition):
         _make_buy_plan(db_session, test_requisition)
         resp = client.get("/v2/partials/buy-plans")
-        assert resp.status_code == 200
-
-    def test_list_filter_status(self, client: TestClient):
-        resp = client.get("/v2/partials/buy-plans?status=draft")
-        assert resp.status_code == 200
-
-    def test_list_mine_only(self, client: TestClient):
-        resp = client.get("/v2/partials/buy-plans?mine=true")
-        assert resp.status_code == 200
-
-    def test_list_search(self, client: TestClient):
-        resp = client.get("/v2/partials/buy-plans?q=SO-12345")
         assert resp.status_code == 200

--- a/tests/test_htmx_views_nightly29.py
+++ b/tests/test_htmx_views_nightly29.py
@@ -43,6 +43,18 @@ def _json_request(payload: dict) -> MagicMock:
     return req
 
 
+async def _call_bulk(handler, payload, user, db):
+    """Invoke a bulk_archive/unarchive coroutine with parts_list_partial mocked.
+
+    Returns ``(result, mock_list)`` so callers can assert on both the response and
+    the patched partial.
+    """
+    with patch("app.routers.htmx_views.parts_list_partial", new_callable=AsyncMock) as mock_list:
+        mock_list.return_value = HTMLResponse("<div>ok</div>")
+        result = await handler(request=_json_request(payload), user=user, db=db)
+    return result, mock_list
+
+
 def _make_requisition(db: Session, user: User) -> Requisition:
     req = Requisition(name="N29 Req", status="active", created_by=user.id)
     db.add(req)
@@ -73,10 +85,9 @@ class TestBulkArchiveDirect:
         """Lines 9866–9868: body parsed; empty lists skip both if-branches."""
         from app.routers.htmx_views import bulk_archive
 
-        mock_req = _json_request({"requirement_ids": [], "requisition_ids": []})
-        with patch("app.routers.htmx_views.parts_list_partial", new_callable=AsyncMock) as mock_list:
-            mock_list.return_value = HTMLResponse("<div>ok</div>")
-            result = await bulk_archive(request=mock_req, user=test_user, db=db_session)
+        result, mock_list = await _call_bulk(
+            bulk_archive, {"requirement_ids": [], "requisition_ids": []}, test_user, db_session
+        )
 
         assert result.status_code == 200
         mock_list.assert_awaited_once()
@@ -88,10 +99,9 @@ class TestBulkArchiveDirect:
         req = _make_requisition(db_session, test_user)
         part = _make_requirement(db_session, req)
 
-        mock_req = _json_request({"requirement_ids": [part.id], "requisition_ids": []})
-        with patch("app.routers.htmx_views.parts_list_partial", new_callable=AsyncMock) as mock_list:
-            mock_list.return_value = HTMLResponse("<div>ok</div>")
-            result = await bulk_archive(request=mock_req, user=test_user, db=db_session)
+        result, _ = await _call_bulk(
+            bulk_archive, {"requirement_ids": [part.id], "requisition_ids": []}, test_user, db_session
+        )
 
         assert result.status_code == 200
         db_session.refresh(part)
@@ -104,10 +114,9 @@ class TestBulkArchiveDirect:
         req = _make_requisition(db_session, test_user)
         part = _make_requirement(db_session, req)
 
-        mock_req = _json_request({"requirement_ids": [], "requisition_ids": [req.id]})
-        with patch("app.routers.htmx_views.parts_list_partial", new_callable=AsyncMock) as mock_list:
-            mock_list.return_value = HTMLResponse("<div>ok</div>")
-            result = await bulk_archive(request=mock_req, user=test_user, db=db_session)
+        result, _ = await _call_bulk(
+            bulk_archive, {"requirement_ids": [], "requisition_ids": [req.id]}, test_user, db_session
+        )
 
         assert result.status_code == 200
         db_session.refresh(req)
@@ -122,10 +131,9 @@ class TestBulkArchiveDirect:
         req = _make_requisition(db_session, test_user)
         part = _make_requirement(db_session, req)
 
-        mock_req = _json_request({"requirement_ids": [part.id], "requisition_ids": [req.id]})
-        with patch("app.routers.htmx_views.parts_list_partial", new_callable=AsyncMock) as mock_list:
-            mock_list.return_value = HTMLResponse("<div>ok</div>")
-            result = await bulk_archive(request=mock_req, user=test_user, db=db_session)
+        result, _ = await _call_bulk(
+            bulk_archive, {"requirement_ids": [part.id], "requisition_ids": [req.id]}, test_user, db_session
+        )
 
         assert result.status_code == 200
 
@@ -140,10 +148,9 @@ class TestBulkUnarchiveDirect:
         """Lines 9902–9904: body parsed; empty lists skip both if-branches."""
         from app.routers.htmx_views import bulk_unarchive
 
-        mock_req = _json_request({"requirement_ids": [], "requisition_ids": []})
-        with patch("app.routers.htmx_views.parts_list_partial", new_callable=AsyncMock) as mock_list:
-            mock_list.return_value = HTMLResponse("<div>ok</div>")
-            result = await bulk_unarchive(request=mock_req, user=test_user, db=db_session)
+        result, mock_list = await _call_bulk(
+            bulk_unarchive, {"requirement_ids": [], "requisition_ids": []}, test_user, db_session
+        )
 
         assert result.status_code == 200
         mock_list.assert_awaited_once()
@@ -159,10 +166,9 @@ class TestBulkUnarchiveDirect:
         part.sourcing_status = SourcingStatus.ARCHIVED
         db_session.commit()
 
-        mock_req = _json_request({"requirement_ids": [part.id], "requisition_ids": []})
-        with patch("app.routers.htmx_views.parts_list_partial", new_callable=AsyncMock) as mock_list:
-            mock_list.return_value = HTMLResponse("<div>ok</div>")
-            result = await bulk_unarchive(request=mock_req, user=test_user, db=db_session)
+        result, _ = await _call_bulk(
+            bulk_unarchive, {"requirement_ids": [part.id], "requisition_ids": []}, test_user, db_session
+        )
 
         assert result.status_code == 200
         db_session.refresh(part)
@@ -178,10 +184,9 @@ class TestBulkUnarchiveDirect:
         part.sourcing_status = SourcingStatus.ARCHIVED
         db_session.commit()
 
-        mock_req = _json_request({"requirement_ids": [], "requisition_ids": [req.id]})
-        with patch("app.routers.htmx_views.parts_list_partial", new_callable=AsyncMock) as mock_list:
-            mock_list.return_value = HTMLResponse("<div>ok</div>")
-            result = await bulk_unarchive(request=mock_req, user=test_user, db=db_session)
+        result, _ = await _call_bulk(
+            bulk_unarchive, {"requirement_ids": [], "requisition_ids": [req.id]}, test_user, db_session
+        )
 
         assert result.status_code == 200
         db_session.refresh(req)
@@ -199,9 +204,8 @@ class TestBulkUnarchiveDirect:
         part.sourcing_status = SourcingStatus.ARCHIVED
         db_session.commit()
 
-        mock_req = _json_request({"requirement_ids": [part.id], "requisition_ids": [req.id]})
-        with patch("app.routers.htmx_views.parts_list_partial", new_callable=AsyncMock) as mock_list:
-            mock_list.return_value = HTMLResponse("<div>ok</div>")
-            result = await bulk_unarchive(request=mock_req, user=test_user, db=db_session)
+        result, _ = await _call_bulk(
+            bulk_unarchive, {"requirement_ids": [part.id], "requisition_ids": [req.id]}, test_user, db_session
+        )
 
         assert result.status_code == 200

--- a/tests/test_jobs_coverage.py
+++ b/tests/test_jobs_coverage.py
@@ -129,17 +129,20 @@ def _make_req_mock(id_, deadline, req_name):
     return SimpleNamespace(id=id_, deadline=deadline, name=req_name, status="active")
 
 
+def _db_returning_reqs(mock_db, reqs):
+    """Wire mock_db.query so the bid-due-alerts query returns ``reqs``."""
+    mock_query = MagicMock()
+    mock_query.filter.return_value.limit.return_value.all.return_value = reqs
+    mock_db.query.return_value = mock_query
+
+
 class TestJobBidDueAlerts:
     def test_creates_tasks_for_approaching_deadlines(self):
         """_job_bid_due_alerts creates tasks for requisitions with deadlines within 2
         days."""
         mock_db = MagicMock()
         tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
-        mock_req = _make_req_mock(1, tomorrow, "REQ-001")
-
-        mock_query = MagicMock()
-        mock_query.filter.return_value.limit.return_value.all.return_value = [mock_req]
-        mock_db.query.return_value = mock_query
+        _db_returning_reqs(mock_db, [_make_req_mock(1, tomorrow, "REQ-001")])
 
         mock_on_bid_due = MagicMock(return_value=MagicMock())
 
@@ -157,11 +160,7 @@ class TestJobBidDueAlerts:
     def test_skips_non_iso_deadlines(self):
         """_job_bid_due_alerts skips requisitions with non-ISO deadlines."""
         mock_db = MagicMock()
-        mock_req = _make_req_mock(1, "not-a-date", "REQ-002")
-
-        mock_query = MagicMock()
-        mock_query.filter.return_value.limit.return_value.all.return_value = [mock_req]
-        mock_db.query.return_value = mock_query
+        _db_returning_reqs(mock_db, [_make_req_mock(1, "not-a-date", "REQ-002")])
 
         mock_on_bid_due = MagicMock()
 
@@ -176,37 +175,18 @@ class TestJobBidDueAlerts:
         mock_on_bid_due.assert_not_called()
         mock_db.close.assert_called_once()
 
-    def test_skips_far_future_deadlines(self):
-        """_job_bid_due_alerts skips requisitions with deadlines > 2 days away."""
+    @pytest.mark.parametrize(
+        ("days_offset", "req_name"),
+        [
+            pytest.param(10, "REQ-003", id="far_future_deadlines"),
+            pytest.param(-5, "REQ-004", id="old_past_deadlines"),
+        ],
+    )
+    def test_skips_out_of_window_deadlines(self, days_offset, req_name):
+        """_job_bid_due_alerts skips deadlines > 2 days out or > 1 day in the past."""
         mock_db = MagicMock()
-        far_future = (datetime.now(timezone.utc) + timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%S")
-        mock_req = _make_req_mock(1, far_future, "REQ-003")
-
-        mock_query = MagicMock()
-        mock_query.filter.return_value.limit.return_value.all.return_value = [mock_req]
-        mock_db.query.return_value = mock_query
-
-        mock_on_bid_due = MagicMock()
-
-        with (
-            patch("app.database.SessionLocal", return_value=mock_db),
-            patch("app.services.task_service.on_bid_due_soon", mock_on_bid_due),
-        ):
-            from app.jobs.task_jobs import _job_bid_due_alerts
-
-            asyncio.run(_job_bid_due_alerts())
-
-        mock_on_bid_due.assert_not_called()
-
-    def test_skips_old_past_deadlines(self):
-        """_job_bid_due_alerts skips deadlines more than 1 day in the past."""
-        mock_db = MagicMock()
-        old_past = (datetime.now(timezone.utc) - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%S")
-        mock_req = _make_req_mock(1, old_past, "REQ-004")
-
-        mock_query = MagicMock()
-        mock_query.filter.return_value.limit.return_value.all.return_value = [mock_req]
-        mock_db.query.return_value = mock_query
+        deadline = (datetime.now(timezone.utc) + timedelta(days=days_offset)).strftime("%Y-%m-%dT%H:%M:%S")
+        _db_returning_reqs(mock_db, [_make_req_mock(1, deadline, req_name)])
 
         mock_on_bid_due = MagicMock()
 
@@ -227,10 +207,7 @@ class TestJobBidDueAlerts:
         mock_db = MagicMock()
         tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
         mock_reqs = [_make_req_mock(i, tomorrow, f"REQ-{i}") for i in range(_BID_DUE_CAP + 5)]
-
-        mock_query = MagicMock()
-        mock_query.filter.return_value.limit.return_value.all.return_value = mock_reqs
-        mock_db.query.return_value = mock_query
+        _db_returning_reqs(mock_db, mock_reqs)
 
         mock_on_bid_due = MagicMock(return_value=MagicMock())  # Always returns a task
 
@@ -247,9 +224,7 @@ class TestJobBidDueAlerts:
     def test_no_reqs_found(self):
         """_job_bid_due_alerts handles no matching requisitions."""
         mock_db = MagicMock()
-        mock_query = MagicMock()
-        mock_query.filter.return_value.limit.return_value.all.return_value = []
-        mock_db.query.return_value = mock_query
+        _db_returning_reqs(mock_db, [])
 
         mock_on_bid_due = MagicMock()
 
@@ -270,10 +245,7 @@ class TestJobBidDueAlerts:
         mock_db = MagicMock()
         tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
         mock_reqs = [_make_req_mock(i, tomorrow, f"REQ-{i}") for i in range(3)]
-
-        mock_query = MagicMock()
-        mock_query.filter.return_value.limit.return_value.all.return_value = mock_reqs
-        mock_db.query.return_value = mock_query
+        _db_returning_reqs(mock_db, mock_reqs)
 
         mock_on_bid_due = MagicMock(side_effect=[MagicMock(), None, MagicMock()])
 
@@ -305,11 +277,7 @@ class TestJobBidDueAlerts:
         """Naive datetime deadlines are treated as UTC."""
         mock_db = MagicMock()
         tomorrow = (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%d")
-        mock_req = _make_req_mock(1, tomorrow, "REQ-TZ")
-
-        mock_query = MagicMock()
-        mock_query.filter.return_value.limit.return_value.all.return_value = [mock_req]
-        mock_db.query.return_value = mock_query
+        _db_returning_reqs(mock_db, [_make_req_mock(1, tomorrow, "REQ-TZ")])
 
         mock_on_bid_due = MagicMock(return_value=MagicMock())
 
@@ -678,6 +646,11 @@ class TestJobExpireStale:
 # ═══════════════════════════════════════════════════════════════════════
 
 
+async def _run_fn_to_thread(fn, *args):
+    """asyncio.to_thread stand-in that runs the callable synchronously."""
+    return fn(*args)
+
+
 class TestRegisterTaggingJobs:
     def test_registers_all_jobs_unconditionally(self):
         """register_tagging_jobs adds the 5 tagging/spec jobs unconditionally.
@@ -708,13 +681,10 @@ class TestJobInternalBoost:
         mock_db = MagicMock()
         mock_boost = MagicMock(return_value={"boosted": 10})
 
-        async def fake_to_thread(fn, *args):
-            return fn(*args)
-
         with (
             patch("app.database.SessionLocal", return_value=mock_db),
             patch("app.services.enrichment.boost_confidence_internal", mock_boost),
-            patch("asyncio.to_thread", side_effect=fake_to_thread),
+            patch("asyncio.to_thread", side_effect=_run_fn_to_thread),
         ):
             from app.jobs.tagging_jobs import _job_internal_boost
 
@@ -727,13 +697,10 @@ class TestJobInternalBoost:
         """Exception rolls back and re-raises."""
         mock_db = MagicMock()
 
-        async def fake_to_thread(fn, *args):
-            return fn(*args)
-
         with (
             patch("app.database.SessionLocal", return_value=mock_db),
             patch("app.services.enrichment.boost_confidence_internal", side_effect=Exception("Boost failed")),
-            patch("asyncio.to_thread", side_effect=fake_to_thread),
+            patch("asyncio.to_thread", side_effect=_run_fn_to_thread),
         ):
             from app.jobs.tagging_jobs import _job_internal_boost
 
@@ -750,13 +717,10 @@ class TestJobPrefixBackfill:
         mock_db = MagicMock()
         mock_backfill = MagicMock(return_value={"tagged": 5})
 
-        async def fake_to_thread(fn, *args):
-            return fn(*args)
-
         with (
             patch("app.database.SessionLocal", return_value=mock_db),
             patch("app.services.tagging_backfill.run_prefix_backfill", mock_backfill),
-            patch("asyncio.to_thread", side_effect=fake_to_thread),
+            patch("asyncio.to_thread", side_effect=_run_fn_to_thread),
         ):
             from app.jobs.tagging_jobs import _job_prefix_backfill
 
@@ -769,13 +733,10 @@ class TestJobPrefixBackfill:
         """Exception rolls back and re-raises."""
         mock_db = MagicMock()
 
-        async def fake_to_thread(fn, *args):
-            return fn(*args)
-
         with (
             patch("app.database.SessionLocal", return_value=mock_db),
             patch("app.services.tagging_backfill.run_prefix_backfill", side_effect=Exception("Backfill failed")),
-            patch("asyncio.to_thread", side_effect=fake_to_thread),
+            patch("asyncio.to_thread", side_effect=_run_fn_to_thread),
         ):
             from app.jobs.tagging_jobs import _job_prefix_backfill
 
@@ -792,13 +753,10 @@ class TestJobSightingMining:
         mock_db = MagicMock()
         mock_mining = MagicMock(return_value={"mined": 3})
 
-        async def fake_to_thread(fn, *args):
-            return fn(*args)
-
         with (
             patch("app.database.SessionLocal", return_value=mock_db),
             patch("app.services.tagging_backfill.backfill_manufacturer_from_sightings", mock_mining),
-            patch("asyncio.to_thread", side_effect=fake_to_thread),
+            patch("asyncio.to_thread", side_effect=_run_fn_to_thread),
         ):
             from app.jobs.tagging_jobs import _job_sighting_mining
 
@@ -811,16 +769,13 @@ class TestJobSightingMining:
         """Exception rolls back and re-raises."""
         mock_db = MagicMock()
 
-        async def fake_to_thread(fn, *args):
-            return fn(*args)
-
         with (
             patch("app.database.SessionLocal", return_value=mock_db),
             patch(
                 "app.services.tagging_backfill.backfill_manufacturer_from_sightings",
                 side_effect=Exception("Mining failed"),
             ),
-            patch("asyncio.to_thread", side_effect=fake_to_thread),
+            patch("asyncio.to_thread", side_effect=_run_fn_to_thread),
         ):
             from app.jobs.tagging_jobs import _job_sighting_mining
 

--- a/tests/test_mpn_decoder_storage.py
+++ b/tests/test_mpn_decoder_storage.py
@@ -129,11 +129,9 @@ def test_wd_ambiguous_era_shapes_return_none(mpn):
     assert decode_mpn(mpn) is None, f"{mpn} is era-ambiguous — must not decode"
 
 
-def test_non_drive_mpn_returns_none():
-    assert decode_mpn("LM358N") is None
-    assert decode_mpn("GARBAGE123") is None
-    assert decode_mpn("") is None
-    assert decode_mpn(None) is None
+@pytest.mark.parametrize("mpn", ["LM358N", "GARBAGE123", "", None])
+def test_non_drive_mpn_returns_none(mpn):
+    assert decode_mpn(mpn) is None
 
 
 @pytest.mark.parametrize("mpn", ["MGK50", "MGJN9", "DT10171-H7R6-4F", "MDR60"])

--- a/tests/test_nc_phase9.py
+++ b/tests/test_nc_phase9.py
@@ -4,6 +4,8 @@ Called by: pytest
 Depends on: conftest.py, nc_worker.monitoring
 """
 
+import pytest
+
 from app.services.nc_worker.monitoring import (
     _get_hash_set,
     _known_html_hashes,
@@ -12,29 +14,26 @@ from app.services.nc_worker.monitoring import (
 )
 
 
-def test_log_daily_report(capsys):
-    """log_daily_report produces structured log output."""
-    # Just verify it doesn't raise
-    log_daily_report(
-        searches_completed=47,
-        sightings_created=312,
-        parts_gated_out=23,
-        parts_deduped=11,
-        failed_searches=0,
-        queue_remaining=8,
-        circuit_breaker_status="OK",
-    )
+@pytest.mark.parametrize(
+    ("searches_completed", "sightings_created", "parts_gated_out", "parts_deduped", "queue_remaining"),
+    [
+        pytest.param(47, 312, 23, 11, 8, id="active"),
+        pytest.param(0, 0, 0, 0, 0, id="zero_searches"),
+    ],
+)
+def test_log_daily_report(searches_completed, sightings_created, parts_gated_out, parts_deduped, queue_remaining):
+    """log_daily_report produces structured log output without raising.
 
-
-def test_log_daily_report_zero_searches():
-    """Daily report handles zero activity (confirms worker is alive)."""
+    The zero-activity case confirms the report still emits when the worker is alive but
+    idle.
+    """
     log_daily_report(
-        searches_completed=0,
-        sightings_created=0,
-        parts_gated_out=0,
-        parts_deduped=0,
+        searches_completed=searches_completed,
+        sightings_created=sightings_created,
+        parts_gated_out=parts_gated_out,
+        parts_deduped=parts_deduped,
         failed_searches=0,
-        queue_remaining=0,
+        queue_remaining=queue_remaining,
         circuit_breaker_status="OK",
     )
 

--- a/tests/test_partsurfer_resolver.py
+++ b/tests/test_partsurfer_resolver.py
@@ -38,19 +38,28 @@ def _resp(text: str, status_code: int = 200):
 
 
 @pytest.mark.asyncio
-async def test_dimm_fixture_returns_exact_description():
-    resp = _resp(_fixture("dimm_726719-B21.html"))
+@pytest.mark.parametrize(
+    ("fixture", "spare_pn", "expected"),
+    [
+        pytest.param(
+            "dimm_726719-B21.html",
+            "726719-B21",
+            "HPE 16GB (1X16GB) DUAL RANK X4 DDR4-2133 CAS-15-15-15 REGISTERED MEMORY KIT",
+            id="dimm",
+        ),
+        pytest.param(
+            "ssd_875507-B21.html",
+            "875507-B21",
+            "HPE 240GB SATA 6G READ INTENSIVE SFF RW PM883 SSD",
+            id="ssd",
+        ),
+    ],
+)
+async def test_fixture_returns_exact_description(fixture: str, spare_pn: str, expected: str):
+    resp = _resp(_fixture(fixture))
     with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
-        desc = await partsurfer_resolver.fetch_partsurfer_description("726719-B21")
-    assert desc == "HPE 16GB (1X16GB) DUAL RANK X4 DDR4-2133 CAS-15-15-15 REGISTERED MEMORY KIT"
-
-
-@pytest.mark.asyncio
-async def test_ssd_fixture_returns_exact_description():
-    resp = _resp(_fixture("ssd_875507-B21.html"))
-    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
-        desc = await partsurfer_resolver.fetch_partsurfer_description("875507-B21")
-    assert desc == "HPE 240GB SATA 6G READ INTENSIVE SFF RW PM883 SSD"
+        desc = await partsurfer_resolver.fetch_partsurfer_description(spare_pn)
+    assert desc == expected
 
 
 @pytest.mark.asyncio
@@ -67,19 +76,22 @@ async def test_outbound_request_uses_exact_url_and_contact_ua():
 
 
 @pytest.mark.asyncio
-async def test_not_found_fixture_returns_none():
-    # A real-shaped Search.aspx page with no lblDescription span → None (no guess).
-    resp = _resp(_fixture("notfound.html"))
+@pytest.mark.parametrize(
+    ("resp", "spare_pn"),
+    [
+        # A real-shaped Search.aspx page with no lblDescription span → None (no guess).
+        pytest.param(_resp(_fixture("notfound.html")), "ZZZNOTAPART999", id="not_found_fixture"),
+        # A 404/3xx is a GENUINE no-result (not a throttle) → None, the spare moves on.
+        pytest.param(_resp(_fixture("dimm_726719-B21.html"), status_code=404), "726719-B21", id="genuine_non_200"),
+        # The span is present but empty/whitespace → None (an empty string is not a description).
+        pytest.param(
+            _resp('<span id="ctl00_BodyContentPlaceHolder_lblDescription">   </span>'), "726719-B21", id="empty_lbl"
+        ),
+    ],
+)
+async def test_no_result_returns_none(resp, spare_pn: str):
     with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
-        assert await partsurfer_resolver.fetch_partsurfer_description("ZZZNOTAPART999") is None
-
-
-@pytest.mark.asyncio
-async def test_genuine_non_200_returns_none():
-    # A 404/3xx is a GENUINE no-result (not a throttle) → None, the spare moves on.
-    resp = _resp(_fixture("dimm_726719-B21.html"), status_code=404)
-    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
-        assert await partsurfer_resolver.fetch_partsurfer_description("726719-B21") is None
+        assert await partsurfer_resolver.fetch_partsurfer_description(spare_pn) is None
 
 
 @pytest.mark.asyncio
@@ -132,14 +144,6 @@ async def test_text_attribute_raises_returns_none():
             raise ValueError("decode boom")
 
     with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=_BadText())):
-        assert await partsurfer_resolver.fetch_partsurfer_description("726719-B21") is None
-
-
-@pytest.mark.asyncio
-async def test_empty_lbldescription_returns_none():
-    # The span is present but empty/whitespace → None (an empty string is not a description).
-    resp = _resp('<span id="ctl00_BodyContentPlaceHolder_lblDescription">   </span>')
-    with patch.object(partsurfer_resolver.http_redirect, "get", new=AsyncMock(return_value=resp)):
         assert await partsurfer_resolver.fetch_partsurfer_description("726719-B21") is None
 
 

--- a/tests/test_prometheus_metrics.py
+++ b/tests/test_prometheus_metrics.py
@@ -18,6 +18,7 @@ values, so they remain stable when run in parallel with xdist.
 
 from unittest.mock import patch
 
+import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 from starlette.responses import StreamingResponse
@@ -121,36 +122,26 @@ def test_metrics_path_itself_is_excluded() -> None:
     assert 'handler="/metrics"' not in body
 
 
-def test_static_assets_excluded() -> None:
-    """/static/* is excluded — would otherwise create one label per asset filename."""
+@pytest.mark.parametrize(
+    "paths",
+    [
+        # /static/* — would otherwise create one label per asset filename.
+        pytest.param(["/static/htmx_app.js"], id="static_assets"),
+        # /health — pings would dominate the counter and skew SLO percentiles.
+        pytest.param(["/health"], id="health"),
+        # /sw.js, /favicon.ico, /robots.txt — high-rate, no-signal browser noise.
+        pytest.param(["/sw.js", "/favicon.ico", "/robots.txt"], id="browser_noise"),
+    ],
+)
+def test_cardinality_dangerous_paths_excluded(paths: list[str]) -> None:
+    """Excluded paths never appear as a counted handler label."""
     with patch("app.main.settings.metrics_token", "test-token"):
         with _client() as client:
-            client.get("/static/htmx_app.js")
+            for path in paths:
+                client.get(path)
             body = _get_metrics_text(client)
-    assert 'handler="/static/htmx_app.js"' not in body
-
-
-def test_health_excluded() -> None:
-    """/health is excluded — pings would dominate the counter and skew SLO
-    percentiles."""
-    with patch("app.main.settings.metrics_token", "test-token"):
-        with _client() as client:
-            client.get("/health")
-            body = _get_metrics_text(client)
-    assert 'handler="/health"' not in body
-
-
-def test_browser_noise_paths_excluded() -> None:
-    """/sw.js, /favicon.ico, /robots.txt are excluded — high-rate, no-signal noise."""
-    with patch("app.main.settings.metrics_token", "test-token"):
-        with _client() as client:
-            client.get("/sw.js")
-            client.get("/favicon.ico")
-            client.get("/robots.txt")
-            body = _get_metrics_text(client)
-    assert 'handler="/sw.js"' not in body
-    assert 'handler="/favicon.ico"' not in body
-    assert 'handler="/robots.txt"' not in body
+    for path in paths:
+        assert f'handler="{path}"' not in body
 
 
 # ── Critical regressions surfaced during review ──────────────────────────────

--- a/tests/test_quick_search.py
+++ b/tests/test_quick_search.py
@@ -10,6 +10,7 @@ Depends on: app/routers/materials.py, app/search_service.py
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models import MaterialCard, MaterialVendorHistory
@@ -17,18 +18,18 @@ from app.models import MaterialCard, MaterialVendorHistory
 # ── Validation tests ──────────────────────────────────────────────────────
 
 
-def test_quick_search_missing_mpn(client):
-    """Should reject request with missing MPN."""
-    resp = client.post("/api/quick-search", json={})
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        pytest.param({}, "MPN is required", id="missing_mpn"),
+        pytest.param({"mpn": "A"}, "at least 2 characters", id="short_mpn"),
+    ],
+)
+def test_quick_search_rejects_invalid_mpn(client, payload, expected_error):
+    """Should reject requests with a missing or too-short MPN."""
+    resp = client.post("/api/quick-search", json=payload)
     assert resp.status_code == 400
-    assert "MPN is required" in resp.json()["error"]
-
-
-def test_quick_search_short_mpn(client):
-    """Should reject MPN shorter than 2 characters."""
-    resp = client.post("/api/quick-search", json={"mpn": "A"})
-    assert resp.status_code == 400
-    assert "at least 2 characters" in resp.json()["error"]
+    assert expected_error in resp.json()["error"]
 
 
 # ── Successful search (mocked connectors) ────────────────────────────────

--- a/tests/test_quote_builder_coverage.py
+++ b/tests/test_quote_builder_coverage.py
@@ -20,6 +20,7 @@ os.environ["TESTING"] = "1"
 
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -155,8 +156,18 @@ class TestQuoteBuilderSaveErrors:
         "margin_pct": 33.3,
     }
 
-    def test_save_value_error(
+    @pytest.mark.parametrize(
+        "save_error,expected_status",
+        [
+            (ValueError("requirement not found"), 404),
+            (RuntimeError("DB exploded"), 500),
+        ],
+        ids=["value_error", "generic_exception"],
+    )
+    def test_save_error_status(
         self,
+        save_error,
+        expected_status,
         client: TestClient,
         test_requisition: Requisition,
         test_customer_site: CustomerSite,
@@ -167,33 +178,13 @@ class TestQuoteBuilderSaveErrors:
         with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
             with patch(
                 "app.services.quote_builder_service.save_quote_from_builder",
-                side_effect=ValueError("requirement not found"),
+                side_effect=save_error,
             ):
                 resp = client.post(
                     f"/v2/partials/quote-builder/{test_requisition.id}/save",
                     json={"lines": [self._VALID_LINE]},
                 )
-        assert resp.status_code == 404
-
-    def test_save_generic_exception(
-        self,
-        client: TestClient,
-        test_requisition: Requisition,
-        test_customer_site: CustomerSite,
-        db_session: Session,
-    ):
-        test_requisition.customer_site_id = test_customer_site.id
-        db_session.flush()
-        with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
-            with patch(
-                "app.services.quote_builder_service.save_quote_from_builder",
-                side_effect=RuntimeError("DB exploded"),
-            ):
-                resp = client.post(
-                    f"/v2/partials/quote-builder/{test_requisition.id}/save",
-                    json={"lines": [self._VALID_LINE]},
-                )
-        assert resp.status_code == 500
+        assert resp.status_code == expected_status
 
 
 # ── quote_builder_export_excel: error path ────────────────────────────────
@@ -223,24 +214,21 @@ class TestQuoteBuilderExportPdfErrors:
         )
         assert resp.status_code == 404
 
-    def test_export_pdf_value_error(self, client: TestClient, test_quote):
+    @pytest.mark.parametrize(
+        "pdf_error,expected_status",
+        [
+            (ValueError("quote not found"), 404),
+            (RuntimeError("weasyprint crash"), 500),
+        ],
+        ids=["value_error", "generic_exception"],
+    )
+    def test_export_pdf_error_status(self, pdf_error, expected_status, client: TestClient, test_quote):
         with patch(
             "app.services.document_service.generate_quote_report_pdf",
-            side_effect=ValueError("quote not found"),
+            side_effect=pdf_error,
         ):
             resp = client.get(
                 f"/v2/partials/quote-builder/{test_quote.requisition_id}/export/pdf",
                 params={"quote_id": test_quote.id},
             )
-        assert resp.status_code == 404
-
-    def test_export_pdf_generic_exception(self, client: TestClient, test_quote):
-        with patch(
-            "app.services.document_service.generate_quote_report_pdf",
-            side_effect=RuntimeError("weasyprint crash"),
-        ):
-            resp = client.get(
-                f"/v2/partials/quote-builder/{test_quote.requisition_id}/export/pdf",
-                params={"quote_id": test_quote.id},
-            )
-        assert resp.status_code == 500
+        assert resp.status_code == expected_status

--- a/tests/test_quote_builder_nightly.py
+++ b/tests/test_quote_builder_nightly.py
@@ -38,59 +38,66 @@ def _run(coro):
     return asyncio.get_event_loop().run_until_complete(coro)
 
 
+def _call_modal_multi(requisition_ids, user, db):
+    """Invoke the async quote_builder_modal_multi function synchronously."""
+    return _run(
+        quote_builder_modal_multi(
+            request=_make_request(),
+            requisition_ids=requisition_ids,
+            user=user,
+            db=db,
+        )
+    )
+
+
+def _call_modal_multi_capturing(requisition_ids, user, db, found_req):
+    """Run modal_multi with get_req_for_user stubbed to found_req and template_response
+    captured.
+
+    Returns (result, captured_context).
+    """
+    mock_response = HTMLResponse("<html>modal</html>")
+    captured_ctx: dict = {}
+
+    def _fake_template_response(template_name, context):
+        captured_ctx.update(context)
+        return mock_response
+
+    with patch("app.dependencies.get_req_for_user", return_value=found_req):
+        with patch(
+            "app.template_env.template_response",
+            side_effect=_fake_template_response,
+        ):
+            result = _call_modal_multi(requisition_ids, user, db)
+
+    return result, mock_response, captured_ctx
+
+
 class TestQuoteBuilderModalMultiInvalidIds:
     """Lines 80-83: ValueError branch when IDs contain non-numeric text."""
 
-    def test_non_numeric_ids_raise_400(self, db_session: Session, test_user: User):
+    @pytest.mark.parametrize(
+        "requisition_ids",
+        ["abc,def", "1,bad,3"],
+        ids=["non_numeric", "mixed_valid_invalid"],
+    )
+    def test_invalid_ids_raise_400(self, requisition_ids, db_session: Session, test_user: User):
         with pytest.raises(HTTPException) as exc_info:
-            _run(
-                quote_builder_modal_multi(
-                    request=_make_request(),
-                    requisition_ids="abc,def",
-                    user=test_user,
-                    db=db_session,
-                )
-            )
-        assert exc_info.value.status_code == 400
-
-    def test_mixed_valid_invalid_ids_raise_400(self, db_session: Session, test_user: User):
-        with pytest.raises(HTTPException) as exc_info:
-            _run(
-                quote_builder_modal_multi(
-                    request=_make_request(),
-                    requisition_ids="1,bad,3",
-                    user=test_user,
-                    db=db_session,
-                )
-            )
+            _call_modal_multi(requisition_ids, test_user, db_session)
         assert exc_info.value.status_code == 400
 
 
 class TestQuoteBuilderModalMultiEmptyIds:
     """Lines 84-85: empty list branch when requisition_ids is blank or whitespace."""
 
-    def test_empty_string_raises_400(self, db_session: Session, test_user: User):
+    @pytest.mark.parametrize(
+        "requisition_ids",
+        ["", "  ,  "],
+        ids=["empty_string", "whitespace_only"],
+    )
+    def test_empty_ids_raise_400(self, requisition_ids, db_session: Session, test_user: User):
         with pytest.raises(HTTPException) as exc_info:
-            _run(
-                quote_builder_modal_multi(
-                    request=_make_request(),
-                    requisition_ids="",
-                    user=test_user,
-                    db=db_session,
-                )
-            )
-        assert exc_info.value.status_code == 400
-
-    def test_whitespace_only_raises_400(self, db_session: Session, test_user: User):
-        with pytest.raises(HTTPException) as exc_info:
-            _run(
-                quote_builder_modal_multi(
-                    request=_make_request(),
-                    requisition_ids="  ,  ",
-                    user=test_user,
-                    db=db_session,
-                )
-            )
+            _call_modal_multi(requisition_ids, test_user, db_session)
         assert exc_info.value.status_code == 400
 
 
@@ -100,14 +107,7 @@ class TestQuoteBuilderModalMultiNotFound:
     def test_req_not_found_raises_404(self, db_session: Session, test_user: User):
         with patch("app.dependencies.get_req_for_user", return_value=None):
             with pytest.raises(HTTPException) as exc_info:
-                _run(
-                    quote_builder_modal_multi(
-                        request=_make_request(),
-                        requisition_ids="99999",
-                        user=test_user,
-                        db=db_session,
-                    )
-                )
+                _call_modal_multi("99999", test_user, db_session)
         assert exc_info.value.status_code == 404
 
 
@@ -123,18 +123,9 @@ class TestQuoteBuilderModalMultiNoCustomerSite:
     ):
         test_requisition.customer_site_id = None
 
-        mock_response = HTMLResponse("<html>modal</html>")
-
-        with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
-            with patch("app.template_env.template_response", return_value=mock_response):
-                result = _run(
-                    quote_builder_modal_multi(
-                        request=_make_request(),
-                        requisition_ids=str(test_requisition.id),
-                        user=test_user,
-                        db=db_session,
-                    )
-                )
+        result, mock_response, _ = _call_modal_multi_capturing(
+            str(test_requisition.id), test_user, db_session, test_requisition
+        )
 
         assert result is mock_response
 
@@ -152,26 +143,9 @@ class TestQuoteBuilderModalMultiWithCustomerSite:
         test_requisition.customer_site_id = test_customer_site.id
         db_session.flush()
 
-        mock_response = HTMLResponse("<html>modal</html>")
-        captured_ctx: dict = {}
-
-        def _fake_template_response(template_name, context):
-            captured_ctx.update(context)
-            return mock_response
-
-        with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
-            with patch(
-                "app.template_env.template_response",
-                side_effect=_fake_template_response,
-            ):
-                result = _run(
-                    quote_builder_modal_multi(
-                        request=_make_request(),
-                        requisition_ids=str(test_requisition.id),
-                        user=test_user,
-                        db=db_session,
-                    )
-                )
+        result, mock_response, captured_ctx = _call_modal_multi_capturing(
+            str(test_requisition.id), test_user, db_session, test_requisition
+        )
 
         assert result is mock_response
         assert captured_ctx.get("has_customer_site") is True
@@ -187,26 +161,9 @@ class TestQuoteBuilderModalMultiWithCustomerSite:
         """customer_site_id set but db.get returns None → customer_name stays empty."""
         test_requisition.customer_site_id = 99999  # non-existent
 
-        mock_response = HTMLResponse("<html>modal</html>")
-        captured_ctx: dict = {}
-
-        def _fake_template_response(template_name, context):
-            captured_ctx.update(context)
-            return mock_response
-
-        with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
-            with patch(
-                "app.template_env.template_response",
-                side_effect=_fake_template_response,
-            ):
-                result = _run(
-                    quote_builder_modal_multi(
-                        request=_make_request(),
-                        requisition_ids=str(test_requisition.id),
-                        user=test_user,
-                        db=db_session,
-                    )
-                )
+        result, mock_response, captured_ctx = _call_modal_multi_capturing(
+            str(test_requisition.id), test_user, db_session, test_requisition
+        )
 
         assert result is mock_response
         assert captured_ctx.get("has_customer_site") is True
@@ -223,25 +180,6 @@ class TestQuoteBuilderModalMultiWithCustomerSite:
         test_requisition.customer_site_id = None
         raw_ids = f"{test_requisition.id},{test_requisition.id + 1}"
 
-        mock_response = HTMLResponse("<html>modal</html>")
-        captured_ctx: dict = {}
-
-        def _fake_template_response(template_name, context):
-            captured_ctx.update(context)
-            return mock_response
-
-        with patch("app.dependencies.get_req_for_user", return_value=test_requisition):
-            with patch(
-                "app.template_env.template_response",
-                side_effect=_fake_template_response,
-            ):
-                _run(
-                    quote_builder_modal_multi(
-                        request=_make_request(),
-                        requisition_ids=raw_ids,
-                        user=test_user,
-                        db=db_session,
-                    )
-                )
+        _, _, captured_ctx = _call_modal_multi_capturing(raw_ids, test_user, db_session, test_requisition)
 
         assert captured_ctx.get("multi_req_ids") == raw_ids

--- a/tests/test_requirement_status_coverage.py
+++ b/tests/test_requirement_status_coverage.py
@@ -33,13 +33,19 @@ from app.services.requirement_status import (
 )
 
 
+def set_requirement_status(test_requisition, db_session, status):
+    """Arrange the requisition's first requirement at `status` and return it."""
+    req_item = test_requisition.requirements[0]
+    req_item.sourcing_status = status
+    db_session.commit()
+    return req_item
+
+
 class TestTransitionRequirementNoActor:
     """Lines 73-74 — transition with no actor logs with user_id=None."""
 
     def test_transition_without_actor_creates_log_with_null_user(self, db_session, test_requisition):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = set_requirement_status(test_requisition, db_session, "open")
 
         changed = transition_requirement(req_item, "sourcing", db_session, actor=None)
         assert changed is True
@@ -58,9 +64,7 @@ class TestTransitionRequirementNoActor:
 
     def test_transition_activity_log_exception_does_not_crash(self, db_session, test_requisition):
         """ActivityLog creation failure is swallowed (lines 73-74)."""
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = set_requirement_status(test_requisition, db_session, "open")
 
         with patch("app.services.requirement_status.ActivityLog", side_effect=Exception("db error")):
             # Should not raise — exception is swallowed
@@ -74,9 +78,7 @@ class TestOnRfqSentValueError:
 
     def test_value_error_during_rfq_transition_is_caught(self, db_session, test_requisition):
         """If transition_requirement raises ValueError, it's caught and skipped."""
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = set_requirement_status(test_requisition, db_session, "open")
 
         with patch(
             "app.services.requirement_status.transition_requirement",
@@ -90,9 +92,7 @@ class TestOnOfferCreatedEdgeCases:
     """Lines 105-107 — ValueError during offer transition is caught."""
 
     def test_value_error_during_offer_transition_is_caught(self, db_session, test_requisition):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = set_requirement_status(test_requisition, db_session, "open")
 
         with patch(
             "app.services.requirement_status.transition_requirement",
@@ -103,9 +103,7 @@ class TestOnOfferCreatedEdgeCases:
 
     def test_on_offer_created_from_won_does_not_change(self, db_session, test_requisition):
         """Won status → on_offer_created returns False without transition."""
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "won"
-        db_session.commit()
+        req_item = set_requirement_status(test_requisition, db_session, "won")
 
         result = on_offer_created(req_item, db_session)
         assert result is False
@@ -113,9 +111,7 @@ class TestOnOfferCreatedEdgeCases:
 
     def test_on_offer_created_from_quoted_does_not_change(self, db_session, test_requisition):
         """Quoted status → on_offer_created returns False without transition."""
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "quoted"
-        db_session.commit()
+        req_item = set_requirement_status(test_requisition, db_session, "quoted")
 
         result = on_offer_created(req_item, db_session)
         assert result is False
@@ -125,9 +121,7 @@ class TestOnQuoteBuiltValueError:
     """Lines 124-125 — ValueError during quote transition is caught."""
 
     def test_value_error_during_quote_transition_is_caught(self, db_session, test_requisition):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = set_requirement_status(test_requisition, db_session, "open")
 
         with patch(
             "app.services.requirement_status.transition_requirement",
@@ -138,9 +132,7 @@ class TestOnQuoteBuiltValueError:
 
     def test_on_quote_built_from_open_status(self, db_session, test_requisition, test_user):
         """Open status → on_quote_built transitions to quoted."""
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = set_requirement_status(test_requisition, db_session, "open")
 
         changed = on_quote_built([req_item.id], db_session, actor=test_user)
         assert changed == 1

--- a/tests/test_requirements_async_coverage.py
+++ b/tests/test_requirements_async_coverage.py
@@ -17,14 +17,27 @@ os.environ["TESTING"] = "1"
 
 from unittest.mock import patch
 
+import pytest
+
 from app.models import Requirement
 
-# ── list_requirements 404 ─────────────────────────────────────────────
+# ── req-not-found 404 paths ───────────────────────────────────────────
+# Each endpoint short-circuits to 404 when get_req_for_user returns None.
 
 
-def test_list_requirements_req_not_found(client):
+@pytest.mark.parametrize(
+    ("method", "url", "kwargs"),
+    [
+        ("get", "/api/requisitions/99999/requirements", {}),
+        ("post", "/api/requisitions/99999/search", {"json": {}}),
+        ("get", "/api/requisitions/99999/sightings/cached", {}),
+        ("get", "/api/requisitions/99999/leads", {}),
+    ],
+    ids=["list_requirements", "search_requirements", "get_cached_sightings", "list_requisition_leads"],
+)
+def test_endpoint_req_not_found(client, method, url, kwargs):
     with patch("app.routers.requisitions.requirements.get_req_for_user", return_value=None):
-        resp = client.get("/api/requisitions/99999/requirements")
+        resp = getattr(client, method)(url, **kwargs)
     assert resp.status_code == 404
 
 
@@ -88,34 +101,7 @@ class TestAddRequirements:
         assert resp.status_code == 422
 
 
-# ── search_requirements ───────────────────────────────────────────────
-
-
-def test_search_requirements_req_not_found(client):
-    with patch("app.routers.requisitions.requirements.get_req_for_user", return_value=None):
-        resp = client.post(
-            "/api/requisitions/99999/search",
-            json={},
-        )
-    assert resp.status_code == 404
-
-
-# ── get_cached_sightings ──────────────────────────────────────────────
-
-
-def test_get_cached_sightings_req_not_found(client):
-    with patch("app.routers.requisitions.requirements.get_req_for_user", return_value=None):
-        resp = client.get("/api/requisitions/99999/sightings/cached")
-    assert resp.status_code == 404
-
-
 # ── list_requisition_leads ────────────────────────────────────────────
-
-
-def test_list_requisition_leads_req_not_found(client):
-    with patch("app.routers.requisitions.requirements.get_req_for_user", return_value=None):
-        resp = client.get("/api/requisitions/99999/leads")
-    assert resp.status_code == 404
 
 
 def test_list_requisition_leads_success(client, test_requisition):

--- a/tests/test_requirements_async_direct.py
+++ b/tests/test_requirements_async_direct.py
@@ -37,6 +37,20 @@ def _make_json_request(body: dict) -> MagicMock:
     return mock_req
 
 
+def _make_form_request(form_get) -> MagicMock:
+    """Create a mock Request whose .form() returns a mock with the given .get."""
+    mock_req = MagicMock(spec=Request)
+    mock_req.headers = {}
+
+    async def _form():
+        form_mock = MagicMock()
+        form_mock.get = form_get
+        return form_mock
+
+    mock_req.form = _form
+    return mock_req
+
+
 def _make_requirement(db: Session, req: Requisition, mpn: str = "LM317T") -> Requirement:
     r = Requirement(
         requisition_id=req.id,
@@ -398,17 +412,9 @@ async def test_import_stock_list_success(db_session: Session, test_user: User, t
     mock_file.read = AsyncMock(return_value=csv_content)
     mock_file.filename = "stock.csv"
 
-    mock_req = MagicMock(spec=Request)
-    mock_req.headers = {}
-
-    async def _form():
-        form_mock = MagicMock()
-        form_mock.get = lambda key, default=None: (
-            mock_file if key == "file" else "Test Vendor" if key == "vendor_name" else default
-        )
-        return form_mock
-
-    mock_req.form = _form
+    mock_req = _make_form_request(
+        lambda key, default=None: mock_file if key == "file" else "Test Vendor" if key == "vendor_name" else default
+    )
 
     with (
         patch(
@@ -438,15 +444,7 @@ async def test_import_stock_list_no_file_raises(db_session: Session, test_user: 
     """Covers lines 1204-1207: no file → 400."""
     from app.routers.requisitions.requirements import import_stock_list
 
-    mock_req = MagicMock(spec=Request)
-    mock_req.headers = {}
-
-    async def _form():
-        form_mock = MagicMock()
-        form_mock.get = lambda key, default=None: None  # no file
-        return form_mock
-
-    mock_req.form = _form
+    mock_req = _make_form_request(lambda key, default=None: None)  # no file
 
     with pytest.raises(HTTPException) as exc:
         await import_stock_list(
@@ -892,15 +890,7 @@ async def test_import_stock_list_no_filename_raises_400(
     mock_file.read = AsyncMock(return_value=b"mpn,qty\nLM317T,100\n")
     mock_file.filename = None  # no filename
 
-    mock_req = MagicMock(spec=Request)
-    mock_req.headers = {}
-
-    async def _form():
-        form_mock = MagicMock()
-        form_mock.get = lambda key, default=None: mock_file if key == "file" else default
-        return form_mock
-
-    mock_req.form = _form
+    mock_req = _make_form_request(lambda key, default=None: mock_file if key == "file" else default)
 
     with pytest.raises(HTTPException) as exc_info:
         await import_stock_list(
@@ -941,17 +931,9 @@ async def test_import_stock_list_with_requirement_having_substitutes(
     mock_file.read = AsyncMock(return_value=csv_content)
     mock_file.filename = "stock.csv"
 
-    mock_req = MagicMock(spec=Request)
-    mock_req.headers = {}
-
-    async def _form():
-        form_mock = MagicMock()
-        form_mock.get = lambda key, default=None: (
-            mock_file if key == "file" else "Acme Surplus" if key == "vendor_name" else default
-        )
-        return form_mock
-
-    mock_req.form = _form
+    mock_req = _make_form_request(
+        lambda key, default=None: mock_file if key == "file" else "Acme Surplus" if key == "vendor_name" else default
+    )
 
     with (
         patch(
@@ -992,15 +974,7 @@ async def test_import_stock_list_commit_exception_raises_500(
     mock_file.read = AsyncMock(return_value=b"mpn,qty\nLM317T,100\n")
     mock_file.filename = "stock.csv"
 
-    mock_req = MagicMock(spec=Request)
-    mock_req.headers = {}
-
-    async def _form():
-        form_mock = MagicMock()
-        form_mock.get = lambda key, default=None: mock_file if key == "file" else default
-        return form_mock
-
-    mock_req.form = _form
+    mock_req = _make_form_request(lambda key, default=None: mock_file if key == "file" else default)
 
     with (
         patch(
@@ -1164,15 +1138,7 @@ async def test_import_stock_list_normalize_stock_row_returns_none(
     mock_file.read = AsyncMock(return_value=b"mpn,qty\nBAD_ROW,100\n")
     mock_file.filename = "stock.csv"
 
-    mock_req = MagicMock(spec=Request)
-    mock_req.headers = {}
-
-    async def _form():
-        form_mock = MagicMock()
-        form_mock.get = lambda key, default=None: mock_file if key == "file" else default
-        return form_mock
-
-    mock_req.form = _form
+    mock_req = _make_form_request(lambda key, default=None: mock_file if key == "file" else default)
 
     with (
         patch(
@@ -1213,15 +1179,7 @@ async def test_import_stock_list_mpn_not_in_req_mpns(
     mock_file.read = AsyncMock(return_value=b"mpn,qty\nXYZ999,100\n")
     mock_file.filename = "stock.csv"
 
-    mock_req = MagicMock(spec=Request)
-    mock_req.headers = {}
-
-    async def _form():
-        form_mock = MagicMock()
-        form_mock.get = lambda key, default=None: mock_file if key == "file" else default
-        return form_mock
-
-    mock_req.form = _form
+    mock_req = _make_form_request(lambda key, default=None: mock_file if key == "file" else default)
 
     with (
         patch(

--- a/tests/test_response_analytics.py
+++ b/tests/test_response_analytics.py
@@ -11,6 +11,8 @@ Depends on: app.services.response_analytics, conftest fixtures
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
+
 from app.models import ActivityLog, VendorCard, VendorContact
 from app.models.email_intelligence import EmailIntelligence
 from app.models.offers import VendorResponse
@@ -289,8 +291,15 @@ class TestComputeEmailHealthScore:
         result = compute_email_health_score(db_session, 99999)
         assert result["metrics"]["response_rate"] == 0.0
 
-    def test_response_time_ideal(self, db_session, test_user):
-        """Response time <= 4h scores 100."""
+    @pytest.mark.parametrize(
+        ("response_delay_hours", "expected_score"),
+        [
+            pytest.param(2, 100.0, id="ideal_under_4h"),
+            pytest.param(170, 0.0, id="worst_over_168h"),
+        ],
+    )
+    def test_response_time_boundary_scores(self, db_session, test_user, response_delay_hours, expected_score):
+        """Response time <= 4h scores 100; >= 168h scores 0."""
         card = _make_vendor_card(db_session)
         _make_activity_log(db_session, test_user.id, card.id, "rfq_sent")
         now = datetime.now(timezone.utc)
@@ -298,30 +307,13 @@ class TestComputeEmailHealthScore:
             db_session,
             vendor_email="sales@testvendor.com",
             received_at=now,
-            created_at=now - timedelta(hours=2),
+            created_at=now - timedelta(hours=response_delay_hours),
         )
 
         from app.services.response_analytics import compute_email_health_score
 
         result = compute_email_health_score(db_session, card.id)
-        assert result["response_time_score"] == 100.0
-
-    def test_response_time_worst(self, db_session, test_user):
-        """Response time >= 168h scores 0."""
-        card = _make_vendor_card(db_session)
-        _make_activity_log(db_session, test_user.id, card.id, "rfq_sent")
-        now = datetime.now(timezone.utc)
-        _make_vendor_response(
-            db_session,
-            vendor_email="sales@testvendor.com",
-            received_at=now,
-            created_at=now - timedelta(hours=170),
-        )
-
-        from app.services.response_analytics import compute_email_health_score
-
-        result = compute_email_health_score(db_session, card.id)
-        assert result["response_time_score"] == 0.0
+        assert result["response_time_score"] == expected_score
 
     def test_response_time_unknown_defaults_neutral(self, db_session):
         """Unknown response time defaults to 50 (neutral)."""

--- a/tests/test_routers_documents.py
+++ b/tests/test_routers_documents.py
@@ -8,9 +8,35 @@ Called by: pytest
 Depends on: app/routers/documents.py, conftest.py
 """
 
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
+
+
+@contextmanager
+def _client_as_sales(db_session, sales_user):
+    """TestClient with db + auth overridden to a sales user; overrides cleaned up
+    after."""
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    def _override_db():
+        yield db_session
+
+    def _override_user():
+        return sales_user
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[require_user] = _override_user
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        for dep in [get_db, require_user]:
+            app.dependency_overrides.pop(dep, None)
+
 
 # ── RFQ PDF ──────────────────────────────────────────────────────────
 
@@ -69,46 +95,14 @@ def test_quote_pdf_generation_error(mock_gen, client, test_quote):
 @patch("app.services.document_service.generate_rfq_summary_pdf", return_value=b"%PDF-fake-content")
 def test_rfq_pdf_scope_enforced_for_sales(mock_gen, db_session, sales_user, test_requisition):
     """Sales users cannot download PDFs for requisitions they don't own."""
-    from app.database import get_db
-    from app.dependencies import require_user
-    from app.main import app
-
-    def _override_db():
-        yield db_session
-
-    def _override_user():
-        return sales_user
-
-    app.dependency_overrides[get_db] = _override_db
-    app.dependency_overrides[require_user] = _override_user
-    try:
-        with TestClient(app) as c:
-            resp = c.get(f"/api/requisitions/{test_requisition.id}/pdf")
-    finally:
-        for dep in [get_db, require_user]:
-            app.dependency_overrides.pop(dep, None)
+    with _client_as_sales(db_session, sales_user) as c:
+        resp = c.get(f"/api/requisitions/{test_requisition.id}/pdf")
     assert resp.status_code == 404
 
 
 @patch("app.services.document_service.generate_quote_report_pdf", return_value=b"%PDF-quote-content")
 def test_quote_pdf_scope_enforced_for_sales(mock_gen, db_session, sales_user, test_quote):
     """Sales users cannot download quote PDFs for foreign requisitions."""
-    from app.database import get_db
-    from app.dependencies import require_user
-    from app.main import app
-
-    def _override_db():
-        yield db_session
-
-    def _override_user():
-        return sales_user
-
-    app.dependency_overrides[get_db] = _override_db
-    app.dependency_overrides[require_user] = _override_user
-    try:
-        with TestClient(app) as c:
-            resp = c.get(f"/api/quotes/{test_quote.id}/pdf")
-    finally:
-        for dep in [get_db, require_user]:
-            app.dependency_overrides.pop(dep, None)
+    with _client_as_sales(db_session, sales_user) as c:
+        resp = c.get(f"/api/quotes/{test_quote.id}/pdf")
     assert resp.status_code == 404

--- a/tests/test_routers_error_reports.py
+++ b/tests/test_routers_error_reports.py
@@ -16,6 +16,16 @@ from sqlalchemy.orm import Session
 from app.models import User
 from app.models.trouble_ticket import TroubleTicket
 
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _create_report(client, db_session, **payload) -> TroubleTicket:
+    """POST a report via the JSON API and return the persisted TroubleTicket."""
+    resp = client.post("/api/error-reports", json=payload)
+    assert resp.status_code == 200
+    return db_session.get(TroubleTicket, resp.json()["id"])
+
+
 # ── Fixtures ─────────────────────────────────────────────────────────
 
 
@@ -78,80 +88,39 @@ class TestCreateErrorReport:
         assert data["id"] > 0
         assert data["status"] == "created"
 
-    def test_submit_without_message_returns_422(self, client):
-        resp = client.post(
-            "/api/error-reports",
-            json={
-                "current_url": "https://example.com",
-            },
-        )
-        assert resp.status_code == 422
-
-    def test_submit_empty_message_rejected(self, client):
-        resp = client.post(
-            "/api/error-reports",
-            json={
-                "message": "",
-            },
-        )
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"current_url": "https://example.com"},  # missing message
+            {"message": ""},  # empty message
+        ],
+        ids=["without_message", "empty_message"],
+    )
+    def test_submit_invalid_message_returns_422(self, client, body):
+        resp = client.post("/api/error-reports", json=body)
         assert resp.status_code == 422
 
     def test_message_stored_as_description(self, client, db_session):
-        resp = client.post(
-            "/api/error-reports",
-            json={
-                "message": "The search results are not showing up correctly",
-            },
-        )
-        assert resp.status_code == 200
-        ticket_id = resp.json()["id"]
-        ticket = db_session.get(TroubleTicket, ticket_id)
+        ticket = _create_report(client, db_session, message="The search results are not showing up correctly")
         assert ticket.description == "The search results are not showing up correctly"
 
     def test_title_derived_from_message(self, client, db_session):
         msg = "Short bug report"
-        resp = client.post(
-            "/api/error-reports",
-            json={"message": msg},
-        )
-        assert resp.status_code == 200
-        ticket_id = resp.json()["id"]
-        ticket = db_session.get(TroubleTicket, ticket_id)
+        ticket = _create_report(client, db_session, message=msg)
         assert ticket.title == msg[:120]
 
     def test_long_title_truncated(self, client, db_session):
         msg = "A" * 200
-        resp = client.post(
-            "/api/error-reports",
-            json={"message": msg},
-        )
-        assert resp.status_code == 200
-        ticket_id = resp.json()["id"]
-        ticket = db_session.get(TroubleTicket, ticket_id)
+        ticket = _create_report(client, db_session, message=msg)
         assert len(ticket.title) == 120
         assert ticket.description == msg
 
     def test_current_url_stored(self, client, db_session):
-        resp = client.post(
-            "/api/error-reports",
-            json={
-                "message": "Page is broken",
-                "current_url": "https://app.example.com/rfq",
-            },
-        )
-        assert resp.status_code == 200
-        ticket_id = resp.json()["id"]
-        ticket = db_session.get(TroubleTicket, ticket_id)
+        ticket = _create_report(client, db_session, message="Page is broken", current_url="https://app.example.com/rfq")
         assert ticket.current_page == "https://app.example.com/rfq"
 
     def test_source_set_to_report_button(self, client, db_session):
-        resp = client.post(
-            "/api/error-reports",
-            json={"message": "Something broke"},
-        )
-        assert resp.status_code == 200
-        ticket_id = resp.json()["id"]
-        ticket = db_session.get(TroubleTicket, ticket_id)
+        ticket = _create_report(client, db_session, message="Something broke")
         assert ticket.source == "report_button"
 
     def test_submit_via_trouble_tickets_path(self, client):
@@ -164,19 +133,12 @@ class TestCreateErrorReport:
         assert resp.json()["status"] == "created"
 
     def test_ticket_number_derived_from_id(self, client, db_session):
-        resp = client.post(
-            "/api/error-reports",
-            json={"message": "First ticket"},
-        )
-        ticket_id = resp.json()["id"]
-        ticket = db_session.get(TroubleTicket, ticket_id)
+        ticket = _create_report(client, db_session, message="First ticket")
         assert ticket.ticket_number == f"TT-{ticket.id:04d}"
 
     def test_sequential_ticket_numbers(self, client, db_session):
-        resp1 = client.post("/api/error-reports", json={"message": "Ticket one"})
-        resp2 = client.post("/api/error-reports", json={"message": "Ticket two"})
-        t1 = db_session.get(TroubleTicket, resp1.json()["id"])
-        t2 = db_session.get(TroubleTicket, resp2.json()["id"])
+        t1 = _create_report(client, db_session, message="Ticket one")
+        t2 = _create_report(client, db_session, message="Ticket two")
         assert t2.id > t1.id
         assert t2.ticket_number > t1.ticket_number
 

--- a/tests/test_routers_vendor_contacts.py
+++ b/tests/test_routers_vendor_contacts.py
@@ -12,6 +12,22 @@ from unittest.mock import AsyncMock
 
 from app.models import Contact, Requisition, VendorCard, VendorContact, VendorResponse
 
+
+def make_vendor_card(db_session, normalized_name, display_name, **kwargs):
+    """Create, persist, and return a VendorCard for lookup-waterfall tests.
+
+    Defaults emails/phones to empty lists and sighting_count to 1 so callers only pass
+    the fields a given tier scenario actually varies.
+    """
+    kwargs.setdefault("emails", [])
+    kwargs.setdefault("phones", [])
+    kwargs.setdefault("sighting_count", 1)
+    card = VendorCard(normalized_name=normalized_name, display_name=display_name, **kwargs)
+    db_session.add(card)
+    db_session.commit()
+    return card
+
+
 # ── Contacts CRUD ────────────────────────────────────────────────────────
 
 
@@ -327,16 +343,7 @@ def test_lookup_tier1_cached(client, db_session, test_vendor_card):
 
 def test_lookup_tier2_scrape(client, db_session, monkeypatch):
     """Vendor with website but no emails triggers scrape (tier=2)."""
-    vc = VendorCard(
-        normalized_name="scrapetest co",
-        display_name="ScrapeTest Co",
-        website="https://scrapetest.example.com",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "scrapetest co", "ScrapeTest Co", website="https://scrapetest.example.com")
 
     async def mock_scrape(url):
         return {"emails": ["found@scrapetest.com"], "phones": ["+1-555-9999"]}
@@ -355,15 +362,7 @@ def test_lookup_tier2_scrape(client, db_session, monkeypatch):
 
 def test_lookup_tier3_ai(client, db_session, monkeypatch):
     """Vendor with no website/emails triggers AI lookup (tier=3)."""
-    vc = VendorCard(
-        normalized_name="aitest vendor",
-        display_name="AITest Vendor",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "aitest vendor", "AITest Vendor")
 
     monkeypatch.setattr(
         "app.routers.vendor_contacts.get_credential_cached",
@@ -392,15 +391,7 @@ def test_lookup_tier3_ai(client, db_session, monkeypatch):
 
 def test_lookup_no_api_key(client, db_session, monkeypatch):
     """Vendor with no emails/website and no API key returns tier=0."""
-    vc = VendorCard(
-        normalized_name="nokey vendor",
-        display_name="NoKey Vendor",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "nokey vendor", "NoKey Vendor")
 
     monkeypatch.setattr(
         "app.routers.vendor_contacts.get_credential_cached",
@@ -441,16 +432,7 @@ def test_lookup_creates_card(client, db_session, monkeypatch):
 
 def test_lookup_ssrf_blocked(client, db_session, monkeypatch):
     """Vendor with private URL returns empty contacts from scrape."""
-    vc = VendorCard(
-        normalized_name="ssrf test vendor",
-        display_name="SSRF Test Vendor",
-        website="http://127.0.0.1/evil",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "ssrf test vendor", "SSRF Test Vendor", website="http://127.0.0.1/evil")
 
     async def mock_scrape(url):
         return {"emails": [], "phones": []}
@@ -474,14 +456,7 @@ def test_lookup_ssrf_blocked(client, db_session, monkeypatch):
 def test_lookup_creates_card_integrity_error(client, db_session, monkeypatch):
     """lookup_vendor_contact handles IntegrityError on card creation (race
     condition)."""
-    vc = VendorCard(
-        normalized_name="race vendor",
-        display_name="Race Vendor",
-        emails=["already@race.com"],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "race vendor", "Race Vendor", emails=["already@race.com"])
 
     resp = client.post("/api/vendor-contact", json={"vendor_name": "Race Vendor"})
     assert resp.status_code == 200
@@ -491,16 +466,7 @@ def test_lookup_creates_card_integrity_error(client, db_session, monkeypatch):
 
 def test_lookup_tier2_scrape_no_emails_after_merge(client, db_session, monkeypatch):
     """Tier 2: scrape returns data but merge doesn't produce card.emails."""
-    vc = VendorCard(
-        normalized_name="scrape empty vendor",
-        display_name="Scrape Empty Vendor",
-        website="https://emptyresult.com",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "scrape empty vendor", "Scrape Empty Vendor", website="https://emptyresult.com")
 
     async def mock_scrape(url):
         return {"emails": ["found@scrape.com"], "phones": []}
@@ -517,16 +483,7 @@ def test_lookup_tier2_scrape_no_emails_after_merge(client, db_session, monkeypat
 
 def test_lookup_tier2_scrape_exception(client, db_session, monkeypatch):
     """Tier 2: scrape throws exception, falls through to tier 3."""
-    vc = VendorCard(
-        normalized_name="scrape fail vendor",
-        display_name="Scrape Fail Vendor",
-        website="https://fails.com",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "scrape fail vendor", "Scrape Fail Vendor", website="https://fails.com")
 
     async def mock_scrape(url):
         raise ConnectionError("Timeout")
@@ -542,15 +499,7 @@ def test_lookup_tier2_scrape_exception(client, db_session, monkeypatch):
 
 def test_lookup_tier3_ai_string_emails(client, db_session, monkeypatch):
     """Tier 3: AI returns emails as a string instead of list."""
-    vc = VendorCard(
-        normalized_name="stringemail vendor",
-        display_name="StringEmail Vendor",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "stringemail vendor", "StringEmail Vendor")
 
     monkeypatch.setattr("app.routers.vendor_contacts.get_credential_cached", lambda *a, **kw: "fake-key")
 
@@ -574,15 +523,7 @@ def test_lookup_tier3_ai_string_emails(client, db_session, monkeypatch):
 
 def test_lookup_tier3_ai_returns_none(client, db_session, monkeypatch):
     """Tier 3: AI returns None/non-dict."""
-    vc = VendorCard(
-        normalized_name="nullai vendor",
-        display_name="NullAI Vendor",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "nullai vendor", "NullAI Vendor")
 
     monkeypatch.setattr("app.routers.vendor_contacts.get_credential_cached", lambda *a, **kw: "fake-key")
 
@@ -599,15 +540,7 @@ def test_lookup_tier3_ai_returns_none(client, db_session, monkeypatch):
 
 def test_lookup_tier3_ai_exception(client, db_session, monkeypatch):
     """Tier 3: AI lookup throws exception returns tier=0 with error."""
-    vc = VendorCard(
-        normalized_name="ai error vendor",
-        display_name="AI Error Vendor",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "ai error vendor", "AI Error Vendor")
 
     monkeypatch.setattr("app.routers.vendor_contacts.get_credential_cached", lambda *a, **kw: "fake-key")
 
@@ -626,16 +559,7 @@ def test_lookup_tier3_ai_exception(client, db_session, monkeypatch):
 
 def test_lookup_tier3_ai_with_website_hint(client, db_session, monkeypatch):
     """Tier 3: AI lookup includes website hint when card has a website."""
-    vc = VendorCard(
-        normalized_name="hinted vendor",
-        display_name="Hinted Vendor",
-        website="https://hinted.com",
-        emails=[],
-        phones=[],
-        sighting_count=1,
-    )
-    db_session.add(vc)
-    db_session.commit()
+    make_vendor_card(db_session, "hinted vendor", "Hinted Vendor", website="https://hinted.com")
 
     async def mock_scrape(url):
         return {"emails": [], "phones": []}
@@ -661,14 +585,7 @@ def test_lookup_vendor_contact_integrity_error_race(client, db_session, monkeypa
     from app.vendor_utils import normalize_vendor_name
 
     norm = normalize_vendor_name("Integrity Race Vendor")
-    existing_vc = VendorCard(
-        normalized_name=norm,
-        display_name="Integrity Race Vendor",
-        emails=["exists@race.com"],
-        sighting_count=1,
-    )
-    db_session.add(existing_vc)
-    db_session.commit()
+    make_vendor_card(db_session, norm, "Integrity Race Vendor", emails=["exists@race.com"])
 
     monkeypatch.setattr("app.routers.vendor_contacts.get_credential_cached", lambda *a, **kw: None)
 

--- a/tests/test_schemas_coverage.py
+++ b/tests/test_schemas_coverage.py
@@ -71,13 +71,10 @@ class TestBuyPlanLineEdit:
         s = BuyPlanLineEdit(requirement_id=1, offer_id=2, quantity=5, sales_note="rush")
         assert s.sales_note == "rush"
 
-    def test_quantity_must_be_positive(self):
+    @pytest.mark.parametrize("quantity", [0, -1], ids=["zero", "negative"])
+    def test_quantity_must_be_positive(self, quantity):
         with pytest.raises(ValidationError):
-            BuyPlanLineEdit(requirement_id=1, offer_id=2, quantity=0)
-
-    def test_quantity_negative_rejected(self):
-        with pytest.raises(ValidationError):
-            BuyPlanLineEdit(requirement_id=1, offer_id=2, quantity=-1)
+            BuyPlanLineEdit(requirement_id=1, offer_id=2, quantity=quantity)
 
     def test_missing_required_fields(self):
         with pytest.raises(ValidationError):
@@ -109,21 +106,23 @@ class TestSOVerificationRequest:
         assert s.action == "approve"
         assert s.rejection_note is None
 
-    def test_reject_with_note(self):
-        s = SOVerificationRequest(action="reject", rejection_note="  wrong SO  ")
-        assert s.rejection_note == "wrong SO"
+    @pytest.mark.parametrize(
+        ("action", "raw_note", "expected"),
+        [
+            ("reject", "  wrong SO  ", "wrong SO"),
+            ("halt", "on hold", "on hold"),
+            ("approve", "  info  ", "info"),
+        ],
+        ids=["reject_with_note", "halt_with_note", "approve_with_note_strips"],
+    )
+    def test_note_stripped(self, action, raw_note, expected):
+        s = SOVerificationRequest(action=action, rejection_note=raw_note)
+        assert s.rejection_note == expected
 
-    def test_halt_with_note(self):
-        s = SOVerificationRequest(action="halt", rejection_note="on hold")
-        assert s.rejection_note == "on hold"
-
-    def test_reject_requires_note(self):
+    @pytest.mark.parametrize("action", ["reject", "halt"])
+    def test_requires_note(self, action):
         with pytest.raises(ValidationError, match="note is required"):
-            SOVerificationRequest(action="reject")
-
-    def test_halt_requires_note(self):
-        with pytest.raises(ValidationError, match="note is required"):
-            SOVerificationRequest(action="halt")
+            SOVerificationRequest(action=action)
 
     def test_reject_blank_note_rejected(self):
         with pytest.raises(ValidationError):
@@ -132,10 +131,6 @@ class TestSOVerificationRequest:
     def test_invalid_action(self):
         with pytest.raises(ValidationError):
             SOVerificationRequest(action="cancel")
-
-    def test_approve_with_note_strips(self):
-        s = SOVerificationRequest(action="approve", rejection_note="  info  ")
-        assert s.rejection_note == "info"
 
 
 class TestPOConfirmation:
@@ -150,15 +145,11 @@ class TestPOConfirmation:
         s = POConfirmation(po_number="  PO-999  ", estimated_ship_date=dt)
         assert s.po_number == "PO-999"
 
-    def test_blank_po_number(self):
+    @pytest.mark.parametrize("po_number", ["   ", ""], ids=["blank", "empty"])
+    def test_missing_po_number(self, po_number):
         dt = datetime(2026, 6, 1, tzinfo=timezone.utc)
         with pytest.raises(ValidationError, match="PO number is required"):
-            POConfirmation(po_number="   ", estimated_ship_date=dt)
-
-    def test_empty_po_number(self):
-        dt = datetime(2026, 6, 1, tzinfo=timezone.utc)
-        with pytest.raises(ValidationError, match="PO number is required"):
-            POConfirmation(po_number="", estimated_ship_date=dt)
+            POConfirmation(po_number=po_number, estimated_ship_date=dt)
 
 
 class TestPOVerificationRequest:
@@ -166,9 +157,17 @@ class TestPOVerificationRequest:
         s = POVerificationRequest(action="approve")
         assert s.action == "approve"
 
-    def test_reject_with_note(self):
-        s = POVerificationRequest(action="reject", rejection_note="wrong amount")
-        assert s.rejection_note == "wrong amount"
+    @pytest.mark.parametrize(
+        ("action", "raw_note", "expected"),
+        [
+            ("reject", "wrong amount", "wrong amount"),
+            ("approve", "  fyi  ", "fyi"),
+        ],
+        ids=["reject_with_note", "approve_with_note_strips"],
+    )
+    def test_note_stripped(self, action, raw_note, expected):
+        s = POVerificationRequest(action=action, rejection_note=raw_note)
+        assert s.rejection_note == expected
 
     def test_reject_without_note(self):
         with pytest.raises(ValidationError, match="note is required"):
@@ -182,10 +181,6 @@ class TestPOVerificationRequest:
         with pytest.raises(ValidationError):
             POVerificationRequest(action="halt")
 
-    def test_approve_with_note_strips(self):
-        s = POVerificationRequest(action="approve", rejection_note="  fyi  ")
-        assert s.rejection_note == "fyi"
-
 
 class TestBuyPlanLineIssue:
     def test_sold_out(self):
@@ -193,9 +188,18 @@ class TestBuyPlanLineIssue:
         assert s.issue_type == "sold_out"
         assert s.note is None
 
-    def test_other_with_note(self):
-        s = BuyPlanLineIssue(issue_type="other", note="custom issue")
-        assert s.note == "custom issue"
+    @pytest.mark.parametrize(
+        ("issue_type", "raw_note", "expected"),
+        [
+            ("other", "custom issue", "custom issue"),
+            ("price_changed", "went up 10%", "went up 10%"),
+            ("other", "  spaces  ", "spaces"),
+        ],
+        ids=["other_with_note", "price_changed", "note_stripped"],
+    )
+    def test_note_round_trip(self, issue_type, raw_note, expected):
+        s = BuyPlanLineIssue(issue_type=issue_type, note=raw_note)
+        assert s.note == expected
 
     def test_other_requires_note(self):
         with pytest.raises(ValidationError, match="note is required"):
@@ -205,10 +209,6 @@ class TestBuyPlanLineIssue:
         with pytest.raises(ValidationError):
             BuyPlanLineIssue(issue_type="other", note="   ")
 
-    def test_price_changed(self):
-        s = BuyPlanLineIssue(issue_type="price_changed", note="went up 10%")
-        assert s.note == "went up 10%"
-
     def test_lead_time_changed(self):
         s = BuyPlanLineIssue(issue_type="lead_time_changed")
         assert s.issue_type == "lead_time_changed"
@@ -217,20 +217,13 @@ class TestBuyPlanLineIssue:
         with pytest.raises(ValidationError):
             BuyPlanLineIssue(issue_type="damaged")
 
-    def test_note_stripped(self):
-        s = BuyPlanLineIssue(issue_type="other", note="  spaces  ")
-        assert s.note == "spaces"
-
 
 class TestVerificationGroupUpdate:
-    def test_add(self):
-        s = VerificationGroupUpdate(user_id=42, action="add")
-        assert s.user_id == 42
-        assert s.action == "add"
-
-    def test_remove(self):
-        s = VerificationGroupUpdate(user_id=1, action="remove")
-        assert s.action == "remove"
+    @pytest.mark.parametrize(("user_id", "action"), [(42, "add"), (1, "remove")])
+    def test_valid_actions(self, user_id, action):
+        s = VerificationGroupUpdate(user_id=user_id, action=action)
+        assert s.user_id == user_id
+        assert s.action == action
 
     def test_invalid_action(self):
         with pytest.raises(ValidationError):
@@ -288,33 +281,20 @@ class TestKnowledgeEntryCreate:
         with pytest.raises(ValidationError):
             KnowledgeEntryCreate(entry_type="fact", content="x", source="twitter")
 
-    def test_content_min_length(self):
+    @pytest.mark.parametrize("content", ["", "x" * 10001], ids=["min_length", "max_length"])
+    def test_invalid_content_length(self, content):
         with pytest.raises(ValidationError):
-            KnowledgeEntryCreate(entry_type="fact", content="")
+            KnowledgeEntryCreate(entry_type="fact", content=content)
 
-    def test_content_max_length(self):
+    @pytest.mark.parametrize("confidence", [0.5, 0.0, 1.0], ids=["range", "zero", "one"])
+    def test_confidence_valid(self, confidence):
+        s = KnowledgeEntryCreate(entry_type="fact", content="x", confidence=confidence)
+        assert s.confidence == confidence
+
+    @pytest.mark.parametrize("confidence", [1.1, -0.1], ids=["too_high", "negative"])
+    def test_confidence_out_of_range(self, confidence):
         with pytest.raises(ValidationError):
-            KnowledgeEntryCreate(entry_type="fact", content="x" * 10001)
-
-    def test_confidence_range(self):
-        s = KnowledgeEntryCreate(entry_type="fact", content="x", confidence=0.5)
-        assert s.confidence == 0.5
-
-    def test_confidence_zero(self):
-        s = KnowledgeEntryCreate(entry_type="fact", content="x", confidence=0.0)
-        assert s.confidence == 0.0
-
-    def test_confidence_one(self):
-        s = KnowledgeEntryCreate(entry_type="fact", content="x", confidence=1.0)
-        assert s.confidence == 1.0
-
-    def test_confidence_too_high(self):
-        with pytest.raises(ValidationError):
-            KnowledgeEntryCreate(entry_type="fact", content="x", confidence=1.1)
-
-    def test_confidence_negative(self):
-        with pytest.raises(ValidationError):
-            KnowledgeEntryCreate(entry_type="fact", content="x", confidence=-0.1)
+            KnowledgeEntryCreate(entry_type="fact", content="x", confidence=confidence)
 
     def test_optional_foreign_keys(self):
         s = KnowledgeEntryCreate(
@@ -365,13 +345,10 @@ class TestAnswerCreate:
         s = AnswerCreate(content="The MOQ is 100")
         assert s.content == "The MOQ is 100"
 
-    def test_empty_content(self):
+    @pytest.mark.parametrize("content", ["", "x" * 10001], ids=["empty", "too_long"])
+    def test_invalid_content_length(self, content):
         with pytest.raises(ValidationError):
-            AnswerCreate(content="")
-
-    def test_max_length(self):
-        with pytest.raises(ValidationError):
-            AnswerCreate(content="x" * 10001)
+            AnswerCreate(content=content)
 
 
 class TestKnowledgeEntryUpdate:
@@ -464,13 +441,14 @@ class TestPhoneCallLog:
         )
         assert s.parts == ["LM358", "NE555"]
 
-    def test_blank_vendor_name(self):
+    @pytest.mark.parametrize(
+        ("vendor_name", "vendor_phone"),
+        [("   ", "555"), ("Acme", "  ")],
+        ids=["blank_vendor_name", "blank_vendor_phone"],
+    )
+    def test_blank_fields_rejected(self, vendor_name, vendor_phone):
         with pytest.raises(ValidationError, match="must not be blank"):
-            PhoneCallLog(requisition_id=1, vendor_name="   ", vendor_phone="555")
-
-    def test_blank_vendor_phone(self):
-        with pytest.raises(ValidationError, match="must not be blank"):
-            PhoneCallLog(requisition_id=1, vendor_name="Acme", vendor_phone="  ")
+            PhoneCallLog(requisition_id=1, vendor_name=vendor_name, vendor_phone=vendor_phone)
 
     def test_strips_whitespace(self):
         s = PhoneCallLog(requisition_id=1, vendor_name="  Acme  ", vendor_phone=" 555 ")
@@ -570,15 +548,11 @@ class TestTaskCreate:
         with pytest.raises(ValidationError, match="at least 24 hours"):
             TaskCreate(title="X", assigned_to_id=1, due_at=soon)
 
-    def test_title_min_length(self):
+    @pytest.mark.parametrize("title", ["", "x" * 256], ids=["min_length", "max_length"])
+    def test_invalid_title_length(self, title):
         future = datetime.now(timezone.utc) + timedelta(hours=48)
         with pytest.raises(ValidationError):
-            TaskCreate(title="", assigned_to_id=1, due_at=future)
-
-    def test_title_max_length(self):
-        future = datetime.now(timezone.utc) + timedelta(hours=48)
-        with pytest.raises(ValidationError):
-            TaskCreate(title="x" * 256, assigned_to_id=1, due_at=future)
+            TaskCreate(title=title, assigned_to_id=1, due_at=future)
 
     def test_naive_datetime_treated_as_utc(self):
         future_naive = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=48)
@@ -738,14 +712,11 @@ class TestPoolFilters:
         assert s.page == 3
         assert s.per_page == 50
 
-    def test_page_minimum(self):
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"page": 0}, {"per_page": 0}, {"per_page": 101}],
+        ids=["page_minimum", "per_page_minimum", "per_page_maximum"],
+    )
+    def test_bounds_rejected(self, kwargs):
         with pytest.raises(ValidationError):
-            PoolFilters(page=0)
-
-    def test_per_page_minimum(self):
-        with pytest.raises(ValidationError):
-            PoolFilters(per_page=0)
-
-    def test_per_page_maximum(self):
-        with pytest.raises(ValidationError):
-            PoolFilters(per_page=101)
+            PoolFilters(**kwargs)

--- a/tests/test_search_affinity.py
+++ b/tests/test_search_affinity.py
@@ -61,6 +61,14 @@ def _make_requirement(db: Session, requisition: Requisition, mpn: str = "LM317T"
     return req
 
 
+@pytest.fixture
+def requirement(db_session) -> Requirement:
+    """A persisted Requirement with its parent user + requisition."""
+    user = _make_user(db_session)
+    reqn = _make_requisition(db_session, user)
+    return _make_requirement(db_session, reqn)
+
+
 MOCK_AFFINITY = [
     {
         "vendor_name": "Vendor Alpha",
@@ -116,19 +124,15 @@ MOCK_STATS = [
 
 class TestSearchIncludesVendorAffinity:
     @pytest.mark.asyncio
-    async def test_search_includes_vendor_affinity(self, db_session):
+    async def test_search_includes_vendor_affinity(self, db_session, requirement):
         """Affinity suggestions appear in search results with
         source_type='vendor_affinity'."""
-        user = _make_user(db_session)
-        reqn = _make_requisition(db_session, user)
-        req = _make_requirement(db_session, reqn)
-
         with (
             patch("app.search_service._fetch_fresh", new_callable=AsyncMock) as mock_fetch,
             patch("app.search_service.find_vendor_affinity", return_value=list(MOCK_AFFINITY)),
         ):
             mock_fetch.return_value = (list(MOCK_FRESH), list(MOCK_STATS))
-            result = await search_requirement(req, db_session)
+            result = await search_requirement(requirement, db_session)
 
         sightings = result["sightings"]
         affinity_results = [s for s in sightings if s.get("source_type") == "vendor_affinity"]
@@ -146,18 +150,14 @@ class TestSearchIncludesVendorAffinity:
 
 class TestAffinityResultFields:
     @pytest.mark.asyncio
-    async def test_affinity_results_have_correct_fields(self, db_session):
+    async def test_affinity_results_have_correct_fields(self, db_session, requirement):
         """Affinity results include source_badge, confidence_pct, and reasoning."""
-        user = _make_user(db_session)
-        reqn = _make_requisition(db_session, user)
-        req = _make_requirement(db_session, reqn)
-
         with (
             patch("app.search_service._fetch_fresh", new_callable=AsyncMock) as mock_fetch,
             patch("app.search_service.find_vendor_affinity", return_value=list(MOCK_AFFINITY)),
         ):
             mock_fetch.return_value = (list(MOCK_FRESH), list(MOCK_STATS))
-            result = await search_requirement(req, db_session)
+            result = await search_requirement(requirement, db_session)
 
         affinity_results = [s for s in result["sightings"] if s.get("is_affinity")]
 
@@ -178,12 +178,8 @@ class TestAffinityResultFields:
 
 class TestAffinityDedupWithLiveResults:
     @pytest.mark.asyncio
-    async def test_affinity_dedup_with_live_results(self, db_session):
+    async def test_affinity_dedup_with_live_results(self, db_session, requirement):
         """If a vendor already appears in live results, skip the affinity suggestion."""
-        user = _make_user(db_session)
-        reqn = _make_requisition(db_session, user)
-        req = _make_requirement(db_session, reqn)
-
         # Affinity includes "Arrow" which is already in live results
         affinity_with_dupe = list(MOCK_AFFINITY) + [
             {
@@ -202,7 +198,7 @@ class TestAffinityDedupWithLiveResults:
             patch("app.search_service.find_vendor_affinity", return_value=affinity_with_dupe),
         ):
             mock_fetch.return_value = (list(MOCK_FRESH), list(MOCK_STATS))
-            result = await search_requirement(req, db_session)
+            result = await search_requirement(requirement, db_session)
 
         sightings = result["sightings"]
         affinity_results = [s for s in sightings if s.get("is_affinity")]

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -20,7 +20,9 @@ import os
 
 os.environ["TESTING"] = "1"
 
+from contextlib import ExitStack, contextmanager
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -152,6 +154,37 @@ def _setup_mock_connectors(mocks, default_results=None, class_names=None):
     for mock, cls_name in zip(mocks, class_names):
         mock.return_value.search = AsyncMock(return_value=list(default_results))
         mock.return_value.__class__.__name__ = cls_name
+
+
+# Short attribute name per connector class, in the canonical order above.
+_CONNECTOR_ATTR_NAMES = [
+    "nexar",
+    "brokerbin",
+    "ebay",
+    "digikey",
+    "mouser",
+    "oemsecrets",
+    "sourcengine",
+    "element14",
+]
+
+
+@contextmanager
+def _patched_connectors(creds_value="fake-key"):
+    """Patch all 8 connector classes (at their source in app.search_service) plus the
+    standard credential lookups, configure them with default empty results, and yield a
+    namespace of the mocks keyed by short name (m.nexar, m.brokerbin, ...).
+
+    Tests override individual connectors via m.<name>.return_value.search = AsyncMock(...).
+    """
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch(creds_value))
+        )
+        stack.enter_context(patch("app.services.credential_service.get_credential", return_value=creds_value))
+        mocks = [stack.enter_context(patch(f"app.search_service.{cls}")) for cls in _CONNECTOR_CLASS_NAMES]
+        _setup_mock_connectors(mocks)
+        yield SimpleNamespace(**dict(zip(_CONNECTOR_ATTR_NAMES, mocks)))
 
 
 # ── get_all_pns ──────────────────────────────────────────────────────────
@@ -1640,21 +1673,8 @@ class TestFetchFresh:
         """One connector returns results successfully."""
         _make_api_source(db_session, "nexar")
 
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = AsyncMock(
+        with _patched_connectors() as m:
+            m.nexar.return_value.search = AsyncMock(
                 return_value=[
                     {"vendor_name": "Arrow", "mpn_matched": "LM317T", "vendor_sku": "ARR-1", "source_type": "nexar"},
                 ]
@@ -1671,25 +1691,11 @@ class TestFetchFresh:
         _make_api_source(db_session, "nexar")
         _make_api_source(db_session, "brokerbin")
 
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-
+        with _patched_connectors() as m:
             # Nexar errors out
-            MockNexar.return_value.search = AsyncMock(side_effect=Exception("Nexar down"))
+            m.nexar.return_value.search = AsyncMock(side_effect=Exception("Nexar down"))
             # BrokerBin returns results
-            MockBB.return_value.search = AsyncMock(
+            m.brokerbin.return_value.search = AsyncMock(
                 return_value=[
                     {
                         "vendor_name": "BrokerVendor",
@@ -1710,29 +1716,15 @@ class TestFetchFresh:
     @pytest.mark.asyncio
     async def test_dedup_results(self, db_session):
         """Duplicate results (same vendor, mpn_key, vendor_sku) are deduped."""
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-
+        with _patched_connectors() as m:
             dup_result = {
                 "vendor_name": "Arrow",
                 "mpn_matched": "LM317T",
                 "vendor_sku": "ARR-1",
                 "source_type": "nexar",
             }
-            MockNexar.return_value.search = AsyncMock(return_value=[dup_result.copy()])
-            MockBB.return_value.search = AsyncMock(return_value=[dup_result.copy()])
+            m.nexar.return_value.search = AsyncMock(return_value=[dup_result.copy()])
+            m.brokerbin.return_value.search = AsyncMock(return_value=[dup_result.copy()])
 
             results, stats = await _fetch_fresh(["LM317T"], db_session)
 
@@ -1743,23 +1735,9 @@ class TestFetchFresh:
     async def test_dedup_integer_vendor_sku(self, db_session):
         """Dedup handles integer vendor_sku without crashing (OEMSecrets returns int
         SKUs)."""
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-
+        with _patched_connectors() as m:
             # OEMSecrets returns vendor_sku as integer
-            MockOEM.return_value.search = AsyncMock(
+            m.oemsecrets.return_value.search = AsyncMock(
                 return_value=[
                     {
                         "vendor_name": "Farnell",
@@ -1778,21 +1756,7 @@ class TestFetchFresh:
     @pytest.mark.asyncio
     async def test_junk_vendors_filtered(self, db_session):
         """Junk vendor names (empty, 'unknown', etc.) are filtered out."""
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-
+        with _patched_connectors() as m:
             junk_results = [
                 {"vendor_name": "", "mpn_matched": "LM317T", "vendor_sku": "1"},
                 {"vendor_name": "Unknown", "mpn_matched": "LM317T", "vendor_sku": "2"},
@@ -1806,7 +1770,7 @@ class TestFetchFresh:
                 {"vendor_name": "no sellers listed", "mpn_matched": "LM317T", "vendor_sku": "10"},
                 {"vendor_name": "Good Vendor", "mpn_matched": "LM317T", "vendor_sku": "11"},
             ]
-            MockNexar.return_value.search = AsyncMock(return_value=junk_results)
+            m.nexar.return_value.search = AsyncMock(return_value=junk_results)
 
             results, stats = await _fetch_fresh(["LM317T"], db_session)
 
@@ -1818,27 +1782,14 @@ class TestFetchFresh:
         """Stats are aggregated across multiple PNs for same connector."""
         _make_api_source(db_session, "nexar")
 
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
+        with _patched_connectors() as m:
 
             async def _nexar_search(pn):
                 return [
                     {"vendor_name": f"V-{pn}", "mpn_matched": pn, "vendor_sku": f"SKU-{pn}", "source_type": "nexar"}
                 ]
 
-            MockNexar.return_value.search = AsyncMock(side_effect=_nexar_search)
+            m.nexar.return_value.search = AsyncMock(side_effect=_nexar_search)
 
             results, stats = await _fetch_fresh(["LM317T", "LM7805"], db_session)
 
@@ -1850,21 +1801,8 @@ class TestFetchFresh:
     @pytest.mark.asyncio
     async def test_db_stats_commit_failure(self, db_session):
         """DB stats commit failure doesn't break the search."""
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = AsyncMock(
+        with _patched_connectors() as m:
+            m.nexar.return_value.search = AsyncMock(
                 return_value=[
                     {"vendor_name": "Arrow", "mpn_matched": "LM317T", "vendor_sku": "1"},
                 ]
@@ -1934,21 +1872,8 @@ class TestFetchFresh:
                 raise Exception("Temporary failure")
             return [{"vendor_name": "Arrow", "mpn_matched": pn, "vendor_sku": "A1"}]
 
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = AsyncMock(side_effect=_flaky_search)
+        with _patched_connectors() as m:
+            m.nexar.return_value.search = AsyncMock(side_effect=_flaky_search)
 
             results, stats = await _fetch_fresh(["PN1", "PN2"], db_session)
 
@@ -1973,21 +1898,8 @@ class TestFetchFresh:
             # Second call errors
             raise Exception("Second call failed")
 
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = AsyncMock(side_effect=_flaky_search)
+        with _patched_connectors() as m:
+            m.nexar.return_value.search = AsyncMock(side_effect=_flaky_search)
 
             results, stats = await _fetch_fresh(["PN1", "PN2"], db_session)
 
@@ -2019,21 +1931,8 @@ class TestFetchFresh:
         src = _make_api_source(db_session, "nexar")
         old_searches = src.total_searches
 
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = AsyncMock(
+        with _patched_connectors() as m:
+            m.nexar.return_value.search = AsyncMock(
                 return_value=[
                     {"vendor_name": "Arrow", "mpn_matched": "LM317T", "vendor_sku": "1"},
                 ]
@@ -2053,21 +1952,8 @@ class TestFetchFresh:
         """ApiSource.last_error, last_error_at, error_count_24h updated on failure."""
         src = _make_api_source(db_session, "nexar")
 
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = AsyncMock(side_effect=Exception("API timeout"))
+        with _patched_connectors() as m:
+            m.nexar.return_value.search = AsyncMock(side_effect=Exception("API timeout"))
 
             results, stats = await _fetch_fresh(["LM317T"], db_session)
 
@@ -2083,21 +1969,8 @@ class TestFetchFresh:
         src.avg_response_ms = 200
         db_session.commit()
 
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = AsyncMock(
+        with _patched_connectors() as m:
+            m.nexar.return_value.search = AsyncMock(
                 return_value=[
                     {"vendor_name": "Arrow", "mpn_matched": "LM317T", "vendor_sku": "1"},
                 ]
@@ -2115,21 +1988,8 @@ class TestFetchFresh:
         src.avg_response_ms = None
         db_session.commit()
 
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = AsyncMock(
+        with _patched_connectors() as m:
+            m.nexar.return_value.search = AsyncMock(
                 return_value=[
                     {"vendor_name": "Arrow", "mpn_matched": "LM317T", "vendor_sku": "1"},
                 ]
@@ -2145,21 +2005,8 @@ class TestFetchFresh:
     async def test_source_not_in_src_map_skipped(self, db_session):
         """Connectors without matching ApiSource records skip stats update."""
         # Don't create any ApiSource records
-        with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
-        ):
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = AsyncMock(
+        with _patched_connectors() as m:
+            m.nexar.return_value.search = AsyncMock(
                 return_value=[
                     {"vendor_name": "Arrow", "mpn_matched": "LM317T", "vendor_sku": "1"},
                 ]
@@ -2707,24 +2554,13 @@ class TestSearchThrottling:
             return result
 
         with (
-            patch("app.search_service.get_credentials_batch", side_effect=_fake_creds_batch("fake-key")),
-            patch("app.services.credential_service.get_credential", return_value="fake-key"),
-            patch("app.search_service.NexarConnector") as MockNexar,
-            patch("app.search_service.BrokerBinConnector") as MockBB,
-            patch("app.search_service.EbayConnector") as MockEbay,
-            patch("app.search_service.DigiKeyConnector") as MockDK,
-            patch("app.search_service.MouserConnector") as MockMouser,
-            patch("app.search_service.OEMSecretsConnector") as MockOEM,
-            patch("app.search_service.SourcengineConnector") as MockSrc,
-            patch("app.search_service.Element14Connector") as MockE14,
+            _patched_connectors() as m,
             patch("app.config.settings") as mock_settings,
         ):
             mock_settings.search_concurrency_limit = 2
             mock_settings.search_total_timeout_s = 5.0
 
-            mocks = [MockNexar, MockBB, MockEbay, MockDK, MockMouser, MockOEM, MockSrc, MockE14]
-            _setup_mock_connectors(mocks)
-            MockNexar.return_value.search = _tracking_search
+            m.nexar.return_value.search = _tracking_search
 
             _make_api_source(db_session, "nexar")
             # Search 5 PNs — only nexar is active, so 5 tasks

--- a/tests/test_search_service_cooldown.py
+++ b/tests/test_search_service_cooldown.py
@@ -30,6 +30,30 @@ def _mk_card(db: Session, mpn: str, last_searched_at):
     return card
 
 
+def _mk_requirement(db: Session, test_user, *, req_name, primary_mpn, now, customer_name="Test Co", substitutes=None):
+    req = Requisition(
+        name=req_name,
+        customer_name=customer_name,
+        status="active",
+        created_by=test_user.id,
+        created_at=now,
+    )
+    db.add(req)
+    db.flush()
+    # Only set substitutes when provided so the JSON default (list) still applies
+    # when omitted, matching how callers that don't pass substitutes behave.
+    extra = {"substitutes": substitutes} if substitutes is not None else {}
+    item = Requirement(
+        requisition_id=req.id,
+        primary_mpn=primary_mpn,
+        created_at=now,
+        **extra,
+    )
+    db.add(item)
+    db.flush()
+    return item
+
+
 class TestMpnCooldownPartition:
     def test_partitions_stale_and_fresh_mpns(self, db_session: Session):
         now = datetime.now(timezone.utc)
@@ -78,24 +102,14 @@ class TestSearchRequirementCooldown:
         # resolver block would call _fetch_fresh a second time on the AVL.
         monkeypatch.setattr(settings, "spec_resolver_enabled", False)
         now = datetime.now(timezone.utc)
-        req = Requisition(
-            name="REQ-CD-1",
-            customer_name="Test Co",
-            status="active",
-            created_by=test_user.id,
-            created_at=now,
-        )
-        db_session.add(req)
-        db_session.flush()
-
-        item = Requirement(
-            requisition_id=req.id,
+        item = _mk_requirement(
+            db_session,
+            test_user,
+            req_name="REQ-CD-1",
             primary_mpn="STALEMPN",
+            now=now,
             substitutes=[{"mpn": "FRESHMPN"}],
-            created_at=now,
         )
-        db_session.add(item)
-        db_session.flush()
 
         # FRESHMPN already searched 12h ago → should be skipped
         _mk_card(db_session, "FRESHMPN", now - timedelta(hours=12))
@@ -124,21 +138,7 @@ class TestSearchRequirementCooldown:
         # default ever flips.
         monkeypatch.setattr(settings, "spec_resolver_enabled", False)
         now = datetime.now(timezone.utc)
-        req = Requisition(
-            name="REQ-CD-2",
-            customer_name="Test Co",
-            status="active",
-            created_by=test_user.id,
-            created_at=now,
-        )
-        db_session.add(req)
-        db_session.flush()
-        item = Requirement(
-            requisition_id=req.id,
-            primary_mpn="NEWMPN",
-            created_at=now,
-        )
-        db_session.add(item)
+        item = _mk_requirement(db_session, test_user, req_name="REQ-CD-2", primary_mpn="NEWMPN", now=now)
         db_session.commit()
 
         with patch(
@@ -160,21 +160,7 @@ class TestSearchRequirementCooldown:
         # Defensive pin against future flag-default flips.
         monkeypatch.setattr(settings, "spec_resolver_enabled", False)
         now = datetime.now(timezone.utc)
-        req = Requisition(
-            name="REQ-CD-AFFINITY",
-            customer_name="Test Co",
-            status="active",
-            created_by=test_user.id,
-            created_at=now,
-        )
-        db_session.add(req)
-        db_session.flush()
-        item = Requirement(
-            requisition_id=req.id,
-            primary_mpn="CACHEDMPN",
-            created_at=now,
-        )
-        db_session.add(item)
+        item = _mk_requirement(db_session, test_user, req_name="REQ-CD-AFFINITY", primary_mpn="CACHEDMPN", now=now)
         _mk_card(db_session, "CACHEDMPN", now - timedelta(hours=1))
         db_session.commit()
 
@@ -205,22 +191,15 @@ class TestIcsNcEnqueueOnRefresh:
         # resolver default flips on (extra AVL enqueues).
         monkeypatch.setattr(settings, "spec_resolver_enabled", False)
         now = datetime.now(timezone.utc)
-        req = Requisition(
-            name="REQ-CD-3",
-            customer_name="C",
-            status="active",
-            created_by=test_user.id,
-            created_at=now,
-        )
-        db_session.add(req)
-        db_session.flush()
-        item = Requirement(
-            requisition_id=req.id,
+        item = _mk_requirement(
+            db_session,
+            test_user,
+            req_name="REQ-CD-3",
             primary_mpn="EM1",
+            now=now,
+            customer_name="C",
             substitutes=[{"mpn": "EM2"}],
-            created_at=now,
         )
-        db_session.add(item)
         db_session.commit()
 
         with (
@@ -241,21 +220,9 @@ class TestIcsNcEnqueueOnRefresh:
         # Defensive pin against future flag-default flips.
         monkeypatch.setattr(settings, "spec_resolver_enabled", False)
         now = datetime.now(timezone.utc)
-        req = Requisition(
-            name="REQ-CD-CACHED",
-            customer_name="C",
-            status="active",
-            created_by=test_user.id,
-            created_at=now,
+        item = _mk_requirement(
+            db_session, test_user, req_name="REQ-CD-CACHED", primary_mpn="CACHED1", now=now, customer_name="C"
         )
-        db_session.add(req)
-        db_session.flush()
-        item = Requirement(
-            requisition_id=req.id,
-            primary_mpn="CACHED1",
-            created_at=now,
-        )
-        db_session.add(item)
         _mk_card(db_session, "CACHED1", now - timedelta(hours=1))
         db_session.commit()
 

--- a/tests/test_services/test_prospect_contacts.py
+++ b/tests/test_services/test_prospect_contacts.py
@@ -14,176 +14,106 @@ os.environ["RATE_LIMIT_ENABLED"] = "false"
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 # ── Seniority Classification ────────────────────────────────────────
 
 
 class TestClassifyContactSeniority:
-    def test_vp(self):
+    @pytest.mark.parametrize(
+        ("title", "expected"),
+        [
+            ("VP of Procurement", "decision_maker"),
+            ("Vice President, Supply Chain", "decision_maker"),
+            ("Director of Sourcing", "decision_maker"),
+            ("Sr. Dir. Global Procurement", "decision_maker"),
+            ("SVP Operations", "decision_maker"),
+            ("Chief Procurement Officer", "decision_maker"),
+            ("Head of Purchasing", "decision_maker"),
+            ("General Manager, Procurement", "decision_maker"),
+            ("Procurement Manager", "influencer"),
+            ("Senior Buyer", "influencer"),
+            ("Lead Component Engineer", "influencer"),
+            ("Commodity Manager - Electronics", "influencer"),
+            ("Buyer", "executor"),
+            ("Purchasing Agent", "executor"),
+            ("Supply Chain Coordinator", "executor"),
+            ("Procurement Analyst", "executor"),
+            ("Software Engineer", "other"),
+            ("", "other"),
+            (None, "other"),
+            ("CPO", "decision_maker"),
+        ],
+        ids=[
+            "vp",
+            "vice_president",
+            "director",
+            "sr_director",
+            "svp",
+            "chief",
+            "head_of",
+            "general_manager",
+            "manager",
+            "senior",
+            "lead",
+            "commodity_manager",
+            "buyer",
+            "purchasing_agent",
+            "coordinator",
+            "analyst",
+            "other",
+            "empty",
+            "none",
+            "cpo",
+        ],
+    )
+    def test_classify(self, title, expected):
         from app.services.prospect_contacts import classify_contact_seniority
 
-        assert classify_contact_seniority("VP of Procurement") == "decision_maker"
-
-    def test_vice_president(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Vice President, Supply Chain") == "decision_maker"
-
-    def test_director(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Director of Sourcing") == "decision_maker"
-
-    def test_sr_director(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Sr. Dir. Global Procurement") == "decision_maker"
-
-    def test_svp(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("SVP Operations") == "decision_maker"
-
-    def test_chief(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Chief Procurement Officer") == "decision_maker"
-
-    def test_head_of(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Head of Purchasing") == "decision_maker"
-
-    def test_general_manager(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("General Manager, Procurement") == "decision_maker"
-
-    def test_manager(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Procurement Manager") == "influencer"
-
-    def test_senior(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Senior Buyer") == "influencer"
-
-    def test_lead(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Lead Component Engineer") == "influencer"
-
-    def test_commodity_manager(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Commodity Manager - Electronics") == "influencer"
-
-    def test_buyer(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Buyer") == "executor"
-
-    def test_purchasing_agent(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Purchasing Agent") == "executor"
-
-    def test_coordinator(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Supply Chain Coordinator") == "executor"
-
-    def test_analyst(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Procurement Analyst") == "executor"
-
-    def test_other(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("Software Engineer") == "other"
-
-    def test_empty(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("") == "other"
-
-    def test_none(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority(None) == "other"
-
-    def test_cpo(self):
-        from app.services.prospect_contacts import classify_contact_seniority
-
-        assert classify_contact_seniority("CPO") == "decision_maker"
+        assert classify_contact_seniority(title) == expected
 
 
 # ── Email Masking ────────────────────────────────────────────────────
 
 
 class TestMaskEmail:
-    def test_standard_email(self):
+    @pytest.mark.parametrize(
+        ("email", "expected"),
+        [
+            ("john.smith@company.com", "j***@comp..."),
+            ("a@b.co", "a***@b.co"),
+            ("", ""),
+            (None, ""),
+            ("notanemail", ""),
+        ],
+        ids=["standard_email", "short_domain", "empty", "none", "no_at_sign"],
+    )
+    def test_mask(self, email, expected):
         from app.services.prospect_contacts import mask_email
 
-        result = mask_email("john.smith@company.com")
-        assert result == "j***@comp..."
-
-    def test_short_domain(self):
-        from app.services.prospect_contacts import mask_email
-
-        result = mask_email("a@b.co")
-        assert result == "a***@b.co"
-
-    def test_empty(self):
-        from app.services.prospect_contacts import mask_email
-
-        assert mask_email("") == ""
-
-    def test_none(self):
-        from app.services.prospect_contacts import mask_email
-
-        assert mask_email(None) == ""
-
-    def test_no_at_sign(self):
-        from app.services.prospect_contacts import mask_email
-
-        assert mask_email("notanemail") == ""
+        assert mask_email(email) == expected
 
 
 # ── Personal Email Filter ────────────────────────────────────────────
 
 
 class TestPersonalEmailFilter:
-    def test_gmail(self):
+    @pytest.mark.parametrize(
+        ("email", "expected"),
+        [
+            ("john@gmail.com", True),
+            ("jane@yahoo.com", True),
+            ("john@raytheon.com", False),
+            ("", False),
+            ("user@hotmail.com", True),
+            ("user@outlook.com", True),
+        ],
+        ids=["gmail", "yahoo", "corporate", "empty", "hotmail", "outlook"],
+    )
+    def test_is_personal(self, email, expected):
         from app.services.prospect_contacts import _is_personal_email
 
-        assert _is_personal_email("john@gmail.com") is True
-
-    def test_yahoo(self):
-        from app.services.prospect_contacts import _is_personal_email
-
-        assert _is_personal_email("jane@yahoo.com") is True
-
-    def test_corporate(self):
-        from app.services.prospect_contacts import _is_personal_email
-
-        assert _is_personal_email("john@raytheon.com") is False
-
-    def test_empty(self):
-        from app.services.prospect_contacts import _is_personal_email
-
-        assert _is_personal_email("") is False
-
-    def test_hotmail(self):
-        from app.services.prospect_contacts import _is_personal_email
-
-        assert _is_personal_email("user@hotmail.com") is True
-
-    def test_outlook(self):
-        from app.services.prospect_contacts import _is_personal_email
-
-        assert _is_personal_email("user@outlook.com") is True
+        assert _is_personal_email(email) is expected
 
 
 # ── New Hire Detection ───────────────────────────────────────────────

--- a/tests/test_sighting_aggregation.py
+++ b/tests/test_sighting_aggregation.py
@@ -7,9 +7,11 @@ Called by: pytest
 Depends on: app.services.sighting_aggregation, conftest fixtures
 """
 
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models.sourcing import Requirement, Requisition, Sighting
@@ -73,28 +75,37 @@ def _make_sighting(
     return s
 
 
+@contextmanager
+def _patch_ai_qty(qty: int | None, approximate: bool = False):
+    """Patch the AI qty estimator to return a fixed result (mocked at the source
+    module)."""
+    with patch(
+        "app.services.sighting_aggregation._estimate_qty_with_ai",
+        return_value={"qty": qty, "approximate": approximate},
+    ):
+        yield
+
+
 # ── Tier label tests ─────────────────────────────────────────────────
 
 
 class TestScoreToTier:
-    def test_none_is_poor(self):
-        assert _score_to_tier(None) == "Poor"
-
-    def test_excellent(self):
-        assert _score_to_tier(70) == "Excellent"
-        assert _score_to_tier(100) == "Excellent"
-
-    def test_good(self):
-        assert _score_to_tier(40) == "Good"
-        assert _score_to_tier(69.9) == "Good"
-
-    def test_fair(self):
-        assert _score_to_tier(20) == "Fair"
-        assert _score_to_tier(39.9) == "Fair"
-
-    def test_poor(self):
-        assert _score_to_tier(0) == "Poor"
-        assert _score_to_tier(19.9) == "Poor"
+    @pytest.mark.parametrize(
+        ("score", "expected_tier"),
+        [
+            (None, "Poor"),
+            (70, "Excellent"),
+            (100, "Excellent"),
+            (40, "Good"),
+            (69.9, "Good"),
+            (20, "Fair"),
+            (39.9, "Fair"),
+            (0, "Poor"),
+            (19.9, "Poor"),
+        ],
+    )
+    def test_score_to_tier(self, score, expected_tier):
+        assert _score_to_tier(score) == expected_tier
 
 
 # ── Grouping tests ───────────────────────────────────────────────────
@@ -113,9 +124,7 @@ class TestVendorGrouping:
         )
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 300, "approximate": False}
-        ):
+        with _patch_ai_qty(300):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert len(results) == 1
@@ -129,9 +138,7 @@ class TestVendorGrouping:
         _make_sighting(db_session, item.id, vendor_name="Mouser", unit_price=1.5)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert len(results) == 2
@@ -143,9 +150,7 @@ class TestVendorGrouping:
         _make_sighting(db_session, item.id, vendor_name="Arrow Electronics", is_unavailable=True)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": None, "approximate": False}
-        ):
+        with _patch_ai_qty(None):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert len(results) == 0
@@ -161,9 +166,7 @@ class TestPriceAggregation:
         _make_sighting(db_session, item.id, unit_price=3.0)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 200, "approximate": False}
-        ):
+        with _patch_ai_qty(200):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert len(results) == 1
@@ -176,9 +179,7 @@ class TestPriceAggregation:
         _make_sighting(db_session, item.id, unit_price=8.0)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 300, "approximate": False}
-        ):
+        with _patch_ai_qty(300):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].best_price == 2.0
@@ -188,9 +189,7 @@ class TestPriceAggregation:
         _make_sighting(db_session, item.id, unit_price=None)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].avg_price is None
@@ -208,9 +207,7 @@ class TestQtyFallback:
         _make_sighting(db_session, item.id, qty_available=200)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": None, "approximate": False}
-        ):
+        with _patch_ai_qty(None):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         # Fallback: max of non-null = max(100, 200) = 200
@@ -222,9 +219,7 @@ class TestQtyFallback:
         _make_sighting(db_session, item.id, qty_available=200)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 250, "approximate": False}
-        ):
+        with _patch_ai_qty(250):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].estimated_qty == 250
@@ -234,9 +229,7 @@ class TestQtyFallback:
         _make_sighting(db_session, item.id, qty_available=None)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": None, "approximate": False}
-        ):
+        with _patch_ai_qty(None):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].estimated_qty is None
@@ -251,9 +244,7 @@ class TestTierInSummary:
         _make_sighting(db_session, item.id, score=80)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].tier == "Excellent"
@@ -266,9 +257,7 @@ class TestTierInSummary:
         _make_sighting(db_session, item.id, score=75)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 200, "approximate": False}
-        ):
+        with _patch_ai_qty(200):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].score == 75.0
@@ -284,9 +273,7 @@ class TestUpsert:
         _make_sighting(db_session, item.id, unit_price=1.0, qty_available=100, score=50)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             first = rebuild_vendor_summaries(db_session, item.id)
         db_session.commit()
 
@@ -297,9 +284,7 @@ class TestUpsert:
         _make_sighting(db_session, item.id, unit_price=3.0, qty_available=200, score=90)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 300, "approximate": False}
-        ):
+        with _patch_ai_qty(300):
             second = rebuild_vendor_summaries(db_session, item.id)
         db_session.commit()
 
@@ -320,9 +305,7 @@ class TestUpsert:
         _make_sighting(db_session, item.id, vendor_name="Mouser")
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id, vendor_names=["Arrow Electronics"])
 
         assert len(results) == 1
@@ -348,9 +331,7 @@ class TestVendorPhoneLookup:
         _make_sighting(db_session, item.id, vendor_name="Arrow Electronics")
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].vendor_phone == "+1-555-0100"
@@ -360,9 +341,7 @@ class TestVendorPhoneLookup:
         _make_sighting(db_session, item.id, vendor_name="Unknown Vendor")
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].vendor_phone is None
@@ -379,9 +358,7 @@ class TestSourceTypes:
         _make_sighting(db_session, item.id, source_type="email")
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 300, "approximate": False}
-        ):
+        with _patch_ai_qty(300):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert set(results[0].source_types) == {"api", "email"}
@@ -431,9 +408,7 @@ class TestVendorSummaryNewColumns:
         _make_sighting_extended(db_session, item.id, created_at=newer)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 200, "approximate": False}
-        ):
+        with _patch_ai_qty(200):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert len(results) == 1
@@ -451,9 +426,7 @@ class TestVendorSummaryNewColumns:
         _make_sighting_extended(db_session, item.id, lead_time_days=None)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 300, "approximate": False}
-        ):
+        with _patch_ai_qty(300):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert len(results) == 1
@@ -466,9 +439,7 @@ class TestVendorSummaryNewColumns:
         _make_sighting_extended(db_session, item.id, moq=None)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 300, "approximate": False}
-        ):
+        with _patch_ai_qty(300):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert len(results) == 1
@@ -488,9 +459,7 @@ class TestVendorSummaryNewColumns:
         _make_sighting_extended(db_session, item.id, vendor_name="Arrow Electronics")
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert len(results) == 1
@@ -501,9 +470,7 @@ class TestVendorSummaryNewColumns:
         _make_sighting_extended(db_session, item.id, vendor_email="sales@arrow.com")
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].has_contact_info is True
@@ -522,9 +489,7 @@ class TestVendorSummaryNewColumns:
         _make_sighting_extended(db_session, item.id, vendor_name="Arrow Electronics")
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].has_contact_info is True
@@ -534,9 +499,7 @@ class TestVendorSummaryNewColumns:
         _make_sighting_extended(db_session, item.id, vendor_email=None, vendor_phone=None)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].has_contact_info is False
@@ -546,9 +509,7 @@ class TestVendorSummaryNewColumns:
         _make_sighting_extended(db_session, item.id, lead_time_days=None)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].best_lead_time_days is None
@@ -558,9 +519,7 @@ class TestVendorSummaryNewColumns:
         _make_sighting_extended(db_session, item.id, moq=None)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].min_moq is None
@@ -590,12 +549,7 @@ class TestEstimateQtyWithAI:
         assert result == {"qty": 300, "approximate": False}
 
     def test_two_values_with_none_mixed(self):
-        # One None and two non-null → sum the non-null
-        result = _estimate_qty_with_ai([None, 100, 200])
-        # 3 non-null values → AI path; mock to test fallback
-        # Actually 2 non-null values [100, 200] → sum path
-        # Wait - None gets filtered: [100, 200] = 2, which is <= 2
-        # Result: 100 + 200 = 300 without AI
+        # None gets filtered out → single non-null value [100] → sum path, no AI
         result = _estimate_qty_with_ai([None, 100])
         assert result == {"qty": 100, "approximate": False}
 
@@ -672,9 +626,7 @@ class TestRebuildVendorSummariesFromSightings:
         sighting = _make_sighting(db_session, item.id, vendor_name="arrow electronics", qty_available=100)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai", return_value={"qty": 100, "approximate": False}
-        ):
+        with _patch_ai_qty(100):
             rebuild_vendor_summaries_from_sightings(db_session, item.id, [sighting])
             db_session.flush()
 
@@ -713,10 +665,7 @@ class TestRebuildVendorSummariesFromSightings:
         db_session.commit()
 
         with (
-            patch(
-                "app.services.sighting_aggregation._estimate_qty_with_ai",
-                return_value={"qty": 50, "approximate": False},
-            ),
+            _patch_ai_qty(50),
             patch("app.services.sighting_aggregation.rebuild_vendor_summaries") as mock_rebuild,
         ):
             rebuild_vendor_summaries_from_sightings(db_session, item.id, [sighting, mock_sighting_no_vendor])
@@ -739,10 +688,7 @@ class TestApproximateQtyLogging:
         _make_sighting(db_session, item.id, qty_available=100)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai",
-            return_value={"qty": 150, "approximate": True},
-        ):
+        with _patch_ai_qty(150, approximate=True):
             results = rebuild_vendor_summaries(db_session, item.id)
 
         assert results[0].estimated_qty == 150
@@ -768,10 +714,7 @@ class TestRebuildFromSightings:
         s3 = _make_sighting(db_session, item.id, vendor_name="Arrow Electronics", unit_price=3.0)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai",
-            return_value={"qty": 100, "approximate": False},
-        ):
+        with _patch_ai_qty(100):
             rebuild_vendor_summaries_from_sightings(db_session, item.id, [s1, s2, s3])
         db_session.commit()
 
@@ -805,10 +748,7 @@ class TestRebuildFromSightings:
         s_new = _make_sighting(db_session, item.id, vendor_name="Newark", unit_price=3.0)
         db_session.commit()
 
-        with patch(
-            "app.services.sighting_aggregation._estimate_qty_with_ai",
-            return_value={"qty": 100, "approximate": False},
-        ):
+        with _patch_ai_qty(100):
             rebuild_vendor_summaries_from_sightings(db_session, item.id, [s_new])
         db_session.commit()
 

--- a/tests/test_sightings_batch_ops_coverage.py
+++ b/tests/test_sightings_batch_ops_coverage.py
@@ -21,6 +21,7 @@ import os
 
 os.environ["TESTING"] = "1"
 
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -28,6 +29,17 @@ from fastapi.responses import HTMLResponse as _HTMLResponse
 from sqlalchemy.orm import Session
 
 # ── helpers ──────────────────────────────────────────────────────────
+
+
+@contextmanager
+def _patched_broker():
+    """Patch app.routers.sightings.broker with an AsyncMock publish."""
+    with patch(
+        "app.routers.sightings.broker",
+        new_callable=MagicMock,
+    ) as mock_broker:
+        mock_broker.publish = AsyncMock()
+        yield mock_broker
 
 
 def _make_user(db: Session, role: str = "buyer", suffix: str = ""):
@@ -85,6 +97,42 @@ def _make_requirement_recently_searched(db: Session, user_id: int, mpn: str = "F
     return req, requirement
 
 
+def _make_vendor_card_with_contact(
+    db: Session,
+    normalized_name: str,
+    display_name: str,
+    card_email: str,
+    contact_name: str,
+    contact_email: str,
+    sighting_count: int,
+):
+    """VendorCard with one verified VendorContact, committed."""
+    from app.models import VendorCard, VendorContact
+
+    card = VendorCard(
+        normalized_name=normalized_name,
+        display_name=display_name,
+        emails=[card_email],
+        phones=[],
+        sighting_count=sighting_count,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(card)
+    db.flush()
+
+    contact = VendorContact(
+        vendor_card_id=card.id,
+        full_name=contact_name,
+        email=contact_email,
+        source="manual",
+        is_verified=True,
+        confidence=90,
+    )
+    db.add(contact)
+    db.commit()
+    return card, contact
+
+
 # ── batch-refresh: skipped-only path (line 738: level = "info") ───────
 
 
@@ -93,11 +141,7 @@ def test_batch_refresh_all_skipped_returns_info_level(client, db_session, test_u
     _, requirement = _make_requirement_recently_searched(db_session, test_user.id)
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         resp = client.post(
             "/v2/partials/sightings/batch-refresh",
             data={"requirement_ids": json.dumps([requirement.id])},
@@ -113,11 +157,7 @@ def test_batch_refresh_success_path_level_success(client, db_session, test_user)
     _, requirement = _make_req_and_requirement(db_session, test_user.id, mpn="ATMEL001")
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         with patch(
             "app.search_service.search_requirement",
             new_callable=AsyncMock,
@@ -136,11 +176,7 @@ def test_batch_refresh_exception_in_search_counts_as_failed(client, db_session, 
     _, requirement = _make_req_and_requirement(db_session, test_user.id, mpn="ERRPN")
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         with patch(
             "app.search_service.search_requirement",
             new_callable=AsyncMock,
@@ -162,11 +198,7 @@ def test_batch_refresh_broker_publish_called(client, db_session, test_user):
     _, req2 = _make_req_and_requirement(db_session, test_user.id, mpn="PNX002")
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker() as mock_broker:
         with patch(
             "app.search_service.search_requirement",
             new_callable=AsyncMock,
@@ -183,11 +215,7 @@ def test_batch_refresh_broker_publish_called(client, db_session, test_user):
 
 def test_batch_refresh_nonexistent_id_increments_failed(client, db_session):
     """Non-existent requirement ID increments failed counter (lines 711-712)."""
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         resp = client.post(
             "/v2/partials/sightings/batch-refresh",
             data={"requirement_ids": "[88888]"},
@@ -365,11 +393,7 @@ def test_mark_unavailable_broker_publish_called(client, db_session, test_user):
     db_session.add(sighting)
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker() as mock_broker:
         with patch(
             "app.routers.sightings.sightings_detail",
             new_callable=AsyncMock,
@@ -390,11 +414,7 @@ def test_mark_unavailable_no_matching_sightings_still_succeeds(client, db_sessio
     _, requirement = _make_req_and_requirement(db_session, test_user.id, mpn="NOMATCH01")
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         with patch(
             "app.routers.sightings.sightings_detail",
             new_callable=AsyncMock,
@@ -416,11 +436,7 @@ def test_assign_buyer_broker_publish_called(client, db_session, test_user):
     _, requirement = _make_req_and_requirement(db_session, test_user.id, mpn="ASGN01")
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker() as mock_broker:
         with patch(
             "app.routers.sightings.sightings_detail",
             new_callable=AsyncMock,
@@ -441,11 +457,7 @@ def test_assign_buyer_clears_assignment_with_empty_id(client, db_session, test_u
     requirement.assigned_buyer_id = test_user.id
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         with patch(
             "app.routers.sightings.sightings_detail",
             new_callable=AsyncMock,
@@ -504,11 +516,7 @@ def test_advance_status_valid_transition_updates_db(client, db_session, test_use
     requirement.sourcing_status = "open"
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker() as mock_broker:
         with patch(
             "app.routers.sightings.sightings_detail",
             new_callable=AsyncMock,
@@ -533,11 +541,7 @@ def test_advance_status_logs_activity(client, db_session, test_user):
     requirement.sourcing_status = "open"
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         with patch(
             "app.routers.sightings.sightings_detail",
             new_callable=AsyncMock,
@@ -560,32 +564,18 @@ def test_advance_status_logs_activity(client, db_session, test_user):
 def test_preview_inquiry_with_vendor_card_and_contact(client, db_session, test_user):
     """Preview-inquiry resolves vendor email from VendorCard+VendorContact (lines
     1153-1159)."""
-    from app.models import VendorCard, VendorContact
-
     _, requirement = _make_req_and_requirement(db_session, test_user.id, mpn="PREV01")
     db_session.commit()
 
-    card = VendorCard(
+    _make_vendor_card_with_contact(
+        db_session,
         normalized_name="previewvendor",
         display_name="Preview Vendor",
-        emails=["sales@previewvendor.com"],
-        phones=[],
+        card_email="sales@previewvendor.com",
+        contact_name="Preview Contact",
+        contact_email="contact@previewvendor.com",
         sighting_count=5,
-        created_at=datetime.now(timezone.utc),
     )
-    db_session.add(card)
-    db_session.flush()
-
-    contact = VendorContact(
-        vendor_card_id=card.id,
-        full_name="Preview Contact",
-        email="contact@previewvendor.com",
-        source="manual",
-        is_verified=True,
-        confidence=90,
-    )
-    db_session.add(contact)
-    db_session.commit()
 
     with patch(
         "app.email_service._build_html_body",
@@ -689,38 +679,20 @@ def test_send_inquiry_missing_email_body_returns_400(client, db_session, test_us
 def test_send_inquiry_with_vendor_card_resolves_email(client, db_session, test_user):
     """Send-inquiry resolves vendor email from VendorCard+VendorContact (lines
     1220-1227)."""
-    from app.models import VendorCard, VendorContact
-
     _, requirement = _make_req_and_requirement(db_session, test_user.id, mpn="SEND01")
     db_session.commit()
 
-    card = VendorCard(
+    _make_vendor_card_with_contact(
+        db_session,
         normalized_name="sendvendor",
         display_name="Send Vendor",
-        emails=["sales@sendvendor.com"],
-        phones=[],
+        card_email="sales@sendvendor.com",
+        contact_name="Send Contact",
+        contact_email="contact@sendvendor.com",
         sighting_count=1,
-        created_at=datetime.now(timezone.utc),
     )
-    db_session.add(card)
-    db_session.flush()
 
-    contact = VendorContact(
-        vendor_card_id=card.id,
-        full_name="Send Contact",
-        email="contact@sendvendor.com",
-        source="manual",
-        is_verified=True,
-        confidence=90,
-    )
-    db_session.add(contact)
-    db_session.commit()
-
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker() as mock_broker:
         with patch(
             "app.email_service.send_batch_rfq",
             new_callable=AsyncMock,
@@ -744,11 +716,7 @@ def test_send_inquiry_failed_sends_warning_toast(client, db_session, test_user):
     _, requirement = _make_req_and_requirement(db_session, test_user.id, mpn="SENDFAIL")
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         with patch(
             "app.email_service.send_batch_rfq",
             new_callable=AsyncMock,
@@ -773,11 +741,7 @@ def test_send_inquiry_broker_publish_per_requirement(client, db_session, test_us
     _, req2 = _make_req_and_requirement(db_session, test_user.id, mpn="BRKR02")
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker() as mock_broker:
         with patch(
             "app.email_service.send_batch_rfq",
             new_callable=AsyncMock,
@@ -802,11 +766,7 @@ def test_send_inquiry_auto_progress_increments_count(client, db_session, test_us
     requirement.sourcing_status = "open"
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         with patch(
             "app.email_service.send_batch_rfq",
             new_callable=AsyncMock,
@@ -833,11 +793,7 @@ def test_send_inquiry_success_toast_with_progressed_count(client, db_session, te
     requirement.sourcing_status = "open"
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         with patch(
             "app.email_service.send_batch_rfq",
             new_callable=AsyncMock,
@@ -867,11 +823,7 @@ def test_send_inquiry_unknown_vendor_empty_email(client, db_session, test_user):
     _, requirement = _make_req_and_requirement(db_session, test_user.id, mpn="NOVCARD")
     db_session.commit()
 
-    with patch(
-        "app.routers.sightings.broker",
-        new_callable=MagicMock,
-    ) as mock_broker:
-        mock_broker.publish = AsyncMock()
+    with _patched_broker():
         with patch(
             "app.email_service.send_batch_rfq",
             new_callable=AsyncMock,

--- a/tests/test_sightings_coverage.py
+++ b/tests/test_sightings_coverage.py
@@ -25,6 +25,8 @@ import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from app.models.intelligence import ActivityLog
 from app.models.offers import Offer
 from app.models.sourcing import Requirement, Requisition, Sighting
@@ -147,26 +149,20 @@ class TestHeatmapCriticalHotUrgency:
 class TestDetailPhoneFromCard:
     """Vendor phone fallback from VendorCard (lines 365-367), age_days (line 372)."""
 
-    def test_phone_populated_from_vendor_card_list(self, client, db_session):
-        """VendorCard.phones list used when summary has no vendor_phone."""
+    @pytest.mark.parametrize(
+        "phones",
+        [
+            pytest.param(["+1-555-9999"], id="list"),
+            pytest.param("+1-555-8888", id="string"),
+        ],
+    )
+    def test_phone_populated_from_vendor_card(self, client, db_session, phones):
+        """VendorCard.phones (list or string) used when summary has no vendor_phone."""
         req, r, _ = _seed_active(db_session)
         vc = VendorCard(
             normalized_name="cover vendor",
             display_name="Cover Vendor",
-            phones=["+1-555-9999"],
-        )
-        db_session.add(vc)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
-        assert resp.status_code == 200
-
-    def test_phone_populated_from_vendor_card_string(self, client, db_session):
-        """VendorCard.phones as string used when summary has no vendor_phone."""
-        req, r, _ = _seed_active(db_session)
-        vc = VendorCard(
-            normalized_name="cover vendor",
-            display_name="Cover Vendor",
-            phones="+1-555-8888",
+            phones=phones,
         )
         db_session.add(vc)
         db_session.commit()
@@ -264,26 +260,22 @@ class TestSuggestedActionSourcingStatus:
         resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
         assert resp.status_code == 200
 
-    def test_offered_no_pending_offers(self, client, db_session):
-        """'offered' status but no pending offers → advance to quoted."""
-        _, r, _ = _seed_active(db_session)
-        r.sourcing_status = "offered"
-        db_session.commit()
-        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
-        assert resp.status_code == 200
+    @pytest.mark.parametrize(
+        "sourcing_status",
+        [
+            pytest.param("offered", id="offered_no_pending_offers"),
+            pytest.param("won", id="won_status"),
+            pytest.param("custom_unknown_status", id="unknown_status_returns_none_action"),
+        ],
+    )
+    def test_status_only_detail_renders(self, client, db_session, sourcing_status):
+        """Status-only suggested-action branches each render detail (200).
 
-    def test_won_status(self, client, db_session):
-        """'won' status → proceed to fulfillment."""
+        'offered' (no pending offers) → advance to quoted; 'won' → fulfillment; unknown
+        status → suggested_action is None (else branch).
+        """
         _, r, _ = _seed_active(db_session)
-        r.sourcing_status = "won"
-        db_session.commit()
-        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
-        assert resp.status_code == 200
-
-    def test_unknown_status_returns_none_action(self, client, db_session):
-        """Unknown status → suggested_action is None (else branch)."""
-        _, r, _ = _seed_active(db_session)
-        r.sourcing_status = "custom_unknown_status"
+        r.sourcing_status = sourcing_status
         db_session.commit()
         resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
         assert resp.status_code == 200
@@ -547,24 +539,18 @@ class TestSendInquiryEndpoint:
 class TestSortDirections:
     """Sort direction asc/desc for all sort columns to cover branching."""
 
-    def test_sort_by_created_asc(self, client, db_session):
+    @pytest.mark.parametrize(
+        "sort,direction",
+        [
+            ("created", "asc"),
+            ("created", "desc"),
+            ("status", "asc"),
+            ("priority", "asc"),
+        ],
+    )
+    def test_sort(self, client, db_session, sort, direction):
         _seed_active(db_session)
-        resp = client.get("/v2/partials/sightings?sort=created&dir=asc")
-        assert resp.status_code == 200
-
-    def test_sort_by_created_desc(self, client, db_session):
-        _seed_active(db_session)
-        resp = client.get("/v2/partials/sightings?sort=created&dir=desc")
-        assert resp.status_code == 200
-
-    def test_sort_by_status_asc(self, client, db_session):
-        _seed_active(db_session)
-        resp = client.get("/v2/partials/sightings?sort=status&dir=asc")
-        assert resp.status_code == 200
-
-    def test_sort_by_priority_asc(self, client, db_session):
-        _seed_active(db_session)
-        resp = client.get("/v2/partials/sightings?sort=priority&dir=asc")
+        resp = client.get(f"/v2/partials/sightings?sort={sort}&dir={direction}")
         assert resp.status_code == 200
 
 

--- a/tests/test_sightings_log_activity.py
+++ b/tests/test_sightings_log_activity.py
@@ -6,6 +6,7 @@ Called by: pytest
 Depends on: conftest fixtures (client, db_session, test_user, test_requisition)
 """
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -49,15 +50,62 @@ class TestLogActivity:
         assert record.user_id == test_user.id
         assert record.requisition_id == test_requisition.id
 
-    def test_empty_notes_returns_400(self, client: TestClient, db_session: Session, test_requisition: Requisition):
-        """Empty or whitespace-only notes should be rejected with 400."""
+    @pytest.mark.parametrize(
+        ("channel", "notes", "expected"),
+        [
+            pytest.param(
+                "call",
+                "Spoke with rep about pricing",
+                {"activity_type": "call_logged", "direction": "outbound", "channel": "call"},
+                id="call",
+            ),
+            pytest.param(
+                "email",
+                "Sent follow-up email",
+                {"activity_type": "email_sent", "channel": "email"},
+                id="email",
+            ),
+        ],
+    )
+    def test_channel_maps_to_activity(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_requisition: Requisition,
+        channel: str,
+        notes: str,
+        expected: dict,
+    ):
+        """Each channel maps to its canonical activity type / direction."""
         req_id = _get_requirement_id(db_session, test_requisition)
 
         resp = client.post(
             f"/v2/partials/sightings/{req_id}/log-activity",
-            data={"notes": "   ", "channel": "note"},
+            data={"notes": notes, "channel": channel},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 200
+
+        record = db_session.query(ActivityLog).filter(ActivityLog.requirement_id == req_id).first()
+        assert record is not None
+        for field, value in expected.items():
+            assert getattr(record, field) == value
+
+    @pytest.mark.parametrize(
+        ("data", "case"),
+        [
+            ({"notes": "   ", "channel": "note"}, "whitespace-only notes"),
+            ({"notes": "Some note", "channel": "fax"}, "invalid channel"),
+        ],
+        ids=["empty_notes", "invalid_channel"],
+    )
+    def test_invalid_input_returns_400(
+        self, client: TestClient, db_session: Session, test_requisition: Requisition, data: dict, case: str
+    ):
+        """Whitespace-only notes and unknown channels are rejected with 400."""
+        req_id = _get_requirement_id(db_session, test_requisition)
+
+        resp = client.post(f"/v2/partials/sightings/{req_id}/log-activity", data=data)
+        assert resp.status_code == 400, case
 
     def test_missing_notes_returns_422(self, client: TestClient, db_session: Session, test_requisition: Requisition):
         """Missing notes field should return 422 (FastAPI validation)."""
@@ -69,81 +117,34 @@ class TestLogActivity:
         )
         assert resp.status_code == 422
 
-    def test_channel_call(self, client: TestClient, db_session: Session, test_requisition: Requisition):
-        """Channel 'call' creates the canonical call_logged activity type (outbound
-        direction)."""
-        req_id = _get_requirement_id(db_session, test_requisition)
-
-        resp = client.post(
-            f"/v2/partials/sightings/{req_id}/log-activity",
-            data={"notes": "Spoke with rep about pricing", "channel": "call"},
-        )
-        assert resp.status_code == 200
-
-        record = db_session.query(ActivityLog).filter(ActivityLog.requirement_id == req_id).first()
-        assert record is not None
-        assert record.activity_type == "call_logged"
-        assert record.direction == "outbound"
-        assert record.channel == "call"
-
-    def test_channel_email(self, client: TestClient, db_session: Session, test_requisition: Requisition):
-        """Channel 'email' creates email_sent activity type."""
-        req_id = _get_requirement_id(db_session, test_requisition)
-
-        resp = client.post(
-            f"/v2/partials/sightings/{req_id}/log-activity",
-            data={"notes": "Sent follow-up email", "channel": "email"},
-        )
-        assert resp.status_code == 200
-
-        record = db_session.query(ActivityLog).filter(ActivityLog.requirement_id == req_id).first()
-        assert record is not None
-        assert record.activity_type == "email_sent"
-        assert record.channel == "email"
-
-    def test_invalid_channel_returns_400(self, client: TestClient, db_session: Session, test_requisition: Requisition):
-        """Invalid channel value should be rejected."""
-        req_id = _get_requirement_id(db_session, test_requisition)
-
-        resp = client.post(
-            f"/v2/partials/sightings/{req_id}/log-activity",
-            data={"notes": "Some note", "channel": "fax"},
-        )
-        assert resp.status_code == 400
-
-    def test_vendor_name_optional(self, client: TestClient, db_session: Session, test_requisition: Requisition):
-        """Vendor name is stored in contact_name when provided."""
-        req_id = _get_requirement_id(db_session, test_requisition)
-
-        resp = client.post(
-            f"/v2/partials/sightings/{req_id}/log-activity",
-            data={
-                "notes": "Got quote from Arrow",
-                "channel": "note",
-                "vendor_name": "Arrow Electronics",
-            },
-        )
-        assert resp.status_code == 200
-
-        record = db_session.query(ActivityLog).filter(ActivityLog.requirement_id == req_id).first()
-        assert record is not None
-        assert record.contact_name == "Arrow Electronics"
-
-    def test_vendor_name_empty_stored_as_none(
-        self, client: TestClient, db_session: Session, test_requisition: Requisition
+    @pytest.mark.parametrize(
+        ("vendor_name", "notes", "expected_contact_name"),
+        [
+            pytest.param("Arrow Electronics", "Got quote from Arrow", "Arrow Electronics", id="provided"),
+            pytest.param("", "General note", None, id="empty_stored_as_none"),
+        ],
+    )
+    def test_vendor_name_stored_in_contact_name(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_requisition: Requisition,
+        vendor_name: str,
+        notes: str,
+        expected_contact_name: str | None,
     ):
-        """Empty vendor_name should be stored as None, not empty string."""
+        """Vendor name maps to contact_name; an empty value is stored as None."""
         req_id = _get_requirement_id(db_session, test_requisition)
 
         resp = client.post(
             f"/v2/partials/sightings/{req_id}/log-activity",
-            data={"notes": "General note", "channel": "note", "vendor_name": ""},
+            data={"notes": notes, "channel": "note", "vendor_name": vendor_name},
         )
         assert resp.status_code == 200
 
         record = db_session.query(ActivityLog).filter(ActivityLog.requirement_id == req_id).first()
         assert record is not None
-        assert record.contact_name is None
+        assert record.contact_name == expected_contact_name
 
     def test_nonexistent_requirement_returns_404(
         self, client: TestClient, db_session: Session, test_requisition: Requisition

--- a/tests/test_signature_batch.py
+++ b/tests/test_signature_batch.py
@@ -22,6 +22,18 @@ from app.services.signature_parser import (
 from tests.conftest import engine  # noqa: F401 — ensures SQLite engine is used
 
 
+def _run(coro):
+    """Run an async coroutine to completion in the current event loop."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _mock_redis(get_value):
+    """Build a MagicMock Redis whose .get() returns get_value."""
+    mock_r = MagicMock()
+    mock_r.get.return_value = get_value
+    return mock_r
+
+
 @pytest.fixture()
 def low_confidence_extracts(db_session):
     """Create 5 low-confidence regex-parsed signature extracts."""
@@ -129,17 +141,15 @@ def test_build_prompt_with_missing_fields(low_confidence_extracts):
 @patch("app.services.signature_parser._get_redis")
 def test_batch_parse_skips_when_inflight(mock_redis, db_session, low_confidence_extracts):
     """Returns None when a batch is already inflight (Redis key exists)."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_existing"
-    mock_redis.return_value = mock_r
+    mock_redis.return_value = _mock_redis(b"batch_sig_existing")
 
-    result = asyncio.get_event_loop().run_until_complete(batch_parse_signatures(db_session))
+    result = _run(batch_parse_signatures(db_session))
     assert result is None
 
 
 def test_batch_parse_no_records(db_session):
     """Returns None when no low-confidence records exist."""
-    result = asyncio.get_event_loop().run_until_complete(batch_parse_signatures(db_session))
+    result = _run(batch_parse_signatures(db_session))
     assert result is None
 
 
@@ -149,11 +159,9 @@ def test_batch_parse_no_body_still_submits(mock_submit, mock_redis, db_session, 
     """Records without VendorResponse body still get submitted — prompt uses existing
     fields."""
     mock_submit.return_value = "batch_sig_nobody"
-    mock_r = MagicMock()
-    mock_r.get.return_value = None  # No inflight batch
-    mock_redis.return_value = mock_r
+    mock_redis.return_value = _mock_redis(None)  # No inflight batch
 
-    result = asyncio.get_event_loop().run_until_complete(batch_parse_signatures(db_session))
+    result = _run(batch_parse_signatures(db_session))
 
     assert result == "batch_sig_nobody"
     requests = mock_submit.call_args[0][0]
@@ -166,11 +174,10 @@ def test_batch_parse_no_body_still_submits(mock_submit, mock_redis, db_session, 
 def test_batch_parse_submits_batch(mock_submit, mock_redis, db_session, low_confidence_extracts):
     """Submits a batch and stores batch_id in Redis."""
     mock_submit.return_value = "batch_sig_123"
-    mock_r = MagicMock()
-    mock_r.get.return_value = None  # No inflight batch
+    mock_r = _mock_redis(None)  # No inflight batch
     mock_redis.return_value = mock_r
 
-    result = asyncio.get_event_loop().run_until_complete(batch_parse_signatures(db_session))
+    result = _run(batch_parse_signatures(db_session))
 
     assert result == "batch_sig_123"
     mock_submit.assert_called_once()
@@ -196,11 +203,9 @@ def test_batch_parse_skips_high_confidence(
 ):
     """Only picks up records with confidence < 0.7."""
     mock_submit.return_value = "batch_sig_456"
-    mock_r = MagicMock()
-    mock_r.get.return_value = None  # No inflight batch
-    mock_redis.return_value = mock_r
+    mock_redis.return_value = _mock_redis(None)  # No inflight batch
 
-    result = asyncio.get_event_loop().run_until_complete(batch_parse_signatures(db_session))
+    result = _run(batch_parse_signatures(db_session))
 
     assert result == "batch_sig_456"
     requests = mock_submit.call_args[0][0]
@@ -213,11 +218,9 @@ def test_batch_parse_skips_high_confidence(
 def test_batch_parse_skips_non_regex(mock_submit, mock_redis, db_session, low_confidence_extracts, batch_api_extracts):
     """Only picks up records with extraction_method = 'regex'."""
     mock_submit.return_value = "batch_sig_003"
-    mock_r = MagicMock()
-    mock_r.get.return_value = None
-    mock_redis.return_value = mock_r
+    mock_redis.return_value = _mock_redis(None)
 
-    result = asyncio.get_event_loop().run_until_complete(batch_parse_signatures(db_session))
+    result = _run(batch_parse_signatures(db_session))
 
     assert result == "batch_sig_003"
     requests = mock_submit.call_args[0][0]
@@ -229,11 +232,10 @@ def test_batch_parse_skips_non_regex(mock_submit, mock_redis, db_session, low_co
 def test_batch_parse_submit_fails(mock_submit, mock_redis, db_session, low_confidence_extracts):
     """Returns None when claude_batch_submit fails."""
     mock_submit.return_value = None
-    mock_r = MagicMock()
-    mock_r.get.return_value = None  # No inflight batch
+    mock_r = _mock_redis(None)  # No inflight batch
     mock_redis.return_value = mock_r
 
-    result = asyncio.get_event_loop().run_until_complete(batch_parse_signatures(db_session))
+    result = _run(batch_parse_signatures(db_session))
 
     assert result is None
     mock_r.set.assert_not_called()
@@ -247,18 +249,16 @@ def test_process_results_no_redis(mock_redis, db_session):
     """Returns None when Redis is unavailable."""
     mock_redis.return_value = None
 
-    result = asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    result = _run(process_signature_batch_results(db_session))
     assert result is None
 
 
 @patch("app.services.signature_parser._get_redis")
 def test_process_results_no_batch_id(mock_redis, db_session):
     """Returns None when no batch_id is stored in Redis."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = None
-    mock_redis.return_value = mock_r
+    mock_redis.return_value = _mock_redis(None)
 
-    result = asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    result = _run(process_signature_batch_results(db_session))
     assert result is None
 
 
@@ -266,12 +266,11 @@ def test_process_results_no_batch_id(mock_redis, db_session):
 @patch("app.services.signature_parser.claude_batch_results")
 def test_process_results_still_processing(mock_results, mock_redis, db_session):
     """Returns None when batch is still processing."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_123"
+    mock_r = _mock_redis(b"batch_sig_123")
     mock_redis.return_value = mock_r
     mock_results.return_value = None
 
-    result = asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    result = _run(process_signature_batch_results(db_session))
     assert result is None
     mock_r.delete.assert_not_called()
 
@@ -280,8 +279,7 @@ def test_process_results_still_processing(mock_results, mock_redis, db_session):
 @patch("app.services.signature_parser.claude_batch_results")
 def test_process_results_applies_data(mock_results, mock_redis, db_session, low_confidence_extracts):
     """Applies AI results to EmailSignatureExtract records and clears Redis key."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_123"
+    mock_r = _mock_redis(b"batch_sig_123")
     mock_redis.return_value = mock_r
 
     results_dict = {}
@@ -300,7 +298,7 @@ def test_process_results_applies_data(mock_results, mock_redis, db_session, low_
 
     mock_results.return_value = results_dict
 
-    result = asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    result = _run(process_signature_batch_results(db_session))
 
     assert result["applied"] == 5
     assert result["errors"] == 0
@@ -321,8 +319,7 @@ def test_process_results_applies_data(mock_results, mock_redis, db_session, low_
 @patch("app.services.signature_parser.claude_batch_results")
 def test_process_results_handles_none_entry(mock_results, mock_redis, db_session, low_confidence_extracts):
     """Skips records with None results (errors) without crashing."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_123"
+    mock_r = _mock_redis(b"batch_sig_123")
     mock_redis.return_value = mock_r
 
     extract = low_confidence_extracts[0]
@@ -331,7 +328,7 @@ def test_process_results_handles_none_entry(mock_results, mock_redis, db_session
     }
     mock_results.return_value = results_dict
 
-    result = asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    result = _run(process_signature_batch_results(db_session))
 
     assert result["applied"] == 0
     assert result["errors"] == 1
@@ -346,8 +343,7 @@ def test_process_results_handles_none_entry(mock_results, mock_redis, db_session
 @patch("app.services.signature_parser.claude_batch_results")
 def test_process_results_commit_failure_keeps_redis_key(mock_results, mock_redis, db_session, low_confidence_extracts):
     """On commit failure, returns stats but does NOT clear Redis key."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_123"
+    mock_r = _mock_redis(b"batch_sig_123")
     mock_redis.return_value = mock_r
 
     extract = low_confidence_extracts[0]
@@ -367,7 +363,7 @@ def test_process_results_commit_failure_keeps_redis_key(mock_results, mock_redis
 
     # Make commit raise an exception
     with patch.object(db_session, "commit", side_effect=Exception("DB error")):
-        result = asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+        result = _run(process_signature_batch_results(db_session))
 
     assert result is not None
     assert result["applied"] == 1
@@ -379,8 +375,7 @@ def test_process_results_commit_failure_keeps_redis_key(mock_results, mock_redis
 @patch("app.services.signature_parser.claude_batch_results")
 def test_process_results_partial_fields(mock_results, mock_redis, db_session, low_confidence_extracts):
     """Handles partial results where some fields are null."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_123"
+    mock_r = _mock_redis(b"batch_sig_123")
     mock_redis.return_value = mock_r
 
     extract = low_confidence_extracts[0]
@@ -398,7 +393,7 @@ def test_process_results_partial_fields(mock_results, mock_redis, db_session, lo
     }
     mock_results.return_value = results_dict
 
-    result = asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    result = _run(process_signature_batch_results(db_session))
 
     assert result["applied"] == 1
     db_session.refresh(extract)
@@ -415,8 +410,7 @@ def test_process_results_partial_fields(mock_results, mock_redis, db_session, lo
 @patch("app.services.signature_parser.claude_batch_results")
 def test_process_results_only_updates_nonnull(mock_results, mock_redis, db_session, low_confidence_extracts):
     """Only updates fields where AI returned non-null values."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_001"
+    mock_r = _mock_redis(b"batch_sig_001")
     mock_redis.return_value = mock_r
 
     record = low_confidence_extracts[0]
@@ -436,7 +430,7 @@ def test_process_results_only_updates_nonnull(mock_results, mock_redis, db_sessi
     }
     mock_results.return_value = results_dict
 
-    result = asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    result = _run(process_signature_batch_results(db_session))
 
     assert result["applied"] == 1
     db_session.refresh(record)
@@ -449,8 +443,7 @@ def test_process_results_only_updates_nonnull(mock_results, mock_redis, db_sessi
 @patch("app.services.signature_parser.claude_batch_results")
 def test_process_results_bad_custom_id(mock_results, mock_redis, db_session):
     """Handles malformed custom_id gracefully."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_001"
+    mock_r = _mock_redis(b"batch_sig_001")
     mock_redis.return_value = mock_r
 
     results_dict = {
@@ -460,7 +453,7 @@ def test_process_results_bad_custom_id(mock_results, mock_redis, db_session):
     }
     mock_results.return_value = results_dict
 
-    result = asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    result = _run(process_signature_batch_results(db_session))
 
     assert result["applied"] == 0
     assert result["errors"] == 3
@@ -470,8 +463,7 @@ def test_process_results_bad_custom_id(mock_results, mock_redis, db_session):
 @patch("app.services.signature_parser.claude_batch_results")
 def test_process_results_confidence_all_fields(mock_results, mock_redis, db_session, low_confidence_extracts):
     """Confidence caps at 0.95 when all 8 fields are filled."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_001"
+    mock_r = _mock_redis(b"batch_sig_001")
     mock_redis.return_value = mock_r
 
     record = low_confidence_extracts[0]
@@ -489,7 +481,7 @@ def test_process_results_confidence_all_fields(mock_results, mock_redis, db_sess
     }
     mock_results.return_value = results_dict
 
-    asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    _run(process_signature_batch_results(db_session))
 
     db_session.refresh(record)
     # 8 fields * 0.08 + 0.5 = 1.14 -> capped at 0.95
@@ -500,8 +492,7 @@ def test_process_results_confidence_all_fields(mock_results, mock_redis, db_sess
 @patch("app.services.signature_parser.claude_batch_results")
 def test_process_results_confidence_partial(mock_results, mock_redis, db_session, low_confidence_extracts):
     """Confidence calculation with partial fields."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_sig_001"
+    mock_r = _mock_redis(b"batch_sig_001")
     mock_redis.return_value = mock_r
 
     record = low_confidence_extracts[1]  # has phone but no full_name, title, company
@@ -520,7 +511,7 @@ def test_process_results_confidence_partial(mock_results, mock_redis, db_session
     }
     mock_results.return_value = results_dict
 
-    asyncio.get_event_loop().run_until_complete(process_signature_batch_results(db_session))
+    _run(process_signature_batch_results(db_session))
 
     db_session.refresh(record)
     # phone + title = 2 fields => 0.5 + 2*0.08 = 0.66

--- a/tests/test_signature_parser_batch.py
+++ b/tests/test_signature_parser_batch.py
@@ -10,6 +10,8 @@ Depends on: app.services.signature_parser, app.models.EmailSignatureExtract, con
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from app.models import EmailSignatureExtract
 from app.services.signature_parser import (
     batch_parse_signatures,
@@ -17,6 +19,30 @@ from app.services.signature_parser import (
     process_signature_batch_results,
 )
 from tests.conftest import engine  # noqa: F401 — ensures SQLite engine is used
+
+
+def _make_extract(db_session, sender_email, confidence, **kwargs):
+    """Create and commit a regex-method EmailSignatureExtract, returning it
+    refreshed."""
+    extract = EmailSignatureExtract(
+        sender_email=sender_email,
+        extraction_method=kwargs.pop("extraction_method", "regex"),
+        confidence=confidence,
+        created_at=datetime.now(timezone.utc),
+        **kwargs,
+    )
+    db_session.add(extract)
+    db_session.commit()
+    db_session.refresh(extract)
+    return extract
+
+
+def _mock_redis(get_value):
+    """Build a MagicMock Redis whose .get() returns get_value."""
+    mock_redis = MagicMock()
+    mock_redis.get.return_value = get_value
+    return mock_redis
+
 
 # ── Mobile label branch (line 146) ───────────────────────────────────────
 
@@ -88,8 +114,7 @@ class TestBatchParseSignatures:
 
     async def test_redis_pending_returns_none(self, db_session):
         """Redis already has a pending batch_id → inflight guard fires, returns None."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"existing-batch-id"
+        mock_redis = _mock_redis(b"existing-batch-id")
         with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
             result = await batch_parse_signatures(db_session)
         assert result is None
@@ -97,8 +122,7 @@ class TestBatchParseSignatures:
 
     async def test_redis_key_none_proceeds(self, db_session):
         """Redis present but key is None (no pending batch) → proceeds normally."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = None
+        mock_redis = _mock_redis(None)
         with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
             # No records in DB → still returns None (no records branch)
             result = await batch_parse_signatures(db_session)
@@ -106,15 +130,7 @@ class TestBatchParseSignatures:
 
     async def test_submits_batch_and_returns_batch_id(self, db_session):
         """Low-confidence regex record present → submits batch, returns batch_id."""
-        extract = EmailSignatureExtract(
-            sender_email="batch-submit@example.com",
-            extraction_method="regex",
-            confidence=0.5,
-            full_name="Test User",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(extract)
-        db_session.commit()
+        _make_extract(db_session, "batch-submit@example.com", 0.5, full_name="Test User")
 
         with patch("app.services.signature_parser._get_redis", return_value=None):
             with patch(
@@ -128,17 +144,9 @@ class TestBatchParseSignatures:
 
     async def test_submits_batch_and_stores_in_redis(self, db_session):
         """batch_id returned by submit is stored in Redis."""
-        extract = EmailSignatureExtract(
-            sender_email="redis-store@example.com",
-            extraction_method="regex",
-            confidence=0.4,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(extract)
-        db_session.commit()
+        _make_extract(db_session, "redis-store@example.com", 0.4)
 
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = None  # No pending batch
+        mock_redis = _mock_redis(None)  # No pending batch
 
         with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
             with patch(
@@ -157,14 +165,7 @@ class TestBatchParseSignatures:
         """ClaudeUnavailableError during submit → returns None gracefully."""
         from app.utils.claude_errors import ClaudeUnavailableError
 
-        extract = EmailSignatureExtract(
-            sender_email="unavail@example.com",
-            extraction_method="regex",
-            confidence=0.5,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(extract)
-        db_session.commit()
+        _make_extract(db_session, "unavail@example.com", 0.5)
 
         with patch("app.services.signature_parser._get_redis", return_value=None):
             with patch(
@@ -180,14 +181,7 @@ class TestBatchParseSignatures:
         """ClaudeError during submit → returns None gracefully."""
         from app.utils.claude_errors import ClaudeError
 
-        extract = EmailSignatureExtract(
-            sender_email="claude-err@example.com",
-            extraction_method="regex",
-            confidence=0.55,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(extract)
-        db_session.commit()
+        _make_extract(db_session, "claude-err@example.com", 0.55)
 
         with patch("app.services.signature_parser._get_redis", return_value=None):
             with patch(
@@ -201,14 +195,7 @@ class TestBatchParseSignatures:
 
     async def test_submit_returns_none_returns_none(self, db_session):
         """claude_batch_submit returns None → function returns None."""
-        extract = EmailSignatureExtract(
-            sender_email="null-batch@example.com",
-            extraction_method="regex",
-            confidence=0.3,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(extract)
-        db_session.commit()
+        _make_extract(db_session, "null-batch@example.com", 0.3)
 
         with patch("app.services.signature_parser._get_redis", return_value=None):
             with patch(
@@ -222,21 +209,8 @@ class TestBatchParseSignatures:
 
     async def test_skips_high_confidence_records(self, db_session):
         """Records with confidence >= 0.7 or method != 'regex' are not included."""
-        high_conf = EmailSignatureExtract(
-            sender_email="high-conf@example.com",
-            extraction_method="regex",
-            confidence=0.85,
-            created_at=datetime.now(timezone.utc),
-        )
-        ai_method = EmailSignatureExtract(
-            sender_email="ai-method@example.com",
-            extraction_method="claude_ai",
-            confidence=0.4,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(high_conf)
-        db_session.add(ai_method)
-        db_session.commit()
+        _make_extract(db_session, "high-conf@example.com", 0.85)
+        _make_extract(db_session, "ai-method@example.com", 0.4, extraction_method="claude_ai")
 
         with patch("app.services.signature_parser._get_redis", return_value=None):
             result = await batch_parse_signatures(db_session)
@@ -259,16 +233,14 @@ class TestProcessSignatureBatchResults:
 
     async def test_no_pending_batch_returns_none(self, db_session):
         """Redis present but no key stored → returns None."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = None
+        mock_redis = _mock_redis(None)
         with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
             result = await process_signature_batch_results(db_session)
         assert result is None
 
     async def test_still_processing_returns_none(self, db_session):
         """claude_batch_results returns None (still processing) → returns None."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-123"
+        mock_redis = _mock_redis(b"batch-123")
         with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
             with patch(
                 "app.services.signature_parser.claude_batch_results",
@@ -282,8 +254,7 @@ class TestProcessSignatureBatchResults:
         """ClaudeError when polling results → returns None."""
         from app.utils.claude_errors import ClaudeError
 
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-456"
+        mock_redis = _mock_redis(b"batch-456")
         with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
             with patch(
                 "app.services.signature_parser.claude_batch_results",
@@ -295,18 +266,9 @@ class TestProcessSignatureBatchResults:
 
     async def test_applies_results_to_records(self, db_session):
         """Valid results are applied to EmailSignatureExtract records."""
-        extract = EmailSignatureExtract(
-            sender_email="batch-apply@example.com",
-            extraction_method="regex",
-            confidence=0.5,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(extract)
-        db_session.commit()
-        db_session.refresh(extract)
+        extract = _make_extract(db_session, "batch-apply@example.com", 0.5)
 
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-789"
+        mock_redis = _mock_redis(b"batch-789")
 
         results = {
             f"sig_parse-{extract.id}": {
@@ -339,31 +301,24 @@ class TestProcessSignatureBatchResults:
         assert extract.extraction_method == "batch_api"
         assert extract.confidence > 0.5  # Recalculated after applying fields
 
-    async def test_batch_result_none_value_counts_as_error(self, db_session):
-        """A result entry with None value (failed parse) → counted as error, not
-        applied."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-err"
-
-        results = {"sig_parse-9999": None}
-
-        with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
-            with patch(
-                "app.services.signature_parser.claude_batch_results",
-                new_callable=AsyncMock,
-                return_value=results,
-            ):
-                stats = await process_signature_batch_results(db_session)
-
-        assert stats["applied"] == 0
-        assert stats["errors"] == 1
-
-    async def test_bad_custom_id_format_counts_as_error(self, db_session):
-        """custom_id without '-' separator → error, not crash."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-fmt"
-
-        results = {"nohyphen": {"full_name": "Test"}}
+    @pytest.mark.parametrize(
+        ("batch_id", "results", "check_applied_zero"),
+        [
+            # A result entry with None value (failed parse) → error, not applied.
+            (b"batch-err", {"sig_parse-9999": None}, True),
+            # custom_id without '-' separator → error, not crash.
+            (b"batch-fmt", {"nohyphen": {"full_name": "Test"}}, False),
+            # custom_id with non-integer after '-' → error.
+            (b"batch-int", {"sig_parse-abc": {"full_name": "Test"}}, False),
+            # Valid custom_id format but record doesn't exist in DB → error.
+            (b"batch-notfound", {"sig_parse-99999": {"full_name": "Ghost"}}, True),
+        ],
+        ids=["none_value", "bad_format", "non_integer", "record_not_found"],
+    )
+    async def test_invalid_result_entry_counts_as_error(self, db_session, batch_id, results, check_applied_zero):
+        """A bad result entry (None value / malformed custom_id / missing record) →
+        error."""
+        mock_redis = _mock_redis(batch_id)
 
         with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
             with patch(
@@ -374,56 +329,14 @@ class TestProcessSignatureBatchResults:
                 stats = await process_signature_batch_results(db_session)
 
         assert stats["errors"] == 1
-
-    async def test_non_integer_record_id_counts_as_error(self, db_session):
-        """custom_id with non-integer after '-' → error."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-int"
-
-        results = {"sig_parse-abc": {"full_name": "Test"}}
-
-        with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
-            with patch(
-                "app.services.signature_parser.claude_batch_results",
-                new_callable=AsyncMock,
-                return_value=results,
-            ):
-                stats = await process_signature_batch_results(db_session)
-
-        assert stats["errors"] == 1
-
-    async def test_record_not_found_counts_as_error(self, db_session):
-        """Valid custom_id format but record doesn't exist in DB → error."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-notfound"
-
-        results = {"sig_parse-99999": {"full_name": "Ghost"}}
-
-        with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
-            with patch(
-                "app.services.signature_parser.claude_batch_results",
-                new_callable=AsyncMock,
-                return_value=results,
-            ):
-                stats = await process_signature_batch_results(db_session)
-
-        assert stats["errors"] == 1
-        assert stats["applied"] == 0
+        if check_applied_zero:
+            assert stats["applied"] == 0
 
     async def test_deletes_redis_key_after_success(self, db_session):
         """Redis key is deleted after successful commit."""
-        extract = EmailSignatureExtract(
-            sender_email="redis-del@example.com",
-            extraction_method="regex",
-            confidence=0.4,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(extract)
-        db_session.commit()
-        db_session.refresh(extract)
+        extract = _make_extract(db_session, "redis-del@example.com", 0.4)
 
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-del"
+        mock_redis = _mock_redis(b"batch-del")
 
         results = {
             f"sig_parse-{extract.id}": {
@@ -450,8 +363,7 @@ class TestProcessSignatureBatchResults:
 
     async def test_batch_id_from_string_redis(self, db_session):
         """batch_id returned as plain string (not bytes) is handled correctly."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = "batch-str-not-bytes"  # plain str, not bytes
+        mock_redis = _mock_redis("batch-str-not-bytes")  # plain str, not bytes
 
         with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
             with patch(
@@ -467,8 +379,7 @@ class TestProcessSignatureBatchResults:
 
     async def test_empty_results_returns_zero_stats(self, db_session):
         """Empty results dict → applied=0, errors=0, Redis key deleted."""
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-empty"
+        mock_redis = _mock_redis(b"batch-empty")
 
         with patch("app.services.signature_parser._get_redis", return_value=mock_redis):
             with patch(
@@ -484,18 +395,9 @@ class TestProcessSignatureBatchResults:
     async def test_commit_failure_returns_stats_without_clearing_redis(self, db_session):
         """DB commit failure → stats returned but Redis key NOT deleted (retry
         allowed)."""
-        extract = EmailSignatureExtract(
-            sender_email="commit-fail@example.com",
-            extraction_method="regex",
-            confidence=0.5,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(extract)
-        db_session.commit()
-        db_session.refresh(extract)
+        extract = _make_extract(db_session, "commit-fail@example.com", 0.5)
 
-        mock_redis = MagicMock()
-        mock_redis.get.return_value = b"batch-commitfail"
+        mock_redis = _mock_redis(b"batch-commitfail")
 
         results = {
             f"sig_parse-{extract.id}": {

--- a/tests/test_sourcing_leads_nightly.py
+++ b/tests/test_sourcing_leads_nightly.py
@@ -16,6 +16,8 @@ os.environ["TESTING"] = "1"
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
+import pytest
+
 
 def _now():
     return datetime.now(timezone.utc)
@@ -25,29 +27,20 @@ def _now():
 
 
 class TestSourceReliability:
-    def test_salesforce_base_85(self):
+    @pytest.mark.parametrize(
+        ("source", "lo", "hi"),
+        [
+            ("salesforce", 80, 93),  # base 85 ± tier
+            ("avail_history", 80, 93),
+            ("digikey", 88, 100),
+            ("unknown_xyz", 55, 65),
+        ],
+        ids=["salesforce_base_85", "avail_history_base_85", "digikey_base_90", "unknown_base_60"],
+    )
+    def test_base_score_in_range(self, source, lo, hi):
         from app.services.sourcing_leads import _source_reliability
 
-        score = _source_reliability("salesforce", None)
-        assert 80 <= score <= 93  # base 85 ± tier
-
-    def test_avail_history_base_85(self):
-        from app.services.sourcing_leads import _source_reliability
-
-        score = _source_reliability("avail_history", None)
-        assert 80 <= score <= 93
-
-    def test_digikey_base_90(self):
-        from app.services.sourcing_leads import _source_reliability
-
-        score = _source_reliability("digikey", None)
-        assert score >= 88
-
-    def test_unknown_base_60(self):
-        from app.services.sourcing_leads import _source_reliability
-
-        score = _source_reliability("unknown_xyz", None)
-        assert 55 <= score <= 65
+        assert lo <= _source_reliability(source, None) <= hi
 
     def test_t1_tier_boosts(self):
         from app.services.sourcing_leads import _source_reliability
@@ -61,30 +54,22 @@ class TestSourceReliability:
 
 
 class TestFreshnessScore:
-    def test_12_hours_returns_95(self):
+    @pytest.mark.parametrize(
+        ("age", "expected"),
+        [
+            (timedelta(hours=12), 95.0),
+            (timedelta(hours=23), 95.0),
+            (timedelta(days=2), 85.0),
+            (timedelta(days=5), 72.0),
+            (None, 45.0),
+        ],
+        ids=["12_hours", "23_hours", "2_days", "5_days", "none"],
+    )
+    def test_freshness_score(self, age, expected):
         from app.services.sourcing_leads import _freshness_score
 
-        assert _freshness_score(_now() - timedelta(hours=12)) == 95.0
-
-    def test_23_hours_returns_95(self):
-        from app.services.sourcing_leads import _freshness_score
-
-        assert _freshness_score(_now() - timedelta(hours=23)) == 95.0
-
-    def test_2_days_returns_85(self):
-        from app.services.sourcing_leads import _freshness_score
-
-        assert _freshness_score(_now() - timedelta(days=2)) == 85.0
-
-    def test_5_days_returns_72(self):
-        from app.services.sourcing_leads import _freshness_score
-
-        assert _freshness_score(_now() - timedelta(days=5)) == 72.0
-
-    def test_none_returns_45(self):
-        from app.services.sourcing_leads import _freshness_score
-
-        assert _freshness_score(None) == 45.0
+        seen_at = None if age is None else _now() - age
+        assert _freshness_score(seen_at) == expected
 
 
 # ── _historical_success_score (lines 139, 155) ────────────────────────

--- a/tests/test_sourcing_leads_service.py
+++ b/tests/test_sourcing_leads_service.py
@@ -6,6 +6,7 @@ Depends on: conftest fixtures, sourcing lead models, vendor card models
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models.sourcing import Requirement, Requisition, Sighting
@@ -114,42 +115,38 @@ class TestNormalizeMpn:
     """sourcing_leads now uses the canonical normalize_mpn_key (lowercase, strips all
     non-alphanumeric) instead of a local re-implementation."""
 
-    def test_normalizes_dashes_spaces(self):
-        assert normalize_mpn_key("LM-317 T") == "lm317t"
-
-    def test_normalizes_underscores_dots(self):
-        assert normalize_mpn_key("LM_317.T") == "lm317t"
-
-    def test_empty_string(self):
-        assert normalize_mpn_key("") == ""
-
-    def test_none(self):
-        assert normalize_mpn_key(None) == ""
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("LM-317 T", "lm317t"),
+            ("LM_317.T", "lm317t"),
+            ("", ""),
+            (None, ""),
+        ],
+        ids=["dashes_spaces", "underscores_dots", "empty_string", "none"],
+    )
+    def test_normalize(self, raw, expected):
+        assert normalize_mpn_key(raw) == expected
 
 
 class TestClamp:
-    def test_within_range(self):
-        assert _clamp(50.0) == 50.0
-
-    def test_below_minimum(self):
-        assert _clamp(-10.0) == 0.0
-
-    def test_above_maximum(self):
-        assert _clamp(120.0) == 100.0
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [(50.0, 50.0), (-10.0, 0.0), (120.0, 100.0)],
+        ids=["within_range", "below_minimum", "above_maximum"],
+    )
+    def test_clamp(self, value, expected):
+        assert _clamp(value) == expected
 
 
 class TestConfidenceBand:
-    def test_high(self):
-        assert _confidence_band(80.0) == "high"
-
-    def test_medium(self):
-        assert _confidence_band(60.0) == "medium"
-
-    def test_low(self):
-        assert _confidence_band(30.0) == "low"
-
-    def test_boundary_75(self):
-        assert _confidence_band(75.0) == "high"
+    @pytest.mark.parametrize(
+        ("score", "expected"),
+        [(80.0, "high"), (60.0, "medium"), (30.0, "low"), (75.0, "high")],
+        ids=["high", "medium", "low", "boundary_75"],
+    )
+    def test_confidence_band(self, score, expected):
+        assert _confidence_band(score) == expected
 
 
 class TestSafetyBand:
@@ -167,78 +164,74 @@ class TestSafetyBand:
 
 
 class TestSourceReliability:
-    def test_authorized_distributor(self):
-        assert _source_reliability("digikey", None) == 90
-
-    def test_marketplace_source(self):
-        assert _source_reliability("brokerbin", None) == 72
-
-    def test_ai_source(self):
-        assert _source_reliability("ai", None) == 40
-
-    def test_tier_bonus(self):
-        score = _source_reliability("digikey", "T1")
-        assert score == 98  # 90 + 8
-
-    def test_tier_penalty(self):
-        score = _source_reliability("digikey", "T7")
-        assert score == 75  # 90 - 15
-
-    def test_unknown_source(self):
-        assert _source_reliability("unknown_thing", None) == 60
+    @pytest.mark.parametrize(
+        ("source", "tier", "expected"),
+        [
+            ("digikey", None, 90),
+            ("brokerbin", None, 72),
+            ("ai", None, 40),
+            ("digikey", "T1", 98),  # 90 + 8 tier bonus
+            ("digikey", "T7", 75),  # 90 - 15 tier penalty
+            ("unknown_thing", None, 60),
+        ],
+        ids=[
+            "authorized_distributor",
+            "marketplace_source",
+            "ai_source",
+            "tier_bonus",
+            "tier_penalty",
+            "unknown_source",
+        ],
+    )
+    def test_source_reliability(self, source, tier, expected):
+        assert _source_reliability(source, tier) == expected
 
 
 class TestFreshnessScore:
-    def test_recent(self):
-        now = datetime.now(timezone.utc)
-        assert _freshness_score(now) == 95.0
-
-    def test_week_old(self):
-        week_ago = datetime.now(timezone.utc) - timedelta(days=5)
-        assert _freshness_score(week_ago) == 72.0
-
-    def test_old(self):
-        old = datetime.now(timezone.utc) - timedelta(days=60)
-        assert _freshness_score(old) == 25.0
+    @pytest.mark.parametrize(
+        ("days_ago", "expected"),
+        [(0, 95.0), (5, 72.0), (60, 25.0)],
+        ids=["recent", "week_old", "old"],
+    )
+    def test_freshness_score(self, days_ago, expected):
+        when = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        assert _freshness_score(when) == expected
 
     def test_none_date(self):
         assert _freshness_score(None) == 45.0
 
 
 class TestMatchType:
-    def test_exact(self):
-        assert _match_type_for_parts("LM317T", "LM317T") == "exact"
-
-    def test_normalized(self):
-        assert _match_type_for_parts("LM317T", "LM-317T") == "exact"
-
-    def test_substring_normalized(self):
-        assert _match_type_for_parts("LM317", "LM317TANOPB") == "normalized"
-
-    def test_cross_ref(self):
-        subs = [{"mpn": "MC7805"}, {"mpn": "LM340"}]
-        assert _match_type_for_parts("LM317T", "MC7805", substitutes=subs) == "cross_ref"
-
-    def test_fuzzy(self):
-        assert _match_type_for_parts("ABC123", "XYZ789") == "fuzzy"
-
-    def test_empty_parts(self):
-        assert _match_type_for_parts("", "") == "exact"
+    @pytest.mark.parametrize(
+        ("requirement_mpn", "candidate_mpn", "substitutes", "expected"),
+        [
+            ("LM317T", "LM317T", None, "exact"),
+            ("LM317T", "LM-317T", None, "exact"),
+            ("LM317", "LM317TANOPB", None, "normalized"),
+            ("LM317T", "MC7805", [{"mpn": "MC7805"}, {"mpn": "LM340"}], "cross_ref"),
+            ("ABC123", "XYZ789", None, "fuzzy"),
+            ("", "", None, "exact"),
+        ],
+        ids=["exact", "normalized", "substring_normalized", "cross_ref", "fuzzy", "empty_parts"],
+    )
+    def test_match_type(self, requirement_mpn, candidate_mpn, substitutes, expected):
+        assert _match_type_for_parts(requirement_mpn, candidate_mpn, substitutes=substitutes) == expected
 
 
 class TestSourceCategory:
-    def test_api_sources(self):
-        assert _source_category("digikey") == "api"
-        assert _source_category("mouser") == "api"
-
-    def test_marketplace_sources(self):
-        assert _source_category("brokerbin") == "marketplace"
-
-    def test_web_ai(self):
-        assert _source_category("ai") == "web_ai"
-
-    def test_unknown_defaults_marketplace(self):
-        assert _source_category("something_random") == "marketplace"
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ("digikey", "api"),
+            ("mouser", "api"),
+            ("brokerbin", "marketplace"),
+            ("ai", "web_ai"),
+            ("something_random", "marketplace"),
+        ],
+        ids=["api_digikey", "api_mouser", "marketplace", "web_ai", "unknown_defaults_marketplace"],
+    )
+    def test_source_category(self, source, expected):
+        assert _source_category(source) == expected
 
 
 # ── DB-integrated tests ─────────────────────────────────────────────
@@ -420,8 +413,6 @@ class TestUpdateLeadStatus:
 
     def test_invalid_status_raises(self, db_session: Session):
         lead = self._setup_lead(db_session)
-        import pytest
-
         with pytest.raises(ValueError, match="Unsupported lead status"):
             update_lead_status(db_session, lead.id, "invalid_status")
 

--- a/tests/test_sql_helpers.py
+++ b/tests/test_sql_helpers.py
@@ -3,28 +3,21 @@
 Covers: percent, underscore, backslash, combined, and clean string.
 """
 
+import pytest
+
 from app.utils.sql_helpers import escape_like
 
 
-def test_escape_percent():
-    assert escape_like("100%") == r"100\%"
-
-
-def test_escape_underscore():
-    assert escape_like("some_name") == r"some\_name"
-
-
-def test_escape_backslash():
-    assert escape_like(r"path\to") == r"path\\to"
-
-
-def test_escape_combined():
-    assert escape_like(r"100%_test\end") == r"100\%\_test\\end"
-
-
-def test_clean_string():
-    assert escape_like("normal text") == "normal text"
-
-
-def test_empty_string():
-    assert escape_like("") == ""
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("100%", r"100\%", id="percent"),
+        pytest.param("some_name", r"some\_name", id="underscore"),
+        pytest.param(r"path\to", r"path\\to", id="backslash"),
+        pytest.param(r"100%_test\end", r"100\%\_test\\end", id="combined"),
+        pytest.param("normal text", "normal text", id="clean_string"),
+        pytest.param("", "", id="empty_string"),
+    ],
+)
+def test_escape_like(value, expected):
+    assert escape_like(value) == expected

--- a/tests/test_startup_seed.py
+++ b/tests/test_startup_seed.py
@@ -10,30 +10,26 @@ from sqlalchemy.orm import Session
 from app.constants import ApiSourceStatus
 
 
+def make_api_source(name, display_name, status, *, is_active, source_type="broker"):
+    """Build an ApiSource row with the fields these seed tests vary."""
+    from app.models import ApiSource
+
+    return ApiSource(
+        name=name,
+        display_name=display_name,
+        category="search",
+        source_type=source_type,
+        status=status,
+        is_active=is_active,
+    )
+
+
 def test_startup_flips_icsource_to_live(db_session: Session):
     from app.models import ApiSource
     from app.startup import seed_browser_worker_sources
 
-    db_session.add(
-        ApiSource(
-            name="icsource",
-            display_name="ICsource",
-            category="search",
-            source_type="broker",
-            status="disabled",
-            is_active=False,
-        )
-    )
-    db_session.add(
-        ApiSource(
-            name="netcomponents",
-            display_name="NetComponents",
-            category="search",
-            source_type="broker",
-            status="pending",
-            is_active=False,
-        )
-    )
+    db_session.add(make_api_source("icsource", "ICsource", "disabled", is_active=False))
+    db_session.add(make_api_source("netcomponents", "NetComponents", "pending", is_active=False))
     db_session.commit()
 
     seed_browser_worker_sources(db_session)
@@ -52,16 +48,7 @@ def test_seed_is_idempotent(db_session: Session):
     from app.models import ApiSource
     from app.startup import seed_browser_worker_sources
 
-    db_session.add(
-        ApiSource(
-            name="icsource",
-            display_name="ICsource",
-            category="search",
-            source_type="broker",
-            status="disabled",
-            is_active=False,
-        )
-    )
+    db_session.add(make_api_source("icsource", "ICsource", "disabled", is_active=False))
     db_session.commit()
 
     seed_browser_worker_sources(db_session)
@@ -144,36 +131,10 @@ def test_health_monitor_excludes_browser_worker_sources(db_session: Session):
     from app.constants import BROWSER_WORKER_SOURCES, ApiSourceStatus
     from app.models import ApiSource
 
-    db_session.add(
-        ApiSource(
-            name="icsource",
-            display_name="ICsource",
-            category="search",
-            source_type="broker",
-            status=ApiSourceStatus.LIVE.value,
-            is_active=True,
-        )
-    )
-    db_session.add(
-        ApiSource(
-            name="netcomponents",
-            display_name="NetComponents",
-            category="search",
-            source_type="broker",
-            status=ApiSourceStatus.LIVE.value,
-            is_active=True,
-        )
-    )
-    db_session.add(
-        ApiSource(
-            name="digikey",
-            display_name="Digi-Key",
-            category="search",
-            source_type="distributor",
-            status=ApiSourceStatus.LIVE.value,
-            is_active=True,
-        )
-    )
+    live = ApiSourceStatus.LIVE.value
+    db_session.add(make_api_source("icsource", "ICsource", live, is_active=True))
+    db_session.add(make_api_source("netcomponents", "NetComponents", live, is_active=True))
+    db_session.add(make_api_source("digikey", "Digi-Key", live, is_active=True, source_type="distributor"))
     db_session.commit()
 
     rows = (

--- a/tests/test_tagging_ai_batch_coverage.py
+++ b/tests/test_tagging_ai_batch_coverage.py
@@ -70,6 +70,48 @@ def _run(coro):
     return loop.run_until_complete(coro)
 
 
+def _succeeded_line(custom_id: str, classifications: list) -> str:
+    """Build one JSONL result line wrapping a succeeded structured_output tool_use."""
+    return json.dumps(
+        {
+            "custom_id": custom_id,
+            "result": {
+                "type": "succeeded",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "structured_output",
+                            "input": {"classifications": classifications},
+                        }
+                    ]
+                },
+            },
+        }
+    )
+
+
+def _write_jsonl(*lines: str) -> str:
+    """Write the given lines (newline-terminated) to a temp .jsonl file; return its
+    path."""
+    tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
+    tmp.write("".join(line + "\n" for line in lines))
+    tmp.close()
+    return tmp.name
+
+
+def _wire_http(mock_http, tmp_path: str, results_url: str) -> None:
+    """Wire mock_http.get (status=ended) and mock_http.stream (serves tmp_path)."""
+    status_resp = MagicMock()
+    status_resp.status_code = 200
+    status_resp.json.return_value = {
+        "processing_status": "ended",
+        "results_url": results_url,
+    }
+    mock_http.get = AsyncMock(return_value=status_resp)
+    mock_http.stream = _make_fake_stream(tmp_path)
+
+
 class TestApplyBatchResultsBlankLines:
     @patch("app.database.SessionLocal")
     @patch("app.http_client.http")
@@ -78,39 +120,12 @@ class TestApplyBatchResultsBlankLines:
         """Line 481: blank lines in JSONL are skipped without counting as errors."""
         mock_session_local.return_value = db_session
 
-        # Write JSONL with blank lines interspersed
-        result_line = json.dumps(
-            {
-                "custom_id": "backfill_0",
-                "result": {
-                    "type": "succeeded",
-                    "message": {
-                        "content": [
-                            {
-                                "type": "tool_use",
-                                "name": "structured_output",
-                                "input": {"classifications": []},
-                            }
-                        ]
-                    },
-                },
-            }
-        )
-        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
-        tmp.write("\n")  # Blank line (skipped)
-        tmp.write(result_line + "\n")
-        tmp.write("   \n")  # Whitespace-only line (skipped after strip)
-        tmp.close()
-        tmp_path = tmp.name
+        # JSONL with blank lines interspersed: "" → "\n" (blank, skipped),
+        # the real line, then "   " → "   \n" (whitespace-only, skipped).
+        result_line = _succeeded_line("backfill_0", [])
+        tmp_path = _write_jsonl("", result_line, "   ")
 
-        status_resp = MagicMock()
-        status_resp.status_code = 200
-        status_resp.json.return_value = {
-            "processing_status": "ended",
-            "results_url": "https://api.anthropic.com/results/batch_blank",
-        }
-        mock_http.get = AsyncMock(return_value=status_resp)
-        mock_http.stream = _make_fake_stream(tmp_path)
+        _wire_http(mock_http, tmp_path, "https://api.anthropic.com/results/batch_blank")
 
         try:
             result = _run(apply_batch_results_chunked("batch_blank"))
@@ -136,45 +151,13 @@ class TestApplyBatchResultsClassificationsAsDict:
         mock_session_local.return_value = db_session
 
         # Normal case: input is a dict with 'classifications' array
-        result_line = json.dumps(
-            {
-                "custom_id": "backfill_0",
-                "result": {
-                    "type": "succeeded",
-                    "message": {
-                        "content": [
-                            {
-                                "type": "tool_use",
-                                "name": "structured_output",
-                                "input": {
-                                    "classifications": [
-                                        {
-                                            "mpn": "LM317T",
-                                            "manufacturer": "Texas Instruments",
-                                            "category": "Regulators",
-                                        }
-                                    ]
-                                },
-                            }
-                        ]
-                    },
-                },
-            }
+        result_line = _succeeded_line(
+            "backfill_0",
+            [{"mpn": "LM317T", "manufacturer": "Texas Instruments", "category": "Regulators"}],
         )
+        tmp_path = _write_jsonl(result_line)
 
-        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
-        tmp.write(result_line + "\n")
-        tmp.close()
-        tmp_path = tmp.name
-
-        status_resp = MagicMock()
-        status_resp.status_code = 200
-        status_resp.json.return_value = {
-            "processing_status": "ended",
-            "results_url": "https://api.anthropic.com/results/batch_dict",
-        }
-        mock_http.get = AsyncMock(return_value=status_resp)
-        mock_http.stream = _make_fake_stream(tmp_path)
+        _wire_http(mock_http, tmp_path, "https://api.anthropic.com/results/batch_dict")
 
         try:
             result = _run(apply_batch_results_chunked("batch_dict"))
@@ -209,37 +192,10 @@ class TestApplyBatchResultsMidBatchFlush:
             }
             for i in range(100)
         ]
-        result_line = json.dumps(
-            {
-                "custom_id": "backfill_0",
-                "result": {
-                    "type": "succeeded",
-                    "message": {
-                        "content": [
-                            {
-                                "type": "tool_use",
-                                "name": "structured_output",
-                                "input": {"classifications": classifications},
-                            }
-                        ]
-                    },
-                },
-            }
-        )
+        result_line = _succeeded_line("backfill_0", classifications)
+        tmp_path = _write_jsonl(result_line)
 
-        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
-        tmp.write(result_line + "\n")
-        tmp.close()
-        tmp_path = tmp.name
-
-        status_resp = MagicMock()
-        status_resp.status_code = 200
-        status_resp.json.return_value = {
-            "processing_status": "ended",
-            "results_url": "https://api.anthropic.com/results/batch_100",
-        }
-        mock_http.get = AsyncMock(return_value=status_resp)
-        mock_http.stream = _make_fake_stream(tmp_path)
+        _wire_http(mock_http, tmp_path, "https://api.anthropic.com/results/batch_100")
 
         try:
             result = _run(apply_batch_results_chunked("batch_100"))
@@ -262,40 +218,10 @@ class TestApplyBatchResultsProgressLog:
         mock_session_local.return_value = db_session
 
         # Write exactly 500 valid-but-empty-classification lines
-        lines = []
-        for i in range(500):
-            line = json.dumps(
-                {
-                    "custom_id": f"backfill_{i}",
-                    "result": {
-                        "type": "succeeded",
-                        "message": {
-                            "content": [
-                                {
-                                    "type": "tool_use",
-                                    "name": "structured_output",
-                                    "input": {"classifications": []},
-                                }
-                            ]
-                        },
-                    },
-                }
-            )
-            lines.append(line)
+        lines = [_succeeded_line(f"backfill_{i}", []) for i in range(500)]
+        tmp_path = _write_jsonl(*lines)
 
-        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
-        tmp.write("\n".join(lines) + "\n")
-        tmp.close()
-        tmp_path = tmp.name
-
-        status_resp = MagicMock()
-        status_resp.status_code = 200
-        status_resp.json.return_value = {
-            "processing_status": "ended",
-            "results_url": "https://api.anthropic.com/results/batch_500",
-        }
-        mock_http.get = AsyncMock(return_value=status_resp)
-        mock_http.stream = _make_fake_stream(tmp_path)
+        _wire_http(mock_http, tmp_path, "https://api.anthropic.com/results/batch_500")
 
         try:
             result = _run(apply_batch_results_chunked("batch_500"))
@@ -317,37 +243,10 @@ class TestApplyBatchResultsExceptionPath:
         mock_session_local.return_value = db_session
 
         # Write a valid-looking JSONL line
-        result_line = json.dumps(
-            {
-                "custom_id": "backfill_0",
-                "result": {
-                    "type": "succeeded",
-                    "message": {
-                        "content": [
-                            {
-                                "type": "tool_use",
-                                "name": "structured_output",
-                                "input": {"classifications": []},
-                            }
-                        ]
-                    },
-                },
-            }
-        )
+        result_line = _succeeded_line("backfill_0", [])
+        tmp_path = _write_jsonl(result_line)
 
-        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
-        tmp.write(result_line + "\n")
-        tmp.close()
-        tmp_path = tmp.name
-
-        status_resp = MagicMock()
-        status_resp.status_code = 200
-        status_resp.json.return_value = {
-            "processing_status": "ended",
-            "results_url": "https://api.anthropic.com/results/batch_exc",
-        }
-        mock_http.get = AsyncMock(return_value=status_resp)
-        mock_http.stream = _make_fake_stream(tmp_path)
+        _wire_http(mock_http, tmp_path, "https://api.anthropic.com/results/batch_exc")
 
         # Patch db.commit to raise (triggers exception path)
         with patch.object(db_session, "commit", side_effect=RuntimeError("Commit failed")):
@@ -368,37 +267,10 @@ class TestApplyBatchResultsOSErrorOnUnlink:
         """Lines 546-547: OSError when os.unlink(tmp_path) is silently caught."""
         mock_session_local.return_value = db_session
 
-        result_line = json.dumps(
-            {
-                "custom_id": "backfill_0",
-                "result": {
-                    "type": "succeeded",
-                    "message": {
-                        "content": [
-                            {
-                                "type": "tool_use",
-                                "name": "structured_output",
-                                "input": {"classifications": []},
-                            }
-                        ]
-                    },
-                },
-            }
-        )
+        result_line = _succeeded_line("backfill_0", [])
+        tmp_path = _write_jsonl(result_line)
 
-        tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", dir="/tmp", delete=False, mode="w")
-        tmp.write(result_line + "\n")
-        tmp.close()
-        tmp_path = tmp.name
-
-        status_resp = MagicMock()
-        status_resp.status_code = 200
-        status_resp.json.return_value = {
-            "processing_status": "ended",
-            "results_url": "https://api.anthropic.com/results/batch_oserr",
-        }
-        mock_http.get = AsyncMock(return_value=status_resp)
-        mock_http.stream = _make_fake_stream(tmp_path)
+        _wire_http(mock_http, tmp_path, "https://api.anthropic.com/results/batch_oserr")
 
         # Patch os.unlink to raise OSError inside the finally block
         with patch("os.unlink", side_effect=OSError("file already gone")):

--- a/tests/test_tagging_service.py
+++ b/tests/test_tagging_service.py
@@ -7,6 +7,8 @@ Depends on: app.services.tagging, app.services.prefix_lookup, app.models.tags
 
 from datetime import datetime, timezone
 
+import pytest
+
 from app.models.tags import EntityTag, MaterialTag, Tag, TagThresholdConfig
 from app.services.prefix_lookup import lookup_manufacturer_by_prefix
 from app.services.tagging import (
@@ -46,37 +48,37 @@ def _seed_thresholds(db):
 # ── Prefix Lookup ──────────────────────────────────────────────────────
 
 
-def test_prefix_lookup_known_prefix():
-    mfr, conf = lookup_manufacturer_by_prefix("tps65217")
-    assert mfr == "Texas Instruments"
-    assert conf == 0.9
-
-
-def test_prefix_lookup_long_prefix():
-    mfr, conf = lookup_manufacturer_by_prefix("atmega328p")
-    assert mfr == "Microchip Technology"
-    assert conf == 0.9
-
-
-def test_prefix_lookup_unknown():
-    mfr, conf = lookup_manufacturer_by_prefix("zzzxxx123")
-    assert mfr is None
-    assert conf == 0.0
-
-
-def test_prefix_lookup_short_prefix_skipped():
-    """2-char prefixes are now skipped (below min confidence floor)."""
-    mfr, conf = lookup_manufacturer_by_prefix("ad5292")
-    # AD is a 2-char prefix — now returns None (skip) instead of 0.70
-    # But ADM/ADP/ADG are 3-char, so "adm..." would match. "ad5292" has no 3+ match.
-    assert mfr is None
-    assert conf == 0.0
-
-
-def test_prefix_lookup_stm32():
-    mfr, conf = lookup_manufacturer_by_prefix("stm32f407vgt6")
-    assert mfr == "STMicroelectronics"
-    assert conf == 0.9
+@pytest.mark.parametrize(
+    ("mpn", "expected_mfr", "expected_conf"),
+    [
+        ("tps65217", "Texas Instruments", 0.9),
+        ("atmega328p", "Microchip Technology", 0.9),
+        ("stm32f407vgt6", "STMicroelectronics", 0.9),
+        ("nrf52840", "Nordic Semiconductor", 0.9),
+        ("esp32s3", "Espressif Systems", 0.9),
+        ("zzzxxx123", None, 0.0),
+        # 2-char prefixes are now skipped (below min confidence floor). AD/FT/SI all
+        # return None instead of their old sub-floor scores; "ad5292" has no 3+ match.
+        ("ad5292", None, 0.0),
+        ("ft232r", None, 0.0),
+        ("si5351", None, 0.0),
+    ],
+    ids=[
+        "known_prefix",
+        "long_prefix",
+        "stm32",
+        "nordic",
+        "espressif",
+        "unknown",
+        "ad_2char_skipped",
+        "ftdi_2char_skipped",
+        "silicon_labs_2char_skipped",
+    ],
+)
+def test_prefix_lookup(mpn, expected_mfr, expected_conf):
+    mfr, conf = lookup_manufacturer_by_prefix(mpn)
+    assert mfr == expected_mfr
+    assert conf == expected_conf
 
 
 def test_prefix_lookup_most_specific_wins():
@@ -85,63 +87,23 @@ def test_prefix_lookup_most_specific_wins():
     assert mfr == "STMicroelectronics"
 
 
-def test_prefix_lookup_nordic():
-    mfr, conf = lookup_manufacturer_by_prefix("nrf52840")
-    assert mfr == "Nordic Semiconductor"
-    assert conf == 0.9
-
-
-def test_prefix_lookup_espressif():
-    mfr, conf = lookup_manufacturer_by_prefix("esp32s3")
-    assert mfr == "Espressif Systems"
-    assert conf == 0.9
-
-
-def test_prefix_lookup_ftdi_2char_skipped():
-    """FT is a 2-char prefix — now skipped (below min confidence floor)."""
-    mfr, conf = lookup_manufacturer_by_prefix("ft232r")
-    assert mfr is None
-    assert conf == 0.0
-
-
-def test_prefix_lookup_silicon_labs_2char_skipped():
-    """SI is a 2-char prefix — now skipped (below min confidence floor)."""
-    mfr, conf = lookup_manufacturer_by_prefix("si5351")
-    assert mfr is None
-    assert conf == 0.0
-
-
-def test_new_prefix_entries():
+@pytest.mark.parametrize(
+    ("mpn", "expected_mfr"),
+    [
+        ("R7FA2E1A93CFM", "Renesas Electronics"),
+        ("SRR1260A-100M", "Bourns"),
+        ("GD25Q128CSIG", "GigaDevice"),
+        ("MP2315GJ", None),  # Monolithic Power — MP is 2-char prefix, now skipped
+        ("RTL8211F", "Realtek"),
+        ("SX1276IMLTRT", "Semtech"),
+        ("MX25L12835F", "Macronix"),
+    ],
+    ids=["renesas", "bourns", "gigadevice", "monolithic_power_2char", "realtek", "semtech", "macronix"],
+)
+def test_new_prefix_entries(mpn, expected_mfr):
     """Verify new prefix entries from Phase 2 expansion match correctly."""
-    from app.services.prefix_lookup import lookup_manufacturer_by_prefix
-
-    # Renesas
-    mfr, conf = lookup_manufacturer_by_prefix("R7FA2E1A93CFM")
-    assert mfr == "Renesas Electronics"
-
-    # Bourns
-    mfr, conf = lookup_manufacturer_by_prefix("SRR1260A-100M")
-    assert mfr == "Bourns"
-
-    # GigaDevice
-    mfr, conf = lookup_manufacturer_by_prefix("GD25Q128CSIG")
-    assert mfr == "GigaDevice"
-
-    # Monolithic Power — MP is 2-char prefix, now skipped
-    mfr, conf = lookup_manufacturer_by_prefix("MP2315GJ")
-    assert mfr is None  # 2-char prefix below confidence floor
-
-    # Realtek
-    mfr, conf = lookup_manufacturer_by_prefix("RTL8211F")
-    assert mfr == "Realtek"
-
-    # Semtech
-    mfr, conf = lookup_manufacturer_by_prefix("SX1276IMLTRT")
-    assert mfr == "Semtech"
-
-    # Macronix
-    mfr, conf = lookup_manufacturer_by_prefix("MX25L12835F")
-    assert mfr == "Macronix"
+    mfr, _ = lookup_manufacturer_by_prefix(mpn)
+    assert mfr == expected_mfr
 
 
 # ── classify_material_card ─────────────────────────────────────────────

--- a/tests/test_tags_router_coverage.py
+++ b/tests/test_tags_router_coverage.py
@@ -26,6 +26,13 @@ def _make_tag(db: Session, name: str, tag_type: str = "brand") -> Tag:
     return tag
 
 
+def _make_card(db: Session, normalized_mpn: str, display_mpn: str, search_count: int = 0) -> MaterialCard:
+    mc = MaterialCard(normalized_mpn=normalized_mpn, display_mpn=display_mpn, search_count=search_count)
+    db.add(mc)
+    db.flush()
+    return mc
+
+
 class TestListTags:
     """Tests for GET /api/tags/ list endpoint."""
 
@@ -257,12 +264,7 @@ class TestGetMaterialCardTags:
 
     def test_returns_empty_for_card_with_no_tags(self, client, db_session: Session):
         """Returns empty list for a material card with no tags."""
-        mc = MaterialCard(
-            normalized_mpn="test-mpn-001",
-            display_mpn="TEST-MPN-001",
-            search_count=0,
-        )
-        db_session.add(mc)
+        mc = _make_card(db_session, "test-mpn-001", "TEST-MPN-001")
         db_session.commit()
 
         resp = client.get(f"/api/tags/material-cards/{mc.id}")
@@ -271,13 +273,7 @@ class TestGetMaterialCardTags:
 
     def test_returns_high_confidence_tags_only(self, client, db_session: Session):
         """Returns only material tags with confidence >= 0.7."""
-        mc = MaterialCard(
-            normalized_mpn="lm317t-tag-test",
-            display_mpn="LM317T",
-            search_count=5,
-        )
-        db_session.add(mc)
-        db_session.flush()
+        mc = _make_card(db_session, "lm317t-tag-test", "LM317T", search_count=5)
 
         tag_high = _make_tag(db_session, "TI", "brand")
         tag_low = _make_tag(db_session, "Regulator", "commodity")
@@ -310,13 +306,7 @@ class TestGetMaterialCardTags:
     def test_material_tag_response_fields(self, client, db_session: Session):
         """Material tag response includes tag details, confidence, source,
         classified_at."""
-        mc = MaterialCard(
-            normalized_mpn="ne555-tag-test",
-            display_mpn="NE555",
-            search_count=1,
-        )
-        db_session.add(mc)
-        db_session.flush()
+        mc = _make_card(db_session, "ne555-tag-test", "NE555", search_count=1)
 
         tag = _make_tag(db_session, "Signetics", "brand")
         db_session.flush()
@@ -345,13 +335,7 @@ class TestGetMaterialCardTags:
 
     def test_boundary_confidence_070_included(self, client, db_session: Session):
         """Tag with exactly 0.7 confidence is included."""
-        mc = MaterialCard(
-            normalized_mpn="boundary-conf-test",
-            display_mpn="BOUNDARY",
-            search_count=0,
-        )
-        db_session.add(mc)
-        db_session.flush()
+        mc = _make_card(db_session, "boundary-conf-test", "BOUNDARY")
 
         tag = _make_tag(db_session, "BoundaryTag", "commodity")
         db_session.flush()
@@ -378,13 +362,7 @@ class TestGetMaterialCardTags:
         db_session.add(child)
         db_session.flush()
 
-        mc = MaterialCard(
-            normalized_mpn="mosfet-parent-test",
-            display_mpn="MOSFET",
-            search_count=0,
-        )
-        db_session.add(mc)
-        db_session.flush()
+        mc = _make_card(db_session, "mosfet-parent-test", "MOSFET")
 
         mt = MaterialTag(
             material_card_id=mc.id,

--- a/tests/test_teams_call_jobs_coverage.py
+++ b/tests/test_teams_call_jobs_coverage.py
@@ -18,6 +18,7 @@ import os
 
 os.environ["TESTING"] = "1"
 
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -59,6 +60,32 @@ def _make_db(wm_row=None, users=None):
 
 
 # ---------------------------------------------------------------------------
+# Helper: patch the job's lazy-imported dependencies at their source modules
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _patch_job_deps(mock_db, *, graph_client=None, log_call_activity=None, token=None):
+    """Patch SessionLocal/SystemConfig/log_call_activity/GraphClient/get_valid_token.
+
+    Mirrors the exact source-module targets the job lazily imports. Callers override
+    only what varies; the rest default to inert mocks.
+    """
+    if graph_client is None:
+        graph_client = MagicMock()
+    if log_call_activity is None:
+        log_call_activity = MagicMock(return_value=None)
+    with (
+        patch("app.database.SessionLocal", return_value=mock_db),
+        patch("app.models.config.SystemConfig", MagicMock()),
+        patch("app.services.activity_service.log_call_activity", log_call_activity),
+        patch("app.utils.graph_client.GraphClient", graph_client),
+        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value=token)),
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
 # _job_sync_teams_calls — no users
 # ---------------------------------------------------------------------------
 
@@ -69,13 +96,7 @@ async def test_job_sync_no_users():
 
     mock_db = _make_db(wm_row=None, users=[])
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", MagicMock(return_value=None)),
-        patch("app.utils.graph_client.GraphClient", MagicMock()),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value=None)),
-    ):
+    with _patch_job_deps(mock_db):
         await _job_sync_teams_calls()
 
     mock_db.commit.assert_called_once()
@@ -96,13 +117,7 @@ async def test_job_sync_with_existing_watermark():
 
     mock_db = _make_db(wm_row=wm_row, users=[])
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", MagicMock(return_value=None)),
-        patch("app.utils.graph_client.GraphClient", MagicMock()),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value=None)),
-    ):
+    with _patch_job_deps(mock_db):
         await _job_sync_teams_calls()
 
     mock_db.commit.assert_called_once()
@@ -126,13 +141,7 @@ async def test_job_sync_corrupted_watermark():
 
     mock_db = _make_db(wm_row=wm_row, users=[])
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", MagicMock(return_value=None)),
-        patch("app.utils.graph_client.GraphClient", MagicMock()),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value=None)),
-    ):
+    with _patch_job_deps(mock_db):
         await _job_sync_teams_calls()
 
     mock_db.commit.assert_called_once()
@@ -154,13 +163,7 @@ async def test_job_sync_token_failure_skips_user():
     mock_db = _make_db(wm_row=None, users=[mock_user])
     mock_graph_cls = MagicMock()
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", MagicMock(return_value=None)),
-        patch("app.utils.graph_client.GraphClient", mock_graph_cls),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value=None)),
-    ):
+    with _patch_job_deps(mock_db, graph_client=mock_graph_cls):
         await _job_sync_teams_calls()
 
     mock_graph_cls.assert_not_called()
@@ -186,13 +189,7 @@ async def test_job_sync_graph_fetch_failure_continues():
     mock_gc_instance.get_all_pages.side_effect = RuntimeError("Graph API timeout")
     mock_graph_cls = MagicMock(return_value=mock_gc_instance)
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", MagicMock(return_value=None)),
-        patch("app.utils.graph_client.GraphClient", mock_graph_cls),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value="tok-abc")),
-    ):
+    with _patch_job_deps(mock_db, graph_client=mock_graph_cls, token="tok-abc"):
         await _job_sync_teams_calls()
 
     mock_db.commit.assert_called_once()
@@ -232,13 +229,7 @@ async def test_job_sync_logs_call_records():
 
     mock_log = MagicMock(return_value=MagicMock())  # truthy return value
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", mock_log),
-        patch("app.utils.graph_client.GraphClient", mock_graph_cls),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value="tok-xyz")),
-    ):
+    with _patch_job_deps(mock_db, graph_client=mock_graph_cls, log_call_activity=mock_log, token="tok-xyz"):
         await _job_sync_teams_calls()
 
     assert mock_log.call_count == 2
@@ -268,13 +259,7 @@ async def test_job_sync_record_missing_id_skipped():
 
     mock_log = MagicMock(return_value=None)
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", mock_log),
-        patch("app.utils.graph_client.GraphClient", mock_graph_cls),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value="tok-abc")),
-    ):
+    with _patch_job_deps(mock_db, graph_client=mock_graph_cls, log_call_activity=mock_log, token="tok-abc"):
         await _job_sync_teams_calls()
 
     mock_log.assert_not_called()
@@ -307,13 +292,7 @@ async def test_job_sync_invalid_datetime_duration_zero():
         logged_durations.append(kwargs.get("duration_seconds", -1))
         return MagicMock()
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", _log_call),
-        patch("app.utils.graph_client.GraphClient", mock_graph_cls),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value="tok")),
-    ):
+    with _patch_job_deps(mock_db, graph_client=mock_graph_cls, log_call_activity=_log_call, token="tok"):
         await _job_sync_teams_calls()
 
     assert logged_durations == [0]
@@ -331,13 +310,7 @@ async def test_job_sync_top_level_exception_rollback():
     mock_db = MagicMock()
     mock_db.query.side_effect = RuntimeError("DB exploded")
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", MagicMock()),
-        patch("app.utils.graph_client.GraphClient", MagicMock()),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value=None)),
-    ):
+    with _patch_job_deps(mock_db):
         with pytest.raises(RuntimeError, match="DB exploded"):
             await _job_sync_teams_calls()
 
@@ -372,13 +345,7 @@ async def test_job_sync_log_call_activity_returns_none():
     mock_gc_instance.get_all_pages.return_value = records
     mock_graph_cls = MagicMock(return_value=mock_gc_instance)
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", MagicMock(return_value=None)),
-        patch("app.utils.graph_client.GraphClient", mock_graph_cls),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value="tok")),
-    ):
+    with _patch_job_deps(mock_db, graph_client=mock_graph_cls, token="tok"):
         await _job_sync_teams_calls()
 
     mock_db.commit.assert_called_once()
@@ -412,13 +379,7 @@ async def test_job_sync_record_no_datetime_fields():
         logged_durations.append(kwargs.get("duration_seconds", -1))
         return MagicMock()
 
-    with (
-        patch("app.database.SessionLocal", return_value=mock_db),
-        patch("app.models.config.SystemConfig", MagicMock()),
-        patch("app.services.activity_service.log_call_activity", _log_call),
-        patch("app.utils.graph_client.GraphClient", mock_graph_cls),
-        patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value="tok")),
-    ):
+    with _patch_job_deps(mock_db, graph_client=mock_graph_cls, log_call_activity=_log_call, token="tok"):
         await _job_sync_teams_calls()
 
     assert logged_durations == [0]

--- a/tests/test_vendor_unavailability.py
+++ b/tests/test_vendor_unavailability.py
@@ -855,35 +855,41 @@ class TestOverrideO1LiveTruth:
 
 
 class TestOverrideO2Restock:
-    def test_fires_at_exact_factor_boundary(self, db_session: Session):
+    @pytest.mark.parametrize(
+        ("reason", "qty_at_mark", "fresh_qty", "expected_count", "expected_flag"),
+        [
+            (UnavailabilityReason.SOLD_ELSEWHERE, 100, 200, 0, False),  # fires at exact factor boundary
+            (UnavailabilityReason.SOLD_ELSEWHERE, 100, 199, 1, True),  # below factor stays stamped
+            (UnavailabilityReason.SOLD_ELSEWHERE, None, 100000, 1, True),  # null snapshot is no signal
+            (UnavailabilityReason.SOLD_ELSEWHERE, 100, None, 1, True),  # null fresh qty is no signal
+            (UnavailabilityReason.SOLD_ELSEWHERE, 0, 1, 0, False),  # snapshot zero releases on any positive fresh qty
+            (UnavailabilityReason.DIFFERENT_PART, 100, 1000, 1, True),  # disabled for different part
+        ],
+        ids=[
+            "fires_at_exact_factor_boundary",
+            "below_factor_stays_stamped",
+            "null_snapshot_is_no_signal",
+            "null_fresh_qty_is_no_signal",
+            "snapshot_zero_releases_on_any_positive_fresh_qty",
+            "disabled_for_different_part",
+        ],
+    )
+    def test_restock_jump_matrix(
+        self, db_session: Session, reason, qty_at_mark, fresh_qty, expected_count, expected_flag
+    ):
         requirement = _make_requirement(db_session)
-        _make_record(db_session, qty_at_mark=100)
+        _make_record(db_session, reason=reason, qty_at_mark=qty_at_mark)
         row = _make_sighting(
             db_session,
             requirement,
             "Acme Components",
             mpn_matched="ST3300657SS",
-            qty_available=200,
+            qty_available=fresh_qty,
             source_type="brokerbin",
         )
 
-        assert apply_to_fresh_sightings(db_session, requirement, [row]) == 0
-        assert bool(row.is_unavailable) is False
-
-    def test_below_factor_stays_stamped(self, db_session: Session):
-        requirement = _make_requirement(db_session)
-        _make_record(db_session, qty_at_mark=100)
-        row = _make_sighting(
-            db_session,
-            requirement,
-            "Acme Components",
-            mpn_matched="ST3300657SS",
-            qty_available=199,
-            source_type="brokerbin",
-        )
-
-        assert apply_to_fresh_sightings(db_session, requirement, [row]) == 1
-        assert row.is_unavailable is True
+        assert apply_to_fresh_sightings(db_session, requirement, [row]) == expected_count
+        assert bool(row.is_unavailable) is expected_flag
 
     def test_strict_greater_required_even_at_factor_one(self, db_session: Session, monkeypatch):
         """An identical echo can never release regardless of knob misconfiguration."""
@@ -898,67 +904,6 @@ class TestOverrideO2Restock:
             "Acme Components",
             mpn_matched="ST3300657SS",
             qty_available=100,
-            source_type="brokerbin",
-        )
-
-        assert apply_to_fresh_sightings(db_session, requirement, [row]) == 1
-        assert row.is_unavailable is True
-
-    def test_null_snapshot_is_no_signal(self, db_session: Session):
-        requirement = _make_requirement(db_session)
-        _make_record(db_session, qty_at_mark=None)
-        row = _make_sighting(
-            db_session,
-            requirement,
-            "Acme Components",
-            mpn_matched="ST3300657SS",
-            qty_available=100000,
-            source_type="brokerbin",
-        )
-
-        assert apply_to_fresh_sightings(db_session, requirement, [row]) == 1
-        assert row.is_unavailable is True
-
-    def test_null_fresh_qty_is_no_signal(self, db_session: Session):
-        requirement = _make_requirement(db_session)
-        _make_record(db_session, qty_at_mark=100)
-        row = _make_sighting(
-            db_session,
-            requirement,
-            "Acme Components",
-            mpn_matched="ST3300657SS",
-            qty_available=None,
-            source_type="brokerbin",
-        )
-
-        assert apply_to_fresh_sightings(db_session, requirement, [row]) == 1
-        assert row.is_unavailable is True
-
-    def test_snapshot_zero_releases_on_any_positive_fresh_qty(self, db_session: Session):
-        requirement = _make_requirement(db_session)
-        _make_record(db_session, qty_at_mark=0)
-        row = _make_sighting(
-            db_session,
-            requirement,
-            "Acme Components",
-            mpn_matched="ST3300657SS",
-            qty_available=1,
-            source_type="brokerbin",
-        )
-
-        assert apply_to_fresh_sightings(db_session, requirement, [row]) == 0
-        assert bool(row.is_unavailable) is False
-
-    def test_disabled_for_different_part(self, db_session: Session):
-        """More of the wrong part is still the wrong part."""
-        requirement = _make_requirement(db_session)
-        _make_record(db_session, reason=UnavailabilityReason.DIFFERENT_PART, qty_at_mark=100)
-        row = _make_sighting(
-            db_session,
-            requirement,
-            "Acme Components",
-            mpn_matched="ST3300657SS",
-            qty_available=1000,
             source_type="brokerbin",
         )
 

--- a/tests/test_webhook_security_integration.py
+++ b/tests/test_webhook_security_integration.py
@@ -57,6 +57,20 @@ def _clear_replay_cache():
     _seen_notifications.clear()
 
 
+def _make_sub(db_session: Session, user: User, subscription_id: str, client_state: str | None):
+    sub = GraphSubscription(
+        user_id=user.id,
+        subscription_id=subscription_id,
+        resource="/me/messages",
+        change_type="created",
+        expiration_dt=datetime.now(timezone.utc) + timedelta(hours=48),
+        client_state=client_state,
+    )
+    db_session.add(sub)
+    db_session.commit()
+    return sub
+
+
 @pytest.fixture()
 def client_state_1():
     return secrets.token_hex(16)
@@ -65,17 +79,7 @@ def client_state_1():
 @pytest.fixture()
 def sub1(db_session: Session, admin_user: User, client_state_1: str):
     """A GraphSubscription with a known client_state."""
-    sub = GraphSubscription(
-        user_id=admin_user.id,
-        subscription_id="sub-sec-001",
-        resource="/me/messages",
-        change_type="created",
-        expiration_dt=datetime.now(timezone.utc) + timedelta(hours=48),
-        client_state=client_state_1,
-    )
-    db_session.add(sub)
-    db_session.commit()
-    return sub
+    return _make_sub(db_session, admin_user, "sub-sec-001", client_state_1)
 
 
 @pytest.fixture()
@@ -85,17 +89,7 @@ def client_state_2():
 
 @pytest.fixture()
 def sub2(db_session: Session, admin_user: User, client_state_2: str):
-    sub = GraphSubscription(
-        user_id=admin_user.id,
-        subscription_id="sub-sec-002",
-        resource="/me/messages",
-        change_type="created",
-        expiration_dt=datetime.now(timezone.utc) + timedelta(hours=48),
-        client_state=client_state_2,
-    )
-    db_session.add(sub)
-    db_session.commit()
-    return sub
+    return _make_sub(db_session, admin_user, "sub-sec-002", client_state_2)
 
 
 @pytest.fixture()
@@ -105,33 +99,13 @@ def client_state_3():
 
 @pytest.fixture()
 def sub3(db_session: Session, admin_user: User, client_state_3: str):
-    sub = GraphSubscription(
-        user_id=admin_user.id,
-        subscription_id="sub-sec-003",
-        resource="/me/messages",
-        change_type="created",
-        expiration_dt=datetime.now(timezone.utc) + timedelta(hours=48),
-        client_state=client_state_3,
-    )
-    db_session.add(sub)
-    db_session.commit()
-    return sub
+    return _make_sub(db_session, admin_user, "sub-sec-003", client_state_3)
 
 
 @pytest.fixture()
 def sub_no_state(db_session: Session, admin_user: User):
     """Subscription with no client_state set."""
-    sub = GraphSubscription(
-        user_id=admin_user.id,
-        subscription_id="sub-sec-004",
-        resource="/me/messages",
-        change_type="created",
-        expiration_dt=datetime.now(timezone.utc) + timedelta(hours=48),
-        client_state=None,
-    )
-    db_session.add(sub)
-    db_session.commit()
-    return sub
+    return _make_sub(db_session, admin_user, "sub-sec-004", None)
 
 
 @pytest.fixture()
@@ -141,17 +115,7 @@ def client_state_5():
 
 @pytest.fixture()
 def sub5(db_session: Session, admin_user: User, client_state_5: str):
-    sub = GraphSubscription(
-        user_id=admin_user.id,
-        subscription_id="sub-sec-005",
-        resource="/me/messages",
-        change_type="created",
-        expiration_dt=datetime.now(timezone.utc) + timedelta(hours=48),
-        client_state=client_state_5,
-    )
-    db_session.add(sub)
-    db_session.commit()
-    return sub
+    return _make_sub(db_session, admin_user, "sub-sec-005", client_state_5)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of the codebase-wide simplification program — **tests wave (5/8)**, full simplify (within-file only).

## What changed
- Copy-paste test functions differing only in data → `@pytest.mark.parametrize` (one case per original; IDs preserved).
- Repeated arrange/setup blocks → local helper functions / module-level fixtures **defined in the same file**.
- Removed exact-duplicate test functions and dead/commented tests.

`conftest.py` and all shared fixtures untouched; no assertion weakened; mock/patch targets unchanged.

## Verification (coverage preserved)
- ruff clean
- **Full suite: 16623 passed, 0 failed** (baseline 16,563). The collected/passed count *rises* where multi-assert tests were split into discrete parametrized cases — no test case was dropped (exact-duplicate removals are 1-for-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)