### PR TITLE
feat(seed): --owner option to assign sample deals to a user's lenses

### DIFF
--- a/app/management/seed_sample_data.py
+++ b/app/management/seed_sample_data.py
@@ -43,6 +43,7 @@ from typing import Any
 from loguru import logger
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.constants import (
     ActivityType,
     AIFlagSeverity,
@@ -156,6 +157,43 @@ def _seed_users(db: Session, counts: _Counts) -> dict[str, User]:
         )
         out[var] = row
     return out
+
+
+# Sample-user roles redirected to the --owner user so the sample deals land in
+# THAT user's default "mine" lenses (requisition created_by, buy-plan-line
+# buyer_id, buy-plan submitted_by_id, excess owner_id). u_manager is intentionally
+# NOT redirected — it stays the distinct approver/verifier so the approve/verify
+# workflow still shows a second actor.
+_OWNER_REDIRECT_ROLES = ("u_seeder", "u_sales", "u_buyer1", "u_buyer2", "u_trader")
+
+
+def _resolve_owner_user(db: Session, email: str) -> User:
+    """Resolve the ``--owner`` email to a User row (case-insensitive).
+
+    Returns the existing user if present. Otherwise PRE-PROVISIONS a real owner
+    account (so it's ready when that person logs in via OAuth, which matches on
+    email): this user is NOT sample-tagged and is therefore NEVER removed by
+    ``--wipe``. Role is ``admin`` when the email is in ``settings.admin_emails``,
+    else ``buyer``.
+    """
+    norm = email.strip()
+    user = db.query(User).filter(User.email.ilike(norm)).first()
+    if user is not None:
+        logger.info("seed-sample: --owner resolved to existing user id={} email={}", user.id, user.email)
+        return user
+    admin_emails = settings.admin_emails if isinstance(settings.admin_emails, list) else []
+    role = "admin" if norm.lower() in {e.lower() for e in admin_emails} else "buyer"
+    user = User(email=norm, name=norm.split("@", 1)[0], role=role, is_active=True)
+    db.add(user)
+    db.flush()
+    logger.warning(
+        "seed-sample: --owner user not found; pre-provisioned REAL owner account "
+        "id={} email={} role={} (not sample-tagged; survives --wipe)",
+        user.id,
+        user.email,
+        role,
+    )
+    return user
 
 
 def _seed_companies(db: Session, counts: _Counts, u: dict[str, User]) -> dict[str, Company]:
@@ -1505,14 +1543,28 @@ def _seed_wf_f(db: Session, counts: _Counts, reqs1: dict, vc: dict, u: dict) -> 
 # ── Orchestration ────────────────────────────────────────────────────
 
 
-def seed(db: Session) -> _Counts:
+def seed(db: Session, owner_email: str | None = None) -> _Counts:
     """Idempotently seed (or top up) the full sample dataset.
+
+    When *owner_email* is given, the sample deals (requisitions, quotes, buy plans
+    + their lines, excess lists) are assigned to that user instead of the sample
+    actor users, so they populate THAT user's default "mine"/"orders"/"deals"
+    lenses (not just the admin "supervise" lens). See ``_resolve_owner_user``.
 
     Returns per-model counts.
     """
     counts: _Counts = {}
     u = _seed_users(db, counts)
     db.flush()
+    if owner_email:
+        owner = _resolve_owner_user(db, owner_email)
+        for role in _OWNER_REDIRECT_ROLES:
+            u[role] = owner
+        logger.info(
+            "seed-sample: sample deals owned by {} (redirected roles: {})",
+            owner.email,
+            ", ".join(_OWNER_REDIRECT_ROLES),
+        )
     co = _seed_companies(db, counts, u)
     site = _seed_sites(db, counts, co, u)
     con = _seed_contacts(db, counts, site, co)
@@ -1660,6 +1712,16 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description="Seed (or wipe) the AvailAI sample dataset (idempotent additive).")
     parser.add_argument("--wipe", action="store_true", help="Delete only tagged sample rows, then exit.")
+    parser.add_argument(
+        "--owner",
+        metavar="EMAIL",
+        default=None,
+        help=(
+            "Assign the sample deals (requisitions/quotes/buy plans/excess) to this user's email "
+            "so they show in that user's default 'mine'/'orders'/'deals' lenses. Resolves an "
+            "existing user or pre-provisions a real (non-sample, never-wiped) account. Ignored with --wipe."
+        ),
+    )
     args = parser.parse_args(argv)
 
     from app.database import SessionLocal
@@ -1669,7 +1731,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.wipe:
             wipe(db)
         else:
-            seed(db)
+            seed(db, owner_email=args.owner)
     finally:
         db.close()
     return 0

--- a/app/management/seed_sample_data.py
+++ b/app/management/seed_sample_data.py
@@ -160,10 +160,16 @@ def _seed_users(db: Session, counts: _Counts) -> dict[str, User]:
 
 
 # Sample-user roles redirected to the --owner user so the sample deals land in
-# THAT user's default "mine" lenses (requisition created_by, buy-plan-line
-# buyer_id, buy-plan submitted_by_id, excess owner_id). u_manager is intentionally
-# NOT redirected — it stays the distinct approver/verifier so the approve/verify
-# workflow still shows a second actor.
+# THAT user's own-work lenses, keyed on the fields each lens filters:
+#   - buy-plan-line buyer_id   → buy-plans "orders" (buyer_line_queue)
+#   - buy-plan submitted_by_id → buy-plans "deals" (deals_board scope=mine)
+#   - excess owner_id          → resell "Open to Me"
+#   - requisition created_by   → requisitions owner-filter dropdown + the
+#                                auto-"my reqs" filter that fires only for SALES-role
+#                                users (admins/buyers see all reqs by default, so the
+#                                sample reqs are visible to an admin owner regardless).
+# u_manager is intentionally NOT redirected — it stays the distinct approver/verifier
+# so the approve/verify workflow still shows a second actor.
 _OWNER_REDIRECT_ROLES = ("u_seeder", "u_sales", "u_buyer1", "u_buyer2", "u_trader")
 
 
@@ -894,7 +900,19 @@ def _seed_wf_c(
         db, counts, q_sent, offer=None, mpn="AVSAMPLE-CUSTOM-001", qty=10, cost=Decimal(500), sell=Decimal(600)
     )
 
-    bp_draft = _mk_buy_plan(db, counts, q_sent, req2, BuyPlanStatus.DRAFT, SOVerificationStatus.PENDING, u, extra={})
+    # submitted_by_id is set even on the DRAFT so it appears in its owner's "deals"
+    # board (deals_board scope=mine filters BuyPlan.submitted_by_id == user); u_seeder
+    # is redirected to the --owner user when that option is used.
+    bp_draft = _mk_buy_plan(
+        db,
+        counts,
+        q_sent,
+        req2,
+        BuyPlanStatus.DRAFT,
+        SOVerificationStatus.PENDING,
+        u,
+        extra={"submitted_by_id": u["u_seeder"].id},
+    )
     if bp_draft is not None:
         _mk_buy_plan_line(
             db,
@@ -1548,8 +1566,10 @@ def seed(db: Session, owner_email: str | None = None) -> _Counts:
 
     When *owner_email* is given, the sample deals (requisitions, quotes, buy plans
     + their lines, excess lists) are assigned to that user instead of the sample
-    actor users, so they populate THAT user's default "mine"/"orders"/"deals"
-    lenses (not just the admin "supervise" lens). See ``_resolve_owner_user``.
+    actor users, so they surface in that user's own-work lenses (buy-plans "orders"
+    + "deals", resell "Open to Me", and the requisitions owner-filter / SALES
+    auto-filter) rather than only the admin "supervise" lens. See
+    ``_resolve_owner_user`` and ``_OWNER_REDIRECT_ROLES``.
 
     Returns per-model counts.
     """

--- a/tests/test_seed_sample_data.py
+++ b/tests/test_seed_sample_data.py
@@ -253,3 +253,61 @@ def test_wipe_on_empty_db_is_noop(db_session: Session) -> None:
 
     assert sum(deleted.values()) == 0
     assert db_session.get(Company, real_company.id) is not None
+
+
+def test_owner_assigns_deals_to_existing_user(db_session: Session) -> None:
+    """--owner redirects deal ownership to the named user's default 'mine' lenses.
+
+    Requisition created_by, buy-plan-line buyer_id, buy-plan submitted_by_id and
+    excess owner_id all become the owner — while u_manager stays the distinct
+    approver so the approve/verify workflow still shows a second actor.
+    """
+    owner = User(email="boss@trioscs.com", name="Boss", role="admin", is_active=True)
+    db_session.add(owner)
+    db_session.commit()
+
+    sds.seed(db_session, owner_email="boss@trioscs.com")
+
+    # The existing user was reused, not duplicated: 6 sample users + the owner.
+    assert _count(db_session, User) == 7
+    assert db_session.query(User).filter(User.email == "boss@trioscs.com").count() == 1
+
+    # Every sample requisition is owned by the owner ('mine' requisitions lens).
+    reqs = db_session.query(Requisition).filter(Requisition.name.like("AVSAMPLE%")).all()
+    assert reqs and all(r.created_by == owner.id for r in reqs)
+
+    # Every buy-plan line's buyer is the owner ('orders' lens = BuyPlanLine.buyer_id).
+    from app.models.buy_plan import BuyPlanLine
+
+    lines = db_session.query(BuyPlanLine).all()
+    assert lines and all(line.buyer_id == owner.id for line in lines)
+
+    # The ACTIVE plan is submitted by the owner ('deals' lens = BuyPlan.submitted_by_id)
+    # but APPROVED by the distinct sample manager (not the owner).
+    q_won2 = db_session.query(Quote).filter_by(quote_number="AVSAMPLE-Q-0005").one()
+    bp_active = db_session.query(BuyPlan).filter_by(quote_id=q_won2.id).one()
+    assert bp_active.submitted_by_id == owner.id
+    assert bp_active.approved_by_id is not None and bp_active.approved_by_id != owner.id
+    manager = db_session.query(User).filter(User.email.like("manager.avsample@%")).one()
+    assert bp_active.approved_by_id == manager.id
+
+    # The sample excess list is owned by the owner ('Open to Me' resell lens).
+    assert db_session.query(ExcessList).filter(ExcessList.owner_id == owner.id).count() == 1
+
+
+def test_owner_pre_provisions_missing_user_and_survives_wipe(db_session: Session) -> None:
+    """An unknown --owner email pre-provisions a REAL (non-sample) user that --wipe
+    keeps."""
+    sds.seed(db_session, owner_email="newowner@trioscs.com")
+
+    owner = db_session.query(User).filter(User.email == "newowner@trioscs.com").one()
+    assert owner.is_active is True
+    # Real account — NOT sample-tagged (its email is not on the avsample domain).
+    assert not owner.email.endswith("avsample.test")
+    assert db_session.query(Requisition).filter(Requisition.name.like("AVSAMPLE%")).first().created_by == owner.id
+
+    sds.wipe(db_session)
+
+    # Sample users gone; the pre-provisioned real owner survives.
+    assert db_session.query(User).filter(User.email.like("%avsample@avsample.test")).count() == 0
+    assert db_session.get(User, owner.id) is not None

--- a/tests/test_seed_sample_data.py
+++ b/tests/test_seed_sample_data.py
@@ -256,7 +256,7 @@ def test_wipe_on_empty_db_is_noop(db_session: Session) -> None:
 
 
 def test_owner_assigns_deals_to_existing_user(db_session: Session) -> None:
-    """--owner redirects deal ownership to the named user's default 'mine' lenses.
+    """--owner redirects deal ownership to the named user's own-work lenses.
 
     Requisition created_by, buy-plan-line buyer_id, buy-plan submitted_by_id and
     excess owner_id all become the owner — while u_manager stays the distinct
@@ -282,11 +282,16 @@ def test_owner_assigns_deals_to_existing_user(db_session: Session) -> None:
     lines = db_session.query(BuyPlanLine).all()
     assert lines and all(line.buyer_id == owner.id for line in lines)
 
-    # The ACTIVE plan is submitted by the owner ('deals' lens = BuyPlan.submitted_by_id)
-    # but APPROVED by the distinct sample manager (not the owner).
+    # EVERY buy plan — draft, pending AND active — is submitted by the owner so all
+    # three surface in the owner's "deals" board (deals_board scope=mine filters
+    # BuyPlan.submitted_by_id == user; the DRAFT must not be left with NULL).
+    plans = db_session.query(BuyPlan).all()
+    assert len(plans) == 3
+    assert all(bp.submitted_by_id == owner.id for bp in plans)
+
+    # The ACTIVE plan is APPROVED by the distinct sample manager (not the owner).
     q_won2 = db_session.query(Quote).filter_by(quote_number="AVSAMPLE-Q-0005").one()
     bp_active = db_session.query(BuyPlan).filter_by(quote_id=q_won2.id).one()
-    assert bp_active.submitted_by_id == owner.id
     assert bp_active.approved_by_id is not None and bp_active.approved_by_id != owner.id
     manager = db_session.query(User).filter(User.email.like("manager.avsample@%")).one()
     assert bp_active.approved_by_id == manager.id
@@ -310,4 +315,30 @@ def test_owner_pre_provisions_missing_user_and_survives_wipe(db_session: Session
 
     # Sample users gone; the pre-provisioned real owner survives.
     assert db_session.query(User).filter(User.email.like("%avsample@avsample.test")).count() == 0
+    assert db_session.get(User, owner.id) is not None
+
+
+def test_wipe_with_owner_succeeds_under_fk_enforcement(db_session: Session) -> None:
+    """Wipe() of an --owner-seeded DB succeeds under FK enforcement.
+
+    With --owner the RESTRICT FKs (ExcessList.owner_id, ExcessOffer.submitted_by,
+    CustomerBid.owner_id, ExcessOutreach.submitted_by) point at the REAL owner user,
+    which wipe() does NOT delete. Deleting the tagged child rows while that real parent
+    survives must still satisfy ondelete=RESTRICT — this exercises that path under the
+    conftest engine's PRAGMA foreign_keys=ON (else it's a no-op guarantee).
+    """
+    assert db_session.execute(text("PRAGMA foreign_keys")).scalar() == 1
+
+    sds.seed(db_session, owner_email="fkowner@trioscs.com")
+    owner = db_session.query(User).filter(User.email == "fkowner@trioscs.com").one()
+
+    deleted = sds.wipe(db_session)  # must not raise IntegrityError under RESTRICT
+
+    assert sum(deleted.values()) > 0
+    # All tagged excess rows (which referenced the real owner) are gone, no orphans.
+    assert _count(db_session, ExcessList) == 0
+    assert _count(db_session, ExcessOffer) == 0
+    assert _count(db_session, CustomerBid) == 0
+    assert _count(db_session, ExcessOutreach) == 0
+    # The real owner survives the wipe.
     assert db_session.get(User, owner.id) is not None


### PR DESCRIPTION
## What

Adds `python -m app.management.seed_sample_data --owner EMAIL`. By default the sample deals are owned by the sample actor users, so they only surface in the admin **supervise** lens. With `--owner`, the sample **requisitions, quotes, buy plans (+ lines) and excess lists** are assigned to the named user, so they populate **that user's default "mine" / "orders" / "deals" / resell lenses**.

## How

- Redirects the sample actor roles (`u_seeder`, `u_sales`, `u_buyer1`, `u_buyer2`, `u_trader`) to the resolved owner. The lenses filter on exactly the reassigned fields: requisition `created_by`, buy-plan-line `buyer_id`, buy-plan `submitted_by_id` (deals), excess `owner_id` (resell).
- **`u_manager` is intentionally left distinct** — it stays the approver/verifier so the approve/verify workflow still shows a second actor.
- Owner resolved case-insensitively. An unknown email **pre-provisions a real (non-sample) account** (role = admin if in `ADMIN_EMAILS`, else buyer) so it's ready when that person logs in via OAuth (matched on email). It is **never sample-tagged**, so `--wipe` leaves it intact.
- Idempotent-additive + `--wipe` semantics unchanged.

## Tests (10 passing)

Adds: existing-user redirect (asserts requisition `created_by` / buy-plan-line `buyer_id` / buy-plan `submitted_by_id` / excess `owner_id` all == owner, and that the manager stays a distinct approver), and missing-user pre-provision that survives `--wipe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)