### PR TITLE
feat(crm): contact-level email attribution — per-contact clocks from email (P1a)

### DIFF
--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -42,11 +42,46 @@ _RULE_MEANINGFUL_TYPES: frozenset[str] = frozenset(
 # ═══════════════════════════════════════════════════════════════════════
 
 
+def _resolve_site_contact(email_lower: str, company_id: int, site_id: int | None, db: Session) -> int | None:
+    """Return the SiteContact.id whose email matches email_lower within the company's
+    sites.
+
+    Scoped to the matched site when known, otherwise searches all active sites for the
+    company. Prefers email_verified=True, then is_primary=True, then first found.
+    Returns None if no match — NO change to existing behaviour.
+    """
+    q = (
+        db.query(SiteContact)
+        .join(CustomerSite, SiteContact.customer_site_id == CustomerSite.id)
+        .filter(
+            func.lower(SiteContact.email) == email_lower,
+            CustomerSite.company_id == company_id,
+            CustomerSite.is_active.is_(True),
+        )
+    )
+    if site_id is not None:
+        q = q.filter(SiteContact.customer_site_id == site_id)
+    candidates = q.all()
+    if not candidates:
+        return None
+    # Prefer verified, then primary, then first
+    for sc in candidates:
+        if sc.email_verified:
+            return sc.id
+    for sc in candidates:
+        if sc.is_primary:
+            return sc.id
+    return candidates[0].id
+
+
 def match_email_to_entity(email_addr: str, db: Session) -> dict | None:
     """Match an email address to a company or vendor card.
 
     Returns {"type": "company"|"vendor", "id": int, "name": str} or None. Checks
     customer sites first, then vendor contacts, then vendor card email lists.
+
+    For customer-side matches also resolves the SiteContact whose email equals the
+    address and includes site_contact_id in the result (None when no contact found).
     """
     if not email_addr:
         return None
@@ -63,7 +98,14 @@ def match_email_to_entity(email_addr: str, db: Session) -> dict | None:
         .first()
     )
     if site:
-        return {"type": "company", "id": site.company_id, "name": site.site_name, "site_id": site.id}
+        sc_id = _resolve_site_contact(email_lower, site.company_id, site.id, db)
+        return {
+            "type": "company",
+            "id": site.company_id,
+            "name": site.site_name,
+            "site_id": site.id,
+            "site_contact_id": sc_id,
+        }
 
     # 2. Check vendor_contacts table (exact match)
     vc = db.query(VendorContact).filter(func.lower(VendorContact.email) == email_lower).first()
@@ -76,7 +118,8 @@ def match_email_to_entity(email_addr: str, db: Session) -> dict | None:
     if domain and domain not in _GENERIC_DOMAINS:
         company = db.query(Company).filter(func.lower(Company.domain) == domain, Company.is_active.is_(True)).first()
         if company:
-            return {"type": "company", "id": company.id, "name": company.name}
+            sc_id = _resolve_site_contact(email_lower, company.id, None, db)
+            return {"type": "company", "id": company.id, "name": company.name, "site_contact_id": sc_id}
 
     # 4. Domain match against vendor_cards
     if domain and domain not in _GENERIC_DOMAINS:
@@ -169,8 +212,8 @@ def match_phone_to_entity(phone: str, db: Session) -> dict | None:
 def _match_entity_links(match: dict | None) -> dict:
     """Translate a contact-match dict into ActivityLog entity-link kwargs.
 
-    Returns company_id / vendor_card_id / vendor_contact_id / customer_site_id with only
-    the matched side populated (the other side stays None).
+    Returns company_id / vendor_card_id / vendor_contact_id / customer_site_id /
+    site_contact_id with only the matched side populated (the other side stays None).
     """
     if match and match["type"] == "company":
         return {
@@ -178,6 +221,7 @@ def _match_entity_links(match: dict | None) -> dict:
             "vendor_card_id": None,
             "vendor_contact_id": None,
             "customer_site_id": match.get("site_id"),
+            "site_contact_id": match.get("site_contact_id"),
         }
     if match and match["type"] == "vendor":
         return {
@@ -185,8 +229,15 @@ def _match_entity_links(match: dict | None) -> dict:
             "vendor_card_id": match["id"],
             "vendor_contact_id": match.get("vendor_contact_id"),
             "customer_site_id": None,
+            "site_contact_id": None,
         }
-    return {"company_id": None, "vendor_card_id": None, "vendor_contact_id": None, "customer_site_id": None}
+    return {
+        "company_id": None,
+        "vendor_card_id": None,
+        "vendor_contact_id": None,
+        "customer_site_id": None,
+        "site_contact_id": None,
+    }
 
 
 def log_email_activity(

--- a/tests/test_p1a_contact_email_attribution.py
+++ b/tests/test_p1a_contact_email_attribution.py
@@ -1,0 +1,328 @@
+"""test_p1a_contact_email_attribution.py — TDD for P1a: attribute matched email to
+SiteContact.
+
+Verifies that when an inbound or outbound email address matches a known SiteContact,
+the resulting ActivityLog.site_contact_id is set and the cadence clocks advance.
+Also verifies the regression guard: no SiteContact match → site_contact_id stays None.
+
+Called by: pytest
+Depends on: app/services/activity_service.py, app/services/cadence_service.py
+"""
+
+from datetime import datetime, timezone
+
+from app.models import Company, CustomerSite, SiteContact
+from app.services.activity_service import (
+    _match_entity_links,
+    log_email_activity,
+    match_email_to_entity,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_company(db, name="CorpX", domain="corpx.com"):
+    co = Company(name=name, domain=domain, is_active=True, created_at=datetime.now(timezone.utc))
+    db.add(co)
+    db.flush()
+    return co
+
+
+def _make_site(db, company_id, contact_email="site@corpx.com"):
+    site = CustomerSite(
+        company_id=company_id,
+        site_name="HQ",
+        is_active=True,
+        contact_email=contact_email,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(site)
+    db.flush()
+    return site
+
+
+def _make_contact(db, site_id, email="alice@corpx.com", is_primary=False, email_verified=False):
+    sc = SiteContact(
+        customer_site_id=site_id,
+        full_name="Alice Smith",
+        email=email,
+        is_primary=is_primary,
+        email_verified=email_verified,
+    )
+    db.add(sc)
+    db.flush()
+    return sc
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────
+
+
+class TestMatchEmailToEntityIncludesSiteContact:
+    """match_email_to_entity should include site_contact_id when a SiteContact
+    matches."""
+
+    def test_inbound_from_address_matches_site_contact(self, db_session):
+        """SiteContact email == email_addr → site_contact_id in result."""
+        co = _make_company(db_session)
+        site = _make_site(db_session, co.id, contact_email="site@corpx.com")
+        contact = _make_contact(db_session, site.id, email="alice@corpx.com")
+        db_session.commit()
+
+        # alice@corpx.com matches by domain (corpx.com company match)
+        result = match_email_to_entity("alice@corpx.com", db_session)
+        assert result is not None
+        assert result["type"] == "company"
+        assert result["id"] == co.id
+        assert result.get("site_contact_id") == contact.id
+
+    def test_outbound_to_address_matches_site_contact(self, db_session):
+        """Same address flow for outbound — match returns site_contact_id."""
+        co = _make_company(db_session)
+        site = _make_site(db_session, co.id, contact_email="bob@corpx.com")
+        contact = _make_contact(db_session, site.id, email="bob@corpx.com")
+        db_session.commit()
+
+        result = match_email_to_entity("bob@corpx.com", db_session)
+        assert result is not None
+        assert result.get("site_contact_id") == contact.id
+
+    def test_exact_site_contact_email_match_via_site_contact_email(self, db_session):
+        """Contact email matches even when it differs from site contact_email."""
+        co = _make_company(db_session)
+        site = _make_site(db_session, co.id, contact_email="site@corpx.com")
+        contact = _make_contact(db_session, site.id, email="manager@corpx.com")
+        db_session.commit()
+
+        result = match_email_to_entity("manager@corpx.com", db_session)
+        assert result is not None
+        assert result.get("site_contact_id") == contact.id
+
+    def test_no_site_contact_match_leaves_id_none(self, db_session):
+        """When no SiteContact matches, site_contact_id absent/None — regression
+        guard."""
+        co = _make_company(db_session)
+        _make_site(db_session, co.id, contact_email="site@corpx.com")
+        # No SiteContact with this email
+        db_session.commit()
+
+        result = match_email_to_entity("unknown@corpx.com", db_session)
+        assert result is not None
+        assert result["type"] == "company"
+        assert result.get("site_contact_id") is None
+
+    def test_case_insensitive_contact_resolution(self, db_session):
+        """Contact lookup is case-insensitive."""
+        co = _make_company(db_session)
+        site = _make_site(db_session, co.id, contact_email="site@corpx.com")
+        contact = _make_contact(db_session, site.id, email="Alice@CorpX.COM")
+        db_session.commit()
+
+        result = match_email_to_entity("alice@corpx.com", db_session)
+        assert result is not None
+        assert result.get("site_contact_id") == contact.id
+
+    def test_vendor_side_unaffected(self, db_session):
+        """Vendor matches have no site_contact_id (vendor-side out of scope for P1a)."""
+        from app.models import VendorCard, VendorContact
+
+        card = VendorCard(
+            normalized_name="acmevendor",
+            display_name="Acme Vendor",
+            domain="acmevendor.com",
+            is_blacklisted=False,
+            sighting_count=5,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(card)
+        db_session.flush()
+        vc = VendorContact(
+            vendor_card_id=card.id,
+            email="sales@acmevendor.com",
+            full_name="Sales",
+            source="manual",
+        )
+        db_session.add(vc)
+        db_session.commit()
+
+        result = match_email_to_entity("sales@acmevendor.com", db_session)
+        assert result is not None
+        assert result["type"] == "vendor"
+        # No site_contact_id on vendor matches
+        assert result.get("site_contact_id") is None
+
+
+class TestMatchEntityLinksIncludesSiteContact:
+    """_match_entity_links must thread site_contact_id through to ActivityLog kwargs."""
+
+    def test_site_contact_id_in_company_links(self):
+        match = {"type": "company", "id": 10, "name": "Corp", "site_id": 5, "site_contact_id": 42}
+        links = _match_entity_links(match)
+        assert links["company_id"] == 10
+        assert links["customer_site_id"] == 5
+        assert links["site_contact_id"] == 42
+
+    def test_site_contact_id_none_when_absent(self):
+        match = {"type": "company", "id": 10, "name": "Corp", "site_id": 5}
+        links = _match_entity_links(match)
+        assert links.get("site_contact_id") is None
+
+    def test_vendor_links_no_site_contact_id(self):
+        match = {"type": "vendor", "id": 7, "name": "Vendor", "vendor_contact_id": 3}
+        links = _match_entity_links(match)
+        assert links["vendor_card_id"] == 7
+        assert links.get("site_contact_id") is None
+
+    def test_none_match_all_none(self):
+        links = _match_entity_links(None)
+        assert links["company_id"] is None
+        assert links.get("site_contact_id") is None
+
+
+class TestLogEmailActivitySiteContactCadence:
+    """log_email_activity must set site_contact_id and advance cadence clocks."""
+
+    def test_inbound_meaningful_advances_last_reply_at(self, db_session, test_user):
+        """Inbound meaningful email → contact.last_reply_at advances."""
+        co = _make_company(db_session)
+        site = _make_site(db_session, co.id, contact_email="alice@corpx.com")
+        contact = _make_contact(db_session, site.id, email="alice@corpx.com")
+        db_session.commit()
+
+        # Inbound email from alice — is_meaningful is None at log time (not yet AI-scored).
+        # bump_clocks only fires for meaningful inbound. To test the cadence path we
+        # set is_meaningful=True inline after flush by checking the row manually.
+        # Instead, log as meaningful by checking the existing clock logic:
+        # direction=received → INBOUND; bump_clocks_from_activity fires only if is_meaningful.
+        # The ActivityLog is not marked meaningful at email log time (email_received is NOT
+        # in _RULE_MEANINGFUL_TYPES). So we assert site_contact_id is set and verify
+        # the clock path by checking is_meaningful=None (unscored) — the clock won't advance
+        # here yet; that's correct per spec. We only assert site_contact_id linkage.
+        record = log_email_activity(
+            user_id=test_user.id,
+            direction="received",
+            email_addr="alice@corpx.com",
+            subject="RE: RFQ",
+            external_id="inbound-001",
+            contact_name="Alice",
+            db=db_session,
+        )
+        db_session.commit()
+
+        assert record is not None
+        assert record.site_contact_id == contact.id
+        assert record.company_id == co.id
+
+    def test_outbound_advances_last_outbound_at(self, db_session, test_user):
+        """Outbound email to a SiteContact's email → site_contact_id set, clock
+        advances."""
+        co = _make_company(db_session)
+        site = _make_site(db_session, co.id, contact_email="bob@corpx.com")
+        contact = _make_contact(db_session, site.id, email="bob@corpx.com")
+        db_session.commit()
+
+        before = contact.last_outbound_at
+
+        record = log_email_activity(
+            user_id=test_user.id,
+            direction="sent",
+            email_addr="bob@corpx.com",
+            subject="RFQ for PO123",
+            external_id="outbound-001",
+            contact_name="Bob",
+            db=db_session,
+        )
+        db_session.commit()
+        db_session.refresh(contact)
+
+        assert record is not None
+        assert record.site_contact_id == contact.id
+        # Clock advanced from None or earlier value
+        assert contact.last_outbound_at is not None
+        if before is not None:
+            assert contact.last_outbound_at >= before
+
+    def test_no_contact_match_site_contact_id_none(self, db_session, test_user):
+        """Email to domain-matched company but no SiteContact → site_contact_id is
+        None."""
+        co = _make_company(db_session)
+        _make_site(db_session, co.id, contact_email="site@corpx.com")
+        # No SiteContact with purchasing@corpx.com
+        db_session.commit()
+
+        record = log_email_activity(
+            user_id=test_user.id,
+            direction="sent",
+            email_addr="purchasing@corpx.com",
+            subject="RFQ",
+            external_id="outbound-002",
+            contact_name="Purchasing",
+            db=db_session,
+        )
+        db_session.commit()
+
+        assert record is not None
+        assert record.company_id == co.id  # company still matched
+        assert record.site_contact_id is None  # no contact resolved
+
+    def test_meaningful_inbound_advances_last_reply_at(self, db_session, test_user):
+        """Meaningful inbound email → last_reply_at on SiteContact advances."""
+        co = _make_company(db_session)
+        site = _make_site(db_session, co.id, contact_email="carol@corpx.com")
+        contact = _make_contact(db_session, site.id, email="carol@corpx.com")
+        db_session.commit()
+
+        record = log_email_activity(
+            user_id=test_user.id,
+            direction="received",
+            email_addr="carol@corpx.com",
+            subject="Quote accepted",
+            external_id="inbound-meaningful-001",
+            contact_name="Carol",
+            db=db_session,
+        )
+        assert record is not None
+        # Mark is_meaningful=True to simulate AI scoring
+        record.is_meaningful = True
+        db_session.flush()
+
+        # Manually trigger bump after marking meaningful
+        from app.services.cadence_service import bump_clocks_from_activity
+
+        bump_clocks_from_activity(db_session, record)
+        db_session.commit()
+        db_session.refresh(contact)
+
+        assert record.site_contact_id == contact.id
+        assert contact.last_reply_at is not None
+
+    def test_prefers_verified_contact_over_unverified(self, db_session, test_user):
+        """When multiple SiteContacts share an email, prefer email_verified=True."""
+        co = _make_company(db_session)
+        site = _make_site(db_session, co.id, contact_email="site@corpx.com")
+        # Two contacts at the same site with same email — verified one should win
+        unverified = _make_contact(db_session, site.id, email="shared@corpx.com", email_verified=False)
+        verified = _make_contact(db_session, site.id, email="shared2@corpx.com", email_verified=True)
+        db_session.commit()
+
+        # Test that verified one is found when matched
+        result = match_email_to_entity("shared2@corpx.com", db_session)
+        assert result is not None
+        assert result.get("site_contact_id") == verified.id
+
+    def test_prefers_primary_contact(self, db_session):
+        """When multiple contacts share an email (in practice via domain), is_primary
+        wins."""
+        # In practice the UniqueConstraint prevents two contacts with same email at same site.
+        # Test that is_primary contact is returned for domain match when multiple contacts exist.
+        co = _make_company(db_session)
+        site = _make_site(db_session, co.id, contact_email="site@corpx.com")
+        non_primary = _make_contact(db_session, site.id, email="np@corpx.com", is_primary=False)
+        primary = _make_contact(db_session, site.id, email="primary@corpx.com", is_primary=True)
+        db_session.commit()
+
+        # Each email is unique so each resolves to its own contact
+        result_np = match_email_to_entity("np@corpx.com", db_session)
+        result_primary = match_email_to_entity("primary@corpx.com", db_session)
+
+        assert result_np is not None and result_np.get("site_contact_id") == non_primary.id
+        assert result_primary is not None and result_primary.get("site_contact_id") == primary.id

--- a/tests/test_p1a_contact_email_attribution.py
+++ b/tests/test_p1a_contact_email_attribution.py
@@ -264,8 +264,8 @@ class TestLogEmailActivitySiteContactCadence:
         assert record.company_id == co.id  # company still matched
         assert record.site_contact_id is None  # no contact resolved
 
-    def test_meaningful_inbound_advances_last_reply_at(self, db_session, test_user):
-        """Meaningful inbound email → last_reply_at on SiteContact advances."""
+    def test_meaningful_inbound_advances_cadence_clocks(self, db_session, test_user):
+        """Meaningful inbound email sets site_contact_id AND advances last_reply_at."""
         co = _make_company(db_session)
         site = _make_site(db_session, co.id, contact_email="carol@corpx.com")
         contact = _make_contact(db_session, site.id, email="carol@corpx.com")
@@ -296,33 +296,79 @@ class TestLogEmailActivitySiteContactCadence:
         assert contact.last_reply_at is not None
 
     def test_prefers_verified_contact_over_unverified(self, db_session, test_user):
-        """When multiple SiteContacts share an email, prefer email_verified=True."""
+        """Two cross-site contacts with the SAME email → prefer email_verified=True.
+
+        The per-site unique constraint allows the same email across different sites of
+        the same company.  We use the domain-match path (site_id=None) so both contacts
+        are candidates and the preference branch is exercised.
+        """
         co = _make_company(db_session)
-        site = _make_site(db_session, co.id, contact_email="site@corpx.com")
-        # Two contacts at the same site with same email — verified one should win
-        unverified = _make_contact(db_session, site.id, email="shared@corpx.com", email_verified=False)
-        verified = _make_contact(db_session, site.id, email="shared2@corpx.com", email_verified=True)
+        # Two different sites; neither site's contact_email equals shared@corpx.com so
+        # match_email_to_entity falls through to the domain-match path (step 3) which
+        # calls _resolve_site_contact with site_id=None, collecting both candidates.
+        site_a = _make_site(db_session, co.id, contact_email="hq@corpx.com")
+        site_b = _make_site(db_session, co.id, contact_email="ops@corpx.com")
+        unverified = _make_contact(db_session, site_a.id, email="shared@corpx.com", email_verified=False)
+        verified = _make_contact(db_session, site_b.id, email="shared@corpx.com", email_verified=True)
         db_session.commit()
 
-        # Test that verified one is found when matched
-        result = match_email_to_entity("shared2@corpx.com", db_session)
+        result = match_email_to_entity("shared@corpx.com", db_session)
         assert result is not None
+        # Both contacts matched; verified one must win
         assert result.get("site_contact_id") == verified.id
 
-    def test_prefers_primary_contact(self, db_session):
-        """When multiple contacts share an email (in practice via domain), is_primary
-        wins."""
-        # In practice the UniqueConstraint prevents two contacts with same email at same site.
-        # Test that is_primary contact is returned for domain match when multiple contacts exist.
+    def test_inbound_unscored_sets_site_contact_id(self, db_session, test_user):
+        """Inbound email from a known SiteContact → site_contact_id is linked on the
+        record regardless of is_meaningful scoring."""
         co = _make_company(db_session)
-        site = _make_site(db_session, co.id, contact_email="site@corpx.com")
-        non_primary = _make_contact(db_session, site.id, email="np@corpx.com", is_primary=False)
-        primary = _make_contact(db_session, site.id, email="primary@corpx.com", is_primary=True)
+        site = _make_site(db_session, co.id, contact_email="carol@corpx.com")
+        contact = _make_contact(db_session, site.id, email="carol@corpx.com")
         db_session.commit()
 
-        # Each email is unique so each resolves to its own contact
-        result_np = match_email_to_entity("np@corpx.com", db_session)
-        result_primary = match_email_to_entity("primary@corpx.com", db_session)
+        record = log_email_activity(
+            user_id=test_user.id,
+            direction="received",
+            email_addr="carol@corpx.com",
+            subject="Just checking in",
+            external_id="inbound-unscored-001",
+            contact_name="Carol",
+            db=db_session,
+        )
+        db_session.commit()
 
-        assert result_np is not None and result_np.get("site_contact_id") == non_primary.id
-        assert result_primary is not None and result_primary.get("site_contact_id") == primary.id
+        assert record is not None
+        assert record.site_contact_id == contact.id
+
+    def test_prefers_primary_contact(self, db_session):
+        """Two cross-site contacts with the SAME email, neither verified → is_primary
+        wins.
+
+        The per-site unique constraint allows the same email across different sites of
+        the same company.  We use the domain-match path (site_id=None) so both contacts
+        are candidates and the primary-preference branch is exercised.
+        """
+        co = _make_company(db_session)
+        # Two different sites; neither site contact_email matches shared2@corpx.com so
+        # the domain-match path fires and collects both contacts as candidates.
+        site_a = _make_site(db_session, co.id, contact_email="hq2@corpx.com")
+        site_b = _make_site(db_session, co.id, contact_email="ops2@corpx.com")
+        non_primary = _make_contact(
+            db_session,
+            site_a.id,
+            email="shared2@corpx.com",
+            is_primary=False,
+            email_verified=False,
+        )
+        primary = _make_contact(
+            db_session,
+            site_b.id,
+            email="shared2@corpx.com",
+            is_primary=True,
+            email_verified=False,
+        )
+        db_session.commit()
+
+        result = match_email_to_entity("shared2@corpx.com", db_session)
+        assert result is not None
+        # Both contacts matched; primary one must win
+        assert result.get("site_contact_id") == primary.id


### PR DESCRIPTION
Phase 1a of the capture-completeness roadmap. Closes the cockpit caveat where per-contact reply clocks stayed NULL because email matched company/site but never a contact.

`match_email_to_entity` now also resolves the SiteContact whose email matches the address (case-insensitive, scoped to the matched company%27s sites, prefers verified→primary→first; None if no match — no regression), threaded via `_match_entity_links` → `log_email_activity` → ActivityLog.site_contact_id. The existing `bump_clocks_from_activity` then advances the contact%27s last_outbound_at / last_reply_at. Additive key only; company/site matching unchanged; indexed scoped lookup (no hot-path scan).

Review-verified regression-safe + correctly scoped (no cross-company over-matching). 17 tests incl. multi-candidate preference (sanity-checked by reversing the order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)