### PR TITLE
Add Qualify-with-AI: offer pre-fill + ask-the-vendor for missing details

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -3213,6 +3213,24 @@ async def send_reply_htmx(
     if not body:
         raise HTTPException(400, "Reply body is required")
 
+    # DNC hard-block — never email a do-not-contact vendor (checked in all modes).
+    if vr.vendor_email:
+        from sqlalchemy import func as _sqlfunc
+
+        dnc = (
+            db.query(SiteContact)
+            .filter(
+                _sqlfunc.lower(SiteContact.email) == vr.vendor_email.lower(),
+                SiteContact.do_not_contact.is_(True),
+            )
+            .first()
+        )
+        if dnc:
+            return HTMLResponse(
+                '<div class="rounded bg-rose-50 border border-rose-200 text-rose-700 text-xs px-2 py-1.5">'
+                "This vendor is on the do-not-contact list — reply not sent.</div>"
+            )
+
     is_testing = os.environ.get("TESTING") == "1"
     email_sent = False
 

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -2907,6 +2907,166 @@ async def sightings_offer_edit_form(
     return template_response("htmx/partials/sightings/offer_form_modal.html", ctx)
 
 
+def _offer_for_requirement_or_404(db: Session, requirement_id: int, offer_id: int):
+    requirement = db.get(Requirement, requirement_id)
+    offer = db.get(Offer, offer_id)
+    if not requirement or not offer or offer.requirement_id != requirement_id:
+        raise HTTPException(404, "Not found")
+    return requirement, offer
+
+
+@router.get(
+    "/v2/partials/sightings/{requirement_id}/offers/{offer_id}/qualify-ai",
+    response_class=HTMLResponse,
+)
+async def sightings_qualify_ai(
+    request: Request,
+    requirement_id: int,
+    offer_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    """Qualify-with-AI modal: parse the linked vendor email, pre-fill the offer form,
+    and compute the ask-the-vendor gap checklist. Read-only; nothing is sent or saved."""
+    from ..models.offers import VendorResponse
+    from ..services.offer_qualification import compute_qual_gaps, normalize_offer_condition
+    from ..services.response_parser import extract_draft_offers, parse_vendor_response
+
+    requirement, offer = _offer_for_requirement_or_404(db, requirement_id, offer_id)
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
+
+    vr = db.get(VendorResponse, offer.vendor_response_id) if offer.vendor_response_id else None
+    if not vr:
+        raise HTTPException(404, "No linked vendor email for this offer")
+
+    def _json_safe(v: object) -> object:
+        if v is None:
+            return ""
+        if isinstance(v, Decimal):
+            return str(v)
+        if isinstance(v, (date, datetime)):
+            return v.isoformat()
+        return v
+
+    fields = [
+        "vendor_name",
+        "mpn",
+        "manufacturer",
+        "qty_available",
+        "unit_price",
+        "lead_time",
+        "date_code",
+        "condition",
+        "packaging",
+        "firmware",
+        "hardware_code",
+        "moq",
+        "spq",
+        "warranty",
+        "country_of_origin",
+        "notes",
+    ]
+    prefill = {f: _json_safe(getattr(offer, f, None)) for f in fields}
+    _q = offer.qualification or {}
+    for _qk in (
+        "usage",
+        "refurbished_by",
+        "refurb_process",
+        "cert_doc",
+        "part_condition",
+        "provenance_story",
+        "terms",
+        "lead_time_reason",
+    ):
+        prefill[_qk] = _json_safe(_q.get(_qk))
+
+    rfq_context = {"mpn": requirement.primary_mpn, "qty": requirement.target_qty}
+    try:
+        parsed = await parse_vendor_response(vr.body or "", vr.subject or "", vr.vendor_name or "", rfq_context)
+    except Exception as exc:  # parse must never break the modal
+        logger.warning("qualify-ai parse failed for offer {}: {}", offer_id, exc)
+        parsed = None
+
+    confidence = None
+    ai_extract: dict = {}
+    if parsed:
+        confidence = parsed.get("confidence")
+        drafts = extract_draft_offers(parsed, vr.vendor_name or "")
+        if drafts:
+            ai_extract = next(
+                (d for d in drafts if (d.get("mpn") or "").lower() == (offer.mpn or "").lower()),
+                drafts[0],
+            )
+    # Overlay AI values onto EMPTY offer fields only — never clobber saved values.
+    for f in ("manufacturer", "qty_available", "unit_price", "lead_time", "date_code", "condition", "packaging", "moq"):
+        if prefill.get(f) in (None, "") and ai_extract.get(f) not in (None, ""):
+            prefill[f] = _json_safe(ai_extract.get(f))
+
+    condition = normalize_offer_condition(prefill.get("condition")) or prefill.get("condition")
+    gap_items = compute_qual_gaps(prefill, condition)
+
+    ctx = {
+        "request": request,
+        "requirement": requirement,
+        "offer": offer,
+        "prefill": prefill,
+        "gap_items": gap_items,
+        "confidence": confidence,
+        "vr": vr,
+    }
+    return template_response("htmx/partials/sightings/qual_request_modal.html", ctx)
+
+
+@router.post(
+    "/v2/partials/sightings/{requirement_id}/offers/{offer_id}/qualify-ai/draft-request",
+    response_class=HTMLResponse,
+)
+async def sightings_qualify_ai_draft(
+    request: Request,
+    requirement_id: int,
+    offer_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(require_user),
+):
+    """Draft a vendor reply asking for the chosen qualification items (AI-suggested gaps
+    the user kept, plus any custom items the user added).
+
+    Renders the editable compose box; sending goes through the existing send-reply path.
+    """
+    from ..models.offers import VendorResponse
+    from ..services.email_drafting import draft_email
+
+    requirement, offer = _offer_for_requirement_or_404(db, requirement_id, offer_id)
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
+
+    vr = db.get(VendorResponse, offer.vendor_response_id) if offer.vendor_response_id else None
+    if not vr:
+        raise HTTPException(404, "No linked vendor email for this offer")
+
+    form = await request.form()
+    checked = [c.strip() for c in form.getlist("checked_items") if c and c.strip()]
+    custom = [c.strip() for c in form.getlist("custom_items") if c and c.strip()]
+    items_requested = checked + custom
+
+    result = await draft_email(
+        "qual_request",
+        {"vendor_name": vr.vendor_name, "subject": vr.subject, "mpn": offer.mpn, "items_requested": items_requested},
+    )
+
+    default_subject = vr.subject or "RFQ"
+    if not default_subject.lower().startswith("re:"):
+        default_subject = f"Re: {default_subject}"
+    ctx = {
+        "request": request,
+        "req_id": offer.requisition_id,
+        "r": vr,
+        "reply_subject": (result or {}).get("subject") or default_subject,
+        "reply_body": (result or {}).get("body") or "",
+        "ai_failed": result is None,
+    }
+    return template_response("htmx/partials/requisitions/tabs/reply_compose.html", ctx)
+
+
 @router.post("/v2/partials/sightings/{requirement_id}/offers/{offer_id}", response_class=HTMLResponse)
 async def sightings_update_offer(
     request: Request,

--- a/app/services/email_drafting.py
+++ b/app/services/email_drafting.py
@@ -35,6 +35,13 @@ _VENDOR_REPLY_SYSTEM = (
     "Return JSON with two string fields: 'subject' and 'body'."
 )
 
+_QUAL_REQUEST_SYSTEM = (
+    "You are a concise procurement buyer replying to a vendor to qualify an offer. "
+    "Write a short, professional reply asking ONLY for the specific details listed — "
+    "nothing more. Do not restate what you already know. Return JSON with two string "
+    "fields: 'subject' and 'body'. Body is plain text, 2-5 sentences."
+)
+
 
 async def draft_email(kind: str, context: dict[str, Any]) -> dict | None:
     """Draft an email of ``kind`` from ``context``.
@@ -49,6 +56,8 @@ async def draft_email(kind: str, context: dict[str, Any]) -> dict | None:
         return await _draft_follow_up(context)
     if kind == "vendor_reply":
         return await _draft_vendor_reply(context)
+    if kind == "qual_request":
+        return await _draft_qual_request(context)
     raise ValueError(f"Unknown draft kind: {kind!r}")
 
 
@@ -119,6 +128,34 @@ async def _draft_vendor_reply(context: dict[str, Any]) -> dict | None:
         return None
     reply_subject = str(result.get("subject") or _reply_subject(subject)).strip()
     return {"subject": reply_subject, "body": str(result["body"]).strip()}
+
+
+async def _draft_qual_request(context: dict[str, Any]) -> dict | None:
+    vendor_name = context.get("vendor_name") or "there"
+    mpn = context.get("mpn") or ""
+    subject = _reply_subject(context.get("subject") or "RFQ")
+    items = [str(i).strip() for i in (context.get("items_requested") or []) if str(i).strip()]
+    items_str = "\n".join(f"- {i}" for i in items) if items else "- (no items specified)"
+    prompt = (
+        f"Vendor: {vendor_name}\n"
+        f"Part: {mpn}\n"
+        f"Details we still need to qualify this offer:\n{items_str}\n\n"
+        "Write the reply asking only for these items."
+    )
+    try:
+        result = await claude_json(
+            prompt,
+            system=_QUAL_REQUEST_SYSTEM,
+            model_tier=FAST,
+            max_tokens=400,
+            cost_bucket=_COST_BUCKET,
+        )
+    except ClaudeError as exc:
+        logger.warning("qual_request draft failed: {}", exc)
+        return None
+    if not isinstance(result, dict) or not result.get("body"):
+        return None
+    return {"subject": subject, "body": str(result["body"]).strip()}
 
 
 def _format_parts(parts: Any) -> str:

--- a/app/services/offer_qualification.py
+++ b/app/services/offer_qualification.py
@@ -147,6 +147,40 @@ def validate_essentials(condition: str | None, data: dict) -> list[str]:
     return errors
 
 
+# Ask-the-vendor checklist: (label, prefill_key, conditions where shown). Rows with
+# prefill_key=None (usage, part condition, refurb fields) are never auto-filled by the
+# parser, so they are always pre-checked when relevant.
+_QUAL_CHECKLIST: list[tuple[str, str | None, set[str]]] = [
+    ("Manufacturer", "manufacturer", {"new"}),
+    ("Packaging", "packaging", {"new_no_pkg", "pulls"}),
+    ("Usage (boards/systems)", None, {"pulls"}),
+    ("Part condition", None, {"pulls"}),
+    ("Refurbished by", None, {"refurb"}),
+    ("Refurb process", None, {"refurb"}),
+    ("Date code", "date_code", {"new", "new_no_pkg", "pulls", "refurb"}),
+    ("MOQ", "moq", {"new", "new_no_pkg", "pulls", "refurb"}),
+]
+
+
+def compute_qual_gaps(prefill: dict, condition: str | None) -> list[dict]:
+    """Build the ask-the-vendor checklist for an offer's parsed condition.
+
+    Returns ordered rows ``[{label, key, prechecked}]``. A row is PRE-CHECKED when its
+    value is missing after pre-fill (a genuine gap); fields the parser can never fill are
+    always pre-checked. Only rows relevant to ``condition`` are returned; empty list when
+    condition is unset.
+    """
+    if not condition:
+        return []
+    rows: list[dict] = []
+    for label, key, conds in _QUAL_CHECKLIST:
+        if condition not in conds:
+            continue
+        value = prefill.get(key) if key else None
+        rows.append({"label": label, "key": key, "prechecked": value in (None, "", [])})
+    return rows
+
+
 def compose_note(condition: str | None, data: dict) -> str:
     from app.utils.normalization import normalize_packaging as _norm_pkg
 

--- a/app/templates/htmx/partials/offers/_qual_checklist.html
+++ b/app/templates/htmx/partials/offers/_qual_checklist.html
@@ -1,0 +1,37 @@
+{# _qual_checklist.html — ask-the-vendor gap checklist with user-addable custom items.
+   Receives: requirement, offer, gap_items (list of {label, key, prechecked}).
+   Posts checked AI gaps + the user's own custom items to the draft-request route;
+   the drafted reply lands in #qual-compose-{offer.id}. #}
+<div class="mt-4 border-t border-gray-100 pt-3" x-data="{ customItems: [''] }">
+  <p class="text-xs font-semibold text-gray-700 mb-2">Missing to qualify — ask the vendor?</p>
+  <form hx-post="/v2/partials/sightings/{{ requirement.id }}/offers/{{ offer.id }}/qualify-ai/draft-request"
+        hx-target="#qual-compose-{{ offer.id }}" hx-swap="innerHTML" data-loading-disable
+        class="space-y-1.5">
+    {% for item in gap_items %}
+    <label class="flex items-center gap-2 text-sm text-gray-700">
+      <input type="checkbox" name="checked_items" value="{{ item.label }}"
+             {% if item.prechecked %}checked{% endif %}
+             class="rounded border-gray-300 text-brand-600 focus:ring-brand-500">
+      <span>{{ item.label }}</span>
+      {% if item.prechecked %}<span class="text-[11px] text-amber-600">missing</span>{% endif %}
+    </label>
+    {% endfor %}
+
+    {# Items the AI didn't suggest — the user can add any number of their own #}
+    <template x-for="(it, idx) in customItems" :key="idx">
+      <div class="flex items-center gap-2">
+        <input type="text" name="custom_items" x-model="customItems[idx]"
+               placeholder="Add your own request…"
+               class="flex-1 px-2 py-1 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
+        <button type="button" x-show="customItems.length > 1" @click="customItems.splice(idx, 1)"
+                class="text-gray-400 hover:text-rose-600 text-sm" aria-label="Remove item">&times;</button>
+      </div>
+    </template>
+    <button type="button" @click="customItems.push('')"
+            class="text-xs font-medium text-brand-600 hover:text-brand-700">+ Add item</button>
+
+    <div class="pt-2">
+      <button type="submit" class="btn btn-primary btn-sm">Draft request</button>
+    </div>
+  </form>
+</div>

--- a/app/templates/htmx/partials/sightings/_offer_row.html
+++ b/app/templates/htmx/partials/sightings/_offer_row.html
@@ -45,6 +45,10 @@
            class="absolute right-0 top-full mt-1 w-36 bg-white border border-gray-200 rounded-lg shadow-lg z-10 py-1 text-xs">
         <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/edit-form'}); open = false"
                 class="w-full text-left px-3 py-1.5 text-gray-700 hover:bg-gray-50">Edit</button>
+        {% if o.vendor_response_id %}
+        <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/qualify-ai'}); open = false"
+                class="w-full text-left px-3 py-1.5 text-brand-600 hover:bg-brand-50">Qualify with AI</button>
+        {% endif %}
         {% if o.status == 'pending_review' %}
         <button hx-post="/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/review"
                 hx-vals='{"action": "approve"}'

--- a/app/templates/htmx/partials/sightings/qual_request_modal.html
+++ b/app/templates/htmx/partials/sightings/qual_request_modal.html
@@ -1,0 +1,42 @@
+{# qual_request_modal.html — "Qualify with AI" modal loaded into #modal-content.
+   AI-prefilled offer form (same component + save path as the edit modal) + the
+   ask-the-vendor gap checklist + a compose pane for the drafted reply.
+   Receives: requirement, offer, prefill, gap_items, confidence, vr. #}
+<div class="p-4">
+  <h3 class="text-sm font-semibold text-gray-900 mb-2">Qualify with AI — {{ offer.vendor_name }}</h3>
+
+  {% if confidence is not none %}
+  <div class="mb-3 inline-flex items-center gap-1.5 text-xs rounded bg-brand-50 border border-brand-100 px-2 py-1 text-brand-700">
+    <span class="h-1.5 w-1.5 rounded-full {{ 'bg-emerald-500' if confidence >= 0.8 else 'bg-amber-500' if confidence >= 0.5 else 'bg-gray-400' }}"></span>
+    AI-filled from "{{ vr.subject or 'vendor email' }}" — {{ (confidence * 100)|round|int }}% · review before saving
+  </div>
+  {% else %}
+  <div class="mb-3 text-xs text-gray-400">AI pre-fill unavailable — review and fill manually.</div>
+  {% endif %}
+
+  {# Pre-filled offer form — same Alpine component and save path as the edit modal #}
+  <form x-data='offerQualification({{ (prefill or {})|tojson }})'
+        hx-post="/v2/partials/sightings/{{ requirement.id }}/offers/{{ offer.id }}"
+        hx-target="#sightings-offers-panel" hx-swap="innerHTML"
+        hx-on::after-request="if(event.detail.successful) $dispatch('close-modal')"
+        data-loading-disable class="space-y-3">
+    {% set mpn_default = requirement.primary_mpn %}
+    {% include "htmx/partials/offers/_offer_form_fields.html" %}
+    <div>
+      <label class="block text-xs text-gray-500 mb-1">Notes</label>
+      <textarea name="notes" rows="2"
+                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
+                placeholder="Any additional details...">{{ prefill.get('notes', '') if prefill else '' }}</textarea>
+    </div>
+    <div class="flex justify-end gap-2 pt-1">
+      <button type="button" @click="$dispatch('close-modal')" class="btn btn-ghost btn-sm">Cancel</button>
+      <button type="submit" :disabled="!essentialsMet()" class="btn btn-primary btn-sm">Save Offer</button>
+    </div>
+  </form>
+
+  {# Ask-the-vendor gap checklist (+ user-added custom items) #}
+  {% include "htmx/partials/offers/_qual_checklist.html" %}
+
+  {# Drafted reply appears here, then sends via the existing send-reply path #}
+  <div id="qual-compose-{{ offer.id }}"></div>
+</div>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1275,6 +1275,28 @@ Surfaces (all human-edit-before-send; nothing auto-sends):
 Gives `rephrase_rfq` and `VendorResponse.classification` their first live consumers.
 All paths degrade gracefully when Claude is unavailable (cost_bucket="email_drafting").
 
+### Qualify-with-AI (offer pre-fill + ask-the-vendor for what's missing)
+
+```
+Offer row kebab "Qualify with AI" (shown only when offer.vendor_response_id set)
+  GET /v2/partials/sightings/{requirement_id}/offers/{offer_id}/qualify-ai
+    --> parse_vendor_response(linked email) --> extract_draft_offers
+        --> pre-fill the offer form (AI fills EMPTY fields only; saved values win)
+    --> offer_qualification.compute_qual_gaps(prefill, condition)
+        --> condition-aware checklist (genuine gaps pre-checked)
+    --> qual_request_modal.html : pre-filled offer form (same save path as edit) +
+        _qual_checklist.html (gap checkboxes + user-addable custom items via "+ Add item")
+  POST .../offers/{offer_id}/qualify-ai/draft-request
+    checked_items[] (AI gaps kept) + custom_items[] (user's own, not AI-suggested)
+    --> draft_email("qual_request") --> reply_compose.html in #qual-compose-{offer_id}
+  Send → existing send-reply path (Graph as user; TESTING bypass)
+    --> NEW: DNC hard-block in send_reply_htmx (SiteContact.do_not_contact) — never emails DNC vendors
+```
+
+Ownership-guarded via require_requisition_access (offer.requisition_id, owner_id=entered_by_id).
+Read-only pre-fill; never auto-saves or auto-sends. Loop-closes: a vendor's reply becomes a new
+linked VendorResponse, so re-opening Qualify-with-AI fills the remaining fields.
+
 ## 8. Activity Digest (AI Timeline Summary)
 
 ```

--- a/tests/test_qualify_ai.py
+++ b/tests/test_qualify_ai.py
@@ -1,0 +1,233 @@
+"""Qualify-with-AI: ask-the-vendor checklist + qual_request drafting.
+
+Service layer — compute_qual_gaps (condition-aware gap checklist) and the
+draft_email 'qual_request' kind (drafts a vendor reply asking only for the
+chosen items, including user-added custom items the AI never suggested).
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.constants import UserRole
+from app.models.crm import CustomerSite, SiteContact
+from app.models.offers import Offer, VendorResponse
+from app.models.sourcing import Requirement
+from app.services import email_drafting
+from app.services.offer_qualification import compute_qual_gaps
+from app.utils.claude_errors import ClaudeError
+
+
+# ── compute_qual_gaps ────────────────────────────────────────────────────────
+def test_gaps_empty_when_no_condition():
+    assert compute_qual_gaps({}, None) == []
+
+
+def test_gaps_new_missing_manufacturer_prechecked():
+    items = compute_qual_gaps({"condition": "new"}, "new")
+    by = {i["label"]: i for i in items}
+    assert by["Manufacturer"]["prechecked"] is True
+    # date code / MOQ shown as meter items, prechecked when empty
+    assert by["Date code"]["prechecked"] is True
+
+
+def test_gaps_new_manufacturer_present_unchecked():
+    items = compute_qual_gaps({"condition": "new", "manufacturer": "TI"}, "new")
+    by = {i["label"]: i for i in items}
+    assert by["Manufacturer"]["prechecked"] is False
+
+
+def test_gaps_pulls_always_asks_usage_and_part_condition():
+    # usage / part_condition are never auto-fillable → always pre-checked for pulls
+    items = compute_qual_gaps({"condition": "pulls", "packaging": "Tray"}, "pulls")
+    by = {i["label"]: i for i in items}
+    assert by["Usage (boards/systems)"]["prechecked"] is True
+    assert by["Part condition"]["prechecked"] is True
+    assert by["Packaging"]["prechecked"] is False  # present
+
+
+def test_gaps_refurb_asks_refurb_fields():
+    items = compute_qual_gaps({"condition": "refurb"}, "refurb")
+    by = {i["label"]: i for i in items}
+    assert by["Refurbished by"]["prechecked"] is True
+    assert by["Refurb process"]["prechecked"] is True
+
+
+def test_gaps_only_show_rows_relevant_to_condition():
+    labels = {i["label"] for i in compute_qual_gaps({"condition": "new"}, "new")}
+    assert "Usage (boards/systems)" not in labels  # pulls-only
+    assert "Refurbished by" not in labels  # refurb-only
+
+
+# ── draft_email('qual_request') ──────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_qual_request_returns_subject_and_body():
+    with patch.object(email_drafting, "claude_json", new_callable=AsyncMock) as m:
+        m.return_value = {"body": "Could you confirm the date code and MOQ?"}
+        result = await email_drafting.draft_email(
+            "qual_request",
+            {
+                "vendor_name": "Acme",
+                "subject": "RFQ - LM358N",
+                "mpn": "LM358N",
+                "items_requested": ["Date code", "MOQ"],
+            },
+        )
+    assert result is not None
+    assert result["subject"].lower().startswith("re:")
+    assert "date code" in result["body"].lower()
+
+
+@pytest.mark.asyncio
+async def test_qual_request_includes_user_added_custom_items():
+    # The user can add items the AI never suggested; they must reach the prompt.
+    with patch.object(email_drafting, "claude_json", new_callable=AsyncMock) as m:
+        m.return_value = {"body": "Please share the RoHS certificate and country of origin."}
+        await email_drafting.draft_email(
+            "qual_request",
+            {
+                "vendor_name": "Acme",
+                "subject": "RFQ",
+                "mpn": "LM358N",
+                "items_requested": ["RoHS certificate", "Country of origin"],
+            },
+        )
+    prompt = m.call_args[0][0]
+    assert "RoHS certificate" in prompt
+    assert "Country of origin" in prompt
+
+
+@pytest.mark.asyncio
+async def test_qual_request_none_on_claude_error():
+    with patch.object(email_drafting, "claude_json", new_callable=AsyncMock) as m:
+        m.side_effect = ClaudeError("boom")
+        result = await email_drafting.draft_email("qual_request", {"vendor_name": "Acme", "items_requested": ["X"]})
+    assert result is None
+
+
+# ── Routes (GET prefill+gaps, POST draft-request, DNC send guard) ────────────
+def _setup_offer_with_email(db, requisition, owner_id, *, condition="new", with_email=True):
+    req = db.query(Requirement).filter(Requirement.requisition_id == requisition.id).first()
+    vr = None
+    if with_email:
+        vr = VendorResponse(
+            requisition_id=requisition.id,
+            vendor_name="Acme",
+            vendor_email="sales@acme.example",
+            subject="RE: RFQ - LM317T",
+            body="We can do 5000 pcs at $0.38.",
+            classification="quote_provided",
+            status="new",
+            received_at=datetime.now(timezone.utc),
+        )
+        db.add(vr)
+        db.commit()
+        db.refresh(vr)
+    o = Offer(
+        requisition_id=requisition.id,
+        requirement_id=req.id,
+        vendor_name="Acme",
+        mpn="LM317T",
+        unit_price=0.38,
+        condition=condition,
+        entered_by_id=owner_id,
+        status="pending_review",
+        vendor_response_id=(vr.id if vr else None),
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(o)
+    db.commit()
+    db.refresh(o)
+    return req, vr, o
+
+
+_PARSED = {
+    "confidence": 0.9,
+    "parts": [{"status": "quoted", "mpn": "LM317T", "unit_price": 0.38, "manufacturer": "TI", "date_code": None}],
+}
+
+
+def test_qualify_ai_get_renders_form_and_gaps(client, db_session, test_requisition, test_user):
+    _req, _vr, o = _setup_offer_with_email(db_session, test_requisition, test_user.id, condition="new")
+    with patch("app.services.response_parser.parse_vendor_response", new_callable=AsyncMock) as m:
+        m.return_value = _PARSED
+        resp = client.get(f"/v2/partials/sightings/{o.requirement_id}/offers/{o.id}/qualify-ai")
+    assert resp.status_code == 200
+    assert "Qualify with AI" in resp.text
+    assert "Draft request" in resp.text
+    assert "+ Add item" in resp.text  # user can add items the AI didn't suggest
+    assert "Date code" in resp.text  # a computed gap row for condition=new
+
+
+def test_qualify_ai_get_404_without_linked_email(client, db_session, test_requisition, test_user):
+    _req, _vr, o = _setup_offer_with_email(db_session, test_requisition, test_user.id, with_email=False)
+    resp = client.get(f"/v2/partials/sightings/{o.requirement_id}/offers/{o.id}/qualify-ai")
+    assert resp.status_code == 404
+
+
+def test_qualify_ai_get_blocks_non_owner_sales(client, db_session, test_requisition, test_user, admin_user):
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+    _req, _vr, o = _setup_offer_with_email(db_session, test_requisition, admin_user.id)
+    resp = client.get(f"/v2/partials/sightings/{o.requirement_id}/offers/{o.id}/qualify-ai")
+    assert resp.status_code == 404
+
+
+def test_qualify_ai_draft_request_merges_ai_and_custom_items(client, db_session, test_requisition, test_user):
+    _req, _vr, o = _setup_offer_with_email(db_session, test_requisition, test_user.id)
+    with patch("app.services.email_drafting.draft_email", new_callable=AsyncMock) as m:
+        m.return_value = {"subject": "Re: RFQ", "body": "Please confirm date code and RoHS."}
+        resp = client.post(
+            f"/v2/partials/sightings/{o.requirement_id}/offers/{o.id}/qualify-ai/draft-request",
+            data={"checked_items": ["Date code"], "custom_items": ["RoHS certificate", ""]},
+        )
+    assert resp.status_code == 200
+    assert "Please confirm date code and RoHS." in resp.text
+    assert "send-reply" in resp.text and "<textarea" in resp.text
+    items = m.call_args[0][1]["items_requested"]
+    assert "Date code" in items and "RoHS certificate" in items and "" not in items
+
+
+def test_qualify_ai_draft_request_custom_only(client, db_session, test_requisition, test_user):
+    _req, _vr, o = _setup_offer_with_email(db_session, test_requisition, test_user.id)
+    with patch("app.services.email_drafting.draft_email", new_callable=AsyncMock) as m:
+        m.return_value = {"subject": "Re: RFQ", "body": "Please share country of origin."}
+        resp = client.post(
+            f"/v2/partials/sightings/{o.requirement_id}/offers/{o.id}/qualify-ai/draft-request",
+            data={"custom_items": ["Country of origin"]},
+        )
+    assert resp.status_code == 200
+    assert m.call_args[0][1]["items_requested"] == ["Country of origin"]
+
+
+def test_send_reply_blocks_dnc_vendor(client, db_session, test_requisition, test_company):
+    site = CustomerSite(company_id=test_company.id, site_name="Acme")
+    db_session.add(site)
+    db_session.commit()
+    db_session.refresh(site)
+    vr = VendorResponse(
+        requisition_id=test_requisition.id,
+        vendor_name="Acme",
+        vendor_email="dnc@acme.example",
+        subject="RE: RFQ",
+        body="x",
+        classification="quote_provided",
+        status="new",
+        received_at=datetime.now(timezone.utc),
+    )
+    db_session.add(vr)
+    db_session.add(
+        SiteContact(customer_site_id=site.id, full_name="Acme", email="dnc@acme.example", do_not_contact=True)
+    )
+    db_session.commit()
+    db_session.refresh(vr)
+    resp = client.post(
+        f"/v2/partials/requisitions/{test_requisition.id}/responses/{vr.id}/send-reply",
+        data={"subject": "Re: RFQ", "body": "asking for info"},
+    )
+    assert resp.status_code == 200
+    assert "do-not-contact" in resp.text
+    db_session.refresh(vr)
+    assert vr.status != "reviewed"  # blocked, not sent


### PR DESCRIPTION
## Summary
**Idea 1 — Qualify-with-AI + ask-the-vendor.** A one-click "Qualify with AI" action on any offer that has a linked vendor email: it reads the email, pre-fills the offer qualification form, and surfaces a *condition-aware* checklist of what's still missing to qualify — which the user sends back to the vendor as a drafted reply. Everything is human-confirmed; nothing auto-saves or auto-sends.

Builds on the email-drafting engine from #442 (now on main).

## Flow
- **Kebab → "Qualify with AI"** (shown only when `offer.vendor_response_id` is set) opens a modal:
  - **Pre-filled offer form** — `parse_vendor_response` → `extract_draft_offers`; AI fills only *empty* fields (saved values always win). Same form + save path as the edit modal.
  - **"Missing to qualify — ask the vendor?" checklist** — `compute_qual_gaps(prefill, condition)` shows only the rows relevant to the parsed condition (new / new-no-pkg / pulls / refurb), with genuine gaps pre-checked.
  - **The user can add items the AI didn't suggest** — a "+ Add item" control adds any number of custom request lines.
- **Draft request** → `draft_email('qual_request', …)` merges kept AI gaps **+ the user's custom items** into a short vendor reply, shown in an editable box.
- **Send** → the existing send-reply path (Graph as the signed-in user; TESTING bypass).

## Security
- Every endpoint is ownership-guarded via `require_requisition_access` (offer → requisition, `owner_id=entered_by_id`).
- **New DNC hard-block** added to `send_reply_htmx`: a vendor on the do-not-contact list is never emailed (checked in all modes).

## Verification
- **15 new tests** (`tests/test_qualify_ai.py`): gap computation per condition, `qual_request` drafting incl. user-custom items, route prefill/gaps, ownership-blocked, DNC-blocked, and the AI-gap **+ custom-item merge**.
- Full suite green (18,774); ruff + mypy clean. APP_MAP updated.

## Notes
- Read-only pre-fill — never auto-saves the offer or auto-sends.
- Loop-closes naturally: a vendor's reply becomes a new linked `VendorResponse`, so re-opening Qualify-with-AI fills the remaining fields.
- Threading uses `Re:`-subject (same as #442); true Graph threading remains a future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2RvWabJWDFpnWqzAgxhxQ
