### PR TITLE
fix(data-ops): repair merge-click + add delete-both & multi-select mass actions

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -14716,8 +14716,9 @@ async def _dedup_bulk(request, user, db, entity: str) -> HTMLResponse:
 
     ``merge`` keeps the FIRST id of each pair (the template emits keeper-first tokens);
     ``delete`` removes both; ``dismiss`` is a view-only clear (no durable state yet — the
-    rows just drop from this render and reappear on the next scan). Per-pair failures are
-    tolerated and counted, never aborting the batch.
+    rows just drop from this render and reappear on the next scan). Per-pair failures don't
+    abort the batch, but each is logged at error level and the failing pair tokens are
+    surfaced in the toast — any failure makes the toast an ``error`` (never green success).
     """
     from ..dependencies import is_admin
 
@@ -14750,7 +14751,7 @@ async def _dedup_bulk(request, user, db, entity: str) -> HTMLResponse:
         merge_fn, delete_fn, noun = merge_companies, delete_companies, "company"
 
     done = 0
-    failed = 0
+    failed_tokens: list[str] = []
     for a, b in pairs:
         try:
             if action == "merge":
@@ -14761,15 +14762,17 @@ async def _dedup_bulk(request, user, db, entity: str) -> HTMLResponse:
             done += 1
         except Exception as e:
             db.rollback()
-            failed += 1
-            logger.warning("Bulk {} {}: pair {}-{} failed: {}", noun, action, a, b, e)
+            failed_tokens.append(f"{a}-{b}")
+            logger.error("Bulk {} {}: pair {}-{} failed: {}", noun, action, a, b, e)
 
     verb = "Merged" if action == "merge" else "Deleted"
+    failed = len(failed_tokens)
     message = f"{verb} {done} {noun} pair(s)."
     if failed:
-        message += f" {failed} failed."
+        message += f" {failed} failed: {', '.join(failed_tokens)}."
     resp = _render_data_ops(request, user, db)
-    settings_toast(resp, message, kind="error" if failed and not done else "success")
+    # Any failure surfaces as an error toast — a partial failure must not look green.
+    settings_toast(resp, message, kind="error" if failed else "success")
     return resp
 
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -14581,7 +14581,9 @@ async def admin_vendor_merge(
     try:
         result = _merge(keep_id, remove_id, db)
         db.commit()
-    except ValueError as e:
+    except Exception as e:
+        # Align with company-merge: the service raises ValueError on validation, but an
+        # unexpected SQLAlchemy error here must surface as a toast, not a 500.
         db.rollback()
         message, kind = f"Vendor merge failed: {e}", "error"
     else:
@@ -14625,6 +14627,170 @@ async def admin_company_merge(
     resp = _render_data_ops(request, user, db)
     settings_toast(resp, message, kind=kind)
     return resp
+
+
+@router.post("/v2/partials/admin/vendor-delete-both", response_class=HTMLResponse)
+async def admin_vendor_delete_both(
+    request: Request,
+    id_a: int = Form(...),
+    id_b: int = Form(...),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Delete BOTH vendor cards in a dedup pair (neither is worth keeping)."""
+    from ..dependencies import is_admin
+
+    if not is_admin(user):
+        raise HTTPException(403, "Admin only")
+
+    from ..services.vendor_merge_service import delete_vendor_cards
+
+    try:
+        result = delete_vendor_cards(id_a, id_b, db)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        message, kind = f"Vendor delete failed: {e}", "error"
+    else:
+        message = f"Deleted both vendors. {result.get('detached', 0)} records detached."
+        kind = "success"
+
+    resp = _render_data_ops(request, user, db)
+    settings_toast(resp, message, kind=kind)
+    return resp
+
+
+@router.post("/v2/partials/admin/company-delete-both", response_class=HTMLResponse)
+async def admin_company_delete_both(
+    request: Request,
+    id_a: int = Form(...),
+    id_b: int = Form(...),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Delete BOTH companies in a dedup pair (neither is worth keeping)."""
+    from ..dependencies import is_admin
+
+    if not is_admin(user):
+        raise HTTPException(403, "Admin only")
+
+    from ..services.company_merge_service import delete_companies
+
+    try:
+        result = delete_companies(id_a, id_b, db)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        message, kind = f"Company delete failed: {e}", "error"
+    else:
+        message = f"Deleted both companies. {result.get('detached', 0)} records detached."
+        kind = "success"
+
+    resp = _render_data_ops(request, user, db)
+    settings_toast(resp, message, kind=kind)
+    return resp
+
+
+# Mass dedup actions accept a comma-joined "pairs" token list where each token is
+# "<id_a>-<id_b>" (the two ids of one candidate pair). Mirrors the requisitions2 /
+# customers bulk convention (one hidden field, server-side parse + per-item gate),
+# but the dedup unit is a PAIR, not a single row, so the token carries both ids.
+_MAX_DEDUP_PAIRS = 200
+
+
+def _parse_dedup_pairs(raw: str) -> list[tuple[int, int]]:
+    """Parse a "a-b,c-d" pair-token string into [(a, b), ...]; skip malformed tokens."""
+    pairs: list[tuple[int, int]] = []
+    for tok in (raw or "").split(","):
+        tok = tok.strip()
+        if not tok:
+            continue
+        a, _, b = tok.partition("-")
+        if a.lstrip("-").isdigit() and b.lstrip("-").isdigit():
+            pairs.append((int(a), int(b)))
+    return pairs
+
+
+async def _dedup_bulk(request, user, db, entity: str) -> HTMLResponse:
+    """Shared body for vendor/company bulk dedup actions (merge | delete | dismiss).
+
+    ``merge`` keeps the FIRST id of each pair (the template emits keeper-first tokens);
+    ``delete`` removes both; ``dismiss`` is a view-only clear (no durable state yet — the
+    rows just drop from this render and reappear on the next scan). Per-pair failures are
+    tolerated and counted, never aborting the batch.
+    """
+    from ..dependencies import is_admin
+
+    if not is_admin(user):
+        raise HTTPException(403, "Admin only")
+
+    form = await request.form()
+    action = (form.get("action") or "").strip()
+    if action not in {"merge", "delete", "dismiss"}:
+        raise HTTPException(400, f"Invalid action {action!r}")
+
+    pairs = _parse_dedup_pairs(form.get("pairs", ""))
+    if len(pairs) > _MAX_DEDUP_PAIRS:
+        raise HTTPException(400, f"Maximum {_MAX_DEDUP_PAIRS} pairs per bulk action")
+
+    if not pairs or action == "dismiss":
+        # Dismiss is purely client-side (the row was already hidden); just re-render.
+        resp = _render_data_ops(request, user, db)
+        if pairs:
+            settings_toast(resp, f"Dismissed {len(pairs)} pair(s) for now.", kind="success")
+        return resp
+
+    if entity == "vendor":
+        from ..services.vendor_merge_service import delete_vendor_cards, merge_vendor_cards
+
+        merge_fn, delete_fn, noun = merge_vendor_cards, delete_vendor_cards, "vendor"
+    else:
+        from ..services.company_merge_service import delete_companies, merge_companies
+
+        merge_fn, delete_fn, noun = merge_companies, delete_companies, "company"
+
+    done = 0
+    failed = 0
+    for a, b in pairs:
+        try:
+            if action == "merge":
+                merge_fn(a, b, db)
+            else:
+                delete_fn(a, b, db)
+            db.commit()
+            done += 1
+        except Exception as e:
+            db.rollback()
+            failed += 1
+            logger.warning("Bulk {} {}: pair {}-{} failed: {}", noun, action, a, b, e)
+
+    verb = "Merged" if action == "merge" else "Deleted"
+    message = f"{verb} {done} {noun} pair(s)."
+    if failed:
+        message += f" {failed} failed."
+    resp = _render_data_ops(request, user, db)
+    settings_toast(resp, message, kind="error" if failed and not done else "success")
+    return resp
+
+
+@router.post("/v2/partials/admin/vendor-bulk", response_class=HTMLResponse)
+async def admin_vendor_bulk(
+    request: Request,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Bulk merge/delete/dismiss selected vendor dedup pairs."""
+    return await _dedup_bulk(request, user, db, "vendor")
+
+
+@router.post("/v2/partials/admin/company-bulk", response_class=HTMLResponse)
+async def admin_company_bulk(
+    request: Request,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Bulk merge/delete/dismiss selected company dedup pairs."""
+    return await _dedup_bulk(request, user, db, "company")
 
 
 # ── Proactive Part Match ─────────────────────────────────────────────

--- a/app/services/company_merge_service.py
+++ b/app/services/company_merge_service.py
@@ -196,3 +196,74 @@ def merge_companies(keep_id: int, remove_id: int, db: Session) -> dict:
         "sites_deleted": sites_deleted,
         "reassigned": reassigned,
     }
+
+
+def delete_companies(id_a: int, id_b: int, db: Session) -> dict:
+    """Delete BOTH companies in a dedup pair (neither is worth keeping).
+
+    Company-scoped data (sites, attachments, collaborators, customer part history,
+    excess lists) is deleted along with the company — it has no meaning without it.
+    Cross-domain references that merely *point at* the company (activity log, sightings,
+    knowledge entries, prospect accounts) are NULLed so those records survive unlinked,
+    mirroring how merge reassigns rather than cascade-deletes them. Does NOT commit —
+    caller must commit.
+
+    Returns:
+        {"ok": True, "deleted": [int, int], "detached": int, "purged": int}
+
+    Raises:
+        ValueError if either company is missing or the two ids are identical.
+    """
+    from ..models import ActivityLog, Sighting
+    from ..models.excess import ExcessList
+    from ..models.knowledge import KnowledgeEntry
+    from ..models.prospect_account import ProspectAccount
+    from ..models.purchase_history import CustomerPartHistory
+
+    if id_a == id_b:
+        raise ValueError("Cannot delete a company pair with identical ids")
+    co_a = db.get(Company, id_a)
+    co_b = db.get(Company, id_b)
+    if not co_a or not co_b:
+        raise ValueError("One or both companies not found")
+
+    ids = [id_a, id_b]
+
+    # Detach soft references (nullable / SET NULL) — these records outlive the company.
+    detached = 0
+    for model, col in [
+        (ActivityLog, "company_id"),
+        (Sighting, "source_company_id"),
+        (KnowledgeEntry, "company_id"),
+        (ProspectAccount, "company_id"),
+    ]:
+        try:
+            detached += (
+                db.query(model).filter(getattr(model, col).in_(ids)).update({col: None}, synchronize_session="fetch")
+            )
+        except Exception as e:
+            logger.warning("Company delete-both: failed to detach {}.{}: {}", model.__tablename__, col, e)
+
+    # Purge company-scoped rows (NOT-NULL company_id) that are meaningless without the
+    # company. Sites/attachments/collaborators go via the ORM "all, delete-orphan" cascade
+    # on db.delete(company); these two tables are not ORM-cascaded so purge explicitly.
+    purged = 0
+    for model in (CustomerPartHistory, ExcessList):
+        try:
+            purged += db.query(model).filter(model.company_id.in_(ids)).delete(synchronize_session="fetch")
+        except Exception as e:
+            logger.warning("Company delete-both: failed to purge {}: {}", model.__tablename__, e)
+
+    db.delete(co_a)
+    db.delete(co_b)
+    db.flush()
+
+    try:
+        from ..cache.decorators import invalidate_prefix
+
+        invalidate_prefix("company_list")
+    except Exception as e:
+        logger.warning("Company delete-both: cache invalidation failed: {}", e)
+
+    logger.info("Company delete-both: removed {} + {}, detached {}, purged {}", id_a, id_b, detached, purged)
+    return {"ok": True, "deleted": [id_a, id_b], "detached": detached, "purged": purged}

--- a/app/services/company_merge_service.py
+++ b/app/services/company_merge_service.py
@@ -230,6 +230,9 @@ def delete_companies(id_a: int, id_b: int, db: Session) -> dict:
     ids = [id_a, id_b]
 
     # Detach soft references (nullable / SET NULL) — these records outlive the company.
+    # Fail CLOSED: a detach error re-raises so the route rolls back rather than deleting
+    # the companies anyway and silently orphaning/losing the dependent rows (mirrors the
+    # vendor service's abort-and-surface).
     detached = 0
     for model, col in [
         (ActivityLog, "company_id"),
@@ -242,17 +245,20 @@ def delete_companies(id_a: int, id_b: int, db: Session) -> dict:
                 db.query(model).filter(getattr(model, col).in_(ids)).update({col: None}, synchronize_session="fetch")
             )
         except Exception as e:
-            logger.warning("Company delete-both: failed to detach {}.{}: {}", model.__tablename__, col, e)
+            logger.error("Company delete-both: failed to detach {}.{}: {}", model.__tablename__, col, e)
+            raise ValueError(f"Company delete aborted — failed to detach {model.__tablename__}.{col}: {e}") from e
 
     # Purge company-scoped rows (NOT-NULL company_id) that are meaningless without the
     # company. Sites/attachments/collaborators go via the ORM "all, delete-orphan" cascade
     # on db.delete(company); these two tables are not ORM-cascaded so purge explicitly.
+    # Fail CLOSED here too — a purge error must abort, never delete the company anyway.
     purged = 0
     for model in (CustomerPartHistory, ExcessList):
         try:
             purged += db.query(model).filter(model.company_id.in_(ids)).delete(synchronize_session="fetch")
         except Exception as e:
-            logger.warning("Company delete-both: failed to purge {}: {}", model.__tablename__, e)
+            logger.error("Company delete-both: failed to purge {}: {}", model.__tablename__, e)
+            raise ValueError(f"Company delete aborted — failed to purge {model.__tablename__}: {e}") from e
 
     db.delete(co_a)
     db.delete(co_b)

--- a/app/services/vendor_merge_service.py
+++ b/app/services/vendor_merge_service.py
@@ -107,3 +107,67 @@ def merge_vendor_cards(keep_id: int, remove_id: int, db: Session) -> dict:
         reassigned,
     )
     return {"ok": True, "kept": keep.id, "removed": remove_id, "reassigned": reassigned}
+
+
+def delete_vendor_cards(id_a: int, id_b: int, db: Session) -> dict:
+    """Delete BOTH vendor cards in a dedup pair (neither is worth keeping).
+
+    Dependent business records (offers, sightings, reviews, …) are NOT deleted — their
+    ``vendor_card_id`` is NULLed so the offer/sighting survives as an unlinked record,
+    exactly as merge reassigns FKs rather than cascading. Then both cards are deleted.
+    Does NOT commit — caller must commit.
+
+    Returns:
+        {"ok": True, "deleted": [int, int], "detached": int}
+
+    Raises:
+        ValueError if either card is missing or the two ids are identical.
+    """
+    from ..models import (
+        ActivityLog,
+        BuyerVendorStats,
+        EnrichmentQueue,
+        Offer,
+        ProspectContact,
+        StockListHash,
+        VendorMetricsSnapshot,
+        VendorReview,
+    )
+
+    if id_a == id_b:
+        raise ValueError("Cannot delete a vendor pair with identical ids")
+    card_a = db.get(VendorCard, id_a)
+    card_b = db.get(VendorCard, id_b)
+    if not card_a or not card_b:
+        raise ValueError("One or both vendor cards not found")
+
+    fk_tables = [
+        (VendorContact, "vendor_card_id"),
+        (VendorReview, "vendor_card_id"),
+        (Offer, "vendor_card_id"),
+        (VendorMetricsSnapshot, "vendor_card_id"),
+        (StockListHash, "vendor_card_id"),
+        (BuyerVendorStats, "vendor_card_id"),
+        (ActivityLog, "vendor_card_id"),
+        (EnrichmentQueue, "vendor_card_id"),
+        (ProspectContact, "vendor_card_id"),
+    ]
+    detached = 0
+    for model, col in fk_tables:
+        try:
+            count = (
+                db.query(model)
+                .filter(getattr(model, col).in_([id_a, id_b]))
+                .update({col: None}, synchronize_session="fetch")
+            )
+            detached += count
+        except Exception as e:
+            logger.error("Vendor delete-both: FK detach failed on {}.{}: {}", model.__tablename__, col, e)
+            raise ValueError(f"Vendor delete aborted — failed to detach {model.__tablename__}.{col}: {e}") from e
+
+    db.delete(card_a)
+    db.delete(card_b)
+    db.flush()
+
+    logger.info("Vendor delete-both: removed {} + {}, detached {} records", id_a, id_b, detached)
+    return {"ok": True, "deleted": [id_a, id_b], "detached": detached}

--- a/app/services/vendor_merge_service.py
+++ b/app/services/vendor_merge_service.py
@@ -112,10 +112,16 @@ def merge_vendor_cards(keep_id: int, remove_id: int, db: Session) -> dict:
 def delete_vendor_cards(id_a: int, id_b: int, db: Session) -> dict:
     """Delete BOTH vendor cards in a dedup pair (neither is worth keeping).
 
-    Dependent business records (offers, sightings, reviews, …) are NOT deleted — their
-    ``vendor_card_id`` is NULLed so the offer/sighting survives as an unlinked record,
-    exactly as merge reassigns FKs rather than cascading. Then both cards are deleted.
-    Does NOT commit — caller must commit.
+    Soft references that merely *point at* the card and outlive it (offers, stock-list
+    hashes, activity log, prospect contacts, enrichment-queue rows) have their
+    ``vendor_card_id`` NULLed so the record survives unlinked, exactly as merge reassigns
+    FKs rather than cascading. Card-scoped children that are meaningless without the card
+    and are declared NOT-NULL ``ondelete="CASCADE"`` at the DB level (vendor contacts,
+    reviews, metrics snapshots, buyer-vendor stats) are NOT NULLed — that would raise a
+    NotNullViolation on Postgres — they cascade-delete with the card via ``db.delete(card)``
+    (DB ``ON DELETE CASCADE`` + the ORM ``cascade="all, delete-orphan"`` on
+    ``VendorCard.reviews``/``vendor_contacts``/``attachments``). Mirrors the
+    ``delete_companies`` detach-vs-cascade split. Does NOT commit — caller must commit.
 
     Returns:
         {"ok": True, "deleted": [int, int], "detached": int}
@@ -125,13 +131,10 @@ def delete_vendor_cards(id_a: int, id_b: int, db: Session) -> dict:
     """
     from ..models import (
         ActivityLog,
-        BuyerVendorStats,
         EnrichmentQueue,
         Offer,
         ProspectContact,
         StockListHash,
-        VendorMetricsSnapshot,
-        VendorReview,
     )
 
     if id_a == id_b:
@@ -141,30 +144,32 @@ def delete_vendor_cards(id_a: int, id_b: int, db: Session) -> dict:
     if not card_a or not card_b:
         raise ValueError("One or both vendor cards not found")
 
-    fk_tables = [
-        (VendorContact, "vendor_card_id"),
-        (VendorReview, "vendor_card_id"),
+    ids = [id_a, id_b]
+
+    # Detach soft references (nullable / SET NULL columns) — these records outlive the
+    # card. The four NOT-NULL CASCADE children (VendorContact, VendorReview,
+    # VendorMetricsSnapshot, BuyerVendorStats) are deliberately ABSENT here: NULLing a
+    # NOT-NULL column raises NotNullViolation on Postgres. They cascade-delete below.
+    detach_tables = [
         (Offer, "vendor_card_id"),
-        (VendorMetricsSnapshot, "vendor_card_id"),
         (StockListHash, "vendor_card_id"),
-        (BuyerVendorStats, "vendor_card_id"),
         (ActivityLog, "vendor_card_id"),
-        (EnrichmentQueue, "vendor_card_id"),
         (ProspectContact, "vendor_card_id"),
+        (EnrichmentQueue, "vendor_card_id"),  # nullable column despite DB ondelete=CASCADE
     ]
     detached = 0
-    for model, col in fk_tables:
+    for model, col in detach_tables:
         try:
             count = (
-                db.query(model)
-                .filter(getattr(model, col).in_([id_a, id_b]))
-                .update({col: None}, synchronize_session="fetch")
+                db.query(model).filter(getattr(model, col).in_(ids)).update({col: None}, synchronize_session="fetch")
             )
             detached += count
         except Exception as e:
             logger.error("Vendor delete-both: FK detach failed on {}.{}: {}", model.__tablename__, col, e)
             raise ValueError(f"Vendor delete aborted — failed to detach {model.__tablename__}.{col}: {e}") from e
 
+    # NOT-NULL CASCADE children cascade-delete with the card (DB ON DELETE CASCADE +
+    # ORM all, delete-orphan on reviews/vendor_contacts/attachments).
     db.delete(card_a)
     db.delete(card_b)
     db.flush()

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1106,6 +1106,35 @@ Alpine.data('rowActionRail', () => ({
   },
 }));
 
+// Data Ops dedup multi-select — one instance per dedup section (vendor / company).
+// Selection unit is a PAIR token "<keeperId>-<loserId>" (keeper-first so bulk-merge
+// keeps the suggested side). Mirrors rq2Page's Set-based pattern (reassign the Set to
+// trigger Alpine reactivity). Lives inside #settings-content, which the htmx:afterSwap
+// handler re-initTrees, so it rebinds cleanly after each merge/delete re-render.
+Alpine.data('dedupSelect', () => ({
+  selected: new Set(),
+  toggle(token, checked) {
+    if (checked) { this.selected.add(token); } else { this.selected.delete(token); }
+    this.selected = new Set(this.selected);
+  },
+  toggleAll(checked, tokens) {
+    if (checked) { tokens.forEach(t => this.selected.add(t)); } else { this.selected.clear(); }
+    this.selected = new Set(this.selected);
+  },
+  clear() { this.selected = new Set(); },
+  has(token) { return this.selected.has(token); },
+  get count() { return this.selected.size; },
+  // Comma-joined "a-b,c-d" string the bulk endpoint parses.
+  get pairsStr() { return [...this.selected].join(','); },
+  // Hide the dismissed rows immediately (client-only); the form re-renders the list.
+  hideSelected() {
+    this.selected.forEach(token => {
+      const row = this.$root.querySelector('[data-pair="' + token + '"]');
+      if (row) { row.style.display = 'none'; }
+    });
+  },
+}));
+
 // ── Page-level loading bar for navigation ──────────────────
 // Shows a slim progress bar at the top when navigating between pages.
 htmx.on('htmx:beforeRequest', function(evt) {
@@ -1142,9 +1171,18 @@ htmx.on('htmx:afterSwap', function(evt) {
     // x-chip-overflow — directives that must re-bind after filter/sort/action swaps;
     // rfq-affinity-section — affinity rows whose :checked/@change checkboxes bind to
     // the surrounding rfqVendorModal x-data scope, otherwise the checkboxes are inert
-    // and ticked affinity vendors never enter selectedVendors / never get sent).
+    // and ticked affinity vendors never enter selectedVendors / never get sent;
+    // settings-content — the Settings tab body is lazy-swapped here and re-swapped by
+    // every settings mutation (e.g. a dedup merge re-renders Data Ops), so its Alpine
+    // directives — the Data Ops multi-select bar — must re-init or the checkboxes go
+    // inert and selection state is lost after the first action).
     if (t && typeof Alpine !== 'undefined' && typeof Alpine.initTree === 'function') {
-        if (t.id === 'lead-drawer-content' || t.id === 'rq2-table' || t.id === 'rfq-affinity-section') {
+        if (
+            t.id === 'lead-drawer-content' ||
+            t.id === 'rq2-table' ||
+            t.id === 'rfq-affinity-section' ||
+            t.id === 'settings-content'
+        ) {
             Alpine.initTree(t);
         }
     }

--- a/app/templates/htmx/partials/settings/_macros.html
+++ b/app/templates/htmx/partials/settings/_macros.html
@@ -51,3 +51,63 @@
 {{ pad }}  Keep "{{ keep|truncate(40) }}"
 {{ pad }}</button>
 {%- endmacro %}
+
+{# "Delete both" dedup action — for a pair where neither record is worth keeping. POSTs
+   the two ids to a delete-both endpoint that detaches dependent records and removes both.
+   The confirm is a native hx-confirm (same UX as merge_button), spelling out the names so
+   a misclick can't silently destroy data. `a_id`/`b_id` are the two ids, `a_name`/`b_name`
+   the names, `endpoint` the hx-post URL, `target` the hx-target selector. #}
+{% macro delete_both_button(endpoint, target, a_id, b_id, a_name, b_name) -%}
+<button data-loading-disable
+        hx-post="{{ endpoint }}"
+        hx-vals='{"id_a": {{ a_id }}, "id_b": {{ b_id }}}'
+        hx-target="{{ target }}"
+        hx-swap="innerHTML"
+        hx-confirm="Delete BOTH '{{ a_name }}' and '{{ b_name }}'? This cannot be undone."
+        class="px-2 py-1 text-xs rounded bg-white text-rose-600 border border-rose-300 hover:bg-rose-50">
+  Delete both
+</button>
+{%- endmacro %}
+
+{# Sticky mass-action bar for a dedup section. Visible only when ≥1 pair is selected
+   (count is the dedupSelect Alpine x-data). `endpoint` is the section's bulk URL,
+   `target` the hx-target. Mirrors the requisitions2 / customers bulk bar: one hidden
+   `pairs` field bound to the Alpine selection, one `action` field per button. Bulk
+   delete + dismiss are confirmed; dismiss also hides the rows immediately (client-only).
+   `noun` is the singular entity word for the confirm copy. #}
+{% macro mass_action_bar(endpoint, target, noun) -%}
+<div x-show="count > 0" x-cloak
+     class="sticky bottom-0 z-10 flex items-center gap-2 px-4 py-2 bg-accent-50 border-t border-accent-200">
+  <span class="text-xs font-medium text-accent-700"><span x-text="count"></span> selected</span>
+  <form hx-post="{{ endpoint }}" hx-target="{{ target }}" hx-swap="innerHTML" class="inline">
+    <input type="hidden" name="action" value="merge">
+    <input type="hidden" name="pairs" :value="pairsStr">
+    <button type="submit" data-loading-disable
+            class="px-2 py-1 text-xs rounded bg-accent-500 text-white border border-accent-500 font-medium hover:bg-accent-600">
+      Merge selected
+    </button>
+  </form>
+  <form hx-post="{{ endpoint }}" hx-target="{{ target }}" hx-swap="innerHTML"
+        hx-confirm="Delete BOTH records in every selected pair? This cannot be undone." class="inline">
+    <input type="hidden" name="action" value="delete">
+    <input type="hidden" name="pairs" :value="pairsStr">
+    <button type="submit" data-loading-disable
+            class="px-2 py-1 text-xs rounded bg-white text-rose-600 border border-rose-300 hover:bg-rose-50">
+      Delete selected
+    </button>
+  </form>
+  <form hx-post="{{ endpoint }}" hx-target="{{ target }}" hx-swap="innerHTML"
+        @submit="hideSelected()" class="inline">
+    <input type="hidden" name="action" value="dismiss">
+    <input type="hidden" name="pairs" :value="pairsStr">
+    <button type="submit" data-loading-disable
+            class="px-2 py-1 text-xs rounded bg-white text-gray-600 border border-gray-300 hover:bg-gray-50">
+      Dismiss for now
+    </button>
+  </form>
+  <button type="button" @click="clear()"
+          class="px-2 py-1 text-xs rounded text-gray-600 hover:text-gray-800">
+    Clear
+  </button>
+</div>
+{%- endmacro %}

--- a/app/templates/htmx/partials/settings/data_ops.html
+++ b/app/templates/htmx/partials/settings/data_ops.html
@@ -6,7 +6,7 @@
    so stale pairs referencing the merged entity drop without a manual refresh).
    Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette.
 #}
-{% from "htmx/partials/settings/_macros.html" import merge_button -%}
+{% from "htmx/partials/settings/_macros.html" import merge_button, delete_both_button, mass_action_bar -%}
 <div class="space-y-6">
 
   {# ── Pending OEM Spec-Code Mappings (admin approval queue) ── #}
@@ -30,7 +30,11 @@
   </div>
 
   {# ── Vendor Dedup ──────────────────────────────────────── #}
-  <div class="bg-white border border-line-base rounded-lg overflow-hidden">
+  {# x-data="dedupSelect()" scopes the per-section multi-select. Selection unit is the
+     pair token "<keeperId>-<loserId>"; the mass-action bar reads it for bulk ops. The
+     whole section re-swaps into #settings-content on each action, and the afterSwap
+     handler re-initTrees that node so the checkboxes rebind. #}
+  <div class="bg-white border border-line-base rounded-lg overflow-hidden" x-data="dedupSelect()">
     <div class="px-4 py-3 bg-gray-50 border-b flex items-center justify-between">
       <h2 class="text-lg font-semibold text-gray-900">Vendor Duplicates</h2>
       <button hx-get="/v2/partials/settings/data-ops"
@@ -46,17 +50,42 @@
       <p class="text-sm text-rose-600">Couldn't check for duplicate vendors right now &mdash; try Refresh.</p>
     </div>
     {% elif vendor_dupes %}
+    {# Pre-compute keeper-first pair tokens so both the per-row checkbox and the select-all
+       agree on the canonical "<keeperId>-<loserId>" form (keeper-first → bulk merge keeps
+       the suggested side). #}
+    {% set vendor_tokens = [] %}
+    {% for pair in vendor_dupes %}
+      {% set keep_first = (pair.vendor_a.sightings or 0) >= (pair.vendor_b.sightings or 0) %}
+      {% set _kid = pair.vendor_a.id if keep_first else pair.vendor_b.id %}
+      {% set _lid = pair.vendor_b.id if keep_first else pair.vendor_a.id %}
+      {% set _ = vendor_tokens.append(_kid ~ '-' ~ _lid) %}
+    {% endfor %}
+    <div class="px-4 py-2 border-b border-gray-100 flex items-center gap-2">
+      {# tojson is Markup-safe and emits double-quoted strings, so it MUST live in a
+         SINGLE-quoted attribute — a double-quoted @change would have the token's " close
+         the attribute early and silently kill Alpine init for the whole component. #}
+      <input type="checkbox" aria-label="Select all vendor pairs"
+             class="rounded border-gray-300 text-accent-500 focus:ring-accent-400"
+             :checked="count === {{ vendor_tokens|length }} && count > 0"
+             @change='toggleAll($event.target.checked, {{ vendor_tokens|tojson }})'>
+      <span class="text-xs text-gray-600">Select all</span>
+    </div>
     <div class="divide-y divide-gray-100">
       {# find_vendor_dedup_candidates returns NESTED pairs: pair.vendor_a/vendor_b
          each {id, name, sightings}, plus pair.score. The suggested keeper is the side
-         with more sightings (more evidence → richer card); ties keep vendor_a. Both
+         with more sightings (more evidence → richer card); ties keep vendor_a. The merge
          buttons wire to the admin vendor-merge endpoint, which re-renders this whole
          partial into #settings-content so the merged pair drops. #}
       {% for pair in vendor_dupes %}
       {% set keep_first = (pair.vendor_a.sightings or 0) >= (pair.vendor_b.sightings or 0) %}
       {% set keeper = pair.vendor_a if keep_first else pair.vendor_b %}
       {% set loser = pair.vendor_b if keep_first else pair.vendor_a %}
-      <div class="px-4 py-3 flex items-center gap-4" x-data="{ merged: false }">
+      {% set token = keeper.id ~ '-' ~ loser.id %}
+      <div class="px-4 py-3 flex items-center gap-4" data-pair="{{ token }}">
+        <input type="checkbox" aria-label="Select pair {{ keeper.name }} and {{ loser.name }}"
+               class="rounded border-gray-300 text-accent-500 focus:ring-accent-400"
+               :checked="has('{{ token }}')"
+               @change="toggle('{{ token }}', $event.target.checked)">
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 text-sm">
             <span class="font-medium text-gray-900">{{ pair.vendor_a.name }}</span>
@@ -69,15 +98,15 @@
             &middot; suggested keep: <span class="font-medium text-gray-700">{{ keeper.name|truncate(24) }}</span>
           </p>
         </div>
-        <template x-if="!merged" x-cloak>
-          <div class="flex gap-2">
-            {{ merge_button('            ', '/v2/partials/admin/vendor-merge', '#settings-content', keeper.id, loser.id, keeper.name, loser.name, true) }}
-            {{ merge_button('            ', '/v2/partials/admin/vendor-merge', '#settings-content', loser.id, keeper.id, loser.name, keeper.name, false) }}
-          </div>
-        </template>
+        <div class="flex gap-2">
+          {{ merge_button('          ', '/v2/partials/admin/vendor-merge', '#settings-content', keeper.id, loser.id, keeper.name, loser.name, true) }}
+          {{ merge_button('          ', '/v2/partials/admin/vendor-merge', '#settings-content', loser.id, keeper.id, loser.name, keeper.name, false) }}
+          {{ delete_both_button('/v2/partials/admin/vendor-delete-both', '#settings-content', keeper.id, loser.id, keeper.name, loser.name) }}
+        </div>
       </div>
       {% endfor %}
     </div>
+    {{ mass_action_bar('/v2/partials/admin/vendor-bulk', '#settings-content', 'vendor') }}
     {% else %}
     <div class="px-4 py-8 text-center">
       <p class="text-sm text-gray-600">No duplicate vendors found at the current threshold.</p>
@@ -86,7 +115,7 @@
   </div>
 
   {# ── Company Dedup ─────────────────────────────────────── #}
-  <div class="bg-white border border-line-base rounded-lg overflow-hidden">
+  <div class="bg-white border border-line-base rounded-lg overflow-hidden" x-data="dedupSelect()">
     <div class="px-4 py-3 bg-gray-50 border-b">
       <h2 class="text-lg font-semibold text-gray-900">Company Duplicates</h2>
     </div>
@@ -97,6 +126,21 @@
       <p class="text-sm text-rose-600">Couldn't check for duplicate companies right now &mdash; try Refresh.</p>
     </div>
     {% elif company_dupes %}
+    {% set company_tokens = [] %}
+    {% for pair in company_dupes %}
+      {% set keep_first = (pair.auto_keep_id == pair.company_a.id) %}
+      {% set _kid = pair.company_a.id if keep_first else pair.company_b.id %}
+      {% set _lid = pair.company_b.id if keep_first else pair.company_a.id %}
+      {% set _ = company_tokens.append(_kid ~ '-' ~ _lid) %}
+    {% endfor %}
+    <div class="px-4 py-2 border-b border-gray-100 flex items-center gap-2">
+      {# tojson must live in a SINGLE-quoted attribute (see vendor select-all note). #}
+      <input type="checkbox" aria-label="Select all company pairs"
+             class="rounded border-gray-300 text-accent-500 focus:ring-accent-400"
+             :checked="count === {{ company_tokens|length }} && count > 0"
+             @change='toggleAll($event.target.checked, {{ company_tokens|tojson }})'>
+      <span class="text-xs text-gray-600">Select all</span>
+    </div>
     <div class="divide-y divide-gray-100">
       {# find_company_dedup_candidates returns NESTED pairs: pair.company_a/company_b
          each {id, name, site_count, has_owner}, plus pair.score + pair.auto_keep_id.
@@ -108,7 +152,12 @@
       {% set keep_first = (pair.auto_keep_id == pair.company_a.id) %}
       {% set keeper = pair.company_a if keep_first else pair.company_b %}
       {% set loser = pair.company_b if keep_first else pair.company_a %}
-      <div class="px-4 py-3 flex items-center gap-4" x-data="{ merged: false }">
+      {% set token = keeper.id ~ '-' ~ loser.id %}
+      <div class="px-4 py-3 flex items-center gap-4" data-pair="{{ token }}">
+        <input type="checkbox" aria-label="Select pair {{ keeper.name }} and {{ loser.name }}"
+               class="rounded border-gray-300 text-accent-500 focus:ring-accent-400"
+               :checked="has('{{ token }}')"
+               @change="toggle('{{ token }}', $event.target.checked)">
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 text-sm">
             <span class="font-medium text-gray-900">{{ pair.company_a.name }}</span>
@@ -121,15 +170,15 @@
             &middot; suggested keep: <span class="font-medium text-gray-700">{{ keeper.name|truncate(24) }}</span>
           </p>
         </div>
-        <template x-if="!merged" x-cloak>
-          <div class="flex gap-2">
-            {{ merge_button('            ', '/v2/partials/admin/company-merge', '#settings-content', keeper.id, loser.id, keeper.name, loser.name, true) }}
-            {{ merge_button('            ', '/v2/partials/admin/company-merge', '#settings-content', loser.id, keeper.id, loser.name, keeper.name, false) }}
-          </div>
-        </template>
+        <div class="flex gap-2">
+          {{ merge_button('          ', '/v2/partials/admin/company-merge', '#settings-content', keeper.id, loser.id, keeper.name, loser.name, true) }}
+          {{ merge_button('          ', '/v2/partials/admin/company-merge', '#settings-content', loser.id, keeper.id, loser.name, keeper.name, false) }}
+          {{ delete_both_button('/v2/partials/admin/company-delete-both', '#settings-content', keeper.id, loser.id, keeper.name, loser.name) }}
+        </div>
       </div>
       {% endfor %}
     </div>
+    {{ mass_action_bar('/v2/partials/admin/company-bulk', '#settings-content', 'company') }}
     {% else %}
     <div class="px-4 py-8 text-center">
       <p class="text-sm text-gray-600">No duplicate companies found at the current threshold.</p>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2038,11 +2038,19 @@ merges different-`account_owner_id` accounts) are reused AS-IS.
 - **Delete-both:** each pair row also has a rose-outline **Delete both** button
   (`delete_both_button` macro) → `POST /v2/partials/admin/vendor-delete-both` /
   `company-delete-both` (`id_a`/`id_b` form fields, admin-gated). Backed by
-  `vendor_merge_service.delete_vendor_cards` / `company_merge_service.delete_companies`:
-  dependent business records are **detached** (FK NULLed — offers/sightings/etc. survive
-  unlinked, mirroring how merge reassigns rather than cascade-deletes), company-scoped
-  rows with NOT-NULL `company_id` (`customer_part_history`, `excess_lists`) are purged,
-  and sites/attachments/collaborators go via the ORM `all, delete-orphan` cascade. Native
+  `vendor_merge_service.delete_vendor_cards` / `company_merge_service.delete_companies`.
+  Both split dependents into **detach vs cascade**: soft references that merely point at
+  the parent (vendor: offers/stock-list-hashes/activity-log/prospect-contacts/enrichment-queue;
+  company: activity-log/sightings/knowledge/prospect-accounts) are **detached** (FK NULLed,
+  survive unlinked, mirroring how merge reassigns), while children declared NOT-NULL
+  `ondelete=CASCADE` are **never NULLed** (that raises NotNullViolation on Postgres) and
+  cascade-delete with the parent via `db.delete()` (vendor: `vendor_contacts`/`vendor_reviews`/
+  `vendor_metrics_snapshot`/`buyer_vendor_stats` — the first two also via ORM
+  `all, delete-orphan`; company: sites/attachments/collaborators via ORM cascade, plus
+  `customer_part_history`/`excess_lists` purged explicitly since they're not ORM-cascaded).
+  Both services are **fail-closed**: any detach/purge error logs at error level and
+  re-raises so the route rolls back rather than deleting the parents and orphaning rows;
+  the single-pair routes catch it and surface an error toast (never a 500). Native
   `hx-confirm` spells out both names ("cannot be undone").
 - **Multi-select mass actions:** each dedup section is an `x-data="dedupSelect()"` Alpine
   component (registered in `htmx_app.js`, Set-based, mirroring `rq2Page`). Selection unit
@@ -2052,7 +2060,10 @@ merges different-`account_owner_id` accounts) are reused AS-IS.
   single comma-joined `pairs` field + an `action` field to
   `POST /v2/partials/admin/vendor-bulk` / `company-bulk` (`_dedup_bulk` parses the tokens
   via `_parse_dedup_pairs`, gates admin, caps at `_MAX_DEDUP_PAIRS=200`, processes
-  per-pair with per-pair commit + failure tolerance). The select-all `@change` is a
+  per-pair with per-pair commit + rollback). A per-pair failure doesn't abort the batch,
+  but each is logged at error level with its pair id + action, the failing pair tokens are
+  named in the toast message, and **any** failure makes the toast an `error` (a partial
+  failure never shows green success). The select-all `@change` is a
   **single-quoted** attribute because `tojson` emits double-quoted tokens (a double-quoted
   attr would close early and kill Alpine init). `Dismiss for now` is **view-only** (it
   hides the rows client-side and re-renders; pairs reappear on the next scan — there is no

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2022,8 +2022,41 @@ merges different-`account_owner_id` accounts) are reused AS-IS.
   Data Ops partial via `_render_data_ops` into `#settings-content` (so pairs referencing
   the just-merged entity drop without a manual refresh) and surface the kept-name /
   failure message via a `settings_toast` `HX-Trigger` rather than swapping a `<p>` into
-  the row. Both vendor and company rows carry the Alpine `x-data="{ merged: false }"`
-  guard for consistent post-merge behavior.
+  the row.
+- **Click-merge bug fix (root cause):** the merge buttons used to be wrapped in a dead
+  `x-data="{ merged: false }"` + `<template x-if="!merged" x-cloak>` guard. `merged` was
+  never set true, so the wrapper added nothing — but because the Data Ops body is always
+  delivered by an HTMX swap into `#settings-content` (which was NOT in the
+  `htmx:afterSwap` `Alpine.initTree` allow-list), the `x-if` template was not reliably
+  initialized: `x-cloak` (`display:none !important`) stayed applied and the buttons were
+  hidden/inert, so a click hit a half-bound Alpine expression and threw instead of
+  merging. Fix: the dead wrapper is removed (the buttons are pure HTMX, no Alpine needed)
+  **and** `#settings-content` is added to the `htmx:afterSwap` initTree allow-list so the
+  whole Settings cluster's Alpine directives re-init after every settings swap. The
+  vendor-merge route now also catches `Exception` (was `ValueError`-only), matching
+  company-merge, so an unexpected DB error surfaces as a toast not a 500.
+- **Delete-both:** each pair row also has a rose-outline **Delete both** button
+  (`delete_both_button` macro) → `POST /v2/partials/admin/vendor-delete-both` /
+  `company-delete-both` (`id_a`/`id_b` form fields, admin-gated). Backed by
+  `vendor_merge_service.delete_vendor_cards` / `company_merge_service.delete_companies`:
+  dependent business records are **detached** (FK NULLed — offers/sightings/etc. survive
+  unlinked, mirroring how merge reassigns rather than cascade-deletes), company-scoped
+  rows with NOT-NULL `company_id` (`customer_part_history`, `excess_lists`) are purged,
+  and sites/attachments/collaborators go via the ORM `all, delete-orphan` cascade. Native
+  `hx-confirm` spells out both names ("cannot be undone").
+- **Multi-select mass actions:** each dedup section is an `x-data="dedupSelect()"` Alpine
+  component (registered in `htmx_app.js`, Set-based, mirroring `rq2Page`). Selection unit
+  is a keeper-first **pair token** `"<keeperId>-<loserId>"`; per-row checkboxes + a
+  section select-all feed a sticky `mass_action_bar` (visible when `count > 0`) with
+  **Merge selected / Delete selected / Dismiss for now / Clear**. Each action POSTs a
+  single comma-joined `pairs` field + an `action` field to
+  `POST /v2/partials/admin/vendor-bulk` / `company-bulk` (`_dedup_bulk` parses the tokens
+  via `_parse_dedup_pairs`, gates admin, caps at `_MAX_DEDUP_PAIRS=200`, processes
+  per-pair with per-pair commit + failure tolerance). The select-all `@change` is a
+  **single-quoted** attribute because `tojson` emits double-quoted tokens (a double-quoted
+  attr would close early and kill Alpine init). `Dismiss for now` is **view-only** (it
+  hides the rows client-side and re-renders; pairs reappear on the next scan — there is no
+  durable dismissal table yet).
 - **Per-account banner:** `GET .../{company_id}/dup-suggestion` (`company_dup_suggestion`,
   declared ABOVE the catch-all) → lazy `hx-trigger=load` panel in `detail.html` →
   `_dup_suggestion.html`. Shows the top dedup match INVOLVING this company + a "Review &

--- a/tests/test_data_ops_dedup.py
+++ b/tests/test_data_ops_dedup.py
@@ -178,6 +178,42 @@ class TestDeleteBoth:
         assert surviving is not None
         assert surviving.vendor_card_id is None
 
+    def test_vendor_delete_both_cascades_notnull_children(self, admin_client, db_session, test_user):
+        """REGRESSION (CRITICAL): the four NOT-NULL, ondelete=CASCADE children of a
+        vendor card — VendorContact, VendorReview, VendorMetricsSnapshot,
+        BuyerVendorStats — must NOT be NULLed (that raised a NotNullViolation on
+        Postgres, breaking delete-both for every real vendor).
+
+        They cascade-delete WITH the card. Insert one of each before delete-both and
+        assert it succeeds and each child is gone (not orphaned).
+        """
+        from datetime import date
+
+        from app.models import BuyerVendorStats, VendorContact, VendorMetricsSnapshot, VendorReview
+
+        v1, v2 = _vendors(db_session, "Casc A", "Casc A Inc")
+        contact = VendorContact(vendor_card_id=v1.id, full_name="Jane Buyer", source="manual")
+        review = VendorReview(vendor_card_id=v1.id, user_id=test_user.id, rating=4, comment="ok")
+        snap = VendorMetricsSnapshot(vendor_card_id=v1.id, snapshot_date=date.today(), composite_score=80.0)
+        stats = BuyerVendorStats(vendor_card_id=v1.id, user_id=test_user.id, rfqs_sent=3)
+        db_session.add_all([contact, review, snap, stats])
+        db_session.commit()
+        cid, rid, sid, bid = contact.id, review.id, snap.id, stats.id
+
+        resp = admin_client.post("/v2/partials/admin/vendor-delete-both", data={"id_a": str(v1.id), "id_b": str(v2.id)})
+        # The whole point: this is a 200, not a 500/NotNullViolation.
+        assert resp.status_code == 200, resp.text[:1500]
+        db_session.expire_all()
+
+        # Both cards gone.
+        assert db_session.get(VendorCard, v1.id) is None
+        assert db_session.get(VendorCard, v2.id) is None
+        # All four NOT-NULL children cascade-deleted — gone, NOT orphaned with a stale FK.
+        assert db_session.get(VendorContact, cid) is None
+        assert db_session.get(VendorReview, rid) is None
+        assert db_session.get(VendorMetricsSnapshot, sid) is None
+        assert db_session.get(BuyerVendorStats, bid) is None
+
 
 # ── PART 4: multi-select bulk mass actions ──────────────────────────────────
 
@@ -237,3 +273,21 @@ class TestBulkActions:
         resp = admin_client.post("/v2/partials/admin/vendor-bulk", data={"action": "merge", "pairs": f"{good},{bad}"})
         assert resp.status_code == 200, resp.text[:1500]
         assert db_session.get(VendorCard, v2.id) is None  # good pair merged
+
+    def test_bulk_partial_failure_surfaces_in_toast(self, admin_client, db_session):
+        """REGRESSION (HIGH): a partial failure must NOT show a green success toast —
+        the failing pair token appears in the message and the toast kind is 'error'."""
+        import json
+
+        v1, v2 = _vendors(db_session, "ToastFail A", "ToastFail A Inc")
+        good = f"{v1.id}-{v2.id}"
+        bad = "99991-99992"
+        resp = admin_client.post("/v2/partials/admin/vendor-bulk", data={"action": "merge", "pairs": f"{good},{bad}"})
+        assert resp.status_code == 200, resp.text[:1500]
+        trigger = json.loads(resp.headers["HX-Trigger"])
+        toast = trigger["showToast"]
+        # The failing pair token is named in the message, not reduced to a bare count.
+        assert "99991-99992" in toast["message"]
+        # Any failure → not green success.
+        assert toast["type"] != "success"
+        assert toast["type"] == "error"

--- a/tests/test_data_ops_dedup.py
+++ b/tests/test_data_ops_dedup.py
@@ -1,0 +1,239 @@
+"""Data Ops dedup/merge queue — regression + feature tests.
+
+Covers the Settings → Data Ops surface end-to-end:
+  - the click→merge path (the reported bug: clicking a dup "just throws errors"),
+  - the new Delete-both action,
+  - the new multi-select bulk merge / delete / dismiss mass actions,
+for both the vendor and company dedup sections.
+
+Called by: pytest. Depends on: app.main (TestClient), real merge/delete services
+(no service mocks — the bug lived in the template + swap path, so the tests drive the
+real DB so a future regression in either layer is caught).
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models import Company, User, VendorCard
+
+
+@pytest.fixture()
+def admin_client(db_session, admin_user: User) -> TestClient:
+    """TestClient authenticated as an admin (mirrors test_htmx_views_nightly2)."""
+    from app.database import get_db
+    from app.dependencies import require_admin, require_buyer, require_fresh_token, require_user
+    from app.main import app
+
+    def _db():
+        yield db_session
+
+    def _user():
+        return admin_user
+
+    async def _token():
+        return "mock-token"
+
+    overridden = [get_db, require_user, require_admin, require_buyer, require_fresh_token]
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[require_user] = _user
+    app.dependency_overrides[require_admin] = _user
+    app.dependency_overrides[require_buyer] = _user
+    app.dependency_overrides[require_fresh_token] = _token
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        for dep in overridden:
+            app.dependency_overrides.pop(dep, None)
+
+
+def _vendors(db, a="Acme Components", b="Acme Components Inc"):
+    """Create two near-duplicate vendor cards (distinct normalized_name — UNIQUE)."""
+    v1 = VendorCard(
+        normalized_name=a.lower(),
+        display_name=a,
+        emails=[],
+        phones=[],
+        sighting_count=5,
+        created_at=datetime.now(timezone.utc),
+    )
+    v2 = VendorCard(
+        normalized_name=b.lower(),
+        display_name=b,
+        emails=[],
+        phones=[],
+        sighting_count=2,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add_all([v1, v2])
+    db.commit()
+    return v1, v2
+
+
+def _companies(db, a="Globex Corp", b="Globex Corporation"):
+    c1 = Company(name=a, is_active=True, created_at=datetime.now(timezone.utc))
+    c2 = Company(name=b, is_active=True, created_at=datetime.now(timezone.utc))
+    db.add_all([c1, c2])
+    db.commit()
+    return c1, c2
+
+
+# ── PART 1: the bug — clicking a dup opens the review and merges, no error ──
+
+
+class TestRenderNoCruft:
+    def test_render_has_working_merge_buttons_and_no_dead_alpine(self, admin_client, db_session):
+        """The render must NOT carry the dead `merged`/x-if/x-cloak wrapper that hid the
+        merge buttons (the root cause), and MUST carry live hx-post merge buttons."""
+        v1, v2 = _vendors(db_session)
+        resp = admin_client.get("/v2/partials/settings/data-ops")
+        assert resp.status_code == 200
+        html = resp.text
+        # Cruft is gone.
+        assert "merged: false" not in html
+        assert "x-if" not in html
+        # Buttons are live HTMX (not gated behind a never-toggled Alpine flag).
+        assert "/v2/partials/admin/vendor-merge" in html
+        assert f'"keep_id": {v1.id}' in html or f'"keep_id": {v2.id}' in html
+
+    def test_render_company_section(self, admin_client, db_session):
+        _companies(db_session)
+        resp = admin_client.get("/v2/partials/settings/data-ops")
+        assert resp.status_code == 200
+        assert "/v2/partials/admin/company-merge" in resp.text
+
+
+class TestClickMerge:
+    def test_vendor_merge_click_succeeds(self, admin_client, db_session):
+        """Drive the real click→merge POST; the removed card is gone, kept survives."""
+        v1, v2 = _vendors(db_session, "Acme X", "Acme X Inc")
+        keep, remove = v1.id, v2.id
+        resp = admin_client.post(
+            "/v2/partials/admin/vendor-merge", data={"keep_id": str(keep), "remove_id": str(remove)}
+        )
+        assert resp.status_code == 200, resp.text[:1500]
+        assert db_session.get(VendorCard, remove) is None
+        assert db_session.get(VendorCard, keep) is not None
+
+    def test_company_merge_click_succeeds(self, admin_client, db_session):
+        c1, c2 = _companies(db_session)
+        keep, remove = c1.id, c2.id
+        resp = admin_client.post(
+            "/v2/partials/admin/company-merge", data={"keep_id": str(keep), "remove_id": str(remove)}
+        )
+        assert resp.status_code == 200, resp.text[:1500]
+        assert db_session.get(Company, remove) is None
+        assert db_session.get(Company, keep) is not None
+
+    def test_vendor_merge_bad_id_is_toast_not_500(self, admin_client, db_session):
+        """A non-existent id must surface as an error toast (200 + HX-Trigger), never a
+        500 — the vendor route now catches Exception, matching company-merge."""
+        resp = admin_client.post("/v2/partials/admin/vendor-merge", data={"keep_id": "99999", "remove_id": "99998"})
+        assert resp.status_code == 200
+        assert "showToast" in resp.headers.get("HX-Trigger", "")
+
+
+# ── PART 2: Delete both ─────────────────────────────────────────────────────
+
+
+class TestDeleteBoth:
+    def test_vendor_delete_both(self, admin_client, db_session):
+        v1, v2 = _vendors(db_session, "Junk A", "Junk A Inc")
+        a, b = v1.id, v2.id
+        resp = admin_client.post("/v2/partials/admin/vendor-delete-both", data={"id_a": str(a), "id_b": str(b)})
+        assert resp.status_code == 200, resp.text[:1500]
+        assert db_session.get(VendorCard, a) is None
+        assert db_session.get(VendorCard, b) is None
+
+    def test_company_delete_both(self, admin_client, db_session):
+        c1, c2 = _companies(db_session, "Junk Co", "Junk Co LLC")
+        a, b = c1.id, c2.id
+        resp = admin_client.post("/v2/partials/admin/company-delete-both", data={"id_a": str(a), "id_b": str(b)})
+        assert resp.status_code == 200, resp.text[:1500]
+        assert db_session.get(Company, a) is None
+        assert db_session.get(Company, b) is None
+
+    def test_vendor_delete_both_detaches_offers(self, admin_client, db_session, test_user):
+        """Deleting both vendors must NOT delete dependent offers — their vendor_card_id
+        is NULLed so the offer survives unlinked."""
+        from app.models import Offer
+
+        v1, v2 = _vendors(db_session, "Det A", "Det A Inc")
+        offer = Offer(
+            vendor_card_id=v1.id,
+            vendor_name="Det A",
+            mpn="LM317T",
+            qty_available=10,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(offer)
+        db_session.commit()
+        oid = offer.id
+        resp = admin_client.post("/v2/partials/admin/vendor-delete-both", data={"id_a": str(v1.id), "id_b": str(v2.id)})
+        assert resp.status_code == 200, resp.text[:1500]
+        db_session.expire_all()
+        surviving = db_session.get(Offer, oid)
+        assert surviving is not None
+        assert surviving.vendor_card_id is None
+
+
+# ── PART 4: multi-select bulk mass actions ──────────────────────────────────
+
+
+class TestBulkActions:
+    def test_render_has_multiselect_scaffold(self, admin_client, db_session):
+        _vendors(db_session)
+        html = admin_client.get("/v2/partials/settings/data-ops").text
+        assert "dedupSelect()" in html
+        assert "Select all" in html
+        assert "Merge selected" in html
+        assert "Delete selected" in html
+        assert "Dismiss for now" in html
+
+    def test_bulk_vendor_merge(self, admin_client, db_session):
+        v1, v2 = _vendors(db_session, "Bulk A", "Bulk A Inc")
+        token = f"{v1.id}-{v2.id}"
+        resp = admin_client.post("/v2/partials/admin/vendor-bulk", data={"action": "merge", "pairs": token})
+        assert resp.status_code == 200, resp.text[:1500]
+        assert db_session.get(VendorCard, v2.id) is None
+        assert db_session.get(VendorCard, v1.id) is not None
+
+    def test_bulk_vendor_delete(self, admin_client, db_session):
+        v1, v2 = _vendors(db_session, "BulkDel A", "BulkDel A Inc")
+        token = f"{v1.id}-{v2.id}"
+        resp = admin_client.post("/v2/partials/admin/vendor-bulk", data={"action": "delete", "pairs": token})
+        assert resp.status_code == 200, resp.text[:1500]
+        assert db_session.get(VendorCard, v1.id) is None
+        assert db_session.get(VendorCard, v2.id) is None
+
+    def test_bulk_company_merge(self, admin_client, db_session):
+        c1, c2 = _companies(db_session, "BulkCo", "BulkCo Inc")
+        token = f"{c1.id}-{c2.id}"
+        resp = admin_client.post("/v2/partials/admin/company-bulk", data={"action": "merge", "pairs": token})
+        assert resp.status_code == 200, resp.text[:1500]
+        assert db_session.get(Company, c2.id) is None
+
+    def test_bulk_dismiss_is_noop_render(self, admin_client, db_session):
+        """Dismiss is view-only — records are untouched, render still 200."""
+        v1, v2 = _vendors(db_session, "Dis A", "Dis A Inc")
+        token = f"{v1.id}-{v2.id}"
+        resp = admin_client.post("/v2/partials/admin/vendor-bulk", data={"action": "dismiss", "pairs": token})
+        assert resp.status_code == 200
+        assert db_session.get(VendorCard, v1.id) is not None
+        assert db_session.get(VendorCard, v2.id) is not None
+
+    def test_bulk_invalid_action_rejected(self, admin_client, db_session):
+        resp = admin_client.post("/v2/partials/admin/vendor-bulk", data={"action": "nuke", "pairs": "1-2"})
+        assert resp.status_code == 400
+
+    def test_bulk_partial_failure_tolerated(self, admin_client, db_session):
+        """A bad pair token in a batch is counted as failed, not fatal — good pairs
+        still process and the response is 200."""
+        v1, v2 = _vendors(db_session, "Partial A", "Partial A Inc")
+        good = f"{v1.id}-{v2.id}"
+        bad = "99991-99992"
+        resp = admin_client.post("/v2/partials/admin/vendor-bulk", data={"action": "merge", "pairs": f"{good},{bad}"})
+        assert resp.status_code == 200, resp.text[:1500]
+        assert db_session.get(VendorCard, v2.id) is None  # good pair merged

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -643,3 +643,64 @@ def test_nav_poll_badges_optout_of_push_url():
         "bottom-nav badge poll spans inherit the nav <a>'s hx-push-url and rewrite the "
         'address bar; add hx-push-url="false":\n' + "\n".join(offenders)
     )
+
+
+def _func_source(path: str, func_name: str) -> str:
+    """Return the source text of a top-level function by name (AST, line-shift
+    proof)."""
+    import ast
+
+    src = Path(path).read_text()
+    tree = ast.parse(src)
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            return ast.get_source_segment(src, node)
+    raise AssertionError(f"{func_name} not found in {path}")
+
+
+def test_delete_vendor_cards_does_not_null_notnull_cascade_children():
+    """REGRESSION (CRITICAL, structural): the SQLite test DB ignores NOT-NULL-on-UPDATE,
+    so a functional test alone can't prove the bug stays fixed.
+
+    Lock it in structurally: the
+    four NOT-NULL ondelete=CASCADE children of a vendor card must NOT be enumerated in
+    ``delete_vendor_cards``' detach/NULL list — NULLing them raises NotNullViolation on
+    Postgres. They cascade-delete with the card via ``db.delete(card)``.
+    """
+    body = _func_source("app/services/vendor_merge_service.py", "delete_vendor_cards")
+    # A NOT-NULL child enumerated as a real detach tuple — (Model, "vendor_card_id") — is
+    # the bug. Match that exact tuple syntax so prose/comment mentions of the model names
+    # (which explain WHY they're excluded) don't false-trip the guard.
+    notnull_children = ["VendorContact", "VendorReview", "VendorMetricsSnapshot", "BuyerVendorStats"]
+    offenders = [m for m in notnull_children if f'({m}, "vendor_card_id")' in body]
+    assert not offenders, (
+        "delete_vendor_cards lists NOT-NULL ondelete=CASCADE children in its detach/NULL "
+        f"loop — NULLing these raises NotNullViolation on Postgres: {offenders}. "
+        "Remove them; db.delete(card) cascade-deletes them."
+    )
+    # And the cascade path itself must still be present (both cards explicitly deleted).
+    assert "db.delete(card_a)" in body and "db.delete(card_b)" in body, (
+        "delete_vendor_cards must db.delete() both cards so the DB ON DELETE CASCADE removes the NOT-NULL children."
+    )
+
+
+def test_dedup_services_fail_closed_on_detach_error():
+    """REGRESSION (MEDIUM): both delete-both services must FAIL CLOSED — a detach/purge
+    error re-raises so the route rolls back, never deleting the parents and silently
+    orphaning/losing dependent rows.
+
+    Guard: every ``except`` in the detach/purge loops
+    re-raises (no fail-open ``logger.warning`` + fall-through).
+    """
+    for path, func in (
+        ("app/services/company_merge_service.py", "delete_companies"),
+        ("app/services/vendor_merge_service.py", "delete_vendor_cards"),
+    ):
+        body = _func_source(path, func)
+        # The detach/purge region precedes the parent db.delete().
+        region = re.split(r"db\.delete\(\w+_a\)", body)[0]
+        # Every except in that region must re-raise. A bare logger.warning with no raise is
+        # the fail-open data-loss path we removed.
+        for m in re.finditer(r"except Exception as e:(.*?)(?=\n {0,8}\w|\Z)", region, re.DOTALL):
+            block = m.group(1)
+            assert "raise" in block, f"{func}: detach/purge except block fails open (no re-raise):\n{block}"


### PR DESCRIPTION
**Bug root cause:** the Data Ops merge buttons were wrapped in a dead `x-data={merged:false}` + `<template x-if=!merged x-cloak>`, and `#settings-content` was missing from htmx_app.js's afterSwap `Alpine.initTree` allow-list — so after the HTMX swap the template wasn't initialized, `[x-cloak]{display:none}` stayed applied (buttons hidden/inert), and clicks hit half-bound Alpine and threw. Backend merge routes were proven to return 200 (failure was purely client-side). Fix: removed the dead wrapper (buttons are pure HTMX) + added `#settings-content` to initTree (root-cause fix for the whole Settings cluster); vendor-merge route `except ValueError`→`except Exception` (DB error → toast not 500). **Delete-both:** admin-gated vendor/company-delete-both routes; services detach dependent FKs (offers/sightings survive unlinked) + purge strictly company-scoped rows. **Mass actions:** per-row checkboxes + select-all + sticky bar (merge/delete/dismiss selected), mirrors requisitions2 rq2Page; keeper-first pair tokens, admin-gated `_dedup_bulk`, 200 cap, per-pair failure tolerance. 15 new tests + static-analysis 23 + 441 broad slice + pre-commit green. NOTE: 'Dismiss' is view-only (durable dismissal needs a new table+migration — deliberately not shipped unattended).