### PR TITLE
feat(ui): CRM foundation conformance — shell/tabs accent, vendor tab unify, data-table, figures

### DIFF
--- a/app/templates/htmx/partials/crm/_shell_macros.html
+++ b/app/templates/htmx/partials/crm/_shell_macros.html
@@ -1,6 +1,6 @@
 {# _shell_macros.html — Jinja macros for the CRM shell tab bar.
    Used by: crm/shell.html (tab buttons).
-   Depends on: Alpine.js, HTMX, brand palette.
+   Depends on: Alpine.js, HTMX, accent palette (post-PR0).
 
    tab_button() renders one Pattern-C tab button. The @click and :class
    Alpine attributes are mechanically derived from `name` (the active/inactive
@@ -9,7 +9,7 @@
 #}
 {% macro tab_button(name, url, label, trigger) -%}
 <button @click="tab = '{{ name }}'"
-            :class="tab === '{{ name }}' ? 'border-b-2 border-brand-500 text-brand-600 bg-brand-50' : 'text-gray-500 hover:text-brand-600 hover:bg-brand-50'"
+            :class="tab === '{{ name }}' ? 'border-b-2 border-accent-500 text-accent-700 bg-accent-50' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'"
             class="px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors"
             hx-get="{{ url|safe }}"
             hx-target="#crm-tab-content"

--- a/app/templates/htmx/partials/crm/shell.html
+++ b/app/templates/htmx/partials/crm/shell.html
@@ -1,24 +1,35 @@
-{# shell.html — CRM tab bar with Customers/Vendors sub-tabs.
+{# shell.html — CRM shell: page header + Customers/Vendors tab bar.
    Receives: user (User), default_tab (str).
    Called by: crm/views.py crm_shell route.
-   Depends on: Alpine.js, HTMX, brand palette.
+   Depends on: Alpine.js, HTMX, accent palette (post-PR0), _shell_macros.html.
 #}
 {% from "htmx/partials/crm/_shell_macros.html" import tab_button -%}
 <div x-data="{ tab: '{{ default_tab }}' }">
-  {# Tab bar — Pattern C (Settings-style with bg-brand-50 fill) #}
-  <div class="flex gap-1 mb-6 border-b border-brand-200">
+
+  {# ── CRM page header — Three-Second Rule: "Where am I?" ───────────────── #}
+  <div class="flex items-center justify-between mb-4">
+    <div>
+      <h1 class="text-lg font-bold text-gray-900">CRM</h1>
+      <p class="text-xs text-gray-500">Companies &amp; Vendors</p>
+    </div>
+  </div>
+
+  {# Tab bar — Pattern C (active: accent underline + accent-50 fill) #}
+  <div class="flex gap-1 mb-6 border-b border-line-base">
     {{ tab_button('customers', '/v2/partials/customers', 'Customers', 'load, click' if default_tab == 'customers' else 'click') }}
     {{ tab_button('vendors', '/v2/partials/vendors?hx_target=%23crm-tab-content&push_url_base=/v2/crm', 'Vendors', 'load, click' if default_tab == 'vendors' else 'click') }}
   </div>
 
-  {# Tab content — lazy-loaded by HTMX #}
+  {# Tab content — lazy-loaded by HTMX.
+     Skeleton: two rows of placeholder bars approximating the split-panel/table shape
+     so there is no layout jump when the dense partial swaps in. #}
   <div id="crm-tab-content">
-    <div class="flex items-center justify-center py-6 sm:py-8 text-gray-400 text-sm">
-      <svg class="animate-spin h-5 w-5 mr-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
-      </svg>
-      Loading...
+    <div class="animate-pulse space-y-3 py-4" aria-hidden="true">
+      <div class="h-8 bg-gray-100 rounded-lg w-full"></div>
+      <div class="flex gap-3">
+        <div class="h-64 bg-gray-100 rounded-lg w-1/3"></div>
+        <div class="h-64 bg-gray-100 rounded-lg flex-1"></div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/templates/htmx/partials/customers/_account_list.html
+++ b/app/templates/htmx/partials/customers/_account_list.html
@@ -3,7 +3,7 @@
    workspace-level Alpine selectedId. Checkboxes enable bulk select for bulk actions.
    Receives: companies, total, limit, offset (filters come from #cdm-filters via hx-include).
    Called by: list.html (initial include) and companies_account_list_partial route (refresh).
-   Depends on: workspace x-data (selectedId), brand palette, timeago filter.
+   Depends on: workspace x-data (selectedId), accent palette (post-PR0), timeago filter.
    Bulk actions: POST /v2/partials/customers/bulk/{action} with ids (comma-separated).
 #}
 {% from "htmx/partials/shared/_alert_macros.html" import alert_row_attrs %}
@@ -29,7 +29,7 @@
      data-offset="{{ offset }}" data-limit="{{ limit }}">
   <div class="flex items-center justify-between px-3 py-1.5 text-[11px] font-medium text-gray-600">
     <label class="flex items-center gap-2 cursor-pointer select-none">
-      <input type="checkbox" class="rounded border-gray-300 text-brand-500 focus:ring-brand-500"
+      <input type="checkbox" class="rounded border-gray-300 input-focus text-accent-500"
              :checked="allSelected"
              @change="toggleAll($event.target.checked)"
              aria-label="Select all accounts on this page">
@@ -44,14 +44,14 @@
       <a href="#" role="button"
          hx-get="/v2/partials/customers/archived"
          hx-target="#cdm-list" hx-swap="innerHTML" hx-push-url="false"
-         class="font-medium text-gray-600 hover:text-brand-700 hover:underline underline-offset-2 focus:outline-none focus:ring-2 focus:ring-brand-400 rounded px-1"
+         class="font-medium text-gray-600 hover:text-accent-700 hover:underline underline-offset-2 focus:outline-none focus:ring-2 focus:ring-accent-500 rounded px-1"
          title="View archived (Do Not Call) accounts">Archive (DNC)</a>
     </div>
   </div>
 
   {# Bulk action bar — visible only when ≥1 row is checked #}
   <div x-show="count > 0" x-cloak class="px-3 pb-2 flex items-center gap-2 flex-wrap">
-    <span class="text-xs font-medium text-brand-700" x-text="count + ' selected'"></span>
+    <span class="text-xs font-medium text-accent-700" x-text="count + ' selected'"></span>
     {# Deactivate #}
     <form hx-post="/v2/partials/customers/bulk/deactivate"
           hx-target="#cdm-list" hx-swap="innerHTML"
@@ -77,7 +77,7 @@
         Assign owner ▾
       </button>
       <div x-show="open" x-cloak @click.outside="open = false"
-           class="absolute left-0 top-full mt-1 z-20 bg-white border border-gray-200 rounded-lg shadow-lg p-2 w-48">
+           class="absolute left-0 top-full mt-1 z-20 bg-white border border-line-base rounded-lg shadow-lg p-2 w-48">
         <form hx-post="/v2/partials/customers/bulk/assign-owner"
               hx-target="#cdm-list" hx-swap="innerHTML"
               hx-include="#cdm-filters"
@@ -108,15 +108,15 @@
        is a flat picker — no accordion, no per-site drill-down navigation. #}
   <div id="cdm-row-{{ c.id }}"{{ alert_row_attrs(alert_markers, 'company-' ~ c.id) }}
        class="flex items-center gap-2 px-2 py-2.5 hover:bg-gray-50 transition-colors border-l-2"
-       :class="selectedId === {{ c.id }} ? 'bg-brand-50 border-l-brand-500' : 'border-l-transparent'">
+       :class="selectedId === {{ c.id }} ? 'bg-accent-50 border-l-accent-500' : 'border-l-transparent'">
     {# Checkbox — stops click propagation so ticking a checkbox doesn't also load the detail #}
-    <input type="checkbox" class="rounded border-gray-300 text-brand-500 focus:ring-brand-500 flex-shrink-0"
+    <input type="checkbox" class="rounded border-gray-300 input-focus text-accent-500 flex-shrink-0"
            :checked="selectedIds['{{ c.id }}']"
            @click.stop="toggle('{{ c.id }}')"
            aria-label="Select {{ c.name }}">
     {# Row body — the actual click-to-detail area #}
     <div role="button" tabindex="0"
-         class="flex items-center gap-2 flex-1 min-w-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-500"
+         class="flex items-center gap-2 flex-1 min-w-0 cursor-pointer focus:outline-none focus:ring-2 focus:ring-inset focus:ring-accent-500"
          hx-get="/v2/partials/customers/{{ c.id }}"
          hx-target="#cdm-detail"
          hx-swap="innerHTML"
@@ -162,7 +162,7 @@
      hx-target-error="#cdm-error"
      hx-include="#cdm-filters"
      hx-trigger="click, keyup[key=='Enter']"
-     class="px-2.5 py-1 text-xs bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-500">Prev</a>
+     class="px-2.5 py-1 text-xs bg-white border border-line-base rounded-lg hover:bg-accent-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent-500">Prev</a>
   {% endif %}
   <span class="px-2 py-1 text-xs text-gray-600">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
   {% if offset + limit < total %}
@@ -173,7 +173,7 @@
      hx-target-error="#cdm-error"
      hx-include="#cdm-filters"
      hx-trigger="click, keyup[key=='Enter']"
-     class="px-2.5 py-1 text-xs bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-500">Next</a>
+     class="px-2.5 py-1 text-xs bg-white border border-line-base rounded-lg hover:bg-accent-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent-500">Next</a>
   {% endif %}
 </div>
 {% endif %}

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -143,9 +143,9 @@
           <span class="font-medium text-gray-700">{{ cadence_label.get(cadence_state, cadence_state|title) }}</span>
         </span>
         <span class="text-gray-300">·</span>
-        <span>Win <span class="font-semibold text-gray-900">{% if win_rate is not none %}{{ win_rate }}%{% else %}—{% endif %}</span></span>
+        <span>Win <span class="figure-accent font-semibold">{% if win_rate is not none %}{{ win_rate }}%{% else %}—{% endif %}</span></span>
         <span class="text-gray-300">·</span>
-        <span>Rev 90d <span class="font-semibold text-gray-900">{% if revenue_90d %}${{ "{:,.0f}".format(revenue_90d) }}{% else %}—{% endif %}</span></span>
+        <span>Rev 90d <span class="figure-accent font-semibold">{% if revenue_90d %}${{ "{:,.0f}".format(revenue_90d) }}{% else %}—{% endif %}</span></span>
         <span class="text-gray-300">·</span>
         <span>Last req <span class="font-semibold text-gray-900">{% if last_req_date %}{{ last_req_date[:10] }}{% else %}—{% endif %}</span></span>
         <span class="text-gray-300">·</span>
@@ -169,8 +169,8 @@
                 aria-controls="acct-settings-{{ company.id }}"
                 aria-label="Cadence &amp; settings"
                 title="Cadence &amp; settings"
-                :class="showAcctSettings ? 'bg-brand-50 text-brand-600 border-brand-200' : 'text-gray-600 border-gray-200 hover:bg-gray-50'"
-                class="inline-flex items-center rounded-lg border p-1.5 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500">
+                :class="showAcctSettings ? 'bg-accent-50 text-accent-700 border-accent-200' : 'text-gray-600 border-gray-200 hover:bg-gray-50'"
+                class="inline-flex items-center rounded-lg border p-1.5 transition-colors focus:outline-none focus:ring-2 focus:ring-accent-500">
           <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
@@ -180,7 +180,7 @@
         {# Kebab — overflow actions (Merge duplicate) #}
         <div class="relative inline-block" x-data="{ open: false }" @click.outside="open = false">
           <button @click.stop="open = !open" type="button"
-                  class="p-1.5 text-gray-400 hover:text-gray-600 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  class="p-1.5 text-gray-400 hover:text-gray-600 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-accent-500"
                   aria-label="More account actions"
                   :aria-expanded="open ? 'true' : 'false'"
                   aria-haspopup="menu">
@@ -312,11 +312,11 @@
                 hx-target="#company-tab-content"
                 hx-swap="innerHTML"
                 hx-push-url="/v2/customers/{{ company.id }}?tab={{ tab_id }}"
-                :class="activeTab === '{{ tab_id }}' ? 'border-brand-500 text-brand-600 font-semibold' : 'border-transparent text-gray-600 hover:text-gray-700 hover:border-gray-300'"
+                :class="activeTab === '{{ tab_id }}' ? 'border-accent-500 text-accent-700 font-semibold' : 'border-transparent text-gray-600 hover:text-gray-700 hover:border-gray-300'"
                 class="shrink-0 whitespace-nowrap py-3 px-1 text-sm font-medium border-b-2 transition-colors inline-flex items-center gap-1.5">
           {{ tab_label }}
           {% if tab_count is not none and tab_count > 0 %}
-            <span class="inline-flex items-center justify-center h-5 min-w-[20px] px-1 text-xs font-bold rounded-full bg-brand-100 text-brand-600">{{ tab_count }}</span>
+            <span class="inline-flex items-center justify-center h-5 min-w-[20px] px-1 text-xs font-bold rounded-full bg-accent-100 text-accent-700">{{ tab_count }}</span>
           {% endif %}
         </button>
         {% endfor %}

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -81,7 +81,7 @@
           </div>
           <div class="flex flex-wrap items-center gap-x-1.5 text-xs text-gray-600">
             {% if company.domain %}
-              <a href="https://{{ company.domain }}" target="_blank" rel="noopener noreferrer" class="text-brand-500 hover:text-brand-600">{{ company.domain }}</a>
+              <a href="https://{{ company.domain }}" target="_blank" rel="noopener noreferrer" class="text-accent-600 hover:text-accent-700">{{ company.domain }}</a>
             {% endif %}
             {# Industry — inline-editable (WS1) #}
             {% if company.domain %}<span class="text-gray-300">·</span>{% endif %}

--- a/app/templates/htmx/partials/customers/list.html
+++ b/app/templates/htmx/partials/customers/list.html
@@ -5,7 +5,7 @@
              limit, offset, overdue_count, account_types, disposition, has_open_reqs.
    Called by: companies_list_partial route (htmx_views.py).
    Depends on: splitPanel Alpine component (htmx_app.js), _account_list.html,
-               _detail_empty.html, brand palette.
+               _detail_empty.html, accent palette (post-PR0).
 #}
 
 {# fitHeight: sized to the viewport in both mount contexts (standalone page and
@@ -18,6 +18,7 @@
      @resize.window.debounce.150ms="fitHeight()">
 
   {# ── Filter / sort bar ─────────────────────────────────────── #}
+  {# All filter controls use .input / .input-sm (accent ring, line border) per PR0. #}
   <form id="cdm-filters" class="flex items-center gap-2 flex-wrap pb-3 flex-shrink-0"
         hx-get="/v2/partials/customers/account-list"
         hx-target="#cdm-list"
@@ -27,10 +28,10 @@
 
     <input id="cdm-search" aria-label="Search accounts" type="text" name="search" value="{{ search }}"
            placeholder="Search accounts..."
-           class="flex-1 min-w-[160px] px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+           class="input flex-1 min-w-[160px]">
 
     <select name="staleness" aria-label="Filter by activity staleness"
-            class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
+            class="input input-sm">
       <option value="">All activity</option>
       <option value="overdue" {{ "selected" if staleness == "overdue" }}>Overdue (30d+)</option>
       <option value="due_soon" {{ "selected" if staleness == "due_soon" }}>Due soon (14&ndash;30d)</option>
@@ -43,7 +44,7 @@
     </select>
 
     <select name="account_type" aria-label="Filter by account type"
-            class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
+            class="input input-sm">
       <option value="">All types</option>
       {% for t in account_types %}
       <option value="{{ t }}" {{ "selected" if account_type == t }}>{{ t }}</option>
@@ -52,7 +53,7 @@
 
     {% if all_segment_tags %}
     <select name="segment" aria-label="Filter by segment tag"
-            class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
+            class="input input-sm">
       <option value="0">All segments</option>
       {% for t in all_segment_tags %}
       <option value="{{ t.id }}" {{ "selected" if segment == t.id }}>{{ t.name }}</option>
@@ -61,7 +62,7 @@
     {% endif %}
 
     <select name="sort" aria-label="Sort accounts"
-            class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
+            class="input input-sm">
       <option value="oldest" {{ "selected" if sort == "oldest" }}>Longest since activity</option>
       <option value="newest" {{ "selected" if sort == "newest" }}>Most recent activity</option>
       <option value="outbound_asc" {{ "selected" if sort == "outbound_asc" }}>Stalest outbound</option>
@@ -72,12 +73,12 @@
 
     <label class="inline-flex items-center gap-1.5 px-2 py-1.5 text-sm text-gray-600 cursor-pointer">
       <input type="checkbox" name="my_only" value="1" {{ "checked" if my_only }}
-             class="rounded border-gray-300 text-brand-500 focus:ring-brand-500">
+             class="rounded border-gray-300 input-focus text-accent-500">
       My accounts
     </label>
 
     <select name="disposition" aria-label="Filter by disposition"
-            class="px-2 py-1.5 text-sm border border-gray-200 rounded-lg">
+            class="input input-sm">
       <option value="">All accounts</option>
       <option value="active" {{ "selected" if disposition == "active" }}>Active only</option>
       <option value="bucket" {{ "selected" if disposition == "bucket" }}>Bucketed only</option>
@@ -85,7 +86,7 @@
 
     <label class="inline-flex items-center gap-1.5 px-2 py-1.5 text-sm text-gray-600 cursor-pointer">
       <input type="checkbox" name="has_open_reqs" value="1" {{ "checked" if has_open_reqs }}
-             class="rounded border-gray-300 text-brand-500 focus:ring-brand-500">
+             class="rounded border-gray-300 input-focus text-accent-500">
       Has open reqs
     </label>
 
@@ -103,26 +104,26 @@
   </form>
 
   {# Export + cross-company contacts links + Import — below the filter bar, above the split workspace #}
+  {# Import modal uses the shared modal-* primitives to match vendors import and the rest of the app. #}
   <div class="flex justify-end gap-3 text-xs text-gray-600 mb-1" x-data="{ importOpen: false }">
     <a hx-get="/v2/partials/contacts" hx-target="#main-content" hx-push-url="/v2/contacts"
-       class="hover:text-brand-600 hover:underline cursor-pointer">All contacts</a>
-    <a href="/v2/customers/export.csv" class="hover:text-brand-600 hover:underline">Export CSV</a>
-    <a href="/v2/customers/contacts/export.csv" class="hover:text-brand-600 hover:underline">Export contacts</a>
-    {# Import modal trigger #}
+       class="hover:text-accent-600 hover:underline cursor-pointer">All contacts</a>
+    <a href="/v2/customers/export.csv" class="hover:text-accent-600 hover:underline">Export CSV</a>
+    <a href="/v2/customers/contacts/export.csv" class="hover:text-accent-600 hover:underline">Export contacts</a>
     <button type="button" @click="importOpen = true"
-            class="hover:text-brand-600 hover:underline cursor-pointer">Import CSV</button>
-    {# Import modal — upload → server previews → confirm creates rows #}
+            class="hover:text-accent-600 hover:underline cursor-pointer">Import CSV</button>
+
+    {# Import modal — built on shared modal-* primitives to match vendors import modal. #}
     <div x-show="importOpen" x-cloak
          class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
          @keydown.escape.window="importOpen = false">
-      <div class="bg-white rounded-xl shadow-xl w-full max-w-2xl mx-4 p-6 space-y-4"
+      <div class="bg-white rounded-xl shadow-xl w-full max-w-2xl mx-4 relative"
            @click.stop>
-        <div class="flex items-center justify-between">
-          <h3 class="text-base font-semibold text-gray-900">Import Companies / Contacts</h3>
-          <button type="button" @click="importOpen = false"
-                  class="text-gray-400 hover:text-gray-600 text-lg leading-none">&times;</button>
+        <div class="modal-header">
+          <h3 class="h4">Import Companies / Contacts</h3>
+          <button type="button" class="modal-close" @click="importOpen = false" aria-label="Close">&times;</button>
         </div>
-        <div class="space-y-3">
+        <div class="modal-body space-y-4">
           <div>
             <p class="text-sm font-medium text-gray-700 mb-1">Import Companies</p>
             <p class="text-xs text-gray-500 mb-2">CSV columns: <code>name</code> (required), <code>website</code>, <code>account_type</code></p>
@@ -132,7 +133,7 @@
                   hx-encoding="multipart/form-data">
               <div class="flex gap-2">
                 <input type="file" name="file" accept=".csv"
-                       class="text-xs text-gray-600 border border-gray-200 rounded px-2 py-1 flex-1">
+                       class="text-xs text-gray-600 border border-line-base rounded px-2 py-1 flex-1">
                 <button type="submit" class="btn btn-primary btn-sm whitespace-nowrap">
                   Preview
                 </button>
@@ -148,7 +149,7 @@
                   hx-encoding="multipart/form-data">
               <div class="flex gap-2">
                 <input type="file" name="file" accept=".csv"
-                       class="text-xs text-gray-600 border border-gray-200 rounded px-2 py-1 flex-1">
+                       class="text-xs text-gray-600 border border-line-base rounded px-2 py-1 flex-1">
                 <button type="submit" class="btn btn-secondary btn-sm whitespace-nowrap">
                   Preview contacts
                 </button>
@@ -157,6 +158,9 @@
           </div>
           {# Preview / confirm result lands here #}
           <div id="import-result"></div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary btn-sm" @click="importOpen = false">Close</button>
         </div>
       </div>
     </div>
@@ -168,19 +172,19 @@
 
   {# ── Split workspace: account list (left) + detail panel (right) ── #}
   <div id="split-cdm"
-       class="flex flex-1 overflow-hidden min-h-0 bg-white border border-gray-200 rounded-lg"
+       class="flex flex-1 overflow-hidden min-h-0 bg-white border border-line-base rounded-lg"
        x-data="splitPanel('cdm', 35)">
 
     {# Left panel: scrollable account list #}
-    <div class="border-r border-gray-200 flex flex-col bg-white flex-shrink-0 overflow-hidden"
+    <div class="border-r border-line-base flex flex-col bg-white flex-shrink-0 overflow-hidden"
          :style="'width: ' + leftWidth + '%'">
       <div id="cdm-list" class="flex-1 overflow-y-auto">
         {% include "htmx/partials/customers/_account_list.html" %}
       </div>
     </div>
 
-    {# Resizable divider #}
-    <div class="w-1 bg-gray-200 hover:bg-brand-400 cursor-col-resize flex-shrink-0 transition-colors"
+    {# Resizable divider — active drag state uses accent (interactive accent moment). #}
+    <div class="w-1 bg-gray-200 hover:bg-accent-400 cursor-col-resize flex-shrink-0 transition-colors"
          role="separator" aria-label="Resize panels" tabindex="0"
          @mousedown="startResize($event)"
          @touchstart.prevent="startTouchResize($event)"

--- a/app/templates/htmx/partials/vendors/list.html
+++ b/app/templates/htmx/partials/vendors/list.html
@@ -1,14 +1,18 @@
 {# Vendor list partial — sortable table with blacklisted toggle and cadence clocks.
-   Receives: vendors, q, hide_blacklisted, sort, dir, total, limit, offset, now_utc.
+   Receives: vendors, q, hide_blacklisted, sort, dir, total, limit, offset, now_utc,
+             view, my_only, hx_target, push_url_base.
    Each vendor has .cadence_state attached by the route (tier=None → standard 30d).
    Called by: vendors_list_partial route.
-   Depends on: brand palette, timeago filter.
+   Depends on: accent palette (post-PR0), timeago filter.
 #}
 
 <div class="page-fluid" x-data="{ importOpen: false }">
+
+  {# ── Page header: title + primary CTA ────────────────────────────────────── #}
   <div class="flex items-center justify-between mb-4">
     <div>
-      <p class="text-sm text-gray-600 mt-1">{{ total }} vendor{{ "s" if total != 1 }}</p>
+      <h2 class="text-base font-semibold text-gray-900">Vendors</h2>
+      <p class="text-xs text-gray-500 mt-0.5">{{ total }} vendor{{ "s" if total != 1 }}</p>
     </div>
     <div class="flex items-center gap-2">
       <a hx-get="/v2/partials/vendor-contacts"
@@ -24,7 +28,7 @@
       <button hx-get="/v2/partials/vendors/create-form"
               hx-target="#main-content"
               data-loading-disable
-              class="btn-primary btn-sm">
+              class="btn btn-primary btn-sm">
         <svg class="h-4 w-4 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
         Add Vendor
       </button>
@@ -36,7 +40,7 @@
   <div x-show="importOpen" x-cloak
        class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
        @keydown.escape.window="importOpen = false">
-    <div class="bg-white rounded-lg shadow-xl w-full max-w-md" @click.outside="importOpen = false">
+    <div class="bg-white rounded-xl shadow-xl w-full max-w-md relative" @click.outside="importOpen = false">
       <div class="modal-header">
         <h3 class="h4">Import Vendors</h3>
         <button type="button" class="modal-close" @click="importOpen = false" aria-label="Close">&times;</button>
@@ -48,7 +52,7 @@
             hx-encoding="multipart/form-data">
         <p class="text-sm text-gray-600">Upload a CSV with a header row of <code>name,email,phone,website</code>. Existing vendors (matched by normalized name) are skipped.</p>
         <input type="file" name="file" accept=".csv,text/csv" required
-               class="block w-full text-sm text-gray-600 file:mr-3 file:rounded file:border-0 file:bg-brand-50 file:px-3 file:py-1.5 file:text-sm file:text-brand-700">
+               class="block w-full text-sm text-gray-600 file:mr-3 file:rounded file:border-0 file:bg-accent-50 file:px-3 file:py-1.5 file:text-sm file:text-accent-700">
         <div id="vendor-import-result"></div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary btn-sm" @click="importOpen = false">Close</button>
@@ -58,14 +62,15 @@
     </div>
   </div>
 
-  {# Tab bar: All Vendors / My Vendors #}
-  <div class="flex gap-1 mb-4 border-b-2 border-gray-200">
+  {# Sub-tab bar: All Vendors / My Vendors / Find by Part
+     Active state: accent underline + accent-700 text (mirrors the CRM shell tab bar). #}
+  <div class="flex gap-1 mb-4 border-b border-line-base">
     <a href="/v2/vendors"
        hx-get="/v2/partials/vendors?hx_target={{ hx_target|default('#main-content')|urlencode }}&push_url_base={{ push_url_base|default('/v2/vendors')|urlencode }}"
        hx-target="{{ hx_target|default('#main-content') }}"
        hx-push-url="{{ push_url_base|default('/v2/vendors') }}"
        class="px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-[2px]
-              {{ 'text-brand-600 border-brand-500' if not my_only else 'text-gray-600 border-transparent hover:text-gray-700 hover:border-gray-300' }}">
+              {{ 'text-accent-700 border-accent-500' if not my_only else 'text-gray-600 border-transparent hover:text-gray-700 hover:border-gray-300' }}">
       All Vendors
     </a>
     <a href="/v2/vendors?my_only=1"
@@ -73,7 +78,7 @@
        hx-target="{{ hx_target|default('#main-content') }}"
        hx-push-url="{{ push_url_base|default('/v2/vendors') }}?my_only=1"
        class="px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-[2px]
-              {{ 'text-brand-600 border-brand-500' if my_only else 'text-gray-600 border-transparent hover:text-gray-700 hover:border-gray-300' }}">
+              {{ 'text-accent-700 border-accent-500' if my_only else 'text-gray-600 border-transparent hover:text-gray-700 hover:border-gray-300' }}">
       My Vendors
     </a>
     <a hx-get="/v2/partials/vendors/find-by-part?hx_target={{ hx_target|default('#main-content')|urlencode }}&push_url_base={{ push_url_base|default('/v2/vendors')|urlencode }}"
@@ -85,8 +90,8 @@
     </a>
   </div>
 
-  {# Filter bar #}
-  <div class="bg-white rounded-lg shadow border border-gray-200 p-4 mb-6"
+  {# Filter bar — .card wraps chrome so it matches the rest of the app. #}
+  <div class="card p-4 mb-6"
        x-data="{ view: '{{ view|default('table') }}' }">
     <form id="vendor-filters" class="flex flex-wrap gap-3 items-end" onsubmit="return false">
       <div class="flex-1 min-w-[200px]">
@@ -97,7 +102,7 @@
                hx-push-url="{{ push_url_base|default('/v2/vendors') }}"
                hx-include="#vendor-filters"
                hx-trigger="input delay:300ms"
-               class="w-full px-3 py-1.5 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+               class="input w-full">
       </div>
       {% if my_only %}<input type="hidden" name="my_only" value="1">{% endif %}
       <input type="hidden" name="hx_target" value="{{ hx_target|default('#main-content') }}">
@@ -106,10 +111,9 @@
       <input type="hidden" name="dir" value="{{ dir }}">
       <input type="hidden" name="view" :value="view">
       <div class="flex items-center gap-2">
-        {# Sort by stalest outbound #}
         <select name="sort_select" aria-label="Sort vendors"
                 onchange="document.querySelector('#vendor-filters [name=sort]').value = this.value; htmx.trigger(document.querySelector('#vendor-filters [name=q]'), 'changed')"
-                class="px-2 py-1.5 text-xs border border-gray-200 rounded-lg bg-white focus:ring-2 focus:ring-brand-500">
+                class="input input-sm">
           <option value="sighting_count" {{ 'selected' if sort == 'sighting_count' }}>Most Sightings</option>
           <option value="display_name" {{ 'selected' if sort == 'display_name' }}>Name A–Z</option>
           <option value="overall_win_rate" {{ 'selected' if sort == 'overall_win_rate' }}>Win Rate</option>
@@ -120,14 +124,13 @@
           <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
             <input type="checkbox" x-model="hideBlacklisted"
                    @change="htmx.trigger(document.querySelector('#vendor-filters [name=q]'), 'changed')"
-                   class="h-4 w-4 rounded border-gray-200 text-brand-500 focus:ring-brand-500">
+                   class="h-4 w-4 rounded border-gray-200 input-focus text-accent-500">
             Hide blacklisted
           </label>
         </div>
-        {# View toggle: table / cards #}
         <button type="button"
                 @click="view = view === 'cards' ? 'table' : 'cards'; $nextTick(() => htmx.trigger(document.querySelector('#vendor-filters [name=q]'), 'changed'))"
-                class="px-3 py-1.5 text-xs font-medium bg-white border border-gray-200 rounded-lg hover:bg-brand-50"
+                class="btn btn-secondary btn-sm"
                 x-text="view === 'cards' ? 'Table' : 'Cards'">
         </button>
       </div>
@@ -143,91 +146,89 @@
   </div>
   {% endif %}
 
-  {# Cadence dot color map \u2014 same keys as customer _account_list.html #}
+  {# Cadence dot color map — same keys as customer _account_list.html #}
   {% set dot_colors = {"new": "bg-gray-300", "on_target": "bg-emerald-400", "due": "bg-amber-400", "overdue": "bg-rose-500"} %}
 
-  {# Table view #}
+  {# Table view — .table-wrapper + .data-table for consistent density and accent chrome. #}
   {% if view != 'cards' and vendors %}
-  <div class="bg-white rounded-lg shadow border border-gray-200 overflow-hidden">
-    <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
-        <thead class="bg-gray-50">
-          <tr>
-            {# Cadence dot column \u2014 no label, narrow #}
-            <th class="px-2 py-3 w-6"></th>
-            {% for col_name, col_key in [('Vendor', 'display_name'), ('Score', None), ('Sightings', 'sighting_count'), ('Win Rate', 'overall_win_rate'), ('Location', 'hq_country'), ('Industry', 'industry')] %}
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              {% if col_key %}
-              <a hx-get="/v2/partials/vendors?sort={{ col_key }}&dir={{ 'asc' if sort == col_key and dir == 'desc' else 'desc' }}"
-                 hx-target="{{ hx_target|default('#main-content') }}"
-                 hx-push-url="{{ push_url_base|default('/v2/vendors') }}"
-                 hx-include="#vendor-filters"
-                 class="cursor-pointer hover:text-brand-500 inline-flex items-center gap-1">
-                {{ col_name }}
-                {% if sort == col_key %}
-                <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  {% if dir == 'asc' %}<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>
-                  {% else %}<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>{% endif %}
-                </svg>
-                {% endif %}
-              </a>
-              {% else %}
+  <div class="table-wrapper">
+    <table class="data-table">
+      <thead>
+        <tr>
+          {# Cadence dot column — no label, narrow #}
+          <th class="w-6 px-2"></th>
+          {% for col_name, col_key in [('Vendor', 'display_name'), ('Score', None), ('Sightings', 'sighting_count'), ('Win Rate', 'overall_win_rate'), ('Location', 'hq_country'), ('Industry', 'industry')] %}
+          <th>
+            {% if col_key %}
+            <a hx-get="/v2/partials/vendors?sort={{ col_key }}&dir={{ 'asc' if sort == col_key and dir == 'desc' else 'desc' }}"
+               hx-target="{{ hx_target|default('#main-content') }}"
+               hx-push-url="{{ push_url_base|default('/v2/vendors') }}"
+               hx-include="#vendor-filters"
+               class="cursor-pointer hover:text-accent-600 inline-flex items-center gap-1">
               {{ col_name }}
+              {% if sort == col_key %}
+              <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                {% if dir == 'asc' %}<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>
+                {% else %}<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>{% endif %}
+              </svg>
               {% endif %}
-            </th>
-            {% endfor %}
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cadence</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-gray-200">
-          {% for v in vendors %}
-          <tr class="{{ 'bg-rose-50' if v.is_blacklisted else '' }} hover:bg-brand-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-500"
-              role="button" tabindex="0"
-              hx-get="/v2/partials/vendors/{{ v.id }}"
-              hx-target="{{ hx_target|default('#main-content') }}"
-              hx-push-url="/v2/vendors/{{ v.id }}"
-              hx-trigger="click, keyup[key=='Enter']"
-              preload="mouseover">
-            {# Cadence dot #}
-            <td class="px-2 py-3">
-              <span class="w-2.5 h-2.5 rounded-full flex-shrink-0 inline-block {{ dot_colors.get(v.cadence_state, 'bg-gray-300') }}"
-                    role="img"
-                    aria-label="{{ v.cadence_state|replace('_', ' ')|title if v.cadence_state else 'New' }}"
-                    title="{{ v.cadence_state|replace('_', ' ')|title if v.cadence_state else 'New' }}"></span>
-            </td>
-            <td class="px-4 py-3">
-              <div>
-                <p class="text-sm font-medium text-brand-500">{{ v.display_name }}</p>
-                {% if v.domain %}<p class="text-xs text-gray-600">{{ v.domain }}</p>{% endif %}
-              </div>
-            </td>
-            <td class="px-4 py-3">
-              {% if v.is_blacklisted %}
-                <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-rose-50 text-rose-700">Blacklisted</span>
-              {% elif v.vendor_score %}
-                <span class="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-emerald-50 text-emerald-700">{{ "%.0f"|format(v.vendor_score) }}</span>
-              {% else %}
-                <span class="text-xs text-gray-600">&mdash;</span>
-              {% endif %}
-            </td>
-            <td class="px-4 py-3 text-sm text-gray-600">{{ v.sighting_count or 0 }}</td>
-            <td class="px-4 py-3 text-sm text-gray-600">{{ "%.0f%%"|format(v.overall_win_rate * 100) if v.overall_win_rate else "\u2014" }}</td>
-            <td class="px-4 py-3 text-sm text-gray-600">{{ v.hq_country or "\u2014" }}</td>
-            <td class="px-4 py-3 text-sm text-gray-600">{{ v.industry or "\u2014" }}</td>
-            {# Dual cadence clocks #}
-            <td class="px-4 py-3 text-right">
-              <p class="text-[11px] {% if v.cadence_state == 'overdue' %}text-rose-600 font-medium{% elif v.cadence_state == 'due' %}text-amber-600{% else %}text-gray-400{% endif %}">
-                Out {{ v.last_outbound_at|timeago if v.last_outbound_at else "never" }}
-              </p>
-              <p class="text-[11px] text-gray-400">
-                Reply {{ v.last_reply_at|timeago if v.last_reply_at else "\u2014" }}
-              </p>
-            </td>
-          </tr>
+            </a>
+            {% else %}
+            {{ col_name }}
+            {% endif %}
+          </th>
           {% endfor %}
-        </tbody>
-      </table>
-    </div>
+          <th>Cadence</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for v in vendors %}
+        <tr class="{{ 'bg-rose-50' if v.is_blacklisted else '' }} cursor-pointer focus:outline-none focus:ring-2 focus:ring-inset focus:ring-accent-500"
+            role="button" tabindex="0"
+            hx-get="/v2/partials/vendors/{{ v.id }}"
+            hx-target="{{ hx_target|default('#main-content') }}"
+            hx-push-url="/v2/vendors/{{ v.id }}"
+            hx-trigger="click, keyup[key=='Enter']"
+            preload="mouseover">
+          {# Cadence dot #}
+          <td class="px-2">
+            <span class="w-2.5 h-2.5 rounded-full flex-shrink-0 inline-block {{ dot_colors.get(v.cadence_state, 'bg-gray-300') }}"
+                  role="img"
+                  aria-label="{{ v.cadence_state|replace('_', ' ')|title if v.cadence_state else 'New' }}"
+                  title="{{ v.cadence_state|replace('_', ' ')|title if v.cadence_state else 'New' }}"></span>
+          </td>
+          <td>
+            <div>
+              <p class="text-sm font-medium text-accent-700">{{ v.display_name }}</p>
+              {% if v.domain %}<p class="text-xs text-gray-600">{{ v.domain }}</p>{% endif %}
+            </div>
+          </td>
+          <td>
+            {% if v.is_blacklisted %}
+              <span class="badge bg-rose-50 text-rose-700 border-rose-200">Blacklisted</span>
+            {% elif v.vendor_score %}
+              <span class="badge badge-success">{{ "%.0f"|format(v.vendor_score) }}</span>
+            {% else %}
+              <span class="text-xs text-gray-600">&mdash;</span>
+            {% endif %}
+          </td>
+          <td class="text-gray-600">{{ v.sighting_count or 0 }}</td>
+          <td class="text-gray-600">{{ "%.0f%%"|format(v.overall_win_rate * 100) if v.overall_win_rate else "—" }}</td>
+          <td class="text-gray-600">{{ v.hq_country or "—" }}</td>
+          <td class="text-gray-600">{{ v.industry or "—" }}</td>
+          {# Dual cadence clocks #}
+          <td class="text-right">
+            <p class="text-[11px] {% if v.cadence_state == 'overdue' %}text-rose-600 font-medium{% elif v.cadence_state == 'due' %}text-amber-600{% else %}text-gray-400{% endif %}">
+              Out {{ v.last_outbound_at|timeago if v.last_outbound_at else "never" }}
+            </p>
+            <p class="text-[11px] text-gray-400">
+              Reply {{ v.last_reply_at|timeago if v.last_reply_at else "—" }}
+            </p>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
 
   {# Pagination #}
@@ -239,7 +240,7 @@
          hx-target="{{ hx_target|default('#main-content') }}"
          hx-include="#vendor-filters"
          preload="mouseover"
-         class="px-3 py-1.5 text-sm bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Prev</a>
+         class="btn btn-secondary btn-sm cursor-pointer">Prev</a>
       {% endif %}
       <span class="px-3 py-1.5 text-sm text-gray-600">{{ offset + 1 }}&ndash;{{ [offset + limit, total]|min }} of {{ total }}</span>
       {% if offset + limit < total %}
@@ -247,7 +248,7 @@
          hx-target="{{ hx_target|default('#main-content') }}"
          hx-include="#vendor-filters"
          preload="mouseover"
-         class="px-3 py-1.5 text-sm bg-white border border-gray-200 rounded-lg hover:bg-brand-50 cursor-pointer">Next</a>
+         class="btn btn-secondary btn-sm cursor-pointer">Next</a>
       {% endif %}
     </nav>
   </div>
@@ -255,9 +256,9 @@
 
   {% endif %}
 
-  {# Empty state (no vendors at all) #}
+  {# Empty state — .card matches the rest of the app chrome. #}
   {% if not vendors %}
-  <div class="bg-white rounded-lg shadow border border-gray-200 p-6 sm:p-8 text-center">
+  <div class="card p-6 sm:p-8 text-center">
     <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
     <p class="mt-2 text-sm text-gray-600">No vendors found</p>
   </div>

--- a/app/templates/htmx/partials/vendors/list.html
+++ b/app/templates/htmx/partials/vendors/list.html
@@ -5,6 +5,7 @@
    Called by: vendors_list_partial route.
    Depends on: accent palette (post-PR0), timeago filter.
 #}
+{% from "htmx/partials/shared/_macros.html" import badge %}
 
 <div class="page-fluid" x-data="{ importOpen: false }">
 
@@ -152,7 +153,7 @@
   {# Table view — .table-wrapper + .data-table for consistent density and accent chrome. #}
   {% if view != 'cards' and vendors %}
   <div class="table-wrapper">
-    <table class="data-table">
+    <table class="data-table w-full">
       <thead>
         <tr>
           {# Cadence dot column — no label, narrow #}
@@ -205,7 +206,7 @@
           </td>
           <td>
             {% if v.is_blacklisted %}
-              <span class="badge bg-rose-50 text-rose-700 border-rose-200">Blacklisted</span>
+              {{ badge('Blacklisted', 'danger') }}
             {% elif v.vendor_score %}
               <span class="badge badge-success">{{ "%.0f"|format(v.vendor_score) }}</span>
             {% else %}


### PR DESCRIPTION
## What

Phase 3 UI program — the **CRM** cluster spanning `crm/`, `vendors/`, `customers/`. Implements all 13 findings from the total UI audit (key `crm`), including rebuilding the pre-foundation Vendors tab to match the Customers patterns.

## Changes (13/13 findings)

- **CRM shell** — tab bar active → `border-accent-500 text-accent-700 bg-accent-50`; added `<h1>CRM</h1>` + eyebrow; shell border → `.border-line-base`; skeleton loader matches split-panel shape.
- **Vendors tab unify** — table → `.table-wrapper` + `.data-table`; filter bar/empty-state → `.card`; sub-tab active + vendor-name link → accent; controls → `.input`/`.input-sm`; checkboxes → `input-focus text-accent-500`; pagination → `.btn-secondary .btn-sm`; score/blacklist → `.badge` family. Mirrors existing customers-list conventions.
- **Customers** — selected row → `bg-accent-50 border-l-accent-500`; focus rings/hover → accent; Import-CSV modal rebuilt on `modal-header/body/footer/close`; Win%/Rev-90d → `.figure-accent`; account tabs active → accent.

Files: `crm/_shell_macros.html`, `crm/shell.html`, `vendors/list.html`, `customers/list.html`, `customers/_account_list.html`, `customers/detail.html`.

## Verification
CI gates merge. Visual sign-off is part of the consolidated local deploy-for-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_