### PR TITLE
feat(quotes): advisory quote pre-flight checks (DNC / non-US COO / MPN drift)

### DIFF
--- a/app/routers/crm/quotes.py
+++ b/app/routers/crm/quotes.py
@@ -378,8 +378,8 @@ async def quote_preflight_check(
 ):
     """Advisory pre-send checks (DNC recipient / non-US country-of-origin / MPN drift).
 
-    Read-only; returns the warnings the send UI surfaces. Advisory only — it never blocks
-    the send (the salesperson decides). See app/services/quote_preflight.py.
+    Read-only; returns the warnings the send UI surfaces. Advisory only — it never
+    blocks the send (the salesperson decides). See app/services/quote_preflight.py.
     """
     from ...dependencies import get_quote_for_user
     from ...services.quote_preflight import quote_preflight

--- a/app/routers/crm/quotes.py
+++ b/app/routers/crm/quotes.py
@@ -370,6 +370,27 @@ async def preview_quote_email(
     return {"html": html}
 
 
+@router.get("/api/quotes/{quote_id}/preflight")
+async def quote_preflight_check(
+    quote_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Advisory pre-send checks (DNC recipient / non-US country-of-origin / MPN drift).
+
+    Read-only; returns the warnings the send UI surfaces. Advisory only — it never blocks
+    the send (the salesperson decides). See app/services/quote_preflight.py.
+    """
+    from ...dependencies import get_quote_for_user
+    from ...services.quote_preflight import quote_preflight
+
+    quote = get_quote_for_user(db, user, quote_id)
+    if not quote:
+        raise HTTPException(404, "Quote not found")
+    warnings = quote_preflight(db, quote)
+    return {"warnings": [w.to_dict() for w in warnings], "count": len(warnings)}
+
+
 @router.post("/api/quotes/{quote_id}/send")
 async def send_quote(
     quote_id: int,

--- a/app/routers/quote_builder.py
+++ b/app/routers/quote_builder.py
@@ -295,6 +295,7 @@ def _build_quote_tab_context(request: Request, db: Session, req, quote=None) -> 
         build_quote_tab_data,
         quote_export_context,
     )
+    from ..services.quote_preflight import quote_preflight
 
     if quote is None:
         quote = (
@@ -338,6 +339,9 @@ def _build_quote_tab_context(request: Request, db: Session, req, quote=None) -> 
         "has_customer_site": bool(req.customer_site_id),
         "quote": quote,
         "summary": quote_export_context(quote) if quote else None,
+        # Advisory pre-send checks (DNC / non-US COO / MPN drift). Surfaced as a banner
+        # above Send; never blocks the send (see services/quote_preflight.py).
+        "preflight_warnings": [w.to_dict() for w in quote_preflight(db, quote)] if quote else [],
     }
 
 

--- a/app/services/quote_preflight.py
+++ b/app/services/quote_preflight.py
@@ -1,0 +1,136 @@
+"""quote_preflight.py — advisory pre-send checks for customer quotes.
+
+What: ``quote_preflight(db, quote)`` runs deterministic, READ-ONLY checks just before a quote
+      email is sent and returns a list of advisory ``PreflightWarning``s. It NEVER blocks the
+      send — the send UI surfaces the warnings and the salesperson decides. Three checks:
+        1. dnc                — recipient site or matching contact is marked Do-Not-Contact
+        2. country_of_origin  — a quoted line's sourced offer has a non-US country of origin
+        3. mpn_drift          — a quoted MPN is not one the requisition actually asked for
+Called by: app/routers/crm/quotes.py (GET /api/quotes/{id}/preflight; the send/preview UI).
+Depends on: models (Quote, CustomerSite, SiteContact, Offer, Requirement),
+            app.utils.normalization.normalize_mpn.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models import CustomerSite, Offer, Quote, Requirement, SiteContact
+from app.utils.normalization import normalize_mpn
+
+# Accepted spellings of the United States, reduced to letters-only for comparison.
+_US_COUNTRY_KEYS = {
+    "US",
+    "USA",
+    "USOFA",
+    "UNITEDSTATES",
+    "UNITEDSTATESOFAMERICA",
+    "UNITEDSTATESAMERICA",
+    "AMERICA",
+}
+
+_MAX_LISTED = 5  # cap the MPNs/lines named in a message so the banner stays short
+
+
+@dataclass(frozen=True)
+class PreflightWarning:
+    """One advisory finding. ``level`` is always 'warning' — preflight never errors/blocks."""
+
+    code: str  # "dnc" | "country_of_origin" | "mpn_drift"
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"code": self.code, "level": "warning", "message": self.message}
+
+
+def _coo_is_non_us(value: object) -> bool:
+    """True if *value* is a non-empty country of origin that is not the United States.
+
+    Accepts ``object`` so a SQLAlchemy column value passes cleanly; coerced to str here.
+    """
+    key = re.sub(r"[^A-Z]", "", str(value or "").upper())
+    return bool(key) and key not in _US_COUNTRY_KEYS
+
+
+def _quote_line_refs(quote: Quote) -> list[tuple[str | None, int | None]]:
+    """Return [(mpn, offer_id), ...] for a quote, preferring the structured quote_lines
+    relationship and falling back to the legacy line_items JSON (no offer_id there)."""
+    if quote.quote_lines:
+        return [(ql.mpn, ql.offer_id) for ql in quote.quote_lines]
+    refs: list[tuple[str | None, int | None]] = []
+    raw_items = quote.line_items
+    items = raw_items if isinstance(raw_items, list) else []
+    for item in items:
+        if isinstance(item, dict):
+            refs.append((item.get("mpn"), item.get("offer_id")))
+    return refs
+
+
+def quote_preflight(db: Session, quote: Quote) -> list[PreflightWarning]:
+    """Run the advisory pre-send checks. Pure read; returns [] when nothing is flagged."""
+    warnings: list[PreflightWarning] = []
+
+    # 1. Do-Not-Contact recipient — site-level flag and/or a matching DNC contact.
+    site = db.get(CustomerSite, quote.customer_site_id) if quote.customer_site_id else None
+    if site is not None:
+        if site.do_not_contact:
+            warnings.append(PreflightWarning("dnc", f"Customer site “{site.site_name}” is marked Do-Not-Contact."))
+        recipient = (site.contact_email or "").strip().lower()
+        if recipient:
+            dnc_contact = (
+                db.query(SiteContact)
+                .filter(
+                    SiteContact.customer_site_id == site.id,
+                    func.lower(SiteContact.email) == recipient,
+                    SiteContact.do_not_contact.is_(True),
+                )
+                .first()
+            )
+            if dnc_contact is not None:
+                warnings.append(PreflightWarning("dnc", f"Recipient {site.contact_email} is a Do-Not-Contact contact."))
+
+    line_refs = _quote_line_refs(quote)
+
+    # 2. Non-US country of origin — read from each quoted line's sourced offer.
+    non_us: list[tuple[str | None, str]] = []
+    for mpn, offer_id in line_refs:
+        if not offer_id:
+            continue
+        offer = db.get(Offer, offer_id)
+        if offer is None:
+            continue
+        coo = offer.country_of_origin
+        if _coo_is_non_us(coo):
+            non_us.append((mpn, str(coo).strip()))
+    if non_us:
+        listing = ", ".join(f"{mpn or '—'} ({coo})" for mpn, coo in non_us[:_MAX_LISTED])
+        warnings.append(
+            PreflightWarning(
+                "country_of_origin",
+                f"Non-US country of origin on {len(non_us)} line(s): {listing}.",
+            )
+        )
+
+    # 3. MPN drift — quoted MPNs that aren't any of the requisition's requirement MPNs.
+    requirement_keys: set[str] = set()
+    if quote.requisition_id:
+        for req in db.query(Requirement).filter(Requirement.requisition_id == quote.requisition_id):
+            for raw in (req.primary_mpn, req.customer_pn, req.oem_pn):
+                key = normalize_mpn(raw)
+                if key:
+                    requirement_keys.add(key)
+    drift: list[str] = []
+    if requirement_keys:  # only meaningful when the requisition declares MPNs at all
+        for mpn, _offer_id in line_refs:
+            key = normalize_mpn(mpn)
+            if key and key not in requirement_keys:
+                drift.append(mpn or "—")
+    if drift:
+        listing = ", ".join(drift[:_MAX_LISTED])
+        warnings.append(PreflightWarning("mpn_drift", f"{len(drift)} quoted MPN(s) not on the requisition: {listing}."))
+
+    return warnings

--- a/app/services/quote_preflight.py
+++ b/app/services/quote_preflight.py
@@ -38,7 +38,10 @@ _MAX_LISTED = 5  # cap the MPNs/lines named in a message so the banner stays sho
 
 @dataclass(frozen=True)
 class PreflightWarning:
-    """One advisory finding. ``level`` is always 'warning' — preflight never errors/blocks."""
+    """One advisory finding.
+
+    ``level`` is always 'warning' — preflight never errors/blocks.
+    """
 
     code: str  # "dnc" | "country_of_origin" | "mpn_drift"
     message: str
@@ -71,7 +74,10 @@ def _quote_line_refs(quote: Quote) -> list[tuple[str | None, int | None]]:
 
 
 def quote_preflight(db: Session, quote: Quote) -> list[PreflightWarning]:
-    """Run the advisory pre-send checks. Pure read; returns [] when nothing is flagged."""
+    """Run the advisory pre-send checks.
+
+    Pure read; returns [] when nothing is flagged.
+    """
     warnings: list[PreflightWarning] = []
 
     # 1. Do-Not-Contact recipient — site-level flag and/or a matching DNC contact.

--- a/app/templates/htmx/partials/requisitions/tabs/build_quote.html
+++ b/app/templates/htmx/partials/requisitions/tabs/build_quote.html
@@ -153,6 +153,26 @@
   {# ── Assembled-quote summary (clean export preview) ───────────── #}
   {% if quote and summary %}
   <div class="card">
+    {# Advisory pre-send checks — DNC / non-US country-of-origin / MPN drift. Informational
+       only; the Send button below is never disabled (see services/quote_preflight.py). #}
+    {% if preflight_warnings and quote.status == 'draft' %}
+    <div class="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2" role="status"
+         aria-label="Quote pre-send advisories">
+      <p class="text-xs font-semibold text-amber-700 flex items-center gap-1">
+        <svg class="h-3.5 w-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round"
+                d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+        </svg>
+        Before you send — {{ preflight_warnings|length }} advisory check{{ 's' if preflight_warnings|length != 1 }}
+      </p>
+      <ul class="mt-1 space-y-0.5 pl-5 list-disc">
+        {% for w in preflight_warnings %}
+        <li class="text-xs text-amber-700">{{ w.message }}</li>
+        {% endfor %}
+      </ul>
+      <p class="text-[11px] text-amber-600 mt-1">Advisory only — review, then send if it's correct.</p>
+    </div>
+    {% endif %}
     <div class="flex items-start justify-between gap-3">
       <div>
         <p class="text-base font-semibold text-gray-900">{{ summary.quote_number }}</p>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1168,8 +1168,18 @@ requisitions/tabs/build_quote.html  (quoteBuilderTab Alpine: live margin + guard
               |                  (parses QuoteBuilderLine[]; delegates to
               v                   save_quote_from_builder -> revision lifecycle preserved)
         re-render tab with inline clean summary (quote_export_context) +
+        advisory pre-send banner (quote_preflight) +
         Download PDF (existing /export/pdf) / Send (existing /quotes/{id}/send)
 ```
+
+**Quote pre-flight (advisory, never blocks send).** `services/quote_preflight.py`
+`quote_preflight(db, quote)` runs three deterministic read-only checks and returns a list of
+`PreflightWarning`s: **dnc** (recipient `CustomerSite.do_not_contact`, or a `SiteContact` at
+that site whose email matches the recipient and is `do_not_contact`), **country_of_origin**
+(a quoted line's sourced `Offer.country_of_origin` is non-US), and **mpn_drift** (a quoted MPN,
+via `normalize_mpn`, is not among the requisition's requirement MPNs). The Build-Quote tab
+(`quote_builder._build_quote_tab_context`) surfaces them as an amber banner above Send; it never
+disables Send. Also exposed at `GET /api/quotes/{id}/preflight` (`{warnings, count}`).
 
 `quoteBuilderTab` (in `htmx_app.js`) is the single-stage simplification of the
 modal's `quoteBuilder` (same `(sell-cost)/sell` margin math + blended rollup, no

--- a/tests/test_quote_preflight.py
+++ b/tests/test_quote_preflight.py
@@ -1,0 +1,181 @@
+"""tests/test_quote_preflight.py — Tests for app/services/quote_preflight.py.
+
+Covers the three advisory checks (dnc / country_of_origin / mpn_drift), the clean path,
+and the never-blocks contract.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models import Offer, Quote, QuoteLine, Requirement, SiteContact
+from app.services.quote_preflight import PreflightWarning, quote_preflight
+
+
+def _add_requirement(db: Session, requisition_id: int, **kw) -> Requirement:
+    r = Requirement(requisition_id=requisition_id, **kw)
+    db.add(r)
+    db.commit()
+    return r
+
+
+def _add_line(db: Session, quote: Quote, mpn: str, offer_id: int | None = None) -> QuoteLine:
+    ql = QuoteLine(quote_id=quote.id, mpn=mpn, offer_id=offer_id, qty=1)
+    db.add(ql)
+    db.commit()
+    db.refresh(quote)
+    return ql
+
+
+def _codes(warnings: list[PreflightWarning]) -> set[str]:
+    return {w.code for w in warnings}
+
+
+class TestPreflightClean:
+    def test_quote_with_matching_mpn_no_offer_coo_no_dnc_is_clean(self, db_session, test_quote):
+        _add_requirement(db_session, test_quote.requisition_id, primary_mpn="LM317T")
+        _add_line(db_session, test_quote, mpn="LM317T")
+        assert quote_preflight(db_session, test_quote) == []
+
+    def test_returns_list_of_preflight_warnings(self, db_session, test_quote):
+        # Contract: always a list, never raises / blocks — even with no requisition MPNs.
+        result = quote_preflight(db_session, test_quote)
+        assert isinstance(result, list)
+
+
+class TestDncCheck:
+    def test_dnc_site_flagged(self, db_session, test_quote, test_customer_site):
+        test_customer_site.do_not_contact = True
+        db_session.commit()
+        assert "dnc" in _codes(quote_preflight(db_session, test_quote))
+
+    def test_dnc_contact_matching_recipient_flagged(self, db_session, test_quote, test_customer_site):
+        # A contact at the site, same email as the site recipient, marked DNC.
+        db_session.add(
+            SiteContact(
+                customer_site_id=test_customer_site.id,
+                full_name="Jane Doe",
+                email=test_customer_site.contact_email,
+                do_not_contact=True,
+            )
+        )
+        db_session.commit()
+        assert "dnc" in _codes(quote_preflight(db_session, test_quote))
+
+    def test_non_dnc_contact_not_flagged(self, db_session, test_quote, test_customer_site):
+        db_session.add(
+            SiteContact(
+                customer_site_id=test_customer_site.id,
+                full_name="Jane Doe",
+                email=test_customer_site.contact_email,
+                do_not_contact=False,
+            )
+        )
+        db_session.commit()
+        assert "dnc" not in _codes(quote_preflight(db_session, test_quote))
+
+
+class TestCountryOfOriginCheck:
+    def _offer_with_coo(self, db_session, test_quote, coo):
+        offer = Offer(
+            requisition_id=test_quote.requisition_id,
+            vendor_name="Arrow",
+            mpn="LM317T",
+            qty_available=100,
+            unit_price=0.5,
+            status="active",
+            country_of_origin=coo,
+        )
+        db_session.add(offer)
+        db_session.commit()
+        _add_line(db_session, test_quote, mpn="LM317T", offer_id=offer.id)
+
+    def test_non_us_coo_flagged(self, db_session, test_quote):
+        self._offer_with_coo(db_session, test_quote, "China")
+        assert "country_of_origin" in _codes(quote_preflight(db_session, test_quote))
+
+    def test_us_coo_not_flagged(self, db_session, test_quote):
+        self._offer_with_coo(db_session, test_quote, "United States")
+        assert "country_of_origin" not in _codes(quote_preflight(db_session, test_quote))
+
+    def test_usa_abbrev_not_flagged(self, db_session, test_quote):
+        self._offer_with_coo(db_session, test_quote, "U.S.A.")
+        assert "country_of_origin" not in _codes(quote_preflight(db_session, test_quote))
+
+    def test_blank_coo_not_flagged(self, db_session, test_quote):
+        self._offer_with_coo(db_session, test_quote, "")
+        assert "country_of_origin" not in _codes(quote_preflight(db_session, test_quote))
+
+
+class TestMpnDriftCheck:
+    def test_drift_flagged_when_line_mpn_absent_from_requirements(self, db_session, test_quote):
+        _add_requirement(db_session, test_quote.requisition_id, primary_mpn="LM317T")
+        _add_line(db_session, test_quote, mpn="TOTALLY-DIFFERENT-9999")
+        warnings = quote_preflight(db_session, test_quote)
+        assert "mpn_drift" in _codes(warnings)
+
+    def test_no_drift_when_line_matches_requirement(self, db_session, test_quote):
+        _add_requirement(db_session, test_quote.requisition_id, customer_pn="CUST-PN-1", primary_mpn="LM317T")
+        _add_line(db_session, test_quote, mpn="lm317t")  # case-insensitive via normalize_mpn
+        assert "mpn_drift" not in _codes(quote_preflight(db_session, test_quote))
+
+    def test_no_drift_check_when_requisition_has_no_mpns(self, db_session, test_user):
+        # A requisition whose requirement carries no MPN at all → nothing to compare
+        # against, so drift is never asserted (avoids false positives on MPN-less reqs).
+        from app.models import Requisition
+
+        req = Requisition(name="REQ-NO-MPN", customer_name="X", status="active", created_by=test_user.id)
+        db_session.add(req)
+        db_session.flush()
+        db_session.add(Requirement(requisition_id=req.id, target_qty=1))  # no primary/customer/oem PN
+        quote = Quote(requisition_id=req.id, quote_number="NO-MPN-Q-1", status="draft", line_items=[])
+        db_session.add(quote)
+        db_session.commit()
+        db_session.refresh(quote)
+        _add_line(db_session, quote, mpn="ANYTHING")
+        assert "mpn_drift" not in _codes(quote_preflight(db_session, quote))
+
+
+class TestPreflightEndpoint:
+    def test_endpoint_returns_warnings_json(self, client, db_session, test_quote, test_customer_site):
+        test_customer_site.do_not_contact = True
+        db_session.commit()
+        resp = client.get(f"/api/quotes/{test_quote.id}/preflight")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] >= 1
+        assert any(w["code"] == "dnc" for w in data["warnings"])
+        assert all(w["level"] == "warning" for w in data["warnings"])
+
+    def test_endpoint_clean_quote_returns_empty(self, client, db_session, test_quote):
+        _add_requirement(db_session, test_quote.requisition_id, primary_mpn="LM317T")
+        _add_line(db_session, test_quote, mpn="LM317T")
+        resp = client.get(f"/api/quotes/{test_quote.id}/preflight")
+        assert resp.status_code == 200
+        assert resp.json() == {"warnings": [], "count": 0}
+
+    def test_endpoint_404_for_missing_quote(self, client):
+        resp = client.get("/api/quotes/999999/preflight")
+        assert resp.status_code == 404
+        assert "error" in resp.json()  # project error envelope, not "detail"
+
+
+def test_multiple_warnings_accumulate_and_never_block(db_session, test_quote, test_customer_site):
+    """All three issues at once → three advisory warnings, returned (not raised)."""
+    test_customer_site.do_not_contact = True
+    db_session.commit()
+    _add_requirement(db_session, test_quote.requisition_id, primary_mpn="LM317T")
+    offer = Offer(
+        requisition_id=test_quote.requisition_id,
+        vendor_name="Arrow",
+        mpn="FOREIGN-1",
+        qty_available=10,
+        unit_price=1.0,
+        status="active",
+        country_of_origin="Malaysia",
+    )
+    db_session.add(offer)
+    db_session.commit()
+    _add_line(db_session, test_quote, mpn="FOREIGN-1", offer_id=offer.id)
+
+    warnings = quote_preflight(db_session, test_quote)
+    assert _codes(warnings) == {"dnc", "country_of_origin", "mpn_drift"}
+    assert all(w.to_dict()["level"] == "warning" for w in warnings)


### PR DESCRIPTION
## What

Phase 2 of the consolidation plan: a **Quote Pre-flight** advisory feature. A deterministic,
read-only `quote_preflight(db, quote)` service surfaces last-second sanity warnings before a
salesperson sends a customer quote — and **never blocks the send**.

### Three checks
- **dnc** — recipient `CustomerSite.do_not_contact`, or a `SiteContact` at that site whose email
  matches the recipient and is flagged `do_not_contact`.
- **country_of_origin** — a quoted line's sourced `Offer.country_of_origin` is non-US
  (letters-only normalization accepts US / USA / United States[ of America] / America).
- **mpn_drift** — a quoted MPN (via `normalize_mpn`) isn't among the requisition's requirement
  MPNs (`primary_mpn`/`customer_pn`/`oem_pn`). Skipped when the requisition declares no MPNs, so
  no false positives.

### Surfaced two ways (advisory only)
- The **Build-Quote tab** renders an amber banner above the Send button
  (`quote_builder._build_quote_tab_context` → `build_quote.html`). Send is never disabled.
- **`GET /api/quotes/{id}/preflight`** → `{warnings, count}` for API/UI consumers.

This resolves the spec's open question by gating at the build-quote send surface (the real UI
path) advisorily, not at the raw `/api/quotes/{id}/send` (which stays unchanged so programmatic
sends are never blocked).

## Files
- `app/services/quote_preflight.py` *(new)* — service + `PreflightWarning`
- `app/routers/crm/quotes.py` — `GET /api/quotes/{id}/preflight`
- `app/routers/quote_builder.py` — `preflight_warnings` in the tab context
- `app/templates/htmx/partials/requisitions/tabs/build_quote.html` — advisory banner
- `tests/test_quote_preflight.py` *(new)* — 16 tests
- `docs/APP_MAP_INTERACTIONS.md` — documented

## Verification
- `tests/test_quote_preflight.py` — **16 passed** (each check, clean path, endpoint 200 + 404
  error-envelope, never-blocks/accumulate contract).
- Affected build-quote-tab + quotes-router + quote_builder tests — **60 passed**.
- `ruff` + CI-style `mypy --config-file=pyproject.toml app/` clean (zero new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_