### PR TITLE
feat(crm): unified account activity timeline + quote-value bug fix (cockpit P3-4)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -5071,6 +5071,10 @@ async def company_tab(
         # Merge all three sources into a single chronological timeline
         timeline = build_account_timeline(contacts, quotes, activities, req_map=req_map)
 
+        # Compute truncation flag: True if ANY source hit its limit
+        # (RFQ .limit(30), quotes .limit(20), activities .limit(30))
+        timeline_truncated = len(contacts) >= 30 or len(quotes) >= 20 or len(activities) >= 30
+
         # Load email intelligence for email activities (retained for potential future use)
         email_external_ids = [a.external_id for a in activities if a.external_id and a.channel == "email"]
         email_intel_map: dict = {}
@@ -5085,6 +5089,7 @@ async def company_tab(
             {
                 "company": company,
                 "timeline": timeline,
+                "timeline_truncated": timeline_truncated,
                 # Keep raw lists available for summary counts
                 "contacts": contacts,
                 "quotes": quotes,

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4730,6 +4730,86 @@ async def check_company_duplicate(
     return HTMLResponse("")
 
 
+def build_account_timeline(contacts, quotes, activities, *, req_map):
+    """Merge RFQ contacts, quotes, and activity logs into a single sorted list.
+
+    Each event dict has the shape:
+        {ts, kind, channel, direction, title, detail, is_meaningful,
+         quality_score, quality_classification, raw}
+
+    ``kind`` is one of "rfq" | "quote" | "activity".
+    Events are sorted descending by ``ts`` (newest first).
+    ``raw`` carries the original ORM object for template use.
+
+    Called by: company_tab (activity branch) in htmx_views.py.
+    """
+    from datetime import datetime, timezone
+
+    _epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    events: list[dict] = []
+
+    for c in contacts or []:
+        ts = c.created_at or _epoch
+        events.append(
+            {
+                "ts": ts,
+                "kind": "rfq",
+                "channel": "email",
+                "direction": "outbound",
+                "title": c.vendor_name or "Unknown Vendor",
+                "detail": c.subject or "",
+                "is_meaningful": True,
+                "quality_score": None,
+                "quality_classification": None,
+                "raw": c,
+                "req": req_map.get(c.requisition_id) if req_map and c.requisition_id else None,
+            }
+        )
+
+    for q in quotes or []:
+        ts = q.created_at or _epoch
+        # Use won_revenue for won quotes; fall back to subtotal then total_cost
+        if q.status == "won" and q.won_revenue:
+            display_value = q.won_revenue
+        else:
+            display_value = q.subtotal or q.total_cost
+        events.append(
+            {
+                "ts": ts,
+                "kind": "quote",
+                "channel": "internal",
+                "direction": None,
+                "title": q.quote_number or "Quote",
+                "detail": "${:,.2f}".format(float(display_value)) if display_value else "",
+                "is_meaningful": True,
+                "quality_score": None,
+                "quality_classification": None,
+                "raw": q,
+                "display_value": display_value,
+            }
+        )
+
+    for a in activities or []:
+        ts = a.occurred_at or a.created_at or _epoch
+        events.append(
+            {
+                "ts": ts,
+                "kind": "activity",
+                "channel": a.channel,
+                "direction": a.direction,
+                "title": (a.activity_type or "").replace("_", " ").title(),
+                "detail": a.summary or a.notes or a.subject or "",
+                "is_meaningful": a.is_meaningful,
+                "quality_score": a.quality_score,
+                "quality_classification": a.quality_classification,
+                "raw": a,
+            }
+        )
+
+    events.sort(key=lambda e: e["ts"], reverse=True)
+    return events
+
+
 def _company_quotes_query(db: Session, company):
     """Quotes belonging to an account: union of quotes linked via the
     company's customer sites OR via the company's requisitions (the latter
@@ -4988,7 +5068,10 @@ async def company_tab(
             .all()
         )
 
-        # Load email intelligence for email activities
+        # Merge all three sources into a single chronological timeline
+        timeline = build_account_timeline(contacts, quotes, activities, req_map=req_map)
+
+        # Load email intelligence for email activities (retained for potential future use)
         email_external_ids = [a.external_id for a in activities if a.external_id and a.channel == "email"]
         email_intel_map: dict = {}
         if email_external_ids:
@@ -5001,6 +5084,8 @@ async def company_tab(
         ctx.update(
             {
                 "company": company,
+                "timeline": timeline,
+                # Keep raw lists available for summary counts
                 "contacts": contacts,
                 "quotes": quotes,
                 "activities": activities,

--- a/app/templates/htmx/partials/customers/tabs/activity_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/activity_tab.html
@@ -214,6 +214,13 @@
 
       {% endfor %}
     </div>
+
+    {# ── Truncation Footer ─────────────────────────────────── #}
+    {% if timeline_truncated %}
+    <div class='px-4 py-2 bg-gray-50 border-t border-gray-200'>
+      <p class='text-xs text-gray-400'>Showing most recent activity — older history may not appear.</p>
+    </div>
+    {% endif %}
   </div>
   {% endif %}
 

--- a/app/templates/htmx/partials/customers/tabs/activity_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/activity_tab.html
@@ -1,138 +1,230 @@
-{# activity_tab.html — Company activity timeline with RFQ contacts, quotes, and activity logs.
-   Receives: company (Company), contacts (list[Contact]), quotes (list[Quote]),
+{# activity_tab.html — Unified account activity timeline (P3-4).
+   Replaces the old 3-section layout (RFQ History / Quotes / Activity Log) with
+   a single chronological timeline.  Each row shows a kind/channel icon,
+   direction indicator, title/detail, relative timestamp, and — for activity
+   entries — a quality badge.  An Alpine hide-noise toggle filters out
+   non-meaningful (is_meaningful==False) activity events.
+
+   Receives: company (Company), timeline (list[dict] from build_account_timeline),
+             contacts (list[Contact]), quotes (list[Quote]),
              activities (list[ActivityLog]), req_map (dict[int, Requisition]).
    Called by: company_tab route (tab=="activity") in htmx_views.py.
-   Depends on: HTMX, Tailwind CSS with brand palette, activity_row macro.
+   Depends on: HTMX, Tailwind CSS with brand palette, Alpine.js.
 #}
-{% from "htmx/partials/shared/_macros.html" import activity_row %}
-<div class="space-y-4">
 
-  <div hx-get="/v2/partials/customers/{{ company.id }}/activity-digest"
-       hx-trigger="load" hx-target="this" hx-swap="innerHTML">
-    <div class="rounded-lg border border-brand-200 bg-white p-4 animate-pulse">
-      <div class="h-3 w-2/3 bg-gray-100 rounded"></div>
+<div class='space-y-4'>
+
+  {# ── AI Digest (lazy) ──────────────────────────────────────── #}
+  <div hx-get='/v2/partials/customers/{{ company.id }}/activity-digest'
+       hx-trigger='load' hx-target='this' hx-swap='innerHTML'>
+    <div class='rounded-lg border border-brand-200 bg-white p-4 animate-pulse'>
+      <div class='h-3 w-2/3 bg-gray-100 rounded'></div>
     </div>
   </div>
 
-  {# ── Summary Bar ───────────────────────────────────────── #}
+  {# ── Summary Bar ───────────────────────────────────────────── #}
   {% set rfq_count = contacts|length if contacts else 0 %}
   {% set quote_count = quotes|length if quotes else 0 %}
   {% set activity_count = activities|length if activities else 0 %}
-  <div class="grid grid-cols-3 gap-3">
-    <div class="bg-white rounded-lg border border-gray-200 p-3 text-center">
-      <p class="text-lg font-bold text-brand-600">{{ rfq_count }}</p>
-      <p class="text-xs text-gray-500">RFQs Sent</p>
+  <div class='grid grid-cols-3 gap-3'>
+    <div class='bg-white rounded-lg border border-gray-200 p-3 text-center'>
+      <p class='text-lg font-bold text-brand-600'>{{ rfq_count }}</p>
+      <p class='text-xs text-gray-500'>RFQs Sent</p>
     </div>
-    <div class="bg-white rounded-lg border border-gray-200 p-3 text-center">
-      <p class="text-lg font-bold text-emerald-600">{{ quote_count }}</p>
-      <p class="text-xs text-gray-500">Quotes</p>
+    <div class='bg-white rounded-lg border border-gray-200 p-3 text-center'>
+      <p class='text-lg font-bold text-emerald-600'>{{ quote_count }}</p>
+      <p class='text-xs text-gray-500'>Quotes</p>
     </div>
-    <div class="bg-white rounded-lg border border-gray-200 p-3 text-center">
-      <p class="text-lg font-bold text-gray-600">{{ activity_count }}</p>
-      <p class="text-xs text-gray-500">Activities</p>
+    <div class='bg-white rounded-lg border border-gray-200 p-3 text-center'>
+      <p class='text-lg font-bold text-gray-600'>{{ activity_count }}</p>
+      <p class='text-xs text-gray-500'>Activities</p>
     </div>
   </div>
 
-  {# ── RFQ History ──────────────────────────────────────── #}
-  {% if contacts %}
-  <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
-    <div class="px-4 py-3 bg-gray-50 border-b">
-      <h3 class="text-sm font-semibold text-gray-900">RFQ History</h3>
+  {# ── Unified Timeline ──────────────────────────────────────── #}
+  {% if timeline %}
+  <div class='bg-white rounded-lg border border-gray-200 overflow-hidden'
+       x-data='{ hideNoise: false }'>
+
+    {# ── Timeline header + toggle ─────────────────────── #}
+    <div class='px-4 py-3 bg-gray-50 border-b flex items-center justify-between'>
+      <h3 class='text-sm font-semibold text-gray-900'>Timeline</h3>
+      <label class='flex items-center gap-1.5 cursor-pointer select-none'>
+        <input type='checkbox' x-model='hideNoise' class='h-3.5 w-3.5 rounded border-gray-300 text-brand-600 focus:ring-brand-500'>
+        <span class='text-xs text-gray-500'>Hide routine</span>
+      </label>
     </div>
-    <div class="divide-y divide-gray-100">
-      {% for c in contacts[:20] %}
-      <div class="flex items-center gap-3 px-4 py-2.5 hover:bg-brand-50">
-        {% set st_colors = {
-          'sent': 'bg-brand-50 text-brand-700',
-          'opened': 'bg-amber-50 text-amber-700',
-          'responded': 'bg-emerald-50 text-emerald-700',
-          'quoted': 'bg-emerald-50 text-emerald-700',
-          'declined': 'bg-rose-50 text-rose-700',
-          'bounced': 'bg-rose-50 text-rose-600',
-          'failed': 'bg-rose-50 text-rose-700'
-        } %}
-        <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full {{ st_colors.get(c.status, 'bg-gray-100 text-gray-600') }}">
-          {{ (c.status or 'sent')|capitalize }}
+
+    {# ── Timeline rows ────────────────────────────────── #}
+    <div class='divide-y divide-gray-50'>
+      {% for ev in timeline %}
+
+      {# Determine if this event is noise (only activity entries can be noise) #}
+      {% set is_noise = (ev.kind == 'activity' and ev.is_meaningful == false) %}
+
+      {# ── RFQ row ──────────────────────────────────────── #}
+      {% if ev.kind == 'rfq' %}
+      {% set c = ev.raw %}
+      {% set st_colors = {
+        'sent': 'bg-brand-50 text-brand-700',
+        'opened': 'bg-amber-50 text-amber-700',
+        'responded': 'bg-emerald-50 text-emerald-700',
+        'quoted': 'bg-emerald-50 text-emerald-700',
+        'declined': 'bg-rose-50 text-rose-700',
+        'bounced': 'bg-rose-50 text-rose-600',
+        'failed': 'bg-rose-50 text-rose-700'
+      } %}
+      <div class='flex items-start gap-3 px-4 py-3 hover:bg-brand-50'>
+        {# RFQ icon — paper-airplane #}
+        <span class='flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-600'>
+          <svg class='h-4 w-4' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='1.8' aria-hidden='true'>
+            <path stroke-linecap='round' stroke-linejoin='round' d='M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5'/>
+          </svg>
         </span>
-        <div class="flex-1 min-w-0">
-          <p class="text-sm text-gray-900 truncate">
-            <span class="font-medium">{{ c.vendor_name or "Unknown" }}</span>
-            {% if c.vendor_contact %}<span class="text-gray-500"> — {{ c.vendor_contact }}</span>{% endif %}
-          </p>
-          {% if c.subject %}<p class="text-xs text-gray-400 truncate">{{ c.subject }}</p>{% endif %}
+        <div class='flex-1 min-w-0'>
+          <div class='flex items-center gap-2 flex-wrap'>
+            <span class='text-xs font-medium px-1.5 py-0.5 rounded-full {{ st_colors.get(c.status, "bg-gray-100 text-gray-600") }}'>
+              {{ (c.status or 'sent')|capitalize }}
+            </span>
+            <p class='text-sm font-medium text-gray-900'>RFQ — {{ c.vendor_name or "Unknown" }}</p>
+            {% if c.vendor_contact %}
+            <span class='text-xs text-gray-500'>{{ c.vendor_contact }}</span>
+            {% endif %}
+            {# outbound direction pill #}
+            <span class='inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-brand-50 text-brand-600'>
+              <svg class='h-2.5 w-2.5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2' aria-hidden='true'><path stroke-linecap='round' stroke-linejoin='round' d='M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25'/></svg>
+              Out
+            </span>
+          </div>
+          {% if c.subject %}<p class='text-xs text-gray-400 truncate mt-0.5'>{{ c.subject }}</p>{% endif %}
         </div>
-        {% set req = req_map.get(c.requisition_id) if req_map else None %}
-        {% if req %}
-        <a hx-get="/v2/partials/requisitions/{{ req.id }}"
-           hx-target="#main-content"
-           hx-push-url="/v2/requisitions/{{ req.id }}"
-           class="text-xs text-brand-500 hover:text-brand-600 whitespace-nowrap cursor-pointer">
-          Req #{{ req.id }}
-        </a>
-        {% endif %}
-        <span class="text-xs text-gray-400 whitespace-nowrap">{{ c.created_at.strftime('%b %d') if c.created_at else "" }}</span>
+        <div class='text-right flex-shrink-0 flex flex-col items-end gap-1'>
+          {% if ev.req %}
+          <a hx-get='/v2/partials/requisitions/{{ ev.req.id }}'
+             hx-target='#main-content'
+             hx-push-url='/v2/requisitions/{{ ev.req.id }}'
+             class='text-xs text-brand-500 hover:text-brand-600 cursor-pointer whitespace-nowrap'>
+            Req #{{ ev.req.id }}
+          </a>
+          {% endif %}
+          <span class='text-[11px] text-gray-400 whitespace-nowrap'>{{ ev.ts.strftime('%b %d') if ev.ts else "" }}</span>
+        </div>
       </div>
-      {% endfor %}
-    </div>
-  </div>
-  {% endif %}
 
-  {# ── Quotes ────────────────────────────────────────────── #}
-  {% if quotes %}
-  <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
-    <div class="px-4 py-3 bg-gray-50 border-b">
-      <h3 class="text-sm font-semibold text-gray-900">Quotes</h3>
-    </div>
-    <div class="divide-y divide-gray-100">
-      {% for q in quotes[:20] %}
+      {# ── Quote row ─────────────────────────────────────── #}
+      {% elif ev.kind == 'quote' %}
+      {% set q = ev.raw %}
       {% set q_colors = {
         'draft': 'bg-gray-100 text-gray-600',
         'sent': 'bg-brand-50 text-brand-700',
         'won': 'bg-emerald-50 text-emerald-700',
         'lost': 'bg-rose-50 text-rose-700',
       } %}
-      <div class="flex items-center gap-3 px-4 py-2.5 hover:bg-brand-50 cursor-pointer"
-           hx-get="/v2/partials/quotes/{{ q.id }}"
-           hx-target="#main-content"
-           hx-push-url="/v2/quotes/{{ q.id }}">
-        <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full {{ q_colors.get(q.status, 'bg-gray-100 text-gray-600') }}">
-          {{ (q.status or 'draft')|capitalize }}
+      <div class='flex items-start gap-3 px-4 py-3 hover:bg-brand-50 cursor-pointer'
+           hx-get='/v2/partials/quotes/{{ q.id }}'
+           hx-target='#main-content'
+           hx-push-url='/v2/quotes/{{ q.id }}'>
+        {# Quote icon — document-text #}
+        <span class='flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100 text-emerald-600'>
+          <svg class='h-4 w-4' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='1.8' aria-hidden='true'>
+            <path stroke-linecap='round' stroke-linejoin='round' d='M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z'/>
+          </svg>
         </span>
-        <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-gray-900">{{ q.quote_number or "Quote" }}</p>
-          {% if q.total_amount %}
-          <p class="text-xs text-gray-500">${{ "{:,.2f}".format(q.total_amount) }}</p>
+        <div class='flex-1 min-w-0'>
+          <div class='flex items-center gap-2 flex-wrap'>
+            <span class='text-xs font-medium px-1.5 py-0.5 rounded-full {{ q_colors.get(q.status, "bg-gray-100 text-gray-600") }}'>
+              {{ (q.status or 'draft')|capitalize }}
+            </span>
+            <p class='text-sm font-medium text-gray-900'>{{ q.quote_number or "Quote" }}</p>
+          </div>
+          {% if ev.display_value %}
+          <p class='text-xs text-gray-500 mt-0.5'>${{ "{:,.2f}".format(ev.display_value|float) }}</p>
           {% endif %}
         </div>
-        <span class="text-xs text-gray-400 whitespace-nowrap">{{ q.created_at.strftime('%b %d') if q.created_at else "" }}</span>
+        <span class='text-[11px] text-gray-400 whitespace-nowrap flex-shrink-0'>{{ ev.ts.strftime('%b %d') if ev.ts else "" }}</span>
       </div>
+
+      {# ── Activity row ──────────────────────────────────── #}
+      {% else %}
+      {% set a = ev.raw %}
+      <div class='flex gap-3 py-3 px-4 border-b border-gray-50 last:border-0 hover:bg-gray-50 {% if is_noise %}js-timeline-noise{% endif %}'
+           {% if is_noise %}x-show='!hideNoise'{% endif %}>
+        {# Reuse the activity icon logic inline (same as activity_row macro) #}
+        {%- set icon_map = {
+          'rfq_sent':             {'accent': 'bg-brand-100 text-brand-600',     'path': 'M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5'},
+          'email_received':       {'accent': 'bg-blue-100 text-blue-600',       'path': 'M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75'},
+          'call_logged':          {'accent': 'bg-emerald-100 text-emerald-600', 'path': 'M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z'},
+          'sales_note':           {'accent': 'bg-gray-100 text-gray-500',       'path': 'M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10'},
+          'task_completed':       {'accent': 'bg-emerald-100 text-emerald-600', 'path': 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z'},
+          'status_changed':       {'accent': 'bg-gray-100 text-gray-500',       'path': 'M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99'},
+          'offer_created':        {'accent': 'bg-amber-100 text-amber-600',     'path': 'M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9zm.75 12.75h3m-3 2.25h3m-6-9.75v-1.5m0 0V9m0 1.5h1.5m-1.5 0H9'},
+          'offer_status_changed': {'accent': 'bg-amber-100 text-amber-600',     'path': 'M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z'},
+          'sighting_added':       {'accent': 'bg-indigo-100 text-indigo-600',   'path': 'M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z'},
+          'assignment_changed':   {'accent': 'bg-gray-100 text-gray-500',       'path': 'M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z'},
+          'req_archived':         {'accent': 'bg-gray-100 text-gray-500',       'path': 'M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z'},
+          'req_unarchived':       {'accent': 'bg-gray-100 text-gray-500',       'path': 'M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5'}
+        } -%}
+        {%- set fallback = {'accent': 'bg-gray-100 text-gray-500', 'path': 'M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z'} -%}
+        {%- set icon = icon_map.get(a.activity_type, fallback) -%}
+        <span class='flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full {{ icon.accent }}'>
+          <svg class='h-4 w-4' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='1.8' aria-hidden='true'>
+            <path stroke-linecap='round' stroke-linejoin='round' d='{{ icon.path }}'/>
+          </svg>
+        </span>
+        <div class='flex-1 min-w-0'>
+          <div class='flex items-center gap-2 flex-wrap'>
+            <p class='text-sm font-medium text-gray-900'>{{ ev.title }}</p>
+            {# Direction pill (inbound/outbound) #}
+            {% if ev.direction == 'inbound' %}
+            <span class='inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-blue-50 text-blue-600'>
+              <svg class='h-2.5 w-2.5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2' aria-hidden='true'><path stroke-linecap='round' stroke-linejoin='round' d='M19.5 4.5l-15 15m0 0h11.25m-11.25 0V8.25'/></svg>
+              In
+            </span>
+            {% elif ev.direction == 'outbound' %}
+            <span class='inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-brand-50 text-brand-600'>
+              <svg class='h-2.5 w-2.5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2' aria-hidden='true'><path stroke-linecap='round' stroke-linejoin='round' d='M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25'/></svg>
+              Out
+            </span>
+            {% endif %}
+            {# Channel badge #}
+            {% if a.channel and a.channel not in ('system', 'manual', 'internal') %}
+            <span class='inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-gray-100 text-gray-600'>{{ a.channel|capitalize }}</span>
+            {% endif %}
+            {# Quality badge — only for activity events with quality data #}
+            {% if ev.is_meaningful == true %}
+            <span class='inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-emerald-50 text-emerald-700'>Meaningful</span>
+            {% elif ev.is_meaningful == false %}
+            <span class='inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-gray-100 text-gray-400'>Routine</span>
+            {% endif %}
+          </div>
+          {# Contact attribution #}
+          {% set who = a.vendor_card.display_name if a.vendor_card_id and a.vendor_card else a.contact_name %}
+          {% if who %}
+          <p class='text-xs text-gray-500 mt-0.5'>{{ who }}</p>
+          {% endif %}
+          {% if ev.detail %}
+          <p class='text-xs text-gray-600 mt-0.5 leading-relaxed line-clamp-2'>{{ ev.detail }}</p>
+          {% endif %}
+        </div>
+        <div class='text-right flex-shrink-0'>
+          <p class='text-[11px] text-gray-400 whitespace-nowrap'>{{ (a.occurred_at or a.created_at)|timeago }}</p>
+        </div>
+      </div>
+      {% endif %}
+
       {% endfor %}
     </div>
   </div>
   {% endif %}
 
-  {# ── Activity Log ──────────────────────────────────────── #}
-  {% if activities %}
-  <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
-    <div class="px-4 py-3 bg-gray-50 border-b">
-      <h3 class="text-sm font-semibold text-gray-900">Activity Log</h3>
-    </div>
-    <div class="px-4 py-2">
-      {% for a in activities[:30] %}
-      {{ activity_row(a) }}
-      {% endfor %}
-    </div>
-  </div>
-  {% endif %}
-
-  {# ── Empty State ───────────────────────────────────────── #}
-  {% if not contacts and not quotes and not activities %}
-  <div class="p-8 text-center">
-    <svg class="mx-auto h-10 w-10 text-gray-300 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+  {# ── Empty State ───────────────────────────────────────────── #}
+  {% if not timeline %}
+  <div class='p-8 text-center'>
+    <svg class='mx-auto h-10 w-10 text-gray-300 mb-3' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+      <path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'/>
     </svg>
-    <p class="text-sm text-gray-500">No activity recorded for this company yet.</p>
-    <p class="text-xs text-gray-400 mt-1">Activity will appear here as you send RFQs, create quotes, and log interactions.</p>
+    <p class='text-sm text-gray-500'>No activity recorded for this company yet.</p>
+    <p class='text-xs text-gray-400 mt-1'>Activity will appear here as you send RFQs, create quotes, and log interactions.</p>
   </div>
   {% endif %}
 

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -1577,3 +1577,143 @@ class TestUnifiedTimelineHelper:
         events = build_account_timeline([rfq], [quote], [act], req_map={})
         assert events[0]["ts"] == new
         assert events[-1]["ts"] == old
+
+
+class TestActivityTabTruncation:
+    """Test that the activity timeline indicates when results are truncated."""
+
+    def test_activity_tab_shows_truncation_footer_when_rfq_limit_hit(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """When >30 RFQ contacts exist, the timeline shows the truncation footer."""
+        from app.models.offers import Contact as RfqContact
+        from app.models.sourcing import Requisition
+
+        company = Company(name="Busy Corp", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+
+        # Create a requisition for the company
+        req = Requisition(name="RFQ-001", customer_name=company.name, company_id=company.id, status="active")
+        db_session.add(req)
+        db_session.flush()
+
+        # Create 31 RFQ contacts (exceeds .limit(30))
+        base_ts = datetime.now(timezone.utc)
+        for i in range(31):
+            contact = RfqContact(
+                requisition_id=req.id,
+                user_id=test_user.id,
+                contact_type="rfq",
+                vendor_name=f"Vendor {i:02d}",
+                vendor_contact="test@example.com",
+                subject=f"RFQ {i}",
+                status="sent",
+                created_at=base_ts - timedelta(hours=i),
+            )
+            db_session.add(contact)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/activity")
+        assert resp.status_code == 200
+        assert "Showing most recent activity" in resp.text
+
+    def test_activity_tab_shows_truncation_footer_when_quote_limit_hit(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """When >20 quotes exist, the timeline shows the truncation footer."""
+        from decimal import Decimal
+
+        from app.models.crm import CustomerSite
+        from app.models.quotes import Quote
+        from app.models.sourcing import Requisition
+
+        company = Company(name="Quote Busy Corp", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+
+        # Create a site for the company
+        site = CustomerSite(company_id=company.id, site_name="Main")
+        db_session.add(site)
+        db_session.flush()
+
+        # Create a requisition for the company to link quotes
+        req = Requisition(name="QT-REQ-001", company_id=company.id, customer_site_id=site.id, status="active")
+        db_session.add(req)
+        db_session.flush()
+
+        # Create 21 quotes (exceeds .limit(20))
+        base_ts = datetime.now(timezone.utc)
+        for i in range(21):
+            quote = Quote(
+                requisition_id=req.id,
+                customer_site_id=site.id,
+                quote_number=f"Q-{i:03d}",
+                status="sent",
+                subtotal=Decimal("1000.00"),
+                total_cost=Decimal("1000.00"),
+                created_at=base_ts - timedelta(hours=i),
+            )
+            db_session.add(quote)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/activity")
+        assert resp.status_code == 200
+        assert "Showing most recent activity" in resp.text
+
+    def test_activity_tab_shows_truncation_footer_when_activity_limit_hit(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """When >30 activities exist, the timeline shows the truncation footer."""
+        from app.models.intelligence import ActivityLog
+
+        company = Company(name="Active Corp", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+
+        # Create 31 activity logs (exceeds .limit(30))
+        base_ts = datetime.now(timezone.utc)
+        for i in range(31):
+            activity = ActivityLog(
+                company_id=company.id,
+                activity_type="sales_note",
+                channel="manual",
+                notes=f"Activity {i}",
+                is_meaningful=True,
+                created_at=base_ts - timedelta(hours=i),
+            )
+            db_session.add(activity)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/activity")
+        assert resp.status_code == 200
+        assert "Showing most recent activity" in resp.text
+
+    def test_activity_tab_no_truncation_footer_when_under_limits(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """When all sources are under their limits, no truncation footer appears."""
+        from app.models.intelligence import ActivityLog
+
+        company = Company(name="Small Corp", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+
+        # Create just 5 activities (well under .limit(30))
+        base_ts = datetime.now(timezone.utc)
+        for i in range(5):
+            activity = ActivityLog(
+                company_id=company.id,
+                activity_type="sales_note",
+                channel="manual",
+                notes=f"Activity {i}",
+                is_meaningful=True,
+                created_at=base_ts - timedelta(hours=i),
+            )
+            db_session.add(activity)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{company.id}/tab/activity")
+        assert resp.status_code == 200
+        # Truncation footer should NOT appear
+        assert "Showing most recent activity" not in resp.text

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -1200,3 +1200,380 @@ class TestCompanyDetailCadenceCard:
         # These exact strings were the old stat-row labels — they must be gone
         assert "Open Requisitions" not in html
         assert ">Created<" not in html
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# P3-4: Unified Activity Timeline
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestUnifiedActivityTimeline:
+    """P3-4: activity tab merges RFQ contacts + quotes + activity logs into ONE
+    chronological timeline, fixes the q.total_amount bug, adds quality badges,
+    and exposes a hide-noise toggle.
+    """
+
+    # ── helpers ─────────────────────────────────────────────────────────────
+
+    def _make_company(self, db_session: Session, name: str = "Timeline Co") -> "Company":
+        from app.models.crm import Company
+
+        co = Company(name=name, is_active=True)
+        db_session.add(co)
+        db_session.flush()
+        return co
+
+    def _make_requisition(self, db_session: Session, company, name: str = "REQ-001"):
+        from app.models.sourcing import Requisition
+
+        req = Requisition(name=name, customer_name=company.name, company_id=company.id, status="active")
+        db_session.add(req)
+        db_session.flush()
+        return req
+
+    # ── route returns 200 with merged timeline ────────────────────────────
+
+    def test_activity_tab_returns_200(self, client: TestClient, db_session: Session, test_user: User):
+        """GET /v2/partials/customers/{id}/tab/activity returns 200."""
+        co = self._make_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
+        assert resp.status_code == 200
+
+    def test_all_three_event_kinds_appear_in_timeline(self, client: TestClient, db_session: Session, test_user: User):
+        """Timeline shows events from all three sources: RFQ, quote, activity."""
+        from decimal import Decimal
+
+        from app.models.intelligence import ActivityLog
+        from app.models.offers import Contact as RfqContact
+        from app.models.quotes import Quote
+
+        co = self._make_company(db_session, "MergeTest Co")
+        req = self._make_requisition(db_session, co)
+
+        # RFQ contact
+        rfq = RfqContact(
+            requisition_id=req.id,
+            user_id=test_user.id,
+            contact_type="rfq",
+            vendor_name="Acme Vendor",
+            status="sent",
+            created_at=datetime(2026, 6, 10, tzinfo=timezone.utc),
+        )
+        db_session.add(rfq)
+
+        # Quote with real money value (subtotal — the correct field)
+        q = Quote(
+            requisition_id=req.id,
+            quote_number="QT-2026-001",
+            subtotal=Decimal("9999.00"),
+            status="sent",
+            created_at=datetime(2026, 6, 11, tzinfo=timezone.utc),
+        )
+        db_session.add(q)
+
+        # Meaningful activity
+        act = ActivityLog(
+            user_id=test_user.id,
+            activity_type="email_received",
+            channel="email",
+            company_id=co.id,
+            subject="Follow-up RE: STM32",
+            direction="inbound",
+            is_meaningful=True,
+            quality_score=0.85,
+            quality_classification="meaningful",
+            created_at=datetime(2026, 6, 12, tzinfo=timezone.utc),
+        )
+        db_session.add(act)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
+        assert resp.status_code == 200
+        html = resp.text
+
+        # All three kinds present
+        assert "Acme Vendor" in html, "RFQ vendor missing from timeline"
+        assert "QT-2026-001" in html, "Quote number missing from timeline"
+        assert "Email Received" in html, "Activity entry missing from timeline"
+
+    def test_quote_value_renders_not_blank(self, client: TestClient, db_session: Session, test_user: User):
+        """Quote dollar value renders (guards the q.total_amount bug fix).
+
+        The old template used q.total_amount which does NOT exist on Quote, so every
+        quote row rendered blank.  Now uses q.subtotal (or won_revenue for won quotes).
+        A quote with subtotal=1234.56 must show that value.
+        """
+        from decimal import Decimal
+
+        from app.models.quotes import Quote
+
+        co = self._make_company(db_session, "QuoteBug Co")
+        req = self._make_requisition(db_session, co)
+
+        q = Quote(
+            requisition_id=req.id,
+            quote_number="QT-BUG-001",
+            subtotal=Decimal("1234.56"),
+            status="sent",
+            created_at=datetime(2026, 6, 10, tzinfo=timezone.utc),
+        )
+        db_session.add(q)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
+        assert resp.status_code == 200
+        # Dollar value must appear — "1,234.56" formatted
+        assert "1,234.56" in resp.text, "Quote subtotal not rendered (total_amount bug still present)"
+
+    def test_won_quote_shows_won_revenue(self, client: TestClient, db_session: Session, test_user: User):
+        """Won quote shows won_revenue rather than subtotal."""
+        from decimal import Decimal
+
+        from app.models.quotes import Quote
+
+        co = self._make_company(db_session, "WonQuote Co")
+        req = self._make_requisition(db_session, co)
+
+        q = Quote(
+            requisition_id=req.id,
+            quote_number="QT-WON-001",
+            subtotal=Decimal("5000.00"),
+            won_revenue=Decimal("4800.00"),
+            status="won",
+            created_at=datetime(2026, 6, 10, tzinfo=timezone.utc),
+        )
+        db_session.add(q)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
+        assert resp.status_code == 200
+        assert "4,800.00" in resp.text, "Won revenue not rendered for won quote"
+
+    def test_meaningful_activity_has_quality_badge(self, client: TestClient, db_session: Session, test_user: User):
+        """Meaningful activity entry carries a quality badge in the rendered HTML."""
+        from app.models.intelligence import ActivityLog
+
+        co = self._make_company(db_session, "QualityBadge Co")
+        act = ActivityLog(
+            user_id=test_user.id,
+            activity_type="email_received",
+            channel="email",
+            company_id=co.id,
+            subject="Pricing request",
+            is_meaningful=True,
+            quality_score=0.9,
+            quality_classification="meaningful",
+            created_at=datetime(2026, 6, 12, tzinfo=timezone.utc),
+        )
+        db_session.add(act)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
+        assert resp.status_code == 200
+        # "Meaningful" badge text must appear
+        assert "meaningful" in resp.text.lower(), "Meaningful quality badge not rendered"
+
+    def test_noise_activity_has_hide_noise_marker(self, client: TestClient, db_session: Session, test_user: User):
+        """Non-meaningful (noise) activity has the hide-noise CSS class/marker."""
+        from app.models.intelligence import ActivityLog
+
+        co = self._make_company(db_session, "NoiseTest Co")
+        noise = ActivityLog(
+            user_id=test_user.id,
+            activity_type="email_received",
+            channel="email",
+            company_id=co.id,
+            subject="Out of office: re-joining Mon",
+            is_meaningful=False,
+            quality_score=0.1,
+            quality_classification="noise",
+            created_at=datetime(2026, 6, 10, tzinfo=timezone.utc),
+        )
+        db_session.add(noise)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
+        assert resp.status_code == 200
+        # Noise entries must carry the js-timeline-noise class for Alpine toggle
+        assert "js-timeline-noise" in resp.text, "Noise marker class missing from noise entry"
+
+    def test_hide_noise_toggle_control_present(self, client: TestClient, db_session: Session, test_user: User):
+        """Hide-noise Alpine toggle control is rendered in the activity tab."""
+        from app.models.intelligence import ActivityLog
+
+        co = self._make_company(db_session, "ToggleTest Co")
+        act = ActivityLog(
+            user_id=test_user.id,
+            activity_type="email_received",
+            channel="email",
+            company_id=co.id,
+            is_meaningful=False,
+            created_at=datetime(2026, 6, 10, tzinfo=timezone.utc),
+        )
+        db_session.add(act)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
+        assert resp.status_code == 200
+        html = resp.text
+        # Alpine x-data toggle must be present
+        assert "hideNoise" in html, "Alpine hideNoise toggle not in template"
+        assert "Hide routine" in html or "hide routine" in html.lower(), "Hide routine toggle label not found"
+
+    def test_events_are_sorted_newest_first(self, client: TestClient, db_session: Session, test_user: User):
+        """Timeline events appear in descending chronological order (newest first)."""
+        from decimal import Decimal
+
+        from app.models.intelligence import ActivityLog
+        from app.models.quotes import Quote
+
+        co = self._make_company(db_session, "SortTest Co")
+        req = self._make_requisition(db_session, co)
+
+        # Older quote
+        q = Quote(
+            requisition_id=req.id,
+            quote_number="QT-SORT-OLD",
+            subtotal=Decimal("100.00"),
+            status="draft",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+        db_session.add(q)
+
+        # Newer activity
+        act = ActivityLog(
+            user_id=test_user.id,
+            activity_type="sales_note",
+            channel="manual",
+            company_id=co.id,
+            notes="Follow-up call done",
+            is_meaningful=True,
+            created_at=datetime(2026, 6, 5, tzinfo=timezone.utc),
+        )
+        db_session.add(act)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
+        assert resp.status_code == 200
+        html = resp.text
+
+        # The newer activity should appear before (lower index) the older quote
+        act_pos = html.find("Follow-up call done")
+        quote_pos = html.find("QT-SORT-OLD")
+        assert act_pos != -1, "Activity note not found in timeline"
+        assert quote_pos != -1, "Quote not found in timeline"
+        assert act_pos < quote_pos, "Newer activity should appear before older quote (newest-first order)"
+
+    def test_no_separate_rfq_history_section(self, client: TestClient, db_session: Session, test_user: User):
+        """The old 'RFQ History' section heading is gone — replaced by unified
+        timeline."""
+        co = self._make_company(db_session, "NoSectionsTest Co")
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/activity")
+        assert resp.status_code == 200
+        assert "RFQ History" not in resp.text, "Old 'RFQ History' section still present"
+        assert "Activity Log" not in resp.text, "Old 'Activity Log' section still present"
+
+
+class TestUnifiedTimelineHelper:
+    """Unit tests for the build_account_timeline helper function."""
+
+    def test_build_timeline_merges_three_sources(self):
+        """build_account_timeline produces events from all 3 source lists."""
+        from datetime import datetime, timezone
+        from decimal import Decimal
+        from types import SimpleNamespace
+
+        from app.routers.htmx_views import build_account_timeline
+
+        t1 = datetime(2026, 6, 10, tzinfo=timezone.utc)
+        t2 = datetime(2026, 6, 11, tzinfo=timezone.utc)
+        t3 = datetime(2026, 6, 12, tzinfo=timezone.utc)
+
+        rfq = SimpleNamespace(
+            vendor_name="Acme",
+            vendor_contact=None,
+            subject="Test RFQ",
+            status="sent",
+            created_at=t1,
+            requisition_id=1,
+        )
+        quote = SimpleNamespace(
+            id=1,
+            quote_number="QT-001",
+            subtotal=Decimal("500.00"),
+            total_cost=Decimal("490.00"),
+            won_revenue=None,
+            status="sent",
+            created_at=t2,
+        )
+        act = SimpleNamespace(
+            activity_type="email_received",
+            channel="email",
+            direction="inbound",
+            subject="Hello",
+            summary=None,
+            notes=None,
+            is_meaningful=True,
+            quality_score=0.8,
+            quality_classification="meaningful",
+            occurred_at=None,
+            created_at=t3,
+            contact_name="Alice",
+            vendor_card_id=None,
+            vendor_card=None,
+        )
+
+        events = build_account_timeline([rfq], [quote], [act], req_map={1: SimpleNamespace(id=1)})
+        kinds = {e["kind"] for e in events}
+        assert "rfq" in kinds
+        assert "quote" in kinds
+        assert "activity" in kinds
+
+    def test_build_timeline_sorted_desc(self):
+        """Events are sorted newest-first."""
+        from datetime import datetime, timezone
+        from types import SimpleNamespace
+
+        from app.routers.htmx_views import build_account_timeline
+
+        old = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        mid = datetime(2026, 6, 5, tzinfo=timezone.utc)
+        new = datetime(2026, 6, 9, tzinfo=timezone.utc)
+
+        rfq = SimpleNamespace(
+            vendor_name="V",
+            vendor_contact=None,
+            subject=None,
+            status="sent",
+            created_at=old,
+            requisition_id=None,
+        )
+        quote = SimpleNamespace(
+            id=2,
+            quote_number="Q",
+            subtotal=None,
+            total_cost=None,
+            won_revenue=None,
+            status="draft",
+            created_at=mid,
+        )
+        act = SimpleNamespace(
+            activity_type="sales_note",
+            channel="manual",
+            direction=None,
+            subject=None,
+            summary=None,
+            notes="note",
+            is_meaningful=True,
+            quality_score=None,
+            quality_classification=None,
+            occurred_at=None,
+            created_at=new,
+            contact_name=None,
+            vendor_card_id=None,
+            vendor_card=None,
+        )
+
+        events = build_account_timeline([rfq], [quote], [act], req_map={})
+        assert events[0]["ts"] == new
+        assert events[-1]["ts"] == old


### PR DESCRIPTION
## Cockpit P3-4 — unified activity timeline + quote-value bug fix

The account-detail Activity tab was three disconnected stacked lists (RFQ history / Quotes / Activity log). Now it's ONE chronological relationship timeline.

### Changed
- **Unified timeline** — a route helper (`build_account_timeline`) merges RFQs, quotes, and activity-log events into one list sorted newest-first (tz-safe via `UTCDateTime`), rendered as a single timeline with per-kind/channel icons + direction indicators.
- **Quality badges** — activity events show Meaningful / Routine via `is_meaningful`; RFQ/quote events are inherently meaningful (no badge).
- **Hide-noise toggle** — Alpine toggle hides `is_meaningful == false` activities (RFQ/quote never hidden; default shows all).
- **Truncation honesty** — when any source hits its cap, a muted "Showing most recent activity — older history may not appear" footer renders (no silent truncation).
- **Bug fix** — `activity_tab` rendered `q.total_amount` (a non-existent Quote field → blank). Replaced with a route-computed `display_value` (`won_revenue` for won quotes, else `subtotal`) so quote dollar values actually render.

### Tests
15 new (merge/sort helper unit tests + integration: all 3 kinds present & ordered, quote value non-blank [guards the bug], quality badges, hide-noise marker + toggle, truncation footer present/absent). `test_crm_views` green (83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
