### PR TITLE
chore: consolidate junk-manufacturer constants (⚠️ review — broadens enrichment filter)

### DIFF
--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -23,6 +23,7 @@ from app.services.tagging import (
     get_or_create_commodity_tag,
     tag_material_card,
 )
+from app.shared_constants import JUNK_MANUFACTURERS
 
 # Connector configs: (source_name, connector_class_path, credential_keys, confidence)
 # Ordered by priority — authoritative distributors first
@@ -65,8 +66,6 @@ _CONNECTOR_CONFIGS = [
     },
 ]
 
-_IGNORED_MANUFACTURERS = {"", "unknown", "n/a", "various", "none", "other", "generic"}
-
 
 def _manufacturers_agree(a: str, b: str) -> bool:
     """Fuzzy manufacturer-name match: exact, or either name contains the other."""
@@ -79,14 +78,14 @@ def _nexar_manufacturer(data: dict) -> str | None:
     """Extract the first result's manufacturer name from a Nexar GraphQL payload.
 
     Returns the trimmed name, or None when there is no result or it is a junk/placeholder
-    manufacturer (per ``_IGNORED_MANUFACTURERS``).
+    manufacturer (per ``JUNK_MANUFACTURERS``).
     """
     results = (data.get("data") or {}).get("supSearchMpn", {}).get("results", [])
     if not results:
         return None
     part = results[0].get("part", {})
     mfr = ((part.get("manufacturer") or {}).get("name") or "").strip()
-    if not mfr or mfr.lower() in _IGNORED_MANUFACTURERS:
+    if not mfr or mfr.lower() in JUNK_MANUFACTURERS:
         return None
     return mfr
 
@@ -124,7 +123,7 @@ async def _try_connector_config(config: dict, mpn: str) -> dict | None:
         results = await asyncio.wait_for(connector.search(mpn), timeout=15)
         for r in results:
             mfr = (r.get("manufacturer") or "").strip()
-            if mfr.lower() not in _IGNORED_MANUFACTURERS:
+            if mfr.lower() not in JUNK_MANUFACTURERS:
                 return {
                     "manufacturer": mfr,
                     "category": (r.get("category") or r.get("description") or "").strip()[:200] or None,

--- a/app/services/tagging_backfill.py
+++ b/app/services/tagging_backfill.py
@@ -25,6 +25,7 @@ from app.services.tagging import (
     get_or_create_commodity_tag,
     tag_material_card,
 )
+from app.shared_constants import JUNK_MANUFACTURERS
 
 
 def _untagged_card_filter(db: Session):
@@ -198,9 +199,6 @@ def run_prefix_backfill(db: Session, batch_size: int = 1000) -> dict:
     }
 
 
-_JUNK_MANUFACTURERS = {"unknown", "n/a", "various", "", "none", "other", "generic", "-", "na"}
-
-
 def backfill_manufacturer_from_sightings(db: Session, batch_size: int = 500) -> dict:
     """Mine sighting manufacturer data for untagged material cards.
 
@@ -259,7 +257,7 @@ def backfill_manufacturer_from_sightings(db: Session, batch_size: int = 500) -> 
             mfr_counts: Counter = Counter()
             for (mfr,) in sighting_mfrs:
                 cleaned = mfr.strip()
-                if cleaned.lower() not in _JUNK_MANUFACTURERS:
+                if cleaned.lower() not in JUNK_MANUFACTURERS:
                     mfr_counts[cleaned] += 1
 
             if not mfr_counts:

--- a/app/shared_constants.py
+++ b/app/shared_constants.py
@@ -115,6 +115,12 @@ JUNK_VENDORS: set[str] = {
     "no seller",
 }
 
+# ── Junk manufacturer names ──────────────────────────────────────────────
+# Union of enrichment.py._IGNORED_MANUFACTURERS and tagging_backfill.py._JUNK_MANUFACTURERS.
+# Used to skip placeholder/noise values when harvesting manufacturer data from sightings or
+# connector payloads. Stored as frozenset for fast membership tests and immutability.
+JUNK_MANUFACTURERS: frozenset[str] = frozenset({"", "unknown", "n/a", "various", "none", "other", "generic", "-", "na"})
+
 # ── RFQ subject tags ────────────────────────────────────────────────────
 # Extracts the requisition ID from an RFQ email subject tag. Matches both
 # [ref:123] (current, written by email_service.send_batch_rfq) and

--- a/tests/test_junk_manufacturers_constant.py
+++ b/tests/test_junk_manufacturers_constant.py
@@ -1,0 +1,39 @@
+"""Tests for the consolidated JUNK_MANUFACTURERS constant in app/shared_constants.py.
+
+Verifies the union of the two previously-independent sets and that both call-sites
+(enrichment.py, tagging_backfill.py) still perform the expected membership check.
+
+Called by: pytest
+Depends on: app.shared_constants
+"""
+
+import pytest
+
+from app.shared_constants import JUNK_MANUFACTURERS
+
+
+class TestJunkManufacturersConstant:
+    """JUNK_MANUFACTURERS is a frozenset containing the union of both old sets."""
+
+    def test_is_frozenset(self):
+        assert isinstance(JUNK_MANUFACTURERS, frozenset)
+
+    # Values from the original enrichment.py._IGNORED_MANUFACTURERS
+    @pytest.mark.parametrize("value", ["", "unknown", "n/a", "various", "none", "other", "generic"])
+    def test_contains_original_enrichment_values(self, value):
+        assert value in JUNK_MANUFACTURERS
+
+    # Values added by tagging_backfill.py._JUNK_MANUFACTURERS (the superset)
+    @pytest.mark.parametrize("value", ["-", "na"])
+    def test_contains_tagging_backfill_additions(self, value):
+        assert value in JUNK_MANUFACTURERS
+
+    # Legitimate manufacturer names must NOT be filtered
+    @pytest.mark.parametrize("value", ["Texas Instruments", "NXP", "STMicroelectronics", "Murata"])
+    def test_real_manufacturers_not_in_set(self, value):
+        assert value.lower() not in JUNK_MANUFACTURERS
+
+    def test_membership_check_is_case_sensitive_lowercase(self):
+        # Callers always do .lower() before checking — the set stores lowercase values.
+        assert "UNKNOWN" not in JUNK_MANUFACTURERS
+        assert "unknown" in JUNK_MANUFACTURERS


### PR DESCRIPTION
## ⚠️ NEEDS REVIEW — not strictly behavior-preserving (staged, not auto-merged)

Consolidates two duplicate junk-manufacturer constant sets into one `JUNK_MANUFACTURERS` frozenset in `app/shared_constants.py` (the canonical home alongside `JUNK_DOMAINS`/`JUNK_VENDORS`), imported by `enrichment.py` and `tagging_backfill.py`.

**The one behavior delta:** `enrichment.py` now also rejects `"-"` and `"na"` as junk manufacturers (these were in `tagging_backfill`'s set but not enrichment's; the consolidated set is the union). A Nexar/distributor payload returning a manufacturer of `"-"` or `"na"` (case-insensitive) will now be filtered rather than promoted to the card. This is almost certainly correct (both are unambiguous noise) — but it's a genuine enrichment-path change, so **please eyeball before merging**.

## Verification
- ruff / ruff-format / docformatter / mypy clean on the 3 changed files
- New `tests/test_junk_manufacturers_constant.py` (type, all original values, the 2 additions, real names, lowercase contract)
- Targeted (enrichment/tagging) — 92 passed; **full non-e2e suite — 20,394 passed, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_