### PR TITLE
test: de-flake batch-refresh parallel test (assert concurrency, not wall-clock)

### DIFF
--- a/tests/test_sightings_batch_ops.py
+++ b/tests/test_sightings_batch_ops.py
@@ -11,7 +11,6 @@ Depends on: app/routers/sightings.py, tests/conftest.py
 import asyncio
 import json
 import os
-import time
 
 os.environ["TESTING"] = "1"
 
@@ -120,34 +119,44 @@ def test_batch_refresh_valid_requirement(client, db_session, test_user):
 def test_batch_refresh_runs_searches_in_parallel(client, db_session, test_user):
     """Batch-refresh must run search_requirement calls concurrently.
 
-    With the serial loop, N requirements = N × wall_time. With gather, N requirements ≈
-    1 × wall_time. We verify this by giving each search a 0.2s sleep and asserting that
-    3 requirements complete in well under 0.6s.
+    A serial loop awaits each search before starting the next, so peak concurrency is 1.
+    With ``asyncio.gather`` all three are in flight at once, so peak concurrency is 3. We
+    assert that directly via a peak-in-flight counter — deterministic regardless of runner
+    speed (the old wall-clock threshold flaked on loaded CI runners where parallel work
+    still exceeded the serial-floor time budget).
     """
     _, req1 = _make_req_and_requirement(db_session, test_user.id)
     _, req2 = _make_req_and_requirement(db_session, test_user.id)
     _, req3 = _make_req_and_requirement(db_session, test_user.id)
     db_session.commit()
 
+    inflight = 0
+    peak_inflight = 0
+
     async def slow_search(req_obj, db):
-        await asyncio.sleep(0.2)
-        return None
+        nonlocal inflight, peak_inflight
+        inflight += 1
+        peak_inflight = max(peak_inflight, inflight)
+        try:
+            # A short sleep widens the overlap window so all gathered coroutines are
+            # genuinely in flight together; the assertion is on concurrency, not timing.
+            await asyncio.sleep(0.05)
+            return None
+        finally:
+            inflight -= 1
 
     with patch(
         "app.search_service.search_requirement",
         side_effect=slow_search,
     ):
-        start = time.perf_counter()
         resp = client.post(
             "/v2/partials/sightings/batch-refresh",
             data={"requirement_ids": json.dumps([req1.id, req2.id, req3.id])},
         )
-        elapsed = time.perf_counter() - start
 
     assert resp.status_code == 200
-    # Serial would be ≥0.6s. Parallel should be ~0.2s + overhead.
-    # Give generous headroom for CI jitter but stay under the serial floor.
-    assert elapsed < 0.5, f"batch-refresh still serial: {elapsed:.3f}s for 3 × 0.2s"
+    # Serial execution would peak at 1 concurrent search; gather peaks at all 3.
+    assert peak_inflight == 3, f"batch-refresh still serial: peak {peak_inflight} concurrent search(es), expected 3"
 
 
 # ── batch-assign ──────────────────────────────────────────────────


### PR DESCRIPTION
## Why

`main` (HEAD `68729a04`, the merge of dependabot #438) has a **red `test` job**. I reproduced
the full suite locally against #438's bumped deps (fastapi 0.138, sentry 2.63, sse-starlette
3.4.5, anthropic 0.111, nh3 0.3.6) — **20307 passed, 0 failed**. So **#438 introduced no
regression**; the CI red was 3 flaky failures, the persistent one being this timing test.

## The fix

`test_batch_refresh_runs_searches_in_parallel` asserted parallelism by **wall-clock**
(`elapsed < 0.5s` for 3 × 0.2s searches). On CI's loaded 2-vCPU runner the parallel path still
took **~1.6s**, so it fails on CI essentially every run while passing locally — it blocks `main`
and every PR built on it.

Replaced the wall-clock budget with a **deterministic peak-concurrency counter**: each patched
search increments an in-flight counter on entry / decrements on exit; a serial loop peaks at 1,
`asyncio.gather` peaks at 3. The assertion `peak_inflight == 3` proves the endpoint runs the
searches concurrently — independent of runner speed. Also drops the now-unused `time` import.

## Verification
- Fixed test passes in isolation; full `tests/test_sightings_batch_ops.py` → **32 passed**.
- `ruff check` + `ruff format --check` clean.

## Not in scope (noted)
The other two CI failures — `test_vendor_attachments.py::TestMigration143Roundtrip` (×2) — **pass
locally** (in isolation and in the full `-n auto` run) and use the hermetic `run_ops` harness
(`Operations.context`, not the process-global `op` proxy). They're a rare xdist scheduling flake,
unrelated to #438; a re-run clears them. Not touched here to avoid a speculative, unverifiable
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_