### PR TITLE
feat(ui): Sales Hub foundation conformance — toolbar primitives, Bid-Due urgency, vendor-trust chip

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -15583,11 +15583,7 @@ async def part_tab_offers(
     offers = db.query(Offer).filter(Offer.requirement_id == requirement_id).order_by(Offer.created_at.desc()).all()
 
     # Build vendor-trust map (name → tier) from VendorSightingSummary for trust chips
-    summaries = (
-        db.query(VendorSightingSummary)
-        .filter(VendorSightingSummary.requirement_id == requirement_id)
-        .all()
-    )
+    summaries = db.query(VendorSightingSummary).filter(VendorSightingSummary.requirement_id == requirement_id).all()
     vendor_tier_map: dict[str, str | None] = {s.vendor_name: s.tier for s in summaries}
 
     ctx = _base_ctx(request, user, "requisitions")

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -106,6 +106,7 @@ from ..services.part_history_service import (
     sightings_for_card,
 )
 from ..services.prospect_priority import build_priority_snapshot, build_signal_tags, contacts_summary
+from ..services.sighting_aggregation import get_vendor_tier_map
 from ..services.sighting_ingest import sighting_from_row
 from ..services.status_machine import require_valid_transition
 from ..services.vendor_unavailability import apply_to_fresh_sightings, maybe_release_on_offer
@@ -15582,9 +15583,7 @@ async def part_tab_offers(
 
     offers = db.query(Offer).filter(Offer.requirement_id == requirement_id).order_by(Offer.created_at.desc()).all()
 
-    # Build vendor-trust map (name → tier) from VendorSightingSummary for trust chips
-    summaries = db.query(VendorSightingSummary).filter(VendorSightingSummary.requirement_id == requirement_id).all()
-    vendor_tier_map: dict[str, str | None] = {s.vendor_name: s.tier for s in summaries}
+    vendor_tier_map = get_vendor_tier_map(db, requirement_id)
 
     ctx = _base_ctx(request, user, "requisitions")
     ctx.update({"requirement": req, "offers": offers, "vendor_tier_map": vendor_tier_map})
@@ -15609,6 +15608,7 @@ async def part_tab_sourcing(
         .order_by(VendorSightingSummary.score.desc(), VendorSightingSummary.id.desc())
         .all()
     )
+    vendor_tier_map = get_vendor_tier_map(db, requirement_id)
 
     # Raw sightings grouped by vendor for popover breakdowns
     raw_sightings = (
@@ -15629,6 +15629,7 @@ async def part_tab_sourcing(
         {
             "requirement": req,
             "summaries": summaries,
+            "vendor_tier_map": vendor_tier_map,
             "raw_sightings_by_vendor": raw_by_vendor,
             "vendor_statuses": vendor_statuses,
         }

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -15582,8 +15582,16 @@ async def part_tab_offers(
 
     offers = db.query(Offer).filter(Offer.requirement_id == requirement_id).order_by(Offer.created_at.desc()).all()
 
+    # Build vendor-trust map (name → tier) from VendorSightingSummary for trust chips
+    summaries = (
+        db.query(VendorSightingSummary)
+        .filter(VendorSightingSummary.requirement_id == requirement_id)
+        .all()
+    )
+    vendor_tier_map: dict[str, str | None] = {s.vendor_name: s.tier for s in summaries}
+
     ctx = _base_ctx(request, user, "requisitions")
-    ctx.update({"requirement": req, "offers": offers})
+    ctx.update({"requirement": req, "offers": offers, "vendor_tier_map": vendor_tier_map})
     return template_response("htmx/partials/parts/tabs/offers.html", ctx)
 
 

--- a/app/services/sighting_aggregation.py
+++ b/app/services/sighting_aggregation.py
@@ -227,3 +227,16 @@ def rebuild_vendor_summaries_from_sightings(
             rebuild_vendor_summaries(db, requirement_id)
     except Exception:
         logger.warning("Vendor summary rebuild failed for requirement {}", requirement_id, exc_info=True)
+
+
+def get_vendor_tier_map(
+    db: Session,
+    requirement_id: int,
+) -> dict[str, str | None]:
+    """Return vendor_name → tier for all VendorSightingSummary rows.
+
+    Used by part_tab_offers and part_tab_sourcing to render vendor-trust chips without
+    duplicating the VendorSightingSummary query at each call site.
+    """
+    summaries = db.query(VendorSightingSummary).filter(VendorSightingSummary.requirement_id == requirement_id).all()
+    return {s.vendor_name: s.tier for s in summaries}

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -558,8 +558,8 @@ table {
   background: rgba(58, 66, 82, 0.04);
 }
 .ws-tab-active {
-  color: #3A4252;
-  border-bottom-color: #3A4252;
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 /* ── Source progress chips ────────────────────────────────────────── */

--- a/app/templates/htmx/partials/parts/header.html
+++ b/app/templates/htmx/partials/parts/header.html
@@ -5,7 +5,8 @@
 
 {% from "htmx/partials/shared/_macros.html" import status_badge %}
 
-<div class="px-3 py-2 border-b border-gray-200 bg-white flex-shrink-0">
+{# border-line-base replaces border-gray-200 hairline (finding 6) #}
+<div class="px-3 py-2 border-b border-line-base bg-white flex-shrink-0">
   <div class="flex items-center justify-between gap-4">
 
     {# Left: MPN chips + Brand + Requisition context #}

--- a/app/templates/htmx/partials/parts/list.html
+++ b/app/templates/htmx/partials/parts/list.html
@@ -18,17 +18,17 @@
          overflowing the page (the search input goes full-width on its own line). #}
       <div class="flex flex-wrap gap-2 items-center">
 
-        {# Add Req button #}
+        {# Add Req button — .btn-primary .btn-sm (findings 2, 5) #}
         <button type="button"
                 @click="$dispatch('open-modal', {wide: true, url: '/v2/partials/requisitions/import-form'})"
-                class="px-2 py-0.5 text-[10px] font-semibold rounded bg-brand-500 text-white hover:bg-brand-600 transition-colors flex-shrink-0 inline-flex items-center gap-1">
+                class="btn-primary btn-sm flex-shrink-0 inline-flex items-center gap-1">
           <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
           </svg>
           Req
         </button>
 
-        {# Search input — searches MPN, brand, req name, customer #}
+        {# Search input — .input .input-sm + accent focus ring (findings 1, 3) #}
         <div class="relative flex-shrink-0 w-full sm:w-[180px]">
           <svg class="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-3 w-3 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
             <circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/>
@@ -39,17 +39,18 @@
                  hx-swap="morph:innerHTML"
                  hx-trigger="input delay:300ms"
                  :hx-vals="filterVals"
-                 class="w-full pl-7 pr-2 py-0.5 text-[10px] border border-gray-300 rounded focus:ring-1 focus:ring-brand-500 focus:border-brand-500 placeholder:text-gray-400">
+                 class="input input-sm w-full pl-7 pr-2">
         </div>
 
+        {# Status filter pills — accent active state, .chip pattern (findings 1, 2, 5) #}
         {% for s_val, s_label in [('', 'All'), ('open', 'Open'), ('sourcing', 'Src'), ('offered', 'Ofd'), ('quoted', 'Qtd'), ('archived', 'Arc')] %}
         <button type="button"
                 @click="pStatus = '{{ s_val }}'"
                 hx-get="/v2/partials/parts"
                 hx-target="#parts-list"
                 :hx-vals="_fp({status: '{{ s_val }}'})"
-                class="px-2 py-0.5 text-[10px] font-semibold rounded transition-colors flex-shrink-0
-                       {{ 'bg-brand-500 text-white' if status == s_val else 'bg-white text-gray-500 border border-gray-300 hover:bg-brand-50 hover:text-brand-600' }}">
+                class="chip flex-shrink-0
+                       {{ 'bg-accent-500 text-white border-accent-500' if status == s_val else 'bg-white text-gray-500 border-line-base hover:bg-accent-50 hover:text-accent-600' }}">
           {{ s_label }}
         </button>
         {% endfor %}
@@ -62,23 +63,23 @@
     </div>
   </div>
 
-  {# ── Bulk action bar (visible when items selected) ─────── #}
+  {# ── Bulk action bar (visible when items selected) — accent colors (finding 2) ─── #}
   <div x-show="selectedIds.length > 0" x-cloak
-       class="px-3 py-1.5 bg-brand-50 border-b border-brand-200 flex items-center gap-2 flex-shrink-0">
-    <span class="text-[10px] font-semibold text-brand-700" x-text="selectedIds.length + ' selected'"></span>
+       class="px-3 py-1.5 bg-accent-50 border-b border-accent-200 flex items-center gap-2 flex-shrink-0">
+    <span class="text-[11px] font-semibold text-accent-700" x-text="selectedIds.length + ' selected'"></span>
     {% if status == 'archived' %}
     <button type="button" @click="bulkUnarchive()"
-            class="px-2 py-0.5 text-[10px] font-semibold bg-brand-500 text-white rounded hover:bg-brand-600">
+            class="px-2 py-0.5 text-[11px] font-semibold bg-accent-500 text-white rounded hover:bg-accent-600">
       Unarchive
     </button>
     {% else %}
     <button type="button" @click="bulkArchive()"
-            class="px-2 py-0.5 text-[10px] font-semibold bg-gray-500 text-white rounded hover:bg-gray-600">
+            class="px-2 py-0.5 text-[11px] font-semibold bg-gray-500 text-white rounded hover:bg-gray-600">
       Archive
     </button>
     {% endif %}
     <button type="button" @click="clearSelection()"
-            class="px-2 py-0.5 text-[10px] font-semibold text-gray-500 hover:text-gray-700">
+            class="px-2 py-0.5 text-[11px] font-semibold text-gray-500 hover:text-gray-700">
       Clear
     </button>
   </div>
@@ -90,7 +91,8 @@
         <thead>
           <tr>
             <th class="w-6">
-              <input aria-label="Select all parts" type="checkbox" class="h-3 w-3 rounded border-gray-300 text-brand-500"
+              {# Checkbox accent color (finding 2) #}
+              <input aria-label="Select all parts" type="checkbox" class="h-3 w-3 rounded border-line-base text-accent-500"
                      @change="toggleAll($event)" :checked="allSelected">
             </th>
             {% set col_defs = {
@@ -116,7 +118,7 @@
                 <a hx-get="/v2/partials/parts"
                    hx-target="#parts-list"
                    :hx-vals="_fp({sort: '{{ sort_key }}', dir: '{{ 'asc' if sort == sort_key and dir == 'desc' else 'desc' }}'})"
-                   class="cursor-pointer hover:text-brand-600 inline-flex items-center gap-0.5">
+                   class="cursor-pointer hover:text-accent-600 inline-flex items-center gap-0.5">
                   {{ label }}
                   {% if sort == sort_key %}
                   <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
@@ -139,7 +141,8 @@
               :class="selectedPartId === {{ req.id }} ? 'row-selected' : ''"
               @click="selectPart({{ req.id }}); htmx.ajax('GET', '/v2/partials/parts/{{ req.id }}/tab/' + activeTab, {target: '#part-detail'})">
             <td class="w-6" @click.stop>
-              <input aria-label="Select part {{ req.primary_mpn }}" type="checkbox" class="h-3 w-3 rounded border-gray-300 text-brand-500"
+              {# Checkbox accent color (finding 2) #}
+              <input aria-label="Select part {{ req.primary_mpn }}" type="checkbox" class="h-3 w-3 rounded border-line-base text-accent-500"
                      :checked="selectedIds.includes({{ req.id }})"
                      @change="toggleId({{ req.id }}, $event)">
             </td>
@@ -173,21 +176,34 @@
                     {% if stats.get('best_price') %}<span class="text-emerald-600">${{ '{:,.4f}'.format(stats.get('best_price')) }}</span>{% else %}—{% endif %}
                   {% elif col_key == 'owner' %}
                     {% if req.requisition and req.requisition.claimed_by %}
-                      <span class="inline-flex items-center justify-center h-5 w-5 rounded-full bg-brand-100 text-brand-600 text-[9px] font-bold" title="{{ req.requisition.claimed_by.name }}">{{ req.requisition.claimed_by.name[:1] }}</span>
+                      {# Avatar initial — text-[10px] floor preserved for single-initial avatars (finding 1) #}
+                      <span class="inline-flex items-center justify-center h-5 w-5 rounded-full bg-accent-100 text-accent-600 text-[10px] font-bold" title="{{ req.requisition.claimed_by.name }}">{{ req.requisition.claimed_by.name[:1] }}</span>
                     {% else %}—{% endif %}
                   {% elif col_key == 'created' %}
                     {{ req.created_at.strftime('%m/%d') if req.created_at else '—' }}
                   {% elif col_key == 'specs' %}
                     {% set spec_count = [req.customer_pn, req.condition, req.date_codes, req.packaging, req.firmware, req.hardware_codes]|reject('none')|reject('equalto', '')|list|length %}
                     {% if spec_count > 0 %}
-                      <span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-md border
+                      {# Spec badge — raised to text-[11px] readability floor; neutral border via border-line-base (findings 1, 6) #}
+                      <span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[11px] font-medium rounded-md border
                                    {% if spec_count == 6 %}bg-emerald-50 text-emerald-600 border-emerald-200
                                    {% elif spec_count >= 4 %}bg-sky-50 text-sky-600 border-sky-200
-                                   {% else %}bg-gray-50 text-gray-500 border-gray-200{% endif %}"
-                            title="Cust PN, Condition, Date Codes, Packaging, Firmware, Hardware">{{ spec_count }}<span class="text-[9px] opacity-60">/6</span></span>
+                                   {% else %}bg-gray-50 text-gray-500 border-line-base{% endif %}"
+                            title="Cust PN, Condition, Date Codes, Packaging, Firmware, Hardware">{{ spec_count }}<span class="text-[10px] opacity-60">/6</span></span>
                     {% else %}<span class="text-gray-300">—</span>{% endif %}
                   {% elif col_key == 'need_by_date' %}
-                    {{ req.need_by_date or '—' }}
+                    {# Bid Due urgency treatment: overdue=rose, <=2 days=amber, else neutral (finding 8) #}
+                    {% if req.need_by_date %}
+                      {% set today = now_utc.date() %}
+                      {% set delta_days = (req.need_by_date - today).days %}
+                      {% if delta_days < 0 %}
+                        <span class="text-rose-600 font-semibold" title="Overdue by {{ delta_days|abs }} day{{ 's' if delta_days|abs != 1 else '' }}">{{ req.need_by_date }}</span>
+                      {% elif delta_days <= 2 %}
+                        <span class="text-amber-600 font-semibold" title="Due in {{ delta_days }} day{{ 's' if delta_days != 1 else '' }}">{{ req.need_by_date }}</span>
+                      {% else %}
+                        {{ req.need_by_date }}
+                      {% endif %}
+                    {% else %}—{% endif %}
                   {% endif %}
                 </td>
               {% endif %}
@@ -198,31 +214,37 @@
       </table>
   </div>
   {% else %}
+  {# Empty state — Add Req primary CTA answers "What next?" (finding 13) #}
   <div class="flex-1 flex flex-col items-center justify-center text-gray-400 py-6 sm:py-8">
     <svg class="h-10 w-10 text-gray-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
     </svg>
     <p class="text-xs font-medium">No parts found</p>
     <p class="text-xs mt-0.5 text-gray-300">Adjust filters or add requirements</p>
+    <button type="button"
+            @click="$dispatch('open-modal', {wide: true, url: '/v2/partials/requisitions/import-form'})"
+            class="btn-primary btn-sm mt-3">
+      Add Requisition
+    </button>
   </div>
   {% endif %}
 
-  {# ── Pagination ──────────────────────────────────────────── #}
+  {# ── Pagination — .btn-secondary .btn-sm, border-line-base strip (findings 1, 4, 5, 6) ─── #}
   {% if total > limit %}
-  <div class="px-3 py-1.5 border-t-2 border-brand-200 bg-gray-50 flex-shrink-0 flex items-center justify-between">
-    <span class="text-[10px] text-gray-400 font-data">{{ offset + 1 }}\u2013{{ [offset + limit, total]|min }} / {{ total }}</span>
+  <div class="px-3 py-1.5 border-t border-line-base bg-gray-50 flex-shrink-0 flex items-center justify-between">
+    <span class="text-[11px] text-gray-400 font-data">{{ offset + 1 }}–{{ [offset + limit, total]|min }} / {{ total }}</span>
     <div class="flex gap-1">
       {% if offset > 0 %}
       <button hx-get="/v2/partials/parts"
               hx-target="#parts-list"
               :hx-vals="_fp({offset: {{ offset - limit }}})"
-              class="px-2 py-0.5 text-[10px] font-semibold bg-white border border-gray-300 rounded hover:bg-brand-50 text-gray-600">Prev</button>
+              class="btn-secondary btn-sm">Prev</button>
       {% endif %}
       {% if offset + limit < total %}
       <button hx-get="/v2/partials/parts"
               hx-target="#parts-list"
               :hx-vals="_fp({offset: {{ offset + limit }}})"
-              class="px-2 py-0.5 text-[10px] font-semibold bg-white border border-gray-300 rounded hover:bg-brand-50 text-gray-600">Next</button>
+              class="btn-secondary btn-sm">Next</button>
       {% endif %}
     </div>
   </div>
@@ -233,8 +255,8 @@
        x-show="visible" x-cloak
        class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 bg-gray-800 text-white px-4 py-2 rounded-lg shadow-lg flex items-center gap-3 text-xs">
     <span x-text="message"></span>
-    <button @click="undo()" class="font-semibold text-brand-300 hover:text-brand-100 underline">Undo</button>
-    <span class="text-gray-400 text-[10px]" x-text="countdown + 's'"></span>
+    <button @click="undo()" class="font-semibold text-accent-300 hover:text-accent-100 underline">Undo</button>
+    <span class="text-gray-400 text-[11px]" x-text="countdown + 's'"></span>
   </div>
 </div>
 

--- a/app/templates/htmx/partials/parts/tabs/offers.html
+++ b/app/templates/htmx/partials/parts/tabs/offers.html
@@ -34,7 +34,7 @@
             {% if tier == 'Excellent' or tier == 'Good' %}
               <span class="badge-success ml-1" title="Tier: {{ tier }} — vendor has prior sightings">Known</span>
             {% elif tier == 'Fair' %}
-              <span class="badge ml-1 text-gray-500" title="Tier: {{ tier }} — limited sighting history">New</span>
+              <span class="badge ml-1 text-gray-600" title="Tier: {{ tier }} — limited sighting history">New</span>
             {% elif tier %}
               <span class="badge ml-1 text-gray-400" title="Tier: {{ tier }}">New</span>
             {% endif %}

--- a/app/templates/htmx/partials/parts/tabs/offers.html
+++ b/app/templates/htmx/partials/parts/tabs/offers.html
@@ -1,6 +1,6 @@
 {# Offers tab — all offers for a specific part number.
    Called by: GET /v2/partials/parts/{id}/tab/offers
-   Depends on: requirement, offers
+   Depends on: requirement, offers, vendor_tier_map (dict[vendor_name, tier])
 #}
 
 <div>
@@ -9,49 +9,62 @@
   </div>
 
   {% if offers %}
-  <div class="overflow-x-auto rounded-lg border border-gray-200">
-    <table class="min-w-full divide-y divide-gray-200 text-sm">
+  {# border-line-base replaces border-gray-200 hairlines (finding 6) #}
+  <div class="overflow-x-auto rounded-lg border border-line-base">
+    <table class="compact-table">
       <thead class="bg-gray-50">
         <tr>
-          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
-          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Price</th>
-          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Qty</th>
-          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Date Code</th>
-          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Condition</th>
-          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Lead Time</th>
-          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-          <th class="table-cell--head text-left text-xs font-medium text-gray-500 uppercase">Created</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Price</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Qty</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Date Code</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Condition</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Lead Time</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Status</th>
+          <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Created</th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-gray-100">
+      <tbody>
         {% for offer in offers %}
         <tr class="hover:bg-gray-50">
-          <td class="table-cell font-medium text-gray-900 whitespace-nowrap">{{ offer.vendor_name or '—' }}</td>
-          <td class="table-cell whitespace-nowrap">{{ '${:,.4f}'.format(offer.unit_price) if offer.unit_price else '—' }}</td>
-          <td class="table-cell whitespace-nowrap">{{ '{:,}'.format(offer.qty_available) if offer.qty_available else '—' }}</td>
-          <td class="table-cell whitespace-nowrap">{{ offer.date_code or '—' }}</td>
-          <td class="table-cell whitespace-nowrap">{{ offer.condition or '—' }}</td>
-          <td class="table-cell whitespace-nowrap">{{ offer.lead_time or '—' }}</td>
-          <td class="table-cell whitespace-nowrap">
-            {% if offer.status == 'active' %}
-              <span class="badge bg-green-100 text-green-700">Active</span>
-            {% elif offer.status == 'sold' %}
-              <span class="badge bg-blue-100 text-blue-700">Sold</span>
-            {% else %}
-              <span class="badge bg-gray-100 text-gray-600">{{ offer.status or 'active' }}</span>
-            {% endif %}
-            {% if offer.is_stale %}
-              <span class="ml-1 px-1.5 py-0.5 text-xs rounded bg-amber-50 text-amber-600" title="Over 14 days old">Stale</span>
+          <td class="compact-cell font-medium text-gray-900 whitespace-nowrap">
+            {{ offer.vendor_name or '—' }}
+            {# Vendor-trust chip reusing tier from VendorSightingSummary (finding 10) #}
+            {% set tier = vendor_tier_map.get(offer.vendor_name) if offer.vendor_name else none %}
+            {% if tier == 'Excellent' or tier == 'Good' %}
+              <span class="badge-success ml-1" title="Tier: {{ tier }} — vendor has prior sightings">Known</span>
+            {% elif tier == 'Fair' %}
+              <span class="badge ml-1 text-gray-500" title="Tier: {{ tier }} — limited sighting history">New</span>
+            {% elif tier %}
+              <span class="badge ml-1 text-gray-400" title="Tier: {{ tier }}">New</span>
             {% endif %}
           </td>
-          <td class="table-cell text-gray-600 whitespace-nowrap">{{ offer.created_at.strftime('%m/%d/%y') if offer.created_at else '—' }}</td>
+          <td class="compact-cell whitespace-nowrap">{{ '${:,.4f}'.format(offer.unit_price) if offer.unit_price else '—' }}</td>
+          <td class="compact-cell whitespace-nowrap">{{ '{:,}'.format(offer.qty_available) if offer.qty_available else '—' }}</td>
+          <td class="compact-cell whitespace-nowrap">{{ offer.date_code or '—' }}</td>
+          <td class="compact-cell whitespace-nowrap">{{ offer.condition or '—' }}</td>
+          <td class="compact-cell whitespace-nowrap">{{ offer.lead_time or '—' }}</td>
+          <td class="compact-cell whitespace-nowrap">
+            {# Offer status via .badge-* shared vocabulary (finding 11) #}
+            {% if offer.status == 'active' %}
+              <span class="badge-success">Active</span>
+            {% elif offer.status == 'sold' %}
+              <span class="badge-info">Sold</span>
+            {% else %}
+              <span class="badge">{{ offer.status or 'active' }}</span>
+            {% endif %}
+            {% if offer.is_stale %}
+              <span class="badge-warning ml-1" title="Over 14 days old">Stale</span>
+            {% endif %}
+          </td>
+          <td class="compact-cell text-gray-600 whitespace-nowrap">{{ offer.created_at.strftime('%m/%d/%y') if offer.created_at else '—' }}</td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
   </div>
   {% else %}
-  <div class="p-8 text-center text-gray-400 border border-dashed border-gray-200 rounded-lg">
+  <div class="p-8 text-center text-gray-400 border border-dashed border-line-subtle rounded-lg">
     <p class="text-sm">No offers yet for this part</p>
   </div>
   {% endif %}

--- a/app/templates/htmx/partials/parts/tabs/sourcing.html
+++ b/app/templates/htmx/partials/parts/tabs/sourcing.html
@@ -9,8 +9,9 @@
   </div>
 
   {% if summaries %}
-  <div class="overflow-x-auto rounded-lg border border-gray-200">
-    <table class="min-w-full divide-y divide-gray-200 text-sm">
+  {# border-line-base replaces border-gray-200; .compact-table carries the divide token (finding 6) #}
+  <div class="overflow-x-auto rounded-lg border border-line-base">
+    <table class="compact-table">
       <thead class="bg-gray-50">
         <tr>
           <th class="compact-cell--head text-left text-xs font-medium text-gray-500 uppercase">Vendor</th>
@@ -49,7 +50,7 @@
           </th>
         </tr>
       </thead>
-      <tbody class="divide-y divide-gray-100">
+      <tbody>
         {% for s in summaries %}
         <tr class="hover:bg-gray-50">
           <td class="compact-cell font-medium text-gray-900 whitespace-nowrap">{{ s.vendor_name or '—' }}</td>
@@ -116,7 +117,8 @@
               </table>
             </div>
           </td>
-          <td class="px-3 py-2 whitespace-nowrap">
+          {# compact-cell replaces inline px-3 py-2 (finding 7) #}
+          <td class="compact-cell whitespace-nowrap">
             {% if s.score is not none %}
               {% set score_pct = s.score|int %}
               <span class="{{ 'text-green-600' if score_pct >= 70 else 'text-amber-600' if score_pct >= 40 else 'text-gray-500' if score_pct >= 20 else 'text-red-500' }}">
@@ -124,7 +126,8 @@
               </span>
             {% else %}—{% endif %}
           </td>
-          <td class="px-3 py-2 whitespace-nowrap">
+          {# compact-cell replaces inline px-3 py-2 (finding 7) #}
+          <td class="compact-cell whitespace-nowrap">
             {% if s.tier %}
               <span class="px-1.5 py-0.5 text-xs font-medium rounded
                 {{ 'bg-green-50 text-green-700' if s.tier == 'Excellent' else

--- a/app/templates/htmx/partials/parts/workspace.html
+++ b/app/templates/htmx/partials/parts/workspace.html
@@ -9,12 +9,21 @@
      open value, and stage-weighted forecast, near the requisitions they summarize. The
      split-panel height below subtracts this 26px strip so the layout doesn't overflow. #}
 {% if pipeline %}
-<div class="h-[26px] flex items-center gap-4 px-3 text-xs text-gray-500 bg-gray-50 border-b border-gray-200">
-  <span><span class="font-medium text-gray-700">{{ pipeline.open_count }}</span> open deal{{ "" if pipeline.open_count == 1 else "s" }}</span>
+{# border-line-base replaces border-gray-200 (finding 12) #}
+<div class="h-[26px] flex items-center gap-4 px-3 text-xs text-gray-500 bg-gray-50 border-b border-line-base">
+  {# Page eyebrow answers "Where am I?" (finding 9) #}
+  <span class="font-semibold text-gray-700 mr-1">Sales Hub</span>
   <span class="text-gray-300">·</span>
-  <span><span class="font-medium text-gray-700">${{ "{:,.0f}".format(pipeline.open_value) }}</span> open value</span>
+  <span><span class="figure-accent">{{ pipeline.open_count }}</span> open deal{{ "" if pipeline.open_count == 1 else "s" }}</span>
   <span class="text-gray-300">·</span>
-  <span><span class="font-medium text-gray-700">${{ "{:,.0f}".format(pipeline.weighted_value) }}</span> weighted forecast</span>
+  <span><span class="figure-accent">${{ "{:,.0f}".format(pipeline.open_value) }}</span> open value</span>
+  <span class="text-gray-300">·</span>
+  <span><span class="figure-accent">${{ "{:,.0f}".format(pipeline.weighted_value) }}</span> weighted forecast</span>
+</div>
+{% else %}
+{# No pipeline data: still render the page identity eyebrow (finding 9) #}
+<div class="h-[26px] flex items-center gap-2 px-3 text-xs bg-gray-50 border-b border-line-base">
+  <span class="font-semibold text-gray-700">Sales Hub</span>
 </div>
 {% endif %}
 
@@ -61,7 +70,8 @@
      @htmx:after-swap.window="if ($event.detail.target && $event.detail.target.id === 'parts-list') $nextTick(() => clearPartIfGone())">
 
   {# ── Left Panel: Parts Table ──────────────────────────────── #}
-  <div class="flex flex-col min-w-0 border-r border-gray-200" :style="'width: ' + (splitRatio * 100) + '%'">
+  {# border-line-base replaces border-gray-200 (finding 12) #}
+  <div class="flex flex-col min-w-0 border-r border-line-base" :style="'width: ' + (splitRatio * 100) + '%'">
     <div id="parts-list" class="flex-1 flex flex-col min-h-0"
          hx-get="/v2/partials/parts"
          hx-trigger="load"
@@ -72,9 +82,9 @@
     </div>
   </div>
 
-  {# ── Drag Handle ──────────────────────────────────────────── #}
-  <div class="w-[3px] cursor-col-resize bg-gray-200 hover:bg-brand-400 transition-colors flex-shrink-0 relative group"
-       :class="dragging ? 'bg-brand-500' : ''"
+  {# ── Drag Handle — accent hover/active (finding 12) ──────── #}
+  <div class="w-[3px] cursor-col-resize bg-gray-200 hover:bg-accent-400 transition-colors flex-shrink-0 relative group"
+       :class="dragging ? 'bg-accent-500' : ''"
        @mousedown="startDrag($event)">
     <div class="absolute inset-y-0 -left-2 -right-2"></div>
     <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -96,9 +106,9 @@
         <div id="part-header-wrap"
              x-effect="if (selectedPartId) htmx.ajax('GET', '/v2/partials/parts/' + selectedPartId + '/header', {target: '#part-header-wrap', swap: 'innerHTML'})">
         </div>
-        {# Tab bar #}
-        <div class="border-b-2 border-brand-200 bg-white px-2 flex-shrink-0">
-          <nav class="flex -mb-[2px] overflow-x-auto">
+        {# Tab bar — border-line-base replaces border-brand-200 (finding 4) #}
+        <div class="border-b border-line-base bg-white px-2 flex-shrink-0">
+          <nav class="flex -mb-[1px] overflow-x-auto">
             {% for tab_key, tab_label in [('offers', 'Offers'), ('sourcing', 'Sightings'), ('notes', 'Sales Notes'), ('activity', 'Activity'), ('comms', 'Tasks'), ('req-details', 'REQ Detail'), ('quotes', 'Quotes')] %}
             <button @click="activeTab = '{{ tab_key }}'; htmx.ajax('GET', '/v2/partials/parts/' + selectedPartId + '/tab/{{ tab_key }}', {target: '#part-detail'})"
                     :class="activeTab === '{{ tab_key }}' ? 'ws-tab-active' : ''"
@@ -136,14 +146,12 @@
 
 {# ── Scroll sync script ──────────────────────────────────────── #}
 <script>
-  // Sync top scrollbar ↔ content for both panels
   function initScrollSync() {
     requestAnimationFrame(function() {
       document.querySelectorAll('.top-scroll-bar').forEach(function(bar) {
         var contentId = bar.dataset.syncTarget;
         var content = document.getElementById(contentId);
         if (!content) return;
-        // Measure widest child (table or any overflow content)
         var scrollW = content.scrollWidth;
         var spacer = bar.querySelector('.scroll-spacer');
         if (spacer && scrollW > content.clientWidth) {

--- a/e2e/sales-hub-ui.spec.ts
+++ b/e2e/sales-hub-ui.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * sales-hub-ui.spec.ts — UI-cleanup regression tests for the Sales Hub
+ * (parts workspace at /v2/requisitions).
+ *
+ * Tests: accent active states, readability floor, Bid Due urgency coloring,
+ * empty-state CTA, vendor-trust chip on offers tab, ws-tab-active CSS variable.
+ *
+ * Called by: npx playwright test --project=dead-ends (via partial checks)
+ *            npx playwright test e2e/sales-hub-ui.spec.ts
+ * Depends on: running app server in TESTING=1 mode, no seeded data required.
+ */
+import { test, expect } from '@playwright/test';
+
+const HX_HEADER = { 'HX-Request': 'true' };
+
+test.describe('Sales Hub — parts/list partial', () => {
+  test('returns 200 for /v2/partials/parts', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts', { headers: HX_HEADER });
+    expect(res.status()).toBeLessThan(500);
+  });
+
+  test('empty-state contains an Add Requisition button', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts', { headers: HX_HEADER });
+    const body = await res.text();
+    if (body.includes('No parts found')) {
+      expect(body).toContain('Add Requisition');
+      expect(body).toContain('btn-primary');
+    }
+  });
+
+  test('filter pills use accent-500 active class not brand-500', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts?status=open', { headers: HX_HEADER });
+    const body = await res.text();
+    expect(body).not.toContain('bg-brand-500 text-white');
+    expect(body).toContain('accent-500');
+  });
+
+  test('Add Req button uses btn-primary not bespoke brand-500', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts', { headers: HX_HEADER });
+    const body = await res.text();
+    expect(body).toContain('btn-primary');
+    expect(body).not.toMatch(/class="[^"]*px-2 py-0\.5[^"]*bg-brand-500[^"]*"/);
+  });
+
+  test('search input uses .input .input-sm not bespoke focus:ring-brand-500', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts', { headers: HX_HEADER });
+    const body = await res.text();
+    expect(body).toContain('input input-sm');
+    expect(body).not.toContain('focus:ring-brand-500');
+  });
+
+  test('pagination uses btn-secondary btn-sm', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts', { headers: HX_HEADER });
+    const body = await res.text();
+    if (body.includes('Prev') || body.includes('Next')) {
+      expect(body).toContain('btn-secondary');
+    }
+  });
+});
+
+test.describe('Sales Hub — parts/workspace partial', () => {
+  test('returns 200 for /v2/partials/parts/workspace', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts/workspace', { headers: HX_HEADER });
+    expect(res.status()).toBeLessThan(500);
+  });
+
+  test('pipeline strip always shows Sales Hub eyebrow', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts/workspace', { headers: HX_HEADER });
+    const body = await res.text();
+    expect(body).toContain('Sales Hub');
+  });
+
+  test('drag handle uses accent-400/accent-500 not brand-400/brand-500', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts/workspace', { headers: HX_HEADER });
+    const body = await res.text();
+    expect(body).toContain('hover:bg-accent-400');
+    expect(body).toContain("'bg-accent-500'");
+    expect(body).not.toContain('hover:bg-brand-400');
+    expect(body).not.toContain("'bg-brand-500'");
+  });
+});
+
+test.describe('Sales Hub — ws-tab-active CSS', () => {
+  test('styles.css .ws-tab-active uses var(--accent)', async ({ request }) => {
+    const res = await request.get('/static/styles.css');
+    if (res.status() === 404) test.skip();
+    const body = await res.text();
+    expect(body).toContain('color: var(--accent)');
+    expect(body).not.toContain('color: #3A4252');
+  });
+});
+
+test.describe('Sales Hub — offers tab partial', () => {
+  test('/v2/partials/parts/1/tab/offers returns non-500', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts/1/tab/offers', { headers: HX_HEADER });
+    expect(res.status()).not.toBe(500);
+  });
+
+  test('offers tab uses .badge-success/.badge-info not raw bg-green-100', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts/1/tab/offers', { headers: HX_HEADER });
+    if (res.status() === 404) test.skip();
+    const body = await res.text();
+    expect(body).not.toContain('bg-green-100 text-green-700');
+    expect(body).not.toContain('bg-blue-100 text-blue-700');
+  });
+});
+
+test.describe('Sales Hub — sourcing tab partial', () => {
+  test('/v2/partials/parts/1/tab/sourcing returns non-500', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts/1/tab/sourcing', { headers: HX_HEADER });
+    expect(res.status()).not.toBe(500);
+  });
+
+  test('sourcing tab Score/Tier cells use compact-cell', async ({ request }) => {
+    const res = await request.get('/v2/partials/parts/1/tab/sourcing', { headers: HX_HEADER });
+    if (res.status() === 404) test.skip();
+    const body = await res.text();
+    expect(body).not.toContain('"px-3 py-2 whitespace-nowrap"');
+  });
+});

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -66,13 +66,13 @@ def test_htmx_ajax_calls_have_indicator():
         ("app/templates/htmx/partials/parts/cell_edit.html", 12),
         ("app/templates/htmx/partials/parts/cell_edit.html", 26),
         ("app/templates/htmx/partials/parts/cell_edit.html", 37),
-        ("app/templates/htmx/partials/parts/workspace.html", 97),
-        ("app/templates/htmx/partials/parts/workspace.html", 103),
+        ("app/templates/htmx/partials/parts/workspace.html", 107),
+        ("app/templates/htmx/partials/parts/workspace.html", 113),
         ("app/templates/htmx/partials/parts/list.html", 11),
         ("app/templates/htmx/partials/parts/list.html", 12),
-        ("app/templates/htmx/partials/parts/list.html", 140),
-        ("app/templates/htmx/partials/parts/list.html", 279),
-        ("app/templates/htmx/partials/parts/list.html", 326),
+        ("app/templates/htmx/partials/parts/list.html", 142),
+        ("app/templates/htmx/partials/parts/list.html", 301),
+        ("app/templates/htmx/partials/parts/list.html", 348),
         ("app/templates/htmx/partials/parts/tabs/req_details.html", 209),
     }
 


### PR DESCRIPTION
## What

Phase 3 UI program — the **Sales Hub / Requisitions** page cluster (`parts/`), the app's central work surface. Implements all 13 findings from the total UI audit (key `sales-hub`).

## Changes (13/13 findings)

- **Toolbar rebuilt on primitives** — hand-rolled `text-[10px]` brand filter pills / Add-Req / Prev-Next → `.btn-primary` / `.chip` (accent active) / `.btn-secondary .btn-sm` / `.input .input-sm`. Clears the page's biggest readability-floor (11px) + accent debt + consistency smell in one pass.
- **Bid-Due urgency** (highest buyer payoff) — `need_by_date` column now computes days-to-due and colors overdue → `text-rose-600 font-semibold`, ≤2 days → amber, else neutral.
- **Vendor-trust chip on Offers tab** — `part_tab_offers` (`htmx_views.py`) now queries `VendorSightingSummary` to build a `vendor_tier_map`; offers table renders a trust chip per vendor, reusing existing tier data.
- **Accent / line-tokens** — `.ws-tab-active` → `var(--accent)` (styles.css); drag-handle hover/active → `accent-*`; `border-gray-*`/`border-brand-200` → `.border-line-base`; detail-tab tables → `.compact-table`/`compact-cell`.
- **Status badges** — offers/sourcing status → `.badge` family.
- **Hierarchy** — "Sales Hub" eyebrow always rendered; hero numerics → `.figure-accent`.
- **Empty state** — gains an "Add Requisition" `.btn-primary` CTA.

Files: `styles.css` (`.ws-tab-active`), `htmx_views.py` (offers query), `parts/list.html`, `parts/workspace.html`, `parts/header.html`, `parts/tabs/offers.html`, `parts/tabs/sourcing.html`, + new E2E spec.

## Verification
CI (frontend build + tests + pytest, incl. changed-files ruff/mypy gate on `htmx_views.py`) gates merge. Visual sign-off is part of the consolidated local deploy-for-review. **This is the first of two styles.css branches; lands before `feat/ui-search`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_