### PR TITLE
feat(qp-c1): activate the approvals engine's buy-plan gate; retire the bridge

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -894,6 +894,7 @@ class AlertKind(StrEnum):
     INBOUND_VENDOR = "inbound_vendor"
     BUYPLAN_ACTION = "buyplan_action"
     TASKS_ACTION = "tasks_action"
+    APPROVAL_ACTION = "approval_action"
 
 
 class SightingsSkipReason(StrEnum):
@@ -941,12 +942,14 @@ class ApprovalSubjectType(StrEnum):
 
     Single source of truth for the approval_requests.subject_type column. The
     (subject_type, subject_id) pair points back at the originating entity without a
-    cross-table FK (mirrors MaterialCardAudit.material_card_id). BUY_PLAN, QUOTE, and
-    RESELL_OFFER are added by later phases (QP Phase C) when their fan-out lands.
+    cross-table FK (mirrors MaterialCardAudit.material_card_id). BUY_PLAN (QP Phase C1)
+    routes the live buy-plan gate through the engine; QUOTE and RESELL_OFFER follow in
+    later phases when their fan-out lands.
     """
 
     QUALITY_PLAN = "quality_plan"
     PREPAYMENT = "prepayment"
+    BUY_PLAN = "buy_plan"
 
 
 class ApprovalRequestStatus(StrEnum):

--- a/app/routers/approvals.py
+++ b/app/routers/approvals.py
@@ -5,14 +5,15 @@ Purpose: HTTP surface for approval workflows. Returns JSON; HTMX partials can
            - app.services.approvals.service (decide)
            - app.services.approvals.events (reassign, cancel)
 
-         Task 12: GET /v2/approvals/requests also merges pending BuyPlan rows
-         (read-only bridge). GET /v2/approvals/queue renders the HTML queue
-         template surfacing both engine requests and pending buy-plan approvals.
+         QP Phase C1: the engine OWNS the buy-plan gate, so list_requests and the
+         /v2/approvals/queue view are engine-only — a buy-plan submission surfaces here
+         as a native ApprovalRequest (gate_type=buy_plan, subject_type=buy_plan). The old
+         read-only buy-plan bridge has been retired.
 
 Called by: app.main (router registration).
 Depends on: app.services.approvals.service, app.services.approvals.events,
             app.dependencies (require_user, require_approval_gatekeeper),
-            app.database (get_db), app.models.approvals, app.models.buy_plan,
+            app.database (get_db), app.models.approvals,
             app.constants, app.template_env.
 """
 
@@ -25,7 +26,6 @@ from ..database import get_db
 from ..dependencies import require_approval_gatekeeper, require_user
 from ..models.approvals import ApprovalRequest
 from ..models.auth import User
-from ..models.buy_plan import BuyPlan
 from ..services.approvals.events import cancel as svc_cancel
 from ..services.approvals.events import reassign as svc_reassign
 from ..services.approvals.service import decide as svc_decide
@@ -37,14 +37,17 @@ router = APIRouter(tags=["approvals"])
 def _serialize_request(r: ApprovalRequest) -> dict:
     """Project an ApprovalRequest to its JSON shape (shared by list + detail).
 
-    The 9-field engine-item projection: id, gate_type, status, amount-as-str, currency,
-    requested_by_id, owner_id, resolved_at (iso), resolution_note, created_at (iso).
-    Distinct from `_buy_plan_as_queue_item` (the read-only buy-plan bridge contract).
+    The 11-field engine-item projection: id, gate_type, status, subject_type, subject_id,
+    amount-as-str, currency, requested_by_id, owner_id, resolved_at (iso), resolution_note,
+    created_at (iso). subject_type/subject_id let a caller link a buy_plan request back to
+    its plan detail partial.
     """
     return {
         "id": r.id,
         "gate_type": r.gate_type,
         "status": r.status,
+        "subject_type": r.subject_type,
+        "subject_id": r.subject_id,
         "amount": str(r.amount) if r.amount is not None else None,
         "currency": r.currency,
         "requested_by_id": r.requested_by_id,
@@ -52,26 +55,6 @@ def _serialize_request(r: ApprovalRequest) -> dict:
         "resolved_at": r.resolved_at.isoformat() if r.resolved_at else None,
         "resolution_note": r.resolution_note,
         "created_at": r.created_at.isoformat() if r.created_at else None,
-    }
-
-
-def _buy_plan_as_queue_item(bp: BuyPlan) -> dict:
-    """Serialize a pending BuyPlan as a unified-queue item.
-
-    The source="buy_plan" field distinguishes these read-only bridge items from engine
-    ApprovalRequest items. detail_url links to the existing buy-plan detail partial
-    (which already has the gated approve/reject actions).
-    """
-    return {
-        "source": "buy_plan",
-        "subject_id": bp.id,
-        "gate_type": "buy_plan",
-        "status": bp.status,
-        "amount": str(bp.total_cost) if bp.total_cost is not None else None,
-        "currency": "USD",
-        "requested_by_id": bp.submitted_by_id,
-        "created_at": bp.created_at.isoformat() if bp.created_at else None,
-        "detail_url": f"/v2/partials/buy-plans/{bp.id}",
     }
 
 
@@ -158,36 +141,22 @@ def list_requests(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_user),
 ):
-    """List ApprovalRequests merged with pending BuyPlan approvals (read-only bridge).
+    """List engine ApprovalRequests (optionally filtered by gate_type / status).
 
-    Engine items come from ApprovalRequest; buy-plan items are read-only rows
-    for BuyPlans with status='pending' (Task 12 bridge). Buy-plan items carry
-    source='buy_plan' and detail_url so the caller can link to the existing
-    gated approve/reject UI without duplicating that action here.
+    QP Phase C1: engine-only. A buy-plan submission is a native ApprovalRequest
+    (gate_type=buy_plan, subject_type=buy_plan), so the old read-only buy-plan bridge is
+    gone — filter on gate_type='buy_plan' to get exactly the buy-plan requests.
 
     Returns: {"items": [...], "total": N}.
     """
     q = select(ApprovalRequest)
-    if gate_type and gate_type != "buy_plan":
+    if gate_type:
         q = q.where(ApprovalRequest.gate_type == gate_type)
-    elif gate_type:
-        # gate_type=buy_plan: engine has no such type; return only buy-plan bridge items
-        q = q.where(ApprovalRequest.gate_type == "__never__")
     if status:
         q = q.where(ApprovalRequest.status == status)
 
     rows = db.execute(q).scalars().all()
-
     items = [_serialize_request(r) for r in rows]
-
-    # Bridge: merge pending BuyPlan rows unless a non-buy_plan gate_type filter excludes them
-    include_buy_plans = not gate_type or gate_type == "buy_plan"
-    if include_buy_plans:
-        bp_status_filter = status if status else "pending"
-        if bp_status_filter == "pending":
-            bp_rows = db.execute(select(BuyPlan).where(BuyPlan.status == "pending")).scalars().all()
-            items.extend(_buy_plan_as_queue_item(bp) for bp in bp_rows)
-
     return {"items": items, "total": len(items)}
 
 
@@ -197,21 +166,19 @@ def get_queue(
     db: Session = Depends(get_db),
     current_user: User = Depends(require_user),
 ):
-    """Render the unified approvals queue as an HTMX partial.
+    """Render the engine approvals queue as an HTMX partial.
 
-    Surfaces both engine ApprovalRequests and pending BuyPlan approvals in one table.
-    Buy-plan rows link to the existing buy-plan detail partial where the gated
-    approve/reject actions already live. No behavior change to buy-plan approval — this
-    is read-only surfacing only.
+    QP Phase C1: engine-only. Every pending approval — buy plans included — is an
+    ApprovalRequest, so the queue renders one table of engine rows. A buy_plan-subject row
+    links to its plan detail partial and offers inline approve/reject posting to the
+    engine's decision endpoint.
     """
     engine_rows = db.execute(select(ApprovalRequest)).scalars().all()
-    buy_plan_rows = db.execute(select(BuyPlan).where(BuyPlan.status == "pending")).scalars().all()
 
     ctx = {
         "request": request,
         "current_user": current_user,
         "engine_requests": engine_rows,
-        "buy_plan_rows": buy_plan_rows,
     }
     return template_response("htmx/partials/approvals/_queue.html", ctx)
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -11117,7 +11117,20 @@ async def buy_plan_approve_partial(
 
     Gated by ``require_buyplan_approver`` (403 unless the user holds the per-user
     can_approve_buy_plans right). Reject requires a reason (enforced in the service).
+
+    QP Phase C1: the approval engine OWNS the gate. We look up the open BUY_PLAN
+    ApprovalRequest for this plan and resolve it via the engine's ``decide`` — which drives
+    the buy-plan side effects (ACTIVE + buyer tasks / DRAFT) in the SAME transaction. We let
+    ``decide`` raise (no swallowing) so a side-effect failure rolls back the whole decision
+    atomically (RISK 1). If NO open request exists — a plan that went PENDING before C1
+    deployed — we fall back to the legacy ``approve_buy_plan`` and log a WARNING (RISK 3,
+    transition window; the fallback is removed in a follow-up once no pre-C1 plans remain).
     """
+    from sqlalchemy import select as _select
+
+    from ..constants import ApprovalRequestStatus, ApprovalSubjectType
+    from ..models.approvals import ApprovalRequest
+    from ..services.approvals.service import decide as svc_decide
     from ..services.buyplan_notifications import (
         notify_approved,
         notify_rejected,
@@ -11128,14 +11141,36 @@ async def buy_plan_approve_partial(
     form = await request.form()
     action = form.get("action", "approve")
     origin = form.get("origin", "")
+    notes = form.get("notes")
+
+    open_request = (
+        db.execute(
+            _select(ApprovalRequest).where(
+                ApprovalRequest.subject_type == ApprovalSubjectType.BUY_PLAN,
+                ApprovalRequest.subject_id == plan_id,
+                ApprovalRequest.status == ApprovalRequestStatus.REQUESTED,
+            )
+        )
+        .scalars()
+        .first()
+    )
 
     try:
-        plan = approve_buy_plan(plan_id, action, user, db, notes=form.get("notes"))
+        if open_request is not None:
+            # Engine path: decide() resolves the request AND drives the plan side effects.
+            svc_decide(db, open_request.id, user, action, comment=notes or None)
+        else:
+            # RISK 3 fallback: plan pending pre-C1 with no engine request yet.
+            logger.warning(
+                "Buy plan {} approve/reject with no open engine request — falling back to legacy approve_buy_plan",
+                plan_id,
+            )
+            approve_buy_plan(plan_id, action, user, db, notes=notes)
         db.commit()
         if action == "approve":
-            await run_notify_bg(notify_approved, plan.id)
+            await run_notify_bg(notify_approved, plan_id)
         else:
-            await run_notify_bg(notify_rejected, plan.id)
+            await run_notify_bg(notify_rejected, plan_id)
     except PermissionError as e:
         # The dependency already 403s unauthorized callers; this maps the service's
         # defense-in-depth approval-right check to 403 (not 400) if it is ever reached.

--- a/app/services/alerts/sources/__init__.py
+++ b/app/services/alerts/sources/__init__.py
@@ -6,6 +6,7 @@ registry is fully populated. Tab keys match the nav item ids in mobile_nav.html.
 """
 
 from ..registry import register
+from .approvals import ApprovalRequestActionSource
 from .buyplan import BuyplanActionSource
 from .inbound_customer import InboundCustomerSource
 from .offers import OfferConfirmedSource
@@ -15,5 +16,12 @@ register("requisitions", OfferConfirmedSource())  # Sales Hub
 register("buy-plans", BuyplanActionSource())  # Buy Plans is its own primary nav tab
 register("crm", InboundCustomerSource())  # CRM — inbound from a customer
 register("my-day", TasksActionSource())  # My Day — open tasks assigned to me
+register("approvals", ApprovalRequestActionSource())  # Approvals — engine requests I must decide
 
-__all__ = ["OfferConfirmedSource", "BuyplanActionSource", "InboundCustomerSource", "TasksActionSource"]
+__all__ = [
+    "OfferConfirmedSource",
+    "BuyplanActionSource",
+    "InboundCustomerSource",
+    "TasksActionSource",
+    "ApprovalRequestActionSource",
+]

--- a/app/services/alerts/sources/approvals.py
+++ b/app/services/alerts/sources/approvals.py
@@ -1,0 +1,73 @@
+"""ApprovalRequestActionSource — ACTION alert for engine approvals awaiting MY decision.
+
+Surfaces the open approval work the current user personally owns: every REQUESTED
+ApprovalRequest on which the user holds a PENDING recipient row — exactly the set the
+engine's ``decide`` would let them act on. Covers ALL engine gates (buy_plan, prepayment,
+…) since C1 routes the live buy-plan gate through the engine, so a pending buy plan now
+counts here for its assigned approvers (the buy-plans tab still counts the buyer-PO and
+ops-verify steps; the approval decision moved to this Approvals tab).
+
+As an ACTION source the count derives PURELY from work-state: it does NOT subtract
+seen_ref_ids. ``alert_seen`` only gates the cosmetic one-time pulse; the item leaves the
+count only when the request is decided / cancelled. Hence ``count_for_user`` ==
+``len(new_items_for_user(...))`` — both delegate to one helper.
+
+Called by: services/alerts/sources/__init__.py (registered centrally under the "approvals"
+           tab).
+Depends on: services/alerts/base.AlertSource, models/approvals.{ApprovalRequest,
+            ApprovalStep,ApprovalStepRecipient}, constants.{AlertKind,
+            ApprovalRequestStatus,ApprovalRecipientStatus}.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.constants import (
+    AlertKind,
+    ApprovalRecipientStatus,
+    ApprovalRequestStatus,
+)
+from app.models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
+from app.models.auth import User
+
+from ..base import AlertItem, AlertSource, Temperament
+
+
+class ApprovalRequestActionSource(AlertSource):
+    """Open engine approval requests this user must decide (ACTION)."""
+
+    key = "approval_action"
+    kind = AlertKind.APPROVAL_ACTION
+    temperament = Temperament.ACTION
+
+    def _actionable_items(self, db: Session, user: User) -> list[AlertItem]:
+        """REQUESTED requests where the user holds a PENDING recipient row.
+
+        ACTION semantics: the single source of truth for both public methods (count = len);
+        never consults seen_ref_ids. Each item anchors to its request row (``ar-{id}``) and
+        carries the request id as ref_id.
+        """
+        rows = (
+            db.execute(
+                select(ApprovalRequest.id)
+                .join(ApprovalStep, ApprovalStep.request_id == ApprovalRequest.id)
+                .join(ApprovalStepRecipient, ApprovalStepRecipient.step_id == ApprovalStep.id)
+                .where(
+                    ApprovalRequest.status == ApprovalRequestStatus.REQUESTED,
+                    ApprovalStepRecipient.user_id == user.id,
+                    ApprovalStepRecipient.status == ApprovalRecipientStatus.PENDING,
+                )
+                .distinct()
+            )
+            .scalars()
+            .all()
+        )
+        return [AlertItem(ref_id=req_id, anchor=f"ar-{req_id}") for req_id in rows]
+
+    def count_for_user(self, db: Session, user: User) -> int:
+        return len(self._actionable_items(db, user))
+
+    def new_items_for_user(self, db: Session, user: User) -> list[AlertItem]:
+        return self._actionable_items(db, user)

--- a/app/services/alerts/sources/buyplan.py
+++ b/app/services/alerts/sources/buyplan.py
@@ -4,8 +4,11 @@ Surfaces the open work the current user personally owns across three buy-plan ro
 unioned into one count + spotlight list:
 
   1. Buyer PO step — a BuyPlanLine assigned to me that is still AWAITING_PO.
-  2. Manager approval — a PENDING buy plan with no approver yet, where my role lets
-     me approve (manager/admin — the same rule buyplan_workflow.approve_buy_plan enforces).
+  2. Manager approval — a PENDING buy plan WITH NO OPEN BUY_PLAN ApprovalRequest, where I
+     hold can_approve_buy_plans. Post-C1 the engine owns the gate, so a plan that opened an
+     engine request is counted by the approvals badge instead (counting it here too would
+     double-count); only a pre-C1 transition-window plan (no engine request) still surfaces
+     here so it never goes invisible.
   3. Ops verify — a buy plan whose SO is still PENDING and unverified, where I am an
      active member of the ops verification group (the same rule verify_so enforces).
 
@@ -84,12 +87,32 @@ class BuyplanActionSource(AlertSource):
         #    right. Single source of truth: can_approve_buy_plans (the per-user column the
         #    approve route + service enforce), NOT a role set — so the badge never counts a
         #    step the user could not actually act on, and always counts one they can.
+        #
+        #    Post-C1, the approvals engine OWNS the buy-plan gate: a PENDING plan opens a
+        #    BUY_PLAN ApprovalRequest that the dedicated approvals badge counts. Counting
+        #    that same plan here too would DOUBLE-count it (buy-plans badge + approvals
+        #    badge). So this branch counts ONLY pending plans with NO open engine request —
+        #    i.e. post-C1 plans surface on the approvals badge alone, while a pre-C1
+        #    transition-window plan (PENDING but never got an engine request) still surfaces
+        #    here so it never goes invisible.
         if can_approve_buy_plans(user):
+            from app.constants import ApprovalRequestStatus, ApprovalSubjectType
+            from app.models.approvals import ApprovalRequest
+
+            open_req_subq = (
+                db.query(ApprovalRequest.subject_id)
+                .filter(
+                    ApprovalRequest.subject_type == ApprovalSubjectType.BUY_PLAN,
+                    ApprovalRequest.status == ApprovalRequestStatus.REQUESTED,
+                )
+                .subquery()
+            )
             approval_plans = (
                 db.query(BuyPlan.id)
                 .filter(
                     BuyPlan.status == BuyPlanStatus.PENDING,
                     BuyPlan.approved_by_id.is_(None),
+                    BuyPlan.id.not_in(db.query(open_req_subq.c.subject_id)),
                 )
                 .all()
             )

--- a/app/services/approvals/service.py
+++ b/app/services/approvals/service.py
@@ -17,6 +17,12 @@ Purpose: The orchestration core of the Approval Engine.
          "decided" ApprovalOutbox rows (in_app + email — the locked dual-channel notice)
          for the notification worker.
 
+         For a BUY_PLAN subject, decide ALSO drives the buy-plan side effects in the SAME
+         session/flush — approve → plan ACTIVE + buyer tasks, reject → plan DRAFT — by
+         delegating to buyplan_workflow's shared helpers. These run inline (no swallowing
+         try/except), so a side-effect failure rolls back the whole decision atomically:
+         the request can never land APPROVED while the plan stays PENDING (QP Phase C1).
+
 Called by: routers/approvals.py (Task 5+), buy-plan / prepayment flows that gate on
            approval.
 Depends on: app.models.approvals, app.models.quality_plan (Prepayment),
@@ -44,9 +50,10 @@ from ...models.approvals import (
     ApprovalStep,
     ApprovalStepRecipient,
 )
+from ...models.buy_plan import BuyPlan
 from ...models.quality_plan import Prepayment, QualityPlan
 from .events import record as _record_event
-from .routing import route_request
+from .routing import NoEligibleApproverError, route_request
 
 # action → terminal request status / per-recipient status / audit event_type
 _APPROVE = "approve"
@@ -59,7 +66,7 @@ def create_request(
     *,
     gate_type: str,
     amount: Decimal | None,
-    subject: Prepayment | QualityPlan,
+    subject: Prepayment | QualityPlan | BuyPlan,
     requested_by: Any,
     owner: Any,
     currency: str = "USD",
@@ -70,8 +77,8 @@ def create_request(
         db: SQLAlchemy session (sync, 2.0 style).
         gate_type: An ApprovalGateType value (the gate this request belongs to).
         amount: Spend amount used for threshold routing (may be None for non-spend gates).
-        subject: The entity being approved — a Prepayment or a QualityPlan. The polymorphic
-            (subject_type, subject_id) pair is set from its type + id.
+        subject: The entity being approved — a Prepayment, a QualityPlan, or a BuyPlan. The
+            polymorphic (subject_type, subject_id) pair is set from its type + id.
         requested_by: The User who triggered the request.
         owner: The User who owns the originating entity (notified on resolution).
         currency: ISO currency code of *amount* (defaults to "USD").
@@ -81,7 +88,7 @@ def create_request(
         and carrying its genesis 'submitted' audit event.
 
     Raises:
-        TypeError: If *subject* is neither a Prepayment nor a QualityPlan.
+        TypeError: If *subject* is not a Prepayment, QualityPlan, or BuyPlan.
         NoEligibleApproverError: Propagated from route_request when no approver is eligible.
     """
     request = ApprovalRequest(
@@ -97,14 +104,24 @@ def create_request(
         request.subject_type = ApprovalSubjectType.PREPAYMENT
     elif isinstance(subject, QualityPlan):
         request.subject_type = ApprovalSubjectType.QUALITY_PLAN
+    elif isinstance(subject, BuyPlan):
+        request.subject_type = ApprovalSubjectType.BUY_PLAN
     else:
-        raise TypeError(f"subject must be a Prepayment or QualityPlan, got {type(subject).__name__}")
+        raise TypeError(f"subject must be a Prepayment, QualityPlan, or BuyPlan, got {type(subject).__name__}")
     request.subject_id = subject.id
 
     db.add(request)
     db.flush()  # Assign request.id before routing
 
-    route_request(db, request)
+    try:
+        route_request(db, request)
+    except NoEligibleApproverError:
+        # Routing found no eligible approver: the request has no recipients and is
+        # meaningless. Remove the half-built row so a caller that catches this error and
+        # still commits (e.g. the buy-plan submit path) leaves NO orphan engine state.
+        db.delete(request)
+        db.flush()
+        raise
 
     # Genesis audit row: the 'submitted' event anchors the request's append-only trail.
     _record_event(db, request, requested_by, "submitted")
@@ -208,4 +225,23 @@ def decide(
     )
 
     db.flush()
+
+    # On-resolve subject dispatch. A BUY_PLAN request drives the EXISTING buy-plan side
+    # effects (approve → ACTIVE + buyer tasks, reject → DRAFT) in THIS session, before the
+    # router commits. Lazy import: buyplan_workflow imports the approvals package, so a
+    # top-level import here would be circular. We deliberately do NOT wrap this in a
+    # swallowing try/except — a side-effect failure must propagate so the router's
+    # transaction rolls back the whole decision atomically (RISK 1: no APPROVED-request /
+    # PENDING-plan split-brain).
+    if request.subject_type == ApprovalSubjectType.BUY_PLAN and request.subject_id is not None:
+        from ..buyplan_workflow import _run_approve_side_effects, _run_reject_side_effects
+
+        plan = db.get(BuyPlan, request.subject_id)
+        if plan is not None:
+            if approved:
+                _run_approve_side_effects(plan, user, db, notes=comment)
+            else:
+                _run_reject_side_effects(plan, user, db, reason=comment or "Rejected")
+            db.flush()
+
     return request

--- a/app/services/buyplan_workflow.py
+++ b/app/services/buyplan_workflow.py
@@ -10,6 +10,7 @@ Depends on: buyplan_scoring, buyplan_builder, models, config
 from datetime import datetime, timezone
 
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from ..config import settings
@@ -79,6 +80,9 @@ def submit_buy_plan(
     else:
         plan.status = BuyPlanStatus.PENDING.value
         logger.info("Buy plan {} pending approval (cost={:.2f})", plan_id, float(plan.total_cost or 0))
+        # Open the engine gate: route a BUY_PLAN ApprovalRequest to can_approve_buy_plans
+        # holders (cancels any stale open request first — RISK 2).
+        _open_engine_request_for_plan(plan, user, db)
 
     db.flush()
     return plan
@@ -115,32 +119,114 @@ def approve_buy_plan(
     if not can_approve_buy_plans(user):
         raise PermissionError("Buy-plan approval right required to approve/reject")
 
-    now = datetime.now(timezone.utc)
     if action == "approve":
-        if line_overrides:
-            _apply_line_overrides(plan, line_overrides, db)
-        plan.status = BuyPlanStatus.ACTIVE.value
-        plan.approved_by_id = user.id
-        plan.approved_at = now
-        plan.approval_notes = notes
-        logger.info("Buy plan {} approved by {}", plan_id, user.email)
-        _generate_buyer_tasks(plan, db)
-        _log_approval_activity(plan, "approve", user, notes, db)
+        _run_approve_side_effects(plan, user, db, line_overrides=line_overrides, notes=notes)
     elif action == "reject":
         reason = (notes or "").strip()
         if not reason:
             raise ValueError("A rejection reason is required")
-        plan.status = BuyPlanStatus.DRAFT.value
-        plan.approved_by_id = user.id
-        plan.approved_at = now
-        plan.approval_notes = reason
-        logger.info("Buy plan {} rejected by {}: {}", plan_id, user.email, reason)
-        _log_approval_activity(plan, "reject", user, reason, db)
+        _run_reject_side_effects(plan, user, db, reason=reason)
     else:
         raise ValueError(f"Invalid action: {action}")
 
     db.flush()
     return plan
+
+
+def _run_approve_side_effects(
+    plan: BuyPlan,
+    user: User,
+    db: Session,
+    *,
+    line_overrides: list[dict] | None = None,
+    notes: str | None = None,
+) -> None:
+    """Apply the on-approve side effects to *plan* (status→ACTIVE + buyer tasks).
+
+    The single arbitration point for a buy-plan approval's effects, called by BOTH the
+    legacy ``approve_buy_plan`` path and the approvals-engine ``decide()`` dispatch so the
+    two paths can never drift. Optional manager ``line_overrides`` swap vendors/quantities
+    before the plan is activated. Stamps approver/decision metadata, generates the buyer
+    'Cut PO' tasks, and writes the audit ActivityLog row. The caller owns the flush/commit.
+    """
+    now = datetime.now(timezone.utc)
+    if line_overrides:
+        _apply_line_overrides(plan, line_overrides, db)
+    plan.status = BuyPlanStatus.ACTIVE.value
+    plan.approved_by_id = user.id
+    plan.approved_at = now
+    plan.approval_notes = notes
+    logger.info("Buy plan {} approved by {}", plan.id, user.email)
+    _generate_buyer_tasks(plan, db)
+    _log_approval_activity(plan, "approve", user, notes, db)
+
+
+def _run_reject_side_effects(plan: BuyPlan, user: User, db: Session, *, reason: str) -> None:
+    """Apply the on-reject side effects to *plan* (status→DRAFT, back to salesperson).
+
+    Counterpart to ``_run_approve_side_effects``; shared by the legacy path and the engine
+    ``decide()`` dispatch. Stamps the rejecting user + reason and writes the audit
+    ActivityLog row. The caller owns the flush/commit.
+    """
+    plan.status = BuyPlanStatus.DRAFT.value
+    plan.approved_by_id = user.id
+    plan.approved_at = datetime.now(timezone.utc)
+    plan.approval_notes = reason
+    logger.info("Buy plan {} rejected by {}: {}", plan.id, user.email, reason)
+    _log_approval_activity(plan, "reject", user, reason, db)
+
+
+def _open_engine_request_for_plan(plan: BuyPlan, user: User, db: Session) -> None:
+    """Open a BUY_PLAN ApprovalRequest for *plan*, cancelling any stale open one first.
+
+    Called when a plan enters PENDING (submit / resubmit). RISK 2 (double request): a
+    resubmit must never leave two REQUESTED rows racing for the same plan, so we cancel
+    every existing open (REQUESTED) request for this plan via the engine's ``cancel``
+    BEFORE creating the fresh one — leaving exactly one open request. ``cancel`` is safe
+    here because *user* is the requester/owner of any prior request (we always pass
+    requested_by=owner=user). If no approver holds ``can_approve_buy_plans`` the engine
+    raises NoEligibleApproverError; we log a WARNING and leave the plan PENDING with no
+    orphan engine state (the create_request flush is the only write, and it is rolled into
+    the caller's transaction — a failed route leaves nothing half-built).
+
+    Lazy imports: the approvals service imports buyplan_workflow (decide() dispatch), so a
+    top-level import here would be circular.
+    """
+    from ..constants import (
+        ApprovalGateType,
+        ApprovalRequestStatus,
+        ApprovalSubjectType,
+    )
+    from ..models.approvals import ApprovalRequest
+    from .approvals.events import cancel as svc_cancel
+    from .approvals.routing import NoEligibleApproverError
+    from .approvals.service import create_request
+
+    stale = (
+        db.execute(
+            select(ApprovalRequest).where(
+                ApprovalRequest.subject_type == ApprovalSubjectType.BUY_PLAN,
+                ApprovalRequest.subject_id == plan.id,
+                ApprovalRequest.status == ApprovalRequestStatus.REQUESTED,
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for ar in stale:
+        svc_cancel(db, ar.id, actor=user)
+
+    try:
+        create_request(
+            db,
+            gate_type=ApprovalGateType.BUY_PLAN,
+            amount=plan.total_cost,
+            subject=plan,
+            requested_by=user,
+            owner=user,
+        )
+    except NoEligibleApproverError:
+        logger.warning("Buy plan {} pending but no BUY_PLAN approver configured", plan.id)
 
 
 def _log_approval_activity(plan: BuyPlan, action: str, user: User, notes: str | None, db: Session) -> None:
@@ -517,6 +603,9 @@ def resubmit_buy_plan(
         plan.approved_at = datetime.now(timezone.utc)
     else:
         plan.status = BuyPlanStatus.PENDING.value
+        # Re-open the engine gate. Cancels the stale request from the prior submission so
+        # exactly ONE REQUESTED request exists for this plan (RISK 2).
+        _open_engine_request_for_plan(plan, user, db)
 
     db.flush()
     return plan

--- a/app/services/buyplan_workflow.py
+++ b/app/services/buyplan_workflow.py
@@ -148,7 +148,16 @@ def _run_approve_side_effects(
     two paths can never drift. Optional manager ``line_overrides`` swap vendors/quantities
     before the plan is activated. Stamps approver/decision metadata, generates the buyer
     'Cut PO' tasks, and writes the audit ActivityLog row. The caller owns the flush/commit.
+
+    State guard FIRST: only a PENDING plan may be approved. This is the single point that
+    protects BOTH approval paths — if an approver decides a STALE engine request whose plan
+    has since left PENDING (e.g. it was cancelled or halted out from under the queue), this
+    raises cleanly so the router turns it into a 400 / idempotent no-op instead of silently
+    resurrecting the cancelled plan to ACTIVE. ``approve_buy_plan`` keeps its own pre-check
+    (defense in depth); the engine ``decide()`` dispatch relies on this one.
     """
+    if plan.status != BuyPlanStatus.PENDING.value:
+        raise ValueError(f"Can only approve a pending plan (current: {plan.status})")
     now = datetime.now(timezone.utc)
     if line_overrides:
         _apply_line_overrides(plan, line_overrides, db)
@@ -167,7 +176,14 @@ def _run_reject_side_effects(plan: BuyPlan, user: User, db: Session, *, reason: 
     Counterpart to ``_run_approve_side_effects``; shared by the legacy path and the engine
     ``decide()`` dispatch. Stamps the rejecting user + reason and writes the audit
     ActivityLog row. The caller owns the flush/commit.
+
+    State guard FIRST (same rationale as ``_run_approve_side_effects``): only a PENDING plan
+    may be rejected, so deciding a stale request whose plan already left PENDING raises a
+    clean ValueError (→ router 400) rather than dragging a cancelled/halted plan back to
+    DRAFT.
     """
+    if plan.status != BuyPlanStatus.PENDING.value:
+        raise ValueError(f"Can only reject a pending plan (current: {plan.status})")
     plan.status = BuyPlanStatus.DRAFT.value
     plan.approved_by_id = user.id
     plan.approved_at = datetime.now(timezone.utc)
@@ -176,33 +192,38 @@ def _run_reject_side_effects(plan: BuyPlan, user: User, db: Session, *, reason: 
     _log_approval_activity(plan, "reject", user, reason, db)
 
 
-def _open_engine_request_for_plan(plan: BuyPlan, user: User, db: Session) -> None:
-    """Open a BUY_PLAN ApprovalRequest for *plan*, cancelling any stale open one first.
+def _cancel_open_engine_requests_for_plan(plan: BuyPlan, user: User, db: Session) -> int:
+    """Cancel every open (REQUESTED) BUY_PLAN ApprovalRequest for *plan* via the engine.
 
-    Called when a plan enters PENDING (submit / resubmit). RISK 2 (double request): a
-    resubmit must never leave two REQUESTED rows racing for the same plan, so we cancel
-    every existing open (REQUESTED) request for this plan via the engine's ``cancel``
-    BEFORE creating the fresh one — leaving exactly one open request. ``cancel`` is safe
-    here because *user* is the requester/owner of any prior request (we always pass
-    requested_by=owner=user). If no approver holds ``can_approve_buy_plans`` the engine
-    raises NoEligibleApproverError; we log a WARNING and leave the plan PENDING with no
-    orphan engine state (the create_request flush is the only write, and it is rolled into
-    the caller's transaction — a failed route leaves nothing half-built).
+    The single point that closes a plan's engine gate when the plan leaves PENDING — called
+    by ``_open_engine_request_for_plan`` (before opening a fresh request, RISK 2: never two
+    live REQUESTED rows) AND by the non-decide transitions that take a plan out of PENDING
+    (``cancel_buy_plan``, ``verify_so`` HALT). Cancelling the open request there means no
+    REQUESTED row is orphaned in the approvals queue/badge for a plan that no longer exists
+    to approve — and, crucially, closes the resurrection vector (an approver can no longer
+    pick a stale request out of the queue and re-activate a cancelled plan).
 
-    Lazy imports: the approvals service imports buyplan_workflow (decide() dispatch), so a
-    top-level import here would be circular.
+    Authz: each request is cancelled on behalf of its OWN ``requested_by`` (falling back to
+    ``owner``), the user who originally submitted the plan — so the engine ``cancel`` authz
+    (requester/owner OR manager/admin) is satisfied for EVERY transition caller, regardless
+    of whether the user driving the transition is the submitter, a manager/admin, or an
+    ops-group member who is neither (the verify_so HALT case). The plan-level audit of who
+    cancelled/halted the plan is already captured on the plan + its activity log; this
+    cancel is a system-driven consequence of the plan leaving PENDING, not a separate
+    user-initiated cancel of someone else's request. ``user`` is used only as a final
+    fallback actor when a request somehow carries no requester/owner.
+
+    Returns the number of requests cancelled. Lazy imports avoid the circular import (the
+    approvals service imports buyplan_workflow for the decide() dispatch).
     """
     from ..constants import (
-        ApprovalGateType,
         ApprovalRequestStatus,
         ApprovalSubjectType,
     )
     from ..models.approvals import ApprovalRequest
     from .approvals.events import cancel as svc_cancel
-    from .approvals.routing import NoEligibleApproverError
-    from .approvals.service import create_request
 
-    stale = (
+    open_requests = (
         db.execute(
             select(ApprovalRequest).where(
                 ApprovalRequest.subject_type == ApprovalSubjectType.BUY_PLAN,
@@ -213,8 +234,34 @@ def _open_engine_request_for_plan(plan: BuyPlan, user: User, db: Session) -> Non
         .scalars()
         .all()
     )
-    for ar in stale:
-        svc_cancel(db, ar.id, actor=user)
+    cancelled = 0
+    for ar in open_requests:
+        actor = ar.requested_by or ar.owner or user
+        svc_cancel(db, ar.id, actor=actor)
+        cancelled += 1
+    return cancelled
+
+
+def _open_engine_request_for_plan(plan: BuyPlan, user: User, db: Session) -> None:
+    """Open a BUY_PLAN ApprovalRequest for *plan*, cancelling any stale open one first.
+
+    Called when a plan enters PENDING (submit / resubmit). RISK 2 (double request): a
+    resubmit must never leave two REQUESTED rows racing for the same plan, so we cancel
+    every existing open (REQUESTED) request for this plan via
+    ``_cancel_open_engine_requests_for_plan`` BEFORE creating the fresh one — leaving exactly
+    one open request. If no approver holds ``can_approve_buy_plans`` the engine raises
+    NoEligibleApproverError; we log a WARNING and leave the plan PENDING with no orphan
+    engine state (the create_request flush is the only write, and it is rolled into the
+    caller's transaction — a failed route leaves nothing half-built).
+
+    Lazy imports: the approvals service imports buyplan_workflow (decide() dispatch), so a
+    top-level import here would be circular.
+    """
+    from ..constants import ApprovalGateType
+    from .approvals.routing import NoEligibleApproverError
+    from .approvals.service import create_request
+
+    _cancel_open_engine_requests_for_plan(plan, user, db)
 
     try:
         create_request(
@@ -296,6 +343,13 @@ def verify_so(
         # SOVerificationStatus has no dedicated HALTED value, so a halt reuses REJECTED
         # for so_status; it is distinguished from a plain reject by plan.status == HALTED
         # (set just below).
+        # If the plan is still PENDING when halted, close its open engine request BEFORE the
+        # transition so no REQUESTED row is orphaned in the approvals queue/badge and the
+        # plan can never be resurrected by approving a stale request (the canceller is an
+        # ops member who may be neither the submitter nor a manager/admin, so the helper
+        # cancels on behalf of each request's own requester/owner — authz always satisfied).
+        if plan.status == BuyPlanStatus.PENDING.value:
+            _cancel_open_engine_requests_for_plan(plan, user, db)
         plan.so_status = SOVerificationStatus.REJECTED.value
         plan.so_rejection_note = rejection_note
         plan.status = BuyPlanStatus.HALTED.value
@@ -534,6 +588,15 @@ def cancel_buy_plan(plan_id: int, user: User, db: Session, *, reason: str | None
         raise ValueError(f"Buy plan {plan_id} not found")
     if plan.status in (BuyPlanStatus.COMPLETED.value, BuyPlanStatus.CANCELLED.value):
         raise ValueError(f"Cannot cancel plan in '{plan.status}' status")
+
+    # If the plan is still PENDING, close its open engine request BEFORE the transition so
+    # no REQUESTED row is orphaned in the approvals queue/badge — and, critically, so an
+    # approver can no longer pull a stale request out of the queue and resurrect this
+    # cancelled plan to ACTIVE. The helper cancels on behalf of each request's own
+    # requester/owner, so the engine cancel authz is satisfied even when the canceller is
+    # the (non-manager) plan owner.
+    if plan.status == BuyPlanStatus.PENDING.value:
+        _cancel_open_engine_requests_for_plan(plan, user, db)
 
     plan.status = BuyPlanStatus.CANCELLED.value
     plan.cancelled_at = datetime.now(timezone.utc)

--- a/app/templates/htmx/partials/approvals/_queue.html
+++ b/app/templates/htmx/partials/approvals/_queue.html
@@ -1,33 +1,37 @@
 {#
-  approvals/_queue.html — Unified approvals queue: engine prepayment requests + pending buy-plan approvals.
+  approvals/_queue.html — Engine approvals queue: every pending approval is an ApprovalRequest.
 
-  Purpose: Single view for approvers to see all pending approval items.
-           Engine ApprovalRequest rows are actioned inline; BuyPlan rows are read-only
-           links to the existing buy-plan detail partial (which has the gated approve/reject).
-           No behavior change to buy-plan approval — read-only bridge only.
+  Purpose: Single view for approvers to see all pending approval items. Every row is an
+           engine ApprovalRequest (prepayments, buy plans, …) actioned inline against the
+           engine's decision endpoint. QP Phase C1 retired the read-only buy-plan bridge:
+           a buy-plan submission now surfaces here as a native buy_plan-subject request,
+           and its Subject cell links to the plan detail partial.
 
   Receives:
     engine_requests (list[ApprovalRequest]) — engine approval requests (any status).
-    buy_plan_rows   (list[BuyPlan])         — pending buy-plan approvals (status=pending only).
     current_user    (User)                  — authenticated user.
     request         (Request)               — FastAPI request (required by template_response).
 
   Called by: routers/approvals.py → GET /v2/approvals/queue.
-  Depends on: Tailwind CSS, HTMX, app accent palette, .compact-table from styles.css.
+  Depends on: Tailwind CSS, HTMX, app accent palette, .compact-table from styles.css,
+              shared/_macros.html (btn_primary/btn_danger — canonical .btn-sm sizing).
 #}
+{% from "htmx/partials/shared/_macros.html" import btn_primary, btn_danger %}
 
+{# Count only OPEN (requested) rows for the "pending" header — resolved rows still render
+   below (with a View link) but are not "pending". #}
+{% set pending_count = engine_requests | selectattr('status', 'equalto', 'requested') | list | length %}
 <div id="approvals-queue" class="page-fluid">
   <div class="flex items-center justify-between mb-5">
     <div>
       <h2 class="text-lg font-semibold text-gray-900">Approvals Queue</h2>
       <p class="text-sm text-gray-600 mt-0.5">
-        {{ engine_requests|length + buy_plan_rows|length }} item{{ 's' if (engine_requests|length + buy_plan_rows|length) != 1 }} pending
+        {{ pending_count }} item{{ 's' if pending_count != 1 }} pending
       </p>
     </div>
   </div>
 
-  {% set total = engine_requests|length + buy_plan_rows|length %}
-  {% if total == 0 %}
+  {% if engine_requests|length == 0 %}
   <div class="rounded-lg border border-gray-200 bg-white px-6 py-10 text-center">
     <p class="text-sm text-gray-600">No pending approvals.</p>
   </div>
@@ -54,7 +58,18 @@
               {{ ar.gate_type | replace('_', ' ') | title }}
             </span>
           </td>
-          <td class="td-label text-gray-700">Request #{{ ar.id }}</td>
+          <td class="td-label text-gray-700">
+            {% if ar.subject_type == 'buy_plan' and ar.subject_id %}
+            {# Buy-plan subject: link to the plan detail partial (read-context for the approver). #}
+            <a href="/v2/partials/buy-plans/{{ ar.subject_id }}"
+               hx-get="/v2/partials/buy-plans/{{ ar.subject_id }}"
+               hx-target="#main-content"
+               hx-push-url="false"
+               class="font-medium text-brand-600 hover:text-brand-800">Plan #{{ ar.subject_id }}</a>
+            {% else %}
+            Request #{{ ar.id }}
+            {% endif %}
+          </td>
           <td>{% if ar.amount %}${{ "{:,.2f}".format(ar.amount) }}{% else %}—{% endif %}</td>
           <td class="td-label">
             <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
@@ -66,40 +81,29 @@
           </td>
           <td>{{ ar.created_at.strftime('%Y-%m-%d') if ar.created_at else '—' }}</td>
           <td class="td-label text-right">
+            {% if ar.status == 'requested' %}
+            {# Inline approve/reject against the engine decision endpoint (returns JSON), then
+               re-fetch the whole queue into #main-content on success. The refresh htmx.ajax
+               carries an indicator: (HTMX 2.x doesn't auto-read hx-indicator for imperative
+               calls). A 403 (not a pending recipient) is fail-quiet: the queue is unchanged. #}
+            <div class="inline-flex items-center gap-1.5">
+              {{ btn_primary('Approve', {
+                'hx-post': '/v2/approvals/requests/' ~ ar.id ~ '/decision',
+                'hx-vals': "js:{action: 'approve'}",
+                'hx-swap': 'none',
+                'hx-on::after-request': "if(event.detail.successful) htmx.ajax('GET','/v2/approvals/queue',{target:'#main-content',indicator:'#approvals-queue'})"
+              }) }}
+              {{ btn_danger('Reject', {
+                'hx-post': '/v2/approvals/requests/' ~ ar.id ~ '/decision',
+                'hx-vals': "js:{action: 'reject', comment: prompt('Reason for rejection?') || ''}",
+                'hx-swap': 'none',
+                'hx-on::after-request': "if(event.detail.successful) htmx.ajax('GET','/v2/approvals/queue',{target:'#main-content',indicator:'#approvals-queue'})"
+              }) }}
+            </div>
+            {% else %}
             <a href="/v2/approvals/requests/{{ ar.id }}"
                class="text-xs font-medium text-brand-600 hover:text-brand-800">View</a>
-          </td>
-        </tr>
-        {% endfor %}
-
-        {# ── Buy-Plan bridge rows (read-only; link to existing detail partial) ── #}
-        {% for bp in buy_plan_rows %}
-        <tr>
-          <td class="td-label">
-            <span class="inline-flex items-center rounded-full bg-purple-50 px-2 py-0.5 text-xs font-medium text-purple-700 ring-1 ring-inset ring-purple-200">
-              Buy Plan
-            </span>
-          </td>
-          <td class="td-label">
-            Plan #{{ bp.id }}
-            {% if bp.requisition %}
-            <span class="text-gray-600 text-xs ml-1">· {{ bp.requisition.name }}</span>
             {% endif %}
-          </td>
-          <td>{% if bp.total_cost %}${{ "{:,.2f}".format(bp.total_cost) }}{% else %}—{% endif %}</td>
-          <td class="td-label">
-            <span class="inline-flex items-center rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-200">
-              Pending
-            </span>
-          </td>
-          <td>{{ bp.created_at.strftime('%Y-%m-%d') if bp.created_at else '—' }}</td>
-          <td class="td-label text-right">
-            {# Link to existing buy-plan detail partial — approve/reject already gated there #}
-            <a href="/v2/partials/buy-plans/{{ bp.id }}"
-               hx-get="/v2/partials/buy-plans/{{ bp.id }}"
-               hx-target="#main-content"
-               hx-push-url="false"
-               class="text-xs font-medium text-brand-600 hover:text-brand-800">Review</a>
           </td>
         </tr>
         {% endfor %}

--- a/app/templates/htmx/partials/shared/mobile_nav.html
+++ b/app/templates/htmx/partials/shared/mobile_nav.html
@@ -11,7 +11,7 @@
        moreOpen: false,
        activeNav: '{{ current_view }}',
        urlToNav(url) {
-         const map = {'/v2/requisitions':'requisitions','/v2/sightings':'sightings','/v2/materials':'materials','/v2/search':'search','/v2/buy-plans':'buy-plans','/v2/resell':'resell','/v2/crm':'crm','/v2/customers':'crm','/v2/contacts':'crm','/v2/vendor-contacts':'crm','/v2/vendors':'crm','/v2/proactive':'proactive','/v2/prospecting':'prospecting','/v2/my-day':'my-day','/v2/settings':'settings'};
+         const map = {'/v2/requisitions':'requisitions','/v2/sightings':'sightings','/v2/materials':'materials','/v2/search':'search','/v2/buy-plans':'buy-plans','/v2/resell':'resell','/v2/crm':'crm','/v2/customers':'crm','/v2/contacts':'crm','/v2/vendor-contacts':'crm','/v2/vendors':'crm','/v2/proactive':'proactive','/v2/prospecting':'prospecting','/v2/my-day':'my-day','/v2/approvals':'approvals','/v2/settings':'settings'};
          for (const [prefix, id] of Object.entries(map)) { if (url.startsWith(prefix)) return id; }
          return this.activeNav;
        }
@@ -41,7 +41,9 @@
       ('prospecting', 'Prospect', '/v2/prospecting', '/v2/partials/prospecting',
        'M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7'),
       ('my-day', 'Tasks', '/v2/my-day', '/v2/partials/my-day',
-       'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z')
+       'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z'),
+      ('approvals', 'Approvals', '/v2/approvals/queue', '/v2/approvals/queue',
+       'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z')
     ] %}
     {% for id, label, href, partial, icon_path in nav_items %}
     {# Per-user nav gate: hide a section the user lacks access to. `access` is a
@@ -71,7 +73,7 @@
               hx-swap="innerHTML"
               hx-push-url="false"
               class="absolute -top-1.5 -right-2 flex items-center justify-center min-w-[14px] h-[14px]"></span>
-        {% elif id in ('requisitions', 'buy-plans', 'crm', 'my-day') %}
+        {% elif id in ('requisitions', 'buy-plans', 'crm', 'my-day', 'approvals') %}
         {# Cross-app alert badge — same emerald pill as proactive, fed by the AlertSource registry #}
         <span id="{{ id }}-nav-badge"
               hx-get="/v2/partials/alerts/{{ id }}/badge"

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -377,12 +377,12 @@ Managed via Settings > Ops Group (admin only); seeded from `ADMIN_EMAILS` on sta
 | currency | String 10, nullable | |
 | requested_by_id | FK -> users (SET NULL) | |
 | owner_id | FK -> users (SET NULL) | Indexed (`ix_approval_req_owner`) |
-| subject_type | String 50, nullable | `ApprovalSubjectType` (`quality_plan`\|`prepayment`; BUY_PLAN/QUOTE/RESELL_OFFER added by later QP-Phase-C phases). **Polymorphic** — no cross-table FK (mirrors `MaterialCardAudit.material_card_id`); survives subject deletion. Migration 159 replaced the two nullable subject FK columns with this pair. |
+| subject_type | String 50, nullable | `ApprovalSubjectType` (`quality_plan`\|`prepayment`\|`buy_plan`; QUOTE/RESELL_OFFER added by later QP-Phase-C phases). `buy_plan` (QP Phase C1) routes the live buy-plan gate through the engine. **Polymorphic** — no cross-table FK (mirrors `MaterialCardAudit.material_card_id`); survives subject deletion. Migration 159 replaced the two nullable subject FK columns with this pair. |
 | subject_id | Integer, nullable | The subject's PK. `(subject_type, subject_id)` composite-indexed (`ix_approval_req_subject`). |
 | resolved_at | UTCDateTime, nullable | |
 | expires_at | UTCDateTime, nullable | |
 
-> Set by `approvals.service.create_request` from the passed subject (Prepayment → `prepayment`, QualityPlan → `quality_plan`). The router `_serialize_request`/`_buy_plan_as_queue_item` JSON shapes do not expose these columns.
+> Set by `approvals.service.create_request` from the passed subject (Prepayment → `prepayment`, QualityPlan → `quality_plan`, BuyPlan → `buy_plan`). The router `_serialize_request` JSON shape now exposes `subject_type`/`subject_id` (QP Phase C1, so a `buy_plan` request links back to its plan detail partial); the read-only buy-plan bridge `_buy_plan_as_queue_item` was retired.
 
 **`approval_steps`** — Ordered stages within an ApprovalRequest.
 | Column | Type | Notes |
@@ -928,7 +928,7 @@ Self-invalidates: service regens when `basis_last_activity_at` or `basis_activit
 |--------|------|-------|
 | id | Integer PK | |
 | user_id | FK -> users (CASCADE) | |
-| alert_kind | String 40 | `AlertKind` value (offer_confirmed\|inbound_customer\|inbound_vendor\|buyplan_action) |
+| alert_kind | String 40 | `AlertKind` value (offer_confirmed\|inbound_customer\|inbound_vendor\|buyplan_action\|tasks_action\|approval_action) |
 | ref_id | Integer | Source item's id (offer.id, activity_log.id, buy_plan(_line).id — no DB-level FK, kind-scoped) |
 | seen_at | UTCDateTime | When marked seen (Python default) |
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -5054,6 +5054,28 @@ open request exists — a plan that went `PENDING` before C1 deployed — it fal
 legacy `approve_buy_plan` and logs a WARNING (RISK 3, transition window, removed in a
 follow-up).
 
+**Leaving PENDING outside `decide()` cancels the open engine request (no orphan, no
+resurrection):** a PENDING plan carries a live `REQUESTED` `BUY_PLAN` `ApprovalRequest`, so
+any transition that takes the plan out of PENDING *without going through `decide()`* must
+close that request or it would orphan a row in the approvals queue/badge — and, worse, let
+an approver pull the stale request and resurrect the plan. `cancel_buy_plan` and the
+`verify_so` **HALT** branch therefore call
+`_cancel_open_engine_requests_for_plan(plan, user, db)` (the stale-cancel loop factored out
+of `_open_engine_request_for_plan`) **at/before the transition, only when the plan is still
+PENDING**. That helper cancels each open request on behalf of the request's OWN
+`requested_by`/`owner` (the original submitter), so the `events.cancel` authz
+(requester/owner OR manager/admin) is satisfied for EVERY caller — including a `verify_so`
+HALT driven by an ops-group member who is neither the submitter nor a manager/admin. As a
+second line of defense, `_run_approve_side_effects`/`_run_reject_side_effects` re-check
+`plan.status == PENDING` at entry: deciding a stale request whose plan already left PENDING
+raises `ValueError` → the router returns a clean 400 (via `get_db`'s rollback) instead of
+silently reactivating a cancelled/halted plan.
+
+The buy-plans ACTION badge (`alerts/sources/buyplan.py`, branch 2 — manager approval) counts
+ONLY pending plans with **no open `BUY_PLAN` `ApprovalRequest`**, so a post-C1 plan surfaces
+on the **Approvals** badge alone (no double-count) while a pre-C1 transition-window plan (no
+engine request) still surfaces on the buy-plans badge and never goes invisible.
+
 The **read-only buy-plan bridge is RETIRED** (C1). `list_requests`/`get_queue`
 (`routers/approvals.py`) are engine-only: a buy plan surfaces as a native `ApprovalRequest`
 (`gate_type=buy_plan`, `subject_type=buy_plan`). `_serialize_request(r)` is the single

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -5004,13 +5004,15 @@ checkboxes bind to it; `window.ticketBulkAction(kind, ids, status)` POSTs and fi
 `approvals.service.create_request(db, *, gate_type, amount, subject, requested_by, owner,
 currency="USD")` is the single entry for spawning a routed approval:
 - Persists an `ApprovalRequest`, setting the **polymorphic** `(subject_type, subject_id)`
-  pair from the subject (`Prepayment` → `prepayment`, `QualityPlan` → `quality_plan`) — no
-  cross-table FK (mirrors `MaterialCardAudit`). `currency` (defaults USD) lands on
-  `request.currency`; `prepayment_service.create_prepayment` passes
+  pair from the subject (`Prepayment` → `prepayment`, `QualityPlan` → `quality_plan`,
+  `BuyPlan` → `buy_plan`) — no cross-table FK (mirrors `MaterialCardAudit`). `currency`
+  (defaults USD) lands on `request.currency`; `prepayment_service.create_prepayment` passes
   `currency=prepayment.currency`, completing the currency contract.
 - Flushes, calls `routing.route_request`, then records the **genesis `submitted`**
   `ApprovalEvent` + `ActivityLog` (`APPROVAL_REQUESTED`) — so every request's append-only
-  trail starts with a creation row (its `event_type` is `submitted`).
+  trail starts with a creation row (its `event_type` is `submitted`). If routing raises
+  `NoEligibleApproverError` the half-built request is **deleted** before re-raising, so a
+  caller that catches the error and still commits leaves no orphan engine state.
 
 `approvals.service.decide(db, request_id, user, action, comment=None)` resolves a request
 (first-responder-wins, row-locked). On resolution it records one `approved`/`rejected`
@@ -5018,6 +5020,16 @@ currency="USD")` is the single entry for spawning a routed approval:
 (`owner_id` → `requested_by_id` → decider) — one `channel='in_app'` and one
 `channel='email'` (Mike's locked dual-channel notice). Both carry the same payload
 `{"event_type": "decided", "decision": <approved|rejected>, "comment": <comment>}`.
+
+**On-resolve subject dispatch (QP Phase C1):** after the flush, a `subject_type=='buy_plan'`
+request drives the EXISTING buy-plan side effects in the SAME session — approve →
+`buyplan_workflow._run_approve_side_effects` (plan `ACTIVE` + `_generate_buyer_tasks` +
+approver stamp + audit `ActivityLog`); reject → `_run_reject_side_effects` (plan `DRAFT`).
+The dispatch runs inline with **no swallowing try/except**, so a side-effect failure
+propagates and the router's transaction rolls the whole decision back atomically — a request
+can never land `APPROVED` while its plan stays `PENDING` (RISK 1). `_run_approve_side_effects`
+/`_run_reject_side_effects` are the single arbitration point shared by BOTH the engine
+dispatch and the legacy `approve_buy_plan`, so the two paths can never drift.
 
 `jobs.approval_outbox.dispatch_pending` drains the outbox (60s job):
 - `in_app` → `notifications.write_in_app`; the `Notification.body` now carries the decision
@@ -5028,6 +5040,28 @@ currency="USD")` is the single entry for spawning a routed approval:
 - Channel server_default is `in_app` (migration 159) so an outbox row without an explicit
   channel is never silently treated as email.
 
-Router JSON (`routers/approvals.py`): `_serialize_request(r)` is the single 9-field engine-item
-projection shared by `list_requests` + `get_request` (distinct from the read-only buy-plan
-bridge `_buy_plan_as_queue_item`, which is unchanged).
+**Buy-plan submission → engine gate (QP Phase C1):** `buyplan_workflow.submit_buy_plan`
+(and `resubmit_buy_plan`), on the non-auto-approve path, call
+`_open_engine_request_for_plan(plan, user, db)` — which FIRST cancels every existing open
+(`REQUESTED`) `ApprovalRequest` for the plan via `events.cancel` (so a resubmit never leaves
+two live requests — RISK 2), THEN `create_request(gate_type=BUY_PLAN, subject=plan,
+requested_by=owner=user)` routes a request to every `can_approve_buy_plans` holder. No
+approver configured → `NoEligibleApproverError` is caught, logged WARNING, plan stays
+`PENDING` with no engine state. The live approve/reject POST
+(`/v2/partials/buy-plans/{id}/approve`, `buy_plan_approve_partial`) looks up the open
+`BUY_PLAN` request and resolves it via `decide` (side effects run inside `decide`); if NO
+open request exists — a plan that went `PENDING` before C1 deployed — it falls back to the
+legacy `approve_buy_plan` and logs a WARNING (RISK 3, transition window, removed in a
+follow-up).
+
+The **read-only buy-plan bridge is RETIRED** (C1). `list_requests`/`get_queue`
+(`routers/approvals.py`) are engine-only: a buy plan surfaces as a native `ApprovalRequest`
+(`gate_type=buy_plan`, `subject_type=buy_plan`). `_serialize_request(r)` is the single
+11-field engine-item projection shared by `list_requests` + `get_request` (now carrying
+`subject_type`/`subject_id` so a `buy_plan` request links back to its plan detail partial).
+The `/v2/approvals/queue` partial renders one engine table with inline approve/reject for
+`requested` rows posting to the decision endpoint; a `buy_plan`-subject row links to
+`/v2/partials/buy-plans/{subject_id}`. An **Approvals** primary-nav item
+(`mobile_nav.html` → `/v2/approvals/queue`) surfaces the queue, with an emerald badge fed by
+`ApprovalRequestActionSource` (tab `approvals`, `AlertKind.APPROVAL_ACTION`) counting open
+requests where the user is a PENDING recipient.

--- a/tests/test_approvals_bridge.py
+++ b/tests/test_approvals_bridge.py
@@ -1,17 +1,22 @@
-"""test_approvals_bridge.py — Tests for Task 12: unified approvals queue bridges buy-
-plan approvals.
+"""test_approvals_bridge.py — Engine-native approvals queue (QP Phase C1).
+
+The read-only buy-plan bridge is RETIRED. A buy-plan submission now surfaces in the queue
+as a native engine ApprovalRequest (gate_type=buy_plan, subject_type=buy_plan, subject_id
+= plan id), NOT a synthetic source="buy_plan" bridge item.
 
 Covers:
-  - GET /v2/approvals/requests returns both engine ApprovalRequest items AND pending BuyPlan items.
-  - BuyPlan item includes source="buy_plan", gate_type="buy_plan", and a detail_url linking to the
-    existing buy-plan detail partial (/v2/partials/buy-plans/{id}).
-  - BuyPlan with non-pending status is NOT included.
-  - GET /v2/approvals/queue renders the HTML queue template (200, text/html).
-  - The HTML queue contains the buy-plan row with a link to the detail page.
+  - GET /v2/approvals/requests lists a buy_plan-subject ApprovalRequest as an engine item
+    (no `source` field; carries subject_type/subject_id) alongside other engine requests.
+  - The list NEVER emits a synthetic source="buy_plan" bridge item.
+  - Filtering gate_type=buy_plan returns exactly the buy-plan requests.
+  - A pending BuyPlan with NO ApprovalRequest (pre-C1 / unrouted) does NOT appear — the
+    queue is engine-only.
+  - GET /v2/approvals/queue renders HTML; a buy_plan-subject row links to the plan detail
+    partial (/v2/partials/buy-plans/{id}) and the queue still renders for prepayment rows.
 
 Called by: pytest
-Depends on: conftest (db_session, test_user), app.routers.approvals,
-            app.models.buy_plan, app.models.approvals, app.dependencies.
+Depends on: conftest (db_session), app.routers.approvals, app.models.approvals,
+            app.models.buy_plan, app.dependencies.
 """
 
 import uuid
@@ -20,6 +25,7 @@ from datetime import datetime, timezone
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.constants import ApprovalGateType, ApprovalSubjectType
 from app.database import get_db
 from app.dependencies import require_user
 from app.models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
@@ -45,7 +51,7 @@ def _make_user(db: Session, *, can_approve: bool = True) -> User:
     return u
 
 
-def _make_pending_buy_plan(db: Session, user: User, *, status: str = "pending") -> BuyPlan:
+def _make_buy_plan(db: Session, user: User, *, status: str = "pending") -> BuyPlan:
     req = Requisition(
         name=f"REQ-BRIDGE-{uuid.uuid4().hex[:6]}",
         customer_name="BridgeCo",
@@ -73,15 +79,37 @@ def _make_pending_buy_plan(db: Session, user: User, *, status: str = "pending") 
         status=status,
         so_status="pending",
         submitted_by_id=user.id,
+        total_cost=12_000,
     )
     db.add(bp)
     db.flush()
     return bp
 
 
-def _make_engine_request(db: Session, user: User) -> ApprovalRequest:
+def _make_buy_plan_request(db: Session, bp: BuyPlan, user: User) -> ApprovalRequest:
+    """A native engine BUY_PLAN ApprovalRequest for *bp*, routed to *user* (pending)."""
     ar = ApprovalRequest(
-        gate_type="prepayment",
+        gate_type=ApprovalGateType.BUY_PLAN,
+        status="requested",
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        amount=bp.total_cost,
+        requested_by_id=user.id,
+        owner_id=user.id,
+    )
+    db.add(ar)
+    db.flush()
+    step = ApprovalStep(request_id=ar.id, seq=1, rule="any", status="pending")
+    db.add(step)
+    db.flush()
+    db.add(ApprovalStepRecipient(step_id=step.id, user_id=user.id, status="pending"))
+    db.flush()
+    return ar
+
+
+def _make_prepayment_request(db: Session, user: User) -> ApprovalRequest:
+    ar = ApprovalRequest(
+        gate_type=ApprovalGateType.PREPAYMENT,
         status="requested",
         requested_by_id=user.id,
         owner_id=user.id,
@@ -91,7 +119,7 @@ def _make_engine_request(db: Session, user: User) -> ApprovalRequest:
     step = ApprovalStep(request_id=ar.id, seq=1, rule="any", status="pending")
     db.add(step)
     db.flush()
-    ApprovalStepRecipient(step_id=step.id, user_id=user.id, status="pending")
+    db.add(ApprovalStepRecipient(step_id=step.id, user_id=user.id, status="pending"))
     db.flush()
     return ar
 
@@ -117,12 +145,13 @@ def _build_client(db: Session, user: User):
 # ── Tests ────────────────────────────────────────────────────────────────
 
 
-class TestUnifiedQueue:
-    def test_list_includes_pending_buy_plan(self, db_session: Session) -> None:
-        """GET /v2/approvals/requests returns pending BuyPlan as an item with
-        source=buy_plan."""
+class TestEngineNativeQueue:
+    def test_list_includes_buy_plan_request_as_engine_item(self, db_session: Session) -> None:
+        """A buy-plan submission surfaces as a native engine item carrying
+        subject_type=buy_plan + subject_id, with NO `source` field."""
         user = _make_user(db_session)
-        bp = _make_pending_buy_plan(db_session, user, status="pending")
+        bp = _make_buy_plan(db_session, user, status="pending")
+        ar = _make_buy_plan_request(db_session, bp, user)
         db_session.commit()
 
         for client in _build_client(db_session, user):
@@ -130,63 +159,77 @@ class TestUnifiedQueue:
 
         assert resp.status_code == 200
         body = resp.json()
-        bp_items = [i for i in body["items"] if i.get("source") == "buy_plan" and i.get("subject_id") == bp.id]
-        assert len(bp_items) == 1, f"Expected 1 buy_plan item, got: {bp_items}"
-
-    def test_list_buy_plan_item_has_detail_url(self, db_session: Session) -> None:
-        """Buy-plan item includes detail_url pointing at the existing buy-plan detail
-        partial."""
-        user = _make_user(db_session)
-        bp = _make_pending_buy_plan(db_session, user, status="pending")
-        db_session.commit()
-
-        for client in _build_client(db_session, user):
-            resp = client.get("/v2/approvals/requests")
-
-        body = resp.json()
-        bp_items = [i for i in body["items"] if i.get("source") == "buy_plan" and i.get("subject_id") == bp.id]
-        assert len(bp_items) == 1
-        item = bp_items[0]
+        items = {i["id"]: i for i in body["items"]}
+        assert ar.id in items
+        item = items[ar.id]
+        assert "source" not in item, "engine items must not carry a bridge `source` field"
         assert item["gate_type"] == "buy_plan"
-        assert item["detail_url"] == f"/v2/partials/buy-plans/{bp.id}"
+        assert item["subject_type"] == "buy_plan"
+        assert item["subject_id"] == bp.id
 
-    def test_list_both_engine_and_buy_plan_items(self, db_session: Session) -> None:
-        """Queue lists a prepayment engine request AND a pending buy-plan in the same
-        response."""
+    def test_list_never_emits_bridge_source(self, db_session: Session) -> None:
+        """The retired bridge must never produce a synthetic source='buy_plan' item."""
         user = _make_user(db_session)
-        ar = _make_engine_request(db_session, user)
-        bp = _make_pending_buy_plan(db_session, user, status="pending")
+        bp = _make_buy_plan(db_session, user, status="pending")
+        _make_buy_plan_request(db_session, bp, user)
         db_session.commit()
 
         for client in _build_client(db_session, user):
             resp = client.get("/v2/approvals/requests")
 
         body = resp.json()
-        sources = {i.get("source") for i in body["items"]}
-        assert "buy_plan" in sources, f"Missing buy_plan source; sources={sources}"
-        # Engine request items don't have a source field (or source=engine)
-        engine_items = [i for i in body["items"] if i.get("id") == ar.id]
-        assert len(engine_items) == 1
+        assert all(i.get("source") != "buy_plan" for i in body["items"])
 
-    def test_non_pending_buy_plan_excluded(self, db_session: Session) -> None:
-        """BuyPlan with status != 'pending' is NOT included in the unified queue."""
+    def test_filter_gate_type_buy_plan(self, db_session: Session) -> None:
+        """gate_type=buy_plan returns exactly the buy-plan requests, not prepayments."""
         user = _make_user(db_session)
-        # "active" = buy-plan status after manager approved → should NOT appear in approval queue
-        _make_pending_buy_plan(db_session, user, status="active")
+        bp = _make_buy_plan(db_session, user, status="pending")
+        ar = _make_buy_plan_request(db_session, bp, user)
+        _make_prepayment_request(db_session, user)
+        db_session.commit()
+
+        for client in _build_client(db_session, user):
+            resp = client.get("/v2/approvals/requests?gate_type=buy_plan")
+
+        body = resp.json()
+        ids = {i["id"] for i in body["items"]}
+        assert ids == {ar.id}
+        assert all(i["gate_type"] == "buy_plan" for i in body["items"])
+
+    def test_pending_buy_plan_without_request_is_absent(self, db_session: Session) -> None:
+        """A pending BuyPlan with no ApprovalRequest does NOT appear — the queue is
+        engine-only (no read-only bridge surfacing a bare BuyPlan)."""
+        user = _make_user(db_session)
+        bp = _make_buy_plan(db_session, user, status="pending")  # no engine request
         db_session.commit()
 
         for client in _build_client(db_session, user):
             resp = client.get("/v2/approvals/requests")
 
         body = resp.json()
-        active_bp_items = [i for i in body["items"] if i.get("source") == "buy_plan" and i.get("status") == "active"]
-        assert len(active_bp_items) == 0, "Non-pending buy plans should not appear in the approval queue"
+        assert all(i.get("subject_id") != bp.id for i in body["items"])
 
-    def test_queue_html_renders_buy_plan_row_with_link(self, db_session: Session) -> None:
-        """GET /v2/approvals/queue returns HTML with buy-plan row linking to detail
-        partial."""
+    def test_both_buy_plan_and_prepayment_listed(self, db_session: Session) -> None:
+        """Buy-plan and prepayment engine requests both appear in one response."""
         user = _make_user(db_session)
-        bp = _make_pending_buy_plan(db_session, user, status="pending")
+        bp = _make_buy_plan(db_session, user, status="pending")
+        bp_ar = _make_buy_plan_request(db_session, bp, user)
+        pp_ar = _make_prepayment_request(db_session, user)
+        db_session.commit()
+
+        for client in _build_client(db_session, user):
+            resp = client.get("/v2/approvals/requests")
+
+        body = resp.json()
+        ids = {i["id"] for i in body["items"]}
+        assert {bp_ar.id, pp_ar.id} <= ids
+
+    def test_queue_html_links_buy_plan_subject_to_detail(self, db_session: Session) -> None:
+        """GET /v2/approvals/queue renders HTML; a buy_plan-subject row links to the
+        plan detail partial."""
+        user = _make_user(db_session)
+        bp = _make_buy_plan(db_session, user, status="pending")
+        _make_buy_plan_request(db_session, bp, user)
         db_session.commit()
 
         for client in _build_client(db_session, user):
@@ -194,5 +237,32 @@ class TestUnifiedQueue:
 
         assert resp.status_code == 200
         assert "text/html" in resp.headers.get("content-type", "")
-        body = resp.text
-        assert f"/v2/partials/buy-plans/{bp.id}" in body
+        assert f"/v2/partials/buy-plans/{bp.id}" in resp.text
+
+    def test_queue_header_counts_only_open_requests(self, db_session: Session) -> None:
+        """The 'N items pending' header counts only REQUESTED rows — a resolved request
+        renders (with a View link) but must not inflate the pending count."""
+        user = _make_user(db_session)
+        bp = _make_buy_plan(db_session, user, status="pending")
+        _make_buy_plan_request(db_session, bp, user)  # one open
+        resolved = _make_prepayment_request(db_session, user)
+        resolved.status = "approved"  # a historical, non-pending row
+        db_session.commit()
+
+        for client in _build_client(db_session, user):
+            resp = client.get("/v2/approvals/queue")
+
+        assert resp.status_code == 200
+        assert "1 item pending" in resp.text, resp.text[:400]
+
+    def test_queue_html_renders_prepayment_row(self, db_session: Session) -> None:
+        """The engine-only queue still renders non-buy-plan rows (prepayment)."""
+        user = _make_user(db_session)
+        ar = _make_prepayment_request(db_session, user)
+        db_session.commit()
+
+        for client in _build_client(db_session, user):
+            resp = client.get("/v2/approvals/queue")
+
+        assert resp.status_code == 200
+        assert f"/v2/approvals/requests/{ar.id}" in resp.text

--- a/tests/test_buyplan_nav.py
+++ b/tests/test_buyplan_nav.py
@@ -35,6 +35,13 @@ class TestMobileNavTemplate:
         src = _TEMPLATE.read_text()
         assert "('reporting'," not in src, "'reporting' nav item still present in nav_items"
 
+    def test_nav_items_has_approvals_entry(self):
+        """nav_items tuple contains the C1 'approvals' entry → /v2/approvals/queue."""
+        src = _TEMPLATE.read_text()
+        assert "('approvals'," in src, "'approvals' nav item missing from nav_items"
+        assert "'/v2/approvals/queue'" in src, "Approvals nav must point at the engine queue"
+        assert "'/v2/approvals':'approvals'" in src, "urlToNav must map /v2/approvals to 'approvals'"
+
     def test_url_to_nav_maps_buy_plans_to_itself(self):
         """UrlToNav maps /v2/buy-plans to 'buy-plans'."""
         src = _TEMPLATE.read_text()
@@ -52,7 +59,7 @@ class TestMobileNavTemplate:
         verifies the badge wiring, not an incidental 'buy-plans' string elsewhere.
         """
         src = _TEMPLATE.read_text()
-        assert "{% elif id in ('requisitions', 'buy-plans', 'crm', 'my-day') %}" in src
+        assert "{% elif id in ('requisitions', 'buy-plans', 'crm', 'my-day', 'approvals') %}" in src
 
 
 class TestNavIdAlias:

--- a/tests/test_c1_buyplan_gate.py
+++ b/tests/test_c1_buyplan_gate.py
@@ -33,19 +33,22 @@ from app.constants import (
     ApprovalRequestStatus,
     ApprovalSubjectType,
     BuyPlanStatus,
+    SOVerificationStatus,
 )
 from app.database import get_db
 from app.dependencies import require_buyplan_approver, require_user
 from app.models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
 from app.models.auth import User
-from app.models.buy_plan import BuyPlan
+from app.models.buy_plan import BuyPlan, VerificationGroupMember
 from app.models.quotes import Quote
 from app.models.sourcing import Requisition
 from app.services.approvals.service import decide as svc_decide
 from app.services.buyplan_workflow import (
     approve_buy_plan,
+    cancel_buy_plan,
     resubmit_buy_plan,
     submit_buy_plan,
+    verify_so,
 )
 
 # ── Helpers ─────────────────────────────────────────────────────────────
@@ -405,3 +408,149 @@ def test_legacy_approve_and_engine_decide_reach_same_active_state(db_session: Se
     db_session.refresh(engine_plan)
     assert engine_plan.status == BuyPlanStatus.ACTIVE.value
     assert engine_plan.approved_by_id == approver.id
+
+
+# ── Cancel / halt cascade the open engine request (no orphan, no resurrection) ──
+
+
+def _ops_member(db: Session, *, role: str = "buyer") -> User:
+    """An active ops verification-group member (defaults to a plain buyer — NEITHER the
+    plan submitter NOR a manager/admin — to prove the engine cancel authz still
+    holds)."""
+    u = User(
+        email=f"c1-ops-{uuid.uuid4().hex[:6]}@test.com",
+        name="C1 Ops",
+        role=role,
+        azure_id=f"azure-c1-ops-{uuid.uuid4().hex[:8]}",
+        can_approve_buy_plans=False,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(u)
+    db.flush()
+    db.add(VerificationGroupMember(user_id=u.id, is_active=True))
+    db.flush()
+    return u
+
+
+def test_cancel_pending_plan_cancels_open_request(db_session: Session) -> None:
+    """(a) Cancelling a PENDING plan with an open engine request CANCELS that request
+    (it no longer sits REQUESTED in the queue/badge), and a later approve is
+    impossible."""
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-C1CANCEL", approver, db_session)
+    ar_id = _open_requests(db_session, plan.id)[0].id
+
+    cancel_buy_plan(plan.id, approver, db_session, reason="customer pulled the order")
+
+    db_session.refresh(plan)
+    assert plan.status == BuyPlanStatus.CANCELLED.value
+    # The request is CANCELLED, not REQUESTED — no orphan in the approvals queue/badge.
+    assert db_session.get(ApprovalRequest, ar_id).status == ApprovalRequestStatus.CANCELLED
+    assert _open_requests(db_session, plan.id) == []
+
+    # Deciding the now-CANCELLED request is impossible (engine rejects a non-REQUESTED req).
+    raised = False
+    try:
+        svc_decide(db_session, ar_id, approver, "approve", comment="too late")
+    except ValueError:
+        raised = True
+    assert raised, "approving a cancelled engine request must raise"
+    db_session.refresh(plan)
+    assert plan.status == BuyPlanStatus.CANCELLED.value
+
+
+def test_orphan_request_approval_does_not_resurrect_cancelled_plan(db_session: Session, monkeypatch) -> None:
+    """(b) THE proven bug, closed: if a stale REQUESTED request survives (cancel cascade
+    suppressed) on a CANCELLED plan, approving it must NOT resurrect the plan.
+
+    The state guard in ``_run_approve_side_effects`` raises ValueError → the request stays
+    open and the plan stays CANCELLED with no buyer tasks generated.
+    """
+    import app.services.buyplan_workflow as bw
+
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-C1ORPHAN", approver, db_session)
+    ar_id = _open_requests(db_session, plan.id)[0].id
+
+    # Simulate the PRE-FIX orphan: cancel the plan WITHOUT cascading the request (patch the
+    # cascade to a no-op), leaving the request stuck REQUESTED on a CANCELLED plan.
+    monkeypatch.setattr(bw, "_cancel_open_engine_requests_for_plan", lambda *a, **k: 0)
+    cancel_buy_plan(plan.id, approver, db_session, reason="cancelled")
+    monkeypatch.undo()
+    db_session.refresh(plan)
+    assert plan.status == BuyPlanStatus.CANCELLED.value
+    assert _open_requests(db_session, plan.id)  # the orphan still sits REQUESTED
+
+    # An approver picks the orphan out of the queue and approves it.
+    task_calls: list = []
+    monkeypatch.setattr(bw, "_generate_buyer_tasks", lambda *a, **k: task_calls.append(1))
+
+    raised = False
+    try:
+        svc_decide(db_session, ar_id, approver, "approve", comment="resurrect?")
+    except ValueError:
+        raised = True
+    assert raised, "the state guard must reject approving an orphan on a cancelled plan"
+
+    # No resurrection: plan stays CANCELLED, never went ACTIVE, no buyer tasks generated.
+    db_session.refresh(plan)
+    assert plan.status == BuyPlanStatus.CANCELLED.value
+    assert task_calls == [], "buyer tasks must NOT be generated for a cancelled plan"
+
+
+def test_verify_so_halt_cancels_open_request(db_session: Session) -> None:
+    """(c) HALTing a PENDING plan (via verify_so) cancels its open engine request, even
+    when the halting ops member is a plain buyer (not submitter, not manager/admin) —
+    the helper cancels on behalf of the request's own requester/owner so authz holds."""
+    approver = _make_approver(db_session)
+    ops = _ops_member(db_session)  # plain buyer, distinct from the approver/submitter
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-C1HALT", approver, db_session)
+    ar_id = _open_requests(db_session, plan.id)[0].id
+    assert plan.status == BuyPlanStatus.PENDING.value
+
+    verify_so(plan.id, "halt", ops, db_session, rejection_note="SO mismatch in Acctivate")
+
+    db_session.refresh(plan)
+    assert plan.status == BuyPlanStatus.HALTED.value
+    assert db_session.get(ApprovalRequest, ar_id).status == ApprovalRequestStatus.CANCELLED
+    assert _open_requests(db_session, plan.id) == []
+
+
+# ── Badge: post-C1 plan counts on approvals only; pre-C1 plan counts on buy-plans ──
+
+
+def test_buyplan_badge_excludes_plans_with_open_engine_request(db_session: Session) -> None:
+    """(d) A post-C1 PENDING plan (open engine request) is NOT counted by the buy-plans
+    ACTION badge (it surfaces on the approvals badge instead — no double-count); a
+    pre-C1 PENDING plan (NO engine request) still counts on the buy-plans badge so it
+    stays visible."""
+    from app.services.alerts.sources.approvals import ApprovalRequestActionSource
+    from app.services.alerts.sources.buyplan import BuyplanActionSource
+
+    bp_source = BuyplanActionSource()
+    appr_source = ApprovalRequestActionSource()
+
+    approver = _make_approver(db_session)
+
+    # Post-C1 plan: PENDING with an open engine request routed to the approver.
+    post_c1 = _make_draft_plan(db_session, approver)
+    submit_buy_plan(post_c1.id, "SO-C1BADGE", approver, db_session)
+    db_session.flush()
+
+    # The post-C1 plan counts on the approvals badge, NOT the buy-plans badge.
+    assert appr_source.count_for_user(db_session, approver) == 1
+    assert bp_source.count_for_user(db_session, approver) == 0
+
+    # Pre-C1 plan: PENDING with NO engine request (transition window). It must stay visible
+    # on the buy-plans badge.
+    pre_c1 = _make_draft_plan(db_session, approver)
+    pre_c1.status = BuyPlanStatus.PENDING.value
+    pre_c1.so_status = SOVerificationStatus.PENDING.value
+    db_session.flush()
+
+    assert bp_source.count_for_user(db_session, approver) == 1
+    # The approvals badge is unchanged by the pre-C1 plan (it has no engine request).
+    assert appr_source.count_for_user(db_session, approver) == 1

--- a/tests/test_c1_buyplan_gate.py
+++ b/tests/test_c1_buyplan_gate.py
@@ -1,0 +1,407 @@
+"""test_c1_buyplan_gate.py — QP Phase C1: the approvals engine OWNS the buy-plan gate.
+
+Covers the C1 contract + its three reviewed risk-mitigations:
+  - submit_buy_plan (above auto-approve threshold) creates a BUY_PLAN ApprovalRequest
+    routed to can_approve_buy_plans holders; plan stays PENDING.
+  - decide(approve) drives the buy-plan side effects in the SAME session before commit:
+    plan ACTIVE + buyer tasks generated + approved_by set + request APPROVED (RISK 1 —
+    atomic dispatch inside decide()).
+  - decide(reject) drives the reject side effects: plan → DRAFT, request REJECTED.
+  - resubmit cancels the stale open request so exactly ONE REQUESTED request remains
+    (RISK 2 — no double request).
+  - the approve router falls back to legacy approve_buy_plan when no open engine request
+    exists (RISK 3 — pre-C1 transition window) and does not crash.
+  - NoEligibleApproverError (no approver configured) leaves the plan PENDING with no
+    orphan engine state.
+  - ApprovalRequestActionSource counts open requests the user must decide (nav badge).
+
+Called by: pytest
+Depends on: conftest (db_session), app.services.buyplan_workflow,
+            app.services.approvals.service, app.models.{approvals,buy_plan,auth}.
+"""
+
+import contextlib
+import uuid
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.constants import (
+    ApprovalGateType,
+    ApprovalRequestStatus,
+    ApprovalSubjectType,
+    BuyPlanStatus,
+)
+from app.database import get_db
+from app.dependencies import require_buyplan_approver, require_user
+from app.models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
+from app.models.auth import User
+from app.models.buy_plan import BuyPlan
+from app.models.quotes import Quote
+from app.models.sourcing import Requisition
+from app.services.approvals.service import decide as svc_decide
+from app.services.buyplan_workflow import (
+    approve_buy_plan,
+    resubmit_buy_plan,
+    submit_buy_plan,
+)
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_approver(db: Session) -> User:
+    u = User(
+        email=f"c1-approver-{uuid.uuid4().hex[:6]}@test.com",
+        name="C1 Approver",
+        role="admin",
+        azure_id=f"azure-c1-appr-{uuid.uuid4().hex[:8]}",
+        can_approve_buy_plans=True,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_draft_plan(db: Session, user: User, *, total_cost: float = 10_000.0) -> BuyPlan:
+    """A draft buy plan over the auto-approve threshold (so submit → PENDING, not
+    ACTIVE)."""
+    req = Requisition(
+        name=f"REQ-C1-{uuid.uuid4().hex[:6]}",
+        customer_name="C1Co",
+        status="active",
+        created_by=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(req)
+    db.flush()
+
+    quote = Quote(
+        requisition_id=req.id,
+        quote_number=f"QC1-{uuid.uuid4().hex[:8]}",
+        line_items=[],
+        status="sent",
+        created_by_id=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(quote)
+    db.flush()
+
+    bp = BuyPlan(
+        requisition_id=req.id,
+        quote_id=quote.id,
+        status=BuyPlanStatus.DRAFT.value,
+        so_status="pending",
+        total_cost=total_cost,
+    )
+    db.add(bp)
+    db.flush()
+    return bp
+
+
+def _open_requests(db: Session, plan_id: int) -> list[ApprovalRequest]:
+    return list(
+        db.execute(
+            select(ApprovalRequest).where(
+                ApprovalRequest.subject_type == ApprovalSubjectType.BUY_PLAN,
+                ApprovalRequest.subject_id == plan_id,
+                ApprovalRequest.status == ApprovalRequestStatus.REQUESTED,
+            )
+        ).scalars()
+    )
+
+
+# ── submit → engine request ──────────────────────────────────────────────
+
+
+def test_submit_creates_buy_plan_request(db_session: Session) -> None:
+    """A non-auto-approved submit creates ONE BUY_PLAN ApprovalRequest, plan stays
+    PENDING."""
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+
+    submit_buy_plan(plan.id, "SO-1001", approver, db_session)
+
+    assert plan.status == BuyPlanStatus.PENDING.value
+    reqs = _open_requests(db_session, plan.id)
+    assert len(reqs) == 1
+    ar = reqs[0]
+    assert ar.gate_type == ApprovalGateType.BUY_PLAN
+    assert ar.subject_type == ApprovalSubjectType.BUY_PLAN
+    assert ar.subject_id == plan.id
+    # Routed to the approver as a PENDING recipient.
+    recip = db_session.execute(
+        select(ApprovalStepRecipient)
+        .join(ApprovalStep, ApprovalStepRecipient.step_id == ApprovalStep.id)
+        .where(ApprovalStep.request_id == ar.id, ApprovalStepRecipient.user_id == approver.id)
+    ).scalar_one()
+    assert recip.status == "pending"
+
+
+# ── RISK 1: decide() drives side effects atomically, same session ─────────
+
+
+def test_decide_approve_drives_side_effects_same_session(db_session: Session) -> None:
+    """RISK 1: after decide(approve), plan is ACTIVE *and* request APPROVED in the SAME
+    session before any commit, with buyer-task gen run + approver stamped."""
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-1002", approver, db_session)
+    ar = _open_requests(db_session, plan.id)[0]
+
+    resolved = svc_decide(db_session, ar.id, approver, "approve", comment="LGTM")
+
+    # No commit has happened — assert end-state in the live session.
+    assert resolved.status == ApprovalRequestStatus.APPROVED
+    db_session.refresh(plan)
+    assert plan.status == BuyPlanStatus.ACTIVE.value
+    assert plan.approved_by_id == approver.id
+    assert plan.approved_at is not None
+    assert plan.approval_notes == "LGTM"
+
+
+def test_decide_reject_sends_plan_to_draft(db_session: Session) -> None:
+    """Decide(reject) → request REJECTED + plan back to DRAFT."""
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-1003", approver, db_session)
+    ar = _open_requests(db_session, plan.id)[0]
+
+    resolved = svc_decide(db_session, ar.id, approver, "reject", comment="price too high")
+
+    assert resolved.status == ApprovalRequestStatus.REJECTED
+    db_session.refresh(plan)
+    assert plan.status == BuyPlanStatus.DRAFT.value
+    assert plan.approval_notes == "price too high"
+
+
+def test_decide_approve_rolls_back_on_side_effect_failure(db_session: Session, monkeypatch) -> None:
+    """RISK 1 (atomicity): if a side effect raises, decide() propagates — the caller's
+    transaction rolls back so the request can't land APPROVED while the plan stays
+    PENDING."""
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-1004", approver, db_session)
+    # Commit the submission so it is its own transaction (mirrors production: submit and
+    # decide are separate requests). The rollback below then reverts ONLY the decide work.
+    db_session.commit()
+    ar = _open_requests(db_session, plan.id)[0]
+
+    import app.services.buyplan_workflow as bw
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("buyer task generation blew up")
+
+    monkeypatch.setattr(bw, "_generate_buyer_tasks", _boom)
+
+    raised = False
+    try:
+        svc_decide(db_session, ar.id, approver, "approve", comment="ok")
+    except RuntimeError:
+        raised = True
+        db_session.rollback()
+    assert raised, "decide() must NOT swallow the side-effect failure"
+
+    # After rollback: request still REQUESTED and plan still PENDING (no split-brain) —
+    # the engine never moved the request to APPROVED because the dispatch raised inline.
+    db_session.expire_all()
+    ar2 = db_session.get(ApprovalRequest, ar.id)
+    plan2 = db_session.get(BuyPlan, plan.id)
+    assert ar2.status == ApprovalRequestStatus.REQUESTED
+    assert plan2.status == BuyPlanStatus.PENDING.value
+
+
+# ── RISK 2: resubmit cancels the stale request ────────────────────────────
+
+
+def test_resubmit_leaves_exactly_one_open_request(db_session: Session) -> None:
+    """RISK 2: resubmit cancels the stale open request before creating a new one, so
+    exactly ONE REQUESTED request exists for the plan."""
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-1005", approver, db_session)
+    first = _open_requests(db_session, plan.id)
+    assert len(first) == 1
+    first_id = first[0].id
+
+    # Manager rejects → plan back to DRAFT, request resolved.
+    ar = db_session.get(ApprovalRequest, first_id)
+    svc_decide(db_session, ar.id, approver, "reject", comment="redo it")
+    db_session.refresh(plan)
+    assert plan.status == BuyPlanStatus.DRAFT.value
+
+    # Salesperson resubmits.
+    resubmit_buy_plan(plan.id, "SO-1005R", approver, db_session)
+    assert plan.status == BuyPlanStatus.PENDING.value
+
+    open_now = _open_requests(db_session, plan.id)
+    assert len(open_now) == 1, f"expected exactly 1 open request, got {[r.id for r in open_now]}"
+    assert open_now[0].id != first_id, "resubmit must create a fresh request"
+
+
+def test_resubmit_after_unresolved_submit_cancels_stale(db_session: Session) -> None:
+    """RISK 2 (direct): even if the first request was never decided, a second submit-
+    style open cancels it — never two live REQUESTED rows.
+
+    Forced by submitting, resetting the plan to DRAFT directly, then resubmitting.
+    """
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-1006", approver, db_session)
+    stale_id = _open_requests(db_session, plan.id)[0].id
+
+    # Bypass the manager decision: force the plan back to DRAFT (stale request still open).
+    plan.status = BuyPlanStatus.DRAFT.value
+    db_session.flush()
+
+    resubmit_buy_plan(plan.id, "SO-1006R", approver, db_session)
+
+    open_now = _open_requests(db_session, plan.id)
+    assert len(open_now) == 1
+    assert open_now[0].id != stale_id
+    stale = db_session.get(ApprovalRequest, stale_id)
+    assert stale.status == ApprovalRequestStatus.CANCELLED
+
+
+# ── No eligible approver: plan PENDING, no orphan engine state ─────────────
+
+
+def test_submit_with_no_approver_leaves_plan_pending(db_session: Session) -> None:
+    """If no user holds can_approve_buy_plans, routing raises NoEligibleApproverError;
+    the submit logs a WARNING and leaves the plan PENDING with no open request."""
+    # Submitter does NOT have the approval right, and no other approver exists.
+    submitter = User(
+        email=f"c1-noappr-{uuid.uuid4().hex[:6]}@test.com",
+        name="No Approver",
+        role="buyer",
+        azure_id=f"azure-c1-noappr-{uuid.uuid4().hex[:8]}",
+        can_approve_buy_plans=False,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(submitter)
+    db_session.flush()
+    plan = _make_draft_plan(db_session, submitter)
+
+    submit_buy_plan(plan.id, "SO-1007", submitter, db_session)
+
+    assert plan.status == BuyPlanStatus.PENDING.value
+    assert _open_requests(db_session, plan.id) == []
+
+
+# ── RISK 3: router fallback when no open request (pre-C1 plan) ─────────────
+
+
+@contextlib.contextmanager
+def _build_client(db: Session, user: User):
+    """A TestClient with db + auth (buy-plan approver) overrides, cleaned up on exit
+    even if the request raises (contextmanager guarantees the finally block runs)."""
+    from app.main import app
+
+    def _db():
+        yield db
+
+    def _user():
+        return user
+
+    overrides = {get_db: _db, require_user: _user, require_buyplan_approver: _user}
+    app.dependency_overrides.update(overrides)
+    try:
+        yield TestClient(app, raise_server_exceptions=True)
+    finally:
+        for key in overrides:
+            app.dependency_overrides.pop(key, None)
+
+
+def test_approve_router_falls_back_when_no_open_request(db_session: Session) -> None:
+    """RISK 3: a plan that is PENDING with NO open engine request (submitted pre-C1) is
+    approved via the legacy approve_buy_plan fallback — the action does not crash."""
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    # Put the plan straight into PENDING WITHOUT opening an engine request (pre-C1 state).
+    plan.status = BuyPlanStatus.PENDING.value
+    plan.submitted_by_id = approver.id
+    db_session.flush()
+    db_session.commit()
+    assert _open_requests(db_session, plan.id) == []
+
+    with _build_client(db_session, approver) as client:
+        resp = client.post(
+            f"/v2/partials/buy-plans/{plan.id}/approve",
+            data={"action": "approve"},
+        )
+
+    assert resp.status_code == 200
+    db_session.expire_all()
+    plan2 = db_session.get(BuyPlan, plan.id)
+    assert plan2.status == BuyPlanStatus.ACTIVE.value
+    assert plan2.approved_by_id == approver.id
+
+
+def test_approve_router_uses_engine_when_request_open(db_session: Session) -> None:
+    """Happy path: with an open engine request, the router resolves it via decide()."""
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-1008", approver, db_session)
+    db_session.commit()
+    ar_id = _open_requests(db_session, plan.id)[0].id
+
+    with _build_client(db_session, approver) as client:
+        resp = client.post(
+            f"/v2/partials/buy-plans/{plan.id}/approve",
+            data={"action": "approve", "notes": "engine path"},
+        )
+
+    assert resp.status_code == 200
+    db_session.expire_all()
+    assert db_session.get(BuyPlan, plan.id).status == BuyPlanStatus.ACTIVE.value
+    assert db_session.get(ApprovalRequest, ar_id).status == ApprovalRequestStatus.APPROVED
+
+
+# ── Nav badge alert source ────────────────────────────────────────────────
+
+
+def test_approval_action_source_counts_my_open_requests(db_session: Session) -> None:
+    """ApprovalRequestActionSource counts open requests where the user is a PENDING
+    recipient, and drops the count once the request is decided."""
+    from app.services.alerts.sources.approvals import ApprovalRequestActionSource
+
+    approver = _make_approver(db_session)
+    plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(plan.id, "SO-1009", approver, db_session)
+    db_session.flush()
+
+    source = ApprovalRequestActionSource()
+    assert source.count_for_user(db_session, approver) == 1
+
+    ar = _open_requests(db_session, plan.id)[0]
+    svc_decide(db_session, ar.id, approver, "approve", comment="done")
+    db_session.flush()
+    assert source.count_for_user(db_session, approver) == 0
+
+
+# ── Side-effect helper parity (extraction was behavior-neutral) ───────────
+
+
+def test_legacy_approve_and_engine_decide_reach_same_active_state(db_session: Session) -> None:
+    """approve_buy_plan and decide() both call the shared _run_approve_side_effects, so
+    a plan approved either way lands in the same ACTIVE end-state."""
+    approver = _make_approver(db_session)
+
+    # Legacy path (no engine request): force PENDING then approve directly.
+    legacy_plan = _make_draft_plan(db_session, approver)
+    legacy_plan.status = BuyPlanStatus.PENDING.value
+    db_session.flush()
+    approve_buy_plan(legacy_plan.id, "approve", approver, db_session, notes="legacy")
+    assert legacy_plan.status == BuyPlanStatus.ACTIVE.value
+    assert legacy_plan.approved_by_id == approver.id
+
+    # Engine path.
+    engine_plan = _make_draft_plan(db_session, approver)
+    submit_buy_plan(engine_plan.id, "SO-1010", approver, db_session)
+    ar = _open_requests(db_session, engine_plan.id)[0]
+    svc_decide(db_session, ar.id, approver, "approve", comment="engine")
+    db_session.refresh(engine_plan)
+    assert engine_plan.status == BuyPlanStatus.ACTIVE.value
+    assert engine_plan.approved_by_id == approver.id


### PR DESCRIPTION
## QP Phase C1 — buy-plan approvals run through the engine

Buy-plan approval now flows through the shared approvals engine instead of the read-only bridge.

- **Submit/resubmit** a buy plan → creates a `BUY_PLAN` `ApprovalRequest` (routed to `can_approve_buy_plans` holders); cancels any stale open request first (no duplicates).
- **Approve/reject** via the engine `decide()` — drives the existing buy-plan side effects **atomically** (status→ACTIVE + buyer-task generation, or →DRAFT); a side-effect failure rolls back the whole transaction.
- **Read-only bridge retired** (`_buy_plan_as_queue_item`/`__never__` gone); the **approvals queue** is in nav with inline approve/reject + a recipient-scoped badge.
- **No migration** (`BUY_PLAN` added to `ApprovalSubjectType`; `gate_type`/`subject_type` are `String(50)`).

**Reviewed (dual adversarial):** correctness pass clean; the deep engine-rewire pass caught + we fixed a real bug — a cancelled/halted PENDING plan left an orphan request that could resurrect the plan to ACTIVE on approval. Fixed at root: re-added the `status==PENDING` guard to the side-effect helpers, cancel/halt now cascade-cancel the open engine request, badge no longer double-counts. New regression test verified to fail without the guard.

Full suite green (20,679+); RISK 1/2/3 (atomicity, no-double-request, deploy-window fallback) all tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)