### PR TITLE
test: nightly coverage pass — bring 8 modules to 85%+

### DIFF
--- a/app/management/backfill_buyplan_cph.py
+++ b/app/management/backfill_buyplan_cph.py
@@ -27,7 +27,7 @@ def backfill(db: Session) -> int:
     return len(plans)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     db = SessionLocal()
     try:
         backfill(db)

--- a/app/management/backfill_quote_source.py
+++ b/app/management/backfill_quote_source.py
@@ -33,7 +33,7 @@ def backfill(db: Session) -> int:
     return len(updated)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     db = SessionLocal()
     try:
         backfill(db)

--- a/tests/test_backfill_management.py
+++ b/tests/test_backfill_management.py
@@ -217,4 +217,3 @@ def test_backfill_quote_source_no_null_source_quotes(db_session: Session):
     assert q2.source == "proactive"
     db_session.refresh(q1)
     assert q1.source == "email"
-

--- a/tests/test_backfill_management.py
+++ b/tests/test_backfill_management.py
@@ -1,0 +1,220 @@
+"""Tests for app/management/backfill_buyplan_cph.py and backfill_quote_source.py."""
+
+import os
+import uuid
+
+os.environ["TESTING"] = "1"
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.constants import BuyPlanStatus
+
+
+def _make_requisition(db: Session):
+    from app.models.crm import Company
+    from app.models.sourcing import Requisition
+
+    co = Company(name="Test Co", is_active=True, created_at=datetime.now(timezone.utc))
+    db.add(co)
+    db.flush()
+    req = Requisition(
+        company_id=co.id,
+        name="Test Requisition",
+        status="active",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(req)
+    db.flush()
+    return req
+
+
+def _make_buy_plan(db: Session, status: str, requisition_id: int, recorded: bool = False):
+    from app.models.buy_plan import BuyPlan
+    from app.models.quotes import Quote
+
+    # BuyPlan requires a quote_id; Quote requires a requisition_id and quote_number
+    q = Quote(
+        requisition_id=requisition_id,
+        quote_number=f"QT-{uuid.uuid4().hex[:8].upper()}",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(q)
+    db.flush()
+
+    plan = BuyPlan(
+        quote_id=q.id,
+        requisition_id=requisition_id,
+        status=status,
+        purchase_history_recorded_at=datetime.now(timezone.utc) if recorded else None,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(plan)
+    db.flush()
+    return plan
+
+
+# ── backfill_buyplan_cph ──────────────────────────────────────────────────────
+
+
+def test_backfill_buyplan_cph_records_completed_plans(db_session: Session):
+    """Completed plans without history are processed; returns count."""
+    from unittest.mock import patch
+
+    from app.management.backfill_buyplan_cph import backfill
+
+    req = _make_requisition(db_session)
+    plan = _make_buy_plan(db_session, BuyPlanStatus.COMPLETED.value, req.id)
+    db_session.commit()
+
+    with patch("app.management.backfill_buyplan_cph.record_buyplan_purchase_history") as mock_record:
+        count = backfill(db_session)
+
+    assert count >= 1
+    mock_record.assert_called()
+
+
+def test_backfill_buyplan_cph_skips_already_recorded(db_session: Session):
+    """Plans already recorded (purchase_history_recorded_at set) are skipped."""
+    from unittest.mock import patch
+
+    from app.management.backfill_buyplan_cph import backfill
+
+    req = _make_requisition(db_session)
+    plan = _make_buy_plan(db_session, BuyPlanStatus.COMPLETED.value, req.id, recorded=True)
+    db_session.commit()
+
+    with patch("app.management.backfill_buyplan_cph.record_buyplan_purchase_history") as mock_record:
+        count = backfill(db_session)
+
+    assert count == 0
+    mock_record.assert_not_called()
+
+
+def test_backfill_buyplan_cph_skips_non_completed(db_session: Session):
+    """Only COMPLETED plans are processed; drafts are ignored."""
+    from unittest.mock import patch
+
+    from app.management.backfill_buyplan_cph import backfill
+
+    req = _make_requisition(db_session)
+    _make_buy_plan(db_session, BuyPlanStatus.DRAFT.value, req.id)
+    db_session.commit()
+
+    with patch("app.management.backfill_buyplan_cph.record_buyplan_purchase_history") as mock_record:
+        count = backfill(db_session)
+
+    assert count == 0
+    mock_record.assert_not_called()
+
+
+def test_backfill_buyplan_cph_empty_db(db_session: Session):
+    """Returns 0 when no plans exist."""
+    from app.management.backfill_buyplan_cph import backfill
+
+    count = backfill(db_session)
+    assert count == 0
+
+
+# ── backfill_quote_source ─────────────────────────────────────────────────────
+
+
+def _make_quote(db: Session, source=None, requisition_id: int | None = None):
+    from app.models.crm import Company
+    from app.models.quotes import Quote
+    from app.models.sourcing import Requisition
+
+    if requisition_id is None:
+        co = Company(name="Quote Co", is_active=True, created_at=datetime.now(timezone.utc))
+        db.add(co)
+        db.flush()
+        req = Requisition(
+            company_id=co.id,
+            name="Quote Req",
+            status="active",
+            created_at=datetime.now(timezone.utc),
+        )
+        db.add(req)
+        db.flush()
+        requisition_id = req.id
+
+    q = Quote(
+        requisition_id=requisition_id,
+        quote_number=f"QT-{uuid.uuid4().hex[:8].upper()}",
+        source=source,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(q)
+    db.flush()
+    return q
+
+
+def _make_proactive_offer(db: Session, quote_id: int):
+    from app.models.intelligence import ProactiveOffer
+
+    po = ProactiveOffer(
+        converted_quote_id=quote_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(po)
+    db.flush()
+    return po
+
+
+def test_backfill_quote_source_sets_proactive(db_session: Session):
+    """Quotes linked via ProactiveOffer.converted_quote_id get source='proactive'."""
+    from app.management.backfill_quote_source import backfill
+
+    quote = _make_quote(db_session, source=None)
+    _make_proactive_offer(db_session, quote.id)
+    db_session.commit()
+
+    count = backfill(db_session)
+
+    assert count >= 1
+    db_session.refresh(quote)
+    assert quote.source == "proactive"
+
+
+def test_backfill_quote_source_skips_already_set(db_session: Session):
+    """Quotes that already have a source are not modified."""
+    from app.management.backfill_quote_source import backfill
+
+    quote = _make_quote(db_session, source="manual")
+    _make_proactive_offer(db_session, quote.id)
+    db_session.commit()
+
+    count = backfill(db_session)
+
+    assert count == 0
+    db_session.refresh(quote)
+    assert quote.source == "manual"
+
+
+def test_backfill_quote_source_empty_db(db_session: Session):
+    """Returns 0 when no proactive offers exist."""
+    from app.management.backfill_quote_source import backfill
+
+    count = backfill(db_session)
+    assert count == 0
+
+
+def test_backfill_quote_source_no_null_source_quotes(db_session: Session):
+    """Proactive offers pointing to quotes with a source set are not updated."""
+    from app.management.backfill_quote_source import backfill
+
+    q1 = _make_quote(db_session, source="email")
+    q2 = _make_quote(db_session, source=None)
+    _make_proactive_offer(db_session, q1.id)
+    _make_proactive_offer(db_session, q2.id)
+    db_session.commit()
+
+    count = backfill(db_session)
+
+    assert count == 1
+    db_session.refresh(q2)
+    assert q2.source == "proactive"
+    db_session.refresh(q1)
+    assert q1.source == "email"
+

--- a/tests/test_clay_service.py
+++ b/tests/test_clay_service.py
@@ -198,3 +198,147 @@ def test_endpoint_accepts_valid(client):
         )
     assert r.status_code == 200
     assert r.json()["status"] == "applied"
+
+
+# ── Additional branch coverage ────────────────────────────────────────────────
+
+
+class TestRequestEnrichmentEdgeCases:
+    def test_unsupported_entity_type_returns_error(self):
+        with patch.object(clay_service, "enabled_and_configured", return_value=True):
+            with patch.object(clay_service, "circuit_open", return_value=False):
+                out = asyncio.run(clay_service.request_enrichment("x.com", "contact", 1))
+        assert out["status"] == "error"
+        assert "unsupported" in out["reason"]
+
+    def test_network_error_returns_error(self):
+        with (
+            patch.object(clay_service, "enabled_and_configured", return_value=True),
+            patch.object(clay_service, "circuit_open", return_value=False),
+            patch.object(clay_service, "_webhook_url", return_value="https://clay/hook"),
+            patch.object(clay_service, "_secret", return_value=""),
+            patch.object(clay_service, "set_cached"),
+            patch.object(clay_service, "http") as mock_http,
+        ):
+            mock_http.post = AsyncMock(side_effect=Exception("connection refused"))
+            out = asyncio.run(clay_service.request_enrichment("x.com", "company", 1))
+        assert out["status"] == "error"
+        assert "connection refused" in out["reason"]
+
+    def test_non_2xx_response_returns_error(self):
+        with (
+            patch.object(clay_service, "enabled_and_configured", return_value=True),
+            patch.object(clay_service, "circuit_open", return_value=False),
+            patch.object(clay_service, "_webhook_url", return_value="https://clay/hook"),
+            patch.object(clay_service, "_secret", return_value=""),
+            patch.object(clay_service, "set_cached"),
+            patch.object(clay_service, "http") as mock_http,
+        ):
+            mock_http.post = AsyncMock(return_value=_resp(400))
+            out = asyncio.run(clay_service.request_enrichment("x.com", "company", 1))
+        assert out["status"] == "error"
+        assert "400" in out["reason"]
+
+
+class TestVerifySignatureEdgeCases:
+    def test_signature_without_prefix(self):
+        import hashlib
+        import hmac
+
+        body = b'{"x":1}'
+        raw_sig = hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+        with patch.object(clay_service, "_secret", return_value="secret"):
+            assert clay_service.verify_signature(body, raw_sig) is True
+
+    def test_empty_provided_returns_false(self):
+        with patch.object(clay_service, "_secret", return_value="secret"):
+            assert clay_service.verify_signature(b"body", None) is False
+
+
+class TestConfidenceFromMarker:
+    def test_none_returns_70(self):
+        assert clay_service._confidence_from_marker(None) == 70
+
+    def test_int_above_1(self):
+        assert clay_service._confidence_from_marker(90) == 90
+
+    def test_float_below_1(self):
+        assert clay_service._confidence_from_marker(0.8) == 80
+
+    def test_string_high(self):
+        assert clay_service._confidence_from_marker("high") == 90
+
+    def test_string_medium(self):
+        assert clay_service._confidence_from_marker("b") == 70
+
+    def test_string_low(self):
+        assert clay_service._confidence_from_marker("c") == 40
+
+    def test_string_unknown_returns_default(self):
+        assert clay_service._confidence_from_marker("unknown_val") == 70
+
+
+class TestHandleCallbackEdgeCases:
+    def test_company_not_found(self):
+        corr = {"entity_type": "company", "entity_id": 99999, "domain": "missing.com"}
+        db = MagicMock()
+        db.get.return_value = None
+        with (
+            patch.object(clay_service, "get_cached", return_value=corr),
+            patch.object(clay_service, "set_cached"),
+        ):
+            out = clay_service.handle_callback({"correlation_token": "tok"}, db)
+        assert out["status"] == "rejected"
+        assert out["reason"] == "company_not_found"
+
+    def test_commit_failure_returns_error(self, db_session, test_vendor_card):
+        corr = {"entity_type": "vendor_card", "entity_id": test_vendor_card.id, "domain": "co.com"}
+        payload = {"correlation_token": "tok"}
+        with (
+            patch.object(clay_service, "get_cached", return_value=corr),
+            patch.object(clay_service, "set_cached"),
+            patch("app.enrichment_service.apply_enrichment_to_vendor", return_value=[]),
+            patch.object(db_session, "commit", side_effect=Exception("db error")),
+        ):
+            out = clay_service.handle_callback(payload, db_session)
+        assert out["status"] == "error"
+        assert out["reason"] == "commit_failed"
+
+
+class TestAddVendorContactsEdgeCases:
+    def test_skip_non_dict_contacts(self, db_session, test_vendor_card):
+        from app.models import VendorContact
+
+        contacts = ["not-a-dict", 42]
+        count = clay_service._add_vendor_contacts(db_session, VendorContact, test_vendor_card.id, contacts)
+        assert count == 0
+
+    def test_skip_contact_with_no_email_and_no_name(self, db_session, test_vendor_card):
+        from app.models import VendorContact
+
+        contacts = [{"email": "", "full_name": None}]
+        count = clay_service._add_vendor_contacts(db_session, VendorContact, test_vendor_card.id, contacts)
+        assert count == 0
+
+    def test_skip_duplicate_email(self, db_session, test_vendor_card, test_vendor_contact):
+        from app.models import VendorContact
+
+        existing_email = test_vendor_contact.email
+        contacts = [{"email": existing_email, "full_name": "Jane"}]
+        count = clay_service._add_vendor_contacts(db_session, VendorContact, test_vendor_card.id, contacts)
+        assert count == 0
+
+
+class TestAddSiteContactsEdgeCases:
+    def test_skip_contact_with_no_name(self, db_session, test_customer_site):
+        from app.models import SiteContact
+
+        contacts = [{"full_name": None, "name": None, "email": "x@y.com"}]
+        count = clay_service._add_site_contacts(db_session, SiteContact, test_customer_site.id, contacts)
+        assert count == 0
+
+    def test_skip_non_dict(self, db_session, test_customer_site):
+        from app.models import SiteContact
+
+        count = clay_service._add_site_contacts(db_session, SiteContact, test_customer_site.id, ["bad"])
+        assert count == 0

--- a/tests/test_company_utils.py
+++ b/tests/test_company_utils.py
@@ -1,10 +1,20 @@
 """Tests for app/company_utils.py — normalization and dedup detection."""
 
+import os
+
+os.environ["TESTING"] = "1"
+
 from datetime import datetime, timezone
 
 import pytest
 
-from app.company_utils import find_company_dedup_candidates, normalize_company_name
+from app.company_utils import (
+    _auto_keep_rank,
+    _pair_dict,
+    find_company_dedup_candidates,
+    normalize_company_name,
+    suggest_clean_company_name,
+)
 from app.models import Company, CustomerSite
 
 
@@ -124,3 +134,163 @@ class TestFindCompanyDedupCandidates:
         candidates = find_company_dedup_candidates(db_session, threshold=80)
         # Should not match inactive company
         assert len(candidates) == 0
+
+
+class TestSuggestCleanCompanyName:
+    @pytest.mark.parametrize(
+        "raw,expected_contains,expected_not_contains",
+        [
+            ("ACME CORP", "ACME", ["Corp", "corp"]),
+            ("Mouser Electronics, Inc.", "Electronics", ["Inc", "inc"]),
+            ("The Phoenix Company", "Phoenix", ["The ", "Company"]),
+            ("DigiKey Corp.", "DigiKey", ["Corp"]),
+            ("  Foo   Bar  ", "Foo Bar", []),
+            ("Arrow Electronics, LLC", "Arrow Electronics", ["LLC"]),
+        ],
+    )
+    def test_suggest_clean(self, raw, expected_contains, expected_not_contains):
+        result = suggest_clean_company_name(raw)
+        assert expected_contains in result
+        for not_expected in expected_not_contains:
+            assert not_expected not in result
+
+    def test_empty_returns_empty(self):
+        assert suggest_clean_company_name("") == ""
+
+    def test_none_returns_empty(self):
+        assert suggest_clean_company_name(None) == ""
+
+    def test_preserves_case(self):
+        result = suggest_clean_company_name("Arrow Electronics Inc")
+        assert result[0].isupper()
+
+    def test_strips_trailing_comma(self):
+        result = suggest_clean_company_name("Acme Corp,")
+        assert "," not in result
+
+    def test_strips_leading_the(self):
+        result = suggest_clean_company_name("The Phoenix Company")
+        assert not result.startswith("The ")
+
+
+class TestPairDictHelpers:
+    def _company_dict(self, id: int, name: str, sites: int = 0, owner: bool = False, strategic: bool = False):
+        return {
+            "id": id,
+            "name": name,
+            "site_count": sites,
+            "has_owner": owner,
+            "is_strategic": strategic,
+        }
+
+    def test_pair_dict_shape(self):
+        a = self._company_dict(1, "Alpha Corp", sites=3, owner=True)
+        b = self._company_dict(2, "Alpha Corporation", sites=1)
+        result = _pair_dict(a, b, 92)
+        assert result["score"] == 92
+        assert "company_a" in result
+        assert "company_b" in result
+        assert "auto_keep_id" in result
+
+    def test_pair_dict_auto_keep_prefers_more_sites(self):
+        a = self._company_dict(1, "A Corp", sites=5)
+        b = self._company_dict(2, "A Corporation", sites=1)
+        result = _pair_dict(a, b, 90)
+        assert result["auto_keep_id"] == 1
+
+    def test_pair_dict_auto_keep_prefers_owner(self):
+        a = self._company_dict(1, "B Corp", sites=1, owner=True)
+        b = self._company_dict(2, "B Corporation", sites=1, owner=False)
+        result = _pair_dict(a, b, 90)
+        assert result["auto_keep_id"] == 1
+
+    def test_pair_dict_auto_keep_prefers_strategic(self):
+        a = self._company_dict(1, "C Corp", sites=1, owner=False, strategic=True)
+        b = self._company_dict(2, "C Corporation", sites=1, owner=False, strategic=False)
+        result = _pair_dict(a, b, 85)
+        assert result["auto_keep_id"] == 1
+
+    def test_auto_keep_rank_lower_id_tiebreak(self):
+        a = self._company_dict(1, "D Corp", sites=0)
+        b = self._company_dict(2, "D Corporation", sites=0)
+        # Equal sites/owner/strategic → lower id wins
+        rank_a = _auto_keep_rank(a)
+        rank_b = _auto_keep_rank(b)
+        assert rank_a > rank_b
+
+
+class TestFindCompanyDedupCandidatesPGPath:
+    """Test the PostgreSQL code path by mocking the dialect."""
+
+    def _pg_db(self, pair_rows=None):
+        from unittest.mock import MagicMock
+
+        mock_db = MagicMock()
+        mock_db.bind = MagicMock()
+        mock_db.bind.dialect.name = "postgresql"
+        query = mock_db.query.return_value
+        query.filter.return_value = query
+        query.order_by.return_value = query
+        query.limit.return_value = query
+        query.all.return_value = pair_rows if pair_rows is not None else []
+        query.outerjoin.return_value = query
+        query.group_by.return_value = query
+        return mock_db
+
+    def test_pg_path_returns_empty_when_no_pairs(self):
+        from app.company_utils import _find_company_dedup_candidates_pg
+
+        db = self._pg_db(pair_rows=[])
+        result = _find_company_dedup_candidates_pg(db, threshold=85, limit=50)
+        assert result == []
+
+    def test_pg_path_with_pairs_builds_candidates(self):
+        from unittest.mock import MagicMock
+
+        from app.company_utils import _find_company_dedup_candidates_pg
+
+        row = MagicMock()
+        row.a_id = 1
+        row.a_name = "Alpha Corp"
+        row.b_id = 2
+        row.b_name = "Alpha Corporation"
+        row.sim = 0.92
+
+        attr_row_a = MagicMock()
+        attr_row_a.id = 1
+        attr_row_a.account_owner_id = None
+        attr_row_a.is_strategic = False
+        attr_row_a.site_count = 2
+
+        attr_row_b = MagicMock()
+        attr_row_b.id = 2
+        attr_row_b.account_owner_id = 5
+        attr_row_b.is_strategic = False
+        attr_row_b.site_count = 1
+
+        db = MagicMock()
+        db.bind = MagicMock()
+        db.bind.dialect.name = "postgresql"
+
+        call_count = [0]
+
+        def query_side_effect(*args):
+            call_count[0] += 1
+            q = MagicMock()
+            q.filter.return_value = q
+            q.order_by.return_value = q
+            q.limit.return_value = q
+            q.outerjoin.return_value = q
+            q.group_by.return_value = q
+            if call_count[0] == 1:
+                q.all.return_value = [row]
+            else:
+                q.all.return_value = [attr_row_a, attr_row_b]
+            return q
+
+        db.query.side_effect = query_side_effect
+
+        result = _find_company_dedup_candidates_pg(db, threshold=85, limit=50)
+        assert len(result) == 1
+        assert result[0]["score"] == 92
+        assert result[0]["company_a"]["name"] == "Alpha Corp"

--- a/tests/test_datasheet_library.py
+++ b/tests/test_datasheet_library.py
@@ -67,6 +67,51 @@ async def test_fetch_bytes_ok():
         assert await dl.fetch_datasheet_bytes("DRV", "ITM") == b"%PDF-bytes"
 
 
+async def test_upload_returns_none_when_no_token():
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"id": "X", "webUrl": "https://sp/x"}
+    with (
+        patch.object(dl.settings, "datasheet_library_drive_id", "DRV"),
+        patch("app.services.datasheet_library.get_app_graph_token", AsyncMock(return_value=None)),
+    ):
+        out = await dl.upload_datasheet_to_library("x.pdf", b"x", "application/pdf")
+    assert out is None
+
+
+async def test_fetch_bytes_returns_none_when_no_token():
+    with patch("app.services.datasheet_library.get_app_graph_token", AsyncMock(return_value=None)):
+        result = await dl.fetch_datasheet_bytes("DRV", "ITM")
+    assert result is None
+
+
+async def test_fetch_bytes_returns_none_on_exception():
+    with (
+        patch("app.services.datasheet_library.get_app_graph_token", AsyncMock(return_value="T")),
+        patch("app.services.datasheet_library.http_redirect") as httpr,
+    ):
+        httpr.get = AsyncMock(side_effect=RuntimeError("network error"))
+        result = await dl.fetch_datasheet_bytes("DRV", "ITM")
+    assert result is None
+
+
+async def test_fetch_bytes_returns_none_on_non_200():
+    resp = MagicMock(status_code=404, content=b"")
+    with (
+        patch("app.services.datasheet_library.get_app_graph_token", AsyncMock(return_value="T")),
+        patch("app.services.datasheet_library.http_redirect") as httpr,
+    ):
+        httpr.get = AsyncMock(return_value=resp)
+        result = await dl.fetch_datasheet_bytes("DRV", "ITM")
+    assert result is None
+
+
+async def test_fetch_bytes_returns_none_for_empty_ids():
+    result = await dl.fetch_datasheet_bytes("", "ITM")
+    assert result is None
+    result = await dl.fetch_datasheet_bytes("DRV", "")
+    assert result is None
+
+
 def test_sanitize_blocks_traversal_and_specials():
     from app.services.datasheet_library import _sanitize
 

--- a/tests/test_hunter_connector.py
+++ b/tests/test_hunter_connector.py
@@ -163,6 +163,125 @@ class TestHunterEmailFinder:
         assert await HunterConnector("key").email_finder("example.com", "", "Smith") is None
 
 
+class TestHunterVerify:
+    @pytest.mark.asyncio
+    async def test_verify_returns_deliverable(self):
+        from app.connectors.hunter import HunterConnector
+
+        mock_resp = _mock_response(200, {"data": {"result": "deliverable", "score": 95}})
+        with patch("app.connectors.hunter.http") as mock_http:
+            mock_http.get = AsyncMock(return_value=mock_resp)
+            result = await HunterConnector("key").verify("alice@example.com")
+
+        assert result["result"] == "deliverable"
+        assert result["score"] == 95
+
+    @pytest.mark.asyncio
+    async def test_verify_no_key_returns_unknown(self):
+        from app.connectors.hunter import HunterConnector
+
+        result = await HunterConnector("").verify("alice@example.com")
+        assert result["result"] == "unknown"
+        assert result["score"] == 0
+
+    @pytest.mark.asyncio
+    async def test_verify_no_email_returns_unknown(self):
+        from app.connectors.hunter import HunterConnector
+
+        result = await HunterConnector("key").verify("")
+        assert result["result"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_verify_network_error_returns_unknown(self):
+        from app.connectors.hunter import HunterConnector
+
+        with patch("app.connectors.hunter.http") as mock_http:
+            mock_http.get = AsyncMock(side_effect=Exception("network failure"))
+            result = await HunterConnector("key").verify("bob@example.com")
+
+        assert result["result"] == "unknown"
+        assert result["score"] == 0
+
+    @pytest.mark.asyncio
+    async def test_verify_non_200_returns_unknown(self):
+        from app.connectors.hunter import HunterConnector
+
+        mock_resp = _mock_response(503, {})
+        with patch("app.connectors.hunter.http") as mock_http:
+            mock_http.get = AsyncMock(return_value=mock_resp)
+            result = await HunterConnector("key").verify("bob@example.com")
+
+        assert result["result"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_verify_missing_data_key_returns_defaults(self):
+        from app.connectors.hunter import HunterConnector
+
+        mock_resp = _mock_response(200, {})
+        with patch("app.connectors.hunter.http") as mock_http:
+            mock_http.get = AsyncMock(return_value=mock_resp)
+            result = await HunterConnector("key").verify("bob@example.com")
+
+        assert result["result"] == "unknown"
+        assert result["score"] == 0
+
+
+class TestHunterEmailFinderEdgeCases:
+    @pytest.mark.asyncio
+    async def test_401_raises_auth_error(self):
+        from app.connectors.errors import ConnectorAuthError
+        from app.connectors.hunter import HunterConnector
+
+        mock_resp = _mock_response(401, {})
+        with patch("app.connectors.hunter.http") as mock_http:
+            mock_http.get = AsyncMock(return_value=mock_resp)
+            with pytest.raises(ConnectorAuthError):
+                await HunterConnector("key").email_finder("example.com", "Alice", "Smith")
+
+    @pytest.mark.asyncio
+    async def test_429_raises_rate_limit(self):
+        from app.connectors.errors import ConnectorRateLimitError
+        from app.connectors.hunter import HunterConnector
+
+        mock_resp = _mock_response(429, {})
+        with patch("app.connectors.hunter.http") as mock_http:
+            mock_http.get = AsyncMock(return_value=mock_resp)
+            with pytest.raises(ConnectorRateLimitError):
+                await HunterConnector("key").email_finder("example.com", "Alice", "Smith")
+
+    @pytest.mark.asyncio
+    async def test_non_200_returns_none(self):
+        from app.connectors.hunter import HunterConnector
+
+        mock_resp = _mock_response(500, {})
+        with patch("app.connectors.hunter.http") as mock_http:
+            mock_http.get = AsyncMock(return_value=mock_resp)
+            result = await HunterConnector("key").email_finder("example.com", "Alice", "Smith")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_none(self):
+        from app.connectors.hunter import HunterConnector
+
+        with patch("app.connectors.hunter.http") as mock_http:
+            mock_http.get = AsyncMock(side_effect=Exception("timeout"))
+            result = await HunterConnector("key").email_finder("example.com", "Alice", "Smith")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_email_in_response_returns_none(self):
+        from app.connectors.hunter import HunterConnector
+
+        mock_resp = _mock_response(200, {"data": {"email": "", "score": 0}})
+        with patch("app.connectors.hunter.http") as mock_http:
+            mock_http.get = AsyncMock(return_value=mock_resp)
+            result = await HunterConnector("key").email_finder("example.com", "Alice", "Smith")
+
+        assert result is None
+
+
 class TestHunterWaterfallIntegration:
     @pytest.mark.asyncio
     async def test_hunter_contacts_included_in_waterfall(self):

--- a/tests/test_prospect_reclamation.py
+++ b/tests/test_prospect_reclamation.py
@@ -1,0 +1,447 @@
+"""Tests for app/services/prospect_reclamation.py — SP4 sweep, surface, reclaim."""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.constants import ProspectAccountStatus
+from app.models.auth import User
+from app.models.crm import Company
+from app.models.prospect_account import ProspectAccount
+
+
+def _make_user(db: Session, email: str | None = None) -> User:
+    u = User(
+        email=email or f"user-{uuid.uuid4().hex[:6]}@test.com",
+        name="Test",
+        role="buyer",
+        azure_id=uuid.uuid4().hex,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_company(db: Session, owner_id=None, domain: str | None = None) -> Company:
+    c = Company(
+        name=f"Co-{uuid.uuid4().hex[:6]}",
+        domain=domain or f"{uuid.uuid4().hex[:8]}.com",
+        is_active=True,
+        account_owner_id=owner_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(c)
+    db.flush()
+    return c
+
+
+def _make_prospect(
+    db: Session,
+    company: Company | None = None,
+    status: str = "suggested",
+    swept_at=None,
+    swept_from_owner_id=None,
+    domain: str | None = None,
+) -> ProspectAccount:
+    pa = ProspectAccount(
+        name=f"Prospect-{uuid.uuid4().hex[:6]}",
+        domain=domain or (company.domain if company else f"{uuid.uuid4().hex[:8]}.com"),
+        discovery_source="clay",
+        status=status,
+        fit_score=0,
+        readiness_score=0,
+        company_id=company.id if company else None,
+        swept_at=swept_at,
+        swept_from_owner_id=swept_from_owner_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(pa)
+    db.flush()
+    return pa
+
+
+# ── job_account_sweep_with_db ─────────────────────────────────────────────────
+
+
+async def test_sweep_moves_dormant_account_to_prospecting(db_session: Session, monkeypatch):
+    """A dormant owned account gets swept — owner cleared, ProspectAccount updated."""
+    from app.services import prospect_reclamation as pr
+
+    owner = _make_user(db_session)
+    co = _make_company(db_session, owner_id=owner.id)
+    pa = _make_prospect(db_session, company=co)
+    db_session.commit()
+
+    monkeypatch.setattr("app.config.settings.account_sweep_inactivity_days", 30)
+
+    last_active = datetime.now(timezone.utc) - timedelta(days=45)
+    mock_result = {"prospect_id": pa.id}
+
+    with (
+        patch("app.services.activity_service.get_last_activity_at", return_value=last_active),
+        patch("app.services.prospect_claim.send_company_to_prospecting", return_value=mock_result),
+        patch("app.services.prospect_reclamation._send_sweep_notification", new_callable=AsyncMock),
+    ):
+        await pr.job_account_sweep_with_db(db_session)
+
+    db_session.refresh(pa)
+    assert pa.swept_from_owner_id == owner.id
+    assert pa.swept_at is not None
+    assert pa.discovery_source == "auto_sweep"
+
+
+async def test_sweep_skips_already_swept_account(db_session: Session, monkeypatch):
+    """A company with an already-swept ProspectAccount is skipped (idempotent)."""
+    from app.services import prospect_reclamation as pr
+
+    owner = _make_user(db_session)
+    co = _make_company(db_session, owner_id=owner.id)
+    swept_time = datetime.now(timezone.utc) - timedelta(days=1)
+    _make_prospect(db_session, company=co, swept_at=swept_time)
+    db_session.commit()
+
+    monkeypatch.setattr("app.config.settings.account_sweep_inactivity_days", 30)
+
+    mock_sweep = MagicMock()
+    with patch("app.services.prospect_claim.send_company_to_prospecting", mock_sweep):
+        await pr.job_account_sweep_with_db(db_session)
+
+    mock_sweep.assert_not_called()
+
+
+async def test_sweep_skips_active_account(db_session: Session, monkeypatch):
+    """A company with recent activity (within inactivity_days) is skipped."""
+    from app.services import prospect_reclamation as pr
+
+    owner = _make_user(db_session)
+    co = _make_company(db_session, owner_id=owner.id)
+    db_session.commit()
+
+    monkeypatch.setattr("app.config.settings.account_sweep_inactivity_days", 30)
+
+    recent_activity = datetime.now(timezone.utc) - timedelta(days=5)
+    mock_sweep = MagicMock()
+
+    with (
+        patch("app.services.activity_service.get_last_activity_at", return_value=recent_activity),
+        patch("app.services.prospect_claim.send_company_to_prospecting", mock_sweep),
+    ):
+        await pr.job_account_sweep_with_db(db_session)
+
+    mock_sweep.assert_not_called()
+
+
+async def test_sweep_skips_when_owner_not_found(db_session: Session, monkeypatch):
+    """Company whose account_owner_id resolves to no User is skipped gracefully."""
+    from app.services import prospect_reclamation as pr
+
+    real_owner = _make_user(db_session)
+    co = _make_company(db_session, owner_id=real_owner.id)
+    db_session.commit()
+
+    monkeypatch.setattr("app.config.settings.account_sweep_inactivity_days", 30)
+
+    old_activity = datetime.now(timezone.utc) - timedelta(days=60)
+    mock_sweep = MagicMock()
+
+    original_get = db_session.get
+
+    def mock_db_get(model, pk):
+        from app.models.auth import User as UserModel
+
+        if model is UserModel and pk == real_owner.id:
+            return None
+        return original_get(model, pk)
+
+    with (
+        patch("app.services.activity_service.get_last_activity_at", return_value=old_activity),
+        patch("app.services.prospect_claim.send_company_to_prospecting", mock_sweep),
+        patch.object(db_session, "get", side_effect=mock_db_get),
+    ):
+        await pr.job_account_sweep_with_db(db_session)
+
+    mock_sweep.assert_not_called()
+
+
+async def test_sweep_handles_never_active_account(db_session: Session, monkeypatch):
+    """A company with no activity at all (last_activity=None) is swept."""
+    from app.services import prospect_reclamation as pr
+
+    owner = _make_user(db_session)
+    co = _make_company(db_session, owner_id=owner.id)
+    pa = _make_prospect(db_session, company=co)
+    db_session.commit()
+
+    monkeypatch.setattr("app.config.settings.account_sweep_inactivity_days", 30)
+
+    mock_result = {"prospect_id": pa.id}
+
+    with (
+        patch("app.services.activity_service.get_last_activity_at", return_value=None),
+        patch("app.services.prospect_claim.send_company_to_prospecting", return_value=mock_result),
+        patch("app.services.prospect_reclamation._send_sweep_notification", new_callable=AsyncMock),
+    ):
+        await pr.job_account_sweep_with_db(db_session)
+
+    db_session.refresh(pa)
+    assert pa.swept_from_owner_id == owner.id
+
+
+# ── job_auto_surface_with_db ──────────────────────────────────────────────────
+
+
+async def test_auto_surface_creates_prospect_for_past_customer(db_session: Session):
+    """Company with a requisition but no owner gets surfaced as reactivation."""
+    from app.models.sourcing import Requisition
+    from app.services import prospect_reclamation as pr
+
+    co = _make_company(db_session, owner_id=None, domain="past-customer-123.com")
+    req = Requisition(
+        company_id=co.id,
+        name="Old Order",
+        status="closed",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req)
+    db_session.commit()
+
+    await pr.job_auto_surface_with_db(db_session)
+
+    pa = db_session.query(ProspectAccount).filter(ProspectAccount.company_id == co.id).first()
+    assert pa is not None
+    assert pa.discovery_source == "reactivation"
+    assert pa.status == ProspectAccountStatus.SUGGESTED
+
+
+async def test_auto_surface_skips_already_in_pool(db_session: Session):
+    """Company already in pool (non-dismissed ProspectAccount) is skipped."""
+    from app.models.sourcing import Requisition
+    from app.services import prospect_reclamation as pr
+
+    co = _make_company(db_session, owner_id=None, domain="already-pooled.com")
+    req = Requisition(
+        company_id=co.id,
+        name="Old Order",
+        status="closed",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req)
+    existing_pa = _make_prospect(db_session, company=co, status="suggested", domain="already-pooled.com")
+    db_session.commit()
+
+    initial_count = db_session.query(ProspectAccount).filter(ProspectAccount.company_id == co.id).count()
+    await pr.job_auto_surface_with_db(db_session)
+
+    final_count = db_session.query(ProspectAccount).filter(ProspectAccount.company_id == co.id).count()
+    assert final_count == initial_count
+
+
+async def test_auto_surface_skips_no_domain(db_session: Session):
+    """Company with no domain is skipped with a warning."""
+    from app.models.sourcing import Requisition
+    from app.services import prospect_reclamation as pr
+
+    co = Company(
+        name="NoDomain Corp",
+        domain=None,
+        is_active=True,
+        account_owner_id=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(co)
+    db_session.flush()
+
+    req = Requisition(
+        company_id=co.id,
+        name="Old Req",
+        status="closed",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req)
+    db_session.commit()
+
+    await pr.job_auto_surface_with_db(db_session)
+
+    pa = db_session.query(ProspectAccount).filter(ProspectAccount.company_id == co.id).first()
+    assert pa is None
+
+
+async def test_auto_surface_merges_existing_domain_prospect(db_session: Session):
+    """Domain collision: existing ProspectAccount without company_id gets linked."""
+    from app.models.sourcing import Requisition
+    from app.services import prospect_reclamation as pr
+
+    domain = "domain-collision.com"
+    co = _make_company(db_session, owner_id=None, domain=domain)
+    req = Requisition(
+        company_id=co.id,
+        name="Old Req",
+        status="closed",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req)
+
+    orphan_pa = ProspectAccount(
+        name="Orphan",
+        domain=domain,
+        discovery_source="clay",
+        status="suggested",
+        fit_score=0,
+        readiness_score=0,
+        company_id=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(orphan_pa)
+    db_session.commit()
+
+    await pr.job_auto_surface_with_db(db_session)
+
+    db_session.refresh(orphan_pa)
+    assert orphan_pa.company_id == co.id
+
+
+# ── reclaim_prospect_account ──────────────────────────────────────────────────
+
+
+def test_reclaim_succeeds_for_former_owner(db_session: Session):
+    """Former owner can reclaim their swept account."""
+    from app.services.prospect_reclamation import reclaim_prospect_account
+
+    owner = _make_user(db_session)
+    co = _make_company(db_session, domain=f"reclaim-{uuid.uuid4().hex[:6]}.com")
+    pa = _make_prospect(db_session, company=co, swept_from_owner_id=owner.id)
+    db_session.commit()
+
+    with patch("app.services.activity_service.log_activity"):
+        result = reclaim_prospect_account(pa.id, owner.id, db_session)
+
+    assert result["status"] == "reclaimed"
+    assert result["prospect_id"] == pa.id
+    db_session.refresh(pa)
+    assert pa.status == ProspectAccountStatus.DISMISSED
+
+
+def test_reclaim_succeeds_for_admin(db_session: Session):
+    """Admin can reclaim any swept account regardless of former ownership."""
+    from app.services.prospect_reclamation import reclaim_prospect_account
+
+    owner = _make_user(db_session)
+    admin = _make_user(db_session)
+    co = _make_company(db_session, domain=f"admin-reclaim-{uuid.uuid4().hex[:6]}.com")
+    pa = _make_prospect(db_session, company=co, swept_from_owner_id=owner.id)
+    db_session.commit()
+
+    with patch("app.services.activity_service.log_activity"):
+        result = reclaim_prospect_account(pa.id, admin.id, db_session, is_admin=True)
+
+    assert result["status"] == "reclaimed"
+
+
+def test_reclaim_raises_lookup_error_when_not_found(db_session: Session):
+    """Raises LookupError for unknown prospect_id."""
+    from app.services.prospect_reclamation import reclaim_prospect_account
+
+    owner = _make_user(db_session)
+    db_session.commit()
+
+    with pytest.raises(LookupError, match="not found"):
+        reclaim_prospect_account(99999, owner.id, db_session)
+
+
+def test_reclaim_raises_value_error_for_wrong_status(db_session: Session):
+    """Raises ValueError when prospect is already dismissed."""
+    from app.services.prospect_reclamation import reclaim_prospect_account
+
+    owner = _make_user(db_session)
+    pa = _make_prospect(db_session, status="dismissed", swept_from_owner_id=owner.id)
+    db_session.commit()
+
+    with pytest.raises(ValueError, match="Cannot reclaim"):
+        reclaim_prospect_account(pa.id, owner.id, db_session)
+
+
+def test_reclaim_raises_permission_denied_for_other_user(db_session: Session):
+    """Non-owner, non-admin user cannot reclaim another's account."""
+    from app.services.prospect_reclamation import reclaim_prospect_account
+
+    owner = _make_user(db_session)
+    other = _make_user(db_session)
+    pa = _make_prospect(db_session, swept_from_owner_id=owner.id)
+    db_session.commit()
+
+    with pytest.raises(ValueError, match="permission denied"):
+        reclaim_prospect_account(pa.id, other.id, db_session, is_admin=False)
+
+
+def test_reclaim_manager_email_grants_access(db_session: Session, monkeypatch):
+    """Manager email in settings gets reclaim permission."""
+    from app.services.prospect_reclamation import reclaim_prospect_account
+
+    manager = _make_user(db_session, email="manager@trio.com")
+    owner = _make_user(db_session)
+    pa = _make_prospect(db_session, swept_from_owner_id=owner.id)
+    db_session.commit()
+
+    monkeypatch.setattr("app.config.settings.account_sweep_manager_email", "manager@trio.com")
+
+    with patch("app.services.activity_service.log_activity"):
+        result = reclaim_prospect_account(pa.id, manager.id, db_session, is_admin=False)
+
+    assert result["status"] == "reclaimed"
+
+
+# ── _send_sweep_notification ──────────────────────────────────────────────────
+
+
+async def test_sweep_notification_skips_without_token(db_session: Session):
+    """Notification is silently skipped when no valid token exists for the user."""
+    from app.services.prospect_reclamation import _send_sweep_notification
+
+    owner = _make_user(db_session)
+    co = _make_company(db_session)
+    db_session.commit()
+
+    with patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value=None):
+        await _send_sweep_notification(
+            owner=owner,
+            company=co,
+            last_activity_at=None,
+            prospect_id=1,
+            db=db_session,
+        )
+
+
+async def test_sweep_notification_sends_with_token(db_session: Session, monkeypatch):
+    """Notification sends via GraphClient when a valid token exists."""
+    from app.services.prospect_reclamation import _send_sweep_notification
+
+    owner = _make_user(db_session)
+    co = _make_company(db_session)
+    db_session.commit()
+
+    monkeypatch.setattr("app.config.settings.account_sweep_manager_email", "mgr@trio.com")
+
+    mock_gc = MagicMock()
+    mock_gc.post_json = AsyncMock()
+
+    with (
+        patch("app.utils.token_manager.get_valid_token", new_callable=AsyncMock, return_value="tok"),
+        patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+    ):
+        await _send_sweep_notification(
+            owner=owner,
+            company=co,
+            last_activity_at=datetime.now(timezone.utc) - timedelta(days=40),
+            prospect_id=1,
+            db=db_session,
+        )
+
+    mock_gc.post_json.assert_called_once()

--- a/tests/test_prospect_screening.py
+++ b/tests/test_prospect_screening.py
@@ -300,7 +300,8 @@ async def test_screen_prospect_grounding_check_bypasses_llm(db_session, monkeypa
 
 
 async def test_screen_prospect_llm_returns_insufficient_data_with_grounding(db_session, monkeypatch):
-    """When grounding is present but LLM says insufficient_data, scores are not written."""
+    """When grounding is present but LLM says insufficient_data, scores are not
+    written."""
     monkeypatch.setattr(settings, "ai_screen_enabled", True)
     monkeypatch.setattr(settings, "ai_screen_daily_cap", 999)
     monkeypatch.setattr(settings, "ai_screen_min_match", 40)

--- a/tests/test_prospect_screening.py
+++ b/tests/test_prospect_screening.py
@@ -278,6 +278,214 @@ async def test_screen_prospect_disabled_returns_skipped(db_session, monkeypatch)
     assert result["verdict"] == "disabled"
 
 
+async def test_screen_prospect_grounding_check_bypasses_llm(db_session, monkeypatch):
+    """Insufficient grounding with web_search disabled: early return without LLM call."""
+    monkeypatch.setattr(settings, "ai_screen_enabled", True)
+    monkeypatch.setattr(settings, "ai_screen_daily_cap", 999)
+    monkeypatch.setattr(settings, "ai_screen_web_search_enabled", False)
+
+    p = _prospect(db_session, industry=None, naics_code=None, description=None, enrichment_data={})
+
+    from app.services import prospect_screening as ps
+
+    mock_llm = AsyncMock()
+    with patch.object(ps, "_call_screen_llm", mock_llm):
+        with patch("app.cache.intel_cache.get_count", return_value=0):
+            result = await ps.screen_prospect(p, db_session)
+
+    mock_llm.assert_not_called()
+    assert result["verdict"] == "insufficient_data"
+    db_session.refresh(p)
+    assert p.enrichment_data["ai_screen"]["needs_more_enrichment"] is True
+
+
+async def test_screen_prospect_llm_returns_insufficient_data_with_grounding(db_session, monkeypatch):
+    """When grounding is present but LLM says insufficient_data, scores are not written."""
+    monkeypatch.setattr(settings, "ai_screen_enabled", True)
+    monkeypatch.setattr(settings, "ai_screen_daily_cap", 999)
+    monkeypatch.setattr(settings, "ai_screen_min_match", 40)
+
+    p = _prospect(db_session, industry="Software", enrichment_data={}, readiness_signals={})
+
+    verdict = {
+        "trio_match_score": 0,
+        "opportunity_score": 0,
+        "excess_likelihood": 0,
+        "verdict": "insufficient_data",
+        "rationale": "Industry is software — no electronics component need evident.",
+        "evidence": ["industry=Software"],
+        "confidence": 20,
+        "model": "claude-sonnet-4-6",
+        "screened_at": "2026-06-22T00:00:00+00:00",
+    }
+
+    from app.services import prospect_screening as ps
+
+    with patch.object(ps, "_call_screen_llm", new_callable=AsyncMock, return_value=verdict):
+        with patch("app.cache.intel_cache.get_count", return_value=0):
+            with patch("app.cache.intel_cache.incr_count", return_value=1):
+                result = await ps.screen_prospect(p, db_session)
+
+    assert result["verdict"] == "insufficient_data"
+    db_session.refresh(p)
+    assert (p.trio_match_score or 0) == 0
+    assert p.enrichment_data["ai_screen"]["needs_more_enrichment"] is True
+
+
+async def test_screen_prospect_empty_llm_response(db_session, monkeypatch):
+    """Empty LLM response returns error verdict gracefully."""
+    monkeypatch.setattr(settings, "ai_screen_enabled", True)
+    monkeypatch.setattr(settings, "ai_screen_daily_cap", 999)
+
+    p = _prospect(db_session, industry="Aerospace", enrichment_data={})
+
+    from app.services import prospect_screening as ps
+
+    with patch.object(ps, "_call_screen_llm", new_callable=AsyncMock, return_value={}):
+        with patch("app.cache.intel_cache.get_count", return_value=0):
+            result = await ps.screen_prospect(p, db_session)
+
+    assert result["verdict"] == "error"
+
+
+# ── _grounding_is_sufficient direct tests ────────────────────────────────────
+
+
+def test_grounding_sufficient_with_industry(db_session):
+    from app.services.prospect_screening import _grounding_is_sufficient
+
+    p = _prospect(db_session, industry="Aerospace")
+    assert _grounding_is_sufficient(p) is True
+
+
+def test_grounding_sufficient_with_naics(db_session):
+    from app.services.prospect_screening import _grounding_is_sufficient
+
+    p = _prospect(db_session, naics_code="336412")
+    assert _grounding_is_sufficient(p) is True
+
+
+def test_grounding_sufficient_with_description(db_session):
+    from app.services.prospect_screening import _grounding_is_sufficient
+
+    p = _prospect(db_session, description="Aerospace OEM.")
+    assert _grounding_is_sufficient(p) is True
+
+
+def test_grounding_sufficient_with_sam_gov(db_session):
+    from app.services.prospect_screening import _grounding_is_sufficient
+
+    p = _prospect(db_session, enrichment_data={"sam_gov": {"purpose": "defense"}})
+    assert _grounding_is_sufficient(p) is True
+
+
+def test_grounding_insufficient_no_data(db_session):
+    from app.services.prospect_screening import _grounding_is_sufficient
+
+    p = _prospect(db_session, industry=None, naics_code=None, description=None, enrichment_data={})
+    assert _grounding_is_sufficient(p) is False
+
+
+# ── _assemble_context branches ────────────────────────────────────────────────
+
+
+def test_assemble_context_includes_decision_maker(db_session):
+    from app.services.prospect_screening import _assemble_context
+
+    p = _prospect(
+        db_session,
+        industry="Aerospace",
+        contacts_preview=[
+            {
+                "name": "Jane VP",
+                "title": "VP Procurement",
+                "email": "j@co.com",
+                "verified": True,
+                "seniority": "decision_maker",
+            }
+        ],
+    )
+    ctx = _assemble_context(p)
+    assert "decision-maker" in ctx
+    assert "Jane VP" in ctx
+
+
+def test_assemble_context_verified_contacts_no_dm(db_session):
+    from app.services.prospect_screening import _assemble_context
+
+    p = _prospect(
+        db_session,
+        contacts_preview=[
+            {"name": "Bob Buyer", "title": "Buyer", "email": "b@co.com", "verified": True, "seniority": "staff"}
+        ],
+    )
+    ctx = _assemble_context(p)
+    assert "verified contact" in ctx
+
+
+def test_assemble_context_sam_gov_data(db_session):
+    from app.services.prospect_screening import _assemble_context
+
+    p = _prospect(
+        db_session,
+        enrichment_data={
+            "sam_gov": {
+                "purpose": "Defense contractor",
+                "naics_codes": [{"code": "336412", "description": "Aircraft Engine Parts", "primary": True}],
+            }
+        },
+    )
+    ctx = _assemble_context(p)
+    assert "SAM.gov" in ctx
+    assert "336412" in ctx
+
+
+def test_assemble_context_news_signals(db_session):
+    from app.services.prospect_screening import _assemble_context
+
+    p = _prospect(
+        db_session,
+        enrichment_data={"recent_news": [{"title": "Company wins DoD contract"}, {"title": "Q2 expansion"}]},
+    )
+    ctx = _assemble_context(p)
+    assert "Recent news" in ctx
+    assert "DoD" in ctx
+
+
+def test_assemble_context_hiring_signal(db_session):
+    from app.services.prospect_screening import _assemble_context
+
+    p = _prospect(
+        db_session,
+        readiness_signals={"hiring": {"type": "expanding", "count": 5}},
+    )
+    ctx = _assemble_context(p)
+    assert "Hiring signal" in ctx
+
+
+def test_assemble_context_trio_history(db_session):
+    from app.services.prospect_screening import _assemble_context
+
+    p = _prospect(
+        db_session,
+        historical_context={"quote_count": 3, "bought_before": True, "last_activity": "2025-01-15"},
+    )
+    ctx = _assemble_context(p)
+    assert "3 quotes" in ctx
+    assert "prior customer" in ctx
+
+
+def test_assemble_context_events(db_session):
+    from app.services.prospect_screening import _assemble_context
+
+    p = _prospect(
+        db_session,
+        readiness_signals={"events": [{"type": "acquisition"}, {"type": "funding"}]},
+    )
+    ctx = _assemble_context(p)
+    assert "Recent events" in ctx
+
+
 async def test_screen_prospect_llm_error_is_fire_and_forget(db_session, monkeypatch):
     """LLM failure must not propagate — returns error verdict, prospect unchanged."""
     monkeypatch.setattr(settings, "ai_screen_enabled", True)


### PR DESCRIPTION
## Summary

Nightly coverage routine — bring previously under-85% modules up to target.

- **New** `tests/test_backfill_management.py` — covers `backfill_buyplan_cph` + `backfill_quote_source` (completed plans, already-recorded skip, non-completed skip, empty DB, quote source proactive/skip/mixed)
- **New** `tests/test_prospect_reclamation.py` — covers sweep (dormant/already-swept/active/missing-owner/never-active), auto-surface (past customer, already-in-pool, no-domain, domain collision), reclaim (former owner, admin, manager email, wrong status, permission denied), sweep notification (no-token, sends-with-token)
- **Expanded** `tests/test_clay_service.py` — verify/confidence/callback/contacts edge cases
- **Expanded** `tests/test_company_utils.py` — `suggest_clean_company_name`, `_pair_dict`, PostgreSQL dedup path (mocked dialect)
- **Expanded** `tests/test_datasheet_library.py` — token-missing, exception, non-200 fetch paths
- **Expanded** `tests/test_hunter_connector.py` — `verify()` happy path + error paths, `email_finder()` auth/rate-limit/network/empty-email errors
- **Expanded** `tests/test_prospect_screening.py` — `_grounding_is_sufficient` direct tests, `_assemble_context` branch coverage
- **`# pragma: no cover`** on `__main__` blocks in both backfill management scripts

## Coverage results (modules targeted)

| Module | Before | After |
|--------|--------|-------|
| `app/connectors/hunter.py` | 71% | **100%** |
| `app/services/datasheet_library.py` | 83% | **100%** |
| `app/management/backfill_buyplan_cph.py` | 78% | **100%** |
| `app/management/backfill_quote_source.py` | 78% | **100%** |
| `app/company_utils.py` | 72% | **99%** |
| `app/services/clay_service.py` | 84% | **97%** |
| `app/services/prospect_screening.py` | 80% | **93%** |
| `app/services/prospect_reclamation.py` | 77% | **87%** |

**Overall suite: 96% — 18,310 passed, 0 failed**

## Test plan
- [x] All 150 tests in modified files pass locally
- [x] Full suite: 18,310 passed, 0 failed
- [x] `ruff check` passes on all modified files
- [x] No new mocks of SQLAlchemy model columns introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt5jm9njwFmH4yFHZ8pTqE)_