### PR TITLE
feat(ui): Settings page accent conformance (PR7 peripheral)

### DIFF
--- a/app/templates/htmx/partials/settings/_connector_macros.html
+++ b/app/templates/htmx/partials/settings/_connector_macros.html
@@ -152,7 +152,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
                hx-swap="none"
                {{ _refresh_attr(s) }}
                aria-label="Enable {{ s.display_name }}">
-        <div class="w-8 h-4 bg-gray-200 rounded-full peer peer-focus-visible:ring-2 peer-focus-visible:ring-brand-400 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-brand-600 relative"></div>
+        <div class="w-8 h-4 bg-gray-200 rounded-full peer peer-focus-visible:ring-2 peer-focus-visible:ring-accent-400 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-accent-600 relative"></div>
       </label>
 
       {# Test button #}

--- a/app/templates/htmx/partials/settings/_macros.html
+++ b/app/templates/htmx/partials/settings/_macros.html
@@ -16,8 +16,8 @@
 {% macro tab_button(tab, url, label, icon_paths, extra_attrs='', target='#settings-content') -%}
 <button @click="tab = '{{ tab }}'"
             :class="tab === '{{ tab }}'
-              ? 'border-b-2 border-brand-500 text-brand-600 bg-brand-50'
-              : 'text-gray-600 hover:text-brand-600 hover:bg-brand-50'"
+              ? 'border-b-2 border-accent-500 text-accent-600 bg-accent-50'
+              : 'text-gray-600 hover:text-accent-600 hover:bg-accent-50'"
             class="shrink-0 whitespace-nowrap px-4 py-2.5 text-sm font-medium rounded-t-lg transition-colors"
             hx-get="{{ url }}"
             hx-target="{{ target }}"{{ extra_attrs|safe }}>
@@ -47,7 +47,7 @@
 {{ pad }}        hx-target="{{ target }}"
 {{ pad }}        hx-swap="innerHTML"
 {{ pad }}        hx-confirm="Merge '{{ drop }}' into '{{ keep }}'?"
-{{ pad }}        class="px-2 py-1 text-xs rounded {% if is_keeper %}bg-brand-500 text-white border border-brand-500 font-medium hover:bg-brand-600{% else %}bg-white text-gray-600 border border-gray-300 hover:bg-gray-50{% endif %}">
+{{ pad }}        class="px-2 py-1 text-xs rounded {% if is_keeper %}bg-accent-500 text-white border border-accent-500 font-medium hover:bg-accent-600{% else %}bg-white text-gray-600 border border-gray-300 hover:bg-gray-50{% endif %}">
 {{ pad }}  Keep "{{ keep|truncate(40) }}"
 {{ pad }}</button>
 {%- endmacro %}

--- a/app/templates/htmx/partials/settings/_mailbox_sync_card.html
+++ b/app/templates/htmx/partials/settings/_mailbox_sync_card.html
@@ -2,7 +2,7 @@
    Receives: inbox_status (dict from get_inbox_sync_status).
    Friendly copy + a real disconnected empty state; m365 errors shown as plain text. #}
 {% set dot = {'ok': 'bg-emerald-500', 'warning': 'bg-amber-500', 'error': 'bg-rose-500'} %}
-<div id="mailbox-sync-card" class="bg-white border border-brand-200 rounded-lg p-4">
+<div id="mailbox-sync-card" class="bg-white border border-line-base rounded-lg p-4">
   <div class="flex items-center justify-between">
     <h3 class="text-sm font-semibold text-gray-900 flex items-center gap-2">
       <span class="w-2.5 h-2.5 rounded-full {{ dot.get(inbox_status.health, 'bg-gray-300') }}"></span>
@@ -12,10 +12,10 @@
     <button hx-post="/v2/partials/settings/inbox/scan-now"
             hx-target="#mailbox-sync-card" hx-swap="outerHTML" data-loading-disable
             hx-indicator="#mailbox-scan-spinner"
-            class="px-3 py-1.5 text-xs font-medium text-brand-600 bg-brand-50 border border-brand-200 rounded-lg hover:bg-brand-100 inline-flex items-center gap-1.5">
+            class="px-3 py-1.5 text-xs font-medium text-accent-600 bg-accent-50 border border-accent-200 rounded-lg hover:bg-accent-100 inline-flex items-center gap-1.5">
       Scan now
       <span id="mailbox-scan-spinner" class="htmx-indicator">
-        <svg class="animate-spin h-3 w-3 text-brand-500" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+        <svg class="animate-spin h-3 w-3 text-accent-500" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
       </span>
     </button>
     {% endif %}

--- a/app/templates/htmx/partials/settings/data_ops.html
+++ b/app/templates/htmx/partials/settings/data_ops.html
@@ -10,14 +10,14 @@
 <div class="space-y-6">
 
   {# ── Pending OEM Spec-Code Mappings (admin approval queue) ── #}
-  <div class="bg-white border border-brand-200 rounded-lg overflow-hidden">
+  <div class="bg-white border border-line-base rounded-lg overflow-hidden">
     <div class="px-4 py-3 bg-gray-50 border-b flex items-center justify-between">
       <h2 class="text-lg font-semibold text-gray-900">OEM Spec-Code Approvals</h2>
       <a hx-get="/admin/spec-codes/pending"
          hx-target="#main-content"
          hx-push-url="true"
          href="/admin/spec-codes/pending"
-         class="px-3 py-1 text-xs font-medium text-brand-600 border border-brand-200 rounded hover:bg-brand-50">
+         class="px-3 py-1 text-xs font-medium text-accent-600 border border-accent-200 rounded hover:bg-accent-50">
         Open queue
       </a>
     </div>
@@ -30,12 +30,12 @@
   </div>
 
   {# ── Vendor Dedup ──────────────────────────────────────── #}
-  <div class="bg-white border border-brand-200 rounded-lg overflow-hidden">
+  <div class="bg-white border border-line-base rounded-lg overflow-hidden">
     <div class="px-4 py-3 bg-gray-50 border-b flex items-center justify-between">
       <h2 class="text-lg font-semibold text-gray-900">Vendor Duplicates</h2>
       <button hx-get="/v2/partials/settings/data-ops"
               hx-target="#settings-content"
-              class="px-3 py-1 text-xs font-medium text-brand-500 border border-brand-200 rounded hover:bg-brand-50">
+              class="px-3 py-1 text-xs font-medium text-accent-600 border border-accent-200 rounded hover:bg-accent-50">
         Refresh
       </button>
     </div>
@@ -86,7 +86,7 @@
   </div>
 
   {# ── Company Dedup ─────────────────────────────────────── #}
-  <div class="bg-white border border-brand-200 rounded-lg overflow-hidden">
+  <div class="bg-white border border-line-base rounded-lg overflow-hidden">
     <div class="px-4 py-3 bg-gray-50 border-b">
       <h2 class="text-lg font-semibold text-gray-900">Company Duplicates</h2>
     </div>

--- a/app/templates/htmx/partials/settings/index.html
+++ b/app/templates/htmx/partials/settings/index.html
@@ -18,7 +18,7 @@
 {% set content_url = _tab_content_urls.get(active_tab, '/v2/partials/settings/' ~ active_tab) %}
 <div class="page-fluid" x-data="{ tab: '{{ active_tab }}' }">
   {# Tab buttons — scroll horizontally on narrow screens instead of overflowing the page #}
-  <div class="flex gap-1 mb-6 border-b border-brand-200 overflow-x-auto">
+  <div class="flex gap-1 mb-6 border-b border-line-base overflow-x-auto">
     {{ tab_button('connectors', '/v2/partials/settings/connectors', 'Connectors', ['M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4']) }}
 
     {% if is_admin %}
@@ -46,7 +46,7 @@
        hx-target="#settings-content"
        hx-indicator="#settings-load-spinner">
     <div id="settings-load-spinner" class="htmx-indicator flex items-center justify-center py-6 sm:py-8">
-      <svg class="h-6 w-6 text-brand-400 animate-spin" viewBox="0 0 24 24" fill="none">
+      <svg class="h-6 w-6 text-accent-400 animate-spin" viewBox="0 0 24 24" fill="none">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
       </svg>

--- a/app/templates/htmx/partials/settings/ops_group.html
+++ b/app/templates/htmx/partials/settings/ops_group.html
@@ -4,8 +4,8 @@
                 admin/buy_plan_ops.toggle_ops_member (POST, swaps #ops-group-content).
    CSRF: htmx_app.js injects x-csrftoken on the toggle POST automatically. #}
 <div class="space-y-4" id="ops-group-content">
-  <div class="bg-white border border-brand-200 rounded-lg overflow-hidden">
-    <div class="px-5 py-4 bg-gray-50 border-b border-brand-200">
+  <div class="bg-white border border-line-base rounded-lg overflow-hidden">
+    <div class="px-5 py-4 bg-gray-50 border-b border-line-base">
       <h2 class="text-lg font-semibold text-gray-900">Ops Verification Group</h2>
       <p class="text-xs text-gray-600 mt-0.5">
         Members can verify Sales Orders and Purchase Orders in the buy-plan workflow.
@@ -30,7 +30,7 @@
         </thead>
         <tbody class="divide-y divide-gray-100">
           {% for row in rows %}
-          <tr class="hover:bg-brand-50/50 transition-colors">
+          <tr class="hover:bg-accent-50/50 transition-colors">
             <td class="table-cell">
               <div class="text-sm font-medium text-gray-900">{{ row.user.name or row.user.email }}</div>
               <div class="text-xs text-gray-600">{{ row.user.email }}</div>
@@ -58,7 +58,7 @@
                       hx-target="#ops-group-content" hx-swap="outerHTML"
                       hx-confirm="Grant {{ row.user.name or row.user.email }} authority to verify Sales Orders and Purchase Orders?"
                       data-loading-disable
-                      class="px-2.5 py-1 text-xs font-medium text-brand-600 bg-brand-50 border border-brand-200 rounded hover:bg-brand-100 transition-colors">Add</button>
+                      class="px-2.5 py-1 text-xs font-medium text-accent-600 bg-accent-50 border border-accent-200 rounded hover:bg-accent-100 transition-colors">Add</button>
               {% endif %}
             </td>
           </tr>

--- a/app/templates/htmx/partials/settings/profile.html
+++ b/app/templates/htmx/partials/settings/profile.html
@@ -12,7 +12,7 @@
 <div class="max-w-2xl">
   {# Identity + click-to-call card. Alpine holds name/extension so each save
      posts both fields (the endpoint requires name AND extension together). #}
-  <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6"
+  <div class="bg-white border border-line-base rounded-lg p-4 mb-6"
        x-data='{
          editingName: false,
          name: {{ (profile_user.name or "")|tojson }},
@@ -24,7 +24,7 @@
     <div class="space-y-5">
       {# Avatar + editable display name (email shown once, here) #}
       <div class="flex items-center gap-4">
-        <div class="w-14 h-14 rounded-full bg-brand-500 flex items-center justify-center text-white text-xl font-bold">
+        <div class="w-14 h-14 rounded-full bg-accent-500 flex items-center justify-center text-white text-xl font-bold">
           <span x-text="(name && name[0] ? name[0] : '?').toUpperCase()">{{ profile_user.name[0]|upper if profile_user.name else '?' }}</span>
         </div>
         <div class="min-w-0">
@@ -33,7 +33,7 @@
             <p class="text-lg font-semibold text-gray-900 truncate" x-text="name">{{ profile_user.name }}</p>
             <button type="button"
                     @click="draftName = name; editingName = true; $nextTick(() => $refs.nameInput.focus())"
-                    class="text-gray-400 hover:text-brand-600 shrink-0"
+                    class="text-gray-400 hover:text-accent-600 shrink-0"
                     title="Edit display name" aria-label="Edit display name">
               <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
@@ -49,9 +49,9 @@
             <input type="text" name="name" x-ref="nameInput" x-model="draftName"
                    maxlength="255" required
                    @keydown.escape="editingName = false"
-                   class="text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-brand-400">
+                   class="input input-sm w-auto">
             <input type="hidden" name="extension" :value="extension">
-            <button type="submit" class="text-xs font-medium text-brand-600 hover:text-brand-800">Save</button>
+            <button type="submit" class="text-xs font-medium text-accent-600 hover:text-accent-800">Save</button>
             <button type="button" @click="editingName = false" class="text-xs text-gray-400 hover:text-gray-600">Cancel</button>
           </form>
           <p class="text-sm text-gray-600 truncate">{{ profile_user.email }}</p>
@@ -64,7 +64,7 @@
       <div>
         <label class="block text-sm font-medium text-gray-600 mb-1.5">Role</label>
         {% set role_colors = {
-          'admin': 'bg-brand-500 text-white',
+          'admin': 'bg-accent-500 text-white',
           'buyer': 'bg-emerald-50 text-emerald-700',
           'sales': 'bg-amber-50 text-amber-700',
           'manager': 'bg-brand-100 text-brand-600',
@@ -93,15 +93,15 @@
         <div class="flex items-center gap-2">
           <input type="text" name="extension" x-model="extension"
                  maxlength="20" placeholder="e.g. 1234"
-                 class="w-40 text-sm border border-gray-300 rounded px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-brand-400">
-          <button type="submit" class="px-3 py-1.5 text-xs font-medium text-brand-600 bg-brand-50 border border-brand-200 rounded-lg hover:bg-brand-100">Save</button>
+                 class="input input-sm w-40">
+          <button type="submit" class="px-3 py-1.5 text-xs font-medium text-accent-600 bg-accent-50 border border-accent-200 rounded-lg hover:bg-accent-100">Save</button>
         </div>
       </form>
     </div>
   </div>
 
   {# 8x8 click-to-call enable/disable #}
-  <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6"
+  <div class="bg-white border border-line-base rounded-lg p-4 mb-6"
        x-data="{ enabled: {{ 'true' if profile_user.eight_by_eight_enabled is defined and profile_user.eight_by_eight_enabled else 'false' }} }">
     <div class="flex items-center justify-between">
       <div>
@@ -114,20 +114,20 @@
                hx-post="/api/user/toggle-8x8"
                hx-swap="none"
                data-loading-disable>
-        <div class="w-11 h-6 bg-gray-200 peer-focus:ring-2 peer-focus:ring-brand-300 rounded-full
+        <div class="w-11 h-6 bg-gray-200 peer-focus:ring-2 peer-focus:ring-accent-300 rounded-full
                     peer peer-checked:after:translate-x-full peer-checked:after:border-white
                     after:content-[''] after:absolute after:top-[2px] after:left-[2px]
                     after:bg-white after:border-gray-300 after:border after:rounded-full
-                    after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                    after:h-5 after:w-5 after:transition-all peer-checked:bg-accent-500"></div>
       </label>
     </div>
-    <div x-show="enabled" x-cloak class="mt-3 p-3 bg-brand-50 rounded-md">
-      <p class="text-xs text-brand-600">Click-to-call is active. Phone numbers across the app will dial through 8x8.</p>
+    <div x-show="enabled" x-cloak class="mt-3 p-3 bg-accent-50 rounded-md">
+      <p class="text-xs text-accent-600">Click-to-call is active. Phone numbers across the app will dial through 8x8.</p>
     </div>
   </div>
 
   {# Notifications card — two toggles cloned from the 8x8 toggle markup #}
-  <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6">
+  <div class="bg-white border border-line-base rounded-lg p-4 mb-6">
     <h3 class="text-sm font-semibold text-gray-900 mb-4">Notifications</h3>
     <div class="space-y-4">
       {# Buy-plan email updates #}
@@ -143,11 +143,11 @@
                  hx-post="/api/user/toggle-buyplan-email"
                  hx-swap="none"
                  data-loading-disable>
-          <div class="w-11 h-6 bg-gray-200 peer-focus:ring-2 peer-focus:ring-brand-300 rounded-full
+          <div class="w-11 h-6 bg-gray-200 peer-focus:ring-2 peer-focus:ring-accent-300 rounded-full
                       peer peer-checked:after:translate-x-full peer-checked:after:border-white
                       after:content-[''] after:absolute after:top-[2px] after:left-[2px]
                       after:bg-white after:border-gray-300 after:border after:rounded-full
-                      after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                      after:h-5 after:w-5 after:transition-all peer-checked:bg-accent-500"></div>
         </label>
       </div>
 
@@ -164,11 +164,11 @@
                  hx-post="/api/user/toggle-new-offer-alert"
                  hx-swap="none"
                  data-loading-disable>
-          <div class="w-11 h-6 bg-gray-200 peer-focus:ring-2 peer-focus:ring-brand-300 rounded-full
+          <div class="w-11 h-6 bg-gray-200 peer-focus:ring-2 peer-focus:ring-accent-300 rounded-full
                       peer peer-checked:after:translate-x-full peer-checked:after:border-white
                       after:content-[''] after:absolute after:top-[2px] after:left-[2px]
                       after:bg-white after:border-gray-300 after:border after:rounded-full
-                      after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                      after:h-5 after:w-5 after:transition-all peer-checked:bg-accent-500"></div>
         </label>
       </div>
     </div>

--- a/app/templates/htmx/partials/settings/system.html
+++ b/app/templates/htmx/partials/settings/system.html
@@ -13,9 +13,9 @@
 #}
 
 <div class="max-w-2xl">
-  <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6">
+  <div class="bg-white border border-line-base rounded-lg p-4 mb-6">
     <div class="flex items-center gap-2 mb-1">
-      <svg class="w-5 h-5 text-brand-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg class="w-5 h-5 text-accent-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/>
       </svg>
       <h2 class="text-lg font-semibold text-gray-900">System Settings</h2>
@@ -45,11 +45,11 @@
                    hx-ext="json-enc"
                    data-loading-disable
                    aria-label="{{ item.label }}">
-            <div class="w-11 h-6 bg-gray-200 peer-focus:ring-2 peer-focus:ring-brand-300 rounded-full
+            <div class="w-11 h-6 bg-gray-200 peer-focus:ring-2 peer-focus:ring-accent-300 rounded-full
                         peer peer-checked:after:translate-x-full peer-checked:after:border-white
                         after:content-[''] after:absolute after:top-[2px] after:left-[2px]
                         after:bg-white after:border-gray-300 after:border after:rounded-full
-                        after:h-5 after:w-5 after:transition-all peer-checked:bg-brand-500"></div>
+                        after:h-5 after:w-5 after:transition-all peer-checked:bg-accent-500"></div>
           </label>
         </div>
         {% else %}
@@ -70,11 +70,10 @@
               <input type="number" name="value" value="{{ item.value }}"
                      min="{{ item.min }}" step="1" required
                      aria-label="{{ item.label }}"
-                     class="w-24 text-sm border border-gray-300 rounded px-2 py-1.5
-                            focus:outline-none focus:ring-2 focus:ring-brand-400">
+                     class="input input-sm w-24">
               <button type="submit" data-loading-disable
-                      class="px-3 py-1.5 text-xs font-medium text-brand-600 bg-brand-50
-                             border border-brand-200 rounded-lg hover:bg-brand-100">Save</button>
+                      class="px-3 py-1.5 text-xs font-medium text-accent-600 bg-accent-50
+                             border border-accent-200 rounded-lg hover:bg-accent-100">Save</button>
             </form>
           </div>
         </div>
@@ -86,7 +85,7 @@
 
   {# Read-only job-state watermarks — collapsed disclosure, never editable. #}
   {% if job_state %}
-  <div class="bg-white border border-brand-200 rounded-lg p-4 mb-6"
+  <div class="bg-white border border-line-base rounded-lg p-4 mb-6"
        x-data="{ open: false }">
     <button type="button" @click="open = !open"
             class="w-full flex items-center justify-between text-left">

--- a/app/templates/htmx/partials/settings/user_access_panel.html
+++ b/app/templates/htmx/partials/settings/user_access_panel.html
@@ -11,16 +11,16 @@
      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
      role="dialog" aria-modal="true" aria-label="Edit access"
      @click.self="$el.remove()" @keydown.escape.window="$el.remove()">
-  <div class="bg-white rounded-lg border border-brand-200 shadow-2xl w-full max-w-lg mx-4 max-h-[85vh] overflow-y-auto">
+  <div class="bg-white rounded-lg border border-line-base shadow-2xl w-full max-w-lg mx-4 max-h-[85vh] overflow-y-auto">
 
     {# ── Header ──────────────────────────────────────────────────────── #}
-    <div class="flex items-start justify-between px-5 py-4 border-b border-brand-200 sticky top-0 bg-white">
+    <div class="flex items-start justify-between px-5 py-4 border-b border-line-base sticky top-0 bg-white">
       <div>
         <h3 class="text-lg font-semibold text-brand-900">Access — {{ target.name or target.email }}</h3>
         <p class="text-xs text-gray-600 mt-0.5">Default follows the user's role.</p>
       </div>
       <button type="button" @click="$el.closest('#user-access-panel').remove()"
-              class="btn-secondary btn-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+              class="btn-secondary btn-sm focus:outline-none focus:ring-2 focus:ring-accent-500"
               aria-label="Close">Close</button>
     </div>
 

--- a/app/templates/htmx/partials/settings/users.html
+++ b/app/templates/htmx/partials/settings/users.html
@@ -11,8 +11,8 @@
   {% endif %}
 
   {# ── Invite ──────────────────────────────────────────────────────── #}
-  <div class="bg-white border border-brand-200 rounded-lg overflow-hidden">
-    <div class="px-5 py-4 bg-gray-50 border-b border-brand-200">
+  <div class="bg-white border border-line-base rounded-lg overflow-hidden">
+    <div class="px-5 py-4 bg-gray-50 border-b border-line-base">
       <h2 class="text-lg font-semibold text-gray-900">Invite a user</h2>
       <p class="text-xs text-gray-600 mt-0.5">
         Add a teammate by email and pick their role. They can sign in with their
@@ -46,8 +46,8 @@
   </div>
 
   {# ── User table ──────────────────────────────────────────────────── #}
-  <div class="bg-white border border-brand-200 rounded-lg overflow-hidden">
-    <div class="px-5 py-4 bg-gray-50 border-b border-brand-200 flex items-start justify-between gap-3">
+  <div class="bg-white border border-line-base rounded-lg overflow-hidden">
+    <div class="px-5 py-4 bg-gray-50 border-b border-line-base flex items-start justify-between gap-3">
       <div>
         <h2 class="text-lg font-semibold text-gray-900">Users</h2>
         <p class="text-xs text-gray-600 mt-0.5">
@@ -76,7 +76,7 @@
         </thead>
         <tbody class="divide-y divide-gray-100">
           {% for row in rows %}
-          <tr class="hover:bg-brand-50/50 transition-colors">
+          <tr class="hover:bg-accent-50/50 transition-colors">
             <td class="table-cell">
               <div class="text-sm font-medium text-gray-900">{{ row.user.name or row.user.email }}</div>
               <div class="text-xs text-gray-600">{{ row.user.email }}</div>

--- a/app/templates/htmx/partials/settings/users_audit.html
+++ b/app/templates/htmx/partials/settings/users_audit.html
@@ -17,16 +17,16 @@
      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
      role="dialog" aria-modal="true" aria-label="User management audit log"
      @click.self="$el.remove()" @keydown.escape.window="$el.remove()">
-  <div class="bg-white rounded-lg border border-brand-200 shadow-2xl w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col">
+  <div class="bg-white rounded-lg border border-line-base shadow-2xl w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col">
 
     {# ── Header ──────────────────────────────────────────────────────── #}
-    <div class="flex items-start justify-between px-5 py-4 border-b border-brand-200">
+    <div class="flex items-start justify-between px-5 py-4 border-b border-line-base">
       <div>
         <h3 class="text-lg font-semibold text-brand-900">User management audit log</h3>
         <p class="text-xs text-gray-600 mt-0.5">Every invite, role change, activation and access change, newest first.</p>
       </div>
       <button type="button" @click="$el.closest('#user-audit-log').remove()"
-              class="btn-secondary btn-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+              class="btn-secondary btn-sm focus:outline-none focus:ring-2 focus:ring-accent-500"
               aria-label="Close">Close</button>
     </div>
 
@@ -47,7 +47,7 @@
         </thead>
         <tbody class="divide-y divide-gray-100">
           {% for row in audit_rows %}
-          <tr class="hover:bg-brand-50/50 transition-colors">
+          <tr class="hover:bg-accent-50/50 transition-colors">
             <td class="table-cell text-xs text-gray-600 whitespace-nowrap">{{ row.when | fmtdate }}</td>
             <td class="table-cell text-sm text-gray-900">
               {{ row.actor.name or row.actor.email if row.actor else 'system' }}
@@ -56,7 +56,7 @@
               {{ row.target.name or row.target.email if row.target else '—' }}
             </td>
             <td class="table-cell">
-              <span class="badge bg-brand-50 text-brand-700 border-brand-200">{{ action_labels.get(row.action, row.action) }}</span>
+              <span class="badge-info">{{ action_labels.get(row.action, row.action) }}</span>
             </td>
             <td class="table-cell text-xs text-gray-600">
               {% if row.detail %}
@@ -71,7 +71,7 @@
       </table>
     </div>
     {% if truncated %}
-    <div class="px-5 py-3 border-t border-brand-200 text-xs text-gray-600">Showing latest {{ limit }} of {{ total }}.</div>
+    <div class="px-5 py-3 border-t border-line-base text-xs text-gray-600">Showing latest {{ limit }} of {{ total }}.</div>
     {% endif %}
     {% endif %}
   </div>


### PR DESCRIPTION
PR7 peripheral conformance: 11 Settings templates, 82 brand→55 accent + 21 border-line swaps; 0 migratable brand left. Ratchet + 1797 render tests green; Alpine/hx behavior unchanged. Template-only.