### PR TITLE
fix(authz): close 15 pre-multi-user IDOR/priv-esc gaps (audit-driven, dual-reviewed)

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -18,6 +18,7 @@ Depends on: models, database, config
 
 import hmac
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from fastapi import Depends, HTTPException, Request
 from loguru import logger
@@ -27,6 +28,9 @@ from sqlalchemy.orm import Session, selectinload
 from .constants import RESTRICTED_ROLES, ROLE_ACCESS_DEFAULTS, AccessKey, ApprovalRecipientStatus, UserRole
 from .database import get_db
 from .models import AccountCollaborator, BuyPlan, Company, CustomerSite, Quote, Requisition, User
+
+if TYPE_CHECKING:
+    from .models import ProspectContact
 
 # Non-interactive service account seeded by startup.py. It authenticates via the
 # x-agent-key header and is barred from admin/settings/buyer (RFQ) endpoints.
@@ -121,6 +125,23 @@ def can_manage_account(user: User, company: Company, db: "Session") -> bool:  # 
         .exists()
     )
     return bool(db.scalar(select(collab_exists)))
+
+
+def require_prospect_site_access(db: Session, user: User, pc: "ProspectContact") -> None:
+    """Gate a mutation on a site-linked prospect contact on account-management rights.
+
+    A prospect tied to a CustomerSite belongs to a customer account, so the actor must be
+    able to manage that account (mirrors the promote-prospect path). Vendor-linked prospects
+    (``pc.vendor_card_id``) are global and stay un-gated. Raises 403 if not authorized.
+
+    Shared by the JSON prospect endpoints (``app/routers/ai.py``) and the HTMX
+    vendor-prospect partials (``app/routers/htmx_views.py``) so the guard lives once.
+    """
+    if pc.customer_site_id and not pc.vendor_card_id:
+        site = db.get(CustomerSite, pc.customer_site_id)
+        company = db.get(Company, site.company_id) if site else None
+        if not company or not can_manage_account(user, company, db):
+            raise HTTPException(403, "Not authorized to manage this account")
 
 
 def can_manage_account_team(user: User, company: Company) -> bool:

--- a/app/routers/ai.py
+++ b/app/routers/ai.py
@@ -249,6 +249,22 @@ async def list_prospect_contacts(
     ]
 
 
+def _require_prospect_site_access(db: Session, user: User, pc: "ProspectContact") -> None:
+    """Gate a mutation on a site-linked prospect contact on account-management rights.
+
+    Mirrors promote_prospect_contact: a prospect tied to a CustomerSite belongs to a
+    customer account, so the actor must be able to manage that account. Vendor-linked
+    prospects (pc.vendor_card_id) are global and stay un-gated. 403 if not authorized.
+    """
+    if pc.customer_site_id and not pc.vendor_card_id:
+        from ..models import Company
+
+        site = db.get(CustomerSite, pc.customer_site_id)
+        company = db.get(Company, site.company_id) if site else None
+        if not company or not can_manage_account(user, company, db):
+            raise HTTPException(403, "Not authorized to manage this account")
+
+
 @router.post("/api/ai/prospect-contacts/{contact_id}/save", response_model=SimpleOkIdResponse)
 async def save_prospect_contact(
     contact_id: int,
@@ -260,6 +276,7 @@ async def save_prospect_contact(
     pc = db.query(ProspectContact).filter(ProspectContact.id == contact_id).first()
     if not pc:
         raise HTTPException(404, "Prospect contact not found")
+    _require_prospect_site_access(db, user, pc)
     pc.is_saved = True
     pc.saved_by_id = user.id
     if payload and payload.notes:
@@ -289,6 +306,7 @@ async def delete_prospect_contact(
     pc = db.query(ProspectContact).filter(ProspectContact.id == contact_id).first()
     if not pc:
         raise HTTPException(404, "Prospect contact not found")
+    _require_prospect_site_access(db, user, pc)
     db.delete(pc)
     db.commit()
     return {"ok": True}
@@ -304,13 +322,8 @@ async def promote_prospect_contact(
     # Authz: a site-linked prospect promotes into a SiteContact under a customer account,
     # so gate it on account-management. Vendor-linked prospects are global (no owner).
     pc = db.get(ProspectContact, contact_id)
-    if pc is not None and pc.customer_site_id and not pc.vendor_card_id:
-        from ..models import Company
-
-        site = db.get(CustomerSite, pc.customer_site_id)
-        company = db.get(Company, site.company_id) if site else None
-        if not company or not can_manage_account(user, company, db):
-            raise HTTPException(403, "Not authorized to manage this account")
+    if pc is not None:
+        _require_prospect_site_access(db, user, pc)
 
     from ..services.ai_offer_service import promote_prospect_contact as _promote
 
@@ -760,6 +773,17 @@ async def ai_apply_freeform_rfq(
 
     if not payload.customer_site_id:
         raise HTTPException(400, "customer_site_id required")
+
+    # Creating a requisition under a customer site is an account action — gate it on
+    # account-management (mirrors the prospect-contact site gate).
+    from ..models import Company
+
+    site = db.get(CustomerSite, payload.customer_site_id)
+    if not site:
+        raise HTTPException(404, "Customer site not found")
+    company = db.get(Company, site.company_id) if site.company_id else None
+    if not company or not can_manage_account(user, company, db):
+        raise HTTPException(403, "Not authorized to manage this account")
 
     try:
         result = _apply(

--- a/app/routers/ai.py
+++ b/app/routers/ai.py
@@ -22,6 +22,7 @@ from ..database import get_db
 from ..dependencies import (
     can_manage_account,
     get_req_for_user,
+    require_prospect_site_access,
     require_requisition_access,
     require_user,
 )
@@ -249,22 +250,6 @@ async def list_prospect_contacts(
     ]
 
 
-def _require_prospect_site_access(db: Session, user: User, pc: "ProspectContact") -> None:
-    """Gate a mutation on a site-linked prospect contact on account-management rights.
-
-    Mirrors promote_prospect_contact: a prospect tied to a CustomerSite belongs to a
-    customer account, so the actor must be able to manage that account. Vendor-linked
-    prospects (pc.vendor_card_id) are global and stay un-gated. 403 if not authorized.
-    """
-    if pc.customer_site_id and not pc.vendor_card_id:
-        from ..models import Company
-
-        site = db.get(CustomerSite, pc.customer_site_id)
-        company = db.get(Company, site.company_id) if site else None
-        if not company or not can_manage_account(user, company, db):
-            raise HTTPException(403, "Not authorized to manage this account")
-
-
 @router.post("/api/ai/prospect-contacts/{contact_id}/save", response_model=SimpleOkIdResponse)
 async def save_prospect_contact(
     contact_id: int,
@@ -276,7 +261,7 @@ async def save_prospect_contact(
     pc = db.query(ProspectContact).filter(ProspectContact.id == contact_id).first()
     if not pc:
         raise HTTPException(404, "Prospect contact not found")
-    _require_prospect_site_access(db, user, pc)
+    require_prospect_site_access(db, user, pc)
     pc.is_saved = True
     pc.saved_by_id = user.id
     if payload and payload.notes:
@@ -306,7 +291,7 @@ async def delete_prospect_contact(
     pc = db.query(ProspectContact).filter(ProspectContact.id == contact_id).first()
     if not pc:
         raise HTTPException(404, "Prospect contact not found")
-    _require_prospect_site_access(db, user, pc)
+    require_prospect_site_access(db, user, pc)
     db.delete(pc)
     db.commit()
     return {"ok": True}
@@ -323,7 +308,7 @@ async def promote_prospect_contact(
     # so gate it on account-management. Vendor-linked prospects are global (no owner).
     pc = db.get(ProspectContact, contact_id)
     if pc is not None:
-        _require_prospect_site_access(db, user, pc)
+        require_prospect_site_access(db, user, pc)
 
     from ..services.ai_offer_service import promote_prospect_contact as _promote
 

--- a/app/routers/crm/quotes.py
+++ b/app/routers/crm/quotes.py
@@ -159,7 +159,16 @@ async def create_quote(
     offer_ids = payload.offer_ids
     line_items = [li.model_dump() for li in payload.line_items] if payload.line_items else []
     if offer_ids and not line_items:
-        offers = db.query(Offer).options(joinedload(Offer.requirement)).filter(Offer.id.in_(offer_ids)).all()
+        # Scope offers to THIS requisition — a foreign offer_id must never copy cross-owner
+        # pricing into the quote or advance another owner's requirement to 'quoted'.
+        offers = (
+            db.query(Offer)
+            .options(joinedload(Offer.requirement))
+            .filter(Offer.id.in_(offer_ids), Offer.requisition_id == req_id)
+            .all()
+        )
+        if {o.id for o in offers} != set(offer_ids):
+            raise HTTPException(400, "One or more offers do not belong to this requisition")
         quoted_prices = _preload_last_quoted_prices(db)
         line_items = []
         for o in offers:
@@ -274,7 +283,10 @@ async def create_quote(
         if req_item_ids:
             from ...models import Offer as OfferModel
 
-            offers_used = db.query(OfferModel).filter(OfferModel.id.in_(req_item_ids)).all()
+            # Defense-in-depth: only advance requirements for offers on THIS requisition.
+            offers_used = (
+                db.query(OfferModel).filter(OfferModel.id.in_(req_item_ids), OfferModel.requisition_id == req_id).all()
+            )
             requirement_ids = list({o.requirement_id for o in offers_used if o.requirement_id})
             if requirement_ids:
                 on_quote_built(requirement_ids, db, actor=user)

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -58,6 +58,7 @@ from ..dependencies import (
     require_admin,
     require_buyer,
     require_buyplan_approver,
+    require_prospect_site_access,
     require_requisition_access,
     require_user,
     user_has_access,
@@ -5349,6 +5350,7 @@ async def vendor_prospect_save(
     pc = db.query(ProspectContact).filter(ProspectContact.id == prospect_id).first()
     if not pc:
         raise HTTPException(404, "Prospect contact not found")
+    require_prospect_site_access(db, user, pc)
 
     pc.is_saved = True
     pc.saved_by_id = user.id
@@ -5376,6 +5378,7 @@ async def vendor_prospect_promote(
     pc = db.query(ProspectContact).filter(ProspectContact.id == prospect_id).first()
     if not pc:
         raise HTTPException(404, "Prospect contact not found")
+    require_prospect_site_access(db, user, pc)
 
     # Dedup: check if email already exists on this vendor
     existing = None
@@ -5433,6 +5436,7 @@ async def vendor_prospect_delete(
     pc = db.query(ProspectContact).filter(ProspectContact.id == prospect_id).first()
     if not pc:
         raise HTTPException(404, "Prospect contact not found")
+    require_prospect_site_access(db, user, pc)
     db.delete(pc)
     db.commit()
     # Return empty string to remove the card from DOM
@@ -15335,6 +15339,14 @@ async def proactive_do_not_offer(
         cid = int(company_id)
     except (ValueError, TypeError):
         raise HTTPException(400, "company_id must be an integer")
+
+    # Authz: a do-not-offer rule is scoped to a customer account, so the actor must be
+    # able to manage that account — otherwise a cross-account actor could suppress offers
+    # for any company by passing an arbitrary company_id in the form.
+    company = db.get(Company, cid)
+    if not company or not can_manage_account(user, company, db):
+        raise HTTPException(403, "Not authorized to manage this account")
+
     if not is_do_not_offer(db, mpn, cid):
         dno = ProactiveDoNotOffer(
             mpn=mpn.upper(),

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -26,6 +26,7 @@ from sqlalchemy import func as sqlfunc
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..constants import (
+    RESTRICTED_ROLES,
     AccessKey,
     ActivityType,
     AttributionStatus,
@@ -2959,6 +2960,7 @@ async def ai_rephrase_email(
 ):
     """Rephrase the RFQ email so each send reads uniquely, keeping all parts intact."""
     get_requisition_or_404(db, req_id)  # validates existence
+    require_requisition_access(db, req_id, user)
 
     user_text = body.strip()
     if not user_text:
@@ -6307,9 +6309,19 @@ async def create_company(
         tax_id=form.get("tax_id", "").strip() or None,
         source=form.get("source", "").strip() or "manual",
     )
+    # Assigning a NEW account to someone other than yourself is a manager action, and the
+    # target must be a real active user (mirrors the bulk assign-owner path). A plain rep
+    # assigning to self / leaving it blank keeps the current behaviour.
     owner_id = form.get("owner_id", "")
     if owner_id and owner_id.isdigit():
-        company.account_owner_id = int(owner_id)
+        new_owner_id = int(owner_id)
+        if new_owner_id != user.id:
+            if not is_manager_or_admin(user):
+                raise HTTPException(403, "Only a manager can assign an account to another user")
+            target = db.get(User, new_owner_id)
+            if not target or not target.is_active:
+                raise HTTPException(400, "Owner must be an active user")
+        company.account_owner_id = new_owner_id
     db.add(company)
     db.flush()
 
@@ -8948,11 +8960,23 @@ async def edit_company(
     company.source = source or company.source
     tax_id = form.get("tax_id", "").strip()
     company.tax_id = tax_id or None
+    # Owner reassignment is a TEAM action — only the primary owner / a manager may seize
+    # primary ownership (can_manage_account admits collaborators + site-owners, who must
+    # NOT be able to lock out the real owner). Gate only when the value actually changes.
     owner_id = form.get("owner_id", "")
     if owner_id and owner_id.isdigit():
-        company.account_owner_id = int(owner_id)
+        new_owner_id = int(owner_id)
+        if new_owner_id != company.account_owner_id:
+            if not can_manage_account_team(user, company):
+                raise HTTPException(403, "Only the account owner or a manager can change the primary owner")
+            company.account_owner_id = new_owner_id
 
     parent_company_id_raw = form.get("parent_company_id", "").strip()
+    # Parent-company (hierarchy) edits are also a team action — match set_parent_company,
+    # which gates on owner/manager — so a collaborator can't restructure the hierarchy.
+    if parent_company_id_raw != (str(company.parent_company_id or "")):
+        if not can_manage_account_team(user, company):
+            raise HTTPException(403, "Only the account owner or a manager can change company hierarchy")
     _set_parent_company(db, company, parent_company_id_raw)
 
     # Registry fields — DRY via apply_company_field.
@@ -10408,16 +10432,17 @@ async def send_batch_follow_up(
     threshold_days = getattr(cfg, "follow_up_days", 2) if cfg else 2
     threshold = datetime.now(timezone.utc) - timedelta(days=threshold_days)
 
-    stale = (
-        db.query(RfqContact)
-        .filter(
-            RfqContact.contact_type == "email",
-            RfqContact.status.in_(["sent", "opened"]),
-            RfqContact.created_at < threshold,
-        )
-        .limit(50)
-        .all()
+    q = db.query(RfqContact).filter(
+        RfqContact.contact_type == "email",
+        RfqContact.status.in_(["sent", "opened"]),
+        RfqContact.created_at < threshold,
     )
+    # Restricted roles act only on contacts under their own requisitions; buyer/manager/admin
+    # stay global. Keep this in lockstep with follow_up_badge so the badge counts what the
+    # batch acts on.
+    if user.role in RESTRICTED_ROLES:
+        q = q.join(Requisition, RfqContact.requisition_id == Requisition.id).filter(Requisition.created_by == user.id)
+    stale = q.limit(50).all()
 
     sent_count = 0
     for contact in stale:
@@ -10443,16 +10468,15 @@ async def follow_up_badge(
     from ..models.offers import Contact as RfqContact
 
     threshold = datetime.now(timezone.utc) - timedelta(days=2)
-    count = (
-        db.query(sqlfunc.count(RfqContact.id))
-        .filter(
-            RfqContact.contact_type == "email",
-            RfqContact.status.in_(["sent", "opened"]),
-            RfqContact.created_at < threshold,
-        )
-        .scalar()
-        or 0
+    q = db.query(sqlfunc.count(RfqContact.id)).filter(
+        RfqContact.contact_type == "email",
+        RfqContact.status.in_(["sent", "opened"]),
+        RfqContact.created_at < threshold,
     )
+    # Same per-owner scope as send_batch_follow_up so the badge matches the batch.
+    if user.role in RESTRICTED_ROLES:
+        q = q.join(Requisition, RfqContact.requisition_id == Requisition.id).filter(Requisition.created_by == user.id)
+    count = q.scalar() or 0
     if count > 0:
         return HTMLResponse(
             f'<span class="ml-auto px-1.5 py-0.5 text-[10px] font-bold text-white bg-amber-500 rounded-full">{count}</span>'
@@ -11497,6 +11521,8 @@ async def sourcing_search_trigger(
     req = db.query(Requirement).filter(Requirement.id == requirement_id).first()
     if not req:
         raise HTTPException(404, "Requirement not found")
+    # Search triggers connector SPEND + cross-owner disclosure — scope to the owner.
+    require_requisition_access(db, req.requisition_id, user, label="Requirement")
 
     mpn = req.primary_mpn or ""
     sources = ["brokerbin", "nexar", "digikey", "mouser", "oemsecrets", "element14"]

--- a/app/routers/proactive.py
+++ b/app/routers/proactive.py
@@ -12,8 +12,8 @@ from sqlalchemy.orm import Session, joinedload
 
 from ..cache.decorators import cached_endpoint
 from ..database import get_db
-from ..dependencies import require_user
-from ..models import ProactiveDoNotOffer, ProactiveMatch, SiteContact, User
+from ..dependencies import can_manage_account, require_user
+from ..models import Company, ProactiveDoNotOffer, ProactiveMatch, SiteContact, User
 from ..scheduler import get_valid_token
 from ..schemas.proactive import (
     DismissMatches,
@@ -106,6 +106,11 @@ async def add_do_not_offer(
         mpn = (item.mpn or "").strip().upper()
         if not mpn or not item.company_id:
             continue
+        # A do-not-offer suppression is an account action — only someone who manages the
+        # company may add it. Without this, any user could suppress MPNs for any account.
+        company = db.get(Company, item.company_id)
+        if not company or not can_manage_account(user, company, db):
+            raise HTTPException(403, "Not authorized to manage this account")
         existing = (
             db.query(ProactiveDoNotOffer)
             .filter(
@@ -125,10 +130,12 @@ async def add_do_not_offer(
             )
             suppressed += 1
 
-        # Auto-dismiss any open matches for this mpn + company
+        # Auto-dismiss this user's open matches for this mpn + company. Scope to
+        # salesperson_id (mirrors /dismiss) so we never wipe another owner's open matches.
         db.query(ProactiveMatch).filter(
             ProactiveMatch.mpn == mpn,
             ProactiveMatch.company_id == item.company_id,
+            ProactiveMatch.salesperson_id == user.id,
             ProactiveMatch.status == "new",
         ).update(
             {"status": "dismissed", "dismiss_reason": "do_not_offer"},

--- a/app/routers/quality_plans.py
+++ b/app/routers/quality_plans.py
@@ -16,7 +16,7 @@ from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session, joinedload
 
 from ..database import get_db
-from ..dependencies import require_user
+from ..dependencies import require_requisition_access, require_user
 from ..models.buy_plan import BuyPlan, BuyPlanLine
 from ..models.crm import CustomerSite
 from ..models.quality_plan import QualityPlan
@@ -62,6 +62,23 @@ def _qp_detail_response(request: Request, user, db: Session, qp: QualityPlan) ->
     return template_response("htmx/partials/qp/detail.html", ctx)
 
 
+def _require_qp_access(db: Session, user, qp: QualityPlan) -> None:
+    """Enforce requisition-ownership scope on a Quality Plan action.
+
+    A QP belongs to its BuyPlan's parent requisition; restricted roles may only act on
+    QPs under requisitions they own (or that they created). 404 (not 403) so a QP's
+    existence isn't leaked. No-op for buyer/manager/admin.
+    """
+    bp = db.get(BuyPlan, qp.buy_plan_id) if qp.buy_plan_id else None
+    require_requisition_access(
+        db,
+        bp.requisition_id if bp else None,
+        user,
+        owner_id=qp.created_by_id,
+        label="Quality plan",
+    )
+
+
 @router.get("/v2/qp/{qp_id}", response_class=HTMLResponse)
 def qp_detail(
     request: Request,
@@ -85,6 +102,7 @@ def qp_detail(
     )
     if qp is None:
         raise HTTPException(status_code=404, detail="Quality plan not found")
+    _require_qp_access(db, user, qp)
 
     return _qp_detail_response(request, user, db, qp)
 
@@ -104,6 +122,7 @@ def qp_submit(
     qp = db.get(QualityPlan, qp_id)
     if qp is None:
         raise HTTPException(status_code=404, detail="Quality plan not found")
+    _require_qp_access(db, user, qp)
 
     try:
         qp = submit(db, qp_id, user)

--- a/app/routers/sources.py
+++ b/app/routers/sources.py
@@ -26,7 +26,13 @@ from sqlalchemy.orm import Session
 from ..config import settings
 from ..constants import AccessKey
 from ..database import get_db
-from ..dependencies import require_access, require_fresh_token, require_settings_access, require_user
+from ..dependencies import (
+    require_access,
+    require_fresh_token,
+    require_requisition_access,
+    require_settings_access,
+    require_user,
+)
 from ..models import (
     ApiSource,
     Requirement,
@@ -912,6 +918,9 @@ async def parse_response_attachments(
     vr = db.query(VendorResponse).filter_by(id=response_id).first()
     if not vr:
         raise HTTPException(404, "Response not found")
+    # Parsing attachments creates/overwrites Sightings on vr.requisition_id — same
+    # ownership gate every Sighting-mutating handler enforces.
+    require_requisition_access(db, vr.requisition_id, user)
 
     if not vr.message_id:
         raise HTTPException(400, "No message ID — cannot fetch attachments")

--- a/app/services/prepayment_service.py
+++ b/app/services/prepayment_service.py
@@ -19,6 +19,7 @@ from decimal import Decimal
 from sqlalchemy.orm import Session
 
 from ..constants import ApprovalGateType
+from ..dependencies import get_buyplan_for_user
 from ..models.approvals import ApprovalRequest
 from ..models.quality_plan import Prepayment
 from ..services.approvals.service import create_request
@@ -53,9 +54,15 @@ def create_prepayment(
     Raises:
         NoEligibleApproverError: Propagated from route_request when no eligible
             approver exists for the PREPAYMENT gate at this amount.
+        HTTPException(404): If *created_by* may not access *buy_plan_id* (restricted
+            roles not owning the parent requisition).
     """
+    # Ownership gate (service-layer so the router stays thin): a Prepayment + routed
+    # ApprovalRequest must not be attachable to a buy plan the actor can't access.
+    plan = get_buyplan_for_user(db, created_by, buy_plan_id)
+
     prepayment = Prepayment(
-        buy_plan_id=buy_plan_id,
+        buy_plan_id=plan.id,
         vendor_card_id=vendor_card_id,
         payment_method=payment_method,
         total_incl_fees=total_incl_fees,

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1994,13 +1994,25 @@ REUSING the helpers above (no new ad-hoc checks):
 - `create_company` (`POST /v2/partials/customers/create`) — assigning `owner_id != self` requires
   `is_manager_or_admin` and validates the target is an active `User` (else 400), matching the bulk
   assign-owner path.
-- `ai.py` site-linked prospect records — `save_prospect_contact`, `delete_prospect_contact`, and
-  `apply_freeform_rfq` resolve `customer_site_id → CustomerSite.company_id → Company` and require
-  `can_manage_account` (mirrors `promote_prospect_contact`); vendor-linked prospects stay global.
+- `ai.py` site-linked prospect records — `save_prospect_contact`, `delete_prospect_contact`,
+  `promote_prospect_contact`, and `apply_freeform_rfq` resolve
+  `customer_site_id → CustomerSite.company_id → Company` and require `can_manage_account`;
+  vendor-linked prospects stay global. The site-prospect guard lives once as
+  `dependencies.require_prospect_site_access(db, user, pc)` (shared helper) — imported by both
+  `ai.py` and `htmx_views.py`, never duplicated.
+- `htmx_views` vendor-prospect twins — `vendor_prospect_save` / `vendor_prospect_promote` /
+  `vendor_prospect_delete` (`POST|DELETE /v2/partials/vendors/{vendor_id}/ai/prospect/{prospect_id}`
+  `[/save|/promote]`) are the HTMX siblings of the `ai.py` routes above and reach the same
+  `ProspectContact` mutate/delete; they call `require_prospect_site_access` after the 404 check,
+  before mutation, so a cross-account actor can no longer hijack a site-linked prospect by id.
 - `proactive.add_do_not_offer` (`POST /api/proactive/do-not-offer`) — each item's `Company` is
   gated on `can_manage_account` before the DNO row is written, and the auto-dismiss UPDATE is
   scoped to `ProactiveMatch.salesperson_id == user.id` (mirrors `/dismiss`) so it never wipes
   another owner's open matches.
+- `htmx_views.proactive_do_not_offer` (`POST /v2/partials/proactive/do-not-offer`) — the HTMX
+  sibling of `add_do_not_offer`; resolves the form `company_id`/`customer_site_id` to a `Company`
+  and requires `can_manage_account` before inserting `ProactiveDoNotOffer`, so an arbitrary
+  form-supplied company can no longer be suppressed.
 - `sources.parse_response_attachments` (`POST /api/email-mining/parse-response-attachments/{id}`)
   — `require_requisition_access(db, vr.requisition_id, user)` before any Sighting create/overwrite.
 - `prepayment_service.create_prepayment` — `get_buyplan_for_user(db, created_by, buy_plan_id)` (the

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1985,6 +1985,41 @@ join; 404-not-403 so existence isn't leaked) and `require_requisition_access`; o
 company-access helper performs a real `can_manage_account` check (was a no-op). Restricted
 roles get 403 (company routes) or 404 (requisition-derived) on entities they don't own.
 
+**Per-entity authz hardening (Phase 1b — `fix/authz-hardening`, code-only).** A second pass
+closed 13 remaining object-level / privilege-escalation gaps, deduped into 9 fix groups, each
+REUSING the helpers above (no new ad-hoc checks):
+- `edit_company` (`POST /v2/partials/customers/{id}/edit`) — primary-owner *reassignment* and
+  parent-company (hierarchy) edits now require `can_manage_account_team` (collaborators / site-
+  owners can no longer seize ownership), gated only when the value actually changes.
+- `create_company` (`POST /v2/partials/customers/create`) — assigning `owner_id != self` requires
+  `is_manager_or_admin` and validates the target is an active `User` (else 400), matching the bulk
+  assign-owner path.
+- `ai.py` site-linked prospect records — `save_prospect_contact`, `delete_prospect_contact`, and
+  `apply_freeform_rfq` resolve `customer_site_id → CustomerSite.company_id → Company` and require
+  `can_manage_account` (mirrors `promote_prospect_contact`); vendor-linked prospects stay global.
+- `proactive.add_do_not_offer` (`POST /api/proactive/do-not-offer`) — each item's `Company` is
+  gated on `can_manage_account` before the DNO row is written, and the auto-dismiss UPDATE is
+  scoped to `ProactiveMatch.salesperson_id == user.id` (mirrors `/dismiss`) so it never wipes
+  another owner's open matches.
+- `sources.parse_response_attachments` (`POST /api/email-mining/parse-response-attachments/{id}`)
+  — `require_requisition_access(db, vr.requisition_id, user)` before any Sighting create/overwrite.
+- `prepayment_service.create_prepayment` — `get_buyplan_for_user(db, created_by, buy_plan_id)` (the
+  ownership check lives in the service so the router stays thin), so a Prepayment + routed
+  ApprovalRequest cannot be attached to a buy plan the actor can't access.
+- `htmx_views`: `sourcing_search_trigger` (connector spend) + `ai_rephrase_email` gated on
+  `require_requisition_access`; `send_batch_follow_up` and `follow_up_badge` scope the stale-
+  `RfqContact` query for `RESTRICTED_ROLES` (join `Requisition`, filter `created_by == user.id`)
+  so the badge matches what the batch acts on.
+- `crm.quotes.create_quote` (`POST /api/requisitions/{req_id}/quote`) — `offer_ids` filtered to
+  `Offer.requisition_id == req_id` (400 on any mismatch) and the `on_quote_built` requirement-
+  advance query filtered the same way, so foreign offers can't enter the quote or advance another
+  owner's requirement.
+- `quality_plans` `qp_detail` / `qp_submit` — `_require_qp_access` loads the parent BuyPlan and
+  calls `require_requisition_access(..., owner_id=qp.created_by_id, label="Quality plan")` (404 so
+  a QP's existence isn't leaked).
+Regression coverage: `tests/test_authz_hardening.py` (cross-account 403/404 + legitimate owner/
+manager/admin allowed + per-owner data-isolation asserts for proactive / follow-ups / quote).
+
 **Disposition (Increment 1, migration 118).** Salespeople dispose of accounts +
 contacts via setter routes in `htmx_views.py` (all owner-or-admin where they touch
 ownership/disposition; `is_admin = user.role == UserRole.ADMIN`, mirroring

--- a/tests/test_ai_router_coverage.py
+++ b/tests/test_ai_router_coverage.py
@@ -536,7 +536,18 @@ class TestApplyFreeformRfq:
             )
         assert resp.status_code == 404
 
-    def test_applies_rfq_successfully(self, client, db_session):
+    def test_applies_rfq_successfully(self, client, db_session, test_user):
+        # The route now gates the site's account on can_manage_account, so the site must
+        # exist under a company the actor owns before the (mocked) service runs.
+        from app.models import Company
+
+        company = Company(name="Freeform RFQ Co", is_active=True, account_owner_id=test_user.id)
+        db_session.add(company)
+        db_session.flush()
+        site = CustomerSite(company_id=company.id, site_name="HQ")
+        db_session.add(site)
+        db_session.commit()
+        db_session.refresh(site)
         with (
             patch("app.services.ai_offer_service.apply_freeform_rfq") as mock_apply,
             patch("app.cache.decorators.invalidate_prefix"),
@@ -547,7 +558,7 @@ class TestApplyFreeformRfq:
                 json={
                     "name": "Test RFQ",
                     "customer_name": "Acme",
-                    "customer_site_id": 1,
+                    "customer_site_id": site.id,
                     "requirements": [{"mpn": "LM317T", "target_qty": 100}],
                 },
             )

--- a/tests/test_authz_hardening.py
+++ b/tests/test_authz_hardening.py
@@ -1,0 +1,699 @@
+"""Consolidated authz-hardening regression suite (pre-multi-user launch blocker).
+
+Single security-batch file for the 9 fix groups / 13 routes hardened on
+`fix/authz-hardening`. Each gate REUSES an existing helper from app/dependencies.py
+(can_manage_account / can_manage_account_team / require_requisition_access /
+get_buyplan_for_user / is_manager_or_admin) — these tests lock in the boundary:
+
+  - a cross-account / restricted-role actor is DENIED (403 for account gates, 404 for
+    requisition-ownership gates so existence isn't leaked), with NO mutation, and
+  - a legitimate owner / manager / admin is ALLOWED,
+  - and for proactive / follow-ups / quote we additionally assert the OTHER owner's data
+    is untouched.
+
+The shared `client` fixture overrides require_user to return `test_user`; we mutate that
+same object's role / re-own resources to admin_user to simulate a restricted non-owner.
+
+Called by: pytest
+Depends on: app.routers.{ai,proactive,sources,htmx_views,quality_plans,crm.quotes},
+            app.services.prepayment_service, conftest fixtures.
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from app.config import settings
+from app.constants import UserRole
+from app.models import (
+    Company,
+    CustomerSite,
+    Offer,
+    ProactiveDoNotOffer,
+    ProactiveMatch,
+    ProspectContact,
+    Requirement,
+    Requisition,
+)
+from app.models.buy_plan import BuyPlan
+from app.models.offers import Contact as RfqContact
+from app.models.offers import VendorResponse
+from app.models.quality_plan import QualityPlan
+from app.models.quotes import Quote
+
+# ── Shared builders ──────────────────────────────────────────────────────
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _make_sales(test_user, db_session):
+    """Flip the request actor to a restricted SALES role (observed at request time)."""
+    test_user.role = UserRole.SALES
+    db_session.commit()
+
+
+def _make_trader(test_user, db_session):
+    test_user.role = UserRole.TRADER
+    db_session.commit()
+
+
+def _foreign_company(db_session, admin_user):
+    """A company owned by admin_user (not the request actor)."""
+    co = Company(name="Foreign Owned Co", is_active=True, account_owner_id=admin_user.id, created_at=_now())
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    return co
+
+
+def _owned_company(db_session, test_user):
+    """A company whose primary account owner IS the request actor."""
+    co = Company(name="My Owned Co", is_active=True, account_owner_id=test_user.id, created_at=_now())
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    return co
+
+
+def _site(db_session, company, *, owner_id=None):
+    site = CustomerSite(company_id=company.id, site_name="HQ", owner_id=owner_id)
+    db_session.add(site)
+    db_session.commit()
+    db_session.refresh(site)
+    return site
+
+
+def _requisition(db_session, owner_id, *, name="REQ-AUTHZ", site_id=None):
+    req = Requisition(
+        name=name,
+        customer_name="Cust",
+        status="active",
+        created_by=owner_id,
+        customer_site_id=site_id,
+        created_at=_now(),
+    )
+    db_session.add(req)
+    db_session.flush()
+    item = Requirement(requisition_id=req.id, primary_mpn="LM317T", target_qty=100, created_at=_now())
+    db_session.add(item)
+    db_session.commit()
+    db_session.refresh(req)
+    return req
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FIX GROUP 1 — edit_company owner reassignment needs the TEAM gate
+# Route: POST /v2/partials/customers/{company_id}/edit  (htmx_views.edit_company)
+# Helper: can_manage_account_team
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_g1_site_owner_cannot_seize_primary_ownership(client, db_session, test_user, admin_user):
+    """A site-owner passes can_manage_account but fails _team → 403; owner unchanged."""
+    co = _foreign_company(db_session, admin_user)  # primary owner = admin_user
+    _site(db_session, co, owner_id=test_user.id)  # test_user is only a SITE owner → can_manage_account True
+    resp = client.post(
+        f"/v2/partials/customers/{co.id}/edit",
+        data={"name": co.name, "owner_id": str(test_user.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 403
+    db_session.refresh(co)
+    assert co.account_owner_id == admin_user.id  # ownership NOT seized
+
+
+def test_g1_site_owner_cannot_change_hierarchy(client, db_session, test_user, admin_user):
+    """A site-owner (not team) cannot restructure parent company → 403."""
+    parent = _foreign_company(db_session, admin_user)
+    co = Company(name="Child Co", is_active=True, account_owner_id=admin_user.id, created_at=_now())
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    _site(db_session, co, owner_id=test_user.id)
+    resp = client.post(
+        f"/v2/partials/customers/{co.id}/edit",
+        data={"name": co.name, "parent_company_id": str(parent.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 403
+    db_session.refresh(co)
+    assert co.parent_company_id is None
+
+
+def test_g1_primary_owner_can_reassign(client, db_session, test_user, admin_user):
+    """The primary account owner CAN reassign primary ownership → 200."""
+    co = _owned_company(db_session, test_user)  # test_user is primary owner
+    resp = client.post(
+        f"/v2/partials/customers/{co.id}/edit",
+        data={"name": co.name, "owner_id": str(admin_user.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    db_session.refresh(co)
+    assert co.account_owner_id == admin_user.id
+
+
+def test_g1_manager_can_reassign(client, db_session, test_user, admin_user):
+    """A manager may reassign even an account they don't own → 200."""
+    test_user.role = UserRole.MANAGER
+    db_session.commit()
+    co = _foreign_company(db_session, admin_user)
+    resp = client.post(
+        f"/v2/partials/customers/{co.id}/edit",
+        data={"name": co.name, "owner_id": str(test_user.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    db_session.refresh(co)
+    assert co.account_owner_id == test_user.id
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FIX GROUP 2 — ai.py site-linked prospect records need can_manage_account
+# Routes: DELETE /api/ai/prospect-contacts/{id}  (2a)
+#         POST   /api/ai/prospect-contacts/{id}/save  (2b)
+#         POST   /api/ai/apply-freeform-rfq  (2c)
+# Helper: can_manage_account
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _site_linked_pc(db_session, site):
+    pc = ProspectContact(
+        customer_site_id=site.id,
+        full_name="Jane Doe",
+        email="jane@x.com",
+        source="web_search",
+        confidence="high",
+    )
+    db_session.add(pc)
+    db_session.commit()
+    db_session.refresh(pc)
+    return pc
+
+
+def test_g2a_delete_site_prospect_blocks_non_owner(client, db_session, test_user, admin_user):
+    co = _foreign_company(db_session, admin_user)
+    site = _site(db_session, co)  # no site owner → test_user (buyer, not manager) cannot manage
+    pc = _site_linked_pc(db_session, site)
+    resp = client.delete(f"/api/ai/prospect-contacts/{pc.id}")
+    assert resp.status_code == 403
+    assert db_session.get(ProspectContact, pc.id) is not None  # NOT deleted
+
+
+def test_g2b_save_site_prospect_blocks_non_owner(client, db_session, test_user, admin_user):
+    co = _foreign_company(db_session, admin_user)
+    site = _site(db_session, co)
+    pc = _site_linked_pc(db_session, site)
+    resp = client.post(f"/api/ai/prospect-contacts/{pc.id}/save")
+    assert resp.status_code == 403
+    db_session.refresh(pc)
+    assert pc.is_saved is False  # NOT mutated
+
+
+def test_g2_site_prospect_allows_account_owner(client, db_session, test_user):
+    co = _owned_company(db_session, test_user)  # test_user is account owner
+    site = _site(db_session, co)
+    pc = _site_linked_pc(db_session, site)
+    resp = client.post(f"/api/ai/prospect-contacts/{pc.id}/save")
+    assert resp.status_code == 200
+    db_session.refresh(pc)
+    assert pc.is_saved is True
+
+
+def test_g2_vendor_linked_prospect_stays_global(client, db_session, test_user, test_vendor_card):
+    """Vendor-linked prospects have no account owner — the gate is a no-op (200)."""
+    pc = ProspectContact(
+        vendor_card_id=test_vendor_card.id,
+        full_name="Vendor Rep",
+        email="rep@vendor.com",
+        source="web_search",
+        confidence="high",
+    )
+    db_session.add(pc)
+    db_session.commit()
+    db_session.refresh(pc)
+    resp = client.post(f"/api/ai/prospect-contacts/{pc.id}/save")
+    assert resp.status_code == 200
+
+
+def test_g2c_apply_freeform_rfq_blocks_non_owner(client, db_session, test_user, admin_user):
+    co = _foreign_company(db_session, admin_user)
+    site = _site(db_session, co)
+    resp = client.post(
+        "/api/ai/apply-freeform-rfq",
+        json={
+            "name": "RFQ",
+            "customer_name": "Cust",
+            "customer_site_id": site.id,
+            "requirements": [{"primary_mpn": "LM317T", "target_qty": 10}],
+        },
+    )
+    assert resp.status_code == 403
+
+
+def test_g2c_apply_freeform_rfq_allows_owner(client, db_session, test_user):
+    co = _owned_company(db_session, test_user)
+    site = _site(db_session, co)
+    with (
+        patch("app.services.ai_offer_service.apply_freeform_rfq") as mock_apply,
+        patch("app.cache.decorators.invalidate_prefix"),
+    ):
+        mock_apply.return_value = {"requisition_id": 1, "requirements_created": 1}
+        resp = client.post(
+            "/api/ai/apply-freeform-rfq",
+            json={
+                "name": "RFQ",
+                "customer_name": "Cust",
+                "customer_site_id": site.id,
+                "requirements": [{"primary_mpn": "LM317T", "target_qty": 10}],
+            },
+        )
+    assert resp.status_code == 200
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FIX GROUP 3 — proactive do-not-offer per-account authz + per-owner scope
+# Route: POST /api/proactive/do-not-offer  (proactive.add_do_not_offer)
+# Helper: can_manage_account  (+ salesperson_id scope on auto-dismiss)
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _proactive_match(db_session, *, company, salesperson_id, mpn="LM317T", status="new"):
+    """A complete ProactiveMatch (offer_id/requirement_id are NOT NULL) for the given
+    owner."""
+    req = _requisition(db_session, salesperson_id, name=f"REQ-PM-{salesperson_id}")
+    item = db_session.query(Requirement).filter_by(requisition_id=req.id).first()
+    site = _site(db_session, company)
+    offer = Offer(
+        requisition_id=req.id,
+        requirement_id=item.id,
+        vendor_name="V",
+        mpn=mpn,
+        unit_price=Decimal("1.00"),
+        qty_available=10,
+        entered_by_id=salesperson_id,
+        status="active",
+        created_at=_now(),
+    )
+    db_session.add(offer)
+    db_session.flush()
+    match = ProactiveMatch(
+        offer_id=offer.id,
+        requirement_id=item.id,
+        requisition_id=req.id,
+        customer_site_id=site.id,
+        salesperson_id=salesperson_id,
+        company_id=company.id,
+        mpn=mpn,
+        status=status,
+        created_at=_now(),
+    )
+    db_session.add(match)
+    db_session.commit()
+    db_session.refresh(match)
+    return match
+
+
+def test_g3_do_not_offer_blocks_non_owner_and_preserves_other_matches(client, db_session, test_user, admin_user):
+    """Non-owner do-not-offer → 403, no DNO row, the owner's 'new' matches untouched."""
+    co = _foreign_company(db_session, admin_user)  # owned by admin_user, not test_user
+    # admin_user's open match for the same mpn+company — must survive
+    owner_match = _proactive_match(db_session, company=co, salesperson_id=admin_user.id)
+
+    resp = client.post(
+        "/api/proactive/do-not-offer",
+        json={"items": [{"mpn": "LM317T", "company_id": co.id}]},
+    )
+    assert resp.status_code == 403
+    # No suppression row created
+    assert db_session.query(ProactiveDoNotOffer).filter_by(company_id=co.id).count() == 0
+    # The rightful owner's open match is untouched
+    db_session.refresh(owner_match)
+    assert owner_match.status == "new"
+
+
+def test_g3_do_not_offer_allows_owner_and_dismisses_only_own_match(client, db_session, test_user, admin_user):
+    """Owner → 200; auto-dismiss scoped to salesperson_id (other owner's match
+    survives)."""
+    co = _owned_company(db_session, test_user)
+    my_match = _proactive_match(db_session, company=co, salesperson_id=test_user.id)
+    other_match = _proactive_match(db_session, company=co, salesperson_id=admin_user.id)
+
+    resp = client.post(
+        "/api/proactive/do-not-offer",
+        json={"items": [{"mpn": "LM317T", "company_id": co.id}]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["suppressed"] == 1
+    db_session.refresh(my_match)
+    db_session.refresh(other_match)
+    assert my_match.status == "dismissed"  # own match dismissed
+    assert other_match.status == "new"  # the OTHER owner's match untouched
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FIX GROUP 4 — email-mining parse-response-attachments needs req ownership
+# Route: POST /api/email-mining/parse-response-attachments/{response_id}
+# Helper: require_requisition_access
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _vendor_response(db_session, owner_id, *, message_id="msg-x"):
+    req = _requisition(db_session, owner_id, name="REQ-VR")
+    vr = VendorResponse(
+        requisition_id=req.id,
+        vendor_name="ACME",
+        vendor_email="s@acme.com",
+        subject="re",
+        message_id=message_id,
+        status="new",
+        received_at=_now(),
+        created_at=_now(),
+    )
+    db_session.add(vr)
+    db_session.commit()
+    db_session.refresh(vr)
+    return vr
+
+
+def _connect_m365(test_user, db_session):
+    """The parse route gates on M365 connection BEFORE the ownership check; satisfy it
+    so the ownership boundary is the thing under test."""
+    test_user.m365_connected = True
+    test_user.access_token = "test-token"
+    db_session.commit()
+
+
+def test_g4_parse_attachments_blocks_non_owner_sales(client, db_session, test_user, admin_user):
+    vr = _vendor_response(db_session, admin_user.id)  # foreign requisition
+    _connect_m365(test_user, db_session)
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/api/email-mining/parse-response-attachments/{vr.id}")
+    assert resp.status_code == 404
+
+
+def test_g4_parse_attachments_blocks_non_owner_trader(client, db_session, test_user, admin_user):
+    vr = _vendor_response(db_session, admin_user.id)
+    _connect_m365(test_user, db_session)
+    _make_trader(test_user, db_session)
+    resp = client.post(f"/api/email-mining/parse-response-attachments/{vr.id}")
+    assert resp.status_code == 404
+
+
+def test_g4_parse_attachments_owner_passes_ownership_gate(client, db_session, test_user):
+    """Owner is past the ownership gate; later logic 400s (no message_id) — NOT a
+    404."""
+    vr = _vendor_response(db_session, test_user.id, message_id=None)
+    _connect_m365(test_user, db_session)
+    _make_sales(test_user, db_session)  # restricted but OWNS the requisition
+    resp = client.post(f"/api/email-mining/parse-response-attachments/{vr.id}")
+    assert resp.status_code != 404  # passed the ownership gate (400 from missing message_id)
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FIX GROUP 5 — prepayment creation needs buy-plan ownership (service layer)
+# Route: POST /v2/prepayments  (prepayments.post_prepayment → create_prepayment)
+# Helper: get_buyplan_for_user
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _buy_plan(db_session, owner_id):
+    req = _requisition(db_session, owner_id, name="REQ-PP")
+    quote = Quote(
+        requisition_id=req.id,
+        quote_number="Q-PP",
+        status="sent",
+        line_items=[],
+        created_by_id=owner_id,
+        created_at=_now(),
+    )
+    db_session.add(quote)
+    db_session.flush()
+    bp = BuyPlan(quote_id=quote.id, requisition_id=req.id, status="draft", so_status="pending")
+    db_session.add(bp)
+    db_session.commit()
+    db_session.refresh(bp)
+    return bp
+
+
+def test_g5_prepayment_blocks_restricted_non_owner_sales(client, db_session, test_user, admin_user):
+    bp = _buy_plan(db_session, admin_user.id)  # foreign buy plan
+    _make_sales(test_user, db_session)
+    resp = client.post(
+        "/v2/prepayments",
+        json={"buy_plan_id": bp.id, "total_incl_fees": "100.00"},
+    )
+    assert resp.status_code == 404
+    # No prepayment attached to the foreign plan
+    from app.models.quality_plan import Prepayment
+
+    assert db_session.query(Prepayment).filter_by(buy_plan_id=bp.id).count() == 0
+
+
+def test_g5_prepayment_allows_buyer_owner(client, db_session, test_user):
+    bp = _buy_plan(db_session, test_user.id)  # test_user (buyer) owns the requisition
+    resp = client.post(
+        "/v2/prepayments",
+        json={"buy_plan_id": bp.id, "total_incl_fees": "100.00"},
+    )
+    # Past the ownership gate. Routing may raise NoEligibleApprover (no approvers seeded);
+    # the security boundary is simply that it is NOT a 404 buy-plan-ownership rejection.
+    assert resp.status_code != 404
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FIX GROUP 6 — htmx requisition-scoped mutations need require_requisition_access
+# Routes: 6a POST /v2/partials/sourcing/{requirement_id}/search
+#         6b POST /v2/partials/follow-ups/send-batch (+ follow_up_badge scope)
+#         6c POST /v2/partials/requisitions/{req_id}/ai-rephrase-email
+# Helpers: require_requisition_access / RESTRICTED_ROLES scope
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_g6a_sourcing_search_blocks_non_owner_sales(client, db_session, test_user, admin_user):
+    req = _requisition(db_session, admin_user.id, name="REQ-SRC")
+    item = db_session.query(Requirement).filter_by(requisition_id=req.id).first()
+    _make_sales(test_user, db_session)
+    resp = client.post(f"/v2/partials/sourcing/{item.id}/search")
+    assert resp.status_code == 404
+
+
+def test_g6c_ai_rephrase_email_blocks_non_owner_sales(client, db_session, test_user, admin_user):
+    req = _requisition(db_session, admin_user.id, name="REQ-REPH")
+    _make_sales(test_user, db_session)
+    resp = client.post(
+        f"/v2/partials/requisitions/{req.id}/ai-rephrase-email",
+        data={"body": "hello"},
+    )
+    assert resp.status_code == 404
+
+
+def test_g6b_send_batch_leaves_other_owners_stale_contacts_untouched(client, db_session, test_user, admin_user):
+    """A SALES user's send-batch must not touch another owner's stale RfqContact."""
+    stale_at = _now() - __import__("datetime").timedelta(days=30)
+    # Another owner's requisition + a stale 'sent' email contact under it
+    other_req = _requisition(db_session, admin_user.id, name="REQ-OTHER-FU")
+    other_contact = RfqContact(
+        requisition_id=other_req.id,
+        user_id=admin_user.id,
+        contact_type="email",
+        vendor_name="OtherVendor",
+        status="sent",
+        created_at=stale_at,
+    )
+    db_session.add(other_contact)
+    db_session.commit()
+
+    _make_sales(test_user, db_session)  # restricted role, owns nothing here
+    resp = client.post("/v2/partials/follow-ups/send-batch")
+    assert resp.status_code == 200
+    db_session.refresh(other_contact)
+    # The other owner's stale contact was NOT acted on by this user's batch
+    assert other_contact.status == "sent"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FIX GROUP 7 — create_quote must scope offer_ids to the target requisition
+# Route: POST /api/requisitions/{req_id}/quote  (crm.quotes.create_quote)
+# Helper: Offer.requisition_id == req_id filter (+ on_quote_built scope)
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_g7_create_quote_rejects_foreign_offer_and_leaves_req_b_untouched(client, db_session, test_user, admin_user):
+    """Owner of req A cannot pull a foreign offer (req B) into the quote → 400; req B's
+    requirement status unchanged."""
+    site = _site(db_session, _owned_company(db_session, test_user))
+    req_a = _requisition(db_session, test_user.id, name="REQ-A", site_id=site.id)
+    req_b = _requisition(db_session, admin_user.id, name="REQ-B")
+    item_b = db_session.query(Requirement).filter_by(requisition_id=req_b.id).first()
+    status_before = item_b.sourcing_status
+
+    foreign_offer = Offer(
+        requisition_id=req_b.id,
+        requirement_id=item_b.id,
+        vendor_name="V",
+        mpn="LM317T",
+        unit_price=Decimal("1.00"),
+        qty_available=10,
+        entered_by_id=admin_user.id,
+        status="active",
+        created_at=_now(),
+    )
+    db_session.add(foreign_offer)
+    db_session.commit()
+
+    resp = client.post(
+        f"/api/requisitions/{req_a.id}/quote",
+        json={"offer_ids": [foreign_offer.id], "line_items": []},
+    )
+    assert resp.status_code == 400  # offer does not belong to this requisition
+    # No quote created for req A
+    assert db_session.query(Quote).filter_by(requisition_id=req_a.id).count() == 0
+    # Req B's requirement was NOT advanced to 'quoted'
+    db_session.refresh(item_b)
+    assert item_b.sourcing_status == status_before
+
+
+def test_g7_create_quote_allows_own_offer(client, db_session, test_user):
+    site = _site(db_session, _owned_company(db_session, test_user))
+    req = _requisition(db_session, test_user.id, name="REQ-OWN", site_id=site.id)
+    item = db_session.query(Requirement).filter_by(requisition_id=req.id).first()
+    own_offer = Offer(
+        requisition_id=req.id,
+        requirement_id=item.id,
+        vendor_name="V",
+        mpn="LM317T",
+        unit_price=Decimal("1.00"),
+        qty_available=10,
+        entered_by_id=test_user.id,
+        status="active",
+        created_at=_now(),
+    )
+    db_session.add(own_offer)
+    db_session.commit()
+
+    resp = client.post(
+        f"/api/requisitions/{req.id}/quote",
+        json={"offer_ids": [own_offer.id], "line_items": []},
+    )
+    assert resp.status_code == 200
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FIX GROUP 8 — QP submit/read need requisition-ownership scope
+# Routes: GET /v2/qp/{qp_id}, POST /v2/qp/{qp_id}/submit  (quality_plans)
+# Helper: require_requisition_access (via _require_qp_access)
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _quality_plan(db_session, owner_id):
+    req = _requisition(db_session, owner_id, name="REQ-QP")
+    quote = Quote(requisition_id=req.id, quote_number="Q-QP", status="sent", line_items=[], created_at=_now())
+    db_session.add(quote)
+    db_session.flush()
+    bp = BuyPlan(quote_id=quote.id, requisition_id=req.id, status="draft", so_status="pending")
+    db_session.add(bp)
+    db_session.flush()
+    qp = QualityPlan(buy_plan_id=bp.id, created_by_id=owner_id, status="draft", order_type="new")
+    db_session.add(qp)
+    db_session.commit()
+    db_session.refresh(qp)
+    return qp
+
+
+def test_g8_qp_detail_blocks_non_owner_sales(client, db_session, test_user, admin_user):
+    qp = _quality_plan(db_session, admin_user.id)
+    _make_sales(test_user, db_session)
+    resp = client.get(f"/v2/qp/{qp.id}")
+    assert resp.status_code == 404
+
+
+def test_g8_qp_submit_blocks_non_owner_trader(client, db_session, test_user, admin_user):
+    qp = _quality_plan(db_session, admin_user.id)
+    _make_trader(test_user, db_session)
+    resp = client.post(f"/v2/qp/{qp.id}/submit")
+    assert resp.status_code == 404
+    db_session.refresh(qp)
+    assert qp.status == "draft"  # not submitted
+
+
+def test_g8_qp_detail_allows_owner(client, db_session, test_user):
+    qp = _quality_plan(db_session, test_user.id)
+    resp = client.get(f"/v2/qp/{qp.id}")
+    assert resp.status_code == 200
+
+
+def test_g8_qp_detail_allows_manager(client, db_session, test_user, admin_user):
+    qp = _quality_plan(db_session, admin_user.id)  # owned by someone else
+    test_user.role = UserRole.MANAGER
+    db_session.commit()
+    resp = client.get(f"/v2/qp/{qp.id}")
+    assert resp.status_code == 200
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# FIX GROUP 9 — create_company owner assignment needs manager gate + active user
+# Route: POST /v2/partials/customers/create  (htmx_views.create_company)
+# Helper: is_manager_or_admin (+ active-user validation)
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_g9_rep_cannot_assign_other_owner(client, db_session, test_user, admin_user):
+    """A plain rep (buyer) assigning another user as owner → 403."""
+    resp = client.post(
+        "/v2/partials/customers/create",
+        data={"name": "G9 RepBlocked Co", "owner_id": str(admin_user.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 403
+    assert db_session.query(Company).filter_by(name="G9 RepBlocked Co").count() == 0
+
+
+def test_g9_rep_can_assign_self(client, db_session, test_user):
+    resp = client.post(
+        "/v2/partials/customers/create",
+        data={"name": "G9 RepSelf Co", "owner_id": str(test_user.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    co = db_session.query(Company).filter_by(name="G9 RepSelf Co").first()
+    assert co is not None and co.account_owner_id == test_user.id
+
+
+def test_g9_manager_inactive_owner_rejected(client, db_session, test_user, admin_user):
+    """Manager assigning an INACTIVE owner → 400."""
+    test_user.role = UserRole.MANAGER
+    admin_user.is_active = False
+    db_session.commit()
+    resp = client.post(
+        "/v2/partials/customers/create",
+        data={"name": "G9 Inactive Co", "owner_id": str(admin_user.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 400
+    assert db_session.query(Company).filter_by(name="G9 Inactive Co").count() == 0
+
+
+def test_g9_manager_can_assign_active_user(client, db_session, test_user, admin_user):
+    test_user.role = UserRole.MANAGER
+    db_session.commit()
+    resp = client.post(
+        "/v2/partials/customers/create",
+        data={"name": "G9 MgrAssign Co", "owner_id": str(admin_user.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    co = db_session.query(Company).filter_by(name="G9 MgrAssign Co").first()
+    assert co is not None and co.account_owner_id == admin_user.id
+
+
+@pytest.fixture(autouse=True)
+def _ai_features_on(monkeypatch):
+    """Group-2 ai routes sit behind the AI gate; enable so ownership guards are
+    reached."""
+    monkeypatch.setattr(settings, "ai_features_enabled", "all")
+    yield

--- a/tests/test_authz_hardening.py
+++ b/tests/test_authz_hardening.py
@@ -691,6 +691,121 @@ def test_g9_manager_can_assign_active_user(client, db_session, test_user, admin_
     assert co is not None and co.account_owner_id == admin_user.id
 
 
+# ══════════════════════════════════════════════════════════════════════════
+# SIBLING ROUTES — htmx_views reaches the SAME mutations as Group 2 / Group 3.
+# These were pre-existing un-gated twins of the gated ai.py / proactive.py routes;
+# they now reuse the SAME helpers (require_prospect_site_access / can_manage_account).
+#
+# Concern A — vendor_prospect_{save,delete} on a SITE-linked prospect:
+#   POST   /v2/partials/vendors/{vendor_id}/ai/prospect/{prospect_id}/save
+#   DELETE /v2/partials/vendors/{vendor_id}/ai/prospect/{prospect_id}
+# Concern B — proactive do-not-offer for a foreign company:
+#   POST   /v2/partials/proactive/do-not-offer
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_siblingA_htmx_vendor_prospect_save_blocks_non_owner(
+    client, db_session, test_user, admin_user, test_vendor_card
+):
+    """A SALES non-owner saving a site-linked prospect via the htmx twin → 403, no
+    mutation."""
+    _make_sales(test_user, db_session)
+    co = _foreign_company(db_session, admin_user)
+    site = _site(db_session, co)  # no site owner → SALES non-owner cannot manage
+    pc = _site_linked_pc(db_session, site)
+    resp = client.post(
+        f"/v2/partials/vendors/{test_vendor_card.id}/ai/prospect/{pc.id}/save",
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 403
+    db_session.refresh(pc)
+    assert pc.is_saved is False  # NOT mutated
+
+
+def test_siblingA_htmx_vendor_prospect_delete_blocks_non_owner(
+    client, db_session, test_user, admin_user, test_vendor_card
+):
+    """A SALES non-owner deleting a site-linked prospect via the htmx twin → 403, row
+    survives."""
+    _make_sales(test_user, db_session)
+    co = _foreign_company(db_session, admin_user)
+    site = _site(db_session, co)
+    pc = _site_linked_pc(db_session, site)
+    resp = client.delete(
+        f"/v2/partials/vendors/{test_vendor_card.id}/ai/prospect/{pc.id}",
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 403
+    assert db_session.get(ProspectContact, pc.id) is not None  # NOT deleted
+
+
+def test_siblingA_htmx_vendor_prospect_save_allows_owner(client, db_session, test_user, test_vendor_card):
+    """The account owner saving a site-linked prospect via the htmx twin → 200,
+    mutated."""
+    co = _owned_company(db_session, test_user)  # test_user is account owner
+    site = _site(db_session, co)
+    pc = _site_linked_pc(db_session, site)
+    resp = client.post(
+        f"/v2/partials/vendors/{test_vendor_card.id}/ai/prospect/{pc.id}/save",
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    db_session.refresh(pc)
+    assert pc.is_saved is True
+
+
+def test_siblingA_htmx_vendor_prospect_save_vendor_linked_stays_global(client, db_session, test_user, test_vendor_card):
+    """A vendor-linked prospect has no account owner — the gate is a no-op even for
+    SALES."""
+    _make_sales(test_user, db_session)
+    pc = ProspectContact(
+        vendor_card_id=test_vendor_card.id,
+        full_name="Vendor Rep",
+        email="rep@vendor.com",
+        source="web_search",
+        confidence="high",
+    )
+    db_session.add(pc)
+    db_session.commit()
+    db_session.refresh(pc)
+    resp = client.post(
+        f"/v2/partials/vendors/{test_vendor_card.id}/ai/prospect/{pc.id}/save",
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    db_session.refresh(pc)
+    assert pc.is_saved is True
+
+
+def test_siblingB_htmx_do_not_offer_blocks_non_owner(client, db_session, test_user, admin_user):
+    """A SALES non-owner suppressing a foreign company's MPN via the htmx twin → 403, no
+    row."""
+    _make_sales(test_user, db_session)
+    co = _foreign_company(db_session, admin_user)  # owned by admin_user
+    resp = client.post(
+        "/v2/partials/proactive/do-not-offer",
+        data={"mpn": "LM317T", "company_id": str(co.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 403
+    assert db_session.query(ProactiveDoNotOffer).filter_by(company_id=co.id).count() == 0
+
+
+def test_siblingB_htmx_do_not_offer_allows_owner(client, db_session, test_user):
+    """The account owner suppressing their own company's MPN via the htmx twin → 200,
+    row created."""
+    co = _owned_company(db_session, test_user)
+    resp = client.post(
+        "/v2/partials/proactive/do-not-offer",
+        data={"mpn": "lm317t", "company_id": str(co.id)},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 200
+    rows = db_session.query(ProactiveDoNotOffer).filter_by(company_id=co.id).all()
+    assert len(rows) == 1
+    assert rows[0].mpn == "LM317T"  # upper-cased on insert
+
+
 @pytest.fixture(autouse=True)
 def _ai_features_on(monkeypatch):
     """Group-2 ai routes sit behind the AI gate; enable so ownership guards are

--- a/tests/test_htmx_views_deep.py
+++ b/tests/test_htmx_views_deep.py
@@ -547,6 +547,7 @@ class TestProactiveRoutes:
 
     def test_proactive_do_not_offer_valid(self, client: TestClient, db_session: Session, test_user: User):
         co = _company(db_session)
+        co.account_owner_id = test_user.id  # actor must manage the account (authz gate)
         db_session.commit()
         with patch("app.services.proactive_helpers.is_do_not_offer", return_value=True):
             resp = client.post(

--- a/tests/test_htmx_views_nightly11.py
+++ b/tests/test_htmx_views_nightly11.py
@@ -488,7 +488,11 @@ class TestProactiveDoNotOffer:
         )
         assert resp.status_code == 400
 
-    def test_do_not_offer_creates_record(self, client: TestClient, db_session: Session, test_company: Company):
+    def test_do_not_offer_creates_record(
+        self, client: TestClient, db_session: Session, test_company: Company, test_user: User
+    ):
+        test_company.account_owner_id = test_user.id  # actor must manage the account (authz gate)
+        db_session.commit()
         resp = client.post(
             "/v2/partials/proactive/do-not-offer",
             data={"mpn": "LM317T", "company_id": str(test_company.id)},
@@ -500,7 +504,11 @@ class TestProactiveDoNotOffer:
         assert rec is not None
         assert rec.mpn == "LM317T"
 
-    def test_do_not_offer_duplicate_is_idempotent(self, client: TestClient, db_session: Session, test_company: Company):
+    def test_do_not_offer_duplicate_is_idempotent(
+        self, client: TestClient, db_session: Session, test_company: Company, test_user: User
+    ):
+        test_company.account_owner_id = test_user.id  # actor must manage the account (authz gate)
+        db_session.commit()
         client.post(
             "/v2/partials/proactive/do-not-offer",
             data={"mpn": "LM317T", "company_id": str(test_company.id)},

--- a/tests/test_htmx_views_nightly2.py
+++ b/tests/test_htmx_views_nightly2.py
@@ -694,6 +694,7 @@ class TestProactiveRoutes:
             name="Test Co",
             website="https://testco.com",
             is_active=True,
+            account_owner_id=test_user.id,  # actor must manage the account (authz gate)
             created_at=datetime.now(timezone.utc),
         )
         db_session.add(company)

--- a/tests/test_routers_ai.py
+++ b/tests/test_routers_ai.py
@@ -1130,7 +1130,9 @@ def test_apply_freeform_rfq_success(ai_client, db_session, ai_test_user):
     """POST /api/ai/apply-freeform-rfq creates requisition + requirements."""
     from app.models import Company, CustomerSite, Requirement, Requisition
 
-    co = Company(name="Apply Co", is_active=True)
+    # apply-freeform-rfq now gates the site's account on can_manage_account — make the
+    # actor the account owner so the (real) create path runs.
+    co = Company(name="Apply Co", is_active=True, account_owner_id=ai_test_user.id)
     db_session.add(co)
     db_session.flush()
     site = CustomerSite(company_id=co.id, site_name="Apply HQ")

--- a/tests/test_routers_proactive.py
+++ b/tests/test_routers_proactive.py
@@ -466,8 +466,11 @@ class TestDoNotOffer:
         resp = client.post("/api/proactive/do-not-offer", json={"items": []})
         assert resp.status_code == 400
 
-    def test_do_not_offer_success(self, client, db_session, test_company):
+    def test_do_not_offer_success(self, client, db_session, test_company, test_user):
         """Suppresses MPNs and returns count."""
+        # do-not-offer is now an account action (can_manage_account); grant ownership.
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
         resp = client.post(
             "/api/proactive/do-not-offer",
             json={
@@ -495,8 +498,11 @@ class TestDoNotOffer:
         assert resp.status_code == 200
         assert resp.json()["suppressed"] == 0
 
-    def test_do_not_offer_duplicate_ignored(self, client, db_session, test_company):
+    def test_do_not_offer_duplicate_ignored(self, client, db_session, test_company, test_user):
         """Second suppression of same MPN+company is not counted again."""
+        # do-not-offer is now an account action (can_manage_account); grant ownership.
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
         payload = {"items": [{"mpn": "LM317T", "company_id": test_company.id}]}
         resp1 = client.post("/api/proactive/do-not-offer", json=payload)
         assert resp1.json()["suppressed"] == 1
@@ -507,6 +513,9 @@ class TestDoNotOffer:
         self, client, db_session, test_company, test_user, test_requisition, test_offer, test_customer_site
     ):
         """Suppression auto-dismisses open proactive matches."""
+        # do-not-offer is now an account action (can_manage_account); grant ownership.
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
         match = _make_match(
             db_session, test_user, test_requisition, test_offer, test_customer_site, company_id=test_company.id
         )

--- a/tests/test_sprint8_proactive.py
+++ b/tests/test_sprint8_proactive.py
@@ -123,7 +123,9 @@ class TestProactiveBadge:
 
 
 class TestDoNotOffer:
-    def test_suppress(self, client: TestClient, test_company):
+    def test_suppress(self, client: TestClient, db_session: Session, test_company, test_user: User):
+        test_company.account_owner_id = test_user.id  # actor must manage the account (authz gate)
+        db_session.commit()
         resp = client.post(
             "/v2/partials/proactive/do-not-offer",
             data={"mpn": "LM317T", "customer_site_id": str(test_company.id)},


### PR DESCRIPTION
## Pre-multi-user authorization hardening

Closes 15 confirmed object-level authz gaps found by an adversarially-verified audit of all 386 mutating routes on main (13 primary + 2 sibling-route bypasses caught by the security gap-closure review). Every fix reuses an existing server-side helper — no band-aids.

**Helpers reused:** `can_manage_account` / `can_manage_account_team` / `require_requisition_access` / `get_buyplan_for_user` / `is_manager_or_admin`, plus a new shared `require_prospect_site_access` (extracted from `ai.py`, used by both `ai.py` and `htmx_views.py`).

**Top risks closed:** account-ownership seizure (`edit_company`), cross-account prospect-contact delete (incl. the `vendor_prospect_delete` sibling), global proactive suppression (both routes), cross-owner Sighting injection, attaching a financial Prepayment+approval to any buy plan, cross-owner quote/offer disclosure.

**Tests:** `tests/test_authz_hardening.py` (36 route tests — cross-account 403/404 + legitimate owner/manager allowed + per-owner data-isolation asserts). Broad sweep 4,395 passed / 0 failed. Happy-path breaks fixed by granting ownership in setup (gates untouched). No migration. APP_MAP_INTERACTIONS updated.

**Review:** dual adversarial review (regression-clean + security gap-closure) — the gap-closure pass is what surfaced the 2 sibling bypasses, now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)