### PR TITLE
Add reply-likelihood vendor ranking in the RFQ composer

### DIFF
--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -1361,6 +1361,7 @@ class RankedVendor(NamedTuple):
     has_contact: bool
     lead_time_days: int | None = None
     vendor_score: float | None = None
+    email_health_score: float | None = None
 
 
 class CoverageEntry(TypedDict):
@@ -1402,6 +1403,7 @@ class SuggestedVendor(NamedTuple):
     engagement_score: float | None
     vendor_score: float | None = None
     lead_time_days: int | None = None
+    email_health_score: float | None = None
 
 
 def _cards_with_resolvable_email(db: Session, card_ids: list[int]) -> set[int]:
@@ -1550,7 +1552,7 @@ def _coverage_ranked_vendor_rows(db: Session, req_id_list: list[int], excluded: 
     # has_contact: one batched VendorContact lookup over all representative card ids.
     contactable_card_ids = _cards_with_resolvable_email(db, [g["card"].id for g in groups.values() if g["card"]])
 
-    ranked: list[tuple[int, bool, float, tuple[int, object], RankedVendor]] = []
+    ranked: list[tuple[int, bool, float, float, tuple[int, object], RankedVendor]] = []
     for key, g in groups.items():
         card = g["card"]
         excl_key: object
@@ -1569,6 +1571,7 @@ def _coverage_ranked_vendor_rows(db: Session, req_id_list: list[int], excluded: 
         has_contact = card is not None and card.id in contactable_card_ids
         lead_times = g["lead_times"]
         lead_time_days = min(lead_times) if lead_times else None
+        email_health = card.email_health_score if (card is not None and card.email_health_score is not None) else None
         rv = RankedVendor(
             card=card,
             vendor_name=display,
@@ -1577,6 +1580,7 @@ def _coverage_ranked_vendor_rows(db: Session, req_id_list: list[int], excluded: 
             has_contact=has_contact,
             lead_time_days=lead_time_days,
             vendor_score=(card.vendor_score if card is not None else None),
+            email_health_score=email_health,
         )
         engagement = card.engagement_score if (card is not None and card.engagement_score is not None) else None
         # Stable, deterministic tiebreak (F-L1): carded ties keep NUMERIC card.id order
@@ -1584,19 +1588,22 @@ def _coverage_ranked_vendor_rows(db: Session, req_id_list: list[int], excluded: 
         # was lexicographic ("10" < "2"), drifting which equally-ranked vendor fell off the
         # cap-20 vs main's numeric id order.
         tiebreak: tuple[int, object] = (0, card.id) if card is not None else (1, str(key))
-        # Sort tuple: covered desc, has_contact desc, engagement desc nullslast, then tiebreak.
+        # Sort tuple: covered desc, has_contact desc, reply-health desc nullslast,
+        # engagement desc nullslast, then tiebreak. Coverage stays dominant; email
+        # health (likelihood of a useful reply) ranks vendors within a coverage tier.
         ranked.append(
             (
                 -covered,
                 not has_contact,  # False(0) sorts before True(1) → contactable first
+                -(email_health if email_health is not None else float("-inf")),
                 -(engagement if engagement is not None else float("-inf")),
                 tiebreak,
                 rv,
             )
         )
 
-    ranked.sort(key=lambda t: (t[0], t[1], t[2], t[3]))
-    return [t[4] for t in ranked[:20]]
+    ranked.sort(key=lambda t: (t[0], t[1], t[2], t[3], t[4]))
+    return [t[5] for t in ranked[:20]]
 
 
 def _find_affinity_in_thread(mpn: str) -> list[dict]:
@@ -1670,6 +1677,7 @@ async def sightings_vendor_modal(
                     engagement_score=(r.card.engagement_score if r.card is not None else None),
                     vendor_score=r.vendor_score,
                     lead_time_days=r.lead_time_days,
+                    email_health_score=r.email_health_score,
                 )
             )
             coverage[key] = CoverageEntry(
@@ -1733,6 +1741,7 @@ async def sightings_vendor_modal(
                     engagement_score=card.engagement_score,
                     vendor_score=card.vendor_score,
                     lead_time_days=None,  # preselect-only: no VSS context to compute min
+                    email_health_score=card.email_health_score,
                 )
             else:
                 # No matching card — cardless synthetic row, no contact resolvable
@@ -1747,6 +1756,7 @@ async def sightings_vendor_modal(
                     engagement_score=None,
                     vendor_score=None,
                     lead_time_days=None,
+                    email_health_score=None,
                 )
             suggested_vendors.append(sv)
             existing_norms.add(norm)

--- a/app/templates/htmx/partials/sightings/vendor_modal.html
+++ b/app/templates/htmx/partials/sightings/vendor_modal.html
@@ -62,6 +62,9 @@
           {% elif v.vendor_score is not none %}
           <span class="text-xs text-gray-400">Score: {{ v.vendor_score|round|int }}</span>
           {% endif %}
+          {% if v.email_health_score is not none %}
+          <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-indigo-50 text-indigo-700">{{ v.email_health_score|round|int }} reply health</span>
+          {% endif %}
         </label>
         {% elif v.has_contact and is_dnc %}
         {# DNC row — has an email but it is do-not-contact flagged. Disabled checkbox +

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -935,7 +935,12 @@ the `rfqVendorModal` section below) is fed from four sources:
    `''`-email contact can't win and resolve `vendor_email=''` → skip while the badge said
    contactable (the empty-email asymmetry). `card.emails` is deliberately NOT consulted
    (the send path resolves the address only from `VendorContact` rows), so the "no contact
-   on file" badge never lies.
+   on file" badge never lies. **Reply-likelihood ranking:** within a coverage tier the sort
+   now ranks by `VendorCard.email_health_score` (the nightly response-health composite from
+   `response_analytics`, previously persisted but unconsumed) — full key is `covered_count
+   desc, has_contact desc, email_health_score desc nullslast, engagement_score desc nullslast,
+   tiebreak` — and each carded row renders a "N reply health" chip. Coverage and contactability
+   stay dominant; reply health only orders vendors *within* a tier.
    Order: `covered_count` desc, then `has_contact` desc (contactable above
    equal-coverage non-contactable), then engagement desc nullslast, then a stable,
    deterministic tiebreak — `(0, card.id)` for carded (numeric id order, matching main;

--- a/tests/test_vendor_reply_ranking.py
+++ b/tests/test_vendor_reply_ranking.py
@@ -1,0 +1,90 @@
+"""Idea 3 — reply-likelihood vendor ranking.
+
+Wire the already-persisted VendorCard.email_health_score into the RFQ-composer vendor
+sort (a tiebreaker within a coverage tier) and thread it onto the ranked rows so the
+modal can render a "reply health" chip. Coverage stays dominant.
+"""
+
+from app.models.sourcing import Requirement, Requisition
+from app.models.vendor_sighting_summary import VendorSightingSummary
+from app.models.vendors import VendorCard
+from app.routers.sightings import _coverage_ranked_vendor_rows
+
+
+def _seed(db, healths):
+    req = Requisition(name="Rank RFQ", status="active", customer_name="X")
+    db.add(req)
+    db.flush()
+    r = Requirement(requisition_id=req.id, primary_mpn="RANK-1", target_qty=10, sourcing_status="open")
+    db.add(r)
+    db.flush()
+    for name, health in healths:
+        card = VendorCard(normalized_name=name.lower(), display_name=name, email_health_score=health)
+        db.add(card)
+        db.flush()
+        db.add(
+            VendorSightingSummary(
+                requirement_id=r.id,
+                vendor_name=name,
+                vendor_card_id=card.id,
+                estimated_qty=10,
+                listing_count=1,
+                score=50.0,
+            )
+        )
+    db.commit()
+    return r
+
+
+def test_higher_reply_health_ranks_first_within_coverage_tier(db_session):
+    r = _seed(db_session, [("Vendor Low", 10.0), ("Vendor High", 90.0)])
+    rows = _coverage_ranked_vendor_rows(db_session, [r.id], set())
+    names = [row.vendor_name for row in rows]
+    assert names.index("Vendor High") < names.index("Vendor Low")
+
+
+def test_email_health_threaded_onto_ranked_row(db_session):
+    r = _seed(db_session, [("Vendor High", 90.0)])
+    rows = _coverage_ranked_vendor_rows(db_session, [r.id], set())
+    by = {row.vendor_name: row for row in rows}
+    assert by["Vendor High"].email_health_score == 90.0
+
+
+def test_coverage_still_dominates_reply_health(db_session):
+    # A vendor covering MORE parts outranks a higher-reply-health vendor covering fewer.
+    req = Requisition(name="Cov RFQ", status="active", customer_name="X")
+    db_session.add(req)
+    db_session.flush()
+    r1 = Requirement(requisition_id=req.id, primary_mpn="A", target_qty=1, sourcing_status="open")
+    r2 = Requirement(requisition_id=req.id, primary_mpn="B", target_qty=1, sourcing_status="open")
+    db_session.add_all([r1, r2])
+    db_session.flush()
+    broad = VendorCard(normalized_name="broad", display_name="Broad", email_health_score=5.0)
+    narrow = VendorCard(normalized_name="narrow", display_name="Narrow", email_health_score=99.0)
+    db_session.add_all([broad, narrow])
+    db_session.flush()
+    for rid in (r1.id, r2.id):
+        db_session.add(
+            VendorSightingSummary(
+                requirement_id=rid,
+                vendor_name="Broad",
+                vendor_card_id=broad.id,
+                estimated_qty=1,
+                listing_count=1,
+                score=50.0,
+            )
+        )
+    db_session.add(
+        VendorSightingSummary(
+            requirement_id=r1.id,
+            vendor_name="Narrow",
+            vendor_card_id=narrow.id,
+            estimated_qty=1,
+            listing_count=1,
+            score=50.0,
+        )
+    )
+    db_session.commit()
+    rows = _coverage_ranked_vendor_rows(db_session, [r1.id, r2.id], set())
+    names = [row.vendor_name for row in rows]
+    assert names.index("Broad") < names.index("Narrow")  # 2 parts beats higher reply health on 1


### PR DESCRIPTION
## Summary
**Idea 3 — reply-likelihood vendor ranking.** The RFQ composer ranked vendors by coverage only, so brokers kept soliciting high-coverage vendors who never reply. `VendorCard.email_health_score` (a 0–100 response-health composite computed nightly by `response_analytics`) was persisted but had **zero consumers**. This wires it into the composer's ranking and surfaces it.

## What changed
- **Sort:** `_coverage_ranked_vendor_rows` now ranks by `email_health_score` as a *within-tier* key — full order: `covered_count desc → has_contact desc → email_health_score desc (nullslast) → engagement_score desc (nullslast) → tiebreak`. Coverage and contactability stay dominant; reply health only orders vendors inside a tier.
- **Thread-through:** added `email_health_score` to the `RankedVendor` and `SuggestedVendor` NamedTuples and every construction site (carded → the card's score; cardless/preselect → None).
- **UI:** a compact indigo **"N reply health"** chip beside the existing Score badge in the vendor modal (carded rows only).
- No new model, column, or migration — pure wiring of existing data. No LLM call.

## Verification
- **3 unit tests** (`tests/test_vendor_reply_ranking.py`): higher reply-health ranks first within a coverage tier, the score is threaded onto the ranked row, and **coverage still dominates** (more parts beats higher reply-health on fewer).
- Full suite green (18,873); the existing vendor-modal tests exercise the new chip. ruff + mypy clean. APP_MAP updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2RvWabJWDFpnWqzAgxhxQ
