### PR TITLE
feat(reports): Activity Scorecard — per-user metrics, weighted score + leaderboard

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -11437,6 +11437,52 @@ async def settings_users_tab(
     return template_response("htmx/partials/settings/users.html", ctx)
 
 
+@router.get("/v2/partials/settings/scorecard", response_class=HTMLResponse)
+async def settings_scorecard_tab(
+    request: Request,
+    time_range: str = "this_month",
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Activity Scorecard tab — per-user activity leaderboard. Manager/admin only.
+
+    A leaderboard of all users' activity is oversight/performance data, so it is gated
+    to the supervisor tier (MANAGER + ADMIN) via is_manager_or_admin — buyers/sales/
+    traders never see it. On an HX-Request triggered by the time-range selector only the
+    table fragment is swapped; the first paint (and a direct hit) renders the full tab.
+    """
+    if not is_manager_or_admin(user):
+        raise HTTPException(403, "Managers and admins only")
+    from ..services.activity_scorecard import (
+        DEFAULT_TIME_RANGE,
+        TALK_TIME_BUCKET_SECONDS,
+        TIME_RANGE_LABELS,
+        TIME_RANGES,
+        compute_scorecard,
+        scoring_formula_parts,
+    )
+
+    if time_range not in TIME_RANGES:
+        time_range = DEFAULT_TIME_RANGE
+
+    ctx = _base_ctx(request, user, "settings")
+    ctx.update(
+        {
+            "rows": compute_scorecard(db, time_range),
+            "time_range": time_range,
+            "time_ranges": TIME_RANGES,
+            "time_range_labels": TIME_RANGE_LABELS,
+            "formula_parts": scoring_formula_parts(),
+            "talk_bucket_min": TALK_TIME_BUCKET_SECONDS // 60,
+        }
+    )
+
+    # Time-range selector swaps only the table fragment; full-tab on first paint.
+    if request.headers.get("HX-Request") == "true" and request.headers.get("HX-Trigger-Name") == "time_range":
+        return template_response("htmx/partials/settings/_scorecard_table.html", ctx)
+    return template_response("htmx/partials/settings/scorecard.html", ctx)
+
+
 @router.post("/v2/partials/buy-plans/{plan_id}/reset", response_class=HTMLResponse)
 async def buy_plan_reset_partial(
     request: Request,
@@ -14120,6 +14166,8 @@ async def settings_partial(
     ctx = _base_ctx(request, user, "settings")
     ctx["active_tab"] = tab
     ctx["is_admin"] = user.role == UserRole.ADMIN
+    # Supervisor-tier flag — gates the Activity Scorecard tab (manager + admin).
+    ctx["is_manager"] = is_manager_or_admin(user)
     return template_response("htmx/partials/settings/index.html", ctx)
 
 

--- a/app/services/activity_scorecard.py
+++ b/app/services/activity_scorecard.py
@@ -1,0 +1,296 @@
+"""Activity Scorecard — per-user activity metrics + a weighted score, ranked.
+
+Computes a leaderboard of per-user sales/sourcing activity over a time range
+(this_week / this_month / this_quarter / all_time, default this_month):
+
+  - calls            — ActivityLog rows on the PHONE channel (made + received)
+  - talk_time_seconds — SUM(duration_seconds) over those PHONE rows
+  - emails_sent      — EMAIL channel, OUTBOUND direction
+  - ims_sent         — TEAMS/WECHAT channel, OUTBOUND direction
+  - accounts_added   — Company.created_by_id count per user
+  - contacts_added   — SiteContact.created_by_id count per user
+
+The score is a weighted sum of the six metrics (see WEIGHTS below — the single,
+easy-to-tune knob). Rows are returned ranked by score descending.
+
+Called by: routers/htmx_views.py (settings/scorecard tab).
+Depends on: models (ActivityLog, Company, SiteContact, User), constants
+  (Channel, Direction), database session.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+
+from sqlalchemy import case
+from sqlalchemy import func as sqlfunc
+from sqlalchemy.orm import Session
+
+from ..constants import Channel, Direction
+from ..models import ActivityLog, Company, SiteContact, User
+
+# ── Scoring weights — THE tuning knob ─────────────────────────────────────────
+# A user's score is the weighted sum of their metrics. Each weight is "points per
+# unit" of that metric. Talk time is scored per 5 minutes (300s) of conversation,
+# everything else per event. Edit these to re-balance the leaderboard — nothing
+# else needs to change.
+TALK_TIME_BUCKET_SECONDS = 300  # 5 minutes = 1 talk-time point
+
+
+@dataclass(frozen=True)
+class ScoreWeights:
+    """Points awarded per unit of each activity metric."""
+
+    call: float = 1.0
+    talk_time_per_bucket: float = 1.0  # per TALK_TIME_BUCKET_SECONDS (5 min)
+    email: float = 1.0
+    im: float = 0.5
+    account_added: float = 5.0
+    contact_added: float = 2.0
+
+
+WEIGHTS = ScoreWeights()
+
+# Valid time-range keys (the selector vocabulary). Default is this_month.
+TIME_RANGES: tuple[str, ...] = ("this_week", "this_month", "this_quarter", "all_time")
+DEFAULT_TIME_RANGE = "this_month"
+
+# Human labels for the selector / header (single source of truth for the UI copy).
+TIME_RANGE_LABELS: dict[str, str] = {
+    "this_week": "This week",
+    "this_month": "This month",
+    "this_quarter": "This quarter",
+    "all_time": "All time",
+}
+
+
+@dataclass(frozen=True)
+class ScorecardRow:
+    """One user's activity metrics + computed score (rank assigned after sort)."""
+
+    user_id: int
+    user: User
+    calls: int
+    talk_time_seconds: int
+    emails_sent: int
+    ims_sent: int
+    accounts_added: int
+    contacts_added: int
+    score: float
+    rank: int = 0  # 1-based, assigned by compute_scorecard after ranking
+
+    @property
+    def talk_time_hms(self) -> str:
+        """Talk time formatted as ``h:mm`` (e.g. 1:05, 0:00)."""
+        return format_talk_time(self.talk_time_seconds)
+
+
+def format_talk_time(total_seconds: int | None) -> str:
+    """Format a seconds total as ``h:mm`` (hours uncapped, minutes zero-padded)."""
+    secs = int(total_seconds or 0)
+    hours, remainder = divmod(secs, 3600)
+    minutes = remainder // 60
+    return f"{hours}:{minutes:02d}"
+
+
+def compute_score(
+    *,
+    calls: int,
+    talk_time_seconds: int,
+    emails_sent: int,
+    ims_sent: int,
+    accounts_added: int,
+    contacts_added: int,
+    weights: ScoreWeights = WEIGHTS,
+) -> float:
+    """Weighted-sum score for one user's metrics. Rounded to 1 decimal place.
+
+    Talk time contributes ``weights.talk_time_per_bucket`` points per
+    ``TALK_TIME_BUCKET_SECONDS`` (5 min) of conversation, pro-rated (not stepped),
+    so a 7.5-minute call is worth 1.5 talk-time points.
+    """
+    talk_buckets = (talk_time_seconds or 0) / TALK_TIME_BUCKET_SECONDS
+    score = (
+        calls * weights.call
+        + talk_buckets * weights.talk_time_per_bucket
+        + emails_sent * weights.email
+        + ims_sent * weights.im
+        + accounts_added * weights.account_added
+        + contacts_added * weights.contact_added
+    )
+    return round(score, 1)
+
+
+def range_start(time_range: str, *, now: datetime | None = None) -> datetime | None:
+    """Resolve a time-range key to its inclusive UTC start (None = all_time).
+
+    Weeks start Monday. Months/quarters start on the 1st of the period. The value
+    is a timezone-aware UTC datetime so it compares cleanly against the stored
+    ``created_at`` column (also UTC-aware).
+    """
+    if time_range == "all_time":
+        return None
+    now = now or datetime.now(timezone.utc)
+    today = now.date()
+    if time_range == "this_week":
+        start_date = today - timedelta(days=today.weekday())
+    elif time_range == "this_quarter":
+        quarter_first_month = 3 * ((today.month - 1) // 3) + 1
+        start_date = date(today.year, quarter_first_month, 1)
+    else:  # this_month (default) — unknown keys fall back to month
+        start_date = date(today.year, today.month, 1)
+    return datetime(start_date.year, start_date.month, start_date.day, tzinfo=timezone.utc)
+
+
+def _activity_metrics_by_user(db: Session, start: datetime | None) -> dict[int, dict[str, int]]:
+    """One GROUP BY query over activity_log → {user_id: {calls, talk, emails, ims}}.
+
+    Aggregates all four ActivityLog-derived metrics in a single pass using conditional
+    aggregates (FILTER-style CASE) so there is no per-user loop and no N+1. NULL user_id
+    rows (system/unattributed activity) are excluded.
+    """
+    is_phone = ActivityLog.channel == Channel.PHONE
+    is_email_out = (ActivityLog.channel == Channel.EMAIL) & (ActivityLog.direction == Direction.OUTBOUND)
+    is_im_out = ActivityLog.channel.in_((Channel.TEAMS, Channel.WECHAT)) & (ActivityLog.direction == Direction.OUTBOUND)
+
+    calls_expr = sqlfunc.sum(case((is_phone, 1), else_=0))
+    talk_expr = sqlfunc.sum(case((is_phone, sqlfunc.coalesce(ActivityLog.duration_seconds, 0)), else_=0))
+    emails_expr = sqlfunc.sum(case((is_email_out, 1), else_=0))
+    ims_expr = sqlfunc.sum(case((is_im_out, 1), else_=0))
+
+    query = db.query(
+        ActivityLog.user_id,
+        calls_expr.label("calls"),
+        talk_expr.label("talk"),
+        emails_expr.label("emails"),
+        ims_expr.label("ims"),
+    ).filter(ActivityLog.user_id.isnot(None))
+    if start is not None:
+        query = query.filter(ActivityLog.created_at >= start)
+    query = query.group_by(ActivityLog.user_id)
+
+    return {
+        row.user_id: {
+            "calls": int(row.calls or 0),
+            "talk": int(row.talk or 0),
+            "emails": int(row.emails or 0),
+            "ims": int(row.ims or 0),
+        }
+        for row in query.all()
+    }
+
+
+def _created_counts(db: Session, model, created_col, start: datetime | None) -> dict[int, int]:
+    """GROUP BY a model's creator column → {user_id: count} (one query, no loop)."""
+    query = db.query(created_col, sqlfunc.count(model.id)).filter(created_col.isnot(None))
+    if start is not None:
+        query = query.filter(model.created_at >= start)
+    return {uid: int(count) for uid, count in query.group_by(created_col).all()}
+
+
+def compute_scorecard(
+    db: Session,
+    time_range: str = DEFAULT_TIME_RANGE,
+    *,
+    weights: ScoreWeights = WEIGHTS,
+    now: datetime | None = None,
+) -> list[ScorecardRow]:
+    """Per-user activity scorecard, ranked by score descending.
+
+    Aggregates efficiently: one GROUP BY over activity_log, one over companies, one
+    over site_contacts, and one User lookup — four queries total, independent of the
+    number of users. Users with zero activity in the range are omitted (the
+    leaderboard shows only contributors). Ties break on user name then id so the
+    order is deterministic.
+    """
+    if time_range not in TIME_RANGES:
+        time_range = DEFAULT_TIME_RANGE
+    start = range_start(time_range, now=now)
+
+    activity = _activity_metrics_by_user(db, start)
+    accounts = _created_counts(db, Company, Company.created_by_id, start)
+    contacts = _created_counts(db, SiteContact, SiteContact.created_by_id, start)
+
+    user_ids = set(activity) | set(accounts) | set(contacts)
+    if not user_ids:
+        return []
+
+    users = {u.id: u for u in db.query(User).filter(User.id.in_(user_ids)).all()}
+
+    rows: list[ScorecardRow] = []
+    for uid in user_ids:
+        user = users.get(uid)
+        if user is None:  # user deleted but activity rows remain — skip orphans
+            continue
+        metrics = activity.get(uid, {})
+        calls = metrics.get("calls", 0)
+        talk = metrics.get("talk", 0)
+        emails = metrics.get("emails", 0)
+        ims = metrics.get("ims", 0)
+        accounts_added = accounts.get(uid, 0)
+        contacts_added = contacts.get(uid, 0)
+        score = compute_score(
+            calls=calls,
+            talk_time_seconds=talk,
+            emails_sent=emails,
+            ims_sent=ims,
+            accounts_added=accounts_added,
+            contacts_added=contacts_added,
+            weights=weights,
+        )
+        rows.append(
+            ScorecardRow(
+                user_id=uid,
+                user=user,
+                calls=calls,
+                talk_time_seconds=talk,
+                emails_sent=emails,
+                ims_sent=ims,
+                accounts_added=accounts_added,
+                contacts_added=contacts_added,
+                score=score,
+            )
+        )
+
+    rows.sort(key=lambda r: (-r.score, (r.user.name or r.user.email or "").lower(), r.user_id))
+    return [_with_rank(row, i + 1) for i, row in enumerate(rows)]
+
+
+def _with_rank(row: ScorecardRow, rank: int) -> ScorecardRow:
+    """Return a copy of ``row`` with its 1-based ``rank`` field set."""
+    return ScorecardRow(
+        user_id=row.user_id,
+        user=row.user,
+        calls=row.calls,
+        talk_time_seconds=row.talk_time_seconds,
+        emails_sent=row.emails_sent,
+        ims_sent=row.ims_sent,
+        accounts_added=row.accounts_added,
+        contacts_added=row.contacts_added,
+        score=row.score,
+        rank=rank,
+    )
+
+
+def scoring_formula_parts(weights: ScoreWeights = WEIGHTS) -> list[dict[str, str]]:
+    """Human-readable breakdown of the weights for transparent UI display.
+
+    Each entry is ``{"label": ..., "weight": ...}`` describing one term of the
+    weighted sum, so the template can render the formula without hard-coding the
+    numbers (they stay in sync with WEIGHTS automatically).
+    """
+    bucket_min = TALK_TIME_BUCKET_SECONDS // 60
+    return [
+        {"label": "Call", "weight": f"{_fmt(weights.call)} pt each"},
+        {"label": "Talk time", "weight": f"{_fmt(weights.talk_time_per_bucket)} pt / {bucket_min} min"},
+        {"label": "Email sent", "weight": f"{_fmt(weights.email)} pt each"},
+        {"label": "IM sent", "weight": f"{_fmt(weights.im)} pt each"},
+        {"label": "Account added", "weight": f"{_fmt(weights.account_added)} pts each"},
+        {"label": "Contact added", "weight": f"{_fmt(weights.contact_added)} pts each"},
+    ]
+
+
+def _fmt(value: float) -> str:
+    """Format a weight without a trailing ``.0`` (1.0 → "1", 0.5 → "0.5")."""
+    return str(int(value)) if value == int(value) else str(value)

--- a/app/templates/htmx/partials/settings/_scorecard_table.html
+++ b/app/templates/htmx/partials/settings/_scorecard_table.html
@@ -1,0 +1,55 @@
+{#
+  settings/_scorecard_table.html — the ranked leaderboard table fragment.
+  Swapped into #scorecard-table on time-range change (and included on first paint).
+
+  Receives: rows (list[ScorecardRow]), time_range_labels (dict), time_range (str).
+  Called by: settings/scorecard.html (include) and htmx_views.settings_scorecard_tab
+             (HX-Request fragment render).
+  Depends on: the user_avatar macro, .data-table styles.
+#}
+{% from "htmx/partials/shared/_macros.html" import user_avatar %}
+
+{% if not rows %}
+<div class="rounded-lg border border-dashed border-line-base bg-white px-6 py-10 text-center">
+  <p class="text-sm font-medium text-gray-700">No activity recorded for {{ time_range_labels[time_range]|lower }}.</p>
+  <p class="text-xs text-gray-600 mt-1">Calls, emails, IMs, and new accounts/contacts will appear here as the team works.</p>
+</div>
+{% else %}
+<div class="overflow-x-auto rounded-lg border border-line-base bg-white">
+  <table class="data-table w-full">
+    <thead>
+      <tr>
+        <th class="text-right w-12">#</th>
+        <th class="text-left">User</th>
+        <th class="text-right">Calls</th>
+        <th class="text-right">Talk time</th>
+        <th class="text-right">Emails</th>
+        <th class="text-right">IMs</th>
+        <th class="text-right">Accounts added</th>
+        <th class="text-right">Contacts added</th>
+        <th class="text-right">Score</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      <tr>
+        <td class="text-right font-semibold text-gray-600 tabular-nums">{{ row.rank }}</td>
+        <td class="text-left">
+          <div class="flex items-center gap-2">
+            {{ user_avatar(row.user, size='sm') }}
+            <span class="font-medium text-gray-900">{{ row.user.name or row.user.email }}</span>
+          </div>
+        </td>
+        <td class="text-right tabular-nums">{{ row.calls }}</td>
+        <td class="text-right tabular-nums">{{ row.talk_time_hms }}</td>
+        <td class="text-right tabular-nums">{{ row.emails_sent }}</td>
+        <td class="text-right tabular-nums">{{ row.ims_sent }}</td>
+        <td class="text-right tabular-nums">{{ row.accounts_added }}</td>
+        <td class="text-right tabular-nums">{{ row.contacts_added }}</td>
+        <td class="text-right font-semibold text-accent-700 tabular-nums">{{ row.score }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}

--- a/app/templates/htmx/partials/settings/index.html
+++ b/app/templates/htmx/partials/settings/index.html
@@ -36,6 +36,11 @@
     {{ tab_button('tickets', '/v2/partials/trouble-tickets/workspace', 'Tickets', ['M12 12.75c1.148 0 2.278.08 3.383.237 1.037.146 1.866.966 1.866 2.013 0 3.728-2.35 6.75-5.25 6.75S6.75 18.728 6.75 15c0-1.046.83-1.867 1.866-2.013A24.204 24.204 0 0112 12.75z']) }}
     {% endif %}
 
+    {# Activity Scorecard — per-user activity leaderboard (manager + admin oversight) #}
+    {% if is_manager %}
+    {{ tab_button('scorecard', '/v2/partials/settings/scorecard', 'Scorecard', ['M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z']) }}
+    {% endif %}
+
     {{ tab_button('profile', '/v2/partials/settings/profile', 'Profile', ['M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z']) }}
   </div>
 

--- a/app/templates/htmx/partials/settings/scorecard.html
+++ b/app/templates/htmx/partials/settings/scorecard.html
@@ -1,0 +1,61 @@
+{#
+  settings/scorecard.html — Activity Scorecard tab (manager/admin only).
+  A ranked per-user activity leaderboard with a tunable weighted score, a time-range
+  selector (hx-get refresh), and the scoring formula shown transparently.
+
+  Receives: rows (list[ScorecardRow]), time_range (str), time_range_labels (dict),
+            time_ranges (tuple[str]), formula_parts (list[{label, weight}]),
+            talk_bucket_min (int).
+  Called by: htmx_views.settings_scorecard_tab (GET /v2/partials/settings/scorecard).
+  Depends on: HTMX, Tailwind, the user_avatar macro, _scorecard_table.html fragment.
+#}
+{% from "htmx/partials/shared/_macros.html" import user_avatar %}
+
+<div class="space-y-5" id="scorecard-root">
+
+  {# Header + time-range selector. The select swaps ONLY the table fragment so the
+     formula/header stay put and the whole page never gets replaced. #}
+  <div class="flex flex-wrap items-end justify-between gap-4">
+    <div>
+      <h2 class="text-lg font-semibold text-gray-900">Activity Scorecard</h2>
+      <p class="text-sm text-gray-600">
+        Per-user activity leaderboard — ranked by a weighted activity score.
+      </p>
+    </div>
+
+    <label class="flex items-center gap-2 text-xs font-medium text-gray-600">
+      Time range
+      <select name="time_range"
+              hx-get="/v2/partials/settings/scorecard"
+              hx-trigger="change"
+              hx-target="#scorecard-table"
+              hx-swap="innerHTML"
+              hx-indicator="#scorecard-spinner"
+              class="input input-sm w-auto">
+        {% for key in time_ranges %}
+        <option value="{{ key }}" {% if key == time_range %}selected{% endif %}>{{ time_range_labels[key] }}</option>
+        {% endfor %}
+      </select>
+      <svg id="scorecard-spinner" class="htmx-indicator h-4 w-4 text-accent-400 animate-spin" viewBox="0 0 24 24" fill="none">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+      </svg>
+    </label>
+  </div>
+
+  {# Scoring formula — shown transparently so the ranking is never a black box.
+     Numbers come from the service WEIGHTS constant, so this stays in sync. #}
+  <div class="rounded-lg border border-line-base bg-gray-50 px-4 py-3">
+    <p class="text-xs font-semibold uppercase tracking-wider text-gray-600 mb-2">How the score is calculated</p>
+    <div class="flex flex-wrap gap-x-5 gap-y-1.5 text-sm text-gray-700">
+      {% for part in formula_parts %}
+      <span><span class="font-medium text-gray-900">{{ part.label }}</span> &middot; {{ part.weight }}</span>
+      {% endfor %}
+    </div>
+  </div>
+
+  {# Leaderboard table — swapped in place on time-range change. #}
+  <div id="scorecard-table">
+    {% include "htmx/partials/settings/_scorecard_table.html" %}
+  </div>
+</div>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -3998,7 +3998,31 @@ PROSPECT SCORING:
         +---> fit_score (ICP match)
         +---> readiness_score (buying signals)
         +---> prospect_priority.py (rank order)
+
+ACTIVITY SCORECARD (per-user leaderboard, on-demand read):
+    activity_scorecard.py  (Settings -> Scorecard tab; manager/admin only)
+        +---> calls            = activity_log WHERE channel=PHONE (both directions)
+        +---> talk_time        = SUM(duration_seconds) over those PHONE rows
+        +---> emails_sent      = channel=EMAIL AND direction=OUTBOUND
+        +---> ims_sent         = channel IN (TEAMS,WECHAT) AND direction=OUTBOUND
+        +---> accounts_added   = COUNT(companies.created_by_id) per user
+        +---> contacts_added   = COUNT(site_contacts.created_by_id) per user
+        +---> score = weighted sum (WEIGHTS const: call=1, talk=1/5min,
+        |             email=1, im=0.5, account=5, contact=2) -> rank desc
+        +---> 4 GROUP BY queries total (no per-user N+1); range:
+              this_week / this_month (default) / this_quarter / all_time
 ```
+
+### Settings -> Activity Scorecard Tab (`/v2/partials/settings/scorecard`, manager/admin)
+
+`htmx_views.settings_scorecard_tab` gates on `is_manager_or_admin` (a leaderboard of
+all users' activity is oversight/performance data — buyers/sales/traders never see it),
+calls `activity_scorecard.compute_scorecard(db, time_range)`, and renders
+`settings/scorecard.html` (full tab) or `settings/_scorecard_table.html` (fragment) when
+the time-range `<select>` fires an `HX-Request` (`HX-Trigger-Name: time_range`). The tab
+button lives in `settings/index.html` behind `{% if is_manager %}` (set in
+`settings_partial`). The scoring formula is rendered transparently from
+`scoring_formula_parts()` so the weights stay in sync with the `WEIGHTS` constant.
 
 ---
 

--- a/tests/test_activity_scorecard.py
+++ b/tests/test_activity_scorecard.py
@@ -1,0 +1,314 @@
+"""Tests for the Activity Scorecard — service aggregation, scoring, ranking, route.
+
+Covers:
+  - per-user metric aggregation (calls/talk/emails/IMs/accounts/contacts)
+  - channel/direction mapping correctness (only the right rows count)
+  - time-range windowing (this_week/month/quarter/all_time)
+  - the weighted score + h:mm talk-time formatting
+  - ranking order (score desc, deterministic tie-break) + 1-based ranks
+  - the settings/scorecard route: manager/admin → 200, buyer → 403
+
+Depends on: tests/conftest.py fixtures (db_session), app.services.activity_scorecard,
+app.models, app.constants.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.constants import Channel, Direction
+from app.models import ActivityLog, Company, CustomerSite, SiteContact, User
+from app.services.activity_scorecard import (
+    DEFAULT_TIME_RANGE,
+    TALK_TIME_BUCKET_SECONDS,
+    WEIGHTS,
+    ScoreWeights,
+    compute_score,
+    compute_scorecard,
+    format_talk_time,
+    range_start,
+    scoring_formula_parts,
+)
+
+UTC = timezone.utc
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def users(db_session):
+    """Three users: a buyer, a manager, an admin."""
+    rows = [
+        User(email="alice@trioscs.com", name="Alice", role="buyer", azure_id="az-a"),
+        User(email="mgr@trioscs.com", name="Manager Mo", role="manager", azure_id="az-m"),
+        User(email="boss@trioscs.com", name="Admin Ada", role="admin", azure_id="az-ad"),
+    ]
+    db_session.add_all(rows)
+    db_session.commit()
+    for r in rows:
+        db_session.refresh(r)
+    return {"buyer": rows[0], "manager": rows[1], "admin": rows[2]}
+
+
+def _log(db, user, channel, *, direction=None, duration=None, when=None):
+    """Insert one ActivityLog row with the minimum fields the scorecard reads."""
+    row = ActivityLog(
+        user_id=user.id,
+        activity_type="x",  # not read by the scorecard (it keys on channel/direction)
+        channel=channel,
+        direction=direction,
+        duration_seconds=duration,
+        created_at=when or datetime.now(UTC),
+    )
+    db.add(row)
+    return row
+
+
+# ── Pure scoring / formatting ───────────────────────────────────────────────
+
+
+def test_format_talk_time():
+    assert format_talk_time(0) == "0:00"
+    assert format_talk_time(None) == "0:00"
+    assert format_talk_time(65) == "0:01"
+    assert format_talk_time(300) == "0:05"
+    assert format_talk_time(3600) == "1:00"
+    assert format_talk_time(3665) == "1:01"  # 1h 1m 5s -> drops seconds
+
+
+def test_compute_score_matches_documented_weights():
+    # 2 calls + 10 min talk (=2 buckets) + 3 emails + 4 IMs + 1 account + 2 contacts
+    score = compute_score(
+        calls=2,
+        talk_time_seconds=10 * 60,
+        emails_sent=3,
+        ims_sent=4,
+        accounts_added=1,
+        contacts_added=2,
+    )
+    # 2*1 + 2*1 + 3*1 + 4*0.5 + 1*5 + 2*2 = 2+2+3+2+5+4 = 18
+    assert score == 18.0
+
+
+def test_compute_score_talk_time_is_pro_rated():
+    # 7.5 minutes = 1.5 buckets -> 1.5 talk points, nothing else
+    assert (
+        compute_score(
+            calls=0,
+            talk_time_seconds=int(7.5 * 60),
+            emails_sent=0,
+            ims_sent=0,
+            accounts_added=0,
+            contacts_added=0,
+        )
+        == 1.5
+    )
+
+
+def test_score_weights_are_the_documented_defaults():
+    assert WEIGHTS == ScoreWeights(
+        call=1.0,
+        talk_time_per_bucket=1.0,
+        email=1.0,
+        im=0.5,
+        account_added=5.0,
+        contact_added=2.0,
+    )
+    assert TALK_TIME_BUCKET_SECONDS == 300
+
+
+def test_scoring_formula_parts_stay_in_sync_with_weights():
+    parts = scoring_formula_parts()
+    labels = {p["label"] for p in parts}
+    assert labels == {"Call", "Talk time", "Email sent", "IM sent", "Account added", "Contact added"}
+    talk = next(p for p in parts if p["label"] == "Talk time")
+    assert "5 min" in talk["weight"]
+    im = next(p for p in parts if p["label"] == "IM sent")
+    assert "0.5" in im["weight"]
+
+
+# ── Metric aggregation correctness ──────────────────────────────────────────
+
+
+def test_only_correct_channels_and_directions_count(db_session, users):
+    alice = users["buyer"]
+    # 2 phone calls (both directions count) with talk time
+    _log(db_session, alice, Channel.PHONE, direction=Direction.OUTBOUND, duration=120)
+    _log(db_session, alice, Channel.PHONE, direction=Direction.INBOUND, duration=180)
+    # outbound email counts; inbound email does NOT
+    _log(db_session, alice, Channel.EMAIL, direction=Direction.OUTBOUND)
+    _log(db_session, alice, Channel.EMAIL, direction=Direction.INBOUND)
+    # outbound Teams + WeChat count as IMs; inbound Teams does NOT
+    _log(db_session, alice, Channel.TEAMS, direction=Direction.OUTBOUND)
+    _log(db_session, alice, Channel.WECHAT, direction=Direction.OUTBOUND)
+    _log(db_session, alice, Channel.TEAMS, direction=Direction.INBOUND)
+    # an unrelated channel (system) is ignored entirely
+    _log(db_session, alice, Channel.SYSTEM, direction=Direction.OUTBOUND)
+    db_session.commit()
+
+    rows = compute_scorecard(db_session, "all_time")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.calls == 2
+    assert row.talk_time_seconds == 300
+    assert row.talk_time_hms == "0:05"
+    assert row.emails_sent == 1
+    assert row.ims_sent == 2
+
+
+def test_accounts_and_contacts_counted_by_creator(db_session, users):
+    alice, mgr = users["buyer"], users["manager"]
+    db_session.add_all(
+        [
+            Company(name="C1", created_by_id=alice.id),
+            Company(name="C2", created_by_id=alice.id),
+            Company(name="C3", created_by_id=mgr.id),
+            Company(name="C-null", created_by_id=None),  # no creator -> not counted
+        ]
+    )
+    site = CustomerSite(company_id=None, site_name="HQ")  # company_id NOT NULL? set below
+    company = Company(name="Host", created_by_id=None)
+    db_session.add(company)
+    db_session.flush()
+    site.company_id = company.id
+    db_session.add(site)
+    db_session.flush()
+    db_session.add_all(
+        [
+            SiteContact(customer_site_id=site.id, full_name="K One", created_by_id=alice.id),
+            SiteContact(customer_site_id=site.id, full_name="K Two", created_by_id=mgr.id),
+        ]
+    )
+    db_session.commit()
+
+    rows = {r.user_id: r for r in compute_scorecard(db_session, "all_time")}
+    assert rows[alice.id].accounts_added == 2
+    assert rows[alice.id].contacts_added == 1
+    assert rows[mgr.id].accounts_added == 1
+    assert rows[mgr.id].contacts_added == 1
+
+
+def test_time_range_windows_out_old_rows(db_session, users):
+    alice = users["buyer"]
+    now = datetime.now(UTC)
+    old = now - timedelta(days=40)  # before this_month, before this_week
+    _log(db_session, alice, Channel.PHONE, duration=60, when=old)
+    _log(db_session, alice, Channel.PHONE, duration=60, when=now)
+    db_session.commit()
+
+    assert compute_scorecard(db_session, "all_time")[0].calls == 2
+    # this_month / this_week should exclude the 40-day-old row
+    month = compute_scorecard(db_session, "this_month")
+    assert month and month[0].calls == 1
+
+
+def test_null_user_activity_excluded(db_session, users):
+    row = ActivityLog(user_id=None, activity_type="x", channel=Channel.PHONE, duration_seconds=60)
+    db_session.add(row)
+    db_session.commit()
+    assert compute_scorecard(db_session, "all_time") == []
+
+
+# ── Ranking ─────────────────────────────────────────────────────────────────
+
+
+def test_ranking_is_score_desc_with_ranks_assigned(db_session, users):
+    alice, mgr, admin = users["buyer"], users["manager"], users["admin"]
+    # admin: 1 account added = 5 pts (highest)
+    db_session.add(Company(name="A-co", created_by_id=admin.id))
+    # mgr: 3 calls = 3 pts (middle)
+    for _ in range(3):
+        _log(db_session, mgr, Channel.PHONE)
+    # alice: 1 outbound email = 1 pt (lowest)
+    _log(db_session, alice, Channel.EMAIL, direction=Direction.OUTBOUND)
+    db_session.commit()
+
+    rows = compute_scorecard(db_session, "all_time")
+    assert [r.user_id for r in rows] == [admin.id, mgr.id, alice.id]
+    assert [r.rank for r in rows] == [1, 2, 3]
+    assert [r.score for r in rows] == [5.0, 3.0, 1.0]
+
+
+def test_tie_break_is_deterministic_by_name(db_session, users):
+    alice, mgr = users["buyer"], users["manager"]  # "Alice" < "Manager Mo"
+    _log(db_session, alice, Channel.PHONE)
+    _log(db_session, mgr, Channel.PHONE)
+    db_session.commit()
+    rows = compute_scorecard(db_session, "all_time")
+    assert [r.score for r in rows] == [1.0, 1.0]
+    assert [r.user.name for r in rows] == ["Alice", "Manager Mo"]
+    assert [r.rank for r in rows] == [1, 2]
+
+
+# ── Route render + authz ────────────────────────────────────────────────────
+
+
+def _client_as(db_session, user) -> TestClient:
+    """A TestClient authed (via require_user override) as the given user."""
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[get_db] = lambda: db_session
+    app.dependency_overrides[require_user] = lambda: user
+    return TestClient(app)
+
+
+def test_scorecard_route_renders_for_manager(db_session, users):
+    mgr = users["manager"]
+    _log(db_session, users["buyer"], Channel.PHONE, duration=300)
+    db_session.commit()
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    client = _client_as(db_session, mgr)
+    try:
+        resp = client.get("/v2/partials/settings/scorecard")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Activity Scorecard" in body
+        assert "Score" in body
+        assert "Alice" in body  # the contributor appears in the leaderboard table
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(require_user, None)
+
+
+def test_scorecard_route_honors_time_range_param(db_session, users):
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    client = _client_as(db_session, users["admin"])
+    try:
+        resp = client.get("/v2/partials/settings/scorecard?time_range=this_quarter")
+        assert resp.status_code == 200
+        assert "This quarter" in resp.text
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(require_user, None)
+
+
+def test_scorecard_route_forbidden_for_buyer(db_session, users):
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    client = _client_as(db_session, users["buyer"])
+    try:
+        resp = client.get("/v2/partials/settings/scorecard")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(require_user, None)
+
+
+def test_range_start_all_time_is_none():
+    assert range_start("all_time") is None
+
+
+def test_default_time_range_constant():
+    assert DEFAULT_TIME_RANGE == "this_month"


### PR DESCRIPTION
A ranked per-user activity leaderboard (manager/admin-only, as a Settings tab). **Metrics** (from ActivityLog channel/direction + created_by): calls (PHONE in+out), talk time (SUM duration), emails sent (EMAIL outbound), IMs sent (TEAMS/WECHAT outbound), accounts added (Company.created_by_id), contacts added (SiteContact.created_by_id). **Score** = weighted sum (tunable WEIGHTS const): call=1, talk=1/5min, email=1, im=0.5, account=5, contact=2; ranked desc. **Aggregated** in 4 GROUP BY queries (no N+1). **Time ranges:** week/month(default)/quarter/all, via hx-get fragment swap. Page uses .data-table + user_avatar; scoring formula rendered transparently from the WEIGHTS const. **Authz:** is_manager_or_admin (buyers/sales/traders → 403). 16 new tests + static-analysis green; pre-commit clean. New Settings tab chosen over a bottom-nav item (nav full; oversight content already lives in Settings).