### PR TITLE
fix(proactive): scorecard display + buy-plan→CPH auto-feed design spec

### DIFF
--- a/app/templates/htmx/partials/proactive/scorecard.html
+++ b/app/templates/htmx/partials/proactive/scorecard.html
@@ -1,6 +1,7 @@
 {#
   scorecard.html — Proactive selling metrics panel.
-  Receives: stats (dict with total_sent, total_converted, conversion_rate, total_revenue).
+  Receives: stats (dict with total_sent, total_converted, conversion_rate, converted_revenue).
+           conversion_rate is already a whole-number percent (e.g. 33.3 → "33%").
   Called by: htmx_views.py proactive_scorecard route.
   Depends on: Tailwind CSS with brand palette.
 #}
@@ -22,11 +23,11 @@
     </div>
     <div class="bg-brand-50 rounded-lg p-3 text-center border border-brand-100">
       <p class="text-xs text-brand-600 font-medium mb-1">Conv. Rate</p>
-      <p class="text-2xl font-bold text-brand-700">{{ "%.0f%%"|format(stats.get('conversion_rate', 0) * 100) }}</p>
+      <p class="text-2xl font-bold text-brand-700">{{ "%.0f%%"|format(stats.get('conversion_rate', 0)) }}</p>
     </div>
     <div class="bg-gray-50 rounded-lg p-3 text-center border border-gray-200">
       <p class="text-xs text-gray-500 font-medium mb-1">Revenue</p>
-      <p class="text-2xl font-bold text-gray-900">${{ "{:,.0f}".format(stats.get('total_revenue', 0)) }}</p>
+      <p class="text-2xl font-bold text-gray-900">${{ "{:,.0f}".format(stats.get('converted_revenue', 0)) }}</p>
     </div>
   </div>
 </div>

--- a/docs/superpowers/specs/2026-06-17-proactive-buyplan-cph-feed-design.md
+++ b/docs/superpowers/specs/2026-06-17-proactive-buyplan-cph-feed-design.md
@@ -1,0 +1,193 @@
+# Proactive auto-feed: customer purchase history from buy-plan completion
+
+**Date:** 2026-06-17
+**Status:** Design — approved decisions locked, pending spec review
+**Author:** session with mkhoury
+
+## 1. Problem
+
+The Proactive tab is a proactive-selling cockpit: it watches incoming vendor stock
+(Offers) and surfaces *"a customer who bought this exact part before could buy it again —
+here's the margin."* Its entire matching backbone is `customer_part_history` (CPH).
+
+Today CPH only grows from two premature hooks — `_record_offer_won_history`
+(`source='avail_offer'`) and `_record_quote_won_history` (`source='avail_quote_won'`) —
+which fire when an offer/quote is *marked won*, before there is a confirmed customer PO.
+There is **no bulk or authoritative ingestion**, so on a fresh database CPH is empty, the
+tab shows nothing, and a rep who opens it once never returns. This is the single biggest
+blocker to adoption and to the "minimal updating" goal.
+
+**Key insight (from the business):** every fulfilled customer order closes through a
+**buy plan** that carries the customer PO number and the sales-order (SO) number, entered
+by buyers/salespeople as part of the normal workflow. Salesforce is being retired, so the
+buy plan is the authoritative system of record for "which customer bought which part."
+
+Therefore: record CPH automatically at **buy-plan completion**. The proactive backbone
+fills itself as a byproduct of work reps already do — zero extra effort.
+
+## 2. Locked decisions
+
+| Decision | Choice |
+|---|---|
+| System of record | **Buy plan** — every fulfilled order has one (+ SO#). |
+| Authoritative CPH source | New `source='buy_plan'`. **Retire** the `avail_offer` / `avail_quote_won` write hooks. |
+| Trigger | Buy plan → **COMPLETED** (`check_completion`); record only **VERIFIED** lines. |
+| Idempotency | New column `buy_plans_v3.purchase_history_recorded_at`. |
+| History | One-time idempotent **backfill** of existing COMPLETED plans. |
+| Engine | **Aggregate CPH per (company, card)** across sources so legacy + buy_plan rows are coherent and the newest history dominates. |
+| Responsiveness | On completion, immediately re-match live offers for the purchased parts (don't wait for the 4h scan). |
+
+## 3. Current-state facts (verified in code + live DB)
+
+- `check_completion` (`app/services/buyplan_workflow.py:314-339`) is the single
+  ACTIVE→COMPLETED transition. It already sets `plan.status=COMPLETED` and
+  `plan.completed_at`, and runs only once (guarded on `status==ACTIVE`). **No CPH call
+  exists here today** (grep-confirmed).
+- A buy-plan line resolves to a part via `line.requirement.material_card_id`, fallback
+  `line.offer.material_card_id` (`app/models/buy_plan.py:186-187,233-234`). The customer
+  resolves via `plan.requisition.customer_site.company_id`.
+- `line.unit_sell` is the price the customer paid (drives future margin math); `line.quantity`
+  is the qty; `line.status` VERIFIED vs CANCELLED distinguishes a real purchase.
+- `upsert_purchase(db, *, company_id, material_card_id, source, unit_price, quantity,
+  purchased_at, source_ref)` (`app/services/purchase_history_service.py`) is keyed on
+  `(company_id, material_card_id, source)`; on conflict it increments `purchase_count`,
+  updates rolling `avg_unit_price`, accumulates `total_quantity`.
+- `_find_matches` (`app/services/proactive_matching.py:142-310`) queries all CPH rows for
+  a card and **dedups by `company_id`, first row wins (unordered)** — so with multiple
+  sources per company the scored row is arbitrary. This is why aggregation is needed.
+- Live DB today: 6 buy plans (2 COMPLETED), all lines part-resolvable with `unit_sell` set
+  — backfill will produce real CPH immediately.
+
+## 4. Components
+
+### 4.1 `record_buyplan_purchase_history(plan, db)` — new
+Location: `app/services/purchase_history_service.py` (next to `upsert_purchase`).
+
+Behavior:
+1. If `plan.purchase_history_recorded_at` is set → return (idempotent no-op).
+2. Resolve `company_id` from `plan.requisition.customer_site.company_id`. If missing → log
+   warning, set the flag (so we don't retry forever), return.
+3. For each line with `status == VERIFIED`:
+   - Resolve `material_card_id` = `line.requirement.material_card_id` or
+     `line.offer.material_card_id`. If neither → log, skip line.
+   - `upsert_purchase(company_id=…, material_card_id=…, source="buy_plan",
+     unit_price=line.unit_sell, quantity=line.quantity,
+     purchased_at=plan.completed_at, source_ref=plan.sales_order_number)`.
+   - Collect the set of affected `material_card_id`s.
+4. Set `plan.purchase_history_recorded_at = now`, `db.flush()`.
+5. Call `refresh_matches_for_cards(affected_cards, db)` (4.4) — best-effort.
+
+Wrapped so any failure logs and never raises (completion must not break on a CPH error).
+
+### 4.2 Hook into completion
+In `check_completion`, immediately after `plan.status = COMPLETED` / `plan.completed_at`
+/ `case_report` are set, call `record_buyplan_purchase_history(plan, db)`.
+
+### 4.3 Migration — `buy_plans_v3.purchase_history_recorded_at`
+New nullable `UTCDateTime` column. Standard Alembic up/down (revision id ≤ 32 chars).
+Model: add the column to `BuyPlan` (`app/models/buy_plan.py`).
+
+### 4.4 Immediate match refresh — `refresh_matches_for_cards(card_ids, db)`
+For each affected card, find live offers (status active / not stale) and call
+`find_matches_for_offer(offer.id, db)` (bounded to the most recent N offers per card, N=5,
+to cap cost). The engine's existing dedup prevents duplicate matches. Best-effort; logged.
+Rationale: a purchased part we already hold stock for should surface a match *now*, not in
+up to 4 hours.
+
+### 4.5 Retire legacy CPH write hooks
+Remove the `upsert_purchase` calls (and the now-dead `_record_offer_won_history` /
+`_record_quote_won_history` helpers) from `app/routers/crm/offers.py` and
+`app/routers/crm/quotes.py`. Existing legacy CPH rows are left in place (harmless; handled
+by aggregation). Update/remove the corresponding tests.
+
+### 4.6 Engine aggregation — `_find_matches`
+Replace "dedup by company_id, first wins" with: group the card's CPH rows by `company_id`;
+per company aggregate `last_purchased_at = max`, `purchase_count = sum`,
+`avg_unit_price = count-weighted average`, `last_unit_price = the most-recent row's`. Score
+once per company from the aggregate. This makes multi-source history coherent and ensures
+the strongest/newest purchase signal drives the score.
+
+### 4.7 Backfill — `app/management/backfill_buyplan_cph.py`
+Walks `BuyPlan` where `status==COMPLETED` and `purchase_history_recorded_at IS NULL`,
+calls `record_buyplan_purchase_history` for each, prints a summary. Idempotent via the
+flag. Run once post-deploy: `docker compose exec app python -m app.management.backfill_buyplan_cph`.
+
+## 5. Data flow
+
+```
+buy plan lines all VERIFIED + SO approved
+        │  check_completion → status=COMPLETED, completed_at set
+        ▼
+record_buyplan_purchase_history(plan)
+        │  per VERIFIED line → upsert_purchase(source="buy_plan", unit_price=unit_sell, …)
+        │  set purchase_history_recorded_at
+        ▼
+refresh_matches_for_cards(affected)  → find_matches_for_offer for live stock
+        ▼
+ProactiveMatch rows appear on the account owner's Proactive tab
+(4h scan continues to handle newly-arriving offers independently)
+```
+
+## 6. Error handling & edge cases
+
+- CPH side effects never block completion (best-effort, logged) — mirrors today's hooks.
+- No customer_site/company on the requisition → skip, set flag, log.
+- Line with no resolvable card (requirement + offer both null/cardless) → skip line, log.
+- `unit_sell` is None → record purchase with `unit_price=None` (counts the purchase;
+  margin stays neutral until a priced purchase exists).
+- A completed plan later cancelled: **not** decremented (out of scope; completion is
+  terminal and purchases are effectively immutable). Documented, not handled.
+- Re-entrancy: `check_completion` transitions once; the flag guards backfill/any re-run.
+- Immediate refresh (4.4) matches the purchased part against **all** customers with CPH
+  for it — including the one who just bought, if we still hold stock. That is acceptable
+  (a legitimate "more available" reorder nudge) and the 21-day post-*send* throttle still
+  applies once an offer goes out. A "suppress recently-purchased customer" rule is **out
+  of scope** here; revisit in SP2 if it proves noisy.
+
+## 7. Testing (TDD — write first)
+
+1. Completing a plan records one CPH row per VERIFIED line with the right
+   company/card/`unit_price=unit_sell`/qty/`source="buy_plan"`/`source_ref=SO#`.
+2. CANCELLED lines are not recorded.
+3. Idempotent: calling the recorder twice does not double-count; flag is set.
+4. Part resolves via requirement; falls back to offer; unresolvable line skipped while
+   siblings still record.
+5. Missing company → no rows, flag set, warning logged.
+6. `refresh_matches_for_cards` creates a ProactiveMatch when a live offer + CPH owner exist.
+7. Offer-won / quote-won no longer write CPH (retired-hook regression).
+8. Engine aggregation: a company with two CPH rows (legacy + buy_plan) scores from the
+   aggregate (summed count, max date, weighted avg).
+9. Backfill records COMPLETED plans and is idempotent on re-run.
+10. Migration upgrade→downgrade→upgrade.
+
+## 8. Rollout
+
+1. Land migration + code behind tests; full suite green.
+2. Deploy (`./deploy.sh`).
+3. Run the backfill command once; verify CPH rows + that the Proactive tab reflects real
+   completed-deal history.
+4. Update `docs/APP_MAP_INTERACTIONS.md` (CPH now fed by buy-plan completion; legacy hooks
+   retired) and `docs/APP_MAP_DATABASE.md` (new column).
+
+## 9. Program roadmap (this is sub-project 1 of 4 — others out of scope here)
+
+The proactive tab drives revenue only when matches are **present** (this spec),
+**trustworthy**, reps are **prompted**, and ROI is **visible**:
+
+- **SP1 — Automated data feed (this spec).** Tab fills itself from buy-plan completion.
+- **SP2 — Rep workflow completeness.** Editable sell price on Prepare (service already
+  accepts `sell_prices`); a "do not offer" button (backend exists, no UI); fix the 7-day
+  visibility window vs 30-day status divergence so matches don't silently vanish.
+- **SP3 — Adoption & nudges.** Live nav badge (`hx-trigger="every Ns"`), a daily "new
+  proactive matches" digest/notification, and an onboarding empty-state.
+- **SP4 — Revenue visibility.** Surface the already-computed `gross_profit` /
+  `anticipated_revenue` / pipeline on the Scorecard; attribute won revenue back to
+  proactive offers.
+
+Each is its own spec → plan → implementation cycle.
+
+## 10. Out of scope
+
+SP2–SP4 above; any Salesforce/Acctivate importer (SFDC retiring; the buy-plan feed makes
+external purchase-history import unnecessary). The scorecard display bugs were already
+fixed and deployed separately (commit `0ab421a5`).

--- a/scripts/seed_proactive_demo.py
+++ b/scripts/seed_proactive_demo.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python
+"""Seed realistic TRIO-style demo data for the Proactive tab.
+
+What it does: builds a believable proactive-selling scenario for one salesperson —
+enterprise customers (data-center / server / storage buyers), their purchase history
+(customer_part_history), live vendor stock (offers) for the same parts, then runs the
+matching engine to mint ProactiveMatch rows, plus a few sent/converted ProactiveOffers
+so the Sent tab and Scorecard are non-empty.
+
+Called by: a human, manually, against the live DB —
+    docker compose exec app python scripts/seed_proactive_demo.py
+    docker compose exec app python scripts/seed_proactive_demo.py --wipe   # remove demo data
+
+Depends on: app.models, app.services.proactive_matching.find_matches_for_offer.
+Idempotent: re-running refreshes match created_at (keeps them inside the 7-day "new"
+window) without duplicating companies/parts/offers. All demo rows are tagged with the
+SEED_TAG marker so --wipe removes exactly what this script created and nothing else.
+
+NOTE: writes only CRM/offer/proactive rows. It never mutates MaterialCard category/specs
+(that must go through the F1 spec_tiers ladder), so created demo cards carry MPN only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from loguru import logger
+
+from app.database import SessionLocal
+from app.models import (
+    Company,
+    CustomerSite,
+    MaterialCard,
+    Offer,
+    Requisition,
+    SiteContact,
+    User,
+    VendorCard,
+)
+from app.models.intelligence import ProactiveMatch, ProactiveOffer, ProactiveThrottle
+from app.models.purchase_history import CustomerPartHistory
+from app.services.proactive_matching import find_matches_for_offer
+
+SEED_TAG = "PROACTIVE_DEMO_SEED"
+VIEWER_EMAIL = "mkhoury@trioscs.com"
+NOW = datetime.now(timezone.utc)
+
+
+def norm(mpn: str) -> str:
+    return re.sub(r"[^A-Z0-9]", "", mpn.upper())
+
+
+# ── Curated enterprise parts (display values drive the match rows) ──────────────
+# (key, display_mpn, manufacturer, description, our_cost, condition)
+PARTS = {
+    "P1": ("HMA82GR7CJR4N-XN", "SK Hynix", "16GB DDR4-3200 RDIMM 1Rx4 ECC Registered", 58.0, "New"),
+    "P2": ("M393A4K40DB3-CWE", "Samsung", "32GB DDR4-3200 RDIMM 2Rx4 ECC Registered", 72.0, "New"),
+    "P3": ("SSDPEDME800G401", "Intel", "DC P3700 800GB NVMe PCIe 3.0 HHHL SSD", 210.0, "New"),
+    "P4": ("MZQL23T8HCLS-00A07", "Samsung", "PM9A3 3.84TB U.2 NVMe Enterprise SSD", 295.0, "New"),
+    "P5": ("WUH722222ALE6L4", "Western Digital", "Ultrastar DC HC570 22TB SATA 3.5in HDD", 290.0, "New"),
+    "P6": ("ST16000NM001G", "Seagate", "Exos X16 16TB SATA 7200RPM 3.5in HDD", 175.0, "New"),
+    "P7": ("X710-DA2", "Intel", "Ethernet Converged Network Adapter Dual SFP+", 180.0, "New"),
+    "P8": ("MCX516A-CCAT", "NVIDIA Mellanox", "ConnectX-5 EN 100GbE Dual QSFP28 NIC", 405.0, "New"),
+    "P9": ("SRF7J", "Intel", "Xeon Gold 6248R 24-Core 3.0GHz Processor", 820.0, "Refurbished"),
+    "P10": ("UCS-MR-X32G2RW", "Cisco", "32GB DDR4-3200 RDIMM (Cisco UCS)", 76.0, "New"),
+}
+
+# ── Vendors offering the stock (some get a VendorCard for the reliability badge) ─
+# (key, vendor_name, qty, vendor_card: None | ("trusted", score) | ("unreliable", ghost_rate))
+VENDOR_OF = {
+    "P1": ("Avnet", 1200, ("trusted", 88.0)),
+    "P2": ("TD SYNNEX", 800, None),
+    "P3": ("Arrow Electronics", 240, ("trusted", 82.0)),
+    "P4": ("Flagship Technologies", 150, None),
+    "P5": ("ServerSupply", 320, None),
+    "P6": ("Stordis", 500, None),
+    "P7": ("Arrow Electronics", 600, ("trusted", 82.0)),
+    "P8": ("Apex Brokers", 90, ("unreliable", 0.42)),
+    "P9": ("ServerMonkey", 60, None),
+    "P10": ("ASI Corp", 400, None),
+}
+
+# ── Customers (TRIO-style fictional buyers) + their contacts ────────────────────
+# name, site_name, city, state, [(full_name, title, email, is_primary)]
+CUSTOMERS = {
+    "cascade": (
+        "Cascade Data Systems",
+        "Cascade DC-1",
+        "Hillsboro",
+        "OR",
+        [
+            ("Priya Nair", "Procurement Manager", "priya.nair@cascadedata.example", True),
+            ("Tom Reyes", "Hardware Buyer", "tom.reyes@cascadedata.example", False),
+        ],
+    ),
+    "northwind": (
+        "Northwind Server Solutions",
+        "Northwind HQ",
+        "Eden Prairie",
+        "MN",
+        [("Greg Olsen", "Senior Buyer", "greg.olsen@northwindservers.example", True)],
+    ),
+    "meridian": (
+        "Meridian Cloud Infrastructure",
+        "Meridian East",
+        "Ashburn",
+        "VA",
+        [
+            ("Dana Whitfield", "Supply Chain Lead", "dana.whitfield@meridiancloud.example", True),
+            ("Luis Ortega", "Component Buyer", "luis.ortega@meridiancloud.example", False),
+        ],
+    ),
+    "atlas": (
+        "Atlas Storage Networks",
+        "Atlas West",
+        "Fremont",
+        "CA",
+        [("Karen Liu", "Procurement Specialist", "karen.liu@atlasstorage.example", True)],
+    ),
+    "helix": (
+        "Helix Semiconductor Trading",
+        "Helix HQ",
+        "Plano",
+        "TX",
+        [("Sam Becker", "Senior Trader", "sam.becker@helixsemi.example", True)],
+    ),
+}
+
+# ── Purchase history matrix: customer -> [(part, count, days_ago, markup, last_qty, total_qty)]
+#    markup = avg_unit_price / our_cost  → margin% = (1 - 1/markup) * 100
+PURCHASES = {
+    "cascade": [
+        ("P1", 5, 45, 1.45, 600, 3000),
+        ("P3", 3, 90, 1.30, 120, 360),
+        ("P5", 2, 200, 1.20, 100, 200),
+        ("P6", 4, 120, 1.55, 250, 1000),
+    ],
+    "northwind": [("P2", 6, 30, 1.50, 400, 2400), ("P9", 2, 300, 1.25, 24, 48), ("P10", 3, 75, 1.35, 200, 600)],
+    "meridian": [
+        ("P4", 4, 60, 1.40, 80, 320),
+        ("P8", 3, 110, 1.60, 40, 120),
+        ("P7", 5, 40, 1.30, 300, 1500),
+        ("P1", 2, 210, 1.18, 200, 400),
+    ],
+    "atlas": [("P5", 6, 25, 1.50, 300, 1800), ("P6", 3, 150, 1.35, 150, 450), ("P4", 2, 220, 1.22, 40, 80)],
+    "helix": [
+        ("P2", 8, 20, 1.28, 500, 4000),
+        ("P9", 4, 95, 1.45, 48, 192),
+        ("P10", 5, 55, 1.33, 250, 1250),
+        ("P8", 2, 260, 1.30, 20, 40),
+    ],
+}
+
+# ── Sent / converted offers for the Sent tab + Scorecard ────────────────────────
+# (customer_key, status, days_ago, [(part, qty, markup)])
+SENT_OFFERS = [
+    ("cascade", "converted", 12, [("P6", 250, 1.55), ("P1", 300, 1.45)]),
+    ("helix", "converted", 9, [("P2", 500, 1.28)]),
+    ("northwind", "sent", 6, [("P10", 200, 1.35), ("P9", 24, 1.25)]),
+    ("meridian", "sent", 4, [("P7", 300, 1.30)]),
+    ("atlas", "sent", 3, [("P5", 300, 1.50)]),
+    ("cascade", "sent", 2, [("P3", 120, 1.30)]),
+]
+
+
+def get_or_create_card(db, key) -> MaterialCard:
+    display, mfr, desc, cost, cond = PARTS[key]
+    nm = norm(display)
+    card = (
+        db.query(MaterialCard)
+        .filter((MaterialCard.normalized_mpn == nm) | (MaterialCard.display_mpn == display))
+        .first()
+    )
+    if card:
+        return card
+    card = MaterialCard(normalized_mpn=nm, display_mpn=display)
+    db.add(card)
+    db.flush()
+    logger.info(f"  created demo card {display} (id={card.id})")
+    return card
+
+
+def get_or_create_vendor_card(db, vendor_name, kind):
+    nn = vendor_name.lower().strip()
+    vc = db.query(VendorCard).filter(VendorCard.normalized_name == nn).first()
+    if not vc:
+        vc = VendorCard(normalized_name=nn, display_name=vendor_name)
+        db.add(vc)
+    if kind:
+        flavor, val = kind
+        if flavor == "trusted":
+            vc.vendor_score = val
+            vc.ghost_rate = 0.05
+            vc.total_wins = 18
+            vc.overall_win_rate = 0.46
+        else:
+            vc.vendor_score = 35.0
+            vc.ghost_rate = val
+            vc.total_wins = 1
+            vc.overall_win_rate = 0.06
+    db.flush()
+    return vc
+
+
+def wipe(db, viewer):
+    """Remove exactly the demo data this script created."""
+    company_ids = [c.id for c in db.query(Company.id).filter(Company.name.in_([v[0] for v in CUSTOMERS.values()]))]
+    site_ids = (
+        [s.id for s in db.query(CustomerSite.id).filter(CustomerSite.company_id.in_(company_ids))]
+        if company_ids
+        else []
+    )
+    n_pm = (
+        db.query(ProactiveMatch).filter(ProactiveMatch.company_id.in_(company_ids)).delete(synchronize_session=False)
+        if company_ids
+        else 0
+    )
+    n_po = (
+        db.query(ProactiveOffer)
+        .filter(ProactiveOffer.graph_message_id.like(f"{SEED_TAG}%"))
+        .delete(synchronize_session=False)
+    )
+    if site_ids:
+        db.query(ProactiveThrottle).filter(ProactiveThrottle.customer_site_id.in_(site_ids)).delete(
+            synchronize_session=False
+        )
+    n_off = db.query(Offer).filter(Offer.source == SEED_TAG).delete(synchronize_session=False)
+    n_cph = (
+        db.query(CustomerPartHistory)
+        .filter(CustomerPartHistory.company_id.in_(company_ids))
+        .delete(synchronize_session=False)
+        if company_ids
+        else 0
+    )
+    if site_ids:
+        db.query(SiteContact).filter(SiteContact.customer_site_id.in_(site_ids)).delete(synchronize_session=False)
+    db.query(Requisition).filter(Requisition.name == f"AVAIL Vendor Stock — {SEED_TAG}").delete(
+        synchronize_session=False
+    )
+    if site_ids:
+        db.query(CustomerSite).filter(CustomerSite.id.in_(site_ids)).delete(synchronize_session=False)
+    if company_ids:
+        db.query(Company).filter(Company.id.in_(company_ids)).delete(synchronize_session=False)
+    db.commit()
+    logger.info(
+        f"WIPED demo data: {n_pm} matches, {n_po} sent-offers, {n_off} offers, {n_cph} CPH, "
+        f"{len(site_ids)} sites, {len(company_ids)} companies"
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--wipe", action="store_true", help="remove demo data and exit")
+    ap.add_argument("--viewer", default=VIEWER_EMAIL, help="salesperson email who will view the tab")
+    args = ap.parse_args()
+
+    db = SessionLocal()
+    viewer = db.query(User).filter(User.email == args.viewer).first()
+    if not viewer:
+        logger.error(f"viewer {args.viewer!r} not found — aborting")
+        sys.exit(1)
+    logger.info(f"viewer = {viewer.email} (id={viewer.id})")
+
+    if args.wipe:
+        wipe(db, viewer)
+        return
+
+    # 1. Cards + vendor cards
+    cards = {k: get_or_create_card(db, k) for k in PARTS}
+    vcards = {k: get_or_create_vendor_card(db, VENDOR_OF[k][0], VENDOR_OF[k][2]) for k in PARTS}
+
+    # 2. Holding requisition for the vendor offers (FK container only)
+    holding = db.query(Requisition).filter(Requisition.name == f"AVAIL Vendor Stock — {SEED_TAG}").first()
+    if not holding:
+        holding = Requisition(name=f"AVAIL Vendor Stock — {SEED_TAG}", status="archived", created_by=viewer.id)
+        db.add(holding)
+        db.flush()
+
+    # 3. Companies + sites + contacts (owned by viewer)
+    companies, sites = {}, {}
+    for key, (name, site_name, city, state, contacts) in CUSTOMERS.items():
+        co = db.query(Company).filter(Company.name == name).first()
+        if not co:
+            co = Company(name=name)
+            db.add(co)
+        co.is_active = True
+        co.account_owner_id = viewer.id
+        db.flush()
+        companies[key] = co
+        site = (
+            db.query(CustomerSite).filter(CustomerSite.company_id == co.id, CustomerSite.site_name == site_name).first()
+        )
+        if not site:
+            site = CustomerSite(company_id=co.id, site_name=site_name)
+            db.add(site)
+        site.is_active = True
+        site.city, site.state, site.country = city, state, "USA"
+        db.flush()
+        sites[key] = site
+        for full_name, title, email, primary in contacts:
+            sc = (
+                db.query(SiteContact)
+                .filter(SiteContact.customer_site_id == site.id, SiteContact.email == email)
+                .first()
+            )
+            if not sc:
+                sc = SiteContact(customer_site_id=site.id, full_name=full_name, email=email)
+                db.add(sc)
+            sc.title, sc.is_primary, sc.is_active = title, primary, True
+            db.flush()
+
+    # 4. Purchase history (CPH)
+    for ckey, rows in PURCHASES.items():
+        co = companies[ckey]
+        for pkey, count, days_ago, markup, last_qty, total_qty in rows:
+            card = cards[pkey]
+            cost = PARTS[pkey][3]
+            avg = round(cost * markup, 2)
+            cph = (
+                db.query(CustomerPartHistory)
+                .filter(
+                    CustomerPartHistory.company_id == co.id,
+                    CustomerPartHistory.material_card_id == card.id,
+                    CustomerPartHistory.source == "demo_seed",
+                )
+                .first()
+            )
+            if not cph:
+                cph = CustomerPartHistory(
+                    company_id=co.id, material_card_id=card.id, mpn=PARTS[pkey][0], source="demo_seed"
+                )
+                db.add(cph)
+            cph.purchase_count = count
+            cph.last_purchased_at = NOW - timedelta(days=days_ago)
+            cph.avg_unit_price = Decimal(str(avg))
+            cph.last_unit_price = Decimal(str(avg))
+            cph.last_quantity = last_qty
+            cph.total_quantity = total_qty
+            db.flush()
+
+    # 5. Vendor offers (one per part) — refresh created_at each run
+    offers = {}
+    for pkey, (display, mfr, desc, cost, cond) in PARTS.items():
+        vname, qty, _ = VENDOR_OF[pkey]
+        off = db.query(Offer).filter(Offer.material_card_id == cards[pkey].id, Offer.source == SEED_TAG).first()
+        if not off:
+            off = Offer(requisition_id=holding.id, material_card_id=cards[pkey].id, source=SEED_TAG)
+            db.add(off)
+        off.vendor_name = vname
+        off.vendor_card_id = vcards[pkey].id
+        off.mpn = display
+        off.manufacturer = mfr
+        off.qty_available = qty
+        off.unit_price = Decimal(str(cost))
+        off.currency = "USD"
+        off.condition = cond
+        off.warranty = "90 days"
+        off.lead_time = "In stock"
+        off.country_of_origin = "US"
+        off.status = "active"
+        off.entered_by_id = viewer.id
+        off.created_at = NOW
+        db.flush()
+        offers[pkey] = off
+
+    # 6. Clear prior demo matches/throttle for these companies, then regenerate fresh
+    company_ids = [c.id for c in companies.values()]
+    site_ids = [s.id for s in sites.values()]
+    db.query(ProactiveMatch).filter(ProactiveMatch.company_id.in_(company_ids)).delete(synchronize_session=False)
+    db.query(ProactiveThrottle).filter(ProactiveThrottle.customer_site_id.in_(site_ids)).delete(
+        synchronize_session=False
+    )
+    db.flush()
+    total_matches = 0
+    for pkey, off in offers.items():
+        total_matches += len(find_matches_for_offer(off.id, db))
+    db.commit()
+
+    # 7. Sent / converted ProactiveOffers (Sent tab + Scorecard)
+    db.query(ProactiveOffer).filter(ProactiveOffer.graph_message_id.like(f"{SEED_TAG}%")).delete(
+        synchronize_session=False
+    )
+    db.flush()
+    for i, (ckey, status, days_ago, lines) in enumerate(SENT_OFFERS):
+        site = sites[ckey]
+        contacts = db.query(SiteContact).filter(SiteContact.customer_site_id == site.id).all()
+        emails = [c.email for c in contacts if c.email]
+        line_items, total_sell, total_cost = [], 0.0, 0.0
+        for pkey, qty, markup in lines:
+            cost = PARTS[pkey][3]
+            sell = round(cost * markup, 2)
+            line_items.append(
+                {"mpn": PARTS[pkey][0], "vendor_name": VENDOR_OF[pkey][0], "qty": qty, "cost": cost, "sell": sell}
+            )
+            total_sell += sell * qty
+            total_cost += cost * qty
+        po = ProactiveOffer(
+            customer_site_id=site.id,
+            salesperson_id=viewer.id,
+            line_items=line_items,
+            recipient_emails=emails,
+            recipient_contact_ids=[c.id for c in contacts],
+            subject=f"Parts Available — {companies[ckey].name}",
+            status=status,
+            total_sell=round(total_sell, 2),
+            total_cost=round(total_cost, 2),
+            sent_at=NOW - timedelta(days=days_ago),
+            graph_message_id=f"{SEED_TAG}-{i}",
+        )
+        if status == "converted":
+            po.converted_at = NOW - timedelta(days=days_ago - 1)
+        db.add(po)
+    db.commit()
+
+    # 8. Summary
+    n_new = (
+        db.query(ProactiveMatch)
+        .filter(ProactiveMatch.company_id.in_(company_ids), ProactiveMatch.status == "new")
+        .count()
+    )
+    n_sent = (
+        db.query(ProactiveOffer)
+        .filter(ProactiveOffer.salesperson_id == viewer.id, ProactiveOffer.graph_message_id.like(f"{SEED_TAG}%"))
+        .count()
+    )
+    n_conv = (
+        db.query(ProactiveOffer)
+        .filter(
+            ProactiveOffer.salesperson_id == viewer.id,
+            ProactiveOffer.graph_message_id.like(f"{SEED_TAG}%"),
+            ProactiveOffer.status == "converted",
+        )
+        .count()
+    )
+    logger.info("─" * 60)
+    logger.info(f"DONE. {len(companies)} customers, {len(PARTS)} parts, {total_matches} matches generated")
+    logger.info(f"  Matches tab (status=new): {n_new}")
+    logger.info(f"  Sent tab: {n_sent} offers ({n_conv} converted)")
+    logger.info(
+        f"  Scorecard: sent={n_sent} converted={n_conv} conv_rate={round(n_conv / n_sent * 100, 1) if n_sent else 0}%"
+    )
+    logger.info(f"  All visible to: {viewer.email} (id={viewer.id})")
+    db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_proactive_scorecard_render.py
+++ b/tests/test_proactive_scorecard_render.py
@@ -1,0 +1,55 @@
+"""Regression tests for the proactive Scorecard panel rendering.
+
+Guards the data-contract between get_scorecard() (proactive_service) and the
+scorecard.html template: conversion_rate is already a whole-number percent (must
+NOT be multiplied by 100 again), and the revenue card reads converted_revenue
+(the key the service actually returns) — not the never-set total_revenue.
+
+Called by: pytest. Depends on: app.template_env.templates, app.services.proactive_service.
+"""
+
+from app.template_env import templates
+
+
+def _render(stats: dict) -> str:
+    return templates.get_template("htmx/partials/proactive/scorecard.html").render(stats=stats)
+
+
+def test_conversion_rate_not_multiplied_by_100():
+    """A 33.3% rate (already a percent) must render as '33%', never '3330%'."""
+    html = _render({"total_sent": 6, "total_converted": 2, "conversion_rate": 33.3, "converted_revenue": 0})
+    assert "33%" in html
+    assert "3330%" not in html
+
+
+def test_revenue_reads_converted_revenue_key():
+    """Revenue card must read converted_revenue, not the never-set total_revenue."""
+    html = _render({"total_sent": 6, "total_converted": 2, "conversion_rate": 33.3, "converted_revenue": 139122.5})
+    assert "$139,122" in html  # rounded, thousands-separated
+    # The old buggy key being absent must not silently render $0.
+    assert "$0" not in html
+
+
+def test_revenue_defaults_to_zero_when_no_converted_revenue():
+    """With no converted revenue the card shows $0 (not a KeyError)."""
+    html = _render({"total_sent": 3, "total_converted": 0, "conversion_rate": 0, "converted_revenue": 0})
+    assert "$0" in html
+    assert "0%" in html
+
+
+def test_scorecard_matches_service_contract():
+    """Render directly from a get_scorecard-shaped dict to keep the contract honest."""
+    # Shape mirrors proactive_service.get_scorecard() return value.
+    stats = {
+        "total_sent": 6,
+        "total_converted": 2,
+        "total_quoted": 0,
+        "total_po": 0,
+        "conversion_rate": 33.3,
+        "anticipated_revenue": 278580.0,
+        "converted_revenue": 139122.5,
+        "gross_profit": 41972.5,
+    }
+    html = _render(stats)
+    assert "33%" in html and "3330%" not in html
+    assert "$139,122" in html


### PR DESCRIPTION
## Summary
Proactive-tab work session. Two things land here; a third (the buy-plan→CPH auto-feed) is **design-only** in this PR.

### 1. Scorecard display fix (already deployed to staging — build `0ab421a5-...`)
`app/templates/htmx/partials/proactive/scorecard.html` had two data-contract bugs vs `get_scorecard()`:
- **Conversion rate ×100** — `conversion_rate` is already a whole-number percent, but the template multiplied by 100 again (a 33% rate rendered as **3330%**).
- **Revenue always $0** — template read a `total_revenue` key the service never returns; it returns `converted_revenue`.

Fixed both; added `tests/test_proactive_scorecard_render.py` (4 tests) guarding the render contract. Live now shows **33% / $139,122**.

### 2. Demo seed tool
`scripts/seed_proactive_demo.py` — idempotent, re-runnable (`--wipe`) TRIO-style demo data for the Proactive tab (5 enterprise customers, real catalog parts, purchase history, vendor stock, 18 matches + 6 sent/2 converted offers), owned by the viewing salesperson. For testing/demos.

### 3. Design spec (no code)
`docs/superpowers/specs/2026-06-17-proactive-buyplan-cph-feed-design.md` — auto-feed `customer_part_history` at buy-plan **COMPLETED** so the proactive backbone fills itself from the work reps already do (buyers/salespeople enter customer PO# + SO#). SFDC is being retired, so this replaces any external purchase-history import. Implementation will follow in a separate PR.

## Test plan
- `pytest tests/test_proactive_scorecard_render.py tests/test_routers_proactive.py tests/test_proactive_service.py tests/test_proactive_prepare.py` → 81 pass.
- pre-commit (ruff/format/mypy) + static-analysis guards green.
- Scorecard verified live as the seeded salesperson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)