### PR TITLE
fix(test): update stale do-not-offer assertions to SP2 hidden-row behavior

### DIFF
--- a/tests/test_htmx_views_nightly11.py
+++ b/tests/test_htmx_views_nightly11.py
@@ -478,7 +478,8 @@ class TestProactiveDoNotOffer:
             data={"mpn": "LM317T", "company_id": str(test_company.id)},
         )
         assert resp.status_code == 200
-        assert "Suppressed" in resp.text
+        # SP2: do-not-offer returns a collapsed/hidden row (htmx removal), not a "Suppressed" message
+        assert "display:none" in resp.text
         rec = db_session.query(ProactiveDoNotOffer).filter_by(company_id=test_company.id).first()
         assert rec is not None
         assert rec.mpn == "LM317T"

--- a/tests/test_sprint8_proactive.py
+++ b/tests/test_sprint8_proactive.py
@@ -129,7 +129,8 @@ class TestDoNotOffer:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "Suppressed" in resp.text
+        # SP2: do-not-offer returns a collapsed/hidden row (htmx removal), not a "Suppressed" message
+        assert "display:none" in resp.text
 
     def test_suppress_missing_fields(self, client: TestClient):
         resp = client.post(


### PR DESCRIPTION
## Fix stale do-not-offer tests (un-red main)

Two proactive **do-not-offer** tests were failing on `main` (pre-existing, not from any open feature branch):

```
assert 'Suppressed' in '<tr style="display:none" aria-hidden="true"></tr>'
```

**Root cause:** SP2 (`feat(proactive): SP2 workflow trust — DNO button`) changed `POST /v2/partials/proactive/do-not-offer` to create the `ProactiveDoNotOffer` record and return a **collapsed/hidden htmx removal row** (so the row disappears from the proactive table) — the endpoint has *no* "Suppressed" text path. The two tests still asserted the old copy, so they went red when SP2 merged.

**Fix (test-only):** assert the real behavior — the `ProactiveDoNotOffer` record is created (already checked in one test) and the response is the collapsed row (`display:none`). No production code changed.

Verified: both tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
