### PR TITLE
feat(ui): Sourcing sweep onto canonical design-system layer (UX consistency PR 3/6)

### DIFF
--- a/app/templates/htmx/partials/materials/add_modal.html
+++ b/app/templates/htmx/partials/materials/add_modal.html
@@ -66,9 +66,9 @@
     <p class="mt-4 text-xs text-gray-400">Only the MPN is required — anything left blank is filled by enrichment, never guessed.</p>
     <div class="mt-6 flex justify-end gap-3 pt-4 border-t border-gray-100">
       <button type="button" @click="$dispatch('close-modal')"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">Cancel</button>
+              class="btn-secondary">Cancel</button>
       <button type="submit"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 shadow-sm transition-colors">Add part</button>
+              class="btn-primary">Add part</button>
     </div>
   </form>
 </div>

--- a/app/templates/htmx/partials/materials/crosses_section.html
+++ b/app/templates/htmx/partials/materials/crosses_section.html
@@ -16,7 +16,7 @@
       </div>
       <h2 class="text-sm font-semibold text-gray-900 tracking-tight">Crosses & Substitutes</h2>
       {% if card.cross_references %}
-      <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-[10px] font-bold text-brand-600 bg-brand-50 border border-brand-200 rounded-full tabular-nums">
+      <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-xs font-bold text-brand-600 bg-brand-50 border border-brand-200 rounded-full tabular-nums">
         {{ card.cross_references|length }}
       </span>
       {% endif %}
@@ -99,7 +99,7 @@
             hx-post="/v2/partials/materials/{{ card.id }}/find-crosses"
               hx-target="#crosses-section"
               hx-swap="outerHTML"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-white bg-brand-500 rounded-md hover:bg-brand-600 shadow-sm transition-all duration-150">
+              class="btn btn-primary btn-sm">
         <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
         </svg>

--- a/app/templates/htmx/partials/materials/detail.html
+++ b/app/templates/htmx/partials/materials/detail.html
@@ -12,7 +12,7 @@
   {# ── Hero Header ─────────────────────────────────────────── #}
   {# pr-8 keeps the top-right stats/Enrich cluster clear of the global modal
      close X (base.html chrome), which floats over the panel's top-right. #}
-  <div class="bg-white border border-brand-200 rounded-lg p-6 mb-6">
+  <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6">
     <div class="flex items-start justify-between pr-8">
       <div>
         <h1 class="text-3xl font-bold text-gray-900 font-mono">{{ card.display_mpn or card.normalized_mpn }}</h1>
@@ -51,11 +51,11 @@
           {% endif %}
         </div>
         {% if card.description %}
-        <p class="text-sm text-gray-500 mt-2">{{ card.description }}</p>
+        <p class="text-sm text-gray-600 mt-2">{{ card.description }}</p>
         {% endif %}
       </div>
       <div class="text-right space-y-1.5 ml-6 flex-shrink-0">
-        <p class="text-sm text-gray-500">Searches: <span class="font-bold text-brand-600">{{ card.search_count or 0 }}</span></p>
+        <p class="text-sm text-gray-600">Searches: <span class="font-bold text-brand-600">{{ card.search_count or 0 }}</span></p>
         {% if card.last_searched_at %}
         <p class="text-xs text-gray-400">Last: {{ card.last_searched_at.strftime('%b %d, %Y') }}</p>
         {% endif %}
@@ -116,7 +116,7 @@
               <span class="font-medium text-gray-900">{{ conflict.get('key', '')|replace('_', ' ') }}</span>:
               manual <span class="font-mono">{{ conflict.get('manual', {}).get('value') }}</span> kept —
               {{ ev.get('source') }} reported <span class="font-mono">{{ ev.get('value') }}</span>
-              <span class="text-gray-500">(conf {{ ev.get('confidence') }}{% if ev.get('observed_at') %}, {{ ev.get('observed_at')[:10] }}{% endif %})</span>
+              <span class="text-gray-600">(conf {{ ev.get('confidence') }}{% if ev.get('observed_at') %}, {{ ev.get('observed_at')[:10] }}{% endif %})</span>
             </span>
           </div>
           {# hx-vals quoting is intentional: SINGLE-quoted attribute + |tojson is the
@@ -164,22 +164,22 @@
             data-loading-disable
             class="grid grid-cols-2 md:grid-cols-4 gap-3">
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Manufacturer</label>
+          <label class="form-label">Manufacturer</label>
           <input type="text" name="manufacturer" value="{{ card.manufacturer or '' }}"
                  class="w-full px-3 py-2 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Category</label>
+          <label class="form-label">Category</label>
           <input type="text" name="category" value="{{ card.category or '' }}"
                  class="w-full px-3 py-2 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Package</label>
+          <label class="form-label">Package</label>
           <input type="text" name="package_type" value="{{ card.package_type or '' }}"
                  class="w-full px-3 py-2 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Lifecycle</label>
+          <label class="form-label">Lifecycle</label>
           <select name="lifecycle_status" class="w-full px-3 py-2 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
             <option value="">Unknown</option>
             {% for val in ['active', 'eol', 'obsolete', 'nrfnd', 'ltb'] %}
@@ -188,12 +188,12 @@
           </select>
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">Pin Count</label>
+          <label class="form-label">Pin Count</label>
           <input type="number" name="pin_count" value="{{ card.pin_count or '' }}"
                  class="w-full px-3 py-2 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 mb-1">RoHS</label>
+          <label class="form-label">RoHS</label>
           <select name="rohs_status" class="w-full px-3 py-2 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
             <option value="">Unknown</option>
             {% for val in ['compliant', 'non-compliant', 'exempt'] %}
@@ -202,7 +202,7 @@
           </select>
         </div>
         <div class="col-span-2">
-          <label class="block text-xs font-medium text-gray-500 mb-1">Description</label>
+          <label class="form-label">Description</label>
           <input type="text" name="description" value="{{ card.description or '' }}"
                  class="w-full px-3 py-2 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>

--- a/app/templates/htmx/partials/materials/enrich_status.html
+++ b/app/templates/htmx/partials/materials/enrich_status.html
@@ -30,7 +30,7 @@
 {% set badge = es_styles.get(es) %}
 <p class="inline-flex items-center gap-1.5 text-xs text-emerald-600">
   {% if badge %}
-  <span class="inline-flex px-2 py-0.5 text-[10px] font-medium rounded-full border {{ badge[0] }}">{{ badge[1] }}</span>
+  <span class="badge {{ badge[0] }}">{{ badge[1] }}</span>
   {% endif %}
   {% if card.enriched_at %}
   <svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20">

--- a/app/templates/htmx/partials/materials/filters/global.html
+++ b/app/templates/htmx/partials/materials/filters/global.html
@@ -15,7 +15,7 @@
   ('obsolete', 'Obsolete'), ('ltb', 'LTB')
 ] %}
 <div class="mb-3">
-  <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Lifecycle</h4>
+  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Lifecycle</h4>
   <div class="space-y-0.5">
     {% for value, label in lifecycle_opts %}
     {% if lc_counts.get(value, 0) > 0 %}
@@ -37,7 +37,7 @@
   ('compliant', 'Compliant'), ('non-compliant', 'Non-compliant'), ('exempt', 'Exempt')
 ] %}
 <div class="mb-3">
-  <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">RoHS</h4>
+  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">RoHS</h4>
   <div class="space-y-0.5">
     {% for value, label in rohs_opts %}
     {% if rohs_counts.get(value, 0) > 0 %}
@@ -62,7 +62,7 @@
 ] %}
 {% if condition_counts %}
 <div class="mb-3">
-  <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Condition</h4>
+  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Condition</h4>
   <div class="space-y-0.5">
     {% for value, label in condition_opts %}
     {% if condition_counts.get(value, 0) > 0 %}
@@ -83,7 +83,7 @@
 {# Has-datasheet boolean toggle — datasheet_url IS NOT NULL #}
 {% if ds_count > 0 %}
 <div class="mb-3">
-  <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Datasheet</h4>
+  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Datasheet</h4>
   <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
     <input aria-label="Only parts with a datasheet" type="checkbox"
            :checked="hasDatasheet"
@@ -99,7 +99,7 @@
    a manual value). Hidden until conflicts exist, matching the Datasheet toggle. #}
 {% if nr_count > 0 %}
 <div class="mb-3">
-  <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Review</h4>
+  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Review</h4>
   <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
     <input aria-label="Only parts needing conflict review" type="checkbox"
            :checked="needsReview"

--- a/app/templates/htmx/partials/materials/filters/manufacturers.html
+++ b/app/templates/htmx/partials/materials/filters/manufacturers.html
@@ -5,7 +5,7 @@
 #}
 {% if manufacturer_options %}
 <div class="mb-3" x-data="{mfgSearch: '', mfgExpanded: false}">
-  <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Brand</h4>
+  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Brand</h4>
   <input aria-label="Search manufacturers" type="text" x-model="mfgSearch"
          @focus="mfgExpanded = true"
          placeholder="Search manufacturers..."

--- a/app/templates/htmx/partials/materials/fru_section.html
+++ b/app/templates/htmx/partials/materials/fru_section.html
@@ -27,7 +27,7 @@
         </div>
         <h2 class="text-sm font-semibold text-gray-900 tracking-tight">FRU matrix</h2>
         <span class="font-mono text-sm font-semibold text-gray-800">{{ fru_view.fru_raw }}</span>
-        <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-[10px] font-bold text-brand-600 bg-brand-50 border border-brand-200 rounded-full tabular-nums">
+        <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-xs font-bold text-brand-600 bg-brand-50 border border-brand-200 rounded-full tabular-nums">
           {{ fru_view.total_links }}
         </span>
       </div>
@@ -50,8 +50,8 @@
       {% set section_idx = loop.index0 %}
       <div class="{{ 'mb-6' if not loop.last else '' }}">
         <div class="flex items-center gap-2 mb-1">
-          <h3 class="text-xs font-medium text-gray-500">{{ section.label }}</h3>
-          <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-[10px] font-bold text-brand-600 bg-brand-50 border border-brand-200 rounded-full tabular-nums">{{ section.items|length }}</span>
+          <h3 class="text-xs font-medium text-gray-600">{{ section.label }}</h3>
+          <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-xs font-bold text-brand-600 bg-brand-50 border border-brand-200 rounded-full tabular-nums">{{ section.items|length }}</span>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-1.5">
           {% for item in section.items %}
@@ -108,7 +108,7 @@
           </svg>
         </div>
         <h2 class="text-sm font-semibold text-gray-900 tracking-tight">Used in FRUs</h2>
-        <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-[10px] font-bold text-brand-600 bg-brand-50 border border-brand-200 rounded-full tabular-nums">
+        <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-xs font-bold text-brand-600 bg-brand-50 border border-brand-200 rounded-full tabular-nums">
           {{ fru_usages_total }}
         </span>
       </div>
@@ -143,7 +143,7 @@
               </span>
               {% else %}<span class="text-gray-400">-</span>{% endif %}
             </td>
-            <td class="py-2 px-3 text-gray-500">
+            <td class="py-2 px-3 text-gray-600">
               {{ [u.manufacturer, u.description, u.machine, u.series]|select|join(' · ') or '-' }}
             </td>
           </tr>

--- a/app/templates/htmx/partials/materials/insights.html
+++ b/app/templates/htmx/partials/materials/insights.html
@@ -37,7 +37,7 @@
         <p class="text-lg font-bold text-emerald-700 font-mono">${{ "%.4f"|format(prices|min) }}</p>
       </div>
       <div class="text-center bg-gray-50 rounded-lg p-3 border border-gray-200">
-        <p class="text-xs text-gray-500 font-medium mb-1">Average</p>
+        <p class="text-xs text-gray-600 font-medium mb-1">Average</p>
         <p class="text-lg font-bold text-gray-900 font-mono">${{ "%.4f"|format(prices|sum / prices|length) }}</p>
       </div>
       <div class="text-center bg-rose-50 rounded-lg p-3 border border-rose-100">

--- a/app/templates/htmx/partials/materials/list.html
+++ b/app/templates/htmx/partials/materials/list.html
@@ -25,7 +25,7 @@
    many parts matched the current search/filters (vs the bare "N parts"). #}
 <div class="flex items-baseline gap-2 mb-2 px-1">
   <span class="text-sm font-semibold text-gray-700 tabular-nums">{{ "{:,}".format(total) }}</span>
-  <span class="text-sm text-gray-500">result{{ '' if total == 1 else 's' }}{% if commodity_display %} in {{ commodity_display }}{% endif %}{% if q %} &middot; matching &ldquo;{{ q }}&rdquo;{% endif %}</span>
+  <span class="text-sm text-gray-600">result{{ '' if total == 1 else 's' }}{% if commodity_display %} in {{ commodity_display }}{% endif %}{% if q %} &middot; matching &ldquo;{{ q }}&rdquo;{% endif %}</span>
 </div>
 {# Screen-reader announcement of the new count on each swap. #}
 <div class="sr-only" role="status" aria-live="polite">{{ "{:,}".format(total) }} result{{ '' if total == 1 else 's' }}{% if commodity_display %} in {{ commodity_display }}{% endif %}{% if q %} matching {{ q }}{% endif %}</div>
@@ -89,7 +89,7 @@
               {% if m.cross_references %}
               {# Neutral gray — count metadata, not a status; indigo means exactly
                  "OEM-official" (the OEM-SOURCED badge below). #}
-              <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full border bg-gray-100 text-gray-600 border-gray-200"
+              <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded-full border bg-gray-100 text-gray-600 border-gray-200"
                     title="Known cross-references / substitutes">
                 {{ m.cross_references|length }} alternate{{ '' if m.cross_references|length == 1 else 's' }}
               </span>
@@ -100,7 +100,7 @@
               {% for spec in m._primary_specs[:3] %}
               {# title keeps the label visible on hover when the commodity-scoped
                  rendering shows the value only. leading-none trims pill height. #}
-              <span class="inline-block px-1.5 py-0.5 bg-gray-50 text-[10px] leading-none text-gray-500 rounded font-data"
+              <span class="inline-block px-1.5 py-0.5 bg-gray-50 text-xs leading-none text-gray-600 rounded font-data"
                     title="{{ spec.label }}: {{ spec.value }}">
                 {%- if not commodity and spec.label %}{{ spec.label }}: {% endif %}{{ spec.value }}
               </span>
@@ -108,7 +108,7 @@
             </div>
             {% endif %}
           </td>
-          <td class="td-label text-gray-500 truncate max-w-[200px]" title="{{ m.description or '' }}">{{ m.description or "--" }}</td>
+          <td class="td-label text-gray-600 truncate max-w-[200px]" title="{{ m.description or '' }}">{{ m.description or "--" }}</td>
           {# Dual-brand cell with category folded in as a muted sub-line (no standalone
              Category column). Dual-brand: "IBM · Seagate Technology" when brand (OEM
              label) and manufacturer (actual maker) are both set and DIFFERENT COMPANIES
@@ -129,47 +129,47 @@
             <div class="flex flex-wrap items-center gap-1">
               {% set es = m.enrichment_status %}
               {% if es == "verified" %}
-              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-emerald-50 text-emerald-700 border-emerald-200"
+              <span class="badge bg-emerald-50 text-emerald-700 border-emerald-200"
                     title="Verified from {{ (m.enrichment_provenance or {}).get('description', {}).get('source', 'catalog') }}">
                 VERIFIED
               </span>
               {% elif es == "web_sourced" %}
               {% set _u = (m.enrichment_provenance or {}).get('source_urls', [None])[0] %}
               <a href="{{ _u or '#' }}" target="_blank" rel="noopener"
-                 class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-sky-50 text-sky-700 border-sky-200"
+                 class="badge bg-sky-50 text-sky-700 border-sky-200"
                  title="Web-sourced from {{ (m.enrichment_provenance or {}).get('source_domains', ['authoritative page'])|join(', ') }} — below API-verified">
                 WEB-SOURCED
               </a>
               {% elif es == "oem_sourced" %}
               {% set _ou = (m.enrichment_provenance or {}).get('source_urls', [None])[0] %}
               <a href="{{ _ou or '#' }}" target="_blank" rel="noopener"
-                 class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-indigo-50 text-indigo-700 border-indigo-200"
+                 class="badge bg-indigo-50 text-indigo-700 border-indigo-200"
                  title="OEM-official source: {{ (m.enrichment_provenance or {}).get('source_domains', ['vendor page'])|join(', ') }} — description from the OEM; specs not distributor-verified">
                 OEM-SOURCED
               </a>
               {% elif es == "ai_inferred" %}
-              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-amber-50 text-amber-700 border-amber-200"
+              <span class="badge bg-amber-50 text-amber-700 border-amber-200"
                     title="AI guess (&ge;95% confidence) — RECONFIRM NEEDED before trusting; not verified">
                 AI GUESS · RECONFIRM
               </span>
               {% elif es == "not_found" %}
-              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-gray-100 text-gray-500 border-gray-200"
+              <span class="badge bg-gray-100 text-gray-500 border-gray-200"
                     title="No authoritative source found this part">
                 NOT FOUND
               </span>
               {% elif es == "not_catalogued" %}
-              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border bg-slate-100 text-slate-600 border-slate-300"
+              <span class="badge bg-slate-100 text-slate-600 border-slate-300"
                     title="Recognised OEM service/FRU part; no public specs published">
                 NOT CATALOGUED
               </span>
               {% endif %}
               {% if m.lifecycle_status %}
-              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border {{ lc_colors.get(m.lifecycle_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
+              <span class="badge {{ lc_colors.get(m.lifecycle_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
                 {{ m.lifecycle_status|upper }}
               </span>
               {% endif %}
               {% if m.condition %}
-              <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border {{ cond_colors.get(m.condition, 'bg-gray-100 text-gray-600 border-gray-200') }}"
+              <span class="badge {{ cond_colors.get(m.condition, 'bg-gray-100 text-gray-600 border-gray-200') }}"
                     title="Stock condition">
                 {{ m.condition|upper }}
               </span>
@@ -189,27 +189,27 @@
             <span class="text-gray-400 text-xs">--</span>
             {% endif %}
           </td>
-          <td class="td-label text-gray-500">{{ m.last_searched_at.strftime('%b %d') if m.last_searched_at else "--" }}</td>
+          <td class="td-label text-gray-600">{{ m.last_searched_at.strftime('%b %d') if m.last_searched_at else "--" }}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
   </div>
   {% else %}
-  <div class="text-center py-12 text-gray-400">
+  <div class="text-center py-6 sm:py-8 text-gray-400">
     <svg class="mx-auto h-10 w-10 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/>
     </svg>
     {% if parametric_active and spec_coverage and spec_coverage.with_specs < spec_coverage.total %}
     {# Coverage-aware nudge: parametric facets only exist on spec-enriched cards, so a
        zero here mostly means "not yet spec-enriched", not "no such parts". #}
-    <p class="text-sm font-medium text-gray-500">No matches — but most parts here haven't been spec-enriched yet. Try clearing parametric filters.</p>
+    <p class="text-sm font-medium text-gray-600">No matches — but most parts here haven't been spec-enriched yet. Try clearing parametric filters.</p>
     <p class="text-xs text-gray-400 mt-1">
       Only {{ "{:,}".format(spec_coverage.with_specs) }} of {{ "{:,}".format(spec_coverage.total) }}
       {% if commodity_display %}{{ commodity_display }} {% endif %}parts have filterable specs so far
     </p>
     {% else %}
-    <p class="text-sm font-medium text-gray-500">No results match your filters</p>
+    <p class="text-sm font-medium text-gray-600">No results match your filters</p>
     <p class="text-xs text-gray-400 mt-1">Try removing a filter or broadening your search</p>
     {% endif %}
   </div>
@@ -224,7 +224,7 @@
     <button @click="goToPage({{ (offset - limit) // limit }})"
        class="px-3 py-1.5 text-sm bg-white border border-brand-200 rounded-lg hover:bg-brand-50 cursor-pointer transition-colors">Prev</button>
     {% endif %}
-    <span class="px-3 py-1.5 text-sm text-gray-500">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
+    <span class="px-3 py-1.5 text-sm text-gray-600">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
     {% if offset + limit < total %}
     <button @click="goToPage({{ (offset + limit) // limit }})"
        class="px-3 py-1.5 text-sm bg-white border border-brand-200 rounded-lg hover:bg-brand-50 cursor-pointer transition-colors">Next</button>

--- a/app/templates/htmx/partials/materials/tabs/customers.html
+++ b/app/templates/htmx/partials/materials/tabs/customers.html
@@ -5,22 +5,22 @@
 #}
 <table class="w-full text-xs font-mono">
   <thead><tr class="text-left text-gray-500 border-b border-gray-200">
-    <th class="py-2 px-3 font-medium">Company</th>
-    <th class="py-2 px-3 text-right font-medium">Purchases</th>
-    <th class="py-2 px-3 text-right font-medium">Total Qty</th>
-    <th class="py-2 px-3 text-right font-medium">Avg Price</th>
-    <th class="py-2 px-3 font-medium">Last Purchased</th>
-    <th class="py-2 px-3 font-medium">Source</th>
+    <th class="compact-cell--head font-medium">Company</th>
+    <th class="compact-cell--head text-right font-medium">Purchases</th>
+    <th class="compact-cell--head text-right font-medium">Total Qty</th>
+    <th class="compact-cell--head text-right font-medium">Avg Price</th>
+    <th class="compact-cell--head font-medium">Last Purchased</th>
+    <th class="compact-cell--head font-medium">Source</th>
   </tr></thead>
   <tbody>
     {% for c in customers %}
     <tr class="border-b border-gray-100 hover:bg-brand-50/50 transition-colors">
-      <td class="py-2 px-3 font-semibold text-gray-900">{{ c.company.name if c.company else '--' }}</td>
-      <td class="py-2 px-3 text-right">{{ c.purchase_count or 0 }}</td>
-      <td class="py-2 px-3 text-right">{{ "{:,}".format(c.total_quantity) if c.total_quantity else '-' }}</td>
-      <td class="py-2 px-3 text-right">{% if c.avg_unit_price %}<span class="text-emerald-700 font-medium">${{ "%.4f"|format(c.avg_unit_price) }}</span>{% else %}<span class="text-gray-400">-</span>{% endif %}</td>
-      <td class="py-2 px-3">{{ c.last_purchased_at.strftime('%Y-%m-%d') if c.last_purchased_at else '-' }}</td>
-      <td class="py-2 px-3">{{ c.source or '-' }}</td>
+      <td class="compact-cell font-semibold text-gray-900">{{ c.company.name if c.company else '--' }}</td>
+      <td class="compact-cell text-right">{{ c.purchase_count or 0 }}</td>
+      <td class="compact-cell text-right">{{ "{:,}".format(c.total_quantity) if c.total_quantity else '-' }}</td>
+      <td class="compact-cell text-right">{% if c.avg_unit_price %}<span class="text-emerald-700 font-medium">${{ "%.4f"|format(c.avg_unit_price) }}</span>{% else %}<span class="text-gray-400">-</span>{% endif %}</td>
+      <td class="compact-cell">{{ c.last_purchased_at.strftime('%Y-%m-%d') if c.last_purchased_at else '-' }}</td>
+      <td class="compact-cell">{{ c.source or '-' }}</td>
     </tr>
     {% else %}
     <tr><td colspan="6" class="py-8 text-center text-gray-400 text-sm">No customer purchase history</td></tr>

--- a/app/templates/htmx/partials/materials/tabs/sourcing.html
+++ b/app/templates/htmx/partials/materials/tabs/sourcing.html
@@ -29,7 +29,7 @@
       <td class="py-2 px-3 font-semibold text-brand-600">#{{ r.requisition_id }}</td>
       <td class="py-2 px-3">{{ r.primary_mpn or '-' }}</td>
       <td class="py-2 px-3">
-        <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full border {{ st_colors.get(r.sourcing_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
+        <span class="badge {{ st_colors.get(r.sourcing_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
           {{ (r.sourcing_status or 'open')|capitalize }}
         </span>
       </td>

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -51,14 +51,14 @@
           </div>
         </template>
         <template x-if="activeFilterCount === 0">
-          <span class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest">Filters</span>
+          <span class="text-xs font-semibold text-gray-400 uppercase tracking-widest">Filters</span>
         </template>
       </div>
 
       {# ── Recents (re-entry accelerator) ─────────────────────────────#}
       <template x-if="recentCommodities.length > 0">
         <div class="mb-3">
-          <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Recent</h4>
+          <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Recent</h4>
           <div class="flex flex-wrap gap-1">
             <template x-for="rc in recentCommodities" :key="rc">
               <button @click="selectCommodity(rc)"
@@ -71,7 +71,7 @@
       </template>
 
       {# ── Category (the entry point) ─────────────────────────────────#}
-      <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Category</h4>
+      <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Category</h4>
       <input type="text" x-model="categorySearch" placeholder="Jump to category…"
              aria-label="Filter categories"
              class="w-full mb-1 px-2 py-1 text-[13px] border border-gray-200 rounded focus:ring-1 focus:ring-brand-500 focus:border-brand-500">
@@ -173,7 +173,7 @@
             </label>
           </div>
           <div class="mb-3">
-            <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Part type</h4>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Part type</h4>
             <div class="flex flex-wrap gap-1">
               {# Vocabulary lives on the component (INTERNAL_MODES) — single front-end source of truth. #}
               <template x-for="opt in INTERNAL_MODES" :key="'int-' + opt[0]">
@@ -186,7 +186,7 @@
             </div>
           </div>
           <div class="mb-3">
-            <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Searched within</h4>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Searched within</h4>
             <div class="flex flex-wrap gap-1">
               {# Vocabulary lives on the component (SEARCH_BUCKETS) — single front-end source of truth. #}
               <template x-for="opt in SEARCH_BUCKETS" :key="'sw-' + opt[0]">
@@ -199,7 +199,7 @@
             </div>
           </div>
           <div class="mb-3">
-            <h4 class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Min searches</h4>
+            <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Min searches</h4>
             <input type="number" min="0" step="1" placeholder="0"
                    :value="minSearches || ''"
                    @input.debounce.600ms="setMinSearches($event.target.value)"
@@ -283,7 +283,7 @@
           </svg>
           Filters
           <template x-if="activeFilterCount > 0" x-cloak>
-            <span class="bg-brand-500 text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 leading-none" x-text="activeFilterCount"></span>
+            <span class="bg-brand-500 text-white text-xs font-bold rounded-full px-1.5 py-0.5 leading-none" x-text="activeFilterCount"></span>
           </template>
         </button>
 

--- a/app/templates/htmx/partials/search/dossier_hero.html
+++ b/app/templates/htmx/partials/search/dossier_hero.html
@@ -65,7 +65,7 @@
         </div>
 
         {% if known and card.description %}
-        <p class="mt-3 text-xs text-gray-500 max-w-xl leading-relaxed">{{ card.description }}</p>
+        <p class="mt-3 text-xs text-gray-600 max-w-xl leading-relaxed">{{ card.description }}</p>
         {% elif not known %}
         <p class="mt-3 text-xs text-gray-400 max-w-xl leading-relaxed">We don't have history on this part — the live market below will tell us who has it.</p>
         {% endif %}
@@ -73,13 +73,13 @@
 
       {# Zone B — market price strip + sparkline #}
       <div class="lg:w-[200px] lg:border-l lg:border-brand-100 lg:pl-5 shrink-0">
-        <p class="text-[10px] uppercase tracking-wide text-gray-400 font-semibold">Market price</p>
+        <p class="text-xs uppercase tracking-wide text-gray-400 font-semibold">Market price</p>
         {% if pt %}
         <div class="mt-1 flex items-baseline gap-1.5">
           <span class="font-mono text-2xl font-bold text-brand-900">${{ (pt.last_price if pt.last_price is not none else pt.min_price)|pricefmt }}</span>
           <span class="text-xs text-gray-400">last</span>
         </div>
-        <p class="font-mono text-xs text-gray-500 mt-0.5">${{ pt.min_price|pricefmt }} – ${{ pt.max_price|pricefmt }}</p>
+        <p class="font-mono text-xs text-gray-600 mt-0.5">${{ pt.min_price|pricefmt }} – ${{ pt.max_price|pricefmt }}</p>
         {# Sparkline from min/last/max — a 3-point glanceable trend (no axes). #}
         {% set lo = pt.min_price|float %}
         {% set hi = pt.max_price|float %}
@@ -92,18 +92,18 @@
           <polyline fill="none" stroke="#838B9B" stroke-width="1.5" points="0,{{ '%.1f'|format(y_lo) }} 60,{{ '%.1f'|format(y_hi) }} 120,{{ '%.1f'|format(y_last) }}"/>
           <circle cx="120" cy="{{ '%.1f'|format(y_last) }}" r="2" fill="#4B5463"/>
         </svg>
-        <p class="text-[10px] text-gray-400 mt-1">{{ pt.currency }} · min–max–last</p>
+        <p class="text-xs text-gray-400 mt-1">{{ pt.currency }} · min–max–last</p>
         {% else %}
         <div class="mt-1 rounded-lg border border-dashed border-brand-200 px-3 py-4 text-center">
           <p class="font-mono text-sm text-gray-300">$ — — —</p>
-          <p class="text-[10px] text-gray-400 mt-1">No price history yet — run the market</p>
+          <p class="text-xs text-gray-400 mt-1">No price history yet — run the market</p>
         </div>
         {% endif %}
       </div>
 
       {# Zone C — knowledge counts #}
       <div class="lg:w-[150px] lg:border-l lg:border-brand-100 lg:pl-5 shrink-0">
-        <p class="text-[10px] uppercase tracking-wide text-gray-400 font-semibold mb-2">What we know</p>
+        <p class="text-xs uppercase tracking-wide text-gray-400 font-semibold mb-2">What we know</p>
         <div class="grid grid-cols-2 gap-x-3 gap-y-2 count-tile">
           <div><div class="font-mono text-lg font-bold leading-none {{ 'text-brand-900' if history.offers_count else 'text-gray-300' }}">{{ history.offers_count }}</div><dt>Offers</dt></div>
           <div><div class="font-mono text-lg font-bold leading-none {{ 'text-emerald-600' if history.confirmed_count else 'text-gray-300' }}">{{ history.confirmed_count }}</div><dt>Won</dt></div>
@@ -115,7 +115,7 @@
           {% for b in history.buyers[:3] %}
           <span class="h-5 w-5 rounded-full bg-blue-100 text-blue-700 grid place-items-center text-[9px] font-semibold ring-2 ring-white" title="{{ b.name or b.email }}">{{ (b.name or b.email)[:2]|upper }}</span>
           {% endfor %}
-          <span class="text-[10px] text-gray-400 pl-2.5">{{ history.buyers|length }} buyer{{ '' if history.buyers|length == 1 else 's' }}</span>
+          <span class="text-xs text-gray-400 pl-2.5">{{ history.buyers|length }} buyer{{ '' if history.buyers|length == 1 else 's' }}</span>
         </div>
         {% endif %}
       </div>

--- a/app/templates/htmx/partials/search/dossier_market.html
+++ b/app/templates/htmx/partials/search/dossier_market.html
@@ -19,7 +19,7 @@
 {# ── CACHE HIT — cached rows in the light market card ── #}
 
 <div class="px-4 py-2.5 border-b border-brand-100 flex items-center gap-3 text-[11px]">
-  <span class="inline-flex items-center gap-1.5 text-gray-500">
+  <span class="inline-flex items-center gap-1.5 text-gray-600">
     <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>cached
   </span>
   <span class="text-gray-400">{{ cached_rows|length }} offer{{ '' if cached_rows|length == 1 else 's' }}</span>

--- a/app/templates/htmx/partials/search/dossier_recent.html
+++ b/app/templates/htmx/partials/search/dossier_recent.html
@@ -19,7 +19,7 @@
       </div>
       <div class="shrink-0 text-right">
         <p class="text-[11px] text-gray-400">{{ c.last_searched_at|timeago }}</p>
-        {% if c.search_count %}<p class="text-[10px] text-gray-300 font-mono">{{ c.search_count }}×</p>{% endif %}
+        {% if c.search_count %}<p class="text-xs text-gray-300 font-mono">{{ c.search_count }}×</p>{% endif %}
       </div>
     </a>
     {% endfor %}

--- a/app/templates/htmx/partials/search/dossier_specs.html
+++ b/app/templates/htmx/partials/search/dossier_specs.html
@@ -11,7 +11,7 @@
 
 {% if card is none %}
 <div class="rounded-lg bg-brand-50 border border-brand-100 px-4 py-6 text-center">
-  <p class="text-sm font-medium text-gray-500">New to us — no enrichment yet</p>
+  <p class="text-sm font-medium text-gray-600">New to us — no enrichment yet</p>
   <p class="text-xs text-gray-400 mt-1">The first sourcing action queues this part for enrichment.</p>
 </div>
 {% else %}
@@ -24,7 +24,7 @@
   {% set val = field.value if field is mapping else field %}
   {% if val is not none and val != '' %}
   <div>
-    <dt class="text-[10px] uppercase tracking-wide text-gray-400">{{ key|replace('_', ' ') }}</dt>
+    <dt class="text-xs uppercase tracking-wide text-gray-400">{{ key|replace('_', ' ') }}</dt>
     <dd class="text-gray-900">
       <span class="font-mono">{{ val }}</span>
       {% if field is mapping and field.source %}
@@ -40,30 +40,30 @@
   {% endfor %}
 
   {% if card.package_type %}
-  <div><dt class="text-[10px] uppercase tracking-wide text-gray-400">Package</dt><dd class="font-mono text-gray-900">{{ card.package_type }}</dd></div>
+  <div><dt class="text-xs uppercase tracking-wide text-gray-400">Package</dt><dd class="font-mono text-gray-900">{{ card.package_type }}</dd></div>
   {% endif %}
   {% if card.pin_count %}
-  <div><dt class="text-[10px] uppercase tracking-wide text-gray-400">Pins</dt><dd class="font-mono text-gray-900">{{ card.pin_count }}</dd></div>
+  <div><dt class="text-xs uppercase tracking-wide text-gray-400">Pins</dt><dd class="font-mono text-gray-900">{{ card.pin_count }}</dd></div>
   {% endif %}
   {% if card.rohs_status %}
-  <div><dt class="text-[10px] uppercase tracking-wide text-gray-400">RoHS</dt><dd class="text-gray-900">{{ card.rohs_status|title }}</dd></div>
+  <div><dt class="text-xs uppercase tracking-wide text-gray-400">RoHS</dt><dd class="text-gray-900">{{ card.rohs_status|title }}</dd></div>
   {% endif %}
   {% if card.lifecycle_status %}
-  <div><dt class="text-[10px] uppercase tracking-wide text-gray-400">Lifecycle</dt><dd class="text-gray-900">{{ card.lifecycle_status|title }}</dd></div>
+  <div><dt class="text-xs uppercase tracking-wide text-gray-400">Lifecycle</dt><dd class="text-gray-900">{{ card.lifecycle_status|title }}</dd></div>
   {% endif %}
   {% if card.condition %}
-  <div><dt class="text-[10px] uppercase tracking-wide text-gray-400">Condition</dt><dd class="text-gray-900">{{ card.condition }}</dd></div>
+  <div><dt class="text-xs uppercase tracking-wide text-gray-400">Condition</dt><dd class="text-gray-900">{{ card.condition }}</dd></div>
   {% endif %}
 </dl>
 
 {% if card.specs_summary %}
-<p class="mt-3 text-xs text-gray-500 leading-relaxed">{{ card.specs_summary }}</p>
+<p class="mt-3 text-xs text-gray-600 leading-relaxed">{{ card.specs_summary }}</p>
 {% endif %}
 
 {# Cross references. #}
 {% if card.cross_references %}
 <div class="mt-4">
-  <p class="text-[10px] uppercase tracking-wide text-gray-400 mb-1.5">Cross references</p>
+  <p class="text-xs uppercase tracking-wide text-gray-400 mb-1.5">Cross references</p>
   <div class="flex flex-wrap gap-1.5">
     {% for x in card.cross_references %}
     <span class="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-mono text-gray-600">
@@ -77,10 +77,10 @@
 {% else %}
 <div class="rounded-lg bg-brand-50 border border-brand-100 px-4 py-6 text-center">
   {% if unenriched %}
-  <p class="text-sm font-medium text-gray-500">Unenriched — enriching…</p>
+  <p class="text-sm font-medium text-gray-600">Unenriched — enriching…</p>
   <p class="text-xs text-gray-400 mt-1">We know this part, but its specs haven't been filled in yet.</p>
   {% else %}
-  <p class="text-sm font-medium text-gray-500">No specs on record.</p>
+  <p class="text-sm font-medium text-gray-600">No specs on record.</p>
   {% endif %}
 </div>
 {% endif %}

--- a/app/templates/htmx/partials/search/form.html
+++ b/app/templates/htmx/partials/search/form.html
@@ -18,9 +18,7 @@
                       placeholder:text-gray-400 tracking-tight"
                required>
         <button type="submit" :disabled="!q.trim()"
-                class="px-4 py-2 bg-brand-500 text-white font-semibold rounded-lg
-                       hover:bg-brand-600 disabled:opacity-50 disabled:cursor-not-allowed
-                       transition-colors flex items-center gap-2 whitespace-nowrap text-sm">
+                class="btn-primary whitespace-nowrap">
           <span id="ds-landing-spin" class="htmx-indicator">
             <svg class="inline h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
           </span>

--- a/app/templates/htmx/partials/search/full_results.html
+++ b/app/templates/htmx/partials/search/full_results.html
@@ -13,7 +13,7 @@
 
   {# ── Page header ── #}
   <div class="mb-6">
-    <p class="mt-1 text-sm text-gray-500">
+    <p class="mt-1 text-sm text-gray-600">
       {% if results.total_count > 0 %}
         {{ results.total_count }} result{{ "s" if results.total_count != 1 }} for "<span class="font-medium text-gray-700">{{ query }}</span>"
         {% if ai_search %}
@@ -49,7 +49,7 @@
 
   {% if results.total_count == 0 %}
   {# ── Empty state ── #}
-  <div class="bg-white border border-brand-200 rounded-xl shadow-sm p-12 text-center">
+  <div class="bg-white border border-brand-200 rounded-xl shadow-sm p-6 sm:p-8 text-center">
     <svg class="mx-auto w-16 h-16 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round"
             d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"/>
@@ -123,11 +123,11 @@
           <p class="text-base font-semibold text-gray-900">{{ bm.name|default(bm.display_name|default(bm.full_name|default(bm.primary_mpn|default(bm.mpn|default("—"))))) }}</p>
           <div class="flex items-center gap-2 mt-0.5">
             <span class="inline-block rounded bg-brand-200 px-2 py-0.5 text-xs font-medium text-brand-700">{{ bm.type|replace("_", " ")|title }}</span>
-            {% if bm.email %}<span class="text-xs text-gray-500">{{ bm.email }}</span>{% endif %}
-            {% if bm.customer_name %}<span class="text-xs text-gray-500">{{ bm.customer_name }}</span>{% endif %}
-            {% if bm.domain %}<span class="text-xs text-gray-500">{{ bm.domain }}</span>{% endif %}
-            {% if bm.brand %}<span class="text-xs text-gray-500">{{ bm.brand }}</span>{% endif %}
-            {% if bm.vendor_name %}<span class="text-xs text-gray-500">{{ bm.vendor_name }}</span>{% endif %}
+            {% if bm.email %}<span class="text-xs text-gray-600">{{ bm.email }}</span>{% endif %}
+            {% if bm.customer_name %}<span class="text-xs text-gray-600">{{ bm.customer_name }}</span>{% endif %}
+            {% if bm.domain %}<span class="text-xs text-gray-600">{{ bm.domain }}</span>{% endif %}
+            {% if bm.brand %}<span class="text-xs text-gray-600">{{ bm.brand }}</span>{% endif %}
+            {% if bm.vendor_name %}<span class="text-xs text-gray-600">{{ bm.vendor_name }}</span>{% endif %}
           </div>
         </div>
       </div>
@@ -166,7 +166,7 @@
                    hx-push-url="/v2/requisitions/{{ item.id }}"
                    class="font-medium text-gray-900 hover:text-brand-600">{{ item.name }}</a>
               </td>
-              <td class="px-4 py-2.5 text-gray-500">{{ item.customer_name|default("—") }}</td>
+              <td class="px-4 py-2.5 text-gray-600">{{ item.customer_name|default("—") }}</td>
               <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.status|default("") }}</td>
 
               {% elif group_key == "companies" %}
@@ -177,7 +177,7 @@
                    hx-push-url="/v2/customers/{{ item.id }}"
                    class="font-medium text-gray-900 hover:text-brand-600">{{ item.name }}</a>
               </td>
-              <td class="px-4 py-2.5 text-gray-500">{{ item.domain|default("—") }}</td>
+              <td class="px-4 py-2.5 text-gray-600">{{ item.domain|default("—") }}</td>
               <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.account_type|default("") }}</td>
 
               {% elif group_key == "vendors" %}
@@ -188,7 +188,7 @@
                    hx-push-url="/v2/vendors/{{ item.id }}"
                    class="font-medium text-gray-900 hover:text-brand-600">{{ item.display_name }}</a>
               </td>
-              <td class="px-4 py-2.5 text-gray-500">{{ item.domain|default("—") }}</td>
+              <td class="px-4 py-2.5 text-gray-600">{{ item.domain|default("—") }}</td>
 
               {% elif group_key == "vendor_contacts" %}
               <td class="px-4 py-2.5">
@@ -198,12 +198,12 @@
                    hx-push-url="/v2/vendors/{{ item.vendor_card_id|default(item.id) }}"
                    class="font-medium text-gray-900 hover:text-brand-600">{{ item.full_name }}</a>
               </td>
-              <td class="px-4 py-2.5 text-gray-500">{{ item.email|default("—") }}</td>
+              <td class="px-4 py-2.5 text-gray-600">{{ item.email|default("—") }}</td>
               <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.title|default("") }}</td>
 
               {% elif group_key == "site_contacts" %}
               <td class="px-4 py-2.5 font-medium text-gray-900">{{ item.full_name }}</td>
-              <td class="px-4 py-2.5 text-gray-500">{{ item.email|default("—") }}</td>
+              <td class="px-4 py-2.5 text-gray-600">{{ item.email|default("—") }}</td>
 
               {% elif group_key == "parts" %}
               <td class="px-4 py-2.5">
@@ -213,7 +213,7 @@
                    hx-push-url="/v2/requisitions/{{ item.requisition_id|default('') }}"
                    class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.primary_mpn }}</a>
               </td>
-              <td class="px-4 py-2.5 text-gray-500">{{ item.brand|default("—") }}</td>
+              <td class="px-4 py-2.5 text-gray-600">{{ item.brand|default("—") }}</td>
 
               {% elif group_key == "offers" %}
               <td class="px-4 py-2.5">
@@ -223,7 +223,7 @@
                    hx-push-url="/v2/requisitions/{{ item.requisition_id|default('') }}"
                    class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.mpn }}</a>
               </td>
-              <td class="px-4 py-2.5 text-gray-500">{{ item.vendor_name|default("—") }}</td>
+              <td class="px-4 py-2.5 text-gray-600">{{ item.vendor_name|default("—") }}</td>
               <td class="px-4 py-2.5 text-emerald-600 font-medium">
                 {% if item.unit_price %}${{ "%.2f"|format(item.unit_price) }}{% else %}—{% endif %}
               </td>
@@ -249,30 +249,30 @@
         <thead class="bg-gray-50 border-b border-gray-200">
           <tr>
             {% if group_key == "requisitions" %}
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Customer</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Status</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Customer</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Status</th>
             {% elif group_key == "companies" %}
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Domain</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Type</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Domain</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Type</th>
             {% elif group_key == "vendors" %}
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Domain</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Domain</th>
             {% elif group_key == "vendor_contacts" %}
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Email</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Title</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Email</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Title</th>
             {% elif group_key == "site_contacts" %}
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Email</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Name</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Email</th>
             {% elif group_key == "parts" %}
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">MPN</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Brand</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">MPN</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Brand</th>
             {% elif group_key == "offers" %}
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">MPN</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Vendor</th>
-            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Price</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">MPN</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Vendor</th>
+            <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Price</th>
             {% endif %}
           </tr>
         </thead>
@@ -288,7 +288,7 @@
                  hx-push-url="/v2/requisitions/{{ item.id }}"
                  class="font-medium text-gray-900 hover:text-brand-600">{{ item.name }}</a>
             </td>
-            <td class="px-4 py-2.5 text-gray-500">{{ item.customer_name|default("—") }}</td>
+            <td class="px-4 py-2.5 text-gray-600">{{ item.customer_name|default("—") }}</td>
             <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.status|default("") }}</td>
 
             {% elif group_key == "companies" %}
@@ -299,7 +299,7 @@
                  hx-push-url="/v2/customers/{{ item.id }}"
                  class="font-medium text-gray-900 hover:text-brand-600">{{ item.name }}</a>
             </td>
-            <td class="px-4 py-2.5 text-gray-500">{{ item.domain|default("—") }}</td>
+            <td class="px-4 py-2.5 text-gray-600">{{ item.domain|default("—") }}</td>
             <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.account_type|default("") }}</td>
 
             {% elif group_key == "vendors" %}
@@ -310,7 +310,7 @@
                  hx-push-url="/v2/vendors/{{ item.id }}"
                  class="font-medium text-gray-900 hover:text-brand-600">{{ item.display_name }}</a>
             </td>
-            <td class="px-4 py-2.5 text-gray-500">{{ item.domain|default("—") }}</td>
+            <td class="px-4 py-2.5 text-gray-600">{{ item.domain|default("—") }}</td>
 
             {% elif group_key == "vendor_contacts" %}
             <td class="px-4 py-2.5">
@@ -320,12 +320,12 @@
                  hx-push-url="/v2/vendors/{{ item.vendor_card_id|default(item.id) }}"
                  class="font-medium text-gray-900 hover:text-brand-600">{{ item.full_name }}</a>
             </td>
-            <td class="px-4 py-2.5 text-gray-500">{{ item.email|default("—") }}</td>
+            <td class="px-4 py-2.5 text-gray-600">{{ item.email|default("—") }}</td>
             <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.title|default("") }}</td>
 
             {% elif group_key == "site_contacts" %}
             <td class="px-4 py-2.5 font-medium text-gray-900">{{ item.full_name }}</td>
-            <td class="px-4 py-2.5 text-gray-500">{{ item.email|default("—") }}</td>
+            <td class="px-4 py-2.5 text-gray-600">{{ item.email|default("—") }}</td>
 
             {% elif group_key == "parts" %}
             <td class="px-4 py-2.5">
@@ -335,7 +335,7 @@
                  hx-push-url="/v2/requisitions/{{ item.requisition_id|default('') }}"
                  class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.primary_mpn }}</a>
             </td>
-            <td class="px-4 py-2.5 text-gray-500">{{ item.brand|default("—") }}</td>
+            <td class="px-4 py-2.5 text-gray-600">{{ item.brand|default("—") }}</td>
 
             {% elif group_key == "offers" %}
             <td class="px-4 py-2.5">
@@ -345,7 +345,7 @@
                  hx-push-url="/v2/requisitions/{{ item.requisition_id|default('') }}"
                  class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.mpn }}</a>
             </td>
-            <td class="px-4 py-2.5 text-gray-500">{{ item.vendor_name|default("—") }}</td>
+            <td class="px-4 py-2.5 text-gray-600">{{ item.vendor_name|default("—") }}</td>
             <td class="px-4 py-2.5 text-emerald-600 font-medium">
               {% if item.unit_price %}${{ "%.2f"|format(item.unit_price) }}{% else %}—{% endif %}
             </td>

--- a/app/templates/htmx/partials/search/history_panel.html
+++ b/app/templates/htmx/partials/search/history_panel.html
@@ -13,10 +13,10 @@
 <div class="p-6 text-center">
   {% if fru_hit %}
   {# A crosswalk-known part isn't "new to us" — only its trading history is empty. #}
-  <p class="text-sm font-medium text-gray-500">No trading history yet</p>
+  <p class="text-sm font-medium text-gray-600">No trading history yet</p>
   <p class="text-xs text-gray-400 mt-1">We know this part from the FRU crosswalk below.</p>
   {% else %}
-  <p class="text-sm font-medium text-gray-500">No prior history</p>
+  <p class="text-sm font-medium text-gray-600">No prior history</p>
   <p class="text-xs text-gray-400 mt-1">This part looks new to us.</p>
   {% endif %}
 </div>
@@ -27,10 +27,10 @@
     <div class="flex items-center justify-between gap-2">
       <div class="min-w-0">
         <p class="text-sm font-semibold text-gray-900 truncate">{{ history.display_mpn }}</p>
-        <p class="text-xs text-gray-500 truncate">
+        <p class="text-xs text-gray-600 truncate">
           {{ history.manufacturer or "—" }}
           {% if history.lifecycle_status %}
-          <span class="ml-1 inline-block rounded px-1.5 py-0.5 text-[10px] font-medium bg-gray-100 text-gray-600">
+          <span class="ml-1 inline-block rounded px-1.5 py-0.5 text-xs font-medium bg-gray-100 text-gray-600">
             {{ history.lifecycle_status }}</span>
           {% endif %}
         </p>
@@ -72,7 +72,7 @@
     {% for o in history.offers %}
     <div class="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
       <span class="truncate">{{ o.vendor_name }}</span>
-      <span class="shrink-0 text-gray-500">{{ o.qty_available or "—" }} · ${{ o.unit_price or "—" }} · {{ o.status }}</span>
+      <span class="shrink-0 text-gray-600">{{ o.qty_available or "—" }} · ${{ o.unit_price or "—" }} · {{ o.status }}</span>
     </div>
     {% else %}<p class="py-1 text-gray-400">None.</p>{% endfor %}
     {% if history.offers_count > history.offers|length %}
@@ -89,7 +89,7 @@
     {% for c in history.customer_purchases %}
     <div class="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
       <span class="truncate">{{ c.company.name if c.company else "Customer" }}</span>
-      <span class="shrink-0 text-gray-500">×{{ c.purchase_count }} · ${{ c.avg_unit_price or "—" }}</span>
+      <span class="shrink-0 text-gray-600">×{{ c.purchase_count }} · ${{ c.avg_unit_price or "—" }}</span>
     </div>
     {% endfor %}
     {% if not history.won_offers and not history.customer_purchases %}<p class="py-1 text-gray-400">None.</p>{% endif %}
@@ -99,7 +99,7 @@
     {% for s in history.sightings %}
     <div class="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
       <span class="truncate">{{ s.vendor_name }}</span>
-      <span class="shrink-0 text-gray-500">{{ s.qty_available or "—" }} · ${{ s.unit_price or "—" }} · {{ s.source_type or "—" }}</span>
+      <span class="shrink-0 text-gray-600">{{ s.qty_available or "—" }} · ${{ s.unit_price or "—" }} · {{ s.source_type or "—" }}</span>
     </div>
     {% else %}<p class="py-1 text-gray-400">None.</p>{% endfor %}
   {% endcall %}
@@ -108,7 +108,7 @@
     {% for r in history.requirements %}
     <div class="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
       <span class="truncate">Req #{{ r.requisition_id }}</span>
-      <span class="shrink-0 text-gray-500">{{ r.sourcing_status }}</span>
+      <span class="shrink-0 text-gray-600">{{ r.sourcing_status }}</span>
     </div>
     {% else %}<p class="py-1 text-gray-400">None.</p>{% endfor %}
   {% endcall %}

--- a/app/templates/htmx/partials/search/lead_detail.html
+++ b/app/templates/htmx/partials/search/lead_detail.html
@@ -77,15 +77,15 @@
     <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Part Details</h3>
     <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
       <div>
-        <dt class="text-gray-500 text-xs">MPN</dt>
+        <dt class="text-gray-600 text-xs">MPN</dt>
         <dd class="font-mono font-medium text-gray-900">{{ s.mpn_matched or s.mpn or "—" }}</dd>
       </div>
       <div>
-        <dt class="text-gray-500 text-xs">Manufacturer</dt>
+        <dt class="text-gray-600 text-xs">Manufacturer</dt>
         <dd class="text-gray-900">{{ s.manufacturer or "—" }}</dd>
       </div>
       <div>
-        <dt class="text-gray-500 text-xs">Unit Price</dt>
+        <dt class="text-gray-600 text-xs">Unit Price</dt>
         <dd class="font-medium {{ 'text-emerald-700' if s.unit_price else 'text-gray-400' }}">
           {% if s.unit_price %}
             ${{ "%.4f"|format(s.unit_price) if s.unit_price < 1 else "%.2f"|format(s.unit_price) }}
@@ -94,42 +94,42 @@
         </dd>
       </div>
       <div>
-        <dt class="text-gray-500 text-xs">Qty Available</dt>
+        <dt class="text-gray-600 text-xs">Qty Available</dt>
         <dd class="text-gray-900">{% if s.qty_available %}{{ "{:,}".format(s.qty_available) }}{% else %}—{% endif %}</dd>
       </div>
       {% if s.moq %}
       <div>
-        <dt class="text-gray-500 text-xs">MOQ</dt>
+        <dt class="text-gray-600 text-xs">MOQ</dt>
         <dd class="text-gray-900">{{ "{:,}".format(s.moq) }}</dd>
       </div>
       {% endif %}
       {% if s.lead_time %}
       <div>
-        <dt class="text-gray-500 text-xs">Lead Time</dt>
+        <dt class="text-gray-600 text-xs">Lead Time</dt>
         <dd class="text-gray-900">{{ s.lead_time }}</dd>
       </div>
       {% endif %}
       {% if s.condition %}
       <div>
-        <dt class="text-gray-500 text-xs">Condition</dt>
+        <dt class="text-gray-600 text-xs">Condition</dt>
         <dd class="text-gray-900">{{ s.condition }}</dd>
       </div>
       {% endif %}
       {% if s.date_code %}
       <div>
-        <dt class="text-gray-500 text-xs">Date Code</dt>
+        <dt class="text-gray-600 text-xs">Date Code</dt>
         <dd class="text-gray-900">{{ s.date_code }}</dd>
       </div>
       {% endif %}
       {% if s.packaging %}
       <div>
-        <dt class="text-gray-500 text-xs">Packaging</dt>
+        <dt class="text-gray-600 text-xs">Packaging</dt>
         <dd class="text-gray-900">{{ s.packaging }}</dd>
       </div>
       {% endif %}
       {% if s.country %}
       <div>
-        <dt class="text-gray-500 text-xs">Country</dt>
+        <dt class="text-gray-600 text-xs">Country</dt>
         <dd class="text-gray-900">{{ s.country }}</dd>
       </div>
       {% endif %}
@@ -172,7 +172,7 @@
   {# ── Section 3c: Sources found ── #}
   {% if s.sources_found and s.sources_found|length > 0 %}
   <div class="flex items-center gap-2 flex-wrap">
-    <span class="text-xs text-gray-500">Found in:</span>
+    <span class="text-xs text-gray-600">Found in:</span>
     {% for src_name in s.sources_found %}
     <span class="px-2 py-0.5 text-xs font-medium rounded bg-gray-100 text-gray-600">{{ src_name }}</span>
     {% endfor %}
@@ -198,12 +198,12 @@
     <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Source Attribution</h3>
     <div class="space-y-2 text-sm">
       <div class="flex items-center justify-between">
-        <span class="text-gray-500">Source</span>
+        <span class="text-gray-600">Source</span>
         <span class="font-medium text-gray-900">{{ s.source_type or "Unknown" }}</span>
       </div>
       {% if s.evidence_tier %}
       <div class="flex items-center justify-between">
-        <span class="text-gray-500">Evidence Tier</span>
+        <span class="text-gray-600">Evidence Tier</span>
         {% set tier = s.evidence_tier|upper %}
         {% if tier in ("T1", "T2") %}
           <span class="px-2 py-0.5 text-xs font-medium rounded bg-brand-50 text-brand-600">{{ tier }} — Direct Source</span>
@@ -216,7 +216,7 @@
       {% endif %}
       {% if s.vendor_sku %}
       <div class="flex items-center justify-between">
-        <span class="text-gray-500">Vendor SKU</span>
+        <span class="text-gray-600">Vendor SKU</span>
         <span class="font-mono text-xs text-gray-700">{{ s.vendor_sku }}</span>
       </div>
       {% endif %}
@@ -300,7 +300,7 @@
     <div class="space-y-2">
       {% for name, value in s.score_components.items() %}
       <div class="flex items-center gap-3">
-        <span class="text-xs text-gray-500 w-24 capitalize">{{ name }}</span>
+        <span class="text-xs text-gray-600 w-24 capitalize">{{ name }}</span>
         <div class="flex-1 bg-gray-100 rounded-full h-2">
           <div class="h-2 rounded-full {{ 'bg-emerald-500' if value >= 60 else ('bg-amber-500' if value >= 40 else 'bg-rose-400') }}"
                style="width: {{ value }}%"></div>

--- a/app/templates/htmx/partials/search/requisition_picker_modal.html
+++ b/app/templates/htmx/partials/search/requisition_picker_modal.html
@@ -17,18 +17,18 @@
               hx-swap="innerHTML"
               data-loading-disable>
         <div class="font-medium">{{ req.name }}</div>
-        <div class="text-xs text-gray-500">{{ req.customer_name|default('', true) }} &middot; {{ req.requirements|length }} parts</div>
+        <div class="text-xs text-gray-600">{{ req.customer_name|default('', true) }} &middot; {{ req.requirements|length }} parts</div>
       </button>
       {% endfor %}
     </div>
     {% else %}
-    <p class="text-sm text-gray-500">No requisitions found. Create one first.</p>
+    <p class="text-sm text-gray-600">No requisitions found. Create one first.</p>
     {% endif %}
 
     <div id="modal-result" class="mt-3"></div>
 
     <div class="mt-4 flex justify-end">
-      <button @click="$el.closest('[class*=fixed]').remove()" class="px-4 py-2 text-sm text-gray-500 hover:text-brand-700">
+      <button @click="$el.closest('[class*=fixed]').remove()" class="px-4 py-2 text-sm text-gray-600 hover:text-brand-700">
         Close
       </button>
     </div>

--- a/app/templates/htmx/partials/search/results_shell.html
+++ b/app/templates/htmx/partials/search/results_shell.html
@@ -24,7 +24,7 @@
 
   {# source progress chips #}
   <div id="source-progress" class="px-4 py-3 border-b border-brand-100 flex flex-wrap gap-1.5 items-center">
-    <span class="text-[11px] text-gray-500 mr-1">Sources:</span>
+    <span class="text-[11px] text-gray-600 mr-1">Sources:</span>
     {% for source in enabled_sources %}
     <span id="source-chip-{{ source.name }}" class="source-chip source-chip--searching">
       <span class="inline-block w-1.5 h-1.5 rounded-full bg-current animate-pulse mr-1"></span>{{ source.name }}
@@ -46,7 +46,7 @@
     <div sse-swap="done" hx-swap="none"></div>
   </div>
 
-  <div id="search-stats" class="hidden px-4 py-2.5 border-t border-brand-100 text-[11px] text-gray-500"></div>
+  <div id="search-stats" class="hidden px-4 py-2.5 border-t border-brand-100 text-[11px] text-gray-600"></div>
 
   {# Empty state — reframed as a pivot to knowledge. #}
   <div id="search-empty-state" class="hidden px-6 py-12 text-center">
@@ -54,7 +54,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
     </svg>
     <p class="text-base font-semibold text-brand-900">No live stock right now.</p>
-    <p class="text-sm text-gray-500 mt-1">Here's what we already know about this part.</p>
+    <p class="text-sm text-gray-600 mt-1">Here's what we already know about this part.</p>
     <a href="#know" class="mt-4 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-50 border border-brand-200 text-brand-700 text-sm hover:bg-brand-100">
       Jump to What we know
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M19 14l-7 7m0 0l-7-7m7 7V3"/></svg>

--- a/app/templates/htmx/partials/search/shortlist_bar.html
+++ b/app/templates/htmx/partials/search/shortlist_bar.html
@@ -19,7 +19,7 @@
     </span>
     <div class="flex items-center gap-2">
       <button @click="$dispatch('open-modal', {url: '/v2/partials/search/requisition-picker?items=' + encodeURIComponent(JSON.stringify($store.shortlist.items))})"
-              class="px-4 py-2 text-sm font-semibold bg-brand-500 text-white rounded-lg hover:bg-brand-600 transition-colors">
+              class="btn-primary">
         Add to Requisition
       </button>
       <button @click="$dispatch('open-modal', {url: '/v2/partials/search/requisition-picker?action=rfq&items=' + encodeURIComponent(JSON.stringify($store.shortlist.items))})"
@@ -27,7 +27,7 @@
         Create RFQ
       </button>
       <button @click="$store.shortlist.clear()"
-              class="px-3 py-2 text-sm text-gray-500 hover:text-brand-700 transition-colors">
+              class="px-3 py-2 text-sm text-gray-600 hover:text-brand-700 transition-colors">
         Clear
       </button>
     </div>

--- a/app/templates/htmx/partials/search/vendor_card.html
+++ b/app/templates/htmx/partials/search/vendor_card.html
@@ -30,9 +30,9 @@
       <span class="lg:hidden h-2.5 w-2.5 rounded-full {% if conf == 'green' %}bg-emerald-500{% elif conf == 'amber' %}bg-amber-500{% else %}bg-rose-500{% endif %}"></span>
       <span class="text-sm font-semibold text-brand-900 truncate">{{ card.vendor_name }}</span>
       {% if card.is_authorized %}
-      <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-emerald-50 text-emerald-700 border border-emerald-200">AUTH</span>
+      <span class="px-1.5 py-0.5 text-xs font-medium rounded bg-emerald-50 text-emerald-700 border border-emerald-200">AUTH</span>
       {% endif %}
-      <span class="px-1.5 py-0.5 text-[10px] font-medium rounded border
+      <span class="px-1.5 py-0.5 text-xs font-medium rounded border
         {% if conf == 'green' %}bg-emerald-50 text-emerald-700 border-emerald-200
         {% elif conf == 'amber' %}bg-amber-50 text-amber-700 border-amber-200
         {% else %}bg-rose-50 text-rose-700 border-rose-200{% endif %}">{{ card.confidence_pct|default(0) }}%</span>
@@ -40,7 +40,7 @@
       <span class="source-badge source-badge--{{ src }}">{{ src }}</span>
       {% endfor %}
     </div>
-    <div class="text-[11px] text-gray-500 mt-0.5 font-mono">
+    <div class="text-[11px] text-gray-600 mt-0.5 font-mono">
       {{ card.mpn_matched }}{% if card.manufacturer %} · {{ card.manufacturer }}{% endif %}
     </div>
   </div>
@@ -61,7 +61,7 @@
   </div>
 
   {# region / lead #}
-  <div class="text-[11px] text-gray-500 mt-0.5 lg:mt-0">{{ card.lead_quality|default('')|title }}{% if card.reason %} · {{ card.reason }}{% endif %}</div>
+  <div class="text-[11px] text-gray-600 mt-0.5 lg:mt-0">{{ card.lead_quality|default('')|title }}{% if card.reason %} · {{ card.reason }}{% endif %}</div>
 
   {# actions (reveal on hover desktop, always visible on mobile/touch) #}
   <div class="flex lg:justify-end items-center gap-1 mt-2 lg:mt-0 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
@@ -76,7 +76,7 @@
     <button type="button"
             hx-get="/v2/partials/search/lead-detail?search_id={{ search_id }}&vendor_key={{ card.vendor_name|lower|trim }}"
             hx-target="#lead-drawer-content" hx-swap="innerHTML"
-            class="px-2 py-1 rounded text-[11px] text-gray-500 hover:text-brand-700 hover:bg-brand-50">Details →</button>
+            class="px-2 py-1 rounded text-[11px] text-gray-600 hover:text-brand-700 hover:bg-brand-50">Details →</button>
   </div>
 
   {# Sub-offers table (expandable) #}

--- a/app/templates/htmx/partials/sightings/_offer_row.html
+++ b/app/templates/htmx/partials/sightings/_offer_row.html
@@ -19,7 +19,7 @@
       <div class="flex items-center gap-2">
         <button @click.stop="expand = !expand"
                 class="font-medium text-gray-900 text-sm truncate hover:text-brand-600 text-left">{{ o.vendor_name or '—' }}</button>
-        <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full {{ sc.get(o.status, 'bg-gray-100 text-gray-600') }}">
+        <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded-full {{ sc.get(o.status, 'bg-gray-100 text-gray-600') }}">
           {{ (o.status or 'unknown')|replace('_', ' ')|capitalize }}
         </span>
         {{ qual_badge(o) }}
@@ -29,7 +29,7 @@
         · {{ '{:,}'.format(o.qty_available) if o.qty_available else '—' }} pcs
         {% if o.lead_time %}<span class="font-sans">· {{ o.lead_time }}</span>{% endif %}
       </div>
-      <div class="text-[10px] text-gray-300 mt-0.5">
+      <div class="text-xs text-gray-300 mt-0.5">
         ↳ {{ (o.requisition.customer_name or '—') if o.requisition else '—' }}
         {% if o.requisition_id %}· Req #{{ o.requisition_id }}{% endif %}
       </div>
@@ -82,13 +82,13 @@
     <p class="text-gray-700">{{ o.qualification_note }}</p>
     {% endif %}
     {% if q.get('provenance_story') %}
-    <p class="text-gray-500"><span class="font-medium text-gray-600">Provenance:</span> {{ q.provenance_story }}</p>
+    <p class="text-gray-600"><span class="font-medium text-gray-600">Provenance:</span> {{ q.provenance_story }}</p>
     {% endif %}
     {% if q.get('terms') %}
-    <p class="text-gray-500"><span class="font-medium text-gray-600">Terms:</span> {{ q.terms }}</p>
+    <p class="text-gray-600"><span class="font-medium text-gray-600">Terms:</span> {{ q.terms }}</p>
     {% endif %}
     {% if q.get('lead_time_reason') %}
-    <p class="text-gray-500"><span class="font-medium text-gray-600">Lead time:</span> {{ q.lead_time_reason }}</p>
+    <p class="text-gray-600"><span class="font-medium text-gray-600">Lead time:</span> {{ q.lead_time_reason }}</p>
     {% endif %}
     {# ── One-tap vendor request chips ─────────────────────────────── #}
     <div class="flex flex-wrap gap-1 pt-1">
@@ -97,7 +97,7 @@
       <button hx-post="/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/request"
               hx-vals='{"kind":"{{ kind_key }}"}'
               hx-target="#sightings-offers-panel" hx-swap="innerHTML" data-loading-disable
-              class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded border border-gray-200 bg-white text-gray-600 hover:bg-gray-50 hover:border-gray-300 transition-colors">
+              class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded border border-gray-200 bg-white text-gray-600 hover:bg-gray-50 hover:border-gray-300 transition-colors">
         {{ kind_labels[kind_key] }}
       </button>
       {% endfor %}
@@ -117,14 +117,14 @@
       {% set r_kind = r.get('kind', '') %}
       {% set r_status = r.get('status', '') %}
       {% set color = status_colors.get(r_status, 'bg-gray-100 text-gray-500') %}
-      <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full {{ color }}">
+      <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded-full {{ color }}">
         {{ kind_display.get(r_kind, r_kind|capitalize) }}{% if r_status != 'pending' %} — {{ r_status }}{% endif %}
       </span>
       {# Per-PENDING Send control: fires the token-bearing send route for this entry. #}
       {% if r_status == 'pending' %}
       <button hx-post="/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/request/{{ loop.index0 }}/send"
               hx-target="#sightings-offers-panel" hx-swap="innerHTML" data-loading-disable
-              class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded border border-blue-200 bg-white text-blue-600 hover:bg-blue-50 hover:border-blue-300 transition-colors">
+              class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded border border-blue-200 bg-white text-blue-600 hover:bg-blue-50 hover:border-blue-300 transition-colors">
         Send
       </button>
       {% endif %}

--- a/app/templates/htmx/partials/sightings/_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/_vendor_row.html
@@ -299,7 +299,7 @@
 
         {# explain_lead one-liner #}
         {% if intel.get('explain_lead') %}
-        <p class="text-[11px] text-gray-500 italic border-t border-gray-100 pt-1.5 mt-1">
+        <p class="text-[11px] text-gray-600 italic border-t border-gray-100 pt-1.5 mt-1">
           {{ intel.explain_lead }}
         </p>
         {% endif %}

--- a/app/templates/htmx/partials/sightings/activity_section.html
+++ b/app/templates/htmx/partials/sightings/activity_section.html
@@ -4,7 +4,7 @@
    Context vars: activities (list of ActivityLog), requirement
 #}
 
-<h4 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Activity</h4>
+<h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">Activity</h4>
 
 {# ── Inline Log Note Form ──────────────────────────────────── #}
 <div x-data="{ open: false }" class="mb-3">
@@ -29,7 +29,7 @@
         class="space-y-2 p-3 bg-gray-50 rounded-lg border border-gray-200">
 
     <div>
-      <label class="block text-[10px] font-medium text-gray-500 uppercase tracking-wider mb-1">Channel</label>
+      <label class="block text-xs font-medium text-gray-600 uppercase tracking-wider mb-1">Channel</label>
       <select name="channel"
               class="w-full rounded-md border-gray-300 text-xs py-1.5 px-2 focus:border-brand-400 focus:ring-brand-400">
         <option value="note">Note</option>
@@ -39,7 +39,7 @@
     </div>
 
     <div>
-      <label class="block text-[10px] font-medium text-gray-500 uppercase tracking-wider mb-1">Vendor (optional)</label>
+      <label class="block text-xs font-medium text-gray-600 uppercase tracking-wider mb-1">Vendor (optional)</label>
       <input type="text"
              name="vendor_name"
              placeholder="e.g. Arrow Electronics"
@@ -47,7 +47,7 @@
     </div>
 
     <div>
-      <label class="block text-[10px] font-medium text-gray-500 uppercase tracking-wider mb-1">Notes</label>
+      <label class="block text-xs font-medium text-gray-600 uppercase tracking-wider mb-1">Notes</label>
       <textarea name="notes"
                 rows="3"
                 required

--- a/app/templates/htmx/partials/sightings/composer_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/composer_vendor_row.html
@@ -19,10 +19,10 @@
        data-vendor-norm="{{ vendor.normalized_name }}">
   <input type="checkbox" disabled class="rounded border-gray-300 cursor-not-allowed">
   <div class="flex-1 min-w-0">
-    <span class="text-sm font-medium text-gray-500">{{ vendor.display_name }}</span>
-    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-rose-100 text-rose-700">marked unavailable</span>
+    <span class="text-sm font-medium text-gray-600">{{ vendor.display_name }}</span>
+    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-rose-100 text-rose-700">marked unavailable</span>
     {% if matched_existing %}
-    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor{% if contact_added %} — contact email added{% endif %}</span>
+    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor{% if contact_added %} — contact email added{% endif %}</span>
     {% endif %}
   </div>
 </label>
@@ -37,7 +37,7 @@
   <div class="flex-1 min-w-0">
     <span class="text-sm font-medium text-gray-700">{{ vendor.display_name }}</span>
     {% if matched_existing %}
-    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor{% if contact_added %} — contact email added{% endif %}</span>
+    <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-indigo-50 text-indigo-700">matched existing vendor{% if contact_added %} — contact email added{% endif %}</span>
     {% endif %}
   </div>
 </label>

--- a/app/templates/htmx/partials/sightings/detail.html
+++ b/app/templates/htmx/partials/sightings/detail.html
@@ -15,7 +15,7 @@
     <div>
       {{ mpn_chips(requirement, link_map=link_map) }}
       {% if requirement.manufacturer %}
-      <p class="text-xs text-gray-500 mt-1">{{ requirement.manufacturer }}</p>
+      <p class="text-xs text-gray-600 mt-1">{{ requirement.manufacturer }}</p>
       {% endif %}
     </div>
     {{ m.search_button(requirement, target="#sightings-detail", swap="innerHTML") }}
@@ -107,11 +107,11 @@
     <table class="compact-table w-full">
       <thead>
         <tr>
-          <th class="px-2 py-1.5 text-left">Vendor</th>
-          <th class="px-2 py-1.5 text-right">Qty</th>
-          <th class="px-2 py-1.5 text-right">Best Price</th>
-          <th class="px-2 py-1.5 text-right">Score</th>
-          <th class="px-2 py-1.5 w-8" aria-hidden="true"></th>
+          <th class="compact-cell--head text-left">Vendor</th>
+          <th class="compact-cell--head text-right">Qty</th>
+          <th class="compact-cell--head text-right">Best Price</th>
+          <th class="compact-cell--head text-right">Score</th>
+          <th class="compact-cell--head w-8" aria-hidden="true"></th>
         </tr>
       </thead>
       {# Each vendor renders its own <tbody> for an isolated Alpine `expanded`

--- a/app/templates/htmx/partials/sightings/list.html
+++ b/app/templates/htmx/partials/sightings/list.html
@@ -168,7 +168,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
         <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
       </svg>
-      <p class="text-sm font-medium text-gray-500">Select a requirement</p>
+      <p class="text-sm font-medium text-gray-600">Select a requirement</p>
       <p class="text-xs text-gray-400 mt-1">Click a row to view vendors, offers & activity</p>
     </div>
     {# Skeleton loader — visible while HTMX request is in-flight #}

--- a/app/templates/htmx/partials/sightings/offer_form_modal.html
+++ b/app/templates/htmx/partials/sightings/offer_form_modal.html
@@ -34,9 +34,9 @@
 
     <div class="flex justify-end gap-2 pt-1">
       <button type="button" @click="$dispatch('close-modal')"
-              class="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Cancel</button>
+              class="btn btn-ghost btn-sm">Cancel</button>
       <button type="submit" :disabled="!essentialsMet()"
-              class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600 disabled:opacity-50 disabled:cursor-not-allowed">
+              class="btn btn-primary btn-sm">
         Save Offer
       </button>
     </div>

--- a/app/templates/htmx/partials/sightings/offers_panel.html
+++ b/app/templates/htmx/partials/sightings/offers_panel.html
@@ -7,7 +7,7 @@
     All offers for {{ requirement.primary_mpn }} · {{ part_offers|length }}
   </h4>
   <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/{{ requirement.id }}/offer-form'})"
-          class="px-2.5 py-1 text-[11px] font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 inline-flex items-center gap-1">
+          class="btn-primary btn-sm">
     <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
     Enter Offer
   </button>

--- a/app/templates/htmx/partials/sightings/preview_inquiry.html
+++ b/app/templates/htmx/partials/sightings/preview_inquiry.html
@@ -29,7 +29,7 @@
         <div class="flex items-center justify-between">
           <span class="text-sm font-semibold text-gray-800">{{ p.vendor_name }}</span>
           {% if p.vendor_email %}
-          <span class="text-xs text-gray-500">{{ p.vendor_email }}</span>
+          <span class="text-xs text-gray-600">{{ p.vendor_email }}</span>
           {% else %}
           <span class="inline-flex items-center gap-1 text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full">
             <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
@@ -39,7 +39,7 @@
           </span>
           {% endif %}
         </div>
-        <div class="text-xs text-gray-500 mt-1">
+        <div class="text-xs text-gray-600 mt-1">
           <span class="font-medium text-gray-600">Subject:</span> {{ p.subject }}
         </div>
       </div>
@@ -52,8 +52,8 @@
       {# Parts summary #}
       {% if p.parts %}
       <div class="px-3 py-1.5 bg-gray-50 border-t border-gray-100">
-        <span class="text-[10px] text-gray-400 uppercase tracking-wider">Parts:</span>
-        <span class="text-xs text-gray-500 ml-1">
+        <span class="text-xs text-gray-400 uppercase tracking-wider">Parts:</span>
+        <span class="text-xs text-gray-600 ml-1">
           {% for part in p.parts %}{{ part.mpn }} ({{ part.qty }} pcs){{ ', ' if not loop.last else '' }}{% endfor %}
         </span>
       </div>

--- a/app/templates/htmx/partials/sightings/table.html
+++ b/app/templates/htmx/partials/sightings/table.html
@@ -141,12 +141,12 @@
           {{ mpn_chips(r, link_map=link_map) }}
         </td>
         {% set desc = r|part_description %}
-        <td class="px-3 py-2 text-sm text-gray-500 truncate max-w-[180px] hidden sm:table-cell" title="{{ desc }}">{{ desc or '—' }}</td>
+        <td class="px-3 py-2 text-sm text-gray-600 truncate max-w-[180px] hidden sm:table-cell" title="{{ desc }}">{{ desc or '—' }}</td>
         <td class="px-3 py-2 text-right font-mono hidden sm:table-cell">{{ r.target_qty or '—' }}</td>
         <td class="px-3 py-2 text-gray-600 truncate max-w-[140px] hidden xl:table-cell">
           {{ r.requisition.customer_name or '—' }}
         </td>
-        <td class="px-3 py-2 text-gray-500 text-xs truncate hidden xl:table-cell">
+        <td class="px-3 py-2 text-gray-600 text-xs truncate hidden xl:table-cell">
           {{ r.requisition.creator.name if r.requisition.creator else '—' }}
         </td>
         <td class="px-3 py-2 coverage-cell"
@@ -219,7 +219,7 @@
         <div class="flex-1 min-w-0">{{ mpn_chips(r, link_map=link_map) }}</div>
         <span class="transition-colors duration-200 ml-2 flex-shrink-0">{{ m.status_badge(r.sourcing_status) }}</span>
       </div>
-      <div class="flex items-center gap-3 text-xs text-gray-500">
+      <div class="flex items-center gap-3 text-xs text-gray-600">
         {% if r.target_qty %}<span>{{ r.target_qty }} pcs</span>{% endif %}
         {% if r.requisition.customer_name %}<span class="truncate max-w-[120px]">{{ r.requisition.customer_name }}</span>{% endif %}
       </div>
@@ -268,14 +268,14 @@
     <span class="text-xs font-medium text-gray-600" x-text="$store.sightingSelection.count + ' selected'"></span>
     <span x-show="$store.sightingSelection.count > visibleSelectedCount && visibleSelectedCount > 0"
           x-cloak
-          class="text-xs text-gray-500">
+          class="text-xs text-gray-600">
       + <span x-text="$store.sightingSelection.count - visibleSelectedCount"></span> on other pages
     </span>
     <button @click="$dispatch('open-modal', {url: '/v2/partials/sightings/vendor-modal?requirement_ids=' + $store.sightingSelection.array.join(',')})"
-            class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-brand-500 text-white text-xs font-medium hover:bg-brand-600 transition-colors">
+            class="btn-primary btn-sm">
       Send to Vendors
     </button>
-    <button class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gray-200 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+    <button class="btn-secondary btn-sm"
             hx-post="/v2/partials/sightings/batch-refresh"
             hx-vals='js:{requirement_ids: JSON.stringify($store.sightingSelection.array)}'
             hx-target="#sightings-table"
@@ -286,7 +286,7 @@
 
     {# ── Batch Status Dropdown ─────────────────────────────── #}
     <div x-data="{ open: false }" class="relative">
-      <button @click="open = !open" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gray-200 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors">
+      <button @click="open = !open" class="btn-secondary btn-sm">
         Change Status
         <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
       </button>
@@ -297,7 +297,7 @@
               @htmx:after-request="open = false"
               x-data="{ status: '' }">
           <input type="hidden" name="requirement_ids" :value="JSON.stringify($store.sightingSelection.array)">
-          <label class="text-xs font-medium text-gray-700 mb-1 block">New status</label>
+          <label class="form-label">New status</label>
           <select name="status" x-model="status"
                   class="w-full rounded-lg border border-gray-200 px-2 py-1.5 text-sm mb-2">
             <option value="">Select...</option>
@@ -310,7 +310,7 @@
             <option value="archived">Archived</option>
           </select>
           <button type="submit" :disabled="!status"
-                  class="w-full px-3 py-1.5 rounded-lg bg-brand-500 text-white text-xs font-medium hover:bg-brand-600 disabled:opacity-50 disabled:cursor-not-allowed">
+                  class="btn-primary btn-sm w-full">
             Apply
           </button>
         </form>
@@ -319,7 +319,7 @@
 
     {# ── Batch Notes Dropdown ──────────────────────────────── #}
     <div x-data="{ open: false }" class="relative">
-      <button @click="open = !open" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gray-200 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors">
+      <button @click="open = !open" class="btn-secondary btn-sm">
         Add Note
         <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
       </button>
@@ -330,11 +330,11 @@
               @htmx:after-request="open = false"
               x-data="{ noteText: '' }">
           <input type="hidden" name="requirement_ids" :value="JSON.stringify($store.sightingSelection.array)">
-          <label class="text-xs font-medium text-gray-700 mb-1 block">Note</label>
+          <label class="form-label">Note</label>
           <textarea name="notes" x-model="noteText" rows="3" placeholder="Add a note to all selected..."
                     class="w-full rounded-lg border border-gray-200 px-2 py-1.5 text-sm mb-2 resize-none"></textarea>
           <button type="submit" :disabled="!noteText.trim()"
-                  class="w-full px-3 py-1.5 rounded-lg bg-brand-500 text-white text-xs font-medium hover:bg-brand-600 disabled:opacity-50 disabled:cursor-not-allowed">
+                  class="btn-primary btn-sm w-full">
             Apply
           </button>
         </form>

--- a/app/templates/htmx/partials/sightings/unavailable_form.html
+++ b/app/templates/htmx/partials/sightings/unavailable_form.html
@@ -11,7 +11,7 @@
    On success: re-renders #sightings-detail and closes the modal. #}
 <div class="p-4">
   <h3 class="text-sm font-semibold text-gray-900 mb-1">Mark unavailable — {{ vendor_name }}</h3>
-  <p class="text-[11px] text-gray-500 mb-3">
+  <p class="text-[11px] text-gray-600 mb-3">
     This applies to all of this vendor's listings of this MPN{% if requirement.primary_mpn %}
     ({{ requirement.primary_mpn }}){% endif %} — every condition and variant shares one record.
     While the mark is active, {{ vendor_name }} is left out of RFQ suggestions for this part.
@@ -43,7 +43,7 @@
     <input type="hidden" name="vendor_name" value="{{ vendor_name }}">
 
     <fieldset>
-      <legend class="block text-xs text-gray-500 mb-1">What did we learn?</legend>
+      <legend class="block text-xs text-gray-600 mb-1">What did we learn?</legend>
       <div class="space-y-0.5">
         {% for reason in reasons %}
         <label class="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-50 cursor-pointer">
@@ -57,17 +57,17 @@
     </fieldset>
 
     <div>
-      <label class="block text-xs text-gray-500 mb-1">Note (optional)</label>
+      <label class="block text-xs text-gray-600 mb-1">Note (optional)</label>
       <textarea name="note" rows="2"
-                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
+                class="input"
                 placeholder="What we learned about this vendor's stock...">{{ current.note if current and current.note else '' }}</textarea>
     </div>
 
     <div class="flex justify-end gap-2 pt-1">
       <button type="button" @click="$dispatch('close-modal')"
-              class="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Cancel</button>
+              class="btn btn-sm btn-ghost">Cancel</button>
       <button type="submit"
-              class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+              class="btn btn-primary btn-sm">
         Mark unavailable
       </button>
     </div>

--- a/app/templates/htmx/partials/sightings/vendor_affinity_rows.html
+++ b/app/templates/htmx/partials/sightings/vendor_affinity_rows.html
@@ -22,9 +22,9 @@
            class="rounded border-gray-300">
     <div class="flex-1 min-w-0">
       <span class="text-sm font-medium text-gray-700">{{ v.vendor_name }}</span>
-      <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full border border-indigo-200 bg-indigo-50 text-indigo-700"
+      <span class="ml-2 badge bg-indigo-50 text-indigo-700 border-indigo-200"
             title="{{ v.reasoning }}">affinity</span>
-      <span class="ml-2 text-[10px] text-gray-400">{{ (v.confidence * 100)|round|int }}% match</span>
+      <span class="ml-2 text-xs text-gray-400">{{ (v.confidence * 100)|round|int }}% match</span>
     </div>
   </label>
   {% endfor %}
@@ -33,5 +33,5 @@
 <p class="text-xs text-gray-400 italic">No additional vendors found by affinity.</p>
 {% endif %}
 {% if affinity_partial %}
-<p class="mt-1 text-[10px] text-gray-400 italic">Suggestions incomplete — some parts could not be checked.</p>
+<p class="mt-1 text-xs text-gray-400 italic">Suggestions incomplete — some parts could not be checked.</p>
 {% endif %}

--- a/app/templates/htmx/partials/sightings/vendor_modal.html
+++ b/app/templates/htmx/partials/sightings/vendor_modal.html
@@ -45,11 +45,11 @@
                   title="Covers: {{ cov.mpns }}">{{ cov.count }}/{{ parts|length }} parts</span>
             {% endif %}
             {% if v.response_rate %}
-            <span class="ml-2 text-[10px] text-gray-400">{{ (v.response_rate * 100)|round|int }}% response</span>
+            <span class="ml-2 text-xs text-gray-400">{{ (v.response_rate * 100)|round|int }}% response</span>
             {% endif %}
           </div>
           {% if v.engagement_score %}
-          <span class="text-[10px] text-gray-400">Score: {{ v.engagement_score|round|int }}</span>
+          <span class="text-xs text-gray-400">Score: {{ v.engagement_score|round|int }}</span>
           {% endif %}
         </label>
         {% else %}
@@ -163,7 +163,7 @@
                class="w-full px-2 py-1 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-brand-500">
         <button type="button" :disabled="!newVendorName.trim() || addingVendorBusy"
                 @click="createVendor()"
-                class="px-3 py-1 text-xs font-semibold bg-brand-500 text-white rounded hover:bg-brand-600 disabled:opacity-50">
+                class="btn-primary btn-sm">
           <span x-text="addingVendorBusy ? 'Adding...' : 'Add Vendor'"></span>
         </button>
       </div>
@@ -172,7 +172,7 @@
     {# Parts reference (read-only) #}
     <div class="mb-4">
       <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Parts</label>
-      <div class="text-xs text-gray-500 bg-gray-50 rounded-lg p-2 max-h-24 overflow-y-auto font-mono">
+      <div class="text-xs text-gray-600 bg-gray-50 rounded-lg p-2 max-h-24 overflow-y-auto font-mono">
         {% for p in parts %}
         <div>{{ p.mpn }} — {{ p.qty }} pcs{{ ' @ $%.2f'|format(p.target_price) if p.target_price else '' }}</div>
         {% endfor %}

--- a/app/templates/htmx/partials/sourcing/_filter_macros.html
+++ b/app/templates/htmx/partials/sourcing/_filter_macros.html
@@ -18,7 +18,7 @@
                            f_confidence, f_safety, f_freshness, f_source, f_status,
                            f_contactability, f_corroborated, f_sort) -%}
 <div class="flex items-center gap-1.5">
-  <span class="text-[11px] text-gray-500 font-medium">{{ label }}:</span>
+  <span class="text-[11px] text-gray-600 font-medium">{{ label }}:</span>
   {% for val, opt_label in options %}
   <a hx-get="/v2/partials/sourcing/{{ requirement_id }}?confidence={{ val if param == 'confidence' else f_confidence }}&safety={{ val if param == 'safety' else f_safety }}&freshness={{ val if param == 'freshness' else f_freshness }}&source={{ f_source }}&status={{ val if param == 'status' else f_status }}&contactability={{ val if param == 'contactability' else f_contactability }}&corroborated={{ val if param == 'corroborated' else f_corroborated }}&sort={{ f_sort }}"
      hx-target="{{ target }}" hx-push-url="true"

--- a/app/templates/htmx/partials/sourcing/filter_bar.html
+++ b/app/templates/htmx/partials/sourcing/filter_bar.html
@@ -15,7 +15,7 @@
                  'f_freshness': f_freshness, 'f_source': f_source, 'f_status': f_status,
                  'f_contactability': f_contactability, 'f_corroborated': f_corroborated,
                  'f_sort': f_sort} %}
-<div id="sourcing-filters" class="bg-white rounded-lg border border-brand-200 p-3 space-y-2"
+<div id="sourcing-filters" class="card-sm space-y-2"
      x-data="{ showMore: false }">
   {# Row 1: always visible — Confidence + Safety + Sort + toggle #}
   <div class="flex flex-wrap items-center gap-3">
@@ -24,7 +24,7 @@
     {{ filter_pill_group('Safety', 'safety', [('low_risk', 'Low'), ('medium_risk', 'Med'), ('high_risk', 'High')], f_safety, **_state) | indent(4, false) }}
 
     <div class="flex items-center gap-1.5">
-      <span class="text-[11px] text-gray-500 font-medium">Sort:</span>
+      <span class="text-[11px] text-gray-600 font-medium">Sort:</span>
       <select hx-get="/v2/partials/sourcing/{{ requirement.id }}"
               hx-target="{{ target }}" hx-push-url="true"
               hx-include="#sourcing-filters"
@@ -50,7 +50,7 @@
 
       {# Source checkboxes #}
       <div class="flex items-center gap-1.5">
-        <span class="text-[11px] text-gray-500 font-medium">Source:</span>
+        <span class="text-[11px] text-gray-600 font-medium">Source:</span>
         {% for src in ['brokerbin', 'nexar', 'digikey', 'mouser', 'oemsecrets', 'element14'] %}
         <label class="flex items-center gap-0.5 text-[11px] cursor-pointer">
           <input type="checkbox" name="source" value="{{ src }}"

--- a/app/templates/htmx/partials/sourcing/lead_card.html
+++ b/app/templates/htmx/partials/sourcing/lead_card.html
@@ -40,7 +40,7 @@
     {# Row 2: Confidence score + progress bar #}
     <div>
       <div class="flex items-center justify-between mb-1">
-        <span class="text-xs text-gray-500">Confidence</span>
+        <span class="text-xs text-gray-600">Confidence</span>
         <span class="text-sm font-semibold
           {% if lead.confidence_score >= 70 %}text-emerald-700
           {% elif lead.confidence_score >= 40 %}text-amber-700
@@ -85,7 +85,7 @@
 
     {# Row 5: Contact preview #}
     {% if lead.contact_email or lead.contact_phone %}
-    <div class="text-xs text-gray-500 truncate">
+    <div class="text-xs text-gray-600 truncate">
       {{ lead.contact_email or lead.contact_phone }}
     </div>
     {% endif %}
@@ -106,11 +106,11 @@
     <div class="flex flex-wrap gap-1">
       {% for flag in lead.risk_flags %}
         {% if flag.startswith('positive:') %}
-          <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-emerald-50 text-emerald-600">
+          <span class="px-1.5 py-0.5 text-xs font-medium rounded bg-emerald-50 text-emerald-600">
             {{ flag.replace('positive:', '')|replace('_', ' ')|title }}
           </span>
         {% else %}
-          <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-amber-50 text-amber-600">
+          <span class="px-1.5 py-0.5 text-xs font-medium rounded bg-amber-50 text-amber-600">
             {{ flag|replace('_', ' ')|title }}
           </span>
         {% endif %}

--- a/app/templates/htmx/partials/sourcing/lead_detail.html
+++ b/app/templates/htmx/partials/sourcing/lead_detail.html
@@ -9,11 +9,11 @@
 <div class="space-y-6 max-w-4xl">
 
   {# ===== Lead Summary Card ===== #}
-  <div class="bg-white rounded-lg border border-brand-200 p-6">
+  <div class="bg-white rounded-lg border border-brand-200 p-4">
     <div class="flex items-start justify-between">
       <div>
         <h1 class="text-xl font-bold text-gray-900">{{ lead.vendor_name }}</h1>
-        <p class="text-sm text-gray-500 mt-1">
+        <p class="text-sm text-gray-600 mt-1">
           <span class="font-mono">{{ lead.part_number_matched }}</span>
           {% if lead.match_type != 'exact' %}
           <span class="text-xs text-amber-600 ml-1">({{ lead.match_type }} match)</span>
@@ -100,11 +100,11 @@
     <div class="flex flex-wrap gap-1 mt-2">
       {% for flag in lead.risk_flags %}
         {% if flag.startswith('positive:') %}
-          <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-emerald-50 text-emerald-600">
+          <span class="px-1.5 py-0.5 text-xs font-medium rounded bg-emerald-50 text-emerald-600">
             {{ flag.replace('positive:', '')|replace('_', ' ')|title }}
           </span>
         {% else %}
-          <span class="px-1.5 py-0.5 text-[10px] font-medium rounded bg-amber-50 text-amber-600">
+          <span class="px-1.5 py-0.5 text-xs font-medium rounded bg-amber-50 text-amber-600">
             {{ flag|replace('_', ' ')|title }}
           </span>
         {% endif %}
@@ -114,7 +114,7 @@
 
     {# Notes for buyer #}
     {% if lead.notes_for_buyer %}
-    <p class="text-xs text-gray-500 italic mt-2">{{ lead.notes_for_buyer }}</p>
+    <p class="text-xs text-gray-600 italic mt-2">{{ lead.notes_for_buyer }}</p>
     {% endif %}
 
     {# Signal snapshot: qty, price, lead time, condition, date code, packaging, MOQ #}
@@ -233,7 +233,7 @@
               'buyer_confirmed': 'bg-emerald-50 text-emerald-700',
               'rejected': 'bg-rose-50 text-rose-700'
             } %}
-            <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded
+            <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded
                          {{ verify_colors.get(ev.verification_state, 'bg-gray-100 text-gray-600') }}">
               {{ ev.verification_state|replace('_', ' ')|title }}
             </span>
@@ -264,7 +264,7 @@
             {% with source_type=ev.source_type %}
               {% include "htmx/partials/shared/source_badge.html" %}
             {% endwith %}
-            <span class="text-gray-500">{{ ev.signal_type|replace('_', ' ') }}</span>
+            <span class="text-gray-600">{{ ev.signal_type|replace('_', ' ') }}</span>
           </div>
           {% endfor %}
         </div>
@@ -335,10 +335,9 @@
           class="space-y-3">
       <div class="flex gap-3">
         <div class="flex-1">
-          <label class="text-xs text-gray-500">Status</label>
+          <label class="form-label">Status</label>
           <select name="status"
-                  class="w-full mt-1 text-sm border border-gray-300 rounded-lg px-3 py-2
-                         focus:ring-brand-500 focus:border-brand-500">
+                  class="mt-1 input">
             {% for val, label in [
               ('new', 'New'),
               ('contacted', 'Contacted'),
@@ -352,16 +351,14 @@
           </select>
         </div>
         <div class="flex-1">
-          <label class="text-xs text-gray-500">Note (optional)</label>
+          <label class="form-label">Note (optional)</label>
           <input type="text" name="note" placeholder="Add a note..."
-                 class="w-full mt-1 text-sm border border-gray-300 rounded-lg px-3 py-2
-                        focus:ring-brand-500 focus:border-brand-500">
+                 class="mt-1 input">
         </div>
       </div>
       <div class="flex gap-2">
         <button type="submit"
-                class="px-4 py-2 bg-brand-500 text-white text-sm font-medium rounded-lg
-                       hover:bg-brand-600">
+                class="btn-primary">
           Update Status
         </button>
         {% if lead.contact_email %}
@@ -398,7 +395,7 @@
       <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">History</h3>
       <div class="space-y-2">
         {% for event in lead.feedback_events|sort(attribute='created_at', reverse=True) %}
-        <div class="flex items-center gap-3 text-xs text-gray-500">
+        <div class="flex items-center gap-3 text-xs text-gray-600">
           <span>{{ event.created_at | timesince }}</span>
           <span class="font-medium text-gray-700">{{ event.status|replace('_', ' ')|title }}</span>
           {% if event.note %}

--- a/app/templates/htmx/partials/sourcing/lead_panel.html
+++ b/app/templates/htmx/partials/sourcing/lead_panel.html
@@ -33,11 +33,11 @@
 <div class="p-4 space-y-3">
 
   {# ===== Summary Section ===== #}
-  <div class="bg-white rounded-lg border border-brand-200 p-3">
+  <div class="card-sm">
     <div class="flex items-start justify-between gap-2">
       <div class="min-w-0">
         <h2 class="text-base font-bold text-gray-900 truncate">{{ lead.vendor_name }}</h2>
-        <p class="text-xs text-gray-500">
+        <p class="text-xs text-gray-600">
           <span class="font-mono">{{ lead.part_number_matched }}</span>
           {% if lead.match_type != 'exact' %}
           <span class="text-amber-600 ml-0.5">({{ lead.match_type }})</span>
@@ -166,30 +166,27 @@
   </div>
 
   {# ===== Buyer Actions (compact inline) ===== #}
-  <div class="bg-white rounded-lg border border-brand-200 p-3">
+  <div class="card-sm">
     <form hx-post="/v2/partials/sourcing/leads/{{ lead.id }}/status"
           hx-target="#split-right-sourcing"
           data-loading-disable
           class="flex items-end gap-2">
       <div class="flex-1 min-w-0">
-        <label class="text-[10px] text-gray-500">Status</label>
+        <label class="text-xs text-gray-600">Status</label>
         <select name="status"
-                class="w-full text-xs border border-gray-300 rounded px-2 py-1.5
-                       focus:ring-brand-500 focus:border-brand-500">
+                class="input input-sm">
           {% for val, label in [('new', 'New'), ('contacted', 'Contacted'), ('has_stock', 'Has Stock'), ('no_stock', 'No Stock'), ('bad_lead', 'Bad Lead'), ('do_not_contact', 'Do Not Contact')] %}
           <option value="{{ val }}" {{ 'selected' if lead.buyer_status == val }}>{{ label }}</option>
           {% endfor %}
         </select>
       </div>
       <div class="flex-1 min-w-0">
-        <label class="text-[10px] text-gray-500">Note</label>
+        <label class="text-xs text-gray-600">Note</label>
         <input type="text" name="note" placeholder="Optional note..."
-               class="w-full text-xs border border-gray-300 rounded px-2 py-1.5
-                      focus:ring-brand-500 focus:border-brand-500">
+               class="input input-sm">
       </div>
       <button type="submit"
-              class="px-3 py-1.5 bg-brand-500 text-white text-xs font-medium rounded
-                     hover:bg-brand-600 flex-shrink-0">
+              class="btn-primary btn-sm flex-shrink-0">
         Update
       </button>
       {% if lead.contact_email %}
@@ -203,7 +200,7 @@
   </div>
 
   {# ===== Contact Info (compact) ===== #}
-  <div class="bg-white rounded-lg border border-brand-200 p-3">
+  <div class="card-sm">
     <h3 class="text-xs font-semibold text-gray-900 mb-2">Contact</h3>
     <div class="grid grid-cols-3 gap-2 text-xs">
       <div>
@@ -290,7 +287,7 @@
           {% for ev in items %}
           <div class="inline-flex items-center gap-1 px-1.5 py-0.5 bg-gray-50 rounded text-[10px]">
             {% with source_type=ev.source_type %}{% include "htmx/partials/shared/source_badge.html" %}{% endwith %}
-            <span class="text-gray-500">{{ ev.signal_type|replace('_', ' ') }}</span>
+            <span class="text-gray-600">{{ ev.signal_type|replace('_', ' ') }}</span>
           </div>
           {% endfor %}
         </div>
@@ -320,7 +317,7 @@
     {{ collapse_header('Activity (' ~ lead.feedback_events|length ~ ')', 'w-full px-3 py-2 flex items-center justify-between text-left') | indent(4, false) }}
     <div x-show="open" x-cloak x-collapse class="border-t border-gray-100 px-3 py-2 space-y-1">
       {% for event in lead.feedback_events|sort(attribute='created_at', reverse=True) %}
-      <div class="flex items-center gap-2 text-[11px] text-gray-500">
+      <div class="flex items-center gap-2 text-[11px] text-gray-600">
         <span>{{ event.created_at | timesince }}</span>
         <span class="font-medium text-gray-700">{{ event.status|replace('_', ' ')|title }}</span>
         {% if event.note %}

--- a/app/templates/htmx/partials/sourcing/lead_row.html
+++ b/app/templates/htmx/partials/sourcing/lead_row.html
@@ -37,7 +37,7 @@
       'has_stock': 'text-emerald-600',
       'bad_lead': 'text-gray-400 line-through',
     } %}
-    <span class="text-[10px] font-medium {{ status_colors.get(lead.buyer_status, 'text-gray-500') }} flex-shrink-0">
+    <span class="text-xs font-medium {{ status_colors.get(lead.buyer_status, 'text-gray-500') }} flex-shrink-0">
       {{ lead.buyer_status|replace('_', ' ')|title }}
     </span>
     {% endif %}
@@ -65,7 +65,7 @@
     </span>
 
     {# Freshness #}
-    <span class="text-[10px] text-gray-400 flex-shrink-0 w-[40px] text-right">
+    <span class="text-xs text-gray-400 flex-shrink-0 w-[40px] text-right">
       {% if lead.source_last_seen_at %}{{ lead.source_last_seen_at | timesince }}{% else %}--{% endif %}
     </span>
 
@@ -103,10 +103,10 @@
     </span>
     {% endif %}
     {% if lead.reason_summary %}
-    <span class="text-[10px] text-gray-400 truncate">{{ lead.reason_summary }}</span>
+    <span class="text-xs text-gray-400 truncate">{{ lead.reason_summary }}</span>
     {% endif %}
     {% if lead.corroborated %}
-    <span class="text-[10px] text-emerald-600 font-medium flex-shrink-0">✓ {{ lead.evidence_count }}</span>
+    <span class="text-xs text-emerald-600 font-medium flex-shrink-0">✓ {{ lead.evidence_count }}</span>
     {% endif %}
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/sourcing/results.html
+++ b/app/templates/htmx/partials/sourcing/results.html
@@ -11,7 +11,7 @@
     <div>
       {% from "htmx/partials/shared/_mpn_chips.html" import mpn_chips %}
       {{ mpn_chips(requirement) }}
-      <p class="text-sm text-gray-500 mt-1">
+      <p class="text-sm text-gray-600 mt-1">
         {{ requirement.brand or '' }}
         {% if requirement.brand %}&middot;{% endif %}
         {{ total }} lead{{ 's' if total != 1 }} found
@@ -28,8 +28,7 @@
       <button hx-post="/v2/partials/sourcing/{{ requirement.id }}/search"
               hx-target="#main-content"
               data-loading-disable
-              class="px-4 py-2 bg-brand-500 text-white text-sm font-medium rounded-lg
-                     hover:bg-brand-600 flex items-center gap-2">
+              class="btn-primary">
         Re-search
       </button>
     </div>

--- a/app/templates/htmx/partials/sourcing/workspace.html
+++ b/app/templates/htmx/partials/sourcing/workspace.html
@@ -19,7 +19,7 @@
     <div class="flex items-center gap-3">
       {% from "htmx/partials/shared/_mpn_chips.html" import mpn_chips %}
       <div>{{ mpn_chips(requirement) }}</div>
-      <span class="text-xs text-gray-500">
+      <span class="text-xs text-gray-600">
         {{ requirement.brand or '' }}{% if requirement.brand %} · {% endif %}{{ total }} lead{{ 's' if total != 1 }}
       </span>
     </div>
@@ -27,13 +27,12 @@
       <a href="/sourcing/{{ requirement.id }}"
          hx-get="/v2/partials/sourcing/{{ requirement.id }}"
          hx-target="#main-content" hx-push-url="/sourcing/{{ requirement.id }}"
-         class="text-xs text-gray-500 hover:text-brand-500"
+         class="text-xs text-gray-600 hover:text-brand-500"
          title="Switch to card grid view">Grid view</a>
       <button hx-post="/v2/partials/sourcing/{{ requirement.id }}/search"
               hx-target="#main-content"
               data-loading-disable
-              class="px-3 py-1.5 bg-brand-500 text-white text-xs font-medium rounded-lg
-                     hover:bg-brand-600">
+              class="btn-primary btn-sm">
         Re-search
       </button>
     </div>
@@ -74,7 +73,7 @@
 
         {# Pagination #}
         {% if total_pages > 1 %}
-        <div class="px-3 py-2 flex items-center justify-between text-xs text-gray-500 border-t border-gray-200">
+        <div class="px-3 py-2 flex items-center justify-between text-xs text-gray-600 border-t border-gray-200">
           <span>{{ page }} / {{ total_pages }}</span>
           <div class="flex gap-1">
             {% if page > 1 %}
@@ -92,7 +91,7 @@
         {% endif %}
 
         {% else %}
-        <div class="flex flex-col items-center justify-center py-12 text-gray-400">
+        <div class="flex flex-col items-center justify-center py-6 sm:py-8 text-gray-400">
           <svg class="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
                   d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -1567,7 +1567,8 @@ class TestVendorAffinityOnDemand:
             resp = self._get(client, items)
         assert resp.status_code == 200
         assert "Gamma Supply" in resp.text
-        assert "border border-indigo-200 bg-indigo-50 text-indigo-700" in resp.text
+        # Canonical .badge pill (PR3 UX sweep) carries the border; indigo colors preserved.
+        assert "badge bg-indigo-50 text-indigo-700 border-indigo-200" in resp.text
         assert ">affinity</span>" in resp.text
         assert "55%" in resp.text
         assert 'title="Vendor shares commodity tags (3 matching tag(s))"' in resp.text

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -62,7 +62,7 @@ def test_htmx_ajax_calls_have_indicator():
     allowlist: set[tuple[str, int]] = {
         ("app/templates/htmx/base.html", 56),
         ("app/templates/requisitions2/_inline_cell.html", 16),
-        ("app/templates/htmx/partials/sourcing/workspace.html", 177),
+        ("app/templates/htmx/partials/sourcing/workspace.html", 176),
         ("app/templates/htmx/partials/excess/bid_form.html", 16),
         ("app/templates/htmx/partials/parts/cell_edit.html", 12),
         ("app/templates/htmx/partials/parts/cell_edit.html", 26),
@@ -494,7 +494,7 @@ def test_tiny_text_does_not_grow():
 
     Ratchet — sweeps lower this as they bump 10px → text-xs / text-[11px].
     """
-    BASELINE = 229
+    BASELINE = 165
     count = _tpl_substring_count("text-[10px]")
     assert count <= BASELINE, (
         f"text-[10px] usages rose to {count} (baseline {BASELINE}). Use text-xs "
@@ -509,7 +509,7 @@ def test_low_contrast_secondary_text_does_not_grow():
     Ratchet only (decorative icon grays are fine) — caps growth rather than banning
     outright.
     """
-    BASELINE = 839
+    BASELINE = 718
     count = _tpl_substring_count("text-gray-500")
     assert count <= BASELINE, (
         f"text-gray-500 usages rose to {count} (baseline {BASELINE}). Prefer "
@@ -534,7 +534,7 @@ def test_inline_table_cell_padding_does_not_grow():
 
     Ratchet.
     """
-    BASELINE = 647
+    BASELINE = 612
     count = _tpl_regex_count(r'<t[dh][^>]*class="[^"]*\bp[xy]-[0-9]')
     assert count <= BASELINE, (
         f"inline-padded <td>/<th> rose to {count} (baseline {BASELINE}). Use "
@@ -547,7 +547,7 @@ def test_inline_button_sizing_does_not_grow():
 
     Macro files are the canonical source and are excluded. Ratchet.
     """
-    BASELINE = 321
+    BASELINE = 300
     count = _tpl_regex_count(r'<button[^>]*class="[^"]*\bp[xy]-[0-9]', exclude={"_macros.html"})
     assert count <= BASELINE, (
         f"inline-sized <button> rose to {count} (baseline {BASELINE}). Use .btn-sm/md/lg or the btn_* macros."


### PR DESCRIPTION
## What & why

PR 3 of 6 in the app-wide front-end UX consistency pass. Sweeps the **Sourcing** surface onto the canonical design-system layer (PR 1 #413). Class-only, zero behavior change — adopting the locked classes by removing inline drift, plus balanced density trims.

Triaged 58 templates → **45 swept** (sightings, materials + 4 tabs + filters/modals, search dossier blocks, sourcing SSE workspace, manufacturers). Driven by the throttled per-file agent sweep (chunks of 5 to stay under rate limits) with the strict class-only checklist; 2 files that hit a transient 429 I finished by hand. Agents were deliberately conservative — they skipped borderless badges, `border-gray` surfaces, non-canonical button colors, and specificity-owned `.compact-table` cells (anything that would shift a color/border/density).

## What changed (class-only)
`.btn*`/`btn-primary btn-sm` · `.badge` · `.card*` · `.table-cell*`/`.compact-cell*` · `.input`/`.form-label` · **`text-gray-500`→`600`** (body) · `text-[10px]`→`text-xs` · empty-state `p-12`→`p-6 sm:p-8`. The `requisitions2` opp-table core and the SSE results shell got **text-only** safe fixes (locked specs untouched).

**Drift ratchets dropped and re-locked** in `test_static_analysis.py`: text-[10px] 229→**165**, text-gray-500 839→**718**, td/th inline pad 647→**612**, button inline sizing 321→**300**. Also bumped the `sourcing/workspace.html` htmx.ajax allowlist line (177→176, an eyebrow-label edit shifted it).

## Verification
- Full pytest suite: **18,173 passed** — one sightings affinity-chip test updated to assert the canonical `.badge` form (the chip is still a bordered indigo pill; whole sightings module 213/213 green)
- 45/45 changed templates compile; 20 static-analysis guards green at the new tighter baselines
- **Class-only confirmed** on every `tojson`/`hx-vals`/SSE/opp-table file (no load-bearing attribute changed)
- Vite build green; Playwright **`dead-ends` + `requisitions2-visuals`: 32 passed**

Template-only (plus 2 test updates) — no migrations, no schema, no API changes. Builds on PR 1 + PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132w7Ci6y7CSUNfPJmY2XCM