### PR TITLE
feat(offers): wire #7 vendor-requests to actually send

### DIFF
--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -2817,9 +2817,12 @@ async def sightings_offer_request(
 ):
     """Log a pending vendor request (images / FPQ / cert / pkg qty) on an offer.
 
-    v1: logs the request to offer.qualification['requests'] and returns the drafted
-    RFQ-back line as a toast. Does NOT send email — the buyer copies the draft into
-    the existing solicit modal (Contact.requisition_id NOT NULL caveat out of scope).
+    Logs the request to offer.qualification['requests'] (status="pending") and returns
+    the drafted RFQ-back line as a toast. This route is require_buyer-only (NO Graph
+    token) so logging never 401s on an expired token. Sending a logged PENDING request
+    as a real email is now available on demand via the separate token-bearing route
+    `.../offers/{offer_id}/request/{index}/send` (sightings_offer_request_send) — the
+    buyer no longer has to copy the draft into the solicit modal by hand.
     """
     from datetime import datetime, timezone
 
@@ -2848,3 +2851,156 @@ async def sightings_offer_request(
     db.commit()
     db.expire_all()
     return _append_oob_toast(_refresh_offers_panel(request, requirement_id, db), f"Logged request: {draft}")
+
+
+@router.post(
+    "/v2/partials/sightings/{requirement_id}/offers/{offer_id}/request/{index}/send",
+    response_class=HTMLResponse,
+)
+async def sightings_offer_request_send(
+    request: Request,
+    requirement_id: int,
+    offer_id: int,
+    index: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_buyer),
+    token: str = Depends(require_fresh_token),
+):
+    """Send a previously-logged PENDING #7 vendor request as a real RFQ-back email.
+
+    Distinct from the logging route (sightings_offer_request) on purpose: this route
+    also requires a fresh Graph token (require_fresh_token) so the actual send fails
+    loudly on an expired token, while LOGGING a request never 401s. `index` addresses
+    the entry in offer.qualification['requests'] (append-only, so the index is stable).
+
+    Flow: resolve the vendor's best contact email (_best_contacts_by_card, mirroring the
+    batch send-inquiry path), draft the request body via request_template, and hand a
+    single vendor group to send_batch_rfq with the SCALAR requisition_id (single-req
+    mode; passing both the scalar and a parts-map raises ValueError). send_batch_rfq
+    commits internally and can expire the session, so the entry-status update is applied
+    AFTER it returns against a freshly re-fetched offer. Idempotent on an already-"sent"
+    entry; a single request is logged as an outreach activity but does NOT auto-progress
+    the sourcing status (one clarification is not a full RFQ round).
+    """
+    from datetime import datetime, timezone
+
+    from ..email_service import send_batch_rfq
+    from ..services.offer_qualification import request_template
+
+    offer = db.get(Offer, offer_id)
+    # Scope the offer to the path requirement (prevents cross-requirement IDOR via a
+    # guessed offer_id); 404 if the offer is missing or belongs to another requirement.
+    if offer is None or offer.requirement_id != requirement_id:
+        raise HTTPException(status_code=404, detail={"error": "offer not found for this requirement"})
+
+    q = dict(offer.qualification or {})
+    reqs = list(q.get("requests") or [])
+    if index < 0 or index >= len(reqs):
+        raise HTTPException(status_code=404, detail={"error": "request not found"})
+    # Copy the entry into a fresh nested dict (the dict()/list() above are SHALLOW, so
+    # reqs[index] is still the committed-JSON baseline object — see the post-send block).
+    entry = dict(reqs[index])
+    reqs[index] = entry
+
+    # Idempotency: a request already sent is never re-sent (the entry is the durable
+    # record of the outreach). Surface an info toast, leave state untouched.
+    if entry.get("status") == "sent":
+        return _append_oob_toast(
+            _refresh_offers_panel(request, requirement_id, db),
+            "Request already sent",
+            "info",
+        )
+
+    # Requisition guard: Contact.requisition_id is NOT NULL, so send_batch_rfq can write
+    # no tracking row without a requisition. An offer with no requisition (unsolicited
+    # inbound) is marked "skipped" rather than firing an untracked email.
+    if offer.requisition_id is None:
+        entry["status"] = "skipped"
+        q["requests"] = reqs
+        offer.qualification = q
+        db.commit()
+        return _append_oob_toast(
+            _refresh_offers_panel(request, requirement_id, db),
+            "No requisition on this offer — not sent",
+            "warning",
+        )
+
+    # Resolve the vendor's BEST contact email exactly as the batch send path does:
+    # worst-first ordering + last-wins dict so a real email always beats a NULL/'' row.
+    contact_map = (
+        {c.vendor_card_id: c for c in _best_contacts_by_card(db, [offer.vendor_card_id])}
+        if offer.vendor_card_id
+        else {}
+    )
+    contact = contact_map.get(offer.vendor_card_id)
+    vendor_email = contact.email if contact and contact.email else ""
+
+    draft = request_template(entry["kind"], offer.mpn)
+    requirement = db.get(Requirement, requirement_id)
+    parts = [{"mpn": offer.mpn, "qty": requirement.target_qty if requirement else None}]
+
+    # Single-requisition mode: pass the SCALAR requisition_id (one Contact row, parts
+    # from the vendor group). Passing requisition_parts_map AS WELL would raise ValueError.
+    results = await send_batch_rfq(
+        token=token,
+        db=db,
+        user_id=user.id,
+        requisition_id=offer.requisition_id,
+        vendor_groups=[
+            {
+                "vendor_name": offer.vendor_name,
+                "vendor_email": vendor_email,
+                "parts": parts,
+                "subject": f"Request: {entry['kind']} — {offer.mpn}",
+                "body": draft,
+            }
+        ],
+    )
+
+    # CRITICAL: send_batch_rfq does its own db.commit() and can expire the session, so
+    # re-fetch the offer and re-read the requests list before mutating the entry status.
+    offer = db.get(Offer, offer_id)
+    q = dict(offer.qualification or {})
+    reqs = list(q.get("requests") or [])
+    # COPY the target entry into a fresh nested dict before mutating: dict(q)/list(reqs)
+    # are SHALLOW, so reqs[index] is still the SAME object SQLAlchemy holds as the
+    # committed JSON baseline. Mutating it in place would make the new value equal the
+    # (already-mutated) old value and the JSON flush would write nothing. Re-slotting a
+    # fresh dict keeps the change detectable.
+    entry = dict(reqs[index])
+    reqs[index] = entry
+
+    r = results[0]
+    if r["status"] == "sent":
+        entry["status"] = "sent"
+        entry["contact_id"] = r.get("id")
+        entry["sent_at"] = datetime.now(timezone.utc).isoformat()
+        toast_msg, toast_level = (f"Request sent to {offer.vendor_name}", "success")
+        # Log the outreach (mirrors sightings_send_inquiry's rfq_sent), but deliberately
+        # NO auto_progress: one clarification request is not a full RFQ round.
+        log_rfq_activity(
+            db=db,
+            rfq_id=offer.requisition_id,
+            activity_type="rfq_sent",
+            description=f"Requested {entry['kind']} from {offer.vendor_name}",
+            user_id=user.id,
+            requirement_id=requirement_id,
+        )
+    elif r["status"] == "skipped":
+        entry["status"] = "skipped"
+        toast_msg, toast_level = ("Not sent — no contact email on file", "warning")
+    else:
+        entry["status"] = "failed"
+        entry["error"] = r.get("error")
+        toast_msg, toast_level = (f"Send failed for {offer.vendor_name}", "error")
+
+    # Reassign a NEW dict so SQLAlchemy's JSON change detection persists the mutation.
+    q["requests"] = reqs
+    offer.qualification = q
+    db.commit()
+
+    return _append_oob_toast(
+        _refresh_offers_panel(request, requirement_id, db),
+        toast_msg,
+        toast_level,
+    )

--- a/app/templates/htmx/partials/sightings/_offer_row.html
+++ b/app/templates/htmx/partials/sightings/_offer_row.html
@@ -106,8 +106,13 @@
     {% set requests = q.get('requests', []) %}
     {% if requests %}
     {% set kind_display = {'images': 'Images', 'fpq': 'FPQ', 'cert': 'Cert', 'pkg_qty': 'Pkg qty'} %}
-    {% set status_colors = {'pending': 'bg-amber-50 text-amber-700', 'sent': 'bg-blue-50 text-blue-700'} %}
-    <div class="flex flex-wrap gap-1 pt-0.5">
+    {% set status_colors = {
+      'pending': 'bg-amber-50 text-amber-700',
+      'sent': 'bg-blue-50 text-blue-700',
+      'skipped': 'bg-amber-100 text-amber-600',
+      'failed': 'bg-rose-50 text-rose-700',
+    } %}
+    <div class="flex flex-wrap items-center gap-1 pt-0.5">
       {% for r in requests %}
       {% set r_kind = r.get('kind', '') %}
       {% set r_status = r.get('status', '') %}
@@ -115,6 +120,14 @@
       <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full {{ color }}">
         {{ kind_display.get(r_kind, r_kind|capitalize) }}{% if r_status != 'pending' %} — {{ r_status }}{% endif %}
       </span>
+      {# Per-PENDING Send control: fires the token-bearing send route for this entry. #}
+      {% if r_status == 'pending' %}
+      <button hx-post="/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/request/{{ loop.index0 }}/send"
+              hx-target="#sightings-offers-panel" hx-swap="innerHTML" data-loading-disable
+              class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded border border-blue-200 bg-white text-blue-600 hover:bg-blue-50 hover:border-blue-300 transition-colors">
+        Send
+      </button>
+      {% endif %}
       {% endfor %}
     </div>
     {% endif %}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -621,11 +621,33 @@ extra form step required.
 
 **One-tap vendor requests (#7).** `POST .../offers/{offer_id}/request` (scoped to
 the path's `requirement_id` to prevent IDOR) accepts `kind` ∈ `REQUEST_KINDS`
-(`images`/`fpq`/`cert`/`pkg_qty`). v1: logs the pending request into
-`offer.qualification["requests"]` and drafts the request text via `request_template`;
-does NOT auto-send email (the existing solicit modal sends). The `offer_id` is
-validated against the `requirement_id` path parameter so a buyer can only request
-on their own requirement's offers.
+(`images`/`fpq`/`cert`/`pkg_qty`). Logs the pending request into
+`offer.qualification["requests"]` (status `"pending"`) and drafts the request text via
+`request_template`. This route is `require_buyer`-only (NO Graph token) so logging
+never 401s on an expired M365 token. The `offer_id` is validated against the
+`requirement_id` path parameter so a buyer can only request on their own requirement's
+offers.
+
+**Sending a logged request (#7 send).** `POST .../offers/{offer_id}/request/{index}/send`
+(`sightings_offer_request_send`) sends a single PENDING entry as a real RFQ-back email.
+This is a SEPARATE, token-bearing route: it adds `require_fresh_token` on top of
+`require_buyer` so the actual send fails loudly on an expired token while LOGGING never
+does. `{index}` addresses the append-only `qualification["requests"]` list (stable
+index). It resolves the vendor's best contact email via `_best_contacts_by_card`
+(mirroring the batch send-inquiry path), drafts the body with `request_template`, and
+hands ONE vendor group to `send_batch_rfq` with the SCALAR `requisition_id`
+(single-requisition mode — passing the scalar AND a parts-map raises `ValueError`).
+Because `send_batch_rfq` commits internally and can expire the session, the entry-status
+update is applied AFTER it returns against a freshly re-fetched offer (and the mutated
+entry is re-slotted as a fresh nested dict so the JSON column flush is detectable — a
+shallow copy would mutate the committed baseline and persist nothing). Outcomes per
+entry: `sent` (records `contact_id`/`sent_at` and logs an `rfq_sent` activity, but does
+NOT auto-progress the sourcing status — one clarification is not a full RFQ round),
+`skipped` (no contact email, OR `offer.requisition_id is None` since
+`Contact.requisition_id` is NOT NULL — guarded BEFORE any send), `failed` (records the
+error). Idempotent: an already-`sent` entry is a no-op. The template shows a per-PENDING
+**Send** button next to each pending request pill (`status_colors` adds `skipped`/`failed`
+states).
 
 **Live badge/meter vs. stored snapshot.** `Offer.qualification_summary` (property)
 recomputes status+meter live from the current column values — the display badge always

--- a/tests/test_offer_qualification_routes.py
+++ b/tests/test_offer_qualification_routes.py
@@ -128,6 +128,164 @@ def test_request_scoped_to_requirement_blocks_cross_requirement_offer(client, db
     assert (o.qualification or {}).get("requests", []) == []  # not mutated
 
 
+def _seed_offer_with_pending_request(db_session, test_requisition, test_user, test_vendor_card, *, vendor_email="x"):
+    """Offer (req + requisition + vendor card) carrying one pending #7 request.
+
+    `vendor_email` only documents intent; the actual contact email is created by the
+    test_vendor_contact fixture when requested. Returns (requirement_id, offer).
+    """
+    from app.models.offers import Offer
+
+    rid = test_requisition.requirements[0].id
+    o = Offer(
+        requisition_id=test_requisition.id,
+        requirement_id=rid,
+        vendor_card_id=test_vendor_card.id,
+        vendor_name="Arrow Electronics",
+        mpn="LM317T",
+        qualification={
+            "requests": [
+                {"kind": "images", "status": "pending", "requested_at": "2026-06-17T00:00:00+00:00", "contact_id": None}
+            ]
+        },
+        entered_by_id=test_user.id,
+    )
+    db_session.add(o)
+    db_session.commit()
+    return rid, o
+
+
+def test_request_send_marks_entry_sent(
+    client, db_session, test_requisition, test_user, test_vendor_card, test_vendor_contact, monkeypatch
+):
+    """Send a logged pending request → mocked send_batch_rfq returns 'sent' → the entry
+    flips to status='sent' with contact_id set; 200."""
+    import app.email_service as email_service
+
+    async def _fake_send(**kwargs):
+        return [{"id": 777, "vendor_name": "Arrow Electronics", "vendor_email": "john@arrow.com", "status": "sent"}]
+
+    monkeypatch.setattr(email_service, "send_batch_rfq", _fake_send)
+
+    rid, o = _seed_offer_with_pending_request(db_session, test_requisition, test_user, test_vendor_card)
+    resp = client.post(f"/v2/partials/sightings/{rid}/offers/{o.id}/request/0/send")
+    assert resp.status_code == 200
+    db_session.expire(o)
+    db_session.refresh(o)
+    entry = o.qualification["requests"][0]
+    assert entry["status"] == "sent"
+    assert entry["contact_id"] == 777
+    assert entry.get("sent_at")
+
+
+def test_request_send_no_email_marks_skipped(
+    client, db_session, test_requisition, test_user, test_vendor_card, monkeypatch
+):
+    """No resolvable contact email → send_batch_rfq returns 'skipped' →
+    entry='skipped'."""
+    import app.email_service as email_service
+
+    async def _fake_send(**kwargs):
+        return [
+            {
+                "vendor_name": "Arrow Electronics",
+                "vendor_email": "",
+                "status": "skipped",
+                "error": "no contact email on file",
+            }
+        ]
+
+    monkeypatch.setattr(email_service, "send_batch_rfq", _fake_send)
+
+    # No test_vendor_contact fixture → the card has no VendorContact email.
+    rid, o = _seed_offer_with_pending_request(db_session, test_requisition, test_user, test_vendor_card)
+    resp = client.post(f"/v2/partials/sightings/{rid}/offers/{o.id}/request/0/send")
+    assert resp.status_code == 200
+    db_session.expire(o)
+    db_session.refresh(o)
+    assert o.qualification["requests"][0]["status"] == "skipped"
+
+
+def test_request_send_idempotent_when_already_sent(
+    client, db_session, test_requisition, test_user, test_vendor_card, test_vendor_contact, monkeypatch
+):
+    """An already-sent entry is a no-op: send_batch_rfq is NOT called again."""
+    import app.email_service as email_service
+
+    calls = {"n": 0}
+
+    async def _fake_send(**kwargs):
+        calls["n"] += 1
+        return [{"id": 1, "vendor_name": "Arrow Electronics", "vendor_email": "john@arrow.com", "status": "sent"}]
+
+    monkeypatch.setattr(email_service, "send_batch_rfq", _fake_send)
+
+    rid, o = _seed_offer_with_pending_request(db_session, test_requisition, test_user, test_vendor_card)
+    # Pre-mark the entry as already sent.
+    o.qualification = {"requests": [{"kind": "images", "status": "sent", "contact_id": 5}]}
+    db_session.commit()
+
+    resp = client.post(f"/v2/partials/sightings/{rid}/offers/{o.id}/request/0/send")
+    assert resp.status_code == 200
+    assert calls["n"] == 0  # never re-sent
+    db_session.expire(o)
+    db_session.refresh(o)
+    assert o.qualification["requests"][0]["status"] == "sent"
+
+
+def test_request_send_no_requisition_marks_skipped_without_sending(
+    client, db_session, test_requisition, test_user, test_vendor_card, monkeypatch
+):
+    """Requisition guard: an offer with requisition_id=None is marked 'skipped' and
+    send_batch_rfq is NEVER called (Contact.requisition_id is NOT NULL)."""
+    import app.email_service as email_service
+    from app.models.offers import Offer
+
+    calls = {"n": 0}
+
+    async def _fake_send(**kwargs):
+        calls["n"] += 1
+        return [{"status": "sent", "id": 1}]
+
+    monkeypatch.setattr(email_service, "send_batch_rfq", _fake_send)
+
+    rid = test_requisition.requirements[0].id
+    o = Offer(
+        requisition_id=None,  # unsolicited inbound — no requisition
+        requirement_id=rid,
+        vendor_card_id=test_vendor_card.id,
+        vendor_name="Arrow Electronics",
+        mpn="LM317T",
+        qualification={"requests": [{"kind": "images", "status": "pending", "contact_id": None}]},
+        entered_by_id=test_user.id,
+    )
+    db_session.add(o)
+    db_session.commit()
+    resp = client.post(f"/v2/partials/sightings/{rid}/offers/{o.id}/request/0/send")
+    assert resp.status_code == 200
+    assert calls["n"] == 0  # never attempted a send
+    db_session.expire(o)
+    db_session.refresh(o)
+    assert o.qualification["requests"][0]["status"] == "skipped"
+
+
+def test_request_send_cross_requirement_offer_is_404(client, db_session, test_requisition, test_user):
+    """IDOR guard: sending on an offer that belongs to another requirement → 404."""
+    own_rid, _other_rid, o = _make_cross_req_offer(db_session, test_requisition, test_user)
+    # Give it a pending request so only the IDOR guard (not index range) can 404.
+    o.qualification = {"requests": [{"kind": "images", "status": "pending"}]}
+    db_session.commit()
+    resp = client.post(f"/v2/partials/sightings/{own_rid}/offers/{o.id}/request/0/send")
+    assert resp.status_code == 404
+
+
+def test_request_send_out_of_range_index_is_404(client, db_session, test_requisition, test_user, test_vendor_card):
+    """An index past the end of the requests list → 404 'request not found'."""
+    rid, o = _seed_offer_with_pending_request(db_session, test_requisition, test_user, test_vendor_card)
+    resp = client.post(f"/v2/partials/sightings/{rid}/offers/{o.id}/request/9/send")
+    assert resp.status_code == 404
+
+
 def test_sightings_edit_merges_qualification_preserving_requests(client, db_session, test_requisition, test_user):
     """Regression: editing an unrelated field must MERGE (not overwrite) the qualification
     JSON — the logged #7 requests array and the stored `usage` survive, and the merged


### PR DESCRIPTION
Final follow-up to the offer-qualification feature — wires the #7 "request from vendor" chips to actually send the RFQ-back, instead of only logging + drafting.

## What
- **New token-bearing route** `POST /v2/partials/sightings/{requirement_id}/offers/{offer_id}/request/{index}/send` (deps `require_buyer` + `require_fresh_token`) — sends a specific PENDING request entry via the existing `send_batch_rfq`, using the offer's own requisition (no scratch req; `Contact.requisition_id` NOT NULL satisfied). The logging route stays `require_buyer`-only so logging never 401s on an expired Graph token.
- **Per-pending "Send" button** on each logged request; status flows pending → sent / skipped (no vendor email) / failed, with matching pill colors.
- Idempotent (already-sent → no re-send), IDOR-scoped, bounds-checked, no auto-progress (a clarification request isn't a full RFQ round).

## Correctness notes
- The implementer caught a real SQLAlchemy JSON-persistence trap during RED (shallow copies left the entry pointing at the committed baseline → status silently stayed "pending"); fixed by re-slotting a fresh nested dict + reassigning `offer.qualification`. A refetch-based test now *proves* persistence.
- Post-send ordering is correct: `send_batch_rfq` commits internally, so the entry-status update happens after, against a re-fetched offer.

## Tests
17,477 pass. 6 new: sent (+contact_id, persisted via refetch), skipped (no email), no-requisition skip (send not called), idempotent already-sent, cross-req 404, out-of-range 404. No migration.

> ⚠️ The single full-suite failure (`test_activity_audit_followup.py::is_meaningful`) is the **pre-existing `main` red** (verified on pristine origin/main) — activity-audit work, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)