### PR TITLE
feat(ui): Search Dossier foundation conformance — .btn-primary/.input sweep, .figure-accent, hairlines

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -610,10 +610,10 @@ table {
 }
 /* Count-tile label (uppercase micro caption under each mono numeral). */
 .count-tile dt {
-    font-size: 0.62rem;
+    font-size: 0.6875rem; /* 11px — meets the PR0 readability floor */
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: #838B9B;
+    @apply text-gray-500; /* token-backed; replaces hardcoded #838B9B */
 }
 /* Rotating section chevron. */
 .chev { transition: transform 0.2s ease; }

--- a/app/templates/htmx/partials/search/dossier_hero.html
+++ b/app/templates/htmx/partials/search/dossier_hero.html
@@ -45,7 +45,7 @@
               <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>FRU crosswalk
             </span>
           {% endif %}
-          {% if card.category %}<span class="rounded-md bg-brand-50 px-2 py-0.5 text-[11px] font-medium text-brand-700">{{ card.category }}</span>{% endif %}
+          {% if card.category %}<span class="rounded-md bg-accent-50 px-2 py-0.5 text-[11px] font-medium text-accent-700">{{ card.category }}</span>{% endif %}
           {% set lc = (card.lifecycle_status or '')|lower %}
           {% if card.lifecycle_status %}
           <span class="rounded-md px-2 py-0.5 text-[11px] font-medium border
@@ -115,8 +115,7 @@
         {% if history.buyers %}
         <div class="mt-2 flex items-center -space-x-1.5">
           {% for b in history.buyers[:3] %}
-          {# text-[10px] meets the 11px-floor exception for decorative non-text initials in a 20px circle #}
-          <span class="h-5 w-5 rounded-full bg-brand-100 text-brand-700 grid place-items-center text-[10px] font-semibold ring-2 ring-white" title="{{ b.name or b.email }}">{{ (b.name or b.email)[:2]|upper }}</span>
+          <span class="h-5 w-5 rounded-full bg-accent-100 text-accent-700 grid place-items-center text-[11px] font-semibold ring-2 ring-white" title="{{ b.name or b.email }}">{{ (b.name or b.email)[:2]|upper }}</span>
           {% endfor %}
           <span class="text-xs text-gray-400 pl-2.5">{{ history.buyers|length }} buyer{{ '' if history.buyers|length == 1 else 's' }}</span>
         </div>

--- a/app/templates/htmx/partials/search/dossier_hero.html
+++ b/app/templates/htmx/partials/search/dossier_hero.html
@@ -45,7 +45,7 @@
               <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>FRU crosswalk
             </span>
           {% endif %}
-          {% if card.category %}<span class="rounded-md bg-blue-50 px-2 py-0.5 text-[11px] font-medium text-blue-700">{{ card.category }}</span>{% endif %}
+          {% if card.category %}<span class="rounded-md bg-brand-50 px-2 py-0.5 text-[11px] font-medium text-brand-700">{{ card.category }}</span>{% endif %}
           {% set lc = (card.lifecycle_status or '')|lower %}
           {% if card.lifecycle_status %}
           <span class="rounded-md px-2 py-0.5 text-[11px] font-medium border
@@ -72,15 +72,16 @@
       </div>
 
       {# Zone B — market price strip + sparkline #}
-      <div class="lg:w-[200px] lg:border-l lg:border-brand-100 lg:pl-5 shrink-0">
+      <div class="lg:w-[200px] lg:border-l border-line-subtle lg:pl-5 shrink-0">
         <p class="text-xs uppercase tracking-wide text-gray-400 font-semibold">Market price</p>
         {% if pt %}
         <div class="mt-1 flex items-baseline gap-1.5">
-          <span class="font-mono text-2xl font-bold text-brand-900">${{ (pt.last_price if pt.last_price is not none else pt.min_price)|pricefmt }}</span>
+          {# figure-accent: tabular-nums + accent color for the decision-driving numeral #}
+          <span class="font-mono text-2xl font-bold figure-accent">${{ (pt.last_price if pt.last_price is not none else pt.min_price)|pricefmt }}</span>
           <span class="text-xs text-gray-400">last</span>
         </div>
         <p class="font-mono text-xs text-gray-600 mt-0.5">${{ pt.min_price|pricefmt }} – ${{ pt.max_price|pricefmt }}</p>
-        {# Sparkline from min/last/max — a 3-point glanceable trend (no axes). #}
+        {# Sparkline from min/last/max — a 3-point glanceable trend (no axes). currentColor via text-brand-400 wrapper. #}
         {% set lo = pt.min_price|float %}
         {% set hi = pt.max_price|float %}
         {% set last = (pt.last_price if pt.last_price is not none else pt.max_price)|float %}
@@ -88,9 +89,9 @@
         {% set y_lo = 30 - ((lo - lo) / span) * 28 %}
         {% set y_hi = 30 - ((hi - lo) / span) * 28 %}
         {% set y_last = 30 - ((last - lo) / span) * 28 %}
-        <svg viewBox="0 0 120 32" class="mt-2 w-full h-8" preserveAspectRatio="none">
-          <polyline fill="none" stroke="#838B9B" stroke-width="1.5" points="0,{{ '%.1f'|format(y_lo) }} 60,{{ '%.1f'|format(y_hi) }} 120,{{ '%.1f'|format(y_last) }}"/>
-          <circle cx="120" cy="{{ '%.1f'|format(y_last) }}" r="2" fill="#4B5463"/>
+        <svg viewBox="0 0 120 32" class="mt-2 w-full h-8 text-brand-400" preserveAspectRatio="none">
+          <polyline fill="none" stroke="currentColor" stroke-width="1.5" points="0,{{ '%.1f'|format(y_lo) }} 60,{{ '%.1f'|format(y_hi) }} 120,{{ '%.1f'|format(y_last) }}"/>
+          <circle cx="120" cy="{{ '%.1f'|format(y_last) }}" r="2" fill="currentColor"/>
         </svg>
         <p class="text-xs text-gray-400 mt-1">{{ pt.currency }} · min–max–last</p>
         {% else %}
@@ -102,18 +103,20 @@
       </div>
 
       {# Zone C — knowledge counts #}
-      <div class="lg:w-[150px] lg:border-l lg:border-brand-100 lg:pl-5 shrink-0">
+      <div class="lg:w-[150px] lg:border-l border-line-subtle lg:pl-5 shrink-0">
         <p class="text-xs uppercase tracking-wide text-gray-400 font-semibold mb-2">What we know</p>
         <div class="grid grid-cols-2 gap-x-3 gap-y-2 count-tile">
-          <div><div class="font-mono text-lg font-bold leading-none {{ 'text-brand-900' if history.offers_count else 'text-gray-300' }}">{{ history.offers_count }}</div><dt>Offers</dt></div>
+          {# figure-accent on non-zero counts; gray-300 for zero/empty — buyers scan these first #}
+          <div><div class="font-mono text-lg font-bold leading-none {{ 'figure-accent' if history.offers_count else 'text-gray-300' }}">{{ history.offers_count }}</div><dt>Offers</dt></div>
           <div><div class="font-mono text-lg font-bold leading-none {{ 'text-emerald-600' if history.confirmed_count else 'text-gray-300' }}">{{ history.confirmed_count }}</div><dt>Won</dt></div>
-          <div><div class="font-mono text-lg font-bold leading-none {{ 'text-brand-900' if history.sightings_count else 'text-gray-300' }}">{{ history.sightings_count }}</div><dt>Sightings</dt></div>
-          <div><div class="font-mono text-lg font-bold leading-none {{ 'text-brand-900' if history.requirements_count else 'text-gray-300' }}">{{ history.requirements_count }}</div><dt>Reqs</dt></div>
+          <div><div class="font-mono text-lg font-bold leading-none {{ 'figure-accent' if history.sightings_count else 'text-gray-300' }}">{{ history.sightings_count }}</div><dt>Sightings</dt></div>
+          <div><div class="font-mono text-lg font-bold leading-none {{ 'figure-accent' if history.requirements_count else 'text-gray-300' }}">{{ history.requirements_count }}</div><dt>Reqs</dt></div>
         </div>
         {% if history.buyers %}
         <div class="mt-2 flex items-center -space-x-1.5">
           {% for b in history.buyers[:3] %}
-          <span class="h-5 w-5 rounded-full bg-blue-100 text-blue-700 grid place-items-center text-[9px] font-semibold ring-2 ring-white" title="{{ b.name or b.email }}">{{ (b.name or b.email)[:2]|upper }}</span>
+          {# text-[10px] meets the 11px-floor exception for decorative non-text initials in a 20px circle #}
+          <span class="h-5 w-5 rounded-full bg-brand-100 text-brand-700 grid place-items-center text-[10px] font-semibold ring-2 ring-white" title="{{ b.name or b.email }}">{{ (b.name or b.email)[:2]|upper }}</span>
           {% endfor %}
           <span class="text-xs text-gray-400 pl-2.5">{{ history.buyers|length }} buyer{{ '' if history.buyers|length == 1 else 's' }}</span>
         </div>
@@ -129,16 +132,16 @@
       Actions create a quick-source requisition and capture the live results below.
     </p>
     <div class="flex items-center gap-2">
-      {# Send RFQ — primary. POSTs the shortlisted rows (endpoint lands in the next task). #}
+      {# Send RFQ — primary CTA migrated to .btn-primary (accent token + accent focus ring). #}
       <button type="button" @click="sendRfq()"
-              class="px-4 py-2 rounded-lg bg-brand-600 text-white text-sm font-semibold hover:bg-brand-700 transition-colors inline-flex items-center gap-2 shadow-sm">
+              class="btn-primary shadow-sm inline-flex items-center gap-2">
         <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M3 11l18-8-8 18-2-7-8-3z"/></svg>Send RFQ
       </button>
       <button type="button" @click="addOffer()"
-              class="px-4 py-2 rounded-lg bg-white border border-brand-300 text-brand-700 text-sm font-medium hover:bg-brand-50 transition-colors">Add Offer</button>
+              class="btn-secondary">Add Offer</button>
       {# Add to Requisition — intentional (non-scratch) path: existing requisition picker in the global modal. #}
       <button type="button" @click="addToReq()"
-              class="px-4 py-2 rounded-lg bg-white border border-brand-300 text-brand-700 text-sm font-medium hover:bg-brand-50 transition-colors inline-flex items-center gap-1.5">
+              class="btn-secondary inline-flex items-center gap-1.5">
         Add to Requisition
       </button>
       {# overflow #}

--- a/app/templates/htmx/partials/search/dossier_shell.html
+++ b/app/templates/htmx/partials/search/dossier_shell.html
@@ -19,11 +19,12 @@
     <form class="flex flex-1 items-center gap-2"
           x-data="{ q: '{{ mpn|default('') }}' }"
           @submit.prevent="const v=q.trim(); if(v){ const u='/v2/partials/search?mpn='+encodeURIComponent(v); htmx.ajax('GET', u, {target:'#main-content', indicator:'#ds-bar-spin'}); history.pushState({},'','/v2/search?mpn='+encodeURIComponent(v)); }">
+      {# input-focus adds accent ring on keyboard focus — a11y fix for the bare bg-transparent bar #}
       <input x-model="q" name="mpn" type="text" aria-label="Part number"
              placeholder="Enter a part number…"
-             class="flex-1 bg-transparent px-1 py-1 text-sm font-mono tracking-tight text-brand-900 placeholder:text-gray-400 outline-none">
+             class="flex-1 bg-transparent px-1 py-1 text-sm font-mono tracking-tight text-brand-900 placeholder:text-gray-400 input-focus rounded-md">
       <span id="ds-bar-spin" class="htmx-indicator"><svg class="inline h-4 w-4 animate-spin text-brand-500" viewBox="0 0 24 24" fill="none"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg></span>
-      <button type="submit" class="px-3 py-1.5 bg-brand-600 text-white text-xs font-semibold rounded-lg hover:bg-brand-700 transition-colors">Search</button>
+      <button type="submit" class="btn-primary btn-sm">Search</button>
     </form>
     <span class="hidden md:inline text-[11px] text-gray-400 ml-1">Nexar · BrokerBin · DigiKey · Mouser · eBay · OEMSecrets…</span>
   </div>
@@ -39,11 +40,11 @@
       <span class="font-mono text-sm font-bold text-brand-900 truncate">{{ mpn }}</span>
       <div class="ml-auto flex items-center gap-2">
         <button @click="$dispatch('dossier-send-rfq')"
-                class="px-3 py-1.5 rounded-lg bg-brand-600 text-white text-xs font-semibold hover:bg-brand-700 inline-flex items-center gap-1.5">
+                class="btn-primary btn-sm inline-flex items-center gap-1.5">
           <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M3 11l18-8-8 18-2-7-8-3z"/></svg><span class="hidden sm:inline">Send RFQ</span>
         </button>
-        <button @click="$dispatch('dossier-add-offer')" class="hidden sm:inline-flex px-3 py-1.5 rounded-lg bg-white border border-brand-300 text-brand-700 text-xs font-medium hover:bg-brand-50">Add Offer</button>
-        <button @click="$dispatch('dossier-add-to-req')" class="hidden sm:inline-flex px-3 py-1.5 rounded-lg bg-white border border-brand-300 text-brand-700 text-xs font-medium hover:bg-brand-50">Add to Req</button>
+        <button @click="$dispatch('dossier-add-offer')" class="hidden sm:inline-flex btn-secondary btn-sm">Add Offer</button>
+        <button @click="$dispatch('dossier-add-to-req')" class="hidden sm:inline-flex btn-secondary btn-sm">Add to Req</button>
       </div>
     </div>
   </div>
@@ -56,8 +57,10 @@
   <div id="dossier-hero"
        hx-get="/v2/partials/search/dossier/hero?mpn={{ mpn|urlencode }}"
        hx-trigger="load" hx-target="this" hx-swap="outerHTML">
+    {# Skeleton header matches the resolved hero geometry: title + pill row + freshness placeholder #}
     <section class="rounded-xl bg-white border border-brand-200 shadow-sm p-5 animate-pulse">
       <div class="h-7 w-56 bg-brand-100 rounded"></div>
+      <div class="mt-2 h-4 w-32 bg-brand-100 rounded"></div>
       <div class="mt-3 h-3 w-72 bg-brand-100 rounded"></div>
       <div class="mt-4 flex gap-3">
         <div class="h-9 w-24 bg-brand-100 rounded"></div>
@@ -79,15 +82,21 @@
       <div id="dossier-market"
            hx-get="/v2/partials/search/dossier/market?mpn={{ mpn|urlencode }}"
            hx-trigger="load" hx-target="this" hx-swap="innerHTML">
-        <div class="divide-y divide-brand-100 border-t border-brand-100">
-          {% for _ in range(3) %}
-          <div class="px-4 py-3 flex items-center gap-4 animate-pulse">
-            <div class="h-8 w-1 rounded bg-brand-100"></div>
+        {# Skeleton: ~py-2.5 freshness header placeholder + row stubs matches resolved dossier_market layout #}
+        <div class="border-t border-line-subtle">
+          <div class="px-4 py-2.5 animate-pulse">
             <div class="h-3 w-40 rounded bg-brand-100"></div>
-            <div class="ml-auto h-3 w-16 rounded bg-brand-100"></div>
-            <div class="h-3 w-20 rounded bg-brand-100"></div>
           </div>
-          {% endfor %}
+          <div class="divide-y divide-brand-100">
+            {% for _ in range(3) %}
+            <div class="px-4 py-3 flex items-center gap-4 animate-pulse">
+              <div class="h-8 w-1 rounded bg-brand-100"></div>
+              <div class="h-3 w-40 rounded bg-brand-100"></div>
+              <div class="ml-auto h-3 w-16 rounded bg-brand-100"></div>
+              <div class="h-3 w-20 rounded bg-brand-100"></div>
+            </div>
+            {% endfor %}
+          </div>
         </div>
       </div>
     </div>
@@ -106,7 +115,7 @@
       <div id="dossier-history" class="px-4 pb-4"
            hx-get="/v2/partials/search/history?mpn={{ mpn|urlencode }}"
            hx-trigger="load" hx-target="this" hx-swap="innerHTML">
-        <div class="rounded-xl bg-white p-6 border border-gray-100 shadow-sm animate-pulse">
+        <div class="rounded-xl bg-white p-6 border border-line-subtle shadow-sm animate-pulse">
           <div class="h-4 w-2/3 bg-gray-100 rounded"></div>
           <div class="mt-3 h-3 w-1/2 bg-gray-100 rounded"></div>
         </div>
@@ -159,7 +168,7 @@
        x-transition:enter-start="translate-x-full" x-transition:enter-end="translate-x-0"
        x-transition:leave="transition ease-in duration-150 transform"
        x-transition:leave-start="translate-x-0" x-transition:leave-end="translate-x-full"
-       class="fixed inset-y-0 right-0 w-full max-w-lg bg-white shadow-2xl border-l border-gray-200 z-50"
+       class="fixed inset-y-0 right-0 w-full max-w-lg bg-white shadow-2xl border-l border-line-subtle z-50"
        x-cloak>
     <div id="lead-drawer-content" class="h-full" @htmx:after-swap="drawerOpen = true"></div>
   </div>
@@ -168,10 +177,11 @@
 {# ── MOBILE bottom action sheet (above the fixed bottom nav). ── #}
 <div class="sm:hidden fixed left-0 right-0 bottom-[52px] z-30 bg-white border-t border-brand-200 px-3 py-2 flex items-center gap-2"
      x-data="{ sheet: false }">
-  <button @click="$dispatch('dossier-send-rfq')" class="flex-1 px-3 py-2.5 rounded-lg bg-brand-600 text-white text-sm font-semibold inline-flex items-center justify-center gap-2">
+  {# Mobile Send RFQ — primary CTA migrated to .btn-primary flex-1 #}
+  <button @click="$dispatch('dossier-send-rfq')" class="btn-primary flex-1 inline-flex items-center justify-center gap-2">
     <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M3 11l18-8-8 18-2-7-8-3z"/></svg>Send RFQ
   </button>
-  <button @click="sheet=true" class="px-4 py-2.5 rounded-lg bg-white border border-brand-300 text-brand-700 text-sm font-medium">Actions</button>
+  <button @click="sheet=true" class="btn-secondary">Actions</button>
   <div x-show="sheet" x-cloak @click="sheet=false" class="fixed inset-0 bg-black/40 z-40"></div>
   <div x-show="sheet" x-cloak x-transition:enter="transition ease-out duration-200" x-transition:enter-start="translate-y-full" x-transition:enter-end="translate-y-0"
        class="fixed left-0 right-0 bottom-0 z-50 bg-white rounded-t-2xl border-t border-brand-200 p-4 space-y-1">

--- a/app/templates/htmx/partials/search/dossier_specs.html
+++ b/app/templates/htmx/partials/search/dossier_specs.html
@@ -29,7 +29,7 @@
       <span class="font-mono">{{ val }}</span>
       {% if field is mapping and field.source %}
       {% set conf = field.confidence|default(0)|float %}
-      <span class="ml-1 align-middle rounded px-1 text-[9px] {{ 'bg-brand-50 text-brand-600' if conf >= 0.9 else 'bg-gray-50 text-gray-500' }}"
+      <span class="ml-1 align-middle badge-mini {{ 'bg-brand-50 text-brand-600' if conf >= 0.9 else 'bg-gray-50 text-gray-500' }}"
             title="source: {{ field.source }}{% if field.confidence is not none %} · conf {{ field.confidence }}{% endif %}">
         {{ 'Direct' if conf >= 0.9 else 'Sourced' }}
       </span>

--- a/app/templates/htmx/partials/search/form.html
+++ b/app/templates/htmx/partials/search/form.html
@@ -13,9 +13,7 @@
       <div class="flex gap-2">
         <input aria-label="Part number search" type="text" name="mpn" x-model="q"
                placeholder="Enter part number (e.g. LM317T, STM32F407VG)"
-               class="flex-1 px-3 py-2 text-sm font-mono border border-brand-200 rounded-lg
-                      focus:ring-2 focus:ring-brand-500 focus:border-brand-500
-                      placeholder:text-gray-400 tracking-tight"
+               class="input flex-1 font-mono tracking-tight"
                required>
         <button type="submit" :disabled="!q.trim()"
                 class="btn-primary whitespace-nowrap">

--- a/app/templates/htmx/partials/search/history_panel.html
+++ b/app/templates/htmx/partials/search/history_panel.html
@@ -23,7 +23,7 @@
 {% else %}
 <div x-data="{ open: 'offers' }">
   {# Header #}
-  <div class="p-4 border-b border-gray-100">
+  <div class="p-4 border-b border-line-subtle">
     <div class="flex items-center justify-between gap-2">
       <div class="min-w-0">
         <p class="text-sm font-semibold text-gray-900 truncate">{{ history.display_mpn }}</p>
@@ -37,7 +37,7 @@
       </div>
       <a href="/v2/materials/{{ history.card_id }}" hx-get="/v2/partials/materials/{{ history.card_id }}"
          hx-target="#main-content" hx-push-url="/v2/materials/{{ history.card_id }}"
-         class="shrink-0 text-xs font-medium text-blue-600 hover:text-blue-700">Open full part page →</a>
+         class="shrink-0 text-xs font-medium text-brand-600 hover:text-brand-700">Open full part page →</a>
     </div>
     {# Summary stat row #}
     <div class="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-600">
@@ -50,7 +50,7 @@
     {% if history.buyers %}
     <div class="mt-2 flex flex-wrap gap-1">
       {% for b in history.buyers %}
-      <span class="inline-block rounded-full bg-blue-50 px-2 py-0.5 text-[11px] text-blue-700">{{ b.name or b.email }}</span>
+      <span class="inline-block rounded-full bg-brand-100 px-2 py-0.5 text-[11px] text-brand-700">{{ b.name or b.email }}</span>
       {% endfor %}
     </div>
     {% endif %}
@@ -58,7 +58,7 @@
 
   {# Accordion sections #}
   {% macro section(key, label, count) %}
-  <div class="border-b border-gray-100 last:border-b-0">
+  <div class="border-b border-line-subtle last:border-b-0">
     <button type="button" @click="open = (open === '{{ key }}' ? '' : '{{ key }}')"
             class="flex w-full items-center justify-between px-4 py-2.5 text-left text-sm font-medium text-gray-700 hover:bg-gray-50">
       <span>{{ label }} <span class="text-gray-400">({{ count }})</span></span>
@@ -70,24 +70,24 @@
 
   {% call section('offers', 'Offers', history.offers_count) %}
     {% for o in history.offers %}
-    <div class="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
+    <div class="flex items-center justify-between py-1 border-b border-line-subtle last:border-0">
       <span class="truncate">{{ o.vendor_name }}</span>
       <span class="shrink-0 text-gray-600">{{ o.qty_available or "—" }} · ${{ o.unit_price or "—" }} · {{ o.status }}</span>
     </div>
     {% else %}<p class="py-1 text-gray-400">None.</p>{% endfor %}
     {% if history.offers_count > history.offers|length %}
-    <a href="/v2/materials/{{ history.card_id }}" class="mt-1 inline-block text-blue-600">View all on part page →</a>{% endif %}
+    <a href="/v2/materials/{{ history.card_id }}" class="mt-1 inline-block text-brand-600 hover:text-brand-700">View all on part page →</a>{% endif %}
   {% endcall %}
 
   {% call section('confirmed', 'Confirmed / Won', history.confirmed_count) %}
     {% for o in history.won_offers %}
-    <div class="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
+    <div class="flex items-center justify-between py-1 border-b border-line-subtle last:border-0">
       <span class="truncate">{{ o.vendor_name }}</span>
       <span class="shrink-0 text-emerald-600">{{ o.status }} · ${{ o.unit_price or "—" }}</span>
     </div>
     {% endfor %}
     {% for c in history.customer_purchases %}
-    <div class="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
+    <div class="flex items-center justify-between py-1 border-b border-line-subtle last:border-0">
       <span class="truncate">{{ c.company.name if c.company else "Customer" }}</span>
       <span class="shrink-0 text-gray-600">×{{ c.purchase_count }} · ${{ c.avg_unit_price or "—" }}</span>
     </div>
@@ -97,7 +97,7 @@
 
   {% call section('sightings', 'Sightings', history.sightings_count) %}
     {% for s in history.sightings %}
-    <div class="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
+    <div class="flex items-center justify-between py-1 border-b border-line-subtle last:border-0">
       <span class="truncate">{{ s.vendor_name }}</span>
       <span class="shrink-0 text-gray-600">{{ s.qty_available or "—" }} · ${{ s.unit_price or "—" }} · {{ s.source_type or "—" }}</span>
     </div>
@@ -106,7 +106,7 @@
 
   {% call section('reqs', 'Requisitions', history.requirements_count) %}
     {% for r in history.requirements %}
-    <div class="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
+    <div class="flex items-center justify-between py-1 border-b border-line-subtle last:border-0">
       <span class="truncate">Req #{{ r.requisition_id }}</span>
       <span class="shrink-0 text-gray-600">{{ r.sourcing_status }}</span>
     </div>
@@ -114,7 +114,7 @@
   {% endcall %}
 
   {% if history.price_trend %}
-  <div class="px-4 py-2.5 text-xs text-gray-600 border-t border-gray-100">
+  <div class="px-4 py-2.5 text-xs text-gray-600 border-t border-line-subtle">
     Price ({{ history.price_trend.currency }}):
     <span class="font-medium">${{ history.price_trend.min_price }}</span> –
     <span class="font-medium">${{ history.price_trend.max_price }}</span>
@@ -129,13 +129,13 @@
      Full matrix lives on the materials surface — the deep link lands on the
      faceted results, which render the fru_section for the same q. #}
 {% if fru_hit %}
-<div class="mt-3 rounded-xl bg-white border border-gray-100 shadow-sm p-4">
+<div class="mt-3 rounded-xl bg-white border border-line-subtle shadow-sm p-4">
   <div class="flex items-center justify-between gap-2">
     <p class="text-sm font-semibold text-gray-900">FRU crosswalk</p>
     <a href="/v2/materials?q={{ fru_query | urlencode }}"
        hx-get="/v2/partials/materials?q={{ fru_query | urlencode }}"
        hx-target="#main-content" hx-push-url="/v2/materials?q={{ fru_query | urlencode }}"
-       class="shrink-0 text-xs font-medium text-blue-600 hover:text-blue-700">View full FRU matrix →</a>
+       class="shrink-0 text-xs font-medium text-brand-600 hover:text-brand-700">View full FRU matrix →</a>
   </div>
 
   {% if fru_view %}

--- a/app/templates/htmx/partials/search/history_panel.html
+++ b/app/templates/htmx/partials/search/history_panel.html
@@ -50,7 +50,7 @@
     {% if history.buyers %}
     <div class="mt-2 flex flex-wrap gap-1">
       {% for b in history.buyers %}
-      <span class="inline-block rounded-full bg-brand-100 px-2 py-0.5 text-[11px] text-brand-700">{{ b.name or b.email }}</span>
+      <span class="inline-block rounded-full bg-accent-100 px-2 py-0.5 text-[11px] text-accent-700">{{ b.name or b.email }}</span>
       {% endfor %}
     </div>
     {% endif %}

--- a/app/templates/htmx/partials/search/lead_detail.html
+++ b/app/templates/htmx/partials/search/lead_detail.html
@@ -7,7 +7,7 @@
 {% set s = lead %}
 
 {# Drawer header with close button #}
-<div class="flex items-center justify-between px-5 py-4 border-b border-gray-200 bg-brand-700">
+<div class="flex items-center justify-between px-5 py-4 border-b border-line-subtle bg-brand-700">
   <div class="min-w-0">
     <h2 class="text-lg font-bold text-white truncate">{{ s.vendor_name }}</h2>
     <p class="text-xs text-brand-300 mt-0.5">{{ s.mpn_matched or s.mpn or mpn }}</p>
@@ -73,7 +73,7 @@
   </div>
 
   {# ── Section 3: Key Data ── #}
-  <div class="bg-white rounded-lg border border-gray-200 p-4">
+  <div class="bg-white rounded-lg border border-line-subtle p-4">
     <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Part Details</h3>
     <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
       <div>
@@ -138,22 +138,22 @@
 
   {# ── Section 3b: Sub-offers table (when vendor has multiple source offers) ── #}
   {% if s.sub_offers and s.sub_offers|length > 0 %}
-  <div class="bg-gray-800 rounded-lg border border-gray-700 p-4">
-    <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+  <div class="bg-white rounded-lg border border-line-subtle p-4">
+    <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
       All Offers ({{ s.sub_offers|length }})
     </h3>
     <div class="overflow-x-auto">
       <table class="w-full text-sm">
         <thead>
-          <tr class="text-xs text-gray-400 border-b border-gray-700">
+          <tr class="text-xs text-gray-500 border-b border-line-subtle">
             <th class="text-left pb-2 pr-3">Source</th>
             <th class="text-right pb-2 pr-3">Price</th>
             <th class="text-right pb-2">Qty</th>
           </tr>
         </thead>
-        <tbody class="text-white">
+        <tbody class="text-gray-800">
           {% for offer in s.sub_offers %}
-          <tr class="border-b border-gray-700/50 last:border-0">
+          <tr class="border-b border-line-subtle last:border-0">
             <td class="py-1.5 pr-3 text-xs">{{ offer.source_type or "—" }}</td>
             <td class="py-1.5 pr-3 text-right font-mono text-xs">
               {% if offer.unit_price %}${{ "%.4f"|format(offer.unit_price) if offer.unit_price < 1 else "%.2f"|format(offer.unit_price) }}{% else %}RFQ{% endif %}
@@ -188,13 +188,13 @@
         qty_available: {{ s.qty_available or 'null' }},
         vendor_key: '{{ s.vendor_key|default("")|replace("'", "\\'") }}'
       })"
-      class="flex-1 px-4 py-2 text-sm font-medium rounded-lg bg-brand-600 text-white hover:bg-brand-700 transition-colors text-center">
+      class="btn-primary flex-1 text-center">
       Add to Shortlist
     </button>
   </div>
 
   {# ── Section 4: Source Attribution ── #}
-  <div class="bg-white rounded-lg border border-gray-200 p-4">
+  <div class="bg-white rounded-lg border border-line-subtle p-4">
     <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Source Attribution</h3>
     <div class="space-y-2 text-sm">
       <div class="flex items-center justify-between">
@@ -223,7 +223,7 @@
     </div>
     {# External links #}
     {% if s.click_url or s.octopart_url or s.vendor_url %}
-    <div class="mt-3 pt-3 border-t border-gray-100 flex gap-3 flex-wrap">
+    <div class="mt-3 pt-3 border-t border-line-subtle flex gap-3 flex-wrap">
       {% if s.click_url %}
       <a href="{{ s.click_url }}" target="_blank" rel="noopener"
          class="text-xs text-brand-600 hover:text-brand-700 underline">View on Source</a>
@@ -241,7 +241,7 @@
   </div>
 
   {# ── Section 5: Contact Information ── #}
-  <div class="bg-white rounded-lg border border-gray-200 p-4">
+  <div class="bg-white rounded-lg border border-line-subtle p-4">
     <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Contact Information</h3>
     {% if s.vendor_email or s.vendor_phone or s.vendor_url %}
     <div class="space-y-2 text-sm">
@@ -277,7 +277,7 @@
 
   {# ── Section 6: View Material Card Link ── #}
   {% if material_card_id %}
-  <div class="bg-white rounded-lg border border-gray-200 p-4">
+  <div class="bg-white rounded-lg border border-line-subtle p-4">
     <a hx-get="/v2/partials/materials/{{ material_card_id }}"
        hx-target="#main-content"
        hx-push-url="/v2/materials/{{ material_card_id }}"
@@ -295,7 +295,7 @@
 
   {# ── Section 7: Score Breakdown ── #}
   {% if s.score_components %}
-  <div class="bg-white rounded-lg border border-gray-200 p-4">
+  <div class="bg-white rounded-lg border border-line-subtle p-4">
     <h3 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Score Breakdown</h3>
     <div class="space-y-2">
       {% for name, value in s.score_components.items() %}

--- a/app/templates/htmx/partials/search/lead_detail.html
+++ b/app/templates/htmx/partials/search/lead_detail.html
@@ -145,7 +145,7 @@
     <div class="overflow-x-auto">
       <table class="w-full text-sm">
         <thead>
-          <tr class="text-xs text-gray-500 border-b border-line-subtle">
+          <tr class="text-xs text-gray-600 border-b border-line-subtle">
             <th class="text-left pb-2 pr-3">Source</th>
             <th class="text-right pb-2 pr-3">Price</th>
             <th class="text-right pb-2">Qty</th>

--- a/app/templates/htmx/partials/search/shortlist_bar.html
+++ b/app/templates/htmx/partials/search/shortlist_bar.html
@@ -23,11 +23,11 @@
         Add to Requisition
       </button>
       <button @click="$dispatch('open-modal', {url: '/v2/partials/search/requisition-picker?action=rfq&items=' + encodeURIComponent(JSON.stringify($store.shortlist.items))})"
-              class="px-4 py-2 text-sm font-semibold bg-white text-brand-700 rounded-lg hover:bg-brand-50 transition-colors border border-brand-300">
+              class="btn-secondary">
         Create RFQ
       </button>
       <button @click="$store.shortlist.clear()"
-              class="px-3 py-2 text-sm text-gray-600 hover:text-brand-700 transition-colors">
+              class="btn-ghost btn-sm">
         Clear
       </button>
     </div>

--- a/app/templates/htmx/partials/search/vendor_card.html
+++ b/app/templates/htmx/partials/search/vendor_card.html
@@ -63,8 +63,8 @@
   {# region / lead #}
   <div class="text-[11px] text-gray-600 mt-0.5 lg:mt-0">{{ card.lead_quality|default('')|title }}{% if card.reason %} · {{ card.reason }}{% endif %}</div>
 
-  {# actions (reveal on hover desktop, always visible on mobile/touch) #}
-  <div class="flex lg:justify-end items-center gap-1 mt-2 lg:mt-0 lg:opacity-0 lg:group-hover:opacity-100 transition-opacity">
+  {# actions — low-emphasis on desktop, full on hover/focus; always visible on mobile/touch #}
+  <div class="flex lg:justify-end items-center gap-1 mt-2 lg:mt-0 lg:opacity-60 lg:group-hover:opacity-100 lg:focus-within:opacity-100 transition-opacity">
     <button type="button" title="RFQ this vendor"
             hx-post="/v2/partials/search/quick-source/rfq"
             hx-vals='{"mpn": "{{ card.mpn_matched|e }}", "vendor_name": "{{ card.vendor_name|e }}"}'
@@ -85,17 +85,17 @@
     <button @click="expanded = !expanded" class="text-[11px] text-brand-600 hover:text-brand-700">
       <span x-text="expanded ? 'Hide offers' : '{{ card.offer_count|default(card.sub_offers|length) }} offers'"></span>
     </button>
-    <div x-show="expanded" x-cloak x-transition class="mt-2 border-t border-gray-200 pt-2">
-      <table class="w-full text-xs">
-        <thead><tr class="text-gray-500">
-          <th class="text-left py-1">Source</th>
-          <th class="text-right py-1">Price</th>
-          <th class="text-right py-1">Qty</th>
+    <div x-show="expanded" x-cloak x-transition class="mt-2 border-t border-line-subtle pt-2">
+      <table class="compact-table w-full">
+        <thead><tr>
+          <th class="text-left">Source</th>
+          <th class="text-right">Price</th>
+          <th class="text-right">Qty</th>
         </tr></thead>
         <tbody>
         {% for offer in card.sub_offers %}
-          <tr class="text-gray-700 border-t border-gray-100">
-            <td class="py-1">{{ offer.source_type|default('') }}</td>
+          <tr class="border-t border-line-subtle">
+            <td>{{ offer.source_type|default('') }}</td>
             <td class="text-right font-mono">{% if offer.unit_price %}${{ "%.4f"|format(offer.unit_price) }}{% else %}-{% endif %}</td>
             <td class="text-right font-mono">{{ "{:,}".format(offer.qty_available) if offer.qty_available else '-' }}</td>
           </tr>


### PR DESCRIPTION
## What

Phase 3 UI program — the **Search / Part Dossier** cluster (`search/`). Implements all 17 findings from the total UI audit (key `search`).

## Changes (17/17 findings)

- **Primary CTAs → `.btn-primary`** — hero/rail/mobile Send RFQ, tier-1 Search, drawer Add-to-Shortlist (`bg-brand-600` → accent + accent focus ring).
- **Inputs → `.input`/`input-focus`** — landing search; the bare tier-1 sticky bar gains a keyboard focus ring (a11y + accent).
- **Secondary buttons → `.btn-secondary`/`.btn-ghost`** — all hand-rolled outline buttons across hero/shell/drawer/shortlist-bar.
- **Hero figures → `.figure-accent`** — market price + 4 knowledge-count numerals (non-zero only).
- **Readability** — `text-[9px]` avatar → `text-[10px]`; evidence tag → `.badge-mini`; `.count-tile dt` 0.62rem → 0.6875rem (11px floor) + token color (styles.css).
- **Stray-color sweep** — blue-* links/chips → brand; SVG sparkline inline hex → `currentColor`.
- **Hairlines** — `border-gray-*` → `.border-line-subtle` across history/vendor-card/drawer.
- **Density/UX** — sub-offers table → `.compact-table`; per-vendor row actions discoverable (`lg:opacity-60` + `focus-within`); skeleton header matches resolved market header.

Files: `styles.css` (`.count-tile dt`) + 8 `search/` templates.

## Verification
CI gates merge. Visual sign-off is part of the consolidated local deploy-for-review. **Second of two styles.css branches — will update-branch onto main after `feat/ui-sales-hub` lands (the two hunks are non-overlapping).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_