### PR TITLE
fix(activity): manual phone-logs are meaningful (P1e regression — unblocks CI)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -6363,6 +6363,12 @@ async def log_phone_call(
     )
     if log is not None:
         log.notes = notes or f"Called {vendor_name} at {vendor_phone}"
+        # A manually logged call is a deliberate human interaction → always meaningful,
+        # regardless of P1e's duration-gating in log_call_activity (which targets
+        # auto-captured Teams/8x8 calls that carry a real duration). Without this, a
+        # no-duration manual log lands is_meaningful=False and drops out of the
+        # meaningful-activity surfaces and the reply clock.
+        log.is_meaningful = True
     db.commit()
     logger.info("Phone call logged for req {} vendor {} by {}", req_id, vendor_name, user.email)
 


### PR DESCRIPTION
## TL;DR
`test_log_phone_call_uses_canonical_call_logged` is **not flaky** — it's a deterministic regression that's **red on `main`, blocking every PR's `test` job** (it killed CI on #374 and #382). This fixes it.

## Root cause
P1e (`c041f62a`, "duration-gated meaningful calls") changed the **shared** `log_call_activity` to set `is_meaningful` from call duration. Correct for **auto-captured** Teams/8x8 calls (real durations), but the **manual** log-phone endpoint passes `duration=None` → `is_meaningful=False`, so a deliberately hand-logged call dropped out of meaningful-activity surfaces + the reply clock, and the `#9` contract test went red.

## Fix
Scoped to the manual endpoint (`POST /v2/partials/requisitions/{id}/log-phone`) — **no change to `log_call_activity`** (concurrent P1e/P2d work edits it; its duration-gating tests must stay green). Force `is_meaningful=True` on the manually-logged row: a buyer who deliberately logs a call counts as a real interaction; auto-capture stays duration-gated.

## Verified
- `#9` test green; **all P1e (`test_p1e_call_teams_grading`) + activity-quality tests still pass** (92 passed targeted).
- Full suite: 17,471 passed (1 unrelated local-only failure: `test_static_public_image_served_from_dist` needs the Vite `dist` that CI builds but this worktree doesn't — passes in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwpL91Zg37qaSLhsNV1S8P