### PR TITLE
fix(deploy): verify-ci matches check-run job names (test/security)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,12 @@ jobs:
               --jq ".check_runs[] | select(.name==\"$1\") | (if .status!=\"completed\" then .status else .conclusion end)" \
               2>/dev/null | head -1
           }
+          # NOTE: check-runs are named after the JOB (test, security), not the
+          # workflow ("CI — Tests" / "Security Scanning"). Match the job names.
           for attempt in $(seq 1 40); do
-            T=$(check_state "CI — Tests")
-            S=$(check_state "Security Scanning")
-            echo "attempt $attempt — CI — Tests=${T:-missing}  Security Scanning=${S:-missing}"
+            T=$(check_state "test")
+            S=$(check_state "security")
+            echo "attempt $attempt — test=${T:-missing}  security=${S:-missing}"
             case "$T" in failure|cancelled|timed_out|action_required|stale)
               echo "ERROR: 'CI — Tests' for $SHA = $T — refusing to deploy." >&2; exit 1;; esac
             case "$S" in failure|cancelled|timed_out|action_required|stale)


### PR DESCRIPTION
The release-deploy `verify-ci` gate matched workflow names ("CI — Tests"/"Security Scanning") but check-runs are named after the **job** (`test`/`security`), so it never saw green CI and always timed out — every release deploy has been failing at the gate (deploy job skipped). This matches the job names. Pre-existing bug; surfaced when triggering the v2.5.0 release deploy.