### PR TITLE
feat(ui): Sales+Requisitions sweep onto canonical design-system layer (UX consistency PR 2/6)

### DIFF
--- a/app/templates/htmx/partials/parts/header.html
+++ b/app/templates/htmx/partials/parts/header.html
@@ -21,7 +21,7 @@
           {% if requirement.primary_mpn or requirement.substitutes %}
             {{ mpn_chips(requirement) }}
           {% else %}
-            <span class="text-[10px] text-gray-400 cursor-pointer hover:text-brand-500 transition-colors">+ Add part numbers</span>
+            <span class="text-xs text-gray-400 cursor-pointer hover:text-brand-500 transition-colors">+ Add part numbers</span>
           {% endif %}
         </div>
         {% if requirement.manufacturer %}
@@ -29,7 +29,7 @@
         <span id="hdr-manufacturer"
               hx-get="/v2/partials/parts/{{ requirement.id }}/header/edit/manufacturer"
               hx-target="#hdr-manufacturer" hx-swap="outerHTML"
-              class="text-sm text-gray-500 cursor-pointer hover:text-brand-500 truncate"
+              class="text-sm text-gray-600 cursor-pointer hover:text-brand-500 truncate"
               title="Click to edit manufacturer">
           {{ requirement.manufacturer }}
         </span>
@@ -38,7 +38,7 @@
         <span id="hdr-brand"
               hx-get="/v2/partials/parts/{{ requirement.id }}/header/edit/brand"
               hx-target="#hdr-brand" hx-swap="outerHTML"
-              class="text-sm text-gray-500 cursor-pointer hover:text-brand-500 truncate"
+              class="text-sm text-gray-600 cursor-pointer hover:text-brand-500 truncate"
               title="Click to edit brand">
           {{ requirement.brand or 'No brand' }}
         </span>
@@ -52,7 +52,7 @@
       <p id="hdr-description"
          hx-get="/v2/partials/parts/{{ requirement.id }}/header/edit/description"
          hx-target="#hdr-description" hx-swap="outerHTML"
-         class="text-xs text-gray-500 mt-0.5 cursor-pointer hover:text-brand-500 truncate"
+         class="text-xs text-gray-600 mt-0.5 cursor-pointer hover:text-brand-500 truncate"
          title="Click to edit description">
         {{ requirement|part_description or '+ Add description' }}
       </p>
@@ -74,7 +74,7 @@
       <span id="hdr-condition"
             hx-get="/v2/partials/parts/{{ requirement.id }}/header/edit/condition"
             hx-target="#hdr-condition" hx-swap="outerHTML"
-            class="text-xs text-gray-500 cursor-pointer hover:text-brand-500"
+            class="text-xs text-gray-600 cursor-pointer hover:text-brand-500"
             title="Click to edit condition">
         {{ requirement.condition or '—' }}
       </span>
@@ -88,7 +88,7 @@
               title="Click to edit qty">
           {{ '{:,}'.format(requirement.target_qty) if requirement.target_qty else '—' }}
         </span>
-        <span class="text-[10px] text-gray-400 block">qty</span>
+        <span class="text-xs text-gray-400 block">qty</span>
       </div>
 
       {# Target Price — inline editable #}
@@ -100,7 +100,7 @@
               title="Click to edit target price">
           {{ '${:,.4f}'.format(requirement.target_price) if requirement.target_price else '—' }}
         </span>
-        <span class="text-[10px] text-gray-400 block">target</span>
+        <span class="text-xs text-gray-400 block">target</span>
       </div>
 
     </div>

--- a/app/templates/htmx/partials/parts/list.html
+++ b/app/templates/htmx/partials/parts/list.html
@@ -157,7 +157,7 @@
                     {{ mpn_chips(req, sub_card_map) }}
                   {% elif col_key == 'description' %}
                     {% set desc = req|part_description %}
-                    <span class="text-xs text-gray-500 truncate max-w-[200px] block" title="{{ desc }}">{{ desc or '—' }}</span>
+                    <span class="text-xs text-gray-600 truncate max-w-[200px] block" title="{{ desc }}">{{ desc or '—' }}</span>
                   {% elif col_key == 'brand' %}
                     {{ req.brand or '—' }}
                   {% elif col_key == 'requisition' %}
@@ -196,12 +196,12 @@
       </table>
   </div>
   {% else %}
-  <div class="flex-1 flex flex-col items-center justify-center text-gray-400 py-12">
+  <div class="flex-1 flex flex-col items-center justify-center text-gray-400 py-6 sm:py-8">
     <svg class="h-10 w-10 text-gray-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
     </svg>
     <p class="text-xs font-medium">No parts found</p>
-    <p class="text-[10px] mt-0.5 text-gray-300">Adjust filters or add requirements</p>
+    <p class="text-xs mt-0.5 text-gray-300">Adjust filters or add requirements</p>
   </div>
   {% endif %}
 

--- a/app/templates/htmx/partials/parts/tabs/activity.html
+++ b/app/templates/htmx/partials/parts/tabs/activity.html
@@ -6,7 +6,7 @@
 
 <div>
   <div class="mb-2">
-    <p class="text-xs text-gray-500">{{ activities|length }} event{{ 's' if activities|length != 1 else '' }}</p>
+    <p class="text-xs text-gray-600">{{ activities|length }} event{{ 's' if activities|length != 1 else '' }}</p>
   </div>
 
   {% if activities %}

--- a/app/templates/htmx/partials/parts/tabs/comms.html
+++ b/app/templates/htmx/partials/parts/tabs/comms.html
@@ -16,7 +16,7 @@
                required
                class="flex-1 px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         <button type="submit"
-                class="px-3 py-1.5 text-sm font-medium bg-brand-500 text-white rounded-lg hover:bg-brand-600">
+                class="btn-primary btn-sm">
           Add
         </button>
       </div>
@@ -41,7 +41,7 @@
 
   {% if pending_tasks %}
   <div class="mb-4">
-    <h4 class="text-xs font-medium text-gray-500 uppercase mb-2">Open ({{ pending_tasks|length }})</h4>
+    <h4 class="text-xs font-medium text-gray-600 uppercase mb-2">Open ({{ pending_tasks|length }})</h4>
     <div class="space-y-2">
       {% for task in pending_tasks %}
       <div class="flex items-start gap-3 p-3 rounded-lg border border-gray-200 bg-white hover:border-brand-200">
@@ -54,7 +54,7 @@
         <div class="flex-1 min-w-0">
           <p class="text-sm font-medium text-gray-900">{{ task.title }}</p>
           {% if task.description %}
-            <p class="text-xs text-gray-500 mt-0.5">{{ task.description }}</p>
+            <p class="text-xs text-gray-600 mt-0.5">{{ task.description }}</p>
           {% endif %}
           <div class="flex items-center gap-3 mt-1.5 text-xs text-gray-400 flex-wrap">
             {% if task.assignee %}
@@ -106,7 +106,7 @@
           </svg>
         </button>
         <div class="flex-1 min-w-0">
-          <p class="text-sm text-gray-500 line-through">{{ task.title }}</p>
+          <p class="text-sm text-gray-600 line-through">{{ task.title }}</p>
           <div class="flex items-center gap-2 mt-1 text-xs text-gray-400">
             {% if task.assignee %}<span>{{ task.assignee.name or task.assignee.email }}</span>{% endif %}
             {% if task.completed_at %}<span>Done {{ task.completed_at.strftime('%m/%d/%y') }}</span>{% endif %}
@@ -119,12 +119,12 @@
   {% endif %}
 
   {% if not pending_tasks and not done_tasks %}
-  <div class="mx-auto max-w-sm rounded-xl bg-white p-12 text-center shadow-sm border border-gray-100">
+  <div class="mx-auto max-w-sm rounded-xl bg-white p-6 sm:p-8 text-center shadow-sm border border-gray-100">
     <svg class="mx-auto mb-4 h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round"
             d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
     </svg>
-    <p class="text-base font-medium text-gray-500">No tasks yet.</p>
+    <p class="text-base font-medium text-gray-600">No tasks yet.</p>
     <p class="text-sm text-gray-400 mt-1">Add a task above to coordinate with your team.</p>
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/parts/tabs/notes.html
+++ b/app/templates/htmx/partials/parts/tabs/notes.html
@@ -4,10 +4,10 @@
    Depends on: HTMX, Alpine.js, brand palette.
 #}
 <div id="notes-tab-content" class="space-y-3">
-  <div class="bg-white rounded-lg border border-brand-200 p-4">
+  <div class="card">
     <div class="flex items-center justify-between mb-3">
       <h3 class="text-sm font-semibold text-gray-900">Sales Notes</h3>
-      <span class="text-[10px] text-gray-400">{{ requirement.primary_mpn }}</span>
+      <span class="text-xs text-gray-400">{{ requirement.primary_mpn }}</span>
     </div>
     <form hx-patch="/v2/partials/parts/{{ requirement.id }}/notes"
           hx-target="#notes-tab-content"
@@ -21,7 +21,7 @@
                 class="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 resize-y">{{ requirement.sale_notes or '' }}</textarea>
       <div class="flex items-center gap-2 mt-2">
         <button type="submit" :disabled="saving"
-                class="px-3 py-1.5 text-xs font-semibold bg-brand-500 text-white rounded-lg hover:bg-brand-600 disabled:opacity-50 inline-flex items-center gap-1">
+                class="btn-primary btn-sm">
           <svg x-show="saving" x-cloak class="h-3 w-3 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>

--- a/app/templates/htmx/partials/parts/tabs/offers.html
+++ b/app/templates/htmx/partials/parts/tabs/offers.html
@@ -5,7 +5,7 @@
 
 <div>
   <div class="flex items-center justify-between mb-2">
-    <p class="text-xs text-gray-500">{{ offers|length }} offer{{ 's' if offers|length != 1 else '' }}</p>
+    <p class="text-xs text-gray-600">{{ offers|length }} offer{{ 's' if offers|length != 1 else '' }}</p>
   </div>
 
   {% if offers %}
@@ -13,38 +13,38 @@
     <table class="min-w-full divide-y divide-gray-200 text-sm">
       <thead class="bg-gray-50">
         <tr>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Price</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Qty</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Date Code</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Condition</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Lead Time</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Price</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Qty</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Date Code</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Condition</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Lead Time</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Created</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-100">
         {% for offer in offers %}
         <tr class="hover:bg-gray-50">
-          <td class="px-3 py-2 font-medium text-gray-900 whitespace-nowrap">{{ offer.vendor_name or '—' }}</td>
-          <td class="px-3 py-2 whitespace-nowrap">{{ '${:,.4f}'.format(offer.unit_price) if offer.unit_price else '—' }}</td>
-          <td class="px-3 py-2 whitespace-nowrap">{{ '{:,}'.format(offer.qty_available) if offer.qty_available else '—' }}</td>
-          <td class="px-3 py-2 whitespace-nowrap">{{ offer.date_code or '—' }}</td>
-          <td class="px-3 py-2 whitespace-nowrap">{{ offer.condition or '—' }}</td>
-          <td class="px-3 py-2 whitespace-nowrap">{{ offer.lead_time or '—' }}</td>
-          <td class="px-3 py-2 whitespace-nowrap">
+          <td class="table-cell font-medium text-gray-900 whitespace-nowrap">{{ offer.vendor_name or '—' }}</td>
+          <td class="table-cell whitespace-nowrap">{{ '${:,.4f}'.format(offer.unit_price) if offer.unit_price else '—' }}</td>
+          <td class="table-cell whitespace-nowrap">{{ '{:,}'.format(offer.qty_available) if offer.qty_available else '—' }}</td>
+          <td class="table-cell whitespace-nowrap">{{ offer.date_code or '—' }}</td>
+          <td class="table-cell whitespace-nowrap">{{ offer.condition or '—' }}</td>
+          <td class="table-cell whitespace-nowrap">{{ offer.lead_time or '—' }}</td>
+          <td class="table-cell whitespace-nowrap">
             {% if offer.status == 'active' %}
-              <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-700">Active</span>
+              <span class="badge bg-green-100 text-green-700">Active</span>
             {% elif offer.status == 'sold' %}
-              <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-blue-100 text-blue-700">Sold</span>
+              <span class="badge bg-blue-100 text-blue-700">Sold</span>
             {% else %}
-              <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600">{{ offer.status or 'active' }}</span>
+              <span class="badge bg-gray-100 text-gray-600">{{ offer.status or 'active' }}</span>
             {% endif %}
             {% if offer.is_stale %}
               <span class="ml-1 px-1.5 py-0.5 text-xs rounded bg-amber-50 text-amber-600" title="Over 14 days old">Stale</span>
             {% endif %}
           </td>
-          <td class="px-3 py-2 text-gray-500 whitespace-nowrap">{{ offer.created_at.strftime('%m/%d/%y') if offer.created_at else '—' }}</td>
+          <td class="table-cell text-gray-600 whitespace-nowrap">{{ offer.created_at.strftime('%m/%d/%y') if offer.created_at else '—' }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/app/templates/htmx/partials/parts/tabs/quotes.html
+++ b/app/templates/htmx/partials/parts/tabs/quotes.html
@@ -5,7 +5,7 @@
 #}
 <div>
   {% if quote_lines %}
-  <p class="text-sm text-gray-500 mb-4">
+  <p class="text-sm text-gray-600 mb-4">
     <span class="font-semibold text-gray-900">{{ quote_lines|length }}</span> quote line{{ "s" if quote_lines|length != 1 }} including
     <span class="font-medium text-gray-700">{{ requirement.primary_mpn or "this part" }}</span>
     <span class="text-gray-400">(incl. substitutes &amp; same canonical part)</span>
@@ -14,15 +14,15 @@
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50 sticky top-0">
         <tr>
-          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Quote #</th>
-          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Customer</th>
-          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Requisition</th>
-          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN Quoted</th>
-          <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
-          <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Sell</th>
-          <th class="px-4 py-2.5 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Margin %</th>
-          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-          <th class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Quote #</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Customer</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Requisition</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN Quoted</th>
+          <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
+          <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Sell</th>
+          <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Margin %</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200">
@@ -32,13 +32,13 @@
             hx-get="/v2/partials/quotes/{{ q.id }}"
             hx-target="#main-content"
             hx-push-url="/v2/quotes/{{ q.id }}">
-          <td class="px-4 py-2.5 text-sm font-medium text-brand-500 hover:text-brand-600">{{ q.quote_number or "Q-" ~ q.id }}</td>
-          <td class="px-4 py-2.5 text-sm text-gray-500">{{ (q.requisition.customer_name if q.requisition else None) or "—" }}</td>
-          <td class="px-4 py-2.5 text-sm text-gray-500">{{ q.requisition.name if q.requisition else "—" }}</td>
-          <td class="px-4 py-2.5 text-sm text-gray-700">{{ line.mpn }}</td>
-          <td class="px-4 py-2.5 text-sm text-gray-900 text-right">{{ line.qty if line.qty is not none else "—" }}</td>
-          <td class="px-4 py-2.5 text-sm text-gray-900 font-medium text-right">{{ "${:,.2f}".format(line.sell_price) if line.sell_price is not none else "—" }}</td>
-          <td class="px-4 py-2.5 text-sm text-right">
+          <td class="table-cell text-sm font-medium text-brand-500 hover:text-brand-600">{{ q.quote_number or "Q-" ~ q.id }}</td>
+          <td class="table-cell text-sm text-gray-600">{{ (q.requisition.customer_name if q.requisition else None) or "—" }}</td>
+          <td class="table-cell text-sm text-gray-600">{{ q.requisition.name if q.requisition else "—" }}</td>
+          <td class="table-cell text-sm text-gray-700">{{ line.mpn }}</td>
+          <td class="table-cell text-sm text-gray-900 text-right">{{ line.qty if line.qty is not none else "—" }}</td>
+          <td class="table-cell text-sm text-gray-900 font-medium text-right">{{ "${:,.2f}".format(line.sell_price) if line.sell_price is not none else "—" }}</td>
+          <td class="table-cell text-sm text-right">
             {% if line.margin_pct is not none %}
               {% if line.margin_pct >= 30 %}
                 <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-50 text-emerald-700">{{ "%.1f%%"|format(line.margin_pct) }}</span>
@@ -48,10 +48,10 @@
                 <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-rose-50 text-rose-700">{{ "%.1f%%"|format(line.margin_pct) }}</span>
               {% endif %}
             {% else %}
-              <span class="text-gray-500">—</span>
+              <span class="text-gray-600">—</span>
             {% endif %}
           </td>
-          <td class="px-4 py-2.5">
+          <td class="table-cell">
             {% set quote_colors = {
               "draft": "bg-brand-100 text-brand-600",
               "sent": "bg-amber-50 text-amber-700",
@@ -61,14 +61,14 @@
             } %}
             <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ quote_colors.get(q.status, 'bg-gray-100 text-gray-600') }}">{{ q.status|capitalize }}</span>
           </td>
-          <td class="px-4 py-2.5 text-sm text-gray-500">{{ q.created_at.strftime('%b %d, %Y') if q.created_at else "—" }}</td>
+          <td class="table-cell text-sm text-gray-600">{{ q.created_at.strftime('%b %d, %Y') if q.created_at else "—" }}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
   </div>
   {% else %}
-  <div class="py-12 text-center">
+  <div class="py-6 sm:py-8 text-center">
     <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
     </svg>

--- a/app/templates/htmx/partials/parts/tabs/quotes.html
+++ b/app/templates/htmx/partials/parts/tabs/quotes.html
@@ -41,11 +41,11 @@
           <td class="table-cell text-sm text-right">
             {% if line.margin_pct is not none %}
               {% if line.margin_pct >= 30 %}
-                <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-50 text-emerald-700">{{ "%.1f%%"|format(line.margin_pct) }}</span>
+                <span class="badge bg-emerald-50 text-emerald-700">{{ "%.1f%%"|format(line.margin_pct) }}</span>
               {% elif line.margin_pct >= 15 %}
-                <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-amber-50 text-amber-700">{{ "%.1f%%"|format(line.margin_pct) }}</span>
+                <span class="badge bg-amber-50 text-amber-700">{{ "%.1f%%"|format(line.margin_pct) }}</span>
               {% else %}
-                <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-rose-50 text-rose-700">{{ "%.1f%%"|format(line.margin_pct) }}</span>
+                <span class="badge bg-rose-50 text-rose-700">{{ "%.1f%%"|format(line.margin_pct) }}</span>
               {% endif %}
             {% else %}
               <span class="text-gray-600">—</span>

--- a/app/templates/htmx/partials/parts/tabs/req_details.html
+++ b/app/templates/htmx/partials/parts/tabs/req_details.html
@@ -29,7 +29,7 @@
     ] %}
     {% for field_key, field_label, field_value in spec_fields %}
     <div class="flex items-center gap-1">
-      <span class="text-xs text-gray-500 whitespace-nowrap">{{ field_label }}:</span>
+      <span class="text-xs text-gray-600 whitespace-nowrap">{{ field_label }}:</span>
       {% if not is_archived %}
       <div id="reqd-spec-{{ field_key }}"
            class="cursor-pointer hover:bg-brand-50 rounded px-1 py-0.5 transition-colors min-w-0"
@@ -49,7 +49,7 @@
 
   {# ── Description (click-to-edit, full width) ─────────────── #}
   <div class="mt-2">
-    <span class="text-xs text-gray-500">Description:</span>
+    <span class="text-xs text-gray-600">Description:</span>
     {% if not is_archived %}
     <div id="reqd-description"
          class="cursor-pointer hover:bg-brand-50 rounded px-1 py-0.5 transition-colors mt-0.5"
@@ -73,7 +73,7 @@
   <div class="grid grid-cols-2 gap-x-6 gap-y-1.5 text-sm">
     {# Name #}
     <div class="flex items-center gap-1">
-      <span class="text-xs text-gray-500 whitespace-nowrap">Name:</span>
+      <span class="text-xs text-gray-600 whitespace-nowrap">Name:</span>
       {% if not is_archived %}
       <div id="reqd-name"
            class="cursor-pointer hover:bg-brand-50 rounded px-1 py-0.5 transition-colors min-w-0"
@@ -89,7 +89,7 @@
 
     {# Status #}
     <div class="flex items-center gap-1">
-      <span class="text-xs text-gray-500 whitespace-nowrap">Status:</span>
+      <span class="text-xs text-gray-600 whitespace-nowrap">Status:</span>
       {% if not is_archived %}
       <div id="reqd-status"
            class="cursor-pointer hover:bg-brand-50 rounded px-1 py-0.5 transition-colors"
@@ -105,7 +105,7 @@
 
     {# Customer (read-only) #}
     <div class="flex items-center gap-1">
-      <span class="text-xs text-gray-500 whitespace-nowrap">Customer:</span>
+      <span class="text-xs text-gray-600 whitespace-nowrap">Customer:</span>
       <div class="px-1 py-0.5">
         <span class="text-gray-900">{{ req.customer_name or '—' }}</span>
       </div>
@@ -113,7 +113,7 @@
 
     {# Urgency #}
     <div class="flex items-center gap-1">
-      <span class="text-xs text-gray-500 whitespace-nowrap">Urgency:</span>
+      <span class="text-xs text-gray-600 whitespace-nowrap">Urgency:</span>
       {% if not is_archived %}
       <div id="reqd-urgency"
            class="cursor-pointer hover:bg-brand-50 rounded px-1 py-0.5 transition-colors"
@@ -129,7 +129,7 @@
 
     {# Deadline #}
     <div class="flex items-center gap-1">
-      <span class="text-xs text-gray-500 whitespace-nowrap">Deadline:</span>
+      <span class="text-xs text-gray-600 whitespace-nowrap">Deadline:</span>
       {% if not is_archived %}
       <div id="reqd-deadline"
            class="cursor-pointer hover:bg-brand-50 rounded px-1 py-0.5 transition-colors"
@@ -145,7 +145,7 @@
 
     {# Owner #}
     <div class="flex items-center gap-1">
-      <span class="text-xs text-gray-500 whitespace-nowrap">Owner:</span>
+      <span class="text-xs text-gray-600 whitespace-nowrap">Owner:</span>
       {% if not is_archived %}
       <div id="reqd-owner"
            class="cursor-pointer hover:bg-brand-50 rounded px-1 py-0.5 transition-colors"

--- a/app/templates/htmx/partials/parts/tabs/sourcing.html
+++ b/app/templates/htmx/partials/parts/tabs/sourcing.html
@@ -5,7 +5,7 @@
 
 <div>
   <div class="mb-2">
-    <p class="text-xs text-gray-500">{{ summaries|length }} vendor{{ 's' if summaries|length != 1 else '' }}</p>
+    <p class="text-xs text-gray-600">{{ summaries|length }} vendor{{ 's' if summaries|length != 1 else '' }}</p>
   </div>
 
   {% if summaries %}
@@ -13,12 +13,12 @@
     <table class="min-w-full divide-y divide-gray-200 text-sm">
       <thead class="bg-gray-50">
         <tr>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Phone</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Qty</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase">Price</th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase relative cursor-help"
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Phone</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Qty</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Price</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase relative cursor-help"
               x-data="{ showTip: false }" @mouseenter="showTip = true" @mouseleave="showTip = false">
             Score
             <div x-show="showTip" x-cloak
@@ -33,7 +33,7 @@
               </ul>
             </div>
           </th>
-          <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase relative cursor-help"
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase relative cursor-help"
               x-data="{ showTip: false }" @mouseenter="showTip = true" @mouseleave="showTip = false">
             Tier
             <div x-show="showTip" x-cloak
@@ -52,8 +52,8 @@
       <tbody class="divide-y divide-gray-100">
         {% for s in summaries %}
         <tr class="hover:bg-gray-50">
-          <td class="px-3 py-2 font-medium text-gray-900 whitespace-nowrap">{{ s.vendor_name or '—' }}</td>
-          <td class="px-3 py-2 whitespace-nowrap">
+          <td class="compact-cell font-medium text-gray-900 whitespace-nowrap">{{ s.vendor_name or '—' }}</td>
+          <td class="compact-cell whitespace-nowrap">
             {% set status = vendor_statuses.get(s.vendor_name, 'sighting') %}
             {% set status_styles = {
               'sighting': 'bg-gray-100 text-gray-600',
@@ -73,16 +73,16 @@
               {{ status_labels.get(status, status|capitalize) }}
             </span>
           </td>
-          <td class="px-3 py-2 whitespace-nowrap text-xs">
+          <td class="compact-cell whitespace-nowrap text-xs">
             {% if s.vendor_phone %}
               <a href="tel:{{ s.vendor_phone }}" class="text-brand-500 hover:underline">{{ s.vendor_phone }}</a>
             {% else %}—{% endif %}
           </td>
           {# Qty cell — click for breakdown popover #}
-          <td class="px-3 py-2 whitespace-nowrap relative" x-data="{ showQty: false }">
+          <td class="compact-cell whitespace-nowrap relative" x-data="{ showQty: false }">
             <span role="button" tabindex="0" @click="showQty = !showQty" @keydown.enter="showQty = !showQty" @keydown.space.prevent="showQty = !showQty" class="cursor-pointer hover:text-brand-500" aria-label="Show quantity breakdown">
               {{ '{:,}'.format(s.estimated_qty) if s.estimated_qty else '—' }}
-              {% if s.listing_count > 1 %}<span class="text-[10px] text-gray-400 ml-0.5">({{ s.listing_count }})</span>{% endif %}
+              {% if s.listing_count > 1 %}<span class="text-xs text-gray-400 ml-0.5">({{ s.listing_count }})</span>{% endif %}
             </span>
             <div x-show="showQty" role="tooltip" @click.away="showQty = false" x-cloak
                  class="absolute z-50 mt-1 w-64 p-3 bg-white border border-gray-200 rounded-lg shadow-lg text-xs">
@@ -98,7 +98,7 @@
             </div>
           </td>
           {# Price cell — click for breakdown popover #}
-          <td class="px-3 py-2 whitespace-nowrap relative" x-data="{ showPrice: false }">
+          <td class="compact-cell whitespace-nowrap relative" x-data="{ showPrice: false }">
             <span role="button" tabindex="0" @click="showPrice = !showPrice" @keydown.enter="showPrice = !showPrice" @keydown.space.prevent="showPrice = !showPrice" class="cursor-pointer hover:text-brand-500" aria-label="Show price breakdown">
               {{ '${:,.4f}'.format(s.avg_price) if s.avg_price else '—' }}
             </span>

--- a/app/templates/htmx/partials/parts/workspace.html
+++ b/app/templates/htmx/partials/parts/workspace.html
@@ -118,7 +118,7 @@
         <svg class="h-12 w-12 mb-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
         </svg>
-        <p class="text-sm font-medium text-gray-500">Select a part</p>
+        <p class="text-sm font-medium text-gray-600">Select a part</p>
         <p class="text-xs text-gray-400 mt-1">Click a row to view offers, sourcing & activity</p>
       </div>
       {# Scrollbar + content — always in DOM, shown when part selected #}

--- a/app/templates/htmx/partials/requisitions/add_offer_form.html
+++ b/app/templates/htmx/partials/requisitions/add_offer_form.html
@@ -3,7 +3,7 @@
    Called by: htmx_views.py add_offer_form route.
    Depends on: HTMX, Tailwind CSS with brand palette.
 #}
-<div class="bg-white border border-brand-200 rounded-lg p-4 mb-4">
+<div class="card mb-4">
   <div class="flex items-center justify-between mb-3">
     <h3 class="text-sm font-semibold text-gray-900">Add Manual Offer</h3>
     <button hx-get="/v2/partials/requisitions/{{ req.id }}/tab/offers"
@@ -24,8 +24,8 @@
     {# Linked Requirement #}
     {% if requirements %}
     <div>
-      <label class="block text-xs text-gray-500 mb-1">Linked Requirement</label>
-      <select name="requirement_id" class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+      <label class="form-label">Linked Requirement</label>
+      <select name="requirement_id" class="input input-sm">
         <option value="">— None —</option>
         {% for r in requirements %}
         <option value="{{ r.id }}">{{ r.primary_mpn }} (qty {{ r.target_qty or '—' }})</option>
@@ -36,14 +36,14 @@
 
     {# Notes #}
     <div>
-      <label class="block text-xs text-gray-500 mb-1">Notes</label>
+      <label class="form-label">Notes</label>
       <textarea name="notes" rows="2"
-                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
+                class="input input-sm"
                 placeholder="Any additional details..."></textarea>
     </div>
 
     <button type="submit" :disabled="!essentialsMet()"
-            class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600 disabled:opacity-50 disabled:cursor-not-allowed">
+            class="btn btn-sm btn-primary">
       Save Offer
     </button>
   </form>

--- a/app/templates/htmx/partials/requisitions/detail.html
+++ b/app/templates/htmx/partials/requisitions/detail.html
@@ -12,7 +12,7 @@
   <a hx-get="/v2/partials/requisitions"
      hx-target="#main-content"
      hx-push-url="/v2/requisitions"
-     class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-brand-500 mb-3 cursor-pointer">
+     class="inline-flex items-center gap-1 text-sm text-gray-600 hover:text-brand-500 mb-3 cursor-pointer">
     <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
     </svg>

--- a/app/templates/htmx/partials/requisitions/detail_header.html
+++ b/app/templates/htmx/partials/requisitions/detail_header.html
@@ -6,7 +6,7 @@
 #}
 {% from "htmx/partials/shared/_macros.html" import req_status_badge, urgency_badge %}
 
-<div id="req-header" class="bg-white rounded-lg shadow border border-gray-200 p-6 mb-6">
+<div id="req-header" class="bg-white rounded-lg shadow border border-gray-200 p-4 mb-6">
   <div class="flex items-start justify-between">
     <div class="flex-1 min-w-0">
       {# Inline-editable name #}
@@ -19,7 +19,7 @@
           title="Click to edit name">
         {{ req.name }}
       </h1>
-      <div class="flex flex-wrap items-center gap-4 mt-2 text-sm text-gray-500">
+      <div class="flex flex-wrap items-center gap-4 mt-2 text-sm text-gray-600">
         {% if req.customer_name %}
         <span>Customer: <span class="text-gray-900">{{ req.customer_name }}</span></span>
         {% endif %}
@@ -56,7 +56,7 @@
       <button hx-get="/v2/partials/requisitions/{{ req.id }}/rfq-compose"
               hx-target="#tab-content" hx-swap="innerHTML"
               data-loading-disable
-              class="px-3 py-1.5 text-xs font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600">
+              class="btn-primary btn-sm">
         <svg data-loading class="h-3 w-3 mr-1 spinner inline" fill="none" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-dasharray="31.4" stroke-dashoffset="10"/></svg>
         Send RFQ
       </button>
@@ -96,19 +96,19 @@
   <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4 pt-4 border-t border-gray-200">
     <div class="text-center">
       <p class="text-2xl font-bold text-brand-500">{{ requirements|length }}</p>
-      <p class="text-xs text-gray-500">Parts</p>
+      <p class="text-xs text-gray-600">Parts</p>
     </div>
     <div class="text-center">
       <p class="text-2xl font-bold text-brand-500">{{ req.offer_count|default(0) }}</p>
-      <p class="text-xs text-gray-500">Offers</p>
+      <p class="text-xs text-gray-600">Offers</p>
     </div>
     <div class="text-center">
       <p class="text-2xl font-bold {{ 'text-emerald-600' if coverage_pct >= 80 else 'text-amber-600' if coverage_pct >= 40 else 'text-gray-900' }}">{{ coverage_pct }}%</p>
-      <p class="text-xs text-gray-500">Coverage</p>
+      <p class="text-xs text-gray-600">Coverage</p>
     </div>
     <div class="text-center">
       <p class="text-2xl font-bold text-gray-900">{{ days_open }}</p>
-      <p class="text-xs text-gray-500">Age</p>
+      <p class="text-xs text-gray-600">Age</p>
     </div>
   </div>
 </div>

--- a/app/templates/htmx/partials/requisitions/edit_offer_form.html
+++ b/app/templates/htmx/partials/requisitions/edit_offer_form.html
@@ -21,22 +21,22 @@
       <div>
         <label class="block text-xs text-gray-500 mb-1">Vendor Name *</label>
         <input type="text" name="vendor_name" required value="{{ offer.vendor_name or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Qty Available</label>
         <input type="number" name="qty_available" min="1" value="{{ offer.qty_available or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Unit Price (USD)</label>
         <input type="number" name="unit_price" step="0.0001" min="0" value="{{ offer.unit_price or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Lead Time</label>
         <input type="text" name="lead_time" value="{{ offer.lead_time or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
     </div>
 
@@ -45,16 +45,16 @@
       <div>
         <label class="block text-xs text-gray-500 mb-1">Manufacturer</label>
         <input type="text" name="manufacturer" value="{{ offer.manufacturer or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Date Code</label>
         <input type="text" name="date_code" value="{{ offer.date_code or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Condition</label>
-        <select name="condition" class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+        <select name="condition" class="input input-sm">
           <option value="">--</option>
           <option value="new" {{ 'selected' if offer.condition == 'new' }}>New</option>
           <option value="refurb" {{ 'selected' if offer.condition in ('refurb', 'refurbished') }}>Refurbished</option>
@@ -64,7 +64,7 @@
       <div>
         <label class="block text-xs text-gray-500 mb-1">MOQ</label>
         <input type="number" name="moq" min="1" value="{{ offer.moq or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
     </div>
 
@@ -73,22 +73,22 @@
       <div>
         <label class="block text-xs text-gray-500 mb-1">SPQ</label>
         <input type="number" name="spq" min="1" value="{{ offer.spq or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Packaging</label>
         <input type="text" name="packaging" value="{{ offer.packaging or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Firmware</label>
         <input type="text" name="firmware" value="{{ offer.firmware or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Hardware Code</label>
         <input type="text" name="hardware_code" value="{{ offer.hardware_code or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
     </div>
 
@@ -97,22 +97,22 @@
       <div>
         <label class="block text-xs text-gray-500 mb-1">Warranty</label>
         <input type="text" name="warranty" value="{{ offer.warranty or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Country of Origin</label>
         <input type="text" name="country_of_origin" value="{{ offer.country_of_origin or '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <div>
         <label class="block text-xs text-gray-500 mb-1">Valid Until</label>
         <input type="date" name="valid_until" value="{{ offer.valid_until.isoformat() if offer.valid_until else '' }}"
-               class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       {% if requirements %}
       <div>
         <label class="block text-xs text-gray-500 mb-1">Linked Requirement</label>
-        <select name="requirement_id" class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+        <select name="requirement_id" class="input input-sm">
           <option value="">— None —</option>
           {% for r in requirements %}
           <option value="{{ r.id }}" {{ 'selected' if offer.requirement_id == r.id }}>{{ r.primary_mpn }} (qty {{ r.target_qty or '—' }})</option>
@@ -126,11 +126,11 @@
     <div>
       <label class="block text-xs text-gray-500 mb-1">Notes</label>
       <textarea name="notes" rows="2"
-                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">{{ offer.notes or '' }}</textarea>
+                class="input input-sm">{{ offer.notes or '' }}</textarea>
     </div>
 
     <button type="submit"
-            class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+            class="btn-primary btn-sm">
       Save Changes
     </button>
   </form>

--- a/app/templates/htmx/partials/requisitions/list.html
+++ b/app/templates/htmx/partials/requisitions/list.html
@@ -12,13 +12,13 @@
   {# Header #}
   <div class="flex items-center justify-between mb-4">
     <div>
-      <p class="text-sm text-gray-500 mt-1">{{ total }} total</p>
+      <p class="text-sm text-gray-600 mt-1">{{ total }} total</p>
     </div>
     <button @click="$dispatch('open-modal')"
             hx-get="/v2/partials/requisitions/create-form"
             hx-target="#modal-content"
             data-loading-disable
-            class="inline-flex items-center px-4 py-2 bg-brand-500 text-white text-sm font-medium rounded-lg hover:bg-brand-600 transition-colors">
+            class="btn-primary btn-md">
       <svg data-loading class="h-4 w-4 mr-1.5 spinner" fill="none" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-dasharray="31.4" stroke-dashoffset="10"/></svg>
       <svg data-loading-remove class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
       New Requisition
@@ -33,7 +33,7 @@
       <div class="flex flex-wrap gap-3 items-end">
         {# Search #}
         <div class="relative flex-1 min-w-[200px]">
-          <label for="req-search" class="block text-xs font-medium text-gray-500 mb-1">Search</label>
+          <label for="req-search" class="form-label">Search</label>
           <svg class="pointer-events-none absolute left-3 bottom-2 h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/>
           </svg>
@@ -51,7 +51,7 @@
           {# Search scope indicators — show what matched when actively searching #}
           {% if match_counts %}
           <div class="flex items-center gap-1.5 mt-1.5 animate-fade-in">
-            <span class="text-[10px] text-gray-400 uppercase tracking-wide mr-0.5">Matched:</span>
+            <span class="text-xs text-gray-400 uppercase tracking-wide mr-0.5">Matched:</span>
             {% set scopes = [
               ("name", "Names", "bg-brand-50 text-brand-600 border-brand-200", match_counts.name),
               ("customer", "Customers", "bg-sky-50 text-sky-600 border-sky-200", match_counts.customer),
@@ -59,11 +59,11 @@
             ] %}
             {% for key, label, colors, count in scopes %}
               {% if count > 0 %}
-              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-semibold rounded-full border transition-all duration-300 {{ colors }}">
+              <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded-full border transition-all duration-300 {{ colors }}">
                 <span class="tabular-nums">{{ count }}</span> {{ label }}
               </span>
               {% else %}
-              <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-medium rounded-full border border-gray-100 text-gray-300">
+              <span class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full border border-gray-100 text-gray-300">
                 {{ label }}
               </span>
               {% endif %}
@@ -77,7 +77,7 @@
         {# Owner dropdown (non-sales only) #}
         {% if user_role != 'sales' %}
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Owner</label>
+          <label class="form-label">Owner</label>
           <select name="owner" aria-label="Filter by owner"
                   hx-get="/v2/partials/requisitions"
                   hx-target="#main-content"
@@ -95,7 +95,7 @@
 
         {# Date range #}
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">From</label>
+          <label class="form-label">From</label>
           <input type="date" name="date_from" value="{{ date_from }}" aria-label="Filter from date"
                  hx-get="/v2/partials/requisitions"
                  hx-target="#main-content"
@@ -105,7 +105,7 @@
                  class="px-3 py-1.5 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">To</label>
+          <label class="form-label">To</label>
           <input type="date" name="date_to" value="{{ date_to }}" aria-label="Filter to date"
                  hx-get="/v2/partials/requisitions"
                  hx-target="#main-content"
@@ -116,7 +116,7 @@
         </div>
 
         {# Loading spinner #}
-        <span id="req-loading" class="htmx-indicator flex items-center gap-1 text-sm text-gray-500 self-end pb-1">
+        <span id="req-loading" class="htmx-indicator flex items-center gap-1 text-sm text-gray-600 self-end pb-1">
           <svg class="h-4 w-4 animate-spin text-brand-500" viewBox="0 0 24 24" fill="none">
             <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-dasharray="31.4" stroke-dashoffset="10"/>
           </svg>
@@ -140,7 +140,7 @@
         {% endfor %}
 
         <span class="text-gray-300 mx-1 self-center">|</span>
-        <span class="text-xs text-gray-500 self-center mr-1">Urgency:</span>
+        <span class="text-xs text-gray-600 self-center mr-1">Urgency:</span>
         <input type="hidden" name="urgency" value="{{ urgency }}">
         {% for u_val, u_label in [('hot', 'Hot'), ('critical', 'Critical')] %}
         <button type="button" x-data="{ active: '{{ urgency }}' === '{{ u_val }}' }"
@@ -239,7 +239,7 @@
               {% set columns = [('Name', 'name'), ('Customer', 'customer_name'), ('Owner', None), ('Parts', 'req_count'), ('Offers', 'offer_count'), ('Status', 'status'), ('Urgency', 'urgency'), ('Deadline', 'deadline'), ('Updated', 'updated_at'), ('Created', 'created_at'), ('', None)] %}
             {% endif %}
             {% for col_name, col_key in columns %}
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               {% if col_key %}
               <a hx-get="/v2/partials/requisitions"
                  hx-target="#main-content"
@@ -270,9 +270,9 @@
       </table>
     </div>
     {% else %}
-    <div class="p-12 text-center">
+    <div class="p-6 sm:p-8 text-center">
       <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
-      <p class="mt-2 text-sm text-gray-500">No requisitions found</p>
+      <p class="mt-2 text-sm text-gray-600">No requisitions found</p>
       <button @click="$dispatch('open-modal')"
               hx-get="/v2/partials/requisitions/create-form"
               hx-target="#modal-content"
@@ -293,7 +293,7 @@
          preload="mouseover"
          class="px-3 py-1.5 text-sm bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Prev</a>
       {% endif %}
-      <span class="px-3 py-1.5 text-sm text-gray-500">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
+      <span class="px-3 py-1.5 text-sm text-gray-600">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
       {% if offset + limit < total %}
       <a hx-get="/v2/partials/requisitions"
          hx-target="#main-content"

--- a/app/templates/htmx/partials/requisitions/req_row.html
+++ b/app/templates/htmx/partials/requisitions/req_row.html
@@ -7,7 +7,7 @@
 
 {# Reusable cell macros — name/owner/status/urgency are inline-editable (dblclick); others are read-only #}
 {% macro cell_name() %}
-  <td class="px-4 py-3 text-sm font-medium text-brand-500 group-hover:text-brand-600"
+  <td class="table-cell text-sm font-medium text-brand-500 group-hover:text-brand-600"
       hx-get="/v2/partials/requisitions/{{ req.id }}/edit/name?context=row"
       hx-target="this"
       hx-swap="innerHTML"
@@ -23,13 +23,13 @@
         {{ req.name }}
       </a>
       {% if req.match_reason|default(none) == 'part' and req.matched_mpn|default(none) %}
-        <span class="match-badge inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-semibold rounded-full bg-violet-50 text-violet-600 border border-violet-200"
+        <span class="match-badge inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs font-semibold rounded-full bg-violet-50 text-violet-600 border border-violet-200"
               title="Matched part: {{ req.matched_mpn }}">
           <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
           {{ req.matched_mpn }}
         </span>
       {% elif req.match_reason|default(none) == 'customer' %}
-        <span class="match-badge inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-semibold rounded-full bg-sky-50 text-sky-600 border border-sky-200">
+        <span class="match-badge inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs font-semibold rounded-full bg-sky-50 text-sky-600 border border-sky-200">
           <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
           customer match
         </span>
@@ -39,11 +39,11 @@
 {% endmacro %}
 
 {% macro cell_customer() %}
-  <td class="px-4 py-3 text-sm text-gray-500">{{ req.customer_name or "—" }}</td>
+  <td class="table-cell text-sm text-gray-600">{{ req.customer_name or "—" }}</td>
 {% endmacro %}
 
 {% macro cell_owner() %}
-  <td class="px-4 py-3 text-sm text-gray-500"
+  <td class="table-cell text-sm text-gray-600"
       hx-get="/v2/partials/requisitions/{{ req.id }}/edit/owner?context=row"
       hx-target="this"
       hx-swap="innerHTML"
@@ -60,15 +60,15 @@
 {% endmacro %}
 
 {% macro cell_parts() %}
-  <td class="px-4 py-3 text-sm text-gray-500 tabular-nums">{{ req.req_count }}</td>
+  <td class="table-cell text-sm text-gray-600 tabular-nums">{{ req.req_count }}</td>
 {% endmacro %}
 
 {% macro cell_offers() %}
-  <td class="px-4 py-3 text-sm text-gray-500 tabular-nums">{{ req.offer_count|default(0) }}</td>
+  <td class="table-cell text-sm text-gray-600 tabular-nums">{{ req.offer_count|default(0) }}</td>
 {% endmacro %}
 
 {% macro cell_status() %}
-  <td class="px-4 py-3"
+  <td class="table-cell"
       hx-get="/v2/partials/requisitions/{{ req.id }}/edit/status?context=row"
       hx-target="this"
       hx-swap="innerHTML"
@@ -80,7 +80,7 @@
 {% endmacro %}
 
 {% macro cell_urgency() %}
-  <td class="px-4 py-3"
+  <td class="table-cell"
       hx-get="/v2/partials/requisitions/{{ req.id }}/edit/urgency?context=row"
       hx-target="this"
       hx-swap="innerHTML"
@@ -92,7 +92,7 @@
 {% endmacro %}
 
 {% macro cell_deadline() %}
-  <td class="px-4 py-3 text-sm text-gray-500 whitespace-nowrap">
+  <td class="table-cell text-sm text-gray-600 whitespace-nowrap">
     {% if req.deadline == 'ASAP' %}
       <span class="text-amber-600 font-medium">ASAP</span>
     {% elif req.deadline %}
@@ -104,11 +104,11 @@
 {% endmacro %}
 
 {% macro cell_updated() %}
-  <td class="px-4 py-3 text-sm text-gray-500" title="{{ req.updated_at.strftime('%b %d, %Y') if req.updated_at else '' }}">{{ req.updated_at|timeago if req.updated_at else "—" }}</td>
+  <td class="table-cell text-sm text-gray-600" title="{{ req.updated_at.strftime('%b %d, %Y') if req.updated_at else '' }}">{{ req.updated_at|timeago if req.updated_at else "—" }}</td>
 {% endmacro %}
 
 {% macro cell_created() %}
-  <td class="px-4 py-3 text-sm text-gray-500" title="{{ req.created_at.strftime('%b %d, %Y') if req.created_at else '' }}">{{ req.created_at|timeago if req.created_at else "—" }}</td>
+  <td class="table-cell text-sm text-gray-600" title="{{ req.created_at.strftime('%b %d, %Y') if req.created_at else '' }}">{{ req.created_at|timeago if req.created_at else "—" }}</td>
 {% endmacro %}
 
 {% macro cell_actions() %}

--- a/app/templates/htmx/partials/requisitions/response_status_badge.html
+++ b/app/templates/htmx/partials/requisitions/response_status_badge.html
@@ -9,6 +9,6 @@
   'rejected': 'bg-rose-50 text-rose-700',
   'flagged': 'bg-amber-50 text-amber-700',
 } %}
-<span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ status_colors.get(response.status, 'bg-gray-100 text-gray-600') }}">
+<span class="badge {{ status_colors.get(response.status, 'bg-gray-100 text-gray-600') }}">
   {{ response.status|capitalize }}
 </span>

--- a/app/templates/htmx/partials/requisitions/rfq_compose.html
+++ b/app/templates/htmx/partials/requisitions/rfq_compose.html
@@ -39,7 +39,7 @@
     <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
       <div class="px-4 py-3 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
         <h3 class="text-sm font-semibold text-gray-900">Select Vendors ({{ vendors|length }} available)</h3>
-        <label class="flex items-center gap-2 text-xs text-gray-500 cursor-pointer">
+        <label class="flex items-center gap-2 text-xs text-gray-600 cursor-pointer">
           <input type="checkbox"
                  @change="selectedVendors = $event.target.checked ? {{ vendors|map(attribute='id')|list|tojson }} : []"
                  class="rounded border-gray-300 text-brand-500 focus:ring-brand-500">
@@ -59,7 +59,7 @@
             <div class="flex items-center gap-2">
               <p class="text-sm font-medium text-gray-900">{{ v.display_name }}</p>
               {% if v.already_asked %}
-              <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-amber-50 text-amber-700">
+              <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded-full bg-amber-50 text-amber-700">
                 Already Asked
               </span>
               {% endif %}
@@ -70,7 +70,7 @@
             {% if v.emails %}
             <div class="mt-1 flex flex-wrap gap-1">
               {% for email in v.emails[:3] %}
-              <span class="text-xs text-gray-500">{{ email }}</span>
+              <span class="text-xs text-gray-600">{{ email }}</span>
               {% endfor %}
             </div>
             {% else %}
@@ -90,8 +90,8 @@
         {% endfor %}
       </div>
       {% else %}
-      <div class="p-8 text-center">
-        <p class="text-sm text-gray-500">No vendors found with sightings for this requisition.</p>
+      <div class="p-6 sm:p-8 text-center">
+        <p class="text-sm text-gray-600">No vendors found with sightings for this requisition.</p>
         <p class="text-xs text-gray-400 mt-1">Search for parts first to find vendors.</p>
       </div>
       {% endif %}
@@ -103,7 +103,7 @@
       <div class="flex items-center justify-between mb-2">
         <div>
           <h3 class="text-sm font-semibold text-gray-900">Email Body</h3>
-          <p class="text-xs text-gray-500 mt-0.5">Write your email, then hit Clean Up to polish grammar and tone</p>
+          <p class="text-xs text-gray-600 mt-0.5">Write your email, then hit Clean Up to polish grammar and tone</p>
         </div>
         <button type="button"
                 hx-post="/v2/partials/requisitions/{{ req.id }}/ai-cleanup-email"
@@ -130,7 +130,7 @@
         <textarea name="body" rows="8"
                   id="rfq-body-textarea"
                   placeholder="Write your RFQ email here..."
-                  class="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"></textarea>
+                  class="input"></textarea>
       </div>
 
       <div id="ai-draft-area">
@@ -144,7 +144,7 @@
     <div class="mt-4 flex items-center gap-3">
       <button type="submit"
               x-bind:disabled="selectedVendors.length === 0"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 disabled:opacity-50 disabled:cursor-not-allowed">
+              class="btn-primary">
         <span x-text="'Send RFQ to ' + selectedVendors.length + ' vendor(s)'">Send RFQ</span>
       </button>
       <p class="text-xs text-gray-400" x-show="selectedVendors.length === 0" x-cloak>

--- a/app/templates/htmx/partials/requisitions/rfq_prepare.html
+++ b/app/templates/htmx/partials/requisitions/rfq_prepare.html
@@ -6,12 +6,12 @@
 <div class="bg-white rounded-lg shadow border border-gray-200 p-4">
   <div class="flex items-center justify-between mb-3">
     <h3 class="text-sm font-semibold text-gray-900">RFQ Preparation</h3>
-    <span class="text-xs text-gray-500">{{ total_contacted }} vendor{{ "s" if total_contacted != 1 }} already contacted</span>
+    <span class="text-xs text-gray-600">{{ total_contacted }} vendor{{ "s" if total_contacted != 1 }} already contacted</span>
   </div>
 
   {% if mpns %}
   <div class="mb-3">
-    <p class="text-xs text-gray-500 mb-1">Parts in this requisition:</p>
+    <p class="text-xs text-gray-600 mb-1">Parts in this requisition:</p>
     <div class="flex flex-wrap gap-1">
       {% for mpn in mpns %}
       <span class="px-2 py-0.5 text-xs font-mono bg-gray-100 text-gray-700 rounded">{{ mpn }}</span>
@@ -27,7 +27,7 @@
     <div class="flex items-center justify-between px-3 py-2 rounded border {{ 'border-gray-100 bg-gray-50 opacity-60' if v.already_contacted else 'border-brand-100 bg-brand-50' }}">
       <div>
         <p class="text-sm font-medium text-gray-900">{{ v.display_name }}</p>
-        <p class="text-xs text-gray-500">{{ v.sighting_count }} sighting{{ "s" if v.sighting_count != 1 }}</p>
+        <p class="text-xs text-gray-600">{{ v.sighting_count }} sighting{{ "s" if v.sighting_count != 1 }}</p>
       </div>
       {% if v.already_contacted %}
       <span class="text-xs text-gray-400">Already contacted</span>

--- a/app/templates/htmx/partials/requisitions/rfq_results.html
+++ b/app/templates/htmx/partials/requisitions/rfq_results.html
@@ -22,17 +22,17 @@
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
-          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
-          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Email</th>
-          <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Email</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Status</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200">
         {% for r in sent_results %}
         <tr class="hover:bg-brand-50">
-          <td class="px-4 py-2 text-sm font-medium text-gray-900">{{ r.vendor }}</td>
-          <td class="px-4 py-2 text-sm text-gray-500">{{ r.email }}</td>
-          <td class="px-4 py-2">
+          <td class="table-cell text-sm font-medium text-gray-900">{{ r.vendor }}</td>
+          <td class="table-cell text-sm text-gray-600">{{ r.email }}</td>
+          <td class="table-cell">
             <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-brand-50 text-brand-700">
               {{ r.status|capitalize }}
             </span>

--- a/app/templates/htmx/partials/requisitions/tabs/activity.html
+++ b/app/templates/htmx/partials/requisitions/tabs/activity.html
@@ -9,7 +9,7 @@
   {# ── AI digest (lazy-loaded) ───────────────────────────────────────── #}
   <div hx-get="/v2/partials/requisitions/{{ req.id }}/activity-digest"
        hx-trigger="load" hx-target="this" hx-swap="innerHTML">
-    <div class="rounded-lg border border-brand-200 bg-white p-4 animate-pulse">
+    <div class="card animate-pulse">
       <div class="h-3 w-2/3 bg-gray-100 rounded"></div>
     </div>
   </div>
@@ -18,22 +18,22 @@
   {% set rfq_events = activities | selectattr('activity_type', 'equalto', 'rfq_sent') | list | length %}
   {% set offer_events = activities | selectattr('activity_type', 'equalto', 'offer_created') | list | length %}
   <div class="grid grid-cols-3 gap-3">
-    <div class="bg-white rounded-lg border border-brand-200 p-3 text-center hover:bg-brand-50 transition-colors">
+    <div class="card-sm text-center hover:bg-brand-50 transition-colors">
       <p class="text-lg font-bold text-brand-600">{{ rfq_events }}</p>
-      <p class="text-xs text-gray-500">RFQ Events</p>
+      <p class="text-xs text-gray-600">RFQ Events</p>
     </div>
-    <div class="bg-white rounded-lg border border-brand-200 p-3 text-center hover:bg-brand-50 transition-colors">
+    <div class="card-sm text-center hover:bg-brand-50 transition-colors">
       <p class="text-lg font-bold text-amber-600">{{ offer_events }}</p>
-      <p class="text-xs text-gray-500">Offers</p>
+      <p class="text-xs text-gray-600">Offers</p>
     </div>
-    <div class="bg-white rounded-lg border border-brand-200 p-3 text-center hover:bg-brand-50 transition-colors">
+    <div class="card-sm text-center hover:bg-brand-50 transition-colors">
       <p class="text-lg font-bold text-gray-600">{{ activities | length }}</p>
-      <p class="text-xs text-gray-500">Activities</p>
+      <p class="text-xs text-gray-600">Activities</p>
     </div>
   </div>
 
   {# ── Log Activity Form ────────────────────────────────── #}
-  <div x-data="{ showForm: false }" class="bg-white rounded-lg border border-brand-200 p-4">
+  <div x-data="{ showForm: false }" class="card">
     <div class="flex items-center justify-between">
       <h3 class="text-sm font-semibold text-gray-900">Activity Log</h3>
       <button @click="showForm = !showForm"
@@ -54,7 +54,7 @@
           class="mt-3 space-y-3 p-3 bg-brand-50 rounded-lg border border-brand-200">
       <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Type</label>
+          <label class="form-label">Type</label>
           <select name="activity_type"
                   class="w-full px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500">
             <option value="note">Note</option>
@@ -63,28 +63,28 @@
           </select>
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Vendor</label>
+          <label class="form-label">Vendor</label>
           <input type="text" name="vendor_name" placeholder="Vendor name"
                  class="w-full px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500">
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Phone</label>
+          <label class="form-label">Phone</label>
           <input type="text" name="contact_phone" placeholder="Phone"
                  class="w-full px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500">
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Email</label>
+          <label class="form-label">Email</label>
           <input type="text" name="contact_email" placeholder="Email"
                  class="w-full px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500">
         </div>
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-500 mb-1">Notes</label>
+        <label class="form-label">Notes</label>
         <textarea name="notes" rows="2" placeholder="Activity notes..."
                   class="w-full px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500"></textarea>
       </div>
       <button type="submit"
-              class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600">
+              class="btn-primary btn-sm">
         Log Activity
       </button>
     </form>
@@ -125,11 +125,11 @@
     </div>
     {% else %}
     {# ── Empty state ─────────────────────────────────────── #}
-    <div class="py-12 text-center">
+    <div class="py-6 sm:py-8 text-center">
       <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
       </svg>
-      <p class="text-sm font-medium text-gray-500 mt-3">No activity recorded yet.</p>
+      <p class="text-sm font-medium text-gray-600 mt-3">No activity recorded yet.</p>
       <p class="text-xs text-gray-400 mt-1">Click "+ Log Activity" above to add a note, call, or email.</p>
     </div>
     {% endif %}

--- a/app/templates/htmx/partials/requisitions/tabs/buy_plans.html
+++ b/app/templates/htmx/partials/requisitions/tabs/buy_plans.html
@@ -6,7 +6,7 @@
 <div>
   {% if buy_plans %}
   <div class="flex items-center justify-between mb-4">
-    <p class="text-sm text-gray-500">
+    <p class="text-sm text-gray-600">
       <span class="font-semibold text-gray-900">{{ buy_plans|length }}</span> buy plan{{ "s" if buy_plans|length != 1 }}
     </p>
   </div>
@@ -29,7 +29,7 @@
             hx-target="#main-content"
             hx-push-url="/v2/buy-plans/{{ bp.id }}">
           <td class="px-4 py-2.5 text-sm font-medium text-brand-500 hover:text-brand-600">#{{ bp.id }}</td>
-          <td class="px-4 py-2.5 text-sm text-gray-500 font-mono">{{ bp.sales_order_number or "—" }}</td>
+          <td class="px-4 py-2.5 text-sm text-gray-600 font-mono">{{ bp.sales_order_number or "—" }}</td>
           <td class="px-4 py-2.5">
             {% set bp_colors = {
               "draft": "bg-slate-50 text-slate-600",
@@ -43,21 +43,21 @@
               {{ (bp.status or 'unknown')|replace('_', ' ')|capitalize }}
             </span>
           </td>
-          <td class="px-4 py-2.5 text-sm text-gray-500 text-right">{{ bp.lines|length if bp.lines else 0 }}</td>
+          <td class="px-4 py-2.5 text-sm text-gray-600 text-right">{{ bp.lines|length if bp.lines else 0 }}</td>
           <td class="px-4 py-2.5 text-sm text-gray-900 font-medium text-right">{{ "${:,.2f}".format(bp.total_cost) if bp.total_cost else "—" }}</td>
-          <td class="px-4 py-2.5 text-sm text-gray-500">{{ bp.created_at.strftime('%b %d, %Y') if bp.created_at else "—" }}</td>
+          <td class="px-4 py-2.5 text-sm text-gray-600">{{ bp.created_at.strftime('%b %d, %Y') if bp.created_at else "—" }}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
   </div>
   {% else %}
-  <div class="py-12 text-center">
+  <div class="py-6 sm:py-8 text-center">
     <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
             d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
     </svg>
-    <p class="text-sm font-medium text-gray-500 mt-3">No buy plans linked.</p>
+    <p class="text-sm font-medium text-gray-600 mt-3">No buy plans linked.</p>
     <p class="text-xs text-gray-400 mt-1">Buy plans are created after a quote is won and a sales order is received.</p>
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/requisitions/tabs/offers.html
+++ b/app/templates/htmx/partials/requisitions/tabs/offers.html
@@ -11,7 +11,7 @@
   <div class="mb-4" x-data="{ addOpen: false }">
     <div class="relative inline-block">
       <button @click="addOpen = !addOpen" type="button"
-              class="px-3 py-1.5 text-xs font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 inline-flex items-center gap-1.5">
+              class="btn btn-sm btn-primary">
         <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>
@@ -64,12 +64,12 @@
   {% if offers %}
   {# Action bar — appears when offers are selected #}
   <div class="flex items-center justify-between mb-4">
-    <p class="text-sm text-gray-500">
+    <p class="text-sm text-gray-600">
       <span class="font-semibold text-gray-900">{{ offers|length }}</span> offer{{ "s" if offers|length != 1 }}
     </p>
     <div class="flex items-center gap-2">
       <template x-if="selectedOffers.length > 0" x-cloak>
-        <span class="text-xs text-gray-500 mr-2" x-text="selectedOffers.length + ' selected'"></span>
+        <span class="text-xs text-gray-600 mr-2" x-text="selectedOffers.length + ' selected'"></span>
       </template>
       {% if draft_quote %}
       <button x-show="selectedOffers.length > 0" x-cloak
@@ -103,7 +103,7 @@
               hx-include="[name='offer_ids']"
               hx-target="#main-content"
               data-loading-disable
-              class="px-3 py-1.5 text-xs font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600"
+              class="btn btn-sm btn-primary"
               x-cloak>
         Create Quote from Selected
       </button>
@@ -151,23 +151,23 @@
           </td>
           <td data-col-key="vendor" class="px-4 py-2.5 text-sm font-medium text-gray-900">{{ o.vendor_name or "—" }}</td>
           <td data-col-key="mpn" class="px-4 py-2.5 text-sm font-mono text-gray-900">{{ o.mpn or "—" }}</td>
-          <td data-col-key="qty" class="px-4 py-2.5 text-sm text-gray-500 text-right">{{ "{:,}".format(o.qty_available) if o.qty_available else "—" }}</td>
+          <td data-col-key="qty" class="px-4 py-2.5 text-sm text-gray-600 text-right">{{ "{:,}".format(o.qty_available) if o.qty_available else "—" }}</td>
           <td data-col-key="price" class="px-4 py-2.5 text-sm text-right {{ 'text-emerald-700 font-medium' if o.unit_price else 'text-gray-500' }}">
             {{ "${:,.4f}".format(o.unit_price) if o.unit_price else "RFQ" }}
           </td>
-          <td data-col-key="condition" class="px-4 py-2.5 text-sm text-gray-500">{{ (o.condition or "—")|capitalize }}</td>
-          <td data-col-key="date_code" class="px-4 py-2.5 text-sm text-gray-500">{{ o.date_code or "—" }}</td>
-          <td data-col-key="lead_time" class="px-4 py-2.5 text-sm text-gray-500">{{ o.lead_time or "—" }}</td>
-          <td data-col-key="manufacturer" class="px-4 py-2.5 text-sm text-gray-500">{{ o.manufacturer or "—" }}</td>
-          <td data-col-key="moq" class="px-4 py-2.5 text-sm text-gray-500 text-right">{{ "{:,}".format(o.moq) if o.moq else "—" }}</td>
-          <td data-col-key="spq" class="px-4 py-2.5 text-sm text-gray-500 text-right">{{ "{:,}".format(o.spq) if o.spq else "—" }}</td>
-          <td data-col-key="packaging" class="px-4 py-2.5 text-sm text-gray-500">{{ o.packaging or "—" }}</td>
-          <td data-col-key="firmware" class="px-4 py-2.5 text-sm text-gray-500">{{ o.firmware or "—" }}</td>
-          <td data-col-key="hardware_code" class="px-4 py-2.5 text-sm text-gray-500">{{ o.hardware_code or "—" }}</td>
-          <td data-col-key="warranty" class="px-4 py-2.5 text-sm text-gray-500">{{ o.warranty or "—" }}</td>
-          <td data-col-key="country_of_origin" class="px-4 py-2.5 text-sm text-gray-500">{{ o.country_of_origin or "—" }}</td>
-          <td data-col-key="valid_until" class="px-4 py-2.5 text-sm text-gray-500">{{ o.valid_until.strftime('%b %d, %Y') if o.valid_until else "—" }}</td>
-          <td data-col-key="notes" class="px-4 py-2.5 text-sm text-gray-500 max-w-[200px] truncate" title="{{ o.notes or '' }}">{{ o.notes or "—" }}</td>
+          <td data-col-key="condition" class="px-4 py-2.5 text-sm text-gray-600">{{ (o.condition or "—")|capitalize }}</td>
+          <td data-col-key="date_code" class="px-4 py-2.5 text-sm text-gray-600">{{ o.date_code or "—" }}</td>
+          <td data-col-key="lead_time" class="px-4 py-2.5 text-sm text-gray-600">{{ o.lead_time or "—" }}</td>
+          <td data-col-key="manufacturer" class="px-4 py-2.5 text-sm text-gray-600">{{ o.manufacturer or "—" }}</td>
+          <td data-col-key="moq" class="px-4 py-2.5 text-sm text-gray-600 text-right">{{ "{:,}".format(o.moq) if o.moq else "—" }}</td>
+          <td data-col-key="spq" class="px-4 py-2.5 text-sm text-gray-600 text-right">{{ "{:,}".format(o.spq) if o.spq else "—" }}</td>
+          <td data-col-key="packaging" class="px-4 py-2.5 text-sm text-gray-600">{{ o.packaging or "—" }}</td>
+          <td data-col-key="firmware" class="px-4 py-2.5 text-sm text-gray-600">{{ o.firmware or "—" }}</td>
+          <td data-col-key="hardware_code" class="px-4 py-2.5 text-sm text-gray-600">{{ o.hardware_code or "—" }}</td>
+          <td data-col-key="warranty" class="px-4 py-2.5 text-sm text-gray-600">{{ o.warranty or "—" }}</td>
+          <td data-col-key="country_of_origin" class="px-4 py-2.5 text-sm text-gray-600">{{ o.country_of_origin or "—" }}</td>
+          <td data-col-key="valid_until" class="px-4 py-2.5 text-sm text-gray-600">{{ o.valid_until.strftime('%b %d, %Y') if o.valid_until else "—" }}</td>
+          <td data-col-key="notes" class="px-4 py-2.5 text-sm text-gray-600 max-w-[200px] truncate" title="{{ o.notes or '' }}">{{ o.notes or "—" }}</td>
           <td data-col-key="status" class="px-4 py-2.5">
             {% set offer_colors = {
               "active": "bg-emerald-50 text-emerald-700",
@@ -254,16 +254,16 @@
     </form>
   </div>
   {% else %}
-  <div class="py-12 text-center">
+  <div class="py-6 sm:py-8 text-center">
     <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
             d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
     </svg>
     {% if qual %}
-    <p class="text-sm font-medium text-gray-500 mt-3">No offers match this filter.</p>
+    <p class="text-sm font-medium text-gray-600 mt-3">No offers match this filter.</p>
     <p class="text-xs text-gray-400 mt-1">Try selecting a different filter above or clear the filter to see all offers.</p>
     {% else %}
-    <p class="text-sm font-medium text-gray-500 mt-3">No offers received yet.</p>
+    <p class="text-sm font-medium text-gray-600 mt-3">No offers received yet.</p>
     <p class="text-xs text-gray-400 mt-1">Offers appear here when vendors respond to RFQs or when leads are promoted.</p>
     {% endif %}
   </div>

--- a/app/templates/htmx/partials/requisitions/tabs/parse_email_form.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parse_email_form.html
@@ -22,12 +22,12 @@
       <div>
         <label class="text-xs text-gray-500 block mb-1">Subject (optional)</label>
         <input type="text" name="email_subject" placeholder="RE: RFQ for LM317T"
-               class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+               class="input">
       </div>
       <div>
         <label class="text-xs text-gray-500 block mb-1">Vendor Name (optional)</label>
         <input type="text" name="vendor_name" placeholder="Arrow Electronics"
-               class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+               class="input">
       </div>
     </div>
 
@@ -35,12 +35,12 @@
       <label class="text-xs text-gray-500 block mb-1">Email Body</label>
       <textarea name="email_body" rows="6" required
                 placeholder="Paste the full vendor email here..."
-                class="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-brand-500 focus:border-brand-500 font-mono"></textarea>
+                class="input font-mono"></textarea>
     </div>
 
     <div class="flex items-center gap-2">
       <button type="submit" :disabled="parsing"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 disabled:opacity-50 inline-flex items-center gap-2">
+              class="btn-primary">
         <svg x-show="parsing" x-cloak class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>

--- a/app/templates/htmx/partials/requisitions/tabs/parsed_email_results.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parsed_email_results.html
@@ -42,11 +42,11 @@
         {% set q_conf = ((q.confidence or 0.5) * 100)|round|int %}
         <div class="absolute top-3 right-3">
           {% if q_conf >= 80 %}
-          <span class="px-2 py-0.5 text-[10px] font-medium rounded-full bg-emerald-50 text-emerald-700">{{ q_conf }}%</span>
+          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-50 text-emerald-700">{{ q_conf }}%</span>
           {% elif q_conf >= 50 %}
-          <span class="px-2 py-0.5 text-[10px] font-medium rounded-full bg-amber-50 text-amber-700">{{ q_conf }}%</span>
+          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-amber-50 text-amber-700">{{ q_conf }}%</span>
           {% else %}
-          <span class="px-2 py-0.5 text-[10px] font-medium rounded-full bg-rose-50 text-rose-700">{{ q_conf }}%</span>
+          <span class="px-2 py-0.5 text-xs font-medium rounded-full bg-rose-50 text-rose-700">{{ q_conf }}%</span>
           {% endif %}
           <button type="button"
                   @click="$el.closest('[id^=parsed-card]').remove(); cards--"
@@ -59,61 +59,61 @@
 
         <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Part Number</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Part Number</label>
             <input type="text" name="offers[{{ loop.index0 }}].mpn"
                    value="{{ q.part_number or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500 font-mono">
+                   class="input input-sm font-mono">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Manufacturer</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Manufacturer</label>
             <input type="text" name="offers[{{ loop.index0 }}].manufacturer"
                    value="{{ q.manufacturer or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Quantity</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Quantity</label>
             <input type="number" name="offers[{{ loop.index0 }}].qty_available"
                    value="{{ q.quantity_available or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Unit Price</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Unit Price</label>
             <input type="number" step="0.0001" name="offers[{{ loop.index0 }}].unit_price"
                    value="{{ q.unit_price or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Lead Time</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Lead Time</label>
             <input type="text" name="offers[{{ loop.index0 }}].lead_time"
                    value="{{ q.lead_time_text or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Date Code</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Date Code</label>
             <input type="text" name="offers[{{ loop.index0 }}].date_code"
                    value="{{ q.date_code or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Condition</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Condition</label>
             <input type="text" name="offers[{{ loop.index0 }}].condition"
                    value="{{ q.condition or 'new' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">MOQ</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">MOQ</label>
             <input type="number" name="offers[{{ loop.index0 }}].moq"
                    value="{{ q.moq or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
         </div>
 
         {% if q.notes %}
         <div class="mt-2">
-          <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Notes</label>
+          <label class="text-xs text-gray-600 uppercase block mb-0.5">Notes</label>
           <input type="text" name="offers[{{ loop.index0 }}].notes"
                  value="{{ q.notes }}"
-                 class="w-full px-2 py-1 text-sm border border-gray-200 rounded text-gray-500">
+                 class="w-full px-2 py-1 text-sm border border-gray-200 rounded text-gray-600">
         </div>
         {% endif %}
       </div>
@@ -124,7 +124,7 @@
       <button type="submit" :disabled="saving || cards === 0"
               @htmx:before-request="saving = true"
               @htmx:after-request="saving = false"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 disabled:opacity-50 inline-flex items-center gap-2">
+              class="btn-primary">
         <svg x-show="saving" x-cloak class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
@@ -138,7 +138,7 @@
 
   {% else %}
   <div class="p-6 text-center bg-white rounded-lg border border-gray-200">
-    <p class="text-sm text-gray-500">No offers could be parsed from this email.</p>
+    <p class="text-sm text-gray-600">No offers could be parsed from this email.</p>
     <p class="text-xs text-gray-400 mt-1">Try pasting a different email or check the format.</p>
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/requisitions/tabs/parsed_offer_results.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parsed_offer_results.html
@@ -37,52 +37,52 @@
 
         <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Vendor</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Vendor</label>
             <input type="text" name="offers[{{ loop.index0 }}].vendor_name"
                    value="{{ o.vendor_name or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Part Number</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Part Number</label>
             <input type="text" name="offers[{{ loop.index0 }}].mpn"
                    value="{{ o.mpn or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500 font-mono">
+                   class="input input-sm font-mono">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Manufacturer</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Manufacturer</label>
             <input type="text" name="offers[{{ loop.index0 }}].manufacturer"
                    value="{{ o.manufacturer or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Quantity</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Quantity</label>
             <input type="number" name="offers[{{ loop.index0 }}].qty_available"
                    value="{{ o.qty_available or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Unit Price</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Unit Price</label>
             <input type="number" step="0.0001" name="offers[{{ loop.index0 }}].unit_price"
                    value="{{ o.unit_price or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Lead Time</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Lead Time</label>
             <input type="text" name="offers[{{ loop.index0 }}].lead_time"
                    value="{{ o.lead_time or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Date Code</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Date Code</label>
             <input type="text" name="offers[{{ loop.index0 }}].date_code"
                    value="{{ o.date_code or '' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
           <div>
-            <label class="text-[10px] text-gray-500 uppercase block mb-0.5">Condition</label>
+            <label class="text-xs text-gray-600 uppercase block mb-0.5">Condition</label>
             <input type="text" name="offers[{{ loop.index0 }}].condition"
                    value="{{ o.condition or 'new' }}"
-                   class="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500">
+                   class="input input-sm">
           </div>
         </div>
       </div>
@@ -93,7 +93,7 @@
       <button type="submit" :disabled="saving || cards === 0"
               @htmx:before-request="saving = true"
               @htmx:after-request="saving = false"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 disabled:opacity-50 inline-flex items-center gap-2">
+              class="btn-primary btn-sm">
         <svg x-show="saving" x-cloak class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
@@ -101,13 +101,13 @@
         <span x-text="saving ? 'Saving...' : 'Save ' + cards + ' Offer' + (cards !== 1 ? 's' : '')"></span>
       </button>
       <button type="button" @click="$el.closest('#parse-area').innerHTML = ''"
-              class="px-4 py-2 text-sm font-medium text-gray-500 hover:text-gray-700">Cancel</button>
+              class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-700">Cancel</button>
     </div>
   </form>
 
   {% else %}
   <div class="p-6 text-center bg-white rounded-lg border border-gray-200">
-    <p class="text-sm text-gray-500">No offers could be parsed from the text.</p>
+    <p class="text-sm text-gray-600">No offers could be parsed from the text.</p>
     <p class="text-xs text-gray-400 mt-1">Try pasting different text or use a more structured format.</p>
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/requisitions/tabs/parts.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parts.html
@@ -20,7 +20,7 @@
               hx-target="closest div"
               hx-swap="innerHTML"
               data-loading-disable
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 transition-colors">
+              class="btn-primary btn-sm">
         <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"/>
         </svg>
@@ -173,7 +173,7 @@
       </div>
 
       <button type="submit"
-              class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 inline-flex items-center gap-1.5">
+              class="btn-primary btn-sm">
         <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>

--- a/app/templates/htmx/partials/requisitions/tabs/paste_offer_form.html
+++ b/app/templates/htmx/partials/requisitions/tabs/paste_offer_form.html
@@ -9,7 +9,7 @@
     <button @click="$el.closest('#parse-area').innerHTML = ''"
             class="text-xs text-gray-400 hover:text-gray-600">Close</button>
   </div>
-  <p class="text-xs text-gray-500 mb-3">Paste any vendor text (email, chat, spreadsheet rows). AI will extract offer lines matched against this RFQ's parts.</p>
+  <p class="text-xs text-gray-600 mb-3">Paste any vendor text (email, chat, spreadsheet rows). AI will extract offer lines matched against this RFQ's parts.</p>
 
   <form hx-post="/v2/partials/requisitions/{{ req.id }}/parse-offer"
         hx-target="#parse-area"
@@ -19,15 +19,15 @@
         @htmx:after-request="parsing = false">
 
     <div class="mb-3">
-      <label class="text-xs text-gray-500 block mb-1">Vendor Text</label>
+      <label class="form-label">Vendor Text</label>
       <textarea name="raw_text" rows="6" required
                 placeholder="Paste vendor offer text here..."
-                class="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-brand-500 focus:border-brand-500 font-mono"></textarea>
+                class="input font-mono"></textarea>
     </div>
 
     <div class="flex items-center gap-2">
       <button type="submit" :disabled="parsing"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 disabled:opacity-50 inline-flex items-center gap-2">
+              class="btn-primary btn-sm">
         <svg x-show="parsing" x-cloak class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>

--- a/app/templates/htmx/partials/requisitions/tabs/quotes.html
+++ b/app/templates/htmx/partials/requisitions/tabs/quotes.html
@@ -6,7 +6,7 @@
 <div>
   {% if quotes %}
   <div class="flex items-center justify-between mb-4">
-    <p class="text-sm text-gray-500">
+    <p class="text-sm text-gray-600">
       <span class="font-semibold text-gray-900">{{ quotes|length }}</span> quote{{ "s" if quotes|length != 1 }}
     </p>
   </div>
@@ -29,7 +29,7 @@
             hx-target="#main-content"
             hx-push-url="/v2/quotes/{{ q.id }}">
           <td class="px-4 py-2.5 text-sm font-medium text-brand-500 hover:text-brand-600">{{ q.quote_number or "Q-" ~ q.id }}</td>
-          <td class="px-4 py-2.5 text-sm text-gray-500">{{ q.customer_name or "—" }}</td>
+          <td class="px-4 py-2.5 text-sm text-gray-600">{{ q.customer_name or "—" }}</td>
           <td class="px-4 py-2.5 text-sm text-gray-900 font-medium text-right">{{ "${:,.2f}".format(q.subtotal) if q.subtotal else "—" }}</td>
           <td class="px-4 py-2.5 text-sm text-right">
             {% if q.total_margin_pct is not none %}
@@ -41,7 +41,7 @@
                 <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-rose-50 text-rose-700">{{ "%.1f%%"|format(q.total_margin_pct) }}</span>
               {% endif %}
             {% else %}
-              <span class="text-gray-500">—</span>
+              <span class="text-gray-600">—</span>
             {% endif %}
           </td>
           <td class="px-4 py-2.5">
@@ -56,19 +56,19 @@
               {{ q.status|capitalize }}
             </span>
           </td>
-          <td class="px-4 py-2.5 text-sm text-gray-500">{{ q.created_at.strftime('%b %d, %Y') if q.created_at else "—" }}</td>
+          <td class="px-4 py-2.5 text-sm text-gray-600">{{ q.created_at.strftime('%b %d, %Y') if q.created_at else "—" }}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
   </div>
   {% else %}
-  <div class="py-12 text-center">
+  <div class="py-6 sm:py-8 text-center">
     <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
             d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
     </svg>
-    <p class="text-sm font-medium text-gray-500 mt-3">No quotes generated.</p>
+    <p class="text-sm font-medium text-gray-600 mt-3">No quotes generated.</p>
     <p class="text-xs text-gray-400 mt-1">Create a quote from the Offers tab by selecting offers and clicking "Create Quote."</p>
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/requisitions/tabs/req_row.html
+++ b/app/templates/htmx/partials/requisitions/tabs/req_row.html
@@ -18,28 +18,28 @@
     {{ mpn_chips(r) }}
   </td>
   {% set desc = r|part_description %}
-  <td data-col-key="description" class="px-4 py-2.5 text-sm text-gray-500 max-w-[200px] truncate" x-show="!editing" x-cloak title="{{ desc }}">{{ desc or "—" }}</td>
-  <td data-col-key="brand" class="px-4 py-2.5 text-sm text-gray-500" x-show="!editing" x-cloak>{{ r.brand or "—" }}</td>
-  <td data-col-key="qty" class="px-4 py-2.5 text-sm text-gray-500 text-right tabular-nums" x-show="!editing" x-cloak>
+  <td data-col-key="description" class="px-4 py-2.5 text-sm text-gray-600 max-w-[200px] truncate" x-show="!editing" x-cloak title="{{ desc }}">{{ desc or "—" }}</td>
+  <td data-col-key="brand" class="px-4 py-2.5 text-sm text-gray-600" x-show="!editing" x-cloak>{{ r.brand or "—" }}</td>
+  <td data-col-key="qty" class="px-4 py-2.5 text-sm text-gray-600 text-right tabular-nums" x-show="!editing" x-cloak>
     {{ "{:,}".format(r.target_qty) if r.target_qty else "—" }}
   </td>
-  <td data-col-key="customer_pn" class="px-4 py-2.5 text-sm text-gray-500" x-show="!editing" x-cloak>{{ r.customer_pn or "—" }}</td>
+  <td data-col-key="customer_pn" class="px-4 py-2.5 text-sm text-gray-600" x-show="!editing" x-cloak>{{ r.customer_pn or "—" }}</td>
   <td data-col-key="target_price" class="px-4 py-2.5 text-sm text-right tabular-nums" x-show="!editing" x-cloak>
     {% if r.target_price %}
       <span class="text-emerald-700 font-medium">${{ "{:,.4f}".format(r.target_price) }}</span>
     {% else %}
-      <span class="text-gray-500">—</span>
+      <span class="text-gray-600">—</span>
     {% endif %}
   </td>
-  <td data-col-key="need_by_date" class="px-4 py-2.5 text-sm text-gray-500" x-show="!editing" x-cloak>
+  <td data-col-key="need_by_date" class="px-4 py-2.5 text-sm text-gray-600" x-show="!editing" x-cloak>
     {{ r.need_by_date.strftime('%b %d, %Y') if r.need_by_date else "—" }}
   </td>
-  <td data-col-key="condition" class="px-4 py-2.5 text-sm text-gray-500" x-show="!editing" x-cloak>{{ (r.condition or "—")|capitalize }}</td>
-  <td data-col-key="date_codes" class="px-4 py-2.5 text-sm text-gray-500" x-show="!editing" x-cloak>{{ r.date_codes or "—" }}</td>
-  <td data-col-key="firmware" class="px-4 py-2.5 text-sm text-gray-500" x-show="!editing" x-cloak>{{ r.firmware or "—" }}</td>
-  <td data-col-key="hardware_codes" class="px-4 py-2.5 text-sm text-gray-500" x-show="!editing" x-cloak>{{ r.hardware_codes or "—" }}</td>
-  <td data-col-key="packaging" class="px-4 py-2.5 text-sm text-gray-500" x-show="!editing" x-cloak>{{ r.packaging or "—" }}</td>
-  <td data-col-key="notes" class="px-4 py-2.5 text-sm text-gray-500 max-w-[200px] truncate" x-show="!editing" x-cloak title="{{ r.notes or '' }}">{{ r.notes or "—" }}</td>
+  <td data-col-key="condition" class="px-4 py-2.5 text-sm text-gray-600" x-show="!editing" x-cloak>{{ (r.condition or "—")|capitalize }}</td>
+  <td data-col-key="date_codes" class="px-4 py-2.5 text-sm text-gray-600" x-show="!editing" x-cloak>{{ r.date_codes or "—" }}</td>
+  <td data-col-key="firmware" class="px-4 py-2.5 text-sm text-gray-600" x-show="!editing" x-cloak>{{ r.firmware or "—" }}</td>
+  <td data-col-key="hardware_codes" class="px-4 py-2.5 text-sm text-gray-600" x-show="!editing" x-cloak>{{ r.hardware_codes or "—" }}</td>
+  <td data-col-key="packaging" class="px-4 py-2.5 text-sm text-gray-600" x-show="!editing" x-cloak>{{ r.packaging or "—" }}</td>
+  <td data-col-key="notes" class="px-4 py-2.5 text-sm text-gray-600 max-w-[200px] truncate" x-show="!editing" x-cloak title="{{ r.notes or '' }}">{{ r.notes or "—" }}</td>
   <td data-col-key="status" class="px-4 py-2.5" x-show="!editing" x-cloak>
     {% from "htmx/partials/shared/_macros.html" import status_badge %}
     {{ status_badge(r.sourcing_status or 'open') }}
@@ -57,7 +57,7 @@
       <span class="text-gray-400 tabular-nums">0</span>
     {% endif %}
     {% if r.last_searched_at %}
-    <div class="text-[10px] text-gray-400">{{ r.last_searched_at|timeago }}</div>
+    <div class="text-xs text-gray-400">{{ r.last_searched_at|timeago }}</div>
     {% endif %}
   </td>
   <td class="px-4 py-2.5 text-center" x-show="!editing" x-cloak>
@@ -143,7 +143,7 @@
       {# Structured substitute rows — initialised from data-subs JSON attribute #}
       <div x-data="{ subs: JSON.parse($el.dataset.subs || '[]') }"
            data-subs="{{ r.substitutes | tojson if r.substitutes else '[]' }}">
-        <div class="text-xs text-gray-500 mb-1">Substitutes</div>
+        <div class="text-xs text-gray-600 mb-1">Substitutes</div>
         <template x-for="(sub, idx) in subs" :key="idx">
           <div class="flex gap-1.5 items-center mb-1">
             <input aria-label="Sub MPN" :name="'sub_mpn'" x-model="sub.mpn" placeholder="Sub MPN"
@@ -171,7 +171,7 @@
       <textarea name="notes" rows="1" placeholder="Notes"
                 class="w-full px-2 py-1.5 text-sm border border-brand-200 rounded focus:ring-2 focus:ring-brand-500">{{ r.notes or '' }}</textarea>
       <div class="flex items-center gap-2">
-        <button type="submit" class="px-3 py-1.5 text-xs font-medium bg-brand-500 text-white rounded hover:bg-brand-600">Save</button>
+        <button type="submit" class="btn-primary btn-sm">Save</button>
         <button type="button" @click="editing = false" class="px-3 py-1.5 text-xs font-medium text-gray-600 border border-gray-300 rounded hover:bg-gray-100">Cancel</button>
       </div>
     </form>

--- a/app/templates/htmx/partials/requisitions/tabs/response_card.html
+++ b/app/templates/htmx/partials/requisitions/tabs/response_card.html
@@ -7,7 +7,7 @@
   <div class="flex items-start justify-between mb-2">
     <div>
       <h4 class="font-semibold text-gray-900">{{ r.vendor_name or "Unknown Vendor" }}</h4>
-      <p class="text-xs text-gray-500">{{ r.vendor_email or "" }} &middot; {{ r.received_at.strftime('%b %d, %Y %H:%M') if r.received_at else "&mdash;" }}</p>
+      <p class="text-xs text-gray-600">{{ r.vendor_email or "" }} &middot; {{ r.received_at.strftime('%b %d, %Y %H:%M') if r.received_at else "&mdash;" }}</p>
     </div>
     <div class="flex items-center gap-2">
       {% set class_colors = {
@@ -42,19 +42,19 @@
   {% endif %}
   {% if r.parsed_data %}
   <div class="bg-gray-50 rounded p-3 mb-3 text-sm">
-    <p class="text-xs font-medium text-gray-500 uppercase mb-1">AI-Parsed Data</p>
+    <p class="text-xs font-medium text-gray-600 uppercase mb-1">AI-Parsed Data</p>
     <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs">
       {% if r.parsed_data.get('parts') %}
-      <div><span class="text-gray-500">Parts:</span> <span class="font-mono">{{ r.parsed_data['parts']|join(', ') if r.parsed_data['parts'] is iterable and r.parsed_data['parts'] is not string else r.parsed_data['parts'] }}</span></div>
+      <div><span class="text-gray-600">Parts:</span> <span class="font-mono">{{ r.parsed_data['parts']|join(', ') if r.parsed_data['parts'] is iterable and r.parsed_data['parts'] is not string else r.parsed_data['parts'] }}</span></div>
       {% endif %}
       {% if r.parsed_data.get('qty') %}
-      <div><span class="text-gray-500">Qty:</span> {{ r.parsed_data['qty'] }}</div>
+      <div><span class="text-gray-600">Qty:</span> {{ r.parsed_data['qty'] }}</div>
       {% endif %}
       {% if r.parsed_data.get('price') %}
-      <div><span class="text-gray-500">Price:</span> ${{ r.parsed_data['price'] }}</div>
+      <div><span class="text-gray-600">Price:</span> ${{ r.parsed_data['price'] }}</div>
       {% endif %}
       {% if r.parsed_data.get('lead_time') %}
-      <div><span class="text-gray-500">Lead Time:</span> {{ r.parsed_data['lead_time'] }}</div>
+      <div><span class="text-gray-600">Lead Time:</span> {{ r.parsed_data['lead_time'] }}</div>
       {% endif %}
     </div>
   </div>

--- a/app/templates/htmx/partials/requisitions/tabs/responses.html
+++ b/app/templates/htmx/partials/requisitions/tabs/responses.html
@@ -7,14 +7,14 @@
 <div>
   {# Action bar #}
   <div class="flex items-center justify-between mb-4">
-    <p class="text-sm text-gray-500">
+    <p class="text-sm text-gray-600">
       <span class="font-semibold text-gray-900">{{ responses|length }}</span> vendor response{{ "s" if responses|length != 1 }}
     </p>
     <button hx-post="/v2/partials/requisitions/{{ req.id }}/poll-inbox"
             hx-target="#tab-content"
             hx-swap="innerHTML"
             hx-indicator="#poll-spinner"
-            class="px-3 py-1.5 text-xs font-medium text-brand-600 bg-brand-50 border border-brand-200 rounded-lg hover:bg-brand-100 inline-flex items-center gap-1.5">
+            class="btn btn-sm text-brand-600 bg-brand-50 border border-brand-200 hover:bg-brand-100">
       <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
       </svg>
@@ -37,7 +37,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
             d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
     </svg>
-    <p class="text-sm text-gray-500 mt-2">No vendor responses yet.</p>
+    <p class="text-sm text-gray-600 mt-2">No vendor responses yet.</p>
     <p class="text-xs text-gray-400 mt-1">Click "Poll Inbox" to check for vendor replies, or responses will appear when vendors reply to RFQs.</p>
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/requisitions/tabs/tasks.html
+++ b/app/templates/htmx/partials/requisitions/tabs/tasks.html
@@ -27,12 +27,12 @@
           @htmx:after-request.camel="if(event.detail.successful) { $el.reset(); Alpine.store('toast').message='Task added'; Alpine.store('toast').type='success'; Alpine.store('toast').show=true; }"
           class="flex flex-wrap items-end gap-3">
       <div class="flex-1 min-w-[180px]">
-        <label class="block text-xs font-medium text-gray-500 mb-1">Title</label>
+        <label class="form-label">Title</label>
         <input type="text" name="title" required placeholder="Task title"
                class="w-full px-3 py-1.5 border border-brand-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-500 mb-1">Type</label>
+        <label class="form-label">Type</label>
         <select name="task_type" class="px-3 py-1.5 border border-brand-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
           <option value="general">General</option>
           <option value="sourcing">Sourcing</option>
@@ -40,7 +40,7 @@
         </select>
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-500 mb-1">Priority</label>
+        <label class="form-label">Priority</label>
         <select name="priority" class="px-3 py-1.5 border border-brand-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
           <option value="2">Medium</option>
           <option value="1">Low</option>
@@ -48,7 +48,7 @@
         </select>
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-500 mb-1">Assignee</label>
+        <label class="form-label">Assignee</label>
         <select name="assigned_to_id" class="px-3 py-1.5 border border-brand-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
           <option value="">Unassigned</option>
           {% for u in users %}
@@ -57,11 +57,11 @@
         </select>
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-500 mb-1">Due</label>
+        <label class="form-label">Due</label>
         <input type="date" name="due_at" class="px-3 py-1.5 border border-brand-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
       </div>
       <button type="submit"
-              class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 inline-flex items-center gap-1.5">
+              class="btn-primary btn-sm">
         <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
         </svg>
@@ -101,7 +101,7 @@
           "sales": "bg-amber-50 text-amber-700",
           "general": "bg-gray-100 text-gray-600"
         } %}
-        <span class="flex-shrink-0 inline-flex px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded-full {{ type_colors.get(t.task_type, 'bg-gray-100 text-gray-600') }}">
+        <span class="flex-shrink-0 inline-flex px-2 py-0.5 text-xs font-semibold uppercase tracking-wider rounded-full {{ type_colors.get(t.task_type, 'bg-gray-100 text-gray-600') }}">
           {{ t.task_type }}
         </span>
 
@@ -131,12 +131,12 @@
 
         {# AI priority score #}
         {% if t.ai_priority_score and t.ai_priority_score > 0 %}
-          <span class="flex-shrink-0 text-[10px] text-brand-400 font-mono" title="AI Priority Score">{{ "%.0f"|format(t.ai_priority_score * 100) }}</span>
+          <span class="flex-shrink-0 text-xs text-brand-400 font-mono" title="AI Priority Score">{{ "%.0f"|format(t.ai_priority_score * 100) }}</span>
         {% endif %}
 
         {# Assignee avatar #}
         {% if t.assignee %}
-          <span class="flex-shrink-0 inline-flex items-center justify-center h-6 w-6 rounded-full bg-brand-100 text-brand-600 text-[10px] font-bold"
+          <span class="flex-shrink-0 inline-flex items-center justify-center h-6 w-6 rounded-full bg-brand-100 text-brand-600 text-xs font-bold"
                 title="{{ t.assignee.name }}">
             {{ t.assignee.name[:1]|upper }}
           </span>
@@ -144,7 +144,7 @@
 
         {# Due date #}
         {% if t.due_at %}
-          <span class="flex-shrink-0 text-xs text-gray-500">{{ t.due_at.strftime('%b %d') }}</span>
+          <span class="flex-shrink-0 text-xs text-gray-600">{{ t.due_at.strftime('%b %d') }}</span>
         {% endif %}
 
         {# Delete button #}
@@ -162,12 +162,12 @@
       </div>
       {% endfor %}
     {% else %}
-      <div class="py-12 text-center">
+      <div class="py-6 sm:py-8 text-center">
         <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
                 d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
         </svg>
-        <p class="text-sm font-medium text-gray-500 mt-3">No tasks yet.</p>
+        <p class="text-sm font-medium text-gray-600 mt-3">No tasks yet.</p>
         <p class="text-xs text-gray-400 mt-1">Add a task to track work on this requisition.</p>
       </div>
     {% endif %}

--- a/app/templates/htmx/partials/requisitions/unified_modal.html
+++ b/app/templates/htmx/partials/requisitions/unified_modal.html
@@ -15,7 +15,7 @@
   <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4 flex-shrink-0">
     {# Name #}
     <div>
-      <label class="block text-xs font-medium text-gray-700 mb-1">Name <span class="text-rose-500">*</span></label>
+      <label class="form-label">Name <span class="text-rose-500">*</span></label>
       <input type="text" x-model="reqName" required placeholder="e.g. Acme Q2 BOM, Harris RFQ #4521"
              class="w-full px-3 py-1.5 border border-brand-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
     </div>
@@ -23,7 +23,7 @@
     {# Customer picker #}
     <div x-data="customerPicker()" class="relative"
          x-effect="customerSiteId = selectedSiteId; customerName = selectedName">
-      <label class="block text-xs font-medium text-gray-700 mb-1">Customer</label>
+      <label class="form-label">Customer</label>
 
       {# Selected state #}
       <div x-show="selectedSiteId" x-cloak class="flex items-center gap-2">
@@ -93,7 +93,7 @@
         <div data-lookup-result></div>
         <button type="button" :disabled="!newName.trim() || lookingUp"
                 @click="lookupCompany()"
-                class="px-3 py-1 text-xs font-semibold bg-brand-500 text-white rounded hover:bg-brand-600 disabled:opacity-50 inline-flex items-center gap-1">
+                class="btn-primary btn-sm">
           <svg x-show="lookingUp" x-cloak class="h-3 w-3 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
@@ -105,7 +105,7 @@
 
     {# Deadline / ASAP #}
     <div>
-      <label class="block text-xs font-medium text-gray-700 mb-1">Deadline</label>
+      <label class="form-label">Deadline</label>
       <div class="flex items-center gap-2">
         <input type="date" x-model="deadline" :disabled="urgency === 'critical'" x-show="urgency !== 'critical'" x-cloak
                class="px-2 py-1 text-[13px] text-gray-800 border border-gray-300 rounded focus:ring-1 focus:ring-brand-500 focus:border-brand-500">
@@ -133,7 +133,7 @@
                 class="text-xs font-medium text-brand-500 hover:text-brand-700 transition-colors">
           + Add sub
         </button>
-        <span class="text-[10px] text-gray-400" x-show="parts.length > 0" x-cloak
+        <span class="text-xs text-gray-400" x-show="parts.length > 0" x-cloak
               x-text="'(to row ' + (activePartIdx + 1) + ')'"></span>
         <span class="text-gray-300">|</span>
         <button type="button" @click="showBulkFill = !showBulkFill"
@@ -167,7 +167,7 @@
           <svg class="h-5 w-5 text-gray-400 mb-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"/>
           </svg>
-          <span class="text-xs text-gray-500">Drop a file or click to browse</span>
+          <span class="text-xs text-gray-600">Drop a file or click to browse</span>
           <span class="text-xs text-gray-400">.xlsx, .csv, .txt</span>
           <input aria-label="Upload BOM file" type="file" x-ref="fileInput" accept=".xlsx,.csv,.txt,.xls" class="hidden"
                  @change="$el.closest('label').querySelector('span').textContent = $el.files[0]?.name || 'Drop a file or click to browse'">
@@ -178,7 +178,7 @@
 
       <div class="mt-2 flex items-center gap-2">
         <button type="button" @click="parseWithAI()" :disabled="parsing"
-                class="px-3 py-1.5 text-xs font-semibold text-white bg-brand-500 rounded-lg hover:bg-brand-600 disabled:opacity-50 inline-flex items-center gap-2">
+                class="btn-primary btn-sm">
           <svg x-show="parsing" x-cloak class="h-3.5 w-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
@@ -225,7 +225,7 @@
               <input aria-label="MPN *" type="text" x-model="part.primary_mpn" placeholder="MPN *"
                      class="w-full px-1.5 py-1.5 text-[13px] text-gray-800 border border-gray-300 rounded focus:ring-1 focus:ring-brand-500 focus:border-brand-500 font-mono bg-white">
               <button x-show="part.substitutes.length > 0" x-cloak type="button" @click="part.showSubs = !part.showSubs"
-                      class="mt-1 text-[10px] font-semibold px-2 py-0.5 rounded bg-brand-100 text-brand-700 hover:bg-brand-200 transition-colors w-full text-center">
+                      class="mt-1 text-xs font-semibold px-2 py-0.5 rounded bg-brand-100 text-brand-700 hover:bg-brand-200 transition-colors w-full text-center">
                 <span x-text="part.substitutes.length + ' sub' + (part.substitutes.length !== 1 ? 's' : '') + (part.showSubs ? ' ▴' : ' ▾')"></span>
               </button>
             </div>
@@ -373,7 +373,7 @@
                   </div>
                   <div class="flex items-center gap-1.5 px-2 py-1.5">
                     <button type="button" @click="addSub(part)"
-                            class="text-[10px] font-semibold text-brand-500 hover:text-brand-700" title="Add another sub">+</button>
+                            class="text-xs font-semibold text-brand-500 hover:text-brand-700" title="Add another sub">+</button>
                     <button type="button" @click="removeSub(part, si)"
                             class="text-gray-400 hover:text-rose-500" title="Remove sub">
                       <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -446,7 +446,7 @@
         </template>
       </button>
       <button type="button" @click="$dispatch('close-modal')"
-              class="px-4 py-2 text-sm font-medium text-gray-500 hover:text-gray-700">Cancel</button>
+              class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-700">Cancel</button>
     </form>
   </div>
 

--- a/app/templates/requisitions2/_detail_empty.html
+++ b/app/templates/requisitions2/_detail_empty.html
@@ -9,6 +9,6 @@
     <path stroke-linecap="round" stroke-linejoin="round"
           d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
   </svg>
-  <p class="text-lg font-medium text-gray-500">Select a requisition</p>
+  <p class="text-lg font-medium text-gray-600">Select a requisition</p>
   <p class="text-sm mt-1">Click a row on the left to view details</p>
 </div>

--- a/app/templates/requisitions2/_detail_panel.html
+++ b/app/templates/requisitions2/_detail_panel.html
@@ -25,7 +25,7 @@
   <div class="flex items-center gap-3 px-5 py-3 border-b border-gray-200 bg-gray-50 flex-shrink-0">
     <div class="flex-1 min-w-0">
       <h2 class="text-base font-semibold text-gray-900 truncate">{{ req.name }}</h2>
-      <p class="text-xs text-gray-500 mt-0.5">{{ req.customer_display or 'No customer' }}</p>
+      <p class="text-xs text-gray-600 mt-0.5">{{ req.customer_display or 'No customer' }}</p>
     </div>
     <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full flex-shrink-0 {{ status_styles.get(req.status, 'bg-gray-100 text-gray-600') }}">
       {{ req.status }}

--- a/app/templates/requisitions2/_modal.html
+++ b/app/templates/requisitions2/_modal.html
@@ -27,15 +27,15 @@
 
     {# Requisition fields #}
     <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-      <dt class="text-gray-500">Customer</dt>
+      <dt class="text-gray-600">Customer</dt>
       <dd class="text-gray-900">{{ req.customer_display or 'N/A' }}</dd>
-      <dt class="text-gray-500">Owner</dt>
+      <dt class="text-gray-600">Owner</dt>
       <dd class="text-gray-900">{{ req.created_by_name or 'Unassigned' }}</dd>
-      <dt class="text-gray-500">Urgency</dt>
+      <dt class="text-gray-600">Urgency</dt>
       <dd class="text-gray-900">{{ req.urgency or 'normal' }}</dd>
-      <dt class="text-gray-500">Deadline</dt>
+      <dt class="text-gray-600">Deadline</dt>
       <dd class="text-gray-900">{{ req.deadline.strftime('%Y-%m-%d') if req.deadline else 'None' }}</dd>
-      <dt class="text-gray-500">Created</dt>
+      <dt class="text-gray-600">Created</dt>
       <dd class="text-gray-900">{{ req.created_at.strftime('%Y-%m-%d') if req.created_at else 'N/A' }}</dd>
     </dl>
 
@@ -46,17 +46,17 @@
       <table class="min-w-full divide-y divide-gray-200 text-sm">
         <thead class="bg-gray-50">
           <tr>
-            <th class="px-3 py-1 text-left text-xs font-medium text-gray-500">Part Number</th>
-            <th class="px-3 py-1 text-right text-xs font-medium text-gray-500">Qty</th>
-            <th class="px-3 py-1 text-left text-xs font-medium text-gray-500">Description</th>
+            <th class="compact-cell--head text-left text-xs font-medium text-gray-500">Part Number</th>
+            <th class="compact-cell--head text-right text-xs font-medium text-gray-500">Qty</th>
+            <th class="compact-cell--head text-left text-xs font-medium text-gray-500">Description</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
           {% for r in requirements[:10] %}
           <tr>
-            <td class="px-3 py-1">{{ r.primary_mpn or 'No PN' }}</td>
-            <td class="px-3 py-1 text-right">{{ r.target_qty or '—' }}</td>
-            <td class="px-3 py-1 text-gray-500">{{ r.description or '' }}</td>
+            <td class="compact-cell--dense">{{ r.primary_mpn or 'No PN' }}</td>
+            <td class="compact-cell--dense text-right">{{ r.target_qty or '—' }}</td>
+            <td class="compact-cell--dense text-gray-600">{{ r.description or '' }}</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/requisitions2/_offers_tab.html
+++ b/app/templates/requisitions2/_offers_tab.html
@@ -20,27 +20,27 @@
   <table class="min-w-full divide-y divide-gray-200 text-sm">
     <thead class="bg-gray-50">
       <tr>
-        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
-        <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Qty</th>
-        <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Unit $</th>
-        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Lead</th>
-        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+        <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
+        <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase">Qty</th>
+        <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase">Unit $</th>
+        <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Lead</th>
+        <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Status</th>
       </tr>
     </thead>
     <tbody class="divide-y divide-gray-100">
       {% for o in offers %}
       <tr class="hover:bg-gray-50">
-        <td class="px-4 py-2">
+        <td class="table-cell">
           <div class="text-gray-900">{{ o.vendor_name or '—' }}</div>
           {% if o.requirement and o.requirement.primary_mpn %}
           <div class="text-[11px] text-gray-400 font-mono mt-0.5">{{ o.requirement.primary_mpn }}</div>
           {% endif %}
         </td>
-        <td class="px-4 py-2 text-right text-gray-600">{{ '{:,}'.format(o.qty_available) if o.qty_available else '—' }}</td>
-        <td class="px-4 py-2 text-right text-gray-600 font-mono">{{ '${:,.4f}'.format(o.unit_price) if o.unit_price is not none else 'RFQ' }}</td>
-        <td class="px-4 py-2 text-gray-600">{{ o.lead_time or '—' }}</td>
-        <td class="px-4 py-2">
-          <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ sc.get(o.status, 'bg-gray-100 text-gray-600') }}">
+        <td class="table-cell text-right text-gray-600">{{ '{:,}'.format(o.qty_available) if o.qty_available else '—' }}</td>
+        <td class="table-cell text-right text-gray-600 font-mono">{{ '${:,.4f}'.format(o.unit_price) if o.unit_price is not none else 'RFQ' }}</td>
+        <td class="table-cell text-gray-600">{{ o.lead_time or '—' }}</td>
+        <td class="table-cell">
+          <span class="badge {{ sc.get(o.status, 'bg-gray-100 text-gray-600') }}">
             {{ (o.status or 'unknown')|replace('_', ' ')|capitalize }}
           </span>
         </td>
@@ -50,7 +50,7 @@
   </table>
 </div>
 {% else %}
-<div class="px-5 py-8 text-center text-sm text-gray-400">
+<div class="px-5 py-6 sm:py-8 text-center text-sm text-gray-400">
   No offers yet for this requisition.
 </div>
 {% endif %}

--- a/app/templates/requisitions2/_single_row.html
+++ b/app/templates/requisitions2/_single_row.html
@@ -26,9 +26,9 @@
             hx-get="/requisitions2/{{ req.id }}/edit/name" hx-target="closest td" hx-swap="innerHTML"
             @click.stop>{{ req.name }}</span>
       {% if req.urgency == 'hot' %}
-      <span class="inline-flex h-4 px-1 text-[10px] font-semibold rounded bg-amber-50 text-amber-700">HOT</span>
+      <span class="inline-flex h-4 px-1 text-xs font-semibold rounded bg-amber-50 text-amber-700">HOT</span>
       {% elif req.urgency == 'critical' %}
-      <span class="inline-flex h-4 px-1 text-[10px] font-semibold rounded bg-rose-50 text-rose-700" title="critical">CRIT</span>
+      <span class="inline-flex h-4 px-1 text-xs font-semibold rounded bg-rose-50 text-rose-700" title="critical">CRIT</span>
       {% endif %}
     </div>
   </td>

--- a/app/templates/requisitions2/_table.html
+++ b/app/templates/requisitions2/_table.html
@@ -113,7 +113,7 @@
     {{ page_link(pagination.page - 1, 'Prev') }}
     {% endif %}
   </div>
-  <span class="text-gray-500">
+  <span class="text-gray-600">
     {{ pagination.page }}/{{ pagination.total_pages }}
   </span>
   <div>

--- a/app/templates/requisitions2/_table_rows.html
+++ b/app/templates/requisitions2/_table_rows.html
@@ -51,7 +51,7 @@
       <path stroke-linecap="round" stroke-linejoin="round"
             d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
     </svg>
-    <p class="mt-2 text-sm text-gray-500">No requisitions found.</p>
+    <p class="mt-2 text-sm text-gray-600">No requisitions found.</p>
     <p class="text-xs text-gray-400 mt-1">Try adjusting your filters.</p>
   </td>
 </tr>

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -494,7 +494,7 @@ def test_tiny_text_does_not_grow():
 
     Ratchet — sweeps lower this as they bump 10px → text-xs / text-[11px].
     """
-    BASELINE = 270
+    BASELINE = 229
     count = _tpl_substring_count("text-[10px]")
     assert count <= BASELINE, (
         f"text-[10px] usages rose to {count} (baseline {BASELINE}). Use text-xs "
@@ -509,7 +509,7 @@ def test_low_contrast_secondary_text_does_not_grow():
     Ratchet only (decorative icon grays are fine) — caps growth rather than banning
     outright.
     """
-    BASELINE = 998
+    BASELINE = 839
     count = _tpl_substring_count("text-gray-500")
     assert count <= BASELINE, (
         f"text-gray-500 usages rose to {count} (baseline {BASELINE}). Prefer "
@@ -520,7 +520,7 @@ def test_low_contrast_secondary_text_does_not_grow():
 def test_focus_ring_1_does_not_grow():
     """One focus-ring spec: ring-2 (see .input / .btn). Ratchet down the legacy
     ring-1 usages; never add a new one."""
-    BASELINE = 81
+    BASELINE = 65
     count = _tpl_substring_count("focus:ring-1")
     assert count <= BASELINE, (
         f"focus:ring-1 usages rose to {count} (baseline {BASELINE}). Use the "
@@ -534,7 +534,7 @@ def test_inline_table_cell_padding_does_not_grow():
 
     Ratchet.
     """
-    BASELINE = 726
+    BASELINE = 647
     count = _tpl_regex_count(r'<t[dh][^>]*class="[^"]*\bp[xy]-[0-9]')
     assert count <= BASELINE, (
         f"inline-padded <td>/<th> rose to {count} (baseline {BASELINE}). Use "
@@ -547,7 +547,7 @@ def test_inline_button_sizing_does_not_grow():
 
     Macro files are the canonical source and are excluded. Ratchet.
     """
-    BASELINE = 341
+    BASELINE = 321
     count = _tpl_regex_count(r'<button[^>]*class="[^"]*\bp[xy]-[0-9]', exclude={"_macros.html"})
     assert count <= BASELINE, (
         f"inline-sized <button> rose to {count} (baseline {BASELINE}). Use .btn-sm/md/lg or the btn_* macros."


### PR DESCRIPTION
## What & why

PR 2 of 6 in the app-wide front-end UX consistency pass. Sweeps the **Sales + Requisitions** surface onto the canonical design-system layer shipped in PR 1 (#413). Class-only, zero behavior change — adopting the locked `.btn`/`.badge`/`.card`/`.input`/`.table-cell`/type-scale classes by *removing* inline drift, plus balanced density trims.

Triaged 56 templates → **41 with real drift swept** (13 no-ops skipped). Driven by a per-file agent sweep with a strict class-only checklist (the agents were deliberately conservative — they skipped any conversion that would shift a color, border, or density, e.g. `border-gray-200` surfaces and borderless badges were left alone).

## Scope
- `parts/` — list, header, workspace, and all detail tabs (offers, quotes, sourcing, notes, comms, activity, req_details)
- `requisitions/` — list, detail, all 7 detail tabs, RFQ compose/prepare/results, offer add/edit/parse forms, response card/status badge
- `requisitions2/` — standard panels (full sweep); **opp-table core = text-only** safe fixes (`opp-*` locked spec untouched)

## What changed (class-only)
13 `btn-primary btn-sm` · 26 `.table-cell--head` · 18 `.compact-cell` · 40 `.input` · 20 `.form-label` · 8 `.badge` · 7 `.card` · **149 `text-gray-500`→`600`** (contrast) · 11 empty-state `p-12`→`p-6 sm:p-8` · `text-[10px]`→`text-xs`.

**Drift ratchets dropped and re-locked** in `test_static_analysis.py`: text-[10px] 270→**229**, text-gray-500 998→**839**, focus:ring-1 81→**65**, td/th inline pad 726→**647**, button inline sizing 341→**321**.

## Verification
- Full pytest suite: **18,173 passed** (the 1 fail was the stale-base dist-image test, fixed by #415 — resolved by merging `main`)
- 41/41 changed templates compile; 20 static-analysis guards green at the new tighter baselines
- **Class-only discipline confirmed** on every `hx-vals`/`tojson`/SSE/opp-table file (no load-bearing attribute changed)
- Vite build green; Playwright **`dead-ends` + `requisitions2-visuals`: 32 passed** (every partial renders non-500; opp-table behavior unchanged)

Template-only — no migrations, no schema, no API changes. Builds on PR 1's canonical layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132w7Ci6y7CSUNfPJmY2XCM