### PR TITLE
feat(ui): Buy Plans/Quotes/Proactive/Prospect sweep onto canonical layer (UX consistency PR 5/6)

### DIFF
--- a/app/templates/htmx/partials/buy_plans/_board.html
+++ b/app/templates/htmx/partials/buy_plans/_board.html
@@ -15,7 +15,7 @@
    Suppressed via hide_strip when embedded under the supervise lens (which renders
    its own strip above the board). Defaults to shown when the flag is absent. #}
 {% if not hide_strip %}
-<div class="flex items-center gap-4 mb-3 text-xs text-gray-500">
+<div class="flex items-center gap-4 mb-3 text-xs text-gray-600">
   <span>{{ open_cards|length }} open deal{{ 's' if open_cards|length != 1 }}</span>
   <span>${{ '{:,.0f}'.format(open_value) }} open value</span>
   {% if scope == 'all' %}
@@ -45,7 +45,7 @@
         <div class="flex items-start justify-between gap-2">
           <span class="text-sm font-bold text-gray-900 leading-tight">{{ d.customer_name or '-' }}</span>
           {% if d.is_stock_sale %}
-          <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded bg-purple-50 text-purple-600 flex-shrink-0">stock</span>
+          <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded bg-purple-50 text-purple-600 flex-shrink-0">stock</span>
           {% endif %}
         </div>
         {# Value + margin #}
@@ -60,7 +60,7 @@
         </div>
         {# Blocker #}
         {% if d.blocker %}
-        <div class="mt-1.5 text-xs text-gray-500">{{ d.blocker }}</div>
+        <div class="mt-1.5 text-xs text-gray-600">{{ d.blocker }}</div>
         {% endif %}
         {# PO progress bar #}
         {% if d.po_progress[1] %}

--- a/app/templates/htmx/partials/buy_plans/_orders_queue.html
+++ b/app/templates/htmx/partials/buy_plans/_orders_queue.html
@@ -13,7 +13,7 @@
 {% set kicked = queue|selectattr('kicked_back')|list %}
 
 {# ── Slim metric strip (contextual, non-dominating) ── #}
-<div class="flex items-center gap-4 mb-3 text-xs text-gray-500">
+<div class="flex items-center gap-4 mb-3 text-xs text-gray-600">
   <span>{{ queue|length }} PO{{ 's' if queue|length != 1 }} to cut</span>
   {% if kicked %}
   <span class="text-rose-600 font-medium">{{ kicked|length }} kicked back</span>
@@ -106,11 +106,11 @@
   </table>
 </div>
 {% else %}
-<div class="bg-white rounded-lg shadow border border-brand-200 px-4 py-12 text-center">
+<div class="bg-white rounded-lg shadow border border-brand-200 px-4 py-6 sm:py-8 text-center">
   <svg class="mx-auto h-12 w-12 text-emerald-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
   </svg>
-  <p class="text-sm font-medium text-gray-500">You're all caught up — no POs to cut.</p>
+  <p class="text-sm font-medium text-gray-600">You're all caught up — no POs to cut.</p>
 </div>
 {% endif %}
 
@@ -128,7 +128,7 @@
         {% for row in team %}
         {% if row.buyer_name != ns.prev %}
         <tr class="bg-gray-100/60">
-          <td colspan="4" class="px-4 py-1.5 text-xs font-medium text-gray-500">{{ row.buyer_name or 'Unassigned' }}</td>
+          <td colspan="4" class="px-4 py-1.5 text-xs font-medium text-gray-600">{{ row.buyer_name or 'Unassigned' }}</td>
         </tr>
         {% set ns.prev = row.buyer_name %}
         {% endif %}
@@ -145,10 +145,10 @@
           {# Part #}
           <td class="px-4 py-2 font-mono text-xs text-gray-600">{{ row.mpn or '-' }}</td>
           {# Vendor #}
-          <td class="px-4 py-2 text-gray-500">{{ row.vendor_name or '-' }}</td>
+          <td class="px-4 py-2 text-gray-600">{{ row.vendor_name or '-' }}</td>
           {# Qty + status badge #}
           <td class="px-4 py-2 text-right whitespace-nowrap">
-            <span class="text-gray-500">{{ '{:,}'.format(row.quantity) if row.quantity is not none else '-' }}</span>
+            <span class="text-gray-600">{{ '{:,}'.format(row.quantity) if row.quantity is not none else '-' }}</span>
             {% if row.status == 'awaiting_po' %}
             <span class="ml-2 inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-amber-50 text-amber-700">PO to cut</span>
             {% elif row.status == 'pending_verify' %}

--- a/app/templates/htmx/partials/buy_plans/_supervise.html
+++ b/app/templates/htmx/partials/buy_plans/_supervise.html
@@ -15,7 +15,7 @@
 {% set nothing = not (tri.approvals or tri.so_pending or tri.overdue_pos or tri.po_pending_verify or tri.flagged or tri.halted) %}
 
 {# ── Slim metric strip (contextual, non-dominating) ── #}
-<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mb-4 text-xs text-gray-500">
+<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mb-4 text-xs text-gray-600">
   <span>${{ '{:,.0f}'.format(strip.open_value) }} open value</span>
   <span>{{ '{:.1f}'.format(strip.avg_margin) }}% avg margin</span>
   <span>{{ strip.approval_count }} approval{{ 's' if strip.approval_count != 1 }} waiting</span>

--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -68,7 +68,7 @@
         {% endif %}
       </div>
     </div>
-    <div class="mt-1 text-sm text-gray-500 flex flex-wrap gap-x-4">
+    <div class="mt-1 text-sm text-gray-600 flex flex-wrap gap-x-4">
       <span>
         {% if bp.requisition and bp.requisition.customer_name %}
           {{ bp.requisition.customer_name }}
@@ -192,7 +192,7 @@
       <span class="text-sm text-blue-800">Sales Order {{ bp.sales_order_number or '#' }} needs verification.</span>
     </div>
     <button @click="modalType = 'verify-so'; showModal = true"
-            class="flex-shrink-0 px-3 py-1.5 bg-brand-500 text-white text-xs font-medium rounded-md hover:bg-brand-600 transition-colors">
+            class="flex-shrink-0 btn btn-primary btn-sm">
       Verify SO
     </button>
   </div>
@@ -214,7 +214,7 @@
       <span class="text-sm text-blue-800">Plan was rejected. Review notes and resubmit.</span>
     </div>
     <button @click="modalType = 'submit'; showModal = true"
-            class="flex-shrink-0 px-3 py-1.5 bg-brand-500 text-white text-xs font-medium rounded-md hover:bg-brand-600 transition-colors">
+            class="flex-shrink-0 btn btn-primary btn-sm">
       Submit
     </button>
   </div>
@@ -230,7 +230,7 @@
       <span class="text-sm text-blue-800">Ready to submit. Add SO# to proceed.</span>
     </div>
     <button @click="modalType = 'submit'; showModal = true"
-            class="flex-shrink-0 px-3 py-1.5 bg-brand-500 text-white text-xs font-medium rounded-md hover:bg-brand-600 transition-colors">
+            class="flex-shrink-0 btn btn-primary btn-sm">
       Submit
     </button>
   </div>
@@ -240,7 +240,7 @@
   <div class="bg-white rounded-lg shadow-sm overflow-hidden border border-brand-200 mb-6">
     <div class="px-4 py-3 bg-gray-50 border-b border-brand-200">
       <h2 class="text-lg font-semibold text-gray-900">Line Items
-        <span class="ml-1 text-sm font-normal text-gray-500">({{ lines|length }})</span>
+        <span class="ml-1 text-sm font-normal text-gray-600">({{ lines|length }})</span>
       </h2>
     </div>
     <div class="overflow-x-auto">
@@ -265,7 +265,7 @@
             </td>
             {# Description — from MaterialCard (source of truth) #}
             {% set desc = line.requirement|part_description if line.requirement else '' %}
-            <td class="px-4 py-3 text-sm text-gray-500 truncate max-w-[200px]" title="{{ desc }}">
+            <td class="px-4 py-3 text-sm text-gray-600 truncate max-w-[200px]" title="{{ desc }}">
               {{ desc or '-' }}
             </td>
             {# Vendor + buyer below #}
@@ -286,11 +286,11 @@
                 'pending_verify': 'bg-brand-100 text-brand-600',
                 'verified': 'bg-emerald-50 text-emerald-700',
                 'issue': 'bg-rose-50 text-rose-700',
-                'cancelled': 'bg-gray-100 text-gray-500'
+                'cancelled': 'bg-gray-100 text-gray-600'
               } %}
               {{ status_badge(line.status, status_map=line_colors) }}
               {% if line.po_number %}
-              <div class="font-mono text-xs text-gray-500 mt-0.5">{{ line.po_number }}</div>
+              <div class="font-mono text-xs text-gray-600 mt-0.5">{{ line.po_number }}</div>
               {% endif %}
             </td>
             {# Action #}
@@ -357,11 +357,11 @@
           {% endfor %}
           {% if not lines %}
           <tr>
-            <td colspan="7" class="px-4 py-12 text-center">
+            <td colspan="7" class="px-4 py-6 sm:py-8 text-center">
               <svg class="mx-auto h-8 w-8 text-gray-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
               </svg>
-              <p class="text-sm text-gray-500">No line items.</p>
+              <p class="text-sm text-gray-600">No line items.</p>
             </td>
           </tr>
           {% endif %}
@@ -381,7 +381,7 @@
         <svg class="w-4 h-4 text-brand-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
         <span class="text-sm font-semibold text-gray-700">AI Insights</span>
         {% if flag_count > 0 %}
-        <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-amber-100 text-amber-700 text-[10px] font-bold">{{ flag_count }}</span>
+        <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-amber-100 text-amber-700 text-xs font-bold">{{ flag_count }}</span>
         {% endif %}
       </div>
       {{ collapse_chevron("showAi") }}
@@ -458,7 +458,7 @@
         {% if bp.so_status == 'approved' %}
         <svg class="w-4 h-4 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
         {% else %}
-        <span class="inline-flex px-1.5 py-0.5 text-[10px] font-semibold rounded-full bg-amber-50 text-amber-700">pending</span>
+        <span class="inline-flex px-1.5 py-0.5 text-xs font-semibold rounded-full bg-amber-50 text-amber-700">pending</span>
         {% endif %}
       </div>
       {{ collapse_chevron("showSo") }}
@@ -475,7 +475,7 @@
           {{ bp.so_status|capitalize if bp.so_status else 'Pending' }}
         </span>
         {% if bp.so_verified_by %}
-        <span class="text-gray-500">by {{ bp.so_verified_by.name }}</span>
+        <span class="text-gray-600">by {{ bp.so_verified_by.name }}</span>
         {% endif %}
       </div>
       {% if bp.so_rejection_note %}
@@ -531,7 +531,7 @@
                     :hx-vals="JSON.stringify({sales_order_number: so, customer_po_number: cpo, salesperson_notes: notes})"
                     data-loading-disable
                     @click="showModal = false"
-                    class="px-4 py-2 text-sm bg-brand-500 text-white rounded-md hover:bg-brand-600 font-medium transition-colors">
+                    class="btn btn-primary">
               Submit
             </button>
           </div>
@@ -615,7 +615,7 @@
                     :hx-vals="JSON.stringify({action: action, rejection_note: note})"
                     data-loading-disable
                     @click="showModal = false"
-                    class="px-4 py-2 text-sm bg-brand-500 text-white rounded-md hover:bg-brand-600 font-medium transition-colors">
+                    class="btn btn-primary">
               Confirm
             </button>
           </div>
@@ -639,7 +639,7 @@
                     :hx-vals="JSON.stringify({reason: reason})"
                     data-loading-disable
                     @click="showModal = false"
-                    class="px-4 py-2 text-sm bg-rose-500 text-white rounded-md hover:bg-rose-600 font-medium transition-colors">
+                    class="btn btn-danger">
               Cancel Plan
             </button>
           </div>

--- a/app/templates/htmx/partials/offers/_field_macros.html
+++ b/app/templates/htmx/partials/offers/_field_macros.html
@@ -6,7 +6,7 @@
 {# Radio chip selector — drives both a hidden radio input and an Alpine x-model. #}
 {%- macro chip_select(label, name, options, model) -%}
 <div>
-  <label class="block text-xs text-gray-500 mb-1">{{ label }}</label>
+  <label class="block text-xs text-gray-600 mb-1">{{ label }}</label>
   <div class="flex flex-wrap gap-1.5">
     {% for value, text in options %}
     <label class="cursor-pointer">
@@ -22,7 +22,7 @@
 {# Plain optional text input (label + text box pre-filled from prefill dict `p`). #}
 {%- macro text_field(label, name, placeholder, p) -%}
 <div>
-    <label class="block text-xs text-gray-500 mb-1">{{ label }}</label>
+    <label class="block text-xs text-gray-600 mb-1">{{ label }}</label>
     <input type="text" name="{{ name }}" value="{{ p.get(name, '') }}"
            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
            placeholder="{{ placeholder }}">
@@ -32,8 +32,8 @@
 {# Qualification status badge — colored pill with filled/total count or "Unqualified". #}
 {%- macro qual_badge(offer) -%}
 {% set s = offer.qualification_summary %}
-{% set cmap = {'complete':'bg-emerald-50 text-emerald-700','essentials':'bg-amber-50 text-amber-700','incomplete':'bg-rose-50 text-rose-700','unset':'bg-gray-100 text-gray-500'} %}
-<span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full {{ cmap.get(s.status, 'bg-gray-100 text-gray-600') }}"
+{% set cmap = {'complete':'bg-emerald-50 text-emerald-700','essentials':'bg-amber-50 text-amber-700','incomplete':'bg-rose-50 text-rose-700','unset':'bg-gray-100 text-gray-600'} %}
+<span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded-full {{ cmap.get(s.status, 'bg-gray-100 text-gray-600') }}"
       title="{{ s.note or 'Not qualified' }}">
   {% if s.status == 'unset' %}Unqualified{% elif s.total %}{{ s.filled }}/{{ s.total }}{% else %}{{ s.status|capitalize }}{% endif %}
 </span>

--- a/app/templates/htmx/partials/offers/_offer_form_fields.html
+++ b/app/templates/htmx/partials/offers/_offer_form_fields.html
@@ -11,25 +11,25 @@
 {# Row 1: Vendor Name, MPN, Qty Available, Unit Price #}
 <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
   <div>
-    <label class="block text-xs text-gray-500 mb-1">Vendor Name *</label>
+    <label class="block text-xs text-gray-600 mb-1">Vendor Name *</label>
     <input type="text" name="vendor_name" required value="{{ p.get('vendor_name', '') }}"
            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
            placeholder="e.g. Arrow Electronics">
   </div>
   <div>
-    <label class="block text-xs text-gray-500 mb-1">MPN *</label>
+    <label class="block text-xs text-gray-600 mb-1">MPN *</label>
     <input type="text" name="mpn" required value="{{ p.get('mpn') or mpn_default or '' }}"
            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
            placeholder="e.g. LM317T">
   </div>
   <div>
-    <label class="block text-xs text-gray-500 mb-1">Qty Available</label>
+    <label class="block text-xs text-gray-600 mb-1">Qty Available</label>
     <input type="number" name="qty_available" min="1" value="{{ p.get('qty_available', '') }}"
            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
            placeholder="5000">
   </div>
   <div>
-    <label class="block text-xs text-gray-500 mb-1">Unit Price (USD)</label>
+    <label class="block text-xs text-gray-600 mb-1">Unit Price (USD)</label>
     <input type="number" name="unit_price" step="0.0001" min="0" value="{{ p.get('unit_price', '') }}"
            class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
            placeholder="0.4500">
@@ -41,20 +41,20 @@
 
 {# More details — remaining optional fields in a collapsible panel #}
 <details class="mt-1">
-  <summary class="text-xs text-gray-500 cursor-pointer">More details</summary>
+  <summary class="text-xs text-gray-600 cursor-pointer">More details</summary>
   <div class="mt-2 space-y-3">
 
     {# Row 2 (minus condition): Manufacturer, Lead Time, Date Code #}
     <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Manufacturer</label>
+        <label class="block text-xs text-gray-600 mb-1">Manufacturer</label>
         <input type="text" name="manufacturer" x-model="manufacturer" value="{{ p.get('manufacturer', '') }}"
                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
                placeholder="e.g. Texas Instruments">
       </div>
       {{ text_field('Lead Time', 'lead_time', '2-3 weeks', p) }}
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Date Code</label>
+        <label class="block text-xs text-gray-600 mb-1">Date Code</label>
         <input type="text" name="date_code" x-model="date_code" value="{{ p.get('date_code', '') }}"
                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
                placeholder="2025+">
@@ -64,19 +64,19 @@
     {# Row 3: MOQ, SPQ, Packaging (for new condition), Firmware #}
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
       <div>
-        <label class="block text-xs text-gray-500 mb-1">MOQ</label>
+        <label class="block text-xs text-gray-600 mb-1">MOQ</label>
         <input type="number" name="moq" min="1" value="{{ p.get('moq', '') }}"
                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
                placeholder="1">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">SPQ</label>
+        <label class="block text-xs text-gray-600 mb-1">SPQ</label>
         <input type="number" name="spq" min="1" value="{{ p.get('spq', '') }}"
                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
                placeholder="1">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Packaging</label>
+        <label class="block text-xs text-gray-600 mb-1">Packaging</label>
         <input type="text" name="packaging" x-model="packaging" value="{{ p.get('packaging', '') }}"
                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
                placeholder="e.g. Tape & Reel">
@@ -90,7 +90,7 @@
       {{ text_field('Warranty', 'warranty', 'e.g. 1 year', p) }}
       {{ text_field('Country of Origin', 'country_of_origin', 'e.g. US, CN', p) }}
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Valid Until</label>
+        <label class="block text-xs text-gray-600 mb-1">Valid Until</label>
         <input type="date" name="valid_until" value="{{ p.get('valid_until', '') }}"
                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
       </div>

--- a/app/templates/htmx/partials/offers/_qualification_fields.html
+++ b/app/templates/htmx/partials/offers/_qualification_fields.html
@@ -19,7 +19,7 @@
 <div class="space-y-3 rounded-md bg-gray-50 p-3">
   {# Condition spine #}
   <div>
-    <label class="block text-xs text-gray-500 mb-1">Condition *</label>
+    <label class="block text-xs text-gray-600 mb-1">Condition *</label>
     <select name="condition" x-model="condition"
             class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
       <option value="">— choose —</option>
@@ -40,7 +40,7 @@
     {{ chip_select('Packaging *', 'packaging', PACKAGING_OPTS, 'packaging') }}
     {{ chip_select('Usage *', 'usage', [('boards', 'Pulled from boards'), ('systems', 'Pulled from systems')], 'usage') }}
     <div>
-      <label class="block text-xs text-gray-500 mb-1">Part condition</label>
+      <label class="block text-xs text-gray-600 mb-1">Part condition</label>
       <input type="text" name="part_condition" x-model="part_condition" value="{{ p.get('part_condition', '') }}"
              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
              placeholder="e.g. light wear, clean">
@@ -51,7 +51,7 @@
   <div x-show="condition === 'refurb'" x-cloak class="space-y-2">
     {{ chip_select('Refurbished by *', 'refurbished_by', [('supplier', 'Supplier'), ('third_party', '3rd party')], 'refurbished_by') }}
     <div>
-      <label class="block text-xs text-gray-500 mb-1">Process *</label>
+      <label class="block text-xs text-gray-600 mb-1">Process *</label>
       <input type="text" name="refurb_process" x-model="refurb_process" value="{{ p.get('refurb_process', '') }}"
              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
              placeholder="What was done, and how">
@@ -65,7 +65,7 @@
   <div x-show="condition" x-cloak class="text-xs">
     <div class="text-gray-400 mb-0.5">Standardized note (auto)</div>
     <div class="rounded bg-white border border-gray-200 px-2 py-1 text-gray-700" x-text="noteText() || '—'"></div>
-    <div class="mt-1 text-gray-500" x-show="meterTotal() > 0">
+    <div class="mt-1 text-gray-600" x-show="meterTotal() > 0">
       Qualified <span x-text="meterFilled()"></span>/<span x-text="meterTotal()"></span>
     </div>
   </div>

--- a/app/templates/htmx/partials/offers/review_queue.html
+++ b/app/templates/htmx/partials/offers/review_queue.html
@@ -8,7 +8,7 @@
 <div id="review-queue-content" class="max-w-7xl mx-auto">
   <div class="flex items-center justify-between mb-6">
     <div>
-      <p class="text-sm text-gray-500 mt-1">
+      <p class="text-sm text-gray-600 mt-1">
         <span class="font-medium text-amber-600">{{ offers|length }}</span> offer{{ 's' if offers|length != 1 }} pending review
       </p>
     </div>
@@ -34,7 +34,7 @@
               <span class="text-amber-700 font-medium">{{ (o.parse_confidence * 100)|int }}%</span>
               {% else %}
               <span class="w-2 h-2 rounded-full bg-gray-400"></span>
-              <span class="text-gray-500">{{ (o.parse_confidence * 100)|int if o.parse_confidence else 0 }}%</span>
+              <span class="text-gray-600">{{ (o.parse_confidence * 100)|int if o.parse_confidence else 0 }}%</span>
               {% endif %}
             </span>
             {% endif %}
@@ -115,7 +115,7 @@
     {% endfor %}
   </div>
   {% else %}
-  <div class="bg-white rounded-lg border border-brand-200 p-12 text-center">
+  <div class="bg-white rounded-lg border border-brand-200 p-6 sm:p-8 text-center">
     <svg class="mx-auto h-12 w-12 text-emerald-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
     </svg>

--- a/app/templates/htmx/partials/proactive/_macros.html
+++ b/app/templates/htmx/partials/proactive/_macros.html
@@ -17,13 +17,13 @@
         <div class="flex-1 min-w-0">
           <h3 class="text-sm font-semibold text-gray-900 truncate">{{ group.company_name | default(default_name) }}</h3>
           {% if group.site_name %}
-          <span class="text-xs text-gray-500">{{ group.site_name }}</span>
+          <span class="text-xs text-gray-600">{{ group.site_name }}</span>
           {% endif %}
         </div>{% endmacro %}
 
 {# Empty-state card for a tab with no rows. icon_path is the <path d="…"> value
    for the centred outline icon; title/subtitle are the two lines of copy. #}
-{% macro empty_state(icon_path, title, subtitle) %}    <div class="bg-white rounded-lg border border-brand-200 p-12 text-center">
+{% macro empty_state(icon_path, title, subtitle) %}    <div class="bg-white rounded-lg border border-brand-200 p-6 sm:p-8 text-center">
       <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
         <path stroke-linecap="round" stroke-linejoin="round" d="{{ icon_path }}"/>
       </svg>

--- a/app/templates/htmx/partials/proactive/_match_row.html
+++ b/app/templates/htmx/partials/proactive/_match_row.html
@@ -21,7 +21,7 @@
     <p class="text-xs text-gray-400 mt-0.5">{{ match.manufacturer }}</p>
     {% endif %}
     {% if match.customer_purchase_count %}
-    <span class="inline-flex items-center gap-0.5 text-[10px] text-gray-400 mt-0.5"
+    <span class="inline-flex items-center gap-0.5 text-xs text-gray-400 mt-0.5"
           title="Customer bought {{ match.customer_purchase_count }}x{% if match.customer_last_purchased_at %}, last {{ match.customer_last_purchased_at }}{% endif %}">
       <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
       {{ match.customer_purchase_count }}&times;
@@ -32,9 +32,9 @@
   <td class="px-3 py-2.5 text-sm text-gray-700">
     {{ match.vendor_name | default('--') }}
     {% if match.ghost_rate is not none and match.ghost_rate > 30 %}
-    <span class="ml-1 text-[10px] text-rose-500 font-medium">unreliable</span>
+    <span class="ml-1 text-xs text-rose-500 font-medium">unreliable</span>
     {% elif match.vendor_score is not none and match.vendor_score >= 70 %}
-    <span class="ml-1 text-[10px] text-emerald-500 font-medium">trusted</span>
+    <span class="ml-1 text-xs text-emerald-500 font-medium">trusted</span>
     {% endif %}
   </td>
   {# Qty #}
@@ -48,23 +48,23 @@
   {# Margin pill #}
   <td class="px-3 py-2.5">
     {% if match.margin_pct is not none %}
-    <span class="inline-flex px-1.5 py-0.5 text-[10px] font-semibold rounded
+    <span class="inline-flex px-1.5 py-0.5 text-xs font-semibold rounded
       {{ 'bg-emerald-50 text-emerald-700' if match.margin_pct >= 20 else
          'bg-amber-50 text-amber-700' if match.margin_pct >= 10 else
          'bg-rose-50 text-rose-700' }}">
       {{ "%.0f"|format(match.margin_pct) }}%
     </span>
     {% else %}
-    <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded bg-gray-100 text-gray-400">N/A</span>
+    <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded bg-gray-100 text-gray-400">N/A</span>
     {% endif %}
   </td>
   {# Score pill #}
   <td class="px-3 py-2.5">
     {% set score = match.match_score|default(0) %}
-    <span class="inline-flex px-1.5 py-0.5 text-[10px] font-bold rounded
+    <span class="inline-flex px-1.5 py-0.5 text-xs font-bold rounded
       {{ 'bg-emerald-50 text-emerald-700' if score >= 75 else
          'bg-amber-50 text-amber-700' if score >= 50 else
-         'bg-gray-100 text-gray-500' }}">
+         'bg-gray-100 text-gray-600' }}">
       {{ score }}
     </span>
   </td>
@@ -79,7 +79,7 @@
       <input type='hidden' name='company_id' value='{{ group.company_id | default("") }}'>
       <button type='submit'
               title="Never offer this part to this customer"
-              class='text-[10px] text-gray-400 hover:text-rose-500 transition-colors px-1.5 py-0.5 rounded hover:bg-rose-50'>
+              class='text-xs text-gray-400 hover:text-rose-500 transition-colors px-1.5 py-0.5 rounded hover:bg-rose-50'>
         Don&rsquo;t offer
       </button>
     </form>

--- a/app/templates/htmx/partials/proactive/list.html
+++ b/app/templates/htmx/partials/proactive/list.html
@@ -11,7 +11,7 @@
   {# Header #}
   <div class="flex items-center justify-between mb-6">
     <div>
-      <p class="text-sm text-gray-500 mt-1">AI-matched vendor stock to customer purchase history</p>
+      <p class="text-sm text-gray-600 mt-1">AI-matched vendor stock to customer purchase history</p>
     </div>
     <button @click="showScorecard = !showScorecard"
             class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-brand-600 bg-brand-50 border border-brand-200 rounded-lg hover:bg-brand-100 transition-colors">
@@ -57,7 +57,7 @@
       </svg>
       Matches
       {% if match_count|default(0) > 0 %}
-      <span class="ml-auto px-1.5 py-0.5 text-[10px] font-bold text-white bg-emerald-500 rounded-full">{{ match_count }}</span>
+      <span class="ml-auto px-1.5 py-0.5 text-xs font-bold text-white bg-emerald-500 rounded-full">{{ match_count }}</span>
       {% endif %}
     </a>
     <a hx-get="/v2/partials/proactive?tab=sent" hx-target="#main-content"
@@ -105,7 +105,7 @@
         <span class="text-xs text-gray-400 mr-2">{{ group.matches|length }} match{{ 'es' if group.matches|length != 1 }}</span>
 
         {# Select all checkbox #}
-        <label class="flex items-center gap-1 text-xs text-gray-500 cursor-pointer mr-2">
+        <label class="flex items-center gap-1 text-xs text-gray-600 cursor-pointer mr-2">
           <input type="checkbox" @change="toggleAll()"
                  :checked="selectedCount === {{ group.matches|length }}"
                  class="rounded border-gray-300 text-brand-500 focus:ring-brand-500">
@@ -151,12 +151,12 @@
             <thead class="bg-gray-50/50">
               <tr>
                 <th class="w-10 px-3 py-2"></th>
-                <th class="px-3 py-2 text-left text-[10px] font-medium text-gray-500 uppercase tracking-wider">MPN</th>
-                <th class="px-3 py-2 text-left text-[10px] font-medium text-gray-500 uppercase tracking-wider w-[140px]">Vendor</th>
-                <th class="px-3 py-2 text-right text-[10px] font-medium text-gray-500 uppercase tracking-wider w-[80px]">Qty</th>
-                <th class="px-3 py-2 text-right text-[10px] font-medium text-gray-500 uppercase tracking-wider w-[90px]">Price</th>
-                <th class="px-3 py-2 text-left text-[10px] font-medium text-gray-500 uppercase tracking-wider w-[70px]">Margin</th>
-                <th class="px-3 py-2 text-left text-[10px] font-medium text-gray-500 uppercase tracking-wider w-[60px]">Score</th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN</th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[140px]">Vendor</th>
+                <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-[80px]">Qty</th>
+                <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-[90px]">Price</th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[70px]">Margin</th>
+                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[60px]">Score</th>
                 <th class="px-3 py-2 w-[90px]"></th>
               </tr>
             </thead>
@@ -171,7 +171,7 @@
     </div>
     {% endfor %}
   {% else %}
-  <div class="bg-white rounded-lg border border-brand-200 p-12 text-center">
+  <div class="bg-white rounded-lg border border-brand-200 p-6 sm:p-8 text-center">
     <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
     </svg>
@@ -181,7 +181,7 @@
             hx-target="#main-content"
             hx-swap="innerHTML"
             data-loading-disable
-            class="mt-6 inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 transition-colors disabled:opacity-50">
+            class="mt-6 btn-primary">
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
       </svg>
@@ -206,12 +206,12 @@
         <table class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50/50">
             <tr>
-              <th class="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase tracking-wider">Parts</th>
-              <th class="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase tracking-wider">Sent To</th>
-              <th class="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase tracking-wider">Sent</th>
-              <th class="px-4 py-2 text-right text-[10px] font-medium text-gray-500 uppercase tracking-wider">Revenue</th>
-              <th class="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase tracking-wider">Status</th>
-              <th class="px-4 py-2 text-right text-[10px] font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Parts</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Sent To</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Sent</th>
+              <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Revenue</th>
+              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+              <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-100">
@@ -236,10 +236,10 @@
                   {% endfor %}
                 </div>
               </td>
-              <td class="px-4 py-3 text-xs text-gray-500">
+              <td class="px-4 py-3 text-xs text-gray-600">
                 {{ offer.recipient_emails | join(', ') | truncate(40) }}
               </td>
-              <td class="px-4 py-3 text-xs text-gray-500">
+              <td class="px-4 py-3 text-xs text-gray-600">
                 {{ offer.sent_at | timeago }}
               </td>
               <td class="px-4 py-3 text-sm text-right tabular-nums">
@@ -249,7 +249,7 @@
               </td>
               <td class="px-4 py-3">
                 {% set status = offer.status | default('sent') %}
-                <span class="inline-flex px-2 py-0.5 text-[10px] font-semibold rounded-full
+                <span class="inline-flex px-2 py-0.5 text-xs font-semibold rounded-full
                   {{ 'bg-emerald-50 text-emerald-700' if status == 'converted' else
                      'bg-brand-50 text-brand-600' if status == 'sent' else
                      'bg-gray-100 text-gray-600' }}">

--- a/app/templates/htmx/partials/proactive/prepare.html
+++ b/app/templates/htmx/partials/proactive/prepare.html
@@ -32,7 +32,7 @@
   {# Header #}
   <h1 class="text-xl font-bold text-gray-900 mb-1">Prepare Offer — {{ company_name }}</h1>
   {% if site_name %}
-  <p class="text-sm text-gray-500 mb-6">{{ site_name }}</p>
+  <p class="text-sm text-gray-600 mb-6">{{ site_name }}</p>
   {% endif %}
 
   {# Error banner #}
@@ -51,12 +51,12 @@
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50/50">
           <tr>
-            <th class="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase">MPN</th>
-            <th class="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase">Vendor</th>
-            <th class="px-4 py-2 text-right text-[10px] font-medium text-gray-500 uppercase">Qty</th>
-            <th class="px-4 py-2 text-right text-[10px] font-medium text-gray-500 uppercase">Cost</th>
-            <th class="px-4 py-2 text-right text-[10px] font-medium text-gray-500 uppercase">Sell Price</th>
-            <th class="px-4 py-2 text-left text-[10px] font-medium text-gray-500 uppercase">Margin</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">MPN</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
+            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Qty</th>
+            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Cost</th>
+            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Sell Price</th>
+            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Margin</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
@@ -92,14 +92,14 @@
             </td>
             <td class="px-4 py-2.5">
               {% if m.margin_pct is not none %}
-              <span class="inline-flex px-1.5 py-0.5 text-[10px] font-semibold rounded
+              <span class="inline-flex px-1.5 py-0.5 text-xs font-semibold rounded
                 {{ 'bg-emerald-50 text-emerald-700' if m.margin_pct >= 20 else
                    'bg-amber-50 text-amber-700' if m.margin_pct >= 10 else
                    'bg-rose-50 text-rose-700' }}">
                 {{ "%.0f"|format(m.margin_pct) }}%
               </span>
               {% else %}
-              <span class="text-[10px] text-gray-400">N/A</span>
+              <span class="text-xs text-gray-400">N/A</span>
               {% endif %}
             </td>
           </tr>
@@ -126,7 +126,7 @@
                  class="rounded border-gray-300 text-brand-500 focus:ring-brand-500 disabled:opacity-40">
           <div class="flex-1 min-w-0">
             <p class="text-sm font-medium text-gray-900">{{ c.full_name or '(unnamed)' }}</p>
-            <p class="text-xs text-gray-500">
+            <p class="text-xs text-gray-600">
               {{ c.email or '(no email)' }}
               {% if c.title %} &middot; {{ c.title }}{% endif %}
               {% if c.is_primary %}
@@ -138,7 +138,7 @@
         {% endfor %}
       {% else %}
         <div class="text-center py-6">
-          <p class="text-sm text-gray-500">No contacts on file.</p>
+          <p class="text-sm text-gray-600">No contacts on file.</p>
         </div>
       {% endif %}
     </div>
@@ -168,7 +168,7 @@
         <label for="subject-input" class="block text-xs font-medium text-gray-600 mb-1">Subject</label>
         <input type="text" name="subject" id="subject-input"
                value="Parts Available — {{ company_name }}"
-               class="w-full rounded-lg border-gray-300 text-sm focus:border-brand-500 focus:ring-brand-500">
+               class="input">
       </div>
 
       {# Body #}
@@ -176,7 +176,7 @@
         <label for="body-input" class="block text-xs font-medium text-gray-600 mb-1">Body</label>
         <textarea name="body" id="body-input" rows="6"
                   placeholder="Type your message or use AI draft..."
-                  class="w-full rounded-lg border-gray-300 text-sm focus:border-brand-500 focus:ring-brand-500"></textarea>
+                  class="input"></textarea>
       </div>
 
       {# AI Draft button #}

--- a/app/templates/htmx/partials/proactive/scorecard.html
+++ b/app/templates/htmx/partials/proactive/scorecard.html
@@ -29,7 +29,7 @@
     </div>
     {# Row 2 — money #}
     <div class="bg-gray-50 rounded-lg p-3 text-center border border-gray-200">
-      <p class="text-xs text-gray-500 font-medium mb-1">Revenue</p>
+      <p class="text-xs text-gray-600 font-medium mb-1">Revenue</p>
       <p class="text-2xl font-bold text-gray-900">${{ "{:,.0f}".format(stats.get('converted_revenue', 0)) }}</p>
     </div>
     <div class="bg-emerald-50 rounded-lg p-3 text-center border border-emerald-100">

--- a/app/templates/htmx/partials/prospecting/_card.html
+++ b/app/templates/htmx/partials/prospecting/_card.html
@@ -48,7 +48,7 @@
     <div class="mb-2">
       {% set fit = prospect.fit_score or 0 %}
       <div class="flex items-center justify-between text-xs mb-0.5">
-        <span class="text-gray-500">Fit <span class="text-gray-300">(ICP match)</span></span>
+        <span class="text-gray-600">Fit <span class="text-gray-300">(ICP match)</span></span>
         <span class="font-medium {{ score.score_text_color(fit) }}">{{ fit }}%</span>
       </div>
       <div class="w-full h-1.5 bg-gray-200 rounded-full overflow-hidden">
@@ -58,7 +58,7 @@
     <div class="mb-2.5">
       {% set ready = prospect.readiness_score or 0 %}
       <div class="flex items-center justify-between text-xs mb-0.5">
-        <span class="text-gray-500">Readiness <span class="text-gray-300">(timing)</span></span>
+        <span class="text-gray-600">Readiness <span class="text-gray-300">(timing)</span></span>
         <span class="font-medium {{ score.score_text_color(ready) }}">{{ ready }}%</span>
       </div>
       <div class="w-full h-1.5 bg-gray-200 rounded-full overflow-hidden">
@@ -73,7 +73,7 @@
     <div class="mb-2">
       {% set match = ai_screen.get('trio_match_score', 0) %}
       <div class="flex items-center justify-between text-xs mb-0.5">
-        <span class="text-gray-500">AI Match <span class="text-gray-300">(procurement fit)</span></span>
+        <span class="text-gray-600">AI Match <span class="text-gray-300">(procurement fit)</span></span>
         <span class="font-medium {{ score.score_text_color(match) }}">{{ match }}%</span>
       </div>
       <div class="w-full h-1.5 bg-gray-200 rounded-full overflow-hidden">
@@ -96,7 +96,7 @@
     {% endif %}
 
     {# Industry · Region · contacts #}
-    <div class="flex items-center flex-wrap gap-x-2 gap-y-0.5 text-xs text-gray-500">
+    <div class="flex items-center flex-wrap gap-x-2 gap-y-0.5 text-xs text-gray-600">
       {% if prospect.industry %}<span class="truncate max-w-[55%]">{{ prospect.industry }}</span>{% endif %}
       {% if prospect.industry and prospect.region %}<span class="text-gray-300">&middot;</span>{% endif %}
       {% if prospect.region %}<span>{{ prospect.region }}</span>{% endif %}
@@ -109,10 +109,10 @@
     {# Discovery source + claimed-by #}
     <div class="mt-2 flex items-center justify-between">
       {% if prospect.discovery_source %}
-      <span class="inline-flex px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-500 rounded-full">{{ prospect.discovery_source }}</span>
+      <span class="inline-flex px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 rounded-full">{{ prospect.discovery_source }}</span>
       {% else %}<span></span>{% endif %}
       {% if prospect.status == 'claimed' and prospect.claimed_by_user %}
-      <span class="text-xs text-gray-500">Claimed by {{ prospect.claimed_by_user.name|default('—') }}</span>
+      <span class="text-xs text-gray-600">Claimed by {{ prospect.claimed_by_user.name|default('—') }}</span>
       {% endif %}
     </div>
   </a>

--- a/app/templates/htmx/partials/prospecting/detail.html
+++ b/app/templates/htmx/partials/prospecting/detail.html
@@ -33,7 +33,7 @@
             {{ prospect.status|capitalize }}
           </span>
           {% if prospect.claimed_by_user %}
-          <span class="text-sm text-gray-500">Claimed by {{ prospect.claimed_by_user.name }}</span>
+          <span class="text-sm text-gray-600">Claimed by {{ prospect.claimed_by_user.name }}</span>
           {% endif %}
         </div>
       </div>
@@ -92,7 +92,7 @@
   <div class="bg-white border {{ 'border-emerald-300' if snapshot.is_buyer_ready else 'border-brand-200' }} rounded-lg p-5 mb-6">
     <div class="flex items-center justify-between mb-3">
       <div class="flex items-center gap-3">
-        <span class="text-sm font-medium text-gray-500">Buyer-ready score</span>
+        <span class="text-sm font-medium text-gray-600">Buyer-ready score</span>
         <span class="text-2xl font-bold {{ score.score_text_color(snapshot.buyer_ready_score) }}">{{ snapshot.buyer_ready_score }}<span class="text-sm text-gray-400">/100</span></span>
       </div>
       {% if snapshot.is_buyer_ready %}
@@ -119,20 +119,20 @@
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
     {# Fit score #}
     <div class="bg-white border border-brand-200 rounded-lg p-6">
-      <div class="text-sm font-medium text-gray-500 mb-2">Fit Score <span class="text-gray-300">· ICP match</span></div>
+      <div class="text-sm font-medium text-gray-600 mb-2">Fit Score <span class="text-gray-300">· ICP match</span></div>
       {% set fit = prospect.fit_score or 0 %}
       <div class="text-3xl font-bold {{ score.score_text_color(fit) }}">{{ fit }}%</div>
       <div class="mt-3 w-full h-2.5 bg-gray-200 rounded-full overflow-hidden">
         <div class="h-full rounded-full transition-all {{ score.score_bar_color(fit) }}" style="width: {{ fit }}%"></div>
       </div>
       {% if prospect.fit_reasoning %}
-      <p class="mt-3 text-xs text-gray-500 leading-relaxed">{{ prospect.fit_reasoning }}</p>
+      <p class="mt-3 text-xs text-gray-600 leading-relaxed">{{ prospect.fit_reasoning }}</p>
       {% endif %}
     </div>
 
     {# Readiness score #}
     <div class="bg-white border border-brand-200 rounded-lg p-6">
-      <div class="text-sm font-medium text-gray-500 mb-2">Readiness Score <span class="text-gray-300">· near-term timing</span></div>
+      <div class="text-sm font-medium text-gray-600 mb-2">Readiness Score <span class="text-gray-300">· near-term timing</span></div>
       {% set ready = prospect.readiness_score or 0 %}
       <div class="text-3xl font-bold {{ score.score_text_color(ready) }}">{{ ready }}%</div>
       <div class="mt-3 w-full h-2.5 bg-gray-200 rounded-full overflow-hidden">
@@ -180,17 +180,17 @@
       <div class="text-center">
         <p class="text-2xl font-bold {{ 'text-emerald-600' if match >= 70 else ('text-amber-600' if match >= 40 else 'text-rose-600') }}">
           {{ match }}</p>
-        <p class="text-xs text-gray-500 mt-0.5">Match</p>
+        <p class="text-xs text-gray-600 mt-0.5">Match</p>
       </div>
       {% set opp = ai_screen.get('opportunity_score', 0) %}
       <div class="text-center">
         <p class="text-2xl font-bold text-gray-700">{{ opp }}</p>
-        <p class="text-xs text-gray-500 mt-0.5">Opportunity</p>
+        <p class="text-xs text-gray-600 mt-0.5">Opportunity</p>
       </div>
       {% set excess = ai_screen.get('excess_likelihood', 0) %}
       <div class="text-center">
-        <p class="text-2xl font-bold text-gray-500">{{ excess }}</p>
-        <p class="text-xs text-gray-500 mt-0.5">Excess</p>
+        <p class="text-2xl font-bold text-gray-600">{{ excess }}</p>
+        <p class="text-xs text-gray-600 mt-0.5">Excess</p>
       </div>
     </div>
 
@@ -201,7 +201,7 @@
 
     {# Evidence list #}
     {% if ai_screen.get('evidence') %}
-    <ul class="text-xs text-gray-500 space-y-0.5 mb-3">
+    <ul class="text-xs text-gray-600 space-y-0.5 mb-3">
       {% for item in ai_screen.evidence %}
       <li class="truncate">&bull; {{ item }}</li>
       {% endfor %}
@@ -231,7 +231,7 @@
       <div class="py-2.5 flex items-center justify-between gap-3">
         <div class="min-w-0">
           <p class="text-sm font-medium text-gray-900 truncate">{{ c.get('name', 'Unknown') }}</p>
-          {% if c.get('title') %}<p class="text-xs text-gray-500 truncate">{{ c.title }}</p>{% endif %}
+          {% if c.get('title') %}<p class="text-xs text-gray-600 truncate">{{ c.title }}</p>{% endif %}
           {% if c.get('email') %}<p class="text-xs text-brand-400 truncate">{{ c.email }}</p>{% endif %}
         </div>
         <div class="shrink-0 flex items-center gap-1.5">
@@ -244,7 +244,7 @@
             Verified
           </span>
           {% else %}
-          <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-500">Unverified</span>
+          <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600">Unverified</span>
           {% endif %}
         </div>
       </div>
@@ -270,7 +270,7 @@
   {# Discovery info #}
   <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6">
     <div class="flex items-center gap-3 text-sm">
-      <span class="text-gray-500">Discovery Source:</span>
+      <span class="text-gray-600">Discovery Source:</span>
       <span class="inline-flex px-2.5 py-0.5 text-xs font-medium bg-brand-100 text-brand-600 rounded-full">
         {{ prospect.discovery_source }}
       </span>
@@ -342,7 +342,7 @@
     <svg class="mx-auto w-8 h-8 text-brand-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
     </svg>
-    <p class="text-sm text-gray-500">No enrichment data yet.</p>
+    <p class="text-sm text-gray-600">No enrichment data yet.</p>
     <p class="text-xs text-gray-400 mt-1">Click "Enrich" above to gather free data from SAM.gov and news sources.</p>
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/prospecting/enrich_status.html
+++ b/app/templates/htmx/partials/prospecting/enrich_status.html
@@ -9,7 +9,7 @@
      hx-trigger="every 2s"
      hx-target="this"
      hx-swap="outerHTML"
-     class="inline-flex items-center gap-2 text-sm text-gray-500">
+     class="inline-flex items-center gap-2 text-sm text-gray-600">
   <svg class="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>

--- a/app/templates/htmx/partials/prospecting/list.html
+++ b/app/templates/htmx/partials/prospecting/list.html
@@ -18,7 +18,7 @@
        hx-target="#prospect-stats" hx-swap="innerHTML"></div>
 
   <div class="flex items-center justify-between mb-4">
-    <span class="text-sm text-gray-500">
+    <span class="text-sm text-gray-600">
       {{ total }} {% if status %}{{ status }}{% endif %} prospect{{ "s" if total != 1 }}
       {% if q %}matching &ldquo;{{ q }}&rdquo;{% endif %}
     </span>
@@ -36,7 +36,7 @@
               hx-target="#add-prospect-result"
               hx-swap="innerHTML"
               hx-on::after-request="if(event.detail.successful) this.reset()">
-          <label class="block text-xs font-medium text-gray-500 mb-1" for="add-domain-input">Company domain</label>
+          <label class="block text-xs font-medium text-gray-600 mb-1" for="add-domain-input">Company domain</label>
           <div class="flex gap-2">
             <input id="add-domain-input" type="text" name="domain" placeholder="acme.com" required
                    class="flex-1 px-2.5 py-1.5 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
@@ -107,12 +107,12 @@
     {% endfor %}
   </div>
   {% else %}
-  <div class="bg-white border border-brand-200 rounded-lg p-12 text-center">
+  <div class="bg-white border border-brand-200 rounded-lg p-6 sm:p-8 text-center">
     <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
             d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"/>
     </svg>
-    <p class="mt-2 text-sm text-gray-500">No prospects found</p>
+    <p class="mt-2 text-sm text-gray-600">No prospects found</p>
     {% if q or status %}
     <p class="text-xs text-gray-400 mt-1">Try clearing the filter or searching for something else.</p>
     {% else %}
@@ -135,7 +135,7 @@
     <span class="px-3 py-1.5 text-sm text-gray-400 border border-gray-100 rounded-lg cursor-not-allowed">&larr; Prev</span>
     {% endif %}
 
-    <span class="px-3 py-1.5 text-sm text-gray-500">Page {{ page }} of {{ total_pages }}</span>
+    <span class="px-3 py-1.5 text-sm text-gray-600">Page {{ page }} of {{ total_pages }}</span>
 
     {% if page < total_pages %}
     <a hx-get="/v2/partials/prospecting?page={{ page + 1 }}&status={{ status|urlencode }}&sort={{ sort|urlencode }}&q={{ q|urlencode }}"

--- a/app/templates/htmx/partials/prospecting/stats.html
+++ b/app/templates/htmx/partials/prospecting/stats.html
@@ -6,19 +6,19 @@
 #}
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
   <div class="bg-white rounded-lg border border-brand-200 p-4 text-center">
-    <p class="text-xs text-gray-500">Suggested</p>
+    <p class="text-xs text-gray-600">Suggested</p>
     <p class="text-2xl font-bold text-gray-900">{{ total }}</p>
   </div>
   <div class="bg-white rounded-lg border border-emerald-200 p-4 text-center">
-    <p class="text-xs text-gray-500">Buyer-ready</p>
+    <p class="text-xs text-gray-600">Buyer-ready</p>
     <p class="text-2xl font-bold text-emerald-600">{{ buyer_ready }}</p>
   </div>
   <div class="bg-white rounded-lg border border-brand-200 p-4 text-center">
-    <p class="text-xs text-gray-500">Call now</p>
+    <p class="text-xs text-gray-600">Call now</p>
     <p class="text-2xl font-bold text-brand-600">{{ call_now }}</p>
   </div>
   <div class="bg-white rounded-lg border border-brand-200 p-4 text-center">
-    <p class="text-xs text-gray-500">Claimed</p>
+    <p class="text-xs text-gray-600">Claimed</p>
     <p class="text-2xl font-bold text-gray-900">{{ claimed }}</p>
   </div>
 </div>

--- a/app/templates/htmx/partials/quote_builder/_macros.html
+++ b/app/templates/htmx/partials/quote_builder/_macros.html
@@ -11,7 +11,7 @@
    is true the value uses the semibold variant (Qty Needed / Target Price). #}
 {%- macro spec_field(label, expr, emphasis=False) -%}
 <div>
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">{{ label }}</span>
+              <span class="text-xs text-gray-400 uppercase tracking-wide">{{ label }}</span>
               <p class="text-sm font-mono {% if emphasis %}font-semibold {% endif %}text-gray-900" x-text="{{ expr | safe }}"></p>
             </div>
 {%- endmacro -%}

--- a/app/templates/htmx/partials/quote_builder/modal.html
+++ b/app/templates/htmx/partials/quote_builder/modal.html
@@ -15,7 +15,7 @@
     <div class="flex items-center gap-3">
       <h2 class="text-lg font-bold text-brand-800 tracking-tight">Quote Builder</h2>
       <span x-show="saved" class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-100 text-emerald-700" x-text="quoteNumber" x-cloak></span>
-      <span class="text-sm text-gray-500">
+      <span class="text-sm text-gray-600">
         for <span class="font-medium text-gray-700">{{ customer_name or req.name }}</span>
       </span>
     </div>
@@ -119,7 +119,7 @@
               </p>
             </div>
             <span x-show="line.offer_count > 0" x-cloak
-                  class="flex-shrink-0 px-1.5 py-0.5 text-[10px] font-semibold rounded bg-brand-100 text-brand-600 tabular-nums"
+                  class="flex-shrink-0 px-1.5 py-0.5 text-xs font-semibold rounded bg-brand-100 text-brand-600 tabular-nums"
                   x-text="line.offer_count"></span>
           </button>
         </template>
@@ -129,7 +129,7 @@
       </div>
 
       {# Keyboard hints #}
-      <div class="px-4 py-2 border-t border-brand-100 text-[10px] text-gray-400 flex gap-3 flex-shrink-0">
+      <div class="px-4 py-2 border-t border-brand-100 text-xs text-gray-400 flex gap-3 flex-shrink-0">
         <span>{{ qb.kbd("j") }}/{{ qb.kbd("k") }} Nav</span>
         <span>{{ qb.kbd("1") }}-{{ qb.kbd("9") }} Offer</span>
         <span>{{ qb.kbd("Enter") }} Confirm</span>
@@ -141,14 +141,14 @@
 
       {# Desktop-only guard #}
       <div class="lg:hidden flex items-center justify-center h-full p-8 text-center">
-        <p class="text-sm text-gray-500 font-medium">Quote Builder requires a desktop browser (1024px+).</p>
+        <p class="text-sm text-gray-600 font-medium">Quote Builder requires a desktop browser (1024px+).</p>
       </div>
 
       <div class="hidden lg:block space-y-5">
 
         {# 1. Customer Specs #}
         <div class="bg-gray-50 rounded-lg border border-brand-100 px-4 py-3">
-          <h3 class="text-[10px] font-semibold uppercase tracking-wider text-brand-400 mb-2">Customer Requirements</h3>
+          <h3 class="text-xs font-semibold uppercase tracking-wider text-brand-400 mb-2">Customer Requirements</h3>
           <div class="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-1.5">
             {{ qb.spec_field("Qty Needed", "activeLine.target_qty?.toLocaleString() || '—'", emphasis=True) }}
             {{ qb.spec_field("Target Price", "activeLine.target_price ? '$' + activeLine.target_price.toFixed(4) : '—'", emphasis=True) }}
@@ -161,7 +161,7 @@
           </div>
           <template x-if="activeLine.sale_notes" x-cloak>
             <div class="mt-2 pt-2 border-t border-brand-100">
-              <span class="text-[10px] text-gray-400 uppercase tracking-wide">Notes</span>
+              <span class="text-xs text-gray-400 uppercase tracking-wide">Notes</span>
               <p class="text-sm text-gray-700 mt-0.5" x-text="activeLine.sale_notes"></p>
             </div>
           </template>
@@ -169,9 +169,9 @@
 
         {# 2. Offers Table #}
         <div>
-          <h3 class="text-[10px] font-semibold uppercase tracking-wider text-brand-400 mb-2 flex items-center gap-2">
+          <h3 class="text-xs font-semibold uppercase tracking-wider text-brand-400 mb-2 flex items-center gap-2">
             Vendor Offers
-            <span class="inline-flex px-1.5 py-0.5 text-[10px] font-semibold rounded bg-brand-100 text-brand-600"
+            <span class="inline-flex px-1.5 py-0.5 text-xs font-semibold rounded bg-brand-100 text-brand-600"
                   x-text="activeLine.offers.length"></span>
           </h3>
           <div x-show="activeLine.offers.length > 0" x-cloak class="rounded-lg border-2 border-brand-200 overflow-hidden">
@@ -212,7 +212,7 @@
                     <td class="px-3 py-2 text-sm text-right tabular-nums">
                       <span x-text="offer.qty_available.toLocaleString()"></span>
                       <span x-show="offer.qty_available < activeLine.target_qty" x-cloak
-                            class="ml-1 text-[10px] text-amber-600 font-medium">Low</span>
+                            class="ml-1 text-xs text-amber-600 font-medium">Low</span>
                     </td>
                     <td class="px-3 py-2 text-sm text-gray-600" x-text="offer.lead_time || '—'"></td>
                     <td class="px-3 py-2 text-sm text-gray-600" x-text="offer.date_code || '—'"></td>
@@ -237,7 +237,7 @@
           {# Price spread bar #}
           <template x-if="activeLine.offers.length > 1" x-cloak>
             <div class="mt-2 px-1">
-              <div class="flex items-center gap-2 text-[10px] text-gray-400">
+              <div class="flex items-center gap-2 text-xs text-gray-400">
                 <span class="font-mono tabular-nums" x-text="'$' + minPrice.toFixed(4)"></span>
                 <div class="flex-1 relative h-4 flex items-center">
                   <div class="absolute inset-x-0 h-1 bg-gradient-to-r from-emerald-200 via-amber-200 to-rose-200 rounded-full"></div>
@@ -281,14 +281,14 @@
                   <template x-for="h in activeLine.pricing_history.recent" :key="h.quote_number">
                     <tr>
                       <td class="px-3 py-1.5 text-sm text-gray-700" x-text="h.quote_number"></td>
-                      <td class="px-3 py-1.5 text-sm text-gray-500" x-text="h.date"></td>
+                      <td class="px-3 py-1.5 text-sm text-gray-600" x-text="h.date"></td>
                       <td class="px-3 py-1.5 text-sm text-right font-mono" x-text="'$' + (h.cost || 0).toFixed(4)"></td>
                       <td class="px-3 py-1.5 text-sm text-right font-mono" x-text="'$' + (h.sell || 0).toFixed(4)"></td>
                       <td class="px-3 py-1.5 text-sm text-right font-semibold tabular-nums"
                           :class="h.margin >= 25 ? 'text-emerald-600' : h.margin >= 15 ? 'text-amber-600' : 'text-rose-600'"
                           x-text="(h.margin || 0).toFixed(1) + '%'"></td>
                       <td class="px-3 py-1.5">
-                        <span class="inline-flex px-1.5 py-0.5 text-[10px] font-semibold rounded-full"
+                        <span class="inline-flex px-1.5 py-0.5 text-xs font-semibold rounded-full"
                               :class="h.result === 'won' ? 'bg-emerald-50 text-emerald-700' : h.result === 'lost' ? 'bg-rose-50 text-rose-700' : 'bg-gray-100 text-gray-600'"
                               x-text="h.result || 'draft'"></span>
                       </td>
@@ -303,7 +303,7 @@
         {# 4. Decision Area #}
         <div class="rounded-lg border-2 p-4 space-y-3 transition-colors duration-300"
              :class="activeLine.status === 'decided' ? 'border-emerald-300 bg-emerald-50/30' : 'border-brand-200 bg-brand-50'">
-          <h3 class="text-[10px] font-semibold uppercase tracking-wider mb-1 transition-colors duration-300"
+          <h3 class="text-xs font-semibold uppercase tracking-wider mb-1 transition-colors duration-300"
               :class="activeLine.status === 'decided' ? 'text-emerald-600' : 'text-brand-400'">
             <span x-show="activeLine.status !== 'decided'" x-cloak>Set Price</span>
             <span x-show="activeLine.status === 'decided'" x-cloak>Decided</span>
@@ -311,9 +311,9 @@
 
           {# Selected offer summary #}
           <div x-show="selectedOffer" class="flex items-center gap-4 text-sm" x-cloak>
-            <span class="text-gray-500">Vendor:</span>
+            <span class="text-gray-600">Vendor:</span>
             <span class="font-medium text-gray-900" x-text="selectedOffer?.vendor_name"></span>
-            <span class="text-gray-500">Cost:</span>
+            <span class="text-gray-600">Cost:</span>
             <span class="font-mono font-semibold text-gray-900" x-text="'$' + (selectedOffer?.unit_price || 0).toFixed(4)"></span>
             <span x-show="selectedOffer && selectedOffer.qty_available < activeLine.target_qty" x-cloak
                   class="text-xs text-amber-600 font-medium" x-cloak>
@@ -324,7 +324,7 @@
           {# Sell price + margin #}
           <div class="flex items-end gap-4">
             <div>
-              <label class="block text-[10px] text-gray-500 uppercase tracking-wide mb-1">Sell Price</label>
+              <label class="block text-xs text-gray-600 uppercase tracking-wide mb-1">Sell Price</label>
               <div class="relative">
                 <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
                 <input aria-label="Sell price" type="number" step="0.0001"
@@ -339,7 +339,7 @@
               </div>
             </div>
             <div>
-              <label class="block text-[10px] text-gray-500 uppercase tracking-wide mb-1">Margin</label>
+              <label class="block text-xs text-gray-600 uppercase tracking-wide mb-1">Margin</label>
               <p class="text-2xl font-bold tabular-nums py-0.5"
                  :class="{
                    'text-emerald-600': margin >= 25,
@@ -351,15 +351,15 @@
             </div>
             <div class="flex gap-4 ml-auto text-center">
               <div>
-                <span class="text-[10px] text-gray-400 uppercase tracking-wide">Ext Cost</span>
+                <span class="text-xs text-gray-400 uppercase tracking-wide">Ext Cost</span>
                 <p class="text-sm font-mono font-semibold text-gray-900" x-text="'$' + extCost.toFixed(2)"></p>
               </div>
               <div>
-                <span class="text-[10px] text-gray-400 uppercase tracking-wide">Ext Sell</span>
+                <span class="text-xs text-gray-400 uppercase tracking-wide">Ext Sell</span>
                 <p class="text-sm font-mono font-semibold text-gray-900" x-text="'$' + extSell.toFixed(2)"></p>
               </div>
               <div>
-                <span class="text-[10px] text-gray-400 uppercase tracking-wide">Line Profit</span>
+                <span class="text-xs text-gray-400 uppercase tracking-wide">Line Profit</span>
                 <p class="text-sm font-mono font-semibold"
                    :class="lineProfit > 0 ? 'text-emerald-600' : 'text-rose-600'"
                    x-text="'$' + lineProfit.toFixed(2)"></p>
@@ -369,7 +369,7 @@
 
           {# Line notes #}
           <div>
-            <label class="block text-[10px] text-gray-500 uppercase tracking-wide mb-1">Line Notes</label>
+            <label class="block text-xs text-gray-600 uppercase tracking-wide mb-1">Line Notes</label>
             <input type="text" x-model="activeLine.buyer_notes" placeholder="Optional notes..."
                    class="w-full px-3 py-1.5 text-sm border border-brand-100 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white placeholder-gray-300">
           </div>
@@ -407,21 +407,21 @@
   <div class="flex-shrink-0 px-6 py-3 bg-white border-t-2 border-brand-200 flex items-center justify-between">
     <div class="flex gap-6">
       <div class="text-center">
-        <p class="text-[10px] text-gray-400 uppercase tracking-wide">Decided</p>
+        <p class="text-xs text-gray-400 uppercase tracking-wide">Decided</p>
         <p class="text-lg font-bold text-brand-600 tabular-nums">
           <span x-text="decidedCount"></span>/<span x-text="totalCount" class="text-gray-400"></span>
         </p>
       </div>
       <div class="text-center">
-        <p class="text-[10px] text-gray-400 uppercase tracking-wide">Total Cost</p>
+        <p class="text-xs text-gray-400 uppercase tracking-wide">Total Cost</p>
         <p class="text-lg font-bold text-gray-900 font-mono tabular-nums" x-text="'$' + totalCost.toFixed(2)"></p>
       </div>
       <div class="text-center">
-        <p class="text-[10px] text-gray-400 uppercase tracking-wide">Total Sell</p>
+        <p class="text-xs text-gray-400 uppercase tracking-wide">Total Sell</p>
         <p class="text-lg font-bold text-gray-900 font-mono tabular-nums" x-text="'$' + totalSell.toFixed(2)"></p>
       </div>
       <div class="text-center">
-        <p class="text-[10px] text-gray-400 uppercase tracking-wide">Blended Margin</p>
+        <p class="text-xs text-gray-400 uppercase tracking-wide">Blended Margin</p>
         <p class="text-lg font-bold tabular-nums"
            :class="blendedMargin >= 25 ? 'text-emerald-600' : blendedMargin >= 15 ? 'text-amber-600' : 'text-rose-600'"
            x-text="blendedMargin.toFixed(1) + '%'"></p>
@@ -429,7 +429,7 @@
       {# Bulk markup #}
       <div class="flex items-end gap-2">
         <div>
-          <label class="block text-[10px] text-gray-400 uppercase tracking-wide mb-0.5">Markup %</label>
+          <label class="block text-xs text-gray-400 uppercase tracking-wide mb-0.5">Markup %</label>
           <input type="number" step="0.1" x-model.number="bulkMarkupPct" value="25"
                  class="w-20 px-2 py-1 text-sm border border-brand-200 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
@@ -455,7 +455,7 @@
       </button>
       <button @click="saveQuote()"
               :disabled="!hasCustomerSite || decidedCount === 0 || saving"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 flex items-center gap-1.5 transition-colors disabled:opacity-50">
+              class="btn-primary">
         <svg x-show="saving" x-cloak class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-dasharray="31.4" stroke-dashoffset="10"/></svg>
         <svg x-show="!saving" x-cloak class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
         <span x-text="saved ? 'Update Quote' : 'Save Quote'"></span>

--- a/app/templates/htmx/partials/quotes/detail.html
+++ b/app/templates/htmx/partials/quotes/detail.html
@@ -11,7 +11,7 @@
 <div class="max-w-7xl mx-auto" x-data="{ showMarkup: false, showHistory: false }">
 
   {# Header card #}
-  <div class="bg-white border border-brand-200 rounded-lg p-6 mb-6">
+  <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6">
     <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
       <div>
         <div class="flex items-center gap-3">
@@ -106,7 +106,7 @@
             hx-target="#main-content"
             hx-confirm="Send this quote to the customer?"
             data-loading-disable
-            class="px-4 py-2 bg-brand-500 text-white text-sm font-medium rounded-md hover:bg-brand-600 flex items-center gap-1.5 transition-colors">
+            class="btn-primary btn-md">
       {{ loading_spinner("h-4 w-4 spinner") }}
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
       Send Quote
@@ -192,7 +192,7 @@
       <input type="number" name="markup_pct" step="0.1" value="25"
              class="w-24 px-3 py-1.5 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
       <button type="submit" data-loading-disable
-              class="px-4 py-1.5 bg-brand-500 text-white text-sm font-medium rounded-md hover:bg-brand-600 transition-colors">
+              class="btn-primary btn-sm">
         {{ loading_spinner("h-3 w-3 mr-1 spinner inline") }}
         Apply to All Lines
       </button>
@@ -204,7 +204,7 @@
   <div class="bg-white rounded-lg shadow border border-brand-200 overflow-hidden mb-6">
     <div class="px-4 py-3 bg-gray-50 border-b border-brand-200 flex items-center justify-between">
       <h2 class="text-lg font-semibold text-gray-900">Line Items
-        <span class="ml-1 text-sm font-normal text-gray-500">({{ lines|length }})</span>
+        <span class="ml-1 text-sm font-normal text-gray-600">({{ lines|length }})</span>
       </h2>
       <span class="text-xs text-gray-400">Double-click a row to edit</span>
     </div>
@@ -212,14 +212,14 @@
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Manufacturer</th>
-            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
-            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Cost Price</th>
-            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Sell Price</th>
-            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Margin %</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN</th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Manufacturer</th>
+            <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
+            <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Cost Price</th>
+            <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Sell Price</th>
+            <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Margin %</th>
+            <th class="table-cell--head text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
           </tr>
         </thead>
         <tbody id="quote-lines-body" class="divide-y divide-gray-200">
@@ -232,7 +232,7 @@
               <svg class="mx-auto h-8 w-8 text-gray-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
               </svg>
-              <p class="text-sm text-gray-500">No line items yet. Add one below or select from offers.</p>
+              <p class="text-sm text-gray-600">No line items yet. Add one below or select from offers.</p>
             </td>
           </tr>
           {% endif %}
@@ -250,32 +250,32 @@
             data-loading-disable
             class="flex flex-wrap gap-2 items-end">
         <div>
-          <label class="block text-xs text-gray-500 mb-1">MPN</label>
+          <label class="block text-xs text-gray-600 mb-1">MPN</label>
           <input type="text" name="mpn" required placeholder="LM317T"
                  class="w-32 px-2 py-1.5 text-sm border border-brand-200 rounded-md font-mono focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Manufacturer</label>
+          <label class="block text-xs text-gray-600 mb-1">Manufacturer</label>
           <input type="text" name="manufacturer" placeholder="TI"
                  class="w-28 px-2 py-1.5 text-sm border border-brand-200 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Qty</label>
+          <label class="block text-xs text-gray-600 mb-1">Qty</label>
           <input type="number" name="qty" value="1" min="1"
                  class="w-20 px-2 py-1.5 text-sm border border-brand-200 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Cost</label>
+          <label class="block text-xs text-gray-600 mb-1">Cost</label>
           <input type="number" name="cost_price" step="0.0001" placeholder="0.5000"
                  class="w-24 px-2 py-1.5 text-sm border border-brand-200 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Sell</label>
+          <label class="block text-xs text-gray-600 mb-1">Sell</label>
           <input type="number" name="sell_price" step="0.0001" placeholder="0.7500"
                  class="w-24 px-2 py-1.5 text-sm border border-brand-200 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
         </div>
         <button type="submit" data-loading-disable
-                class="px-3 py-1.5 bg-brand-500 text-white text-sm font-medium rounded-md hover:bg-brand-600 transition-colors flex items-center gap-1">
+                class="btn-primary btn-sm">
           {{ loading_spinner("h-3 w-3 spinner") }}
           <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
           Add Line
@@ -306,7 +306,7 @@
           <div hx-get="/v2/partials/quotes/pricing-history/{{ line.mpn }}"
                hx-trigger="revealed"
                hx-swap="innerHTML"
-               class="px-4 py-3 text-sm text-gray-500">
+               class="px-4 py-3 text-sm text-gray-600">
             <span class="htmx-indicator">Loading pricing history...</span>
           </div>
         </div>
@@ -319,7 +319,7 @@
 
   {# Offer gallery #}
   {% if offers %}
-  <div class="bg-white border border-brand-200 rounded-lg p-6 mb-6">
+  <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6">
     <h2 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
       <svg class="w-5 h-5 text-brand-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/>
@@ -338,7 +338,7 @@
     <svg class="mx-auto h-10 w-10 text-gray-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
     </svg>
-    <p class="text-sm text-gray-500">No offers received yet for this requisition.</p>
+    <p class="text-sm text-gray-600">No offers received yet for this requisition.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/quotes/line_row.html
+++ b/app/templates/htmx/partials/quotes/line_row.html
@@ -52,7 +52,7 @@
     </template>
   </td>
   {% set desc = line|part_description %}
-  <td class="px-4 py-3 text-sm text-gray-500 truncate max-w-[200px]" x-show="!editing" x-cloak title="{{ desc }}">{{ desc or '-' }}</td>
+  <td class="px-4 py-3 text-sm text-gray-600 truncate max-w-[200px]" x-show="!editing" x-cloak title="{{ desc }}">{{ desc or '-' }}</td>
   <td class="px-4 py-3 text-sm text-gray-600" x-show="!editing" x-cloak>{{ line.manufacturer or '-' }}</td>
   <td class="px-4 py-3 text-sm text-gray-600 text-right" x-show="!editing" x-cloak>{{ '{:,}'.format(line.qty) if line.qty else '-' }}</td>
   <td class="px-4 py-3 text-sm text-gray-600 text-right" x-show="!editing" x-cloak>${{ '{:,.4f}'.format(line.cost_price|float) if line.cost_price else '-' }}</td>

--- a/app/templates/htmx/partials/quotes/preview.html
+++ b/app/templates/htmx/partials/quotes/preview.html
@@ -7,31 +7,31 @@
   <div class="bg-white rounded-lg shadow border border-gray-200 p-6">
     <div class="flex items-center justify-between mb-4">
       <h2 class="text-lg font-bold text-gray-900">Quote Preview</h2>
-      <span class="text-sm text-gray-500">{{ quote.quote_number }}</span>
+      <span class="text-sm text-gray-600">{{ quote.quote_number }}</span>
     </div>
 
     {# Quote header info #}
     <div class="bg-gray-50 rounded-lg p-4 mb-4 text-sm">
       <div class="grid grid-cols-2 gap-3">
         <div>
-          <p class="text-xs text-gray-500">Status</p>
+          <p class="text-xs text-gray-600">Status</p>
           <p class="font-medium text-gray-900">{{ quote.status|title }}</p>
         </div>
         {% if quote.payment_terms %}
         <div>
-          <p class="text-xs text-gray-500">Payment Terms</p>
+          <p class="text-xs text-gray-600">Payment Terms</p>
           <p class="text-gray-900">{{ quote.payment_terms }}</p>
         </div>
         {% endif %}
         {% if quote.shipping_terms %}
         <div>
-          <p class="text-xs text-gray-500">Shipping Terms</p>
+          <p class="text-xs text-gray-600">Shipping Terms</p>
           <p class="text-gray-900">{{ quote.shipping_terms }}</p>
         </div>
         {% endif %}
         {% if quote.subtotal %}
         <div>
-          <p class="text-xs text-gray-500">Subtotal</p>
+          <p class="text-xs text-gray-600">Subtotal</p>
           <p class="font-medium text-gray-900">${{ "%.2f"|format(quote.subtotal) }}</p>
         </div>
         {% endif %}
@@ -55,8 +55,8 @@
         {% for line in quote.quote_lines %}
         <tr>
           <td class="px-3 py-2 text-sm font-mono text-gray-900">{{ line.mpn or '—' }}</td>
-          <td class="px-3 py-2 text-sm text-gray-500">{{ line|part_description or '—' }}</td>
-          <td class="px-3 py-2 text-sm text-gray-500">{{ line.manufacturer or '—' }}</td>
+          <td class="px-3 py-2 text-sm text-gray-600">{{ line|part_description or '—' }}</td>
+          <td class="px-3 py-2 text-sm text-gray-600">{{ line.manufacturer or '—' }}</td>
           <td class="px-3 py-2 text-sm text-right text-gray-900">{{ "{:,}".format(line.qty) if line.qty else '—' }}</td>
           <td class="px-3 py-2 text-sm text-right text-gray-900">{{ "$%.4f"|format(line.sell_price) if line.sell_price else '—' }}</td>
           <td class="px-3 py-2 text-sm text-right font-medium text-gray-900">

--- a/app/templates/htmx/partials/quotes/pricing_history.html
+++ b/app/templates/htmx/partials/quotes/pricing_history.html
@@ -23,8 +23,8 @@
       <tr class="hover:bg-brand-50">
         <td class="px-3 py-2 text-sm text-gray-900">{{ o.vendor_name or '—' }}</td>
         <td class="px-3 py-2 text-sm text-right font-medium text-emerald-700">${{ "%.4f"|format(o.unit_price) }}</td>
-        <td class="px-3 py-2 text-sm text-right text-gray-500">{{ "{:,}".format(o.qty_available) if o.qty_available else '—' }}</td>
-        <td class="px-3 py-2 text-sm text-gray-500">{{ o.created_at.strftime('%b %d, %Y') if o.created_at else '—' }}</td>
+        <td class="px-3 py-2 text-sm text-right text-gray-600">{{ "{:,}".format(o.qty_available) if o.qty_available else '—' }}</td>
+        <td class="px-3 py-2 text-sm text-gray-600">{{ o.created_at.strftime('%b %d, %Y') if o.created_at else '—' }}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -494,7 +494,7 @@ def test_tiny_text_does_not_grow():
 
     Ratchet — sweeps lower this as they bump 10px → text-xs / text-[11px].
     """
-    BASELINE = 125
+    BASELINE = 70
     count = _tpl_substring_count("text-[10px]")
     assert count <= BASELINE, (
         f"text-[10px] usages rose to {count} (baseline {BASELINE}). Use text-xs "
@@ -509,7 +509,7 @@ def test_low_contrast_secondary_text_does_not_grow():
     Ratchet only (decorative icon grays are fine) — caps growth rather than banning
     outright.
     """
-    BASELINE = 583
+    BASELINE = 482
     count = _tpl_substring_count("text-gray-500")
     assert count <= BASELINE, (
         f"text-gray-500 usages rose to {count} (baseline {BASELINE}). Prefer "
@@ -534,7 +534,7 @@ def test_inline_table_cell_padding_does_not_grow():
 
     Ratchet.
     """
-    BASELINE = 612
+    BASELINE = 604
     count = _tpl_regex_count(r'<t[dh][^>]*class="[^"]*\bp[xy]-[0-9]')
     assert count <= BASELINE, (
         f"inline-padded <td>/<th> rose to {count} (baseline {BASELINE}). Use "
@@ -547,7 +547,7 @@ def test_inline_button_sizing_does_not_grow():
 
     Macro files are the canonical source and are excluded. Ratchet.
     """
-    BASELINE = 299
+    BASELINE = 288
     count = _tpl_regex_count(r'<button[^>]*class="[^"]*\bp[xy]-[0-9]', exclude={"_macros.html"})
     assert count <= BASELINE, (
         f"inline-sized <button> rose to {count} (baseline {BASELINE}). Use .btn-sm/md/lg or the btn_* macros."


### PR DESCRIPTION
## What & why

PR 5 of 6 in the app-wide front-end UX consistency pass. Sweeps the **deal-pipeline** surface (buy_plans / quotes / quote_builder / proactive / prospecting / offers) onto the canonical design-system layer (PR 1 #413). Class-only, zero behavior change.

Triaged 32 templates → **24 swept**. The heaviest files got the **full canonical sweep**: `quote_builder/modal`, `proactive/list`, the **650-line role-aware `buy_plans/detail`** (buyer/sales/ops), `quotes/detail`, `proactive/prepare` (cells→`.table-cell*`/`.compact-cell*`, cards→`.card*`, buttons→`.btn*`, badges→`.badge`). The remaining lighter files got the **readability + floor pass** (`text-gray-500`→`600` on body text with headers/eyebrows/Alpine-bindings preserved, `text-[10px]`→`text-xs`, empty-state `p-12`→`p-6 sm:p-8`).

**Drift ratchets dropped and re-locked** in `test_static_analysis.py`: text-[10px] 125→**70**, text-gray-500 583→**482**, td/th inline pad 612→**604**, button inline sizing 299→**288**.

## Verification
- Full pytest suite: **18,178 passed** (the 3 `api_sources` failures were the inherited #418 gap, now resolved — this branch merges `main` which includes #422)
- 24/24 changed templates compile; 20 static-analysis guards green at the new baselines
- Vite build green; Playwright **`dead-ends` + `requisitions2-visuals`: 32 passed**

Template-only (+1 test-baseline file) — no migrations, no schema, no API changes. Builds on PR 1–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132w7Ci6y7CSUNfPJmY2XCM