### PR TITLE
Rename module Trading → Resell (UI + routes + code identity)

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -140,10 +140,10 @@ class SourcingStatus(StrEnum):
 class ExcessListStatus(StrEnum):
     """Status lifecycle for ExcessList records.
 
-    Trading (resell-brokerage) lifecycle: draft -> open -> collecting -> bid_out
+    Resell (resell-brokerage) lifecycle: draft -> open -> collecting -> bid_out
     -> awarded -> closed/expired. The new members are chosen to map onto existing
     ``status_badge`` keys (open->sky, collecting/sourcing->amber, bid_out/quoted->
-    violet, awarded/won->emerald). ACTIVE / BIDDING are the pre-Trading members,
+    violet, awarded/won->emerald). ACTIVE / BIDDING are the pre-Resell members,
     kept for backward-compat (additive reshape — a later cutover chunk retires them).
     """
 

--- a/app/main.py
+++ b/app/main.py
@@ -564,10 +564,10 @@ from .routers.proactive import router as proactive_router
 from .routers.quote_builder import router as quote_builder_router
 from .routers.requisitions import router as reqs_router
 from .routers.requisitions2 import router as requisitions2_router
+from .routers.resell import router as resell_router
 from .routers.sightings import router as sightings_router
 from .routers.sources import router as sources_router
 from .routers.tags import router as tags_router
-from .routers.trading import router as trading_router
 from .routers.v13_features import router as v13_router
 from .routers.vendor_contacts import router as vendor_contacts_router
 from .routers.vendors_crud import router as vendors_crud_router
@@ -592,7 +592,7 @@ app.include_router(requisitions2_router)
 app.include_router(sightings_router)
 app.include_router(sources_router)
 app.include_router(tags_router)
-app.include_router(trading_router)
+app.include_router(resell_router)
 app.include_router(v13_router)
 app.include_router(vendor_contacts_router)
 app.include_router(vendors_crud_router)

--- a/app/management/seed_resell_demo.py
+++ b/app/management/seed_resell_demo.py
@@ -1,10 +1,10 @@
-"""seed_trading_demo.py — Idempotent demo seed for the Trading workspace (Chunk F).
+"""seed_resell_demo.py — Idempotent demo seed for the Resell workspace (Chunk F).
 
-Run after deploy so the user can open ``/v2/trading`` on staging and judge the look
+Run after deploy so the user can open ``/v2/resell`` on staging and judge the look
 across all three deal shapes:
 
-    python -m app.management.seed_trading_demo          # seed / re-seed (idempotent)
-    python -m app.management.seed_trading_demo --reset  # delete the demo data first
+    python -m app.management.seed_resell_demo          # seed / re-seed (idempotent)
+    python -m app.management.seed_resell_demo --reset  # delete the demo data first
 
 Creates (all find-or-create by a stable key — safe to re-run; never duplicates):
   • a trader USER (the list owner) and a buyer USER (the offering broker — passes the
@@ -113,7 +113,7 @@ def _get_or_create_user(db: Session, email: str, name: str, role: str) -> User:
         user = User(email=email, name=name, role=role, created_at=_now())
         db.add(user)
         db.flush()
-        logger.info("seed-trading: created user {} ({})", email, role)
+        logger.info("seed-resell: created user {} ({})", email, role)
     return user
 
 
@@ -123,7 +123,7 @@ def _get_or_create_company(db: Session, name: str) -> Company:
         co = Company(name=name, account_type="Customer", is_active=True, created_at=_now())
         db.add(co)
         db.flush()
-        logger.info("seed-trading: created company {}", name)
+        logger.info("seed-resell: created company {}", name)
     return co
 
 
@@ -150,7 +150,7 @@ def _get_or_create_list(
         el.close_at = _now() + timedelta(days=close_in_days)
     db.add(el)
     db.flush()
-    logger.info("seed-trading: created list {!r} (status={})", title, status)
+    logger.info("seed-resell: created list {!r} (status={})", title, status)
     return el, True
 
 
@@ -250,7 +250,7 @@ def _build_collecting(db: Session, company: Company, owner: User, broker: User) 
         take_all_total_price=Decimal("48500.00"),
     )
     db.commit()
-    logger.info("seed-trading: seeded offers (per-line + unmatched + take-all) on {!r}", el.title)
+    logger.info("seed-resell: seeded offers (per-line + unmatched + take-all) on {!r}", el.title)
 
 
 def _build_oneoff(db: Session, company: Company, owner: User, broker: User) -> None:
@@ -299,7 +299,7 @@ def _build_oneoff(db: Session, company: Company, owner: User, broker: User) -> N
         ],
     )
     db.commit()
-    logger.info("seed-trading: seeded 2 offers on the one-off {!r}", el.title)
+    logger.info("seed-resell: seeded 2 offers on the one-off {!r}", el.title)
 
 
 def _build_awarded(db: Session, company: Company, owner: User) -> None:
@@ -317,7 +317,7 @@ def _build_awarded(db: Session, company: Company, owner: User) -> None:
             item.status = ExcessLineItemStatus.AWARDED
         el.total_line_items = 6
         db.commit()
-    logger.info("seed-trading: ensured awarded list {!r}", el.title)
+    logger.info("seed-resell: ensured awarded list {!r}", el.title)
 
 
 # ── reset ────────────────────────────────────────────────────────────
@@ -337,7 +337,7 @@ def _reset(db: Session) -> None:
     if co:
         db.delete(co)
     db.commit()
-    logger.info("seed-trading: reset complete ({} demo lists removed)", len(lists))
+    logger.info("seed-resell: reset complete ({} demo lists removed)", len(lists))
 
 
 # ── entry point ──────────────────────────────────────────────────────
@@ -353,7 +353,7 @@ def seed(db: Session) -> None:
     _build_collecting(db, company, trader, broker)
     _build_oneoff(db, company, trader, broker)
     _build_awarded(db, company, trader)
-    logger.info("seed-trading: done — open /v2/trading as the Demo Trader to view all three shapes.")
+    logger.info("seed-resell: done — open /v2/resell as the Demo Trader to view all three shapes.")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -41,7 +41,7 @@ from .enrichment_run import EnrichmentRun  # noqa: F401
 # Enrichment Worker Status
 from .enrichment_worker_status import EnrichmentWorkerStatus  # noqa: F401
 
-# Excess Inventory / Trading (resell-brokerage) offers
+# Excess Inventory / Resell (resell-brokerage) offers
 from .excess import (  # noqa: F401
     CustomerBid,
     CustomerBidLine,

--- a/app/models/excess.py
+++ b/app/models/excess.py
@@ -1,6 +1,6 @@
-"""Excess Inventory & Trading (resell-brokerage) models.
+"""Excess Inventory & Resell (resell-brokerage) models.
 
-Data models for the Trading workspace: customers post excess/surplus inventory
+Data models for the Resell workspace: customers post excess/surplus inventory
 (ExcessList / ExcessLineItem), brokers submit offers to buy (ExcessOffer /
 ExcessOfferLine), and the trader assembles a clean bid back to the seller
 (CustomerBid / CustomerBidLine). This is the reverse of sourcing: the customer
@@ -12,7 +12,7 @@ Business Rules:
 - ExcessOffers are inbound broker offers to buy (per_line or take_all)
 - CustomerBids are the outbound clean bid back to the seller
 
-Called by: routers/trading.py, services/excess_service.py
+Called by: routers/resell.py, services/excess_service.py
 Depends on: models/base, models with Company, User, VendorCard, CustomerSite
 """
 
@@ -128,7 +128,7 @@ class ExcessLineItem(Base):
 class ExcessOffer(Base):
     """Inbound offer from another broker to BUY a posted excess list.
 
-    The Trading-module replacement for the per-line, money-required ``Bid``. An offer
+    The Resell-module replacement for the per-line, money-required ``Bid``. An offer
     is either ``per_line`` (carries ``ExcessOfferLine`` rows, one per part the broker
     will buy) or ``take_all`` (binds the whole list, no line rows, optional lump
     ``take_all_total_price``). Matching is part-number only; ``unit_price`` is collected

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -295,8 +295,8 @@ async def quotes_list_redirect():
 @router.get("/v2/customers/{company_id:int}", response_class=HTMLResponse)
 @router.get("/v2/buy-plans", response_class=HTMLResponse)
 @router.get("/v2/buy-plans/{bp_id:int}", response_class=HTMLResponse)
-@router.get("/v2/trading", response_class=HTMLResponse)
-@router.get("/v2/trading/{list_id:int}", response_class=HTMLResponse)
+@router.get("/v2/resell", response_class=HTMLResponse)
+@router.get("/v2/resell/{list_id:int}", response_class=HTMLResponse)
 @router.get("/v2/quotes/{quote_id:int}", response_class=HTMLResponse)
 @router.get("/v2/settings", response_class=HTMLResponse)
 @router.get("/v2/prospecting", response_class=HTMLResponse)
@@ -322,7 +322,7 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
     # /requisitions). Anything unmatched defaults to the requisitions view.
     _VIEW_SEGMENTS = (
         "buy-plans",
-        "trading",
+        "resell",
         "quotes",
         "prospecting",
         "proactive",
@@ -349,8 +349,8 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
         partial_url = "/v2/partials/crm/shell"
     elif current_view == "sightings":
         partial_url = "/v2/partials/sightings/workspace"
-    elif current_view == "trading":
-        partial_url = "/v2/partials/trading/workspace"
+    elif current_view == "resell":
+        partial_url = "/v2/partials/resell/workspace"
     elif current_view == "search":
         # Deep-link the Part Dossier: ?mpn= rides along to /v2/partials/search so a
         # bookmarked /v2/search?mpn=<PN> paints the dossier on first load.
@@ -365,7 +365,7 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
         "vendors",
         "customers",
         "buy-plans",
-        "trading",
+        "resell",
         "quotes",
         "prospecting",
         "trouble-tickets",

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -1,12 +1,12 @@
-"""routers/trading.py — Thin HTMX router for the Trading workspace (Chunk F).
+"""routers/resell.py — Thin HTMX router for the Resell workspace (Chunk F).
 
-ADDITIVE vertical slice. Builds the viewable Trading workspace on top of the
+ADDITIVE vertical slice. Builds the viewable Resell workspace on top of the
 already-green backend (Chunk A models, Chunk B excess_service offers, Chunk C
 excess_mirror): a split-panel page, lens-switched lists (My Lists / Open to Me),
 adaptive detail (lines / offers / build-bid / activity), and inbound-offer entry
 (per_line / take_all) reusing the service's submit_offer + import parsers.
 
-Strategy is additive-first: NEW templates under htmx/partials/trading/, NEW
+Strategy is additive-first: NEW templates under htmx/partials/resell/, NEW
 endpoints here, NEW nav item. The OLD excess router/templates stay mounted — a
 later cutover chunk removes them. Logic stays in excess_service / excess_mirror;
 this layer only resolves request → context → template (the fat-service / thin-
@@ -40,7 +40,7 @@ from ..models.excess import CustomerBid, ExcessLineItem, ExcessList, ExcessOffer
 from ..services import bid_back_service, excess_mirror, excess_service
 from ..template_env import template_response
 
-router = APIRouter(tags=["trading"])
+router = APIRouter(tags=["resell"])
 
 MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB
 ALLOWED_EXTENSIONS = {".csv", ".tsv", ".xlsx", ".xls"}
@@ -193,7 +193,7 @@ def _require_owner(el: ExcessList, user: User) -> None:
     """Raise 403 if *user* is not the list owner.
 
     Used by mutation endpoints that only the owner may call (add-line, import-preview,
-    import-confirm). Mirrors the guard in trading_publish.
+    import-confirm). Mirrors the guard in resell_publish.
     """
     if el.owner_id != user.id:
         raise HTTPException(403, "Only the list owner can edit it")
@@ -239,8 +239,8 @@ def _detail_context(request: Request, db: Session, el: ExcessList, user: User) -
 # ── Full workspace page ──────────────────────────────────────────────
 
 
-@router.get("/v2/partials/trading/workspace", response_class=HTMLResponse)
-async def trading_workspace(
+@router.get("/v2/partials/resell/workspace", response_class=HTMLResponse)
+async def resell_workspace(
     request: Request,
     lens: str = Query("mine"),
     stage: str = Query(""),
@@ -248,10 +248,10 @@ async def trading_workspace(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Split-panel Trading workspace shell: lens pills + stat strip + lists."""
+    """Split-panel Resell workspace shell: lens pills + stat strip + lists."""
     lens = lens if lens in ("mine", "open") else "mine"
     return template_response(
-        "htmx/partials/trading/workspace.html",
+        "htmx/partials/resell/workspace.html",
         {
             "request": request,
             "user": user,
@@ -267,8 +267,8 @@ async def trading_workspace(
 # ── Left list partial ────────────────────────────────────────────────
 
 
-@router.get("/v2/partials/trading/lists", response_class=HTMLResponse)
-async def trading_lists(
+@router.get("/v2/partials/resell/lists", response_class=HTMLResponse)
+async def resell_lists(
     request: Request,
     lens: str = Query("mine"),
     stage: str = Query(""),
@@ -305,7 +305,7 @@ async def trading_lists(
     cards = [_list_card(db, el, can_see_customer=can_see_customer) for el in lists]
 
     return template_response(
-        "htmx/partials/trading/_lists.html",
+        "htmx/partials/resell/_lists.html",
         {
             "request": request,
             "user": user,
@@ -321,8 +321,8 @@ async def trading_lists(
 # ── Right detail + lazy tab bodies ───────────────────────────────────
 
 
-@router.get("/v2/partials/trading/{list_id}", response_class=HTMLResponse)
-async def trading_detail(
+@router.get("/v2/partials/resell/{list_id}", response_class=HTMLResponse)
+async def resell_detail(
     request: Request,
     list_id: int,
     user: User = Depends(require_user),
@@ -330,11 +330,11 @@ async def trading_detail(
 ):
     """Right detail partial — slim header, breadcrumb, chips, lazy tabs."""
     el, _ = _get_list_for_user(db, list_id, user)
-    return template_response("htmx/partials/trading/detail.html", _detail_context(request, db, el, user))
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
 
 
-@router.get("/v2/partials/trading/{list_id}/lines", response_class=HTMLResponse)
-async def trading_lines(
+@router.get("/v2/partials/resell/{list_id}/lines", response_class=HTMLResponse)
+async def resell_lines(
     request: Request,
     list_id: int,
     user: User = Depends(require_user),
@@ -342,11 +342,11 @@ async def trading_lines(
 ):
     """Lazy Lines tab body — adaptive: 1 line → card, ≥2 → compact table."""
     el, _ = _get_list_for_user(db, list_id, user)
-    return template_response("htmx/partials/trading/_lines.html", _detail_context(request, db, el, user))
+    return template_response("htmx/partials/resell/_lines.html", _detail_context(request, db, el, user))
 
 
-@router.get("/v2/partials/trading/{list_id}/offers", response_class=HTMLResponse)
-async def trading_offers(
+@router.get("/v2/partials/resell/{list_id}/offers", response_class=HTMLResponse)
+async def resell_offers(
     request: Request,
     list_id: int,
     user: User = Depends(require_user),
@@ -365,7 +365,7 @@ async def trading_offers(
     if not is_owner:
         # Non-owner: render an empty offers view — no offer data in the response.
         return template_response(
-            "htmx/partials/trading/_offers.html",
+            "htmx/partials/resell/_offers.html",
             {
                 "request": request,
                 "user": user,
@@ -411,7 +411,7 @@ async def trading_offers(
                 unmatched.append(entry)
 
     return template_response(
-        "htmx/partials/trading/_offers.html",
+        "htmx/partials/resell/_offers.html",
         {
             "request": request,
             "user": user,
@@ -427,8 +427,8 @@ async def trading_offers(
     )
 
 
-@router.get("/v2/partials/trading/{list_id}/lines/{line_id}/offers", response_class=HTMLResponse)
-async def trading_line_offer_compare(
+@router.get("/v2/partials/resell/{list_id}/lines/{line_id}/offers", response_class=HTMLResponse)
+async def resell_line_offer_compare(
     request: Request,
     list_id: int,
     line_id: int,
@@ -460,7 +460,7 @@ async def trading_line_offer_compare(
 
     priced = [r["line"].unit_price for r in rows if r["line"].unit_price is not None]
     return template_response(
-        "htmx/partials/trading/offer_compare.html",
+        "htmx/partials/resell/offer_compare.html",
         {
             "request": request,
             "list": el,
@@ -504,8 +504,8 @@ def _build_bid_context(request: Request, db: Session, el: ExcessList, user: User
     }
 
 
-@router.get("/v2/partials/trading/{list_id}/build-bid", response_class=HTMLResponse)
-async def trading_build_bid(
+@router.get("/v2/partials/resell/{list_id}/build-bid", response_class=HTMLResponse)
+async def resell_build_bid(
     request: Request,
     list_id: int,
     user: User = Depends(require_user),
@@ -519,11 +519,11 @@ async def trading_build_bid(
     """
     el = excess_service.get_excess_list(db, list_id)
     _require_owner(el, user)
-    return template_response("htmx/partials/trading/_build_bid.html", _build_bid_context(request, db, el, user))
+    return template_response("htmx/partials/resell/_build_bid.html", _build_bid_context(request, db, el, user))
 
 
-@router.post("/api/trading/{list_id}/bid", response_class=HTMLResponse)
-async def trading_assemble_bid(
+@router.post("/api/resell/{list_id}/bid", response_class=HTMLResponse)
+async def resell_assemble_bid(
     request: Request,
     list_id: int,
     selections_json: str = Form(...),
@@ -556,11 +556,11 @@ async def trading_assemble_bid(
     ]
     bid_back_service.build_bid_back(db, list_id=list_id, owner=user, selections=selections)
     el = excess_service.get_excess_list(db, list_id)
-    return template_response("htmx/partials/trading/_build_bid.html", _build_bid_context(request, db, el, user))
+    return template_response("htmx/partials/resell/_build_bid.html", _build_bid_context(request, db, el, user))
 
 
-@router.get("/api/trading/{list_id}/bid/{bid_id}/pdf")
-async def trading_bid_pdf(
+@router.get("/api/resell/{list_id}/bid/{bid_id}/pdf")
+async def resell_bid_pdf(
     list_id: int,
     bid_id: int,
     user: User = Depends(require_user),
@@ -598,8 +598,8 @@ async def trading_bid_pdf(
 # ── Modal forms ──────────────────────────────────────────────────────
 
 
-@router.get("/v2/partials/trading/create-form", response_class=HTMLResponse)
-async def trading_create_form(
+@router.get("/v2/partials/resell/create-form", response_class=HTMLResponse)
+async def resell_create_form(
     request: Request,
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
@@ -609,13 +609,13 @@ async def trading_create_form(
         raise HTTPException(403, "You do not have permission to post excess lists")
     companies = db.query(Company).order_by(Company.name).all()
     return template_response(
-        "htmx/partials/trading/create_modal.html",
+        "htmx/partials/resell/create_modal.html",
         {"request": request, "companies": companies},
     )
 
 
-@router.get("/v2/partials/trading/{list_id}/add-line-form", response_class=HTMLResponse)
-async def trading_add_line_form(
+@router.get("/v2/partials/resell/{list_id}/add-line-form", response_class=HTMLResponse)
+async def resell_add_line_form(
     request: Request,
     list_id: int,
     user: User = Depends(require_user),
@@ -627,13 +627,13 @@ async def trading_add_line_form(
     if el.status != ExcessListStatus.DRAFT:
         raise HTTPException(409, "Posted lists are locked; revise as a new version")
     return template_response(
-        "htmx/partials/trading/add_line_modal.html",
+        "htmx/partials/resell/add_line_modal.html",
         {"request": request, "list_id": list_id},
     )
 
 
-@router.get("/v2/partials/trading/{list_id}/offer-form", response_class=HTMLResponse)
-async def trading_offer_form(
+@router.get("/v2/partials/resell/{list_id}/offer-form", response_class=HTMLResponse)
+async def resell_offer_form(
     request: Request,
     list_id: int,
     user: User = Depends(require_user),
@@ -646,7 +646,7 @@ async def trading_offer_form(
     if el.owner_id == user.id:
         raise HTTPException(403, "You cannot offer on your own excess list")
     return template_response(
-        "htmx/partials/trading/offer_form.html",
+        "htmx/partials/resell/offer_form.html",
         {"request": request, "list": el},
     )
 
@@ -654,8 +654,8 @@ async def trading_offer_form(
 # ── Mutations (thin — delegate to the service) ───────────────────────
 
 
-@router.post("/api/trading/lists", response_class=HTMLResponse)
-async def trading_create_list(
+@router.post("/api/resell/lists", response_class=HTMLResponse)
+async def resell_create_list(
     request: Request,
     title: str = Form(...),
     company_id: int = Form(...),
@@ -673,11 +673,11 @@ async def trading_create_list(
         owner_id=user.id,
         notes=notes or None,
     )
-    return await trading_lists(request, lens="mine", stage="", q="", user=user, db=db)
+    return await resell_lists(request, lens="mine", stage="", q="", user=user, db=db)
 
 
-@router.post("/api/trading/{list_id}/lines", response_class=HTMLResponse)
-async def trading_add_line(
+@router.post("/api/resell/{list_id}/lines", response_class=HTMLResponse)
+async def resell_add_line(
     request: Request,
     list_id: int,
     part_number: str = Form(...),
@@ -712,11 +712,11 @@ async def trading_add_line(
     excess_service._resolve_line_material_card(db, item)
     el.total_line_items = (el.total_line_items or 0) + 1
     db.commit()
-    return await trading_lines(request, list_id=list_id, user=user, db=db)
+    return await resell_lines(request, list_id=list_id, user=user, db=db)
 
 
-@router.post("/api/trading/{list_id}/import-preview", response_class=HTMLResponse)
-async def trading_import_preview(
+@router.post("/api/resell/{list_id}/import-preview", response_class=HTMLResponse)
+async def resell_import_preview(
     request: Request,
     list_id: int,
     file: UploadFile,
@@ -739,7 +739,7 @@ async def trading_import_preview(
         raise HTTPException(400, "No data rows found")
     result = excess_service.preview_import(rows)
     return template_response(
-        "htmx/partials/trading/import_preview.html",
+        "htmx/partials/resell/import_preview.html",
         {
             "request": request,
             "list_id": list_id,
@@ -750,8 +750,8 @@ async def trading_import_preview(
     )
 
 
-@router.post("/api/trading/{list_id}/import-confirm", response_class=HTMLResponse)
-async def trading_import_confirm(
+@router.post("/api/resell/{list_id}/import-confirm", response_class=HTMLResponse)
+async def resell_import_confirm(
     request: Request,
     list_id: int,
     rows_json: str = Form(...),
@@ -770,11 +770,11 @@ async def trading_import_confirm(
     except (json.JSONDecodeError, ValueError) as exc:
         raise HTTPException(400, "Invalid import payload") from exc
     excess_service.confirm_import(db, list_id, rows)
-    return await trading_lines(request, list_id=list_id, user=user, db=db)
+    return await resell_lines(request, list_id=list_id, user=user, db=db)
 
 
-@router.post("/api/trading/{list_id}/publish", response_class=HTMLResponse)
-async def trading_publish(
+@router.post("/api/resell/{list_id}/publish", response_class=HTMLResponse)
+async def resell_publish(
     request: Request,
     list_id: int,
     user: User = Depends(require_user),
@@ -788,11 +788,11 @@ async def trading_publish(
         raise HTTPException(403, "Only the list owner can publish it")
     excess_mirror.publish_list(db, list_id, user)
     el = excess_service.get_excess_list(db, list_id)
-    return template_response("htmx/partials/trading/detail.html", _detail_context(request, db, el, user))
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
 
 
-@router.post("/api/trading/{list_id}/close", response_class=HTMLResponse)
-async def trading_close(
+@router.post("/api/resell/{list_id}/close", response_class=HTMLResponse)
+async def resell_close(
     request: Request,
     list_id: int,
     user: User = Depends(require_user),
@@ -801,11 +801,11 @@ async def trading_close(
     """Close a posted list (owner-only): flip to bid_out + stamp close_at, re-render
     detail."""
     el = excess_service.close_list(db, list_id, user)
-    return template_response("htmx/partials/trading/detail.html", _detail_context(request, db, el, user))
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
 
 
-@router.post("/api/trading/{list_id}/offers", response_class=HTMLResponse)
-async def trading_submit_offer(
+@router.post("/api/resell/{list_id}/offers", response_class=HTMLResponse)
+async def resell_submit_offer(
     request: Request,
     list_id: int,
     scope: str = Form(...),
@@ -853,7 +853,7 @@ async def trading_submit_offer(
     )
 
     el = excess_service.get_excess_list(db, list_id)
-    return await trading_offers(request, list_id=el.id, user=user, db=db)
+    return await resell_offers(request, list_id=el.id, user=user, db=db)
 
 
 # ── tiny parse helpers (forms send strings) ──────────────────────────

--- a/app/schemas/excess.py
+++ b/app/schemas/excess.py
@@ -1,9 +1,9 @@
-"""Pydantic schemas for Excess Inventory & Trading offers.
+"""Pydantic schemas for Excess Inventory & Resell offers.
 
-Request/response models for the Trading workspace: excess lists, line items,
+Request/response models for the Resell workspace: excess lists, line items,
 bulk import, and inbound broker offers (ExcessOffer / ExcessOfferLine).
 
-Called by: routers/trading.py
+Called by: routers/resell.py
 Depends on: pydantic
 """
 
@@ -123,7 +123,7 @@ class ConfirmImportRequest(BaseModel):
 
 
 class ExcessStatsResponse(BaseModel):
-    """Aggregate stats for the Trading workspace (offer counts, not bid counts)."""
+    """Aggregate stats for the Resell workspace (offer counts, not bid counts)."""
 
     total_lists: int = 0
     total_line_items: int = 0
@@ -133,7 +133,7 @@ class ExcessStatsResponse(BaseModel):
     awarded_items: int = 0
 
 
-# ── ExcessOffer (inbound broker offers — Trading module) ─────────────
+# ── ExcessOffer (inbound broker offers — Resell module) ─────────────
 
 
 class ExcessOfferLineCreate(BaseModel):

--- a/app/services/bid_back_service.py
+++ b/app/services/bid_back_service.py
@@ -11,7 +11,7 @@ carry ONLY part / mfr / qty / condition / our unit + extended price, and the hea
 carries no seller-company identity. The Quote PDF accidentally hid the vendor by never
 passing the field; the bid back makes that guarantee explicit and testable.
 
-Called by: routers.trading (Build Bid tab), services.document_service (generate_bid_report_pdf).
+Called by: routers.resell (Build Bid tab), services.document_service (generate_bid_report_pdf).
 Depends on: models.excess (CustomerBid/Line, ExcessList, ExcessLineItem), constants,
     a request-scoped Session.
 """

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -1,11 +1,11 @@
-"""excess_service.py — Business logic for the Trading workspace.
+"""excess_service.py — Business logic for the Resell workspace.
 
 Handles CRUD operations for ExcessList, bulk import of ExcessLineItems with
 flexible header detection (part_number/mpn, quantity/qty, etc.), MaterialCard
 resolution, role-derived capabilities, inbound broker offers (ExcessOffer /
 ExcessOfferLine), the best-price rollup, list close, and aggregate stats.
 
-Called by: routers/trading.py
+Called by: routers/resell.py
 Depends on: models (ExcessList, ExcessLineItem, ExcessOffer, Company), database
 """
 
@@ -31,7 +31,7 @@ from ..models.excess import ExcessLineItem, ExcessList, ExcessOffer, ExcessOffer
 from ..utils.normalization import normalize_mpn_key
 
 # ---------------------------------------------------------------------------
-# Trading capabilities — role-derived powers (spec §"Roles & capabilities")
+# Resell capabilities — role-derived powers (spec §"Roles & capabilities")
 # ---------------------------------------------------------------------------
 #
 # Two powers modelled as capabilities (NOT scattered ``role == 'trader'`` checks),
@@ -402,7 +402,7 @@ def confirm_import(db: Session, list_id: int, validated_rows: list[dict]) -> dic
 
 
 # ---------------------------------------------------------------------------
-# Trading: inbound offers (ExcessOffer / ExcessOfferLine) + best-price rollup
+# Resell: inbound offers (ExcessOffer / ExcessOfferLine) + best-price rollup
 # ---------------------------------------------------------------------------
 #
 # An inbound offer is a broker's offer to BUY a posted excess list. It is either
@@ -621,7 +621,7 @@ def close_list(db: Session, list_id: int, owner: User) -> ExcessList:
 
 
 def get_excess_stats(db: Session) -> dict:
-    """Compute aggregate stats for the Trading workspace (offer counts, not bid counts).
+    """Compute aggregate stats for the Resell workspace (offer counts, not bid counts).
 
     Returns {total_lists, total_line_items, open_offers, matched_items, total_offers,
     awarded_items}.

--- a/app/templates/htmx/partials/resell/_build_bid.html
+++ b/app/templates/htmx/partials/resell/_build_bid.html
@@ -1,5 +1,5 @@
 {#
-  trading/_build_bid.html — Build Bid tab body (owner-only bid-back builder).
+  resell/_build_bid.html — Build Bid tab body (owner-only bid-back builder).
   Each line shows its best collected unit price as a PLANNING REFERENCE and an
   editable "our offer" input pre-filled from it; checked lines are assembled into a
   CustomerBid (priced from the inputs / best-offer seed). Once assembled, the clean
@@ -7,7 +7,7 @@
   identity-clean; spec §"Customer Bid").
   Receives: list, line_items, line_count, bid (CustomerBid|None),
             summary (bid_back_export_context|None), user.
-  Called by: trading.trading_build_bid (lazy) + trading_assemble_bid (re-render).
+  Called by: resell.resell_build_bid (lazy) + resell_assemble_bid (re-render).
 #}
 {% set el = list %}
 
@@ -41,7 +41,7 @@
   </p>
 
   {# ── Builder table ────────────────────────────────────────────── #}
-  <form hx-post="/api/trading/{{ el.id }}/bid"
+  <form hx-post="/api/resell/{{ el.id }}/bid"
         hx-target="#tab-build-{{ el.id }}"
         hx-swap="innerHTML"
         data-loading-disable
@@ -110,7 +110,7 @@
         <p class="text-base font-semibold text-gray-900">{{ summary.bid_number }}</p>
         <p class="text-xs text-gray-400 mt-0.5">{{ summary.line_count }} line{{ 's' if summary.line_count != 1 }} · rev {{ summary.revision }} · {{ summary.status }}</p>
       </div>
-      <a href="/api/trading/{{ el.id }}/bid/{{ bid.id }}/pdf"
+      <a href="/api/resell/{{ el.id }}/bid/{{ bid.id }}/pdf"
          class="btn-secondary btn-sm">
         <svg class="h-3.5 w-3.5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
         Download PDF

--- a/app/templates/htmx/partials/resell/_lines.html
+++ b/app/templates/htmx/partials/resell/_lines.html
@@ -1,12 +1,12 @@
 {#
-  trading/_lines.html — Lines tab body (adaptive).
+  resell/_lines.html — Lines tab body (adaptive).
   Density scales to line count (spec §"Flexible detail"):
     • ≥2 lines → compact table (compact-cell).
     • exactly 1 line → one .card, no table chrome.
   Each line surfaces qty / condition / best-offer$ / offer-count (▸N → opens the
   per-line comparison). Owner draft lists get the Paste/Upload/+Add affordance.
   Receives: list, line_items, line_count, shape, can_see_customer, can_post, user.
-  Called by: trading.trading_lines + detail.html (default tab) + add-line/import re-render.
+  Called by: resell.resell_lines + detail.html (default tab) + add-line/import re-render.
 #}
 {% set el = list %}
 {% set is_owner = can_see_customer %}
@@ -15,7 +15,7 @@
 {# Reusable best-offer / offer-count chip → opens the per-line comparison modal. #}
 {% macro _line_offer_badge(el, item) %}
   {% if (item.offer_count or 0) > 0 %}
-  <button hx-get="/v2/partials/trading/{{ el.id }}/lines/{{ item.id }}/offers"
+  <button hx-get="/v2/partials/resell/{{ el.id }}/lines/{{ item.id }}/offers"
           hx-target="#modal-content"
           @click="$dispatch('open-modal', { wide: true })"
           class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 text-amber-700 hover:bg-amber-200 transition-colors whitespace-nowrap">
@@ -35,14 +35,14 @@
     <div class="flex items-center justify-between gap-2">
       <p class="text-xs text-gray-500">Add parts — drop a file, or add one line.</p>
       <button @click="$dispatch('open-modal')"
-              hx-get="/v2/partials/trading/{{ el.id }}/add-line-form"
+              hx-get="/v2/partials/resell/{{ el.id }}/add-line-form"
               hx-target="#modal-content"
               class="btn-secondary btn-sm">
         <svg class="h-3.5 w-3.5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
         Add line
       </button>
     </div>
-    <form hx-post="/api/trading/{{ el.id }}/import-preview"
+    <form hx-post="/api/resell/{{ el.id }}/import-preview"
           hx-encoding="multipart/form-data"
           hx-target="#import-area"
           hx-swap="innerHTML"

--- a/app/templates/htmx/partials/resell/_lists.html
+++ b/app/templates/htmx/partials/resell/_lists.html
@@ -1,11 +1,11 @@
 {#
-  trading/_lists.html — Left list partial: stage filters + search + opportunity rows.
-  Each row swaps the detail panel and pushes /v2/trading/{id}. Status pills map
+  resell/_lists.html — Left list partial: stage filters + search + opportunity rows.
+  Each row swaps the detail panel and pushes /v2/resell/{id}. Status pills map
   onto EXISTING status_badge keys (open→sky, collecting→sourcing, bid_out→quoted,
   awarded→won, draft→muted) — no new colors (spec §"Design consistency").
   Receives: cards [{list, customer_name, coverage_filled, coverage_total,
             offer_count, hours_until}], lens, stage, q, can_post, user.
-  Called by: trading.trading_lists.
+  Called by: resell.resell_lists.
 #}
 {% from "htmx/partials/shared/_macros.html" import status_badge, coverage_meter, time_text, filter_pill %}
 
@@ -23,16 +23,16 @@
       {% set stages = [('', 'All'), ('open', 'Open'), ('collecting', 'Collecting'), ('bid_out', 'Bid out'), ('awarded', 'Awarded')] %}
       {% for value, label in stages %}
         {{ filter_pill(label, value, stage, {
-          'hx-get': '/v2/partials/trading/lists?lens=' ~ lens ~ '&stage=' ~ value,
-          'hx-target': '#trading-list-body',
+          'hx-get': '/v2/partials/resell/lists?lens=' ~ lens ~ '&stage=' ~ value,
+          'hx-target': '#resell-list-body',
           'hx-swap': 'innerHTML'
         }) }}
       {% endfor %}
     </div>
     <input type="search" name="q" value="{{ q }}" placeholder="Search lists…"
-           aria-label="Search trading lists"
-           hx-get="/v2/partials/trading/lists?lens={{ lens }}&stage={{ stage }}"
-           hx-target="#trading-list-body"
+           aria-label="Search resell lists"
+           hx-get="/v2/partials/resell/lists?lens={{ lens }}&stage={{ stage }}"
+           hx-target="#resell-list-body"
            hx-swap="innerHTML"
            hx-trigger="input changed delay:300ms, search"
            class="w-full px-3 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
@@ -43,10 +43,10 @@
     {% if cards %}
     {% for c in cards %}
     {% set el = c.list %}
-    <a hx-get="/v2/partials/trading/{{ el.id }}"
-       hx-target="#split-right-trading"
+    <a hx-get="/v2/partials/resell/{{ el.id }}"
+       hx-target="#split-right-resell"
        hx-swap="innerHTML"
-       hx-push-url="/v2/trading/{{ el.id }}"
+       hx-push-url="/v2/resell/{{ el.id }}"
        class="block px-3 py-2.5 border-b border-gray-100 cursor-pointer hover:bg-brand-50/60 transition-colors">
       <div class="flex items-start justify-between gap-2">
         <div class="min-w-0 flex-1">
@@ -98,7 +98,7 @@
           <p>You haven't posted any excess lists yet.</p>
           {% if can_post %}
           <button @click="$dispatch('open-modal')"
-                  hx-get="/v2/partials/trading/create-form"
+                  hx-get="/v2/partials/resell/create-form"
                   hx-target="#modal-content"
                   class="mt-4 btn-primary btn-sm">Post a list</button>
           {% endif %}

--- a/app/templates/htmx/partials/resell/_offers.html
+++ b/app/templates/htmx/partials/resell/_offers.html
@@ -1,5 +1,5 @@
 {#
-  trading/_offers.html — Offers tab body.
+  resell/_offers.html — Offers tab body.
   Owner view: take-all offers as a PINNED BANNER on top (the take-all is the
   headline; lines are its contents — spec §"Flexible detail"), then per-line
   offers stacked under each line, plus an unmatched-queue card for rows that
@@ -7,7 +7,7 @@
   Non-owner: offers are private to the owner — show only the submit-offer prompt.
   Receives: list, line_items, by_line {line_id: [{offer, line}]}, unmatched,
             take_all_offers, is_owner, can_see_customer, shape.
-  Called by: trading.trading_offers (lazy + offer-submit re-render).
+  Called by: resell.resell_offers (lazy + offer-submit re-render).
 #}
 {% set el = list %}
 
@@ -62,7 +62,7 @@
     <div class="rounded-lg border border-brand-200 overflow-hidden">
       <div class="flex items-center justify-between px-3 py-2 bg-gray-50 border-b border-brand-100">
         <span class="text-sm font-mono font-medium text-gray-900">{{ item.part_number }}</span>
-        <button hx-get="/v2/partials/trading/{{ el.id }}/lines/{{ item.id }}/offers"
+        <button hx-get="/v2/partials/resell/{{ el.id }}/lines/{{ item.id }}/offers"
                 hx-target="#modal-content"
                 @click="$dispatch('open-modal', { wide: true })"
                 class="text-xs text-brand-500 hover:text-brand-600 font-medium">Compare ▸</button>

--- a/app/templates/htmx/partials/resell/add_line_modal.html
+++ b/app/templates/htmx/partials/resell/add_line_modal.html
@@ -1,12 +1,12 @@
 {#
-  trading/add_line_modal.html — Add-one-line modal (reuses the excess add-line shape).
-  Posts to /api/trading/{id}/lines which re-renders the Lines tab body.
+  resell/add_line_modal.html — Add-one-line modal (reuses the excess add-line shape).
+  Posts to /api/resell/{id}/lines which re-renders the Lines tab body.
   Receives: list_id.
-  Called by: trading.trading_add_line_form.
+  Called by: resell.resell_add_line_form.
 #}
 <div class="p-5">
   <h3 class="text-lg font-semibold text-gray-900 mb-4">Add line</h3>
-  <form hx-post="/api/trading/{{ list_id }}/lines"
+  <form hx-post="/api/resell/{{ list_id }}/lines"
         hx-target="#tab-lines-{{ list_id }}"
         hx-swap="innerHTML"
         data-loading-disable

--- a/app/templates/htmx/partials/resell/create_modal.html
+++ b/app/templates/htmx/partials/resell/create_modal.html
@@ -1,14 +1,14 @@
 {#
-  trading/create_modal.html — New-list modal (reuses the excess create-modal shape).
-  Posts to /api/trading/lists which re-renders the My-Lists list partial.
+  resell/create_modal.html — New-list modal (reuses the excess create-modal shape).
+  Posts to /api/resell/lists which re-renders the My-Lists list partial.
   Receives: companies.
-  Called by: trading.trading_create_form.
+  Called by: resell.resell_create_form.
 #}
 <div class="p-5">
   <h2 class="text-lg font-semibold text-gray-900 mb-5">New excess list</h2>
 
-  <form hx-post="/api/trading/lists"
-        hx-target="#trading-list-body"
+  <form hx-post="/api/resell/lists"
+        hx-target="#resell-list-body"
         hx-swap="innerHTML"
         data-loading-disable
         @htmx:after-request.camel="if(event.detail.successful){ $dispatch('close-modal'); $store.toast.message='List created'; $store.toast.type='success'; $store.toast.show=true; }"

--- a/app/templates/htmx/partials/resell/detail.html
+++ b/app/templates/htmx/partials/resell/detail.html
@@ -1,11 +1,11 @@
 {#
-  trading/detail.html — Right detail panel: slim header + breadcrumb + chips + lazy tabs.
+  resell/detail.html — Right detail panel: slim header + breadcrumb + chips + lazy tabs.
   One adaptive surface for all three deal shapes — the tab bodies reshape, the
   panel never branches to a new page (spec §"Flexible detail").
   Receives: list, line_items, line_count, offer_count, take_all_count,
             can_see_customer, can_post, can_offer, shape, hours_until, is_posted, user.
-  Called by: trading.trading_detail (+ publish re-render).
-  Depends on: shared/_macros.html, partials/trading/_lines.html, _offers.html.
+  Called by: resell.resell_detail (+ publish re-render).
+  Depends on: shared/_macros.html, partials/resell/_lines.html, _offers.html.
 #}
 {% from "htmx/partials/shared/_macros.html" import status_badge, time_text %}
 {% set el = list %}
@@ -17,9 +17,9 @@
   <div class="px-5 py-3 border-b border-brand-200 bg-white flex-shrink-0">
     {# Breadcrumb #}
     <nav class="text-xs text-gray-400 mb-1" aria-label="Breadcrumb">
-      <a hx-get="/v2/partials/trading/workspace?lens=mine"
-         hx-target="#main-content" hx-push-url="/v2/trading"
-         class="hover:text-brand-500">Trading</a>
+      <a hx-get="/v2/partials/resell/workspace?lens=mine"
+         hx-target="#main-content" hx-push-url="/v2/resell"
+         class="hover:text-brand-500">Resell</a>
       <span class="mx-1">›</span>
       <span class="text-gray-600">{{ el.title }}</span>
     </nav>
@@ -58,8 +58,8 @@
       {# Owner / offerer actions #}
       <div class="flex items-center gap-2 flex-shrink-0">
         {% if can_see_customer and el.status == 'draft' and line_count > 0 %}
-        <button hx-post="/api/trading/{{ el.id }}/publish"
-                hx-target="#split-right-trading"
+        <button hx-post="/api/resell/{{ el.id }}/publish"
+                hx-target="#split-right-resell"
                 hx-swap="innerHTML"
                 hx-confirm="Post this list? Lines lock and become visible to brokers."
                 data-loading-disable
@@ -69,8 +69,8 @@
         </button>
         {% endif %}
         {% if can_see_customer and el.status in ['open', 'collecting'] %}
-        <button hx-post="/api/trading/{{ el.id }}/close"
-                hx-target="#split-right-trading"
+        <button hx-post="/api/resell/{{ el.id }}/close"
+                hx-target="#split-right-resell"
                 hx-swap="innerHTML"
                 hx-confirm="Close this list? The posting window ends and the bid goes out."
                 data-loading-disable
@@ -80,7 +80,7 @@
         {% endif %}
         {% if can_offer %}
         <button @click="$dispatch('open-modal')"
-                hx-get="/v2/partials/trading/{{ el.id }}/offer-form"
+                hx-get="/v2/partials/resell/{{ el.id }}/offer-form"
                 hx-target="#modal-content"
                 class="btn-primary btn-sm">
           <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
@@ -109,14 +109,14 @@
 
     {# Lines — loads immediately (default tab). #}
     <div x-show="tab === 'lines'" id="tab-lines-{{ el.id }}">
-      {% include "htmx/partials/trading/_lines.html" %}
+      {% include "htmx/partials/resell/_lines.html" %}
     </div>
 
     {# Offers — lazy. LANDMINE: intersect/load MUST carry an explicit hx-target
        or it inherits #main-content's hx-target="this" and wipes the page. #}
     <div x-show="tab === 'offers'" x-cloak>
       <div id="tab-offers-{{ el.id }}"
-           hx-get="/v2/partials/trading/{{ el.id }}/offers"
+           hx-get="/v2/partials/resell/{{ el.id }}/offers"
            hx-trigger="intersect once"
            hx-target="#tab-offers-{{ el.id }}"
            hx-swap="innerHTML">
@@ -130,7 +130,7 @@
     <div x-show="tab === 'build'" x-cloak>
       {% if can_see_customer %}
       <div id="tab-build-{{ el.id }}"
-           hx-get="/v2/partials/trading/{{ el.id }}/build-bid"
+           hx-get="/v2/partials/resell/{{ el.id }}/build-bid"
            hx-trigger="intersect once"
            hx-target="#tab-build-{{ el.id }}"
            hx-swap="innerHTML">

--- a/app/templates/htmx/partials/resell/import_preview.html
+++ b/app/templates/htmx/partials/resell/import_preview.html
@@ -1,9 +1,9 @@
 {#
-  trading/import_preview.html — Preview of a parsed import (reuses the excess grid).
-  Confirm → /api/trading/{id}/import-confirm (re-renders the Lines tab).
+  resell/import_preview.html — Preview of a parsed import (reuses the excess grid).
+  Confirm → /api/resell/{id}/import-confirm (re-renders the Lines tab).
   Receives: list_id, filename, valid_count, error_count, errors, preview_rows,
             all_valid_rows_json.
-  Called by: trading.trading_import_preview.
+  Called by: resell.resell_import_preview.
 #}
 <div class="space-y-3" id="import-area">
   <div class="flex items-center gap-3 text-sm">
@@ -53,7 +53,7 @@
   {% endif %}
 
   {% if valid_count %}
-  <form hx-post="/api/trading/{{ list_id }}/import-confirm"
+  <form hx-post="/api/resell/{{ list_id }}/import-confirm"
         hx-target="#tab-lines-{{ list_id }}"
         hx-swap="innerHTML"
         data-loading-disable

--- a/app/templates/htmx/partials/resell/offer_compare.html
+++ b/app/templates/htmx/partials/resell/offer_compare.html
@@ -1,10 +1,10 @@
 {#
-  trading/offer_compare.html — Per-line offer comparison (modal, owner view).
+  resell/offer_compare.html — Per-line offer comparison (modal, owner view).
   Cloned from quote_builder/modal.html: best unit price highlighted emerald +
   a price-spread bar. NO auto-select — with many broker offers the trader
   eyeballs terms / lead / reputation first (spec §"Offer collection").
   Receives: list, item, rows [{offer, line}], min_price, max_price, is_owner.
-  Called by: trading.trading_line_offer_compare.
+  Called by: resell.resell_line_offer_compare.
 #}
 {% set el = list %}
 

--- a/app/templates/htmx/partials/resell/offer_form.html
+++ b/app/templates/htmx/partials/resell/offer_form.html
@@ -1,17 +1,17 @@
 {#
-  trading/offer_form.html — Submit-offer modal (per-line / take-all scope toggle).
+  resell/offer_form.html — Submit-offer modal (per-line / take-all scope toggle).
   Single-line quick-add path this slice; the paste/upload funnel reuses the same
   import_preview grid. Price is OPTIONAL (a broker may bid "take-all, price TBD").
   The service enforces can_offer + the self-offer guard.
   Receives: list (ExcessList).
-  Called by: trading.trading_offer_form.
+  Called by: resell.resell_offer_form.
 #}
 {% set el = list %}
 <div class="p-5" x-data="{ scope: 'per_line' }">
   <h2 class="text-lg font-semibold text-gray-900 mb-1">Submit offer</h2>
   <p class="text-sm text-gray-500 mb-4">On <span class="font-medium text-gray-700">{{ el.title }}</span></p>
 
-  <form hx-post="/api/trading/{{ el.id }}/offers"
+  <form hx-post="/api/resell/{{ el.id }}/offers"
         hx-target="#tab-offers-{{ el.id }}"
         hx-swap="innerHTML"
         data-loading-disable

--- a/app/templates/htmx/partials/resell/workspace.html
+++ b/app/templates/htmx/partials/resell/workspace.html
@@ -1,15 +1,15 @@
 {#
-  trading/workspace.html — Trading workspace shell (Chunk F).
+  resell/workspace.html — Resell workspace shell (Chunk F).
   Split-panel: left = lists (lazy), right = detail. Lens pills (My Lists / Open
   to Me) + a stat-card triage strip (each card filters the list). Built entirely
   from shared components — splitPanel(), stat_card, filter_pill — so it reads
   native (spec §"The management page").
   Receives: lens ('mine'|'open'), stage, q, stats (dict), user, can_post.
-  Called by: trading.trading_workspace.
-  Depends on: shared/_macros.html, partials/trading/_lists.html, splitPanel JS.
+  Called by: resell.resell_workspace.
+  Depends on: shared/_macros.html, partials/resell/_lists.html, splitPanel JS.
 #}
 {% from "htmx/partials/shared/_macros.html" import stat_card %}
-<title hx-swap-oob="true">Trading — AvailAI</title>
+<title hx-swap-oob="true">Resell — AvailAI</title>
 
 <div class="page-fluid flex flex-col h-[calc(100vh-7.5rem)]"
      x-data="{ lens: '{{ lens }}', stage: '{{ stage }}' }">
@@ -20,8 +20,8 @@
       {% for l, label in [('mine', 'My Lists'), ('open', 'Open to Me')] %}
       {# Alpine-reactive highlight so the active pill flips before the server swap
          returns, then stays correct after the re-rendered shell re-inits x-data. #}
-      <button hx-get="/v2/partials/trading/lists?lens={{ l }}"
-              hx-target="#trading-list-body"
+      <button hx-get="/v2/partials/resell/lists?lens={{ l }}"
+              hx-target="#resell-list-body"
               hx-swap="innerHTML"
               @click="lens = '{{ l }}'; stage = ''"
               :class="lens === '{{ l }}'
@@ -34,7 +34,7 @@
     </div>
     {% if can_post %}
     <button @click="$dispatch('open-modal')"
-            hx-get="/v2/partials/trading/create-form"
+            hx-get="/v2/partials/resell/create-form"
             hx-target="#modal-content"
             class="btn-primary btn-sm">
       <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -60,8 +60,8 @@
     ] %}
     {% for stage_key, label, value, sub in glance %}
     <button type="button"
-            hx-get="/v2/partials/trading/lists?lens=mine&stage={{ stage_key }}"
-            hx-target="#trading-list-body"
+            hx-get="/v2/partials/resell/lists?lens=mine&stage={{ stage_key }}"
+            hx-target="#resell-list-body"
             hx-swap="innerHTML"
             @click="stage = '{{ stage_key }}'"
             :class="stage === '{{ stage_key }}' ? 'ring-2 ring-brand-400' : ''"
@@ -73,8 +73,8 @@
 
   {# ── Split panel: lists (left) + detail (right) ─────────────────── #}
   <div class="flex flex-1 overflow-hidden min-h-0 rounded-xl border border-brand-200 bg-white"
-       id="split-trading"
-       x-data="splitPanel('trading', 38)">
+       id="split-resell"
+       x-data="splitPanel('resell', 38)">
 
     {# Left: lists — lazy-loaded so the shell paints instantly.
        LANDMINE (spec HTMX trap): hx-trigger="load" carries an EXPLICIT
@@ -82,11 +82,11 @@
        wipe the page. #}
     <div class="overflow-auto border-r border-brand-200 flex-shrink-0"
          :style="'width:' + leftWidth + '%'"
-         id="split-left-trading">
-      <div id="trading-list-body"
-           hx-get="/v2/partials/trading/lists?lens={{ lens }}&stage={{ stage }}{% if q %}&q={{ q }}{% endif %}"
+         id="split-left-resell">
+      <div id="resell-list-body"
+           hx-get="/v2/partials/resell/lists?lens={{ lens }}&stage={{ stage }}{% if q %}&q={{ q }}{% endif %}"
            hx-trigger="load"
-           hx-target="#trading-list-body"
+           hx-target="#resell-list-body"
            hx-swap="innerHTML">
         <div class="p-8 text-center text-gray-400 text-sm">Loading…</div>
       </div>
@@ -104,7 +104,7 @@
     </div>
 
     {# Right: detail — painted on row select. #}
-    <div class="overflow-y-auto flex-1 bg-brand-50" id="split-right-trading">
+    <div class="overflow-y-auto flex-1 bg-brand-50" id="split-right-resell">
       <div class="flex items-center justify-center h-full text-gray-400">
         <div class="text-center px-6">
           <svg class="mx-auto h-10 w-10 text-gray-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">

--- a/app/templates/htmx/partials/shared/mobile_nav.html
+++ b/app/templates/htmx/partials/shared/mobile_nav.html
@@ -11,7 +11,7 @@
        moreOpen: false,
        activeNav: '{{ current_view }}',
        urlToNav(url) {
-         const map = {'/v2/requisitions':'requisitions','/v2/sightings':'sightings','/v2/materials':'materials','/v2/search':'search','/v2/buy-plans':'buy-plans','/v2/trading':'trading','/v2/crm':'crm','/v2/customers':'crm','/v2/vendors':'crm','/v2/proactive':'proactive','/v2/prospecting':'prospecting','/v2/settings':'settings'};
+         const map = {'/v2/requisitions':'requisitions','/v2/sightings':'sightings','/v2/materials':'materials','/v2/search':'search','/v2/buy-plans':'buy-plans','/v2/resell':'resell','/v2/crm':'crm','/v2/customers':'crm','/v2/vendors':'crm','/v2/proactive':'proactive','/v2/prospecting':'prospecting','/v2/settings':'settings'};
          for (const [prefix, id] of Object.entries(map)) { if (url.startsWith(prefix)) return id; }
          return this.activeNav;
        }
@@ -32,7 +32,7 @@
        'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z'),
       ('buy-plans', 'Buy Plans', '/v2/buy-plans', '/v2/partials/buy-plans',
        'M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z'),
-      ('trading', 'Trading', '/v2/trading', '/v2/partials/trading/workspace',
+      ('resell', 'Resell', '/v2/resell', '/v2/partials/resell/workspace',
        'M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4'),
       ('crm', 'CRM', '/v2/crm', '/v2/partials/crm/shell',
        'M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z'),

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -134,7 +134,7 @@ authoritative reference. Static-analysis tests in
 | Vendors | 16 | partials/vendors/ |
 | Customers | 14 | partials/customers/ |
 | Materials | 13 | partials/materials/ |
-| Trading | 11 | partials/trading/ — resell-brokerage workspace (replaced the removed `partials/excess/`; router `routers/trading.py`) |
+| Resell | 11 | partials/resell/ — resell-brokerage workspace (replaced the removed `partials/excess/`; router `routers/resell.py`) |
 | Parts | 13 | partials/parts/ |
 | Quotes | 5 | partials/quotes/ — `list.html` removed (standalone Quotes tab retired); detail/macros/line_row/preview/pricing_history remain |
 | Sightings | 7 | partials/sightings/ |

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -550,7 +550,7 @@ Managed via Settings > Ops Group (admin only); seeded from `ADMIN_EMAILS` on sta
 
 ---
 
-### Excess Inventory / Trading (resell-brokerage)
+### Excess Inventory / Resell (resell-brokerage)
 
 > Migration 126 added the inbound-offer tables + rollup columns; migration 127 added the
 > bid-back tables + posting window; **migration 128 (the CUTOVER) dropped the old
@@ -559,7 +559,7 @@ Managed via Settings > Ops Group (admin only); seeded from `ADMIN_EMAILS` on sta
 > `Bid*`, schemas, the `app/routers/excess.py` router + `partials/excess/*` templates, the
 > `email_service`/`email_jobs` inbox-RFQ callers, and the `create_bid`/`accept_bid`/
 > `send_bid_solicitation`/`match_excess_demand` service methods). `ExcessListStatus` keeps the
-> Trading lifecycle members (open/collecting/bid_out/awarded); the pre-Trading active/bidding
+> Resell lifecycle members (open/collecting/bid_out/awarded); the pre-Resell active/bidding
 > members remain (not in the cutover's removal scope).
 >
 > Service logic lives in `app/services/excess_service.py`:
@@ -567,8 +567,8 @@ Managed via Settings > Ops Group (admin only); seeded from `ADMIN_EMAILS` on sta
 > part-number-only matching via `normalize_mpn_key`; unmatched/ambiguous rows queued),
 > `recompute_line_rollup`/`withdraw_offer` (min priced active offer -> best_offer_*),
 > `close_list`, `get_excess_stats` (offer counts), list/line CRUD + import, and
-> `material_card_id` resolution on the import path. The thin router is `app/routers/trading.py`
-> (templates under `app/templates/htmx/partials/trading/*`).
+> `material_card_id` resolution on the import path. The thin router is `app/routers/resell.py`
+> (templates under `app/templates/htmx/partials/resell/*`).
 >
 > Sighting live-mirror lives in `app/services/excess_mirror.py` (Chunk C, additive):
 > `sync_list_mirror`/`publish_list` are the dual-write owners — every active posted
@@ -611,7 +611,7 @@ Managed via Settings > Ops Group (admin only); seeded from `ADMIN_EMAILS` on sta
 - material_card_id -> material_cards (SET NULL) — resolved on create for the Sighting mirror
 - best_offer_unit_price, best_offer_id (plain int, not a hard FK), offer_count — best-price rollup
 
-**`excess_offers`** — Inbound broker offer to BUY a posted list (the Trading offer model; replaced the dropped `bids`)
+**`excess_offers`** — Inbound broker offer to BUY a posted list (the Resell offer model; replaced the dropped `bids`)
 - excess_list_id -> excess_lists (CASCADE), submitted_by -> users
 - offerer_company_id -> companies / offerer_vendor_card_id -> vendor_cards (both SET NULL)
 - scope: per_line | take_all; take_all_total_price (lump, take_all only); valid_until
@@ -634,7 +634,7 @@ Managed via Settings > Ops Group (admin only); seeded from `ADMIN_EMAILS` on sta
   — INTERNAL provenance only; NEVER exported to the customer doc
 
 > **Dropped in migration 128 (cutover):** `bids` (vendor bids on excess items) and
-> `bid_solicitations` (outbound bid-request emails). The Trading module's
+> `bid_solicitations` (outbound bid-request emails). The Resell module's
 > `excess_offers`/`excess_offer_lines` + `customer_bids`/`customer_bid_lines` replace them;
 > the migration's downgrade recreates both tables structure-only (schema-reversible).
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1159,33 +1159,33 @@ GET /v2/partials/buy-plans?lens=          (shell: switcher + lazy #bp-hub-body)
                              so the action re-renders THIS body into #bp-hub-body.
 ```
 
-**Trading workspace — resell/excess split-panel (Chunk F, ADDITIVE).** `/v2/trading` is
+**Resell workspace — resell/excess split-panel (Chunk F, ADDITIVE).** `/v2/resell` is
 its own primary-nav tab (9th item in `mobile_nav.html`) served by the `v2_page` shell →
-`GET /v2/partials/trading/workspace` (router `app/routers/trading.py`, mounted alongside the
-OLD `excess` router which a later cutover chunk removes). The workspace is a `splitPanel('trading')`
+`GET /v2/partials/resell/workspace` (router `app/routers/resell.py`, mounted alongside the
+OLD `excess` router which a later cutover chunk removes). The workspace is a `splitPanel('resell')`
 shell: lens pills (My Lists / Open to Me, buy-plans-hub pattern) + a `stat_card` triage strip
 (Open · Offers to review · Take-all · Bids out · Awarded — each card a one-click stage filter) +
 a lazy left list and a right detail. Logic stays in `excess_service` (offers/import) +
 `excess_mirror` (publish); the router is thin (request → context → partial).
 
 ```
-GET /v2/partials/trading/workspace?lens=mine|open   (shell: pills + stats + splitPanel)
+GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + splitPanel)
     |
-    +-- GET /v2/partials/trading/lists?lens=&stage=&q=   (left list; rows → detail)
+    +-- GET /v2/partials/resell/lists?lens=&stage=&q=   (left list; rows → detail)
     |        lens=mine  → lists OWNED by user (seller name VISIBLE)
     |        lens=open  → posted lists owned by OTHERS, customer-ANONYMIZED (pure whitelist)
-    +-- GET /v2/partials/trading/{id}                    (right detail: breadcrumb + chips +
+    +-- GET /v2/partials/resell/{id}                    (right detail: breadcrumb + chips +
     |        lazy tabs Lines · Offers · Build Bid · Activity; customer chip owner-only)
     |        +-- GET .../{id}/lines    (adaptive: 1 line → .card, ≥2 → compact-table)
     |        +-- GET .../{id}/offers   (owner-only stack: pinned take-all banner +
     |        |     per-line offer tables + unmatched queue; non-owner sees nothing)
     |        +-- GET .../{id}/lines/{line_id}/offers  (per-line comparison: best emerald +
     |              price-spread bar, cloned from quote_builder/modal.html, NO auto-select)
-    +-- POST /api/trading/lists                          (create → excess_service.create_excess_list)
-    +-- POST /api/trading/{id}/lines                     (add line; resolves MaterialCard)
-    +-- POST /api/trading/{id}/import-preview|import-confirm  (reuse excess parsers + preview grid)
-    +-- POST /api/trading/{id}/publish                   (excess_mirror.publish_list → Sighting mirror)
-    +-- POST /api/trading/{id}/offers                    (excess_service.submit_offer; scope
+    +-- POST /api/resell/lists                          (create → excess_service.create_excess_list)
+    +-- POST /api/resell/{id}/lines                     (add line; resolves MaterialCard)
+    +-- POST /api/resell/{id}/import-preview|import-confirm  (reuse excess parsers + preview grid)
+    +-- POST /api/resell/{id}/publish                   (excess_mirror.publish_list → Sighting mirror)
+    +-- POST /api/resell/{id}/offers                    (excess_service.submit_offer; scope
           per_line|take_all; service enforces can_offer + the self-offer guard)
 ```
 
@@ -1195,7 +1195,7 @@ any take-all offer pins as a violet banner above the lines. Status pills reuse e
 `status_badge` keys — no new colors (open→sky, collecting→sourcing/amber, bid_out→quoted/violet,
 awarded→won/emerald, draft→muted). Customer hiding is view discipline (single-tenant): the
 offerer-facing list + non-owner detail project ONLY MPN/qty/condition, never the seller company.
-Demo seed: `python -m app.management.seed_trading_demo` (idempotent; `--reset` to clear) creates
+Demo seed: `python -m app.management.seed_resell_demo` (idempotent; `--reset` to clear) creates
 three deal shapes (40-line collecting w/ per-line + unmatched + take-all offers, a single-line
 one-off w/ 2 offers, an awarded list).
 
@@ -3470,10 +3470,10 @@ APScheduler (scheduler.py)
 BROWSER (HTMX + Alpine.js)
 
   0. Bottom navigation (mobile_nav.html):
-     Reqs | Sightings | Materials | Search | Buy Plans | Trading | CRM | ...
+     Reqs | Sightings | Materials | Search | Buy Plans | Resell | CRM | ...
      "Materials" tab links to /v2/materials, loads /v2/partials/materials/workspace
-     "Trading" tab links to /v2/trading, loads /v2/partials/trading/workspace
-     (resell/excess split-panel — see § Trading workspace).
+     "Resell" tab links to /v2/resell, loads /v2/partials/resell/workspace
+     (resell/excess split-panel — see § Resell workspace).
      Quotes has NO top-level nav tab — surfaced via the Reqs and CRM account
      tab strips (see § 5 Quote Building).
 
@@ -3723,7 +3723,7 @@ the current implementation.
 | Buy Plans | 10 | submit/approve, SO+PO verify, confirm-PO, flag-issue, cancel (service + line cascade), reset; ops-group admin tab |
 | Materials | 20 | CRUD, substitutes, stock levels, price history |
 | Sightings | 27 | CRUD, RFQ send, batch RFQ, inquiry (cross-requisition composer: vendor-affinity GET + composer-vendor POST), vendor+part unavailability (mark/clear/reason modal) |
-| Trading | 20 | Resell-brokerage workspace (`routers/trading.py`): lists, line items, import, inbound offers (per_line/take_all + unmatched queue), best-price rollup, build/close bid-back + PDF. Replaced the removed old-excess router (bids/solicitations gone) |
+| Resell | 20 | Resell-brokerage workspace (`routers/resell.py`): lists, line items, import, inbound offers (per_line/take_all + unmatched queue), best-price rollup, build/close bid-back + PDF. Replaced the removed old-excess router (bids/solicitations gone) |
 | AI | 18 | Parse email, normalize, find contacts, draft RFQ |
 | Proactive | 12 | Matches, refresh, dismiss, send, scorecard |
 | Prospects | 9 | HTMX tab only (JSON `/api/prospects/*` removed, consolidated): list, stats, add-domain, detail, claim, dismiss, release, enrich (background — spawns run_enrichment_job; pulls real contacts + firmographics via Lusha chain: enrich_entity + find_suggested_contacts, fill-only onto prospect columns; recomputes both fit_score and readiness_score; 24h gate prevents repeat paid pulls), enrich-status (poll; HTTP 286 stops) |

--- a/tests/e2e/test_navigation_smoke.py
+++ b/tests/e2e/test_navigation_smoke.py
@@ -23,7 +23,7 @@ NAV_ITEMS = [
     ("buy-plans", "/v2/buy-plans", "/v2/partials/buy-plans"),
     ("follow-ups", "/v2/follow-ups", "/v2/partials/follow-ups"),
     ("proactive", "/v2/proactive", "/v2/partials/proactive"),
-    ("trading", "/v2/trading", "/v2/partials/trading/workspace"),
+    ("resell", "/v2/resell", "/v2/partials/resell/workspace"),
     ("settings", "/v2/settings", "/v2/partials/settings"),
 ]
 

--- a/tests/test_excess_service_comprehensive.py
+++ b/tests/test_excess_service_comprehensive.py
@@ -227,7 +227,7 @@ class TestGetExcessStats:
         item = _make_line_item(db_session, el)
 
         # An inbound broker offer (an OPEN ExcessOffer with a matched line) — the
-        # Trading replacement for the old per-line bid.
+        # Resell replacement for the old per-line bid.
         submit_offer(
             db_session,
             list_id=el.id,

--- a/tests/test_htmx_views.py
+++ b/tests/test_htmx_views.py
@@ -186,7 +186,7 @@ class TestV2FullPages:
             "/v2/vendors",
             "/v2/customers",
             "/v2/buy-plans",
-            "/v2/trading",
+            "/v2/resell",
             "/v2/quotes",
             "/v2/settings",
             "/v2/prospecting",

--- a/tests/test_htmx_views_coverage.py
+++ b/tests/test_htmx_views_coverage.py
@@ -174,7 +174,7 @@ class TestV2PageRouting:
         [
             "/v2/crm",
             "/v2/sightings",
-            "/v2/trading/1",
+            "/v2/resell/1",
             "/v2/prospecting/1",
             "/v2/trouble-tickets/1",
         ],

--- a/tests/test_htmx_views_deep.py
+++ b/tests/test_htmx_views_deep.py
@@ -138,7 +138,7 @@ class TestV2PagePathVariants:
         "path",
         [
             "/v2/buy-plans",
-            "/v2/trading",
+            "/v2/resell",
             "/v2/quotes",
             "/v2/prospecting",
             "/v2/proactive",
@@ -152,7 +152,7 @@ class TestV2PagePathVariants:
             "/v2/materials/1",
             "/v2/prospecting/1",
             "/v2/trouble-tickets/1",
-            "/v2/trading/1",
+            "/v2/resell/1",
             "/v2/prospecting/5",
             "/v2/sourcing/leads/1",
         ],

--- a/tests/test_htmx_views_nightly10.py
+++ b/tests/test_htmx_views_nightly10.py
@@ -102,8 +102,8 @@ class TestShellPageRouting:
         "path",
         [
             "/v2/buy-plans/42",
-            "/v2/trading",
-            "/v2/trading/7",
+            "/v2/resell",
+            "/v2/resell/7",
             "/v2/quotes",
             "/v2/quotes/99",
             "/v2/settings",

--- a/tests/test_models_excess.py
+++ b/tests/test_models_excess.py
@@ -1,4 +1,4 @@
-"""Tests for Excess Inventory (Trading) models and schemas.
+"""Tests for Excess Inventory (Resell) models and schemas.
 
 Verifies ExcessList / ExcessLineItem model creation, defaults, cascade deletes,
 and Pydantic validation.

--- a/tests/test_resell_bid_back.py
+++ b/tests/test_resell_bid_back.py
@@ -1,4 +1,4 @@
-"""test_trading_bid_back.py — Bid-back assembly + clean export + posting window (Chunk
+"""test_resell_bid_back.py — Bid-back assembly + clean export + posting window (Chunk
 E).
 
 Covers the outbound bid-back the owner assembles from collected inbound offers:

--- a/tests/test_resell_capabilities.py
+++ b/tests/test_resell_capabilities.py
@@ -1,4 +1,4 @@
-"""test_trading_capabilities.py — Role-derived capability checks for the Trading module.
+"""test_resell_capabilities.py — Role-derived capability checks for the Resell module.
 
 Covers ``can_post`` (sales + traders, plus admin/manager) and ``can_offer``
 (buyers + traders, plus admin/manager), derived from ``User.role`` — the spec

--- a/tests/test_resell_mirror.py
+++ b/tests/test_resell_mirror.py
@@ -1,4 +1,4 @@
-"""test_trading_mirror.py — Sighting live-mirror + virtual requirement (Chunk C).
+"""test_resell_mirror.py — Sighting live-mirror + virtual requirement (Chunk C).
 
 Covers the additive Sighting live-mirror (spec §"Sighting live-mirror"): each posted
 ``ExcessLineItem`` mirrors into a ``Sighting`` so the existing matcher sees it for free,

--- a/tests/test_resell_models.py
+++ b/tests/test_resell_models.py
@@ -1,4 +1,4 @@
-"""Tests for the additive Trading (resell-brokerage) schema foundation.
+"""Tests for the additive Resell (resell-brokerage) schema foundation.
 
 Covers the inbound-offer models (ExcessOffer / ExcessOfferLine), the
 additive columns on the kept models (ExcessLineItem rollup + material_card_id,

--- a/tests/test_resell_offers.py
+++ b/tests/test_resell_offers.py
@@ -1,6 +1,6 @@
-"""test_trading_offers.py — Inbound-offer submission + line MaterialCard resolve.
+"""test_resell_offers.py — Inbound-offer submission + line MaterialCard resolve.
 
-Covers the additive Trading offer-collection core (spec §"Offer collection"):
+Covers the additive Resell offer-collection core (spec §"Offer collection"):
 - ``ExcessLineItem.material_card_id`` resolved on the import/create path (reusing
   the canonical ``resolve_material_card``; nullable when the MPN won't resolve).
 - ``submit_offer`` for both scopes:

--- a/tests/test_resell_rollup.py
+++ b/tests/test_resell_rollup.py
@@ -1,4 +1,4 @@
-"""test_trading_rollup.py — Best-price rollup across a line's inbound offers.
+"""test_resell_rollup.py — Best-price rollup across a line's inbound offers.
 
 Covers ``recompute_line_rollup`` / ``withdraw_offer`` (spec §"Offer collection",
 "best-price rollup per line"): best_offer_unit_price = min unit_price across the

--- a/tests/test_resell_routes.py
+++ b/tests/test_resell_routes.py
@@ -1,4 +1,4 @@
-"""test_trading_routes.py — Route/render tests for the Trading workspace (Chunk F).
+"""test_resell_routes.py — Route/render tests for the Resell workspace (Chunk F).
 
 Exercises the NEW additive endpoints end-to-end with the TestClient: each returns
 200 + the right partial for a seeded list; an offer submit creates an ExcessOffer;
@@ -98,16 +98,16 @@ def single_line_list(db_session: Session, trader_user: User, test_company: Compa
 def test_workspace_renders(client, trader_user, posted_list):
     """The split-panel shell renders with the lens pills + stat strip."""
     # client's overridden user is the buyer fixture; the route still renders.
-    resp = client.get("/v2/partials/trading/workspace")
+    resp = client.get("/v2/partials/resell/workspace")
     assert resp.status_code == 200
     body = resp.text
     assert "My Lists" in body
     assert "Open to Me" in body
-    assert "split-trading" in body  # splitPanel container
+    assert "split-resell" in body  # splitPanel container
 
 
 def test_full_page_route(client, trader_user):
-    """/v2/trading serves the base shell, wired to load the workspace partial.
+    """/v2/resell serves the base shell, wired to load the workspace partial.
 
     v2_page authenticates via the session-based get_user (not the Depends-injected
     require_user), so we patch that helper — the established pattern for shell tests.
@@ -115,9 +115,9 @@ def test_full_page_route(client, trader_user):
     from unittest.mock import patch
 
     with patch("app.routers.htmx_views.get_user", return_value=trader_user):
-        resp = client.get("/v2/trading")
+        resp = client.get("/v2/resell")
     assert resp.status_code == 200
-    assert "/v2/partials/trading/workspace" in resp.text
+    assert "/v2/partials/resell/workspace" in resp.text
 
 
 def test_lists_mine_shows_customer(client, db_session, trader_user, posted_list):
@@ -128,7 +128,7 @@ def test_lists_mine_shows_customer(client, db_session, trader_user, posted_list)
 
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
-        resp = client.get("/v2/partials/trading/lists?lens=mine")
+        resp = client.get("/v2/partials/resell/lists?lens=mine")
         assert resp.status_code == 200
         assert posted_list.title in resp.text
         assert "Acme Electronics" in resp.text  # test_company name visible to owner
@@ -139,7 +139,7 @@ def test_lists_mine_shows_customer(client, db_session, trader_user, posted_list)
 def test_lists_open_lens_hides_customer(client, db_session, trader_user, posted_list):
     """Open-to-Me lens (offerer view) lists the posting but NEVER the seller name."""
     # The default client user is the buyer fixture (!= owner) → sees it under 'open'.
-    resp = client.get("/v2/partials/trading/lists?lens=open")
+    resp = client.get("/v2/partials/resell/lists?lens=open")
     assert resp.status_code == 200
     body = resp.text
     assert posted_list.title in body
@@ -152,24 +152,24 @@ def test_lists_open_lens_hides_customer(client, db_session, trader_user, posted_
 
 def test_detail_renders_tabs(client, trader_user, posted_list):
     """Detail renders the breadcrumb + chips + the four lazy tabs."""
-    resp = client.get(f"/v2/partials/trading/{posted_list.id}")
+    resp = client.get(f"/v2/partials/resell/{posted_list.id}")
     assert resp.status_code == 200
     body = resp.text
-    assert "Trading" in body and posted_list.title in body
+    assert "Resell" in body and posted_list.title in body
     for label in ("Lines", "Offers", "Build Bid", "Activity"):
         assert label in body
 
 
 def test_lines_multi_is_table(client, trader_user, posted_list):
     """≥2 lines → compact table shape."""
-    resp = client.get(f"/v2/partials/trading/{posted_list.id}/lines")
+    resp = client.get(f"/v2/partials/resell/{posted_list.id}/lines")
     assert resp.status_code == 200
     assert "compact-table" in resp.text
 
 
 def test_lines_single_is_card(client, trader_user, single_line_list):
     """Exactly 1 line → single card, no table chrome."""
-    resp = client.get(f"/v2/partials/trading/{single_line_list.id}/lines")
+    resp = client.get(f"/v2/partials/resell/{single_line_list.id}/lines")
     assert resp.status_code == 200
     body = resp.text
     assert "compact-table" not in body
@@ -183,7 +183,7 @@ def test_offers_tab_renders(client, trader_user, posted_list):
 
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
-        resp = client.get(f"/v2/partials/trading/{posted_list.id}/offers")
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/offers")
         assert resp.status_code == 200
     finally:
         app.dependency_overrides.pop(require_user, None)
@@ -197,7 +197,7 @@ def test_submit_offer_creates_excess_offer(client, db_session, trader_user, post
     user)."""
     line = db_session.query(ExcessLineItem).filter_by(excess_list_id=posted_list.id).first()
     resp = client.post(
-        f"/api/trading/{posted_list.id}/offers",
+        f"/api/resell/{posted_list.id}/offers",
         data={
             "scope": "per_line",
             "mpn_raw": line.part_number,
@@ -220,7 +220,7 @@ def test_submit_offer_creates_excess_offer(client, db_session, trader_user, post
 def test_submit_take_all_offer(client, db_session, trader_user, posted_list):
     """A take-all offer submit creates a take_all-scoped ExcessOffer (no lines)."""
     resp = client.post(
-        f"/api/trading/{posted_list.id}/offers",
+        f"/api/resell/{posted_list.id}/offers",
         data={"scope": "take_all", "take_all_total_price": "48500.00", "notes": "whole lot"},
     )
     assert resp.status_code == 200
@@ -238,7 +238,7 @@ def test_self_offer_blocked(client, db_session, trader_user, posted_list):
     app.dependency_overrides[require_user] = lambda: trader_user  # the owner
     try:
         resp = client.post(
-            f"/api/trading/{posted_list.id}/offers",
+            f"/api/resell/{posted_list.id}/offers",
             data={"scope": "per_line", "mpn_raw": "XCVU9P-2FLGA2104I", "quantity": "10"},
         )
         assert resp.status_code == 403
@@ -257,7 +257,7 @@ def test_create_list(client, db_session, trader_user, test_company):
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
         resp = client.post(
-            "/api/trading/lists",
+            "/api/resell/lists",
             data={"title": "Brand new list", "company_id": str(test_company.id), "notes": "n"},
         )
         assert resp.status_code == 200
@@ -278,7 +278,7 @@ def test_add_line_renders_lines(client, db_session, trader_user, draft_list):
     try:
         before = db_session.query(ExcessLineItem).filter_by(excess_list_id=draft_list.id).count()
         resp = client.post(
-            f"/api/trading/{draft_list.id}/lines",
+            f"/api/resell/{draft_list.id}/lines",
             data={"part_number": "LM358N", "quantity": "500", "manufacturer": "TI", "condition": "New"},
         )
         assert resp.status_code == 200
@@ -294,7 +294,7 @@ def test_offer_compare_renders(client, db_session, trader_user, posted_list, tes
     line = db_session.query(ExcessLineItem).filter_by(excess_list_id=posted_list.id).first()
     # Submit one offer as the buyer (client default user).
     client.post(
-        f"/api/trading/{posted_list.id}/offers",
+        f"/api/resell/{posted_list.id}/offers",
         data={"scope": "per_line", "mpn_raw": line.part_number, "quantity": "40", "unit_price": "9.99"},
     )
     # Owner (trader_user) can access the comparison.
@@ -303,7 +303,7 @@ def test_offer_compare_renders(client, db_session, trader_user, posted_list, tes
 
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
-        resp = client.get(f"/v2/partials/trading/{posted_list.id}/lines/{line.id}/offers")
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/lines/{line.id}/offers")
         assert resp.status_code == 200
         assert line.part_number in resp.text
         assert "Best" in resp.text
@@ -342,19 +342,19 @@ def draft_list(db_session: Session, trader_user: User, test_company: Company) ->
 def test_non_owner_draft_detail_404(client, draft_list, test_user):
     """Non-owner GET on a DRAFT list → 404 (existence not revealed)."""
     # The default client user (test_user, a buyer) is NOT the owner.
-    resp = client.get(f"/v2/partials/trading/{draft_list.id}")
+    resp = client.get(f"/v2/partials/resell/{draft_list.id}")
     assert resp.status_code == 404
 
 
 def test_non_owner_draft_lines_404(client, draft_list, test_user):
     """Non-owner GET on draft list's lines tab → 404."""
-    resp = client.get(f"/v2/partials/trading/{draft_list.id}/lines")
+    resp = client.get(f"/v2/partials/resell/{draft_list.id}/lines")
     assert resp.status_code == 404
 
 
 def test_non_owner_draft_offers_404(client, draft_list, test_user):
     """Non-owner GET on draft list's offers tab → 404."""
-    resp = client.get(f"/v2/partials/trading/{draft_list.id}/offers")
+    resp = client.get(f"/v2/partials/resell/{draft_list.id}/offers")
     assert resp.status_code == 404
 
 
@@ -369,13 +369,13 @@ def test_non_owner_posted_list_200_no_offers_no_customer(client, db_session, pos
     assert test_user.id != trader_user.id
 
     # Detail is visible (not 404/403).
-    resp = client.get(f"/v2/partials/trading/{posted_list.id}")
+    resp = client.get(f"/v2/partials/resell/{posted_list.id}")
     assert resp.status_code == 200
     # Customer name must not leak to non-owner.
     assert "Acme Electronics" not in resp.text
 
     # Offers tab: 200 but no offer payloads.
-    resp = client.get(f"/v2/partials/trading/{posted_list.id}/offers")
+    resp = client.get(f"/v2/partials/resell/{posted_list.id}/offers")
     assert resp.status_code == 200
     # The is_owner=False path renders an empty offers view — no offer rows.
     # The _offers.html template does not render offer rows when is_owner is False.
@@ -385,7 +385,7 @@ def test_non_owner_posted_list_200_no_offers_no_customer(client, db_session, pos
 def test_non_owner_add_line_403(client, posted_list, test_user):
     """Non-owner POST add-line → 403."""
     resp = client.post(
-        f"/api/trading/{posted_list.id}/lines",
+        f"/api/resell/{posted_list.id}/lines",
         data={"part_number": "HACK-001", "quantity": "1"},
     )
     assert resp.status_code == 403
@@ -394,7 +394,7 @@ def test_non_owner_add_line_403(client, posted_list, test_user):
 def test_non_owner_import_confirm_403(client, posted_list, test_user):
     """Non-owner POST import-confirm → 403."""
     resp = client.post(
-        f"/api/trading/{posted_list.id}/import-confirm",
+        f"/api/resell/{posted_list.id}/import-confirm",
         data={"rows_json": json.dumps([{"part_number": "HACK-002", "quantity": 1}])},
     )
     assert resp.status_code == 403
@@ -403,7 +403,7 @@ def test_non_owner_import_confirm_403(client, posted_list, test_user):
 def test_non_owner_line_offer_compare_403(client, db_session, posted_list, test_user):
     """Non-owner GET line-offer-compare → 403 (comparison is owner-only)."""
     line = db_session.query(ExcessLineItem).filter_by(excess_list_id=posted_list.id).first()
-    resp = client.get(f"/v2/partials/trading/{posted_list.id}/lines/{line.id}/offers")
+    resp = client.get(f"/v2/partials/resell/{posted_list.id}/lines/{line.id}/offers")
     assert resp.status_code == 403
 
 
@@ -414,7 +414,7 @@ def test_owner_draft_detail_200(client, db_session, draft_list, trader_user):
 
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
-        resp = client.get(f"/v2/partials/trading/{draft_list.id}")
+        resp = client.get(f"/v2/partials/resell/{draft_list.id}")
         assert resp.status_code == 200
         assert "Private draft" in resp.text
     finally:
@@ -434,14 +434,14 @@ def test_owner_offers_tab_full_data(client, db_session, posted_list, trader_user
     line = db_session.query(ExcessLineItem).filter_by(excess_list_id=posted_list.id).first()
     # Submit an offer as the buyer (non-owner client).
     client.post(
-        f"/api/trading/{posted_list.id}/offers",
+        f"/api/resell/{posted_list.id}/offers",
         data={"scope": "per_line", "mpn_raw": line.part_number, "quantity": "10", "unit_price": "5.00"},
     )
 
     # Now view the offers tab AS THE OWNER.
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
-        resp = client.get(f"/v2/partials/trading/{posted_list.id}/offers")
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/offers")
         assert resp.status_code == 200
         body = resp.text
         # Owner sees the offer table — the "offers are private" banner must NOT appear.
@@ -471,7 +471,7 @@ def _seed_best_price(db_session, posted_list, price="100.0000"):
 def test_build_bid_tab_owner_only(client, db_session, trader_user, posted_list, test_user):
     """Non-owner GET on the Build-Bid tab → 403; owner → 200."""
     # Default client user (buyer) is NOT the owner.
-    resp = client.get(f"/v2/partials/trading/{posted_list.id}/build-bid")
+    resp = client.get(f"/v2/partials/resell/{posted_list.id}/build-bid")
     assert resp.status_code == 403
 
     from app.dependencies import require_user
@@ -479,7 +479,7 @@ def test_build_bid_tab_owner_only(client, db_session, trader_user, posted_list, 
 
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
-        resp = client.get(f"/v2/partials/trading/{posted_list.id}/build-bid")
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/build-bid")
         assert resp.status_code == 200
         assert "Assemble bid" in resp.text
     finally:
@@ -498,7 +498,7 @@ def test_assemble_bid_creates_customer_bid(client, db_session, trader_user, post
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
         resp = client.post(
-            f"/api/trading/{posted_list.id}/bid",
+            f"/api/resell/{posted_list.id}/bid",
             data={
                 "selections_json": json.dumps([{"excess_line_item_id": line.id, "customer_unit_price": ""}]),
             },
@@ -515,7 +515,7 @@ def test_assemble_bid_creates_customer_bid(client, db_session, trader_user, post
 def test_assemble_bid_non_owner_403(client, posted_list, test_user):
     """Non-owner POST on the bid endpoint → 403."""
     resp = client.post(
-        f"/api/trading/{posted_list.id}/bid",
+        f"/api/resell/{posted_list.id}/bid",
         data={"selections_json": json.dumps([{"excess_line_item_id": 1}])},
     )
     assert resp.status_code == 403
@@ -548,12 +548,12 @@ def test_bid_pdf_download_owner_only(client, db_session, trader_user, posted_lis
     )
 
     # Non-owner blocked.
-    resp = client.get(f"/api/trading/{posted_list.id}/bid/{bid.id}/pdf")
+    resp = client.get(f"/api/resell/{posted_list.id}/bid/{bid.id}/pdf")
     assert resp.status_code == 403
 
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
-        resp = client.get(f"/api/trading/{posted_list.id}/bid/{bid.id}/pdf")
+        resp = client.get(f"/api/resell/{posted_list.id}/bid/{bid.id}/pdf")
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/pdf"
         assert resp.content[:4] == b"%PDF"
@@ -565,7 +565,7 @@ def test_close_endpoint_owner_only(client, db_session, trader_user, posted_list,
     """The close endpoint is owner-only; owner close stamps close_at + bid_out
     status."""
     # Non-owner blocked.
-    resp = client.post(f"/api/trading/{posted_list.id}/close")
+    resp = client.post(f"/api/resell/{posted_list.id}/close")
     assert resp.status_code == 403
 
     from app.dependencies import require_user
@@ -573,7 +573,7 @@ def test_close_endpoint_owner_only(client, db_session, trader_user, posted_list,
 
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
-        resp = client.post(f"/api/trading/{posted_list.id}/close")
+        resp = client.post(f"/api/resell/{posted_list.id}/close")
         assert resp.status_code == 200
         db_session.refresh(posted_list)
         assert posted_list.status == ExcessListStatus.BID_OUT
@@ -595,7 +595,7 @@ def test_add_line_to_posted_list_returns_409(client, db_session, trader_user, po
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
         resp = client.post(
-            f"/api/trading/{posted_list.id}/lines",
+            f"/api/resell/{posted_list.id}/lines",
             data={"part_number": "LOCK-TEST-001", "quantity": "10"},
         )
         assert resp.status_code == 409
@@ -614,7 +614,7 @@ def test_add_line_to_draft_list_works(client, db_session, trader_user, draft_lis
     try:
         before = db_session.query(ExcessLineItem).filter_by(excess_list_id=draft_list.id).count()
         resp = client.post(
-            f"/api/trading/{draft_list.id}/lines",
+            f"/api/resell/{draft_list.id}/lines",
             data={"part_number": "DRAFT-ADD-002", "quantity": "5"},
         )
         assert resp.status_code == 200
@@ -632,7 +632,7 @@ def test_import_confirm_to_posted_list_returns_409(client, db_session, trader_us
     app.dependency_overrides[require_user] = lambda: trader_user
     try:
         resp = client.post(
-            f"/api/trading/{posted_list.id}/import-confirm",
+            f"/api/resell/{posted_list.id}/import-confirm",
             data={"rows_json": json.dumps([{"part_number": "HACK-003", "quantity": 1}])},
         )
         assert resp.status_code == 409

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -508,8 +508,8 @@ def test_low_contrast_secondary_text_does_not_grow():
     Ratchet only (decorative icon grays are fine) — caps growth rather than banning
     outright.
     """
-    BASELINE = 413  # +3 for the Trading workspace partials (lists/detail/offers muted
-    # metadata copy — the established trading look; the bid-builder itself uses the
+    BASELINE = 413  # +3 for the Resell workspace partials (lists/detail/offers muted
+    # metadata copy — the established resell look; the bid-builder itself uses the
     # higher-contrast text-gray-600 per this rule).
     count = _tpl_substring_count("text-gray-500")
     assert count <= BASELINE, (
@@ -535,8 +535,8 @@ def test_inline_table_cell_padding_does_not_grow():
 
     Ratchet.
     """
-    BASELINE = 527  # +4 for the Trading workspace email-solicitation / offer tables
-    # (inline-padded cells in the trading partials; the bid-builder + bid PDF use
+    BASELINE = 527  # +4 for the Resell workspace email-solicitation / offer tables
+    # (inline-padded cells in the resell partials; the bid-builder + bid PDF use
     # .compact-table / CSS cell padding, not inline px-/py-).
     count = _tpl_regex_count(r'<t[dh][^>]*class="[^"]*\bp[xy]-[0-9]')
     assert count <= BASELINE, (
@@ -550,8 +550,8 @@ def test_inline_button_sizing_does_not_grow():
 
     Macro files are the canonical source and are excluded. Ratchet.
     """
-    BASELINE = 275  # 272 + 3 for the Trading workspace scope-toggle / lens-pill buttons
-    # (inline-padded pills in the trading partials; the bid-builder buttons use .btn/.btn-sm).
+    BASELINE = 275  # 272 + 3 for the Resell workspace scope-toggle / lens-pill buttons
+    # (inline-padded pills in the resell partials; the bid-builder buttons use .btn/.btn-sm).
     count = _tpl_regex_count(r'<button[^>]*class="[^"]*\bp[xy]-[0-9]', exclude={"_macros.html"})
     assert count <= BASELINE, (
         f"inline-sized <button> rose to {count} (baseline {BASELINE}). Use .btn-sm/md/lg or the btn_* macros."


### PR DESCRIPTION
## What
Renames the just-shipped module from **Trading** → **Resell** (the user-facing name), end-to-end and consistently — no `trading` vocabulary left behind a "Resell" label.

- Routes: `/v2/trading` → `/v2/resell`, `/v2/partials/trading/*` → `/v2/partials/resell/*`, `/api/trading/*` → `/api/resell/*`
- Router file `app/routers/trading.py` → `app/routers/resell.py` (+ functions `trading_*` → `resell_*`); `main.py` registration
- Templates dir `htmx/partials/trading/` → `htmx/partials/resell/` (includes + hx-* paths updated)
- Nav tab + JS active-tab map; page titles/breadcrumb "Trading" → "Resell"
- `seed_trading_demo.py` → `seed_resell_demo.py`; `test_trading_*.py` → `test_resell_*.py` (+ updated refs in shared test files)
- Doc-comments + APP_MAP updated

## Kept intentionally
- The **`excess_*` data layer** (`ExcessList`/`ExcessOffer`/`excess_service.py`/`excess_mirror.py`/`bid_back_service.py`) — that's the data vocabulary ("Resell/Excess Brokerage").
- Migration `127_trading_additive_schema.py` (shipped — renaming a shipped migration is forbidden).
- 3 **coincidental** "trading" mentions left intact: "trading team" (unified_score), "trading history" (search), "Phoenix Trading" (a test company name).

## Testing
Full suite **18,899 passed / 0 errors**; ruff clean; `import app.main` clean. Grep-sweep confirms zero `trading` route/router/template/seed remnants in `app/` + `tests/` (only the 3 coincidental spots). Pure rename — no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cj2RipLxT5U2E8RmcQQ4ng