### PR TITLE
test(simplify 8/8): parametrize + dedup test setup

### DIFF
--- a/tests/test_account_summary_service.py
+++ b/tests/test_account_summary_service.py
@@ -250,33 +250,19 @@ class TestAccountSummaryService:
         result = _run(generate_account_summary(co.id, db_session))
         assert result == {}
 
+    @pytest.mark.parametrize(
+        "claude_return",
+        [
+            pytest.param(None, id="none"),
+            pytest.param("not a dict", id="non_dict"),
+            pytest.param({}, id="empty_dict"),
+        ],
+    )
     @patch(_DT_PATCH, _FakeDatetime)
     @patch("app.utils.claude_client.claude_json", new_callable=AsyncMock)
-    def test_claude_json_returns_none(self, mock_claude, db_session):
-        """claude_json returns None -> returns {}."""
-        mock_claude.return_value = None
-        co = _make_company(db_session)
-        db_session.commit()
-
-        result = _run(generate_account_summary(co.id, db_session))
-        assert result == {}
-
-    @patch(_DT_PATCH, _FakeDatetime)
-    @patch("app.utils.claude_client.claude_json", new_callable=AsyncMock)
-    def test_claude_json_returns_non_dict(self, mock_claude, db_session):
-        """claude_json returns string -> returns {}."""
-        mock_claude.return_value = "not a dict"
-        co = _make_company(db_session)
-        db_session.commit()
-
-        result = _run(generate_account_summary(co.id, db_session))
-        assert result == {}
-
-    @patch(_DT_PATCH, _FakeDatetime)
-    @patch("app.utils.claude_client.claude_json", new_callable=AsyncMock)
-    def test_claude_json_returns_empty_dict(self, mock_claude, db_session):
-        """claude_json returns {} (falsy) -> 'not result' is True -> returns {}."""
-        mock_claude.return_value = {}
+    def test_claude_json_returns_falsy_or_non_dict(self, mock_claude, db_session, claude_return):
+        """claude_json returns None/non-dict/empty-dict -> returns {}."""
+        mock_claude.return_value = claude_return
         co = _make_company(db_session)
         db_session.commit()
 

--- a/tests/test_activity_digest_service.py
+++ b/tests/test_activity_digest_service.py
@@ -74,6 +74,16 @@ def test_select_system_prompt_by_entity():
     assert "relationship" in svc._system_prompt(DigestEntityType.COMPANY).lower()
 
 
+class _LockHeldRedis:
+    """Stub Redis whose lock is always held by someone else (SET NX fails)."""
+
+    def set(self, *a, **k):
+        return False
+
+    def delete(self, *a, **k):
+        return None
+
+
 def _mk_activity(db, **kw):
     from datetime import datetime, timezone
 
@@ -198,14 +208,7 @@ async def test_lock_miss_without_existing_returns_generating(db_session, monkeyp
 
     monkeypatch.setattr("app.utils.claude_client.claude_structured", fake_cs)
 
-    class FakeRedis:
-        def set(self, *a, **k):
-            return False  # lock already held by someone else
-
-        def delete(self, *a, **k):
-            return None
-
-    monkeypatch.setattr(svc, "_get_redis", lambda: FakeRedis())
+    monkeypatch.setattr(svc, "_get_redis", lambda: _LockHeldRedis())
 
     _mk_activity(db_session, requisition_id=5)
     _mk_activity(db_session, requisition_id=5)
@@ -292,14 +295,7 @@ async def test_lock_miss_with_existing_serves_stale(db_session, monkeypatch):
     db_session.commit()
     _mk_activity(db_session, requisition_id=22)
 
-    class BusyRedis:
-        def set(self, *a, **k):
-            return False
-
-        def delete(self, *a, **k):
-            return None
-
-    monkeypatch.setattr(svc, "_get_redis", lambda: BusyRedis())
+    monkeypatch.setattr(svc, "_get_redis", lambda: _LockHeldRedis())
 
     out = await svc.get_or_build_digest(DigestEntityType.REQUISITION, 22, db_session)
     assert out["state"] == "ready"

--- a/tests/test_activity_endpoint.py
+++ b/tests/test_activity_endpoint.py
@@ -64,20 +64,12 @@ class TestCallInitiated:
         record = db_session.get(ActivityLog, resp.json()["id"])
         assert record.requisition_id == test_requisition.id
 
-    def test_invalid_phone_returns_400(self, client):
+    @pytest.mark.parametrize("phone_number", ["call john", ""], ids=["non_numeric", "empty"])
+    def test_bad_phone_returns_400(self, client, phone_number):
         resp = client.post(
             "/api/activity/call-initiated",
             json={
-                "phone_number": "call john",
-            },
-        )
-        assert resp.status_code == 400
-
-    def test_empty_phone_returns_400(self, client):
-        resp = client.post(
-            "/api/activity/call-initiated",
-            json={
-                "phone_number": "",
+                "phone_number": phone_number,
             },
         )
         assert resp.status_code == 400

--- a/tests/test_activity_outreach.py
+++ b/tests/test_activity_outreach.py
@@ -120,13 +120,17 @@ class TestOutreachInitiated:
         assert site.last_activity_at is not None
         assert site.last_activity_at.replace(tzinfo=timezone.utc) > before
 
-    def test_invalid_phone_returns_400(self, client, cdm_company):
-        resp = self._post(client, cdm_company, "phone", "call pat")
-        assert resp.status_code == 400
-        assert "error" in resp.json()
-
-    def test_invalid_email_returns_400(self, client, cdm_company):
-        resp = self._post(client, cdm_company, "email", "not-an-email")
+    @pytest.mark.parametrize(
+        ("channel", "value"),
+        [
+            pytest.param("phone", "call pat", id="invalid_phone"),
+            pytest.param("email", "not-an-email", id="invalid_email"),
+            # An all-whitespace WeChat handle must 400, not log 'WeChat message to '.
+            pytest.param("wechat", "   ", id="wechat_whitespace"),
+        ],
+    )
+    def test_invalid_contact_value_returns_400(self, client, cdm_company, channel, value):
+        resp = self._post(client, cdm_company, channel, value)
         assert resp.status_code == 400
         assert "error" in resp.json()
 
@@ -295,12 +299,6 @@ class TestOutreachInitiated:
         assert record.site_contact_id is None
         assert record.customer_site_id == cdm_company["site"].id
         assert "contact" in resp.json()["dropped_links"]
-
-    def test_wechat_whitespace_value_returns_400(self, client, cdm_company):
-        """An all-whitespace WeChat handle must 400, not log 'WeChat message to '."""
-        resp = self._post(client, cdm_company, "wechat", "   ")
-        assert resp.status_code == 400
-        assert "error" in resp.json()
 
     def test_oversized_contact_value_returns_422(self, client, cdm_company):
         """contact_value beyond the String(255) snapshot columns is a 422 at the

--- a/tests/test_ai_gate.py
+++ b/tests/test_ai_gate.py
@@ -122,14 +122,19 @@ class TestProcessAIGate:
         item.updated_at = None
         return item
 
+    def _db_with_items(self, items: list) -> MagicMock:
+        """Build a mock db session whose pending-items query returns `items`."""
+        query_mock = MagicMock()
+        query_mock.filter.return_value.order_by.return_value.limit.return_value.all.return_value = items
+        db_mock = MagicMock()
+        db_mock.query.return_value = query_mock
+        return db_mock
+
     @pytest.mark.asyncio
     async def test_no_pending_items_skips(self, db_session):
         model = MagicMock()
         model.status = "pending"
-        query_mock = MagicMock()
-        query_mock.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
-        db_session_mock = MagicMock()
-        db_session_mock.query.return_value = query_mock
+        db_session_mock = self._db_with_items([])
 
         gate = AIGate(model, "ICsource", "search_ics")
         await gate.process_ai_gate(db_session_mock)
@@ -150,10 +155,7 @@ class TestProcessAIGate:
         item = self._make_item("LM358")
 
         model = MagicMock()
-        query_mock = MagicMock()
-        query_mock.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [item]
-        db_mock = MagicMock()
-        db_mock.query.return_value = query_mock
+        db_mock = self._db_with_items([item])
 
         gate = AIGate(model, "ICsource", "search_ics")
         # Pre-populate cache
@@ -171,10 +173,7 @@ class TestProcessAIGate:
         item = self._make_item("LM358")
 
         model = MagicMock()
-        query_mock = MagicMock()
-        query_mock.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [item]
-        db_mock = MagicMock()
-        db_mock.query.return_value = query_mock
+        db_mock = self._db_with_items([item])
 
         gate = AIGate(model, "ICsource", "search_ics")
 
@@ -190,10 +189,7 @@ class TestProcessAIGate:
         item = self._make_item("STM32F407")
 
         model = MagicMock()
-        query_mock = MagicMock()
-        query_mock.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [item]
-        db_mock = MagicMock()
-        db_mock.query.return_value = query_mock
+        db_mock = self._db_with_items([item])
 
         gate = AIGate(model, "ICsource", "search_ics")
         classifications = [
@@ -211,10 +207,7 @@ class TestProcessAIGate:
         item = self._make_item("RC0402")
 
         model = MagicMock()
-        query_mock = MagicMock()
-        query_mock.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [item]
-        db_mock = MagicMock()
-        db_mock.query.return_value = query_mock
+        db_mock = self._db_with_items([item])
 
         gate = AIGate(model, "ICsource", "search_ics")
         classifications = [{"mpn": "RC0402", "search_ics": False, "commodity": "passive", "reason": "resistor"}]
@@ -230,10 +223,7 @@ class TestProcessAIGate:
         item = self._make_item("UNKNOWNPART")
 
         model = MagicMock()
-        query_mock = MagicMock()
-        query_mock.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [item]
-        db_mock = MagicMock()
-        db_mock.query.return_value = query_mock
+        db_mock = self._db_with_items([item])
 
         gate = AIGate(model, "ICsource", "search_ics")
         # Classification doesn't include this MPN

--- a/tests/test_ai_live_web_coverage.py
+++ b/tests/test_ai_live_web_coverage.py
@@ -16,6 +16,8 @@ os.environ["TESTING"] = "1"
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from app.connectors.ai_live_web import AIWebSearchConnector
 from app.utils.claude_errors import ClaudeError, ClaudeUnavailableError
 
@@ -23,92 +25,75 @@ from app.utils.claude_errors import ClaudeError, ClaudeUnavailableError
 class TestNormalizeVendorUrl:
     """Lines 67-75 — URL normalization edge cases."""
 
-    def test_empty_url_returns_none(self):
-        assert AIWebSearchConnector._normalize_vendor_url("") is None
-
-    def test_www_prefix_gets_https(self):
-        """www.
-
-        URL gets https:// prepended (line 72).
-        """
-        result = AIWebSearchConnector._normalize_vendor_url("www.example.com/part")
-        assert result == "https://www.example.com/part"
-
-    def test_no_scheme_no_www_returns_none(self):
-        """URL without http/https and without www → None (line 74)."""
-        result = AIWebSearchConnector._normalize_vendor_url("example.com/part")
-        assert result is None
-
-    def test_valid_https_url_passes_through(self):
-        result = AIWebSearchConnector._normalize_vendor_url("https://example.com/part")
-        assert result == "https://example.com/part"
-
-    def test_valid_http_url_passes_through(self):
-        result = AIWebSearchConnector._normalize_vendor_url("http://example.com/part")
-        assert result == "http://example.com/part"
+    @pytest.mark.parametrize(
+        ("raw_url", "expected"),
+        [
+            pytest.param("", None, id="empty_url_returns_none"),
+            # www. URL gets https:// prepended (line 72).
+            pytest.param("www.example.com/part", "https://www.example.com/part", id="www_prefix_gets_https"),
+            # URL without http/https and without www → None (line 74).
+            pytest.param("example.com/part", None, id="no_scheme_no_www_returns_none"),
+            pytest.param("https://example.com/part", "https://example.com/part", id="valid_https_passes_through"),
+            pytest.param("http://example.com/part", "http://example.com/part", id="valid_http_passes_through"),
+        ],
+    )
+    def test_normalize(self, raw_url, expected):
+        assert AIWebSearchConnector._normalize_vendor_url(raw_url) == expected
 
 
 class TestHasCurrentStockSignal:
     """Line 78-84 — stock signal detection."""
 
-    def test_explicit_bool_true_returns_true(self):
-        item = {"in_stock_explicit": True}
-        assert AIWebSearchConnector._has_current_stock_signal(item, "") is True
-
-    def test_explicit_bool_false_checks_evidence(self):
-        item = {"in_stock_explicit": False}
-        # evidence contains stock signal
-        assert AIWebSearchConnector._has_current_stock_signal(item, "qty available") is True
-
-    def test_non_bool_explicit_checks_evidence(self):
-        item = {"in_stock_explicit": "yes"}
-        assert AIWebSearchConnector._has_current_stock_signal(item, "in stock now") is True
-
-    def test_no_signal_returns_false(self):
-        item = {}
-        assert AIWebSearchConnector._has_current_stock_signal(item, "no stock info") is False
+    @pytest.mark.parametrize(
+        ("item", "evidence_note", "expected"),
+        [
+            pytest.param({"in_stock_explicit": True}, "", True, id="explicit_bool_true_returns_true"),
+            # explicit False falls through to the evidence check, which contains a signal.
+            pytest.param({"in_stock_explicit": False}, "qty available", True, id="explicit_bool_false_checks_evidence"),
+            pytest.param({"in_stock_explicit": "yes"}, "in stock now", True, id="non_bool_explicit_checks_evidence"),
+            pytest.param({}, "no stock info", False, id="no_signal_returns_false"),
+        ],
+    )
+    def test_has_current_stock_signal(self, item, evidence_note, expected):
+        assert AIWebSearchConnector._has_current_stock_signal(item, evidence_note) is expected
 
 
 class TestIsRecentListing:
     """Lines 87-91 — listing age gate."""
 
-    def test_none_age_is_recent(self):
-        assert AIWebSearchConnector._is_recent_listing({"listing_age_days": None}) is True
-
-    def test_zero_age_is_recent(self):
-        assert AIWebSearchConnector._is_recent_listing({"listing_age_days": 0}) is True
-
-    def test_30_days_is_recent(self):
-        assert AIWebSearchConnector._is_recent_listing({"listing_age_days": 30}) is True
-
-    def test_31_days_is_not_recent(self):
-        assert AIWebSearchConnector._is_recent_listing({"listing_age_days": 31}) is False
-
-    def test_negative_age_is_not_recent(self):
-        assert AIWebSearchConnector._is_recent_listing({"listing_age_days": -1}) is False
+    @pytest.mark.parametrize(
+        ("listing_age_days", "expected"),
+        [
+            pytest.param(None, True, id="none_age_is_recent"),
+            pytest.param(0, True, id="zero_age_is_recent"),
+            pytest.param(30, True, id="30_days_is_recent"),
+            pytest.param(31, False, id="31_days_is_not_recent"),
+            pytest.param(-1, False, id="negative_age_is_not_recent"),
+        ],
+    )
+    def test_is_recent_listing(self, listing_age_days, expected):
+        assert AIWebSearchConnector._is_recent_listing({"listing_age_days": listing_age_days}) is expected
 
 
 class TestDoSearchErrorHandling:
     """Lines 123-128, 132 — Claude error paths."""
 
-    async def test_claude_unavailable_returns_empty(self):
-        """ClaudeUnavailableError → empty list (lines 123-125)."""
+    @pytest.mark.parametrize(
+        ("error", "query"),
+        [
+            # ClaudeUnavailableError → empty list (lines 123-125).
+            pytest.param(ClaudeUnavailableError("not configured"), "LM358", id="claude_unavailable_returns_empty"),
+            # ClaudeError → empty list (lines 126-128).
+            pytest.param(ClaudeError("api error"), "NE555", id="claude_error_returns_empty"),
+        ],
+    )
+    async def test_claude_error_returns_empty(self, error, query):
         connector = AIWebSearchConnector(api_key="test-key")
         with patch(
             "app.connectors.ai_live_web.claude_json",
-            new=AsyncMock(side_effect=ClaudeUnavailableError("not configured")),
+            new=AsyncMock(side_effect=error),
         ):
-            out = await connector._do_search("LM358")
-        assert out == []
-
-    async def test_claude_error_returns_empty(self):
-        """ClaudeError → empty list (lines 126-128)."""
-        connector = AIWebSearchConnector(api_key="test-key")
-        with patch(
-            "app.connectors.ai_live_web.claude_json",
-            new=AsyncMock(side_effect=ClaudeError("api error")),
-        ):
-            out = await connector._do_search("NE555")
+            out = await connector._do_search(query)
         assert out == []
 
     async def test_offers_not_list_returns_empty(self):
@@ -154,34 +139,24 @@ class TestDoSearchQualityGates:
         out = await self._search_with_offers(["not a dict", self._base_offer()])
         assert len(out) == 1
 
-    async def test_zero_qty_dropped(self):
-        """Qty <= 0 → dropped (lines 159-160)."""
-        out = await self._search_with_offers([self._base_offer(qty_available=0)])
-        assert out == []
-
-    async def test_none_qty_dropped(self):
-        """Qty=None → dropped."""
-        out = await self._search_with_offers([self._base_offer(qty_available=None)])
-        assert out == []
-
-    async def test_missing_vendor_url_dropped(self):
-        """No vendor_url → dropped (lines 161-162)."""
-        out = await self._search_with_offers([self._base_offer(vendor_url="")])
-        assert out == []
-
-    async def test_missing_evidence_dropped(self):
-        """No evidence_note → dropped (lines 165-166)."""
-        out = await self._search_with_offers([self._base_offer(evidence_note="")])
-        assert out == []
-
-    async def test_no_stock_signal_dropped(self):
-        """evidence_note with no stock signal → dropped (line 167-169)."""
-        out = await self._search_with_offers([self._base_offer(evidence_note="product page", in_stock_explicit=False)])
-        assert out == []
-
-    async def test_stale_listing_dropped(self):
-        """Listing older than 30 days → dropped (lines 170-172)."""
-        out = await self._search_with_offers([self._base_offer(listing_age_days=45, in_stock_explicit=True)])
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            # Qty <= 0 → dropped (lines 159-160).
+            pytest.param({"qty_available": 0}, id="zero_qty_dropped"),
+            pytest.param({"qty_available": None}, id="none_qty_dropped"),
+            # No vendor_url → dropped (lines 161-162).
+            pytest.param({"vendor_url": ""}, id="missing_vendor_url_dropped"),
+            # No evidence_note → dropped (lines 165-166).
+            pytest.param({"evidence_note": ""}, id="missing_evidence_dropped"),
+            # evidence_note with no stock signal → dropped (line 167-169).
+            pytest.param({"evidence_note": "product page", "in_stock_explicit": False}, id="no_stock_signal_dropped"),
+            # Listing older than 30 days → dropped (lines 170-172).
+            pytest.param({"listing_age_days": 45, "in_stock_explicit": True}, id="stale_listing_dropped"),
+        ],
+    )
+    async def test_offer_dropped(self, overrides):
+        out = await self._search_with_offers([self._base_offer(**overrides)])
         assert out == []
 
     async def test_evidence_without_qty_token_dropped(self):

--- a/tests/test_ai_router_nightly.py
+++ b/tests/test_ai_router_nightly.py
@@ -16,6 +16,7 @@ os.environ["RATE_LIMIT_ENABLED"] = "false"
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models import Requirement, Requisition
@@ -69,11 +70,6 @@ class TestGenerateDescription:
         with (
             patch("app.routers.ai.settings") as mock_settings,
             patch(
-                "app.routers.ai.ai_generate_description_for_requirement.__wrapped__",
-                new_callable=AsyncMock,
-            )
-            if False
-            else patch(
                 "app.services.description_service.generate_verified_description",
                 new_callable=AsyncMock,
                 return_value=fake_result,
@@ -130,27 +126,18 @@ class TestSaveParsedOffers:
 
 
 class TestParseIntake:
-    def test_parse_intake_short_text_returns_422(self, client):
-        """POST /api/ai/intake-parse with text < 5 chars → 422."""
-        resp = client.post("/api/ai/intake-parse", json={"text": "hi", "mode": "auto"})
-        assert resp.status_code == 422
-
-    def test_parse_intake_empty_text_returns_422(self, client):
-        """POST /api/ai/intake-parse with empty text → 422."""
-        resp = client.post("/api/ai/intake-parse", json={"text": "", "mode": "auto"})
-        assert resp.status_code == 422
-
-    def test_parse_intake_too_long_returns_422(self, client):
-        """POST /api/ai/intake-parse with text > 12000 chars → 422."""
-        resp = client.post("/api/ai/intake-parse", json={"text": "x" * 12001, "mode": "auto"})
-        assert resp.status_code == 422
-
-    def test_parse_intake_invalid_mode_returns_422(self, client):
-        """POST /api/ai/intake-parse with invalid mode → 422."""
-        resp = client.post(
-            "/api/ai/intake-parse",
-            json={"text": "I need 500 pcs of LM317T", "mode": "invalid"},
-        )
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param({"text": "hi", "mode": "auto"}, id="short_text"),
+            pytest.param({"text": "", "mode": "auto"}, id="empty_text"),
+            pytest.param({"text": "x" * 12001, "mode": "auto"}, id="too_long"),
+            pytest.param({"text": "I need 500 pcs of LM317T", "mode": "invalid"}, id="invalid_mode"),
+        ],
+    )
+    def test_parse_intake_invalid_body_returns_422(self, client, body):
+        """POST /api/ai/intake-parse with invalid text/mode → 422."""
+        resp = client.post("/api/ai/intake-parse", json=body)
         assert resp.status_code == 422
 
     def test_parse_intake_invalid_requisition_id_returns_404(self, client):

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -15,6 +15,18 @@ from fastapi.testclient import TestClient
 from app.models import User
 from app.models.config import ApiSource, ApiUsageLog
 
+
+def _mock_session_returning(active_sources):
+    """Build a mock DB session whose active-source query returns ``active_sources``.
+
+    Returns ``(mock_session, mock_session_cls)`` matching the query chain
+    ``query(...).filter(...).filter(...).all()`` used by run_health_checks.
+    """
+    mock_session = MagicMock()
+    mock_session.query.return_value.filter.return_value.filter.return_value.all.return_value = active_sources
+    return mock_session, MagicMock(return_value=mock_session)
+
+
 # ── Model Tests ──────────────────────────────────────────────────────
 
 
@@ -315,9 +327,7 @@ async def test_run_health_checks_ping(db_session):
     db_session.add_all([src1, src2])
     db_session.commit()
 
-    mock_session = MagicMock()
-    mock_session.query.return_value.filter.return_value.filter.return_value.all.return_value = [src1, src2]
-    mock_session_cls = MagicMock(return_value=mock_session)
+    mock_session, mock_session_cls = _mock_session_returning([src1, src2])
     ping_mock = AsyncMock(return_value={"success": True, "elapsed_ms": 42, "error": None})
 
     with (
@@ -350,9 +360,7 @@ async def test_run_health_checks_deep(db_session):
     db_session.add(src)
     db_session.commit()
 
-    mock_session = MagicMock()
-    mock_session.query.return_value.filter.return_value.filter.return_value.all.return_value = [src]
-    mock_session_cls = MagicMock(return_value=mock_session)
+    mock_session, mock_session_cls = _mock_session_returning([src])
     deep_mock = AsyncMock(
         return_value={
             "success": True,
@@ -389,9 +397,7 @@ async def test_run_health_checks_mixed_results(db_session):
     db_session.add_all([src_ok, src_bad])
     db_session.commit()
 
-    mock_session = MagicMock()
-    mock_session.query.return_value.filter.return_value.filter.return_value.all.return_value = [src_ok, src_bad]
-    mock_session_cls = MagicMock(return_value=mock_session)
+    mock_session, mock_session_cls = _mock_session_returning([src_ok, src_bad])
     ping_mock = AsyncMock(
         side_effect=[
             {"success": True, "elapsed_ms": 50, "error": None},
@@ -423,9 +429,7 @@ async def test_run_health_checks_source_crash(db_session):
     db_session.add(src)
     db_session.commit()
 
-    mock_session = MagicMock()
-    mock_session.query.return_value.filter.return_value.filter.return_value.all.return_value = [src]
-    mock_session_cls = MagicMock(return_value=mock_session)
+    mock_session, mock_session_cls = _mock_session_returning([src])
     ping_mock = AsyncMock(side_effect=RuntimeError("unexpected crash"))
 
     with (
@@ -467,9 +471,7 @@ async def test_run_health_checks_db_error_rollback():
 @pytest.mark.asyncio
 async def test_run_health_checks_no_active_sources():
     """run_health_checks with no active sources returns zeroes."""
-    mock_session = MagicMock()
-    mock_session.query.return_value.filter.return_value.filter.return_value.all.return_value = []
-    mock_session_cls = MagicMock(return_value=mock_session)
+    mock_session, mock_session_cls = _mock_session_returning([])
 
     with patch("app.database.SessionLocal", mock_session_cls):
         from app.services.health_monitor import run_health_checks

--- a/tests/test_api_manufacturer_validation.py
+++ b/tests/test_api_manufacturer_validation.py
@@ -6,65 +6,46 @@ What calls it: pytest
 Depends on: app/routers/requisitions/requirements.py, app/schemas/requisitions.py, conftest fixtures
 """
 
+import pytest
 
-def test_api_create_requirement_requires_manufacturer(client, db_session, test_user):
+
+def _make_requisition(db_session, test_user):
     from app.models.sourcing import Requisition
 
     req = Requisition(name="Test", status="active", created_by=test_user.id, claimed_by_id=test_user.id)
     db_session.add(req)
+    db_session.flush()
+    return req
+
+
+@pytest.mark.parametrize(
+    "body,expected_statuses",
+    [
+        ({"primary_mpn": "LM317T", "target_qty": 100}, (400, 422)),  # missing manufacturer
+        (
+            {"primary_mpn": "LM317T", "manufacturer": "Texas Instruments", "target_qty": 100},
+            (200, 201),
+        ),  # valid manufacturer
+        (
+            {"primary_mpn": "LM317T", "manufacturer": "   ", "target_qty": 100},
+            (400, 422),
+        ),  # blank manufacturer rejected
+    ],
+    ids=["requires_manufacturer", "with_manufacturer", "blank_manufacturer_rejected"],
+)
+def test_api_create_requirement_manufacturer_validation(client, db_session, test_user, body, expected_statuses):
+    req = _make_requisition(db_session, test_user)
     db_session.commit()
-    resp = client.post(
-        f"/api/requisitions/{req.id}/requirements",
-        json={
-            "primary_mpn": "LM317T",
-            "target_qty": 100,
-        },
-    )
-    assert resp.status_code in (400, 422)
-
-
-def test_api_create_requirement_with_manufacturer(client, db_session, test_user):
-    from app.models.sourcing import Requisition
-
-    req = Requisition(name="Test", status="active", created_by=test_user.id, claimed_by_id=test_user.id)
-    db_session.add(req)
-    db_session.commit()
-    resp = client.post(
-        f"/api/requisitions/{req.id}/requirements",
-        json={
-            "primary_mpn": "LM317T",
-            "manufacturer": "Texas Instruments",
-            "target_qty": 100,
-        },
-    )
-    assert resp.status_code in (200, 201)
-
-
-def test_api_create_requirement_blank_manufacturer_rejected(client, db_session, test_user):
-    from app.models.sourcing import Requisition
-
-    req = Requisition(name="Test", status="active", created_by=test_user.id, claimed_by_id=test_user.id)
-    db_session.add(req)
-    db_session.commit()
-    resp = client.post(
-        f"/api/requisitions/{req.id}/requirements",
-        json={
-            "primary_mpn": "LM317T",
-            "manufacturer": "   ",
-            "target_qty": 100,
-        },
-    )
-    assert resp.status_code in (400, 422)
+    resp = client.post(f"/api/requisitions/{req.id}/requirements", json=body)
+    assert resp.status_code in expected_statuses
 
 
 def test_api_update_requirement_manufacturer_optional(client, db_session, test_user):
     """PUT /api/requirements/{id} should accept updates without manufacturer (field is
     optional on update)."""
-    from app.models.sourcing import Requirement, Requisition
+    from app.models.sourcing import Requirement
 
-    req = Requisition(name="Test", status="active", created_by=test_user.id, claimed_by_id=test_user.id)
-    db_session.add(req)
-    db_session.flush()
+    req = _make_requisition(db_session, test_user)
     r = Requirement(requisition_id=req.id, primary_mpn="LM317T", manufacturer="Texas Instruments")
     db_session.add(r)
     db_session.commit()
@@ -75,11 +56,9 @@ def test_api_update_requirement_manufacturer_optional(client, db_session, test_u
 
 def test_api_update_requirement_sets_manufacturer(client, db_session, test_user):
     """PUT /api/requirements/{id} should update manufacturer when provided."""
-    from app.models.sourcing import Requirement, Requisition
+    from app.models.sourcing import Requirement
 
-    req = Requisition(name="Test", status="active", created_by=test_user.id, claimed_by_id=test_user.id)
-    db_session.add(req)
-    db_session.flush()
+    req = _make_requisition(db_session, test_user)
     r = Requirement(requisition_id=req.id, primary_mpn="LM317T", manufacturer="Texas Instruments")
     db_session.add(r)
     db_session.commit()

--- a/tests/test_attachment_parser_coverage.py
+++ b/tests/test_attachment_parser_coverage.py
@@ -27,56 +27,44 @@ from tests.conftest import engine  # noqa: F401
 
 
 class TestMatchHeadersDeterministicEmptyHeader:
-    def test_empty_string_header_is_skipped(self):
-        """Line 45: empty header string (after strip) is skipped, not matched."""
-        # "" after strip → continue without adding to mapping
-        headers = ["", "Part Number", "Qty"]
-        mapping = _match_headers_deterministic(headers)
-        # Index 0 (empty string) should not be in mapping
-        assert 0 not in mapping
-        # Indices 1 and 2 should still map
-        assert mapping[1] == "mpn"
-        assert mapping[2] == "qty"
-
-    def test_whitespace_only_header_is_skipped(self):
-        """Whitespace-only headers strip to empty and are skipped."""
-        headers = ["   ", "MPN"]
+    @pytest.mark.parametrize(
+        ("headers", "expected"),
+        [
+            pytest.param(["", "Part Number", "Qty"], {1: "mpn", 2: "qty"}, id="empty_string_header"),
+            pytest.param(["   ", "MPN"], {1: "mpn"}, id="whitespace_only_header"),
+        ],
+    )
+    def test_blank_header_is_skipped(self, headers, expected):
+        """Line 45: a blank header (empty/whitespace after strip) is skipped, not matched."""
         mapping = _match_headers_deterministic(headers)
         assert 0 not in mapping
-        assert mapping[1] == "mpn"
+        for idx, field in expected.items():
+            assert mapping[idx] == field
 
 
 class TestAIDetectColumnsNoMappingsKey:
     @pytest.mark.asyncio
-    async def test_result_without_mappings_key_returns_empty(self):
-        """Line 132: claude_structured returns result that has no 'mappings' key."""
+    @pytest.mark.parametrize(
+        ("claude_return", "headers", "sample_rows"),
+        [
+            pytest.param(
+                {"some_other_key": "value"}, ["Col A", "Col B"], [["LM317T", "100"]], id="result_without_mappings_key"
+            ),
+            pytest.param(None, ["Col A"], [["LM317T"]], id="none_result"),
+        ],
+    )
+    async def test_missing_mappings_returns_empty(self, claude_return, headers, sample_rows):
+        """Line 132: claude_structured returns no usable 'mappings' (missing key or None)."""
         from app.services.attachment_parser import _ai_detect_columns
 
         with patch(
             "app.utils.claude_client.claude_structured",
             new_callable=AsyncMock,
-            return_value={"some_other_key": "value"},  # No 'mappings'
+            return_value=claude_return,
         ):
             result = await _ai_detect_columns(
-                headers=["Col A", "Col B"],
-                sample_rows=[["LM317T", "100"]],
-                vendor_domain="test.com",
-            )
-        assert result == {}
-
-    @pytest.mark.asyncio
-    async def test_none_result_returns_empty(self):
-        """Line 132: claude_structured returns None."""
-        from app.services.attachment_parser import _ai_detect_columns
-
-        with patch(
-            "app.utils.claude_client.claude_structured",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
-            result = await _ai_detect_columns(
-                headers=["Col A"],
-                sample_rows=[["LM317T"]],
+                headers=headers,
+                sample_rows=sample_rows,
                 vendor_domain="test.com",
             )
         assert result == {}
@@ -170,32 +158,23 @@ class TestParseAttachmentBranches:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_empty_headers_returns_empty(self):
-        """Line 377: no headers → returns []."""
+    @pytest.mark.parametrize(
+        ("file_bytes", "filename", "fingerprint"),
+        [
+            pytest.param(b"", "empty.csv", "fp_empty", id="empty_headers"),
+            pytest.param(b"Part Number,Qty\n", "headers_only.csv", "fp_hdr_only", id="headers_only_no_data_rows"),
+        ],
+    )
+    async def test_no_headers_or_data_rows_returns_empty(self, file_bytes, filename, fingerprint):
+        """Line 377: missing headers or missing data rows → returns []."""
         with (
             patch("app.utils.file_validation.validate_file", return_value=(True, "csv")),
-            patch("app.utils.file_validation.file_fingerprint", return_value="fp_empty"),
-            patch("app.utils.file_validation.detect_encoding", return_value="utf-8"),
-        ):
-            # Empty CSV has no headers
-            result = await parse_attachment(
-                file_bytes=b"",
-                filename="empty.csv",
-                vendor_domain="vendor.com",
-            )
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_headers_only_no_data_rows_returns_empty(self):
-        """Line 377: headers exist but no data rows → returns []."""
-        with (
-            patch("app.utils.file_validation.validate_file", return_value=(True, "csv")),
-            patch("app.utils.file_validation.file_fingerprint", return_value="fp_hdr_only"),
+            patch("app.utils.file_validation.file_fingerprint", return_value=fingerprint),
             patch("app.utils.file_validation.detect_encoding", return_value="utf-8"),
         ):
             result = await parse_attachment(
-                file_bytes=b"Part Number,Qty\n",
-                filename="headers_only.csv",
+                file_bytes=file_bytes,
+                filename=filename,
                 vendor_domain="vendor.com",
             )
         assert result == []

--- a/tests/test_auth_deps_unit.py
+++ b/tests/test_auth_deps_unit.py
@@ -220,40 +220,18 @@ class TestRequireAdmin:
 class TestRequireBuyer:
     """Tests for require_buyer(request, db)."""
 
-    def test_buyer_role_allowed(self, db_session: Session):
-        user = _create_user(db_session, role="buyer")
-        request = _make_request(session_data={"user_id": user.id})
-
-        result = require_buyer(request, db_session)
-
-        assert result.id == user.id
-
-    def test_sales_role_allowed(self, db_session: Session):
-        user = _create_user(db_session, email="sales@test.com", role="sales")
-        request = _make_request(session_data={"user_id": user.id})
-
-        result = require_buyer(request, db_session)
-
-        assert result.id == user.id
-
-    def test_trader_role_allowed(self, db_session: Session):
-        user = _create_user(db_session, email="trader@test.com", role="trader")
-        request = _make_request(session_data={"user_id": user.id})
-
-        result = require_buyer(request, db_session)
-
-        assert result.id == user.id
-
-    def test_manager_role_allowed(self, db_session: Session):
-        user = _create_user(db_session, email="mgr@test.com", role="manager")
-        request = _make_request(session_data={"user_id": user.id})
-
-        result = require_buyer(request, db_session)
-
-        assert result.id == user.id
-
-    def test_admin_role_allowed(self, db_session: Session):
-        user = _create_user(db_session, email="adm@test.com", role="admin")
+    @pytest.mark.parametrize(
+        ("email", "role"),
+        [
+            pytest.param("unit@test.com", "buyer", id="buyer"),
+            pytest.param("sales@test.com", "sales", id="sales"),
+            pytest.param("trader@test.com", "trader", id="trader"),
+            pytest.param("mgr@test.com", "manager", id="manager"),
+            pytest.param("adm@test.com", "admin", id="admin"),
+        ],
+    )
+    def test_role_allowed(self, db_session: Session, email: str, role: str):
+        user = _create_user(db_session, email=email, role=role)
         request = _make_request(session_data={"user_id": user.id})
 
         result = require_buyer(request, db_session)

--- a/tests/test_buy_plan_service.py
+++ b/tests/test_buy_plan_service.py
@@ -1358,14 +1358,6 @@ class TestAutoCompleteViaPOVerify:
 # ── Coverage Gap Tests ──────────────────────────────────────────────
 
 
-def _make_ops_member_v2(db, user):
-    """Create a VerificationGroupMember for ops verification tests."""
-    vgm = VerificationGroupMember(user_id=user.id, is_active=True)
-    db.add(vgm)
-    db.flush()
-    return vgm
-
-
 class TestBuyPlanCoverageGaps:
     """Cover specific uncovered lines in buy_plan_service."""
 
@@ -1399,7 +1391,7 @@ class TestBuyPlanCoverageGaps:
         plan, line, _, _ = _make_draft_plan(db_session, test_quote, test_user)
         plan.status = BuyPlanStatus.ACTIVE.value
         plan.so_status = SOVerificationStatus.PENDING.value
-        _make_ops_member_v2(db_session, admin_user)
+        _make_ops_member(db_session, admin_user)
         db_session.flush()
 
         with pytest.raises(ValueError, match="Invalid SO verification"):
@@ -1438,7 +1430,7 @@ class TestBuyPlanCoverageGaps:
         plan, line, _, _ = _make_draft_plan(db_session, test_quote, test_user)
         plan.status = BuyPlanStatus.ACTIVE.value
         line.status = BuyPlanLineStatus.AWAITING_PO.value
-        _make_ops_member_v2(db_session, admin_user)
+        _make_ops_member(db_session, admin_user)
         db_session.flush()
 
         with pytest.raises(ValueError, match="pending verification"):
@@ -1449,7 +1441,7 @@ class TestBuyPlanCoverageGaps:
         plan, line, _, _ = _make_draft_plan(db_session, test_quote, test_user)
         plan.status = BuyPlanStatus.ACTIVE.value
         line.status = BuyPlanLineStatus.PENDING_VERIFY.value
-        _make_ops_member_v2(db_session, admin_user)
+        _make_ops_member(db_session, admin_user)
         db_session.flush()
 
         with pytest.raises(ValueError, match="Invalid PO verification"):
@@ -1709,61 +1701,26 @@ class TestCoverageGaps2:
         score = score_offer(offer, req, vendor)
         assert score > 0
 
-    def test_score_lead_time_7_days(self, db_session, test_requisition):
-        """Line 115-116: lead_time 7 days gets 85."""
+    @pytest.mark.parametrize(
+        ("lead_time", "vendor_name"),
+        [
+            ("7 days", "Lead7"),  # lines 115-116: 7 days gets 85
+            ("14 days", "Lead14"),  # lines 117-118: 14 days gets 70
+            ("30 days", "Lead30"),  # lines 119-120: 30 days gets 50
+            ("60 days", "Lead60"),  # lines 121-122: 60 days gets max(30, 100-60)=40
+        ],
+        ids=["7_days", "14_days", "30_days", "60_days"],
+    )
+    def test_score_lead_time(self, db_session, test_requisition, lead_time, vendor_name):
+        """Lines 115-122: lead-time tiers all yield a positive score."""
         req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
         offer = _make_offer(
             db_session,
             test_requisition.id,
             req.id,
             unit_price=0.50,
-            lead_time="7 days",
-            vendor_name="Lead7",
-        )
-        db_session.flush()
-        score = score_offer(offer, req, None)
-        assert score > 0
-
-    def test_score_lead_time_14_days(self, db_session, test_requisition):
-        """Lines 117-118: lead_time 14 days gets 70."""
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        offer = _make_offer(
-            db_session,
-            test_requisition.id,
-            req.id,
-            unit_price=0.50,
-            lead_time="14 days",
-            vendor_name="Lead14",
-        )
-        db_session.flush()
-        score = score_offer(offer, req, None)
-        assert score > 0
-
-    def test_score_lead_time_30_days(self, db_session, test_requisition):
-        """Lines 119-120: lead_time 30 days gets 50."""
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        offer = _make_offer(
-            db_session,
-            test_requisition.id,
-            req.id,
-            unit_price=0.50,
-            lead_time="30 days",
-            vendor_name="Lead30",
-        )
-        db_session.flush()
-        score = score_offer(offer, req, None)
-        assert score > 0
-
-    def test_score_lead_time_60_days(self, db_session, test_requisition):
-        """Lines 121-122: lead_time 60 days gets max(30, 100-60)=40."""
-        req = db_session.query(Requirement).filter_by(requisition_id=test_requisition.id).first()
-        offer = _make_offer(
-            db_session,
-            test_requisition.id,
-            req.id,
-            unit_price=0.50,
-            lead_time="60 days",
-            vendor_name="Lead60",
+            lead_time=lead_time,
+            vendor_name=vendor_name,
         )
         db_session.flush()
         score = score_offer(offer, req, None)

--- a/tests/test_buyer_leaderboard.py
+++ b/tests/test_buyer_leaderboard.py
@@ -11,7 +11,7 @@ from datetime import date, datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
-from app.models import BuyerLeaderboardSnapshot, BuyPlan, Offer, StockListHash, User
+from app.models import BuyerLeaderboardSnapshot, Offer, StockListHash, User
 from app.services.buyer_leaderboard import (
     PTS_LOGGED,
     PTS_STOCK_LIST,
@@ -64,17 +64,6 @@ def _make_offer(db: Session, user: User, created_at: datetime) -> Offer:
     db.add(o)
     db.flush()
     return o
-
-
-def _make_buy_plan(db: Session, status: str = "draft") -> BuyPlan:
-    bp = BuyPlan(
-        name="BP-TEST",
-        status=status,
-        created_at=datetime.now(timezone.utc),
-    )
-    db.add(bp)
-    db.flush()
-    return bp
 
 
 def _make_stock_hash(db: Session, user: User, first_seen_at: datetime) -> StockListHash:

--- a/tests/test_buyplan_scoring.py
+++ b/tests/test_buyplan_scoring.py
@@ -15,6 +15,8 @@ Depends on: app/services/buyplan_scoring.py, conftest.py
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from app.models import Offer, Requirement, Requisition, User, VendorCard
 from app.services.buyplan_scoring import (
     _country_to_region,
@@ -30,42 +32,26 @@ from tests.conftest import engine  # noqa: F401
 
 
 class TestParseLeadTimeDays:
-    def test_none_returns_none(self):
-        assert _parse_lead_time_days(None) is None
-
-    def test_empty_string_returns_none(self):
-        assert _parse_lead_time_days("") is None
-
-    def test_stock(self):
-        assert _parse_lead_time_days("stock") == 0
-
-    def test_in_stock(self):
-        assert _parse_lead_time_days("In Stock") == 0
-
-    def test_immediate(self):
-        assert _parse_lead_time_days("immediate") == 0
-
-    def test_same_day(self):
-        assert _parse_lead_time_days("Same Day") == 0
-
-    def test_days_range(self):
-        # "3-5 days" should return 5 (last number)
-        assert _parse_lead_time_days("3-5 days") == 5
-
-    def test_single_days(self):
-        assert _parse_lead_time_days("7 days") == 7
-
-    def test_weeks(self):
-        assert _parse_lead_time_days("2 weeks") == 14
-
-    def test_months(self):
-        assert _parse_lead_time_days("3 months") == 90
-
-    def test_no_numbers(self):
-        assert _parse_lead_time_days("unknown") is None
-
-    def test_whitespace(self):
-        assert _parse_lead_time_days("  10 days  ") == 10
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(None, None, id="none_returns_none"),
+            pytest.param("", None, id="empty_string_returns_none"),
+            pytest.param("stock", 0, id="stock"),
+            pytest.param("In Stock", 0, id="in_stock"),
+            pytest.param("immediate", 0, id="immediate"),
+            pytest.param("Same Day", 0, id="same_day"),
+            # "3-5 days" should return 5 (last number)
+            pytest.param("3-5 days", 5, id="days_range"),
+            pytest.param("7 days", 7, id="single_days"),
+            pytest.param("2 weeks", 14, id="weeks"),
+            pytest.param("3 months", 90, id="months"),
+            pytest.param("unknown", None, id="no_numbers"),
+            pytest.param("  10 days  ", 10, id="whitespace"),
+        ],
+    )
+    def test_parse(self, value, expected):
+        assert _parse_lead_time_days(value) == expected
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -209,36 +195,21 @@ class TestScoreOffer:
         score = score_offer(offer, req, None)
         assert 0 <= score <= 100
 
-    def test_lead_time_3_days(self):
-        """3-day lead time gets 100 score."""
-        offer = self._make_offer(unit_price=10.0, lead_time="3 days")
+    @pytest.mark.parametrize(
+        "lead_time",
+        [
+            pytest.param("3 days", id="3_days"),  # 3-day lead time gets 100 score
+            pytest.param("7 days", id="7_days"),
+            pytest.param("14 days", id="14_days"),
+            pytest.param("30 days", id="30_days"),
+            pytest.param(None, id="unknown"),  # unknown lead time (None) gets 40
+        ],
+    )
+    def test_lead_time_variants(self, lead_time):
+        """Each non-long lead time yields a positive score."""
+        offer = self._make_offer(unit_price=10.0, lead_time=lead_time)
         req = self._make_requirement(target_price=10.0)
 
-        score = score_offer(offer, req, None)
-        assert score > 0
-
-    def test_lead_time_7_days(self):
-        offer = self._make_offer(unit_price=10.0, lead_time="7 days")
-        req = self._make_requirement(target_price=10.0)
-        score = score_offer(offer, req, None)
-        assert score > 0
-
-    def test_lead_time_14_days(self):
-        offer = self._make_offer(unit_price=10.0, lead_time="14 days")
-        req = self._make_requirement(target_price=10.0)
-        score = score_offer(offer, req, None)
-        assert score > 0
-
-    def test_lead_time_30_days(self):
-        offer = self._make_offer(unit_price=10.0, lead_time="30 days")
-        req = self._make_requirement(target_price=10.0)
-        score = score_offer(offer, req, None)
-        assert score > 0
-
-    def test_lead_time_unknown(self):
-        """Unknown lead time (None) gets 40."""
-        offer = self._make_offer(unit_price=10.0, lead_time=None)
-        req = self._make_requirement(target_price=10.0)
         score = score_offer(offer, req, None)
         assert score > 0
 

--- a/tests/test_buyplan_workflow_bugs.py
+++ b/tests/test_buyplan_workflow_bugs.py
@@ -246,37 +246,32 @@ class TestApproveBuyPlanRoleCheck:
 
 
 class TestShouldAutoApprove:
-    def test_low_cost_no_flags_auto_approves(self, db_session):
+    @pytest.mark.parametrize(
+        ("total_cost", "ai_flags", "expected"),
+        [
+            pytest.param(100.0, [], True, id="low_cost_no_flags_auto_approves"),
+            pytest.param(10000.0, [], False, id="high_cost_does_not_auto_approve"),
+            pytest.param(
+                100.0,
+                [{"type": "stale_offer", "severity": "critical", "message": "test"}],
+                False,
+                id="critical_flags_prevent_auto_approve",
+            ),
+            pytest.param(
+                100.0,
+                [{"type": "low_margin", "severity": "warning", "message": "test"}],
+                True,
+                id="warning_flags_allow_auto_approve",
+            ),
+        ],
+    )
+    def test_auto_approve_decision(self, db_session, total_cost, ai_flags, expected):
         plan, _ = _make_plan_with_lines(
             db_session,
-            total_cost=100.0,
-            ai_flags=[],
+            total_cost=total_cost,
+            ai_flags=ai_flags,
         )
-        assert _should_auto_approve(plan) is True
-
-    def test_high_cost_does_not_auto_approve(self, db_session):
-        plan, _ = _make_plan_with_lines(
-            db_session,
-            total_cost=10000.0,
-            ai_flags=[],
-        )
-        assert _should_auto_approve(plan) is False
-
-    def test_critical_flags_prevent_auto_approve(self, db_session):
-        plan, _ = _make_plan_with_lines(
-            db_session,
-            total_cost=100.0,
-            ai_flags=[{"type": "stale_offer", "severity": "critical", "message": "test"}],
-        )
-        assert _should_auto_approve(plan) is False
-
-    def test_warning_flags_allow_auto_approve(self, db_session):
-        plan, _ = _make_plan_with_lines(
-            db_session,
-            total_cost=100.0,
-            ai_flags=[{"type": "low_margin", "severity": "warning", "message": "test"}],
-        )
-        assert _should_auto_approve(plan) is True
+        assert _should_auto_approve(plan) is expected
 
     def test_submit_and_resubmit_use_same_logic(self, db_session):
         """Verify submit and resubmit produce same auto-approve decision."""

--- a/tests/test_cache_intel.py
+++ b/tests/test_cache_intel.py
@@ -10,6 +10,8 @@ import json
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import app.cache.intel_cache as cache_mod
 from app.cache.intel_cache import (
     _get_redis,
@@ -17,6 +19,23 @@ from app.cache.intel_cache import (
     get_cached,
     set_cached,
 )
+
+
+def _make_ctx_db() -> MagicMock:
+    """Build a mock DB session usable as a context manager (``with SessionLocal() as
+    db``)."""
+    mock_db = MagicMock()
+    mock_db.__enter__ = MagicMock(return_value=mock_db)
+    mock_db.__exit__ = MagicMock(return_value=False)
+    return mock_db
+
+
+def _rowcount_result(rowcount: int) -> MagicMock:
+    """Build a mock execute() result reporting the given rowcount."""
+    result = MagicMock()
+    result.rowcount = rowcount
+    return result
+
 
 # ═══════════════════════════════════════════════════════════════════════
 #  _get_redis — TESTING=1 returns None
@@ -74,9 +93,7 @@ class TestGetCachedRedis:
         mock_get_redis.return_value = mock_redis
 
         # PG also returns None (miss)
-        mock_db = MagicMock()
-        mock_db.__enter__ = MagicMock(return_value=mock_db)
-        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_db = _make_ctx_db()
         mock_db.execute.return_value.fetchone.return_value = None
         mock_session_local.return_value = mock_db
 
@@ -88,9 +105,7 @@ class TestGetCachedPostgres:
     @patch("app.cache.intel_cache.SessionLocal")
     @patch("app.cache.intel_cache._get_redis", return_value=None)
     def test_pg_hit(self, mock_redis, mock_session_local):
-        mock_db = MagicMock()
-        mock_db.__enter__ = MagicMock(return_value=mock_db)
-        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_db = _make_ctx_db()
         mock_db.execute.return_value.fetchone.return_value = ({"intel": "data"},)
         mock_session_local.return_value = mock_db
 
@@ -100,9 +115,7 @@ class TestGetCachedPostgres:
     @patch("app.cache.intel_cache.SessionLocal")
     @patch("app.cache.intel_cache._get_redis", return_value=None)
     def test_pg_miss(self, mock_redis, mock_session_local):
-        mock_db = MagicMock()
-        mock_db.__enter__ = MagicMock(return_value=mock_db)
-        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_db = _make_ctx_db()
         mock_db.execute.return_value.fetchone.return_value = None
         mock_session_local.return_value = mock_db
 
@@ -144,9 +157,7 @@ class TestSetCached:
         mock_redis.setex.side_effect = Exception("Redis write failed")
         mock_get_redis.return_value = mock_redis
 
-        mock_db = MagicMock()
-        mock_db.__enter__ = MagicMock(return_value=mock_db)
-        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_db = _make_ctx_db()
         mock_session_local.return_value = mock_db
 
         set_cached("company:acme", {"intel": "data"}, ttl_days=7)
@@ -157,9 +168,7 @@ class TestSetCached:
     @patch("app.cache.intel_cache.SessionLocal")
     @patch("app.cache.intel_cache._get_redis", return_value=None)
     def test_pg_write_when_no_redis(self, mock_redis, mock_session_local):
-        mock_db = MagicMock()
-        mock_db.__enter__ = MagicMock(return_value=mock_db)
-        mock_db.__exit__ = MagicMock(return_value=False)
+        mock_db = _make_ctx_db()
         mock_session_local.return_value = mock_db
 
         set_cached("company:test", {"data": True})
@@ -182,57 +191,34 @@ class TestSetCached:
 
 
 class TestCleanupExpired:
+    @pytest.mark.parametrize(
+        ("batch_rowcounts", "expected_count"),
+        [
+            pytest.param([500, 0], 500, id="single_batch_then_done"),
+            pytest.param([1000, 200], 1200, id="full_batch_then_partial"),
+        ],
+    )
     @patch("app.cache.intel_cache.SessionLocal")
-    def test_deletes_expired_batched(self, mock_session_local):
-        mock_db = MagicMock()
-        mock_db.__enter__ = MagicMock(return_value=mock_db)
-        mock_db.__exit__ = MagicMock(return_value=False)
-        # First batch deletes 500, second batch deletes 0 → done
-        result1 = MagicMock()
-        result1.rowcount = 500
-        result2 = MagicMock()
-        result2.rowcount = 0
-        mock_db.execute.side_effect = [result1, result2]
+    def test_deletes_expired_batched(self, mock_session_local, batch_rowcounts, expected_count):
+        mock_db = _make_ctx_db()
+        mock_db.execute.side_effect = [_rowcount_result(n) for n in batch_rowcounts]
         mock_session_local.return_value = mock_db
 
-        count = cleanup_expired()
-        assert count == 500
+        assert cleanup_expired() == expected_count
 
     @patch("app.cache.intel_cache.SessionLocal")
     def test_no_expired_returns_zero(self, mock_session_local):
-        mock_db = MagicMock()
-        mock_db.__enter__ = MagicMock(return_value=mock_db)
-        mock_db.__exit__ = MagicMock(return_value=False)
-        result = MagicMock()
-        result.rowcount = 0
-        mock_db.execute.return_value = result
+        mock_db = _make_ctx_db()
+        mock_db.execute.return_value = _rowcount_result(0)
         mock_session_local.return_value = mock_db
 
-        count = cleanup_expired()
-        assert count == 0
+        assert cleanup_expired() == 0
 
     @patch("app.cache.intel_cache.SessionLocal")
     def test_db_error_returns_zero(self, mock_session_local):
         mock_session_local.side_effect = Exception("DB error")
 
-        count = cleanup_expired()
-        assert count == 0
-
-    @patch("app.cache.intel_cache.SessionLocal")
-    def test_multiple_batches(self, mock_session_local):
-        mock_db = MagicMock()
-        mock_db.__enter__ = MagicMock(return_value=mock_db)
-        mock_db.__exit__ = MagicMock(return_value=False)
-        # 1000 (full batch) → 200 (partial) → done
-        r1 = MagicMock()
-        r1.rowcount = 1000
-        r2 = MagicMock()
-        r2.rowcount = 200
-        mock_db.execute.side_effect = [r1, r2]
-        mock_session_local.return_value = mock_db
-
-        count = cleanup_expired()
-        assert count == 1200
+        assert cleanup_expired() == 0
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_commodity_registry.py
+++ b/tests/test_commodity_registry.py
@@ -4,6 +4,7 @@ Covers: app/services/commodity_registry.py
 Depends on: conftest.py, faceted search models
 """
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models import CommoditySpecSchema
@@ -28,10 +29,17 @@ def test_get_all_commodities_returns_flat_list():
     assert len(commodities) >= 40
 
 
-def test_get_parent_group_returns_group_name():
-    assert get_parent_group("capacitors") == "Passives"
-    assert get_parent_group("network_cards") == "IT / Server Hardware"
-    assert get_parent_group("cpu") == "Processors & Programmable"
+@pytest.mark.parametrize(
+    ("commodity", "expected_group"),
+    [
+        ("capacitors", "Passives"),
+        ("network_cards", "IT / Server Hardware"),
+        ("cpu", "Processors & Programmable"),
+        ("not_a_real_commodity", "Misc"),
+    ],
+)
+def test_get_parent_group_returns_group_name(commodity, expected_group):
+    assert get_parent_group(commodity) == expected_group
 
 
 def test_trio_taxonomy_additions_have_parents_and_display_names():
@@ -44,11 +52,6 @@ def test_trio_taxonomy_additions_have_parents_and_display_names():
     assert get_display_name("tape_drives") == "Tape Drives"
     assert get_display_name("ics_other") == "ICs (General)"
     assert get_display_name("oem_assemblies") == "OEM Assemblies"
-
-
-def test_get_parent_group_unknown_returns_misc():
-    group = get_parent_group("not_a_real_commodity")
-    assert group == "Misc"
 
 
 def test_seed_commodity_schemas_inserts_rows(db_session: Session):
@@ -68,7 +71,5 @@ def test_seed_commodity_schemas_is_idempotent(db_session: Session):
 
 def test_expanded_seeds_have_minimum_specs():
     """Every commodity should have at least 4 specs after expansion."""
-    from app.services.commodity_registry import COMMODITY_SPEC_SEEDS
-
     for commodity, specs in COMMODITY_SPEC_SEEDS.items():
         assert len(specs) >= 4, f"{commodity} has only {len(specs)} specs, expected >= 4"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,75 +20,54 @@ def _make(**overrides) -> Settings:
     return Settings(_env_file=None, **overrides)
 
 
+def _settings_with(env: dict[str, str]) -> Settings:
+    """Build a Settings from a clean environment containing only ``env``."""
+    with patch.dict(os.environ, env, clear=True):
+        return _make()
+
+
 class TestDefaults:
     """Default values apply when env vars are absent."""
 
-    def test_default_app_url(self):
-        with patch.dict(os.environ, {}, clear=True):
-            s = _make()
-        assert s.app_url == "http://localhost:8000"
-
-    def test_default_database_url(self):
-        with patch.dict(os.environ, {}, clear=True):
-            s = _make()
-        assert s.database_url == "postgresql://availai:availai@db:5432/availai"
-
-    def test_default_rate_limit_enabled(self):
-        with patch.dict(os.environ, {}, clear=True):
-            s = _make()
-        assert s.rate_limit_enabled is True
-
-    def test_default_rate_limit_ai_search(self):
-        with patch.dict(os.environ, {}, clear=True):
-            s = _make()
-        assert s.rate_limit_ai_search == "10/minute"
-
-    def test_default_admin_emails_empty(self):
-        with patch.dict(os.environ, {}, clear=True):
-            s = _make()
-        assert s.admin_emails == []
-
-    def test_default_own_domains(self):
-        with patch.dict(os.environ, {}, clear=True):
-            s = _make()
-        assert s.own_domains == frozenset({"trioscs.com"})
+    @pytest.mark.parametrize(
+        ("attr", "expected"),
+        [
+            ("app_url", "http://localhost:8000"),
+            ("database_url", "postgresql://availai:availai@db:5432/availai"),
+            ("rate_limit_enabled", True),
+            ("rate_limit_ai_search", "10/minute"),
+            ("admin_emails", []),
+            ("own_domains", frozenset({"trioscs.com"})),
+        ],
+    )
+    def test_default(self, attr, expected):
+        s = _settings_with({})
+        assert getattr(s, attr) == expected
 
 
 class TestBooleanCoercion:
     """Boolean env vars coerce string values correctly."""
 
-    def test_true_lowercase(self):
-        with patch.dict(os.environ, {"RATE_LIMIT_ENABLED": "true"}, clear=True):
-            s = _make()
-        assert s.rate_limit_enabled is True
-
-    def test_true_uppercase(self):
-        with patch.dict(os.environ, {"RATE_LIMIT_ENABLED": "TRUE"}, clear=True):
-            s = _make()
-        assert s.rate_limit_enabled is True
-
-    def test_false_string(self):
-        with patch.dict(os.environ, {"RATE_LIMIT_ENABLED": "false"}, clear=True):
-            s = _make()
-        assert s.rate_limit_enabled is False
-
-    def test_one_is_true(self):
-        with patch.dict(os.environ, {"RATE_LIMIT_ENABLED": "1"}, clear=True):
-            s = _make()
-        assert s.rate_limit_enabled is True
-
-    def test_zero_is_false(self):
-        with patch.dict(os.environ, {"RATE_LIMIT_ENABLED": "0"}, clear=True):
-            s = _make()
-        assert s.rate_limit_enabled is False
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("true", True),
+            ("TRUE", True),
+            ("false", False),
+            ("1", True),
+            ("0", False),
+        ],
+    )
+    def test_rate_limit_enabled(self, value, expected):
+        s = _settings_with({"RATE_LIMIT_ENABLED": value})
+        assert s.rate_limit_enabled is expected
 
 
 class TestDatabaseUrlValidator:
     """DATABASE_URL must start with postgresql (or sqlite when TESTING=1)."""
 
     def test_valid_postgresql(self):
-        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://u:p@h/db"}, clear=True):
-            s = _make()
+        s = _settings_with({"DATABASE_URL": "postgresql://u:p@h/db"})
         assert s.database_url.startswith("postgresql")
 
     def test_invalid_mysql_raises(self):
@@ -97,8 +76,7 @@ class TestDatabaseUrlValidator:
                 _make()
 
     def test_sqlite_allowed_when_testing(self):
-        with patch.dict(os.environ, {"TESTING": "1", "DATABASE_URL": "sqlite://"}, clear=True):
-            s = _make()
+        s = _settings_with({"TESTING": "1", "DATABASE_URL": "sqlite://"})
         assert s.database_url == "sqlite://"
 
     def test_sqlite_rejected_when_not_testing(self):
@@ -111,38 +89,29 @@ class TestDatabaseUrlValidator:
 class TestSampleRateValidator:
     """Sentry sample rates must be 0.0-1.0."""
 
-    def test_valid_rate(self):
-        with patch.dict(os.environ, {"SENTRY_TRACES_SAMPLE_RATE": "0.5"}, clear=True):
-            s = _make()
-        assert s.sentry_traces_sample_rate == 0.5
+    @pytest.mark.parametrize("value", ["0.5", "0.0", "1.0"])
+    def test_valid_rate(self, value):
+        s = _settings_with({"SENTRY_TRACES_SAMPLE_RATE": value})
+        assert s.sentry_traces_sample_rate == float(value)
 
-    def test_rate_too_high(self):
-        with patch.dict(os.environ, {"SENTRY_TRACES_SAMPLE_RATE": "1.5"}, clear=True):
+    @pytest.mark.parametrize(
+        ("env_key", "value"),
+        [
+            ("SENTRY_TRACES_SAMPLE_RATE", "1.5"),
+            ("SENTRY_PROFILES_SAMPLE_RATE", "-0.1"),
+        ],
+    )
+    def test_rate_out_of_range_raises(self, env_key, value):
+        with patch.dict(os.environ, {env_key: value}, clear=True):
             with pytest.raises(ValidationError, match="Sample rate must be between"):
                 _make()
-
-    def test_rate_negative(self):
-        with patch.dict(os.environ, {"SENTRY_PROFILES_SAMPLE_RATE": "-0.1"}, clear=True):
-            with pytest.raises(ValidationError, match="Sample rate must be between"):
-                _make()
-
-    def test_rate_zero_is_valid(self):
-        with patch.dict(os.environ, {"SENTRY_TRACES_SAMPLE_RATE": "0.0"}, clear=True):
-            s = _make()
-        assert s.sentry_traces_sample_rate == 0.0
-
-    def test_rate_one_is_valid(self):
-        with patch.dict(os.environ, {"SENTRY_TRACES_SAMPLE_RATE": "1.0"}, clear=True):
-            s = _make()
-        assert s.sentry_traces_sample_rate == 1.0
 
 
 class TestConfidenceValidator:
     """Confidence thresholds must be 0.0-1.0."""
 
     def test_valid_confidence(self):
-        with patch.dict(os.environ, {"MIN_TAG_CONFIDENCE": "0.85"}, clear=True):
-            s = _make()
+        s = _settings_with({"MIN_TAG_CONFIDENCE": "0.85"})
         assert s.min_tag_confidence == 0.85
 
     def test_confidence_too_high(self):
@@ -154,44 +123,32 @@ class TestConfidenceValidator:
 class TestCsvParsing:
     """Comma-separated env vars parse into lists correctly."""
 
-    def test_admin_emails_csv(self):
-        with patch.dict(os.environ, {"ADMIN_EMAILS": "a@b.com, c@d.com , E@F.COM"}, clear=True):
-            s = _make()
-        assert s.admin_emails == ["a@b.com", "c@d.com", "e@f.com"]
-
-    def test_admin_emails_empty_string(self):
-        with patch.dict(os.environ, {"ADMIN_EMAILS": ""}, clear=True):
-            s = _make()
-        assert s.admin_emails == []
-
-    def test_stock_sale_vendor_names_csv(self):
-        with patch.dict(os.environ, {"STOCK_SALE_VENDOR_NAMES": "Trio, Internal"}, clear=True):
-            s = _make()
-        assert s.stock_sale_vendor_names == ["trio", "internal"]
-
-    def test_stock_sale_notify_emails_csv(self):
-        with patch.dict(os.environ, {"STOCK_SALE_NOTIFY_EMAILS": "a@x.com,b@y.com"}, clear=True):
-            s = _make()
-        assert s.stock_sale_notify_emails == ["a@x.com", "b@y.com"]
-
-    def test_own_domains_csv(self):
-        with patch.dict(os.environ, {"OWN_DOMAINS": "trioscs.com, example.com"}, clear=True):
-            s = _make()
-        assert s.own_domains == frozenset({"trioscs.com", "example.com"})
+    @pytest.mark.parametrize(
+        ("env_key", "value", "attr", "expected"),
+        [
+            ("ADMIN_EMAILS", "a@b.com, c@d.com , E@F.COM", "admin_emails", ["a@b.com", "c@d.com", "e@f.com"]),
+            ("ADMIN_EMAILS", "", "admin_emails", []),
+            ("STOCK_SALE_VENDOR_NAMES", "Trio, Internal", "stock_sale_vendor_names", ["trio", "internal"]),
+            ("STOCK_SALE_NOTIFY_EMAILS", "a@x.com,b@y.com", "stock_sale_notify_emails", ["a@x.com", "b@y.com"]),
+            ("OWN_DOMAINS", "trioscs.com, example.com", "own_domains", frozenset({"trioscs.com", "example.com"})),
+        ],
+        ids=["admin_emails", "admin_emails_empty", "vendor_names", "notify_emails", "own_domains"],
+    )
+    def test_csv(self, env_key, value, attr, expected):
+        s = _settings_with({env_key: value})
+        assert getattr(s, attr) == expected
 
 
 class TestTypeCoercion:
     """Integer and float env vars coerce from strings."""
 
     def test_int_from_string(self):
-        with patch.dict(os.environ, {"FOLLOW_UP_DAYS": "7"}, clear=True):
-            s = _make()
+        s = _settings_with({"FOLLOW_UP_DAYS": "7"})
         assert s.follow_up_days == 7
         assert isinstance(s.follow_up_days, int)
 
     def test_float_from_string(self):
-        with patch.dict(os.environ, {"PROACTIVE_MIN_MARGIN_PCT": "25.5"}, clear=True):
-            s = _make()
+        s = _settings_with({"PROACTIVE_MIN_MARGIN_PCT": "25.5"})
         assert s.proactive_min_margin_pct == 25.5
 
     def test_invalid_int_raises(self):
@@ -204,6 +161,5 @@ class TestSecretKeyFallback:
     """SECRET_KEY env var maps to secret_key field."""
 
     def test_secret_key_direct(self):
-        with patch.dict(os.environ, {"SECRET_KEY": "my-secret"}, clear=True):
-            s = _make()
+        s = _settings_with({"SECRET_KEY": "my-secret"})
         assert s.secret_key == "my-secret"

--- a/tests/test_connector_errors.py
+++ b/tests/test_connector_errors.py
@@ -14,17 +14,23 @@ class TestConnectorErrorHierarchy:
     """All connector hard-error types must inherit from ConnectorError, which in turn
     inherits from RuntimeError so existing catches still work."""
 
-    def test_connector_error_is_runtime_error(self):
-        assert issubclass(ConnectorError, RuntimeError)
-
-    def test_auth_error_is_connector_error(self):
-        assert issubclass(ConnectorAuthError, ConnectorError)
-
-    def test_rate_limit_error_is_connector_error(self):
-        assert issubclass(ConnectorRateLimitError, ConnectorError)
-
-    def test_quota_error_is_connector_error(self):
-        assert issubclass(ConnectorQuotaError, ConnectorError)
+    @pytest.mark.parametrize(
+        ("subclass", "base"),
+        [
+            (ConnectorError, RuntimeError),
+            (ConnectorAuthError, ConnectorError),
+            (ConnectorRateLimitError, ConnectorError),
+            (ConnectorQuotaError, ConnectorError),
+        ],
+        ids=[
+            "connector_error_is_runtime_error",
+            "auth_error_is_connector_error",
+            "rate_limit_error_is_connector_error",
+            "quota_error_is_connector_error",
+        ],
+    )
+    def test_inheritance(self, subclass, base):
+        assert issubclass(subclass, base)
 
     def test_specific_types_are_distinct(self):
         """Operator code branches on the specific type to produce distinct messages —

--- a/tests/test_connector_rate_limits.py
+++ b/tests/test_connector_rate_limits.py
@@ -34,29 +34,31 @@ def _mock_response(status_code=200, json_data=None, text="", headers=None):
 
 
 class TestParseRetryAfter:
-    def test_with_numeric_header(self):
+    @pytest.mark.parametrize(
+        ("headers", "expected"),
+        [
+            pytest.param({"Retry-After": "10"}, 10.0, id="numeric_header"),
+            pytest.param({"Retry-After": "0.5"}, 1.0, id="small_header_clamps_to_1"),
+        ],
+    )
+    def test_explicit_value(self, headers, expected):
         from app.connectors.sources import _parse_retry_after
 
-        resp = _mock_response(429, headers={"Retry-After": "10"})
-        assert _parse_retry_after(resp) == 10.0
+        resp = _mock_response(429, headers=headers)
+        assert _parse_retry_after(resp) == expected
 
-    def test_with_small_header_clamps_to_1(self):
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            pytest.param({}, id="without_header"),
+            pytest.param({"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}, id="non_numeric_header"),
+        ],
+    )
+    def test_returns_default_with_jitter(self, headers):
+        """Missing or non-numeric header falls back to 5 + jitter(0, 2)."""
         from app.connectors.sources import _parse_retry_after
 
-        resp = _mock_response(429, headers={"Retry-After": "0.5"})
-        assert _parse_retry_after(resp) == 1.0
-
-    def test_without_header_returns_default(self):
-        from app.connectors.sources import _parse_retry_after
-
-        resp = _mock_response(429, headers={})
-        result = _parse_retry_after(resp)
-        assert 5.0 <= result <= 7.0  # 5 + jitter(0, 2)
-
-    def test_with_non_numeric_header_returns_default(self):
-        from app.connectors.sources import _parse_retry_after
-
-        resp = _mock_response(429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"})
+        resp = _mock_response(429, headers=headers)
         result = _parse_retry_after(resp)
         assert 5.0 <= result <= 7.0
 
@@ -67,18 +69,18 @@ class TestParseRetryAfter:
 
 
 class TestConnectorSemaphore:
-    def test_digikey_concurrency_limit(self):
+    @pytest.mark.parametrize(
+        ("connector_name", "expected_value"),
+        [
+            ("DigiKeyConnector", 2),  # DigiKey limited to 2 concurrent requests
+            ("SomeUnknownConnector", 3),  # default limit
+        ],
+    )
+    def test_concurrency_limit(self, connector_name, expected_value):
         from app.connectors.sources import _get_connector_semaphore
 
-        sem = _get_connector_semaphore("DigiKeyConnector")
-        # DigiKey should be limited to 2 concurrent requests
-        assert sem._value == 2
-
-    def test_default_concurrency_limit(self):
-        from app.connectors.sources import _get_connector_semaphore
-
-        sem = _get_connector_semaphore("SomeUnknownConnector")
-        assert sem._value == 3
+        sem = _get_connector_semaphore(connector_name)
+        assert sem._value == expected_value
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_contact_quality.py
+++ b/tests/test_contact_quality.py
@@ -7,6 +7,7 @@ Depends on: conftest fixtures (db_session, test_company, test_customer_site)
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models.crm import Company, SiteContact
@@ -25,64 +26,49 @@ from app.services.contact_quality import (
 class TestValidateContact:
     """Tests for contact dict validation."""
 
-    def test_valid_contact(self):
-        contact = {"full_name": "Jane Doe", "email": "jane@example.com", "phone": "+1-555-1234"}
+    @pytest.mark.parametrize(
+        ("contact", "expect_empty_issues"),
+        [
+            ({"full_name": "Jane Doe", "email": "jane@example.com", "phone": "+1-555-1234"}, True),
+            ({"full_name": "Jane Doe", "email": "jane@example.com", "phone": ""}, True),
+            ({"full_name": "Jane Doe", "email": "jane@example.com"}, False),
+            ({"full_name": "Jo", "email": "jo@a.co"}, False),
+        ],
+        ids=["valid_contact", "phone_empty_is_ok", "phone_absent_is_ok", "valid_minimal_name"],
+    )
+    def test_valid_contacts(self, contact, expect_empty_issues):
         is_valid, issues = validate_contact(contact)
         assert is_valid is True
-        assert issues == []
+        if expect_empty_issues:
+            assert issues == []
 
-    def test_missing_name(self):
-        contact = {"full_name": "", "email": "jane@example.com"}
+    @pytest.mark.parametrize(
+        ("contact", "expected_issue"),
+        [
+            ({"full_name": "", "email": "jane@example.com"}, "missing_name"),
+            ({"full_name": "J", "email": "jane@example.com"}, "missing_name"),
+            ({"email": "jane@example.com"}, "missing_name"),
+            ({"full_name": "  ", "email": "jane@example.com"}, "missing_name"),
+            ({"full_name": "Jane Doe", "email": ""}, "missing_email"),
+            ({"full_name": "Jane Doe"}, "missing_email"),
+            ({"full_name": "Jane Doe", "email": "not-an-email"}, "invalid_email_format"),
+            ({"full_name": "Jane Doe", "email": "jane@example.com", "phone": "123"}, "phone_too_short"),
+        ],
+        ids=[
+            "missing_name",
+            "name_too_short",
+            "name_none",
+            "whitespace_name_stripped",
+            "missing_email",
+            "email_none",
+            "invalid_email_format",
+            "phone_too_short",
+        ],
+    )
+    def test_invalid_contacts(self, contact, expected_issue):
         is_valid, issues = validate_contact(contact)
         assert is_valid is False
-        assert "missing_name" in issues
-
-    def test_name_too_short(self):
-        contact = {"full_name": "J", "email": "jane@example.com"}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is False
-        assert "missing_name" in issues
-
-    def test_name_none(self):
-        contact = {"email": "jane@example.com"}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is False
-        assert "missing_name" in issues
-
-    def test_missing_email(self):
-        contact = {"full_name": "Jane Doe", "email": ""}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is False
-        assert "missing_email" in issues
-
-    def test_email_none(self):
-        contact = {"full_name": "Jane Doe"}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is False
-        assert "missing_email" in issues
-
-    def test_invalid_email_format(self):
-        contact = {"full_name": "Jane Doe", "email": "not-an-email"}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is False
-        assert "invalid_email_format" in issues
-
-    def test_phone_too_short(self):
-        contact = {"full_name": "Jane Doe", "email": "jane@example.com", "phone": "123"}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is False
-        assert "phone_too_short" in issues
-
-    def test_phone_empty_is_ok(self):
-        contact = {"full_name": "Jane Doe", "email": "jane@example.com", "phone": ""}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is True
-        assert issues == []
-
-    def test_phone_absent_is_ok(self):
-        contact = {"full_name": "Jane Doe", "email": "jane@example.com"}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is True
+        assert expected_issue in issues
 
     def test_multiple_issues(self):
         contact = {"full_name": "", "email": "bad", "phone": "12"}
@@ -92,17 +78,6 @@ class TestValidateContact:
         assert "missing_name" in issues
         assert "invalid_email_format" in issues
         assert "phone_too_short" in issues
-
-    def test_whitespace_name_stripped(self):
-        contact = {"full_name": "  ", "email": "jane@example.com"}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is False
-        assert "missing_name" in issues
-
-    def test_valid_minimal_name(self):
-        contact = {"full_name": "Jo", "email": "jo@a.co"}
-        is_valid, issues = validate_contact(contact)
-        assert is_valid is True
 
 
 # ── dedup_contacts ──────────────────────────────────────────────────
@@ -176,8 +151,6 @@ class TestDedupContacts:
 
         Skipped: UNIQUE constraint on (customer_site_id, email) prevents duplicate creation.
         """
-        import pytest
-
         pytest.skip("UNIQUE constraint on (customer_site_id, email) prevents duplicate creation")
 
     def test_contacts_with_no_email_skipped(self, db_session: Session, test_customer_site):
@@ -204,8 +177,6 @@ class TestDedupContacts:
 
         Skipped: UNIQUE constraint on (customer_site_id, email) prevents duplicate creation.
         """
-        import pytest
-
         pytest.skip("UNIQUE constraint on (customer_site_id, email) prevents duplicate creation")
 
     def test_empty_site(self, db_session: Session, test_customer_site):
@@ -219,74 +190,36 @@ class TestDedupContacts:
 class TestScoreContactCompleteness:
     """Tests for the 0-100 completeness scorer."""
 
-    def test_fully_complete_contact(self, db_session: Session, test_customer_site):
-        c = SiteContact(
-            customer_site_id=test_customer_site.id,
-            full_name="Alice Smith",
-            email="alice@example.com",
-            email_verified=True,
-            phone="+1-555-0001",
-            phone_verified=True,
-            title="VP Purchasing",
-            linkedin_url="https://linkedin.com/in/alice",
-        )
+    @pytest.mark.parametrize(
+        ("fields", "expected"),
+        [
+            # 25 email + 20 name + 15 phone + 5 phone_verified + 15 title + 10 linkedin + 10 email_verified = 100
+            (
+                {
+                    "full_name": "Alice Smith",
+                    "email": "alice@example.com",
+                    "email_verified": True,
+                    "phone": "+1-555-0001",
+                    "phone_verified": True,
+                    "title": "VP Purchasing",
+                    "linkedin_url": "https://linkedin.com/in/alice",
+                },
+                100,
+            ),
+            ({"full_name": "Unknown", "email": None}, 0),
+            ({"full_name": "Unknown", "email": "x@y.com"}, 25),  # email only
+            ({"full_name": "Alice", "email": "alice@test.com"}, 45),  # 25 + 20
+            # 25 email + 20 name + 15 phone = 60
+            ({"full_name": "Alice", "email": "a@b.com", "phone": "+1-555", "phone_verified": False}, 60),
+        ],
+        ids=["fully_complete", "empty", "email_only", "name_and_email", "phone_without_verified"],
+    )
+    def test_score(self, db_session: Session, test_customer_site, fields, expected):
+        c = SiteContact(customer_site_id=test_customer_site.id, **fields)
         db_session.add(c)
         db_session.flush()
 
-        score = score_contact_completeness(c)
-        # 25 email + 20 name + 15 phone + 5 phone_verified + 15 title + 10 linkedin + 10 email_verified = 100
-        assert score == 100
-
-    def test_empty_contact(self, db_session: Session, test_customer_site):
-        c = SiteContact(
-            customer_site_id=test_customer_site.id,
-            full_name="Unknown",
-            email=None,
-        )
-        db_session.add(c)
-        db_session.flush()
-
-        score = score_contact_completeness(c)
-        assert score == 0
-
-    def test_email_only(self, db_session: Session, test_customer_site):
-        c = SiteContact(
-            customer_site_id=test_customer_site.id,
-            full_name="Unknown",
-            email="x@y.com",
-        )
-        db_session.add(c)
-        db_session.flush()
-
-        score = score_contact_completeness(c)
-        assert score == 25  # email only
-
-    def test_name_and_email(self, db_session: Session, test_customer_site):
-        c = SiteContact(
-            customer_site_id=test_customer_site.id,
-            full_name="Alice",
-            email="alice@test.com",
-        )
-        db_session.add(c)
-        db_session.flush()
-
-        score = score_contact_completeness(c)
-        assert score == 45  # 25 + 20
-
-    def test_phone_without_verified(self, db_session: Session, test_customer_site):
-        c = SiteContact(
-            customer_site_id=test_customer_site.id,
-            full_name="Alice",
-            email="a@b.com",
-            phone="+1-555",
-            phone_verified=False,
-        )
-        db_session.add(c)
-        db_session.flush()
-
-        score = score_contact_completeness(c)
-        # 25 email + 20 name + 15 phone = 60
-        assert score == 60
+        assert score_contact_completeness(c) == expected
 
     def test_score_capped_at_100(self, db_session: Session, test_customer_site):
         """Ensure score never exceeds 100 even with all fields."""

--- a/tests/test_core_jobs.py
+++ b/tests/test_core_jobs.py
@@ -57,29 +57,24 @@ class TestRegisterCoreJobs:
         job_ids = [call.kwargs["id"] for call in scheduler.add_job.call_args_list]
         assert "webhook_subs" in job_ids
 
-    def test_total_job_count_without_webhooks(self):
-        """Exactly 6 jobs when activity tracking disabled."""
+    @pytest.mark.parametrize(
+        ("activity_tracking_enabled", "expected_count"),
+        [
+            pytest.param(False, 6, id="without_webhooks"),
+            pytest.param(True, 7, id="with_webhooks"),
+        ],
+    )
+    def test_total_job_count(self, activity_tracking_enabled: bool, expected_count: int):
+        """Exactly 6 jobs without activity tracking, 7 with it enabled."""
         from app.jobs.core_jobs import register_core_jobs
 
         scheduler = MagicMock()
         settings = MagicMock()
         settings.inbox_scan_interval_min = 10
-        settings.activity_tracking_enabled = False
+        settings.activity_tracking_enabled = activity_tracking_enabled
 
         register_core_jobs(scheduler, settings)
-        assert scheduler.add_job.call_count == 6
-
-    def test_total_job_count_with_webhooks(self):
-        """Exactly 7 jobs when activity tracking enabled."""
-        from app.jobs.core_jobs import register_core_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.inbox_scan_interval_min = 10
-        settings.activity_tracking_enabled = True
-
-        register_core_jobs(scheduler, settings)
-        assert scheduler.add_job.call_count == 7
+        assert scheduler.add_job.call_count == expected_count
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -555,9 +550,16 @@ class TestJobBatchResults:
 
         mock_db.close.assert_called_once()
 
+    @pytest.mark.parametrize(
+        ("side_effect", "expected_exc", "match"),
+        [
+            pytest.param(asyncio.TimeoutError(), asyncio.TimeoutError, None, id="timeout"),
+            pytest.param(ValueError("bad data"), ValueError, "bad data", id="generic_exception"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_handles_timeout(self):
-        """TimeoutError is re-raised for _traced_job to catch."""
+    async def test_reraises_and_closes(self, side_effect, expected_exc, match):
+        """TimeoutError / generic exception is re-raised; session is closed."""
         from app.jobs.core_jobs import _job_batch_results
 
         mock_db = MagicMock()
@@ -565,26 +567,9 @@ class TestJobBatchResults:
         with (
             patch("app.database.SessionLocal", return_value=mock_db),
             patch("app.email_service.process_batch_results", AsyncMock()),
-            patch("asyncio.wait_for", side_effect=asyncio.TimeoutError()),
+            patch("asyncio.wait_for", side_effect=side_effect),
         ):
-            with pytest.raises(asyncio.TimeoutError):
-                await _job_batch_results.__wrapped__()
-
-        mock_db.close.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_handles_generic_exception(self):
-        """Generic exception is re-raised."""
-        from app.jobs.core_jobs import _job_batch_results
-
-        mock_db = MagicMock()
-
-        with (
-            patch("app.database.SessionLocal", return_value=mock_db),
-            patch("app.email_service.process_batch_results", AsyncMock()),
-            patch("asyncio.wait_for", side_effect=ValueError("bad data")),
-        ):
-            with pytest.raises(ValueError, match="bad data"):
+            with pytest.raises(expected_exc, match=match):
                 await _job_batch_results.__wrapped__()
 
         mock_db.close.assert_called_once()
@@ -615,8 +600,15 @@ class TestJobBatchParseSignatures:
 
         mock_db.close.assert_called_once()
 
+    @pytest.mark.parametrize(
+        ("side_effect", "expected_exc", "match"),
+        [
+            pytest.param(asyncio.TimeoutError(), asyncio.TimeoutError, None, id="timeout"),
+            pytest.param(RuntimeError("parse error"), RuntimeError, "parse error", id="exception"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_handles_timeout(self):
+    async def test_reraises_and_rolls_back(self, side_effect, expected_exc, match):
         from app.jobs.core_jobs import _job_batch_parse_signatures
 
         mock_db = MagicMock()
@@ -624,25 +616,9 @@ class TestJobBatchParseSignatures:
         with (
             patch("app.database.SessionLocal", return_value=mock_db),
             patch("app.services.signature_parser.batch_parse_signatures", AsyncMock()),
-            patch("asyncio.wait_for", side_effect=asyncio.TimeoutError()),
+            patch("asyncio.wait_for", side_effect=side_effect),
         ):
-            with pytest.raises(asyncio.TimeoutError):
-                await _job_batch_parse_signatures.__wrapped__()
-
-        mock_db.rollback.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_handles_exception(self):
-        from app.jobs.core_jobs import _job_batch_parse_signatures
-
-        mock_db = MagicMock()
-
-        with (
-            patch("app.database.SessionLocal", return_value=mock_db),
-            patch("app.services.signature_parser.batch_parse_signatures", AsyncMock()),
-            patch("asyncio.wait_for", side_effect=RuntimeError("parse error")),
-        ):
-            with pytest.raises(RuntimeError, match="parse error"):
+            with pytest.raises(expected_exc, match=match):
                 await _job_batch_parse_signatures.__wrapped__()
 
         mock_db.rollback.assert_called_once()
@@ -667,8 +643,15 @@ class TestJobPollSignatureBatch:
 
         mock_db.close.assert_called_once()
 
+    @pytest.mark.parametrize(
+        ("side_effect", "expected_exc", "match"),
+        [
+            pytest.param(asyncio.TimeoutError(), asyncio.TimeoutError, None, id="timeout"),
+            pytest.param(RuntimeError("poll error"), RuntimeError, "poll error", id="exception"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_handles_timeout(self):
+    async def test_reraises_and_rolls_back(self, side_effect, expected_exc, match):
         from app.jobs.core_jobs import _job_poll_signature_batch
 
         mock_db = MagicMock()
@@ -676,25 +659,9 @@ class TestJobPollSignatureBatch:
         with (
             patch("app.database.SessionLocal", return_value=mock_db),
             patch("app.services.signature_parser.process_signature_batch_results", AsyncMock()),
-            patch("asyncio.wait_for", side_effect=asyncio.TimeoutError()),
+            patch("asyncio.wait_for", side_effect=side_effect),
         ):
-            with pytest.raises(asyncio.TimeoutError):
-                await _job_poll_signature_batch.__wrapped__()
-
-        mock_db.rollback.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_handles_exception(self):
-        from app.jobs.core_jobs import _job_poll_signature_batch
-
-        mock_db = MagicMock()
-
-        with (
-            patch("app.database.SessionLocal", return_value=mock_db),
-            patch("app.services.signature_parser.process_signature_batch_results", AsyncMock()),
-            patch("asyncio.wait_for", side_effect=RuntimeError("poll error")),
-        ):
-            with pytest.raises(RuntimeError, match="poll error"):
+            with pytest.raises(expected_exc, match=match):
                 await _job_poll_signature_batch.__wrapped__()
 
         mock_db.rollback.assert_called_once()

--- a/tests/test_email_intelligence_phase1.py
+++ b/tests/test_email_intelligence_phase1.py
@@ -128,6 +128,18 @@ class TestStockListsFieldRemoved:
 
 
 class TestContactsSyncDelta:
+    @staticmethod
+    def _run_sync(mock_gc, test_user, db_session):
+        """Wire access_token + GraphClient(mock_gc) and run _sync_user_contacts to
+        completion."""
+        test_user.access_token = "fake-token"
+        db_session.commit()
+
+        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
+            from app.jobs.email_jobs import _sync_user_contacts
+
+            asyncio.get_event_loop().run_until_complete(_sync_user_contacts(test_user, db_session))
+
     def test_sync_user_contacts_uses_delta_query(self, db_session, test_user):
         """_sync_user_contacts uses delta_query instead of get_all_pages."""
         mock_gc = MagicMock()
@@ -146,13 +158,7 @@ class TestContactsSyncDelta:
             )
         )
 
-        test_user.access_token = "fake-token"
-        db_session.commit()
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
-            from app.jobs.email_jobs import _sync_user_contacts
-
-            asyncio.get_event_loop().run_until_complete(_sync_user_contacts(test_user, db_session))
+        self._run_sync(mock_gc, test_user, db_session)
 
         # Verify delta_query was called (not get_all_pages)
         mock_gc.delta_query.assert_called_once()
@@ -165,13 +171,7 @@ class TestContactsSyncDelta:
         mock_gc = MagicMock()
         mock_gc.delta_query = AsyncMock(return_value=([], "new-delta-token"))
 
-        test_user.access_token = "fake-token"
-        db_session.commit()
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
-            from app.jobs.email_jobs import _sync_user_contacts
-
-            asyncio.get_event_loop().run_until_complete(_sync_user_contacts(test_user, db_session))
+        self._run_sync(mock_gc, test_user, db_session)
 
         sync = (
             db_session.query(SyncState)
@@ -189,12 +189,6 @@ class TestContactsSyncDelta:
         mock_gc.delta_query = AsyncMock(side_effect=GraphSyncStateExpired("expired"))
         mock_gc.get_all_pages = AsyncMock(return_value=[])
 
-        test_user.access_token = "fake-token"
-        db_session.commit()
-
-        with patch("app.utils.graph_client.GraphClient", return_value=mock_gc):
-            from app.jobs.email_jobs import _sync_user_contacts
-
-            asyncio.get_event_loop().run_until_complete(_sync_user_contacts(test_user, db_session))
+        self._run_sync(mock_gc, test_user, db_session)
 
         mock_gc.get_all_pages.assert_called_once()

--- a/tests/test_email_service_coverage.py
+++ b/tests/test_email_service_coverage.py
@@ -139,28 +139,24 @@ class TestHandleExcessBidReplyEmptyBody:
 
 class TestHandleExcessBidReplyNoneResult:
     @pytest.mark.asyncio
-    async def test_none_result_leaves_solicitation_unchanged(self, db_session: Session, test_user: User):
-        """claude_structured returning None leaves solicitation status unchanged (lines
-        958-959)."""
+    @pytest.mark.parametrize(
+        ("content", "parse_result"),
+        [
+            pytest.param("I have some parts, please advise.", None, id="none_result"),
+            pytest.param("We may be interested.", {}, id="empty_dict_falsy"),
+        ],
+    )
+    async def test_falsy_result_leaves_solicitation_unchanged(
+        self, content: str, parse_result, db_session: Session, test_user: User
+    ):
+        """claude_structured returning None or {} (falsy) leaves solicitation status
+        unchanged (lines 958-959)."""
         sol = _make_excess_solicitation(db_session, test_user)
-        msg = {"body": {"content": "I have some parts, please advise."}}
+        msg = {"body": {"content": content}}
 
         # claude_structured is imported lazily from app.utils.claude_client inside the function
         with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock) as mock_claude:
-            mock_claude.return_value = None
-            await _handle_excess_bid_reply(msg, sol.id, db_session)
-
-        db_session.refresh(sol)
-        assert sol.status == "sent"
-
-    @pytest.mark.asyncio
-    async def test_empty_dict_result_treated_as_falsy(self, db_session: Session, test_user: User):
-        """claude_structured returning {} (falsy dict) leaves solicitation unchanged."""
-        sol = _make_excess_solicitation(db_session, test_user)
-        msg = {"body": {"content": "We may be interested."}}
-
-        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock) as mock_claude:
-            mock_claude.return_value = {}
+            mock_claude.return_value = parse_result
             await _handle_excess_bid_reply(msg, sol.id, db_session)
 
         db_session.refresh(sol)
@@ -172,27 +168,29 @@ class TestHandleExcessBidReplyNoneResult:
 
 class TestHandleExcessBidReplyIncomplete:
     @pytest.mark.asyncio
-    async def test_missing_unit_price_skips_bid_creation(self, db_session: Session, test_user: User):
-        """Parse result with unit_price=None returns early without creating bid (lines
-        971-972)."""
+    @pytest.mark.parametrize(
+        ("content", "result"),
+        [
+            pytest.param(
+                "We can supply 200 units.",
+                {"unit_price": None, "quantity_wanted": 200, "lead_time_days": 5, "notes": None},
+                id="missing_unit_price",
+            ),
+            pytest.param(
+                "Our unit price is $0.50.",
+                {"unit_price": 0.50, "quantity_wanted": None, "lead_time_days": None, "notes": None},
+                id="missing_quantity",
+            ),
+        ],
+    )
+    async def test_incomplete_parse_skips_bid_creation(
+        self, content: str, result: dict, db_session: Session, test_user: User
+    ):
+        """Parse result missing unit_price or quantity returns early without creating
+        bid (lines 971-972)."""
         sol = _make_excess_solicitation(db_session, test_user)
-        msg = {"body": {"content": "We can supply 200 units."}}
+        msg = {"body": {"content": content}}
 
-        result = {"unit_price": None, "quantity_wanted": 200, "lead_time_days": 5, "notes": None}
-        with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock) as mock_claude:
-            mock_claude.return_value = result
-            await _handle_excess_bid_reply(msg, sol.id, db_session)
-
-        db_session.refresh(sol)
-        assert sol.status == "sent"
-
-    @pytest.mark.asyncio
-    async def test_missing_quantity_skips_bid_creation(self, db_session: Session, test_user: User):
-        """Parse result with quantity_wanted=None returns early without creating bid."""
-        sol = _make_excess_solicitation(db_session, test_user)
-        msg = {"body": {"content": "Our unit price is $0.50."}}
-
-        result = {"unit_price": 0.50, "quantity_wanted": None, "lead_time_days": None, "notes": None}
         with patch("app.utils.claude_client.claude_structured", new_callable=AsyncMock) as mock_claude:
             mock_claude.return_value = result
             await _handle_excess_bid_reply(msg, sol.id, db_session)

--- a/tests/test_enrich_from_sightings.py
+++ b/tests/test_enrich_from_sightings.py
@@ -10,6 +10,8 @@ Depends on: scripts/enrich_from_sightings.py
 import os
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from scripts.enrich_from_sightings import (
@@ -22,59 +24,66 @@ from scripts.enrich_from_sightings import (
 
 
 class TestExtractDescription:
-    def test_digikey_description(self):
-        raw = {"description": "IC MCU 32BIT 256KB FLASH 100LQFP", "vendor_name": "DigiKey"}
-        assert _extract_description(raw, "digikey") == "IC MCU 32BIT 256KB FLASH 100LQFP"
-
-    def test_mouser_description(self):
-        raw = {"description": "ARM Cortex-M4 STM32F4 Microcontroller IC", "vendor_name": "Mouser"}
-        assert _extract_description(raw, "mouser") == "ARM Cortex-M4 STM32F4 Microcontroller IC"
-
-    def test_ebay_title_fallback(self):
-        raw = {"ebay_title": "Samsung 16GB DDR4-3200 ECC RDIMM Memory Module"}
-        assert _extract_description(raw, "ebay") == "Samsung 16GB DDR4-3200 ECC RDIMM Memory Module"
-
-    def test_none_raw_data(self):
-        assert _extract_description(None, "digikey") is None
-
-    def test_empty_dict(self):
-        assert _extract_description({}, "digikey") is None
-
-    def test_short_description_skipped(self):
-        raw = {"description": "IC"}
-        assert _extract_description(raw, "digikey") is None
-
-    def test_non_string_description(self):
-        raw = {"description": 12345}
-        assert _extract_description(raw, "digikey") is None
+    @pytest.mark.parametrize(
+        ("raw", "source", "expected"),
+        [
+            (
+                {"description": "IC MCU 32BIT 256KB FLASH 100LQFP", "vendor_name": "DigiKey"},
+                "digikey",
+                "IC MCU 32BIT 256KB FLASH 100LQFP",
+            ),
+            (
+                {"description": "ARM Cortex-M4 STM32F4 Microcontroller IC", "vendor_name": "Mouser"},
+                "mouser",
+                "ARM Cortex-M4 STM32F4 Microcontroller IC",
+            ),
+            (
+                {"ebay_title": "Samsung 16GB DDR4-3200 ECC RDIMM Memory Module"},
+                "ebay",
+                "Samsung 16GB DDR4-3200 ECC RDIMM Memory Module",
+            ),
+            (None, "digikey", None),
+            ({}, "digikey", None),
+            ({"description": "IC"}, "digikey", None),
+            ({"description": 12345}, "digikey", None),
+            ({"description": "  padded description  "}, "digikey", "padded description"),
+        ],
+        ids=[
+            "digikey_description",
+            "mouser_description",
+            "ebay_title_fallback",
+            "none_raw_data",
+            "empty_dict",
+            "short_description_skipped",
+            "non_string_description",
+            "stripped",
+        ],
+    )
+    def test_extract_description(self, raw, source, expected):
+        assert _extract_description(raw, source) == expected
 
     def test_truncated_to_1000(self):
         raw = {"description": "A" * 1500}
         result = _extract_description(raw, "digikey")
         assert len(result) == 1000
 
-    def test_stripped(self):
-        raw = {"description": "  padded description  "}
-        assert _extract_description(raw, "digikey") == "padded description"
-
 
 # ── _extract_datasheet_url tests ──────────────────────────────────────
 
 
 class TestExtractDatasheetUrl:
-    def test_valid_url(self):
-        raw = {"datasheet_url": "https://example.com/datasheet.pdf"}
-        assert _extract_datasheet_url(raw) == "https://example.com/datasheet.pdf"
-
-    def test_no_url(self):
-        assert _extract_datasheet_url({}) is None
-
-    def test_non_http_url(self):
-        raw = {"datasheet_url": "ftp://example.com/file"}
-        assert _extract_datasheet_url(raw) is None
-
-    def test_none_raw_data(self):
-        assert _extract_datasheet_url(None) is None
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ({"datasheet_url": "https://example.com/datasheet.pdf"}, "https://example.com/datasheet.pdf"),
+            ({}, None),
+            ({"datasheet_url": "ftp://example.com/file"}, None),
+            (None, None),
+        ],
+        ids=["valid_url", "no_url", "non_http_url", "none_raw_data"],
+    )
+    def test_extract_datasheet_url(self, raw, expected):
+        assert _extract_datasheet_url(raw) == expected
 
     def test_truncated_to_1000(self):
         raw = {"datasheet_url": "https://example.com/" + "a" * 1500}

--- a/tests/test_error_reports.py
+++ b/tests/test_error_reports.py
@@ -1,5 +1,7 @@
 """Tests for error_reports router — trouble ticket CRUD endpoints."""
 
+import pytest
+
 
 def test_create_error_report(client):
     """POST /api/error-reports creates a trouble ticket."""
@@ -10,9 +12,20 @@ def test_create_error_report(client):
     assert data["status"] == "created"
 
 
-def test_create_error_report_empty_message(client):
-    """POST /api/error-reports rejects empty message."""
-    resp = client.post("/api/error-reports", json={"message": ""})
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"message": ""}, id="empty_message"),
+        pytest.param(
+            {"message": "Bug", "screenshot": "x" * (2 * 1024 * 1024 + 1)},
+            id="screenshot_too_large",
+        ),
+    ],
+)
+def test_create_error_report_rejects_invalid_payload(client, payload):
+    """POST /api/error-reports rejects empty messages and oversized (>2MB)
+    screenshots."""
+    resp = client.post("/api/error-reports", json=payload)
     assert resp.status_code == 422
 
 
@@ -58,15 +71,3 @@ def test_trouble_tickets_alias(client):
     resp = client.post("/api/trouble-tickets", json={"message": "Via alias"})
     assert resp.status_code == 200
     assert resp.json()["status"] == "created"
-
-
-def test_create_error_report_screenshot_too_large(client):
-    """Reject screenshots larger than 2MB."""
-    resp = client.post(
-        "/api/error-reports",
-        json={
-            "message": "Bug",
-            "screenshot": "x" * (2 * 1024 * 1024 + 1),
-        },
-    )
-    assert resp.status_code == 422

--- a/tests/test_error_reports_async_direct.py
+++ b/tests/test_error_reports_async_direct.py
@@ -49,6 +49,16 @@ def _make_mock_request(content_type: str, body: bytes) -> MagicMock:
     return mock_req
 
 
+async def _submit(mock_req, db, user, bg_tasks=None):
+    """Invoke submit_trouble_ticket with the standard kwargs."""
+    return await submit_trouble_ticket(
+        request=mock_req,
+        background_tasks=bg_tasks if bg_tasks is not None else BackgroundTasks(),
+        user=user,
+        db=db,
+    )
+
+
 # ── JSON path (lines 187-193) ────────────────────────────────────────────────
 
 
@@ -58,14 +68,8 @@ async def test_submit_json_path_basic(db_session: Session, test_user: User):
         "application/json",
         b'{"description": "Button broken", "page_url": "/v2/search"}',
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 200
     assert "Report submitted" in resp.body.decode()
 
@@ -82,14 +86,8 @@ async def test_submit_json_with_ua_and_viewport(db_session: Session, test_user: 
             }
         ).encode(),
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 200
 
     ticket = db_session.query(TroubleTicket).filter(TroubleTicket.description == "Chrome bug").first()
@@ -112,14 +110,8 @@ async def test_submit_json_with_network_log_string(db_session: Session, test_use
             }
         ).encode(),
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 200
 
 
@@ -134,14 +126,8 @@ async def test_submit_json_with_invalid_network_log(db_session: Session, test_us
             }
         ).encode(),
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 200
 
 
@@ -156,14 +142,8 @@ async def test_submit_json_with_dict_network_log(db_session: Session, test_user:
             }
         ).encode(),
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 200
 
 
@@ -173,14 +153,8 @@ async def test_submit_json_empty_description_returns_422(db_session: Session, te
         "application/json",
         b'{"description": "   "}',
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 422
     assert "describe" in resp.body.decode().lower() or "problem" in resp.body.decode().lower()
 
@@ -193,14 +167,8 @@ async def test_submit_json_too_long_description_returns_422(db_session: Session,
         "application/json",
         json.dumps({"description": "X" * (MAX_MESSAGE_LEN + 1)}).encode(),
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 422
     assert "too long" in resp.body.decode().lower() or "max" in resp.body.decode().lower()
 
@@ -221,14 +189,8 @@ async def test_submit_json_with_screenshot_saves_path(db_session: Session, test_
             "application/json",
             json.dumps({"description": "Screenshot test", "screenshot": b64}).encode(),
         )
-        bg_tasks = BackgroundTasks()
 
-        resp = await submit_trouble_ticket(
-            request=mock_req,
-            background_tasks=bg_tasks,
-            user=test_user,
-            db=db_session,
-        )
+        resp = await _submit(mock_req, db_session, test_user)
         assert resp.status_code == 200
 
         ticket = db_session.query(TroubleTicket).filter(TroubleTicket.description == "Screenshot test").first()
@@ -252,14 +214,8 @@ async def test_submit_json_screenshot_bad_b64_no_path(db_session: Session, test_
             "application/json",
             json.dumps({"description": "Bad screenshot test", "screenshot": "invalid!!!"}).encode(),
         )
-        bg_tasks = BackgroundTasks()
 
-        resp = await submit_trouble_ticket(
-            request=mock_req,
-            background_tasks=bg_tasks,
-            user=test_user,
-            db=db_session,
-        )
+        resp = await _submit(mock_req, db_session, test_user)
         assert resp.status_code == 200
     finally:
         er_mod.UPLOAD_DIR = original_dir
@@ -274,14 +230,8 @@ async def test_submit_form_path_basic(db_session: Session, test_user: User):
         "application/x-www-form-urlencoded",
         b"message=Form+encoded+ticket&current_url=%2Fv2%2Fsearch",
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 200
     assert "Report submitted" in resp.body.decode()
 
@@ -292,14 +242,8 @@ async def test_submit_form_path_empty_message(db_session: Session, test_user: Us
         "application/x-www-form-urlencoded",
         b"message=+",
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 422
 
 
@@ -312,15 +256,9 @@ async def test_submit_db_error_returns_500_html(db_session: Session, test_user: 
         "application/json",
         b'{"description": "DB error test"}',
     )
-    bg_tasks = BackgroundTasks()
 
     with patch("app.routers.error_reports._create_ticket", side_effect=Exception("DB down")):
-        resp = await submit_trouble_ticket(
-            request=mock_req,
-            background_tasks=bg_tasks,
-            user=test_user,
-            db=db_session,
-        )
+        resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 500
     assert "went wrong" in resp.body.decode().lower()
 
@@ -337,14 +275,8 @@ async def test_submit_json_invalid_body_returns_422(db_session: Session, test_us
         raise ValueError("invalid json")
 
     mock_req.json = _bad_json
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 422
     assert "Invalid request" in resp.body.decode()
 
@@ -361,12 +293,7 @@ async def test_submit_adds_background_task(db_session: Session, test_user: User)
 
     bg_tasks = MagicMock(spec=BackgroundTasks)
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user, bg_tasks=bg_tasks)
     assert resp.status_code == 200
     bg_tasks.add_task.assert_called_once()
 
@@ -385,14 +312,8 @@ async def test_submit_json_only_ua_sets_browser_info(db_session: Session, test_u
             }
         ).encode(),
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 200
 
     ticket = db_session.query(TroubleTicket).filter(TroubleTicket.description == "UA only").first()
@@ -411,14 +332,8 @@ async def test_submit_json_with_error_log(db_session: Session, test_user: User):
             }
         ).encode(),
     )
-    bg_tasks = BackgroundTasks()
 
-    resp = await submit_trouble_ticket(
-        request=mock_req,
-        background_tasks=bg_tasks,
-        user=test_user,
-        db=db_session,
-    )
+    resp = await _submit(mock_req, db_session, test_user)
     assert resp.status_code == 200
 
     ticket = db_session.query(TroubleTicket).filter(TroubleTicket.description == "JS error test").first()

--- a/tests/test_excess_solicitations.py
+++ b/tests/test_excess_solicitations.py
@@ -56,18 +56,6 @@ def excess_list_with_items(db_session: Session, test_user: User, test_company: C
     return el, items
 
 
-def _mock_graph_client():
-    """Build a mock GraphClient with post_json and get_json."""
-    gc = AsyncMock()
-    # sendMail returns None (202 No Content)
-    gc.post_json = AsyncMock(return_value=None)
-    # Sent items lookup returns a matching message
-    gc.get_json = AsyncMock(
-        return_value={"value": [{"id": "graph-msg-abc123", "conversationId": "conv-xyz", "subject": "placeholder"}]}
-    )
-    return gc
-
-
 class TestSendValidation:
     """Validation: empty line_item_ids returns 422."""
 

--- a/tests/test_htmx_views_coverage.py
+++ b/tests/test_htmx_views_coverage.py
@@ -17,6 +17,7 @@ os.environ["TESTING"] = "1"
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -167,12 +168,19 @@ class TestUnauthenticatedPageLoad:
 class TestV2PageRouting:
     """Test that various URL patterns derive the correct partial_url."""
 
-    def test_v2_crm(self, client: TestClient):
-        resp = client.get("/v2/crm")
-        assert resp.status_code == 200
-
-    def test_v2_sightings_page(self, client: TestClient):
-        resp = client.get("/v2/sightings")
+    # Non-existent IDs just check partial_url derivation, not 404.
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "/v2/crm",
+            "/v2/sightings",
+            "/v2/excess/1",
+            "/v2/prospecting/1",
+            "/v2/trouble-tickets/1",
+        ],
+    )
+    def test_v2_page_routes(self, client: TestClient, url: str):
+        resp = client.get(url)
         assert resp.status_code == 200
 
     def test_v2_buy_plans_detail(self, client: TestClient, db_session: Session, test_user: User):
@@ -184,24 +192,11 @@ class TestV2PageRouting:
         resp = client.get(f"/v2/buy-plans/{bp.id}")
         assert resp.status_code == 200
 
-    def test_v2_excess_detail(self, client: TestClient):
-        # non-existent ID just checks partial_url derivation, not 404
-        resp = client.get("/v2/excess/1")
-        assert resp.status_code == 200
-
     def test_v2_quotes_detail(self, client: TestClient, db_session: Session, test_user: User):
         req = _make_requisition(db_session, test_user)
         quote = _make_quote(db_session, req, test_user)
         db_session.commit()
         resp = client.get(f"/v2/quotes/{quote.id}")
-        assert resp.status_code == 200
-
-    def test_v2_prospecting_detail(self, client: TestClient):
-        resp = client.get("/v2/prospecting/1")
-        assert resp.status_code == 200
-
-    def test_v2_trouble_tickets_detail(self, client: TestClient):
-        resp = client.get("/v2/trouble-tickets/1")
         assert resp.status_code == 200
 
 
@@ -211,17 +206,18 @@ class TestV2PageRouting:
 
 
 class TestVendorFindByPart:
-    def test_find_by_part_no_mpn(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors/find-by-part")
-        assert resp.status_code == 200
-
-    def test_find_by_part_with_mpn(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors/find-by-part?mpn=LM317T")
-        assert resp.status_code == 200
-
-    def test_find_by_part_short_mpn(self, client: TestClient):
-        # Very short MPN that normalize_mpn might return None for
-        resp = client.get("/v2/partials/vendors/find-by-part?mpn=AB")
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "/v2/partials/vendors/find-by-part",
+            "/v2/partials/vendors/find-by-part?mpn=LM317T",
+            # Very short MPN that normalize_mpn might return None for
+            "/v2/partials/vendors/find-by-part?mpn=AB",
+        ],
+        ids=["no_mpn", "with_mpn", "short_mpn"],
+    )
+    def test_find_by_part(self, client: TestClient, url: str):
+        resp = client.get(url)
         assert resp.status_code == 200
 
 
@@ -244,35 +240,21 @@ class TestVendorDetailMpnFilter:
 
 
 class TestCustomerTabs:
-    def test_tab_sites(self, client: TestClient, db_session: Session):
+    @pytest.mark.parametrize(
+        ("tab", "expected_status"),
+        [
+            ("sites", 200),
+            ("contacts", 200),
+            ("requisitions", 200),
+            ("activity", 200),
+            ("bogus", 404),
+        ],
+    )
+    def test_tab(self, client: TestClient, db_session: Session, tab: str, expected_status: int):
         co = _make_company(db_session)
         db_session.commit()
-        resp = client.get(f"/v2/partials/customers/{co.id}/tab/sites")
-        assert resp.status_code == 200
-
-    def test_tab_contacts_empty(self, client: TestClient, db_session: Session):
-        co = _make_company(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/customers/{co.id}/tab/contacts")
-        assert resp.status_code == 200
-
-    def test_tab_requisitions_empty(self, client: TestClient, db_session: Session):
-        co = _make_company(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/customers/{co.id}/tab/requisitions")
-        assert resp.status_code == 200
-
-    def test_tab_activity(self, client: TestClient, db_session: Session):
-        co = _make_company(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
-        assert resp.status_code == 200
-
-    def test_tab_invalid(self, client: TestClient, db_session: Session):
-        co = _make_company(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/customers/{co.id}/tab/bogus")
-        assert resp.status_code == 404
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/{tab}")
+        assert resp.status_code == expected_status
 
     def test_tab_not_found(self, client: TestClient):
         resp = client.get("/v2/partials/customers/999999/tab/sites")
@@ -345,12 +327,13 @@ class TestBuyPlanDetail:
 
 
 class TestQuotesList:
-    def test_quotes_list(self, client: TestClient):
-        resp = client.get("/v2/partials/quotes")
-        assert resp.status_code == 200
-
-    def test_quotes_list_with_status(self, client: TestClient):
-        resp = client.get("/v2/partials/quotes?status=draft")
+    @pytest.mark.parametrize(
+        "url",
+        ["/v2/partials/quotes", "/v2/partials/quotes?status=draft"],
+        ids=["all", "with_status"],
+    )
+    def test_quotes_list(self, client: TestClient, url: str):
+        resp = client.get(url)
         assert resp.status_code == 200
 
     def test_quotes_list_with_search(self, client: TestClient, db_session: Session, test_user: User):
@@ -472,41 +455,34 @@ class TestFollowUpSend:
 
 
 class TestOfferPromoteReject:
-    def test_promote_offer(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_requisition(db_session, test_user)
-        offer = _make_offer(db_session, req, test_user, status=OfferStatus.PENDING_REVIEW)
-        db_session.commit()
-        resp = client.post(f"/v2/partials/offers/{offer.id}/promote")
-        assert resp.status_code == 200
-
-    def test_promote_offer_not_found(self, client: TestClient):
-        resp = client.post("/v2/partials/offers/999999/promote")
-        assert resp.status_code == 404
-
-    def test_promote_wrong_status(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_requisition(db_session, test_user)
-        offer = _make_offer(db_session, req, test_user, status=OfferStatus.ACTIVE)
-        db_session.commit()
-        resp = client.post(f"/v2/partials/offers/{offer.id}/promote")
-        assert resp.status_code == 400
-
-    def test_reject_offer(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_requisition(db_session, test_user)
-        offer = _make_offer(db_session, req, test_user, status=OfferStatus.PENDING_REVIEW)
-        db_session.commit()
-        resp = client.post(f"/v2/partials/offers/{offer.id}/reject")
-        assert resp.status_code == 200
-
-    def test_reject_offer_not_found(self, client: TestClient):
-        resp = client.post("/v2/partials/offers/999999/reject")
-        assert resp.status_code == 404
-
-    def test_reject_wrong_status(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_requisition(db_session, test_user)
-        offer = _make_offer(db_session, req, test_user, status=OfferStatus.ACTIVE)
-        db_session.commit()
-        resp = client.post(f"/v2/partials/offers/{offer.id}/reject")
-        assert resp.status_code == 400
+    @pytest.mark.parametrize("action", ["promote", "reject"])
+    @pytest.mark.parametrize(
+        ("offer_status", "expected_status"),
+        [
+            (OfferStatus.PENDING_REVIEW, 200),
+            (None, 404),  # offer does not exist
+            (OfferStatus.ACTIVE, 400),  # wrong status
+        ],
+        ids=["pending_review", "not_found", "wrong_status"],
+    )
+    def test_promote_reject(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: User,
+        action: str,
+        offer_status,
+        expected_status: int,
+    ):
+        if offer_status is None:
+            offer_id = 999999
+        else:
+            req = _make_requisition(db_session, test_user)
+            offer = _make_offer(db_session, req, test_user, status=offer_status)
+            db_session.commit()
+            offer_id = offer.id
+        resp = client.post(f"/v2/partials/offers/{offer_id}/{action}")
+        assert resp.status_code == expected_status
 
     def test_offer_changelog(self, client: TestClient, db_session: Session, test_user: User):
         req = _make_requisition(db_session, test_user)
@@ -841,28 +817,11 @@ class TestReviewResponse:
 
 
 class TestVendorTabsExtra:
-    def test_tab_analytics(self, client: TestClient, db_session: Session):
+    @pytest.mark.parametrize("tab", ["analytics", "emails", "reviews", "find_contacts"])
+    def test_vendor_tab(self, client: TestClient, db_session: Session, tab: str):
         vc = _make_vendor_card(db_session)
         db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/analytics")
-        assert resp.status_code == 200
-
-    def test_tab_emails(self, client: TestClient, db_session: Session):
-        vc = _make_vendor_card(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/emails")
-        assert resp.status_code == 200
-
-    def test_tab_reviews(self, client: TestClient, db_session: Session):
-        vc = _make_vendor_card(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/reviews")
-        assert resp.status_code == 200
-
-    def test_tab_find_contacts(self, client: TestClient, db_session: Session):
-        vc = _make_vendor_card(db_session)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/find_contacts")
+        resp = client.get(f"/v2/partials/vendors/{vc.id}/tab/{tab}")
         assert resp.status_code == 200
 
     def test_vendor_list_with_my_only(self, client: TestClient, db_session: Session):
@@ -904,16 +863,11 @@ class TestRequisitionListEdgeCases:
         resp = client.get("/v2/partials/requisitions?q=CPN-001")
         assert resp.status_code == 200
 
-    def test_list_sort_status(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("sort", ["status", "customer_name"])
+    def test_list_sort(self, client: TestClient, db_session: Session, test_user: User, sort: str):
         _make_requisition(db_session, test_user)
         db_session.commit()
-        resp = client.get("/v2/partials/requisitions?sort=status&dir=asc")
-        assert resp.status_code == 200
-
-    def test_list_sort_customer_name(self, client: TestClient, db_session: Session, test_user: User):
-        _make_requisition(db_session, test_user)
-        db_session.commit()
-        resp = client.get("/v2/partials/requisitions?sort=customer_name&dir=asc")
+        resp = client.get(f"/v2/partials/requisitions?sort={sort}&dir=asc")
         assert resp.status_code == 200
 
 
@@ -923,18 +877,13 @@ class TestRequisitionListEdgeCases:
 
 
 class TestPartsWorkspaceTabExtras:
-    def test_parts_list_endpoint(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("with_req_filter", [False, True], ids=["no_filter", "req_filter"])
+    def test_parts_list(self, client: TestClient, db_session: Session, test_user: User, with_req_filter: bool):
         req = _make_requisition(db_session, test_user)
         _make_requirement(db_session, req)
         db_session.commit()
-        resp = client.get("/v2/partials/parts")
-        assert resp.status_code == 200
-
-    def test_parts_list_with_req_filter(self, client: TestClient, db_session: Session, test_user: User):
-        req = _make_requisition(db_session, test_user)
-        _make_requirement(db_session, req)
-        db_session.commit()
-        resp = client.get(f"/v2/partials/parts?req_id={req.id}")
+        url = f"/v2/partials/parts?req_id={req.id}" if with_req_filter else "/v2/partials/parts"
+        resp = client.get(url)
         assert resp.status_code == 200
 
 
@@ -944,10 +893,14 @@ class TestPartsWorkspaceTabExtras:
 
 
 class TestSightingsWorkspaceExtra:
-    def test_sightings_workspace(self, client: TestClient):
-        resp = client.get("/v2/partials/sightings/workspace")
-        assert resp.status_code == 200
-
-    def test_sightings_workspace_with_filters(self, client: TestClient):
-        resp = client.get("/v2/partials/sightings/workspace?q=LM317T")
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "/v2/partials/sightings/workspace",
+            "/v2/partials/sightings/workspace?q=LM317T",
+        ],
+        ids=["no_filters", "with_filters"],
+    )
+    def test_sightings_workspace(self, client: TestClient, url: str):
+        resp = client.get(url)
         assert resp.status_code == 200

--- a/tests/test_htmx_views_nightly17.py
+++ b/tests/test_htmx_views_nightly17.py
@@ -14,6 +14,7 @@ import os
 
 os.environ["TESTING"] = "1"
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.models import VendorCard
@@ -34,20 +35,17 @@ class TestVendorsListPartial:
         resp = client.get(f"/v2/partials/vendors?q={test_vendor_card.display_name[:5]}")
         assert resp.status_code == 200
 
-    def test_list_show_blacklisted(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors?hide_blacklisted=false")
-        assert resp.status_code == 200
-
-    def test_list_sort_by_name(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors?sort=display_name&dir=asc")
-        assert resp.status_code == 200
-
-    def test_list_my_only(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors?my_only=true")
-        assert resp.status_code == 200
-
-    def test_list_pagination(self, client: TestClient):
-        resp = client.get("/v2/partials/vendors?limit=10&offset=0")
+    @pytest.mark.parametrize(
+        "query",
+        [
+            pytest.param("hide_blacklisted=false", id="show_blacklisted"),
+            pytest.param("sort=display_name&dir=asc", id="sort_by_name"),
+            pytest.param("my_only=true", id="my_only"),
+            pytest.param("limit=10&offset=0", id="pagination"),
+        ],
+    )
+    def test_list_query_params(self, client: TestClient, query: str):
+        resp = client.get(f"/v2/partials/vendors?{query}")
         assert resp.status_code == 200
 
 
@@ -85,32 +83,20 @@ class TestVendorDetailPartial:
 
 
 class TestVendorTab:
-    def test_tab_overview(self, client: TestClient, test_vendor_card: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/overview")
-        assert resp.status_code == 200
-
-    def test_tab_contacts(self, client: TestClient, test_vendor_card: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/contacts")
-        assert resp.status_code == 200
-
-    def test_tab_find_contacts(self, client: TestClient, test_vendor_card: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/find_contacts")
-        assert resp.status_code == 200
-
-    def test_tab_emails(self, client: TestClient, test_vendor_card: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/emails")
-        assert resp.status_code == 200
-
-    def test_tab_analytics(self, client: TestClient, test_vendor_card: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/analytics")
-        assert resp.status_code == 200
-
-    def test_tab_reviews(self, client: TestClient, test_vendor_card: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/reviews")
-        assert resp.status_code == 200
-
-    def test_tab_offers(self, client: TestClient, test_vendor_card: VendorCard):
-        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/offers")
+    @pytest.mark.parametrize(
+        "tab",
+        [
+            "overview",
+            "contacts",
+            "find_contacts",
+            "emails",
+            "analytics",
+            "reviews",
+            "offers",
+        ],
+    )
+    def test_tab_valid(self, client: TestClient, test_vendor_card: VendorCard, tab: str):
+        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/{tab}")
         assert resp.status_code == 200
 
     def test_tab_invalid(self, client: TestClient, test_vendor_card: VendorCard):

--- a/tests/test_htmx_views_nightly2.py
+++ b/tests/test_htmx_views_nightly2.py
@@ -145,6 +145,14 @@ def _ticket(db: Session, user: User, **kw) -> TroubleTicket:
     return obj
 
 
+def _part(db: Session, user: User) -> Requirement:
+    """Create a committed requisition + requirement and return the requirement."""
+    req = _req(db, user)
+    item = _requirement(db, req)
+    db.commit()
+    return item
+
+
 # ── Parts List Partial ────────────────────────────────────────────────
 
 
@@ -238,66 +246,20 @@ class TestPartsListPartial:
 
 
 class TestPartsTabs:
-    def test_part_tab_offers(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+    @pytest.mark.parametrize("tab", ["offers", "sourcing", "req-details", "activity", "comms", "notes"])
+    def test_part_tab(self, client, db_session: Session, test_user: User, tab):
+        item = _part(db_session, test_user)
 
-        resp = client.get(f"/v2/partials/parts/{item.id}/tab/offers")
+        resp = client.get(f"/v2/partials/parts/{item.id}/tab/{tab}")
         assert resp.status_code == 200
 
-    def test_part_tab_offers_not_found(self, client, db_session: Session):
-        resp = client.get("/v2/partials/parts/999999/tab/offers")
-        assert resp.status_code == 404
-
-    def test_part_tab_sourcing(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/tab/sourcing")
-        assert resp.status_code == 200
-
-    def test_part_tab_req_details(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/tab/req-details")
-        assert resp.status_code == 200
-
-    def test_part_tab_activity(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/tab/activity")
-        assert resp.status_code == 200
-
-    def test_part_tab_comms(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/tab/comms")
-        assert resp.status_code == 200
-
-    def test_part_tab_notes(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/tab/notes")
-        assert resp.status_code == 200
-
-    def test_part_tab_notes_not_found(self, client, db_session: Session):
-        resp = client.get("/v2/partials/parts/999999/tab/notes")
+    @pytest.mark.parametrize("tab", ["offers", "notes"])
+    def test_part_tab_not_found(self, client, db_session: Session, tab):
+        resp = client.get(f"/v2/partials/parts/999999/tab/{tab}")
         assert resp.status_code == 404
 
     def test_save_part_notes(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+        item = _part(db_session, test_user)
 
         resp = client.patch(
             f"/v2/partials/parts/{item.id}/notes",
@@ -310,237 +272,125 @@ class TestPartsTabs:
 
 
 class TestPartHeaderEdit:
-    def test_part_header_edit_name(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+    @pytest.mark.parametrize(
+        ("field", "expected"),
+        [
+            ("brand", 200),
+            ("sourcing_status", 200),
+            ("condition", 200),
+            ("description", 200),
+            ("substitutes", 200),
+            ("target_qty", 200),
+            ("not_a_field", 400),
+        ],
+    )
+    def test_part_header_edit(self, client, db_session: Session, test_user: User, field, expected):
+        item = _part(db_session, test_user)
 
-        resp = client.get(f"/v2/partials/parts/{item.id}/header/edit/brand")
-        assert resp.status_code == 200
+        resp = client.get(f"/v2/partials/parts/{item.id}/header/edit/{field}")
+        assert resp.status_code == expected
 
-    def test_part_header_edit_sourcing_status(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/header/edit/sourcing_status")
-        assert resp.status_code == 200
-
-    def test_part_header_edit_condition(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/header/edit/condition")
-        assert resp.status_code == 200
-
-    def test_part_header_edit_description(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/header/edit/description")
-        assert resp.status_code == 200
-
-    def test_part_header_edit_substitutes(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/header/edit/substitutes")
-        assert resp.status_code == 200
-
-    def test_part_header_edit_target_qty(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/header/edit/target_qty")
-        assert resp.status_code == 200
-
-    def test_part_header_edit_invalid_field(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/header/edit/not_a_field")
-        assert resp.status_code == 400
-
-    def test_part_header_save_brand(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+    @pytest.mark.parametrize(
+        ("field", "value", "expected"),
+        [
+            ("brand", "Texas Instruments", 200),
+            ("target_qty", "500", 200),
+            ("target_price", "0.50", 200),
+            ("manufacturer", "TI", 200),
+            ("not_valid", "x", 400),
+        ],
+    )
+    def test_part_header_save(self, client, db_session: Session, test_user: User, field, value, expected):
+        item = _part(db_session, test_user)
 
         resp = client.patch(
             f"/v2/partials/parts/{item.id}/header",
-            data={"field": "brand", "value": "Texas Instruments"},
+            data={"field": field, "value": value},
         )
-        assert resp.status_code == 200
-
-    def test_part_header_save_target_qty(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.patch(
-            f"/v2/partials/parts/{item.id}/header",
-            data={"field": "target_qty", "value": "500"},
-        )
-        assert resp.status_code == 200
-
-    def test_part_header_save_target_price(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.patch(
-            f"/v2/partials/parts/{item.id}/header",
-            data={"field": "target_price", "value": "0.50"},
-        )
-        assert resp.status_code == 200
-
-    def test_part_header_save_manufacturer(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.patch(
-            f"/v2/partials/parts/{item.id}/header",
-            data={"field": "manufacturer", "value": "TI"},
-        )
-        assert resp.status_code == 200
-
-    def test_part_header_save_invalid_field(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.patch(
-            f"/v2/partials/parts/{item.id}/header",
-            data={"field": "not_valid", "value": "x"},
-        )
-        assert resp.status_code == 400
+        assert resp.status_code == expected
 
 
 # ── Part Cell Inline Edit ─────────────────────────────────────────────
 
 
 class TestPartCellEdit:
-    def test_cell_edit_sourcing_status(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+    @pytest.mark.parametrize(
+        ("field", "expected"),
+        [
+            ("sourcing_status", 200),
+            ("invalid", 400),
+        ],
+    )
+    def test_cell_edit(self, client, db_session: Session, test_user: User, field, expected):
+        item = _part(db_session, test_user)
 
-        resp = client.get(f"/v2/partials/parts/{item.id}/cell/edit/sourcing_status")
-        assert resp.status_code == 200
+        resp = client.get(f"/v2/partials/parts/{item.id}/cell/edit/{field}")
+        assert resp.status_code == expected
 
-    def test_cell_edit_invalid_field(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+    @pytest.mark.parametrize(
+        ("field", "expected"),
+        [
+            ("target_qty", 200),
+            ("invalid", 400),
+        ],
+    )
+    def test_cell_display(self, client, db_session: Session, test_user: User, field, expected):
+        item = _part(db_session, test_user)
 
-        resp = client.get(f"/v2/partials/parts/{item.id}/cell/edit/invalid")
-        assert resp.status_code == 400
+        resp = client.get(f"/v2/partials/parts/{item.id}/cell/display/{field}")
+        assert resp.status_code == expected
 
-    def test_cell_display(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/cell/display/target_qty")
-        assert resp.status_code == 200
-
-    def test_cell_display_invalid(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/cell/display/invalid")
-        assert resp.status_code == 400
-
-    def test_cell_save_target_qty(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.patch(
-            f"/v2/partials/parts/{item.id}/cell",
-            data={"field": "target_qty", "value": "250"},
-        )
-        assert resp.status_code == 200
-
-    def test_cell_save_target_price(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+    @pytest.mark.parametrize(
+        ("field", "value", "expected"),
+        [
+            ("target_qty", "250", 200),
+            ("target_price", "0.75", 200),
+            ("invalid_field", "x", 400),
+        ],
+    )
+    def test_cell_save(self, client, db_session: Session, test_user: User, field, value, expected):
+        item = _part(db_session, test_user)
 
         resp = client.patch(
             f"/v2/partials/parts/{item.id}/cell",
-            data={"field": "target_price", "value": "0.75"},
+            data={"field": field, "value": value},
         )
-        assert resp.status_code == 200
-
-    def test_cell_save_invalid_field(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.patch(
-            f"/v2/partials/parts/{item.id}/cell",
-            data={"field": "invalid_field", "value": "x"},
-        )
-        assert resp.status_code == 400
+        assert resp.status_code == expected
 
 
 # ── Part Spec Edit ────────────────────────────────────────────────────
 
 
 class TestPartSpecEdit:
-    def test_spec_edit_customer_pn(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+    @pytest.mark.parametrize(
+        ("field", "expected"),
+        [
+            ("customer_pn", 200),
+            ("condition", 200),
+            ("invalid", 400),
+        ],
+    )
+    def test_spec_edit(self, client, db_session: Session, test_user: User, field, expected):
+        item = _part(db_session, test_user)
 
-        resp = client.get(f"/v2/partials/parts/{item.id}/edit-spec/customer_pn")
-        assert resp.status_code == 200
+        resp = client.get(f"/v2/partials/parts/{item.id}/edit-spec/{field}")
+        assert resp.status_code == expected
 
-    def test_spec_edit_condition(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/edit-spec/condition")
-        assert resp.status_code == 200
-
-    def test_spec_edit_invalid_field(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.get(f"/v2/partials/parts/{item.id}/edit-spec/invalid")
-        assert resp.status_code == 400
-
-    def test_spec_save(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+    @pytest.mark.parametrize(
+        ("field", "value", "expected"),
+        [
+            ("customer_pn", "CUST-123", 200),
+            ("not_valid", "x", 400),
+        ],
+    )
+    def test_spec_save(self, client, db_session: Session, test_user: User, field, value, expected):
+        item = _part(db_session, test_user)
 
         resp = client.patch(
             f"/v2/partials/parts/{item.id}/save-spec",
-            data={"field": "customer_pn", "value": "CUST-123"},
+            data={"field": field, "value": value},
         )
-        assert resp.status_code == 200
-
-    def test_spec_save_invalid_field(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
-
-        resp = client.patch(
-            f"/v2/partials/parts/{item.id}/save-spec",
-            data={"field": "not_valid", "value": "x"},
-        )
-        assert resp.status_code == 400
+        assert resp.status_code == expected
 
 
 # ── Part Tasks ────────────────────────────────────────────────────────
@@ -548,9 +398,7 @@ class TestPartSpecEdit:
 
 class TestPartTasks:
     def test_create_part_task(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+        item = _part(db_session, test_user)
 
         resp = client.post(
             f"/v2/partials/parts/{item.id}/tasks",
@@ -559,9 +407,7 @@ class TestPartTasks:
         assert resp.status_code == 200
 
     def test_create_part_task_no_title(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+        item = _part(db_session, test_user)
 
         resp = client.post(f"/v2/partials/parts/{item.id}/tasks", data={"notes": "No title"})
         assert resp.status_code == 422
@@ -678,9 +524,7 @@ class TestPartTasks:
 
 class TestArchiveSystem:
     def test_archive_single_part(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+        item = _part(db_session, test_user)
 
         resp = client.patch(f"/v2/partials/parts/{item.id}/archive")
         assert resp.status_code == 200
@@ -718,9 +562,7 @@ class TestArchiveSystem:
         assert resp.status_code == 200
 
     def test_bulk_archive(self, client, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        item = _requirement(db_session, req)
-        db_session.commit()
+        item = _part(db_session, test_user)
 
         resp = client.post(
             "/v2/partials/parts/bulk-archive",

--- a/tests/test_htmx_views_nightly28.py
+++ b/tests/test_htmx_views_nightly28.py
@@ -18,6 +18,7 @@ os.environ["TESTING"] = "1"
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -73,23 +74,19 @@ class TestStalenessHelper:
 
         assert _staleness_tier(None) == "new"
 
-    def test_recent_timestamp(self):
+    @pytest.mark.parametrize(
+        ("days_ago", "expected"),
+        [
+            pytest.param(5, "recent", id="recent"),
+            pytest.param(20, "due_soon", id="due_soon"),
+            pytest.param(40, "overdue", id="overdue"),
+        ],
+    )
+    def test_aware_timestamp_tier(self, days_ago, expected):
         from app.routers.htmx_views import _staleness_tier
 
-        ts = datetime.now(timezone.utc) - timedelta(days=5)
-        assert _staleness_tier(ts) == "recent"
-
-    def test_due_soon_timestamp(self):
-        from app.routers.htmx_views import _staleness_tier
-
-        ts = datetime.now(timezone.utc) - timedelta(days=20)
-        assert _staleness_tier(ts) == "due_soon"
-
-    def test_overdue_timestamp(self):
-        from app.routers.htmx_views import _staleness_tier
-
-        ts = datetime.now(timezone.utc) - timedelta(days=40)
-        assert _staleness_tier(ts) == "overdue"
+        ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        assert _staleness_tier(ts) == expected
 
     def test_naive_datetime_treated_as_utc(self):
         """Naive datetime (no tzinfo) → line 4283 adds UTC, staleness computed
@@ -105,42 +102,42 @@ class TestStalenessHelper:
 class TestSanitizeHxParams:
     """Tests for _sanitize_hx_params() — allowlist enforcement."""
 
-    def test_invalid_hx_target_replaced_with_default(self):
-        """Line 4271: invalid hx_target replaced with '#main-content'."""
+    @pytest.mark.parametrize(
+        ("hx_target", "push_url_base", "default_push", "expected_target", "expected_push"),
+        [
+            # Line 4271: invalid hx_target replaced with '#main-content'.
+            pytest.param(
+                "evil-target",
+                "/v2/vendors",
+                "/v2/vendors",
+                "#main-content",
+                "/v2/vendors",
+                id="invalid_target_replaced",
+            ),
+            # Line 4273: invalid push_url_base replaced with default_push arg.
+            pytest.param(
+                "#main-content", "/evil/path", "/v2/vendors", "#main-content", "/v2/vendors", id="invalid_push_replaced"
+            ),
+            pytest.param("bad", "bad", "/v2/customers", "#main-content", "/v2/customers", id="both_invalid_replaced"),
+            pytest.param(
+                "#main-content", "/v2/vendors", "/v2/vendors", "#main-content", "/v2/vendors", id="valid_pass_through"
+            ),
+            pytest.param(
+                "#crm-tab-content",
+                "/v2/customers",
+                "/v2/vendors",
+                "#crm-tab-content",
+                "/v2/customers",
+                id="crm_tab_content_allowed",
+            ),
+        ],
+    )
+    def test_sanitize_hx_params(self, hx_target, push_url_base, default_push, expected_target, expected_push):
         from app.routers.htmx_views import _sanitize_hx_params
 
-        target, push = _sanitize_hx_params("evil-target", "/v2/vendors", "/v2/vendors")
-        assert target == "#main-content"
-        assert push == "/v2/vendors"
-
-    def test_invalid_push_url_replaced_with_default(self):
-        """Line 4273: invalid push_url_base replaced with default_push arg."""
-        from app.routers.htmx_views import _sanitize_hx_params
-
-        target, push = _sanitize_hx_params("#main-content", "/evil/path", "/v2/vendors")
-        assert target == "#main-content"
-        assert push == "/v2/vendors"
-
-    def test_both_invalid_both_replaced(self):
-        from app.routers.htmx_views import _sanitize_hx_params
-
-        target, push = _sanitize_hx_params("bad", "bad", "/v2/customers")
-        assert target == "#main-content"
-        assert push == "/v2/customers"
-
-    def test_valid_values_pass_through_unchanged(self):
-        from app.routers.htmx_views import _sanitize_hx_params
-
-        target, push = _sanitize_hx_params("#main-content", "/v2/vendors", "/v2/vendors")
-        assert target == "#main-content"
-        assert push == "/v2/vendors"
-
-    def test_crm_tab_content_is_allowed(self):
-        from app.routers.htmx_views import _sanitize_hx_params
-
-        target, push = _sanitize_hx_params("#crm-tab-content", "/v2/customers", "/v2/vendors")
-        assert target == "#crm-tab-content"
-        assert push == "/v2/customers"
+        target, push = _sanitize_hx_params(hx_target, push_url_base, default_push)
+        assert target == expected_target
+        assert push == expected_push
 
 
 class TestV2PageRequisitionsPath:

--- a/tests/test_htmx_views_nightly5.py
+++ b/tests/test_htmx_views_nightly5.py
@@ -16,6 +16,7 @@ os.environ["TESTING"] = "1"
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -531,25 +532,17 @@ class TestAddOfferstoDraftQuote:
 
 
 class TestEmailReply:
-    def test_missing_to_returns_400(self, client: TestClient):
-        """Missing 'to' field → 400."""
-        resp = client.post(
-            "/v2/partials/emails/reply",
-            data={"body": "Hello there", "subject": "Test"},
-        )
-        assert resp.status_code == 400
-
-    def test_missing_body_returns_400(self, client: TestClient):
-        """Missing 'body' field → 400."""
-        resp = client.post(
-            "/v2/partials/emails/reply",
-            data={"to": "vendor@example.com", "subject": "Test"},
-        )
-        assert resp.status_code == 400
-
-    def test_both_missing_returns_400(self, client: TestClient):
-        """Both 'to' and 'body' missing → 400."""
-        resp = client.post("/v2/partials/emails/reply", data={"subject": "Test"})
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param({"body": "Hello there", "subject": "Test"}, id="missing_to"),
+            pytest.param({"to": "vendor@example.com", "subject": "Test"}, id="missing_body"),
+            pytest.param({"subject": "Test"}, id="both_missing"),
+        ],
+    )
+    def test_missing_required_field_returns_400(self, client: TestClient, data: dict):
+        """Missing 'to' and/or 'body' → 400."""
+        resp = client.post("/v2/partials/emails/reply", data=data)
         assert resp.status_code == 400
 
     def test_graph_api_connection_error_returns_200_with_error(self, client: TestClient):
@@ -645,35 +638,21 @@ class TestReviewResponse:
         )
         assert resp.status_code == 400
 
-    def test_valid_reviewed_status(
+    @pytest.mark.parametrize("status", ["reviewed", "rejected"])
+    def test_valid_status_returns_200(
         self,
         client: TestClient,
         db_session: Session,
         test_requisition: Requisition,
+        status: str,
     ):
-        """Valid 'reviewed' status → 200 and response card template."""
+        """Valid 'reviewed'/'rejected' status → 200 and response card template."""
         vr = _vendor_response(db_session, test_requisition)
         db_session.commit()
 
         resp = client.post(
             f"/v2/partials/requisitions/{test_requisition.id}/responses/{vr.id}/review",
-            data={"status": "reviewed"},
-        )
-        assert resp.status_code == 200
-
-    def test_valid_rejected_status(
-        self,
-        client: TestClient,
-        db_session: Session,
-        test_requisition: Requisition,
-    ):
-        """Valid 'rejected' status → 200."""
-        vr = _vendor_response(db_session, test_requisition)
-        db_session.commit()
-
-        resp = client.post(
-            f"/v2/partials/requisitions/{test_requisition.id}/responses/{vr.id}/review",
-            data={"status": "rejected"},
+            data={"status": status},
         )
         assert resp.status_code == 200
 

--- a/tests/test_htmx_views_nightly8.py
+++ b/tests/test_htmx_views_nightly8.py
@@ -13,6 +13,7 @@ import os
 import uuid
 from datetime import datetime, timezone
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -239,32 +240,24 @@ class TestBulkActionAssign:
 class TestRequisitionCreateWithParts:
     """Covers lines 1022, 1052-1072 (create req with parts text)."""
 
-    def test_create_with_parts_text(self, client: TestClient, db_session: Session, test_user: User):
-        resp = client.post(
-            "/v2/partials/requisitions/create",
-            data={
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {
                 "name": "N8-CREATE-01",
                 "customer_name": "Acme",
                 "parts_text": "LM317T, 500\nTL431, 200\n",
             },
-        )
-        assert resp.status_code == 200
-
-    def test_create_with_invalid_qty_in_parts(self, client: TestClient, db_session: Session, test_user: User):
-        resp = client.post(
-            "/v2/partials/requisitions/create",
-            data={
+            {
                 "name": "N8-CREATE-02",
                 "parts_text": "LM317T, notanumber",
             },
-        )
-        assert resp.status_code == 200
-
-    def test_create_minimal(self, client: TestClient, db_session: Session, test_user: User):
-        resp = client.post(
-            "/v2/partials/requisitions/create",
-            data={"name": "N8-CREATE-03"},
-        )
+            {"name": "N8-CREATE-03"},
+        ],
+        ids=["with_parts_text", "invalid_qty_in_parts", "minimal"],
+    )
+    def test_create(self, client: TestClient, db_session: Session, test_user: User, data):
+        resp = client.post("/v2/partials/requisitions/create", data=data)
         assert resp.status_code == 200
 
 
@@ -447,40 +440,30 @@ class TestEditOfferHtmx:
 class TestLogActivity:
     """Covers lines 2385-2404 (log activity for requisition)."""
 
-    def test_log_note_activity(self, client: TestClient, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        resp = client.post(
-            f"/v2/partials/requisitions/{req.id}/log-activity",
-            data={
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {
                 "activity_type": "note",
                 "notes": "Contacted vendor about availability.",
                 "vendor_name": "Arrow Electronics",
             },
-        )
-        assert resp.status_code == 200
-
-    def test_log_phone_call_activity(self, client: TestClient, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        resp = client.post(
-            f"/v2/partials/requisitions/{req.id}/log-activity",
-            data={
+            {
                 "activity_type": "phone_call",
                 "notes": "Called about LM317T",
                 "vendor_name": "Mouser",
             },
-        )
-        assert resp.status_code == 200
-
-    def test_log_email_activity(self, client: TestClient, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        resp = client.post(
-            f"/v2/partials/requisitions/{req.id}/log-activity",
-            data={
+            {
                 "activity_type": "email_sent",
                 "vendor_name": "DigiKey",
                 "contact_email": "rfq@digikey.com",
             },
-        )
+        ],
+        ids=["note", "phone_call", "email_sent"],
+    )
+    def test_log_activity(self, client: TestClient, db_session: Session, test_user: User, data):
+        req = _req(db_session, test_user)
+        resp = client.post(f"/v2/partials/requisitions/{req.id}/log-activity", data=data)
         assert resp.status_code == 200
 
     def test_log_activity_req_not_found(self, client: TestClient):
@@ -582,27 +565,17 @@ class TestSendFollowUpHtmx:
 class TestMarkResponseReviewed:
     """Covers lines 2803-2815 (mark vendor response as reviewed)."""
 
-    def test_mark_reviewed(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize("status", ["reviewed", "rejected"])
+    def test_mark_status(self, client: TestClient, db_session: Session, test_user: User, status):
         req = _req(db_session, test_user)
         vr = _vendor_response(db_session, req)
         resp = client.post(
             f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/review",
-            data={"status": "reviewed"},
+            data={"status": status},
         )
         assert resp.status_code == 200
         db_session.refresh(vr)
-        assert vr.status == "reviewed"
-
-    def test_mark_rejected(self, client: TestClient, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        vr = _vendor_response(db_session, req)
-        resp = client.post(
-            f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/review",
-            data={"status": "rejected"},
-        )
-        assert resp.status_code == 200
-        db_session.refresh(vr)
-        assert vr.status == "rejected"
+        assert vr.status == status
 
     def test_mark_invalid_status(self, client: TestClient, db_session: Session, test_user: User):
         req = _req(db_session, test_user)
@@ -809,20 +782,13 @@ class TestCreateQuoteFromOffers:
 class TestBuyPlansListPartial:
     """Covers lines 5891, 5898-5904 (buy plans list)."""
 
-    def test_buy_plans_list_empty(self, client: TestClient, db_session: Session):
-        resp = client.get("/v2/partials/buy-plans")
-        assert resp.status_code == 200
-
-    def test_buy_plans_list_with_status_filter(self, client: TestClient, db_session: Session, test_user: User):
-        resp = client.get("/v2/partials/buy-plans?status=pending")
-        assert resp.status_code == 200
-
-    def test_buy_plans_list_mine_filter(self, client: TestClient, db_session: Session, test_user: User):
-        resp = client.get("/v2/partials/buy-plans?mine=true")
-        assert resp.status_code == 200
-
-    def test_buy_plans_list_with_search(self, client: TestClient, db_session: Session, test_user: User):
-        resp = client.get("/v2/partials/buy-plans?q=SO-1234")
+    @pytest.mark.parametrize(
+        "query",
+        ["", "?status=pending", "?mine=true", "?q=SO-1234"],
+        ids=["empty", "status_filter", "mine_filter", "search"],
+    )
+    def test_buy_plans_list(self, client: TestClient, db_session: Session, query):
+        resp = client.get(f"/v2/partials/buy-plans{query}")
         assert resp.status_code == 200
 
 
@@ -995,35 +961,22 @@ class TestRfqPreparePanel:
 class TestRequisitionInlineSave:
     """Covers lines 1705, 1731, 1746-1747 (inline save for req fields)."""
 
-    def test_inline_save_urgency(self, client: TestClient, db_session: Session, test_user: User):
+    @pytest.mark.parametrize(
+        ("field", "value", "context"),
+        [
+            ("urgency", "hot", "row"),
+            ("deadline", "2026-06-30", "row"),
+            ("owner", None, "row"),  # value filled with test_user.id below
+            ("name", "Renamed Req", "header"),
+        ],
+        ids=["urgency", "deadline", "owner", "name"],
+    )
+    def test_inline_save_field(self, client: TestClient, db_session: Session, test_user: User, field, value, context):
         req = _req(db_session, test_user)
+        resolved_value = str(test_user.id) if field == "owner" else value
         resp = client.patch(
             f"/v2/partials/requisitions/{req.id}/inline",
-            data={"field": "urgency", "value": "hot", "context": "row"},
-        )
-        assert resp.status_code == 200
-
-    def test_inline_save_deadline(self, client: TestClient, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        resp = client.patch(
-            f"/v2/partials/requisitions/{req.id}/inline",
-            data={"field": "deadline", "value": "2026-06-30", "context": "row"},
-        )
-        assert resp.status_code == 200
-
-    def test_inline_save_owner(self, client: TestClient, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        resp = client.patch(
-            f"/v2/partials/requisitions/{req.id}/inline",
-            data={"field": "owner", "value": str(test_user.id), "context": "row"},
-        )
-        assert resp.status_code == 200
-
-    def test_inline_save_name(self, client: TestClient, db_session: Session, test_user: User):
-        req = _req(db_session, test_user)
-        resp = client.patch(
-            f"/v2/partials/requisitions/{req.id}/inline",
-            data={"field": "name", "value": "Renamed Req", "context": "header"},
+            data={"field": field, "value": resolved_value, "context": context},
         )
         assert resp.status_code == 200
 

--- a/tests/test_integration_requisitions.py
+++ b/tests/test_integration_requisitions.py
@@ -12,6 +12,18 @@ import pytest
 pytestmark = pytest.mark.slow
 
 
+def _create_req(client, **fields) -> int:
+    """POST a requisition and return its id."""
+    resp = client.post("/api/requisitions", json=fields)
+    assert resp.status_code == 200
+    return resp.json()["id"]
+
+
+def _add_requirements(client, req_id: int, items) -> dict:
+    """POST requirements to a requisition and return the parsed JSON response."""
+    return client.post(f"/api/requisitions/{req_id}/requirements", json=items).json()
+
+
 # -- Requisition CRUD -----------------------------------------------------
 
 
@@ -45,13 +57,7 @@ def test_list_requisitions_empty(client):
 
 
 def test_list_requisitions_after_create(client):
-    client.post(
-        "/api/requisitions",
-        json={
-            "name": "REQ-LIST-001",
-            "customer_name": "ListCo",
-        },
-    )
+    _create_req(client, name="REQ-LIST-001", customer_name="ListCo")
     resp = client.get("/api/requisitions")
     assert resp.status_code == 200
     names = [r["name"] for r in resp.json()["requisitions"]]
@@ -59,20 +65,8 @@ def test_list_requisitions_after_create(client):
 
 
 def test_list_requisitions_search_filter(client):
-    client.post(
-        "/api/requisitions",
-        json={
-            "name": "REQ-ALPHA",
-            "customer_name": "Alpha Inc",
-        },
-    )
-    client.post(
-        "/api/requisitions",
-        json={
-            "name": "REQ-BETA",
-            "customer_name": "Beta LLC",
-        },
-    )
+    _create_req(client, name="REQ-ALPHA", customer_name="Alpha Inc")
+    _create_req(client, name="REQ-BETA", customer_name="Beta LLC")
     resp = client.get("/api/requisitions?q=ALPHA")
     assert resp.status_code == 200
     names = [r["name"] for r in resp.json()["requisitions"]]
@@ -80,14 +74,7 @@ def test_list_requisitions_search_filter(client):
 
 
 def test_archive_requisition(client):
-    create = client.post(
-        "/api/requisitions",
-        json={
-            "name": "REQ-ARCH",
-            "customer_name": "ArchCo",
-        },
-    )
-    req_id = create.json()["id"]
+    req_id = _create_req(client, name="REQ-ARCH", customer_name="ArchCo")
     resp = client.put(f"/api/requisitions/{req_id}/archive")
     assert resp.status_code == 200
     assert resp.json()["status"] == "archived"
@@ -105,8 +92,7 @@ def test_archive_nonexistent(client):
 
 
 def test_add_requirement(client):
-    create = client.post("/api/requisitions", json={"name": "REQ-ITEMS"})
-    req_id = create.json()["id"]
+    req_id = _create_req(client, name="REQ-ITEMS")
     # Endpoint expects a list or single dict (not {"items": [...]})
     resp = client.post(
         f"/api/requisitions/{req_id}/requirements",
@@ -119,8 +105,7 @@ def test_add_requirement(client):
 
 
 def test_add_multiple_requirements(client):
-    create = client.post("/api/requisitions", json={"name": "REQ-MULTI"})
-    req_id = create.json()["id"]
+    req_id = _create_req(client, name="REQ-MULTI")
     resp = client.post(
         f"/api/requisitions/{req_id}/requirements",
         json=[
@@ -134,8 +119,7 @@ def test_add_multiple_requirements(client):
 
 
 def test_add_requirement_skips_blank_mpn(client):
-    create = client.post("/api/requisitions", json={"name": "REQ-BLANK"})
-    req_id = create.json()["id"]
+    req_id = _create_req(client, name="REQ-BLANK")
     resp = client.post(
         f"/api/requisitions/{req_id}/requirements",
         json=[
@@ -149,13 +133,11 @@ def test_add_requirement_skips_blank_mpn(client):
 
 
 def test_list_requirements(client):
-    create = client.post("/api/requisitions", json={"name": "REQ-LISTREQ"})
-    req_id = create.json()["id"]
-    client.post(
-        f"/api/requisitions/{req_id}/requirements",
-        json=[
-            {"primary_mpn": "AD8045", "manufacturer": "ADI", "target_qty": 50},
-        ],
+    req_id = _create_req(client, name="REQ-LISTREQ")
+    _add_requirements(
+        client,
+        req_id,
+        [{"primary_mpn": "AD8045", "manufacturer": "ADI", "target_qty": 50}],
     )
     resp = client.get(f"/api/requisitions/{req_id}/requirements")
     assert resp.status_code == 200
@@ -165,14 +147,12 @@ def test_list_requirements(client):
 
 
 def test_delete_requirement(client):
-    create = client.post("/api/requisitions", json={"name": "REQ-DEL"})
-    req_id = create.json()["id"]
-    items = client.post(
-        f"/api/requisitions/{req_id}/requirements",
-        json=[
-            {"primary_mpn": "TMP123", "manufacturer": "TI", "target_qty": 10},
-        ],
-    ).json()
+    req_id = _create_req(client, name="REQ-DEL")
+    items = _add_requirements(
+        client,
+        req_id,
+        [{"primary_mpn": "TMP123", "manufacturer": "TI", "target_qty": 10}],
+    )
     item_id = items["created"][0]["id"]
 
     resp = client.delete(f"/api/requirements/{item_id}")
@@ -183,14 +163,12 @@ def test_delete_requirement(client):
 
 
 def test_update_requirement(client):
-    create = client.post("/api/requisitions", json={"name": "REQ-UPD"})
-    req_id = create.json()["id"]
-    items = client.post(
-        f"/api/requisitions/{req_id}/requirements",
-        json=[
-            {"primary_mpn": "OLD-MPN", "manufacturer": "TI", "target_qty": 10},
-        ],
-    ).json()
+    req_id = _create_req(client, name="REQ-UPD")
+    items = _add_requirements(
+        client,
+        req_id,
+        [{"primary_mpn": "OLD-MPN", "manufacturer": "TI", "target_qty": 10}],
+    )
     item_id = items["created"][0]["id"]
 
     resp = client.put(
@@ -215,14 +193,7 @@ def test_update_requirement(client):
 
 def test_get_saved_sightings_empty(client):
     """Req with no sightings returns empty dict."""
-    resp = client.post(
-        "/api/requisitions",
-        json={
-            "name": "REQ-SIGHT-EMPTY",
-            "customer_name": "Test",
-        },
-    )
-    req_id = resp.json()["id"]
+    req_id = _create_req(client, name="REQ-SIGHT-EMPTY", customer_name="Test")
     resp = client.get(f"/api/requisitions/{req_id}/sightings")
     assert resp.status_code == 200
     assert resp.json() == {}
@@ -232,21 +203,8 @@ def test_get_saved_sightings_returns_data(client, db_session):
     """Sightings saved in DB are returned grouped by requirement."""
     from app.models import Sighting
 
-    resp = client.post(
-        "/api/requisitions",
-        json={
-            "name": "REQ-SIGHT-DATA",
-            "customer_name": "SightCo",
-        },
-    )
-    req_id = resp.json()["id"]
-    client.post(
-        f"/api/requisitions/{req_id}/requirements",
-        json={
-            "primary_mpn": "LM358N",
-            "manufacturer": "TI",
-        },
-    )
+    req_id = _create_req(client, name="REQ-SIGHT-DATA", customer_name="SightCo")
+    _add_requirements(client, req_id, {"primary_mpn": "LM358N", "manufacturer": "TI"})
     # Get the requirement ID from the list endpoint
     reqs = client.get(f"/api/requisitions/{req_id}/requirements").json()
     item_id = reqs[0]["id"]

--- a/tests/test_jobs_health.py
+++ b/tests/test_jobs_health.py
@@ -39,36 +39,28 @@ def _clear_scheduler_jobs():
         job.remove()
 
 
-# ── _job_health_ping() ────────────────────────────────────────────────
+# ── _job_health_ping() / _job_health_deep() ───────────────────────────
 
 
-def test_job_health_ping():
-    """_job_health_ping delegates to run_health_checks('ping')."""
+@pytest.mark.parametrize(
+    ("job_name", "check_type", "result"),
+    [
+        ("_job_health_ping", "ping", {"total": 3, "passed": 3, "failed": 0}),
+        ("_job_health_deep", "deep", {"total": 3, "passed": 2, "failed": 1}),
+    ],
+)
+def test_job_health_delegates_to_run_health_checks(job_name, check_type, result):
+    """Health jobs delegate to run_health_checks(check_type)."""
     with patch(
         "app.services.health_monitor.run_health_checks",
         new_callable=AsyncMock,
-        return_value={"total": 3, "passed": 3, "failed": 0},
+        return_value=result,
     ) as mock_check:
-        from app.jobs.health_jobs import _job_health_ping
+        import app.jobs.health_jobs as health_jobs
 
-        asyncio.run(_job_health_ping())
-        mock_check.assert_awaited_once_with("ping")
-
-
-# ── _job_health_deep() ────────────────────────────────────────────────
-
-
-def test_job_health_deep():
-    """_job_health_deep delegates to run_health_checks('deep')."""
-    with patch(
-        "app.services.health_monitor.run_health_checks",
-        new_callable=AsyncMock,
-        return_value={"total": 3, "passed": 2, "failed": 1},
-    ) as mock_check:
-        from app.jobs.health_jobs import _job_health_deep
-
-        asyncio.run(_job_health_deep())
-        mock_check.assert_awaited_once_with("deep")
+        job = getattr(health_jobs, job_name)
+        asyncio.run(job())
+        mock_check.assert_awaited_once_with(check_type)
 
 
 # ── _job_cleanup_usage_log() ──────────────────────────────────────────

--- a/tests/test_jobs_maintenance.py
+++ b/tests/test_jobs_maintenance.py
@@ -110,35 +110,22 @@ def test_reset_connector_errors_exception(scheduler_db):
 # ── _job_auto_attribute_activities() ──────────────────────────────────
 
 
-def test_auto_attribute_activities_success(scheduler_db):
-    """_job_auto_attribute_activities happy path with matches."""
-    mock_attribution = MagicMock(
-        return_value={
-            "rule_matched": 5,
-            "ai_matched": 3,
-            "auto_dismissed": 1,
-        }
-    )
+@pytest.mark.parametrize(
+    "report",
+    [
+        pytest.param({"rule_matched": 5, "ai_matched": 3, "auto_dismissed": 1}, id="with_matches"),
+        pytest.param({"rule_matched": 0, "ai_matched": 0, "auto_dismissed": 0}, id="no_matches"),
+    ],
+)
+def test_auto_attribute_activities_success(scheduler_db, report):
+    """_job_auto_attribute_activities runs the service and exercises both the match and
+    no-match logging branches."""
+    mock_attribution = MagicMock(return_value=report)
     with patch("app.services.auto_attribution_service.run_auto_attribution", mock_attribution):
         from app.jobs.maintenance_jobs import _job_auto_attribute_activities
 
         asyncio.run(_job_auto_attribute_activities())
     mock_attribution.assert_called_once()
-
-
-def test_auto_attribute_activities_no_matches(scheduler_db):
-    """_job_auto_attribute_activities no matches."""
-    mock_attribution = MagicMock(
-        return_value={
-            "rule_matched": 0,
-            "ai_matched": 0,
-            "auto_dismissed": 0,
-        }
-    )
-    with patch("app.services.auto_attribution_service.run_auto_attribution", mock_attribution):
-        from app.jobs.maintenance_jobs import _job_auto_attribute_activities
-
-        asyncio.run(_job_auto_attribute_activities())
 
 
 def test_auto_attribute_activities_error(scheduler_db):
@@ -154,33 +141,22 @@ def test_auto_attribute_activities_error(scheduler_db):
 # ── _job_auto_dedup() ─────────────────────────────────────────────────
 
 
-def test_auto_dedup_success(scheduler_db):
-    """_job_auto_dedup happy path with merges."""
-    mock_dedup = MagicMock(
-        return_value={
-            "vendors_merged": 2,
-            "companies_merged": 1,
-        }
-    )
+@pytest.mark.parametrize(
+    "report",
+    [
+        pytest.param({"vendors_merged": 2, "companies_merged": 1}, id="with_merges"),
+        pytest.param({"vendors_merged": 0, "companies_merged": 0}, id="no_merges"),
+    ],
+)
+def test_auto_dedup_success(scheduler_db, report):
+    """_job_auto_dedup runs the service and exercises both the merge and no-merge
+    logging branches."""
+    mock_dedup = MagicMock(return_value=report)
     with patch("app.services.auto_dedup_service.run_auto_dedup", mock_dedup):
         from app.jobs.maintenance_jobs import _job_auto_dedup
 
         asyncio.run(_job_auto_dedup())
     mock_dedup.assert_called_once()
-
-
-def test_auto_dedup_no_merges(scheduler_db):
-    """_job_auto_dedup no merges."""
-    mock_dedup = MagicMock(
-        return_value={
-            "vendors_merged": 0,
-            "companies_merged": 0,
-        }
-    )
-    with patch("app.services.auto_dedup_service.run_auto_dedup", mock_dedup):
-        from app.jobs.maintenance_jobs import _job_auto_dedup
-
-        asyncio.run(_job_auto_dedup())
 
 
 def test_auto_dedup_error(scheduler_db):

--- a/tests/test_knowledge_jobs_coverage.py
+++ b/tests/test_knowledge_jobs_coverage.py
@@ -10,6 +10,7 @@ import os
 
 os.environ["TESTING"] = "1"
 
+from contextlib import ExitStack
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,6 +19,26 @@ from sqlalchemy.orm import Session
 
 from app.models import User
 from app.models.sourcing import Requisition
+
+# The five knowledge_service insight generators _job_refresh_insights calls.
+_INSIGHT_GENERATORS = (
+    "generate_insights",
+    "generate_pipeline_insights",
+    "generate_vendor_insights",
+    "generate_company_insights",
+    "generate_mpn_insights",
+)
+
+
+def _patch_insight_generators(stack: ExitStack, **overrides):
+    """Patch every knowledge_service insight generator on the given ExitStack.
+
+    Each generator defaults to an AsyncMock returning []. Pass a generator name as a
+    keyword (e.g. generate_insights=mock) to override one with a specific mock.
+    """
+    for name in _INSIGHT_GENERATORS:
+        mock = overrides.get(name, AsyncMock(return_value=[]))
+        stack.enter_context(patch(f"app.services.knowledge_service.{name}", new=mock))
 
 
 @pytest.fixture()
@@ -135,19 +156,10 @@ class TestJobRefreshInsights:
         from app.jobs.knowledge_jobs import _job_refresh_insights
 
         mock_session = _make_mock_session()
-        with patch("app.database.SessionLocal", return_value=mock_session):
-            with patch("app.services.knowledge_service.generate_insights", new=AsyncMock(return_value=[])):
-                with patch("app.services.knowledge_service.generate_pipeline_insights", new=AsyncMock(return_value=[])):
-                    with patch(
-                        "app.services.knowledge_service.generate_vendor_insights", new=AsyncMock(return_value=[])
-                    ):
-                        with patch(
-                            "app.services.knowledge_service.generate_company_insights", new=AsyncMock(return_value=[])
-                        ):
-                            with patch(
-                                "app.services.knowledge_service.generate_mpn_insights", new=AsyncMock(return_value=[])
-                            ):
-                                await _job_refresh_insights()
+        with ExitStack() as stack:
+            stack.enter_context(patch("app.database.SessionLocal", return_value=mock_session))
+            _patch_insight_generators(stack)
+            await _job_refresh_insights()
 
         mock_session.close.assert_called_once()
 
@@ -158,19 +170,10 @@ class TestJobRefreshInsights:
         mock_generate = AsyncMock(return_value=[MagicMock()])
         mock_session = _make_mock_session(req_ids=[1, 2, 3])
 
-        with patch("app.database.SessionLocal", return_value=mock_session):
-            with patch("app.services.knowledge_service.generate_insights", new=mock_generate):
-                with patch("app.services.knowledge_service.generate_pipeline_insights", new=AsyncMock(return_value=[])):
-                    with patch(
-                        "app.services.knowledge_service.generate_vendor_insights", new=AsyncMock(return_value=[])
-                    ):
-                        with patch(
-                            "app.services.knowledge_service.generate_company_insights", new=AsyncMock(return_value=[])
-                        ):
-                            with patch(
-                                "app.services.knowledge_service.generate_mpn_insights", new=AsyncMock(return_value=[])
-                            ):
-                                await _job_refresh_insights()
+        with ExitStack() as stack:
+            stack.enter_context(patch("app.database.SessionLocal", return_value=mock_session))
+            _patch_insight_generators(stack, generate_insights=mock_generate)
+            await _job_refresh_insights()
 
         assert mock_generate.call_count == 3
 
@@ -181,41 +184,23 @@ class TestJobRefreshInsights:
         mock_generate = AsyncMock(side_effect=Exception("AI failed"))
         mock_session = _make_mock_session(req_ids=[1])
 
-        with patch("app.database.SessionLocal", return_value=mock_session):
-            with patch("app.services.knowledge_service.generate_insights", new=mock_generate):
-                with patch("app.services.knowledge_service.generate_pipeline_insights", new=AsyncMock(return_value=[])):
-                    with patch(
-                        "app.services.knowledge_service.generate_vendor_insights", new=AsyncMock(return_value=[])
-                    ):
-                        with patch(
-                            "app.services.knowledge_service.generate_company_insights", new=AsyncMock(return_value=[])
-                        ):
-                            with patch(
-                                "app.services.knowledge_service.generate_mpn_insights", new=AsyncMock(return_value=[])
-                            ):
-                                await _job_refresh_insights()  # Should not raise
+        with ExitStack() as stack:
+            stack.enter_context(patch("app.database.SessionLocal", return_value=mock_session))
+            _patch_insight_generators(stack, generate_insights=mock_generate)
+            await _job_refresh_insights()  # Should not raise
 
     async def test_refresh_pipeline_exception_continues(self):
         """If pipeline insights fail, rest of job continues."""
         from app.jobs.knowledge_jobs import _job_refresh_insights
 
         mock_session = _make_mock_session()
-        with patch("app.database.SessionLocal", return_value=mock_session):
-            with patch("app.services.knowledge_service.generate_insights", new=AsyncMock(return_value=[])):
-                with patch(
-                    "app.services.knowledge_service.generate_pipeline_insights",
-                    new=AsyncMock(side_effect=Exception("pipeline fail")),
-                ):
-                    with patch(
-                        "app.services.knowledge_service.generate_vendor_insights", new=AsyncMock(return_value=[])
-                    ):
-                        with patch(
-                            "app.services.knowledge_service.generate_company_insights", new=AsyncMock(return_value=[])
-                        ):
-                            with patch(
-                                "app.services.knowledge_service.generate_mpn_insights", new=AsyncMock(return_value=[])
-                            ):
-                                await _job_refresh_insights()  # Should not raise
+        with ExitStack() as stack:
+            stack.enter_context(patch("app.database.SessionLocal", return_value=mock_session))
+            _patch_insight_generators(
+                stack,
+                generate_pipeline_insights=AsyncMock(side_effect=Exception("pipeline fail")),
+            )
+            await _job_refresh_insights()  # Should not raise
 
     async def test_refresh_insights_db_error_logs_and_continues(self):
         """DB errors within each section are caught and logged; job completes."""
@@ -239,16 +224,9 @@ class TestJobRefreshInsights:
         mock_vendor = AsyncMock(return_value=[MagicMock()])
         mock_session = _make_mock_session(vendor_ids=[10, 20])
 
-        with patch("app.database.SessionLocal", return_value=mock_session):
-            with patch("app.services.knowledge_service.generate_insights", new=AsyncMock(return_value=[])):
-                with patch("app.services.knowledge_service.generate_pipeline_insights", new=AsyncMock(return_value=[])):
-                    with patch("app.services.knowledge_service.generate_vendor_insights", new=mock_vendor):
-                        with patch(
-                            "app.services.knowledge_service.generate_company_insights", new=AsyncMock(return_value=[])
-                        ):
-                            with patch(
-                                "app.services.knowledge_service.generate_mpn_insights", new=AsyncMock(return_value=[])
-                            ):
-                                await _job_refresh_insights()
+        with ExitStack() as stack:
+            stack.enter_context(patch("app.database.SessionLocal", return_value=mock_session))
+            _patch_insight_generators(stack, generate_vendor_insights=mock_vendor)
+            await _job_refresh_insights()
 
         assert mock_vendor.call_count == 2

--- a/tests/test_large_modules_coverage.py
+++ b/tests/test_large_modules_coverage.py
@@ -17,123 +17,99 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+
+def _make_user(db_session, *, email, azure_id, name):
+    """Create, persist, and refresh a buyer User for knowledge_service tests."""
+    from app.models import User
+
+    user = User(
+        email=email,
+        name=name,
+        role="buyer",
+        azure_id=azure_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # Part 1: app/jobs/email_jobs.py
 # ═══════════════════════════════════════════════════════════════════════
 
 
+def _register_and_get_job_ids(**enabled_flags):
+    """Register email jobs with all feature flags off except those overridden, return
+    job ids."""
+    from app.jobs.email_jobs import register_email_jobs
+
+    scheduler = MagicMock()
+    settings = MagicMock()
+    settings.contacts_sync_enabled = False
+    settings.activity_tracking_enabled = False
+    settings.ownership_sweep_enabled = False
+    settings.contact_scoring_enabled = False
+    settings.customer_enrichment_enabled = False
+    for name, value in enabled_flags.items():
+        setattr(settings, name, value)
+
+    register_email_jobs(scheduler, settings)
+
+    return [call.kwargs.get("id") or call[1].get("id") for call in scheduler.add_job.call_args_list]
+
+
 class TestRegisterEmailJobs:
     """Test register_email_jobs() — the scheduler registration function."""
 
-    def test_registers_always_on_jobs(self):
-        """Should always register contact_status_compute, email_health, calendar, sent
-        folders."""
-        from app.jobs.email_jobs import register_email_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.contacts_sync_enabled = False
-        settings.activity_tracking_enabled = False
-        settings.ownership_sweep_enabled = False
-        settings.contact_scoring_enabled = False
-        settings.customer_enrichment_enabled = False
-
-        register_email_jobs(scheduler, settings)
-
-        job_ids = [call.kwargs.get("id") or call[1].get("id") for call in scheduler.add_job.call_args_list]
-        assert "contact_status_compute" in job_ids
-        assert "email_health_update" in job_ids
-        assert "calendar_scan" in job_ids
-        assert "scan_sent_folders" in job_ids
-        # These should NOT be registered
-        assert "contacts_sync" not in job_ids
-        assert "ownership_sweep" not in job_ids
-        assert "contact_scoring" not in job_ids
-        assert "email_reverification" not in job_ids
-
-    def test_registers_contacts_sync_when_enabled(self):
-        from app.jobs.email_jobs import register_email_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.contacts_sync_enabled = True
-        settings.activity_tracking_enabled = False
-        settings.ownership_sweep_enabled = False
-        settings.contact_scoring_enabled = False
-        settings.customer_enrichment_enabled = False
-
-        register_email_jobs(scheduler, settings)
-
-        job_ids = [call.kwargs.get("id") or call[1].get("id") for call in scheduler.add_job.call_args_list]
-        assert "contacts_sync" in job_ids
-
-    def test_registers_ownership_when_both_enabled(self):
-        from app.jobs.email_jobs import register_email_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.contacts_sync_enabled = False
-        settings.activity_tracking_enabled = True
-        settings.ownership_sweep_enabled = True
-        settings.contact_scoring_enabled = False
-        settings.customer_enrichment_enabled = False
-
-        register_email_jobs(scheduler, settings)
-
-        job_ids = [call.kwargs.get("id") or call[1].get("id") for call in scheduler.add_job.call_args_list]
-        assert "ownership_sweep" in job_ids
-        assert "site_ownership_sweep" in job_ids
-
-    def test_registers_contact_scoring_when_enabled(self):
-        from app.jobs.email_jobs import register_email_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.contacts_sync_enabled = False
-        settings.activity_tracking_enabled = False
-        settings.ownership_sweep_enabled = False
-        settings.contact_scoring_enabled = True
-        settings.customer_enrichment_enabled = False
-
-        register_email_jobs(scheduler, settings)
-
-        job_ids = [call.kwargs.get("id") or call[1].get("id") for call in scheduler.add_job.call_args_list]
-        assert "contact_scoring" in job_ids
-
-    def test_registers_reverification_when_enrichment_enabled(self):
-        from app.jobs.email_jobs import register_email_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.contacts_sync_enabled = False
-        settings.activity_tracking_enabled = False
-        settings.ownership_sweep_enabled = False
-        settings.contact_scoring_enabled = False
-        settings.customer_enrichment_enabled = True
-
-        register_email_jobs(scheduler, settings)
-
-        job_ids = [call.kwargs.get("id") or call[1].get("id") for call in scheduler.add_job.call_args_list]
-        assert "email_reverification" in job_ids
-
-    def test_activity_tracking_without_ownership(self):
-        """When activity_tracking is on but ownership_sweep is off, no ownership jobs
-        registered."""
-        from app.jobs.email_jobs import register_email_jobs
-
-        scheduler = MagicMock()
-        settings = MagicMock()
-        settings.contacts_sync_enabled = False
-        settings.activity_tracking_enabled = True
-        settings.ownership_sweep_enabled = False
-        settings.contact_scoring_enabled = False
-        settings.customer_enrichment_enabled = False
-
-        register_email_jobs(scheduler, settings)
-
-        job_ids = [call.kwargs.get("id") or call[1].get("id") for call in scheduler.add_job.call_args_list]
-        assert "ownership_sweep" not in job_ids
-        assert "site_ownership_sweep" not in job_ids
+    @pytest.mark.parametrize(
+        ("flags", "expected_present", "expected_absent"),
+        [
+            pytest.param(
+                {},
+                ["contact_status_compute", "email_health_update", "calendar_scan", "scan_sent_folders"],
+                ["contacts_sync", "ownership_sweep", "contact_scoring", "email_reverification"],
+                id="always_on_jobs",
+            ),
+            pytest.param(
+                {"contacts_sync_enabled": True},
+                ["contacts_sync"],
+                [],
+                id="contacts_sync_when_enabled",
+            ),
+            pytest.param(
+                {"activity_tracking_enabled": True, "ownership_sweep_enabled": True},
+                ["ownership_sweep", "site_ownership_sweep"],
+                [],
+                id="ownership_when_both_enabled",
+            ),
+            pytest.param(
+                {"contact_scoring_enabled": True},
+                ["contact_scoring"],
+                [],
+                id="contact_scoring_when_enabled",
+            ),
+            pytest.param(
+                {"customer_enrichment_enabled": True},
+                ["email_reverification"],
+                [],
+                id="reverification_when_enrichment_enabled",
+            ),
+            pytest.param(
+                {"activity_tracking_enabled": True, "ownership_sweep_enabled": False},
+                [],
+                ["ownership_sweep", "site_ownership_sweep"],
+                id="activity_tracking_without_ownership",
+            ),
+        ],
+    )
+    def test_job_registration(self, flags, expected_present, expected_absent):
+        job_ids = _register_and_get_job_ids(**flags)
+        for job_id in expected_present:
+            assert job_id in job_ids
+        for job_id in expected_absent:
+            assert job_id not in job_ids
 
 
 class TestDetectAttachments:
@@ -785,25 +761,20 @@ class TestScanOutboundRfqs:
 class TestIsExpired:
     """Test the _is_expired() helper."""
 
-    def test_none_not_expired(self):
+    @pytest.mark.parametrize(
+        ("offset", "expected"),
+        [
+            pytest.param(None, False, id="none_not_expired"),
+            pytest.param(timedelta(days=30), False, id="future_not_expired"),
+            pytest.param(timedelta(days=-1), True, id="past_is_expired"),
+        ],
+    )
+    def test_relative_to_now(self, offset, expected):
         from app.services.knowledge_service import _is_expired
 
         now = datetime.now(timezone.utc)
-        assert _is_expired(None, now) is False
-
-    def test_future_not_expired(self):
-        from app.services.knowledge_service import _is_expired
-
-        now = datetime.now(timezone.utc)
-        future = now + timedelta(days=30)
-        assert _is_expired(future, now) is False
-
-    def test_past_is_expired(self):
-        from app.services.knowledge_service import _is_expired
-
-        now = datetime.now(timezone.utc)
-        past = now - timedelta(days=1)
-        assert _is_expired(past, now) is True
+        value = None if offset is None else now + offset
+        assert _is_expired(value, now) is expected
 
     def test_naive_datetime_handled(self):
         from app.services.knowledge_service import _is_expired
@@ -817,20 +788,9 @@ class TestCreateEntry:
     """Test create_entry() — knowledge entry creation."""
 
     def test_creates_entry_and_commits(self, db_session):
-        # Need a user first
-        from app.models import User
         from app.services.knowledge_service import create_entry
 
-        user = User(
-            email="test@test.com",
-            name="Test",
-            role="buyer",
-            azure_id="az-001",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test@test.com", azure_id="az-001", name="Test")
 
         entry = create_entry(
             db_session,
@@ -849,19 +809,9 @@ class TestCreateEntry:
         assert entry.created_by == user.id
 
     def test_creates_entry_without_commit(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry
 
-        user = User(
-            email="test2@test.com",
-            name="Test2",
-            role="buyer",
-            azure_id="az-002",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test2@test.com", azure_id="az-002", name="Test2")
 
         entry = create_entry(
             db_session,
@@ -874,19 +824,9 @@ class TestCreateEntry:
         assert entry.id is not None
 
     def test_creates_entry_with_entity_linkage(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry
 
-        user = User(
-            email="test3@test.com",
-            name="Test3",
-            role="buyer",
-            azure_id="az-003",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test3@test.com", azure_id="az-003", name="Test3")
 
         entry = create_entry(
             db_session,
@@ -905,19 +845,9 @@ class TestGetEntries:
     """Test get_entries() — flexible query."""
 
     def test_returns_entries_filtered_by_type(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, get_entries
 
-        user = User(
-            email="test4@test.com",
-            name="Test4",
-            role="buyer",
-            azure_id="az-004",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test4@test.com", azure_id="az-004", name="Test4")
 
         create_entry(db_session, user_id=user.id, entry_type="fact", content="A fact")
         create_entry(db_session, user_id=user.id, entry_type="note", content="A note")
@@ -927,19 +857,9 @@ class TestGetEntries:
         assert facts[0].entry_type == "fact"
 
     def test_excludes_expired_when_requested(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, get_entries
 
-        user = User(
-            email="test5@test.com",
-            name="Test5",
-            role="buyer",
-            azure_id="az-005",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test5@test.com", azure_id="az-005", name="Test5")
 
         # Create an expired entry
         create_entry(
@@ -966,19 +886,9 @@ class TestGetEntries:
         assert active_entries[0].content == "Fresh fact"
 
     def test_excludes_answers_from_listing(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, get_entries
 
-        user = User(
-            email="test6@test.com",
-            name="Test6",
-            role="buyer",
-            azure_id="az-006",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test6@test.com", azure_id="az-006", name="Test6")
 
         q = create_entry(db_session, user_id=user.id, entry_type="question", content="Q?")
         create_entry(db_session, user_id=user.id, entry_type="answer", content="A.", parent_id=q.id)
@@ -993,19 +903,9 @@ class TestGetEntry:
     """Test get_entry()."""
 
     def test_returns_entry_with_answers(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, get_entry
 
-        user = User(
-            email="test7@test.com",
-            name="Test7",
-            role="buyer",
-            azure_id="az-007",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test7@test.com", azure_id="az-007", name="Test7")
 
         q = create_entry(db_session, user_id=user.id, entry_type="question", content="Q?")
         create_entry(db_session, user_id=user.id, entry_type="answer", content="A.", parent_id=q.id)
@@ -1025,19 +925,9 @@ class TestUpdateEntry:
     """Test update_entry()."""
 
     def test_updates_content(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, update_entry
 
-        user = User(
-            email="test8@test.com",
-            name="Test8",
-            role="buyer",
-            azure_id="az-008",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test8@test.com", azure_id="az-008", name="Test8")
 
         entry = create_entry(db_session, user_id=user.id, entry_type="note", content="Original")
         updated = update_entry(db_session, entry.id, user.id, content="Updated")
@@ -1055,19 +945,9 @@ class TestDeleteEntry:
     """Test delete_entry()."""
 
     def test_deletes_entry(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, delete_entry, get_entry
 
-        user = User(
-            email="test9@test.com",
-            name="Test9",
-            role="buyer",
-            azure_id="az-009",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test9@test.com", azure_id="az-009", name="Test9")
 
         entry = create_entry(db_session, user_id=user.id, entry_type="note", content="To delete")
         assert delete_entry(db_session, entry.id, user.id) is True
@@ -1083,19 +963,9 @@ class TestPostQuestion:
     """Test post_question()."""
 
     def test_creates_question_entry(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import post_question
 
-        user = User(
-            email="test10@test.com",
-            name="Test10",
-            role="buyer",
-            azure_id="az-010",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test10@test.com", azure_id="az-010", name="Test10")
 
         q = post_question(
             db_session,
@@ -1114,19 +984,9 @@ class TestPostAnswer:
     """Test post_answer()."""
 
     def test_creates_answer_and_resolves_question(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import post_answer, post_question
 
-        user = User(
-            email="test11@test.com",
-            name="Test11",
-            role="buyer",
-            azure_id="az-011",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test11@test.com", azure_id="az-011", name="Test11")
 
         q = post_question(
             db_session,
@@ -1153,19 +1013,9 @@ class TestPostAnswer:
         assert q.is_resolved is True
 
     def test_returns_none_for_non_question(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, post_answer
 
-        user = User(
-            email="test12@test.com",
-            name="Test12",
-            role="buyer",
-            azure_id="az-012",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test12@test.com", azure_id="az-012", name="Test12")
 
         note = create_entry(db_session, user_id=user.id, entry_type="note", content="Just a note")
         answer = post_answer(db_session, user_id=user.id, question_id=note.id, content="A.")
@@ -1182,19 +1032,9 @@ class TestCaptureQuoteFact:
     """Test capture_quote_fact()."""
 
     def test_captures_price_facts(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import capture_quote_fact
 
-        user = User(
-            email="test13@test.com",
-            name="Test13",
-            role="buyer",
-            azure_id="az-013",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test13@test.com", azure_id="az-013", name="Test13")
 
         mock_quote = MagicMock()
         mock_quote.quote_number = "Q-001"
@@ -1231,19 +1071,9 @@ class TestCaptureOfferFact:
     """Test capture_offer_fact()."""
 
     def test_captures_offer_with_all_fields(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import capture_offer_fact
 
-        user = User(
-            email="test14@test.com",
-            name="Test14",
-            role="buyer",
-            azure_id="az-014",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test14@test.com", azure_id="az-014", name="Test14")
 
         mock_offer = MagicMock()
         mock_offer.mpn = "LM358N"
@@ -1329,19 +1159,10 @@ class TestBuildContext:
         assert build_context(db_session, requisition_id=99999) == ""
 
     def test_returns_context_with_direct_knowledge(self, db_session):
-        from app.models import Requisition, User
+        from app.models import Requisition
         from app.services.knowledge_service import build_context, create_entry
 
-        user = User(
-            email="test16@test.com",
-            name="Test16",
-            role="buyer",
-            azure_id="az-016",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test16@test.com", azure_id="az-016", name="Test16")
 
         req = Requisition(
             name="Test Req",
@@ -1378,19 +1199,10 @@ class TestGenerateInsights:
 
     @pytest.mark.asyncio
     async def test_generates_insights_from_claude(self, db_session):
-        from app.models import Requisition, User
+        from app.models import Requisition
         from app.services.knowledge_service import create_entry, generate_insights
 
-        user = User(
-            email="test17@test.com",
-            name="Test17",
-            role="buyer",
-            azure_id="az-017",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test17@test.com", azure_id="az-017", name="Test17")
 
         req = Requisition(
             name="Test Req 2",
@@ -1426,20 +1238,11 @@ class TestGenerateInsights:
 
     @pytest.mark.asyncio
     async def test_handles_claude_unavailable(self, db_session):
-        from app.models import Requisition, User
+        from app.models import Requisition
         from app.services.knowledge_service import create_entry, generate_insights
         from app.utils.claude_errors import ClaudeUnavailableError
 
-        user = User(
-            email="test18@test.com",
-            name="Test18",
-            role="buyer",
-            azure_id="az-018",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test18@test.com", azure_id="az-018", name="Test18")
 
         req = Requisition(
             name="Test Req 3",
@@ -1469,20 +1272,11 @@ class TestGenerateInsights:
 
     @pytest.mark.asyncio
     async def test_handles_claude_error(self, db_session):
-        from app.models import Requisition, User
+        from app.models import Requisition
         from app.services.knowledge_service import create_entry, generate_insights
         from app.utils.claude_errors import ClaudeError
 
-        user = User(
-            email="test19@test.com",
-            name="Test19",
-            role="buyer",
-            azure_id="az-019",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test19@test.com", azure_id="az-019", name="Test19")
 
         req = Requisition(
             name="Test Req 4",
@@ -1523,19 +1317,9 @@ class TestGenerateMpnInsights:
 
     @pytest.mark.asyncio
     async def test_generates_mpn_insights(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, generate_mpn_insights
 
-        user = User(
-            email="test20@test.com",
-            name="Test20",
-            role="buyer",
-            azure_id="az-020",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test20@test.com", azure_id="az-020", name="Test20")
 
         create_entry(
             db_session,
@@ -1595,19 +1379,10 @@ class TestGetCachedInsights:
     """Test cached insight getters."""
 
     def test_get_cached_insights(self, db_session):
-        from app.models import Requisition, User
+        from app.models import Requisition
         from app.services.knowledge_service import create_entry, get_cached_insights
 
-        user = User(
-            email="test21@test.com",
-            name="Test21",
-            role="buyer",
-            azure_id="az-021",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test21@test.com", azure_id="az-021", name="Test21")
 
         req = Requisition(
             name="Test Req 5",
@@ -1633,19 +1408,9 @@ class TestGetCachedInsights:
         assert cached[0].content == "Cached insight"
 
     def test_get_cached_mpn_insights(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, get_cached_mpn_insights
 
-        user = User(
-            email="test22@test.com",
-            name="Test22",
-            role="buyer",
-            azure_id="az-022",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test22@test.com", azure_id="az-022", name="Test22")
 
         create_entry(
             db_session,
@@ -1660,19 +1425,9 @@ class TestGetCachedInsights:
         assert len(cached) == 1
 
     def test_get_cached_pipeline_insights(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import create_entry, get_cached_pipeline_insights
 
-        user = User(
-            email="test23@test.com",
-            name="Test23",
-            role="buyer",
-            azure_id="az-023",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test23@test.com", azure_id="az-023", name="Test23")
 
         create_entry(
             db_session,
@@ -1708,19 +1463,9 @@ class TestBuildMpnContext:
         assert build_mpn_context(db_session, mpn="UNKNOWN-12345") == ""
 
     def test_includes_knowledge_entries(self, db_session):
-        from app.models import User
         from app.services.knowledge_service import build_mpn_context, create_entry
 
-        user = User(
-            email="test24@test.com",
-            name="Test24",
-            role="buyer",
-            azure_id="az-024",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test24@test.com", azure_id="az-024", name="Test24")
 
         create_entry(
             db_session,
@@ -1772,19 +1517,10 @@ class TestBuildPipelineContext:
         assert build_pipeline_context(db_session) == ""
 
     def test_includes_status_breakdown(self, db_session):
-        from app.models import Requisition, User
+        from app.models import Requisition
         from app.services.knowledge_service import build_pipeline_context
 
-        user = User(
-            email="test25@test.com",
-            name="Test25",
-            role="buyer",
-            azure_id="az-025",
-            created_at=datetime.now(timezone.utc),
-        )
-        db_session.add(user)
-        db_session.commit()
-        db_session.refresh(user)
+        user = _make_user(db_session, email="test25@test.com", azure_id="az-025", name="Test25")
 
         for status in ["active", "active", "closed"]:
             req = Requisition(

--- a/tests/test_m365_strengthen.py
+++ b/tests/test_m365_strengthen.py
@@ -238,143 +238,78 @@ def test_group_by_thread_empty():
 # ── test_detect_attachments ──────────────────────────────────────────────
 
 
-def test_detect_attachments_xlsx_flagged():
-    """An email with .xlsx attachment is flagged for mining pipeline."""
+_XLSX_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+@pytest.mark.parametrize(
+    "msg_id, attachments, expected_names",
+    [
+        pytest.param(
+            "msg-123",
+            [{"name": "stock_list.xlsx", "contentType": _XLSX_TYPE, "size": 45000, "isInline": False}],
+            ["stock_list.xlsx"],
+            id="xlsx_flagged",
+        ),
+        pytest.param(
+            "msg-456",
+            [{"name": "quote.pdf", "contentType": "application/pdf", "size": 120000, "isInline": False}],
+            ["quote.pdf"],
+            id="pdf_flagged",
+        ),
+        pytest.param(
+            "msg-789",
+            [{"name": "logo.png", "contentType": "image/png", "size": 5000, "isInline": True}],
+            [],
+            id="inline_image_excluded",
+        ),
+        pytest.param(
+            "msg-mixed",
+            [
+                {"name": "signature.jpg", "contentType": "image/jpeg", "size": 3000, "isInline": True},
+                {"name": "inventory.xlsx", "contentType": _XLSX_TYPE, "size": 80000, "isInline": False},
+            ],
+            ["inventory.xlsx"],
+            id="mixed_only_file_flagged",
+        ),
+    ],
+)
+def test_detect_attachments(msg_id, attachments, expected_names):
+    """File attachments (xlsx/pdf) are flagged; inline images are excluded."""
     mock_gc = AsyncMock()
-    mock_gc.get_json = AsyncMock(
-        return_value={
-            "value": [
-                {
-                    "name": "stock_list.xlsx",
-                    "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                    "size": 45000,
-                    "isInline": False,
-                },
-            ]
-        }
-    )
+    mock_gc.get_json = AsyncMock(return_value={"value": attachments})
 
     from app.jobs.email_jobs import detect_attachments
 
-    result = asyncio.get_event_loop().run_until_complete(detect_attachments(mock_gc, "msg-123"))
+    result = asyncio.get_event_loop().run_until_complete(detect_attachments(mock_gc, msg_id))
 
-    assert len(result) == 1
-    assert result[0]["name"] == "stock_list.xlsx"
-    assert result[0]["size"] == 45000
-
-
-def test_detect_attachments_pdf_flagged():
-    """An email with .pdf attachment is flagged."""
-    mock_gc = AsyncMock()
-    mock_gc.get_json = AsyncMock(
-        return_value={
-            "value": [
-                {
-                    "name": "quote.pdf",
-                    "contentType": "application/pdf",
-                    "size": 120000,
-                    "isInline": False,
-                },
-            ]
-        }
-    )
-
-    from app.jobs.email_jobs import detect_attachments
-
-    result = asyncio.get_event_loop().run_until_complete(detect_attachments(mock_gc, "msg-456"))
-
-    assert len(result) == 1
-    assert result[0]["name"] == "quote.pdf"
-
-
-def test_detect_attachments_inline_image_excluded():
-    """An inline image is NOT flagged as a file attachment."""
-    mock_gc = AsyncMock()
-    mock_gc.get_json = AsyncMock(
-        return_value={
-            "value": [
-                {
-                    "name": "logo.png",
-                    "contentType": "image/png",
-                    "size": 5000,
-                    "isInline": True,
-                },
-            ]
-        }
-    )
-
-    from app.jobs.email_jobs import detect_attachments
-
-    result = asyncio.get_event_loop().run_until_complete(detect_attachments(mock_gc, "msg-789"))
-
-    assert len(result) == 0
-
-
-def test_detect_attachments_mixed():
-    """Mixed inline image + file attachment: only file is flagged."""
-    mock_gc = AsyncMock()
-    mock_gc.get_json = AsyncMock(
-        return_value={
-            "value": [
-                {
-                    "name": "signature.jpg",
-                    "contentType": "image/jpeg",
-                    "size": 3000,
-                    "isInline": True,
-                },
-                {
-                    "name": "inventory.xlsx",
-                    "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                    "size": 80000,
-                    "isInline": False,
-                },
-            ]
-        }
-    )
-
-    from app.jobs.email_jobs import detect_attachments
-
-    result = asyncio.get_event_loop().run_until_complete(detect_attachments(mock_gc, "msg-mixed"))
-
-    assert len(result) == 1
-    assert result[0]["name"] == "inventory.xlsx"
+    assert len(result) == len(expected_names)
+    assert [r["name"] for r in result] == expected_names
+    # Sizes round-trip for flagged attachments
+    sizes_by_name = {a["name"]: a["size"] for a in attachments}
+    for r in result:
+        assert r["size"] == sizes_by_name[r["name"]]
 
 
 # ── test_retry_honors_retry_after ────────────────────────────────────────
 
 
-def test_retry_honors_retry_after():
-    """429 with Retry-After header: client uses max(backoff, Retry-After)."""
-    from app.utils.graph_client import _parse_retry_after
-
-    # Create a mock response with Retry-After header
-    mock_resp = MagicMock()
-    mock_resp.headers = {"Retry-After": "10"}
-
-    result = _parse_retry_after(mock_resp)
-    assert result == 10
-
-
-def test_retry_after_missing():
-    """Missing Retry-After returns None."""
+@pytest.mark.parametrize(
+    "headers, expected",
+    [
+        pytest.param({"Retry-After": "10"}, 10, id="honors_retry_after"),
+        pytest.param({}, None, id="missing"),
+        pytest.param({"Retry-After": "Sat, 01 Jan 2028 00:00:00 GMT"}, None, id="non_numeric"),
+    ],
+)
+def test_parse_retry_after(headers, expected):
+    """_parse_retry_after returns the numeric seconds, or None when absent/non-
+    numeric."""
     from app.utils.graph_client import _parse_retry_after
 
     mock_resp = MagicMock()
-    mock_resp.headers = {}
+    mock_resp.headers = headers
 
-    result = _parse_retry_after(mock_resp)
-    assert result is None
-
-
-def test_retry_after_non_numeric():
-    """Non-numeric Retry-After returns None."""
-    from app.utils.graph_client import _parse_retry_after
-
-    mock_resp = MagicMock()
-    mock_resp.headers = {"Retry-After": "Sat, 01 Jan 2028 00:00:00 GMT"}
-
-    result = _parse_retry_after(mock_resp)
-    assert result is None
+    assert _parse_retry_after(mock_resp) == expected
 
 
 # ── test_401_not_retried ─────────────────────────────────────────────────

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,10 +7,40 @@ Missing lines: 37-38, 45-53, 57-65, 117-120, 160-170, 191-195,
 
 import asyncio
 import os
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+
+
+@contextmanager
+def no_testing_env():
+    """Temporarily unset the TESTING env var, restoring it (to "1") on exit.
+
+    The lifespan/module-import branches under test only run when TESTING is unset.
+    """
+    original = os.environ.pop("TESTING", None)
+    try:
+        yield
+    finally:
+        os.environ["TESTING"] = original if original is not None else "1"
+
+
+def run_lifespan(mock_app):
+    """Run the app lifespan async context (enter + exit) on a fresh event loop."""
+    from app.main import lifespan
+
+    async def _run():
+        async with lifespan(mock_app):
+            pass
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
 
 # ── Lifespan: S1 secret key fail-fast (lines 37-38) ──────────────────
 
@@ -24,26 +54,19 @@ class TestLifespanSecretKey:
         from app.main import lifespan
 
         mock_app = MagicMock()
-        original = os.environ.pop("TESTING", None)
-        try:
-            with patch("app.main.settings") as mock_settings:
-                mock_settings.secret_key = "change-me-in-production"
-                mock_settings.sentry_dsn = ""
-                mock_settings.azure_client_id = "x"
-                mock_settings.azure_client_secret = "x"
-                mock_settings.azure_tenant_id = "x"
+        with no_testing_env(), patch("app.main.settings") as mock_settings:
+            mock_settings.secret_key = "change-me-in-production"
+            mock_settings.sentry_dsn = ""
+            mock_settings.azure_client_id = "x"
+            mock_settings.azure_client_secret = "x"
+            mock_settings.azure_tenant_id = "x"
 
-                loop = asyncio.new_event_loop()
-                try:
-                    with pytest.raises(RuntimeError, match="SESSION_SECRET or SECRET_KEY must be set"):
-                        loop.run_until_complete(lifespan(mock_app).__aenter__())
-                finally:
-                    loop.close()
-        finally:
-            if original is not None:
-                os.environ["TESTING"] = original
-            else:
-                os.environ["TESTING"] = "1"
+            loop = asyncio.new_event_loop()
+            try:
+                with pytest.raises(RuntimeError, match="SESSION_SECRET or SECRET_KEY must be set"):
+                    loop.run_until_complete(lifespan(mock_app).__aenter__())
+            finally:
+                loop.close()
 
 
 # ── Lifespan: S2 missing env var warnings (lines 45-53) ──────────────
@@ -54,86 +77,52 @@ class TestLifespanMissingEnvVars:
 
     def test_missing_azure_vars_logs_warning(self):
         """When TESTING is unset and Azure vars are missing, logs warning."""
-        from app.main import lifespan
-
         mock_app = MagicMock()
-        original = os.environ.pop("TESTING", None)
-        try:
-            with (
-                patch("app.main.settings") as mock_settings,
-                patch("app.startup.run_startup_migrations"),
-                patch("app.startup.seed_api_sources"),
-                patch("app.connector_status.log_connector_status", return_value={}),
-                patch("app.scheduler.configure_scheduler"),
-                patch("app.scheduler.scheduler") as mock_sched,
-                patch("app.http_client.close_clients", new_callable=AsyncMock),
-                patch("app.main.logger") as mock_logger,
-            ):
-                mock_settings.secret_key = "a-real-secret-key"
-                mock_settings.sentry_dsn = ""
-                mock_settings.azure_client_id = ""
-                mock_settings.azure_client_secret = ""
-                mock_settings.azure_tenant_id = ""
+        with (
+            no_testing_env(),
+            patch("app.main.settings") as mock_settings,
+            patch("app.startup.run_startup_migrations"),
+            patch("app.startup.seed_api_sources"),
+            patch("app.connector_status.log_connector_status", return_value={}),
+            patch("app.scheduler.configure_scheduler"),
+            patch("app.scheduler.scheduler"),
+            patch("app.http_client.close_clients", new_callable=AsyncMock),
+            patch("app.main.logger") as mock_logger,
+        ):
+            mock_settings.secret_key = "a-real-secret-key"
+            mock_settings.sentry_dsn = ""
+            mock_settings.azure_client_id = ""
+            mock_settings.azure_client_secret = ""
+            mock_settings.azure_tenant_id = ""
 
-                loop = asyncio.new_event_loop()
-                try:
+            run_lifespan(mock_app)
 
-                    async def run_lifespan():
-                        async with lifespan(mock_app) as _:
-                            pass
-
-                    loop.run_until_complete(run_lifespan())
-                finally:
-                    loop.close()
-
-                mock_logger.warning.assert_called()
-        finally:
-            if original is not None:
-                os.environ["TESTING"] = original
-            else:
-                os.environ["TESTING"] = "1"
+            mock_logger.warning.assert_called()
 
     def test_no_missing_azure_vars_no_warning(self):
         """When TESTING is unset and all Azure vars are present, no warning."""
-        from app.main import lifespan
-
         mock_app = MagicMock()
-        original = os.environ.pop("TESTING", None)
-        try:
-            with (
-                patch("app.main.settings") as mock_settings,
-                patch("app.startup.run_startup_migrations"),
-                patch("app.startup.seed_api_sources"),
-                patch("app.connector_status.log_connector_status", return_value={}),
-                patch("app.scheduler.configure_scheduler"),
-                patch("app.scheduler.scheduler") as mock_sched,
-                patch("app.http_client.close_clients", new_callable=AsyncMock),
-                patch("app.main.logger") as mock_logger,
-            ):
-                mock_settings.secret_key = "a-real-secret-key"
-                mock_settings.sentry_dsn = ""
-                mock_settings.azure_client_id = "cid"
-                mock_settings.azure_client_secret = "csecret"
-                mock_settings.azure_tenant_id = "tid"
+        with (
+            no_testing_env(),
+            patch("app.main.settings") as mock_settings,
+            patch("app.startup.run_startup_migrations"),
+            patch("app.startup.seed_api_sources"),
+            patch("app.connector_status.log_connector_status", return_value={}),
+            patch("app.scheduler.configure_scheduler"),
+            patch("app.scheduler.scheduler"),
+            patch("app.http_client.close_clients", new_callable=AsyncMock),
+            patch("app.main.logger") as mock_logger,
+        ):
+            mock_settings.secret_key = "a-real-secret-key"
+            mock_settings.sentry_dsn = ""
+            mock_settings.azure_client_id = "cid"
+            mock_settings.azure_client_secret = "csecret"
+            mock_settings.azure_tenant_id = "tid"
 
-                loop = asyncio.new_event_loop()
-                try:
+            run_lifespan(mock_app)
 
-                    async def run_lifespan():
-                        async with lifespan(mock_app) as _:
-                            pass
-
-                    loop.run_until_complete(run_lifespan())
-                finally:
-                    loop.close()
-
-                for c in mock_logger.warning.call_args_list:
-                    assert "Missing env vars" not in str(c)
-        finally:
-            if original is not None:
-                os.environ["TESTING"] = original
-            else:
-                os.environ["TESTING"] = "1"
+            for c in mock_logger.warning.call_args_list:
+                assert "Missing env vars" not in str(c)
 
 
 # ── Lifespan: Sentry init (lines 57-65) ──────────────────────────────
@@ -142,165 +131,85 @@ class TestLifespanMissingEnvVars:
 class TestLifespanSentry:
     """Cover lines 57-65: Sentry SDK initialization when DSN is set."""
 
+    @staticmethod
+    @contextmanager
+    def _sentry_lifespan(*, sentry_dsn, app_url):
+        """Run lifespan with TESTING unset and a Sentry DSN set, yielding the init
+        mock."""
+        mock_app = MagicMock()
+        with (
+            no_testing_env(),
+            patch("app.main.settings") as mock_settings,
+            patch("app.startup.run_startup_migrations"),
+            patch("app.startup.seed_api_sources"),
+            patch("app.connector_status.log_connector_status", return_value={}),
+            patch("app.scheduler.configure_scheduler"),
+            patch("app.scheduler.scheduler"),
+            patch("app.http_client.close_clients", new_callable=AsyncMock),
+            patch("sentry_sdk.init") as mock_sentry_init,
+        ):
+            mock_settings.secret_key = "a-real-secret-key"
+            mock_settings.sentry_dsn = sentry_dsn
+            mock_settings.sentry_traces_sample_rate = 0.1
+            mock_settings.sentry_profiles_sample_rate = 0.1
+            mock_settings.app_url = app_url
+            mock_settings.azure_client_id = "cid"
+            mock_settings.azure_client_secret = "csecret"
+            mock_settings.azure_tenant_id = "tid"
+
+            run_lifespan(mock_app)
+            yield mock_sentry_init
+
     def test_sentry_init_when_dsn_set(self):
         """When sentry_dsn is set, sentry_sdk.init is called."""
-        from app.main import lifespan
-
-        mock_app = MagicMock()
-        original = os.environ.pop("TESTING", None)
-        try:
-            with (
-                patch("app.main.settings") as mock_settings,
-                patch("app.startup.run_startup_migrations"),
-                patch("app.startup.seed_api_sources"),
-                patch("app.connector_status.log_connector_status", return_value={}),
-                patch("app.scheduler.configure_scheduler"),
-                patch("app.scheduler.scheduler") as mock_sched,
-                patch("app.http_client.close_clients", new_callable=AsyncMock),
-                patch("sentry_sdk.init") as mock_sentry_init,
-            ):
-                mock_settings.secret_key = "a-real-secret-key"
-                mock_settings.sentry_dsn = "https://examplePublicKey@o0.ingest.sentry.io/0"
-                mock_settings.sentry_traces_sample_rate = 0.1
-                mock_settings.sentry_profiles_sample_rate = 0.1
-                mock_settings.app_url = "https://app.example.com"
-                mock_settings.azure_client_id = "cid"
-                mock_settings.azure_client_secret = "csecret"
-                mock_settings.azure_tenant_id = "tid"
-
-                loop = asyncio.new_event_loop()
-                try:
-
-                    async def run_lifespan():
-                        async with lifespan(mock_app) as _:
-                            pass
-
-                    loop.run_until_complete(run_lifespan())
-                finally:
-                    loop.close()
-
-                mock_sentry_init.assert_called_once()
-                call_kwargs = mock_sentry_init.call_args[1]
-                assert call_kwargs["environment"] == "production"
-                assert "integrations" in call_kwargs
-                assert len(call_kwargs["integrations"]) == 4
-                assert call_kwargs["before_send"] is not None
-        finally:
-            if original is not None:
-                os.environ["TESTING"] = original
-            else:
-                os.environ["TESTING"] = "1"
+        with self._sentry_lifespan(
+            sentry_dsn="https://examplePublicKey@o0.ingest.sentry.io/0",
+            app_url="https://app.example.com",
+        ) as mock_sentry_init:
+            mock_sentry_init.assert_called_once()
+            call_kwargs = mock_sentry_init.call_args[1]
+            assert call_kwargs["environment"] == "production"
+            assert "integrations" in call_kwargs
+            assert len(call_kwargs["integrations"]) == 4
+            assert call_kwargs["before_send"] is not None
 
     def test_sentry_before_send_scrubs_headers(self):
         """Verify _sentry_before_send scrubs sensitive headers and vars."""
-        from app.main import lifespan
+        with self._sentry_lifespan(
+            sentry_dsn="https://examplePublicKey@o0.ingest.sentry.io/0",
+            app_url="https://app.example.com",
+        ) as mock_sentry_init:
+            before_send = mock_sentry_init.call_args[1]["before_send"]
 
-        mock_app = MagicMock()
-        original = os.environ.pop("TESTING", None)
-        try:
-            with (
-                patch("app.main.settings") as mock_settings,
-                patch("app.startup.run_startup_migrations"),
-                patch("app.startup.seed_api_sources"),
-                patch("app.connector_status.log_connector_status", return_value={}),
-                patch("app.scheduler.configure_scheduler"),
-                patch("app.scheduler.scheduler") as mock_sched,
-                patch("app.http_client.close_clients", new_callable=AsyncMock),
-                patch("sentry_sdk.init") as mock_sentry_init,
-            ):
-                mock_settings.secret_key = "a-real-secret-key"
-                mock_settings.sentry_dsn = "https://examplePublicKey@o0.ingest.sentry.io/0"
-                mock_settings.sentry_traces_sample_rate = 0.1
-                mock_settings.sentry_profiles_sample_rate = 0.1
-                mock_settings.app_url = "https://app.example.com"
-                mock_settings.azure_client_id = "cid"
-                mock_settings.azure_client_secret = "csecret"
-                mock_settings.azure_tenant_id = "tid"
+            # Test header scrubbing
+            event = {
+                "request": {
+                    "headers": {"Authorization": "Bearer secret123", "Content-Type": "text/html"},
+                    "query_string": "apiKey=secret123&q=test",
+                },
+                "exception": {
+                    "values": [{"stacktrace": {"frames": [{"vars": {"api_key": "sk-1234", "name": "test"}}]}}]
+                },
+            }
+            result = before_send(event, {})
+            assert result["request"]["headers"]["Authorization"] == "[Filtered]"
+            assert result["request"]["headers"]["Content-Type"] == "text/html"
+            assert result["request"]["query_string"] == "[Filtered]"
+            assert result["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]["api_key"] == "[Filtered]"
+            assert result["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]["name"] == "test"
 
-                loop = asyncio.new_event_loop()
-                try:
-
-                    async def run_lifespan():
-                        async with lifespan(mock_app) as _:
-                            pass
-
-                    loop.run_until_complete(run_lifespan())
-                finally:
-                    loop.close()
-
-                before_send = mock_sentry_init.call_args[1]["before_send"]
-
-                # Test header scrubbing
-                event = {
-                    "request": {
-                        "headers": {"Authorization": "Bearer secret123", "Content-Type": "text/html"},
-                        "query_string": "apiKey=secret123&q=test",
-                    },
-                    "exception": {
-                        "values": [{"stacktrace": {"frames": [{"vars": {"api_key": "sk-1234", "name": "test"}}]}}]
-                    },
-                }
-                result = before_send(event, {})
-                assert result["request"]["headers"]["Authorization"] == "[Filtered]"
-                assert result["request"]["headers"]["Content-Type"] == "text/html"
-                assert result["request"]["query_string"] == "[Filtered]"
-                assert result["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]["api_key"] == "[Filtered]"
-                assert result["exception"]["values"][0]["stacktrace"]["frames"][0]["vars"]["name"] == "test"
-
-                # Test with empty/missing sections
-                assert before_send({}, {}) == {}
-                assert before_send({"exception": None}, {}) == {"exception": None}
-                assert before_send({"exception": {}}, {}) == {"exception": {}}
-        finally:
-            if original is not None:
-                os.environ["TESTING"] = original
-            else:
-                os.environ["TESTING"] = "1"
+            # Test with empty/missing sections
+            assert before_send({}, {}) == {}
+            assert before_send({"exception": None}, {}) == {"exception": None}
+            assert before_send({"exception": {}}, {}) == {"exception": {}}
 
     def test_sentry_init_development_env(self):
         """When app_url is http, sentry environment is 'development'."""
-        from app.main import lifespan
-
-        mock_app = MagicMock()
-        original = os.environ.pop("TESTING", None)
-        try:
-            with (
-                patch("app.main.settings") as mock_settings,
-                patch("app.startup.run_startup_migrations"),
-                patch("app.startup.seed_api_sources"),
-                patch("app.connector_status.log_connector_status", return_value={}),
-                patch("app.scheduler.configure_scheduler"),
-                patch("app.scheduler.scheduler") as mock_sched,
-                patch("app.http_client.close_clients", new_callable=AsyncMock),
-                patch("sentry_sdk.init") as mock_sentry_init,
-            ):
-                mock_settings.secret_key = "a-real-secret-key"
-                mock_settings.sentry_dsn = "https://example@sentry.io/0"
-                mock_settings.sentry_traces_sample_rate = 0.1
-                mock_settings.sentry_profiles_sample_rate = 0.1
-                mock_settings.app_url = "http://localhost:8000"
-                mock_settings.azure_client_id = "cid"
-                mock_settings.azure_client_secret = "csecret"
-                mock_settings.azure_tenant_id = "tid"
-
-                loop = asyncio.new_event_loop()
-                try:
-
-                    async def run_lifespan():
-                        async with lifespan(mock_app) as _:
-                            pass
-
-                    loop.run_until_complete(run_lifespan())
-                finally:
-                    loop.close()
-
-                call_kwargs = mock_sentry_init.call_args[1]
-                assert call_kwargs["environment"] == "development"
-        finally:
-            if original is not None:
-                os.environ["TESTING"] = original
-            else:
-                os.environ["TESTING"] = "1"
+        with self._sentry_lifespan(
+            sentry_dsn="https://example@sentry.io/0",
+            app_url="http://localhost:8000",
+        ) as mock_sentry_init:
+            assert mock_sentry_init.call_args[1]["environment"] == "development"
 
 
 # ── Rate limit handler (lines 117-120) ────────────────────────────────
@@ -668,22 +577,17 @@ class TestModuleLevelBranches:
         from app.config import settings as real_settings
 
         original_rl = real_settings.rate_limit_enabled
-        original_testing = os.environ.pop("TESTING", None)
         real_settings.rate_limit_enabled = True
 
         try:
-            # Reload the module — this re-runs all module-level code
-            importlib.reload(main_mod)
+            with no_testing_env():
+                # Reload the module — this re-runs all module-level code
+                importlib.reload(main_mod)
         except Exception:
             pass  # Module reload may fail due to side effects, that's ok
         finally:
             # Restore original state
             real_settings.rate_limit_enabled = original_rl
-            if original_testing is not None:
-                os.environ["TESTING"] = original_testing
-            else:
-                os.environ["TESTING"] = "1"
-
             # Restore the original app object to avoid breaking other tests
             main_mod.app = original_app
 

--- a/tests/test_manufacturer_validation.py
+++ b/tests/test_manufacturer_validation.py
@@ -28,26 +28,21 @@ def test_requisition_for_mfr(db_session: Session, test_user: User) -> Requisitio
     return req
 
 
-def test_add_requirement_rejects_empty_manufacturer(client, test_requisition_for_mfr):
-    """Creating a requirement without manufacturer should fail with 422."""
+@pytest.mark.parametrize(
+    "manufacturer",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace"),
+    ],
+)
+def test_add_requirement_rejects_invalid_manufacturer(client, test_requisition_for_mfr, manufacturer):
+    """Creating a requirement with an empty/whitespace manufacturer should fail with
+    422."""
     resp = client.post(
         f"/v2/partials/requisitions/{test_requisition_for_mfr.id}/requirements",
         data={
             "primary_mpn": "LM317T",
-            "manufacturer": "",
-            "target_qty": "100",
-        },
-    )
-    assert resp.status_code == 422 or "manufacturer" in resp.text.lower()
-
-
-def test_add_requirement_rejects_whitespace_manufacturer(client, test_requisition_for_mfr):
-    """Whitespace-only manufacturer should be rejected with 422."""
-    resp = client.post(
-        f"/v2/partials/requisitions/{test_requisition_for_mfr.id}/requirements",
-        data={
-            "primary_mpn": "LM317T",
-            "manufacturer": "   ",
+            "manufacturer": manufacturer,
             "target_qty": "100",
         },
     )

--- a/tests/test_material_enrichment_batch.py
+++ b/tests/test_material_enrichment_batch.py
@@ -21,6 +21,19 @@ from app.services.material_enrichment_service import (
 from tests.conftest import engine  # noqa: F401 — ensures SQLite engine is used
 
 
+def _run(coro):
+    """Run an async coroutine to completion on the current event loop."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _mock_redis(mock_redis, get_value=None):
+    """Wire mock_redis to return a MagicMock whose .get() yields get_value."""
+    mock_r = MagicMock()
+    mock_r.get.return_value = get_value
+    mock_redis.return_value = mock_r
+    return mock_r
+
+
 @pytest.fixture()
 def unenriched_cards(db_session):
     """Create 5 material cards with enriched_at = NULL."""
@@ -63,7 +76,7 @@ def enriched_cards(db_session):
 
 def test_batch_enrich_no_cards(db_session):
     """Returns None when no unenriched cards exist."""
-    result = asyncio.get_event_loop().run_until_complete(batch_enrich_materials(db_session))
+    result = _run(batch_enrich_materials(db_session))
     assert result is None
 
 
@@ -72,11 +85,9 @@ def test_batch_enrich_no_cards(db_session):
 def test_batch_enrich_submits_batch(mock_submit, mock_redis, db_session, unenriched_cards):
     """Submits a batch and stores batch_id in Redis."""
     mock_submit.return_value = "batch_abc123"
-    mock_r = MagicMock()
-    mock_r.get.return_value = None  # No in-flight batch
-    mock_redis.return_value = mock_r
+    mock_r = _mock_redis(mock_redis)  # No in-flight batch
 
-    result = asyncio.get_event_loop().run_until_complete(batch_enrich_materials(db_session))
+    result = _run(batch_enrich_materials(db_session))
 
     assert result == "batch_abc123"
     mock_submit.assert_called_once()
@@ -99,11 +110,9 @@ def test_batch_enrich_submits_batch(mock_submit, mock_redis, db_session, unenric
 def test_batch_enrich_skips_enriched(mock_submit, mock_redis, db_session, unenriched_cards, enriched_cards):
     """Only picks up cards with enriched_at IS NULL."""
     mock_submit.return_value = "batch_xyz"
-    mock_r = MagicMock()
-    mock_r.get.return_value = None  # No in-flight batch
-    mock_redis.return_value = mock_r
+    _mock_redis(mock_redis)  # No in-flight batch
 
-    result = asyncio.get_event_loop().run_until_complete(batch_enrich_materials(db_session))
+    result = _run(batch_enrich_materials(db_session))
 
     assert result == "batch_xyz"
     requests = mock_submit.call_args[0][0]
@@ -122,11 +131,9 @@ def test_batch_enrich_skips_enriched(mock_submit, mock_redis, db_session, unenri
 def test_batch_enrich_submit_fails(mock_submit, mock_redis, db_session, unenriched_cards):
     """Returns None when claude_batch_submit fails."""
     mock_submit.return_value = None
-    mock_r = MagicMock()
-    mock_r.get.return_value = None  # No in-flight batch
-    mock_redis.return_value = mock_r
+    mock_r = _mock_redis(mock_redis)  # No in-flight batch
 
-    result = asyncio.get_event_loop().run_until_complete(batch_enrich_materials(db_session))
+    result = _run(batch_enrich_materials(db_session))
 
     assert result is None
     mock_r.set.assert_not_called()
@@ -136,11 +143,9 @@ def test_batch_enrich_submit_fails(mock_submit, mock_redis, db_session, unenrich
 @patch("app.services.material_enrichment_service.claude_batch_submit")
 def test_batch_enrich_skips_if_inflight(mock_submit, mock_redis, db_session, unenriched_cards):
     """Returns None immediately when a batch is already in-flight in Redis."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_already_running"  # Simulate in-flight batch
-    mock_redis.return_value = mock_r
+    _mock_redis(mock_redis, get_value=b"batch_already_running")  # Simulate in-flight batch
 
-    result = asyncio.get_event_loop().run_until_complete(batch_enrich_materials(db_session))
+    result = _run(batch_enrich_materials(db_session))
 
     assert result is None
     mock_submit.assert_not_called()
@@ -152,11 +157,9 @@ def test_batch_enrich_skips_if_inflight(mock_submit, mock_redis, db_session, une
 @patch("app.services.material_enrichment_service._get_redis")
 def test_process_results_no_batch_id(mock_redis, db_session):
     """Returns 0 when no batch_id is stored in Redis."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = None
-    mock_redis.return_value = mock_r
+    _mock_redis(mock_redis)
 
-    result = asyncio.get_event_loop().run_until_complete(process_material_batch_results(db_session))
+    result = _run(process_material_batch_results(db_session))
     assert result is None
 
 
@@ -164,12 +167,10 @@ def test_process_results_no_batch_id(mock_redis, db_session):
 @patch("app.services.material_enrichment_service.claude_batch_results")
 def test_process_results_still_processing(mock_results, mock_redis, db_session):
     """Returns None when batch is still processing."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_abc123"
-    mock_redis.return_value = mock_r
+    mock_r = _mock_redis(mock_redis, get_value=b"batch_abc123")
     mock_results.return_value = None  # Still processing
 
-    result = asyncio.get_event_loop().run_until_complete(process_material_batch_results(db_session))
+    result = _run(process_material_batch_results(db_session))
     assert result is None
     # Should NOT clear the Redis key
     mock_r.delete.assert_not_called()
@@ -179,9 +180,7 @@ def test_process_results_still_processing(mock_results, mock_redis, db_session):
 @patch("app.services.material_enrichment_service.claude_batch_results")
 def test_process_results_applies_enrichment(mock_results, mock_redis, db_session, unenriched_cards):
     """Applies AI results to material cards and clears Redis key."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_abc123"
-    mock_redis.return_value = mock_r
+    mock_r = _mock_redis(mock_redis, get_value=b"batch_abc123")
 
     # Build results keyed by the custom_id pattern used in batch_enrich_materials
     results_dict = {}
@@ -200,7 +199,7 @@ def test_process_results_applies_enrichment(mock_results, mock_redis, db_session
 
     mock_results.return_value = results_dict
 
-    result = asyncio.get_event_loop().run_until_complete(process_material_batch_results(db_session))
+    result = _run(process_material_batch_results(db_session))
 
     assert result["applied"] == 5
     assert result["errors"] == 0
@@ -221,9 +220,7 @@ def test_process_results_applies_enrichment(mock_results, mock_redis, db_session
 @patch("app.services.material_enrichment_service.claude_batch_results")
 def test_process_results_handles_none_entry(mock_results, mock_redis, db_session, unenriched_cards):
     """Skips cards with None results (errors) without crashing."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_abc123"
-    mock_redis.return_value = mock_r
+    mock_r = _mock_redis(mock_redis, get_value=b"batch_abc123")
 
     card = unenriched_cards[0]
     results_dict = {
@@ -231,7 +228,7 @@ def test_process_results_handles_none_entry(mock_results, mock_redis, db_session
     }
     mock_results.return_value = results_dict
 
-    result = asyncio.get_event_loop().run_until_complete(process_material_batch_results(db_session))
+    result = _run(process_material_batch_results(db_session))
 
     # Only the error entry, so 0 applied
     assert result["applied"] == 0
@@ -247,9 +244,7 @@ def test_process_results_handles_none_entry(mock_results, mock_redis, db_session
 @patch("app.services.material_enrichment_service.claude_batch_results")
 def test_process_results_invalid_category_falls_back(mock_results, mock_redis, db_session, unenriched_cards):
     """Invalid category gets replaced with 'other'."""
-    mock_r = MagicMock()
-    mock_r.get.return_value = b"batch_abc123"
-    mock_redis.return_value = mock_r
+    _mock_redis(mock_redis, get_value=b"batch_abc123")
 
     card = unenriched_cards[0]
     results_dict = {
@@ -265,7 +260,7 @@ def test_process_results_invalid_category_falls_back(mock_results, mock_redis, d
     }
     mock_results.return_value = results_dict
 
-    result = asyncio.get_event_loop().run_until_complete(process_material_batch_results(db_session))
+    result = _run(process_material_batch_results(db_session))
 
     assert result["applied"] == 1
     db_session.refresh(card)

--- a/tests/test_materials_coverage.py
+++ b/tests/test_materials_coverage.py
@@ -22,10 +22,40 @@ import os
 os.environ["TESTING"] = "1"
 
 import io
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
+import pytest
+from fastapi.testclient import TestClient
+
 from app.models import MaterialCard, Offer, VendorCard
+
+
+@contextmanager
+def admin_client(db_session, admin_user):
+    """Yield a TestClient with db + admin auth dependency overrides applied.
+
+    Restores the original overrides on exit. Used by the admin-only endpoints
+    (delete/restore/merge/backfill) which all need the same override scaffolding.
+    """
+    from app.database import get_db
+    from app.dependencies import require_admin, require_user
+    from app.main import app
+
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[require_user] = lambda: admin_user
+    app.dependency_overrides[require_admin] = lambda: admin_user
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(require_user, None)
+        app.dependency_overrides.pop(require_admin, None)
 
 
 class TestListMaterialsShortQuery:
@@ -268,12 +298,6 @@ class TestDeleteMaterialAlreadyDeleted:
 
     def test_delete_already_deleted_returns_400(self, client, db_session, admin_user):
         """DELETE on already-deleted card returns 400."""
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-        from app.dependencies import require_admin, require_user
-        from app.main import app
-
         mc = MaterialCard(
             normalized_mpn="alreadydel001",
             display_mpn="ALREADYDEL001",
@@ -285,20 +309,8 @@ class TestDeleteMaterialAlreadyDeleted:
         db_session.add(mc)
         db_session.commit()
 
-        def _override_db():
-            yield db_session
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = lambda: admin_user
-        app.dependency_overrides[require_admin] = lambda: admin_user
-
-        try:
-            with TestClient(app) as c:
-                resp = c.delete(f"/api/materials/{mc.id}")
-        finally:
-            app.dependency_overrides.pop(get_db, None)
-            app.dependency_overrides.pop(require_user, None)
-            app.dependency_overrides.pop(require_admin, None)
+        with admin_client(db_session, admin_user) as c:
+            resp = c.delete(f"/api/materials/{mc.id}")
 
         assert resp.status_code == 400
 
@@ -308,12 +320,6 @@ class TestRestoreMaterial:
 
     def test_restore_deleted_card(self, client, db_session, admin_user):
         """POST /api/materials/{id}/restore restores a soft-deleted card."""
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-        from app.dependencies import require_admin, require_user
-        from app.main import app
-
         mc = MaterialCard(
             normalized_mpn="restore001",
             display_mpn="RESTORE001",
@@ -325,20 +331,8 @@ class TestRestoreMaterial:
         db_session.add(mc)
         db_session.commit()
 
-        def _override_db():
-            yield db_session
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = lambda: admin_user
-        app.dependency_overrides[require_admin] = lambda: admin_user
-
-        try:
-            with TestClient(app) as c:
-                resp = c.post(f"/api/materials/{mc.id}/restore")
-        finally:
-            app.dependency_overrides.pop(get_db, None)
-            app.dependency_overrides.pop(require_user, None)
-            app.dependency_overrides.pop(require_admin, None)
+        with admin_client(db_session, admin_user) as c:
+            resp = c.post(f"/api/materials/{mc.id}/restore")
 
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
@@ -347,12 +341,6 @@ class TestRestoreMaterial:
 
     def test_restore_not_deleted_returns_400(self, client, db_session, admin_user):
         """POST /api/materials/{id}/restore on non-deleted card returns 400."""
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-        from app.dependencies import require_admin, require_user
-        from app.main import app
-
         mc = MaterialCard(
             normalized_mpn="restore002",
             display_mpn="RESTORE002",
@@ -363,45 +351,15 @@ class TestRestoreMaterial:
         db_session.add(mc)
         db_session.commit()
 
-        def _override_db():
-            yield db_session
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = lambda: admin_user
-        app.dependency_overrides[require_admin] = lambda: admin_user
-
-        try:
-            with TestClient(app) as c:
-                resp = c.post(f"/api/materials/{mc.id}/restore")
-        finally:
-            app.dependency_overrides.pop(get_db, None)
-            app.dependency_overrides.pop(require_user, None)
-            app.dependency_overrides.pop(require_admin, None)
+        with admin_client(db_session, admin_user) as c:
+            resp = c.post(f"/api/materials/{mc.id}/restore")
 
         assert resp.status_code == 400
 
     def test_restore_not_found_returns_404(self, client, db_session, admin_user):
         """POST /api/materials/99999/restore returns 404."""
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-        from app.dependencies import require_admin, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = lambda: admin_user
-        app.dependency_overrides[require_admin] = lambda: admin_user
-
-        try:
-            with TestClient(app) as c:
-                resp = c.post("/api/materials/99999/restore")
-        finally:
-            app.dependency_overrides.pop(get_db, None)
-            app.dependency_overrides.pop(require_user, None)
-            app.dependency_overrides.pop(require_admin, None)
+        with admin_client(db_session, admin_user) as c:
+            resp = c.post("/api/materials/99999/restore")
 
         assert resp.status_code == 404
 
@@ -409,108 +367,32 @@ class TestRestoreMaterial:
 class TestMergeMaterial:
     """Merge endpoint (lines 355-369)."""
 
-    def test_merge_missing_source_returns_400(self, client, db_session, admin_user):
-        """POST /api/materials/merge with missing source_card_id returns 400."""
-        from fastapi.testclient import TestClient
+    @pytest.mark.parametrize(
+        ("body", "expected_status"),
+        [
+            ({"target_card_id": 1}, 400),  # missing source_card_id
+            ({"source_card_id": 1}, 400),  # missing target_card_id
+            ({"source_card_id": 99998, "target_card_id": 99999}, 404),  # nonexistent IDs
+        ],
+        ids=["missing_source", "missing_target", "not_found"],
+    )
+    def test_merge_invalid_request(self, client, db_session, admin_user, body, expected_status):
+        """POST /api/materials/merge rejects missing IDs (400) and nonexistent IDs
+        (404)."""
+        with admin_client(db_session, admin_user) as c:
+            resp = c.post("/api/materials/merge", json=body)
 
-        from app.database import get_db
-        from app.dependencies import require_admin, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = lambda: admin_user
-        app.dependency_overrides[require_admin] = lambda: admin_user
-
-        try:
-            with TestClient(app) as c:
-                resp = c.post("/api/materials/merge", json={"target_card_id": 1})
-        finally:
-            app.dependency_overrides.pop(get_db, None)
-            app.dependency_overrides.pop(require_user, None)
-            app.dependency_overrides.pop(require_admin, None)
-
-        assert resp.status_code == 400
-
-    def test_merge_missing_target_returns_400(self, client, db_session, admin_user):
-        """POST /api/materials/merge with missing target_card_id returns 400."""
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-        from app.dependencies import require_admin, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = lambda: admin_user
-        app.dependency_overrides[require_admin] = lambda: admin_user
-
-        try:
-            with TestClient(app) as c:
-                resp = c.post("/api/materials/merge", json={"source_card_id": 1})
-        finally:
-            app.dependency_overrides.pop(get_db, None)
-            app.dependency_overrides.pop(require_user, None)
-            app.dependency_overrides.pop(require_admin, None)
-
-        assert resp.status_code == 400
+        assert resp.status_code == expected_status
 
     def test_merge_same_card_returns_400(self, client, db_session, admin_user, test_material_card):
         """POST /api/materials/merge with source==target returns 400."""
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-        from app.dependencies import require_admin, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = lambda: admin_user
-        app.dependency_overrides[require_admin] = lambda: admin_user
-
-        try:
-            with TestClient(app) as c:
-                resp = c.post(
-                    "/api/materials/merge",
-                    json={"source_card_id": test_material_card.id, "target_card_id": test_material_card.id},
-                )
-        finally:
-            app.dependency_overrides.pop(get_db, None)
-            app.dependency_overrides.pop(require_user, None)
-            app.dependency_overrides.pop(require_admin, None)
+        with admin_client(db_session, admin_user) as c:
+            resp = c.post(
+                "/api/materials/merge",
+                json={"source_card_id": test_material_card.id, "target_card_id": test_material_card.id},
+            )
 
         assert resp.status_code == 400
-
-    def test_merge_not_found_returns_404(self, client, db_session, admin_user):
-        """POST /api/materials/merge with nonexistent IDs returns 404."""
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-        from app.dependencies import require_admin, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = lambda: admin_user
-        app.dependency_overrides[require_admin] = lambda: admin_user
-
-        try:
-            with TestClient(app) as c:
-                resp = c.post("/api/materials/merge", json={"source_card_id": 99998, "target_card_id": 99999})
-        finally:
-            app.dependency_overrides.pop(get_db, None)
-            app.dependency_overrides.pop(require_user, None)
-            app.dependency_overrides.pop(require_admin, None)
-
-        assert resp.status_code == 404
 
 
 class TestBackfillManufacturers:
@@ -518,26 +400,8 @@ class TestBackfillManufacturers:
 
     def test_backfill_manufacturers_returns_count(self, client, db_session, admin_user):
         """POST /materials/backfill-manufacturers returns enriched_records count."""
-        from fastapi.testclient import TestClient
-
-        from app.database import get_db
-        from app.dependencies import require_admin, require_user
-        from app.main import app
-
-        def _override_db():
-            yield db_session
-
-        app.dependency_overrides[get_db] = _override_db
-        app.dependency_overrides[require_user] = lambda: admin_user
-        app.dependency_overrides[require_admin] = lambda: admin_user
-
-        try:
-            with TestClient(app) as c:
-                resp = c.post("/materials/backfill-manufacturers")
-        finally:
-            app.dependency_overrides.pop(get_db, None)
-            app.dependency_overrides.pop(require_user, None)
-            app.dependency_overrides.pop(require_admin, None)
+        with admin_client(db_session, admin_user) as c:
+            resp = c.post("/materials/backfill-manufacturers")
 
         assert resp.status_code == 200
         assert "enriched_records" in resp.json()

--- a/tests/test_materials_detail_parity.py
+++ b/tests/test_materials_detail_parity.py
@@ -8,6 +8,7 @@ Depends on: the /v2/partials/materials/{card_id} and .../tab/{tab_name} routes.
 from datetime import datetime, timezone
 from decimal import Decimal
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -74,23 +75,17 @@ def _seed(db: Session) -> MaterialCard:
     return card
 
 
-def test_material_detail_renders_card(client: TestClient, db_session: Session):
-    """Detail page still loads and renders the part MPN after the refactor."""
+@pytest.mark.parametrize(
+    "path_suffix,expected_text",
+    [
+        ("", "LM317T"),  # detail page renders the part MPN after the refactor
+        ("/tab/sourcing", "LM317T"),
+        ("/tab/customers", "ACME Inc"),
+    ],
+    ids=["detail", "sourcing_tab", "customers_tab"],
+)
+def test_material_detail_renders(client: TestClient, db_session: Session, path_suffix: str, expected_text: str):
     card = _seed(db_session)
-    resp = client.get(f"/v2/partials/materials/{card.id}", headers={"HX-Request": "true"})
+    resp = client.get(f"/v2/partials/materials/{card.id}{path_suffix}", headers={"HX-Request": "true"})
     assert resp.status_code == 200
-    assert "LM317T" in resp.text
-
-
-def test_material_sourcing_tab_renders_requirement(client: TestClient, db_session: Session):
-    card = _seed(db_session)
-    resp = client.get(f"/v2/partials/materials/{card.id}/tab/sourcing", headers={"HX-Request": "true"})
-    assert resp.status_code == 200
-    assert "LM317T" in resp.text
-
-
-def test_material_customers_tab_renders_purchase(client: TestClient, db_session: Session):
-    card = _seed(db_session)
-    resp = client.get(f"/v2/partials/materials/{card.id}/tab/customers", headers={"HX-Request": "true"})
-    assert resp.status_code == 200
-    assert "ACME Inc" in resp.text
+    assert expected_text in resp.text

--- a/tests/test_migration_098_materials_perf_idx.py
+++ b/tests/test_migration_098_materials_perf_idx.py
@@ -39,6 +39,16 @@ _HISTORICAL_NAMES = {name for name, _cols, _kw in _mod._HISTORICAL_INDEXES}
 _ALL_NAMES = _NEW_NAMES | _HISTORICAL_NAMES
 
 
+def _script_directory():
+    """Build a ScriptDirectory pointed at the repo's alembic/ for chain walks."""
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    cfg = Config()
+    cfg.set_main_option("script_location", os.path.join(_REPO_ROOT, "alembic"))
+    return ScriptDirectory.from_config(cfg)
+
+
 class TestRevisionMetadata:
     def test_revision_id(self):
         assert _mod.revision == "098_materials_perf_idx"
@@ -57,12 +67,7 @@ class TestRevisionMetadata:
         # test_migration_chain.py owns that invariant) AND 098 must sit on the mainline
         # walked from that head. Reachability instead of a pinned head name, so this
         # test survives future migrations landing on top.
-        from alembic.config import Config
-        from alembic.script import ScriptDirectory
-
-        cfg = Config()
-        cfg.set_main_option("script_location", os.path.join(_REPO_ROOT, "alembic"))
-        script = ScriptDirectory.from_config(cfg)
+        script = _script_directory()
         heads = script.get_heads()
         assert len(heads) == 1, f"expected a single head, got {heads}"
         mainline = {rev.revision for rev in script.iterate_revisions(heads[0], "base")}
@@ -72,12 +77,7 @@ class TestRevisionMetadata:
         # The two _HISTORICAL_INDEXES names are owned by eabe89205d07, which must
         # remain a live ancestor of 098 — the ownership split (downgrade keeps the
         # pair) is only correct while that revision is still in the applied history.
-        from alembic.config import Config
-        from alembic.script import ScriptDirectory
-
-        cfg = Config()
-        cfg.set_main_option("script_location", os.path.join(_REPO_ROOT, "alembic"))
-        script = ScriptDirectory.from_config(cfg)
+        script = _script_directory()
         ancestors = {rev.revision for rev in script.iterate_revisions(_mod.revision, "base")}
         assert "eabe89205d07" in ancestors, (
             "eabe89205d07 is no longer an ancestor of 098 — if it was removed from the "

--- a/tests/test_nc_phase2.py
+++ b/tests/test_nc_phase2.py
@@ -7,6 +7,8 @@ Depends on: conftest.py, nc_worker modules
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import pytest
+
 from app.models import NcSearchQueue, Requirement
 from app.services.nc_worker.config import NcConfig
 from app.services.nc_worker.mpn_normalizer import strip_packaging_suffixes as normalize_mpn
@@ -45,70 +47,29 @@ def test_config_from_env():
 # ── MPN Normalizer Tests ────────────────────────────────────────────
 
 
-def test_normalize_uppercase_and_strip():
-    """Uppercase and strip whitespace."""
-    assert normalize_mpn("  p5040nsn72qc  ") == "P5040NSN72QC"
-
-
-def test_normalize_no_change_package_code():
-    """DR is a package code (SOIC), not a suffix — should NOT be stripped."""
-    assert normalize_mpn("LM358DR") == "LM358DR"
-
-
-def test_normalize_strip_tape_reel_dash():
-    """-TR (tape and reel) is stripped."""
-    assert normalize_mpn("STM32F103C8T6-TR") == "STM32F103C8T6"
-
-
-def test_normalize_strip_tape_reel_slash():
-    """/TR (tape and reel) is stripped."""
-    assert normalize_mpn("AD8232ACPZ/TR") == "AD8232ACPZ"
-
-
-def test_normalize_strip_cut_tape():
-    """/CT (cut tape) is stripped."""
-    assert normalize_mpn("SN74HC595N/CT") == "SN74HC595N"
-
-
-def test_normalize_strip_no_datasheet():
-    """-ND (no datasheet, DigiKey) is stripped."""
-    assert normalize_mpn("LM7805CT-ND") == "LM7805CT"
-
-
-def test_normalize_strip_digikey_reel():
-    """-DKR (DigiKey reel) is stripped."""
-    assert normalize_mpn("RC0805FR-071KL-DKR") == "RC0805FR-071KL"
-
-
-def test_normalize_strip_lead_free():
-    """#PBF (lead-free) is stripped."""
-    assert normalize_mpn("IRF540N#PBF") == "IRF540N"
-
-
-def test_normalize_strip_nopb():
-    """/NOPB (no lead, TI) is stripped."""
-    assert normalize_mpn("LM317T/NOPB") == "LM317T"
-
-
-def test_normalize_strip_reel_suffix():
-    """-RL (reel packaging) is stripped. The base part is the same component."""
-    assert normalize_mpn("ADP3338AKCZ-3.3-RL") == "ADP3338AKCZ-3.3"
-
-
-def test_normalize_strip_internal_whitespace():
-    """Internal whitespace is removed."""
-    assert normalize_mpn("STM 32F 103") == "STM32F103"
-
-
-def test_normalize_empty():
-    """Empty and None return empty string."""
-    assert normalize_mpn("") == ""
-    assert normalize_mpn("   ") == ""
-
-
-def test_normalize_pbf_dash():
-    """-PBF (lead-free, dash form) is stripped."""
-    assert normalize_mpn("LT1963EST-3.3-PBF") == "LT1963EST-3.3"
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("  p5040nsn72qc  ", "P5040NSN72QC", id="uppercase_and_strip"),
+        pytest.param("LM358DR", "LM358DR", id="no_change_package_code"),
+        pytest.param("STM32F103C8T6-TR", "STM32F103C8T6", id="strip_tape_reel_dash"),
+        pytest.param("AD8232ACPZ/TR", "AD8232ACPZ", id="strip_tape_reel_slash"),
+        pytest.param("SN74HC595N/CT", "SN74HC595N", id="strip_cut_tape"),
+        pytest.param("LM7805CT-ND", "LM7805CT", id="strip_no_datasheet"),
+        pytest.param("RC0805FR-071KL-DKR", "RC0805FR-071KL", id="strip_digikey_reel"),
+        pytest.param("IRF540N#PBF", "IRF540N", id="strip_lead_free"),
+        pytest.param("LM317T/NOPB", "LM317T", id="strip_nopb"),
+        pytest.param("ADP3338AKCZ-3.3-RL", "ADP3338AKCZ-3.3", id="strip_reel_suffix"),
+        pytest.param("STM 32F 103", "STM32F103", id="strip_internal_whitespace"),
+        pytest.param("", "", id="empty"),
+        pytest.param("   ", "", id="whitespace_only"),
+        pytest.param("LT1963EST-3.3-PBF", "LT1963EST-3.3", id="pbf_dash"),
+    ],
+)
+def test_normalize_mpn(raw, expected):
+    """strip_packaging_suffixes uppercases, strips noise/whitespace, and drops packaging
+    suffixes while preserving real package codes and base parts."""
+    assert normalize_mpn(raw) == expected
 
 
 # ── Queue Manager Tests ─────────────────────────────────────────────

--- a/tests/test_normalization_helpers_coverage.py
+++ b/tests/test_normalization_helpers_coverage.py
@@ -11,6 +11,8 @@ import os
 
 os.environ["TESTING"] = "1"
 
+import pytest
+
 from app.utils.normalization_helpers import (
     fix_encoding,
     normalize_country,
@@ -20,162 +22,98 @@ from app.utils.normalization_helpers import (
 
 
 class TestNormalizePhoneE164:
-    def test_none_returns_none(self):
-        assert normalize_phone_e164(None) is None
-
-    def test_empty_string_returns_none(self):
-        assert normalize_phone_e164("") is None
-
-    def test_whitespace_only_returns_none(self):
-        assert normalize_phone_e164("   ") is None
-
-    def test_too_short_returns_none(self):
-        assert normalize_phone_e164("123") is None
-
-    def test_nanp_10_digits(self):
-        assert normalize_phone_e164("5551234567") == "+15551234567"
-
-    def test_nanp_with_leading_1(self):
-        assert normalize_phone_e164("15551234567") == "+15551234567"
-
-    def test_formatted_nanp(self):
-        assert normalize_phone_e164("(555) 123-4567") == "+15551234567"
-
-    def test_with_plus_prefix(self):
-        assert normalize_phone_e164("+442079460958") == "+442079460958"
-
-    def test_uk_number_with_plus(self):
-        assert normalize_phone_e164("+44 20 7946 0958") == "+442079460958"
-
-    def test_11_plus_digits_without_plus(self):
-        # 12 digits, not NANP (doesn't start with 1 followed by 10) → +{digits}
-        assert normalize_phone_e164("442079460958") == "+442079460958"
-
-    def test_7_to_9_digits_assumed_us_domestic(self):
-        # 7 digits — assume US domestic
-        result = normalize_phone_e164("5551234")
-        assert result == "+15551234"
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, None),
+            ("", None),
+            ("   ", None),  # whitespace only
+            ("123", None),  # too short
+            ("5551234567", "+15551234567"),  # NANP 10 digits
+            ("15551234567", "+15551234567"),  # NANP with leading 1
+            ("(555) 123-4567", "+15551234567"),  # formatted NANP
+            ("+442079460958", "+442079460958"),  # with plus prefix
+            ("+44 20 7946 0958", "+442079460958"),  # UK number with plus
+            # 12 digits, not NANP (doesn't start with 1 followed by 10) -> +{digits}
+            ("442079460958", "+442079460958"),
+            ("5551234", "+15551234"),  # 7 digits — assume US domestic
+            ("(555) 123-4567 ext. 100", "+15551234567"),  # extension stripped
+            ("555-123-4567 x200", "+15551234567"),  # extension x format stripped
+            ("1-800-555-0100", "+18005550100"),  # dashes stripped
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert normalize_phone_e164(raw) == expected
 
     def test_8_digit_number_assumed_us(self):
         result = normalize_phone_e164("55512345")
         assert result is not None
         assert result.startswith("+1")
 
-    def test_extension_stripped(self):
-        result = normalize_phone_e164("(555) 123-4567 ext. 100")
-        assert result == "+15551234567"
-
-    def test_extension_x_format_stripped(self):
-        result = normalize_phone_e164("555-123-4567 x200")
-        assert result == "+15551234567"
-
-    def test_dashes_stripped(self):
-        assert normalize_phone_e164("1-800-555-0100") == "+18005550100"
-
 
 class TestNormalizeCountry:
-    def test_none_returns_none(self):
-        assert normalize_country(None) is None
-
-    def test_empty_string_returns_none(self):
-        assert normalize_country("") is None
-
-    def test_whitespace_only_returns_none(self):
-        assert normalize_country("   ") is None
-
-    def test_full_name_united_states(self):
-        assert normalize_country("United States") == "US"
-
-    def test_abbreviation_usa(self):
-        assert normalize_country("USA") == "US"
-
-    def test_two_letter_code_passthrough(self):
-        assert normalize_country("DE") == "DE"
-
-    def test_germany_full_name(self):
-        assert normalize_country("Germany") == "DE"
-
-    def test_deutschland(self):
-        assert normalize_country("Deutschland") == "DE"
-
-    def test_uk_abbreviation(self):
-        assert normalize_country("UK") == "GB"
-
-    def test_japan(self):
-        assert normalize_country("Japan") == "JP"
-
-    def test_china(self):
-        assert normalize_country("China") == "CN"
-
-    def test_unknown_country_returned_unchanged(self):
-        # Unknown country string — returned as-is (don't lose data)
-        result = normalize_country("Atlantis")
-        assert result == "Atlantis"
-
-    def test_case_insensitive_lookup(self):
-        assert normalize_country("united states") == "US"
-        assert normalize_country("UNITED STATES") == "US"
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, None),
+            ("", None),
+            ("   ", None),  # whitespace only
+            ("United States", "US"),  # full name
+            ("USA", "US"),  # abbreviation
+            ("DE", "DE"),  # two-letter code passthrough
+            ("Germany", "DE"),  # full name
+            ("Deutschland", "DE"),
+            ("UK", "GB"),  # abbreviation
+            ("Japan", "JP"),
+            ("China", "CN"),
+            ("Atlantis", "Atlantis"),  # unknown — returned as-is (don't lose data)
+            ("united states", "US"),  # case-insensitive lookup
+            ("UNITED STATES", "US"),  # case-insensitive lookup
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert normalize_country(raw) == expected
 
 
 class TestNormalizeUSState:
-    def test_none_returns_none(self):
-        assert normalize_us_state(None) is None
-
-    def test_empty_string_returns_none(self):
-        assert normalize_us_state("") is None
-
-    def test_whitespace_only_returns_none(self):
-        assert normalize_us_state("   ") is None
-
-    def test_full_name_california(self):
-        assert normalize_us_state("California") == "CA"
-
-    def test_abbreviation_ca(self):
-        assert normalize_us_state("CA") == "CA"
-
-    def test_lowercase_abbreviation(self):
-        assert normalize_us_state("ca") == "CA"
-
-    def test_new_york_full(self):
-        assert normalize_us_state("New York") == "NY"
-
-    def test_texas_abbreviation(self):
-        assert normalize_us_state("TX") == "TX"
-
-    def test_dc_abbreviation(self):
-        assert normalize_us_state("DC") == "DC"
-
-    def test_district_of_columbia_full(self):
-        assert normalize_us_state("District of Columbia") == "DC"
-
-    def test_unknown_state_returned_unchanged(self):
-        # Unknown state string — returned as-is
-        result = normalize_us_state("Narnia")
-        assert result == "Narnia"
-
-    def test_territory_puerto_rico(self):
-        assert normalize_us_state("Puerto Rico") == "PR"
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, None),
+            ("", None),
+            ("   ", None),  # whitespace only
+            ("California", "CA"),  # full name
+            ("CA", "CA"),  # abbreviation
+            ("ca", "CA"),  # lowercase abbreviation
+            ("New York", "NY"),  # full name
+            ("TX", "TX"),  # abbreviation
+            ("DC", "DC"),  # abbreviation
+            ("District of Columbia", "DC"),  # full name
+            ("Narnia", "Narnia"),  # unknown — returned as-is
+            ("Puerto Rico", "PR"),  # territory
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert normalize_us_state(raw) == expected
 
 
 class TestFixEncoding:
-    def test_none_returns_none(self):
-        assert fix_encoding(None) is None
-
-    def test_empty_string_returned_unchanged(self):
-        assert fix_encoding("") == ""
-
-    def test_clean_text_unchanged(self):
-        assert fix_encoding("Arrow Electronics") == "Arrow Electronics"
-
-    def test_int_l_pattern(self):
-        # "int?l" should become "Int'l"
-        assert fix_encoding("int?l") == "Int'l"
-
-    def test_int_l_uppercase(self):
-        assert fix_encoding("INT?L") == "Int'l"
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, None),
+            ("", ""),  # empty string returned unchanged
+            ("Arrow Electronics", "Arrow Electronics"),  # clean text unchanged
+            ("int?l", "Int'l"),  # "int?l" should become "Int'l"
+            ("INT?L", "Int'l"),  # uppercase
+            ("Normal ASCII text with no issues", "Normal ASCII text with no issues"),  # no mojibake
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert fix_encoding(raw) == expected
 
     def test_mojibake_right_single_quote(self):
-        # â → '
+        # mojibake -> '
         corrupted = "â"
         result = fix_encoding(f"It{corrupted}s available")
         assert "'" in result
@@ -184,7 +122,3 @@ class TestFixEncoding:
         corrupted = "â"
         result = fix_encoding(f"{corrupted}Hello")
         assert "'" in result
-
-    def test_no_mojibake_unchanged(self):
-        text = "Normal ASCII text with no issues"
-        assert fix_encoding(text) == text

--- a/tests/test_oem_badges.py
+++ b/tests/test_oem_badges.py
@@ -1,6 +1,7 @@
 """Badge rendering for oem_sourced + not_catalogued in the materials list partial, and
 the dual-brand result-row cell ("IBM · Seagate Technology")."""
 
+import pytest
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 
@@ -40,16 +41,21 @@ def _render(status, provenance=None, *, brand=None, manufacturer="Lenovo", show_
     return tmpl.render(materials=[card], lc_colors={}, total=1, limit=50, offset=0)
 
 
-def test_oem_sourced_badge_renders():
-    html = _render(
-        "oem_sourced", {"source_urls": ["https://support.lenovo.com/x"], "source_domains": ["support.lenovo.com"]}
-    )
-    assert "OEM-SOURCED" in html
-
-
-def test_not_catalogued_badge_renders():
-    html = _render("not_catalogued")
-    assert "NOT CATALOGUED" in html
+@pytest.mark.parametrize(
+    ("status", "provenance", "expected"),
+    [
+        pytest.param(
+            "oem_sourced",
+            {"source_urls": ["https://support.lenovo.com/x"], "source_domains": ["support.lenovo.com"]},
+            "OEM-SOURCED",
+            id="oem_sourced",
+        ),
+        pytest.param("not_catalogued", None, "NOT CATALOGUED", id="not_catalogued"),
+    ],
+)
+def test_status_badge_renders(status, provenance, expected):
+    html = _render(status, provenance)
+    assert expected in html
 
 
 # --- Dual-brand cell: brand (OEM label) · manufacturer (actual maker) ---

--- a/tests/test_offer_activity_logging.py
+++ b/tests/test_offer_activity_logging.py
@@ -7,6 +7,8 @@ Called by: pytest
 Depends on: app/services/activity_service.py, app/constants.py, conftest.py
 """
 
+import pytest
+
 from app.constants import ActivityType
 from app.models import ActivityLog
 
@@ -157,23 +159,42 @@ def test_add_offer_htmx_logs_offer_created(client, db_session, test_requisition)
     assert len(rows) == before + 1
 
 
-def test_reject_offer_logs_status_changed(client, db_session, test_requisition, test_offer):
-    """PUT /api/offers/{id}/reject writes one offer_status_changed activity row."""
-    test_offer.status = "pending_review"
+@pytest.mark.parametrize(
+    ("method", "url", "data", "initial_status"),
+    [
+        pytest.param("put", "/api/offers/{offer}/reject", None, "pending_review", id="api_reject"),
+        pytest.param("patch", "/api/offers/{offer}/mark-sold", None, "active", id="api_mark_sold"),
+        pytest.param("post", "/api/offers/{offer}/reject", None, "pending_review", id="api_reject_t4_review"),
+        pytest.param(
+            "post",
+            "/v2/partials/requisitions/{req}/offers/{offer}/review",
+            {"action": "reject"},
+            "pending_review",
+            id="htmx_review_reject",
+        ),
+        pytest.param(
+            "post",
+            "/v2/partials/requisitions/{req}/offers/{offer}/mark-sold",
+            None,
+            "active",
+            id="htmx_mark_sold",
+        ),
+        pytest.param("post", "/v2/partials/offers/{offer}/promote", None, "pending_review", id="htmx_promote"),
+        pytest.param("post", "/v2/partials/offers/{offer}/reject", None, "pending_review", id="htmx_reject"),
+    ],
+)
+def test_status_change_route_logs_status_changed(
+    client, db_session, test_requisition, test_offer, method, url, data, initial_status
+):
+    """Each offer status-change route writes exactly one offer_status_changed activity
+    row."""
+    test_offer.status = initial_status
     db_session.commit()
     before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
-    resp = client.put(f"/api/offers/{test_offer.id}/reject")
-    assert resp.status_code == 200, resp.text
-    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
-    assert len(rows) == before + 1
-
-
-def test_mark_offer_sold_logs_status_changed(client, db_session, test_requisition, test_offer):
-    """PATCH /api/offers/{id}/mark-sold writes one offer_status_changed activity row."""
-    test_offer.status = "active"
-    db_session.commit()
-    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
-    resp = client.patch(f"/api/offers/{test_offer.id}/mark-sold")
+    resp = getattr(client, method)(
+        url.format(req=test_requisition.id, offer=test_offer.id),
+        data=data,
+    )
     assert resp.status_code == 200, resp.text
     rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
     assert len(rows) == before + 1
@@ -191,67 +212,6 @@ def test_promote_offer_logs_status_changed(client, db_session, test_requisition,
     rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
     assert len(rows) == before + 1
     assert rows[0].details["old_status"] != rows[0].details["new_status"]
-
-
-def test_reject_offer_t4_review_logs_status_changed(client, db_session, test_requisition, test_offer):
-    """POST /api/offers/{id}/reject (T4 review) writes one offer_status_changed activity
-    row."""
-    test_offer.status = "pending_review"
-    db_session.commit()
-    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
-    resp = client.post(f"/api/offers/{test_offer.id}/reject")
-    assert resp.status_code == 200, resp.text
-    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
-    assert len(rows) == before + 1
-
-
-def test_review_offer_htmx_reject_logs_status_changed(client, db_session, test_requisition, test_offer):
-    """The HTMX review handler with action=reject logs one offer_status_changed row."""
-    test_offer.status = "pending_review"
-    db_session.commit()
-    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
-    resp = client.post(
-        f"/v2/partials/requisitions/{test_requisition.id}/offers/{test_offer.id}/review",
-        data={"action": "reject"},
-    )
-    assert resp.status_code == 200, resp.text
-    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
-    assert len(rows) == before + 1
-
-
-def test_mark_offer_sold_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):
-    """The mark-sold HTMX handler logs one offer_status_changed row."""
-    test_offer.status = "active"
-    db_session.commit()
-    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
-    resp = client.post(
-        f"/v2/partials/requisitions/{test_requisition.id}/offers/{test_offer.id}/mark-sold",
-    )
-    assert resp.status_code == 200, resp.text
-    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
-    assert len(rows) == before + 1
-
-
-def test_promote_offer_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):
-    """The promote-offer HTMX handler logs one offer_status_changed row."""
-    test_offer.status = "pending_review"
-    db_session.commit()
-    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
-    resp = client.post(f"/v2/partials/offers/{test_offer.id}/promote")
-    assert resp.status_code == 200, resp.text
-    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
-    assert len(rows) == before + 1
-
-
-def test_reject_offer_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):
-    """The reject-offer HTMX handler logs one offer_status_changed row."""
-    test_offer.status = "pending_review"
-    db_session.commit()
-    before = len(_activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED))
-    resp = client.post(f"/v2/partials/offers/{test_offer.id}/reject")
-    assert resp.status_code == 200, resp.text
-    rows = _activity_rows(db_session, test_requisition.id, ActivityType.OFFER_STATUS_CHANGED)
-    assert len(rows) == before + 1
 
 
 def test_review_offer_htmx_logs_status_changed(client, db_session, test_requisition, test_offer):

--- a/tests/test_offers_jobs_comprehensive.py
+++ b/tests/test_offers_jobs_comprehensive.py
@@ -40,6 +40,16 @@ def _clear_scheduler_jobs():
         job.remove()
 
 
+def _mock_strategic_vendor(sv_id, expires_at, vendor_card):
+    """Build a mock strategic-vendor row as returned by get_expiring_soon()."""
+    mock_sv = MagicMock()
+    mock_sv.id = sv_id
+    mock_sv.user_id = None  # set by callers that need it
+    mock_sv.expires_at = expires_at
+    mock_sv.vendor_card = vendor_card
+    return mock_sv
+
+
 # ── register_offers_jobs() ─────────────────────────────────────────────
 
 
@@ -246,11 +256,8 @@ class TestWarnStrategicExpiring:
         """Creates ActivityLog entries for expiring strategic vendors."""
         from app.models import ActivityLog
 
-        mock_sv = MagicMock()
-        mock_sv.id = 99
+        mock_sv = _mock_strategic_vendor(99, datetime.now(timezone.utc) + timedelta(days=3), test_vendor_card)
         mock_sv.user_id = test_user.id
-        mock_sv.expires_at = datetime.now(timezone.utc) + timedelta(days=3)
-        mock_sv.vendor_card = test_vendor_card
 
         with patch("app.services.strategic_vendor_service.get_expiring_soon", return_value=[mock_sv]):
             from app.jobs.offers_jobs import _job_warn_strategic_expiring
@@ -276,11 +283,8 @@ class TestWarnStrategicExpiring:
         scheduler_db.add(existing)
         scheduler_db.commit()
 
-        mock_sv = MagicMock()
-        mock_sv.id = 99
+        mock_sv = _mock_strategic_vendor(99, datetime.now(timezone.utc) + timedelta(days=3), test_vendor_card)
         mock_sv.user_id = test_user.id
-        mock_sv.expires_at = datetime.now(timezone.utc) + timedelta(days=3)
-        mock_sv.vendor_card = test_vendor_card
 
         with patch("app.services.strategic_vendor_service.get_expiring_soon", return_value=[mock_sv]):
             from app.jobs.offers_jobs import _job_warn_strategic_expiring
@@ -292,11 +296,8 @@ class TestWarnStrategicExpiring:
 
     def test_warn_naive_timezone_handling(self, scheduler_db, test_user, test_vendor_card):
         """Handles naive datetime (no tzinfo) on expires_at."""
-        mock_sv = MagicMock()
-        mock_sv.id = 100
+        mock_sv = _mock_strategic_vendor(100, datetime(2026, 4, 1, 12, 0, 0), test_vendor_card)  # Naive datetime
         mock_sv.user_id = test_user.id
-        mock_sv.expires_at = datetime(2026, 4, 1, 12, 0, 0)  # Naive datetime
-        mock_sv.vendor_card = test_vendor_card
 
         with patch("app.services.strategic_vendor_service.get_expiring_soon", return_value=[mock_sv]):
             from app.jobs.offers_jobs import _job_warn_strategic_expiring
@@ -307,11 +308,8 @@ class TestWarnStrategicExpiring:
         """Handles missing vendor_card gracefully (shows 'Unknown')."""
         from app.models import ActivityLog
 
-        mock_sv = MagicMock()
-        mock_sv.id = 101
+        mock_sv = _mock_strategic_vendor(101, datetime.now(timezone.utc) + timedelta(days=2), None)
         mock_sv.user_id = test_user.id
-        mock_sv.expires_at = datetime.now(timezone.utc) + timedelta(days=2)
-        mock_sv.vendor_card = None
 
         with patch("app.services.strategic_vendor_service.get_expiring_soon", return_value=[mock_sv]):
             from app.jobs.offers_jobs import _job_warn_strategic_expiring

--- a/tests/test_ownership_service.py
+++ b/tests/test_ownership_service.py
@@ -28,23 +28,22 @@ class TestDaysSinceActivity:
         result = _days_since_activity(test_company, datetime.now(timezone.utc))
         assert result is None
 
-    def test_returns_days_since_last_activity(self, db_session: Session, test_company: Company):
-        """Correct day count when last_activity_at is set."""
+    @pytest.mark.parametrize(
+        ("days", "naive"),
+        [
+            pytest.param(10, False, id="aware_datetime"),
+            pytest.param(5, True, id="naive_datetime_gets_utc"),
+        ],
+    )
+    def test_returns_days_since_last_activity(self, db_session: Session, test_company: Company, days: int, naive: bool):
+        """Correct day count; naive datetimes get UTC timezone applied."""
         from app.services.ownership_service import _days_since_activity
 
         now = datetime.now(timezone.utc)
-        test_company.last_activity_at = now - timedelta(days=10)
+        last_activity = now - timedelta(days=days)
+        test_company.last_activity_at = last_activity.replace(tzinfo=None) if naive else last_activity
         result = _days_since_activity(test_company, now)
-        assert result == 10
-
-    def test_handles_naive_datetime(self, db_session: Session, test_company: Company):
-        """Naive datetimes get UTC timezone applied."""
-        from app.services.ownership_service import _days_since_activity
-
-        now = datetime.now(timezone.utc)
-        test_company.last_activity_at = (now - timedelta(days=5)).replace(tzinfo=None)
-        result = _days_since_activity(test_company, now)
-        assert result == 5
+        assert result == days
 
 
 class TestClearOwnership:
@@ -107,23 +106,22 @@ class TestSiteDaysSinceActivity:
         result = _site_days_since_activity(test_customer_site, datetime.now(timezone.utc))
         assert result is None
 
-    def test_returns_correct_days(self, db_session: Session, test_customer_site: CustomerSite):
-        """Correct day count."""
+    @pytest.mark.parametrize(
+        ("days", "naive"),
+        [
+            pytest.param(15, False, id="aware_datetime"),
+            pytest.param(7, True, id="naive_datetime_gets_utc"),
+        ],
+    )
+    def test_returns_correct_days(self, db_session: Session, test_customer_site: CustomerSite, days: int, naive: bool):
+        """Correct day count; naive datetimes get UTC timezone applied."""
         from app.services.ownership_service import _site_days_since_activity
 
         now = datetime.now(timezone.utc)
-        test_customer_site.last_activity_at = now - timedelta(days=15)
+        last_activity = now - timedelta(days=days)
+        test_customer_site.last_activity_at = last_activity.replace(tzinfo=None) if naive else last_activity
         result = _site_days_since_activity(test_customer_site, now)
-        assert result == 15
-
-    def test_handles_naive_datetime(self, db_session: Session, test_customer_site: CustomerSite):
-        """Naive datetimes get UTC timezone applied."""
-        from app.services.ownership_service import _site_days_since_activity
-
-        now = datetime.now(timezone.utc)
-        test_customer_site.last_activity_at = (now - timedelta(days=7)).replace(tzinfo=None)
-        result = _site_days_since_activity(test_customer_site, now)
-        assert result == 7
+        assert result == days
 
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -529,12 +527,26 @@ class TestGetOpenPoolAccounts:
 class TestGetMyAccounts:
     """Tests for get_my_accounts()."""
 
-    def test_returns_owned_accounts_with_status(self, db_session: Session, test_company: Company, sales_user: User):
-        """Returns accounts owned by user with health status."""
+    @pytest.mark.parametrize(
+        ("days_inactive", "expected_status"),
+        [
+            pytest.param(5, "green", id="recent_green"),
+            pytest.param(25, "yellow", id="warning_zone_yellow"),
+            pytest.param(35, "red", id="past_limit_red"),
+            pytest.param(None, "no_activity", id="no_activity"),
+        ],
+    )
+    def test_returns_owned_accounts_with_status(
+        self, db_session: Session, test_company: Company, sales_user: User, days_inactive, expected_status: str
+    ):
+        """Returns accounts owned by user with the correct health status."""
         from app.services.ownership_service import get_my_accounts
 
         test_company.account_owner_id = sales_user.id
-        test_company.last_activity_at = datetime.now(timezone.utc) - timedelta(days=5)
+        if days_inactive is None:
+            test_company.last_activity_at = None
+        else:
+            test_company.last_activity_at = datetime.now(timezone.utc) - timedelta(days=days_inactive)
         test_company.is_active = True
         db_session.commit()
 
@@ -544,55 +556,7 @@ class TestGetMyAccounts:
             result = get_my_accounts(sales_user.id, db_session)
 
         assert len(result) == 1
-        assert result[0]["status"] == "green"
-
-    def test_yellow_status_in_warning_zone(self, db_session: Session, test_company: Company, sales_user: User):
-        """Account in warning zone shows yellow status."""
-        from app.services.ownership_service import get_my_accounts
-
-        test_company.account_owner_id = sales_user.id
-        test_company.last_activity_at = datetime.now(timezone.utc) - timedelta(days=25)
-        test_company.is_active = True
-        db_session.commit()
-
-        with patch("app.services.ownership_service.settings") as mock_settings:
-            mock_settings.customer_inactivity_days = 30
-            mock_settings.strategic_inactivity_days = 90
-            result = get_my_accounts(sales_user.id, db_session)
-
-        assert result[0]["status"] == "yellow"
-
-    def test_red_status_past_limit(self, db_session: Session, test_company: Company, sales_user: User):
-        """Account past inactivity limit shows red status."""
-        from app.services.ownership_service import get_my_accounts
-
-        test_company.account_owner_id = sales_user.id
-        test_company.last_activity_at = datetime.now(timezone.utc) - timedelta(days=35)
-        test_company.is_active = True
-        db_session.commit()
-
-        with patch("app.services.ownership_service.settings") as mock_settings:
-            mock_settings.customer_inactivity_days = 30
-            mock_settings.strategic_inactivity_days = 90
-            result = get_my_accounts(sales_user.id, db_session)
-
-        assert result[0]["status"] == "red"
-
-    def test_no_activity_status(self, db_session: Session, test_company: Company, sales_user: User):
-        """Account with no activity shows no_activity status."""
-        from app.services.ownership_service import get_my_accounts
-
-        test_company.account_owner_id = sales_user.id
-        test_company.last_activity_at = None
-        test_company.is_active = True
-        db_session.commit()
-
-        with patch("app.services.ownership_service.settings") as mock_settings:
-            mock_settings.customer_inactivity_days = 30
-            mock_settings.strategic_inactivity_days = 90
-            result = get_my_accounts(sales_user.id, db_session)
-
-        assert result[0]["status"] == "no_activity"
+        assert result[0]["status"] == expected_status
 
     def test_excludes_other_users_accounts(
         self, db_session: Session, test_company: Company, sales_user: User, test_user: User
@@ -836,14 +800,32 @@ class TestGetOpenPoolSites:
 class TestGetMySites:
     """Tests for get_my_sites()."""
 
+    @pytest.mark.parametrize(
+        ("days_inactive", "expected_status"),
+        [
+            pytest.param(5, "green", id="recent_green"),
+            pytest.param(25, "yellow", id="warning_zone_yellow"),
+            pytest.param(35, "red", id="past_limit_red"),
+            pytest.param(None, "no_activity", id="no_activity"),
+        ],
+    )
     def test_returns_owned_sites_with_status(
-        self, db_session: Session, test_customer_site: CustomerSite, sales_user: User, test_company: Company
+        self,
+        db_session: Session,
+        test_customer_site: CustomerSite,
+        sales_user: User,
+        test_company: Company,
+        days_inactive,
+        expected_status: str,
     ):
-        """Returns sites owned by user with health status."""
+        """Returns sites owned by user with the correct health status."""
         from app.services.ownership_service import get_my_sites
 
         test_customer_site.owner_id = sales_user.id
-        test_customer_site.last_activity_at = datetime.now(timezone.utc) - timedelta(days=5)
+        if days_inactive is None:
+            test_customer_site.last_activity_at = None
+        else:
+            test_customer_site.last_activity_at = datetime.now(timezone.utc) - timedelta(days=days_inactive)
         test_customer_site.is_active = True
         db_session.commit()
 
@@ -852,53 +834,8 @@ class TestGetMySites:
             result = get_my_sites(sales_user.id, db_session)
 
         assert len(result) == 1
-        assert result[0]["status"] == "green"
+        assert result[0]["status"] == expected_status
         assert result[0]["company_name"] == test_company.name
-
-    def test_yellow_status(self, db_session: Session, test_customer_site: CustomerSite, sales_user: User):
-        """Site in warning zone shows yellow."""
-        from app.services.ownership_service import get_my_sites
-
-        test_customer_site.owner_id = sales_user.id
-        test_customer_site.last_activity_at = datetime.now(timezone.utc) - timedelta(days=25)
-        test_customer_site.is_active = True
-        db_session.commit()
-
-        with patch("app.services.ownership_service.settings") as mock_settings:
-            mock_settings.customer_inactivity_days = 30
-            result = get_my_sites(sales_user.id, db_session)
-
-        assert result[0]["status"] == "yellow"
-
-    def test_red_status(self, db_session: Session, test_customer_site: CustomerSite, sales_user: User):
-        """Site past limit shows red."""
-        from app.services.ownership_service import get_my_sites
-
-        test_customer_site.owner_id = sales_user.id
-        test_customer_site.last_activity_at = datetime.now(timezone.utc) - timedelta(days=35)
-        test_customer_site.is_active = True
-        db_session.commit()
-
-        with patch("app.services.ownership_service.settings") as mock_settings:
-            mock_settings.customer_inactivity_days = 30
-            result = get_my_sites(sales_user.id, db_session)
-
-        assert result[0]["status"] == "red"
-
-    def test_no_activity_status(self, db_session: Session, test_customer_site: CustomerSite, sales_user: User):
-        """Site with no activity shows no_activity."""
-        from app.services.ownership_service import get_my_sites
-
-        test_customer_site.owner_id = sales_user.id
-        test_customer_site.last_activity_at = None
-        test_customer_site.is_active = True
-        db_session.commit()
-
-        with patch("app.services.ownership_service.settings") as mock_settings:
-            mock_settings.customer_inactivity_days = 30
-            result = get_my_sites(sales_user.id, db_session)
-
-        assert result[0]["status"] == "no_activity"
 
 
 class TestGetSitesAtRisk:

--- a/tests/test_part_level_endpoints.py
+++ b/tests/test_part_level_endpoints.py
@@ -12,14 +12,22 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _first_requirement(db_session, requisition):
+    """Return the first Requirement row for the given requisition."""
+    from app.models import Requirement
+
+    return db_session.query(Requirement).filter(Requirement.requisition_id == requisition.id).first()
+
+
 # ── Part-level Offers ───────────────────────────────────────────────
 
 
 def test_list_requirement_offers_empty(client, test_requisition, db_session):
     """GET /api/requirements/{id}/offers returns empty list when no offers exist."""
-    from app.models import Requirement
-
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     resp = client.get(f"/api/requirements/{req.id}/offers")
     assert resp.status_code == 200
     assert resp.json() == []
@@ -27,9 +35,9 @@ def test_list_requirement_offers_empty(client, test_requisition, db_session):
 
 def test_list_requirement_offers_with_data(client, test_requisition, db_session):
     """GET /api/requirements/{id}/offers returns offers for this requirement."""
-    from app.models import Offer, Requirement
+    from app.models import Offer
 
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     offer = Offer(
         requisition_id=test_requisition.id,
         requirement_id=req.id,
@@ -56,9 +64,9 @@ def test_list_requirement_offers_with_data(client, test_requisition, db_session)
 def test_list_requirement_offers_includes_extended_fields(client, test_requisition, db_session):
     """GET /api/requirements/{id}/offers returns country_of_origin, firmware, source,
     entered_by."""
-    from app.models import Offer, Requirement
+    from app.models import Offer
 
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     offer = Offer(
         requisition_id=test_requisition.id,
         requirement_id=req.id,
@@ -98,9 +106,7 @@ def test_list_requirement_offers_404(client):
 
 def test_list_requirement_sightings_empty(client, test_requisition, db_session):
     """GET /api/requirements/{id}/sightings returns empty list when none exist."""
-    from app.models import Requirement
-
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     resp = client.get(f"/api/requirements/{req.id}/sightings")
     assert resp.status_code == 200
     data = resp.json()
@@ -110,9 +116,9 @@ def test_list_requirement_sightings_empty(client, test_requisition, db_session):
 
 def test_list_requirement_sightings_with_data(client, test_requisition, db_session):
     """GET /api/requirements/{id}/sightings returns sightings for this requirement."""
-    from app.models import Requirement, Sighting
+    from app.models import Sighting
 
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     sighting = Sighting(
         requirement_id=req.id,
         vendor_name="Arrow",
@@ -142,9 +148,7 @@ def test_list_requirement_sightings_with_data(client, test_requisition, db_sessi
 
 def test_list_requirement_notes_empty(client, test_requisition, db_session):
     """GET /api/requirements/{id}/notes returns empty when no notes."""
-    from app.models import Requirement
-
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     req.notes = None
     db_session.commit()
 
@@ -157,9 +161,7 @@ def test_list_requirement_notes_empty(client, test_requisition, db_session):
 
 def test_add_requirement_note(client, test_requisition, db_session):
     """POST /api/requirements/{id}/notes appends to requirement notes."""
-    from app.models import Requirement
-
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     req.notes = None
     db_session.commit()
 
@@ -177,18 +179,16 @@ def test_add_requirement_note(client, test_requisition, db_session):
 
 def test_add_requirement_note_empty_text(client, test_requisition, db_session):
     """POST /api/requirements/{id}/notes rejects empty text."""
-    from app.models import Requirement
-
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     resp = client.post(f"/api/requirements/{req.id}/notes", json={"text": ""})
     assert resp.status_code == 422
 
 
 def test_list_requirement_notes_with_offer_notes(client, test_requisition, db_session):
     """GET /api/requirements/{id}/notes includes offer notes."""
-    from app.models import Offer, Requirement
+    from app.models import Offer
 
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     offer = Offer(
         requisition_id=test_requisition.id,
         requirement_id=req.id,
@@ -214,9 +214,7 @@ def test_list_requirement_notes_with_offer_notes(client, test_requisition, db_se
 
 def test_list_requirement_tasks_empty(client, test_requisition, db_session):
     """GET /api/requirements/{id}/tasks returns empty when no tasks."""
-    from app.models import Requirement
-
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     resp = client.get(f"/api/requirements/{req.id}/tasks")
     assert resp.status_code == 200
     assert resp.json() == []
@@ -224,9 +222,7 @@ def test_list_requirement_tasks_empty(client, test_requisition, db_session):
 
 def test_create_requirement_task(client, test_requisition, db_session):
     """POST /api/requirements/{id}/tasks creates a task linked to the requirement."""
-    from app.models import Requirement
-
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     resp = client.post(f"/api/requirements/{req.id}/tasks", json={"title": "Follow up on pricing"})
     assert resp.status_code == 200
     data = resp.json()
@@ -243,9 +239,7 @@ def test_create_requirement_task(client, test_requisition, db_session):
 
 def test_create_requirement_task_empty_title(client, test_requisition, db_session):
     """POST /api/requirements/{id}/tasks rejects empty title."""
-    from app.models import Requirement
-
-    req = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    req = _first_requirement(db_session, test_requisition)
     resp = client.post(f"/api/requirements/{req.id}/tasks", json={"title": ""})
     assert resp.status_code == 422
 

--- a/tests/test_presence_service_coverage.py
+++ b/tests/test_presence_service_coverage.py
@@ -17,177 +17,105 @@ os.environ["TESTING"] = "1"
 
 from unittest.mock import AsyncMock
 
+import pytest
+
+import app.services.presence_service as svc
+
+
+@pytest.fixture()
+def isolated_cache():
+    """Snapshot _presence_cache (and _CACHE_MAX), clear it for the test, then
+    restore."""
+    original_cache = svc._presence_cache.copy()
+    original_max = svc._CACHE_MAX
+    svc._presence_cache.clear()
+    try:
+        yield svc
+    finally:
+        svc._CACHE_MAX = original_max
+        svc._presence_cache.clear()
+        svc._presence_cache.update(original_cache)
+
+
 # ---------------------------------------------------------------------------
 # LRU eviction — lines 35-37
 # ---------------------------------------------------------------------------
 
 
-async def test_get_presence_lru_eviction_triggers():
+async def test_get_presence_lru_eviction_triggers(isolated_cache):
     """When cache is at _CACHE_MAX, oldest 20% entries are evicted before inserting."""
     import time
 
-    import app.services.presence_service as svc
+    isolated_cache._CACHE_MAX = 5
 
-    # Save original values and patch _CACHE_MAX to a small number for test speed
-    original_cache = svc._presence_cache.copy()
-    original_max = svc._CACHE_MAX
+    # Fill cache to exactly _CACHE_MAX entries with staggered timestamps
+    base_time = time.monotonic() - 100
+    for i in range(5):
+        isolated_cache._presence_cache[f"user{i}@example.com"] = ("Available", base_time + i)
 
-    try:
-        svc._CACHE_MAX = 5
-        svc._presence_cache.clear()
+    assert len(isolated_cache._presence_cache) == 5
 
-        # Fill cache to exactly _CACHE_MAX entries with staggered timestamps
-        base_time = time.monotonic() - 100
-        for i in range(5):
-            svc._presence_cache[f"user{i}@example.com"] = ("Available", base_time + i)
+    # Now call get_presence for a new email — eviction should fire (5 >= 5)
+    mock_gc = AsyncMock()
+    mock_gc.get_json.return_value = {"availability": "Busy"}
 
-        assert len(svc._presence_cache) == 5
+    result = await isolated_cache.get_presence("new_user@example.com", mock_gc)
 
-        # Now call get_presence for a new email — eviction should fire (5 >= 5)
-        mock_gc = AsyncMock()
-        mock_gc.get_json.return_value = {"availability": "Busy"}
-
-        result = await svc.get_presence("new_user@example.com", mock_gc)
-
-        # After eviction (removes oldest 20% = 1 entry) and insert, size should be ≤ 5
-        assert result == "Busy"
-        assert "new_user@example.com" in svc._presence_cache
-        # One entry was evicted (user0, the oldest), so size should be 5 again
-        assert len(svc._presence_cache) == 5
-        assert "user0@example.com" not in svc._presence_cache
-
-    finally:
-        svc._CACHE_MAX = original_max
-        svc._presence_cache.clear()
-        svc._presence_cache.update(original_cache)
+    # After eviction (removes oldest 20% = 1 entry) and insert, size should be ≤ 5
+    assert result == "Busy"
+    assert "new_user@example.com" in isolated_cache._presence_cache
+    # One entry was evicted (user0, the oldest), so size should be 5 again
+    assert len(isolated_cache._presence_cache) == 5
+    assert "user0@example.com" not in isolated_cache._presence_cache
 
 
-async def test_get_presence_lru_eviction_removes_oldest_twenty_percent():
+async def test_get_presence_lru_eviction_removes_oldest_twenty_percent(isolated_cache):
     """LRU eviction removes exactly _CACHE_MAX // 5 oldest entries."""
     import time
 
-    import app.services.presence_service as svc
+    isolated_cache._CACHE_MAX = 10
 
-    original_cache = svc._presence_cache.copy()
-    original_max = svc._CACHE_MAX
+    base_time = time.monotonic() - 200
+    for i in range(10):
+        isolated_cache._presence_cache[f"evict{i}@example.com"] = ("Away", base_time + i)
 
-    try:
-        svc._CACHE_MAX = 10
-        svc._presence_cache.clear()
+    mock_gc = AsyncMock()
+    mock_gc.get_json.return_value = {"availability": "DoNotDisturb"}
 
-        base_time = time.monotonic() - 200
-        for i in range(10):
-            svc._presence_cache[f"evict{i}@example.com"] = ("Away", base_time + i)
+    result = await isolated_cache.get_presence("fresh@example.com", mock_gc)
 
-        mock_gc = AsyncMock()
-        mock_gc.get_json.return_value = {"availability": "DoNotDisturb"}
-
-        result = await svc.get_presence("fresh@example.com", mock_gc)
-
-        assert result == "DoNotDisturb"
-        # 2 oldest (10 // 5 = 2) should be evicted, then 1 new entry added → 9 total
-        assert len(svc._presence_cache) == 9
-        assert "evict0@example.com" not in svc._presence_cache
-        assert "evict1@example.com" not in svc._presence_cache
-
-    finally:
-        svc._CACHE_MAX = original_max
-        svc._presence_cache.clear()
-        svc._presence_cache.update(original_cache)
+    assert result == "DoNotDisturb"
+    # 2 oldest (10 // 5 = 2) should be evicted, then 1 new entry added → 9 total
+    assert len(isolated_cache._presence_cache) == 9
+    assert "evict0@example.com" not in isolated_cache._presence_cache
+    assert "evict1@example.com" not in isolated_cache._presence_cache
 
 
 # ---------------------------------------------------------------------------
-# Exception handling — auth failure (lines 41-43)
+# Exception handling — auth failure (lines 41-43) and general warning (lines 44-46)
 # ---------------------------------------------------------------------------
 
 
-async def test_get_presence_auth_failure_401_returns_none():
-    """When graph client raises an error containing '401', logs auth error and returns
-    None."""
-    import app.services.presence_service as svc
+@pytest.mark.parametrize(
+    ("email", "error"),
+    [
+        # Errors containing 401/403 log an auth error and return None.
+        pytest.param("authfail@example.com", Exception("401 Unauthorized — token expired"), id="auth_failure_401"),
+        pytest.param("forbidden@example.com", Exception("403 Forbidden — insufficient scope"), id="auth_failure_403"),
+        # Non-auth exceptions log a warning (not error) and return None.
+        pytest.param("offline@example.com", ConnectionError("Network unreachable"), id="general_exception"),
+        pytest.param("timeout@example.com", TimeoutError("Request timed out"), id="timeout_exception"),
+    ],
+)
+async def test_get_presence_exception_returns_none(isolated_cache, email, error):
+    """A get_json failure returns None and does not cache the email."""
+    mock_gc = AsyncMock()
+    mock_gc.get_json.side_effect = error
 
-    original_cache = svc._presence_cache.copy()
-    svc._presence_cache.clear()
+    result = await isolated_cache.get_presence(email, mock_gc)
 
-    try:
-        mock_gc = AsyncMock()
-        mock_gc.get_json.side_effect = Exception("401 Unauthorized — token expired")
-
-        result = await svc.get_presence("authfail@example.com", mock_gc)
-
-        assert result is None
-        assert "authfail@example.com" not in svc._presence_cache
-
-    finally:
-        svc._presence_cache.clear()
-        svc._presence_cache.update(original_cache)
-
-
-async def test_get_presence_auth_failure_403_returns_none():
-    """When graph client raises an error containing '403', logs auth error and returns
-    None."""
-    import app.services.presence_service as svc
-
-    original_cache = svc._presence_cache.copy()
-    svc._presence_cache.clear()
-
-    try:
-        mock_gc = AsyncMock()
-        mock_gc.get_json.side_effect = Exception("403 Forbidden — insufficient scope")
-
-        result = await svc.get_presence("forbidden@example.com", mock_gc)
-
-        assert result is None
-
-    finally:
-        svc._presence_cache.clear()
-        svc._presence_cache.update(original_cache)
-
-
-# ---------------------------------------------------------------------------
-# Exception handling — general warning (lines 44-46)
-# ---------------------------------------------------------------------------
-
-
-async def test_get_presence_general_exception_returns_none():
-    """Non-auth exceptions log a warning (not error) and return None."""
-    import app.services.presence_service as svc
-
-    original_cache = svc._presence_cache.copy()
-    svc._presence_cache.clear()
-
-    try:
-        mock_gc = AsyncMock()
-        mock_gc.get_json.side_effect = ConnectionError("Network unreachable")
-
-        result = await svc.get_presence("offline@example.com", mock_gc)
-
-        assert result is None
-        assert "offline@example.com" not in svc._presence_cache
-
-    finally:
-        svc._presence_cache.clear()
-        svc._presence_cache.update(original_cache)
-
-
-async def test_get_presence_timeout_exception_returns_none():
-    """TimeoutError is a general exception — logs warning and returns None."""
-    import app.services.presence_service as svc
-
-    original_cache = svc._presence_cache.copy()
-    svc._presence_cache.clear()
-
-    try:
-        mock_gc = AsyncMock()
-        mock_gc.get_json.side_effect = TimeoutError("Request timed out")
-
-        result = await svc.get_presence("timeout@example.com", mock_gc)
-
-        assert result is None
-
-    finally:
-        svc._presence_cache.clear()
-        svc._presence_cache.update(original_cache)
+    assert result is None
+    assert email not in isolated_cache._presence_cache
 
 
 # ---------------------------------------------------------------------------
@@ -195,25 +123,16 @@ async def test_get_presence_timeout_exception_returns_none():
 # ---------------------------------------------------------------------------
 
 
-def test_presence_color_be_right_back():
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        pytest.param("BeRightBack", "bg-amber-400", id="be_right_back"),
+        pytest.param("DoNotDisturb", "bg-rose-400", id="do_not_disturb"),
+        pytest.param("Offline", "bg-gray-300", id="offline"),
+        pytest.param("PresenceUnknown", "bg-gray-300", id="unknown_string"),
+    ],
+)
+def test_presence_color(status, expected):
     from app.services.presence_service import presence_color
 
-    assert presence_color("BeRightBack") == "bg-amber-400"
-
-
-def test_presence_color_do_not_disturb():
-    from app.services.presence_service import presence_color
-
-    assert presence_color("DoNotDisturb") == "bg-rose-400"
-
-
-def test_presence_color_offline():
-    from app.services.presence_service import presence_color
-
-    assert presence_color("Offline") == "bg-gray-300"
-
-
-def test_presence_color_unknown_string():
-    from app.services.presence_service import presence_color
-
-    assert presence_color("PresenceUnknown") == "bg-gray-300"
+    assert presence_color(status) == expected

--- a/tests/test_prospect_free_enrichment.py
+++ b/tests/test_prospect_free_enrichment.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 from xml.etree.ElementTree import Element, SubElement, tostring
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models.prospect_account import ProspectAccount
@@ -56,51 +57,66 @@ def _build_rss_xml(items: list[dict]) -> bytes:
     return tostring(rss)
 
 
+def _run(coro):
+    """Run an async coroutine to completion on the event loop."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _mock_http(get_return=None, get_side_effect=None) -> MagicMock:
+    """Build a mock http client whose async .get() returns/raises as configured."""
+    http = MagicMock()
+    http.get = AsyncMock(return_value=get_return, side_effect=get_side_effect)
+    return http
+
+
+def _mock_batch_session(prospect_id_rows: list) -> MagicMock:
+    """Build a mock Session whose chained query returns the given prospect-id rows."""
+    session = MagicMock(spec=Session)
+    query = MagicMock()
+    query.filter.return_value = query
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.all.return_value = prospect_id_rows
+    session.query.return_value = query
+    session.close = MagicMock()
+    return session
+
+
 # ── _classify_headline tests ─────────────────────────────────────────
 
 
 class TestClassifyHeadline:
-    def test_funding(self):
-        assert _classify_headline("Acme raises $50M in Series B") == "funding"
-        assert _classify_headline("Company IPO expected next quarter") == "funding"
-
-    def test_acquisition(self):
-        assert _classify_headline("BigCorp acquires SmallCo for $1B") == "acquisition"
-        assert _classify_headline("Merger between Acme and Widget Corp") == "acquisition"
-        assert _classify_headline("Company buys rival firm") == "acquisition"
-
-    def test_expansion(self):
-        assert _classify_headline("Acme opens new facility in Texas") == "expansion"
-        assert _classify_headline("Company expands operations globally") == "expansion"
-        assert _classify_headline("New plant announced in Ohio") == "expansion"
-
-    def test_product(self):
-        assert _classify_headline("Acme launches new product line") == "product"
-        assert _classify_headline("Company unveils groundbreaking tech") == "product"
-        assert _classify_headline("Company introduces new component") == "product"
-
-    def test_hiring(self):
-        assert _classify_headline("Acme hiring 500 engineers") == "hiring"
-        assert _classify_headline("Company recruits top talent") == "hiring"
-
-    def test_layoffs(self):
-        assert _classify_headline("Company announces layoffs") == "layoffs"
-        assert _classify_headline("Acme cuts 200 jobs") == "layoffs"
-        assert _classify_headline("Restructuring plan announced") == "layoffs"
-
-    def test_contract(self):
-        assert _classify_headline("Acme wins $100M defense contract") == "contract"
-        assert _classify_headline("Government awards major deal") == "contract"
-        assert _classify_headline("Pentagon contract to Acme Corp") == "contract"
-
-    def test_regulatory(self):
-        assert _classify_headline("FDA approves new device") == "regulatory"
-        assert _classify_headline("Company receives FAA certification") == "regulatory"
-        assert _classify_headline("Regulatory compliance update") == "regulatory"
-
-    def test_general(self):
-        assert _classify_headline("Acme Corp reports Q4 earnings") == "general"
-        assert _classify_headline("Market update for semiconductors") == "general"
+    @pytest.mark.parametrize(
+        ("headline", "expected"),
+        [
+            ("Acme raises $50M in Series B", "funding"),
+            ("Company IPO expected next quarter", "funding"),
+            ("BigCorp acquires SmallCo for $1B", "acquisition"),
+            ("Merger between Acme and Widget Corp", "acquisition"),
+            ("Company buys rival firm", "acquisition"),
+            ("Acme opens new facility in Texas", "expansion"),
+            ("Company expands operations globally", "expansion"),
+            ("New plant announced in Ohio", "expansion"),
+            ("Acme launches new product line", "product"),
+            ("Company unveils groundbreaking tech", "product"),
+            ("Company introduces new component", "product"),
+            ("Acme hiring 500 engineers", "hiring"),
+            ("Company recruits top talent", "hiring"),
+            ("Company announces layoffs", "layoffs"),
+            ("Acme cuts 200 jobs", "layoffs"),
+            ("Restructuring plan announced", "layoffs"),
+            ("Acme wins $100M defense contract", "contract"),
+            ("Government awards major deal", "contract"),
+            ("Pentagon contract to Acme Corp", "contract"),
+            ("FDA approves new device", "regulatory"),
+            ("Company receives FAA certification", "regulatory"),
+            ("Regulatory compliance update", "regulatory"),
+            ("Acme Corp reports Q4 earnings", "general"),
+            ("Market update for semiconductors", "general"),
+        ],
+    )
+    def test_classify(self, headline, expected):
+        assert _classify_headline(headline) == expected
 
 
 # ── enrich_from_sam_gov tests ────────────────────────────────────────
@@ -109,12 +125,12 @@ class TestClassifyHeadline:
 class TestEnrichFromSamGov:
     def test_empty_name_returns_none(self, db_session):
         prospect = _make_prospect(db_session, name="")
-        result = asyncio.get_event_loop().run_until_complete(enrich_from_sam_gov(prospect))
+        result = _run(enrich_from_sam_gov(prospect))
         assert result is None
 
     def test_whitespace_name_returns_none(self, db_session):
         prospect = _make_prospect(db_session, name="   ")
-        result = asyncio.get_event_loop().run_until_complete(enrich_from_sam_gov(prospect))
+        result = _run(enrich_from_sam_gov(prospect))
         assert result is None
 
     def test_successful_enrichment(self, db_session):
@@ -153,11 +169,8 @@ class TestEnrichFromSamGov:
             ]
         }
 
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(return_value=mock_resp)
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_sam_gov(prospect))
+        with patch("app.http_client.http", _mock_http(get_return=mock_resp)):
+            result = _run(enrich_from_sam_gov(prospect))
 
         assert result is not None
         assert result["source"] == "sam_gov"
@@ -175,11 +188,8 @@ class TestEnrichFromSamGov:
         mock_resp.status_code = 429
         mock_resp.text = "Rate limited"
 
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(return_value=mock_resp)
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_sam_gov(prospect))
+        with patch("app.http_client.http", _mock_http(get_return=mock_resp)):
+            result = _run(enrich_from_sam_gov(prospect))
         assert result is None
 
     def test_no_entities_returns_none(self, db_session):
@@ -188,20 +198,14 @@ class TestEnrichFromSamGov:
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"entityData": []}
 
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(return_value=mock_resp)
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_sam_gov(prospect))
+        with patch("app.http_client.http", _mock_http(get_return=mock_resp)):
+            result = _run(enrich_from_sam_gov(prospect))
         assert result is None
 
     def test_exception_returns_none(self, db_session):
         prospect = _make_prospect(db_session, name="Acme Corp")
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(side_effect=ConnectionError("DNS failure"))
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_sam_gov(prospect))
+        with patch("app.http_client.http", _mock_http(get_side_effect=ConnectionError("DNS failure"))):
+            result = _run(enrich_from_sam_gov(prospect))
         assert result is None
 
     def test_naics_dict_filter(self, db_session):
@@ -225,11 +229,8 @@ class TestEnrichFromSamGov:
             ]
         }
 
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(return_value=mock_resp)
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_sam_gov(prospect))
+        with patch("app.http_client.http", _mock_http(get_return=mock_resp)):
+            result = _run(enrich_from_sam_gov(prospect))
 
         assert len(result["naics_codes"]) == 1
         assert result["naics_codes"][0]["code"] == "111"
@@ -241,7 +242,7 @@ class TestEnrichFromSamGov:
 class TestEnrichFromGoogleNews:
     def test_empty_name_returns_empty(self, db_session):
         prospect = _make_prospect(db_session, name="")
-        result = asyncio.get_event_loop().run_until_complete(enrich_from_google_news(prospect))
+        result = _run(enrich_from_google_news(prospect))
         assert result == []
 
     def test_successful_fetch(self, db_session):
@@ -257,11 +258,8 @@ class TestEnrichFromGoogleNews:
         mock_resp.status_code = 200
         mock_resp.content = rss_xml
 
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(return_value=mock_resp)
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_google_news(prospect))
+        with patch("app.http_client.http", _mock_http(get_return=mock_resp)):
+            result = _run(enrich_from_google_news(prospect))
 
         assert len(result) == 2
         assert result[0]["signal_type"] == "funding"
@@ -272,11 +270,8 @@ class TestEnrichFromGoogleNews:
         mock_resp = MagicMock()
         mock_resp.status_code = 503
 
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(return_value=mock_resp)
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_google_news(prospect))
+        with patch("app.http_client.http", _mock_http(get_return=mock_resp)):
+            result = _run(enrich_from_google_news(prospect))
         assert result == []
 
     def test_max_items_limit(self, db_session):
@@ -288,11 +283,8 @@ class TestEnrichFromGoogleNews:
         mock_resp.status_code = 200
         mock_resp.content = rss_xml
 
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(return_value=mock_resp)
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_google_news(prospect, max_items=3))
+        with patch("app.http_client.http", _mock_http(get_return=mock_resp)):
+            result = _run(enrich_from_google_news(prospect, max_items=3))
         assert len(result) == 3
 
     def test_no_channel_returns_empty(self, db_session):
@@ -304,20 +296,14 @@ class TestEnrichFromGoogleNews:
         mock_resp.status_code = 200
         mock_resp.content = rss_xml
 
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(return_value=mock_resp)
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_google_news(prospect))
+        with patch("app.http_client.http", _mock_http(get_return=mock_resp)):
+            result = _run(enrich_from_google_news(prospect))
         assert result == []
 
     def test_exception_returns_empty(self, db_session):
         prospect = _make_prospect(db_session, name="Acme Corp")
-        mock_http = MagicMock()
-        mock_http.get = AsyncMock(side_effect=Exception("Network error"))
-
-        with patch("app.http_client.http", mock_http):
-            result = asyncio.get_event_loop().run_until_complete(enrich_from_google_news(prospect))
+        with patch("app.http_client.http", _mock_http(get_side_effect=Exception("Network error"))):
+            result = _run(enrich_from_google_news(prospect))
         assert result == []
 
 
@@ -326,7 +312,7 @@ class TestEnrichFromGoogleNews:
 
 class TestRunFreeEnrichment:
     def test_prospect_not_found(self, db_session):
-        result = asyncio.get_event_loop().run_until_complete(run_free_enrichment(99999, db=db_session))
+        result = _run(run_free_enrichment(99999, db=db_session))
         assert result == {"error": "not_found"}
 
     def test_sam_gov_enriches(self, db_session):
@@ -350,7 +336,7 @@ class TestRunFreeEnrichment:
                 new_callable=AsyncMock,
                 return_value=[],
             ):
-                result = asyncio.get_event_loop().run_until_complete(run_free_enrichment(prospect.id, db=db_session))
+                result = _run(run_free_enrichment(prospect.id, db=db_session))
 
         assert result["sam_gov"] is True
         assert result["news_count"] == 0
@@ -375,7 +361,7 @@ class TestRunFreeEnrichment:
                 new_callable=AsyncMock,
                 return_value=[],
             ):
-                result = asyncio.get_event_loop().run_until_complete(run_free_enrichment(prospect.id, db=db_session))
+                result = _run(run_free_enrichment(prospect.id, db=db_session))
 
         mock_sam.assert_not_called()
         assert result["sam_gov"] is False
@@ -411,7 +397,7 @@ class TestRunFreeEnrichment:
                 new_callable=AsyncMock,
                 return_value=news,
             ):
-                result = asyncio.get_event_loop().run_until_complete(run_free_enrichment(prospect.id, db=db_session))
+                result = _run(run_free_enrichment(prospect.id, db=db_session))
 
         assert result["news_count"] == 2
         db_session.refresh(prospect)
@@ -431,7 +417,7 @@ class TestRunFreeEnrichment:
             new_callable=AsyncMock,
             side_effect=Exception("boom"),
         ):
-            result = asyncio.get_event_loop().run_until_complete(run_free_enrichment(prospect.id, db=db_session))
+            result = _run(run_free_enrichment(prospect.id, db=db_session))
 
         assert "error" in result
 
@@ -444,7 +430,7 @@ class TestRunFreeEnrichment:
             "app.database.SessionLocal",
             return_value=mock_session,
         ):
-            result = asyncio.get_event_loop().run_until_complete(run_free_enrichment(123))
+            result = _run(run_free_enrichment(123))
 
         assert result == {"error": "not_found"}
         mock_session.close.assert_called_once()
@@ -468,7 +454,7 @@ class TestRunFreeEnrichment:
                 new_callable=AsyncMock,
                 return_value=[],
             ):
-                asyncio.get_event_loop().run_until_complete(run_free_enrichment(prospect.id, db=db_session))
+                _run(run_free_enrichment(prospect.id, db=db_session))
 
         db_session.refresh(prospect)
         assert prospect.naics_code == "999999"  # Unchanged
@@ -503,7 +489,7 @@ class TestRunFreeEnrichment:
                 new_callable=AsyncMock,
                 return_value=news,
             ):
-                asyncio.get_event_loop().run_until_complete(run_free_enrichment(prospect.id, db=db_session))
+                _run(run_free_enrichment(prospect.id, db=db_session))
 
         db_session.refresh(prospect)
         events = prospect.readiness_signals.get("events", [])
@@ -527,14 +513,7 @@ class TestRunFreeEnrichmentBatch:
             )
         db_session.commit()
 
-        mock_session = MagicMock(spec=Session)
-        prospects_query = MagicMock()
-        prospects_query.filter.return_value = prospects_query
-        prospects_query.order_by.return_value = prospects_query
-        prospects_query.limit.return_value = prospects_query
-        prospects_query.all.return_value = [(1,), (2,), (3,)]
-        mock_session.query.return_value = prospects_query
-        mock_session.close = MagicMock()
+        mock_session = _mock_batch_session([(1,), (2,), (3,)])
 
         with patch(
             "app.database.SessionLocal",
@@ -545,7 +524,7 @@ class TestRunFreeEnrichmentBatch:
                 new_callable=AsyncMock,
                 return_value={"sam_gov": True, "news_count": 2},
             ) as mock_enrich:
-                result = asyncio.get_event_loop().run_until_complete(run_free_enrichment_batch(min_fit_score=40))
+                result = _run(run_free_enrichment_batch(min_fit_score=40))
 
         assert result["processed"] == 3
         assert result["sam_hits"] == 3
@@ -553,14 +532,7 @@ class TestRunFreeEnrichmentBatch:
         assert mock_enrich.call_count == 3
 
     def test_batch_counts_errors(self):
-        mock_session = MagicMock(spec=Session)
-        prospects_query = MagicMock()
-        prospects_query.filter.return_value = prospects_query
-        prospects_query.order_by.return_value = prospects_query
-        prospects_query.limit.return_value = prospects_query
-        prospects_query.all.return_value = [(1,)]
-        mock_session.query.return_value = prospects_query
-        mock_session.close = MagicMock()
+        mock_session = _mock_batch_session([(1,)])
 
         with patch(
             "app.database.SessionLocal",
@@ -571,20 +543,13 @@ class TestRunFreeEnrichmentBatch:
                 new_callable=AsyncMock,
                 return_value={"error": "not_found"},
             ):
-                result = asyncio.get_event_loop().run_until_complete(run_free_enrichment_batch())
+                result = _run(run_free_enrichment_batch())
 
         assert result["errors"] == 1
         assert result["processed"] == 0
 
     def test_batch_handles_exception_in_enrichment(self):
-        mock_session = MagicMock(spec=Session)
-        prospects_query = MagicMock()
-        prospects_query.filter.return_value = prospects_query
-        prospects_query.order_by.return_value = prospects_query
-        prospects_query.limit.return_value = prospects_query
-        prospects_query.all.return_value = [(1,)]
-        mock_session.query.return_value = prospects_query
-        mock_session.close = MagicMock()
+        mock_session = _mock_batch_session([(1,)])
 
         with patch(
             "app.database.SessionLocal",
@@ -595,25 +560,18 @@ class TestRunFreeEnrichmentBatch:
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("crash"),
             ):
-                result = asyncio.get_event_loop().run_until_complete(run_free_enrichment_batch())
+                result = _run(run_free_enrichment_batch())
 
         assert result["errors"] == 1
 
     def test_batch_empty_prospects(self):
-        mock_session = MagicMock(spec=Session)
-        prospects_query = MagicMock()
-        prospects_query.filter.return_value = prospects_query
-        prospects_query.order_by.return_value = prospects_query
-        prospects_query.limit.return_value = prospects_query
-        prospects_query.all.return_value = []
-        mock_session.query.return_value = prospects_query
-        mock_session.close = MagicMock()
+        mock_session = _mock_batch_session([])
 
         with patch(
             "app.database.SessionLocal",
             return_value=mock_session,
         ):
-            result = asyncio.get_event_loop().run_until_complete(run_free_enrichment_batch())
+            result = _run(run_free_enrichment_batch())
 
         assert result["processed"] == 0
         assert result["errors"] == 0

--- a/tests/test_requirement_entry_fixes.py
+++ b/tests/test_requirement_entry_fixes.py
@@ -20,6 +20,8 @@ from app.models import Requisition, User
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
+_AUTH_DEPS = [get_db, require_user, require_buyer, require_admin]
+
 
 def _make_client(db_session: Session, user: User) -> TestClient:
     """Build a TestClient authenticated as the given user."""
@@ -56,6 +58,12 @@ def _make_sales_client(db_session: Session, user: User) -> TestClient:
     app.dependency_overrides[require_buyer] = _override_user
     app.dependency_overrides[require_admin] = _not_admin
     return TestClient(app)
+
+
+def _clear_overrides() -> None:
+    """Remove the auth dependency overrides installed by the client helpers."""
+    for dep in _AUTH_DEPS:
+        app.dependency_overrides.pop(dep, None)
 
 
 # ── B2: RequirementUpdate rejects blank MPN ──────────────────────────
@@ -128,8 +136,7 @@ def test_sourcing_score_sales_cannot_see_others(db_session, sales_user, test_use
         resp = sales_c.get(f"/api/requisitions/{req.id}/sourcing-score")
         assert resp.status_code == 404
     finally:
-        for dep in [get_db, require_user, require_buyer, require_admin]:
-            app.dependency_overrides.pop(dep, None)
+        _clear_overrides()
 
 
 # ── B10: Batch archive respects role ─────────────────────────────────
@@ -169,8 +176,7 @@ def test_batch_archive_sales_only_own(db_session, sales_user, test_user):
         assert own_req.status == "archived"
         assert other_req.status == "active"
     finally:
-        for dep in [get_db, require_user, require_buyer, require_admin]:
-            app.dependency_overrides.pop(dep, None)
+        _clear_overrides()
 
 
 # ── B11: Batch assign requires admin ─────────────────────────────────
@@ -186,8 +192,7 @@ def test_batch_assign_non_admin_rejected(db_session, sales_user):
         )
         assert resp.status_code == 403
     finally:
-        for dep in [get_db, require_user, require_buyer, require_admin]:
-            app.dependency_overrides.pop(dep, None)
+        _clear_overrides()
 
 
 def test_batch_assign_admin_allowed(db_session, admin_user, test_requisition, test_user):
@@ -201,8 +206,7 @@ def test_batch_assign_admin_allowed(db_session, admin_user, test_requisition, te
         assert resp.status_code == 200
         assert resp.json()["assigned_count"] == 1
     finally:
-        for dep in [get_db, require_user, require_buyer, require_admin]:
-            app.dependency_overrides.pop(dep, None)
+        _clear_overrides()
 
 
 # ── B16: Condition/packaging normalized on create ────────────────────

--- a/tests/test_requirement_manufacturer.py
+++ b/tests/test_requirement_manufacturer.py
@@ -5,24 +5,29 @@ What calls it: pytest
 Depends on: app/models/sourcing.py, tests/conftest.py
 """
 
+import pytest
+
 from app.models.sourcing import Requirement, Requisition
 
 
-def test_requirement_has_manufacturer(db_session, test_user):
+def _make_requisition(db_session, test_user) -> Requisition:
     req = Requisition(name="Test", status="active", created_by=test_user.id)
     db_session.add(req)
     db_session.flush()
-    r = Requirement(requisition_id=req.id, primary_mpn="LM317T", manufacturer="Texas Instruments")
-    db_session.add(r)
-    db_session.commit()
-    assert r.manufacturer == "Texas Instruments"
+    return req
 
 
-def test_requirement_manufacturer_defaults_empty(db_session, test_user):
-    req = Requisition(name="Test", status="active", created_by=test_user.id)
-    db_session.add(req)
-    db_session.flush()
-    r = Requirement(requisition_id=req.id, primary_mpn="LM317T")
+@pytest.mark.parametrize(
+    "manufacturer_kwargs, expected",
+    [
+        ({"manufacturer": "Texas Instruments"}, "Texas Instruments"),
+        ({}, ""),
+    ],
+    ids=["stores_value", "defaults_empty"],
+)
+def test_requirement_manufacturer(db_session, test_user, manufacturer_kwargs, expected):
+    req = _make_requisition(db_session, test_user)
+    r = Requirement(requisition_id=req.id, primary_mpn="LM317T", **manufacturer_kwargs)
     db_session.add(r)
     db_session.commit()
-    assert r.manufacturer == ""
+    assert r.manufacturer == expected

--- a/tests/test_requirement_status.py
+++ b/tests/test_requirement_status.py
@@ -32,45 +32,44 @@ from app.services.requirement_status import (
 )
 
 
+def _first_requirement(test_requisition, db_session, sourcing_status):
+    """Return the requisition's first requirement with its sourcing_status set +
+    committed."""
+    req_item = test_requisition.requirements[0]
+    req_item.sourcing_status = sourcing_status
+    db_session.commit()
+    return req_item
+
+
 class TestTransitionRequirement:
     def test_open_to_sourcing(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, "open")
 
         changed = transition_requirement(req_item, "sourcing", db_session, actor=test_user)
         assert changed is True
         assert req_item.sourcing_status == "sourcing"
 
     def test_with_enum(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, "open")
 
         changed = transition_requirement(req_item, RequirementSourcingStatus.OFFERED, db_session, actor=test_user)
         assert changed is True
         assert req_item.sourcing_status == "offered"
 
     def test_illegal_transition_raises(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "won"
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, "won")
 
         with pytest.raises(ValueError, match="Invalid requirement transition"):
             transition_requirement(req_item, "open", db_session, actor=test_user)
 
     def test_noop_when_same_status(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "sourcing"
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, "sourcing")
 
         changed = transition_requirement(req_item, "sourcing", db_session, actor=test_user)
         assert changed is False
 
     def test_creates_activity_log(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, "open")
 
         transition_requirement(req_item, "sourcing", db_session, actor=test_user)
         db_session.flush()
@@ -88,9 +87,7 @@ class TestTransitionRequirement:
         assert "open → sourcing" in logs[0].subject
 
     def test_none_status_defaults_to_open(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = None
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, None)
 
         transition_requirement(req_item, "sourcing", db_session, actor=test_user)
         assert req_item.sourcing_status == "sourcing"
@@ -102,54 +99,31 @@ class TestTransitionRequirement:
 
 class TestOnRfqSent:
     def test_marks_parts_as_sourcing(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, "open")
 
         changed = on_rfq_sent([req_item.id], db_session, actor=test_user)
         assert changed == 1
         assert req_item.sourcing_status == "sourcing"
 
-    def test_skips_already_sourcing(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "sourcing"
-        db_session.commit()
-
-        changed = on_rfq_sent([req_item.id], db_session, actor=test_user)
-        assert changed == 0
-
-    def test_skips_offered(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "offered"
-        db_session.commit()
+    @pytest.mark.parametrize("initial_status", ["sourcing", "offered"])
+    def test_skips_non_open(self, db_session, test_requisition, test_user, initial_status):
+        req_item = _first_requirement(test_requisition, db_session, initial_status)
 
         changed = on_rfq_sent([req_item.id], db_session, actor=test_user)
         assert changed == 0
 
 
 class TestOnOfferCreated:
-    def test_open_to_offered(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "open"
-        db_session.commit()
-
-        changed = on_offer_created(req_item, db_session, actor=test_user)
-        assert changed is True
-        assert req_item.sourcing_status == "offered"
-
-    def test_sourcing_to_offered(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "sourcing"
-        db_session.commit()
+    @pytest.mark.parametrize("initial_status", ["open", "sourcing"])
+    def test_advances_to_offered(self, db_session, test_requisition, test_user, initial_status):
+        req_item = _first_requirement(test_requisition, db_session, initial_status)
 
         changed = on_offer_created(req_item, db_session, actor=test_user)
         assert changed is True
         assert req_item.sourcing_status == "offered"
 
     def test_does_not_demote_from_quoted(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "quoted"
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, "quoted")
 
         changed = on_offer_created(req_item, db_session, actor=test_user)
         assert changed is False
@@ -158,18 +132,14 @@ class TestOnOfferCreated:
 
 class TestOnQuoteBuilt:
     def test_marks_offered_as_quoted(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "offered"
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, "offered")
 
         changed = on_quote_built([req_item.id], db_session, actor=test_user)
         assert changed == 1
         assert req_item.sourcing_status == "quoted"
 
     def test_skips_already_won(self, db_session, test_requisition, test_user):
-        req_item = test_requisition.requirements[0]
-        req_item.sourcing_status = "won"
-        db_session.commit()
+        req_item = _first_requirement(test_requisition, db_session, "won")
 
         changed = on_quote_built([req_item.id], db_session, actor=test_user)
         assert changed == 0

--- a/tests/test_requirements_router_coverage.py
+++ b/tests/test_requirements_router_coverage.py
@@ -107,6 +107,37 @@ def _make_material_card(db: Session, mpn: str = "LM317T") -> MaterialCard:
     return mc
 
 
+def _make_sourcing_lead(db: Session, req: Requisition, user: User, **kw):
+    from app.models.sourcing_lead import SourcingLead
+
+    defaults = dict(
+        requisition_id=req.id,
+        requirement_id=req.requirements[0].id,
+        lead_id="LEAD-TEST-001",
+        vendor_name="Arrow Electronics",
+        vendor_name_normalized="arrow electronics",
+        part_number_requested="LM317T",
+        part_number_matched="LM317T",
+        match_type="exact",
+        primary_source_type="brokerbin",
+        primary_source_name="BrokerBin",
+        confidence_score=80.0,
+        confidence_band="high",
+        vendor_safety_score=75.0,
+        vendor_safety_band="medium",
+        buyer_status="open",
+        buyer_owner_user_id=user.id,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    defaults.update(kw)
+    lead = SourcingLead(**defaults)
+    db.add(lead)
+    db.commit()
+    db.refresh(lead)
+    return lead
+
+
 # ══════════════════════════════════════════════════════════════════════════
 # _dedupe_substitutes helper function
 # ══════════════════════════════════════════════════════════════════════════
@@ -514,62 +545,34 @@ class TestLeadsWithData:
 
 
 class TestSourcingLeadCRUD:
-    def _make_sourcing_lead(self, db, req, user):
-        from app.models.sourcing_lead import SourcingLead
-
-        lead = SourcingLead(
-            requisition_id=req.id,
-            requirement_id=req.requirements[0].id,
-            lead_id="LEAD-TEST-001",
-            vendor_name="Arrow Electronics",
-            vendor_name_normalized="arrow electronics",
-            part_number_requested="LM317T",
-            part_number_matched="LM317T",
-            match_type="exact",
-            primary_source_type="brokerbin",
-            primary_source_name="BrokerBin",
-            confidence_score=80.0,
-            confidence_band="high",
-            vendor_safety_score=75.0,
-            vendor_safety_band="medium",
-            buyer_status="open",
-            buyer_owner_user_id=user.id,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
-        )
-        db.add(lead)
-        db.commit()
-        db.refresh(lead)
-        return lead
-
     def test_list_leads_with_lead(self, client, db_session, test_user, test_requisition):
-        self._make_sourcing_lead(db_session, test_requisition, test_user)
+        _make_sourcing_lead(db_session, test_requisition, test_user)
         resp = client.get(f"/api/requisitions/{test_requisition.id}/leads")
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) >= 1
 
     def test_get_lead_detail(self, client, db_session, test_user, test_requisition):
-        lead = self._make_sourcing_lead(db_session, test_requisition, test_user)
+        lead = _make_sourcing_lead(db_session, test_requisition, test_user)
         resp = client.get(f"/api/leads/{lead.id}")
         assert resp.status_code == 200
         data = resp.json()
         assert data["vendor_name"] == "Arrow Electronics"
 
     def test_get_lead_not_authorized(self, client, db_session, test_user, test_requisition):
-        lead = self._make_sourcing_lead(db_session, test_requisition, test_user)
+        lead = _make_sourcing_lead(db_session, test_requisition, test_user)
         with patch("app.routers.requisitions.requirements.get_req_for_user", return_value=None):
             resp = client.get(f"/api/leads/{lead.id}")
         assert resp.status_code == 403
 
     def test_patch_lead_status_not_authorized(self, client, db_session, test_user, test_requisition):
-        lead = self._make_sourcing_lead(db_session, test_requisition, test_user)
+        lead = _make_sourcing_lead(db_session, test_requisition, test_user)
         with patch("app.routers.requisitions.requirements.get_req_for_user", return_value=None):
             resp = client.patch(f"/api/leads/{lead.id}/status", json={"status": "contacted"})
         assert resp.status_code == 403
 
     def test_add_lead_feedback_not_authorized(self, client, db_session, test_user, test_requisition):
-        lead = self._make_sourcing_lead(db_session, test_requisition, test_user)
+        lead = _make_sourcing_lead(db_session, test_requisition, test_user)
         with patch("app.routers.requisitions.requirements.get_req_for_user", return_value=None):
             resp = client.post(f"/api/leads/{lead.id}/feedback", json={"note": "Test note"})
         assert resp.status_code == 403
@@ -684,33 +687,21 @@ class TestBatchAddRequirements:
 
 
 class TestPatchLeadStatus:
-    def _make_sourcing_lead(self, db, req, user):
-        from app.models.sourcing_lead import SourcingLead
-
-        lead = SourcingLead(
-            requisition_id=req.id,
-            requirement_id=req.requirements[0].id,
+    @staticmethod
+    def _make_sourcing_lead(db, req, user):
+        return _make_sourcing_lead(
+            db,
+            req,
+            user,
             lead_id="LEAD-STATUS-001",
             vendor_name="Digi-Key",
             vendor_name_normalized="digi-key",
-            part_number_requested="LM317T",
-            part_number_matched="LM317T",
-            match_type="exact",
             primary_source_type="digikey",
             primary_source_name="DigiKey",
             confidence_score=85.0,
-            confidence_band="high",
             vendor_safety_score=80.0,
-            vendor_safety_band="medium",
             buyer_status="new",
-            buyer_owner_user_id=user.id,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
         )
-        db.add(lead)
-        db.commit()
-        db.refresh(lead)
-        return lead
 
     def test_patch_status_success(self, client, db_session, test_user, test_requisition):
         lead = self._make_sourcing_lead(db_session, test_requisition, test_user)

--- a/tests/test_requisition_service.py
+++ b/tests/test_requisition_service.py
@@ -84,27 +84,21 @@ class TestParsePositiveInt:
     def test_valid_string(self):
         assert parse_positive_int("42") == 42
 
-    def test_zero_raises_400(self):
+    @pytest.mark.parametrize(
+        ("value", "field_name", "expected_detail"),
+        [
+            pytest.param(0, "qty", "qty", id="zero"),
+            pytest.param(-1, "value", None, id="negative"),
+            pytest.param("abc", "target_qty", "target_qty", id="non_numeric"),
+            pytest.param(None, "value", None, id="none"),
+        ],
+    )
+    def test_raises_400(self, value, field_name, expected_detail):
         with pytest.raises(HTTPException) as exc_info:
-            parse_positive_int(0, field_name="qty")
+            parse_positive_int(value, field_name=field_name)  # type: ignore[arg-type]
         assert exc_info.value.status_code == 400
-        assert "qty" in exc_info.value.detail
-
-    def test_negative_raises_400(self):
-        with pytest.raises(HTTPException) as exc_info:
-            parse_positive_int(-1)
-        assert exc_info.value.status_code == 400
-
-    def test_non_numeric_raises_400(self):
-        with pytest.raises(HTTPException) as exc_info:
-            parse_positive_int("abc", field_name="target_qty")
-        assert exc_info.value.status_code == 400
-        assert "target_qty" in exc_info.value.detail
-
-    def test_none_raises_400(self):
-        with pytest.raises(HTTPException) as exc_info:
-            parse_positive_int(None)  # type: ignore[arg-type]
-        assert exc_info.value.status_code == 400
+        if expected_detail is not None:
+            assert expected_detail in exc_info.value.detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routers_crm.py
+++ b/tests/test_routers_crm.py
@@ -149,37 +149,38 @@ def test_quote_to_dict_sent():
 # ── next_quote_number ────────────────────────────────────────────────────
 
 
-def test_next_quote_number_first():
-    db = MagicMock()
-    db.query.return_value.filter.return_value.order_by.return_value.with_for_update.return_value.first.return_value = (
-        None
-    )
-    result = next_quote_number(db)
-    assert result.startswith("Q-")
-    assert result.endswith("-0001")
-
-
-def test_next_quote_number_increment():
-    last = MagicMock()
-    last.quote_number = "Q-2026-0042"
+def _mock_db_with_last_quote(last_quote_number):
+    """Build a mock db whose query chain returns a Quote with the given number (or
+    None)."""
+    last = None
+    if last_quote_number is not None:
+        last = MagicMock()
+        last.quote_number = last_quote_number
     db = MagicMock()
     db.query.return_value.filter.return_value.order_by.return_value.with_for_update.return_value.first.return_value = (
         last
     )
-    result = next_quote_number(db)
-    assert result == "Q-2026-0043"
+    return db
 
 
-def test_next_quote_number_bad_format():
-    """Handles corrupted quote numbers gracefully."""
-    last = MagicMock()
-    last.quote_number = "Q-2026-XXXX"
-    db = MagicMock()
-    db.query.return_value.filter.return_value.order_by.return_value.with_for_update.return_value.first.return_value = (
-        last
-    )
+@pytest.mark.parametrize(
+    ("last_quote_number", "expected_prefix", "expected_suffix", "expected_exact"),
+    [
+        pytest.param(None, "Q-", "-0001", None, id="first"),
+        pytest.param("Q-2026-0042", None, None, "Q-2026-0043", id="increment"),
+        pytest.param("Q-2026-XXXX", None, "-0001", None, id="bad_format"),
+    ],
+)
+def test_next_quote_number(last_quote_number, expected_prefix, expected_suffix, expected_exact):
+    """First quote, increment, and graceful handling of corrupted quote numbers."""
+    db = _mock_db_with_last_quote(last_quote_number)
     result = next_quote_number(db)
-    assert result.endswith("-0001")
+    if expected_exact is not None:
+        assert result == expected_exact
+    if expected_prefix is not None:
+        assert result.startswith(expected_prefix)
+    if expected_suffix is not None:
+        assert result.endswith(expected_suffix)
 
 
 def test_quote_creation_retries_on_integrity_error(

--- a/tests/test_routers_v13.py
+++ b/tests/test_routers_v13.py
@@ -9,6 +9,8 @@ Covers: activity serialization, null handling, GET/POST activity endpoints
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+import pytest
+
 # ═══════════════════════════════════════════════════════════════════════
 #  _activity_to_dict unit tests (existing)
 # ═══════════════════════════════════════════════════════════════════════
@@ -267,11 +269,6 @@ def test_log_email_click(client):
 
 
 # ═══════════════════════════════════════════════════════════════════════
-#  Sales / Ownership Endpoints
-# ═══════════════════════════════════════════════════════════════════════
-
-
-# ═══════════════════════════════════════════════════════════════════════
 #  Additional Coverage Tests
 # ═══════════════════════════════════════════════════════════════════════
 
@@ -330,39 +327,18 @@ def test_graph_webhook_success(client):
     assert resp.json()["status"] == "accepted"
 
 
-def test_log_company_call_not_found(client):
-    """POST /api/companies/99999/activities/call returns 404."""
-    resp = client.post(
-        "/api/companies/99999/activities/call",
-        json={"phone": "+1-555-1234"},
-    )
-    assert resp.status_code == 404
-
-
-def test_log_company_note_not_found(client):
-    """POST /api/companies/99999/activities/note returns 404."""
-    resp = client.post(
-        "/api/companies/99999/activities/note",
-        json={"notes": "test note"},
-    )
-    assert resp.status_code == 404
-
-
-def test_log_vendor_call_not_found(client):
-    """POST /api/vendors/99999/activities/call returns 404."""
-    resp = client.post(
-        "/api/vendors/99999/activities/call",
-        json={"phone": "+1-555-1234"},
-    )
-    assert resp.status_code == 404
-
-
-def test_log_vendor_note_not_found(client):
-    """POST /api/vendors/99999/activities/note returns 404."""
-    resp = client.post(
-        "/api/vendors/99999/activities/note",
-        json={"notes": "test note"},
-    )
+@pytest.mark.parametrize(
+    ("path", "body"),
+    [
+        pytest.param("/api/companies/99999/activities/call", {"phone": "+1-555-1234"}, id="company_call"),
+        pytest.param("/api/companies/99999/activities/note", {"notes": "test note"}, id="company_note"),
+        pytest.param("/api/vendors/99999/activities/call", {"phone": "+1-555-1234"}, id="vendor_call"),
+        pytest.param("/api/vendors/99999/activities/note", {"notes": "test note"}, id="vendor_note"),
+    ],
+)
+def test_log_activity_not_found(client, path, body):
+    """POST logging endpoints for a non-existent company/vendor returns 404."""
+    resp = client.post(path, json=body)
     assert resp.status_code == 404
 
 

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -4,6 +4,8 @@ Called by: pytest
 Depends on: app.utils.sanitize
 """
 
+import pytest
+
 from app.utils.sanitize import sanitize_dict, sanitize_text
 
 
@@ -18,23 +20,22 @@ class TestSanitizeText:
         assert sanitize_text(3.14) == 3.14
         assert sanitize_text(True) is True
 
-    def test_plain_text_entities_escaped(self):
-        # Plain text without special chars is unchanged
-        assert sanitize_text("hello world") == "hello world"
-
-    def test_ampersand_escaped(self):
-        assert sanitize_text("a & b") == "a &amp; b"
-
-    def test_angle_brackets_in_tag_like_pattern_stripped(self):
-        result = sanitize_text("1 < 2 > 0")
-        assert result == "1  0"
-
-    def test_lone_angle_brackets_escaped(self):
-        assert sanitize_text("a < b") == "a &lt; b"
-
-    def test_quotes_escaped(self):
-        assert sanitize_text('say "hello"') == "say &quot;hello&quot;"
-        assert sanitize_text("it's") == "it&#x27;s"
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param("hello world", "hello world", id="plain_text"),
+            pytest.param("a & b", "a &amp; b", id="ampersand"),
+            pytest.param("1 < 2 > 0", "1  0", id="tag_like_angle_brackets_stripped"),
+            pytest.param("a < b", "a &lt; b", id="lone_angle_bracket"),
+            pytest.param('say "hello"', "say &quot;hello&quot;", id="double_quotes"),
+            pytest.param("it's", "it&#x27;s", id="single_quote"),
+            pytest.param("", "", id="empty_string"),
+            pytest.param("   ", "   ", id="whitespace_only"),
+            pytest.param("12345", "12345", id="numeric_string"),
+        ],
+    )
+    def test_text_escaping(self, value, expected):
+        assert sanitize_text(value) == expected
 
     def test_script_tag_stripped(self):
         result = sanitize_text("<script>alert(1)</script>")
@@ -57,44 +58,38 @@ class TestSanitizeText:
         assert "<span>" not in result
         assert "text" in result
 
-    def test_javascript_uri_neutralized(self):
-        result = sanitize_text("javascript:alert(1)")
-        assert "javascript:" not in result
-        assert "_blocked_:" in result
-
-    def test_javascript_uri_case_insensitive(self):
-        result = sanitize_text("JavaScript:void(0)")
-        assert "_blocked_:" in result
-
-    def test_javascript_uri_with_spaces(self):
-        result = sanitize_text("javascript :alert(1)")
+    @pytest.mark.parametrize(
+        ("value", "absent"),
+        [
+            pytest.param("javascript:alert(1)", "javascript:", id="javascript_uri"),
+            pytest.param("JavaScript:void(0)", None, id="javascript_uri_case_insensitive"),
+            pytest.param("javascript :alert(1)", None, id="javascript_uri_with_spaces"),
+            pytest.param("DATA:image/png;base64,abc", None, id="data_uri_case_insensitive"),
+        ],
+    )
+    def test_uri_scheme_neutralized(self, value, absent):
+        result = sanitize_text(value)
+        if absent is not None:
+            assert absent not in result
         assert "_blocked_:" in result
 
     def test_data_uri_neutralized(self):
         result = sanitize_text("data:text/html,<h1>XSS</h1>")
         assert "data:" not in result.lower() or "_blocked_:" in result
 
-    def test_data_uri_case_insensitive(self):
-        result = sanitize_text("DATA:image/png;base64,abc")
-        assert "_blocked_:" in result
-
-    def test_onclick_neutralized(self):
-        result = sanitize_text("onclick=alert(1)")
-        assert "onclick=" not in result
-        assert "_blocked_=" in result
-
-    def test_onmouseover_neutralized(self):
-        result = sanitize_text("onmouseover=doStuff()")
-        assert "onmouseover=" not in result
-        assert "_blocked_=" in result
-
-    def test_onerror_neutralized(self):
-        result = sanitize_text("onerror=hack()")
-        assert "onerror=" not in result
-        assert "_blocked_=" in result
-
-    def test_event_handler_case_insensitive(self):
-        result = sanitize_text("ONCLICK=bad()")
+    @pytest.mark.parametrize(
+        ("value", "absent"),
+        [
+            pytest.param("onclick=alert(1)", "onclick=", id="onclick"),
+            pytest.param("onmouseover=doStuff()", "onmouseover=", id="onmouseover"),
+            pytest.param("onerror=hack()", "onerror=", id="onerror"),
+            pytest.param("ONCLICK=bad()", None, id="event_handler_case_insensitive"),
+        ],
+    )
+    def test_event_handler_neutralized(self, value, absent):
+        result = sanitize_text(value)
+        if absent is not None:
+            assert absent not in result
         assert "_blocked_=" in result
 
     def test_mixed_attack_tag_plus_event_plus_uri(self):
@@ -103,15 +98,6 @@ class TestSanitizeText:
         assert "<a" not in result
         assert "javascript:" not in result
         assert "onclick=" not in result
-
-    def test_empty_string(self):
-        assert sanitize_text("") == ""
-
-    def test_whitespace_only(self):
-        assert sanitize_text("   ") == "   "
-
-    def test_numeric_string_unchanged(self):
-        assert sanitize_text("12345") == "12345"
 
 
 class TestSanitizeDict:

--- a/tests/test_schemas_ai.py
+++ b/tests/test_schemas_ai.py
@@ -85,29 +85,38 @@ from app.schemas.ai import (
 
 
 class TestDraftOfferItemValidators:
-    def test_condition_none_passes(self):
-        d = DraftOfferItem(condition=None)
-        assert d.condition is None
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            ("Factory New", "new"),
+        ],
+        ids=["none_passes", "normalized"],
+    )
+    def test_condition(self, value, expected):
+        assert DraftOfferItem(condition=value).condition == expected
 
-    def test_condition_normalized(self):
-        d = DraftOfferItem(condition="Factory New")
-        assert d.condition == "new"
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, None),
+            ("Tape & Reel", "reel"),
+        ],
+        ids=["none_passes", "normalized"],
+    )
+    def test_packaging(self, value, expected):
+        assert DraftOfferItem(packaging=value).packaging == expected
 
-    def test_packaging_none_passes(self):
-        d = DraftOfferItem(packaging=None)
-        assert d.packaging is None
-
-    def test_packaging_normalized(self):
-        d = DraftOfferItem(packaging="Tape & Reel")
-        assert d.packaging == "reel"
-
-    def test_mpn_empty_passes(self):
-        d = DraftOfferItem(mpn="")
-        assert d.mpn == ""
-
-    def test_mpn_normalized(self):
-        d = DraftOfferItem(mpn="lm317t")
-        assert d.mpn == "LM317T"
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("", ""),
+            ("lm317t", "LM317T"),
+        ],
+        ids=["empty_passes", "normalized"],
+    )
+    def test_mpn(self, value, expected):
+        assert DraftOfferItem(mpn=value).mpn == expected
 
 
 class TestParseEmailRequest:

--- a/tests/test_search_service_nightly.py
+++ b/tests/test_search_service_nightly.py
@@ -27,6 +27,7 @@ os.environ["TESTING"] = "1"
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from sqlalchemy.orm import Session
 
 from app.models import (
@@ -95,14 +96,16 @@ def _make_requirement(db: Session, requisition: Requisition, mpn: str = "LM317T"
 
 
 class TestQuickSearchMpnEmptyMpn:
-    async def test_empty_string_returns_empty(self, db_session: Session):
-        """Empty MPN string returns empty result dict (line 370)."""
-        result = await quick_search_mpn("", db_session)
-        assert result == {"sightings": [], "source_stats": [], "material_card": None}
-
-    async def test_whitespace_only_returns_empty(self, db_session: Session):
-        """Whitespace-only MPN hits the guard at line 370."""
-        result = await quick_search_mpn("   ", db_session)
+    @pytest.mark.parametrize(
+        ("mpn", "case"),
+        [
+            ("", "empty_string"),
+            ("   ", "whitespace_only"),
+        ],
+    )
+    async def test_blank_mpn_returns_empty(self, mpn: str, case: str, db_session: Session):
+        """Empty/blank MPN returns empty result dict — hits the guard at line 370."""
+        result = await quick_search_mpn(mpn, db_session)
         assert result == {"sightings": [], "source_stats": [], "material_card": None}
 
 

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -42,25 +42,19 @@ class TestRetryAfterCap:
         resp.headers = {"Retry-After": retry_after}
         return resp
 
-    def test_normal_value_passes_through(self):
-        resp = self._make_response("10")
-        assert _parse_retry_after(resp) == 10.0
-
-    def test_minimum_floor_of_1_second(self):
-        resp = self._make_response("0.1")
-        assert _parse_retry_after(resp) == 1.0
-
-    def test_extreme_value_capped_at_300(self):
-        resp = self._make_response("999999")
-        assert _parse_retry_after(resp) == 300.0
-
-    def test_moderate_value_capped_at_300(self):
-        resp = self._make_response("600")
-        assert _parse_retry_after(resp) == 300.0
-
-    def test_300_exactly_passes(self):
-        resp = self._make_response("300")
-        assert _parse_retry_after(resp) == 300.0
+    @pytest.mark.parametrize(
+        ("retry_after", "expected"),
+        [
+            ("10", 10.0),  # normal value passes through
+            ("0.1", 1.0),  # minimum floor of 1 second
+            ("999999", 300.0),  # extreme value capped at 300
+            ("600", 300.0),  # moderate value capped at 300
+            ("300", 300.0),  # 300 exactly passes
+        ],
+    )
+    def test_value_clamped(self, retry_after: str, expected: float):
+        resp = self._make_response(retry_after)
+        assert _parse_retry_after(resp) == expected
 
     def test_missing_header_uses_default(self):
         resp = MagicMock(spec=httpx.Response)

--- a/tests/test_security_h3_h4_h6.py
+++ b/tests/test_security_h3_h4_h6.py
@@ -10,136 +10,67 @@ Depends on: conftest fixtures (db_session, client, test_user)
 
 import io
 
+import pytest
+
+
+def _make_offer(db_session, req_name, mpn):
+    """Create a minimal Requisition + Offer and return the offer id."""
+    from app.models import Offer, Requisition, User
+
+    user = db_session.query(User).first()
+    req = Requisition(
+        name=req_name,
+        customer_name="Test Co",
+        status="active",
+        created_by=user.id,
+    )
+    db_session.add(req)
+    db_session.flush()
+    offer = Offer(
+        requisition_id=req.id,
+        vendor_name="Test Vendor",
+        mpn=mpn,
+        qty_available=100,
+        unit_price=1.0,
+        status="new",
+    )
+    db_session.add(offer)
+    db_session.commit()
+    return offer.id
+
 
 class TestOfferAttachmentFileType:
     """Verify rejected file types return 400."""
 
-    def test_rejected_extension_exe(self, client, db_session):
-        """Uploading .exe attachment returns 400."""
-        from app.models import Offer, Requisition, User
+    @pytest.mark.parametrize(
+        "req_name,mpn,filename,content",
+        [
+            ("REQ-ATT-001", "TEST-001", "malware.exe", b"fake exe content"),
+            ("REQ-ATT-002", "TEST-002", "script.bat", b"echo hello"),
+            ("REQ-ATT-004", "TEST-004", "noext", b"some data"),
+        ],
+        ids=["exe", "bat", "no_extension"],
+    )
+    def test_rejected_file_type(self, client, db_session, req_name, mpn, filename, content):
+        """Uploading a disallowed (or extension-less) attachment returns 400."""
+        offer_id = _make_offer(db_session, req_name, mpn)
 
-        # Create minimal offer for the endpoint
-        user = db_session.query(User).first()
-        req = Requisition(
-            name="REQ-ATT-001",
-            customer_name="Test Co",
-            status="active",
-            created_by=user.id,
-        )
-        db_session.add(req)
-        db_session.flush()
-        offer = Offer(
-            requisition_id=req.id,
-            vendor_name="Test Vendor",
-            mpn="TEST-001",
-            qty_available=100,
-            unit_price=1.0,
-            status="new",
-        )
-        db_session.add(offer)
-        db_session.commit()
-
-        content = b"fake exe content"
         resp = client.post(
-            f"/api/offers/{offer.id}/attachments",
-            files={"file": ("malware.exe", io.BytesIO(content), "application/octet-stream")},
-        )
-        assert resp.status_code == 400
-        assert "not allowed" in resp.json()["error"].lower()
-
-    def test_rejected_extension_bat(self, client, db_session):
-        """Uploading .bat attachment returns 400."""
-        from app.models import Offer, Requisition, User
-
-        user = db_session.query(User).first()
-        req = Requisition(
-            name="REQ-ATT-002",
-            customer_name="Test Co",
-            status="active",
-            created_by=user.id,
-        )
-        db_session.add(req)
-        db_session.flush()
-        offer = Offer(
-            requisition_id=req.id,
-            vendor_name="Test Vendor",
-            mpn="TEST-002",
-            qty_available=100,
-            unit_price=1.0,
-            status="new",
-        )
-        db_session.add(offer)
-        db_session.commit()
-
-        content = b"echo hello"
-        resp = client.post(
-            f"/api/offers/{offer.id}/attachments",
-            files={"file": ("script.bat", io.BytesIO(content), "application/octet-stream")},
+            f"/api/offers/{offer_id}/attachments",
+            files={"file": (filename, io.BytesIO(content), "application/octet-stream")},
         )
         assert resp.status_code == 400
         assert "not allowed" in resp.json()["error"].lower()
 
     def test_allowed_extension_pdf_reaches_onedrive(self, client, db_session):
         """Uploading .pdf passes file type check (may fail at OneDrive step)."""
-        from app.models import Offer, Requisition, User
-
-        user = db_session.query(User).first()
-        req = Requisition(
-            name="REQ-ATT-003",
-            customer_name="Test Co",
-            status="active",
-            created_by=user.id,
-        )
-        db_session.add(req)
-        db_session.flush()
-        offer = Offer(
-            requisition_id=req.id,
-            vendor_name="Test Vendor",
-            mpn="TEST-003",
-            qty_available=100,
-            unit_price=1.0,
-            status="new",
-        )
-        db_session.add(offer)
-        db_session.commit()
+        offer_id = _make_offer(db_session, "REQ-ATT-003", "TEST-003")
 
         content = b"%PDF-1.4 fake pdf"
         resp = client.post(
-            f"/api/offers/{offer.id}/attachments",
+            f"/api/offers/{offer_id}/attachments",
             files={"file": ("doc.pdf", io.BytesIO(content), "application/pdf")},
         )
         # Should NOT be a file-type error; will likely fail at OneDrive auth
         if resp.status_code == 400:
             assert "not allowed" not in resp.json().get("error", "").lower()
-
-    def test_no_extension_rejected(self, client, db_session):
-        """Uploading a file with no extension returns 400."""
-        from app.models import Offer, Requisition, User
-
-        user = db_session.query(User).first()
-        req = Requisition(
-            name="REQ-ATT-004",
-            customer_name="Test Co",
-            status="active",
-            created_by=user.id,
-        )
-        db_session.add(req)
-        db_session.flush()
-        offer = Offer(
-            requisition_id=req.id,
-            vendor_name="Test Vendor",
-            mpn="TEST-004",
-            qty_available=100,
-            unit_price=1.0,
-            status="new",
-        )
-        db_session.add(offer)
-        db_session.commit()
-
-        content = b"some data"
-        resp = client.post(
-            f"/api/offers/{offer.id}/attachments",
-            files={"file": ("noext", io.BytesIO(content), "application/octet-stream")},
-        )
-        assert resp.status_code == 400
-        assert "not allowed" in resp.json()["error"].lower()

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -7,6 +7,10 @@ Called by: pytest
 Depends on: app.main (request_id_middleware)
 """
 
+import re
+
+import pytest
+
 
 def test_x_request_id_header(client):
     """Every response includes X-Request-ID."""
@@ -15,34 +19,20 @@ def test_x_request_id_header(client):
     assert len(resp.headers["X-Request-ID"]) == 8  # uuid[:8]
 
 
-def test_x_content_type_options(client):
-    """X-Content-Type-Options: nosniff prevents MIME sniffing."""
+@pytest.mark.parametrize(
+    ("header", "expected"),
+    [
+        ("X-Content-Type-Options", "nosniff"),  # prevents MIME sniffing
+        ("X-Frame-Options", "DENY"),  # prevents clickjacking
+        ("X-XSS-Protection", "1; mode=block"),  # enables XSS auditor
+        ("Referrer-Policy", "strict-origin-when-cross-origin"),
+        ("X-API-Version", "v1"),
+    ],
+)
+def test_static_security_header(client, header, expected):
+    """Each fixed security/version header has its expected value on every response."""
     resp = client.get("/health")
-    assert resp.headers.get("X-Content-Type-Options") == "nosniff"
-
-
-def test_x_frame_options(client):
-    """X-Frame-Options: DENY prevents clickjacking."""
-    resp = client.get("/health")
-    assert resp.headers.get("X-Frame-Options") == "DENY"
-
-
-def test_x_xss_protection(client):
-    """X-XSS-Protection enables XSS auditor."""
-    resp = client.get("/health")
-    assert resp.headers.get("X-XSS-Protection") == "1; mode=block"
-
-
-def test_referrer_policy(client):
-    """Referrer-Policy is set to strict-origin-when-cross-origin."""
-    resp = client.get("/health")
-    assert resp.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
-
-
-def test_api_version_header(client):
-    """All responses include X-API-Version: v1."""
-    resp = client.get("/health")
-    assert resp.headers.get("X-API-Version") == "v1"
+    assert resp.headers.get(header) == expected
 
 
 def test_security_headers_on_api_endpoint(client, test_requisition):
@@ -98,9 +88,6 @@ def test_error_response_format(client):
 
 
 # ── CSP tests ────────────────────────────────────────────────────────
-
-
-import re
 
 
 def test_csp_header_present_on_all_responses(client):

--- a/tests/test_services_ai.py
+++ b/tests/test_services_ai.py
@@ -14,6 +14,7 @@ Called by: pytest
 Depends on: app/services/ai_service.py, app/utils/claude_client.py
 """
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -29,6 +30,31 @@ from app.services.ai_service import (
     enrich_contacts_websearch,
     rephrase_rfq,
 )
+
+
+def _patch_claude_json(**kwargs):
+    """Patch claude_json as an AsyncMock (pass return_value or side_effect)."""
+    return patch("app.services.ai_service.claude_json", new_callable=AsyncMock, **kwargs)
+
+
+def _patch_routed_text(**kwargs):
+    """Patch routed_text as an AsyncMock (pass return_value or side_effect)."""
+    return patch("app.services.ai_service.routed_text", new_callable=AsyncMock, **kwargs)
+
+
+@contextmanager
+def _intel_patches(claude_kwargs):
+    """Patch the cache + claude_json trio used by company_intel().
+
+    Yields (mock_get_cached, mock_claude_json, mock_set_cached).
+    """
+    with (
+        patch("app.services.ai_service.get_cached", return_value=None) as mock_get,
+        _patch_claude_json(**claude_kwargs) as mock_claude,
+        patch("app.services.ai_service.set_cached") as mock_set,
+    ):
+        yield mock_get, mock_claude, mock_set
+
 
 # ── Constants & schema sanity checks ───────────────────────────────
 
@@ -89,11 +115,7 @@ class TestEnrichContactsWebsearch:
             ]
         }
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Acme Corp", domain="acme.com")
 
         assert len(contacts) == 2
@@ -115,35 +137,25 @@ class TestEnrichContactsWebsearch:
             }
         ]
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Example Inc")
 
         assert len(contacts) == 1
         assert contacts[0]["full_name"] == "Alice Johnson"
 
-    async def test_empty_result_returns_empty_list(self):
-        """When claude_json returns None, return empty list."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
-            contacts = await enrich_contacts_websearch("Nobody Corp")
-
-        assert contacts == []
-
-    async def test_dict_without_contacts_key(self):
-        """claude_json returns a dict missing the 'contacts' key."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value={"error": "no results"},
-        ):
-            contacts = await enrich_contacts_websearch("Ghost Corp")
+    @pytest.mark.parametrize(
+        "claude_return",
+        [
+            pytest.param(None, id="none"),
+            pytest.param({"error": "no results"}, id="dict-without-contacts-key"),
+            pytest.param("not a dict or list", id="string"),
+            pytest.param(42, id="int"),
+        ],
+    )
+    async def test_returns_empty_list_for_unusable_result(self, claude_return):
+        """None, dict-without-contacts, and unexpected types all yield []."""
+        with _patch_claude_json(return_value=claude_return):
+            contacts = await enrich_contacts_websearch("Edge Corp")
 
         assert contacts == []
 
@@ -153,11 +165,7 @@ class TestEnrichContactsWebsearch:
             "contacts": [{"full_name": f"Person {i}", "title": "Buyer", "email": f"p{i}@co.com"} for i in range(10)]
         }
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Big Corp", limit=3)
 
         assert len(contacts) == 3
@@ -166,11 +174,7 @@ class TestEnrichContactsWebsearch:
         """Default limit is 5 contacts."""
         mock_result = {"contacts": [{"full_name": f"Person {i}", "title": "Buyer"} for i in range(10)]}
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Big Corp")
 
         assert len(contacts) == 5
@@ -186,11 +190,7 @@ class TestEnrichContactsWebsearch:
             ]
         }
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Filter Corp")
 
         assert len(contacts) == 1
@@ -207,108 +207,52 @@ class TestEnrichContactsWebsearch:
             ]
         }
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Mixed Corp")
 
         assert len(contacts) == 1
 
-    async def test_confidence_medium_when_email_matches_domain(self):
-        """Confidence = medium when email domain matches company domain."""
-        mock_result = {
-            "contacts": [
-                {
-                    "full_name": "Jane",
-                    "email": "jane@acme.com",
-                    "title": "Buyer",
-                }
-            ]
-        }
+    @pytest.mark.parametrize(
+        ("contact", "domain", "expected_confidence"),
+        [
+            pytest.param(
+                {"full_name": "Jane", "email": "jane@acme.com", "title": "Buyer"},
+                "acme.com",
+                "medium",
+                id="email-matches-domain",
+            ),
+            pytest.param(
+                {"full_name": "Jane", "email": "jane@gmail.com", "title": "Buyer"},
+                "acme.com",
+                "medium",
+                id="email-no-domain-match",
+            ),
+            pytest.param(
+                {"full_name": "Jane", "email": None, "linkedin_url": "https://linkedin.com/in/jane"},
+                None,
+                "low",
+                id="no-email-but-linkedin",
+            ),
+            pytest.param(
+                {"full_name": "Jane", "email": None, "linkedin_url": None},
+                None,
+                "low",
+                id="no-email-no-linkedin",
+            ),
+        ],
+    )
+    async def test_confidence_levels(self, contact, domain, expected_confidence):
+        """Confidence is medium with any email, low otherwise."""
+        with _patch_claude_json(return_value={"contacts": [contact]}):
+            contacts = await enrich_contacts_websearch("Acme Corp", domain=domain)
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
-            contacts = await enrich_contacts_websearch("Acme Corp", domain="acme.com")
-
-        assert contacts[0]["confidence"] == "medium"
-
-    async def test_confidence_medium_when_email_no_domain_match(self):
-        """Confidence = medium when email exists but domain doesn't match."""
-        mock_result = {
-            "contacts": [
-                {
-                    "full_name": "Jane",
-                    "email": "jane@gmail.com",
-                    "title": "Buyer",
-                }
-            ]
-        }
-
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
-            contacts = await enrich_contacts_websearch("Acme Corp", domain="acme.com")
-
-        assert contacts[0]["confidence"] == "medium"
-
-    async def test_confidence_low_when_no_email_but_linkedin(self):
-        """Confidence = low when no email but LinkedIn present."""
-        mock_result = {
-            "contacts": [
-                {
-                    "full_name": "Jane",
-                    "email": None,
-                    "linkedin_url": "https://linkedin.com/in/jane",
-                }
-            ]
-        }
-
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
-            contacts = await enrich_contacts_websearch("Acme Corp")
-
-        assert contacts[0]["confidence"] == "low"
-
-    async def test_confidence_low_when_no_email_no_linkedin(self):
-        """Confidence = low when only name is present."""
-        mock_result = {
-            "contacts": [
-                {
-                    "full_name": "Jane",
-                    "email": None,
-                    "linkedin_url": None,
-                }
-            ]
-        }
-
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
-            contacts = await enrich_contacts_websearch("Acme Corp")
-
-        assert contacts[0]["confidence"] == "low"
+        assert contacts[0]["confidence"] == expected_confidence
 
     async def test_email_normalized_lowercase(self):
         """Email addresses are lowercased."""
         mock_result = {"contacts": [{"full_name": "Jane", "email": "  Jane@ACME.com  "}]}
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Acme Corp")
 
         assert contacts[0]["email"] == "jane@acme.com"
@@ -327,11 +271,7 @@ class TestEnrichContactsWebsearch:
             ]
         }
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Acme Corp")
 
         assert contacts[0]["title"] is None
@@ -352,11 +292,7 @@ class TestEnrichContactsWebsearch:
             ]
         }
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Acme Corp")
 
         c = contacts[0]
@@ -367,29 +303,20 @@ class TestEnrichContactsWebsearch:
 
     async def test_custom_title_keywords(self):
         """Custom title_keywords are passed in the prompt."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value={"contacts": []},
-        ) as mock_claude:
+        with _patch_claude_json(return_value={"contacts": []}) as mock_claude:
             await enrich_contacts_websearch(
                 "Acme Corp",
                 title_keywords=["CTO", "engineering manager"],
             )
 
         # The prompt (first positional arg) should include custom keywords
-        call_args = mock_claude.call_args
-        prompt = call_args.args[0]
+        prompt = mock_claude.call_args.args[0]
         assert "CTO" in prompt
         assert "engineering manager" in prompt
 
     async def test_domain_included_in_prompt(self):
         """When domain is provided it appears in the prompt."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value={"contacts": []},
-        ) as mock_claude:
+        with _patch_claude_json(return_value={"contacts": []}) as mock_claude:
             await enrich_contacts_websearch("Acme Corp", domain="acme.com")
 
         prompt = mock_claude.call_args.args[0]
@@ -397,11 +324,7 @@ class TestEnrichContactsWebsearch:
 
     async def test_domain_not_in_prompt_when_none(self):
         """When domain is None, no domain parenthetical in the prompt."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value={"contacts": []},
-        ) as mock_claude:
+        with _patch_claude_json(return_value={"contacts": []}) as mock_claude:
             await enrich_contacts_websearch("Acme Corp", domain=None)
 
         prompt = mock_claude.call_args.args[0]
@@ -410,11 +333,7 @@ class TestEnrichContactsWebsearch:
 
     async def test_uses_smart_model_tier(self):
         """Contact enrichment uses the SMART model tier."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value={"contacts": []},
-        ) as mock_claude:
+        with _patch_claude_json(return_value={"contacts": []}) as mock_claude:
             await enrich_contacts_websearch("Acme Corp")
 
         kwargs = mock_claude.call_args.kwargs
@@ -422,11 +341,7 @@ class TestEnrichContactsWebsearch:
 
     async def test_uses_web_search_tool(self):
         """Contact enrichment enables the web_search tool."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value={"contacts": []},
-        ) as mock_claude:
+        with _patch_claude_json(return_value={"contacts": []}) as mock_claude:
             await enrich_contacts_websearch("Acme Corp")
 
         kwargs = mock_claude.call_args.kwargs
@@ -443,37 +358,11 @@ class TestEnrichContactsWebsearch:
             ]
         }
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Test Co")
 
         for c in contacts:
             assert c["source"] == "web_search"
-
-    async def test_unexpected_return_type_returns_empty(self):
-        """If claude_json returns an unexpected type (e.g., string), return empty."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value="not a dict or list",
-        ):
-            contacts = await enrich_contacts_websearch("Bad Corp")
-
-        assert contacts == []
-
-    async def test_int_return_type_returns_empty(self):
-        """If claude_json returns an int, return empty."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=42,
-        ):
-            contacts = await enrich_contacts_websearch("Bad Corp")
-
-        assert contacts == []
 
 
 # ── Feature 3: Company Intelligence Cards ──────────────────────────
@@ -495,20 +384,7 @@ class TestCompanyIntel:
             "sources": ["acme.com", "reuters.com"],
         }
 
-        with (
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value=mock_intel,
-            ),
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.set_cached",
-            ) as mock_set,
-        ):
+        with _intel_patches({"return_value": mock_intel}) as (_, _, mock_set):
             result = await company_intel("Acme Corp")
 
         assert result is not None
@@ -523,14 +399,8 @@ class TestCompanyIntel:
         cached_data = {"summary": "Cached intel", "revenue": "$1B"}
 
         with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=cached_data,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-            ) as mock_claude,
+            patch("app.services.ai_service.get_cached", return_value=cached_data),
+            _patch_claude_json() as mock_claude,
         ):
             result = await company_intel("Acme Corp")
 
@@ -539,20 +409,7 @@ class TestCompanyIntel:
 
     async def test_cache_key_lowered_and_stripped(self):
         """Cache key normalizes company name to lowercase/stripped."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ) as mock_get,
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value={"summary": "test"},
-            ),
-            patch(
-                "app.services.ai_service.set_cached",
-            ),
-        ):
+        with _intel_patches({"return_value": {"summary": "test"}}) as (mock_get, _, _):
             await company_intel("  ACME Corp  ")
 
         # get_cached should be called with lowered/stripped key
@@ -560,106 +417,33 @@ class TestCompanyIntel:
 
     async def test_set_cached_with_7_day_ttl(self):
         """Cache entries use 7-day TTL."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value={"summary": "test"},
-            ),
-            patch(
-                "app.services.ai_service.set_cached",
-            ) as mock_set,
-        ):
+        with _intel_patches({"return_value": {"summary": "test"}}) as (_, _, mock_set):
             await company_intel("Acme Corp")
 
         mock_set.assert_called_once()
         args = mock_set.call_args
         assert args.kwargs.get("ttl_days") == 7 or args.args[2] == 7
 
-    async def test_returns_none_on_api_failure(self):
-        """Returns None when claude_json returns None."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.set_cached",
-            ) as mock_set,
-        ):
-            result = await company_intel("Ghost Corp")
-
-        assert result is None
-        mock_set.assert_not_called()
-
-    async def test_returns_none_on_non_dict_response(self):
-        """Returns None when claude_json returns a non-dict (e.g., list, string)."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value=["not", "a", "dict"],
-            ),
-            patch(
-                "app.services.ai_service.set_cached",
-            ) as mock_set,
-        ):
+    @pytest.mark.parametrize(
+        "claude_return",
+        [
+            pytest.param(None, id="none"),
+            pytest.param(["not", "a", "dict"], id="list"),
+            pytest.param({}, id="empty-dict"),
+            pytest.param("just a string", id="string"),
+        ],
+    )
+    async def test_returns_none_without_caching_for_unusable_result(self, claude_return):
+        """None, non-dict, and empty-dict results all yield None and skip caching."""
+        with _intel_patches({"return_value": claude_return}) as (_, _, mock_set):
             result = await company_intel("Bad Corp")
 
         assert result is None
         mock_set.assert_not_called()
 
-    async def test_returns_none_on_empty_dict(self):
-        """Returns None when claude_json returns an empty dict (falsy check)."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value={},
-            ),
-            patch(
-                "app.services.ai_service.set_cached",
-            ) as mock_set,
-        ):
-            result = await company_intel("Empty Corp")
-
-        # Empty dict is falsy -> should return None
-        assert result is None
-        mock_set.assert_not_called()
-
     async def test_domain_included_in_prompt(self):
         """When domain is provided it appears in the prompt."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value={"summary": "test"},
-            ) as mock_claude,
-            patch(
-                "app.services.ai_service.set_cached",
-            ),
-        ):
+        with _intel_patches({"return_value": {"summary": "test"}}) as (_, mock_claude, _):
             await company_intel("Acme Corp", domain="acme.com")
 
         prompt = mock_claude.call_args.args[0]
@@ -667,20 +451,7 @@ class TestCompanyIntel:
 
     async def test_domain_not_in_prompt_when_none(self):
         """When domain is None, no domain parenthetical."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value={"summary": "test"},
-            ) as mock_claude,
-            patch(
-                "app.services.ai_service.set_cached",
-            ),
-        ):
+        with _intel_patches({"return_value": {"summary": "test"}}) as (_, mock_claude, _):
             await company_intel("Acme Corp", domain=None)
 
         prompt = mock_claude.call_args.args[0]
@@ -688,20 +459,7 @@ class TestCompanyIntel:
 
     async def test_uses_smart_model_tier(self):
         """Company intel uses the SMART model tier."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value={"summary": "test"},
-            ) as mock_claude,
-            patch(
-                "app.services.ai_service.set_cached",
-            ),
-        ):
+        with _intel_patches({"return_value": {"summary": "test"}}) as (_, mock_claude, _):
             await company_intel("Acme Corp")
 
         kwargs = mock_claude.call_args.kwargs
@@ -709,47 +467,13 @@ class TestCompanyIntel:
 
     async def test_uses_web_search_tool(self):
         """Company intel enables the web_search tool."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value={"summary": "test"},
-            ) as mock_claude,
-            patch(
-                "app.services.ai_service.set_cached",
-            ),
-        ):
+        with _intel_patches({"return_value": {"summary": "test"}}) as (_, mock_claude, _):
             await company_intel("Acme Corp")
 
         kwargs = mock_claude.call_args.kwargs
         assert kwargs["tools"] is not None
         tool_types = [t["type"] for t in kwargs["tools"]]
         assert "web_search_20250305" in tool_types
-
-    async def test_string_return_from_claude_returns_none(self):
-        """If claude_json somehow returns a string, return None."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value="just a string",
-            ),
-            patch(
-                "app.services.ai_service.set_cached",
-            ) as mock_set,
-        ):
-            result = await company_intel("String Corp")
-
-        assert result is None
-        mock_set.assert_not_called()
 
 
 # ── Feature 4: Smart RFQ Email Drafts ─────────────────────────────
@@ -766,11 +490,7 @@ class TestDraftRfq:
             "Please provide your best pricing and availability."
         )
 
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value=expected_body,
-        ):
+        with _patch_routed_text(return_value=expected_body):
             result = await draft_rfq(
                 vendor_name="Arrow Electronics",
                 parts=[{"mpn": "LM317T", "qty": 1000, "target_price": 0.50}],
@@ -780,11 +500,7 @@ class TestDraftRfq:
 
     async def test_returns_none_on_api_failure(self):
         """Returns None when claude_text returns None."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
+        with _patch_routed_text(return_value=None):
             result = await draft_rfq(
                 vendor_name="Arrow",
                 parts=[{"mpn": "LM317T", "qty": 1000}],
@@ -802,11 +518,7 @@ class TestDraftRfq:
             "best_price": "$0.45",
         }
 
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Arrow Electronics",
                 parts=[{"mpn": "LM317T", "qty": 1000}],
@@ -822,11 +534,7 @@ class TestDraftRfq:
 
     async def test_no_history_context_when_none(self):
         """No history section in prompt when vendor_history is None."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Arrow Electronics",
                 parts=[{"mpn": "LM317T", "qty": 1000}],
@@ -838,11 +546,7 @@ class TestDraftRfq:
 
     async def test_target_price_in_parts_string(self):
         """Target price is shown when provided."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Arrow",
                 parts=[{"mpn": "LM317T", "qty": 1000, "target_price": 0.50}],
@@ -853,11 +557,7 @@ class TestDraftRfq:
 
     async def test_no_target_price_when_absent(self):
         """When target_price is missing, no target mentioned."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Arrow",
                 parts=[{"mpn": "LM317T", "qty": 1000}],
@@ -874,11 +574,7 @@ class TestDraftRfq:
             {"mpn": "TL431", "qty": 2000, "target_price": 0.25},
         ]
 
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(vendor_name="Arrow", parts=parts)
 
         prompt = mock_claude.call_args.args[0]
@@ -890,11 +586,7 @@ class TestDraftRfq:
         """Only the first 20 parts are included in the prompt."""
         parts = [{"mpn": f"PART-{i:03d}", "qty": 100} for i in range(30)]
 
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(vendor_name="Arrow", parts=parts)
 
         prompt = mock_claude.call_args.args[0]
@@ -903,11 +595,7 @@ class TestDraftRfq:
 
     async def test_uses_fast_model_tier(self):
         """RFQ drafts use the FAST model tier."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Arrow",
                 parts=[{"mpn": "LM317T", "qty": 1000}],
@@ -918,11 +606,7 @@ class TestDraftRfq:
 
     async def test_user_name_in_prompt(self):
         """User name is passed into the prompt."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Arrow",
                 parts=[{"mpn": "LM317T", "qty": 1000}],
@@ -934,11 +618,7 @@ class TestDraftRfq:
 
     async def test_default_sender_when_no_user_name(self):
         """Default sender label when user_name is empty."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Arrow",
                 parts=[{"mpn": "LM317T", "qty": 1000}],
@@ -950,11 +630,7 @@ class TestDraftRfq:
 
     async def test_vendor_name_in_prompt(self):
         """Vendor name appears in the prompt."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Mouser Electronics",
                 parts=[{"mpn": "LM317T", "qty": 1000}],
@@ -965,11 +641,7 @@ class TestDraftRfq:
 
     async def test_empty_parts_list(self):
         """Empty parts list still calls claude_text."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             result = await draft_rfq(vendor_name="Arrow", parts=[])
 
         assert result == "email body"
@@ -977,11 +649,7 @@ class TestDraftRfq:
 
     async def test_parts_with_missing_fields(self):
         """Parts with missing mpn/qty use '?' placeholder."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Arrow",
                 parts=[{"target_price": 0.50}],  # no mpn or qty
@@ -994,11 +662,7 @@ class TestDraftRfq:
         """Vendor history dict with missing keys uses defaults gracefully."""
         history = {"total_rfqs": 5}  # other fields missing
 
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="email body",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="email body") as mock_claude:
             await draft_rfq(
                 vendor_name="Arrow",
                 parts=[{"mpn": "LM317T", "qty": 1000}],
@@ -1021,22 +685,14 @@ class TestRephraseRfq:
         original = "Please quote LM317T x1000 pcs."
         rephrased = "Could you provide pricing for LM317T, quantity 1000?"
 
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value=rephrased,
-        ):
+        with _patch_routed_text(return_value=rephrased):
             result = await rephrase_rfq(original)
 
         assert result == rephrased
 
     async def test_returns_none_on_api_failure(self):
         """Returns None when claude_text returns None."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value=None,
-        ):
+        with _patch_routed_text(return_value=None):
             result = await rephrase_rfq("Please quote LM317T.")
 
         assert result is None
@@ -1045,11 +701,7 @@ class TestRephraseRfq:
         """The original email body is included in the prompt."""
         original = "Please quote LM317T x1000 pcs at $0.50 target."
 
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="rephrased text",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="rephrased text") as mock_claude:
             await rephrase_rfq(original)
 
         prompt = mock_claude.call_args.args[0]
@@ -1057,11 +709,7 @@ class TestRephraseRfq:
 
     async def test_uses_fast_model_tier(self):
         """Rephrase uses the FAST model tier."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="rephrased text",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="rephrased text") as mock_claude:
             await rephrase_rfq("Please quote LM317T.")
 
         kwargs = mock_claude.call_args.kwargs
@@ -1069,11 +717,7 @@ class TestRephraseRfq:
 
     async def test_max_tokens_is_800(self):
         """Rephrase requests 800 max tokens."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="rephrased text",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="rephrased text") as mock_claude:
             await rephrase_rfq("Please quote LM317T.")
 
         kwargs = mock_claude.call_args.kwargs
@@ -1081,11 +725,7 @@ class TestRephraseRfq:
 
     async def test_empty_body_still_calls_claude(self):
         """Even with empty body, the function calls claude_text."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="rephrased empty",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="rephrased empty") as mock_claude:
             result = await rephrase_rfq("")
 
         assert result == "rephrased empty"
@@ -1095,11 +735,7 @@ class TestRephraseRfq:
         """A long email body is passed through without truncation."""
         long_body = "Line of text. " * 500  # ~7500 chars
 
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            return_value="rephrased",
-        ) as mock_claude:
+        with _patch_routed_text(return_value="rephrased") as mock_claude:
             await rephrase_rfq(long_body)
 
         prompt = mock_claude.call_args.args[0]
@@ -1114,37 +750,19 @@ class TestErrorHandling:
 
     async def test_enrich_contacts_claude_exception_propagates(self):
         """If claude_json raises an unexpected exception, it propagates."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("Unexpected error"),
-        ):
+        with _patch_claude_json(side_effect=RuntimeError("Unexpected error")):
             with pytest.raises(RuntimeError, match="Unexpected error"):
                 await enrich_contacts_websearch("Error Corp")
 
     async def test_company_intel_claude_exception_propagates(self):
         """If claude_json raises an unexpected exception, it propagates."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                side_effect=RuntimeError("API down"),
-            ),
-        ):
+        with _intel_patches({"side_effect": RuntimeError("API down")}):
             with pytest.raises(RuntimeError, match="API down"):
                 await company_intel("Error Corp")
 
     async def test_draft_rfq_claude_exception_propagates(self):
         """If claude_text raises an unexpected exception, it propagates."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            side_effect=TimeoutError("Timed out"),
-        ):
+        with _patch_routed_text(side_effect=TimeoutError("Timed out")):
             with pytest.raises(TimeoutError, match="Timed out"):
                 await draft_rfq(
                     vendor_name="Timeout Vendor",
@@ -1153,21 +771,13 @@ class TestErrorHandling:
 
     async def test_rephrase_rfq_claude_exception_propagates(self):
         """If claude_text raises an unexpected exception, it propagates."""
-        with patch(
-            "app.services.ai_service.routed_text",
-            new_callable=AsyncMock,
-            side_effect=ConnectionError("Network failure"),
-        ):
+        with _patch_routed_text(side_effect=ConnectionError("Network failure")):
             with pytest.raises(ConnectionError, match="Network failure"):
                 await rephrase_rfq("Some body")
 
     async def test_enrich_contacts_empty_company_name(self):
         """Empty company name still calls claude_json."""
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value={"contacts": []},
-        ) as mock_claude:
+        with _patch_claude_json(return_value={"contacts": []}) as mock_claude:
             result = await enrich_contacts_websearch("")
 
         assert result == []
@@ -1175,20 +785,7 @@ class TestErrorHandling:
 
     async def test_company_intel_empty_company_name(self):
         """Empty company name still proceeds (caching with empty key)."""
-        with (
-            patch(
-                "app.services.ai_service.get_cached",
-                return_value=None,
-            ),
-            patch(
-                "app.services.ai_service.claude_json",
-                new_callable=AsyncMock,
-                return_value={"summary": "minimal"},
-            ),
-            patch(
-                "app.services.ai_service.set_cached",
-            ),
-        ):
+        with _intel_patches({"return_value": {"summary": "minimal"}}):
             result = await company_intel("")
 
         assert result is not None
@@ -1205,11 +802,7 @@ class TestErrorHandling:
             ]
         }
 
-        with patch(
-            "app.services.ai_service.claude_json",
-            new_callable=AsyncMock,
-            return_value=mock_result,
-        ):
+        with _patch_claude_json(return_value=mock_result):
             contacts = await enrich_contacts_websearch("Mixed Corp")
 
         assert len(contacts) == 2

--- a/tests/test_sightings_scoring.py
+++ b/tests/test_sightings_scoring.py
@@ -8,11 +8,17 @@ from app.models.intelligence import ActivityLog
 from app.models.sourcing import Requirement, Requisition
 
 
-def test_requirement_has_priority_score(db_session):
-    """Requirement model should have a priority_score column."""
+def _make_requisition(db_session):
+    """Create and flush an active test Requisition, returning it with an id assigned."""
     req = Requisition(name="Test RFQ", status="active")
     db_session.add(req)
     db_session.flush()
+    return req
+
+
+def test_requirement_has_priority_score(db_session):
+    """Requirement model should have a priority_score column."""
+    req = _make_requisition(db_session)
     r = Requirement(
         requisition_id=req.id,
         primary_mpn="TEST-001",
@@ -26,9 +32,7 @@ def test_requirement_has_priority_score(db_session):
 
 def test_requirement_has_assigned_buyer_id(db_session, test_user):
     """Requirement model should have an assigned_buyer_id column."""
-    req = Requisition(name="Test RFQ", status="active")
-    db_session.add(req)
-    db_session.flush()
+    req = _make_requisition(db_session)
     r = Requirement(
         requisition_id=req.id,
         primary_mpn="TEST-002",
@@ -42,9 +46,7 @@ def test_requirement_has_assigned_buyer_id(db_session, test_user):
 
 def test_activity_log_has_requirement_id(db_session, test_user):
     """ActivityLog model should have a requirement_id FK column."""
-    req = Requisition(name="Test RFQ", status="active")
-    db_session.add(req)
-    db_session.flush()
+    req = _make_requisition(db_session)
     r = Requirement(
         requisition_id=req.id,
         primary_mpn="TEST-003",

--- a/tests/test_smart_ai_trigger.py
+++ b/tests/test_smart_ai_trigger.py
@@ -5,6 +5,8 @@ Called by: pytest
 Depends on: app.search_service.should_trigger_ai_search
 """
 
+import pytest
+
 from app.search_service import should_trigger_ai_search
 
 # ── Unit tests for should_trigger_ai_search() ─────────────────────
@@ -13,136 +15,56 @@ from app.search_service import should_trigger_ai_search
 class TestShouldTriggerAISearch:
     """Pure logic tests — no DB or async needed."""
 
-    def test_trigger_few_results(self):
-        """<5 API results should trigger AI search."""
+    @pytest.mark.parametrize(
+        (
+            "api_result_count",
+            "has_price_below_target",
+            "is_obsolete",
+            "months_since_last_sighting",
+            "manual_trigger",
+            "expected",
+        ),
+        [
+            # <5 API results should trigger AI search.
+            pytest.param(3, True, False, 1.0, False, True, id="few_results"),
+            # 10 results with good prices, not obsolete, recent sightings -> no trigger.
+            pytest.param(10, True, False, 1.0, False, False, id="many_results"),
+            # All prices above target should trigger AI search.
+            pytest.param(10, False, False, 1.0, False, True, id="no_price_below_target"),
+            # Some prices below target with enough results -> no trigger.
+            pytest.param(10, True, False, 1.0, False, False, id="has_price_below_target"),
+            # Obsolete part should always trigger AI search.
+            pytest.param(10, True, True, 1.0, False, True, id="obsolete"),
+            # >6 months since last sighting should trigger AI search.
+            pytest.param(10, True, False, 7.0, False, True, id="stale_sightings"),
+            # Manual trigger always returns True regardless of other conditions.
+            pytest.param(100, True, False, 0.1, True, True, id="manual"),
+            # None months_since_last_sighting (no history) with enough results -> no trigger.
+            pytest.param(10, True, False, None, False, False, id="no_sighting_history"),
+            # Exactly 5 results (not <5) with good conditions -> no trigger.
+            pytest.param(5, True, False, 1.0, False, False, id="exactly_5_results"),
+            # Exactly 6 months since last sighting -> trigger (>=6).
+            pytest.param(10, True, False, 6.0, False, True, id="exactly_6_months"),
+            # 15 results with prices below target -> AI not triggered.
+            pytest.param(15, True, False, 2.0, False, False, id="ai_skipped_when_rich_results"),
+        ],
+    )
+    def test_should_trigger_ai_search(
+        self,
+        api_result_count,
+        has_price_below_target,
+        is_obsolete,
+        months_since_last_sighting,
+        manual_trigger,
+        expected,
+    ):
         assert (
             should_trigger_ai_search(
-                api_result_count=3,
-                has_price_below_target=True,
-                is_obsolete=False,
-                months_since_last_sighting=1.0,
+                api_result_count=api_result_count,
+                has_price_below_target=has_price_below_target,
+                is_obsolete=is_obsolete,
+                months_since_last_sighting=months_since_last_sighting,
+                manual_trigger=manual_trigger,
             )
-            is True
-        )
-
-    def test_trigger_many_results(self):
-        """10 results with good prices, not obsolete, recent sightings -> no trigger."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=10,
-                has_price_below_target=True,
-                is_obsolete=False,
-                months_since_last_sighting=1.0,
-            )
-            is False
-        )
-
-    def test_trigger_no_price_below_target(self):
-        """All prices above target should trigger AI search."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=10,
-                has_price_below_target=False,
-                is_obsolete=False,
-                months_since_last_sighting=1.0,
-            )
-            is True
-        )
-
-    def test_trigger_has_price_below_target(self):
-        """Some prices below target with enough results -> no trigger."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=10,
-                has_price_below_target=True,
-                is_obsolete=False,
-                months_since_last_sighting=1.0,
-            )
-            is False
-        )
-
-    def test_trigger_obsolete(self):
-        """Obsolete part should always trigger AI search."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=10,
-                has_price_below_target=True,
-                is_obsolete=True,
-                months_since_last_sighting=1.0,
-            )
-            is True
-        )
-
-    def test_trigger_stale_sightings(self):
-        """>6 months since last sighting should trigger AI search."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=10,
-                has_price_below_target=True,
-                is_obsolete=False,
-                months_since_last_sighting=7.0,
-            )
-            is True
-        )
-
-    def test_trigger_manual(self):
-        """Manual trigger always returns True regardless of other conditions."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=100,
-                has_price_below_target=True,
-                is_obsolete=False,
-                months_since_last_sighting=0.1,
-                manual_trigger=True,
-            )
-            is True
-        )
-
-    def test_trigger_no_sighting_history(self):
-        """None months_since_last_sighting (no history) with enough results -> no
-        trigger."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=10,
-                has_price_below_target=True,
-                is_obsolete=False,
-                months_since_last_sighting=None,
-            )
-            is False
-        )
-
-    def test_trigger_exactly_5_results(self):
-        """Exactly 5 results (not <5) with good conditions -> no trigger."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=5,
-                has_price_below_target=True,
-                is_obsolete=False,
-                months_since_last_sighting=1.0,
-            )
-            is False
-        )
-
-    def test_trigger_exactly_6_months(self):
-        """Exactly 6 months since last sighting -> trigger (>=6)."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=10,
-                has_price_below_target=True,
-                is_obsolete=False,
-                months_since_last_sighting=6.0,
-            )
-            is True
-        )
-
-    def test_ai_skipped_when_rich_results(self):
-        """15 results with prices below target -> AI not triggered."""
-        assert (
-            should_trigger_ai_search(
-                api_result_count=15,
-                has_price_below_target=True,
-                is_obsolete=False,
-                months_since_last_sighting=2.0,
-            )
-            is False
+            is expected
         )

--- a/tests/test_sourcengine_connector.py
+++ b/tests/test_sourcengine_connector.py
@@ -103,84 +103,97 @@ class TestSourcengineParseEdgeCases:
 
         return SourcengineConnector(api_key="test-key")
 
-    def test_non_list_offers_returns_empty(self):
-        """When offers field is not a list → treat as empty."""
-        connector = self._make_connector()
-        data = {"offers": "not-a-list"}
-        result = connector._parse(data, "LM317T")
-        assert result == []
-
-    def test_non_dict_offer_items_skipped(self):
-        """Non-dict items in offers list are skipped."""
-        connector = self._make_connector()
-        data = {
-            "offers": [
-                "string-not-dict",
-                42,
-                None,
+    @pytest.mark.parametrize(
+        ("data", "expected_vendor_name"),
+        [
+            pytest.param({"offers": "not-a-list"}, None, id="non_list_offers_returns_empty"),
+            pytest.param(
                 {
-                    "supplier": {"name": "Arrow"},
-                    "mpn": "LM317T",
-                    "quantity": 500,
-                    "unit_price": 0.80,
+                    "offers": [
+                        "string-not-dict",
+                        42,
+                        None,
+                        {
+                            "supplier": {"name": "Arrow"},
+                            "mpn": "LM317T",
+                            "quantity": 500,
+                            "unit_price": 0.80,
+                        },
+                    ]
                 },
-            ]
-        }
-        result = connector._parse(data, "LM317T")
-        assert len(result) == 1
-        assert result[0]["vendor_name"] == "Arrow"
-
-    def test_supplier_as_string_not_dict(self):
-        """Supplier field is a string → use str() directly."""
-        connector = self._make_connector()
-        data = {
-            "offers": [
+                "Arrow",
+                id="non_dict_offer_items_skipped",
+            ),
+            pytest.param(
                 {
-                    "supplier": "Mouser Electronics",
-                    "mpn": "LM317T",
-                    "quantity": 200,
-                    "unit_price": 0.90,
-                }
-            ]
-        }
-        result = connector._parse(data, "LM317T")
-        assert len(result) == 1
-        assert result[0]["vendor_name"] == "Mouser Electronics"
-
-    def test_empty_supplier_name_skipped(self):
-        """Offer with no resolvable supplier name → skipped."""
-        connector = self._make_connector()
-        data = {
-            "offers": [
+                    "offers": [
+                        {
+                            "supplier": "Mouser Electronics",
+                            "mpn": "LM317T",
+                            "quantity": 200,
+                            "unit_price": 0.90,
+                        }
+                    ]
+                },
+                "Mouser Electronics",
+                id="supplier_as_string_not_dict",
+            ),
+            pytest.param(
                 {
-                    "supplier": {},  # dict but name is empty
-                    "mpn": "LM317T",
-                    "quantity": 100,
-                    "unit_price": 1.00,
-                    # No supplier_name or company fallbacks
-                }
-            ]
-        }
-        result = connector._parse(data, "LM317T")
-        assert result == []
-
-    def test_supplier_name_from_fallback_fields(self):
-        """No supplier dict name → falls back to supplier_name or company."""
-        connector = self._make_connector()
-        data = {
-            "offers": [
+                    "offers": [
+                        {
+                            "supplier": {},  # dict but name is empty
+                            "mpn": "LM317T",
+                            "quantity": 100,
+                            "unit_price": 1.00,
+                            # No supplier_name or company fallbacks
+                        }
+                    ]
+                },
+                None,
+                id="empty_supplier_name_skipped",
+            ),
+            pytest.param(
                 {
-                    "supplier": {},
-                    "supplier_name": "DigiKey",
-                    "mpn": "LM317T",
-                    "quantity": 300,
-                    "unit_price": 0.65,
-                }
-            ]
-        }
+                    "offers": [
+                        {
+                            "supplier": {},
+                            "supplier_name": "DigiKey",
+                            "mpn": "LM317T",
+                            "quantity": 300,
+                            "unit_price": 0.65,
+                        }
+                    ]
+                },
+                "DigiKey",
+                id="supplier_name_from_fallback_fields",
+            ),
+            pytest.param(
+                {
+                    "results": [
+                        {
+                            "supplier": {"name": "Nexar"},
+                            "mpn": "LM317T",
+                            "quantity": 1000,
+                            "unit_price": 0.55,
+                        }
+                    ]
+                },
+                "Nexar",
+                id="results_key_fallback",
+            ),
+        ],
+    )
+    def test_parse_supplier_name_resolution(self, data, expected_vendor_name):
+        """_parse resolves (or rejects) the vendor name across supplier
+        shapes/fallbacks."""
+        connector = self._make_connector()
         result = connector._parse(data, "LM317T")
-        assert len(result) == 1
-        assert result[0]["vendor_name"] == "DigiKey"
+        if expected_vendor_name is None:
+            assert result == []
+        else:
+            assert len(result) == 1
+            assert result[0]["vendor_name"] == expected_vendor_name
 
     def test_deduplication_by_vendor_mpn_sku(self):
         """Duplicate vendor+mpn+sku combinations are deduplicated."""
@@ -205,23 +218,6 @@ class TestSourcengineParseEdgeCases:
         }
         result = connector._parse(data, "LM317T")
         assert len(result) == 1
-
-    def test_results_key_fallback(self):
-        """Uses 'results' key when 'offers' is absent."""
-        connector = self._make_connector()
-        data = {
-            "results": [
-                {
-                    "supplier": {"name": "Nexar"},
-                    "mpn": "LM317T",
-                    "quantity": 1000,
-                    "unit_price": 0.55,
-                }
-            ]
-        }
-        result = connector._parse(data, "LM317T")
-        assert len(result) == 1
-        assert result[0]["vendor_name"] == "Nexar"
 
     def test_manufacturer_as_dict(self):
         """Manufacturer field as dict → extracts name key."""

--- a/tests/test_sse_broker_coverage.py
+++ b/tests/test_sse_broker_coverage.py
@@ -13,6 +13,7 @@ os.environ["TESTING"] = "1"
 
 import asyncio
 
+from app.services.sse_broker import SSEBroker
 from tests.conftest import engine  # noqa: F401
 
 
@@ -21,8 +22,6 @@ class TestSSEBrokerInit:
 
     def test_broker_has_empty_channels_on_init(self):
         """New broker starts with empty channel dict."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         assert len(b._channels) == 0
 
@@ -34,8 +33,6 @@ class TestSSEBrokerInit:
 
     def test_queue_maxsize_default(self):
         """Default queue max size is 200."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         assert b._queue_maxsize == 200
 
@@ -45,24 +42,18 @@ class TestSSEBrokerSubscribe:
 
     def test_subscribe_creates_queue(self):
         """Subscribe() returns an asyncio.Queue."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         q = b.subscribe("test-channel")
         assert isinstance(q, asyncio.Queue)
 
     def test_subscribe_adds_queue_to_channel(self):
         """Subscribe() adds queue to the channel set."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         q = b.subscribe("my-channel")
         assert q in b._channels["my-channel"]
 
     def test_subscribe_multiple_listeners_same_channel(self):
         """Multiple subscribers on same channel each get their own queue."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         q1 = b.subscribe("channel-a")
         q2 = b.subscribe("channel-a")
@@ -71,8 +62,6 @@ class TestSSEBrokerSubscribe:
 
     def test_subscribe_queue_respects_maxsize(self):
         """Subscribed queue uses the configured maxsize."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         q = b.subscribe("size-test")
         assert q.maxsize == b._queue_maxsize
@@ -83,8 +72,6 @@ class TestSSEBrokerUnsubscribe:
 
     def test_unsubscribe_removes_queue(self):
         """Unsubscribe() removes the queue from the channel."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         q = b.subscribe("unsub-test")
         assert q in b._channels["unsub-test"]
@@ -94,8 +81,6 @@ class TestSSEBrokerUnsubscribe:
 
     def test_unsubscribe_nonexistent_queue_is_safe(self):
         """Unsubscribe() of a queue not in channel does not raise."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         fake_q = asyncio.Queue()
         # Should not raise even if queue was never subscribed
@@ -103,8 +88,6 @@ class TestSSEBrokerUnsubscribe:
 
     def test_unsubscribe_leaves_other_queues_intact(self):
         """Unsubscribing one queue doesn't remove others."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         q1 = b.subscribe("multi")
         q2 = b.subscribe("multi")
@@ -119,8 +102,6 @@ class TestSSEBrokerPublish:
 
     async def test_publish_sends_to_all_subscribers(self):
         """Publish() puts event on all subscriber queues."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         q1 = b.subscribe("pub-test")
         q2 = b.subscribe("pub-test")
@@ -134,15 +115,11 @@ class TestSSEBrokerPublish:
 
     async def test_publish_to_empty_channel_is_safe(self):
         """Publish() to a channel with no subscribers does not raise."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         await b.publish("empty-channel", "ping", "")
 
     async def test_publish_drops_oldest_when_queue_full(self):
         """When queue is full, oldest event is dropped to make room."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         b._queue_maxsize = 3
         q = b.subscribe("full-test")
@@ -166,8 +143,6 @@ class TestSSEBrokerPublish:
 
     async def test_publish_default_data_is_empty_string(self):
         """Publish() with no data argument defaults to empty string."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         q = b.subscribe("default-data")
 
@@ -182,8 +157,6 @@ class TestSSEBrokerPublish:
         but race)."""
         import asyncio
         from unittest.mock import patch
-
-        from app.services.sse_broker import SSEBroker
 
         b = SSEBroker()
         q = b.subscribe("full-exception-test")
@@ -200,8 +173,6 @@ class TestSSEBrokerListen:
 
     async def test_listen_yields_published_events(self):
         """Listen() yields events as they are published."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
 
         received = []
@@ -224,8 +195,6 @@ class TestSSEBrokerListen:
 
     async def test_listen_unsubscribes_on_cancel(self):
         """Listen() unsubscribes from channel when generator exits via break."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
 
         result = []
@@ -247,8 +216,6 @@ class TestSSEBrokerListen:
 
     async def test_listen_subscribes_on_start(self):
         """Listen() subscribes to channel when generator starts iterating."""
-        from app.services.sse_broker import SSEBroker
-
         b = SSEBroker()
         channel = "subscribe-check-2"
 

--- a/tests/test_vendor_affinity_coverage.py
+++ b/tests/test_vendor_affinity_coverage.py
@@ -303,19 +303,27 @@ class TestFindAffinityVendorsL3:
 
 
 class TestClassifyMpn:
-    def test_successful_classification(self):
+    @pytest.mark.parametrize(
+        ("mpn", "manufacturer", "category"),
+        [
+            ("LM317T", "Texas Instruments", "Voltage Regulator"),
+            ("RC0402", None, "Resistor"),
+        ],
+        ids=["with_manufacturer_hint", "no_manufacturer_hint"],
+    )
+    def test_successful_classification(self, mpn, manufacturer, category):
         from app.services.vendor_affinity_service import _classify_mpn
 
         mock_client = MagicMock()
-        mock_client.messages.create.return_value = MagicMock(content=[MagicMock(text="Voltage Regulator")])
+        mock_client.messages.create.return_value = MagicMock(content=[MagicMock(text=category)])
 
         mock_anthropic_mod = MagicMock()
         mock_anthropic_mod.Anthropic.return_value = mock_client
 
         with patch.dict("sys.modules", {"anthropic": mock_anthropic_mod}):
-            result = _classify_mpn("LM317T", "Texas Instruments", "sk-fake")
+            result = _classify_mpn(mpn, manufacturer, "sk-fake")
 
-        assert result == "Voltage Regulator"
+        assert result == category
 
     def test_returns_none_on_exception(self):
         from app.services.vendor_affinity_service import _classify_mpn
@@ -327,20 +335,6 @@ class TestClassifyMpn:
             result = _classify_mpn("LM317T", None, "sk-fake")
 
         assert result is None
-
-    def test_no_manufacturer_hint(self):
-        from app.services.vendor_affinity_service import _classify_mpn
-
-        mock_client = MagicMock()
-        mock_client.messages.create.return_value = MagicMock(content=[MagicMock(text="Resistor")])
-
-        mock_anthropic_mod = MagicMock()
-        mock_anthropic_mod.Anthropic.return_value = mock_client
-
-        with patch.dict("sys.modules", {"anthropic": mock_anthropic_mod}):
-            result = _classify_mpn("RC0402", None, "sk-fake")
-
-        assert result == "Resistor"
 
 
 class TestScoreAffinityMatches:

--- a/tests/test_vendor_discovery.py
+++ b/tests/test_vendor_discovery.py
@@ -6,6 +6,7 @@ Depends on: app.models.vendors, app.models.sourcing, app.models.intelligence
 
 from decimal import Decimal
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -19,27 +20,24 @@ from tests.conftest import engine  # noqa: F401
 class TestJsonbTagColumns:
     """Test that VendorCard tag columns accept JSONB data."""
 
-    def test_brand_tags_accepts_list(self, db_session: Session):
-        """VendorCard.brand_tags stores a list."""
+    @pytest.mark.parametrize(
+        ("normalized_name", "display_name", "column", "value"),
+        [
+            ("test vendor", "Test Vendor", "brand_tags", ["TI", "NXP", "ST"]),
+            ("test vendor 2", "Test Vendor 2", "commodity_tags", ["Microcontrollers", "Memory"]),
+        ],
+        ids=["brand_tags", "commodity_tags"],
+    )
+    def test_tag_column_accepts_list(self, db_session: Session, normalized_name, display_name, column, value):
+        """VendorCard tag columns store a list."""
         v = VendorCard(
-            normalized_name="test vendor",
-            display_name="Test Vendor",
-            brand_tags=["TI", "NXP", "ST"],
+            normalized_name=normalized_name,
+            display_name=display_name,
+            **{column: value},
         )
         db_session.add(v)
         db_session.flush()
-        assert v.brand_tags == ["TI", "NXP", "ST"]
-
-    def test_commodity_tags_accepts_list(self, db_session: Session):
-        """VendorCard.commodity_tags stores a list."""
-        v = VendorCard(
-            normalized_name="test vendor 2",
-            display_name="Test Vendor 2",
-            commodity_tags=["Microcontrollers", "Memory"],
-        )
-        db_session.add(v)
-        db_session.flush()
-        assert v.commodity_tags == ["Microcontrollers", "Memory"]
+        assert getattr(v, column) == value
 
 
 class TestEnhancedBrowseSearch:

--- a/tests/test_vendor_email_nightly2.py
+++ b/tests/test_vendor_email_nightly2.py
@@ -49,6 +49,22 @@ def _make_ei_row(sender_email, sender_domain=None, received_at=None):
     return ei
 
 
+def _query_dispatcher(routes, default):
+    """Return a ``db.query`` side_effect that maps each model class to a chain.
+
+    *routes* is a list of ``(model, chain)`` pairs; the first matching model wins.
+    Anything not listed returns *default*.
+    """
+
+    def patched_query(model, *args, **kwargs):
+        for route_model, chain in routes:
+            if model is route_model:
+                return chain
+        return default
+
+    return patched_query
+
+
 class TestMaterialVendorHistoryLoopBody:
     """Cover lines 140-147: the for-loop body inside the MaterialVendorHistory try block."""
 
@@ -62,12 +78,10 @@ class TestMaterialVendorHistoryLoopBody:
         ei_chain = _make_query_chain([])
         sighting_chain = _make_query_chain([])
 
-        def patched_query(model, *args, **kwargs):
-            if model is MaterialVendorHistory:
-                return history_chain
-            if model is EmailIntelligence:
-                return ei_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [(MaterialVendorHistory, history_chain), (EmailIntelligence, ei_chain)],
+            default=sighting_chain,
+        )
 
         mock_mpn = MagicMock()
         with patch.object(db_session, "query", side_effect=patched_query):
@@ -87,12 +101,10 @@ class TestMaterialVendorHistoryLoopBody:
         ei_chain = _make_query_chain([])
         sighting_chain = _make_query_chain([])
 
-        def patched_query(model, *args, **kwargs):
-            if model is MaterialVendorHistory:
-                return history_chain
-            if model is EmailIntelligence:
-                return ei_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [(MaterialVendorHistory, history_chain), (EmailIntelligence, ei_chain)],
+            default=sighting_chain,
+        )
 
         mock_mpn = MagicMock()
         with patch.object(db_session, "query", side_effect=patched_query):
@@ -111,12 +123,10 @@ class TestMaterialVendorHistoryLoopBody:
         ei_chain = _make_query_chain([])
         sighting_chain = _make_query_chain([])
 
-        def patched_query(model, *args, **kwargs):
-            if model is MaterialVendorHistory:
-                return history_chain
-            if model is EmailIntelligence:
-                return ei_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [(MaterialVendorHistory, history_chain), (EmailIntelligence, ei_chain)],
+            default=sighting_chain,
+        )
 
         mock_mpn = MagicMock()
         with patch.object(db_session, "query", side_effect=patched_query):
@@ -163,14 +173,15 @@ class TestMaterialVendorHistoryLoopBody:
             normalize_calls.append((name, r))
             return r
 
-        def patched_query(model, *args, **kwargs):
-            if model is MaterialVendorHistory:
-                return history_chain
-            if model is EmailIntelligence:
-                return ei_chain
-            if model is VendorCard or model is VendorContact:
-                return empty_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [
+                (MaterialVendorHistory, history_chain),
+                (EmailIntelligence, ei_chain),
+                (VendorCard, empty_chain),
+                (VendorContact, empty_chain),
+            ],
+            default=sighting_chain,
+        )
 
         mock_mpn = MagicMock()
         with patch.object(db_session, "query", side_effect=patched_query):
@@ -208,14 +219,15 @@ class TestMaterialVendorHistoryLoopBody:
         sighting_chain = _make_query_chain([])
         empty_chain = _make_query_chain([])
 
-        def patched_query(model, *args, **kwargs):
-            if model is MaterialVendorHistory:
-                return history_chain
-            if model is EmailIntelligence:
-                return ei_chain
-            if model is VendorCard or model is VendorContact:
-                return empty_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [
+                (MaterialVendorHistory, history_chain),
+                (EmailIntelligence, ei_chain),
+                (VendorCard, empty_chain),
+                (VendorContact, empty_chain),
+            ],
+            default=sighting_chain,
+        )
 
         mock_mpn = MagicMock()
         with patch.object(db_session, "query", side_effect=patched_query):
@@ -243,12 +255,10 @@ class TestEmailIntelligenceLoopBody:
         sighting_chain = _make_query_chain([])
         history_chain = _make_query_chain([])
 
-        def patched_query(model, *args, **kwargs):
-            if model is EmailIntelligence:
-                return ei_chain
-            if model is MaterialVendorHistory:
-                return history_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [(EmailIntelligence, ei_chain), (MaterialVendorHistory, history_chain)],
+            default=sighting_chain,
+        )
 
         with patch.object(db_session, "query", side_effect=patched_query):
             result = _query_db_for_part("LM317T", db_session)
@@ -265,23 +275,15 @@ class TestEmailIntelligenceLoopBody:
         sighting_chain = _make_query_chain([])
         history_chain = _make_query_chain([])
 
-        call_count = {"n": 0}
-
-        def normalize_returning_none(name):
-            call_count["n"] += 1
-            return None
-
-        def patched_query(model, *args, **kwargs):
-            if model is EmailIntelligence:
-                return ei_chain
-            if model is MaterialVendorHistory:
-                return history_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [(EmailIntelligence, ei_chain), (MaterialVendorHistory, history_chain)],
+            default=sighting_chain,
+        )
 
         with patch.object(db_session, "query", side_effect=patched_query):
             with patch(
                 "app.services.vendor_email_lookup.normalize_vendor_name",
-                side_effect=normalize_returning_none,
+                return_value=None,
             ):
                 result = _query_db_for_part("LM317T", db_session)
 
@@ -301,12 +303,10 @@ class TestEmailIntelligenceLoopBody:
         sighting_chain = _make_query_chain([])
         history_chain = _make_query_chain([])
 
-        def patched_query(model, *args, **kwargs):
-            if model is EmailIntelligence:
-                return ei_chain
-            if model is MaterialVendorHistory:
-                return history_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [(EmailIntelligence, ei_chain), (MaterialVendorHistory, history_chain)],
+            default=sighting_chain,
+        )
 
         with patch.object(db_session, "query", side_effect=patched_query):
             result = _query_db_for_part("LM317T", db_session)
@@ -332,12 +332,10 @@ class TestEmailIntelligenceLoopBody:
         sighting_chain = _make_query_chain([])
         history_chain = _make_query_chain([])
 
-        def patched_query(model, *args, **kwargs):
-            if model is EmailIntelligence:
-                return ei_chain
-            if model is MaterialVendorHistory:
-                return history_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [(EmailIntelligence, ei_chain), (MaterialVendorHistory, history_chain)],
+            default=sighting_chain,
+        )
 
         with patch.object(db_session, "query", side_effect=patched_query):
             result = _query_db_for_part("LM317T", db_session)
@@ -374,20 +372,19 @@ class TestEmailIntelligenceLoopBody:
         ei_chain = _make_query_chain([ei_row])
         history_chain = _make_query_chain([])
 
-        real_normalize = __import__("app.vendor_utils", fromlist=["normalize_vendor_name"]).normalize_vendor_name
-
         from app.models.vendors import VendorCard, VendorContact
 
         empty_chain = _make_query_chain([])
 
-        def patched_query(model, *args, **kwargs):
-            if model is EmailIntelligence:
-                return ei_chain
-            if model is MaterialVendorHistory:
-                return history_chain
-            if model is VendorCard or model is VendorContact:
-                return empty_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [
+                (EmailIntelligence, ei_chain),
+                (MaterialVendorHistory, history_chain),
+                (VendorCard, empty_chain),
+                (VendorContact, empty_chain),
+            ],
+            default=sighting_chain,
+        )
 
         # We need the sighting vendor to have domain=arrow.com so the match fires.
         # Patch _query_db_for_part is not ideal — instead we pre-seed vendors via
@@ -418,12 +415,10 @@ class TestEmailIntelligenceLoopBody:
         sighting_chain = _make_query_chain([])
         history_chain = _make_query_chain([])
 
-        def patched_query(model, *args, **kwargs):
-            if model is EmailIntelligence:
-                return ei_chain
-            if model is MaterialVendorHistory:
-                return history_chain
-            return sighting_chain
+        patched_query = _query_dispatcher(
+            [(EmailIntelligence, ei_chain), (MaterialVendorHistory, history_chain)],
+            default=sighting_chain,
+        )
 
         with patch.object(db_session, "query", side_effect=patched_query):
             result = _query_db_for_part("LM317T", db_session)

--- a/tests/test_web_extractor.py
+++ b/tests/test_web_extractor.py
@@ -40,23 +40,22 @@ async def test_all_gates_pass(mock_cj):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "override",
+    [
+        pytest.param({"source_urls": ["https://www.ebay.com/itm/1"]}, id="untrusted_domain"),
+        pytest.param({"exact_mpn_found": "LM317MT"}, id="mpn_mismatch"),
+        pytest.param({"confidence": 0.80}, id="low_confidence"),
+        # Gate 4 (anti-hallucination quality floor): a too-short description.
+        pytest.param({"description": "reg"}, id="short_description"),
+        # Gate 4: a missing manufacturer (never accept web data without a maker).
+        pytest.param({"manufacturer": ""}, id="missing_manufacturer"),
+    ],
+)
 @patch("app.services.enrichment_worker.web_extractor.claude_json", new_callable=AsyncMock)
-async def test_untrusted_domain_rejected(mock_cj):
-    mock_cj.return_value = {**_GOOD, "source_urls": ["https://www.ebay.com/itm/1"]}
-    assert (await extract_part_from_web("LM317T", "lm317t")).status == "failed"
-
-
-@pytest.mark.asyncio
-@patch("app.services.enrichment_worker.web_extractor.claude_json", new_callable=AsyncMock)
-async def test_mpn_mismatch_rejected(mock_cj):
-    mock_cj.return_value = {**_GOOD, "exact_mpn_found": "LM317MT"}
-    assert (await extract_part_from_web("LM317T", "lm317t")).status == "failed"
-
-
-@pytest.mark.asyncio
-@patch("app.services.enrichment_worker.web_extractor.claude_json", new_callable=AsyncMock)
-async def test_low_confidence_rejected(mock_cj):
-    mock_cj.return_value = {**_GOOD, "confidence": 0.80}
+async def test_gate_rejects(mock_cj, override):
+    """Each trust gate rejects a single bad field → status 'failed'."""
+    mock_cj.return_value = {**_GOOD, **override}
     assert (await extract_part_from_web("LM317T", "lm317t")).status == "failed"
 
 
@@ -79,22 +78,6 @@ async def test_claude_backend_error_propagates(mock_cj):
     mock_cj.side_effect = ClaudeRateLimitError("429")
     with pytest.raises(ClaudeError):
         await extract_part_from_web("LM317T", "lm317t")
-
-
-@pytest.mark.asyncio
-@patch("app.services.enrichment_worker.web_extractor.claude_json", new_callable=AsyncMock)
-async def test_short_description_rejected(mock_cj):
-    """Gate 4 (anti-hallucination quality floor): a too-short description → failed."""
-    mock_cj.return_value = {**_GOOD, "description": "reg"}
-    assert (await extract_part_from_web("LM317T", "lm317t")).status == "failed"
-
-
-@pytest.mark.asyncio
-@patch("app.services.enrichment_worker.web_extractor.claude_json", new_callable=AsyncMock)
-async def test_missing_manufacturer_rejected(mock_cj):
-    """Gate 4: a missing manufacturer → failed (we never accept web data without a maker)."""
-    mock_cj.return_value = {**_GOOD, "manufacturer": ""}
-    assert (await extract_part_from_web("LM317T", "lm317t")).status == "failed"
 
 
 def test_prompt_constrains_category_to_canonical_vocabulary():

--- a/tests/test_worker_lane_split.py
+++ b/tests/test_worker_lane_split.py
@@ -45,12 +45,16 @@ def _mk(db, mpn=_PLAIN_MPN):
     return card
 
 
-def _patches(*, web="not_found", connectors_hit=False):
+def _patches(*, web="not_found", connectors_hit=False, oem_tiers_miss=False):
     """Patch every external tier enrich_card may call; return the cm dict.
 
     By default connectors miss (fetch_authoritative -> []) and the web/OEM/Opus tiers
     return their non-hit shapes, so the card terminates not_found unless a tier is
     asserted to have fired.
+
+    With ``oem_tiers_miss=True`` the OEM tiers (cross_reference_mpn / extract_oem_description)
+    and the Opus fallback (infer_part) are pre-wired to return their "no match" shapes, so an
+    OEM-shaped card runs them all and terminates not_catalogued.
     """
     merged = (
         ({"description": "Found"}, {"description": {"source": "digikey_api"}}, ["digikey"])
@@ -58,6 +62,11 @@ def _patches(*, web="not_found", connectors_hit=False):
         else ({}, {}, [])
     )
     web_res = WebExtractResult(status=web)
+    xref_kwargs = (
+        {"return_value": type("Xr", (), {"status": "no_match", "resolved_mpn": None})()} if oem_tiers_miss else {}
+    )
+    oem_kwargs = {"return_value": type("Oem", (), {"status": "not_found"})()} if oem_tiers_miss else {}
+    infer_kwargs = {"return_value": type("Inf", (), {"status": "not_found"})()} if oem_tiers_miss else {}
     return {
         "fetch": patch(
             "app.services.authoritative_enrichment_service.fetch_authoritative",
@@ -76,14 +85,17 @@ def _patches(*, web="not_found", connectors_hit=False):
         "xref": patch(
             "app.services.authoritative_enrichment_service.cross_reference_mpn",
             new_callable=AsyncMock,
+            **xref_kwargs,
         ),
         "oem": patch(
             "app.services.authoritative_enrichment_service.extract_oem_description",
             new_callable=AsyncMock,
+            **oem_kwargs,
         ),
         "infer": patch(
             "app.services.ai_inference_fallback.infer_part",
             new_callable=AsyncMock,
+            **infer_kwargs,
         ),
     }
 
@@ -148,22 +160,7 @@ async def test_priority_lane_runs_oem_tiers_for_oem_mpn_but_skips_web(db_session
     Terminates not_catalogued (HIGH_PRECISION vendor + oem_attempted).
     """
     card = _mk(db_session, _OEM_MPN)
-    p = _patches()
-    p["xref"] = patch(
-        "app.services.authoritative_enrichment_service.cross_reference_mpn",
-        new_callable=AsyncMock,
-        return_value=type("Xr", (), {"status": "no_match", "resolved_mpn": None})(),
-    )
-    p["oem"] = patch(
-        "app.services.authoritative_enrichment_service.extract_oem_description",
-        new_callable=AsyncMock,
-        return_value=type("Oem", (), {"status": "not_found"})(),
-    )
-    p["infer"] = patch(
-        "app.services.ai_inference_fallback.infer_part",
-        new_callable=AsyncMock,
-        return_value=type("Inf", (), {"status": "not_found"})(),
-    )
+    p = _patches(oem_tiers_miss=True)
     with p["fetch"], p["merge"], p["web"] as mweb, p["xref"] as mxref, p["oem"] as moem, p["infer"] as minf:
         status = await enrich_card(card, db_session, connectors=[], full_pipeline=True)
 
@@ -179,22 +176,7 @@ async def test_oem_web_skip_can_be_disabled_by_flag(db_session):
     """With enrichment_skip_web_for_oem_mpns off, the priority lane runs the web tier
     even for an OEM-shaped MPN — pins the flag as the only gate on that skip."""
     card = _mk(db_session, _OEM_MPN)
-    p = _patches()
-    p["xref"] = patch(
-        "app.services.authoritative_enrichment_service.cross_reference_mpn",
-        new_callable=AsyncMock,
-        return_value=type("Xr", (), {"status": "no_match", "resolved_mpn": None})(),
-    )
-    p["oem"] = patch(
-        "app.services.authoritative_enrichment_service.extract_oem_description",
-        new_callable=AsyncMock,
-        return_value=type("Oem", (), {"status": "not_found"})(),
-    )
-    p["infer"] = patch(
-        "app.services.ai_inference_fallback.infer_part",
-        new_callable=AsyncMock,
-        return_value=type("Inf", (), {"status": "not_found"})(),
-    )
+    p = _patches(oem_tiers_miss=True)
     with (
         patch("app.config.settings.enrichment_skip_web_for_oem_mpns", False),
         p["fetch"],

--- a/tests/test_workflow_state_clarity.py
+++ b/tests/test_workflow_state_clarity.py
@@ -235,31 +235,38 @@ class TestSourcingStatusTransitions:
         assert validate_transition("requirement", "open", "open") is True
 
 
+def _make_offer(db_session, *, mpn, status):
+    """Create a Requisition + Requirement + Offer with the given MPN and offer
+    status."""
+    from app.models.offers import Offer
+    from app.models.sourcing import Requirement, Requisition
+
+    req = Requisition(name="Test Req", customer_name="Test", status="active")
+    db_session.add(req)
+    db_session.flush()
+    reqmt = Requirement(requisition_id=req.id, primary_mpn=mpn)
+    db_session.add(reqmt)
+    db_session.flush()
+    offer = Offer(
+        requirement_id=reqmt.id,
+        requisition_id=req.id,
+        vendor_name="V",
+        mpn=mpn,
+        status=status,
+        unit_price=1.0,
+        source="manual",
+    )
+    db_session.add(offer)
+    db_session.commit()
+    return offer
+
+
 class TestStatusMachineValidation:
     """Status machine prevents invalid offer/quote transitions."""
 
     def test_offer_sold_cannot_go_active(self, client, db_session):
         """Once sold, offer cannot go back to active."""
-        from app.models.offers import Offer
-        from app.models.sourcing import Requirement, Requisition
-
-        req = Requisition(name="Test Req", customer_name="Test", status="active")
-        db_session.add(req)
-        db_session.flush()
-        reqmt = Requirement(requisition_id=req.id, primary_mpn="TEST-001")
-        db_session.add(reqmt)
-        db_session.flush()
-        offer = Offer(
-            requirement_id=reqmt.id,
-            requisition_id=req.id,
-            vendor_name="V",
-            mpn="TEST-001",
-            status="sold",
-            unit_price=1.0,
-            source="manual",
-        )
-        db_session.add(offer)
-        db_session.commit()
+        offer = _make_offer(db_session, mpn="TEST-001", status="sold")
 
         # Try to approve (→ active) a sold offer via generic update
         resp = client.put(
@@ -270,26 +277,7 @@ class TestStatusMachineValidation:
 
     def test_offer_rejected_is_terminal(self, client, db_session):
         """Rejected offers cannot transition to any other status."""
-        from app.models.offers import Offer
-        from app.models.sourcing import Requirement, Requisition
-
-        req = Requisition(name="Test Req", customer_name="Test", status="active")
-        db_session.add(req)
-        db_session.flush()
-        reqmt = Requirement(requisition_id=req.id, primary_mpn="TEST-002")
-        db_session.add(reqmt)
-        db_session.flush()
-        offer = Offer(
-            requirement_id=reqmt.id,
-            requisition_id=req.id,
-            vendor_name="V",
-            mpn="TEST-002",
-            status="rejected",
-            unit_price=1.0,
-            source="manual",
-        )
-        db_session.add(offer)
-        db_session.commit()
+        offer = _make_offer(db_session, mpn="TEST-002", status="rejected")
 
         resp = client.put(
             f"/api/offers/{offer.id}",
@@ -299,26 +287,7 @@ class TestStatusMachineValidation:
 
     def test_valid_offer_transition_succeeds(self, client, db_session):
         """pending_review → active is a valid transition."""
-        from app.models.offers import Offer
-        from app.models.sourcing import Requirement, Requisition
-
-        req = Requisition(name="Test Req", customer_name="Test", status="active")
-        db_session.add(req)
-        db_session.flush()
-        reqmt = Requirement(requisition_id=req.id, primary_mpn="TEST-003")
-        db_session.add(reqmt)
-        db_session.flush()
-        offer = Offer(
-            requirement_id=reqmt.id,
-            requisition_id=req.id,
-            vendor_name="V",
-            mpn="TEST-003",
-            status="pending_review",
-            unit_price=1.0,
-            source="manual",
-        )
-        db_session.add(offer)
-        db_session.commit()
+        offer = _make_offer(db_session, mpn="TEST-003", status="pending_review")
 
         resp = client.put(f"/api/offers/{offer.id}/approve")
         assert resp.status_code == 200


### PR DESCRIPTION
Part of the codebase-wide simplification program — **tests wave (8/8)**, full simplify (within-file only).

## What changed
- Copy-paste test functions differing only in data → `@pytest.mark.parametrize` (one case per original; IDs preserved).
- Repeated arrange/setup blocks → local helper functions / module-level fixtures **defined in the same file**.
- Removed exact-duplicate test functions and dead/commented tests.

`conftest.py` and all shared fixtures untouched; no assertion weakened; mock/patch targets unchanged.

## Verification (coverage preserved)
- ruff clean
- **Full suite: 16610 passed, 0 failed** (baseline 16,563). The collected/passed count *rises* where multi-assert tests were split into discrete parametrized cases — no test case was dropped (exact-duplicate removals are 1-for-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)