### PR TITLE
fix(profile): accurate, graceful mailbox-sync status (retire raw 'hit a snag')

### DIFF
--- a/app/jobs/core_jobs.py
+++ b/app/jobs/core_jobs.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from ..constants import RequisitionStatus
 from ..scheduler import _traced_job
+from ..services.m365_status import REASON_TRANSIENT, reason_for
 from ..utils.token_manager import _utc
 
 
@@ -143,7 +144,7 @@ async def _job_token_refresh():
                 try:
                     user = task_db.get(User, user_id)
                     if user:
-                        user.m365_error_reason = str(e)[:255]
+                        user.m365_error_reason = reason_for(e)
                         task_db.commit()
                 except Exception:
                     task_db.rollback()
@@ -211,7 +212,8 @@ async def _job_inbox_scan():
                 try:
                     user = scan_db.get(User, user_id)
                     if user:
-                        user.m365_error_reason = "Inbox scan timed out"
+                        # A timeout is transient — it self-heals on the next scan.
+                        user.m365_error_reason = REASON_TRANSIENT
                         scan_db.commit()
                 except sqlalchemy.exc.SQLAlchemyError:
                     scan_db.rollback()
@@ -222,7 +224,7 @@ async def _job_inbox_scan():
                 try:
                     user = scan_db.get(User, user_id)
                     if user:
-                        user.m365_error_reason = str(e)[:255]
+                        user.m365_error_reason = reason_for(e)
                         scan_db.commit()
                 except sqlalchemy.exc.SQLAlchemyError:
                     scan_db.rollback()

--- a/app/jobs/email_jobs.py
+++ b/app/jobs/email_jobs.py
@@ -443,6 +443,17 @@ async def _scan_user_inbox(user, db):
 
     if poll_succeeded:
         user.last_inbox_scan = datetime.now(timezone.utc)
+        # A successful poll proves the token + connectivity are healthy right
+        # now, so a stale token/scan error no longer reflects reality — clear it
+        # so the Settings card stops showing a resolved error. Leave the Graph
+        # subscription warning alone: webhooks are a separate channel with their
+        # own renewal lifecycle (webhook_service), and a mailbox poll says
+        # nothing about subscription health.
+        from ..services.m365_status import REASON_SUBSCRIPTION
+
+        if user.m365_error_reason and user.m365_error_reason != REASON_SUBSCRIPTION:
+            user.m365_error_reason = None
+        user.m365_last_healthy = datetime.now(timezone.utc)
         db.commit()
 
 

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -1575,6 +1575,7 @@ def get_inbox_sync_status(db: Session, user) -> dict:
     env default — so this staleness threshold matches the actual scan cadence.
     """
     from app.services.admin_service import get_effective_int
+    from app.services.m365_status import action_for_reason
 
     now = datetime.now(timezone.utc)
     connected = bool(getattr(user, "m365_connected", False))
@@ -1598,11 +1599,18 @@ def get_inbox_sync_status(db: Session, user) -> dict:
     else:
         health = InboxSyncHealth.OK
 
+    error_reason = getattr(user, "m365_error_reason", None)
+    # Reverse-map the persisted reason to the user's next step so the card can
+    # show a specific, accurate message (reconnect vs. self-healing) instead of
+    # a generic "snag". None/legacy reasons resolve to a safe non-reconnect action.
+    error_action = action_for_reason(error_reason)
+
     return {
         "connected": connected,
         "last_scan_at": _utc(last_scan) if last_scan else None,
         "is_stale": is_stale,
         "token_ok": token_ok,
-        "error_reason": getattr(user, "m365_error_reason", None),
+        "error_reason": error_reason,
+        "error_action": error_action.value if error_action else None,
         "health": health,
     }

--- a/app/services/m365_status.py
+++ b/app/services/m365_status.py
@@ -1,0 +1,113 @@
+"""m365_status.py — single source of truth for mailbox-sync error copy.
+
+Background jobs that touch Microsoft 365 (token refresh, inbox scan, Graph
+subscription renewal) record a failure reason on ``User.m365_error_reason``.
+That field is surfaced verbatim in the Settings → Profile mailbox-sync card and
+the disconnected banner, so it MUST be a user-meaningful, actionable sentence —
+never a raw ``str(exception)`` stack message.
+
+This module classifies an arbitrary failure into a small, stable vocabulary and
+maps each category to (a) the friendly reason string we persist and (b) the
+next step the user can actually take. The status reader
+(``activity_service.get_inbox_sync_status``) reverse-maps the persisted reason
+back to an action so the template can show a specific, accurate message.
+
+Called by:
+    app/utils/token_manager.py      (token refresh)
+    app/jobs/core_jobs.py           (scheduled token refresh + inbox scan)
+    app/services/webhook_service.py (Graph subscription renewal)
+    app/services/activity_service.py (status reader → template)
+Depends on: nothing app-specific (kept dependency-free to avoid import cycles).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class M365ErrorCategory(StrEnum):
+    """Why mailbox sync is unhealthy — drives the user-facing copy + next step."""
+
+    # Sign-in / token is dead — only a reconnect fixes it.
+    AUTH = "auth"
+    # Transient network / timeout / Graph 5xx — self-heals on the next cycle.
+    TRANSIENT = "transient"
+    # Graph webhook subscription renewal failing — email tracking degraded.
+    SUBSCRIPTION = "subscription"
+
+
+# What the user should do about each category. ``None`` = nothing, it self-heals.
+class M365ErrorAction(StrEnum):
+    RECONNECT = "reconnect"  # send them to /auth/login
+    WAIT = "wait"  # transient — syncing resumes automatically
+
+
+# Canonical persisted reason strings. These are the EXACT values written to
+# ``User.m365_error_reason`` so the reader can reverse-map them to an action and
+# so a successful renewal can clear its own message without clobbering others.
+REASON_AUTH = "Microsoft 365 sign-in expired — reconnect to resume mailbox sync."
+REASON_TRANSIENT = "Temporary connection issue reaching Microsoft 365 — sync will resume automatically."
+# Subscription copy is unchanged from its original wording for backward
+# compatibility with webhook_service's clear-on-success guard and its tests.
+REASON_SUBSCRIPTION = "Email tracking degraded — Graph subscription renewal failing"
+
+_CATEGORY_REASON: dict[M365ErrorCategory, str] = {
+    M365ErrorCategory.AUTH: REASON_AUTH,
+    M365ErrorCategory.TRANSIENT: REASON_TRANSIENT,
+    M365ErrorCategory.SUBSCRIPTION: REASON_SUBSCRIPTION,
+}
+
+_REASON_ACTION: dict[str, M365ErrorAction | None] = {
+    REASON_AUTH: M365ErrorAction.RECONNECT,
+    REASON_TRANSIENT: M365ErrorAction.WAIT,
+    REASON_SUBSCRIPTION: None,  # informational — nothing the user can do
+}
+
+# Substrings (lowercased) in a raw error that signal a dead sign-in/token.
+# Everything else is treated as transient (timeouts, 5xx, network blips, parse
+# errors) — a scary raw message must never reach the UI.
+_AUTH_SIGNALS = (
+    "invalid_grant",
+    "invalid_client",
+    "token refresh failed",
+    "token expired",
+    "unauthorized",
+    "aadsts",
+    "401",
+    "403",
+    "interaction_required",
+    "consent",
+)
+
+
+def classify_m365_error(err: object) -> M365ErrorCategory:
+    """Map an exception or raw message to a stable error category.
+
+    Anything that looks like a dead sign-in/token → AUTH (needs reconnect). Everything
+    else (timeouts, network, Graph 5xx, parse errors, unknown) → TRANSIENT, because
+    surfacing a raw stack string as a permanent error and telling the user to reconnect
+    is both inaccurate and unactionable.
+    """
+    text = str(err).lower()
+    if any(sig in text for sig in _AUTH_SIGNALS):
+        return M365ErrorCategory.AUTH
+    return M365ErrorCategory.TRANSIENT
+
+
+def reason_for(err: object) -> str:
+    """Friendly, user-facing reason string for a raw error — never raw text."""
+    return _CATEGORY_REASON[classify_m365_error(err)]
+
+
+def action_for_reason(reason: str | None) -> M365ErrorAction | None:
+    """Reverse-map a persisted reason to the user's next step.
+
+    Returns ``None`` for no-reason or any unrecognized legacy string. An
+    unrecognized reason is treated as transient (WAIT) rather than RECONNECT so
+    a stale legacy value can never wrongly tell the user to reconnect.
+    """
+    if not reason:
+        return None
+    if reason in _REASON_ACTION:
+        return _REASON_ACTION[reason]
+    return M365ErrorAction.WAIT

--- a/app/templates/htmx/partials/settings/_mailbox_sync_card.html
+++ b/app/templates/htmx/partials/settings/_mailbox_sync_card.html
@@ -28,7 +28,16 @@
       {% if inbox_status.last_scan_at %}{{ inbox_status.last_scan_at|timeago }}{% else %}not yet{% endif %}
     </div>
     {% if inbox_status.error_reason %}
-    <div class="text-rose-600">We hit a snag syncing your mailbox: {{ inbox_status.error_reason }}. Try reconnecting from the sign-in screen.</div>
+      {% if inbox_status.error_action == 'reconnect' %}
+      {# Sign-in/token is dead — reconnect is the real fix. #}
+      <div class="text-rose-600">
+        {{ inbox_status.error_reason }}
+        <a href="/auth/login" class="font-medium underline">Reconnect Microsoft 365</a>.
+      </div>
+      {% else %}
+      {# Transient / subscription degradation — self-heals or is informational. #}
+      <div class="text-amber-600">{{ inbox_status.error_reason }}</div>
+      {% endif %}
     {% elif inbox_status.is_stale %}
     <div class="text-amber-600">Sync is running behind — the next check should catch it up.</div>
     {% endif %}
@@ -39,8 +48,12 @@
     <p class="text-sm font-medium text-gray-700">Mailbox not connected</p>
     <p class="mt-1 text-xs text-gray-500">Sign in with Microsoft 365 to let AvailAI read replies and keep your requisitions up to date.</p>
     {% if inbox_status.error_reason %}
-    <p class="mt-2 text-xs text-rose-600">Last error: {{ inbox_status.error_reason }}.</p>
+    <p class="mt-2 text-xs text-rose-600">{{ inbox_status.error_reason }}</p>
     {% endif %}
+    <a href="/auth/login"
+       class="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-accent-600 rounded-lg hover:bg-accent-700">
+      Connect Microsoft 365
+    </a>
   </div>
   {% endif %}
 </div>

--- a/app/utils/token_manager.py
+++ b/app/utils/token_manager.py
@@ -41,7 +41,11 @@ async def get_valid_token(user, db) -> str | None:
         user.m365_error_reason = None
         db.commit()
     else:
-        user.m365_error_reason = "Token refresh failed"
+        # A failed refresh means the sign-in/refresh token is dead — only a
+        # reconnect fixes it. Record the actionable reason, not a raw string.
+        from ..services.m365_status import reason_for
+
+        user.m365_error_reason = reason_for("token refresh failed")
         db.commit()
     return token
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1563,7 +1563,15 @@ activity_service.get_inbox_sync_status(user)
     |       WARNING — last_inbox_scan > 2× inbox_scan_interval_min ago
     |       OK     — connected, token valid, scan recent
     |
-    +---> Returns: {connected, last_scan_at, is_stale, token_ok, error_reason, health}
+    +---> Reverse-maps m365_error_reason -> error_action via
+    |     m365_status.action_for_reason():
+    |       REASON_AUTH         -> "reconnect" (sign-in dead; link to /auth/login)
+    |       REASON_TRANSIENT    -> "wait" (self-heals on next cycle)
+    |       REASON_SUBSCRIPTION -> None (informational; webhook channel)
+    |       None / legacy raw   -> None / "wait" (never wrongly "reconnect")
+    |
+    +---> Returns: {connected, last_scan_at, is_stale, token_ok,
+    |               error_reason, error_action, health}
     |
     v
 Two surfaces:
@@ -1571,9 +1579,22 @@ Two surfaces:
        (shown when health=error or is_stale=True; included at top of list.html)
     2. Settings → Profile: settings/_mailbox_sync_card.html
        (connected: friendly sync status + "Scan now" button + last-checked
-        timeago; not connected: a "Mailbox not connected" empty state with a
-        reconnect hint and no Scan-now button. m365_error_reason is rendered as
-        friendly text, not a raw string.)
+        timeago; on error, branches on error_action — "reconnect" shows the
+        accurate reason + a Reconnect Microsoft 365 link, otherwise an amber
+        self-healing note. not connected: a "Mailbox not connected" empty state
+        with a Connect Microsoft 365 button. m365_error_reason is ALWAYS a
+        friendly, actionable sentence — never a raw str(exception).)
+
+m365_error_reason vocabulary (app/services/m365_status.py is the single source
+of truth — all four writers route through it):
+    - token_manager.get_valid_token + core_jobs token-refresh failure
+      -> reason_for(): auth-signal errors -> REASON_AUTH, else REASON_TRANSIENT
+    - core_jobs inbox-scan timeout -> REASON_TRANSIENT; scan exception
+      -> reason_for() (classified, never raw str(e))
+    - webhook_service subscription renewal >= 3 fails -> REASON_SUBSCRIPTION
+A successful inbox poll (email_jobs._scan_user_inbox) clears a self-healed
+token/scan reason (NOT the subscription one — separate webhook lifecycle) so
+the card stops showing a resolved error.
 
 "Scan now" button:
     POST /v2/partials/settings/inbox/scan-now

--- a/tests/test_core_jobs.py
+++ b/tests/test_core_jobs.py
@@ -332,7 +332,12 @@ class TestJobTokenRefresh:
             await _job_token_refresh.__wrapped__()
 
         db_session.refresh(test_user)
-        assert "Token endpoint down" in (test_user.m365_error_reason or "")
+        # The raw exception text must NOT leak into the user-facing reason; a
+        # non-auth failure surfaces as the friendly self-healing message.
+        from app.services.m365_status import REASON_TRANSIENT
+
+        assert test_user.m365_error_reason == REASON_TRANSIENT
+        assert "Token endpoint down" not in (test_user.m365_error_reason or "")
 
     @pytest.mark.asyncio
     async def test_works_without_redis(self, db_session: Session, test_user: User):
@@ -487,7 +492,9 @@ class TestJobInboxScan:
             await _job_inbox_scan.__wrapped__()
 
         db_session.refresh(test_user)
-        assert test_user.m365_error_reason == "Inbox scan timed out"
+        from app.services.m365_status import REASON_TRANSIENT
+
+        assert test_user.m365_error_reason == REASON_TRANSIENT
 
     @pytest.mark.asyncio
     async def test_handles_scan_exception(self, db_session: Session, test_user: User):
@@ -510,7 +517,11 @@ class TestJobInboxScan:
             await _job_inbox_scan.__wrapped__()
 
         db_session.refresh(test_user)
-        assert "Graph API error" in (test_user.m365_error_reason or "")
+        # Raw Graph exception text must not reach the user-facing reason.
+        from app.services.m365_status import REASON_TRANSIENT
+
+        assert test_user.m365_error_reason == REASON_TRANSIENT
+        assert "Graph API error" not in (test_user.m365_error_reason or "")
 
     @pytest.mark.asyncio
     async def test_selector_error_reraises(self):

--- a/tests/test_jobs_core.py
+++ b/tests/test_jobs_core.py
@@ -330,7 +330,9 @@ def test_get_valid_token_sets_error_when_refresh_fails(db_session, test_user):
 
         token = asyncio.run(get_valid_token(test_user, db_session))
         assert token is None
-        assert test_user.m365_error_reason == "Token refresh failed"
+        from app.services.m365_status import REASON_AUTH
+
+        assert test_user.m365_error_reason == REASON_AUTH
 
 
 def test_get_valid_token_no_token_no_expiry(db_session, test_user):
@@ -588,8 +590,10 @@ def test_inbox_scan_handles_timeout(scheduler_db, test_user):
         from app.jobs.core_jobs import _job_inbox_scan
 
         asyncio.run(_job_inbox_scan())
-        # User should have an error set
-        assert test_user.m365_error_reason == "Inbox scan timed out"
+        # A timeout is transient — surfaced as the self-healing reason.
+        from app.services.m365_status import REASON_TRANSIENT
+
+        assert test_user.m365_error_reason == REASON_TRANSIENT
 
 
 def test_inbox_scan_error_in_user_gathering(scheduler_db):
@@ -639,7 +643,9 @@ def test_inbox_scan_safe_scan_timeout(scheduler_db, test_user):
             asyncio.run(_job_inbox_scan())
 
     scheduler_db.refresh(test_user)
-    assert test_user.m365_error_reason == "Inbox scan timed out"
+    from app.services.m365_status import REASON_TRANSIENT
+
+    assert test_user.m365_error_reason == REASON_TRANSIENT
 
 
 def test_inbox_scan_safe_scan_exception(scheduler_db, test_user):

--- a/tests/test_jobs_coverage_2.py
+++ b/tests/test_jobs_coverage_2.py
@@ -2623,7 +2623,11 @@ class TestJobTokenRefreshEdgeCases:
                     ):
                         _run(_job_token_refresh.__wrapped__())
 
-        assert "token expired" in user.m365_error_reason
+        # "token expired" is an auth failure → actionable reconnect reason,
+        # not the raw exception text.
+        from app.services.m365_status import REASON_AUTH
+
+        assert user.m365_error_reason == REASON_AUTH
 
     @patch("app.jobs.core_jobs.logger")
     def test_generic_exception(self, mock_logger):

--- a/tests/test_m365_status.py
+++ b/tests/test_m365_status.py
@@ -1,0 +1,181 @@
+"""Tests for accurate, graceful mailbox-sync status (the 'snag' fix).
+
+Covers app/services/m365_status.py (error classification + actionable copy) and
+the parts of app/services/activity_service.get_inbox_sync_status that surface it.
+
+Regression guards for the original bug:
+  - a raw exception string was pasted into a generic red "snag" banner
+  - the banner told the user to reconnect even for transient/server-side errors
+  - the banner was sticky: a self-healed error kept showing because nothing
+    cleared User.m365_error_reason on a successful scan
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from app.constants import InboxSyncHealth
+from app.services.activity_service import get_inbox_sync_status
+from app.services.m365_status import (
+    REASON_AUTH,
+    REASON_SUBSCRIPTION,
+    REASON_TRANSIENT,
+    M365ErrorAction,
+    M365ErrorCategory,
+    action_for_reason,
+    classify_m365_error,
+    reason_for,
+)
+
+
+def _user(**kw):
+    base = dict(
+        m365_connected=True,
+        last_inbox_scan=datetime.now(timezone.utc),
+        token_expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        access_token="t",
+        m365_error_reason=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# ── classify_m365_error ─────────────────────────────────────────────────
+
+
+def test_auth_signals_classify_as_auth():
+    for raw in ["invalid_grant", "Token refresh failed", "AADSTS700082", "401 Unauthorized", "token expired"]:
+        assert classify_m365_error(raw) == M365ErrorCategory.AUTH, raw
+
+
+def test_non_auth_errors_classify_as_transient():
+    for raw in [Exception("read timeout"), "Graph API error", "503 Service Unavailable", "random parse error"]:
+        assert classify_m365_error(raw) == M365ErrorCategory.TRANSIENT, raw
+
+
+def test_reason_for_never_returns_raw_text():
+    """The persisted reason must be a friendly sentence, never the raw error."""
+    raw = "ValueError: kaboom at line 42 <object 0x7f>"
+    reason = reason_for(Exception(raw))
+    assert reason == REASON_TRANSIENT
+    assert "kaboom" not in reason
+    assert "0x7f" not in reason
+
+
+def test_reason_for_auth_is_reconnect_copy():
+    assert reason_for("invalid_grant") == REASON_AUTH
+
+
+# ── action_for_reason (reverse map → template branch) ───────────────────
+
+
+def test_action_for_known_reasons():
+    assert action_for_reason(REASON_AUTH) == M365ErrorAction.RECONNECT
+    assert action_for_reason(REASON_TRANSIENT) == M365ErrorAction.WAIT
+    assert action_for_reason(REASON_SUBSCRIPTION) is None
+
+
+def test_action_for_none_and_legacy():
+    assert action_for_reason(None) is None
+    assert action_for_reason("") is None
+    # A stale legacy raw string must never resolve to RECONNECT.
+    assert action_for_reason("Inbox scan timed out") == M365ErrorAction.WAIT
+
+
+# ── get_inbox_sync_status surfaces action, degrades gracefully ──────────
+
+
+def test_status_auth_error_surfaces_reconnect_action():
+    s = get_inbox_sync_status(None, _user(m365_error_reason=REASON_AUTH))
+    assert s["error_reason"] == REASON_AUTH
+    assert s["error_action"] == "reconnect"
+
+
+def test_status_transient_error_surfaces_wait_action():
+    s = get_inbox_sync_status(None, _user(m365_error_reason=REASON_TRANSIENT))
+    assert s["error_action"] == "wait"
+    # transient ≠ "reconnect" — that was the misleading-instruction bug
+    assert s["error_action"] != "reconnect"
+
+
+def test_status_subscription_error_has_no_action():
+    s = get_inbox_sync_status(None, _user(m365_error_reason=REASON_SUBSCRIPTION))
+    assert s["error_reason"] == REASON_SUBSCRIPTION
+    assert s["error_action"] is None
+
+
+def test_status_no_error_has_no_action():
+    s = get_inbox_sync_status(None, _user())
+    assert s["error_reason"] is None
+    assert s["error_action"] is None
+
+
+def test_status_missing_token_is_error_with_reason():
+    """No delegated token → ERROR health, and an auth reason → reconnect."""
+    s = get_inbox_sync_status(None, _user(access_token=None, m365_error_reason=REASON_AUTH))
+    assert s["health"] == InboxSyncHealth.ERROR
+    assert s["token_ok"] is False
+    assert s["error_action"] == "reconnect"
+
+
+def test_status_does_not_crash_on_minimal_user():
+    """A graph hiccup must not break the Profile page: missing optional attrs
+    must not raise — the status still resolves."""
+    minimal = SimpleNamespace()  # no m365_* attrs at all
+    s = get_inbox_sync_status(None, minimal)
+    assert s["connected"] is False
+    assert s["health"] == InboxSyncHealth.ERROR
+    assert s["error_reason"] is None
+    assert s["error_action"] is None
+
+
+# ── successful scan clears a self-healed error (sticky-banner fix) ───────
+
+
+def _patch_successful_scan(monkeypatch):
+    """Stub the inbox-scan seams so _scan_user_inbox's poll succeeds."""
+    from unittest.mock import AsyncMock
+
+    import app.jobs.email_jobs as ej
+
+    monkeypatch.setattr("app.utils.token_manager.get_valid_token", AsyncMock(return_value="valid-token"))
+    monkeypatch.setattr("app.email_service.poll_inbox", AsyncMock(return_value=[]))
+    # _scan_stock_list_attachments is lazily imported from inventory_jobs;
+    # the other two sub-ops are module-level names in email_jobs.
+    monkeypatch.setattr("app.jobs.inventory_jobs._scan_stock_list_attachments", AsyncMock(return_value=None))
+    monkeypatch.setattr(ej, "_mine_vendor_contacts", AsyncMock(return_value=None))
+    monkeypatch.setattr(ej, "_scan_outbound_rfqs", AsyncMock(return_value=None))
+
+
+async def test_successful_scan_clears_stale_transient_error(db_session, test_user, monkeypatch):
+    """A healthy scan proves connectivity → a self-healed transient error is cleared, so
+    the Settings card stops showing a resolved 'snag'."""
+    from app.jobs.email_jobs import _scan_user_inbox
+
+    test_user.access_token = "at"
+    test_user.m365_connected = True
+    test_user.m365_error_reason = REASON_TRANSIENT
+    db_session.commit()
+
+    _patch_successful_scan(monkeypatch)
+    await _scan_user_inbox(test_user, db_session)
+
+    db_session.refresh(test_user)
+    assert test_user.m365_error_reason is None
+    assert test_user.last_inbox_scan is not None
+
+
+async def test_successful_scan_keeps_subscription_warning(db_session, test_user, monkeypatch):
+    """A mailbox poll says nothing about Graph webhook health — the separate
+    subscription warning must survive a successful scan."""
+    from app.jobs.email_jobs import _scan_user_inbox
+
+    test_user.access_token = "at"
+    test_user.m365_connected = True
+    test_user.m365_error_reason = REASON_SUBSCRIPTION
+    db_session.commit()
+
+    _patch_successful_scan(monkeypatch)
+    await _scan_user_inbox(test_user, db_session)
+
+    db_session.refresh(test_user)
+    assert test_user.m365_error_reason == REASON_SUBSCRIPTION

--- a/tests/test_profile_render.py
+++ b/tests/test_profile_render.py
@@ -61,6 +61,47 @@ def test_mailbox_card_disconnected_empty_state(client, db_session, test_user):
     assert "Mailbox not connected" in html
 
 
+def test_mailbox_card_auth_error_shows_reconnect(client, db_session, test_user):
+    """A dead sign-in surfaces an actionable reconnect link, not a generic snag."""
+    from app.services.m365_status import REASON_AUTH
+
+    test_user.m365_connected = True
+    test_user.access_token = "tok"
+    test_user.token_expires_at = None
+    test_user.m365_error_reason = REASON_AUTH
+    db_session.commit()
+    html = _html(client)
+    assert 'href="/auth/login"' in html
+    assert "Reconnect Microsoft 365" in html
+    # the old generic copy is gone
+    assert "hit a snag" not in html.lower()
+
+
+def test_mailbox_card_transient_error_no_reconnect(client, db_session, test_user):
+    """A transient error reads as self-healing — no reconnect, no raw text, no snag."""
+    from app.services.m365_status import REASON_TRANSIENT
+
+    test_user.m365_connected = True
+    test_user.access_token = "tok"
+    test_user.token_expires_at = None
+    test_user.m365_error_reason = REASON_TRANSIENT
+    db_session.commit()
+    html = _html(client)
+    assert REASON_TRANSIENT in html
+    assert "hit a snag" not in html.lower()
+    # transient must not push the user to reconnect
+    assert "Reconnect Microsoft 365" not in html
+
+
+def test_mailbox_card_never_shows_generic_snag(client, db_session, test_user):
+    """Regression: the generic 'we hit a snag' banner is fully retired."""
+    test_user.m365_connected = True
+    test_user.m365_error_reason = "Inbox scan timed out"  # legacy raw value
+    db_session.commit()
+    html = _html(client)
+    assert "hit a snag" not in html.lower()
+
+
 def test_name_with_quotes_does_not_break_alpine_attr(client, db_session, test_user):
     # tojson escapes ' and " so a tricky name stays inside the single-quoted x-data.
     test_user.name = 'O\'Brien "Co"'

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -89,7 +89,10 @@ class TestGetValidToken:
             result = await get_valid_token(user, db)
 
         assert result is None
-        assert user.m365_error_reason == "Token refresh failed"
+        # A dead refresh token → actionable "reconnect" reason, not a raw string.
+        from app.services.m365_status import REASON_AUTH
+
+        assert user.m365_error_reason == REASON_AUTH
 
 
 class TestRefreshUserToken:


### PR DESCRIPTION
**Root cause (status-presentation, not a Graph outage):** the mailbox-sync card showed 'We hit a snag syncing your mailbox: {error}. Try reconnecting…' whenever `User.m365_error_reason` was set, but two writers (token-refresh job, inbox-scan error path) stored raw `str(exception)[:255]` — so any transient Graph timeout/5xx/parse error leaked a developer string into a scary banner with a 'reconnect' CTA that fixes none of those. Worse, the field was **latched**: only cleared on a successful token refresh or subscription renewal — a successful inbox scan never cleared it, so a self-healed error kept showing next to 'health: ok / just now'. (The page never crashed — purely an inaccurate, raw, sticky message + wrong CTA.) **Fix:** new `app/services/m365_status.py` classifies failures into AUTH→reconnect / TRANSIENT→self-heals / SUBSCRIPTION→info; all 4 writers route through it (no raw exception text reaches the UI); the card shows the accurate reason + a real 'Reconnect Microsoft 365' link only when reconnect is the actual fix, else an amber self-healing note; a successful poll now clears self-healed reasons; the disconnected state gets a real Connect button. 440 tests + 16 new m365_status cases (graceful Graph-error / missing-token / unhealthy-subscription / scan-clears-stale) + static-analysis green; pre-commit clean.