### PR TITLE
fix(reqs-panel): drop redundant Urgency cell from detail metadata grid

### DIFF
--- a/app/templates/requisitions2/_detail_panel.html
+++ b/app/templates/requisitions2/_detail_panel.html
@@ -66,6 +66,8 @@
   </div>
 
   {# ── Metadata grid ──────────────────────────────────────────── #}
+  {# Urgency is intentionally absent here — it's surfaced once via the header pill
+     above (showing only when it's non-normal); a grid cell would duplicate it. #}
   <div class="grid grid-cols-3 gap-x-4 gap-y-2 px-5 py-3 border-b border-gray-200 text-sm flex-shrink-0">
     <div>
       <dt class="text-xs font-medium text-gray-400 uppercase">Owner</dt>
@@ -76,20 +78,16 @@
       <dd class="text-gray-900 mt-0.5">{{ req.requirement_count }}</dd>
     </div>
     <div>
+      <dt class="text-xs font-medium text-gray-400 uppercase">Offers</dt>
+      <dd class="text-gray-900 mt-0.5">{{ req.offer_count or 0 }}</dd>
+    </div>
+    <div>
       <dt class="text-xs font-medium text-gray-400 uppercase">Deadline</dt>
       <dd class="text-gray-900 mt-0.5">{{ req.deadline or '—' }}</dd>
     </div>
     <div>
       <dt class="text-xs font-medium text-gray-400 uppercase">Created</dt>
       <dd class="text-gray-900 mt-0.5">{{ req.created_at.strftime('%Y-%m-%d') if req.created_at else '—' }}</dd>
-    </div>
-    <div>
-      <dt class="text-xs font-medium text-gray-400 uppercase">Urgency</dt>
-      <dd class="text-gray-900 mt-0.5">{{ req.urgency or 'normal' }}</dd>
-    </div>
-    <div>
-      <dt class="text-xs font-medium text-gray-400 uppercase">Offers</dt>
-      <dd class="text-gray-900 mt-0.5">{{ req.offer_count or 0 }}</dd>
     </div>
   </div>
 

--- a/tests/test_panel_column_alignment.py
+++ b/tests/test_panel_column_alignment.py
@@ -216,6 +216,18 @@ class TestReqsDetailTabs:
         detail = get_requisition_detail(db_session, test_requisition.id, test_user.id, "buyer")
         assert detail["req"]["offer_count"] == 2
 
+    def test_urgency_not_duplicated_in_metadata_grid(
+        self, client: TestClient, db_session: Session, test_requisition: Requisition
+    ):
+        """Urgency is surfaced once via the header pill — it must NOT also appear as a
+        redundant metadata-grid field (the grid <dt>Urgency</dt> cell is removed)."""
+        test_requisition.urgency = "critical"
+        db_session.commit()
+        resp = client.get(f"/requisitions2/{test_requisition.id}/detail")
+        assert resp.status_code == 200
+        assert ">Urgency</dt>" not in resp.text  # no redundant grid label
+        assert "critical" in resp.text  # still surfaced via the header pill
+
     def test_lazy_tabs_enforce_ownership_for_sales(
         self, client: TestClient, sales_user: User, test_requisition: Requisition
     ):


### PR DESCRIPTION
## Why
Follow-up to #345. The requisitions2 detail panel showed **Urgency twice** — as the header pill (when non-normal) and again as a metadata-grid field. Approved cleanup.

## What
Remove the redundant Urgency cell from the metadata grid; the header pill is the single home for urgency (and it only shows when urgency is non-normal, so "normal" noise is gone too). Grid reorders to a clean **Owner · Parts · Offers / Deadline · Created**.

## Note on the second flagged item (no change)
The other flagged item — "reqs list Status column is a bare dot" — was a **misread on my part**: `status_dot` already renders `<span class="opp-status-label">{{ label }}</span>`, so the Status column already shows **dot + label** (e.g. "● Sourcing"). Verified against the existing `test_opp_macros.py` assertions; no change made.

## Tests
- New guard `test_urgency_not_duplicated_in_metadata_grid` (TDD red→green).
- Full suite: **16,950 passed**. Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwpL91Zg37qaSLhsNV1S8P