### PR TITLE
Harden + optimize the enrichment API layer (resilience, cost, maintenance)

### DIFF
--- a/app/cache/intel_cache.py
+++ b/app/cache/intel_cache.py
@@ -191,6 +191,40 @@ def flush_enrichment_cache() -> int:
     return count
 
 
+def incr_provider_usage(provider: str, ttl_days: int = 35) -> int | None:
+    """Increment a per-provider monthly call counter (Redis only, best-effort).
+
+    Lets you see roughly how many billable calls each provider has had this
+    month (key ``usage:<provider>:<YYYYMM>``). Returns the new count or None.
+    """
+    r = _get_redis()
+    if not r:
+        return None
+    try:
+        month = datetime.now(timezone.utc).strftime("%Y%m")
+        key = f"{_REDIS_PREFIX}usage:{provider}:{month}"
+        val = r.incr(key)
+        if val == 1:
+            r.expire(key, int(ttl_days * 86400))
+        return val
+    except Exception as e:
+        log.debug("Provider usage incr error for %s: %s", provider, e)
+        return None
+
+
+def get_provider_usage(provider: str) -> int:
+    """Read the current month's call count for a provider (0 if unavailable)."""
+    r = _get_redis()
+    if not r:
+        return 0
+    try:
+        month = datetime.now(timezone.utc).strftime("%Y%m")
+        val = r.get(f"{_REDIS_PREFIX}usage:{provider}:{month}")
+        return int(val) if val else 0
+    except Exception:
+        return 0
+
+
 def cleanup_expired() -> int:
     """Remove expired cache entries in batches. Returns count deleted.
 

--- a/app/config.py
+++ b/app/config.py
@@ -93,6 +93,15 @@ class Settings:
     lusha_api_key: str = os.getenv("LUSHA_API_KEY", "")
     lusha_api_base_url: str = os.getenv("LUSHA_API_BASE_URL", "https://api.lusha.com")
 
+    # Outbound API resilience — per-provider rate limits (requests/min) + retries.
+    provider_max_retries: int = int(os.getenv("PROVIDER_MAX_RETRIES", "2"))
+    lusha_rpm: int = int(os.getenv("LUSHA_RPM", "60"))
+    apollo_rpm: int = int(os.getenv("APOLLO_RPM", "60"))
+    explorium_rpm: int = int(os.getenv("EXPLORIUM_RPM", "200"))
+    clay_rpm: int = int(os.getenv("CLAY_RPM", "120"))
+    hunter_rpm: int = int(os.getenv("HUNTER_RPM", "30"))
+    default_provider_rpm: int = int(os.getenv("DEFAULT_PROVIDER_RPM", "120"))
+
     # Clay — asynchronous enrichment (no real-time API):
     #   we POST a domain to the table's inbound webhook (CLAY_WEBHOOK_URL),
     #   Clay enriches and POSTs the row back to /api/webhooks/clay, echoing

--- a/app/connectors/apollo_client.py
+++ b/app/connectors/apollo_client.py
@@ -76,10 +76,7 @@ async def search_contacts(
             lambda: http.post(
                 f"{APOLLO_BASE}/mixed_people/search",
                 json=payload,
-                headers={
-                    "Content-Type": "application/json",
-                    "X-Api-Key": api_key,
-                },
+                headers=auth_headers(api_key),
                 timeout=30,
             ),
         )
@@ -187,10 +184,7 @@ async def enrich_person(
             lambda: http.post(
                 f"{APOLLO_BASE}/people/match",
                 json=payload,
-                headers={
-                    "Content-Type": "application/json",
-                    "X-Api-Key": api_key,
-                },
+                headers=auth_headers(api_key),
                 timeout=30,
             ),
         )
@@ -258,7 +252,7 @@ async def enrich_company(domain: str) -> dict | None:
             lambda: http.get(
                 f"{APOLLO_BASE}/organizations/enrich",
                 params={"domain": domain},
-                headers={"X-Api-Key": api_key},
+                headers=auth_headers(api_key, json_body=False),
                 timeout=15,
             ),
         )
@@ -294,6 +288,14 @@ async def enrich_company(domain: str) -> dict | None:
     except Exception as e:
         log.warning("Apollo company enrich error: %s", e)
         return None
+
+
+def auth_headers(api_key: str, *, json_body: bool = True) -> dict:
+    """Apollo auth headers — single source of truth (X-Api-Key)."""
+    h = {"X-Api-Key": api_key}
+    if json_body:
+        h["Content-Type"] = "application/json"
+    return h
 
 
 def _full_name(person: dict) -> str:

--- a/app/connectors/apollo_client.py
+++ b/app/connectors/apollo_client.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any
 
 from app.config import settings
+from app.connectors.resilience import resilient_call
 from app.http_client import http
 
 log = logging.getLogger("avail.apollo")
@@ -70,14 +71,17 @@ async def search_contacts(
         payload["q_organization_domains_list"] = [domain]
 
     try:
-        resp = await http.post(
-            f"{APOLLO_BASE}/mixed_people/search",
-            json=payload,
-            headers={
-                "Content-Type": "application/json",
-                "X-Api-Key": api_key,
-            },
-            timeout=30,
+        resp = await resilient_call(
+            "apollo",
+            lambda: http.post(
+                f"{APOLLO_BASE}/mixed_people/search",
+                json=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Api-Key": api_key,
+                },
+                timeout=30,
+            ),
         )
 
         if resp.status_code != 200:
@@ -178,14 +182,17 @@ async def enrich_person(
         return None
 
     try:
-        resp = await http.post(
-            f"{APOLLO_BASE}/people/match",
-            json=payload,
-            headers={
-                "Content-Type": "application/json",
-                "X-Api-Key": api_key,
-            },
-            timeout=30,
+        resp = await resilient_call(
+            "apollo",
+            lambda: http.post(
+                f"{APOLLO_BASE}/people/match",
+                json=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Api-Key": api_key,
+                },
+                timeout=30,
+            ),
         )
 
         if resp.status_code != 200:
@@ -246,11 +253,14 @@ async def enrich_company(domain: str) -> dict | None:
         return None
 
     try:
-        resp = await http.get(
-            f"{APOLLO_BASE}/organizations/enrich",
-            params={"domain": domain},
-            headers={"X-Api-Key": api_key},
-            timeout=15,
+        resp = await resilient_call(
+            "apollo",
+            lambda: http.get(
+                f"{APOLLO_BASE}/organizations/enrich",
+                params={"domain": domain},
+                headers={"X-Api-Key": api_key},
+                timeout=15,
+            ),
         )
 
         if resp.status_code != 200:

--- a/app/connectors/lusha_client.py
+++ b/app/connectors/lusha_client.py
@@ -23,6 +23,7 @@ Gracefully returns empty/None when the key is not configured.
 import logging
 from typing import Any
 
+from app.connectors.resilience import resilient_call
 from app.http_client import http
 from app.services.credential_service import get_credential_cached
 
@@ -107,11 +108,14 @@ async def enrich_company(domain: str) -> dict | None:
         return None
 
     try:
-        resp = await http.get(
-            f"{LUSHA_BASE}/company",
-            params={"domain": domain},
-            headers=_headers(key),
-            timeout=15,
+        resp = await resilient_call(
+            "lusha",
+            lambda: http.get(
+                f"{LUSHA_BASE}/company",
+                params={"domain": domain},
+                headers=_headers(key),
+                timeout=15,
+            ),
         )
         if resp.status_code != 200:
             log.warning("Lusha company lookup failed: %s %s", resp.status_code, resp.text[:200])
@@ -178,11 +182,14 @@ async def search_contacts(
                 "contacts": {"include": {"jobTitles": titles}},
             },
         }
-        search_resp = await http.post(
-            f"{LUSHA_BASE}/prospecting/contact/search",
-            headers=_headers(key),
-            json=search_payload,
-            timeout=30,
+        search_resp = await resilient_call(
+            "lusha",
+            lambda: http.post(
+                f"{LUSHA_BASE}/prospecting/contact/search",
+                headers=_headers(key),
+                json=search_payload,
+                timeout=30,
+            ),
         )
         if search_resp.status_code != 200:
             log.warning("Lusha search failed: %s %s", search_resp.status_code, search_resp.text[:200])
@@ -199,11 +206,14 @@ async def search_contacts(
             return []
 
         # Step 2 — enrich the matched contactIds to get emails/phones.
-        enrich_resp = await http.post(
-            f"{LUSHA_BASE}/prospecting/contact/enrich",
-            headers=_headers(key),
-            json={"requestId": request_id, "contactIds": contact_ids[:limit]},
-            timeout=30,
+        enrich_resp = await resilient_call(
+            "lusha",
+            lambda: http.post(
+                f"{LUSHA_BASE}/prospecting/contact/enrich",
+                headers=_headers(key),
+                json={"requestId": request_id, "contactIds": contact_ids[:limit]},
+                timeout=30,
+            ),
         )
         if enrich_resp.status_code != 200:
             log.warning("Lusha enrich failed: %s %s", enrich_resp.status_code, enrich_resp.text[:200])

--- a/app/connectors/resilience.py
+++ b/app/connectors/resilience.py
@@ -147,6 +147,14 @@ def record_provider_result(
     """
     if _testing():
         return
+    # Count every billable success (cheap Redis INCR) before any throttling.
+    if ok:
+        try:
+            from app.cache.intel_cache import incr_provider_usage
+            incr_provider_usage(provider)
+        except Exception:
+            pass
+
     source_name = _SOURCE_NAMES.get(provider)
     if not source_name:
         return

--- a/app/connectors/resilience.py
+++ b/app/connectors/resilience.py
@@ -1,0 +1,287 @@
+"""Outbound resilience for provider API calls.
+
+Wraps a provider HTTP call with three protections so one flaky/over-limit
+vendor API can't waste credits or cascade into failures:
+
+  1. **Circuit breaker** (per provider) — stop hammering a known-down API.
+  2. **Retry with backoff** on 429 / 5xx / timeouts, honoring ``Retry-After``.
+  3. **Token-bucket rate limit** (per provider, requests/min from config).
+
+It also records health: on success/auth-failure it updates the matching
+``ApiSource`` row (status / last_success / last_error) and, on an auth failure,
+fires a throttled Teams alert.
+
+Usage (keeps the caller's own ``http`` as the patch point for tests):
+
+    from app.connectors.resilience import resilient_call
+    resp = await resilient_call("lusha", lambda: http.post(url, json=payload))
+    if resp.status_code != 200:
+        ...
+
+On an open breaker or exhausted timeouts, ``ProviderUnavailable`` is raised —
+callers already wrap provider calls in try/except and degrade to empty results.
+
+Called by: app/connectors/* and app/services/* enrichment providers.
+Depends on: app.connectors.sources (circuit breaker), app.config, app.database.
+"""
+
+import asyncio
+import logging
+import os
+import random
+import time
+
+import httpx
+
+from app.config import settings
+
+log = logging.getLogger("avail.resilience")
+
+# Statuses worth retrying — transient server/throttle errors.
+RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+AUTH_STATUS = {401, 403}
+
+# Map short provider name → the ApiSource.name used in the credential store.
+_SOURCE_NAMES = {
+    "lusha": "lusha_enrichment",
+    "apollo": "apollo_enrichment",
+    "explorium": "explorium_enrichment",
+    "clay": "clay_enrichment",
+    "hunter": "hunter_enrichment",
+    "rocketreach": "rocketreach_enrichment",
+    "clearbit": "clearbit_enrichment",
+    "anthropic": "anthropic_ai",
+}
+
+
+class ProviderUnavailable(Exception):
+    """Raised when the breaker is open or all retries are exhausted."""
+
+
+def _testing() -> bool:
+    return bool(os.environ.get("TESTING"))
+
+
+# ── Per-provider token-bucket rate limiting ──────────────────────────
+
+
+class _TokenBucket:
+    def __init__(self, rate_per_sec: float, capacity: float):
+        self.rate = rate_per_sec
+        self.capacity = capacity
+        self.tokens = capacity
+        self.updated = time.monotonic()
+        self.lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        async with self.lock:
+            now = time.monotonic()
+            self.tokens = min(self.capacity, self.tokens + (now - self.updated) * self.rate)
+            self.updated = now
+            if self.tokens < 1:
+                wait = (1 - self.tokens) / self.rate
+                await asyncio.sleep(wait)
+                self.tokens = 0.0
+                self.updated = time.monotonic()
+            else:
+                self.tokens -= 1
+
+
+_buckets: dict[str, _TokenBucket] = {}
+
+
+def _rpm_for(provider: str, override: int | None) -> int:
+    if override:
+        return override
+    return {
+        "lusha": settings.lusha_rpm,
+        "apollo": settings.apollo_rpm,
+        "explorium": settings.explorium_rpm,
+        "clay": settings.clay_rpm,
+        "hunter": settings.hunter_rpm,
+    }.get(provider, settings.default_provider_rpm)
+
+
+def _bucket_for(provider: str, rpm: int | None) -> _TokenBucket:
+    if provider not in _buckets:
+        rate = max(_rpm_for(provider, rpm), 1) / 60.0
+        # Allow a small burst (~10s of traffic) but never less than 1.
+        capacity = max(1.0, _rpm_for(provider, rpm) / 6.0)
+        _buckets[provider] = _TokenBucket(rate, capacity)
+    return _buckets[provider]
+
+
+# ── Backoff ──────────────────────────────────────────────────────────
+
+
+def _retry_after_seconds(resp: httpx.Response) -> float | None:
+    val = resp.headers.get("Retry-After")
+    if not val:
+        return None
+    try:
+        return max(0.0, float(val))
+    except ValueError:
+        return None  # HTTP-date form — fall back to exponential backoff
+
+
+def _backoff(attempt: int) -> float:
+    if _testing():
+        return 0.0
+    return min(30.0, 2 ** attempt + random.uniform(0, 1))
+
+
+# ── Health bookkeeping ───────────────────────────────────────────────
+
+_last_success_write: dict[str, float] = {}
+_last_alert: dict[str, float] = {}
+_SUCCESS_WRITE_INTERVAL = 60.0      # throttle last_success writes
+_ALERT_INTERVAL = 3600.0            # throttle auth-failure alerts
+
+
+def record_provider_result(
+    provider: str, *, ok: bool, error: str | None = None, auth_failure: bool = False
+) -> None:
+    """Best-effort: persist provider health to ApiSource; alert on auth failure.
+
+    No-ops under TESTING (no real DB / no outbound alert).
+    """
+    if _testing():
+        return
+    source_name = _SOURCE_NAMES.get(provider)
+    if not source_name:
+        return
+
+    now = time.monotonic()
+    if ok and (now - _last_success_write.get(provider, 0)) < _SUCCESS_WRITE_INTERVAL:
+        return  # avoid a DB write on every successful call
+
+    try:
+        from datetime import datetime, timezone
+
+        from app.database import SessionLocal
+        from app.models import ApiSource
+
+        with SessionLocal() as db:
+            src = db.query(ApiSource).filter_by(name=source_name).first()
+            if not src:
+                return
+            if ok:
+                src.last_success = datetime.now(timezone.utc)
+                if src.status == "error":
+                    src.status = "active"
+                _last_success_write[provider] = now
+            else:
+                src.last_error = (error or "request failed")[:500]
+                if auth_failure:
+                    src.status = "error"
+            db.commit()
+    except Exception as e:
+        log.debug("record_provider_result skipped for %s: %s", provider, e)
+
+    if auth_failure and (now - _last_alert.get(provider, 0)) >= _ALERT_INTERVAL:
+        _last_alert[provider] = now
+        asyncio.create_task(_alert_auth_failure(provider, error or ""))
+
+
+async def _alert_auth_failure(provider: str, error: str) -> None:
+    """Post a throttled auth-failure card to the Teams webhook, if configured."""
+    webhook = getattr(settings, "teams_webhook_url", "")
+    if not webhook:
+        return
+    from app.http_client import http
+
+    try:
+        await http.post(
+            webhook,
+            json={
+                "type": "message",
+                "attachments": [{
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": {
+                        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                        "type": "AdaptiveCard",
+                        "version": "1.4",
+                        "body": [{
+                            "type": "TextBlock",
+                            "text": f"⚠️ {provider} API auth failure — check the key. ({error[:120]})",
+                            "wrap": True,
+                        }],
+                    },
+                }],
+            },
+            timeout=10,
+        )
+    except Exception as e:
+        log.debug("Teams auth-failure alert failed for %s: %s", provider, e)
+
+
+# ── The wrapper ──────────────────────────────────────────────────────
+
+
+async def resilient_call(
+    provider: str,
+    factory,
+    *,
+    max_retries: int | None = None,
+    rpm: int | None = None,
+    retryable_status: set[int] | None = None,
+) -> httpx.Response:
+    """Run ``factory()`` (a coroutine returning an httpx.Response) with
+    breaker + retry/backoff + rate limiting + health bookkeeping.
+
+    Returns the Response (including non-retryable 4xx and auth responses, so the
+    caller can inspect status_code). Raises ProviderUnavailable when the breaker
+    is open or timeouts are exhausted.
+    """
+    from app.connectors.sources import get_breaker
+
+    breaker = get_breaker(f"provider:{provider}")
+    if breaker.current_state == "open":
+        raise ProviderUnavailable(f"{provider} circuit breaker open")
+
+    retries = settings.provider_max_retries if max_retries is None else max_retries
+    retryable = RETRYABLE_STATUS if retryable_status is None else retryable_status
+    bucket = _bucket_for(provider, rpm)
+
+    for attempt in range(retries + 1):
+        await bucket.acquire()
+        try:
+            resp = await factory()
+        except (httpx.TimeoutException, httpx.TransportError) as e:
+            breaker.record_failure()
+            if attempt < retries:
+                await asyncio.sleep(_backoff(attempt))
+                continue
+            record_provider_result(provider, ok=False, error=f"{type(e).__name__}: {e}")
+            raise ProviderUnavailable(f"{provider}: {type(e).__name__}") from e
+
+        status = resp.status_code
+        if status in retryable:
+            breaker.record_failure()
+            if attempt < retries:
+                delay = _retry_after_seconds(resp)
+                await asyncio.sleep(delay if delay is not None else _backoff(attempt))
+                continue
+            record_provider_result(provider, ok=False, error=f"HTTP {status}")
+            return resp
+
+        if status in AUTH_STATUS:
+            breaker.record_failure()
+            record_provider_result(
+                provider, ok=False, error=f"HTTP {status} (auth)", auth_failure=True
+            )
+            return resp
+
+        breaker.record_success()
+        record_provider_result(provider, ok=(status < 400),
+                               error=None if status < 400 else f"HTTP {status}")
+        return resp
+
+    raise ProviderUnavailable(provider)  # pragma: no cover (loop returns first)
+
+
+def reset_state() -> None:
+    """Clear rate-limit buckets + health throttles (used by tests)."""
+    _buckets.clear()
+    _last_success_write.clear()
+    _last_alert.clear()

--- a/app/enrichment_service.py
+++ b/app/enrichment_service.py
@@ -926,6 +926,33 @@ async def find_suggested_contacts(
     return result
 
 
+# ── Provider configuration ───────────────────────────────────────────
+
+# Synchronous enrichment providers that can satisfy enrich_entity /
+# find_suggested_contacts (Clay is async-only and intentionally excluded).
+SYNC_PROVIDER_KEYS = [
+    ("lusha_enrichment", "LUSHA_API_KEY"),
+    ("apollo_enrichment", "APOLLO_API_KEY"),
+    ("explorium_enrichment", "EXPLORIUM_API_KEY"),
+    ("hunter_enrichment", "HUNTER_API_KEY"),
+    ("rocketreach_enrichment", "ROCKETREACH_API_KEY"),
+    ("clearbit_enrichment", "CLEARBIT_API_KEY"),
+    ("anthropic_ai", "ANTHROPIC_API_KEY"),
+]
+
+# Human-readable hint for the "nothing configured" error responses.
+ENRICHMENT_KEYS_HINT = "LUSHA_API_KEY, APOLLO_API_KEY, EXPLORIUM_API_KEY, or ANTHROPIC_API_KEY"
+
+
+def enrichment_provider_configured() -> bool:
+    """True if at least one synchronous enrichment provider key is configured.
+
+    Single source of truth for the "do we have any enrichment provider?" gate
+    that several routers share — avoids the per-router OR-chains drifting apart.
+    """
+    return any(get_credential_cached(src, key) for src, key in SYNC_PROVIDER_KEYS)
+
+
 def apply_enrichment_to_company(company, data: dict) -> list[str]:
     """Apply enrichment data dict to a Company model. Returns list of fields updated."""
     updated = []

--- a/app/enrichment_service.py
+++ b/app/enrichment_service.py
@@ -760,9 +760,10 @@ async def enrich_entity(domain: str, name: str = "") -> dict:
     # Layer 2: output normalization
     normalized = normalize_company_output(result)
 
-    # Cache enrichment result for 14 days
-    if any(v for k, v in normalized.items() if k != "domain"):
-        set_cached(cache_key, normalized, ttl_days=14)
+    # Cache 14 days when we found data; negative-cache misses for 1 day so a
+    # domain with no provider coverage doesn't re-bill every lookup.
+    has_data = any(v for k, v in normalized.items() if k not in ("domain", "source"))
+    set_cached(cache_key, normalized, ttl_days=14 if has_data else 1)
 
     return normalized
 
@@ -770,12 +771,20 @@ async def enrich_entity(domain: str, name: str = "") -> dict:
 async def find_suggested_contacts(
     domain: str, name: str = "", title_filter: str = ""
 ) -> list[dict]:
-    """Find suggested contacts at a company from all configured providers.
+    """Find suggested contacts at a company from configured providers.
 
-    All 5 sources run concurrently via asyncio.gather.
-    Returns deduplicated list sorted by relevance. Each contact has:
+    Cheaper/paid providers (Lusha, Explorium, Hunter, RocketReach, Apollo) run
+    concurrently first; the expensive AI web-search lookup only runs if those are
+    sparse. Results are cached 7 days per domain+title to avoid re-billing.
+    Returns a deduplicated, relevance-filtered list. Each contact has:
     full_name, title, email, phone, linkedin_url, location, source
     """
+    from .cache.intel_cache import get_cached, set_cached
+
+    cache_key = f"contacts:{_clean_domain(domain)}:{(title_filter or '').lower().strip()}"
+    cached = get_cached(cache_key)
+    if cached is not None:
+        return cached
 
     async def _safe_hunter(domain: str) -> list[dict]:
         try:
@@ -851,38 +860,6 @@ async def find_suggested_contacts(
             log.debug("Apollo contacts skipped: %s", e)
             return []
 
-    # Run all 6 sources concurrently
-    results = await asyncio.gather(
-        _lusha_find_contacts(domain, title_filter),
-        _explorium_find_contacts(domain, title_filter),
-        _safe_hunter(domain),
-        _safe_rocketreach(domain),
-        _safe_apollo_contacts(domain),
-        _ai_find_contacts(domain, name, title_filter),
-        return_exceptions=True,
-    )
-
-    all_contacts = []
-    for r in results:
-        if isinstance(r, Exception):
-            log.debug("Contact provider failed: %s", r)
-            continue
-        all_contacts.extend(r)
-
-    # Deduplicate by email or linkedin_url or full_name
-    seen = set()
-    unique = []
-    for c in all_contacts:
-        key = (
-            (c.get("email") or "").lower()
-            or c.get("linkedin_url")
-            or (c.get("full_name") or "").lower()
-        )
-        if not key or key in seen:
-            continue
-        seen.add(key)
-        unique.append(c)
-
     # Filter to relevant B2B titles — avoid wasting credits on irrelevant contacts
     _RELEVANT_KEYWORDS = {
         "procurement", "purchasing", "buyer", "sourcing", "supply chain",
@@ -898,9 +875,55 @@ async def find_suggested_contacts(
             return bool(contact.get("email"))  # Keep if has email but no title
         return any(kw in title for kw in _RELEVANT_KEYWORDS)
 
+    def _dedupe(contacts: list[dict]) -> list[dict]:
+        seen: set = set()
+        unique: list[dict] = []
+        for c in contacts:
+            key = (
+                (c.get("email") or "").lower()
+                or c.get("linkedin_url")
+                or (c.get("full_name") or "").lower()
+            )
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            unique.append(c)
+        return unique
+
+    def _collect(results) -> list[dict]:
+        out: list[dict] = []
+        for r in results:
+            if isinstance(r, Exception):
+                log.debug("Contact provider failed: %s", r)
+                continue
+            out.extend(r)
+        return out
+
+    # Tier 1: the paid/cheaper providers run concurrently.
+    tier1 = await asyncio.gather(
+        _lusha_find_contacts(domain, title_filter),
+        _explorium_find_contacts(domain, title_filter),
+        _safe_hunter(domain),
+        _safe_rocketreach(domain),
+        _safe_apollo_contacts(domain),
+        return_exceptions=True,
+    )
+    unique = _dedupe(_collect(tier1))
+
+    # Tier 2: only spend on the AI web-search lookup if results are still sparse.
+    AI_CONTACT_THRESHOLD = 3
+    if sum(1 for c in unique if _is_relevant(c)) < AI_CONTACT_THRESHOLD:
+        ai = await _ai_find_contacts(domain, name, title_filter)
+        if isinstance(ai, list):
+            unique = _dedupe(unique + ai)
+
     filtered = [c for c in unique if _is_relevant(c)]
     # If filter removed everything, return unfiltered (don't lose all results)
-    return filtered if filtered else unique
+    result = filtered if filtered else unique
+
+    if result:
+        set_cached(cache_key, result, ttl_days=7)
+    return result
 
 
 def apply_enrichment_to_company(company, data: dict) -> list[str]:

--- a/app/enrichment_service.py
+++ b/app/enrichment_service.py
@@ -13,6 +13,7 @@ import re
 from datetime import datetime, timezone
 from typing import Optional
 
+from .connectors.resilience import resilient_call
 from .http_client import http
 from .services.ai_service import enrich_contacts_websearch
 from .services.credential_service import get_credential_cached
@@ -364,11 +365,14 @@ async def _explorium_match_business(domain: str, name: str = "") -> Optional[str
     business = {"domain": domain}
     if name:
         business["name"] = name
-    resp = await http.post(
-        f"{EXPLORIUM_BASE}/businesses/match",
-        headers=_explorium_headers(),
-        json={"businesses_to_match": [business]},
-        timeout=15,
+    resp = await resilient_call(
+        "explorium",
+        lambda: http.post(
+            f"{EXPLORIUM_BASE}/businesses/match",
+            headers=_explorium_headers(),
+            json={"businesses_to_match": [business]},
+            timeout=15,
+        ),
     )
     if resp.status_code != 200:
         log.warning("Explorium match failed: %s %s", resp.status_code, resp.text[:200])
@@ -389,11 +393,14 @@ async def _explorium_find_company(domain: str, name: str = "") -> Optional[dict]
         if not business_id:
             return None
 
-        resp = await http.post(
-            f"{EXPLORIUM_BASE}/businesses/firmographics/enrich",
-            headers=_explorium_headers(),
-            json={"business_ids": [business_id]},
-            timeout=15,
+        resp = await resilient_call(
+            "explorium",
+            lambda: http.post(
+                f"{EXPLORIUM_BASE}/businesses/firmographics/enrich",
+                headers=_explorium_headers(),
+                json={"business_ids": [business_id]},
+                timeout=15,
+            ),
         )
         if resp.status_code != 200:
             log.warning("Explorium firmographics failed: %s", resp.status_code)
@@ -438,11 +445,14 @@ async def _explorium_find_contacts(domain: str, title_filter: str = "") -> list[
         payload = {"business_ids": [business_id], "size": 10}
         if title_filter:
             payload["filters"] = {"job_title": [title_filter]}
-        resp = await http.post(
-            f"{EXPLORIUM_BASE}/prospects",
-            headers=_explorium_headers(),
-            json=payload,
-            timeout=20,
+        resp = await resilient_call(
+            "explorium",
+            lambda: http.post(
+                f"{EXPLORIUM_BASE}/prospects",
+                headers=_explorium_headers(),
+                json=payload,
+                timeout=20,
+            ),
         )
         if resp.status_code != 200:
             return []
@@ -457,11 +467,14 @@ async def _explorium_find_contacts(domain: str, title_filter: str = "") -> list[
         ]
         contact_info: dict[str, dict] = {}
         if prospect_ids:
-            eresp = await http.post(
-                f"{EXPLORIUM_BASE}/prospects/contacts_information/enrich",
-                headers=_explorium_headers(),
-                json={"prospect_ids": prospect_ids},
-                timeout=20,
+            eresp = await resilient_call(
+                "explorium",
+                lambda: http.post(
+                    f"{EXPLORIUM_BASE}/prospects/contacts_information/enrich",
+                    headers=_explorium_headers(),
+                    json={"prospect_ids": prospect_ids},
+                    timeout=20,
+                ),
             )
             if eresp.status_code == 200:
                 for rec in _explorium_records(eresp.json()):

--- a/app/routers/crm/enrichment.py
+++ b/app/routers/crm/enrichment.py
@@ -12,7 +12,7 @@ from ...dependencies import require_admin, require_buyer, require_user, is_admin
 from ...models import Company, CustomerSite, SiteContact, SyncLog, User, VendorCard, VendorContact
 from ...schemas.crm import AddContactsToVendor, AddContactToSite, CustomerImportRow, EnrichDomainRequest
 from ...rate_limit import limiter
-from ...services.credential_service import get_credential_cached
+from ...enrichment_service import ENRICHMENT_KEYS_HINT, enrichment_provider_configured
 
 router = APIRouter()
 
@@ -28,15 +28,10 @@ async def enrich_company(
     db: Session = Depends(get_db),
 ):
     """Enrich a customer company with external data."""
-    if (
-        not get_credential_cached("lusha_enrichment", "LUSHA_API_KEY")
-        and not get_credential_cached("apollo_enrichment", "APOLLO_API_KEY")
-        and not get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY")
-        and not get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY")
-    ):
+    if not enrichment_provider_configured():
         raise HTTPException(
             503,
-            "No enrichment providers configured — set LUSHA_API_KEY, APOLLO_API_KEY, EXPLORIUM_API_KEY, or ANTHROPIC_API_KEY in .env",
+            f"No enrichment providers configured — set {ENRICHMENT_KEYS_HINT} in .env",
         )
     from ...enrichment_service import apply_enrichment_to_company, enrich_entity
 
@@ -71,15 +66,10 @@ async def enrich_vendor_card(
     db: Session = Depends(get_db),
 ):
     """Enrich a vendor card with external data."""
-    if (
-        not get_credential_cached("lusha_enrichment", "LUSHA_API_KEY")
-        and not get_credential_cached("apollo_enrichment", "APOLLO_API_KEY")
-        and not get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY")
-        and not get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY")
-    ):
+    if not enrichment_provider_configured():
         raise HTTPException(
             503,
-            "No enrichment providers configured — set LUSHA_API_KEY, APOLLO_API_KEY, EXPLORIUM_API_KEY, or ANTHROPIC_API_KEY in .env",
+            f"No enrichment providers configured — set {ENRICHMENT_KEYS_HINT} in .env",
         )
     from ...enrichment_service import apply_enrichment_to_vendor, enrich_entity
 
@@ -115,15 +105,10 @@ async def get_suggested_contacts(
     db: Session = Depends(get_db),
 ):
     """Find suggested contacts at a company from enrichment providers."""
-    if (
-        not get_credential_cached("lusha_enrichment", "LUSHA_API_KEY")
-        and not get_credential_cached("apollo_enrichment", "APOLLO_API_KEY")
-        and not get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY")
-        and not get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY")
-    ):
+    if not enrichment_provider_configured():
         raise HTTPException(
             503,
-            "No enrichment providers configured — set LUSHA_API_KEY, APOLLO_API_KEY, EXPLORIUM_API_KEY, or ANTHROPIC_API_KEY in .env",
+            f"No enrichment providers configured — set {ENRICHMENT_KEYS_HINT} in .env",
         )
     from ...enrichment_service import find_suggested_contacts
 

--- a/app/routers/v13_features.py
+++ b/app/routers/v13_features.py
@@ -91,14 +91,30 @@ async def clay_webhook(
     shared secret (x-clay-secret header) and the correlation token we sent.
     We verify the secret, then route the enriched fields into the queue.
     """
-    from app.services.clay_service import handle_clay_callback, verify_clay_secret
+    import json as _json
+
+    from app.services.clay_service import (
+        MAX_CALLBACK_BYTES,
+        handle_clay_callback,
+        verify_clay_secret,
+        verify_clay_signature,
+    )
 
     secret = request.headers.get("x-clay-secret")
     if not verify_clay_secret(secret):
         raise HTTPException(403, "Invalid Clay webhook secret")
 
+    raw = await request.body()
+    if len(raw) > MAX_CALLBACK_BYTES:
+        raise HTTPException(413, "Payload too large")
+
+    # Optional stronger check: if Clay sends an HMAC signature, it must verify.
+    signature = request.headers.get("x-clay-signature")
+    if signature is not None and not verify_clay_signature(raw, signature):
+        raise HTTPException(403, "Invalid Clay signature")
+
     try:
-        payload = await request.json()
+        payload = _json.loads(raw)
     except (ValueError, UnicodeDecodeError):
         raise HTTPException(400, "Invalid JSON payload")
     if not isinstance(payload, dict):

--- a/app/services/clay_service.py
+++ b/app/services/clay_service.py
@@ -19,6 +19,7 @@ Depends on:
   - app.services.deep_enrichment_service.route_enrichment (confidence routing)
 """
 
+import hashlib
 import hmac
 import json
 import logging
@@ -34,6 +35,11 @@ log = logging.getLogger("avail.clay")
 # Clay to finish even a slow waterfall, short enough to self-clean.
 _CORR_PREFIX = "clay:corr:"
 _CORR_TTL_DAYS = 7
+
+# Reject callback bodies larger than this (defends against abuse / runaway rows).
+MAX_CALLBACK_BYTES = 256 * 1024
+# Cap how many contacts a single callback can enqueue.
+MAX_CALLBACK_CONTACTS = 100
 
 # Company firmographic fields Clay may return that we know how to apply.
 _COMPANY_FIELDS = (
@@ -109,7 +115,10 @@ async def request_clay_enrichment(
     }
 
     try:
-        resp = await http.post(webhook_url, headers=headers, json=body, timeout=15)
+        from app.connectors.resilience import resilient_call
+        resp = await resilient_call(
+            "clay", lambda: http.post(webhook_url, headers=headers, json=body, timeout=15)
+        )
     except Exception as e:
         log.warning("Clay webhook POST failed for %s: %s", domain, e)
         invalidate(_corr_key(token))
@@ -137,6 +146,20 @@ def verify_clay_secret(provided: str | None) -> bool:
         log.warning("Clay callback hit but CLAY_CALLBACK_SECRET is not configured — rejecting")
         return False
     return hmac.compare_digest(expected, provided or "")
+
+
+def verify_clay_signature(raw_body: bytes, provided: str | None) -> bool:
+    """Optional stronger check: HMAC-SHA256 of the raw body keyed by the secret.
+
+    Verifies body integrity (not just a shared header). Accepts an optional
+    ``sha256=`` prefix. Returns False if no secret/signature is present.
+    """
+    secret = _clay_secret()
+    if not secret or not provided:
+        return False
+    prov = provided.split("=", 1)[1] if provided.startswith("sha256=") else provided
+    expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, prov)
 
 
 def _confidence_from_email_marker(marker) -> float:
@@ -195,7 +218,7 @@ def handle_clay_callback(payload: dict, db) -> dict:
     contacts = payload.get("contacts") or []
     contacts_added = 0
     if isinstance(contacts, list):
-        for c in contacts:
+        for c in contacts[:MAX_CALLBACK_CONTACTS]:
             if not isinstance(c, dict):
                 continue
             email = (c.get("email") or "").strip().lower()

--- a/app/services/prospect_discovery_apollo.py
+++ b/app/services/prospect_discovery_apollo.py
@@ -53,14 +53,18 @@ async def check_people_signals(domain: str) -> dict:
             "page": 1,
         }
 
-        resp = await http.post(
-            f"{APOLLO_BASE}/mixed_people/search",
-            json=payload,
-            headers={
-                "Content-Type": "application/json",
-                "X-Api-Key": api_key,
-            },
-            timeout=30,
+        from app.connectors.resilience import resilient_call
+        resp = await resilient_call(
+            "apollo",
+            lambda: http.post(
+                f"{APOLLO_BASE}/mixed_people/search",
+                json=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Api-Key": api_key,
+                },
+                timeout=30,
+            ),
         )
 
         if resp.status_code != 200:

--- a/app/services/prospect_discovery_apollo.py
+++ b/app/services/prospect_discovery_apollo.py
@@ -10,7 +10,7 @@ from loguru import logger
 from sqlalchemy.orm import Session
 
 from app.config import settings
-from app.connectors.apollo_client import APOLLO_BASE, DEFAULT_TITLES
+from app.connectors.apollo_client import APOLLO_BASE, auth_headers
 from app.http_client import http
 from app.models.prospect_account import ProspectAccount
 
@@ -59,10 +59,7 @@ async def check_people_signals(domain: str) -> dict:
             lambda: http.post(
                 f"{APOLLO_BASE}/mixed_people/search",
                 json=payload,
-                headers={
-                    "Content-Type": "application/json",
-                    "X-Api-Key": api_key,
-                },
+                headers=auth_headers(api_key),
                 timeout=30,
             ),
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,22 @@ _PG_ONLY_TABLES = {"buyer_profiles"}
 
 
 @pytest.fixture(autouse=True)
+def _reset_resilience():
+    """Reset per-provider circuit breakers + rate-limit buckets between tests
+    so outbound-resilience state never leaks across test cases."""
+    try:
+        from app.connectors import resilience
+        from app.connectors.sources import _breakers
+        resilience.reset_state()
+        _breakers.clear()
+        yield
+        resilience.reset_state()
+        _breakers.clear()
+    except Exception:
+        yield
+
+
+@pytest.fixture(autouse=True)
 def db_session():
     """Create all tables, yield a session, then tear down."""
     _sqlite_safe = [

--- a/tests/test_cache_intel.py
+++ b/tests/test_cache_intel.py
@@ -20,7 +20,6 @@ from app.cache.intel_cache import (
     set_cached,
 )
 
-
 # ═══════════════════════════════════════════════════════════════════════
 #  _get_redis — TESTING=1 returns None
 # ═══════════════════════════════════════════════════════════════════════
@@ -350,3 +349,37 @@ class TestInvalidatePgError:
         """PG error during invalidate is caught silently."""
         mock_session_local.side_effect = Exception("DB connection error")
         invalidate("company:test")  # Should not raise
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Per-provider usage counters
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestProviderUsage:
+    @patch("app.cache.intel_cache._get_redis", return_value=None)
+    def test_incr_no_redis_returns_none(self, _mock):
+        from app.cache.intel_cache import incr_provider_usage
+        assert incr_provider_usage("lusha") is None
+
+    @patch("app.cache.intel_cache._get_redis")
+    def test_incr_sets_expiry_on_first_hit(self, mock_get_redis):
+        from app.cache.intel_cache import incr_provider_usage
+        r = MagicMock()
+        r.incr.return_value = 1
+        mock_get_redis.return_value = r
+        assert incr_provider_usage("apollo") == 1
+        r.expire.assert_called_once()
+
+    @patch("app.cache.intel_cache._get_redis")
+    def test_get_usage_reads_count(self, mock_get_redis):
+        from app.cache.intel_cache import get_provider_usage
+        r = MagicMock()
+        r.get.return_value = "42"
+        mock_get_redis.return_value = r
+        assert get_provider_usage("explorium") == 42
+
+    @patch("app.cache.intel_cache._get_redis", return_value=None)
+    def test_get_usage_no_redis_returns_zero(self, _mock):
+        from app.cache.intel_cache import get_provider_usage
+        assert get_provider_usage("clay") == 0

--- a/tests/test_clay_service.py
+++ b/tests/test_clay_service.py
@@ -183,3 +183,58 @@ def test_clay_webhook_rejects_non_object_payload(client):
             headers={"x-clay-secret": "right"},
         )
     assert resp.status_code == 400
+
+
+# ── HMAC signature + payload-size hardening ──────────────────────────
+
+
+class TestVerifyClaySignature:
+    def test_no_secret_or_sig_returns_false(self):
+        with patch.object(clay_service, "_clay_secret", return_value=""):
+            assert clay_service.verify_clay_signature(b"{}", "abc") is False
+        with patch.object(clay_service, "_clay_secret", return_value="s"):
+            assert clay_service.verify_clay_signature(b"{}", None) is False
+
+    def test_valid_signature(self):
+        import hashlib
+        import hmac
+        body = b'{"correlation_token":"t"}'
+        sig = hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+        with patch.object(clay_service, "_clay_secret", return_value="s3cret"):
+            assert clay_service.verify_clay_signature(body, sig) is True
+            assert clay_service.verify_clay_signature(body, "sha256=" + sig) is True
+            assert clay_service.verify_clay_signature(body, "deadbeef") is False
+
+
+def test_clay_webhook_rejects_oversize_payload(client):
+    big = "x" * (clay_service.MAX_CALLBACK_BYTES + 1)
+    with patch("app.services.clay_service.verify_clay_secret", return_value=True):
+        resp = client.post(
+            "/api/webhooks/clay",
+            content=('{"correlation_token":"t","pad":"%s"}' % big).encode(),
+            headers={"x-clay-secret": "right", "Content-Type": "application/json"},
+        )
+    assert resp.status_code == 413
+
+
+def test_clay_webhook_rejects_bad_signature_when_present(client):
+    with patch("app.services.clay_service.verify_clay_secret", return_value=True), \
+         patch("app.services.clay_service.verify_clay_signature", return_value=False):
+        resp = client.post(
+            "/api/webhooks/clay",
+            json={"correlation_token": "t"},
+            headers={"x-clay-secret": "right", "x-clay-signature": "bad"},
+        )
+    assert resp.status_code == 403
+
+
+def test_clay_webhook_accepts_valid_signature(client):
+    with patch("app.services.clay_service.verify_clay_secret", return_value=True), \
+         patch("app.services.clay_service.verify_clay_signature", return_value=True), \
+         patch("app.services.clay_service.handle_clay_callback", return_value={"status": "applied"}):
+        resp = client.post(
+            "/api/webhooks/clay",
+            json={"correlation_token": "t", "industry": "Electronics"},
+            headers={"x-clay-secret": "right", "x-clay-signature": "sha256=deadbeef"},
+        )
+    assert resp.status_code == 200

--- a/tests/test_enrichment_service.py
+++ b/tests/test_enrichment_service.py
@@ -28,6 +28,15 @@ from app.enrichment_service import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stub_intel_cache():
+    """Keep the intel cache out of unit tests (no real DB/Redis round-trips).
+    Tests that need a cache hit re-patch get_cached inside the test body."""
+    with patch("app.cache.intel_cache.get_cached", return_value=None), \
+         patch("app.cache.intel_cache.set_cached"):
+        yield
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # _clean_domain
 # ═══════════════════════════════════════════════════════════════════════
@@ -1239,6 +1248,48 @@ class TestEnrichEntitySafeProviderExceptions:
                                     enrich_entity("test.com")
                                 )
                                 assert result["domain"] == "test.com"
+
+
+class TestFindSuggestedContactsWaterfall:
+    """Phase B: caching + AI-gating in the contact waterfall."""
+
+    def test_cache_hit_short_circuits(self):
+        from app.enrichment_service import find_suggested_contacts
+        cached = [{"full_name": "Cached Person", "source": "lusha"}]
+        with patch("app.cache.intel_cache.get_cached", return_value=cached):
+            with patch(
+                "app.enrichment_service._lusha_find_contacts", new_callable=AsyncMock
+            ) as lusha:
+                result = asyncio.run(find_suggested_contacts("example.com"))
+                assert result == cached
+                lusha.assert_not_awaited()  # providers never run on a cache hit
+
+    def test_ai_skipped_when_tier1_has_enough(self):
+        from app.enrichment_service import find_suggested_contacts
+        rich = [
+            {"full_name": f"Buyer {i}", "title": "Buyer", "email": f"b{i}@x.com", "source": "lusha"}
+            for i in range(3)
+        ]
+        with patch("app.enrichment_service.get_credential_cached", return_value=None), \
+             patch("app.enrichment_service._lusha_find_contacts",
+                   new_callable=AsyncMock, return_value=rich), \
+             patch("app.enrichment_service._ai_find_contacts",
+                   new_callable=AsyncMock, return_value=[]) as ai:
+            result = asyncio.run(find_suggested_contacts("example.com"))
+            assert len(result) == 3
+            ai.assert_not_awaited()  # tier-1 was rich → don't spend on AI
+
+    def test_ai_called_when_sparse(self):
+        from app.enrichment_service import find_suggested_contacts
+        with patch("app.enrichment_service.get_credential_cached", return_value=None), \
+             patch("app.enrichment_service._lusha_find_contacts",
+                   new_callable=AsyncMock,
+                   return_value=[{"full_name": "Solo", "title": "Buyer",
+                                  "email": "s@x.com", "source": "lusha"}]), \
+             patch("app.enrichment_service._ai_find_contacts",
+                   new_callable=AsyncMock, return_value=[]) as ai:
+            asyncio.run(find_suggested_contacts("example.com"))
+            ai.assert_awaited()  # sparse tier-1 → fall through to AI
 
 
 class TestFindSuggestedContactsProviderExceptions:

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,98 @@
+"""Tests for the outbound resilience wrapper (app/connectors/resilience.py).
+
+Covers: pass-through success, retry on 429/5xx then success, Retry-After,
+breaker-open short-circuit, timeout exhaustion → ProviderUnavailable, and
+auth-failure passthrough. Backoff sleeps are 0 under TESTING (TESTING=1 in conftest).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.connectors import resilience
+from app.connectors.resilience import ProviderUnavailable, resilient_call
+
+
+def _resp(status, headers=None):
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status
+    r.headers = headers or {}
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    resilience.reset_state()
+    from app.connectors.sources import _breakers
+    _breakers.clear()
+    yield
+
+
+def test_success_passthrough():
+    factory = AsyncMock(return_value=_resp(200))
+    resp = asyncio.run(resilient_call("lusha", factory))
+    assert resp.status_code == 200
+    assert factory.await_count == 1
+
+
+def test_retries_on_500_then_succeeds():
+    factory = AsyncMock(side_effect=[_resp(500), _resp(200)])
+    resp = asyncio.run(resilient_call("apollo", factory, max_retries=2))
+    assert resp.status_code == 200
+    assert factory.await_count == 2
+
+
+def test_retryable_exhausted_returns_last_response():
+    factory = AsyncMock(side_effect=[_resp(503), _resp(503), _resp(503)])
+    resp = asyncio.run(resilient_call("explorium", factory, max_retries=2))
+    assert resp.status_code == 503
+    assert factory.await_count == 3
+
+
+def test_respects_retry_after_header():
+    factory = AsyncMock(side_effect=[_resp(429, {"Retry-After": "0"}), _resp(200)])
+    resp = asyncio.run(resilient_call("clay", factory, max_retries=1))
+    assert resp.status_code == 200
+    assert factory.await_count == 2
+
+
+def test_auth_failure_passes_response_through():
+    factory = AsyncMock(return_value=_resp(401))
+    resp = asyncio.run(resilient_call("lusha", factory))
+    assert resp.status_code == 401
+    # Not retried — auth errors won't fix themselves
+    assert factory.await_count == 1
+
+
+def test_timeout_exhaustion_raises_provider_unavailable():
+    factory = AsyncMock(side_effect=httpx.ConnectTimeout("boom"))
+    with pytest.raises(ProviderUnavailable):
+        asyncio.run(resilient_call("apollo", factory, max_retries=1))
+    assert factory.await_count == 2
+
+
+def test_open_breaker_short_circuits():
+    from app.connectors.sources import get_breaker
+    breaker = get_breaker("provider:lusha")
+    for _ in range(breaker.fail_max):
+        breaker.record_failure()
+    assert breaker.current_state == "open"
+    factory = AsyncMock(return_value=_resp(200))
+    with pytest.raises(ProviderUnavailable):
+        asyncio.run(resilient_call("lusha", factory))
+    factory.assert_not_awaited()
+
+
+def test_non_retryable_4xx_returns_immediately():
+    factory = AsyncMock(return_value=_resp(404))
+    resp = asyncio.run(resilient_call("explorium", factory, max_retries=2))
+    assert resp.status_code == 404
+    assert factory.await_count == 1
+
+
+def test_record_provider_result_noop_under_testing():
+    # Under TESTING, no DB/alert side effects — should not raise.
+    resilience.record_provider_result("lusha", ok=True)
+    resilience.record_provider_result("lusha", ok=False, error="x", auth_failure=True)

--- a/tests/test_routers_crm.py
+++ b/tests/test_routers_crm.py
@@ -914,12 +914,12 @@ class TestSitesAdditional:
 
 
 class TestEnrichment:
-    @patch("app.routers.crm.enrichment.get_credential_cached", return_value=None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=False)
     def test_enrich_company_no_provider(self, mock_cred, client, db_session, test_company):
         resp = client.post(f"/api/enrich/company/{test_company.id}")
         assert resp.status_code == 503
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     @patch("app.enrichment_service.enrich_entity", new_callable=AsyncMock)
     @patch("app.enrichment_service.apply_enrichment_to_company")
     def test_enrich_company_success(self, mock_apply, mock_enrich, mock_cred, client, db_session, test_company):
@@ -932,12 +932,12 @@ class TestEnrichment:
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     def test_enrich_company_not_found(self, mock_cred, client):
         resp = client.post("/api/enrich/company/99999")
         assert resp.status_code == 404
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     @patch("app.enrichment_service.enrich_entity", new_callable=AsyncMock)
     @patch("app.enrichment_service.apply_enrichment_to_company")
     def test_enrich_company_no_domain(self, mock_apply, mock_enrich, mock_cred, client, db_session, test_company):
@@ -949,7 +949,7 @@ class TestEnrichment:
         resp = client.post(f"/api/enrich/company/{test_company.id}")
         assert resp.status_code == 400
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     @patch("app.enrichment_service.enrich_entity", new_callable=AsyncMock)
     @patch("app.enrichment_service.apply_enrichment_to_company")
     def test_enrich_company_with_override_domain(self, mock_apply, mock_enrich, mock_cred, client, db_session, test_company):
@@ -964,12 +964,12 @@ class TestEnrichment:
         assert resp.status_code == 200
         mock_enrich.assert_called_once_with("override-domain.com", test_company.name)
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", return_value=None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=False)
     def test_enrich_vendor_no_provider(self, mock_cred, client, db_session, test_vendor_card):
         resp = client.post(f"/api/enrich/vendor/{test_vendor_card.id}")
         assert resp.status_code == 503
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     @patch("app.enrichment_service.enrich_entity", new_callable=AsyncMock)
     @patch("app.enrichment_service.apply_enrichment_to_vendor")
     def test_enrich_vendor_success(self, mock_apply, mock_enrich, mock_cred, client, db_session, test_vendor_card):
@@ -982,12 +982,12 @@ class TestEnrichment:
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     def test_enrich_vendor_not_found(self, mock_cred, client):
         resp = client.post("/api/enrich/vendor/99999")
         assert resp.status_code == 404
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     @patch("app.enrichment_service.enrich_entity", new_callable=AsyncMock)
     @patch("app.enrichment_service.apply_enrichment_to_vendor")
     def test_enrich_vendor_no_domain(self, mock_apply, mock_enrich, mock_cred, client, db_session, test_vendor_card):
@@ -998,7 +998,7 @@ class TestEnrichment:
         resp = client.post(f"/api/enrich/vendor/{test_vendor_card.id}")
         assert resp.status_code == 400
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     @patch("app.enrichment_service.enrich_entity", new_callable=AsyncMock)
     @patch("app.enrichment_service.apply_enrichment_to_vendor")
     def test_enrich_vendor_override_domain(self, mock_apply, mock_enrich, mock_cred, client, db_session, test_vendor_card):
@@ -1011,17 +1011,17 @@ class TestEnrichment:
         )
         assert resp.status_code == 200
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", return_value=None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=False)
     def test_suggested_contacts_no_provider(self, mock_cred, client):
         resp = client.get("/api/suggested-contacts", params={"domain": "acme.com"})
         assert resp.status_code == 503
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     def test_suggested_contacts_no_domain(self, mock_cred, client):
         resp = client.get("/api/suggested-contacts")
         assert resp.status_code == 400
 
-    @patch("app.routers.crm.enrichment.get_credential_cached", side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None)
+    @patch("app.routers.crm.enrichment.enrichment_provider_configured", return_value=True)
     @patch("app.enrichment_service.find_suggested_contacts", new_callable=AsyncMock)
     def test_suggested_contacts_success(self, mock_contacts, mock_cred, client):
         mock_contacts.return_value = [


### PR DESCRIPTION
Stacked on #419 (base = `api-integrations`). Implements the optimize/maximize/harden roadmap in three phases.

## Phase A — Harden the connection
- New `app/connectors/resilience.py`: per-provider **circuit breaker** + **retry/backoff** (honors `Retry-After`) + **token-bucket rate limiting** + health bookkeeping.
- `record_provider_result` updates `ApiSource.status/last_success/last_error` and fires a throttled **Teams auth-failure alert**.
- Wired Lusha / Apollo / Explorium / Clay outbound calls through `resilient_call()` (kept each connector's `http` as the test patch point; backoff/DB/alerts are no-ops under TESTING).
- **Clay callback hardening**: optional **HMAC body signature** (`x-clay-signature`), payload size cap (256 KB), and contact cap.
- conftest resets breaker/rate-limit state between tests.

## Phase B — Cut API spend + latency
- Cache `find_suggested_contacts` 7 days per domain+title (was uncached → re-billed every call).
- **Negative-cache** `enrich_entity` misses for 1 day.
- **Tiered waterfall**: run paid providers first; only spend on the expensive AI web-search lookup when results are still sparse (< 3 relevant).
- Per-provider **monthly usage counters** (Redis INCR) via `record_provider_result`.

## Phase C — Reduce maintenance drift
- Single `enrichment_provider_configured()` helper replaces the triplicated 503 gate (the duplication that caused the original Apollo/Explorium divergence).
- Apollo `auth_headers()` — one source of truth for `X-Api-Key`, shared by `apollo_client` + `prospect_discovery_apollo`.

## Testing
All affected suites green, run individually: resilience (9), Lusha+Clay (28), enrichment incl. cache/AI-gating (130), connectors+discovery+sources (305+), v13 (60), **CRM (247)**, cache/usage counters, deep-enrichment, main-coverage, circuit-breaker. New modules pass Ruff clean.

## Deliberately deferred (own follow-up)
Full provider **registry/Protocol** consolidation of the 40-entry source catalog (`main.py`) + test-connector dispatch — high churn, low incremental benefit; best as its own PR. Pre-existing dead imports in `crm/enrichment.py` left untouched (not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)