### PR TITLE
feat(ui): reorganize My Day into an action-first daily worklist

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -17488,6 +17488,8 @@ async def my_day_partial(
 
     # 1. Overdue / due follow-up accounts I own — reuse the shared _needs_call_filter
     #    (staleness="needs_call") so the count and this list always agree with the CRM chip.
+    #    Eager-load primary_contact so each row can render the one-click call/email
+    #    outreach action without an N+1 lazy-load per account (up to 50 rows).
     _accounts_q = _cdm_company_query(
         db,
         user,
@@ -17497,14 +17499,19 @@ async def my_day_partial(
         my_only=True,
         sort="outbound_asc",
         now=now,
-    )
+    ).options(joinedload(Company.primary_contact))
     accounts = _accounts_q.limit(50).all()
 
     # Annotate each account with its cadence_state (reused — not recomputed inline).
+    # attention_count = accounts the page exists to action: overdue (clock blown) or
+    # never-contacted ("new"). Surfaced as the header's single key figure.
     account_rows = []
+    attention_count = 0
     for co in accounts:
         state = _cadence_state(co.tier, co.last_outbound_at, now)
         out_days = (now - co.last_outbound_at).days if co.last_outbound_at else None
+        if state in ("overdue", "new"):
+            attention_count += 1
         account_rows.append({"company": co, "cadence_state": state, "out_days": out_days})
 
     # 2. My open tasks — due/overdue first (get_my_tasks already excludes done).
@@ -17516,6 +17523,7 @@ async def my_day_partial(
 
     ctx = _base_ctx(request, user, "my-day")
     ctx["account_rows"] = account_rows
+    ctx["attention_count"] = attention_count
     ctx["tasks"] = tasks
     ctx["now_utc"] = now
     return template_response("htmx/partials/my_day.html", ctx)

--- a/app/templates/htmx/partials/my_day.html
+++ b/app/templates/htmx/partials/my_day.html
@@ -1,61 +1,93 @@
-{# my_day.html — "My Day" worklist: overdue/due accounts + my open tasks.
+{# my_day.html — "My Day" action-first daily worklist.
+   Reorganized (PR6 of the total-UI review) from a flat two-section list into a
+   prioritized worklist: an attention header answering "what needs me today?",
+   a Follow-up call-down list with urgency rails + one-click call/email outreach
+   on every row, and a due/overdue-first task queue.
+
    Receives: account_rows (list of {company, cadence_state, out_days}),
+             attention_count (int — overdue + never-contacted accounts),
              tasks (list[RequisitionTask], due/overdue first),
              now_utc (datetime).
    Called by: /v2/partials/my-day (my_day_partial route in htmx_views.py).
-   Depends on: crm_service cadence model, task_service.get_my_tasks.
+   Depends on: crm_service cadence model, task_service.get_my_tasks, the shared
+               outreach_btn macro (call/email + auto activity logging) and
+               task_priority_badge / badge primitives.
 #}
-{% from "htmx/partials/shared/_macros.html" import task_priority_badge %}
+{% from "htmx/partials/shared/_macros.html" import task_priority_badge, badge %}
+{% from "htmx/partials/customers/_contact_macros.html" import outreach_btn %}
+
+{% set CALL_ICON = "M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" %}
+{% set EMAIL_ICON = "M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" %}
+
+{# Per-cadence presentation: dot color, badge tone (mapped onto .badge primitive),
+   left urgency rail, and human label. overdue/new = call-now (rose); due = amber. #}
 {% set cadence_dot = {
-  'new':       'bg-gray-300',
+  'new':       'bg-rose-500',
   'on_target': 'bg-emerald-400',
   'due':       'bg-amber-400',
   'overdue':   'bg-rose-500'
 } %}
 {% set cadence_label = {
-  'new':       'New',
+  'new':       'Never contacted',
   'on_target': 'On Target',
   'due':       'Due',
   'overdue':   'Overdue'
 } %}
-{% set cadence_badge = {
-  'new':       'bg-gray-100 text-gray-600 border-gray-200',
-  'on_target': 'bg-emerald-100 text-emerald-700 border-emerald-200',
-  'due':       'bg-amber-100 text-amber-700 border-amber-200',
-  'overdue':   'bg-rose-100 text-rose-700 border-rose-200'
+{% set cadence_tone = {
+  'new':       'danger',
+  'on_target': 'success',
+  'due':       'warning',
+  'overdue':   'danger'
+} %}
+{% set cadence_rail = {
+  'new':       'border-l-4 border-l-rose-400',
+  'on_target': 'border-l-4 border-l-emerald-300',
+  'due':       'border-l-4 border-l-amber-300',
+  'overdue':   'border-l-4 border-l-rose-400'
 } %}
 
 <title hx-swap-oob="true">My Day — AvailAI</title>
 
 <div class="page-readable space-y-6 py-4">
 
-  {# ── Page header ─────────────────────────────────────────────────── #}
+  {# ── Attention header — answers "what needs me today?" in <3s ───────── #}
   <div>
     <h1 class="text-xl font-bold text-gray-900">My Day</h1>
-    <p class="text-sm text-gray-500 mt-0.5">Accounts needing a call + your open tasks.</p>
+    {% if attention_count %}
+    <p class="text-sm text-gray-600 mt-0.5">
+      <span class="figure-accent text-2xl font-bold align-middle">{{ attention_count }}</span>
+      <span class="align-middle">
+        {{ 'account needs' if attention_count == 1 else 'accounts need' }} a call today
+        {% if tasks %}&middot; {{ tasks|length }} open {{ 'task' if tasks|length == 1 else 'tasks' }}{% endif %}
+      </span>
+    </p>
+    {% else %}
+    <p class="text-sm text-gray-600 mt-0.5">
+      {% if tasks %}{{ tasks|length }} open {{ 'task' if tasks|length == 1 else 'tasks' }} — no accounts overdue for a call.
+      {% else %}Accounts needing a call + your open tasks.{% endif %}
+    </p>
+    {% endif %}
   </div>
 
   {% if not account_rows and not tasks %}
   {# ── Empty state ─────────────────────────────────────────────────── #}
   <div class="card px-6 py-10 text-center">
-    <svg xmlns="http://www.w3.org/2000/svg" class="mx-auto h-10 w-10 text-gray-300 mb-3"
+    <svg xmlns="http://www.w3.org/2000/svg" class="mx-auto h-10 w-10 text-emerald-400 mb-3"
          fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"
          stroke-linecap="round" stroke-linejoin="round">
       <path d="M5 13l4 4L19 7"/>
     </svg>
     <p class="text-sm font-semibold text-gray-700">All caught up — nothing due today.</p>
-    <p class="text-xs text-gray-400 mt-1">Check back later or head to CRM to explore your accounts.</p>
+    <p class="text-xs text-gray-600 mt-1">Check back later or head to CRM to explore your accounts.</p>
   </div>
 
   {% else %}
 
-  {# ── Section 1: Follow up ─────────────────────────────────────────── #}
+  {# ── Section 1: Follow up (the call-down list) ────────────────────── #}
   <section>
-    <h2 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
+    <h2 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">
       Follow up
-      {% if account_rows %}
-      <span class="ml-1.5 badge bg-rose-100 text-rose-700 border-rose-200">{{ account_rows|length }}</span>
-      {% endif %}
+      {% if account_rows %}{{ badge(account_rows|length, tone='danger') }}{% endif %}
     </h2>
 
     {% if account_rows %}
@@ -63,10 +95,12 @@
       {% for row in account_rows %}
       {% set co = row.company %}
       {% set state = row.cadence_state %}
+      {% set contact = co.primary_contact %}
+      {% set reachable = contact and not contact.do_not_contact %}
       <li>
-        <div class="flex items-center gap-2 rounded-lg border border-line-base bg-white px-4 py-3
+        <div class="flex items-center gap-2 rounded-lg border border-line-base {{ cadence_rail.get(state, '') }} bg-white px-4 py-3
                     hover:border-accent-300 hover:bg-accent-50 transition-colors group">
-          {# Company link — takes up full flex-1 area #}
+          {# Company link — fills the row, navigates into the account #}
           <a href="/v2/customers/{{ co.id }}"
              hx-get="/v2/partials/customers/{{ co.id }}"
              hx-target="#main-content"
@@ -77,13 +111,11 @@
             <span class="flex-shrink-0 w-2.5 h-2.5 rounded-full {{ cadence_dot.get(state, 'bg-gray-300') }}"
                   role="img" aria-label="{{ cadence_label.get(state, state|title) }}"></span>
 
-            {# Company name + badge #}
+            {# Company name + cadence badge #}
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2 min-w-0">
                 <span class="text-sm font-semibold text-gray-900 truncate group-hover:text-accent-700">{{ co.name }}</span>
-                <span class="badge {{ cadence_badge.get(state, 'bg-gray-100 text-gray-600 border-gray-200') }} flex-shrink-0">
-                  {{ cadence_label.get(state, state|title) }}
-                </span>
+                {{ badge(cadence_label.get(state, state|title), tone=cadence_tone.get(state, 'neutral')) }}
               </div>
               <div class="flex items-center gap-2 text-xs text-gray-600 mt-0.5">
                 {% if co.account_owner %}
@@ -95,45 +127,55 @@
                 {% else %}
                   <span>Never contacted</span>
                 {% endif %}
+                {% if contact and contact.full_name %}
+                  <span>&middot;</span>
+                  <span class="truncate">{{ contact.full_name }}</span>
+                {% endif %}
               </div>
             </div>
-
-            {# Chevron #}
-            <svg xmlns="http://www.w3.org/2000/svg" class="flex-shrink-0 h-4 w-4 text-gray-300 group-hover:text-accent-400"
-                 fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
-            </svg>
           </a>
 
-          {# Quick-action: Log note button — repoints to the customer add-note-form modal.
-             (A dedicated call-log endpoint does not exist; note form is the closest
-             usable surface. Follow-up: add a call-type variant to the note form.) #}
-          <button @click="$dispatch('open-modal', {url: '/v2/partials/customers/{{ co.id }}/activity/add-note-form'})"
-                  hx-get="/v2/partials/customers/{{ co.id }}/activity/add-note-form"
-                  hx-target="#modal-content"
-                  class="flex-shrink-0 btn-secondary btn-sm"
-                  title="Log a note for {{ co.name }}">
-            <svg class="w-3.5 h-3.5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
-            </svg>
-            Log
-          </button>
+          {# ── One-click outreach rail — "the phone is the weapon". Call / Email
+             go through the shared outreach_btn macro (tel:/Outlook deeplink +
+             data-outreach-log so every touch auto-logs an outbound activity and
+             advances the cadence clock). Log = manual note modal. ───────── #}
+          <div class="flex-shrink-0 flex items-center gap-1.5" @click.stop>
+            {% if reachable and contact.phone %}
+              {{ outreach_btn("Call", "tel:" ~ contact.phone, "phone", contact.phone,
+                              co.id, contact.customer_site_id, contact.id, contact.full_name,
+                              CALL_ICON) }}
+            {% endif %}
+            {% if reachable and contact.email %}
+              {{ outreach_btn("Email", "https://outlook.office.com/mail/deeplink/compose?to=" ~ contact.email|urlencode, "email", contact.email,
+                              co.id, contact.customer_site_id, contact.id, contact.full_name,
+                              EMAIL_ICON, new_tab=True) }}
+            {% endif %}
+            {# Log — opens the manual note modal (records the call outcome). #}
+            <button @click="$dispatch('open-modal', {url: '/v2/partials/customers/{{ co.id }}/activity/add-note-form'})"
+                    hx-get="/v2/partials/customers/{{ co.id }}/activity/add-note-form"
+                    hx-target="#modal-content"
+                    class="btn-secondary btn-sm"
+                    title="Log a call/note for {{ co.name }}">
+              <svg class="w-3.5 h-3.5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+              </svg>
+              Log
+            </button>
+          </div>
         </div>
       </li>
       {% endfor %}
     </ul>
     {% else %}
-    <p class="text-sm text-gray-400 italic">No accounts need a call right now.</p>
+    <p class="text-sm text-gray-600 italic">No accounts need a call right now.</p>
     {% endif %}
   </section>
 
-  {# ── Section 2: My tasks ──────────────────────────────────────────── #}
+  {# ── Section 2: My tasks (due/overdue first) ──────────────────────── #}
   <section>
-    <h2 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
+    <h2 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">
       My tasks
-      {% if tasks %}
-      <span class="ml-1.5 badge bg-amber-100 text-amber-700 border-amber-200">{{ tasks|length }}</span>
-      {% endif %}
+      {% if tasks %}{{ badge(tasks|length, tone='warning') }}{% endif %}
     </h2>
 
     {% if tasks %}
@@ -142,11 +184,12 @@
       {% set _due_state = task_due_state(t, now_utc) %}
       {% set is_overdue = _due_state[0] %}
       {% set is_due_today = _due_state[1] %}
+      {% set task_rail = 'border-l-4 border-l-rose-400' if is_overdue else ('border-l-4 border-l-amber-300' if is_due_today else '') %}
       <li id="my-day-task-{{ t.id }}"
-          class="flex items-start gap-3 rounded-lg border border-line-base bg-white px-4 py-3">
+          class="flex items-start gap-3 rounded-lg border border-line-base {{ task_rail }} bg-white px-4 py-3">
 
-        {# Complete checkbox — posts to step 5 endpoint with from_my_day=true so it
-           returns an empty fragment, removing this row via outerHTML swap. #}
+        {# Complete checkbox — posts to the complete endpoint with from_my_day=true so
+           it returns an empty fragment, removing this row via outerHTML swap. #}
         <form hx-post="/v2/partials/tasks/{{ t.id }}/complete?from_my_day=true"
               hx-target="#my-day-task-{{ t.id }}"
               hx-swap="outerHTML"
@@ -166,7 +209,7 @@
 
           {# Due date with overdue/due-today/future badge #}
           {% if t.due_at %}
-            <span class="ml-0 text-xs {% if is_overdue %}text-rose-600 font-semibold{% elif is_due_today %}text-amber-600 font-semibold{% else %}text-gray-400{% endif %}">
+            <span class="ml-0 text-xs {% if is_overdue %}text-rose-600 font-semibold{% elif is_due_today %}text-amber-600 font-semibold{% else %}text-gray-600{% endif %}">
               {% if is_overdue %}&middot; Overdue ({{ t.due_at.strftime('%b %-d') }}){% elif is_due_today %}&middot; Due today{% else %}&middot; due {{ t.due_at.strftime('%b %-d') }}{% endif %}
             </span>
           {% endif %}
@@ -178,7 +221,7 @@
                  hx-get="/v2/partials/customers/{{ t.company.id }}"
                  hx-target="#main-content"
                  hx-push-url="/v2/customers/{{ t.company.id }}"
-                 class="text-brand-500 hover:text-brand-700">{{ t.company.name }}</a>
+                 class="text-accent-600 hover:text-accent-700">{{ t.company.name }}</a>
             {% elif t.site_contact %}
               <span>{{ t.site_contact.full_name }}</span>
             {% elif t.requisition %}
@@ -186,7 +229,7 @@
                  hx-get="/v2/partials/requisitions/{{ t.requisition.id }}"
                  hx-target="#main-content"
                  hx-push-url="/v2/requisitions/{{ t.requisition.id }}"
-                 class="text-brand-500 hover:text-brand-700">{{ t.requisition.name or ('REQ-' ~ t.requisition.id) }}</a>
+                 class="text-accent-600 hover:text-accent-700">{{ t.requisition.name or ('REQ-' ~ t.requisition.id) }}</a>
             {% endif %}
           </div>
         </div>
@@ -194,7 +237,7 @@
       {% endfor %}
     </ul>
     {% else %}
-    <p class="text-sm text-gray-400 italic">No open tasks assigned to you.</p>
+    <p class="text-sm text-gray-600 italic">No open tasks assigned to you.</p>
     {% endif %}
   </section>
 

--- a/tests/test_my_day.py
+++ b/tests/test_my_day.py
@@ -27,7 +27,40 @@ from sqlalchemy.orm import Session
 from starlette.testclient import TestClient
 
 from app.models import ActivityLog, Company
+from app.models.crm import CustomerSite, SiteContact
 from app.models.task import RequisitionTask
+
+
+def _add_primary_contact(
+    db_session: Session,
+    company: Company,
+    *,
+    phone: str = "+15551234567",
+    email: str = "buyer@acme.test",
+    do_not_contact: bool = False,
+) -> SiteContact:
+    """Attach a primary SiteContact (via a CustomerSite) to ``company``.
+
+    Used to exercise the My Day one-click outreach rail (Call / Email), which reads
+    ``company.primary_contact``.
+    """
+    site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+    db_session.add(site)
+    db_session.flush()
+    contact = SiteContact(
+        customer_site_id=site.id,
+        full_name="Pat Buyer",
+        phone=phone,
+        email=email,
+        do_not_contact=do_not_contact,
+    )
+    db_session.add(contact)
+    db_session.flush()
+    company.primary_contact_id = contact.id
+    db_session.commit()
+    db_session.refresh(company)
+    return contact
+
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -250,6 +283,61 @@ class TestMyDayCompleteTask:
         client.post(f"/v2/partials/tasks/{my_open_task.id}/complete?from_my_day=true")
         after = db_session.query(ActivityLog).count()
         assert after == before
+
+
+class TestMyDayAttentionHeader:
+    def test_attention_count_shown_for_overdue_account(
+        self, client: TestClient, db_session: Session, overdue_owned_company
+    ):
+        """The header surfaces a 'needs a call today' attention figure for an overdue
+        account."""
+        resp = client.get("/v2/partials/my-day")
+        assert resp.status_code == 200
+        assert "need" in resp.text and "a call today" in resp.text
+        # The accent key-figure container is present (figure-accent token).
+        assert "figure-accent" in resp.text
+
+    def test_no_attention_figure_when_no_accounts(self, client: TestClient, db_session: Session, my_open_task):
+        """With tasks but no overdue accounts, the call-today figure is absent."""
+        resp = client.get("/v2/partials/my-day")
+        assert resp.status_code == 200
+        assert "a call today" not in resp.text
+
+
+class TestMyDayOutreach:
+    def test_call_and_email_actions_render_for_reachable_contact(
+        self, client: TestClient, db_session: Session, overdue_owned_company
+    ):
+        """A reachable primary contact yields one-click Call (tel:) + Email links."""
+        _add_primary_contact(db_session, overdue_owned_company)
+        resp = client.get("/v2/partials/my-day")
+        assert resp.status_code == 200
+        assert "tel:+15551234567" in resp.text
+        assert "buyer@acme.test" in resp.text
+        # Outreach auto-logging hook is wired on the action.
+        assert "data-outreach-log" in resp.text
+
+    def test_outreach_suppressed_for_do_not_contact(
+        self, client: TestClient, db_session: Session, overdue_owned_company
+    ):
+        """A do_not_contact primary contact gets no Call/Email affordance."""
+        _add_primary_contact(db_session, overdue_owned_company, do_not_contact=True)
+        resp = client.get("/v2/partials/my-day")
+        assert resp.status_code == 200
+        assert "tel:+15551234567" not in resp.text
+        assert "buyer@acme.test" not in resp.text
+
+    def test_no_call_link_when_account_has_no_contact(
+        self, client: TestClient, db_session: Session, overdue_owned_company
+    ):
+        """An overdue account with no primary contact still renders (no tel: link), and
+        the row's Log action remains available."""
+        resp = client.get("/v2/partials/my-day")
+        assert resp.status_code == 200
+        assert overdue_owned_company.name in resp.text
+        assert "tel:" not in resp.text
+        # The manual log affordance is always present on a follow-up row.
+        assert "activity/add-note-form" in resp.text
 
 
 class TestMyDayFullPage:


### PR DESCRIPTION
Live-review request ('be useful, not just a list'). Adds: attention header with .figure-accent count of accounts needing a call today; per-row left urgency rail (rose=overdue/never, amber=due); one-click Call(tel:)/Email(Outlook)/Log on every Follow-up row via the shared outreach_btn macro (auto-logs outbound + advances cadence; DNC suppressed); priority badges restored; accent/gray-600 conformance. Route adds attention_count + joinedload(primary_contact) (no N+1, no new schema). 18 My-Day tests + ratchet green.