### PR TITLE
feat(ui): Settings/Excess/Tickets/Admin + shared shells sweep (UX consistency PR 6/6)

### DIFF
--- a/app/templates/htmx/partials/_dashboard_cards.html
+++ b/app/templates/htmx/partials/_dashboard_cards.html
@@ -19,6 +19,6 @@
         </svg>
       </div>
       <p class="text-3xl font-bold text-brand-600">{{ count }}</p>
-      <p class="text-sm text-gray-500 mt-1">{{ label }}</p>
+      <p class="text-sm text-gray-600 mt-1">{{ label }}</p>
     </div>
 {%- endmacro %}

--- a/app/templates/htmx/partials/admin/_macros.html
+++ b/app/templates/htmx/partials/admin/_macros.html
@@ -17,7 +17,7 @@
 #}
 {% macro data_ops_count_card(label, count) -%}
 <div class="bg-white rounded-lg shadow border border-gray-200 p-4 text-center">
-      <p class="text-xs text-gray-500">{{ label }}</p>
+      <p class="text-xs text-gray-600">{{ label }}</p>
       <p class="text-xl font-bold text-gray-900">{{ "{:,}".format(count) }}</p>
     </div>
 {%- endmacro %}

--- a/app/templates/htmx/partials/admin/data_ops.html
+++ b/app/templates/htmx/partials/admin/data_ops.html
@@ -22,9 +22,9 @@
           data-loading-disable
           class="flex items-center gap-3">
       <input aria-label="Upload vendor CSV file" type="file" name="file" accept=".csv"
-             class="text-sm text-gray-500 file:mr-2 file:py-1 file:px-3 file:rounded file:border-0 file:text-xs file:font-medium file:bg-brand-50 file:text-brand-600 hover:file:bg-brand-100">
+             class="text-sm text-gray-600 file:mr-2 file:py-1 file:px-3 file:rounded file:border-0 file:text-xs file:font-medium file:bg-brand-50 file:text-brand-600 hover:file:bg-brand-100">
       <button type="submit"
-              class="px-3 py-1.5 text-xs font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+              class="btn btn-sm btn-primary">
         Import
       </button>
     </form>

--- a/app/templates/htmx/partials/admin/spec_codes_empty.html
+++ b/app/templates/htmx/partials/admin/spec_codes_empty.html
@@ -7,6 +7,6 @@
 #}
 <div id="spec-codes-content"{% if oob %} hx-swap-oob="true"{% endif %}>
   <div class="bg-white border border-brand-200 rounded-lg px-4 py-8 text-center">
-    <p class="text-sm text-gray-500">No pending mappings.</p>
+    <p class="text-sm text-gray-600">No pending mappings.</p>
   </div>
 </div>

--- a/app/templates/htmx/partials/admin/spec_codes_pending.html
+++ b/app/templates/htmx/partials/admin/spec_codes_pending.html
@@ -35,23 +35,23 @@
           <tbody class="divide-y divide-gray-100" id="spec-codes-pending-tbody">
             {% for row in rows %}
             <tr id="spec-row-{{ row.id }}" class="align-top hover:bg-brand-50/30 transition-colors">
-              <td class="px-4 py-3 text-sm font-mono text-gray-900">{{ row.oem }}</td>
-              <td class="px-4 py-3 text-sm font-mono text-gray-900">{{ row.spec_code }}</td>
-              <td class="px-4 py-3 text-sm">
+              <td class="table-cell text-sm font-mono text-gray-900">{{ row.oem }}</td>
+              <td class="table-cell text-sm font-mono text-gray-900">{{ row.spec_code }}</td>
+              <td class="table-cell text-sm">
                 <ul class="space-y-1">
                   {% for entry in row.proposed_avl %}
                     <li>
                       <code class="text-gray-900">{{ entry.mpn }}</code>
-                      <span class="text-gray-500">— {{ entry.manufacturer }} (rank {{ entry.rank }})</span>
+                      <span class="text-gray-600">— {{ entry.manufacturer }} (rank {{ entry.rank }})</span>
                       {% if entry.notes %}
-                        <span class="block text-xs text-gray-500 pl-3">{{ entry.notes }}</span>
+                        <span class="block text-xs text-gray-600 pl-3">{{ entry.notes }}</span>
                       {% endif %}
                     </li>
                   {% endfor %}
                 </ul>
               </td>
-              <td class="px-4 py-3 text-sm text-gray-900">{{ "%.2f"|format(row.llm_confidence) }}</td>
-              <td class="px-4 py-3 text-sm">
+              <td class="table-cell text-sm text-gray-900">{{ "%.2f"|format(row.llm_confidence) }}</td>
+              <td class="table-cell text-sm">
                 {% if row.citations %}
                   {% for c in row.citations %}
                     {% if c.url and (c.url.startswith('http://') or c.url.startswith('https://')) %}
@@ -65,10 +65,10 @@
                   <span class="text-gray-400">—</span>
                 {% endif %}
               </td>
-              <td class="px-4 py-3 text-sm text-gray-600">
+              <td class="table-cell text-sm text-gray-600">
                 {{ (row.used_in_requirement_ids or [])|length }} req(s)
               </td>
-              <td class="px-4 py-3">
+              <td class="table-cell">
                 <div class="flex flex-wrap gap-2">
                   <button data-loading-disable
                           hx-post="/admin/spec-codes/pending/{{ row.id }}/approve"

--- a/app/templates/htmx/partials/dashboard.html
+++ b/app/templates/htmx/partials/dashboard.html
@@ -34,8 +34,7 @@
     <h3 class="text-base font-semibold text-gray-900 mb-4">Quick Actions</h3>
     <div class="flex flex-wrap gap-3"
          x-data="{ showReqModal: false }">
-      <button class="inline-flex items-center gap-2 px-5 py-2.5 bg-brand-500 text-white text-sm font-medium rounded-lg
-                     hover:bg-brand-600 transition-colors shadow-sm"
+      <button class="btn btn-lg btn-primary gap-2 shadow-sm"
               @click="$dispatch('open-create-requisition')">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />

--- a/app/templates/htmx/partials/excess/add_line_item_modal.html
+++ b/app/templates/htmx/partials/excess/add_line_item_modal.html
@@ -2,7 +2,7 @@
    Receives: list_id.
    Called by: excess router add-line-item-form endpoint.
 #}
-<div class="p-6">
+<div class="p-4">
   <h3 class="text-lg font-semibold text-gray-900 mb-4">Add Line Item</h3>
   <form hx-post="/api/excess-lists/{{ list_id }}/line-items"
         hx-target="#main-content"
@@ -13,56 +13,56 @@
         hx-swap="innerHTML"
         class="space-y-4">
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Part Number *</label>
+      <label class="form-label">Part Number *</label>
       <input type="text" name="part_number" required
-             class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+             class="input"
              placeholder="e.g. LM358N">
     </div>
     <div class="grid grid-cols-2 gap-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Manufacturer</label>
+        <label class="form-label">Manufacturer</label>
         <input type="text" name="manufacturer"
-               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+               class="input"
                placeholder="e.g. Texas Instruments">
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Quantity *</label>
+        <label class="form-label">Quantity *</label>
         <input type="number" name="quantity" required min="1" value="1"
-               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+               class="input">
       </div>
     </div>
     <div class="grid grid-cols-3 gap-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Condition</label>
+        <label class="form-label">Condition</label>
         <select name="condition"
-                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+                class="input">
           <option value="New" selected>New</option>
           <option value="Used">Used</option>
           <option value="Refurbished">Refurbished</option>
         </select>
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Date Code</label>
+        <label class="form-label">Date Code</label>
         <input type="text" name="date_code"
-               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+               class="input"
                placeholder="e.g. 2024+">
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Asking Price</label>
+        <label class="form-label">Asking Price</label>
         <input type="number" name="asking_price" step="0.01" min="0"
-               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+               class="input"
                placeholder="0.00">
       </div>
     </div>
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Notes</label>
+      <label class="form-label">Notes</label>
       <textarea name="notes" rows="2"
-                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                class="input"
                 placeholder="Optional notes..."></textarea>
     </div>
     <div class="flex justify-end gap-3 pt-2">
       <button type="button" @click="$dispatch('close-modal')"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50">
+              class="btn btn-md btn-secondary">
         Cancel
       </button>
       <button type="submit"

--- a/app/templates/htmx/partials/excess/bid_form.html
+++ b/app/templates/htmx/partials/excess/bid_form.html
@@ -3,9 +3,9 @@
    Called by: partial_bid_form route.
    Depends on: brand palette, Alpine.js, HTMX, json-enc extension.
 #}
-<div class="p-6">
+<div class="p-4">
   <h3 class="text-lg font-semibold text-gray-900 mb-1">Record Bid</h3>
-  <p class="text-sm text-gray-500 mb-4">{{ item.part_number }} — {{ "{:,}".format(item.quantity) }} pcs
+  <p class="text-sm text-gray-600 mb-4">{{ item.part_number }} — {{ "{:,}".format(item.quantity) }} pcs
     {% if item.asking_price is not none %} @ ${{ "{:,.2f}".format(item.asking_price|float) }}{% endif %}
   </p>
 
@@ -17,9 +17,9 @@
         class="space-y-4">
 
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Bidder Company</label>
+      <label class="form-label">Bidder Company</label>
       <select name="bidder_company_id"
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+              class="input">
         <option value="">— Select company —</option>
         {% for co in companies %}
         <option value="{{ co.id }}">{{ co.name }}</option>
@@ -29,29 +29,29 @@
 
     <div class="grid grid-cols-2 gap-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Price per Unit *</label>
+        <label class="form-label">Price per Unit *</label>
         <input type="number" name="unit_price" required min="0" step="0.0001"
-               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+               class="input"
                placeholder="0.0000">
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Quantity Wanted *</label>
+        <label class="form-label">Quantity Wanted *</label>
         <input type="number" name="quantity_wanted" required min="1" value="{{ item.quantity }}"
-               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+               class="input">
       </div>
     </div>
 
     <div class="grid grid-cols-2 gap-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Lead Time (days)</label>
+        <label class="form-label">Lead Time (days)</label>
         <input type="number" name="lead_time_days" min="0"
-               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+               class="input"
                placeholder="Optional">
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Source</label>
+        <label class="form-label">Source</label>
         <select name="source"
-                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+                class="input">
           <option value="manual" selected>Manual Entry</option>
           <option value="phone">Phone Call</option>
         </select>
@@ -59,15 +59,15 @@
     </div>
 
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Notes</label>
+      <label class="form-label">Notes</label>
       <textarea name="notes" rows="2"
-                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                class="input"
                 placeholder="Optional notes..."></textarea>
     </div>
 
     <div class="flex justify-end gap-3 pt-2">
       <button type="button" @click="$dispatch('close-modal')"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50">
+              class="btn btn-secondary">
         Cancel
       </button>
       <button type="submit"

--- a/app/templates/htmx/partials/excess/bid_list.html
+++ b/app/templates/htmx/partials/excess/bid_list.html
@@ -6,16 +6,16 @@
 {% set bid_status_colors = {
   "pending": "bg-amber-50 text-amber-700",
   "accepted": "bg-emerald-50 text-emerald-700",
-  "rejected": "bg-gray-100 text-gray-500",
+  "rejected": "bg-gray-100 text-gray-600",
   "expired": "bg-rose-50 text-rose-600",
-  "withdrawn": "bg-gray-100 text-gray-500",
+  "withdrawn": "bg-gray-100 text-gray-600",
 } %}
 
-<div class="p-6 max-w-3xl">
+<div class="p-4 max-w-3xl">
   <div class="flex items-center justify-between mb-4">
     <div>
       <h3 class="text-lg font-semibold text-gray-900">Bids for {{ item.part_number }}</h3>
-      <p class="text-sm text-gray-500">{{ "{:,}".format(item.quantity) }} pcs
+      <p class="text-sm text-gray-600">{{ "{:,}".format(item.quantity) }} pcs
         {% if item.asking_price is not none %} — asking ${{ "{:,.4f}".format(item.asking_price|float) }}{% endif %}
       </p>
     </div>
@@ -96,7 +96,7 @@
         </tr>
         {% if bid.notes %}
         <tr class="{{ 'bg-emerald-50/30' if bid.status == 'accepted' else '' }}">
-          <td colspan="6" class="px-3 py-1.5 text-xs text-gray-500 italic">{{ bid.notes }}</td>
+          <td colspan="6" class="px-3 py-1.5 text-xs text-gray-600 italic">{{ bid.notes }}</td>
         </tr>
         {% endif %}
         {% endfor %}

--- a/app/templates/htmx/partials/excess/create_modal.html
+++ b/app/templates/htmx/partials/excess/create_modal.html
@@ -3,7 +3,7 @@
    Called by: "New List" button dispatching open-modal + hx-get.
    Depends on: modal.html shell, brand palette, Alpine.js.
 #}
-<div class="p-6">
+<div class="p-4">
   <div class="flex items-center justify-between mb-6">
     <h2 class="text-lg font-semibold text-gray-900">New Excess List</h2>
     {# Close handled by the global modal chrome X (base.html) #}
@@ -39,9 +39,9 @@
     </div>
     <div class="mt-6 flex justify-end gap-3 pt-4 border-t border-gray-100">
       <button type="button" @click="$dispatch('close-modal')"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">Cancel</button>
+              class="btn btn-secondary">Cancel</button>
       <button type="submit"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 shadow-sm transition-colors">Create List</button>
+              class="btn btn-primary">Create List</button>
     </div>
   </form>
 </div>

--- a/app/templates/htmx/partials/excess/detail.html
+++ b/app/templates/htmx/partials/excess/detail.html
@@ -26,7 +26,7 @@
 <div class="max-w-5xl mx-auto space-y-6">
 
   {# ── Header Card ────────────────────────────────────────────────── #}
-  <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-6">
+  <div class="card">
     <div class="flex items-start justify-between">
       {# Single-quoted x-data: |tojson emits double quotes (and escapes single quotes),
          so it is safe inside single quotes but would break a double-quoted attribute. #}
@@ -63,7 +63,7 @@
         </form>
 
         {# Meta row #}
-        <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-500">
+        <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-600">
           <span>{{ list.company.name if list.company else "\u2014" }}</span>
           {% if list.owner %}
           <span class="flex items-center gap-1">
@@ -166,7 +166,7 @@
   {# ── File Upload / Import ───────────────────────────────────────── #}
   {% if list.status == "draft" %}
   <div id="import-area">
-    <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-6"
+    <div class="card-lg"
          x-data="{ dragging: false, uploading: false }">
       <h2 class="text-lg font-semibold text-gray-900 mb-4">Import Line Items</h2>
 
@@ -197,7 +197,7 @@
               <p class="mt-2 text-sm text-gray-600">
                 <span class="font-medium text-brand-600">Click to upload</span> or drag and drop
               </p>
-              <p class="mt-1 text-xs text-gray-500">CSV, TSV, or Excel files (max 10 MB)</p>
+              <p class="mt-1 text-xs text-gray-600">CSV, TSV, or Excel files (max 10 MB)</p>
             </div>
           </template>
           <template x-if="uploading" x-cloak>
@@ -218,7 +218,7 @@
     <button @click="$dispatch('open-modal')"
             hx-get="/v2/partials/excess/{{ list.id }}/add-line-item-form"
             hx-target="#modal-content"
-            class="inline-flex items-center px-4 py-2 bg-brand-500 text-white text-sm font-medium rounded-lg hover:bg-brand-600 transition-colors">
+            class="btn-primary">
       <svg class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
       </svg>
@@ -235,18 +235,18 @@
         <table class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Part Number</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Manufacturer</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Condition</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date Code</th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Asking Price</th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-              <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Matches</th>
-              <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Bids</th>
-              <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Sent</th>
-              <th class="px-4 py-3 w-10"></th>
+              <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Part Number</th>
+              <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+              <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Manufacturer</th>
+              <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
+              <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Condition</th>
+              <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date Code</th>
+              <th class="table-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Asking Price</th>
+              <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+              <th class="table-cell--head text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Matches</th>
+              <th class="table-cell--head text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Bids</th>
+              <th class="table-cell--head text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Sent</th>
+              <th class="table-cell--head w-10"></th>
             </tr>
           </thead>
           <tbody id="line-items-body" class="divide-y divide-gray-200">
@@ -258,12 +258,12 @@
       </div>
     </div>
     {% else %}
-    <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-12 text-center">
+    <div class="card text-center p-6 sm:p-8">
       <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
       </svg>
       <h3 class="mt-3 text-sm font-medium text-gray-900">No line items yet</h3>
-      <p class="mt-1 text-sm text-gray-500">
+      <p class="mt-1 text-sm text-gray-600">
         {% if list.status == "draft" %}
           Upload a file above or add items manually to get started.
         {% else %}

--- a/app/templates/htmx/partials/excess/import_preview.html
+++ b/app/templates/htmx/partials/excess/import_preview.html
@@ -8,7 +8,7 @@
     {% if error_count %}
       <span class="font-medium text-red-500">{{ error_count }} errors</span>
     {% endif %}
-    <span class="text-gray-500">from {{ filename }}</span>
+    <span class="text-gray-600">from {{ filename }}</span>
   </div>
 
   {% if errors %}
@@ -26,30 +26,30 @@
     <table class="min-w-full text-sm">
       <thead class="bg-gray-50 dark:bg-gray-800">
         <tr>
-          <th class="px-3 py-2 text-left font-medium">Part Number</th>
-          <th class="px-3 py-2 text-left font-medium">Manufacturer</th>
-          <th class="px-3 py-2 text-right font-medium">Qty</th>
-          <th class="px-3 py-2 text-left font-medium">Date Code</th>
-          <th class="px-3 py-2 text-left font-medium">Condition</th>
-          <th class="px-3 py-2 text-right font-medium">Asking Price</th>
+          <th class="compact-cell--head text-left font-medium">Part Number</th>
+          <th class="compact-cell--head text-left font-medium">Manufacturer</th>
+          <th class="compact-cell--head text-right font-medium">Qty</th>
+          <th class="compact-cell--head text-left font-medium">Date Code</th>
+          <th class="compact-cell--head text-left font-medium">Condition</th>
+          <th class="compact-cell--head text-right font-medium">Asking Price</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
         {% for row in preview_rows %}
         <tr>
-          <td class="px-3 py-2 font-mono">{{ row.part_number or '-' }}</td>
-          <td class="px-3 py-2">{{ row.manufacturer or '-' }}</td>
-          <td class="px-3 py-2 text-right">{{ row.quantity or '-' }}</td>
-          <td class="px-3 py-2">{{ row.date_code or '-' }}</td>
-          <td class="px-3 py-2">{{ row.condition or '-' }}</td>
-          <td class="px-3 py-2 text-right">{{ '${:,.2f}'.format(row.asking_price) if row.asking_price else '-' }}</td>
+          <td class="compact-cell font-mono">{{ row.part_number or '-' }}</td>
+          <td class="compact-cell">{{ row.manufacturer or '-' }}</td>
+          <td class="compact-cell text-right">{{ row.quantity or '-' }}</td>
+          <td class="compact-cell">{{ row.date_code or '-' }}</td>
+          <td class="compact-cell">{{ row.condition or '-' }}</td>
+          <td class="compact-cell text-right">{{ '${:,.2f}'.format(row.asking_price) if row.asking_price else '-' }}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
   </div>
   {% if valid_count > preview_rows|length %}
-    <p class="text-xs text-gray-500">Showing {{ preview_rows|length }} of {{ valid_count }} valid rows</p>
+    <p class="text-xs text-gray-600">Showing {{ preview_rows|length }} of {{ valid_count }} valid rows</p>
   {% endif %}
   {% endif %}
 

--- a/app/templates/htmx/partials/excess/line_item_row.html
+++ b/app/templates/htmx/partials/excess/line_item_row.html
@@ -8,10 +8,10 @@
   "available": "bg-emerald-50 text-emerald-700",
   "bidding": "bg-amber-50 text-amber-700",
   "awarded": "bg-blue-50 text-blue-700",
-  "withdrawn": "bg-gray-100 text-gray-500",
+  "withdrawn": "bg-gray-100 text-gray-600",
 } %}
 <tr id="line-item-{{ item.id }}" class="hover:bg-gray-50 group">
-  <td class="px-4 py-3">
+  <td class="table-cell">
     <span class="text-sm font-semibold text-gray-900">{{ item.part_number }}</span>
     {% if item.notes %}
     <span class="ml-1 text-gray-400 cursor-help" title="{{ item.notes }}">
@@ -21,24 +21,24 @@
     </span>
     {% endif %}
     {% if item.normalized_part_number and item.normalized_part_number != item.part_number.strip().lower() %}
-    <p class="text-[10px] text-gray-400 font-mono mt-0.5">&rarr; {{ item.normalized_part_number }}</p>
+    <p class="text-xs text-gray-400 font-mono mt-0.5">&rarr; {{ item.normalized_part_number }}</p>
     {% endif %}
   </td>
   {% set desc = item|part_description %}
-  <td class="px-4 py-3 text-sm text-gray-500 truncate max-w-[200px]" title="{{ desc }}">{{ desc or "\u2014" }}</td>
-  <td class="px-4 py-3 text-sm text-gray-600">{{ item.manufacturer or "\u2014" }}</td>
-  <td class="px-4 py-3 text-sm text-gray-600 text-right tabular-nums">{{ "{:,}".format(item.quantity) }}</td>
-  <td class="px-4 py-3 text-sm text-gray-600">{{ item.condition or "\u2014" }}</td>
-  <td class="px-4 py-3 text-sm text-gray-600">{{ item.date_code or "\u2014" }}</td>
-  <td class="px-4 py-3 text-sm text-gray-600 text-right tabular-nums">
+  <td class="table-cell text-sm text-gray-600 truncate max-w-[200px]" title="{{ desc }}">{{ desc or "\u2014" }}</td>
+  <td class="table-cell text-sm text-gray-600">{{ item.manufacturer or "\u2014" }}</td>
+  <td class="table-cell text-sm text-gray-600 text-right tabular-nums">{{ "{:,}".format(item.quantity) }}</td>
+  <td class="table-cell text-sm text-gray-600">{{ item.condition or "\u2014" }}</td>
+  <td class="table-cell text-sm text-gray-600">{{ item.date_code or "\u2014" }}</td>
+  <td class="table-cell text-sm text-gray-600 text-right tabular-nums">
     {% if item.asking_price is not none %}${{ "{:,.2f}".format(item.asking_price|float) }}{% else %}&mdash;{% endif %}
   </td>
-  <td class="px-4 py-3">
+  <td class="table-cell">
     <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ item_status_colors.get(item.status, 'bg-gray-100 text-gray-600') }}">
       {{ item.status|capitalize }}
     </span>
   </td>
-  <td class="px-4 py-3 text-center">
+  <td class="table-cell text-center">
     {% if item.demand_match_count %}
     <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-brand-100 text-brand-700"
           title="Matched against {{ item.demand_match_count }} active requirement(s)">
@@ -49,7 +49,7 @@
     <span class="text-xs text-gray-400">&mdash;</span>
     {% endif %}
   </td>
-  <td class="px-4 py-3 text-center">
+  <td class="table-cell text-center">
     {% set bid_count = item.bids|length if item.bids else 0 %}
     {% if bid_count > 0 %}
     <a hx-get="/v2/partials/excess/{{ item.excess_list_id }}/line-items/{{ item.id }}/bids"
@@ -70,7 +70,7 @@
     </a>
     {% endif %}
   </td>
-  <td class="px-4 py-3 text-center">
+  <td class="table-cell text-center">
     {% set sol_count = item.solicitations|length if item.solicitations else 0 %}
     {% if sol_count > 0 %}
     <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-violet-100 text-violet-700"
@@ -84,7 +84,7 @@
     <span class="text-xs text-gray-400">&mdash;</span>
     {% endif %}
   </td>
-  <td class="px-4 py-3 text-right">
+  <td class="table-cell text-right">
     {{ excess_delete_button(
          "/api/excess-lists/" ~ item.excess_list_id ~ "/line-items/" ~ item.id,
          "#line-item-" ~ item.id,

--- a/app/templates/htmx/partials/excess/list.html
+++ b/app/templates/htmx/partials/excess/list.html
@@ -9,13 +9,13 @@
   {# Header #}
   <div class="flex items-center justify-between mb-4">
     <div>
-      <p class="text-sm text-gray-500 mt-1">{{ total }} list{{ "s" if total != 1 else "" }}</p>
+      <p class="text-sm text-gray-600 mt-1">{{ total }} list{{ "s" if total != 1 else "" }}</p>
     </div>
     <button @click="$dispatch('open-modal')"
             hx-get="/v2/partials/excess/create-form"
             hx-target="#modal-content"
             data-loading-disable
-            class="inline-flex items-center px-4 py-2 bg-brand-500 text-white text-sm font-medium rounded-lg hover:bg-brand-600 transition-colors">
+            class="btn btn-primary">
       <svg data-loading class="h-4 w-4 mr-1.5 spinner" fill="none" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" stroke-dasharray="31.4" stroke-dashoffset="10"/></svg>
       <svg data-loading-remove class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
       New List
@@ -40,7 +40,7 @@
       </div>
       <div>
         <p class="text-lg font-bold text-gray-900 tabular-nums">{{ value }}</p>
-        <p class="text-[10px] text-gray-500 uppercase tracking-wider">{{ label }}</p>
+        <p class="text-xs text-gray-600 uppercase tracking-wider">{{ label }}</p>
       </div>
     </div>
     {% endfor %}
@@ -95,12 +95,12 @@
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Title</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Company</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Line Items</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
-            <th class="px-4 py-3 w-10"></th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Title</th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Company</th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+            <th class="table-cell--head text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Line Items</th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+            <th class="table-cell--head w-10"></th>
           </tr>
         </thead>
         <tbody id="excess-table-body" class="divide-y divide-gray-200">
@@ -121,7 +121,7 @@
          hx-target="#main-content" hx-swap="morph"
          class="px-3 py-1.5 text-sm bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Prev</a>
       {% endif %}
-      <span class="px-3 py-1.5 text-sm text-gray-500">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
+      <span class="px-3 py-1.5 text-sm text-gray-600">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
       {% if offset + limit < total %}
       <a hx-get="/v2/partials/excess?offset={{ offset + limit }}&q={{ q }}&status={{ status_filter }}"
          hx-target="#main-content" hx-swap="morph"
@@ -133,12 +133,12 @@
 
   {% else %}
   {# Empty state #}
-  <div class="bg-white rounded-lg shadow border border-gray-200 p-12 text-center">
+  <div class="bg-white rounded-lg shadow border border-gray-200 p-6 sm:p-8 text-center">
     <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
     </svg>
     <h3 class="mt-3 text-sm font-medium text-gray-900">No excess lists</h3>
-    <p class="mt-1 text-sm text-gray-500">
+    <p class="mt-1 text-sm text-gray-600">
       {% if q or status_filter %}
         No lists match your filters. <a hx-get="/v2/partials/excess" hx-target="#main-content" hx-push-url="true" class="text-brand-500 hover:text-brand-600 cursor-pointer">Clear filters</a>
       {% else %}
@@ -150,7 +150,7 @@
       <button @click="$dispatch('open-modal')"
               hx-get="/v2/partials/excess/create-form"
               hx-target="#modal-content"
-              class="inline-flex items-center px-4 py-2 bg-brand-500 text-white text-sm font-medium rounded-lg hover:bg-brand-600 transition-colors">
+              class="btn btn-primary">
         <svg class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
         New List
       </button>

--- a/app/templates/htmx/partials/excess/row.html
+++ b/app/templates/htmx/partials/excess/row.html
@@ -16,18 +16,18 @@
     hx-target="#main-content"
     hx-push-url="/v2/excess/{{ list.id }}"
     preload="mouseover">
-  <td class="px-4 py-3">
+  <td class="table-cell">
     <p class="text-sm font-medium text-brand-600">{{ list.title }}</p>
   </td>
-  <td class="px-4 py-3 text-sm text-gray-600">{{ list.company.name if list.company else "\u2014" }}</td>
-  <td class="px-4 py-3">
+  <td class="table-cell text-sm text-gray-600">{{ list.company.name if list.company else "\u2014" }}</td>
+  <td class="table-cell">
     <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full {{ status_colors.get(list.status, 'bg-gray-100 text-gray-600') }}">
       {{ list.status|capitalize }}
     </span>
   </td>
-  <td class="px-4 py-3 text-sm text-gray-600 text-center">{{ list.total_line_items or 0 }}</td>
-  <td class="px-4 py-3 text-sm text-gray-500">{{ list.created_at.strftime('%Y-%m-%d') if list.created_at else "\u2014" }}</td>
-  <td class="px-4 py-3 text-right" @click.stop>
+  <td class="table-cell text-sm text-gray-600 text-center">{{ list.total_line_items or 0 }}</td>
+  <td class="table-cell text-sm text-gray-600">{{ list.created_at.strftime('%Y-%m-%d') if list.created_at else "\u2014" }}</td>
+  <td class="table-cell text-right" @click.stop>
     {{ excess_delete_button(
          "/api/excess-lists/" ~ list.id,
          "#excess-row-" ~ list.id,

--- a/app/templates/htmx/partials/excess/solicit_modal.html
+++ b/app/templates/htmx/partials/excess/solicit_modal.html
@@ -13,7 +13,7 @@
   <div class="flex items-center justify-between mb-5">
     <div>
       <h2 class="text-lg font-semibold text-gray-900">Solicit Bids</h2>
-      <p class="text-sm text-gray-500 mt-0.5">
+      <p class="text-sm text-gray-600 mt-0.5">
         Compose a bid request for {{ items|length }} item{{ "s" if items|length != 1 else "" }}
       </p>
     </div>
@@ -34,27 +34,27 @@
 
     {# ── Recipient Email ─────────────────────────────────────────────── #}
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">
+      <label class="form-label">
         Recipient Email <span class="text-rose-500">*</span>
       </label>
       <input aria-label="Recipient Email" type="email" name="recipient_email" x-model="recipientEmail" required
              placeholder="vendor@example.com"
-             class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+             class="input">
     </div>
 
     {# ── Recipient Name ──────────────────────────────────────────────── #}
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Recipient Name</label>
+      <label class="form-label">Recipient Name</label>
       <input type="text" name="recipient_name" x-model="recipientName"
              placeholder="Contact name (optional)"
-             class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+             class="input">
     </div>
 
     {# ── Subject ─────────────────────────────────────────────────────── #}
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Subject</label>
+      <label class="form-label">Subject</label>
       <input type="text" name="subject" x-model="subject"
-             class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+             class="input">
     </div>
 
     {# ── Bundled toggle ──────────────────────────────────────────────── #}
@@ -69,10 +69,10 @@
 
     {# ── Message ─────────────────────────────────────────────────────── #}
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Message</label>
+      <label class="form-label">Message</label>
       <textarea name="message" x-model="message" rows="4"
                 placeholder="Write your message here..."
-                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 resize-y"></textarea>
+                class="input resize-y"></textarea>
       <div class="mt-1.5 flex justify-end">
         <button type="button" @click="polishEmail()"
                 :disabled="polishing || !message.trim()"
@@ -97,28 +97,28 @@
     {# ── Parts Table ─────────────────────────────────────────────────── #}
     {% if items %}
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-2">
+      <label class="form-label mb-2">
         Selected Parts ({{ items|length }})
       </label>
       <div class="border border-gray-200 rounded-lg overflow-hidden">
         <table class="min-w-full divide-y divide-gray-200 text-sm">
           <thead class="bg-gray-50">
             <tr>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN</th>
-              <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Condition</th>
-              <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date Code</th>
-              <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Asking Price</th>
+              <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN</th>
+              <th class="compact-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
+              <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Condition</th>
+              <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date Code</th>
+              <th class="compact-cell--head text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Asking Price</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-200 bg-white">
             {% for item in items %}
             <tr>
-              <td class="px-3 py-2 font-mono font-medium text-gray-900">{{ item.part_number }}</td>
-              <td class="px-3 py-2 text-right text-gray-700">{{ "{:,}".format(item.quantity) }}</td>
-              <td class="px-3 py-2 text-gray-600">{{ item.condition or "—" }}</td>
-              <td class="px-3 py-2 text-gray-600">{{ item.date_code or "—" }}</td>
-              <td class="px-3 py-2 text-right text-gray-700">
+              <td class="compact-cell font-mono font-medium text-gray-900">{{ item.part_number }}</td>
+              <td class="compact-cell text-right text-gray-700">{{ "{:,}".format(item.quantity) }}</td>
+              <td class="compact-cell text-gray-600">{{ item.condition or "—" }}</td>
+              <td class="compact-cell text-gray-600">{{ item.date_code or "—" }}</td>
+              <td class="compact-cell text-right text-gray-700">
                 {% if item.asking_price is not none %}
                   ${{ "{:,.4f}".format(item.asking_price|float) }}
                 {% else %}
@@ -140,11 +140,11 @@
     {# ── Actions ─────────────────────────────────────────────────────── #}
     <div class="flex justify-end gap-3 pt-2 border-t border-gray-100">
       <button type="button" @click="$dispatch('close-modal')"
-              class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+              class="btn btn-secondary">
         Cancel
       </button>
       <button type="submit" {% if not items %}disabled{% endif %}
-              class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+              class="btn btn-primary shadow-sm">
         <svg class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round"
                 d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>

--- a/app/templates/htmx/partials/follow_ups/list.html
+++ b/app/templates/htmx/partials/follow_ups/list.html
@@ -9,7 +9,7 @@
 <div class="max-w-7xl mx-auto">
   <div class="flex items-center justify-between mb-6">
     <div>
-      <p class="text-sm text-gray-500 mt-1">
+      <p class="text-sm text-gray-600 mt-1">
         <span class="font-medium text-amber-600">{{ total }}</span> contact{{ "s" if total != 1 }} needing follow-up
       </p>
     </div>
@@ -18,7 +18,7 @@
             hx-target="#main-content"
             hx-confirm="Send follow-up emails to all {{ total }} contacts?"
             data-loading-disable
-            class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 transition-colors shadow-sm">
+            class="btn btn-primary shadow-sm">
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
       </svg>
@@ -39,7 +39,7 @@
           <div class="flex items-center gap-2 mb-2">
             <h4 class="text-sm font-semibold text-gray-900">{{ fu.vendor_name or "Unknown Vendor" }}</h4>
             {% set days = fu.days_waiting %}
-            <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border
+            <span class="badge
               {{ 'bg-rose-50 text-rose-700 border-rose-200' if days >= 7 else
                  'bg-amber-50 text-amber-700 border-amber-200' if days >= 3 else
                  'bg-brand-50 text-brand-600 border-brand-200' }}">
@@ -49,7 +49,7 @@
               'sent': 'bg-sky-50 text-sky-700 border-sky-200',
               'opened': 'bg-amber-50 text-amber-700 border-amber-200',
             } %}
-            <span class="inline-flex items-center px-2 py-0.5 text-[10px] font-semibold rounded-full border {{ st_colors.get(fu.status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
+            <span class="badge {{ st_colors.get(fu.status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
               {% if fu.status == 'opened' %}
               <svg class="h-2.5 w-2.5 mr-0.5" fill="currentColor" viewBox="0 0 20 20">
                 <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
@@ -62,7 +62,7 @@
 
           {# Contact email #}
           {% if fu.vendor_email %}
-          <p class="text-xs text-gray-500 mb-1">
+          <p class="text-xs text-gray-600 mb-1">
             <svg class="inline h-3 w-3 mr-1 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
             </svg>
@@ -73,7 +73,7 @@
           {# Parts list #}
           {% if fu.parts %}
           <p class="text-xs text-gray-400 truncate">
-            <span class="text-gray-500 font-medium">Parts:</span>
+            <span class="text-gray-600 font-medium">Parts:</span>
             <span class="font-mono">{{ parts_summary(fu.parts) }}</span>
           </p>
           {% endif %}
@@ -115,7 +115,7 @@
                     class="w-full px-3 py-2 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-white"></textarea>
         </div>
         <button type="submit"
-                class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 transition-colors">
+                class="btn btn-primary">
           <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/>
           </svg>
@@ -126,7 +126,7 @@
     {% endfor %}
   </div>
   {% else %}
-  <div class="bg-white rounded-lg border border-brand-200 p-12 text-center">
+  <div class="bg-white rounded-lg border border-brand-200 p-6 sm:p-8 text-center">
     <svg class="mx-auto h-12 w-12 text-emerald-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
     </svg>

--- a/app/templates/htmx/partials/knowledge/list.html
+++ b/app/templates/htmx/partials/knowledge/list.html
@@ -14,7 +14,7 @@
            hx-get="/v2/partials/knowledge"
            hx-trigger="keyup changed delay:300ms"
            hx-target="#knowledge-list"
-           class="w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:ring-brand-500 focus:border-brand-500">
+           class="input">
   </div>
 
   {# Add entry form #}
@@ -30,9 +30,9 @@
       </select>
     </div>
     <textarea name="content" rows="2" placeholder="Enter knowledge content..."
-              class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"></textarea>
+              class="input input-sm"></textarea>
     <button type="submit"
-            class="px-3 py-1.5 text-xs font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+            class="btn btn-sm btn-primary">
       Add Entry
     </button>
   </form>
@@ -43,7 +43,7 @@
       {% for e in entries %}
       <div class="bg-white rounded-lg border border-gray-200 p-3">
         <div class="flex items-center gap-2 mb-1">
-          <span class="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-gray-100 text-gray-600">{{ e.entry_type }}</span>
+          <span class="px-1.5 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600">{{ e.entry_type }}</span>
         </div>
         <p class="text-sm text-gray-600">{{ e.content[:200] }}{{ '...' if e.content|length > 200 }}</p>
         {% if e.created_at %}

--- a/app/templates/htmx/partials/settings/_macros.html
+++ b/app/templates/htmx/partials/settings/_macros.html
@@ -15,7 +15,7 @@
 <button @click="tab = '{{ tab }}'"
             :class="tab === '{{ tab }}'
               ? 'border-b-2 border-brand-500 text-brand-600 bg-brand-50'
-              : 'text-gray-500 hover:text-brand-600 hover:bg-brand-50'"
+              : 'text-gray-600 hover:text-brand-600 hover:bg-brand-50'"
             class="px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors"
             hx-get="{{ url }}"
             hx-target="#settings-content"{{ extra_attrs|safe }}>

--- a/app/templates/htmx/partials/settings/data_ops.html
+++ b/app/templates/htmx/partials/settings/data_ops.html
@@ -47,7 +47,7 @@
             <span class="text-gray-400">&harr;</span>
             <span class="font-medium text-gray-900">{{ pair.name_b }}</span>
           </div>
-          <p class="text-xs text-gray-500 mt-0.5">
+          <p class="text-xs text-gray-600 mt-0.5">
             Score: {{ pair.score }}% match
             &middot; {{ pair.sightings_a or 0 }} vs {{ pair.sightings_b or 0 }} sightings
           </p>
@@ -63,7 +63,7 @@
     </div>
     {% else %}
     <div class="px-4 py-8 text-center">
-      <p class="text-sm text-gray-500">No duplicate vendors found at the current threshold.</p>
+      <p class="text-sm text-gray-600">No duplicate vendors found at the current threshold.</p>
     </div>
     {% endif %}
   </div>
@@ -92,7 +92,7 @@
             <span class="text-gray-400">&harr;</span>
             <span class="font-medium text-gray-900">{{ pair.company_b.name }}</span>
           </div>
-          <p class="text-xs text-gray-500 mt-0.5">
+          <p class="text-xs text-gray-600 mt-0.5">
             Score: {{ pair.score }}% match
             &middot; {{ pair.company_a.site_count or 0 }} vs {{ pair.company_b.site_count or 0 }} sites
             &middot; suggested keep: <span class="font-medium text-gray-700">{{ keeper.name|truncate(24) }}</span>
@@ -107,7 +107,7 @@
     </div>
     {% else %}
     <div class="px-4 py-8 text-center">
-      <p class="text-sm text-gray-500">No duplicate customers found at the current threshold.</p>
+      <p class="text-sm text-gray-600">No duplicate customers found at the current threshold.</p>
     </div>
     {% endif %}
   </div>

--- a/app/templates/htmx/partials/settings/index.html
+++ b/app/templates/htmx/partials/settings/index.html
@@ -31,7 +31,7 @@
        hx-trigger="load"
        hx-target="#settings-content"
        hx-indicator="#settings-load-spinner">
-    <div id="settings-load-spinner" class="htmx-indicator flex items-center justify-center py-12">
+    <div id="settings-load-spinner" class="htmx-indicator flex items-center justify-center py-6 sm:py-8">
       <svg class="h-6 w-6 text-brand-400 animate-spin" viewBox="0 0 24 24" fill="none">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>

--- a/app/templates/htmx/partials/settings/ops_group.html
+++ b/app/templates/htmx/partials/settings/ops_group.html
@@ -7,7 +7,7 @@
   <div class="bg-white border border-brand-200 rounded-lg overflow-hidden">
     <div class="px-5 py-4 bg-gray-50 border-b border-brand-200">
       <h2 class="text-lg font-semibold text-gray-900">Ops Verification Group</h2>
-      <p class="text-xs text-gray-500 mt-0.5">
+      <p class="text-xs text-gray-600 mt-0.5">
         Members can verify Sales Orders and Purchase Orders in the buy-plan workflow.
         Buy plans cannot complete without at least one active member.
         <span class="font-medium text-gray-700">{{ active_count }} active member{{ '' if active_count == 1 else 's' }}.</span>
@@ -15,38 +15,38 @@
     </div>
 
     {% if not rows %}
-    <div class="px-5 py-8 text-center text-sm text-gray-500">No users found.</div>
+    <div class="px-5 py-8 text-center text-sm text-gray-600">No users found.</div>
     {% else %}
     <div class="overflow-x-auto">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
-            <th class="px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
-            <th class="px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
-            <th class="px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Member since</th>
-            <th class="px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-            <th class="px-5 py-3"></th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Member since</th>
+            <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+            <th class="table-cell--head"></th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
           {% for row in rows %}
           <tr class="hover:bg-brand-50/50 transition-colors">
-            <td class="px-5 py-3">
+            <td class="table-cell">
               <div class="text-sm font-medium text-gray-900">{{ row.user.name or row.user.email }}</div>
-              <div class="text-xs text-gray-500">{{ row.user.email }}</div>
+              <div class="text-xs text-gray-600">{{ row.user.email }}</div>
             </td>
-            <td class="px-5 py-3 text-sm text-gray-600">{{ row.user.role }}</td>
-            <td class="px-5 py-3 text-xs text-gray-500">{{ row.member.added_at | fmtdate if row.member else '—' }}</td>
-            <td class="px-5 py-3">
+            <td class="table-cell text-sm text-gray-600">{{ row.user.role }}</td>
+            <td class="table-cell text-xs text-gray-600">{{ row.member.added_at | fmtdate if row.member else '—' }}</td>
+            <td class="table-cell">
               {% if row.is_member %}
               <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-700">Active</span>
               {% elif row.member %}
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-500">Inactive</span>
+              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">Inactive</span>
               {% else %}
               <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-50 text-gray-400">Not a member</span>
               {% endif %}
             </td>
-            <td class="px-5 py-3 text-right">
+            <td class="table-cell text-right">
               {% if row.is_member %}
               <button hx-post="/api/admin/ops-group/toggle" hx-vals='{"user_id": {{ row.user.id }}}'
                       hx-target="#ops-group-content" hx-swap="outerHTML"

--- a/app/templates/htmx/partials/settings/profile.html
+++ b/app/templates/htmx/partials/settings/profile.html
@@ -6,7 +6,7 @@
 #}
 
 <div class="max-w-2xl">
-  <div class="bg-white border border-brand-200 rounded-lg p-6 mb-6">
+  <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6">
     <h2 class="text-lg font-semibold text-gray-900 mb-5">Your Profile</h2>
 
     <div class="space-y-5">
@@ -17,7 +17,7 @@
         </div>
         <div>
           <p class="text-lg font-semibold text-gray-900">{{ profile_user.name }}</p>
-          <p class="text-sm text-gray-500">{{ profile_user.email }}</p>
+          <p class="text-sm text-gray-600">{{ profile_user.email }}</p>
         </div>
       </div>
 
@@ -25,7 +25,7 @@
 
       {# Role badge #}
       <div>
-        <label class="block text-sm font-medium text-gray-500 mb-1.5">Role</label>
+        <label class="block text-sm font-medium text-gray-600 mb-1.5">Role</label>
         {% set role_colors = {
           'admin': 'bg-brand-500 text-white',
           'buyer': 'bg-emerald-50 text-emerald-700',
@@ -40,14 +40,14 @@
 
       {# Email #}
       <div>
-        <label class="block text-sm font-medium text-gray-500 mb-1.5">Email</label>
+        <label class="block text-sm font-medium text-gray-600 mb-1.5">Email</label>
         <p class="text-sm text-gray-800">{{ profile_user.email }}</p>
       </div>
 
       {# Account created #}
       {% if profile_user.created_at %}
       <div>
-        <label class="block text-sm font-medium text-gray-500 mb-1.5">Member Since</label>
+        <label class="block text-sm font-medium text-gray-600 mb-1.5">Member Since</label>
         <p class="text-sm text-gray-800">{{ profile_user.created_at.strftime('%B %d, %Y') }}</p>
       </div>
       {% endif %}
@@ -55,12 +55,12 @@
   </div>
 
   {# 8x8 VoIP Toggle #}
-  <div class="bg-white border border-brand-200 rounded-lg p-6"
+  <div class="bg-white border border-brand-200 rounded-lg p-4"
        x-data="{ enabled: {{ 'true' if profile_user.eight_by_eight_enabled is defined and profile_user.eight_by_eight_enabled else 'false' }} }">
     <div class="flex items-center justify-between">
       <div>
         <h3 class="text-sm font-semibold text-gray-900">8x8 Click-to-Call</h3>
-        <p class="text-xs text-gray-500 mt-0.5">Enable click-to-call integration for phone numbers. When enabled, clicking a phone number will initiate a call through 8x8 VoIP.</p>
+        <p class="text-xs text-gray-600 mt-0.5">Enable click-to-call integration for phone numbers. When enabled, clicking a phone number will initiate a call through 8x8 VoIP.</p>
       </div>
       <label class="relative inline-flex items-center cursor-pointer ml-4">
         <input type="checkbox" x-model="enabled"

--- a/app/templates/htmx/partials/settings/sources.html
+++ b/app/templates/htmx/partials/settings/sources.html
@@ -9,7 +9,7 @@
   <div class="px-5 py-4 bg-gray-50 border-b border-brand-200 flex items-center justify-between">
     <div>
       <h2 class="text-lg font-semibold text-gray-900">Data Sources</h2>
-      <p class="text-xs text-gray-500 mt-0.5">Manage connector status and monitor health.</p>
+      <p class="text-xs text-gray-600 mt-0.5">Manage connector status and monitor health.</p>
     </div>
     {% if sources %}
     <span class="text-xs text-gray-400">
@@ -108,7 +108,7 @@
           </td>
 
           {# Last successful timestamp #}
-          <td class="px-5 py-3 text-sm text-gray-500">
+          <td class="px-5 py-3 text-sm text-gray-600">
             {% if source.last_success %}
             {{ source.last_success.strftime('%b %d, %H:%M') }}
             {% else %}
@@ -135,7 +135,7 @@
         {% endfor %}
         {% else %}
         <tr>
-          <td colspan="6" class="px-5 py-8 text-center text-sm text-gray-500">No sources configured.</td>
+          <td colspan="6" class="px-5 py-8 text-center text-sm text-gray-600">No sources configured.</td>
         </tr>
         {% endif %}
       </tbody>

--- a/app/templates/htmx/partials/settings/system.html
+++ b/app/templates/htmx/partials/settings/system.html
@@ -15,7 +15,7 @@
       </svg>
       <div>
         <h2 class="text-lg font-semibold text-gray-900">System Configuration</h2>
-        <p class="text-xs text-gray-500 mt-0.5">Admin-only settings. Changes take effect immediately.</p>
+        <p class="text-xs text-gray-600 mt-0.5">Admin-only settings. Changes take effect immediately.</p>
       </div>
     </div>
   </div>
@@ -24,9 +24,9 @@
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
-          <th class="px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Key</th>
-          <th class="px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Value</th>
-          <th class="px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Updated</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Key</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Value</th>
+          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Updated</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-100">
@@ -38,7 +38,7 @@
         <tr class="hover:bg-brand-50/50 transition-colors"
             x-data="{ editing: false, showValue: false }">
           {# Config key #}
-          <td class="px-5 py-3">
+          <td class="table-cell">
             <div class="flex items-center gap-2">
               <span class="text-sm font-mono text-gray-900">{{ key }}</span>
               {% if is_sensitive %}
@@ -50,11 +50,11 @@
           </td>
 
           {# Value — inline editable #}
-          <td class="px-5 py-3">
+          <td class="table-cell">
             {# Display mode #}
             <div x-show="!editing" x-cloak class="flex items-center gap-2">
               {% if is_sensitive %}
-              <span x-show="!showValue" x-cloak class="text-sm text-gray-500 font-mono">{{ '*' * 12 }}</span>
+              <span x-show="!showValue" x-cloak class="text-sm text-gray-600 font-mono">{{ '*' * 12 }}</span>
               <span x-show="showValue" class="text-sm text-gray-900 font-mono" x-cloak>{{ val }}</span>
               <button @click="showValue = !showValue"
                       class="text-gray-400 hover:text-gray-600 transition-colors" type="button">
@@ -108,14 +108,14 @@
           </td>
 
           {# Last updated #}
-          <td class="px-5 py-3 text-xs text-gray-400">
+          <td class="table-cell text-xs text-gray-400">
             {{ item.updated_at | fmtdate }}
           </td>
         </tr>
         {% endfor %}
         {% else %}
         <tr>
-          <td colspan="3" class="px-5 py-8 text-center text-sm text-gray-500">No configuration entries.</td>
+          <td colspan="3" class="px-5 py-8 text-center text-sm text-gray-600">No configuration entries.</td>
         </tr>
         {% endif %}
       </tbody>

--- a/app/templates/htmx/partials/shared/_macros.html
+++ b/app/templates/htmx/partials/shared/_macros.html
@@ -35,7 +35,7 @@ Usage:
   <input type="hidden" name="urgency" :value="asap ? 'critical' : 'normal'">
   <button type="button" @click="asap = !asap"
           :class="asap ? 'bg-amber-500 text-white' : 'bg-gray-100 text-gray-600'"
-          class="px-2 py-1 text-[10px] font-semibold rounded transition-colors whitespace-nowrap">
+          class="px-2 py-1 text-xs font-semibold rounded transition-colors whitespace-nowrap">
     ASAP
   </button>
 </div>
@@ -54,7 +54,7 @@ Usage:
   'info':    'bg-sky-50 text-sky-700 border-sky-200',
   'brand':   'bg-brand-50 text-brand-700 border-brand-200',
   'violet':  'bg-violet-50 text-violet-700 border-violet-200',
-  'neutral': 'bg-gray-50 text-gray-500 border-gray-200',
+  'neutral': 'bg-gray-50 text-gray-600 border-gray-200',
   'muted':   'bg-gray-100 text-gray-600 border-gray-200'
 } %}
 
@@ -82,20 +82,20 @@ Usage:
   'won': 'bg-emerald-50 text-emerald-700 border-emerald-300',
   'completed': 'bg-emerald-50 text-emerald-600 border-emerald-200',
   'lost': 'bg-rose-50 text-rose-500 border-rose-200',
-  'archived': 'bg-gray-50 text-gray-500 border-gray-200',
+  'archived': 'bg-gray-50 text-gray-600 border-gray-200',
   'rejected': 'bg-rose-50 text-rose-500 border-rose-200',
   'reviewed': 'bg-emerald-50 text-emerald-600 border-emerald-200',
   'flagged': 'bg-amber-50 text-amber-600 border-amber-200',
   'expired': 'bg-gray-50 text-gray-400 border-gray-200',
   'cancelled': 'bg-gray-50 text-gray-400 border-gray-200',
   'halted': 'bg-rose-50 text-rose-500 border-rose-200',
-  'sold': 'bg-gray-50 text-gray-500 border-gray-200',
+  'sold': 'bg-gray-50 text-gray-600 border-gray-200',
   'healthy': 'bg-emerald-50 text-emerald-600 border-emerald-200',
   'degraded': 'bg-amber-50 text-amber-600 border-amber-200',
   'down': 'bg-rose-50 text-rose-500 border-rose-200'
 } -%}
 {%- set colors = status_map if status_map else default_map -%}
-<span class="badge {{ colors.get(value, 'bg-gray-50 text-gray-500 border-gray-200') }}">
+<span class="badge {{ colors.get(value, 'bg-gray-50 text-gray-600 border-gray-200') }}">
   {{ value|replace('_', ' ')|capitalize }}
 </span>
 {%- endmacro %}
@@ -118,7 +118,7 @@ Usage:
   "sourcing": "bg-sky-50 text-sky-600 border-sky-200",
   "won": "bg-emerald-50 text-emerald-700 border-emerald-300",
   "lost": "bg-rose-50 text-rose-500 border-rose-200",
-  "archived": "bg-gray-50 text-gray-500 border-gray-200",
+  "archived": "bg-gray-50 text-gray-600 border-gray-200",
   "awarded": "bg-emerald-50 text-emerald-600 border-emerald-200",
   "cancelled": "bg-gray-50 text-gray-400 border-gray-200"
 } -%}
@@ -401,9 +401,9 @@ Usage:
     Search
   </button>
   {% if requirement.last_searched_at %}
-  <span class="text-[10px] text-gray-400">{{ requirement.last_searched_at|timeago }}</span>
+  <span class="text-xs text-gray-400">{{ requirement.last_searched_at|timeago }}</span>
   {% else %}
-  <span class="text-[10px] text-gray-400 italic">Never searched</span>
+  <span class="text-xs text-gray-400 italic">Never searched</span>
   {% endif %}
 </div>
 {%- endmacro %}
@@ -428,12 +428,12 @@ Usage:
   <div class="opp-name-cell__title flex items-center gap-1.5 min-w-0">
     <span class="truncate block min-w-0 text-[12px] text-[color:var(--opp-text-tertiary)]" x-truncate-tip>{{ req.name }}</span>
     {% if req.match_reason == 'part' and req.matched_mpn %}
-      <span class="match-badge inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-semibold rounded-full bg-violet-50 text-violet-600 border border-violet-200" title="Matched part: {{ req.matched_mpn }}">
+      <span class="match-badge inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs font-semibold rounded-full bg-violet-50 text-violet-600 border border-violet-200" title="Matched part: {{ req.matched_mpn }}">
         <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
         {{ req.matched_mpn }}
       </span>
     {% elif req.match_reason == 'customer' %}
-      <span class="match-badge inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-semibold rounded-full bg-sky-50 text-sky-600 border border-sky-200">
+      <span class="match-badge inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs font-semibold rounded-full bg-sky-50 text-sky-600 border border-sky-200">
         <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
         customer match
       </span>
@@ -483,17 +483,17 @@ Usage:
   'rfq_sent':             {'accent': 'bg-brand-100 text-brand-600',     'path': 'M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5'},
   'email_received':       {'accent': 'bg-blue-100 text-blue-600',       'path': 'M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75'},
   'call_logged':          {'accent': 'bg-emerald-100 text-emerald-600', 'path': 'M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106c-.44-.11-.902.055-1.173.417l-.97 1.293c-.282.376-.769.542-1.21.38a12.035 12.035 0 01-7.143-7.143c-.162-.441.004-.928.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102a1.125 1.125 0 00-1.091-.852H4.5A2.25 2.25 0 002.25 4.5v2.25z'},
-  'status_changed':       {'accent': 'bg-gray-100 text-gray-500',       'path': 'M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99'},
+  'status_changed':       {'accent': 'bg-gray-100 text-gray-600',       'path': 'M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99'},
   'offer_created':        {'accent': 'bg-amber-100 text-amber-600',     'path': 'M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9zm.75 12.75h3m-3 2.25h3m-6-9.75v-1.5m0 0V9m0 1.5h1.5m-1.5 0H9'},
   'offer_status_changed': {'accent': 'bg-amber-100 text-amber-600',     'path': 'M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z'},
   'sighting_added':       {'accent': 'bg-indigo-100 text-indigo-600',   'path': 'M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z'},
-  'sales_note':           {'accent': 'bg-gray-100 text-gray-500',       'path': 'M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10'},
+  'sales_note':           {'accent': 'bg-gray-100 text-gray-600',       'path': 'M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10'},
   'task_completed':       {'accent': 'bg-emerald-100 text-emerald-600', 'path': 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z'},
-  'assignment_changed':   {'accent': 'bg-gray-100 text-gray-500',       'path': 'M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z'},
-  'req_archived':         {'accent': 'bg-gray-100 text-gray-500',       'path': 'M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z'},
-  'req_unarchived':       {'accent': 'bg-gray-100 text-gray-500',       'path': 'M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5'}
+  'assignment_changed':   {'accent': 'bg-gray-100 text-gray-600',       'path': 'M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z'},
+  'req_archived':         {'accent': 'bg-gray-100 text-gray-600',       'path': 'M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z'},
+  'req_unarchived':       {'accent': 'bg-gray-100 text-gray-600',       'path': 'M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5'}
 } -%}
-{%- set fallback = {'accent': 'bg-gray-100 text-gray-500', 'path': 'M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z'} -%}
+{%- set fallback = {'accent': 'bg-gray-100 text-gray-600', 'path': 'M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z'} -%}
 {%- set icon = icon_map.get(activity_type, fallback) -%}
 <span class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full {{ icon.accent }}">
   <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
@@ -527,10 +527,10 @@ Usage:
       <p class="text-sm font-medium text-gray-900">{{ a.activity_type|replace('_', ' ')|title }}</p>
       {% set who = a.vendor_card.display_name if a.vendor_card_id and a.vendor_card else a.contact_name %}
       {% if who %}
-      <span class="text-xs text-gray-500 truncate">{{ who }}</span>
+      <span class="text-xs text-gray-600 truncate">{{ who }}</span>
       {% endif %}
       {% if a.channel and a.channel not in ('system', 'manual') %}
-      <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-gray-100 text-gray-600">{{ a.channel|capitalize }}</span>
+      <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600">{{ a.channel|capitalize }}</span>
       {% endif %}
     </div>
     {% if a.summary or a.notes %}
@@ -562,7 +562,7 @@ Usage:
 #}
 {% macro cadence_hero(entity, cadence_state, next_best_touch, now_utc) %}
 {%- set badge_colors = {
-  "new":       "bg-gray-100 text-gray-500",
+  "new":       "bg-gray-100 text-gray-600",
   "on_target": "bg-emerald-100 text-emerald-700",
   "due":       "bg-amber-100 text-amber-700",
   "overdue":   "bg-rose-100 text-rose-700"
@@ -577,7 +577,7 @@ Usage:
   {# Hero row: cadence badge + next-best-touch #}
   <div class="flex items-center justify-between flex-wrap gap-2 mb-3">
     <div class="flex items-center gap-2">
-      <span class="px-2.5 py-1 text-xs font-semibold rounded-full {{ badge_colors.get(cadence_state, 'bg-gray-100 text-gray-500') }}">
+      <span class="px-2.5 py-1 text-xs font-semibold rounded-full {{ badge_colors.get(cadence_state, 'bg-gray-100 text-gray-600') }}">
         {{ badge_labels.get(cadence_state, cadence_state|title) }}
       </span>
     </div>
@@ -614,7 +614,7 @@ Usage:
     {% if entity.last_outbound_at %}
       {% set out_days = ((now_utc - entity.last_outbound_at).days) if now_utc is defined else 0 %}
       <p class="text-lg font-bold text-gray-900">{{ out_days }}d</p>
-      <p class="text-[10px] text-gray-400">{{ entity.last_outbound_at.strftime('%b %d') }}</p>
+      <p class="text-xs text-gray-400">{{ entity.last_outbound_at.strftime('%b %d') }}</p>
     {% else %}
       <p class="text-sm font-medium text-gray-400">Never</p>
     {% endif %}
@@ -627,7 +627,7 @@ Usage:
     {% if entity.last_reply_at %}
       {% set reply_days = ((now_utc - entity.last_reply_at).days) if now_utc is defined else 0 %}
       <p class="text-lg font-bold text-gray-900">{{ reply_days }}d</p>
-      <p class="text-[10px] text-gray-400">{{ entity.last_reply_at.strftime('%b %d') }}</p>
+      <p class="text-xs text-gray-400">{{ entity.last_reply_at.strftime('%b %d') }}</p>
     {% else %}
       <p class="text-sm font-medium text-gray-400">—</p>
     {% endif %}

--- a/app/templates/htmx/partials/shared/empty_state.html
+++ b/app/templates/htmx/partials/shared/empty_state.html
@@ -5,17 +5,17 @@
   Depends on: HTMX (optional, for action_url)
   Context vars: message (str), action_url (str, optional), action_label (str, optional)
 #}
-<div class="mx-auto max-w-sm rounded-xl bg-white p-12 text-center shadow-sm border border-gray-100">
+<div class="mx-auto max-w-sm rounded-xl bg-white p-6 sm:p-8 text-center shadow-sm border border-gray-100">
   <svg class="mx-auto mb-4 h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
     <path stroke-linecap="round" stroke-linejoin="round"
           d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
   </svg>
-  <p class="text-base font-medium text-gray-500">{{ message|default("No items found.") }}</p>
+  <p class="text-base font-medium text-gray-600">{{ message|default("No items found.") }}</p>
   {% if action_url %}
   <a href="{{ action_url }}"
      hx-get="{{ action_url }}"
      hx-target="#main-content"
-     class="mt-6 inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-brand-600 transition-colors">
+     class="mt-6 btn-primary">
     {{ action_label|default("Create one") }}
   </a>
   {% endif %}

--- a/app/templates/htmx/partials/shared/insights_panel.html
+++ b/app/templates/htmx/partials/shared/insights_panel.html
@@ -39,7 +39,7 @@
         <div class="flex-1 min-w-0">
           <p class="text-sm text-gray-700">{{ entry.content }}</p>
           {% if entry.expires_at %}
-          <p class="text-[10px] text-gray-400 mt-1">Expires {{ entry.expires_at.strftime('%b %d, %Y') }}</p>
+          <p class="text-xs text-gray-400 mt-1">Expires {{ entry.expires_at.strftime('%b %d, %Y') }}</p>
           {% endif %}
         </div>
       </div>
@@ -48,7 +48,7 @@
   </div>
   {% else %}
   <div class="px-4 py-6 text-center">
-    <p class="text-sm text-gray-500">No insights yet.</p>
+    <p class="text-sm text-gray-600">No insights yet.</p>
     <p class="text-xs text-gray-400 mt-1">Click "Refresh" to generate AI insights.</p>
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/shared/offer_card.html
+++ b/app/templates/htmx/partials/shared/offer_card.html
@@ -85,7 +85,7 @@
               hx-target="#quote-lines-body"
               hx-swap="beforeend"
               data-loading-disable
-              class="px-2 py-1 text-xs bg-brand-500 text-white rounded hover:bg-brand-600">
+              class="btn btn-sm btn-primary">
         Select for Quote
       </button>
       {% endif %}
@@ -95,7 +95,7 @@
               class="px-2 py-1 text-xs bg-emerald-500 text-white rounded hover:bg-emerald-600">Approve</button>
       <button hx-put="/api/offers/{{ offer.id }}/reject" hx-swap="none"
               data-loading-disable
-              class="px-2 py-1 text-xs bg-rose-500 text-white rounded hover:bg-rose-600">Reject</button>
+              class="btn btn-sm btn-danger">Reject</button>
       {% endif %}
     </div>
   </div>

--- a/app/templates/htmx/partials/shared/pagination.html
+++ b/app/templates/htmx/partials/shared/pagination.html
@@ -47,7 +47,7 @@
   </div>
 
   <div class="flex items-center gap-2">
-    <span class="text-sm text-gray-500">Page {{ page }} of {{ total_pages }}</span>
+    <span class="text-sm text-gray-600">Page {{ page }} of {{ total_pages }}</span>
     {% if total_pages > 5 %}
     <input aria-label="Go to page" type="number" min="1" max="{{ total_pages }}" value="{{ page }}"
            hx-get="{{ base_url }}"

--- a/app/templates/htmx/partials/shared/safety_review.html
+++ b/app/templates/htmx/partials/shared/safety_review.html
@@ -35,7 +35,7 @@
     {# Header #}
     <div class="flex items-center justify-between">
       <h3 class="text-base font-semibold text-gray-900">Vendor Trust & Safety Review</h3>
-      <span class="inline-flex rounded-full border px-2.5 py-0.5 text-xs font-medium
+      <span class="badge
                    {{ badge_styles.get(safety_band, 'bg-gray-100 text-gray-600 border-gray-200') }}">
         {{ badge_labels.get(safety_band, 'Unknown') }}
       </span>

--- a/app/templates/htmx/partials/shared/search_results.html
+++ b/app/templates/htmx/partials/shared/search_results.html
@@ -57,7 +57,7 @@
         </div>
         <div class="min-w-0 flex-1">
           <p class="text-sm font-semibold text-gray-900 truncate">{{ bm.name|default(bm.display_name|default(bm.full_name|default(bm.primary_mpn|default(bm.mpn|default("—"))))) }}</p>
-          <p class="text-xs text-gray-500 truncate">
+          <p class="text-xs text-gray-600 truncate">
             <span class="inline-block rounded bg-brand-100 px-1.5 py-0.5 text-xs font-medium text-brand-700">{{ bm.type|replace("_", " ")|title }}</span>
             {% if bm.email %}<span class="ml-1">{{ bm.email }}</span>{% endif %}
             {% if bm.customer_name %}<span class="ml-1">{{ bm.customer_name }}</span>{% endif %}
@@ -257,7 +257,7 @@
   <div class="px-4 py-6 text-center text-sm text-gray-400">
     No results for "<strong class="text-gray-600">{{ query }}</strong>"
     {% if not ai_search %}
-    <p class="mt-1 text-xs">Press <kbd class="px-1.5 py-0.5 rounded bg-gray-100 text-gray-500 font-mono text-xs">Enter</kbd> for AI-powered search</p>
+    <p class="mt-1 text-xs">Press <kbd class="px-1.5 py-0.5 rounded bg-gray-100 text-gray-600 font-mono text-xs">Enter</kbd> for AI-powered search</p>
     {% endif %}
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/shared/trouble_report_form.html
+++ b/app/templates/htmx/partials/shared/trouble_report_form.html
@@ -9,7 +9,7 @@
     </div>
     <div>
       <h3 class="text-lg font-semibold text-gray-900">Report a Problem</h3>
-      <p class="text-sm text-gray-500">Describe the issue — a screenshot has been captured automatically.</p>
+      <p class="text-sm text-gray-600">Describe the issue — a screenshot has been captured automatically.</p>
     </div>
   </div>
 

--- a/app/templates/htmx/partials/tickets/_context.html
+++ b/app/templates/htmx/partials/tickets/_context.html
@@ -21,6 +21,6 @@ Usage:
   {{ context_field("Network Log:", ticket.network_errors|tojson(indent=2), variant="pre", scroll=True) }}
 #}
 {%- macro context_field(label, value, variant="inline", scroll=False) -%}
-<div><span class="text-xs font-medium text-gray-500">{{ label }}</span>
+<div><span class="text-xs font-medium text-gray-600">{{ label }}</span>
         {% if variant == "pre" %}<pre class="text-xs text-gray-700 mt-1 bg-gray-100 rounded p-2 overflow-x-auto{% if scroll %} max-h-40{% endif %}">{{ value }}</pre>{% else %}<span class="text-xs text-gray-700 ml-1">{{ value }}</span>{% endif %}</div>
 {%- endmacro -%}

--- a/app/templates/htmx/partials/tickets/_row.html
+++ b/app/templates/htmx/partials/tickets/_row.html
@@ -8,7 +8,7 @@
     {% if t.status == 'submitted' %}bg-yellow-100 text-yellow-700
     {% elif t.status == 'in_progress' %}bg-blue-100 text-blue-700
     {% elif t.status == 'resolved' %}bg-green-100 text-green-700
-    {% elif t.status == 'wont_fix' %}bg-gray-100 text-gray-500
-    {% else %}bg-gray-100 text-gray-500{% endif %}">{{ t.status|replace('_', ' ')|title }}</span>
+    {% elif t.status == 'wont_fix' %}bg-gray-100 text-gray-600
+    {% else %}bg-gray-100 text-gray-600{% endif %}">{{ t.status|replace('_', ' ')|title }}</span>
   <span class="text-xs text-gray-400 w-24 shrink-0 text-right">{{ t.created_at|fmtdate }}</span>
 </div>

--- a/app/templates/htmx/partials/tickets/detail.html
+++ b/app/templates/htmx/partials/tickets/detail.html
@@ -5,7 +5,7 @@
   {# Back button #}
   <a hx-get="/v2/partials/trouble-tickets/workspace" hx-target="#main-content" hx-push-url="/v2/trouble-tickets"
      @click="currentView = 'tickets'"
-     class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4 cursor-pointer">
+     class="inline-flex items-center gap-1 text-sm text-gray-600 hover:text-gray-700 mb-4 cursor-pointer">
     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M15 19l-7-7 7-7"/></svg>
     Back to Tickets
   </a>
@@ -14,7 +14,7 @@
   <div class="flex items-start justify-between mb-6">
     <div>
       <h1 class="text-xl font-bold text-gray-900">{{ ticket.ticket_number }}</h1>
-      <p class="text-sm text-gray-500 mt-1">
+      <p class="text-sm text-gray-600 mt-1">
         Submitted {{ ticket.created_at|fmtdate("%b %d, %Y %H:%M") }}
         {% if ticket.submitter %} by {{ ticket.submitter.name or ticket.submitter.email }}{% endif %}
       </p>

--- a/app/templates/htmx/partials/tickets/workspace.html
+++ b/app/templates/htmx/partials/tickets/workspace.html
@@ -6,7 +6,7 @@
             hx-target="#ticket-list"
             hx-swap="innerHTML"
             hx-indicator="#analyze-spinner"
-            class="inline-flex items-center gap-2 px-4 py-2 bg-brand-500 text-white text-sm font-medium rounded-lg hover:bg-brand-600 transition-colors">
+            class="btn btn-primary gap-2">
       {{ sparkle_icon("w-4 h-4") }}
       Analyze
       <svg id="analyze-spinner" class="htmx-indicator animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -494,7 +494,7 @@ def test_tiny_text_does_not_grow():
 
     Ratchet — sweeps lower this as they bump 10px → text-xs / text-[11px].
     """
-    BASELINE = 70
+    BASELINE = 56
     count = _tpl_substring_count("text-[10px]")
     assert count <= BASELINE, (
         f"text-[10px] usages rose to {count} (baseline {BASELINE}). Use text-xs "
@@ -509,7 +509,7 @@ def test_low_contrast_secondary_text_does_not_grow():
     Ratchet only (decorative icon grays are fine) — caps growth rather than banning
     outright.
     """
-    BASELINE = 482
+    BASELINE = 409
     count = _tpl_substring_count("text-gray-500")
     assert count <= BASELINE, (
         f"text-gray-500 usages rose to {count} (baseline {BASELINE}). Prefer "
@@ -534,7 +534,7 @@ def test_inline_table_cell_padding_does_not_grow():
 
     Ratchet.
     """
-    BASELINE = 604
+    BASELINE = 523
     count = _tpl_regex_count(r'<t[dh][^>]*class="[^"]*\bp[xy]-[0-9]')
     assert count <= BASELINE, (
         f"inline-padded <td>/<th> rose to {count} (baseline {BASELINE}). Use "
@@ -547,7 +547,7 @@ def test_inline_button_sizing_does_not_grow():
 
     Macro files are the canonical source and are excluded. Ratchet.
     """
-    BASELINE = 288
+    BASELINE = 271
     count = _tpl_regex_count(r'<button[^>]*class="[^"]*\bp[xy]-[0-9]', exclude={"_macros.html"})
     assert count <= BASELINE, (
         f"inline-sized <button> rose to {count} (baseline {BASELINE}). Use .btn-sm/md/lg or the btn_* macros."


### PR DESCRIPTION
## What & why — final wave

PR 6 of 6, completing the app-wide front-end UX consistency pass. Sweeps the remaining surfaces — **settings / excess / tickets / admin / knowledge / follow_ups / dashboard + shared shells + login** — onto the canonical design-system layer (PR 1 #413). Class-only, zero behavior change.

37 templates swept: 33 got the **full canonical sweep** (cells→`.table-cell*`/`.compact-cell*`, cards→`.card*`, buttons→`.btn*`, badges→`.badge` + readability), the rest + the app-wide `shared/_macros.html` got the **readability + floor pass**.

**Deliberate exclusions:** `shared/mobile_nav.html` (its 10px nav labels are the one intentional exception — never bumped) and `login.html`'s `bg-gray-800` sign-in button (non-canonical color, left as-is).

**Ratchets reconciled to the program floor** (after PR 5 + PR 6): text-[10px] **56**, text-gray-500 **409**, td/th inline pad **523**, button inline sizing **271**.

> Program total vs PR 1 start: **text-gray-500 998→409 (−59%)**, **text-[10px] 270→56 (−79%)**, td/th 726→523, buttons 341→271.

## Verification
- Full pytest suite: **18,181 passed**, 0 failures (validates the app-wide `_macros.html` + shell changes)
- 37/37 changed templates compile; 20 static-analysis guards green at the final baselines
- Vite build green; Playwright **`dead-ends` + `requisitions2-visuals` + `accessibility`: 35 passed**

Template-only (+1 test-baseline file) — no migrations, no schema, no API changes. Builds on PR 1–5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132w7Ci6y7CSUNfPJmY2XCM