### PR TITLE
test(crm): align activity-tab integration test with unified timeline (P3-4 follow-up)

### DIFF
--- a/tests/test_phase_integration_fixes.py
+++ b/tests/test_phase_integration_fixes.py
@@ -305,7 +305,7 @@ class TestCompanyActivityTab:
         resp = client.get(f"/v2/partials/customers/{company.id}/tab/activity")
         assert resp.status_code == 200
         assert "Activity Vendor" in resp.text
-        assert "RFQ History" in resp.text
+        assert "RFQ — Activity Vendor" in resp.text  # unified timeline RFQ row title
         assert f"Req #{req.id}" in resp.text
 
     def test_company_activity_tab_empty(self, client: TestClient, db_session: Session, test_user: User):


### PR DESCRIPTION
P3-4 unified the account-detail Activity tab (3 sections → one chronological timeline), removing the "RFQ History" section header. `test_phase_integration_fixes.py::TestCompanyActivityTab::test_company_activity_tab_with_rfq` still asserted that removed header (P3-4 implementer ran test_crm_views but not this file).

Fix (test-only): assert the real unified-timeline row title `RFQ — <vendor>` instead of the gone `"RFQ History"` header; the other assertions (vendor name, `Req #N`) were already valid. `test_phase_integration_fixes.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)