### PR TITLE
feat(proactive): SP4 — surface gross profit + pipeline on the scorecard

### DIFF
--- a/app/templates/htmx/partials/proactive/scorecard.html
+++ b/app/templates/htmx/partials/proactive/scorecard.html
@@ -1,6 +1,7 @@
 {#
   scorecard.html — Proactive selling metrics panel.
-  Receives: stats (dict with total_sent, total_converted, conversion_rate, converted_revenue).
+  Receives: stats (dict with total_sent, total_converted, conversion_rate, converted_revenue,
+            gross_profit, anticipated_revenue).
            conversion_rate is already a whole-number percent (e.g. 33.3 → "33%").
   Called by: htmx_views.py proactive_scorecard route.
   Depends on: Tailwind CSS with brand palette.
@@ -12,7 +13,8 @@
     </svg>
     <h3 class="text-sm font-semibold text-gray-900">Proactive Scorecard</h3>
   </div>
-  <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+  <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+    {# Row 1 — activity #}
     <div class="bg-brand-50 rounded-lg p-3 text-center border border-brand-100">
       <p class="text-xs text-brand-600 font-medium mb-1">Sent</p>
       <p class="text-2xl font-bold text-gray-900">{{ stats.get('total_sent', 0) }}</p>
@@ -25,9 +27,18 @@
       <p class="text-xs text-brand-600 font-medium mb-1">Conv. Rate</p>
       <p class="text-2xl font-bold text-brand-700">{{ "%.0f%%"|format(stats.get('conversion_rate', 0)) }}</p>
     </div>
+    {# Row 2 — money #}
     <div class="bg-gray-50 rounded-lg p-3 text-center border border-gray-200">
       <p class="text-xs text-gray-500 font-medium mb-1">Revenue</p>
       <p class="text-2xl font-bold text-gray-900">${{ "{:,.0f}".format(stats.get('converted_revenue', 0)) }}</p>
+    </div>
+    <div class="bg-emerald-50 rounded-lg p-3 text-center border border-emerald-100">
+      <p class="text-xs text-emerald-600 font-medium mb-1">Gross Profit</p>
+      <p class="text-2xl font-bold text-emerald-700">${{ "{:,.0f}".format(stats.get('gross_profit', 0)) }}</p>
+    </div>
+    <div class="bg-amber-50 rounded-lg p-3 text-center border border-amber-100">
+      <p class="text-xs text-amber-600 font-medium mb-1">Pipeline</p>
+      <p class="text-2xl font-bold text-amber-700">${{ "{:,.0f}".format(stats.get('anticipated_revenue', 0)) }}</p>
     </div>
   </div>
 </div>

--- a/tests/test_proactive_scorecard_render.py
+++ b/tests/test_proactive_scorecard_render.py
@@ -24,7 +24,17 @@ def test_conversion_rate_not_multiplied_by_100():
 
 def test_revenue_reads_converted_revenue_key():
     """Revenue card must read converted_revenue, not the never-set total_revenue."""
-    html = _render({"total_sent": 6, "total_converted": 2, "conversion_rate": 33.3, "converted_revenue": 139122.5})
+    # Provide all money keys so defaults don't produce a stray $0.
+    html = _render(
+        {
+            "total_sent": 6,
+            "total_converted": 2,
+            "conversion_rate": 33.3,
+            "converted_revenue": 139122.5,
+            "gross_profit": 41972.5,
+            "anticipated_revenue": 278580.0,
+        }
+    )
     assert "$139,122" in html  # rounded, thousands-separated
     # The old buggy key being absent must not silently render $0.
     assert "$0" not in html
@@ -53,3 +63,54 @@ def test_scorecard_matches_service_contract():
     html = _render(stats)
     assert "33%" in html and "3330%" not in html
     assert "$139,122" in html
+
+
+def test_gross_profit_renders():
+    """gross_profit=41972.5 → '$41,972' (Python round-half-even: .5 rounds to even →
+    41972)."""
+    html = _render(
+        {
+            "total_sent": 6,
+            "total_converted": 2,
+            "conversion_rate": 33.3,
+            "converted_revenue": 0,
+            "gross_profit": 41972.5,
+            "anticipated_revenue": 0,
+        }
+    )
+    assert "$41,972" in html
+
+
+def test_pipeline_renders():
+    """anticipated_revenue=278580.0 → '$278,580'."""
+    html = _render(
+        {
+            "total_sent": 6,
+            "total_converted": 2,
+            "conversion_rate": 33.3,
+            "converted_revenue": 0,
+            "gross_profit": 0,
+            "anticipated_revenue": 278580.0,
+        }
+    )
+    assert "$278,580" in html
+
+
+def test_conv_rate_no_double_100_with_money_fields():
+    """Conv.
+
+    Rate still renders correctly when the full service dict (incl. money fields) is
+    used.
+    """
+    html = _render(
+        {
+            "total_sent": 6,
+            "total_converted": 2,
+            "conversion_rate": 33.3,
+            "converted_revenue": 139122.5,
+            "gross_profit": 41972.5,
+            "anticipated_revenue": 278580.0,
+        }
+    )
+    assert "33%" in html
+    assert "3330%" not in html


### PR DESCRIPTION
SP4 of the proactive program — make ROI visible. The Scorecard service already computed these; the panel just wasn't showing them.

## Change (template only — no service change)
`scorecard.html` goes from 4 cards to **6, in two rows of three**:
- **Activity:** Sent · Converted · Conv. Rate
- **Money:** Revenue (realized) · **Gross Profit** (`gross_profit`) · **Pipeline** (`anticipated_revenue` — sent-but-not-yet-converted potential)

Reuses the existing card styling/palette (Gross Profit emerald, Pipeline amber — both already in the CSS bundle). Conv. Rate keeps the no-double-100 fix.

Scoped deliberately: no `total_quoted`/`total_po`/per-rep breakdown and **no `Quote.source` attribution/migration** — the audit said defer those until real proactive wins exist.

## Tests
`test_proactive_scorecard_render.py` extended: asserts Gross Profit (`$41,972`, banker's rounding) + Pipeline (`$278,580`) render, Conv. Rate stays correct. 7 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)