### PR TITLE
test(static): skip dist-image test when the Vite build is absent

### DIFF
--- a/tests/test_static_fallback_serving.py
+++ b/tests/test_static_fallback_serving.py
@@ -7,10 +7,23 @@ avail_logo_tight.png 404.
 """
 
 import os
+from pathlib import Path
+
+import pytest
 
 os.environ["TESTING"] = "1"
 
+# avail_logo_tight.png lives only under app/static/dist (Vite copies publicDir there).
+# dist/ is a gitignored BUILD artifact — absent in a fresh checkout/worktree until
+# `npm run build`. CI builds before pytest, so it runs there; locally we skip honestly
+# rather than red on a missing build (a 404 here means "not built", not a serving defect).
+_DIST_IMAGE = Path(__file__).resolve().parent.parent / "app" / "static" / "dist" / "avail_logo_tight.png"
 
+
+@pytest.mark.skipif(
+    not _DIST_IMAGE.exists(),
+    reason="requires the Vite build (app/static/dist/) — run `npm run build`; CI builds before pytest",
+)
 def test_static_public_image_served_from_dist(client):
     # avail_logo_tight.png exists only under app/static/dist (publicDir copy).
     r = client.get("/static/avail_logo_tight.png")


### PR DESCRIPTION
## What
`test_static_public_image_served_from_dist` asserts a **dist-only** asset (`app/static/dist/avail_logo_tight.png`, a Vite publicDir copy) serves via `/static`. `dist/` is a gitignored build artifact, so the test 404-failed in any fresh checkout/worktree that hadn't run `npm run build`.

## Why
This false alarm was misread as an xdist isolation flake in `test_authoritative_enrichment.py` multiple times this session. An exhaustive reproduction (20× isolation, 3× full sharded, single-process sequential, 16× pairwise) proved **no such pollution exists** (18,036 passed deterministically) — the only reproducible red was this missing-build artifact, which fails even in isolation.

## Fix
`@pytest.mark.skipif(not dist_image.exists())` with a clear reason. CI builds before pytest so it still runs there; local/worktree runs skip honestly instead of red-on-missing-build. Test-only, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)