### PR TITLE
feat(crm): AI company organization — dedup foundation + surfaces (Increment 3)

### DIFF
--- a/MIGRATION_NUMBERS_IN_FLIGHT.txt
+++ b/MIGRATION_NUMBERS_IN_FLIGHT.txt
@@ -44,3 +44,4 @@
 117 feat/datasheet-company-library material_card_datasheets.library_drive_id (RE-NUMBERED 116->117: 116_site_contact_dnc landed on main first; RE-CHAINED onto 116_site_contact_dnc)
 118 feat/crm-disposition Company.disposition(active/bucket)+disposition_reason/set_by/set_at + site_contacts.is_priority/is_archived (Boolean NOT NULL server_default false); chains onto 117_datasheet_library_drive_id
 119 worktree-comm-ledger-alerts alert_seen table (per-user cross-app alert read-state) for the AlertSource primitive; RE-NUMBERED 117->118->119: feat/datasheet-company-library(117) + feat/crm-disposition(118) merged to main first; RE-CHAINED onto 118_company_disposition, single head verified via `alembic heads`
+120 feat/crm-aiorg Company.normalized_name(pg_trgm GIN, Postgres-guarded)+alternate_names JSON; backfill from name; chains onto 119_alert_seen

--- a/alembic/versions/120_company_name_matching.py
+++ b/alembic/versions/120_company_name_matching.py
@@ -1,0 +1,84 @@
+"""Company name-matching foundation — normalized_name + alternate_names (Increment 3).
+
+Mirrors VendorCard's dedup foundation onto Company so the duplicate scanner has a durable
+match key and merges can record absorbed (loser) names:
+
+- companies.normalized_name (String(255), nullable, btree-indexed): the suffix-stripped /
+  lowercased match key. NULLABLE and NOT unique on purpose — companies legitimately share
+  a normalized form across the dedup window (the policy keeps different-owner accounts
+  separate), so this is a similarity key, not a constraint (contrast VendorCard, where it
+  IS unique). Kept in lockstep with `name` by Company._sync_normalized_name (@validates).
+- companies.alternate_names (JSON): names this company has been known by; merge_companies
+  appends the loser's name (+ its alternates) here so a re-import of the old name
+  fuzzy-matches an existing card instead of recreating the duplicate.
+
+Backfill: normalized_name is populated from the existing `name` using the SAME normalizer
+the scanner uses (app.vendor_utils.normalize_vendor_name) — Inc/LLC/Ltd/Corp/GmbH +
+leading-"the" stripped, lowercased, whitespace collapsed. Blank/whitespace names stay NULL.
+
+pg_trgm: on PostgreSQL we additionally create a GIN(normalized_name gin_trgm_ops) index so
+find_company_dedup_candidates can drop the 500-row O(n^2) rapidfuzz cap and scan with
+func.similarity(). pg_trgm is Postgres-only; the extension + GIN index are guarded behind
+`dialect.name == "postgresql"` (the SQLite test DB keeps the rapidfuzz path —
+feedback_sqlite_masks_postgres). The plain btree index is created on all dialects.
+
+Revision ID: 120_company_name_matching
+Revises: 119_alert_seen
+Create Date: 2026-06-19
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "120_company_name_matching"
+down_revision = "119_alert_seen"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    op.add_column("companies", sa.Column("normalized_name", sa.String(length=255), nullable=True))
+    op.add_column("companies", sa.Column("alternate_names", sa.JSON(), nullable=True))
+
+    # Plain btree index (all dialects) — exact-normalized lookups + the column scan.
+    op.create_index("ix_companies_normalized_name", "companies", ["normalized_name"], unique=False)
+
+    # Backfill normalized_name from name with the project normalizer (identical to
+    # scan-time scoring). Done in Python so the regex/suffix logic stays single-sourced.
+    from app.vendor_utils import normalize_vendor_name
+
+    companies = sa.table(
+        "companies",
+        sa.column("id", sa.Integer),
+        sa.column("name", sa.String),
+        sa.column("normalized_name", sa.String),
+    )
+    rows = bind.execute(sa.select(companies.c.id, companies.c.name)).fetchall()
+    for row in rows:
+        norm = normalize_vendor_name(row.name or "") or None
+        if norm:
+            bind.execute(sa.update(companies).where(companies.c.id == row.id).values(normalized_name=norm))
+
+    if bind.dialect.name == "postgresql":
+        # pg_trgm GIN index for similarity() scanning — Postgres-only (SQLite has no
+        # pg_trgm; the scanner falls back to rapidfuzz there).
+        op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        op.create_index(
+            "ix_companies_normalized_name_trgm",
+            "companies",
+            [sa.text("normalized_name gin_trgm_ops")],
+            unique=False,
+            postgresql_using="gin",
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.drop_index("ix_companies_normalized_name_trgm", table_name="companies", if_exists=True)
+    op.drop_index("ix_companies_normalized_name", table_name="companies")
+    op.drop_column("companies", "alternate_names")
+    op.drop_column("companies", "normalized_name")

--- a/app/company_utils.py
+++ b/app/company_utils.py
@@ -1,6 +1,32 @@
 """Company name normalization and fuzzy dedup helpers."""
 
+import re
+
+from .vendor_utils import _SUFFIX_PATTERN
 from .vendor_utils import normalize_vendor_name as normalize_company_name
+
+
+def suggest_clean_company_name(name: str) -> str:
+    """Return a display-cased name with legal suffixes / leading "the" stripped.
+
+    The suggest-only counterpart to normalize_company_name (which lowercases for
+    matching): this preserves the original casing so the chip can offer a human-friendly
+    "Suggested name". Reuses the SAME suffix regex as the matcher, applied to the
+    original-case string. Returns "" if the input is empty or normalizes to nothing.
+    """
+    if not name:
+        return ""
+    n = name.strip()
+    for _ in range(3):
+        prev = n
+        n = re.sub(r",\s*$", "", n)
+        n = _SUFFIX_PATTERN.sub("", n).strip()
+        n = re.sub(r"[,.\-]+$", "", n).strip()
+        if n == prev:
+            break
+    n = re.sub(r"^the\s+", "", n, flags=re.IGNORECASE)
+    n = re.sub(r"\s+", " ", n).strip()
+    return n
 
 
 def _auto_keep_rank(company: dict) -> tuple[int, int, int, int]:
@@ -16,22 +42,126 @@ def _auto_keep_rank(company: dict) -> tuple[int, int, int, int]:
     )
 
 
-def find_company_dedup_candidates(db, threshold: int = 85, limit: int = 50) -> list[dict]:
-    """Find potential duplicate companies using fuzzy name matching.
+def _pair_dict(a: dict, b: dict, score: int) -> dict:
+    """Build one nested candidate dict (the public shape both backends emit).
 
-    Queries active companies, normalizes names, and pairwise compares with
-    token_sort_ratio.  Returns scored pairs with an auto_keep_id heuristic:
-      1. More sites wins
-      2. Tie → has account_owner_id wins
-      3. Tie → is_strategic wins
-      4. Tie → lower id (older record) wins
+    auto_keep_id follows the heuristic: more sites → has owner → is strategic → older id.
+    """
+    auto_keep = a if _auto_keep_rank(a) >= _auto_keep_rank(b) else b
+    return {
+        "company_a": {
+            "id": a["id"],
+            "name": a["name"],
+            "site_count": a["site_count"],
+            "has_owner": a["has_owner"],
+        },
+        "company_b": {
+            "id": b["id"],
+            "name": b["name"],
+            "site_count": b["site_count"],
+            "has_owner": b["has_owner"],
+        },
+        "score": int(score),
+        "auto_keep_id": auto_keep["id"],
+    }
+
+
+def _find_company_dedup_candidates_pg(db, threshold: int, limit: int) -> list[dict]:
+    """PostgreSQL path: pg_trgm self-join on normalized_name — no 500-row O(n^2) cap.
+
+    Uses func.similarity() over the GIN(normalized_name gin_trgm_ops) index (migration
+    120). The `%` operator (set via pg_trgm.similarity_threshold default 0.3) plus an
+    explicit similarity() >= threshold/100 predicate keep only real near-dups. Pairs are
+    deduplicated with a < b on id so each unordered pair appears once. site_count /
+    has_owner / is_strategic are fetched per id afterward for the auto_keep heuristic and
+    the rendered row.
+    """
+    from sqlalchemy import func, text
+
+    from .models import Company, CustomerSite
+
+    a = Company.__table__.alias("a")
+    b = Company.__table__.alias("b")
+    sim = func.similarity(a.c.normalized_name, b.c.normalized_name)
+
+    pair_rows = (
+        db.query(
+            a.c.id.label("a_id"),
+            a.c.name.label("a_name"),
+            b.c.id.label("b_id"),
+            b.c.name.label("b_name"),
+            sim.label("sim"),
+        )
+        .filter(
+            a.c.is_active.is_(True),
+            b.c.is_active.is_(True),
+            a.c.id < b.c.id,
+            a.c.normalized_name.isnot(None),
+            b.c.normalized_name.isnot(None),
+            a.c.normalized_name != "",
+            b.c.normalized_name != "",
+            a.c.normalized_name.op("%")(b.c.normalized_name),
+            sim >= (threshold / 100.0),
+        )
+        .order_by(text("sim DESC"))
+        .limit(limit)
+        .all()
+    )
+
+    if not pair_rows:
+        return []
+
+    # Fetch attributes for every company involved (one grouped query).
+    ids = {r.a_id for r in pair_rows} | {r.b_id for r in pair_rows}
+    attr_rows = (
+        db.query(
+            Company.id,
+            Company.account_owner_id,
+            Company.is_strategic,
+            func.count(CustomerSite.id).label("site_count"),
+        )
+        .outerjoin(CustomerSite, CustomerSite.company_id == Company.id)
+        .filter(Company.id.in_(ids))
+        .group_by(Company.id)
+        .all()
+    )
+    attrs = {
+        r.id: {
+            "site_count": r.site_count or 0,
+            "has_owner": r.account_owner_id is not None,
+            "is_strategic": bool(r.is_strategic),
+        }
+        for r in attr_rows
+    }
+
+    candidates = []
+    for r in pair_rows:
+        a_dict = {
+            "id": r.a_id,
+            "name": r.a_name,
+            **attrs.get(r.a_id, {"site_count": 0, "has_owner": False, "is_strategic": False}),
+        }
+        b_dict = {
+            "id": r.b_id,
+            "name": r.b_name,
+            **attrs.get(r.b_id, {"site_count": 0, "has_owner": False, "is_strategic": False}),
+        }
+        candidates.append(_pair_dict(a_dict, b_dict, round(r.sim * 100)))
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    return candidates
+
+
+def _find_company_dedup_candidates_rapidfuzz(db, threshold: int, limit: int) -> list[dict]:
+    """SQLite / fallback path: load active companies and pairwise token_sort_ratio.
+
+    Preserves the original 500-row cap (rapidfuzz is O(n^2) in Python). Used by the test
+    DB, which has no pg_trgm.
     """
     from rapidfuzz import fuzz
     from sqlalchemy import func
 
     from .models import Company, CustomerSite
 
-    # Load up to 500 active companies with site counts
     rows = (
         db.query(
             Company.id,
@@ -48,7 +178,6 @@ def find_company_dedup_candidates(db, threshold: int = 85, limit: int = 50) -> l
         .all()
     )
 
-    # Normalize names up front
     enriched = []
     for r in rows:
         norm = normalize_company_name(r.name)
@@ -65,32 +194,11 @@ def find_company_dedup_candidates(db, threshold: int = 85, limit: int = 50) -> l
             )
 
     candidates = []
-
     for i, a in enumerate(enriched):
         for b in enriched[i + 1 :]:
             score = fuzz.token_sort_ratio(a["norm"], b["norm"])
             if score >= threshold:
-                auto_keep = a if _auto_keep_rank(a) >= _auto_keep_rank(b) else b
-
-                candidates.append(
-                    {
-                        "company_a": {
-                            "id": a["id"],
-                            "name": a["name"],
-                            "site_count": a["site_count"],
-                            "has_owner": a["has_owner"],
-                        },
-                        "company_b": {
-                            "id": b["id"],
-                            "name": b["name"],
-                            "site_count": b["site_count"],
-                            "has_owner": b["has_owner"],
-                        },
-                        "score": score,
-                        "auto_keep_id": auto_keep["id"],
-                    }
-                )
-
+                candidates.append(_pair_dict(a, b, score))
             if len(candidates) >= limit:
                 break
         if len(candidates) >= limit:
@@ -98,3 +206,22 @@ def find_company_dedup_candidates(db, threshold: int = 85, limit: int = 50) -> l
 
     candidates.sort(key=lambda x: x["score"], reverse=True)
     return candidates
+
+
+def find_company_dedup_candidates(db, threshold: int = 85, limit: int = 50) -> list[dict]:
+    """Find potential duplicate companies using fuzzy name matching.
+
+    Returns scored pairs with an auto_keep_id heuristic (more sites → has account owner →
+    is strategic → lower id). Each pair is nested:
+        {"company_a": {id, name, site_count, has_owner},
+         "company_b": {...}, "score": int, "auto_keep_id": int}
+
+    Backend by dialect (same shape either way):
+      - PostgreSQL: pg_trgm self-join on normalized_name via func.similarity() — drops the
+        500-row O(n^2) cap (migration 120's GIN index).
+      - SQLite / fallback: the original rapidfuzz token_sort_ratio scan (500-row cap),
+        keeping the test DB green (pg_trgm is Postgres-only — feedback_sqlite_masks_postgres).
+    """
+    if db.bind is not None and db.bind.dialect.name == "postgresql":
+        return _find_company_dedup_candidates_pg(db, threshold, limit)
+    return _find_company_dedup_candidates_rapidfuzz(db, threshold, limit)

--- a/app/models/crm.py
+++ b/app/models/crm.py
@@ -16,6 +16,18 @@ class Company(Base):
     __tablename__ = "companies"
     id = Column(Integer, primary_key=True)
     name = Column(String(255), nullable=False)
+
+    # AI organization (Increment 3) — durable dedup foundation, mirrors VendorCard.
+    # normalized_name is the suffix-stripped/lowercased match key, kept in sync with
+    # `name` by the @validates hook below. Unlike VendorCard it is NULLABLE and NOT
+    # unique: companies legitimately share a normalized form across the dedup window
+    # (e.g. different-owner accounts the policy keeps separate). The pg_trgm GIN index
+    # (migration 120, Postgres-only) is for similarity scanning, not a constraint.
+    normalized_name = Column(String(255), index=True)
+    # Names this company has been known by (loser names absorbed on merge), so a
+    # re-import of the old name fuzzy-matches here instead of recreating the dupe.
+    alternate_names = Column(JSON, default=list)
+
     website = Column(String(500))
     industry = Column(String(255))
     notes = Column(Text)
@@ -95,6 +107,21 @@ class Company(Base):
     def _validate_currency(self, _key, value):
         if value is not None and not re.fullmatch(r"[A-Z]{3}", value):
             raise ValueError(f"Invalid ISO 4217 currency code: {value}")
+        return value
+
+    @validates("name")
+    def _sync_normalized_name(self, _key, value):
+        """Keep normalized_name in lockstep with name on every create/rename.
+
+        Uses the same normalizer the dedup scanner uses
+        (vendor_utils.normalize_vendor_name via company_utils), so the durable match key
+        is identical to scan-time scoring. Covers all create paths (API create,
+        prospect-claim, importers) without touching each one. Empty/whitespace names
+        normalize to None (no spurious '' match key).
+        """
+        from ..vendor_utils import normalize_vendor_name
+
+        self.normalized_name = normalize_vendor_name(value) or None
         return value
 
     __table_args__ = (

--- a/app/routers/crm/companies.py
+++ b/app/routers/crm/companies.py
@@ -376,7 +376,12 @@ async def create_company(
     """
     from ...enrichment_service import normalize_company_input
 
+    # AI typo-fix + domain cleanup. SUGGEST-ONLY for the NAME (Increment 3): the
+    # AI-corrected name is used to strengthen the duplicate check, but the stored name is
+    # what the rep typed (whitespace-trimmed). Any normalization is surfaced post-create
+    # as the "Suggested name — Apply?" chip rather than silently overwriting the input.
     clean_name, clean_domain = await normalize_company_input(payload.name, payload.domain or "")
+    stored_name = (payload.name or "").strip() or clean_name
 
     # Duplicate check (unless force=True)
     if not force:
@@ -394,7 +399,7 @@ async def create_company(
             payload.website.replace("https://", "").replace("http://", "").replace("www.", "").split("/")[0].lower()
         )
     company = Company(
-        name=clean_name,
+        name=stored_name,
         website=payload.website,
         industry=payload.industry,
         notes=payload.notes,

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -5454,6 +5454,119 @@ async def company_site_detail_partial(
     return template_response("htmx/partials/customers/site_detail.html", ctx)
 
 
+# ── Increment 3: AI-organization surfaces (per-account) ───────────────────────
+# STATIC trailing segments (dup-suggestion / name-suggestion / apply-name), so they
+# MUST precede the GET /v2/partials/customers/{company_id} catch-all below. ADDITIVE —
+# the merge engine (merge_companies) and the dedup scanner are reused as-is; no merge
+# logic lives here. The dup banner reuses the existing merge-form → preview → POST
+# .../merge flow. Naming is suggest-only — never a silent rewrite.
+
+
+@router.get("/v2/partials/customers/{company_id}/dup-suggestion", response_class=HTMLResponse)
+async def company_dup_suggestion(
+    request: Request,
+    company_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Lazy per-account duplicate banner — top dedup match for THIS company + a Merge
+    button reusing the merge-form/preview/merge flow.
+
+    Renders nothing (empty 200) when there is no near-duplicate.
+    """
+    from ..company_utils import find_company_dedup_candidates
+
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    # Scan, then pick the highest-scoring pair that INVOLVES this company. The scanner
+    # already honors the auto_keep heuristic; here we only need the OTHER side as the
+    # merge-away candidate.
+    try:
+        candidates = find_company_dedup_candidates(db, threshold=85, limit=50)
+    except Exception as e:  # pragma: no cover - defensive, mirrors data-ops scan guard
+        logger.warning("dup-suggestion scan failed for company {}: {}", company_id, e)
+        return HTMLResponse("")
+
+    match = None
+    for pair in candidates:
+        a, b = pair["company_a"], pair["company_b"]
+        if a["id"] == company_id:
+            match = {"id": b["id"], "name": b["name"], "score": pair["score"]}
+            break
+        if b["id"] == company_id:
+            match = {"id": a["id"], "name": a["name"], "score": pair["score"]}
+            break
+
+    if not match:
+        return HTMLResponse("")
+
+    ctx = {"request": request, "company": company, "match": match}
+    return template_response("htmx/partials/customers/_dup_suggestion.html", ctx)
+
+
+@router.get("/v2/partials/customers/{company_id}/name-suggestion", response_class=HTMLResponse)
+async def company_name_suggestion(
+    request: Request,
+    company_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Suggest-only name-normalization chip: surface the suffix-stripped form of the
+    current name as "Suggested name: X — Apply?".
+
+    Uses the same normalizer the dedup scanner uses, re-cased from the original tokens
+    (so we only strip the legal suffix / leading "the", never lowercase the whole name).
+    Renders nothing (empty 200) when the current name is already clean.
+    """
+    from ..company_utils import suggest_clean_company_name
+
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    suggested = suggest_clean_company_name(company.name or "")
+    if not suggested or suggested == (company.name or "").strip():
+        return HTMLResponse("")
+
+    ctx = {"request": request, "company": company, "suggested": suggested}
+    return template_response("htmx/partials/customers/_name_suggestion.html", ctx)
+
+
+@router.post("/v2/partials/customers/{company_id}/apply-name", response_class=HTMLResponse)
+async def company_apply_name(
+    request: Request,
+    company_id: int,
+    name: str = Form(...),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Apply a suggested company name (rep-initiated; the suggest-only counterpart to a
+    silent rewrite).
+
+    normalized_name follows automatically via Company._sync_normalized_name
+    (@validates). Returns an empty 200 so the chip removes itself (hx-swap outerHTML).
+    """
+    company = db.query(Company).filter(Company.id == company_id).first()
+    if not company:
+        raise HTTPException(404, "Company not found")
+
+    new_name = (name or "").strip()
+    if not new_name:
+        raise HTTPException(400, "Name is required")
+
+    company.name = new_name  # @validates resyncs normalized_name
+    db.commit()
+
+    from ..cache.decorators import invalidate_prefix
+
+    invalidate_prefix("company_list")
+    invalidate_prefix("companies_typeahead")
+    logger.info("Company {} renamed to '{}' (suggested) by {}", company_id, new_name, user.email)
+    return HTMLResponse("")
+
+
 @router.get("/v2/partials/customers/{company_id}", response_class=HTMLResponse)
 async def company_detail_partial(
     request: Request,

--- a/app/services/company_merge_service.py
+++ b/app/services/company_merge_service.py
@@ -53,6 +53,24 @@ def merge_companies(keep_id: int, remove_id: int, db: Session) -> dict:
         sep = f"\n\n--- Merged from {remove.name} ---\n"
         keep.notes = (keep.notes or "") + sep + remove.notes
 
+    # 2b. Absorb the loser's name + its alternates into keep.alternate_names so a
+    #     re-import of the old name fuzzy-matches the survivor instead of recreating the
+    #     duplicate (mirrors VendorCard._record_alternate_name). Dedup, and never store
+    #     keep's own display name as one of its alternates. Backfill keep.normalized_name
+    #     if it was never set (legacy rows pre-date migration 120).
+    alts = list(keep.alternate_names or [])
+    seen = set(alts)
+    for candidate in [remove.name, *(remove.alternate_names or [])]:
+        if candidate and candidate != keep.name and candidate not in seen:
+            alts.append(candidate)
+            seen.add(candidate)
+    keep.alternate_names = alts
+
+    if not keep.normalized_name:
+        from ..vendor_utils import normalize_vendor_name
+
+        keep.normalized_name = normalize_vendor_name(keep.name or "") or None
+
     # 3. Fill enrichment gaps
     for field in (
         "domain",

--- a/app/templates/htmx/partials/customers/_dup_suggestion.html
+++ b/app/templates/htmx/partials/customers/_dup_suggestion.html
@@ -1,0 +1,33 @@
+{# _dup_suggestion.html — per-account "possible duplicate" banner (Increment 3, AI-org).
+   Lazy-loaded into detail.html via hx-trigger=load. Surfaces the single top dedup match
+   for THIS account and offers a Merge button that reuses the existing
+   merge-form → merge-preview → POST .../merge flow (no merge logic here).
+   Renders nothing (empty 200) when there is no near-duplicate.
+   Receives: company (Company, the keeper), match {id, name, score}.
+   Called by: company_dup_suggestion route in htmx_views.py.
+   Depends on: HTMX, Alpine.js, Tailwind brand palette, _merge_form.html.
+#}
+<div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
+  <div class="flex items-start justify-between gap-3">
+    <div class="min-w-0">
+      <p class="text-sm font-semibold text-amber-800">
+        Possible duplicate account
+      </p>
+      <p class="mt-0.5 text-sm text-amber-700">
+        <span class="font-medium">{{ match.name }}</span>
+        looks like the same company ({{ match.score }}% name match).
+      </p>
+    </div>
+    <button type="button"
+            title="Merge {{ match.name }} into {{ company.name }}"
+            class="flex-shrink-0 inline-flex items-center gap-1 rounded-md border border-amber-300
+                   bg-white px-2.5 py-1.5 text-xs font-medium text-amber-800 hover:bg-amber-100
+                   focus:outline-none focus:ring-2 focus:ring-amber-500"
+            hx-get="/v2/partials/customers/{{ company.id }}/merge-form"
+            hx-target="#modal-content"
+            hx-swap="innerHTML"
+            @click="$dispatch('open-modal')">
+      Review &amp; merge
+    </button>
+  </div>
+</div>

--- a/app/templates/htmx/partials/customers/_name_suggestion.html
+++ b/app/templates/htmx/partials/customers/_name_suggestion.html
@@ -1,0 +1,22 @@
+{# _name_suggestion.html — suggest-only company-name normalization chip (Increment 3).
+   Surfaces the cleaned name (suffix-stripped via the same normalizer the importer uses)
+   as "Suggested name: X — Apply?". NEVER rewrites silently: the rep clicks Apply, which
+   POSTs to the apply-name route. After applying, the chip swaps itself out (empty).
+   Renders nothing (empty 200) when the current name is already clean.
+   Receives: company (Company), suggested (str).
+   Called by: company_name_suggestion route in htmx_views.py.
+   Depends on: HTMX, Tailwind brand palette.
+#}
+<div class="inline-flex items-center gap-2 rounded-md border border-brand-200 bg-brand-50
+            px-2.5 py-1 text-xs text-brand-700">
+  <span>Suggested name: <span class="font-semibold">{{ suggested }}</span></span>
+  <button type="button"
+          class="rounded bg-brand-500 px-2 py-0.5 text-[11px] font-medium text-white
+                 hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          hx-post="/v2/partials/customers/{{ company.id }}/apply-name"
+          hx-vals='{"name": {{ suggested|tojson }}}'
+          hx-target="closest div"
+          hx-swap="outerHTML">
+    Apply
+  </button>
+</div>

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -12,6 +12,14 @@
 {# max-w-3xl: must fit the CDM right panel (~60% viewport), not just full-page #}
 <div class="max-w-3xl mx-auto space-y-6">
 
+  {# Possible-duplicate banner — lazy (hx-target=this avoids inheriting the
+     #main-content hx-target). Renders nothing when there is no near-dup. #}
+  <div hx-get="/v2/partials/customers/{{ company.id }}/dup-suggestion"
+       hx-target="this"
+       hx-trigger="load"
+       hx-swap="innerHTML"
+       class="empty:hidden"></div>
+
   {# ── Header Card ─────────────────────────────────────────── #}
   <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-6">
     <div class="flex items-start justify-between">
@@ -22,6 +30,12 @@
         </div>
         <div>
           <h1 class="text-2xl font-bold text-gray-900">{{ company.name }}</h1>
+          {# Suggest-only name-normalization chip — lazy, renders nothing when clean. #}
+          <div hx-get="/v2/partials/customers/{{ company.id }}/name-suggestion"
+               hx-target="this"
+               hx-trigger="load"
+               hx-swap="innerHTML"
+               class="mt-1 empty:hidden"></div>
           <div class="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500">
             {% if company.domain %}
               <a href="https://{{ company.domain }}" target="_blank" rel="noopener noreferrer" class="text-brand-500 hover:text-brand-600">{{ company.domain }}</a>

--- a/app/templates/htmx/partials/settings/data_ops.html
+++ b/app/templates/htmx/partials/settings/data_ops.html
@@ -76,19 +76,31 @@
 
     {% if company_dupes %}
     <div class="divide-y divide-gray-100">
+      {# find_company_dedup_candidates returns NESTED pairs: pair.company_a/company_b
+         each {id, name, site_count, has_owner}, plus pair.score + pair.auto_keep_id.
+         The default-direction button keeps auto_keep_id (more sites → has owner →
+         strategic → older); the second button keeps the other side. Both wire to the
+         admin company-merge endpoint, swapping the row in place. #}
       {% for pair in company_dupes %}
+      {% set keep_first = (pair.auto_keep_id == pair.company_a.id) %}
+      {% set keeper = pair.company_a if keep_first else pair.company_b %}
+      {% set loser = pair.company_b if keep_first else pair.company_a %}
       <div class="px-4 py-3 flex items-center gap-4">
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 text-sm">
-            <span class="font-medium text-gray-900">{{ pair.name_a }}</span>
+            <span class="font-medium text-gray-900">{{ pair.company_a.name }}</span>
             <span class="text-gray-400">&harr;</span>
-            <span class="font-medium text-gray-900">{{ pair.name_b }}</span>
+            <span class="font-medium text-gray-900">{{ pair.company_b.name }}</span>
           </div>
-          <p class="text-xs text-gray-500 mt-0.5">Score: {{ pair.score }}% match</p>
+          <p class="text-xs text-gray-500 mt-0.5">
+            Score: {{ pair.score }}% match
+            &middot; {{ pair.company_a.site_count or 0 }} vs {{ pair.company_b.site_count or 0 }} sites
+            &middot; suggested keep: <span class="font-medium text-gray-700">{{ keeper.name|truncate(24) }}</span>
+          </p>
         </div>
         <div class="flex gap-2">
-          {{ merge_button('          ', '/v2/partials/admin/company-merge', 'closest div.flex.items-center', pair.id_a, pair.id_b, pair.name_a, pair.name_b) }}
-          {{ merge_button('          ', '/v2/partials/admin/company-merge', 'closest div.flex.items-center', pair.id_b, pair.id_a, pair.name_b, pair.name_a) }}
+          {{ merge_button('          ', '/v2/partials/admin/company-merge', 'closest div.flex.items-center', keeper.id, loser.id, keeper.name, loser.name) }}
+          {{ merge_button('          ', '/v2/partials/admin/company-merge', 'closest div.flex.items-center', loser.id, keeper.id, loser.name, keeper.name) }}
         </div>
       </div>
       {% endfor %}

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -268,6 +268,8 @@ Managed via Settings > Ops Group (admin only); seeded from `ADMIN_EMAILS` on sta
 | disposition_reason | String, nullable | Optional free-text rationale for the disposition (parity with prospect dismiss audit). |
 | disposition_set_by | FK -> users (SET NULL) | Who set the disposition. |
 | disposition_set_at | UTCDateTime, nullable | When the disposition was last set. |
+| normalized_name | String 255, indexed (btree + Postgres GIN pg_trgm), **nullable, NOT unique** | Migration 120 (Increment 3, AI-org). Suffix-stripped/lowercased dedup match key, kept in lockstep with `name` by `Company._sync_normalized_name` (`@validates("name")`) using `vendor_utils.normalize_vendor_name` — the SAME normalizer the dedup scanner scores with. Mirrors VendorCard but is **nullable + non-unique** on purpose (companies legitimately share a normalized form across the dedup window; the policy keeps different-owner accounts separate). The `ix_companies_normalized_name_trgm` GIN index is Postgres-guarded (`dialect.name == 'postgresql'`); SQLite gets only the btree and the scanner falls back to rapidfuzz. |
+| alternate_names | JSON (default []) | Migration 120. Names this company has been known by. `merge_companies` appends the loser's `name` (+ its own `alternate_names`, deduped, never keep's display name) so a re-import of the old name fuzzy-matches the survivor instead of recreating the duplicate (mirrors `VendorCard._record_alternate_name`). |
 
 **`customer_sites`** — Delivery/contact locations for a company
 | Column | Type | Notes |

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1444,6 +1444,41 @@ Three additive routes in `htmx_views.py` (declared ABOVE the
 The legacy in-panel **Sites tab** (`tabs/sites_tab.html` / `site_card.html`) is
 left intact (harmlessly redundant) — its retirement is a follow-up.
 
+**AI organization (Increment 3, migration 120).** Durable company-dedup foundation +
+review/banner surfaces — the merge engine (`company_merge_service.merge_companies`) and
+the locked nightly tiering (`auto_dedup_service`: ≥98 auto / 92-97 Claude-confirm, never
+merges different-`account_owner_id` accounts) are reused AS-IS.
+- **Durable foundation:** `companies.normalized_name` (kept in lockstep with `name` via
+  `Company._sync_normalized_name` `@validates`) + `companies.alternate_names`.
+  `merge_companies` now also appends the loser's `name` + its alternates into
+  `keep.alternate_names` (deduped) and backfills `keep.normalized_name` if empty, so a
+  re-import of the old name fuzzy-matches the survivor.
+- **Scanner** `company_utils.find_company_dedup_candidates(db, threshold, limit)` returns
+  NESTED pairs `{company_a:{id,name,site_count,has_owner}, company_b:{…}, score,
+  auto_keep_id}`. Dialect-split, same shape: **PostgreSQL** = pg_trgm self-join on
+  `normalized_name` via `func.similarity()` (drops the 500-row O(n²) cap, uses the GIN
+  index); **SQLite/fallback** = the original rapidfuzz `token_sort_ratio` scan (500-row
+  cap) so the test DB stays green.
+- **Review queue (home):** `settings/data_ops.html` Company-Duplicates loop rewritten
+  against the nested shape (was reading FLAT `pair.name_a/id_a/sightings_a` → rendered
+  blank + emitted empty merge ids; dead). Default keep/remove direction follows
+  `pair.auto_keep_id`; both buttons POST `/v2/partials/admin/company-merge`. Reached via
+  `GET /v2/partials/settings/data-ops` (`require_user` + explicit `is_admin` gate).
+- **Per-account banner:** `GET .../{company_id}/dup-suggestion` (`company_dup_suggestion`,
+  declared ABOVE the catch-all) → lazy `hx-trigger=load` panel in `detail.html` →
+  `_dup_suggestion.html`. Shows the top dedup match INVOLVING this company + a "Review &
+  merge" button reusing the existing `merge-form → merge-preview → POST .../merge` flow.
+  Empty 200 when no near-dup.
+- **Name-suggestion chip (suggest-only):** `GET .../{company_id}/name-suggestion`
+  (`company_name_suggestion`) → `_name_suggestion.html`, lazy in the header. Surfaces
+  `company_utils.suggest_clean_company_name` (display-cased suffix-strip) as "Suggested
+  name: X" with an Apply button → `POST .../{company_id}/apply-name`
+  (`company_apply_name`; sets `Company.name`, `@validates` resyncs `normalized_name`,
+  `invalidate_prefix('company_list','companies_typeahead')`). Empty 200 when already
+  clean. **create_company no longer silently stores the AI-typo-corrected name** — it
+  keeps the rep's typed name (the AI fix still strengthens the duplicate check), making
+  naming suggest-only end-to-end.
+
 ---
 
 ## 11. Cross-App Alerts (Nav Badges + In-Tab Spotlight)

--- a/tests/test_crm_aiorg.py
+++ b/tests/test_crm_aiorg.py
@@ -1,0 +1,281 @@
+"""test_crm_aiorg.py — Increment 3: AI company organization (durable foundation +
+surfaces).
+
+Covers:
+- Company.normalized_name derived/backfilled from name (suffix-stripped) + set on create.
+- merge_companies appends the loser's name to keep.alternate_names (dedup) + backfills
+  keep.normalized_name.
+- find_company_dedup_candidates nested shape + finds an obvious near-dup pair on SQLite.
+- The settings/data_ops Company-Duplicates review queue renders names (not blank) +
+  emits non-empty merge ids for a seeded dup pair (admin client).
+- The per-account dup-suggestion route (200 with a Merge affordance when a near-dup
+  exists; empty when none; auth-gated).
+- The name-suggestion chip surfaces a suggestion for a suffix-heavy name + the apply
+  route updates the name.
+
+Called by: pytest
+Depends on: conftest.py fixtures, app.company_utils, app.services.company_merge_service,
+            app.routers.htmx_views
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.company_utils import find_company_dedup_candidates, normalize_company_name
+from app.models import Company, CustomerSite, User
+from app.services.company_merge_service import merge_companies
+
+
+def _make_company(db: Session, name: str, *, sites: int = 0, normalized_name=..., domain=None) -> Company:
+    kwargs = dict(
+        name=name,
+        is_active=True,
+        domain=domain,
+        created_at=datetime.now(timezone.utc),
+    )
+    if normalized_name is not ...:
+        kwargs["normalized_name"] = normalized_name
+    c = Company(**kwargs)
+    db.add(c)
+    db.flush()
+    for i in range(sites):
+        db.add(CustomerSite(company_id=c.id, site_name=f"Site {i + 1}", created_at=datetime.now(timezone.utc)))
+    db.flush()
+    return c
+
+
+# ── normalized_name on the model ──────────────────────────────────────────
+
+
+class TestNormalizedName:
+    def test_set_explicitly_matches_normalizer(self, db_session: Session):
+        c = _make_company(db_session, "Mouser Electronics, Inc.", normalized_name=...)
+        # The create paths set normalized_name from the name; emulate the validator/event.
+        assert c.normalized_name is not None
+        assert c.normalized_name == normalize_company_name("Mouser Electronics, Inc.")
+        assert c.normalized_name == "mouser electronics"
+
+    def test_event_fires_on_rename(self, db_session: Session):
+        c = _make_company(db_session, "Acme Corp")
+        assert c.normalized_name == "acme"
+        c.name = "Globex LLC"
+        db_session.flush()
+        assert c.normalized_name == "globex"
+
+    def test_alternate_names_defaults_to_list(self, db_session: Session):
+        c = _make_company(db_session, "Acme Corp")
+        db_session.commit()
+        db_session.refresh(c)
+        assert c.alternate_names == []
+
+
+# ── merge_companies alternate-name + normalized_name behavior ───────────────
+
+
+class TestMergeAlternateNames:
+    def test_loser_name_appended_to_keep_alternates(self, db_session: Session):
+        keep = _make_company(db_session, "Arrow Electronics")
+        remove = _make_company(db_session, "Arrow Electronic")
+        db_session.commit()
+
+        merge_companies(keep.id, remove.id, db_session)
+        db_session.commit()
+        db_session.refresh(keep)
+
+        assert "Arrow Electronic" in (keep.alternate_names or [])
+
+    def test_loser_alternates_carried_over_dedup(self, db_session: Session):
+        keep = _make_company(db_session, "Arrow Electronics")
+        remove = _make_company(db_session, "Arrow Electronic")
+        remove.alternate_names = ["Arrow Elec Co", "Arrow Electronics"]  # one dupes keep.name
+        db_session.commit()
+
+        merge_companies(keep.id, remove.id, db_session)
+        db_session.commit()
+        db_session.refresh(keep)
+
+        alts = keep.alternate_names or []
+        # Loser name + its alternate are present.
+        assert "Arrow Electronic" in alts
+        assert "Arrow Elec Co" in alts
+        # No duplicates, and keep's own display name is not stored as an alternate.
+        assert len(alts) == len(set(alts))
+        assert "Arrow Electronics" not in alts
+
+    def test_backfills_keep_normalized_name_when_empty(self, db_session: Session):
+        keep = _make_company(db_session, "Arrow Electronics", normalized_name=None)
+        remove = _make_company(db_session, "Arrow Electronic")
+        db_session.commit()
+
+        merge_companies(keep.id, remove.id, db_session)
+        db_session.commit()
+        db_session.refresh(keep)
+
+        assert keep.normalized_name == normalize_company_name("Arrow Electronics")
+
+
+# ── find_company_dedup_candidates (nested shape, SQLite rapidfuzz) ──────────
+
+
+class TestFindCompanyDedupCandidates:
+    def test_nested_shape_and_near_dup(self, db_session: Session):
+        a = _make_company(db_session, "Beta Corporation")
+        b = _make_company(db_session, "Beta Corp")
+        db_session.commit()
+
+        candidates = find_company_dedup_candidates(db_session, threshold=80)
+        assert len(candidates) >= 1
+        pair = candidates[0]
+        # Nested shape preserved.
+        assert "company_a" in pair and "company_b" in pair
+        assert {"id", "name", "site_count", "has_owner"} <= set(pair["company_a"].keys())
+        assert "score" in pair and "auto_keep_id" in pair
+        names = {pair["company_a"]["name"], pair["company_b"]["name"]}
+        assert names == {"Beta Corporation", "Beta Corp"}
+        assert pair["auto_keep_id"] in {a.id, b.id}
+
+    def test_ignores_distinct(self, db_session: Session):
+        _make_company(db_session, "Acme Corporation")
+        _make_company(db_session, "Zeta Industries")
+        db_session.commit()
+        assert find_company_dedup_candidates(db_session, threshold=85) == []
+
+
+# ── settings/data_ops review queue (admin) ─────────────────────────────────
+
+
+@pytest.fixture()
+def admin_client(db_session: Session, admin_user: User) -> TestClient:
+    """TestClient whose require_user resolves to an admin (data-ops gates on
+    is_admin)."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: admin_user
+    app.dependency_overrides[require_admin] = lambda: admin_user
+    app.dependency_overrides[require_buyer] = lambda: admin_user
+
+    async def _fresh():
+        return "mock-token"
+
+    app.dependency_overrides[require_fresh_token] = _fresh
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        for dep in (get_db, require_user, require_admin, require_buyer, require_fresh_token):
+            app.dependency_overrides.pop(dep, None)
+
+
+class TestDataOpsReviewQueue:
+    def test_renders_names_and_merge_ids(self, admin_client: TestClient, db_session: Session):
+        a = _make_company(db_session, "Beta Corporation", sites=3)
+        b = _make_company(db_session, "Beta Corp", sites=1)
+        db_session.commit()
+
+        resp = admin_client.get("/v2/partials/settings/data-ops", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        body = resp.text
+        # Names render (the old FLAT-key bug rendered blank).
+        assert "Beta Corporation" in body
+        assert "Beta Corp" in body
+        # Non-empty merge ids are emitted (the old bug emitted empty ids).
+        assert f'"keep_id": {a.id}' in body or f'"keep_id": {b.id}' in body
+        assert "/v2/partials/admin/company-merge" in body
+
+    def test_non_admin_blocked(self, client: TestClient):
+        # The default `client` fixture resolves require_user to a buyer.
+        resp = client.get("/v2/partials/settings/data-ops", headers={"HX-Request": "true"})
+        assert resp.status_code == 403
+
+
+# ── per-account dup-suggestion banner ──────────────────────────────────────
+
+
+class TestDupSuggestionRoute:
+    def test_returns_merge_affordance_when_near_dup(self, client: TestClient, db_session: Session):
+        keep = _make_company(db_session, "Beta Corporation", sites=2)
+        _make_company(db_session, "Beta Corp", sites=1)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{keep.id}/dup-suggestion", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Beta Corp" in resp.text
+        # Reuses the merge-form flow.
+        assert "/merge-form" in resp.text or "merge-preview" in resp.text
+
+    def test_empty_when_no_dup(self, client: TestClient, db_session: Session):
+        solo = _make_company(db_session, "Singular Unique Industries")
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{solo.id}/dup-suggestion", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert resp.text.strip() == ""
+
+    def test_auth_gated(self, unauthenticated_client: TestClient, db_session: Session):
+        solo = _make_company(db_session, "Some Company")
+        db_session.commit()
+        resp = unauthenticated_client.get(f"/v2/partials/customers/{solo.id}/dup-suggestion")
+        assert resp.status_code == 401
+
+
+# ── name-suggestion chip (suggest-only) ────────────────────────────────────
+
+
+class TestNameSuggestionChip:
+    def test_surfaces_suggestion_for_suffix_heavy_name(self, client: TestClient, db_session: Session):
+        # "Inc." is stripped but the rest of the (multi-word, display-cased) name is kept.
+        c = _make_company(db_session, "Mouser Electronics, Inc.")
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{c.id}/name-suggestion", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        # Suggested name strips the legal suffix while preserving display casing.
+        assert "Mouser Electronics" in resp.text
+        assert f"/v2/partials/customers/{c.id}/apply-name" in resp.text
+
+    def test_empty_when_name_already_clean(self, client: TestClient, db_session: Session):
+        c = _make_company(db_session, "Phoenix Trading")
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{c.id}/name-suggestion", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert resp.text.strip() == ""
+
+    def test_apply_route_updates_name(self, client: TestClient, db_session: Session):
+        c = _make_company(db_session, "Mouser Electronics, Inc.")
+        db_session.commit()
+        resp = client.post(
+            f"/v2/partials/customers/{c.id}/apply-name",
+            data={"name": "Mouser Electronics"},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        db_session.expire(c)
+        refreshed = db_session.get(Company, c.id)
+        assert refreshed.name == "Mouser Electronics"
+        # normalized_name tracks the new name.
+        assert refreshed.normalized_name == normalize_company_name("Mouser Electronics")
+
+
+class TestCreateIsSuggestOnly:
+    """create_company must NOT silently rewrite the rep's typed name (suggest-only)."""
+
+    def test_create_keeps_typed_name(self, client: TestClient, db_session: Session):
+        from unittest.mock import AsyncMock, patch
+
+        # AI typo-fix would "correct" the typed name; suggest-only means it is NOT stored.
+        with (
+            patch("app.routers.crm.companies.get_credential_cached", return_value=None),
+            patch("app.enrichment_service.normalize_company_input", new_callable=AsyncMock) as mock_norm,
+        ):
+            mock_norm.return_value = ("Corrected Name", "typedco.com")
+            resp = client.post("/api/companies", json={"name": "Typedd Naame"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "Typedd Naame"  # what the rep typed, NOT the AI rewrite
+        stored = db_session.get(Company, data["id"])
+        # normalized_name is derived from the stored (typed) name.
+        assert stored.normalized_name == normalize_company_name("Typedd Naame")


### PR DESCRIPTION
Third cockpit refinement (design: docs/superpowers/specs/2026-06-18-crm-disposition-ia-aiorg-design.md). User chose full depth incl. the durable foundation.

**Foundation (migration 120, `120_company_name_matching` → 119_alert_seen, single head):**
- `Company.normalized_name` (nullable, indexed, `@validates`-synced from name) + `Company.alternate_names` (JSON). pg_trgm extension + GIN(`normalized_name gin_trgm_ops`) index **Postgres-guarded** (`dialect.name=='postgresql'`); plain btree on all dialects; `normalized_name` backfilled.
- `merge_companies` absorbs the loser's name + alternates into `keep.alternate_names` (dedup) + backfills `normalized_name` — so re-importing the old name fuzzy-matches the survivor instead of recreating the dupe.
- `find_company_dedup_candidates` dialect-split: **PG** `func.similarity()` self-join (no 500-row cap) / **SQLite** rapidfuzz fallback — identical nested shape.

**Surfaces:**
- The dead `data_ops.html` Company-Duplicates queue **rewritten** against the real nested shape + wired to `POST /v2/partials/admin/company-merge` (was rendering blank + emitting empty merge ids).
- Per-account **duplicate banner** (`GET .../{id}/dup-suggestion`, lazy) + suggest-only **name chip** (`GET .../{id}/name-suggestion`, `POST .../{id}/apply-name`); `create_company` made suggest-only (no silent rewrite).

**Locked policy honored:** passive review queue; nightly auto-merge tiering (≥98 / 92-97) + different-owner skip untouched; naming suggest-only end-to-end.

**Deferred (clean follow-ups, not half-built):** AI same-entity verdict chips in the queue; within-account site-grouping suggestion.

Tests: `test_crm_aiorg.py` 18 ✓; full suite 17,865 passed (1 pre-existing env-only static-asset failure, fails identically on HEAD). ⚠️ The PG `similarity()` path runs only on Postgres (not in SQLite CI) → needs a live-PG smoke at deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)