### PR TITLE
feat(buy-plans): card naming (BP/SO/PO) + denser kanban tiles + flagged-issue reason

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -89,6 +89,7 @@ from ..models.vendors import VendorContact
 from ..scoring import classify_lead, explain_lead, score_unified
 from ..services import clay_oauth, task_service
 from ..services.activity_service import log_activity as _log_activity
+from ..services.buyplan_naming import summarize_top_flag
 from ..services.commodity_registry import COMMODITY_TREE, get_display_name
 from ..services.faceted_search_service import (
     INTERNAL_FILTER_VALUES,
@@ -11118,8 +11119,6 @@ async def buy_plan_detail_partial(
         ],
     )
 
-    from ..services.buyplan_naming import summarize_top_flag
-
     ctx = _base_ctx(request, user, "buy-plans")
     ctx.update(
         {
@@ -13466,8 +13465,6 @@ async def build_buy_plan_htmx(
     ctx["lines"] = bp_lines
     ctx["user"] = user
     ctx["is_ops_member"] = _is_ops_member(user, db)
-    from ..services.buyplan_naming import summarize_top_flag
-
     ctx["top_flag"] = summarize_top_flag(plan.ai_flags)
     return template_response("htmx/partials/buy_plans/detail.html", ctx)
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -11118,6 +11118,8 @@ async def buy_plan_detail_partial(
         ],
     )
 
+    from ..services.buyplan_naming import summarize_top_flag
+
     ctx = _base_ctx(request, user, "buy-plans")
     ctx.update(
         {
@@ -11125,6 +11127,8 @@ async def buy_plan_detail_partial(
             "lines": bp.lines or [],
             "is_ops_member": _is_ops_member(user, db),
             "user": user,
+            # Most-urgent flag reason so the indicator states the issue at first glance.
+            "top_flag": summarize_top_flag(bp.ai_flags),
         }
     )
     return template_response("htmx/partials/buy_plans/detail.html", ctx)
@@ -13462,6 +13466,9 @@ async def build_buy_plan_htmx(
     ctx["lines"] = bp_lines
     ctx["user"] = user
     ctx["is_ops_member"] = _is_ops_member(user, db)
+    from ..services.buyplan_naming import summarize_top_flag
+
+    ctx["top_flag"] = summarize_top_flag(plan.ai_flags)
     return template_response("htmx/partials/buy_plans/detail.html", ctx)
 
 

--- a/app/services/buyplan_hub.py
+++ b/app/services/buyplan_hub.py
@@ -20,6 +20,8 @@ from sqlalchemy.orm import Session, joinedload
 from ..config import settings
 from ..constants import BuyPlanLineStatus, BuyPlanStatus, SOVerificationStatus
 from ..models.buy_plan import BuyPlan, BuyPlanLine
+from ..models.crm import CustomerSite
+from ..models.quotes import Quote
 from .buyplan_naming import (
     CARD_KIND_BUY_PLAN,
     CARD_KIND_PO,
@@ -100,7 +102,10 @@ def buyer_line_queue(db: Session, user: object) -> list[dict]:
             BuyPlan.status == BuyPlanStatus.ACTIVE,
         )
         .options(
-            joinedload(BuyPlanLine.buy_plan).joinedload(BuyPlan.quote),
+            joinedload(BuyPlanLine.buy_plan)
+            .joinedload(BuyPlan.quote)
+            .joinedload(Quote.customer_site)
+            .joinedload(CustomerSite.company),
             joinedload(BuyPlanLine.requirement),
             joinedload(BuyPlanLine.offer),
         )
@@ -169,7 +174,10 @@ def team_line_queue(db: Session, user: object) -> list[dict]:
             BuyPlanLine.buyer_id != user.id,
         )
         .options(
-            joinedload(BuyPlanLine.buy_plan).joinedload(BuyPlan.quote),
+            joinedload(BuyPlanLine.buy_plan)
+            .joinedload(BuyPlan.quote)
+            .joinedload(Quote.customer_site)
+            .joinedload(CustomerSite.company),
             joinedload(BuyPlanLine.requirement),
             joinedload(BuyPlanLine.offer),
             joinedload(BuyPlanLine.buyer),
@@ -398,8 +406,8 @@ def deals_board(db: Session, user: object, *, scope: str) -> dict[str, list[dict
             )
         )
         .options(
-            # Eager-load quote + lines; customer_site/company lazy-loaded within session
-            joinedload(BuyPlan.quote),
+            # Eager-load quote → customer_site → company (eliminates N+1 per card)
+            joinedload(BuyPlan.quote).joinedload(Quote.customer_site).joinedload(CustomerSite.company),
             joinedload(BuyPlan.submitted_by),
             # lines + their requirement feed _primary_mpn / _our_po_numbers on the card
             joinedload(BuyPlan.lines).joinedload(BuyPlanLine.requirement),
@@ -469,7 +477,8 @@ def completed_archive(
 
     plans = (
         base.options(
-            joinedload(BuyPlan.quote),
+            # Eager-load quote → customer_site → company (eliminates N+1 per card)
+            joinedload(BuyPlan.quote).joinedload(Quote.customer_site).joinedload(CustomerSite.company),
             joinedload(BuyPlan.submitted_by),
             joinedload(BuyPlan.lines).joinedload(BuyPlanLine.requirement),
         )
@@ -560,7 +569,10 @@ def supervise_overview(db: Session) -> dict:
             BuyPlan.status == BuyPlanStatus.PENDING,
             BuyPlan.approved_by_id.is_(None),
         )
-        .options(joinedload(BuyPlan.quote), joinedload(BuyPlan.submitted_by))
+        .options(
+            joinedload(BuyPlan.quote).joinedload(Quote.customer_site).joinedload(CustomerSite.company),
+            joinedload(BuyPlan.submitted_by),
+        )
         .order_by(BuyPlan.created_at.asc())
         .all()
     )
@@ -572,7 +584,10 @@ def supervise_overview(db: Session) -> dict:
             BuyPlan.status == BuyPlanStatus.ACTIVE,
             BuyPlan.so_status == SOVerificationStatus.PENDING,
         )
-        .options(joinedload(BuyPlan.quote), joinedload(BuyPlan.submitted_by))
+        .options(
+            joinedload(BuyPlan.quote).joinedload(Quote.customer_site).joinedload(CustomerSite.company),
+            joinedload(BuyPlan.submitted_by),
+        )
         .order_by(BuyPlan.created_at.asc())
         .all()
     )
@@ -581,7 +596,10 @@ def supervise_overview(db: Session) -> dict:
     halted_plans = (
         db.query(BuyPlan)
         .filter(BuyPlan.status == BuyPlanStatus.HALTED)
-        .options(joinedload(BuyPlan.quote), joinedload(BuyPlan.submitted_by))
+        .options(
+            joinedload(BuyPlan.quote).joinedload(Quote.customer_site).joinedload(CustomerSite.company),
+            joinedload(BuyPlan.submitted_by),
+        )
         .order_by(BuyPlan.created_at.asc())
         .all()
     )
@@ -601,7 +619,10 @@ def supervise_overview(db: Session) -> dict:
             func.coalesce(BuyPlanLine.last_nudge_at, BuyPlan.approved_at) < nudge_threshold,
         )
         .options(
-            joinedload(BuyPlanLine.buy_plan).joinedload(BuyPlan.quote),
+            joinedload(BuyPlanLine.buy_plan)
+            .joinedload(BuyPlan.quote)
+            .joinedload(Quote.customer_site)
+            .joinedload(CustomerSite.company),
             joinedload(BuyPlanLine.offer),
             joinedload(BuyPlanLine.buyer),
         )
@@ -614,7 +635,10 @@ def supervise_overview(db: Session) -> dict:
         db.query(BuyPlanLine)
         .filter(BuyPlanLine.status == BuyPlanLineStatus.PENDING_VERIFY)
         .options(
-            joinedload(BuyPlanLine.buy_plan).joinedload(BuyPlan.quote),
+            joinedload(BuyPlanLine.buy_plan)
+            .joinedload(BuyPlan.quote)
+            .joinedload(Quote.customer_site)
+            .joinedload(CustomerSite.company),
             joinedload(BuyPlanLine.offer),
             joinedload(BuyPlanLine.buyer),
         )
@@ -627,7 +651,10 @@ def supervise_overview(db: Session) -> dict:
         db.query(BuyPlanLine)
         .filter(BuyPlanLine.status == BuyPlanLineStatus.ISSUE)
         .options(
-            joinedload(BuyPlanLine.buy_plan).joinedload(BuyPlan.quote),
+            joinedload(BuyPlanLine.buy_plan)
+            .joinedload(BuyPlan.quote)
+            .joinedload(Quote.customer_site)
+            .joinedload(CustomerSite.company),
             joinedload(BuyPlanLine.offer),
             joinedload(BuyPlanLine.buyer),
         )

--- a/app/services/buyplan_hub.py
+++ b/app/services/buyplan_hub.py
@@ -20,6 +20,44 @@ from sqlalchemy.orm import Session, joinedload
 from ..config import settings
 from ..constants import BuyPlanLineStatus, BuyPlanStatus, SOVerificationStatus
 from ..models.buy_plan import BuyPlan, BuyPlanLine
+from .buyplan_naming import (
+    CARD_KIND_BUY_PLAN,
+    CARD_KIND_PO,
+    CARD_KIND_SALES_ORDER,
+    build_card_title,
+)
+
+
+def _user_name(user: object | None) -> str | None:
+    """Display name for a User (``name`` preferred, ``email`` fallback), or ``None``.
+
+    The single owner-name derivation reused by every Deal Hub read model so the
+    Account Manager (``submitted_by``) and the Buyer (``line.buyer``) format
+    identically wherever they appear in a card title.
+    """
+    if user is None:
+        return None
+    name: str | None = getattr(user, "name", None) or getattr(user, "email", None)
+    return name
+
+
+def _issue_reason(line: BuyPlanLine) -> str:
+    """Human-readable reason a buyer flagged this line, for at-a-glance triage.
+
+    Buyers raise a line issue via ``buyplan_workflow.flag_line_issue`` which records
+    an ``issue_type`` code (``sold_out`` / ``price_changed`` / ``lead_time_changed``
+    / ``other``) plus an optional free-text ``issue_note``. The note is the most
+    specific signal, so it wins; otherwise the type code is humanised
+    (``lead_time_changed`` → ``Lead time changed``). Falls back to ``"Issue"`` when
+    neither is set (legacy rows).
+    """
+    note = (line.issue_note or "").strip()
+    if note:
+        return note
+    code = (line.issue_type or "").strip()
+    if code:
+        return code.replace("_", " ").capitalize()
+    return "Issue"
 
 
 def _customer_name(plan: BuyPlan) -> str | None:
@@ -244,12 +282,52 @@ def _compute_blocker(plan: BuyPlan) -> str:
     return ""
 
 
+def _primary_mpn(plan: BuyPlan) -> str | None:
+    """The plan's headline part number for at-a-glance scanning.
+
+    Returns the first non-cancelled line's requirement MPN (lines are id-ordered),
+    i.e. the part the deal leads with. ``None`` when no line carries a requirement
+    MPN (e.g. a fresh plan with unlinked lines).
+    """
+    for ln in plan.lines:
+        if ln.status == BuyPlanLineStatus.CANCELLED:
+            continue
+        req = ln.requirement
+        if req and req.primary_mpn:
+            return req.primary_mpn
+    return None
+
+
+def _our_po_numbers(plan: BuyPlan) -> list[str]:
+    """Distinct purchase-order numbers we've cut on this plan's lines, in line order.
+
+    These are *our* POs to vendors (``BuyPlanLine.po_number``) — distinct from
+    ``BuyPlan.customer_po_number`` (the customer's PO to us). Cancelled lines are
+    skipped. Order is preserved (id-ordered lines) and duplicates collapse, so a
+    reviewer sees exactly which POs the deal involves.
+    """
+    seen: list[str] = []
+    for ln in plan.lines:
+        if ln.status == BuyPlanLineStatus.CANCELLED:
+            continue
+        po = (ln.po_number or "").strip()
+        if po and po not in seen:
+            seen.append(po)
+    return seen
+
+
 def _deal_card(plan: BuyPlan, user: object) -> dict:
     """Build the shared deal-card read dict for one plan.
 
     Used by both the active board (``deals_board``) and the completed archive
     (``completed_archive``) so a card looks identical wherever it renders. The
     ``completed_at`` field is meaningful only for archived (COMPLETED) plans.
+
+    ``card_title`` is the canonical ``{SO#} - {Customer} - {Owner} - BP`` title
+    (Owner = the Account Manager / sales owner) built by the shared
+    :func:`buyplan_naming.build_card_title` helper. ``tso``, ``po_numbers`` and
+    ``primary_mpn`` give the denser tile the sales-order #, the POs involved and
+    the headline part without opening the deal.
     """
     # po_progress: (verified_count, total_non_cancelled_count)
     active_lines = [ln for ln in plan.lines if ln.status != BuyPlanLineStatus.CANCELLED]
@@ -258,9 +336,23 @@ def _deal_card(plan: BuyPlan, user: object) -> dict:
     # needs_my_action: sales owner must act when plan is DRAFT
     needs_my_action = plan.status == BuyPlanStatus.DRAFT and plan.submitted_by_id == user.id
 
+    customer_name = _customer_name(plan)
+    # Owner on a Buy-Plan card is the Account Manager (sales owner = submitted_by).
+    owner_name = _user_name(plan.submitted_by)
+
     return {
         "plan_id": plan.id,
-        "customer_name": _customer_name(plan),
+        "card_title": build_card_title(
+            sales_order_number=plan.sales_order_number,
+            customer_name=customer_name,
+            owner_name=owner_name,
+            kind=CARD_KIND_BUY_PLAN,
+        ),
+        "customer_name": customer_name,
+        "owner_name": owner_name,
+        "tso": plan.sales_order_number,
+        "po_numbers": _our_po_numbers(plan),
+        "primary_mpn": _primary_mpn(plan),
         "value": plan.total_cost,
         "margin_pct": plan.total_margin_pct,
         "stage_label": _STAGE_LABELS.get(plan.status, plan.status),
@@ -308,7 +400,9 @@ def deals_board(db: Session, user: object, *, scope: str) -> dict[str, list[dict
         .options(
             # Eager-load quote + lines; customer_site/company lazy-loaded within session
             joinedload(BuyPlan.quote),
-            joinedload(BuyPlan.lines),
+            joinedload(BuyPlan.submitted_by),
+            # lines + their requirement feed _primary_mpn / _our_po_numbers on the card
+            joinedload(BuyPlan.lines).joinedload(BuyPlanLine.requirement),
         )
         .order_by(BuyPlan.created_at.desc())
     )
@@ -374,7 +468,11 @@ def completed_archive(
     total = base.with_entities(func.count(BuyPlan.id)).scalar() or 0
 
     plans = (
-        base.options(joinedload(BuyPlan.quote), joinedload(BuyPlan.lines))
+        base.options(
+            joinedload(BuyPlan.quote),
+            joinedload(BuyPlan.submitted_by),
+            joinedload(BuyPlan.lines).joinedload(BuyPlanLine.requirement),
+        )
         .order_by(BuyPlan.completed_at.desc().nullslast(), BuyPlan.created_at.desc())
         .limit(limit)
         .offset(offset)
@@ -538,32 +636,53 @@ def supervise_overview(db: Session) -> dict:
     )
 
     # ── Helpers ──────────────────────────────────────────────────────
-    def _submitted_by_name(plan: BuyPlan) -> str | None:
-        sub = plan.submitted_by
-        if sub:
-            return sub.name or sub.email
-        return None
+    def _plan_dict(plan: BuyPlan, *, kind: str | None = None) -> dict:
+        """Plan triage row.
 
-    def _plan_dict(plan: BuyPlan) -> dict:
-        return {
+        With ``kind`` set (e.g. "SO"), include the canonical
+        ``{SO#} - {Customer} - {Owner} - {kind}`` title; Owner is the Account Manager.
+        """
+        customer_name = _customer_name(plan)
+        owner_name = _user_name(plan.submitted_by)
+        row = {
             "plan_id": plan.id,
-            "customer_name": _customer_name(plan),
+            "customer_name": customer_name,
             "value": plan.total_cost,
-            "submitted_by_name": _submitted_by_name(plan),
+            "submitted_by_name": owner_name,
         }
+        if kind is not None:
+            row["card_title"] = build_card_title(
+                sales_order_number=plan.sales_order_number,
+                customer_name=customer_name,
+                owner_name=owner_name,
+                kind=kind,
+            )
+        return row
 
-    def _line_dict(ln: BuyPlanLine, *, include_issue_type: bool = False) -> dict:
+    def _line_dict(ln: BuyPlanLine, *, include_issue_type: bool = False, kind: str | None = None) -> dict:
         offer = ln.offer
         buyer = ln.buyer
+        plan = ln.buy_plan
         row = {
             "line_id": ln.id,
             "plan_id": ln.buy_plan_id,
             "mpn": offer.mpn if offer else None,
             "vendor_name": offer.vendor_name if offer else None,
-            "buyer_name": (buyer.name or buyer.email) if buyer else None,
+            "buyer_name": _user_name(buyer),
         }
         if include_issue_type:
+            # Human-readable issue reason: the buyer's free-text note when present,
+            # else the issue-type label (underscores → spaces). Falls back to "issue".
             row["issue_type"] = ln.issue_type
+            row["issue_reason"] = _issue_reason(ln)
+        if kind is not None:
+            # PO approval row: Owner is the Buyer (per-line procurement owner).
+            row["card_title"] = build_card_title(
+                sales_order_number=plan.sales_order_number if plan else None,
+                customer_name=_customer_name(plan) if plan else None,
+                owner_name=_user_name(buyer),
+                kind=kind,
+            )
         return row
 
     return {
@@ -579,10 +698,12 @@ def supervise_overview(db: Session) -> dict:
         },
         "triage": {
             "approvals": [_plan_dict(p) for p in approval_plans],
-            "so_pending": [_plan_dict(p) for p in so_pending_plans],
+            # SO-approval rows carry the "{SO#} - {Customer} - {AcctMgr} - SO" title.
+            "so_pending": [_plan_dict(p, kind=CARD_KIND_SALES_ORDER) for p in so_pending_plans],
             "halted": [_plan_dict(p) for p in halted_plans],
             "overdue_pos": [_line_dict(ln) for ln in overdue_lines],
-            "po_pending_verify": [_line_dict(ln) for ln in po_pending_verify_lines],
+            # PO-approval rows carry the "{SO#} - {Customer} - {Buyer} - PO" title.
+            "po_pending_verify": [_line_dict(ln, kind=CARD_KIND_PO) for ln in po_pending_verify_lines],
             "flagged": [_line_dict(ln, include_issue_type=True) for ln in flagged_lines],
         },
     }

--- a/app/services/buyplan_naming.py
+++ b/app/services/buyplan_naming.py
@@ -1,0 +1,105 @@
+"""buyplan_naming.py — Single shared title helper for Buy-Plan deal cards / triage rows.
+
+Purpose: Derive the canonical card/row title used everywhere a buy plan surfaces as an
+         actionable tile in the Deal Hub, so the deal board, the SO-approval triage and
+         the PO-approval triage all read identically:
+
+             {SalesOrder#} - {Customer} - {Owner} - {Type}
+
+         Type suffix and Owner source differ per surface:
+           - Deal (Buy Plan) card      → suffix "BP", Owner = Account Manager (sales owner)
+           - Sales-Order approval row  → suffix "SO", Owner = Account Manager (sales owner)
+           - PO approval row           → suffix "PO", Owner = the Buyer
+
+         Field sources on the model (see app/models/buy_plan.py):
+           - SalesOrder#       BuyPlan.sales_order_number
+           - Customer          quote → customer_site → company.name (buyplan_hub._customer_name)
+           - Account Manager   BuyPlan.submitted_by (sales owner who submitted the plan)
+           - Buyer             BuyPlanLine.buyer (per-line procurement owner)
+
+         Missing values collapse to an em dash so the title never renders ragged
+         (e.g. a fresh DRAFT with no SO# yet → "— - Acme - Jordan - BP").
+
+Called by: app/services/buyplan_hub.py (deal-card + supervise triage read models).
+Depends on: nothing (pure string assembly — callers pass already-derived display values).
+"""
+
+from __future__ import annotations
+
+#: Display placeholder for any absent title field (matches the template em-dash fallback).
+_MISSING = "—"
+
+#: The three deal-hub surfaces and their title suffix. Kept here so a card type can never
+#: drift from its suffix in one template while the others stay correct.
+CARD_KIND_BUY_PLAN = "BP"
+CARD_KIND_SALES_ORDER = "SO"
+CARD_KIND_PO = "PO"
+
+_VALID_KINDS = frozenset({CARD_KIND_BUY_PLAN, CARD_KIND_SALES_ORDER, CARD_KIND_PO})
+
+
+def build_card_title(
+    *,
+    sales_order_number: str | None,
+    customer_name: str | None,
+    owner_name: str | None,
+    kind: str,
+) -> str:
+    """Return the canonical ``{SO#} - {Customer} - {Owner} - {Type}`` card title.
+
+    Parameters
+    ----------
+    sales_order_number:
+        ``BuyPlan.sales_order_number`` (the TSO). ``None``/blank → em dash.
+    customer_name:
+        The derived customer display name (``buyplan_hub._customer_name``).
+        ``None``/blank → em dash.
+    owner_name:
+        The owner display name for this surface — the Account Manager
+        (``BuyPlan.submitted_by``) for BP/SO cards, or the Buyer
+        (``BuyPlanLine.buyer``) for PO cards. ``None``/blank → em dash.
+    kind:
+        One of ``"BP"`` / ``"SO"`` / ``"PO"`` (use the ``CARD_KIND_*`` constants).
+        The suffix is appended verbatim so every surface ends in its type tag.
+
+    Raises
+    ------
+    ValueError
+        If ``kind`` is not one of the three known card types — surfacing a wiring
+        mistake loudly rather than rendering an untyped title.
+    """
+    if kind not in _VALID_KINDS:
+        raise ValueError(f"Unknown card kind {kind!r}. Valid: {sorted(_VALID_KINDS)}")
+
+    so = (sales_order_number or "").strip() or _MISSING
+    customer = (customer_name or "").strip() or _MISSING
+    owner = (owner_name or "").strip() or _MISSING
+    return f"{so} - {customer} - {owner} - {kind}"
+
+
+#: AI-flag severities worst → least, so the flagged-issue indicator leads with the most
+#: urgent reason. Unknown/absent severities sort last (treated as least urgent).
+_SEVERITY_RANK: dict[str, int] = {"critical": 0, "warning": 1, "info": 2}
+
+
+def summarize_top_flag(ai_flags: list[dict] | None) -> dict | None:
+    """Return the single most-urgent AI flag so an indicator can state what's wrong.
+
+    The flagged-issue indicator on a buy plan must say the *actual* problem at first
+    glance, not just a count. ``ai_flags`` is the ``BuyPlan.ai_flags`` JSON list of
+    ``{type, severity, line_id, message}`` dicts produced by
+    ``buyplan_builder.generate_ai_flags`` (e.g. ``"Margin 8.50% below 15% threshold"``,
+    ``"No buyer assigned for line (reason: unknown)"``).
+
+    Returns the worst flag (critical → warning → info; original order breaks ties)
+    as ``{"severity", "message"}``, or ``None`` when there are no flags. The
+    ``message`` is the verbatim reason text the flag system recorded.
+    """
+    if not ai_flags:
+        return None
+    # min() with a stable key keeps the first flag of the worst severity (ties unchanged).
+    worst = min(ai_flags, key=lambda f: _SEVERITY_RANK.get((f or {}).get("severity"), 99))
+    return {
+        "severity": worst.get("severity"),
+        "message": worst.get("message") or "",
+    }

--- a/app/templates/htmx/partials/buy_plans/_board.html
+++ b/app/templates/htmx/partials/buy_plans/_board.html
@@ -37,10 +37,12 @@
       <span class="text-xs font-semibold text-gray-600 uppercase tracking-wider">{{ label }}</span>
       <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 rounded-full bg-gray-200 text-gray-600 text-xs font-medium">{{ board[key]|length }}</span>
     </div>
-    <div class="p-2 space-y-2 flex-1">
+    <div class="p-2 space-y-1.5 flex-1">
       {% for d in cards %}
       {% set m = d.margin_pct|float if d.margin_pct is not none else 0 %}
       {# Finding #9: keyboard navigation — real focusable element with accent focus ring and role=link #}
+      {# Denser tile: canonical "{SO#} - {Customer} - {Owner} - BP" title, then a tight
+         line of deal facts (TSO / POs / part) so a reviewer reads the deal without opening it. #}
       <div hx-get="/v2/partials/buy-plans/{{ d.plan_id }}"
            hx-target="#main-content"
            hx-push-url="/v2/buy-plans/{{ d.plan_id }}"
@@ -49,31 +51,43 @@
            role="link"
            @keydown.enter.prevent="$el.click()"
            @keydown.space.prevent="$el.click()"
-           class="bg-white rounded-md border border-line-base p-3 cursor-pointer hover:shadow-sm transition-shadow
+           class="bg-white rounded-md border border-line-base px-2.5 py-2 cursor-pointer hover:shadow-sm transition-shadow
                   focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:outline-none
                   {% if d.needs_my_action %}ring-2 ring-amber-400{% endif %}">
-        {# Customer + stock badge #}
+        {# Canonical card title + stock badge #}
         <div class="flex items-start justify-between gap-2">
-          <span class="text-sm font-bold text-gray-900 leading-tight">{{ d.customer_name or '-' }}</span>
+          <span class="text-sm font-bold text-gray-900 leading-tight truncate" title="{{ d.card_title }}">{{ d.card_title }}</span>
           {% if d.is_stock_sale %}
           {# Finding #7: bespoke stock tag → .chip primitive #}
           <span class="chip bg-purple-50 text-purple-700 border-purple-200 flex-shrink-0">stock</span>
           {% endif %}
         </div>
-        {# Value + margin #}
-        <div class="mt-1.5 flex items-center justify-between gap-2">
+        {# Value + margin (primary money row) #}
+        <div class="mt-1 flex items-center justify-between gap-2">
           <span class="text-sm font-semibold text-gray-900">${{ '{:,.2f}'.format(d.value|float) if d.value else '0.00' }}</span>
           <span class="{% if m >= 30 %}badge-success{% elif m >= 15 %}badge-warning{% else %}badge-danger{% endif %}">
             {{ '{:.1f}'.format(m) }}%
           </span>
         </div>
+        {# Deal-fact line: SO# / our PO(s) / primary part — denser signal, no wasted rows #}
+        <div class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-600">
+          <span title="Sales order #">SO <span class="font-mono text-gray-700">{{ d.tso or '—' }}</span></span>
+          {% if d.primary_mpn %}
+          <span class="text-gray-300" aria-hidden="true">·</span>
+          <span class="font-mono text-gray-700 truncate max-w-[10rem]" title="Primary part {{ d.primary_mpn }}">{{ d.primary_mpn }}</span>
+          {% endif %}
+          {% if d.po_numbers %}
+          <span class="text-gray-300" aria-hidden="true">·</span>
+          <span title="PO(s): {{ d.po_numbers|join(', ') }}">PO <span class="font-mono text-gray-700">{{ d.po_numbers|join(', ') }}</span></span>
+          {% endif %}
+        </div>
         {# Blocker #}
         {% if d.blocker %}
-        <div class="mt-1.5 text-xs text-gray-600">{{ d.blocker }}</div>
+        <div class="mt-1 text-xs text-gray-600">{{ d.blocker }}</div>
         {% endif %}
         {# PO progress bar #}
         {% if d.po_progress[1] %}
-        <div class="mt-2">
+        <div class="mt-1.5">
           <div class="flex items-center justify-between text-[11px] text-gray-400 mb-0.5">
             <span>POs</span>
             <span>{{ d.po_progress[0] }}/{{ d.po_progress[1] }}</span>

--- a/app/templates/htmx/partials/buy_plans/_supervise.html
+++ b/app/templates/htmx/partials/buy_plans/_supervise.html
@@ -84,8 +84,7 @@
       {% for p in tri.so_pending %}
       <div class="flex items-center justify-between gap-3 px-4 py-2">
         <div class="min-w-0">
-          <span class="text-sm font-bold text-gray-900">{{ p.customer_name or '—' }}</span>
-          <span class="ml-2 text-xs text-gray-400">{{ p.submitted_by_name or '—' }}</span>
+          <span class="text-sm font-bold text-gray-900 truncate" title="{{ p.card_title }}">{{ p.card_title }}</span>
         </div>
         <div class="flex items-center gap-3 flex-shrink-0">
           <span class="text-sm font-semibold text-gray-700">${{ '{:,.2f}'.format(p.value|float) if p.value else '0.00' }}</span>
@@ -114,8 +113,8 @@
       {% for ln in tri.po_pending_verify %}
       <div class="flex items-center justify-between gap-3 px-4 py-2">
         <div class="min-w-0">
-          <span class="text-sm font-mono font-medium text-gray-900">{{ ln.mpn or '—' }}</span>
-          <span class="ml-2 text-xs text-gray-400">{{ ln.vendor_name or '—' }} · {{ ln.buyer_name or '—' }}</span>
+          <span class="text-sm font-bold text-gray-900 truncate" title="{{ ln.card_title }}">{{ ln.card_title }}</span>
+          <span class="ml-2 text-xs text-gray-400">{{ ln.mpn or '—' }} · {{ ln.vendor_name or '—' }}</span>
         </div>
         <form hx-post="/v2/partials/buy-plans/{{ ln.plan_id }}/lines/{{ ln.line_id }}/verify-po"
               hx-target="#bp-hub-body" hx-swap="innerHTML" class="flex items-center gap-1.5 flex-shrink-0">
@@ -173,8 +172,9 @@
          preload="mouseover"
          class="flex items-center justify-between gap-3 px-4 py-2 cursor-pointer hover:bg-rose-50/40
                 focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:outline-none focus-visible:bg-rose-50/40">
-        <span class="text-sm font-mono font-medium text-gray-900">{{ ln.mpn or '—' }}</span>
-        <span class="text-xs text-rose-600 flex-shrink-0">{{ ln.issue_type or 'issue' }}</span>
+        <span class="text-sm font-mono font-medium text-gray-900 flex-shrink-0">{{ ln.mpn or '—' }}</span>
+        {# Real flag reason at a glance — the buyer's note, else the humanised issue type. #}
+        <span class="text-xs text-rose-600 truncate text-right" title="{{ ln.issue_reason }}">{{ ln.issue_reason }}</span>
       </a>
       {% endfor %}
     </div>

--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -384,12 +384,19 @@
   {% set flag_count = bp.ai_flags|length if bp.ai_flags else 0 %}
   {% if bp.ai_summary or flag_count > 0 %}
   <div class="border-t border-gray-100">
-    <button @click="showAi = !showAi" class="w-full px-4 py-2 flex items-center justify-between text-left hover:bg-gray-50 transition-colors">
-      <div class="flex items-center gap-2">
-        <svg class="w-4 h-4 text-brand-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
-        <span class="text-sm font-semibold text-gray-700">AI Insights</span>
+    {% set top_flag = top_flag if top_flag is defined else None %}
+    <button @click="showAi = !showAi" class="w-full px-4 py-2 flex items-center justify-between gap-3 text-left hover:bg-gray-50 transition-colors">
+      <div class="flex items-center gap-2 min-w-0">
+        <svg class="w-4 h-4 flex-shrink-0 text-brand-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
+        <span class="text-sm font-semibold text-gray-700 flex-shrink-0">AI Insights</span>
         {% if flag_count > 0 %}
-        <span class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-amber-100 text-amber-700 text-xs font-bold">{{ flag_count }}</span>
+        <span class="inline-flex items-center justify-center w-5 h-5 flex-shrink-0 rounded-full bg-amber-100 text-amber-700 text-xs font-bold">{{ flag_count }}</span>
+        {% endif %}
+        {# State the actual top issue at first glance — the verbatim flag reason, not just a count. #}
+        {% if top_flag and top_flag.message %}
+        <span class="text-xs truncate
+                     {% if top_flag.severity == 'critical' %}text-rose-600{% elif top_flag.severity == 'warning' %}text-amber-700{% else %}text-gray-500{% endif %}"
+              title="{{ top_flag.message }}">{{ top_flag.message }}</span>
         {% endif %}
       </div>
       {{ collapse_chevron("showAi") }}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1298,6 +1298,21 @@ GET /v2/partials/buy-plans?lens=          (shell: switcher + lazy #bp-hub-body)
                              THIS body into #bp-hub-body.
 ```
 
+**Deal-card naming + denser tiles.** `services/buyplan_naming.build_card_title` is the
+single shared title helper — every actionable surface derives the identical
+`{SalesOrder#} - {Customer} - {Owner} - {Type}` title (missing fields → em dash):
+deal-board cards end `- BP` (Owner = the Account Manager / `BuyPlan.submitted_by`),
+SO-approval triage rows end `- SO` (Owner = the Account Manager), PO-approval
+(`po_pending_verify`) triage rows end `- PO` (Owner = the Buyer / `BuyPlanLine.buyer`).
+`_deal_card` also exposes `tso` (`sales_order_number`), `po_numbers` (distinct
+`BuyPlanLine.po_number`s — OUR vendor POs, not `customer_po_number`) and `primary_mpn`
+so the tile shows the deal at a glance without opening it. **Flagged-issue honesty:**
+`supervise_overview` flagged rows carry `issue_reason` (`buyplan_hub._issue_reason`:
+buyer's `issue_note` when set, else the humanised `issue_type`); the detail page's
+"AI Insights" indicator shows the worst flag's verbatim reason via
+`buyplan_naming.summarize_top_flag(bp.ai_flags)` (critical → warning → info) — both state
+WHAT is wrong, not just a count.
+
 **Resell workspace — resell/excess split-panel (Chunk F, ADDITIVE).** `/v2/resell` is
 its own primary-nav tab (9th item in `mobile_nav.html`) served by the `v2_page` shell →
 `GET /v2/partials/resell/workspace` (router `app/routers/resell.py`, mounted alongside the

--- a/tests/test_buyplan_hub_board.py
+++ b/tests/test_buyplan_hub_board.py
@@ -293,7 +293,12 @@ def test_deals_board_dict_fields(db_session, test_user, test_quote, test_requisi
 
     required_keys = {
         "plan_id",
+        "card_title",
         "customer_name",
+        "owner_name",
+        "tso",
+        "po_numbers",
+        "primary_mpn",
         "value",
         "margin_pct",
         "stage_label",
@@ -305,6 +310,62 @@ def test_deals_board_dict_fields(db_session, test_user, test_quote, test_requisi
     assert required_keys.issubset(deal.keys())
     assert deal["plan_id"] == plan.id
     assert deal["is_stock_sale"] is True
+
+
+# ── 10. Card title (BP) + denser-tile deal facts ─────────────────────
+
+
+def test_deals_board_card_title_is_buy_plan(db_session, test_user, test_quote, test_requisition):
+    """Buy-Plan card title = '{SO#} - {Customer} - {Owner} - BP'; Owner = Account Manager."""
+    from app.services.buyplan_hub import deals_board
+
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        submitted_by_id=test_user.id,
+    )
+    plan.sales_order_number = "TSO-9001"
+    db_session.flush()
+
+    board = deals_board(db_session, test_user, scope="all")
+    deal = next(d for d in board["active"] if d["plan_id"] == plan.id)
+
+    # Owner on a BP card is the sales owner (submitted_by), NOT a buyer.
+    owner = test_user.name or test_user.email
+    assert deal["card_title"].endswith(" - BP")
+    assert deal["card_title"].startswith("TSO-9001 - ")
+    assert owner in deal["card_title"]
+    assert deal["owner_name"] == owner
+    assert deal["tso"] == "TSO-9001"
+
+
+def test_deals_board_po_numbers_dedup_and_exclude_cancelled(db_session, test_user, test_quote, test_requisition):
+    """Tile po_numbers = distinct line po_number values, cancelled lines excluded."""
+    from app.services.buyplan_hub import deals_board
+
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        submitted_by_id=test_user.id,
+    )
+    l1 = _make_line(db_session, buy_plan_id=plan.id, status=BuyPlanLineStatus.VERIFIED)
+    l2 = _make_line(db_session, buy_plan_id=plan.id, status=BuyPlanLineStatus.VERIFIED)
+    l3 = _make_line(db_session, buy_plan_id=plan.id, status=BuyPlanLineStatus.PENDING_VERIFY)
+    cancelled = _make_line(db_session, buy_plan_id=plan.id, status=BuyPlanLineStatus.CANCELLED)
+    l1.po_number = "PO-100"
+    l2.po_number = "PO-100"  # duplicate collapses
+    l3.po_number = "PO-200"
+    cancelled.po_number = "PO-DEAD"  # excluded (line cancelled)
+    db_session.flush()
+
+    board = deals_board(db_session, test_user, scope="all")
+    deal = next(d for d in board["active"] if d["plan_id"] == plan.id)
+
+    assert deal["po_numbers"] == ["PO-100", "PO-200"]
 
 
 # ── 8. needs_my_action for DRAFT ─────────────────────────────────────

--- a/tests/test_buyplan_hub_supervise.py
+++ b/tests/test_buyplan_hub_supervise.py
@@ -196,6 +196,34 @@ def test_supervise_flagged(db_session, test_user, test_quote, test_requisition):
     assert "issue_type" in row
     assert row["issue_type"] == LineIssueType.LEAD_TIME_CHANGED
     assert row["plan_id"] == plan.id
+    # The flagged row states the ACTUAL reason (Part 4): humanised type code when no note.
+    assert row["issue_reason"] == "Lead time changed"
+
+
+def test_supervise_flagged_reason_prefers_note(db_session, test_user, test_quote, test_requisition):
+    """When a buyer left a free-text issue_note, the flagged reason shows that note."""
+    from app.services.buyplan_hub import supervise_overview
+
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+    )
+    line = _make_line(
+        db_session,
+        buy_plan_id=plan.id,
+        buyer_id=test_user.id,
+        status=BuyPlanLineStatus.ISSUE,
+        issue_type=LineIssueType.OTHER,
+    )
+    line.issue_note = "Vendor MOQ doubled — needs reprice"
+    db_session.flush()
+
+    result = supervise_overview(db_session)
+    row = next(d for d in result["triage"]["flagged"] if d["line_id"] == line.id)
+    # The specific note wins over the generic type label.
+    assert row["issue_reason"] == "Vendor MOQ doubled — needs reprice"
 
 
 # ── 4. Overdue AWAITING_PO lines ─────────────────────────────────────
@@ -372,7 +400,10 @@ def test_supervise_so_pending(db_session, test_user, test_quote, test_requisitio
     assert plan.id in so_ids
 
     row = next(d for d in result["triage"]["so_pending"] if d["plan_id"] == plan.id)
-    assert set(row.keys()) == {"plan_id", "customer_name", "value", "submitted_by_name"}
+    assert set(row.keys()) == {"plan_id", "customer_name", "value", "submitted_by_name", "card_title"}
+    # SO-approval row carries the canonical title ending "- SO"; Owner = Account Manager.
+    assert row["card_title"].endswith(" - SO")
+    assert (test_user.name or test_user.email) in row["card_title"]
 
 
 def test_supervise_so_approved_not_pending(db_session, test_quote, test_requisition):
@@ -419,8 +450,11 @@ def test_supervise_po_pending_verify(db_session, test_user, test_quote, test_req
     assert line.id in pv_ids
 
     row = next(d for d in result["triage"]["po_pending_verify"] if d["line_id"] == line.id)
-    assert set(row.keys()) == {"line_id", "plan_id", "mpn", "vendor_name", "buyer_name"}
+    assert set(row.keys()) == {"line_id", "plan_id", "mpn", "vendor_name", "buyer_name", "card_title"}
     assert row["plan_id"] == plan.id
+    # PO-approval row carries the canonical title ending "- PO"; Owner = the Buyer.
+    assert row["card_title"].endswith(" - PO")
+    assert (test_user.name or test_user.email) in row["card_title"]
 
 
 def test_supervise_awaiting_po_not_pending_verify(db_session, test_user, test_quote, test_requisition):

--- a/tests/test_buyplan_naming.py
+++ b/tests/test_buyplan_naming.py
@@ -1,0 +1,132 @@
+"""test_buyplan_naming.py — the shared deal-card title + top-flag-reason helpers.
+
+Covers:
+- build_card_title assembles "{SO#} - {Customer} - {Owner} - {Type}" for each kind
+- BP/SO/PO suffix is appended verbatim and per-kind
+- Missing SO# / customer / owner each collapse to an em dash (never ragged)
+- Unknown kind raises ValueError (loud wiring-mistake signal)
+- summarize_top_flag returns the worst-severity flag's verbatim reason (Part 4)
+
+Depends on: app/services/buyplan_naming.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.buyplan_naming import (
+    CARD_KIND_BUY_PLAN,
+    CARD_KIND_PO,
+    CARD_KIND_SALES_ORDER,
+    build_card_title,
+    summarize_top_flag,
+)
+
+# ── build_card_title: suffix + owner per kind ─────────────────────────
+
+
+def test_buy_plan_title_suffix_bp():
+    """Buy-Plan card ends '- BP' with the Account Manager as Owner."""
+    title = build_card_title(
+        sales_order_number="TSO-1234",
+        customer_name="Acme Electronics",
+        owner_name="Jordan Sales",
+        kind=CARD_KIND_BUY_PLAN,
+    )
+    assert title == "TSO-1234 - Acme Electronics - Jordan Sales - BP"
+
+
+def test_sales_order_title_suffix_so():
+    """SO-approval card ends '- SO' with the Account Manager as Owner."""
+    title = build_card_title(
+        sales_order_number="TSO-1234",
+        customer_name="Acme Electronics",
+        owner_name="Jordan Sales",
+        kind=CARD_KIND_SALES_ORDER,
+    )
+    assert title == "TSO-1234 - Acme Electronics - Jordan Sales - SO"
+
+
+def test_po_title_suffix_po_with_buyer_owner():
+    """PO-approval card ends '- PO' with the Buyer as Owner (distinct from the AM)."""
+    title = build_card_title(
+        sales_order_number="TSO-1234",
+        customer_name="Acme Electronics",
+        owner_name="Pat Buyer",  # the Buyer, not the sales owner
+        kind=CARD_KIND_PO,
+    )
+    assert title == "TSO-1234 - Acme Electronics - Pat Buyer - PO"
+    assert title.endswith(" - PO")
+
+
+def test_all_three_kinds_share_one_prefix():
+    """Same SO#/customer → identical prefix across all three kinds; only the suffix
+    differs."""
+    common = dict(sales_order_number="TSO-7", customer_name="Globex", owner_name="Sam")
+    bp = build_card_title(kind=CARD_KIND_BUY_PLAN, **common)
+    so = build_card_title(kind=CARD_KIND_SALES_ORDER, **common)
+    po = build_card_title(kind=CARD_KIND_PO, **common)
+    assert bp[:-2] == so[:-2] == po[:-2] == "TSO-7 - Globex - Sam - "
+    assert (bp[-2:], so[-2:], po[-2:]) == ("BP", "SO", "PO")
+
+
+# ── Missing-field fallbacks ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "so,customer,owner,expected",
+    [
+        (None, "Acme", "Sam", "— - Acme - Sam - BP"),  # no SO# yet (fresh draft)
+        ("TSO-1", None, "Sam", "TSO-1 - — - Sam - BP"),  # customer site deleted
+        ("TSO-1", "Acme", None, "TSO-1 - Acme - — - BP"),  # owner unset
+        ("  ", "  ", "  ", "— - — - — - BP"),  # all blank/whitespace
+    ],
+)
+def test_missing_fields_collapse_to_em_dash(so, customer, owner, expected):
+    assert (
+        build_card_title(sales_order_number=so, customer_name=customer, owner_name=owner, kind=CARD_KIND_BUY_PLAN)
+        == expected
+    )
+
+
+def test_unknown_kind_raises():
+    """An unrecognised card kind is a wiring bug — raise, don't render an untyped
+    title."""
+    with pytest.raises(ValueError, match="Unknown card kind"):
+        build_card_title(sales_order_number="X", customer_name="Y", owner_name="Z", kind="XX")
+
+
+# ── summarize_top_flag: the actual issue at first glance (Part 4) ──────
+
+
+def test_top_flag_none_when_empty():
+    assert summarize_top_flag(None) is None
+    assert summarize_top_flag([]) is None
+
+
+def test_top_flag_returns_verbatim_reason():
+    """The reason string is the verbatim message the flag system recorded."""
+    flags = [{"type": "low_margin", "severity": "warning", "message": "Margin 8.50% below 15% threshold"}]
+    top = summarize_top_flag(flags)
+    assert top == {"severity": "warning", "message": "Margin 8.50% below 15% threshold"}
+
+
+def test_top_flag_picks_worst_severity():
+    """Critical beats warning beats info, regardless of list order."""
+    flags = [
+        {"severity": "info", "message": "cheaper offer exists"},
+        {"severity": "warning", "message": "stale offer"},
+        {"severity": "critical", "message": "No buyer assigned for line (reason: unknown)"},
+    ]
+    top = summarize_top_flag(flags)
+    assert top["severity"] == "critical"
+    assert top["message"] == "No buyer assigned for line (reason: unknown)"
+
+
+def test_top_flag_ties_keep_first():
+    """Among equal-severity flags, the first one wins (stable)."""
+    flags = [
+        {"severity": "warning", "message": "first warning"},
+        {"severity": "warning", "message": "second warning"},
+    ]
+    assert summarize_top_flag(flags)["message"] == "first warning"


### PR DESCRIPTION
Shared `build_card_title` helper titles cards `{SO#} - {Customer} - {Owner} - {Type}`: BP & SO owner = Account Manager (submitted_by), PO owner = the per-line Buyer (no plan-level buyer exists). Denser deal tiles surface TSO + our PO numbers + primary part for quick reviewer scan (reuses .chip/.badge/font-mono; tightened padding). Flagged-issue indicators now state the actual reason — `summarize_top_flag` returns the worst AI flag's verbatim message (critical>warning>info); supervise rows show the buyer note / humanised issue type. NOTE: the board has ONE deal-card type + SO/PO approval triage rows in _supervise.html (not 3 separate tiles) — convention applied to all 3 real contexts; no invented model fields. 788 buy-plan + 138 impacted + static-analysis green; independent review found no bugs; pre-commit clean.