### PR TITLE
fix(webhook): keep Graph subscription on transient failure (only delete on 404/410)

### DIFF
--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -28,6 +28,11 @@ from app.models import ActivityLog, GraphSubscription, User
 
 # Graph webhook subscriptions for mail expire after max 3 days (4230 min)
 SUBSCRIPTION_LIFETIME_HOURS = 70  # ~3 days, renew before expiry
+
+# HTTP status codes returned by GraphClient.patch_json that confirm the
+# subscription is definitively gone on the server side. Any other error code
+# (e.g. 401, 503) or the string "max_retries" is treated as transient.
+_SUBSCRIPTION_GONE_STATUSES = {404, 410}
 RENEW_BUFFER_HOURS = 6  # renew when less than 6h remaining
 
 # Replay protection: reject duplicate notifications within this window
@@ -197,13 +202,24 @@ async def renew_subscription(sub: GraphSubscription, db: Session) -> bool:
             f"/subscriptions/{sub.subscription_id}",
             {"expirationDateTime": new_expiration.strftime("%Y-%m-%dT%H:%M:%S.0000000Z")},
         )
-        if "error" in result:
-            raise RuntimeError(result.get("detail") or f"Graph error {result.get('error')}")
     except Exception as e:
-        logger.error(f"Failed to renew subscription {sub.subscription_id}: {e}")
-        # Subscription may have expired — delete and let scheduler recreate
-        db.delete(sub)
-        db.commit()
+        # Network/timeout error — Graph has not confirmed the subscription is gone.
+        # Keep the record so the next renewal cycle can retry.
+        logger.warning(f"Transient error renewing subscription {sub.subscription_id}: {e}")
+        return False
+
+    if "error" in result:
+        error_code = result.get("error")
+        if error_code in _SUBSCRIPTION_GONE_STATUSES:
+            # Graph confirmed the subscription no longer exists (404/410).
+            # Delete our record so the scheduler recreates it.
+            logger.warning(f"Subscription {sub.subscription_id} is gone (Graph {error_code}), removing record")
+            db.delete(sub)
+            db.commit()
+        else:
+            # Transient or auth error (e.g. 401, 503, "max_retries").
+            # Keep the subscription — next renewal cycle will retry.
+            logger.warning(f"Transient Graph error renewing subscription {sub.subscription_id}: {error_code}")
         return False
 
     sub.expiration_dt = new_expiration

--- a/tests/test_renew_subscription_resilience.py
+++ b/tests/test_renew_subscription_resilience.py
@@ -1,0 +1,259 @@
+"""tests/test_renew_subscription_resilience.py — TDD tests for resilient
+renew_subscription.
+
+Contract being implemented:
+- 404 or 410 from Graph → subscription is genuinely gone → delete it, return False
+- Any other error code (401, 503, etc.) or "max_retries" → transient → keep sub, return False
+- Raised exception (network/timeout) → transient → keep sub, return False
+- Success (no "error" key) → advance expiration_dt, return True
+
+These tests were written BEFORE the fix so they initially FAIL against the old code
+(which deletes on ANY failure). After the fix they go GREEN.
+
+Called by: pytest
+Depends on: app/services/webhook_service.py
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.models import GraphSubscription
+
+_PATCH_GET_TOKEN = "app.scheduler.get_valid_token"
+_PATCH_GRAPH_CLIENT = "app.utils.graph_client.GraphClient"
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _make_subscription(db, user, sub_id="sub-resilience-001", client_state="state-test"):
+    sub = GraphSubscription(
+        user_id=user.id,
+        subscription_id=sub_id,
+        resource="/me/messages",
+        change_type="created",
+        expiration_dt=datetime.now(timezone.utc) + timedelta(hours=48),
+        client_state=client_state,
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+    return sub
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  Transient errors — subscription MUST be kept
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestRenewTransientErrors:
+    """Graph returns an error code that is NOT 404/410 → keep the subscription."""
+
+    def test_503_keeps_subscription(self, db_session, test_user):
+        """HTTP 503 from Graph is transient — subscription row must NOT be deleted."""
+        from app.services.webhook_service import renew_subscription
+
+        sub = _make_subscription(db_session, test_user, sub_id="sub-503-keep")
+        sub_pk = sub.id
+
+        mock_gc = MagicMock()
+        mock_gc.patch_json = AsyncMock(return_value={"error": 503, "detail": "Service Unavailable"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(renew_subscription(sub, db_session))
+
+        assert result is False
+        # Subscription MUST still exist
+        assert db_session.get(GraphSubscription, sub_pk) is not None
+
+    def test_401_keeps_subscription(self, db_session, test_user):
+        """HTTP 401 (token expired) is transient/auth — keep subscription."""
+        from app.services.webhook_service import renew_subscription
+
+        sub = _make_subscription(db_session, test_user, sub_id="sub-401-keep")
+        sub_pk = sub.id
+
+        mock_gc = MagicMock()
+        mock_gc.patch_json = AsyncMock(return_value={"error": 401, "detail": "Unauthorized"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(renew_subscription(sub, db_session))
+
+        assert result is False
+        assert db_session.get(GraphSubscription, sub_pk) is not None
+
+    def test_max_retries_keeps_subscription(self, db_session, test_user):
+        """'max_retries' error string means Graph kept 429/5xx-ing — transient, keep
+        sub."""
+        from app.services.webhook_service import renew_subscription
+
+        sub = _make_subscription(db_session, test_user, sub_id="sub-maxretry-keep")
+        sub_pk = sub.id
+
+        mock_gc = MagicMock()
+        mock_gc.patch_json = AsyncMock(return_value={"error": "max_retries", "detail": "Too many retries"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(renew_subscription(sub, db_session))
+
+        assert result is False
+        assert db_session.get(GraphSubscription, sub_pk) is not None
+
+    def test_unknown_error_code_keeps_subscription(self, db_session, test_user):
+        """An unrecognised numeric error code keeps the subscription (safe default)."""
+        from app.services.webhook_service import renew_subscription
+
+        sub = _make_subscription(db_session, test_user, sub_id="sub-unknown-keep")
+        sub_pk = sub.id
+
+        mock_gc = MagicMock()
+        mock_gc.patch_json = AsyncMock(return_value={"error": 500, "detail": "Internal Server Error"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(renew_subscription(sub, db_session))
+
+        assert result is False
+        assert db_session.get(GraphSubscription, sub_pk) is not None
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  Network / raised exceptions — subscription MUST be kept
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestRenewNetworkExceptions:
+    """patch_json raises an exception (timeout, DNS, etc.) → keep the subscription."""
+
+    def test_timeout_exception_keeps_subscription(self, db_session, test_user):
+        """A network timeout should NOT delete the subscription."""
+        from app.services.webhook_service import renew_subscription
+
+        sub = _make_subscription(db_session, test_user, sub_id="sub-timeout-keep")
+        sub_pk = sub.id
+
+        mock_gc = MagicMock()
+        mock_gc.patch_json = AsyncMock(side_effect=TimeoutError("connection timed out"))
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(renew_subscription(sub, db_session))
+
+        assert result is False
+        assert db_session.get(GraphSubscription, sub_pk) is not None
+
+    def test_runtime_exception_keeps_subscription(self, db_session, test_user):
+        """A generic RuntimeError from patch_json keeps the subscription."""
+        from app.services.webhook_service import renew_subscription
+
+        sub = _make_subscription(db_session, test_user, sub_id="sub-rterr-keep")
+        sub_pk = sub.id
+
+        mock_gc = MagicMock()
+        mock_gc.patch_json = AsyncMock(side_effect=RuntimeError("unexpected error"))
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(renew_subscription(sub, db_session))
+
+        assert result is False
+        assert db_session.get(GraphSubscription, sub_pk) is not None
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  Gone statuses — subscription MUST be deleted
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestRenewGoneStatuses:
+    """Graph returns 404 or 410 → subscription is confirmed gone → delete it."""
+
+    def test_410_deletes_subscription(self, db_session, test_user):
+        """HTTP 410 Gone means Graph has deleted the subscription — delete our
+        record."""
+        from app.services.webhook_service import renew_subscription
+
+        sub = _make_subscription(db_session, test_user, sub_id="sub-410-delete")
+        sub_pk = sub.id
+
+        mock_gc = MagicMock()
+        mock_gc.patch_json = AsyncMock(return_value={"error": 410, "detail": "Gone"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(renew_subscription(sub, db_session))
+
+        assert result is False
+        assert db_session.get(GraphSubscription, sub_pk) is None
+
+    def test_404_deletes_subscription(self, db_session, test_user):
+        """HTTP 404 Not Found means the subscription no longer exists on Graph."""
+        from app.services.webhook_service import renew_subscription
+
+        sub = _make_subscription(db_session, test_user, sub_id="sub-404-delete")
+        sub_pk = sub.id
+
+        mock_gc = MagicMock()
+        mock_gc.patch_json = AsyncMock(return_value={"error": 404, "detail": "Not Found"})
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(renew_subscription(sub, db_session))
+
+        assert result is False
+        assert db_session.get(GraphSubscription, sub_pk) is None
+
+
+# ══════════════════════════════════════════════════════════════════════
+#  Success path — expiration advances
+# ══════════════════════════════════════════════════════════════════════
+
+
+class TestRenewSuccess:
+    def test_success_returns_true_and_advances_expiration(self, db_session, test_user):
+        """Successful renewal sets a future expiration_dt and returns True."""
+        from app.services.webhook_service import renew_subscription
+
+        sub = _make_subscription(db_session, test_user, sub_id="sub-success-adv")
+        old_exp = sub.expiration_dt
+
+        mock_gc = MagicMock()
+        mock_gc.patch_json = AsyncMock(return_value={})  # no "error" key → success
+
+        with (
+            patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
+            patch(_PATCH_GRAPH_CLIENT, return_value=mock_gc),
+        ):
+            result = _run(renew_subscription(sub, db_session))
+
+        assert result is True
+        new_exp = sub.expiration_dt
+        # Strip tz for comparison (SQLite round-trips lose tz)
+        old_naive = old_exp.replace(tzinfo=None) if old_exp.tzinfo else old_exp
+        new_naive = new_exp.replace(tzinfo=None) if new_exp.tzinfo else new_exp
+        assert new_naive > old_naive

--- a/tests/test_services_webhook.py
+++ b/tests/test_services_webhook.py
@@ -814,15 +814,16 @@ class TestRenewSubscription:
             result = _run(renew_subscription(sub, db_session))
             assert result is False
 
-    def test_renew_graph_error_deletes_subscription(self, db_session, test_user):
-        """Graph error deletes the subscription and returns False."""
+    def test_renew_graph_exception_keeps_subscription(self, db_session, test_user):
+        """A raised exception (e.g. network) keeps the subscription (transient
+        error)."""
         from app.services.webhook_service import renew_subscription
 
         sub = _make_subscription(db_session, test_user, sub_id="sub-graph-err")
         sub_id_val = sub.id
 
         mock_gc = MagicMock()
-        mock_gc.patch_json = AsyncMock(side_effect=Exception("Graph 404"))
+        mock_gc.patch_json = AsyncMock(side_effect=Exception("network error"))
 
         with (
             patch(_PATCH_GET_TOKEN, new_callable=AsyncMock, return_value="token"),
@@ -830,9 +831,9 @@ class TestRenewSubscription:
         ):
             result = _run(renew_subscription(sub, db_session))
             assert result is False
-            # Subscription should be deleted
-            deleted = db_session.get(GraphSubscription, sub_id_val)
-            assert deleted is None
+            # Subscription must NOT be deleted — this is a transient failure
+            still_exists = db_session.get(GraphSubscription, sub_id_val)
+            assert still_exists is not None
 
     def test_renew_calls_correct_graph_endpoint(self, db_session, test_user):
         """Renewal calls PATCH on the correct subscription endpoint."""

--- a/tests/test_webhook_service_coverage.py
+++ b/tests/test_webhook_service_coverage.py
@@ -171,8 +171,9 @@ class TestEnsureAllUsersSubscribedEdgeCases:
 
 
 class TestRenewSubscriptionEdgeCases:
-    def test_renew_with_error_only_no_detail(self, db_session, test_user):
-        """Graph response with 'error' field but no 'detail' deletes sub."""
+    def test_renew_with_unknown_string_error_keeps_sub(self, db_session, test_user):
+        """Graph response with an unknown string error code keeps the subscription
+        (transient)."""
         from app.services.webhook_service import renew_subscription
 
         sub = GraphSubscription(
@@ -197,7 +198,8 @@ class TestRenewSubscriptionEdgeCases:
             result = _run(renew_subscription(sub, db_session))
 
         assert result is False
-        assert db_session.get(GraphSubscription, sub_pk) is None
+        # Unknown string errors are transient — subscription must NOT be deleted
+        assert db_session.get(GraphSubscription, sub_pk) is not None
 
 
 class TestCreateTeamsSubscription:


### PR DESCRIPTION
## Keep Graph mail subscription on transient failure (only delete on 404/410)

**Problem:** `renew_subscription()` deleted the Graph mail subscription on **any** failure — a transient timeout, a `503`, a token blip, or a network exception all hit `db.delete(sub)`. When that happened, **inbound email capture went dark** until a separate 5-minute job recreated the subscription. Silent availability loss on the app's most important capture channel.

**Fix (root cause):** classify the failure. `GraphClient.patch_json` returns `{"error": <status>}` on failure (it already retries `429`/`5xx` internally), or raises on network/timeout. Now:
- **HTTP 404 / 410 (Gone)** → subscription is genuinely dead → delete + let the recreate job rebuild it. *(the only delete path)*
- **Any other status (401, exhausted retries, …)** → transient/auth → **keep** the subscription, log a warning, retry next renewal cycle.
- **Raised exception (network/timeout)** → transient → **keep**, log, retry.
- **Success** → unchanged.

`_SUBSCRIPTION_GONE_STATUSES = {404, 410}` makes the gate self-documenting. No model/migration change; `renew_expiring_subscriptions` / `ensure_all_users_subscribed` untouched.

**Tests:** 9 new resilience tests (transient-keeps / exception-keeps / 404-deletes / 410-deletes / success-renews, with DB-state verification); 2 pre-existing tests that asserted the *old buggy* delete-on-any-failure behavior were corrected to the new contract. Full webhook suite green (107 tests).

First of the capture-reliability fixes (probe items #1). Follow-ups: subscription-health observability columns + endpoint (#2/#4, needs a migration), sent-folder recovery (#5/#6), and the Plan-1-stacked send-timestamp clock (#7/#8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
