### PR TITLE
feat(crm): manual account segment tags + left-list segment filter (P2a)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4554,6 +4554,21 @@ from ..services.crm_service import company_contact_rows as _company_contact_rows
 from ..services.crm_service import next_best_touch as _next_best_touch  # noqa: E402
 from ..services.crm_service import order_by_clock as _order_by_clock  # noqa: E402
 from ..services.crm_service import staleness_tier as _staleness_tier  # noqa: E402, F401
+from ..services.tagging import (  # noqa: E402
+    assign_segment_tag as _assign_segment_tag,
+)
+from ..services.tagging import (
+    get_or_create_segment_tag as _get_or_create_segment_tag,
+)
+from ..services.tagging import (
+    list_all_segment_tags as _list_all_segment_tags,
+)
+from ..services.tagging import (
+    list_company_segment_tags as _list_company_segment_tags,
+)
+from ..services.tagging import (
+    unassign_segment_tag as _unassign_segment_tag,
+)
 
 _ALLOWED_HX_TARGETS = {"#main-content", "#crm-tab-content"}
 _ALLOWED_PUSH_URL_BASES = {"/v2/vendors", "/v2/customers", "/v2/crm"}
@@ -4576,6 +4591,7 @@ async def companies_list_partial(
     account_type: str = "",
     my_only: bool = False,
     sort: str = "oldest",
+    segment: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     user: User = Depends(require_user),
@@ -4592,6 +4608,7 @@ async def companies_list_partial(
             account_type=account_type,
             my_only=my_only,
             sort=sort,
+            segment=segment,
             limit=limit,
             offset=offset,
             include_overdue=True,
@@ -4608,6 +4625,7 @@ async def companies_account_list_partial(
     account_type: str = "",
     my_only: bool = False,
     sort: str = "oldest",
+    segment: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     user: User = Depends(require_user),
@@ -4628,6 +4646,7 @@ async def companies_account_list_partial(
             account_type=account_type,
             my_only=my_only,
             sort=sort,
+            segment=segment,
             limit=limit,
             offset=offset,
         )
@@ -4856,6 +4875,109 @@ def _company_quotes_query(db: Session, company):
     return db.query(Quote).filter(or_(*conds)).options(joinedload(Quote.requisition))
 
 
+@router.get("/v2/partials/customers/{company_id}/segment-tags", response_class=HTMLResponse)
+async def company_segment_tags_partial(
+    request: Request,
+    company_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Return the segment-tag chips + editor partial for a company."""
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+    tags = _list_company_segment_tags(company_id=company_id, db=db)
+    all_segment_tags = _list_all_segment_tags(db=db)
+    return template_response(
+        "htmx/partials/customers/_segment_tags.html",
+        {
+            "request": request,
+            "company": company,
+            "segment_tags": tags,
+            "all_segment_tags": all_segment_tags,
+        },
+    )
+
+
+@router.post("/v2/partials/customers/{company_id}/segment-tags", response_class=HTMLResponse)
+async def company_assign_segment_tag(
+    request: Request,
+    company_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Assign a segment tag to a company.
+
+    Accepts tag_id= (existing) or tag_name= (creates new).
+    """
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    form = await request.form()
+    tag_id_raw = form.get("tag_id", "").strip()
+    tag_name_raw = form.get("tag_name", "").strip()
+
+    if tag_name_raw:
+        tag = _get_or_create_segment_tag(tag_name_raw, db)
+    elif tag_id_raw:
+        try:
+            tag_id = int(tag_id_raw)
+        except ValueError:
+            raise HTTPException(400, "tag_id must be an integer")
+        from ..models.tags import Tag as _Tag
+
+        tag = db.query(_Tag).filter_by(id=tag_id).first()
+        if not tag:
+            raise HTTPException(404, "Tag not found")
+    else:
+        raise HTTPException(400, "Provide tag_id or tag_name")
+
+    _assign_segment_tag(company_id=company_id, tag_id=tag.id, db=db)
+    db.commit()
+
+    tags = _list_company_segment_tags(company_id=company_id, db=db)
+    all_segment_tags = _list_all_segment_tags(db=db)
+    return template_response(
+        "htmx/partials/customers/_segment_tags.html",
+        {
+            "request": request,
+            "company": company,
+            "segment_tags": tags,
+            "all_segment_tags": all_segment_tags,
+        },
+    )
+
+
+@router.delete("/v2/partials/customers/{company_id}/segment-tags/{tag_id}", response_class=HTMLResponse)
+async def company_unassign_segment_tag(
+    request: Request,
+    company_id: int,
+    tag_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Remove a segment tag from a company."""
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    _unassign_segment_tag(company_id=company_id, tag_id=tag_id, db=db)
+    db.commit()
+
+    tags = _list_company_segment_tags(company_id=company_id, db=db)
+    all_segment_tags = _list_all_segment_tags(db=db)
+    return template_response(
+        "htmx/partials/customers/_segment_tags.html",
+        {
+            "request": request,
+            "company": company,
+            "segment_tags": tags,
+            "all_segment_tags": all_segment_tags,
+        },
+    )
+
+
 @router.get("/v2/partials/customers/{company_id}", response_class=HTMLResponse)
 async def company_detail_partial(
     request: Request,
@@ -4907,6 +5029,8 @@ async def company_detail_partial(
     _cadence = _cadence_state(company.tier, company.last_outbound_at)
     _nbt = _next_best_touch(company.tier, company.last_outbound_at)
     contact_rows = _company_contact_rows(db, company_id, sites=sites)
+    segment_tags = _list_company_segment_tags(company_id=company_id, db=db)
+    all_segment_tags = _list_all_segment_tags(db=db)
 
     ctx = _base_ctx(request, user, "customers")
     ctx.update(
@@ -4931,6 +5055,9 @@ async def company_detail_partial(
             "last_req_date": _stats.get("last_req_date"),
             # Clock day calculations
             "now_utc": datetime.now(_tz.utc),
+            # Segment tags
+            "segment_tags": segment_tags,
+            "all_segment_tags": all_segment_tags,
         }
     )
     return template_response("htmx/partials/customers/detail.html", ctx)

--- a/app/services/crm_service.py
+++ b/app/services/crm_service.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session, joinedload
 from ..constants import RequisitionStatus
 from ..models import Company, CustomerSite, Quote, Requisition, SiteContact
 from ..models.auth import User
+from ..models.tags import EntityTag
 from ..models.vendors import VendorCard
 from ..utils.search_builder import SearchBuilder
 
@@ -151,6 +152,7 @@ def cdm_company_query(
     my_only: bool,
     sort: str,
     now: datetime | None = None,
+    segment: int = 0,
 ):
     """Build the filtered + sorted CDM account list query.
 
@@ -185,6 +187,18 @@ def cdm_company_query(
         query = query.filter(Company.account_type == account_type)
     if my_only:
         query = query.filter(Company.account_owner_id == user.id)
+    if segment:
+        query = query.filter(
+            db.query(EntityTag)
+            .filter(
+                EntityTag.entity_type == "company",
+                EntityTag.entity_id == Company.id,
+                EntityTag.tag_id == segment,
+                EntityTag.is_visible.is_(True),
+            )
+            .correlate(Company)
+            .exists()
+        )
 
     # Cadence clock sorts return a fully-ordered query directly (order_by_clock
     # calls query.order_by(...) internally), so we return early to avoid
@@ -229,6 +243,7 @@ def cdm_list_ctx(
     sort: str,
     limit: int,
     offset: int,
+    segment: int = 0,
     include_overdue: bool = False,
 ) -> dict:
     """Shared context for the CDM workspace shell and its account-list partial.
@@ -237,10 +252,21 @@ def cdm_list_ctx(
     "needs a call" chip, an extra COUNT query) AND account_types (the type
     dropdown options). The account-list refresh route re-renders neither, so
     it omits both and skips the COUNT query.
+    segment: when non-zero, filter companies carrying that segment tag_id.
     """
+    from .tagging import list_all_segment_tags
+
     now = datetime.now(timezone.utc)
     query = cdm_company_query(
-        db, user, search=search, staleness=staleness, account_type=account_type, my_only=my_only, sort=sort, now=now
+        db,
+        user,
+        search=search,
+        staleness=staleness,
+        account_type=account_type,
+        my_only=my_only,
+        sort=sort,
+        now=now,
+        segment=segment,
     )
     total = query.count()
     companies = query.offset(offset).limit(limit).all()
@@ -255,9 +281,11 @@ def cdm_list_ctx(
         "account_type": account_type,
         "my_only": my_only,
         "sort": sort,
+        "segment": segment,
         "total": total,
         "limit": limit,
         "offset": offset,
+        "all_segment_tags": list_all_segment_tags(db),
     }
     if include_overdue:
         ctx["overdue_count"] = cdm_overdue_count(db, user, now=now)

--- a/app/services/tagging.py
+++ b/app/services/tagging.py
@@ -261,10 +261,16 @@ def recalculate_entity_tag_visibility(entity_type: str, entity_id: int, db: Sess
     thresholds = {cfg.tag_type: cfg for cfg in db.query(TagThresholdConfig).filter_by(entity_type=entity_type).all()}
 
     for et in entity_tags:
-        et.total_entity_interactions = total
         tag = db.get(Tag, et.tag_id)
         if not tag:  # pragma: no cover
             continue
+
+        # Segment tags are always visible — never subject to count thresholds.
+        if tag.tag_type == "segment":
+            et.is_visible = True
+            continue
+
+        et.total_entity_interactions = total
 
         cfg = thresholds.get(tag.tag_type)
         if not cfg:
@@ -314,3 +320,85 @@ def propagate_tags_to_entity(
         recalculate_entity_tag_visibility(entity_type, entity_id, db)
     except Exception:  # pragma: no cover
         logger.exception(f"Failed to recalculate visibility for {entity_type}:{entity_id}")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  MANUAL SEGMENT TAGS — always-visible, rep-controlled segmentation
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def get_or_create_segment_tag(name: str, db: Session) -> Tag:
+    """Find or create a Tag with tag_type='segment'. Case-insensitive dedup.
+
+    Segment tags are created on-demand by reps (e.g. "OEM", "At-risk", "Key-target").
+    Race-safe via savepoint + IntegrityError retry.
+    """
+    normalized = name.strip()
+    by_name = select(Tag).where(func.lower(Tag.name) == normalized.lower(), Tag.tag_type == "segment")
+
+    tag = db.execute(by_name).scalar_one_or_none()
+    if tag:
+        return tag
+
+    try:
+        with db.begin_nested():
+            tag = Tag(name=normalized, tag_type="segment", created_at=datetime.now(timezone.utc))
+            db.add(tag)
+            db.flush()
+        return tag
+    except IntegrityError:
+        return db.execute(by_name).scalar_one()
+
+
+def assign_segment_tag(company_id: int, tag_id: int, db: Session) -> EntityTag:
+    """Assign a segment tag to a company.
+
+    Upserts an EntityTag(entity_type='company', is_visible=True). Manual segment tags
+    are ALWAYS visible — they are never subject to the count-threshold visibility gates
+    used for AI brand/commodity tags.
+    """
+    existing = db.query(EntityTag).filter_by(entity_type="company", entity_id=company_id, tag_id=tag_id).first()
+    if existing:
+        existing.is_visible = True
+        return existing
+
+    et = EntityTag(
+        entity_type="company",
+        entity_id=company_id,
+        tag_id=tag_id,
+        is_visible=True,
+        interaction_count=0,
+        total_entity_interactions=0,
+    )
+    db.add(et)
+    db.flush()
+    return et
+
+
+def unassign_segment_tag(company_id: int, tag_id: int, db: Session) -> None:
+    """Remove a segment tag assignment from a company."""
+    et = db.query(EntityTag).filter_by(entity_type="company", entity_id=company_id, tag_id=tag_id).first()
+    if et:
+        db.delete(et)
+        db.flush()
+
+
+def list_company_segment_tags(company_id: int, db: Session) -> list[Tag]:
+    """Return all segment Tags assigned to a company (is_visible=True)."""
+    return (
+        db.query(Tag)
+        .join(EntityTag, EntityTag.tag_id == Tag.id)
+        .filter(
+            EntityTag.entity_type == "company",
+            EntityTag.entity_id == company_id,
+            EntityTag.is_visible.is_(True),
+            Tag.tag_type == "segment",
+        )
+        .order_by(Tag.name)
+        .all()
+    )
+
+
+def list_all_segment_tags(db: Session) -> list[Tag]:
+    """Return all Tags with tag_type='segment', ordered alphabetically."""
+    return db.query(Tag).filter(Tag.tag_type == "segment").order_by(Tag.name).all()

--- a/app/templates/htmx/partials/customers/_segment_tags.html
+++ b/app/templates/htmx/partials/customers/_segment_tags.html
@@ -1,0 +1,78 @@
+{# Segment-tag chips + editor for a company.
+   Renders the company's current segment chips + an add-from-existing dropdown
+   + a new-tag input. All mutations use HTMX partial swaps targeting this
+   container (#segment-tags-{{ company.id }}).
+
+   Receives: company, segment_tags (list[Tag] — current), all_segment_tags (list[Tag] — for dropdown).
+   Called by: company_detail_partial + segment-tag routes (htmx_views.py).
+#}
+
+<div id='segment-tags-{{ company.id }}' class='flex flex-wrap items-center gap-2'>
+
+  {# Existing chips — each has an × remove button #}
+  {% for tag in segment_tags %}
+  <span class='inline-flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium rounded-full bg-violet-100 text-violet-700 border border-violet-200'>
+    {{ tag.name }}
+    <button type='button'
+            class='ml-0.5 text-violet-400 hover:text-violet-600 focus:outline-none'
+            title='Remove {{ tag.name }}'
+            hx-delete='/v2/partials/customers/{{ company.id }}/segment-tags/{{ tag.id }}'
+            hx-target='#segment-tags-{{ company.id }}'
+            hx-swap='outerHTML'>
+      <svg class='h-3 w-3' viewBox='0 0 20 20' fill='currentColor'>
+        <path fill-rule='evenodd' d='M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z' clip-rule='evenodd'/>
+      </svg>
+    </button>
+  </span>
+  {% endfor %}
+
+  {# Add from existing dropdown — Alpine keeps the UI open/closed #}
+  <div x-data='{ open: false }' class='relative'>
+    <button type='button'
+            @click='open = !open'
+            class='inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border border-dashed border-violet-300 text-violet-500 hover:border-violet-500 hover:text-violet-700 transition-colors'>
+      <svg class='h-3 w-3' fill='none' viewBox='0 0 24 24' stroke='currentColor'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 4v16m8-8H4'/></svg>
+      Tag
+    </button>
+
+    <div x-show='open' @click.outside='open = false' x-cloak
+         class='absolute left-0 top-6 z-20 w-48 bg-white rounded-lg shadow-lg border border-gray-200 p-2'>
+
+      {# Pick an existing segment tag (exclude already-assigned ones) #}
+      {% set assigned_ids = segment_tags | map(attribute='id') | list %}
+      {% set ns = namespace(has_available=false) %}
+      {% for t in all_segment_tags %}{% if t.id not in assigned_ids %}{% set ns.has_available = true %}{% endif %}{% endfor %}
+      {% if ns.has_available %}
+      <p class='text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-1 px-1'>Add existing</p>
+      {% for t in all_segment_tags %}
+      {% if t.id not in assigned_ids %}
+      <button type='button'
+              class='block w-full text-left px-2 py-1 text-xs text-gray-700 hover:bg-violet-50 hover:text-violet-700 rounded'
+              hx-post='/v2/partials/customers/{{ company.id }}/segment-tags'
+              hx-vals='{"tag_id": "{{ t.id }}"}'
+              hx-target='#segment-tags-{{ company.id }}'
+              hx-swap='outerHTML'
+              @click='open = false'>
+        {{ t.name }}
+      </button>
+      {% endif %}
+      {% endfor %}
+      {% endif %}
+
+      {# Create a new tag by name #}
+      <p class='text-[10px] font-semibold text-gray-400 uppercase tracking-wider mt-2 mb-1 px-1'>New tag</p>
+      <form hx-post='/v2/partials/customers/{{ company.id }}/segment-tags'
+            hx-target='#segment-tags-{{ company.id }}'
+            hx-swap='outerHTML'
+            @submit='open = false'
+            class='flex gap-1'>
+        <input type='text' name='tag_name' placeholder='e.g. OEM'
+               class='flex-1 min-w-0 px-2 py-1 text-xs border border-gray-200 rounded focus:ring-1 focus:ring-violet-500 focus:border-violet-500'
+               required maxlength='60'>
+        <button type='submit'
+                class='px-2 py-1 text-xs font-medium bg-violet-500 text-white rounded hover:bg-violet-600'>Add</button>
+      </form>
+    </div>
+  </div>
+
+</div>

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -225,6 +225,12 @@
     </div>
   </div>
 
+  {# ── Segment Tags ────────────────────────────────────────── #}
+  <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4">
+    <h2 class="text-sm font-semibold text-gray-900 mb-2">Segments</h2>
+    {% include "htmx/partials/customers/_segment_tags.html" %}
+  </div>
+
   {# ── Notes ───────────────────────────────────────────────── #}
   {% if company.notes %}
   <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4">

--- a/app/templates/htmx/partials/customers/list.html
+++ b/app/templates/htmx/partials/customers/list.html
@@ -50,6 +50,16 @@
       {% endfor %}
     </select>
 
+    {% if all_segment_tags %}
+    <select name="segment" aria-label="Filter by segment tag"
+            class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
+      <option value="0">All segments</option>
+      {% for t in all_segment_tags %}
+      <option value="{{ t.id }}" {{ "selected" if segment == t.id }}>{{ t.name }}</option>
+      {% endfor %}
+    </select>
+    {% endif %}
+
     <select name="sort" aria-label="Sort accounts"
             class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
       <option value="oldest" {{ "selected" if sort == "oldest" }}>Longest since activity</option>

--- a/tests/test_crm_service.py
+++ b/tests/test_crm_service.py
@@ -471,3 +471,251 @@ class TestCdmCompanyQueryClockSorts:
         names = [c.name for c in results if c.name.startswith("Reply-")]
         assert names.index("Reply-Null Co") < names.index("Reply-Old Co")
         assert names.index("Reply-Old Co") < names.index("Reply-Recent Co")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestSegmentTagService — P2a manual account segmentation tags
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSegmentTagService:
+    """Tests for manual segment-tag service functions.
+
+    Written FIRST (TDD RED) — these will fail until the functions are
+    implemented in app/services/tagging.py (or crm_service.py).
+
+    segment tags differ from AI brand/commodity tags:
+    - tag_type = 'segment'
+    - EntityTag.is_visible = True ALWAYS (not subject to count thresholds)
+    - Managed by rep action (assign / unassign), not by propagate waterfall
+    """
+
+    def test_assign_segment_tag_creates_entity_tag(self, db_session: Session):
+        """Assigning a segment tag creates an EntityTag(is_visible=True) for the
+        company."""
+        from app.models.tags import EntityTag
+        from app.services.tagging import assign_segment_tag, get_or_create_segment_tag
+
+        co = _make_company(db_session, "Seg Co A")
+        db_session.commit()
+
+        tag = get_or_create_segment_tag("OEM", db_session)
+        assign_segment_tag(company_id=co.id, tag_id=tag.id, db=db_session)
+        db_session.flush()
+
+        et = db_session.query(EntityTag).filter_by(entity_type="company", entity_id=co.id, tag_id=tag.id).first()
+        assert et is not None
+        assert et.is_visible is True
+
+    def test_assign_segment_tag_idempotent(self, db_session: Session):
+        """Assigning the same tag twice does not create a duplicate EntityTag."""
+        from app.models.tags import EntityTag
+        from app.services.tagging import assign_segment_tag, get_or_create_segment_tag
+
+        co = _make_company(db_session, "Seg Co Idem")
+        db_session.commit()
+
+        tag = get_or_create_segment_tag("Key-target", db_session)
+        assign_segment_tag(company_id=co.id, tag_id=tag.id, db=db_session)
+        db_session.flush()
+        assign_segment_tag(company_id=co.id, tag_id=tag.id, db=db_session)
+        db_session.flush()
+
+        count = db_session.query(EntityTag).filter_by(entity_type="company", entity_id=co.id, tag_id=tag.id).count()
+        assert count == 1
+
+    def test_unassign_segment_tag_removes_entity_tag(self, db_session: Session):
+        """Unassigning a segment tag removes the EntityTag row."""
+        from app.models.tags import EntityTag
+        from app.services.tagging import assign_segment_tag, get_or_create_segment_tag, unassign_segment_tag
+
+        co = _make_company(db_session, "Seg Co B")
+        db_session.commit()
+
+        tag = get_or_create_segment_tag("At-risk", db_session)
+        assign_segment_tag(company_id=co.id, tag_id=tag.id, db=db_session)
+        db_session.flush()
+
+        unassign_segment_tag(company_id=co.id, tag_id=tag.id, db=db_session)
+        db_session.flush()
+
+        et = db_session.query(EntityTag).filter_by(entity_type="company", entity_id=co.id, tag_id=tag.id).first()
+        assert et is None
+
+    def test_list_company_segment_tags_returns_assigned(self, db_session: Session):
+        """list_company_segment_tags returns the Tag rows for a company's segment
+        tags."""
+        from app.services.tagging import assign_segment_tag, get_or_create_segment_tag, list_company_segment_tags
+
+        co = _make_company(db_session, "Seg Co C")
+        db_session.commit()
+
+        tag_a = get_or_create_segment_tag("OEM", db_session)
+        tag_b = get_or_create_segment_tag("At-risk", db_session)
+        assign_segment_tag(company_id=co.id, tag_id=tag_a.id, db=db_session)
+        assign_segment_tag(company_id=co.id, tag_id=tag_b.id, db=db_session)
+        db_session.flush()
+
+        tags = list_company_segment_tags(company_id=co.id, db=db_session)
+        names = {t.name for t in tags}
+        assert "OEM" in names
+        assert "At-risk" in names
+
+    def test_list_all_segment_tags_returns_all_created(self, db_session: Session):
+        """list_all_segment_tags returns every Tag with tag_type='segment'."""
+        from app.services.tagging import get_or_create_segment_tag, list_all_segment_tags
+
+        get_or_create_segment_tag("OEM", db_session)
+        get_or_create_segment_tag("Key-target", db_session)
+        get_or_create_segment_tag("At-risk", db_session)
+        db_session.flush()
+
+        all_tags = list_all_segment_tags(db=db_session)
+        names = {t.name for t in all_tags}
+        assert "OEM" in names
+        assert "Key-target" in names
+        assert "At-risk" in names
+
+    def test_segment_tag_is_always_visible_not_affected_by_thresholds(self, db_session: Session):
+        """recalculate_entity_tag_visibility does NOT flip segment tags to
+        is_visible=False even with zero interaction count."""
+        from app.models.tags import EntityTag
+        from app.services.tagging import (
+            assign_segment_tag,
+            get_or_create_segment_tag,
+            recalculate_entity_tag_visibility,
+        )
+
+        co = _make_company(db_session, "Seg Visibility Co")
+        db_session.commit()
+
+        tag = get_or_create_segment_tag("OEM", db_session)
+        assign_segment_tag(company_id=co.id, tag_id=tag.id, db=db_session)
+        db_session.flush()
+
+        # Calling recalculate should NOT touch segment tags
+        recalculate_entity_tag_visibility("company", co.id, db_session)
+        db_session.flush()
+
+        et = db_session.query(EntityTag).filter_by(entity_type="company", entity_id=co.id, tag_id=tag.id).first()
+        assert et is not None
+        assert et.is_visible is True
+
+    def test_get_or_create_segment_tag_case_insensitive(self, db_session: Session):
+        """get_or_create_segment_tag deduplicates case-insensitively."""
+        from app.services.tagging import get_or_create_segment_tag
+
+        t1 = get_or_create_segment_tag("OEM", db_session)
+        db_session.flush()
+        t2 = get_or_create_segment_tag("oem", db_session)
+        db_session.flush()
+
+        assert t1.id == t2.id
+
+
+class TestCdmCompanyQuerySegmentFilter:
+    """Tests for cdm_company_query with segment= filter.
+
+    Written FIRST (TDD RED) — will fail until cdm_company_query accepts segment= and
+    filters by EntityTag(tag_type='segment', is_visible=True).
+    """
+
+    def test_segment_filter_returns_only_tagged_companies(self, db_session: Session):
+        """cdm_company_query(segment=tag_id) returns only companies with that segment
+        tag."""
+        from app.models import User
+        from app.services.crm_service import cdm_company_query
+        from app.services.tagging import assign_segment_tag, get_or_create_segment_tag
+
+        user = User(email="seg-filter@example.com", name="Seg Tester", is_active=True)
+        db_session.add(user)
+
+        co_tagged = Company(name="Seg-Tagged Co", is_active=True)
+        co_other = Company(name="Seg-Untagged Co", is_active=True)
+        db_session.add_all([co_tagged, co_other])
+        db_session.flush()
+
+        tag = get_or_create_segment_tag("OEM", db_session)
+        assign_segment_tag(company_id=co_tagged.id, tag_id=tag.id, db=db_session)
+        db_session.commit()
+
+        results = cdm_company_query(
+            db_session,
+            user,
+            search="",
+            staleness="",
+            account_type="",
+            my_only=False,
+            sort="oldest",
+            segment=tag.id,
+        ).all()
+
+        names = {c.name for c in results}
+        assert "Seg-Tagged Co" in names
+        assert "Seg-Untagged Co" not in names
+
+    def test_segment_filter_composes_with_my_only(self, db_session: Session):
+        """Segment= filter composes with my_only — only returns owned+tagged
+        companies."""
+
+        from app.models import User
+        from app.services.crm_service import cdm_company_query
+        from app.services.tagging import assign_segment_tag, get_or_create_segment_tag
+
+        owner = User(email="owner-seg@example.com", name="Owner", role="sales", is_active=True)
+        other_user = User(email="other-seg@example.com", name="Other", role="sales", is_active=True)
+        db_session.add_all([owner, other_user])
+        db_session.flush()
+
+        co_mine = Company(name="MySegCo", is_active=True, account_owner_id=owner.id)
+        co_theirs = Company(name="TheirSegCo", is_active=True, account_owner_id=other_user.id)
+        db_session.add_all([co_mine, co_theirs])
+        db_session.flush()
+
+        tag = get_or_create_segment_tag("Key-target", db_session)
+        assign_segment_tag(company_id=co_mine.id, tag_id=tag.id, db=db_session)
+        assign_segment_tag(company_id=co_theirs.id, tag_id=tag.id, db=db_session)
+        db_session.commit()
+
+        results = cdm_company_query(
+            db_session,
+            owner,
+            search="",
+            staleness="",
+            account_type="",
+            my_only=True,
+            sort="oldest",
+            segment=tag.id,
+        ).all()
+
+        names = {c.name for c in results}
+        assert "MySegCo" in names
+        assert "TheirSegCo" not in names
+
+    def test_segment_filter_zero_returns_all(self, db_session: Session):
+        """Segment=0 (or None / empty) returns all companies (no filter applied)."""
+        from app.models import User
+        from app.services.crm_service import cdm_company_query
+
+        user = User(email="seg-zero@example.com", name="Zero Tester", is_active=True)
+        db_session.add(user)
+
+        co1 = Company(name="ZeroSeg-Co1", is_active=True)
+        co2 = Company(name="ZeroSeg-Co2", is_active=True)
+        db_session.add_all([co1, co2])
+        db_session.commit()
+
+        results = cdm_company_query(
+            db_session,
+            user,
+            search="",
+            staleness="",
+            account_type="",
+            my_only=False,
+            sort="oldest",
+            segment=0,
+        ).all()
+
+        names = {c.name for c in results}
+        assert "ZeroSeg-Co1" in names
+        assert "ZeroSeg-Co2" in names

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -1990,3 +1990,118 @@ class TestVendorDetailCadenceHero:
         assert resp.status_code == 200
         assert "Sightings" in resp.text
         assert "7" in resp.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestSegmentTagViews — P2a manual account segmentation tags
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSegmentTagViews:
+    """Tests for segment-tag UI endpoints.
+
+    Written FIRST (TDD RED) — will fail until the routes are added to
+    htmx_views.py and the templates updated.
+
+    Routes tested:
+      POST /v2/partials/customers/{company_id}/segment-tags   (assign)
+      DELETE /v2/partials/customers/{company_id}/segment-tags/{tag_id}  (unassign)
+      GET  /v2/partials/customers/{company_id}/segment-tags   (chips partial)
+    """
+
+    def _make_company(self, db_session: Session, name: str = "SegView Co") -> Company:
+        co = Company(name=name, is_active=True)
+        db_session.add(co)
+        db_session.commit()
+        db_session.refresh(co)
+        return co
+
+    def test_segment_chips_partial_returns_html(self, client: TestClient, db_session: Session, test_user: User):
+        """GET /v2/partials/customers/{id}/segment-tags returns 200 HTML."""
+        co = self._make_company(db_session)
+        resp = client.get(f"/v2/partials/customers/{co.id}/segment-tags")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers.get("content-type", "")
+
+    def test_assign_segment_tag_returns_chips_partial(self, client: TestClient, db_session: Session, test_user: User):
+        """POST assign creates the EntityTag and re-renders the chips partial."""
+        from app.services.tagging import get_or_create_segment_tag
+
+        co = self._make_company(db_session, "AssignSeg Co")
+        tag = get_or_create_segment_tag("OEM", db_session)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{co.id}/segment-tags",
+            data={"tag_id": str(tag.id)},
+        )
+        assert resp.status_code == 200
+        assert "OEM" in resp.text
+
+    def test_unassign_segment_tag_returns_chips_partial(self, client: TestClient, db_session: Session, test_user: User):
+        """DELETE unassign removes the EntityTag and re-renders the chips partial.
+
+        The tag may still appear in the 'add existing' dropdown, but the active chip
+        (which carries a remove-button with hx-delete) must be gone.
+        """
+        from app.services.tagging import assign_segment_tag, get_or_create_segment_tag
+
+        co = self._make_company(db_session, "UnassignSeg Co")
+        tag = get_or_create_segment_tag("At-risk", db_session)
+        assign_segment_tag(company_id=co.id, tag_id=tag.id, db=db_session)
+        db_session.commit()
+
+        resp = client.delete(f"/v2/partials/customers/{co.id}/segment-tags/{tag.id}")
+        assert resp.status_code == 200
+        # The remove-button for this tag must no longer be present after removal.
+        # (The tag name may still appear in the "add existing" dropdown.)
+        assert f"hx-delete='/v2/partials/customers/{co.id}/segment-tags/{tag.id}'" not in resp.text
+
+    def test_account_detail_renders_segment_tag_section(self, client: TestClient, db_session: Session, test_user: User):
+        """Company detail page includes the segment-tags editor block."""
+        co = self._make_company(db_session, "DetailSeg Co")
+
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+        # The segment tag editor container must be present in the detail
+        assert "segment-tags" in resp.text
+
+    def test_list_filter_bar_renders_segment_dropdown(self, client: TestClient, db_session: Session, test_user: User):
+        """The CDM filter bar renders a segment-tags dropdown when segment tags
+        exist."""
+        from app.services.tagging import get_or_create_segment_tag
+
+        get_or_create_segment_tag("OEM", db_session)
+        get_or_create_segment_tag("At-risk", db_session)
+        db_session.commit()
+
+        resp = client.get("/v2/partials/customers")
+        assert resp.status_code == 200
+        # The dropdown name attribute must be present
+        assert 'name="segment"' in resp.text
+        assert "OEM" in resp.text
+
+    def test_account_list_segment_filter_param_accepted(self, client: TestClient, db_session: Session, test_user: User):
+        """The account-list partial accepts a segment= query param without error."""
+        from app.services.tagging import assign_segment_tag, get_or_create_segment_tag
+
+        co = self._make_company(db_session, "FilterAccept Co")
+        tag = get_or_create_segment_tag("OEM", db_session)
+        assign_segment_tag(company_id=co.id, tag_id=tag.id, db=db_session)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/account-list?segment={tag.id}")
+        assert resp.status_code == 200
+        assert "FilterAccept Co" in resp.text
+
+    def test_create_new_segment_tag_via_name_param(self, client: TestClient, db_session: Session, test_user: User):
+        """POST with tag_name= (instead of tag_id=) creates a new segment tag and
+        assigns it."""
+        co = self._make_company(db_session, "NewTag Co")
+
+        resp = client.post(
+            f"/v2/partials/customers/{co.id}/segment-tags",
+            data={"tag_name": "Growth"},
+        )
+        assert resp.status_code == 200
+        assert "Growth" in resp.text


### PR DESCRIPTION
Phase 2a. Rep-controlled account segmentation reusing the existing Tag/EntityTag infra (no migration).

- `Tag(tag_type=%27segment%27)` + `EntityTag(entity_type=%27company%27, is_visible=True)`; manual segment tags are ALWAYS visible — `recalculate_entity_tag_visibility` now skips them so the AI brand/commodity count-threshold logic is unchanged.
- Account detail: segment chips + add-existing/new editor (HTMX swaps, static-guard-safe single-quoted Alpine + object-literal hx-vals).
- Left list: a `segment` filter (correlated-EXISTS, composes with my/staleness/type) + a dropdown that renders when ≥1 segment tag exists.

17 new tests (incl. always-visible regression guard, filter composition); /qa green (ruff, mypy, pre-commit, targeted pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)