### PR TITLE
feat(ui): Buy Plans foundation conformance — accent, primitives, line-tokens, a11y

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -72,6 +72,7 @@
      shares one shape. */
   .badge-success { @apply badge bg-emerald-50 text-emerald-700 border-emerald-200; }
   .badge-warning { @apply badge bg-amber-50 text-amber-700 border-amber-200; }
+  .badge-danger  { @apply badge bg-rose-50 text-rose-700 border-rose-200; }
   .badge-info    { @apply badge bg-brand-100 text-brand-700 border-brand-200; }
 
   /* ── Cards — resting surfaces. Border is brand-200 (the dominant card
@@ -125,6 +126,8 @@
      once drained, the !important block is deleted. ─────────────────── */
   .border-line-base   { border-color: var(--line); }
   .border-line-subtle { border-color: var(--line-subtle); }
+  .divide-line-base > * + *   { border-color: var(--line); }
+  .divide-line-subtle > * + * { border-color: var(--line-subtle); }
 
   /* ── Table wrapper ──────────────────────────────────────────────── */
   .table-wrapper {

--- a/app/templates/htmx/partials/buy_plans/_board.html
+++ b/app/templates/htmx/partials/buy_plans/_board.html
@@ -27,34 +27,42 @@
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
   {% for key, label in columns %}
   {% set cards = board[key]|sort(attribute='needs_my_action', reverse=True) %}
-  <div class="bg-gray-50 rounded-lg border border-gray-200 flex flex-col min-h-[120px]">
-    <div class="px-3 py-2 border-b border-gray-200 flex items-center justify-between">
+  {# Finding #5: border-gray-200 → border-line-base on column shells #}
+  <div class="bg-gray-50 rounded-lg border border-line-base flex flex-col min-h-[120px]">
+    <div class="px-3 py-2 border-b border-line-base flex items-center justify-between">
       <span class="text-xs font-semibold text-gray-600 uppercase tracking-wider">{{ label }}</span>
       <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 rounded-full bg-gray-200 text-gray-600 text-xs font-medium">{{ board[key]|length }}</span>
     </div>
     <div class="p-2 space-y-2 flex-1">
       {% for d in cards %}
       {% set m = d.margin_pct|float if d.margin_pct is not none else 0 %}
+      {# Finding #9: keyboard navigation — real focusable element with accent focus ring and role=link #}
       <div hx-get="/v2/partials/buy-plans/{{ d.plan_id }}"
            hx-target="#main-content"
            hx-push-url="/v2/buy-plans/{{ d.plan_id }}"
            preload="mouseover"
+           tabindex="0"
+           role="link"
+           @keydown.enter.prevent="htmx.ajax('GET', '/v2/partials/buy-plans/{{ d.plan_id }}', {target: '#main-content', swap: 'innerHTML'}); history.pushState(null, '', '/v2/buy-plans/{{ d.plan_id }}')"
+           @keydown.space.prevent="htmx.ajax('GET', '/v2/partials/buy-plans/{{ d.plan_id }}', {target: '#main-content', swap: 'innerHTML'}); history.pushState(null, '', '/v2/buy-plans/{{ d.plan_id }}')"
            class="bg-white rounded-md border border-brand-200 p-3 cursor-pointer hover:shadow-sm transition-shadow
+                  focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:outline-none
                   {% if d.needs_my_action %}ring-2 ring-amber-400{% endif %}">
         {# Customer + stock badge #}
         <div class="flex items-start justify-between gap-2">
           <span class="text-sm font-bold text-gray-900 leading-tight">{{ d.customer_name or '-' }}</span>
           {% if d.is_stock_sale %}
-          <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded bg-purple-50 text-purple-600 flex-shrink-0">stock</span>
+          {# Finding #7: bespoke stock tag → .chip primitive #}
+          <span class="chip bg-purple-50 text-purple-600 border-purple-200 flex-shrink-0">stock</span>
           {% endif %}
         </div>
         {# Value + margin #}
         <div class="mt-1.5 flex items-center justify-between gap-2">
           <span class="text-sm font-semibold text-gray-900">${{ '{:,.2f}'.format(d.value|float) if d.value else '0.00' }}</span>
-          <span class="inline-flex px-2 py-0.5 rounded-full text-xs font-medium
-                       {% if m >= 30 %}bg-emerald-50 text-emerald-700
-                       {% elif m >= 15 %}bg-amber-50 text-amber-700
-                       {% else %}bg-rose-50 text-rose-700{% endif %}">
+          <span class="badge
+                       {% if m >= 30 %}bg-emerald-50 text-emerald-700 border-emerald-200
+                       {% elif m >= 15 %}bg-amber-50 text-amber-700 border-amber-200
+                       {% else %}bg-rose-50 text-rose-700 border-rose-200{% endif %}">
             {{ '{:.1f}'.format(m) }}%
           </span>
         </div>

--- a/app/templates/htmx/partials/buy_plans/_board.html
+++ b/app/templates/htmx/partials/buy_plans/_board.html
@@ -43,9 +43,9 @@
            preload="mouseover"
            tabindex="0"
            role="link"
-           @keydown.enter.prevent="htmx.ajax('GET', '/v2/partials/buy-plans/{{ d.plan_id }}', {target: '#main-content', swap: 'innerHTML'}); history.pushState(null, '', '/v2/buy-plans/{{ d.plan_id }}')"
-           @keydown.space.prevent="htmx.ajax('GET', '/v2/partials/buy-plans/{{ d.plan_id }}', {target: '#main-content', swap: 'innerHTML'}); history.pushState(null, '', '/v2/buy-plans/{{ d.plan_id }}')"
-           class="bg-white rounded-md border border-brand-200 p-3 cursor-pointer hover:shadow-sm transition-shadow
+           @keydown.enter.prevent="$el.click()"
+           @keydown.space.prevent="$el.click()"
+           class="bg-white rounded-md border border-line-base p-3 cursor-pointer hover:shadow-sm transition-shadow
                   focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:outline-none
                   {% if d.needs_my_action %}ring-2 ring-amber-400{% endif %}">
         {# Customer + stock badge #}
@@ -53,16 +53,13 @@
           <span class="text-sm font-bold text-gray-900 leading-tight">{{ d.customer_name or '-' }}</span>
           {% if d.is_stock_sale %}
           {# Finding #7: bespoke stock tag → .chip primitive #}
-          <span class="chip bg-purple-50 text-purple-600 border-purple-200 flex-shrink-0">stock</span>
+          <span class="chip bg-purple-50 text-purple-700 border-purple-200 flex-shrink-0">stock</span>
           {% endif %}
         </div>
         {# Value + margin #}
         <div class="mt-1.5 flex items-center justify-between gap-2">
           <span class="text-sm font-semibold text-gray-900">${{ '{:,.2f}'.format(d.value|float) if d.value else '0.00' }}</span>
-          <span class="badge
-                       {% if m >= 30 %}bg-emerald-50 text-emerald-700 border-emerald-200
-                       {% elif m >= 15 %}bg-amber-50 text-amber-700 border-amber-200
-                       {% else %}bg-rose-50 text-rose-700 border-rose-200{% endif %}">
+          <span class="{% if m >= 30 %}badge-success{% elif m >= 15 %}badge-warning{% else %}badge-danger{% endif %}">
             {{ '{:.1f}'.format(m) }}%
           </span>
         </div>

--- a/app/templates/htmx/partials/buy_plans/_orders_queue.html
+++ b/app/templates/htmx/partials/buy_plans/_orders_queue.html
@@ -21,23 +21,24 @@
 </div>
 
 {% if queue %}
+{# Finding #1: convert to data-table; drop per-cell px-4 py-3 and per-th text-xs font-medium text-gray-500 uppercase tracking-wider #}
 <div class="overflow-x-auto bg-white rounded-lg shadow border border-brand-200">
-  <table class="min-w-full divide-y divide-gray-200">
-    <thead class="bg-gray-50">
+  <table class="data-table w-full">
+    <thead>
       <tr>
-        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Customer</th>
-        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Part</th>
-        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Vendor</th>
-        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
-        <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Unit Cost</th>
-        <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
+        <th class="text-left">Customer</th>
+        <th class="text-left">Part</th>
+        <th class="text-left">Vendor</th>
+        <th class="text-right">Qty</th>
+        <th class="text-right">Unit Cost</th>
+        <th class="text-left">Action</th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-200">
+    <tbody>
       {% for row in queue %}
-      <tr id="bp-line-{{ row.line_id }}" class="transition-colors {% if row.kicked_back %}bg-rose-50{% else %}hover:bg-brand-50/40{% endif %}">
+      <tr id="bp-line-{{ row.line_id }}" class="transition-colors {% if row.kicked_back %}bg-rose-50{% endif %}">
         {# Customer (links to the deal detail) #}
-        <td class="px-4 py-3">
+        <td>
           <a hx-get="/v2/partials/buy-plans/{{ row.plan_id }}"
              hx-target="#main-content"
              hx-push-url="/v2/buy-plans/{{ row.plan_id }}"
@@ -53,20 +54,20 @@
           {% endif %}
         </td>
         {# Part (MPN + description) #}
-        <td class="px-4 py-3">
-          <div class="text-sm font-mono font-medium text-gray-900">{{ row.mpn or '-' }}</div>
+        <td>
+          <div class="font-mono font-medium text-gray-900">{{ row.mpn or '-' }}</div>
           {% if row.description %}
           <div class="text-xs text-gray-400 truncate max-w-[220px]" title="{{ row.description }}">{{ row.description }}</div>
           {% endif %}
         </td>
         {# Vendor #}
-        <td class="px-4 py-3 text-sm text-gray-900">{{ row.vendor_name or '-' }}</td>
+        <td>{{ row.vendor_name or '-' }}</td>
         {# Qty #}
-        <td class="px-4 py-3 text-sm text-gray-600 text-right">{{ '{:,}'.format(row.quantity) if row.quantity is not none else '-' }}</td>
+        <td class="text-right">{{ '{:,}'.format(row.quantity) if row.quantity is not none else '-' }}</td>
         {# Unit cost #}
-        <td class="px-4 py-3 text-sm text-gray-600 text-right">${{ '{:,.4f}'.format(row.unit_cost|float) if row.unit_cost else '-' }}</td>
+        <td class="text-right">${{ '{:,.4f}'.format(row.unit_cost|float) if row.unit_cost else '-' }}</td>
         {# Action: inline confirm-PO form (origin=queue) + flag issue #}
-        <td class="px-4 py-3">
+        <td>
           <div x-data="{ showPo: false }">
             <a @click="showPo = !showPo" class="text-sm text-brand-500 hover:text-brand-600 font-medium cursor-pointer">
               {{ 'Re-cut PO' if row.kicked_back else 'Enter PO' }} &rarr;
@@ -77,13 +78,14 @@
                     hx-swap="innerHTML"
                     class="space-y-1.5">
                 <input type="hidden" name="origin" value="queue">
+                {# Finding #3: bespoke border+focus-ring → .input .input-sm #}
                 <input aria-label="PO#" name="po_number" type="text" placeholder="PO#" required
-                       class="w-28 px-2 py-1 text-xs border border-brand-200 rounded-md focus:ring-brand-500">
+                       class="input input-sm w-28">
                 <input aria-label="Estimated ship date" name="estimated_ship_date" type="date"
-                       class="w-28 px-2 py-1 text-xs border border-brand-200 rounded-md focus:ring-brand-500">
+                       class="input input-sm w-28">
                 <div class="flex gap-1">
                   <button type="submit" data-loading-disable
-                          class="px-2 py-1 text-xs bg-brand-500 text-white rounded-md hover:bg-brand-600 transition-colors">
+                          class="btn btn-primary btn-sm">
                     Confirm
                   </button>
                   <button type="button"
@@ -92,7 +94,7 @@
                           hx-swap="innerHTML"
                           hx-vals='{"issue_type": "other"}'
                           hx-confirm="Flag an issue on this line?"
-                          class="px-2 py-1 text-xs text-rose-600 border border-rose-200 rounded-md hover:bg-rose-50 transition-colors">
+                          class="btn btn-danger btn-sm">
                     Issue
                   </button>
                 </div>
@@ -121,20 +123,21 @@
     <h3 class="text-xs uppercase tracking-wide text-gray-400 font-medium">Team Orders</h3>
     <p class="text-xs text-gray-400">What other buyers are working on (read-only).</p>
   </div>
-  <div class="overflow-x-auto bg-gray-50/60 rounded-lg border border-gray-200">
-    <table class="min-w-full divide-y divide-gray-200 text-sm">
-      <tbody class="divide-y divide-gray-100">
+  {# Finding #5: border-gray-200 → border-line-base #}
+  <div class="overflow-x-auto bg-gray-50/60 rounded-lg border border-line-base">
+    <table class="data-table w-full text-sm">
+      <tbody>
         {% set ns = namespace(prev=None) %}
         {% for row in team %}
         {% if row.buyer_name != ns.prev %}
         <tr class="bg-gray-100/60">
-          <td colspan="4" class="px-4 py-1.5 text-xs font-medium text-gray-600">{{ row.buyer_name or 'Unassigned' }}</td>
+          <td colspan="4" class="text-xs font-medium text-gray-600">{{ row.buyer_name or 'Unassigned' }}</td>
         </tr>
         {% set ns.prev = row.buyer_name %}
         {% endif %}
-        <tr class="{% if row.kicked_back %}bg-rose-50/50{% else %}hover:bg-gray-100/50{% endif %} transition-colors">
+        <tr class="{% if row.kicked_back %}bg-rose-50/50{% endif %} transition-colors">
           {# Customer (read-only link to the plan detail) #}
-          <td class="px-4 py-2">
+          <td>
             <a hx-get="/v2/partials/buy-plans/{{ row.plan_id }}"
                hx-target="#main-content"
                hx-push-url="/v2/buy-plans/{{ row.plan_id }}"
@@ -143,16 +146,16 @@
             </a>
           </td>
           {# Part #}
-          <td class="px-4 py-2 font-mono text-xs text-gray-600">{{ row.mpn or '-' }}</td>
+          <td class="font-mono text-xs text-gray-600">{{ row.mpn or '-' }}</td>
           {# Vendor #}
-          <td class="px-4 py-2 text-gray-600">{{ row.vendor_name or '-' }}</td>
-          {# Qty + status badge #}
-          <td class="px-4 py-2 text-right whitespace-nowrap">
+          <td class="text-gray-600">{{ row.vendor_name or '-' }}</td>
+          {# Qty + status badge (Finding #7: inline pills → .badge primitive) #}
+          <td class="text-right whitespace-nowrap">
             <span class="text-gray-600">{{ '{:,}'.format(row.quantity) if row.quantity is not none else '-' }}</span>
             {% if row.status == 'awaiting_po' %}
-            <span class="ml-2 inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-amber-50 text-amber-700">PO to cut</span>
+            <span class="ml-2 badge bg-amber-50 text-amber-700 border-amber-200">PO to cut</span>
             {% elif row.status == 'pending_verify' %}
-            <span class="ml-2 inline-flex px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700">verifying</span>
+            <span class="ml-2 badge bg-blue-50 text-blue-700 border-blue-200">verifying</span>
             {% endif %}
           </td>
         </tr>

--- a/app/templates/htmx/partials/buy_plans/_orders_queue.html
+++ b/app/templates/htmx/partials/buy_plans/_orders_queue.html
@@ -22,7 +22,7 @@
 
 {% if queue %}
 {# Finding #1: convert to data-table; drop per-cell px-4 py-3 and per-th text-xs font-medium text-gray-500 uppercase tracking-wider #}
-<div class="overflow-x-auto bg-white rounded-lg shadow border border-brand-200">
+<div class="overflow-x-auto bg-white rounded-lg shadow border border-line-base">
   <table class="data-table w-full">
     <thead>
       <tr>
@@ -108,7 +108,7 @@
   </table>
 </div>
 {% else %}
-<div class="bg-white rounded-lg shadow border border-brand-200 px-4 py-6 sm:py-8 text-center">
+<div class="bg-white rounded-lg shadow border border-line-base px-4 py-6 sm:py-8 text-center">
   <svg class="mx-auto h-12 w-12 text-emerald-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
   </svg>
@@ -153,9 +153,9 @@
           <td class="text-right whitespace-nowrap">
             <span class="text-gray-600">{{ '{:,}'.format(row.quantity) if row.quantity is not none else '-' }}</span>
             {% if row.status == 'awaiting_po' %}
-            <span class="ml-2 badge bg-amber-50 text-amber-700 border-amber-200">PO to cut</span>
+            <span class="ml-2 badge-warning">PO to cut</span>
             {% elif row.status == 'pending_verify' %}
-            <span class="ml-2 badge bg-blue-50 text-blue-700 border-blue-200">verifying</span>
+            <span class="ml-2 badge-info">verifying</span>
             {% endif %}
           </td>
         </tr>

--- a/app/templates/htmx/partials/buy_plans/_supervise.html
+++ b/app/templates/htmx/partials/buy_plans/_supervise.html
@@ -36,11 +36,12 @@
 
   {# ── Approvals (manager/admin) ── #}
   {% if is_manager and tri.approvals %}
+  {# Finding #5: section card border-line-base/subtle #}
   <div class="bg-white rounded-lg shadow-sm border border-amber-200">
-    <div class="px-4 py-2 border-b border-gray-100 text-xs font-semibold text-gray-600 uppercase tracking-wider">
+    <div class="px-4 py-2 border-b border-line-subtle text-xs font-semibold text-gray-600 uppercase tracking-wider">
       Approvals waiting ({{ tri.approvals|length }})
     </div>
-    <div class="divide-y divide-gray-100">
+    <div class="divide-y divide-line-subtle">
       {% for p in tri.approvals %}
       <div class="flex items-center justify-between gap-3 px-4 py-2">
         <div class="min-w-0">
@@ -49,16 +50,17 @@
         </div>
         <div class="flex items-center gap-3 flex-shrink-0">
           <span class="text-sm font-semibold text-gray-700">${{ '{:,.2f}'.format(p.value|float) if p.value else '0.00' }}</span>
+          {# Finding #4: raw emerald/rose buttons → .btn family #}
           <form hx-post="/v2/partials/buy-plans/{{ p.plan_id }}/approve"
                 hx-target="#bp-hub-body" hx-swap="innerHTML" class="flex items-center gap-1.5">
             <input type="hidden" name="origin" value="supervise">
             <button type="submit" name="action" value="approve" data-loading-disable
-                    class="px-2.5 py-1 text-xs font-medium bg-emerald-500 text-white rounded-md hover:bg-emerald-600 transition-colors">
+                    class="btn btn-primary btn-sm">
               Approve
             </button>
             <button type="submit" name="action" value="reject" data-loading-disable
                     hx-confirm="Reject this buy plan?"
-                    class="px-2.5 py-1 text-xs font-medium text-rose-600 border border-rose-200 rounded-md hover:bg-rose-50 transition-colors">
+                    class="btn btn-danger btn-sm">
               Reject
             </button>
           </form>
@@ -71,11 +73,11 @@
 
   {# ── Needs SO verification (ops) ── #}
   {% if is_ops and tri.so_pending %}
-  <div class="bg-white rounded-lg shadow-sm border border-brand-200">
-    <div class="px-4 py-2 border-b border-gray-100 text-xs font-semibold text-gray-600 uppercase tracking-wider">
+  <div class="bg-white rounded-lg shadow-sm border border-line-base">
+    <div class="px-4 py-2 border-b border-line-subtle text-xs font-semibold text-gray-600 uppercase tracking-wider">
       Needs SO verification ({{ tri.so_pending|length }})
     </div>
-    <div class="divide-y divide-gray-100">
+    <div class="divide-y divide-line-subtle">
       {% for p in tri.so_pending %}
       <div class="flex items-center justify-between gap-3 px-4 py-2">
         <div class="min-w-0">
@@ -88,7 +90,7 @@
                 hx-target="#bp-hub-body" hx-swap="innerHTML" class="flex items-center gap-1.5">
             <input type="hidden" name="origin" value="supervise">
             <button type="submit" name="action" value="approve" data-loading-disable
-                    class="px-2.5 py-1 text-xs font-medium bg-emerald-500 text-white rounded-md hover:bg-emerald-600 transition-colors">
+                    class="btn btn-primary btn-sm">
               Verify SO
             </button>
           </form>
@@ -101,11 +103,11 @@
 
   {# ── POs awaiting verification (ops) ── #}
   {% if is_ops and tri.po_pending_verify %}
-  <div class="bg-white rounded-lg shadow-sm border border-brand-200">
-    <div class="px-4 py-2 border-b border-gray-100 text-xs font-semibold text-gray-600 uppercase tracking-wider">
+  <div class="bg-white rounded-lg shadow-sm border border-line-base">
+    <div class="px-4 py-2 border-b border-line-subtle text-xs font-semibold text-gray-600 uppercase tracking-wider">
       POs awaiting verification ({{ tri.po_pending_verify|length }})
     </div>
-    <div class="divide-y divide-gray-100">
+    <div class="divide-y divide-line-subtle">
       {% for ln in tri.po_pending_verify %}
       <div class="flex items-center justify-between gap-3 px-4 py-2">
         <div class="min-w-0">
@@ -116,12 +118,12 @@
               hx-target="#bp-hub-body" hx-swap="innerHTML" class="flex items-center gap-1.5 flex-shrink-0">
           <input type="hidden" name="origin" value="supervise">
           <button type="submit" name="action" value="approve" data-loading-disable
-                  class="px-2.5 py-1 text-xs font-medium bg-emerald-500 text-white rounded-md hover:bg-emerald-600 transition-colors">
+                  class="btn btn-primary btn-sm">
             Verify PO
           </button>
           <button type="submit" name="action" value="reject" data-loading-disable
                   hx-confirm="Kick this PO back to the buyer?"
-                  class="px-2.5 py-1 text-xs font-medium text-rose-600 border border-rose-200 rounded-md hover:bg-rose-50 transition-colors">
+                  class="btn btn-danger btn-sm">
             Reject
           </button>
         </form>
@@ -134,16 +136,18 @@
   {# ── Overdue POs ── #}
   {% if tri.overdue_pos %}
   <div class="bg-white rounded-lg shadow-sm border border-rose-200">
-    <div class="px-4 py-2 border-b border-gray-100 text-xs font-semibold text-gray-600 uppercase tracking-wider">
+    <div class="px-4 py-2 border-b border-line-subtle text-xs font-semibold text-gray-600 uppercase tracking-wider">
       Overdue POs ({{ tri.overdue_pos|length }})
     </div>
-    <div class="divide-y divide-gray-100">
+    {# Finding #9: real focusable links for keyboard nav on triage rows #}
+    <div class="divide-y divide-line-subtle">
       {% for ln in tri.overdue_pos %}
       <a hx-get="/v2/partials/buy-plans/{{ ln.plan_id }}"
          hx-target="#main-content"
          hx-push-url="/v2/buy-plans/{{ ln.plan_id }}"
          preload="mouseover"
-         class="flex items-center justify-between gap-3 px-4 py-2 cursor-pointer hover:bg-rose-50/40">
+         class="flex items-center justify-between gap-3 px-4 py-2 cursor-pointer hover:bg-rose-50/40
+                focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:outline-none focus-visible:bg-rose-50/40">
         <span class="text-sm font-mono font-medium text-gray-900">{{ ln.mpn or '—' }}</span>
         <span class="text-xs text-gray-400 flex-shrink-0">{{ ln.vendor_name or '—' }} · {{ ln.buyer_name or '—' }}</span>
       </a>
@@ -155,16 +159,17 @@
   {# ── Flagged issues ── #}
   {% if tri.flagged %}
   <div class="bg-white rounded-lg shadow-sm border border-rose-200">
-    <div class="px-4 py-2 border-b border-gray-100 text-xs font-semibold text-gray-600 uppercase tracking-wider">
+    <div class="px-4 py-2 border-b border-line-subtle text-xs font-semibold text-gray-600 uppercase tracking-wider">
       Flagged issues ({{ tri.flagged|length }})
     </div>
-    <div class="divide-y divide-gray-100">
+    <div class="divide-y divide-line-subtle">
       {% for ln in tri.flagged %}
       <a hx-get="/v2/partials/buy-plans/{{ ln.plan_id }}"
          hx-target="#main-content"
          hx-push-url="/v2/buy-plans/{{ ln.plan_id }}"
          preload="mouseover"
-         class="flex items-center justify-between gap-3 px-4 py-2 cursor-pointer hover:bg-rose-50/40">
+         class="flex items-center justify-between gap-3 px-4 py-2 cursor-pointer hover:bg-rose-50/40
+                focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:outline-none focus-visible:bg-rose-50/40">
         <span class="text-sm font-mono font-medium text-gray-900">{{ ln.mpn or '—' }}</span>
         <span class="text-xs text-rose-600 flex-shrink-0">{{ ln.issue_type or 'issue' }}</span>
       </a>
@@ -175,17 +180,18 @@
 
   {# ── Halted ── #}
   {% if tri.halted %}
-  <div class="bg-white rounded-lg shadow-sm border border-gray-200">
-    <div class="px-4 py-2 border-b border-gray-100 text-xs font-semibold text-gray-600 uppercase tracking-wider">
+  <div class="bg-white rounded-lg shadow-sm border border-line-base">
+    <div class="px-4 py-2 border-b border-line-subtle text-xs font-semibold text-gray-600 uppercase tracking-wider">
       Halted ({{ tri.halted|length }})
     </div>
-    <div class="divide-y divide-gray-100">
+    <div class="divide-y divide-line-subtle">
       {% for p in tri.halted %}
       <a hx-get="/v2/partials/buy-plans/{{ p.plan_id }}"
          hx-target="#main-content"
          hx-push-url="/v2/buy-plans/{{ p.plan_id }}"
          preload="mouseover"
-         class="flex items-center justify-between gap-3 px-4 py-2 cursor-pointer hover:bg-gray-50">
+         class="flex items-center justify-between gap-3 px-4 py-2 cursor-pointer hover:bg-gray-50
+                focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:outline-none">
         <span class="text-sm font-bold text-gray-900">{{ p.customer_name or '—' }}</span>
         <span class="text-xs text-gray-400 flex-shrink-0">{{ p.submitted_by_name or '—' }}</span>
       </a>

--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -129,7 +129,7 @@
     {% set step_label = bp.status|capitalize %}
   {% endif %}
 
-  <div class="mb-5 bg-white rounded-lg border border-brand-200 px-5 py-4">
+  <div class="mb-5 bg-white rounded-lg border border-line-base px-5 py-4">
     <div class="flex gap-1.5">
       {% for i in range(1, 6) %}
         {% if bp.status == 'cancelled' %}
@@ -241,8 +241,8 @@
 
   {# ═══ 4. SIMPLIFIED LINE ITEMS TABLE ═══ #}
   {# Finding #1: convert to data-table, drop per-cell px-4 py-3 and per-th font-medium text-gray-500 uppercase #}
-  <div class="bg-white rounded-lg shadow-sm overflow-hidden border border-brand-200 mb-6">
-    <div class="px-4 py-3 bg-gray-50 border-b border-brand-200">
+  <div class="bg-white rounded-lg shadow-sm overflow-hidden border border-line-base mb-6">
+    <div class="px-4 py-3 bg-gray-50 border-b border-line-base">
       <h2 class="text-lg font-semibold text-gray-900">Line Items
         <span class="ml-1 text-sm font-normal text-gray-600">({{ lines|length }})</span>
       </h2>
@@ -262,7 +262,7 @@
         </thead>
         <tbody>
           {% for line in lines %}
-          <tr id="bp-line-{{ line.id }}" class="hover:bg-brand-50/40 transition-colors">
+          <tr id="bp-line-{{ line.id }}" class="transition-colors">
             {# Part (MPN) #}
             <td class="font-mono font-medium text-gray-900">
               {{ line.requirement.primary_mpn if line.requirement else '-' }}
@@ -464,21 +464,21 @@
         <svg class="w-4 h-4 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
         {% else %}
         {# Finding #7: bespoke inline pill → .badge primitive #}
-        <span class="badge bg-amber-50 text-amber-700 border-amber-200">pending</span>
+        <span class="badge-warning">pending</span>
         {% endif %}
       </div>
       {{ collapse_chevron("showSo") }}
     </button>
     <div x-show="showSo" x-cloak x-collapse class="px-4 pb-4">
       <div class="flex items-center gap-3 text-sm">
-        {% set so_colors = {
-          'pending': 'bg-amber-50 text-amber-700 border-amber-200',
-          'approved': 'bg-emerald-50 text-emerald-700 border-emerald-200',
-          'rejected': 'bg-rose-50 text-rose-700 border-rose-200'
+        {% set so_badge = {
+          'pending': 'badge-warning',
+          'approved': 'badge-success',
+          'rejected': 'badge-danger'
         } %}
         <span class="text-gray-600">Status:</span>
         {# Finding #7: bespoke SO status pill → .badge primitive #}
-        <span class="badge {{ so_colors.get(bp.so_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
+        <span class="{{ so_badge.get(bp.so_status, 'badge') }}">
           {{ bp.so_status|capitalize if bp.so_status else 'Pending' }}
         </span>
         {% if bp.so_verified_by %}

--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -35,19 +35,22 @@
         <h1 class="text-2xl font-bold text-gray-900">Buy Plan #{{ bp.id }}</h1>
         {{ status_badge(bp.status) }}
         {% if bp.is_stock_sale %}
-        <span class="inline-flex px-2.5 py-1 text-xs font-semibold rounded-full bg-purple-100 text-purple-800">
-          <svg class="w-3 h-3 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
+        {# Finding #7: bespoke stock-sale tag → .chip primitive #}
+        <span class="chip bg-purple-50 text-purple-700 border-purple-200 inline-flex items-center gap-1">
+          <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
           Stock Sale
         </span>
         {% endif %}
       </div>
-      <div class="flex items-center gap-4 text-sm text-gray-600">
-        <span class="font-semibold text-gray-900">${{ '{:,.2f}'.format(total_cost) }}</span>
-        <span class="{% if margin >= 30 %}text-emerald-700{% elif margin >= 15 %}text-amber-700{% else %}text-rose-700{% endif %} font-semibold">
+      {# Finding #6: total value → .figure-accent; margin keeps its semantic colour;
+         lines/vendors demoted to lighter weight so the money figure wins hierarchy #}
+      <div class="flex items-center gap-4 text-sm text-gray-500">
+        <span class="figure-accent text-base font-bold">${{ '{:,.2f}'.format(total_cost) }}</span>
+        <span class="{% if margin >= 30 %}text-emerald-700{% elif margin >= 15 %}text-amber-700{% else %}text-rose-700{% endif %} font-semibold text-sm">
           {{ '{:.1f}'.format(margin) }}%
         </span>
-        <span>{{ lines|length }} line{{ 's' if lines|length != 1 }}</span>
-        <span>{{ unique_vendors|length }} vendor{{ 's' if unique_vendors|length != 1 }}</span>
+        <span class="text-xs text-gray-400">{{ lines|length }} line{{ 's' if lines|length != 1 }}</span>
+        <span class="text-xs text-gray-400">{{ unique_vendors|length }} vendor{{ 's' if unique_vendors|length != 1 }}</span>
         {# Cancel/Reset only shown here when NOT in action banner #}
         {% if not has_action_banner %}
           {% if bp.status in ('halted', 'cancelled') %}
@@ -55,13 +58,13 @@
                   hx-target="#main-content"
                   hx-confirm="Reset this buy plan to draft?"
                   data-loading-disable
-                  class="px-3 py-1.5 bg-white border border-brand-200 text-brand-700 text-xs font-medium rounded-md hover:bg-brand-50 transition-colors">
+                  class="btn btn-secondary btn-sm">
             Reset to Draft
           </button>
           {% endif %}
           {% if bp.status not in ('completed', 'cancelled') %}
           <button @click="modalType = 'cancel'; showModal = true"
-                  class="px-3 py-1.5 bg-white border border-gray-300 text-gray-600 text-xs font-medium rounded-md hover:bg-gray-50 transition-colors">
+                  class="btn btn-secondary btn-sm">
             Cancel
           </button>
           {% endif %}
@@ -96,7 +99,6 @@
   </div>
 
   {# ═══ 2. PROGRESS BAR STEPPER ═══ #}
-  {# Determine stepper state #}
   {% set steps = ['Draft', 'Submit', 'Approve', 'PO Exec', 'Complete'] %}
   {% if bp.status == 'draft' %}
     {% set filled = 1 %}
@@ -165,6 +167,7 @@
   {% endif %}
 
   {# Manager/Admin: plan pending approval #}
+  {# Finding #4: raw bg-emerald-600/bg-rose-600 banner buttons → .btn family #}
   {% if show_approval_banner %}
   <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
     <div class="flex items-center gap-3">
@@ -173,11 +176,11 @@
     </div>
     <div class="flex gap-2 flex-shrink-0">
       <button @click="modalType = 'approve'; showModal = true"
-              class="px-3 py-1.5 bg-emerald-600 text-white text-xs font-medium rounded-md hover:bg-emerald-700 transition-colors">
+              class="btn btn-primary btn-sm">
         Approve
       </button>
       <button @click="modalType = 'reject'; showModal = true"
-              class="px-3 py-1.5 bg-rose-600 text-white text-xs font-medium rounded-md hover:bg-rose-700 transition-colors">
+              class="btn btn-danger btn-sm">
         Reject
       </button>
     </div>
@@ -237,6 +240,7 @@
   {% endif %}
 
   {# ═══ 4. SIMPLIFIED LINE ITEMS TABLE ═══ #}
+  {# Finding #1: convert to data-table, drop per-cell px-4 py-3 and per-th font-medium text-gray-500 uppercase #}
   <div class="bg-white rounded-lg shadow-sm overflow-hidden border border-brand-200 mb-6">
     <div class="px-4 py-3 bg-gray-50 border-b border-brand-200">
       <h2 class="text-lg font-semibold text-gray-900">Line Items
@@ -244,43 +248,43 @@
       </h2>
     </div>
     <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
+      <table class="data-table w-full">
+        <thead>
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Part</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Vendor</th>
-            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
-            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Unit Cost</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
+            <th class="text-left">Part</th>
+            <th class="text-left">Description</th>
+            <th class="text-left">Vendor</th>
+            <th class="text-right">Qty</th>
+            <th class="text-right">Unit Cost</th>
+            <th class="text-left">Status</th>
+            <th class="text-left">Action</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-200">
+        <tbody>
           {% for line in lines %}
           <tr id="bp-line-{{ line.id }}" class="hover:bg-brand-50/40 transition-colors">
             {# Part (MPN) #}
-            <td class="px-4 py-3 text-sm font-mono font-medium text-gray-900">
+            <td class="font-mono font-medium text-gray-900">
               {{ line.requirement.primary_mpn if line.requirement else '-' }}
             </td>
             {# Description — from MaterialCard (source of truth) #}
             {% set desc = line.requirement|part_description if line.requirement else '' %}
-            <td class="px-4 py-3 text-sm text-gray-600 truncate max-w-[200px]" title="{{ desc }}">
+            <td class="text-gray-600 truncate max-w-[200px]" title="{{ desc }}">
               {{ desc or '-' }}
             </td>
             {# Vendor + buyer below #}
-            <td class="px-4 py-3">
-              <div class="text-sm text-gray-900">{{ line.offer.vendor_name if line.offer else '-' }}</div>
+            <td>
+              <div class="text-gray-900">{{ line.offer.vendor_name if line.offer else '-' }}</div>
               {% if line.buyer %}
               <div class="text-xs text-gray-400">{{ line.buyer.name }}</div>
               {% endif %}
             </td>
             {# Qty #}
-            <td class="px-4 py-3 text-sm text-gray-600 text-right">{{ '{:,}'.format(line.quantity) }}</td>
+            <td class="text-right text-gray-600">{{ '{:,}'.format(line.quantity) }}</td>
             {# Unit Cost #}
-            <td class="px-4 py-3 text-sm text-gray-600 text-right">${{ '{:,.4f}'.format(line.unit_cost|float) if line.unit_cost else '-' }}</td>
+            <td class="text-right text-gray-600">${{ '{:,.4f}'.format(line.unit_cost|float) if line.unit_cost else '-' }}</td>
             {# Status + PO# #}
-            <td class="px-4 py-3">
+            <td>
               {% set line_colors = {
                 'awaiting_po': 'bg-amber-50 text-amber-700',
                 'pending_verify': 'bg-brand-100 text-brand-600',
@@ -293,8 +297,8 @@
               <div class="font-mono text-xs text-gray-600 mt-0.5">{{ line.po_number }}</div>
               {% endif %}
             </td>
-            {# Action #}
-            <td class="px-4 py-3">
+            {# Action — Finding #4: bespoke bg-emerald/rose buttons → .btn family #}
+            <td>
               {% if bp.status == 'active' %}
                 {% if line.status == 'awaiting_po' %}
                   <div x-data="{ showPo: false, poNum: '', shipDate: '' }">
@@ -302,24 +306,25 @@
                       Enter PO &rarr;
                     </a>
                     <div x-show="showPo" x-cloak x-collapse class="mt-2 space-y-1.5">
+                      {# Finding #3: bespoke border+focus-ring → .input .input-sm #}
                       <div>
                         <input aria-label="PO#" x-model="poNum" type="text" placeholder="PO#"
-                               class="w-28 px-2 py-1 text-xs border border-brand-200 rounded-md focus:ring-brand-500">
+                               class="input input-sm w-28">
                       </div>
                       <div>
                         <input aria-label="Estimated ship date" x-model="shipDate" type="date"
-                               class="w-28 px-2 py-1 text-xs border border-brand-200 rounded-md focus:ring-brand-500">
+                               class="input input-sm w-28">
                       </div>
                       <div class="flex gap-1">
                         <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/lines/{{ line.id }}/confirm-po"
                                 hx-target="#main-content"
                                 :hx-vals="JSON.stringify({po_number: poNum, estimated_ship_date: shipDate})"
                                 data-loading-disable
-                                class="px-2 py-1 text-xs bg-brand-500 text-white rounded-md hover:bg-brand-600 transition-colors">
+                                class="btn btn-primary btn-sm">
                           Confirm
                         </button>
                         <button @click="$dispatch('open-modal', { type: 'issue-{{ line.id }}' }); modalType = 'issue-{{ line.id }}'; showModal = true"
-                                class="px-2 py-1 text-xs text-rose-600 border border-rose-200 rounded-md hover:bg-rose-50 transition-colors">
+                                class="btn btn-danger btn-sm">
                           Issue
                         </button>
                       </div>
@@ -331,7 +336,7 @@
                             hx-target="#main-content"
                             hx-vals='{"action": "approve"}'
                             data-loading-disable
-                            class="px-2.5 py-1 text-xs bg-emerald-600 text-white rounded-md hover:bg-emerald-700 transition-colors font-medium">
+                            class="btn btn-primary btn-sm">
                       Verify
                     </button>
                     <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/lines/{{ line.id }}/verify-po"
@@ -339,7 +344,7 @@
                             hx-vals='{"action": "reject"}'
                             data-loading-disable
                             hx-confirm="Reject this PO?"
-                            class="px-2.5 py-1 text-xs text-rose-600 border border-rose-200 rounded-md hover:bg-rose-50 transition-colors font-medium">
+                            class="btn btn-danger btn-sm">
                       Reject
                     </button>
                   </div>
@@ -357,7 +362,7 @@
           {% endfor %}
           {% if not lines %}
           <tr>
-            <td colspan="7" class="px-4 py-6 sm:py-8 text-center">
+            <td colspan="7" class="py-6 sm:py-8 text-center">
               <svg class="mx-auto h-8 w-8 text-gray-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
               </svg>
@@ -458,7 +463,8 @@
         {% if bp.so_status == 'approved' %}
         <svg class="w-4 h-4 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
         {% else %}
-        <span class="inline-flex px-1.5 py-0.5 text-xs font-semibold rounded-full bg-amber-50 text-amber-700">pending</span>
+        {# Finding #7: bespoke inline pill → .badge primitive #}
+        <span class="badge bg-amber-50 text-amber-700 border-amber-200">pending</span>
         {% endif %}
       </div>
       {{ collapse_chevron("showSo") }}
@@ -471,7 +477,8 @@
           'rejected': 'bg-rose-50 text-rose-700 border-rose-200'
         } %}
         <span class="text-gray-600">Status:</span>
-        <span class="inline-flex px-2.5 py-0.5 text-xs font-semibold rounded-full {{ so_colors.get(bp.so_status, 'bg-gray-100 text-gray-600') }}">
+        {# Finding #7: bespoke SO status pill → .badge primitive #}
+        <span class="badge {{ so_colors.get(bp.so_status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
           {{ bp.so_status|capitalize if bp.so_status else 'Pending' }}
         </span>
         {% if bp.so_verified_by %}
@@ -509,19 +516,18 @@
           <div class="space-y-3">
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">SO# <span class="text-rose-500">*</span></label>
+              {# Finding #3: bespoke modal inputs → .input #}
               <input x-model="so" type="text" required
-                     class="w-full px-3 py-2 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                     class="input w-full"
                      placeholder="Acctivate Sales Order #">
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Customer PO#</label>
-              <input x-model="cpo" type="text"
-                     class="w-full px-3 py-2 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+              <input x-model="cpo" type="text" class="input w-full">
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Notes</label>
-              <textarea x-model="notes" rows="2"
-                        class="w-full px-3 py-2 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"></textarea>
+              <textarea x-model="notes" rows="2" class="input w-full"></textarea>
             </div>
           </div>
           <div class="mt-5 flex justify-end gap-2">
@@ -544,17 +550,17 @@
           <h3 class="text-lg font-semibold text-gray-900 mb-4">Approve Buy Plan</h3>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Notes (optional)</label>
-            <textarea x-model="notes" rows="3"
-                      class="w-full px-3 py-2 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"></textarea>
+            <textarea x-model="notes" rows="3" class="input w-full"></textarea>
           </div>
           <div class="mt-5 flex justify-end gap-2">
             {{ modal_cancel_btn() }}
+            {# Finding #4: raw bg-emerald-600 → .btn btn-primary #}
             <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/approve"
                     hx-target="#main-content"
                     :hx-vals="JSON.stringify({action: 'approve', notes: notes})"
                     data-loading-disable
                     @click="showModal = false"
-                    class="px-4 py-2 text-sm bg-emerald-600 text-white rounded-md hover:bg-emerald-700 font-medium transition-colors">
+                    class="btn btn-primary">
               Approve
             </button>
           </div>
@@ -568,17 +574,18 @@
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Reason <span class="text-rose-500">*</span></label>
             <textarea x-model="notes" rows="3" required
-                      class="w-full px-3 py-2 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                      class="input w-full"
                       placeholder="Why is this being rejected?"></textarea>
           </div>
           <div class="mt-5 flex justify-end gap-2">
             {{ modal_cancel_btn() }}
+            {# Finding #4: raw bg-rose-600 → .btn btn-danger #}
             <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/approve"
                     hx-target="#main-content"
                     :hx-vals="JSON.stringify({action: 'reject', notes: notes})"
                     data-loading-disable
                     @click="showModal = false"
-                    class="px-4 py-2 text-sm bg-rose-600 text-white rounded-md hover:bg-rose-700 font-medium transition-colors">
+                    class="btn btn-danger">
               Reject
             </button>
           </div>
@@ -604,7 +611,7 @@
             <div x-show="action !== 'approve'" x-cloak x-collapse>
               <label class="block text-sm font-medium text-gray-700 mb-1">Note <span class="text-rose-500">*</span></label>
               <textarea x-model="note" rows="2"
-                        class="w-full px-3 py-2 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                        class="input w-full"
                         placeholder="Reason for rejection or halt..."></textarea>
             </div>
           </div>
@@ -629,7 +636,7 @@
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Reason</label>
             <textarea x-model="reason" rows="2"
-                      class="w-full px-3 py-2 border border-brand-200 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                      class="input w-full"
                       placeholder="Why is this being cancelled?"></textarea>
           </div>
           <div class="mt-5 flex justify-end gap-2">

--- a/app/templates/htmx/partials/buy_plans/hub.html
+++ b/app/templates/htmx/partials/buy_plans/hub.html
@@ -19,14 +19,15 @@
     {# Highlight is Alpine-reactive (:class on lens) so the active pill updates the
        instant a lens is clicked — before the server swap returns — and stays correct
        after the re-rendered hub re-inits x-data with the server lens. Mirrors the
-       settings tab_button pattern (partials/settings/_macros.html). #}
+       settings tab_button pattern (partials/settings/_macros.html).
+       Active state uses accent-600 (PR0 single-accent rule); inactive chrome stays brand-*. #}
     <button hx-get="/v2/partials/buy-plans?lens={{ l }}"
             hx-target="#main-content"
             hx-swap="innerHTML"
             hx-push-url="/v2/buy-plans?lens={{ l }}"
             @click="lens = '{{ l }}'"
             :class="lens === '{{ l }}'
-                    ? 'bg-brand-500 text-white shadow-sm'
+                    ? 'bg-accent-600 text-white shadow-sm'
                     : 'bg-brand-100 text-brand-600 hover:bg-brand-200'"
             class="px-3.5 py-1.5 text-sm font-medium rounded-full transition-colors">
       {{ label }}
@@ -46,6 +47,13 @@
        hx-trigger="load"
        hx-target="#bp-hub-body"
        hx-swap="innerHTML">
-    <div class="p-8 text-center text-gray-400 text-sm">Loading…</div>
+    {# Finding #8: spinner consistent with other lazy bodies in the app #}
+    <div class="p-4 text-center text-gray-400 text-sm flex items-center justify-center gap-2">
+      <svg class="h-5 w-5 text-gray-400 animate-spin" viewBox="0 0 24 24" fill="none">
+        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3"
+                stroke-dasharray="31.4" stroke-dashoffset="10"/>
+      </svg>
+      <span>Loading…</span>
+    </div>
   </div>
 </div>

--- a/tests/test_buyplan_hub_routes.py
+++ b/tests/test_buyplan_hub_routes.py
@@ -98,7 +98,7 @@ def test_hub_lens_highlight_is_alpine_reactive(client: TestClient):
     assert "x-data=\"{ lens: 'orders' }\"" in body
     # Active-pill highlight is bound reactively to that lens var.
     assert ':class="lens ===' in body
-    assert "bg-brand-500 text-white shadow-sm" in body
+    assert "bg-accent-600 text-white shadow-sm" in body
 
 
 def test_hub_shell_lens_deals_loads_board_mine(client: TestClient):


### PR DESCRIPTION
## What

Phase 3 UI program — the **Buy Plans** page cluster (`buy_plans/`). Implements all 9 findings from the total UI audit (`docs/superpowers/plans/2026-06-24-total-ui-review-audit.json`, key `buy-plans`), bringing this pre-PR0 surface onto the foundation baseline.

## Changes (9/9 findings)

- **Tables → `.data-table`** — both bespoke `min-w-full divide-y` tables (`_orders_queue.html`, `detail.html`) adopt the locked th/td padding + unified 11px-uppercase header; dead inline `px-4 py-3` / `text-gray-500` removed.
- **Accent migration** — active lens pill `bg-brand-500` → `bg-accent-600`; inline-form focus rings → `.input` / `.input-sm`.
- **Button primitives** — raw `bg-emerald-600`/`bg-rose-600` actions → `.btn .btn-primary .btn-sm` (approve/verify) and `.btn .btn-danger .btn-sm` (reject/issue), matching the `.btn` buttons already on the page.
- **Line-tokens** — `border-gray-*` / `divide-gray-*` shells, dividers, table → `.border-line-base` / `.border-line-subtle` / `divide-line-subtle`.
- **Hierarchy** — deal total promoted to `.figure-accent`; secondary figures demoted.
- **Badges** — bespoke status/stock pills routed through `.badge` / `.chip`.
- **Polish** — bare "Loading…" → spinner SVG; deal cards gain `tabindex`/`role`/Enter-Space handlers + accent focus-visible ring (a11y).

Files: `hub.html`, `_board.html`, `_orders_queue.html`, `_supervise.html`, `detail.html`.

## Verification
CI (frontend build + frontend tests + pytest) gates merge. Visual sign-off is part of the consolidated local deploy-for-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_