### PR TITLE
feat(crm): inline edit for customer sites + contacts (drawer) (P2c)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -5677,6 +5677,25 @@ async def edit_company(
     return await company_detail_partial(request=request, company_id=company_id, user=user, db=db)
 
 
+@router.get("/v2/partials/customers/{company_id}/sites/{site_id}/edit-form", response_class=HTMLResponse)
+async def site_edit_form(
+    request: Request,
+    company_id: int,
+    site_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Return modal edit form for a customer site."""
+    site = db.query(CustomerSite).filter(CustomerSite.id == site_id, CustomerSite.company_id == company_id).first()
+    if not site:
+        raise HTTPException(404, "Site not found")
+    users = db.query(User).order_by(User.name).all()
+    return template_response(
+        "htmx/partials/customers/tabs/site_edit_modal.html",
+        {"request": request, "site": site, "company_id": company_id, "users": users},
+    )
+
+
 @router.post("/v2/partials/customers/{company_id}/sites/{site_id}/edit", response_class=HTMLResponse)
 async def edit_site(
     request: Request,
@@ -5692,15 +5711,120 @@ async def edit_site(
 
     form = await request.form()
     site_name = form.get("site_name", "").strip()
-    if site_name:
-        site.site_name = site_name
+    if not site_name:
+        raise HTTPException(400, "site_name is required")
+    site.site_name = site_name
+    site.address_line1 = form.get("address_line1", "").strip() or site.address_line1
+    site.address_line2 = form.get("address_line2", "").strip() or site.address_line2
     site.city = form.get("city", "").strip() or site.city
+    site.state = form.get("state", "").strip() or site.state
+    site.zip = form.get("zip", "").strip() or site.zip
     site.country = form.get("country", "").strip() or site.country
     site.site_type = form.get("site_type", "").strip() or site.site_type
+    site.payment_terms = form.get("payment_terms", "").strip() or site.payment_terms
+    site.shipping_terms = form.get("shipping_terms", "").strip() or site.shipping_terms
+    notes_val = form.get("notes", "").strip()
+    if notes_val:
+        site.notes = notes_val
+    owner_id = form.get("owner_id", "")
+    if owner_id and str(owner_id).isdigit():
+        site.owner_id = int(owner_id)
+    site.updated_at = datetime.now(timezone.utc)
     db.commit()
     logger.info("Site {} edited by {}", site_id, user.email)
 
     return await company_tab(request=request, company_id=company_id, tab="sites", user=user, db=db)
+
+
+@router.get(
+    "/v2/partials/customers/{company_id}/sites/{site_id}/contacts/{contact_id}/edit-form",
+    response_class=HTMLResponse,
+)
+async def contact_edit_form(
+    request: Request,
+    company_id: int,
+    site_id: int,
+    contact_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Return modal edit form for a site contact."""
+    contact = (
+        db.query(SiteContact).filter(SiteContact.id == contact_id, SiteContact.customer_site_id == site_id).first()
+    )
+    if not contact:
+        raise HTTPException(404, "Contact not found")
+    # Verify site belongs to company
+    site = db.query(CustomerSite).filter(CustomerSite.id == site_id, CustomerSite.company_id == company_id).first()
+    if not site:
+        raise HTTPException(404, "Site not found")
+    return template_response(
+        "htmx/partials/customers/tabs/contact_edit_modal.html",
+        {"request": request, "contact": contact, "site": site, "company_id": company_id},
+    )
+
+
+@router.post(
+    "/v2/partials/customers/{company_id}/sites/{site_id}/contacts/{contact_id}/edit",
+    response_class=HTMLResponse,
+)
+async def edit_site_contact(
+    request: Request,
+    company_id: int,
+    site_id: int,
+    contact_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Update editable contact fields (never contact_role) and return refreshed contacts
+    panel."""
+    contact = (
+        db.query(SiteContact).filter(SiteContact.id == contact_id, SiteContact.customer_site_id == site_id).first()
+    )
+    if not contact:
+        raise HTTPException(404, "Contact not found")
+    site = db.query(CustomerSite).filter(CustomerSite.id == site_id, CustomerSite.company_id == company_id).first()
+    if not site:
+        raise HTTPException(404, "Site not found")
+
+    form = await request.form()
+    full_name = form.get("full_name", "").strip()
+    if not full_name:
+        raise HTTPException(400, "full_name is required")
+
+    email_val = form.get("email", "").strip()
+    if email_val and "@" not in email_val:
+        raise HTTPException(400, "Invalid email address")
+
+    contact.full_name = full_name
+    contact.title = form.get("title", "").strip() or contact.title
+    contact.email = email_val or contact.email
+    phone_val = form.get("phone", "").strip()
+    if phone_val:
+        contact.phone = phone_val
+    wechat_val = form.get("wechat_id", "").strip()
+    if wechat_val:
+        contact.wechat_id = wechat_val
+    notes_val = form.get("notes", "").strip()
+    if notes_val:
+        contact.notes = notes_val
+    # contact_role is intentionally NOT updated here — owned by the P2b role setter
+    contact.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    logger.info("Contact {} edited by {}", contact_id, user.email)
+
+    contacts = (
+        db.query(SiteContact)
+        .filter(SiteContact.customer_site_id == site_id, SiteContact.is_active.is_(True))
+        .order_by(SiteContact.is_primary.desc(), SiteContact.full_name)
+        .all()
+    )
+    company = db.query(Company).filter(Company.id == company_id).first()
+    ctx = _base_ctx(request, user, "customers")
+    ctx["site"] = site
+    ctx["contacts"] = contacts
+    ctx["company"] = company
+    return template_response("htmx/partials/customers/tabs/site_contacts.html", ctx)
 
 
 @router.post(

--- a/app/templates/htmx/partials/customers/tabs/contact_edit_modal.html
+++ b/app/templates/htmx/partials/customers/tabs/contact_edit_modal.html
@@ -1,0 +1,63 @@
+{# contact_edit_modal.html — Edit form for a SiteContact, loaded into #modal-content
+   via $dispatch('open-modal', {url: '...'}). The base modal renders ✕/backdrop/Escape.
+   Receives: contact (SiteContact), site (CustomerSite), company_id (int).
+   On success: re-renders #site-{site.id}-contacts and closes the modal.
+   Called by: GET /v2/partials/customers/{company_id}/sites/{site_id}/contacts/{contact_id}/edit-form
+   NOTE: contact_role is NOT editable here — use the P2b role setter endpoint instead.
+#}
+<div class='p-5'>
+  <h3 class='text-sm font-semibold text-gray-900 mb-4'>Edit Contact</h3>
+
+  <form hx-post='/v2/partials/customers/{{ company_id }}/sites/{{ site.id }}/contacts/{{ contact.id }}/edit'
+        hx-target='#site-{{ site.id }}-contacts'
+        hx-swap='innerHTML'
+        hx-on::after-request='if(event.detail.successful) $dispatch("close-modal")'
+        data-loading-disable
+        class='space-y-3'>
+
+    <div>
+      <label class='block text-xs font-medium text-gray-700 mb-1'>Full Name <span class="text-rose-500">*</span></label>
+      <input type='text' name='full_name' required value='{{ contact.full_name or "" }}'
+             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+    </div>
+
+    <div>
+      <label class='block text-xs font-medium text-gray-700 mb-1'>Title</label>
+      <input type='text' name='title' value='{{ contact.title or "" }}'
+             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+    </div>
+
+    <div>
+      <label class='block text-xs font-medium text-gray-700 mb-1'>Email</label>
+      <input type='email' name='email' value='{{ contact.email or "" }}'
+             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+    </div>
+
+    <div>
+      <label class='block text-xs font-medium text-gray-700 mb-1'>Phone</label>
+      <input type='tel' name='phone' value='{{ contact.phone or "" }}'
+             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+    </div>
+
+    <div>
+      <label class='block text-xs font-medium text-gray-700 mb-1'>WeChat ID</label>
+      <input type='text' name='wechat_id' value='{{ contact.wechat_id or "" }}' maxlength='100'
+             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+    </div>
+
+    <div>
+      <label class='block text-xs font-medium text-gray-700 mb-1'>Notes</label>
+      <textarea name='notes' rows='2'
+                class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>{{ contact.notes or "" }}</textarea>
+    </div>
+
+    <div class='flex justify-end gap-2 pt-1'>
+      <button type='button' @click='$dispatch("close-modal")'
+              class='px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800'>Cancel</button>
+      <button type='submit'
+              class='px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600'>
+        Save Changes
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/templates/htmx/partials/customers/tabs/site_card.html
+++ b/app/templates/htmx/partials/customers/tabs/site_card.html
@@ -60,6 +60,10 @@
 
     {# Site actions #}
     <div class="px-4 py-2 bg-gray-50 border-t border-gray-100 flex items-center gap-2">
+      <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/sites/{{ s.id }}/edit-form'})"
+              class="text-xs text-brand-500 hover:text-brand-700">
+        Edit Site
+      </button>
       <button hx-delete="/v2/partials/customers/{{ company.id }}/sites/{{ s.id }}"
               hx-target="#site-{{ s.id }}"
               hx-swap="outerHTML"

--- a/app/templates/htmx/partials/customers/tabs/site_contacts.html
+++ b/app/templates/htmx/partials/customers/tabs/site_contacts.html
@@ -60,6 +60,10 @@
         </div>
       </div>
       <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+        <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/sites/{{ site.id }}/contacts/{{ c.id }}/edit-form'})"
+                class="text-[10px] text-brand-500 hover:text-brand-700" title="Edit contact">
+          Edit
+        </button>
         {% if not c.is_primary %}
         <button hx-post="/v2/partials/customers/{{ company.id }}/sites/{{ site.id }}/contacts/{{ c.id }}/primary"
                 hx-target="#site-{{ site.id }}-contacts"

--- a/app/templates/htmx/partials/customers/tabs/site_edit_modal.html
+++ b/app/templates/htmx/partials/customers/tabs/site_edit_modal.html
@@ -1,0 +1,105 @@
+{# site_edit_modal.html — Edit form for a CustomerSite, loaded into #modal-content
+   via $dispatch('open-modal', {url: '...'}). The base modal renders ✕/backdrop/Escape.
+   Receives: site (CustomerSite), company_id (int), users (list[User]).
+   On success: re-renders #sites-list area and closes the modal.
+   Called by: GET /v2/partials/customers/{company_id}/sites/{site_id}/edit-form
+#}
+<div class='p-5'>
+  <h3 class='text-sm font-semibold text-gray-900 mb-4'>Edit Site</h3>
+
+  <form hx-post='/v2/partials/customers/{{ company_id }}/sites/{{ site.id }}/edit'
+        hx-target='#main-content'
+        hx-swap='innerHTML'
+        hx-on::after-request='if(event.detail.successful) $dispatch("close-modal")'
+        data-loading-disable
+        class='space-y-3'>
+
+    <div>
+      <label class='block text-xs font-medium text-gray-700 mb-1'>Site Name <span class="text-rose-500">*</span></label>
+      <input type='text' name='site_name' required value='{{ site.site_name or "" }}'
+             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+    </div>
+
+    <div>
+      <label class='block text-xs font-medium text-gray-700 mb-1'>Site Type</label>
+      <select name='site_type'
+              class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+        <option value=''>—</option>
+        <option value='hq' {% if site.site_type == 'hq' %}selected{% endif %}>HQ</option>
+        <option value='branch' {% if site.site_type == 'branch' %}selected{% endif %}>Branch</option>
+        <option value='warehouse' {% if site.site_type == 'warehouse' %}selected{% endif %}>Warehouse</option>
+        <option value='manufacturing' {% if site.site_type == 'manufacturing' %}selected{% endif %}>Manufacturing</option>
+        <option value='other' {% if site.site_type == 'other' %}selected{% endif %}>Other</option>
+      </select>
+    </div>
+
+    <div class='grid grid-cols-2 gap-2'>
+      <div>
+        <label class='block text-xs font-medium text-gray-700 mb-1'>Address Line 1</label>
+        <input type='text' name='address_line1' value='{{ site.address_line1 or "" }}'
+               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+      </div>
+      <div>
+        <label class='block text-xs font-medium text-gray-700 mb-1'>Address Line 2</label>
+        <input type='text' name='address_line2' value='{{ site.address_line2 or "" }}'
+               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+      </div>
+    </div>
+
+    <div class='grid grid-cols-2 gap-2'>
+      <div>
+        <label class='block text-xs font-medium text-gray-700 mb-1'>City</label>
+        <input type='text' name='city' value='{{ site.city or "" }}'
+               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+      </div>
+      <div>
+        <label class='block text-xs font-medium text-gray-700 mb-1'>State</label>
+        <input type='text' name='state' value='{{ site.state or "" }}'
+               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+      </div>
+    </div>
+
+    <div class='grid grid-cols-2 gap-2'>
+      <div>
+        <label class='block text-xs font-medium text-gray-700 mb-1'>ZIP</label>
+        <input type='text' name='zip' value='{{ site.zip or "" }}'
+               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+      </div>
+      <div>
+        <label class='block text-xs font-medium text-gray-700 mb-1'>Country</label>
+        <input type='text' name='country' value='{{ site.country or "" }}'
+               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+      </div>
+    </div>
+
+    <div class='grid grid-cols-2 gap-2'>
+      <div>
+        <label class='block text-xs font-medium text-gray-700 mb-1'>Payment Terms</label>
+        <input type='text' name='payment_terms' value='{{ site.payment_terms or "" }}'
+               placeholder='e.g. Net30'
+               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+      </div>
+      <div>
+        <label class='block text-xs font-medium text-gray-700 mb-1'>Shipping Terms</label>
+        <input type='text' name='shipping_terms' value='{{ site.shipping_terms or "" }}'
+               placeholder='e.g. FCA'
+               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+      </div>
+    </div>
+
+    <div>
+      <label class='block text-xs font-medium text-gray-700 mb-1'>Notes</label>
+      <textarea name='notes' rows='2'
+                class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>{{ site.notes or "" }}</textarea>
+    </div>
+
+    <div class='flex justify-end gap-2 pt-1'>
+      <button type='button' @click='$dispatch("close-modal")'
+              class='px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800'>Cancel</button>
+      <button type='submit'
+              class='px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600'>
+        Save Changes
+      </button>
+    </div>
+  </form>
+</div>

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -2349,3 +2349,226 @@ class TestRoleChipLegacy:
         company, _, _ = self._make_company_with_contact(db_session, contact_role=None)
         resp = client.get(f"/v2/partials/customers/{company.id}")
         assert resp.status_code == 200
+
+
+class TestEditSite:
+    """P2c: Edit-site modal form (GET edit-form + POST edit)."""
+
+    def _make_company_with_site(self, db_session: Session):
+        from app.models.crm import CustomerSite
+
+        company = Company(name="Edit Site Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(
+            company_id=company.id,
+            site_name="HQ",
+            site_type="hq",
+            city="Boston",
+            country="US",
+            address_line1="123 Main St",
+            payment_terms="Net30",
+            shipping_terms="FCA",
+            is_active=True,
+        )
+        db_session.add(site)
+        db_session.commit()
+        return company, site
+
+    def test_get_site_edit_form_returns_200(self, client: TestClient, db_session: Session, test_user: User):
+        """GET edit-form route renders a form pre-populated with site fields."""
+        company, site = self._make_company_with_site(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/sites/{site.id}/edit-form")
+        assert resp.status_code == 200
+        assert "HQ" in resp.text
+        assert "Boston" in resp.text
+
+    def test_get_site_edit_form_404_on_missing_site(self, client: TestClient, db_session: Session, test_user: User):
+        """GET edit-form for a nonexistent site returns 404."""
+        company, _ = self._make_company_with_site(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/sites/99999/edit-form")
+        assert resp.status_code == 404
+
+    def test_post_site_edit_persists_payment_terms_and_address(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """POST edit saves payment_terms + address fields; re-rendered sites tab shows
+        new values."""
+        from app.models.crm import CustomerSite
+
+        company, site = self._make_company_with_site(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/edit",
+            data={
+                "site_name": "HQ",
+                "address_line1": "456 New Ave",
+                "city": "Cambridge",
+                "state": "MA",
+                "zip": "02139",
+                "country": "US",
+                "payment_terms": "Net60",
+                "shipping_terms": "DAP",
+                "site_type": "hq",
+                "notes": "updated note",
+            },
+        )
+        assert resp.status_code == 200
+        db_session.expire_all()
+        updated = db_session.query(CustomerSite).filter(CustomerSite.id == site.id).first()
+        assert updated is not None
+        assert updated.payment_terms == "Net60"
+        assert updated.address_line1 == "456 New Ave"
+        assert updated.city == "Cambridge"
+        assert updated.state == "MA"
+        assert updated.zip == "02139"
+        assert updated.shipping_terms == "DAP"
+        assert updated.notes == "updated note"
+
+    def test_post_site_edit_re_renders_sites_tab(self, client: TestClient, db_session: Session, test_user: User):
+        """POST edit response is the refreshed sites tab containing the updated site
+        name."""
+        company, site = self._make_company_with_site(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/edit",
+            data={"site_name": "New HQ Name", "city": "Salem", "country": "US"},
+        )
+        assert resp.status_code == 200
+        assert "New HQ Name" in resp.text
+
+    def test_post_site_edit_missing_site_name_returns_400(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """POST edit with empty site_name returns 400."""
+        company, site = self._make_company_with_site(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/edit",
+            data={"site_name": "", "city": "Boston", "country": "US"},
+        )
+        assert resp.status_code == 400
+
+
+class TestEditContact:
+    """P2c: Edit-contact modal form (GET edit-form + POST edit)."""
+
+    def _make_company_with_contact(self, db_session: Session):
+        from app.models.crm import CustomerSite, SiteContact
+
+        company = Company(name="Edit Contact Co", is_active=True)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+        db_session.add(site)
+        db_session.flush()
+        contact = SiteContact(
+            customer_site_id=site.id,
+            full_name="Alice Smith",
+            title="Buyer",
+            email="alice@editco.com",
+            phone="+16175550001",
+            wechat_id="alice_wc",
+            notes="original note",
+            contact_role="buyer",
+        )
+        db_session.add(contact)
+        db_session.commit()
+        return company, site, contact
+
+    def test_get_contact_edit_form_returns_200(self, client: TestClient, db_session: Session, test_user: User):
+        """GET edit-form renders form pre-populated with contact fields."""
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts/{contact.id}/edit-form")
+        assert resp.status_code == 200
+        assert "Alice Smith" in resp.text
+        assert "alice@editco.com" in resp.text
+
+    def test_get_contact_edit_form_404_on_missing_contact(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """GET edit-form for nonexistent contact returns 404."""
+        company, site, _ = self._make_company_with_contact(db_session)
+        resp = client.get(f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts/99999/edit-form")
+        assert resp.status_code == 404
+
+    def test_post_contact_edit_persists_title_and_phone(self, client: TestClient, db_session: Session, test_user: User):
+        """POST edit saves title + phone; re-rendered contacts show new values."""
+        from app.models.crm import SiteContact
+
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts/{contact.id}/edit",
+            data={
+                "full_name": "Alice Smith",
+                "title": "Senior Buyer",
+                "email": "alice@editco.com",
+                "phone": "+16175550099",
+                "wechat_id": "alice_wc",
+                "notes": "updated note",
+            },
+        )
+        assert resp.status_code == 200
+        db_session.expire_all()
+        updated = db_session.query(SiteContact).filter(SiteContact.id == contact.id).first()
+        assert updated is not None
+        assert updated.title == "Senior Buyer"
+        assert updated.phone == "+16175550099"
+        assert updated.notes == "updated note"
+
+    def test_post_contact_edit_does_not_touch_contact_role(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """POST contact edit never modifies contact_role (owned by P2b role setter)."""
+        from app.models.crm import SiteContact
+
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts/{contact.id}/edit",
+            data={
+                "full_name": "Alice Smith",
+                "contact_role": "decision_maker",  # attacker tries to override role
+                "title": "Buyer",
+                "email": "alice@editco.com",
+                "phone": "+16175550001",
+                "wechat_id": "alice_wc",
+                "notes": "original note",
+            },
+        )
+        assert resp.status_code == 200
+        db_session.expire_all()
+        updated = db_session.query(SiteContact).filter(SiteContact.id == contact.id).first()
+        assert updated is not None
+        assert updated.contact_role == "buyer"  # unchanged
+
+    def test_post_contact_edit_re_renders_contacts_panel(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """POST edit response contains the updated name in the re-rendered contacts
+        panel."""
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts/{contact.id}/edit",
+            data={"full_name": "Alice Updated", "title": "VP", "email": "alice@editco.com", "phone": ""},
+        )
+        assert resp.status_code == 200
+        assert "Alice Updated" in resp.text
+
+    def test_post_contact_edit_missing_full_name_returns_400(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """POST edit with empty full_name returns 400."""
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts/{contact.id}/edit",
+            data={"full_name": "", "title": "Buyer", "email": "alice@editco.com"},
+        )
+        assert resp.status_code == 400
+
+    def test_post_contact_edit_invalid_email_returns_400(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """POST edit with malformed email returns 400."""
+        company, site, contact = self._make_company_with_contact(db_session)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts/{contact.id}/edit",
+            data={"full_name": "Alice Smith", "email": "not-an-email"},
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
Phase 2c. Adds the missing edit-site + edit-contact paths (audit flagged %22NO UPDATE SITE ENDPOINT%22) via modals, so reps can fix stale data.

- Edit-site: updates site_name (required)/address/payment+shipping terms/site_type/notes; cross-tenant-checked; re-renders the sites tab.
- Edit-contact: updates full_name (required)/title/email/phone/wechat/notes; `contact_role` deliberately untouched (P2b owns it — adversarial test confirms a role override is ignored); re-renders the contacts panel.
- Server-side validation; auth + company-scope checks (no IDOR); static-guard-safe modals.

12 tests (DB-state persistence + validation + role-untouched); review-approved. Minor follow-ups: expose owner_id select in the site modal; allow clearing optional fields; tighter site re-render swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)