### PR TITLE
style: Aptos-first app font with loaded Inter fallback (unify typography)

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 /* ── Design System: Clean, high-contrast utility ──────────────────────
-   Font: Aptos → Segoe UI → system-ui
+   Font: Aptos (system, Win11/Office) → Inter (loaded web font) → Segoe UI → system-ui
    Hairlines: --line #BFC4CE (base) · --line-subtle #D5D8DF (see :root)
    Body text: #1e293b (slate-800), secondary: #4B5463 (brand-600)
    Min interactive font: 11px, body: 13px, headings: 15px
@@ -11,7 +11,7 @@
 
 @layer base {
   body {
-    @apply text-[14px] text-gray-900 leading-normal antialiased;
+    @apply font-sans text-[14px] text-gray-900 leading-normal antialiased;
   }
 }
 
@@ -418,7 +418,7 @@ hr { border-color: #BFC4CE; }
   font-size: 13px;
 }
 .compact-table th {
-  font-family: 'Aptos', 'Segoe UI', system-ui, sans-serif;
+  font-family: 'Aptos', 'Inter', 'Segoe UI', system-ui, sans-serif;
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -442,7 +442,7 @@ hr { border-color: #BFC4CE; }
   font-size: 12px;
 }
 .compact-table td.td-label {
-  font-family: 'Aptos', 'Segoe UI', system-ui, sans-serif;
+  font-family: 'Aptos', 'Inter', 'Segoe UI', system-ui, sans-serif;
   font-size: 13px;
 }
 .compact-table tbody tr {
@@ -524,7 +524,7 @@ table {
   letter-spacing: 0.03em;
   text-transform: uppercase;
   border-radius: 4px;
-  font-family: 'Aptos', 'Segoe UI', system-ui, sans-serif;
+  font-family: 'Aptos', 'Inter', 'Segoe UI', system-ui, sans-serif;
 }
 /* ── Panel chrome — workspace panels ──────────────────────────────── */
 .panel-header {
@@ -537,7 +537,7 @@ table {
   flex-shrink: 0;
 }
 .panel-title {
-  font-family: 'Aptos', 'Segoe UI', system-ui, sans-serif;
+  font-family: 'Aptos', 'Inter', 'Segoe UI', system-ui, sans-serif;
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -554,7 +554,7 @@ table {
   border-bottom: 2px solid transparent;
   transition: all 0.15s;
   white-space: nowrap;
-  font-family: 'Aptos', 'Segoe UI', system-ui, sans-serif;
+  font-family: 'Aptos', 'Inter', 'Segoe UI', system-ui, sans-serif;
 }
 .ws-tab:hover {
   color: #4B5463;

--- a/app/templates/htmx/base.html
+++ b/app/templates/htmx/base.html
@@ -5,7 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="app-build" content="{{ build_commit|default('') }}">
   <title>{% block title %}AvailAI{% endblock %}</title>
-  <!-- Aptos (Office 365/Win11) → Segoe UI → system fallbacks -->
+  <!-- App UI face: Inter (loaded web font) → Aptos → Segoe UI → system fallbacks -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
   {% for css_file in vite_css|default([]) %}
   <link rel="stylesheet" href="/static/{{ css_file }}">
   {% endfor %}

--- a/app/templates/htmx/login.html
+++ b/app/templates/htmx/login.html
@@ -9,7 +9,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AvailAI - Sign In</title>
-  <!-- Aptos (Office 365/Win11) → Segoe UI → system fallbacks -->
+  <!-- App UI face: Inter (loaded web font) → Aptos → Segoe UI → system fallbacks -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
   {% for css_file in css_files|default([]) %}
   <link rel="stylesheet" href="/static/{{ css_file }}">
   {% endfor %}

--- a/app/templates/requisitions2/page.html
+++ b/app/templates/requisitions2/page.html
@@ -11,6 +11,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Requisitions — AvailAI</title>
+  {# App UI face: Inter (loaded web font) → Aptos → Segoe UI → system fallbacks. #}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
   {# Vite-built CSS bundles — hash-named so cache-busting is automatic.
      No source fallback: /static/styles.css is raw Tailwind (@tailwind ...) that
      can't render and 404s via Caddy (serves dist) — matches base.html. #}

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/root/availai/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/root/availai/node_modules

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,20 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Aptos', 'Segoe UI', 'system-ui', '-apple-system', 'sans-serif'],
+        // Aptos is the primary UI face — a Microsoft system font present on Win11
+        // and Office-enabled machines (the user's environment). Inter is a real,
+        // loaded web font (Google Fonts link in base.html/login.html) that acts
+        // as the cross-platform fallback for non-Aptos machines. Aptos cannot be
+        // web-loaded (Microsoft-licensed), so it sits first in the stack and wins
+        // on machines that have it; everyone else gets loaded Inter.
+        sans: [
+          'Aptos',
+          'Inter',
+          'Segoe UI',
+          'system-ui',
+          '-apple-system',
+          'sans-serif',
+        ],
       },
       // Two-tier shadow language: `card` for resting surfaces (≈ the old
       // shadow-sm, brand-tinted), `float` for modals/dropdowns/action rails.


### PR DESCRIPTION
Unifies the app's font stack. Finding: the buy-plan page wasn't using a special font — the whole app's stack (Aptos-first) was already global but the only loaded fallback was the OS system font, so it varied by machine. Now: `font-sans = Aptos, Inter, Segoe UI, system-ui, -apple-system, sans-serif` applied consistently (tailwind.config.js + body + 5 component classes); **Aptos** stays primary (Microsoft-licensed, can't be web-loaded, but present on Win11/Office), with **Inter loaded via Google Fonts** as a real cross-platform fallback so non-Aptos machines get a close, consistent face instead of an arbitrary system font. CSP already allows Google Fonts. Type scale untouched. 44 tests + security-headers green. NOTE: PDF/print report templates left on their Arial print face (out of scope).