### PR TITLE
fix(connectors): worker-aware status (Worker active/down from heartbeat, not hardcoded Live)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -14392,6 +14392,22 @@ def _build_connector_field(db, source_name: str, env_var: str) -> dict:
     return {"is_set": is_set, "masked": masked}
 
 
+def _worker_status_row(source_name: str, db):
+    """Return the worker-status singleton for a worker-backed source (or None).
+
+    Maps an ApiSource.name (thebrokersite/netcomponents/icsource) to its heartbeat model
+    via connector_service.WORKER_BACKED_SOURCES, reading the id=1 singleton.
+    """
+    from ..models import IcsWorkerStatus, NcWorkerStatus, TbfWorkerStatus
+    from ..services import connector_service
+
+    worker_key = connector_service.WORKER_BACKED_SOURCES.get(source_name)
+    model = {"tbf": TbfWorkerStatus, "nc": NcWorkerStatus, "ics": IcsWorkerStatus}.get(worker_key)
+    if model is None:
+        return None
+    return db.get(model, 1)
+
+
 def _enrich_source(source, db) -> dict:
     """Build the per-source context dict for the connectors tab."""
     from ..services import connector_service
@@ -14413,12 +14429,18 @@ def _enrich_source(source, db) -> dict:
         oauth_connected = False
         needs_reconnect = False
 
+    # Worker-backed sources: derive status from the worker heartbeat, not a direct API.
+    worker = None
+    if connector_service.is_worker_backed(source):
+        worker = connector_service.worker_health(_worker_status_row(name, db))
+
     state = connector_service.connector_state(
         source,
         credential_set=credential_set,
         oauth_connected=oauth_connected,
         needs_reconnect=needs_reconnect,
         keyless=keyless,
+        worker=worker,
     )
 
     # Keyless note
@@ -14430,11 +14452,14 @@ def _enrich_source(source, db) -> dict:
     else:
         keyless_note = ""
 
-    # Planned connectors are never testable — they have no implementation yet.
-    if ct == "planned":
+    # Testability:
+    #  - planned: never (no implementation yet)
+    #  - worker-backed: never via the API-probe Test button — health is the heartbeat,
+    #    not a synchronous search (the worker runs out-of-process on a schedule)
+    #  - else: has some form of access
+    if ct == "planned" or worker is not None:
         testable = False
     else:
-        # Testable = has some form of access
         testable = bool(credential_set or oauth_connected or keyless)
 
     return {
@@ -14455,6 +14480,8 @@ def _enrich_source(source, db) -> dict:
         "error_count_24h": getattr(source, "error_count_24h", 0) or 0,
         "keyless_note": keyless_note,
         "testable": testable,
+        # Worker-backed health (None for direct-API/keyless/oauth sources).
+        "worker": worker,
     }
 
 

--- a/app/services/connector_service.py
+++ b/app/services/connector_service.py
@@ -3,9 +3,18 @@
 Pure helpers (no DB/IO): collapse an ApiSource's credentials + is_active + health
 status into one display `state`, and classify its control type + display group.
 
+Worker-backed sources (the browser-automation scrapers — TBF / NetComponents / ICsource)
+have no direct API to ping: their work is done by a host systemd worker that writes a
+heartbeat row. For these, status is computed from the worker heartbeat (worker_health)
+rather than from credentials, so a worker-served source NEVER shows "no API"/"needs
+setup"/"broken" just because it lacks a direct API key — it shows the worker's real
+health (Worker active vs Worker down).
+
 Called by: app/routers/htmx_views.py (settings_connectors_tab, connector_card_partial),
-app/routers/sources.py (test-all). Depends on: nothing.
+app/routers/sources.py (test-all). Depends on: nothing (heartbeat row is passed in).
 """
+
+from datetime import datetime, timezone
 
 GROUP_ORDER: list[tuple[str, str]] = [
     ("part_sourcing", "Part Sourcing"),
@@ -19,6 +28,24 @@ GROUP_ORDER: list[tuple[str, str]] = [
 _OAUTH_CLAY = {"clay_enrichment"}
 _MULTI_FIELD = {"eight_by_eight"}
 _BROWSER = {"icsource", "netcomponents", "thebrokersite"}
+
+# Explicit worker→source mapping. Each browser-backed source is served by a host
+# systemd worker (avail-<key>-worker.service) that writes a heartbeat singleton row.
+# The Connectors page reads that heartbeat to show the worker's real health instead of
+# pinging a (non-existent) direct API. Keyed by ApiSource.name → short worker key used
+# by the worker-status models / admin endpoint.
+WORKER_BACKED_SOURCES: dict[str, str] = {
+    "thebrokersite": "tbf",
+    "netcomponents": "nc",
+    "icsource": "ics",
+}
+
+# A worker heartbeat older than this is treated as stalled (the worker crashed or
+# wedged). Mirrors settings.worker_heartbeat_stale_minutes (15) and the admin
+# /api/admin/workers/status threshold. Kept here as a module default so the pure helper
+# needs no settings import; the caller may override via stale_seconds=.
+WORKER_HEARTBEAT_STALE_SECONDS = 15 * 60
+
 _SCOPES = {"azure_oauth", "teams_notifications"}
 _AI = {"anthropic_ai", "ai_live_web"}
 _MANUAL = {"stock_list_import"}
@@ -73,12 +100,91 @@ def is_keyless(source) -> bool:
     return control_type(source) in ("keyless", "scopes") or not (source.env_vars or [])
 
 
+def is_worker_backed(source) -> bool:
+    """Return True when a host worker (not a direct API) serves this source."""
+    return source.name in WORKER_BACKED_SOURCES
+
+
+def worker_health(row, *, now: datetime | None = None, stale_seconds: int = WORKER_HEARTBEAT_STALE_SECONDS) -> dict:
+    """Collapse a worker-status heartbeat row into a health verdict (pure, no IO).
+
+    `row` is a *WorkerStatus singleton (TbfWorkerStatus / NcWorkerStatus / IcsWorkerStatus)
+    or None when the row is absent. Returns a dict the connectors UI renders directly:
+
+        healthy            — bool: heartbeat recent, running, breaker closed
+        heartbeat_age_secs — int | None: seconds since last heartbeat (None if never)
+        last_search_at     — datetime | None: last completed search (worker's "last run")
+        problem            — str | None: human-readable reason it's unhealthy (else None)
+
+    Unhealthy when: no row / no heartbeat / heartbeat stale / not running / breaker open.
+    """
+    now = now or datetime.now(timezone.utc)
+    if row is None:
+        return {
+            "healthy": False,
+            "heartbeat_age_secs": None,
+            "last_search_at": None,
+            "problem": "Worker has never reported in",
+        }
+
+    hb = row.last_heartbeat
+    age = None
+    if hb is not None:
+        hb = hb if hb.tzinfo else hb.replace(tzinfo=timezone.utc)
+        age = int((now - hb).total_seconds())
+
+    last_search_at = getattr(row, "last_search_at", None)
+    out = {"healthy": False, "heartbeat_age_secs": age, "last_search_at": last_search_at, "problem": None}
+
+    if getattr(row, "circuit_breaker_open", False):
+        out["problem"] = (getattr(row, "circuit_breaker_reason", None) or "").strip() or "Circuit breaker open"
+        return out
+    if age is None:
+        out["problem"] = "Worker has never sent a heartbeat"
+        return out
+    if not getattr(row, "is_running", False):
+        out["problem"] = "Worker is not running"
+        return out
+    if age > stale_seconds:
+        mins = age // 60
+        out["problem"] = f"No heartbeat for {mins} min — worker stalled"
+        return out
+
+    out["healthy"] = True
+    return out
+
+
 def connector_state(
-    source, *, credential_set: bool, oauth_connected: bool, needs_reconnect: bool, keyless: bool
+    source,
+    *,
+    credential_set: bool,
+    oauth_connected: bool,
+    needs_reconnect: bool,
+    keyless: bool,
+    worker: dict | None = None,
 ) -> str:
+    """Return the display state for a connector.
+
+    For worker-backed sources (TBF / NetComponents / ICsource) the state is derived
+    from the worker heartbeat verdict (`worker`, from worker_health()) — NOT from
+    credentials — so a worker-served source never reads as "needs_setup"/"error" just
+    for lacking a direct API key:
+        worker_active — worker healthy (recent heartbeat, running, breaker closed)
+        worker_down   — worker stalled / not running / breaker open / no heartbeat
+        off           — the source is switched off by the operator (is_active=False)
+    """
     # Planned connectors surface as a distinct "planned" state — no other checks apply.
     if control_type(source) == "planned":
         return "planned"
+
+    # Worker-backed sources: health comes from the worker heartbeat, not from a key.
+    if is_worker_backed(source):
+        if not source.is_active:
+            return "off"
+        if worker and worker.get("healthy"):
+            return "worker_active"
+        return "worker_down"
+
     if needs_reconnect:
         return "needs_reconnect"
     has_access = credential_set or oauth_connected or keyless

--- a/app/templates/htmx/partials/settings/_connector_macros.html
+++ b/app/templates/htmx/partials/settings/_connector_macros.html
@@ -16,7 +16,9 @@
 {% macro state_badge(s) %}
 {%- set _states = {
   'live':           ('bg-green-100 text-green-800', 'bg-green-500',   'Live'),
+  'worker_active':  ('bg-green-100 text-green-800', 'bg-green-500',   'Worker active'),
   'error':          ('bg-red-100 text-red-800',     'bg-red-500',     'Error'),
+  'worker_down':    ('bg-red-100 text-red-800',     'bg-red-500',     'Worker down'),
   'off':            ('bg-gray-100 text-gray-600',   'bg-gray-400',    'Off'),
   'needs_setup':    ('bg-amber-100 text-amber-800', 'bg-amber-500',   'Needs setup'),
   'needs_reconnect':('bg-amber-100 text-amber-800', 'bg-amber-500',   'Needs reconnect'),
@@ -32,6 +34,8 @@
 
 {% macro _state_help(state) -%}
 {%- if state == 'live' -%}Connected, on, and answering
+{%- elif state == 'worker_active' -%}A background worker is doing the searching — it's running and reporting in
+{%- elif state == 'worker_down' -%}A background worker does the searching, but it has stopped reporting in — see the note below
 {%- elif state == 'off' -%}Set up and ready, but switched off
 {%- elif state == 'untested' -%}Credentials saved but not checked yet — run Test
 {%- elif state == 'needs_setup' -%}Add credentials to turn this on
@@ -39,6 +43,26 @@
 {%- elif state == 'error' -%}Last check failed
 {%- elif state == 'planned' -%}Connector on the roadmap — not built yet
 {%- endif -%}
+{%- endmacro %}
+
+{# ── Worker-backed health detail ─────────────────────────────────────── #}
+{# Renders the verified worker health for browser-backed sources (TBF / NetComponents
+   / ICsource): "Worker active" with the heartbeat age + last successful search, or
+   the specific problem when the worker has stalled. s.worker is the worker_health()
+   verdict dict ({healthy, heartbeat_age_secs, last_search_at, problem}) or None. #}
+{% macro worker_detail(s) -%}
+{%- set w = s.worker -%}
+{%- if w %}
+  {% if w.healthy %}
+  <p class="text-xs text-green-700">
+    Worker active — last reported in
+    {%- if w.heartbeat_age_secs is not none %} {{ w.heartbeat_age_secs // 60 if w.heartbeat_age_secs >= 60 else w.heartbeat_age_secs }}{{ ' min' if w.heartbeat_age_secs >= 60 else ' sec' }} ago{% else %} just now{% endif %}.
+    {% if w.last_search_at %}Last search {{ w.last_search_at.strftime('%b %d, %H:%M UTC') }}.{% else %}No searches completed yet.{% endif %}
+  </p>
+  {% else %}
+  <p class="text-xs text-red-600">Worker down — {{ w.problem or 'worker is not reporting in' }}.</p>
+  {% endif %}
+{%- endif %}
 {%- endmacro %}
 
 {# ── Inline spinner (respects prefers-reduced-motion) ────────────────── #}
@@ -147,7 +171,7 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
                {% if s.state == 'needs_setup' %}disabled{% endif %}
                hx-put="/api/sources/{{ s.id }}/activate"
                hx-trigger="change"
-               {% if s.state == 'live' %}hx-confirm='Turn off {{ s.display_name|e }}? Searches will return fewer results until it&#39;s back on.'{% endif %}
+               {% if s.state in ('live', 'worker_active') %}hx-confirm='Turn off {{ s.display_name|e }}? Searches will return fewer results until it&#39;s back on.'{% endif %}
                hx-target="#connector-card-{{ s.id }}"
                hx-swap="none"
                {{ _refresh_attr(s) }}
@@ -210,9 +234,11 @@ hx-on::after-request='if(event.detail.successful){htmx.ajax("GET","/v2/partials/
     </div>
 
   {% elif s.control_type == 'browser_login' %}
-    {% if s.state == 'needs_setup' %}
-    <p class="text-xs text-gray-500">Sign in with your {{ s.display_name }} account so the worker can search for you</p>
-    {% endif %}
+    {# Worker-backed: health is the worker heartbeat, not a direct API. Only surface the
+       worker verdict when the source is switched on (worker_active / worker_down); an
+       operator-disabled source reads 'Off' and shows no worker note. #}
+    {% if s.state in ('worker_active', 'worker_down') %}{{ worker_detail(s) }}{% endif %}
+    <p class="text-xs text-gray-500">A background worker signs in to {{ s.display_name }} and searches for you. Update the login it uses below.</p>
     <div class="space-y-2">
       {% for ev, field in s.creds.items() %}
         {{ key_field(s, ev, field) }}

--- a/app/templates/htmx/partials/settings/connectors.html
+++ b/app/templates/htmx/partials/settings/connectors.html
@@ -8,10 +8,13 @@
 <title hx-swap-oob="true">Connectors · Settings</title>
 {% import 'htmx/partials/settings/_connector_macros.html' as cm %}
 
+{# "live" counts working connectors: direct-API live + worker-backed healthy.
+   "need setup" counts everything not working and not deliberately off (incl. worker_down). #}
+{%- set _ok_states = ['live', 'worker_active'] -%}
 {%- set _all = [] -%}
 {%- for g in connector_groups %}{% for s in g.sources %}{{ _all.append(s) or '' }}{% endfor %}{% endfor -%}
-{%- set _live = _all | selectattr('state', 'equalto', 'live') | list | length -%}
-{%- set _needs = _all | rejectattr('state', 'in', ['live', 'off']) | list | length -%}
+{%- set _live = _all | selectattr('state', 'in', _ok_states) | list | length -%}
+{%- set _needs = _all | rejectattr('state', 'in', _ok_states + ['off', 'planned']) | list | length -%}
 
 <div id="connectors-root" class="space-y-8" hx-ext="loading-states">
   <div class="flex items-start justify-between gap-4 mb-2">
@@ -59,8 +62,8 @@
   {% endif %}
 
   {% for group in connector_groups %}
-  {%- set g_live = group.sources | selectattr('state', 'equalto', 'live') | list | length -%}
-  {%- set g_needs = group.sources | rejectattr('state', 'in', ['live', 'off']) | list | length -%}
+  {%- set g_live = group.sources | selectattr('state', 'in', _ok_states) | list | length -%}
+  {%- set g_needs = group.sources | rejectattr('state', 'in', _ok_states + ['off', 'planned']) | list | length -%}
   <section id="connector-group-{{ group.key }}" x-data="{ open: true }">
     <button type="button" @click="open = !open"
             class="w-full flex items-center justify-between gap-2 min-h-[2rem] text-left group">

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -531,14 +531,37 @@ holds this set, and `run_health_checks` excludes those names from the
 ping loop. Their `api_sources` row is seeded to `LIVE` + `is_active=True`
 once at startup by `seed_browser_worker_sources` (see `app/startup.py`)
 and the seed survives because the ping loop never touches them. Their
-actual health is tracked via `IcsWorkerStatus` / `NcWorkerStatus`
-heartbeats; both singletons are seeded at startup so
+actual health is tracked via `IcsWorkerStatus` / `NcWorkerStatus` /
+`TbfWorkerStatus` heartbeats; all three singletons are seeded at startup so
 `update_worker_status()` writes are not silently dropped. Each worker
-(ics, nc, and enrichment) refreshes `last_heartbeat` on **every** loop
+(ics, nc, tbf, and enrichment) refreshes `last_heartbeat` on **every** loop
 tick via `_record_heartbeat()` at the top of the loop — so the heartbeat
 reflects process liveness independent of work, and stays fresh on idle /
 cap-sleep / breaker-open / off-hours paths (a liveness monitor reading
 `last_heartbeat` won't false-alarm "DOWN" while a worker is merely paused).
+
+**Worker-aware Connectors-page status.** The Settings → Connectors page must
+NOT render a worker-backed source as "broken"/"no API"/"needs setup" just
+because it has no direct API key. `connector_service.is_worker_backed()` (the
+explicit `WORKER_BACKED_SOURCES` map: `thebrokersite`→tbf, `netcomponents`→nc,
+`icsource`→ics) routes these sources through `connector_service.worker_health()`
+instead of the key/credential ladder. `worker_health(row)` reads the heartbeat
+singleton and returns a verdict (`healthy`, `heartbeat_age_secs`,
+`last_search_at`, `problem`); a worker is **unhealthy** when the row is missing,
+the heartbeat is absent or older than `settings.worker_heartbeat_stale_minutes`
+(15 min, same threshold as `/api/admin/workers/status`), `is_running` is false,
+or the circuit breaker is open. `connector_state()` then yields two
+worker-specific states for active worker sources — `worker_active` (badge
+"Worker active" + heartbeat age + last search) and `worker_down` (badge "Worker
+down" + the specific problem) — or `off` when the operator has switched the
+source off. Worker-backed sources are never offered the synchronous API "Test"
+button (their health is the heartbeat, not a request/response probe). The
+header/group live-vs-need-setup counters treat `worker_active` as live and
+`worker_down` as needing attention. Logic in `app/services/connector_service.py`;
+heartbeat read + enrich in `htmx_views._enrich_source` /
+`_worker_status_row`; rendering in `settings/_connector_macros.html`
+(`worker_detail` macro). Tests: `tests/test_connector_service.py` (pure
+verdict/state) and `tests/test_connectors_settings.py` (rendered badges).
 
 ### Removed (2026-05-14)
 

--- a/tests/test_connector_service.py
+++ b/tests/test_connector_service.py
@@ -1,7 +1,21 @@
 # tests/test_connector_service.py
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 from app.services import connector_service as cs
+
+
+def _worker_row(**kw):
+    """A worker-status singleton row (TbfWorkerStatus-shaped) for worker_health()."""
+    base = dict(
+        is_running=True,
+        last_heartbeat=datetime.now(timezone.utc),
+        last_search_at=None,
+        circuit_breaker_open=False,
+        circuit_breaker_reason=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
 
 
 def _src(**kw):
@@ -202,3 +216,139 @@ def test_connector_state_planned_ignores_active_flag():
         keyless=False,
     )
     assert result == "planned"
+
+
+# ── Worker-aware status (TBF / NetComponents / ICsource browser workers) ──────
+
+
+def test_worker_backed_sources_mapping():
+    """The three browser-worker sources map to their worker keys; others don't."""
+    for name in ("thebrokersite", "netcomponents", "icsource"):
+        assert cs.is_worker_backed(_src(name=name))
+        assert name in cs.WORKER_BACKED_SOURCES
+    assert not cs.is_worker_backed(_src(name="nexar"))
+    assert not cs.is_worker_backed(_src(name="mouser"))
+    assert cs.WORKER_BACKED_SOURCES == {"thebrokersite": "tbf", "netcomponents": "nc", "icsource": "ics"}
+
+
+def test_worker_health_healthy_recent_heartbeat():
+    """Running worker with a fresh heartbeat and closed breaker is healthy."""
+    v = cs.worker_health(_worker_row(last_heartbeat=datetime.now(timezone.utc) - timedelta(seconds=30)))
+    assert v["healthy"] is True
+    assert v["problem"] is None
+    assert v["heartbeat_age_secs"] is not None and v["heartbeat_age_secs"] < 120
+
+
+def test_worker_health_stale_heartbeat_unhealthy():
+    """A heartbeat older than the stale threshold is unhealthy with a 'stalled'
+    reason."""
+    old = datetime.now(timezone.utc) - timedelta(minutes=40)
+    v = cs.worker_health(_worker_row(last_heartbeat=old))
+    assert v["healthy"] is False
+    assert "stalled" in v["problem"].lower()
+
+
+def test_worker_health_not_running_unhealthy():
+    v = cs.worker_health(_worker_row(is_running=False))
+    assert v["healthy"] is False
+    assert "not running" in v["problem"].lower()
+
+
+def test_worker_health_circuit_breaker_open_unhealthy():
+    v = cs.worker_health(_worker_row(circuit_breaker_open=True, circuit_breaker_reason="Blocked by site"))
+    assert v["healthy"] is False
+    assert v["problem"] == "Blocked by site"
+
+
+def test_worker_health_missing_row_unhealthy():
+    v = cs.worker_health(None)
+    assert v["healthy"] is False
+    assert v["problem"]
+    assert v["heartbeat_age_secs"] is None
+
+
+def test_worker_health_no_heartbeat_unhealthy():
+    v = cs.worker_health(_worker_row(last_heartbeat=None))
+    assert v["healthy"] is False
+    assert v["heartbeat_age_secs"] is None
+
+
+def test_worker_health_naive_datetime_is_treated_as_utc():
+    """A naive (tz-less) heartbeat must not crash — it's coerced to UTC."""
+    naive = (datetime.now(timezone.utc) - timedelta(seconds=20)).replace(tzinfo=None)
+    v = cs.worker_health(_worker_row(last_heartbeat=naive))
+    assert v["healthy"] is True
+
+
+def test_state_worker_active_when_worker_healthy():
+    """A worker-backed source with a healthy worker reads 'worker_active', not
+    'live'/'error'."""
+    src = _src(name="thebrokersite", env_vars=["TBF_USERNAME", "TBF_PASSWORD"], status="live", is_active=True)
+    state = cs.connector_state(
+        src,
+        credential_set=False,  # no direct key — must NOT matter
+        oauth_connected=False,
+        needs_reconnect=False,
+        keyless=False,
+        worker={"healthy": True},
+    )
+    assert state == "worker_active"
+
+
+def test_state_worker_down_when_worker_unhealthy():
+    """A worker-backed source whose worker is stalled reads 'worker_down', never
+    'live'."""
+    src = _src(name="netcomponents", env_vars=["NC_USERNAME"], status="live", is_active=True)
+    state = cs.connector_state(
+        src,
+        credential_set=True,
+        oauth_connected=False,
+        needs_reconnect=False,
+        keyless=False,
+        worker={"healthy": False, "problem": "No heartbeat for 40 min — worker stalled"},
+    )
+    assert state == "worker_down"
+
+
+def test_state_worker_backed_never_needs_setup_without_key():
+    """A keyless worker-backed source must NEVER read 'needs_setup' just for lacking a
+    key."""
+    src = _src(name="icsource", env_vars=[], status="pending", is_active=True)
+    state = cs.connector_state(
+        src,
+        credential_set=False,
+        oauth_connected=False,
+        needs_reconnect=False,
+        keyless=True,
+        worker={"healthy": True},
+    )
+    assert state == "worker_active"
+    assert state != "needs_setup"
+
+
+def test_state_worker_backed_off_when_inactive():
+    """An operator-disabled worker source reads 'off' (not worker_down)."""
+    src = _src(name="thebrokersite", status="live", is_active=False)
+    state = cs.connector_state(
+        src,
+        credential_set=True,
+        oauth_connected=False,
+        needs_reconnect=False,
+        keyless=False,
+        worker={"healthy": True},
+    )
+    assert state == "off"
+
+
+def test_keyless_direct_api_still_needs_setup_without_access():
+    """Regression guard: a NON-worker keyless/keyed source still surfaces needs_setup
+    when it has no access — the worker carve-out must not leak to direct APIs."""
+    src = _src(name="mouser", env_vars=["MOUSER_API_KEY"], status="pending", is_active=False)
+    state = cs.connector_state(
+        src,
+        credential_set=False,
+        oauth_connected=False,
+        needs_reconnect=False,
+        keyless=False,
+    )
+    assert state == "needs_setup"

--- a/tests/test_connectors_settings.py
+++ b/tests/test_connectors_settings.py
@@ -551,3 +551,102 @@ def test_header_and_group_use_consistent_vocab(admin_client):
     html = admin_client.get("/v2/partials/settings/connectors").text
     assert "need attention" not in html, "Header should use unified 'need setup' vocab"
     assert "need setup" in html or "needs setup" in html.lower()
+
+
+# ── Worker-aware status: browser-worker sources show worker health ────────
+
+
+def _set_active(db_session, name):
+    """Make a seeded ApiSource active (the connectors page only shows worker state for
+    active worker sources; inactive → 'off')."""
+    from app.models import ApiSource as AS
+
+    src = db_session.query(AS).filter_by(name=name).first()
+    assert src is not None, f"{name} must be seeded"
+    src.is_active = True
+    db_session.commit()
+    return src
+
+
+@pytest.fixture()
+def admin_client_worker_healthy(db_session, admin_user):
+    """Admin client with a HEALTHY NetComponents worker heartbeat seeded."""
+    from datetime import datetime, timezone
+
+    from app.models import NcWorkerStatus
+
+    _seed_sources(db_session)
+    _set_active(db_session, "netcomponents")
+    db_session.add(
+        NcWorkerStatus(
+            id=1,
+            is_running=True,
+            last_heartbeat=datetime.now(timezone.utc),
+            last_search_at=datetime.now(timezone.utc),
+            circuit_breaker_open=False,
+        )
+    )
+    db_session.commit()
+    yield from _make_admin_client(db_session, admin_user)
+
+
+@pytest.fixture()
+def admin_client_worker_stalled(db_session, admin_user):
+    """Admin client with a STALLED ICsource worker (heartbeat 40 min old)."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models import IcsWorkerStatus
+
+    _seed_sources(db_session)
+    _set_active(db_session, "icsource")
+    db_session.add(
+        IcsWorkerStatus(
+            id=1,
+            is_running=True,
+            last_heartbeat=datetime.now(timezone.utc) - timedelta(minutes=40),
+            circuit_breaker_open=False,
+        )
+    )
+    db_session.commit()
+    yield from _make_admin_client(db_session, admin_user)
+
+
+def test_worker_backed_source_shows_worker_active_not_broken(admin_client_worker_healthy):
+    """A worker-backed source with a healthy worker shows 'Worker active' — NOT
+    'Error'/'Needs setup'/'broken' — even though it has no direct API key."""
+    html = admin_client_worker_healthy.get("/v2/partials/settings/connectors").text
+    assert "Worker active" in html, "Expected 'Worker active' badge for a healthy worker source"
+    # The bug we are fixing: it must NOT read as broken/no-API/needs-setup.
+    assert "Worker down" not in html
+    # NetComponents card must not claim it needs an API key / setup.
+    assert "background worker" in html.lower(), "Expected worker explanation copy"
+
+
+def test_stalled_worker_shows_worker_down(admin_client_worker_stalled):
+    """A worker-backed source whose worker has stalled shows 'Worker down' + the
+    problem."""
+    html = admin_client_worker_stalled.get("/v2/partials/settings/connectors").text
+    assert "Worker down" in html, "Expected 'Worker down' badge for a stalled worker"
+    assert "stalled" in html.lower(), "Expected the stall reason to surface"
+    assert "Worker active" not in html
+
+
+def test_worker_source_has_no_api_test_button(admin_client_worker_healthy):
+    """Worker-backed sources are not testable via the synchronous API probe — their
+    health is the heartbeat, so no per-card Test button targets the NC source."""
+    html = admin_client_worker_healthy.get("/v2/partials/settings/connectors").text
+    # The NC card is rendered; assert it offers the worker login form, not an API test.
+    assert "Save login" in html, "Expected the browser-login Save form for the worker source"
+
+
+def test_keyless_direct_api_source_still_shows_needs_or_off(admin_client):
+    """Regression: a keyless DIRECT-API source (SAM.gov) is unaffected by the worker
+    carve-out — with no toggle on it renders 'Off' (keyless = has access, inactive)."""
+    html = admin_client.get("/v2/partials/settings/connectors").text
+    # SAM.gov is keyless + inactive in the seed → 'Off' (never 'Worker active').
+    assert "SAM.gov" in html
+    # Worker badges must only attach to the three browser-worker sources.
+    # SAM.gov is in the Enrichment group; it must not borrow a worker badge.
+    assert "Worker active" not in html and "Worker down" not in html, (
+        "Direct-API keyless source must not render a worker badge"
+    )


### PR DESCRIPTION
**Bug:** the three worker-backed sources (The Broker Forum, NetComponents, ICsource) rendered a **hardcoded 'Live'** set at boot by `seed_browser_worker_sources` — they never consulted the worker heartbeat. So a crashed/stalled worker showed green (false positive), and keyless NetComponents risked reading 'needs setup'/'broken' for lacking a direct API key. **Fix:** explicit `WORKER_BACKED_SOURCES = {thebrokersite:tbf, netcomponents:nc, icsource:ics}` + a `worker_health()` read of each worker's status table, producing four states — (a) direct API live, (b) direct API error/needs_setup, (c) **worker_active** (+ heartbeat age + last search), (d) **worker_down** (stalled: no heartbeat / not running / breaker open). Worker sources never show 'no API/broken' for lacking a key, aren't offered the synchronous API 'Test', and counters treat worker_active as live / worker_down as needs-attention (15-min stale threshold, matching /api/admin/workers/status). Full suite **20,527 passed**; live-verified against the prod DB (TBF/NC/ICS → worker_active w/ real heartbeats; Mouser→needs_setup; SAM.gov→off).