### PR TITLE
feat(enrichment): eBay-title mining — wire eBay connector into the description-grammar ladder

### DIFF
--- a/alembic/versions/096_spec_provenance.py
+++ b/alembic/versions/096_spec_provenance.py
@@ -68,6 +68,7 @@ _SOURCE_TIER_SQL_CASE = (
     "WHEN 'partsurfer_desc' THEN 84 "
     "WHEN 'connector_desc' THEN 84 "
     "WHEN 'desc_parse' THEN 83 "
+    "WHEN 'ebay_title' THEN 83 "
     "WHEN 'fru_desc_parse' THEN 82 "
     "WHEN 'partsurfer' THEN 80 "
     "WHEN 'psref' THEN 80 "

--- a/app/config.py
+++ b/app/config.py
@@ -144,6 +144,11 @@ class Settings(BaseSettings):
     # ladder at partsurfer_desc (tier 84). See app/services/enrichment_worker/partsurfer_resolver.
     partsurfer_desc_enabled: bool = True
     connector_desc_harvest_enabled: bool = True
+    # eBay-title mining: eBay listing TITLES are free-text part descriptions; feed each into
+    # the desc grammar (categorize uncategorized cards + fill facets) at ebay_title/tier 83,
+    # arbitrated by the F1 ladder. Dormant no-op until EBAY_CLIENT_ID/EBAY_CLIENT_SECRET are
+    # set (creds absent → skipped, like every other connector). See enrichment.harvest_ebay_titles.
+    ebay_title_mining_enabled: bool = True
     # Cap on live PartSurfer fetches per batch (each is a polite 1-req/2s GET — the worker
     # paces them). Keeps a batch's wall-time bounded; uncategorized HP cards drain over batches.
     partsurfer_fetch_per_batch: int = 5

--- a/app/services/desc_extractor/_common.py
+++ b/app/services/desc_extractor/_common.py
@@ -75,6 +75,14 @@ PARTSURFER_DESC_CONFIDENCE = 0.90
 CONNECTOR_DESC_SOURCE = "connector_desc"
 CONNECTOR_DESC_CONFIDENCE = 0.90
 
+# eBay-title mining: eBay listing TITLES are external marketplace free-text part
+# descriptions — the same desc grammar run over an eBay Browse title we fetch. External
+# (noisier than a curated distributor description), so it ranks with the card's own
+# desc_parse rather than connector_desc (spec_tiers.SOURCE_TIER: ebay_title=83 = desc_parse
+# 83 < connector_desc 84). See app/services/enrichment.harvest_ebay_titles.
+EBAY_TITLE_SOURCE = "ebay_title"
+EBAY_TITLE_CONFIDENCE = 0.90
+
 # The only commodities the extractor fills specs for — single source of truth shared
 # by extract_desc (routing) and writer.py (card eligibility / the spec'd _HANDLED
 # set). The PSU-vs-CPU wattage guard is structural: only extract_psu can emit the

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -167,19 +167,27 @@ async def enrich_batch(mpns: list[str], db: Session, concurrency: int = 5) -> di
         nonlocal matched, skipped
         async with sem:
             result = await enrich_material_card(mpn, db)
-            if not result:
-                skipped += 1
-                return
 
-            # Apply to card
             card = db.query(MaterialCard).filter_by(normalized_mpn=mpn).first()
             if not card:
                 skipped += 1
                 return
 
-            _apply_enrichment_to_card(card, result, db)
-            matched += 1
-            sources[result["source"]] = sources.get(result["source"], 0) + 1
+            if result:
+                _apply_enrichment_to_card(card, result, db)
+                matched += 1
+                sources[result["source"]] = sources.get(result["source"], 0) + 1
+            else:
+                skipped += 1
+
+            # eBay-title mining runs on EVERY card, not just manufacturer-matched ones:
+            # eBay returns no structured manufacturer, so its value (a free-text title fed
+            # to the desc grammar) is independent of the distributor connectors above and
+            # is exactly what an uncategorized, no-distributor-match card needs. No-op when
+            # the flag is off or eBay creds are absent. Best-effort (swallows its own errors).
+            ebay_written = await harvest_ebay_titles(mpn, card, db)
+            if ebay_written:
+                sources["ebay_title"] = sources.get("ebay_title", 0) + ebay_written
 
     # Process sequentially within the semaphore to avoid SQLAlchemy session issues
     for i, mpn in enumerate(mpns):
@@ -303,6 +311,70 @@ def _harvest_connector_enrichment(card: MaterialCard, enrichment: dict, ladder_s
             record_spec(
                 db, int(card.id), facet_key, value, source=ladder_source, confidence=0.95, schema_cache=schema_cache
             )
+
+
+async def harvest_ebay_titles(mpn: str, card: MaterialCard, db: Session) -> int:
+    """eBay-title mining: feed an eBay listing's TITLE through the desc-grammar ladder.
+
+    eBay titles are free-text part descriptions (the connector returns no structured
+    manufacturer), so — unlike the distributor connectors — eBay has no place in the
+    manufacturer-finding ``_CONNECTOR_CONFIGS`` loop. Instead each Browse listing's title
+    is run through the SAME description-grammar path distributor descriptions use
+    (``categorize_and_record``): it categorizes an UNCATEGORIZED card and fills facets, all
+    arbitrated by the F1 ladder at ``ebay_title``/tier 83 (= the card's own desc_parse, below
+    the curated distributor description connector_desc 84 and the decoders 85). Returns the
+    number of facets written across all titles.
+
+    Gating: a no-op (returns 0, no network) when ``settings.ebay_title_mining_enabled`` is
+    off OR the eBay credentials are absent — so the feature stays dormant until
+    EBAY_CLIENT_ID/EBAY_CLIENT_SECRET are set, exactly like every other connector.
+
+    Best-effort: each title is harvested in its own per-card SAVEPOINT inside
+    ``categorize_and_record`` (a DB-level failure rolls back only that write and re-raises).
+    The caller (``enrich_batch._process_one``) is unguarded, so this function swallows and
+    logs any error to keep the rest of the batch alive. Does not commit — the caller owns
+    the transaction.
+    """
+    from app.config import settings
+
+    if not settings.ebay_title_mining_enabled:
+        return 0
+
+    client_id = get_credential_cached("ebay", "EBAY_CLIENT_ID")
+    client_secret = get_credential_cached("ebay", "EBAY_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        return 0  # dormant until eBay creds exist — safe no-op
+
+    from app.connectors.ebay import EbayConnector
+    from app.services.desc_extractor._common import EBAY_TITLE_CONFIDENCE, EBAY_TITLE_SOURCE
+    from app.services.desc_extractor.writer import categorize_and_record
+
+    written = 0
+    try:
+        connector = EbayConnector(client_id, client_secret)
+        results = await asyncio.wait_for(connector.search(mpn), timeout=15)
+        seen: set[str] = set()
+        for r in results:
+            title = (r.get("ebay_title") or "").strip()
+            if not title or title.lower() in seen:
+                continue
+            seen.add(title.lower())
+            # Fill-only categorize + facet fill; the ladder arbitrates every write, so an
+            # eBay title can never displace a higher-tier (mpn_decode/connector_desc) value.
+            _categorized, n = categorize_and_record(
+                db, card, description=title, source=EBAY_TITLE_SOURCE, confidence=EBAY_TITLE_CONFIDENCE
+            )
+            written += n
+            # Once the card is categorized, later titles for the same MPN only refine facets;
+            # categorize_and_record is fill-only, so it stays cheap. Stop after the first
+            # title that categorizes an uncategorized card to avoid re-parsing every listing.
+            if _categorized:
+                break
+    except TimeoutError:
+        logger.warning("eBay-title mining timed out for {}", mpn)
+    except Exception:
+        logger.exception("eBay-title mining failed for card_id={}", card.id)
+    return written
 
 
 def _run_boost_loop(db: Session, base_query, confidence: float, source: str, label: str, batch_size: int) -> int:

--- a/app/services/spec_tiers.py
+++ b/app/services/spec_tiers.py
@@ -87,6 +87,11 @@ SOURCE_TIER: dict[str, int] = {
     # more authoritative than the card's own desc_parse (83), below the deterministic decoders (85).
     "partsurfer_desc": 84,
     "desc_parse": 83,
+    # eBay listing titles are external marketplace free-text part descriptions — the same
+    # desc grammar run over an eBay Browse title we fetch. Same evidence class as the
+    # card's own desc_parse (83): below the curated distributor description (connector_desc
+    # 84) and the deterministic decoders (mpn_decode 85). See eBay-title-mining.
+    "ebay_title": 83,
     "fru_desc_parse": 82,
     "partsurfer": 80,
     "psref": 80,

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2030,6 +2030,22 @@ owns arbitration in one place:
        return a typed `EnrichSummary(categorized, specs_written)` (frozen dataclass — the
        backfill aggregates it by attribute, not by dict key). Commodities mapped so far:
        capacitors, resistors (the top-demand passives).
+    3.8. enrichment.py::harvest_ebay_titles    — eBay-TITLE mining,
+       source="ebay_title" (tier 83), conf 0.90 (settings.ebay_title_mining_enabled,
+       default ON). Called by enrich_batch._process_one for EVERY card (not only the
+       manufacturer-matched ones): eBay's connector returns NO structured manufacturer,
+       so unlike the distributor connectors eBay has no place in the manufacturer-finding
+       _CONNECTOR_CONFIGS loop — its sole value is the listing TITLE, a free-text part
+       description. Each Browse listing's `ebay_title` is run through the SAME desc grammar
+       distributor descriptions use → writer.categorize_and_record(source="ebay_title",
+       tier 83, conf 0.90): categorizes an UNCATEGORIZED card + fills facets via the F1
+       ladder. ebay_title (83) ties the card's own desc_parse (external marketplace
+       free-text, noisier than a curated distributor description connector_desc 84) and
+       loses to the deterministic decoders (85), so an eBay title can never displace a
+       higher-tier value. DORMANT no-op (returns 0, no network) when the flag is off OR
+       EBAY_CLIENT_ID/EBAY_CLIENT_SECRET are absent (creds gated via get_credential_cached,
+       like every other connector). Best-effort: swallows + logs its own errors so a
+       failure never aborts the unguarded batch loop; commit-free (caller owns the txn).
     4. spec_enrichment_service.py::enrich_card_specs    — AI spec reader,
        source="spec_extraction" (tier 60), facets gated at confidence >= 0.85
        (FACET_MIN_CONF — an AI output-quality floor, not cross-source
@@ -2094,6 +2110,11 @@ SOURCE_TIER  manual:100
                desc grammar; outranks the card's own desc_parse 83, loses to mpn_decode 85,
                ties fru_matrix_decode 84 — different vendors, tie not load-bearing)
              · desc_parse:83
+             · ebay_title:83 (eBay-title mining — an eBay Browse listing TITLE is an
+               external marketplace free-text part description, fed to the same desc
+               grammar; written by enrichment.harvest_ebay_titles. Same evidence class as
+               the card's own desc_parse — external free-text, noisier than a curated
+               distributor description, so below connector_desc 84 and ties desc_parse 83)
              · fru_desc_parse:82 (FRU-linked qual-sheet descriptions — below the card's
                OWN description, above the OEM scrapers)
              · {partsurfer,psref,oem_official}:80 (partsurfer/psref are written by the

--- a/tests/test_ebay_title_mining.py
+++ b/tests/test_ebay_title_mining.py
@@ -1,0 +1,211 @@
+"""tests/test_ebay_title_mining.py — eBay listing TITLES are free-text part
+descriptions; mining them feeds the description-grammar enrichment (the same F1 ladder
+path distributor descriptions use, see connector_desc harvest).
+
+Verifies: the ``ebay_title`` source is registered at tier 83 (and the migration-096 CASE
+stays in sync); a fixture eBay Browse response harvests its titles into the desc grammar,
+landing category + facets via the ladder at ``ebay_title``/83; absent creds (or the flag
+off) is a clean no-op; a harvest failure never aborts the caller.
+
+Depends on: conftest.py (db_session), seed_commodity_schemas, MaterialCard +
+MaterialSpecFacet, spec_tiers.SOURCE_TIER (ebay_title=83), app.services.enrichment.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models import MaterialCard, MaterialSpecFacet
+from app.services import enrichment
+from app.services.commodity_registry import seed_commodity_schemas
+from app.services.desc_extractor._common import EBAY_TITLE_SOURCE
+from app.services.spec_tiers import SOURCE_TIER, tier_for
+from app.services.spec_write_service import record_spec
+
+
+# ── A fixture eBay Browse item_summary/search response ────────────────────────────────
+def _ebay_browse_payload(*titles: str) -> dict:
+    """Shape one eBay Browse ``item_summary/search`` JSON body with the given titles."""
+    return {
+        "itemSummaries": [
+            {
+                "itemId": f"v1|{i}|0",
+                "title": title,
+                "seller": {"username": f"seller{i}"},
+                "price": {"value": "42.00", "currency": "USD"},
+                "condition": "New",
+                "itemWebUrl": f"https://www.ebay.com/itm/{i}",
+            }
+            for i, title in enumerate(titles)
+        ]
+    }
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+def _async_return(value):
+    async def _coro(*a, **k):
+        return value
+
+    return _coro
+
+
+# ── Tier registration ─────────────────────────────────────────────────────────────────
+def test_ebay_title_registered_at_tier_83():
+    assert SOURCE_TIER["ebay_title"] == 83
+    assert tier_for("ebay_title") == 83
+    assert EBAY_TITLE_SOURCE == "ebay_title"
+    # External marketplace free-text title — same evidence class as the card's own
+    # desc_parse; below the curated distributor description (connector_desc 84) and the
+    # deterministic decoders (mpn_decode 85).
+    assert SOURCE_TIER["ebay_title"] == SOURCE_TIER["desc_parse"]
+    assert SOURCE_TIER["ebay_title"] < SOURCE_TIER["connector_desc"]
+    assert SOURCE_TIER["ebay_title"] < SOURCE_TIER["mpn_decode"]
+
+
+def test_migration_096_case_in_sync():
+    """The migration's literal SQL CASE must carry the new source too (its sync test
+    asserts EXACT equality with SOURCE_TIER)."""
+    import importlib.util
+    import os
+
+    path = os.path.join(os.path.dirname(__file__), "..", "alembic", "versions", "096_spec_provenance.py")
+    spec = importlib.util.spec_from_file_location("migration_096_ebay", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert "WHEN 'ebay_title' THEN 83" in mod._SOURCE_TIER_SQL_CASE
+
+
+# ── The harvest itself ─────────────────────────────────────────────────────────────────
+def _facets(db: Session, card_id: int) -> dict:
+    rows = db.query(MaterialSpecFacet).filter_by(material_card_id=card_id).all()
+    return {r.spec_key: r for r in rows}
+
+
+def _run_harvest(db: Session, card: MaterialCard, *titles: str) -> None:
+    """Call the harvest with a mocked eBay Browse fetch + present creds."""
+    payload = _ebay_browse_payload(*titles)
+    with (
+        patch.object(enrichment, "get_credential_cached", return_value="cred"),
+        patch("app.connectors.ebay.http") as http,
+    ):
+        http.post = _async_return(_FakeResponse({"access_token": "tok", "expires_in": 7200}))
+        http.get = _async_return(_FakeResponse(payload))
+        asyncio.run(enrichment.harvest_ebay_titles(card.normalized_mpn, card, db))
+
+
+def test_ebay_title_categorizes_uncategorized_card(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = MaterialCard(normalized_mpn="mem123", display_mpn="MEM123", category=None)
+    db_session.add(card)
+    db_session.flush()
+
+    _run_harvest(db_session, card, "Samsung 16GB (1x16GB) DUAL RANK X4 DDR4-2666 REGISTERED ECC MEMORY")
+    db_session.commit()
+
+    # Title flowed through the desc grammar → categorized + faceted via the F1 ladder.
+    assert card.category == "dram"
+    assert card.category_source == "ebay_title"
+    assert card.category_tier == 83
+    facets = _facets(db_session, card.id)
+    assert "capacity_gb" in facets
+    assert facets["capacity_gb"].source == "ebay_title"
+    assert facets["capacity_gb"].tier == 83
+
+
+def test_ebay_title_loses_to_mpn_decode(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = MaterialCard(normalized_mpn="mem5", display_mpn="MEM5", category="dram")
+    db_session.add(card)
+    db_session.flush()
+    # A higher-tier decoder value lands first.
+    record_spec(db_session, int(card.id), "ddr_type", "DDR4", source="mpn_decode", confidence=0.95, schema_cache=None)
+    db_session.commit()
+
+    # eBay title says DDR3 — must not clobber the mpn_decode DDR4.
+    _run_harvest(db_session, card, "Samsung 8GB DDR3-1600 REGISTERED ECC MEMORY")
+    db_session.commit()
+
+    facets = _facets(db_session, card.id)
+    assert facets["ddr_type"].value_text == "DDR4"
+    assert facets["ddr_type"].source == "mpn_decode"
+
+
+def test_absent_creds_is_noop(db_session: Session):
+    seed_commodity_schemas(db_session)
+    card = MaterialCard(normalized_mpn="mem9", display_mpn="MEM9", category=None)
+    db_session.add(card)
+    db_session.flush()
+
+    # No creds → connector must never be constructed / fetched.
+    calls = {"post": 0, "get": 0}
+
+    def _count(key):
+        async def _coro(*a, **k):
+            calls[key] += 1
+            return _FakeResponse({})
+
+        return _coro
+
+    with (
+        patch.object(enrichment, "get_credential_cached", return_value=None),
+        patch("app.connectors.ebay.http") as http,
+    ):
+        http.post = _count("post")
+        http.get = _count("get")
+        asyncio.run(enrichment.harvest_ebay_titles(card.normalized_mpn, card, db_session))
+    db_session.commit()
+    assert calls == {"post": 0, "get": 0}  # no network when creds absent
+    assert card.category is None
+
+
+def test_flag_off_is_noop(db_session: Session, monkeypatch):
+    seed_commodity_schemas(db_session)
+    monkeypatch.setattr(settings, "ebay_title_mining_enabled", False)
+    card = MaterialCard(normalized_mpn="mem8", display_mpn="MEM8", category=None)
+    db_session.add(card)
+    db_session.flush()
+
+    called = {"n": 0}
+
+    def _cred(*a, **k):
+        called["n"] += 1
+        return "cred"
+
+    with patch.object(enrichment, "get_credential_cached", _cred):
+        asyncio.run(enrichment.harvest_ebay_titles(card.normalized_mpn, card, db_session))
+    db_session.commit()
+    assert card.category is None
+    assert called["n"] == 0  # flag short-circuits before any credential lookup
+
+
+def test_harvest_failure_does_not_propagate(db_session: Session):
+    """A harvest failure is best-effort — caught + logged, never re-raised to the caller."""
+    seed_commodity_schemas(db_session)
+    card = MaterialCard(normalized_mpn="boom1", display_mpn="BOOM1", category=None)
+    db_session.add(card)
+    db_session.flush()
+
+    async def _boom(*a, **k):
+        raise RuntimeError("ebay blew up")
+
+    with (
+        patch.object(enrichment, "get_credential_cached", return_value="cred"),
+        patch("app.connectors.ebay.EbayConnector.search", _boom),
+    ):
+        # Must NOT raise.
+        asyncio.run(enrichment.harvest_ebay_titles(card.normalized_mpn, card, db_session))
+    db_session.commit()
+    assert card.category is None

--- a/tests/test_ebay_title_mining.py
+++ b/tests/test_ebay_title_mining.py
@@ -192,7 +192,8 @@ def test_flag_off_is_noop(db_session: Session, monkeypatch):
 
 
 def test_harvest_failure_does_not_propagate(db_session: Session):
-    """A harvest failure is best-effort — caught + logged, never re-raised to the caller."""
+    """A harvest failure is best-effort — caught + logged, never re-raised to the
+    caller."""
     seed_commodity_schemas(db_session)
     card = MaterialCard(normalized_mpn="boom1", display_mpn="BOOM1", category=None)
     db_session.add(card)

--- a/tests/test_enrichment_service.py
+++ b/tests/test_enrichment_service.py
@@ -484,6 +484,7 @@ class TestEnrichBatch:
                 return_value={"manufacturer": "TI", "source": "digikey", "confidence": 0.95, "category": None},
             ),
             patch("app.services.enrichment._apply_enrichment_to_card"),
+            patch("app.services.enrichment.harvest_ebay_titles", new_callable=AsyncMock, return_value=0),
         ):
             result = await enrich_batch(["lm317t"], db_session)
 
@@ -538,6 +539,7 @@ class TestEnrichBatch:
                 return_value={"manufacturer": "TI", "source": "digikey", "confidence": 0.95, "category": None},
             ),
             patch("app.services.enrichment._apply_enrichment_to_card"),
+            patch("app.services.enrichment.harvest_ebay_titles", new_callable=AsyncMock, return_value=0),
         ):
             result = await enrich_batch(mpns, db_session)
 
@@ -569,6 +571,7 @@ class TestEnrichBatch:
         with (
             patch("app.services.enrichment.enrich_material_card", side_effect=mock_enrich),
             patch("app.services.enrichment._apply_enrichment_to_card"),
+            patch("app.services.enrichment.harvest_ebay_titles", new_callable=AsyncMock, return_value=0),
         ):
             result = await enrich_batch(["p1", "p2"], db_session)
 


### PR DESCRIPTION
## What

eBay listing **TITLES** are free-text part descriptions. This wires the existing (but un-enriched) `EbayConnector` into the enrichment pipeline so each listing title flows through the **same description-grammar path distributor descriptions use** (the PR #328 `connector_desc` precedent) — `writer.categorize_and_record` categorizes an uncategorized `MaterialCard` and fills facets, all arbitrated by the F1 tier ladder.

## How it's wired (tier / source + ladder path)

- **New `SOURCE_TIER` source `ebay_title` at tier 83** — an eBay Browse title is external marketplace free-text, noisier than a curated distributor description, so it **ties the card's own `desc_parse` (83)**, sits **below `connector_desc` (84)** and **below the deterministic decoders (`mpn_decode` 85)**. An eBay title can therefore never displace a higher-tier value.
- New `harvest_ebay_titles(mpn, card, db)` in `app/services/enrichment.py`. The eBay connector returns **no structured manufacturer**, so unlike the distributor connectors it has **no place in the manufacturer-finding `_CONNECTOR_CONFIGS` loop**. Its only value is the title, so the harvest runs on **every card** in `enrich_batch._process_one` (not just manufacturer-matched ones) — the uncategorized, no-distributor-match cohort is exactly where titles help.
- Each `ebay_title` → `categorize_and_record(source="ebay_title", confidence=0.90)` → set_category + record_spec via the ladder.
- Migration 096's literal SQL CASE updated to carry `WHEN 'ebay_title' THEN 83` (its sync test asserts exact equality with `SOURCE_TIER`).

## Gating (dormant until creds exist)

No-op (returns 0, **zero network**) when `settings.ebay_title_mining_enabled` is off **OR** `EBAY_CLIENT_ID` / `EBAY_CLIENT_SECRET` are absent (creds read via `get_credential_cached`, like every other connector). eBay creds are **currently unset**, so this ships **dormant** and activates the moment creds are added — no further deploy needed.

## Safety

Best-effort: `harvest_ebay_titles` swallows + logs its own errors so a failure never aborts the unguarded `enrich_batch` loop; commit-free (caller owns the transaction); per-card SAVEPOINT isolation inside `categorize_and_record`.

## Tests (TDD)

`tests/test_ebay_title_mining.py` — fixture eBay Browse response asserts: titles harvested → category + facets land via the ladder at `ebay_title`/83; loses to `mpn_decode`; absent-creds and flag-off are clean no-ops (no network); harvest failures are isolated. Updated 3 `enrich_batch` unit tests to mock the new harvest.

```
TESTING=1 PYTHONPATH=. python3 -m pytest tests/test_ebay_title_mining.py tests/test_enrichment_service.py tests/test_connector_desc_harvest.py tests/test_spec_tiers.py tests/test_migration_096_spec_provenance.py tests/test_static_analysis.py -q --override-ini="addopts="
```
All pass. ruff + format clean; zero NEW mypy errors (7 pre-existing `Column[...]` errors in `enrichment.py`, identical on main).

## Docs

`docs/APP_MAP_INTERACTIONS.md` — enrichment-writers list (new 3.8) + `SOURCE_TIER` evidence-tiers table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)