### PR TITLE
feat(ui): Trouble-Tickets page accent conformance (PR7 peripheral)

### DIFF
--- a/app/templates/htmx/partials/tickets/_icons.html
+++ b/app/templates/htmx/partials/tickets/_icons.html
@@ -11,7 +11,7 @@ Called-by:
 
 Usage:
   {% from "htmx/partials/tickets/_icons.html" import sparkle_icon, chevron_icon %}
-  {{ sparkle_icon("w-4 h-4 text-brand-500") }}
+  {{ sparkle_icon("w-4 h-4 figure-accent") }}
   <svg :class="open ? 'rotate-90' : ''" ...>  -- chevron keeps its Alpine :class inline
 #}
 

--- a/app/templates/htmx/partials/tickets/_row.html
+++ b/app/templates/htmx/partials/tickets/_row.html
@@ -2,10 +2,12 @@
      hx-target="#main-content"
      hx-push-url="/v2/trouble-tickets/{{ t.id }}"
      class="flex items-center gap-4 px-4 py-3 bg-white border border-gray-100 rounded-lg mb-1 cursor-pointer hover:bg-gray-50 transition-colors">
+  {# Checkbox — accent via accent-color + input-focus ring (not brand-500). #}
   <input type="checkbox" @click.stop
          @change="typeof toggle === 'function' && toggle({{ t.id }})"
          :checked="typeof selected !== 'undefined' && selected.includes({{ t.id }})"
-         class="shrink-0 rounded border-gray-300 text-brand-600 focus:ring-brand-500 cursor-pointer"
+         class="shrink-0 rounded border-gray-300 input-focus cursor-pointer"
+         style="accent-color:var(--accent)"
          aria-label="Select ticket {{ t.ticket_number }}">
   <span class="text-xs font-mono text-gray-400 w-16 shrink-0">{{ t.ticket_number }}</span>
   <span class="text-sm text-gray-700 flex-1 truncate">{{ t.ai_summary or t.title }}</span>

--- a/app/templates/htmx/partials/tickets/detail.html
+++ b/app/templates/htmx/partials/tickets/detail.html
@@ -35,7 +35,7 @@
                 var t = Alpine.store('toast');
                 t.message = 'Could not update status'; t.type = 'error'; t.show = true;
               })"
-              class="text-sm border border-gray-300 rounded-md px-3 py-1.5 focus:border-brand-500 focus:ring-1 focus:ring-brand-500">
+              class="input input-sm">
         <option value="submitted">Submitted</option>
         <option value="in_progress">In Progress</option>
         <option value="resolved">Resolved</option>
@@ -44,12 +44,13 @@
     </div>
   </div>
 
-  {# AI Summary #}
+  {# AI Summary — the one hero AI callout per view. Sparkle + label carry the
+     design-system accent (state marker); the panel chrome is a neutral hairline. #}
   {% if ticket.ai_summary %}
-  <div class="bg-brand-50 border border-brand-200 rounded-lg p-4 mb-6">
+  <div class="bg-gray-50 border border-line-base rounded-lg p-4 mb-6">
     <div class="flex items-center gap-2 mb-1">
-      {{ sparkle_icon("w-4 h-4 text-brand-500") }}
-      <span class="text-xs font-medium text-brand-600">AI Summary</span>
+      {{ sparkle_icon("w-4 h-4 figure-accent") }}
+      <span class="text-xs font-medium figure-accent">AI Summary</span>
     </div>
     <p class="text-sm text-gray-700">{{ ticket.ai_summary }}</p>
   </div>

--- a/app/templates/htmx/partials/tickets/workspace.html
+++ b/app/templates/htmx/partials/tickets/workspace.html
@@ -29,11 +29,13 @@
   <div class="flex gap-2 mb-4" x-data="{ filter: '' }">
     {% set filters = [('', 'All'), ('open', 'Open'), ('resolved', 'Resolved'), ('wont_fix', "Won't Fix")] %}
     {% for val, label in filters %}
+    {# Active filter resolves to the design-system accent (state), inactive stays neutral chrome. #}
     <button @click="filter = '{{ val }}'"
             hx-get="/v2/partials/trouble-tickets/list?status={{ val }}"
             hx-target="#ticket-list"
-            :class="filter === '{{ val }}' ? 'bg-brand-500 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
-            class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors">
+            :style="filter === '{{ val }}' ? 'background-color:var(--accent);color:var(--accent-contrast)' : ''"
+            :class="filter === '{{ val }}' ? '' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+            class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors input-focus">
       {{ label }}
     </button>
     {% endfor %}
@@ -41,8 +43,8 @@
 
   {# Bulk action bar — visible only when rows are selected #}
   <div x-show="selected.length > 0" x-cloak
-       class="flex items-center gap-2 mb-4 p-2 bg-brand-50 border border-brand-200 rounded-lg">
-    <span class="text-xs font-medium text-brand-700" x-text="selected.length + ' selected'"></span>
+       class="flex items-center gap-2 mb-4 p-2 bg-gray-50 border border-line-base rounded-lg">
+    <span class="text-xs font-medium text-gray-700" x-text="selected.length + ' selected'"></span>
     <button @click="diagnoseBulk()" class="btn btn-primary btn-sm gap-1">
       {{ sparkle_icon("w-3.5 h-3.5") }} Diagnose selected
     </button>


### PR DESCRIPTION
PR7 peripheral conformance: 7 interactive brand→accent migrations across the tickets templates; semantic status/severity colors preserved. Ratchet + ticket tests (44) green. Template-only.