### PR TITLE
build(deps): recompile locks on py3.13 form (fix lockfile-sync gate after #423)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -339,15 +339,10 @@ types-setuptools==82.0.0.20260518
 typing-extensions==4.15.0
     # via
     #   -c requirements.txt
-    #   anyio
-    #   cyclonedx-python-lib
     #   mypy
     #   pyee
-    #   pytest-asyncio
-    #   referencing
     #   schemathesis
     #   sqlalchemy
-    #   starlette
 urllib3==2.7.0
     # via
     #   -c requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -200,7 +200,6 @@ typing-extensions==4.15.0
     # via
     #   alembic
     #   anthropic
-    #   anyio
     #   azure-communication-callautomation
     #   azure-core
     #   beautifulsoup4
@@ -210,7 +209,6 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   pyee
     #   sqlalchemy
-    #   starlette
     #   typing-inspection
 typing-inspection==0.4.2
     # via


### PR DESCRIPTION
## Fixes main test gate (lockfile-sync) after #423

#423 cleared the security CVEs (pydantic-settings 2.14.2, msgpack 1.2.1) but its locks were recompiled on **Python 3.12**, which emits extra `# via` annotations (e.g. `typing-extensions` via `anyio`/`starlette`) that CI's **Python 3.13** `pip-compile` does not. The "Verify requirements lockfiles are in sync" gate diffs against a fresh 3.13 recompile, so it failed — re-reddening main's test job.

This restores the 3.13-form annotations (from the last CI-validated lock at `c391f988`) and re-applies only the two security pins. Functional dependencies are unchanged; `pip-audit` stays clean. Comment-annotation-only delta (7 `# via` lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132w7Ci6y7CSUNfPJmY2XCM