### PR TITLE
test(simplify 6/8): parametrize + dedup test setup

### DIFF
--- a/tests/scripts/test_reconstruct_001_baseline.py
+++ b/tests/scripts/test_reconstruct_001_baseline.py
@@ -139,54 +139,56 @@ def test_render_op_create_index_emits_valid_python():
 # alembic op.create_index path unchanged.
 
 
-def test_parse_pg_dump_extracts_index_with_desc_ordering():
-    """An index column with trailing ASC/DESC must be parsed as (column, ordering) not
-    as a single column named 'col DESC'."""
-    sql = textwrap.dedent("""
-    CREATE TABLE public.sightings (id integer NOT NULL, requirement_id integer, score double precision);
-    CREATE INDEX ix_sightings_req_score ON public.sightings USING btree (requirement_id, score DESC);
-    """)
-    result = parse_pg_dump(sql)
-    assert len(result.indexes) == 1
-    ix = result.indexes[0]
-    assert ix.columns == ["requirement_id", "score"], f"DESC must split off the column name; got columns={ix.columns!r}"
-    assert ix.column_orderings == [None, "DESC"]
-    assert ix.where_clause is None
+@pytest.mark.parametrize(
+    ("sql", "expected_columns", "expected_orderings", "expected_where"),
+    [
+        pytest.param(
+            """
+            CREATE TABLE public.sightings (id integer NOT NULL, requirement_id integer, score double precision);
+            CREATE INDEX ix_sightings_req_score ON public.sightings USING btree (requirement_id, score DESC);
+            """,
+            ["requirement_id", "score"],
+            [None, "DESC"],
+            None,
+            id="desc_ordering",
+        ),
+        pytest.param(
+            """
+            CREATE TABLE public.activity_log (id integer NOT NULL, company_id integer, created_at timestamp without time zone);
+            CREATE INDEX ix_activity_company ON public.activity_log USING btree (company_id, created_at) WHERE (company_id IS NOT NULL);
+            """,
+            ["company_id", "created_at"],
+            [None, None],
+            "(company_id IS NOT NULL)",
+            id="partial_where",
+        ),
+        pytest.param(
+            """
+            CREATE TABLE public.ics_search_queue (id integer NOT NULL, normalized_mpn varchar(255), last_searched_at timestamp without time zone, status varchar(50));
+            CREATE INDEX ix_ics_queue_dedup ON public.ics_search_queue USING btree (normalized_mpn, last_searched_at DESC) WHERE ((status)::text = 'completed'::text);
+            """,
+            ["normalized_mpn", "last_searched_at"],
+            [None, "DESC"],
+            "((status)::text = 'completed'::text)",
+            id="desc_and_where",
+        ),
+    ],
+)
+def test_parse_pg_dump_extracts_index_qualifiers(sql, expected_columns, expected_orderings, expected_where):
+    """Index columns with trailing ASC/DESC must split the ordering off the column name,
+    and partial-index WHERE predicates must be captured.
 
-
-def test_parse_pg_dump_extracts_partial_index():
-    """An index with WHERE clause must capture the predicate and still parse columns.
-
-    The old regex (anchored on ``);``) silently dropped these.
+    Covers DESC-only, WHERE-only, and the real-world DESC+WHERE combo
+    (``ix_ics_queue_dedup`` / ``ix_nc_queue_dedup``). The old parser treated
+    ``score DESC`` as one column name and (anchored on ``);``) silently dropped
+    partial-index lines entirely.
     """
-    sql = textwrap.dedent("""
-    CREATE TABLE public.activity_log (id integer NOT NULL, company_id integer, created_at timestamp without time zone);
-    CREATE INDEX ix_activity_company ON public.activity_log USING btree (company_id, created_at) WHERE (company_id IS NOT NULL);
-    """)
-    result = parse_pg_dump(sql)
-    assert len(result.indexes) == 1, (
-        f"partial index must still be parsed (the old regex dropped it); got {len(result.indexes)}"
-    )
+    result = parse_pg_dump(textwrap.dedent(sql))
+    assert len(result.indexes) == 1, f"index must be parsed (the old regex dropped partials); got {len(result.indexes)}"
     ix = result.indexes[0]
-    assert ix.columns == ["company_id", "created_at"]
-    assert ix.column_orderings == [None, None]
-    assert ix.where_clause == "(company_id IS NOT NULL)"
-
-
-def test_parse_pg_dump_extracts_index_with_both_desc_and_where():
-    """Real-world combo from this codebase: ``ix_ics_queue_dedup`` /
-    ``ix_nc_queue_dedup``. Both DESC ordering AND a partial-index WHERE clause
-    on the same index. Both must be captured."""
-    sql = textwrap.dedent("""
-    CREATE TABLE public.ics_search_queue (id integer NOT NULL, normalized_mpn varchar(255), last_searched_at timestamp without time zone, status varchar(50));
-    CREATE INDEX ix_ics_queue_dedup ON public.ics_search_queue USING btree (normalized_mpn, last_searched_at DESC) WHERE ((status)::text = 'completed'::text);
-    """)
-    result = parse_pg_dump(sql)
-    assert len(result.indexes) == 1
-    ix = result.indexes[0]
-    assert ix.columns == ["normalized_mpn", "last_searched_at"]
-    assert ix.column_orderings == [None, "DESC"]
-    assert ix.where_clause == "((status)::text = 'completed'::text)"
+    assert ix.columns == expected_columns, f"DESC must split off the column name; got columns={ix.columns!r}"
+    assert ix.column_orderings == expected_orderings
+    assert ix.where_clause == expected_where
 
 
 def test_render_op_create_index_falls_back_to_execute_for_complex_indexes():

--- a/tests/test_apollo_connector_coverage.py
+++ b/tests/test_apollo_connector_coverage.py
@@ -12,25 +12,44 @@ import os
 
 os.environ["TESTING"] = "1"
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
+
+
+@contextmanager
+def patched_async_client(mock_client: AsyncMock):
+    """Patch httpx.AsyncClient so its `async with` yields `mock_client`."""
+    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        yield mock_client
+
+
+def make_response(status_code: int, payload: dict) -> MagicMock:
+    """Build a MagicMock httpx response with the given status and JSON body."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    return response
+
 
 # -- _parse_company_response --------------------------------------------------
 
 
-def test_parse_company_response_returns_none_when_no_org():
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({}, id="no_org_key"),
+        pytest.param({"organization": None}, id="org_is_none"),
+    ],
+)
+def test_parse_company_response_returns_none(data):
     from app.connectors.apollo import _parse_company_response
 
-    result = _parse_company_response({})
-    assert result is None
-
-
-def test_parse_company_response_returns_none_when_org_is_none():
-    from app.connectors.apollo import _parse_company_response
-
-    result = _parse_company_response({"organization": None})
-    assert result is None
+    assert _parse_company_response(data) is None
 
 
 def test_parse_company_response_full_org():
@@ -97,18 +116,17 @@ def test_parse_company_response_missing_optional_fields():
 # -- _parse_contacts_response -------------------------------------------------
 
 
-def test_parse_contacts_response_empty():
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({"other": "data"}, id="no_people_key"),
+    ],
+)
+def test_parse_contacts_response_returns_empty(data):
     from app.connectors.apollo import _parse_contacts_response
 
-    result = _parse_contacts_response({})
-    assert result == []
-
-
-def test_parse_contacts_response_no_people_key():
-    from app.connectors.apollo import _parse_contacts_response
-
-    result = _parse_contacts_response({"other": "data"})
-    assert result == []
+    assert _parse_contacts_response(data) == []
 
 
 def test_parse_contacts_response_single_person():
@@ -168,86 +186,36 @@ def test_parse_contacts_response_missing_fields():
 async def test_search_company_success():
     from app.connectors.apollo import search_company
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "organization": {
-            "name": "Test Corp",
-            "website_url": "https://testcorp.com",
-        }
-    }
-
+    mock_response = make_response(
+        200,
+        {"organization": {"name": "Test Corp", "website_url": "https://testcorp.com"}},
+    )
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_response)
 
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    with patched_async_client(mock_client):
         result = await search_company("testcorp.com", "fake-key")
 
     assert result is not None
     assert result["legal_name"] == "Test Corp"
 
 
-async def test_search_company_non_200_returns_none():
-    from app.connectors.apollo import search_company
-
-    mock_response = MagicMock()
-    mock_response.status_code = 403
-    mock_response.json.return_value = {}
-
-    mock_client = AsyncMock()
-    mock_client.get = AsyncMock(return_value=mock_response)
-
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-        result = await search_company("testcorp.com", "fake-key")
-
-    assert result is None
-
-
-async def test_search_company_http_error_returns_none():
+@pytest.mark.parametrize(
+    "get_kwargs",
+    [
+        pytest.param({"return_value": make_response(403, {})}, id="non_200"),
+        pytest.param({"side_effect": httpx.HTTPError("connection error")}, id="http_error"),
+        pytest.param({"side_effect": ValueError("bad value")}, id="value_error"),
+        pytest.param({"return_value": make_response(200, {})}, id="response_no_org"),
+    ],
+)
+async def test_search_company_returns_none(get_kwargs):
     from app.connectors.apollo import search_company
 
     mock_client = AsyncMock()
-    mock_client.get = AsyncMock(side_effect=httpx.HTTPError("connection error"))
+    mock_client.get = AsyncMock(**get_kwargs)
 
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-        result = await search_company("testcorp.com", "fake-key")
-
-    assert result is None
-
-
-async def test_search_company_value_error_returns_none():
-    from app.connectors.apollo import search_company
-
-    mock_client = AsyncMock()
-    mock_client.get = AsyncMock(side_effect=ValueError("bad value"))
-
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-        result = await search_company("testcorp.com", "fake-key")
-
-    assert result is None
-
-
-async def test_search_company_response_no_org_returns_none():
-    from app.connectors.apollo import search_company
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {}
-
-    mock_client = AsyncMock()
-    mock_client.get = AsyncMock(return_value=mock_response)
-
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    with patched_async_client(mock_client):
         result = await search_company("testcorp.com", "fake-key")
 
     assert result is None
@@ -259,67 +227,35 @@ async def test_search_company_response_no_org_returns_none():
 async def test_search_contacts_success():
     from app.connectors.apollo import search_contacts
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "people": [
-            {"name": "Jane Doe", "email": "jane@co.com", "title": "CEO"},
-        ]
-    }
-
+    mock_response = make_response(
+        200,
+        {"people": [{"name": "Jane Doe", "email": "jane@co.com", "title": "CEO"}]},
+    )
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(return_value=mock_response)
 
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    with patched_async_client(mock_client):
         result = await search_contacts("co.com", "fake-key", limit=5)
 
     assert len(result) == 1
     assert result[0]["full_name"] == "Jane Doe"
 
 
-async def test_search_contacts_non_200_returns_empty():
-    from app.connectors.apollo import search_contacts
-
-    mock_response = MagicMock()
-    mock_response.status_code = 429
-    mock_response.json.return_value = {}
-
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(return_value=mock_response)
-
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-        result = await search_contacts("co.com", "fake-key")
-
-    assert result == []
-
-
-async def test_search_contacts_http_error_returns_empty():
+@pytest.mark.parametrize(
+    "post_kwargs",
+    [
+        pytest.param({"return_value": make_response(429, {})}, id="non_200"),
+        pytest.param({"side_effect": httpx.HTTPError("timeout")}, id="http_error"),
+        pytest.param({"side_effect": KeyError("missing")}, id="key_error"),
+    ],
+)
+async def test_search_contacts_returns_empty(post_kwargs):
     from app.connectors.apollo import search_contacts
 
     mock_client = AsyncMock()
-    mock_client.post = AsyncMock(side_effect=httpx.HTTPError("timeout"))
+    mock_client.post = AsyncMock(**post_kwargs)
 
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
-        result = await search_contacts("co.com", "fake-key")
-
-    assert result == []
-
-
-async def test_search_contacts_key_error_returns_empty():
-    from app.connectors.apollo import search_contacts
-
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(side_effect=KeyError("missing"))
-
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    with patched_async_client(mock_client):
         result = await search_contacts("co.com", "fake-key")
 
     assert result == []
@@ -329,16 +265,11 @@ async def test_search_contacts_default_limit():
     """search_contacts should pass per_page=10 by default."""
     from app.connectors.apollo import search_contacts
 
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {"people": []}
-
+    mock_response = make_response(200, {"people": []})
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(return_value=mock_response)
 
-    with patch("app.connectors.apollo.httpx.AsyncClient") as mock_cls:
-        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    with patched_async_client(mock_client):
         result = await search_contacts("co.com", "fake-key")
 
     # Verify the per_page was sent as 10

--- a/tests/test_backfill_oem_enrichment.py
+++ b/tests/test_backfill_oem_enrichment.py
@@ -11,6 +11,19 @@ from app.models import MaterialCard
 from app.utils.claude_errors import ClaudeError
 
 
+def _seed_not_found(db_session, n):
+    """Add n NOT_FOUND MaterialCards (01HW000..) and commit."""
+    for i in range(n):
+        db_session.add(
+            MaterialCard(
+                display_mpn=f"01HW{i:03d}",
+                normalized_mpn=f"01hw{i:03d}",
+                enrichment_status=MaterialEnrichmentStatus.NOT_FOUND,
+            )
+        )
+    db_session.commit()
+
+
 @pytest.mark.asyncio
 async def test_dry_run_writes_csv_and_no_commit(db_session, tmp_path):
     import scripts.backfill_oem_enrichment as bf
@@ -40,15 +53,7 @@ async def test_dry_run_writes_csv_and_no_commit(db_session, tmp_path):
 async def test_budget_cap_halts(db_session, tmp_path):
     import scripts.backfill_oem_enrichment as bf
 
-    for i in range(5):
-        db_session.add(
-            MaterialCard(
-                display_mpn=f"01HW{i:03d}",
-                normalized_mpn=f"01hw{i:03d}",
-                enrichment_status=MaterialEnrichmentStatus.NOT_FOUND,
-            )
-        )
-    db_session.commit()
+    _seed_not_found(db_session, 5)
 
     async def fake_enrich(card, db, *, web_meter=None, **kw):
         if web_meter is not None:
@@ -96,15 +101,7 @@ async def test_select_includes_not_catalogued(db_session, tmp_path):
 async def test_bad_card_does_not_abort_run(db_session, tmp_path):
     import scripts.backfill_oem_enrichment as bf
 
-    for i in range(3):
-        db_session.add(
-            MaterialCard(
-                display_mpn=f"01HW{i:03d}",
-                normalized_mpn=f"01hw{i:03d}",
-                enrichment_status=MaterialEnrichmentStatus.NOT_FOUND,
-            )
-        )
-    db_session.commit()
+    _seed_not_found(db_session, 3)
 
     calls = {"n": 0}
 
@@ -128,15 +125,7 @@ async def test_bad_card_does_not_abort_run(db_session, tmp_path):
 async def test_consecutive_claude_errors_abort(db_session, tmp_path):
     import scripts.backfill_oem_enrichment as bf
 
-    for i in range(10):
-        db_session.add(
-            MaterialCard(
-                display_mpn=f"01HW{i:03d}",
-                normalized_mpn=f"01hw{i:03d}",
-                enrichment_status=MaterialEnrichmentStatus.NOT_FOUND,
-            )
-        )
-    db_session.commit()
+    _seed_not_found(db_session, 10)
 
     async def fake_enrich(card, db, **kw):
         raise ClaudeError("backend down")

--- a/tests/test_buyplan_v3_po_verify.py
+++ b/tests/test_buyplan_v3_po_verify.py
@@ -8,6 +8,7 @@ Called by: pytest
 Depends on: conftest fixtures (db_session, client, test_user), buyplan_workflow
 """
 
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
@@ -131,6 +132,20 @@ def _make_plan_with_lines(
     return plan
 
 
+@contextmanager
+def _mock_graph_search(*, return_value=None, side_effect=None):
+    """Patch token + GraphClient so search_sent_messages returns/raises as
+    configured."""
+    with (
+        patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="mock-token"),
+        patch("app.utils.graph_client.GraphClient") as MockGC,
+    ):
+        mock_client = AsyncMock()
+        mock_client.search_sent_messages = AsyncMock(return_value=return_value, side_effect=side_effect)
+        MockGC.return_value = mock_client
+        yield
+
+
 # ── Tests ────────────────────────────────────────────────────────────
 
 
@@ -148,14 +163,7 @@ async def test_verify_po_found_in_sent_folder(db_session: Session, test_user: Us
         }
     ]
 
-    with (
-        patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="mock-token"),
-        patch("app.utils.graph_client.GraphClient") as MockGC,
-    ):
-        mock_client = AsyncMock()
-        mock_client.search_sent_messages = AsyncMock(return_value=mock_messages)
-        MockGC.return_value = mock_client
-
+    with _mock_graph_search(return_value=mock_messages):
         results = await verify_po_sent_v3(plan, db_session)
 
     assert "PO-12345" in results
@@ -175,14 +183,7 @@ async def test_verify_po_not_found(db_session: Session, test_user: User):
     """PO not found in sent folder — line stays in pending_verify."""
     plan = _make_plan_with_lines(db_session, test_user, ["PO-99999"])
 
-    with (
-        patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="mock-token"),
-        patch("app.utils.graph_client.GraphClient") as MockGC,
-    ):
-        mock_client = AsyncMock()
-        mock_client.search_sent_messages = AsyncMock(return_value=[])
-        MockGC.return_value = mock_client
-
+    with _mock_graph_search(return_value=[]):
         results = await verify_po_sent_v3(plan, db_session)
 
     assert results["PO-99999"]["verified"] is False
@@ -197,14 +198,7 @@ async def test_verify_po_graph_error(db_session: Session, test_user: User):
     """Graph API error handled gracefully — returns error reason."""
     plan = _make_plan_with_lines(db_session, test_user, ["PO-ERR-001"])
 
-    with (
-        patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="mock-token"),
-        patch("app.utils.graph_client.GraphClient") as MockGC,
-    ):
-        mock_client = AsyncMock()
-        mock_client.search_sent_messages = AsyncMock(side_effect=RuntimeError("Graph 503"))
-        MockGC.return_value = mock_client
-
+    with _mock_graph_search(side_effect=RuntimeError("Graph 503")):
         results = await verify_po_sent_v3(plan, db_session)
 
     assert results["PO-ERR-001"]["verified"] is False
@@ -230,14 +224,7 @@ async def test_verify_po_all_verified_auto_completes(db_session: Session, test_u
         }
     ]
 
-    with (
-        patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="mock-token"),
-        patch("app.utils.graph_client.GraphClient") as MockGC,
-    ):
-        mock_client = AsyncMock()
-        mock_client.search_sent_messages = AsyncMock(return_value=mock_messages)
-        MockGC.return_value = mock_client
-
+    with _mock_graph_search(return_value=mock_messages):
         results = await verify_po_sent_v3(plan, db_session)
 
     assert results["PO-A"]["verified"] is True

--- a/tests/test_claude_client_nightly.py
+++ b/tests/test_claude_client_nightly.py
@@ -303,33 +303,22 @@ class TestClaudeBatchSubmitGaps:
     _base_request = [{"custom_id": "r1", "prompt": "parse this", "schema": {"type": "object"}}]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status_code", "text", "expected_exc"),
+        [
+            pytest.param(401, "Unauthorized", ClaudeAuthError, id="401_auth_error"),
+            pytest.param(403, "Forbidden", ClaudeAuthError, id="403_auth_error"),
+            pytest.param(429, "Rate Limited", ClaudeRateLimitError, id="429_rate_limit_error"),
+        ],
+    )
     @patch("app.utils.claude_client.get_credential_cached", side_effect=_cred_side_effect)
     @patch("app.utils.claude_client.http")
-    async def test_401_raises_auth_error(self, mock_http, mock_cred):
-        """Line 485: 401 response raises ClaudeAuthError."""
-        mock_http.post = AsyncMock(return_value=_mock_response(401, text="Unauthorized"))
+    async def test_error_status_raises(self, mock_http, mock_cred, status_code, text, expected_exc):
+        """Lines 485, 487: 401/403 raise ClaudeAuthError, 429 raises
+        ClaudeRateLimitError."""
+        mock_http.post = AsyncMock(return_value=_mock_response(status_code, text=text))
 
-        with pytest.raises(ClaudeAuthError):
-            await claude_batch_submit(self._base_request)
-
-    @pytest.mark.asyncio
-    @patch("app.utils.claude_client.get_credential_cached", side_effect=_cred_side_effect)
-    @patch("app.utils.claude_client.http")
-    async def test_403_raises_auth_error(self, mock_http, mock_cred):
-        """Line 485: 403 response raises ClaudeAuthError."""
-        mock_http.post = AsyncMock(return_value=_mock_response(403, text="Forbidden"))
-
-        with pytest.raises(ClaudeAuthError):
-            await claude_batch_submit(self._base_request)
-
-    @pytest.mark.asyncio
-    @patch("app.utils.claude_client.get_credential_cached", side_effect=_cred_side_effect)
-    @patch("app.utils.claude_client.http")
-    async def test_429_raises_rate_limit_error(self, mock_http, mock_cred):
-        """Line 487: 429 response raises ClaudeRateLimitError."""
-        mock_http.post = AsyncMock(return_value=_mock_response(429, text="Rate Limited"))
-
-        with pytest.raises(ClaudeRateLimitError):
+        with pytest.raises(expected_exc):
             await claude_batch_submit(self._base_request)
 
     @pytest.mark.asyncio

--- a/tests/test_company_utils.py
+++ b/tests/test_company_utils.py
@@ -2,31 +2,36 @@
 
 from datetime import datetime, timezone
 
+import pytest
+
 from app.company_utils import find_company_dedup_candidates, normalize_company_name
 from app.models import Company, CustomerSite
 
 
 class TestNormalizeCompanyName:
-    def test_empty_string(self):
-        assert normalize_company_name("") == ""
-
-    def test_lowercase(self):
-        assert normalize_company_name("ACME CORP") == "acme"
-
-    def test_strip_inc(self):
-        assert normalize_company_name("Mouser Electronics, Inc.") == "mouser electronics"
-
-    def test_strip_llc(self):
-        assert normalize_company_name("Acme Solutions LLC") == "acme solutions"
-
-    def test_strip_corp(self):
-        assert normalize_company_name("DigiKey Corp.") == "digikey"
-
-    def test_leading_the(self):
-        assert normalize_company_name("The Phoenix Company") == "phoenix"
-
-    def test_collapse_whitespace(self):
-        assert normalize_company_name("  Foo   Bar   ") == "foo bar"
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("", ""),
+            ("ACME CORP", "acme"),
+            ("Mouser Electronics, Inc.", "mouser electronics"),
+            ("Acme Solutions LLC", "acme solutions"),
+            ("DigiKey Corp.", "digikey"),
+            ("The Phoenix Company", "phoenix"),
+            ("  Foo   Bar   ", "foo bar"),
+        ],
+        ids=[
+            "empty_string",
+            "lowercase",
+            "strip_inc",
+            "strip_llc",
+            "strip_corp",
+            "leading_the",
+            "collapse_whitespace",
+        ],
+    )
+    def test_normalizes(self, raw, expected):
+        assert normalize_company_name(raw) == expected
 
     def test_no_false_strip(self):
         """Should not strip 'inc' from middle of word like 'Incipio'."""

--- a/tests/test_contact_scoring.py
+++ b/tests/test_contact_scoring.py
@@ -9,6 +9,8 @@ Depends on: app/services/contact_intelligence.py
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from app.services.contact_intelligence import (
     W_CHANNEL_DIVERSITY,
     W_FREQUENCY,
@@ -23,36 +25,65 @@ from app.services.contact_intelligence import (
 NOW = datetime(2026, 2, 15, 12, 0, 0, tzinfo=timezone.utc)
 
 
+def score(
+    *,
+    last_interaction_at=NOW,
+    interactions_30d=5,
+    interactions_60d=10,
+    interactions_90d=15,
+    avg_response_hours=None,
+    wins=0,
+    total_interactions=15,
+    distinct_channels=1,
+):
+    """Call compute_contact_relationship_score with the common test defaults.
+
+    Each test overrides only the inputs it exercises.
+    """
+    return compute_contact_relationship_score(
+        last_interaction_at=last_interaction_at,
+        interactions_30d=interactions_30d,
+        interactions_60d=interactions_60d,
+        interactions_90d=interactions_90d,
+        avg_response_hours=avg_response_hours,
+        wins=wins,
+        total_interactions=total_interactions,
+        distinct_channels=distinct_channels,
+        now=NOW,
+    )
+
+
 # ── split_name ─────────────────────────────────────────────────────
 
 
 class TestSplitName:
-    def test_simple_name(self):
-        assert split_name("John Doe") == ("John", "Doe")
-
-    def test_single_name(self):
-        assert split_name("Madonna") == ("Madonna", None)
-
-    def test_prefix_name(self):
-        assert split_name("John van der Berg") == ("John", "van der Berg")
-
-    def test_prefix_de(self):
-        assert split_name("Maria de la Cruz") == ("Maria", "de la Cruz")
-
-    def test_three_part_name(self):
-        assert split_name("John Michael Smith") == ("John", "Michael Smith")
-
-    def test_none(self):
-        assert split_name(None) == (None, None)
-
-    def test_empty(self):
-        assert split_name("") == (None, None)
-
-    def test_whitespace(self):
-        assert split_name("   ") == (None, None)
-
-    def test_leading_trailing_spaces(self):
-        assert split_name("  John Doe  ") == ("John", "Doe")
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("John Doe", ("John", "Doe")),
+            ("Madonna", ("Madonna", None)),
+            ("John van der Berg", ("John", "van der Berg")),
+            ("Maria de la Cruz", ("Maria", "de la Cruz")),
+            ("John Michael Smith", ("John", "Michael Smith")),
+            (None, (None, None)),
+            ("", (None, None)),
+            ("   ", (None, None)),
+            ("  John Doe  ", ("John", "Doe")),
+        ],
+        ids=[
+            "simple_name",
+            "single_name",
+            "prefix_name",
+            "prefix_de",
+            "three_part_name",
+            "none",
+            "empty",
+            "whitespace",
+            "leading_trailing_spaces",
+        ],
+    )
+    def test_split_name(self, raw, expected):
+        assert split_name(raw) == expected
 
 
 # ── Recency scoring ────────────────────────────────────────────────
@@ -61,74 +92,43 @@ class TestSplitName:
 class TestRecencyScore:
     def test_recent_interaction(self):
         """Within 7 days = 100."""
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW - timedelta(days=1),
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=None,
-            wins=0,
-            total_interactions=15,
-            distinct_channels=1,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW - timedelta(days=1))
         assert result["recency_score"] == 100.0
 
     def test_exactly_7_days(self):
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW - timedelta(days=7),
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=None,
-            wins=0,
-            total_interactions=15,
-            distinct_channels=1,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW - timedelta(days=7))
         assert result["recency_score"] == 100.0
 
     def test_old_interaction(self):
         """365+ days = 0."""
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=NOW - timedelta(days=400),
             interactions_30d=0,
             interactions_60d=0,
             interactions_90d=0,
-            avg_response_hours=None,
-            wins=0,
             total_interactions=10,
-            distinct_channels=1,
-            now=NOW,
         )
         assert result["recency_score"] == 0.0
 
     def test_no_interaction(self):
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=None,
             interactions_30d=0,
             interactions_60d=0,
             interactions_90d=0,
-            avg_response_hours=None,
-            wins=0,
             total_interactions=0,
             distinct_channels=0,
-            now=NOW,
         )
         assert result["recency_score"] == 0.0
 
     def test_mid_recency(self):
         """~186 days should be roughly 50%."""
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=NOW - timedelta(days=186),
             interactions_30d=0,
             interactions_60d=0,
             interactions_90d=0,
-            avg_response_hours=None,
-            wins=0,
             total_interactions=10,
-            distinct_channels=1,
-            now=NOW,
         )
         assert 40 <= result["recency_score"] <= 60
 
@@ -138,45 +138,27 @@ class TestRecencyScore:
 
 class TestFrequencyScore:
     def test_high_frequency(self):
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=NOW,
             interactions_30d=15,
             interactions_60d=20,
             interactions_90d=25,
-            avg_response_hours=None,
-            wins=0,
             total_interactions=25,
-            distinct_channels=1,
-            now=NOW,
         )
         assert result["frequency_score"] == 100.0  # capped at 100
 
     def test_zero_frequency(self):
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=NOW,
             interactions_30d=0,
             interactions_60d=0,
             interactions_90d=0,
-            avg_response_hours=None,
-            wins=0,
             total_interactions=0,
-            distinct_channels=1,
-            now=NOW,
         )
         assert result["frequency_score"] == 0.0
 
     def test_half_frequency(self):
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW,
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=None,
-            wins=0,
-            total_interactions=15,
-            distinct_channels=1,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW)
         assert result["frequency_score"] == 50.0
 
 
@@ -185,46 +167,16 @@ class TestFrequencyScore:
 
 class TestResponsivenessScore:
     def test_fast_response(self):
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW,
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=2.0,
-            wins=0,
-            total_interactions=15,
-            distinct_channels=1,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW, avg_response_hours=2.0)
         assert result["responsiveness_score"] == 100.0
 
     def test_slow_response(self):
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW,
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=200.0,
-            wins=0,
-            total_interactions=15,
-            distinct_channels=1,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW, avg_response_hours=200.0)
         assert result["responsiveness_score"] == 0.0
 
     def test_unknown_response(self):
         """None defaults to neutral 50."""
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW,
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=None,
-            wins=0,
-            total_interactions=15,
-            distinct_channels=1,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW, avg_response_hours=None)
         assert result["responsiveness_score"] == 50.0
 
 
@@ -233,44 +185,21 @@ class TestResponsivenessScore:
 
 class TestWinRateScore:
     def test_good_win_rate(self):
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW,
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=None,
-            wins=8,
-            total_interactions=15,
-            distinct_channels=1,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW, wins=8)
         assert 50 <= result["win_rate_score"] <= 60
 
     def test_zero_wins(self):
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW,
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=None,
-            wins=0,
-            total_interactions=15,
-            distinct_channels=1,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW, wins=0)
         assert result["win_rate_score"] == 0.0
 
     def test_zero_interactions(self):
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=None,
             interactions_30d=0,
             interactions_60d=0,
             interactions_90d=0,
-            avg_response_hours=None,
-            wins=0,
             total_interactions=0,
             distinct_channels=0,
-            now=NOW,
         )
         assert result["win_rate_score"] == 0.0
 
@@ -280,44 +209,21 @@ class TestWinRateScore:
 
 class TestChannelScore:
     def test_three_channels(self):
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW,
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=None,
-            wins=0,
-            total_interactions=15,
-            distinct_channels=3,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW, distinct_channels=3)
         assert result["channel_score"] == 100.0
 
     def test_one_channel(self):
-        result = compute_contact_relationship_score(
-            last_interaction_at=NOW,
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
-            avg_response_hours=None,
-            wins=0,
-            total_interactions=15,
-            distinct_channels=1,
-            now=NOW,
-        )
+        result = score(last_interaction_at=NOW, distinct_channels=1)
         assert 30 <= result["channel_score"] <= 40
 
     def test_zero_channels(self):
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=NOW,
             interactions_30d=0,
             interactions_60d=0,
             interactions_90d=0,
-            avg_response_hours=None,
-            wins=0,
             total_interactions=0,
             distinct_channels=0,
-            now=NOW,
         )
         assert result["channel_score"] == 0.0
 
@@ -326,29 +232,29 @@ class TestChannelScore:
 
 
 class TestComputeTrend:
-    def test_all_zero_dormant(self):
-        assert _compute_trend(0, 0, 0) == "dormant"
-
-    def test_warming_from_zero(self):
-        assert _compute_trend(5, 0, 0) == "warming"
-
-    def test_warming_high_30d(self):
-        """30d rate (5) > 1.5 * older rate ((10-5)/2 = 2.5) → warming."""
-        assert _compute_trend(5, 7, 10) == "warming"
-
-    def test_cooling(self):
-        """30d rate (1) < 0.5 * older rate ((10-1)/2 = 4.5) → cooling."""
-        assert _compute_trend(1, 5, 10) == "cooling"
-
-    def test_stable(self):
-        """30d rate (3) is between bounds of older rate ((9-3)/2 = 3) → stable."""
-        assert _compute_trend(3, 6, 9) == "stable"
-
-    def test_only_30d_activity(self):
-        assert _compute_trend(3, 0, 0) == "warming"
-
-    def test_equal_across_windows(self):
-        assert _compute_trend(3, 3, 3) == "warming"
+    @pytest.mark.parametrize(
+        "args, expected",
+        [
+            ((0, 0, 0), "dormant"),
+            ((5, 0, 0), "warming"),
+            ((5, 7, 10), "warming"),
+            ((1, 5, 10), "cooling"),
+            ((3, 6, 9), "stable"),
+            ((3, 0, 0), "warming"),
+            ((3, 3, 3), "warming"),
+        ],
+        ids=[
+            "all_zero_dormant",
+            "warming_from_zero",
+            "warming_high_30d",  # 30d rate (5) > 1.5 * older rate ((10-5)/2 = 2.5)
+            "cooling",  # 30d rate (1) < 0.5 * older rate ((10-1)/2 = 4.5)
+            "stable",  # 30d rate (3) between bounds of older rate ((9-3)/2 = 3)
+            "only_30d_activity",
+            "equal_across_windows",
+        ],
+    )
+    def test_compute_trend(self, args, expected):
+        assert _compute_trend(*args) == expected
 
 
 # ── Overall score integration ──────────────────────────────────────
@@ -357,7 +263,7 @@ class TestComputeTrend:
 class TestOverallScore:
     def test_perfect_score(self):
         """All metrics maxed out → high score."""
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=NOW,
             interactions_30d=15,
             interactions_60d=30,
@@ -366,22 +272,18 @@ class TestOverallScore:
             wins=10,
             total_interactions=20,
             distinct_channels=4,
-            now=NOW,
         )
         assert result["relationship_score"] >= 80
 
     def test_worst_score(self):
         """All metrics zeroed → zero score."""
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=None,
             interactions_30d=0,
             interactions_60d=0,
             interactions_90d=0,
-            avg_response_hours=None,
-            wins=0,
             total_interactions=0,
             distinct_channels=0,
-            now=NOW,
         )
         # responsiveness defaults to 50, so score won't be exactly 0
         assert result["relationship_score"] <= 15
@@ -391,16 +293,11 @@ class TestOverallScore:
         assert abs(total - 1.0) < 0.001
 
     def test_returns_all_fields(self):
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=NOW,
-            interactions_30d=5,
-            interactions_60d=10,
-            interactions_90d=15,
             avg_response_hours=4.0,
             wins=2,
-            total_interactions=15,
             distinct_channels=2,
-            now=NOW,
         )
         assert "relationship_score" in result
         assert "recency_score" in result
@@ -411,15 +308,13 @@ class TestOverallScore:
         assert "activity_trend" in result
 
     def test_score_bounded_0_100(self):
-        result = compute_contact_relationship_score(
+        result = score(
             last_interaction_at=NOW - timedelta(days=500),
             interactions_30d=0,
             interactions_60d=0,
             interactions_90d=0,
             avg_response_hours=500.0,
-            wins=0,
             total_interactions=0,
             distinct_channels=0,
-            now=NOW,
         )
         assert 0 <= result["relationship_score"] <= 100

--- a/tests/test_contact_status_compute.py
+++ b/tests/test_contact_status_compute.py
@@ -14,6 +14,8 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
+
 from app.models import ActivityLog
 from app.models.crm import Company, CustomerSite, SiteContact
 
@@ -74,66 +76,26 @@ class TestContactStatusCompute:
             finally:
                 loop.close()
 
-    def test_active_contact(self, db_session, test_user):
-        """Contact with activity ≤7 days ago → 'active'."""
+    @pytest.mark.parametrize(
+        ("name", "status", "created_days_ago", "activity_days_ago", "expected"),
+        [
+            pytest.param("Active Person", "new", 0, 3, "active", id="active_contact"),
+            pytest.param("Quiet Person", "new", 0, 45, "quiet", id="quiet_contact"),
+            pytest.param("Gone Person", "new", 0, 120, "inactive", id="inactive_contact"),
+            pytest.param("Champion Person", "champion", 0, 120, "champion", id="champion_never_downgraded"),
+            pytest.param("New Person", "new", 5, None, "new", id="no_activity_new_stays_new"),
+            pytest.param("Old Person", "new", 120, None, "inactive", id="no_activity_old_goes_inactive"),
+        ],
+    )
+    def test_status_compute(self, db_session, test_user, name, status, created_days_ago, activity_days_ago, expected):
+        """The auto-compute job derives contact_status from recency, never downgrading
+        champions."""
         site = self._make_site(db_session)
-        sc = self._make_contact(db_session, site.id, "Active Person")
-        self._make_activity(db_session, test_user.id, sc.id, days_ago=3)
+        sc = self._make_contact(db_session, site.id, name, status=status, created_days_ago=created_days_ago)
+        if activity_days_ago is not None:
+            self._make_activity(db_session, test_user.id, sc.id, days_ago=activity_days_ago)
         db_session.commit()
 
         self._run_job(db_session)
         db_session.refresh(sc)
-        assert sc.contact_status == "active"
-
-    def test_quiet_contact(self, db_session, test_user):
-        """Contact with activity 30-90 days ago → 'quiet'."""
-        site = self._make_site(db_session)
-        sc = self._make_contact(db_session, site.id, "Quiet Person")
-        self._make_activity(db_session, test_user.id, sc.id, days_ago=45)
-        db_session.commit()
-
-        self._run_job(db_session)
-        db_session.refresh(sc)
-        assert sc.contact_status == "quiet"
-
-    def test_inactive_contact(self, db_session, test_user):
-        """Contact with activity >90 days ago → 'inactive'."""
-        site = self._make_site(db_session)
-        sc = self._make_contact(db_session, site.id, "Gone Person")
-        self._make_activity(db_session, test_user.id, sc.id, days_ago=120)
-        db_session.commit()
-
-        self._run_job(db_session)
-        db_session.refresh(sc)
-        assert sc.contact_status == "inactive"
-
-    def test_champion_never_downgraded(self, db_session, test_user):
-        """Champion status is never changed by the auto-compute job."""
-        site = self._make_site(db_session)
-        sc = self._make_contact(db_session, site.id, "Champion Person", status="champion")
-        self._make_activity(db_session, test_user.id, sc.id, days_ago=120)
-        db_session.commit()
-
-        self._run_job(db_session)
-        db_session.refresh(sc)
-        assert sc.contact_status == "champion"
-
-    def test_no_activity_new_stays_new(self, db_session):
-        """Contact created recently with no activity stays 'new'."""
-        site = self._make_site(db_session)
-        sc = self._make_contact(db_session, site.id, "New Person", created_days_ago=5)
-        db_session.commit()
-
-        self._run_job(db_session)
-        db_session.refresh(sc)
-        assert sc.contact_status == "new"
-
-    def test_no_activity_old_goes_inactive(self, db_session):
-        """Contact created >90 days ago with no activity → 'inactive'."""
-        site = self._make_site(db_session)
-        sc = self._make_contact(db_session, site.id, "Old Person", created_days_ago=120)
-        db_session.commit()
-
-        self._run_job(db_session)
-        db_session.refresh(sc)
-        assert sc.contact_status == "inactive"
+        assert sc.contact_status == expected

--- a/tests/test_cph_hooks.py
+++ b/tests/test_cph_hooks.py
@@ -78,6 +78,46 @@ def _setup_quote_scenario(db: Session, user: User, company: Company, site: Custo
     return req, quote, card
 
 
+def _setup_offer_scenario(
+    db: Session,
+    user: User,
+    site: CustomerSite,
+    *,
+    req_name: str,
+    vendor_name: str,
+    mpn: str,
+    unit_price: float,
+    qty_available: int,
+    status: str = "active",
+    with_card: bool = True,
+    req_has_site: bool = True,
+) -> Offer:
+    """Create a requisition + offer, returning the offer."""
+    card = _make_card(db, mpn) if with_card else None
+    req = Requisition(
+        name=req_name,
+        customer_site_id=site.id if req_has_site else None,
+        status="active",
+        created_by=user.id,
+    )
+    db.add(req)
+    db.flush()
+    offer = Offer(
+        requisition_id=req.id,
+        vendor_name=vendor_name,
+        mpn=mpn,
+        material_card_id=card.id if card else None,
+        qty_available=qty_available,
+        unit_price=unit_price,
+        entered_by_id=user.id,
+        status=status,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(offer)
+    db.commit()
+    return offer
+
+
 # ── Quote Won → CPH Hook ───────────────────────────────────────────
 
 
@@ -225,28 +265,16 @@ class TestQuoteWonCPHHook:
 class TestOfferWonCPHHook:
     def test_offer_won_creates_cph(self, client, db_session, test_user, test_company, test_customer_site):
         """Updating offer status to 'won' creates a CPH record."""
-        card = _make_card(db_session, "LM7805")
-        req = Requisition(
-            name="REQ-OFFER-WON",
-            customer_site_id=test_customer_site.id,
-            status="active",
-            created_by=test_user.id,
-        )
-        db_session.add(req)
-        db_session.flush()
-        offer = Offer(
-            requisition_id=req.id,
+        offer = _setup_offer_scenario(
+            db_session,
+            test_user,
+            test_customer_site,
+            req_name="REQ-OFFER-WON",
             vendor_name="Arrow",
             mpn="LM7805",
-            material_card_id=card.id,
-            qty_available=500,
             unit_price=0.75,
-            entered_by_id=test_user.id,
-            status="active",
-            created_at=datetime.now(timezone.utc),
+            qty_available=500,
         )
-        db_session.add(offer)
-        db_session.commit()
 
         resp = client.put(
             f"/api/offers/{offer.id}",
@@ -258,7 +286,7 @@ class TestOfferWonCPHHook:
             db_session.query(CustomerPartHistory)
             .filter_by(
                 company_id=test_company.id,
-                material_card_id=card.id,
+                material_card_id=offer.material_card_id,
                 source="avail_offer",
             )
             .first()
@@ -270,28 +298,16 @@ class TestOfferWonCPHHook:
 
     def test_offer_status_active_no_cph(self, client, db_session, test_user, test_company, test_customer_site):
         """Updating offer to non-won status doesn't create CPH."""
-        card = _make_card(db_session, "SN7400")
-        req = Requisition(
-            name="REQ-OFFER-ACTIVE",
-            customer_site_id=test_customer_site.id,
-            status="active",
-            created_by=test_user.id,
-        )
-        db_session.add(req)
-        db_session.flush()
-        offer = Offer(
-            requisition_id=req.id,
+        offer = _setup_offer_scenario(
+            db_session,
+            test_user,
+            test_customer_site,
+            req_name="REQ-OFFER-ACTIVE",
             vendor_name="Mouser",
             mpn="SN7400",
-            material_card_id=card.id,
-            qty_available=100,
             unit_price=0.30,
-            entered_by_id=test_user.id,
-            status="active",
-            created_at=datetime.now(timezone.utc),
+            qty_available=100,
         )
-        db_session.add(offer)
-        db_session.commit()
 
         resp = client.put(
             f"/api/offers/{offer.id}",
@@ -301,35 +317,24 @@ class TestOfferWonCPHHook:
 
         cph_count = (
             db_session.query(CustomerPartHistory)
-            .filter_by(company_id=test_company.id, material_card_id=card.id)
+            .filter_by(company_id=test_company.id, material_card_id=offer.material_card_id)
             .count()
         )
         assert cph_count == 0
 
     def test_offer_already_won_no_double_cph(self, client, db_session, test_user, test_company, test_customer_site):
         """Updating an already-won offer doesn't trigger CPH again."""
-        card = _make_card(db_session, "NE555")
-        req = Requisition(
-            name="REQ-OFFER-ALREADY",
-            customer_site_id=test_customer_site.id,
-            status="active",
-            created_by=test_user.id,
-        )
-        db_session.add(req)
-        db_session.flush()
-        offer = Offer(
-            requisition_id=req.id,
+        offer = _setup_offer_scenario(
+            db_session,
+            test_user,
+            test_customer_site,
+            req_name="REQ-OFFER-ALREADY",
             vendor_name="DigiKey",
             mpn="NE555",
-            material_card_id=card.id,
-            qty_available=200,
             unit_price=0.40,
-            entered_by_id=test_user.id,
+            qty_available=200,
             status="won",
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(offer)
-        db_session.commit()
 
         # Update notes on already-won offer
         resp = client.put(
@@ -340,33 +345,24 @@ class TestOfferWonCPHHook:
 
         cph_count = (
             db_session.query(CustomerPartHistory)
-            .filter_by(company_id=test_company.id, material_card_id=card.id)
+            .filter_by(company_id=test_company.id, material_card_id=offer.material_card_id)
             .count()
         )
         assert cph_count == 0
 
     def test_offer_won_no_card_skipped(self, client, db_session, test_user, test_customer_site):
         """Offer without material_card_id doesn't trigger CPH."""
-        req = Requisition(
-            name="REQ-NOCARD-OFFER",
-            customer_site_id=test_customer_site.id,
-            status="active",
-            created_by=test_user.id,
-        )
-        db_session.add(req)
-        db_session.flush()
-        offer = Offer(
-            requisition_id=req.id,
+        offer = _setup_offer_scenario(
+            db_session,
+            test_user,
+            test_customer_site,
+            req_name="REQ-NOCARD-OFFER",
             vendor_name="Arrow",
             mpn="NOCARD",
-            qty_available=100,
             unit_price=1.00,
-            entered_by_id=test_user.id,
-            status="active",
-            created_at=datetime.now(timezone.utc),
+            qty_available=100,
+            with_card=False,
         )
-        db_session.add(offer)
-        db_session.commit()
 
         resp = client.put(
             f"/api/offers/{offer.id}",
@@ -374,29 +370,19 @@ class TestOfferWonCPHHook:
         )
         assert resp.status_code == 200
 
-    def test_offer_won_no_site_no_error(self, client, db_session, test_user):
+    def test_offer_won_no_site_no_error(self, client, db_session, test_user, test_customer_site):
         """Offer won with no customer site doesn't error."""
-        card = _make_card(db_session, "XTAL1")
-        req = Requisition(
-            name="REQ-NOSITE-OFFER",
-            status="active",
-            created_by=test_user.id,
-        )
-        db_session.add(req)
-        db_session.flush()
-        offer = Offer(
-            requisition_id=req.id,
+        offer = _setup_offer_scenario(
+            db_session,
+            test_user,
+            test_customer_site,
+            req_name="REQ-NOSITE-OFFER",
             vendor_name="Arrow",
             mpn="XTAL1",
-            material_card_id=card.id,
-            qty_available=50,
             unit_price=2.00,
-            entered_by_id=test_user.id,
-            status="active",
-            created_at=datetime.now(timezone.utc),
+            qty_available=50,
+            req_has_site=False,
         )
-        db_session.add(offer)
-        db_session.commit()
 
         resp = client.put(
             f"/api/offers/{offer.id}",

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -6,6 +6,7 @@ Depends on: app.routers.crm.views
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -23,32 +24,25 @@ class TestCRMShell:
         assert resp.status_code == 200
         assert "text/html" in resp.headers.get("content-type", "")
 
-    def test_crm_shell_has_customers_tab(self, client: TestClient):
-        """Shell renders Customers tab button."""
+    @pytest.mark.parametrize(
+        "snippet",
+        [
+            pytest.param("Customers", id="customers_tab"),
+            pytest.param("Vendors", id="vendors_tab"),
+            pytest.param('id="crm-tab-content"', id="tab_content_container"),
+        ],
+    )
+    def test_crm_shell_renders_element(self, client: TestClient, snippet: str):
+        """Shell renders the tab buttons and the #crm-tab-content container."""
         resp = client.get("/v2/partials/crm/shell")
-        assert "Customers" in resp.text
-
-    def test_crm_shell_has_vendors_tab(self, client: TestClient):
-        """Shell renders Vendors tab button."""
-        resp = client.get("/v2/partials/crm/shell")
-        assert "Vendors" in resp.text
-
-    def test_crm_shell_has_tab_content_container(self, client: TestClient):
-        """Shell renders #crm-tab-content container."""
-        resp = client.get("/v2/partials/crm/shell")
-        assert 'id="crm-tab-content"' in resp.text
+        assert snippet in resp.text
 
 
 class TestCRMFullPage:
     """Test CRM full-page route via v2_page dispatcher."""
 
     def test_v2_crm_returns_200(self, client: TestClient):
-        """GET /v2/crm returns 200."""
-        resp = client.get("/v2/crm")
-        assert resp.status_code == 200
-
-    def test_v2_crm_loads_shell_partial(self, client: TestClient):
-        """GET /v2/crm loads the CRM shell partial."""
+        """GET /v2/crm returns 200 (loads the CRM shell partial)."""
         resp = client.get("/v2/crm")
         assert resp.status_code == 200
 
@@ -56,17 +50,26 @@ class TestCRMFullPage:
 class TestVendorListEmbedding:
     """Test vendor list can be embedded in CRM shell."""
 
-    def test_vendor_list_with_custom_target(self, client: TestClient):
-        """Vendor list respects hx_target query parameter."""
-        resp = client.get("/v2/partials/vendors?hx_target=%23crm-tab-content")
+    @pytest.mark.parametrize(
+        ("url", "expected_target"),
+        [
+            pytest.param(
+                "/v2/partials/vendors?hx_target=%23crm-tab-content",
+                'hx-target="#crm-tab-content"',
+                id="custom_target",
+            ),
+            pytest.param(
+                "/v2/partials/vendors",
+                'hx-target="#main-content"',
+                id="default_target",
+            ),
+        ],
+    )
+    def test_vendor_list_target(self, client: TestClient, url: str, expected_target: str):
+        """Vendor list respects hx_target override, defaulting to #main-content."""
+        resp = client.get(url)
         assert resp.status_code == 200
-        assert 'hx-target="#crm-tab-content"' in resp.text
-
-    def test_vendor_list_default_target(self, client: TestClient):
-        """Vendor list defaults to #main-content when no override."""
-        resp = client.get("/v2/partials/vendors")
-        assert resp.status_code == 200
-        assert 'hx-target="#main-content"' in resp.text
+        assert expected_target in resp.text
 
 
 class TestCustomerWorkspace:
@@ -418,57 +421,36 @@ class TestCustomerStaleness:
         assert resp.status_code == 200
         assert "rounded-full" in resp.text
 
-    def test_overdue_company_shows_rose(self, client: TestClient, db_session: Session, test_user: User):
-        """Company with 30+ day old activity shows rose indicator."""
+    @pytest.mark.parametrize(
+        ("name", "days_ago", "expected_class"),
+        [
+            pytest.param("Stale Corp", 45, "bg-rose-500", id="overdue_shows_rose"),
+            pytest.param("New Corp", None, "bg-brand-300", id="new_shows_brand"),
+            pytest.param("DueSoon Corp", 20, "bg-amber-400", id="due_soon_shows_amber"),
+            pytest.param("Recent Corp", 5, "bg-emerald-400", id="recent_shows_emerald"),
+        ],
+    )
+    def test_staleness_tier_indicator(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: User,
+        name: str,
+        days_ago: int | None,
+        expected_class: str,
+    ):
+        """Each staleness tier renders its indicator color.
 
-        c = Company(
-            name="Stale Corp",
-            is_active=True,
-            last_activity_at=datetime.now(timezone.utc) - timedelta(days=45),
-        )
+        overdue (30+d) → rose, never-contacted → brand, due-soon (14-29d) → amber,
+        recent (<14d) → emerald.
+        """
+        last_activity = None if days_ago is None else datetime.now(timezone.utc) - timedelta(days=days_ago)
+        c = Company(name=name, is_active=True, last_activity_at=last_activity)
         db_session.add(c)
         db_session.commit()
 
         resp = client.get("/v2/partials/customers")
-        assert "bg-rose-500" in resp.text
-
-    def test_new_company_shows_brand(self, client: TestClient, db_session: Session, test_user: User):
-        """Company with no activity shows brand indicator."""
-
-        c = Company(name="New Corp", is_active=True, last_activity_at=None)
-        db_session.add(c)
-        db_session.commit()
-
-        resp = client.get("/v2/partials/customers")
-        assert "bg-brand-300" in resp.text
-
-    def test_due_soon_company_shows_amber(self, client: TestClient, db_session: Session, test_user: User):
-        """Company with 14-29 day old activity shows amber indicator."""
-
-        c = Company(
-            name="DueSoon Corp",
-            is_active=True,
-            last_activity_at=datetime.now(timezone.utc) - timedelta(days=20),
-        )
-        db_session.add(c)
-        db_session.commit()
-
-        resp = client.get("/v2/partials/customers")
-        assert "bg-amber-400" in resp.text
-
-    def test_recent_company_shows_emerald(self, client: TestClient, db_session: Session, test_user: User):
-        """Company with <14 day old activity shows emerald indicator."""
-
-        c = Company(
-            name="Recent Corp",
-            is_active=True,
-            last_activity_at=datetime.now(timezone.utc) - timedelta(days=5),
-        )
-        db_session.add(c)
-        db_session.commit()
-
-        resp = client.get("/v2/partials/customers")
-        assert "bg-emerald-400" in resp.text
+        assert expected_class in resp.text
 
     def test_default_sort_is_staleness(self, client: TestClient, db_session: Session, test_user: User):
         """Customer list sorts by staleness (nulls first, then oldest)."""

--- a/tests/test_email_intelligence_phase2.py
+++ b/tests/test_email_intelligence_phase2.py
@@ -16,6 +16,7 @@ import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from tests.conftest import engine  # noqa: F401
@@ -81,91 +82,81 @@ class TestEmailIntelligenceModel:
 
 
 class TestClassifyEmailAI:
-    def test_classify_email_offer(self):
-        """AI correctly classifies an offer email."""
+    @staticmethod
+    def _classify_with_mock(mock_return, subject, body, sender):
+        """Run classify_email_ai with claude_json mocked to mock_return."""
         from app.services.email_intelligence_service import classify_email_ai
 
-        mock_result = {
-            "classification": "offer",
-            "confidence": 0.92,
-            "parts_mentioned": ["LM317T"],
-            "has_pricing": True,
-            "brands_detected": ["TI"],
-            "commodities_detected": ["regulators"],
-        }
+        with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=mock_return):
+            return asyncio.get_event_loop().run_until_complete(classify_email_ai(subject, body, sender))
 
-        with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=mock_result):
-            result = asyncio.get_event_loop().run_until_complete(
-                classify_email_ai("Quote Response", "LM317T available at $0.50", "vendor@test.com")
-            )
-
-        assert result["classification"] == "offer"
-        assert result["confidence"] == 0.92
-
-    def test_classify_email_ooo(self):
-        """AI classifies out-of-office emails."""
-        from app.services.email_intelligence_service import classify_email_ai
-
-        mock_result = {
-            "classification": "ooo",
-            "confidence": 0.95,
-            "parts_mentioned": [],
-            "has_pricing": False,
-            "brands_detected": [],
-            "commodities_detected": [],
-        }
-
-        with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=mock_result):
-            result = asyncio.get_event_loop().run_until_complete(
-                classify_email_ai("Out of Office", "I will be out until March 1", "person@test.com")
-            )
-
-        assert result["classification"] == "ooo"
-
-    def test_classify_email_invalid_class_defaults_general(self):
-        """Invalid classification string defaults to 'general'."""
-        from app.services.email_intelligence_service import classify_email_ai
-
-        mock_result = {
-            "classification": "INVALID",
-            "confidence": 0.8,
-            "parts_mentioned": [],
-            "has_pricing": False,
-            "brands_detected": [],
-            "commodities_detected": [],
-        }
-
-        with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=mock_result):
-            result = asyncio.get_event_loop().run_until_complete(classify_email_ai("Test", "Body", "a@b.com"))
-
-        assert result["classification"] == "general"
+    @pytest.mark.parametrize(
+        ("mock_return", "args", "expected"),
+        [
+            pytest.param(
+                {
+                    "classification": "offer",
+                    "confidence": 0.92,
+                    "parts_mentioned": ["LM317T"],
+                    "has_pricing": True,
+                    "brands_detected": ["TI"],
+                    "commodities_detected": ["regulators"],
+                },
+                ("Quote Response", "LM317T available at $0.50", "vendor@test.com"),
+                {"classification": "offer", "confidence": 0.92},
+                id="offer",
+            ),
+            pytest.param(
+                {
+                    "classification": "ooo",
+                    "confidence": 0.95,
+                    "parts_mentioned": [],
+                    "has_pricing": False,
+                    "brands_detected": [],
+                    "commodities_detected": [],
+                },
+                ("Out of Office", "I will be out until March 1", "person@test.com"),
+                {"classification": "ooo"},
+                id="ooo",
+            ),
+            pytest.param(
+                {
+                    "classification": "INVALID",
+                    "confidence": 0.8,
+                    "parts_mentioned": [],
+                    "has_pricing": False,
+                    "brands_detected": [],
+                    "commodities_detected": [],
+                },
+                ("Test", "Body", "a@b.com"),
+                {"classification": "general"},
+                id="invalid_class_defaults_general",
+            ),
+            pytest.param(
+                {
+                    "classification": "offer",
+                    "confidence": 1.5,
+                    "parts_mentioned": [],
+                    "has_pricing": False,
+                    "brands_detected": [],
+                    "commodities_detected": [],
+                },
+                ("Test", "Body", "a@b.com"),
+                {"confidence": 1.0},
+                id="confidence_clamped",
+            ),
+        ],
+    )
+    def test_classify_email_success(self, mock_return, args, expected):
+        """AI classification maps/clamps fields from Claude's response."""
+        result = self._classify_with_mock(mock_return, *args)
+        for key, value in expected.items():
+            assert result[key] == value
 
     def test_classify_email_claude_failure(self):
         """Returns None when Claude API fails."""
-        from app.services.email_intelligence_service import classify_email_ai
-
-        with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=None):
-            result = asyncio.get_event_loop().run_until_complete(classify_email_ai("Test", "Body", "a@b.com"))
-
+        result = self._classify_with_mock(None, "Test", "Body", "a@b.com")
         assert result is None
-
-    def test_classify_email_confidence_clamped(self):
-        """Confidence values are clamped to 0.0-1.0."""
-        from app.services.email_intelligence_service import classify_email_ai
-
-        mock_result = {
-            "classification": "offer",
-            "confidence": 1.5,
-            "parts_mentioned": [],
-            "has_pricing": False,
-            "brands_detected": [],
-            "commodities_detected": [],
-        }
-
-        with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=mock_result):
-            result = asyncio.get_event_loop().run_until_complete(classify_email_ai("Test", "Body", "a@b.com"))
-
-        assert result["confidence"] == 1.0
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_email_intelligence_phase3.py
+++ b/tests/test_email_intelligence_phase3.py
@@ -15,6 +15,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from tests.conftest import engine  # noqa: F401
 
+
+def make_graph_client(method: str, **async_mock_kwargs) -> MagicMock:
+    """Build a mock GraphClient with `method` as an AsyncMock
+    (return_value/side_effect)."""
+    gc = MagicMock()
+    setattr(gc, method, AsyncMock(**async_mock_kwargs))
+    return gc
+
+
 # ═══════════════════════════════════════════════════════════════════════
 #  3A: Mailbox Settings
 # ═══════════════════════════════════════════════════════════════════════
@@ -25,8 +34,8 @@ class TestMailboxIntelligence:
         """Fetches timezone and working hours from Graph and stores on User."""
         from app.services.mailbox_intelligence import fetch_and_store_mailbox_settings
 
-        mock_gc = MagicMock()
-        mock_gc.get_json = AsyncMock(
+        mock_gc = make_graph_client(
+            "get_json",
             return_value={
                 "timeZone": "Eastern Standard Time",
                 "workingHours": {
@@ -38,7 +47,7 @@ class TestMailboxIntelligence:
                 "automaticRepliesSetting": {
                     "status": "disabled",
                 },
-            }
+            },
         )
 
         with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
@@ -56,8 +65,7 @@ class TestMailboxIntelligence:
         """Returns None on Graph API failure."""
         from app.services.mailbox_intelligence import fetch_and_store_mailbox_settings
 
-        mock_gc = MagicMock()
-        mock_gc.get_json = AsyncMock(side_effect=Exception("Graph API error"))
+        mock_gc = make_graph_client("get_json", side_effect=Exception("Graph API error"))
 
         with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
             result = asyncio.get_event_loop().run_until_complete(
@@ -70,8 +78,7 @@ class TestMailboxIntelligence:
         """Returns None on empty/error response."""
         from app.services.mailbox_intelligence import fetch_and_store_mailbox_settings
 
-        mock_gc = MagicMock()
-        mock_gc.get_json = AsyncMock(return_value={"error": {"code": "ErrorAccessDenied"}})
+        mock_gc = make_graph_client("get_json", return_value={"error": {"code": "ErrorAccessDenied"}})
 
         with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
             result = asyncio.get_event_loop().run_until_complete(
@@ -154,8 +161,8 @@ class TestCalendarIntelligence:
         """Calendar scan detects meetings with external (vendor) attendees."""
         from app.services.calendar_intelligence import scan_calendar_events
 
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(
+        mock_gc = make_graph_client(
+            "get_all_pages",
             return_value=[
                 {
                     "subject": "Quarterly Business Review",
@@ -174,7 +181,7 @@ class TestCalendarIntelligence:
                     "location": {"displayName": "Zoom"},
                     "organizer": {"emailAddress": {"address": "buyer@trioscs.com"}},
                 },
-            ]
+            ],
         )
 
         with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
@@ -190,8 +197,8 @@ class TestCalendarIntelligence:
         """Calendar scan detects trade show events by keyword."""
         from app.services.calendar_intelligence import scan_calendar_events
 
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(
+        mock_gc = make_graph_client(
+            "get_all_pages",
             return_value=[
                 {
                     "subject": "Electronica 2026 Munich",
@@ -201,7 +208,7 @@ class TestCalendarIntelligence:
                     "location": {"displayName": "Messe München"},
                     "organizer": {},
                 },
-            ]
+            ],
         )
 
         with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
@@ -215,8 +222,8 @@ class TestCalendarIntelligence:
         """Internal meetings (only own-domain attendees) are not logged."""
         from app.services.calendar_intelligence import scan_calendar_events
 
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(
+        mock_gc = make_graph_client(
+            "get_all_pages",
             return_value=[
                 {
                     "subject": "Team Standup",
@@ -228,7 +235,7 @@ class TestCalendarIntelligence:
                     "location": {},
                     "organizer": {},
                 },
-            ]
+            ],
         )
 
         with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
@@ -243,8 +250,7 @@ class TestCalendarIntelligence:
         """Returns empty result on Graph API failure."""
         from app.services.calendar_intelligence import scan_calendar_events
 
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(side_effect=Exception("Calendar API error"))
+        mock_gc = make_graph_client("get_all_pages", side_effect=Exception("Calendar API error"))
 
         with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
             result = asyncio.get_event_loop().run_until_complete(
@@ -268,8 +274,7 @@ class TestCalendarIntelligence:
             "organizer": {},
         }
 
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(return_value=[event])
+        mock_gc = make_graph_client("get_all_pages", return_value=[event])
 
         with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
             # First scan

--- a/tests/test_enrich_batch.py
+++ b/tests/test_enrich_batch.py
@@ -84,22 +84,23 @@ class TestBuildPrompt:
 # ── _build_batch_requests tests ───────────────────────────────────────
 
 
+def _cards(count):
+    return [{"id": i, "display_mpn": f"MPN{i}", "manufacturer": None, "description": None} for i in range(count)]
+
+
 class TestBuildBatchRequests:
     def test_single_batch(self):
-        cards = [{"id": i, "display_mpn": f"MPN{i}", "manufacturer": None, "description": None} for i in range(10)]
-        requests = _build_batch_requests(cards)
+        requests = _build_batch_requests(_cards(10))
         assert len(requests) == 1
         assert requests[0]["model_tier"] == "smart"
 
     def test_multiple_batches(self):
-        cards = [{"id": i, "display_mpn": f"MPN{i}", "manufacturer": None, "description": None} for i in range(120)]
-        requests = _build_batch_requests(cards)
+        requests = _build_batch_requests(_cards(120))
         # 120 cards / 50 per batch = 3 batches
         assert len(requests) == 3
 
     def test_custom_ids_unique(self):
-        cards = [{"id": i, "display_mpn": f"MPN{i}", "manufacturer": None, "description": None} for i in range(120)]
-        requests = _build_batch_requests(cards)
+        requests = _build_batch_requests(_cards(120))
         custom_ids = [r["custom_id"] for r in requests]
         assert len(custom_ids) == len(set(custom_ids))
 

--- a/tests/test_enrichment_service.py
+++ b/tests/test_enrichment_service.py
@@ -70,6 +70,55 @@ def _make_material_tag(db, card_id, tag_id, source="ai_classified", confidence=0
     return mt
 
 
+def _connector_config(name="digikey", module=None, klass=None, creds=None, confidence=0.95):
+    """Build a connector config dict for _try_connector_config."""
+    defaults = {
+        "digikey": ("app.connectors.digikey", "DigiKeyConnector"),
+        "mouser": ("app.connectors.mouser", "MouserConnector"),
+        "nexar": ("app.connectors.sources", "NexarConnector"),
+    }
+    default_module, default_class = defaults[name]
+    return {
+        "name": name,
+        "module": module or default_module,
+        "class": klass or default_class,
+        "creds": creds or [(name, f"{name.upper()}_API_KEY")],
+        "confidence": confidence,
+    }
+
+
+def _patch_connector(config, *, search_return=None, search_side_effect=None):
+    """Context-manager group that patches credentials + importlib so
+    _try_connector_config instantiates a mock connector whose .search() behaves as
+    specified."""
+    mock_connector = MagicMock()
+    mock_connector.search = AsyncMock(return_value=search_return, side_effect=search_side_effect)
+    mock_module = MagicMock()
+    getattr(mock_module, config["class"]).return_value = mock_connector
+    return (
+        patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
+        patch("app.services.enrichment.importlib.import_module", return_value=mock_module),
+    )
+
+
+def _nexar_query_result(manufacturer_name):
+    """Build a Nexar supSearchMpn payload returning a single part for the given
+    manufacturer."""
+    return {"data": {"supSearchMpn": {"results": [{"part": {"manufacturer": {"name": manufacturer_name}}}]}}}
+
+
+def _patch_nexar(*, query_return=None, query_side_effect=None):
+    """Context-manager group that patches credentials + NexarConnector with a mock whose
+    _run_query behaves as specified."""
+    mock_connector = MagicMock()
+    mock_connector.AGGREGATE_QUERY = "query"
+    mock_connector._run_query = AsyncMock(return_value=query_return, side_effect=query_side_effect)
+    return (
+        patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
+        patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════
 #  _try_connector_config
 # ═══════════════════════════════════════════════════════════════════════
@@ -81,13 +130,9 @@ class TestTryConnectorConfig:
         """No credentials => returns None."""
         from app.services.enrichment import _try_connector_config
 
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID"), ("digikey", "DIGIKEY_CLIENT_SECRET")],
-            "confidence": 0.95,
-        }
+        config = _connector_config(
+            "digikey", creds=[("digikey", "DIGIKEY_CLIENT_ID"), ("digikey", "DIGIKEY_CLIENT_SECRET")]
+        )
         with patch("app.services.enrichment.get_credential_cached", return_value=None):
             result = await _try_connector_config(config, "LM317T")
         assert result is None
@@ -97,26 +142,12 @@ class TestTryConnectorConfig:
         """Connector returns valid manufacturer data."""
         from app.services.enrichment import _try_connector_config
 
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
-        mock_connector = MagicMock()
-        mock_connector.search = AsyncMock(
-            return_value=[{"manufacturer": "Texas Instruments", "category": "Voltage Regulators"}]
+        config = _connector_config("digikey", creds=[("digikey", "DIGIKEY_CLIENT_ID")])
+        cred_patch, import_patch = _patch_connector(
+            config,
+            search_return=[{"manufacturer": "Texas Instruments", "category": "Voltage Regulators"}],
         )
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.services.enrichment.importlib.import_module") as mock_import,
-        ):
-            mock_module = MagicMock()
-            mock_module.DigiKeyConnector.return_value = mock_connector
-            mock_import.return_value = mock_module
-
+        with cred_patch, import_patch:
             result = await _try_connector_config(config, "LM317T")
 
         assert result is not None
@@ -126,163 +157,28 @@ class TestTryConnectorConfig:
         assert result["confidence"] == 0.95
 
     @pytest.mark.asyncio
-    async def test_ignored_manufacturer_skipped(self):
-        """Manufacturer in _IGNORED_MANUFACTURERS returns None."""
+    @pytest.mark.parametrize(
+        ("connector_name", "search_return", "search_side_effect"),
+        [
+            ("mouser", [{"manufacturer": "Unknown", "category": "Test"}], None),  # ignored manufacturer
+            ("mouser", [], None),  # empty results
+            ("digikey", None, asyncio.TimeoutError()),  # timeout
+            ("digikey", None, Exception("401 Unauthorized")),  # auth error
+            ("digikey", None, Exception("429 rate limited")),  # rate limit
+            ("digikey", None, Exception("Network error")),  # generic error
+        ],
+        ids=["ignored_manufacturer", "empty_results", "timeout", "auth_error", "rate_limit", "generic_error"],
+    )
+    async def test_returns_none_on_bad_search(self, connector_name, search_return, search_side_effect):
+        """Connector search yielding no usable data (ignored maker, empty, or error) =>
+        None."""
         from app.services.enrichment import _try_connector_config
 
-        config = {
-            "name": "mouser",
-            "module": "app.connectors.mouser",
-            "class": "MouserConnector",
-            "creds": [("mouser", "MOUSER_API_KEY")],
-            "confidence": 0.95,
-        }
-        mock_connector = MagicMock()
-        mock_connector.search = AsyncMock(return_value=[{"manufacturer": "Unknown", "category": "Test"}])
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.services.enrichment.importlib.import_module") as mock_import,
-        ):
-            mock_module = MagicMock()
-            mock_module.MouserConnector.return_value = mock_connector
-            mock_import.return_value = mock_module
-
-            result = await _try_connector_config(config, "LM317T")
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_empty_results_returns_none(self):
-        """Connector returns empty results."""
-        from app.services.enrichment import _try_connector_config
-
-        config = {
-            "name": "mouser",
-            "module": "app.connectors.mouser",
-            "class": "MouserConnector",
-            "creds": [("mouser", "MOUSER_API_KEY")],
-            "confidence": 0.95,
-        }
-        mock_connector = MagicMock()
-        mock_connector.search = AsyncMock(return_value=[])
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.services.enrichment.importlib.import_module") as mock_import,
-        ):
-            mock_module = MagicMock()
-            mock_module.MouserConnector.return_value = mock_connector
-            mock_import.return_value = mock_module
-
-            result = await _try_connector_config(config, "LM317T")
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_timeout_returns_none(self):
-        """Connector times out."""
-        from app.services.enrichment import _try_connector_config
-
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
-        mock_connector = MagicMock()
-        mock_connector.search = AsyncMock(side_effect=asyncio.TimeoutError())
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.services.enrichment.importlib.import_module") as mock_import,
-        ):
-            mock_module = MagicMock()
-            mock_module.DigiKeyConnector.return_value = mock_connector
-            mock_import.return_value = mock_module
-
-            result = await _try_connector_config(config, "LM317T")
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_auth_error_returns_none(self):
-        """Connector returns 401 auth error."""
-        from app.services.enrichment import _try_connector_config
-
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
-        mock_connector = MagicMock()
-        mock_connector.search = AsyncMock(side_effect=Exception("401 Unauthorized"))
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.services.enrichment.importlib.import_module") as mock_import,
-        ):
-            mock_module = MagicMock()
-            mock_module.DigiKeyConnector.return_value = mock_connector
-            mock_import.return_value = mock_module
-
-            result = await _try_connector_config(config, "LM317T")
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_rate_limit_error_returns_none(self):
-        """Connector returns 429 rate limit error."""
-        from app.services.enrichment import _try_connector_config
-
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
-        mock_connector = MagicMock()
-        mock_connector.search = AsyncMock(side_effect=Exception("429 rate limited"))
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.services.enrichment.importlib.import_module") as mock_import,
-        ):
-            mock_module = MagicMock()
-            mock_module.DigiKeyConnector.return_value = mock_connector
-            mock_import.return_value = mock_module
-
-            result = await _try_connector_config(config, "LM317T")
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_generic_error_returns_none(self):
-        """Connector raises generic error."""
-        from app.services.enrichment import _try_connector_config
-
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
-        mock_connector = MagicMock()
-        mock_connector.search = AsyncMock(side_effect=Exception("Network error"))
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.services.enrichment.importlib.import_module") as mock_import,
-        ):
-            mock_module = MagicMock()
-            mock_module.DigiKeyConnector.return_value = mock_connector
-            mock_import.return_value = mock_module
-
+        config = _connector_config(connector_name)
+        cred_patch, import_patch = _patch_connector(
+            config, search_return=search_return, search_side_effect=search_side_effect
+        )
+        with cred_patch, import_patch:
             result = await _try_connector_config(config, "LM317T")
 
         assert result is None
@@ -292,26 +188,12 @@ class TestTryConnectorConfig:
         """Uses description as category fallback when category is None."""
         from app.services.enrichment import _try_connector_config
 
-        config = {
-            "name": "mouser",
-            "module": "app.connectors.mouser",
-            "class": "MouserConnector",
-            "creds": [("mouser", "MOUSER_API_KEY")],
-            "confidence": 0.95,
-        }
-        mock_connector = MagicMock()
-        mock_connector.search = AsyncMock(
-            return_value=[{"manufacturer": "Microchip", "category": None, "description": "Microcontroller"}]
+        config = _connector_config("mouser")
+        cred_patch, import_patch = _patch_connector(
+            config,
+            search_return=[{"manufacturer": "Microchip", "category": None, "description": "Microcontroller"}],
         )
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.services.enrichment.importlib.import_module") as mock_import,
-        ):
-            mock_module = MagicMock()
-            mock_module.MouserConnector.return_value = mock_connector
-            mock_import.return_value = mock_module
-
+        with cred_patch, import_patch:
             result = await _try_connector_config(config, "PIC16F877A")
 
         assert result["category"] == "Microcontroller"
@@ -321,24 +203,9 @@ class TestTryConnectorConfig:
         """Returns None category when neither category nor description present."""
         from app.services.enrichment import _try_connector_config
 
-        config = {
-            "name": "mouser",
-            "module": "app.connectors.mouser",
-            "class": "MouserConnector",
-            "creds": [("mouser", "MOUSER_API_KEY")],
-            "confidence": 0.95,
-        }
-        mock_connector = MagicMock()
-        mock_connector.search = AsyncMock(return_value=[{"manufacturer": "STMicro"}])
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.services.enrichment.importlib.import_module") as mock_import,
-        ):
-            mock_module = MagicMock()
-            mock_module.MouserConnector.return_value = mock_connector
-            mock_import.return_value = mock_module
-
+        config = _connector_config("mouser")
+        cred_patch, import_patch = _patch_connector(config, search_return=[{"manufacturer": "STMicro"}])
+        with cred_patch, import_patch:
             result = await _try_connector_config(config, "STM32F4")
 
         assert result["manufacturer"] == "STMicro"
@@ -349,13 +216,7 @@ class TestTryConnectorConfig:
         """Config with 2 credentials checks both; second missing => None."""
         from app.services.enrichment import _try_connector_config
 
-        config = {
-            "name": "nexar",
-            "module": "app.connectors.sources",
-            "class": "NexarConnector",
-            "creds": [("nexar", "NEXAR_CLIENT_ID"), ("nexar", "NEXAR_CLIENT_SECRET")],
-            "confidence": 0.95,
-        }
+        config = _connector_config("nexar", creds=[("nexar", "NEXAR_CLIENT_ID"), ("nexar", "NEXAR_CLIENT_SECRET")])
 
         def mock_cred(source, env):
             if env == "NEXAR_CLIENT_ID":
@@ -927,18 +788,8 @@ class TestNexarBulkValidate:
         mt = _make_material_tag(db_session, card.id, tag.id, source="ai_classified", confidence=0.7)
         db_session.commit()
 
-        mock_connector = MagicMock()
-        mock_connector.AGGREGATE_QUERY = "query"
-        mock_connector._run_query = AsyncMock(
-            return_value={
-                "data": {"supSearchMpn": {"results": [{"part": {"manufacturer": {"name": "Texas Instruments"}}}]}}
-            }
-        )
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
-        ):
+        cred_patch, nexar_patch = _patch_nexar(query_return=_nexar_query_result("Texas Instruments"))
+        with cred_patch, nexar_patch:
             result = await nexar_bulk_validate(db_session, limit=100)
 
         db_session.refresh(mt)
@@ -955,17 +806,10 @@ class TestNexarBulkValidate:
         mt = _make_material_tag(db_session, card.id, tag.id, source="ai_classified", confidence=0.7)
         db_session.commit()
 
-        mock_connector = MagicMock()
-        mock_connector.AGGREGATE_QUERY = "query"
-        mock_connector._run_query = AsyncMock(
-            return_value={
-                "data": {"supSearchMpn": {"results": [{"part": {"manufacturer": {"name": "Microchip Technology"}}}]}}
-            }
-        )
-
+        cred_patch, nexar_patch = _patch_nexar(query_return=_nexar_query_result("Microchip Technology"))
         with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
+            cred_patch,
+            nexar_patch,
             patch("app.services.enrichment._apply_enrichment_to_card") as mock_apply,
         ):
             result = await nexar_bulk_validate(db_session, limit=100)
@@ -974,69 +818,27 @@ class TestNexarBulkValidate:
         mock_apply.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_nexar_no_results(self, db_session):
-        """Nexar returns empty results => no_result count incremented."""
+    @pytest.mark.parametrize(
+        ("brand", "query_return", "query_side_effect"),
+        [
+            ("SomeBrand", {"data": {"supSearchMpn": {"results": []}}}, None),  # empty results
+            ("Brand", None, Exception("API error")),  # query error
+            ("Brand", _nexar_query_result("Unknown"), None),  # ignored manufacturer
+        ],
+        ids=["empty_results", "query_error", "ignored_manufacturer"],
+    )
+    async def test_nexar_no_result_cases(self, db_session, brand, query_return, query_side_effect):
+        """Nexar yielding no usable manufacturer (empty, error, or ignored) =>
+        no_result."""
         from app.services.enrichment import nexar_bulk_validate
 
         card = _make_card(db_session)
-        tag = _make_brand_tag(db_session, "SomeBrand")
+        tag = _make_brand_tag(db_session, brand)
         _make_material_tag(db_session, card.id, tag.id, source="ai_classified", confidence=0.7)
         db_session.commit()
 
-        mock_connector = MagicMock()
-        mock_connector.AGGREGATE_QUERY = "query"
-        mock_connector._run_query = AsyncMock(return_value={"data": {"supSearchMpn": {"results": []}}})
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
-        ):
-            result = await nexar_bulk_validate(db_session, limit=100)
-
-        assert result["no_result"] == 1
-
-    @pytest.mark.asyncio
-    async def test_nexar_query_error(self, db_session):
-        """Nexar query raises exception => no_result."""
-        from app.services.enrichment import nexar_bulk_validate
-
-        card = _make_card(db_session)
-        tag = _make_brand_tag(db_session, "Brand")
-        _make_material_tag(db_session, card.id, tag.id, source="ai_classified", confidence=0.7)
-        db_session.commit()
-
-        mock_connector = MagicMock()
-        mock_connector.AGGREGATE_QUERY = "query"
-        mock_connector._run_query = AsyncMock(side_effect=Exception("API error"))
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
-        ):
-            result = await nexar_bulk_validate(db_session, limit=100)
-
-        assert result["no_result"] == 1
-
-    @pytest.mark.asyncio
-    async def test_nexar_ignored_manufacturer(self, db_session):
-        """Nexar returns ignored manufacturer ('unknown') => no_result."""
-        from app.services.enrichment import nexar_bulk_validate
-
-        card = _make_card(db_session)
-        tag = _make_brand_tag(db_session, "Brand")
-        _make_material_tag(db_session, card.id, tag.id, source="ai_classified", confidence=0.7)
-        db_session.commit()
-
-        mock_connector = MagicMock()
-        mock_connector.AGGREGATE_QUERY = "query"
-        mock_connector._run_query = AsyncMock(
-            return_value={"data": {"supSearchMpn": {"results": [{"part": {"manufacturer": {"name": "Unknown"}}}]}}}
-        )
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
-        ):
+        cred_patch, nexar_patch = _patch_nexar(query_return=query_return, query_side_effect=query_side_effect)
+        with cred_patch, nexar_patch:
             result = await nexar_bulk_validate(db_session, limit=100)
 
         assert result["no_result"] == 1
@@ -1077,17 +879,10 @@ class TestNexarBackfillUntagged:
         card = _make_card(db_session)
         db_session.commit()
 
-        mock_connector = MagicMock()
-        mock_connector.AGGREGATE_QUERY = "query"
-        mock_connector._run_query = AsyncMock(
-            return_value={
-                "data": {"supSearchMpn": {"results": [{"part": {"manufacturer": {"name": "Texas Instruments"}}}]}}
-            }
-        )
-
+        cred_patch, nexar_patch = _patch_nexar(query_return=_nexar_query_result("Texas Instruments"))
         with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
+            cred_patch,
+            nexar_patch,
             patch("app.services.enrichment._apply_enrichment_to_card") as mock_apply,
         ):
             result = await nexar_backfill_untagged(db_session, limit=100)
@@ -1096,63 +891,25 @@ class TestNexarBackfillUntagged:
         mock_apply.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_backfill_no_result(self, db_session):
-        """Nexar returns empty => no_result."""
+    @pytest.mark.parametrize(
+        ("query_return", "query_side_effect"),
+        [
+            ({"data": {"supSearchMpn": {"results": []}}}, None),  # empty results
+            (None, Exception("API failure")),  # query error
+            (_nexar_query_result("N/A"), None),  # ignored manufacturer
+        ],
+        ids=["empty_results", "error_handled", "ignored_manufacturer"],
+    )
+    async def test_backfill_no_result_cases(self, db_session, query_return, query_side_effect):
+        """Nexar yielding no usable manufacturer (empty, error, or ignored) =>
+        no_result."""
         from app.services.enrichment import nexar_backfill_untagged
 
         card = _make_card(db_session)
         db_session.commit()
 
-        mock_connector = MagicMock()
-        mock_connector.AGGREGATE_QUERY = "query"
-        mock_connector._run_query = AsyncMock(return_value={"data": {"supSearchMpn": {"results": []}}})
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
-        ):
-            result = await nexar_backfill_untagged(db_session, limit=100)
-
-        assert result["no_result"] == 1
-
-    @pytest.mark.asyncio
-    async def test_backfill_error_handled(self, db_session):
-        """Nexar query error => no_result, doesn't crash."""
-        from app.services.enrichment import nexar_backfill_untagged
-
-        card = _make_card(db_session)
-        db_session.commit()
-
-        mock_connector = MagicMock()
-        mock_connector.AGGREGATE_QUERY = "query"
-        mock_connector._run_query = AsyncMock(side_effect=Exception("API failure"))
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
-        ):
-            result = await nexar_backfill_untagged(db_session, limit=100)
-
-        assert result["no_result"] == 1
-
-    @pytest.mark.asyncio
-    async def test_backfill_ignored_manufacturer(self, db_session):
-        """Nexar returns 'n/a' manufacturer => no_result."""
-        from app.services.enrichment import nexar_backfill_untagged
-
-        card = _make_card(db_session)
-        db_session.commit()
-
-        mock_connector = MagicMock()
-        mock_connector.AGGREGATE_QUERY = "query"
-        mock_connector._run_query = AsyncMock(
-            return_value={"data": {"supSearchMpn": {"results": [{"part": {"manufacturer": {"name": "N/A"}}}]}}}
-        )
-
-        with (
-            patch("app.services.enrichment.get_credential_cached", return_value="fake-key"),
-            patch("app.connectors.sources.NexarConnector", return_value=mock_connector),
-        ):
+        cred_patch, nexar_patch = _patch_nexar(query_return=query_return, query_side_effect=query_side_effect)
+        with cred_patch, nexar_patch:
             result = await nexar_backfill_untagged(db_session, limit=100)
 
         assert result["no_result"] == 1

--- a/tests/test_enrichment_status_enum.py
+++ b/tests/test_enrichment_status_enum.py
@@ -6,6 +6,14 @@ from app.constants import MaterialEnrichmentStatus
 from app.models import MaterialCard
 
 
+def _card(mpn: str) -> MaterialCard:
+    return MaterialCard(
+        normalized_mpn=mpn.lower(),
+        display_mpn=mpn.upper(),
+        created_at=datetime.now(timezone.utc),
+    )
+
+
 def test_enum_values():
     assert MaterialEnrichmentStatus.WEB_SOURCED == "web_sourced"
     assert set(MaterialEnrichmentStatus) >= {
@@ -17,36 +25,23 @@ def test_enum_values():
     }
 
 
-def test_validator_rejects_bad_status(db_session):
-    card = MaterialCard(normalized_mpn="x1", display_mpn="X1", created_at=datetime.now(timezone.utc))
+@pytest.mark.parametrize("bad_status", ["verifed", "bogus_status"])
+def test_validator_rejects_bad_status(bad_status):
+    card = _card("x1")
     with pytest.raises(ValueError):
-        card.enrichment_status = "verifed"  # typo
+        card.enrichment_status = bad_status
 
 
-def test_validator_accepts_enum_and_literal(db_session):
-    card = MaterialCard(normalized_mpn="x2", display_mpn="X2", created_at=datetime.now(timezone.utc))
-    card.enrichment_status = "web_sourced"
-    assert card.enrichment_status == "web_sourced"
-    card.enrichment_status = MaterialEnrichmentStatus.VERIFIED
-    assert card.enrichment_status == "verified"
-
-
-def test_validator_accepts_oem_tiers():
-    from app.constants import MaterialEnrichmentStatus
-    from app.models import MaterialCard
-
-    c = MaterialCard(display_mpn="01HW917", normalized_mpn="01hw917")
-    c.enrichment_status = MaterialEnrichmentStatus.OEM_SOURCED
-    assert c.enrichment_status == "oem_sourced"
-    c.enrichment_status = "not_catalogued"
-    assert c.enrichment_status == "not_catalogued"
-
-
-def test_validator_still_rejects_junk():
-    import pytest
-
-    from app.models import MaterialCard
-
-    c = MaterialCard(display_mpn="X", normalized_mpn="x")
-    with pytest.raises(ValueError):
-        c.enrichment_status = "bogus_status"
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("web_sourced", "web_sourced"),
+        (MaterialEnrichmentStatus.VERIFIED, "verified"),
+        (MaterialEnrichmentStatus.OEM_SOURCED, "oem_sourced"),
+        ("not_catalogued", "not_catalogued"),
+    ],
+)
+def test_validator_accepts_enum_and_literal(value, expected):
+    card = _card("x2")
+    card.enrichment_status = value
+    assert card.enrichment_status == expected

--- a/tests/test_enrichment_worker.py
+++ b/tests/test_enrichment_worker.py
@@ -6,6 +6,8 @@ create_all builds the table but does not run migrations, so the row may be absen
 test tolerates None (row is None or id==1).
 """
 
+import pytest
+
 
 def test_worker_status_singleton(db_session):
     from app.models.enrichment_worker_status import EnrichmentWorkerStatus
@@ -23,18 +25,21 @@ def test_worker_status_model_importable():
     )
 
     cols = {c.key for c in EnrichmentWorkerStatus.__table__.columns}
-    assert "id" in cols
-    assert "is_running" in cols
-    assert "last_heartbeat" in cols
-    assert "last_enriched_at" in cols
-    assert "enriched_today" in cols
-    assert "web_sourced_today" in cols
-    assert "ai_inferred_today" in cols
-    assert "not_found_today" in cols
-    assert "circuit_breaker_open" in cols
-    assert "circuit_breaker_reason" in cols
-    assert "daily_stats_json" in cols
-    assert "updated_at" in cols
+    expected_cols = {
+        "id",
+        "is_running",
+        "last_heartbeat",
+        "last_enriched_at",
+        "enriched_today",
+        "web_sourced_today",
+        "ai_inferred_today",
+        "not_found_today",
+        "circuit_breaker_open",
+        "circuit_breaker_reason",
+        "daily_stats_json",
+        "updated_at",
+    }
+    assert expected_cols <= cols
     assert callable(update_enrichment_worker_status)
 
 
@@ -646,8 +651,16 @@ def test_run_one_batch_stamps_enriched_at_and_returns_counts(db_session, monkeyp
         assert c.enriched_at is not None
 
 
-def test_run_one_batch_web_cap_disables_web_tier(db_session, monkeypatch):
-    """When web daily cap is reached, 'web_search' is added to disabled set."""
+@pytest.mark.parametrize(
+    ("mpn", "web_daily_cap", "cached_count", "web_disabled"),
+    [
+        ("testpart", 10, 10, True),  # at cap → web tier disabled
+        ("testpart2", 80, 5, False),  # well below cap → web tier enabled
+    ],
+    ids=["at_cap", "below_cap"],
+)
+def test_run_one_batch_web_cap_gating(db_session, mpn, web_daily_cap, cached_count, web_disabled):
+    """The web tier is disabled iff the cached daily count has reached web_daily_cap."""
     import asyncio
     from datetime import datetime, timezone
     from unittest.mock import patch
@@ -660,8 +673,8 @@ def test_run_one_batch_web_cap_disables_web_tier(db_session, monkeypatch):
     now = datetime.now(timezone.utc)
     db_session.add(
         MaterialCard(
-            normalized_mpn="testpart",
-            display_mpn="TESTPART",
+            normalized_mpn=mpn,
+            display_mpn=mpn.upper(),
             enrichment_status="unenriched",
             created_at=now,
         )
@@ -674,7 +687,7 @@ def test_run_one_batch_web_cap_disables_web_tier(db_session, monkeypatch):
         captured_disabled.append(set(disabled) if disabled else set())
         return "not_found"
 
-    cfg = EnrichmentWorkerConfig(batch_size=5, web_daily_cap=10)
+    cfg = EnrichmentWorkerConfig(batch_size=5, web_daily_cap=web_daily_cap)
     breaker = EnrichmentCircuitBreaker(cfg)
 
     with (
@@ -688,66 +701,14 @@ def test_run_one_batch_web_cap_disables_web_tier(db_session, monkeypatch):
         ),
         patch(
             "app.services.enrichment_worker.worker.intel_cache.get_cached",
-            return_value={"count": 10},  # at cap
+            return_value={"count": cached_count},
         ),
         patch("app.services.enrichment_worker.worker.intel_cache.set_cached"),
     ):
         asyncio.run(run_one_batch(db_session, cfg, {}, breaker))
 
     assert len(captured_disabled) == 1
-    assert "web_search" in captured_disabled[0]
-
-
-def test_run_one_batch_below_web_cap_does_not_disable(db_session):
-    """When below web daily cap, 'web_search' is NOT in the disabled set."""
-    import asyncio
-    from datetime import datetime, timezone
-    from unittest.mock import patch
-
-    from app.models import MaterialCard
-    from app.services.enrichment_worker.circuit_breaker import EnrichmentCircuitBreaker
-    from app.services.enrichment_worker.config import EnrichmentWorkerConfig
-    from app.services.enrichment_worker.worker import run_one_batch
-
-    now = datetime.now(timezone.utc)
-    db_session.add(
-        MaterialCard(
-            normalized_mpn="testpart2",
-            display_mpn="TESTPART2",
-            enrichment_status="unenriched",
-            created_at=now,
-        )
-    )
-    db_session.flush()
-
-    captured_disabled: list[set] = []
-
-    async def fake_enrich_card(card, db, disabled=None, **kw):
-        captured_disabled.append(set(disabled) if disabled else set())
-        return "not_found"
-
-    cfg = EnrichmentWorkerConfig(batch_size=5, web_daily_cap=80)
-    breaker = EnrichmentCircuitBreaker(cfg)
-
-    with (
-        patch(
-            "app.services.enrichment_worker.worker.enrich_card",
-            side_effect=fake_enrich_card,
-        ),
-        patch(
-            "app.services.enrichment_worker.worker._connectors_in_order",
-            return_value=[],
-        ),
-        patch(
-            "app.services.enrichment_worker.worker.intel_cache.get_cached",
-            return_value={"count": 5},  # well below cap
-        ),
-        patch("app.services.enrichment_worker.worker.intel_cache.set_cached"),
-    ):
-        asyncio.run(run_one_batch(db_session, cfg, {}, breaker))
-
-    assert len(captured_disabled) == 1
-    assert "web_search" not in captured_disabled[0]
+    assert ("web_search" in captured_disabled[0]) is web_disabled
 
 
 # ---------------------------------------------------------------------------
@@ -1173,10 +1134,21 @@ def test_verified_only_does_not_reset_breaker(db_session):
 # ---------------------------------------------------------------------------
 
 
-def test_run_one_batch_triggers_spec_extraction_for_enriched_cards(db_session):
+@pytest.mark.parametrize(
+    ("mpns", "real_status", "miss_status"),
+    [
+        # ONLY the verified card gets a spec pass; the not_found one is excluded.
+        (("sv", "snf"), "VERIFIED", "NOT_FOUND"),
+        # Merge-integration guard: oem_sourced (a real category) is INCLUDED;
+        # not_catalogued (a terminal miss, like not_found) is EXCLUDED.
+        (("soem", "snc"), "OEM_SOURCED", "NOT_CATALOGUED"),
+    ],
+    ids=["verified_vs_not_found", "oem_sourced_vs_not_catalogued"],
+)
+def test_run_one_batch_spec_extraction_only_real_categories(db_session, mpns, real_status, miss_status):
     """After core enrichment, run_one_batch triggers a single spec-extraction pass for
-    ONLY the cards that landed a real category (verified/web_sourced/ai_inferred) —
-    never the not_found ones."""
+    ONLY the cards that landed a real category (verified/web_sourced/ai_inferred/
+    oem_sourced) — never the terminal-miss ones (not_found/not_catalogued)."""
     import asyncio
     from datetime import datetime, timedelta, timezone
     from unittest.mock import AsyncMock, patch
@@ -1189,17 +1161,23 @@ def test_run_one_batch_triggers_spec_extraction_for_enriched_cards(db_session):
 
     now = datetime.now(timezone.utc)
     # Distinct created_at so selection order is deterministic (newest first):
-    # verified first, then not_found.
-    verified_card = MaterialCard(normalized_mpn="sv", display_mpn="SV", enrichment_status="unenriched", created_at=now)
-    nf_card = MaterialCard(
-        normalized_mpn="snf", display_mpn="SNF", enrichment_status="unenriched", created_at=now - timedelta(seconds=1)
+    # the real-category card is processed before the terminal-miss one.
+    real_mpn, miss_mpn = mpns
+    real_card = MaterialCard(
+        normalized_mpn=real_mpn, display_mpn=real_mpn.upper(), enrichment_status="unenriched", created_at=now
     )
-    db_session.add(verified_card)
-    db_session.add(nf_card)
+    miss_card = MaterialCard(
+        normalized_mpn=miss_mpn,
+        display_mpn=miss_mpn.upper(),
+        enrichment_status="unenriched",
+        created_at=now - timedelta(seconds=1),
+    )
+    db_session.add(real_card)
+    db_session.add(miss_card)
     db_session.flush()
-    verified_id = verified_card.id
+    real_id = real_card.id
 
-    returns = [MaterialEnrichmentStatus.VERIFIED, MaterialEnrichmentStatus.NOT_FOUND]
+    returns = [getattr(MaterialEnrichmentStatus, real_status), getattr(MaterialEnrichmentStatus, miss_status)]
     idx = [0]
 
     async def fake_enrich_card(card, db, **kw):
@@ -1223,58 +1201,7 @@ def test_run_one_batch_triggers_spec_extraction_for_enriched_cards(db_session):
 
     spec_mock.assert_awaited_once()
     passed_ids = spec_mock.await_args.args[0]
-    assert passed_ids == [verified_id]  # ONLY the verified card; not the not_found one
-
-
-def test_run_one_batch_spec_extraction_includes_oem_sourced_excludes_not_catalogued(db_session):
-    """Merge-integration guard: the second-pass spec extraction must INCLUDE oem_sourced
-    (a real category) and EXCLUDE not_catalogued (a terminal miss, like not_found)."""
-    import asyncio
-    from datetime import datetime, timedelta, timezone
-    from unittest.mock import AsyncMock, patch
-
-    from app.constants import MaterialEnrichmentStatus
-    from app.models import MaterialCard
-    from app.services.enrichment_worker.circuit_breaker import EnrichmentCircuitBreaker
-    from app.services.enrichment_worker.config import EnrichmentWorkerConfig
-    from app.services.enrichment_worker.worker import run_one_batch
-
-    now = datetime.now(timezone.utc)
-    # Newest-first selection → oem_sourced card is processed before the not_catalogued one.
-    oem_card = MaterialCard(normalized_mpn="soem", display_mpn="SOEM", enrichment_status="unenriched", created_at=now)
-    nc_card = MaterialCard(
-        normalized_mpn="snc", display_mpn="SNC", enrichment_status="unenriched", created_at=now - timedelta(seconds=1)
-    )
-    db_session.add(oem_card)
-    db_session.add(nc_card)
-    db_session.flush()
-    oem_id = oem_card.id
-
-    returns = [MaterialEnrichmentStatus.OEM_SOURCED, MaterialEnrichmentStatus.NOT_CATALOGUED]
-    idx = [0]
-
-    async def fake_enrich_card(card, db, **kw):
-        st = returns[idx[0]]
-        idx[0] += 1
-        card.enrichment_status = st
-        return st
-
-    cfg = EnrichmentWorkerConfig(batch_size=5, web_daily_cap=80)
-    breaker = EnrichmentCircuitBreaker(cfg)
-    spec_mock = AsyncMock(return_value={"cards_processed": 1, "specs_written": 2})
-
-    with (
-        patch("app.services.enrichment_worker.worker.enrich_card", side_effect=fake_enrich_card),
-        patch("app.services.enrichment_worker.worker._connectors_in_order", return_value=[]),
-        patch("app.services.enrichment_worker.worker.intel_cache.get_cached", return_value=None),
-        patch("app.services.enrichment_worker.worker.intel_cache.set_cached"),
-        patch("app.services.spec_enrichment_service.enrich_card_specs", spec_mock),
-    ):
-        asyncio.run(run_one_batch(db_session, cfg, {}, breaker, set(), {"web_calls": 0}))
-
-    spec_mock.assert_awaited_once()
-    passed_ids = spec_mock.await_args.args[0]
-    assert passed_ids == [oem_id]  # oem_sourced included; not_catalogued excluded
+    assert passed_ids == [real_id]  # ONLY the real-category card; not the terminal-miss one
 
 
 def test_run_one_batch_spec_extraction_claude_error_feeds_breaker(db_session):

--- a/tests/test_error_reports_coverage.py
+++ b/tests/test_error_reports_coverage.py
@@ -17,6 +17,24 @@ import pytest
 
 from app.models.trouble_ticket import TroubleTicket
 
+
+def _make_ticket(submitted_by, **overrides):
+    """Build a submitted TroubleTicket with sensible defaults; override any field."""
+    fields = {
+        "ticket_number": "TT-TEST-001",
+        "submitted_by": submitted_by,
+        "title": "Test ticket",
+        "description": "Test description",
+        "status": "submitted",
+        "source": "report_button",
+        "risk_tier": "low",
+        "category": "other",
+        "created_at": datetime.now(timezone.utc),
+    }
+    fields.update(overrides)
+    return TroubleTicket(**fields)
+
+
 # ── _save_screenshot helper tests ────────────────────────────────────
 
 
@@ -93,16 +111,10 @@ def test_ensure_upload_dir_runs_once(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_generate_ai_summary_success(db_session, test_user):
     """AI summary is stored when claude_text returns a value."""
-    ticket = TroubleTicket(
+    ticket = _make_ticket(
+        test_user.id,
         ticket_number="TT-SUM-001",
-        submitted_by=test_user.id,
-        title="Test ticket",
         description="Something went wrong on the search page with filters",
-        status="submitted",
-        source="report_button",
-        risk_tier="low",
-        category="other",
-        created_at=datetime.now(timezone.utc),
     )
     db_session.add(ticket)
     db_session.commit()
@@ -197,16 +209,11 @@ async def test_generate_ai_summary_handles_claude_exception(test_user, db_sessio
 class TestScreenshotSecurity:
     def test_path_traversal_blocked(self, client, db_session, test_user):
         """Ticket with screenshot_path outside UPLOAD_DIR returns 403."""
-        ticket = TroubleTicket(
+        ticket = _make_ticket(
+            test_user.id,
             ticket_number="TT-TRAV-001",
-            submitted_by=test_user.id,
             title="Traversal test",
             description="Testing path traversal",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
         )
         ticket.screenshot_path = "/etc/passwd"
         db_session.add(ticket)
@@ -229,17 +236,12 @@ class TestScreenshotSecurity:
         orig_upload_dir = error_reports.UPLOAD_DIR
         try:
             error_reports.UPLOAD_DIR = str(tmp_path)
-            ticket = TroubleTicket(
+            ticket = _make_ticket(
+                test_user.id,
                 ticket_number="TT-FILE-001",
-                submitted_by=test_user.id,
                 title="File test",
                 description="Testing file serve",
-                status="submitted",
-                source="report_button",
-                risk_tier="low",
-                category="other",
                 screenshot_path=str(fake_png),
-                created_at=datetime.now(timezone.utc),
             )
             db_session.add(ticket)
             db_session.commit()
@@ -326,16 +328,11 @@ class TestAnalyzeTicketsCoverage:
         from app.utils.claude_errors import ClaudeError
 
         # Create a ticket so analyze has something to work with
-        ticket = TroubleTicket(
+        ticket = _make_ticket(
+            test_user.id,
             ticket_number="TT-ANAL-001",
-            submitted_by=test_user.id,
             title="Analyze error test",
             description="Testing analyze error path",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
         )
         db_session.add(ticket)
         db_session.commit()
@@ -350,16 +347,11 @@ class TestAnalyzeTicketsCoverage:
         """Analyze updates existing RootCauseGroup if title matches."""
         from app.models.root_cause_group import RootCauseGroup
 
-        ticket = TroubleTicket(
+        ticket = _make_ticket(
+            test_user.id,
             ticket_number="TT-ANAL-002",
-            submitted_by=test_user.id,
             title="Existing group test",
             description="Testing existing group update",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
         )
         db_session.add(ticket)
         db_session.commit()
@@ -386,16 +378,11 @@ class TestAnalyzeTicketsCoverage:
     @patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock)
     def test_analyze_groups_missing_from_ticket_map(self, mock_claude, client, db_session, test_user):
         """analyze_tickets handles ticket_ids that don't exist in ticket_map."""
-        ticket = TroubleTicket(
+        ticket = _make_ticket(
+            test_user.id,
             ticket_number="TT-ANAL-003",
-            submitted_by=test_user.id,
             title="Missing ticket test",
             description="Testing missing ticket ids",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
         )
         db_session.add(ticket)
         db_session.commit()
@@ -518,20 +505,11 @@ class TestJsonApiCrud:
 
     def test_list_error_reports_with_status_filter(self, client, db_session, test_user):
         """GET /api/error-reports?status=submitted filters by status."""
-        from datetime import datetime, timezone
-
-        from app.models.trouble_ticket import TroubleTicket
-
-        ticket = TroubleTicket(
+        ticket = _make_ticket(
+            test_user.id,
             ticket_number="TT-LIST-001",
-            submitted_by=test_user.id,
             title="List filter test",
             description="Testing list filter",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
         )
         db_session.add(ticket)
         db_session.commit()
@@ -547,20 +525,11 @@ class TestJsonApiCrud:
         assert resp.status_code == 404
 
     def test_get_error_report_found(self, client, db_session, test_user):
-        from datetime import datetime, timezone
-
-        from app.models.trouble_ticket import TroubleTicket
-
-        ticket = TroubleTicket(
+        ticket = _make_ticket(
+            test_user.id,
             ticket_number="TT-GET-001",
-            submitted_by=test_user.id,
             title="Get test",
             description="Testing get endpoint",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
         )
         db_session.add(ticket)
         db_session.commit()
@@ -571,20 +540,11 @@ class TestJsonApiCrud:
         assert resp.json()["ticket_number"] == ticket.ticket_number
 
     def test_update_ticket_status_to_resolved(self, client, db_session, test_user):
-        from datetime import datetime, timezone
-
-        from app.models.trouble_ticket import TroubleTicket
-
-        ticket = TroubleTicket(
+        ticket = _make_ticket(
+            test_user.id,
             ticket_number="TT-UPD-001",
-            submitted_by=test_user.id,
             title="Update test",
             description="Testing update",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
         )
         db_session.add(ticket)
         db_session.commit()
@@ -605,20 +565,11 @@ class TestJsonApiCrud:
         assert resp.status_code == 404
 
     def test_update_ticket_resolution_notes_only(self, client, db_session, test_user):
-        from datetime import datetime, timezone
-
-        from app.models.trouble_ticket import TroubleTicket
-
-        ticket = TroubleTicket(
+        ticket = _make_ticket(
+            test_user.id,
             ticket_number="TT-UPD-002",
-            submitted_by=test_user.id,
             title="Notes test",
             description="Testing notes update",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
         )
         db_session.add(ticket)
         db_session.commit()

--- a/tests/test_error_reports_coverage3.py
+++ b/tests/test_error_reports_coverage3.py
@@ -14,9 +14,30 @@ os.environ["TESTING"] = "1"
 
 import base64
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from app.models.trouble_ticket import TroubleTicket
+
+
+def _make_ticket(db_session, test_user, ticket_number, title, description, **kwargs):
+    """Helper: build, commit, and refresh a low-risk submitted TroubleTicket."""
+    ticket = TroubleTicket(
+        ticket_number=ticket_number,
+        submitted_by=test_user.id,
+        title=title,
+        description=description,
+        status="submitted",
+        source="report_button",
+        risk_tier="low",
+        category="other",
+        created_at=datetime.now(timezone.utc),
+        **kwargs,
+    )
+    db_session.add(ticket)
+    db_session.commit()
+    db_session.refresh(ticket)
+    return ticket
+
 
 # ── Invalid JSON body ─────────────────────────────────────────────────────
 
@@ -95,21 +116,14 @@ class TestScreenshotEndpointCoverage:
         png_bytes = b"\x89PNG\r\n\x1a\n"
         b64_data = base64.b64encode(png_bytes).decode()
 
-        ticket = TroubleTicket(
-            ticket_number="TT-B64-001",
-            submitted_by=test_user.id,
-            title="B64 screenshot test",
-            description="Testing b64 fallback",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
+        ticket = _make_ticket(
+            db_session,
+            test_user,
+            "TT-B64-001",
+            "B64 screenshot test",
+            "Testing b64 fallback",
             screenshot_b64=b64_data,
-            created_at=datetime.now(timezone.utc),
         )
-        db_session.add(ticket)
-        db_session.commit()
-        db_session.refresh(ticket)
 
         resp = client.get(f"/api/trouble-tickets/{ticket.id}/screenshot")
         assert resp.status_code == 200
@@ -117,20 +131,13 @@ class TestScreenshotEndpointCoverage:
 
     def test_screenshot_no_image_at_all_returns_404(self, client, db_session, test_user):
         """Ticket with neither screenshot_path nor screenshot_b64 returns 404."""
-        ticket = TroubleTicket(
-            ticket_number="TT-NOPIC-001",
-            submitted_by=test_user.id,
-            title="No screenshot",
-            description="No image attached",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
+        ticket = _make_ticket(
+            db_session,
+            test_user,
+            "TT-NOPIC-001",
+            "No screenshot",
+            "No image attached",
         )
-        db_session.add(ticket)
-        db_session.commit()
-        db_session.refresh(ticket)
 
         resp = client.get(f"/api/trouble-tickets/{ticket.id}/screenshot")
         assert resp.status_code == 404
@@ -142,20 +149,13 @@ class TestScreenshotEndpointCoverage:
 class TestUpdateTicketStatusVariants:
     def test_update_status_to_in_progress(self, client, db_session, test_user):
         """PATCH with status=in_progress does NOT set resolved_at."""
-        ticket = TroubleTicket(
-            ticket_number="TT-INPROG-001",
-            submitted_by=test_user.id,
-            title="In progress test",
-            description="Testing in_progress status",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
+        ticket = _make_ticket(
+            db_session,
+            test_user,
+            "TT-INPROG-001",
+            "In progress test",
+            "Testing in_progress status",
         )
-        db_session.add(ticket)
-        db_session.commit()
-        db_session.refresh(ticket)
 
         resp = client.patch(
             f"/api/trouble-tickets/{ticket.id}",
@@ -170,20 +170,13 @@ class TestUpdateTicketStatusVariants:
 
     def test_update_ticket_status_only_no_notes(self, client, db_session, test_user):
         """PATCH with only status field (no resolution_notes) is accepted."""
-        ticket = TroubleTicket(
-            ticket_number="TT-STATONLY-001",
-            submitted_by=test_user.id,
-            title="Status only test",
-            description="Testing status-only update",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
+        ticket = _make_ticket(
+            db_session,
+            test_user,
+            "TT-STATONLY-001",
+            "Status only test",
+            "Testing status-only update",
         )
-        db_session.add(ticket)
-        db_session.commit()
-        db_session.refresh(ticket)
 
         resp = client.patch(
             f"/api/trouble-tickets/{ticket.id}",
@@ -194,20 +187,13 @@ class TestUpdateTicketStatusVariants:
 
     def test_update_trouble_ticket_path_also_works(self, client, db_session, test_user):
         """PATCH /api/trouble-tickets/{id} mirrors /api/error-reports/{id}."""
-        ticket = TroubleTicket(
-            ticket_number="TT-TTPATH-001",
-            submitted_by=test_user.id,
-            title="Trouble ticket path test",
-            description="Testing trouble ticket update path",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
+        ticket = _make_ticket(
+            db_session,
+            test_user,
+            "TT-TTPATH-001",
+            "Trouble ticket path test",
+            "Testing trouble ticket update path",
         )
-        db_session.add(ticket)
-        db_session.commit()
-        db_session.refresh(ticket)
 
         resp = client.patch(
             f"/api/trouble-tickets/{ticket.id}",
@@ -222,21 +208,13 @@ class TestUpdateTicketStatusVariants:
 class TestAnalyzeClaudeUnavailablePath:
     def test_analyze_tickets_claude_unavailable_returns_fallback(self, client, db_session, test_user):
         """ClaudeUnavailableError during analyze returns amber fallback HTML."""
-        from unittest.mock import AsyncMock
-
-        ticket = TroubleTicket(
-            ticket_number="TT-UNAVAIL-001",
-            submitted_by=test_user.id,
-            title="Unavailable test",
-            description="Testing ClaudeUnavailableError path",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
+        _make_ticket(
+            db_session,
+            test_user,
+            "TT-UNAVAIL-001",
+            "Unavailable test",
+            "Testing ClaudeUnavailableError path",
         )
-        db_session.add(ticket)
-        db_session.commit()
 
         from app.utils.claude_errors import ClaudeUnavailableError
 
@@ -253,21 +231,13 @@ class TestAnalyzeClaudeUnavailablePath:
     def test_analyze_returns_no_groups_key_in_result(self, client, db_session, test_user):
         """When claude_structured returns dict without 'groups', fallback HTML is
         shown."""
-        from unittest.mock import AsyncMock
-
-        ticket = TroubleTicket(
-            ticket_number="TT-NOGROUPS-001",
-            submitted_by=test_user.id,
-            title="No groups test",
-            description="Testing missing groups key",
-            status="submitted",
-            source="report_button",
-            risk_tier="low",
-            category="other",
-            created_at=datetime.now(timezone.utc),
+        _make_ticket(
+            db_session,
+            test_user,
+            "TT-NOGROUPS-001",
+            "No groups test",
+            "Testing missing groups key",
         )
-        db_session.add(ticket)
-        db_session.commit()
 
         with patch(
             "app.utils.claude_client.claude_structured",

--- a/tests/test_freeform_parser_service.py
+++ b/tests/test_freeform_parser_service.py
@@ -18,25 +18,25 @@ import pytest
 from app.services.freeform_parser_service import parse_freeform_offer, parse_freeform_rfq
 
 
+def _patch_ai(return_value):
+    """Patch routed_structured at its source module with the given return value."""
+    return patch(
+        "app.services.freeform_parser_service.routed_structured",
+        new_callable=AsyncMock,
+        return_value=return_value,
+    )
+
+
 class TestParseFreeformRFQ:
     @pytest.mark.asyncio
-    async def test_empty_string_returns_none(self):
-        result = await parse_freeform_rfq("")
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_whitespace_only_returns_none(self):
-        result = await parse_freeform_rfq("   ")
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_none_input_returns_none(self):
-        result = await parse_freeform_rfq(None)
+    @pytest.mark.parametrize("text", ["", "   ", None], ids=["empty", "whitespace", "none"])
+    async def test_blank_input_returns_none(self, text):
+        result = await parse_freeform_rfq(text)
         assert result is None
 
     @pytest.mark.asyncio
     async def test_ai_returns_none_propagates(self):
-        with patch("app.services.freeform_parser_service.routed_structured", new_callable=AsyncMock, return_value=None):
+        with _patch_ai(None):
             result = await parse_freeform_rfq("Need 100x LM358")
             assert result is None
 
@@ -56,11 +56,7 @@ class TestParseFreeformRFQ:
                 }
             ],
         }
-        with patch(
-            "app.services.freeform_parser_service.routed_structured",
-            new_callable=AsyncMock,
-            return_value=raw_ai_result,
-        ):
+        with _patch_ai(raw_ai_result):
             result = await parse_freeform_rfq("Need 100x LM358")
         assert result is not None
         req = result["requirements"][0]
@@ -68,9 +64,7 @@ class TestParseFreeformRFQ:
         assert req["target_qty"] == 1
         # substitutes defaults to []
         assert req["substitutes"] == []
-        # condition normalized
-        assert req["condition"] in ("new", "NEW", "new")
-        # default condition set
+        # condition normalized to lowercase default
         assert req["condition"] == "new"
 
     @pytest.mark.asyncio
@@ -79,19 +73,13 @@ class TestParseFreeformRFQ:
             "name": "Test",
             "requirements": [{"primary_mpn": "LM741", "target_qty": 50}],
         }
-        with patch(
-            "app.services.freeform_parser_service.routed_structured",
-            new_callable=AsyncMock,
-            return_value=raw_ai_result,
-        ):
+        with _patch_ai(raw_ai_result):
             result = await parse_freeform_rfq("Need LM741")
         assert result["requirements"][0]["condition"] == "new"
 
     @pytest.mark.asyncio
     async def test_passes_prompt_to_ai(self):
-        with patch(
-            "app.services.freeform_parser_service.routed_structured", new_callable=AsyncMock, return_value=None
-        ) as mock_call:
+        with _patch_ai(None) as mock_call:
             await parse_freeform_rfq("Need 50x BC547")
             mock_call.assert_called_once()
             call_kwargs = mock_call.call_args
@@ -100,9 +88,7 @@ class TestParseFreeformRFQ:
     @pytest.mark.asyncio
     async def test_text_truncated_at_6000(self):
         long_text = "A" * 7000
-        with patch(
-            "app.services.freeform_parser_service.routed_structured", new_callable=AsyncMock, return_value=None
-        ) as mock_call:
+        with _patch_ai(None) as mock_call:
             await parse_freeform_rfq(long_text)
             call_kwargs = mock_call.call_args
             prompt = call_kwargs.kwargs.get("prompt", "")
@@ -111,18 +97,14 @@ class TestParseFreeformRFQ:
 
 class TestParseFreeformOffer:
     @pytest.mark.asyncio
-    async def test_empty_string_returns_none(self):
-        result = await parse_freeform_offer("")
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_none_input_returns_none(self):
-        result = await parse_freeform_offer(None)
+    @pytest.mark.parametrize("text", ["", None], ids=["empty", "none"])
+    async def test_blank_input_returns_none(self, text):
+        result = await parse_freeform_offer(text)
         assert result is None
 
     @pytest.mark.asyncio
     async def test_ai_returns_none_propagates(self):
-        with patch("app.services.freeform_parser_service.routed_structured", new_callable=AsyncMock, return_value=None):
+        with _patch_ai(None):
             result = await parse_freeform_offer("We have 100x LM358 @ $0.50")
             assert result is None
 
@@ -143,11 +125,7 @@ class TestParseFreeformOffer:
                 }
             ],
         }
-        with patch(
-            "app.services.freeform_parser_service.routed_structured",
-            new_callable=AsyncMock,
-            return_value=raw_ai_result,
-        ):
+        with _patch_ai(raw_ai_result):
             result = await parse_freeform_offer("We have 100x LM358 @ $0.50")
         assert result is not None
         offer = result["offers"][0]
@@ -158,18 +136,14 @@ class TestParseFreeformOffer:
     @pytest.mark.asyncio
     async def test_rfq_context_included_in_prompt(self):
         rfq_context = [{"mpn": "LM358", "qty": 100}]
-        with patch(
-            "app.services.freeform_parser_service.routed_structured", new_callable=AsyncMock, return_value=None
-        ) as mock_call:
+        with _patch_ai(None) as mock_call:
             await parse_freeform_offer("We have stock", rfq_context=rfq_context)
             prompt = mock_call.call_args.kwargs.get("prompt", "")
             assert "LM358" in prompt
 
     @pytest.mark.asyncio
     async def test_no_rfq_context(self):
-        with patch(
-            "app.services.freeform_parser_service.routed_structured", new_callable=AsyncMock, return_value=None
-        ) as mock_call:
+        with _patch_ai(None) as mock_call:
             await parse_freeform_offer("We have 50x BC547")
             mock_call.assert_called_once()
 
@@ -179,10 +153,6 @@ class TestParseFreeformOffer:
             "vendor_name": "Vendor",
             "offers": [{"mpn": "BC547", "currency": None}],
         }
-        with patch(
-            "app.services.freeform_parser_service.routed_structured",
-            new_callable=AsyncMock,
-            return_value=raw_ai_result,
-        ):
+        with _patch_ai(raw_ai_result):
             result = await parse_freeform_offer("We have BC547")
         assert result["offers"][0]["currency"] == "USD"

--- a/tests/test_htmx_views_nightly.py
+++ b/tests/test_htmx_views_nightly.py
@@ -15,6 +15,7 @@ os.environ["TESTING"] = "1"
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.constants import BuyPlanStatus, OfferStatus, QuoteStatus, RequisitionStatus, SourcingStatus  # noqa: F401
@@ -220,30 +221,26 @@ class TestRfqSend:
         )
         assert resp.status_code == 400
 
-    def test_rfq_send_multiple_vendors(self, client, db_session: Session, test_user: User):
+    @pytest.mark.parametrize(
+        ("vendor_names", "vendor_emails", "subject"),
+        [
+            (["Arrow", "Digi-Key"], ["arrow@arrow.com", "sales@digikey.com"], "Multi-vendor RFQ"),
+            (["Arrow", "No Email Vendor"], ["arrow@arrow.com", ""], "RFQ skip test"),
+        ],
+        ids=["multiple_vendors", "empty_email_skipped"],
+    )
+    def test_rfq_send_multi_vendor(
+        self, client, db_session: Session, test_user: User, vendor_names, vendor_emails, subject
+    ):
         req = _req(db_session, test_user)
         db_session.commit()
 
         resp = client.post(
             f"/v2/partials/requisitions/{req.id}/rfq-send",
             data={
-                "vendor_names": ["Arrow", "Digi-Key"],
-                "vendor_emails": ["arrow@arrow.com", "sales@digikey.com"],
-                "subject": "Multi-vendor RFQ",
-            },
-        )
-        assert resp.status_code == 200
-
-    def test_rfq_send_empty_email_skipped(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        db_session.commit()
-
-        resp = client.post(
-            f"/v2/partials/requisitions/{req.id}/rfq-send",
-            data={
-                "vendor_names": ["Arrow", "No Email Vendor"],
-                "vendor_emails": ["arrow@arrow.com", ""],
-                "subject": "RFQ skip test",
+                "vendor_names": vendor_names,
+                "vendor_emails": vendor_emails,
+                "subject": subject,
             },
         )
         assert resp.status_code == 200
@@ -475,40 +472,22 @@ class TestMaterialsPartials:
         resp = client.get("/v2/partials/materials/999999")
         assert resp.status_code == 404
 
-    def test_material_tab_vendors(self, client, db_session: Session):
+    @pytest.mark.parametrize(
+        ("tab", "expected_status"),
+        [
+            ("vendors", 200),
+            ("customers", 200),
+            ("sourcing", 200),
+            ("price_history", 200),
+            ("unknown_tab", 404),
+        ],
+    )
+    def test_material_tab(self, client, db_session: Session, tab: str, expected_status: int):
         card = _material_card(db_session)
         db_session.commit()
 
-        resp = client.get(f"/v2/partials/materials/{card.id}/tab/vendors")
-        assert resp.status_code == 200
-
-    def test_material_tab_customers(self, client, db_session: Session):
-        card = _material_card(db_session)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/materials/{card.id}/tab/customers")
-        assert resp.status_code == 200
-
-    def test_material_tab_sourcing(self, client, db_session: Session):
-        card = _material_card(db_session)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/materials/{card.id}/tab/sourcing")
-        assert resp.status_code == 200
-
-    def test_material_tab_price_history(self, client, db_session: Session):
-        card = _material_card(db_session)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/materials/{card.id}/tab/price_history")
-        assert resp.status_code == 200
-
-    def test_material_tab_unknown_returns_404(self, client, db_session: Session):
-        card = _material_card(db_session)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/materials/{card.id}/tab/unknown_tab")
-        assert resp.status_code == 404
+        resp = client.get(f"/v2/partials/materials/{card.id}/tab/{tab}")
+        assert resp.status_code == expected_status
 
     def test_material_tab_missing_card(self, client, db_session: Session):
         resp = client.get("/v2/partials/materials/999999/tab/vendors")
@@ -703,29 +682,22 @@ class TestQuotesPartials:
         resp = client.post("/v2/partials/quotes/999999/send")
         assert resp.status_code == 404
 
-    def test_quote_result_won(self, client, db_session: Session, test_user: User):
+    @pytest.mark.parametrize(
+        ("result", "expected_status"),
+        [
+            ("won", 200),
+            ("lost", 200),
+            ("maybe", 400),
+        ],
+        ids=["won", "lost", "invalid"],
+    )
+    def test_quote_result(self, client, db_session: Session, test_user: User, result: str, expected_status: int):
         req = _req(db_session, test_user)
         q = _quote(db_session, req, test_user, status=QuoteStatus.SENT)
         db_session.commit()
 
-        resp = client.post(f"/v2/partials/quotes/{q.id}/result", data={"result": "won"})
-        assert resp.status_code == 200
-
-    def test_quote_result_lost(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        q = _quote(db_session, req, test_user, status=QuoteStatus.SENT)
-        db_session.commit()
-
-        resp = client.post(f"/v2/partials/quotes/{q.id}/result", data={"result": "lost"})
-        assert resp.status_code == 200
-
-    def test_quote_result_invalid(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        q = _quote(db_session, req, test_user, status=QuoteStatus.SENT)
-        db_session.commit()
-
-        resp = client.post(f"/v2/partials/quotes/{q.id}/result", data={"result": "maybe"})
-        assert resp.status_code == 400
+        resp = client.post(f"/v2/partials/quotes/{q.id}/result", data={"result": result})
+        assert resp.status_code == expected_status
 
     def test_revise_quote(self, client, db_session: Session, test_user: User):
         req = _req(db_session, test_user)
@@ -810,11 +782,16 @@ class TestProspectingPartials:
         resp = client.get("/v2/partials/prospecting")
         assert resp.status_code == 200
 
-    def test_prospecting_list_with_data(self, client, db_session: Session):
+    @pytest.mark.parametrize(
+        "query",
+        ["", "?sort=fit_desc", "?sort=recent_desc"],
+        ids=["with_data", "sort_fit", "sort_recent"],
+    )
+    def test_prospecting_list_with_data(self, client, db_session: Session, query: str):
         _prospect(db_session)
         db_session.commit()
 
-        resp = client.get("/v2/partials/prospecting")
+        resp = client.get(f"/v2/partials/prospecting{query}")
         assert resp.status_code == 200
 
     def test_prospecting_list_filter_status(self, client, db_session: Session):
@@ -829,20 +806,6 @@ class TestProspectingPartials:
         db_session.commit()
 
         resp = client.get("/v2/partials/prospecting?q=Unique")
-        assert resp.status_code == 200
-
-    def test_prospecting_list_sort_fit(self, client, db_session: Session):
-        _prospect(db_session)
-        db_session.commit()
-
-        resp = client.get("/v2/partials/prospecting?sort=fit_desc")
-        assert resp.status_code == 200
-
-    def test_prospecting_list_sort_recent(self, client, db_session: Session):
-        _prospect(db_session)
-        db_session.commit()
-
-        resp = client.get("/v2/partials/prospecting?sort=recent_desc")
         assert resp.status_code == 200
 
     def test_prospecting_stats(self, client, db_session: Session):
@@ -925,41 +888,38 @@ class TestProspectingPartials:
 
 
 class TestSettingsPartials:
-    def test_settings_index(self, client, db_session: Session):
-        resp = client.get("/v2/partials/settings")
-        assert resp.status_code == 200
-
-    def test_settings_index_tab_param(self, client, db_session: Session):
-        resp = client.get("/v2/partials/settings?tab=profile")
-        assert resp.status_code == 200
-
-    def test_settings_sources(self, client, db_session: Session):
-        resp = client.get("/v2/partials/settings/sources")
-        assert resp.status_code == 200
-
-    def test_settings_profile(self, client, db_session: Session):
-        resp = client.get("/v2/partials/settings/profile")
-        assert resp.status_code == 200
-
-    def test_settings_system_non_admin_raises_403(self, client, db_session: Session):
-        resp = client.get("/v2/partials/settings/system")
-        assert resp.status_code == 403
+    @pytest.mark.parametrize(
+        ("path", "expected_status"),
+        [
+            ("/v2/partials/settings", 200),
+            ("/v2/partials/settings?tab=profile", 200),
+            ("/v2/partials/settings/sources", 200),
+            ("/v2/partials/settings/profile", 200),
+            ("/v2/partials/settings/system", 403),  # non-admin
+        ],
+        ids=["index", "index_tab_param", "sources", "profile", "system_non_admin"],
+    )
+    def test_settings(self, client, db_session: Session, path: str, expected_status: int):
+        resp = client.get(path)
+        assert resp.status_code == expected_status
 
 
 # ── Inline Edit / Action ──────────────────────────────────────────────
 
 
 class TestInlineEdit:
-    def test_requisition_inline_edit_cell_name(self, client, db_session: Session, test_user: User):
+    @pytest.mark.parametrize(
+        ("field", "expected_status"),
+        [
+            ("name", 200),
+            ("invalid_field", 400),
+        ],
+    )
+    def test_requisition_inline_edit_cell(
+        self, client, db_session: Session, test_user: User, field: str, expected_status: int
+    ):
         req = _req(db_session, test_user)
         db_session.commit()
 
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/edit/name")
-        assert resp.status_code == 200
-
-    def test_requisition_inline_edit_cell_invalid_field(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/requisitions/{req.id}/edit/invalid_field")
-        assert resp.status_code == 400
+        resp = client.get(f"/v2/partials/requisitions/{req.id}/edit/{field}")
+        assert resp.status_code == expected_status

--- a/tests/test_htmx_views_nightly12.py
+++ b/tests/test_htmx_views_nightly12.py
@@ -16,6 +16,7 @@ os.environ["TESTING"] = "1"
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -91,6 +92,10 @@ def _make_buy_plan(
     return bp
 
 
+def _first_requirement(db: Session, req: Requisition) -> Requirement:
+    return db.query(Requirement).filter_by(requisition_id=req.id).first()
+
+
 # ── Parts list ────────────────────────────────────────────────────────────
 
 
@@ -123,120 +128,48 @@ class TestPartsListPartial:
 # ── Parts tabs ────────────────────────────────────────────────────────────
 
 
-class TestPartTabOffers:
-    def test_offers_tab_200(
+# Each part-detail partial returns 200 for a real requirement; the same path
+# returns 404 for a missing one. Identical arrange/assert across all tabs and
+# the header, so parametrize over the path suffix. (The notes tab has no 404
+# GET case in the original suite, hence the separate 200-only list.)
+_PART_PARTIAL_404_SUFFIXES = [
+    "tab/offers",
+    "tab/sourcing",
+    "tab/req-details",
+    "header",
+    "tab/activity",
+    "tab/comms",
+]
+_PART_PARTIAL_200_SUFFIXES = [*_PART_PARTIAL_404_SUFFIXES, "tab/notes"]
+
+
+class TestPartPartials:
+    @pytest.mark.parametrize("suffix", _PART_PARTIAL_200_SUFFIXES)
+    def test_partial_200(
         self,
         client: TestClient,
         db_session: Session,
         test_requisition: Requisition,
+        suffix: str,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        resp = client.get(f"/v2/partials/parts/{req.id}/tab/offers")
+        req = _first_requirement(db_session, test_requisition)
+        resp = client.get(f"/v2/partials/parts/{req.id}/{suffix}")
         assert resp.status_code == 200
 
-    def test_offers_tab_not_found(self, client: TestClient) -> None:
-        resp = client.get("/v2/partials/parts/99999/tab/offers")
-        assert resp.status_code == 404
-
-
-class TestPartTabSourcing:
-    def test_sourcing_tab_200(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_requisition: Requisition,
-    ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        resp = client.get(f"/v2/partials/parts/{req.id}/tab/sourcing")
-        assert resp.status_code == 200
-
-    def test_sourcing_tab_not_found(self, client: TestClient) -> None:
-        resp = client.get("/v2/partials/parts/99999/tab/sourcing")
-        assert resp.status_code == 404
-
-
-class TestPartTabReqDetails:
-    def test_req_details_tab_200(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_requisition: Requisition,
-    ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        resp = client.get(f"/v2/partials/parts/{req.id}/tab/req-details")
-        assert resp.status_code == 200
-
-    def test_req_details_tab_not_found(self, client: TestClient) -> None:
-        resp = client.get("/v2/partials/parts/99999/tab/req-details")
-        assert resp.status_code == 404
-
-
-class TestPartHeader:
-    def test_header_200(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_requisition: Requisition,
-    ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        resp = client.get(f"/v2/partials/parts/{req.id}/header")
-        assert resp.status_code == 200
-
-    def test_header_not_found(self, client: TestClient) -> None:
-        resp = client.get("/v2/partials/parts/99999/header")
-        assert resp.status_code == 404
-
-
-class TestPartTabActivity:
-    def test_activity_tab_200(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_requisition: Requisition,
-    ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        resp = client.get(f"/v2/partials/parts/{req.id}/tab/activity")
-        assert resp.status_code == 200
-
-    def test_activity_tab_not_found(self, client: TestClient) -> None:
-        resp = client.get("/v2/partials/parts/99999/tab/activity")
-        assert resp.status_code == 404
-
-
-class TestPartTabComms:
-    def test_comms_tab_200(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_requisition: Requisition,
-    ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        resp = client.get(f"/v2/partials/parts/{req.id}/tab/comms")
-        assert resp.status_code == 200
-
-    def test_comms_tab_not_found(self, client: TestClient) -> None:
-        resp = client.get("/v2/partials/parts/99999/tab/comms")
+    @pytest.mark.parametrize("suffix", _PART_PARTIAL_404_SUFFIXES)
+    def test_partial_not_found(self, client: TestClient, suffix: str) -> None:
+        resp = client.get(f"/v2/partials/parts/99999/{suffix}")
         assert resp.status_code == 404
 
 
 class TestPartTabNotes:
-    def test_notes_tab_200(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_requisition: Requisition,
-    ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        resp = client.get(f"/v2/partials/parts/{req.id}/tab/notes")
-        assert resp.status_code == 200
-
     def test_save_notes(
         self,
         client: TestClient,
         db_session: Session,
         test_requisition: Requisition,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+        req = _first_requirement(db_session, test_requisition)
         resp = client.patch(
             f"/v2/partials/parts/{req.id}/notes",
             data={"sale_notes": "Important: check lead times"},
@@ -260,7 +193,7 @@ class TestCreatePartTask:
         db_session: Session,
         test_requisition: Requisition,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+        req = _first_requirement(db_session, test_requisition)
         resp = client.post(
             f"/v2/partials/parts/{req.id}/tasks",
             data={"title": "Call vendor for quote"},
@@ -276,7 +209,7 @@ class TestCreatePartTask:
         db_session: Session,
         test_requisition: Requisition,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+        req = _first_requirement(db_session, test_requisition)
         resp = client.post(f"/v2/partials/parts/{req.id}/tasks", data={"title": ""})
         assert resp.status_code == 422
 
@@ -293,7 +226,7 @@ class TestMarkTaskDone:
         test_requisition: Requisition,
         test_user: User,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+        req = _first_requirement(db_session, test_requisition)
         task = _make_task(db_session, test_requisition, req, test_user)
         resp = client.post(f"/v2/partials/parts/tasks/{task.id}/done")
         assert resp.status_code == 200
@@ -313,7 +246,7 @@ class TestReopenTask:
         test_requisition: Requisition,
         test_user: User,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+        req = _first_requirement(db_session, test_requisition)
         task = _make_task(db_session, test_requisition, req, test_user, status="done")
         resp = client.post(f"/v2/partials/parts/tasks/{task.id}/reopen")
         assert resp.status_code == 200
@@ -335,7 +268,7 @@ class TestArchiveSinglePart:
         db_session: Session,
         test_requisition: Requisition,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+        req = _first_requirement(db_session, test_requisition)
         resp = client.patch(f"/v2/partials/parts/{req.id}/archive")
         assert resp.status_code == 200
         db_session.refresh(req)
@@ -351,7 +284,7 @@ class TestArchiveSinglePart:
         db_session: Session,
         test_requisition: Requisition,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+        req = _first_requirement(db_session, test_requisition)
         req.sourcing_status = "archived"
         db_session.commit()
         resp = client.patch(f"/v2/partials/parts/{req.id}/unarchive")
@@ -405,7 +338,7 @@ class TestBulkArchive:
         db_session: Session,
         test_requisition: Requisition,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+        req = _first_requirement(db_session, test_requisition)
         resp = client.post(
             "/v2/partials/parts/bulk-archive",
             json={"requirement_ids": [req.id], "requisition_ids": []},
@@ -434,7 +367,7 @@ class TestBulkArchive:
         db_session: Session,
         test_requisition: Requisition,
     ) -> None:
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
+        req = _first_requirement(db_session, test_requisition)
         req.sourcing_status = "archived"
         db_session.commit()
         resp = client.post(

--- a/tests/test_htmx_views_nightly22.py
+++ b/tests/test_htmx_views_nightly22.py
@@ -33,6 +33,7 @@ import json
 import uuid
 from datetime import datetime, timezone
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -248,30 +249,20 @@ class TestAddSightingsFromSearch:
 
 
 class TestLeadStatusUpdate:
-    def test_update_status_has_stock(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({"status": "has_stock", "note": "Confirmed 1000 units"}, id="has_stock"),
+            pytest.param({"status": "no_stock"}, id="no_stock"),
+            pytest.param({"status": "contacted"}, id="contacted"),
+        ],
+    )
+    def test_update_status_valid(self, client: TestClient, db_session: Session, test_user: User, data: dict):
         req = _make_req(db_session, test_user)
         lead = _make_lead(db_session, req)
         resp = client.post(
             f"/v2/partials/sourcing/leads/{lead.id}/status",
-            data={"status": "has_stock", "note": "Confirmed 1000 units"},
-        )
-        assert resp.status_code == 200
-
-    def test_update_status_no_stock(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_req(db_session, test_user)
-        lead = _make_lead(db_session, req)
-        resp = client.post(
-            f"/v2/partials/sourcing/leads/{lead.id}/status",
-            data={"status": "no_stock"},
-        )
-        assert resp.status_code == 200
-
-    def test_update_status_contacted(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_req(db_session, test_user)
-        lead = _make_lead(db_session, req)
-        resp = client.post(
-            f"/v2/partials/sourcing/leads/{lead.id}/status",
-            data={"status": "contacted"},
+            data=data,
         )
         assert resp.status_code == 200
 
@@ -328,22 +319,24 @@ class TestLeadFeedback:
 
 
 class TestBulkArchive:
-    def test_bulk_archive_requirement_ids(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("path", ["bulk-archive", "bulk-unarchive"])
+    def test_bulk_requirement_ids(self, client: TestClient, db_session: Session, test_user: User, path: str):
         from app.models import Requirement
 
         req = _make_req(db_session, test_user)
         r = db_session.query(Requirement).filter(Requirement.requisition_id == req.id).first()
         resp = client.post(
-            "/v2/partials/parts/bulk-archive",
+            f"/v2/partials/parts/{path}",
             content=json.dumps({"requirement_ids": [r.id], "requisition_ids": []}),
             headers={"Content-Type": "application/json"},
         )
         assert resp.status_code == 200
 
-    def test_bulk_archive_requisition_ids(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("path", ["bulk-archive", "bulk-unarchive"])
+    def test_bulk_requisition_ids(self, client: TestClient, db_session: Session, test_user: User, path: str):
         req = _make_req(db_session, test_user)
         resp = client.post(
-            "/v2/partials/parts/bulk-archive",
+            f"/v2/partials/parts/{path}",
             content=json.dumps({"requirement_ids": [], "requisition_ids": [req.id]}),
             headers={"Content-Type": "application/json"},
         )
@@ -353,27 +346,6 @@ class TestBulkArchive:
         resp = client.post(
             "/v2/partials/parts/bulk-archive",
             content=json.dumps({"requirement_ids": [], "requisition_ids": []}),
-            headers={"Content-Type": "application/json"},
-        )
-        assert resp.status_code == 200
-
-    def test_bulk_unarchive_requirement_ids(self, client: TestClient, db_session: Session, test_user: User):
-        from app.models import Requirement
-
-        req = _make_req(db_session, test_user)
-        r = db_session.query(Requirement).filter(Requirement.requisition_id == req.id).first()
-        resp = client.post(
-            "/v2/partials/parts/bulk-unarchive",
-            content=json.dumps({"requirement_ids": [r.id], "requisition_ids": []}),
-            headers={"Content-Type": "application/json"},
-        )
-        assert resp.status_code == 200
-
-    def test_bulk_unarchive_requisition_cascade(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_req(db_session, test_user)
-        resp = client.post(
-            "/v2/partials/parts/bulk-unarchive",
-            content=json.dumps({"requirement_ids": [], "requisition_ids": [req.id]}),
             headers={"Content-Type": "application/json"},
         )
         assert resp.status_code == 200
@@ -488,46 +460,30 @@ class TestLogActivity:
 
 
 class TestReviewResponse:
-    def test_review_as_reviewed(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("status", ["reviewed", "rejected"])
+    def test_review_persists_status(self, client: TestClient, db_session: Session, test_user: User, status: str):
         req = _make_req(db_session, test_user)
         vr = _make_vendor_response(db_session, req)
         resp = client.post(
             f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/review",
-            data={"status": "reviewed"},
+            data={"status": status},
         )
         assert resp.status_code == 200
         db_session.refresh(vr)
-        assert vr.status == "reviewed"
-
-    def test_review_as_rejected(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_req(db_session, test_user)
-        vr = _make_vendor_response(db_session, req)
-        resp = client.post(
-            f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/review",
-            data={"status": "rejected"},
-        )
-        assert resp.status_code == 200
+        assert vr.status == status
 
 
 # ── Update Response Status (PATCH) ───────────────────────────────────────
 
 
 class TestUpdateResponseStatus:
-    def test_patch_status_reviewed(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("status", ["reviewed", "flagged"])
+    def test_patch_status_valid(self, client: TestClient, db_session: Session, test_user: User, status: str):
         req = _make_req(db_session, test_user)
         vr = _make_vendor_response(db_session, req)
         resp = client.patch(
             f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/status",
-            data={"status": "reviewed"},
-        )
-        assert resp.status_code == 200
-
-    def test_patch_status_flagged(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_req(db_session, test_user)
-        vr = _make_vendor_response(db_session, req)
-        resp = client.patch(
-            f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/status",
-            data={"status": "flagged"},
+            data={"status": status},
         )
         assert resp.status_code == 200
 
@@ -687,19 +643,20 @@ class TestAddOfferManual:
         )
         assert resp.status_code == 200
 
-    def test_add_offer_missing_vendor(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({"mpn": "LM317T"}, id="missing_vendor"),
+            pytest.param({"vendor_name": "ManualVendor"}, id="missing_mpn"),
+        ],
+    )
+    def test_add_offer_missing_required_field(
+        self, client: TestClient, db_session: Session, test_user: User, data: dict
+    ):
         req = _make_req(db_session, test_user)
         resp = client.post(
             f"/v2/partials/requisitions/{req.id}/add-offer",
-            data={"mpn": "LM317T"},
-        )
-        assert resp.status_code == 400
-
-    def test_add_offer_missing_mpn(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_req(db_session, test_user)
-        resp = client.post(
-            f"/v2/partials/requisitions/{req.id}/add-offer",
-            data={"vendor_name": "ManualVendor"},
+            data=data,
         )
         assert resp.status_code == 400
 
@@ -780,18 +737,11 @@ class TestBuyPlanCancel:
 
 
 class TestRequisitionsBulkAction:
-    def test_bulk_archive(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("action", ["archive", "activate"])
+    def test_bulk_action_success(self, client: TestClient, db_session: Session, test_user: User, action: str):
         req = _make_req(db_session, test_user)
         resp = client.post(
-            "/v2/partials/requisitions/bulk/archive",
-            data={"ids": str(req.id)},
-        )
-        assert resp.status_code == 200
-
-    def test_bulk_activate(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_req(db_session, test_user)
-        resp = client.post(
-            "/v2/partials/requisitions/bulk/activate",
+            f"/v2/partials/requisitions/bulk/{action}",
             data={"ids": str(req.id)},
         )
         assert resp.status_code == 200

--- a/tests/test_htmx_views_nightly9.py
+++ b/tests/test_htmx_views_nightly9.py
@@ -12,6 +12,7 @@ import os
 import uuid
 from datetime import datetime, timezone
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -124,50 +125,31 @@ def _req(db: Session, user: User, **kw) -> Requisition:
 class TestVendorReviews:
     """Covers add_vendor_review and delete_vendor_review."""
 
-    def test_add_review_success(
+    @pytest.mark.parametrize(
+        ("data", "expected_rating"),
+        [
+            ({"rating": "5", "comment": "Excellent"}, 5),
+            ({"rating": "not-a-number", "comment": ""}, 3),
+            ({"rating": "99"}, 5),
+        ],
+        ids=["valid", "invalid_defaults_to_3", "clamps_above_5"],
+    )
+    def test_add_review_rating(
         self,
         client: TestClient,
         db_session: Session,
         test_vendor_card: VendorCard,
+        data: dict,
+        expected_rating: int,
     ):
         resp = client.post(
             f"/v2/partials/vendors/{test_vendor_card.id}/reviews",
-            data={"rating": "5", "comment": "Excellent"},
+            data=data,
         )
         assert resp.status_code == 200
         review = db_session.query(VendorReview).filter_by(vendor_card_id=test_vendor_card.id).first()
         assert review is not None
-        assert review.rating == 5
-
-    def test_add_review_invalid_rating_defaults_to_3(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_vendor_card: VendorCard,
-    ):
-        resp = client.post(
-            f"/v2/partials/vendors/{test_vendor_card.id}/reviews",
-            data={"rating": "not-a-number", "comment": ""},
-        )
-        assert resp.status_code == 200
-        review = db_session.query(VendorReview).filter_by(vendor_card_id=test_vendor_card.id).first()
-        assert review is not None
-        assert review.rating == 3
-
-    def test_add_review_clamps_rating_above_5(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_vendor_card: VendorCard,
-    ):
-        resp = client.post(
-            f"/v2/partials/vendors/{test_vendor_card.id}/reviews",
-            data={"rating": "99"},
-        )
-        assert resp.status_code == 200
-        review = db_session.query(VendorReview).filter_by(vendor_card_id=test_vendor_card.id).first()
-        assert review is not None
-        assert review.rating == 5
+        assert review.rating == expected_rating
 
     def test_add_review_vendor_not_found(self, client: TestClient):
         resp = client.post("/v2/partials/vendors/99999/reviews", data={"rating": "3"})
@@ -763,51 +745,33 @@ class TestEditQuoteMetadata:
 class TestUpdateResponseStatus:
     """Covers update_response_status (lines 5515-5550)."""
 
-    def test_update_status_to_reviewed(
+    @pytest.mark.parametrize(
+        ("status", "verify_stored"),
+        [
+            ("reviewed", True),
+            ("rejected", True),
+            ("flagged", False),
+        ],
+        ids=["reviewed", "rejected", "flagged"],
+    )
+    def test_update_status_valid(
         self,
         client: TestClient,
         db_session: Session,
         test_user: User,
+        status: str,
+        verify_stored: bool,
     ):
         req = _req(db_session, test_user)
         vr = _vendor_response(db_session, req)
         resp = client.patch(
             f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/status",
-            data={"status": "reviewed"},
+            data={"status": status},
         )
         assert resp.status_code == 200
-        db_session.refresh(vr)
-        assert vr.status == "reviewed"
-
-    def test_update_status_to_rejected(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_user: User,
-    ):
-        req = _req(db_session, test_user)
-        vr = _vendor_response(db_session, req)
-        resp = client.patch(
-            f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/status",
-            data={"status": "rejected"},
-        )
-        assert resp.status_code == 200
-        db_session.refresh(vr)
-        assert vr.status == "rejected"
-
-    def test_update_status_to_flagged(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_user: User,
-    ):
-        req = _req(db_session, test_user)
-        vr = _vendor_response(db_session, req)
-        resp = client.patch(
-            f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/status",
-            data={"status": "flagged"},
-        )
-        assert resp.status_code == 200
+        if verify_stored:
+            db_session.refresh(vr)
+            assert vr.status == status
 
     def test_update_status_invalid_raises_400(
         self,

--- a/tests/test_inline_cell_edit.py
+++ b/tests/test_inline_cell_edit.py
@@ -11,6 +11,8 @@ Depends on: conftest fixtures (client, db_session, test_user)
 from datetime import datetime, timezone
 from decimal import Decimal
 
+import pytest
+
 from app.models import Requirement, Requisition
 from tests.conftest import engine  # noqa: F401
 
@@ -47,15 +49,20 @@ def _make_requirement(db, requisition_id, **kwargs):
     return item
 
 
+@pytest.fixture()
+def part(db_session, test_user):
+    """A committed requisition + default requirement, returning the requirement."""
+    requisition = _make_requisition(db_session, test_user.id)
+    item = _make_requirement(db_session, requisition.id)
+    db_session.commit()
+    return item
+
+
 # ── GET /cell/edit/{field} ───────────────────────────────────────────
 
 
-def test_cell_edit_status_returns_select(client, db_session, test_user):
+def test_cell_edit_status_returns_select(client, part):
     """GET cell/edit/sourcing_status returns a <select> element."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id)
-    db_session.commit()
-
     resp = client.get(f"/v2/partials/parts/{part.id}/cell/edit/sourcing_status")
     assert resp.status_code == 200
     html = resp.text
@@ -64,12 +71,8 @@ def test_cell_edit_status_returns_select(client, db_session, test_user):
     assert 'name="value"' in html
 
 
-def test_cell_edit_qty_returns_input(client, db_session, test_user):
+def test_cell_edit_qty_returns_input(client, part):
     """GET cell/edit/target_qty returns a number input."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id)
-    db_session.commit()
-
     resp = client.get(f"/v2/partials/parts/{part.id}/cell/edit/target_qty")
     assert resp.status_code == 200
     html = resp.text
@@ -77,12 +80,8 @@ def test_cell_edit_qty_returns_input(client, db_session, test_user):
     assert f"cell-target_qty-{part.id}" in html
 
 
-def test_cell_edit_price_returns_input(client, db_session, test_user):
+def test_cell_edit_price_returns_input(client, part):
     """GET cell/edit/target_price returns a number input with step."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id)
-    db_session.commit()
-
     resp = client.get(f"/v2/partials/parts/{part.id}/cell/edit/target_price")
     assert resp.status_code == 200
     html = resp.text
@@ -91,12 +90,8 @@ def test_cell_edit_price_returns_input(client, db_session, test_user):
     assert f"cell-target_price-{part.id}" in html
 
 
-def test_cell_edit_invalid_field_returns_400(client, db_session, test_user):
+def test_cell_edit_invalid_field_returns_400(client, part):
     """GET cell/edit with invalid field returns 400."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id)
-    db_session.commit()
-
     resp = client.get(f"/v2/partials/parts/{part.id}/cell/edit/bogus_field")
     assert resp.status_code == 400
 
@@ -146,10 +141,8 @@ def test_cell_display_price(client, db_session, test_user):
     assert "$2.5000" in resp.text
 
 
-def test_cell_display_null_fields(client, db_session, test_user):
+def test_cell_display_null_fields(client, db_session, part):
     """Display cells render em-dash for null values."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id)
     # Force null after creation (bypasses column default=1)
     part.target_qty = None
     part.target_price = None
@@ -157,7 +150,6 @@ def test_cell_display_null_fields(client, db_session, test_user):
 
     resp_qty = client.get(f"/v2/partials/parts/{part.id}/cell/display/target_qty")
     assert resp_qty.status_code == 200
-    print("QTY RESPONSE:", repr(resp_qty.text))
     assert "$" not in resp_qty.text  # no dollar formatting for null
 
     resp_price = client.get(f"/v2/partials/parts/{part.id}/cell/display/target_price")
@@ -165,12 +157,8 @@ def test_cell_display_null_fields(client, db_session, test_user):
     assert "$" not in resp_price.text  # no dollar sign for null price
 
 
-def test_cell_display_invalid_field_returns_400(client, db_session, test_user):
+def test_cell_display_invalid_field_returns_400(client, part):
     """GET cell/display with invalid field returns 400."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id)
-    db_session.commit()
-
     resp = client.get(f"/v2/partials/parts/{part.id}/cell/display/bogus")
     assert resp.status_code == 400
 
@@ -184,12 +172,8 @@ def test_cell_display_missing_part_returns_404(client, db_session, test_user):
 # ── PATCH /cell (save) ───────────────────────────────────────────────
 
 
-def test_cell_save_qty(client, db_session, test_user):
+def test_cell_save_qty(client, db_session, part):
     """PATCH cell saves target_qty and returns display cell."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id, target_qty=5000)
-    db_session.commit()
-
     resp = client.patch(
         f"/v2/partials/parts/{part.id}/cell",
         data={"field": "target_qty", "value": "7500"},
@@ -202,12 +186,8 @@ def test_cell_save_qty(client, db_session, test_user):
     assert part.target_qty == 7500
 
 
-def test_cell_save_price(client, db_session, test_user):
+def test_cell_save_price(client, db_session, part):
     """PATCH cell saves target_price and returns display cell."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id)
-    db_session.commit()
-
     resp = client.patch(
         f"/v2/partials/parts/{part.id}/cell",
         data={"field": "target_price", "value": "3.7500"},
@@ -219,12 +199,8 @@ def test_cell_save_price(client, db_session, test_user):
     assert part.target_price == Decimal("3.7500")
 
 
-def test_cell_save_status(client, db_session, test_user):
+def test_cell_save_status(client, part):
     """PATCH cell saves sourcing_status via transition_requirement."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id, sourcing_status="open")
-    db_session.commit()
-
     resp = client.patch(
         f"/v2/partials/parts/{part.id}/cell",
         data={"field": "sourcing_status", "value": "sourcing"},
@@ -233,12 +209,8 @@ def test_cell_save_status(client, db_session, test_user):
     assert "sourcing" in resp.text
 
 
-def test_cell_save_empty_qty_sets_none(client, db_session, test_user):
+def test_cell_save_empty_qty_sets_none(client, db_session, part):
     """PATCH cell with empty value sets target_qty to None."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id, target_qty=5000)
-    db_session.commit()
-
     resp = client.patch(
         f"/v2/partials/parts/{part.id}/cell",
         data={"field": "target_qty", "value": ""},
@@ -249,12 +221,8 @@ def test_cell_save_empty_qty_sets_none(client, db_session, test_user):
     assert part.target_qty is None
 
 
-def test_cell_save_invalid_qty_sets_none(client, db_session, test_user):
+def test_cell_save_invalid_qty_sets_none(client, db_session, part):
     """PATCH cell with non-numeric qty sets target_qty to None."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id, target_qty=5000)
-    db_session.commit()
-
     resp = client.patch(
         f"/v2/partials/parts/{part.id}/cell",
         data={"field": "target_qty", "value": "abc"},
@@ -265,12 +233,8 @@ def test_cell_save_invalid_qty_sets_none(client, db_session, test_user):
     assert part.target_qty is None
 
 
-def test_cell_save_invalid_field_returns_400(client, db_session, test_user):
+def test_cell_save_invalid_field_returns_400(client, part):
     """PATCH cell with invalid field returns 400."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id)
-    db_session.commit()
-
     resp = client.patch(
         f"/v2/partials/parts/{part.id}/cell",
         data={"field": "bogus", "value": "x"},
@@ -287,12 +251,8 @@ def test_cell_save_missing_part_returns_404(client, db_session, test_user):
     assert resp.status_code == 404
 
 
-def test_cell_save_triggers_part_updated(client, db_session, test_user):
+def test_cell_save_triggers_part_updated(client, part):
     """PATCH cell includes HX-Trigger header with part-updated event."""
-    requisition = _make_requisition(db_session, test_user.id)
-    part = _make_requirement(db_session, requisition.id)
-    db_session.commit()
-
     resp = client.patch(
         f"/v2/partials/parts/{part.id}/cell",
         data={"field": "target_qty", "value": "999"},

--- a/tests/test_integration_crm.py
+++ b/tests/test_integration_crm.py
@@ -85,6 +85,23 @@ def _create_req_with_requirement(client):
     return req["id"], items["created"][0]["id"]
 
 
+def _make_vendor_card(db_session, normalized_name, display_name, **kwargs):
+    """Helper: create + commit a VendorCard, return the refreshed instance."""
+    from app.models import VendorCard
+
+    card = VendorCard(
+        normalized_name=normalized_name,
+        display_name=display_name,
+        emails=[],
+        phones=[],
+        **kwargs,
+    )
+    db_session.add(card)
+    db_session.commit()
+    db_session.refresh(card)
+    return card
+
+
 def test_create_offer(client):
     req_id, req_item_id = _create_req_with_requirement(client)
     resp = client.post(
@@ -193,18 +210,7 @@ def test_delete_nonexistent_offer(client):
 
 def test_offer_fuzzy_match_reuses_existing_card(client, db_session):
     """Fuzzy match reuses existing VendorCard instead of creating a new one."""
-    from app.models import VendorCard
-
-    card = VendorCard(
-        normalized_name="arrow electronics",
-        display_name="Arrow Electronics",
-        emails=[],
-        phones=[],
-        sighting_count=10,
-    )
-    db_session.add(card)
-    db_session.commit()
-    db_session.refresh(card)
+    card = _make_vendor_card(db_session, "arrow electronics", "Arrow Electronics", sighting_count=10)
 
     req_id, req_item_id = _create_req_with_requirement(client)
     # "Arrow Electronic" (missing trailing 's') — close enough for fuzzy ≥88
@@ -226,17 +232,7 @@ def test_offer_fuzzy_match_reuses_existing_card(client, db_session):
 
 def test_offer_vendor_card_id_skips_name_matching(client, db_session):
     """When vendor_card_id is provided, skip all name matching."""
-    from app.models import VendorCard
-
-    card = VendorCard(
-        normalized_name="totally different name",
-        display_name="Totally Different Name",
-        emails=[],
-        phones=[],
-    )
-    db_session.add(card)
-    db_session.commit()
-    db_session.refresh(card)
+    card = _make_vendor_card(db_session, "totally different name", "Totally Different Name")
 
     req_id, req_item_id = _create_req_with_requirement(client)
     resp = client.post(
@@ -255,17 +251,7 @@ def test_offer_vendor_card_id_skips_name_matching(client, db_session):
 
 def test_offer_exact_match_before_fuzzy(client, db_session):
     """Exact normalized match is preferred over fuzzy match."""
-    from app.models import VendorCard
-
-    card = VendorCard(
-        normalized_name="mouser electronics",
-        display_name="Mouser Electronics",
-        emails=[],
-        phones=[],
-    )
-    db_session.add(card)
-    db_session.commit()
-    db_session.refresh(card)
+    card = _make_vendor_card(db_session, "mouser electronics", "Mouser Electronics")
 
     req_id, req_item_id = _create_req_with_requirement(client)
     resp = client.post(

--- a/tests/test_integrity_service.py
+++ b/tests/test_integrity_service.py
@@ -18,6 +18,7 @@ Covers:
 
 from datetime import datetime, timezone
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models import MaterialCard, MaterialCardAudit, MaterialVendorHistory, Offer, Requirement, Sighting
@@ -108,6 +109,21 @@ def _make_card(db: Session, norm: str = "lm317t", display: str = "LM317T") -> Ma
     db.add(c)
     db.commit()
     return c
+
+
+def _orphan_card_via_dangling_delete(db: Session, card_id) -> None:
+    """Delete a card with SQLite FK checks disabled to simulate a dangling FK.
+
+    SQLite enforces FKs, so we temporarily disable them to reproduce the dangling state
+    that can occur in PostgreSQL via race conditions or direct SQL manipulation.
+    """
+    from sqlalchemy import text
+
+    db.execute(text("PRAGMA foreign_keys=OFF"))
+    db.execute(text("DELETE FROM material_cards WHERE id = :cid"), {"cid": card_id})
+    db.commit()
+    db.execute(text("PRAGMA foreign_keys=ON"))
+    db.expire_all()  # Expire ORM cache so it re-reads from DB
 
 
 # ── resolve_material_card Tests ──────────────────────────────────────
@@ -339,50 +355,25 @@ class TestDanglingFKs:
         assert result["requirements"] == 0
 
     def test_detects_dangling_after_card_delete(self, db_session):
-        """If a card is deleted and FK goes to a non-existent ID, detect it.
-
-        SQLite enforces FKs, so we temporarily disable them to simulate the dangling
-        state that can occur in PostgreSQL via race conditions or direct SQL
-        manipulation.
-        """
-        from sqlalchemy import text
-
+        """If a card is deleted and FK goes to a non-existent ID, detect it."""
         user = _make_user(db_session)
         reqn = _make_requisition(db_session, user)
         card = _make_card(db_session)
-        req = _make_requirement(db_session, reqn, card_id=card.id)
-        card_id = card.id
-        req_id = req.id
+        _make_requirement(db_session, reqn, card_id=card.id)
 
-        # Temporarily disable FK checks to simulate dangling state
-        db_session.execute(text("PRAGMA foreign_keys=OFF"))
-        db_session.execute(text("DELETE FROM material_cards WHERE id = :cid"), {"cid": card_id})
-        db_session.commit()
-        db_session.execute(text("PRAGMA foreign_keys=ON"))
-
-        # Expire ORM cache so it re-reads from DB
-        db_session.expire_all()
+        _orphan_card_via_dangling_delete(db_session, card.id)
 
         result = check_dangling_fks(db_session)
         assert result["requirements"] == 1
 
     def test_clear_dangling_fks(self, db_session):
         """clear_dangling_fks sets material_card_id to NULL for dangling refs."""
-        from sqlalchemy import text
-
         user = _make_user(db_session)
         reqn = _make_requisition(db_session, user)
         card = _make_card(db_session)
         req = _make_requirement(db_session, reqn, card_id=card.id)
-        card_id = card.id
-        req_id = req.id
 
-        # Create dangling state by deleting card with FKs disabled
-        db_session.execute(text("PRAGMA foreign_keys=OFF"))
-        db_session.execute(text("DELETE FROM material_cards WHERE id = :cid"), {"cid": card_id})
-        db_session.commit()
-        db_session.execute(text("PRAGMA foreign_keys=ON"))
-        db_session.expire_all()
+        _orphan_card_via_dangling_delete(db_session, card.id)
 
         result = clear_dangling_fks(db_session)
         assert result["requirements"] == 1
@@ -460,20 +451,12 @@ class TestRunIntegrityCheck:
 
     def test_clears_and_heals_dangling(self, db_session):
         """Dangling FKs are cleared, then the now-orphaned records are healed."""
-        from sqlalchemy import text
-
         user = _make_user(db_session)
         reqn = _make_requisition(db_session, user)
         card = _make_card(db_session)
         req = _make_requirement(db_session, reqn, mpn="LM317T", card_id=card.id)
-        card_id = card.id
 
-        # Create dangling state
-        db_session.execute(text("PRAGMA foreign_keys=OFF"))
-        db_session.execute(text("DELETE FROM material_cards WHERE id = :cid"), {"cid": card_id})
-        db_session.commit()
-        db_session.execute(text("PRAGMA foreign_keys=ON"))
-        db_session.expire_all()
+        _orphan_card_via_dangling_delete(db_session, card.id)
 
         report = run_integrity_check(db_session)
 
@@ -944,49 +927,33 @@ class TestSoftDelete:
 
 
 class TestHealExceptionPaths:
-    def test_sighting_heal_exception_rolls_back(self, db_session):
-        """Lines 186-188: exception healing a sighting is caught and rolled back."""
+    @pytest.mark.parametrize(
+        ("entity_key", "fail_mpn"),
+        [
+            ("sightings", "FAIL-SIGHT"),
+            ("offers", "FAIL-OFFER"),
+        ],
+    )
+    def test_heal_exception_rolls_back(self, db_session, entity_key, fail_mpn):
+        """Exception healing a sighting/offer is caught and rolled back (not healed)."""
         from unittest.mock import patch
 
         user = _make_user(db_session)
         reqn = _make_requisition(db_session, user)
         req = _make_requirement(db_session, reqn, card_id=None)
-        _make_sighting(db_session, req, mpn="FAIL-SIGHT", card_id=None)
+        if entity_key == "sightings":
+            _make_sighting(db_session, req, mpn=fail_mpn, card_id=None)
+        else:
+            _make_offer(db_session, reqn, req, mpn=fail_mpn, card_id=None)
 
-        # Make resolve_material_card raise only for sightings by tracking calls
         original = resolve_material_card
-        call_count = [0]
 
         def failing_resolve(mpn, db_arg):
-            call_count[0] += 1
-            if mpn == "FAIL-SIGHT":
-                raise RuntimeError("sighting heal fail")
+            if mpn == fail_mpn:
+                raise RuntimeError(f"{entity_key} heal fail")
             return original(mpn, db_arg)
 
         with patch("app.search_service.resolve_material_card", side_effect=failing_resolve):
             result = heal_orphaned_records(db_session)
 
-        # Sighting should not have been healed
-        assert result["sightings"] == 0
-
-    def test_offer_heal_exception_rolls_back(self, db_session):
-        """Lines 210-212: exception healing an offer is caught and rolled back."""
-        from unittest.mock import patch
-
-        user = _make_user(db_session)
-        reqn = _make_requisition(db_session, user)
-        req = _make_requirement(db_session, reqn, card_id=None)
-        _make_offer(db_session, reqn, req, mpn="FAIL-OFFER", card_id=None)
-
-        original = resolve_material_card
-
-        def failing_resolve(mpn, db_arg):
-            if mpn == "FAIL-OFFER":
-                raise RuntimeError("offer heal fail")
-            return original(mpn, db_arg)
-
-        with patch("app.search_service.resolve_material_card", side_effect=failing_resolve):
-            result = heal_orphaned_records(db_session)
-
-        # Offer should not have been healed
-        assert result["offers"] == 0
+        assert result[entity_key] == 0

--- a/tests/test_jobs_coverage_2.py
+++ b/tests/test_jobs_coverage_2.py
@@ -47,6 +47,31 @@ def _mock_db():
     return db
 
 
+def _two_session_factory(first_db, second_db):
+    """Return a SessionLocal side_effect: first call -> first_db, rest -> second_db.
+
+    Mirrors the selector/task split used by token-refresh and inbox-scan jobs.
+    """
+    call_count = [0]
+
+    def session_factory():
+        call_count[0] += 1
+        return first_db if call_count[0] == 1 else second_db
+
+    return session_factory
+
+
+def _digikey_config():
+    """Standard DigiKey connector config dict used by _try_connector_config tests."""
+    return {
+        "name": "digikey",
+        "module": "app.connectors.digikey",
+        "class": "DigiKeyConnector",
+        "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
+        "confidence": 0.95,
+    }
+
+
 # ===========================================================================
 # offers_jobs.py
 # ===========================================================================
@@ -55,42 +80,27 @@ def _mock_db():
 class TestRegisterOffersJobs:
     """Tests for register_offers_jobs()."""
 
-    def test_register_with_proactive_matching_enabled(self):
+    @pytest.mark.parametrize(
+        "enabled, scan_interval_hours, expected_jobs",
+        [
+            # 6 jobs: proactive_matching + performance_tracking + proactive_offer_expiry
+            # + flag_stale_offers + expire_strategic_vendors + warn_strategic_expiring
+            pytest.param(True, 4, 6, id="enabled"),
+            # 5 jobs (no proactive_matching)
+            pytest.param(False, None, 5, id="disabled"),
+            pytest.param(True, 0, 6, id="interval_below_min"),
+        ],
+    )
+    def test_register(self, enabled, scan_interval_hours, expected_jobs):
         from app.jobs.offers_jobs import register_offers_jobs
 
         scheduler = MagicMock()
         settings = MagicMock()
-        settings.proactive_matching_enabled = True
-        settings.proactive_scan_interval_hours = 4
+        settings.proactive_matching_enabled = enabled
+        settings.proactive_scan_interval_hours = scan_interval_hours
 
         register_offers_jobs(scheduler, settings)
-
-        # 6 jobs: proactive_matching + performance_tracking + proactive_offer_expiry
-        # + flag_stale_offers + expire_strategic_vendors + warn_strategic_expiring
-        assert scheduler.add_job.call_count == 6
-
-    def test_register_with_proactive_matching_disabled(self):
-        from app.jobs.offers_jobs import register_offers_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.proactive_matching_enabled = False
-
-        register_offers_jobs(scheduler, settings)
-
-        # 5 jobs (no proactive_matching)
-        assert scheduler.add_job.call_count == 5
-
-    def test_proactive_scan_interval_minimum_1(self):
-        from app.jobs.offers_jobs import register_offers_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.proactive_matching_enabled = True
-        settings.proactive_scan_interval_hours = 0  # below min
-
-        register_offers_jobs(scheduler, settings)
-        assert scheduler.add_job.call_count == 6
+        assert scheduler.add_job.call_count == expected_jobs
 
 
 class TestJobProactiveMatching:
@@ -738,27 +748,23 @@ class TestParseStockFile:
 
 
 class TestRegisterCoreJobs:
-    def test_registers_with_activity_tracking(self):
+    @pytest.mark.parametrize(
+        "activity_tracking_enabled, expected_jobs",
+        [
+            pytest.param(True, 7, id="with_activity_tracking"),
+            pytest.param(False, 6, id="without_activity_tracking"),
+        ],
+    )
+    def test_registers(self, activity_tracking_enabled, expected_jobs):
         from app.jobs.core_jobs import register_core_jobs
 
         scheduler = MagicMock()
         settings = MagicMock()
         settings.inbox_scan_interval_min = 5
-        settings.activity_tracking_enabled = True
+        settings.activity_tracking_enabled = activity_tracking_enabled
 
         register_core_jobs(scheduler, settings)
-        assert scheduler.add_job.call_count == 7
-
-    def test_registers_without_activity_tracking(self):
-        from app.jobs.core_jobs import register_core_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.inbox_scan_interval_min = 5
-        settings.activity_tracking_enabled = False
-
-        register_core_jobs(scheduler, settings)
-        assert scheduler.add_job.call_count == 6
+        assert scheduler.add_job.call_count == expected_jobs
 
 
 class TestJobAutoArchive:
@@ -854,15 +860,7 @@ class TestJobTokenRefresh:
         task_db = _mock_db()
         task_db.get.return_value = user
 
-        call_count = [0]
-
-        def session_factory():
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return selector_db
-            return task_db
-
-        with patch("app.database.SessionLocal", side_effect=session_factory):
+        with patch("app.database.SessionLocal", side_effect=_two_session_factory(selector_db, task_db)):
             with patch("app.jobs.core_jobs._utc", side_effect=lambda x: x):
                 with patch("app.cache.intel_cache._get_redis", return_value=None):
                     with patch(
@@ -889,15 +887,7 @@ class TestJobTokenRefresh:
         task_db = _mock_db()
         task_db.get.return_value = user
 
-        call_count = [0]
-
-        def session_factory():
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return selector_db
-            return task_db
-
-        with patch("app.database.SessionLocal", side_effect=session_factory):
+        with patch("app.database.SessionLocal", side_effect=_two_session_factory(selector_db, task_db)):
             with patch("app.cache.intel_cache._get_redis", return_value=None):
                 with patch(
                     "app.utils.token_manager.refresh_user_token",
@@ -1212,15 +1202,7 @@ class TestJobInboxScan:
         scan_db = _mock_db()
         scan_db.get.return_value = user
 
-        call_count = [0]
-
-        def session_factory():
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return selector_db
-            return scan_db
-
-        with patch("app.database.SessionLocal", side_effect=session_factory):
+        with patch("app.database.SessionLocal", side_effect=_two_session_factory(selector_db, scan_db)):
             with patch("app.config.settings") as mock_settings:
                 mock_settings.inbox_scan_interval_min = 5
                 with patch(
@@ -1672,13 +1654,7 @@ class TestTryConnectorConfig:
     def test_missing_credentials(self):
         from app.services.enrichment import _try_connector_config
 
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
+        config = _digikey_config()
 
         with patch("app.services.enrichment.get_credential_cached", return_value=None):
             out = _run(_try_connector_config(config, "LM358"))
@@ -1688,13 +1664,7 @@ class TestTryConnectorConfig:
     def test_successful_search(self):
         from app.services.enrichment import _try_connector_config
 
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
+        config = _digikey_config()
 
         mock_connector = MagicMock()
         mock_connector.search = AsyncMock(return_value=[{"manufacturer": "Texas Instruments", "category": "IC"}])
@@ -1711,97 +1681,47 @@ class TestTryConnectorConfig:
         assert out["manufacturer"] == "Texas Instruments"
         assert out["source"] == "digikey"
 
-    def test_timeout(self):
+    @pytest.mark.parametrize(
+        "config, wait_for_kwargs",
+        [
+            pytest.param(
+                _digikey_config(),
+                {"side_effect": asyncio.TimeoutError},
+                id="timeout",
+            ),
+            pytest.param(
+                _digikey_config(),
+                {"side_effect": Exception("401 Unauthorized")},
+                id="auth_error",
+            ),
+            pytest.param(
+                {
+                    "name": "mouser",
+                    "module": "app.connectors.mouser",
+                    "class": "MouserConnector",
+                    "creds": [("mouser", "MOUSER_API_KEY")],
+                    "confidence": 0.95,
+                },
+                {"side_effect": Exception("429 rate limit exceeded")},
+                id="rate_limit_error",
+            ),
+            pytest.param(
+                _digikey_config(),
+                {"return_value": [{"manufacturer": "Unknown", "category": ""}]},
+                id="ignored_manufacturer",
+            ),
+        ],
+    )
+    def test_returns_none(self, config, wait_for_kwargs):
         from app.services.enrichment import _try_connector_config
-
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
 
         with patch("app.services.enrichment.get_credential_cached", return_value="key123"):
             with patch("app.services.enrichment.importlib.import_module") as mock_import:
-                mock_module = MagicMock()
-                mock_import.return_value = mock_module
+                mock_import.return_value = MagicMock()
                 with patch(
                     "app.services.enrichment.asyncio.wait_for",
                     new_callable=AsyncMock,
-                    side_effect=asyncio.TimeoutError,
-                ):
-                    out = _run(_try_connector_config(config, "LM358"))
-
-        assert out is None
-
-    def test_auth_error(self):
-        from app.services.enrichment import _try_connector_config
-
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
-
-        with patch("app.services.enrichment.get_credential_cached", return_value="key123"):
-            with patch("app.services.enrichment.importlib.import_module") as mock_import:
-                mock_module = MagicMock()
-                mock_import.return_value = mock_module
-                with patch(
-                    "app.services.enrichment.asyncio.wait_for",
-                    new_callable=AsyncMock,
-                    side_effect=Exception("401 Unauthorized"),
-                ):
-                    out = _run(_try_connector_config(config, "LM358"))
-
-        assert out is None
-
-    def test_rate_limit_error(self):
-        from app.services.enrichment import _try_connector_config
-
-        config = {
-            "name": "mouser",
-            "module": "app.connectors.mouser",
-            "class": "MouserConnector",
-            "creds": [("mouser", "MOUSER_API_KEY")],
-            "confidence": 0.95,
-        }
-
-        with patch("app.services.enrichment.get_credential_cached", return_value="key123"):
-            with patch("app.services.enrichment.importlib.import_module") as mock_import:
-                mock_module = MagicMock()
-                mock_import.return_value = mock_module
-                with patch(
-                    "app.services.enrichment.asyncio.wait_for",
-                    new_callable=AsyncMock,
-                    side_effect=Exception("429 rate limit exceeded"),
-                ):
-                    out = _run(_try_connector_config(config, "LM358"))
-
-        assert out is None
-
-    def test_ignored_manufacturer(self):
-        from app.services.enrichment import _try_connector_config
-
-        config = {
-            "name": "digikey",
-            "module": "app.connectors.digikey",
-            "class": "DigiKeyConnector",
-            "creds": [("digikey", "DIGIKEY_CLIENT_ID")],
-            "confidence": 0.95,
-        }
-
-        with patch("app.services.enrichment.get_credential_cached", return_value="key123"):
-            with patch("app.services.enrichment.importlib.import_module") as mock_import:
-                mock_module = MagicMock()
-                mock_import.return_value = mock_module
-                with patch(
-                    "app.services.enrichment.asyncio.wait_for",
-                    new_callable=AsyncMock,
-                    return_value=[{"manufacturer": "Unknown", "category": ""}],
+                    **wait_for_kwargs,
                 ):
                     out = _run(_try_connector_config(config, "LM358"))
 
@@ -2619,15 +2539,7 @@ class TestJobTokenRefreshEdgeCases:
         mock_redis = MagicMock()
         mock_redis.set.return_value = True
 
-        call_count = [0]
-
-        def session_factory():
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return selector_db
-            return task_db
-
-        with patch("app.database.SessionLocal", side_effect=session_factory):
+        with patch("app.database.SessionLocal", side_effect=_two_session_factory(selector_db, task_db)):
             with patch("app.jobs.core_jobs._utc", side_effect=lambda x: x):
                 with patch("app.cache.intel_cache._get_redis", return_value=mock_redis):
                     with patch(
@@ -2659,15 +2571,7 @@ class TestJobTokenRefreshEdgeCases:
         mock_redis = MagicMock()
         mock_redis.set.return_value = False
 
-        call_count = [0]
-
-        def session_factory():
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return selector_db
-            return task_db
-
-        with patch("app.database.SessionLocal", side_effect=session_factory):
+        with patch("app.database.SessionLocal", side_effect=_two_session_factory(selector_db, task_db)):
             with patch("app.jobs.core_jobs._utc", side_effect=lambda x: x):
                 with patch("app.cache.intel_cache._get_redis", return_value=mock_redis):
                     _run(_job_token_refresh.__wrapped__())
@@ -2690,15 +2594,7 @@ class TestJobTokenRefreshEdgeCases:
         task_db = _mock_db()
         task_db.get.return_value = user
 
-        call_count = [0]
-
-        def session_factory():
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return selector_db
-            return task_db
-
-        with patch("app.database.SessionLocal", side_effect=session_factory):
+        with patch("app.database.SessionLocal", side_effect=_two_session_factory(selector_db, task_db)):
             with patch("app.jobs.core_jobs._utc", side_effect=lambda x: x):
                 with patch("app.cache.intel_cache._get_redis", return_value=None):
                     with patch(
@@ -2742,15 +2638,7 @@ class TestJobInboxScanEdgeCases:
         scan_db = _mock_db()
         scan_db.get.return_value = user
 
-        call_count = [0]
-
-        def session_factory():
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return selector_db
-            return scan_db
-
-        with patch("app.database.SessionLocal", side_effect=session_factory):
+        with patch("app.database.SessionLocal", side_effect=_two_session_factory(selector_db, scan_db)):
             with patch("app.config.settings") as mock_settings:
                 mock_settings.inbox_scan_interval_min = 5
                 with patch(
@@ -2779,15 +2667,7 @@ class TestJobInboxScanEdgeCases:
         scan_db = _mock_db()
         scan_db.get.return_value = user
 
-        call_count = [0]
-
-        def session_factory():
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return selector_db
-            return scan_db
-
-        with patch("app.database.SessionLocal", side_effect=session_factory):
+        with patch("app.database.SessionLocal", side_effect=_two_session_factory(selector_db, scan_db)):
             with patch("app.config.settings") as mock_settings:
                 mock_settings.inbox_scan_interval_min = 5
                 with patch(

--- a/tests/test_material_card_service.py
+++ b/tests/test_material_card_service.py
@@ -252,17 +252,20 @@ class TestMergeMaterialCards:
         db_session.refresh(item)
         assert item.material_card_id == target.id
 
-    def test_same_id_raises(self, db_session: Session, test_material_card):
-        with pytest.raises(ValueError, match="Cannot merge a card with itself"):
-            merge_material_cards(db_session, test_material_card.id, test_material_card.id, "x@test.com")
-
-    def test_source_not_found_raises(self, db_session: Session, test_material_card):
-        with pytest.raises(ValueError, match="Source card 99999 not found"):
-            merge_material_cards(db_session, 99999, test_material_card.id, "x@test.com")
-
-    def test_target_not_found_raises(self, db_session: Session, test_material_card):
-        with pytest.raises(ValueError, match="Target card 99999 not found"):
-            merge_material_cards(db_session, test_material_card.id, 99999, "x@test.com")
+    @pytest.mark.parametrize(
+        "source_id_self,target_id,match",
+        [
+            (True, "self", "Cannot merge a card with itself"),
+            (False, "card", "Source card 99999 not found"),
+            (True, "missing", "Target card 99999 not found"),
+        ],
+        ids=["same_id", "source_not_found", "target_not_found"],
+    )
+    def test_invalid_merge_raises(self, db_session: Session, test_material_card, source_id_self, target_id, match):
+        source = test_material_card.id if source_id_self else 99999
+        target = {"self": test_material_card.id, "card": test_material_card.id, "missing": 99999}[target_id]
+        with pytest.raises(ValueError, match=match):
+            merge_material_cards(db_session, source, target, "x@test.com")
 
     @patch("app.services.audit_service.log_audit")
     def test_merge_vendor_histories_combined(self, mock_audit, db_session: Session):

--- a/tests/test_material_enrichment_service_coverage.py
+++ b/tests/test_material_enrichment_service_coverage.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.models import MaterialCard
+from app.utils.claude_errors import ClaudeError, ClaudeUnavailableError
 
 
 @pytest.fixture
@@ -197,56 +198,35 @@ async def test_batch_enrich_returns_none_when_no_cards(db):
     assert result is None
 
 
-@pytest.mark.asyncio
-async def test_batch_enrich_claude_unavailable_returns_none(db):
-    """ClaudeUnavailableError → returns None (lines 294-296)."""
-    from app.services.material_enrichment_service import batch_enrich_materials
-    from app.utils.claude_errors import ClaudeUnavailableError
-
-    _make_card(db, "PART-A")
-
-    mock_redis = MagicMock()
-    mock_redis.get.return_value = None
-    with (
-        patch("app.services.material_enrichment_service._get_redis", return_value=mock_redis),
-        patch(
-            "app.services.material_enrichment_service.claude_batch_submit",
-            new_callable=AsyncMock,
-            side_effect=ClaudeUnavailableError("not configured"),
+@pytest.mark.parametrize(
+    ("card_name", "submit_kwargs"),
+    [
+        # ClaudeUnavailableError → returns None (lines 294-296)
+        pytest.param(
+            "PART-A",
+            {"side_effect": ClaudeUnavailableError("not configured")},
+            id="claude_unavailable",
         ),
-    ):
-        result = await batch_enrich_materials(db)
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_batch_enrich_claude_error_returns_none(db):
-    """ClaudeError → returns None (lines 297-299)."""
-    from app.services.material_enrichment_service import batch_enrich_materials
-    from app.utils.claude_errors import ClaudeError
-
-    _make_card(db, "PART-B")
-
-    mock_redis = MagicMock()
-    mock_redis.get.return_value = None
-    with (
-        patch("app.services.material_enrichment_service._get_redis", return_value=mock_redis),
-        patch(
-            "app.services.material_enrichment_service.claude_batch_submit",
-            new_callable=AsyncMock,
-            side_effect=ClaudeError("api error"),
+        # ClaudeError → returns None (lines 297-299)
+        pytest.param(
+            "PART-B",
+            {"side_effect": ClaudeError("api error")},
+            id="claude_error",
         ),
-    ):
-        result = await batch_enrich_materials(db)
-    assert result is None
-
-
+        # claude_batch_submit returns None → returns None (lines 300-302)
+        pytest.param(
+            "PART-C",
+            {"return_value": None},
+            id="none_batch_id",
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_batch_enrich_none_batch_id_returns_none(db):
-    """claude_batch_submit returns None → returns None (lines 300-302)."""
+async def test_batch_enrich_submit_failure_returns_none(db, card_name, submit_kwargs):
+    """A failing/empty claude_batch_submit makes batch_enrich_materials return None."""
     from app.services.material_enrichment_service import batch_enrich_materials
 
-    _make_card(db, "PART-C")
+    _make_card(db, card_name)
 
     mock_redis = MagicMock()
     mock_redis.get.return_value = None
@@ -255,7 +235,7 @@ async def test_batch_enrich_none_batch_id_returns_none(db):
         patch(
             "app.services.material_enrichment_service.claude_batch_submit",
             new_callable=AsyncMock,
-            return_value=None,
+            **submit_kwargs,
         ),
     ):
         result = await batch_enrich_materials(db)
@@ -352,7 +332,6 @@ async def test_process_batch_returns_none_when_still_processing(db):
 async def test_process_batch_claude_error_returns_none(db):
     """ClaudeError during poll → returns None (lines 332-335)."""
     from app.services.material_enrichment_service import process_material_batch_results
-    from app.utils.claude_errors import ClaudeError
 
     mock_redis = MagicMock()
     mock_redis.get.return_value = "batch-456"

--- a/tests/test_materials_ai_search.py
+++ b/tests/test_materials_ai_search.py
@@ -67,22 +67,18 @@ def _patch_claude_json(return_value=None, side_effect=None):
 
 
 @pytest.mark.asyncio
-async def test_interpret_returns_none_for_short_query():
-    """Queries with fewer than 3 words should return None without calling API."""
-    result = await interpret_search_query("DDR5")
-    assert result is None
-
-    result = await interpret_search_query("DDR5 memory")
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_interpret_returns_none_for_empty_query():
-    """Empty or None queries should return None."""
-    result = await interpret_search_query("")
-    assert result is None
-
-    result = await interpret_search_query(None)
+@pytest.mark.parametrize(
+    "query",
+    [
+        pytest.param("DDR5", id="one_word"),
+        pytest.param("DDR5 memory", id="two_words"),
+        pytest.param("", id="empty"),
+        pytest.param(None, id="none"),
+    ],
+)
+async def test_interpret_returns_none_without_api_call(query):
+    """Short, empty, or None queries should return None without calling the API."""
+    result = await interpret_search_query(query)
     assert result is None
 
 

--- a/tests/test_materials_tab.py
+++ b/tests/test_materials_tab.py
@@ -1,6 +1,17 @@
 # tests/test_materials_tab.py
 """Integration tests for Materials tab routes."""
 
+import pytest
+
+from app.models import MaterialCard
+
+
+def _add_card(db_session, mpn, **kwargs):
+    card = MaterialCard(normalized_mpn=mpn, display_mpn=mpn, **kwargs)
+    db_session.add(card)
+    db_session.commit()
+    return card
+
 
 def test_materials_list_returns_workspace(client, db_session):
     """GET /v2/partials/materials returns faceted workspace shell."""
@@ -12,11 +23,7 @@ def test_materials_list_returns_workspace(client, db_session):
 
 def test_materials_faceted_returns_results(client, db_session):
     """GET /v2/partials/materials/faceted returns material rows."""
-    from app.models import MaterialCard
-
-    card = MaterialCard(normalized_mpn="INT-TEST-001", display_mpn="INT-TEST-001", manufacturer="TestMfg")
-    db_session.add(card)
-    db_session.commit()
+    _add_card(db_session, "INT-TEST-001", manufacturer="TestMfg")
 
     resp = client.get("/v2/partials/materials/faceted")
     assert resp.status_code == 200
@@ -25,96 +32,42 @@ def test_materials_faceted_returns_results(client, db_session):
 
 def test_materials_faceted_search_mpn(client, db_session):
     """Faceted search by MPN returns matching material."""
-    from app.models import MaterialCard
-
-    card = MaterialCard(normalized_mpn="LM358DR", display_mpn="LM358DR")
-    db_session.add(card)
-    db_session.commit()
+    _add_card(db_session, "LM358DR")
 
     resp = client.get("/v2/partials/materials/faceted?q=LM358")
     assert resp.status_code == 200
     assert "LM358DR" in resp.text
 
 
-def test_material_detail_returns_html(client, db_session):
-    """GET /v2/partials/materials/{id} returns detail page."""
-    from app.models import MaterialCard
+@pytest.mark.parametrize(
+    ("mpn", "path", "expected_substring"),
+    [
+        pytest.param("DETAIL-001", "", "DETAIL-001", id="detail"),
+        pytest.param("TAB-001", "/tab/vendors", "No vendor history", id="tab_vendors"),
+        pytest.param("CUST-001", "/tab/customers", "No customer purchase history", id="tab_customers"),
+        pytest.param("SRC-001", "/tab/sourcing", "No sourcing activity", id="tab_sourcing"),
+        pytest.param("PRICE-001", "/tab/price_history", "Price tracking active", id="tab_price_history_empty"),
+    ],
+)
+def test_material_detail_and_tabs_render(client, db_session, mpn, path, expected_substring):
+    """Material detail and each tab partial return HTML with the expected content."""
+    card = _add_card(db_session, mpn)
 
-    card = MaterialCard(normalized_mpn="DETAIL-001", display_mpn="DETAIL-001")
-    db_session.add(card)
-    db_session.commit()
-
-    resp = client.get(f"/v2/partials/materials/{card.id}")
+    resp = client.get(f"/v2/partials/materials/{card.id}{path}")
     assert resp.status_code == 200
-    assert "DETAIL-001" in resp.text
-
-
-def test_material_tab_vendors(client, db_session):
-    """GET /v2/partials/materials/{id}/tab/vendors returns vendor table."""
-    from app.models import MaterialCard
-
-    card = MaterialCard(normalized_mpn="TAB-001", display_mpn="TAB-001")
-    db_session.add(card)
-    db_session.commit()
-
-    resp = client.get(f"/v2/partials/materials/{card.id}/tab/vendors")
-    assert resp.status_code == 200
-    assert "No vendor history" in resp.text
-
-
-def test_material_tab_customers(client, db_session):
-    """Customers tab returns HTML."""
-    from app.models import MaterialCard
-
-    card = MaterialCard(normalized_mpn="CUST-001", display_mpn="CUST-001")
-    db_session.add(card)
-    db_session.commit()
-
-    resp = client.get(f"/v2/partials/materials/{card.id}/tab/customers")
-    assert resp.status_code == 200
-    assert "No customer purchase history" in resp.text
-
-
-def test_material_tab_sourcing(client, db_session):
-    """Sourcing tab returns HTML."""
-    from app.models import MaterialCard
-
-    card = MaterialCard(normalized_mpn="SRC-001", display_mpn="SRC-001")
-    db_session.add(card)
-    db_session.commit()
-
-    resp = client.get(f"/v2/partials/materials/{card.id}/tab/sourcing")
-    assert resp.status_code == 200
-    assert "No sourcing activity" in resp.text
-
-
-def test_material_tab_price_history_empty(client, db_session):
-    """Price history tab shows empty state."""
-    from app.models import MaterialCard
-
-    card = MaterialCard(normalized_mpn="PRICE-001", display_mpn="PRICE-001")
-    db_session.add(card)
-    db_session.commit()
-
-    resp = client.get(f"/v2/partials/materials/{card.id}/tab/price_history")
-    assert resp.status_code == 200
-    assert "Price tracking active" in resp.text
+    assert expected_substring in resp.text
 
 
 def test_material_detail_shows_cross_references(client, db_session):
     """Cross-references section appears on material detail when data exists."""
-    from app.models import MaterialCard
-
-    card = MaterialCard(
-        normalized_mpn="XREF-001",
-        display_mpn="XREF-001",
+    card = _add_card(
+        db_session,
+        "XREF-001",
         cross_references=[
             {"mpn": "ALT-100", "manufacturer": "Micron"},
             {"mpn": "ALT-200", "manufacturer": "SK Hynix"},
         ],
     )
-    db_session.add(card)
-    db_session.commit()
 
     resp = client.get(f"/v2/partials/materials/{card.id}")
     assert resp.status_code == 200
@@ -126,11 +79,7 @@ def test_material_detail_shows_cross_references(client, db_session):
 
 def test_material_detail_shows_find_crosses_button_when_empty(client, db_session):
     """Crosses section always visible; shows Find Crosses button when no data."""
-    from app.models import MaterialCard
-
-    card = MaterialCard(normalized_mpn="NOXREF-001", display_mpn="NOXREF-001")
-    db_session.add(card)
-    db_session.commit()
+    card = _add_card(db_session, "NOXREF-001")
 
     resp = client.get(f"/v2/partials/materials/{card.id}")
     assert resp.status_code == 200
@@ -141,11 +90,7 @@ def test_material_detail_shows_find_crosses_button_when_empty(client, db_session
 
 def test_material_tab_unknown_returns_404(client, db_session):
     """Unknown tab name returns 404."""
-    from app.models import MaterialCard
-
-    card = MaterialCard(normalized_mpn="UNK-001", display_mpn="UNK-001")
-    db_session.add(card)
-    db_session.commit()
+    card = _add_card(db_session, "UNK-001")
 
     resp = client.get(f"/v2/partials/materials/{card.id}/tab/nonexistent")
     assert resp.status_code == 404

--- a/tests/test_migration_100_taxonomy_aliases.py
+++ b/tests/test_migration_100_taxonomy_aliases.py
@@ -97,6 +97,11 @@ class TestExecution:
             with Operations.context(ctx):
                 fn()
 
+    @staticmethod
+    def _categories(engine):
+        with engine.connect() as conn:
+            return dict(conn.execute(text("SELECT normalized_mpn, category FROM material_cards")).fetchall())
+
     def test_upgrade_downgrade_upgrade_normalizes_new_aliases(self):
         engine = self._scratch_engine()
 
@@ -112,18 +117,12 @@ class TestExecution:
         }
 
         self._run(engine, _mod.upgrade)
-        with engine.connect() as conn:
-            got = dict(conn.execute(text("SELECT normalized_mpn, category FROM material_cards")).fetchall())
-        assert got == expected
+        assert self._categories(engine) == expected
 
         # Downgrade is a documented no-op (many-to-one normalization is irreversible).
         self._run(engine, _mod.downgrade)
-        with engine.connect() as conn:
-            got = dict(conn.execute(text("SELECT normalized_mpn, category FROM material_cards")).fetchall())
-        assert got == expected
+        assert self._categories(engine) == expected
 
         # Re-upgrade is idempotent.
         self._run(engine, _mod.upgrade)
-        with engine.connect() as conn:
-            got = dict(conn.execute(text("SELECT normalized_mpn, category FROM material_cards")).fetchall())
-        assert got == expected
+        assert self._categories(engine) == expected

--- a/tests/test_nc_phase5.py
+++ b/tests/test_nc_phase5.py
@@ -4,6 +4,8 @@ Called by: pytest
 Depends on: conftest.py, nc_worker modules
 """
 
+import pytest
+
 from app.models import NcSearchQueue, Sighting
 from app.services.nc_worker.result_parser import NcSighting, parse_quantity, parse_results_html
 from app.services.nc_worker.search_engine import build_search_url
@@ -36,29 +38,20 @@ def test_build_search_url_spaces():
 # ── parse_quantity Tests ─────────────────────────────────────────────
 
 
-def test_parse_quantity_plain():
-    assert parse_quantity("208") == 208
-
-
-def test_parse_quantity_comma():
-    assert parse_quantity("10,000") == 10000
-
-
-def test_parse_quantity_plus():
-    assert parse_quantity("80,000+") == 80000
-
-
-def test_parse_quantity_empty():
-    assert parse_quantity("") is None
-    assert parse_quantity(None) is None
-
-
-def test_parse_quantity_whitespace():
-    assert parse_quantity("  5,000  ") == 5000
-
-
-def test_parse_quantity_invalid():
-    assert parse_quantity("N/A") is None
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        pytest.param("208", 208, id="plain"),
+        pytest.param("10,000", 10000, id="comma"),
+        pytest.param("80,000+", 80000, id="plus"),
+        pytest.param("", None, id="empty_str"),
+        pytest.param(None, None, id="none"),
+        pytest.param("  5,000  ", 5000, id="whitespace"),
+        pytest.param("N/A", None, id="invalid"),
+    ],
+)
+def test_parse_quantity(raw, expected):
+    assert parse_quantity(raw) == expected
 
 
 # ── parse_results_html Tests ────────────────────────────────────────
@@ -163,8 +156,9 @@ def test_parse_results_html_no_data_rows():
 # ── Sighting Writer Tests ───────────────────────────────────────────
 
 
-def test_save_nc_sightings(db_session, test_requisition):
-    """save_nc_sightings creates sighting records from NcSighting list."""
+def _make_queue_item(db_session, test_requisition):
+    """Create and persist an NcSearchQueue item for the requisition's first
+    requirement."""
     req = test_requisition.requirements[0]
     queue_item = NcSearchQueue(
         requirement_id=req.id,
@@ -175,6 +169,12 @@ def test_save_nc_sightings(db_session, test_requisition):
     )
     db_session.add(queue_item)
     db_session.commit()
+    return req, queue_item
+
+
+def test_save_nc_sightings(db_session, test_requisition):
+    """save_nc_sightings creates sighting records from NcSighting list."""
+    req, queue_item = _make_queue_item(db_session, test_requisition)
 
     nc_sightings = [
         NcSighting(
@@ -217,16 +217,7 @@ def test_save_nc_sightings(db_session, test_requisition):
 
 def test_save_nc_sightings_dedup(db_session, test_requisition):
     """Duplicate vendor+mpn+qty combos are not created twice."""
-    req = test_requisition.requirements[0]
-    queue_item = NcSearchQueue(
-        requirement_id=req.id,
-        requisition_id=test_requisition.id,
-        mpn="LM317T",
-        normalized_mpn="LM317T",
-        status="searching",
-    )
-    db_session.add(queue_item)
-    db_session.commit()
+    _req, queue_item = _make_queue_item(db_session, test_requisition)
 
     nc_sightings = [
         NcSighting(part_number="LM317T", quantity=5000, vendor_name="Arrow"),
@@ -239,16 +230,7 @@ def test_save_nc_sightings_dedup(db_session, test_requisition):
 
 def test_save_nc_sightings_empty_vendor_skipped(db_session, test_requisition):
     """Sightings with empty vendor_name are skipped."""
-    req = test_requisition.requirements[0]
-    queue_item = NcSearchQueue(
-        requirement_id=req.id,
-        requisition_id=test_requisition.id,
-        mpn="LM317T",
-        normalized_mpn="LM317T",
-        status="searching",
-    )
-    db_session.add(queue_item)
-    db_session.commit()
+    _req, queue_item = _make_queue_item(db_session, test_requisition)
 
     nc_sightings = [
         NcSighting(part_number="LM317T", quantity=5000, vendor_name=""),

--- a/tests/test_oem_domains.py
+++ b/tests/test_oem_domains.py
@@ -1,11 +1,29 @@
+import pytest
+
 from app.services.enrichment_worker.oem_domains import is_crossref_domain, is_oem_domain
 
 
-def test_official_oem_hosts_accepted():
-    assert is_oem_domain("https://support.lenovo.com/parts/01HW917")
-    assert is_oem_domain("https://partsurfer.hpe.com/Search.aspx?SearchText=918042-601")
-    assert is_oem_domain("http://www.dell.com/support/HV52W")
-    assert is_oem_domain("https://parts.hp.com/x")  # dot-suffix of hp.com root
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        # Official OEM hosts / vendor roots accepted.
+        ("https://support.lenovo.com/parts/01HW917", True),
+        ("https://partsurfer.hpe.com/Search.aspx?SearchText=918042-601", True),
+        ("http://www.dell.com/support/HV52W", True),
+        ("https://parts.hp.com/x", True),  # dot-suffix of hp.com root
+        ("https://www.ibm.com/support/x", True),  # ibm.com vendor root
+        ("HTTPS://SUPPORT.LENOVO.COM/x", True),  # host lowercased before matching
+        # Lookalikes, bad schemes, and non-vendor hosts rejected.
+        ("https://evil-lenovo.com/x", False),
+        ("https://lenovo.com.evil.com/x", False),
+        ("ftp://support.lenovo.com/x", False),
+        ("not a url", False),
+        ("", False),
+        ("https://notlenovo.com/x", False),  # not a vendor root or official host
+    ],
+)
+def test_is_oem_domain(url: str, expected: bool):
+    assert is_oem_domain(url) is expected
 
 
 def test_partsurfer_hp_com_is_explicit_official_host():
@@ -17,14 +35,6 @@ def test_partsurfer_hp_com_is_explicit_official_host():
     assert is_oem_domain("https://partsurfer.hp.com/Search.aspx?SearchText=875942-001")
 
 
-def test_lookalike_and_bad_schemes_rejected():
-    assert not is_oem_domain("https://evil-lenovo.com/x")
-    assert not is_oem_domain("https://lenovo.com.evil.com/x")
-    assert not is_oem_domain("ftp://support.lenovo.com/x")
-    assert not is_oem_domain("not a url")
-    assert not is_oem_domain("")
-
-
 def test_crossref_superset_includes_distributors_and_oem():
     # OEM official
     assert is_crossref_domain("https://support.lenovo.com/x")
@@ -34,9 +44,3 @@ def test_crossref_superset_includes_distributors_and_oem():
     assert is_crossref_domain("https://www.ti.com/product/x")
     # junk
     assert not is_crossref_domain("https://reddit.com/r/x")
-
-
-def test_ibm_and_uppercase_host():
-    assert is_oem_domain("https://www.ibm.com/support/x")  # ibm.com vendor root
-    assert is_oem_domain("HTTPS://SUPPORT.LENOVO.COM/x")  # host lowercased before matching
-    assert not is_oem_domain("https://notlenovo.com/x")  # not a vendor root or official host

--- a/tests/test_offers_nightly.py
+++ b/tests/test_offers_nightly.py
@@ -55,6 +55,20 @@ def _make_offer(
     return offer
 
 
+def _make_committed_offer(
+    db: Session,
+    user_id: int,
+    status: str = "active",
+    evidence_tier: str | None = None,
+) -> Offer:
+    """Create + commit a requisition and an offer attached to it, returning the
+    offer."""
+    req = _make_requisition(db, user_id)
+    offer = _make_offer(db, req.id, user_id, status=status, evidence_tier=evidence_tier)
+    db.commit()
+    return offer
+
+
 # ── list_offers — 404 path (line 62) ─────────────────────────────────
 
 
@@ -102,9 +116,7 @@ class TestReviewQueue:
 
     def test_list_review_queue_with_t4_offer(self, client, db_session, test_user):
         """GET /api/offers/review-queue returns T4 pending_review offers."""
-        req = _make_requisition(db_session, test_user.id)
-        offer = _make_offer(db_session, req.id, test_user.id, status="pending_review", evidence_tier="T4")
-        db_session.commit()
+        offer = _make_committed_offer(db_session, test_user.id, status="pending_review", evidence_tier="T4")
 
         resp = client.get("/api/offers/review-queue")
         assert resp.status_code == 200
@@ -113,9 +125,7 @@ class TestReviewQueue:
 
     def test_list_review_queue_excludes_non_t4(self, client, db_session, test_user):
         """Review queue does not include active (non-T4) offers."""
-        req = _make_requisition(db_session, test_user.id)
-        _make_offer(db_session, req.id, test_user.id, status="active", evidence_tier="T5")
-        db_session.commit()
+        _make_committed_offer(db_session, test_user.id, status="active", evidence_tier="T5")
 
         resp = client.get("/api/offers/review-queue")
         assert resp.status_code == 200
@@ -130,9 +140,7 @@ class TestReviewQueue:
 class TestPromoteOffer:
     def test_promote_t4_offer_success(self, client, db_session, test_user):
         """POST /api/offers/{id}/promote promotes T4 pending_review → T5 active."""
-        req = _make_requisition(db_session, test_user.id)
-        offer = _make_offer(db_session, req.id, test_user.id, status="pending_review", evidence_tier="T4")
-        db_session.commit()
+        offer = _make_committed_offer(db_session, test_user.id, status="pending_review", evidence_tier="T4")
 
         resp = client.post(f"/api/offers/{offer.id}/promote")
         assert resp.status_code == 200
@@ -147,9 +155,7 @@ class TestPromoteOffer:
 
     def test_promote_non_t4_returns_400(self, client, db_session, test_user):
         """POST /api/offers/{id}/promote on T5 offer returns 400."""
-        req = _make_requisition(db_session, test_user.id)
-        offer = _make_offer(db_session, req.id, test_user.id, status="active", evidence_tier="T5")
-        db_session.commit()
+        offer = _make_committed_offer(db_session, test_user.id, status="active", evidence_tier="T5")
 
         resp = client.post(f"/api/offers/{offer.id}/promote")
         assert resp.status_code == 400
@@ -166,9 +172,7 @@ class TestPromoteOffer:
 class TestRejectOffer:
     def test_reject_pending_review_offer_success(self, client, db_session, test_user):
         """POST /api/offers/{id}/reject marks offer as rejected."""
-        req = _make_requisition(db_session, test_user.id)
-        offer = _make_offer(db_session, req.id, test_user.id, status="pending_review", evidence_tier="T4")
-        db_session.commit()
+        offer = _make_committed_offer(db_session, test_user.id, status="pending_review", evidence_tier="T4")
 
         resp = client.post(f"/api/offers/{offer.id}/reject")
         assert resp.status_code == 200
@@ -180,9 +184,7 @@ class TestRejectOffer:
 
     def test_reject_active_offer_returns_400(self, client, db_session, test_user):
         """POST /api/offers/{id}/reject on active offer returns 400."""
-        req = _make_requisition(db_session, test_user.id)
-        offer = _make_offer(db_session, req.id, test_user.id, status="active")
-        db_session.commit()
+        offer = _make_committed_offer(db_session, test_user.id, status="active")
 
         resp = client.post(f"/api/offers/{offer.id}/reject")
         assert resp.status_code == 400

--- a/tests/test_part_normalizer.py
+++ b/tests/test_part_normalizer.py
@@ -16,6 +16,7 @@ import pytest
 
 from app.services.ai_part_normalizer import (
     _cache,
+    _call_normalizer,
     _fallback,
     _validate_result,
     clear_cache,
@@ -389,79 +390,45 @@ def test_normalize_parts_endpoint_ai_disabled(client):
 class TestCallNormalizerResponseFormats:
     """Tests for _call_normalizer handling various response formats."""
 
+    @pytest.mark.parametrize(
+        "part, response_key",
+        [
+            ("LM317T", "results"),
+            ("LM358DR", "normalized"),
+            ("NE555P", "parts"),
+        ],
+        ids=["results_key", "normalized_key", "parts_key"],
+    )
     @pytest.mark.asyncio
-    async def test_dict_with_results_key(self):
-        """Response as dict with 'results' key extracts the list."""
-        from app.services.ai_part_normalizer import _call_normalizer
-
-        mock_response = {"results": [{"original": "LM317T", "normalized": "LM317T", "confidence": 0.95}]}
+    async def test_dict_with_list_key_extracts_list(self, part, response_key):
+        """Response as dict with a recognized list key extracts the list."""
+        mock_response = {response_key: [{"original": part, "normalized": part, "confidence": 0.9}]}
         with patch(
             "app.services.ai_part_normalizer.claude_json",
             new_callable=AsyncMock,
             return_value=mock_response,
         ):
-            result = await _call_normalizer(["LM317T"])
+            result = await _call_normalizer([part])
 
         assert result is not None
         assert len(result) == 1
-        assert result[0]["normalized"] == "LM317T"
+        assert result[0]["normalized"] == part
 
+    @pytest.mark.parametrize(
+        "mock_response",
+        [
+            {"unexpected_key": "data"},  # dict without recognized keys
+            "just a string",  # non-dict, non-list response
+        ],
+        ids=["unexpected_dict", "string_response"],
+    )
     @pytest.mark.asyncio
-    async def test_dict_with_normalized_key(self):
-        """Response as dict with 'normalized' key extracts the list."""
-        from app.services.ai_part_normalizer import _call_normalizer
-
-        mock_response = {"normalized": [{"original": "LM358DR", "normalized": "LM358DR", "confidence": 0.9}]}
+    async def test_unrecognized_format_returns_none(self, mock_response):
+        """Unrecognized response shapes return None."""
         with patch(
             "app.services.ai_part_normalizer.claude_json",
             new_callable=AsyncMock,
             return_value=mock_response,
-        ):
-            result = await _call_normalizer(["LM358DR"])
-
-        assert result is not None
-        assert len(result) == 1
-
-    @pytest.mark.asyncio
-    async def test_dict_with_parts_key(self):
-        """Response as dict with 'parts' key extracts the list."""
-        from app.services.ai_part_normalizer import _call_normalizer
-
-        mock_response = {"parts": [{"original": "NE555P", "normalized": "NE555P", "confidence": 0.85}]}
-        with patch(
-            "app.services.ai_part_normalizer.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ):
-            result = await _call_normalizer(["NE555P"])
-
-        assert result is not None
-        assert len(result) == 1
-
-    @pytest.mark.asyncio
-    async def test_unexpected_format_returns_none(self):
-        """Dict without recognized keys returns None and logs warning."""
-        from app.services.ai_part_normalizer import _call_normalizer
-
-        mock_response = {"unexpected_key": "data"}
-        with patch(
-            "app.services.ai_part_normalizer.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_response,
-        ):
-            result = await _call_normalizer(["SOME-PART"])
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_string_response_returns_none(self):
-        """Non-dict, non-list response returns None."""
-        from app.services.ai_part_normalizer import _call_normalizer
-
-        with patch(
-            "app.services.ai_part_normalizer.claude_json",
-            new_callable=AsyncMock,
-            return_value="just a string",
         ):
             result = await _call_normalizer(["SOME-PART"])
 

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -9,6 +9,8 @@ Depends on: app.rate_limit
 
 from unittest.mock import patch
 
+import pytest
+
 
 def test_limiter_is_configured():
     """Rate limiter module exports a Limiter with key_func."""
@@ -51,31 +53,37 @@ def test_resolve_storage_no_redis():
         assert result is None
 
 
-def test_resolve_storage_redis_unavailable():
-    """_resolve_storage returns None when Redis ping fails."""
+@pytest.mark.parametrize(
+    ("redis_url", "ping_side_effect", "ping_return", "expected"),
+    [
+        pytest.param(
+            "redis://localhost:6379/15",
+            ConnectionError,
+            None,
+            None,
+            id="redis_unavailable",
+        ),
+        pytest.param(
+            "redis://localhost:6379/0",
+            None,
+            True,
+            "redis://localhost:6379/0",
+            id="redis_success",
+        ),
+    ],
+)
+def test_resolve_storage_redis(redis_url, ping_side_effect, ping_return, expected):
+    """_resolve_storage returns the Redis URL when ping succeeds, else None."""
     import redis as redis_lib
 
     with patch("app.rate_limit.settings") as mock_settings:
         mock_settings.cache_backend = "redis"
-        mock_settings.redis_url = "redis://localhost:6379/15"
+        mock_settings.redis_url = redis_url
         with patch.object(redis_lib, "from_url") as mock_from_url:
-            mock_from_url.return_value.ping.side_effect = ConnectionError
+            ping = mock_from_url.return_value.ping
+            ping.side_effect = ping_side_effect
+            ping.return_value = ping_return
             from app.rate_limit import _resolve_storage
 
             result = _resolve_storage()
-            assert result is None
-
-
-def test_resolve_storage_redis_success():
-    """_resolve_storage returns Redis URL when ping succeeds (lines 24-25)."""
-    import redis as redis_lib
-
-    with patch("app.rate_limit.settings") as mock_settings:
-        mock_settings.cache_backend = "redis"
-        mock_settings.redis_url = "redis://localhost:6379/0"
-        with patch.object(redis_lib, "from_url") as mock_from_url:
-            mock_from_url.return_value.ping.return_value = True
-            from app.rate_limit import _resolve_storage
-
-            result = _resolve_storage()
-            assert result == "redis://localhost:6379/0"
+            assert result == expected

--- a/tests/test_requisition_list_service.py
+++ b/tests/test_requisition_list_service.py
@@ -9,6 +9,8 @@ Depends on: app/services/requisition_list_service.py, conftest fixtures
 
 from datetime import datetime, timezone
 
+import pytest
+
 from app.models import Requisition
 from app.schemas.requisitions2 import ReqListFilters, ReqStatus, SortColumn, SortOrder
 from app.services.requisition_list_service import (
@@ -21,20 +23,37 @@ from app.services.requisition_list_service import (
     list_requisitions,
 )
 
+
+def _make_req(db_session, name, created_by, *, status="active", created_at=None, **extra):
+    """Build, persist, and return a Requisition with sensible test defaults."""
+    req = Requisition(
+        name=name,
+        status=status,
+        created_by=created_by,
+        created_at=created_at or datetime.now(timezone.utc),
+        **extra,
+    )
+    db_session.add(req)
+    return req
+
+
 # ── helpers: _hours_until_bid_due / _resolve_deal_value ──────────────
 
 
-def test_hours_until_bid_due_none_and_empty():
-    assert _hours_until_bid_due(None) is None
-    assert _hours_until_bid_due("") is None
-    assert _hours_until_bid_due("   ") is None
-
-
-def test_hours_until_bid_due_unparseable_returns_none():
-    # Literal "ASAP" and other non-ISO strings must degrade to None,
-    # not raise, so the urgency accent just doesn't render.
-    assert _hours_until_bid_due("ASAP") is None
-    assert _hours_until_bid_due("next week") is None
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(None, id="none"),
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace"),
+        # Literal "ASAP" and other non-ISO strings must degrade to None,
+        # not raise, so the urgency accent just doesn't render.
+        pytest.param("ASAP", id="literal_asap"),
+        pytest.param("next week", id="prose"),
+    ],
+)
+def test_hours_until_bid_due_returns_none(value):
+    assert _hours_until_bid_due(value) is None
 
 
 def test_hours_until_bid_due_iso_date_treated_as_end_of_day():
@@ -54,40 +73,26 @@ def test_hours_until_bid_due_iso_datetime_parses():
 # ── _resolve_deal_value (extended signature) ─────────────────────────
 
 
-def test_resolve_deal_value_prefers_entered():
-    val, src = _resolve_deal_value(opportunity_value=50000.0, priced_sum=10.0, priced_count=1, requirement_count=5)
-    assert val == 50000.0
-    assert src == "entered"
-
-
-def test_resolve_deal_value_all_priced_is_computed():
-    val, src = _resolve_deal_value(opportunity_value=None, priced_sum=2500.0, priced_count=3, requirement_count=3)
-    assert val == 2500.0
-    assert src == "computed"
-
-
-def test_resolve_deal_value_some_priced_is_partial():
-    val, src = _resolve_deal_value(opportunity_value=None, priced_sum=1800.0, priced_count=3, requirement_count=5)
-    assert val == 1800.0
-    assert src == "partial"
-
-
-def test_resolve_deal_value_zero_price_counts_as_priced():
-    val, src = _resolve_deal_value(opportunity_value=None, priced_sum=1500.0, priced_count=4, requirement_count=4)
-    assert val == 1500.0
-    assert src == "computed"
-
-
-def test_resolve_deal_value_none_priced_is_none():
-    val, src = _resolve_deal_value(opportunity_value=None, priced_sum=0.0, priced_count=0, requirement_count=3)
-    assert val is None
-    assert src == "none"
-
-
-def test_resolve_deal_value_zero_opportunity_falls_through():
-    val, src = _resolve_deal_value(opportunity_value=0.0, priced_sum=1500.0, priced_count=2, requirement_count=2)
-    assert val == 1500.0
-    assert src == "computed"
+@pytest.mark.parametrize(
+    ("opportunity_value", "priced_sum", "priced_count", "requirement_count", "expected_val", "expected_src"),
+    [
+        pytest.param(50000.0, 10.0, 1, 5, 50000.0, "entered", id="prefers_entered"),
+        pytest.param(None, 2500.0, 3, 3, 2500.0, "computed", id="all_priced_is_computed"),
+        pytest.param(None, 1800.0, 3, 5, 1800.0, "partial", id="some_priced_is_partial"),
+        pytest.param(None, 1500.0, 4, 4, 1500.0, "computed", id="zero_price_counts_as_priced"),
+        pytest.param(None, 0.0, 0, 3, None, "none", id="none_priced_is_none"),
+        pytest.param(0.0, 1500.0, 2, 2, 1500.0, "computed", id="zero_opportunity_falls_through"),
+    ],
+)
+def test_resolve_deal_value(opportunity_value, priced_sum, priced_count, requirement_count, expected_val, expected_src):
+    val, src = _resolve_deal_value(
+        opportunity_value=opportunity_value,
+        priced_sum=priced_sum,
+        priced_count=priced_count,
+        requirement_count=requirement_count,
+    )
+    assert val == expected_val
+    assert src == expected_src
 
 
 # ── list_requisitions ────────────────────────────────────────────────
@@ -150,13 +155,7 @@ def test_list_pagination_math(db_session, test_user):
     """Pagination computes correct total_pages."""
     # Create 3 requisitions
     for i in range(3):
-        req = Requisition(
-            name=f"PAGE-REQ-{i}",
-            status="active",
-            created_by=test_user.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
+        _make_req(db_session, f"PAGE-REQ-{i}", test_user.id)
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.active, per_page=2)
@@ -169,13 +168,7 @@ def test_list_pagination_math(db_session, test_user):
 def test_list_pagination_page_2(db_session, test_user):
     """Page 2 returns remaining items."""
     for i in range(3):
-        req = Requisition(
-            name=f"PAGE-REQ-{i}",
-            status="active",
-            created_by=test_user.id,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
+        _make_req(db_session, f"PAGE-REQ-{i}", test_user.id)
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.active, per_page=2, page=2)
@@ -185,19 +178,8 @@ def test_list_pagination_page_2(db_session, test_user):
 
 def test_list_sort_ascending(db_session, test_user):
     """Sort ascending by name orders A before Z."""
-    req_a = Requisition(
-        name="AAA-REQ",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    req_z = Requisition(
-        name="ZZZ-REQ",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    db_session.add_all([req_a, req_z])
+    _make_req(db_session, "AAA-REQ", test_user.id)
+    _make_req(db_session, "ZZZ-REQ", test_user.id)
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.active, sort=SortColumn.name, order=SortOrder.asc)
@@ -209,19 +191,8 @@ def test_list_sort_ascending(db_session, test_user):
 
 def test_list_sort_descending(db_session, test_user):
     """Sort descending by name orders Z before A."""
-    req_a = Requisition(
-        name="AAA-REQ",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    req_z = Requisition(
-        name="ZZZ-REQ",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    db_session.add_all([req_a, req_z])
+    _make_req(db_session, "AAA-REQ", test_user.id)
+    _make_req(db_session, "ZZZ-REQ", test_user.id)
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.active, sort=SortColumn.name, order=SortOrder.desc)
@@ -233,19 +204,8 @@ def test_list_sort_descending(db_session, test_user):
 
 def test_sales_role_filtering(db_session, test_user, sales_user):
     """Sales role only sees own requisitions."""
-    req_buyer = Requisition(
-        name="BUYER-REQ",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    req_sales = Requisition(
-        name="SALES-REQ",
-        status="active",
-        created_by=sales_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    db_session.add_all([req_buyer, req_sales])
+    _make_req(db_session, "BUYER-REQ", test_user.id)
+    _make_req(db_session, "SALES-REQ", sales_user.id)
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.active)
@@ -298,19 +258,8 @@ def test_detail_with_customer_site(db_session, test_user, test_requisition, test
 
 def test_list_filter_by_owner(db_session, test_user, sales_user):
     """Owner filter restricts to specific user."""
-    req_buyer = Requisition(
-        name="BUYER-OWN",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    req_sales = Requisition(
-        name="SALES-OWN",
-        status="active",
-        created_by=sales_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    db_session.add_all([req_buyer, req_sales])
+    _make_req(db_session, "BUYER-OWN", test_user.id)
+    _make_req(db_session, "SALES-OWN", sales_user.id)
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.active, owner=test_user.id)
@@ -322,21 +271,8 @@ def test_list_filter_by_owner(db_session, test_user, sales_user):
 
 def test_list_filter_by_urgency(db_session, test_user):
     """Urgency filter restricts to matching requisitions."""
-    req_hot = Requisition(
-        name="HOT-REQ",
-        status="active",
-        urgency="hot",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    req_normal = Requisition(
-        name="NORMAL-REQ",
-        status="active",
-        urgency="normal",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    db_session.add_all([req_hot, req_normal])
+    _make_req(db_session, "HOT-REQ", test_user.id, urgency="hot")
+    _make_req(db_session, "NORMAL-REQ", test_user.id, urgency="normal")
     db_session.commit()
 
     from app.schemas.requisitions2 import Urgency
@@ -352,13 +288,7 @@ def test_list_filter_by_date_from(db_session, test_user):
     """date_from filter excludes older requisitions."""
     from datetime import date as date_type
 
-    req = Requisition(
-        name="OLD-REQ",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
-    )
-    db_session.add(req)
+    _make_req(db_session, "OLD-REQ", test_user.id, created_at=datetime(2020, 1, 1, tzinfo=timezone.utc))
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.active, date_from=date_type(2025, 1, 1))
@@ -371,13 +301,7 @@ def test_list_filter_by_date_to(db_session, test_user):
     """date_to filter excludes newer requisitions."""
     from datetime import date as date_type
 
-    req = Requisition(
-        name="NEW-REQ",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
-    )
-    db_session.add(req)
+    _make_req(db_session, "NEW-REQ", test_user.id, created_at=datetime(2099, 1, 1, tzinfo=timezone.utc))
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.active, date_to=date_type(2026, 12, 31))
@@ -388,19 +312,8 @@ def test_list_filter_by_date_to(db_session, test_user):
 
 def test_list_status_all(db_session, test_user):
     """Status 'all' shows all requisitions regardless of status."""
-    req_active = Requisition(
-        name="ALL-ACTIVE",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    req_archived = Requisition(
-        name="ALL-ARCHIVED",
-        status="archived",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    db_session.add_all([req_active, req_archived])
+    _make_req(db_session, "ALL-ACTIVE", test_user.id)
+    _make_req(db_session, "ALL-ARCHIVED", test_user.id, status="archived")
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.all)
@@ -412,19 +325,8 @@ def test_list_status_all(db_session, test_user):
 
 def test_list_status_archived(db_session, test_user):
     """Status 'archived' shows only archived/won/lost/closed."""
-    req_active = Requisition(
-        name="ARCH-ACTIVE",
-        status="active",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    req_archived = Requisition(
-        name="ARCH-ARCHIVED",
-        status="archived",
-        created_by=test_user.id,
-        created_at=datetime.now(timezone.utc),
-    )
-    db_session.add_all([req_active, req_archived])
+    _make_req(db_session, "ARCH-ACTIVE", test_user.id)
+    _make_req(db_session, "ARCH-ARCHIVED", test_user.id, status="archived")
     db_session.commit()
 
     filters = ReqListFilters(status=ReqStatus.archived)

--- a/tests/test_routers_sources.py
+++ b/tests/test_routers_sources.py
@@ -44,12 +44,19 @@ def test_get_connector_unknown_source():
     assert result is None
 
 
-def test_get_connector_email_mining_when_enabled(monkeypatch):
-    """Email mining returns test connector when enabled."""
+@pytest.mark.parametrize(
+    ("enabled", "expect_connector"),
+    [
+        pytest.param(True, True, id="enabled"),
+        pytest.param(False, False, id="disabled"),
+    ],
+)
+def test_get_connector_email_mining(monkeypatch, enabled, expect_connector):
+    """Email mining returns the test connector only when enabled."""
     monkeypatch.setattr(
         "app.routers.sources.settings",
         SimpleNamespace(
-            email_mining_enabled=True,
+            email_mining_enabled=enabled,
             nexar_client_id=None,
             brokerbin_api_key=None,
             ebay_client_id=None,
@@ -60,26 +67,10 @@ def test_get_connector_email_mining_when_enabled(monkeypatch):
         ),
     )
     result = _get_connector_for_source("email_mining")
-    assert isinstance(result, _EmailMiningTestConnector)
-
-
-def test_get_connector_email_mining_when_disabled(monkeypatch):
-    """Email mining returns None when disabled."""
-    monkeypatch.setattr(
-        "app.routers.sources.settings",
-        SimpleNamespace(
-            email_mining_enabled=False,
-            nexar_client_id=None,
-            brokerbin_api_key=None,
-            ebay_client_id=None,
-            digikey_client_id=None,
-            mouser_api_key=None,
-            oemsecrets_api_key=None,
-            sourcengine_api_key=None,
-        ),
-    )
-    result = _get_connector_for_source("email_mining")
-    assert result is None
+    if expect_connector:
+        assert isinstance(result, _EmailMiningTestConnector)
+    else:
+        assert result is None
 
 
 # ── _create_sightings_from_attachment ────────────────────────────────
@@ -785,226 +776,167 @@ def test_get_connector_nexar_with_octopart_key():
             assert result is not None
 
 
-def test_get_connector_nexar_with_client_id():
-    """Nexar source returns NexarConnector when NEXAR_CLIENT_ID is set."""
-    creds = {
-        "NEXAR_CLIENT_ID": "nid",
-        "NEXAR_CLIENT_SECRET": "nsec",
-        "OCTOPART_API_KEY": None,
-    }
+@pytest.mark.parametrize(
+    ("source", "connector_path", "creds"),
+    [
+        pytest.param(
+            "nexar",
+            "app.connectors.sources.NexarConnector",
+            {
+                "NEXAR_CLIENT_ID": "nid",
+                "NEXAR_CLIENT_SECRET": "nsec",
+                "OCTOPART_API_KEY": None,
+            },
+            id="nexar-client-id",
+        ),
+        pytest.param(
+            "brokerbin",
+            "app.connectors.sources.BrokerBinConnector",
+            {
+                "NEXAR_CLIENT_ID": None,
+                "NEXAR_CLIENT_SECRET": None,
+                "OCTOPART_API_KEY": None,
+                "BROKERBIN_API_KEY": "bb_key",
+                "BROKERBIN_API_SECRET": "bb_sec",
+            },
+            id="brokerbin",
+        ),
+        pytest.param(
+            "ebay",
+            "app.connectors.ebay.EbayConnector",
+            {
+                "NEXAR_CLIENT_ID": None,
+                "NEXAR_CLIENT_SECRET": None,
+                "OCTOPART_API_KEY": None,
+                "BROKERBIN_API_KEY": None,
+                "BROKERBIN_API_SECRET": None,
+                "EBAY_CLIENT_ID": "ebay_id",
+                "EBAY_CLIENT_SECRET": "ebay_sec",
+            },
+            id="ebay",
+        ),
+        pytest.param(
+            "digikey",
+            "app.connectors.digikey.DigiKeyConnector",
+            {
+                "NEXAR_CLIENT_ID": None,
+                "NEXAR_CLIENT_SECRET": None,
+                "OCTOPART_API_KEY": None,
+                "BROKERBIN_API_KEY": None,
+                "BROKERBIN_API_SECRET": None,
+                "EBAY_CLIENT_ID": None,
+                "EBAY_CLIENT_SECRET": None,
+                "DIGIKEY_CLIENT_ID": "dk_id",
+                "DIGIKEY_CLIENT_SECRET": "dk_sec",
+            },
+            id="digikey",
+        ),
+        pytest.param(
+            "mouser",
+            "app.connectors.mouser.MouserConnector",
+            {
+                "NEXAR_CLIENT_ID": None,
+                "NEXAR_CLIENT_SECRET": None,
+                "OCTOPART_API_KEY": None,
+                "BROKERBIN_API_KEY": None,
+                "BROKERBIN_API_SECRET": None,
+                "EBAY_CLIENT_ID": None,
+                "EBAY_CLIENT_SECRET": None,
+                "DIGIKEY_CLIENT_ID": None,
+                "DIGIKEY_CLIENT_SECRET": None,
+                "MOUSER_API_KEY": "mouser_key",
+            },
+            id="mouser",
+        ),
+        pytest.param(
+            "oemsecrets",
+            "app.connectors.oemsecrets.OEMSecretsConnector",
+            {
+                "NEXAR_CLIENT_ID": None,
+                "NEXAR_CLIENT_SECRET": None,
+                "OCTOPART_API_KEY": None,
+                "BROKERBIN_API_KEY": None,
+                "BROKERBIN_API_SECRET": None,
+                "EBAY_CLIENT_ID": None,
+                "EBAY_CLIENT_SECRET": None,
+                "DIGIKEY_CLIENT_ID": None,
+                "DIGIKEY_CLIENT_SECRET": None,
+                "MOUSER_API_KEY": None,
+                "OEMSECRETS_API_KEY": "oem_key",
+            },
+            id="oemsecrets",
+        ),
+        pytest.param(
+            "sourcengine",
+            "app.connectors.sourcengine.SourcengineConnector",
+            {
+                "NEXAR_CLIENT_ID": None,
+                "NEXAR_CLIENT_SECRET": None,
+                "OCTOPART_API_KEY": None,
+                "BROKERBIN_API_KEY": None,
+                "BROKERBIN_API_SECRET": None,
+                "EBAY_CLIENT_ID": None,
+                "EBAY_CLIENT_SECRET": None,
+                "DIGIKEY_CLIENT_ID": None,
+                "DIGIKEY_CLIENT_SECRET": None,
+                "MOUSER_API_KEY": None,
+                "OEMSECRETS_API_KEY": None,
+                "SOURCENGINE_API_KEY": "src_key",
+            },
+            id="sourcengine",
+        ),
+        pytest.param(
+            "element14",
+            "app.connectors.element14.Element14Connector",
+            {
+                "NEXAR_CLIENT_ID": None,
+                "NEXAR_CLIENT_SECRET": None,
+                "OCTOPART_API_KEY": None,
+                "BROKERBIN_API_KEY": None,
+                "BROKERBIN_API_SECRET": None,
+                "EBAY_CLIENT_ID": None,
+                "EBAY_CLIENT_SECRET": None,
+                "DIGIKEY_CLIENT_ID": None,
+                "DIGIKEY_CLIENT_SECRET": None,
+                "MOUSER_API_KEY": None,
+                "OEMSECRETS_API_KEY": None,
+                "SOURCENGINE_API_KEY": None,
+                "ELEMENT14_API_KEY": "e14_key",
+            },
+            id="newark",
+        ),
+    ],
+)
+def test_get_connector_for_keyed_source(source, connector_path, creds):
+    """Each keyed source returns its connector when the relevant credential is set."""
 
     def fake_cred(db, name, var):
         return creds.get(var)
 
     with patch("app.services.credential_service.get_credential", side_effect=fake_cred):
-        with patch("app.connectors.sources.NexarConnector"):
-            result = _get_connector_for_source("nexar", db=MagicMock())
+        with patch(connector_path):
+            result = _get_connector_for_source(source, db=MagicMock())
             assert result is not None
 
 
-def test_get_connector_brokerbin():
-    """BrokerBin source returns BrokerBinConnector when key is set."""
-    creds = {
-        "NEXAR_CLIENT_ID": None,
-        "NEXAR_CLIENT_SECRET": None,
-        "OCTOPART_API_KEY": None,
-        "BROKERBIN_API_KEY": "bb_key",
-        "BROKERBIN_API_SECRET": "bb_sec",
-    }
+@pytest.mark.parametrize(
+    ("source", "connector_attr"),
+    [
+        pytest.param("anthropic_ai", "_AnthropicTestConnector", id="anthropic_ai"),
+        pytest.param("teams_notifications", "_TeamsTestConnector", id="teams_notifications"),
+        pytest.param("apollo_enrichment", "_ApolloTestConnector", id="apollo_enrichment"),
+        pytest.param("explorium_enrichment", "_ExploriumTestConnector", id="explorium_enrichment"),
+        pytest.param("azure_oauth", "_AzureOAuthTestConnector", id="azure_oauth"),
+    ],
+)
+def test_get_connector_for_test_only_source(source, connector_attr):
+    """Built-in test-only sources return their dedicated test connector (no env_vars
+    needed)."""
+    import app.routers.sources as sources_module
 
-    def fake_cred(db, name, var):
-        return creds.get(var)
-
-    with patch("app.services.credential_service.get_credential", side_effect=fake_cred):
-        with patch("app.connectors.sources.BrokerBinConnector"):
-            result = _get_connector_for_source("brokerbin", db=MagicMock())
-            assert result is not None
-
-
-def test_get_connector_ebay():
-    """EBay source returns EbayConnector when key is set."""
-    creds = {
-        "NEXAR_CLIENT_ID": None,
-        "NEXAR_CLIENT_SECRET": None,
-        "OCTOPART_API_KEY": None,
-        "BROKERBIN_API_KEY": None,
-        "BROKERBIN_API_SECRET": None,
-        "EBAY_CLIENT_ID": "ebay_id",
-        "EBAY_CLIENT_SECRET": "ebay_sec",
-    }
-
-    def fake_cred(db, name, var):
-        return creds.get(var)
-
-    with patch("app.services.credential_service.get_credential", side_effect=fake_cred):
-        with patch("app.connectors.ebay.EbayConnector"):
-            result = _get_connector_for_source("ebay", db=MagicMock())
-            assert result is not None
-
-
-def test_get_connector_digikey():
-    """DigiKey source returns DigiKeyConnector when key is set."""
-    creds = {
-        "NEXAR_CLIENT_ID": None,
-        "NEXAR_CLIENT_SECRET": None,
-        "OCTOPART_API_KEY": None,
-        "BROKERBIN_API_KEY": None,
-        "BROKERBIN_API_SECRET": None,
-        "EBAY_CLIENT_ID": None,
-        "EBAY_CLIENT_SECRET": None,
-        "DIGIKEY_CLIENT_ID": "dk_id",
-        "DIGIKEY_CLIENT_SECRET": "dk_sec",
-    }
-
-    def fake_cred(db, name, var):
-        return creds.get(var)
-
-    with patch("app.services.credential_service.get_credential", side_effect=fake_cred):
-        with patch("app.connectors.digikey.DigiKeyConnector"):
-            result = _get_connector_for_source("digikey", db=MagicMock())
-            assert result is not None
-
-
-def test_get_connector_mouser():
-    """Mouser source returns MouserConnector when key is set."""
-    creds = {
-        "NEXAR_CLIENT_ID": None,
-        "NEXAR_CLIENT_SECRET": None,
-        "OCTOPART_API_KEY": None,
-        "BROKERBIN_API_KEY": None,
-        "BROKERBIN_API_SECRET": None,
-        "EBAY_CLIENT_ID": None,
-        "EBAY_CLIENT_SECRET": None,
-        "DIGIKEY_CLIENT_ID": None,
-        "DIGIKEY_CLIENT_SECRET": None,
-        "MOUSER_API_KEY": "mouser_key",
-    }
-
-    def fake_cred(db, name, var):
-        return creds.get(var)
-
-    with patch("app.services.credential_service.get_credential", side_effect=fake_cred):
-        with patch("app.connectors.mouser.MouserConnector"):
-            result = _get_connector_for_source("mouser", db=MagicMock())
-            assert result is not None
-
-
-def test_get_connector_oemsecrets():
-    """OEMSecrets source returns OEMSecretsConnector when key is set."""
-    creds = {
-        "NEXAR_CLIENT_ID": None,
-        "NEXAR_CLIENT_SECRET": None,
-        "OCTOPART_API_KEY": None,
-        "BROKERBIN_API_KEY": None,
-        "BROKERBIN_API_SECRET": None,
-        "EBAY_CLIENT_ID": None,
-        "EBAY_CLIENT_SECRET": None,
-        "DIGIKEY_CLIENT_ID": None,
-        "DIGIKEY_CLIENT_SECRET": None,
-        "MOUSER_API_KEY": None,
-        "OEMSECRETS_API_KEY": "oem_key",
-    }
-
-    def fake_cred(db, name, var):
-        return creds.get(var)
-
-    with patch("app.services.credential_service.get_credential", side_effect=fake_cred):
-        with patch("app.connectors.oemsecrets.OEMSecretsConnector"):
-            result = _get_connector_for_source("oemsecrets", db=MagicMock())
-            assert result is not None
-
-
-def test_get_connector_sourcengine():
-    """Sourcengine source returns SourcengineConnector when key is set."""
-    creds = {
-        "NEXAR_CLIENT_ID": None,
-        "NEXAR_CLIENT_SECRET": None,
-        "OCTOPART_API_KEY": None,
-        "BROKERBIN_API_KEY": None,
-        "BROKERBIN_API_SECRET": None,
-        "EBAY_CLIENT_ID": None,
-        "EBAY_CLIENT_SECRET": None,
-        "DIGIKEY_CLIENT_ID": None,
-        "DIGIKEY_CLIENT_SECRET": None,
-        "MOUSER_API_KEY": None,
-        "OEMSECRETS_API_KEY": None,
-        "SOURCENGINE_API_KEY": "src_key",
-    }
-
-    def fake_cred(db, name, var):
-        return creds.get(var)
-
-    with patch("app.services.credential_service.get_credential", side_effect=fake_cred):
-        with patch("app.connectors.sourcengine.SourcengineConnector"):
-            result = _get_connector_for_source("sourcengine", db=MagicMock())
-            assert result is not None
-
-
-def test_get_connector_newark():
-    """Newark source returns Element14Connector when key is set."""
-    creds = {
-        "NEXAR_CLIENT_ID": None,
-        "NEXAR_CLIENT_SECRET": None,
-        "OCTOPART_API_KEY": None,
-        "BROKERBIN_API_KEY": None,
-        "BROKERBIN_API_SECRET": None,
-        "EBAY_CLIENT_ID": None,
-        "EBAY_CLIENT_SECRET": None,
-        "DIGIKEY_CLIENT_ID": None,
-        "DIGIKEY_CLIENT_SECRET": None,
-        "MOUSER_API_KEY": None,
-        "OEMSECRETS_API_KEY": None,
-        "SOURCENGINE_API_KEY": None,
-        "ELEMENT14_API_KEY": "e14_key",
-    }
-
-    def fake_cred(db, name, var):
-        return creds.get(var)
-
-    with patch("app.services.credential_service.get_credential", side_effect=fake_cred):
-        with patch("app.connectors.element14.Element14Connector"):
-            result = _get_connector_for_source("element14", db=MagicMock())
-            assert result is not None
-
-
-def test_get_connector_anthropic_ai():
-    """Anthropic AI returns _AnthropicTestConnector (no env_vars needed)."""
-    from app.routers.sources import _AnthropicTestConnector
-
-    result = _get_connector_for_source("anthropic_ai")
-    assert isinstance(result, _AnthropicTestConnector)
-
-
-def test_get_connector_teams_notifications():
-    """Teams returns _TeamsTestConnector."""
-    from app.routers.sources import _TeamsTestConnector
-
-    result = _get_connector_for_source("teams_notifications")
-    assert isinstance(result, _TeamsTestConnector)
-
-
-def test_get_connector_apollo_enrichment():
-    """Apollo returns _ApolloTestConnector."""
-    from app.routers.sources import _ApolloTestConnector
-
-    result = _get_connector_for_source("apollo_enrichment")
-    assert isinstance(result, _ApolloTestConnector)
-
-
-def test_get_connector_explorium_enrichment():
-    """Explorium returns _ExploriumTestConnector."""
-    from app.routers.sources import _ExploriumTestConnector
-
-    result = _get_connector_for_source("explorium_enrichment")
-    assert isinstance(result, _ExploriumTestConnector)
-
-
-def test_get_connector_azure_oauth():
-    """Azure OAuth returns _AzureOAuthTestConnector."""
-    from app.routers.sources import _AzureOAuthTestConnector
-
-    result = _get_connector_for_source("azure_oauth")
-    assert isinstance(result, _AzureOAuthTestConnector)
+    connector_cls = getattr(sources_module, connector_attr)
+    result = _get_connector_for_source(source)
+    assert isinstance(result, connector_cls)
 
 
 def test_get_connector_no_db_env_fallback(monkeypatch):
@@ -1035,19 +967,10 @@ async def test_anthropic_test_connector_search_success():
 
 
 @pytest.mark.asyncio
-async def test_anthropic_test_connector_no_key():
-    """_AnthropicTestConnector raises when claude_text returns None (no API key)."""
-    from app.routers.sources import _AnthropicTestConnector
-
-    connector = _AnthropicTestConnector()
-    with patch("app.utils.claude_client.claude_text", new_callable=AsyncMock, return_value=None):
-        with pytest.raises(ValueError, match="Anthropic API returned no response"):
-            await connector.search("LM358N")
-
-
-@pytest.mark.asyncio
-async def test_anthropic_test_connector_api_error():
-    """_AnthropicTestConnector raises when claude_text returns None."""
+@pytest.mark.parametrize("scenario", ["no_key", "api_error"])
+async def test_anthropic_test_connector_no_response(scenario):
+    """_AnthropicTestConnector raises when claude_text returns None (no API key / API
+    error)."""
     from app.routers.sources import _AnthropicTestConnector
 
     connector = _AnthropicTestConnector()

--- a/tests/test_services/test_prospect_discovery.py
+++ b/tests/test_services/test_prospect_discovery.py
@@ -57,6 +57,17 @@ EXPLORIUM_NO_DOMAIN = {
 }
 
 
+def _mock_response(status_code, *, json_body=None, text=None):
+    """Build a MagicMock httpx-style response for Explorium API patches."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    if json_body is not None:
+        mock_resp.json.return_value = json_body
+    if text is not None:
+        mock_resp.text = text
+    return mock_resp
+
+
 # ── Explorium Tests ──────────────────────────────────────────────────
 
 
@@ -139,13 +150,16 @@ class TestExploriumNormalization:
         assert len(result["events"]) == 2
         assert result["events"][0]["type"] == "funding round"
 
-    def test_region_detection(self):
+    @pytest.mark.parametrize(
+        ("country_code", "expected_region"),
+        [("US", "US"), ("DE", "EU"), ("JP", "Asia"), ("BR", "BR")],
+    )
+    def test_region_detection(self, country_code, expected_region):
         from app.services.prospect_discovery_explorium import normalize_explorium_result
 
-        for cc, expected in [("US", "US"), ("DE", "EU"), ("JP", "Asia"), ("BR", "BR")]:
-            raw = {"name": "Test", "domain": "t.com", "country_code": cc}
-            r = normalize_explorium_result(raw, "automotive")
-            assert r["region"] == expected, f"country_code={cc} should map to {expected}"
+        raw = {"name": "Test", "domain": "t.com", "country_code": country_code}
+        result = normalize_explorium_result(raw, "automotive")
+        assert result["region"] == expected_region
 
 
 class TestExploriumDiscovery:
@@ -171,9 +185,7 @@ class TestExploriumDiscovery:
     async def test_successful_search(self):
         from app.services.prospect_discovery_explorium import discover_companies_with_signals
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"businesses": [EXPLORIUM_RAW_RESULT]}
+        mock_resp = _mock_response(200, json_body={"businesses": [EXPLORIUM_RAW_RESULT]})
 
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
             with patch("app.services.prospect_discovery_explorium.http") as mock_http:
@@ -187,9 +199,7 @@ class TestExploriumDiscovery:
     async def test_api_error_returns_empty(self):
         from app.services.prospect_discovery_explorium import discover_companies_with_signals
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 500
-        mock_resp.text = "Internal Server Error"
+        mock_resp = _mock_response(500, text="Internal Server Error")
 
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
             with patch("app.services.prospect_discovery_explorium.http") as mock_http:
@@ -218,9 +228,7 @@ class TestExploriumBatch:
     async def test_dedup_existing_domains(self):
         from app.services.prospect_discovery_explorium import run_explorium_discovery_batch
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"businesses": [EXPLORIUM_RAW_RESULT]}
+        mock_resp = _mock_response(200, json_body={"businesses": [EXPLORIUM_RAW_RESULT]})
 
         existing = {"raytheon-sensors.com"}  # already in pool
 
@@ -244,9 +252,7 @@ class TestExploriumBatch:
     async def test_batch_returns_prospect_creates(self):
         from app.services.prospect_discovery_explorium import run_explorium_discovery_batch
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"businesses": [EXPLORIUM_RAW_RESULT]}
+        mock_resp = _mock_response(200, json_body={"businesses": [EXPLORIUM_RAW_RESULT]})
 
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
             with patch("app.services.prospect_discovery_explorium.http") as mock_http:
@@ -474,10 +480,8 @@ class TestDedupLogic:
         """Same domain from multiple segment searches is deduped."""
         from app.services.prospect_discovery_explorium import run_explorium_discovery_batch
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
         # Same company appears in every search
-        mock_resp.json.return_value = {"businesses": [EXPLORIUM_RAW_RESULT]}
+        mock_resp = _mock_response(200, json_body={"businesses": [EXPLORIUM_RAW_RESULT]})
 
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
             with patch("app.services.prospect_discovery_explorium.http") as mock_http:
@@ -539,9 +543,7 @@ class TestExploriumCoverageGaps:
         """Line 133: businesses is not a list, gets reset to []."""
         from app.services.prospect_discovery_explorium import discover_companies_with_signals
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"businesses": "not-a-list"}
+        mock_resp = _mock_response(200, json_body={"businesses": "not-a-list"})
 
         async def run():
             with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
@@ -600,17 +602,23 @@ class TestExploriumCoverageGaps:
         result = normalize_explorium_result(raw, "ems_electronics")
         assert result["hiring"] == {}
 
-    def test_normalize_size_all_ranges(self):
+    @pytest.mark.parametrize(
+        ("company_size", "expected_range"),
+        [
+            (30, "1-50"),
+            (100, "51-200"),
+            (300, "201-500"),
+            (800, "501-1000"),
+            (3000, "1001-5000"),
+            (7000, "5001-10000"),
+            (20000, "10001+"),
+        ],
+    )
+    def test_normalize_size_all_ranges(self, company_size, expected_range):
         """Lines 246-258: all size bracket paths in _normalize_size."""
         from app.services.prospect_discovery_explorium import _normalize_size
 
-        assert _normalize_size({"company_size": 30}) == "1-50"
-        assert _normalize_size({"company_size": 100}) == "51-200"
-        assert _normalize_size({"company_size": 300}) == "201-500"
-        assert _normalize_size({"company_size": 800}) == "501-1000"
-        assert _normalize_size({"company_size": 3000}) == "1001-5000"
-        assert _normalize_size({"company_size": 7000}) == "5001-10000"
-        assert _normalize_size({"company_size": 20000}) == "10001+"
+        assert _normalize_size({"company_size": company_size}) == expected_range
 
     @pytest.mark.asyncio
     async def test_batch_skips_empty_domain(self):
@@ -622,9 +630,7 @@ class TestExploriumCoverageGaps:
             "industry": "Unknown",
         }
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"businesses": [no_domain_result]}
+        mock_resp = _mock_response(200, json_body={"businesses": [no_domain_result]})
 
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
             with patch("app.services.prospect_discovery_explorium.http") as mock_http:

--- a/tests/test_services/test_prospect_signals.py
+++ b/tests/test_services/test_prospect_signals.py
@@ -18,12 +18,18 @@ os.environ["RATE_LIMIT_ENABLED"] = "false"
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models import Company, User
 from app.models.prospect_account import ProspectAccount
 
 # ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _run(coro):
+    """Run a coroutine to completion on the active event loop."""
+    return asyncio.get_event_loop().run_until_complete(coro)
 
 
 def _make_prospect(db: Session, **overrides) -> ProspectAccount:
@@ -191,7 +197,7 @@ class TestEnrichMissingSignals:
             },
         )
 
-        result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+        result = _run(enrich_missing_signals(p.id, db_session))
         assert result is False
 
     @patch("app.http_client.http")
@@ -223,7 +229,7 @@ class TestEnrichMissingSignals:
             "app.services.prospect_discovery_explorium._get_api_key",
             return_value="test-key",
         ):
-            result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+            result = _run(enrich_missing_signals(p.id, db_session))
 
         assert result is True
         db_session.refresh(p)
@@ -252,7 +258,7 @@ class TestEnrichMissingSignals:
             "app.services.prospect_discovery_explorium._get_api_key",
             return_value="test-key",
         ):
-            result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+            result = _run(enrich_missing_signals(p.id, db_session))
 
         assert result is False
 
@@ -269,14 +275,14 @@ class TestEnrichMissingSignals:
             "app.services.prospect_discovery_explorium._get_api_key",
             return_value="",
         ):
-            result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+            result = _run(enrich_missing_signals(p.id, db_session))
 
         assert result is False
 
     def test_backfill_nonexistent_prospect(self, db_session):
         from app.services.prospect_signals import enrich_missing_signals
 
-        result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(99999, db_session))
+        result = _run(enrich_missing_signals(99999, db_session))
         assert result is False
 
     @patch("app.http_client.http")
@@ -299,7 +305,7 @@ class TestEnrichMissingSignals:
             "app.services.prospect_discovery_explorium._get_api_key",
             return_value="test-key",
         ):
-            result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+            result = _run(enrich_missing_signals(p.id, db_session))
 
         assert result is False
 
@@ -320,7 +326,7 @@ class TestEnrichMissingSignals:
             "app.services.prospect_discovery_explorium._get_api_key",
             return_value="",
         ):
-            result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+            result = _run(enrich_missing_signals(p.id, db_session))
 
         assert result is False
 
@@ -341,7 +347,7 @@ class TestEnrichMissingSignals:
             "app.services.prospect_discovery_explorium._get_api_key",
             return_value="test-key",
         ):
-            result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+            result = _run(enrich_missing_signals(p.id, db_session))
 
         assert result is False
 
@@ -359,7 +365,7 @@ class TestEnrichMissingSignals:
             "app.services.prospect_discovery_explorium._get_api_key",
             return_value="test-key",
         ):
-            result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+            result = _run(enrich_missing_signals(p.id, db_session))
 
         assert result is False
 
@@ -539,42 +545,35 @@ class TestFindSimilarCustomers:
 
 
 class TestComparesSizes:
-    def test_same_bracket(self):
+    @pytest.mark.parametrize(
+        ("a", "b", "expected"),
+        [
+            ("201-500", "201-500", True),
+            ("201-500", "501-1000", True),
+            ("1-50", "10001+", False),
+            (None, "201-500", False),
+            ("201-500", None, False),
+            (None, None, False),
+            ("300", "400", True),
+            ("10001+", "5001-10000", True),
+            ("lots", "many", False),
+        ],
+        ids=[
+            "same_bracket",
+            "adjacent_bracket",
+            "distant_brackets",
+            "none_first",
+            "none_second",
+            "none_both",
+            "numeric_string",
+            "plus_format",
+            "unparseable",
+        ],
+    )
+    def test_compare_sizes(self, a, b, expected):
         from app.services.prospect_signals import _compare_sizes
 
-        assert _compare_sizes("201-500", "201-500") is True
-
-    def test_adjacent_bracket(self):
-        from app.services.prospect_signals import _compare_sizes
-
-        assert _compare_sizes("201-500", "501-1000") is True
-
-    def test_distant_brackets(self):
-        from app.services.prospect_signals import _compare_sizes
-
-        assert _compare_sizes("1-50", "10001+") is False
-
-    def test_none_values(self):
-        from app.services.prospect_signals import _compare_sizes
-
-        assert _compare_sizes(None, "201-500") is False
-        assert _compare_sizes("201-500", None) is False
-        assert _compare_sizes(None, None) is False
-
-    def test_numeric_string(self):
-        from app.services.prospect_signals import _compare_sizes
-
-        assert _compare_sizes("300", "400") is True
-
-    def test_plus_format(self):
-        from app.services.prospect_signals import _compare_sizes
-
-        assert _compare_sizes("10001+", "5001-10000") is True
-
-    def test_unparseable(self):
-        from app.services.prospect_signals import _compare_sizes
-
-        assert _compare_sizes("lots", "many") is False
+        assert _compare_sizes(a, b) is expected
 
 
 # ── AI Writeup Generation ───────────────────────────────────────────
@@ -599,7 +598,7 @@ class TestGenerateAIWriteup:
             new_callable=AsyncMock,
             return_value="BorgWarner is a major automotive Tier 1 supplier. They show strong buying intent for electronic components.",
         ):
-            result = asyncio.get_event_loop().run_until_complete(generate_ai_writeup(p, db_session))
+            result = _run(generate_ai_writeup(p, db_session))
 
         assert "BorgWarner" in result
         db_session.refresh(p)
@@ -625,7 +624,7 @@ class TestGenerateAIWriteup:
             new_callable=AsyncMock,
             return_value=None,
         ):
-            result = asyncio.get_event_loop().run_until_complete(generate_ai_writeup(p, db_session))
+            result = _run(generate_ai_writeup(p, db_session))
 
         assert "FallbackCorp" in result
         assert "501-1000" in result
@@ -646,7 +645,7 @@ class TestGenerateAIWriteup:
             new_callable=AsyncMock,
             side_effect=Exception("API down"),
         ):
-            result = asyncio.get_event_loop().run_until_complete(generate_ai_writeup(p, db_session))
+            result = _run(generate_ai_writeup(p, db_session))
 
         assert "ExceptionCorp" in result
         db_session.refresh(p)
@@ -662,7 +661,7 @@ class TestGenerateAIWriteup:
             new_callable=AsyncMock,
             return_value="StoreCorp is a great prospect.",
         ):
-            asyncio.get_event_loop().run_until_complete(generate_ai_writeup(p, db_session))
+            _run(generate_ai_writeup(p, db_session))
 
         db_session.refresh(p)
         assert p.ai_writeup == "StoreCorp is a great prospect."
@@ -836,7 +835,7 @@ class TestRunSignalEnrichmentBatch:
         mock_writeup.return_value = "Great prospect."
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            result = asyncio.get_event_loop().run_until_complete(run_signal_enrichment_batch(min_fit_score=40))
+            result = _run(run_signal_enrichment_batch(min_fit_score=40))
 
         assert result["signals_added"] >= 1
         assert result["similar_computed"] >= 1
@@ -856,7 +855,7 @@ class TestRunSignalEnrichmentBatch:
         )
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            result = asyncio.get_event_loop().run_until_complete(run_signal_enrichment_batch(min_fit_score=40))
+            result = _run(run_signal_enrichment_batch(min_fit_score=40))
 
         assert result["signals_added"] == 0
         assert result["similar_computed"] == 0
@@ -879,7 +878,7 @@ class TestRunSignalEnrichmentBatch:
         mock_writeup.return_value = "Writeup."
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            result = asyncio.get_event_loop().run_until_complete(run_signal_enrichment_batch(min_fit_score=40))
+            result = _run(run_signal_enrichment_batch(min_fit_score=40))
 
         assert result["errors"] >= 1
         # Should still attempt writeups despite similar_customers error
@@ -948,7 +947,7 @@ class TestEnrichMissingSignalsHiringAndEvents:
             "app.services.prospect_discovery_explorium._get_api_key",
             return_value="test-key",
         ):
-            result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+            result = _run(enrich_missing_signals(p.id, db_session))
 
         assert result is True
         db_session.refresh(p)
@@ -986,7 +985,7 @@ class TestEnrichMissingSignalsHiringAndEvents:
             "app.services.prospect_discovery_explorium._get_api_key",
             return_value="test-key",
         ):
-            result = asyncio.get_event_loop().run_until_complete(enrich_missing_signals(p.id, db_session))
+            result = _run(enrich_missing_signals(p.id, db_session))
 
         assert result is True
         db_session.refresh(p)
@@ -1039,32 +1038,31 @@ class TestFindSimilarCustomersWeakMatch:
 
 
 class TestToBracketIndexEdgeCases:
-    def test_plus_format_valid(self):
-        """Lines 405-406: _to_bracket_index with '10000+' format."""
+    """_to_bracket_index edge cases exercised through _compare_sizes."""
+
+    @pytest.mark.parametrize(
+        ("a", "b", "expected"),
+        [
+            # Lines 405-406: "10000+" parses to 10000, in bracket (5001, 10000).
+            ("10000+", "5001-10000", True),
+            # Lines 405-406: "abc+" fails to parse -> None -> False.
+            ("abc+", "1001-5000", False),
+            # Lines 411-412: non-parseable dash range -> None -> False.
+            ("abc-def", "1001-5000", False),
+            # Line 425: 2000000 exceeds the largest bracket (10001, 999999).
+            ("2000000", "1001-5000", False),
+        ],
+        ids=[
+            "plus_format_valid",
+            "plus_format_invalid",
+            "dash_format_invalid",
+            "exceeds_all_brackets",
+        ],
+    )
+    def test_compare_sizes_edge_cases(self, a, b, expected):
         from app.services.prospect_signals import _compare_sizes
 
-        # "10000+" should parse to 10000, which is in bracket (5001, 10000)
-        assert _compare_sizes("10000+", "5001-10000") is True
-
-    def test_plus_format_invalid(self):
-        """Lines 405-406: _to_bracket_index with unparseable '+' format."""
-        from app.services.prospect_signals import _compare_sizes
-
-        # "abc+" should fail to parse -> None -> False
-        assert _compare_sizes("abc+", "1001-5000") is False
-
-    def test_dash_format_invalid(self):
-        """Lines 411-412: _to_bracket_index with non-parseable range."""
-        from app.services.prospect_signals import _compare_sizes
-
-        assert _compare_sizes("abc-def", "1001-5000") is False
-
-    def test_exceeds_all_brackets(self):
-        """Line 425: _to_bracket_index returns None when num > max bracket."""
-        from app.services.prospect_signals import _compare_sizes
-
-        # 2000000 exceeds the largest bracket (10001, 999999)
-        assert _compare_sizes("2000000", "1001-5000") is False
+        assert _compare_sizes(a, b) is expected
 
 
 # ── Coverage: run_signal_enrichment_batch error handling ─────────────
@@ -1093,7 +1091,7 @@ class TestRunBatchErrorPaths:
         mock_writeup.return_value = "Writeup."
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            result = asyncio.get_event_loop().run_until_complete(run_signal_enrichment_batch(min_fit_score=40))
+            result = _run(run_signal_enrichment_batch(min_fit_score=40))
 
         assert result["errors"] >= 1
         assert result["signals_added"] == 0
@@ -1117,7 +1115,7 @@ class TestRunBatchErrorPaths:
         mock_writeup.return_value = "Writeup."
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            result = asyncio.get_event_loop().run_until_complete(run_signal_enrichment_batch(min_fit_score=40))
+            result = _run(run_signal_enrichment_batch(min_fit_score=40))
 
         # similar_customers already set → find_similar_customers should NOT be called
         mock_similar.assert_not_called()
@@ -1146,7 +1144,7 @@ class TestRunBatchErrorPaths:
         mock_similar.return_value = []
 
         with patch("app.database.SessionLocal", return_value=db_session):
-            result = asyncio.get_event_loop().run_until_complete(run_signal_enrichment_batch(min_fit_score=40))
+            result = _run(run_signal_enrichment_batch(min_fit_score=40))
 
         assert result["errors"] >= 1
         assert result["writeups_generated"] == 0

--- a/tests/test_services_ai_intake_service.py
+++ b/tests/test_services_ai_intake_service.py
@@ -28,24 +28,24 @@ from app.services.ai_intake_parser import (
 
 
 class TestCleanText:
-    def test_strips_whitespace(self):
-        assert _clean_text("  hello  ") == "hello"
-
-    def test_normalizes_crlf(self):
-        assert _clean_text("a\r\nb\rc") == "a\nb\nc"
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("  hello  ", "hello"),
+            ("a\r\nb\rc", "a\nb\nc"),
+            ("", ""),
+            (None, ""),
+            ("Line 1\n  Line 2\n    Line 3", "Line 1\n  Line 2\n    Line 3"),
+        ],
+        ids=["strips_whitespace", "normalizes_crlf", "empty_str", "none", "preserves_structure"],
+    )
+    def test_clean_text(self, raw, expected):
+        assert _clean_text(raw) == expected
 
     def test_collapses_blank_runs(self):
         result = _clean_text("a\n\n\n\n\nb")
         # _clean_text allows up to 2 consecutive blank lines (3 newlines)
         assert "\n\n\n\n" not in result
-
-    def test_empty_input(self):
-        assert _clean_text("") == ""
-        assert _clean_text(None) == ""
-
-    def test_preserves_structure(self):
-        text = "Line 1\n  Line 2\n    Line 3"
-        assert _clean_text(text) == text
 
 
 # ---------------------------------------------------------------------------
@@ -54,23 +54,20 @@ class TestCleanText:
 
 
 class TestCoerceJsonList:
-    def test_list_passthrough(self):
-        assert _coerce_json_list([1, 2, 3]) == [1, 2, 3]
-
-    def test_json_string(self):
-        assert _coerce_json_list('[{"mpn": "ABC"}]') == [{"mpn": "ABC"}]
-
-    def test_invalid_json(self):
-        assert _coerce_json_list("not json") == []
-
-    def test_none(self):
-        assert _coerce_json_list(None) == []
-
-    def test_non_array_json(self):
-        assert _coerce_json_list('{"key": "val"}') == []
-
-    def test_integer(self):
-        assert _coerce_json_list(42) == []
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ([1, 2, 3], [1, 2, 3]),
+            ('[{"mpn": "ABC"}]', [{"mpn": "ABC"}]),
+            ("not json", []),
+            (None, []),
+            ('{"key": "val"}', []),
+            (42, []),
+        ],
+        ids=["list_passthrough", "json_string", "invalid_json", "none", "non_array_json", "integer"],
+    )
+    def test_coerce_json_list(self, value, expected):
+        assert _coerce_json_list(value) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -79,18 +76,19 @@ class TestCoerceJsonList:
 
 
 class TestCleanScalar:
-    def test_none(self):
-        assert _clean_scalar(None) is None
-
-    def test_empty_string(self):
-        assert _clean_scalar("") is None
-        assert _clean_scalar("   ") is None
-
-    def test_collapses_whitespace(self):
-        assert _clean_scalar("  hello   world  ") == "hello world"
-
-    def test_non_string(self):
-        assert _clean_scalar(42) == "42"
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            ("", None),
+            ("   ", None),
+            ("  hello   world  ", "hello world"),
+            (42, "42"),
+        ],
+        ids=["none", "empty_string", "blank_string", "collapses_whitespace", "non_string"],
+    )
+    def test_clean_scalar(self, value, expected):
+        assert _clean_scalar(value) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -245,34 +243,23 @@ class TestNormalizeOffers:
 
 
 class TestBackfillDocumentType:
-    def test_no_change_when_not_unclear(self):
-        result = {"document_type": "rfq", "requirements": [], "offers": []}
+    @pytest.mark.parametrize(
+        "result,expected",
+        [
+            ({"document_type": "rfq", "requirements": [], "offers": []}, "rfq"),
+            ({"document_type": "unclear", "requirements": [], "offers": [{"mpn": "A"}]}, "offer"),
+            ({"document_type": "unclear", "requirements": [{"mpn": "A"}], "offers": []}, "rfq"),
+            (
+                {"document_type": "unclear", "requirements": [{"mpn": "A"}], "offers": [{"mpn": "B"}, {"mpn": "C"}]},
+                "offer",
+            ),
+            ({"document_type": "unclear", "requirements": [], "offers": []}, "unclear"),
+        ],
+        ids=["no_change_when_not_unclear", "infers_offer", "infers_rfq", "offer_wins_when_more", "stays_unclear"],
+    )
+    def test_backfill_document_type(self, result, expected):
         _backfill_document_type(result)
-        assert result["document_type"] == "rfq"
-
-    def test_infers_offer(self):
-        result = {"document_type": "unclear", "requirements": [], "offers": [{"mpn": "A"}]}
-        _backfill_document_type(result)
-        assert result["document_type"] == "offer"
-
-    def test_infers_rfq(self):
-        result = {"document_type": "unclear", "requirements": [{"mpn": "A"}], "offers": []}
-        _backfill_document_type(result)
-        assert result["document_type"] == "rfq"
-
-    def test_offer_wins_when_more(self):
-        result = {
-            "document_type": "unclear",
-            "requirements": [{"mpn": "A"}],
-            "offers": [{"mpn": "B"}, {"mpn": "C"}],
-        }
-        _backfill_document_type(result)
-        assert result["document_type"] == "offer"
-
-    def test_stays_unclear_when_empty(self):
-        result = {"document_type": "unclear", "requirements": [], "offers": []}
-        _backfill_document_type(result)
-        assert result["document_type"] == "unclear"
+        assert result["document_type"] == expected
 
 
 # ---------------------------------------------------------------------------
@@ -286,20 +273,18 @@ class TestBackfillRequisitionName:
         _backfill_requisition_name(result)
         assert result["requisition_name"] == "My Req"
 
-    def test_generates_rfq_name(self):
-        result = {"requisition_name": None, "document_type": "rfq", "customer_name": "Acme"}
+    @pytest.mark.parametrize(
+        "result,expected_substr",
+        [
+            ({"requisition_name": None, "document_type": "rfq", "customer_name": "Acme"}, "Acme RFQ intake"),
+            ({"requisition_name": None, "document_type": "offer", "vendor_name": "DigiKey"}, "DigiKey offer intake"),
+            ({"requisition_name": None, "document_type": "unclear"}, "AI intake draft"),
+        ],
+        ids=["rfq_name", "offer_name", "fallback_name"],
+    )
+    def test_generates_name(self, result, expected_substr):
         _backfill_requisition_name(result)
-        assert "Acme RFQ intake" in result["requisition_name"]
-
-    def test_generates_offer_name(self):
-        result = {"requisition_name": None, "document_type": "offer", "vendor_name": "DigiKey"}
-        _backfill_requisition_name(result)
-        assert "DigiKey offer intake" in result["requisition_name"]
-
-    def test_generates_fallback_name(self):
-        result = {"requisition_name": None, "document_type": "unclear"}
-        _backfill_requisition_name(result)
-        assert "AI intake draft" in result["requisition_name"]
+        assert expected_substr in result["requisition_name"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services_coverage.py
+++ b/tests/test_services_coverage.py
@@ -25,6 +25,48 @@ from app.services.prospect_contacts import (
     mask_email,
 )
 
+
+def _patch_graph_client(*, pages_return=None, pages_side_effect=None):
+    """Patch GraphClient with a mock whose get_all_pages is stubbed.
+
+    Returns the patch context manager so callers can use it in a `with` block.
+    """
+    mock_gc = MagicMock()
+    if pages_side_effect is not None:
+        mock_gc.get_all_pages = AsyncMock(side_effect=pages_side_effect)
+    else:
+        mock_gc.get_all_pages = AsyncMock(return_value=pages_return)
+    return patch("app.utils.graph_client.GraphClient", return_value=mock_gc)
+
+
+def _add_requirement(db_session, customer_site_id, *, req_name, mpn, brand, qty):
+    """Create a Requisition (linked to a customer site) plus one Requirement.
+
+    Returns the flushed Requirement so callers can attach sightings, etc.
+    """
+    from app.models import Requirement, Requisition
+
+    req = Requisition(
+        name=req_name,
+        customer_name="Acme",
+        customer_site_id=customer_site_id,
+        status="active",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req)
+    db_session.flush()
+    item = Requirement(
+        requisition_id=req.id,
+        primary_mpn=mpn,
+        brand=brand,
+        target_qty=qty,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(item)
+    db_session.flush()
+    return item
+
+
 # ── Health Service ──────────────────────────────────────────────────────
 
 
@@ -313,36 +355,22 @@ class TestMailboxIntelligence:
         assert result["timezone"] == "UTC"
         assert result["auto_reply_status"] == "disabled"
 
-    def test_is_within_working_hours_true(self, db_session):
+    @pytest.mark.parametrize(
+        "start, end, hour, expected",
+        [
+            ("08:00", "17:00", 10, True),  # within
+            ("08:00", "17:00", 20, False),  # after hours
+            (None, None, 10, True),  # no config
+            ("08:00", "17:00", 8, True),  # start boundary inclusive
+            ("08:00", "17:00", 17, False),  # end boundary exclusive
+            ("invalid", "also-bad", 10, True),  # bad format
+        ],
+    )
+    def test_is_within_working_hours(self, db_session, start, end, hour, expected):
         from app.services.mailbox_intelligence import is_within_working_hours
 
-        user = SimpleNamespace(working_hours_start="08:00", working_hours_end="17:00")
-        assert is_within_working_hours(user, 10) is True
-
-    def test_is_within_working_hours_false(self, db_session):
-        from app.services.mailbox_intelligence import is_within_working_hours
-
-        user = SimpleNamespace(working_hours_start="08:00", working_hours_end="17:00")
-        assert is_within_working_hours(user, 20) is False
-
-    def test_is_within_working_hours_no_config(self, db_session):
-        from app.services.mailbox_intelligence import is_within_working_hours
-
-        user = SimpleNamespace(working_hours_start=None, working_hours_end=None)
-        assert is_within_working_hours(user, 10) is True
-
-    def test_is_within_working_hours_boundary(self, db_session):
-        from app.services.mailbox_intelligence import is_within_working_hours
-
-        user = SimpleNamespace(working_hours_start="08:00", working_hours_end="17:00")
-        assert is_within_working_hours(user, 8) is True
-        assert is_within_working_hours(user, 17) is False
-
-    def test_is_within_working_hours_bad_format(self, db_session):
-        from app.services.mailbox_intelligence import is_within_working_hours
-
-        user = SimpleNamespace(working_hours_start="invalid", working_hours_end="also-bad")
-        assert is_within_working_hours(user, 10) is True
+        user = SimpleNamespace(working_hours_start=start, working_hours_end=end)
+        assert is_within_working_hours(user, hour) is expected
 
 
 # ── Prospect Contacts ───────────────────────────────────────────────────
@@ -351,62 +379,64 @@ class TestMailboxIntelligence:
 class TestProspectContacts:
     """Tests for app/services/prospect_contacts.py."""
 
-    def test_classify_decision_maker(self, db_session):
-        assert classify_contact_seniority("VP of Sales") == "decision_maker"
-        assert classify_contact_seniority("Director of Engineering") == "decision_maker"
-        assert classify_contact_seniority("Chief Technology Officer") == "decision_maker"
-        assert classify_contact_seniority("CEO") == "decision_maker"
-        assert classify_contact_seniority("Head of Procurement") == "decision_maker"
-        assert classify_contact_seniority("SVP Operations") == "decision_maker"
-        assert classify_contact_seniority("EVP Sales") == "decision_maker"
+    @pytest.mark.parametrize(
+        "title, expected",
+        [
+            ("VP of Sales", "decision_maker"),
+            ("Director of Engineering", "decision_maker"),
+            ("Chief Technology Officer", "decision_maker"),
+            ("CEO", "decision_maker"),
+            ("Head of Procurement", "decision_maker"),
+            ("SVP Operations", "decision_maker"),
+            ("EVP Sales", "decision_maker"),
+            ("Senior Engineer", "influencer"),
+            ("Project Manager", "influencer"),
+            ("Team Lead", "influencer"),
+            ("Commodity Manager", "influencer"),
+            ("Principal Architect", "influencer"),
+            ("Buyer", "executor"),
+            ("Purchasing Agent", "executor"),
+            ("Procurement Coordinator", "executor"),
+            ("Supply Chain Analyst", "executor"),
+            ("Planning Specialist", "executor"),
+            ("Planner", "executor"),
+            ("Assistant Buyer", "executor"),
+            ("Receptionist", "other"),
+            ("", "other"),
+            (None, "other"),
+        ],
+    )
+    def test_classify_contact_seniority(self, db_session, title, expected):
+        assert classify_contact_seniority(title) == expected
 
-    def test_classify_influencer(self, db_session):
-        assert classify_contact_seniority("Senior Engineer") == "influencer"
-        assert classify_contact_seniority("Project Manager") == "influencer"
-        assert classify_contact_seniority("Team Lead") == "influencer"
-        assert classify_contact_seniority("Commodity Manager") == "influencer"
-        assert classify_contact_seniority("Principal Architect") == "influencer"
+    @pytest.mark.parametrize(
+        "email, expected",
+        [
+            ("john.smith@company.com", "j***@comp..."),
+            ("a@b.co", "a***@b.co"),
+            ("", ""),
+            (None, ""),
+            ("invalid", ""),
+        ],
+    )
+    def test_mask_email(self, db_session, email, expected):
+        assert mask_email(email) == expected
 
-    def test_classify_executor(self, db_session):
-        assert classify_contact_seniority("Buyer") == "executor"
-        assert classify_contact_seniority("Purchasing Agent") == "executor"
-        assert classify_contact_seniority("Procurement Coordinator") == "executor"
-        assert classify_contact_seniority("Supply Chain Analyst") == "executor"
-        assert classify_contact_seniority("Planning Specialist") == "executor"
-        assert classify_contact_seniority("Planner") == "executor"
-        assert classify_contact_seniority("Assistant Buyer") == "executor"
-
-    def test_classify_other(self, db_session):
-        assert classify_contact_seniority("Receptionist") == "other"
-        assert classify_contact_seniority("") == "other"
-        assert classify_contact_seniority(None) == "other"
-
-    def test_mask_email_standard(self, db_session):
-        assert mask_email("john.smith@company.com") == "j***@comp..."
-
-    def test_mask_email_short_domain(self, db_session):
-        assert mask_email("a@b.co") == "a***@b.co"
-
-    def test_mask_email_empty(self, db_session):
-        assert mask_email("") == ""
-        assert mask_email(None) == ""
-
-    def test_mask_email_no_at(self, db_session):
-        assert mask_email("invalid") == ""
-
-    def test_is_personal_email_true(self, db_session):
-        assert _is_personal_email("user@gmail.com") is True
-        assert _is_personal_email("user@yahoo.com") is True
-        assert _is_personal_email("user@hotmail.com") is True
-        assert _is_personal_email("user@protonmail.com") is True
-
-    def test_is_personal_email_false(self, db_session):
-        assert _is_personal_email("user@company.com") is False
-
-    def test_is_personal_email_edge(self, db_session):
-        assert _is_personal_email("") is False
-        assert _is_personal_email(None) is False
-        assert _is_personal_email("no-at-sign") is False
+    @pytest.mark.parametrize(
+        "email, expected",
+        [
+            ("user@gmail.com", True),
+            ("user@yahoo.com", True),
+            ("user@hotmail.com", True),
+            ("user@protonmail.com", True),
+            ("user@company.com", False),
+            ("", False),
+            (None, False),
+            ("no-at-sign", False),
+        ],
+    )
+    def test_is_personal_email(self, db_session, email, expected):
+        assert _is_personal_email(email) is expected
 
     def test_is_new_hire_recent(self, db_session):
         recent = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
@@ -458,28 +488,16 @@ class TestCustomerAnalysisService:
 
     @pytest.mark.asyncio
     async def test_analyze_with_parts(self, db_session, test_company, test_customer_site):
-        from app.models import Requirement, Requisition
         from app.services.customer_analysis_service import analyze_customer_materials
 
-        # Create a requisition linked to customer site
-        req = Requisition(
-            name="REQ-ANALYSIS",
-            customer_name="Acme",
-            customer_site_id=test_customer_site.id,
-            status="active",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
-        db_session.flush()
-        item = Requirement(
-            requisition_id=req.id,
-            primary_mpn="LM317T",
+        _add_requirement(
+            db_session,
+            test_customer_site.id,
+            req_name="REQ-ANALYSIS",
+            mpn="LM317T",
             brand="Texas Instruments",
-            target_qty=100,
-            created_at=datetime.now(timezone.utc),
+            qty=100,
         )
-        db_session.add(item)
-        db_session.flush()
 
         mock_result = {"brands": ["Texas Instruments"], "commodities": ["Voltage Regulators"]}
         with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=mock_result):
@@ -491,27 +509,17 @@ class TestCustomerAnalysisService:
 
     @pytest.mark.asyncio
     async def test_analyze_with_sightings(self, db_session, test_company, test_customer_site):
-        from app.models import Requirement, Requisition, Sighting
+        from app.models import Sighting
         from app.services.customer_analysis_service import analyze_customer_materials
 
-        req = Requisition(
-            name="REQ-SIGHTING",
-            customer_name="Acme",
-            customer_site_id=test_customer_site.id,
-            status="active",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
-        db_session.flush()
-        item = Requirement(
-            requisition_id=req.id,
-            primary_mpn="IC-CHIP-001",
+        item = _add_requirement(
+            db_session,
+            test_customer_site.id,
+            req_name="REQ-SIGHTING",
+            mpn="IC-CHIP-001",
             brand="Intel",
-            target_qty=50,
-            created_at=datetime.now(timezone.utc),
+            qty=50,
         )
-        db_session.add(item)
-        db_session.flush()
         # Add a sighting with a different MPN to exercise the sighting loop
         sighting = Sighting(
             requirement_id=item.id,
@@ -533,27 +541,16 @@ class TestCustomerAnalysisService:
 
     @pytest.mark.asyncio
     async def test_analyze_claude_returns_none(self, db_session, test_company, test_customer_site):
-        from app.models import Requirement, Requisition
         from app.services.customer_analysis_service import analyze_customer_materials
 
-        req = Requisition(
-            name="REQ-ANALYSIS2",
-            customer_name="Acme",
-            customer_site_id=test_customer_site.id,
-            status="active",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(req)
-        db_session.flush()
-        item = Requirement(
-            requisition_id=req.id,
-            primary_mpn="LM317T",
+        _add_requirement(
+            db_session,
+            test_customer_site.id,
+            req_name="REQ-ANALYSIS2",
+            mpn="LM317T",
             brand="TI",
-            target_qty=100,
-            created_at=datetime.now(timezone.utc),
+            qty=100,
         )
-        db_session.add(item)
-        db_session.flush()
 
         with patch("app.utils.claude_client.claude_json", new_callable=AsyncMock, return_value=None):
             result = await analyze_customer_materials(test_company.id, db_session=db_session)
@@ -708,10 +705,7 @@ class TestCalendarIntelligence:
     async def test_scan_calendar_api_error(self, db_session, test_user):
         from app.services.calendar_intelligence import scan_calendar_events
 
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(side_effect=Exception("Graph API error"))
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with _patch_graph_client(pages_side_effect=Exception("Graph API error")):
             result = await scan_calendar_events("token", test_user.id, db_session)
         assert result["events_scanned"] == 0
 
@@ -719,10 +713,7 @@ class TestCalendarIntelligence:
     async def test_scan_calendar_no_events(self, db_session, test_user):
         from app.services.calendar_intelligence import scan_calendar_events
 
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(return_value=[])
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with _patch_graph_client(pages_return=[]):
             result = await scan_calendar_events("token", test_user.id, db_session)
         assert result["events_scanned"] == 0
         assert result["vendor_meetings"] == 0
@@ -748,10 +739,7 @@ class TestCalendarIntelligence:
                 "location": {"displayName": "Teams"},
             }
         ]
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(return_value=events)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with _patch_graph_client(pages_return=events):
             result = await scan_calendar_events("token", test_user.id, db_session)
         assert result["events_scanned"] == 1
         assert result["vendor_meetings"] == 1
@@ -770,10 +758,7 @@ class TestCalendarIntelligence:
                 "location": {"displayName": "Munich"},
             }
         ]
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(return_value=events)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with _patch_graph_client(pages_return=events):
             result = await scan_calendar_events("token", test_user.id, db_session)
         assert result["trade_shows"] == 1
         assert result["activities_logged"] == 1
@@ -798,10 +783,7 @@ class TestCalendarIntelligence:
                 "location": {},
             }
         ]
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(return_value=events)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with _patch_graph_client(pages_return=events):
             result = await scan_calendar_events("token", test_user.id, db_session)
         assert result["vendor_meetings"] == 0
         assert result["activities_logged"] == 0
@@ -819,10 +801,7 @@ class TestCalendarIntelligence:
                 "location": {},
             }
         ]
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(return_value=events)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with _patch_graph_client(pages_return=events):
             # First scan
             r1 = await scan_calendar_events("token", test_user.id, db_session)
             assert r1["activities_logged"] == 1
@@ -843,9 +822,6 @@ class TestCalendarIntelligence:
                 "location": {},
             }
         ]
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(return_value=events)
-
         # Use a mock db that raises on commit
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.first.return_value = None
@@ -853,7 +829,7 @@ class TestCalendarIntelligence:
         mock_db.commit.side_effect = Exception("commit error")
         mock_db.rollback = MagicMock()
 
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with _patch_graph_client(pages_return=events):
             result = await scan_calendar_events("token", test_user.id, mock_db)
         mock_db.rollback.assert_called_once()
 
@@ -873,10 +849,7 @@ class TestCalendarIntelligence:
                 "location": {},
             }
         ]
-        mock_gc = MagicMock()
-        mock_gc.get_all_pages = AsyncMock(return_value=events)
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+        with _patch_graph_client(pages_return=events):
             result = await scan_calendar_events("token", test_user.id, db_session)
         assert result["vendor_meetings"] == 0
 
@@ -887,45 +860,41 @@ class TestCalendarIntelligence:
 class TestCustomerEnrichmentService:
     """Tests for app/services/customer_enrichment_service.py."""
 
-    def test_classify_contact_role_decision_maker(self, db_session):
+    @pytest.mark.parametrize(
+        "title, expected",
+        [
+            ("VP of Sales", "decision_maker"),
+            ("Director", "decision_maker"),
+            ("CEO", "decision_maker"),
+            ("Chief Operating Officer", "decision_maker"),
+            ("Senior Buyer", "buyer"),
+            ("Procurement Manager", "buyer"),
+            ("Supply Chain Lead", "buyer"),
+            ("Design Engineer", "technical"),
+            ("Quality Manager", "technical"),
+            ("Office Manager", "operations"),
+            (None, "unknown"),
+            ("", "unknown"),
+        ],
+    )
+    def test_classify_contact_role(self, db_session, title, expected):
         from app.services.customer_enrichment_service import _classify_contact_role
 
-        assert _classify_contact_role("VP of Sales") == "decision_maker"
-        assert _classify_contact_role("Director") == "decision_maker"
-        assert _classify_contact_role("CEO") == "decision_maker"
-        assert _classify_contact_role("Chief Operating Officer") == "decision_maker"
+        assert _classify_contact_role(title) == expected
 
-    def test_classify_contact_role_buyer(self, db_session):
-        from app.services.customer_enrichment_service import _classify_contact_role
-
-        assert _classify_contact_role("Senior Buyer") == "buyer"
-        assert _classify_contact_role("Procurement Manager") == "buyer"
-        assert _classify_contact_role("Supply Chain Lead") == "buyer"
-
-    def test_classify_contact_role_technical(self, db_session):
-        from app.services.customer_enrichment_service import _classify_contact_role
-
-        assert _classify_contact_role("Design Engineer") == "technical"
-        assert _classify_contact_role("Quality Manager") == "technical"
-
-    def test_classify_contact_role_operations(self, db_session):
-        from app.services.customer_enrichment_service import _classify_contact_role
-
-        assert _classify_contact_role("Office Manager") == "operations"
-
-    def test_classify_contact_role_unknown(self, db_session):
-        from app.services.customer_enrichment_service import _classify_contact_role
-
-        assert _classify_contact_role(None) == "unknown"
-        assert _classify_contact_role("") == "unknown"
-
-    def test_is_direct_dial(self, db_session):
+    @pytest.mark.parametrize(
+        "phone_type, expected",
+        [
+            ("direct_dial", True),
+            ("mobile", True),
+            ("switchboard", False),
+            (None, False),
+        ],
+    )
+    def test_is_direct_dial(self, db_session, phone_type, expected):
         from app.services.customer_enrichment_service import _is_direct_dial
 
-        assert _is_direct_dial("direct_dial") is True
-        assert _is_direct_dial("mobile") is True
-        assert _is_direct_dial("switchboard") is False
-        assert _is_direct_dial(None) is False
+        assert _is_direct_dial(phone_type) is expected
 
     def test_contacts_needed(self, db_session, test_company, test_customer_site):
         from app.services.customer_enrichment_service import _contacts_needed
@@ -940,20 +909,20 @@ class TestCustomerEnrichmentService:
         needed = _contacts_needed(db_session, 99999, 5)
         assert needed == 5
 
-    def test_get_company_domain(self, db_session):
+    @pytest.mark.parametrize(
+        "domain, website, expected",
+        [
+            ("example.com", None, "example.com"),
+            (None, "https://www.example.com/about", "example.com"),
+            (None, None, None),
+            ("", "", None),
+        ],
+    )
+    def test_get_company_domain(self, db_session, domain, website, expected):
         from app.services.customer_enrichment_service import _get_company_domain
 
-        co = SimpleNamespace(domain="example.com", website=None)
-        assert _get_company_domain(co) == "example.com"
-
-        co2 = SimpleNamespace(domain=None, website="https://www.example.com/about")
-        assert _get_company_domain(co2) == "example.com"
-
-        co3 = SimpleNamespace(domain=None, website=None)
-        assert _get_company_domain(co3) is None
-
-        co4 = SimpleNamespace(domain="", website="")
-        assert _get_company_domain(co4) is None
+        co = SimpleNamespace(domain=domain, website=website)
+        assert _get_company_domain(co) == expected
 
     @pytest.mark.asyncio
     async def test_enrich_disabled(self, db_session):

--- a/tests/test_services_ownership.py
+++ b/tests/test_services_ownership.py
@@ -433,57 +433,27 @@ class TestSendManagerDigestEmail:
 
 
 class TestGetMyAccountsStatuses:
-    def test_no_activity_status(self, db_session):
-        """Account with no last_activity_at → 'no_activity'."""
-        sales = _make_sales_user(db_session, "stat1@t.com")
-        _make_company(db_session, name="No Activity Co", owner_id=sales.id, last_activity_at=None)
+    @pytest.mark.parametrize(
+        ("email", "name", "days_inactive", "expected_status"),
+        [
+            ("stat1@t.com", "No Activity Co", None, "no_activity"),
+            ("stat2@t.com", "Green Co", 5, "green"),
+            ("stat3@t.com", "Yellow Co", 24, "yellow"),
+            ("stat4@t.com", "Red Co", 31, "red"),
+        ],
+        ids=["no_activity", "green_zone", "yellow_zone", "red_zone"],
+    )
+    def test_status_classification(self, db_session, email, name, days_inactive, expected_status):
+        """last_activity_at age → health status (none → no_activity, 5 → green, 24 →
+        yellow, 31 → red)."""
+        sales = _make_sales_user(db_session, email)
+        last_activity_at = None if days_inactive is None else datetime.now(timezone.utc) - timedelta(days=days_inactive)
+        _make_company(db_session, name=name, owner_id=sales.id, last_activity_at=last_activity_at)
         db_session.commit()
 
         result = get_my_accounts(sales.id, db_session)
         assert len(result) == 1
-        assert result[0]["status"] == "no_activity"
-
-    def test_green_zone(self, db_session):
-        """Recent activity → 'green'."""
-        sales = _make_sales_user(db_session, "stat2@t.com")
-        _make_company(
-            db_session,
-            name="Green Co",
-            owner_id=sales.id,
-            last_activity_at=datetime.now(timezone.utc) - timedelta(days=5),
-        )
-        db_session.commit()
-
-        result = get_my_accounts(sales.id, db_session)
-        assert result[0]["status"] == "green"
-
-    def test_yellow_zone(self, db_session):
-        """24 days inactive (in 23-30 window) → 'yellow'."""
-        sales = _make_sales_user(db_session, "stat3@t.com")
-        _make_company(
-            db_session,
-            name="Yellow Co",
-            owner_id=sales.id,
-            last_activity_at=datetime.now(timezone.utc) - timedelta(days=24),
-        )
-        db_session.commit()
-
-        result = get_my_accounts(sales.id, db_session)
-        assert result[0]["status"] == "yellow"
-
-    def test_red_zone(self, db_session):
-        """31 days inactive (past 30-day limit) → 'red'."""
-        sales = _make_sales_user(db_session, "stat4@t.com")
-        _make_company(
-            db_session,
-            name="Red Co",
-            owner_id=sales.id,
-            last_activity_at=datetime.now(timezone.utc) - timedelta(days=31),
-        )
-        db_session.commit()
-
-        result = get_my_accounts(sales.id, db_session)
-        assert result[0]["status"] == "red"
+        assert result[0]["status"] == expected_status
 
     def test_strategic_account_longer_limit(self, db_session):
         """Strategic account at 35 days → still 'green' (90-day limit)."""
@@ -537,11 +507,19 @@ class TestSendWarningAlert:
             mock_gc_class.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_graph_error_caught(self, db_session):
+    @pytest.mark.parametrize(
+        ("email", "error_message"),
+        [
+            ("grapherr@t.com", "Graph error"),
+            ("teamserr@t.com", "Send failed"),
+        ],
+        ids=["graph_error", "teams_error"],
+    )
+    async def test_post_json_error_caught(self, db_session, email, error_message):
         """Graph API error during warning email is caught, not raised."""
         from app.services.ownership_service import _send_warning_alert
 
-        sales = _make_sales_user(db_session, "grapherr@t.com")
+        sales = _make_sales_user(db_session, email)
         co = _make_company(db_session, owner_id=sales.id)
         db_session.commit()
 
@@ -550,25 +528,7 @@ class TestSendWarningAlert:
             patch("app.utils.graph_client.GraphClient") as mock_gc_class,
         ):
             mock_gc = mock_gc_class.return_value
-            mock_gc.post_json = AsyncMock(side_effect=Exception("Graph error"))
-            # Should not raise — error is caught internally
-            await _send_warning_alert(co, 25, 30, db_session)
-
-    @pytest.mark.asyncio
-    async def test_teams_error_caught(self, db_session):
-        """Graph API error during warning email is caught, not raised."""
-        from app.services.ownership_service import _send_warning_alert
-
-        sales = _make_sales_user(db_session, "teamserr@t.com")
-        co = _make_company(db_session, owner_id=sales.id)
-        db_session.commit()
-
-        with (
-            patch("app.scheduler.get_valid_token", new_callable=AsyncMock, return_value="fake-token"),
-            patch("app.utils.graph_client.GraphClient") as mock_gc_class,
-        ):
-            mock_gc = mock_gc_class.return_value
-            mock_gc.post_json = AsyncMock(side_effect=Exception("Send failed"))
+            mock_gc.post_json = AsyncMock(side_effect=Exception(error_message))
             # Should not raise — error is caught internally
             await _send_warning_alert(co, 25, 30, db_session)
 

--- a/tests/test_sightings_router_coverage2.py
+++ b/tests/test_sightings_router_coverage2.py
@@ -97,66 +97,23 @@ class TestSightingsRefresh:
 
 
 class TestSightingsListFilters:
-    def test_filter_by_status(self, client: TestClient, req_with_item: tuple):
+    @pytest.mark.parametrize(
+        "params",
+        [
+            pytest.param({"status": "open"}, id="filter_by_status"),
+            pytest.param({"sales_person": "Test"}, id="filter_by_sales_person"),
+            pytest.param({"assigned": "mine"}, id="filter_assigned_mine"),
+            pytest.param({"q": "STM32"}, id="filter_by_query"),
+            pytest.param({"sort": "mpn", "dir": "asc"}, id="sort_by_mpn"),
+            pytest.param({"sort": "created", "dir": "desc"}, id="sort_by_created"),
+            pytest.param({"group_by": "manufacturer"}, id="group_by_manufacturer"),
+            pytest.param({"group_by": "brand"}, id="group_by_brand"),
+        ],
+    )
+    def test_list_filter(self, client: TestClient, req_with_item: tuple, params: dict):
         resp = client.get(
             "/v2/partials/sightings",
-            params={"status": "open"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_filter_by_sales_person(self, client: TestClient, req_with_item: tuple):
-        resp = client.get(
-            "/v2/partials/sightings",
-            params={"sales_person": "Test"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_filter_assigned_mine(self, client: TestClient, req_with_item: tuple):
-        resp = client.get(
-            "/v2/partials/sightings",
-            params={"assigned": "mine"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_filter_by_query(self, client: TestClient, req_with_item: tuple):
-        resp = client.get(
-            "/v2/partials/sightings",
-            params={"q": "STM32"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_sort_by_mpn(self, client: TestClient, req_with_item: tuple):
-        resp = client.get(
-            "/v2/partials/sightings",
-            params={"sort": "mpn", "dir": "asc"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_sort_by_created(self, client: TestClient, req_with_item: tuple):
-        resp = client.get(
-            "/v2/partials/sightings",
-            params={"sort": "created", "dir": "desc"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_group_by_manufacturer(self, client: TestClient, req_with_item: tuple):
-        resp = client.get(
-            "/v2/partials/sightings",
-            params={"group_by": "manufacturer"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_group_by_brand(self, client: TestClient, req_with_item: tuple):
-        resp = client.get(
-            "/v2/partials/sightings",
-            params={"group_by": "brand"},
+            params=params,
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
@@ -188,39 +145,20 @@ class TestSightingsDetail:
         )
         assert resp.status_code == 200
 
-    def test_detail_sourcing_status_no_rfqs(self, client: TestClient, req_with_item: tuple, db_session: Session):
+    @pytest.mark.parametrize(
+        "sourcing_status",
+        [
+            pytest.param("sourcing", id="sourcing_status_no_rfqs"),
+            pytest.param("offered", id="offered_status"),
+            pytest.param("quoted", id="quoted_status"),
+            pytest.param("won", id="won_status"),
+        ],
+    )
+    def test_detail_by_sourcing_status(
+        self, client: TestClient, req_with_item: tuple, db_session: Session, sourcing_status: str
+    ):
         _, item = req_with_item
-        item.sourcing_status = "sourcing"
-        db_session.commit()
-        resp = client.get(
-            f"/v2/partials/sightings/{item.id}/detail",
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_detail_offered_status(self, client: TestClient, req_with_item: tuple, db_session: Session):
-        _, item = req_with_item
-        item.sourcing_status = "offered"
-        db_session.commit()
-        resp = client.get(
-            f"/v2/partials/sightings/{item.id}/detail",
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_detail_quoted_status(self, client: TestClient, req_with_item: tuple, db_session: Session):
-        _, item = req_with_item
-        item.sourcing_status = "quoted"
-        db_session.commit()
-        resp = client.get(
-            f"/v2/partials/sightings/{item.id}/detail",
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_detail_won_status(self, client: TestClient, req_with_item: tuple, db_session: Session):
-        _, item = req_with_item
-        item.sourcing_status = "won"
+        item.sourcing_status = sourcing_status
         db_session.commit()
         resp = client.get(
             f"/v2/partials/sightings/{item.id}/detail",
@@ -261,47 +199,35 @@ class TestAssignBuyerWithId:
 
 
 class TestLogActivity:
-    def test_log_note_success(self, client: TestClient, req_with_item: tuple):
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({"notes": "test note", "channel": "note"}, id="note"),
+            pytest.param({"notes": "called vendor", "channel": "call", "vendor_name": "Acme Vendor"}, id="call"),
+            pytest.param({"notes": "sent email", "channel": "email"}, id="email"),
+        ],
+    )
+    def test_log_activity_success(self, client: TestClient, req_with_item: tuple, data: dict):
         _, item = req_with_item
         resp = client.post(
             f"/v2/partials/sightings/{item.id}/log-activity",
-            data={"notes": "test note", "channel": "note"},
+            data=data,
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
 
-    def test_log_call_success(self, client: TestClient, req_with_item: tuple):
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({"notes": "   ", "channel": "note"}, id="empty_notes"),
+            pytest.param({"notes": "hello", "channel": "invalid"}, id="invalid_channel"),
+        ],
+    )
+    def test_log_activity_bad_request(self, client: TestClient, req_with_item: tuple, data: dict):
         _, item = req_with_item
         resp = client.post(
             f"/v2/partials/sightings/{item.id}/log-activity",
-            data={"notes": "called vendor", "channel": "call", "vendor_name": "Acme Vendor"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_log_email_success(self, client: TestClient, req_with_item: tuple):
-        _, item = req_with_item
-        resp = client.post(
-            f"/v2/partials/sightings/{item.id}/log-activity",
-            data={"notes": "sent email", "channel": "email"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 200
-
-    def test_log_empty_notes(self, client: TestClient, req_with_item: tuple):
-        _, item = req_with_item
-        resp = client.post(
-            f"/v2/partials/sightings/{item.id}/log-activity",
-            data={"notes": "   ", "channel": "note"},
-            headers={"HX-Request": "true"},
-        )
-        assert resp.status_code == 400
-
-    def test_log_invalid_channel(self, client: TestClient, req_with_item: tuple):
-        _, item = req_with_item
-        resp = client.post(
-            f"/v2/partials/sightings/{item.id}/log-activity",
-            data={"notes": "hello", "channel": "invalid"},
+            data=data,
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 400

--- a/tests/test_source_ingest_clean.py
+++ b/tests/test_source_ingest_clean.py
@@ -7,6 +7,8 @@ canon, and source→canonical category mapping.
 
 from __future__ import annotations
 
+import pytest
+
 from app.services.source_ingest.clean import (
     canonicalize_condition,
     clean_record,
@@ -25,12 +27,18 @@ def _rec(**kw) -> SourceRecord:
     return SourceRecord(**base)
 
 
-def test_strip_mpn_suffix_variants():
-    assert strip_mpn_suffix("00AR327 - Pull") == "00AR327"
-    assert strip_mpn_suffix("657239-001 - New") == "657239-001"
-    assert strip_mpn_suffix("P13198-001 - PULL") == "P13198-001"
-    assert strip_mpn_suffix("ABC-x") == "ABC"
-    assert strip_mpn_suffix("ST4000NM0035") == "ST4000NM0035"  # no suffix
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("00AR327 - Pull", "00AR327"),
+        ("657239-001 - New", "657239-001"),
+        ("P13198-001 - PULL", "P13198-001"),
+        ("ABC-x", "ABC"),
+        ("ST4000NM0035", "ST4000NM0035"),  # no suffix
+    ],
+)
+def test_strip_mpn_suffix_variants(raw, expected):
+    assert strip_mpn_suffix(raw) == expected
 
 
 def test_clean_strips_suffix_and_normalizes_key():
@@ -131,23 +139,29 @@ def test_clean_explicit_brand_column_wins_over_trailing_token():
     assert c.brand == "Dell"  # explicit source column beats the description regex
 
 
-def test_canonicalize_condition():
-    # Canon is the MaterialCard.condition documented vocabulary (constants.MaterialCondition):
-    # "Pull" maps to the column's canonical "Pulled", and "Recertified" is reachable.
-    assert canonicalize_condition("New") == "New"
-    assert canonicalize_condition("Pull") == "Pulled"
-    assert canonicalize_condition("Pulled") == "Pulled"
-    assert canonicalize_condition("Refurbished") == "Refurbished"
-    assert canonicalize_condition("Recertified") == "Recertified"
-    assert canonicalize_condition("Factory Recertified") == "Recertified"
-    assert canonicalize_condition("Used") == "Used"
-    assert canonicalize_condition("Factory New") == "New"
-    # Absent / unrecognized input → None (the column stays NULL), NEVER a synthetic
-    # "Unknown" — an Unknown would outvote real sheet conditions in consolidation and
-    # permanently occupy the fill-only-when-empty card column.
-    assert canonicalize_condition("Other") is None
-    assert canonicalize_condition(None) is None
-    assert canonicalize_condition("") is None
+# Canon is the MaterialCard.condition documented vocabulary (constants.MaterialCondition):
+# "Pull" maps to the column's canonical "Pulled", and "Recertified" is reachable.
+# Absent / unrecognized input → None (the column stays NULL), NEVER a synthetic
+# "Unknown" — an Unknown would outvote real sheet conditions in consolidation and
+# permanently occupy the fill-only-when-empty card column.
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("New", "New"),
+        ("Pull", "Pulled"),
+        ("Pulled", "Pulled"),
+        ("Refurbished", "Refurbished"),
+        ("Recertified", "Recertified"),
+        ("Factory Recertified", "Recertified"),
+        ("Used", "Used"),
+        ("Factory New", "New"),
+        ("Other", None),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_canonicalize_condition(raw, expected):
+    assert canonicalize_condition(raw) == expected
 
 
 def test_clean_maps_category_canonical_or_none():
@@ -204,11 +218,12 @@ def test_clean_description_fallback_is_conservative():
     assert clean_record(_rec(raw_mpn="REAL123", category="HDD", description="PSU, 1460W AC Hot Swap")).category == "hdd"
 
 
-def test_clean_blanks_cpu_category_for_polluted_mpn_shapes():
-    # CATALOG.md ingest warning: ~14% of the SFDC 'CPU' bucket is passives/connectors/logic.
-    # Known non-CPU MPN shapes must get their category BLANKED (None — never a tier-95 'cpu'),
-    # because only manual (100) outranks trio_source (95) on the ladder.
-    polluted = [
+# CATALOG.md ingest warning: ~14% of the SFDC 'CPU' bucket is passives/connectors/logic.
+# Known non-CPU MPN shapes must get their category BLANKED (None — never a tier-95 'cpu'),
+# because only manual (100) outranks trio_source (95) on the ladder.
+@pytest.mark.parametrize(
+    "mpn",
+    [
         "GRM155R71C104MA88D",  # Murata MLCC
         "EEEFK1E471GP",  # Panasonic cap
         "SN74ALVC244PWR",  # TI logic
@@ -217,15 +232,16 @@ def test_clean_blanks_cpu_category_for_polluted_mpn_shapes():
         "06035A101JAT2A",  # AVX chip cap
         "640456-9",  # TE connector (single trailing digit)
         "1-640456-0",  # TE connector (prefixed form)
-    ]
-    for mpn in polluted:
-        rec = clean_record(_rec(raw_mpn=mpn, category="CPU"))
-        assert rec is not None and rec.category is None, mpn
+    ],
+)
+def test_clean_blanks_cpu_category_for_polluted_mpn_shapes(mpn):
+    rec = clean_record(_rec(raw_mpn=mpn, category="CPU"))
+    assert rec is not None and rec.category is None, mpn
 
 
-def test_clean_keeps_cpu_category_for_plausible_cpu_mpns():
-    # Real CPU-shaped MPNs keep the category: Intel s-spec, Intel ordering code, HP spare
-    # (three-char dash suffix — distinct from TE's single trailing digit), IBM FRU.
-    for mpn in ["SR3QS", "CM8068403358316", "732505-001", "01EF243"]:
-        rec = clean_record(_rec(raw_mpn=mpn, category="CPU"))
-        assert rec is not None and rec.category == "cpu", mpn
+# Real CPU-shaped MPNs keep the category: Intel s-spec, Intel ordering code, HP spare
+# (three-char dash suffix — distinct from TE's single trailing digit), IBM FRU.
+@pytest.mark.parametrize("mpn", ["SR3QS", "CM8068403358316", "732505-001", "01EF243"])
+def test_clean_keeps_cpu_category_for_plausible_cpu_mpns(mpn):
+    rec = clean_record(_rec(raw_mpn=mpn, category="CPU"))
+    assert rec is not None and rec.category == "cpu", mpn

--- a/tests/test_source_ingest_ingest.py
+++ b/tests/test_source_ingest_ingest.py
@@ -28,6 +28,26 @@ def _facets(db: Session, card_id: int) -> dict:
     return {r.spec_key: (r.value_text if r.value_text is not None else r.value_numeric) for r in rows}
 
 
+def _get_card(db: Session, normalized_mpn: str = "st4000nm0035") -> MaterialCard | None:
+    return db.query(MaterialCard).filter_by(normalized_mpn=normalized_mpn).first()
+
+
+def _manual_maker_card(db: Session) -> MaterialCard:
+    # A card whose manufacturer is pinned at manual(tier 100) — resists trio_source(95).
+    card = MaterialCard(
+        normalized_mpn="st4000nm0035",
+        display_mpn="ST4000NM0035",
+        category="hdd",
+        manufacturer="Seagate Technology",
+        manufacturer_source="manual",
+        manufacturer_confidence=1.0,
+        manufacturer_tier=100,
+    )
+    db.add(card)
+    db.flush()
+    return card
+
+
 def test_augment_creates_new_card_with_category_desc_specs(db_session: Session):
     seed_commodity_schemas(db_session)
     part = _part(
@@ -38,7 +58,7 @@ def test_augment_creates_new_card_with_category_desc_specs(db_session: Session):
     )
     stats = ingest(db_session, [part], apply=True)
 
-    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    card = _get_card(db_session)
     assert card is not None
     assert card.display_mpn == "ST4000NM0035"
     assert card.manufacturer == "Seagate"
@@ -81,7 +101,7 @@ def test_dry_run_writes_nothing_and_stats_match(db_session: Session):
     stats = ingest(db_session, [part], apply=False)
 
     # No card created.
-    assert db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first() is None
+    assert _get_card(db_session) is None
     assert stats["would_create"] == 1
     assert stats["created"] == 0
     assert stats["categories_set"] == 1
@@ -113,7 +133,7 @@ def test_later_lower_tier_cannot_overwrite_trio_source(db_session: Session):
     # trio_source(95) lands first; a later mpn_decode(85) write must lose.
     seed_commodity_schemas(db_session)
     ingest(db_session, [_part(specs={"capacity_gb": "4000"})], apply=True)
-    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    card = _get_card(db_session)
     cache = load_schema_cache(db_session, "hdd")
 
     wrote = record_spec(
@@ -129,7 +149,7 @@ def test_ai_inferred_category_uses_trio_source_ai_tier(db_session: Session):
     seed_commodity_schemas(db_session)
     part = _part(category=None, ai_category="hdd", ai_category_confidence=0.9)
     ingest(db_session, [part], apply=True)
-    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    card = _get_card(db_session)
     assert card.category == "hdd"
     assert card.category_source == "trio_source_ai"
     assert card.category_tier == 88
@@ -144,7 +164,7 @@ def test_ai_description_fill_credits_trio_source_ai(db_session: Session):
     dry = ingest(db_session, [part], apply=False)
     stats = ingest(db_session, [part], apply=True)
 
-    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    card = _get_card(db_session)
     assert card.description == "AI standardized text"
     for s in (dry, stats):
         assert s["descriptions_filled"] == 1
@@ -155,7 +175,7 @@ def test_ai_specs_written_at_trio_source_ai(db_session: Session):
     seed_commodity_schemas(db_session)
     part = _part(ai_specs={"rpm": {"value": "7200", "confidence": 0.9}})
     ingest(db_session, [part], apply=True)
-    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    card = _get_card(db_session)
     assert card.specs_structured["rpm"]["source"] == "trio_source_ai"
     assert card.specs_structured["rpm"]["tier"] == 88
 
@@ -168,7 +188,7 @@ def test_unknown_condition_never_written(db_session: Session):
     # a written Unknown would permanently block a later real value.
     seed_commodity_schemas(db_session)
     stats = ingest(db_session, [_part(condition="Unknown")], apply=True)
-    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    card = _get_card(db_session)
     assert card.condition is None
     assert stats["conditions_filled"] == 0
 
@@ -229,7 +249,7 @@ def test_failed_part_is_isolated_counted_and_siblings_ingest(db_session: Session
     assert stats["created"] == 1  # the failed part is NOT in created
     # The bad part's card was rolled back wholesale; the good sibling persisted fully.
     assert db_session.query(MaterialCard).filter_by(normalized_mpn="badpart").first() is None
-    good_card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    good_card = _get_card(db_session)
     assert good_card is not None
     assert good_card.condition == "New"
     assert _facets(db_session, good_card.id)["capacity_gb"] == 4000
@@ -362,7 +382,7 @@ def test_dry_run_does_not_count_specs_without_resolvable_category(db_session: Se
 def test_new_card_manufacturer_written_via_ladder_with_provenance(db_session: Session):
     seed_commodity_schemas(db_session)
     stats = ingest(db_session, [_part(manufacturer="Seagate")], apply=True)
-    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    card = _get_card(db_session)
     assert card.manufacturer == "Seagate"  # verbatim — manufacturers table unseeded here
     assert card.manufacturer_source == "trio_source"
     assert card.manufacturer_tier == 95
@@ -373,7 +393,7 @@ def test_new_card_manufacturer_written_via_ladder_with_provenance(db_session: Se
 def test_brand_written_via_ladder(db_session: Session):
     seed_commodity_schemas(db_session)
     stats = ingest(db_session, [_part(brand="IBM", manufacturer="Seagate")], apply=True)
-    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    card = _get_card(db_session)
     assert card.brand == "IBM"
     assert card.brand_source == "trio_source"
     assert card.brand_tier == 95
@@ -385,7 +405,7 @@ def test_brand_written_via_ladder(db_session: Session):
 def test_none_brand_and_manufacturer_are_noops(db_session: Session):
     seed_commodity_schemas(db_session)
     stats = ingest(db_session, [_part()], apply=True)
-    card = db_session.query(MaterialCard).filter_by(normalized_mpn="st4000nm0035").first()
+    card = _get_card(db_session)
     assert card.brand is None
     assert card.manufacturer is None
     assert stats["brands_set"] == 0
@@ -394,17 +414,7 @@ def test_none_brand_and_manufacturer_are_noops(db_session: Session):
 
 def test_higher_tier_manufacturer_not_overwritten_by_ingest(db_session: Session):
     seed_commodity_schemas(db_session)
-    card = MaterialCard(
-        normalized_mpn="st4000nm0035",
-        display_mpn="ST4000NM0035",
-        category="hdd",
-        manufacturer="Seagate Technology",
-        manufacturer_source="manual",
-        manufacturer_confidence=1.0,
-        manufacturer_tier=100,
-    )
-    db_session.add(card)
-    db_session.flush()
+    card = _manual_maker_card(db_session)
 
     stats = ingest(db_session, [_part(manufacturer="WrongCo")], apply=True)
     db_session.refresh(card)
@@ -454,17 +464,7 @@ def test_trio_brand_maker_ladder_losses_are_warned(db_session: Session):
     from loguru import logger as loguru_logger
 
     seed_commodity_schemas(db_session)
-    card = MaterialCard(
-        normalized_mpn="st4000nm0035",
-        display_mpn="ST4000NM0035",
-        category="hdd",
-        manufacturer="Seagate Technology",
-        manufacturer_source="manual",
-        manufacturer_confidence=1.0,
-        manufacturer_tier=100,
-    )
-    db_session.add(card)
-    db_session.flush()
+    _manual_maker_card(db_session)
 
     warnings: list[str] = []
     sink_id = loguru_logger.add(lambda message: warnings.append(str(message)), level="WARNING")
@@ -481,17 +481,7 @@ def test_trio_same_value_loss_is_agreement_not_conflict(db_session: Session):
     # returns False (95 < 100) but no conflict is counted — the counter must stay a
     # pure data-conflict signal.
     seed_commodity_schemas(db_session)
-    card = MaterialCard(
-        normalized_mpn="st4000nm0035",
-        display_mpn="ST4000NM0035",
-        category="hdd",
-        manufacturer="Seagate Technology",
-        manufacturer_source="manual",
-        manufacturer_confidence=1.0,
-        manufacturer_tier=100,
-    )
-    db_session.add(card)
-    db_session.flush()
+    _manual_maker_card(db_session)
 
     stats = ingest(db_session, [_part(manufacturer="Seagate Technology")], apply=True)
     assert stats["manufacturers_set"] == 0

--- a/tests/test_template_env.py
+++ b/tests/test_template_env.py
@@ -14,6 +14,7 @@ import pytest
 from app.template_env import (
     _elapsed_seconds,
     _fmtdate_filter,
+    _sanitize_html_filter,
     _timeago_filter,
     _timesince_filter,
     template_response,
@@ -182,34 +183,24 @@ class TestFmtdateFilter:
 
 class TestSanitizeHtmlFilter:
     def test_empty_string(self):
-        from app.template_env import _sanitize_html_filter
-
         assert _sanitize_html_filter("") == ""
 
     def test_none_returns_empty(self):
-        from app.template_env import _sanitize_html_filter
-
         assert _sanitize_html_filter(None) == ""
 
     def test_allows_safe_tags(self):
-        from app.template_env import _sanitize_html_filter
-
         html = "<p>Hello <strong>world</strong></p>"
         result = _sanitize_html_filter(html)
         assert "<p>" in result
         assert "<strong>" in result
 
     def test_strips_script_tags(self):
-        from app.template_env import _sanitize_html_filter
-
         html = "<p>Safe</p><script>alert('xss')</script>"
         result = _sanitize_html_filter(html)
         assert "<script>" not in result
         assert "alert" not in result
 
     def test_preserves_links_with_href(self):
-        from app.template_env import _sanitize_html_filter
-
         html = '<a href="https://example.com" title="Example">Link</a>'
         result = _sanitize_html_filter(html)
         assert "https://example.com" in result

--- a/tests/test_unified_scoring.py
+++ b/tests/test_unified_scoring.py
@@ -7,27 +7,29 @@ Called by: pytest
 Depends on: app.scoring
 """
 
+import pytest
+
 from app.scoring import confidence_color, score_unified
 
 # -- confidence_color ------------------------------------------------------
 
 
-def test_confidence_color_green():
-    assert confidence_color(75) == "green"
-    assert confidence_color(100) == "green"
-    assert confidence_color(90) == "green"
-
-
-def test_confidence_color_amber():
-    assert confidence_color(50) == "amber"
-    assert confidence_color(74) == "amber"
-    assert confidence_color(60) == "amber"
-
-
-def test_confidence_color_red():
-    assert confidence_color(49) == "red"
-    assert confidence_color(0) == "red"
-    assert confidence_color(10) == "red"
+@pytest.mark.parametrize(
+    ("pct", "expected"),
+    [
+        (75, "green"),
+        (100, "green"),
+        (90, "green"),
+        (50, "amber"),
+        (74, "amber"),
+        (60, "amber"),
+        (49, "red"),
+        (0, "red"),
+        (10, "red"),
+    ],
+)
+def test_confidence_color(pct, expected):
+    assert confidence_color(pct) == expected
 
 
 # -- Live API scoring ------------------------------------------------------

--- a/tests/test_unit_normalizer.py
+++ b/tests/test_unit_normalizer.py
@@ -4,103 +4,58 @@ Covers: app/services/unit_normalizer.py
 Depends on: conftest.py
 """
 
+import pytest
+
 from app.services.unit_normalizer import normalize_value
 
 
-def test_capacitance_uf_to_pf():
-    assert normalize_value(100, "uF", "pF") == 100_000_000
-
-
-def test_capacitance_nf_to_pf():
-    assert normalize_value(100, "nF", "pF") == 100_000
-
-
-def test_capacitance_pf_to_pf():
-    assert normalize_value(47, "pF", "pF") == 47
-
-
-def test_resistance_kohm_to_ohm():
-    assert normalize_value(4.7, "kOhm", "ohms") == 4700
-
-
-def test_resistance_megaohm_to_ohm():
-    """MegaOhm converts to ohms (old 'MOhm' key was ambiguous)."""
-    assert normalize_value(1.5, "MegaOhm", "ohms") == 1_500_000
-
-
-def test_inductance_uh_to_nh():
-    assert normalize_value(10, "uH", "nH") == 10_000
-
-
-def test_inductance_mh_to_nh():
-    assert normalize_value(1, "mH", "nH") == 1_000_000
-
-
-def test_frequency_ghz_to_mhz():
-    assert normalize_value(3.2, "GHz", "MHz") == 3200
-
-
-def test_same_unit_passthrough():
-    assert normalize_value(42, "V", "V") == 42
-
-
-def test_unknown_conversion_returns_original():
-    assert normalize_value(99, "widgets", "gadgets") == 99
-
-
-def test_string_value_passthrough():
-    """Non-numeric values pass through unchanged."""
-    assert normalize_value("DDR4", None, None) == "DDR4"
-
-
-def test_resistance_unicode_kohm():
-    """KΩ (Unicode omega) converts to ohms."""
-    assert normalize_value(10, "kΩ", "ohms") == 10_000
-
-
-def test_capacitance_unicode_uf():
-    """ΜF (Unicode micro) converts to pF."""
-    assert normalize_value(100, "µF", "pF") == 100_000_000
-
-
-def test_resistance_ohm_to_ohms():
-    """Singular 'ohm' converts to 'ohms'."""
-    assert normalize_value(5, "ohm", "ohms") == 5
-
-
-def test_resistance_unicode_megaohm():
-    """MΩ (Unicode mega-ohms) converts to ohms."""
-    assert normalize_value(0.5, "MΩ", "ohms") == 500_000
-
-
-def test_milliohm_identity():
-    """Milliohm to mOhm identity conversion."""
-    assert normalize_value(45, "milliohm", "mOhm") == 45
-
-
-def test_inductance_unicode_uh():
-    """ΜH (Unicode micro) converts to nH."""
-    assert normalize_value(10, "µH", "nH") == 10_000
-
-
-def test_current_unicode_ua():
-    """ΜA (Unicode micro) converts to A."""
-    assert normalize_value(500, "µA", "A") == 0.0005
-
-
-# --- Power and current conversions ---
-
-
-def test_power_mw_to_w():
-    assert normalize_value(500, "mW", "W") == 0.5
-
-
-def test_power_kw_to_w():
-    assert normalize_value(2, "kW", "W") == 2000
-
-
-def test_current_ma_to_a():
-    assert normalize_value(200, "mA", "A") == 0.2
+@pytest.mark.parametrize(
+    ("value", "from_unit", "to_unit", "expected"),
+    [
+        pytest.param(100, "uF", "pF", 100_000_000, id="capacitance_uf_to_pf"),
+        pytest.param(100, "nF", "pF", 100_000, id="capacitance_nf_to_pf"),
+        pytest.param(47, "pF", "pF", 47, id="capacitance_pf_to_pf"),
+        pytest.param(4.7, "kOhm", "ohms", 4700, id="resistance_kohm_to_ohm"),
+        # MegaOhm converts to ohms (old 'MOhm' key was ambiguous).
+        pytest.param(1.5, "MegaOhm", "ohms", 1_500_000, id="resistance_megaohm_to_ohm"),
+        pytest.param(10, "uH", "nH", 10_000, id="inductance_uh_to_nh"),
+        pytest.param(1, "mH", "nH", 1_000_000, id="inductance_mh_to_nh"),
+        pytest.param(3.2, "GHz", "MHz", 3200, id="frequency_ghz_to_mhz"),
+        pytest.param(42, "V", "V", 42, id="same_unit_passthrough"),
+        pytest.param(99, "widgets", "gadgets", 99, id="unknown_conversion_returns_original"),
+        # Non-numeric values pass through unchanged.
+        pytest.param("DDR4", None, None, "DDR4", id="string_value_passthrough"),
+        # KΩ (Unicode omega) converts to ohms.
+        pytest.param(10, "kΩ", "ohms", 10_000, id="resistance_unicode_kohm"),
+        # µF (Unicode micro) converts to pF.
+        pytest.param(100, "µF", "pF", 100_000_000, id="capacitance_unicode_uf"),
+        # Singular 'ohm' converts to 'ohms'.
+        pytest.param(5, "ohm", "ohms", 5, id="resistance_ohm_to_ohms"),
+        # MΩ (Unicode mega-ohms) converts to ohms.
+        pytest.param(0.5, "MΩ", "ohms", 500_000, id="resistance_unicode_megaohm"),
+        # Milliohm to mOhm identity conversion.
+        pytest.param(45, "milliohm", "mOhm", 45, id="milliohm_identity"),
+        # µH (Unicode micro) converts to nH.
+        pytest.param(10, "µH", "nH", 10_000, id="inductance_unicode_uh"),
+        # µA (Unicode micro) converts to A.
+        pytest.param(500, "µA", "A", 0.0005, id="current_unicode_ua"),
+        # Power and current conversions.
+        pytest.param(500, "mW", "W", 0.5, id="power_mw_to_w"),
+        pytest.param(2, "kW", "W", 2000, id="power_kw_to_w"),
+        pytest.param(200, "mA", "A", 0.2, id="current_ma_to_a"),
+        # None units return value unchanged.
+        pytest.param(100, None, "pF", 100, id="none_from_unit"),
+        pytest.param(100, "uF", None, 100, id="none_canonical_unit"),
+        pytest.param(100, None, None, 100, id="both_units_none"),
+        # Edge cases: zero, negative, very large.
+        pytest.param(0, "uF", "pF", 0, id="zero_value_converts"),
+        pytest.param(-10, "kOhm", "ohms", -10_000, id="negative_value_converts"),
+        pytest.param(1_000_000, "uF", "pF", 1_000_000_000_000, id="very_large_value"),
+        pytest.param(0.001, "mA", "A", 0.001 * 0.001, id="very_small_fractional_value"),
+    ],
+)
+def test_normalize_value(value, from_unit, to_unit, expected):
+    assert normalize_value(value, from_unit, to_unit) == expected
 
 
 def test_current_ua_to_a():
@@ -108,47 +63,8 @@ def test_current_ua_to_a():
     assert abs(result - 0.0001) < 1e-10
 
 
-# --- String numeric input passes through (not converted) ---
-
-
 def test_string_numeric_value_passthrough():
     """String '100' is not converted even if units suggest a conversion."""
     result = normalize_value("100", "uF", "pF")
     assert result == "100"
     assert isinstance(result, str)
-
-
-# --- None units return value unchanged ---
-
-
-def test_none_from_unit():
-    assert normalize_value(100, None, "pF") == 100
-
-
-def test_none_canonical_unit():
-    assert normalize_value(100, "uF", None) == 100
-
-
-def test_both_units_none():
-    assert normalize_value(100, None, None) == 100
-
-
-# --- Edge cases: zero, negative, very large ---
-
-
-def test_zero_value_converts():
-    assert normalize_value(0, "uF", "pF") == 0
-
-
-def test_negative_value_converts():
-    assert normalize_value(-10, "kOhm", "ohms") == -10_000
-
-
-def test_very_large_value():
-    result = normalize_value(1_000_000, "uF", "pF")
-    assert result == 1_000_000_000_000
-
-
-def test_very_small_fractional_value():
-    result = normalize_value(0.001, "mA", "A")
-    assert result == 0.001 * 0.001

--- a/tests/test_vendor_email_lookup_coverage.py
+++ b/tests/test_vendor_email_lookup_coverage.py
@@ -251,6 +251,11 @@ class TestFindVendorsForParts:
         assert results[""] == []
 
 
+def _arrow_vendor() -> dict:
+    """A single reachable Arrow vendor entry (has an email)."""
+    return {"vendor_name": "Arrow", "emails": ["sales@arrow.com"], "domain": "arrow.com"}
+
+
 class TestBuildInquiryGroups:
     def test_empty_vendor_results_returns_empty_list(self):
         groups = build_inquiry_groups({}, [])
@@ -289,45 +294,39 @@ class TestBuildInquiryGroups:
         assert len(groups) == 0
 
     def test_multiple_parts_same_vendor(self):
-        vendor_results = {
-            "LM317T": [{"vendor_name": "Arrow", "emails": ["sales@arrow.com"], "domain": "arrow.com"}],
-            "STM32F4": [{"vendor_name": "Arrow", "emails": ["sales@arrow.com"], "domain": "arrow.com"}],
-        }
+        vendor_results = {"LM317T": [_arrow_vendor()], "STM32F4": [_arrow_vendor()]}
         parts = [{"mpn": "LM317T", "qty": 100}, {"mpn": "STM32F4", "qty": 50}]
         groups = build_inquiry_groups(vendor_results, parts)
         assert len(groups) == 1  # Same email → grouped together
 
     def test_subject_truncated_beyond_3_parts(self):
-        vendor_results = {
-            f"PART{i}": [{"vendor_name": "Arrow", "emails": ["sales@arrow.com"], "domain": "arrow.com"}]
-            for i in range(5)
-        }
+        vendor_results = {f"PART{i}": [_arrow_vendor()] for i in range(5)}
         parts = [{"mpn": f"PART{i}", "qty": 10} for i in range(5)]
         groups = build_inquiry_groups(vendor_results, parts)
         assert len(groups) == 1
         assert "+ 2 more" in groups[0]["subject"]
 
     def test_body_contains_part_numbers(self):
-        vendor_results = {"LM317T": [{"vendor_name": "Arrow", "emails": ["sales@arrow.com"], "domain": "arrow.com"}]}
+        vendor_results = {"LM317T": [_arrow_vendor()]}
         parts = [{"mpn": "LM317T", "qty": 500}]
         groups = build_inquiry_groups(vendor_results, parts)
         assert "LM317T" in groups[0]["body"]
 
     def test_body_contains_sender_info(self):
-        vendor_results = {"LM317T": [{"vendor_name": "Arrow", "emails": ["sales@arrow.com"], "domain": "arrow.com"}]}
+        vendor_results = {"LM317T": [_arrow_vendor()]}
         parts = [{"mpn": "LM317T", "qty": 500}]
         groups = build_inquiry_groups(vendor_results, parts, company_name="Acme Corp", sender_name="Bob Smith")
         assert "Acme Corp" in groups[0]["body"]
         assert "Bob Smith" in groups[0]["body"]
 
     def test_qty_in_body(self):
-        vendor_results = {"LM317T": [{"vendor_name": "Arrow", "emails": ["sales@arrow.com"], "domain": "arrow.com"}]}
+        vendor_results = {"LM317T": [_arrow_vendor()]}
         parts = [{"mpn": "LM317T", "qty": 750}]
         groups = build_inquiry_groups(vendor_results, parts)
         assert "750" in groups[0]["body"]
 
     def test_zero_qty_omitted_from_body(self):
-        vendor_results = {"LM317T": [{"vendor_name": "Arrow", "emails": ["sales@arrow.com"], "domain": "arrow.com"}]}
+        vendor_results = {"LM317T": [_arrow_vendor()]}
         parts = [{"mpn": "LM317T"}]  # no qty
         groups = build_inquiry_groups(vendor_results, parts)
         # Should still generate a group, just without qty display

--- a/tests/test_vendor_scorecard.py
+++ b/tests/test_vendor_scorecard.py
@@ -69,37 +69,68 @@ def _make_requisition(db: Session, user: User) -> Requisition:
     return r
 
 
+def _add_contacts(db: Session, vc: VendorCard, user: User, req: Requisition, count: int) -> None:
+    """Add `count` email contacts (RFQs sent) tied to the given vendor/requisition."""
+    for _ in range(count):
+        db.add(
+            Contact(
+                requisition_id=req.id,
+                user_id=user.id,
+                contact_type="email",
+                vendor_name=vc.display_name,
+                vendor_name_normalized=vc.normalized_name,
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+    db.flush()
+
+
+def _add_offers(db: Session, vc: VendorCard, user: User, req: Requisition, count: int) -> list[Offer]:
+    """Add `count` active offers for the vendor; return them in creation order."""
+    offers = []
+    for _ in range(count):
+        o = Offer(
+            requisition_id=req.id,
+            vendor_name=vc.display_name,
+            vendor_card_id=vc.id,
+            mpn="LM317T",
+            qty_available=100,
+            unit_price=0.50,
+            entered_by_id=user.id,
+            status="active",
+            created_at=datetime.now(timezone.utc),
+        )
+        db.add(o)
+        db.flush()
+        offers.append(o)
+    return offers
+
+
 # ── _compute_composite tests ─────────────────────────────────────────
 
 
 class TestComputeComposite:
-    def test_all_metrics_present(self):
-        result = _compute_composite(0.8, 0.6, 0.4, 0.9)
-        # (0.8*0.25 + 0.6*0.25 + 0.4*0.25 + 0.9*0.25) / 1.0 = 0.675
-        assert result == pytest.approx(0.675, abs=0.001)
-
-    def test_only_response_rate(self):
-        result = _compute_composite(0.5)
-        # 0.5*0.25 / 0.25 = 0.5
-        assert result == pytest.approx(0.5, abs=0.001)
-
-    def test_no_metrics(self):
-        result = _compute_composite(None)
-        assert result is None
-
-    def test_values_capped_at_1(self):
-        result = _compute_composite(1.5, 2.0)
-        # Both capped to 1.0: (1.0*0.25 + 1.0*0.25) / 0.5 = 1.0
-        assert result == pytest.approx(1.0, abs=0.001)
-
-    def test_two_metrics(self):
-        result = _compute_composite(0.6, 0.4)
-        # (0.6*0.25 + 0.4*0.25) / 0.5 = 0.5
-        assert result == pytest.approx(0.5, abs=0.001)
-
-    def test_zero_values(self):
-        result = _compute_composite(0.0, 0.0, 0.0, 0.0)
-        assert result == pytest.approx(0.0, abs=0.001)
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        [
+            # (0.8*0.25 + 0.6*0.25 + 0.4*0.25 + 0.9*0.25) / 1.0 = 0.675
+            pytest.param((0.8, 0.6, 0.4, 0.9), 0.675, id="all_metrics_present"),
+            # 0.5*0.25 / 0.25 = 0.5
+            pytest.param((0.5,), 0.5, id="only_response_rate"),
+            pytest.param((None,), None, id="no_metrics"),
+            # Both capped to 1.0: (1.0*0.25 + 1.0*0.25) / 0.5 = 1.0
+            pytest.param((1.5, 2.0), 1.0, id="values_capped_at_1"),
+            # (0.6*0.25 + 0.4*0.25) / 0.5 = 0.5
+            pytest.param((0.6, 0.4), 0.5, id="two_metrics"),
+            pytest.param((0.0, 0.0, 0.0, 0.0), 0.0, id="zero_values"),
+        ],
+    )
+    def test_composite(self, args, expected):
+        result = _compute_composite(*args)
+        if expected is None:
+            assert result is None
+        else:
+            assert result == pytest.approx(expected, abs=0.001)
 
 
 # ── compute_vendor_scorecard tests ───────────────────────────────────
@@ -128,17 +159,7 @@ class TestComputeVendorScorecard:
         req = _make_requisition(db_session, user)
 
         # Add fewer than COLD_START_THRESHOLD contacts
-        for i in range(COLD_START_THRESHOLD - 1):
-            c = Contact(
-                requisition_id=req.id,
-                user_id=user.id,
-                contact_type="email",
-                vendor_name=vc.display_name,
-                vendor_name_normalized=vc.normalized_name,
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(c)
-        db_session.flush()
+        _add_contacts(db_session, vc, user, req, COLD_START_THRESHOLD - 1)
 
         result = compute_vendor_scorecard(db_session, vc.id)
         assert result["is_sufficient_data"] is False
@@ -150,17 +171,7 @@ class TestComputeVendorScorecard:
         req = _make_requisition(db_session, user)
 
         # Add enough contacts to cross threshold
-        for i in range(COLD_START_THRESHOLD + 1):
-            c = Contact(
-                requisition_id=req.id,
-                user_id=user.id,
-                contact_type="email",
-                vendor_name=vc.display_name,
-                vendor_name_normalized=vc.normalized_name,
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(c)
-        db_session.flush()
+        _add_contacts(db_session, vc, user, req, COLD_START_THRESHOLD + 1)
 
         result = compute_vendor_scorecard(db_session, vc.id)
         assert result["is_sufficient_data"] is True
@@ -172,16 +183,7 @@ class TestComputeVendorScorecard:
         req = _make_requisition(db_session, user)
 
         # 4 RFQs sent
-        for i in range(4):
-            c = Contact(
-                requisition_id=req.id,
-                user_id=user.id,
-                contact_type="email",
-                vendor_name=vc.display_name,
-                vendor_name_normalized=vc.normalized_name,
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(c)
+        _add_contacts(db_session, vc, user, req, 4)
 
         # 2 responses from vendor domain
         for i in range(2):
@@ -204,22 +206,7 @@ class TestComputeVendorScorecard:
         req = _make_requisition(db_session, user)
 
         # Create offers
-        offers = []
-        for i in range(4):
-            o = Offer(
-                requisition_id=req.id,
-                vendor_name=vc.display_name,
-                vendor_card_id=vc.id,
-                mpn="LM317T",
-                qty_available=100,
-                unit_price=0.50,
-                entered_by_id=user.id,
-                status="active",
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(o)
-            db_session.flush()
-            offers.append(o)
+        offers = _add_offers(db_session, vc, user, req, 4)
 
         # Preload: 2 of 4 offers are in quotes
         quoted_offer_ids = {offers[0].id, offers[1].id}
@@ -232,22 +219,7 @@ class TestComputeVendorScorecard:
         user = _make_user(db_session)
         req = _make_requisition(db_session, user)
 
-        offers = []
-        for i in range(5):
-            o = Offer(
-                requisition_id=req.id,
-                vendor_name=vc.display_name,
-                vendor_card_id=vc.id,
-                mpn="LM317T",
-                qty_available=100,
-                unit_price=0.50,
-                entered_by_id=user.id,
-                status="active",
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(o)
-            db_session.flush()
-            offers.append(o)
+        offers = _add_offers(db_session, vc, user, req, 5)
 
         po_offer_ids = {offers[0].id}
         result = compute_vendor_scorecard(db_session, vc.id, quoted_offer_ids=set(), po_offer_ids=po_offer_ids)
@@ -277,16 +249,7 @@ class TestComputeVendorScorecard:
         req = _make_requisition(db_session, user)
 
         # 2 RFQs sent
-        for _ in range(2):
-            c = Contact(
-                requisition_id=req.id,
-                user_id=user.id,
-                contact_type="email",
-                vendor_name=vc.display_name,
-                vendor_name_normalized=vc.normalized_name,
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(c)
+        _add_contacts(db_session, vc, user, req, 2)
 
         # 1 noise response (should be excluded)
         vr = VendorResponse(
@@ -305,15 +268,7 @@ class TestComputeVendorScorecard:
         user = _make_user(db_session)
         req = _make_requisition(db_session, user)
 
-        c = Contact(
-            requisition_id=req.id,
-            user_id=user.id,
-            contact_type="email",
-            vendor_name=vc.display_name,
-            vendor_name_normalized=vc.normalized_name,
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(c)
+        _add_contacts(db_session, vc, user, req, 1)
 
         # Response from alias domain
         vr = VendorResponse(
@@ -343,17 +298,7 @@ class TestComputeAllVendorScorecards:
         req = _make_requisition(db_session, user)
 
         # Create enough interactions to cross cold-start threshold
-        for i in range(COLD_START_THRESHOLD + 1):
-            c = Contact(
-                requisition_id=req.id,
-                user_id=user.id,
-                contact_type="email",
-                vendor_name=vc.display_name,
-                vendor_name_normalized=vc.normalized_name,
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(c)
-        db_session.flush()
+        _add_contacts(db_session, vc, user, req, COLD_START_THRESHOLD + 1)
 
         result = compute_all_vendor_scorecards(db_session)
         assert result["updated"] == 1
@@ -373,17 +318,7 @@ class TestComputeAllVendorScorecards:
         user = _make_user(db_session)
         req = _make_requisition(db_session, user)
 
-        for i in range(COLD_START_THRESHOLD + 1):
-            c = Contact(
-                requisition_id=req.id,
-                user_id=user.id,
-                contact_type="email",
-                vendor_name=vc.display_name,
-                vendor_name_normalized=vc.normalized_name,
-                created_at=datetime.now(timezone.utc),
-            )
-            db_session.add(c)
-        db_session.flush()
+        _add_contacts(db_session, vc, user, req, COLD_START_THRESHOLD + 1)
 
         # Run twice — should upsert, not duplicate
         compute_all_vendor_scorecards(db_session)


### PR DESCRIPTION
Part of the codebase-wide simplification program — **tests wave (6/8)**, full simplify (within-file only).

## What changed
- Copy-paste test functions differing only in data → `@pytest.mark.parametrize` (one case per original; IDs preserved).
- Repeated arrange/setup blocks → local helper functions / module-level fixtures **defined in the same file**.
- Removed exact-duplicate test functions and dead/commented tests.

`conftest.py` and all shared fixtures untouched; no assertion weakened; mock/patch targets unchanged.

## Verification (coverage preserved)
- ruff clean
- **Full suite: 16687 passed, 0 failed** (baseline 16,563). The collected/passed count *rises* where multi-assert tests were split into discrete parametrized cases — no test case was dropped (exact-duplicate removals are 1-for-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)