### PR TITLE
Worker reliability: self-healing + liveness watchdog ("always working")

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -300,6 +300,13 @@ class Settings(BaseSettings):
     lusha_cooldown_minutes: int = 15  # quota/rate-limit (402/429) circuit cooldown
     prospect_enrich_contacts_per_account: int = 5  # cap for paid contact pulls
 
+    # --- Worker liveness watchdog (scheduler job in the supervised app) ---
+    # Workers heartbeat every loop tick; this job alerts when one that should be
+    # running goes silent (hung/crashed) or trips its circuit breaker.
+    worker_liveness_check_minutes: int = 5
+    worker_heartbeat_stale_minutes: int = 15
+    worker_alert_debounce_minutes: int = 60
+
     # --- Clay Enrichment (async webhook → callback; URL/secret via get_credential_cached) ---
     # Clay has no real-time API: we POST a domain to the table's inbound webhook
     # (CLAY_WEBHOOK_URL) and Clay POSTs the enriched row back to /api/webhooks/clay,

--- a/app/jobs/__init__.py
+++ b/app/jobs/__init__.py
@@ -23,6 +23,7 @@ def register_all_jobs(scheduler, settings):
     from .tagging_jobs import register_tagging_jobs
     from .task_jobs import register_task_jobs
     from .teams_call_jobs import register_teams_call_jobs
+    from .worker_liveness_jobs import register_worker_liveness_jobs
 
     register_cadence_jobs(scheduler, settings)
     register_core_jobs(scheduler, settings)
@@ -39,5 +40,6 @@ def register_all_jobs(scheduler, settings):
     register_task_jobs(scheduler, settings)
     register_quality_jobs(scheduler, settings)
     register_teams_call_jobs(scheduler, settings)
+    register_worker_liveness_jobs(scheduler, settings)
     job_count = len(scheduler.get_jobs())
     logger.info(f"APScheduler configured with {job_count} jobs")

--- a/app/jobs/worker_liveness_jobs.py
+++ b/app/jobs/worker_liveness_jobs.py
@@ -1,0 +1,105 @@
+"""Worker liveness watchdog — alerts when a background worker stops heartbeating.
+
+Each worker (ICS, NetComponents, enrichment) writes ``last_heartbeat`` on every loop
+tick. systemd/docker restart a *crashed* worker, but a *hung* one (wedged browser,
+deadlock, network stall) keeps its process alive while doing nothing — nobody notices.
+This job reads the heartbeats every few minutes and alerts (Teams + Sentry, debounced)
+when a worker that should be running has gone silent, or has its circuit breaker open.
+
+Called by: app/jobs/__init__.py via register_worker_liveness_jobs().
+Depends on: worker_status models, services.teams_notifications, cache.intel_cache (debounce),
+            search_worker_base.monitoring (Sentry).
+"""
+
+from datetime import datetime, timezone
+
+from apscheduler.triggers.interval import IntervalTrigger
+from loguru import logger
+
+from ..scheduler import _traced_job
+
+
+def register_worker_liveness_jobs(scheduler, settings):
+    scheduler.add_job(
+        _job_monitor_worker_heartbeats,
+        IntervalTrigger(minutes=settings.worker_liveness_check_minutes),
+        id="worker_liveness_check",
+        name="Monitor worker heartbeats and alert on stalls",
+    )
+
+
+def _as_utc(dt):
+    """Coerce a (possibly naive) datetime to UTC-aware — ICS stores naive, NC aware."""
+    if dt is None:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+async def _alert(label: str, message: str, debounce_minutes: int) -> None:
+    """Debounced alert (1× per label per window) to Teams + Sentry + logs."""
+    from ..cache.intel_cache import get_cached, set_cached
+
+    key = f"worker_alert:{label}"
+    if get_cached(key) is not None:
+        return  # already alerted within the debounce window
+    set_cached(key, {"alerted": 1}, ttl_days=debounce_minutes / 1440)
+
+    logger.error("WORKER WATCHDOG: {}", message)
+    try:
+        from ..services.search_worker_base.monitoring import capture_sentry_message
+
+        capture_sentry_message(message, level="error", component_name="worker_watchdog")
+    except Exception:  # pragma: no cover - Sentry optional
+        pass
+    try:
+        from ..services.teams_notifications import post_teams_channel
+
+        await post_teams_channel(f"⚠️ **Worker alert — {label}**\n\n{message}")
+    except Exception as e:
+        logger.warning("Worker watchdog Teams alert failed: {}", e)
+
+
+@_traced_job
+async def _job_monitor_worker_heartbeats():
+    from datetime import timedelta
+
+    from ..config import settings
+    from ..database import SessionLocal
+    from ..models import EnrichmentWorkerStatus, IcsWorkerStatus, NcWorkerStatus
+
+    now = datetime.now(timezone.utc)
+    stale_cutoff = now - timedelta(minutes=settings.worker_heartbeat_stale_minutes)
+    debounce = settings.worker_alert_debounce_minutes
+
+    checks = (
+        ("ICS", IcsWorkerStatus),
+        ("NetComponents", NcWorkerStatus),
+        ("Enrichment", EnrichmentWorkerStatus),
+    )
+    db = SessionLocal()
+    try:
+        for label, model in checks:
+            row = db.get(model, 1)
+            if row is None:
+                continue
+            hb = _as_utc(row.last_heartbeat)
+            # Stale: claims to be running but the heartbeat went silent. (A clean
+            # shutdown sets is_running=False, so this won't false-alarm on a stop.)
+            if row.is_running and (hb is None or hb < stale_cutoff):
+                age = "unknown" if hb is None else f"{int((now - hb).total_seconds() // 60)}m"
+                await _alert(
+                    label,
+                    f"{label} worker heartbeat is stale (last seen {age} ago). "
+                    f"It may be hung or crashed — check the service.",
+                    debounce,
+                )
+            # Up but not working: circuit breaker open.
+            elif getattr(row, "circuit_breaker_open", False):
+                reason = getattr(row, "circuit_breaker_reason", None) or "unknown"
+                await _alert(
+                    f"{label}-breaker",
+                    f"{label} worker circuit breaker is OPEN: {reason}",
+                    debounce,
+                )
+    finally:
+        db.close()

--- a/app/routers/admin/system.py
+++ b/app/routers/admin/system.py
@@ -393,3 +393,56 @@ def api_subscription_health(
             for s in subs
         ]
     }
+
+
+@router.get("/api/admin/workers/status")
+def get_workers_status(
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Liveness + queue snapshot for the sourcing-engine workers (ICS, NC, enrichment).
+
+    Glanceable "are they working?" surface: heartbeat age, stale flag, circuit-breaker
+    state, today's counts, and queue depth.
+    """
+    from ...config import settings
+    from ...models import EnrichmentWorkerStatus, IcsWorkerStatus, NcWorkerStatus
+    from ...services.ics_worker.queue_manager import get_queue_stats as ics_queue_stats
+    from ...services.nc_worker.queue_manager import get_queue_stats as nc_queue_stats
+
+    now = datetime.now(timezone.utc)
+    stale_secs = settings.worker_heartbeat_stale_minutes * 60
+
+    def _age(dt):
+        if dt is None:
+            return None
+        d = dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        return int((now - d).total_seconds())
+
+    def _worker(name, row, queue=None):
+        if row is None:
+            return {"name": name, "present": False}
+        age = _age(row.last_heartbeat)
+        out = {
+            "name": name,
+            "present": True,
+            "is_running": bool(row.is_running),
+            "last_heartbeat": _iso(row.last_heartbeat),
+            "heartbeat_age_seconds": age,
+            "stale": bool(row.is_running and (age is None or age > stale_secs)),
+            "circuit_breaker_open": bool(getattr(row, "circuit_breaker_open", False)),
+            "circuit_breaker_reason": getattr(row, "circuit_breaker_reason", None),
+        }
+        if queue is not None:
+            out["queue"] = queue
+        return out
+
+    return {
+        "checked_at": _iso(now),
+        "stale_threshold_seconds": stale_secs,
+        "workers": [
+            _worker("ics", db.get(IcsWorkerStatus, 1), ics_queue_stats(db)),
+            _worker("netcomponents", db.get(NcWorkerStatus, 1), nc_queue_stats(db)),
+            _worker("enrichment", db.get(EnrichmentWorkerStatus, 1)),
+        ],
+    }

--- a/app/services/ics_worker/config.py
+++ b/app/services/ics_worker/config.py
@@ -25,3 +25,8 @@ class IcsConfig:
         self.ICS_BUSINESS_HOURS_START = int(os.environ.get("ICS_BUSINESS_HOURS_START", "8"))
         self.ICS_BUSINESS_HOURS_END = int(os.environ.get("ICS_BUSINESS_HOURS_END", "18"))
         self.ICS_BROWSER_PROFILE_DIR = os.environ.get("ICS_BROWSER_PROFILE_DIR", "/root/ics_browser_profile")
+        # Hard cap on a single search (incl. human-behavior delays) so a wedged page
+        # can't stall the loop/heartbeat. Worst-case real search is ~90s.
+        self.ICS_SEARCH_TIMEOUT_SECONDS = int(os.environ.get("ICS_SEARCH_TIMEOUT_SECONDS", "150"))
+        # Circuit-breaker self-heal cooldown: auto-reset this long after a trip.
+        self.ICS_BREAKER_COOLDOWN_MINUTES = int(os.environ.get("ICS_BREAKER_COOLDOWN_MINUTES", "30"))

--- a/app/services/ics_worker/worker.py
+++ b/app/services/ics_worker/worker.py
@@ -106,7 +106,7 @@ async def main():
 
     config = IcsConfig()
     scheduler = SearchScheduler(config)
-    breaker = CircuitBreaker()
+    breaker = CircuitBreaker(cooldown_seconds=config.ICS_BREAKER_COOLDOWN_MINUTES * 60)
     searches_today = 0
     sightings_today = 0
     last_stats_date = None
@@ -219,6 +219,7 @@ async def main():
 
                 # Get next queued item
                 db = SessionLocal()
+                item = None  # pre-init so the except path's `if item` guard is safe
                 try:
                     # Atomically claim (marks 'searching'; skip-locked on PG) and
                     # auto-reclaim any items a crashed worker left mid-search.
@@ -237,10 +238,23 @@ async def main():
                         await asyncio.sleep(5 * 60)
                         continue
 
-                    # Execute search (already marked 'searching' by the claim)
+                    # Execute search (already marked 'searching' by the claim).
+                    # Hard timeout so a wedged page can't stall the loop/heartbeat forever.
                     logger.info("ICS worker: searching '{}' (queue id={})", item.mpn, item.id)
 
-                    search_result = await search_part(session.page, item.mpn)
+                    try:
+                        search_result = await asyncio.wait_for(
+                            search_part(session.page, item.mpn),
+                            timeout=config.ICS_SEARCH_TIMEOUT_SECONDS,
+                        )
+                    except asyncio.TimeoutError:
+                        logger.error(
+                            "ICS worker: search timed out after {}s (queue id={}) — failing item",
+                            config.ICS_SEARCH_TIMEOUT_SECONDS, item.id,
+                        )
+                        mark_status(db, item, "failed", error="Search timeout")
+                        db.close()
+                        continue
 
                     # Check page health
                     health = await breaker.check_page_health(session.page)

--- a/app/services/ics_worker/worker.py
+++ b/app/services/ics_worker/worker.py
@@ -250,7 +250,8 @@ async def main():
                     except asyncio.TimeoutError:
                         logger.error(
                             "ICS worker: search timed out after {}s (queue id={}) — failing item",
-                            config.ICS_SEARCH_TIMEOUT_SECONDS, item.id,
+                            config.ICS_SEARCH_TIMEOUT_SECONDS,
+                            item.id,
                         )
                         mark_status(db, item, "failed", error="Search timeout")
                         db.close()

--- a/app/services/nc_worker/config.py
+++ b/app/services/nc_worker/config.py
@@ -26,3 +26,5 @@ class NcConfig:
         self.NC_BUSINESS_HOURS_START = int(os.environ.get("NC_BUSINESS_HOURS_START", "8"))
         self.NC_BUSINESS_HOURS_END = int(os.environ.get("NC_BUSINESS_HOURS_END", "18"))
         self.NC_BROWSER_PROFILE_DIR = os.environ.get("NC_BROWSER_PROFILE_DIR", "/root/nc_browser_profile")
+        # Circuit-breaker self-heal cooldown: auto-reset this long after a trip.
+        self.NC_BREAKER_COOLDOWN_MINUTES = int(os.environ.get("NC_BREAKER_COOLDOWN_MINUTES", "30"))

--- a/app/services/nc_worker/worker.py
+++ b/app/services/nc_worker/worker.py
@@ -111,7 +111,7 @@ def main():
 
     config = NcConfig()
     scheduler = SearchScheduler(config)
-    breaker = CircuitBreaker()
+    breaker = CircuitBreaker(cooldown_seconds=config.NC_BREAKER_COOLDOWN_MINUTES * 60)
     searches_today = 0
     sightings_today = 0
     last_stats_date = None

--- a/app/services/search_worker_base/circuit_breaker.py
+++ b/app/services/search_worker_base/circuit_breaker.py
@@ -10,6 +10,8 @@ Called by: worker loop (after each search)
 Depends on: nothing (state machine)
 """
 
+import time
+
 from loguru import logger
 
 
@@ -18,20 +20,35 @@ class CircuitBreakerBase:
 
     Subclasses should add a health check method appropriate for their transport (browser
     page, HTTP response, etc.).
+
+    Self-healing: once tripped, ``should_stop()`` auto-resets after ``cooldown_seconds``
+    so a transient block (captcha, rate-limit) doesn't wedge the worker until a restart.
     """
 
-    def __init__(self):
+    def __init__(self, cooldown_seconds: float = 1800):
         self.consecutive_failures = 0
         self.captcha_count = 0
         self.empty_results_streak = 0
         self.is_open = False
         self.trip_reason = ""
+        self._cooldown_seconds = cooldown_seconds
+        self._tripped_at: float | None = None
 
     def _trip(self, reason: str):
-        """Trip the circuit breaker — all searches stop."""
+        """Trip the circuit breaker — all searches stop until the cooldown elapses."""
         self.is_open = True
         self.trip_reason = reason
-        logger.critical("CIRCUIT BREAKER TRIPPED: {}", reason)
+        self._tripped_at = time.monotonic()
+        logger.critical("CIRCUIT BREAKER TRIPPED: {} (auto-reset in {:.0f}m)", reason, self._cooldown_seconds / 60)
+
+    def _reset(self):
+        """Clear breaker state (called after the cooldown elapses)."""
+        self.is_open = False
+        self.trip_reason = ""
+        self.consecutive_failures = 0
+        self.captcha_count = 0
+        self.empty_results_streak = 0
+        self._tripped_at = None
 
     def record_empty_results(self):
         """Track consecutive empty results — many in a row may indicate shadow-
@@ -45,8 +62,17 @@ class CircuitBreakerBase:
         self.empty_results_streak = 0
 
     def should_stop(self) -> bool:
-        """Return True if the circuit breaker is open (all searches should stop)."""
-        return self.is_open
+        """Return True if the breaker is open and the cooldown has not yet elapsed.
+
+        Auto-resets (self-heals) once ``cooldown_seconds`` have passed since the trip.
+        """
+        if not self.is_open:
+            return False
+        if self._tripped_at is not None and time.monotonic() - self._tripped_at >= self._cooldown_seconds:
+            logger.info("CIRCUIT BREAKER: cooldown elapsed — auto-resetting")
+            self._reset()
+            return False
+        return True
 
     def get_trip_info(self) -> dict:
         """Return circuit breaker state for monitoring."""

--- a/deploy/avail-ics-worker.service
+++ b/deploy/avail-ics-worker.service
@@ -3,6 +3,10 @@ Description=AVAIL ICsource Search Worker
 Documentation=https://github.com/TRIOSCS/Avail-AI-Test
 After=network.target avail-xvfb.service
 Requires=avail-xvfb.service
+# Crash-loop backoff: if it restarts >5 times in an hour, systemd stops trying
+# (and the app-side liveness watchdog alerts on the stale heartbeat).
+StartLimitIntervalSec=3600
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -16,8 +20,12 @@ Environment="PYTHONPATH=/root/availai"
 # host workers carry the same pinned deps as the docker app/enrichment images.
 # deploy.sh refreshes this venv from requirements.txt on every deploy.
 ExecStart=/root/availai/.venv/bin/python -m app.services.ics_worker.worker
-Restart=on-failure
+# always (not on-failure) so a clean exit(0) still restarts — a fresh process
+# usually clears a wedged browser/session.
+Restart=always
 RestartSec=300
+# Xvfb + Chrome init can be slow; don't let systemd kill a slow-but-healthy start.
+TimeoutStartSec=120
 StandardOutput=journal
 StandardError=journal
 

--- a/deploy/avail-nc-worker.service
+++ b/deploy/avail-nc-worker.service
@@ -3,6 +3,10 @@ Description=AVAIL NetComponents Search Worker
 Documentation=https://github.com/TRIOSCS/Avail-AI-Test
 After=network.target avail-xvfb.service
 Requires=avail-xvfb.service
+# Crash-loop backoff: if it restarts >5 times in an hour, systemd stops trying
+# (and the app-side liveness watchdog alerts on the stale heartbeat).
+StartLimitIntervalSec=3600
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -16,8 +20,12 @@ Environment="PYTHONPATH=/root/availai"
 # host workers carry the same pinned deps as the docker app/enrichment images.
 # deploy.sh refreshes this venv from requirements.txt on every deploy.
 ExecStart=/root/availai/.venv/bin/python -m app.services.nc_worker.worker
-Restart=on-failure
+# always (not on-failure) so a clean exit(0) still restarts — a fresh process
+# usually clears a wedged browser/session.
+Restart=always
 RestartSec=300
+# Xvfb + Chrome init can be slow; don't let systemd kill a slow-but-healthy start.
+TimeoutStartSec=120
 StandardOutput=journal
 StandardError=journal
 

--- a/tests/test_email_intelligence_phase6.py
+++ b/tests/test_email_intelligence_phase6.py
@@ -48,6 +48,9 @@ def _scheduler_settings():
         eight_by_eight_enabled=False,
         prospecting_enabled=False,
         customer_enrichment_enabled=False,
+        worker_liveness_check_minutes=5,
+        worker_heartbeat_stale_minutes=15,
+        worker_alert_debounce_minutes=60,
     )
 
 

--- a/tests/test_ics_worker.py
+++ b/tests/test_ics_worker.py
@@ -566,7 +566,8 @@ class TestMainLoop:
 
     @pytest.mark.asyncio
     async def test_main_search_timeout_fails_item(self, db_session):
-        """A search that exceeds the timeout marks the item failed and continues (no hang)."""
+        """A search that exceeds the timeout marks the item failed and continues (no
+        hang)."""
         _seed_worker_status(db_session)
         import app.services.ics_worker.worker as worker_mod
 
@@ -626,7 +627,8 @@ class TestMainLoop:
                 patch("app.services.ics_worker.queue_manager.mark_status") as mock_mark,
                 patch(
                     "app.services.ics_worker.search_engine.search_part",
-                    new_callable=AsyncMock, side_effect=asyncio.TimeoutError,
+                    new_callable=AsyncMock,
+                    side_effect=asyncio.TimeoutError,
                 ),
                 patch("asyncio.sleep", side_effect=mock_sleep),
             ):

--- a/tests/test_ics_worker.py
+++ b/tests/test_ics_worker.py
@@ -4,6 +4,7 @@ Called by: pytest
 Depends on: conftest.py fixtures (db_session)
 """
 
+import asyncio
 import signal
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -273,6 +274,7 @@ class TestMainLoop:
         mock_scheduler.next_delay.return_value = 0
 
         mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
         mock_config.ICS_MAX_DAILY_SEARCHES = 0  # Already exceeded
 
         call_count = 0
@@ -321,6 +323,7 @@ class TestMainLoop:
         mock_scheduler.next_delay.return_value = 0
 
         mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
         mock_config.ICS_MAX_DAILY_SEARCHES = 1000
 
         mock_breaker = MagicMock()
@@ -374,6 +377,7 @@ class TestMainLoop:
         mock_scheduler.next_delay.return_value = 0
 
         mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
         mock_config.ICS_MAX_DAILY_SEARCHES = 1000
 
         mock_breaker = MagicMock()
@@ -428,6 +432,7 @@ class TestMainLoop:
         mock_scheduler.next_delay.return_value = 0
 
         mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
         mock_config.ICS_MAX_DAILY_SEARCHES = 1000
 
         mock_breaker = MagicMock()
@@ -508,6 +513,7 @@ class TestMainLoop:
         mock_scheduler.next_delay.return_value = 0
 
         mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
         mock_config.ICS_MAX_DAILY_SEARCHES = 1000
 
         mock_breaker = MagicMock()
@@ -559,6 +565,80 @@ class TestMainLoop:
             worker_mod._shutdown_requested = original
 
     @pytest.mark.asyncio
+    async def test_main_search_timeout_fails_item(self, db_session):
+        """A search that exceeds the timeout marks the item failed and continues (no hang)."""
+        _seed_worker_status(db_session)
+        import app.services.ics_worker.worker as worker_mod
+
+        mock_session = MagicMock()
+        mock_session.start = AsyncMock()
+        mock_session.stop = AsyncMock()
+        mock_session.is_logged_in = True
+        mock_session.ensure_session = AsyncMock(return_value=True)
+        mock_session.page = MagicMock()
+
+        mock_scheduler = MagicMock()
+        mock_scheduler.is_business_hours.return_value = True
+        mock_scheduler.time_for_break.return_value = False
+        mock_scheduler.next_delay.return_value = 0
+
+        mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
+        mock_config.ICS_MAX_DAILY_SEARCHES = 1000
+
+        mock_breaker = MagicMock()
+        mock_breaker.should_stop.return_value = False
+
+        mock_item = MagicMock()
+        mock_item.id = 1
+        mock_item.mpn = "TEST"
+
+        item_returned = False
+
+        def get_next(db):
+            nonlocal item_returned
+            if not item_returned:
+                item_returned = True
+                return mock_item
+            return None
+
+        call_count = 0
+
+        async def mock_sleep(seconds):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                worker_mod._shutdown_requested = True
+
+        original = worker_mod._shutdown_requested
+        try:
+            worker_mod._shutdown_requested = False
+
+            with (
+                patch("app.database.SessionLocal", return_value=db_session),
+                patch("app.services.ics_worker.queue_manager.recover_stale_searches"),
+                patch("app.services.ics_worker.session_manager.IcsSessionManager", return_value=mock_session),
+                patch("app.services.ics_worker.config.IcsConfig", return_value=mock_config),
+                patch("app.services.ics_worker.scheduler.SearchScheduler", return_value=mock_scheduler),
+                patch("app.services.ics_worker.circuit_breaker.CircuitBreaker", return_value=mock_breaker),
+                patch("app.services.ics_worker.ai_gate.process_ai_gate", new_callable=AsyncMock),
+                patch("app.services.ics_worker.queue_manager.claim_next_queued_item", side_effect=get_next),
+                patch("app.services.ics_worker.queue_manager.mark_status") as mock_mark,
+                patch(
+                    "app.services.ics_worker.search_engine.search_part",
+                    new_callable=AsyncMock, side_effect=asyncio.TimeoutError,
+                ),
+                patch("asyncio.sleep", side_effect=mock_sleep),
+            ):
+                from app.services.ics_worker.worker import main
+
+                await main()
+
+            mock_mark.assert_any_call(db_session, mock_item, "failed", error="Search timeout")
+        finally:
+            worker_mod._shutdown_requested = original
+
+    @pytest.mark.asyncio
     async def test_main_break_time(self, db_session):
         """Worker takes a break when scheduler says so."""
         _seed_worker_status(db_session)
@@ -576,6 +656,7 @@ class TestMainLoop:
         mock_scheduler.next_delay.return_value = 0
 
         mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
         mock_config.ICS_MAX_DAILY_SEARCHES = 1000
 
         mock_breaker = MagicMock()
@@ -631,6 +712,7 @@ class TestMainLoop:
         mock_scheduler.next_delay.return_value = 0
 
         mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
         mock_config.ICS_MAX_DAILY_SEARCHES = 1000
 
         mock_breaker = MagicMock()
@@ -707,6 +789,7 @@ class TestMainLoop:
         mock_scheduler.next_delay.return_value = 0
 
         mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
         mock_config.ICS_MAX_DAILY_SEARCHES = 1000
 
         mock_breaker = MagicMock()
@@ -783,6 +866,7 @@ class TestMainLoop:
         mock_scheduler.next_delay.return_value = 0
 
         mock_config = MagicMock()
+        mock_config.ICS_SEARCH_TIMEOUT_SECONDS = 150
         mock_config.ICS_MAX_DAILY_SEARCHES = 1000
 
         mock_breaker = MagicMock()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -54,6 +54,9 @@ def _mock_settings(**overrides):
         eight_by_eight_enabled=False,
         prospecting_enabled=False,
         customer_enrichment_enabled=False,
+        worker_liveness_check_minutes=5,
+        worker_heartbeat_stale_minutes=15,
+        worker_alert_debounce_minutes=60,
     )
     defaults.update(overrides)
     mock = MagicMock()

--- a/tests/test_search_worker_breaker_cooldown.py
+++ b/tests/test_search_worker_breaker_cooldown.py
@@ -1,7 +1,7 @@
 """Tests for the self-healing circuit-breaker cooldown in CircuitBreakerBase.
 
-Once tripped, should_stop() must auto-reset after cooldown_seconds so a transient
-block (captcha/rate-limit) doesn't wedge a worker until a process restart.
+Once tripped, should_stop() must auto-reset after cooldown_seconds so a transient block
+(captcha/rate-limit) doesn't wedge a worker until a process restart.
 """
 
 import time
@@ -22,13 +22,13 @@ def test_trip_blocks_until_cooldown_then_auto_resets(monkeypatch):
     b = CircuitBreakerBase(cooldown_seconds=60)
     b._trip("captcha detected")
     assert b.is_open is True
-    assert b.should_stop() is True          # just tripped
+    assert b.should_stop() is True  # just tripped
 
     clock[0] += 59
-    assert b.should_stop() is True          # still within cooldown
+    assert b.should_stop() is True  # still within cooldown
 
-    clock[0] += 2                           # now > 60s since trip
-    assert b.should_stop() is False         # auto-reset
+    clock[0] += 2  # now > 60s since trip
+    assert b.should_stop() is False  # auto-reset
     assert b.is_open is False
     assert b.trip_reason == ""
     assert b.consecutive_failures == 0
@@ -42,7 +42,7 @@ def test_ics_subclass_inherits_cooldown(monkeypatch):
     b._trip("rate limited")
     assert b.should_stop() is True
     clock[0] += 11
-    assert b.should_stop() is False         # self-healed
+    assert b.should_stop() is False  # self-healed
 
 
 def test_empty_results_trip_also_self_heals(monkeypatch):

--- a/tests/test_search_worker_breaker_cooldown.py
+++ b/tests/test_search_worker_breaker_cooldown.py
@@ -1,0 +1,58 @@
+"""Tests for the self-healing circuit-breaker cooldown in CircuitBreakerBase.
+
+Once tripped, should_stop() must auto-reset after cooldown_seconds so a transient
+block (captcha/rate-limit) doesn't wedge a worker until a process restart.
+"""
+
+import time
+
+from app.services.ics_worker.circuit_breaker import CircuitBreaker
+from app.services.search_worker_base.circuit_breaker import CircuitBreakerBase
+
+
+def test_not_open_returns_false():
+    b = CircuitBreakerBase(cooldown_seconds=60)
+    assert b.should_stop() is False
+
+
+def test_trip_blocks_until_cooldown_then_auto_resets(monkeypatch):
+    clock = [1000.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+    b = CircuitBreakerBase(cooldown_seconds=60)
+    b._trip("captcha detected")
+    assert b.is_open is True
+    assert b.should_stop() is True          # just tripped
+
+    clock[0] += 59
+    assert b.should_stop() is True          # still within cooldown
+
+    clock[0] += 2                           # now > 60s since trip
+    assert b.should_stop() is False         # auto-reset
+    assert b.is_open is False
+    assert b.trip_reason == ""
+    assert b.consecutive_failures == 0
+
+
+def test_ics_subclass_inherits_cooldown(monkeypatch):
+    clock = [0.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+    b = CircuitBreaker(cooldown_seconds=10)
+    b._trip("rate limited")
+    assert b.should_stop() is True
+    clock[0] += 11
+    assert b.should_stop() is False         # self-healed
+
+
+def test_empty_results_trip_also_self_heals(monkeypatch):
+    clock = [0.0]
+    monkeypatch.setattr(time, "monotonic", lambda: clock[0])
+
+    b = CircuitBreakerBase(cooldown_seconds=30)
+    for _ in range(10):  # 10 consecutive empties trips the breaker
+        b.record_empty_results()
+    assert b.is_open is True
+    assert b.should_stop() is True
+    clock[0] += 31
+    assert b.should_stop() is False

--- a/tests/test_worker_liveness.py
+++ b/tests/test_worker_liveness.py
@@ -1,0 +1,80 @@
+"""Tests for the worker liveness watchdog (app/jobs/worker_liveness_jobs.py).
+
+Alerts (debounced) when a worker that should be running has a stale heartbeat
+(hung/crashed) or an open circuit breaker; stays quiet otherwise.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+from app.jobs.worker_liveness_jobs import _job_monitor_worker_heartbeats
+from app.models import IcsWorkerStatus
+
+
+def _run(db_session):
+    """Run the watchdog job against the test DB with no debounce; return the Teams mock."""
+    teams = AsyncMock()
+    with (
+        patch("app.database.SessionLocal", return_value=db_session),
+        patch("app.cache.intel_cache.get_cached", return_value=None),
+        patch("app.cache.intel_cache.set_cached"),
+        patch("app.services.teams_notifications.post_teams_channel", teams),
+    ):
+        asyncio.run(_job_monitor_worker_heartbeats())
+    return teams
+
+
+def _ics(db_session, **kwargs):
+    row = IcsWorkerStatus(id=1, **kwargs)
+    db_session.add(row)
+    db_session.commit()
+    return row
+
+
+def test_stale_running_worker_alerts(db_session):
+    _ics(db_session, is_running=True,
+         last_heartbeat=datetime.now(timezone.utc) - timedelta(minutes=20))
+    teams = _run(db_session)
+    teams.assert_awaited_once()
+    assert "ICS" in teams.await_args.args[0]
+
+
+def test_fresh_worker_no_alert(db_session):
+    _ics(db_session, is_running=True, last_heartbeat=datetime.now(timezone.utc))
+    teams = _run(db_session)
+    teams.assert_not_awaited()
+
+
+def test_not_running_no_alert(db_session):
+    _ics(db_session, is_running=False,
+         last_heartbeat=datetime.now(timezone.utc) - timedelta(hours=5))
+    teams = _run(db_session)
+    teams.assert_not_awaited()
+
+
+def test_breaker_open_alerts(db_session):
+    _ics(db_session, is_running=True, last_heartbeat=datetime.now(timezone.utc),
+         circuit_breaker_open=True, circuit_breaker_reason="Captcha detected")
+    teams = _run(db_session)
+    teams.assert_awaited_once()
+    assert "circuit breaker is OPEN" in teams.await_args.args[0]
+
+
+def test_missing_rows_no_error(db_session):
+    teams = _run(db_session)  # no singletons seeded
+    teams.assert_not_awaited()
+
+
+def test_debounce_suppresses_repeat(db_session):
+    _ics(db_session, is_running=True,
+         last_heartbeat=datetime.now(timezone.utc) - timedelta(minutes=20))
+    teams = AsyncMock()
+    with (
+        patch("app.database.SessionLocal", return_value=db_session),
+        patch("app.cache.intel_cache.get_cached", return_value={"alerted": 1}),  # already alerted
+        patch("app.cache.intel_cache.set_cached"),
+        patch("app.services.teams_notifications.post_teams_channel", teams),
+    ):
+        asyncio.run(_job_monitor_worker_heartbeats())
+    teams.assert_not_awaited()

--- a/tests/test_worker_liveness.py
+++ b/tests/test_worker_liveness.py
@@ -13,7 +13,8 @@ from app.models import IcsWorkerStatus
 
 
 def _run(db_session):
-    """Run the watchdog job against the test DB with no debounce; return the Teams mock."""
+    """Run the watchdog job against the test DB with no debounce; return the Teams
+    mock."""
     teams = AsyncMock()
     with (
         patch("app.database.SessionLocal", return_value=db_session),
@@ -33,8 +34,7 @@ def _ics(db_session, **kwargs):
 
 
 def test_stale_running_worker_alerts(db_session):
-    _ics(db_session, is_running=True,
-         last_heartbeat=datetime.now(timezone.utc) - timedelta(minutes=20))
+    _ics(db_session, is_running=True, last_heartbeat=datetime.now(timezone.utc) - timedelta(minutes=20))
     teams = _run(db_session)
     teams.assert_awaited_once()
     assert "ICS" in teams.await_args.args[0]
@@ -47,15 +47,19 @@ def test_fresh_worker_no_alert(db_session):
 
 
 def test_not_running_no_alert(db_session):
-    _ics(db_session, is_running=False,
-         last_heartbeat=datetime.now(timezone.utc) - timedelta(hours=5))
+    _ics(db_session, is_running=False, last_heartbeat=datetime.now(timezone.utc) - timedelta(hours=5))
     teams = _run(db_session)
     teams.assert_not_awaited()
 
 
 def test_breaker_open_alerts(db_session):
-    _ics(db_session, is_running=True, last_heartbeat=datetime.now(timezone.utc),
-         circuit_breaker_open=True, circuit_breaker_reason="Captcha detected")
+    _ics(
+        db_session,
+        is_running=True,
+        last_heartbeat=datetime.now(timezone.utc),
+        circuit_breaker_open=True,
+        circuit_breaker_reason="Captcha detected",
+    )
     teams = _run(db_session)
     teams.assert_awaited_once()
     assert "circuit breaker is OPEN" in teams.await_args.args[0]
@@ -67,8 +71,7 @@ def test_missing_rows_no_error(db_session):
 
 
 def test_debounce_suppresses_repeat(db_session):
-    _ics(db_session, is_running=True,
-         last_heartbeat=datetime.now(timezone.utc) - timedelta(minutes=20))
+    _ics(db_session, is_running=True, last_heartbeat=datetime.now(timezone.utc) - timedelta(minutes=20))
     teams = AsyncMock()
     with (
         patch("app.database.SessionLocal", return_value=db_session),

--- a/tests/test_workers_status_endpoint.py
+++ b/tests/test_workers_status_endpoint.py
@@ -1,0 +1,34 @@
+"""Test for GET /api/admin/workers/status (admin worker liveness snapshot)."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.models import IcsWorkerStatus
+
+
+def test_workers_status_endpoint(client, db_session):
+    db_session.add(
+        IcsWorkerStatus(
+            id=1,
+            is_running=True,
+            last_heartbeat=datetime.now(timezone.utc) - timedelta(minutes=20),
+            circuit_breaker_open=False,
+        )
+    )
+    db_session.commit()
+
+    r = client.get("/api/admin/workers/status")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["workers"]) == 3
+    by_name = {w["name"]: w for w in data["workers"]}
+
+    ics = by_name["ics"]
+    assert ics["present"] is True
+    assert ics["is_running"] is True
+    assert ics["stale"] is True  # 20m heartbeat age > 15m default threshold
+    assert ics["heartbeat_age_seconds"] >= 60 * 19
+    assert "queue" in ics  # queue stats included for scraper workers
+
+    # Unseeded singletons report present=False without erroring.
+    assert by_name["netcomponents"]["present"] is False
+    assert by_name["enrichment"]["present"] is False


### PR DESCRIPTION
Stacked on #428 (base = `clay-integration`). Makes the sourcing-engine workers (ICS, NetComponents, enrichment) detect and recover from hangs on their own — and loudly surface it when they can't. Implements the approved plan.

## The gap
Workers already heartbeat every tick and are crash-restarted (systemd / docker `restart`). But **nobody watched the heartbeat**, a *hung* worker (wedged browser/deadlock) looked "up" forever, the ICS/NC circuit breaker never auto-recovered (a 2am captcha wedged sourcing until a manual restart), and a search could hang with no outer timeout.

## What's in it
1. **Liveness watchdog** — `app/jobs/worker_liveness_jobs.py` (5-min scheduler job): alerts (Teams + Sentry, debounced 1×/hr via intel_cache) when a worker that should be running has a stale heartbeat (hung/crashed) or an open circuit breaker. *This is the headline fix — detection.*
2. **Self-healing breaker** — `CircuitBreakerBase` auto-resets after a cooldown (ICS/NC, default 30m), mirroring the enrichment breaker. Transient captcha/rate-limit no longer wedges the worker.
3. **ICS per-search hard timeout** — `asyncio.wait_for(search_part, ICS_SEARCH_TIMEOUT_SECONDS=150)`; on timeout the item is failed and the loop continues (heartbeat keeps ticking). + `item=None` init safety. (NC stays bounded by its HTTP/Playwright timeouts + the watchdog.)
4. **`GET /api/admin/workers/status`** — glanceable liveness + queue snapshot for all three workers.
5. **systemd hardening** (`deploy/avail-{ics,nc}-worker.service`): `Restart=always` (was `on-failure`, won't restart a clean exit), `StartLimitIntervalSec/Burst` crash-loop backoff, `TimeoutStartSec=120`. *Applied on the droplet by you — `systemctl daemon-reload && restart`.*

## Testing
All worker suites green (420): new breaker-cooldown, watchdog (stale/fresh/not-running/breaker/debounce), status endpoint, ICS search-timeout; existing ICS/NC/base/claim/nightly suites; scheduler. New code Ruff-clean.

Note: 6 pre-existing `TestJobRefreshInsights` failures (a `knowledge_service` patch issue) exist on the base branch too — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)