### PR TITLE
feat(nav): rename 'Reqs' nav label to 'Sales Hub'

### DIFF
--- a/app/templates/htmx/partials/requisitions/detail.html
+++ b/app/templates/htmx/partials/requisitions/detail.html
@@ -16,7 +16,7 @@
     <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
     </svg>
-    Requisitions
+    Sales Hub
   </a>
 
   {# Header card — inline editable, swappable via #req-header #}

--- a/app/templates/htmx/partials/shared/mobile_nav.html
+++ b/app/templates/htmx/partials/shared/mobile_nav.html
@@ -22,7 +22,7 @@
      aria-label="Main navigation">
   <div class="flex items-stretch justify-center mx-auto max-w-[720px]">
     {% set nav_items = [
-      ('requisitions', 'Reqs', '/v2/requisitions', '/v2/partials/parts/workspace',
+      ('requisitions', 'Sales Hub', '/v2/requisitions', '/v2/partials/parts/workspace',
        'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2'),
       ('sightings', 'Sightings', '/v2/sightings', '/v2/partials/sightings/workspace',
        'M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z'),

--- a/tests/e2e/test_app_deep.py
+++ b/tests/e2e/test_app_deep.py
@@ -42,7 +42,7 @@ def nav_click(page: Page, href: str):
 
 # Navigation map: (href, label text)
 NAV_ITEMS = [
-    ("/v2/requisitions", "Reqs"),
+    ("/v2/requisitions", "Sales Hub"),
     ("/v2/search", "Search"),
     ("/v2/buy-plans", "Buys"),
     ("/v2/vendors", "Vendors"),


### PR DESCRIPTION
## Rename "Reqs" nav → "Sales Hub"

Renames the user-facing bottom-nav label for `/v2/requisitions` from **Reqs** to **Sales Hub**, and the matching "← back to section" link on the requisition detail page.

### Changed
- `mobile_nav.html` — nav label `'Reqs'` → `'Sales Hub'`
- `requisitions/detail.html` — back-link text `Requisitions` → `Sales Hub`
- `tests/e2e/test_app_deep.py` — nav-label assertion updated

### Intentionally unchanged
- Nav **id** (`requisitions`) and route (`/v2/requisitions`) — so active-state highlighting and all links keep working.
- Domain terminology: the `requisition` object, the "New Requisition" action, "open requisitions" counts, model/route names.

### Tests
`tests/test_requisitions2_routes.py` + `tests/test_browser_back_navigation.py` — 91 passed. (e2e assertion updated to match; e2e is excluded from the default suite.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
