### PR TITLE
Light-skin Live market + degraded-source banner + relevance guard

### DIFF
--- a/app/routers/part_dossier.py
+++ b/app/routers/part_dossier.py
@@ -1,15 +1,15 @@
 """routers/part_dossier.py — the visible Part Dossier ("The Bench") GET routes.
 
 Serves the one-PN sourcing dossier at /v2/search?mpn=<PN>: an instant-from-DB hero +
-specs + history (reused), with the live market terminal streaming in below. All routes
-are server-rendered HTML fragments swapped by HTMX — NOT a SPA.
+specs + history (reused), with the live market streaming in below. All routes are
+server-rendered HTML fragments swapped by HTMX — NOT a SPA.
 
 The four section endpoints are lazy-loaded by dossier_shell.html. Hero does the
 light-footprint write (bump search_count / last_searched_at on an existing card only —
 a bare search never creates a card). Market consults the search:{key}:latest Redis
 pointer (written by search_service.stream_search_mpn) to render cached vendor rows on a
-cache hit, else fires the existing /v2/partials/search/run SSE flow inside the dark
-terminal frame.
+cache hit, else fires the existing /v2/partials/search/run SSE flow; a degraded-source
+banner (get_market_source_health) renders above both branches.
 
 Called by: app/main.py (include_router); dossier_shell.html lazy-load divs.
 Depends on: services.part_history_service.get_part_history, services.fru_matrix_service
@@ -144,16 +144,18 @@ async def dossier_market(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Live-market terminal. Cache hit → cached vendor rows + freshness stamp; cache
-    miss (or ``refresh=1``) → terminal frame whose body auto-fires the existing
-    /v2/partials/search/run SSE flow.
+    """Live-market section (light brand card). Cache hit → cached vendor rows +
+    freshness stamp; cache miss (or ``refresh=1``) → a frame whose body auto-fires the
+    existing /v2/partials/search/run SSE flow.
 
-    The SSE engine is reused UNCHANGED — the cache-miss branch just embeds it in the dark
-    terminal frame. The pointer key search:{key}:latest is written at the end of
-    stream_search_mpn (TTL 900s). ``refresh=1`` (the "↻ Refresh market" button) skips the
-    cache so the connector sweep re-runs.
+    The SSE engine is reused UNCHANGED — the cache-miss branch just embeds it. A
+    degraded-source banner (``market_health``) is rendered above both branches so a
+    sparse market reads as "N sources unavailable" rather than looking empty. The
+    pointer key search:{key}:latest is written at the end of stream_search_mpn (TTL
+    900s). ``refresh=1`` (the "↻ Refresh market" button) skips the cache so the
+    connector sweep re-runs.
     """
-    from ..search_service import _get_search_redis
+    from ..search_service import _get_search_redis, get_market_source_health
 
     display_mpn = mpn.strip().upper()
     key = normalize_mpn_key(mpn)
@@ -175,12 +177,23 @@ async def dossier_market(
         except Exception:
             logger.warning("dossier_market cache lookup failed mpn={} key={}", mpn, key, exc_info=True)
 
+    # Degraded-state banner: which live-market sources are down (auth/quota). Rendered
+    # above both the cache-hit and cache-miss branches so a sparse market reads as
+    # "N sources unavailable" instead of looking mysteriously empty. Best-effort — a
+    # health-check failure must never break the market section itself.
+    try:
+        market_health = get_market_source_health(db)
+    except Exception:
+        logger.warning("dossier_market source-health lookup failed mpn={}", mpn, exc_info=True)
+        market_health = None
+
     ctx = _ctx(request, user)
     ctx.update(
         {
             "mpn": display_mpn,
             "cached_search_id": cached_search_id,
             "cached_rows": cached_rows,
+            "market_health": market_health,
         }
     )
     return template_response("htmx/partials/search/dossier_market.html", ctx)

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -58,6 +58,7 @@ from .utils.async_helpers import safe_background_task
 from .utils.normalization import (
     MAX_SUBSTITUTES,
     detect_currency,
+    fuzzy_mpn_match,
     normalize_condition,
     normalize_date_code,
     normalize_lead_time,
@@ -1312,6 +1313,68 @@ def _build_connectors(db: Session) -> tuple[list, dict[str, dict], set[str]]:
     return connectors, source_stats_map, disabled_sources
 
 
+# Canonical display names for the live-market connectors (used by the dossier
+# degraded-state banner). Keys must match _CONNECTOR_SOURCE_MAP values.
+_MARKET_SOURCE_DISPLAY = {
+    "nexar": "Nexar",
+    "brokerbin": "BrokerBin",
+    "ebay": "eBay",
+    "digikey": "DigiKey",
+    "mouser": "Mouser",
+    "oemsecrets": "OEMSecrets",
+    "sourcengine": "Sourcengine",
+    "element14": "element14",
+}
+
+
+def get_market_source_health(db: Session) -> dict:
+    """Summarize live-market connector health for the dossier degraded-state banner.
+
+    Reuses _build_connectors so the truth is identical to what an actual search runs.
+    Returns::
+
+        {
+          "available": int,          # market connectors that will run
+          "total": int,              # configured market sources (available + down)
+          "down": [{name, display, reason}],          # health_monitor flagged ERROR
+          "unconfigured": [{name, display, reason}],   # no API key set
+        }
+
+    `down` sources are the actionable ones — auth/quota errors the operator must fix
+    by rotating credentials (or restoring quota) in Settings → Sources. `disabled`
+    sources are intentional operator choices and are NOT surfaced as a problem.
+
+    Called by: routers/part_dossier.dossier_market (banner context).
+    """
+    connectors, source_stats_map, _disabled = _build_connectors(db)
+
+    available = [
+        _CONNECTOR_SOURCE_MAP.get(c.__class__.__name__, "")
+        for c in connectors
+        if _CONNECTOR_SOURCE_MAP.get(c.__class__.__name__, "") in _MARKET_SOURCE_DISPLAY
+    ]
+
+    down: list[dict] = []
+    unconfigured: list[dict] = []
+    for name, stat in source_stats_map.items():
+        if name not in _MARKET_SOURCE_DISPLAY:
+            continue
+        entry = {"name": name, "display": _MARKET_SOURCE_DISPLAY[name], "reason": stat.get("error") or ""}
+        status = stat.get("status")
+        if status in (SourceRunStatus.ERROR_SKIPPED.value, SourceRunStatus.ERROR.value):
+            down.append(entry)
+        elif status == SourceRunStatus.SKIPPED.value:
+            unconfigured.append(entry)
+        # SourceRunStatus.DISABLED → intentional; not a degraded-state problem.
+
+    return {
+        "available": len(available),
+        "total": len(available) + len(down),
+        "down": down,
+        "unconfigured": unconfigured,
+    }
+
+
 async def _fetch_fresh(pns: list[str], db: Session) -> tuple[list[dict], list[dict]]:
     """Run all enabled connectors against pns and return (results, source_stats).
 
@@ -2517,6 +2580,7 @@ async def stream_search_mpn(search_id: str, mpn: str) -> None:
     channel = f"search:{search_id}"
     accumulated: list[dict] = []
     total_results = 0
+    off_target_total = 0  # hits excluded by the relevance guard (different MPN)
     sources_completed = 0
     t_start = time.time()
 
@@ -2552,7 +2616,7 @@ async def stream_search_mpn(search_id: str, mpn: str) -> None:
                 await active_broker.publish(
                     channel,
                     "done",
-                    json.dumps({"total_results": 0, "sources": 0, "elapsed_seconds": 0}),
+                    json.dumps({"total_results": 0, "sources": 0, "elapsed_seconds": 0, "off_target": 0}),
                 )
                 return
 
@@ -2589,13 +2653,26 @@ async def stream_search_mpn(search_id: str, mpn: str) -> None:
 
                     try:
                         hits, elapsed_ms = task.result()
-                        hit_count = len(hits)
 
-                        # Score and normalize each hit
-                        scored_hits = []
+                        # Relevance guard: keep only hits whose matched MPN is the
+                        # searched part (or a close revision of it). Keyword-matching
+                        # connectors — e.g. component distributors hit with a storage
+                        # FRU — return rows under a DIFFERENT mpn; those are catalog
+                        # noise, not offers for this part, so we exclude them rather
+                        # than render a $100 component as an "offer" for an HDD.
+                        # Cross-references (alternate/FRU part numbers) live in the
+                        # "What we know" panel, not the live-market offer list.
+                        on_target = []
                         for r in hits:
                             r.setdefault("mpn_matched", mpn)
-                            scored_hits.append(_score_raw_hit(r, vendor_score_map))
+                            if fuzzy_mpn_match(mpn, r.get("mpn_matched")):
+                                on_target.append(r)
+                            else:
+                                off_target_total += 1
+                        hit_count = len(on_target)
+
+                        # Score and normalize each on-target hit
+                        scored_hits = [_score_raw_hit(r, vendor_score_map) for r in on_target]
 
                         # Incremental dedup against accumulated results
                         new_cards, updated_cards = _incremental_dedup(scored_hits, accumulated)
@@ -2692,6 +2769,7 @@ async def stream_search_mpn(search_id: str, mpn: str) -> None:
                         "total_results": total_results,
                         "sources": sources_completed,
                         "elapsed_seconds": elapsed_total,
+                        "off_target": off_target_total,
                     },
                     default=str,
                 ),
@@ -2717,6 +2795,7 @@ async def stream_search_mpn(search_id: str, mpn: str) -> None:
                         "total_results": total_results,
                         "sources": sources_completed,
                         "elapsed_seconds": round(time.time() - t_start, 1),
+                        "off_target": off_target_total,
                         "error": str(e)[:500],
                     },
                     default=str,

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -464,19 +464,23 @@ table {
 .source-chip--mouser { @apply bg-teal-600; }
 .source-chip--oemsecrets { @apply bg-fuchsia-600; }
 .source-chip--element14 { @apply bg-lime-600; }
+.source-chip--ebay { @apply bg-blue-600; }
+.source-chip--sourcengine { @apply bg-slate-600; }
 .source-chip--empty { @apply bg-gray-200 text-gray-400 border-gray-200; }
 .source-chip--error { @apply bg-rose-100 text-rose-600 border-rose-200; }
 .source-chip--disabled { @apply bg-gray-100 text-gray-400 border-gray-200 opacity-50; }
 .source-chip--skipped { @apply bg-gray-100 text-gray-400 border-gray-200 opacity-50; }
 
-/* Source badges (inline in vendor cards) */
+/* Source badges (inline in vendor cards) — light brand-card skin. */
 .source-badge { @apply px-1.5 py-0.5 text-[10px] font-medium rounded border; }
-.source-badge--nexar { @apply bg-violet-900/50 text-violet-400 border-violet-800; }
-.source-badge--brokerbin { @apply bg-sky-900/50 text-sky-400 border-sky-800; }
-.source-badge--digikey { @apply bg-orange-900/50 text-orange-400 border-orange-800; }
-.source-badge--mouser { @apply bg-teal-900/50 text-teal-400 border-teal-800; }
-.source-badge--oemsecrets { @apply bg-fuchsia-900/50 text-fuchsia-400 border-fuchsia-800; }
-.source-badge--element14 { @apply bg-lime-900/50 text-lime-400 border-lime-800; }
+.source-badge--nexar { @apply bg-violet-50 text-violet-700 border-violet-200; }
+.source-badge--brokerbin { @apply bg-sky-50 text-sky-700 border-sky-200; }
+.source-badge--digikey { @apply bg-orange-50 text-orange-700 border-orange-200; }
+.source-badge--mouser { @apply bg-teal-50 text-teal-700 border-teal-200; }
+.source-badge--oemsecrets { @apply bg-fuchsia-50 text-fuchsia-700 border-fuchsia-200; }
+.source-badge--element14 { @apply bg-lime-50 text-lime-700 border-lime-200; }
+.source-badge--ebay { @apply bg-blue-50 text-blue-700 border-blue-200; }
+.source-badge--sourcengine { @apply bg-slate-50 text-slate-700 border-slate-200; }
 
 /* ── Vendor card animation ────────────────────────────────────────── */
 @keyframes slideUp {

--- a/app/templates/htmx/partials/search/dossier_market.html
+++ b/app/templates/htmx/partials/search/dossier_market.html
@@ -1,34 +1,35 @@
-{# Part Dossier live-market terminal body — swapped into #dossier-market.
-   Two branches:
+{# Part Dossier live-market body — swapped into #dossier-market.
+   Renders the degraded-source banner (best-effort) above two branches:
      • CACHE HIT  — cached_rows present → render the cached vendor rows directly
-                    (vendor_card.html, in_dossier terminal rows) + a freshness stamp +
-                    "↻ Refresh market" (force re-run via the SSE flow).
+                    (vendor_card.html) + a freshness stamp + "↻ Refresh market".
      • CACHE MISS — an inner element auto-fires the EXISTING /v2/partials/search/run flow
                     (hx-post, hx-trigger="load"), returning results_shell.html's SSE
-                    experience embedded in the dark terminal frame. The SSE engine is
-                    UNCHANGED — we just embed it here.
+                    experience. The SSE engine is UNCHANGED — we just embed it. The banner
+                    sits OUTSIDE that hx-post div so it survives the cache-miss SSE swap.
 
    Called by: part_dossier.dossier_market (GET /v2/partials/search/dossier/market).
-   Depends on: mpn (display), cached_search_id (str | None), cached_rows (list[dict] | None),
-               results_shell.html / vendor_card.html (in_dossier terminal skin),
-               $store.shortlist + lead-detail drawer (reused). #}
+   Depends on: mpn (display), cached_search_id (str|None), cached_rows (list[dict]|None),
+               market_health (dict|None), dossier_market_banner.html, results_shell.html /
+               vendor_card.html, $store.shortlist + lead-detail drawer (reused). #}
+
+{% include "htmx/partials/search/dossier_market_banner.html" %}
 
 {% if cached_rows %}
-{# ── CACHE HIT — static cached rows in the terminal frame ── #}
-<div class="px-4 py-2.5 border-b border-gray-800 flex items-center gap-3 text-[11px]">
-  <span class="inline-flex items-center gap-1.5 text-gray-400">
-    <span class="h-1.5 w-1.5 rounded-full bg-gray-500"></span>cached
+{# ── CACHE HIT — cached rows in the light market card ── #}
+<div class="px-4 py-2.5 border-b border-brand-100 flex items-center gap-3 text-[11px]">
+  <span class="inline-flex items-center gap-1.5 text-gray-500">
+    <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>cached
   </span>
-  <span class="text-gray-500">{{ cached_rows|length }} offer{{ '' if cached_rows|length == 1 else 's' }}</span>
+  <span class="text-gray-400">{{ cached_rows|length }} offer{{ '' if cached_rows|length == 1 else 's' }}</span>
   <button type="button"
           hx-get="/v2/partials/search/dossier/market?mpn={{ mpn|urlencode }}&amp;refresh=1"
           hx-target="#dossier-market" hx-swap="innerHTML"
-          class="ml-auto px-2.5 py-1 rounded-md border border-gray-700 text-gray-400 hover:text-white hover:border-gray-600 inline-flex items-center gap-1.5">
+          class="ml-auto px-2.5 py-1 rounded-md border border-brand-300 text-brand-600 hover:text-brand-800 hover:bg-brand-50 inline-flex items-center gap-1.5">
     <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
     Refresh market
   </button>
 </div>
-<div id="search-results-cards" class="divide-y divide-gray-800" data-search-id="{{ cached_search_id }}">
+<div id="search-results-cards" class="divide-y divide-brand-100" data-search-id="{{ cached_search_id }}">
   {% for card in cached_rows %}
   {% with card_index=loop.index0, search_id=cached_search_id, swap_oob=False %}
   {% include "htmx/partials/search/vendor_card.html" %}
@@ -37,18 +38,18 @@
 </div>
 
 {% else %}
-{# ── CACHE MISS — auto-fire the existing SSE search flow into this terminal frame. ── #}
+{# ── CACHE MISS — auto-fire the existing SSE search flow (banner above survives the swap). ── #}
 <div hx-post="/v2/partials/search/run"
      hx-vals='{"mpn": "{{ mpn|e }}"}'
      hx-trigger="load"
      hx-target="this" hx-swap="innerHTML">
-  <div class="divide-y divide-gray-800">
+  <div class="divide-y divide-brand-100">
     {% for _ in range(3) %}
     <div class="px-4 py-3 flex items-center gap-4 animate-pulse">
-      <div class="h-8 w-1 rounded bg-gray-700"></div>
-      <div class="h-3 w-40 rounded bg-gray-800"></div>
-      <div class="ml-auto h-3 w-16 rounded bg-gray-800"></div>
-      <div class="h-3 w-20 rounded bg-gray-800"></div>
+      <div class="h-8 w-1 rounded bg-brand-100"></div>
+      <div class="h-3 w-40 rounded bg-brand-100"></div>
+      <div class="ml-auto h-3 w-16 rounded bg-brand-100"></div>
+      <div class="h-3 w-20 rounded bg-brand-100"></div>
     </div>
     {% endfor %}
   </div>

--- a/app/templates/htmx/partials/search/dossier_market_banner.html
+++ b/app/templates/htmx/partials/search/dossier_market_banner.html
@@ -1,0 +1,25 @@
+{# Degraded live-market banner — shown above the market rows when one or more
+   live-market sources are unavailable (auth/quota/rate-limit errors flagged by
+   health_monitor). Makes a sparse or empty market legible ("N of M sources
+   unavailable") instead of looking mysteriously broken. Each source carries its
+   specific reason as a hover tooltip; the link deep-links Settings → Sources where
+   credentials are rotated.
+   Context: market_health = {available, total, down:[{name, display, reason}], unconfigured:[...]}.
+   Called by: dossier_market.html. Renders ONLY when market_health.down is non-empty —
+   `unconfigured` (never-set-up) sources are deliberately NOT surfaced as a problem. #}
+{% if market_health and market_health.down %}
+<div class="mx-4 mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-[12px] leading-relaxed text-amber-800">
+  <div class="flex items-start gap-2">
+    <svg class="h-4 w-4 shrink-0 mt-0.5 text-amber-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+    </svg>
+    <div class="min-w-0">
+      <span class="font-semibold">{{ market_health.down|length }} of {{ market_health.total }} live-market source{{ '' if market_health.total == 1 else 's' }} unavailable</span>
+      —
+      {% for s in market_health.down %}<span title="{{ s.reason }}" class="font-medium underline decoration-dotted decoration-amber-400 underline-offset-2 cursor-help">{{ s.display }}</span>{{ ', ' if not loop.last }}{% endfor %}.
+      Live results are limited until they recover.
+      <a href="/v2/settings" class="font-semibold underline decoration-amber-300 underline-offset-2 hover:text-amber-900">Check Settings&nbsp;→</a>
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/app/templates/htmx/partials/search/dossier_shell.html
+++ b/app/templates/htmx/partials/search/dossier_shell.html
@@ -66,24 +66,26 @@
     </section>
   </div>
 
-  {# LIVE MARKET — dark terminal, open by default. #}
-  <section class="rounded-xl bg-gray-900 border border-gray-800 shadow-sm overflow-hidden"
+  {# LIVE MARKET — light brand card (matches the sections below), open by default. #}
+  <section class="rounded-xl bg-white border border-brand-200 shadow-sm overflow-hidden"
            x-data="{ open: persistOr(true, 'dossier_market_open') }">
-    <header @click="open=!open" class="px-4 py-3 border-b border-gray-800 cursor-pointer select-none flex items-center gap-2">
-      <svg class="chev h-4 w-4 text-gray-500" :class="open && 'open'" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
-      <span class="text-sm font-semibold text-gray-100">Live market</span>
+    <header @click="open=!open" class="flex items-center justify-between px-4 py-3 cursor-pointer select-none">
+      <h2 class="flex items-center gap-2 text-sm font-semibold text-brand-900">
+        <svg class="chev h-4 w-4 text-gray-400" :class="open && 'open'" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
+        Live market
+      </h2>
     </header>
     <div x-show="open" x-collapse>
       <div id="dossier-market"
            hx-get="/v2/partials/search/dossier/market?mpn={{ mpn|urlencode }}"
            hx-trigger="load" hx-target="this" hx-swap="innerHTML">
-        <div class="divide-y divide-gray-800">
+        <div class="divide-y divide-brand-100 border-t border-brand-100">
           {% for _ in range(3) %}
           <div class="px-4 py-3 flex items-center gap-4 animate-pulse">
-            <div class="h-8 w-1 rounded bg-gray-700"></div>
-            <div class="h-3 w-40 rounded bg-gray-800"></div>
-            <div class="ml-auto h-3 w-16 rounded bg-gray-800"></div>
-            <div class="h-3 w-20 rounded bg-gray-800"></div>
+            <div class="h-8 w-1 rounded bg-brand-100"></div>
+            <div class="h-3 w-40 rounded bg-brand-100"></div>
+            <div class="ml-auto h-3 w-16 rounded bg-brand-100"></div>
+            <div class="h-3 w-20 rounded bg-brand-100"></div>
           </div>
           {% endfor %}
         </div>

--- a/app/templates/htmx/partials/search/requisition_picker_modal.html
+++ b/app/templates/htmx/partials/search/requisition_picker_modal.html
@@ -3,13 +3,13 @@
    Depends on: htmx_views requisition_picker + add_to_requisition routes
 #}
 <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-label="Add to requisition" @click.self="$el.remove()" @keydown.escape="$el.remove()">
-  <div class="bg-gray-800 rounded-lg border border-gray-700 shadow-2xl w-full max-w-md mx-4 p-6">
-    <h3 class="text-lg font-semibold text-white mb-4">Add to Requisition</h3>
+  <div class="bg-white rounded-lg border border-brand-200 shadow-2xl w-full max-w-md mx-4 p-6">
+    <h3 class="text-lg font-semibold text-brand-900 mb-4">Add to Requisition</h3>
 
     {% if requisitions %}
     <div class="space-y-2 max-h-64 overflow-y-auto">
       {% for req in requisitions %}
-      <button class="w-full text-left px-3 py-2 rounded bg-gray-700 hover:bg-gray-600 text-sm text-white transition-colors"
+      <button class="w-full text-left px-3 py-2 rounded border border-brand-200 bg-white hover:bg-brand-50 text-sm text-brand-900 transition-colors"
               hx-post="/v2/partials/search/add-to-requisition"
               hx-ext="json-enc"
               hx-vals='{"requisition_id": {{ req.id }}, "mpn": "{{ mpn }}", "items": {{ items_json }}}'
@@ -17,18 +17,18 @@
               hx-swap="innerHTML"
               data-loading-disable>
         <div class="font-medium">{{ req.name }}</div>
-        <div class="text-xs text-gray-400">{{ req.customer_name|default('', true) }} &middot; {{ req.requirements|length }} parts</div>
+        <div class="text-xs text-gray-500">{{ req.customer_name|default('', true) }} &middot; {{ req.requirements|length }} parts</div>
       </button>
       {% endfor %}
     </div>
     {% else %}
-    <p class="text-sm text-gray-400">No requisitions found. Create one first.</p>
+    <p class="text-sm text-gray-500">No requisitions found. Create one first.</p>
     {% endif %}
 
     <div id="modal-result" class="mt-3"></div>
 
     <div class="mt-4 flex justify-end">
-      <button @click="$el.closest('[class*=fixed]').remove()" class="px-4 py-2 text-sm text-gray-400 hover:text-white">
+      <button @click="$el.closest('[class*=fixed]').remove()" class="px-4 py-2 text-sm text-gray-500 hover:text-brand-700">
         Close
       </button>
     </div>

--- a/app/templates/htmx/partials/search/results_shell.html
+++ b/app/templates/htmx/partials/search/results_shell.html
@@ -1,29 +1,29 @@
-{# Live-market terminal body — returned by search_run POST, contains the SSE connection.
-   Re-skinned to the dark "terminal" look for the Part Dossier: it renders INSIDE the
-   #dossier-market frame (the dossier already owns the bg-gray-900 section, collapsible
-   header, and the lead-detail drawer). The history "What we know" column is NOT here —
-   it is its own dossier section. SSE wiring, source-progress chips, $store.shortlist, and
-   the lead-detail Details trigger are all kept intact.
+{# Live-market body — returned by search_run POST, contains the SSE connection.
+   Light brand-card skin matching the rest of the Part Dossier: it renders INSIDE the
+   #dossier-market section (the dossier owns the white card, collapsible header, and the
+   lead-detail drawer). The history "What we know" column is NOT here — it is its own
+   dossier section. SSE wiring, source-progress chips, $store.shortlist, and the
+   lead-detail Details trigger are all kept intact.
    Called by: htmx_views.search_run.
-   Depends on: SSE stream at /v2/partials/search/stream, vendor_card.html (terminal rows). #}
+   Depends on: SSE stream at /v2/partials/search/stream, vendor_card.html (market rows). #}
 
 <div id="search-results-wrapper" data-search-id="{{ search_id }}">
-  {# terminal header: freshness + refresh #}
-  <div class="px-4 py-2.5 border-b border-gray-800 flex items-center gap-3 text-[11px]">
-    <span class="inline-flex items-center gap-1.5 text-emerald-400">
-      <span class="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse"></span>live
+  {# header: freshness + refresh #}
+  <div class="px-4 py-2.5 border-b border-brand-100 flex items-center gap-3 text-[11px]">
+    <span class="inline-flex items-center gap-1.5 text-emerald-600">
+      <span class="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse"></span>live
     </span>
     <button type="button"
             hx-get="/v2/partials/search/dossier/market?mpn={{ mpn|urlencode }}&amp;refresh=1"
             hx-target="#dossier-market" hx-swap="innerHTML"
-            class="ml-auto px-2.5 py-1 rounded-md border border-gray-700 text-gray-400 hover:text-white hover:border-gray-600 inline-flex items-center gap-1.5">
+            class="ml-auto px-2.5 py-1 rounded-md border border-brand-300 text-brand-600 hover:text-brand-800 hover:bg-brand-50 inline-flex items-center gap-1.5">
       <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
       Refresh market
     </button>
   </div>
 
   {# source progress chips #}
-  <div id="source-progress" class="px-4 py-3 border-b border-gray-800 flex flex-wrap gap-1.5 items-center">
+  <div id="source-progress" class="px-4 py-3 border-b border-brand-100 flex flex-wrap gap-1.5 items-center">
     <span class="text-[11px] text-gray-500 mr-1">Sources:</span>
     {% for source in enabled_sources %}
     <span id="source-chip-{{ source.name }}" class="source-chip source-chip--searching">
@@ -39,23 +39,23 @@
     <div id="search-results-cards"
          sse-swap="results"
          hx-swap="beforeend settle:100ms"
-         class="divide-y divide-gray-800">
+         class="divide-y divide-brand-100">
     </div>
     <div sse-swap="source-status" hx-swap="none"></div>
     <div sse-swap="card-update" hx-swap="none"></div>
     <div sse-swap="done" hx-swap="none"></div>
   </div>
 
-  <div id="search-stats" class="hidden px-4 py-2.5 border-t border-gray-800 text-[11px] text-gray-500"></div>
+  <div id="search-stats" class="hidden px-4 py-2.5 border-t border-brand-100 text-[11px] text-gray-500"></div>
 
-  {# Empty state — re-skinned dark, reframed as a pivot to knowledge. #}
+  {# Empty state — reframed as a pivot to knowledge. #}
   <div id="search-empty-state" class="hidden px-6 py-12 text-center">
-    <svg class="mx-auto mb-3 h-10 w-10 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+    <svg class="mx-auto mb-3 h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
     </svg>
-    <p class="text-base font-semibold text-gray-200">No live stock right now.</p>
+    <p class="text-base font-semibold text-brand-900">No live stock right now.</p>
     <p class="text-sm text-gray-500 mt-1">Here's what we already know about this part.</p>
-    <a href="#know" class="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-800 border border-gray-700 text-gray-200 text-sm hover:bg-gray-700">
+    <a href="#know" class="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-50 border border-brand-200 text-brand-700 text-sm hover:bg-brand-100">
       Jump to What we know
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M19 14l-7 7m0 0l-7-7m7 7V3"/></svg>
     </a>
@@ -119,6 +119,21 @@
       if (payload.error) {
         chip.setAttribute('title', payload.error);
       }
+    });
+
+    // 'done' event: surface the relevance-guard count — off-target catalog matches
+    // (a different MPN than the searched part) that were hidden from the market list.
+    wrapper.addEventListener('htmx:sseMessage', function(evt) {
+      if (!evt.detail || evt.detail.type !== 'done') return;
+      var payload;
+      try { payload = JSON.parse(evt.detail.data); } catch (e) { return; }
+      var n = (payload && payload.off_target) || 0;
+      if (n <= 0) return;
+      var stats = document.getElementById('search-stats');
+      if (!stats) return;
+      stats.textContent = n + ' off-target match' + (n === 1 ? '' : 'es') +
+        ' from catalog distributors hidden (different part number' + (n === 1 ? '' : 's') + ').';
+      stats.classList.remove('hidden');
     });
 
     wrapper.addEventListener('htmx:sseClose', function() {

--- a/app/templates/htmx/partials/search/shortlist_bar.html
+++ b/app/templates/htmx/partials/search/shortlist_bar.html
@@ -10,11 +10,11 @@
      x-transition:leave="transition ease-in duration-150 transform"
      x-transition:leave-start="translate-y-0"
      x-transition:leave-end="translate-y-full"
-     class="fixed bottom-16 left-0 right-0 z-30 bg-gray-900 border-t border-gray-700 px-4 py-3 shadow-2xl"
+     class="fixed bottom-16 left-0 right-0 z-30 bg-white border-t border-brand-200 px-4 py-3 shadow-2xl"
      x-cloak>
   <div class="max-w-7xl mx-auto flex items-center justify-between">
-    <span class="text-sm font-medium text-white">
-      <span x-text="$store.shortlist.count" class="font-mono text-brand-400"></span>
+    <span class="text-sm font-medium text-brand-900">
+      <span x-text="$store.shortlist.count" class="font-mono text-brand-600"></span>
       vendor<span x-show="$store.shortlist.count !== 1" x-cloak>s</span> selected
     </span>
     <div class="flex items-center gap-2">
@@ -23,11 +23,11 @@
         Add to Requisition
       </button>
       <button @click="$dispatch('open-modal', {url: '/v2/partials/search/requisition-picker?action=rfq&items=' + encodeURIComponent(JSON.stringify($store.shortlist.items))})"
-              class="px-4 py-2 text-sm font-semibold bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors border border-gray-600">
+              class="px-4 py-2 text-sm font-semibold bg-white text-brand-700 rounded-lg hover:bg-brand-50 transition-colors border border-brand-300">
         Create RFQ
       </button>
       <button @click="$store.shortlist.clear()"
-              class="px-3 py-2 text-sm text-gray-400 hover:text-white transition-colors">
+              class="px-3 py-2 text-sm text-gray-500 hover:text-brand-700 transition-colors">
         Clear
       </button>
     </div>

--- a/app/templates/htmx/partials/search/vendor_card.html
+++ b/app/templates/htmx/partials/search/vendor_card.html
@@ -1,16 +1,15 @@
-{# Single market row — dark "terminal" row for the Part Dossier live-market feed.
+{# Single market row — light brand row for the Part Dossier live-market feed.
    Rendered per SSE event in streaming search (beforeend swap) AND for cached rows in the
    dossier market cache-hit path. Denser than the old fat card, same field contract.
    Confidence bar · vendor + AUTH + source badges · mono price · qty/MOQ · region/lead ·
-   per-row actions (RFQ this / +Offer → quick-source endpoints land in the NEXT task;
-   Details → reuses the existing lead-detail drawer). Shortlist checkbox + slideUp stagger
-   preserved.
+   per-row actions (RFQ this / +Offer → quick-source endpoints; Details → reuses the
+   existing lead-detail drawer). Shortlist checkbox + slideUp stagger preserved.
    Called by: search_service.stream_search_mpn (HTML SSE), htmx_views.search_filter,
               dossier_market.html (cache-hit include).
    Depends on: Alpine.js $store.shortlist, lead-detail drawer (#lead-drawer-content).
    swap_oob: when true, HTMX replaces the existing node with the same id (card-update SSE). #}
 {% set conf = card.confidence_color|default('red') %}
-<div class="mkt-row group lg:grid lg:grid-cols-[10px_1fr_110px_150px_110px_120px] gap-3 px-4 py-3 items-center border-l-2 border-l-transparent hover:bg-gray-800 hover:border-l-brand-400 transition-colors"
+<div class="mkt-row group lg:grid lg:grid-cols-[10px_1fr_110px_150px_110px_120px] gap-3 px-4 py-3 items-center border-l-2 border-l-transparent hover:bg-brand-50 hover:border-l-brand-400 transition-colors"
      style="--i: {{ card_index }}"
      id="vendor-card-{{ card.vendor_name|lower|replace(' ', '-') }}"
      {% if swap_oob %}hx-swap-oob="true"{% endif %}
@@ -29,14 +28,14 @@
              :checked="$store.shortlist.has('{{ card.vendor_name }}', '{{ card.mpn_matched }}')"
              @change="$store.shortlist.toggle({vendor_name: '{{ card.vendor_name }}', mpn: '{{ card.mpn_matched }}', unit_price: {{ card.unit_price or 0 }}, qty_available: {{ card.qty_available or 0 }}, source_type: '{{ card.source_type }}'})">
       <span class="lg:hidden h-2.5 w-2.5 rounded-full {% if conf == 'green' %}bg-emerald-500{% elif conf == 'amber' %}bg-amber-500{% else %}bg-rose-500{% endif %}"></span>
-      <span class="text-sm font-semibold text-white truncate">{{ card.vendor_name }}</span>
+      <span class="text-sm font-semibold text-brand-900 truncate">{{ card.vendor_name }}</span>
       {% if card.is_authorized %}
-      <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-emerald-900/50 text-emerald-400 border border-emerald-800">AUTH</span>
+      <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-emerald-50 text-emerald-700 border border-emerald-200">AUTH</span>
       {% endif %}
       <span class="px-1.5 py-0.5 text-[10px] font-medium rounded border
-        {% if conf == 'green' %}bg-emerald-900/50 text-emerald-400 border-emerald-800
-        {% elif conf == 'amber' %}bg-amber-900/50 text-amber-400 border-amber-800
-        {% else %}bg-rose-900/50 text-rose-400 border-rose-800{% endif %}">{{ card.confidence_pct|default(0) }}%</span>
+        {% if conf == 'green' %}bg-emerald-50 text-emerald-700 border-emerald-200
+        {% elif conf == 'amber' %}bg-amber-50 text-amber-700 border-amber-200
+        {% else %}bg-rose-50 text-rose-700 border-rose-200{% endif %}">{{ card.confidence_pct|default(0) }}%</span>
       {% for src in card.sources_found|default([]) %}
       <span class="source-badge source-badge--{{ src }}">{{ src }}</span>
       {% endfor %}
@@ -49,45 +48,44 @@
   {# price #}
   <div class="lg:text-right mt-1 lg:mt-0">
     {% if card.unit_price %}
-    <span class="font-mono text-base font-semibold text-white">${{ "%.4f"|format(card.unit_price) }}</span>
+    <span class="font-mono text-base font-semibold text-brand-900">${{ "%.4f"|format(card.unit_price) }}</span>
     {% else %}
-    <span class="text-xs text-gray-500">RFQ</span>
+    <span class="text-xs text-gray-400">RFQ</span>
     {% endif %}
   </div>
 
   {# qty / moq #}
-  <div class="lg:text-right font-mono text-xs text-gray-300 mt-0.5 lg:mt-0">
-    {% if card.qty_available %}<span>{{ "{:,}".format(card.qty_available) }}</span><span class="text-gray-500"> avail</span>{% endif %}
-    {% if card.moq %}<span class="text-gray-500"> · MOQ {{ "{:,}".format(card.moq) }}</span>{% endif %}
+  <div class="lg:text-right font-mono text-xs text-gray-700 mt-0.5 lg:mt-0">
+    {% if card.qty_available %}<span>{{ "{:,}".format(card.qty_available) }}</span><span class="text-gray-400"> avail</span>{% endif %}
+    {% if card.moq %}<span class="text-gray-400"> · MOQ {{ "{:,}".format(card.moq) }}</span>{% endif %}
   </div>
 
   {# region / lead #}
-  <div class="text-[11px] text-gray-400 mt-0.5 lg:mt-0">{{ card.lead_quality|default('')|title }}{% if card.reason %} · {{ card.reason }}{% endif %}</div>
+  <div class="text-[11px] text-gray-500 mt-0.5 lg:mt-0">{{ card.lead_quality|default('')|title }}{% if card.reason %} · {{ card.reason }}{% endif %}</div>
 
   {# actions (reveal on hover desktop, always visible on mobile/touch) #}
   <div class="flex lg:justify-end items-center gap-1 mt-2 lg:mt-0 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
-    {# Per-row RFQ / +Offer — endpoints land in the NEXT (actions) task; harmless 404 for now. #}
     <button type="button" title="RFQ this vendor"
             hx-post="/v2/partials/search/quick-source/rfq"
             hx-vals='{"mpn": "{{ card.mpn_matched|e }}", "vendor_name": "{{ card.vendor_name|e }}"}'
-            class="p-1.5 rounded text-gray-400 hover:text-white hover:bg-gray-700"><svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M3 11l18-8-8 18-2-7-8-3z"/></svg></button>
+            class="p-1.5 rounded text-gray-400 hover:text-brand-700 hover:bg-brand-50"><svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M3 11l18-8-8 18-2-7-8-3z"/></svg></button>
     <button type="button" title="Add as offer"
             hx-post="/v2/partials/search/quick-source/offer"
             hx-vals='{"mpn": "{{ card.mpn_matched|e }}", "vendor_name": "{{ card.vendor_name|e }}"}'
-            class="p-1.5 rounded text-gray-400 hover:text-white hover:bg-gray-700"><svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M12 4v16m8-8H4"/></svg></button>
+            class="p-1.5 rounded text-gray-400 hover:text-brand-700 hover:bg-brand-50"><svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M12 4v16m8-8H4"/></svg></button>
     <button type="button"
             hx-get="/v2/partials/search/lead-detail?search_id={{ search_id }}&vendor_key={{ card.vendor_name|lower|trim }}"
             hx-target="#lead-drawer-content" hx-swap="innerHTML"
-            class="px-2 py-1 rounded text-[11px] text-gray-400 hover:text-white hover:bg-gray-700">Details →</button>
+            class="px-2 py-1 rounded text-[11px] text-gray-500 hover:text-brand-700 hover:bg-brand-50">Details →</button>
   </div>
 
   {# Sub-offers table (expandable) #}
   {% if card.sub_offers %}
   <div class="lg:col-span-6 mt-2">
-    <button @click="expanded = !expanded" class="text-[11px] text-brand-400 hover:text-brand-300">
+    <button @click="expanded = !expanded" class="text-[11px] text-brand-600 hover:text-brand-700">
       <span x-text="expanded ? 'Hide offers' : '{{ card.offer_count|default(card.sub_offers|length) }} offers'"></span>
     </button>
-    <div x-show="expanded" x-cloak x-transition class="mt-2 border-t border-gray-700 pt-2">
+    <div x-show="expanded" x-cloak x-transition class="mt-2 border-t border-gray-200 pt-2">
       <table class="w-full text-xs">
         <thead><tr class="text-gray-500">
           <th class="text-left py-1">Source</th>
@@ -96,7 +94,7 @@
         </tr></thead>
         <tbody>
         {% for offer in card.sub_offers %}
-          <tr class="text-gray-300 border-t border-gray-700/50">
+          <tr class="text-gray-700 border-t border-gray-100">
             <td class="py-1">{{ offer.source_type|default('') }}</td>
             <td class="text-right font-mono">{% if offer.unit_price %}${{ "%.4f"|format(offer.unit_price) }}{% else %}-{% endif %}</td>
             <td class="text-right font-mono">{{ "{:,}".format(offer.qty_available) if offer.qty_available else '-' }}</td>

--- a/app/utils/normalization.py
+++ b/app/utils/normalization.py
@@ -395,10 +395,14 @@ def fuzzy_mpn_match(mpn_a: str | None, mpn_b: str | None) -> bool:
     if a_stripped == b_stripped:
         return True
 
-    # One is prefix of the other (trailing revision)
+    # One is prefix of the other (trailing revision). Compare the longer against
+    # the shorter so the check is symmetric — the suffix is the longer key minus
+    # the shared prefix, regardless of argument order. (The old str.replace()
+    # form only worked when the longer MPN was passed first.)
     if a_stripped.startswith(b_stripped) or b_stripped.startswith(a_stripped):
-        suffix = a_stripped.replace(b_stripped, "") or b_stripped.replace(a_stripped, "")
-        if len(suffix) <= 2:  # Short suffix = likely revision
+        longer, shorter = sorted((a_stripped, b_stripped), key=len, reverse=True)
+        suffix = longer[len(shorter) :]
+        if 0 < len(suffix) <= 2:  # Short trailing suffix = likely revision
             return True
 
     return False

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -305,10 +305,13 @@ dossier_shell.html lazy-loads (each div has an explicit hx-target="this"):
     |     bumps search_count/last_searched_at on an EXISTING card only (never
     |     creates one — unknown PN stays "New to us" / "Known via FRU crosswalk").
     +-- GET /v2/partials/search/dossier/market?mpn=  part_dossier.dossier_market
-    |     cache HIT (Redis search:{key}:latest → search:{id}:results) → cached
-    |     vendor rows in the dark terminal frame + "↻ Refresh market"; cache MISS
+    |     A degraded-source banner (dossier_market_banner.html) renders above both
+    |     branches when live-market sources are down (auth/quota) — see market_health
+    |     below. cache HIT (Redis search:{key}:latest → search:{id}:results) → cached
+    |     vendor rows in the light market card + "↻ Refresh market"; cache MISS
     |     (or ?refresh=1) → inner div auto-fires the EXISTING POST /v2/partials/
-    |     search/run SSE flow (results_shell.html) inside the terminal frame.
+    |     search/run SSE flow (results_shell.html). The banner sits OUTSIDE that
+    |     hx-post div so it survives the cache-miss SSE swap.
     +-- GET /v2/partials/search/history?mpn=         (EXISTING search_history_panel)
     +-- GET /v2/partials/search/dossier/specs?mpn=   part_dossier.dossier_specs
 ```
@@ -316,9 +319,27 @@ dossier_shell.html lazy-loads (each div has an explicit hx-target="this"):
 New router `app/routers/part_dossier.py` (GET-only; reuses data/services, no route
 moves). `stream_search_mpn` now also writes the pointer key `search:{normalize_mpn_key
 (mpn)}:latest = search_id` (TTL 900s) so the dossier market cache-hit path can find the
-freshest run. The search-flow `vendor_card.html` + `results_shell.html` are re-skinned in
-place to the dark terminal row/frame (their ONLY consumer is now the dossier market).
-Page-level + per-row RFQ/offer actions (the quick-source endpoints) are a follow-up task.
+freshest run. The search-flow templates (`dossier_shell` "Live market" section,
+`dossier_market`, `results_shell`, `vendor_card`, `shortlist_bar`,
+`requisition_picker_modal`) use the **light brand-card skin** matching the rest of the
+site — the earlier dark "terminal" look was the visual outlier and has been removed.
+Page-level + per-row RFQ/offer actions (the quick-source endpoints) are wired.
+
+**Degraded-source banner** — `search_service.get_market_source_health(db)` reuses
+`_build_connectors` to partition the live-market connectors into available / `down`
+(health_monitor flagged ERROR — auth/quota, operator must rotate credentials in Settings
+→ Sources) / `unconfigured` (no API key). `dossier_market` passes the result as
+`market_health`; the banner names each down source with its specific error as a hover
+tooltip and deep-links `/v2/settings`. Best-effort: a health lookup failure leaves
+`market_health=None` and never breaks the market section.
+
+**Relevance guard** — `stream_search_mpn` keeps only hits whose `mpn_matched`
+`fuzzy_mpn_match`es the searched MPN (handles dash/case + ≤2-char revision suffixes,
+symmetrically). Keyword-match noise from catalog distributors (a different MPN — e.g. a
+component returned for a storage FRU) is excluded before scoring/dedup/cache; the dropped
+count rides the `done` SSE event as `off_target` and surfaces as a footnote in
+`#search-stats`. Cross-references (alternate/FRU part numbers) belong in "What we know",
+not the live-market offer list.
 
 ### 2b. Streaming Part-Search (`/v2/partials/search/run`)
 

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -202,17 +202,17 @@ class TestFuzzyMpnMatch:
             pytest.param("LM317T", "LM317T", True, id="exact_match"),
             pytest.param("lm317t", "LM317T", True, id="case_insensitive"),
             pytest.param("LM2596S-5.0", "LM2596S5.0", True, id="dash_vs_no_dash"),
-            # Short suffix detection uses str.replace which doesn't handle
-            # this case correctly — one-char suffix not detected
-            pytest.param("SN74HC595N", "SN74HC595NA", False, id="trailing_revision"),
+            # Trailing revision is detected regardless of argument order (shorter
+            # base passed first). Suffix "A" is <= 2 chars → likely the same part.
+            pytest.param("SN74HC595N", "SN74HC595NA", True, id="trailing_revision"),
             pytest.param("LM317T", "NE555P", False, id="completely_different"),
             pytest.param(None, "LM317T", False, id="none_a"),
             pytest.param("LM317T", None, False, id="none_b"),
             pytest.param(None, None, False, id="both_none"),
             # MPNs shorter than 3 chars after normalize are rejected
             pytest.param("AB", "AB", False, id="short_mpn_rejected"),
-            # Single-char suffix difference is not a fuzzy match.
-            pytest.param("LM317T", "LM317TA", False, id="one_prefix_of_other_short_suffix"),
+            # Single-char trailing suffix (revision) IS a fuzzy match, either order.
+            pytest.param("LM317T", "LM317TA", True, id="one_prefix_of_other_short_suffix"),
             # Empty string MPN returns False.
             pytest.param("", "LM317T", False, id="empty_string_a"),
             pytest.param("LM317T", "", False, id="empty_string_b"),
@@ -381,6 +381,19 @@ class TestFuzzyMpnMatchRevision:
         result = fuzzy_mpn_match("NE555P", "NE555")
         assert result is True
 
+    def test_revision_match_is_symmetric(self):
+        # The match must hold regardless of argument order — the base MPN passed
+        # first (the common "search the base part, listing carries a suffix" case)
+        # must still match. Regression guard for the old asymmetric str.replace.
+        assert fuzzy_mpn_match("LM317T", "LM317TN") is True
+        assert fuzzy_mpn_match("LM317TN", "LM317T") is True
+        assert fuzzy_mpn_match("17P9905", "17P9905-LF") is True
+        assert fuzzy_mpn_match("17P9905-LF", "17P9905") is True
+
+    def test_long_suffix_still_rejected(self):
+        # A 3+ char trailing difference is NOT a revision (different part).
+        assert fuzzy_mpn_match("LM317T", "LM317TABC") is False
+
 
 class TestParseSubstituteMpns:
     """Cover lines 417-435: parse_substitute_mpns function."""
@@ -444,3 +457,16 @@ class TestParseSubstituteMpns:
         result = parse_substitute_mpns(subs, "LM317T")
         assert len(result) == 1
         assert result[0]["mpn"] == "LM317AT"
+
+
+class TestFuzzyMpnMatchBoundary:
+    """Boundary coverage for the symmetric revision-suffix check."""
+
+    def test_identical_after_strip_is_exact_not_revision(self):
+        # Equal stripped keys → caught by the exact/stripped branch (suffix length 0),
+        # never misclassified as a 0-length revision.
+        assert fuzzy_mpn_match("LM-317-T", "LM317T") is True
+
+    def test_three_char_suffix_rejected_both_orders(self):
+        assert fuzzy_mpn_match("LM317TABC", "LM317T") is False
+        assert fuzzy_mpn_match("LM317T", "LM317TABC") is False

--- a/tests/test_part_dossier_router.py
+++ b/tests/test_part_dossier_router.py
@@ -200,3 +200,107 @@ def test_v2_page_mpn_passthrough(client, test_user):
     assert resp.status_code == 200
     # base_page.html fires hx-get="{{ partial_url }}"; the mpn rides along.
     assert "/v2/partials/search?mpn=LM317T" in resp.text
+
+
+# ── Degraded-market banner (market_health) ────────────────────────────────
+
+
+class TestMarketSourceHealth:
+    """get_market_source_health partitions live-market connectors into available / down
+    (auth-quota errors) / unconfigured."""
+
+    def test_classifies_down_unconfigured_and_ignores_non_market(self, db_session):
+        from app.search_service import get_market_source_health
+
+        # available: a built MouserConnector; down: brokerbin (error_skipped);
+        # unconfigured: ebay (skipped); a non-market/disabled enrichment source is ignored.
+        mouser = type("MouserConnector", (), {})()
+        stats = {
+            "brokerbin": {"source": "brokerbin", "status": "error_skipped", "error": "Auth error — rotate credentials"},
+            "ebay": {"source": "ebay", "status": "skipped", "error": "No API key configured"},
+            "hunter_enrichment": {"source": "hunter_enrichment", "status": "disabled", "error": None},
+        }
+        with patch("app.search_service._build_connectors", return_value=([mouser], stats, set())):
+            h = get_market_source_health(db_session)
+
+        assert h["available"] == 1
+        assert [d["name"] for d in h["down"]] == ["brokerbin"]
+        assert h["down"][0]["display"] == "BrokerBin"
+        assert h["down"][0]["reason"].startswith("Auth error")
+        assert [u["name"] for u in h["unconfigured"]] == ["ebay"]
+        assert h["total"] == 2  # available(1) + down(1); unconfigured excluded
+
+
+def test_market_banner_renders_when_sources_down(client):
+    """When live-market sources are down, the market section shows the degraded banner
+    with the source display name, its reason, and a Settings deep-link."""
+    health = {
+        "available": 2,
+        "total": 6,
+        "down": [{"name": "brokerbin", "display": "BrokerBin", "reason": "Auth error — rotate credentials"}],
+        "unconfigured": [],
+    }
+    with patch("app.search_service.get_market_source_health", return_value=health):
+        resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+    assert resp.status_code == 200
+    body = resp.text
+    assert "BrokerBin" in body
+    assert "unavailable" in body
+    assert "/v2/settings" in body
+    assert "Auth error — rotate credentials" in body  # per-source tooltip reason
+
+
+def test_market_no_banner_when_all_sources_healthy(client):
+    """No down sources → no degraded banner."""
+    health = {"available": 6, "total": 6, "down": [], "unconfigured": []}
+    with patch("app.search_service.get_market_source_health", return_value=health):
+        resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+    assert resp.status_code == 200
+    assert "unavailable" not in resp.text
+
+
+def test_market_section_survives_health_lookup_failure(client):
+    """A health-check failure must never break the market section (best-effort
+    banner)."""
+    with patch("app.search_service.get_market_source_health", side_effect=RuntimeError("boom")):
+        resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+    assert resp.status_code == 200
+    # Cache-miss frame still renders (fires the SSE run flow).
+    assert "/v2/partials/search/run" in resp.text
+
+
+def test_market_health_all_down_no_available(db_session):
+    """When no market connector is built (all errored), available=0 and
+    total==len(down)."""
+    from app.search_service import get_market_source_health
+
+    stats = {
+        "brokerbin": {"source": "brokerbin", "status": "error_skipped", "error": "Auth error"},
+        "nexar": {"source": "nexar", "status": "error_skipped", "error": "Quota exhausted"},
+        "ebay": {"source": "ebay", "status": "skipped", "error": "No API key configured"},
+    }
+    with patch("app.search_service._build_connectors", return_value=([], stats, set())):
+        h = get_market_source_health(db_session)
+
+    assert h["available"] == 0
+    assert {d["name"] for d in h["down"]} == {"brokerbin", "nexar"}
+    assert [u["name"] for u in h["unconfigured"]] == ["ebay"]
+    assert h["total"] == 2  # available(0) + down(2)
+
+
+def test_market_no_banner_when_only_unconfigured(client):
+    """Sources merely unconfigured (never set up) do NOT trigger the degraded banner —
+    only `down` (auth/quota errors) do.
+
+    Confirms the asymmetry is intentional.
+    """
+    health = {
+        "available": 5,
+        "total": 5,
+        "down": [],
+        "unconfigured": [{"name": "ebay", "display": "eBay", "reason": "No API key configured"}],
+    }
+    with patch("app.search_service.get_market_source_health", return_value=health):
+        resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+    assert resp.status_code == 200
+    assert "unavailable" not in resp.text

--- a/tests/test_search_service_stream.py
+++ b/tests/test_search_service_stream.py
@@ -400,3 +400,168 @@ class TestStreamSearchMpnLatestPointer:
         assert f"search:{key}:latest" in setex_keys, setex_keys
         assert setex_keys[f"search:{key}:latest"] == (f"search:{key}:latest", 900, "sid-pointer-1")
         assert "search:sid-pointer-1:results" in setex_keys
+
+
+# ── Test: Relevance guard — off-target (different MPN) hits are excluded ──────
+#
+# Connectors that keyword-match (e.g. component distributors hit with a storage
+# FRU) return rows under a DIFFERENT mpn_matched. Those are catalog noise, not
+# offers for the searched part, so stream_search_mpn must drop them BEFORE
+# scoring/dedup and report the dropped count via the "done" event's off_target.
+
+
+class TestStreamSearchMpnRelevanceGuard:
+    def _conn(self, hits):
+        c = MagicMock()
+        c.source_name = "mouser"
+        c.search = AsyncMock(return_value=hits)
+        return c
+
+    async def test_off_target_hit_excluded_and_counted(self, db_session: Session):
+        """Off-target hits (different MPN) are dropped pre-scoring; off_target counts
+        them."""
+        import json
+
+        mock_broker = MagicMock()
+        mock_broker.publish = AsyncMock()
+        captured: dict = {}
+
+        def fake_dedup(scored, acc):
+            captured["scored"] = list(scored)
+            acc.extend(scored)
+            return (list(scored), [])
+
+        conn = self._conn(
+            [
+                {"mpn_matched": "17P9905", "vendor_name": "BrokerCo"},  # on-target
+                {"mpn_matched": "1300940294", "vendor_name": "Mouser"},  # off-target
+            ]
+        )
+
+        with (
+            patch("app.search_service._build_connectors", return_value=([conn], {}, set())),
+            patch("app.services.sse_broker.broker", mock_broker),
+            patch("app.search_service._render_search_vendor_cards_html", return_value="<div></div>"),
+            patch("app.search_service._incremental_dedup", side_effect=fake_dedup),
+            patch("app.search_service._score_raw_hit", side_effect=lambda r, vm: r),
+        ):
+            await stream_search_mpn("test-relevance-001", "17P9905")
+
+        assert len(captured["scored"]) == 1
+        assert captured["scored"][0]["mpn_matched"] == "17P9905"
+
+        done = [c for c in mock_broker.publish.call_args_list if c[0][1] == "done"][0]
+        payload = json.loads(done[0][2])
+        assert payload["off_target"] == 1
+        assert payload["total_results"] == 1
+
+    async def test_revision_suffix_kept(self, db_session: Session):
+        """A close revision (17P9905 vs 17P9905-LF) is a match — NOT dropped."""
+        import json
+
+        mock_broker = MagicMock()
+        mock_broker.publish = AsyncMock()
+        captured: dict = {}
+
+        def fake_dedup(scored, acc):
+            captured["scored"] = list(scored)
+            return ([], [])
+
+        conn = self._conn([{"mpn_matched": "17P9905-LF", "vendor_name": "BrokerCo"}])
+
+        with (
+            patch("app.search_service._build_connectors", return_value=([conn], {}, set())),
+            patch("app.services.sse_broker.broker", mock_broker),
+            patch("app.search_service._render_search_vendor_cards_html", return_value="<div></div>"),
+            patch("app.search_service._incremental_dedup", side_effect=fake_dedup),
+            patch("app.search_service._score_raw_hit", side_effect=lambda r, vm: r),
+        ):
+            await stream_search_mpn("test-relevance-002", "17P9905")
+
+        assert len(captured["scored"]) == 1
+        done = [c for c in mock_broker.publish.call_args_list if c[0][1] == "done"][0]
+        assert json.loads(done[0][2])["off_target"] == 0
+
+    async def test_missing_mpn_defaults_to_query_and_is_kept(self, db_session: Session):
+        """A hit with no mpn_matched defaults to the searched MPN and is kept."""
+        import json
+
+        mock_broker = MagicMock()
+        mock_broker.publish = AsyncMock()
+        captured: dict = {}
+
+        def fake_dedup(scored, acc):
+            captured["scored"] = list(scored)
+            return ([], [])
+
+        conn = self._conn([{"vendor_name": "BrokerCo", "qty_available": 5}])  # no mpn_matched
+
+        with (
+            patch("app.search_service._build_connectors", return_value=([conn], {}, set())),
+            patch("app.services.sse_broker.broker", mock_broker),
+            patch("app.search_service._render_search_vendor_cards_html", return_value="<div></div>"),
+            patch("app.search_service._incremental_dedup", side_effect=fake_dedup),
+            patch("app.search_service._score_raw_hit", side_effect=lambda r, vm: r),
+        ):
+            await stream_search_mpn("test-relevance-003", "17P9905")
+
+        assert len(captured["scored"]) == 1
+        assert captured["scored"][0]["mpn_matched"] == "17P9905"
+        done = [c for c in mock_broker.publish.call_args_list if c[0][1] == "done"][0]
+        assert json.loads(done[0][2])["off_target"] == 0
+
+    async def test_multiple_connectors_off_target_accumulates(self, db_session: Session):
+        """off_target sums across connectors; only on-target hits reach dedup."""
+        import json
+
+        mock_broker = MagicMock()
+        mock_broker.publish = AsyncMock()
+        scored_seen: list = []
+
+        def fake_dedup(scored, acc):
+            scored_seen.extend(scored)
+            return ([], [])
+
+        c1 = MagicMock()
+        c1.source_name = "brokerbin"
+        c1.search = AsyncMock(
+            return_value=[{"mpn_matched": "17P9905", "vendor_name": "A"}, {"mpn_matched": "WRONG1", "vendor_name": "B"}]
+        )
+        c2 = MagicMock()
+        c2.source_name = "mouser"
+        c2.search = AsyncMock(
+            return_value=[{"mpn_matched": "17P9905", "vendor_name": "C"}, {"mpn_matched": "WRONG2", "vendor_name": "D"}]
+        )
+
+        with (
+            patch("app.search_service._build_connectors", return_value=([c1, c2], {}, set())),
+            patch("app.services.sse_broker.broker", mock_broker),
+            patch("app.search_service._render_search_vendor_cards_html", return_value="<div></div>"),
+            patch("app.search_service._incremental_dedup", side_effect=fake_dedup),
+            patch("app.search_service._score_raw_hit", side_effect=lambda r, vm: r),
+        ):
+            await stream_search_mpn("test-relevance-multi", "17P9905")
+
+        assert len(scored_seen) == 2  # one on-target hit from each connector
+        assert {r["mpn_matched"] for r in scored_seen} == {"17P9905"}
+        done = [c for c in mock_broker.publish.call_args_list if c[0][1] == "done"][0]
+        assert json.loads(done[0][2])["off_target"] == 2  # one off-target from each connector
+
+    async def test_off_target_not_counted_on_error_path(self, db_session: Session):
+        """A crashed connector adds 0 to off_target (the guard runs only on success)."""
+        import json
+
+        mock_broker = MagicMock()
+        mock_broker.publish = AsyncMock()
+        c = MagicMock()
+        c.source_name = "brokerbin"
+        c.search = AsyncMock(side_effect=RuntimeError("API down"))
+
+        with (
+            patch("app.search_service._build_connectors", return_value=([c], {}, set())),
+            patch("app.services.sse_broker.broker", mock_broker),
+        ):
+            await stream_search_mpn("test-relevance-err", "17P9905")
+
+        done = [c for c in mock_broker.publish.call_args_list if c[0][1] == "done"][0]
+        assert json.loads(done[0][2])["off_target"] == 0


### PR DESCRIPTION
## Why
The Part Dossier (`/v2/search?mpn=`) had two reported problems:
1. **Look & feel** — the "Live market" section was a dark terminal (`bg-gray-900`) dropped into an otherwise light, brand-themed page.
2. **Live market blank/wrong** — for a broker-traded part (e.g. `17P9905`, a 450GB FC HDD) it showed nothing useful: the broker connectors that carry the listings are down (BrokerBin 401, Nexar quota, OEMSecrets 401, DigiKey rate-limit), and the only live connectors (Mouser/element14) returned an irrelevant fuzzy match on a **different** MPN (`1300940294`).

## What
1. **Re-skin** the Live market section to the light brand card used site-wide — `dossier_shell` (market section), `dossier_market`, `results_shell`, `vendor_card`, `shortlist_bar`, `requisition_picker_modal`, and `.source-badge--*` / `.source-chip--*` CSS (adds the missing `ebay`/`sourcengine` variants).
2. **Honest degraded state** — `get_market_source_health()` + `dossier_market_banner.html` render *"N of M live-market sources unavailable"* (per-source error on hover) with a Settings deep-link, instead of a mysteriously empty box. Best-effort: a health-lookup failure never breaks the section.
3. **Relevance guard** — `stream_search_mpn` keeps only hits whose `mpn_matched` `fuzzy_mpn_match()`es the searched part; off-target catalog noise is excluded before scoring/dedup/cache and footnoted via the `done` SSE event's `off_target`. Also fixes a **pre-existing asymmetry bug** in `fuzzy_mpn_match` (revision suffixes like `17P9905-LF` now match in both argument orders).

> ⚠️ The underlying *data* gap is operational: rotate the **BrokerBin** + **OEMSecrets** API keys and restore **Nexar** quota. Once valid, auto-recovery flips them live and the market populates. The new banner now states this on the page.

## Verification
- Full suite **17,002 pass**, 0 fail; new tests for the guard, the symmetry fix, `get_market_source_health`, and banner rendering.
- pre-commit clean (ruff / format / docformatter / mypy); Vite/Tailwind build compiles.
- 4-agent adversarial review run; all findings addressed.
- **Live-verified on staging**: light theme (0 dark classes), banner shows "4 of 6 live-market sources unavailable — BrokerBin, DigiKey, Nexar, OEMSecrets", and the relevance guard drops the `1300940294` noise (on-target rows: 0 for `17P9905`).
- `docs/APP_MAP_INTERACTIONS.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)