### PR TITLE
feat(crm): buy-plans tab on the account — deal consolidation (P3)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4875,6 +4875,32 @@ def _company_quotes_query(db: Session, company):
     return db.query(Quote).filter(or_(*conds)).options(joinedload(Quote.requisition))
 
 
+def _company_buy_plans_query(db: Session, company):
+    """Buy plans belonging to an account: all buy-plans whose requisition links
+    to the company (via company_id FK or customer_name match). Returns a Query,
+    or None when the account has no requisitions.
+    Called by: company_detail_partial (count), company_tab (buy_plans).
+    """
+    req_ids = [
+        r.id
+        for r in db.query(Requisition.id)
+        .filter(
+            or_(
+                Requisition.company_id == company.id,
+                sqlfunc.lower(sqlfunc.trim(Requisition.customer_name)) == company.name.lower().strip(),
+            )
+        )
+        .all()
+    ]
+    if not req_ids:
+        return None
+    return (
+        db.query(BuyPlan)
+        .options(joinedload(BuyPlan.lines), joinedload(BuyPlan.requisition))
+        .filter(BuyPlan.requisition_id.in_(req_ids))
+    )
+
+
 @router.get("/v2/partials/customers/{company_id}/segment-tags", response_class=HTMLResponse)
 async def company_segment_tags_partial(
     request: Request,
@@ -5181,6 +5207,9 @@ async def company_detail_partial(
     _cq = _company_quotes_query(db, company)
     quote_count = _cq.count() if _cq is not None else 0
 
+    _bpq = _company_buy_plans_query(db, company)
+    buy_plan_count = _bpq.count() if _bpq is not None else 0
+
     # Cadence card + commercial strip context
     from datetime import timezone as _tz
 
@@ -5198,6 +5227,7 @@ async def company_detail_partial(
             "sites": sites,
             "open_req_count": open_req_count,
             "quote_count": quote_count,
+            "buy_plan_count": buy_plan_count,
             # Pass the active-only sites list — contacts on deactivated sites must
             # not be shown (clicking them would log outreach against, and bump,
             # a deactivated entity).
@@ -5235,7 +5265,7 @@ async def company_tab(
     if not company:
         raise HTTPException(404, "Company not found")
 
-    valid_tabs = {"sites", "contacts", "requisitions", "activity", "quotes"}
+    valid_tabs = {"sites", "contacts", "requisitions", "activity", "quotes", "buy_plans"}
     if tab not in valid_tabs:
         raise HTTPException(404, f"Unknown tab: {tab}")
 
@@ -5317,6 +5347,13 @@ async def company_tab(
         ctx = _base_ctx(request, user, "customers")
         ctx.update({"company": company, "quotes": quotes})
         return template_response("htmx/partials/customers/tabs/quotes_tab.html", ctx)
+
+    elif tab == "buy_plans":
+        bpq = _company_buy_plans_query(db, company)
+        buy_plans = bpq.order_by(BuyPlan.created_at.desc().nullslast()).all() if bpq is not None else []
+        ctx = _base_ctx(request, user, "customers")
+        ctx.update({"company": company, "buy_plans": buy_plans})
+        return template_response("htmx/partials/customers/tabs/buy_plans_tab.html", ctx)
 
     else:  # activity
         from sqlalchemy import or_ as or_clause

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -195,7 +195,8 @@
           ('sites', 'Sites', sites|length),
           ('requisitions', 'Requisitions', open_req_count),
           ('activity', 'Activity', none),
-          ('quotes', 'Quotes', quote_count if quote_count is defined else none)
+          ('quotes', 'Quotes', quote_count if quote_count is defined else none),
+          ('buy_plans', 'Buy Plans', buy_plan_count if buy_plan_count is defined else none)
         ] %}
         <button @click="activeTab = '{{ tab_id }}'"
                 role="tab"

--- a/app/templates/htmx/partials/customers/tabs/buy_plans_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/buy_plans_tab.html
@@ -1,0 +1,66 @@
+{# buy_plans_tab.html — Buy Plans tab for the CRM account (company) detail.
+   Receives: company (Company), buy_plans (list[BuyPlan] with lines loaded).
+   Called by: company_tab route (tab == "buy_plans").
+   Depends on: HTMX, brand palette.
+#}
+<div>
+  {% if buy_plans %}
+  <div class="flex items-center justify-between mb-4">
+    <p class="text-sm text-gray-500">
+      <span class="font-semibold text-gray-900">{{ buy_plans|length }}</span> buy plan{{ "s" if buy_plans|length != 1 }}
+    </p>
+  </div>
+  <div class="overflow-x-auto bg-white rounded-lg border border-brand-200">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50 sticky top-0">
+        <tr>
+          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Buy Plan #</th>
+          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Requisition</th>
+          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">SO#</th>
+          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+          <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Lines</th>
+          <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Total Cost</th>
+          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200">
+        {% for bp in buy_plans %}
+        <tr class="hover:bg-brand-50 cursor-pointer transition-colors"
+            hx-get="/v2/partials/buy-plans/{{ bp.id }}"
+            hx-target="#main-content"
+            hx-push-url="/v2/buy-plans/{{ bp.id }}">
+          <td class="px-4 py-2.5 text-sm font-medium text-brand-500 hover:text-brand-600">#{{ bp.id }}</td>
+          <td class="px-4 py-2.5 text-sm text-gray-500">{{ bp.requisition.name if bp.requisition else "—" }}</td>
+          <td class="px-4 py-2.5 text-sm text-gray-500 font-mono">{{ bp.sales_order_number or "—" }}</td>
+          <td class="px-4 py-2.5">
+            {% set bp_colors = {
+              "draft": "bg-slate-50 text-slate-600",
+              "pending": "bg-amber-50 text-amber-700",
+              "active": "bg-emerald-50 text-emerald-700",
+              "halted": "bg-rose-50 text-rose-700",
+              "completed": "bg-emerald-50 text-emerald-700",
+              "cancelled": "bg-gray-100 text-gray-600"
+            } %}
+            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ bp_colors.get(bp.status, 'bg-gray-100 text-gray-600') }}">
+              {{ (bp.status or 'unknown')|replace('_', ' ')|capitalize }}
+            </span>
+          </td>
+          <td class="px-4 py-2.5 text-sm text-gray-500 text-right">{{ bp.lines|length if bp.lines else 0 }}</td>
+          <td class="px-4 py-2.5 text-sm text-gray-900 font-medium text-right">{{ "${:,.2f}".format(bp.total_cost) if bp.total_cost else "—" }}</td>
+          <td class="px-4 py-2.5 text-sm text-gray-500">{{ bp.created_at.strftime('%b %d, %Y') if bp.created_at else "—" }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <div class="py-12 text-center">
+    <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+    </svg>
+    <p class="text-sm font-medium text-gray-500 mt-3">No buy plans for this account.</p>
+    <p class="text-xs text-gray-400 mt-1">Buy plans are created after a quote is won and a sales order is received.</p>
+  </div>
+  {% endif %}
+</div>

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -2773,3 +2773,118 @@ class TestManualCompanyMerge:
         resp = client.get(f"/v2/partials/customers/{keep.id}")
         assert resp.status_code == 200
         assert "merge" in resp.text.lower()
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# P3: Buy Plans tab on the account (deal consolidation)
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestAccountBuyPlansTab:
+    """P3: account detail exposes a Buy Plans tab listing all buy-plans whose
+    requisition belongs to the company (via company_id FK or name match).
+    """
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _make_company(self, db_session: Session, name: str = "BuyPlan Co") -> Company:
+        co = Company(name=name, is_active=True)
+        db_session.add(co)
+        db_session.flush()
+        return co
+
+    def _make_requisition(self, db_session: Session, company: Company, name: str = "REQ-BP-001"):
+        from app.models.sourcing import Requisition
+
+        req = Requisition(name=name, customer_name=company.name, company_id=company.id, status="active")
+        db_session.add(req)
+        db_session.flush()
+        return req
+
+    def _make_buy_plan(self, db_session: Session, requisition, quote, so_number: str = "SO-001"):
+        from app.models.buy_plan import BuyPlan
+
+        bp = BuyPlan(
+            requisition_id=requisition.id,
+            quote_id=quote.id,
+            sales_order_number=so_number,
+            status="active",
+        )
+        db_session.add(bp)
+        db_session.flush()
+        return bp
+
+    def _make_quote(self, db_session: Session, requisition, quote_number: str = "Q-001"):
+        from decimal import Decimal
+
+        from app.models.quotes import Quote
+
+        q = Quote(
+            requisition_id=requisition.id,
+            quote_number=quote_number,
+            subtotal=Decimal("5000.00"),
+            status="won",
+        )
+        db_session.add(q)
+        db_session.flush()
+        return q
+
+    # ── route returns 200 + correct buy-plans ────────────────────────────────
+
+    def test_buy_plans_tab_returns_200(self, client: TestClient, db_session: Session, test_user: User):
+        """GET /v2/partials/customers/{id}/tab/buy_plans returns 200."""
+        co = self._make_company(db_session)
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/buy_plans")
+        assert resp.status_code == 200
+
+    def test_buy_plans_tab_shows_buy_plan_for_company(self, client: TestClient, db_session: Session, test_user: User):
+        """Company's buy-plan (linked via its requisition) appears in the tab."""
+        co = self._make_company(db_session, "BPTab Show Co")
+        req = self._make_requisition(db_session, co, "REQ-SHOW-001")
+        quote = self._make_quote(db_session, req, "Q-SHOW-001")
+        bp = self._make_buy_plan(db_session, req, quote, "SO-SHOW-001")
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/buy_plans")
+        assert resp.status_code == 200
+        assert "SO-SHOW-001" in resp.text, "Buy plan SO# should appear in tab"
+
+    def test_buy_plans_tab_empty_state_when_no_plans(self, client: TestClient, db_session: Session, test_user: User):
+        """Company with no buy-plans renders the empty-state message."""
+        co = self._make_company(db_session, "NoBP Co")
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/tab/buy_plans")
+        assert resp.status_code == 200
+        # Empty state must say something useful
+        assert "No buy plans" in resp.text or "no buy plans" in resp.text.lower()
+
+    def test_buy_plans_tab_scoped_to_company(self, client: TestClient, db_session: Session, test_user: User):
+        """Buy-plans from another company do NOT appear in this company's tab."""
+        co_a = self._make_company(db_session, "Scoped Co A")
+        co_b = self._make_company(db_session, "Scoped Co B")
+        req_a = self._make_requisition(db_session, co_a, "REQ-A-001")
+        req_b = self._make_requisition(db_session, co_b, "REQ-B-001")
+        quote_a = self._make_quote(db_session, req_a, "Q-A-001")
+        quote_b = self._make_quote(db_session, req_b, "Q-B-001")
+        _bp_a = self._make_buy_plan(db_session, req_a, quote_a, "SO-COMPANY-A")
+        _bp_b = self._make_buy_plan(db_session, req_b, quote_b, "SO-COMPANY-B")
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co_a.id}/tab/buy_plans")
+        assert resp.status_code == 200
+        assert "SO-COMPANY-A" in resp.text, "Company A's buy plan should appear"
+        assert "SO-COMPANY-B" not in resp.text, "Company B's buy plan must NOT appear"
+
+    def test_buy_plan_count_shown_in_account_detail(self, client: TestClient, db_session: Session, test_user: User):
+        """Account detail partial renders a 'Buy Plans' tab with correct count badge."""
+        co = self._make_company(db_session, "CountBadge Co")
+        req = self._make_requisition(db_session, co, "REQ-COUNT-001")
+        quote = self._make_quote(db_session, req, "Q-COUNT-001")
+        _bp = self._make_buy_plan(db_session, req, quote, "SO-COUNT-001")
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}")
+        assert resp.status_code == 200
+        assert "Buy Plans" in resp.text, "Buy Plans tab label must appear in detail"


### PR DESCRIPTION
Phase 3. The account is now the hub for its deal artifacts: alongside the existing Quotes tab, a Buy Plans tab on the account detail lists the account%27s buy-plans (scoped via its requisitions — cross-company isolation tested), each linking to the buy-plan detail.

Mirrors the quotes-tab pattern (query + company_tab branch + template + count). The standalone Buy Plans bottom-nav demotion is intentionally DEFERRED to Phase 5 (Reporting), which provides the cross-account home — nav untouched here.

5 tests incl. cross-company scoping; review-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)