### PR TITLE
fix(enrich): scheme-validate firmographic href (block javascript: XSS)

### DIFF
--- a/app/templates/htmx/partials/shared/_enrich_result.html
+++ b/app/templates/htmx/partials/shared/_enrich_result.html
@@ -68,7 +68,11 @@
         {% endif %}
       </p>
       {% if kind == 'link' %}
-      <a href='{{ val if "://" in val else "https://" ~ val }}' target='_blank' rel='noopener noreferrer'
+      {# Scheme-validate the href (safe_url blocks javascript:/data:/etc). Prepend https://
+         for bare domains via a startswith check — NOT a substring "://" test, which a
+         crafted javascript://… value would slip through. #}
+      {% set href = (val if val.lower().startswith(('http://', 'https://')) else 'https://' ~ val) | safe_url %}
+      <a href='{{ href }}' target='_blank' rel='noopener noreferrer'
          class='block text-sm text-brand-600 hover:text-brand-700 truncate'>{{ val | e }}</a>
       {% else %}
       <p class='text-sm text-gray-900 truncate'>{{ val | e }}</p>

--- a/tests/test_routers_crm.py
+++ b/tests/test_routers_crm.py
@@ -1143,6 +1143,37 @@ class TestEnrichment:
     @patch("app.enrichment_service.enrich_entity", new_callable=AsyncMock)
     @patch("app.enrichment_service.apply_enrichment_to_company")
     @patch("app.enrichment_service.find_suggested_contacts_with_errors", new_callable=AsyncMock)
+    def test_enrich_company_hx_website_javascript_uri_not_an_href(
+        self, mock_find, mock_apply, mock_enrich, mock_cred, client, db_session, test_company
+    ):
+        """A stored javascript:/data: website must never be emitted as a clickable href.
+
+        Guards against XSS: HTML-escaping the text doesn't neutralize a dangerous URL
+        scheme in an href, so the link must be scheme-validated (safe_url).
+        """
+        test_company.domain = "acme.com"
+        test_company.website = "javascript://%0aalert(document.cookie)"
+        db_session.commit()
+        mock_enrich.return_value = {}
+        mock_apply.return_value = []
+        mock_find.return_value = ([], [])
+
+        resp = client.post(f"/api/enrich/company/{test_company.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        body = resp.text.lower()
+        # The dangerous scheme must not appear as the target of any href (single/double-quoted).
+        assert "href='javascript:" not in body
+        assert 'href="javascript:' not in body
+        assert "href='data:" not in body
+        assert 'href="data:' not in body
+
+    @patch(
+        "app.routers.crm.enrichment.get_credential_cached",
+        side_effect=lambda scope, key: "fake-key" if key == "ANTHROPIC_API_KEY" else None,
+    )
+    @patch("app.enrichment_service.enrich_entity", new_callable=AsyncMock)
+    @patch("app.enrichment_service.apply_enrichment_to_company")
+    @patch("app.enrichment_service.find_suggested_contacts_with_errors", new_callable=AsyncMock)
     def test_enrich_company_hx_graceful_degradation(
         self, mock_find, mock_apply, mock_enrich, mock_cred, client, db_session, test_company
     ):


### PR DESCRIPTION
## Security fix (flagged on #458)
The enrich result panel (`shared/_enrich_result.html`) gated the website/LinkedIn `href` on a substring check `"://" in val`. A crafted stored value like `javascript://%0aalert(document.cookie)` contains `://`, so it was emitted verbatim as `href='javascript://…'` — HTML-escaping the link text does **not** neutralize a dangerous URL scheme. **MEDIUM XSS** (requires a malicious value in a company's `website`/`linkedin_url`, e.g. via inline edit or a hostile enrichment source).

## Fix
Normalize bare domains with a `startswith(('http://','https://'))` check (not the substring test), then run the result through the canonical **`safe_url`** filter (`app/template_env.py` — allows only `http(s)://`, else `#`), matching the existing pattern in `_contact_macros.html`.

## Tests
- New `test_enrich_company_hx_website_javascript_uri_not_an_href` — RED on the old template (`<a href='javascript://…'>`), GREEN after the fix.
- Full enrichment + contacts suites pass (38). Normal `http(s)://` links still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)