### PR TITLE
feat(crm): left-panel company→site IA (Increment 2)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -5307,6 +5307,152 @@ async def set_contact_archive(
     )
 
 
+# ── Increment 2: left-panel company→site IA partials ──────────────────────────
+# These three routes carry STATIC first segments after /customers/ (header,
+# sites-accordion) or a specific /sites/{site_id} shape, so they MUST be declared
+# ABOVE the GET /v2/partials/customers/{company_id} catch-all below. Each writes
+# the right panel and honors the response-targets contract (hx-target #cdm-detail,
+# hx-target-error #cdm-error) from the caller markup.
+
+
+@router.get("/v2/partials/customers/{company_id}/header", response_class=HTMLResponse)
+async def company_header_partial(
+    request: Request,
+    company_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Company-header-only partial — header card + cadence + commercial strip, WITHOUT
+    the per-tab strip.
+
+    Loaded into #cdm-detail when a multi-site account's accordion header is clicked (the
+    site children carry the per-site contacts + open reqs).
+    """
+    company = (
+        db.query(Company)
+        .options(joinedload(Company.account_owner), joinedload(Company.sites))
+        .filter(Company.id == company_id)
+        .first()
+    )
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    from datetime import timezone as _tz
+
+    sites = [s for s in (company.sites or []) if s.is_active]
+    contact_rows = _company_contact_rows(db, company_id, sites=sites)
+    _stats = _company_commercial_stats(db, [company.id]).get(company.id, {})
+
+    ctx = _base_ctx(request, user, "customers")
+    ctx.update(
+        {
+            "company": company,
+            "cadence_state": _cadence_state(company.tier, company.last_outbound_at),
+            "next_best_touch": _next_best_touch(company.tier, company.last_outbound_at),
+            "contact_count": len(contact_rows),
+            "site_count": len(sites),
+            "win_rate": _stats.get("win_rate"),
+            "revenue_90d": _stats.get("revenue_90d", 0.0),
+            "last_req_date": _stats.get("last_req_date"),
+            "now_utc": datetime.now(_tz.utc),
+        }
+    )
+    return template_response("htmx/partials/customers/header.html", ctx)
+
+
+@router.get("/v2/partials/customers/{company_id}/sites-accordion", response_class=HTMLResponse)
+async def company_sites_accordion_partial(
+    request: Request,
+    company_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Lazy-loaded list of a company's ACTIVE sites — the children rendered under the
+    left-panel account accordion header.
+
+    Each links to the site-detail view.
+    """
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    sites = (
+        db.query(CustomerSite)
+        .filter(CustomerSite.company_id == company_id, CustomerSite.is_active.is_(True))
+        .order_by(CustomerSite.site_name)
+        .all()
+    )
+    ctx = _base_ctx(request, user, "customers")
+    ctx.update({"company": company, "sites": sites})
+    return template_response("htmx/partials/customers/_sites_accordion.html", ctx)
+
+
+@router.get("/v2/partials/customers/{company_id}/sites/{site_id}", response_class=HTMLResponse)
+async def company_site_detail_partial(
+    request: Request,
+    company_id: int,
+    site_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Site-scoped detail (site fields + per-site clocks + Contacts + "Open requisitions
+    at this site").
+
+    IDOR-safe: the site must belong to the
+    company AND be active, else 404 (mirrors site_contacts_list).
+    """
+    site = (
+        db.query(CustomerSite)
+        .options(joinedload(CustomerSite.owner))
+        .filter(
+            CustomerSite.id == site_id,
+            CustomerSite.company_id == company_id,
+            CustomerSite.is_active.is_(True),
+        )
+        .first()
+    )
+    if not site:
+        raise HTTPException(404, "Site not found")
+
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    from datetime import timezone as _tz
+
+    now_utc = datetime.now(_tz.utc)
+    # Site-scoped contacts — pass this single site so the rows are filtered to it
+    # (keeps the is_active + Increment-1 priority/archive sort).
+    contact_rows = _company_contact_rows(db, company_id, sites=[site])
+
+    # Open requisitions AT THIS SITE — FK-scoped, open statuses only.
+    open_reqs = (
+        db.query(Requisition)
+        .filter(
+            Requisition.customer_site_id == site_id,
+            Requisition.status.notin_([RequisitionStatus.ARCHIVED, RequisitionStatus.WON, RequisitionStatus.LOST]),
+        )
+        .order_by(Requisition.created_at.desc().nullslast())
+        .limit(50)
+        .all()
+    )
+
+    ctx = _base_ctx(request, user, "customers")
+    ctx.update(
+        {
+            "company": company,
+            "site": site,
+            "contact_rows": contact_rows,
+            "open_reqs": open_reqs,
+            "now_utc": now_utc,
+            # Per-site cadence (tier=None → standard 30d target, like contacts).
+            "site_cadence": _cadence_state(None, site.last_outbound_at, now_utc),
+            "site_next_best_touch": _next_best_touch(None, site.last_outbound_at, now_utc),
+        }
+    )
+    return template_response("htmx/partials/customers/site_detail.html", ctx)
+
+
 @router.get("/v2/partials/customers/{company_id}", response_class=HTMLResponse)
 async def company_detail_partial(
     request: Request,

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -5425,12 +5425,13 @@ async def company_site_detail_partial(
     # (keeps the is_active + Increment-1 priority/archive sort).
     contact_rows = _company_contact_rows(db, company_id, sites=[site])
 
-    # Open requisitions AT THIS SITE — FK-scoped, open statuses only.
+    # Open requisitions AT THIS SITE — FK-scoped, non-terminal only (canonical
+    # TERMINAL set = archived/won/lost/cancelled, so CANCELLED doesn't read as open).
     open_reqs = (
         db.query(Requisition)
         .filter(
             Requisition.customer_site_id == site_id,
-            Requisition.status.notin_([RequisitionStatus.ARCHIVED, RequisitionStatus.WON, RequisitionStatus.LOST]),
+            Requisition.status.notin_(RequisitionStatus.TERMINAL),
         )
         .order_by(Requisition.created_at.desc().nullslast())
         .limit(50)

--- a/app/templates/htmx/partials/customers/_account_list.html
+++ b/app/templates/htmx/partials/customers/_account_list.html
@@ -20,6 +20,71 @@
 {% set dot_colors = {"new": "bg-gray-300", "on_target": "bg-emerald-400", "due": "bg-amber-400", "overdue": "bg-rose-500"} %}
 <div class="divide-y divide-gray-100">
   {% for c in companies %}
+  {% if (c.site_count or 0) > 1 %}
+  {# ── Multi-site row → accordion header. Clicking the NAME toggles expand AND
+       loads the company-header partial into #cdm-detail; the site children
+       lazy-load on first expand (intersect once) from /sites-accordion. The
+       toggle chevron and the name share the expand; the site-child links carry
+       their own hx-gets (split targets so they don't fight). No window-level
+       Alpine listeners (they leak across HTMX swaps). #}
+  <div id="cdm-row-{{ c.id }}"{{ alert_row_attrs(alert_markers, 'company-' ~ c.id) }}
+       x-data="{ expanded: false }"
+       class="border-l-2 transition-colors"
+       :class="selectedId === {{ c.id }} ? 'bg-brand-50 border-l-brand-500' : 'border-l-transparent'">
+    <div role="button" tabindex="0"
+         class="flex items-center gap-2.5 px-3 py-2.5 cursor-pointer hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-500"
+         hx-get="/v2/partials/customers/{{ c.id }}/header"
+         hx-target="#cdm-detail"
+         hx-swap="innerHTML"
+         hx-target-error="#cdm-error"
+         hx-trigger="click, keyup[key=='Enter']"
+         data-loading-class="opacity-60 pointer-events-none"
+         preload="mouseover"
+         @click="expanded = true; selectedId = {{ c.id }}; selectedSiteId = null"
+         @keyup.enter="expanded = true; selectedId = {{ c.id }}; selectedSiteId = null">
+      <button type="button"
+              class="flex-shrink-0 -ml-1 p-0.5 rounded text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-brand-500"
+              aria-label="Toggle sites for {{ c.name }}"
+              :aria-expanded="expanded"
+              @click.stop="expanded = !expanded">
+        <svg class="h-4 w-4 transition-transform" :class="{ 'rotate-90': expanded }" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+        </svg>
+      </button>
+      <span class="w-2.5 h-2.5 rounded-full flex-shrink-0 {{ dot_colors.get(c.cadence_state, 'bg-gray-300') }}"
+            role="img" aria-label="{{ c.cadence_state|replace('_', ' ')|title }}"
+            title="{{ c.cadence_state|replace('_', ' ')|title }}"></span>
+      <div class="flex-1 min-w-0">
+        <p class="text-sm font-medium text-gray-900 truncate">{{ c.name }}</p>
+        <p class="text-[11px] text-gray-500 truncate">
+          {{ c.account_type or "—" }}{% if c.account_owner %} &middot; {{ c.account_owner.name }}{% endif %}
+          {% if c.tier %}<span class="ml-1 px-1 py-0.5 rounded text-[10px] bg-gray-100 text-gray-500">{{ c.tier }}</span>{% endif %}
+          <span class="ml-1 px-1 py-0.5 rounded text-[10px] bg-gray-100 text-gray-500">{{ c.site_count }} sites</span>
+        </p>
+      </div>
+      <div class="flex-shrink-0 text-right">
+        <p class="text-[11px] {% if c.cadence_state == 'overdue' %}text-rose-600 font-medium{% elif c.cadence_state == 'due' %}text-amber-600{% else %}text-gray-400{% endif %}">
+          Out {{ c.last_outbound_at|timeago if c.last_outbound_at else "never" }}
+        </p>
+        <p class="text-[11px] text-gray-400">
+          Reply {{ c.last_reply_at|timeago if c.last_reply_at else "—" }}
+        </p>
+      </div>
+    </div>
+    {# Site children — lazy-loaded on first expand (intersect once). #}
+    <div x-show="expanded" x-cloak x-transition class="bg-gray-50/50">
+      <div hx-get="/v2/partials/customers/{{ c.id }}/sites-accordion"
+           hx-trigger="intersect once"
+           hx-target="this"
+           hx-swap="innerHTML"
+           hx-target-error="#cdm-error">
+        <p class="pl-7 pr-2 py-2 text-[11px] text-gray-400">Loading sites…</p>
+      </div>
+    </div>
+  </div>
+  {% else %}
+  {# ── Single-site (or unknown) row → today's exact behavior: load the company
+       detail directly into #cdm-detail. No accordion. #}
   <div id="cdm-row-{{ c.id }}"{{ alert_row_attrs(alert_markers, 'company-' ~ c.id) }} role="button" tabindex="0"
        class="flex items-center gap-2.5 px-3 py-2.5 cursor-pointer hover:bg-gray-50 transition-colors border-l-2 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-500"
        hx-get="/v2/partials/customers/{{ c.id }}"
@@ -29,8 +94,8 @@
        hx-trigger="click, keyup[key=='Enter']"
        data-loading-class="opacity-60 pointer-events-none"
        preload="mouseover"
-       @click="selectedId = {{ c.id }}"
-       @keyup.enter="selectedId = {{ c.id }}"
+       @click="selectedId = {{ c.id }}; selectedSiteId = null"
+       @keyup.enter="selectedId = {{ c.id }}; selectedSiteId = null"
        :class="selectedId === {{ c.id }} ? 'bg-brand-50 border-l-brand-500' : 'border-l-transparent'">
     <span class="w-2.5 h-2.5 rounded-full flex-shrink-0 {{ dot_colors.get(c.cadence_state, 'bg-gray-300') }}"
           role="img" aria-label="{{ c.cadence_state|replace('_', ' ')|title }}"
@@ -51,6 +116,7 @@
       </p>
     </div>
   </div>
+  {% endif %}
   {% endfor %}
 </div>
 

--- a/app/templates/htmx/partials/customers/_sites_accordion.html
+++ b/app/templates/htmx/partials/customers/_sites_accordion.html
@@ -1,0 +1,39 @@
+{# _sites_accordion.html — lazy-loaded list of a multi-site company's ACTIVE
+   sites, rendered as children under the left-panel account accordion header.
+   Each site links to the site-detail view in the right panel (#cdm-detail) and
+   sets both selectedId (company) + selectedSiteId (site) for highlight.
+
+   Receives: company, sites (list[CustomerSite], active only).
+   Called by: company_sites_accordion_partial route in htmx_views.py
+              (hx-get from _account_list.html on first expand).
+   Depends on: workspace x-data (selectedId, selectedSiteId), brand palette.
+#}
+{% if sites %}
+<ul class="pl-7 pr-2 pb-1.5 space-y-0.5">
+  {% for s in sites %}
+  <li>
+    <a role="button" tabindex="0"
+       class="flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer text-xs hover:bg-gray-50 transition-colors border-l-2 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-500"
+       hx-get="/v2/partials/customers/{{ company.id }}/sites/{{ s.id }}"
+       hx-target="#cdm-detail"
+       hx-swap="innerHTML"
+       hx-target-error="#cdm-error"
+       hx-trigger="click, keyup[key=='Enter']"
+       preload="mouseover"
+       @click="selectedId = {{ company.id }}; selectedSiteId = {{ s.id }}"
+       @keyup.enter="selectedId = {{ company.id }}; selectedSiteId = {{ s.id }}"
+       :class="selectedSiteId === {{ s.id }} ? 'bg-brand-50 border-l-brand-500 text-brand-700 font-medium' : 'border-l-transparent text-gray-600'">
+      <span class="flex-1 min-w-0 truncate">{{ s.site_name }}</span>
+      {% if s.site_type %}
+      <span class="flex-shrink-0 px-1 py-0.5 text-[9px] font-medium rounded bg-gray-100 text-gray-500 uppercase">{{ s.site_type }}</span>
+      {% endif %}
+      {% if s.city %}
+      <span class="flex-shrink-0 text-[10px] text-gray-400 truncate max-w-[80px]">{{ s.city }}</span>
+      {% endif %}
+    </a>
+  </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p class="pl-7 pr-2 pb-2 text-[11px] text-gray-400">No active sites.</p>
+{% endif %}

--- a/app/templates/htmx/partials/customers/header.html
+++ b/app/templates/htmx/partials/customers/header.html
@@ -1,0 +1,146 @@
+{# header.html — company-header-only partial (header card + cadence + commercial
+   strip), WITHOUT the per-tab strip. Loaded into #cdm-detail when a multi-site
+   account's accordion header is clicked (Increment 2 — left-panel IA). The
+   per-site work (contacts, open reqs) lives in the site-detail view; this header
+   is the company-level rollup that stays visible while drilling into sites.
+
+   Receives: company, cadence_state, next_best_touch, contact_count, site_count,
+             win_rate, revenue_90d, last_req_date, now_utc.
+   Called by: company_header_partial route in htmx_views.py.
+   Depends on: brand palette, _cadence_hero.html, _disposition_control.html,
+               shared/enrich_button.html.
+#}
+
+<title hx-swap-oob="true">{{ company.name }} — Companies — AvailAI</title>
+
+{# max-w-3xl: must fit the CDM right panel (~60% viewport), not just full-page #}
+<div class="max-w-3xl mx-auto space-y-6">
+
+  {# ── Header Card ─────────────────────────────────────────── #}
+  <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-6">
+    <div class="flex items-start justify-between">
+      <div class="flex items-start gap-4">
+        <div class="flex-shrink-0 h-12 w-12 rounded-full bg-brand-100 flex items-center justify-center">
+          <span class="text-lg font-bold text-brand-600">{{ company.name[:1]|upper }}</span>
+        </div>
+        <div>
+          <h1 class="text-2xl font-bold text-gray-900">{{ company.name }}</h1>
+          <div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500">
+            {% if company.domain %}
+              <a href="https://{{ company.domain }}" target="_blank" rel="noopener noreferrer" class="text-brand-500 hover:text-brand-600">{{ company.domain }}</a>
+            {% endif %}
+            {% if company.industry %}
+              <span class="text-gray-300">|</span>
+              <span>{{ company.industry }}</span>
+            {% endif %}
+            {% if company.hq_city %}
+              <span class="text-gray-300">|</span>
+              <span>{{ company.hq_city }}{% if company.hq_country %}, {{ company.hq_country }}{% endif %}</span>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        {% if company.account_type %}
+        {% set type_colors = {
+          "Customer": "bg-emerald-50 text-emerald-700 border-emerald-200",
+          "Prospect": "bg-brand-100 text-brand-600 border-brand-200",
+          "Partner": "bg-brand-50 text-brand-400 border-brand-200",
+          "Competitor": "bg-rose-50 text-rose-700 border-rose-200"
+        } %}
+        <span class="px-3 py-1 text-sm font-medium rounded-full border {{ type_colors.get(company.account_type, 'bg-gray-100 text-gray-600 border-gray-200') }}">
+          {{ company.account_type }}
+        </span>
+        {% endif %}
+        {% set entity_type = "company" %}
+        {% set entity_id = company.id %}
+        {% include "htmx/partials/shared/enrich_button.html" %}
+      </div>
+    </div>
+
+    {# Quick info grid — 2 cols (the panel is far narrower than the viewport) #}
+    <div class="mt-6 grid grid-cols-2 gap-4">
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="text-xs font-medium text-gray-500 uppercase tracking-wider">Account Owner</p>
+        <p class="mt-1 text-sm font-medium text-gray-900">
+          {% if company.account_owner %}
+            <span class="inline-flex items-center gap-1.5">
+              <span class="inline-flex items-center justify-center h-5 w-5 rounded-full bg-brand-100 text-brand-600 text-[10px] font-bold">{{ company.account_owner.name[:1]|upper }}</span>
+              {{ company.account_owner.name }}
+            </span>
+          {% else %}
+            <span class="text-gray-400">Unassigned</span>
+          {% endif %}
+        </p>
+      </div>
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="text-xs font-medium text-gray-500 uppercase tracking-wider">Credit Terms</p>
+        <p class="mt-1 text-sm font-medium text-gray-900">{{ company.credit_terms or "—" }}</p>
+      </div>
+    </div>
+  </div>
+
+  {# ── Account Cadence Card ──────────────────────────────── #}
+  <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4">
+    {% include 'htmx/partials/customers/_cadence_hero.html' %}
+    {% include 'htmx/partials/customers/_disposition_control.html' %}
+
+    {# Dual clocks: Outbound + Reply #}
+    <div class="grid grid-cols-2 gap-3 mb-3">
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Last Out</p>
+        {% if company.last_outbound_at %}
+          {% set out_days = ((now_utc - company.last_outbound_at).days) if now_utc is defined else 0 %}
+          <p class="text-lg font-bold text-gray-900">{{ out_days }}d</p>
+          <p class="text-[10px] text-gray-400">{{ company.last_outbound_at.strftime('%b %d') }}</p>
+        {% else %}
+          <p class="text-sm font-medium text-gray-400">Never</p>
+        {% endif %}
+      </div>
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Last Reply</p>
+        {% if company.last_reply_at %}
+          {% set reply_days = ((now_utc - company.last_reply_at).days) if now_utc is defined else 0 %}
+          <p class="text-lg font-bold text-gray-900">{{ reply_days }}d</p>
+          <p class="text-[10px] text-gray-400">{{ company.last_reply_at.strftime('%b %d') }}</p>
+        {% else %}
+          <p class="text-sm font-medium text-gray-400">—</p>
+        {% endif %}
+      </div>
+    </div>
+
+    {# Coverage badge — multi-site: drill into a site from the left accordion. #}
+    <p class="text-xs text-gray-500">
+      <span class="font-medium text-gray-700">{{ contact_count }} contact{{ 's' if contact_count != 1 else '' }}</span>
+      <span class="text-gray-300 mx-1">·</span>
+      <span class="font-medium text-gray-700">{{ site_count }} site{{ 's' if site_count != 1 else '' }}</span>
+      <span class="text-gray-300 mx-1">·</span>
+      <span class="text-gray-400">Select a site on the left to see its contacts &amp; open requisitions.</span>
+    </p>
+  </div>
+
+  {# ── Commercial Context Strip ────────────────────────────── #}
+  <div class="bg-white rounded-xl shadow-sm border border-brand-200 px-4 py-3">
+    <div class="flex items-center gap-4 flex-wrap text-sm">
+      <span class="text-xs font-medium text-gray-400 uppercase tracking-wider mr-2">Commercial</span>
+      <span class="text-gray-600">
+        Win rate:
+        <span class="font-semibold text-gray-900">{% if win_rate is not none %}{{ win_rate }}%{% else %}—{% endif %}</span>
+      </span>
+      <span class="text-gray-300">·</span>
+      <span class="text-gray-600">
+        Rev 90d:
+        <span class="font-semibold text-gray-900">{% if revenue_90d %}${{ "{:,.0f}".format(revenue_90d) }}{% else %}—{% endif %}</span>
+      </span>
+      <span class="text-gray-300">·</span>
+      <span class="text-gray-600">
+        Last deal:
+        <span class="font-semibold text-gray-900">{% if last_req_date %}{{ last_req_date[:10] }}{% else %}—{% endif %}</span>
+      </span>
+    </div>
+  </div>
+
+  {# Enrich results placeholder #}
+  <div id="enrich-results-{{ company.id }}"></div>
+
+</div>

--- a/app/templates/htmx/partials/customers/list.html
+++ b/app/templates/htmx/partials/customers/list.html
@@ -13,7 +13,7 @@
    swapped out — never add window listeners via x-init here (they leak across
    HTMX navigations). #}
 <div id="cdm-workspace" class="flex flex-col min-h-[420px]"
-     x-data="{ selectedId: null, fitHeight() { this.$el.style.height = Math.max(420, window.innerHeight - this.$el.getBoundingClientRect().top - 64) + 'px' } }"
+     x-data="{ selectedId: null, selectedSiteId: null, fitHeight() { this.$el.style.height = Math.max(420, window.innerHeight - this.$el.getBoundingClientRect().top - 64) + 'px' } }"
      x-init="$nextTick(() => fitHeight())"
      @resize.window.debounce.150ms="fitHeight()">
 

--- a/app/templates/htmx/partials/customers/site_detail.html
+++ b/app/templates/htmx/partials/customers/site_detail.html
@@ -1,0 +1,178 @@
+{# site_detail.html — site-scoped detail for a multi-site account, loaded into
+   the CDM right panel (#cdm-detail) when a site is picked from the left-panel
+   accordion (Increment 2 — left-panel IA).
+
+   Shows the site's fields + per-site cadence clocks + a mini tab strip:
+     • Contacts — company_contact_rows(db, company_id, sites=[this_site])
+     • Open requisitions at this site — Requisition.customer_site_id == site_id
+   Notes tab is DEFERRED (pending the ActivityLog FK scoping fix).
+
+   Receives: company, site, contact_rows ([{contact, site, legacy}]),
+             open_reqs (list[Requisition]), now_utc, cadence_state (callable),
+             site_cadence, site_next_best_touch.
+   Called by: company_site_detail_partial route in htmx_views.py.
+   Depends on: brand palette, Alpine.js, contacts_tab.html (contact_card macro),
+               crm_service.cadence_state (exposed as cadence_state global).
+#}
+{% from "htmx/partials/customers/tabs/contacts_tab.html" import contact_card with context %}
+
+<title hx-swap-oob="true">{{ site.site_name }} — {{ company.name }} — AvailAI</title>
+
+{% set badge_colors = {
+  'new': 'bg-gray-100 text-gray-500',
+  'on_target': 'bg-emerald-100 text-emerald-700',
+  'due': 'bg-amber-100 text-amber-700',
+  'overdue': 'bg-rose-100 text-rose-700'
+} %}
+
+<div class="max-w-3xl mx-auto space-y-6">
+
+  {# ── Breadcrumb back to the company header ───────────────── #}
+  <div class="flex items-center gap-1.5 text-xs text-gray-500">
+    <a role="button" tabindex="0"
+       class="text-brand-500 hover:text-brand-600 cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-500 rounded"
+       hx-get="/v2/partials/customers/{{ company.id }}/header"
+       hx-target="#cdm-detail"
+       hx-swap="innerHTML"
+       hx-target-error="#cdm-error"
+       hx-trigger="click, keyup[key=='Enter']"
+       @click="selectedSiteId = null">{{ company.name }}</a>
+    <span class="text-gray-300">/</span>
+    <span class="text-gray-700 font-medium">{{ site.site_name }}</span>
+  </div>
+
+  {# ── Site Header Card ────────────────────────────────────── #}
+  <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-6">
+    <div class="flex items-start justify-between flex-wrap gap-3">
+      <div>
+        <div class="flex items-center gap-2 flex-wrap">
+          <h1 class="text-xl font-bold text-gray-900">{{ site.site_name }}</h1>
+          {% if site.site_type %}
+          <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-brand-50 text-brand-600 uppercase">{{ site.site_type }}</span>
+          {% endif %}
+        </div>
+        <div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500">
+          {% if site.city %}
+            <span>{{ site.city }}{% if site.state %}, {{ site.state }}{% endif %}{% if site.country %} · {{ site.country }}{% endif %}</span>
+          {% endif %}
+          {% if site.owner %}
+            <span class="text-gray-300">|</span>
+            <span class="text-brand-500">{{ site.owner.name or site.owner.email }}</span>
+          {% endif %}
+        </div>
+      </div>
+      <span class="px-2.5 py-1 text-xs font-semibold rounded-full {{ badge_colors.get(site_cadence, 'bg-gray-100 text-gray-500') }}">
+        {{ {'new': 'New', 'on_target': 'On Target', 'due': 'Due', 'overdue': 'Overdue'}.get(site_cadence, site_cadence|title) }}
+      </span>
+    </div>
+
+    {# Quick info grid — terms + per-site clocks #}
+    <div class="mt-5 grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="font-medium text-gray-500 uppercase tracking-wider">Payment Terms</p>
+        <p class="mt-1 text-sm font-medium text-gray-900">{{ site.payment_terms or "—" }}</p>
+      </div>
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="font-medium text-gray-500 uppercase tracking-wider">Shipping Terms</p>
+        <p class="mt-1 text-sm font-medium text-gray-900">{{ site.shipping_terms or "—" }}</p>
+      </div>
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="font-medium text-gray-500 uppercase tracking-wider">Last Out</p>
+        {% if site.last_outbound_at %}
+          <p class="mt-1 text-sm font-bold text-gray-900">{{ (now_utc - site.last_outbound_at).days }}d</p>
+        {% else %}
+          <p class="mt-1 text-sm font-medium text-gray-400">Never</p>
+        {% endif %}
+      </div>
+      <div class="p-3 rounded-lg bg-gray-50">
+        <p class="font-medium text-gray-500 uppercase tracking-wider">Last Reply</p>
+        {% if site.last_reply_at %}
+          <p class="mt-1 text-sm font-bold text-gray-900">{{ (now_utc - site.last_reply_at).days }}d</p>
+        {% else %}
+          <p class="mt-1 text-sm font-medium text-gray-400">—</p>
+        {% endif %}
+      </div>
+    </div>
+    <p class="mt-2 text-xs text-gray-500 italic">{{ site_next_best_touch }}</p>
+  </div>
+
+  {# ── Mini tab strip — Contacts + Open requisitions at this site ──── #}
+  <div x-data="{ siteTab: 'contacts' }">
+    <div class="border-b border-gray-200">
+      <nav class="flex gap-6 -mb-px" role="tablist" aria-label="Site detail sections">
+        <button @click="siteTab = 'contacts'"
+                role="tab"
+                :aria-selected="siteTab === 'contacts' ? 'true' : 'false'"
+                :class="siteTab === 'contacts' ? 'border-brand-500 text-brand-600 font-semibold' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'"
+                class="py-3 px-1 text-sm font-medium border-b-2 transition-colors inline-flex items-center gap-1.5">
+          Contacts
+          {% set _real = contact_rows|selectattr('contact')|list|length %}
+          {% if _real > 0 %}
+          <span class="inline-flex items-center justify-center h-5 min-w-[20px] px-1 text-[10px] font-bold rounded-full bg-brand-100 text-brand-600">{{ _real }}</span>
+          {% endif %}
+        </button>
+        <button @click="siteTab = 'reqs'"
+                role="tab"
+                :aria-selected="siteTab === 'reqs' ? 'true' : 'false'"
+                :class="siteTab === 'reqs' ? 'border-brand-500 text-brand-600 font-semibold' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'"
+                class="py-3 px-1 text-sm font-medium border-b-2 transition-colors inline-flex items-center gap-1.5">
+          Open requisitions at this site
+          {% if open_reqs %}
+          <span class="inline-flex items-center justify-center h-5 min-w-[20px] px-1 text-[10px] font-bold rounded-full bg-brand-100 text-brand-600">{{ open_reqs|length }}</span>
+          {% endif %}
+        </button>
+        {# Notes tab deferred — pending the ActivityLog FK scoping fix (Increment 2 follow-up) #}
+      </nav>
+    </div>
+
+    {# ── Contacts panel ──────────────────────────────────────── #}
+    <div x-show="siteTab === 'contacts'" class="mt-4" role="tabpanel">
+      {% if not contact_rows %}
+      <div class="p-6 text-center">
+        <p class="text-sm text-gray-500">No contacts at this site yet.</p>
+      </div>
+      {% else %}
+      <div class="space-y-2">
+        {% for row in contact_rows %}
+          {# Guard legacy contact-is-None rows (fields live on site.contact_*). #}
+          {{ contact_card(company, row.contact, row.site, row.legacy) }}
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+
+    {# ── Open requisitions panel ─────────────────────────────── #}
+    <div x-show="siteTab === 'reqs'" x-cloak class="mt-4" role="tabpanel">
+      {% if open_reqs %}
+      <div class="overflow-x-auto bg-white rounded-lg border border-gray-200">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200">
+            {% for r in open_reqs %}
+            <tr class="hover:bg-brand-50 cursor-pointer"
+                hx-get="/v2/partials/requisitions/{{ r.id }}"
+                hx-target="#main-content"
+                hx-push-url="/v2/requisitions/{{ r.id }}">
+              <td class="px-4 py-2 text-sm font-medium text-brand-500">{{ r.name }}</td>
+              <td class="px-4 py-2 text-sm text-gray-500">{{ r.status or "—" }}</td>
+              <td class="px-4 py-2 text-sm text-gray-500">{{ r.created_at.strftime('%b %d, %Y') if r.created_at else "—" }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      {% else %}
+      <div class="p-6 text-center">
+        <p class="text-sm text-gray-500">No open requisitions at this site.</p>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+
+</div>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1411,6 +1411,39 @@ Bucket suppression is QUERY-LAYER only (never in `cadence_service.materialize_al
 the NULL-safe exclusion lives in the shared `_needs_call_filter` (count==list invariant)
 + `cdm_company_query`'s base, with `staleness='bucket'` the lone escape hatch.
 
+**Left-panel company→site IA (Increment 2, no migration).** The CDM left list
+(`_account_list.html`) branches on `c.site_count` (trigger-maintained on `Company`):
+- `site_count <= 1` → today's behavior: the row hx-gets `GET .../{company_id}`
+  (full company detail) into `#cdm-detail`, setting `selectedId` (+ clearing
+  `selectedSiteId`).
+- `site_count > 1` → the row becomes an Alpine accordion header
+  (`x-data="{expanded}"`, chevron, no window-level listeners). Clicking the name
+  toggles expand AND hx-gets the **company-header partial** into `#cdm-detail`;
+  the site children lazy-load on first expand (`intersect once`) from the
+  **sites-accordion partial**. Each site child hx-gets the **site-detail** route
+  and sets `selectedId` + `selectedSiteId`.
+
+Three additive routes in `htmx_views.py` (declared ABOVE the
+`GET /v2/partials/customers/{company_id}` catch-all):
+- `GET .../{company_id}/header` (`company_header_partial`) → `customers/header.html`
+  — header card + `_cadence_hero.html` + `_disposition_control.html` + dual clocks
+  + commercial strip, WITHOUT the per-tab strip (the company-level rollup that
+  stays visible while drilling into sites).
+- `GET .../{company_id}/sites-accordion` (`company_sites_accordion_partial`) →
+  `customers/_sites_accordion.html` — a `<ul>` of the company's ACTIVE sites
+  (name + type + city), each linking to the site-detail route.
+- `GET .../{company_id}/sites/{site_id}` (`company_site_detail_partial`) →
+  `customers/site_detail.html` — IDOR-safe (`CustomerSite.id == site_id AND
+  company_id == company_id AND is_active`, else 404; mirrors `site_contacts_list`).
+  Renders site fields + per-site clocks (tier=None standard target) + a mini tab
+  strip: **Contacts** (`company_contact_rows(db, company_id, sites=[this_site])`,
+  reusing the `contacts_tab.html` `contact_card` macro `with context`) and **Open
+  requisitions at this site** (`Requisition.customer_site_id == site_id`, open
+  statuses only). The **Notes tab is deferred** pending the ActivityLog FK scoping
+  fix. The `#cdm-workspace` x-data gains `selectedSiteId` for site-row highlight.
+The legacy in-panel **Sites tab** (`tabs/sites_tab.html` / `site_card.html`) is
+left intact (harmlessly redundant) — its retirement is a follow-up.
+
 ---
 
 ## 11. Cross-App Alerts (Nav Badges + In-Tab Spotlight)

--- a/tests/test_crm_ia.py
+++ b/tests/test_crm_ia.py
@@ -1,0 +1,256 @@
+"""tests/test_crm_ia.py — Increment 2: left-panel company→site IA.
+
+TDD spec for the IA feature (docs/superpowers/specs/
+2026-06-18-crm-disposition-ia-aiorg-design.md, "Increment 2 — Left-panel IA").
+
+Covers:
+  * site-detail route GET /v2/partials/customers/{company_id}/sites/{site_id}
+    — 200 for a valid (company, site); 404 IDOR (site under a different
+    company); 404 for an inactive site.
+  * site-detail renders the site's contacts + an "Open requisitions at this
+    site" section (seeded Requisition.customer_site_id == site_id).
+  * company-header partial GET .../{company_id}/header — 200, contains the
+    company name, does NOT contain the per-site contacts tab markup.
+  * sites-accordion partial GET .../{company_id}/sites-accordion — 200 lists
+    the company's active sites.
+  * _account_list.html rendering — site_count > 1 renders the accordion
+    affordance; site_count <= 1 renders the direct detail hx-get. site_count
+    is SEEDED explicitly (the Postgres trigger does not fire under SQLite).
+
+Written FIRST (TDD) — fails until the production code lands.
+
+Called by: pytest
+Depends on: app.models, app.routers.htmx_views (via the TestClient `client`
+            fixture), the in-memory SQLite test engine.
+"""
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models import Company, CustomerSite, SiteContact, User
+from app.models.sourcing import Requisition
+
+NOW = datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_company(
+    db: Session,
+    *,
+    name: str = "IA Co",
+    owner_id: int | None = None,
+    site_count: int = 0,
+) -> Company:
+    co = Company(
+        name=name,
+        is_active=True,
+        account_owner_id=owner_id,
+        site_count=site_count,
+    )
+    db.add(co)
+    db.flush()
+    return co
+
+
+def _make_site(
+    db: Session,
+    company: Company,
+    *,
+    site_name: str = "HQ",
+    site_type: str | None = None,
+    city: str | None = None,
+    is_active: bool = True,
+) -> CustomerSite:
+    site = CustomerSite(
+        company_id=company.id,
+        site_name=site_name,
+        site_type=site_type,
+        city=city,
+        is_active=is_active,
+    )
+    db.add(site)
+    db.flush()
+    return site
+
+
+def _make_contact(db: Session, site: CustomerSite, *, full_name: str) -> SiteContact:
+    c = SiteContact(customer_site_id=site.id, full_name=full_name, is_active=True)
+    db.add(c)
+    db.flush()
+    return c
+
+
+def _make_req(db: Session, *, name: str, site_id: int, status: str = "active") -> Requisition:
+    r = Requisition(name=name, customer_site_id=site_id, status=status)
+    db.add(r)
+    db.flush()
+    return r
+
+
+def _render_account_list(companies) -> str:
+    """Render _account_list.html with a minimal ctx (no DB needed)."""
+    from app.template_env import templates
+
+    tmpl = templates.get_template("htmx/partials/customers/_account_list.html")
+    return tmpl.render(
+        companies=companies,
+        total=len(companies),
+        limit=50,
+        offset=0,
+        alert_markers={},
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestSiteDetailRoute
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSiteDetailRoute:
+    def test_valid_company_site_200(self, client, db_session: Session, test_user: User):
+        co = _make_company(db_session, name="SiteDetailCo", owner_id=test_user.id, site_count=2)
+        site = _make_site(db_session, co, site_name="Austin Plant", site_type="warehouse", city="Austin")
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/sites/{site.id}")
+        assert resp.status_code == 200
+        assert "Austin Plant" in resp.text
+
+    def test_idor_site_under_different_company_404(self, client, db_session: Session, test_user: User):
+        co_a = _make_company(db_session, name="CoA", owner_id=test_user.id, site_count=1)
+        co_b = _make_company(db_session, name="CoB", owner_id=test_user.id, site_count=1)
+        site_b = _make_site(db_session, co_b, site_name="UnderB")
+        db_session.commit()
+
+        # Address site_b under company A's path — IDOR scope filter must 404.
+        resp = client.get(f"/v2/partials/customers/{co_a.id}/sites/{site_b.id}")
+        assert resp.status_code == 404
+
+    def test_inactive_site_404(self, client, db_session: Session, test_user: User):
+        co = _make_company(db_session, name="InactiveSiteCo", owner_id=test_user.id, site_count=1)
+        site = _make_site(db_session, co, site_name="Closed", is_active=False)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/sites/{site.id}")
+        assert resp.status_code == 404
+
+    def test_renders_site_contacts(self, client, db_session: Session, test_user: User):
+        co = _make_company(db_session, name="ContactsCo", owner_id=test_user.id, site_count=2)
+        site = _make_site(db_session, co, site_name="Detroit")
+        _make_contact(db_session, site, full_name="Dana Buyer")
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/sites/{site.id}")
+        assert resp.status_code == 200
+        assert "Dana Buyer" in resp.text
+
+    def test_renders_open_requisitions_at_site(self, client, db_session: Session, test_user: User):
+        co = _make_company(db_session, name="ReqsCo", owner_id=test_user.id, site_count=2)
+        site = _make_site(db_session, co, site_name="Memphis")
+        _make_req(db_session, name="REQ-IA-001", site_id=site.id, status="active")
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/sites/{site.id}")
+        assert resp.status_code == 200
+        assert "REQ-IA-001" in resp.text
+        # Section heading present.
+        assert "Open requisitions at this site" in resp.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestCompanyHeaderPartial
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCompanyHeaderPartial:
+    def test_header_200_contains_name(self, client, db_session: Session, test_user: User):
+        co = _make_company(db_session, name="HeaderOnly Inc", owner_id=test_user.id, site_count=3)
+        _make_site(db_session, co, site_name="One")
+        _make_site(db_session, co, site_name="Two")
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/header")
+        assert resp.status_code == 200
+        assert "HeaderOnly Inc" in resp.text
+
+    def test_header_excludes_company_tab_strip(self, client, db_session: Session, test_user: User):
+        co = _make_company(db_session, name="NoTabsCo", owner_id=test_user.id, site_count=2)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/header")
+        assert resp.status_code == 200
+        # The detail.html tab strip wires per-tab hx-gets to /tab/{tab_id}; the
+        # header-only partial must NOT carry that tab navigation.
+        assert "/tab/contacts" not in resp.text
+        assert 'aria-label="Account detail sections"' not in resp.text
+
+    def test_header_missing_company_404(self, client, db_session: Session, test_user: User):
+        resp = client.get("/v2/partials/customers/999999/header")
+        assert resp.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestSitesAccordionPartial
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSitesAccordionPartial:
+    def test_lists_active_sites(self, client, db_session: Session, test_user: User):
+        co = _make_company(db_session, name="AccordionCo", owner_id=test_user.id, site_count=3)
+        _make_site(db_session, co, site_name="North Branch")
+        _make_site(db_session, co, site_name="South Branch")
+        _make_site(db_session, co, site_name="Shuttered", is_active=False)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{co.id}/sites-accordion")
+        assert resp.status_code == 200
+        assert "North Branch" in resp.text
+        assert "South Branch" in resp.text
+        # Inactive site must not appear.
+        assert "Shuttered" not in resp.text
+
+    def test_missing_company_404(self, client, db_session: Session, test_user: User):
+        resp = client.get("/v2/partials/customers/999999/sites-accordion")
+        assert resp.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestAccountListBranching — site_count drives accordion vs direct detail
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAccountListBranching:
+    def test_multi_site_renders_accordion_affordance(self, db_session: Session):
+        # site_count seeded explicitly — the Postgres trigger does not run under
+        # SQLite, so we must not rely on it.
+        co = _make_company(db_session, name="MultiSite Corp", site_count=4)
+        db_session.flush()
+        co.cadence_state = "on_target"
+        html = _render_account_list([co])
+        # Accordion header lazy-loads its children from the sites-accordion route.
+        assert f"/v2/partials/customers/{co.id}/sites-accordion" in html
+        # The company-header partial is the detail target for a multi-site row.
+        assert f"/v2/partials/customers/{co.id}/header" in html
+
+    def test_single_site_renders_direct_detail(self, db_session: Session):
+        co = _make_company(db_session, name="SingleSite Co", site_count=1)
+        db_session.flush()
+        co.cadence_state = "on_target"
+        html = _render_account_list([co])
+        # Direct detail hx-get (today's behavior) — no accordion / header partial.
+        assert f'hx-get="/v2/partials/customers/{co.id}"' in html
+        assert f"/v2/partials/customers/{co.id}/sites-accordion" not in html
+        assert f"/v2/partials/customers/{co.id}/header" not in html
+
+    def test_zero_site_count_behaves_as_single(self, db_session: Session):
+        co = _make_company(db_session, name="ZeroSite Co", site_count=0)
+        db_session.flush()
+        co.cadence_state = "on_target"
+        html = _render_account_list([co])
+        assert f'hx-get="/v2/partials/customers/{co.id}"' in html
+        assert f"/v2/partials/customers/{co.id}/sites-accordion" not in html

--- a/tests/test_datasheet_capture_nightly.py
+++ b/tests/test_datasheet_capture_nightly.py
@@ -91,12 +91,13 @@ class TestIsSafeUrl:
         assert _is_safe_url("http://metadata.internal/data") is False
 
     def test_empty_getaddrinfo_result_returns_false(self, monkeypatch):
-        """getaddrinfo returns empty list → False (line 48)."""
+        """Getaddrinfo returns empty list → False (line 48)."""
         monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [])
         assert _is_safe_url("https://valid.example.com/file.pdf") is False
 
     def test_invalid_ip_string_in_addrinfo_returns_false(self, monkeypatch):
-        """info[4][0] is not a parseable IP address string → ValueError caught → False."""
+        """Info[4][0] is not a parseable IP address string → ValueError caught →
+        False."""
         monkeypatch.setattr(
             socket,
             "getaddrinfo",
@@ -233,7 +234,7 @@ class TestPdfContainsMpn:
         assert result is False
 
     def test_parse_failure_returns_false(self):
-        """pypdf raises on bad bytes → False, no crash."""
+        """Pypdf raises on bad bytes → False, no crash."""
         result = pdf_contains_mpn(b"not a pdf at all", "LM317T")
         assert result is False
 
@@ -283,7 +284,7 @@ class TestFindDatasheetUrl:
         assert result is None
 
     async def test_none_card_with_testing_env_returns_none(self):
-        """card=None and TESTING=1 → returns None."""
+        """Card=None and TESTING=1 → returns None."""
         result = await find_datasheet_url(None, "LM317T")
         assert result is None
 
@@ -316,7 +317,8 @@ class TestCaptureDatasheetAdditionalBranches:
         mock_find.assert_not_called()
 
     async def test_capture_no_card_resolve_returns_none(self, db_session):
-        """card=None and resolve_material_card also returns None → no datasheet stored."""
+        """Card=None and resolve_material_card also returns None → no datasheet
+        stored."""
         from app.services import datasheet_capture as dc
 
         # No card in DB — query returns None

--- a/tests/test_graph_app_auth_nightly.py
+++ b/tests/test_graph_app_auth_nightly.py
@@ -1,5 +1,4 @@
-"""test_graph_app_auth_nightly.py — Coverage boost for
-app/services/graph_app_auth.py.
+"""test_graph_app_auth_nightly.py — Coverage boost for app/services/graph_app_auth.py.
 
 Targets missing lines: cached-token early return, missing-settings None return, HTTP
 error/bad-status/no-token None returns, token + cache update on success, cache expiry

--- a/tests/test_inventory_jobs_nightly.py
+++ b/tests/test_inventory_jobs_nightly.py
@@ -331,7 +331,8 @@ def test_scan_stock_list_attachments_valueerror_caught(db_session, test_user):
 
 
 def test_download_import_skips_row_when_norm_key_is_none(db_session, test_user):
-    """Rows where normalize_mpn_key returns None are skipped (no MaterialCard created)."""
+    """Rows where normalize_mpn_key returns None are skipped (no MaterialCard
+    created)."""
     from app.models import MaterialCard
 
     test_user.access_token = "at_normkey"
@@ -375,7 +376,8 @@ def test_download_import_skips_row_when_norm_key_is_none(db_session, test_user):
 
 
 def test_download_import_sighting_no_reqs_continue(db_session, test_user, test_requisition):
-    """Items whose MPN has no open requirements hit the 'no reqs' continue (line 495)."""
+    """Items whose MPN has no open requirements hit the 'no reqs' continue (line
+    495)."""
     from app.models import Sighting
 
     test_user.access_token = "at_noreqs"
@@ -561,7 +563,8 @@ def test_download_import_sighting_sqlalchemy_error_rolled_back(db_session, test_
 
 
 def test_download_import_sighting_generic_exception_rolled_back(db_session, test_user, test_requisition):
-    """Generic Exception during sighting creation phase rolls back without re-raising."""
+    """Generic Exception during sighting creation phase rolls back without re-
+    raising."""
 
     test_user.access_token = "at_generr"
     test_requisition.status = "active"
@@ -643,8 +646,8 @@ def test_job_buyplan_nudge_ops_per_line_exception_does_not_crash(
 
 
 def test_download_import_sighting_mixed_mpns_one_with_no_req(db_session, test_user, test_requisition):
-    """When import has two MPNs and only one matches an open req, the other
-    hits the 'no reqs' continue at line 495."""
+    """When import has two MPNs and only one matches an open req, the other hits the 'no
+    reqs' continue at line 495."""
     from app.models import MaterialCard, MaterialVendorHistory, Sighting
 
     test_user.access_token = "at_mixed"


### PR DESCRIPTION
Second cockpit refinement (design: docs/superpowers/specs/2026-06-18-crm-disposition-ia-aiorg-design.md). Additive only — no migration, no route renames.

- **Left list** branches on `Company.site_count`: ≤1 → today's direct company-detail load; >1 → the company name becomes an **accordion** (per-row Alpine `x-data`, no window listeners; chevron toggles, name click loads the **company-header** partial + lazy-loads the sites on first expand via `intersect once`).
- **`GET .../{company_id}/header`** — company header + cadence + commercial strip, no tabs.
- **`GET .../{company_id}/sites-accordion`** — lightweight site list.
- **`GET .../{company_id}/sites/{site_id}`** — site-detail (IDOR-safe: site must belong to company AND be active → else 404): site fields + per-site clocks + site-scoped **Contacts** (`company_contact_rows(sites=[site])`) + **Open requisitions at this site**.
- `list.html` gains `selectedSiteId`. All new right-panel triggers carry the `#cdm-detail`/`#cdm-error` contract. New routes declared above the `{company_id}` catch-all.

**Deferred (concurrent-session collision avoidance):** the Notes-FK scoping fix (touches `activity_service.py`) and retiring the in-panel Sites tab — both follow-ups.

Tests: `test_crm_ia.py` 13 ✓ (IDOR 404s, site-scoped contacts, open-reqs, header has no per-site tabs, accordion branch); 454 CRM regression ✓; static guards ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)