### PR TITLE
fix(http): no-cache HTMX partial responses so deploys show without hard-refresh

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -537,18 +537,19 @@ async def request_id_middleware(request: Request, call_next):
                 response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
             else:
                 response.headers["Cache-Control"] = "public, max-age=3600"
-        # Full-page HTML loads (non-HTMX requests): no-cache so a new deploy's shell + hashed
-        # CSS/JS bundle is fetched fresh instead of a heuristically-cached stale shell. HTMX
-        # partials (HX-Request) and /static (above) are unaffected. Set HERE (outermost
-        # middleware) because header sets on the TemplateResponse itself are dropped by inner
-        # response processing before reaching the client.
-        elif (
-            request.headers.get("HX-Request") is None
-            and not path.startswith("/api")
-            and "/partials/" not in path
-            and "text/html" in (response.headers.get("content-type") or "")
-        ):
-            response.headers["Cache-Control"] = "no-cache, must-revalidate"
+        # Every HTML response — full-page shell AND HTMX partials (/v2/partials/*) — is
+        # made non-cacheable so a new deploy's markup is fetched fresh instead of a
+        # heuristically-cached stale fragment. Without this, browsers cache partial GETs
+        # and in-app HTMX navigation keeps swapping in stale UI until a hard-refresh.
+        # Guard is the response content-type ONLY (starts with "text/html"): that naturally
+        # excludes JSON, content-hashed /static assets (handled above), text/event-stream
+        # SSE streams, and file downloads (PDF/CSV/image Content-Disposition responses),
+        # and we never read the response body — so streaming responses stay intact. Set
+        # HERE (outermost middleware) because header sets on the TemplateResponse itself
+        # are dropped by inner response processing before reaching the client.
+        elif (response.headers.get("content-type") or "").startswith("text/html"):
+            response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+            response.headers["Pragma"] = "no-cache"
 
         # Skip noisy paths (static files, health checks)
         if not (path.startswith("/static") or path == "/health"):

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -58,6 +58,14 @@ FastAPI Middleware Stack (in order):
     │       route table (nesting-agnostic, correct on 0.136.x and 0.137.x).
     ├── 5. CSP Middleware (Content-Security-Policy header)
     ├── 6. Request ID Middleware (UUID tracking, timing, logging)
+    │       Also owns Cache-Control (set HERE, the OUTERMOST @app.middleware, because
+    │       inner response processing drops headers set on the TemplateResponse itself):
+    │       /static/assets/* (Vite-hashed) -> immutable 1yr; other /static -> 1hr; EVERY
+    │       text/html response — full-page shell AND /v2/partials/* HTMX fragments ->
+    │       no-store,no-cache,must-revalidate + Pragma:no-cache (so a redeploy's markup is
+    │       fetched fresh, not heuristically cached stale). Guard is the response
+    │       content-type ONLY (starts "text/html"), so JSON, SSE (text/event-stream), and
+    │       file downloads (Content-Disposition) are untouched and streaming bodies unread.
     └── 7. API Version Middleware (/api/v1/* -> /api/*)
     │
     ▼

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -4170,14 +4170,17 @@ class TestFullWidthContactsForwardLayout:
 
 
 class TestNoCache:
-    """Stage C §6: full-page /v2/* responses carry Cache-Control: no-cache.
+    """Every text/html /v2/* response — full-page shell AND HTMX partial — carries
+    Cache-Control: no-store/no-cache.
 
-    Browsers heuristically cache HTML pages with no Cache-Control header.  After
-    a deploy the stale shell would reference old hashed-CSS/JS bundles, forcing
-    users to hard-refresh.  The fix: page_response() sets
-    Cache-Control: no-cache, must-revalidate on every base_page render.
+    Browsers heuristically cache HTML responses with no Cache-Control header.  After a
+    deploy the stale shell would reference old hashed-CSS/JS bundles and stale partials
+    would keep swapping into in-app navigation, forcing users to hard-refresh.  The fix:
+    the outermost request_id_middleware sets Cache-Control: no-store, no-cache,
+    must-revalidate (+ Pragma: no-cache) on every text/html response.
 
-    HTMX partials and /static/assets/* are intentionally unaffected.
+    /static/assets/* (Vite-hashed) keeps its immutable long cache; JSON/SSE/downloads
+    are intentionally unaffected.
     """
 
     def _authed_client(self, test_user, db_session):
@@ -4273,21 +4276,21 @@ class TestNoCache:
             for dep in [get_db, require_user, require_admin, require_buyer, require_fresh_token]:
                 app.dependency_overrides.pop(dep, None)
 
-    def test_partial_does_not_carry_no_cache_header(self, client: TestClient, test_user):
-        """HTMX partial /v2/partials/customers does NOT carry Cache-Control: no-cache.
+    def test_partial_carries_no_store_header(self, client: TestClient, test_user):
+        """HTMX partial /v2/partials/customers carries Cache-Control: no-store/no-cache.
 
-        Only the full-page shell needs the no-cache guard.  Partials are lightweight and
-        already keyed by server state; adding no-cache would break browser back/forward
-        caching of fragments unnecessarily.
+        Browsers heuristically cache partial GETs too, so without this an in-app HTMX
+        navigation keeps swapping in stale fragments after a deploy until a hard-
+        refresh. Every text/html response (full-page shell AND partial) is made non-
+        cacheable by the outermost request_id_middleware.
         """
         resp = client.get("/v2/partials/customers")
         assert resp.status_code == 200
         cc = resp.headers.get("cache-control", "")
-        # Partials should NOT carry the no-cache directive (either no header at
-        # all, or something like 'no-store' from the framework is acceptable,
-        # but 'no-cache' must not be the explicit page-response injection).
-        # We check that the page_response() wrapper was NOT applied.
-        assert "must-revalidate" not in cc, "HTMX partial should not carry the page-response Cache-Control header"
+        assert "no-store" in cc, f"HTMX partial should carry no-store, got: {cc!r}"
+        assert "no-cache" in cc
+        assert "must-revalidate" in cc
+        assert resp.headers.get("pragma") == "no-cache"
 
 
 # ── Phase-0 CRM Foundations: HTMX form field surfacing tests ─────────────────

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -87,6 +87,45 @@ def test_error_response_format(client):
     assert "request_id" in data
 
 
+# ── Cache-Control no-store tests ──────────────────────────────────────
+
+
+def test_partial_html_response_is_no_store(client):
+    """HTMX partial (/v2/partials/*) HTML responses carry no-store/no-cache.
+
+    Without this, browsers heuristically cache partial GETs and in-app HTMX navigation
+    keeps swapping in stale UI after a deploy until a hard-refresh.
+    """
+    resp = client.get("/v2/partials/requisitions/create-form")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    cache_control = resp.headers.get("Cache-Control", "")
+    assert "no-store" in cache_control
+    assert "no-cache" in cache_control
+    assert "must-revalidate" in cache_control
+    assert resp.headers.get("Pragma") == "no-cache"
+
+
+def test_full_page_html_response_is_no_store(client):
+    """Full-page (non-HTMX) HTML shell is also no-store so a redeploy's shell + hashed
+    bundle refs are fetched fresh, not served from a stale cached shell."""
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    cache_control = resp.headers.get("Cache-Control", "")
+    assert "no-store" in cache_control
+    assert resp.headers.get("Pragma") == "no-cache"
+
+
+def test_json_response_is_not_no_store(client, test_requisition):
+    """JSON API responses are NOT touched by the HTML no-store branch."""
+    resp = client.get("/api/requisitions")
+    assert "application/json" in resp.headers.get("content-type", "")
+    # The HTML branch must not have run: no no-store Cache-Control, no Pragma.
+    assert "no-store" not in resp.headers.get("Cache-Control", "")
+    assert "Pragma" not in resp.headers
+
+
 # ── CSP tests ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Root cause of "deployed UI changes don't appear without a hard-refresh": the outermost `request_id_middleware` set Cache-Control **only on full-page HTML** — its guard explicitly excluded HTMX partials (`HX-Request is None`, `"/partials/" not in path`) and only used `no-cache, must-revalidate` (no `no-store`). Probe confirmed `/v2/partials/...` returned text/html with NO Cache-Control. Fix: every `text/html` response (full page + partial) now gets `Cache-Control: no-store, no-cache, must-revalidate` + `Pragma: no-cache`, still outermost, content-type-guarded so JSON / content-hashed static / SSE / downloads are untouched (test_events_sse confirms SSE undisturbed). Added partial no-store tests; APP_MAP updated; tests + pre-commit green.