### PR TITLE
feat(crm): outbound clock at send time + Contact.sent_at + sent-folder reconcile (P1b)

### DIFF
--- a/MIGRATION_NUMBERS_IN_FLIGHT.txt
+++ b/MIGRATION_NUMBERS_IN_FLIGHT.txt
@@ -38,3 +38,4 @@
 111 feat/auto-datasheet-capture material_card_datasheets + card datasheet stamps (RE-NUMBERED 108->110->111: buyplan-audit(108)/offer-feed(109)/crm-cadence(110) landed on main first; RE-CHAINED onto 110_crm_cadence_clocks; single head verified via `alembic heads`)
 112 feat/offer-qualification-capture offer qualification capture columns (qualification_status/qualification_note/qualification JSON) + condition used->pulls (PR #356; RE-NUMBERED 108->111->112: buyplan-audit/offer-feed/crm-cadence/auto-datasheet all merged to main first; RE-CHAINED onto 111_material_card_datasheets — single head verified via `alembic heads`)
 113 sp4-quote-attribution add quotes.source for proactive revenue attribution; chains onto 112_offer_qualification
+114 feat/p1b-send-time-clock contacts.sent_at for durable send-time tracking; chains onto 113_quote_source

--- a/alembic/versions/114_contact_sent_at.py
+++ b/alembic/versions/114_contact_sent_at.py
@@ -1,0 +1,28 @@
+"""Add contacts.sent_at for durable true send-time tracking.
+
+What: adds contacts.sent_at (UTCDateTime, nullable) so the outbound clock
+      advances at the moment sendMail succeeds rather than waiting up to 30 min
+      for the scan_sent_folder job to find the message.
+Downgrade: drops the column.
+
+Revision ID: 114_contact_sent_at
+Revises: 113_quote_source
+Create Date: 2026-06-18
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "114_contact_sent_at"
+down_revision = "113_quote_source"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("contacts", sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("contacts", "sent_at")

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -49,11 +49,14 @@ def _create_contact(
     body: str,
     status: str,
     error_message: str | None = None,
+    sent_at: datetime | None = None,
 ) -> Contact:
     """Create and flush a Contact record with common fields.
 
     Called by: send_batch_rfq (for success, exception-error, and API-error cases).
     Depends on: normalize_vendor_name.
+    sent_at: set only for status="sent" — records the true send moment so the
+    outbound clock advances immediately without waiting for scan_sent_folder.
     """
     now = datetime.now(timezone.utc)
     contact = Contact(
@@ -70,6 +73,7 @@ def _create_contact(
         error_message=error_message,
         status_updated_at=now,
         created_at=now,
+        sent_at=sent_at,
     )
     db.add(contact)
     db.flush()
@@ -251,6 +255,7 @@ async def send_batch_rfq(
             continue
 
         per_req_parts = _per_req_parts(group)
+        send_time = datetime.now(timezone.utc)
         try:
             with db.begin_nested():
                 contacts = [
@@ -264,9 +269,27 @@ async def send_batch_rfq(
                         tagged_subject,
                         group["body"],
                         "sent",
+                        sent_at=send_time,
                     )
                     for rid, parts in per_req_parts
                 ]
+                # Write the outbound ActivityLog IMMEDIATELY at send time (one row per
+                # involved requisition) so the outbound clock advances now rather than
+                # waiting up to 30 min for scan_sent_folder.  graph_message_id /
+                # graph_conversation_id are not available yet — scan_sent_folder will
+                # reconcile by setting ActivityLog.external_id on the EXISTING row
+                # instead of creating a second one.
+                for contact in contacts:
+                    log_email_activity(
+                        user_id=user_id,
+                        direction="sent",
+                        email_addr=email,
+                        subject=tagged_subject,
+                        external_id=None,  # filled in later by scan_sent_folder
+                        contact_name=group["vendor_name"],
+                        db=db,
+                        requisition_id=contact.requisition_id,
+                    )
         except Exception:
             # The email WAS delivered — report a tracking error for this vendor
             # only; the rest of the batch keeps its rows.

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -289,6 +289,7 @@ async def send_batch_rfq(
                         contact_name=group["vendor_name"],
                         db=db,
                         requisition_id=contact.requisition_id,
+                        occurred_at=send_time,  # ensures reconcile filter matches (no dup)
                     )
         except Exception:
             # The email WAS delivered — report a tracking error for this vendor

--- a/app/jobs/email_jobs.py
+++ b/app/jobs/email_jobs.py
@@ -821,6 +821,8 @@ async def scan_sent_folder(user, db):
     Called by: _job_scan_sent_folders (scheduler, every 30 min)
     Depends on: GraphClient.delta_query, models.ActivityLog, models.SyncState
     """
+    from sqlalchemy import func
+
     from app.utils.graph_client import GraphClient, GraphSyncStateExpired
 
     from ..models import SyncState
@@ -840,7 +842,7 @@ async def scan_sent_folder(user, db):
     delta_token = sync_state.delta_token if sync_state else None
 
     delta_params = {
-        "$select": "id,subject,from,toRecipients,sentDateTime,hasAttachments,internetMessageHeaders",
+        "$select": "id,conversationId,subject,from,toRecipients,sentDateTime,hasAttachments,internetMessageHeaders",
         "$top": "100",
     }
     try:
@@ -893,6 +895,19 @@ async def scan_sent_folder(user, db):
 
     # Process each sent message. Per-message SAVEPOINT: one malformed message
     # must not roll back the batch (and with it the already-flushed delta token).
+    #
+    # Reconcile-first strategy (P1b): send_batch_rfq now writes an outbound
+    # ActivityLog at the moment sendMail succeeds (external_id=NULL, no graph id
+    # yet).  When this scan finds the corresponding message, it UPDATES that
+    # existing row (sets external_id / graph ids) instead of creating a second
+    # one.  This prevents duplicate outbound ActivityLog rows and ensures the
+    # outbound clock was already advanced at send time.
+    #
+    # Idempotency key: same user_id + contact_email (first recipient) +
+    # requisition_id + direction=outbound + external_id IS NULL + occurred_at
+    # within RECONCILE_WINDOW_HOURS of the message's sentDateTime.
+    RECONCILE_WINDOW_HOURS = 48
+
     created_logs = []
     attachment_queue = []
     for msg in messages:
@@ -902,6 +917,7 @@ async def scan_sent_folder(user, db):
             with db.begin_nested():
                 subject = msg.get("subject", "")
                 sent_dt = msg.get("sentDateTime")
+                conversation_id = msg.get("conversationId", "")
 
                 # Skip if we already logged this message (dedup by external_id)
                 existing = (
@@ -937,24 +953,80 @@ async def scan_sent_folder(user, db):
                     except (ValueError, TypeError):
                         occurred_at = datetime.now(timezone.utc)
 
-                # Create one ActivityLog entry per token requisition (they share the
-                # message's external_id, so the dedup check above still skips re-scans)
+                # Reconcile with send-time rows first, then fall back to CREATE.
+                # A send-time ActivityLog row has external_id=NULL (the graph id was
+                # not available at send time).  Match on user + recipient + req +
+                # outbound direction within the reconcile window.
+                reconcile_window_start = (occurred_at or datetime.now(timezone.utc)) - timedelta(
+                    hours=RECONCILE_WINDOW_HOURS
+                )
                 for requisition_id in token_req_ids or [None]:
-                    log_entry = ActivityLog(
-                        user_id=user.id,
-                        activity_type="email_sent",
-                        channel="email",
-                        direction="outbound",
-                        event_type="email",
-                        subject=subject[:500] if subject else None,
-                        contact_email=first_recipient or None,
-                        external_id=msg_id,
-                        requisition_id=requisition_id,
-                        auto_logged=True,
-                        occurred_at=occurred_at,
-                    )
-                    db.add(log_entry)
-                    msg_logs.append(log_entry)
+                    # Try to find the send-time row to reconcile
+                    send_time_row: ActivityLog | None = None
+                    if first_recipient:
+                        q = db.query(ActivityLog).filter(
+                            ActivityLog.user_id == user.id,
+                            ActivityLog.direction == "outbound",
+                            ActivityLog.external_id.is_(None),
+                            func.lower(ActivityLog.contact_email) == first_recipient.lower(),
+                            ActivityLog.occurred_at >= reconcile_window_start,
+                        )
+                        if requisition_id is not None:
+                            q = q.filter(ActivityLog.requisition_id == requisition_id)
+                        send_time_row = q.order_by(ActivityLog.occurred_at.desc()).first()
+
+                    if isinstance(send_time_row, ActivityLog):
+                        # Reconcile: stamp graph id onto the existing row so
+                        # Tier-1 reply-matching works — no duplicate row created.
+                        send_time_row.external_id = msg_id
+                        if conversation_id:
+                            send_time_row.notes = (
+                                (send_time_row.notes or "") + f" graph_conversation_id={conversation_id}"
+                            ).strip()
+                        # Also update the matching Contact(s) with graph ids so
+                        # poll_inbox Tier-1 (conv_id_map lookup) works.
+                        if conversation_id or msg_id:
+                            from ..models.offers import Contact as OfferContact
+
+                            contact_q = db.query(OfferContact).filter(
+                                OfferContact.user_id == user.id,
+                                OfferContact.status == "sent",
+                                OfferContact.graph_message_id.is_(None),
+                                func.lower(OfferContact.vendor_contact) == first_recipient.lower(),
+                            )
+                            if requisition_id is not None:
+                                contact_q = contact_q.filter(OfferContact.requisition_id == requisition_id)
+                            for c in contact_q.all():
+                                if msg_id:
+                                    c.graph_message_id = msg_id
+                                if conversation_id:
+                                    c.graph_conversation_id = conversation_id
+                        msg_logs.append(send_time_row)
+                        logger.debug(
+                            "Sent folder scan [{}]: reconciled existing ActivityLog id={} with graph_message_id {}",
+                            user.email,
+                            send_time_row.id,
+                            msg_id[:20],
+                        )
+                    else:
+                        # No send-time row: fall back to the legacy create path
+                        # (handles sends that pre-date P1b, or edge cases where the
+                        # send-time row was already reconciled or deleted).
+                        log_entry = ActivityLog(
+                            user_id=user.id,
+                            activity_type="email_sent",
+                            channel="email",
+                            direction="outbound",
+                            event_type="email",
+                            subject=subject[:500] if subject else None,
+                            contact_email=first_recipient or None,
+                            external_id=msg_id,
+                            requisition_id=requisition_id,
+                            auto_logged=True,
+                            occurred_at=occurred_at,
+                        )
+                        db.add(log_entry)
+                        msg_logs.append(log_entry)
         except Exception:
             logger.error(
                 f"Sent folder scan [{user.email}]: skipping message {msg_id[:20]} after per-message failure",

--- a/app/jobs/email_jobs.py
+++ b/app/jobs/email_jobs.py
@@ -980,9 +980,10 @@ async def scan_sent_folder(user, db):
                         # Tier-1 reply-matching works — no duplicate row created.
                         send_time_row.external_id = msg_id
                         if conversation_id:
-                            send_time_row.notes = (
-                                (send_time_row.notes or "") + f" graph_conversation_id={conversation_id}"
-                            ).strip()
+                            tag = f"graph_conversation_id={conversation_id}"
+                            existing_notes = send_time_row.notes or ""
+                            if tag not in existing_notes:
+                                send_time_row.notes = (existing_notes + " " + tag).strip()
                         # Also update the matching Contact(s) with graph ids so
                         # poll_inbox Tier-1 (conv_id_map lookup) works.
                         if conversation_id or msg_id:

--- a/app/models/offers.py
+++ b/app/models/offers.py
@@ -233,6 +233,7 @@ class Contact(Base):
     status_updated_at = Column(UTCDateTime)
     graph_message_id = Column(String(500))
     graph_conversation_id = Column(String(500))
+    sent_at = Column(UTCDateTime, nullable=True)
     needs_review = Column(Boolean, default=False)
     parse_result_json = Column(JSON)
     parse_confidence = Column(Float)

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -250,10 +250,16 @@ def log_email_activity(
     db: Session,
     requisition_id: int | None = None,
     requirement_id: int | None = None,
+    occurred_at: datetime | None = None,
 ) -> ActivityLog | None:
     """Log an email activity, matching the contact to a company or vendor.
 
     Returns the ActivityLog record or None if dedup/no-match.
+
+    Pass occurred_at to stamp the exact send/receive time on the row.  When omitted the
+    column default (server-side UTC now) is used.  Always pass occurred_at for send-time
+    rows so the scan_sent_folder reconcile query (which filters ActivityLog.occurred_at
+    >= reconcile_window_start) can match the row and avoid creating a duplicate.
     """
     # Dedup by external_id
     if external_id:
@@ -279,6 +285,7 @@ def log_email_activity(
         summary=f"Email {'to' if direction == 'sent' else 'from'} {contact_name or email_addr}",
         requisition_id=requisition_id,
         requirement_id=requirement_id,
+        occurred_at=occurred_at,
     )
     db.add(record)
     db.flush()

--- a/tests/test_p1b_send_clock.py
+++ b/tests/test_p1b_send_clock.py
@@ -1,0 +1,412 @@
+"""TDD tests for P1b: outbound clock at send time + Contact.sent_at.
+
+Tests written FIRST (RED phase) — they fail until the implementation exists.
+
+Covers:
+1. send_batch_rfq success → Contact.sent_at set AND outbound ActivityLog written
+   immediately with no graph_message_id yet.
+2. scan_sent_folder reconcile → SAME ActivityLog row updated (no duplicate),
+   graph_message_id/graph_conversation_id populated.
+3. Reply-matching (Tier-1): inbound reply using graph_conversation_id still
+   matches after reconciliation.
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.email_service import send_batch_rfq
+from app.models import (
+    ActivityLog,
+    Contact,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper: build a mock GraphClient that sends OK and returns no sent-items
+# (simulates the _find_sent_message lookup finding nothing immediately — so
+# the outbound ActivityLog is written with no graph_message_id).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _mock_gc_send_ok_no_lookup():
+    """GraphClient mock: sendMail succeeds, sent-folder lookup returns no match."""
+    gc = AsyncMock()
+    gc.post_json.return_value = {}  # success: no 'error' key
+    gc.get_json.return_value = {"value": []}  # empty sent-items
+    return gc
+
+
+def _mock_gc_send_ok_with_lookup(req_id, tagged_subject):
+    """GraphClient mock: sendMail succeeds, sent-folder lookup finds the message."""
+    gc = AsyncMock()
+    gc.post_json.return_value = {}
+    gc.get_json.return_value = {
+        "value": [
+            {
+                "id": "graph-msg-001",
+                "conversationId": "graph-conv-001",
+                "subject": tagged_subject,
+                "toRecipients": [{"emailAddress": {"address": "vendor@acme.com"}}],
+            }
+        ]
+    }
+    return gc
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1: Contact.sent_at is set and outbound ActivityLog exists IMMEDIATELY
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSendBatchRfqSentAt:
+    @pytest.mark.asyncio
+    async def test_sent_at_set_on_success(self, db_session, test_user, test_requisition):
+        """Contact.sent_at is populated the moment sendMail succeeds."""
+        gc = _mock_gc_send_ok_no_lookup()
+        vendor_groups = [
+            {
+                "vendor_name": "Acme Parts",
+                "vendor_email": "vendor@acme.com",
+                "parts": ["P100"],
+                "subject": "RFQ",
+                "body": "Please quote.",
+            }
+        ]
+
+        before = datetime.now(timezone.utc)
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            results = await send_batch_rfq(
+                token="tok",
+                db=db_session,
+                user_id=test_user.id,
+                requisition_id=test_requisition.id,
+                vendor_groups=vendor_groups,
+            )
+        after = datetime.now(timezone.utc)
+
+        assert results[0]["status"] == "sent"
+
+        contact = db_session.query(Contact).filter_by(requisition_id=test_requisition.id).first()
+        assert contact is not None
+        # sent_at must be set and fall within the test window
+        assert contact.sent_at is not None, "Contact.sent_at must be set at send time"
+        # Normalise tz-naive values from SQLite
+        ca = contact.sent_at.replace(tzinfo=timezone.utc) if contact.sent_at.tzinfo is None else contact.sent_at
+        assert before <= ca <= after, f"sent_at {ca} not in [{before}, {after}]"
+
+    @pytest.mark.asyncio
+    async def test_outbound_activity_log_exists_immediately(self, db_session, test_user, test_requisition):
+        """After sendMail succeeds, an outbound ActivityLog row exists before the 30-min
+        scan — with direction=outbound and no external_id (no graph id yet)."""
+        gc = _mock_gc_send_ok_no_lookup()
+        vendor_groups = [
+            {
+                "vendor_name": "Acme Parts",
+                "vendor_email": "vendor@acme.com",
+                "parts": ["P100"],
+                "subject": "RFQ",
+                "body": "Please quote.",
+            }
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            results = await send_batch_rfq(
+                token="tok",
+                db=db_session,
+                user_id=test_user.id,
+                requisition_id=test_requisition.id,
+                vendor_groups=vendor_groups,
+            )
+
+        assert results[0]["status"] == "sent"
+
+        outbound_logs = (
+            db_session.query(ActivityLog)
+            .filter(
+                ActivityLog.direction == "outbound",
+                ActivityLog.contact_email == "vendor@acme.com",
+            )
+            .all()
+        )
+        assert len(outbound_logs) == 1, f"Expected exactly 1 outbound ActivityLog, got {len(outbound_logs)}"
+        log = outbound_logs[0]
+        # No graph id yet — scan will fill it later
+        assert log.external_id is None, "ActivityLog.external_id must be NULL at send time (graph id not set yet)"
+
+    @pytest.mark.asyncio
+    async def test_sent_at_not_set_on_failure(self, db_session, test_user, test_requisition):
+        """Contact.sent_at is NOT set when sendMail fails."""
+        gc = AsyncMock()
+        gc.post_json.side_effect = Exception("Network error")
+
+        vendor_groups = [
+            {
+                "vendor_name": "Acme Parts",
+                "vendor_email": "vendor@acme.com",
+                "parts": ["P100"],
+                "subject": "RFQ",
+                "body": "Please quote.",
+            }
+        ]
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await send_batch_rfq(
+                token="tok",
+                db=db_session,
+                user_id=test_user.id,
+                requisition_id=test_requisition.id,
+                vendor_groups=vendor_groups,
+            )
+
+        assert results[0]["status"] == "failed"
+
+        contact = db_session.query(Contact).filter_by(requisition_id=test_requisition.id).first()
+        assert contact is not None
+        assert contact.sent_at is None, "Contact.sent_at must be NULL when send failed"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2: scan_sent_folder reconcile — same ActivityLog row updated, no dup
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestScanSentFolderReconcile:
+    @pytest.mark.asyncio
+    async def test_scan_updates_existing_log_no_duplicate(self, db_session, test_user, test_requisition):
+        """scan_sent_folder, when it finds the graph message for a send that already has
+        an outbound ActivityLog, must UPDATE that row (setting external_id + graph ids)
+        and NOT create a second outbound ActivityLog for the same send."""
+        from app.jobs.email_jobs import scan_sent_folder
+
+        tagged_subject = f"RFQ [ref:{test_requisition.id}]"
+        vendor_email = "vendor@acme.com"
+        graph_msg_id = "graph-msg-001"
+        graph_conv_id = "graph-conv-001"
+
+        # --- Step 1: simulate send_batch_rfq side-effects ---
+        # Create the Contact (status=sent, sent_at set)
+        now = datetime.now(timezone.utc)
+        contact = Contact(
+            requisition_id=test_requisition.id,
+            user_id=test_user.id,
+            contact_type="email",
+            vendor_name="Acme Parts",
+            vendor_name_normalized="acme parts",
+            vendor_contact=vendor_email,
+            parts_included=["P100"],
+            subject=tagged_subject,
+            details="Please quote.",
+            status="sent",
+            sent_at=now,
+            status_updated_at=now,
+            created_at=now,
+        )
+        db_session.add(contact)
+        db_session.flush()
+
+        # Create the outbound ActivityLog (no external_id yet)
+        activity = ActivityLog(
+            user_id=test_user.id,
+            activity_type="email_sent",
+            channel="email",
+            direction="outbound",
+            event_type="email",
+            contact_email=vendor_email,
+            subject=tagged_subject,
+            external_id=None,  # not set at send time
+            requisition_id=test_requisition.id,
+            auto_logged=True,
+            occurred_at=now,
+        )
+        db_session.add(activity)
+        db_session.commit()
+
+        activity_id_before = activity.id
+        log_count_before = (
+            db_session.query(ActivityLog)
+            .filter(
+                ActivityLog.direction == "outbound",
+                ActivityLog.contact_email == vendor_email,
+            )
+            .count()
+        )
+        assert log_count_before == 1
+
+        # --- Step 2: run scan_sent_folder ---
+        gc_mock = MagicMock()
+        gc_mock.delta_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        "id": graph_msg_id,
+                        "subject": tagged_subject,
+                        "sentDateTime": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "toRecipients": [{"emailAddress": {"address": vendor_email}}],
+                        "hasAttachments": False,
+                        "conversationId": graph_conv_id,
+                    }
+                ],
+                "new-delta-token",
+            )
+        )
+
+        with (
+            patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch("app.utils.graph_client.GraphClient", return_value=gc_mock),
+        ):
+            await scan_sent_folder(test_user, db_session)
+
+        # --- Assert: still exactly ONE outbound ActivityLog ---
+        log_count_after = (
+            db_session.query(ActivityLog)
+            .filter(
+                ActivityLog.direction == "outbound",
+                ActivityLog.contact_email == vendor_email,
+            )
+            .count()
+        )
+        assert log_count_after == 1, (
+            f"Expected 1 outbound ActivityLog after scan, got {log_count_after} — duplicate created"
+        )
+
+        # --- Assert: the EXISTING row was updated with graph id ---
+        updated_log = db_session.get(ActivityLog, activity_id_before)
+        assert updated_log is not None
+        assert updated_log.external_id == graph_msg_id, (
+            f"ActivityLog.external_id must be updated to graph_msg_id, got {updated_log.external_id!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_scan_falls_back_to_create_when_no_send_time_log(self, db_session, test_user, test_requisition):
+        """scan_sent_folder falls back to CREATE a new ActivityLog when no existing
+        send-time row is found — preserves backward compatibility with old sends that
+        predate this change."""
+        from app.jobs.email_jobs import scan_sent_folder
+
+        tagged_subject = f"RFQ [ref:{test_requisition.id}]"
+        vendor_email = "legacy@vendor.com"
+        graph_msg_id = "graph-legacy-001"
+
+        # No ActivityLog or Contact row exists (old send, pre-P1b)
+
+        gc_mock = MagicMock()
+        now = datetime.now(timezone.utc)
+        gc_mock.delta_query = AsyncMock(
+            return_value=(
+                [
+                    {
+                        "id": graph_msg_id,
+                        "subject": tagged_subject,
+                        "sentDateTime": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "toRecipients": [{"emailAddress": {"address": vendor_email}}],
+                        "hasAttachments": False,
+                    }
+                ],
+                "new-delta-token",
+            )
+        )
+
+        with (
+            patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+            patch("app.utils.graph_client.GraphClient", return_value=gc_mock),
+        ):
+            result = await scan_sent_folder(test_user, db_session)
+
+        # A new ActivityLog is created (fallback path)
+        assert len(result) >= 1
+        log = db_session.query(ActivityLog).filter(ActivityLog.external_id == graph_msg_id).first()
+        assert log is not None, "Fallback path must create an ActivityLog with external_id set"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 3: Reply-matching (Tier-1) still works after reconciliation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestReplyMatchingAfterReconcile:
+    @pytest.mark.asyncio
+    async def test_tier1_match_works_after_scan_reconcile(self, db_session, test_user, test_requisition):
+        """After scan_sent_folder reconciles the ActivityLog row (sets external_id), a
+        Contact with graph_conversation_id set is still matched by poll_inbox Tier-1
+        (conversation-id lookup)."""
+        from app.email_service import poll_inbox
+
+        graph_conv_id = "graph-conv-999"
+        vendor_email = "vendor@acme.com"
+        tagged_subject = f"RFQ for parts [ref:{test_requisition.id}]"
+
+        # Create a Contact with graph_conversation_id (set by _find_sent_message
+        # right after send, OR by scan_sent_folder reconcile path)
+        now = datetime.now(timezone.utc)
+        contact = Contact(
+            requisition_id=test_requisition.id,
+            user_id=test_user.id,
+            contact_type="email",
+            vendor_name="Acme Parts",
+            vendor_name_normalized="acme parts",
+            vendor_contact=vendor_email,
+            parts_included=["P100"],
+            subject=tagged_subject,
+            details="Please quote.",
+            status="sent",
+            sent_at=now,
+            status_updated_at=now,
+            created_at=now,
+            graph_message_id="graph-msg-999",
+            graph_conversation_id=graph_conv_id,
+        )
+        db_session.add(contact)
+        db_session.commit()
+
+        # Simulate an inbound reply on the same conversation.
+        # SQLite UTCDateTime requires a datetime object (not an ISO string) for
+        # received_at — use a real datetime to avoid the SQLite type-check error.
+        inbound_msg = {
+            "id": "reply-msg-001",
+            "subject": f"Re: {tagged_subject}",
+            "conversationId": graph_conv_id,
+            "from": {"emailAddress": {"address": vendor_email, "name": "Vendor"}},
+            "body": {"content": "We can supply at $1.20 each."},
+            "receivedDateTime": now,  # datetime, not ISO string, so SQLite UTCDateTime accepts it
+            "hasAttachments": False,
+            "toRecipients": [],
+        }
+
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {"value": [inbound_msg]}
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            patch("app.email_service._submit_parse_batch", new_callable=AsyncMock),
+        ):
+            results = await poll_inbox(
+                token="tok",
+                db=db_session,
+                requisition_id=test_requisition.id,
+                scanned_by_user_id=test_user.id,
+            )
+
+        # Tier-1 match: conversation_id match → VendorResponse with contact_id set
+        from app.models import VendorResponse
+
+        vr = db_session.query(VendorResponse).filter_by(graph_conversation_id=graph_conv_id).first()
+        assert vr is not None, "Tier-1 match: VendorResponse must be created for the reply"
+        assert vr.contact_id == contact.id, f"VendorResponse.contact_id must link to the Contact, got {vr.contact_id}"

--- a/tests/test_p1b_send_clock.py
+++ b/tests/test_p1b_send_clock.py
@@ -25,6 +25,7 @@ from app.models import (
     ActivityLog,
     Contact,
 )
+from app.services.activity_service import log_email_activity
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helper: build a mock GraphClient that sends OK and returns no sent-items
@@ -220,23 +221,24 @@ class TestScanSentFolderReconcile:
         db_session.add(contact)
         db_session.flush()
 
-        # Create the outbound ActivityLog (no external_id yet)
-        activity = ActivityLog(
+        # Create the outbound ActivityLog via the REAL log_email_activity path
+        # (exactly as send_batch_rfq does) so this test genuinely exercises the
+        # reconcile match.  occurred_at=now is passed here — without it the row
+        # gets occurred_at=NULL and the reconcile query would miss it (the bug).
+        activity = log_email_activity(
             user_id=test_user.id,
-            activity_type="email_sent",
-            channel="email",
-            direction="outbound",
-            event_type="email",
-            contact_email=vendor_email,
+            direction="sent",
+            email_addr=vendor_email,
             subject=tagged_subject,
             external_id=None,  # not set at send time
+            contact_name="Acme Parts",
+            db=db_session,
             requisition_id=test_requisition.id,
-            auto_logged=True,
             occurred_at=now,
         )
-        db_session.add(activity)
         db_session.commit()
 
+        assert activity is not None, "log_email_activity must return an ActivityLog"
         activity_id_before = activity.id
         log_count_before = (
             db_session.query(ActivityLog)


### PR DESCRIPTION
Phase 1b. The outbound clock now advances at SEND time (not up to 30 min later, never lost if the sent-folder scan misses), with a durable `Contact.sent_at` (migration 114).

- `send_batch_rfq` writes the outbound ActivityLog synchronously on sendMail success (with the true `occurred_at`=send-time) + sets `Contact.sent_at`.
- `scan_sent_folder` now RECONCILES: it updates that existing send-time row with the Graph ids instead of creating a second one (no duplicate; count==1 verified by a revert-proof test). `Contact.graph_conversation_id` still drives Tier-1 reply-matching — unbroken.
- Review caught a real dup bug (NULL `occurred_at` defeated the reconcile match) — fixed by threading the true send-time through `log_email_activity`; the test now exercises the real path.

229 email tests green; migration 114 chained onto 113, claim line present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)