### PR TITLE
fix(test): stop test_alembic corrupting the global alembic import (xdist migration flake)

### DIFF
--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -25,18 +25,17 @@ def _env_py_source():
 def _load_migration():
     """Load the initial migration module dynamically.
 
-    Mocks alembic.op and sqlalchemy so migrations can be imported outside of Alembic's
-    runtime context (where op is a stub).
+    Imports the migration file in isolation via ``importlib`` (the migration's
+    ``from alembic import op`` resolves to the real alembic ``op`` proxy, which imports
+    fine outside a live alembic run — these tests only read the module's source and
+    metadata, never invoke ``op.*``). The module is NOT registered in ``sys.modules`` and
+    nothing in the global ``alembic`` package is mutated: an earlier version stubbed
+    ``sys.modules["alembic"]`` / ``alembic.op`` with ``MagicMock``s and never restored
+    them, which under pytest-xdist corrupted the shared ``alembic`` import for every later
+    test on the same worker (the migration round-trip harness' ``from alembic.migration
+    import MigrationContext`` then failed with ``'alembic' is not a package``). Keeping the
+    load hermetic — no global import-state side effects — is the fix for that flake.
     """
-    import sys
-    from unittest.mock import MagicMock
-
-    # The project's alembic/ dir shadows the real package — inject stubs
-    alembic_mod = sys.modules.get("alembic") or MagicMock()
-    alembic_mod.op = MagicMock()
-    sys.modules["alembic"] = alembic_mod
-    sys.modules["alembic.op"] = alembic_mod.op
-
     files = sorted(MIGRATION_DIR.glob("*.py"))
     assert len(files) >= 1, "No migration files found"
     spec = importlib.util.spec_from_file_location("mig", files[0])


### PR DESCRIPTION
## Why
`TestMigration143Roundtrip` (and other migration round-trip tests) passed solo but **intermittently failed under `-n auto`** with `assert {'vendor_card_attachments'} <= {...}` — the attachment tables never landed on the scratch engine, with no error.

## Root cause
`tests/test_alembic.py::_load_migration()` permanently replaced `sys.modules["alembic"]` and `alembic.op` with `MagicMock`s and **never restored them**. On any xdist worker that ran `test_alembic.py` before it had cached the real alembic submodules, a later migration round-trip test's `from alembic.migration import MigrationContext` then failed (`'alembic' is not a package`) inside the harness — so the migration's `op.create_table` ran against a broken/wrong context and the tables silently weren't created. (This is the residual of issue #470 that the `run_ops` harness alone couldn't defend against, since the corruption happened in a *different* test's import machinery.)

## Fix
Remove the unnecessary global stubbing. The migration loads hermetically via `importlib`; its `from alembic import op` resolves to the real proxy (imports fine outside a live alembic run — these tests only read source/metadata, never invoke `op.*`). No global `alembic` import state is mutated.

## Verification
- Adversarial ordering (`test_alembic` → migration-143 + 096 + 097): **15/15 fail → 0/18**.
- Full `-n auto` suite: **20387 passed**, exit 0. pre-commit clean.

Unblocks promoting the schema-drift `test` gate to *required* (no remaining known flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)