### PR TITLE
feat(crm): contacts accordion + buying-role chips + per-contact clocks (cockpit P3-3)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4873,8 +4873,16 @@ async def company_tab(
         return template_response("htmx/partials/customers/tabs/sites_tab.html", ctx)
 
     elif tab == "contacts":
+        from datetime import timezone as _tz
+
         ctx = _base_ctx(request, user, "customers")
-        ctx.update({"company": company, "contact_rows": _company_contact_rows(db, company_id)})
+        ctx.update(
+            {
+                "company": company,
+                "contact_rows": _company_contact_rows(db, company_id),
+                "now_utc": datetime.now(_tz.utc),
+            }
+        )
         return template_response("htmx/partials/customers/tabs/contacts_tab.html", ctx)
 
     elif tab == "requisitions":

--- a/app/template_env.py
+++ b/app/template_env.py
@@ -271,3 +271,7 @@ def _now() -> datetime:
 
 
 templates.env.globals["now"] = _now
+
+from .services.crm_service import cadence_state  # noqa: E402
+
+templates.env.globals["cadence_state"] = cadence_state

--- a/app/templates/htmx/partials/customers/tabs/contacts_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/contacts_tab.html
@@ -59,7 +59,7 @@
 {% set rep_ts = contact.last_reply_at %}
 {% if out_ts %}
   {# Compute days since last outbound #}
-  {% set out_days = ((now_utc - out_ts).days) if out_ts else none %}
+  {% set out_days = (now_utc - out_ts).days %}
   {# Cadence state from crm_service — pass tier=None (contact-level = standard) #}
   {% set cstate = cadence_state(none, out_ts, now_utc) %}
   {% if cstate == 'overdue' %}
@@ -199,7 +199,7 @@
               class='w-full flex items-center justify-between px-3 py-2 bg-gray-50 hover:bg-gray-100 rounded-t-lg transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-inset'
               :aria-expanded='open'>
         <div class='flex items-center gap-2'>
-          <svg class='h-4 w-4 text-gray-400 transition-transform' :class='"rotate-90": open'
+          <svg class='h-4 w-4 text-gray-400 transition-transform' :class='{ "rotate-90": open }'
                fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'>
             <path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/>
           </svg>

--- a/app/templates/htmx/partials/customers/tabs/contacts_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/contacts_tab.html
@@ -1,12 +1,23 @@
-{# contacts_tab.html — Company contacts with click-to-contact outreach actions.
+{# contacts_tab.html — Company contacts grouped by site (accordion), with role chips
+   and per-contact cadence clocks.
+
    Each Call / Email / Teams / WeChat action opens the native handler (tel:,
    mailto:, Teams deep link, weixin:) AND logs an outbound ActivityLog via the
    delegated [data-outreach-log] listener in htmx_app.js (POST
-   /api/activity/outreach-initiated), which bumps company.last_activity_at.
-   Receives: company, contact_rows ([{contact, site, legacy}]).
+   /api/activity/outreach-initiated), which bumps both the company AND the
+   contact's last_outbound_at via bump_clocks_from_activity → SiteContact clock.
+
+   Receives: company, contact_rows ([{contact, site, legacy}]), now_utc.
    Called by: company_tab route (tab=contacts) and detail.html (inline default tab).
-   Depends on: htmx_app.js outreach logger, brand palette.
+   Depends on: htmx_app.js outreach logger, brand palette, Alpine.js.
+
+   Clock honesty rule: NULL last_outbound_at means "not yet logged" (email activity
+   is not yet universally attributed to site_contact_id). Render "—" / "no logged touch"
+   — NEVER "never replied" (which implies the contact was ignored, not that the log
+   is missing).
 #}
+
+{# ── helpers ─────────────────────────────────────────────────────────────── #}
 
 {% macro outreach_btn(label, href, channel, value, company_id, site_id, contact_id, contact_name, icon_path, new_tab=False) %}
 <a href="{{ href }}"
@@ -27,63 +38,186 @@
 </a>
 {% endmacro %}
 
-{% macro contact_card(company, name, title, site_name, email, phone, wechat, contact_id, site_id, is_primary, legacy) %}
-<div class="bg-white rounded-lg border border-gray-200 p-3 hover:border-brand-200 transition-colors">
-  <div class="flex items-start justify-between gap-3 flex-wrap">
-    <div class="min-w-0">
-      <div class="flex items-center gap-2">
-        <span class="text-sm font-medium text-gray-900">{{ name or "—" }}</span>
-        {% if is_primary %}
-        <span class="px-1 py-0.5 text-[9px] font-medium rounded bg-emerald-50 text-emerald-700">Primary</span>
-        {% endif %}
-        {% if legacy %}
-        <span class="text-[9px] text-gray-400">legacy</span>
-        {% endif %}
-      </div>
-      <p class="text-[11px] text-gray-500">
-        {{ title or "—" }}{% if site_name %} &middot; {{ site_name }}{% endif %}
-      </p>
-      <div class="mt-1 flex items-center gap-3 text-[11px] text-gray-500 flex-wrap">
-        {% if email %}<span class="truncate">{{ email }}</span>{% endif %}
-        {% if phone %}<span>{{ phone }}</span>{% endif %}
-        {% if wechat %}<span>WeChat: {{ wechat }}</span>{% endif %}
-      </div>
-    </div>
-    <div class="flex items-center gap-1.5 flex-wrap flex-shrink-0">
-      {% if phone %}
-      {{ outreach_btn("Call", "tel:" ~ phone, "phone", phone, company.id, site_id, contact_id, name,
-                      "M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z") }}
-      {% endif %}
-      {% if email %}
-      {{ outreach_btn("Email", "mailto:" ~ email, "email", email, company.id, site_id, contact_id, name,
-                      "M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z") }}
-      {{ outreach_btn("Teams", "https://teams.microsoft.com/l/chat/0/0?users=" ~ email|urlencode, "teams", email, company.id, site_id, contact_id, name,
-                      "M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z", new_tab=True) }}
-      {% endif %}
-      {% if wechat %}
-      {{ outreach_btn("WeChat", "weixin://dl/chat?" ~ wechat|urlencode, "wechat", wechat, company.id, site_id, contact_id, name,
-                      "M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z") }}
-      {% endif %}
-    </div>
-  </div>
-</div>
+{# Role chip — color-coded by role; graceful fallback for null/unknown. #}
+{% macro role_chip(role) %}
+{% if role == 'buyer' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-blue-50 text-blue-700">Buyer</span>
+{% elif role == 'technical' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-purple-50 text-purple-700">Technical</span>
+{% elif role == 'decision_maker' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-amber-50 text-amber-700">Decision Maker</span>
+{% elif role == 'operations' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-gray-100 text-gray-600">Operations</span>
+{% elif role %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-gray-100 text-gray-600">{{ role|title }}</span>
+{% endif %}
 {% endmacro %}
 
-<div class="space-y-2">
-  {% for row in contact_rows %}
-    {% if row.legacy %}
-      {{ contact_card(company, row.site.contact_name, row.site.contact_title, row.site.site_name,
-                      row.site.contact_email, row.site.contact_phone, none,
-                      none, row.site.id, False, True) }}
-    {% else %}
-      {{ contact_card(company, row.contact.full_name, row.contact.title,
-                      row.site.site_name if row.site else none,
-                      row.contact.email, row.contact.phone, row.contact.wechat_id,
-                      row.contact.id, row.contact.customer_site_id, row.contact.is_primary, False) }}
-    {% endif %}
+{# Per-contact clock row — outbound + reply with honest empty states. #}
+{% macro contact_clocks(contact, now_utc) %}
+{% set out_ts = contact.last_outbound_at %}
+{% set rep_ts = contact.last_reply_at %}
+{% if out_ts %}
+  {# Compute days since last outbound #}
+  {% set out_days = ((now_utc - out_ts).days) if out_ts else none %}
+  {# Cadence state from crm_service — pass tier=None (contact-level = standard) #}
+  {% set cstate = cadence_state(none, out_ts, now_utc) %}
+  {% if cstate == 'overdue' %}
+    {% set clock_cls = 'text-rose-600' %}
+  {% elif cstate == 'due' %}
+    {% set clock_cls = 'text-amber-600' %}
   {% else %}
-  <div class="p-8 text-center">
-    <p class="text-sm text-gray-500">No contacts found. Add contacts via the Sites tab.</p>
+    {% set clock_cls = 'text-emerald-600' %}
+  {% endif %}
+<div class="mt-1.5 flex items-center gap-3 text-[11px]">
+  <span class="text-gray-400">Out:</span>
+  <span class="{{ clock_cls }} font-medium">{{ out_days }}d ago</span>
+  <span class="text-gray-400">Reply:</span>
+  {% if rep_ts %}
+    {% set rep_days = (now_utc - rep_ts).days %}
+    <span class="text-gray-500">{{ rep_days }}d ago</span>
+  {% else %}
+    <span class="text-gray-300">—</span>
+  {% endif %}
+</div>
+{% else %}
+<div class="mt-1.5 flex items-center gap-3 text-[11px]">
+  <span class="text-gray-400">Out:</span>
+  <span class="text-gray-300" title="no logged touch">—</span>
+  <span class="text-gray-400">Reply:</span>
+  <span class="text-gray-300">—</span>
+</div>
+{% endif %}
+{% endmacro %}
+
+{# Full contact card — SiteContact row. #}
+{% macro contact_card(company, contact, site, legacy) %}
+{% if legacy %}
+  {# Legacy site-level contact (contact is None, fields live on site) #}
+  <div class="bg-white rounded-lg border border-gray-200 p-3 hover:border-brand-200 transition-colors">
+    <div class="flex items-start justify-between gap-3 flex-wrap">
+      <div class="min-w-0">
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium text-gray-900">{{ site.contact_name or "—" }}</span>
+          <span class="text-[9px] text-gray-400">legacy</span>
+        </div>
+        <p class="text-[11px] text-gray-500">
+          {{ site.contact_title or "—" }}
+        </p>
+        <div class="mt-1 flex items-center gap-3 text-[11px] text-gray-500 flex-wrap">
+          {% if site.contact_email %}<span class="truncate">{{ site.contact_email }}</span>{% endif %}
+          {% if site.contact_phone %}<span>{{ site.contact_phone }}</span>{% endif %}
+        </div>
+      </div>
+      <div class="flex items-center gap-1.5 flex-wrap flex-shrink-0">
+        {% if site.contact_phone %}
+        {{ outreach_btn("Call", "tel:" ~ site.contact_phone, "phone", site.contact_phone, company.id, site.id, none, site.contact_name,
+                        "M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z") }}
+        {% endif %}
+        {% if site.contact_email %}
+        {{ outreach_btn("Email", "mailto:" ~ site.contact_email, "email", site.contact_email, company.id, site.id, none, site.contact_name,
+                        "M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z") }}
+        {% endif %}
+      </div>
+    </div>
   </div>
+{% else %}
+  {# Real SiteContact row #}
+  <div class="bg-white rounded-lg border border-gray-200 p-3 hover:border-brand-200 transition-colors">
+    <div class="flex items-start justify-between gap-3 flex-wrap">
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="text-sm font-medium text-gray-900">{{ contact.full_name or "—" }}</span>
+          {% if contact.is_primary %}
+          <span class="px-1 py-0.5 text-[9px] font-medium rounded bg-emerald-50 text-emerald-700">Primary</span>
+          {% endif %}
+          {{ role_chip(contact.contact_role) }}
+        </div>
+        <p class="text-[11px] text-gray-500 mt-0.5">{{ contact.title or "—" }}</p>
+        <div class="mt-1 flex items-center gap-3 text-[11px] text-gray-500 flex-wrap">
+          {% if contact.email %}<span class="truncate">{{ contact.email }}</span>{% endif %}
+          {% if contact.phone %}<span>{{ contact.phone }}</span>{% endif %}
+          {% if contact.wechat_id %}<span>WeChat: {{ contact.wechat_id }}</span>{% endif %}
+        </div>
+        {# Per-contact cadence clocks — honest empty states for NULL timestamps #}
+        {{ contact_clocks(contact, now_utc) }}
+      </div>
+      <div class="flex items-center gap-1.5 flex-wrap flex-shrink-0">
+        {% if contact.phone %}
+        {{ outreach_btn("Call", "tel:" ~ contact.phone, "phone", contact.phone, company.id, contact.customer_site_id, contact.id, contact.full_name,
+                        "M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z") }}
+        {% endif %}
+        {% if contact.email %}
+        {{ outreach_btn("Email", "mailto:" ~ contact.email, "email", contact.email, company.id, contact.customer_site_id, contact.id, contact.full_name,
+                        "M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z") }}
+        {{ outreach_btn("Teams", "https://teams.microsoft.com/l/chat/0/0?users=" ~ contact.email|urlencode, "teams", contact.email, company.id, contact.customer_site_id, contact.id, contact.full_name,
+                        "M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z", new_tab=True) }}
+        {% endif %}
+        {% if contact.wechat_id %}
+        {{ outreach_btn("WeChat", "weixin://dl/chat?" ~ contact.wechat_id|urlencode, "wechat", contact.wechat_id, company.id, contact.customer_site_id, contact.id, contact.full_name,
+                        "M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z") }}
+        {% endif %}
+      </div>
+    </div>
+  </div>
+{% endif %}
+{% endmacro %}
+
+{# ── Group rows by site ────────────────────────────────────────────────────── #}
+{#
+   Build a site-keyed structure: site_id → {site, rows: [...]}
+   Rows with no site (edge case) fall into an "unknown" bucket.
+   Legacy rows always have a site.
+#}
+{% set site_groups = namespace(data={}, order=[]) %}
+{% for row in contact_rows %}
+  {% set sk = row.site.id if row.site else 0 %}
+  {% if sk not in site_groups.data %}
+    {% set _ = site_groups.data.update({sk: {'site': row.site, 'rows': []}}) %}
+    {% set _ = site_groups.order.append(sk) %}
+  {% endif %}
+  {% set _ = site_groups.data[sk]['rows'].append(row) %}
+{% endfor %}
+
+{# ── Render ────────────────────────────────────────────────────────────────── #}
+{% if not contact_rows %}
+<div class="p-8 text-center">
+  <p class="text-sm text-gray-500">No contacts found. Add contacts via the Sites tab.</p>
+</div>
+{% else %}
+<div class="space-y-3">
+  {% for sk in site_groups.order %}
+    {% set group = site_groups.data[sk] %}
+    {% set grp_site = group['site'] %}
+    {% set grp_rows = group['rows'] %}
+    {# Expand HQ / primary site by default (first group) — all others start closed #}
+    {% set is_first = loop.first %}
+    <div x-data='{"open": {{ "true" if is_first else "false" }}}' class="rounded-lg border border-gray-200">
+      {# Site accordion header #}
+      <button type='button'
+              @click='open = !open'
+              class='w-full flex items-center justify-between px-3 py-2 bg-gray-50 hover:bg-gray-100 rounded-t-lg transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-inset'
+              :aria-expanded='open'>
+        <div class='flex items-center gap-2'>
+          <svg class='h-4 w-4 text-gray-400 transition-transform' :class='"rotate-90": open'
+               fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'>
+            <path stroke-linecap='round' stroke-linejoin='round' d='M9 5l7 7-7 7'/>
+          </svg>
+          <span class='text-xs font-semibold text-gray-700'>
+            {{ grp_site.site_name if grp_site else "Unknown Site" }}
+          </span>
+        </div>
+        <span class='text-[11px] text-gray-400'>
+          {{ grp_rows|length }} contact{{ "s" if grp_rows|length != 1 }}
+        </span>
+      </button>
+      {# Contacts list — shown/hidden via Alpine #}
+      <div x-show='open' x-cloak x-transition class='space-y-2 p-2'>
+        {% for row in grp_rows %}
+          {{ contact_card(company, row.contact, row.site, row.legacy) }}
+        {% endfor %}
+      </div>
+    </div>
   {% endfor %}
 </div>
+{% endif %}

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -866,7 +866,7 @@ class TestContactsTabP33:
         resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
         html = resp.text
         # HQ has 2 contacts; the count must appear near the site name
-        assert "2" in html
+        assert "2 contacts" in html
 
     def test_accordion_uses_alpine_xdata(self, client: TestClient, db_session, test_user):
         """Accordion groups use Alpine x-data with an open/expanded boolean."""

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -796,6 +796,224 @@ class TestComputeUserScore:
         assert all(s == 0.0 for s in data["scores"])
 
 
+class TestContactsTabP33:
+    """P3-3 TDD: accordion by site, role chips, per-contact clocks, honest empty states.
+
+    Written FIRST (failing) per TDD — implement contacts_tab.html to pass.
+    """
+
+    def _setup_multi_site_company(self, db_session):
+        """Two active sites with contacts of varying roles and clock states."""
+        from app.models.crm import CustomerSite, SiteContact
+
+        company = Company(name="P33 Accordion Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+
+        site_hq = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+        site_branch = CustomerSite(company_id=company.id, site_name="Branch Office", is_active=True)
+        db_session.add_all([site_hq, site_branch])
+        db_session.flush()
+
+        # HQ contacts: one buyer with outbound clock set, one with NULL clocks
+        contact_buyer = SiteContact(
+            customer_site_id=site_hq.id,
+            full_name="Alice Buyer",
+            email="alice@p33.com",
+            contact_role="buyer",
+            is_primary=True,
+            last_outbound_at=__import__("datetime").datetime(2026, 5, 1, tzinfo=__import__("datetime").timezone.utc),
+        )
+        contact_no_clock = SiteContact(
+            customer_site_id=site_hq.id,
+            full_name="Bob Noclock",
+            email="bob@p33.com",
+            contact_role="technical",
+            last_outbound_at=None,
+            last_reply_at=None,
+        )
+        # Branch: decision_maker
+        contact_dm = SiteContact(
+            customer_site_id=site_branch.id,
+            full_name="Carol Decider",
+            email="carol@p33.com",
+            contact_role="decision_maker",
+        )
+        db_session.add_all([contact_buyer, contact_no_clock, contact_dm])
+        db_session.commit()
+        return company, site_hq, site_branch, contact_buyer, contact_no_clock, contact_dm
+
+    # ── accordion grouping ──────────────────────────────────────────────
+
+    def test_contacts_tab_returns_200(self, client: TestClient, db_session, test_user):
+        """GET contacts tab for a multi-site company returns 200."""
+        company, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert resp.status_code == 200
+
+    def test_contacts_grouped_under_site_headers(self, client: TestClient, db_session, test_user):
+        """Contacts tab renders both site names as accordion headers."""
+        company, site_hq, site_branch, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert resp.status_code == 200
+        html = resp.text
+        assert "HQ" in html
+        assert "Branch Office" in html
+
+    def test_site_header_shows_contact_count(self, client: TestClient, db_session, test_user):
+        """Site header shows the contact count for that site."""
+        company, site_hq, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        # HQ has 2 contacts; the count must appear near the site name
+        assert "2" in html
+
+    def test_accordion_uses_alpine_xdata(self, client: TestClient, db_session, test_user):
+        """Accordion groups use Alpine x-data with an open/expanded boolean."""
+        company, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        assert "x-data" in html
+        assert "x-show" in html
+
+    def test_all_three_contacts_appear(self, client: TestClient, db_session, test_user):
+        """All contacts from both sites appear in the tab."""
+        company, _, _, buyer, noclock, dm = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        assert "Alice Buyer" in html
+        assert "Bob Noclock" in html
+        assert "Carol Decider" in html
+
+    # ── role chips ──────────────────────────────────────────────────────
+
+    def test_buyer_role_chip_renders(self, client: TestClient, db_session, test_user):
+        """Buyer contact_role renders a chip containing 'buyer' text."""
+        company, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        # The chip must contain the role text (case-insensitive acceptable)
+        assert "buyer" in html.lower()
+
+    def test_technical_role_chip_renders(self, client: TestClient, db_session, test_user):
+        """Technical contact_role renders a chip."""
+        company, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        assert "technical" in html.lower()
+
+    def test_decision_maker_role_chip_renders(self, client: TestClient, db_session, test_user):
+        """decision_maker contact_role renders a chip."""
+        company, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        assert "decision" in html.lower()
+
+    def test_null_role_no_chip_crash(self, client: TestClient, db_session, test_user):
+        """A contact with NULL contact_role renders without error (graceful
+        fallback)."""
+        from app.models.crm import CustomerSite, SiteContact
+
+        company = Company(name="NullRole Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+        db_session.add(site)
+        db_session.flush()
+        contact = SiteContact(
+            customer_site_id=site.id,
+            full_name="No Role Pete",
+            email="pete@nullrole.com",
+            contact_role=None,
+        )
+        db_session.add(contact)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert resp.status_code == 200
+        assert "No Role Pete" in resp.text
+
+    # ── per-contact clocks ──────────────────────────────────────────────
+
+    def test_contact_with_outbound_shows_clock_value(self, client: TestClient, db_session, test_user):
+        """Contact with last_outbound_at set shows the outbound clock (days value)."""
+        company, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        # Alice Buyer has last_outbound_at set — some days label must appear
+        # The label "Out" or "out" or similar must be present
+        assert "out" in html.lower() or "outbound" in html.lower()
+
+    def test_null_outbound_shows_dash_not_never_replied(self, client: TestClient, db_session, test_user):
+        """NULL last_outbound_at renders '—' or 'no logged touch' — NOT 'never
+        replied'."""
+        company, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        # Must NOT say "never replied" (honest empty state rule)
+        assert "never replied" not in html.lower()
+        # Must indicate unknown/absent state via dash or descriptive text
+        # "—" (em-dash) OR "no logged touch" must appear somewhere
+        assert "—" in html or "no logged touch" in html.lower()
+
+    def test_null_reply_shows_dash(self, client: TestClient, db_session, test_user):
+        """NULL last_reply_at renders '—' — NOT 'never replied'."""
+        company, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        assert "never replied" not in html.lower()
+
+    def test_cadence_state_new_for_null_outbound(self, client: TestClient, db_session, test_user):
+        """Contact with NULL last_outbound_at renders a 'new' cadence indicator (no
+        red)."""
+        from app.models.crm import CustomerSite, SiteContact
+
+        company = Company(name="NewCadence Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+        db_session.add(site)
+        db_session.flush()
+        contact = SiteContact(
+            customer_site_id=site.id,
+            full_name="Fresh Freddy",
+            email="fresh@cadence.com",
+            last_outbound_at=None,
+        )
+        db_session.add(contact)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert resp.status_code == 200
+        html = resp.text
+        # cadence_state("new") should produce gray indicator, not rose (overdue)
+        # We can't assert no rose at all (there may be other elements), but
+        # "never replied" must not appear
+        assert "never replied" not in html.lower()
+
+    # ── outreach buttons preserved ──────────────────────────────────────
+
+    def test_outreach_buttons_still_present(self, client: TestClient, db_session, test_user):
+        """Outreach buttons (data-outreach-log) are still rendered after accordion
+        refactor."""
+        company, *_ = self._setup_multi_site_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        html = resp.text
+        assert "data-outreach-log" in html
+        assert 'href="mailto:alice@p33.com"' in html
+
+    # ── empty state ─────────────────────────────────────────────────────
+
+    def test_empty_company_shows_no_contacts_message(self, client: TestClient, db_session, test_user):
+        """Company with no contacts shows a helpful empty-state message."""
+        company = Company(name="Empty P33 Co", is_active=True)
+        db_session.add(company)
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/contacts")
+        assert resp.status_code == 200
+        assert "No contacts" in resp.text or "no contacts" in resp.text.lower()
+
+
 class TestCompanyDetailCadenceCard:
     """Tests for the new account-cadence card + commercial-context strip in the company
     detail partial.


### PR DESCRIPTION
## Cockpit P3-3 — contacts accordion + buying roles + per-contact clocks

Customer account-detail Contacts tab is now front-and-centre and relationship-aware.

### Changed
- **Accordion by site** — contacts grouped under collapsible site headers (per-site Alpine collapse, static-guard-safe single-quoted attrs); legacy site-level contacts still render.
- **Buying-role chips** — `SiteContact.contact_role` surfaced as a colored chip (buyer/technical/decision_maker/operations + graceful fallback); `is_primary` badge kept.
- **Per-contact clocks** — each contact shows Out (`last_outbound_at`) + Reply (`last_reply_at`) with a `cadence_state` indicator. **Honest empty states:** NULL → "—"/"no logged touch", never "never replied" (most contact clocks are NULL today because the email pipeline matches by email-string, not FK; click-to-contact DOES set `site_contact_id`, so clicking Call/Email/Teams/WeChat populates the per-contact outbound clock immediately).

### Tests
15 new (accordion x-data, all contacts grouped under their site, role chips per role + null fallback, per-contact clock labels, the "never replied" prohibition checked 3 ways, outreach buttons preserved). `test_crm_views` (68) + `test_static_analysis` (12) green.

Follow-up (separate): attribute inbound email to `site_contact_id` so per-contact reply clocks populate from email, not just clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
