### PR TITLE
feat(buy-plans): move completed transactions to a paginated archive section

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -10997,15 +10997,51 @@ async def buy_plans_board_partial(
     ``scope=all`` is role-gated — a non-manager/non-ops user is forced to
     ``scope=mine`` so no other rep's plans leak.
     """
-    from ..services.buyplan_hub import deals_board
+    from ..services.buyplan_hub import completed_archive, deals_board
 
     scope = scope if scope in ("mine", "all") else "mine"
     if scope == "all" and not _can_supervise(user, db):
         scope = "mine"
 
     ctx = _base_ctx(request, user, "buy-plans")
-    ctx.update({"board": deals_board(db, user, scope=scope), "scope": scope})
+    ctx.update(
+        {
+            "board": deals_board(db, user, scope=scope),
+            "scope": scope,
+            "archive": completed_archive(db, user, scope=scope),
+        }
+    )
     return template_response("htmx/partials/buy_plans/_board.html", ctx)
+
+
+@router.get("/v2/partials/buy-plans/archive", response_class=HTMLResponse)
+async def buy_plans_archive_partial(
+    request: Request,
+    scope: str = "mine",
+    offset: int = 0,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Completed-transactions archive page (lazy "load older" chunk).
+
+    Returns just the rows partial (not the whole section) so an htmx "Load older"
+    click can append the next page in place. ``scope=all`` is role-gated exactly
+    like the board so no other rep's completed plans leak to a non-supervisor.
+    """
+    from ..services.buyplan_hub import completed_archive
+
+    scope = scope if scope in ("mine", "all") else "mine"
+    if scope == "all" and not _can_supervise(user, db):
+        scope = "mine"
+
+    ctx = _base_ctx(request, user, "buy-plans")
+    ctx.update(
+        {
+            "archive": completed_archive(db, user, scope=scope, offset=offset),
+            "scope": scope,
+        }
+    )
+    return template_response("htmx/partials/buy_plans/_archive_rows.html", ctx)
 
 
 def _render_supervise_body(request: Request, user: User, db: Session) -> HTMLResponse:
@@ -11015,11 +11051,17 @@ def _render_supervise_body(request: Request, user: User, db: Session) -> HTMLRes
     Non-supervisors never see cross-user data: they get the mine-scope board instead
     (defense in depth — the hub also hides the Supervise button for them).
     """
-    from ..services.buyplan_hub import deals_board, supervise_overview
+    from ..services.buyplan_hub import completed_archive, deals_board, supervise_overview
 
     if not _can_supervise(user, db):
         ctx = _base_ctx(request, user, "buy-plans")
-        ctx.update({"board": deals_board(db, user, scope="mine"), "scope": "mine"})
+        ctx.update(
+            {
+                "board": deals_board(db, user, scope="mine"),
+                "scope": "mine",
+                "archive": completed_archive(db, user, scope="mine"),
+            }
+        )
         return template_response("htmx/partials/buy_plans/_board.html", ctx)
 
     ctx = _base_ctx(request, user, "buy-plans")
@@ -11027,6 +11069,7 @@ def _render_supervise_body(request: Request, user: User, db: Session) -> HTMLRes
         {
             "overview": supervise_overview(db),
             "board": deals_board(db, user, scope="all"),
+            "archive": completed_archive(db, user, scope="all"),
             "is_ops": _is_ops_member(user, db),
             "is_manager": user.role in (UserRole.MANAGER, UserRole.ADMIN),
             "user": user,

--- a/app/services/buyplan_hub.py
+++ b/app/services/buyplan_hub.py
@@ -173,9 +173,12 @@ _STATUS_TO_COLUMN: dict[str, str] = {
     BuyPlanStatus.PENDING: "pending",
     BuyPlanStatus.ACTIVE: "active",
     BuyPlanStatus.HALTED: "active",
-    BuyPlanStatus.COMPLETED: "done",
+    # COMPLETED → archive section (see completed_archive), not an active column
     # CANCELLED → omitted (no entry)
 }
+
+#: Default page size for the completed-transactions archive ("load older" chunk).
+ARCHIVE_PAGE_SIZE = 20
 
 _STAGE_LABELS: dict[str, str] = {
     BuyPlanStatus.DRAFT: "Draft",
@@ -237,8 +240,36 @@ def _compute_blocker(plan: BuyPlan) -> str:
     return ""
 
 
+def _deal_card(plan: BuyPlan, user: object) -> dict:
+    """Build the shared deal-card read dict for one plan.
+
+    Used by both the active board (``deals_board``) and the completed archive
+    (``completed_archive``) so a card looks identical wherever it renders. The
+    ``completed_at`` field is meaningful only for archived (COMPLETED) plans.
+    """
+    # po_progress: (verified_count, total_non_cancelled_count)
+    active_lines = [ln for ln in plan.lines if ln.status != BuyPlanLineStatus.CANCELLED]
+    verified_count = sum(1 for ln in active_lines if ln.status == BuyPlanLineStatus.VERIFIED)
+
+    # needs_my_action: sales owner must act when plan is DRAFT
+    needs_my_action = plan.status == BuyPlanStatus.DRAFT and plan.submitted_by_id == user.id
+
+    return {
+        "plan_id": plan.id,
+        "customer_name": _customer_name(plan),
+        "value": plan.total_cost,
+        "margin_pct": plan.total_margin_pct,
+        "stage_label": _STAGE_LABELS.get(plan.status, plan.status),
+        "blocker": _compute_blocker(plan),
+        "po_progress": (verified_count, len(active_lines)),
+        "needs_my_action": needs_my_action,
+        "is_stock_sale": plan.is_stock_sale,
+        "completed_at": plan.completed_at,
+    }
+
+
 def deals_board(db: Session, user: object, *, scope: str) -> dict[str, list[dict]]:
-    """Return the stage-grouped deal board for sales or manager views.
+    """Return the stage-grouped *active* deal board for sales or manager views.
 
     Parameters
     ----------
@@ -253,17 +284,23 @@ def deals_board(db: Session, user: object, *, scope: str) -> dict[str, list[dict
 
     Returns
     -------
-    dict with keys ``"draft"``, ``"pending"``, ``"active"``, ``"done"``.
+    dict with keys ``"draft"``, ``"pending"``, ``"active"``.
     Each value is a list of deal dicts ordered newest-first (by ``created_at``
-    descending).  CANCELLED plans are omitted entirely.
+    descending). COMPLETED plans are excluded here — they live in the paginated
+    archive (see ``completed_archive``); CANCELLED plans are omitted entirely.
 
     Each deal dict contains:
         plan_id, customer_name, value, margin_pct, stage_label, blocker,
-        po_progress (cut: int, total: int), needs_my_action: bool, is_stock_sale
+        po_progress (cut: int, total: int), needs_my_action: bool, is_stock_sale,
+        completed_at
     """
     query = (
         db.query(BuyPlan)
-        .filter(BuyPlan.status != BuyPlanStatus.CANCELLED)
+        .filter(
+            BuyPlan.status.notin_(
+                (BuyPlanStatus.CANCELLED, BuyPlanStatus.COMPLETED),
+            )
+        )
         .options(
             # Eager-load quote + lines; customer_site/company lazy-loaded within session
             joinedload(BuyPlan.quote),
@@ -277,39 +314,79 @@ def deals_board(db: Session, user: object, *, scope: str) -> dict[str, list[dict
 
     plans = query.all()
 
-    board: dict[str, list[dict]] = {"draft": [], "pending": [], "active": [], "done": []}
+    board: dict[str, list[dict]] = {"draft": [], "pending": [], "active": []}
 
     for plan in plans:
         column = _STATUS_TO_COLUMN.get(plan.status)
         if column is None:
-            # Safety net — CANCELLED already filtered above; unknown status skipped
+            # Safety net — CANCELLED/COMPLETED already filtered above; unknown status skipped
             continue
-
-        customer_name = _customer_name(plan)
-
-        # po_progress: (verified_count, total_non_cancelled_count)
-        active_lines = [ln for ln in plan.lines if ln.status != BuyPlanLineStatus.CANCELLED]
-        verified_count = sum(1 for ln in active_lines if ln.status == BuyPlanLineStatus.VERIFIED)
-        po_progress = (verified_count, len(active_lines))
-
-        # needs_my_action: sales owner must act when plan is DRAFT
-        needs_my_action = plan.status == BuyPlanStatus.DRAFT and plan.submitted_by_id == user.id
-
-        board[column].append(
-            {
-                "plan_id": plan.id,
-                "customer_name": customer_name,
-                "value": plan.total_cost,
-                "margin_pct": plan.total_margin_pct,
-                "stage_label": _STAGE_LABELS.get(plan.status, plan.status),
-                "blocker": _compute_blocker(plan),
-                "po_progress": po_progress,
-                "needs_my_action": needs_my_action,
-                "is_stock_sale": plan.is_stock_sale,
-            }
-        )
+        board[column].append(_deal_card(plan, user))
 
     return board
+
+
+def completed_archive(
+    db: Session,
+    user: object,
+    *,
+    scope: str,
+    limit: int = ARCHIVE_PAGE_SIZE,
+    offset: int = 0,
+) -> dict:
+    """Return one page of COMPLETED (archived) deals, newest-completed first.
+
+    The active board (``deals_board``) shows only in-progress work; completed
+    transactions move here so the daily 10–15 don't pile up. Ordered by
+    ``completed_at`` descending (NULLS LAST, then ``created_at`` desc as a
+    deterministic tiebreak for any legacy row whose ``completed_at`` was never
+    stamped). Paginated via ``limit``/``offset`` for the "load older" lazy chunk.
+
+    Parameters
+    ----------
+    scope:
+        ``"mine"`` — only plans where ``submitted_by_id == user.id``.
+        ``"all"``  — all completed plans regardless of owner (manager/ops view).
+    limit, offset:
+        Standard page window. ``limit`` is clamped to ``[1, 100]``.
+
+    Returns
+    -------
+    dict with keys:
+        ``deals``       — list of deal dicts (same shape as ``deals_board`` cards,
+                          with ``completed_at`` populated),
+        ``total``       — total COMPLETED plans in scope,
+        ``limit``       — the clamped page size used,
+        ``offset``      — the offset used,
+        ``next_offset`` — offset for the next page, or ``None`` when exhausted.
+    """
+    limit = max(1, min(int(limit), 100))
+    offset = max(0, int(offset))
+
+    base = db.query(BuyPlan).filter(BuyPlan.status == BuyPlanStatus.COMPLETED)
+    if scope == "mine":
+        base = base.filter(BuyPlan.submitted_by_id == user.id)
+
+    total = base.with_entities(func.count(BuyPlan.id)).scalar() or 0
+
+    plans = (
+        base.options(joinedload(BuyPlan.quote), joinedload(BuyPlan.lines))
+        .order_by(BuyPlan.completed_at.desc().nullslast(), BuyPlan.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+
+    deals = [_deal_card(plan, user) for plan in plans]
+    next_offset = offset + limit if offset + limit < total else None
+
+    return {
+        "deals": deals,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "next_offset": next_offset,
+    }
 
 
 # ── Supervise overview ────────────────────────────────────────────────

--- a/app/templates/htmx/partials/buy_plans/_archive.html
+++ b/app/templates/htmx/partials/buy_plans/_archive.html
@@ -1,0 +1,37 @@
+{#
+  buy_plans/_archive.html — collapsed "Completed" archive section below the active board.
+  Holds completed transactions out of the working board so the daily 10–15 completions
+  don't pile up. Collapsed by default (Alpine x-show); header shows the count with
+  .figure-accent on the number. Rows are paginated — only the most recent page is in the
+  DOM; "Load older" (htmx) appends the next page in place (see _archive_rows.html).
+  Receives: archive (dict from buyplan_hub.completed_archive:
+                     deals/total/limit/offset/next_offset),
+            scope (str: 'mine'|'all').
+  Embedded by: _board.html (which both lenses render).
+  Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette.
+#}
+<section class="mt-5" x-data="{ open: false }">
+  <button type="button"
+          @click="open = !open"
+          :aria-expanded="open"
+          class="btn-ghost btn-sm w-full justify-between border border-line-base bg-gray-50 hover:bg-gray-100">
+    <span class="flex items-center gap-2 text-xs font-semibold text-gray-600 uppercase tracking-wider">
+      <svg class="h-3.5 w-3.5 text-gray-400 transition-transform"
+           :class="open ? 'rotate-90' : ''"
+           viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02Z" clip-rule="evenodd"/>
+      </svg>
+      Completed
+      <span class="figure-accent font-bold normal-case">({{ archive.total }})</span>
+    </span>
+    <span class="text-[11px] text-gray-400 normal-case font-normal" x-show="!open">most recent first</span>
+  </button>
+
+  <div x-show="open" x-collapse class="mt-2 space-y-1.5">
+    {% if archive.deals %}
+    {% include "htmx/partials/buy_plans/_archive_rows.html" %}
+    {% else %}
+    <div class="px-3 py-6 text-center text-xs text-gray-300">No completed transactions yet.</div>
+    {% endif %}
+  </div>
+</section>

--- a/app/templates/htmx/partials/buy_plans/_archive_rows.html
+++ b/app/templates/htmx/partials/buy_plans/_archive_rows.html
@@ -1,0 +1,54 @@
+{#
+  buy_plans/_archive_rows.html — one page of completed-transaction archive rows.
+  Reused by _archive.html (initial render) AND htmx_views.buy_plans_archive_partial
+  (the lazy "Load older" append). Renders dense rows + a self-replacing "Load older"
+  button when more pages remain.
+  Receives: archive (dict from buyplan_hub.completed_archive:
+                     deals/total/limit/offset/next_offset),
+            scope (str: 'mine'|'all').
+  Depends on: HTMX, Tailwind CSS with brand palette.
+
+  Append idiom: the "Load older" button targets ITSELF with hx-swap="outerHTML",
+  so the next page's rows replace the button in place (and carry their own button
+  if further pages remain). Rows are emitted as siblings before the button.
+#}
+{% for d in archive.deals %}
+{% set m = d.margin_pct|float if d.margin_pct is not none else 0 %}
+<div hx-get="/v2/partials/buy-plans/{{ d.plan_id }}"
+     hx-target="#main-content"
+     hx-push-url="/v2/buy-plans/{{ d.plan_id }}"
+     preload="mouseover"
+     tabindex="0"
+     role="link"
+     @keydown.enter.prevent="$el.click()"
+     @keydown.space.prevent="$el.click()"
+     class="grid grid-cols-[1fr_auto_auto_auto] items-center gap-3 px-3 py-2 bg-white rounded-md
+            border border-line-base cursor-pointer hover:shadow-sm transition-shadow
+            focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:outline-none">
+  {# Customer + optional stock chip #}
+  <div class="flex items-center gap-2 min-w-0">
+    <span class="text-sm font-semibold text-gray-900 truncate">{{ d.customer_name or '-' }}</span>
+    {% if d.is_stock_sale %}
+    <span class="chip bg-purple-50 text-purple-700 border-purple-200 flex-shrink-0">stock</span>
+    {% endif %}
+  </div>
+  {# Value #}
+  <span class="text-sm font-semibold text-gray-900 text-right tabular-nums whitespace-nowrap">${{ '{:,.2f}'.format(d.value|float) if d.value else '0.00' }}</span>
+  {# Margin #}
+  <span class="{% if m >= 30 %}badge-success{% elif m >= 15 %}badge-warning{% else %}badge-danger{% endif %}">
+    {{ '{:.1f}'.format(m) }}%
+  </span>
+  {# Date completed #}
+  <span class="text-xs text-gray-400 whitespace-nowrap tabular-nums">{{ d.completed_at|fmtdate('%b %d, %Y') }}</span>
+</div>
+{% endfor %}
+
+{% if archive.next_offset is not none %}
+<button hx-get="/v2/partials/buy-plans/archive?scope={{ scope }}&offset={{ archive.next_offset }}"
+        hx-target="this"
+        hx-swap="outerHTML"
+        hx-push-url="false"
+        class="btn-secondary btn-sm w-full text-brand-600">
+  Load older
+</button>
+{% endif %}

--- a/app/templates/htmx/partials/buy_plans/_board.html
+++ b/app/templates/htmx/partials/buy_plans/_board.html
@@ -1,13 +1,17 @@
 {#
-  buy_plans/_board.html — "My Deals" / manager board: 4 stage columns of deal cards.
-  Columns: Draft, Pending, Active, Done. Each card opens the existing detail partial.
+  buy_plans/_board.html — "My Deals" / manager board: 3 active stage columns of deal cards
+  + a collapsed Completed archive section below.
+  Columns: Draft, Pending, Active (in-progress work only). Each card opens the detail partial.
+  Completed transactions move OUT of the board into the archive (see _archive.html) so the
+  daily 10–15 completions don't clutter the working board.
   needs_my_action cards sort first and gain an amber ring. No Alpine on cards — HTMX only.
-  Receives: board (dict: draft/pending/active/done lists from buyplan_hub.deals_board),
-            scope (str: 'mine'|'all').
-  Called by: htmx_views.py buy_plans_board_partial.
-  Depends on: HTMX, Tailwind CSS with brand palette.
+  Receives: board (dict: draft/pending/active lists from buyplan_hub.deals_board),
+            scope (str: 'mine'|'all'),
+            archive (dict from buyplan_hub.completed_archive: deals/total/limit/offset/next_offset).
+  Called by: htmx_views.py buy_plans_board_partial; embedded by _supervise.html.
+  Depends on: HTMX, Alpine.js (archive toggle), Tailwind CSS with brand palette.
 #}
-{% set columns = [('draft', 'Draft'), ('pending', 'Pending'), ('active', 'Active'), ('done', 'Done')] %}
+{% set columns = [('draft', 'Draft'), ('pending', 'Pending'), ('active', 'Active')] %}
 {% set open_cards = board.draft + board.pending + board.active %}
 {% set open_value = open_cards|map(attribute='value')|select|map('float')|sum %}
 
@@ -24,7 +28,7 @@
 </div>
 {% endif %}
 
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
   {% for key, label in columns %}
   {% set cards = board[key]|sort(attribute='needs_my_action', reverse=True) %}
   {# Finding #5: border-gray-200 → border-line-base on column shells #}
@@ -88,3 +92,6 @@
   </div>
   {% endfor %}
 </div>
+
+{# ── Completed archive (collapsed; lives below the active board) ── #}
+{% include "htmx/partials/buy_plans/_archive.html" %}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1266,8 +1266,15 @@ non-supervisor who requests it is served the mine-scope board (defense in depth)
 GET /v2/partials/buy-plans?lens=          (shell: switcher + lazy #bp-hub-body)
     |
     +-- lens=deals     --> GET /partials/buy-plans/board?scope=mine|all
-    |                        services/buyplan_hub.deals_board   (sales stage board;
+    |                        services/buyplan_hub.deals_board   (sales stage board:
+    |                        3 ACTIVE columns Draft/Pending/Active — COMPLETED excluded;
     |                        scope=all role-gated to supervisors)
+    |                        + completed_archive(scope=…) → collapsed "Completed (N)"
+    |                          archive section below the board (_archive.html). Lazy
+    |                          "Load older" pages via GET /partials/buy-plans/archive?
+    |                          scope=…&offset=… (returns _archive_rows.html, self-replacing
+    |                          button, completed_at-desc, page size ARCHIVE_PAGE_SIZE=20).
+    |                          Keeps the daily 10–15 completions out of the working board.
     +-- lens=orders    --> GET /partials/buy-plans/orders
     |                        services/buyplan_hub.buyer_line_queue (buyer PO-cut queue)
     |                        + buyplan_hub.team_line_queue (read-only "Team Orders"
@@ -1276,8 +1283,10 @@ GET /v2/partials/buy-plans?lens=          (shell: switcher + lazy #bp-hub-body)
     +-- lens=supervise --> GET /partials/buy-plans/supervise
                              services/buyplan_hub.supervise_overview (triage strip:
                              approvals / SO+PO verify / overdue / flagged / halted)
-                             + deals_board(scope=all). Triage forms post origin=supervise
-                             so the action re-renders THIS body into #bp-hub-body.
+                             + deals_board(scope=all) + completed_archive(scope=all)
+                             (the same archive section renders below the embedded board).
+                             Triage forms post origin=supervise so the action re-renders
+                             THIS body into #bp-hub-body.
 ```
 
 **Resell workspace — resell/excess split-panel (Chunk F, ADDITIVE).** `/v2/resell` is

--- a/tests/test_buyplan_hub_board.py
+++ b/tests/test_buyplan_hub_board.py
@@ -1,20 +1,24 @@
-"""Tests for buyplan_hub.deals_board — the stage-grouped deal board read model.
+"""Tests for buyplan_hub.deals_board + completed_archive — the deal hub read models.
 
 Covers:
-- Column bucketing by status (DRAFT→draft, PENDING→pending, ACTIVE/HALTED→active,
-  COMPLETED→done, CANCELLED omitted)
+- Column bucketing by status (DRAFT→draft, PENDING→pending, ACTIVE/HALTED→active);
+  COMPLETED moves to the archive, CANCELLED omitted entirely
 - scope=mine filters by submitted_by_id; scope=all returns everything
 - po_progress counts (verified, total-non-cancelled)
 - blocker text: ACTIVE + 2 AWAITING_PO lines → "2 POs to cut"
 - blocker text: all lines VERIFIED + so_status APPROVED → "ready to fulfill"
 - CANCELLED plans omitted from all columns
+- completed_archive: COMPLETED-only, completed_at-desc ordering, scope filtering,
+  and limit/offset pagination (next_offset, total)
 
-Depends on: app/services/buyplan_hub.deals_board,
+Depends on: app/services/buyplan_hub.deals_board + completed_archive,
             conftest fixtures (db_session, test_user, manager_user, test_quote,
             test_requisition).
 """
 
 from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
@@ -33,6 +37,7 @@ def _make_plan(
     total_cost=None,
     total_margin_pct=None,
     is_stock_sale: bool = False,
+    completed_at=None,
 ) -> BuyPlan:
     """Create + flush a minimal BuyPlan header."""
     plan = BuyPlan(
@@ -44,6 +49,7 @@ def _make_plan(
         total_cost=total_cost,
         total_margin_pct=total_margin_pct,
         is_stock_sale=is_stock_sale,
+        completed_at=completed_at,
     )
     db.add(plan)
     db.flush()
@@ -100,20 +106,22 @@ def test_deals_board_column_bucketing(db_session, test_user, test_quote, test_re
 
     board = deals_board(db_session, test_user, scope="all")
 
-    # All four keys must always be present
-    assert set(board.keys()) == {"draft", "pending", "active", "done"}
+    # Active board holds in-progress work only — three columns, no "done".
+    assert set(board.keys()) == {"draft", "pending", "active"}
 
     draft_ids = [d["plan_id"] for d in board["draft"]]
     pending_ids = [d["plan_id"] for d in board["pending"]]
     active_ids = [d["plan_id"] for d in board["active"]]
-    done_ids = [d["plan_id"] for d in board["done"]]
+    all_active_ids = draft_ids + pending_ids + active_ids
 
     assert draft_plan.id in draft_ids
     assert pending_plan.id in pending_ids
     assert active_plan.id in active_ids
     assert halted_plan.id in active_ids  # HALTED → active column
-    assert completed_plan.id in done_ids
-    assert cancelled_plan.id not in (draft_ids + pending_ids + active_ids + done_ids)
+    # COMPLETED moves to the archive — it must NOT clutter the active board.
+    assert completed_plan.id not in all_active_ids
+    # CANCELLED is omitted entirely.
+    assert cancelled_plan.id not in all_active_ids
 
 
 # ── 2. Scope mine vs all ──────────────────────────────────────────────
@@ -328,3 +336,155 @@ def test_deals_board_needs_my_action_draft(db_session, test_user, manager_user, 
 
     assert draft_deal["needs_my_action"] is True
     assert active_deal["needs_my_action"] is False
+
+
+# ── 9. Completed archive: scope, contents, ordering ───────────────────
+
+
+def _ts(days_ago: int) -> datetime:
+    """A tz-aware UTC timestamp ``days_ago`` days in the past."""
+    return datetime.now(timezone.utc) - timedelta(days=days_ago)
+
+
+def test_completed_archive_only_completed_plans(db_session, test_user, test_quote, test_requisition):
+    """Archive returns only COMPLETED plans — never active/cancelled ones."""
+    from app.services.buyplan_hub import completed_archive
+
+    completed = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        submitted_by_id=test_user.id,
+        completed_at=_ts(1),
+    )
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        submitted_by_id=test_user.id,
+    )
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.CANCELLED,
+        submitted_by_id=test_user.id,
+    )
+
+    page = completed_archive(db_session, test_user, scope="all")
+
+    assert page["total"] == 1
+    assert [d["plan_id"] for d in page["deals"]] == [completed.id]
+    # Card carries completed_at for the date-completed column.
+    assert page["deals"][0]["completed_at"] is not None
+
+
+def test_completed_archive_ordered_by_completed_at_desc(db_session, test_user, test_quote, test_requisition):
+    """Most recently completed first; completed_at desc."""
+    from app.services.buyplan_hub import completed_archive
+
+    older = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        submitted_by_id=test_user.id,
+        completed_at=_ts(10),
+    )
+    newer = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        submitted_by_id=test_user.id,
+        completed_at=_ts(2),
+    )
+
+    page = completed_archive(db_session, test_user, scope="all")
+
+    assert [d["plan_id"] for d in page["deals"]] == [newer.id, older.id]
+
+
+def test_completed_archive_scope_mine_filters_owner(db_session, test_user, manager_user, test_quote, test_requisition):
+    """Scope=mine returns only the caller's completed plans; scope=all returns both."""
+    from app.services.buyplan_hub import completed_archive
+
+    mine = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        submitted_by_id=test_user.id,
+        completed_at=_ts(1),
+    )
+    theirs = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        submitted_by_id=manager_user.id,
+        completed_at=_ts(1),
+    )
+
+    mine_page = completed_archive(db_session, test_user, scope="mine")
+    assert [d["plan_id"] for d in mine_page["deals"]] == [mine.id]
+    assert mine_page["total"] == 1
+
+    all_page = completed_archive(db_session, test_user, scope="all")
+    assert {d["plan_id"] for d in all_page["deals"]} == {mine.id, theirs.id}
+    assert all_page["total"] == 2
+
+
+def test_completed_archive_pagination(db_session, test_user, test_quote, test_requisition):
+    """Limit/offset page the archive; next_offset advances then exhausts."""
+    from app.services.buyplan_hub import completed_archive
+
+    # 5 completed plans, distinct completion dates so order is deterministic.
+    plans = [
+        _make_plan(
+            db_session,
+            quote_id=test_quote.id,
+            requisition_id=test_requisition.id,
+            status=BuyPlanStatus.COMPLETED,
+            submitted_by_id=test_user.id,
+            completed_at=_ts(i + 1),
+        )
+        for i in range(5)
+    ]
+    newest_first = [p.id for p in plans]  # _ts(1) is newest → index 0 first
+
+    page1 = completed_archive(db_session, test_user, scope="all", limit=2, offset=0)
+    assert page1["total"] == 5
+    assert page1["limit"] == 2
+    assert page1["offset"] == 0
+    assert [d["plan_id"] for d in page1["deals"]] == newest_first[:2]
+    assert page1["next_offset"] == 2
+
+    page2 = completed_archive(db_session, test_user, scope="all", limit=2, offset=2)
+    assert [d["plan_id"] for d in page2["deals"]] == newest_first[2:4]
+    assert page2["next_offset"] == 4
+
+    page3 = completed_archive(db_session, test_user, scope="all", limit=2, offset=4)
+    assert [d["plan_id"] for d in page3["deals"]] == newest_first[4:]
+    # Last page — no more to load.
+    assert page3["next_offset"] is None
+
+
+def test_completed_archive_empty(db_session, test_user, test_quote, test_requisition):
+    """No completed plans → empty page, total 0, no next_offset."""
+    from app.services.buyplan_hub import completed_archive
+
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        submitted_by_id=test_user.id,
+    )
+
+    page = completed_archive(db_session, test_user, scope="all")
+    assert page["total"] == 0
+    assert page["deals"] == []
+    assert page["next_offset"] is None

--- a/tests/test_buyplan_hub_routes.py
+++ b/tests/test_buyplan_hub_routes.py
@@ -270,9 +270,12 @@ def test_board_mine_rings_needs_my_action(client: TestClient, db_session: Sessio
     resp = client.get("/v2/partials/buy-plans/board?scope=mine")
     assert resp.status_code == 200
     body = resp.text
-    # 4 columns
-    for col in ("Draft", "Pending", "Active", "Done"):
+    # 3 active columns — "Done" is gone; completed work lives in the archive.
+    for col in ("Draft", "Pending", "Active"):
         assert col in body
+    assert ">Done<" not in body
+    # Completed archive section is present below the board.
+    assert "Completed" in body
     # needs_my_action ring
     assert "ring-2 ring-amber-400" in body
 
@@ -322,6 +325,77 @@ def test_board_scope_all_allowed_for_manager(
         app.dependency_overrides.pop(require_user, None)
     assert resp.status_code == 200
     assert f"/v2/partials/buy-plans/{sales_plan.id}" in resp.text
+
+
+# ── Completed archive ──────────────────────────────────────────────────────
+
+
+def test_board_archive_shows_completed_count(client: TestClient, db_session: Session, test_user, test_requisition):
+    """The board's archive section shows the completed count and a completed card."""
+    from datetime import datetime, timezone
+
+    q = _make_quote(db_session, test_requisition.id)
+    done_plan = _make_plan(
+        db_session,
+        quote_id=q.id,
+        req_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        submitted_by_id=test_user.id,
+        completed_at=datetime.now(timezone.utc),
+    )
+    db_session.commit()
+
+    resp = client.get("/v2/partials/buy-plans/board?scope=mine")
+    assert resp.status_code == 200
+    body = resp.text
+    # Count badge "(1)" rendered with the accent figure class.
+    assert "Completed" in body
+    assert "(1)" in body
+    # Completed plan is an openable archive card, NOT in an active column.
+    assert f"/v2/partials/buy-plans/{done_plan.id}" in body
+
+
+def test_archive_partial_returns_rows(client: TestClient, db_session: Session, test_user, test_requisition):
+    """The lazy archive route returns completed rows for the requested page."""
+    from datetime import datetime, timedelta, timezone
+
+    q = _make_quote(db_session, test_requisition.id)
+    now = datetime.now(timezone.utc)
+    plan = _make_plan(
+        db_session,
+        quote_id=q.id,
+        req_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        submitted_by_id=test_user.id,
+        completed_at=now - timedelta(days=3),
+    )
+    db_session.commit()
+
+    resp = client.get("/v2/partials/buy-plans/archive?scope=mine&offset=0")
+    assert resp.status_code == 200
+    assert f"/v2/partials/buy-plans/{plan.id}" in resp.text
+
+
+def test_archive_scope_all_forced_to_mine_for_non_manager(
+    client: TestClient, db_session: Session, test_user, manager_user, test_requisition
+):
+    """Scope=all on the archive route must not leak another user's completed plans."""
+    from datetime import datetime, timezone
+
+    q = _make_quote(db_session, test_requisition.id)
+    other = _make_plan(
+        db_session,
+        quote_id=q.id,
+        req_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        submitted_by_id=manager_user.id,
+        completed_at=datetime.now(timezone.utc),
+    )
+    db_session.commit()
+
+    resp = client.get("/v2/partials/buy-plans/archive?scope=all")
+    assert resp.status_code == 200
+    assert f"/v2/partials/buy-plans/{other.id}" not in resp.text
 
 
 # ── confirm-po origin behavior ─────────────────────────────────────────────


### PR DESCRIPTION
Live-review request: the Done lane backed up (10-15 completions/day). Now the active board shows only in-progress (draft/pending/active); a collapsed 'Completed (N)' archive section sits below (.figure-accent count) with the latest 20 + htmx 'Load older' pagination, ordered by completed_at desc. Active/archive split is in the query (role-gated scope), not CSS. 85 buy-plan tests + ratchet green.