### PR TITLE
fix(proactive): hardening — live-offer scan gate, inbox AI cost metering, convert 403/409

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -1131,7 +1131,7 @@ async def _submit_parse_batch(
         )
         request_map[cid] = vr.id
 
-    batch_id = await claude_batch_submit(requests)
+    batch_id = await claude_batch_submit(requests, cost_bucket="email_mining")
     if not batch_id:
         raise RuntimeError("Batch API returned no batch_id")
 
@@ -1531,7 +1531,7 @@ async def process_batch_results(db: Session) -> int:
 
     for pb in pending_batches:
         try:
-            results = await claude_batch_results(pb.batch_id)
+            results = await claude_batch_results(pb.batch_id, cost_bucket="email_mining")
         except Exception as e:
             logger.warning(f"Batch results check failed for {pb.batch_id}: {e}")
             # Mark as failed if submitted >24h ago

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -9842,6 +9842,8 @@ async def proactive_convert(
     offer = db.query(ProactiveOffer).filter(ProactiveOffer.id == offer_id).first()
     if not offer:
         raise HTTPException(404, "Proactive offer not found")
+    if offer.salesperson_id != user.id:
+        raise HTTPException(403, "Not your proactive offer")
 
     try:
         from ..services.proactive_service import convert_proactive_to_win
@@ -9851,7 +9853,12 @@ async def proactive_convert(
             "htmx/partials/proactive/convert_success.html",
             {"request": request, "offer": offer, "result": result},
         )
-    except (ImportError, RuntimeError, Exception) as exc:
+    except ValueError as exc:
+        exc_str = str(exc).lower()
+        if "already converted" in exc_str:
+            raise HTTPException(409, "This offer has already been converted.")
+        raise HTTPException(403, str(exc))
+    except Exception as exc:
         logger.error("Proactive conversion failed: {}", exc)
         raise HTTPException(500, "Conversion failed. Please try again.")
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -9842,7 +9842,7 @@ async def proactive_convert(
     offer = db.query(ProactiveOffer).filter(ProactiveOffer.id == offer_id).first()
     if not offer:
         raise HTTPException(404, "Proactive offer not found")
-    if offer.salesperson_id != user.id:
+    if offer.salesperson_id and offer.salesperson_id != user.id:
         raise HTTPException(403, "Not your proactive offer")
 
     try:

--- a/app/services/proactive_matching.py
+++ b/app/services/proactive_matching.py
@@ -1,7 +1,9 @@
 """Proactive matching engine — finds customer matches for new inventory.
 
 Uses customer_part_history (CPH) as the primary matching backbone.
-Only confirmed buyer-entered Offers trigger proactive matches.
+Active/approved Offers (including mined inbound) seed proactive matches;
+unverified (pending_review) and terminal (rejected/sold/won/expired) offers
+are excluded so the tab only surfaces live stock.
 
 Scoring: composite of recency (40%) + frequency (30%) + margin potential (30%).
 
@@ -15,7 +17,7 @@ from loguru import logger
 from sqlalchemy.orm import Session
 
 from ..config import settings
-from ..constants import ProactiveMatchStatus
+from ..constants import OfferStatus, ProactiveMatchStatus
 from ..models import (
     ActivityLog,
     Company,
@@ -358,12 +360,15 @@ def run_proactive_scan(db: Session) -> dict:
     """
     since = _get_watermark(db)
 
-    # Oldest-first so the limit processes chronologically
+    # Oldest-first so the limit processes chronologically.
+    # Gate to live offers only: pending_review/rejected/sold/won/expired are excluded.
+    _LIVE_STATUSES = [OfferStatus.ACTIVE.value, OfferStatus.APPROVED.value]
     new_offers = (
         db.query(Offer)
         .filter(
             Offer.created_at > since,
             Offer.material_card_id.isnot(None),
+            Offer.status.in_(_LIVE_STATUSES),
         )
         .order_by(Offer.created_at.asc())
         .limit(5000)

--- a/app/services/proactive_matching.py
+++ b/app/services/proactive_matching.py
@@ -362,6 +362,9 @@ def run_proactive_scan(db: Session) -> dict:
 
     # Oldest-first so the limit processes chronologically.
     # Gate to live offers only: pending_review/rejected/sold/won/expired are excluded.
+    # NOTE: an offer created as pending_review (excluded here) that is later approved
+    # won't be re-scanned because the watermark has already advanced past its created_at.
+    # The proper fix is a re-match hook triggered on offer approval (follow-up task).
     _LIVE_STATUSES = [OfferStatus.ACTIVE.value, OfferStatus.APPROVED.value]
     new_offers = (
         db.query(Offer)

--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -414,7 +414,7 @@ def convert_proactive_to_win(db: Session, proactive_offer_id: int, user: User) -
     po = db.get(ProactiveOffer, proactive_offer_id)
     if not po:
         raise ValueError("Proactive offer not found")
-    if po.salesperson_id != user.id:
+    if po.salesperson_id and po.salesperson_id != user.id:
         raise ValueError("Not your proactive offer")
     if po.status == ProactiveOfferStatus.CONVERTED:
         raise ValueError("Already converted")

--- a/app/services/purchase_history_service.py
+++ b/app/services/purchase_history_service.py
@@ -170,9 +170,16 @@ def refresh_matches_for_cards(db: Session, card_ids: list[int], *, per_card_limi
 
     created = 0
     for card_id in set(card_ids):
+        from app.constants import OfferStatus
+
+        _LIVE_STATUSES = [OfferStatus.ACTIVE.value, OfferStatus.APPROVED.value]
         offers = (
             db.query(Offer.id)
-            .filter(Offer.material_card_id == card_id, Offer.is_stale.isnot(True))
+            .filter(
+                Offer.material_card_id == card_id,
+                Offer.is_stale.isnot(True),
+                Offer.status.in_(_LIVE_STATUSES),
+            )
             .order_by(Offer.created_at.desc())
             .limit(per_card_limit)
             .all()

--- a/app/utils/claude_client.py
+++ b/app/utils/claude_client.py
@@ -485,12 +485,17 @@ def _build_batch_request(
 
 async def claude_batch_submit(
     requests: list[dict],
+    *,
+    cost_bucket: str | None = None,
 ) -> str | None:
     """Submit a batch of structured output requests to the Anthropic Batch API.
 
     Args:
         requests: List of dicts with keys:
             custom_id, prompt, schema, system, model_tier, max_tokens
+        cost_bucket: Optional Redis metering bucket (e.g. "email_mining").
+            When set, logs a ``calls`` counter for the submit event itself.
+            Per-entry usage is metered in ``claude_batch_results``.
 
     Returns:
         Batch ID string for polling, or None on failure.
@@ -546,8 +551,16 @@ async def claude_batch_submit(
 
 async def claude_batch_results(
     batch_id: str,
+    *,
+    cost_bucket: str | None = None,
 ) -> dict | None:
     """Check batch status and retrieve results if complete.
+
+    Args:
+        batch_id: Batch ID returned by ``claude_batch_submit``.
+        cost_bucket: Optional Redis metering bucket (e.g. "email_mining").
+            When set, calls ``_meter_usage`` for each succeeded entry so
+            per-entry token cost is visible in Redis usage counters.
 
     Returns:
         None if still processing or on error.
@@ -610,6 +623,17 @@ async def claude_batch_results(
 
                 if result.get("type") == "succeeded":
                     message = result.get("message", {})
+                    # Meter per-entry token usage when a cost_bucket is set.
+                    if cost_bucket:
+                        model_id = message.get("model", "")
+                        # Derive tier from model id (mirrors streaming path heuristic)
+                        if "haiku" in model_id:
+                            entry_tier = "fast"
+                        elif "opus" in model_id:
+                            entry_tier = "opus"
+                        else:
+                            entry_tier = "smart"
+                        _meter_usage(cost_bucket, entry_tier, message.get("usage", {}))
                     # Extract tool_use input (same as claude_structured)
                     raw_input = _extract_tool_input(message.get("content", []))
                     if raw_input is _MISSING:

--- a/app/utils/claude_client.py
+++ b/app/utils/claude_client.py
@@ -494,8 +494,8 @@ async def claude_batch_submit(
         requests: List of dicts with keys:
             custom_id, prompt, schema, system, model_tier, max_tokens
         cost_bucket: Optional Redis metering bucket (e.g. "email_mining").
-            When set, logs a ``calls`` counter for the submit event itself.
-            Per-entry usage is metered in ``claude_batch_results``.
+            Passed through to ``claude_batch_results`` where per-entry usage
+            is metered on poll completion; no metering occurs at submit time.
 
     Returns:
         Batch ID string for polling, or None on failure.

--- a/tests/test_claude_client.py
+++ b/tests/test_claude_client.py
@@ -862,3 +862,105 @@ class TestErrorDifferentiation:
     async def test_no_key_is_unavailable(self, mock_cred, call):
         with pytest.raises(ClaudeUnavailableError):
             await call()
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Fix 2: batch metering via cost_bucket
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestBatchMetering:
+    """Verify that cost_bucket="email_mining" routes to _meter_usage."""
+
+    def _make_jsonl(self, entries):
+        import json
+
+        return "\n".join(json.dumps({"custom_id": cid, "result": r}) for cid, r in entries)
+
+    @pytest.mark.asyncio
+    @patch("app.utils.claude_client._meter_usage")
+    @patch("app.utils.claude_client.get_credential_cached", side_effect=_cred_side_effect)
+    @patch("app.utils.claude_client.http")
+    async def test_batch_results_meters_with_bucket(self, mock_http, mock_cred, mock_meter):
+        """cost_bucket triggers _meter_usage for each succeeded entry."""
+        jsonl = self._make_jsonl(
+            [
+                (
+                    "r1",
+                    {
+                        "type": "succeeded",
+                        "message": {
+                            "model": "claude-haiku-3",
+                            "usage": {"input_tokens": 100, "output_tokens": 50},
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "name": "structured_output",
+                                    "input": {"parsed": True},
+                                }
+                            ],
+                        },
+                    },
+                ),
+            ]
+        )
+        status_resp = _mock_response(
+            200,
+            {
+                "processing_status": "ended",
+                "results_url": "https://api.anthropic.com/results/batch_m1",
+                "request_counts": {"succeeded": 1, "errored": 0},
+            },
+        )
+        results_resp = _mock_response(200, text=jsonl)
+        mock_http.get = AsyncMock(side_effect=[status_resp, results_resp])
+
+        result = await claude_batch_results("batch_m1", cost_bucket="email_mining")
+
+        assert result == {"r1": {"parsed": True}}
+        mock_meter.assert_called_once()
+        call_args = mock_meter.call_args
+        assert call_args[0][0] == "email_mining"  # bucket
+        assert call_args[0][1] == "fast"  # haiku → fast
+
+    @pytest.mark.asyncio
+    @patch("app.utils.claude_client._meter_usage")
+    @patch("app.utils.claude_client.get_credential_cached", side_effect=_cred_side_effect)
+    @patch("app.utils.claude_client.http")
+    async def test_batch_results_no_bucket_skips_meter(self, mock_http, mock_cred, mock_meter):
+        """Without cost_bucket, _meter_usage is NOT called."""
+        jsonl = self._make_jsonl(
+            [
+                (
+                    "r1",
+                    {
+                        "type": "succeeded",
+                        "message": {
+                            "model": "claude-haiku-3",
+                            "usage": {"input_tokens": 100, "output_tokens": 50},
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "name": "structured_output",
+                                    "input": {"parsed": True},
+                                }
+                            ],
+                        },
+                    },
+                ),
+            ]
+        )
+        status_resp = _mock_response(
+            200,
+            {
+                "processing_status": "ended",
+                "results_url": "https://api.anthropic.com/results/batch_nm",
+                "request_counts": {"succeeded": 1, "errored": 0},
+            },
+        )
+        results_resp = _mock_response(200, text=jsonl)
+        mock_http.get = AsyncMock(side_effect=[status_resp, results_resp])
+
+        await claude_batch_results("batch_nm")  # no cost_bucket
+
+        mock_meter.assert_not_called()

--- a/tests/test_proactive_matching.py
+++ b/tests/test_proactive_matching.py
@@ -893,3 +893,81 @@ def test_aggregates_cph_across_sources(db_session):
     # newest-wins: price and date come from the buy_plan row (5 days ago), not avail_offer (60 days ago)
     assert m.customer_last_price == 20.00
     assert m.customer_last_purchased_at == buy_plan_date
+
+
+# ── Fix 1: live-offer gate tests ─────────────────────────────────────────
+
+
+def test_scan_excludes_pending_review_offer(db_session):
+    """run_proactive_scan: pending_review offer produces NO match (fix 1)."""
+    data = _setup_scenario(db_session)
+
+    _make_offer(
+        db_session,
+        data,
+        status="pending_review",
+        created_at=datetime.now(timezone.utc),
+    )
+
+    from app.models.config import SystemConfig
+
+    db_session.add(
+        SystemConfig(
+            key="proactive_last_scan",
+            value=(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+        )
+    )
+    db_session.commit()
+
+    result = run_proactive_scan(db_session)
+    assert result["matches_created"] == 0, "pending_review offer must not seed proactive matches"
+
+
+def test_scan_includes_active_offer(db_session):
+    """run_proactive_scan: active offer DOES produce a match (fix 1)."""
+    data = _setup_scenario(db_session)
+
+    _make_offer(
+        db_session,
+        data,
+        status="active",
+        created_at=datetime.now(timezone.utc),
+    )
+
+    from app.models.config import SystemConfig
+
+    db_session.add(
+        SystemConfig(
+            key="proactive_last_scan",
+            value=(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+        )
+    )
+    db_session.commit()
+
+    result = run_proactive_scan(db_session)
+    assert result["matches_created"] >= 1, "active offer must seed proactive matches"
+
+
+def test_scan_excludes_expired_offer(db_session):
+    """run_proactive_scan: expired offer produces NO match (fix 1)."""
+    data = _setup_scenario(db_session)
+
+    _make_offer(
+        db_session,
+        data,
+        status="expired",
+        created_at=datetime.now(timezone.utc),
+    )
+
+    from app.models.config import SystemConfig
+
+    db_session.add(
+        SystemConfig(
+            key="proactive_last_scan",
+            value=(datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+        )
+    )
+    db_session.commit()
+
+    result = run_proactive_scan(db_session)
+    assert result["matches_created"] == 0, "expired offer must not seed proactive matches"

--- a/tests/test_sprint8_proactive.py
+++ b/tests/test_sprint8_proactive.py
@@ -250,3 +250,36 @@ class TestProactiveConvert:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
+
+    @patch(
+        "app.services.proactive_service.convert_proactive_to_win",
+        return_value={"ok": True, "requisition_id": 1, "quote_id": 1},
+    )
+    def test_null_salesperson_convert_succeeds(
+        self,
+        mock_convert,
+        client: TestClient,
+        db_session: Session,
+        test_user: User,
+        test_customer_site,
+    ):
+        """An offer with salesperson_id=None is convertible by any authenticated user
+        (not 403)."""
+        from app.models import ProactiveOffer
+
+        po = ProactiveOffer(
+            customer_site_id=test_customer_site.id,
+            salesperson_id=None,  # no owner
+            line_items=[],
+            recipient_emails=[],
+            subject="Unowned offer",
+            status="sent",
+        )
+        db_session.add(po)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/proactive/{po.id}/convert",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200, f"Expected 200 for null salesperson, got {resp.status_code}"

--- a/tests/test_sprint8_proactive.py
+++ b/tests/test_sprint8_proactive.py
@@ -8,6 +8,7 @@ Depends on: conftest.py fixtures, app.routers.htmx_views
 """
 
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -167,3 +168,85 @@ class TestAddDomain:
         # Empty domain returns an inline error chip (200), not a 400.
         assert resp.status_code == 200
         assert "domain" in resp.text.lower()
+
+
+# ── Fix 3: proactive_convert 403/409 ────────────────────────────────
+
+
+class TestProactiveConvert:
+    """Tests for POST /v2/partials/proactive/{offer_id}/convert (fix 3)."""
+
+    def test_cross_user_convert_returns_403(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: User,
+        test_customer_site,
+    ):
+        """A different user's proactive offer → 403 (ownership check)."""
+        from app.models import ProactiveOffer
+
+        other_user = User(
+            email="other@trioscs.com",
+            name="Other User",
+            role="buyer",
+            azure_id="other-azure-999",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(other_user)
+        db_session.flush()
+
+        po = ProactiveOffer(
+            customer_site_id=test_customer_site.id,
+            salesperson_id=other_user.id,  # NOT test_user
+            line_items=[],
+            recipient_emails=[],
+            subject="Test",
+            status="sent",
+        )
+        db_session.add(po)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/proactive/{po.id}/convert",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 403
+
+    @patch(
+        "app.services.proactive_service.convert_proactive_to_win",
+        side_effect=ValueError("Already converted"),
+    )
+    def test_double_convert_returns_409(
+        self,
+        mock_convert,
+        client: TestClient,
+        db_session: Session,
+        test_user: User,
+        test_proactive_offer,
+    ):
+        """Second conversion of the same offer → 409 Conflict."""
+        resp = client.post(
+            f"/v2/partials/proactive/{test_proactive_offer.id}/convert",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 409
+
+    @patch(
+        "app.services.proactive_service.convert_proactive_to_win",
+        return_value={"ok": True, "requisition_id": 1, "quote_id": 1},
+    )
+    def test_valid_convert_succeeds(
+        self,
+        mock_convert,
+        client: TestClient,
+        db_session: Session,
+        test_user: User,
+        test_proactive_offer,
+    ):
+        """Valid conversion → 200 success response."""
+        resp = client.post(
+            f"/v2/partials/proactive/{test_proactive_offer.id}/convert",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
Post-ship hardening of the proactive program (close-out of turning email mining on).

## Fixes
1. **Match-quality gate** — `run_proactive_scan` + `refresh_matches_for_cards` only seed matches from live offers (status active/approved), excluding unverified `pending_review`/terminal. Stale docstring corrected.
2. **Inbox AI cost metering** — `claude_batch_submit/results` accept `cost_bucket` (keyword-only, default None = no change for other callers); inbox parse passes `cost_bucket="email_mining"` so mining spend is now visible (was invisible). Budget cap = noted follow-up.
3. **Convert authz** — cross-user convert blocked at the router (403, IDOR fix), double-convert → 409, genuine errors still 500; ownership checks tolerate null salesperson_id (no spurious 403).

## Review-caught + fixed
Nullable salesperson_id spurious-403 (router + service) + misleading batch-submit docstring; null-salesperson convert test added.

## Deferred (documented in code)
pending_review→approved offers can be missed (watermark advances by created_at) — proper fix is a re-match hook on approval.

## Tests
185 passing; pre-commit clean; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)