### PR TITLE
polish(sightings-panel): smooth drawer close + horizontal scroll on narrow

### DIFF
--- a/app/templates/htmx/partials/sightings/_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/_vendor_row.html
@@ -193,10 +193,17 @@
     </td>
   </tr>
 
-  {# ── Detail drawer — single colspan row; inner div carries the collapse anim ── #}
-  <tr x-show="expanded" x-cloak>
-    <td colspan="5" class="p-0">
-      <div x-show="expanded" x-collapse class="px-3 pb-2 bg-gray-50/50 border-t border-gray-100">
+  {# ── Detail drawer — always-present colspan row; the inner div owns BOTH the
+       show/hide and the collapse animation. The <tr> deliberately has NO x-show:
+       gating the row's display would hide it the instant the collapse starts and
+       cut the close animation short (a visible snap). When collapsed the inner div
+       is display:none, so this row sits at ~0 height. Padding + border are zeroed
+       INLINE (not via Tailwind p-0) because the unlayered, higher-specificity
+       `.compact-table td` rule beats the p-0 class and would otherwise leave a
+       ~12px gap row + a stray divider between vendors. #}
+  <tr>
+    <td colspan="5" style="padding:0;border-bottom:0">
+      <div x-show="expanded" x-cloak x-collapse class="px-3 pb-2 bg-gray-50/50 border-t border-gray-100">
         <div class="grid grid-cols-2 gap-x-4 gap-y-1.5 py-2 text-xs">
           {# ── Unavailability knowledge — first entry, full width ── #}
           {% if unav and is_unavailable %}

--- a/app/templates/htmx/partials/sightings/detail.html
+++ b/app/templates/htmx/partials/sightings/detail.html
@@ -101,6 +101,9 @@
   {% set vendor_collapse_limit = 5 %}
   {% set extra_count = summaries|length - vendor_collapse_limit %}
   <div x-data="{ vendorsExpanded: false }">
+    {# overflow-x-auto: on a narrow split pane / phone the 5 columns scroll
+       horizontally instead of crushing (compact-table cells are nowrap). #}
+    <div class="overflow-x-auto">
     <table class="compact-table w-full">
       <thead>
         <tr>
@@ -120,6 +123,7 @@
       {% include "htmx/partials/sightings/_vendor_row.html" %}
       {% endfor %}
     </table>
+    </div>
     {% if extra_count > 0 %}
     <button @click="vendorsExpanded = !vendorsExpanded"
             class="w-full mt-1 py-1.5 text-xs text-brand-600 hover:text-brand-800 font-medium text-center transition-colors">

--- a/tests/test_panel_column_alignment.py
+++ b/tests/test_panel_column_alignment.py
@@ -143,6 +143,41 @@ class TestSightingsVendorColumns:
         assert "$12.40" in body  # best_price
         assert "82%" in body  # score
 
+    def test_drawer_close_animates_via_inner_collapse(self, client: TestClient, req_with_vendor_summary):
+        """The expand drawer must animate closed smoothly: the collapse lives on the
+        inner div, and the drawer <tr> must NOT carry x-show — gating the row's display
+        directly hides it the instant the collapse starts (a visible snap)."""
+        _req, item = req_with_vendor_summary
+        resp = client.get(f"/v2/partials/sightings/{item.id}/detail")
+        table = _vendors_table(resp.text)
+        drawer_rows = [
+            tr
+            for tr in table.find_all("tr")
+            if len(tr.find_all("td", recursive=False)) == 1 and tr.find("td").get("colspan")
+        ]
+        assert drawer_rows, "expected a drawer row"
+        for tr in drawer_rows:
+            assert not tr.has_attr("x-show"), "drawer <tr> must not gate display with x-show (causes snap)"
+            assert tr.select("[x-collapse]"), "drawer must keep x-collapse on an inner element"
+            # The collapsed (always-present) row must be flush — padding/border zeroed via
+            # INLINE style, because `.compact-table td` (unlayered, higher specificity) beats
+            # Tailwind's p-0 class and would otherwise leave a ~12px gap row between vendors.
+            style = (tr.find("td", recursive=False).get("style") or "").replace(" ", "")
+            assert "padding:0" in style, "drawer <td> must zero padding inline (p-0 class loses to .compact-table td)"
+            assert "border-bottom:0" in style, "drawer <td> must zero its border inline"
+
+    def test_vendor_table_scrolls_horizontally_on_narrow(self, client: TestClient, req_with_vendor_summary):
+        """The 5-column vendor table must sit in an overflow-x-auto wrapper so it stays
+        readable (scrolls) on narrow / phone widths instead of crushing columns."""
+        _req, item = req_with_vendor_summary
+        resp = client.get(f"/v2/partials/sightings/{item.id}/detail")
+        node = _vendors_table(resp.text)
+        while node is not None:
+            if any("overflow-x-auto" in c for c in (node.get("class") or [])):
+                break
+            node = node.parent
+        assert node is not None, "vendors table must be inside an overflow-x-auto wrapper"
+
 
 # ── Track 2: requisitions2 detail panel tabs ────────────────────────────────
 class TestReqsDetailTabs:


### PR DESCRIPTION
## Why
Two cosmetic polish items on the sightings detail Vendors tab (follow-up to #345), approved.

## What
1. **Drawer close animation** — the vendor-row expand drawer snapped shut because the drawer `<tr>` carried `x-show="expanded"` (hid the row the instant the collapse started). Moved show/hide to the inner `<div>` (keeps `x-show` + `x-collapse` + `x-cloak`); the `<tr>` is now always-present with its `<td>` padding + border zeroed **inline** so the collapsed ~0-height row is flush. Animates open **and** closed now.
2. **Horizontal scroll** — wrapped the 5-column vendor table in `overflow-x-auto` so it scrolls on a narrow split pane / phone instead of crushing columns.

## QA (one-shot gate)
| Tool | Result |
|---|---|
| Bug review (code-reviewer) | 1 CRITICAL found → **fixed**: `p-0` class loses to unlayered `.compact-table td{padding}` → moved padding zero inline (else a ~12px gap row between vendors). All other points confirmed non-issues. |
| Static-analysis (Alpine/htmx anti-patterns) | ✅ 12 passed |
| Targeted tests (panel + sightings router) | ✅ 237 passed |
| pre-commit (ruff/format/mypy/docformatter) | ✅ pass |
| Security | N/A (no auth/deps/routes/SQL) |

TDD guard tests added: drawer `<tr>` has no `x-show`, keeps inner `x-collapse`, zeroes `<td>` padding+border inline; table sits in an `overflow-x-auto` wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwpL91Zg37qaSLhsNV1S8P