### PR TITLE
test(crm): make activity-tab date-header test midnight-deterministic

### DIFF
--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -4764,7 +4764,13 @@ class TestAccountActivityTab:
         """ActivityLog rows spanning all sections plus a variety of types."""
         from app.models.intelligence import ActivityLog
 
-        now = datetime.now(timezone.utc)
+        # Anchor to noon UTC of the current day, NOT the literal current instant.
+        # The rows below place "today" activities at now - 1/2/3 hours; with a
+        # literal now() those land on the PREVIOUS calendar day when the suite
+        # runs within ~3h after UTC midnight, so the "Today" date header never
+        # renders and this test flakes. Noon ± a few hours stays on today's date
+        # regardless of run time, making the date-grouping assertions deterministic.
+        now = datetime.now(timezone.utc).replace(hour=12, minute=0, second=0, microsecond=0)
         rows = [
             ActivityLog(
                 company_id=_activity_company.id,


### PR DESCRIPTION
## What

`TestAccountActivityTab::test_date_headers_appear_within_sections` was **red on `main`** during the post-UTC-midnight window.

## Root cause (flaky, not a code bug)

The `_mixed_activities` fixture creates its "today" activities at `now - 1/2/3 hours` using a literal `datetime.now(timezone.utc)`. The test then asserts a **"Today"** date header renders. When the suite runs within ~3h after UTC midnight, those "hours ago" rows fall on the **previous calendar day** → the template renders "Yesterday" instead of "Today" → assertion fails.

The rendering code (`activity_tab.html` date-grouping) is correct; the fixture's notion of "today" was the defect.

## Fix

Anchor the fixture's reference instant to **noon UTC of the current day**. Noon ± a few hours always stays on today's calendar date regardless of run time, so the Today / Yesterday / N-days-ago grouping is deterministic.

- **Fixture-only change** — no rendering/route code touched.
- Verified: full `TestAccountActivityTab` class green (8 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)