### PR TITLE
refactor: extract find_vendor_card_by_name helper (behavior-preserving dedup)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -4341,6 +4341,7 @@ async def create_vendor_partial_early(
     """Create a new VendorCard from the HTMX form (early route to precede
     /{vendor_id})."""
     from ..models import VendorCard
+    from ..utils.vendor_helpers import find_vendor_card_by_name
     from ..vendor_utils import normalize_vendor_name
 
     form = await request.form()
@@ -4349,7 +4350,7 @@ async def create_vendor_partial_early(
         raise HTTPException(400, "Vendor name is required")
 
     norm = normalize_vendor_name(display_name)
-    existing = db.query(VendorCard).filter_by(normalized_name=norm).first()
+    existing = find_vendor_card_by_name(display_name, db)
     if existing:
         raise HTTPException(409, f"Vendor '{existing.display_name}' already exists (ID {existing.id})")
 

--- a/app/routers/sources.py
+++ b/app/routers/sources.py
@@ -54,6 +54,7 @@ from ..schemas.sources import MiningOptions, SourceStatusToggle
 from ..services.admin_service import get_effective_flag
 from ..services.credential_service import get_credential_cached
 from ..services.vendor_unavailability import apply_to_fresh_sightings
+from ..utils.vendor_helpers import find_vendor_card_by_name
 from ..vendor_utils import normalize_vendor_name
 
 router = APIRouter()
@@ -741,7 +742,7 @@ async def scan_inbox_for_vendors(request: Request, user: User = Depends(require_
             continue
 
         norm = normalize_vendor_name(vendor_name)
-        card = db.query(VendorCard).filter_by(normalized_name=norm).first()
+        card = find_vendor_card_by_name(vendor_name, db)
         if not card:
             card = VendorCard(
                 normalized_name=norm,

--- a/app/routers/vendor_contacts.py
+++ b/app/routers/vendor_contacts.py
@@ -29,6 +29,7 @@ from ..utils.vendor_helpers import (
     _background_enrich_vendor,
     clean_emails,
     clean_phones,
+    find_vendor_card_by_name,
     get_or_create_card,
     merge_contact_into_card,
     scrape_website_contacts,
@@ -77,7 +78,7 @@ async def lookup_vendor_contact(
     vendor_name = payload.vendor_name
 
     norm = normalize_vendor_name(vendor_name)
-    card = db.query(VendorCard).filter_by(normalized_name=norm).first()
+    card = find_vendor_card_by_name(vendor_name, db)
     if not card:
         card = VendorCard(normalized_name=norm, display_name=vendor_name, emails=[], phones=[])
         db.add(card)
@@ -85,7 +86,7 @@ async def lookup_vendor_contact(
             db.flush()
         except IntegrityError:
             db.rollback()
-            card = db.query(VendorCard).filter_by(normalized_name=norm).first()
+            card = find_vendor_card_by_name(vendor_name, db)
 
     # TIER 1: Cache check (free, instant)
     if card.emails:

--- a/app/routers/vendors_crud.py
+++ b/app/routers/vendors_crud.py
@@ -28,7 +28,7 @@ from ..schemas.vendors import VendorBlacklistToggle, VendorCardCreate, VendorCar
 from ..services.vendor_duplicates import _fuzzy_match_python  # noqa: F401
 from ..services.vendor_duplicates import check_vendor_duplicate as _check_vendor_duplicate
 from ..utils.search_builder import SearchBuilder
-from ..utils.vendor_helpers import card_to_dict
+from ..utils.vendor_helpers import card_to_dict, find_vendor_card_by_name
 from ..vendor_utils import normalize_vendor_name
 
 router = APIRouter(tags=["vendors"])
@@ -62,7 +62,7 @@ async def create_vendor(
     already exists. Returns 422 if the display_name is missing or blank.
     """
     norm = normalize_vendor_name(data.display_name)
-    existing = db.query(VendorCard).filter_by(normalized_name=norm).first()
+    existing = find_vendor_card_by_name(data.display_name, db)
     if existing:
         raise HTTPException(
             409,

--- a/app/services/vendor_duplicates.py
+++ b/app/services/vendor_duplicates.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.orm import Session
 
 from ..models import VendorCard
+from ..utils.vendor_helpers import find_vendor_card_by_name
 from ..vendor_utils import normalize_vendor_name
 
 FUZZY_MATCH_POOL_SIZE = 500  # Max vendors loaded for fuzzy duplicate check
@@ -86,7 +87,7 @@ def check_vendor_duplicate(name: str, db: Session) -> list[dict]:
     norm = normalize_vendor_name(name)
 
     # Exact match — the one confident duplicate, short-circuits fuzzy entirely
-    exact = db.query(VendorCard).filter_by(normalized_name=norm).first()
+    exact = find_vendor_card_by_name(name, db)
     if exact:
         return [
             {

--- a/app/utils/vendor_helpers.py
+++ b/app/utils/vendor_helpers.py
@@ -56,6 +56,22 @@ def _record_alternate_name(card: VendorCard, vendor_name: str, db: Session, *, c
         db.rollback()
 
 
+def find_vendor_card_by_name(name: str, db: Session) -> VendorCard | None:
+    """Return the VendorCard whose normalized_name matches name, or None.
+
+    Normalizes name with normalize_vendor_name() then performs an exact
+    filter_by(normalized_name=...) lookup — the same idiom used at every call
+    site that only needs a quick existence check (no fuzzy fallback, no create).
+
+    Called by: app.routers.vendors_crud, app.routers.htmx_views,
+               app.routers.vendor_contacts, app.routers.sources,
+               app.services.vendor_duplicates
+    Depends on: vendor_utils.normalize_vendor_name, models.VendorCard
+    """
+    norm = normalize_vendor_name(name)
+    return db.query(VendorCard).filter_by(normalized_name=norm).first()
+
+
 def get_or_create_card(vendor_name: str, db: Session, domain: str | None = None) -> VendorCard:
     """Find existing VendorCard by normalized name, domain, or fuzzy match, or create
     new.

--- a/tests/test_vendor_helpers.py
+++ b/tests/test_vendor_helpers.py
@@ -36,6 +36,7 @@ from app.utils.vendor_helpers import (
     card_to_dict,
     clean_emails,
     clean_phones,
+    find_vendor_card_by_name,
     get_or_create_card,
     is_private_url,
     merge_contact_into_card,
@@ -1098,3 +1099,59 @@ class TestMergeContactIntoCard:
             changed = merge_contact_into_card(card, ["a@b.com"], ["+1-555-0100"], source="api")
         assert changed is True
         assert card.source == "api"
+
+
+# ── find_vendor_card_by_name ─────────────────────────────────────────
+
+
+class TestFindVendorCardByName:
+    """Tests for the find_vendor_card_by_name helper.
+
+    Verifies exact normalized lookup, miss, and case-insensitive normalization.
+    """
+
+    def _add_card(self, db_session, normalized_name: str, display_name: str) -> VendorCard:
+        card = VendorCard(
+            normalized_name=normalized_name,
+            display_name=display_name,
+            emails=[],
+            phones=[],
+        )
+        db_session.add(card)
+        db_session.commit()
+        return card
+
+    def test_returns_card_for_exact_normalized_match(self, db_session):
+        """find_vendor_card_by_name returns the card when normalized name matches."""
+        self._add_card(db_session, "arrow electronics", "Arrow Electronics")
+        result = find_vendor_card_by_name("Arrow Electronics", db_session)
+        assert result is not None
+        assert result.display_name == "Arrow Electronics"
+
+    def test_case_insensitive_normalization(self, db_session):
+        """Normalization lowercases; different-case input hits the same card."""
+        self._add_card(db_session, "arrow electronics", "Arrow Electronics")
+        result = find_vendor_card_by_name("ARROW ELECTRONICS", db_session)
+        assert result is not None
+        assert result.normalized_name == "arrow electronics"
+
+    def test_returns_none_when_no_match(self, db_session):
+        """Returns None when no card matches the normalized name."""
+        result = find_vendor_card_by_name("Nonexistent Vendor XYZ", db_session)
+        assert result is None
+
+    def test_ignores_unrelated_cards(self, db_session):
+        """Does not return cards with different normalized names."""
+        self._add_card(db_session, "arrow electronics", "Arrow Electronics")
+        result = find_vendor_card_by_name("Digikey", db_session)
+        assert result is None
+
+    def test_normalizes_before_query(self, db_session):
+        """Helper normalizes the input — whitespace and punctuation stripped."""
+        from app.vendor_utils import normalize_vendor_name
+
+        raw = "  Arrow  Electronics  "
+        norm = normalize_vendor_name(raw)
+        self._add_card(db_session, norm, "Arrow Electronics")
+        result = find_vendor_card_by_name(raw, db_session)
+        assert result is not None


### PR DESCRIPTION
## What
Extracts the repeated "find vendor card by normalized name" idiom into one helper `find_vendor_card_by_name(name, db)` in `app/utils/vendor_helpers.py`, reused at 5 call sites. **Strictly behavior-preserving** — the helper body is the exact `normalize_vendor_name(name)` → `db.query(VendorCard).filter_by(normalized_name=norm).first()` idiom each site already used.

**Replaced (5):** `vendors_crud.py:65`, `htmx_views.py:4352`, `vendor_contacts.py:80,88`, `sources.py:744`, `vendor_duplicates.py:89` (each keeps its local `norm` where it's reused for `VendorCard(...)` construction).

**Skipped (2, correctly):** `email_service.py:431` (passes the already-normalized `vendor_name_normalized` ORM field), `search_service.py:1911` (interleaved `if not norm: continue` guard) — not the byte-equivalent idiom.

## Verification
ruff / ruff-format / docformatter / mypy clean on all 7 changed files (incl. `htmx_views.py`); +5 tests in `test_vendor_helpers.py`; **full non-e2e suite — 20,384 passed, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qo6wV4QGTh4VUGg92xR7w)_