### PR TITLE
fix(materials): remove the needs-review flag (no purpose)

### DIFF
--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1240,8 +1240,6 @@ Alpine.data('materialsFilter', () => ({
   rohs: [],
   condition: [],
   hasDatasheet: false,
-  // Review queue — has_validation_conflict (authoritative evidence contradicts a manual value).
-  needsReview: false,
   // Sourcing signals (Layer-3 operational filters) — MaterialCard + vendor history.
   hasStock: false,
   hasPrice: false,
@@ -1349,7 +1347,6 @@ Alpine.data('materialsFilter', () => ({
     count += this.rohs.length;
     count += this.condition.length;
     if (this.hasDatasheet) count += 1;
-    if (this.needsReview) count += 1;
     count += this.sourcingActiveCount;
     return count;
   },
@@ -1358,7 +1355,6 @@ Alpine.data('materialsFilter', () => ({
   get attributesActiveCount() {
     return this.lifecycle.length + this.rohs.length + this.condition.length
       + (this.hasDatasheet ? 1 : 0)
-      + (this.needsReview ? 1 : 0)
       + (Array.isArray(this.subFilters.manufacturers) ? this.subFilters.manufacturers.length : 0);
   },
 
@@ -1370,7 +1366,6 @@ Alpine.data('materialsFilter', () => ({
     this.rohs = [];
     this.condition = [];
     this.hasDatasheet = false;
-    this.needsReview = false;
     this.hasStock = false;
     this.hasPrice = false;
     this.hasCrosses = false;
@@ -1436,7 +1431,6 @@ Alpine.data('materialsFilter', () => ({
       this.rohs = (params.get('rohs') || '').split(',').filter(s => s !== '');
       this.condition = (params.get('condition') || '').split(',').filter(s => s !== '');
       this.hasDatasheet = params.get('has_datasheet') === 'true';
-      this.needsReview = params.get('has_validation_conflict') === 'true';
       this.hasStock = params.get('has_stock') === 'true';
       this.hasPrice = params.get('has_price') === 'true';
       this.hasCrosses = params.get('has_crosses') === 'true';
@@ -1490,7 +1484,6 @@ Alpine.data('materialsFilter', () => ({
       this.rohs = [];
       this.condition = [];
       this.hasDatasheet = false;
-      this.needsReview = false;
       this.hasStock = false;
       this.hasPrice = false;
       this.hasCrosses = false;
@@ -1513,7 +1506,6 @@ Alpine.data('materialsFilter', () => ({
     if (this.rohs.length > 0) params.set('rohs', this.rohs.join(','));
     if (this.condition.length > 0) params.set('condition', this.condition.join(','));
     if (this.hasDatasheet) params.set('has_datasheet', 'true');
-    if (this.needsReview) params.set('has_validation_conflict', 'true');
     if (this.hasStock) params.set('has_stock', 'true');
     if (this.hasPrice) params.set('has_price', 'true');
     if (this.hasCrosses) params.set('has_crosses', 'true');
@@ -1564,12 +1556,6 @@ Alpine.data('materialsFilter', () => ({
 
   toggleDatasheet() {
     this.hasDatasheet = !this.hasDatasheet;
-    if (window.innerWidth >= 1024) this.applyFilters();
-  },
-
-  // Review-queue toggle — has_validation_conflict (needs human conflict review).
-  toggleNeedsReview() {
-    this.needsReview = !this.needsReview;
     if (window.innerWidth >= 1024) this.applyFilters();
   },
 

--- a/app/templates/htmx/partials/materials/detail.html
+++ b/app/templates/htmx/partials/materials/detail.html
@@ -39,16 +39,6 @@
             RoHS: {{ card.rohs_status|capitalize }}
           </span>
           {% endif %}
-          {% if card.has_validation_conflict %}
-          {% set conflict_count = (card.validation_conflicts or [])|length %}
-          <span class="inline-flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium rounded-full border bg-amber-50 text-amber-700 border-amber-200"
-                title="An authoritative source contradicts a manual value — see Specifications">
-            <svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20">
-              <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
-            </svg>
-            Needs review — {{ conflict_count }} conflict{{ '' if conflict_count == 1 else 's' }}
-          </span>
-          {% endif %}
         </div>
         {% if card.description %}
         <p class="text-sm text-gray-600 mt-2">{{ card.description }}</p>

--- a/app/templates/htmx/partials/materials/filters/global.html
+++ b/app/templates/htmx/partials/materials/filters/global.html
@@ -7,8 +7,6 @@
 {% set rohs_counts = global_facet_counts.get('rohs', {}) %}
 {% set condition_counts = global_facet_counts.get('condition', {}) %}
 {% set ds_count = global_facet_counts.get('has_datasheet', {}).get('true', 0) %}
-{% set nr_count = global_facet_counts.get('needs_review', {}).get('true', 0) %}
-
 {# Lifecycle facet — stored values: active|eol|obsolete|nrfnd|ltb (NRND→nrfnd) #}
 {% set lifecycle_opts = [
   ('active', 'Active'), ('nrfnd', 'NRND'), ('eol', 'EOL'),
@@ -91,22 +89,6 @@
            class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 h-3.5 w-3.5">
     <span class="text-gray-700 truncate flex-1 text-[13px]">Has datasheet</span>
     <span class="text-[11px] text-gray-400 tabular-nums">{{ ds_count }}</span>
-  </label>
-</div>
-{% endif %}
-
-{# Needs-review toggle — has_validation_conflict (an authoritative source contradicts
-   a manual value). Hidden until conflicts exist, matching the Datasheet toggle. #}
-{% if nr_count > 0 %}
-<div class="mb-3">
-  <h4 class="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-1.5">Review</h4>
-  <label class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer text-sm">
-    <input aria-label="Only parts needing conflict review" type="checkbox"
-           :checked="needsReview"
-           @change="toggleNeedsReview()"
-           class="rounded border-gray-300 text-brand-600 focus:ring-brand-500 h-3.5 w-3.5">
-    <span class="text-gray-700 truncate flex-1 text-[13px]">Needs review</span>
-    <span class="text-[11px] text-gray-400 tabular-nums">{{ nr_count }}</span>
   </label>
 </div>
 {% endif %}

--- a/app/templates/htmx/partials/materials/workspace.html
+++ b/app/templates/htmx/partials/materials/workspace.html
@@ -110,7 +110,6 @@
              "rohs": (Alpine.evaluate(document.querySelector("#materials-workspace"), "rohs") || []).join(","),
              "condition": (Alpine.evaluate(document.querySelector("#materials-workspace"), "condition") || []).join(","),
              "has_datasheet": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasDatasheet") || false,
-             "has_validation_conflict": Alpine.evaluate(document.querySelector("#materials-workspace"), "needsReview") || false,
              "has_stock": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasStock") || false,
              "has_price": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasPrice") || false,
              "has_crosses": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasCrosses") || false,
@@ -243,7 +242,6 @@
                  "rohs": (Alpine.evaluate(document.querySelector("#materials-workspace"), "rohs") || []).join(","),
                  "condition": (Alpine.evaluate(document.querySelector("#materials-workspace"), "condition") || []).join(","),
                  "has_datasheet": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasDatasheet") || false,
-                 "has_validation_conflict": Alpine.evaluate(document.querySelector("#materials-workspace"), "needsReview") || false,
                  "has_stock": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasStock") || false,
                  "has_price": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasPrice") || false,
                  "has_crosses": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasCrosses") || false,
@@ -274,7 +272,7 @@
   <div class="flex-1 min-w-0 relative">
 
     {# ── Compact page header — Three-Second-Rule anchor ─────────────────
-       "Where am I?" — title + active-commodity breadcrumb + Needs review attention chip.
+       "Where am I?" — title + active-commodity breadcrumb.
        Sits above the search bar so it's always visible without scrolling. #}
     <div class="px-3 pt-3 pb-1 flex items-center justify-between border-b border-line-subtle">
       <div class="flex items-center gap-2 min-w-0">
@@ -288,15 +286,6 @@
           </span>
         </template>
       </div>
-      {# Needs-review attention chip — surfaces validation-conflict queue as glanceable one-click action #}
-      <button @click="needsReview = !needsReview; applyFilters()"
-              :class="needsReview ? 'bg-amber-100 text-amber-800 border-amber-300' : 'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100'"
-              class="flex items-center gap-1 px-2 py-0.5 text-[11px] font-medium border rounded-full transition-colors flex-shrink-0">
-        <svg class="w-3 h-3 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-          <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
-        </svg>
-        Needs review
-      </button>
     </div>
 
     {# Search bar + mobile filter button #}
@@ -356,7 +345,7 @@
       <div id="ai-script-container"></div>
 
       {# Active filter chips #}
-      <template x-if="commodity || q || Object.keys(subFilters).length > 0 || confidenceNarrowed || lifecycle.length > 0 || rohs.length > 0 || condition.length > 0 || hasDatasheet || needsReview || sourcingActiveCount > 0" x-cloak>
+      <template x-if="commodity || q || Object.keys(subFilters).length > 0 || confidenceNarrowed || lifecycle.length > 0 || rohs.length > 0 || condition.length > 0 || hasDatasheet || sourcingActiveCount > 0" x-cloak>
         <div class="flex flex-wrap gap-1.5 mt-2">
           <template x-if="q" x-cloak>
             {{ removable_chip('Search: <span x-text="q"></span>', 'blue', "q = ''; applyFilters()") }}
@@ -380,10 +369,6 @@
           {# Has-datasheet chip #}
           <template x-if="hasDatasheet" x-cloak>
             {{ removable_chip('Has datasheet', 'gray', 'hasDatasheet = false; applyFilters()') }}
-          </template>
-          {# Needs-review chip — validation-conflict review queue #}
-          <template x-if="needsReview" x-cloak>
-            {{ removable_chip('Needs review', 'amber', 'needsReview = false; applyFilters()') }}
           </template>
           {# Sourcing-signal chips #}
           <template x-if="hasStock" x-cloak>
@@ -439,7 +424,6 @@
            "rohs": (Alpine.evaluate(document.querySelector("#materials-workspace"), "rohs") || []).join(","),
            "condition": (Alpine.evaluate(document.querySelector("#materials-workspace"), "condition") || []).join(","),
            "has_datasheet": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasDatasheet") || false,
-           "has_validation_conflict": Alpine.evaluate(document.querySelector("#materials-workspace"), "needsReview") || false,
            "has_stock": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasStock") || false,
            "has_price": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasPrice") || false,
            "has_crosses": Alpine.evaluate(document.querySelector("#materials-workspace"), "hasCrosses") || false,

--- a/tests/test_on_add_enrichment.py
+++ b/tests/test_on_add_enrichment.py
@@ -3,7 +3,7 @@
 Covers: POST /api/materials/add (manual/100 writes, blank=blank, inline deterministic
 passes, priority-lane stamp, V3 422 validation), bulk part-number / stock imports
 (inline passes, per-row warnings, NO stamp), the enrich-status badge route (HTTP 286
-stop), the add-form modal route, and the needs-review faceted filter.
+stop), the add-form modal route, and the has_validation_conflict faceted filter.
 Depends on: conftest.py (db_session, client), commodity_registry seeds.
 """
 
@@ -448,7 +448,25 @@ def test_detail_renders_conflict_badge_and_accept(client, db_session: Session):
 
     resp = client.get(f"/v2/partials/materials/{card.id}")
     assert resp.status_code == 200
-    assert "Needs review" in resp.text
-    assert "1 conflict" in resp.text
+    assert "Needs review" not in resp.text
     assert f"/v2/partials/materials/{card.id}/conflicts/category/accept" in resp.text
+    assert "Use this value" in resp.text
+
+
+def test_needs_review_badge_not_in_detail(client, db_session: Session):
+    """Confirm the 'Needs review' badge is not rendered even when
+    has_validation_conflict=True."""
+    card = _make_card(
+        db_session,
+        "review-003",
+        "REVIEW-003",
+        has_validation_conflict=True,
+        validation_conflicts=[_category_conflict()],
+    )
+    db_session.commit()
+
+    resp = client.get(f"/v2/partials/materials/{card.id}")
+    assert resp.status_code == 200
+    # Badge removed — conflict detail panel (Specs section) still renders
+    assert "Needs review" not in resp.text
     assert "Use this value" in resp.text


### PR DESCRIPTION
Removes the 'needs review' flag from the Materials page. It was field-backed by `MaterialCard.has_validation_conflict` (set by the spec-tier ladder when an authoritative source contradicts a manually-set value), surfaced in 3 places: a header attention chip, a sidebar 'Review' filter toggle, and a detail-panel badge. All three UI surfaces + the Alpine `needsReview` state/methods/URL-sync are removed. **Kept:** the conflict-detail panel + 'Use this value' buttons in Specs (the actual resolution tooling). **DB untouched:** the `has_validation_conflict`/`validation_conflicts` columns + `ix_material_cards_needs_review` index are left in place — still written by spec_tiers.py, now unread by the UI; flagged as a follow-up migration candidate (don't drop without removing the writers too). 49 tests green; pre-commit clean.