### PR TITLE
fix(resell): New List 422 — static create-form route was shadowed by /{list_id}

### DIFF
--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -328,6 +328,24 @@ async def resell_lists(
 # ── Right detail + lazy tab bodies ───────────────────────────────────
 
 
+# NB: this static route MUST be registered before the dynamic "/{list_id}" route below —
+# otherwise FastAPI matches "create-form" against {list_id} and 422s on int parsing.
+@router.get("/v2/partials/resell/create-form", response_class=HTMLResponse)
+async def resell_create_form(
+    request: Request,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Render the new-list modal (only for users who can post)."""
+    if not excess_service.can_post(user):
+        raise HTTPException(403, "You do not have permission to post excess lists")
+    companies = db.query(Company).order_by(Company.name).all()
+    return template_response(
+        "htmx/partials/resell/create_modal.html",
+        {"request": request, "companies": companies},
+    )
+
+
 @router.get("/v2/partials/resell/{list_id}", response_class=HTMLResponse)
 async def resell_detail(
     request: Request,
@@ -603,22 +621,6 @@ async def resell_bid_pdf(
 
 
 # ── Modal forms ──────────────────────────────────────────────────────
-
-
-@router.get("/v2/partials/resell/create-form", response_class=HTMLResponse)
-async def resell_create_form(
-    request: Request,
-    user: User = Depends(require_user),
-    db: Session = Depends(get_db),
-):
-    """Render the new-list modal (only for users who can post)."""
-    if not excess_service.can_post(user):
-        raise HTTPException(403, "You do not have permission to post excess lists")
-    companies = db.query(Company).order_by(Company.name).all()
-    return template_response(
-        "htmx/partials/resell/create_modal.html",
-        {"request": request, "companies": companies},
-    )
 
 
 @router.get("/v2/partials/resell/{list_id}/add-line-form", response_class=HTMLResponse)

--- a/tests/test_resell_routes.py
+++ b/tests/test_resell_routes.py
@@ -106,6 +106,30 @@ def test_workspace_renders(client, trader_user, posted_list):
     assert "split-resell" in body  # splitPanel container
 
 
+def test_create_form_route_not_shadowed_by_list_id(client, trader_user):
+    """Regression: the static /v2/partials/resell/create-form route must be matched as itself.
+
+    Before the fix, the dynamic /{list_id} route was registered first, so FastAPI matched
+    'create-form' against {list_id} and returned 422 (int-parse on list_id) — the 'New List'
+    button was dead. Override require_user to a can_post trader and assert the modal renders.
+    """
+    from app.dependencies import require_user
+    from app.main import app
+
+    prev = app.dependency_overrides.get(require_user)
+    app.dependency_overrides[require_user] = lambda: trader_user
+    try:
+        resp = client.get("/v2/partials/resell/create-form")
+    finally:
+        if prev is not None:
+            app.dependency_overrides[require_user] = prev
+        else:
+            app.dependency_overrides.pop(require_user, None)
+
+    assert resp.status_code != 422, f"create-form shadowed by /{{list_id}}: {resp.text}"
+    assert resp.status_code == 200, resp.text  # trader can_post → the new-list modal renders
+
+
 def test_full_page_route(client, trader_user):
     """/v2/resell serves the base shell, wired to load the workspace partial.
 


### PR DESCRIPTION
The Resell **New List** button was dead since the module shipped: it GETs `/v2/partials/resell/create-form`, but the dynamic `/{list_id}` route was registered first, so FastAPI matched `create-form` against `{list_id}` and returned 422 (int-parse). Moved the static route above the dynamic one + added a regression test. One-line root-cause fix, no behavior change otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)