### PR TITLE
feat(crm): set account tier + contact buying-role from the cockpit (P2b)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4978,6 +4978,112 @@ async def company_unassign_segment_tag(
     )
 
 
+_VALID_TIERS = frozenset({"key", "core", "standard", "prospect"})
+
+# Canonical buying-role taxonomy (P2b).  Legacy values (buyer/technical/
+# decision_maker/operations) remain valid in the DB but can only be cleared
+# via the "— clear —" option; they are not in this set.
+CANONICAL_ROLES = ("specifier", "buyer_po", "ap_payer", "logistics", "exec", "other")
+_VALID_ROLES = frozenset(CANONICAL_ROLES)
+
+
+@router.post("/v2/partials/customers/{company_id}/tier", response_class=HTMLResponse)
+async def set_company_tier(
+    request: Request,
+    company_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Set Company.tier; re-renders the cadence hero with updated badge + NBT.
+
+    Accepts tier= from the inline select.  Blank value clears the tier (NULL → behaves
+    as 'standard').  Invalid value → 400.
+    """
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    form = await request.form()
+    tier_raw = (form.get("tier") or "").strip()
+
+    if tier_raw and tier_raw not in _VALID_TIERS:
+        raise HTTPException(400, f"Invalid tier '{tier_raw}'. Valid: {sorted(_VALID_TIERS)}")
+
+    company.tier = tier_raw or None
+    db.commit()
+    db.refresh(company)
+
+    _cadence = _cadence_state(company.tier, company.last_outbound_at)
+    _nbt = _next_best_touch(company.tier, company.last_outbound_at)
+    logger.info("Company {} tier set to {} by {}", company_id, company.tier, user.email)
+    return template_response(
+        "htmx/partials/customers/_cadence_hero.html",
+        {
+            "request": request,
+            "company": company,
+            "cadence_state": _cadence,
+            "next_best_touch": _nbt,
+        },
+    )
+
+
+@router.post(
+    "/v2/partials/customers/{company_id}/contacts/{contact_id}/role",
+    response_class=HTMLResponse,
+)
+async def set_contact_role(
+    request: Request,
+    company_id: int,
+    contact_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Set SiteContact.contact_role; re-renders the role chip editor.
+
+    Accepts contact_role= from the inline select.  Blank value clears the role (NULL).
+    Invalid value → 400 (legacy values that pre-exist in the DB are not accepted via
+    this endpoint; rep must choose a canonical role).
+    """
+    contact = (
+        db.query(SiteContact)
+        .join(CustomerSite)
+        .filter(SiteContact.id == contact_id, CustomerSite.company_id == company_id)
+        .first()
+    )
+    if not contact:
+        raise HTTPException(404, "Contact not found")
+
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    form = await request.form()
+    role_raw = (form.get("contact_role") or "").strip()
+
+    if role_raw and role_raw not in _VALID_ROLES:
+        raise HTTPException(400, f"Invalid contact_role '{role_raw}'. Valid: {sorted(_VALID_ROLES)}")
+
+    contact.contact_role = role_raw or None
+    db.commit()
+    db.refresh(contact)
+
+    logger.info(
+        "Contact {} role set to {} by {} (company {})",
+        contact_id,
+        contact.contact_role,
+        user.email,
+        company_id,
+    )
+    return template_response(
+        "htmx/partials/customers/_role_chip_editor.html",
+        {
+            "request": request,
+            "company": company,
+            "contact": contact,
+        },
+    )
+
+
 @router.get("/v2/partials/customers/{company_id}", response_class=HTMLResponse)
 async def company_detail_partial(
     request: Request,

--- a/app/templates/htmx/partials/customers/_cadence_hero.html
+++ b/app/templates/htmx/partials/customers/_cadence_hero.html
@@ -1,0 +1,35 @@
+{# Cadence hero — cadence badge + settable tier dropdown + next-best-touch.
+   Renders inside the Account Cadence Card (detail.html).
+   Re-rendered by POST /v2/partials/customers/{company_id}/tier to reflect
+   updated tier + recomputed cadence_state / next_best_touch.
+
+   Receives: company, cadence_state, next_best_touch
+#}
+{% set badge_colors = {
+  'new': 'bg-gray-100 text-gray-500',
+  'on_target': 'bg-emerald-100 text-emerald-700',
+  'due': 'bg-amber-100 text-amber-700',
+  'overdue': 'bg-rose-100 text-rose-700'
+} %}
+<div id='cadence-hero' class='flex items-center justify-between flex-wrap gap-2 mb-3'>
+  <div class='flex items-center gap-2'>
+    <span class='px-2.5 py-1 text-xs font-semibold rounded-full {{ badge_colors.get(cadence_state, "bg-gray-100 text-gray-500") }}'>
+      {{ {'new': 'New', 'on_target': 'On Target', 'due': 'Due', 'overdue': 'Overdue'}.get(cadence_state, cadence_state|title) }}
+    </span>
+    {# Tier inline-select — POSTs on change; re-swaps this partial via hx-target='#cadence-hero' #}
+    <form hx-post='/v2/partials/customers/{{ company.id }}/tier'
+          hx-target='#cadence-hero'
+          hx-swap='outerHTML'>
+      <select name='tier'
+              onchange='this.form.requestSubmit()'
+              class='text-xs text-gray-600 font-medium bg-transparent border border-gray-200 rounded px-1.5 py-0.5 hover:border-brand-300 focus:outline-none focus:ring-1 focus:ring-brand-400 cursor-pointer'>
+        <option value='' {% if not company.tier %}selected{% endif %}>— tier —</option>
+        <option value='key' {% if company.tier == 'key' %}selected{% endif %}>Key</option>
+        <option value='core' {% if company.tier == 'core' %}selected{% endif %}>Core</option>
+        <option value='standard' {% if company.tier == 'standard' %}selected{% endif %}>Standard</option>
+        <option value='prospect' {% if company.tier == 'prospect' %}selected{% endif %}>Prospect</option>
+      </select>
+    </form>
+  </div>
+  <span class='text-xs text-gray-600 italic'>{{ next_best_touch }}</span>
+</div>

--- a/app/templates/htmx/partials/customers/_role_chip_editor.html
+++ b/app/templates/htmx/partials/customers/_role_chip_editor.html
@@ -1,0 +1,71 @@
+{# Role chip + inline editor for a SiteContact.
+   Re-rendered by POST /v2/partials/customers/{company_id}/contacts/{contact_id}/role.
+   Renders inside the contact card (contacts_tab.html contact_card macro).
+
+   Receives: company, contact
+   Canonical roles: specifier | buyer_po | ap_payer | logistics | exec | other
+   Legacy roles: buyer | technical | decision_maker | operations (display-only, no 400)
+#}
+{% set role_labels = {
+  'specifier':      'Specifier',
+  'buyer_po':       'Buyer / PO',
+  'ap_payer':       'AP / Payer',
+  'logistics':      'Logistics',
+  'exec':           'Exec',
+  'other':          'Other',
+  'buyer':          'Buyer',
+  'technical':      'Technical',
+  'decision_maker': 'Decision Maker',
+  'operations':     'Operations'
+} %}
+{% set role_colors = {
+  'specifier':      'bg-indigo-50 text-indigo-700',
+  'buyer_po':       'bg-blue-50 text-blue-700',
+  'ap_payer':       'bg-teal-50 text-teal-700',
+  'logistics':      'bg-orange-50 text-orange-700',
+  'exec':           'bg-rose-50 text-rose-700',
+  'other':          'bg-gray-100 text-gray-600',
+  'buyer':          'bg-blue-50 text-blue-700',
+  'technical':      'bg-purple-50 text-purple-700',
+  'decision_maker': 'bg-amber-50 text-amber-700',
+  'operations':     'bg-gray-100 text-gray-600'
+} %}
+<div id='role-chip-{{ contact.id }}' x-data='{"editing": false}' class='inline-flex items-center gap-1'>
+  {# Display chip — click to edit #}
+  {% if contact.contact_role %}
+  <button type='button'
+          @click='editing = true'
+          title='Change role'
+          class='px-1.5 py-0.5 text-[9px] font-medium rounded {{ role_colors.get(contact.contact_role, "bg-gray-100 text-gray-600") }} hover:opacity-80 transition-opacity'>
+    {{ role_labels.get(contact.contact_role, contact.contact_role|replace('_', ' ')|title) }}
+  </button>
+  {% else %}
+  <button type='button'
+          @click='editing = true'
+          title='Set role'
+          class='px-1.5 py-0.5 text-[9px] font-medium rounded bg-gray-50 text-gray-400 border border-dashed border-gray-300 hover:border-brand-300 hover:text-brand-400 transition-colors'>
+    + role
+  </button>
+  {% endif %}
+  {# Inline editor — shown on click #}
+  <form x-show='editing'
+        x-cloak
+        hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/role'
+        hx-target='#role-chip-{{ contact.id }}'
+        hx-swap='outerHTML'
+        @htmx:after-request='editing = false'>
+    <select name='contact_role'
+            onchange='this.form.requestSubmit()'
+            @blur='editing = false'
+            x-init='$nextTick(() => { if (editing) $el.focus() })'
+            class='text-[10px] border border-brand-300 rounded px-1 py-0.5 focus:outline-none focus:ring-1 focus:ring-brand-400'>
+      <option value=''>— clear —</option>
+      <option value='specifier' {% if contact.contact_role == 'specifier' %}selected{% endif %}>Specifier</option>
+      <option value='buyer_po' {% if contact.contact_role == 'buyer_po' %}selected{% endif %}>Buyer / PO</option>
+      <option value='ap_payer' {% if contact.contact_role == 'ap_payer' %}selected{% endif %}>AP / Payer</option>
+      <option value='logistics' {% if contact.contact_role == 'logistics' %}selected{% endif %}>Logistics</option>
+      <option value='exec' {% if contact.contact_role == 'exec' %}selected{% endif %}>Exec</option>
+      <option value='other' {% if contact.contact_role == 'other' %}selected{% endif %}>Other</option>
+    </select>
+  </form>
+</div>

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -96,24 +96,9 @@
 
   {# ── Account Cadence Card ──────────────────────────────── #}
   <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4">
-    {# Hero row: cadence badge + tier + next-best-touch #}
-    <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
-      {% set badge_colors = {
-        "new": "bg-gray-100 text-gray-500",
-        "on_target": "bg-emerald-100 text-emerald-700",
-        "due": "bg-amber-100 text-amber-700",
-        "overdue": "bg-rose-100 text-rose-700"
-      } %}
-      <div class="flex items-center gap-2">
-        <span class="px-2.5 py-1 text-xs font-semibold rounded-full {{ badge_colors.get(cadence_state, 'bg-gray-100 text-gray-500') }}">
-          {{ {"new": "New", "on_target": "On Target", "due": "Due", "overdue": "Overdue"}.get(cadence_state, cadence_state|title) }}
-        </span>
-        {% if company.tier %}
-          <span class="text-xs text-gray-500 font-medium">{{ company.tier|title }}</span>
-        {% endif %}
-      </div>
-      <span class="text-xs text-gray-600 italic">{{ next_best_touch }}</span>
-    </div>
+    {# Hero row: cadence badge + settable tier + next-best-touch.
+       _cadence_hero.html is the HTMX swap target for tier updates. #}
+    {% include 'htmx/partials/customers/_cadence_hero.html' %}
 
     {# Dual clocks: Outbound + Reply #}
     <div class="grid grid-cols-2 gap-3 mb-3">

--- a/app/templates/htmx/partials/customers/tabs/contacts_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/contacts_tab.html
@@ -38,9 +38,25 @@
 </a>
 {% endmacro %}
 
-{# Role chip — color-coded by role; graceful fallback for null/unknown. #}
+{# Role chip — color-coded by role; covers canonical P2b roles + legacy values.
+   Canonical: specifier | buyer_po | ap_payer | logistics | exec | other
+   Legacy (display-only, no migration): buyer | technical | decision_maker | operations
+   Graceful fallback for any unknown value; silent for null.
+#}
 {% macro role_chip(role) %}
-{% if role == 'buyer' %}
+{% if role == 'specifier' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-indigo-50 text-indigo-700">Specifier</span>
+{% elif role == 'buyer_po' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-blue-50 text-blue-700">Buyer / PO</span>
+{% elif role == 'ap_payer' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-teal-50 text-teal-700">AP / Payer</span>
+{% elif role == 'logistics' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-orange-50 text-orange-700">Logistics</span>
+{% elif role == 'exec' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-rose-50 text-rose-700">Exec</span>
+{% elif role == 'other' %}
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-gray-100 text-gray-600">Other</span>
+{% elif role == 'buyer' %}
 <span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-blue-50 text-blue-700">Buyer</span>
 {% elif role == 'technical' %}
 <span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-purple-50 text-purple-700">Technical</span>
@@ -49,7 +65,7 @@
 {% elif role == 'operations' %}
 <span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-gray-100 text-gray-600">Operations</span>
 {% elif role %}
-<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-gray-100 text-gray-600">{{ role|title }}</span>
+<span class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-gray-100 text-gray-600">{{ role|replace('_', ' ')|title }}</span>
 {% endif %}
 {% endmacro %}
 
@@ -131,7 +147,7 @@
           {% if contact.is_primary %}
           <span class="px-1 py-0.5 text-[9px] font-medium rounded bg-emerald-50 text-emerald-700">Primary</span>
           {% endif %}
-          {{ role_chip(contact.contact_role) }}
+          {% include 'htmx/partials/customers/_role_chip_editor.html' %}
         </div>
         <p class="text-[11px] text-gray-500 mt-0.5">{{ contact.title or "—" }}</p>
         <div class="mt-1 flex items-center gap-3 text-[11px] text-gray-500 flex-wrap">

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -2105,3 +2105,247 @@ class TestSegmentTagViews:
         )
         assert resp.status_code == 200
         assert "Growth" in resp.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestTierSetter — P2b account tier setter
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestTierSetter:
+    """Tests for account tier-setter endpoint.
+
+    Written FIRST (TDD RED) — will fail until the route is added.
+
+    Routes tested:
+      POST /v2/partials/customers/{company_id}/tier  (set tier)
+    """
+
+    def _make_company(self, db_session: Session, name: str = "TierSet Co", **kwargs) -> Company:
+        co = Company(name=name, is_active=True, **kwargs)
+        db_session.add(co)
+        db_session.commit()
+        db_session.refresh(co)
+        return co
+
+    def test_set_tier_updates_db(self, client: TestClient, db_session: Session, test_user: User):
+        """POST tier=core persists to Company.tier."""
+        co = self._make_company(db_session)
+        resp = client.post(f"/v2/partials/customers/{co.id}/tier", data={"tier": "core"})
+        assert resp.status_code == 200
+        db_session.refresh(co)
+        assert co.tier == "core"
+
+    def test_set_tier_rerenders_cadence_hero(self, client: TestClient, db_session: Session, test_user: User):
+        """POST tier=core re-renders the cadence hero with updated tier label."""
+        co = self._make_company(db_session)
+        resp = client.post(f"/v2/partials/customers/{co.id}/tier", data={"tier": "core"})
+        assert resp.status_code == 200
+        # The re-rendered hero should show the tier word
+        assert "core" in resp.text.lower() or "Core" in resp.text
+
+    def test_set_tier_cadence_badge_reflects_new_tier(self, client: TestClient, db_session: Session, test_user: User):
+        """Setting tier=key on an account that was last contacted 10 days ago changes
+        cadence from 'due' (standard 30d) to 'overdue' would NOT apply here but key
+        target is 7d so 10d ago → 'due' badge → amber classes present."""
+        outbound_10d_ago = datetime.now(timezone.utc) - timedelta(days=10)
+        co = self._make_company(db_session, last_outbound_at=outbound_10d_ago)
+        # Before: standard tier → 10d is on_target (target=30)
+        resp_before = client.get(f"/v2/partials/customers/{co.id}")
+        assert "bg-emerald-100" in resp_before.text  # on_target
+
+        # After: set tier=key → target=7d, so 10d → 'due' → amber
+        resp = client.post(f"/v2/partials/customers/{co.id}/tier", data={"tier": "key"})
+        assert resp.status_code == 200
+        assert "bg-amber-100" in resp.text  # due
+
+    def test_set_tier_invalid_value_returns_400(self, client: TestClient, db_session: Session, test_user: User):
+        """POST with invalid tier value returns 400."""
+        co = self._make_company(db_session)
+        resp = client.post(f"/v2/partials/customers/{co.id}/tier", data={"tier": "vip"})
+        assert resp.status_code == 400
+
+    def test_set_tier_blank_clears_tier(self, client: TestClient, db_session: Session, test_user: User):
+        """POST with tier='' (blank/unset) clears Company.tier to None."""
+        co = self._make_company(db_session, tier="key")
+        resp = client.post(f"/v2/partials/customers/{co.id}/tier", data={"tier": ""})
+        assert resp.status_code == 200
+        db_session.refresh(co)
+        assert co.tier is None
+
+    def test_set_tier_all_valid_values_accepted(self, client: TestClient, db_session: Session, test_user: User):
+        """All four valid tier values are accepted without 400."""
+        for tier_val in ("key", "core", "standard", "prospect"):
+            co = self._make_company(db_session, name=f"TierSet {tier_val}")
+            resp = client.post(f"/v2/partials/customers/{co.id}/tier", data={"tier": tier_val})
+            assert resp.status_code == 200, f"tier={tier_val} should be accepted"
+
+    def test_set_tier_nonexistent_company_returns_404(self, client: TestClient, db_session: Session, test_user: User):
+        """POST to unknown company_id returns 404."""
+        resp = client.post("/v2/partials/customers/99999/tier", data={"tier": "core"})
+        assert resp.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestBuyingRoleSetter — P2b contact buying-role setter
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBuyingRoleSetter:
+    """Tests for contact buying-role setter endpoint.
+
+    Written FIRST (TDD RED) — will fail until routes are added.
+
+    Routes tested:
+      POST /v2/partials/customers/{company_id}/contacts/{contact_id}/role
+    """
+
+    def _make_company_with_contact(self, db_session: Session, **contact_kwargs):
+        from app.models.crm import CustomerSite, SiteContact
+
+        company = Company(name="RoleSet Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+        db_session.add(site)
+        db_session.flush()
+        contact = SiteContact(
+            customer_site_id=site.id,
+            full_name="Alex Buyer",
+            email="alex@roleset.com",
+            **contact_kwargs,
+        )
+        db_session.add(contact)
+        db_session.commit()
+        db_session.refresh(contact)
+        db_session.refresh(company)
+        return company, site, contact
+
+    def test_set_role_updates_db(self, client: TestClient, db_session: Session, test_user: User):
+        """POST contact_role=buyer_po persists to SiteContact.contact_role."""
+
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": "buyer_po"},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(contact)
+        assert contact.contact_role == "buyer_po"
+
+    def test_set_role_rerenders_chip(self, client: TestClient, db_session: Session, test_user: User):
+        """POST role returns HTML containing the chip for the new role."""
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": "specifier"},
+        )
+        assert resp.status_code == 200
+        assert "specifier" in resp.text.lower() or "Specifier" in resp.text
+
+    def test_set_role_invalid_value_returns_400(self, client: TestClient, db_session: Session, test_user: User):
+        """POST with unknown role value returns 400."""
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": "wizard"},
+        )
+        assert resp.status_code == 400
+
+    def test_set_role_all_canonical_values_accepted(self, client: TestClient, db_session: Session, test_user: User):
+        """All canonical buying-role values are accepted."""
+        for role_val in ("specifier", "buyer_po", "ap_payer", "logistics", "exec", "other"):
+            company, site, contact = self._make_company_with_contact(db_session)
+            resp = client.post(
+                f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+                data={"contact_role": role_val},
+            )
+            assert resp.status_code == 200, f"role={role_val} should be accepted"
+
+    def test_set_role_nonexistent_contact_returns_404(self, client: TestClient, db_session: Session, test_user: User):
+        """POST to unknown contact_id returns 404."""
+        company, _, _ = self._make_company_with_contact(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/99999/role",
+            data={"contact_role": "buyer_po"},
+        )
+        assert resp.status_code == 404
+
+    def test_set_role_blank_clears_role(self, client: TestClient, db_session: Session, test_user: User):
+        """POST with contact_role='' clears the role to None."""
+
+        company, site, contact = self._make_company_with_contact(db_session, contact_role="buyer")
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": ""},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(contact)
+        assert contact.contact_role is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestRoleChipLegacy — role_chip macro handles legacy + new canonical values
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRoleChipLegacy:
+    """Tests that role_chip renders both legacy and new canonical values.
+
+    Written FIRST (TDD RED) — will fail until the template is updated.
+    """
+
+    def _make_company_with_contact(self, db_session: Session, contact_role: str | None = None):
+        from app.models.crm import CustomerSite, SiteContact
+
+        company = Company(name="ChipTest Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+        db_session.add(site)
+        db_session.flush()
+        contact = SiteContact(
+            customer_site_id=site.id,
+            full_name="Chip Test",
+            email="chip@test.com",
+            contact_role=contact_role,
+        )
+        db_session.add(contact)
+        db_session.commit()
+        db_session.refresh(company)
+        return company, site, contact
+
+    def test_legacy_decision_maker_renders_gracefully(self, client: TestClient, db_session: Session, test_user: User):
+        """Legacy role 'decision_maker' still renders a chip without error."""
+        company, _, _ = self._make_company_with_contact(db_session, contact_role="decision_maker")
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        assert "decision" in resp.text.lower() or "Decision" in resp.text
+
+    def test_legacy_buyer_renders_gracefully(self, client: TestClient, db_session: Session, test_user: User):
+        """Legacy role 'buyer' still renders a chip."""
+        company, _, _ = self._make_company_with_contact(db_session, contact_role="buyer")
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        assert "buyer" in resp.text.lower() or "Buyer" in resp.text
+
+    def test_canonical_buyer_po_renders_chip(self, client: TestClient, db_session: Session, test_user: User):
+        """New canonical role 'buyer_po' renders a chip in the contact card."""
+        company, _, _ = self._make_company_with_contact(db_session, contact_role="buyer_po")
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        # Should show some chip text for buyer_po
+        assert "buyer" in resp.text.lower() or "PO" in resp.text or "Buyer" in resp.text
+
+    def test_canonical_specifier_renders_chip(self, client: TestClient, db_session: Session, test_user: User):
+        """New canonical role 'specifier' renders a chip."""
+        company, _, _ = self._make_company_with_contact(db_session, contact_role="specifier")
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        assert "specifier" in resp.text.lower() or "Specifier" in resp.text
+
+    def test_null_role_renders_no_chip(self, client: TestClient, db_session: Session, test_user: User):
+        """NULL contact_role renders no chip (not an error)."""
+        company, _, _ = self._make_company_with_contact(db_session, contact_role=None)
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200


### PR DESCRIPTION
Phase 2b. Reps can now SET an account tier + a contact buying-role inline.

- Tier setter in the cadence hero → updates `Company.tier` (validated server-side against key/core/standard/prospect; blank clears to NULL; invalid→400); re-renders the hero so the cadence badge + next-best-touch recompute.
- Buying-role setter per contact → updates `SiteContact.contact_role` (canonical taxonomy specifier/buyer_po/ap_payer/logistics/exec/other; invalid→400). `role_chip` extended to render all canonical + legacy values; no data migration.
- Both routes auth-gated; static-guard-safe.

18 tests; review-approved. Known minor follow-ups: auto-focus uses x-init (should be $watch); add legacy-value→400 test; remove the now-dead role_chip macro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)