### PR TITLE
test(jobs): isolate eBay harvest in TestEnrichBatch (fix main CI red from #418)

### DIFF
--- a/tests/test_jobs_coverage_2.py
+++ b/tests/test_jobs_coverage_2.py
@@ -1730,6 +1730,23 @@ class TestTryConnectorConfig:
 
 
 class TestEnrichBatch:
+    @pytest.fixture(autouse=True)
+    def _isolate_ebay_harvest(self):
+        """enrich_batch (PR #418) calls harvest_ebay_titles for every found card, which
+        looks the eBay credential up in the api_sources table.
+
+        These unit tests drive enrich_batch with a MagicMock db, so that lookup escapes
+        the mock and hits the table-less in-memory engine (no such table: api_sources).
+        eBay harvesting has its own coverage in test_ebay_title_mining.py; isolate it
+        here so these tests stay focused on enrich_batch's match/skip counting.
+        """
+        with patch(
+            "app.services.enrichment.harvest_ebay_titles",
+            new_callable=AsyncMock,
+            return_value=0,
+        ):
+            yield
+
     def test_batch_enrichment(self):
         from app.services.enrichment import enrich_batch
 


### PR DESCRIPTION
## Fixes main CI red (introduced by #418, not a UX change)

PR #418 (eBay-title mining) made `enrich_batch` call `harvest_ebay_titles` for every found card, which resolves the eBay credential from the `api_sources` table. `TestEnrichBatch`'s unit tests drive `enrich_batch` with a `MagicMock` db, so that lookup **escapes the mock** and hits the table-less in-memory test engine:

```
sqlite3.OperationalError: no such table: api_sources
[SQL: SELECT ... FROM api_sources WHERE api_sources.name = 'ebay' ...]
```

This failed `test_batch_enrichment` / `_no_result` / `_periodic_commit`. #418 was merged with this red, so `main` CI has been red since.

**Runtime is unaffected** — `api_sources` exists in production (API-Keys feature); this is purely a unit-test setup gap. eBay harvesting has dedicated coverage in `test_ebay_title_mining.py`, so an autouse fixture patches `harvest_ebay_titles` to a no-op inside `TestEnrichBatch`.

Test-file only.

## Verification
- `tests/test_jobs_coverage_2.py`: **146 passed** (xdist); `TestEnrichBatch`: 4 passed
- ruff + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132w7Ci6y7CSUNfPJmY2XCM