### PR TITLE
feat(ownership-p4): sweep cooldown + manager reassign + rep/manager notify

### DIFF
--- a/MIGRATION_NUMBERS_IN_FLIGHT.txt
+++ b/MIGRATION_NUMBERS_IN_FLIGHT.txt
@@ -63,3 +63,4 @@
 138  feat/crm-steps-3456  RequisitionTask.requisition_id nullable + company_id/site_contact_id FKs + CHECK >=1 parent (general account/contact tasks); RE-NUMBERED 135->138; RE-CHAINED onto 137_contact_fields
 139  fix/contact-active-visibility  site_contacts.is_active server_default=true + NULL backfill; chains onto 138_general_tasks; single head verified via `alembic heads`
 140  feat/ownership-p3-collaborators  account_collaborators table (Phase 3: helper collaborator access); chains onto 139_contact_is_active_default; single head verified via `alembic heads`
+141  feat/ownership-p4-compliance  prospect_accounts.reclaim_blocked_until (Phase 4: 30-day reclaim cooldown after sweep; managers bypass via reassign); chains onto 140_account_collaborators; single head verified via `alembic heads`

--- a/alembic/versions/141_reclaim_cooldown.py
+++ b/alembic/versions/141_reclaim_cooldown.py
@@ -1,0 +1,38 @@
+"""Add reclaim_blocked_until to prospect_accounts (Phase 4: compliance cooldown).
+
+Revision ID: 141_reclaim_cooldown
+Revises: 140_account_collaborators
+Create Date: 2026-06-24
+
+reclaim_blocked_until enforces a 30-day cooldown after an account is swept: the
+former owner cannot reclaim it until this timestamp passes (see
+prospect_reclamation.reclaim_prospect_account). Managers/admins bypass the cooldown
+via the reassign endpoint, which also clears this column. Set at sweep time to
+swept_at + 30 days.
+
+Schema:
+  - prospect_accounts.reclaim_blocked_until: timezone-aware DateTime, nullable
+
+Downgrade: drops the column.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "141_reclaim_cooldown"
+down_revision = "140_account_collaborators"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "prospect_accounts",
+        sa.Column("reclaim_blocked_until", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("prospect_accounts", "reclaim_blocked_until")

--- a/app/models/prospect_account.py
+++ b/app/models/prospect_account.py
@@ -84,6 +84,11 @@ class ProspectAccount(Base):
     swept_at = Column(UTCDateTime, nullable=True)
     parked_by_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
 
+    # SP4 Phase 4 — compliance cooldown: a former owner cannot reclaim a swept account
+    # until this timestamp passes (managers/admins bypass it via reassign). Set at sweep
+    # time to swept_at + 30 days; cleared on manager reassign.
+    reclaim_blocked_until = Column(UTCDateTime, nullable=True)
+
     # Relationships
     company = relationship("Company", foreign_keys=[company_id])
     claimed_by_user = relationship("User", foreign_keys=[claimed_by])

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -11741,6 +11741,60 @@ async def reclaim_prospect_htmx(
     )
 
 
+@router.post("/v2/partials/prospects/{prospect_id}/reassign", response_class=HTMLResponse)
+async def reassign_prospect_htmx(
+    request: Request,
+    prospect_id: int,
+    to_user_id: int = Form(...),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Manager/admin reassigns a swept prospect's company to another owner.
+
+    Overrides the Phase 4 reclaim cooldown: dismisses the swept prospect, sets the new
+    owner, and clears the cooldown. Manager/admin only. Returns the refreshed prospect
+    card/detail with a showToast trigger.
+    """
+    if not is_manager_or_admin(user):
+        raise HTTPException(403, "Only a manager or admin can reassign an account")
+
+    from ..services.prospect_reclamation import reassign_account
+
+    prospect = db.get(ProspectAccount, prospect_id)
+    if not prospect:
+        raise HTTPException(404, "Prospect not found")
+    if not prospect.company_id:
+        raise HTTPException(400, "Prospect is not linked to a company; nothing to reassign")
+
+    error = None
+    result = None
+    try:
+        result = reassign_account(prospect.company_id, to_user_id, user, db)
+    except HTTPException:
+        raise
+    except LookupError:
+        raise HTTPException(404, "Company not found")
+    except ValueError as e:
+        error = str(e)
+
+    prospect = db.get(ProspectAccount, prospect_id)
+    if not prospect:
+        raise HTTPException(404, "Prospect not found")
+
+    form = await request.form()
+    flt_status = form.get("flt_status", "")
+    msg = error or f"Reassigned {result['company_name']}"
+    return _prospect_action_response(
+        request,
+        user,
+        db,
+        prospect,
+        message=msg,
+        kind="error" if error else "success",
+        flt_status=flt_status,
+    )
+
+
 # ── Settings partials ────────────────────────────────────────────────
 
 

--- a/app/services/prospect_reclamation.py
+++ b/app/services/prospect_reclamation.py
@@ -9,7 +9,7 @@ Depends on: app/services/activity_service.py, app/services/prospect_claim.py,
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from loguru import logger
 from sqlalchemy.orm import Session
@@ -18,6 +18,10 @@ from ..config import settings
 from ..models.auth import User
 from ..models.crm import Company
 from ..models.prospect_account import ProspectAccount
+
+# Phase 4 compliance: a former owner cannot reclaim a freshly-swept account for this many
+# days (managers/admins bypass via reassign). Set on the ProspectAccount at sweep time.
+RECLAIM_COOLDOWN_DAYS = 30
 
 # ── Internal DB-injectable sweep (testable) ───────────────────────────────────
 
@@ -103,6 +107,7 @@ async def job_account_sweep_with_db(db: Session) -> None:
                 if pa:
                     pa.swept_from_owner_id = owner_id
                     pa.swept_at = now
+                    pa.reclaim_blocked_until = now + timedelta(days=RECLAIM_COOLDOWN_DAYS)
                     pa.discovery_source = "auto_sweep"
                     db.commit()
 
@@ -123,6 +128,46 @@ async def job_account_sweep_with_db(db: Session) -> None:
     logger.info("SP4 sweep complete: swept={}, skipped={}", swept_count, skipped_count)
 
 
+def _sweep_notification_recipients(owner: User, db: Session) -> list[str]:
+    """Resolve the deduped recipient list for a sweep notification.
+
+    Includes the rep (former owner), every ACTIVE user with role MANAGER or ADMIN, and
+    the configured settings.account_sweep_manager_email. Order is preserved with the rep
+    first; comparison is case-insensitive so the same address is never sent twice.
+
+    Called by: _send_sweep_notification
+    """
+    from ..constants import UserRole
+
+    recipients: list[str] = []
+    seen: set[str] = set()
+
+    def _add(address: str | None) -> None:
+        if not address:
+            return
+        key = address.strip().lower()
+        if not key or key in seen:
+            return
+        seen.add(key)
+        recipients.append(address.strip())
+
+    _add(owner.email)
+
+    supervisors = (
+        db.query(User)
+        .filter(
+            User.role.in_([UserRole.MANAGER, UserRole.ADMIN]),
+            User.is_active.is_(True),
+        )
+        .all()
+    )
+    for sup in supervisors:
+        _add(sup.email)
+
+    _add(settings.account_sweep_manager_email)
+    return recipients
+
+
 async def _send_sweep_notification(
     owner: User,
     company: Company,
@@ -130,10 +175,13 @@ async def _send_sweep_notification(
     prospect_id: int,
     db: Session,
 ) -> None:
-    """Send Graph /me/sendMail loss-notification to owner.
+    """Send a Graph /me/sendMail loss-notification to the rep and every supervisor.
 
-    Uses get_valid_token(owner, db). On missing token: log warning, return.
-    CC: settings.account_sweep_manager_email if set.
+    Recipients: the former owner, all active MANAGER/ADMIN users, and the configured
+    settings.account_sweep_manager_email (deduped via _sweep_notification_recipients).
+    Sends one message per recipient so a single bad address can't suppress the rest —
+    each send is wrapped in try/except so one failure never breaks the sweep. Uses the
+    OWNER's token (get_valid_token); on a missing token: log a warning and return.
 
     Called by: job_account_sweep_with_db
     """
@@ -150,36 +198,44 @@ async def _send_sweep_notification(
         return
 
     last_active_str = last_activity_at.strftime("%Y-%m-%d") if last_activity_at else "never"
-
-    cc_recipients = []
-    if settings.account_sweep_manager_email:
-        cc_recipients = [{"emailAddress": {"address": settings.account_sweep_manager_email}}]
-
-    payload = {
-        "message": {
-            "subject": f"[AVAIL] Account swept to prospecting pool: {company.name}",
-            "body": {
-                "contentType": "HTML",
-                "content": (
-                    f"<p>Your account <strong>{company.name}</strong> has been automatically moved to the "
-                    f"prospecting pool due to inactivity.</p>"
-                    f"<p><strong>Last activity:</strong> {last_active_str}</p>"
-                    f"<p><strong>Inactivity threshold:</strong> {settings.account_sweep_inactivity_days} days</p>"
-                    f"<p>You can reclaim this account from the Prospecting tab if needed.</p>"
-                ),
-            },
-            "toRecipients": [{"emailAddress": {"address": owner.email}}],
-            "ccRecipients": cc_recipients,
-        },
-        "saveToSentItems": "false",
-    }
+    body_html = (
+        f"<p>The account <strong>{company.name}</strong> has been automatically moved to the "
+        f"prospecting pool due to inactivity.</p>"
+        f"<p><strong>Last activity:</strong> {last_active_str}</p>"
+        f"<p><strong>Inactivity threshold:</strong> {settings.account_sweep_inactivity_days} days</p>"
+        f"<p>It can be reclaimed from the Prospecting tab "
+        f"(former owners after the {RECLAIM_COOLDOWN_DAYS}-day cooldown; "
+        f"managers may reassign it at any time).</p>"
+    )
 
     gc = GraphClient(token)
-    try:
-        await gc.post_json("/me/sendMail", payload)
-        logger.info("SP4 sweep notification sent to {} for company {}", owner.email, company.name)
-    except Exception:
-        logger.exception("SP4 sweep notification failed for {} company {}", owner.email, company.name)
+    recipients = _sweep_notification_recipients(owner, db)
+    sent = 0
+    for address in recipients:
+        payload = {
+            "message": {
+                "subject": f"[AVAIL] Account swept to prospecting pool: {company.name}",
+                "body": {"contentType": "HTML", "content": body_html},
+                "toRecipients": [{"emailAddress": {"address": address}}],
+            },
+            "saveToSentItems": "false",
+        }
+        try:
+            await gc.post_json("/me/sendMail", payload)
+            sent += 1
+        except Exception:
+            logger.exception(
+                "SP4 sweep notification failed for {} (company {})",
+                address,
+                company.name,
+            )
+
+    logger.info(
+        "SP4 sweep notification: sent {}/{} for company {}",
+        sent,
+        len(recipients),
+        company.name,
+    )
 
 
 # ── Auto-surface (Task 6) ─────────────────────────────────────────────────────
@@ -299,8 +355,12 @@ def reclaim_prospect_account(
 ) -> dict:
     """Reclaim a swept prospect: re-assign Company owner, remove from pool, reset clock.
 
-    Permission: swept_from_owner_id == user_id OR is_admin OR
-                user.email == settings.account_sweep_manager_email.
+    Permission: swept_from_owner_id == user_id OR is_admin OR is_manager_or_admin(user)
+                OR user.email == settings.account_sweep_manager_email.
+
+    Compliance (Phase 4): a former owner cannot reclaim while reclaim_blocked_until is in
+    the future (a 30-day post-sweep cooldown). Managers/admins bypass the cooldown — they
+    should use reassign_account, but a direct reclaim is also permitted for them.
 
     Actions:
     - Set Company.account_owner_id = user_id; Company.ownership_cleared_at = None
@@ -308,11 +368,12 @@ def reclaim_prospect_account(
     - Log a "reclaim" ActivityLog entry (resets activity clock)
 
     Returns: {prospect_id, company_id, company_name, status: "reclaimed"}
-    Raises: LookupError (not found), ValueError (permission denied / wrong status)
+    Raises: LookupError (not found), ValueError (permission denied / wrong status / cooldown)
 
     Called by: app/routers/htmx_views.py
     """
     from ..constants import ProspectAccountStatus
+    from ..dependencies import is_manager_or_admin
     from ..services.activity_service import log_activity
 
     pa = db.get(ProspectAccount, prospect_id)
@@ -328,10 +389,20 @@ def reclaim_prospect_account(
 
     manager_email = settings.account_sweep_manager_email
     is_former_owner = pa.swept_from_owner_id == user_id
-    is_manager = bool(manager_email and user.email == manager_email)
+    is_email_manager = bool(manager_email and user.email == manager_email)
+    is_supervisor = is_admin or is_manager_or_admin(user) or is_email_manager
 
-    if not (is_former_owner or is_admin or is_manager):
+    if not (is_former_owner or is_supervisor):
         raise ValueError("Reclaim permission denied: must be former owner, admin, or sweep manager")
+
+    # Phase 4 cooldown: the former owner is blocked until reclaim_blocked_until passes.
+    # Supervisors (manager/admin/configured manager email) bypass it.
+    if is_former_owner and not is_supervisor and pa.reclaim_blocked_until is not None:
+        blocked_until = pa.reclaim_blocked_until
+        if blocked_until.tzinfo is None:
+            blocked_until = blocked_until.replace(tzinfo=timezone.utc)
+        if blocked_until > datetime.now(timezone.utc):
+            raise ValueError("This account is in a 30-day cooldown; ask a manager to reassign it.")
 
     pa.status = ProspectAccountStatus.DISMISSED
     pa.dismissed_at = datetime.now(timezone.utc)
@@ -372,4 +443,93 @@ def reclaim_prospect_account(
         "company_id": company_id,
         "company_name": company_name,
         "status": "reclaimed",
+    }
+
+
+# ── Manager reassign (Phase 4) ────────────────────────────────────────────────
+
+
+def reassign_account(company_id: int, to_user_id: int, by_user: User, db: Session) -> dict:
+    """Manager/admin reassigns a Company to another owner, overriding the reclaim
+    cooldown.
+
+    This is the supervisor escape hatch for the Phase 4 30-day cooldown: a former owner who
+    is still blocked asks a manager to hand the account to someone (often back to them).
+
+    Gate: is_manager_or_admin(by_user) — else HTTPException(403). Actions:
+    - Set Company.account_owner_id = to_user_id; clear ownership_cleared_at.
+    - If a swept ProspectAccount exists for this company, dismiss it and clear
+      reclaim_blocked_until (the cooldown no longer applies once a manager has acted).
+    - Log a "reassign" ActivityLog entry on the company.
+
+    Returns: {company_id, company_name, to_user_id, prospect_id|None, status: "reassigned"}
+    Raises: HTTPException(403) (not a supervisor), LookupError (company missing),
+            ValueError (target user missing).
+
+    Called by: app/routers/htmx_views.py (POST /v2/partials/prospects/{id}/reassign)
+    """
+    from fastapi import HTTPException
+
+    from ..constants import ProspectAccountStatus
+    from ..dependencies import is_manager_or_admin
+    from ..services.activity_service import log_activity
+
+    if not is_manager_or_admin(by_user):
+        raise HTTPException(403, "Only a manager or admin can reassign an account")
+
+    co = db.get(Company, company_id)
+    if co is None:
+        raise LookupError(f"Company {company_id} not found")
+
+    target = db.get(User, to_user_id)
+    if target is None:
+        raise ValueError(f"Target user {to_user_id} not found")
+
+    co.account_owner_id = to_user_id
+    co.ownership_cleared_at = None
+
+    prospect_id: int | None = None
+    swept_pa = (
+        db.query(ProspectAccount)
+        .filter(
+            ProspectAccount.company_id == company_id,
+            ProspectAccount.status != ProspectAccountStatus.DISMISSED,
+            (ProspectAccount.swept_at.is_not(None)) | (ProspectAccount.swept_from_owner_id.is_not(None)),
+        )
+        .first()
+    )
+    if swept_pa is not None:
+        swept_pa.status = ProspectAccountStatus.DISMISSED
+        swept_pa.dismissed_at = datetime.now(timezone.utc)
+        swept_pa.dismissed_by = by_user.id
+        swept_pa.dismiss_reason = "reassigned"
+        swept_pa.reclaim_blocked_until = None
+        prospect_id = swept_pa.id
+
+    log_activity(
+        db,
+        activity_type="reassign",
+        channel="system",
+        user_id=by_user.id,
+        company_id=company_id,
+        summary=f"Account reassigned to user {to_user_id}",
+        details={"to_user_id": to_user_id, "by_user_id": by_user.id, "prospect_id": prospect_id},
+    )
+
+    db.commit()
+
+    logger.info(
+        "SP4 reassign: manager {} reassigned company {} to user {} (prospect {})",
+        by_user.id,
+        company_id,
+        to_user_id,
+        prospect_id,
+    )
+
+    return {
+        "company_id": company_id,
+        "company_name": co.name,
+        "to_user_id": to_user_id,
+        "prospect_id": prospect_id,
+        "status": "reassigned",
     }

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -757,6 +757,7 @@ Key columns:
 | swept_from_owner_id | INT FK users (SET NULL) | owner whose account was auto-swept by the daily 90-day sweep (SP4) |
 | swept_at | UTCDateTime | when the account was swept into the pool (SP4) |
 | parked_by_id | INT FK users (SET NULL) | user who manually parked the account via the sales-park flow (SP4) |
+| reclaim_blocked_until | UTCDateTime | SP4 Phase 4 compliance cooldown: former owner cannot reclaim until this passes (set at sweep = swept_at + 30d; managers bypass via reassign, which clears it) |
 
 `enrichment_data['ai_screen']` (JSONB) holds the full AI screen verdict:
 `{trio_match_score, opportunity_score, excess_likelihood, verdict, rationale, evidence, confidence, model, screened_at, grounding_fingerprint, needs_more_enrichment?}`.

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -4074,8 +4074,8 @@ Three inflows that feed idle CRM accounts into the prospecting pool.
 - Delegates to: `app/services/prospect_reclamation.py::job_account_sweep_with_db(db)`
 - Query: Company WHERE account_owner_id IS NOT NULL AND last ActivityLog.created_at > 90 days ago (or no activity)
 - Idempotency: skips if ProspectAccount.swept_at IS NOT NULL already
-- On match: calls `send_company_to_prospecting()` (clears ownership), sets `swept_from_owner_id`/`swept_at`/`discovery_source="auto_sweep"` on ProspectAccount
-- Notification: `_send_sweep_notification()` → Graph `/me/sendMail` TO rep CC manager (falls back to admin_emails[0])
+- On match: calls `send_company_to_prospecting()` (clears ownership), sets `swept_from_owner_id`/`swept_at`/`reclaim_blocked_until = swept_at + 30d`/`discovery_source="auto_sweep"` on ProspectAccount
+- Notification: `_send_sweep_notification()` → Graph `/me/sendMail`, ONE message per recipient (each in its own try/except so one bad address can't break the sweep). Recipients = rep + every ACTIVE user with role MANAGER/ADMIN + `settings.account_sweep_manager_email`, deduped case-insensitively by `_sweep_notification_recipients()`
 - Token: `get_valid_token(owner, db)` from `app.utils.token_manager`; skips email on missing token (no failure)
 
 ### Daily unassigned past-customer surface (2AM UTC)
@@ -4093,7 +4093,15 @@ Three inflows that feed idle CRM accounts into the prospecting pool.
 
 ### Reclaim: reclaim_prospect_account()
 - Service: `app/services/prospect_reclamation.py::reclaim_prospect_account(prospect_id, user_id, db, *, is_admin)`
-- Permission: swept_from_owner_id == user_id OR is_admin OR user.email == account_sweep_manager_email
+- Permission: swept_from_owner_id == user_id OR is_admin OR `is_manager_or_admin(user)` OR user.email == account_sweep_manager_email
+- Phase 4 cooldown: a former owner is DENIED with "This account is in a 30-day cooldown; ask a manager to reassign it." while `reclaim_blocked_until` is in the future; managers/admins (the supervisor set above) bypass it
 - Actions: dismisses ProspectAccount, re-assigns Company.account_owner_id, logs ActivityLog(activity_type="reclaim")
 - HTMX endpoint: `POST /v2/partials/prospects/{prospect_id}/reclaim` (require_user)
 - Returns: {prospect_id, company_id, company_name, status: "reclaimed"}
+
+### Manager reassign (Phase 4): reassign_account() — cooldown override
+- Service: `app/services/prospect_reclamation.py::reassign_account(company_id, to_user_id, by_user, db)`
+- Gate: `is_manager_or_admin(by_user)` else `HTTPException(403)`
+- Actions: sets `Company.account_owner_id = to_user_id` (clears ownership_cleared_at); if a swept (non-dismissed) ProspectAccount exists for the company, dismisses it (`dismiss_reason="reassigned"`) and clears `reclaim_blocked_until`; logs ActivityLog(activity_type="reassign")
+- HTMX endpoint: `POST /v2/partials/prospects/{prospect_id}/reassign` with `to_user_id` form param (require_user + in-route `is_manager_or_admin` gate)
+- Returns: {company_id, company_name, to_user_id, prospect_id|None, status: "reassigned"}

--- a/tests/test_prospect_reclamation.py
+++ b/tests/test_prospect_reclamation.py
@@ -2,7 +2,9 @@
 
 Covers: reclaim_prospect_account error paths, job_account_sweep wrapper,
 job_account_sweep_with_db sweep logic, _send_sweep_notification,
-job_auto_surface_reactivation wrapper, job_auto_surface_with_db surface logic.
+job_auto_surface_reactivation wrapper, job_auto_surface_with_db surface logic,
+and Phase 4 compliance: reclaim cooldown enforcement, manager reassign, and the
+rep + manager sweep notification fan-out.
 """
 
 import os
@@ -27,11 +29,12 @@ def _uid() -> str:
     return uuid.uuid4().hex[:8]
 
 
-def _user(db: Session, email: str | None = None) -> User:
+def _user(db: Session, email: str | None = None, *, role: str = "buyer", is_active: bool = True) -> User:
     u = User(
         email=email or f"user-{_uid()}@test.com",
         name="Test",
-        role="buyer",
+        role=role,
+        is_active=is_active,
         azure_id=_uid(),
         created_at=datetime.now(timezone.utc),
     )
@@ -60,6 +63,7 @@ def _prospect(
     swept_from_owner_id: int | None = None,
     status: str = "suggested",
     domain: str | None = None,
+    reclaim_blocked_until: datetime | None = None,
 ) -> ProspectAccount:
     pa = ProspectAccount(
         name=f"PA-{_uid()}",
@@ -70,6 +74,7 @@ def _prospect(
         readiness_score=0,
         company_id=company_id,
         swept_from_owner_id=swept_from_owner_id,
+        reclaim_blocked_until=reclaim_blocked_until,
         created_at=datetime.now(timezone.utc),
     )
     db.add(pa)
@@ -316,11 +321,12 @@ class TestSendSweepNotification:
         with patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value=None)):
             await pr._send_sweep_notification(owner, co, None, 1, db_session)
 
-    async def test_sends_with_cc_when_manager_email_set(self, db_session: Session, monkeypatch) -> None:
+    async def test_sends_to_rep_and_configured_manager_email(self, db_session: Session, monkeypatch) -> None:
+        """Rep + configured manager email each receive a (deduped) send."""
         from app.services import prospect_reclamation as pr
 
         monkeypatch.setattr(pr.settings, "account_sweep_manager_email", "manager@trio.com")
-        owner = _user(db_session)
+        owner = _user(db_session, email="rep-cc@trio.com")
         co = _company(db_session)
         db_session.commit()
 
@@ -333,9 +339,13 @@ class TestSendSweepNotification:
         ):
             await pr._send_sweep_notification(owner, co, None, 1, db_session)
 
-        call_args = mock_gc.post_json.call_args
-        payload = call_args[0][1]
-        assert len(payload["message"]["ccRecipients"]) == 1
+        sent_to = {
+            r["emailAddress"]["address"]
+            for call in mock_gc.post_json.call_args_list
+            for r in call[0][1]["message"]["toRecipients"]
+        }
+        assert "rep-cc@trio.com" in sent_to
+        assert "manager@trio.com" in sent_to
 
     async def test_notification_exception_does_not_propagate(self, db_session: Session) -> None:
         from app.services import prospect_reclamation as pr
@@ -451,3 +461,285 @@ class TestJobAutoSurfaceWithDb:
 
         db_session.refresh(pa_existing)
         assert pa_existing.company_id == co.id
+
+
+# ── Phase 4: reclaim cooldown ─────────────────────────────────────────────────
+
+
+class TestReclaimCooldown:
+    def test_former_owner_within_cooldown_denied(self, db_session: Session) -> None:
+        """A former owner cannot reclaim while reclaim_blocked_until is in the
+        future."""
+        from datetime import timedelta
+
+        from app.services.prospect_reclamation import reclaim_prospect_account
+
+        owner = _user(db_session)
+        co = _company(db_session, owner_id=None)
+        future = datetime.now(timezone.utc) + timedelta(days=15)
+        pa = _prospect(db_session, company_id=co.id, swept_from_owner_id=owner.id, reclaim_blocked_until=future)
+        db_session.commit()
+
+        with pytest.raises(ValueError, match="30-day cooldown"):
+            reclaim_prospect_account(pa.id, owner.id, db_session)
+
+        # Account is untouched — still in the pool, owner not restored.
+        db_session.refresh(pa)
+        assert pa.status == ProspectAccountStatus.SUGGESTED
+        db_session.refresh(co)
+        assert co.account_owner_id is None
+
+    def test_former_owner_after_cooldown_allowed(self, db_session: Session) -> None:
+        """A former owner CAN reclaim once reclaim_blocked_until has passed."""
+        from datetime import timedelta
+
+        from app.services.prospect_reclamation import reclaim_prospect_account
+
+        owner = _user(db_session)
+        co = _company(db_session, owner_id=None)
+        past = datetime.now(timezone.utc) - timedelta(days=1)
+        pa = _prospect(db_session, company_id=co.id, swept_from_owner_id=owner.id, reclaim_blocked_until=past)
+        db_session.commit()
+
+        result = reclaim_prospect_account(pa.id, owner.id, db_session)
+        assert result["status"] == "reclaimed"
+        db_session.refresh(co)
+        assert co.account_owner_id == owner.id
+
+    def test_no_cooldown_set_allows_former_owner(self, db_session: Session) -> None:
+        """When reclaim_blocked_until is NULL the former owner reclaims freely."""
+        from app.services.prospect_reclamation import reclaim_prospect_account
+
+        owner = _user(db_session)
+        co = _company(db_session, owner_id=None)
+        pa = _prospect(db_session, company_id=co.id, swept_from_owner_id=owner.id, reclaim_blocked_until=None)
+        db_session.commit()
+
+        result = reclaim_prospect_account(pa.id, owner.id, db_session)
+        assert result["status"] == "reclaimed"
+
+    def test_manager_within_cooldown_allowed(self, db_session: Session, monkeypatch) -> None:
+        """A manager bypasses the cooldown even though the former owner is blocked."""
+        from datetime import timedelta
+
+        from app.services import prospect_reclamation as pr
+        from app.services.prospect_reclamation import reclaim_prospect_account
+
+        owner = _user(db_session)
+        manager = _user(db_session, role="manager")
+        co = _company(db_session, owner_id=None)
+        future = datetime.now(timezone.utc) + timedelta(days=15)
+        pa = _prospect(db_session, company_id=co.id, swept_from_owner_id=owner.id, reclaim_blocked_until=future)
+        db_session.commit()
+
+        # Ensure the bypass is by ROLE, not the configured manager email.
+        monkeypatch.setattr(pr.settings, "account_sweep_manager_email", "")
+        result = reclaim_prospect_account(pa.id, manager.id, db_session)
+        assert result["status"] == "reclaimed"
+        db_session.refresh(co)
+        assert co.account_owner_id == manager.id
+
+    def test_admin_within_cooldown_allowed(self, db_session: Session) -> None:
+        """An admin (is_admin=True) bypasses the cooldown."""
+        from datetime import timedelta
+
+        from app.services.prospect_reclamation import reclaim_prospect_account
+
+        owner = _user(db_session)
+        admin = _user(db_session, role="admin")
+        co = _company(db_session, owner_id=None)
+        future = datetime.now(timezone.utc) + timedelta(days=15)
+        pa = _prospect(db_session, company_id=co.id, swept_from_owner_id=owner.id, reclaim_blocked_until=future)
+        db_session.commit()
+
+        result = reclaim_prospect_account(pa.id, admin.id, db_session, is_admin=True)
+        assert result["status"] == "reclaimed"
+
+
+# ── Phase 4: sweep sets cooldown ──────────────────────────────────────────────
+
+
+class TestSweepSetsCooldown:
+    async def test_sweep_sets_reclaim_blocked_until(self, db_session: Session, monkeypatch) -> None:
+        """A successful sweep stamps reclaim_blocked_until = swept_at + 30 days."""
+        from datetime import timedelta
+
+        from app.services import prospect_reclamation as pr
+
+        monkeypatch.setattr(pr.settings, "account_sweep_inactivity_days", 0)
+        owner = _user(db_session)
+        _company(db_session, owner_id=owner.id)
+        pa = _prospect(db_session)
+        db_session.commit()
+
+        with (
+            patch("app.services.activity_service.get_last_activity_at", return_value=None),
+            patch(
+                "app.services.prospect_claim.send_company_to_prospecting",
+                return_value={"prospect_id": pa.id},
+            ),
+            patch.object(pr, "_send_sweep_notification", AsyncMock()),
+        ):
+            await pr.job_account_sweep_with_db(db_session)
+
+        db_session.refresh(pa)
+        assert pa.swept_at is not None
+        assert pa.reclaim_blocked_until is not None
+        delta = pa.reclaim_blocked_until - pa.swept_at
+        assert abs(delta - timedelta(days=30)) < timedelta(seconds=5)
+
+
+# ── Phase 4: reassign_account ─────────────────────────────────────────────────
+
+
+class TestReassignAccount:
+    def test_manager_reassigns_sets_owner_dismisses_clears_cooldown(self, db_session: Session) -> None:
+        """Manager reassign sets the new owner, dismisses the swept prospect, clears
+        cooldown."""
+        from datetime import timedelta
+
+        from app.models.intelligence import ActivityLog
+        from app.services.prospect_reclamation import reassign_account
+
+        manager = _user(db_session, role="manager")
+        target = _user(db_session)
+        co = _company(db_session, owner_id=None)
+        future = datetime.now(timezone.utc) + timedelta(days=15)
+        pa = _prospect(db_session, company_id=co.id, swept_from_owner_id=target.id, reclaim_blocked_until=future)
+        db_session.commit()
+
+        result = reassign_account(co.id, target.id, manager, db_session)
+        assert result["status"] == "reassigned"
+
+        db_session.refresh(co)
+        assert co.account_owner_id == target.id
+        db_session.refresh(pa)
+        assert pa.status == ProspectAccountStatus.DISMISSED
+        assert pa.reclaim_blocked_until is None
+
+        log = (
+            db_session.query(ActivityLog)
+            .filter(ActivityLog.company_id == co.id, ActivityLog.activity_type == "reassign")
+            .first()
+        )
+        assert log is not None
+
+    def test_admin_reassigns(self, db_session: Session) -> None:
+        from app.services.prospect_reclamation import reassign_account
+
+        admin = _user(db_session, role="admin")
+        target = _user(db_session)
+        co = _company(db_session, owner_id=None)
+        db_session.commit()
+
+        result = reassign_account(co.id, target.id, admin, db_session)
+        assert result["status"] == "reassigned"
+        db_session.refresh(co)
+        assert co.account_owner_id == target.id
+
+    def test_rep_reassign_raises_403(self, db_session: Session) -> None:
+        """A non-manager caller is rejected with HTTP 403."""
+        from fastapi import HTTPException
+
+        from app.services.prospect_reclamation import reassign_account
+
+        rep = _user(db_session, role="sales")
+        target = _user(db_session)
+        co = _company(db_session, owner_id=None)
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            reassign_account(co.id, target.id, rep, db_session)
+        assert exc.value.status_code == 403
+
+    def test_reassign_missing_company_raises_lookup(self, db_session: Session) -> None:
+        from app.services.prospect_reclamation import reassign_account
+
+        manager = _user(db_session, role="manager")
+        target = _user(db_session)
+        db_session.commit()
+
+        with pytest.raises(LookupError):
+            reassign_account(999999, target.id, manager, db_session)
+
+    def test_reassign_missing_target_user_raises(self, db_session: Session) -> None:
+        from app.services.prospect_reclamation import reassign_account
+
+        manager = _user(db_session, role="manager")
+        co = _company(db_session, owner_id=None)
+        db_session.commit()
+
+        with pytest.raises(ValueError, match="not found"):
+            reassign_account(co.id, 999999, manager, db_session)
+
+
+# ── Phase 4: sweep notification fans out to managers/admins ───────────────────
+
+
+class TestSweepNotificationManagerFanout:
+    async def test_includes_active_managers_and_admins(self, db_session: Session, monkeypatch) -> None:
+        """Notification recipients include every active MANAGER/ADMIN plus the
+        configured manager email and the rep, all deduped."""
+        from app.services import prospect_reclamation as pr
+
+        owner = _user(db_session, email="rep@trio.com")
+        mgr = _user(db_session, email="boss@trio.com", role="manager")
+        adm = _user(db_session, email="admin@trio.com", role="admin")
+        # An inactive manager must NOT be notified.
+        _user(db_session, email="ghost@trio.com", role="manager", is_active=False)
+        co = _company(db_session)
+        db_session.commit()
+
+        monkeypatch.setattr(pr.settings, "account_sweep_manager_email", "configured@trio.com")
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock()
+        with (
+            patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value="TOKEN")),
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+        ):
+            await pr._send_sweep_notification(owner, co, None, 1, db_session)
+
+        # One send per unique recipient.
+        sent_to = set()
+        for call in mock_gc.post_json.call_args_list:
+            payload = call[0][1]
+            for r in payload["message"]["toRecipients"]:
+                sent_to.add(r["emailAddress"]["address"])
+
+        assert "rep@trio.com" in sent_to
+        assert "boss@trio.com" in sent_to
+        assert "admin@trio.com" in sent_to
+        assert "configured@trio.com" in sent_to
+        assert "ghost@trio.com" not in sent_to
+
+    async def test_one_failure_does_not_break_others(self, db_session: Session, monkeypatch) -> None:
+        """If one recipient send raises, the others still go out (try/except per
+        send)."""
+        from app.services import prospect_reclamation as pr
+
+        owner = _user(db_session, email="rep2@trio.com")
+        _user(db_session, email="boss2@trio.com", role="manager")
+        co = _company(db_session)
+        db_session.commit()
+
+        monkeypatch.setattr(pr.settings, "account_sweep_manager_email", "")
+
+        calls = {"n": 0}
+
+        async def flaky_post(path, payload):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("first send failed")
+            return {}
+
+        mock_gc = MagicMock()
+        mock_gc.post_json = AsyncMock(side_effect=flaky_post)
+        with (
+            patch("app.utils.token_manager.get_valid_token", AsyncMock(return_value="TOKEN")),
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+        ):
+            # Must not raise despite the first send blowing up.
+            await pr._send_sweep_notification(owner, co, None, 1, db_session)
+
+        assert calls["n"] >= 2

--- a/tests/test_prospecting_tab.py
+++ b/tests/test_prospecting_tab.py
@@ -270,6 +270,68 @@ class TestWriteAuth:
                 app.dependency_overrides.pop(dep, None)
 
 
+# ── Phase 4: manager reassign route (cooldown override) ───────────────────
+
+
+class TestReassignRoute:
+    def _swept_prospect(self, db_session, *, owner_id):
+        from datetime import timedelta
+
+        domain = f"swept-{uuid.uuid4().hex[:6]}.com"
+        co = Company(name="Swept Co", domain=domain, is_active=True, account_owner_id=None)
+        db_session.add(co)
+        db_session.commit()
+        db_session.refresh(co)
+        p = make_prospect(
+            db_session,
+            status="suggested",
+            domain=domain,
+            company_id=co.id,
+            swept_from_owner_id=owner_id,
+            swept_at=datetime.now(timezone.utc),
+            reclaim_blocked_until=datetime.now(timezone.utc) + timedelta(days=15),
+        )
+        return co, p
+
+    def test_rep_reassign_returns_403(self, client, db_session, test_user):
+        # The default `client` is authenticated as a buyer (test_user) → must be denied.
+        co, p = self._swept_prospect(db_session, owner_id=test_user.id)
+        resp = client.post(
+            f"/v2/partials/prospects/{p.id}/reassign",
+            data={"to_user_id": str(test_user.id)},
+        )
+        assert resp.status_code == 403
+
+    def test_manager_reassign_sets_owner_and_dismisses(self, db_session, test_user, manager_user):
+        from app.database import get_db
+        from app.dependencies import require_user
+        from app.main import app
+
+        co, p = self._swept_prospect(db_session, owner_id=test_user.id)
+
+        def _od():
+            yield db_session
+
+        app.dependency_overrides[get_db] = _od
+        app.dependency_overrides[require_user] = lambda: manager_user
+        try:
+            with TestClient(app) as c:
+                resp = c.post(
+                    f"/v2/partials/prospects/{p.id}/reassign",
+                    data={"to_user_id": str(test_user.id)},
+                )
+            assert resp.status_code == 200
+        finally:
+            for dep in (get_db, require_user):
+                app.dependency_overrides.pop(dep, None)
+
+        db_session.refresh(co)
+        assert co.account_owner_id == test_user.id
+        db_session.refresh(p)
+        assert p.status == "dismissed"
+        assert p.reclaim_blocked_until is None
+
+
 # ── Stats: canonical buyer-ready definition ───────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- **30-day reclaim cooldown:** when an account is swept, `ProspectAccount.reclaim_blocked_until` is stamped at `swept_at + 30d`. The former owner is blocked from reclaiming during that window; managers/admins bypass the gate.
- **Manager reassign:** new `POST /v2/partials/prospects/{id}/reassign` route + `reassign_account()` service — manager/admin only; sets `Company.account_owner_id`, dismisses the swept ProspectAccount, clears cooldown, logs activity.
- **Rep + manager sweep notification:** `_send_sweep_notification` now fans out to all active MANAGER/ADMIN users in DB (deduplicated with the configured `account_sweep_manager_email`), one send per recipient inside a try/except so a single failure never aborts the sweep.

## Migration

- **141_reclaim_cooldown** (`down_revision: 140_account_collaborators`) — adds `reclaim_blocked_until` (nullable UTCDateTime) to `prospect_accounts`; downgrade drops the column. Single head confirmed.

## Test plan

- [ ] Former owner within cooldown → 403-equivalent ValueError ("30-day cooldown")
- [ ] Former owner after cooldown → allowed
- [ ] Manager/admin within cooldown → allowed (override)
- [ ] Manager reassign → owner set, prospect dismissed, cooldown cleared
- [ ] Rep calling reassign → 403
- [ ] Sweep sets `reclaim_blocked_until = swept_at + 30d`
- [ ] Sweep notification recipients include active managers/admins; single failed send is swallowed
- [ ] 110 tests pass (`test_prospect_reclamation.py` + `test_prospect_claim.py`); 164 total Phase-4 suite; ruff clean; all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vudvpB7921eTuxg1KAMvf