### PR TITLE
feat(offers): qualification follow-ups — relax gate, IDOR sweep, filter facet

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -1273,6 +1273,7 @@ async def requisition_tab(
     request: Request,
     req_id: int,
     tab: str,
+    qual: str | None = None,
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -1299,9 +1300,10 @@ async def requisition_tab(
         return template_response("htmx/partials/requisitions/tabs/parts.html", ctx)
 
     elif tab == "offers":
-        offers = (
-            db.query(Offer).filter(Offer.requisition_id == req_id).order_by(Offer.created_at.desc().nullslast()).all()
-        )
+        q = db.query(Offer).filter(Offer.requisition_id == req_id)
+        if qual in ("unset", "incomplete", "essentials", "complete"):
+            q = q.filter(Offer.qualification_status == qual)
+        offers = q.order_by(Offer.created_at.desc().nullslast()).all()
         # Check for existing draft quote to show "Add to Quote" button
         draft_quote = (
             db.query(Quote)
@@ -1311,6 +1313,7 @@ async def requisition_tab(
         )
         ctx["offers"] = offers
         ctx["draft_quote"] = draft_quote
+        ctx["qual"] = qual
         return template_response("htmx/partials/requisitions/tabs/offers.html", ctx)
 
     elif tab == "quotes":

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -2130,33 +2130,10 @@ async def add_offer(
 
     from ..services.offer_qualification import (
         apply_qualification,
-        essentials_data,
         normalize_offer_condition,
-        validate_essentials,
     )
     from ..utils.normalization import normalize_mpn_key
     from ..vendor_utils import normalize_vendor_name
-
-    # Gate: validate the submitted essentials before persisting. On a missing essential,
-    # return the existing inline 400 error and do not create the offer.
-    norm_condition = normalize_offer_condition(form.get("condition")) or (form.get("condition") or None)
-    gate_errors = validate_essentials(
-        norm_condition,
-        essentials_data(
-            manufacturer=form.get("manufacturer"),
-            packaging=form.get("packaging"),
-            usage=form.get("usage"),
-            refurbished_by=form.get("refurbished_by"),
-            refurb_process=form.get("refurb_process"),
-            cert_doc=form.get("cert_doc"),
-            part_condition=form.get("part_condition"),
-        ),
-    )
-    if gate_errors:
-        return HTMLResponse(
-            f'<div class="text-sm text-rose-600 p-2">{"; ".join(gate_errors)}</div>',
-            status_code=400,
-        )
 
     offer = Offer(
         requisition_id=req_id,
@@ -2349,9 +2326,7 @@ async def edit_offer(
 
     from ..services.offer_qualification import (
         apply_qualification,
-        essentials_data,
         normalize_offer_condition,
-        validate_essentials,
     )
 
     _qkeys = (
@@ -2375,26 +2350,6 @@ async def edit_offer(
     if cond_raw:
         offer.condition = normalize_offer_condition(cond_raw) or cond_raw
 
-    # Gate: validate the effective essentials before persisting. On a missing essential,
-    # return the existing inline 400 error and do not commit.
-    _q = offer.qualification or {}
-    gate_errors = validate_essentials(
-        offer.condition,
-        essentials_data(
-            manufacturer=offer.manufacturer,
-            packaging=offer.packaging,
-            usage=_q.get("usage"),
-            refurbished_by=_q.get("refurbished_by"),
-            refurb_process=_q.get("refurb_process"),
-            cert_doc=_q.get("cert_doc"),
-            part_condition=_q.get("part_condition"),
-        ),
-    )
-    if gate_errors:
-        return HTMLResponse(
-            f'<div class="text-sm text-rose-600 p-2">{"; ".join(gate_errors)}</div>',
-            status_code=400,
-        )
     apply_qualification(offer)  # non-raising: composes note + sets status
     offer.updated_at = now
     offer.updated_by_id = user.id

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -2495,6 +2495,11 @@ async def sightings_review_offer(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    # Scope the offer to the path requirement (IDOR guard — prevents a guessed offer_id
+    # from a different requirement from being approved/rejected).
+    offer = db.get(Offer, offer_id)
+    if offer is None or offer.requirement_id != requirement_id:
+        raise HTTPException(status_code=404, detail={"error": "offer not found for this requirement"})
     if action == "approve":
         await approve_offer(offer_id, user=user, db=db)
     else:
@@ -2517,6 +2522,10 @@ async def sightings_reconfirm_offer(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    # Scope the offer to the path requirement (IDOR guard).
+    offer = db.get(Offer, offer_id)
+    if offer is None or offer.requirement_id != requirement_id:
+        raise HTTPException(status_code=404, detail={"error": "offer not found for this requirement"})
     await reconfirm_offer(offer_id, user=user, db=db)
     db.expire_all()
     return _refresh_offers_panel(request, requirement_id, db)
@@ -2536,6 +2545,10 @@ async def sightings_mark_offer_sold(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    # Scope the offer to the path requirement (IDOR guard).
+    offer = db.get(Offer, offer_id)
+    if offer is None or offer.requirement_id != requirement_id:
+        raise HTTPException(status_code=404, detail={"error": "offer not found for this requirement"})
     await mark_offer_sold(offer_id, user=user, db=db)
     db.expire_all()
     return _refresh_offers_panel(request, requirement_id, db)
@@ -2555,6 +2568,10 @@ async def sightings_delete_offer(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    # Scope the offer to the path requirement (IDOR guard).
+    offer = db.get(Offer, offer_id)
+    if offer is None or offer.requirement_id != requirement_id:
+        raise HTTPException(status_code=404, detail={"error": "offer not found for this requirement"})
     await delete_offer(offer_id, user=user, db=db)
     db.expire_all()
     return _refresh_offers_panel(request, requirement_id, db)

--- a/app/templates/htmx/partials/requisitions/tabs/offers.html
+++ b/app/templates/htmx/partials/requisitions/tabs/offers.html
@@ -1,8 +1,10 @@
 {# offers.html — Offers tab for requisition detail with action buttons.
-   Receives: offers (list of Offer objects), req (Requisition), draft_quote (Quote or None).
+   Receives: offers (list of Offer objects), req (Requisition), draft_quote (Quote or None),
+             qual (str or None — active qualification_status filter).
    Called by: requisition tab route.
    Depends on: brand palette, HTMX, Alpine.js.
 #}
+{% from 'htmx/partials/offers/_field_macros.html' import qual_badge %}
 <div x-data="{ selectedOffers: [] }">
 
   {# ── Add Offer dropdown ────────────────────────────────── #}
@@ -45,6 +47,19 @@
 
   {# Area where parse forms and results appear #}
   <div id="parse-area" class="mb-4"></div>
+
+  {# Qualification status filter pills #}
+  <div class="flex flex-wrap items-center gap-2 mb-4">
+    {% for s, label in [('', 'All'), ('unset', 'Unset'), ('incomplete', 'Incomplete'), ('essentials', 'Essentials'), ('complete', 'Complete')] %}
+    <button class="px-3 py-1.5 text-sm font-medium rounded-full transition-colors
+                   {% if qual == s %}bg-brand-500 text-white shadow-sm{% else %}bg-brand-100 text-brand-600 hover:bg-brand-200{% endif %}"
+            hx-get="/v2/partials/requisitions/{{ req.id }}/tab/offers?qual={{ s }}"
+            hx-target="#tab-content"
+            hx-swap="innerHTML">
+      {{ label }}
+    </button>
+    {% endfor %}
+  </div>
 
   {% if offers %}
   {# Action bar — appears when offers are selected #}
@@ -162,9 +177,12 @@
               "draft": "bg-brand-100 text-brand-600",
               "sold": "bg-gray-100 text-gray-600"
             } %}
-            <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ offer_colors.get(o.status, 'bg-gray-100 text-gray-600') }}">
-              {{ (o.status or 'unknown')|replace('_', ' ')|capitalize }}
-            </span>
+            <div class="flex items-center gap-1 flex-wrap">
+              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ offer_colors.get(o.status, 'bg-gray-100 text-gray-600') }}">
+                {{ (o.status or 'unknown')|replace('_', ' ')|capitalize }}
+              </span>
+              {{ qual_badge(o) }}
+            </div>
           </td>
           <td class="px-4 py-2.5 text-center" x-data="{ open: false }">
             <div class="relative inline-block">

--- a/app/templates/htmx/partials/requisitions/tabs/offers.html
+++ b/app/templates/htmx/partials/requisitions/tabs/offers.html
@@ -52,7 +52,7 @@
   <div class="flex flex-wrap items-center gap-2 mb-4">
     {% for s, label in [('', 'All'), ('unset', 'Unset'), ('incomplete', 'Incomplete'), ('essentials', 'Essentials'), ('complete', 'Complete')] %}
     <button class="px-3 py-1.5 text-sm font-medium rounded-full transition-colors
-                   {% if qual == s %}bg-brand-500 text-white shadow-sm{% else %}bg-brand-100 text-brand-600 hover:bg-brand-200{% endif %}"
+                   {% if (qual or '') == s %}bg-brand-500 text-white shadow-sm{% else %}bg-brand-100 text-brand-600 hover:bg-brand-200{% endif %}"
             hx-get="/v2/partials/requisitions/{{ req.id }}/tab/offers?qual={{ s }}"
             hx-target="#tab-content"
             hx-swap="innerHTML">
@@ -259,8 +259,13 @@
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
             d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
     </svg>
+    {% if qual %}
+    <p class="text-sm font-medium text-gray-500 mt-3">No offers match this filter.</p>
+    <p class="text-xs text-gray-400 mt-1">Try selecting a different filter above or clear the filter to see all offers.</p>
+    {% else %}
     <p class="text-sm font-medium text-gray-500 mt-3">No offers received yet.</p>
     <p class="text-xs text-gray-400 mt-1">Offers appear here when vendors respond to RFQs or when leads are promoted.</p>
+    {% endif %}
   </div>
   {% endif %}
 </div>

--- a/tests/test_htmx_views_nightly23.py
+++ b/tests/test_htmx_views_nightly23.py
@@ -386,6 +386,43 @@ class TestAddOfferDirect:
             await add_offer(request=mock_req, req_id=99999, user=test_user, db=db_session)
         assert exc_info.value.status_code == 404
 
+    async def test_add_offer_relaxed_gate_missing_manufacturer_returns_200(self, db_session: Session, test_user: User):
+        """Relaxed gate: condition=new without manufacturer must return 200 (not 400).
+
+        Regression guard: before the gate removal this returned 400. After, the offer
+        is created with qualification_status='incomplete' (composed but not blocked).
+        """
+        from app.routers.htmx_views import add_offer
+
+        req = _make_requisition(db_session, test_user)
+        mock_req = _mock_form_request(
+            path=f"/v2/partials/requisitions/{req.id}/add-offer",
+            fields={
+                "vendor_name": "GateTestVendor",
+                "mpn": "LM7805",
+                "qty_available": "50",
+                "unit_price": "0.99",
+                "condition": "new",
+                # manufacturer intentionally omitted — was a gate trigger
+            },
+        )
+        with patch("app.routers.htmx_views.requisition_tab", new_callable=AsyncMock) as mock_tab:
+            mock_tab.return_value = HTMLResponse("tab OK")
+            result = await add_offer(request=mock_req, req_id=req.id, user=test_user, db=db_session)
+        assert result.status_code == 200, (
+            f"Expected 200 (gate relaxed) but got {result.status_code}; body: {result.body}"
+        )
+        # Verify the offer was persisted with qualification_status='incomplete'
+        from app.models.offers import Offer as OfferModel
+
+        offer = (
+            db_session.query(OfferModel).filter(OfferModel.requisition_id == req.id, OfferModel.mpn == "LM7805").first()
+        )
+        assert offer is not None, "Offer was not created"
+        assert offer.qualification_status == "incomplete", (
+            f"Expected qualification_status='incomplete', got {offer.qualification_status!r}"
+        )
+
 
 # ── edit_offer (2152–2215) ────────────────────────────────────────────────
 

--- a/tests/test_offer_qualification_routes.py
+++ b/tests/test_offer_qualification_routes.py
@@ -307,3 +307,51 @@ def test_offer_mutation_happy_path(
     kwargs = {"data": data} if data else {}
     resp = getattr(client, method)(url, **kwargs)
     assert resp.status_code == 200, f"Expected 200 for {method.upper()} {url}, got {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Qualification-status filter facet on Offers tab
+# ---------------------------------------------------------------------------
+
+
+def test_offers_tab_qual_filter_server_side(client, db_session, test_requisition, test_user):
+    """GET /v2/partials/requisitions/{req_id}/tab/offers?qual=incomplete returns only
+    the incomplete offer; without qual returns both.
+
+    Filter is index-backed WHERE clause, not Python post-filter.
+    """
+    rid = test_requisition.requirements[0].id
+    o_incomplete = Offer(
+        requisition_id=test_requisition.id,
+        requirement_id=rid,
+        vendor_name="FilterVendorIncomplete",
+        mpn="FILTMPN1",
+        qualification_status="incomplete",
+        entered_by_id=test_user.id,
+    )
+    o_complete = Offer(
+        requisition_id=test_requisition.id,
+        requirement_id=rid,
+        vendor_name="FilterVendorComplete",
+        mpn="FILTMPN2",
+        qualification_status="complete",
+        entered_by_id=test_user.id,
+    )
+    db_session.add_all([o_incomplete, o_complete])
+    db_session.commit()
+
+    req_id = test_requisition.id
+
+    # Filtered: only incomplete
+    resp = client.get(f"/v2/partials/requisitions/{req_id}/tab/offers?qual=incomplete")
+    assert resp.status_code == 200
+    body = resp.content
+    assert b"FilterVendorIncomplete" in body
+    assert b"FilterVendorComplete" not in body
+
+    # Unfiltered: both visible
+    resp_all = client.get(f"/v2/partials/requisitions/{req_id}/tab/offers")
+    assert resp_all.status_code == 200
+    body_all = resp_all.content
+    assert b"FilterVendorIncomplete" in body_all
+    assert b"FilterVendorComplete" in body_all

--- a/tests/test_offer_qualification_routes.py
+++ b/tests/test_offer_qualification_routes.py
@@ -355,3 +355,16 @@ def test_offers_tab_qual_filter_server_side(client, db_session, test_requisition
     body_all = resp_all.content
     assert b"FilterVendorIncomplete" in body_all
     assert b"FilterVendorComplete" in body_all
+
+    # FIX 1: "All" pill must carry the active class when no qual param is sent.
+    assert b"bg-brand-500" in body_all, "All pill should be active (bg-brand-500) when no qual filter"
+
+    # FIX 2: filter-aware empty state — ?qual=essentials on a req with only incomplete/complete offers.
+    resp_empty = client.get(f"/v2/partials/requisitions/{req_id}/tab/offers?qual=essentials")
+    assert resp_empty.status_code == 200
+    body_empty = resp_empty.content
+    assert b"FilterVendorIncomplete" not in body_empty
+    assert b"FilterVendorComplete" not in body_empty
+    assert b"No offers match this filter" in body_empty, (
+        "Filter-aware empty copy should appear when qual is set and no results"
+    )

--- a/tests/test_offer_qualification_routes.py
+++ b/tests/test_offer_qualification_routes.py
@@ -213,3 +213,97 @@ def test_modal_open_prefills_country_from_last_vendor_offer(client, db_session, 
     resp = client.get(f"/v2/partials/sightings/{rid}/offer-form", params={"vendor_name": "MemVendor"})
     assert resp.status_code == 200
     assert b"JP" in resp.content  # country prefilled into the form
+
+
+# ---------------------------------------------------------------------------
+# IDOR scope guard — mutation routes (review / reconfirm / mark-sold / delete)
+# ---------------------------------------------------------------------------
+
+
+def _make_cross_req_offer(db_session, test_requisition, test_user, status="active"):
+    """Return (own_req_id, other_req_id, offer_on_other_req).
+
+    Creates a second Requirement under the same Requisition and attaches an Offer to
+    *that* one, so POSTing under the first requirement's path hits the IDOR guard.
+    """
+    from app.models.sourcing import Requirement
+
+    own_rid = test_requisition.requirements[0].id
+    other = Requirement(requisition_id=test_requisition.id, primary_mpn="CROSS123", target_qty=1)
+    db_session.add(other)
+    db_session.commit()
+    o = Offer(
+        requisition_id=test_requisition.id,
+        requirement_id=other.id,
+        vendor_name="CrossVendor",
+        mpn="CROSS123",
+        status=status,
+        qualification={},
+        entered_by_id=test_user.id,
+    )
+    db_session.add(o)
+    db_session.commit()
+    return own_rid, other.id, o
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "method,path_suffix,data,initial_status",
+    [
+        ("post", "/review", {"action": "approve"}, "pending_review"),
+        ("post", "/reconfirm", {}, "active"),
+        ("post", "/mark-sold", {}, "active"),
+        ("delete", "", {}, "active"),
+    ],
+    ids=["review", "reconfirm", "mark-sold", "delete"],
+)
+def test_offer_mutation_idor_guard(
+    client, db_session, test_requisition, test_user, method, path_suffix, data, initial_status
+):
+    """IDOR guard: mutating an offer that belongs to a DIFFERENT requirement via path
+    → 404 and the offer is NOT mutated."""
+    own_rid, _other_rid, o = _make_cross_req_offer(db_session, test_requisition, test_user, status=initial_status)
+    url = f"/v2/partials/sightings/{own_rid}/offers/{o.id}{path_suffix}"
+    kwargs = {"data": data} if data else {}
+    resp = getattr(client, method)(url, **kwargs)
+    assert resp.status_code == 404, f"Expected 404 for {method.upper()} {url}, got {resp.status_code}"
+
+    db_session.expire(o)
+    db_session.refresh(o)
+    # Offer must NOT have been mutated: status unchanged and still exists.
+    assert o.status == initial_status, "Offer status was mutated despite IDOR guard"
+    assert db_session.get(type(o), o.id) is not None, "Offer was deleted despite IDOR guard"
+
+
+@pytest.mark.parametrize(
+    "method,path_suffix,data,initial_status",
+    [
+        ("post", "/review", {"action": "approve"}, "pending_review"),
+        ("post", "/reconfirm", {}, "active"),
+        ("post", "/mark-sold", {}, "active"),
+        ("delete", "", {}, "active"),
+    ],
+    ids=["review", "reconfirm", "mark-sold", "delete"],
+)
+def test_offer_mutation_happy_path(
+    client, db_session, test_requisition, test_user, method, path_suffix, data, initial_status
+):
+    """Happy path: mutating an offer that correctly belongs to the path requirement → 200."""
+    rid = test_requisition.requirements[0].id
+    o = Offer(
+        requisition_id=test_requisition.id,
+        requirement_id=rid,
+        vendor_name="HappyVendor",
+        mpn="LM317T",
+        status=initial_status,
+        qualification={},
+        entered_by_id=test_user.id,
+    )
+    db_session.add(o)
+    db_session.commit()
+    url = f"/v2/partials/sightings/{rid}/offers/{o.id}{path_suffix}"
+    kwargs = {"data": data} if data else {}
+    resp = getattr(client, method)(url, **kwargs)
+    assert resp.status_code == 200, f"Expected 200 for {method.upper()} {url}, got {resp.status_code}"


### PR DESCRIPTION
Three follow-ups to the offer-qualification feature (#356). Each independently reviewed.

## What
- **Relax the hard-gate to sightings-only** — the requisitions *Add Manual Offer* / inline-edit now COMPOSE the standardized note + status but no longer hard-block on missing essentials (less friction on quick entry); the sightings convert flow keeps its gate. (`apply_qualification` retained; `validate_essentials→400` removed from `htmx_views.add_offer`/`edit_offer`.)
- **IDOR sweep** — 4 sightings offer-mutation routes (review / reconfirm / mark-sold / delete) loaded the offer by id without binding it to the path requirement. Scoped all four (`offer.requirement_id != requirement_id → 404`), matching the already-shipped sibling pattern. crm/offers primitives untouched.
- **Qualification filter facet** — segmented pills (All / Unset / Incomplete / Essentials / Complete) on the requisitions Offers tab, server-side index-backed WHERE on `qualification_status`, plus the per-row qual badge.

## Tests
17,461 pass. New: relaxed-gate (200 + status=incomplete), IDOR guards (404 + non-mutation across 4 routes, parametrized), filter (server-side, All-pill active, filter-aware empty copy).

> ⚠️ The single full-suite failure (`test_activity_audit_followup.py::test_log_phone_call_uses_canonical_call_logged`, `is_meaningful`) is **pre-existing on `main`** (verified on a pristine origin/main checkout) and unrelated to this PR — it belongs to the activity-audit work, flagged separately.

No migration. Held as a fast-follow: wiring #7 vendor-requests to actually send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)