### PR TITLE
feat(ui): Sightings foundation conformance — .input/.btn primitives, RFQ-send accent, keyboard rows

### DIFF
--- a/app/templates/htmx/partials/sightings/_offer_row.html
+++ b/app/templates/htmx/partials/sightings/_offer_row.html
@@ -5,21 +5,21 @@
    (review/reconfirm/mark-sold/delete) re-render #sightings-offers-panel. #}
 {% from "htmx/partials/offers/_field_macros.html" import qual_badge %}
 {% set sc = {
-  'active': 'bg-emerald-50 text-emerald-700',
-  'pending_review': 'bg-amber-50 text-amber-700',
-  'approved': 'bg-emerald-50 text-emerald-700',
-  'rejected': 'bg-rose-50 text-rose-700',
-  'sold': 'bg-gray-100 text-gray-600',
-  'won': 'bg-emerald-50 text-emerald-700',
-  'expired': 'bg-gray-100 text-gray-500',
+  'active': 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  'pending_review': 'bg-amber-50 text-amber-700 border-amber-200',
+  'approved': 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  'rejected': 'bg-rose-50 text-rose-700 border-rose-200',
+  'sold': 'bg-gray-100 text-gray-600 border-gray-200',
+  'won': 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  'expired': 'bg-gray-100 text-gray-500 border-gray-200',
 } %}
 <div id="offer-row-{{ o.id }}" class="group px-2 py-1.5 hover:bg-gray-50/50" x-data="{ open: false, expand: false }">
   <div class="flex items-center gap-2">
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-2">
         <button @click.stop="expand = !expand"
-                class="font-medium text-gray-900 text-sm truncate hover:text-brand-600 text-left">{{ o.vendor_name or '—' }}</button>
-        <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded-full {{ sc.get(o.status, 'bg-gray-100 text-gray-600') }}">
+                class="font-medium text-gray-900 text-sm truncate hover:text-accent-600 text-left">{{ o.vendor_name or '—' }}</button>
+        <span class="chip {{ sc.get(o.status, 'bg-gray-100 text-gray-600 border-gray-200') }}">
           {{ (o.status or 'unknown')|replace('_', ' ')|capitalize }}
         </span>
         {{ qual_badge(o) }}
@@ -47,7 +47,7 @@
                 class="w-full text-left px-3 py-1.5 text-gray-700 hover:bg-gray-50">Edit</button>
         {% if o.vendor_response_id %}
         <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/qualify-ai'}); open = false"
-                class="w-full text-left px-3 py-1.5 text-brand-600 hover:bg-brand-50">Qualify with AI</button>
+                class="w-full text-left px-3 py-1.5 text-accent-600 hover:bg-accent-50">Qualify with AI</button>
         {% endif %}
         {% if o.status == 'pending_review' %}
         <button hx-post="/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/review"
@@ -64,7 +64,7 @@
         <button hx-post="/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/reconfirm"
                 hx-target="#sightings-offers-panel" hx-swap="innerHTML" data-loading-disable
                 @click.stop="open = false"
-                class="w-full text-left px-3 py-1.5 text-brand-600 hover:bg-brand-50">Reconfirm</button>
+                class="w-full text-left px-3 py-1.5 text-accent-600 hover:bg-accent-50">Reconfirm</button>
         <button hx-post="/v2/partials/sightings/{{ requirement.id }}/offers/{{ o.id }}/mark-sold"
                 hx-target="#sightings-offers-panel" hx-swap="innerHTML"
                 hx-confirm="Mark this offer as sold?" data-loading-disable
@@ -111,17 +111,17 @@
     {% if requests %}
     {% set kind_display = {'images': 'Images', 'fpq': 'FPQ', 'cert': 'Cert', 'pkg_qty': 'Pkg qty'} %}
     {% set status_colors = {
-      'pending': 'bg-amber-50 text-amber-700',
-      'sent': 'bg-blue-50 text-blue-700',
-      'skipped': 'bg-amber-100 text-amber-600',
-      'failed': 'bg-rose-50 text-rose-700',
+      'pending': 'bg-amber-50 text-amber-700 border-amber-200',
+      'sent': 'bg-blue-50 text-blue-700 border-blue-200',
+      'skipped': 'bg-amber-100 text-amber-600 border-amber-200',
+      'failed': 'bg-rose-50 text-rose-700 border-rose-200',
     } %}
     <div class="flex flex-wrap items-center gap-1 pt-0.5">
       {% for r in requests %}
       {% set r_kind = r.get('kind', '') %}
       {% set r_status = r.get('status', '') %}
       {% set color = status_colors.get(r_status, 'bg-gray-100 text-gray-500') %}
-      <span class="inline-flex px-1.5 py-0.5 text-xs font-medium rounded-full {{ color }}">
+      <span class="chip {{ color }}">
         {{ kind_display.get(r_kind, r_kind|capitalize) }}{% if r_status != 'pending' %} — {{ r_status }}{% endif %}
       </span>
       {# Per-PENDING Send control: fires the token-bearing send route for this entry. #}

--- a/app/templates/htmx/partials/sightings/_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/_vendor_row.html
@@ -38,11 +38,11 @@
 {% set sub_matches = matched|reject("equalto", requirement.primary_mpn)|list %}
 
 {% set vs_styles = {
-  'sighting': 'bg-gray-100 text-gray-600',
-  'contacted': 'bg-blue-50 text-blue-700',
-  'offer-in': 'bg-emerald-100 text-emerald-700',
-  'unavailable': 'bg-rose-100 text-rose-700',
-  'blacklisted': 'bg-red-50 text-red-700',
+  'sighting': 'bg-gray-100 text-gray-600 border-gray-200',
+  'contacted': 'bg-blue-50 text-blue-700 border-blue-200',
+  'offer-in': 'bg-emerald-100 text-emerald-700 border-emerald-200',
+  'unavailable': 'bg-rose-100 text-rose-700 border-rose-200',
+  'blacklisted': 'bg-red-50 text-red-700 border-red-200',
 } %}
 {# Status-aware row treatment: unavailable = red tint + dimmed, offer-in = green tint.
    The compact-table hover rule paints over the tr tint on hover (transient) — the at-a-
@@ -73,29 +73,29 @@
         <div class="min-w-0">
           <div class="flex items-center gap-1.5 flex-wrap">
             <span class="font-medium text-sm {{ name_color }}">{{ s.vendor_name }}</span>
-            <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full {{ vs_styles.get(vs, 'bg-gray-100 text-gray-600') }}">
+            <span class="chip {{ vs_styles.get(vs, 'bg-gray-100 text-gray-600 border-gray-200') }}">
               {{ vs|replace('-', ' ')|capitalize }}
             </span>
             {% if unav_restock %}
             {# Bordered emerald-50 chip — deliberately distinct from the solid
                bg-emerald-100 offer-in pill (color-collision rule). #}
-            <span class="inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200"
+            <span class="chip bg-emerald-50 text-emerald-700 border-emerald-200"
                   title="qty {{ unav.qty_at_mark if unav.qty_at_mark is not none else '?' }} → {{ s.estimated_qty or '?' }} since marked — possible restock">
               Possible restock
             </span>
             {% endif %}
             {% if ooo %}
-            <span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-amber-50 text-amber-700">
+            <span class="chip bg-amber-50 text-amber-700 border-amber-200">
               OOO{% if ooo.ooo_return_date %} until {{ ooo.ooo_return_date.strftime('%m/%d') }}{% endif %}
             </span>
             {% endif %}
             {% if overlap > 1 %}
-            <span class="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700">
+            <span class="chip bg-indigo-50 text-indigo-700 border-indigo-200">
               Also on {{ overlap - 1 }} other req{{ 's' if overlap - 1 != 1 }}
             </span>
             {% endif %}
             {% for mpn in sub_matches %}
-            <span class="inline-flex px-1 py-0.5 text-[9px] font-mono rounded bg-amber-50 text-amber-600 border border-amber-100">via {{ mpn }}</span>
+            <span class="chip font-mono bg-amber-50 text-amber-600 border-amber-100">via {{ mpn }}</span>
             {% endfor %}
           </div>
 
@@ -104,7 +104,7 @@
           <div class="flex items-center gap-2 mt-0.5 text-[11px] flex-wrap">
             {% if vendor_phone %}
             <a href="tel:{{ vendor_phone }}" @click.stop
-               class="inline-flex items-center gap-0.5 text-brand-500 hover:text-brand-700">
+               class="inline-flex items-center gap-0.5 text-accent-600 hover:text-accent-700">
               <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"/></svg>
               {{ vendor_phone }}
             </a>
@@ -154,7 +154,7 @@
         {# Visible "Build RFQ" compact pill — shown when the vendor can receive RFQs #}
         {% if vs != 'blacklisted' and not is_unavailable %}
         <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/vendor-modal?requirement_ids={{ requirement.id }}&preselect={{ s.vendor_name|urlencode }}'})"
-                class="inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded border border-brand-200 text-brand-600 hover:bg-brand-50 transition-colors"
+                class="inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded border border-accent-200 text-accent-600 hover:bg-accent-50 transition-colors"
                 title="Build RFQ with {{ s.vendor_name }} preselected">Build RFQ</button>
         {% endif %}
         {% if has_actions %}
@@ -299,7 +299,7 @@
           {% if vendor_phone %}
           <div>
             <span class="text-gray-400">Phone:</span>
-            <a href="tel:{{ vendor_phone }}" @click.stop class="text-brand-500 hover:text-brand-700">{{ vendor_phone }}</a>
+            <a href="tel:{{ vendor_phone }}" @click.stop class="text-accent-600 hover:text-accent-700">{{ vendor_phone }}</a>
           </div>
           {% endif %}
         </div>

--- a/app/templates/htmx/partials/sightings/activity_section.html
+++ b/app/templates/htmx/partials/sightings/activity_section.html
@@ -31,7 +31,7 @@
     <div>
       <label class="block text-xs font-medium text-gray-600 uppercase tracking-wider mb-1">Channel</label>
       <select name="channel"
-              class="w-full rounded-md border-gray-300 text-xs py-1.5 px-2 focus:border-brand-400 focus:ring-brand-400">
+              class="input input-sm">
         <option value="note">Note</option>
         <option value="call">Call</option>
         <option value="email">Email</option>
@@ -43,7 +43,7 @@
       <input type="text"
              name="vendor_name"
              placeholder="e.g. Arrow Electronics"
-             class="w-full rounded-md border-gray-300 text-xs py-1.5 px-2 placeholder-gray-400 focus:border-brand-400 focus:ring-brand-400">
+             class="input input-sm">
     </div>
 
     <div>
@@ -52,13 +52,13 @@
                 rows="3"
                 required
                 placeholder="What happened?"
-                class="w-full rounded-md border-gray-300 text-xs py-1.5 px-2 placeholder-gray-400 focus:border-brand-400 focus:ring-brand-400 resize-none"></textarea>
+                class="input input-sm resize-none"></textarea>
     </div>
 
     <div class="flex justify-end">
       <button type="submit"
               data-loading-disable
-              class="inline-flex items-center gap-1 px-3 py-1.5 rounded-md bg-brand-600 text-white text-xs font-medium hover:bg-brand-700 transition-colors">
+              class="btn-primary btn-sm">
         <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/>
         </svg>

--- a/app/templates/htmx/partials/sightings/detail.html
+++ b/app/templates/htmx/partials/sightings/detail.html
@@ -28,15 +28,15 @@
   <div class="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
     <div>
       <span class="text-gray-400">Qty:</span>
-      <span class="font-mono text-gray-700">{{ requirement.target_qty or '—' }}</span>
+      <span class="font-mono text-sm font-semibold text-gray-800">{{ requirement.target_qty or '—' }}</span>
     </div>
     <div>
       <span class="text-gray-400">Target:</span>
-      <span class="font-mono text-gray-700">{{ '$%.2f'|format(requirement.target_price) if requirement.target_price else '—' }}</span>
+      <span class="figure-accent text-sm font-semibold">{{ '$%.2f'|format(requirement.target_price) if requirement.target_price else '—' }}</span>
     </div>
     <div>
       <span class="text-gray-400">Customer:</span>
-      <a href="/v2/requisitions/{{ requisition.id }}" class="text-brand-600 hover:underline">
+      <a href="/v2/requisitions/{{ requisition.id }}" class="text-accent-600 hover:underline">
         {{ requisition.customer_name or '—' }}
       </a>
     </div>
@@ -57,7 +57,7 @@
               hx-swap="innerHTML"
               data-loading-disable
               name="status"
-              class="inline-block border-0 border-b border-dashed border-gray-300 bg-transparent text-xs {{ status_styles.get(requirement.sourcing_status or 'open', 'text-gray-700') }} p-0 pr-4 focus:ring-0 cursor-pointer hover:border-brand-400">
+              class="inline-block border-0 border-b border-dashed border-gray-300 bg-transparent text-xs {{ status_styles.get(requirement.sourcing_status or 'open', 'text-gray-700') }} p-0 pr-4 focus:ring-0 cursor-pointer hover:border-accent-400">
         <option value="{{ requirement.sourcing_status or 'open' }}" selected>
           {{ (requirement.sourcing_status or 'open')|capitalize }}
         </option>
@@ -82,7 +82,7 @@
       {% for tab_id, tab_label in [('vendors', 'Vendors'), ('offers', 'Offers'), ('activity', 'Activity')] %}
       <button @click="activeTab = '{{ tab_id }}'"
               type="button"
-              :class="activeTab === '{{ tab_id }}' ? 'border-brand-500 text-brand-500' : 'border-transparent text-gray-500 hover:text-gray-900 hover:border-gray-200'"
+              :class="activeTab === '{{ tab_id }}' ? 'border-accent-600 text-accent-600' : 'border-transparent text-gray-500 hover:text-gray-900 hover:border-gray-200'"
               class="py-2 px-1 text-xs font-medium border-b-2 transition-colors whitespace-nowrap">
         {{ tab_label }}
       </button>
@@ -130,7 +130,7 @@
     </div>
     {% if extra_count > 0 %}
     <button @click="vendorsExpanded = !vendorsExpanded"
-            class="w-full mt-1 py-1.5 text-xs text-brand-600 hover:text-brand-800 font-medium text-center transition-colors">
+            class="w-full mt-1 py-1.5 text-xs text-accent-600 hover:text-accent-800 font-medium text-center transition-colors">
       <span x-text="vendorsExpanded ? 'Show less' : 'Show {{ extra_count }} more vendor{{ 's' if extra_count != 1 }}'"></span>
     </button>
     {% endif %}

--- a/app/templates/htmx/partials/sightings/list.html
+++ b/app/templates/htmx/partials/sightings/list.html
@@ -137,8 +137,8 @@
   </div>
 
   {# ── Drag Handle (desktop only) ────────────────────────────── #}
-  <div class="hidden lg:block w-[3px] cursor-col-resize bg-gray-200 hover:bg-brand-400 transition-colors flex-shrink-0 relative group"
-       :class="dragging ? 'bg-brand-500' : ''"
+  <div class="hidden lg:block w-[3px] cursor-col-resize bg-gray-200 hover:bg-accent-400 transition-colors flex-shrink-0 relative group"
+       :class="dragging ? 'bg-accent-500' : ''"
        @mousedown="startDrag($event)">
     <div class="absolute inset-y-0 -left-2 -right-2"></div>
     <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -156,7 +156,7 @@
     {# Mobile back button #}
     <button x-show="mobileDetailOpen" x-cloak
             @click="closeMobileDetail()"
-            class="lg:hidden flex items-center gap-1 px-3 py-2 text-xs font-medium text-brand-600 border-b border-gray-100">
+            class="lg:hidden flex items-center gap-1 px-3 py-2 text-xs font-medium text-accent-600 border-b border-gray-100">
       <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
       </svg>

--- a/app/templates/htmx/partials/sightings/offer_form_modal.html
+++ b/app/templates/htmx/partials/sightings/offer_form_modal.html
@@ -28,7 +28,7 @@
     <div>
       <label class="block text-xs text-gray-500 mb-1">Notes</label>
       <textarea name="notes" rows="2"
-                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
+                class="input resize-none"
                 placeholder="Any additional details...">{{ prefill.get('notes', '') if prefill else '' }}</textarea>
     </div>
 

--- a/app/templates/htmx/partials/sightings/qual_request_modal.html
+++ b/app/templates/htmx/partials/sightings/qual_request_modal.html
@@ -25,7 +25,7 @@
     <div>
       <label class="block text-xs text-gray-500 mb-1">Notes</label>
       <textarea name="notes" rows="2"
-                class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"
+                class="input resize-none"
                 placeholder="Any additional details...">{{ prefill.get('notes', '') if prefill else '' }}</textarea>
     </div>
     <div class="flex justify-end gap-2 pt-1">

--- a/app/templates/htmx/partials/sightings/table.html
+++ b/app/templates/htmx/partials/sightings/table.html
@@ -51,9 +51,9 @@
     {% for val, label, count in pills %}
     <button hx-get="/v2/partials/sightings?status={{ val }}&q={{ q }}&group_by={{ group_by }}&manufacturer={{ manufacturer|default('') }}"
             hx-target="#sightings-table" hx-swap="innerHTML"
-            class="px-2 py-0.5 rounded text-[10px] font-medium transition-colors
+            class="px-2 py-0.5 rounded text-[11px] font-medium transition-colors
                    {{ 'bg-brand-100 text-brand-700' if status == val else 'text-gray-400 hover:text-gray-600' }}">
-      {{ label }} <span class="text-[9px]">{{ count }}</span>
+      {{ label }} <span class="text-[11px]">{{ count }}</span>
     </button>
     {% endfor %}
   </div>
@@ -69,7 +69,7 @@
          hx-trigger="keyup changed delay:300ms"
          hx-target="#sightings-table"
          :hx-vals="JSON.stringify({status: sStatus, group_by: sGroupBy, manufacturer: sManufacturer})"
-         class="flex-1 min-w-[150px] rounded-lg border border-gray-200 px-3 py-1.5 text-sm focus:border-brand-400 focus:ring-1 focus:ring-brand-200 outline-none">
+         class="input flex-1 min-w-[150px]">
   <input aria-label="Filter by manufacturer" type="text" name="manufacturer" value="{{ manufacturer|default('') }}"
          placeholder="Manufacturer..."
          x-model="sManufacturer"
@@ -77,7 +77,7 @@
          hx-trigger="keyup changed delay:300ms"
          hx-target="#sightings-table"
          :hx-vals="JSON.stringify({status: sStatus, group_by: sGroupBy, q: sQ})"
-         class="w-[140px] rounded-lg border border-gray-200 px-3 py-1.5 text-sm focus:border-brand-400 focus:ring-2 focus:ring-brand-200 outline-none">
+         class="input w-[140px]">
   <select name="group_by" x-model="sGroupBy"
           hx-get="/v2/partials/sightings"
           hx-trigger="change"
@@ -120,19 +120,19 @@
   <table class="compact-table w-full">
     <thead>
       <tr>
-        <th class="px-2 py-2 w-8">
+        <th class="w-8">
           <input aria-label="Select all requirements" type="checkbox" x-model="toggleAll"
                  @change="document.querySelectorAll('.req-checkbox').forEach(cb => { cb.checked = toggleAll; if (toggleAll) $store.sightingSelection.toggle(parseInt(cb.value)); else $store.sightingSelection.clear(); })"
                  class="rounded border-gray-300">
         </th>
-        <th class="px-3 py-2 text-left">Part Numbers</th>
-        <th class="px-3 py-2 text-left hidden sm:table-cell">Description</th>
-        <th class="px-3 py-2 text-right w-[60px] hidden sm:table-cell">Qty</th>
-        <th class="px-3 py-2 text-left hidden xl:table-cell">Customer</th>
-        <th class="px-3 py-2 text-left w-[80px] hidden xl:table-cell">Sales</th>
-        <th class="px-3 py-2 text-left w-[80px]">Coverage</th>
-        <th class="px-3 py-2 text-left w-[80px]">Status</th>
-        <th class="px-3 py-2 text-center w-[60px] hidden xl:table-cell">Priority</th>
+        <th class="text-left">Part Numbers</th>
+        <th class="text-left hidden sm:table-cell">Description</th>
+        <th class="text-right w-[60px] hidden sm:table-cell">Qty</th>
+        <th class="text-left hidden xl:table-cell">Customer</th>
+        <th class="text-left w-[80px] hidden xl:table-cell">Sales</th>
+        <th class="text-left w-[80px]">Coverage</th>
+        <th class="text-left w-[80px]">Status</th>
+        <th class="text-center w-[60px] hidden xl:table-cell">Priority</th>
       </tr>
     </thead>
     <tbody>
@@ -145,25 +145,29 @@
       <tr class="group cursor-pointer {{ 'bg-rose-50/30' if is_hot else '' }}"
           :class="selectedReqId == {{ r.id }} ? 'row-selected' : ''"
           @click="selectReq({{ r.id }})"
+          @keydown.enter="selectReq({{ r.id }})"
+          @keydown.space.prevent="selectReq({{ r.id }})"
+          tabindex="0"
+          role="button"
           data-req-id="{{ r.id }}">
-        <td class="px-2 py-2" @click.stop>
+        <td @click.stop>
           <input aria-label="Select requirement {{ r.primary_mpn }}" type="checkbox" class="req-checkbox rounded border-gray-300" value="{{ r.id }}"
                  :checked="$store.sightingSelection.has({{ r.id }})"
                  @change="$store.sightingSelection.toggle({{ r.id }})">
         </td>
-        <td class="px-3 py-2">
+        <td>
           {{ mpn_chips(r, link_map=link_map) }}
         </td>
         {% set desc = r|part_description %}
-        <td class="px-3 py-2 text-sm text-gray-600 truncate max-w-[180px] hidden sm:table-cell" title="{{ desc }}">{{ desc or '—' }}</td>
-        <td class="px-3 py-2 text-right font-mono hidden sm:table-cell">{{ r.target_qty or '—' }}</td>
-        <td class="px-3 py-2 text-gray-600 truncate max-w-[140px] hidden xl:table-cell">
+        <td class="text-sm text-gray-600 truncate max-w-[180px] hidden sm:table-cell" title="{{ desc }}">{{ desc or '—' }}</td>
+        <td class="text-right font-mono hidden sm:table-cell">{{ r.target_qty or '—' }}</td>
+        <td class="text-gray-600 truncate max-w-[140px] hidden xl:table-cell">
           {{ r.requisition.customer_name or '—' }}
         </td>
-        <td class="px-3 py-2 text-gray-600 text-xs truncate hidden xl:table-cell">
+        <td class="text-gray-600 text-xs truncate hidden xl:table-cell">
           {{ r.requisition.creator.name if r.requisition.creator else '—' }}
         </td>
-        <td class="px-3 py-2 coverage-cell"
+        <td class="coverage-cell"
             x-data="{ refreshing: false }"
             :class="refreshing ? 'opacity-60' : ''">
           <div class="relative flex items-center gap-1">
@@ -187,13 +191,13 @@
             </button>
           </div>
         </td>
-        <td class="px-3 py-2">
+        <td>
           <div class="flex items-center gap-1.5">
             <span class="transition-colors duration-200">{{ m.status_badge(r.sourcing_status) }}</span>
             {# Hover-revealed quick Build RFQ button — @click.stop so it doesn't
                select the row; mirrors the refresh icon-button pattern above #}
             <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/vendor-modal?requirement_ids={{ r.id }}'})"
-                    class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-300 hover:text-brand-600"
+                    class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-300 hover:text-accent-600"
                     title="Build RFQ for this part">
               <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
@@ -201,11 +205,11 @@
             </button>
           </div>
         </td>
-        <td class="px-3 py-2 text-center hidden xl:table-cell">
+        <td class="text-center hidden xl:table-cell">
           {% if r.priority_score %}
             {% set pri = r.priority_score %}
             {% set pri_label = 'High' if pri >= 70 else ('Med' if pri >= 40 else 'Low') %}
-            <span class="inline-flex px-1.5 py-0.5 text-[10px] font-semibold rounded-full {{ 'bg-rose-50 text-rose-700' if pri >= 70 else ('bg-amber-50 text-amber-700' if pri >= 40 else 'bg-gray-100 text-gray-500') }}">{{ pri_label }}</span>
+            <span class="chip {{ 'bg-rose-50 text-rose-700 border-rose-200' if pri >= 70 else ('bg-amber-50 text-amber-700 border-amber-200' if pri >= 40 else 'bg-gray-100 text-gray-500 border-gray-200') }}">{{ pri_label }}</span>
           {% endif %}
         </td>
       </tr>
@@ -248,7 +252,7 @@
     {% set cov_pct = ((cov_qty / r.target_qty * 100) if r.target_qty and r.target_qty > 0 else 0)|int %}
     {% set cov_pct = [cov_pct, 100]|min %}
     <div class="bg-white border border-gray-200 rounded-lg p-3 sightings-slide-up cursor-pointer"
-         :class="selectedReqId == {{ r.id }} ? 'ring-2 ring-brand-300' : ''"
+         :class="selectedReqId == {{ r.id }} ? 'ring-2 ring-accent-300' : ''"
          @click="selectReq({{ r.id }})">
       <div class="flex items-center justify-between mb-1.5">
         <div class="flex-1 min-w-0">{{ mpn_chips(r, link_map=link_map) }}</div>
@@ -265,7 +269,7 @@
         </div>
         <span class="text-[10px] text-gray-400 w-7 text-right">{{ cov_pct }}%</span>
         <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/vendor-modal?requirement_ids={{ r.id }}'})"
-                class="inline-flex items-center justify-center min-w-[24px] min-h-[24px] text-gray-400 hover:text-brand-600 transition-colors"
+                class="inline-flex items-center justify-center min-w-[24px] min-h-[24px] text-gray-400 hover:text-accent-600 transition-colors"
                 title="Build RFQ for this part">
           <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>

--- a/app/templates/htmx/partials/sightings/table.html
+++ b/app/templates/htmx/partials/sightings/table.html
@@ -52,7 +52,7 @@
     <button hx-get="/v2/partials/sightings?status={{ val }}&q={{ q }}&group_by={{ group_by }}&manufacturer={{ manufacturer|default('') }}"
             hx-target="#sightings-table" hx-swap="innerHTML"
             class="px-2 py-0.5 rounded text-[11px] font-medium transition-colors
-                   {{ 'bg-brand-100 text-brand-700' if status == val else 'text-gray-400 hover:text-gray-600' }}">
+                   {{ 'bg-accent-100 text-accent-700' if status == val else 'text-gray-400 hover:text-gray-600' }}">
       {{ label }} <span class="text-[11px]">{{ count }}</span>
     </button>
     {% endfor %}
@@ -310,7 +310,7 @@
        x-transition:leave="transition ease-in duration-150"
        x-transition:leave-start="translate-y-0 opacity-100"
        x-transition:leave-end="translate-y-full opacity-0"
-       class="sticky bottom-0 bg-white border-t border-brand-200 px-3 py-2 flex items-center gap-3 shadow-lg">
+       class="sticky bottom-0 bg-white border-t border-accent-200 px-3 py-2 flex items-center gap-3 shadow-lg">
     <span class="text-xs font-medium text-gray-600" x-text="$store.sightingSelection.count + ' selected'"></span>
     <span x-show="$store.sightingSelection.count > visibleSelectedCount && visibleSelectedCount > 0"
           x-cloak

--- a/app/templates/htmx/partials/sightings/unavailable_form.html
+++ b/app/templates/htmx/partials/sightings/unavailable_form.html
@@ -49,7 +49,7 @@
         <label class="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-50 cursor-pointer">
           <input type="radio" name="reason" value="{{ reason.value }}" required
                  {% if current and current.reason == reason.value %}checked{% endif %}
-                 class="border-gray-300 text-brand-600 focus:ring-brand-500">
+                 class="border-gray-300 text-accent-600 focus:ring-accent-500">
           <span class="text-sm text-gray-700">{{ reason.label }}</span>
         </label>
         {% endfor %}

--- a/app/templates/htmx/partials/sightings/vendor_modal.html
+++ b/app/templates/htmx/partials/sightings/vendor_modal.html
@@ -44,7 +44,7 @@
             <span class="text-sm font-medium text-gray-700">{{ v.display_name }}</span>
             {% set cov = coverage.get(v.id) %}
             {% if cov %}
-            <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700"
+            <span class="chip ml-2 bg-indigo-50 text-indigo-700 border-indigo-200"
                   title="Covers: {{ cov.mpns }}">{{ cov.count }}/{{ parts|length }} parts</span>
             {% endif %}
             {% if v.response_rate %}
@@ -82,11 +82,11 @@
             <span class="text-sm font-medium text-gray-500">{{ v.display_name }}</span>
             {% set cov = coverage.get(v.id) %}
             {% if cov %}
-            <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700"
+            <span class="chip ml-2 bg-indigo-50 text-indigo-700 border-indigo-200"
                   title="Covers: {{ cov.mpns }}">{{ cov.count }}/{{ parts|length }} parts</span>
             {% endif %}
             {# Shared color-coded badge component — rose for DNC (compliance: must not send) #}
-            <span class="ml-2 inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-rose-50 text-rose-700">
+            <span class="chip ml-2 bg-rose-50 text-rose-700 border-rose-200">
               <svg class="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M13.477 14.89A6 6 0 015.11 6.524L13.477 14.89zm1.414-1.414L6.524 5.11A6 6 0 0114.89 13.476zM18 10a8 8 0 11-16 0 8 8 0 0116 0z" clip-rule="evenodd"/>
               </svg>
@@ -107,15 +107,15 @@
             <span class="text-sm font-medium text-gray-500">{{ v.display_name }}</span>
             {% set cov = coverage.get(v.id) %}
             {% if cov %}
-            <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-indigo-50 text-indigo-700"
+            <span class="chip ml-2 bg-indigo-50 text-indigo-700 border-indigo-200"
                   title="Covers: {{ cov.mpns }}">{{ cov.count }}/{{ parts|length }} parts</span>
             {% endif %}
-            {# Amber badge for no-email — shared badge component vocabulary #}
-            <span class="ml-2 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-gray-100 text-gray-500">no contact on file</span>
+            {# Neutral badge for no-email — shared chip vocabulary #}
+            <span class="chip ml-2 bg-gray-100 text-gray-500 border-gray-200">no contact on file</span>
             {% if v.lead_time_days is not none %}<span class="ml-2 text-xs text-gray-400">{{ v.lead_time_days }}d lead</span>{% endif %}
           </div>
           <button type="button" @click='addContactFor({{ v.display_name|tojson }})'
-                  class="text-xs font-semibold text-brand-600 hover:text-brand-700">
+                  class="text-xs font-semibold text-accent-600 hover:text-accent-700">
             Add contact
           </button>
         </label>
@@ -137,7 +137,7 @@
                 hx-target="#rfq-affinity-section"
                 hx-swap="innerHTML"
                 hx-indicator="#rfq-affinity-spinner"
-                class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-brand-200 text-brand-700 text-xs font-medium rounded-lg hover:bg-brand-50 transition-colors">
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white border border-accent-200 text-accent-700 text-xs font-medium rounded-lg hover:bg-accent-50 transition-colors">
           <span id="rfq-affinity-spinner" class="htmx-indicator">
             <svg class="h-3.5 w-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -173,12 +173,12 @@
                placeholder="Find any vendor..."
                autocomplete="off"
                aria-label="Find any vendor"
-               class="w-full px-3 py-1.5 border border-gray-200 rounded-lg text-sm focus:border-brand-400 focus:ring-1 focus:ring-brand-200 outline-none">
+               class="input">
         <div x-show="searchOpen" x-cloak
              class="absolute z-50 left-0 right-0 mt-1 max-h-40 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg">
           <template x-for="v in vendorResults" :key="v.id">
             <button type="button" @click="pickVendor(v.name)"
-                    class="w-full text-left px-3 py-1.5 text-sm text-gray-700 hover:bg-brand-50 hover:text-brand-700 truncate"
+                    class="w-full text-left px-3 py-1.5 text-sm text-gray-700 hover:bg-accent-50 hover:text-accent-700 truncate"
                     x-text="v.name"></button>
           </template>
           <div x-show="vendorResults.length === 0" x-cloak
@@ -190,7 +190,7 @@
          modal's "+ New Customer" pattern) — POSTs to the same composer-vendor
          endpoint via createVendor(). #}
       <button type="button" @click="addingVendor = !addingVendor"
-              class="mt-2 text-xs font-semibold text-brand-600 hover:text-brand-700">
+              class="mt-2 text-xs font-semibold text-accent-600 hover:text-accent-700">
         + Add new vendor
       </button>
       <div x-show="addingVendor" x-cloak
@@ -201,11 +201,11 @@
                   class="text-xs text-gray-400 hover:text-gray-600">Cancel</button>
         </div>
         <input aria-label="Vendor name" type="text" x-model="newVendorName" placeholder="Vendor name *"
-               class="w-full px-2 py-1 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-brand-500">
+               class="input input-sm">
         <input aria-label="Website" type="url" x-model="newVendorWebsite" placeholder="Website (optional)"
-               class="w-full px-2 py-1 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-brand-500">
+               class="input input-sm">
         <input aria-label="Contact email" type="email" x-ref="newVendorEmail" x-model="newVendorEmail" placeholder="Contact email (optional)"
-               class="w-full px-2 py-1 text-sm border border-gray-200 rounded focus:ring-1 focus:ring-brand-500">
+               class="input input-sm">
         <button type="button" :disabled="!newVendorName.trim() || addingVendorBusy"
                 @click="createVendor()"
                 class="btn-primary btn-sm">
@@ -218,7 +218,7 @@
     <div class="mb-4">
       <label class="block text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">Parts</label>
       {% if requisition_count is defined and requisition_count > 1 %}
-      <p class="text-xs text-brand-600 mt-0.5 mb-1">Spanning {{ requisition_count }} requisitions</p>
+      <p class="text-xs text-accent-600 mt-0.5 mb-1">Spanning {{ requisition_count }} requisitions</p>
       {% endif %}
       <div class="text-xs text-gray-600 bg-gray-50 rounded-lg p-2 max-h-24 overflow-y-auto font-mono">
         {% for p in parts %}
@@ -269,18 +269,18 @@
         <label class="text-xs font-medium text-gray-500 uppercase tracking-wider">Message</label>
       </div>
       <textarea x-model="emailBody" rows="5" placeholder="Write your inquiry..."
-                class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-brand-400 focus:ring-1 focus:ring-brand-200 outline-none"></textarea>
+                class="input"></textarea>
     </div>
 
     {# Actions #}
     <div class="flex justify-end gap-2">
       <button @click="$dispatch('close-modal')"
-              class="px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 rounded-lg transition-colors">
+              class="btn-secondary">
         Cancel
       </button>
       <button @click="loadPreview()"
               :disabled="selectedCount === 0 || !emailBody || previewing"
-              class="px-4 py-2 text-sm font-medium text-brand-600 bg-brand-50 hover:bg-brand-100 border border-brand-200 rounded-lg transition-colors disabled:bg-gray-100 disabled:text-gray-400 disabled:border-gray-200">
+              class="btn-secondary disabled:opacity-50">
         <span x-show="!previewing" x-cloak>
           Preview <span x-text="selectedCount"></span> Email<span x-show="selectedCount !== 1" x-cloak>s</span>
         </span>
@@ -288,7 +288,7 @@
       </button>
       <button @click="confirmSend()"
               :disabled="selectedCount === 0 || !emailBody || sending"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 hover:bg-brand-600 rounded-lg transition-colors disabled:bg-gray-300">
+              class="btn-primary disabled:opacity-50">
         Send to <span x-text="selectedCount"></span> Vendor<span x-show="selectedCount !== 1" x-cloak>s</span>
       </button>
     </div>
@@ -313,12 +313,12 @@
     {# Actions #}
     <div class="flex justify-between gap-2 border-t border-gray-100 pt-3 flex-shrink-0">
       <button @click="step = 'compose'"
-              class="px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 rounded-lg transition-colors">
+              class="btn-secondary">
         &larr; Back to Edit
       </button>
       <button @click="confirmSend()"
               :disabled="sending"
-              class="px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg transition-colors disabled:bg-gray-300">
+              class="btn-primary disabled:opacity-50">
         <span x-show="!sending" x-cloak>Confirm &amp; Send</span>
         <span x-show="sending" x-cloak>Sending...</span>
       </button>

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -707,7 +707,9 @@ class TestVendorRowThreeStates:
         # Normal row, NO tint; bordered emerald-50 chip (distinct from offer-in solid 100)
         assert "bg-rose-50/60" not in body
         assert "Possible restock" in body
-        assert "bg-emerald-50 text-emerald-700 border border-emerald-200" in body
+        # F9 sweep moved badge to .chip primitive; border is applied via @apply in .chip CSS.
+        # The HTML class attr is: chip bg-emerald-50 text-emerald-700 border-emerald-200
+        assert "chip bg-emerald-50 text-emerald-700 border-emerald-200" in body
         # qty delta old → new in emerald mono + compressed history echo
         assert "100 → 200" in body
         assert 'class="font-mono text-emerald-600"' in body


### PR DESCRIPTION
## What

Phase 3 UI program — the **Sightings** page cluster (`sightings/`). Implements all 12 findings from the total UI audit (key `sightings`).

## Changes (12/12 findings)

- **Form controls → `.input`** — filter bar (Search MPN, Manufacturer), activity-log channel/vendor/notes, offer/qual modal fields, add-vendor inputs. Moves every focus ring from brand to the azure accent + unifies radius.
- **RFQ-send flow on accent** — "Send to N Vendors" / "Confirm & Send" → `.btn-primary`; Cancel/Back/Preview → `.btn-secondary`.
- **Accent interactive states** — active tab indicator, customer link, status-select hover, per-vendor Build-RFQ pill, phone links → `accent-*`.
- **Badges** — vendor/offer/OOO/overlap/sub-MPN/request-status pills → `.chip` primitive (color maps via border).
- **Density** — dead inline `px-*/py-*` stripped from `.compact-table` cells; priority strip → `.chip`.
- **Hierarchy** — Qty/Target values emphasized; Target price → `.figure-accent`.
- **a11y** — requirement `<tr>` rows keyboard-navigable (`tabindex`/`role`/`@keydown.enter`+`space`); mobile selected-state ring → accent.

Files: 8 templates (`table.html`, `vendor_modal.html`, `activity_section.html`, `detail.html`, `_vendor_row.html`, `_offer_row.html`, `offer_form_modal.html`, `qual_request_modal.html`).

## Verification
CI gates merge. Visual sign-off is part of the consolidated local deploy-for-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_