### PR TITLE
feat(ui): Proactive foundation conformance — accent, primitives, data-table, a11y

### DIFF
--- a/app/templates/htmx/partials/proactive/_macros.html
+++ b/app/templates/htmx/partials/proactive/_macros.html
@@ -11,7 +11,7 @@
 {# Customer avatar + company name + optional site name, used in both the
    Matches and Sent group headers. default_name is the |default fallback for a
    missing company_name ('Unknown Customer' on Matches, 'Unknown' on Sent). #}
-{% macro company_header(group, default_name) %}        <div class="flex items-center justify-center w-7 h-7 rounded-full bg-brand-100 text-brand-600 text-xs font-bold">
+{% macro company_header(group, default_name) %}        <div class="flex items-center justify-center w-7 h-7 rounded-full bg-gray-200 text-gray-600 text-xs font-bold">
           {{ (group.company_name or 'U')[0]|upper }}
         </div>
         <div class="flex-1 min-w-0">
@@ -21,12 +21,29 @@
           {% endif %}
         </div>{% endmacro %}
 
+{# Margin badge for a row in the parts table. pct is a float or None. #}
+{% macro margin_badge(pct) %}
+    {% if pct is not none %}
+    <span class="badge-mini
+      {{ 'bg-emerald-50 text-emerald-700' if pct >= 20 else
+         'bg-amber-50 text-amber-700' if pct >= 10 else
+         'bg-rose-50 text-rose-700' }}">
+      {{ "%.0f"|format(pct) }}%
+    </span>
+    {% else %}
+    <span class="badge-mini bg-gray-100 text-gray-400">N/A</span>
+    {% endif %}
+{% endmacro %}
+
 {# Empty-state card for a tab with no rows. icon_path is the <path d="…"> value
-   for the centred outline icon; title/subtitle are the two lines of copy. #}
-{% macro empty_state(icon_path, title, subtitle) %}    <div class="bg-white rounded-lg border border-brand-200 p-6 sm:p-8 text-center">
+   for the centred outline icon; title/subtitle are the two lines of copy.
+   Optional: wrap in {% call empty_state(...) %}...action HTML...{% endcall %}
+   to render an action button below the subtitle. #}
+{% macro empty_state(icon_path, title, subtitle) %}    <div class="bg-white rounded-lg border border-line-base p-6 sm:p-8 text-center">
       <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
         <path stroke-linecap="round" stroke-linejoin="round" d="{{ icon_path }}"/>
       </svg>
       <p class="mt-3 text-sm font-medium text-gray-600">{{ title }}</p>
       <p class="mt-1 text-xs text-gray-400">{{ subtitle }}</p>
+      {% if caller is defined %}{{ caller() }}{% endif %}
     </div>{% endmacro %}

--- a/app/templates/htmx/partials/proactive/_match_row.html
+++ b/app/templates/htmx/partials/proactive/_match_row.html
@@ -6,16 +6,17 @@
 #}
 <tr id="match-row-{{ match.id }}"
     class="hover:bg-gray-50 transition-colors"
-    :class="selected[{{ match.id }}] && 'bg-brand-50'">
-  {# Checkbox #}
-  <td class="w-10 px-3 py-2.5">
+    :class="selected[{{ match.id }}] && 'bg-blue-50'">
+  {# Checkbox — accent via accent-color + input-focus ring (not brand-500) #}
+  <td class="w-10">
     <input aria-label="Select match {{ match.mpn | default('') }}" type="checkbox"
            :checked="selected[{{ match.id }}]"
            @change="toggle({{ match.id }})"
-           class="rounded border-gray-300 text-brand-500 focus:ring-brand-500">
+           class="rounded border-gray-300 input-focus"
+           style="accent-color:var(--accent)">
   </td>
   {# MPN + Manufacturer #}
-  <td class="px-3 py-2.5">
+  <td>
     <p class="text-sm font-medium text-gray-900 font-mono">{{ match.mpn | default('--') }}</p>
     {% if match.manufacturer %}
     <p class="text-xs text-gray-400 mt-0.5">{{ match.manufacturer }}</p>
@@ -29,7 +30,7 @@
     {% endif %}
   </td>
   {# Vendor + reliability #}
-  <td class="px-3 py-2.5 text-sm text-gray-700">
+  <td class="text-sm text-gray-700">
     {{ match.vendor_name | default('--') }}
     {% if match.ghost_rate is not none and match.ghost_rate > 30 %}
     <span class="ml-1 text-xs text-rose-500 font-medium">unreliable</span>
@@ -38,30 +39,30 @@
     {% endif %}
   </td>
   {# Qty #}
-  <td class="px-3 py-2.5 text-sm text-gray-700 text-right tabular-nums">
+  <td class="text-sm text-gray-700 text-right tabular-nums">
     {{ "{:,}".format(match.qty_available|int) if match.qty_available else '--' }}
   </td>
   {# Unit Price #}
-  <td class="px-3 py-2.5 text-sm text-gray-700 text-right tabular-nums">
+  <td class="text-sm text-gray-700 text-right tabular-nums">
     {% if match.unit_price %}${{ "%.4f"|format(match.unit_price) }}{% else %}--{% endif %}
   </td>
-  {# Margin pill #}
-  <td class="px-3 py-2.5">
+  {# Margin pill — .badge-mini via semantic color map #}
+  <td>
     {% if match.margin_pct is not none %}
-    <span class="inline-flex px-1.5 py-0.5 text-xs font-semibold rounded
+    <span class="badge-mini
       {{ 'bg-emerald-50 text-emerald-700' if match.margin_pct >= 20 else
          'bg-amber-50 text-amber-700' if match.margin_pct >= 10 else
          'bg-rose-50 text-rose-700' }}">
       {{ "%.0f"|format(match.margin_pct) }}%
     </span>
     {% else %}
-    <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded bg-gray-100 text-gray-400">N/A</span>
+    <span class="badge-mini bg-gray-100 text-gray-400">N/A</span>
     {% endif %}
   </td>
-  {# Score pill #}
-  <td class="px-3 py-2.5">
+  {# Score pill — .badge-mini #}
+  <td>
     {% set score = match.match_score|default(0) %}
-    <span class="inline-flex px-1.5 py-0.5 text-xs font-bold rounded
+    <span class="badge-mini
       {{ 'bg-emerald-50 text-emerald-700' if score >= 75 else
          'bg-amber-50 text-amber-700' if score >= 50 else
          'bg-gray-100 text-gray-600' }}">
@@ -69,7 +70,7 @@
     </span>
   </td>
   {# Do-Not-Offer button #}
-  <td class="px-3 py-2.5 text-right" id="dno-cell-{{ match.id }}">
+  <td class="text-right" id="dno-cell-{{ match.id }}">
     <form hx-post='/v2/partials/proactive/do-not-offer'
           hx-target='#match-row-{{ match.id }}'
           hx-swap='outerHTML'
@@ -79,7 +80,7 @@
       <input type='hidden' name='company_id' value='{{ group.company_id | default("") }}'>
       <button type='submit'
               title="Never offer this part to this customer"
-              class='text-xs text-gray-400 hover:text-rose-500 transition-colors px-1.5 py-0.5 rounded hover:bg-rose-50'>
+              class='text-xs text-gray-400 hover:text-rose-500 transition-colors px-1.5 py-0.5 rounded hover:bg-rose-50 focus:outline-none focus:ring-2' style='--tw-ring-color:var(--accent-ring)'>
         Don&rsquo;t offer
       </button>
     </form>

--- a/app/templates/htmx/partials/proactive/_match_row.html
+++ b/app/templates/htmx/partials/proactive/_match_row.html
@@ -4,6 +4,7 @@
   Called by: proactive/list.html loop.
   Depends on: Alpine.js (parent proactiveGroup scope), Tailwind CSS.
 #}
+{%- from "htmx/partials/proactive/_macros.html" import margin_badge %}
 <tr id="match-row-{{ match.id }}"
     class="hover:bg-gray-50 transition-colors"
     :class="selected[{{ match.id }}] && 'bg-blue-50'">
@@ -47,18 +48,7 @@
     {% if match.unit_price %}${{ "%.4f"|format(match.unit_price) }}{% else %}--{% endif %}
   </td>
   {# Margin pill — .badge-mini via semantic color map #}
-  <td>
-    {% if match.margin_pct is not none %}
-    <span class="badge-mini
-      {{ 'bg-emerald-50 text-emerald-700' if match.margin_pct >= 20 else
-         'bg-amber-50 text-amber-700' if match.margin_pct >= 10 else
-         'bg-rose-50 text-rose-700' }}">
-      {{ "%.0f"|format(match.margin_pct) }}%
-    </span>
-    {% else %}
-    <span class="badge-mini bg-gray-100 text-gray-400">N/A</span>
-    {% endif %}
-  </td>
+  <td>{{ margin_badge(match.margin_pct) }}</td>
   {# Score pill — .badge-mini #}
   <td>
     {% set score = match.match_score|default(0) %}

--- a/app/templates/htmx/partials/proactive/convert_success.html
+++ b/app/templates/htmx/partials/proactive/convert_success.html
@@ -16,7 +16,7 @@
   <p class="text-sm text-emerald-700 mb-4">Created requisition, quote, and buy plan from proactive offer #{{ offer.id }}.</p>
   <div class="flex gap-2">
     <a hx-get="/v2/partials/requisitions" hx-target="#main-content" hx-push-url="/v2/requisitions"
-       class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-brand-600 bg-white border border-brand-200 rounded-lg hover:bg-brand-50 transition-colors cursor-pointer">
+       class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium bg-white border border-line-base rounded-lg hover:bg-gray-50 transition-colors cursor-pointer" style="color:var(--accent)"
       <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
       </svg>

--- a/app/templates/htmx/partials/proactive/list.html
+++ b/app/templates/htmx/partials/proactive/list.html
@@ -5,7 +5,7 @@
   Called by: htmx_views.py proactive_list_partial endpoint.
   Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette.
 #}
-{%- from "htmx/partials/proactive/_macros.html" import company_header, empty_state %}
+{%- from "htmx/partials/proactive/_macros.html" import company_header, empty_state, margin_badge %}
 
 <div class="page-fluid" x-data="{ showScorecard: false }">
   {# Header — page title + scorecard toggle #}
@@ -31,7 +31,7 @@
        hx-target="this"
        hx-indicator="#proactive-scorecard-spinner">
     <div id="proactive-scorecard-spinner" class="htmx-indicator flex items-center justify-center py-6 text-sm text-gray-400">
-      <svg class="animate-spin h-4 w-4 mr-2 text-brand-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <svg class="animate-spin h-4 w-4 mr-2 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
       </svg>
@@ -180,13 +180,8 @@
     </div>
     {% endfor %}
   {% else %}
-  {# Empty state — .card container for consistent padding/border #}
-  <div class="card p-6 sm:p-8 text-center">
-    <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
-    </svg>
-    <p class="mt-3 text-sm font-medium text-gray-600">No proactive matches yet</p>
-    <p class="mt-1 text-xs text-gray-500 max-w-xs mx-auto">We flag a customer the moment we have vendor stock for a part they&#39;ve bought before — so you can reach out first. Matches appear automatically as deals close and vendor stock arrives.</p>
+  {# Empty state — routed through shared macro for consistent border/padding/icon treatment #}
+  {% call empty_state('M13 10V3L4 14h7v7l9-11h-7z', 'No proactive matches yet', 'We flag a customer the moment we have vendor stock for a part they&#39;ve bought before — so you can reach out first. Matches appear automatically as deals close and vendor stock arrives.') %}
     <button hx-post="/v2/partials/proactive/refresh"
             hx-target="#main-content"
             hx-swap="innerHTML"
@@ -197,7 +192,7 @@
       </svg>
       Check again
     </button>
-  </div>
+  {% endcall %}
   {% endif %}
 
   {% elif tab == 'sent' %}
@@ -228,7 +223,7 @@
             {% for offer in group.offers %}
             <tr class="hover:bg-gray-50 transition-colors" x-data="{ expanded: false }">
               <td>
-                <button @click="expanded = !expanded" class="inline-flex items-center gap-1 text-sm text-brand-600 hover:text-brand-700">
+                <button @click="expanded = !expanded" class="inline-flex items-center gap-1 text-sm font-medium transition-colors" style="color:var(--accent)"
                   <span class="font-medium">{{ offer.line_items|length }} part{{ 's' if offer.line_items|length != 1 }}</span>
                   <svg class="h-3 w-3 transition-transform" :class="expanded ? 'rotate-90' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>

--- a/app/templates/htmx/partials/proactive/list.html
+++ b/app/templates/htmx/partials/proactive/list.html
@@ -8,13 +8,14 @@
 {%- from "htmx/partials/proactive/_macros.html" import company_header, empty_state %}
 
 <div class="page-fluid" x-data="{ showScorecard: false }">
-  {# Header #}
-  <div class="flex items-center justify-between mb-6">
+  {# Header — page title + scorecard toggle #}
+  <div class="flex items-center justify-between mb-4">
     <div>
-      <p class="text-sm text-gray-600 mt-1">AI-matched vendor stock to customer purchase history</p>
+      <h1 class="text-xl font-bold text-gray-900">Proactive</h1>
+      <p class="text-sm text-gray-600 mt-0.5">AI-matched vendor stock to customer purchase history</p>
     </div>
     <button @click="showScorecard = !showScorecard"
-            class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-brand-600 bg-brand-50 border border-brand-200 rounded-lg hover:bg-brand-100 transition-colors">
+            class="btn-secondary btn-sm inline-flex items-center gap-1.5">
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
       </svg>
@@ -22,11 +23,12 @@
     </button>
   </div>
 
-  {# Scorecard panel — lazy-loaded #}
-  <div x-show="showScorecard" x-cloak x-transition class="mb-6"
+  {# Scorecard panel — lazy-loaded, explicit hx-target to prevent main-content takeover #}
+  <div x-show="showScorecard" x-cloak x-transition class="mb-4"
        hx-get="/v2/partials/proactive/scorecard"
        hx-trigger="intersect once"
        hx-swap="innerHTML"
+       hx-target="this"
        hx-indicator="#proactive-scorecard-spinner">
     <div id="proactive-scorecard-spinner" class="htmx-indicator flex items-center justify-center py-6 text-sm text-gray-400">
       <svg class="animate-spin h-4 w-4 mr-2 text-brand-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -47,22 +49,27 @@
   </div>
   {% endif %}
 
-  {# Tab bar #}
-  <div class="flex gap-2 mb-6">
+  {# Tab bar — accent active state + aria-selected for a11y #}
+  <div class="flex gap-2 mb-4" role="tablist">
     <a hx-get="/v2/partials/proactive?tab=matches" hx-target="#main-content"
-       class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-colors
-              {{ 'bg-brand-500 text-white shadow-sm' if tab == 'matches' else 'bg-brand-50 text-brand-600 hover:bg-brand-100 border border-brand-200' }}">
+       role="tab"
+       aria-selected="{{ 'true' if tab == 'matches' else 'false' }}"
+       class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-colors focus:outline-none focus:ring-2"
+       style="{% if tab == 'matches' %}background-color:var(--accent);color:var(--accent-contrast);--tw-ring-color:var(--accent-ring);{% else %}background-color:#f3f4f6;color:#374151;border:1px solid #d1d5db;--tw-ring-color:var(--accent-ring);{% endif %}">
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
       </svg>
       Matches
       {% if match_count|default(0) > 0 %}
-      <span class="ml-auto px-1.5 py-0.5 text-xs font-bold text-white bg-emerald-500 rounded-full">{{ match_count }}</span>
+      {# Amber/attention pill — not emerald (green reads "done", not "needs attention") #}
+      <span class="badge-warning ml-1 text-[11px] font-bold px-1.5 py-0.5">{{ match_count }}</span>
       {% endif %}
     </a>
     <a hx-get="/v2/partials/proactive?tab=sent" hx-target="#main-content"
-       class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-colors
-              {{ 'bg-brand-500 text-white shadow-sm' if tab == 'sent' else 'bg-brand-50 text-brand-600 hover:bg-brand-100 border border-brand-200' }}">
+       role="tab"
+       aria-selected="{{ 'true' if tab == 'sent' else 'false' }}"
+       class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-colors focus:outline-none focus:ring-2"
+       style="{% if tab == 'sent' %}background-color:var(--accent);color:var(--accent-contrast);--tw-ring-color:var(--accent-ring);{% else %}background-color:#f3f4f6;color:#374151;border:1px solid #d1d5db;--tw-ring-color:var(--accent-ring);{% endif %}">
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
       </svg>
@@ -74,7 +81,7 @@
   {# ═══════════════ Matches tab ═══════════════ #}
   {% if matches %}
     {% for group in matches %}
-    <div class="mb-6 bg-white rounded-lg border border-brand-200 overflow-hidden"
+    <div class="mb-4 bg-white rounded-lg overflow-hidden border border-line-base"
          x-data="{
            selected: {},
            expanded: true,
@@ -94,25 +101,27 @@
            },
          }">
 
-      {# Group header #}
-      <div class="flex items-center gap-3 px-4 py-3 bg-gray-50 border-b border-gray-200">
-        <button @click="expanded = !expanded" class="text-gray-400 hover:text-gray-600 transition-colors">
+      {# Group header — border-line-base hairline #}
+      <div class="flex items-center gap-3 px-4 py-3 bg-gray-50 border-b border-line-base">
+        <button @click="expanded = !expanded" class="text-gray-400 hover:text-gray-600 transition-colors focus:outline-none focus:ring-2 rounded" style="--tw-ring-color:var(--accent-ring)">
           <svg class="h-4 w-4 transition-transform" :class="expanded ? 'rotate-0' : '-rotate-90'" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
           </svg>
         </button>
 {{ company_header(group, 'Unknown Customer') }}
-        <span class="text-xs text-gray-400 mr-2">{{ group.matches|length }} match{{ 'es' if group.matches|length != 1 }}</span>
+        {# Per-group match count as .chip #}
+        <span class="chip bg-gray-100 text-gray-600 border-gray-200 mr-2">{{ group.matches|length }} match{{ 'es' if group.matches|length != 1 }}</span>
 
-        {# Select all checkbox #}
+        {# Select all checkbox — accent via accent-color + input-focus ring #}
         <label class="flex items-center gap-1 text-xs text-gray-600 cursor-pointer mr-2">
           <input type="checkbox" @change="toggleAll()"
                  :checked="selectedCount === {{ group.matches|length }}"
-                 class="rounded border-gray-300 text-brand-500 focus:ring-brand-500">
+                 class="rounded border-gray-300 input-focus"
+                 style="accent-color:var(--accent)">
           All
         </label>
 
-        {# Prepare button #}
+        {# Prepare button — .btn-primary .btn-sm #}
         <form method="POST" action="/v2/proactive/prepare/{{ group.customer_site_id }}"
               hx-post="/v2/proactive/prepare/{{ group.customer_site_id }}"
               hx-target="#main-content"
@@ -122,12 +131,12 @@
           </template>
           <button type="submit"
                   :disabled="selectedCount === 0"
-                  class="px-3 py-1.5 text-xs font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                  class="btn-primary btn-sm disabled:opacity-40 disabled:cursor-not-allowed">
             Prepare (<span x-text="selectedCount">0</span>)
           </button>
         </form>
 
-        {# Dismiss button #}
+        {# Dismiss button — .btn-secondary .btn-sm #}
         <form method="POST" action="/v2/partials/proactive/batch-dismiss"
               data-loading-disable
               hx-post="/v2/partials/proactive/batch-dismiss"
@@ -138,29 +147,29 @@
           </template>
           <button type="submit"
                   :disabled="selectedCount === 0"
-                  class="px-3 py-1.5 text-xs font-medium text-gray-600 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                  class="btn-secondary btn-sm disabled:opacity-40 disabled:cursor-not-allowed">
             Dismiss (<span x-text="selectedCount">0</span>)
           </button>
         </form>
       </div>
 
-      {# Match table #}
+      {# Match table — .data-table for unified density + line tokens #}
       <div x-show="expanded" x-cloak x-collapse>
         <div class="overflow-x-auto">
-          <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50/50">
+          <table class="data-table w-full">
+            <thead>
               <tr>
-                <th class="w-10 px-3 py-2"></th>
-                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MPN</th>
-                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[140px]">Vendor</th>
-                <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-[80px]">Qty</th>
-                <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider w-[90px]">Price</th>
-                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[70px]">Margin</th>
-                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[60px]">Score</th>
-                <th class="px-3 py-2 w-[90px]"></th>
+                <th class="w-10 text-left"></th>
+                <th class="text-left">MPN</th>
+                <th class="text-left w-[140px]">Vendor</th>
+                <th class="text-right w-[80px]">Qty</th>
+                <th class="text-right w-[90px]">Price</th>
+                <th class="text-left w-[70px]">Margin</th>
+                <th class="text-left w-[60px]">Score</th>
+                <th class="w-[90px]"></th>
               </tr>
             </thead>
-            <tbody class="divide-y divide-gray-100">
+            <tbody>
               {% for match in group.matches %}
               {% include "htmx/partials/proactive/_match_row.html" %}
               {% endfor %}
@@ -171,12 +180,13 @@
     </div>
     {% endfor %}
   {% else %}
-  <div class="bg-white rounded-lg border border-brand-200 p-6 sm:p-8 text-center">
+  {# Empty state — .card container for consistent padding/border #}
+  <div class="card p-6 sm:p-8 text-center">
     <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
     </svg>
     <p class="mt-3 text-sm font-medium text-gray-600">No proactive matches yet</p>
-    <p class="mt-1 text-xs text-gray-400 max-w-xs mx-auto">We flag a customer the moment we have vendor stock for a part they&#39;ve bought before — so you can reach out first. Matches appear automatically as deals close and vendor stock arrives.</p>
+    <p class="mt-1 text-xs text-gray-500 max-w-xs mx-auto">We flag a customer the moment we have vendor stock for a part they&#39;ve bought before — so you can reach out first. Matches appear automatically as deals close and vendor stock arrives.</p>
     <button hx-post="/v2/partials/proactive/refresh"
             hx-target="#main-content"
             hx-swap="innerHTML"
@@ -194,30 +204,30 @@
   {# ═══════════════ Sent tab (grouped by customer) ═══════════════ #}
   {% if sent %}
     {% for group in sent %}
-    <div class="mb-6 bg-white rounded-lg border border-brand-200 overflow-hidden">
+    <div class="mb-4 bg-white rounded-lg border border-line-base overflow-hidden">
       {# Group header #}
-      <div class="flex items-center gap-3 px-4 py-3 bg-gray-50 border-b border-gray-200">
+      <div class="flex items-center gap-3 px-4 py-3 bg-gray-50 border-b border-line-base">
 {{ company_header(group, 'Unknown') }}
-        <span class="text-xs text-gray-400">{{ group.offers|length }} offer{{ 's' if group.offers|length != 1 }}</span>
+        <span class="chip bg-gray-100 text-gray-600 border-gray-200">{{ group.offers|length }} offer{{ 's' if group.offers|length != 1 }}</span>
       </div>
 
-      {# Offers table #}
+      {# Offers table — .data-table #}
       <div class="overflow-x-auto">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50/50">
+        <table class="data-table w-full">
+          <thead>
             <tr>
-              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Parts</th>
-              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Sent To</th>
-              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Sent</th>
-              <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Revenue</th>
-              <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-              <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+              <th class="text-left">Parts</th>
+              <th class="text-left">Sent To</th>
+              <th class="text-left">Sent</th>
+              <th class="text-right">Revenue</th>
+              <th class="text-left">Status</th>
+              <th class="text-right">Actions</th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-gray-100">
+          <tbody>
             {% for offer in group.offers %}
             <tr class="hover:bg-gray-50 transition-colors" x-data="{ expanded: false }">
-              <td class="px-4 py-3">
+              <td>
                 <button @click="expanded = !expanded" class="inline-flex items-center gap-1 text-sm text-brand-600 hover:text-brand-700">
                   <span class="font-medium">{{ offer.line_items|length }} part{{ 's' if offer.line_items|length != 1 }}</span>
                   <svg class="h-3 w-3 transition-transform" :class="expanded ? 'rotate-90' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -225,7 +235,7 @@
                   </svg>
                 </button>
                 {# Expandable line items #}
-                <div x-show="expanded" x-cloak x-collapse class="mt-2 pl-2 border-l-2 border-brand-100">
+                <div x-show="expanded" x-cloak x-collapse class="mt-2 pl-2 border-l-2 border-line-subtle">
                   {% for item in offer.line_items %}
                   <div class="text-xs text-gray-600 py-0.5">
                     <span class="font-mono font-medium">{{ item.mpn }}</span>
@@ -236,27 +246,30 @@
                   {% endfor %}
                 </div>
               </td>
-              <td class="px-4 py-3 text-xs text-gray-600">
-                {{ offer.recipient_emails | join(', ') | truncate(40) }}
+              <td class="text-xs text-gray-600">
+                {# Full recipient list recoverable on hover #}
+                <span title="{{ offer.recipient_emails | join(', ') }}">{{ offer.recipient_emails | join(', ') | truncate(40) }}</span>
               </td>
-              <td class="px-4 py-3 text-xs text-gray-600">
+              <td class="text-xs text-gray-600">
                 {{ offer.sent_at | timeago }}
               </td>
-              <td class="px-4 py-3 text-sm text-right tabular-nums">
+              <td class="text-sm text-right tabular-nums">
                 {% if offer.total_sell %}
                 <span class="font-medium text-gray-900">${{ "{:,.2f}".format(offer.total_sell) }}</span>
                 {% else %}--{% endif %}
               </td>
-              <td class="px-4 py-3">
+              <td>
                 {% set status = offer.status | default('sent') %}
-                <span class="inline-flex px-2 py-0.5 text-xs font-semibold rounded-full
-                  {{ 'bg-emerald-50 text-emerald-700' if status == 'converted' else
-                     'bg-brand-50 text-brand-600' if status == 'sent' else
-                     'bg-gray-100 text-gray-600' }}">
-                  {{ status | upper }}
-                </span>
+                {# Status pill via .badge primitives #}
+                {% if status == 'converted' %}
+                <span class="badge badge-success">{{ status | upper }}</span>
+                {% elif status == 'sent' %}
+                <span class="badge badge-info">{{ status | upper }}</span>
+                {% else %}
+                <span class="badge bg-gray-100 text-gray-600 border-gray-200">{{ status | upper }}</span>
+                {% endif %}
               </td>
-              <td class="px-4 py-3 text-right">
+              <td class="text-right">
                 {% if status == 'sent' and offer.id %}
                 <button hx-post="/v2/partials/proactive/{{ offer.id }}/convert"
                         hx-target="#main-content"

--- a/app/templates/htmx/partials/proactive/prepare.html
+++ b/app/templates/htmx/partials/proactive/prepare.html
@@ -5,6 +5,7 @@
   Called by: htmx_views.py proactive_prepare_page endpoint.
   Depends on: HTMX, Alpine.js, Tailwind CSS.
 #}
+{%- from "htmx/partials/proactive/_macros.html" import margin_badge %}
 
 <div class="page-readable"
      x-data="{
@@ -22,7 +23,7 @@
 
   {# Back link #}
   <a hx-get="/v2/partials/proactive?tab=matches" hx-target="#main-content"
-     class="inline-flex items-center gap-1 text-sm text-brand-600 hover:text-brand-700 mb-4">
+     class="inline-flex items-center gap-1 text-sm font-medium transition-colors mb-4" style="color:var(--accent)"
     <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
     </svg>
@@ -91,19 +92,7 @@
                        class='input input-sm w-24 text-right tabular-nums'>
               </div>
             </td>
-            <td>
-              {% if m.margin_pct is not none %}
-              {# .badge-mini — consistent with _match_row.html #}
-              <span class="badge-mini
-                {{ 'bg-emerald-50 text-emerald-700' if m.margin_pct >= 20 else
-                   'bg-amber-50 text-amber-700' if m.margin_pct >= 10 else
-                   'bg-rose-50 text-rose-700' }}">
-                {{ "%.0f"|format(m.margin_pct) }}%
-              </span>
-              {% else %}
-              <span class="badge-mini bg-gray-100 text-gray-400">N/A</span>
-              {% endif %}
-            </td>
+            <td>{{ margin_badge(m.margin_pct) }}</td>
           </tr>
           {% endfor %}
         </tbody>
@@ -134,7 +123,7 @@
               {{ c.email or '(no email)' }}
               {% if c.title %} &middot; {{ c.title }}{% endif %}
               {% if c.is_primary %}
-              <span class="badge-mini bg-brand-50 text-brand-600 ml-1">Primary</span>
+              <span class="badge-mini bg-gray-100 text-gray-600 ml-1">Primary</span>
               {% endif %}
             </p>
           </div>

--- a/app/templates/htmx/partials/proactive/prepare.html
+++ b/app/templates/htmx/partials/proactive/prepare.html
@@ -42,44 +42,45 @@
   </div>
   {% endif %}
 
-  {# Selected Parts #}
-  <div class="bg-white rounded-lg border border-gray-200 mb-6 overflow-hidden">
-    <div class="px-4 py-3 bg-gray-50 border-b border-gray-200">
+  {# Selected Parts — .data-table for unified density + line tokens #}
+  <div class="bg-white rounded-lg border border-line-base mb-6 overflow-hidden">
+    <div class="px-4 py-3 bg-gray-50 border-b border-line-base">
       <h2 class="text-sm font-semibold text-gray-900">Selected Parts ({{ matches|length }})</h2>
     </div>
     <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50/50">
+      <table class="data-table w-full">
+        <thead>
           <tr>
-            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">MPN</th>
-            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
-            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Qty</th>
-            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Cost</th>
-            <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase">Sell Price</th>
-            <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Margin</th>
+            <th class="text-left">MPN</th>
+            <th class="text-left">Vendor</th>
+            <th class="text-right">Qty</th>
+            <th class="text-right">Cost</th>
+            <th class="text-right">Sell Price</th>
+            <th class="text-left">Margin</th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-100">
+        <tbody>
           {% for m in matches %}
           {# Compute suggested sell price: cost * 1.3, rounded to 4dp #}
           {% set suggested_sell = "%.4f"|format((m.unit_price * 1.3) if m.unit_price else 0) %}
           <tr class="hover:bg-gray-50" x-data='{ sell: {{ suggested_sell }} }'>
-            <td class="px-4 py-2.5">
+            <td>
               <span class="text-sm font-medium text-gray-900 font-mono">{{ m.mpn }}</span>
               {% if m.manufacturer %}
               <span class="text-xs text-gray-400 ml-1">{{ m.manufacturer }}</span>
               {% endif %}
             </td>
-            <td class="px-4 py-2.5 text-sm text-gray-700">{{ m.vendor_name }}</td>
-            <td class="px-4 py-2.5 text-sm text-gray-700 text-right tabular-nums">
+            <td class="text-sm text-gray-700">{{ m.vendor_name }}</td>
+            <td class="text-sm text-gray-700 text-right tabular-nums">
               {{ "{:,}".format(m.qty_available|int) if m.qty_available else '--' }}
             </td>
-            <td class="px-4 py-2.5 text-sm text-gray-700 text-right tabular-nums">
+            <td class="text-sm text-gray-700 text-right tabular-nums">
               {% if m.unit_price %}${{ "%.4f"|format(m.unit_price) }}{% else %}--{% endif %}
             </td>
-            <td class="px-4 py-2.5 text-right">
+            <td class="text-right">
               <div class="flex items-center justify-end gap-1">
                 <span class="text-xs text-gray-400">$</span>
+                {# .input .input-sm: accent focus ring, consistent with subject/body inputs #}
                 <input type='number'
                        name='sell_price_{{ m.id }}'
                        form='send-form'
@@ -87,19 +88,20 @@
                        min='0'
                        x-model='sell'
                        value='{{ suggested_sell }}'
-                       class='w-24 text-right rounded border-gray-300 text-sm tabular-nums focus:border-brand-500 focus:ring-brand-500 py-1 px-2'>
+                       class='input input-sm w-24 text-right tabular-nums'>
               </div>
             </td>
-            <td class="px-4 py-2.5">
+            <td>
               {% if m.margin_pct is not none %}
-              <span class="inline-flex px-1.5 py-0.5 text-xs font-semibold rounded
+              {# .badge-mini — consistent with _match_row.html #}
+              <span class="badge-mini
                 {{ 'bg-emerald-50 text-emerald-700' if m.margin_pct >= 20 else
                    'bg-amber-50 text-amber-700' if m.margin_pct >= 10 else
                    'bg-rose-50 text-rose-700' }}">
                 {{ "%.0f"|format(m.margin_pct) }}%
               </span>
               {% else %}
-              <span class="text-xs text-gray-400">N/A</span>
+              <span class="badge-mini bg-gray-100 text-gray-400">N/A</span>
               {% endif %}
             </td>
           </tr>
@@ -110,8 +112,8 @@
   </div>
 
   {# Send To — Contact Picker #}
-  <div class="bg-white rounded-lg border border-gray-200 mb-6">
-    <div class="px-4 py-3 bg-gray-50 border-b border-gray-200">
+  <div class="bg-white rounded-lg border border-line-base mb-6">
+    <div class="px-4 py-3 bg-gray-50 border-b border-line-base">
       <h2 class="text-sm font-semibold text-gray-900">Send To</h2>
     </div>
     <div class="p-4 space-y-2">
@@ -119,18 +121,20 @@
         {% for c in contacts %}
         <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer {{ 'opacity-50' if not c.has_email }}"
                {% if not c.has_email %}title="No email address"{% endif %}>
+          {# Checkbox — accent via accent-color + input-focus (not brand-500) #}
           <input type="checkbox"
                  {% if not c.has_email %}disabled{% endif %}
                  :checked="selectedContacts[{{ c.id }}]"
                  @change="toggleContact({{ c.id }})"
-                 class="rounded border-gray-300 text-brand-500 focus:ring-brand-500 disabled:opacity-40">
+                 class="rounded border-gray-300 input-focus disabled:opacity-40"
+                 style="accent-color:var(--accent)">
           <div class="flex-1 min-w-0">
             <p class="text-sm font-medium text-gray-900">{{ c.full_name or '(unnamed)' }}</p>
             <p class="text-xs text-gray-600">
               {{ c.email or '(no email)' }}
               {% if c.title %} &middot; {{ c.title }}{% endif %}
               {% if c.is_primary %}
-              <span class="ml-1 px-1.5 py-0.5 text-[9px] font-semibold bg-brand-50 text-brand-600 rounded">Primary</span>
+              <span class="badge-mini bg-brand-50 text-brand-600 ml-1">Primary</span>
               {% endif %}
             </p>
           </div>
@@ -149,8 +153,8 @@
         hx-post="/v2/proactive/send"
         hx-target="#main-content"
         data-loading-disable
-        class="bg-white rounded-lg border border-gray-200 mb-6">
-    <div class="px-4 py-3 bg-gray-50 border-b border-gray-200">
+        class="bg-white rounded-lg border border-line-base mb-6">
+    <div class="px-4 py-3 bg-gray-50 border-b border-line-base">
       <h2 class="text-sm font-semibold text-gray-900">Email</h2>
     </div>
     <div class="p-4 space-y-4">
@@ -179,19 +183,19 @@
                   class="input"></textarea>
       </div>
 
-      {# AI Draft button #}
+      {# AI Draft button — .btn-secondary (neutral chrome, accent focus ring) #}
       <div id="draft-status" class="flex items-center gap-2">
         <button type="button"
                 hx-post="/v2/partials/proactive/draft"
                 hx-target="#draft-status"
                 hx-include="[name='match_ids'],[name='contact_ids'],[name^='sell_price_']"
                 hx-indicator="#draft-spinner"
-                class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-brand-600 bg-brand-50 border border-brand-200 rounded-lg hover:bg-brand-100 transition-colors">
+                class="btn-secondary btn-sm inline-flex items-center gap-1.5">
           <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z"/>
           </svg>
           Generate AI Draft
-          <svg id="draft-spinner" class="htmx-indicator animate-spin h-3.5 w-3.5 text-brand-400" fill="none" viewBox="0 0 24 24">
+          <svg id="draft-spinner" class="htmx-indicator animate-spin h-3.5 w-3.5 text-gray-400" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
           </svg>
@@ -200,14 +204,16 @@
     </div>
 
     {# Footer actions #}
-    <div class="flex items-center justify-end gap-3 px-4 py-3 bg-gray-50 border-t border-gray-200">
+    <div class="flex items-center justify-end gap-3 px-4 py-3 bg-gray-50 border-t border-line-base">
+      {# Cancel — .btn-ghost for consistent secondary action treatment #}
       <a hx-get="/v2/partials/proactive?tab=matches" hx-target="#main-content"
-         class="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-800 transition-colors cursor-pointer">
+         class="btn-ghost btn-sm cursor-pointer">
         Cancel
       </a>
+      {# Send — .btn-primary: resolves to accent, replacing bespoke brand-500 #}
       <button type="submit"
               :disabled="contactCount === 0"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+              class="btn-primary disabled:opacity-40 disabled:cursor-not-allowed">
         Send to <span x-text="contactCount">0</span> Contact<span x-show="contactCount !== 1" x-cloak>s</span>
       </button>
     </div>

--- a/app/templates/htmx/partials/proactive/scorecard.html
+++ b/app/templates/htmx/partials/proactive/scorecard.html
@@ -6,29 +6,30 @@
   Called by: htmx_views.py proactive_scorecard route.
   Depends on: Tailwind CSS with brand palette.
 #}
-<div class="bg-white rounded-lg border border-brand-200 p-5">
+<div class="bg-white rounded-lg border border-line-base p-5">
   <div class="flex items-center gap-2 mb-4">
-    <svg class="h-5 w-5 text-brand-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <svg class="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
     </svg>
     <h3 class="text-sm font-semibold text-gray-900">Proactive Scorecard</h3>
   </div>
   <div class="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-4">
     {# Row 1 — activity #}
-    <div class="bg-brand-50 rounded-lg p-3 text-center border border-brand-100">
-      <p class="text-xs text-brand-600 font-medium mb-1">Sent</p>
+    <div class="bg-gray-50 rounded-lg p-3 text-center border border-line-subtle">
+      <p class="text-xs text-gray-600 font-medium mb-1">Sent</p>
       <p class="text-2xl font-bold text-gray-900">{{ stats.get('total_sent', 0) }}</p>
     </div>
     <div class="bg-emerald-50 rounded-lg p-3 text-center border border-emerald-100">
       <p class="text-xs text-emerald-600 font-medium mb-1">Converted</p>
       <p class="text-2xl font-bold text-emerald-700">{{ stats.get('total_converted', 0) }}</p>
     </div>
-    <div class="bg-brand-50 rounded-lg p-3 text-center border border-brand-100">
-      <p class="text-xs text-brand-600 font-medium mb-1">Conv. Rate</p>
-      <p class="text-2xl font-bold text-brand-700">{{ "%.0f%%"|format(stats.get('conversion_rate', 0)) }}</p>
+    {# Conv. Rate — .figure-accent (hero KPI, accent color, removing brand-700 debt) #}
+    <div class="bg-gray-50 rounded-lg p-3 text-center border border-line-subtle">
+      <p class="text-xs text-gray-600 font-medium mb-1">Conv. Rate</p>
+      <p class="text-2xl font-bold figure-accent">{{ "%.0f%%"|format(stats.get('conversion_rate', 0)) }}</p>
     </div>
     {# Row 2 — money #}
-    <div class="bg-gray-50 rounded-lg p-3 text-center border border-gray-200">
+    <div class="bg-gray-50 rounded-lg p-3 text-center border border-line-subtle">
       <p class="text-xs text-gray-600 font-medium mb-1">Revenue</p>
       <p class="text-2xl font-bold text-gray-900">${{ "{:,.0f}".format(stats.get('converted_revenue', 0)) }}</p>
     </div>

--- a/tests/test_sp3_proactive_adoption.py
+++ b/tests/test_sp3_proactive_adoption.py
@@ -232,7 +232,7 @@ class TestProactiveRefreshRoute:
             )
 
         assert resp.status_code == 200
-        # The matches tab is active (bg-brand-500)
+        # The matches tab is active (accent CSS var, not brand-500)
         assert "No proactive matches yet" in resp.text or "Matches" in resp.text
 
     def test_refresh_shows_new_match_after_scan(


### PR DESCRIPTION
## What

Phase 3 UI program — the **Proactive** page cluster (`proactive/`). Implements all 16 findings from the total UI audit (key `proactive`).

## Changes (16/16 findings)

- **Accent migration** — active tab → `var(--accent)`; Prepare + "Send to N Contacts" CTAs → `.btn-primary`; scorecard/AI-draft toggles → `.btn-secondary`; Cancel → `.btn-ghost`; checkboxes → `input-focus` + `accent-color`.
- **Inputs** — sell-price field → `.input .input-sm` (accent focus ring).
- **Tables → `.data-table`** — Matches, Sent, Selected-Parts tables; inline cell padding + bespoke headers removed.
- **Badges** — margin/score → `.badge-mini`; status pills → `.badge` family; match-count chip → `.chip`.
- **Line-tokens** — `border-gray-*` / `divide-gray-*` → `.border-line-base` / `.border-line-subtle` across all 4 files.
- **Hierarchy** — Conv. Rate KPI → `.figure-accent`; page `<h1>` "Proactive" added; match-count pill recolored `bg-emerald-500` → `.badge-warning` (amber = needs attention, not green = done).
- **a11y** — tab `role="tab"` + `aria-selected`; Sent-To `title` tooltip.

Files: `list.html`, `_match_row.html`, `prepare.html`, `scorecard.html`.

## Verification
CI gates merge. Visual sign-off is part of the consolidated local deploy-for-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_