### PR TITLE
Enforce requisition-ownership authorization (pre-multi-user IDOR hardening)

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -186,6 +186,13 @@ class UserRole(StrEnum):
     AGENT = "agent"
 
 
+# Roles scoped to requisitions they own (created_by). Single source of truth for the
+# role-scoped access model: sales/trader act only on their own requisitions; buyer/
+# manager/admin are unrestricted. Read by dependencies.require_requisition_access,
+# get_req_for_user, get_quote_for_user, and the bulk/batch handlers.
+RESTRICTED_ROLES = frozenset({UserRole.SALES, UserRole.TRADER})
+
+
 class ProactiveOfferStatus(StrEnum):
     """Status lifecycle for ProactiveOffer records."""
 

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -23,7 +23,7 @@ from fastapi import Depends, HTTPException, Request
 from loguru import logger
 from sqlalchemy.orm import Session, selectinload
 
-from .constants import UserRole
+from .constants import RESTRICTED_ROLES, UserRole
 from .database import get_db
 from .models import Quote, Requisition, User
 
@@ -114,6 +114,32 @@ def require_settings_access(request: Request, db: Session = Depends(get_db)) -> 
 BUYER_ROLES = frozenset({UserRole.BUYER, UserRole.SALES, UserRole.TRADER, UserRole.MANAGER, UserRole.ADMIN})
 
 
+def require_requisition_access(
+    db: Session,
+    req_id: int | None,
+    user: User,
+    *,
+    owner_id: int | None = None,
+    label: str = "Requisition",
+) -> None:
+    """Enforce role-scoped ownership for an action on a requisition-scoped resource.
+
+    No-op for unrestricted roles (buyer/manager/admin). For SALES/TRADER, allows the
+    action only when the user owns the requisition (created_by) or, for unscoped/scratch
+    resources where ``req_id`` is None, when ``owner_id`` matches the user. Raises
+    HTTPException(404) otherwise (404 not 403 so existence isn't leaked).
+    """
+    if getattr(user, "role", None) not in RESTRICTED_ROLES:
+        return
+    if req_id is not None:
+        req = db.get(Requisition, req_id)
+        if req is not None and req.created_by == user.id:
+            return
+    if owner_id is not None and owner_id == user.id:
+        return
+    raise HTTPException(status_code=404, detail=f"{label} not found")
+
+
 def has_buyer_role(user: User | None) -> bool:
     """True when *user* holds a buyer-tier role (require_buyer's allowed set)."""
     return user is not None and user.role in BUYER_ROLES
@@ -144,7 +170,7 @@ def get_req_for_user(db: Session, user: User, req_id: int, options=None) -> Requ
     """
     load_opts = options or [selectinload(Requisition.requirements)]
     q = db.query(Requisition).options(*load_opts).filter_by(id=req_id)
-    if user.role == UserRole.SALES:
+    if user.role in RESTRICTED_ROLES:
         q = q.filter_by(created_by=user.id)
     req = q.first()
     if not req:
@@ -161,7 +187,7 @@ def get_quote_for_user(db: Session, user: User, quote_id: int, options=None) -> 
         .join(Requisition, Quote.requisition_id == Requisition.id)
         .filter(Quote.id == quote_id)
     )
-    if user.role == UserRole.SALES:
+    if user.role in RESTRICTED_ROLES:
         q = q.filter(Requisition.created_by == user.id)
     quote = q.first()
     if not quote:

--- a/app/routers/ai.py
+++ b/app/routers/ai.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session
 
 from ..config import settings
 from ..database import get_db
-from ..dependencies import get_req_for_user, require_user
+from ..dependencies import get_req_for_user, require_requisition_access, require_user
 from ..models import (
     Contact,
     CustomerSite,
@@ -459,6 +459,7 @@ async def ai_generate_description_for_requirement(
     req = db.get(Requirement, requirement_id)
     if not req:
         raise HTTPException(404, "Requirement not found")
+    require_requisition_access(db, req.requisition_id, user)
 
     result = await generate_verified_description(
         req.primary_mpn,
@@ -501,8 +502,7 @@ async def ai_parse_response(
     vr = db.query(VendorResponse).filter(VendorResponse.id == response_id).first()
     if not vr:
         raise HTTPException(404, "Vendor response not found")
-    if vr.requisition_id and not get_req_for_user(db, user, vr.requisition_id, options=[]):
-        raise HTTPException(404, "Vendor response not found")
+    require_requisition_access(db, vr.requisition_id, user, label="Vendor response")
 
     rfq_context = None
     if vr.requisition_id:

--- a/app/routers/crm/clone.py
+++ b/app/routers/crm/clone.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from ...constants import ActivityType, RequisitionStatus
@@ -23,9 +23,9 @@ router = APIRouter()
 async def clone_requisition(req_id: int, user: User = Depends(require_user), db: Session = Depends(get_db)):
     from ...dependencies import get_req_for_user
 
+    # get_req_for_user enforces role-scoped ownership (SALES/TRADER restricted to
+    # requisitions they created) and raises 404 for non-owners.
     req = get_req_for_user(db, user, req_id)
-    if not req:
-        raise HTTPException(404, "Requisition not found")
     new_req = Requisition(
         name=f"{req.name} (clone)",
         customer_name=req.customer_name,

--- a/app/routers/crm/offers.py
+++ b/app/routers/crm/offers.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session, joinedload, selectinload
 from ...constants import ActivityType, OfferStatus, RequisitionStatus, UserRole
 from ...database import get_db
 from ...dependencies import is_admin as _is_admin
-from ...dependencies import require_buyer, require_user
+from ...dependencies import require_buyer, require_requisition_access, require_user
 from ...models import (
     ActivityLog,
     ChangeLog,
@@ -590,6 +590,7 @@ async def update_offer(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     changes = payload.model_dump(exclude_unset=True)
     # Snapshot old values for changelog
     trackable = [
@@ -633,6 +634,7 @@ async def delete_offer(offer_id: int, user: User = Depends(require_buyer), db: S
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     db.delete(offer)
     db.commit()
     return {"ok": True}
@@ -648,6 +650,7 @@ async def reconfirm_offer(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     offer.reconfirmed_at = datetime.now(timezone.utc)
     offer.reconfirm_count = (offer.reconfirm_count or 0) + 1
     db.commit()
@@ -668,6 +671,7 @@ async def approve_offer(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     if offer.status != "pending_review":
         raise HTTPException(400, "Only pending_review offers can be approved")
     old_status = offer.status
@@ -697,6 +701,7 @@ async def reject_offer(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     if offer.status != "pending_review":
         raise HTTPException(400, "Only pending_review offers can be rejected")
     old_status = offer.status
@@ -784,6 +789,7 @@ async def upload_offer_attachment(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     content = await file.read()
     if len(content) > 10 * 1024 * 1024:
         raise HTTPException(400, "File too large (max 10 MB)")
@@ -847,6 +853,7 @@ async def attach_from_onedrive(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     item_id = body.item_id
     from ...utils.graph_client import GraphClient
 
@@ -884,6 +891,14 @@ async def delete_offer_attachment(
     att = db.get(OfferAttachment, att_id)
     if not att:
         raise HTTPException(404, "Attachment not found")
+    parent_offer = db.get(Offer, att.offer_id)
+    require_requisition_access(
+        db,
+        parent_offer.requisition_id if parent_offer else None,
+        user,
+        owner_id=parent_offer.entered_by_id if parent_offer else None,
+        label="Attachment",
+    )
     # Delete from OneDrive if we have the item ID
     if att.onedrive_item_id and user.access_token:
         try:
@@ -991,6 +1006,7 @@ async def promote_offer(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     if offer.evidence_tier != "T4":
         raise HTTPException(400, "Only T4 offers can be promoted")
 
@@ -1024,6 +1040,7 @@ async def reject_offer_t4_review(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     if offer.status != "pending_review":
         raise HTTPException(400, "Only pending_review offers can be rejected")
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -44,10 +44,12 @@ from ..constants import (
 from ..database import get_db
 from ..dependencies import (
     get_quote_for_user,
+    get_req_for_user,
     get_user,
     has_buyer_role,
     require_admin,
     require_buyer,
+    require_requisition_access,
     require_user,
 )
 from ..models import (
@@ -1182,6 +1184,7 @@ async def add_requirement(
         raise HTTPException(422, "Manufacturer is required")
 
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
 
     form_data = await request.form()
     sub_mpns = form_data.getlist("sub_mpn")
@@ -1238,6 +1241,7 @@ async def requisition_search_all(
     """Trigger search for all requirements in a requisition, then refresh parts
     table."""
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
     requirements = db.query(Requirement).filter(Requirement.requisition_id == req_id).all()
     if not requirements:
         return HTMLResponse(
@@ -1481,6 +1485,7 @@ async def parse_email_action(
 ):
     """Parse vendor email and return editable offer cards."""
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
 
     if not email_body.strip():
         return HTMLResponse(
@@ -1530,6 +1535,7 @@ async def parse_offer_action(
 ):
     """Parse freeform vendor text and return editable offer cards."""
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
 
     if not raw_text.strip():
         return HTMLResponse(
@@ -1571,6 +1577,7 @@ async def save_parsed_offers(
 ):
     """Save user-edited parsed offers to the requisition."""
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
 
     form = await request.form()
     vendor_name = form.get("vendor_name", "")
@@ -1726,6 +1733,8 @@ async def requisitions_bulk_action(
         raise HTTPException(400, f"Invalid action: {action}")
 
     reqs = db.query(Requisition).filter(Requisition.id.in_(ids)).all()
+    for r in reqs:
+        require_requisition_access(db, r.id, user)
 
     if action == "archive":
         for r in reqs:
@@ -1777,7 +1786,6 @@ async def requisition_inline_edit_cell(
         field: One of name, status, urgency, deadline, owner.
         context: 'row' for list view, 'header' for detail header.
     """
-    from ..dependencies import get_req_for_user
 
     valid_fields = {"name", "status", "urgency", "deadline", "owner"}
     if field not in valid_fields:
@@ -1807,7 +1815,6 @@ async def requisition_inline_save(
     For context='row', returns the full table row. For context='header', returns the
     updated header card.
     """
-    from ..dependencies import get_req_for_user
 
     req = get_req_for_user(db, user, req_id, options=[])
     if not req:
@@ -1906,7 +1913,6 @@ async def requisition_row_action(
 ):
     """Execute a row-level action (archive, activate, claim, unclaim, won, lost,
     clone)."""
-    from ..dependencies import get_req_for_user
 
     valid_actions = {"archive", "activate", "claim", "unclaim", "won", "lost", "clone"}
     if action_name not in valid_actions:
@@ -1997,6 +2003,7 @@ async def create_quote_from_offers(
         raise HTTPException(400, "No offers selected")
 
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
 
     offers = db.query(Offer).filter(Offer.id.in_(offer_ids), Offer.requisition_id == req_id).all()
     if not offers:
@@ -2072,6 +2079,7 @@ async def review_offer(
     if action not in ("approve", "reject"):
         raise HTTPException(400, "Invalid action")
 
+    require_requisition_access(db, req_id, user)
     offer = db.query(Offer).filter(Offer.id == offer_id, Offer.requisition_id == req_id).first()
     if not offer:
         raise HTTPException(404, "Offer not found")
@@ -2137,6 +2145,7 @@ async def add_offer(
 ):
     """Create a manual offer and return refreshed offers tab."""
     get_requisition_or_404(db, req_id)  # validates existence
+    require_requisition_access(db, req_id, user)
 
     form = await request.form()
     vendor_name = (form.get("vendor_name") or "").strip()
@@ -2231,6 +2240,7 @@ async def reconfirm_offer(
     db: Session = Depends(get_db),
 ):
     """Reconfirm an offer — resets TTL and increments reconfirm count."""
+    require_requisition_access(db, req_id, user)
     offer = db.query(Offer).filter(Offer.id == offer_id, Offer.requisition_id == req_id).first()
     if not offer:
         raise HTTPException(404, "Offer not found")
@@ -2282,6 +2292,7 @@ async def edit_offer(
     """Save edits to an offer and return refreshed offers tab."""
     from ..models.intelligence import ChangeLog
 
+    require_requisition_access(db, req_id, user)
     offer = db.query(Offer).filter(Offer.id == offer_id, Offer.requisition_id == req_id).first()
     if not offer:
         raise HTTPException(404, "Offer not found")
@@ -2389,6 +2400,7 @@ async def delete_offer_htmx(
     db: Session = Depends(get_db),
 ):
     """Delete an offer and return refreshed offers tab."""
+    require_requisition_access(db, req_id, user)
     offer = db.query(Offer).filter(Offer.id == offer_id, Offer.requisition_id == req_id).first()
     if not offer:
         raise HTTPException(404, "Offer not found")
@@ -2410,6 +2422,7 @@ async def mark_offer_sold_htmx(
     """Mark an offer as sold and return refreshed offers tab."""
     from ..models.intelligence import ChangeLog
 
+    require_requisition_access(db, req_id, user)
     offer = db.query(Offer).filter(Offer.id == offer_id, Offer.requisition_id == req_id).first()
     if not offer:
         raise HTTPException(404, "Offer not found")
@@ -2483,6 +2496,7 @@ async def promote_offer_htmx(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     if offer.status != "pending_review":
         raise HTTPException(400, "Only pending_review offers can be promoted")
 
@@ -2529,6 +2543,7 @@ async def reject_offer_htmx(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     if offer.status != "pending_review":
         raise HTTPException(400, "Only pending_review offers can be rejected")
 
@@ -2596,6 +2611,7 @@ async def log_activity(
     from ..models.intelligence import ActivityLog
 
     get_requisition_or_404(db, req_id)  # validates existence
+    require_requisition_access(db, req_id, user)
 
     form = await request.form()
     activity_type = form.get("activity_type", "note")
@@ -2696,6 +2712,7 @@ async def ai_cleanup_email(
 ):
     """Clean up user-written email — fix grammar, tone, and formatting."""
     get_requisition_or_404(db, req_id)  # validates existence
+    require_requisition_access(db, req_id, user)
 
     user_text = body.strip()
     if not user_text:
@@ -2743,6 +2760,7 @@ async def rfq_send(
     from ..models.offers import Contact as RfqContact
 
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
 
     form = await request.form()
     vendor_names = form.getlist("vendor_names")
@@ -2932,6 +2950,7 @@ async def send_follow_up_htmx(
     contact = db.get(RfqContact, contact_id)
     if not contact:
         raise HTTPException(404, "Contact not found")
+    require_requisition_access(db, contact.requisition_id, user, owner_id=contact.user_id, label="Contact")
 
     form = await request.form()
     body = (form.get("body") or "").strip()
@@ -3004,6 +3023,7 @@ async def review_response_htmx(
     """
     from ..models.offers import VendorResponse
 
+    require_requisition_access(db, req_id, user)
     vr = (
         db.query(VendorResponse)
         .filter(
@@ -3041,6 +3061,7 @@ async def poll_inbox_htmx(
     """Trigger a FULL inbox scan for the current user (not requisition-scoped), then
     return the refreshed responses tab."""
     get_requisition_or_404(db, req_id)  # validates existence
+    require_requisition_access(db, req_id, user)
     logger.info("Inbox poll requested for req {} by {}", req_id, user.email)
     await _run_inbox_scan_now(user, db)
     return await requisition_tab(request=request, req_id=req_id, tab="responses", user=user, db=db)
@@ -3059,6 +3080,7 @@ async def delete_requirement(
     Returns empty response for hx-swap='delete'.
     """
     get_requisition_or_404(db, req_id)  # validates existence
+    require_requisition_access(db, req_id, user)
     item = db.query(Requirement).filter(Requirement.id == item_id, Requirement.requisition_id == req_id).first()
     if not item:
         raise HTTPException(404, "Requirement not found")
@@ -3101,6 +3123,7 @@ async def update_requirement(
         raise HTTPException(422, "Manufacturer is required")
 
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
     item = db.query(Requirement).filter(Requirement.id == item_id, Requirement.requisition_id == req_id).first()
     if not item:
         raise HTTPException(404, "Requirement not found")
@@ -3590,6 +3613,7 @@ async def add_to_requisition(
             '<div class="text-red-600 text-sm p-2">Requisition not found.</div>',
             status_code=404,
         )
+    require_requisition_access(db, int(requisition_id), user)
 
     # Find or create Requirement for this MPN
     requirement = (
@@ -7041,6 +7065,7 @@ async def log_phone_call(
 ):
     """Log a phone call to a vendor and return updated activity tab."""
     get_requisition_or_404(db, req_id)  # validates existence
+    require_requisition_access(db, req_id, user)
 
     form = await request.form()
     vendor_name = form.get("vendor_name", "").strip()
@@ -7167,6 +7192,7 @@ async def update_response_status(
     """Update vendor response status (reviewed/rejected/flagged)."""
     from ..models.offers import VendorResponse
 
+    require_requisition_access(db, req_id, user)
     vr = (
         db.query(VendorResponse)
         .filter(
@@ -8291,7 +8317,13 @@ async def lead_status_update(
     Returns updated lead card when called from results view (for OOB swap), or updated
     lead detail when called from lead detail page.
     """
+    from ..models.sourcing_lead import SourcingLead
     from ..services.sourcing_leads import update_lead_status
+
+    _lead = db.get(SourcingLead, lead_id)
+    if not _lead:
+        raise HTTPException(404, "Lead not found")
+    require_requisition_access(db, _lead.requisition_id, user, label="Lead")
 
     form = await request.form()
     status_val = form.get("status", "").strip()
@@ -8376,7 +8408,13 @@ async def lead_feedback(
 
     Returns updated lead detail.
     """
+    from ..models.sourcing_lead import SourcingLead
     from ..services.sourcing_leads import append_lead_feedback
+
+    _lead = db.get(SourcingLead, lead_id)
+    if not _lead:
+        raise HTTPException(404, "Lead not found")
+    require_requisition_access(db, _lead.requisition_id, user, label="Lead")
 
     form = await request.form()
     note = form.get("note", "").strip() or None
@@ -12123,6 +12161,7 @@ async def part_header_save(
     req = db.get(Requirement, requirement_id)
     if not req:
         raise HTTPException(404, "Part not found")
+    require_requisition_access(db, req.requisition_id, user, label="Part")
 
     if field == "sourcing_status":
         from app.services.requirement_status import transition_requirement
@@ -12248,6 +12287,7 @@ async def part_cell_save(
     req = db.get(Requirement, requirement_id)
     if not req:
         raise HTTPException(404, "Part not found")
+    require_requisition_access(db, req.requisition_id, user, label="Part")
 
     if field == "sourcing_status":
         from app.services.requirement_status import transition_requirement
@@ -12330,6 +12370,7 @@ async def part_spec_save(
     req = db.get(Requirement, requirement_id)
     if not req:
         raise HTTPException(404, "Part not found")
+    require_requisition_access(db, req.requisition_id, user, label="Part")
 
     if req.sourcing_status == SourcingStatus.ARCHIVED:
         return HTMLResponse("Cannot edit archived part", status_code=403)
@@ -12441,6 +12482,7 @@ async def save_part_notes(
     req = db.get(Requirement, requirement_id)
     if not req:
         raise HTTPException(404, "Part not found")
+    require_requisition_access(db, req.requisition_id, user, label="Part")
     old_sale_notes = req.sale_notes
     req.sale_notes = sale_notes.strip() or None
     if (req.sale_notes or "") != (old_sale_notes or ""):
@@ -12470,6 +12512,7 @@ async def create_part_task(
     req = db.get(Requirement, requirement_id)
     if not req:
         raise HTTPException(404, "Part not found")
+    require_requisition_access(db, req.requisition_id, user, label="Part")
 
     form = await request.form()
     title = (form.get("title") or "").strip()
@@ -12566,6 +12609,7 @@ async def archive_single_part(
     part = db.get(Requirement, requirement_id)
     if not part:
         raise HTTPException(404, "Part not found")
+    require_requisition_access(db, part.requisition_id, user, label="Part")
 
     part.sourcing_status = SourcingStatus.ARCHIVED
     db.commit()
@@ -12587,6 +12631,7 @@ async def unarchive_single_part(
     part = db.get(Requirement, requirement_id)
     if not part:
         raise HTTPException(404, "Part not found")
+    require_requisition_access(db, part.requisition_id, user, label="Part")
 
     part.sourcing_status = SourcingStatus.OPEN
     db.commit()
@@ -12606,6 +12651,7 @@ async def archive_requisition(
     requisition = db.get(Requisition, req_id)
     if not requisition:
         raise HTTPException(404, "Requisition not found")
+    require_requisition_access(db, req_id, user)
 
     prior_status = requisition.status
     requisition.status = RequisitionStatus.ARCHIVED
@@ -12636,6 +12682,7 @@ async def unarchive_requisition(
     requisition = db.get(Requisition, req_id)
     if not requisition:
         raise HTTPException(404, "Requisition not found")
+    require_requisition_access(db, req_id, user)
 
     prior_status = requisition.status
     requisition.status = RequisitionStatus.ACTIVE
@@ -12669,6 +12716,13 @@ async def bulk_archive(
     body = await request.json()
     requirement_ids = body.get("requirement_ids", [])
     requisition_ids = body.get("requisition_ids", [])
+
+    # Ownership guard (no-op for buyer/manager/admin; 404 for a restricted non-owner)
+    for _rid in requisition_ids:
+        require_requisition_access(db, _rid, user)
+    if requirement_ids:
+        for _r in db.query(Requirement).filter(Requirement.id.in_(requirement_ids)).all():
+            require_requisition_access(db, _r.requisition_id, user, label="Requirement")
 
     # Bulk-update parts in a single query instead of N+1
     if requirement_ids:
@@ -12712,6 +12766,13 @@ async def bulk_unarchive(
     body = await request.json()
     requirement_ids = body.get("requirement_ids", [])
     requisition_ids = body.get("requisition_ids", [])
+
+    # Ownership guard (no-op for buyer/manager/admin; 404 for a restricted non-owner)
+    for _rid in requisition_ids:
+        require_requisition_access(db, _rid, user)
+    if requirement_ids:
+        for _r in db.query(Requirement).filter(Requirement.id.in_(requirement_ids)).all():
+            require_requisition_access(db, _r.requisition_id, user, label="Requirement")
 
     # Bulk-update parts in a single query instead of N+1
     if requirement_ids:

--- a/app/routers/quote_builder.py
+++ b/app/routers/quote_builder.py
@@ -181,8 +181,12 @@ async def quote_builder_save(
     db: Session = Depends(get_db),
 ):
     """Save the quote from the builder modal."""
-    from ..dependencies import get_req_for_user
+    from ..dependencies import get_req_for_user, require_requisition_access
     from ..services.quote_builder_service import save_quote_from_builder
+
+    # Ownership guard: SALES/TRADER may only save quotes for requisitions they own
+    # (no-op for buyer/manager/admin). 404 to avoid leaking existence.
+    require_requisition_access(db, req_id, user)
 
     req = get_req_for_user(db, user, req_id)
     if not req:

--- a/app/routers/requisitions/attachments.py
+++ b/app/routers/requisitions/attachments.py
@@ -190,6 +190,9 @@ async def delete_requisition_attachment(
     att = db.get(RequisitionAttachment, att_id)
     if not att:
         raise HTTPException(404, "Attachment not found")
+    # Ownership guard: SALES/TRADER may only act on requisitions they created
+    # (404s for non-owners before any OneDrive delete or db.delete).
+    get_req_for_user(db, user, att.requisition_id)
     if att.onedrive_item_id:
         from ...scheduler import get_valid_token
 
@@ -295,6 +298,12 @@ async def delete_requirement_attachment(
     att = db.get(RequirementAttachment, att_id)
     if not att:
         raise HTTPException(404, "Attachment not found")
+    # Ownership guard: follow the FK chain (attachment -> requirement -> requisition)
+    # and enforce that SALES/TRADER own the parent requisition (404 otherwise).
+    parent_requirement = db.get(Requirement, att.requirement_id)
+    if not parent_requirement:
+        raise HTTPException(404, "Attachment not found")
+    get_req_for_user(db, user, parent_requirement.requisition_id)
     if att.onedrive_item_id:
         from ...scheduler import get_valid_token
 

--- a/app/routers/requisitions/requirements.py
+++ b/app/routers/requisitions/requirements.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from ...constants import ActivityType, OfferStatus, RequisitionStatus, TaskStatus
 from ...database import get_db
-from ...dependencies import get_req_for_user, require_buyer, require_user
+from ...dependencies import get_req_for_user, require_buyer, require_requisition_access, require_user
 from ...models import (
     ChangeLog,
     Contact,
@@ -1335,6 +1335,7 @@ async def add_requirement_note(
     req = db.query(Requirement).filter(Requirement.id == requirement_id).first()
     if not req:
         raise HTTPException(404, "Requirement not found")
+    require_requisition_access(db, req.requisition_id, user, label="Requirement")
     # Append to existing notes with timestamp
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
     entry = f"[{timestamp} {user.email}] {body.text}"
@@ -1420,6 +1421,7 @@ async def create_requirement_task(
     req = db.query(Requirement).filter(Requirement.id == requirement_id).first()
     if not req:
         raise HTTPException(404, "Requirement not found")
+    require_requisition_access(db, req.requisition_id, user, label="Requirement")
 
     task = RequisitionTask(
         requisition_id=req.requisition_id,

--- a/app/routers/requisitions2.py
+++ b/app/routers/requisitions2.py
@@ -22,7 +22,7 @@ from loguru import logger
 from sqlalchemy.orm import Session, joinedload
 
 from ..config import settings
-from ..constants import UserRole
+from ..constants import RESTRICTED_ROLES
 from ..database import get_db
 from ..dependencies import get_req_for_user, require_user
 from ..models import Offer, Requisition, User
@@ -471,7 +471,7 @@ async def bulk_action(
         return template_response("requisitions2/_table.html", ctx)
 
     reqs_q = db.query(Requisition).filter(Requisition.id.in_(id_list))
-    if user.role == UserRole.SALES:
+    if user.role in RESTRICTED_ROLES:
         reqs_q = reqs_q.filter(Requisition.created_by == user.id)
     reqs = reqs_q.all()
     count = 0

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -41,7 +41,12 @@ from ..constants import (
     UnavailabilityReason,
 )
 from ..database import get_db
-from ..dependencies import require_buyer, require_fresh_token, require_user
+from ..dependencies import (
+    require_buyer,
+    require_fresh_token,
+    require_requisition_access,
+    require_user,
+)
 from ..models import User
 from ..models.intelligence import ActivityLog, MaterialCard, MaterialCardDatasheet
 from ..models.offers import Offer
@@ -758,6 +763,7 @@ async def sightings_refresh(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(status_code=404, detail="Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
 
     is_sse = source == "sse"
     refresh_failed = False
@@ -832,6 +838,8 @@ async def sightings_batch_refresh(
     reqs_by_id = {}
     if requirement_ids:
         reqs = db.query(Requirement).filter(Requirement.id.in_([int(rid) for rid in requirement_ids])).all()
+        for r in reqs:
+            require_requisition_access(db, r.requisition_id, user, label="Requirement")
         reqs_by_id = {r.id: r for r in reqs}
 
     success = 0
@@ -902,6 +910,8 @@ async def sightings_batch_assign(
 
     int_ids = [int(rid) for rid in requirement_ids]
     reqs = db.query(Requirement).filter(Requirement.id.in_(int_ids)).all()
+    for r in reqs:
+        require_requisition_access(db, r.requisition_id, user, label="Requirement")
 
     buyer_name = "nobody"
     if buyer_id:
@@ -945,6 +955,8 @@ async def sightings_batch_status(
 
     int_ids = [int(rid) for rid in requirement_ids]
     reqs = db.query(Requirement).filter(Requirement.id.in_(int_ids)).all()
+    for r in reqs:
+        require_requisition_access(db, r.requisition_id, user, label="Requirement")
 
     updated = 0
     skipped = 0
@@ -1000,6 +1012,8 @@ async def sightings_batch_notes(
 
     int_ids = [int(rid) for rid in requirement_ids]
     reqs = db.query(Requirement).filter(Requirement.id.in_(int_ids)).all()
+    for r in reqs:
+        require_requisition_access(db, r.requisition_id, user, label="Requirement")
 
     for r in reqs:
         activity = ActivityLog(
@@ -1101,6 +1115,7 @@ async def sightings_mark_unavailable(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(status_code=404, detail="Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
 
     try:
         record_unavailability(db, requirement, vendor_name, reason, note, user)
@@ -1136,6 +1151,7 @@ async def sightings_mark_available(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(status_code=404, detail="Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
 
     try:
         clear_unavailability(db, requirement, vendor_name, user)
@@ -1168,6 +1184,7 @@ async def sightings_assign_buyer(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(status_code=404, detail="Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
 
     requirement.assigned_buyer_id = buyer_id
     db.commit()
@@ -1194,6 +1211,7 @@ async def sightings_advance_status(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(status_code=404, detail="Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
 
     current = requirement.sourcing_status or SourcingStatus.OPEN
 
@@ -1243,6 +1261,7 @@ async def sightings_log_activity(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(status_code=404, detail="Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
 
     activity_type_map = {
         "note": "note",
@@ -2112,6 +2131,8 @@ async def sightings_preview_inquiry(
         raise HTTPException(status_code=400, detail="requirement_ids and vendor_names required")
 
     requirements = db.query(Requirement).filter(Requirement.id.in_(requirement_ids)).all()
+    for r in requirements:
+        require_requisition_access(db, r.requisition_id, user, label="Requirement")
 
     # Request-time re-validation against ACTIVE unavailability records (the modal
     # filter alone leaves a TOCTOU hole): excluded vendors are dropped from the
@@ -2241,6 +2262,12 @@ async def sightings_send_inquiry(
         # Without this guard the send would proceed with NO requisition at all —
         # emails out, zero Contact tracking — instead of telling the user.
         raise HTTPException(status_code=400, detail="selected requirements no longer exist — refresh and retry")
+
+    # IDOR guard: a restricted (SALES/TRADER) user may only send RFQs for parts on
+    # requisitions they own. Enforce per distinct requisition_id in the basket — any
+    # non-owned requisition 404s the whole send rather than emailing on its behalf.
+    for _req_id in {r.requisition_id for r in requirements}:
+        require_requisition_access(db, _req_id, user)
 
     # Send-time re-validation (closes the TOCTOU the modal filter alone leaves open):
     # vendors with an ACTIVE unavailability record on the selected parts are dropped
@@ -2611,6 +2638,7 @@ async def sightings_create_offer(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
 
     # Build (and structurally validate) the payload FIRST so a bad numeric/date is
     # reported as a 422 (not masked by the essentials gate below or crashed as a 500).
@@ -2726,6 +2754,7 @@ async def sightings_review_offer(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
     # Scope the offer to the path requirement (IDOR guard — prevents a guessed offer_id
     # from a different requirement from being approved/rejected).
     offer = db.get(Offer, offer_id)
@@ -2753,6 +2782,7 @@ async def sightings_reconfirm_offer(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
     # Scope the offer to the path requirement (IDOR guard).
     offer = db.get(Offer, offer_id)
     if offer is None or offer.requirement_id != requirement_id:
@@ -2776,6 +2806,7 @@ async def sightings_mark_offer_sold(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
     # Scope the offer to the path requirement (IDOR guard).
     offer = db.get(Offer, offer_id)
     if offer is None or offer.requirement_id != requirement_id:
@@ -2799,6 +2830,7 @@ async def sightings_delete_offer(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
     # Scope the offer to the path requirement (IDOR guard).
     offer = db.get(Offer, offer_id)
     if offer is None or offer.requirement_id != requirement_id:
@@ -2916,6 +2948,7 @@ async def sightings_update_offer(
     requirement = db.get(Requirement, requirement_id)
     if not requirement:
         raise HTTPException(404, "Requirement not found")
+    require_requisition_access(db, requirement.requisition_id, user)
 
     # Load the offer FIRST and scope it to the path requirement (prevents cross-requirement
     # IDOR via a guessed offer_id; 404 if missing or owned by another requirement).
@@ -3066,6 +3099,7 @@ async def sightings_offer_request(
     # guessed offer_id); 404 if the offer is missing or belongs to another requirement.
     if offer is None or offer.requirement_id != requirement_id:
         raise HTTPException(status_code=404, detail={"error": "offer not found for this requirement"})
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     draft = request_template(kind, offer.mpn)
     q = dict(offer.qualification or {})
     reqs = list(q.get("requests") or [])
@@ -3123,6 +3157,7 @@ async def sightings_offer_request_send(
     # guessed offer_id); 404 if the offer is missing or belongs to another requirement.
     if offer is None or offer.requirement_id != requirement_id:
         raise HTTPException(status_code=404, detail={"error": "offer not found for this requirement"})
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
 
     q = dict(offer.qualification or {})
     reqs = list(q.get("requests") or [])

--- a/app/services/requisition_service.py
+++ b/app/services/requisition_service.py
@@ -15,7 +15,7 @@ from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from ..constants import ActivityType, RequisitionStatus, UserRole
+from ..constants import RESTRICTED_ROLES, ActivityType, RequisitionStatus
 from ..models import Offer, Requirement, Requisition, User
 from ..utils.normalization import (
     normalize_condition,
@@ -66,7 +66,7 @@ def batch_archive_for_user(db: Session, user: User, ids: list[int]) -> list[int]
         Requisition.id.in_(ids),
         Requisition.status.notin_(RequisitionStatus.TERMINAL),
     ]
-    if user.role == UserRole.SALES:
+    if user.role in RESTRICTED_ROLES:
         conditions.append(Requisition.created_by == user.id)
 
     stmt = (

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -70,6 +70,31 @@ Route Handler
 Response -> Caddy -> Browser -> HTMX swaps into DOM
 ```
 
+## Authorization & Access Control
+
+Two layers: **role gates** (who may reach an endpoint) and **ownership scoping**
+(which records a user may act on).
+
+- **Role gates** — FastAPI dependencies in `app/dependencies.py`: `require_user`
+  (any authenticated active user), `require_buyer` (BUYER_ROLES = buyer/sales/trader/
+  manager/admin), `require_admin`, `require_manager`. The non-interactive `agent`
+  account is excluded from buyer-tier actions.
+- **Ownership scoping (role-scoped model)** — `RESTRICTED_ROLES = {SALES, TRADER}`
+  (single source of truth in `app/constants.py`): sales/trader users may act only on
+  requisitions they created (`Requisition.created_by`); buyer/manager/admin are
+  unrestricted. Enforced through ONE chokepoint, not per-endpoint logic:
+  - `require_requisition_access(db, req_id, user, *, owner_id=None, label=...)` — pure
+    guard, raises 404 for a restricted non-owner. Used after loading a requisition or a
+    requisition-scoped child (Offer/Requirement/Contact/VendorResponse/SourcingLead;
+    `owner_id` covers scratch resources with a null `requisition_id`).
+  - `get_req_for_user` / `get_quote_for_user` — load-and-authorize helpers that return
+    the owned record or 404.
+
+  Every mutating or email-sending endpoint that touches a requisition-scoped resource
+  routes through one of these. Regression tests live in `tests/test_authz_*.py`
+  (a non-owner sales/trader user must get 404). 404 (not 403) is used so resource
+  existence isn't leaked.
+
 ## Frontend Architecture
 
 ```

--- a/tests/test_authz_app_routers_ai.py
+++ b/tests/test_authz_app_routers_ai.py
@@ -1,0 +1,114 @@
+"""Authz regression tests for app/routers/ai.py requisition-ownership IDOR guards.
+
+Restricted roles (SALES/TRADER) must not act on requisition-scoped resources they do not
+own. Buyer/manager/admin remain unrestricted. We act as a restricted non-owner by
+flipping the test user's role and reassigning ownership to another user, then assert the
+mutating endpoints return 404.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.config import settings
+from app.constants import UserRole
+from app.models import Requirement, VendorResponse
+
+
+@pytest.fixture()
+def ai_enabled(monkeypatch):
+    """Force AI features on so ownership guards (which run after the AI gate) are
+    reached."""
+    monkeypatch.setattr(settings, "ai_features_enabled", "all")
+    yield
+
+
+def _other_requirement(db_session, admin_user):
+    """A requirement under a requisition owned by someone other than test_user."""
+    from app.models import Requisition
+
+    req = Requisition(
+        name="REQ-OTHER-OWNER",
+        customer_name="Other Co",
+        status="active",
+        created_by=admin_user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req)
+    db_session.flush()
+    item = Requirement(
+        requisition_id=req.id,
+        primary_mpn="LM317T",
+        target_qty=10,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(item)
+    db_session.commit()
+    db_session.refresh(item)
+    return item
+
+
+# ── #48 POST /api/ai/generate-description/{requirement_id} ────────────────
+
+
+def test_generate_description_blocks_non_owner_sales(client, db_session, test_user, admin_user):
+    test_user.role = UserRole.SALES
+    item = _other_requirement(db_session, admin_user)
+    db_session.commit()
+
+    resp = client.post(f"/api/ai/generate-description/{item.id}")
+    assert resp.status_code == 404
+
+
+def test_generate_description_blocks_non_owner_trader(client, db_session, test_user, admin_user):
+    test_user.role = UserRole.TRADER
+    item = _other_requirement(db_session, admin_user)
+    db_session.commit()
+
+    resp = client.post(f"/api/ai/generate-description/{item.id}")
+    assert resp.status_code == 404
+
+
+def test_generate_description_allows_buyer(client, db_session, test_user, test_requisition):
+    # test_user is a buyer (unrestricted); test_requisition owned by test_user.
+    item = db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first()
+    resp = client.post(f"/api/ai/generate-description/{item.id}")
+    # Buyer passes the ownership guard; not a 404 from the guard.
+    assert resp.status_code != 404
+
+
+# ── #49 POST /api/ai/parse-response/{response_id} ─────────────────────────
+
+
+def test_parse_response_blocks_non_owner_sales(client, db_session, test_user, admin_user, ai_enabled):
+    test_user.role = UserRole.SALES
+    item = _other_requirement(db_session, admin_user)
+    vr = VendorResponse(
+        requisition_id=item.requisition_id,
+        vendor_name="Arrow",
+        subject="re: rfq",
+        body="price is $1",
+    )
+    db_session.add(vr)
+    db_session.commit()
+    db_session.refresh(vr)
+
+    resp = client.post(f"/api/ai/parse-response/{vr.id}")
+    assert resp.status_code == 404
+
+
+def test_parse_response_blocks_non_owner_trader(client, db_session, test_user, admin_user, ai_enabled):
+    test_user.role = UserRole.TRADER
+    item = _other_requirement(db_session, admin_user)
+    vr = VendorResponse(
+        requisition_id=item.requisition_id,
+        vendor_name="Arrow",
+        subject="re: rfq",
+        body="price is $1",
+    )
+    db_session.add(vr)
+    db_session.commit()
+    db_session.refresh(vr)
+
+    resp = client.post(f"/api/ai/parse-response/{vr.id}")
+    assert resp.status_code == 404

--- a/tests/test_authz_app_routers_crm_clone.py
+++ b/tests/test_authz_app_routers_crm_clone.py
@@ -1,0 +1,50 @@
+"""Regression tests for requisition-ownership IDOR guards in app/routers/crm/clone.py.
+
+The clone endpoint must reject SALES/TRADER users attempting to clone a requisition they
+do not own (created_by != user.id), while leaving the buyer/admin happy path intact.
+"""
+
+from app.constants import UserRole
+
+
+def test_clone_requisition_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    """A SALES user cannot clone a requisition owned by someone else (404)."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id  # owned by someone else
+    db_session.commit()
+
+    resp = client.post(f"/api/requisitions/{test_requisition.id}/clone")
+    assert resp.status_code == 404
+
+
+def test_clone_requisition_blocks_non_owner_trader(client, db_session, test_requisition, test_user, admin_user):
+    """A TRADER user cannot clone a requisition owned by someone else (404)."""
+    test_user.role = UserRole.TRADER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+
+    resp = client.post(f"/api/requisitions/{test_requisition.id}/clone")
+    assert resp.status_code == 404
+
+
+def test_clone_requisition_allows_owner_sales(client, db_session, test_requisition, test_user):
+    """A SALES user CAN clone a requisition they own."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id
+    db_session.commit()
+
+    resp = client.post(f"/api/requisitions/{test_requisition.id}/clone")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+def test_clone_requisition_allows_buyer(client, db_session, test_requisition, test_user, admin_user):
+    """A BUYER (unrestricted) can clone any requisition, even one owned by someone
+    else."""
+    test_user.role = UserRole.BUYER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+
+    resp = client.post(f"/api/requisitions/{test_requisition.id}/clone")
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True

--- a/tests/test_authz_app_routers_crm_offers.py
+++ b/tests/test_authz_app_routers_crm_offers.py
@@ -1,0 +1,131 @@
+"""Regression tests: requisition-ownership IDOR guards on app/routers/crm/offers.py.
+
+A SALES (restricted) user who does NOT own the requisition behind an offer must be
+blocked (404) from mutating/sending on that offer. Buyer/admin happy paths are
+covered by the existing offer tests; here we assert the restricted-role lockout.
+"""
+
+import io
+
+import pytest
+
+from app.constants import UserRole
+from app.models import Offer, OfferAttachment
+
+
+@pytest.fixture()
+def foreign_offer(db_session, test_requisition, test_user, admin_user):
+    """An offer on a requisition owned by *someone else* (admin), so a SALES test_user
+    is a non-owner.
+
+    Offer.entered_by_id is also the admin so the owner_id fallback does not accidentally
+    grant access.
+    """
+    test_requisition.created_by = admin_user.id
+    o = Offer(
+        requisition_id=test_requisition.id,
+        vendor_name="Arrow Electronics",
+        mpn="LM317T",
+        qty_available=1000,
+        unit_price=0.50,
+        entered_by_id=admin_user.id,
+        status="pending_review",
+        evidence_tier="T4",
+    )
+    db_session.add(o)
+    db_session.commit()
+    db_session.refresh(o)
+    return o
+
+
+def _make_sales(test_user, db_session):
+    test_user.role = UserRole.SALES
+    db_session.commit()
+
+
+def test_update_offer_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    resp = client.put(f"/api/offers/{foreign_offer.id}", json={"unit_price": 9.99})
+    assert resp.status_code == 404
+
+
+def test_delete_offer_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    resp = client.delete(f"/api/offers/{foreign_offer.id}")
+    assert resp.status_code == 404
+
+
+def test_reconfirm_offer_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    resp = client.put(f"/api/offers/{foreign_offer.id}/reconfirm")
+    assert resp.status_code == 404
+
+
+def test_approve_offer_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    resp = client.put(f"/api/offers/{foreign_offer.id}/approve")
+    assert resp.status_code == 404
+
+
+def test_reject_offer_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    resp = client.put(f"/api/offers/{foreign_offer.id}/reject")
+    assert resp.status_code == 404
+
+
+def test_promote_offer_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/api/offers/{foreign_offer.id}/promote")
+    assert resp.status_code == 404
+
+
+def test_reject_t4_offer_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/api/offers/{foreign_offer.id}/reject")
+    assert resp.status_code == 404
+
+
+def test_upload_attachment_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    resp = client.post(
+        f"/api/offers/{foreign_offer.id}/attachments",
+        files={"file": ("x.pdf", io.BytesIO(b"data"), "application/pdf")},
+    )
+    assert resp.status_code == 404
+
+
+def test_attach_onedrive_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/api/offers/{foreign_offer.id}/attachments/onedrive", json={"item_id": "abc"})
+    assert resp.status_code == 404
+
+
+def test_delete_offer_attachment_blocks_non_owner_sales(client, db_session, test_user, foreign_offer):
+    _make_sales(test_user, db_session)
+    att = OfferAttachment(offer_id=foreign_offer.id, file_name="x.pdf")
+    db_session.add(att)
+    db_session.commit()
+    db_session.refresh(att)
+    resp = client.delete(f"/api/offer-attachments/{att.id}")
+    assert resp.status_code == 404
+
+
+# ── Happy-path sanity: an owning SALES user (created the requisition) is allowed. ──
+
+
+def test_reconfirm_offer_allows_owning_sales(client, db_session, test_user, test_requisition):
+    """When the SALES user OWNS the requisition, the guard is a no-op."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id
+    o = Offer(
+        requisition_id=test_requisition.id,
+        vendor_name="Arrow",
+        mpn="LM317T",
+        entered_by_id=test_user.id,
+        status="active",
+    )
+    db_session.add(o)
+    db_session.commit()
+    db_session.refresh(o)
+    resp = client.put(f"/api/offers/{o.id}/reconfirm")
+    assert resp.status_code == 200

--- a/tests/test_authz_app_routers_crm_quotes.py
+++ b/tests/test_authz_app_routers_crm_quotes.py
@@ -1,0 +1,120 @@
+"""Requisition-ownership IDOR regression tests for app/routers/crm/quotes.py.
+
+Every mutating/sending quote endpoint loads its target via the ownership-aware
+central helpers (get_quote_for_user / get_req_for_user), which restrict SALES and
+TRADER users to resources whose requisition was created_by themselves. These tests
+lock in that a restricted (SALES) non-owner is rejected with 404 (existence not
+leaked) on each mutating endpoint, while leaving the buyer happy path unchanged.
+
+The shared ``client`` fixture overrides require_user to return ``test_user``; we
+flip that user's role to SALES and reassign requisition/quote ownership to a
+different user (admin_user) to simulate a restricted non-owner.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.constants import QuoteStatus, UserRole
+from app.models import CustomerSite, Quote
+
+
+@pytest.fixture()
+def other_owned_quote(db_session, test_requisition, admin_user, test_company):
+    """A DRAFT quote whose requisition is owned by admin_user (not test_user)."""
+    test_requisition.created_by = admin_user.id
+
+    site = CustomerSite(
+        company_id=test_company.id,
+        site_name="HQ",
+        contact_email="buyer@example.com",
+        contact_name="Buyer Person",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(site)
+    db_session.flush()
+    test_requisition.customer_site_id = site.id
+
+    quote = Quote(
+        requisition_id=test_requisition.id,
+        customer_site_id=site.id,
+        quote_number="Q-AUTHZ-001",
+        line_items=[],
+        status=QuoteStatus.DRAFT.value,
+        created_by_id=admin_user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(quote)
+    db_session.commit()
+    db_session.refresh(quote)
+    return quote
+
+
+def _make_sales(test_user, db_session):
+    test_user.role = UserRole.SALES
+    db_session.commit()
+
+
+# ── Non-owner SALES is blocked (404) on every mutating endpoint ──────────
+
+
+def test_create_quote_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+    resp = client.post(
+        f"/api/requisitions/{test_requisition.id}/quote",
+        json={"offer_ids": [], "line_items": []},
+    )
+    assert resp.status_code == 404
+
+
+def test_update_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
+    _make_sales(test_user, db_session)
+    resp = client.put(f"/api/quotes/{other_owned_quote.id}", json={"notes": "hacked"})
+    assert resp.status_code == 404
+
+
+def test_delete_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
+    _make_sales(test_user, db_session)
+    resp = client.delete(f"/api/quotes/{other_owned_quote.id}")
+    assert resp.status_code == 404
+
+
+def test_send_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/api/quotes/{other_owned_quote.id}/send", json={})
+    assert resp.status_code == 404
+
+
+def test_preview_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/api/quotes/{other_owned_quote.id}/preview", json={})
+    assert resp.status_code == 404
+
+
+def test_quote_result_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/api/quotes/{other_owned_quote.id}/result", json={"result": "won"})
+    assert resp.status_code == 404
+
+
+def test_revise_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/api/quotes/{other_owned_quote.id}/revise")
+    assert resp.status_code == 404
+
+
+def test_reopen_quote_blocks_non_owner_sales(client, db_session, test_user, other_owned_quote):
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/api/quotes/{other_owned_quote.id}/reopen", json={"revise": False})
+    assert resp.status_code == 404
+
+
+# ── Buyer happy path stays unchanged (owner / unrestricted role allowed) ─
+
+
+def test_update_quote_allows_buyer_owner(client, other_owned_quote):
+    # test_user is a buyer (unrestricted) by default — must NOT be blocked.
+    resp = client.put(f"/api/quotes/{other_owned_quote.id}", json={"notes": "ok"})
+    assert resp.status_code == 200

--- a/tests/test_authz_app_routers_htmx_views.py
+++ b/tests/test_authz_app_routers_htmx_views.py
@@ -1,0 +1,315 @@
+"""Authz regression tests for requisition-ownership IDOR guards in htmx_views.py.
+
+A SALES/TRADER user may only act on requisitions they created. These tests flip the
+test user's role to SALES and re-own the requisition to someone else (admin_user),
+then assert each mutating/sending endpoint returns 404 (existence not leaked).
+
+The `client` fixture overrides `require_user` to return the *same* `test_user`
+object, so mutating `test_user.role` is observed by the endpoint at request time.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.constants import OfferStatus, UserRole
+from app.models import Offer, Requirement, Requisition
+from app.models.offers import VendorResponse
+
+
+@pytest.fixture()
+def foreign_req(db_session, test_requisition, admin_user):
+    """test_requisition re-owned by admin_user (so test_user-as-SALES is a non-
+    owner)."""
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+    return test_requisition
+
+
+def _make_sales(db_session, test_user):
+    test_user.role = UserRole.SALES
+    db_session.commit()
+
+
+def _requirement_id(db_session, req: Requisition) -> int:
+    return db_session.query(Requirement).filter_by(requisition_id=req.id).first().id
+
+
+def _make_offer(db_session, req: Requisition, *, status="active") -> Offer:
+    rid = _requirement_id(db_session, req)
+    offer = Offer(
+        requisition_id=req.id,
+        requirement_id=rid,
+        vendor_name="Foreign Vendor",
+        mpn="LM317T",
+        status=status,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(offer)
+    db_session.commit()
+    db_session.refresh(offer)
+    return offer
+
+
+# ── HIGH severity ──────────────────────────────────────────────────────
+
+
+def test_rfq_send_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/rfq-send",
+        data={"vendor_names": "Acme", "vendor_emails": "a@b.com", "subject": "x", "body": "y"},
+    )
+    assert resp.status_code == 404
+
+
+def test_create_quote_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    offer = _make_offer(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/create-quote",
+        data={"offer_ids": str(offer.id)},
+    )
+    assert resp.status_code == 404
+
+
+def test_mark_sold_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    offer = _make_offer(db_session, foreign_req, status=OfferStatus.APPROVED)
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/offers/{offer.id}/mark-sold",
+    )
+    assert resp.status_code == 404
+
+
+def test_review_offer_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    offer = _make_offer(db_session, foreign_req, status=OfferStatus.PENDING_REVIEW)
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/offers/{offer.id}/review",
+        data={"action": "approve"},
+    )
+    assert resp.status_code == 404
+
+
+def test_promote_offer_queue_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    offer = _make_offer(db_session, foreign_req, status="pending_review")
+    _make_sales(db_session, test_user)
+    resp = client.post(f"/v2/partials/offers/{offer.id}/promote")
+    assert resp.status_code == 404
+
+
+def test_reject_offer_queue_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    offer = _make_offer(db_session, foreign_req, status="pending_review")
+    _make_sales(db_session, test_user)
+    resp = client.post(f"/v2/partials/offers/{offer.id}/reject")
+    assert resp.status_code == 404
+
+
+# ── MED severity ───────────────────────────────────────────────────────
+
+
+def test_add_offer_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/add-offer",
+        data={"vendor_name": "V", "mpn": "LM317T"},
+    )
+    assert resp.status_code == 404
+
+
+def test_edit_offer_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    offer = _make_offer(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/offers/{offer.id}/edit",
+        data={"vendor_name": "Changed"},
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_offer_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    offer = _make_offer(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.delete(f"/v2/partials/requisitions/{foreign_req.id}/offers/{offer.id}")
+    assert resp.status_code == 404
+
+
+def test_reconfirm_offer_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    offer = _make_offer(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.post(f"/v2/partials/requisitions/{foreign_req.id}/offers/{offer.id}/reconfirm")
+    assert resp.status_code == 404
+
+
+def test_add_requirement_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/requirements",
+        data={"primary_mpn": "ABC123", "manufacturer": "TI"},
+    )
+    assert resp.status_code == 404
+
+
+def test_update_requirement_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    rid = _requirement_id(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.put(
+        f"/v2/partials/requisitions/{foreign_req.id}/requirements/{rid}",
+        data={"primary_mpn": "LM317T", "manufacturer": "TI"},
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_requirement_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    rid = _requirement_id(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.delete(f"/v2/partials/requisitions/{foreign_req.id}/requirements/{rid}")
+    assert resp.status_code == 404
+
+
+def test_save_parsed_offers_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/save-parsed-offers",
+        data={"vendor_name": "V"},
+    )
+    assert resp.status_code == 404
+
+
+def test_log_phone_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/log-phone",
+        data={"vendor_name": "V", "vendor_phone": "555"},
+    )
+    assert resp.status_code == 404
+
+
+def test_response_status_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    vr = VendorResponse(requisition_id=foreign_req.id, vendor_name="V", status="new")
+    db_session.add(vr)
+    db_session.commit()
+    db_session.refresh(vr)
+    _make_sales(db_session, test_user)
+    resp = client.patch(
+        f"/v2/partials/requisitions/{foreign_req.id}/responses/{vr.id}/status",
+        data={"status": "reviewed"},
+    )
+    assert resp.status_code == 404
+
+
+def test_review_response_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    # review_response_htmx loads app.models.offers.VendorResponse by (id, requisition_id).
+    vr = VendorResponse(requisition_id=foreign_req.id, vendor_name="V", status="new")
+    db_session.add(vr)
+    db_session.commit()
+    db_session.refresh(vr)
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/responses/{vr.id}/review",
+        data={"status": "reviewed"},
+    )
+    assert resp.status_code == 404
+
+
+def test_archive_requisition_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    _make_sales(db_session, test_user)
+    resp = client.patch(f"/v2/partials/requisitions/{foreign_req.id}/archive")
+    assert resp.status_code == 404
+
+
+def test_unarchive_requisition_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    _make_sales(db_session, test_user)
+    resp = client.patch(f"/v2/partials/requisitions/{foreign_req.id}/unarchive")
+    assert resp.status_code == 404
+
+
+def test_part_header_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    rid = _requirement_id(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.patch(
+        f"/v2/partials/parts/{rid}/header",
+        data={"field": "target_qty", "value": "5"},
+    )
+    assert resp.status_code == 404
+
+
+def test_part_cell_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    rid = _requirement_id(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.patch(
+        f"/v2/partials/parts/{rid}/cell",
+        data={"field": "target_qty", "value": "5"},
+    )
+    assert resp.status_code == 404
+
+
+def test_part_save_spec_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    rid = _requirement_id(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.patch(
+        f"/v2/partials/parts/{rid}/save-spec",
+        data={"field": "condition", "value": "New"},
+    )
+    assert resp.status_code == 404
+
+
+def test_part_notes_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    rid = _requirement_id(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.patch(f"/v2/partials/parts/{rid}/notes", data={"sale_notes": "hi"})
+    assert resp.status_code == 404
+
+
+def test_part_tasks_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    rid = _requirement_id(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.post(f"/v2/partials/parts/{rid}/tasks", data={"title": "T"})
+    assert resp.status_code == 404
+
+
+def test_part_archive_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    rid = _requirement_id(db_session, foreign_req)
+    _make_sales(db_session, test_user)
+    resp = client.patch(f"/v2/partials/parts/{rid}/archive")
+    assert resp.status_code == 404
+
+
+def test_log_activity_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    _make_sales(db_session, test_user)
+    resp = client.post(
+        f"/v2/partials/requisitions/{foreign_req.id}/log-activity",
+        data={"activity_type": "note", "notes": "x"},
+    )
+    assert resp.status_code == 404
+
+
+def test_search_all_blocks_non_owner_sales(client, db_session, foreign_req, test_user):
+    _make_sales(db_session, test_user)
+    resp = client.post(f"/v2/partials/requisitions/{foreign_req.id}/search-all")
+    assert resp.status_code == 404
+
+
+# ── Happy path: owner (buyer) still allowed ────────────────────────────
+
+
+def test_owner_buyer_can_log_activity(client, db_session, test_requisition, test_user):
+    # test_user is buyer and owns test_requisition by default — must NOT 404.
+    resp = client.post(
+        f"/v2/partials/requisitions/{test_requisition.id}/log-activity",
+        data={"activity_type": "note", "notes": "owner note"},
+    )
+    assert resp.status_code == 200
+
+
+def test_sales_owner_can_add_offer(client, db_session, test_requisition, test_user):
+    # SALES user who OWNS the requisition is allowed through the guard.
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id
+    db_session.commit()
+    resp = client.post(
+        f"/v2/partials/requisitions/{test_requisition.id}/add-offer",
+        data={"vendor_name": "V", "mpn": "LM317T"},
+    )
+    assert resp.status_code == 200

--- a/tests/test_authz_app_routers_quote_builder.py
+++ b/tests/test_authz_app_routers_quote_builder.py
@@ -1,0 +1,92 @@
+"""Authz regression tests for app/routers/quote_builder.py requisition-ownership IDOR.
+
+Policy (approved 2026-06-23): SALES + TRADER may only act on requisitions they
+created (created_by). BUYER / MANAGER / ADMIN are unrestricted. Verifies that the
+only mutating endpoint in this router — POST .../quote-builder/{req_id}/save —
+returns 404 for a restricted non-owner and keeps the buyer happy path working.
+
+The `client` fixture overrides require_user to return `test_user`; flipping that
+user's role and re-pointing the requisition's created_by exercises the guard.
+"""
+
+from app.constants import UserRole
+
+
+def _save_payload():
+    return {
+        "lines": [
+            {
+                "requirement_id": 1,
+                "mpn": "LM317T",
+                "manufacturer": "TI",
+                "qty": 1000,
+                "cost_price": 0.40,
+                "sell_price": 0.50,
+                "margin_pct": 20.0,
+            }
+        ]
+    }
+
+
+def test_quote_save_blocks_non_owner_sales(
+    client, db_session, test_requisition, test_user, admin_user, test_customer_site
+):
+    """SALES non-owner is blocked (404) from saving a quote for another's req."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id  # owned by someone else
+    test_requisition.customer_site_id = test_customer_site.id
+    db_session.commit()
+
+    resp = client.post(
+        f"/v2/partials/quote-builder/{test_requisition.id}/save",
+        json=_save_payload(),
+    )
+    assert resp.status_code == 404
+
+
+def test_quote_save_blocks_non_owner_trader(
+    client, db_session, test_requisition, test_user, admin_user, test_customer_site
+):
+    """TRADER non-owner is blocked (404) — TRADER is restricted just like SALES."""
+    test_user.role = UserRole.TRADER
+    test_requisition.created_by = admin_user.id
+    test_requisition.customer_site_id = test_customer_site.id
+    db_session.commit()
+
+    resp = client.post(
+        f"/v2/partials/quote-builder/{test_requisition.id}/save",
+        json=_save_payload(),
+    )
+    assert resp.status_code == 404
+
+
+def test_quote_save_allows_owner_sales(client, db_session, test_requisition, test_user, test_customer_site):
+    """SALES owner passes the ownership guard (not blocked by 404)."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id  # owner
+    test_requisition.customer_site_id = test_customer_site.id
+    db_session.commit()
+
+    resp = client.post(
+        f"/v2/partials/quote-builder/{test_requisition.id}/save",
+        json=_save_payload(),
+    )
+    # Ownership guard must NOT 404 the owner. (Service may 200 or error on data
+    # specifics, but it must not be the ownership 404.)
+    assert resp.status_code != 404
+
+
+def test_quote_save_allows_buyer_non_owner(
+    client, db_session, test_requisition, test_user, admin_user, test_customer_site
+):
+    """BUYER (default role) is unrestricted even when not the owner."""
+    # test_user is buyer by default
+    test_requisition.created_by = admin_user.id  # someone else's req
+    test_requisition.customer_site_id = test_customer_site.id
+    db_session.commit()
+
+    resp = client.post(
+        f"/v2/partials/quote-builder/{test_requisition.id}/save",
+        json=_save_payload(),
+    )
+    assert resp.status_code != 404

--- a/tests/test_authz_app_routers_requisitions_attachments.py
+++ b/tests/test_authz_app_routers_requisitions_attachments.py
@@ -1,0 +1,179 @@
+"""Authz regression tests for requisition/requirement attachment deletion.
+
+Covers the requisition-ownership IDOR guards added to the DELETE endpoints in
+app/routers/requisitions/attachments.py:
+
+- DELETE /api/requisition-attachments/{att_id}   (HIGH)
+- DELETE /api/requirement-attachments/{att_id}   (HIGH)
+
+A restricted SALES/TRADER user who does NOT own the parent requisition must get
+a 404 BEFORE any OneDrive deletion or DB delete happens. Buyer/admin (owner or
+unrestricted) keep working.
+"""
+
+from datetime import datetime, timezone
+
+from app.constants import UserRole
+from app.models import (
+    Requirement,
+    RequirementAttachment,
+    RequisitionAttachment,
+)
+
+
+def _make_req_attachment(db_session, requisition_id):
+    att = RequisitionAttachment(
+        requisition_id=requisition_id,
+        file_name="spec.pdf",
+        onedrive_item_id=None,  # no OneDrive call; isolates the authz guard
+        onedrive_url="https://example.com/spec.pdf",
+        content_type="application/pdf",
+        size_bytes=123,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(att)
+    db_session.commit()
+    db_session.refresh(att)
+    return att
+
+
+def _make_requirement_attachment(db_session, requirement_id):
+    att = RequirementAttachment(
+        requirement_id=requirement_id,
+        file_name="datasheet.pdf",
+        onedrive_item_id=None,
+        onedrive_url="https://example.com/datasheet.pdf",
+        content_type="application/pdf",
+        size_bytes=456,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(att)
+    db_session.commit()
+    db_session.refresh(att)
+    return att
+
+
+# ── DELETE /api/requisition-attachments/{att_id} ──────────────────────────
+
+
+def test_delete_requisition_attachment_blocks_non_owner_sales(
+    client, db_session, test_requisition, test_user, admin_user
+):
+    """SALES non-owner gets 404 and the attachment is NOT deleted."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id  # owned by someone else
+    db_session.commit()
+
+    att = _make_req_attachment(db_session, test_requisition.id)
+
+    resp = client.delete(f"/api/requisition-attachments/{att.id}")
+    assert resp.status_code == 404
+    # Guard ran before db.delete — record still present.
+    assert db_session.get(RequisitionAttachment, att.id) is not None
+
+
+def test_delete_requisition_attachment_blocks_non_owner_trader(
+    client, db_session, test_requisition, test_user, admin_user
+):
+    """TRADER is restricted the same way as SALES."""
+    test_user.role = UserRole.TRADER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+
+    att = _make_req_attachment(db_session, test_requisition.id)
+
+    resp = client.delete(f"/api/requisition-attachments/{att.id}")
+    assert resp.status_code == 404
+    assert db_session.get(RequisitionAttachment, att.id) is not None
+
+
+def test_delete_requisition_attachment_allows_owner_sales(client, db_session, test_requisition, test_user):
+    """SALES owner (created_by == user) may delete their own attachment."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id
+    db_session.commit()
+
+    att = _make_req_attachment(db_session, test_requisition.id)
+
+    resp = client.delete(f"/api/requisition-attachments/{att.id}")
+    assert resp.status_code == 200
+    assert db_session.get(RequisitionAttachment, att.id) is None
+
+
+def test_delete_requisition_attachment_allows_buyer(client, db_session, test_requisition, test_user, admin_user):
+    """Unrestricted buyer can delete regardless of ownership (happy path)."""
+    test_user.role = UserRole.BUYER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+
+    att = _make_req_attachment(db_session, test_requisition.id)
+
+    resp = client.delete(f"/api/requisition-attachments/{att.id}")
+    assert resp.status_code == 200
+    assert db_session.get(RequisitionAttachment, att.id) is None
+
+
+# ── DELETE /api/requirement-attachments/{att_id} ──────────────────────────
+
+
+def _requirement_id(db_session, requisition_id):
+    req = db_session.query(Requirement).filter(Requirement.requisition_id == requisition_id).first()
+    assert req is not None
+    return req.id
+
+
+def test_delete_requirement_attachment_blocks_non_owner_sales(
+    client, db_session, test_requisition, test_user, admin_user
+):
+    """SALES non-owner gets 404 via the requirement->requisition FK chain."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+
+    req_id = _requirement_id(db_session, test_requisition.id)
+    att = _make_requirement_attachment(db_session, req_id)
+
+    resp = client.delete(f"/api/requirement-attachments/{att.id}")
+    assert resp.status_code == 404
+    assert db_session.get(RequirementAttachment, att.id) is not None
+
+
+def test_delete_requirement_attachment_blocks_non_owner_trader(
+    client, db_session, test_requisition, test_user, admin_user
+):
+    test_user.role = UserRole.TRADER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+
+    req_id = _requirement_id(db_session, test_requisition.id)
+    att = _make_requirement_attachment(db_session, req_id)
+
+    resp = client.delete(f"/api/requirement-attachments/{att.id}")
+    assert resp.status_code == 404
+    assert db_session.get(RequirementAttachment, att.id) is not None
+
+
+def test_delete_requirement_attachment_allows_owner_sales(client, db_session, test_requisition, test_user):
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id
+    db_session.commit()
+
+    req_id = _requirement_id(db_session, test_requisition.id)
+    att = _make_requirement_attachment(db_session, req_id)
+
+    resp = client.delete(f"/api/requirement-attachments/{att.id}")
+    assert resp.status_code == 200
+    assert db_session.get(RequirementAttachment, att.id) is None
+
+
+def test_delete_requirement_attachment_allows_buyer(client, db_session, test_requisition, test_user, admin_user):
+    test_user.role = UserRole.BUYER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+
+    req_id = _requirement_id(db_session, test_requisition.id)
+    att = _make_requirement_attachment(db_session, req_id)
+
+    resp = client.delete(f"/api/requirement-attachments/{att.id}")
+    assert resp.status_code == 200
+    assert db_session.get(RequirementAttachment, att.id) is None

--- a/tests/test_authz_app_routers_requisitions_core.py
+++ b/tests/test_authz_app_routers_requisitions_core.py
@@ -1,0 +1,90 @@
+"""Authz regression tests for app/routers/requisitions/core.py.
+
+Every mutating endpoint in core.py loads its requisition via
+``get_req_for_user(db, user, req_id)``, which filters by ``created_by`` for
+RESTRICTED_ROLES (SALES + TRADER). These tests pin that behavior: a restricted
+non-owner must get 404 (existence not leaked) on requisition-scoped mutations,
+while the buyer happy path keeps working.
+"""
+
+from app.constants import UserRole
+
+
+def _make_foreign(test_requisition, test_user, owner, db_session, role=UserRole.SALES):
+    """Flip the acting user to a restricted role and reassign the req to someone
+    else."""
+    test_user.role = role
+    test_requisition.created_by = owner.id
+    db_session.commit()
+
+
+# ── PUT /api/requisitions/{req_id}/outcome ────────────────────────────────
+
+
+def test_outcome_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    _make_foreign(test_requisition, test_user, admin_user, db_session)
+    resp = client.put(f"/api/requisitions/{test_requisition.id}/outcome", json={"outcome": "won"})
+    assert resp.status_code == 404
+
+
+def test_outcome_blocks_non_owner_trader(client, db_session, test_requisition, test_user, admin_user):
+    _make_foreign(test_requisition, test_user, admin_user, db_session, role=UserRole.TRADER)
+    resp = client.put(f"/api/requisitions/{test_requisition.id}/outcome", json={"outcome": "won"})
+    assert resp.status_code == 404
+
+
+def test_outcome_buyer_happy_path(client, test_requisition):
+    resp = client.put(f"/api/requisitions/{test_requisition.id}/outcome", json={"outcome": "won"})
+    assert resp.status_code == 200
+
+
+# ── PUT /api/requisitions/{req_id}/archive ────────────────────────────────
+
+
+def test_archive_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    _make_foreign(test_requisition, test_user, admin_user, db_session)
+    resp = client.put(f"/api/requisitions/{test_requisition.id}/archive")
+    assert resp.status_code == 404
+
+
+def test_archive_buyer_happy_path(client, test_requisition):
+    resp = client.put(f"/api/requisitions/{test_requisition.id}/archive")
+    assert resp.status_code == 200
+
+
+# ── PUT /api/requisitions/{req_id} (update) ───────────────────────────────
+
+
+def test_update_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    _make_foreign(test_requisition, test_user, admin_user, db_session)
+    resp = client.put(f"/api/requisitions/{test_requisition.id}", json={"name": "Hacked"})
+    assert resp.status_code == 404
+
+
+def test_update_buyer_happy_path(client, test_requisition):
+    resp = client.put(f"/api/requisitions/{test_requisition.id}", json={"name": "Renamed"})
+    assert resp.status_code == 200
+
+
+# ── POST /api/requisitions/{req_id}/dismiss-new-offers ────────────────────
+
+
+def test_dismiss_new_offers_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    _make_foreign(test_requisition, test_user, admin_user, db_session)
+    resp = client.post(f"/api/requisitions/{test_requisition.id}/dismiss-new-offers")
+    assert resp.status_code == 404
+
+
+def test_dismiss_new_offers_buyer_happy_path(client, test_requisition):
+    resp = client.post(f"/api/requisitions/{test_requisition.id}/dismiss-new-offers")
+    assert resp.status_code == 200
+
+
+# ── DELETE /api/requisitions/{req_id}/claim ───────────────────────────────
+# Restricted non-owner must not be able to resolve the req at all (404).
+
+
+def test_unclaim_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    _make_foreign(test_requisition, test_user, admin_user, db_session)
+    resp = client.delete(f"/api/requisitions/{test_requisition.id}/claim")
+    assert resp.status_code == 404

--- a/tests/test_authz_app_routers_requisitions_requirements.py
+++ b/tests/test_authz_app_routers_requisitions_requirements.py
@@ -1,0 +1,100 @@
+"""Requisition-ownership IDOR regression tests for
+app/routers/requisitions/requirements.py.
+
+Covers the mutating requirement-scoped endpoints that load a Requirement by path id and
+previously mutated it with no ownership guard. A restricted (SALES/TRADER) non-owner
+must get 404 (existence not leaked); buyer/manager/admin happy path must stay 200/OK.
+"""
+
+from app.constants import UserRole
+from app.models import Requirement
+
+
+def _requirement_id(db_session, test_requisition):
+    return db_session.query(Requirement).filter(Requirement.requisition_id == test_requisition.id).first().id
+
+
+# ── POST /api/requirements/{requirement_id}/notes ────────────────────────
+
+
+def test_add_requirement_note_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id  # owned by someone else
+    db_session.commit()
+    rid = _requirement_id(db_session, test_requisition)
+
+    resp = client.post(f"/api/requirements/{rid}/notes", json={"text": "sneaky note"})
+    assert resp.status_code == 404
+
+
+def test_add_requirement_note_blocks_non_owner_trader(client, db_session, test_requisition, test_user, admin_user):
+    test_user.role = UserRole.TRADER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+    rid = _requirement_id(db_session, test_requisition)
+
+    resp = client.post(f"/api/requirements/{rid}/notes", json={"text": "sneaky note"})
+    assert resp.status_code == 404
+
+
+def test_add_requirement_note_allows_buyer(client, db_session, test_requisition, test_user):
+    # test_user is a buyer and owns test_requisition (default fixture wiring)
+    assert test_user.role == "buyer"
+    rid = _requirement_id(db_session, test_requisition)
+
+    resp = client.post(f"/api/requirements/{rid}/notes", json={"text": "legit note"})
+    assert resp.status_code == 200
+    assert "legit note" in resp.json()["notes"]
+
+
+def test_add_requirement_note_allows_owning_sales(client, db_session, test_requisition, test_user):
+    # SALES user who OWNS the requisition is allowed through.
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id
+    db_session.commit()
+    rid = _requirement_id(db_session, test_requisition)
+
+    resp = client.post(f"/api/requirements/{rid}/notes", json={"text": "my own note"})
+    assert resp.status_code == 200
+
+
+# ── POST /api/requirements/{requirement_id}/tasks ────────────────────────
+
+
+def test_create_requirement_task_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+    rid = _requirement_id(db_session, test_requisition)
+
+    resp = client.post(f"/api/requirements/{rid}/tasks", json={"title": "sneaky task"})
+    assert resp.status_code == 404
+
+
+def test_create_requirement_task_blocks_non_owner_trader(client, db_session, test_requisition, test_user, admin_user):
+    test_user.role = UserRole.TRADER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+    rid = _requirement_id(db_session, test_requisition)
+
+    resp = client.post(f"/api/requirements/{rid}/tasks", json={"title": "sneaky task"})
+    assert resp.status_code == 404
+
+
+def test_create_requirement_task_allows_buyer(client, db_session, test_requisition, test_user):
+    assert test_user.role == "buyer"
+    rid = _requirement_id(db_session, test_requisition)
+
+    resp = client.post(f"/api/requirements/{rid}/tasks", json={"title": "legit task"})
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "legit task"
+
+
+def test_create_requirement_task_allows_owning_sales(client, db_session, test_requisition, test_user):
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id
+    db_session.commit()
+    rid = _requirement_id(db_session, test_requisition)
+
+    resp = client.post(f"/api/requirements/{rid}/tasks", json={"title": "my own task"})
+    assert resp.status_code == 200

--- a/tests/test_authz_app_routers_sightings.py
+++ b/tests/test_authz_app_routers_sightings.py
@@ -1,0 +1,196 @@
+"""Regression tests: requisition-ownership IDOR guards in app/routers/sightings.py.
+
+A SALES/TRADER user may only act on requisitions they created. Each test flips the
+shared test user's role to SALES and re-owns the requisition to someone else
+(admin_user), then asserts the mutating/sending endpoint returns 404 (existence not
+leaked) instead of acting on a non-owned requisition.
+
+Covers every HIGH-severity sightings endpoint plus the offer-scoped mark-sold mutation.
+"""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.constants import OfferStatus, UserRole
+from app.models import User
+from app.models.offers import Offer
+from app.models.sourcing import Requirement, Requisition
+
+
+def _requirement(db: Session, req: Requisition) -> Requirement:
+    """The single requirement seeded under the test_requisition fixture."""
+    return db.query(Requirement).filter(Requirement.requisition_id == req.id).first()
+
+
+def _offer(db: Session, req: Requisition, requirement: Requirement) -> Offer:
+    """Create a pending_review offer on the requisition/requirement."""
+    offer = Offer(
+        requisition_id=req.id,
+        requirement_id=requirement.id,
+        vendor_name="Acme Parts",
+        mpn="LM317T",
+        status=OfferStatus.PENDING_REVIEW,
+        source="manual",
+    )
+    db.add(offer)
+    db.commit()
+    db.refresh(offer)
+    return offer
+
+
+@pytest.fixture()
+def _as_sales_nonowner(db_session: Session, test_requisition: Requisition, test_user: User, admin_user: User):
+    """Flip the request user to SALES and re-own the requisition to admin_user."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+    return test_requisition
+
+
+# ── requisition-by-path-derived (via requirement) HIGH-severity endpoints ──────
+
+
+def test_advance_status_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    resp = client.patch(
+        f"/v2/partials/sightings/{requirement.id}/advance-status",
+        data={"status": "sourcing"},
+    )
+    assert resp.status_code == 404
+
+
+def test_create_offer_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    resp = client.post(
+        f"/v2/partials/sightings/{requirement.id}/offers",
+        data={"vendor_name": "Acme", "mpn": "LM317T"},
+    )
+    assert resp.status_code == 404
+
+
+def test_review_offer_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    offer = _offer(db_session, req, requirement)
+    resp = client.post(
+        f"/v2/partials/sightings/{requirement.id}/offers/{offer.id}/review",
+        data={"action": "approve"},
+    )
+    assert resp.status_code == 404
+
+
+def test_update_offer_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    offer = _offer(db_session, req, requirement)
+    resp = client.post(
+        f"/v2/partials/sightings/{requirement.id}/offers/{offer.id}",
+        data={"vendor_name": "Acme", "mpn": "LM317T"},
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_offer_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    offer = _offer(db_session, req, requirement)
+    resp = client.delete(f"/v2/partials/sightings/{requirement.id}/offers/{offer.id}")
+    assert resp.status_code == 404
+
+
+def test_mark_offer_sold_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    offer = _offer(db_session, req, requirement)
+    resp = client.post(f"/v2/partials/sightings/{requirement.id}/offers/{offer.id}/mark-sold")
+    assert resp.status_code == 404
+
+
+# ── offer-loaded (no requirement load) HIGH-severity request-send endpoint ─────
+
+
+def test_offer_request_send_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    offer = _offer(db_session, req, requirement)
+    resp = client.post(
+        f"/v2/partials/sightings/{requirement.id}/offers/{offer.id}/request/0/send",
+    )
+    assert resp.status_code == 404
+
+
+def test_offer_request_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    offer = _offer(db_session, req, requirement)
+    resp = client.post(
+        f"/v2/partials/sightings/{requirement.id}/offers/{offer.id}/request",
+        data={"kind": "images"},
+    )
+    assert resp.status_code == 404
+
+
+# ── send-inquiry (basket of requirements) HIGH-severity endpoint ───────────────
+
+
+def test_send_inquiry_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    resp = client.post(
+        "/v2/partials/sightings/send-inquiry",
+        data={
+            "requirement_ids": [str(requirement.id)],
+            "vendor_names": ["Acme"],
+            "email_body": "please quote",
+        },
+    )
+    assert resp.status_code == 404
+
+
+# ── MEDIUM/LOW requirement-scoped mutations also covered ───────────────────────
+
+
+def test_mark_unavailable_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    resp = client.post(
+        f"/v2/partials/sightings/{requirement.id}/mark-unavailable",
+        data={"vendor_name": "Acme", "reason": "sold_elsewhere"},
+    )
+    assert resp.status_code == 404
+
+
+def test_assign_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    resp = client.patch(
+        f"/v2/partials/sightings/{requirement.id}/assign",
+        data={"assigned_buyer_id": ""},
+    )
+    assert resp.status_code == 404
+
+
+def test_log_activity_blocks_non_owner_sales(client, db_session, _as_sales_nonowner):
+    req = _as_sales_nonowner
+    requirement = _requirement(db_session, req)
+    resp = client.post(
+        f"/v2/partials/sightings/{requirement.id}/log-activity",
+        data={"notes": "called vendor", "channel": "note"},
+    )
+    assert resp.status_code == 404
+
+
+# ── happy path: buyer (unrestricted) still allowed ─────────────────────────────
+
+
+def test_buyer_owner_advance_status_allowed(client, db_session, test_requisition):
+    """A buyer (default test_user role) is unrestricted — the guard is a no-op."""
+    requirement = _requirement(db_session, test_requisition)
+    resp = client.patch(
+        f"/v2/partials/sightings/{requirement.id}/advance-status",
+        data={"status": "sourcing"},
+    )
+    # Not a 404 from the ownership guard (transition validity aside).
+    assert resp.status_code != 404

--- a/tests/test_authz_ownership.py
+++ b/tests/test_authz_ownership.py
@@ -1,0 +1,85 @@
+"""Central requisition-ownership authorization helper.
+
+Policy (role-scoped, approved 2026-06-23): SALES and TRADER users may only act on
+requisitions they own (created_by) — or, for unscoped/scratch resources, ones they
+created themselves (owner_id fallback). BUYER / MANAGER / ADMIN are unrestricted. The
+single source of truth is dependencies.RESTRICTED_ROLES.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.constants import UserRole
+from app.dependencies import (
+    RESTRICTED_ROLES,
+    get_req_for_user,
+    require_requisition_access,
+)
+
+
+def _own(db, req, owner_id):
+    req.created_by = owner_id
+    db.commit()
+
+
+def test_restricted_roles_are_sales_and_trader():
+    assert RESTRICTED_ROLES == frozenset({UserRole.SALES, UserRole.TRADER})
+
+
+# ── require_requisition_access ───────────────────────────────────────────────
+def test_buyer_unrestricted_even_when_not_owner(db_session, test_requisition, test_user, admin_user):
+    _own(db_session, test_requisition, admin_user.id)  # owned by someone else
+    # test_user is a buyer → no exception
+    require_requisition_access(db_session, test_requisition.id, test_user)
+
+
+def test_sales_non_owner_blocked(db_session, test_requisition, sales_user, admin_user):
+    _own(db_session, test_requisition, admin_user.id)
+    with pytest.raises(HTTPException) as ei:
+        require_requisition_access(db_session, test_requisition.id, sales_user)
+    assert ei.value.status_code == 404
+
+
+def test_sales_owner_allowed(db_session, test_requisition, sales_user):
+    _own(db_session, test_requisition, sales_user.id)
+    require_requisition_access(db_session, test_requisition.id, sales_user)
+
+
+def test_trader_non_owner_blocked(db_session, test_requisition, trader_user, admin_user):
+    _own(db_session, test_requisition, admin_user.id)
+    with pytest.raises(HTTPException) as ei:
+        require_requisition_access(db_session, test_requisition.id, trader_user)
+    assert ei.value.status_code == 404
+
+
+def test_trader_owner_allowed(db_session, test_requisition, trader_user):
+    _own(db_session, test_requisition, trader_user.id)
+    require_requisition_access(db_session, test_requisition.id, trader_user)
+
+
+def test_owner_id_fallback_for_unscoped_resource(db_session, sales_user, admin_user):
+    # No requisition (e.g. scratch resource): restricted role allowed only if they own it.
+    require_requisition_access(db_session, None, sales_user, owner_id=sales_user.id)
+    with pytest.raises(HTTPException) as ei:
+        require_requisition_access(db_session, None, sales_user, owner_id=admin_user.id)
+    assert ei.value.status_code == 404
+
+
+def test_missing_requisition_blocked_for_restricted(db_session, sales_user):
+    with pytest.raises(HTTPException) as ei:
+        require_requisition_access(db_session, 999999, sales_user)
+    assert ei.value.status_code == 404
+
+
+# ── get_req_for_user now restricts TRADER too (was SALES-only) ────────────────
+def test_get_req_for_user_blocks_trader_non_owner(db_session, test_requisition, trader_user, admin_user):
+    _own(db_session, test_requisition, admin_user.id)
+    with pytest.raises(HTTPException) as ei:
+        get_req_for_user(db_session, trader_user, test_requisition.id)
+    assert ei.value.status_code == 404
+
+
+def test_get_req_for_user_allows_buyer_non_owner(db_session, test_requisition, test_user, admin_user):
+    _own(db_session, test_requisition, admin_user.id)
+    req = get_req_for_user(db_session, test_user, test_requisition.id)
+    assert req.id == test_requisition.id

--- a/tests/test_authz_remaining_fixes.py
+++ b/tests/test_authz_remaining_fixes.py
@@ -1,0 +1,181 @@
+"""Regression tests for the 8 endpoints the first apply pass missed (caught by re-
+audit).
+
+Covers: follow-up send (email), sourcing-lead status/feedback, sightings batch
+assign/status/notes, requisitions2 bulk action, and core batch-archive. A restricted
+non-owner must be unable to act on another user's requisition-scoped resource.
+"""
+
+import json
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.constants import UserRole
+from app.models.offers import Contact
+from app.models.sourcing import Requirement
+from app.models.sourcing_lead import SourcingLead
+
+
+def _requirement(db: Session, requisition) -> Requirement:
+    return db.query(Requirement).filter(Requirement.requisition_id == requisition.id).first()
+
+
+def _as_sales_non_owner(db, test_user, test_requisition, admin_user):
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id  # owned by someone else
+    db.commit()
+
+
+def _make_contact(db, requisition_id, user_id) -> Contact:
+    c = Contact(
+        requisition_id=requisition_id,
+        user_id=user_id,
+        contact_type="rfq",
+        vendor_name="Acme",
+        vendor_contact="sales@acme.example",
+        subject="RFQ",
+        status="sent",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(c)
+    db.commit()
+    db.refresh(c)
+    return c
+
+
+def _make_lead(db, requirement_id, requisition_id) -> SourcingLead:
+    lead = SourcingLead(
+        lead_id=f"L-{requirement_id}-{requisition_id}",
+        requirement_id=requirement_id,
+        requisition_id=requisition_id,
+        part_number_requested="P1",
+        part_number_matched="P1",
+        vendor_name="VendorCo",
+        vendor_name_normalized="vendorco",
+        primary_source_type="broker",
+        primary_source_name="src",
+    )
+    db.add(lead)
+    db.commit()
+    db.refresh(lead)
+    return lead
+
+
+# ── follow-up send (sends email) ─────────────────────────────────────────────
+def test_send_follow_up_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    c = _make_contact(db_session, test_requisition.id, admin_user.id)
+    resp = client.post(f"/v2/partials/follow-ups/{c.id}/send", data={"body": "should not send"})
+    assert resp.status_code == 404
+
+
+# ── sourcing leads ───────────────────────────────────────────────────────────
+def test_lead_status_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    req = _requirement(db_session, test_requisition)
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    lead = _make_lead(db_session, req.id, test_requisition.id)
+    resp = client.post(f"/v2/partials/sourcing/leads/{lead.id}/status", data={"status": "contacted"})
+    assert resp.status_code == 404
+
+
+def test_lead_feedback_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    req = _requirement(db_session, test_requisition)
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    lead = _make_lead(db_session, req.id, test_requisition.id)
+    resp = client.post(f"/v2/partials/sourcing/leads/{lead.id}/feedback", data={"note": "x"})
+    assert resp.status_code == 404
+
+
+# ── sightings batch (form-body multi-id) ─────────────────────────────────────
+def test_batch_assign_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    req = _requirement(db_session, test_requisition)
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    resp = client.post(
+        "/v2/partials/sightings/batch-assign",
+        data={"requirement_ids": json.dumps([req.id]), "buyer_id": str(admin_user.id)},
+    )
+    assert resp.status_code == 404
+    db_session.refresh(req)
+    assert req.assigned_buyer_id != admin_user.id
+
+
+def test_batch_status_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    req = _requirement(db_session, test_requisition)
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    resp = client.post(
+        "/v2/partials/sightings/batch-status",
+        data={"requirement_ids": json.dumps([req.id]), "status": "sourcing"},
+    )
+    assert resp.status_code == 404
+
+
+def test_batch_notes_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    req = _requirement(db_session, test_requisition)
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    resp = client.post(
+        "/v2/partials/sightings/batch-notes",
+        data={"requirement_ids": json.dumps([req.id]), "notes": "hi"},
+    )
+    assert resp.status_code == 404
+
+
+# ── requisitions2 bulk + core batch-archive now restrict TRADER too ──────────
+def test_bulk_action_silently_excludes_non_owner_trader(client, db_session, test_requisition, test_user, admin_user):
+    test_user.role = UserRole.TRADER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+    client.post("/requisitions2/bulk/archive", data={"ids": str(test_requisition.id)})
+    db_session.refresh(test_requisition)
+    assert test_requisition.status != "archived"  # trader non-owner cannot archive it
+
+
+def test_batch_archive_excludes_non_owner_trader(client, db_session, test_requisition, test_user, admin_user):
+    test_user.role = UserRole.TRADER
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+    resp = client.put("/api/requisitions/batch-archive", json={"ids": [test_requisition.id]})
+    assert resp.status_code == 200
+    db_session.refresh(test_requisition)
+    assert test_requisition.status != "archived"
+
+
+# ── parts bulk archive/unarchive + sightings batch-refresh (round-2 misses) ──
+def test_parts_bulk_archive_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    resp = client.post(
+        "/v2/partials/parts/bulk-archive",
+        json={"requisition_ids": [test_requisition.id], "requirement_ids": []},
+    )
+    assert resp.status_code == 404
+    db_session.refresh(test_requisition)
+    assert test_requisition.status != "archived"
+
+
+def test_parts_bulk_unarchive_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    resp = client.post(
+        "/v2/partials/parts/bulk-unarchive",
+        json={"requisition_ids": [test_requisition.id], "requirement_ids": []},
+    )
+    assert resp.status_code == 404
+
+
+def test_batch_refresh_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    req = _requirement(db_session, test_requisition)
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    resp = client.post(
+        "/v2/partials/sightings/batch-refresh",
+        data={"requirement_ids": json.dumps([req.id])},
+    )
+    assert resp.status_code == 404
+
+
+def test_preview_inquiry_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    req = _requirement(db_session, test_requisition)
+    _as_sales_non_owner(db_session, test_user, test_requisition, admin_user)
+    resp = client.post(
+        "/v2/partials/sightings/preview-inquiry",
+        data={"requirement_ids": str(req.id), "vendor_names": "Acme"},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Role-scoped authorization hardening ahead of the multi-user launch (~2 weeks). Sales/trader users may act only on requisitions they created; buyer/manager/admin are unrestricted.

A multi-agent IDOR audit found the requisition-ownership rule was enforced almost nowhere on mutating/sending endpoints (only a few list views). Under the role-scoped model these are real authorization gaps once multiple users exist.

## What changed
- **Single policy chokepoint:** `RESTRICTED_ROLES = {SALES, TRADER}` in `app/constants.py` + `require_requisition_access()` in `app/dependencies.py`. `get_req_for_user` / `get_quote_for_user` aligned to the same set (fixes a prior SALES-only inconsistency).
- **Guards applied** to every requisition-scoped mutating or email-sending endpoint across 12 files — including the `SourcingLead` class, form/JSON-body batch endpoints, follow-up send, and bulk paths that previously restricted SALES but not TRADER.
- **Regression tests** (`tests/test_authz_*.py`): a non-owner sales/trader user must get 404.
- APP_MAP architecture doc updated with the authorization model.

## Verification
- Adversarial re-audit loop converged remaining-IDOR count **8 → 3 → 0**.
- Full test suite: **18,682 passed, 0 failed**.
- ruff + mypy (pre-commit) clean.

## Notes
- 404 (not 403) is returned so resource existence isn't leaked.
- The `ai-email-drafting` branch pre-applied an inline version of this guard to 5 endpoints; it should rebase onto this branch at merge so both use the central helper.
- Must merge + deploy before multi-user go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2RvWabJWDFpnWqzAgxhxQ
