### PR TITLE
test(fix): bind migration op locally in run_ops to kill the xdist migration flake (#470)

### DIFF
--- a/tests/migration_harness.py
+++ b/tests/migration_harness.py
@@ -1,13 +1,21 @@
 """Hermetic alembic-migration execution for migration unit tests.
 
 What: ``run_ops(engine, fn)`` executes a migration module's ``upgrade()``/``downgrade()``
-      directly through the MigrationContext + Operations.context pattern on a caller-
+      directly through a MigrationContext + a LOCALLY-BOUND ``Operations`` on a caller-
       provided scratch engine — NO alembic CLI, no alembic/env.py, no ``alembic.op``
       PROCESS-GLOBAL proxy, no os.environ DATABASE_URL channel. The in-process CLI path
       (command.stamp/upgrade on a temp-file DB) proved load-flaky under pytest-xdist
       (intermittent "table missing" skips from env.py's idempotent wrappers while the
       full suite runs in parallel), so migration round-trip tests share THIS helper
       instead of each file re-deriving the pattern.
+
+      IMPORTANT (issue #470): ``run_ops`` binds the migration module's module-level ``op``
+      name to a ctx-local ``Operations`` for the duration of the call. It deliberately does
+      NOT use ``Operations.context(ctx)`` — that installs alembic's *process-global*
+      ``alembic.op`` proxy, which is shared mutable state. Under pytest-xdist another test
+      that drives alembic could clobber that proxy mid-call, so a migration's
+      ``op.create_table`` would run against the wrong connection (the "attachment tables not
+      created" flake). A locally-bound ``op`` is immune to that.
 Called by: tests/test_migration_096_spec_provenance.py,
       tests/test_migration_097_dual_brand.py (and any future migration round-trip test).
 Depends on: alembic.migration.MigrationContext, alembic.operations.Operations.
@@ -23,8 +31,30 @@ from sqlalchemy.engine import Engine
 
 
 def run_ops(engine: Engine, fn: Callable[[], None]) -> None:
-    """Run a migration module's ``upgrade``/``downgrade`` hermetically on *engine*."""
+    """Run a migration module's ``upgrade``/``downgrade`` hermetically on *engine*.
+
+    ``fn`` is a migration module's ``upgrade``/``downgrade`` function; its ``op.*`` calls
+    resolve the module-global name ``op`` (``from alembic import op``). We temporarily rebind
+    that name in the function's own module namespace to a ctx-local ``Operations`` instance,
+    so the DDL runs against ``engine``'s connection with zero dependence on the shared global
+    proxy (see module docstring / issue #470). The original ``op`` is restored afterwards.
+    """
     with engine.begin() as conn:
         ctx = MigrationContext.configure(conn)
-        with Operations.context(ctx):
+        local_op = Operations(ctx)
+        module_globals = getattr(fn, "__globals__", None)
+        if module_globals is None:
+            # No module namespace to rebind (e.g. a lambda) — fall back to the global proxy.
+            with Operations.context(ctx):
+                fn()
+            return
+        sentinel = object()
+        previous_op = module_globals.get("op", sentinel)
+        module_globals["op"] = local_op
+        try:
             fn()
+        finally:
+            if previous_op is sentinel:
+                module_globals.pop("op", None)
+            else:
+                module_globals["op"] = previous_op

--- a/tests/test_migration_harness.py
+++ b/tests/test_migration_harness.py
@@ -1,0 +1,62 @@
+"""tests/test_migration_harness.py — Tests for the hermetic migration runner.
+
+Called by: pytest
+Depends on: tests.migration_harness.run_ops
+"""
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.pool import StaticPool
+
+from alembic import op as alembic_op
+from tests.migration_harness import run_ops
+
+
+def _mem_engine():
+    return sa.create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+
+def _make_upgrade(table_name):
+    """Build a migration-style upgrade() whose module global `op` is the alembic proxy,
+    mirroring how real migrations reference `op` (``from alembic import op``)."""
+    ns = {"sa": sa, "op": alembic_op}
+    src = f"def upgrade():\n    op.create_table('{table_name}', sa.Column('id', sa.Integer, primary_key=True))\n"
+    exec(src, ns)  # noqa: S102 — controlled source, test-only
+    return ns["upgrade"], ns
+
+
+def test_run_ops_creates_table_via_locally_bound_op():
+    """run_ops must execute the DDL against the provided engine (the happy path)."""
+    upgrade, _ns = _make_upgrade("demo_created")
+    engine = _mem_engine()
+    run_ops(engine, upgrade)
+    assert "demo_created" in inspect(engine).get_table_names()
+
+
+def test_run_ops_restores_module_op_after_running():
+    """run_ops rebinds the migration module's `op` only for the call, then restores it —
+    so it leaves no global/namespace state behind (issue #470 hardening)."""
+    upgrade, ns = _make_upgrade("demo_restore")
+    engine = _mem_engine()
+    run_ops(engine, upgrade)
+    assert ns["op"] is alembic_op  # original proxy restored
+
+
+def test_run_ops_is_independent_of_a_clobbered_global_proxy():
+    """The whole point of the rebind: even if alembic's PROCESS-GLOBAL op proxy is pointing
+    at a different (wrong) context — as a concurrent xdist test could leave it — run_ops
+    still runs the migration against the correct engine, because it binds `op` locally."""
+    # Install a bogus global proxy bound to a DIFFERENT engine (the "clobbered" state).
+    other_engine = _mem_engine()
+    from alembic.migration import MigrationContext
+    from alembic.operations import Operations
+
+    with other_engine.connect() as other_conn:
+        bogus_ctx = MigrationContext.configure(other_conn)
+        with Operations.context(bogus_ctx):  # global alembic.op now points at other_engine
+            upgrade, _ns = _make_upgrade("demo_independent")
+            engine = _mem_engine()
+            run_ops(engine, upgrade)
+            # table landed on the intended engine, NOT the clobbered global one
+            assert "demo_independent" in inspect(engine).get_table_names()
+            assert "demo_independent" not in inspect(other_engine).get_table_names()


### PR DESCRIPTION
## Why

`TestMigration143Roundtrip` (`tests/test_vendor_attachments.py`) **intermittently fails CI**
with "attachment tables not created" — it has reddened otherwise-green PRs (#438, #435, #462,
#461, #421) while passing locally every time. Tracked in **#470**.

## Root cause

`tests/migration_harness.run_ops` **documents** that it avoids alembic's *process-global*
`alembic.op` proxy (because that global is the flaky channel) — but the implementation used
`Operations.context(ctx)`, which **is** exactly that global-proxy installer. The global proxy
is shared mutable state; under pytest-xdist another test that drives alembic can clobber it
mid-call, so a migration's `op.create_table` executes against the wrong connection and the
tables never land on the test's scratch engine.

## Fix

Realize the documented intent: temporarily **rebind the migration module's module-level `op`
name** to a ctx-local `Operations` instance for the duration of the call (and restore it
after), instead of installing the global proxy. The DDL now runs against the intended engine
with zero dependence on global state — immune to any concurrent toucher.

## Verification

- New `tests/test_migration_harness.py` (3 tests) — including a regression test that
  **deliberately clobbers the global `alembic.op` proxy to point at a different engine** and
  asserts `run_ops` still writes to the correct one (and not the clobbered one). This directly
  exercises the failure mechanism.
- All existing migration round-trip tests pass: 094/096/098/100/101/108/**143** (69 passed);
  the 143 roundtrip ran clean across repeated `-n auto` invocations. `ruff` + `mypy` clean.

Closes #470 (pending confirmation across several green CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_