### PR TITLE
feat(crm): account-detail cadence hero + commercial strip (cockpit P3-2)

### DIFF
--- a/app/routers/crm/companies.py
+++ b/app/routers/crm/companies.py
@@ -13,7 +13,7 @@ from ...config import settings
 from ...constants import RequisitionStatus
 from ...database import get_db
 from ...dependencies import require_user
-from ...models import Company, CustomerSite, Quote, Requisition, User
+from ...models import Company, CustomerSite, Requisition, User
 from ...schemas.crm import CompanyCreate, CompanyUpdate
 from ...services.credential_service import get_credential_cached
 from ...utils.async_helpers import safe_background_task
@@ -129,58 +129,11 @@ async def list_companies(
         total = query.count()
         companies = query.offset(offset).limit(limit).all()
 
-        # Compute per-company win_rate and last_req_date
+        # Compute per-company win_rate, revenue_90d, and last_req_date
+        from ...services.crm_service import company_commercial_stats
+
         company_ids = [c.id for c in companies]
-        stats_map: dict[int, dict] = {}
-        if company_ids:
-            from sqlalchemy import case as sa_case
-
-            stats_rows = (
-                db.query(
-                    CustomerSite.company_id,
-                    sqlfunc.count(sa_case((Requisition.status == RequisitionStatus.WON, 1))).label("won_count"),
-                    sqlfunc.count(
-                        sa_case((Requisition.status.in_([RequisitionStatus.WON, RequisitionStatus.LOST]), 1))
-                    ).label("decided_count"),
-                    sqlfunc.max(Requisition.created_at).label("last_req_date"),
-                )
-                .join(Requisition, Requisition.customer_site_id == CustomerSite.id)
-                .filter(CustomerSite.company_id.in_(company_ids))
-                .group_by(CustomerSite.company_id)
-                .all()
-            )
-            for row in stats_rows:
-                wr = round(row.won_count / row.decided_count * 100) if row.decided_count > 0 else None
-                stats_map[row.company_id] = {
-                    "win_rate": wr,
-                    "last_req_date": row.last_req_date.isoformat() if row.last_req_date else None,
-                }
-
-        # 90-day won revenue per company
-        from datetime import datetime as _dt
-        from datetime import timedelta
-        from datetime import timezone as _tz
-
-        rev_cutoff = _dt.now(_tz.utc) - timedelta(days=90)
-        revenue_map: dict[int, float] = {}
-        if company_ids:
-            rev_rows = (
-                db.query(
-                    CustomerSite.company_id,
-                    sqlfunc.coalesce(sqlfunc.sum(Quote.subtotal), 0).label("revenue"),
-                )
-                .join(Requisition, Requisition.customer_site_id == CustomerSite.id)
-                .join(Quote, Quote.requisition_id == Requisition.id)
-                .filter(
-                    CustomerSite.company_id.in_(company_ids),
-                    Requisition.status == RequisitionStatus.WON,
-                    Quote.created_at >= rev_cutoff,
-                )
-                .group_by(CustomerSite.company_id)
-                .all()
-            )
-            for row in rev_rows:
-                revenue_map[row.company_id] = float(row.revenue)
+        stats_map = company_commercial_stats(db, company_ids)
 
         items = []
         for c in companies:
@@ -222,7 +175,7 @@ async def list_companies(
                     "open_req_count": c.open_req_count or 0,
                     "win_rate": st.get("win_rate"),
                     "last_req_date": st.get("last_req_date"),
-                    "revenue_90d": revenue_map.get(c.id, 0),
+                    "revenue_90d": st.get("revenue_90d", 0),
                 }
             )
         return {"items": items, "total": total, "limit": limit, "offset": offset}

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4531,8 +4531,11 @@ async def partials_companies_redirect(request: Request, path: str = ""):
 # additionally re-exported under its historical name because tests
 # (tests/test_htmx_views_nightly28.py) import it from this module — the F401
 # keeps ruff from stripping that alias.
+from ..services.crm_service import cadence_state as _cadence_state  # noqa: E402
 from ..services.crm_service import cdm_list_ctx as _cdm_list_ctx  # noqa: E402
+from ..services.crm_service import company_commercial_stats as _company_commercial_stats  # noqa: E402
 from ..services.crm_service import company_contact_rows as _company_contact_rows  # noqa: E402
+from ..services.crm_service import next_best_touch as _next_best_touch  # noqa: E402
 from ..services.crm_service import staleness_tier as _staleness_tier  # noqa: E402, F401
 
 _ALLOWED_HX_TARGETS = {"#main-content", "#crm-tab-content"}
@@ -4800,6 +4803,14 @@ async def company_detail_partial(
     _cq = _company_quotes_query(db, company)
     quote_count = _cq.count() if _cq is not None else 0
 
+    # Cadence card + commercial strip context
+    from datetime import timezone as _tz
+
+    _stats = _company_commercial_stats(db, [company.id]).get(company.id, {})
+    _cadence = _cadence_state(company.tier, company.last_outbound_at)
+    _nbt = _next_best_touch(company.tier, company.last_outbound_at)
+    contact_rows = _company_contact_rows(db, company_id, sites=sites)
+
     ctx = _base_ctx(request, user, "customers")
     ctx.update(
         {
@@ -4810,8 +4821,19 @@ async def company_detail_partial(
             # Pass the active-only sites list — contacts on deactivated sites must
             # not be shown (clicking them would log outreach against, and bump,
             # a deactivated entity).
-            "contact_rows": _company_contact_rows(db, company_id, sites=sites),
+            "contact_rows": contact_rows,
             "user": user,
+            # Cadence card
+            "cadence_state": _cadence,
+            "next_best_touch": _nbt,
+            "contact_count": len(contact_rows),
+            "site_count": len(sites),
+            # Commercial strip
+            "win_rate": _stats.get("win_rate"),
+            "revenue_90d": _stats.get("revenue_90d", 0.0),
+            "last_req_date": _stats.get("last_req_date"),
+            # Clock day calculations
+            "now_utc": datetime.now(_tz.utc),
         }
     )
     return template_response("htmx/partials/customers/detail.html", ctx)

--- a/app/services/crm_service.py
+++ b/app/services/crm_service.py
@@ -13,10 +13,12 @@ Depends on: app/models (Company, CustomerSite, SiteContact, Quote),
 
 from datetime import datetime, timedelta, timezone
 
+from sqlalchemy import case as sa_case
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
-from ..models import Company, CustomerSite, Quote, SiteContact
+from ..constants import RequisitionStatus
+from ..models import Company, CustomerSite, Quote, Requisition, SiteContact
 from ..models.auth import User
 from ..utils.search_builder import SearchBuilder
 
@@ -287,3 +289,86 @@ def company_contact_rows(db: Session, company_id: int, sites: list[CustomerSite]
         if s.contact_name or s.contact_email:
             rows.append({"contact": None, "site": s, "legacy": True})
     return rows
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  COMMERCIAL STATS — company_commercial_stats, next_best_touch
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def company_commercial_stats(db: Session, company_ids: list[int]) -> dict[int, dict]:
+    """Compute win_rate, revenue_90d, last_req_date for a list of company IDs.
+
+    Returns {company_id: {"win_rate": int|None, "revenue_90d": float, "last_req_date":
+    str|None}}. win_rate is None when no decided (WON+LOST) reqs exist. revenue_90d is
+    sum of Quote.subtotal on WON reqs in last 90 days. last_req_date is ISO string of
+    the max Requisition.created_at across all sites.
+    """
+    if not company_ids:
+        return {}
+
+    # Initialise defaults so every requested id is present in the result
+    result: dict[int, dict] = {
+        cid: {"win_rate": None, "revenue_90d": 0.0, "last_req_date": None} for cid in company_ids
+    }
+
+    # Win-rate + last_req_date — single pass via CustomerSite → Requisition join
+    stats_rows = (
+        db.query(
+            CustomerSite.company_id,
+            func.count(sa_case((Requisition.status == RequisitionStatus.WON, 1))).label("won_count"),
+            func.count(sa_case((Requisition.status.in_([RequisitionStatus.WON, RequisitionStatus.LOST]), 1))).label(
+                "decided_count"
+            ),
+            func.max(Requisition.created_at).label("last_req_date"),
+        )
+        .join(Requisition, Requisition.customer_site_id == CustomerSite.id)
+        .filter(CustomerSite.company_id.in_(company_ids))
+        .group_by(CustomerSite.company_id)
+        .all()
+    )
+    for row in stats_rows:
+        wr = round(row.won_count / row.decided_count * 100) if row.decided_count > 0 else None
+        result[row.company_id]["win_rate"] = wr
+        result[row.company_id]["last_req_date"] = row.last_req_date.isoformat() if row.last_req_date else None
+
+    # 90-day won revenue — CustomerSite → Requisition → Quote join
+    rev_cutoff = datetime.now(timezone.utc) - timedelta(days=90)
+    rev_rows = (
+        db.query(
+            CustomerSite.company_id,
+            func.coalesce(func.sum(Quote.subtotal), 0).label("revenue"),
+        )
+        .join(Requisition, Requisition.customer_site_id == CustomerSite.id)
+        .join(Quote, Quote.requisition_id == Requisition.id)
+        .filter(
+            CustomerSite.company_id.in_(company_ids),
+            Requisition.status == RequisitionStatus.WON,
+            Quote.created_at >= rev_cutoff,
+        )
+        .group_by(CustomerSite.company_id)
+        .all()
+    )
+    for row in rev_rows:
+        result[row.company_id]["revenue_90d"] = float(row.revenue)
+
+    return result
+
+
+def next_best_touch(
+    tier: str | None,
+    last_outbound_at: datetime | None,
+    now: datetime | None = None,
+) -> str:
+    """Human-readable next-best-touch guidance derived from cadence_state.
+
+    "Never contacted — reach out"  (state=new) "Overdue — reach out now" (state=overdue)
+    "Due for outreach"             (state=due) "On track" (state=on_target)
+    """
+    state = cadence_state(tier, last_outbound_at, now)
+    return {
+        "new": "Never contacted — reach out",
+        "overdue": "Overdue — reach out now",
+        "due": "Due for outreach",
+        "on_target": "On track",
+    }.get(state, "On track")

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -94,19 +94,83 @@
     </div>
   </div>
 
-  {# ── Stats Row (3 cols) ──────────────────────────────────── #}
-  <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
-    <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4 text-center hover:bg-brand-50 transition-colors">
-      <p class="text-2xl font-bold text-gray-900">{{ sites|length }}</p>
-      <p class="text-xs font-medium text-gray-500 mt-1">Sites</p>
+  {# ── Account Cadence Card ──────────────────────────────── #}
+  <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4">
+    {# Hero row: cadence badge + tier + next-best-touch #}
+    <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
+      {% set badge_colors = {
+        "new": "bg-gray-100 text-gray-500",
+        "on_target": "bg-emerald-100 text-emerald-700",
+        "due": "bg-amber-100 text-amber-700",
+        "overdue": "bg-rose-100 text-rose-700"
+      } %}
+      <div class="flex items-center gap-2">
+        <span class="px-2.5 py-1 text-xs font-semibold rounded-full {{ badge_colors.get(cadence_state, 'bg-gray-100 text-gray-500') }}">
+          {{ {"new": "New", "on_target": "On Target", "due": "Due", "overdue": "Overdue"}.get(cadence_state, cadence_state|title) }}
+        </span>
+        {% if company.tier %}
+          <span class="text-xs text-gray-500 font-medium">{{ company.tier|title }}</span>
+        {% endif %}
+      </div>
+      <span class="text-xs text-gray-600 italic">{{ next_best_touch }}</span>
     </div>
-    <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4 text-center hover:bg-brand-50 transition-colors">
-      <p class="text-2xl font-bold text-gray-900">{{ open_req_count }}</p>
-      <p class="text-xs font-medium text-gray-500 mt-1">Open Requisitions</p>
+
+    {# Dual clocks: Outbound + Reply #}
+    <div class="grid grid-cols-2 gap-3 mb-3">
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+          <svg class="inline h-3 w-3 mr-1 text-brand-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+          Last Out
+        </p>
+        {% if company.last_outbound_at %}
+          {% set out_days = ((now_utc - company.last_outbound_at).days) if now_utc is defined else 0 %}
+          <p class="text-lg font-bold text-gray-900">{{ out_days }}d</p>
+          <p class="text-[10px] text-gray-400">{{ company.last_outbound_at.strftime('%b %d') }}</p>
+        {% else %}
+          <p class="text-sm font-medium text-gray-400">Never</p>
+        {% endif %}
+      </div>
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+          <svg class="inline h-3 w-3 mr-1 text-brand-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"/></svg>
+          Last Reply
+        </p>
+        {% if company.last_reply_at %}
+          {% set reply_days = ((now_utc - company.last_reply_at).days) if now_utc is defined else 0 %}
+          <p class="text-lg font-bold text-gray-900">{{ reply_days }}d</p>
+          <p class="text-[10px] text-gray-400">{{ company.last_reply_at.strftime('%b %d') }}</p>
+        {% else %}
+          <p class="text-sm font-medium text-gray-400">—</p>
+        {% endif %}
+      </div>
     </div>
-    <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4 text-center hover:bg-brand-50 transition-colors">
-      <p class="text-sm font-medium text-gray-900">{{ company.created_at.strftime('%b %d, %Y') if company.created_at else "—" }}</p>
-      <p class="text-xs font-medium text-gray-500 mt-1">Created</p>
+
+    {# Coverage badge #}
+    <p class="text-xs text-gray-500">
+      <span class="font-medium text-gray-700">{{ contact_count }} contact{{ 's' if contact_count != 1 else '' }}</span>
+      <span class="text-gray-300 mx-1">·</span>
+      <span class="font-medium text-gray-700">{{ site_count }} site{{ 's' if site_count != 1 else '' }}</span>
+    </p>
+  </div>
+
+  {# ── Commercial Context Strip ────────────────────────────── #}
+  <div class="bg-white rounded-xl shadow-sm border border-brand-200 px-4 py-3">
+    <div class="flex items-center gap-4 flex-wrap text-sm">
+      <span class="text-xs font-medium text-gray-400 uppercase tracking-wider mr-2">Commercial</span>
+      <span class="text-gray-600">
+        Win rate:
+        <span class="font-semibold text-gray-900">{% if win_rate is not none %}{{ win_rate }}%{% else %}—{% endif %}</span>
+      </span>
+      <span class="text-gray-300">·</span>
+      <span class="text-gray-600">
+        Rev 90d:
+        <span class="font-semibold text-gray-900">{% if revenue_90d %}${{ "{:,.0f}".format(revenue_90d) }}{% else %}—{% endif %}</span>
+      </span>
+      <span class="text-gray-300">·</span>
+      <span class="text-gray-600">
+        Last deal:
+        <span class="font-semibold text-gray-900">{% if last_req_date %}{{ last_req_date[:10] }}{% else %}—{% endif %}</span>
+      </span>
     </div>
   </div>
 

--- a/tests/test_crm_service.py
+++ b/tests/test_crm_service.py
@@ -1,0 +1,263 @@
+"""tests/test_crm_service.py — Unit tests for CRM service helpers.
+
+Tests for company_commercial_stats() and next_best_touch() which are being
+extracted / added to app/services/crm_service.py as part of CRM cockpit P3-2.
+
+These tests are written FIRST (TDD) — they will FAIL until the production
+functions are implemented.
+
+Called by: pytest
+Depends on: app.services.crm_service, app.models
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import Company, CustomerSite, Quote, Requisition
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+NOW = datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_company(db: Session, name: str = "Test Co") -> Company:
+    co = Company(name=name, is_active=True)
+    db.add(co)
+    db.flush()
+    return co
+
+
+def _make_site(db: Session, company: Company) -> CustomerSite:
+    site = CustomerSite(company_id=company.id, site_name="HQ")
+    db.add(site)
+    db.flush()
+    return site
+
+
+def _make_req(
+    db: Session,
+    site: CustomerSite,
+    status: str,
+    created_at: datetime | None = None,
+) -> Requisition:
+    req = Requisition(
+        name=f"REQ-{status[:3].upper()}-001",
+        customer_name="Test Co",
+        status=status,
+        customer_site_id=site.id,
+        company_id=site.company_id,
+        created_at=created_at or NOW,
+    )
+    db.add(req)
+    db.flush()
+    return req
+
+
+def _make_quote(
+    db: Session,
+    req: Requisition,
+    site: CustomerSite,
+    subtotal: float,
+    created_at: datetime | None = None,
+) -> Quote:
+    q = Quote(
+        requisition_id=req.id,
+        customer_site_id=site.id,
+        quote_number=f"Q-{req.id}-001",
+        status="sent",
+        line_items=[],
+        subtotal=subtotal,
+        total_cost=subtotal * 0.5,
+        total_margin_pct=50.0,
+        created_at=created_at or NOW,
+    )
+    db.add(q)
+    db.flush()
+    return q
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestCompanyCommercialStats
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCompanyCommercialStats:
+    """Tests for company_commercial_stats(db, company_ids) → dict[int, dict].
+
+    The function does NOT exist yet — all tests here will fail with ImportError until it
+    is implemented.
+    """
+
+    def test_returns_win_rate_from_won_and_decided(self, db_session: Session):
+        """Win rate = round(won / (won + lost) * 100), only WON+LOST are 'decided'."""
+        from app.services.crm_service import company_commercial_stats
+
+        co = _make_company(db_session, "WinRate Co")
+        site = _make_site(db_session, co)
+
+        _make_req(db_session, site, "won")
+        _make_req(db_session, site, "won")
+        _make_req(db_session, site, "lost")
+        # active req should NOT count as decided
+        _make_req(db_session, site, "active")
+        db_session.commit()
+
+        result = company_commercial_stats(db_session, [co.id])
+        assert co.id in result
+        stats = result[co.id]
+        # 2 won / 3 decided (won+lost) = 67%
+        assert stats["win_rate"] == 67
+
+    def test_returns_none_win_rate_when_no_decided(self, db_session: Session):
+        """Win rate is None when there are no WON or LOST requisitions."""
+        from app.services.crm_service import company_commercial_stats
+
+        co = _make_company(db_session, "NoneWin Co")
+        site = _make_site(db_session, co)
+
+        _make_req(db_session, site, "active")
+        _make_req(db_session, site, "sourcing")
+        db_session.commit()
+
+        result = company_commercial_stats(db_session, [co.id])
+        assert co.id in result
+        assert result[co.id]["win_rate"] is None
+
+    def test_revenue_90d_sums_won_quotes_within_window(self, db_session: Session):
+        """revenue_90d sums Quote.subtotal for WON reqs with quotes created <= 90d
+        ago."""
+        from app.services.crm_service import company_commercial_stats
+
+        co = _make_company(db_session, "Revenue Co")
+        site = _make_site(db_session, co)
+
+        # WON req within the 90d window
+        req_in = _make_req(db_session, site, "won", created_at=NOW - timedelta(days=30))
+        _make_quote(db_session, req_in, site, subtotal=5000.0, created_at=NOW - timedelta(days=30))
+
+        # WON req OUTSIDE the 90d window — should NOT be included
+        req_out = _make_req(db_session, site, "won", created_at=NOW - timedelta(days=120))
+        _make_quote(db_session, req_out, site, subtotal=9999.0, created_at=NOW - timedelta(days=120))
+
+        db_session.commit()
+
+        result = company_commercial_stats(db_session, [co.id])
+        assert co.id in result
+        assert result[co.id]["revenue_90d"] == pytest.approx(5000.0)
+
+    def test_last_req_date_is_max_created_at(self, db_session: Session):
+        """last_req_date is the ISO string of the most recent requisition's
+        created_at."""
+        from app.services.crm_service import company_commercial_stats
+
+        co = _make_company(db_session, "MaxDate Co")
+        site = _make_site(db_session, co)
+
+        older = NOW - timedelta(days=60)
+        newer = NOW - timedelta(days=10)
+
+        _make_req(db_session, site, "won", created_at=older)
+        _make_req(db_session, site, "active", created_at=newer)
+        db_session.commit()
+
+        result = company_commercial_stats(db_session, [co.id])
+        assert co.id in result
+        # Should return the newer date as an ISO string
+        last_req = result[co.id]["last_req_date"]
+        assert last_req is not None
+        assert newer.isoformat()[:10] in last_req  # date portion matches
+
+    def test_empty_company_ids_returns_empty_dict(self, db_session: Session):
+        """Passing [] returns {} without querying."""
+        from app.services.crm_service import company_commercial_stats
+
+        result = company_commercial_stats(db_session, [])
+        assert result == {}
+
+    def test_multi_company_returns_separate_stats(self, db_session: Session):
+        """Each company gets its own stats dict, correctly isolated."""
+        from app.services.crm_service import company_commercial_stats
+
+        co_a = _make_company(db_session, "Alpha Corp")
+        co_b = _make_company(db_session, "Beta Corp")
+        site_a = _make_site(db_session, co_a)
+        site_b = _make_site(db_session, co_b)
+
+        _make_req(db_session, site_a, "won")
+        _make_req(db_session, site_a, "lost")
+        _make_req(db_session, site_b, "won")
+        _make_req(db_session, site_b, "won")
+        _make_req(db_session, site_b, "won")
+        db_session.commit()
+
+        result = company_commercial_stats(db_session, [co_a.id, co_b.id])
+        assert co_a.id in result
+        assert co_b.id in result
+
+        # Alpha: 1 won / 2 decided = 50%
+        assert result[co_a.id]["win_rate"] == 50
+        # Beta: 3 won / 3 decided = 100%
+        assert result[co_b.id]["win_rate"] == 100
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestNextBestTouch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNextBestTouch:
+    """Tests for next_best_touch(tier, last_outbound_at, now) → str.
+
+    The function does NOT exist yet — all tests here will fail with ImportError until it
+    is implemented.
+    """
+
+    def test_never_contacted_returns_reach_out(self):
+        """last_outbound_at=None → 'Never contacted — reach out'."""
+        from app.services.crm_service import next_best_touch
+
+        result = next_best_touch(tier="standard", last_outbound_at=None, now=NOW)
+        assert result == "Never contacted — reach out"
+
+    def test_never_contacted_with_none_tier(self):
+        """Tier=None and last_outbound_at=None → 'Never contacted — reach out'."""
+        from app.services.crm_service import next_best_touch
+
+        result = next_best_touch(tier=None, last_outbound_at=None, now=NOW)
+        assert result == "Never contacted — reach out"
+
+    def test_overdue_returns_reach_out_now(self):
+        """35 days ago on standard tier (30d target) → 'Overdue — reach out now'."""
+        from app.services.crm_service import next_best_touch
+
+        last_outbound = NOW - timedelta(days=35)
+        result = next_best_touch(tier="standard", last_outbound_at=last_outbound, now=NOW)
+        assert result == "Overdue — reach out now"
+
+    def test_due_returns_due_for_outreach(self):
+        """10 days ago on key tier (7d target) → 'Due for outreach'."""
+        from app.services.crm_service import next_best_touch
+
+        last_outbound = NOW - timedelta(days=10)
+        result = next_best_touch(tier="key", last_outbound_at=last_outbound, now=NOW)
+        assert result == "Due for outreach"
+
+    def test_on_target_returns_on_track(self):
+        """5 days ago on standard tier (30d target) → 'On track'."""
+        from app.services.crm_service import next_best_touch
+
+        last_outbound = NOW - timedelta(days=5)
+        result = next_best_touch(tier="standard", last_outbound_at=last_outbound, now=NOW)
+        assert result == "On track"
+
+    def test_on_target_key_tier_within_window(self):
+        """3 days ago on key tier (7d target) → 'On track'."""
+        from app.services.crm_service import next_best_touch
+
+        last_outbound = NOW - timedelta(days=3)
+        result = next_best_touch(tier="key", last_outbound_at=last_outbound, now=NOW)
+        assert result == "On track"

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -792,4 +792,191 @@ class TestComputeUserScore:
         data = resp.json()
         # User still appears in response with zero scores
         assert len(data["names"]) >= 1
-        assert all(s == 0.0 for s in data["scores"])
+
+
+class TestCompanyDetailCadenceCard:
+    """Tests for the new account-cadence card + commercial-context strip in the company
+    detail partial.
+
+    The old 3-stat row (Sites / Open Requisitions / Created) is being REPLACED
+    by a cadence card that shows:
+      - Two clocks: outbound + reply
+      - A cadence_state badge (color-coded)
+      - Next-best-touch text
+      - Coverage: "N contacts · N sites"
+      - Commercial strip: win rate, revenue 90d, last deal date
+
+    These tests are written FIRST (TDD) — they will FAIL until the route and
+    template are updated in CRM cockpit P3-2.
+    """
+
+    # ─── helpers ────────────────────────────────────────────────────────
+
+    def _make_company(self, db_session, **kwargs) -> Company:
+        co = Company(name="Test Cadence Co", is_active=True, **kwargs)
+        db_session.add(co)
+        db_session.commit()
+        db_session.refresh(co)
+        return co
+
+    # ─── cadence badge ──────────────────────────────────────────────────
+
+    def test_detail_shows_cadence_badge_for_new_company(self, client: TestClient, db_session: Session, test_user: User):
+        """Company with no outbound → cadence badge uses 'new' CSS classes and
+        references never/Never somewhere in the HTML.
+
+        Fails until: route passes cadence_state to template AND template renders
+        the cadence badge with correct classes.
+        """
+        co = self._make_company(db_session, last_outbound_at=None, last_reply_at=None)
+
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+
+        html = resp.text
+        # New cadence badge CSS: bg-gray-100 text-gray-500
+        assert "bg-gray-100" in html
+        assert "text-gray-500" in html
+        # Template must say "never" or "Never" somewhere (the "Out" clock label)
+        assert "never" in html.lower()
+
+    def test_detail_shows_overdue_cadence_badge(self, client: TestClient, db_session: Session, test_user: User):
+        """Company with outbound 40 days ago → overdue badge CSS classes present.
+
+        Fails until: route computes cadence_state and template renders the
+        overdue badge: bg-rose-100 text-rose-700.
+        """
+        outbound_40d_ago = datetime.now(timezone.utc) - timedelta(days=40)
+        co = self._make_company(db_session, last_outbound_at=outbound_40d_ago)
+
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+
+        html = resp.text
+        assert "bg-rose-100" in html
+        assert "text-rose-700" in html
+
+    # ─── outbound clock ─────────────────────────────────────────────────
+
+    def test_detail_shows_outbound_clock(self, client: TestClient, db_session: Session, test_user: User):
+        """Company with last_outbound_at set → shows days count + Out/out label.
+
+        Fails until: route passes last_outbound_at (or computed days) to template
+        AND template renders the outbound clock.
+        """
+        outbound_7d_ago = datetime.now(timezone.utc) - timedelta(days=7)
+        co = self._make_company(db_session, last_outbound_at=outbound_7d_ago)
+
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+
+        html = resp.text
+        # The outbound clock label (case-insensitive)
+        assert "out" in html.lower()
+        # A number representing days (7d = "7")
+        assert "7" in html
+
+    # ─── next-best-touch ────────────────────────────────────────────────
+
+    def test_detail_shows_next_best_touch(self, client: TestClient, db_session: Session, test_user: User):
+        """Company with no outbound → 'Never contacted' shown in HTML.
+
+        Fails until: route computes next_best_touch and template renders it.
+        """
+        co = self._make_company(db_session, last_outbound_at=None)
+
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+
+        assert "Never contacted" in resp.text
+
+    # ─── coverage row ───────────────────────────────────────────────────
+
+    def test_detail_shows_coverage(self, client: TestClient, db_session: Session, test_user: User):
+        """Company with 2 contacts and 1 site → 'contacts' and 'site' in HTML.
+
+        Fails until: route passes contact_count + site_count to template AND
+        template renders the coverage row.
+        """
+        from app.models.crm import CustomerSite, SiteContact
+
+        co = self._make_company(db_session)
+        site = CustomerSite(company_id=co.id, site_name="HQ")
+        db_session.add(site)
+        db_session.flush()
+
+        contact1 = SiteContact(customer_site_id=site.id, full_name="Alice Smith")
+        contact2 = SiteContact(customer_site_id=site.id, full_name="Bob Jones", email="bob@test.com")
+        db_session.add_all([contact1, contact2])
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+
+        html = resp.text
+        # "2 contacts" or "2 contact" (singular/plural variations acceptable)
+        assert "contact" in html.lower()
+        # "1 site" or "1 sites"
+        assert "site" in html.lower()
+        # The numbers 2 and 1 appear
+        assert "2" in html
+        assert "1" in html
+
+    # ─── commercial strip ───────────────────────────────────────────────
+
+    def test_detail_commercial_strip_shows_win_rate(self, client: TestClient, db_session: Session, test_user: User):
+        """Company with WON + LOST reqs → win rate percentage in HTML.
+
+        Fails until: route fetches commercial_stats and template renders win rate %.
+        """
+        from app.models.crm import CustomerSite
+        from app.models.sourcing import Requisition
+
+        co = self._make_company(db_session)
+        site = CustomerSite(company_id=co.id, site_name="HQ")
+        db_session.add(site)
+        db_session.flush()
+
+        req_won = Requisition(
+            name="REQ-WON-001",
+            customer_name=co.name,
+            status="won",
+            customer_site_id=site.id,
+            company_id=co.id,
+        )
+        req_lost = Requisition(
+            name="REQ-LOST-001",
+            customer_name=co.name,
+            status="lost",
+            customer_site_id=site.id,
+            company_id=co.id,
+        )
+        db_session.add_all([req_won, req_lost])
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+
+        html = resp.text
+        # 1 won / 2 decided = 50% win rate — the % symbol must appear
+        assert "%" in html
+        assert "50" in html
+
+    # ─── old labels gone ────────────────────────────────────────────────
+
+    def test_detail_old_stats_labels_gone(self, client: TestClient, db_session: Session, test_user: User):
+        """The old 3-stat row labels 'Open Requisitions' and 'Created' must NOT appear
+        in the new template.
+
+        Fails until: template no longer contains the old stat row from lines
+        97-111 of detail.html.
+        """
+        co = self._make_company(db_session)
+
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+
+        html = resp.text
+        # These exact strings were the old stat-row labels — they must be gone
+        assert "Open Requisitions" not in html
+        assert ">Created<" not in html

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -792,6 +792,8 @@ class TestComputeUserScore:
         data = resp.json()
         # User still appears in response with zero scores
         assert len(data["names"]) >= 1
+        assert len(data["scores"]) > 0
+        assert all(s == 0.0 for s in data["scores"])
 
 
 class TestCompanyDetailCadenceCard:


### PR DESCRIPTION
## Cockpit P3-2 — account-detail cadence hero + commercial strip

Right-pane payoff for the relationship-cadence cockpit. Replaces the weak decorative 3-stat row (Sites / Open Requisitions / Created) with a **cadence hero card** + a secondary **commercial-context strip**.

### Changed
- **Cadence hero** — two clocks (Out `last_outbound_at` / Reply `last_reply_at`, day counts; "never" / "—" for NULL, never "never replied"), a `cadence_state` badge (new→gray / on_target→emerald / due→amber / overdue→rose — same keys as the left-list dots), the tier label, a **next-best-touch** line, and a coverage badge (N contacts · N sites).
- **Commercial strip** (below quick-info, secondary — pipeline stays out of the hub): win rate · 90-day revenue · last deal date.
- **Root-cause de-dup:** the win-rate / revenue-90d / last-req computation that lived only inline in the list route is extracted to a shared `crm_service.company_commercial_stats` helper; `list_companies` refactored to call it (verified mathematically identical — list behavior unchanged) and the detail route reuses it. Coverage is derived from already-fetched contacts/sites (no new query).

### Tests
18 new (12 service + 6 route/template) verifying the helper values, `next_best_touch`, the hero card render (badge/clocks/touch/coverage), the commercial strip, and that the old 3-stat labels are gone. Review caught + I restored a meaningful error-path assertion that had been deleted from an unrelated test. `test_crm_service` + `test_crm_views` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
