### PR TITLE
build(deps): bump pydantic-settings 2.14.2 + msgpack 1.2.1 (fix main security red)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -146,7 +146,7 @@ matplotlib-inline==0.2.2
     # via ipython
 mdurl==0.1.2
     # via markdown-it-py
-msgpack==1.1.2
+msgpack==1.2.1
     # via cachecontrol
 mypy==2.1.0
     # via
@@ -339,10 +339,15 @@ types-setuptools==82.0.0.20260518
 typing-extensions==4.15.0
     # via
     #   -c requirements.txt
+    #   anyio
+    #   cyclonedx-python-lib
     #   mypy
     #   pyee
+    #   pytest-asyncio
+    #   referencing
     #   schemathesis
     #   sqlalchemy
+    #   starlette
 urllib3==2.7.0
     # via
     #   -c requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -46,7 +46,7 @@ starlette-csrf==3.0.0
 beautifulsoup4==4.15.0
 patchright==1.60.1
 # Typed settings from env vars (fail-fast validation at startup)
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 # SSE streaming for HTMX sourcing progress
 sse-starlette>=3.4.4,<4.0
 # Anthropic Claude API (used by claude_client, enrichment, batch extraction)

--- a/requirements.txt
+++ b/requirements.txt
@@ -139,7 +139,7 @@ pydantic==2.13.4
     #   pydantic-settings
 pydantic-core==2.46.4
     # via pydantic
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
     # via -r requirements.in
 pydyf==0.12.1
     # via weasyprint
@@ -200,6 +200,7 @@ typing-extensions==4.15.0
     # via
     #   alembic
     #   anthropic
+    #   anyio
     #   azure-communication-callautomation
     #   azure-core
     #   beautifulsoup4
@@ -209,6 +210,7 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   pyee
     #   sqlalchemy
+    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via


### PR DESCRIPTION
## Fixes main CI security red (newly-published advisories, not a UX change)

`pip-audit` started flagging two advisories on `main` (they were published in the last hour — PRs #413–420 all passed the security gate):

| Package | From | To | Advisory |
|---|---|---|---|
| `pydantic-settings` (direct) | 2.14.1 | **2.14.2** | GHSA-4xgf-cpjx-pc3j — `NestedSecretsSettingsSource` follows symlinks out of `secrets_dir` + bypasses `secrets_dir_max_size` |
| `msgpack` (transitive, dev) | 1.1.2 | **1.2.1** | GHSA-6v7p-g79w-8964 — `Unpacker` SEGV/DoS on reuse-after-error |

Both are patch-level security bumps. Locks recompiled with `pip-compile` (edit `.in`, recompile — per CLAUDE.md). `pip-audit` now reports **no known vulnerabilities**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132w7Ci6y7CSUNfPJmY2XCM