### PR TITLE
chore: drop redundant vite htmx_mobile entry + duplicate gitignore line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ __pycache__/
 uploads/
 *.egg-info/
 dist/
-app/static/dist/
 build/
 .venv/
 node_modules/

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,8 @@ export default defineConfig({
     rollupOptions: {
       input: {
         htmx_app: resolve(__dirname, "app/static/htmx_app.js"),
-        htmx_mobile: resolve(__dirname, "app/static/htmx_mobile.css"),
+        // htmx_mobile.css is imported by htmx_app.js (so it ships in that bundle);
+        // a standalone entry emitted an htmx_mobile-*.css that nothing loaded.
         styles: resolve(__dirname, "app/static/styles.css"),
       },
     },


### PR DESCRIPTION
## What
- **`vite.config.js`** — drop the standalone `htmx_mobile.css` rollup input. It's already imported by `htmx_app.js` (so it ships inside that bundle); the separate `htmx_mobile-*.css` output was loaded by nothing (`_vite_assets()` reads only `htmx_app.js` + `styles.css`).
- **`.gitignore`** — remove `app/static/dist/` (the `dist/` rule already matches at any depth).

## Verification
`npm run build` clean (14.3s); built manifest now has only `htmx_app.js` + `styles.css`; the mobile `@media` rules are still present in `htmx_app-*.css`; grep confirms no template/router references the removed standalone asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_