### PR TITLE
fix(search): universal top-search across all entities + read-gating (IDOR fix)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -499,7 +499,7 @@ async def global_search(
     """Global search across all entity types (type-ahead)."""
     from app.services.global_search_service import fast_search
 
-    results = fast_search(q, db)
+    results = fast_search(q, db, user)
     return template_response(
         "htmx/partials/shared/search_results.html",
         {**_base_ctx(request, user), "results": results, "query": q},
@@ -516,7 +516,7 @@ async def ai_search_endpoint(
     """AI-powered search — triggered by Enter key."""
     from app.services.global_search_service import ai_search
 
-    results = await ai_search(q, db)
+    results = await ai_search(q, db, user)
     return template_response(
         "htmx/partials/shared/search_results.html",
         {**_base_ctx(request, user), "results": results, "query": q, "ai_search": True},
@@ -533,7 +533,7 @@ async def search_results_page(
     """Full search results page."""
     from app.services.global_search_service import fast_search
 
-    results = fast_search(q, db) if q else {"best_match": None, "groups": {}, "total_count": 0}
+    results = fast_search(q, db, user) if q else {"best_match": None, "groups": {}, "total_count": 0}
     return template_response(
         "htmx/partials/search/full_results.html",
         {**_base_ctx(request, user), "results": results, "query": q},

--- a/app/services/global_search_service.py
+++ b/app/services/global_search_service.py
@@ -12,15 +12,19 @@ import hashlib
 from collections.abc import Callable
 
 from loguru import logger
-from sqlalchemy import String, cast, func
-from sqlalchemy.orm import Session
+from sqlalchemy import String, cast, func, or_
+from sqlalchemy.orm import Query, Session
 
+from app.constants import RESTRICTED_ROLES
+from app.models.auth import User
 from app.models.crm import Company, SiteContact
+from app.models.intelligence import MaterialCard
 from app.models.offers import Offer
-from app.models.sourcing import Requirement, Requisition
+from app.models.sourcing import Requirement, Requisition, Sighting
 from app.models.vendors import VendorCard, VendorContact
 from app.utils.claude_client import claude_structured
 from app.utils.claude_errors import ClaudeError, ClaudeUnavailableError
+from app.utils.normalization import normalize_mpn_key
 from app.utils.search_builder import SearchBuilder
 
 RESULT_LIMIT = 5
@@ -63,6 +67,41 @@ def _set_ai_cache(query: str, result: dict) -> None:
 def _is_postgres(db: Session) -> bool:
     """Check if the DB backend is PostgreSQL (vs SQLite in tests)."""
     return bool(db.bind) and db.bind.dialect.name == "postgresql"
+
+
+def _is_restricted(user: User | None) -> bool:
+    """True when *user* is a SALES/TRADER who may only see requisitions they own."""
+    return user is not None and getattr(user, "role", None) in RESTRICTED_ROLES
+
+
+def _scope_owned_reqs(q: Query, user: User | None, *, req_id_col) -> Query:
+    """Restrict a query to requisitions owned by *user* for RESTRICTED_ROLES.
+
+    *req_id_col* is the column on the queried model that references requisitions.id
+    (e.g. Requisition.id, Requirement.requisition_id, Offer.requisition_id). For an
+    unrestricted user (or no user — legacy callers) the query is returned unchanged.
+    Requisition-less rows (NULL req_id, e.g. unsolicited inbound offers) are hidden from
+    restricted users since ownership can't be established.
+    """
+    if not _is_restricted(user):
+        return q
+    owned = q.session.query(Requisition.id).filter(Requisition.created_by == user.id)
+    return q.filter(req_id_col.in_(owned))
+
+
+def _add_mpn_match(sb: SearchBuilder, query: str, *ilike_cols, normalized_col):
+    """OR an exact normalized-MPN match onto the ILIKE filter across *ilike_cols*.
+
+    Typing "lm-2596s-5.0" canonicalizes to the same key the normalized_mpn columns
+    store, so a part number reliably hits its requirement/offer/card/sighting via the
+    index even when separators differ. Falls back to plain ILIKE when the query has no
+    usable MPN key (e.g. a vendor name).
+    """
+    clause = sb.ilike_filter(*ilike_cols)
+    mpn_key = normalize_mpn_key(query)
+    if mpn_key and len(mpn_key) >= 3:
+        clause = or_(clause, normalized_col == mpn_key)
+    return clause
 
 
 def _to_dict(obj, fields: list[str], entity_type: str) -> dict:
@@ -112,7 +151,41 @@ EMPTY_GROUPS = {
     "site_contacts": [],
     "parts": [],
     "offers": [],
+    "material_cards": [],
+    "sightings": [],
 }
+
+
+_SIGHTING_DISPLAY_FIELDS = ["mpn_matched", "vendor_name", "manufacturer", "unit_price", "qty_available"]
+
+
+def _sighting_dedup_key(s) -> tuple[str, str]:
+    """Dedup key for sightings: (normalized MPN, normalized vendor name)."""
+    return (
+        (s.normalized_mpn or s.mpn_matched or "").lower(),
+        (s.vendor_name_normalized or s.vendor_name or "").lower(),
+    )
+
+
+def _dedup_sightings(rows, display_fields: list[str]) -> list[dict]:
+    """Dedup (Sighting, requisition_id) rows by (mpn, vendor), attaching requisition_id.
+
+    *rows* are ``(Sighting, requisition_id)`` tuples from a Sighting↔Requirement join.
+    Capped at RESULT_LIMIT; callers over-fetch so distinct keys still fill the page.
+    """
+    seen: set = set()
+    out: list[dict] = []
+    for sight, req_id in rows:
+        key = _sighting_dedup_key(sight)
+        if key in seen:
+            continue
+        seen.add(key)
+        d = _to_dict(sight, display_fields, "sighting")
+        d["requisition_id"] = req_id
+        out.append(d)
+        if len(out) >= RESULT_LIMIT:
+            break
+    return out
 
 
 def _empty_result() -> dict:
@@ -122,8 +195,19 @@ def _empty_result() -> dict:
 # ── Fast search (Tier 1) ─────────────────────────────────────────────
 
 
-def fast_search(query: str, db: Session) -> dict:
-    """Search all entities with ILIKE + pg_trgm fuzzy matching.
+def fast_search(query: str, db: Session, user: User | None = None) -> dict:
+    """Universal entity search with ILIKE + pg_trgm fuzzy + normalized-MPN matching.
+
+    Returns grouped results across requisitions, companies, vendors, vendor/site
+    contacts, parts, offers, material-hub cards, and sightings. A part number surfaces
+    every requirement/offer/material-card/sighting it appears on; a vendor surfaces its
+    card (matched by name, a contact, or an offer), its contacts, offers, and sightings.
+
+    Read-gating: for RESTRICTED_ROLES (SALES/TRADER), requisition-scoped results
+    (requisitions, parts, offers, sightings) are limited to requisitions the user owns.
+    Shared reference data (companies, vendors, contacts, material cards) follows the
+    app-wide all-visible read policy. *user* is None only for legacy/test callers, which
+    then see everything (no restriction).
 
     Sync function — FastAPI runs it in a thread pool from async handlers. Falls back to
     plain ILIKE on SQLite (test mode).
@@ -138,9 +222,13 @@ def fast_search(query: str, db: Session) -> dict:
     all_results = []
 
     # --- Requisitions ---
-    q = db.query(Requisition).filter(
-        Requisition.is_scratch.is_(False),
-        sb.ilike_filter(Requisition.name, Requisition.customer_name),
+    q = _scope_owned_reqs(
+        db.query(Requisition).filter(
+            Requisition.is_scratch.is_(False),
+            sb.ilike_filter(Requisition.name, Requisition.customer_name),
+        ),
+        user,
+        req_id_col=Requisition.id,
     )
     if use_pg:
         q = q.order_by(
@@ -161,14 +249,36 @@ def fast_search(query: str, db: Session) -> dict:
     groups["companies"] = [_to_dict(r, ["name", "domain", "account_type"], "company") for r in rows]
     all_results.extend(groups["companies"])
 
-    # --- Vendors (includes JSON emails/phones cast to string) ---
+    # --- Vendors — matched by own fields OR via a matching contact/offer vendor name ---
+    # Surface a vendor when its name/email/phone matches, OR when one of its contacts
+    # matches, OR when an offer logged under it matches — so typing a contact name or an
+    # MPN/vendor on an offer still leads back to the vendor card.
+    vendor_via_contact = db.query(VendorContact.vendor_card_id).filter(
+        sb.ilike_filter(VendorContact.full_name, VendorContact.email, VendorContact.phone),
+    )
+    # Scope the offer-based vendor match to the user's own requisitions for restricted
+    # roles — otherwise surfacing a vendor purely because it has an offer on a foreign
+    # requisition would leak the existence of that req-scoped offer (matches the offers
+    # group's own gating).
+    vendor_via_offer = _scope_owned_reqs(
+        db.query(Offer.vendor_card_id).filter(
+            Offer.vendor_card_id.isnot(None),
+            sb.ilike_filter(Offer.vendor_name, Offer.mpn),
+        ),
+        user,
+        req_id_col=Offer.requisition_id,
+    )
     q = db.query(VendorCard).filter(
-        sb.ilike_filter(
-            VendorCard.display_name,
-            VendorCard.normalized_name,
-            VendorCard.domain,
-            cast(VendorCard.emails, String),
-            cast(VendorCard.phones, String),
+        or_(
+            sb.ilike_filter(
+                VendorCard.display_name,
+                VendorCard.normalized_name,
+                VendorCard.domain,
+                cast(VendorCard.emails, String),
+                cast(VendorCard.phones, String),
+            ),
+            VendorCard.id.in_(vendor_via_contact),
+            VendorCard.id.in_(vendor_via_offer),
         )
     )
     if use_pg:
@@ -184,7 +294,9 @@ def fast_search(query: str, db: Session) -> dict:
     if use_pg:
         q = q.order_by(func.similarity(VendorContact.full_name, query).desc())
     rows = q.limit(RESULT_LIMIT).all()
-    groups["vendor_contacts"] = [_to_dict(r, ["full_name", "email", "phone", "title"], "vendor_contact") for r in rows]
+    groups["vendor_contacts"] = [
+        _to_dict(r, ["full_name", "email", "phone", "title", "vendor_card_id"], "vendor_contact") for r in rows
+    ]
     all_results.extend(groups["vendor_contacts"])
 
     # --- Site Contacts ---
@@ -196,13 +308,20 @@ def fast_search(query: str, db: Session) -> dict:
     all_results.extend(groups["site_contacts"])
 
     # --- Parts (Requirements) — dedup by normalized_mpn so same part across reqs shows once ---
-    q = db.query(Requirement).filter(
-        sb.ilike_filter(
-            Requirement.primary_mpn,
-            Requirement.normalized_mpn,
-            Requirement.brand,
-            Requirement.substitutes_text,
-        )
+    q = _scope_owned_reqs(
+        db.query(Requirement).filter(
+            _add_mpn_match(
+                sb,
+                query,
+                Requirement.primary_mpn,
+                Requirement.normalized_mpn,
+                Requirement.brand,
+                Requirement.substitutes_text,
+                normalized_col=Requirement.normalized_mpn,
+            )
+        ),
+        user,
+        req_id_col=Requirement.requisition_id,
     )
     if use_pg:
         q = q.order_by(func.similarity(Requirement.primary_mpn, query).desc())
@@ -213,7 +332,13 @@ def fast_search(query: str, db: Session) -> dict:
     all_results.extend(groups["parts"])
 
     # --- Offers — dedup by (mpn, vendor_name) so same offer combo shows once ---
-    q = db.query(Offer).filter(sb.ilike_filter(Offer.vendor_name, Offer.mpn))
+    q = _scope_owned_reqs(
+        db.query(Offer).filter(
+            _add_mpn_match(sb, query, Offer.vendor_name, Offer.mpn, normalized_col=Offer.normalized_mpn)
+        ),
+        user,
+        req_id_col=Offer.requisition_id,
+    )
     if use_pg:
         q = q.order_by(func.similarity(Offer.mpn, query).desc())
     rows = q.limit(RESULT_LIMIT * 3).all()
@@ -221,6 +346,50 @@ def fast_search(query: str, db: Session) -> dict:
         rows, _offer_dedup_key, ["vendor_name", "mpn", "unit_price", "qty_available", "requisition_id"], "offer"
     )
     all_results.extend(groups["offers"])
+
+    # --- Material cards (material hub) — by MPN / manufacturer / brand / description ---
+    q = db.query(MaterialCard).filter(
+        MaterialCard.deleted_at.is_(None),
+        _add_mpn_match(
+            sb,
+            query,
+            MaterialCard.display_mpn,
+            MaterialCard.normalized_mpn,
+            MaterialCard.manufacturer,
+            MaterialCard.brand,
+            MaterialCard.description,
+            normalized_col=MaterialCard.normalized_mpn,
+        ),
+    )
+    if use_pg:
+        q = q.order_by(func.similarity(MaterialCard.display_mpn, query).desc())
+    rows = q.limit(RESULT_LIMIT).all()
+    groups["material_cards"] = [
+        _to_dict(r, ["display_mpn", "normalized_mpn", "manufacturer", "description"], "material_card") for r in rows
+    ]
+    all_results.extend(groups["material_cards"])
+
+    # --- Sightings — by MPN / vendor; carry parent requisition for nav + read-gating ---
+    q = (
+        db.query(Sighting, Requirement.requisition_id)
+        .join(Requirement, Sighting.requirement_id == Requirement.id)
+        .filter(
+            _add_mpn_match(
+                sb,
+                query,
+                Sighting.mpn_matched,
+                Sighting.vendor_name,
+                Sighting.manufacturer,
+                normalized_col=Sighting.normalized_mpn,
+            )
+        )
+    )
+    if _is_restricted(user):
+        q = q.filter(Requirement.requisition_id.in_(db.query(Requisition.id).filter(Requisition.created_by == user.id)))
+    if use_pg:
+        q = q.order_by(func.similarity(Sighting.mpn_matched, query).desc())
+    groups["sightings"] = _dedup_sightings(q.limit(RESULT_LIMIT * 3).all(), _SIGHTING_DISPLAY_FIELDS)
+    all_results.extend(groups["sightings"])
 
     # --- Best match: first result from first non-empty group ---
     best = all_results[0] if all_results else None
@@ -253,6 +422,8 @@ SEARCH_INTENT_SCHEMA = {
                             "site_contact",
                             "part",
                             "offer",
+                            "material_card",
+                            "sighting",
                         ],
                     },
                     "text_query": {
@@ -292,20 +463,22 @@ Available entities:
 - site_contact: People at customer companies. Fields: full_name, email, phone, title, contact_role (buyer/technical/decision_maker)
 - part: Component requirements. Fields: primary_mpn, normalized_mpn, brand, sourcing_status (open/sourcing/offered/quoted/won/lost)
 - offer: Vendor price quotes. Fields: mpn, vendor_name, status (active/sold)
+- material_card: Material-hub part cards (the canonical part record). Fields: display_mpn, manufacturer, brand, description
+- sighting: Market availability seen for a part at a vendor. Fields: mpn_matched, vendor_name, manufacturer
 
 Rules:
 - If the query looks like an email address, search vendor_contacts and site_contacts by email
 - If the query looks like a phone number, search vendor_contacts and site_contacts by phone
-- If the query looks like a part number (alphanumeric with dashes), search parts and offers by MPN
+- If the query looks like a part number (alphanumeric with dashes), search parts, offers, material_cards, and sightings by MPN
 - If the query mentions a company by name, search companies and vendors
 - If the query is ambiguous, return multiple searches to cover likely intents
 - Always set text_query to the relevant search term extracted from the natural language
 
 Examples:
-- "LM358" -> search parts (text_query="LM358") + offers (text_query="LM358")
-- "john@acme.com" -> search vendor_contacts (text_query="john@acme.com") + site_contacts (text_query="john@acme.com")
-- "open reqs for Raytheon" -> search requisitions (text_query="Raytheon", filters={status:"active", customer_name:"Raytheon"})
-- "who sells LM317?" -> search parts (text_query="LM317") + offers (text_query="LM317") + vendors (text_query="LM317")\
+- "LM358" -> parts + offers + material_cards + sightings (text_query="LM358")
+- "john@acme.com" -> vendor_contacts + site_contacts (text_query="john@acme.com")
+- "open reqs for Raytheon" -> requisitions (text_query="Raytheon", filters={status:"active", customer_name:"Raytheon"})
+- "who sells LM317?" -> parts + offers + material_cards + sightings + vendors (text_query="LM317")\
 """
 
 # Map entity_type -> (Model, search_fields, display_fields, group_key)
@@ -337,6 +510,27 @@ _ENTITY_CONFIG = {
         ["vendor_name", "mpn", "unit_price", "qty_available", "requisition_id"],
         "offers",
     ),
+    "material_card": (
+        MaterialCard,
+        ["display_mpn", "normalized_mpn", "manufacturer", "brand", "description"],
+        ["display_mpn", "normalized_mpn", "manufacturer", "description"],
+        "material_cards",
+    ),
+    "sighting": (
+        Sighting,
+        ["mpn_matched", "vendor_name", "manufacturer"],
+        _SIGHTING_DISPLAY_FIELDS,
+        "sightings",
+    ),
+}
+
+# Entity types whose visibility is gated by requisition ownership for RESTRICTED_ROLES.
+# Maps entity_type -> the column referencing requisitions.id (Sighting reaches it via
+# requirement, handled separately in _run_intent_query).
+_REQ_SCOPED_INTENT = {
+    "requisition": Requisition.id,
+    "part": Requirement.requisition_id,
+    "offer": Offer.requisition_id,
 }
 
 # Map filter names to (entity_type -> model attribute)
@@ -350,8 +544,12 @@ _FILTER_MAP = {
 }
 
 
-def _run_intent_query(search_op: dict, db: Session) -> tuple[str, list[dict]]:
-    """Execute a single search intent operation and return (group_key, results)."""
+def _run_intent_query(search_op: dict, db: Session, user: User | None = None) -> tuple[str, list[dict]]:
+    """Execute a single search intent operation and return (group_key, results).
+
+    Applies the same requisition-ownership read-gating as fast_search() for
+    RESTRICTED_ROLES, and the MaterialCard soft-delete filter.
+    """
     entity_type = search_op.get("entity_type", "")
     text_query = search_op.get("text_query", "")
     filters = search_op.get("filters", {})
@@ -376,6 +574,18 @@ def _run_intent_query(search_op: dict, db: Session) -> tuple[str, list[dict]]:
     if entity_type == "requisition":
         q = q.filter(model.is_scratch.is_(False))
 
+    # Hide soft-deleted material cards.
+    if entity_type == "material_card":
+        q = q.filter(MaterialCard.deleted_at.is_(None))
+
+    # Read-gating: restrict requisition-scoped entities to the user's own requisitions.
+    if (req_id_col := _REQ_SCOPED_INTENT.get(entity_type)) is not None:
+        q = _scope_owned_reqs(q, user, req_id_col=req_id_col)
+    elif entity_type == "sighting" and _is_restricted(user):
+        owned = db.query(Requisition.id).filter(Requisition.created_by == user.id)
+        owned_reqs = db.query(Requirement.id).filter(Requirement.requisition_id.in_(owned))
+        q = q.filter(Sighting.requirement_id.in_(owned_reqs))
+
     # Apply structured filters
     for filter_name, filter_value in (filters or {}).items():
         entity_attrs = _FILTER_MAP.get(filter_name, {})
@@ -398,7 +608,7 @@ def _run_intent_query(search_op: dict, db: Session) -> tuple[str, list[dict]]:
             sb_filter = SearchBuilder(str(filter_value))
             q = q.filter(col.ilike(f"%{sb_filter.safe}%"))
 
-    # Dedup parts by normalized_mpn, offers by (mpn, vendor_name)
+    # Dedup parts by normalized_mpn, offers by (mpn, vendor_name), sightings by (mpn, vendor)
     if entity_type == "part":
         rows = q.limit(RESULT_LIMIT * 3).all()
         return (group_key, _dedup_to_dicts(rows, _part_dedup_key, display_fields, entity_type))
@@ -407,23 +617,34 @@ def _run_intent_query(search_op: dict, db: Session) -> tuple[str, list[dict]]:
         rows = q.limit(RESULT_LIMIT * 3).all()
         return (group_key, _dedup_to_dicts(rows, _offer_dedup_key, display_fields, entity_type))
 
+    if entity_type == "sighting":
+        # Pull the parent requisition (sighting -> requirement -> requisition) in one
+        # joined query for nav, avoiding a per-row lookup.
+        joined = q.join(Requirement, Sighting.requirement_id == Requirement.id).add_columns(Requirement.requisition_id)
+        return (group_key, _dedup_sightings(joined.limit(RESULT_LIMIT * 3).all(), display_fields))
+
     rows = q.limit(RESULT_LIMIT).all()
     return (group_key, [_to_dict(r, display_fields, entity_type) for r in rows])
 
 
-async def ai_search(query: str, db: Session) -> dict:
+async def ai_search(query: str, db: Session, user: User | None = None) -> dict:
     """AI-powered intent search using Claude Haiku.
 
     This function IS async because it awaits claude_structured(). The sync DB queries
     within it are fine — FastAPI handles the mix.
 
     Returns same structure as fast_search() for template compatibility. Falls back to
-    fast_search() on Claude failure.
+    fast_search() on Claude failure. Applies the same requisition-ownership read-gating
+    as fast_search(); the shared cache is used ONLY for unrestricted users so a
+    RESTRICTED_ROLE user can never read another user's owned results from cache.
     """
-    # Check cache first
-    cached = _get_ai_cache(query)
-    if cached is not None:
-        return cached
+    cacheable = not _is_restricted(user)
+
+    # Check cache first (unrestricted users only — restricted results are user-specific).
+    if cacheable:
+        cached = _get_ai_cache(query)
+        if cached is not None:
+            return cached
 
     # Call Claude for intent parsing
     try:
@@ -436,21 +657,21 @@ async def ai_search(query: str, db: Session) -> dict:
         )
     except ClaudeUnavailableError:
         logger.info("Claude not configured — falling back to fast_search")
-        return fast_search(query, db)
+        return fast_search(query, db, user)
     except ClaudeError as e:
         logger.warning("Claude AI failed for search intent: {}", e)
-        return fast_search(query, db)
+        return fast_search(query, db, user)
 
     if not intent or "searches" not in intent:
         logger.debug("AI search: Claude returned None, falling back to fast_search")
-        return fast_search(query, db)
+        return fast_search(query, db, user)
 
     # Execute targeted queries per intent, dedup by (type, id)
     groups = {k: [] for k in EMPTY_GROUPS}
     seen: set[tuple[str, int]] = set()
 
     for search_op in intent["searches"]:
-        group_key, results = _run_intent_query(search_op, db)
+        group_key, results = _run_intent_query(search_op, db, user)
         if group_key and results:
             for r in results:
                 key = (r["type"], r["id"])
@@ -466,7 +687,8 @@ async def ai_search(query: str, db: Session) -> dict:
         "total_count": len(all_results),
     }
 
-    # Cache successful result
-    _set_ai_cache(query, result)
+    # Cache successful result (unrestricted users only).
+    if cacheable:
+        _set_ai_cache(query, result)
 
     return result

--- a/app/services/global_search_service.py
+++ b/app/services/global_search_service.py
@@ -1,7 +1,7 @@
 """Global search service — fast SQL search + AI intent search.
 
 Provides two search tiers:
-  - fast_search(): pg_trgm fuzzy matching across 7 entity types (<100ms)
+  - fast_search(): pg_trgm fuzzy matching across 9 entity types (<100ms)
   - ai_search(): Claude Haiku intent parsing + targeted queries (<2s)
 
 Called by: app/routers/htmx_views.py (global search endpoints)

--- a/app/templates/htmx/partials/search/full_results.html
+++ b/app/templates/htmx/partials/search/full_results.html
@@ -70,6 +70,8 @@
     ("site_contacts", "Customer Contacts", results.groups.get("site_contacts", [])|length),
     ("parts", "Parts", results.groups.get("parts", [])|length),
     ("offers", "Offers", results.groups.get("offers", [])|length),
+    ("material_cards", "Material Hub", results.groups.get("material_cards", [])|length),
+    ("sightings", "Sightings", results.groups.get("sightings", [])|length),
   ] %}
 
   {# ── Tab bar ── #}
@@ -100,7 +102,9 @@
       "vendor": "/v2/vendors/" ~ bm.id,
       "vendor_contact": "/v2/vendors/" ~ (bm.vendor_card_id|default(bm.id)),
       "part": "/v2/requisitions/" ~ (bm.requisition_id|default("")),
-      "offer": "/v2/requisitions/" ~ (bm.requisition_id|default(""))
+      "offer": "/v2/requisitions/" ~ (bm.requisition_id|default("")),
+      "material_card": "/v2/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
+      "sighting": "/v2/requisitions/" ~ (bm.requisition_id|default(""))
     } %}
     {% set bm_partials_map = {
       "requisition": "/v2/partials/requisitions/" ~ bm.id,
@@ -108,7 +112,9 @@
       "vendor": "/v2/partials/vendors/" ~ bm.id,
       "vendor_contact": "/v2/partials/vendors/" ~ (bm.vendor_card_id|default(bm.id)),
       "part": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("")),
-      "offer": "/v2/partials/requisitions/" ~ (bm.requisition_id|default(""))
+      "offer": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("")),
+      "material_card": "/v2/partials/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
+      "sighting": "/v2/partials/requisitions/" ~ (bm.requisition_id|default(""))
     } %}
     <a href="{{ bm_url_map.get(bm.type, '#') }}"
        hx-get="{{ bm_partials_map.get(bm.type, '#') }}"
@@ -120,7 +126,7 @@
           {{ bm.type[0] }}
         </span>
         <div class="min-w-0 flex-1">
-          <p class="text-base font-semibold text-gray-900">{{ bm.name|default(bm.display_name|default(bm.full_name|default(bm.primary_mpn|default(bm.mpn|default("—"))))) }}</p>
+          <p class="text-base font-semibold text-gray-900">{{ bm.name|default(bm.display_name|default(bm.full_name|default(bm.primary_mpn|default(bm.mpn|default(bm.display_mpn|default(bm.mpn_matched|default("—"))))))) }}</p>
           <div class="flex items-center gap-2 mt-0.5">
             <span class="inline-block rounded bg-brand-200 px-2 py-0.5 text-xs font-medium text-brand-700">{{ bm.type|replace("_", " ")|title }}</span>
             {% if bm.email %}<span class="text-xs text-gray-600">{{ bm.email }}</span>{% endif %}
@@ -145,6 +151,8 @@
       ("site_contacts", "Customer Contacts"),
       ("parts", "Parts"),
       ("offers", "Offers"),
+      ("material_cards", "Material Hub"),
+      ("sightings", "Sightings"),
     ] %}
 
     {% for group_key, group_label in group_config %}
@@ -227,6 +235,30 @@
               <td class="px-4 py-2.5 text-emerald-600 font-medium">
                 {% if item.unit_price %}${{ "%.2f"|format(item.unit_price) }}{% else %}—{% endif %}
               </td>
+
+              {% elif group_key == "material_cards" %}
+              <td class="table-cell">
+                <a href="/v2/search?mpn={{ item.display_mpn|default(item.normalized_mpn|default(''))|urlencode }}"
+                   hx-get="/v2/partials/search?mpn={{ item.display_mpn|default(item.normalized_mpn|default(''))|urlencode }}"
+                   hx-target="#main-content"
+                   hx-push-url="/v2/search?mpn={{ item.display_mpn|default(item.normalized_mpn|default(''))|urlencode }}"
+                   class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.display_mpn }}</a>
+              </td>
+              <td class="table-cell text-gray-600">{{ item.manufacturer|default("—") }}</td>
+              <td class="table-cell text-gray-400 text-xs truncate max-w-xs">{{ item.description|default("") }}</td>
+
+              {% elif group_key == "sightings" %}
+              <td class="table-cell">
+                <a href="/v2/requisitions/{{ item.requisition_id|default('') }}"
+                   hx-get="/v2/partials/requisitions/{{ item.requisition_id|default('') }}"
+                   hx-target="#main-content"
+                   hx-push-url="/v2/requisitions/{{ item.requisition_id|default('') }}"
+                   class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.mpn_matched }}</a>
+              </td>
+              <td class="table-cell text-gray-600">{{ item.vendor_name|default("—") }}</td>
+              <td class="table-cell text-emerald-600 font-medium">
+                {% if item.unit_price %}${{ "%.2f"|format(item.unit_price) }}{% else %}—{% endif %}
+              </td>
               {% endif %}
 
             </tr>
@@ -273,6 +305,14 @@
             <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">MPN</th>
             <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Vendor</th>
             <th class="table-cell--head text-left text-xs font-semibold text-gray-500 uppercase">Price</th>
+            {% elif group_key == "material_cards" %}
+            <th class="table-cell--head text-left text-secondary font-semibold uppercase">MPN</th>
+            <th class="table-cell--head text-left text-secondary font-semibold uppercase">Manufacturer</th>
+            <th class="table-cell--head text-left text-secondary font-semibold uppercase">Description</th>
+            {% elif group_key == "sightings" %}
+            <th class="table-cell--head text-left text-secondary font-semibold uppercase">MPN</th>
+            <th class="table-cell--head text-left text-secondary font-semibold uppercase">Vendor</th>
+            <th class="table-cell--head text-left text-secondary font-semibold uppercase">Price</th>
             {% endif %}
           </tr>
         </thead>
@@ -347,6 +387,30 @@
             </td>
             <td class="px-4 py-2.5 text-gray-600">{{ item.vendor_name|default("—") }}</td>
             <td class="px-4 py-2.5 text-emerald-600 font-medium">
+              {% if item.unit_price %}${{ "%.2f"|format(item.unit_price) }}{% else %}—{% endif %}
+            </td>
+
+            {% elif group_key == "material_cards" %}
+            <td class="table-cell">
+              <a href="/v2/search?mpn={{ item.display_mpn|default(item.normalized_mpn|default(''))|urlencode }}"
+                 hx-get="/v2/partials/search?mpn={{ item.display_mpn|default(item.normalized_mpn|default(''))|urlencode }}"
+                 hx-target="#main-content"
+                 hx-push-url="/v2/search?mpn={{ item.display_mpn|default(item.normalized_mpn|default(''))|urlencode }}"
+                 class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.display_mpn }}</a>
+            </td>
+            <td class="table-cell text-gray-600">{{ item.manufacturer|default("—") }}</td>
+            <td class="table-cell text-gray-400 text-xs truncate max-w-xs">{{ item.description|default("") }}</td>
+
+            {% elif group_key == "sightings" %}
+            <td class="table-cell">
+              <a href="/v2/requisitions/{{ item.requisition_id|default('') }}"
+                 hx-get="/v2/partials/requisitions/{{ item.requisition_id|default('') }}"
+                 hx-target="#main-content"
+                 hx-push-url="/v2/requisitions/{{ item.requisition_id|default('') }}"
+                 class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.mpn_matched }}</a>
+            </td>
+            <td class="table-cell text-gray-600">{{ item.vendor_name|default("—") }}</td>
+            <td class="table-cell text-emerald-600 font-medium">
               {% if item.unit_price %}${{ "%.2f"|format(item.unit_price) }}{% else %}—{% endif %}
             </td>
             {% endif %}

--- a/app/templates/htmx/partials/shared/search_results.html
+++ b/app/templates/htmx/partials/shared/search_results.html
@@ -34,7 +34,9 @@
         "vendor": "/v2/vendors/" ~ bm.id,
         "vendor_contact": "/v2/vendors/" ~ (bm.vendor_card_id|default(bm.id)),
         "part": "/v2/requisitions/" ~ (bm.requisition_id|default("")),
-        "offer": "/v2/requisitions/" ~ (bm.requisition_id|default(""))
+        "offer": "/v2/requisitions/" ~ (bm.requisition_id|default("")),
+        "material_card": "/v2/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
+        "sighting": "/v2/requisitions/" ~ (bm.requisition_id|default(""))
       } %}
       {% set bm_partials_map = {
         "requisition": "/v2/partials/requisitions/" ~ bm.id,
@@ -42,7 +44,9 @@
         "vendor": "/v2/partials/vendors/" ~ bm.id,
         "vendor_contact": "/v2/partials/vendors/" ~ (bm.vendor_card_id|default(bm.id)),
         "part": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("")),
-        "offer": "/v2/partials/requisitions/" ~ (bm.requisition_id|default(""))
+        "offer": "/v2/partials/requisitions/" ~ (bm.requisition_id|default("")),
+        "material_card": "/v2/partials/search?mpn=" ~ (bm.display_mpn|default(bm.normalized_mpn|default(""))|urlencode),
+        "sighting": "/v2/partials/requisitions/" ~ (bm.requisition_id|default(""))
       } %}
       <a href="{{ bm_url_map.get(bm.type, '#') }}"
          hx-get="{{ bm_partials_map.get(bm.type, '#') }}"
@@ -56,7 +60,7 @@
           </span>
         </div>
         <div class="min-w-0 flex-1">
-          <p class="text-sm font-semibold text-gray-900 truncate">{{ bm.name|default(bm.display_name|default(bm.full_name|default(bm.primary_mpn|default(bm.mpn|default("—"))))) }}</p>
+          <p class="text-sm font-semibold text-gray-900 truncate">{{ bm.name|default(bm.display_name|default(bm.full_name|default(bm.primary_mpn|default(bm.mpn|default(bm.display_mpn|default(bm.mpn_matched|default("—"))))))) }}</p>
           <p class="text-xs text-gray-600 truncate">
             <span class="inline-block rounded bg-brand-100 px-1.5 py-0.5 text-xs font-medium text-brand-700">{{ bm.type|replace("_", " ")|title }}</span>
             {% if bm.email %}<span class="ml-1">{{ bm.email }}</span>{% endif %}
@@ -100,6 +104,17 @@
           <path stroke-linecap="round" stroke-linejoin="round"
                 d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"/>
         </svg>
+      {% elif entity_type == "material_cards" %}
+        <svg class="h-4 w-4 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round"
+                d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+        </svg>
+      {% elif entity_type == "sightings" %}
+        <svg class="h-4 w-4 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+          <path stroke-linecap="round" stroke-linejoin="round"
+                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+        </svg>
       {% endif %}
     {% endmacro %}
 
@@ -111,7 +126,9 @@
       "vendor_contacts": "Vendor Contacts",
       "site_contacts": "Customer Contacts",
       "parts": "Parts",
-      "offers": "Offers"
+      "offers": "Offers",
+      "material_cards": "Material Hub",
+      "sightings": "Sightings"
     } %}
 
     {# ── Grouped sections ── #}
@@ -220,6 +237,43 @@
             {{ entity_icon("offers") }}
             <span>
               <span class="font-medium font-mono">{{ item.mpn }}</span>
+              {% if item.vendor_name %}
+              <span class="ml-1 text-gray-400">{{ item.vendor_name }}</span>
+              {% endif %}
+              {% if item.unit_price %}
+              <span class="ml-1 text-emerald-600 font-medium">${{ "%.2f"|format(item.unit_price) }}</span>
+              {% endif %}
+            </span>
+          </a>
+
+          {# ── Material Hub cards ── #}
+          {% elif group_key == "material_cards" %}
+          <a href="/v2/search?mpn={{ item.display_mpn|default(item.normalized_mpn|default(''))|urlencode }}"
+             hx-get="/v2/partials/search?mpn={{ item.display_mpn|default(item.normalized_mpn|default(''))|urlencode }}"
+             hx-target="#main-content"
+             hx-push-url="/v2/search?mpn={{ item.display_mpn|default(item.normalized_mpn|default(''))|urlencode }}"
+             @click="searchOpen = false"
+             class="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-brand-50 transition-colors">
+            {{ entity_icon("material_cards") }}
+            <span>
+              <span class="font-medium font-mono">{{ item.display_mpn }}</span>
+              {% if item.manufacturer %}
+              <span class="ml-1 text-gray-400">{{ item.manufacturer }}</span>
+              {% endif %}
+            </span>
+          </a>
+
+          {# ── Sightings ── #}
+          {% elif group_key == "sightings" %}
+          <a href="/v2/requisitions/{{ item.requisition_id|default('') }}"
+             hx-get="/v2/partials/requisitions/{{ item.requisition_id|default('') }}"
+             hx-target="#main-content"
+             hx-push-url="/v2/requisitions/{{ item.requisition_id|default('') }}"
+             @click="searchOpen = false"
+             class="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-brand-50 transition-colors">
+            {{ entity_icon("sightings") }}
+            <span>
+              <span class="font-medium font-mono">{{ item.mpn_matched }}</span>
               {% if item.vendor_name %}
               <span class="ml-1 text-gray-400">{{ item.vendor_name }}</span>
               {% endif %}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -3878,6 +3878,38 @@ Search coverage:
           for parts list filtering
 ```
 
+### Universal Top-Search (global search bar)
+
+The header search input (templates/htmx/partials/shared/topbar.html, name="q") debounces
+into `GET /v2/partials/search/global` → `htmx_views.global_search` →
+`global_search_service.fast_search(q, db, user)` → renders the grouped dropdown
+`partials/shared/search_results.html`. Pressing Enter posts `/v2/partials/search/ai` →
+`ai_search(q, db, user)` (Claude Haiku intent parse, falls back to fast_search). "View all"
+renders the full page `partials/search/full_results.html` via `/v2/partials/search/results`.
+
+```
+fast_search(query, db, user)  — one universal entity search, grouped results:
+    +---> 9 groups: requisitions, companies, vendors, vendor_contacts, site_contacts,
+    |     parts, offers, material_cards (material hub), sightings.
+    +---> Part number: matches Requirement / Offer / MaterialCard / Sighting by ILIKE
+    |     AND by exact normalized_mpn == normalize_mpn_key(query) (separator-insensitive,
+    |     index-backed), so a PN returns every req/offer/card/sighting it appears on.
+    +---> Vendor: VendorCard surfaced by its own name/email/phone OR via a matching
+    |     VendorContact (vendor_card_id subquery) OR a matching Offer.vendor_name — so a
+    |     contact name / stocked MPN leads back to the card. Its contacts, offers, and
+    |     sightings surface in their own groups.
+    +---> Sightings carry their parent requisition_id (Sighting→Requirement join) for nav;
+    |     material cards link to the Part Dossier (/v2/search?mpn=...).
+    +---> Read-gating: for RESTRICTED_ROLES (SALES/TRADER) the requisition-scoped groups
+    |     (requisitions, parts, offers, sightings) are limited to requisitions the user
+    |     owns (created_by); requisition-less offers are hidden from them. Companies /
+    |     vendors / contacts / material cards follow the app-wide all-visible read policy.
+    |     user=None (legacy/test callers) ⇒ unrestricted. _run_intent_query (AI path)
+    |     applies the same gate; ai_search caches only for unrestricted users.
+    +---> Reuses: SearchBuilder (escape_like ILIKE + pg_trgm similarity order),
+          normalize_mpn_key, MaterialCard.deleted_at soft-delete filter.
+```
+
 ---
 
 ## Scoring System Hierarchy

--- a/tests/test_global_search_service.py
+++ b/tests/test_global_search_service.py
@@ -7,10 +7,23 @@ Depends on: app.services.global_search_service, test fixtures from conftest.py
 import pytest
 
 from app.models.crm import Company, CustomerSite, SiteContact
+from app.models.intelligence import MaterialCard
 from app.models.offers import Offer
-from app.models.sourcing import Requirement, Requisition
+from app.models.sourcing import Requirement, Requisition, Sighting
 from app.models.vendors import VendorCard, VendorContact
 from app.services.global_search_service import fast_search
+
+EXPECTED_GROUPS = {
+    "requisitions",
+    "companies",
+    "vendors",
+    "vendor_contacts",
+    "site_contacts",
+    "parts",
+    "offers",
+    "material_cards",
+    "sightings",
+}
 
 
 @pytest.fixture
@@ -54,9 +67,20 @@ def search_db(db_session, test_user):
     sc = SiteContact(customer_site_id=site.id, full_name="Jane Doe", email="jane@acme.com")
     db_session.add(sc)
 
+    # Material card (material hub) — keyed on normalized MPN
+    mc = MaterialCard(
+        normalized_mpn="lm358n",
+        display_mpn="LM358N",
+        manufacturer="Texas Instruments",
+        description="Dual operational amplifier",
+    )
+    db_session.add(mc)
+    db_session.flush()
+
     # Requirement (part)
     part = Requirement(
         requisition_id=req.id,
+        material_card_id=mc.id,
         primary_mpn="LM358N",
         normalized_mpn="lm358n",
         brand="Texas Instruments",
@@ -68,12 +92,28 @@ def search_db(db_session, test_user):
     offer = Offer(
         requisition_id=req.id,
         requirement_id=part.id,
+        vendor_card_id=vendor.id,
         vendor_name="Arrow",
         mpn="LM358N",
+        normalized_mpn="lm358n",
         qty_available=1000,
         unit_price=0.50,
     )
     db_session.add(offer)
+
+    # Sighting — vendor seen offering the part on the requirement
+    sighting = Sighting(
+        requirement_id=part.id,
+        material_card_id=mc.id,
+        vendor_name="Arrow Electronics",
+        vendor_name_normalized="arrow electronics",
+        mpn_matched="LM358N",
+        normalized_mpn="lm358n",
+        manufacturer="Texas Instruments",
+        qty_available=500,
+        unit_price=0.45,
+    )
+    db_session.add(sighting)
 
     db_session.commit()
     return db_session
@@ -84,15 +124,7 @@ def test_fast_search_returns_structure(search_db):
     assert "best_match" in result
     assert "groups" in result
     assert "total_count" in result
-    assert set(result["groups"].keys()) == {
-        "requisitions",
-        "companies",
-        "vendors",
-        "vendor_contacts",
-        "site_contacts",
-        "parts",
-        "offers",
-    }
+    assert set(result["groups"].keys()) == EXPECTED_GROUPS
 
 
 def test_fast_search_finds_requisition_by_name(search_db):
@@ -143,3 +175,124 @@ def test_fast_search_special_chars_safe(search_db, query):
     """SQL injection / wildcard chars don't cause errors (no match, but no error)."""
     result = fast_search(query, search_db)
     assert result["total_count"] == 0
+
+
+# ── Universal cross-entity attachment ─────────────────────────────────
+
+
+def test_part_number_returns_requirement_offer_and_material_card(search_db):
+    """A part number surfaces every entity it is attached to: the requirement,
+    the offer, and the material-hub card."""
+    result = fast_search("LM358N", search_db)
+    groups = result["groups"]
+    assert any(p["primary_mpn"] == "LM358N" for p in groups["parts"]), "part missing"
+    assert any(o["mpn"] == "LM358N" for o in groups["offers"]), "offer missing"
+    assert any(m["display_mpn"] == "LM358N" for m in groups["material_cards"]), "material card missing"
+
+
+def test_part_number_returns_its_sightings(search_db):
+    """A part number surfaces the sightings it appears on."""
+    result = fast_search("LM358N", search_db)
+    assert any(s["mpn_matched"] == "LM358N" for s in result["groups"]["sightings"]), "sighting missing"
+
+
+def test_material_card_matched_by_manufacturer(search_db):
+    """Material cards are searchable by manufacturer, not just MPN."""
+    result = fast_search("Texas Instruments", search_db)
+    assert any(m["display_mpn"] == "LM358N" for m in result["groups"]["material_cards"])
+
+
+def test_normalized_mpn_match_ignores_separators(search_db):
+    """Typing the MPN with stray separators still hits the normalized key."""
+    result = fast_search("lm-358-n", search_db)
+    assert any(m["display_mpn"] == "LM358N" for m in result["groups"]["material_cards"])
+    assert any(p["primary_mpn"] == "LM358N" for p in result["groups"]["parts"])
+
+
+def test_vendor_returns_its_contacts_offers_and_sightings(search_db):
+    """Searching a vendor surfaces the vendor card, its contacts, offers, and
+    sightings."""
+    result = fast_search("Arrow", search_db)
+    groups = result["groups"]
+    assert any(v["display_name"] == "Arrow Electronics" for v in groups["vendors"]), "vendor missing"
+    assert any(c["full_name"] == "John Smith" for c in groups["vendor_contacts"]), "contact missing"
+    assert any(o["vendor_name"] == "Arrow" for o in groups["offers"]), "offer missing"
+    assert any("Arrow" in (s["vendor_name"] or "") for s in groups["sightings"]), "sighting missing"
+
+
+def test_vendor_surfaced_via_contact_name(search_db):
+    """Typing a vendor contact's name surfaces the parent vendor card too."""
+    result = fast_search("John Smith", search_db)
+    assert any(v["display_name"] == "Arrow Electronics" for v in result["groups"]["vendors"]), (
+        "vendor not surfaced via its contact"
+    )
+
+
+# ── Read-gating / authz scoping ───────────────────────────────────────
+
+
+def test_restricted_role_does_not_see_others_requisition(search_db, sales_user):
+    """A SALES user sees no requisition/part/offer/sighting they don't own."""
+    result = fast_search("LM358", search_db, user=sales_user)
+    groups = result["groups"]
+    assert groups["requisitions"] == [], "restricted user saw foreign requisition"
+    assert groups["parts"] == [], "restricted user saw foreign part"
+    assert groups["offers"] == [], "restricted user saw foreign offer"
+    assert groups["sightings"] == [], "restricted user saw foreign sighting"
+
+
+def test_restricted_role_sees_own_requisition(search_db, db_session, sales_user):
+    """A SALES user still sees requisitions they own."""
+    own = Requisition(name="OWN-LM358", customer_name="MyCust", created_by=sales_user.id)
+    db_session.add(own)
+    db_session.commit()
+    result = fast_search("LM358", search_db, user=sales_user)
+    assert any(r["name"] == "OWN-LM358" for r in result["groups"]["requisitions"])
+
+
+def test_unrestricted_role_sees_all_requisitions(search_db, test_user):
+    """A BUYER (unrestricted) sees requisitions regardless of owner."""
+    result = fast_search("LM358", search_db, user=test_user)
+    assert any("LM358" in r["name"] for r in result["groups"]["requisitions"])
+
+
+def test_restricted_role_still_sees_shared_reference_data(search_db, sales_user):
+    """Vendors / material cards are shared reference data — visible to all roles."""
+    result = fast_search("Arrow", search_db, user=sales_user)
+    assert any(v["display_name"] == "Arrow Electronics" for v in result["groups"]["vendors"])
+
+
+def test_restricted_role_does_not_surface_vendor_via_foreign_offer(db_session, test_user, sales_user):
+    """A vendor whose ONLY match is an offer on a requisition the user can't see must
+    not surface — that would leak the existence of a req-scoped offer."""
+    # Foreign requisition owned by a DIFFERENT user (the buyer), not the sales user.
+    foreign_req = Requisition(name="FOREIGN", customer_name="X", created_by=test_user.id)
+    db_session.add(foreign_req)
+    db_session.flush()
+    part = Requirement(requisition_id=foreign_req.id, primary_mpn="SECRET99", normalized_mpn="secret99")
+    db_session.add(part)
+    db_session.flush()
+    # Vendor whose name does NOT match the query — only its offer does.
+    vendor = VendorCard(display_name="QuietVendor", normalized_name="quietvendor")
+    db_session.add(vendor)
+    db_session.flush()
+    db_session.add(
+        Offer(
+            requisition_id=foreign_req.id,
+            requirement_id=part.id,
+            vendor_card_id=vendor.id,
+            vendor_name="QuietVendor",
+            mpn="SECRET99",
+            normalized_mpn="secret99",
+        )
+    )
+    db_session.commit()
+
+    result = fast_search("SECRET99", db_session, user=sales_user)
+    assert result["groups"]["offers"] == [], "restricted user saw the foreign offer"
+    assert all(v["display_name"] != "QuietVendor" for v in result["groups"]["vendors"]), (
+        "restricted user inferred a foreign offer via the vendor group"
+    )
+    # An unrestricted buyer-less call (user=None) DOES surface it (no restriction).
+    open_result = fast_search("SECRET99", db_session, user=None)
+    assert any(v["display_name"] == "QuietVendor" for v in open_result["groups"]["vendors"])

--- a/tests/test_htmx_views.py
+++ b/tests/test_htmx_views.py
@@ -320,6 +320,43 @@ class TestGlobalSearch:
         resp = client.get("/v2/partials/search/results?q=test")
         assert resp.status_code == 200
 
+    def test_global_search_renders_material_and_sighting_groups(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """A part-number query renders the new Material Hub + Sightings groups end-to-
+        end."""
+        from app.models.intelligence import MaterialCard
+        from app.models.sourcing import Requirement, Requisition, Sighting
+
+        req = Requisition(name="REQ-UNI", customer_name="Acme", created_by=test_user.id)
+        db_session.add(req)
+        db_session.flush()
+        mc = MaterialCard(normalized_mpn="uni999", display_mpn="UNI-999", manufacturer="ACME Semi")
+        db_session.add(mc)
+        db_session.flush()
+        part = Requirement(
+            requisition_id=req.id, material_card_id=mc.id, primary_mpn="UNI-999", normalized_mpn="uni999"
+        )
+        db_session.add(part)
+        db_session.flush()
+        db_session.add(
+            Sighting(
+                requirement_id=part.id,
+                vendor_name="Distro Inc",
+                vendor_name_normalized="distro inc",
+                mpn_matched="UNI-999",
+                normalized_mpn="uni999",
+            )
+        )
+        db_session.commit()
+
+        resp = client.get("/v2/partials/search/global?q=UNI-999")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Material Hub" in body
+        assert "Sightings" in body
+        assert "UNI-999" in body
+
 
 # ══════════════════════════════════════════════════════════════════════════
 # Parts Workspace


### PR DESCRIPTION
Rebuilds the global top-search. **Was broken:** wired but limited — no read-gating (SALES/TRADER saw every requisition/part/offer — an IDOR leak), no cross-entity attachment, Material-Hub + Sightings groups missing, normalize_mpn_key never applied, vendor never surfaced via its contacts/MPNs. **Now:** 9 grouped result types (Requisitions, Companies, Vendors [+via contact/offer], Vendor+Site Contacts, Parts/Requirements, Offers, Material-Hub cards, Sightings) with cross-entity attachment (a part → every req/offer/material-card/sighting; a vendor → its card+contacts+offers+sightings), normalized-MPN exact+ILIKE matching, and **RESTRICTED_ROLES read-gating** (req-scoped groups + offer-based vendor match scoped to the user's own requisitions; shared reference data stays visible, mirroring app-wide policy; AI/cache path gated too). Service rewrite (fat service, thin routes). New cross-entity + normalized-MPN + authz/leak regression tests + e2e route render; 286 targeted green, pre-commit clean; APP_MAP updated.