### PR TITLE
test: nightly coverage boost — bring 4 modules to 85%+

### DIFF
--- a/tests/test_categorize_from_desc_nightly.py
+++ b/tests/test_categorize_from_desc_nightly.py
@@ -1,9 +1,10 @@
-"""tests/test_categorize_from_desc_nightly.py — Covers exception handler, _print_report, and main().
+"""tests/test_categorize_from_desc_nightly.py — Covers exception handler, _print_report,
+and main().
 
 Targets lines 174-177, 199-211, 215-237, 241 in app/management/categorize_from_desc.py.
 
-Called by: pytest test suite
-Depends on: conftest.db_session, app.management.categorize_from_desc
+Called by: pytest test suite Depends on: conftest.db_session,
+app.management.categorize_from_desc
 """
 
 import os
@@ -31,7 +32,8 @@ def _card(db: Session, mpn: str, description: str | None, category=None) -> Mate
 
 
 def test_exception_in_loop_increments_failed(db_session: Session):
-    """Patch categorize_and_record to raise — verifies the except block increments failed."""
+    """Patch categorize_and_record to raise — verifies the except block increments
+    failed."""
     seed_commodity_schemas(db_session)
     _card(db_session, "BOOM1", 'HD, 450GB, 15KRPM, 3.5", Fibre Channel')
     db_session.commit()
@@ -64,7 +66,8 @@ def test_print_report_runs_without_error():
 
 
 def test_print_report_empty_by_category():
-    """_print_report with no categories — for-loop body (line 209-210) still runs cleanly."""
+    """_print_report with no categories — for-loop body (line 209-210) still runs
+    cleanly."""
     summary = {
         "mode": "apply",
         "cards_examined": 0,
@@ -95,7 +98,7 @@ _FAKE_SUMMARY = {
 
 
 def test_main_dry_run_calls_rollback():
-    """main() with no --apply flag must call db.rollback() and db.close()."""
+    """Main() with no --apply flag must call db.rollback() and db.close()."""
     fake_db = MagicMock()
     fake_session_cls = MagicMock(return_value=fake_db)
 
@@ -118,7 +121,7 @@ def test_main_dry_run_calls_rollback():
 
 
 def test_main_apply_skips_rollback():
-    """main() with --apply must NOT call db.rollback() and must call db.close()."""
+    """Main() with --apply must NOT call db.rollback() and must call db.close()."""
     fake_db = MagicMock()
     fake_session_cls = MagicMock(return_value=fake_db)
 
@@ -143,7 +146,7 @@ def test_main_apply_skips_rollback():
 
 
 def test_main_closes_db_on_exception():
-    """main() must call db.close() in finally even when run() raises."""
+    """Main() must call db.close() in finally even when run() raises."""
     fake_db = MagicMock()
     fake_session_cls = MagicMock(return_value=fake_db)
 

--- a/tests/test_categorize_from_desc_nightly.py
+++ b/tests/test_categorize_from_desc_nightly.py
@@ -1,0 +1,164 @@
+"""tests/test_categorize_from_desc_nightly.py — Covers exception handler, _print_report, and main().
+
+Targets lines 174-177, 199-211, 215-237, 241 in app/management/categorize_from_desc.py.
+
+Called by: pytest test suite
+Depends on: conftest.db_session, app.management.categorize_from_desc
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.management.categorize_from_desc import _print_report, run
+from app.models import MaterialCard
+from app.services.commodity_registry import seed_commodity_schemas
+
+
+def _card(db: Session, mpn: str, description: str | None, category=None) -> MaterialCard:
+    card = MaterialCard(normalized_mpn=mpn.lower(), display_mpn=mpn, category=category, description=description)
+    db.add(card)
+    db.flush()
+    return card
+
+
+# ── Exception handler (lines 174-177) ───────────────────────────────────────
+
+
+def test_exception_in_loop_increments_failed(db_session: Session):
+    """Patch categorize_and_record to raise — verifies the except block increments failed."""
+    seed_commodity_schemas(db_session)
+    _card(db_session, "BOOM1", 'HD, 450GB, 15KRPM, 3.5", Fibre Channel')
+    db_session.commit()
+
+    with patch("app.management.categorize_from_desc.categorize_and_record", side_effect=RuntimeError("boom")):
+        summary = run(db_session, apply=True)
+
+    assert summary["failed"] == 1
+    assert summary["categorized"] == 0
+
+
+# ── _print_report (lines 199-211) ────────────────────────────────────────────
+
+
+def test_print_report_runs_without_error():
+    """Call _print_report with a complete summary dict — must not raise."""
+    summary = {
+        "mode": "dry-run",
+        "cards_examined": 10,
+        "categorized": 3,
+        "specs_written": 5,
+        "no_grammar_match": 2,
+        "skipped_no_desc": 4,
+        "failed": 1,
+        "by_channel": {"own_desc": 2, "fru_desc": 1},
+        "by_category": {"hdd": 2, "cables": 1},
+    }
+    # Should complete without raising; logger calls are side-effect only.
+    _print_report(summary)
+
+
+def test_print_report_empty_by_category():
+    """_print_report with no categories — for-loop body (line 209-210) still runs cleanly."""
+    summary = {
+        "mode": "apply",
+        "cards_examined": 0,
+        "categorized": 0,
+        "specs_written": 0,
+        "no_grammar_match": 0,
+        "skipped_no_desc": 0,
+        "failed": 0,
+        "by_channel": {},
+        "by_category": {},
+    }
+    _print_report(summary)
+
+
+# ── main() (lines 215-237, 241) ───────────────────────────────────────────────
+
+_FAKE_SUMMARY = {
+    "mode": "dry-run",
+    "cards_examined": 0,
+    "categorized": 0,
+    "specs_written": 0,
+    "no_grammar_match": 0,
+    "skipped_no_desc": 0,
+    "failed": 0,
+    "by_channel": {},
+    "by_category": {},
+}
+
+
+def test_main_dry_run_calls_rollback():
+    """main() with no --apply flag must call db.rollback() and db.close()."""
+    fake_db = MagicMock()
+    fake_session_cls = MagicMock(return_value=fake_db)
+
+    fake_args = MagicMock()
+    fake_args.apply = False
+    fake_args.limit = 0
+
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=fake_args),
+        patch("app.management.categorize_from_desc.run", return_value=_FAKE_SUMMARY) as mock_run,
+        patch("app.database.SessionLocal", fake_session_cls),
+    ):
+        from app.management.categorize_from_desc import main
+
+        main()
+
+    mock_run.assert_called_once_with(fake_db, apply=False, limit=0)
+    fake_db.rollback.assert_called_once()
+    fake_db.close.assert_called_once()
+
+
+def test_main_apply_skips_rollback():
+    """main() with --apply must NOT call db.rollback() and must call db.close()."""
+    fake_db = MagicMock()
+    fake_session_cls = MagicMock(return_value=fake_db)
+
+    fake_args = MagicMock()
+    fake_args.apply = True
+    fake_args.limit = 5
+
+    apply_summary = {**_FAKE_SUMMARY, "mode": "apply"}
+
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=fake_args),
+        patch("app.management.categorize_from_desc.run", return_value=apply_summary) as mock_run,
+        patch("app.database.SessionLocal", fake_session_cls),
+    ):
+        from app.management.categorize_from_desc import main
+
+        main()
+
+    mock_run.assert_called_once_with(fake_db, apply=True, limit=5)
+    fake_db.rollback.assert_not_called()
+    fake_db.close.assert_called_once()
+
+
+def test_main_closes_db_on_exception():
+    """main() must call db.close() in finally even when run() raises."""
+    fake_db = MagicMock()
+    fake_session_cls = MagicMock(return_value=fake_db)
+
+    fake_args = MagicMock()
+    fake_args.apply = False
+    fake_args.limit = 0
+
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=fake_args),
+        patch("app.management.categorize_from_desc.run", side_effect=RuntimeError("db gone")),
+        patch("app.database.SessionLocal", fake_session_cls),
+        pytest.raises(RuntimeError),
+    ):
+        from app.management.categorize_from_desc import main
+
+        main()
+
+    fake_db.close.assert_called_once()

--- a/tests/test_fix_cpu_pollution_nightly.py
+++ b/tests/test_fix_cpu_pollution_nightly.py
@@ -45,7 +45,7 @@ def test_exception_in_set_category_skips_card(db_session: Session):
 
 
 def test_main_dry_run_calls_reclassify_and_closes_db():
-    """main() with --apply omitted calls reclassify with apply=False and closes db."""
+    """Main() with --apply omitted calls reclassify with apply=False and closes db."""
     mock_args = MagicMock()
     mock_args.apply = False
     mock_args.limit = None
@@ -66,7 +66,7 @@ def test_main_dry_run_calls_reclassify_and_closes_db():
 
 
 def test_main_apply_passes_apply_true():
-    """main() with --apply=True forwards apply=True to reclassify_cpu_pollution."""
+    """Main() with --apply=True forwards apply=True to reclassify_cpu_pollution."""
     mock_args = MagicMock()
     mock_args.apply = True
     mock_args.limit = None
@@ -87,7 +87,7 @@ def test_main_apply_passes_apply_true():
 
 
 def test_main_closes_db_even_on_exception():
-    """main() finally block closes db even when reclassify_cpu_pollution raises."""
+    """Main() finally block closes db even when reclassify_cpu_pollution raises."""
     mock_args = MagicMock()
     mock_args.apply = False
     mock_args.limit = None

--- a/tests/test_fix_cpu_pollution_nightly.py
+++ b/tests/test_fix_cpu_pollution_nightly.py
@@ -1,0 +1,110 @@
+"""tests/test_fix_cpu_pollution_nightly.py — Tests for exception handler and main() in
+app/management/fix_cpu_pollution.py.
+
+Covers: exception handler inside the reclassify loop (apply=True), main() happy path,
+main() with apply=True, and main() finally-block on exception.
+
+Depends on: conftest.py (db_session), app.services.commodity_registry.seed_commodity_schemas.
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard
+from app.services.commodity_registry import seed_commodity_schemas
+
+
+def _cpu_card(db: Session, mpn: str) -> MaterialCard:
+    card = MaterialCard(normalized_mpn=mpn.lower(), display_mpn=mpn, category="cpu")
+    card.category_source = "trio_source"
+    card.category_tier = 95
+    db.add(card)
+    db.flush()
+    return card
+
+
+def test_exception_in_set_category_skips_card(db_session: Session):
+    """When set_category raises, the card is skipped and reclassified stays 0."""
+    from app.management.fix_cpu_pollution import reclassify_cpu_pollution
+
+    seed_commodity_schemas(db_session)
+    _cpu_card(db_session, "5-1437720-3")  # TE connector — classifiable
+    db_session.commit()
+
+    with patch("app.management.fix_cpu_pollution.set_category", side_effect=Exception("db error")):
+        stats = reclassify_cpu_pollution(db_session, apply=True)
+
+    assert stats["scanned"] == 1
+    assert stats["reclassified"] == 0
+
+
+def test_main_dry_run_calls_reclassify_and_closes_db():
+    """main() with --apply omitted calls reclassify with apply=False and closes db."""
+    mock_args = MagicMock()
+    mock_args.apply = False
+    mock_args.limit = None
+
+    mock_db = MagicMock()
+
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=mock_args),
+        patch("app.management.fix_cpu_pollution.SessionLocal", return_value=mock_db),
+        patch("app.management.fix_cpu_pollution.reclassify_cpu_pollution") as mock_reclassify,
+    ):
+        from app.management.fix_cpu_pollution import main
+
+        main()
+
+    mock_reclassify.assert_called_once_with(mock_db, apply=False, limit=None)
+    mock_db.close.assert_called_once()
+
+
+def test_main_apply_passes_apply_true():
+    """main() with --apply=True forwards apply=True to reclassify_cpu_pollution."""
+    mock_args = MagicMock()
+    mock_args.apply = True
+    mock_args.limit = None
+
+    mock_db = MagicMock()
+
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=mock_args),
+        patch("app.management.fix_cpu_pollution.SessionLocal", return_value=mock_db),
+        patch("app.management.fix_cpu_pollution.reclassify_cpu_pollution") as mock_reclassify,
+    ):
+        from app.management.fix_cpu_pollution import main
+
+        main()
+
+    mock_reclassify.assert_called_once_with(mock_db, apply=True, limit=None)
+    mock_db.close.assert_called_once()
+
+
+def test_main_closes_db_even_on_exception():
+    """main() finally block closes db even when reclassify_cpu_pollution raises."""
+    mock_args = MagicMock()
+    mock_args.apply = False
+    mock_args.limit = None
+
+    mock_db = MagicMock()
+
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=mock_args),
+        patch("app.management.fix_cpu_pollution.SessionLocal", return_value=mock_db),
+        patch(
+            "app.management.fix_cpu_pollution.reclassify_cpu_pollution",
+            side_effect=RuntimeError("boom"),
+        ),
+    ):
+        from app.management.fix_cpu_pollution import main
+
+        with pytest.raises(RuntimeError, match="boom"):
+            main()
+
+    mock_db.close.assert_called_once()

--- a/tests/test_run_fru_crosswalk_nightly.py
+++ b/tests/test_run_fru_crosswalk_nightly.py
@@ -72,8 +72,8 @@ def _link(
 
 def test_collect_creatable_desc_only_fru(db_session: Session):
     """A FRU link with an extractable description but no decodable mfg_model model
-    triggers fru_descs append (line 213) and the any(extract_desc...) branch (line 227).
-    """
+    triggers fru_descs append (line 213) and the any(extract_desc...) branch (line
+    227)."""
     seed_commodity_schemas(db_session)
     # drive_pn link with a rich description but no mfg (so _decodes returns False) —
     # the description "HDD; 1200GB; 2.5; 10K; SAS" should pass extract_desc.
@@ -100,7 +100,7 @@ def test_collect_creatable_desc_only_fru(db_session: Session):
 
 
 def test_run_create_with_limit(db_session: Session):
-    """limit=1 slices the plan keys, so only 1 card is counted as creatable."""
+    """Limit=1 slices the plan keys, so only 1 card is counted as creatable."""
     seed_commodity_schemas(db_session)
     _link(db_session, "00AAA01", "ST4000NM0035")
     db_session.flush()
@@ -113,7 +113,8 @@ def test_run_create_with_limit(db_session: Session):
 
 
 def test_run_create_integrity_error_skips(db_session: Session, monkeypatch):
-    """When db.flush() raises IntegrityError the card is counted as skipped, not created."""
+    """When db.flush() raises IntegrityError the card is counted as skipped, not
+    created."""
     seed_commodity_schemas(db_session)
     _link(db_session, "00AAA01", "ST4000NM0035")
     db_session.flush()
@@ -129,7 +130,8 @@ def test_run_create_integrity_error_skips(db_session: Session, monkeypatch):
 
 
 def test_measure_drive_pn_break_on_sample_limit(db_session: Session):
-    """Two decodable drive_pn links with sample=1 hits the break (line 334) on the 2nd."""
+    """Two decodable drive_pn links with sample=1 hits the break (line 334) on the
+    2nd."""
     seed_commodity_schemas(db_session)
     # Both ST4000NM0035 and ST8000NM0055 decode (Seagate HDDs).
     _link(db_session, "49Y7001", "ST4000NM0035", kind=FruLinkKind.DRIVE_PN.value, mfg="Seagate")
@@ -172,7 +174,8 @@ def test_main_measure_drive_pn_flag():
 
 
 def test_main_dry_run_all_phases():
-    """Default dry-run all-phases calls both run_drain and run_create, then db.rollback()."""
+    """Default dry-run all-phases calls both run_drain and run_create, then
+    db.rollback()."""
     mock_db = MagicMock()
     with (
         patch("argparse.ArgumentParser.parse_args", return_value=_mock_args()),
@@ -189,7 +192,7 @@ def test_main_dry_run_all_phases():
 
 
 def test_main_drain_only():
-    """phase='drain' calls run_drain but NOT run_create."""
+    """Phase='drain' calls run_drain but NOT run_create."""
     mock_db = MagicMock()
     with (
         patch("argparse.ArgumentParser.parse_args", return_value=_mock_args(phase="drain")),

--- a/tests/test_run_fru_crosswalk_nightly.py
+++ b/tests/test_run_fru_crosswalk_nightly.py
@@ -1,0 +1,217 @@
+"""Edge-case tests for app/management/run_fru_crosswalk.py.
+
+Covers the 30 missing lines (213, 227, 265, 286-290, 334, 372-414):
+  - FRU with description-only enrichability (lines 213, 227)
+  - run_create limit slicing (line 265)
+  - IntegrityError skipped-existing path (lines 286-290)
+  - measure_drive_pn early break on sample (line 334)
+  - main() CLI paths (lines 372-414)
+
+Called by: pytest test suite
+Depends on: tests/conftest.py (db_session fixture), app.management.run_fru_crosswalk
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.constants import FruLinkKind
+from app.management.run_fru_crosswalk import (
+    collect_creatable_cards,
+    main,
+    measure_drive_pn_misreads,
+    run_create,
+)
+from app.models import FruLink
+from app.services.commodity_registry import seed_commodity_schemas
+from app.utils.normalization import normalize_mpn_key
+
+
+def _card(db: Session, mpn: str, category=None, **kw):
+    from app.models import MaterialCard
+
+    card = MaterialCard(normalized_mpn=normalize_mpn_key(mpn), display_mpn=mpn, category=category, **kw)
+    db.add(card)
+    db.flush()
+    return card
+
+
+def _link(
+    db: Session,
+    fru: str,
+    related: str,
+    *,
+    mfg: str | None = "Seagate",
+    kind: str = FruLinkKind.MFG_MODEL.value,
+    sheet: str = "Main",
+    description: str | None = None,
+) -> FruLink:
+    link = FruLink(
+        fru_raw=fru,
+        fru_norm=normalize_mpn_key(fru),
+        related_raw=related,
+        related_norm=normalize_mpn_key(related),
+        rel_kind=kind,
+        manufacturer=mfg,
+        description=description,
+        source_sheet=sheet,
+    )
+    db.add(link)
+    db.flush()
+    return link
+
+
+# ── Line 213 + 227: description-only enrichable FRU ─────────────────────────
+
+
+def test_collect_creatable_desc_only_fru(db_session: Session):
+    """A FRU link with an extractable description but no decodable mfg_model model
+    triggers fru_descs append (line 213) and the any(extract_desc...) branch (line 227).
+    """
+    seed_commodity_schemas(db_session)
+    # drive_pn link with a rich description but no mfg (so _decodes returns False) —
+    # the description "HDD; 1200GB; 2.5; 10K; SAS" should pass extract_desc.
+    link = FruLink(
+        fru_raw="49Y7443",
+        fru_norm=normalize_mpn_key("49Y7443"),
+        related_raw="00VN000",
+        related_norm=normalize_mpn_key("00VN000"),
+        rel_kind=FruLinkKind.MFG_MODEL.value,
+        manufacturer=None,
+        description="HDD; 1200GB; 2.5; 10K; SAS",
+        source_sheet="test",
+    )
+    db_session.add(link)
+    db_session.flush()
+
+    plan = collect_creatable_cards(db_session)
+    key = normalize_mpn_key("49Y7443")
+    assert key in plan
+    assert plan[key]["reason"] == "enrichable_fru"
+
+
+# ── Line 265: run_create with limit ─────────────────────────────────────────
+
+
+def test_run_create_with_limit(db_session: Session):
+    """limit=1 slices the plan keys, so only 1 card is counted as creatable."""
+    seed_commodity_schemas(db_session)
+    _link(db_session, "00AAA01", "ST4000NM0035")
+    db_session.flush()
+
+    summary = run_create(db_session, apply=False, limit=1)
+    assert summary["creatable"] == 1
+
+
+# ── Lines 286-290: IntegrityError on flush skips card ───────────────────────
+
+
+def test_run_create_integrity_error_skips(db_session: Session, monkeypatch):
+    """When db.flush() raises IntegrityError the card is counted as skipped, not created."""
+    seed_commodity_schemas(db_session)
+    _link(db_session, "00AAA01", "ST4000NM0035")
+    db_session.flush()
+
+    monkeypatch.setattr(db_session, "flush", MagicMock(side_effect=IntegrityError("unique violation", None, None)))
+
+    summary = run_create(db_session, apply=True)
+    assert summary["skipped_existing"] >= 1
+    assert summary["created"] == 0
+
+
+# ── Line 334: early break when decoded >= sample ────────────────────────────
+
+
+def test_measure_drive_pn_break_on_sample_limit(db_session: Session):
+    """Two decodable drive_pn links with sample=1 hits the break (line 334) on the 2nd."""
+    seed_commodity_schemas(db_session)
+    # Both ST4000NM0035 and ST8000NM0055 decode (Seagate HDDs).
+    _link(db_session, "49Y7001", "ST4000NM0035", kind=FruLinkKind.DRIVE_PN.value, mfg="Seagate")
+    _link(db_session, "49Y7002", "ST8000NM0055", kind=FruLinkKind.DRIVE_PN.value, mfg="Seagate")
+    db_session.flush()
+
+    result = measure_drive_pn_misreads(db_session, sample=1)
+    assert result["decoded"] == 1
+    assert result["scanned"] >= 1
+
+
+# ── Lines 372-410: main() CLI paths ─────────────────────────────────────────
+
+
+def _mock_args(**kwargs):
+    defaults = {"measure_drive_pn": False, "phase": "all", "apply": False, "limit": 0}
+    defaults.update(kwargs)
+    args = MagicMock()
+    for k, v in defaults.items():
+        setattr(args, k, v)
+    return args
+
+
+def test_main_measure_drive_pn_flag():
+    """--measure-drive-pn calls measure_drive_pn_misreads and returns without drain/create."""
+    mock_db = MagicMock()
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=_mock_args(measure_drive_pn=True)),
+        patch("app.management.run_fru_crosswalk.measure_drive_pn_misreads") as mock_measure,
+        patch("app.management.run_fru_crosswalk.run_drain") as mock_drain,
+        patch("app.management.run_fru_crosswalk.run_create") as mock_create,
+        patch("app.database.SessionLocal", return_value=mock_db),
+    ):
+        main()
+
+    mock_measure.assert_called_once_with(mock_db)
+    mock_drain.assert_not_called()
+    mock_create.assert_not_called()
+    mock_db.close.assert_called_once()
+
+
+def test_main_dry_run_all_phases():
+    """Default dry-run all-phases calls both run_drain and run_create, then db.rollback()."""
+    mock_db = MagicMock()
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=_mock_args()),
+        patch("app.management.run_fru_crosswalk.run_drain") as mock_drain,
+        patch("app.management.run_fru_crosswalk.run_create") as mock_create,
+        patch("app.database.SessionLocal", return_value=mock_db),
+    ):
+        main()
+
+    mock_drain.assert_called_once_with(mock_db, apply=False, limit=0)
+    mock_create.assert_called_once_with(mock_db, apply=False, limit=0)
+    mock_db.rollback.assert_called()
+    mock_db.close.assert_called_once()
+
+
+def test_main_drain_only():
+    """phase='drain' calls run_drain but NOT run_create."""
+    mock_db = MagicMock()
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=_mock_args(phase="drain")),
+        patch("app.management.run_fru_crosswalk.run_drain") as mock_drain,
+        patch("app.management.run_fru_crosswalk.run_create") as mock_create,
+        patch("app.database.SessionLocal", return_value=mock_db),
+    ):
+        main()
+
+    mock_drain.assert_called_once()
+    mock_create.assert_not_called()
+
+
+def test_main_closes_db_on_exception():
+    """db.close() is called even when run_drain raises RuntimeError."""
+    mock_db = MagicMock()
+    with (
+        patch("argparse.ArgumentParser.parse_args", return_value=_mock_args()),
+        patch("app.management.run_fru_crosswalk.run_drain", side_effect=RuntimeError("boom")),
+        patch("app.database.SessionLocal", return_value=mock_db),
+        pytest.raises(RuntimeError),
+    ):
+        main()
+
+    mock_db.close.assert_called_once()

--- a/tests/test_vendor_duplicates.py
+++ b/tests/test_vendor_duplicates.py
@@ -1,0 +1,130 @@
+"""tests/test_vendor_duplicates.py — Tests for app/services/vendor_duplicates.py.
+
+Covers: _fuzzy_match_pg_trgm (lines 31-39), PostgreSQL dialect path (lines 102-108),
+        exact-match short-circuit, and no-bind fallback.
+
+Called by: pytest autodiscovery
+Depends on: conftest.db_session, app.models.VendorCard, app.services.vendor_duplicates
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+os.environ["TESTING"] = "1"
+
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from app.models import VendorCard
+from app.services.vendor_duplicates import _fuzzy_match_pg_trgm, check_vendor_duplicate
+
+
+class TestFuzzyMatchPgTrgm:
+    """Tests for _fuzzy_match_pg_trgm — lines 31-39."""
+
+    def test_returns_formatted_match_list(self):
+        """Mock the db.query chain to exercise lines 31-39."""
+        mock_row = MagicMock()
+        mock_row.id = 1
+        mock_row.display_name = "Arrow Electronics"
+        mock_row.score = 0.85
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.all.return_value = [mock_row]
+
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value = mock_query
+
+        result = _fuzzy_match_pg_trgm(mock_db, "arrow")
+
+        assert result == [{"id": 1, "name": "Arrow Electronics", "match": "fuzzy", "score": 85}]
+
+    def test_empty_result_when_no_rows(self):
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.all.return_value = []
+
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value = mock_query
+
+        result = _fuzzy_match_pg_trgm(mock_db, "unknown")
+        assert result == []
+
+
+class TestCheckVendorDuplicatePostgresDialect:
+    """Tests for the PostgreSQL dialect branch — lines 102-108."""
+
+    def _make_mock_db(self, dialect_name: str) -> MagicMock:
+        """Return a MagicMock Session whose .bind.dialect.name is set and whose
+        .query(...).filter_by(...).first() returns None (no exact match)."""
+        mock_db = MagicMock(spec=Session)
+        mock_bind = MagicMock()
+        mock_bind.dialect.name = dialect_name
+        type(mock_db).bind = property(lambda self: mock_bind)  # type: ignore[assignment]
+        # exact-match query chain → None (no exact match)
+        mock_db.query.return_value.filter_by.return_value.first.return_value = None
+        return mock_db
+
+    def test_postgresql_dialect_calls_pg_trgm(self):
+        """When dialect is postgresql and no exception, _fuzzy_match_pg_trgm is used."""
+        mock_db = self._make_mock_db("postgresql")
+        expected = [{"id": 1, "name": "Foo", "match": "fuzzy", "score": 82}]
+        with patch("app.services.vendor_duplicates._fuzzy_match_pg_trgm", return_value=expected) as mock_pg:
+            result = check_vendor_duplicate("bar inc", mock_db)
+
+        mock_pg.assert_called_once()
+        assert result == expected
+
+    def test_postgresql_dialect_falls_back_on_operational_error(self):
+        """OperationalError from pg_trgm triggers rollback + Python fallback (lines 105-108)."""
+        mock_db = self._make_mock_db("postgresql")
+        err = OperationalError("pg_trgm not installed", None, None)
+
+        with patch("app.services.vendor_duplicates._fuzzy_match_pg_trgm", side_effect=err):
+            with patch("app.services.vendor_duplicates._fuzzy_match_python", return_value=[]) as mock_py:
+                result = check_vendor_duplicate("bar inc", mock_db)
+
+        mock_py.assert_called_once()
+        assert result == []
+
+
+class TestCheckVendorDuplicateExactMatch:
+    """Exact-match short-circuit returns immediately with score 100."""
+
+    def test_exact_match_returns_single_result(self, db_session: Session):
+        card = VendorCard(
+            normalized_name="arrow electronics",
+            display_name="Arrow Electronics",
+        )
+        db_session.add(card)
+        db_session.commit()
+        db_session.refresh(card)
+
+        result = check_vendor_duplicate("Arrow Electronics", db_session)
+
+        assert len(result) == 1
+        assert result[0]["name"] == "Arrow Electronics"
+        assert result[0]["match"] == "exact"
+        assert result[0]["score"] == 100
+        assert result[0]["id"] == card.id
+
+
+class TestCheckVendorDuplicateNoBind:
+    """When db.bind is None the dialect is '' and _fuzzy_match_python is used."""
+
+    def test_no_bind_returns_list(self):
+        """Use a fully mocked session with bind=None so dialect resolves to ''."""
+        mock_db = MagicMock(spec=Session)
+        type(mock_db).bind = property(lambda self: None)  # type: ignore[assignment]
+        mock_db.query.return_value.filter_by.return_value.first.return_value = None
+
+        with patch("app.services.vendor_duplicates._fuzzy_match_python", return_value=[]) as mock_py:
+            result = check_vendor_duplicate("unknown vendor xyz", mock_db)
+
+        mock_py.assert_called_once()
+        assert isinstance(result, list)

--- a/tests/test_vendor_duplicates.py
+++ b/tests/test_vendor_duplicates.py
@@ -1,10 +1,10 @@
 """tests/test_vendor_duplicates.py — Tests for app/services/vendor_duplicates.py.
 
 Covers: _fuzzy_match_pg_trgm (lines 31-39), PostgreSQL dialect path (lines 102-108),
-        exact-match short-circuit, and no-bind fallback.
+exact-match short-circuit, and no-bind fallback.
 
-Called by: pytest autodiscovery
-Depends on: conftest.db_session, app.models.VendorCard, app.services.vendor_duplicates
+Called by: pytest autodiscovery Depends on: conftest.db_session, app.models.VendorCard,
+app.services.vendor_duplicates
 """
 
 import os
@@ -81,7 +81,8 @@ class TestCheckVendorDuplicatePostgresDialect:
         assert result == expected
 
     def test_postgresql_dialect_falls_back_on_operational_error(self):
-        """OperationalError from pg_trgm triggers rollback + Python fallback (lines 105-108)."""
+        """OperationalError from pg_trgm triggers rollback + Python fallback (lines
+        105-108)."""
         mock_db = self._make_mock_db("postgresql")
         err = OperationalError("pg_trgm not installed", None, None)
 


### PR DESCRIPTION
## Summary

- `app/management/categorize_from_desc.py`: **69% → 98%** — covers exception handler, `_print_report()`, and `main()`
- `app/management/fix_cpu_pollution.py`: **71% → 96%** — covers `set_category` exception handler and `main()`
- `app/services/vendor_duplicates.py`: **76% → 100%** — covers `_fuzzy_match_pg_trgm`, the PostgreSQL dialect branch, and the `OperationalError` fallback to Python-side fuzzy
- `app/management/run_fru_crosswalk.py`: **81% → 98%** — covers `fru_descs` description branch, `extract_desc` enrichable path, `run_create` limit slice, `IntegrityError` skip-existing, `measure_drive_pn` sample-break, and `main()`

24 new tests across 4 files. All pass; ruff clean.

## Test plan

- [x] `pytest tests/test_categorize_from_desc_nightly.py` — 6 tests pass
- [x] `pytest tests/test_fix_cpu_pollution_nightly.py` — 4 tests pass
- [x] `pytest tests/test_vendor_duplicates.py` — 6 tests pass
- [x] `pytest tests/test_run_fru_crosswalk_nightly.py` — 8 tests pass
- [x] `ruff check --fix` — 2 auto-fixed, 0 remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPPGuTaqmyHihWy8AdG853)_