### PR TITLE
feat(crm): do-not-contact flag + server-side enforcement (P2d)

### DIFF
--- a/MIGRATION_NUMBERS_IN_FLIGHT.txt
+++ b/MIGRATION_NUMBERS_IN_FLIGHT.txt
@@ -40,3 +40,4 @@
 113 sp4-quote-attribution add quotes.source for proactive revenue attribution; chains onto 112_offer_qualification
 114 feat/p1b-send-time-clock contacts.sent_at for durable send-time tracking; chains onto 113_quote_source
 115 feat/p1c-subscription-health GraphSubscription health columns (last_renewed_at, renew_fail_count, last_error); chains onto 114_contact_sent_at
+116 feat/p2d-do-not-contact site_contacts.do_not_contact (Boolean NOT NULL server_default false); chains onto 115_subscription_health

--- a/alembic/versions/116_site_contact_dnc.py
+++ b/alembic/versions/116_site_contact_dnc.py
@@ -1,0 +1,35 @@
+"""Add do_not_contact flag to site_contacts.
+
+What: adds site_contacts.do_not_contact (Boolean NOT NULL, server_default false)
+      so DNC contacts are persisted durably and can be enforced server-side.
+Downgrade: drops the column.
+
+Revision ID: 116_site_contact_dnc
+Revises: 115_subscription_health
+Create Date: 2026-06-18
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "116_site_contact_dnc"
+down_revision = "115_subscription_health"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "site_contacts",
+        sa.Column(
+            "do_not_contact",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("site_contacts", "do_not_contact")

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -172,6 +172,36 @@ async def send_batch_rfq(
             )
             continue
 
+        # DNC check — skip any email address that belongs to a do-not-contact
+        # SiteContact. Reported as "skipped" (same mechanism as no-email), with
+        # an explicit "do-not-contact" reason so the caller can surface it
+        # distinctly (compliance: the address must never appear in sendMail).
+        from .models.crm import SiteContact
+
+        dnc_match = (
+            db.query(SiteContact)
+            .filter(
+                SiteContact.email == email,
+                SiteContact.do_not_contact.is_(True),
+            )
+            .first()
+        )
+        if dnc_match:
+            logger.warning(
+                "RFQ skipped — do-not-contact flag set for vendor '{}' ({})",
+                group.get("vendor_name"),
+                email,
+            )
+            results.append(
+                {
+                    "vendor_name": group.get("vendor_name"),
+                    "vendor_email": email,
+                    "status": "skipped",
+                    "error": "do-not-contact",
+                }
+            )
+            continue
+
         html_body = _build_html_body(group["body"])
         raw_subject = group["subject"]
         tagged_subject = f"{raw_subject} {avail_token}" if avail_token not in raw_subject else raw_subject

--- a/app/models/crm.py
+++ b/app/models/crm.py
@@ -180,6 +180,7 @@ class SiteContact(Base):
     is_primary = Column(Boolean, default=False)
     is_active = Column(Boolean, default=True)
     contact_status = Column(String(20), default="new")
+    do_not_contact = Column(Boolean, nullable=False, default=False, server_default="false")
 
     # CRM cadence — contact-level clocks
     last_activity_at = Column(UTCDateTime)

--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -224,17 +224,22 @@ def outreach_initiated(
             db, body.company_id, body.customer_site_id, body.site_contact_id
         )
 
-        record = log_outreach_initiated(
-            db,
-            user_id=user.id,
-            channel=body.channel,
-            contact_value=contact_value,
-            company_id=company_id,
-            customer_site_id=customer_site_id,
-            site_contact_id=site_contact_id,
-            contact_name=body.contact_name,
-            origin=body.origin,
-        )
+        try:
+            record = log_outreach_initiated(
+                db,
+                user_id=user.id,
+                channel=body.channel,
+                contact_value=contact_value,
+                company_id=company_id,
+                customer_site_id=customer_site_id,
+                site_contact_id=site_contact_id,
+                contact_name=body.contact_name,
+                origin=body.origin,
+            )
+        except ValueError as exc:
+            if "do-not-contact" in str(exc).lower() or "do not contact" in str(exc).lower():
+                raise HTTPException(403, "Contact is marked do-not-contact — outreach not permitted")
+            raise HTTPException(400, str(exc))
         db.commit()
         # dropped_links tells the client which stale entity links were removed —
         # the touch IS logged, but it won't appear on the account it was clicked

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -5084,6 +5084,59 @@ async def set_contact_role(
     )
 
 
+@router.post(
+    "/v2/partials/customers/{company_id}/contacts/{contact_id}/do-not-contact",
+    response_class=HTMLResponse,
+)
+async def set_contact_dnc(
+    request: Request,
+    company_id: int,
+    contact_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Set or clear SiteContact.do_not_contact; re-renders the DNC toggle partial.
+
+    Accepts do_not_contact= from the inline form.  Non-empty value → True. Empty string
+    → False (clear the flag).
+    """
+    contact = (
+        db.query(SiteContact)
+        .join(CustomerSite)
+        .filter(SiteContact.id == contact_id, CustomerSite.company_id == company_id)
+        .first()
+    )
+    if not contact:
+        raise HTTPException(404, "Contact not found")
+
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    form = await request.form()
+    dnc_raw = (form.get("do_not_contact") or "").strip()
+
+    contact.do_not_contact = bool(dnc_raw)
+    db.commit()
+    db.refresh(contact)
+
+    logger.info(
+        "Contact {} do_not_contact set to {} by {} (company {})",
+        contact_id,
+        contact.do_not_contact,
+        user.email,
+        company_id,
+    )
+    return template_response(
+        "htmx/partials/customers/_dnc_toggle.html",
+        {
+            "request": request,
+            "company": company,
+            "contact": contact,
+        },
+    )
+
+
 @router.get("/v2/partials/customers/{company_id}", response_class=HTMLResponse)
 async def company_detail_partial(
     request: Request,

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -721,7 +721,19 @@ def log_outreach_initiated(
     last_activity_at on the company and site so staleness sorting reflects
     the touch immediately. Re-clicks within OUTREACH_DEDUP_SECONDS return the
     existing record instead of duplicating it. Caller commits.
+
+    Raises ValueError if site_contact_id refers to a DNC contact — caller must
+    convert this to a 403.
     """
+    # DNC check — must be enforced before any log is written so the flag holds
+    # even when the UI is bypassed (e.g. direct API calls).
+    if site_contact_id:
+        from ..models.crm import SiteContact
+
+        contact = db.get(SiteContact, site_contact_id)
+        if contact and contact.do_not_contact:
+            raise ValueError(f"Contact {site_contact_id} is marked do-not-contact")
+
     if channel not in _OUTREACH_CHANNEL_MAP:
         raise ValueError(f"Unknown outreach channel: {channel}")
     activity_type, log_channel, event_type, snapshot_col = _OUTREACH_CHANNEL_MAP[channel]

--- a/app/templates/htmx/partials/customers/_dnc_toggle.html
+++ b/app/templates/htmx/partials/customers/_dnc_toggle.html
@@ -1,0 +1,41 @@
+{# DNC toggle + badge for a SiteContact.
+   Re-rendered by POST /v2/partials/customers/{company_id}/contacts/{contact_id}/do-not-contact.
+   Renders inside the contact card (contacts_tab.html).
+
+   Receives: company, contact
+   When do_not_contact=True: renders a red "Do Not Contact" badge + a clear button.
+   When do_not_contact=False: renders a small "Set DNC" toggle (accessible, minimal).
+#}
+<div id='dnc-toggle-{{ contact.id }}' class='inline-flex items-center gap-1'>
+  {% if contact.do_not_contact %}
+  {# DNC active: badge + clear button #}
+  <span class='px-1.5 py-0.5 text-[9px] font-semibold rounded bg-red-100 text-red-700 border border-red-200'
+        title='Do Not Contact — outreach to this contact is blocked'>
+    Do Not Contact
+  </span>
+  <form hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/do-not-contact'
+        hx-target='#dnc-toggle-{{ contact.id }}'
+        hx-swap='outerHTML'
+        class='inline'>
+    <input type='hidden' name='do_not_contact' value=''>
+    <button type='submit'
+            class='text-[9px] text-red-500 hover:text-red-700 underline ml-0.5 focus:outline-none focus:ring-1 focus:ring-red-400 rounded'
+            title='Clear do-not-contact flag'>
+      clear
+    </button>
+  </form>
+  {% else %}
+  {# DNC not set: small toggle to set it #}
+  <form hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/do-not-contact'
+        hx-target='#dnc-toggle-{{ contact.id }}'
+        hx-swap='outerHTML'
+        class='inline'>
+    <input type='hidden' name='do_not_contact' value='1'>
+    <button type='submit'
+            class='px-1.5 py-0.5 text-[9px] font-medium rounded bg-gray-50 text-gray-400 border border-dashed border-gray-200 hover:border-red-300 hover:text-red-400 transition-colors focus:outline-none focus:ring-1 focus:ring-red-300'
+            title='Mark as Do Not Contact'>
+      DNC
+    </button>
+  </form>
+  {% endif %}
+</div>

--- a/app/templates/htmx/partials/customers/tabs/contacts_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/contacts_tab.html
@@ -148,6 +148,7 @@
           <span class="px-1 py-0.5 text-[9px] font-medium rounded bg-emerald-50 text-emerald-700">Primary</span>
           {% endif %}
           {% include 'htmx/partials/customers/_role_chip_editor.html' %}
+          {% include 'htmx/partials/customers/_dnc_toggle.html' %}
         </div>
         <p class="text-[11px] text-gray-500 mt-0.5">{{ contact.title or "—" }}</p>
         <div class="mt-1 flex items-center gap-3 text-[11px] text-gray-500 flex-wrap">
@@ -159,6 +160,11 @@
         {{ contact_clocks(contact, now_utc) }}
       </div>
       <div class="flex items-center gap-1.5 flex-wrap flex-shrink-0">
+        {% if contact.do_not_contact %}
+        {# DNC: outreach buttons are suppressed — the DNC badge in the header
+           communicates the block; the buttons are simply absent so the UI
+           gives no false affordance. Server enforces independently. #}
+        {% else %}
         {% if contact.phone %}
         {{ outreach_btn("Call", "tel:" ~ contact.phone, "phone", contact.phone, company.id, contact.customer_site_id, contact.id, contact.full_name,
                         "M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z") }}
@@ -172,6 +178,7 @@
         {% if contact.wechat_id %}
         {{ outreach_btn("WeChat", "weixin://dl/chat?" ~ contact.wechat_id|urlencode, "wechat", contact.wechat_id, company.id, contact.customer_site_id, contact.id, contact.full_name,
                         "M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z") }}
+        {% endif %}
         {% endif %}
       </div>
     </div>

--- a/tests/test_dnc_flag.py
+++ b/tests/test_dnc_flag.py
@@ -1,0 +1,419 @@
+"""Tests for the do-not-contact (DNC) flag on SiteContact.
+
+Covers:
+- Toggle DNC on/off via POST /v2/partials/customers/{company_id}/contacts/{contact_id}/do-not-contact
+- Outreach endpoint refuses to log to DNC contacts (no ActivityLog created, 4xx)
+- Non-DNC contacts still work via outreach endpoint
+- send_batch_rfq skips DNC contacts and reports them as "skipped" (status="skipped", error includes "do-not-contact")
+- Non-DNC contacts in the same batch are still sent
+- Contact card renders DNC badge when do_not_contact=True
+
+TDD: tests were written first; implementation follows.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import ActivityLog
+from app.models.crm import Company, CustomerSite, SiteContact
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def dnc_company(db_session: Session):
+    """Company + site + two contacts: one DNC, one not."""
+    company = Company(name="DNC Test Co", is_active=True)
+    db_session.add(company)
+    db_session.flush()
+
+    site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+    db_session.add(site)
+    db_session.flush()
+
+    contact_ok = SiteContact(
+        customer_site_id=site.id,
+        full_name="Safe Contact",
+        email="safe@dnctest.com",
+        phone="+14155550001",
+    )
+    contact_dnc = SiteContact(
+        customer_site_id=site.id,
+        full_name="DNC Person",
+        email="dnc@dnctest.com",
+        phone="+14155550002",
+    )
+    db_session.add(contact_ok)
+    db_session.add(contact_dnc)
+    db_session.commit()
+    db_session.refresh(contact_ok)
+    db_session.refresh(contact_dnc)
+
+    return {
+        "company": company,
+        "site": site,
+        "contact_ok": contact_ok,
+        "contact_dnc": contact_dnc,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clear_rate_limit():
+    """Clear in-memory rate limiter between tests."""
+    from app.routers.activity import _call_log
+
+    _call_log.clear()
+    yield
+    _call_log.clear()
+
+
+# ── Toggle DNC ────────────────────────────────────────────────────────
+
+
+class TestDNCToggle:
+    def _toggle_url(self, company_id: int, contact_id: int) -> str:
+        return f"/v2/partials/customers/{company_id}/contacts/{contact_id}/do-not-contact"
+
+    def test_set_dnc_persists_true(self, client: TestClient, db_session: Session, dnc_company):
+        """POST with dnc=1 sets do_not_contact=True."""
+        contact = dnc_company["contact_ok"]
+        company = dnc_company["company"]
+        assert contact.do_not_contact is False
+
+        resp = client.post(
+            self._toggle_url(company.id, contact.id),
+            data={"do_not_contact": "1"},
+        )
+        assert resp.status_code == 200
+
+        db_session.expire(contact)
+        db_session.refresh(contact)
+        assert contact.do_not_contact is True
+
+    def test_clear_dnc_persists_false(self, client: TestClient, db_session: Session, dnc_company):
+        """POST with do_not_contact='' clears the flag back to False."""
+        contact = dnc_company["contact_dnc"]
+        company = dnc_company["company"]
+
+        # Seed as DNC
+        contact.do_not_contact = True
+        db_session.commit()
+
+        resp = client.post(
+            self._toggle_url(company.id, contact.id),
+            data={"do_not_contact": ""},
+        )
+        assert resp.status_code == 200
+
+        db_session.expire(contact)
+        db_session.refresh(contact)
+        assert contact.do_not_contact is False
+
+    def test_toggle_unknown_contact_returns_404(self, client: TestClient, dnc_company):
+        """Contact that does not exist → 404."""
+        company = dnc_company["company"]
+        resp = client.post(
+            self._toggle_url(company.id, 999999),
+            data={"do_not_contact": "1"},
+        )
+        assert resp.status_code == 404
+
+    def test_toggle_response_is_html(self, client: TestClient, dnc_company):
+        """Response is an HTML partial (the re-rendered card fragment)."""
+        contact = dnc_company["contact_ok"]
+        company = dnc_company["company"]
+        resp = client.post(
+            self._toggle_url(company.id, contact.id),
+            data={"do_not_contact": "1"},
+        )
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers.get("content-type", "")
+
+    def test_dnc_badge_visible_in_response_when_set(self, client: TestClient, dnc_company):
+        """When DNC is active, the response HTML contains the DNC badge."""
+        contact = dnc_company["contact_ok"]
+        company = dnc_company["company"]
+        resp = client.post(
+            self._toggle_url(company.id, contact.id),
+            data={"do_not_contact": "1"},
+        )
+        assert resp.status_code == 200
+        # The DNC badge must be rendered in the partial
+        assert "do-not-contact" in resp.text.lower() or "Do Not Contact" in resp.text
+
+
+# ── Contact card DNC badge ────────────────────────────────────────────
+
+
+class TestContactCardDNCBadge:
+    def test_contact_card_shows_dnc_badge_when_flag_set(self, client: TestClient, db_session: Session, dnc_company):
+        """Contact card rendered via the contacts tab shows DNC badge when flag is
+        True."""
+        contact = dnc_company["contact_dnc"]
+        company = dnc_company["company"]
+
+        contact.do_not_contact = True
+        db_session.commit()
+
+        resp = client.get(
+            f"/v2/partials/customers/{company.id}",
+            params={"tab": "contacts"},
+        )
+        assert resp.status_code == 200
+        assert "Do Not Contact" in resp.text or "do-not-contact" in resp.text.lower()
+
+    def test_contact_card_no_dnc_badge_when_flag_clear(self, client: TestClient, db_session: Session, dnc_company):
+        """Contact card does NOT show the red DNC badge when flag is False.
+
+        (The DNC toggle button with 'Mark as Do Not Contact' title is always present;
+        this test checks that the red active-badge is absent.)
+        """
+        contact = dnc_company["contact_ok"]
+        company = dnc_company["company"]
+
+        assert contact.do_not_contact is False
+        # Ensure contact_dnc is also NOT set so no DNC badge appears at all
+        dnc_company["contact_dnc"].do_not_contact = False
+        db_session.commit()
+
+        resp = client.get(
+            f"/v2/partials/customers/{company.id}",
+            params={"tab": "contacts"},
+        )
+        assert resp.status_code == 200
+        # The red active badge text only renders when do_not_contact=True.
+        # The widget renders as a plain "DNC" button (set-mode) when clear.
+        # bg-red-100 is the badge class; its absence confirms no active badge.
+        assert "bg-red-100" not in resp.text
+
+
+# ── Server-side outreach enforcement ─────────────────────────────────
+
+
+class TestOutreachDNCEnforcement:
+    def _post_outreach(self, client: TestClient, dnc_company, contact, channel="email", value=None):
+        if value is None:
+            value = contact.email or contact.phone
+        return client.post(
+            "/api/activity/outreach-initiated",
+            json={
+                "channel": channel,
+                "contact_value": value,
+                "company_id": dnc_company["company"].id,
+                "customer_site_id": dnc_company["site"].id,
+                "site_contact_id": contact.id,
+                "contact_name": contact.full_name,
+                "origin": "cdm_workspace",
+            },
+        )
+
+    def test_outreach_refused_for_dnc_contact(self, client: TestClient, db_session: Session, dnc_company):
+        """Outreach endpoint returns 4xx for a DNC contact; no ActivityLog created."""
+        contact = dnc_company["contact_dnc"]
+        contact.do_not_contact = True
+        db_session.commit()
+
+        before_count = db_session.query(ActivityLog).count()
+        resp = self._post_outreach(client, dnc_company, contact)
+
+        # Must refuse — 4xx (422 or 403)
+        assert resp.status_code in (403, 422, 400)
+        after_count = db_session.query(ActivityLog).count()
+        assert after_count == before_count, "No ActivityLog should be created for a DNC contact"
+
+    def test_outreach_allowed_for_non_dnc_contact(self, client: TestClient, db_session: Session, dnc_company):
+        """Outreach endpoint succeeds for a non-DNC contact; ActivityLog created."""
+        contact = dnc_company["contact_ok"]
+        assert contact.do_not_contact is False
+
+        resp = self._post_outreach(client, dnc_company, contact)
+        assert resp.status_code == 201
+        assert "id" in resp.json()
+
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record is not None
+        assert record.site_contact_id == contact.id
+
+    def test_outreach_refused_error_message_mentions_dnc(self, client: TestClient, db_session: Session, dnc_company):
+        """Error response must mention DNC / do-not-contact so callers know why."""
+        contact = dnc_company["contact_dnc"]
+        contact.do_not_contact = True
+        db_session.commit()
+
+        resp = self._post_outreach(client, dnc_company, contact)
+        assert resp.status_code in (403, 422, 400)
+        body = resp.text.lower()
+        assert "do not contact" in body or "do-not-contact" in body or "dnc" in body
+
+
+# ── send_batch_rfq DNC enforcement ───────────────────────────────────
+
+
+class TestSendBatchRfqDNC:
+    """send_batch_rfq must skip DNC contacts and report them with status='skipped'."""
+
+    def _make_vendor_group(self, name: str, email: str, parts: list | None = None):
+        return {
+            "vendor_name": name,
+            "vendor_email": email,
+            "parts": parts or ["LM317T"],
+            "subject": f"RFQ for parts from {name}",
+            "body": "Please quote.",
+        }
+
+    @pytest.mark.asyncio
+    async def test_dnc_contact_skipped_not_emailed(self, db_session: Session, test_user, test_requisition, dnc_company):
+        """A vendor group whose email matches a DNC SiteContact must be skipped."""
+        from app.email_service import send_batch_rfq
+
+        contact = dnc_company["contact_dnc"]
+        contact.do_not_contact = True
+        db_session.commit()
+
+        vendor_groups = [
+            self._make_vendor_group("DNC Vendor", contact.email),
+        ]
+
+        mock_gc = AsyncMock()
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                requisition_id=test_requisition.id,
+                vendor_groups=vendor_groups,
+            )
+
+        assert len(results) == 1
+        assert results[0]["status"] == "skipped"
+        assert "do-not-contact" in results[0]["error"].lower() or "do not contact" in results[0]["error"].lower()
+        # Must NOT have attempted to send
+        mock_gc.post_json.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_dnc_contact_still_sent(self, db_session: Session, test_user, test_requisition, dnc_company):
+        """Non-DNC contact in the same batch is still emailed."""
+        from app.email_service import send_batch_rfq
+
+        safe_contact = dnc_company["contact_ok"]
+        assert safe_contact.do_not_contact is False
+
+        vendor_groups = [
+            self._make_vendor_group("Safe Vendor", safe_contact.email),
+        ]
+
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        mock_gc.get_json.return_value = {
+            "value": [
+                {
+                    "id": "sent-msg-1",
+                    "conversationId": "conv-1",
+                    "subject": f"RFQ for parts from Safe Vendor [ref:{test_requisition.id}]",
+                }
+            ]
+        }
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                requisition_id=test_requisition.id,
+                vendor_groups=vendor_groups,
+            )
+
+        assert len(results) == 1
+        assert results[0]["status"] == "sent"
+
+    @pytest.mark.asyncio
+    async def test_mixed_batch_dnc_skipped_non_dnc_sent(
+        self, db_session: Session, test_user, test_requisition, dnc_company
+    ):
+        """Mixed batch: DNC contact skipped, non-DNC contact sent."""
+        from app.email_service import send_batch_rfq
+
+        safe_contact = dnc_company["contact_ok"]
+        dnc_contact = dnc_company["contact_dnc"]
+        dnc_contact.do_not_contact = True
+        db_session.commit()
+
+        vendor_groups = [
+            self._make_vendor_group("Safe Vendor", safe_contact.email),
+            self._make_vendor_group("DNC Vendor", dnc_contact.email),
+        ]
+
+        mock_gc = AsyncMock()
+        mock_gc.post_json.return_value = {}
+        mock_gc.get_json.return_value = {
+            "value": [
+                {
+                    "id": "sent-msg-1",
+                    "conversationId": "conv-1",
+                    "subject": f"RFQ for parts from Safe Vendor [ref:{test_requisition.id}]",
+                }
+            ]
+        }
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                requisition_id=test_requisition.id,
+                vendor_groups=vendor_groups,
+            )
+
+        assert len(results) == 2
+        statuses = {r["vendor_email"]: r["status"] for r in results}
+        assert statuses[safe_contact.email] == "sent"
+        assert statuses[dnc_contact.email] == "skipped"
+
+        # Only one send attempted (the non-DNC one)
+        assert mock_gc.post_json.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_dnc_skipped_result_has_vendor_name(
+        self, db_session: Session, test_user, test_requisition, dnc_company
+    ):
+        """Skipped DNC result includes the vendor_name so the caller can display it."""
+        from app.email_service import send_batch_rfq
+
+        dnc_contact = dnc_company["contact_dnc"]
+        dnc_contact.do_not_contact = True
+        db_session.commit()
+
+        vendor_groups = [
+            self._make_vendor_group("DNC Corp", dnc_contact.email),
+        ]
+
+        mock_gc = AsyncMock()
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value=None),
+        ):
+            results = await send_batch_rfq(
+                token="fake-token",
+                db=db_session,
+                user_id=test_user.id,
+                requisition_id=test_requisition.id,
+                vendor_groups=vendor_groups,
+            )
+
+        assert results[0]["vendor_name"] == "DNC Corp"
+        assert results[0]["vendor_email"] == dnc_contact.email
+        assert results[0]["status"] == "skipped"


### PR DESCRIPTION
Phase 2d. `SiteContact.do_not_contact` (migration 116) — set from the cockpit, badged, outreach buttons suppressed, and ENFORCED server-side:
- `log_outreach_initiated` refuses a DNC contact BEFORE any ActivityLog write (all 4 channels) → 403; non-DNC still logs.
- `send_batch_rfq` excludes DNC contacts pre-send and reports them in the skipped set (reuses X-RFQ-Skipped). P1b send-time/sent_at/reconcile path untouched for non-DNC recipients (verified).

14 tests (ActivityLog-count enforcement + mixed-batch skip); review-approved (refusal-before-write verified, no P1b regression). Minor follow-ups: DNC audit log; inline-import nit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)