### PR TITLE
fix(authz): gate activity-logging + prospect-promote on account ownership (IDOR)

### DIFF
--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -31,7 +31,7 @@ from ..constants import (
     OutreachChannel,
 )
 from ..database import get_db
-from ..dependencies import require_user
+from ..dependencies import can_manage_account, require_user
 from ..models import ActivityLog, Company, CustomerSite, SiteContact, User, VendorCard
 from ..schemas.activity import (
     ActivityTimelineResponse,
@@ -70,6 +70,7 @@ def _check_rate_limit(user_id: int, bucket: str = "call", limit: int = _RATE_LIM
 
 def _validated_entity_ids(
     db: Session,
+    user: User,
     company_id: int | None,
     customer_site_id: int | None,
     site_contact_id: int | None = None,
@@ -116,6 +117,22 @@ def _validated_entity_ids(
         )
         site_contact_id = None
         dropped.append("contact")
+
+    # Authorization: only attribute the activity to an account the user may act on. A
+    # non-owner who clicks call/contact still gets their action logged, but it must NOT
+    # bump another rep's account clocks (last_activity_at / cadence) — drop the links.
+    if company_id is not None:
+        company = db.get(Company, company_id)
+        if company is not None and not can_manage_account(user, company, db):
+            logger.warning(f"activity log: user {user.id} may not manage company {company_id} — dropping account links")
+            company_id = None
+            if customer_site_id is not None and "site" not in dropped:
+                customer_site_id = None
+                dropped.append("site")
+            if site_contact_id is not None and "contact" not in dropped:
+                site_contact_id = None
+                dropped.append("contact")
+            dropped.append("company")
     return company_id, customer_site_id, site_contact_id, dropped
 
 
@@ -142,7 +159,7 @@ def call_initiated(
         phone_display = format_phone_display(body.phone_number)
 
         # Resolve company from vendor if not provided
-        company_id, customer_site_id, _, _ = _validated_entity_ids(db, body.company_id, body.customer_site_id)
+        company_id, customer_site_id, _, _ = _validated_entity_ids(db, user, body.company_id, body.customer_site_id)
         vendor_card_id = body.vendor_card_id
         vendor_name = None
 
@@ -234,7 +251,7 @@ def outreach_initiated(
             raise HTTPException(429, "Too many outreach logs — try again in a minute")
 
         company_id, customer_site_id, site_contact_id, dropped = _validated_entity_ids(
-            db, body.company_id, body.customer_site_id, body.site_contact_id
+            db, user, body.company_id, body.customer_site_id, body.site_contact_id
         )
 
         try:

--- a/app/routers/ai.py
+++ b/app/routers/ai.py
@@ -19,7 +19,12 @@ from sqlalchemy.orm import Session
 
 from ..config import settings
 from ..database import get_db
-from ..dependencies import get_req_for_user, require_requisition_access, require_user
+from ..dependencies import (
+    can_manage_account,
+    get_req_for_user,
+    require_requisition_access,
+    require_user,
+)
 from ..models import (
     Contact,
     CustomerSite,
@@ -296,6 +301,17 @@ async def promote_prospect_contact(
     db: Session = Depends(get_db),
 ):
     """Promote a prospect contact to a VendorContact or SiteContact."""
+    # Authz: a site-linked prospect promotes into a SiteContact under a customer account,
+    # so gate it on account-management. Vendor-linked prospects are global (no owner).
+    pc = db.get(ProspectContact, contact_id)
+    if pc is not None and pc.customer_site_id and not pc.vendor_card_id:
+        from ..models import Company
+
+        site = db.get(CustomerSite, pc.customer_site_id)
+        company = db.get(Company, site.company_id) if site else None
+        if not company or not can_manage_account(user, company, db):
+            raise HTTPException(403, "Not authorized to manage this account")
+
     from ..services.ai_offer_service import promote_prospect_contact as _promote
 
     try:

--- a/app/routers/v13_features/activity.py
+++ b/app/routers/v13_features/activity.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from ...config import settings
 from ...database import get_db
-from ...dependencies import require_admin, require_user
+from ...dependencies import can_manage_account, require_admin, require_user
 from ...models import Company, User, VendorCard
 from ...rate_limit import limiter
 from ...schemas.v13_features import (
@@ -254,6 +254,8 @@ async def log_company_phone_call(
     company = db.get(Company, company_id)
     if not company:
         raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(403, "Not authorized to manage this account")
 
     from app.services.activity_service import log_company_call
 
@@ -283,6 +285,8 @@ async def log_company_note_endpoint(
     company = db.get(Company, company_id)
     if not company:
         raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(403, "Not authorized to manage this account")
 
     from app.services.activity_service import log_company_note
 

--- a/tests/test_activity_authz_idor.py
+++ b/tests/test_activity_authz_idor.py
@@ -1,0 +1,118 @@
+"""IDOR regression tests for the Phase-5 account-authz gates.
+
+A logged-in user who does NOT own/manage an account must not be able to attribute
+activity to it (bumping its staleness/cadence clocks) or promote a prospect into it.
+
+Covers:
+  - POST /api/activity/call-initiated          → cross-account link is DROPPED (still logs the
+                                                  user's own action, but not attributed)
+  - POST /api/activity/outreach-initiated      → cross-account link DROPPED ("company" in dropped_links)
+  - POST /api/companies/{id}/activities/call   → 403
+  - POST /api/companies/{id}/activities/note   → 403
+  - POST /api/ai/prospect-contacts/{id}/promote → 403 for a site-linked prospect (200 for the owner)
+
+Called by: pytest
+Depends on: conftest fixtures — client is authenticated as test_user; sales_user is a
+            DIFFERENT user used as the "other rep" who owns the foreign account.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from app.models import ActivityLog
+from app.models.crm import Company, CustomerSite
+from app.models.enrichment import ProspectContact
+
+
+def _foreign_account(db_session, owner_id):
+    """A company+site owned by *owner_id* (not the authenticated client)."""
+    stale = datetime.now(timezone.utc) - timedelta(days=40)
+    co = Company(name="Other Rep Co", is_active=True, account_owner_id=owner_id, last_activity_at=stale)
+    db_session.add(co)
+    db_session.flush()
+    site = CustomerSite(company_id=co.id, site_name="Their HQ", is_active=True)
+    db_session.add(site)
+    db_session.commit()
+    return co, site
+
+
+def _not_recently_bumped(co):
+    """True if last_activity_at was NOT advanced to ~now (i.e. the clock was
+    untouched)."""
+    return co.last_activity_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc) - timedelta(days=1)
+
+
+class TestActivityAuthzIDOR:
+    def test_call_initiated_drops_unowned_company_link(self, client, db_session, sales_user):
+        co, site = _foreign_account(db_session, sales_user.id)
+        resp = client.post(
+            "/api/activity/call-initiated",
+            json={"phone_number": "4155551234", "company_id": co.id, "customer_site_id": site.id},
+        )
+        assert resp.status_code == 201  # the user's own action is still logged…
+        record = db_session.get(ActivityLog, resp.json()["id"])
+        assert record.company_id is None  # …but NOT attributed to the other rep's account
+        assert record.customer_site_id is None
+        db_session.refresh(co)
+        assert _not_recently_bumped(co)  # staleness clock untouched
+
+    def test_outreach_initiated_drops_unowned_company_link(self, client, db_session, sales_user):
+        co, site = _foreign_account(db_session, sales_user.id)
+        resp = client.post(
+            "/api/activity/outreach-initiated",
+            json={
+                "channel": "phone",
+                "contact_value": "+14155551234",
+                "company_id": co.id,
+                "customer_site_id": site.id,
+            },
+        )
+        assert resp.status_code == 201
+        assert "company" in resp.json()["dropped_links"]
+        db_session.refresh(co)
+        assert _not_recently_bumped(co)
+
+    def test_log_company_call_denied_for_non_owner(self, client, db_session, sales_user):
+        co, _site = _foreign_account(db_session, sales_user.id)
+        resp = client.post(
+            f"/api/companies/{co.id}/activities/call",
+            json={"phone": "+15551234567", "direction": "outbound", "duration_seconds": 30},
+        )
+        assert resp.status_code == 403
+
+    def test_log_company_note_denied_for_non_owner(self, client, db_session, sales_user):
+        co, _site = _foreign_account(db_session, sales_user.id)
+        resp = client.post(f"/api/companies/{co.id}/activities/note", json={"notes": "snooping"})
+        assert resp.status_code == 403
+
+    def test_promote_site_prospect_denied_for_non_owner(self, client, db_session, sales_user):
+        co, site = _foreign_account(db_session, sales_user.id)
+        pc = ProspectContact(
+            customer_site_id=site.id,
+            full_name="Prospect Person",
+            email="p@other.com",
+            source="web_search",
+            confidence="high",
+        )
+        db_session.add(pc)
+        db_session.commit()
+        resp = client.post(f"/api/ai/prospect-contacts/{pc.id}/promote")
+        assert resp.status_code == 403
+        db_session.refresh(pc)
+        assert pc.promoted_to_type is None  # not promoted
+
+    def test_promote_site_prospect_allowed_for_owner(self, client, db_session, test_user):
+        # Positive control: when the client OWNS the account, promotion succeeds (gate not over-broad).
+        co, site = _foreign_account(db_session, test_user.id)
+        pc = ProspectContact(
+            customer_site_id=site.id,
+            full_name="Owned Prospect",
+            email="owned@acme.com",
+            source="web_search",
+            confidence="high",
+        )
+        db_session.add(pc)
+        db_session.commit()
+        resp = client.post(f"/api/ai/prospect-contacts/{pc.id}/promote")
+        assert resp.status_code == 200
+        db_session.refresh(pc)
+        assert pc.promoted_to_type == "site_contact"

--- a/tests/test_activity_endpoint.py
+++ b/tests/test_activity_endpoint.py
@@ -129,7 +129,11 @@ class TestCallInitiated:
         record = db_session.get(ActivityLog, resp.json()["id"])
         assert "origin=vendor_detail" in record.notes
 
-    def test_with_company_id(self, client, db_session, test_company):
+    def test_with_company_id(self, client, db_session, test_company, test_user):
+        # Owner attribution: the authenticated client (test_user) must own the account
+        # for the activity-authz gate to keep the company link.
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
         resp = client.post(
             "/api/activity/call-initiated",
             json={

--- a/tests/test_activity_outreach.py
+++ b/tests/test_activity_outreach.py
@@ -23,11 +23,16 @@ def _clear_rate_limit():
 
 
 @pytest.fixture
-def cdm_company(db_session):
-    """Company + site + contact wired together for outreach tests."""
+def cdm_company(db_session, test_user):
+    """Company + site + contact wired together for outreach tests.
+
+    Owned by ``test_user`` (the authenticated client) so the account-authz gate on
+    the activity-logging routes passes for the happy-path attribution tests.
+    """
     company = Company(
         name="Outreach Test Co",
         is_active=True,
+        account_owner_id=test_user.id,
         last_activity_at=datetime.now(timezone.utc) - timedelta(days=40),
     )
     db_session.add(company)

--- a/tests/test_activity_router_coverage2.py
+++ b/tests/test_activity_router_coverage2.py
@@ -322,8 +322,10 @@ class TestCompanyActivities:
         )
         assert resp.status_code == 404
 
-    def test_log_company_call_success(self, client, test_company, db_session):
+    def test_log_company_call_success(self, client, test_company, db_session, test_user):
         """POST call log creates an activity record."""
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
         with patch(
             "app.services.activity_service.log_company_call",
             return_value=MagicMock(id=42),
@@ -344,8 +346,10 @@ class TestCompanyActivities:
         )
         assert resp.status_code == 404
 
-    def test_log_company_note_success(self, client, test_company, db_session):
+    def test_log_company_note_success(self, client, test_company, db_session, test_user):
         """POST note creates an activity record."""
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
         with patch(
             "app.services.activity_service.log_company_note",
             return_value=MagicMock(id=77),

--- a/tests/test_routers_ai.py
+++ b/tests/test_routers_ai.py
@@ -368,7 +368,7 @@ def test_promote_to_site_contact(ai_client, db_session, ai_test_user):
     """POST /api/ai/prospect-contacts/{id}/promote creates SiteContact."""
     from app.models import Company, CustomerSite, ProspectContact, SiteContact
 
-    co = Company(name="Promo Co")
+    co = Company(name="Promo Co", account_owner_id=ai_test_user.id)
     db_session.add(co)
     db_session.flush()
     site = CustomerSite(company_id=co.id, site_name="HQ")

--- a/tests/test_routers_v13.py
+++ b/tests/test_routers_v13.py
@@ -204,8 +204,10 @@ def test_company_activity_status_with_activity(client, test_company, test_activi
 # ═══════════════════════════════════════════════════════════════════════
 
 
-def test_log_company_call(client, test_company):
+def test_log_company_call(client, test_company, test_user, db_session):
     """POST /api/companies/{id}/activities/call logs a phone call."""
+    test_company.account_owner_id = test_user.id
+    db_session.commit()
     resp = client.post(
         f"/api/companies/{test_company.id}/activities/call",
         json={"phone": "+1-555-1234", "duration_seconds": 180, "notes": "Discussed pricing"},
@@ -215,8 +217,10 @@ def test_log_company_call(client, test_company):
     assert data["status"] == "logged"
 
 
-def test_log_company_note(client, test_company):
+def test_log_company_note(client, test_company, test_user, db_session):
     """POST /api/companies/{id}/activities/note logs a note."""
+    test_company.account_owner_id = test_user.id
+    db_session.commit()
     resp = client.post(
         f"/api/companies/{test_company.id}/activities/note",
         json={"notes": "Met at trade show"},


### PR DESCRIPTION
## Why (Phase-5 pre-multi-user hardening)
A multi-agent authz audit (adversarially verified) found a family of mutating routes gated only by `require_user` that let any logged-in rep act on accounts they don't own — a real cross-account IDOR ahead of the ~2026-07 multi-user launch.

## What
- **`POST /api/activity/call-initiated` + `/outreach-initiated`** — caller-supplied `company_id`/`customer_site_id` were attributed, bumping `last_activity_at` + cadence clocks of another rep's account (pollutes the CDM staleness sort + dormancy sweep). Fixed at the shared `_validated_entity_ids` helper: when the user can't `can_manage_account` the resolved company, the account links are **dropped** (the user's own action is still logged, just un-attributed) — matching the helper's existing "drop dangling links, don't reject" philosophy.
- **`POST /api/companies/{id}/activities/call` + `/note`** (v13) — now **403** for a non-owner.
- **`POST /api/ai/prospect-contacts/{id}/promote`** — a site-linked prospect promotes into a SiteContact under a customer account → now gated on `can_manage_account`; vendor-linked prospects stay global.

## Tests
6 new IDOR deny/allow tests (`tests/test_activity_authz_idor.py`). Existing happy-path activity tests updated to grant the authenticated user account ownership (the documented pattern), since they assumed the old ungated behavior. 192 targeted tests green; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)