### PR TITLE
feat: parked offer follow-ups — add_offer_to_quote IDOR, market-baseline strip, call-meaningful hardening

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -8926,6 +8926,11 @@ async def add_offer_to_quote(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    if not (offer.requisition_id == quote.requisition_id or offer.requisition_id is None):
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "offer does not belong to this quote's requisition"},
+        )
     line = QuoteLine(
         quote_id=quote_id,
         offer_id=offer_id,

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -6357,6 +6357,9 @@ async def log_phone_call(
 
     # Route through log_call_activity so the call is matched to a vendor/company,
     # recorded as the canonical CALL_LOGGED type, and bumps last_activity_at.
+    # force_meaningful=True: a manually logged call is a deliberate human interaction →
+    # always meaningful, regardless of the duration-gate (which targets auto-captured
+    # Teams/8x8 calls that carry a real duration).
     log = log_call_activity(
         user_id=user.id,
         direction="outbound",
@@ -6366,15 +6369,10 @@ async def log_phone_call(
         contact_name=vendor_name,
         db=db,
         requisition_id=req_id,
+        force_meaningful=True,
     )
     if log is not None:
         log.notes = notes or f"Called {vendor_name} at {vendor_phone}"
-        # A manually logged call is a deliberate human interaction → always meaningful,
-        # regardless of P1e's duration-gating in log_call_activity (which targets
-        # auto-captured Teams/8x8 calls that carry a real duration). Without this, a
-        # no-duration manual log lands is_meaningful=False and drops out of the
-        # meaningful-activity surfaces and the reply clock.
-        log.is_meaningful = True
     db.commit()
     logger.info("Phone call logged for req {} vendor {} by {}", req_id, vendor_name, user.email)
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -8924,7 +8924,7 @@ async def add_offer_to_quote(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
-    if not (offer.requisition_id == quote.requisition_id or offer.requisition_id is None):
+    if offer.requisition_id is not None and offer.requisition_id != quote.requisition_id:
         raise HTTPException(
             status_code=403,
             detail={"error": "offer does not belong to this quote's requisition"},

--- a/app/routers/part_dossier.py
+++ b/app/routers/part_dossier.py
@@ -11,6 +11,11 @@ pointer (written by search_service.stream_search_mpn) to render cached vendor ro
 cache hit, else fires the existing /v2/partials/search/run SSE flow; a degraded-source
 banner (get_market_source_health) renders above both branches.
 
+A read-only market-baseline strip (compute_market_baseline) renders at the top of the
+Live-market section when cached rows are present, showing franchise-median price,
+authorized stock, and authorized source count — computed from cached rows, no new DB
+columns, no persistence.
+
 Called by: app/main.py (include_router); dossier_shell.html lazy-load divs.
 Depends on: services.part_history_service.get_part_history, services.fru_matrix_service
             .get_fru_view, search_service (_get_search_redis / _get_cached_search_results
@@ -44,6 +49,47 @@ router = APIRouter(tags=["part-dossier"])
 
 # Recent-searches landing cap (section 9 of the design spec).
 _RECENT_LIMIT = 12
+
+
+def compute_market_baseline(rows: list[dict]) -> dict:
+    """Compute a read-only franchise-price summary from already-fetched market rows.
+
+    Restricted to rows where ``is_authorized is True`` (franchise / authorized
+    distributor). Uses the same median algorithm as search_service._median.
+
+    Args:
+        rows: List of market-row dicts (same schema as cached_rows / vendor_card.html).
+              Each may carry ``unit_price`` (float|None), ``qty_available`` (int|None),
+              and ``is_authorized`` (bool, default False).
+
+    Returns:
+        A dict with keys:
+          - ``has_authorized``: bool — True if any authorized row exists.
+          - ``median_price``:   float|None — median of authorized unit_prices (non-None,
+                                >0 only); None when no such prices exist.
+          - ``total_stock``:    int|None — sum of authorized qty_available values (non-
+                                None only); None when no authorized row has a known qty.
+          - ``sources``:        int — count of authorized rows.
+
+    No DB access, no side-effects. Safe to call with an empty or all-non-authorized list.
+    """
+    auth_rows = [r for r in rows if r.get("is_authorized")]
+    if not auth_rows:
+        return {"has_authorized": False, "median_price": None, "total_stock": None, "sources": 0}
+
+    prices = [r["unit_price"] for r in auth_rows if r.get("unit_price") and r["unit_price"] > 0]
+    sorted_prices = sorted(prices)
+    median_price: float | None = sorted_prices[len(sorted_prices) // 2] if sorted_prices else None
+
+    known_qtys = [r["qty_available"] for r in auth_rows if r.get("qty_available") is not None]
+    total_stock: int | None = sum(known_qtys) if known_qtys else None
+
+    return {
+        "has_authorized": True,
+        "median_price": median_price,
+        "total_stock": total_stock,
+        "sources": len(auth_rows),
+    }
 
 
 def _ctx(request: Request, user: User) -> dict:
@@ -219,6 +265,8 @@ async def dossier_market(
         logger.warning("dossier_market source-health lookup failed mpn={}", mpn, exc_info=True)
         market_health = None
 
+    market_baseline = compute_market_baseline(cached_rows) if cached_rows else None
+
     ctx = _ctx(request, user)
     ctx.update(
         {
@@ -226,6 +274,7 @@ async def dossier_market(
             "cached_search_id": cached_search_id,
             "cached_rows": cached_rows,
             "market_health": market_health,
+            "market_baseline": market_baseline,
         }
     )
     return template_response("htmx/partials/search/dossier_market.html", ctx)

--- a/app/routers/part_dossier.py
+++ b/app/routers/part_dossier.py
@@ -51,47 +51,6 @@ router = APIRouter(tags=["part-dossier"])
 _RECENT_LIMIT = 12
 
 
-def compute_market_baseline(rows: list[dict]) -> dict:
-    """Compute a read-only franchise-price summary from already-fetched market rows.
-
-    Restricted to rows where ``is_authorized is True`` (franchise / authorized
-    distributor). Uses the same median algorithm as search_service._median.
-
-    Args:
-        rows: List of market-row dicts (same schema as cached_rows / vendor_card.html).
-              Each may carry ``unit_price`` (float|None), ``qty_available`` (int|None),
-              and ``is_authorized`` (bool, default False).
-
-    Returns:
-        A dict with keys:
-          - ``has_authorized``: bool — True if any authorized row exists.
-          - ``median_price``:   float|None — median of authorized unit_prices (non-None,
-                                >0 only); None when no such prices exist.
-          - ``total_stock``:    int|None — sum of authorized qty_available values (non-
-                                None only); None when no authorized row has a known qty.
-          - ``sources``:        int — count of authorized rows.
-
-    No DB access, no side-effects. Safe to call with an empty or all-non-authorized list.
-    """
-    auth_rows = [r for r in rows if r.get("is_authorized")]
-    if not auth_rows:
-        return {"has_authorized": False, "median_price": None, "total_stock": None, "sources": 0}
-
-    prices = [r["unit_price"] for r in auth_rows if r.get("unit_price") and r["unit_price"] > 0]
-    sorted_prices = sorted(prices)
-    median_price: float | None = sorted_prices[len(sorted_prices) // 2] if sorted_prices else None
-
-    known_qtys = [r["qty_available"] for r in auth_rows if r.get("qty_available") is not None]
-    total_stock: int | None = sum(known_qtys) if known_qtys else None
-
-    return {
-        "has_authorized": True,
-        "median_price": median_price,
-        "total_stock": total_stock,
-        "sources": len(auth_rows),
-    }
-
-
 def _ctx(request: Request, user: User) -> dict:
     """Shared base context.
 
@@ -233,7 +192,7 @@ async def dossier_market(
     900s). ``refresh=1`` (the "↻ Refresh market" button) skips the cache so the
     connector sweep re-runs.
     """
-    from ..search_service import _get_search_redis, get_market_source_health
+    from ..search_service import _get_search_redis, compute_market_baseline, get_market_source_health
 
     display_mpn = mpn.strip().upper()
     key = normalize_mpn_key(mpn)

--- a/app/routers/v13_features/activity.py
+++ b/app/routers/v13_features/activity.py
@@ -266,6 +266,7 @@ async def log_company_phone_call(
         contact_name=payload.contact_name,
         notes=payload.notes,
         db=db,
+        force_meaningful=True,
     )
     db.commit()
     return {"status": "logged", "activity_id": record.id}

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -93,6 +93,46 @@ def _median(values: list[float]) -> float | None:
     return s[len(s) // 2]
 
 
+def compute_market_baseline(rows: list[dict]) -> dict:
+    """Compute a read-only franchise-price summary from already-fetched market rows.
+
+    Restricted to rows where ``is_authorized is True`` (franchise / authorized
+    distributor). Uses ``_median`` for the upper-median price calculation.
+
+    Args:
+        rows: List of market-row dicts (same schema as cached_rows / vendor_card.html).
+              Each may carry ``unit_price`` (float|None), ``qty_available`` (int|None),
+              and ``is_authorized`` (bool, default False).
+
+    Returns:
+        A dict with keys:
+          - ``has_authorized``: bool — True if any authorized row exists.
+          - ``median_price``:   float|None — median of authorized unit_prices (non-None,
+                                >0 only); None when no such prices exist.
+          - ``total_stock``:    int|None — sum of authorized qty_available values (non-
+                                None only); None when no authorized row has a known qty.
+          - ``sources``:        int — count of authorized rows.
+
+    No DB access, no side-effects. Safe to call with an empty or all-non-authorized list.
+    """
+    auth_rows = [r for r in rows if r.get("is_authorized")]
+    if not auth_rows:
+        return {"has_authorized": False, "median_price": None, "total_stock": None, "sources": 0}
+
+    prices = [r["unit_price"] for r in auth_rows if r.get("unit_price") and r["unit_price"] > 0]
+    median_price = _median(prices)
+
+    known_qtys = [r["qty_available"] for r in auth_rows if r.get("qty_available") is not None]
+    total_stock: int | None = sum(known_qtys) if known_qtys else None
+
+    return {
+        "has_authorized": True,
+        "median_price": median_price,
+        "total_stock": total_stock,
+        "sources": len(auth_rows),
+    }
+
+
 # ── Search result cache (Redis, 15-min TTL) ─────────────────────────────
 
 _SEARCH_CACHE_TTL = 900  # 15 minutes

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -619,6 +619,7 @@ def log_company_call(
     contact_name: str | None,
     notes: str | None,
     db: Session,
+    force_meaningful: bool | None = None,
 ) -> ActivityLog:
     """Log a manual call against a company."""
     activity_type = ActivityType.CALL_LOGGED
@@ -632,7 +633,11 @@ def log_company_call(
         duration_seconds=duration_seconds,
         direction=direction,
         notes=notes,
-        is_meaningful=(duration_seconds is not None and duration_seconds >= CALL_MEANINGFUL_MIN_SECONDS),
+        is_meaningful=(
+            force_meaningful
+            if force_meaningful is not None
+            else (duration_seconds is not None and duration_seconds >= CALL_MEANINGFUL_MIN_SECONDS)
+        ),
     )
     db.add(record)
     db.flush()

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -335,6 +335,7 @@ def log_call_activity(
     subject: str | None = None,
     requisition_id: int | None = None,
     requirement_id: int | None = None,
+    force_meaningful: bool | None = None,
 ) -> ActivityLog | None:
     """Log a phone call activity."""
     direction = _normalize_direction(direction)
@@ -368,7 +369,11 @@ def log_call_activity(
         summary=subject,
         requisition_id=requisition_id,
         requirement_id=requirement_id,
-        is_meaningful=(duration_seconds is not None and duration_seconds >= CALL_MEANINGFUL_MIN_SECONDS),
+        is_meaningful=(
+            force_meaningful
+            if force_meaningful is not None
+            else (duration_seconds is not None and duration_seconds >= CALL_MEANINGFUL_MIN_SECONDS)
+        ),
     )
     db.add(record)
     db.flush()

--- a/app/templates/htmx/partials/search/dossier_market.html
+++ b/app/templates/htmx/partials/search/dossier_market.html
@@ -2,6 +2,8 @@
    Renders the degraded-source banner (best-effort) above two branches:
      • CACHE HIT  — cached_rows present → render the cached vendor rows directly
                     (vendor_card.html) + a freshness stamp + "↻ Refresh market".
+                    A read-only market-baseline strip (market_baseline) renders above the
+                    rows showing franchise-median price / authorized stock / source count.
      • CACHE MISS — an inner element auto-fires the EXISTING /v2/partials/search/run flow
                     (hx-post, hx-trigger="load"), returning results_shell.html's SSE
                     experience. The SSE engine is UNCHANGED — we just embed it. The banner
@@ -9,13 +11,48 @@
 
    Called by: part_dossier.dossier_market (GET /v2/partials/search/dossier/market).
    Depends on: mpn (display), cached_search_id (str|None), cached_rows (list[dict]|None),
-               market_health (dict|None), dossier_market_banner.html, results_shell.html /
-               vendor_card.html, $store.shortlist + lead-detail drawer (reused). #}
+               market_health (dict|None), market_baseline (dict|None),
+               dossier_market_banner.html, results_shell.html / vendor_card.html,
+               $store.shortlist + lead-detail drawer (reused). #}
 
 {% include "htmx/partials/search/dossier_market_banner.html" %}
 
 {% if cached_rows %}
 {# ── CACHE HIT — cached rows in the light market card ── #}
+
+{# ── Market-baseline strip (read-only, authorized rows only) ── #}
+{% if market_baseline %}
+<div class="px-4 py-2.5 border-b border-brand-100 bg-brand-50/60">
+  {% if market_baseline.has_authorized %}
+  <div class="flex flex-wrap items-center gap-x-6 gap-y-1 text-[11px]">
+    <span class="font-semibold text-brand-700 uppercase tracking-wide text-[10px]">Franchise baseline</span>
+    <span class="inline-flex items-center gap-1 text-gray-700">
+      <span class="text-gray-400">Median price</span>
+      {% if market_baseline.median_price is not none %}
+      <span class="font-mono font-semibold text-brand-900">${{ "%.4f"|format(market_baseline.median_price) }}</span>
+      {% else %}
+      <span class="text-gray-400 italic">n/a</span>
+      {% endif %}
+    </span>
+    <span class="inline-flex items-center gap-1 text-gray-700">
+      <span class="text-gray-400">Auth stock</span>
+      {% if market_baseline.total_stock is not none %}
+      <span class="font-semibold text-brand-900">{{ "{:,}".format(market_baseline.total_stock) }}</span>
+      {% else %}
+      <span class="text-gray-400 italic">unknown</span>
+      {% endif %}
+    </span>
+    <span class="inline-flex items-center gap-1 text-gray-700">
+      <span class="text-gray-400">Auth sources</span>
+      <span class="font-semibold text-brand-900">{{ market_baseline.sources }}</span>
+    </span>
+  </div>
+  {% else %}
+  <p class="text-[11px] text-gray-400 italic">No franchise/authorized pricing for this part.</p>
+  {% endif %}
+</div>
+{% endif %}
+
 <div class="px-4 py-2.5 border-b border-brand-100 flex items-center gap-3 text-[11px]">
   <span class="inline-flex items-center gap-1.5 text-gray-500">
     <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>cached

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -312,6 +312,10 @@ dossier_shell.html lazy-loads (each div has an explicit hx-target="this"):
     |     (or ?refresh=1) → inner div auto-fires the EXISTING POST /v2/partials/
     |     search/run SSE flow (results_shell.html). The banner sits OUTSIDE that
     |     hx-post div so it survives the cache-miss SSE swap.
+    |     On cache HIT a read-only market-baseline strip renders above the rows
+    |     (compute_market_baseline helper): franchise-median price, authorized stock,
+    |     and authorized source count — computed from cached rows, no new DB columns,
+    |     no persistence. Graceful empty state when no authorized rows exist.
     +-- GET /v2/partials/search/history?mpn=         (EXISTING search_history_panel)
     +-- GET /v2/partials/search/dossier/specs?mpn=   part_dossier.dossier_specs
 ```
@@ -324,6 +328,16 @@ freshest run. The search-flow templates (`dossier_shell` "Live market" section,
 `requisition_picker_modal`) use the **light brand-card skin** matching the rest of the
 site — the earlier dark "terminal" look was the visual outlier and has been removed.
 Page-level + per-row RFQ/offer actions (the quick-source endpoints) are wired.
+
+**Market-baseline strip (price-sanity step 1)** — `compute_market_baseline(rows)` in
+`app/routers/part_dossier.py` filters the already-fetched cached rows to
+`is_authorized=True` rows and computes: franchise-median price (same upper-median
+algorithm as `search_service._median`), authorized stock (sum of `qty_available`),
+and authorized source count. Passed as `market_baseline` to `dossier_market.html`,
+which renders a read-only strip above the vendor rows on cache HIT. No DB column,
+no persistence, no SSE change, no Alpine state — pure server-side summary. Graceful
+empty state ("No franchise/authorized pricing for this part.") when no authorized
+row exists. `market_baseline=None` on cache MISS (strip omitted entirely).
 
 **Degraded-source banner** — `search_service.get_market_source_health(db)` reuses
 `_build_connectors` to partition the live-market connectors into available / `down`

--- a/tests/test_activity_write_path.py
+++ b/tests/test_activity_write_path.py
@@ -398,6 +398,42 @@ def test_log_call_activity_force_meaningful(db_session, test_user, force_meaning
     assert rec.is_meaningful is expected
 
 
+def test_log_company_call_manual_is_meaningful(db_session, test_user, test_company):
+    """Manual company-call log (force_meaningful=True) is is_meaningful even with no
+    duration — mirrors the requisition log_call_activity fix (T3 / Fix C).
+
+    The auto-capture path (force_meaningful=None with real duration) is unchanged.
+    """
+    from app.services.activity_service import log_company_call
+
+    # Manual log — no duration, but must be meaningful
+    rec = log_company_call(
+        user_id=test_user.id,
+        company_id=test_company.id,
+        direction="outbound",
+        phone="+15550000099",
+        duration_seconds=None,
+        contact_name="Test Contact",
+        notes="Called to follow up on quote",
+        db=db_session,
+        force_meaningful=True,
+    )
+    assert rec.is_meaningful is True
+
+    # Auto-capture path unchanged: no force_meaningful, no duration → not meaningful
+    rec2 = log_company_call(
+        user_id=test_user.id,
+        company_id=test_company.id,
+        direction="inbound",
+        phone="+15550000088",
+        duration_seconds=None,
+        contact_name=None,
+        notes=None,
+        db=db_session,
+    )
+    assert rec2.is_meaningful is False
+
+
 def test_activity_tab_renders_rfq_sent_event(client, db_session, test_requisition, test_user):
     """An RFQ-sent event written via log_activity() appears on the Activity tab.
 

--- a/tests/test_activity_write_path.py
+++ b/tests/test_activity_write_path.py
@@ -367,6 +367,37 @@ def test_log_call_activity_writes_canonical_call_logged(db_session, test_user):
     assert rec.direction == "outbound"
 
 
+@pytest.mark.parametrize(
+    ("force_meaningful", "duration_seconds", "expected"),
+    [
+        pytest.param(True, None, True, id="force_true_no_duration"),
+        pytest.param(None, None, False, id="auto_gate_no_duration"),
+        pytest.param(None, 5, True, id="auto_gate_above_threshold"),
+    ],
+)
+def test_log_call_activity_force_meaningful(db_session, test_user, force_meaningful, duration_seconds, expected):
+    """force_meaningful overrides the duration gate; None falls through to the existing
+    auto-capture logic (unchanged)."""
+    from app.services.activity_service import CALL_MEANINGFUL_MIN_SECONDS
+
+    # Ensure the parametrized "above threshold" case is genuinely above it.
+    if duration_seconds is not None and expected is True:
+        duration_seconds = CALL_MEANINGFUL_MIN_SECONDS
+
+    rec = log_call_activity(
+        user_id=test_user.id,
+        direction="outbound",
+        phone="+15550000001",
+        duration_seconds=duration_seconds,
+        external_id=f"force-meaningful-{force_meaningful}-{duration_seconds}",
+        contact_name="Test Vendor",
+        db=db_session,
+        force_meaningful=force_meaningful,
+    )
+    assert rec is not None
+    assert rec.is_meaningful is expected
+
+
 def test_activity_tab_renders_rfq_sent_event(client, db_session, test_requisition, test_user):
     """An RFQ-sent event written via log_activity() appears on the Activity tab.
 

--- a/tests/test_htmx_views_nightly.py
+++ b/tests/test_htmx_views_nightly.py
@@ -654,6 +654,50 @@ class TestQuotesPartials:
         resp = client.post(f"/v2/partials/quotes/{q.id}/add-offer/999999")
         assert resp.status_code == 404
 
+    def test_add_offer_to_quote_same_requisition(self, client, db_session: Session, test_user: User):
+        """Same-requisition offer attaches successfully (200, QuoteLine created)."""
+        req = _req(db_session, test_user)
+        vendor = _vendor(db_session)
+        offer = _offer(db_session, req, vendor)
+        q = _quote(db_session, req, test_user)
+        db_session.commit()
+
+        resp = client.post(f"/v2/partials/quotes/{q.id}/add-offer/{offer.id}")
+        assert resp.status_code == 200
+
+        line = db_session.query(QuoteLine).filter_by(quote_id=q.id, offer_id=offer.id).first()
+        assert line is not None
+
+    def test_add_offer_to_quote_null_requisition_allowed(self, client, db_session: Session, test_user: User):
+        """Null-requisition offer (unsolicited Tier-5) attaches successfully (Option A
+        allows it)."""
+        req = _req(db_session, test_user)
+        vendor = _vendor(db_session)
+        offer = _offer(db_session, req, vendor, requisition_id=None)
+        q = _quote(db_session, req, test_user)
+        db_session.commit()
+
+        resp = client.post(f"/v2/partials/quotes/{q.id}/add-offer/{offer.id}")
+        assert resp.status_code == 200
+
+        line = db_session.query(QuoteLine).filter_by(quote_id=q.id, offer_id=offer.id).first()
+        assert line is not None
+
+    def test_add_offer_to_quote_cross_requisition_forbidden(self, client, db_session: Session, test_user: User):
+        """Cross-requisition offer → 403, no QuoteLine created."""
+        req_a = _req(db_session, test_user)
+        req_b = _req(db_session, test_user)
+        vendor = _vendor(db_session)
+        offer = _offer(db_session, req_b, vendor)  # belongs to req_b
+        q = _quote(db_session, req_a, test_user)  # quote is for req_a
+        db_session.commit()
+
+        resp = client.post(f"/v2/partials/quotes/{q.id}/add-offer/{offer.id}")
+        assert resp.status_code == 403
+
+        line = db_session.query(QuoteLine).filter_by(quote_id=q.id, offer_id=offer.id).first()
+        assert line is None
+
     def test_send_quote(self, client, db_session: Session, test_user: User):
         req = _req(db_session, test_user)
         q = _quote(db_session, req, test_user, status=QuoteStatus.DRAFT)

--- a/tests/test_part_dossier_router.py
+++ b/tests/test_part_dossier_router.py
@@ -404,7 +404,7 @@ class TestComputeMarketBaseline:
         return {"is_authorized": is_authorized, "unit_price": unit_price, "qty_available": qty_available}
 
     def test_empty_input_returns_no_authorized(self):
-        from app.routers.part_dossier import compute_market_baseline
+        from app.search_service import compute_market_baseline
 
         result = compute_market_baseline([])
         assert result["has_authorized"] is False
@@ -413,7 +413,7 @@ class TestComputeMarketBaseline:
         assert result["sources"] == 0
 
     def test_all_non_authorized_returns_no_authorized(self):
-        from app.routers.part_dossier import compute_market_baseline
+        from app.search_service import compute_market_baseline
 
         rows = [
             self._make_row(is_authorized=False, unit_price=1.50, qty_available=500),
@@ -425,7 +425,7 @@ class TestComputeMarketBaseline:
 
     def test_authorized_rows_median_price_odd_count(self):
         """With 3 authorized rows, median is the middle price when sorted."""
-        from app.routers.part_dossier import compute_market_baseline
+        from app.search_service import compute_market_baseline
 
         rows = [
             self._make_row(is_authorized=True, unit_price=1.00, qty_available=100),
@@ -442,7 +442,7 @@ class TestComputeMarketBaseline:
 
     def test_authorized_rows_median_price_even_count(self):
         """With 2 authorized rows, median uses upper-middle (index len//2 == 1)."""
-        from app.routers.part_dossier import compute_market_baseline
+        from app.search_service import compute_market_baseline
 
         rows = [
             self._make_row(is_authorized=True, unit_price=1.00, qty_available=100),
@@ -456,7 +456,7 @@ class TestComputeMarketBaseline:
     def test_authorized_none_price_excluded_from_median(self):
         """unit_price=None rows are excluded from the price list; stock still
         counted."""
-        from app.routers.part_dossier import compute_market_baseline
+        from app.search_service import compute_market_baseline
 
         rows = [
             self._make_row(is_authorized=True, unit_price=None, qty_available=500),
@@ -470,7 +470,7 @@ class TestComputeMarketBaseline:
     def test_authorized_none_qty_excluded_from_stock_sum(self):
         """qty_available=None means unknown — excluded from sum; median still
         computed."""
-        from app.routers.part_dossier import compute_market_baseline
+        from app.search_service import compute_market_baseline
 
         rows = [
             self._make_row(is_authorized=True, unit_price=1.00, qty_available=None),
@@ -483,7 +483,7 @@ class TestComputeMarketBaseline:
 
     def test_all_authorized_none_price_median_is_none(self):
         """If every authorized row has no price, median is None (not a crash)."""
-        from app.routers.part_dossier import compute_market_baseline
+        from app.search_service import compute_market_baseline
 
         rows = [self._make_row(is_authorized=True, unit_price=None, qty_available=100)]
         result = compute_market_baseline(rows)
@@ -493,7 +493,7 @@ class TestComputeMarketBaseline:
 
     def test_zero_price_excluded_from_median(self):
         """unit_price=0 is not a real price and must be excluded (same as _median)."""
-        from app.routers.part_dossier import compute_market_baseline
+        from app.search_service import compute_market_baseline
 
         rows = [
             self._make_row(is_authorized=True, unit_price=0, qty_available=100),
@@ -505,7 +505,7 @@ class TestComputeMarketBaseline:
 
     def test_mix_authorized_and_non_uses_only_authorized(self):
         """Non-authorized rows must not pollute the median or stock sum."""
-        from app.routers.part_dossier import compute_market_baseline
+        from app.search_service import compute_market_baseline
 
         rows = [
             self._make_row(is_authorized=True, unit_price=10.00, qty_available=50),

--- a/tests/test_part_dossier_router.py
+++ b/tests/test_part_dossier_router.py
@@ -388,3 +388,231 @@ def test_market_no_banner_when_only_unconfigured(client):
         resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
     assert resp.status_code == 200
     assert "unavailable" not in resp.text
+
+
+# ── Market-baseline strip — helper unit tests ──────────────────────────────
+
+
+class TestComputeMarketBaseline:
+    """Unit tests for compute_market_baseline — no DB, no HTTP, no SSE.
+
+    The helper must be importable and work on plain dicts (same schema as cached_rows /
+    vendor_card.html).
+    """
+
+    def _make_row(self, *, is_authorized: bool, unit_price, qty_available) -> dict:
+        return {"is_authorized": is_authorized, "unit_price": unit_price, "qty_available": qty_available}
+
+    def test_empty_input_returns_no_authorized(self):
+        from app.routers.part_dossier import compute_market_baseline
+
+        result = compute_market_baseline([])
+        assert result["has_authorized"] is False
+        assert result["median_price"] is None
+        assert result["total_stock"] is None
+        assert result["sources"] == 0
+
+    def test_all_non_authorized_returns_no_authorized(self):
+        from app.routers.part_dossier import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=False, unit_price=1.50, qty_available=500),
+            self._make_row(is_authorized=False, unit_price=2.00, qty_available=200),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is False
+        assert result["sources"] == 0
+
+    def test_authorized_rows_median_price_odd_count(self):
+        """With 3 authorized rows, median is the middle price when sorted."""
+        from app.routers.part_dossier import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=1.00, qty_available=100),
+            self._make_row(is_authorized=True, unit_price=3.00, qty_available=200),
+            self._make_row(is_authorized=True, unit_price=2.00, qty_available=150),
+            self._make_row(is_authorized=False, unit_price=0.50, qty_available=5000),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is True
+        assert result["sources"] == 3
+        # Sorted prices: [1.00, 2.00, 3.00] → index 1 → 2.00
+        assert result["median_price"] == pytest.approx(2.00)
+        assert result["total_stock"] == 450  # 100 + 200 + 150
+
+    def test_authorized_rows_median_price_even_count(self):
+        """With 2 authorized rows, median uses upper-middle (index len//2 == 1)."""
+        from app.routers.part_dossier import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=1.00, qty_available=100),
+            self._make_row(is_authorized=True, unit_price=3.00, qty_available=200),
+        ]
+        result = compute_market_baseline(rows)
+        # Sorted [1.00, 3.00] → index 1 → 3.00 (same algorithm as _median)
+        assert result["median_price"] == pytest.approx(3.00)
+        assert result["total_stock"] == 300
+
+    def test_authorized_none_price_excluded_from_median(self):
+        """unit_price=None rows are excluded from the price list; stock still
+        counted."""
+        from app.routers.part_dossier import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=None, qty_available=500),
+            self._make_row(is_authorized=True, unit_price=2.50, qty_available=100),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is True
+        assert result["median_price"] == pytest.approx(2.50)
+        assert result["total_stock"] == 600  # None row's qty still counted
+
+    def test_authorized_none_qty_excluded_from_stock_sum(self):
+        """qty_available=None means unknown — excluded from sum; median still
+        computed."""
+        from app.routers.part_dossier import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=1.00, qty_available=None),
+            self._make_row(is_authorized=True, unit_price=2.00, qty_available=None),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is True
+        assert result["total_stock"] is None  # all qtys unknown
+        assert result["median_price"] == pytest.approx(2.00)
+
+    def test_all_authorized_none_price_median_is_none(self):
+        """If every authorized row has no price, median is None (not a crash)."""
+        from app.routers.part_dossier import compute_market_baseline
+
+        rows = [self._make_row(is_authorized=True, unit_price=None, qty_available=100)]
+        result = compute_market_baseline(rows)
+        assert result["has_authorized"] is True
+        assert result["median_price"] is None
+        assert result["total_stock"] == 100
+
+    def test_zero_price_excluded_from_median(self):
+        """unit_price=0 is not a real price and must be excluded (same as _median)."""
+        from app.routers.part_dossier import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=0, qty_available=100),
+            self._make_row(is_authorized=True, unit_price=5.00, qty_available=50),
+        ]
+        result = compute_market_baseline(rows)
+        # Only 5.00 qualifies → median is 5.00
+        assert result["median_price"] == pytest.approx(5.00)
+
+    def test_mix_authorized_and_non_uses_only_authorized(self):
+        """Non-authorized rows must not pollute the median or stock sum."""
+        from app.routers.part_dossier import compute_market_baseline
+
+        rows = [
+            self._make_row(is_authorized=True, unit_price=10.00, qty_available=50),
+            self._make_row(is_authorized=False, unit_price=0.01, qty_available=99999),
+        ]
+        result = compute_market_baseline(rows)
+        assert result["sources"] == 1
+        assert result["median_price"] == pytest.approx(10.00)
+        assert result["total_stock"] == 50
+
+
+# ── Market-baseline strip — render tests ──────────────────────────────────
+
+
+class TestMarketBaselineStripRender:
+    """Light render tests: the dossier_market template renders the strip (and the
+    empty-state path) without Jinja errors when cached rows are provided via a
+    mocked Redis pointer."""
+
+    def _rows_with_baseline(self) -> list[dict]:
+        return [
+            {
+                "vendor_name": "DigiKey",
+                "mpn_matched": "LM317T",
+                "manufacturer": "TI",
+                "unit_price": 1.25,
+                "qty_available": 500,
+                "is_authorized": True,
+                "confidence_color": "green",
+                "confidence_pct": 95,
+                "source_type": "digikey",
+                "sources_found": ["digikey"],
+            },
+            {
+                "vendor_name": "Mouser",
+                "mpn_matched": "LM317T",
+                "manufacturer": "TI",
+                "unit_price": 1.50,
+                "qty_available": 300,
+                "is_authorized": True,
+                "confidence_color": "green",
+                "confidence_pct": 92,
+                "source_type": "mouser",
+                "sources_found": ["mouser"],
+            },
+            {
+                "vendor_name": "GreyBroker",
+                "mpn_matched": "LM317T",
+                "manufacturer": "",
+                "unit_price": 0.75,
+                "qty_available": 2000,
+                "is_authorized": False,
+                "confidence_color": "amber",
+                "confidence_pct": 60,
+                "source_type": "brokerbin",
+                "sources_found": ["brokerbin"],
+            },
+        ]
+
+    def _patch_redis(self, rows):
+        rc = MagicMock()
+        rc.get.side_effect = lambda k: (
+            "sid-baseline-test" if k.endswith(":latest") else (json.dumps(rows) if k.endswith(":results") else None)
+        )
+        return rc
+
+    def test_baseline_strip_shows_franchise_fields(self, client):
+        """Cache hit with 2 authorized rows → strip renders median price, auth stock,
+        and auth source count without Jinja errors."""
+        rows = self._rows_with_baseline()
+        rc = self._patch_redis(rows)
+        with patch("app.search_service._get_search_redis", return_value=rc):
+            resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Franchise baseline" in body
+        assert "Median price" in body
+        assert "Auth stock" in body
+        assert "Auth sources" in body
+        # 2 authorized sources
+        assert "800" in body  # total authorized stock = 500 + 300
+
+    def test_baseline_strip_empty_state_no_authorized(self, client):
+        """When all cached rows are non-authorized, the graceful empty-state renders."""
+        rows = [
+            {
+                "vendor_name": "GreyBroker",
+                "mpn_matched": "LM317T",
+                "manufacturer": "",
+                "unit_price": 0.75,
+                "qty_available": 2000,
+                "is_authorized": False,
+                "confidence_color": "amber",
+                "confidence_pct": 60,
+                "source_type": "brokerbin",
+                "sources_found": ["brokerbin"],
+            }
+        ]
+        rc = self._patch_redis(rows)
+        with patch("app.search_service._get_search_redis", return_value=rc):
+            resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+        assert resp.status_code == 200
+        assert "No franchise/authorized pricing for this part" in resp.text
+
+    def test_baseline_strip_absent_on_cache_miss(self, client):
+        """Cache miss → no baseline strip (it only renders when cached_rows exist)."""
+        resp = client.get("/v2/partials/search/dossier/market", params={"mpn": "LM317T"})
+        assert resp.status_code == 200
+        assert "Franchise baseline" not in resp.text
+        assert "/v2/partials/search/run" in resp.text  # SSE frame fires instead


### PR DESCRIPTION
The three "parked" items from the offer-qualification work, plus the cleanups surfaced by `/simplify` + an architect pass.

## Changes
- **`add_offer_to_quote` IDOR fix (Option A)** — the single "Select for Quote" route now scopes the offer to the quote's requisition (`403` on cross-requisition), allowing null-requisition Tier-5 inbound offers. Mirrors the already-correct bulk sibling. (Guard written positive-polarity for auditability.)
- **Read-only market-baseline strip (price-sanity Step 1)** — on the Part Dossier's Live-market section: franchise/authorized **median price · authorized stock · # authorized sources**, computed from market rows already fetched. No flag, no threshold, no persistence. *Step 2 (the "below market" auto-flag) is intentionally NOT built — it needs a short definition brainstorm.*
- **Call-meaningful hardening** — `log_call_activity` gains a `force_meaningful` kwarg so manual phone logs express intent inside the service instead of a fragile router override. **The architect pass then found the same bug in the company-call path** (`log_company_call`) — manual company calls were also wrongly marked not-meaningful (dropping out of the timeline + reply clock); fixed identically.

## Review depth
Per-task reviews (T1, T3, T2-correctness all clean) + `/simplify` (4 agents) + architect pass. Architect findings applied: moved the market-baseline helper into `search_service.py` (thin-router invariant) reusing `_median` instead of re-implementing it; completed the company-call meaningful fix.

## Tests
17,563 pass, 0 fail. New: 3 IDOR-guard cases, 8 market-baseline unit + 3 render, force_meaningful (requisition + company) cases. No migration.

> Filed-separately (pre-existing, not introduced here): the quotes section has no per-user ownership check beyond authentication — a systemic gap for when this goes multi-user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)