### PR TITLE
feat(crm): contact card — fix role dropdown, click-to-contact, notes modal, horizontal layout

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -688,6 +688,24 @@ class OutreachChannel(StrEnum):
     WECHAT = "wechat"
 
 
+class ContactRole(StrEnum):
+    """Canonical CRM site-contact buying-role taxonomy (Mike's vocabulary).
+
+    Single source of truth for the role dropdown on the customer-tab contact card.
+    `tuple(ContactRole)` drives both CANONICAL_ROLES (app/routers/htmx_views.py) and
+    the `roles` Jinja2 global fallback (app/template_env.py). Stored in
+    site_contacts.contact_role (String(50)); legacy DB values (buyer_po/specifier/
+    ap_payer/logistics/exec/technical/decision_maker/operations) are NOT in this set —
+    they render via the legacy display-label maps but can only be cleared, not re-saved.
+    """
+
+    BUYER = "buyer"
+    MANAGER = "manager"
+    ENGINEER = "engineer"
+    PLANNER = "planner"
+    OTHER = "other"
+
+
 class EventType(StrEnum):
     """Canonical activity_log.event_type values (Communication-Intelligence kind)."""
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -31,6 +31,7 @@ from ..constants import (
     ActivityType,
     AttributionStatus,
     BuyPlanStatus,
+    ContactRole,
     ContactStatus,
     OfferStatus,
     ProactiveMatchStatus,
@@ -6811,10 +6812,12 @@ async def get_company_contacts_for_select(
 
 _VALID_TIERS = frozenset({"key", "core", "standard", "prospect"})
 
-# Canonical buying-role taxonomy (P2b).  Legacy values (buyer/technical/
-# decision_maker/operations) remain valid in the DB but can only be cleared
+# Canonical buying-role taxonomy — sourced from the ContactRole StrEnum (single
+# source of truth in app/constants.py; mirrored as the `roles` Jinja2 global in
+# app/template_env.py). Legacy DB values (buyer_po/specifier/ap_payer/logistics/
+# exec/technical/decision_maker/operations) remain in the DB but can only be cleared
 # via the "— clear —" option; they are not in this set.
-CANONICAL_ROLES = ("specifier", "buyer_po", "ap_payer", "logistics", "exec", "other")
+CANONICAL_ROLES = tuple(ContactRole)
 _VALID_ROLES = frozenset(CANONICAL_ROLES)
 
 # ── Inline-editable field registry (WS1) ────────────────────────────────────
@@ -10060,6 +10063,118 @@ async def contact_files_modal(
         "htmx/partials/customers/_contact_files_modal.html",
         {"request": request, "contact": contact},
     )
+
+
+def _contact_under_company(db: Session, company_id: int, contact_id: int) -> SiteContact:
+    """Load a SiteContact and verify it belongs to *company_id* (via its site).
+
+    Raises HTTPException(404) if the contact does not exist or is not under that company
+    — the contact-notes-modal endpoints share this lookup.
+    """
+    contact = (
+        db.query(SiteContact)
+        .join(CustomerSite, SiteContact.customer_site_id == CustomerSite.id)
+        .filter(SiteContact.id == contact_id, CustomerSite.company_id == company_id)
+        .first()
+    )
+    if not contact:
+        raise HTTPException(404, "Contact not found")
+    return contact
+
+
+def _render_contact_notes_modal(
+    request: Request,
+    company: Company,
+    contact: SiteContact,
+    db: Session,
+    can_manage: bool,
+    error: str | None = None,
+) -> HTMLResponse:
+    """Render the contact-notes modal body (feed + add form).
+
+    Shared by GET + POST.
+    """
+    from ..services.activity_service import get_site_contact_notes
+
+    notes = get_site_contact_notes(contact.id, db)
+    return template_response(
+        "htmx/partials/customers/_contact_notes_modal.html",
+        {
+            "request": request,
+            "company": company,
+            "contact": contact,
+            "notes": notes,
+            "can_manage": can_manage,
+            "error": error,
+        },
+    )
+
+
+@router.get(
+    "/v2/partials/customers/{company_id}/contacts/{contact_id}/notes-modal",
+    response_class=HTMLResponse,
+)
+async def contact_notes_modal(
+    request: Request,
+    company_id: int,
+    contact_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Return the global-modal body with a contact's note feed + add form.
+
+    Loaded by the contact-card drawer "See all notes" / "+ Add note" action via
+    $dispatch('open-modal'). 404 if the contact is not under this company.
+    """
+    company = db.get(Company, company_id)
+    if not company:
+        raise HTTPException(404, "Company not found")
+    contact = _contact_under_company(db, company_id, contact_id)
+    return _render_contact_notes_modal(request, company, contact, db, can_manage=can_manage_account(user, company, db))
+
+
+@router.post(
+    "/v2/partials/customers/{company_id}/contacts/{contact_id}/notes",
+    response_class=HTMLResponse,
+)
+async def add_contact_note(
+    request: Request,
+    company_id: int,
+    contact_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Log a manual note against a contact, then re-render the notes-modal body.
+
+    can_manage_account gate (403 otherwise). Blank note → inline error (no write).
+    """
+    from ..services.activity_service import log_site_contact_note
+
+    company = db.get(Company, company_id)
+    if not company:
+        raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(403, "Only the owner or an admin can add notes for this contact")
+    contact = _contact_under_company(db, company_id, contact_id)
+
+    form = await request.form()
+    notes_text = (form.get("notes") or "").strip()
+    if not notes_text:
+        return _render_contact_notes_modal(
+            request, company, contact, db, can_manage=True, error="Note cannot be empty."
+        )
+
+    log_site_contact_note(
+        user_id=user.id,
+        site_contact_id=contact.id,
+        customer_site_id=contact.customer_site_id,
+        company_id=company_id,
+        notes=notes_text,
+        db=db,
+    )
+    db.commit()
+    logger.info("Note added to contact {} by {} (company {})", contact_id, user.email, company_id)
+    return _render_contact_notes_modal(request, company, contact, db, can_manage=True)
 
 
 @router.post(

--- a/app/services/crm_service.py
+++ b/app/services/crm_service.py
@@ -617,12 +617,14 @@ def company_contact_rows(
             .all()
         )
     now_utc = datetime.now(timezone.utc)
+    recent_notes = _latest_contact_notes(db, [c.id for c in contacts])
     rows = [
         {
             "contact": c,
             "site": site_map.get(c.customer_site_id),
             "legacy": False,
             "cadence": cadence_state(None, c.last_outbound_at, now_utc),
+            "recent_note": recent_notes.get(c.id),
         }
         for c in contacts
     ]
@@ -636,8 +638,37 @@ def company_contact_rows(
             if legacy_email and legacy_email in real_emails:
                 # A real SiteContact already covers this address — suppress the legacy row.
                 continue
-            rows.append({"contact": None, "site": s, "legacy": True, "cadence": "new"})
+            rows.append({"contact": None, "site": s, "legacy": True, "cadence": "new", "recent_note": None})
     return rows
+
+
+def _latest_contact_notes(db: Session, contact_ids: list[int]) -> dict[int, str]:
+    """Return {site_contact_id: latest manual-note text} for the given contacts.
+
+    One batched query (no N+1): picks each contact's newest ActivityLog NOTE so the
+    contact-row drawer can show a recent-note preview without a per-row round-trip. The
+    full note feed lives behind the notes modal (get_site_contact_notes).
+    """
+    if not contact_ids:
+        return {}
+    from ..models.intelligence import ActivityLog
+
+    rows = (
+        db.query(ActivityLog.site_contact_id, ActivityLog.notes, ActivityLog.created_at)
+        .filter(
+            ActivityLog.site_contact_id.in_(contact_ids),
+            ActivityLog.activity_type == "note",
+            ActivityLog.notes.isnot(None),
+        )
+        .order_by(ActivityLog.site_contact_id, ActivityLog.created_at.desc())
+        .all()
+    )
+    latest: dict[int, str] = {}
+    for site_contact_id, notes, _created in rows:
+        # Rows are ordered newest-first per contact; keep the first seen for each.
+        if site_contact_id not in latest and notes:
+            latest[site_contact_id] = notes
+    return latest
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/app/template_env.py
+++ b/app/template_env.py
@@ -340,8 +340,11 @@ templates.env.globals["cadence_state"] = cadence_state
 # inherit template context). Context-level "roles" passed by set_contact_role /
 # contacts_tab endpoints takes precedence; this global is the fallback for the
 # macro-include path.
-# Must stay in sync with CANONICAL_ROLES in app/routers/htmx_views.py.
-_CANONICAL_ROLES = ("specifier", "buyer_po", "ap_payer", "logistics", "exec", "other")
+# Sourced from the ContactRole StrEnum (single source of truth in app/constants.py) —
+# the SAME tuple CANONICAL_ROLES in app/routers/htmx_views.py is built from.
+from .constants import ContactRole  # noqa: E402
+
+_CANONICAL_ROLES = tuple(ContactRole)
 templates.env.globals["roles"] = _CANONICAL_ROLES
 
 # Buy-plan approval right exposed as a Jinja2 global so templates hide the approve/reject

--- a/app/templates/htmx/partials/customers/_contact_macros.html
+++ b/app/templates/htmx/partials/customers/_contact_macros.html
@@ -1,6 +1,6 @@
 {# _contact_macros.html — Shared Jinja2 macros for SiteContact rendering.
    Imported (not included) by contacts_tab.html and _contacts_grouped_list.html
-   via: {% from 'htmx/partials/customers/_contact_macros.html' import contact_card, contact_clocks, outreach_btn, contact_row %}
+   via: {% from 'htmx/partials/customers/_contact_macros.html' import contact_clocks, outreach_btn, contact_row %}
 
    Receives (per call): company, contact, site, legacy, now_utc, cadence (optional).
    Depends on: cadence_state Jinja global (template_env.py:277), brand palette,
@@ -124,376 +124,12 @@
 {% endmacro %}
 
 
-{% macro contact_card(company, contact, site, legacy, now_utc=none, cadence='new') %}
-{% if legacy %}
-  {# Legacy site-level contact (contact is None, fields live on site).
-     h-full: equal-height cells when laid out in the responsive contacts grid. #}
-  <div class="bg-white rounded-lg border border-gray-200 p-3 hover:border-brand-200 transition-colors h-full group">
-    <div class="flex items-start justify-between gap-3 flex-wrap">
-      <div class="min-w-0 flex-1">
-        <div class="flex items-center gap-2 flex-wrap">
-          <span class="text-sm font-medium text-gray-900">{{ site.contact_name or "—" }}</span>
-          <span class="text-[11px] text-gray-400">legacy</span>
-          {# Site label — always visible #}
-          {% if site %}
-          <span class="px-1.5 py-0.5 text-[11px] font-medium rounded bg-gray-100 text-gray-600"
-                title="Site">{{ site.site_name }}</span>
-          {% endif %}
-        </div>
-        <p class="text-[11px] text-gray-600 mt-0.5">{{ site.contact_title or "—" }}</p>
-        <div class="mt-1 flex items-center gap-3 text-[11px] text-gray-600 flex-wrap opacity-0 group-hover:opacity-100 transition-opacity">
-          {% if site.contact_email %}<span class="truncate">{{ site.contact_email }}</span>{% endif %}
-          {% if site.contact_phone %}<span>{{ site.contact_phone }}</span>{% endif %}
-        </div>
-      </div>
-      <div class="flex items-center gap-1.5 flex-wrap flex-shrink-0">
-        {% if site.contact_phone %}
-        {{ outreach_btn("Call", "tel:" ~ site.contact_phone, "phone", site.contact_phone, company.id, site.id, none, site.contact_name,
-                        "M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z") }}
-        {% endif %}
-        {% if site.contact_email %}
-        {{ outreach_btn("Email", "https://outlook.office.com/mail/deeplink/compose?to=" ~ site.contact_email|urlencode, "email", site.contact_email, company.id, site.id, none, site.contact_name,
-                        "M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z", new_tab=True) }}
-        {% endif %}
-      </div>
-    </div>
-  </div>
-{% else %}
-  {# Real SiteContact row #}
-  {# Compute out_days for overdue badge (NULL honesty: only when clock+now_utc set) #}
-  {% set out_ts = contact.last_outbound_at %}
-  {% set out_days = ((now_utc - out_ts).days) if (out_ts and now_utc) else none %}
-
-  {# Role display label map (read-only chip, not the editor) #}
-  {% set role_labels = {
-    'specifier':      'Specifier',
-    'buyer_po':       'Buyer / PO',
-    'ap_payer':       'AP / Payer',
-    'logistics':      'Logistics',
-    'exec':           'Exec',
-    'other':          'Other',
-    'buyer':          'Buyer',
-    'technical':      'Technical',
-    'decision_maker': 'DM',
-    'operations':     'Ops'
-  } %}
-  {% set role_colors = {
-    'specifier':      'bg-indigo-50 text-indigo-700',
-    'buyer_po':       'bg-blue-50 text-blue-700',
-    'ap_payer':       'bg-teal-50 text-teal-700',
-    'logistics':      'bg-orange-50 text-orange-700',
-    'exec':           'bg-rose-50 text-rose-700',
-    'other':          'bg-gray-100 text-gray-600',
-    'buyer':          'bg-blue-50 text-blue-700',
-    'technical':      'bg-purple-50 text-purple-700',
-    'decision_maker': 'bg-amber-50 text-amber-700',
-    'operations':     'bg-gray-100 text-gray-600'
-  } %}
-
-  {# h-full: equal-height cells when laid out in the responsive contacts grid. #}
-  <div class="bg-white rounded-lg border border-gray-200 p-3 hover:border-brand-200 transition-colors h-full group">
-    {# ── Always-visible row: name · primary star · role · site · last-touch + outreach ── #}
-    <div class="flex items-start justify-between gap-3">
-      <div class="min-w-0 flex-1">
-        {# Name line: name, primary star, role chip, site label #}
-        <div class="flex items-center gap-1.5 flex-wrap">
-          <span class="text-sm font-medium text-gray-900">{{ contact.full_name or "—" }}</span>
-          {# Primary star — always visible when set #}
-          {% if contact.is_primary %}
-          <span class="text-amber-400" title="Primary contact for {{ site.site_name if site else 'this site' }}">★</span>
-          {% endif %}
-          {# Role label — always visible (read-only chip), editor in hover zone below #}
-          {% if contact.contact_role %}
-          <span class="px-1.5 py-0.5 text-[11px] font-medium rounded {{ role_colors.get(contact.contact_role, 'bg-gray-100 text-gray-600') }}"
-                title="{{ contact.contact_role }}">
-            {{ role_labels.get(contact.contact_role, contact.contact_role|replace('_', ' ')|title) }}
-          </span>
-          {% endif %}
-          {# Site label — always visible (was missing in company-wide view) #}
-          {% if site %}
-          <span class="px-1.5 py-0.5 text-[11px] font-medium rounded bg-gray-100 text-gray-600"
-                title="Site">{{ site.site_name }}</span>
-          {% endif %}
-        </div>
-        {# Subtitle: title + last-touch indicator #}
-        <div class="flex items-center gap-2 mt-0.5 flex-wrap">
-          {# Title — inline-editable (WS1) #}
-          {% with obj=contact, field='title', entity='contact',
-                  meta={'label': 'Title', 'kind': 'text'},
-                  edit_url='/v2/partials/customers/' ~ company.id ~ '/contacts/' ~ contact.id ~ '/field/edit/title' %}
-            {% include 'htmx/partials/customers/_field_display.html' %}
-          {% endwith %}
-          {{ _last_touch_compact(contact, now_utc, cadence) }}
-          {# Active status badges (critical signals — always visible) #}
-          {% if contact.do_not_contact %}
-          <span class="px-1.5 py-0.5 text-[11px] font-semibold rounded bg-red-100 text-red-700 border border-red-200">DNC</span>
-          {% endif %}
-          {% if contact.is_archived %}
-          <span class="px-1.5 py-0.5 text-[11px] font-semibold rounded bg-gray-200 text-gray-600">Archived</span>
-          {% endif %}
-          {% if contact.is_priority %}
-          <span class="px-1.5 py-0.5 text-[11px] font-semibold rounded bg-amber-100 text-amber-700">Priority</span>
-          {% endif %}
-          {# Overdue cadence badge (only when genuinely overdue) #}
-          {% if cadence == 'overdue' and out_days is not none %}
-          <span class="px-1.5 py-0.5 text-[11px] font-semibold rounded bg-rose-50 text-rose-600">{{ out_days }}d overdue</span>
-          {% endif %}
-        </div>
-      </div>
-
-      {# Right cluster: outreach buttons + kebab #}
-      <div class="flex items-start gap-1.5 flex-shrink-0">
-        {# Outreach buttons (suppressed when DNC) #}
-        {% if not contact.do_not_contact %}
-        <div class="flex items-center gap-1">
-          {% if contact.phone %}
-          {{ outreach_btn("Call", "tel:" ~ contact.phone, "phone", contact.phone, company.id, contact.customer_site_id, contact.id, contact.full_name,
-                          "M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z") }}
-          {% endif %}
-          {% if contact.email %}
-          {{ outreach_btn("Email", "https://outlook.office.com/mail/deeplink/compose?to=" ~ contact.email|urlencode, "email", contact.email, company.id, contact.customer_site_id, contact.id, contact.full_name,
-                          "M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z", new_tab=True) }}
-          {{ outreach_btn("Teams", "https://teams.microsoft.com/l/chat/0/0?users=" ~ contact.email|urlencode, "teams", contact.email, company.id, contact.customer_site_id, contact.id, contact.full_name,
-                          "M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z", new_tab=True) }}
-          {% endif %}
-          {% if contact.wechat_id %}
-          {{ outreach_btn("WeChat", "weixin://dl/chat?" ~ contact.wechat_id|urlencode, "wechat", contact.wechat_id, company.id, contact.customer_site_id, contact.id, contact.full_name,
-                          "M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z", copy=True) }}
-          {% endif %}
-        </div>
-        {% endif %}
-
-        {# Kebab menu — management actions (always accessible via kebab,
-           also revealed on hover via the progressive-disclosure section below) #}
-        <div class="relative inline-block" x-data='{"open": false}' @click.outside='open = false'>
-          <button @click.stop='open = !open' type='button'
-                  class='p-1 text-gray-300 hover:text-gray-600 rounded transition-colors'
-                  aria-label='Contact actions'
-                  :aria-expanded="open ? 'true' : 'false'"
-                  aria-haspopup="menu">
-            <svg class='h-4 w-4' fill='currentColor' viewBox='0 0 20 20'>
-              <path d='M10 6a2 2 0 110-4 2 2 0 010 4zm0 6a2 2 0 110-4 2 2 0 010 4zm0 6a2 2 0 110-4 2 2 0 010 4z'/>
-            </svg>
-          </button>
-          <div x-show='open' x-cloak
-               role="menu"
-               class='absolute right-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-lg z-20 py-1 text-xs text-left'>
-            {# Edit #}
-            <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/edit-form'}); open = false"
-                    role="menuitem"
-                    class='w-full text-left px-3 py-1.5 text-brand-600 hover:bg-brand-50'>Edit</button>
-            {# Files — opens the shared attachments panel in the global modal #}
-            <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/contacts/{{ contact.id }}/files-modal'}); open = false"
-                    role="menuitem"
-                    class='w-full flex items-center gap-1.5 text-left px-3 py-1.5 text-gray-600 hover:bg-gray-50'>
-              <svg class='h-3.5 w-3.5 text-gray-400' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='2'>
-                <path stroke-linecap='round' stroke-linejoin='round' d='M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13'/>
-              </svg>
-              Files
-            </button>
-            {# Set Primary — only when not already primary #}
-            {% if not contact.is_primary %}
-            <button hx-post='/v2/partials/customers/{{ company.id }}/sites/{{ contact.customer_site_id }}/contacts/{{ contact.id }}/primary'
-                    hx-target='#contacts-tab-list'
-                    hx-swap='innerHTML'
-                    @click.stop='open = false'
-                    data-loading-disable
-                    role="menuitem"
-                    class='w-full text-left px-3 py-1.5 text-emerald-700 hover:bg-emerald-50'>Set Primary</button>
-            {% endif %}
-            {# Set as account primary — sets company.primary_contact_id (account-level, not per-site) #}
-            <button hx-post='/v2/partials/customers/{{ company.id }}/primary-contact/{{ contact.id }}'
-                    hx-target='#main-content'
-                    hx-swap='innerHTML'
-                    @click.stop='open = false'
-                    data-loading-disable
-                    role="menuitem"
-                    class='w-full text-left px-3 py-1.5 text-brand-600 hover:bg-brand-50'>Set account primary</button>
-            <div class='border-t border-gray-100 my-1'></div>
-            {# Role editor inline in kebab #}
-            <div id='role-chip-{{ contact.id }}' class='px-3 py-1' x-data='{"editing": false}'>
-              <span class='text-gray-400 block mb-1'>Role</span>
-              <button type='button' x-show='!editing' x-cloak @click='editing = true'
-                      class='text-brand-600 hover:underline'>
-                {% if contact.contact_role %}
-                  {{ role_labels.get(contact.contact_role, contact.contact_role|replace('_', ' ')|title) }} ✎
-                {% else %}
-                  + Set role
-                {% endif %}
-              </button>
-              <form x-show='editing' x-cloak
-                    hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/role'
-                    hx-target='#contacts-tab-list'
-                    hx-swap='innerHTML'
-                    @htmx:after-request='editing = false'>
-                <select name='contact_role'
-                        onchange='this.form.requestSubmit()'
-                        @blur='editing = false'
-                        x-init='$nextTick(() => { if (editing) $el.focus() })'
-                        class='text-xs border border-brand-300 rounded px-1 py-0.5 focus:outline-none focus:ring-2 focus:ring-brand-500 w-full'>
-                  <option value=''>— clear —</option>
-                  {% for r in roles %}<option value='{{ r }}' {% if contact.contact_role == r %}selected{% endif %}>{{ role_labels.get(r, r|replace('_', ' ')|title) }}</option>{% endfor %}
-                </select>
-              </form>
-            </div>
-            <div class='border-t border-gray-100 my-1'></div>
-            {# Priority toggle #}
-            <div id='priority-toggle-{{ contact.id }}' class='px-3 py-1'>
-              {% if contact.is_priority %}
-              <form hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/priority'
-                    hx-target='#contacts-tab-list'
-                    hx-swap='innerHTML'
-                    class='inline'>
-                <input type='hidden' name='is_priority' value=''>
-                <button type='submit' @click.stop=''
-                        class='text-amber-600 hover:underline text-xs'>★ Clear priority</button>
-              </form>
-              {% else %}
-              <form hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/priority'
-                    hx-target='#contacts-tab-list'
-                    hx-swap='innerHTML'
-                    class='inline'>
-                <input type='hidden' name='is_priority' value='1'>
-                <button type='submit' @click.stop=''
-                        class='text-gray-600 hover:text-amber-600 hover:underline text-xs'>★ Mark priority</button>
-              </form>
-              {% endif %}
-            </div>
-            {# Archive toggle #}
-            <div id='archive-toggle-{{ contact.id }}' class='px-3 py-1'>
-              {% if contact.is_archived %}
-              <form hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/archive'
-                    hx-target='#contacts-tab-list'
-                    hx-swap='innerHTML'
-                    class='inline'>
-                <input type='hidden' name='is_archived' value=''>
-                <button type='submit' @click.stop=''
-                        class='text-gray-600 hover:underline text-xs'>↺ Restore from archive</button>
-              </form>
-              {% else %}
-              <form hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/archive'
-                    hx-target='#contacts-tab-list'
-                    hx-swap='innerHTML'
-                    class='inline'>
-                <input type='hidden' name='is_archived' value='1'>
-                <button type='submit' @click.stop=''
-                        class='text-gray-600 hover:underline text-xs'>Archive</button>
-              </form>
-              {% endif %}
-            </div>
-            {# DNC toggle #}
-            <div id='dnc-toggle-{{ contact.id }}' class='px-3 py-1'>
-              {% if contact.do_not_contact %}
-              <form hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/do-not-contact'
-                    hx-target='#contacts-tab-list'
-                    hx-swap='innerHTML'
-                    class='inline'>
-                <input type='hidden' name='do_not_contact' value=''>
-                <button type='submit' @click.stop=''
-                        class='text-red-600 hover:underline text-xs'>Clear DNC</button>
-              </form>
-              {% else %}
-              <form hx-post='/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/do-not-contact'
-                    hx-target='#contacts-tab-list'
-                    hx-swap='innerHTML'
-                    class='inline'>
-                <input type='hidden' name='do_not_contact' value='1'>
-                <button type='submit' @click.stop=''
-                        class='text-gray-600 hover:text-red-600 hover:underline text-xs'>Set DNC</button>
-              </form>
-              {% endif %}
-            </div>
-            {# Merge — dedup this contact with another #}
-            <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/merge-form'}); open = false"
-                    role="menuitem"
-                    class='w-full text-left px-3 py-1.5 text-gray-600 hover:bg-gray-50'>Merge duplicate</button>
-            {# Move — reassign to another account/site #}
-            <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/move-form'}); open = false"
-                    role="menuitem"
-                    class='w-full text-left px-3 py-1.5 text-gray-600 hover:bg-gray-50'>Move to account…</button>
-            <div class='border-t border-gray-100 my-1'></div>
-            {# Delete #}
-            <button hx-delete='/v2/partials/customers/{{ company.id }}/sites/{{ contact.customer_site_id }}/contacts/{{ contact.id }}'
-                    hx-target='#contacts-tab-list'
-                    hx-swap='innerHTML'
-                    hx-confirm='Delete {{ contact.full_name or "this contact" }}?'
-                    @click.stop='open = false'
-                    data-loading-disable
-                    role="menuitem"
-                    class='w-full text-left px-3 py-1.5 text-rose-600 hover:bg-rose-50'>Delete</button>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    {# ── Always-visible contact fields — email/phone/wechat/linkedin show value or "+ Add" #}
-    <div class="mt-2 grid grid-cols-2 gap-x-3 gap-y-1">
-      {% for fname, flabel, fkind in [('email', 'Email', 'text'), ('phone', 'Phone', 'text'), ('wechat_id', 'WeChat ID', 'text'), ('linkedin_url', 'LinkedIn', 'text')] %}
-      <div class="min-w-0">
-        <p class="text-xs font-medium text-gray-400 uppercase tracking-wide">{{ flabel }}</p>
-        {% with obj=contact, field=fname, entity='contact',
-                meta={'label': flabel, 'kind': fkind},
-                edit_url='/v2/partials/customers/' ~ company.id ~ '/contacts/' ~ contact.id ~ '/field/edit/' ~ fname %}
-          {% include 'htmx/partials/customers/_field_display.html' %}
-        {% endwith %}
-      </div>
-      {% endfor %}
-    </div>
-    {# ── Secondary contact fields (inline-editable) ──────────────────────────── #}
-    {% if contact.secondary_email or contact.secondary_phone %}
-    <div class="mt-1 grid grid-cols-2 gap-x-3 gap-y-1">
-      {% if contact.secondary_email %}
-      <div class="min-w-0">
-        <p class="text-xs font-medium text-gray-400 uppercase tracking-wide">2nd Email</p>
-        {% with obj=contact, field='secondary_email', entity='contact',
-                meta={'label': 'Secondary Email', 'kind': 'text'},
-                edit_url='/v2/partials/customers/' ~ company.id ~ '/contacts/' ~ contact.id ~ '/field/edit/secondary_email' %}
-          {% include 'htmx/partials/customers/_field_display.html' %}
-        {% endwith %}
-      </div>
-      {% endif %}
-      {% if contact.secondary_phone %}
-      <div class="min-w-0">
-        <p class="text-xs font-medium text-gray-400 uppercase tracking-wide">2nd Phone</p>
-        {% with obj=contact, field='secondary_phone', entity='contact',
-                meta={'label': 'Secondary Phone', 'kind': 'text'},
-                edit_url='/v2/partials/customers/' ~ company.id ~ '/contacts/' ~ contact.id ~ '/field/edit/secondary_phone' %}
-          {% include 'htmx/partials/customers/_field_display.html' %}
-        {% endwith %}
-      </div>
-      {% endif %}
-    </div>
-    {% endif %}
-    {# ── Reports-to (shows manager name when set) ───────────────────────────── #}
-    {% if contact.reports_to %}
-    <div class="mt-1 text-xs text-gray-500">
-      Reports to: <span class="font-medium text-gray-700">{{ contact.reports_to.full_name or contact.reports_to.first_name or '—' }}</span>
-    </div>
-    {% endif %}
-    {# Per-contact cadence clocks — honest empty states for NULL timestamps #}
-    {{ contact_clocks(contact, now_utc) }}
-
-    {# Additional details — custom key:value fields (WS3), compact inline #}
-    {% if contact.custom_fields %}
-    <div class='mt-2 pt-2 border-t border-gray-100'>
-      <p class='text-xs font-medium text-gray-400 uppercase tracking-wide mb-1'>Additional details</p>
-      <dl class='space-y-0.5'>
-        {% for lbl, val in contact.custom_fields.items() %}
-        <div class='flex items-start gap-2'>
-          <dt class='text-xs font-medium text-gray-700 flex-shrink-0 w-24 truncate' title='{{ lbl }}'>{{ lbl }}</dt>
-          <dd class='text-xs text-gray-600 min-w-0 break-words'>{{ val }}</dd>
-        </div>
-        {% endfor %}
-      </dl>
-    </div>
-    {% endif %}
-  </div>
-{% endif %}
-{% endmacro %}
+{# NOTE: the old per-card `contact_card` macro was removed as dead code — the active
+   CRM customer-tab surface is the compact-table `contact_row` macro below. #}
 
 
 {# ── Compact table row macro — replaces the card layout with a dense <tr> ── #}
-{% macro contact_row(company, contact, site, legacy, now_utc=none, cadence='new', roles=none) %}
+{% macro contact_row(company, contact, site, legacy, now_utc=none, cadence='new', roles=none, recent_note=none) %}
 {# contact_row — single <tr> + expand <tr> pair for one SiteContact (or legacy site contact).
    Always-visible: name · title · phone · email · last-touch
    Expand drawer:  Teams deeplink · WeChat copy · notes · secondary email/phone ·
@@ -576,27 +212,37 @@
   {% set out_days = ((now_utc - out_ts).days) if (out_ts and now_utc) else none %}
   {% set _cname = contact.full_name or '—' %}
 
-  {# Role display map (compact) #}
+  {# Role display map (compact). Canonical = Mike's ContactRole vocabulary
+     (buyer/manager/engineer/planner/other); the remaining keys are LEGACY DB
+     values kept ONLY so pre-existing rows render a clean read-only chip — they
+     are not selectable in the editor (CANONICAL_ROLES drives the <option> list).
+     Every color below uses a shade in the Tailwind safelist (tailwind.config.js). #}
   {% set role_labels = {
+    'buyer':          'Buyer',
+    'manager':        'Manager',
+    'engineer':       'Engineer',
+    'planner':        'Planner',
+    'other':          'Other',
     'specifier':      'Specifier',
     'buyer_po':       'Buyer/PO',
     'ap_payer':       'AP',
     'logistics':      'Logistics',
     'exec':           'Exec',
-    'other':          'Other',
-    'buyer':          'Buyer',
     'technical':      'Tech',
     'decision_maker': 'DM',
     'operations':     'Ops'
   } %}
   {% set role_colors = {
+    'buyer':          'bg-blue-50 text-blue-700',
+    'manager':        'bg-violet-50 text-violet-700',
+    'engineer':       'bg-sky-50 text-sky-700',
+    'planner':        'bg-amber-50 text-amber-700',
+    'other':          'bg-gray-100 text-gray-600',
     'specifier':      'bg-indigo-50 text-indigo-700',
     'buyer_po':       'bg-blue-50 text-blue-700',
     'ap_payer':       'bg-teal-50 text-teal-700',
     'logistics':      'bg-orange-50 text-orange-700',
     'exec':           'bg-rose-50 text-rose-700',
-    'other':          'bg-gray-100 text-gray-600',
-    'buyer':          'bg-blue-50 text-blue-700',
     'technical':      'bg-purple-50 text-purple-700',
     'decision_maker': 'bg-amber-50 text-amber-700',
     'operations':     'bg-gray-100 text-gray-600'
@@ -807,10 +453,48 @@
     </td>
   </tr>
 
-  {# ── Expand drawer row — Teams · WeChat · notes · secondary · reports-to · LinkedIn ── #}
+  {# ── Expand drawer row — DENSE HORIZONTAL flow: contact channels · role · notes ──
+       Lays the detail fields across the width (flex flex-wrap items-center gap-x-4)
+       instead of stacking them, so phone/email/Teams/role/last-contact/notes share rows.
+       Wraps to multiple lines on mobile. #}
   <tr x-show='open' x-cloak class='bg-slate-50'>
     <td colspan='6' class='px-3 py-2.5 border-b border-gray-100'>
-      <div class='flex flex-wrap gap-x-6 gap-y-2 text-xs'>
+      <div class='flex flex-wrap items-center gap-x-4 gap-y-2 text-xs'>
+        {# Phone — click-to-call (tel:); suppressed when DNC #}
+        {% if contact.phone and not contact.do_not_contact %}
+        <div class='flex items-center gap-1'>
+          <span class='text-gray-400 font-medium'>Phone</span>
+          <a href='tel:{{ contact.phone }}'
+             class='text-brand-600 hover:underline font-mono'
+             data-outreach-log
+             data-channel='phone'
+             data-value='{{ contact.phone }}'
+             data-company-id='{{ company.id }}'
+             data-site-id='{{ contact.customer_site_id or "" }}'
+             data-contact-id='{{ contact.id }}'
+             data-contact-name='{{ _cname }}'
+             title='Call {{ _cname }}'
+             @click.stop=''>{{ contact.phone }}</a>
+        </div>
+        {% endif %}
+        {# Email — click-to-compose (Outlook deeplink); suppressed when DNC #}
+        {% if contact.email and not contact.do_not_contact %}
+        <div class='flex items-center gap-1 min-w-0'>
+          <span class='text-gray-400 font-medium flex-shrink-0'>Email</span>
+          <a href='https://outlook.office.com/mail/deeplink/compose?to={{ contact.email|urlencode }}'
+             target='_blank' rel='noopener noreferrer'
+             class='text-brand-600 hover:underline truncate max-w-[16rem]'
+             data-outreach-log
+             data-channel='email'
+             data-value='{{ contact.email }}'
+             data-company-id='{{ company.id }}'
+             data-site-id='{{ contact.customer_site_id or "" }}'
+             data-contact-id='{{ contact.id }}'
+             data-contact-name='{{ _cname }}'
+             title='Email {{ _cname }}'
+             @click.stop=''>{{ contact.email }}</a>
+        </div>
+        {% endif %}
         {# Teams deeplink — always shown when email is set #}
         {% if contact.email and not contact.do_not_contact %}
         <div class='flex items-center gap-1.5'>
@@ -843,7 +527,7 @@
           <span class='text-gray-700'>{{ contact.secondary_email }}</span>
         </div>
         {% endif %}
-        {# Secondary phone #}
+        {# Secondary phone — click-to-call #}
         {% if contact.secondary_phone %}
         <div class='flex items-center gap-1'>
           <span class='text-gray-400 font-medium'>2nd Phone</span>
@@ -855,7 +539,8 @@
              data-company-id='{{ company.id }}'
              data-site-id='{{ contact.customer_site_id or "" }}'
              data-contact-id='{{ contact.id }}'
-             data-contact-name='{{ _cname }}'>{{ contact.secondary_phone }}</a>
+             data-contact-name='{{ _cname }}'
+             @click.stop=''>{{ contact.secondary_phone }}</a>
         </div>
         {% endif %}
         {# LinkedIn — safe_url filter blocks javascript:/vbscript:/data: hrefs #}
@@ -873,16 +558,9 @@
           <span class='text-gray-700 font-medium'>{{ contact.reports_to.full_name or contact.reports_to.first_name or '—' }}</span>
         </div>
         {% endif %}
-        {# Notes — always shown even if empty (truncated at 120 chars) #}
-        {% if contact.notes %}
-        <div class='flex items-start gap-1 w-full'>
-          <span class='text-gray-400 font-medium flex-shrink-0'>Notes</span>
-          <span class='text-gray-700 whitespace-pre-line'>{{ contact.notes | truncate(120, True, '…') }}</span>
-        </div>
-        {% endif %}
-        {# Role editor — inline select in expand drawer; values like buyer_po needed for tests #}
+        {# Role editor — inline select; CANONICAL_ROLES drives the <option> list #}
         {% if roles %}
-        <div class='flex items-center gap-1.5 w-full mt-1' id='role-chip-{{ contact.id }}' x-data='{"editing": false}'>
+        <div class='flex items-center gap-1.5' id='role-chip-{{ contact.id }}' x-data='{"editing": false}'>
           <span class='text-gray-400 font-medium flex-shrink-0'>Role</span>
           <button type='button' x-show='!editing' x-cloak @click.stop='editing=true'
                   class='text-brand-600 hover:underline text-xs'>
@@ -920,6 +598,23 @@
         </div>
         {% endfor %}
         {% endif %}
+        {# ── Recent note + notes modal — full-width footer row for readability ──
+             recent_note = latest ActivityLog NOTE text (batched in company_contact_rows).
+             $dispatch payload is single-quoted JS inside a double-quoted @click —
+             keep the inner quotes single (no literal " inside the attribute). #}
+        <div class='flex items-start gap-2 w-full pt-1.5 mt-0.5 border-t border-gray-200'>
+          <span class='text-gray-400 font-medium flex-shrink-0'>Notes</span>
+          {% if recent_note %}
+          <span class='text-gray-700 whitespace-pre-line min-w-0 break-words'>{{ recent_note | truncate(120, True, '…') }}</span>
+          <button type='button'
+                  @click.stop="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/notes-modal'})"
+                  class='text-brand-600 hover:underline flex-shrink-0'>See all notes</button>
+          {% else %}
+          <button type='button'
+                  @click.stop="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/notes-modal'})"
+                  class='text-brand-600 hover:underline flex-shrink-0'>+ Add note</button>
+          {% endif %}
+        </div>
       </div>
     </td>
   </tr>

--- a/app/templates/htmx/partials/customers/_contact_notes_modal.html
+++ b/app/templates/htmx/partials/customers/_contact_notes_modal.html
@@ -1,0 +1,58 @@
+{# _contact_notes_modal.html — global-modal body: a SiteContact's note feed + add form.
+   Loaded into #modal-content via
+   $dispatch('open-modal', {url: '/v2/partials/customers/{company_id}/contacts/{contact_id}/notes-modal'})
+   from the contact-card drawer ("See all notes" / "+ Add note").
+   The base modal (htmx/base.html) renders the ✕ / backdrop / Escape affordances.
+
+   Receives: company (Company), contact (SiteContact), notes (list[ActivityLog],
+             newest first), can_manage (bool), error (str | None).
+   Called by:
+     - GET  /v2/partials/customers/{company_id}/contacts/{contact_id}/notes-modal
+     - POST /v2/partials/customers/{company_id}/contacts/{contact_id}/notes
+            (re-renders this body via hx-swap='outerHTML' into #contact-notes-modal-body)
+   Depends on: the global modal wrapper, activity_service note logging.
+#}
+<div id="contact-notes-modal-body" class="p-5">
+  <h3 id="modal-title" class="text-sm font-semibold text-gray-900">
+    Notes
+    <span class="font-normal text-gray-600">· {{ contact.full_name or "Contact" }}</span>
+  </h3>
+
+  {% if can_manage %}
+  {# Add-note form — posts the note then re-renders this whole body (feed + form). #}
+  <form class="mt-4"
+        hx-post="/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/notes"
+        hx-target="#contact-notes-modal-body"
+        hx-swap="outerHTML">
+    <label for="note-input-{{ contact.id }}" class="sr-only">Add a note</label>
+    <textarea id="note-input-{{ contact.id }}" name="notes" rows="3"
+              placeholder="Add a note about this contact…"
+              class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"></textarea>
+    {% if error %}
+    <p class="mt-1 text-xs text-rose-600">{{ error }}</p>
+    {% endif %}
+    <div class="mt-2 flex justify-end">
+      <button type="submit" data-loading-disable class="btn btn-primary btn-sm">
+        Add note
+      </button>
+    </div>
+  </form>
+  {% endif %}
+
+  {# Note feed — newest first, with date + author. #}
+  <div class="mt-4 space-y-2">
+    {% if notes %}
+    {% for n in notes %}
+    <div class="rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+      <p class="text-xs text-gray-700 whitespace-pre-line break-words">{{ n.notes }}</p>
+      <p class="mt-1 text-[11px] text-gray-400">
+        {{ (n.created_at.strftime('%b %-d, %Y %-I:%M %p') if n.created_at else '—') }}
+        {% if n.user %}· {{ n.user.name or n.user.email }}{% endif %}
+      </p>
+    </div>
+    {% endfor %}
+    {% else %}
+    <p class="text-xs text-gray-400">No notes yet.</p>
+    {% endif %}
+  </div>
+</div>

--- a/app/templates/htmx/partials/customers/tabs/_contacts_grouped_list.html
+++ b/app/templates/htmx/partials/customers/tabs/_contacts_grouped_list.html
@@ -96,7 +96,7 @@
             <tbody data-contact-row
                    data-site-id="{{ grp_site.id if grp_site else 0 }}"
                    data-contact-search="{{ _cname | lower }}">
-              {{ contact_row(company, row.contact, row.site, row.legacy, now_utc, row.cadence if not row.legacy else 'new', _roles) }}
+              {{ contact_row(company, row.contact, row.site, row.legacy, now_utc, row.cadence if not row.legacy else 'new', _roles, row.recent_note) }}
             </tbody>
           {% endfor %}
         </table>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2118,13 +2118,40 @@ CDM left list (`_account_list.html`), regardless of `site_count`, hx-gets the SA
   Phone is a `tel:` link and Email an Outlook-web compose deeplink — both carry the
   `data-outreach-log` attrs so `htmx_app.js` logs the touch (same path as the old
   `outreach_btn`). Each row has an Alpine `x-data='{open:false}'` **expand drawer**
-  (chevron) revealing Teams deeplink, WeChat copy-id, secondary email/phone,
-  LinkedIn, reports-to, notes, the inline role editor and cadence clocks. Row-level
-  management (edit, set-primary, priority, archive, DNC, merge, move, delete) lives
-  in a per-row kebab so the row stays scannable. Cell padding uses the locked
-  `.compact-table`/`.td-label` utilities (no inline `px-`/`py-` on `<td>`). The old
-  `contact_card` macro is retained in `_contact_macros.html` but no longer rendered
-  by the contacts tab.
+  (chevron) laid out as a **dense horizontal flow** (`flex flex-wrap items-center
+  gap-x-4 gap-y-2`, wraps on mobile) rather than a vertical stack: click-to-contact
+  Phone (`tel:`) + Email (Outlook compose) lead, followed by Teams deeplink, WeChat
+  copy-id, secondary email/phone, LinkedIn, reports-to, the inline role editor and
+  cadence clocks, with a full-width **recent-note** footer (latest `ActivityLog` NOTE
+  preview + a "See all notes" / "+ Add note" button that `$dispatch('open-modal')`s the
+  contact-notes modal). Row-level management (edit, set-primary, priority, archive,
+  DNC, merge, move, delete) lives in a per-row kebab so the row stays scannable. Cell
+  padding uses the locked `.compact-table`/`.td-label` utilities (no inline `px-`/`py-`
+  on `<td>`). The old per-card `contact_card` macro was **removed as dead code** — the
+  `contact_row` macro is the only contact surface.
+- **Buying-role vocabulary — single source `ContactRole` (`app/constants.py`).** The
+  `StrEnum` `buyer/manager/engineer/planner/other` drives BOTH `CANONICAL_ROLES`
+  (`htmx_views.py`, `tuple(ContactRole)`) and the `roles` Jinja2 global fallback
+  (`template_env.py`); `_VALID_ROLES = frozenset(CANONICAL_ROLES)` gates the setter.
+  The role editor (`POST .../contacts/{id}/role` → `set_contact_role`, validated by
+  `_validate_role`: blank → NULL, non-canonical → 400) renders the five options + a
+  "— clear —". Legacy DB values (`buyer_po/specifier/ap_payer/logistics/exec/technical/
+  decision_maker/operations`) remain in the display-label + color maps so existing rows
+  render a clean read-only chip, but they are NOT selectable and 400 if re-submitted.
+  Chip colors are safelisted shades (buyer=blue, manager=violet, engineer=sky,
+  planner=amber, other=gray).
+- **Contact-notes modal (reuses the activity-log notes infra).** `recent_note` (latest
+  `ActivityLog` NOTE per contact) is batched in `crm_service.company_contact_rows`
+  (`_latest_contact_notes`, one grouped query — no N+1) and threaded through to
+  `contact_row`. The drawer button opens
+  `GET /v2/partials/customers/{company_id}/contacts/{contact_id}/notes-modal`
+  (`contact_notes_modal` → `_contact_notes_modal.html`: feed via
+  `activity_service.get_site_contact_notes`, newest-first with date + author, plus an
+  add form; 404 if the contact isn't under that company).
+  `POST /v2/partials/customers/{company_id}/contacts/{contact_id}/notes`
+  (`add_contact_note`) is `can_manage_account`-gated (403 else), blank → inline error,
+  else `activity_service.log_site_contact_note` + commit, re-rendering the modal body
+  (`hx-swap='outerHTML'` into `#contact-notes-modal-body`).
 - The contact edit modal (`_contact_form.html`) always renders **every** known
   contact field as a labeled input (blank → empty field), so a user sees all the
   fields they could fill in.

--- a/tests/test_contacts_ui_compact.py
+++ b/tests/test_contacts_ui_compact.py
@@ -90,7 +90,7 @@ def _render_grouped_list(contact_rows, company=None, now_utc=None, roles=None):
     """Render the _contacts_grouped_list.html template with given data."""
     company = company or _make_company()
     now_utc = now_utc or datetime.now(timezone.utc)
-    roles = roles or ("specifier", "buyer_po", "ap_payer", "logistics", "exec", "other")
+    roles = roles or ("buyer", "manager", "engineer", "planner", "other")
     tpl = ENV.get_template("htmx/partials/customers/tabs/_contacts_grouped_list.html")
     return tpl.render(
         company=company,
@@ -104,7 +104,7 @@ def _render_grouped_list(contact_rows, company=None, now_utc=None, roles=None):
 def _render_contact_form(contact=None, site=None, company=None, mode="edit", sites=None, roles=None):
     """Render the _contact_form.html template."""
     company = company or _make_company()
-    roles = roles or ("specifier", "buyer_po", "ap_payer", "logistics", "exec", "other")
+    roles = roles or ("buyer", "manager", "engineer", "planner", "other")
     tpl = ENV.get_template("htmx/partials/customers/tabs/_contact_form.html")
     ctx = {
         "company": company,
@@ -296,12 +296,34 @@ class TestExpandDrawerContainsWechatTeamsNotes:
         html = _render_grouped_list(rows)
         assert "teams.microsoft.com" in html
 
-    def test_expand_drawer_contains_notes_when_set(self):
-        contact = _make_contact(notes="Call on Tuesdays")
+    def test_expand_drawer_contains_recent_note_preview_when_set(self):
+        """The drawer renders the recent ActivityLog note preview (recent_note) and a
+        'See all notes' button into the notes modal."""
+        contact = _make_contact()
         site = _make_site()
-        rows = [{"contact": contact, "site": site, "legacy": False, "cadence": "new"}]
+        rows = [
+            {
+                "contact": contact,
+                "site": site,
+                "legacy": False,
+                "cadence": "new",
+                "recent_note": "Call on Tuesdays",
+            }
+        ]
         html = _render_grouped_list(rows)
         assert "Call on Tuesdays" in html
+        assert "See all notes" in html
+        assert f"contacts/{contact.id}/notes-modal" in html
+
+    def test_expand_drawer_shows_add_note_when_no_notes(self):
+        """With no recent note, the drawer shows a '+ Add note' button into the
+        modal."""
+        contact = _make_contact()
+        site = _make_site()
+        rows = [{"contact": contact, "site": site, "legacy": False, "cadence": "new", "recent_note": None}]
+        html = _render_grouped_list(rows)
+        assert "+ Add note" in html
+        assert f"contacts/{contact.id}/notes-modal" in html
 
 
 class TestEditModalSurfacesBlankFields:

--- a/tests/test_crm_contact_card.py
+++ b/tests/test_crm_contact_card.py
@@ -1,0 +1,298 @@
+"""test_crm_contact_card.py — CRM customer-tab contact-card rework (2026-06-26).
+
+Covers the four reworked asks on the active `contact_row` macro + its expand drawer:
+  1. Role dropdown — the canonical ContactRole vocabulary (buyer/manager/engineer/
+     planner/other) is accepted by the setter; legacy/unknown values 400; the editor
+     renders all five options; legacy DB values still render read-only.
+  2. Phone + email — click-to-contact (tel: / Outlook-compose) links in the row + drawer.
+  3. Recent notes + notes modal — GET renders the feed + add form; POST logs an
+     ActivityLog NOTE (can_manage_account gated; blank → inline error).
+  4. Horizontal layout — the drawer lays detail fields in a dense flex-wrap flow.
+
+Also pins: the ContactRole enum is the single source of truth (CANONICAL_ROLES /
+the `roles` Jinja global both derive from it) and the dead `contact_card` macro is gone.
+
+Called by: pytest
+Depends on: app.constants.ContactRole, app.routers.htmx_views, app.template_env,
+    app.models (Company, CustomerSite, SiteContact, ActivityLog)
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.constants import ContactRole
+from app.models import Company
+from app.models.auth import User
+from app.models.crm import CustomerSite, SiteContact
+from app.models.intelligence import ActivityLog
+
+
+def _company_site_contact(
+    db: Session,
+    *,
+    owner_id: int | None = None,
+    contact_role: str | None = None,
+    phone: str | None = "+16175551212",
+    email: str | None = "pat@buyerco.com",
+    do_not_contact: bool = False,
+):
+    """Create a company + active site + active contact for contact-card tests."""
+    company = Company(name="BuyerCo", is_active=True, account_owner_id=owner_id)
+    db.add(company)
+    db.flush()
+    site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+    db.add(site)
+    db.flush()
+    contact = SiteContact(
+        customer_site_id=site.id,
+        full_name="Pat Buyer",
+        email=email,
+        phone=phone,
+        contact_role=contact_role,
+        do_not_contact=do_not_contact,
+    )
+    db.add(contact)
+    db.commit()
+    db.refresh(company)
+    db.refresh(contact)
+    return company, site, contact
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 0. ContactRole enum is the single source of truth
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestContactRoleSourceOfTruth:
+    def test_enum_members_are_mikes_vocabulary(self):
+        assert tuple(ContactRole) == (
+            ContactRole.BUYER,
+            ContactRole.MANAGER,
+            ContactRole.ENGINEER,
+            ContactRole.PLANNER,
+            ContactRole.OTHER,
+        )
+        assert [r.value for r in ContactRole] == ["buyer", "manager", "engineer", "planner", "other"]
+
+    def test_canonical_roles_and_jinja_global_derive_from_enum(self):
+        from app.routers.htmx_views import _VALID_ROLES, CANONICAL_ROLES
+        from app.template_env import _CANONICAL_ROLES
+
+        assert tuple(CANONICAL_ROLES) == tuple(ContactRole)
+        assert tuple(_CANONICAL_ROLES) == tuple(ContactRole)
+        assert _VALID_ROLES == frozenset(ContactRole)
+
+    def test_dead_contact_card_macro_removed(self):
+        from app.template_env import templates
+
+        src = templates.env.loader.get_source(templates.env, "htmx/partials/customers/_contact_macros.html")[0]
+        assert "macro contact_card" not in src
+        assert "macro contact_row" in src
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Role dropdown
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRoleDropdown:
+    @pytest.mark.parametrize("role_val", ["buyer", "manager", "engineer", "planner", "other"])
+    def test_setter_accepts_each_canonical_role(
+        self, client: TestClient, db_session: Session, test_user: User, role_val: str
+    ):
+        company, _site, contact = _company_site_contact(db_session, owner_id=test_user.id)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": role_val},
+        )
+        assert resp.status_code == 200, f"{role_val} should be accepted"
+        db_session.refresh(contact)
+        assert contact.contact_role == role_val
+
+    def test_setter_rejects_non_canonical_value(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, contact = _company_site_contact(db_session, owner_id=test_user.id)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": "wizard"},
+        )
+        assert resp.status_code == 400
+
+    def test_setter_rejects_legacy_value(self, client: TestClient, db_session: Session, test_user: User):
+        """Legacy DB roles (buyer_po) are no longer selectable — POST 400s."""
+        company, _site, contact = _company_site_contact(db_session, owner_id=test_user.id)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": "buyer_po"},
+        )
+        assert resp.status_code == 400
+
+    def test_setter_blank_clears_role(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, contact = _company_site_contact(db_session, owner_id=test_user.id, contact_role="buyer")
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": ""},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(contact)
+        assert contact.contact_role is None
+
+    def test_editor_renders_all_five_options(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, contact = _company_site_contact(db_session, owner_id=test_user.id)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": "buyer"},
+        )
+        assert resp.status_code == 200
+        html = resp.text
+        for role in ("buyer", "manager", "engineer", "planner", "other"):
+            assert f"value='{role}'" in html or f'value="{role}"' in html, f"missing option {role}"
+        # The "— clear —" affordance is present.
+        assert "clear" in html.lower()
+
+    def test_legacy_role_renders_read_only_label(self, client: TestClient, db_session: Session, test_user: User):
+        """A pre-existing legacy value still renders a clean chip (display-label
+        fallback)."""
+        company, _site, _contact = _company_site_contact(
+            db_session, owner_id=test_user.id, contact_role="decision_maker"
+        )
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        # legacy label "DM" (decision_maker) renders without error
+        assert "DM" in resp.text or "decision_maker" in resp.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Click-to-contact phone + email
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestClickToContact:
+    def test_phone_renders_tel_link(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, _contact = _company_site_contact(db_session, owner_id=test_user.id, phone="+16175551212")
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        assert "tel:+16175551212" in resp.text
+
+    def test_email_renders_outlook_compose_link(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, _contact = _company_site_contact(db_session, owner_id=test_user.id, email="pat@buyerco.com")
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        assert "outlook.office.com/mail/deeplink/compose?to=pat%40buyerco.com" in resp.text
+
+    def test_dnc_contact_suppresses_clickable_phone(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, _contact = _company_site_contact(
+            db_session, owner_id=test_user.id, phone="+16175559999", do_not_contact=True
+        )
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        # No clickable tel: link for a DNC contact (the value is shown struck-through instead).
+        assert "tel:+16175559999" not in resp.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Recent notes + notes modal
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNotesModal:
+    def test_get_notes_modal_renders_feed_and_form(self, client: TestClient, db_session: Session, test_user: User):
+        from app.services.activity_service import log_site_contact_note
+
+        company, site, contact = _company_site_contact(db_session, owner_id=test_user.id)
+        log_site_contact_note(
+            user_id=test_user.id,
+            site_contact_id=contact.id,
+            customer_site_id=site.id,
+            company_id=company.id,
+            notes="First call went well",
+            db=db_session,
+        )
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{company.id}/contacts/{contact.id}/notes-modal")
+        assert resp.status_code == 200
+        assert 'id="modal-title"' in resp.text
+        assert "First call went well" in resp.text
+        # Add-note form posts back to the notes endpoint.
+        assert f"/v2/partials/customers/{company.id}/contacts/{contact.id}/notes" in resp.text
+
+    def test_get_notes_modal_404_for_contact_not_under_company(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        company_a, _sa, _ca = _company_site_contact(db_session, owner_id=test_user.id)
+        company_b, _sb, contact_b = _company_site_contact(db_session, owner_id=test_user.id, email="other@x.com")
+        resp = client.get(f"/v2/partials/customers/{company_a.id}/contacts/{contact_b.id}/notes-modal")
+        assert resp.status_code == 404
+
+    def test_post_note_adds_activity_log(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, contact = _company_site_contact(db_session, owner_id=test_user.id)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/notes",
+            data={"notes": "Following up next week"},
+        )
+        assert resp.status_code == 200
+        assert "Following up next week" in resp.text
+        notes = (
+            db_session.query(ActivityLog)
+            .filter(ActivityLog.site_contact_id == contact.id, ActivityLog.activity_type == "note")
+            .all()
+        )
+        assert len(notes) == 1
+        assert notes[0].notes == "Following up next week"
+        assert notes[0].user_id == test_user.id
+
+    def test_post_blank_note_is_inline_error_no_write(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, contact = _company_site_contact(db_session, owner_id=test_user.id)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/notes",
+            data={"notes": "   "},
+        )
+        assert resp.status_code == 200
+        assert "empty" in resp.text.lower()
+        count = (
+            db_session.query(ActivityLog)
+            .filter(ActivityLog.site_contact_id == contact.id, ActivityLog.activity_type == "note")
+            .count()
+        )
+        assert count == 0
+
+    def test_post_note_403_for_non_owner(self, client: TestClient, db_session: Session, test_user: User):
+        """A buyer who is neither owner nor manager cannot add notes
+        (can_manage_account)."""
+        # owner_id=None + site owner_id=None → test_user (role=buyer) cannot manage.
+        company, _site, contact = _company_site_contact(db_session, owner_id=None)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/notes",
+            data={"notes": "I should not be allowed"},
+        )
+        assert resp.status_code == 403
+        count = (
+            db_session.query(ActivityLog)
+            .filter(ActivityLog.site_contact_id == contact.id, ActivityLog.activity_type == "note")
+            .count()
+        )
+        assert count == 0
+
+    def test_drawer_links_to_notes_modal(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, contact = _company_site_contact(db_session, owner_id=test_user.id)
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        assert f"contacts/{contact.id}/notes-modal" in resp.text
+        # The open-modal dispatch must keep its inner quotes single (Alpine double-quote gotcha).
+        assert "$dispatch('open-modal'" in resp.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Horizontal layout
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHorizontalDrawerLayout:
+    def test_drawer_uses_dense_horizontal_flow(self, client: TestClient, db_session: Session, test_user: User):
+        company, _site, _contact = _company_site_contact(db_session, owner_id=test_user.id)
+        resp = client.get(f"/v2/partials/customers/{company.id}")
+        assert resp.status_code == 200
+        # Dense horizontal flow utilities (flex-wrap + horizontal gap) per the brief.
+        assert "flex flex-wrap items-center gap-x-4" in resp.text

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -2165,26 +2165,26 @@ class TestBuyingRoleSetter:
         return company, site, contact
 
     def test_set_role_updates_db(self, client: TestClient, db_session: Session, test_user: User):
-        """POST contact_role=buyer_po persists to SiteContact.contact_role."""
+        """POST contact_role=buyer persists to SiteContact.contact_role."""
 
         company, site, contact = self._make_company_with_contact(db_session, owner_id=test_user.id)
         resp = client.post(
             f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
-            data={"contact_role": "buyer_po"},
+            data={"contact_role": "buyer"},
         )
         assert resp.status_code == 200
         db_session.refresh(contact)
-        assert contact.contact_role == "buyer_po"
+        assert contact.contact_role == "buyer"
 
     def test_set_role_rerenders_chip(self, client: TestClient, db_session: Session, test_user: User):
         """POST role returns HTML containing the chip for the new role."""
         company, site, contact = self._make_company_with_contact(db_session, owner_id=test_user.id)
         resp = client.post(
             f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
-            data={"contact_role": "specifier"},
+            data={"contact_role": "engineer"},
         )
         assert resp.status_code == 200
-        assert "specifier" in resp.text.lower() or "Specifier" in resp.text
+        assert "engineer" in resp.text.lower() or "Engineer" in resp.text
 
     def test_set_role_invalid_value_returns_400(self, client: TestClient, db_session: Session, test_user: User):
         """POST with unknown role value returns 400."""
@@ -2195,9 +2195,22 @@ class TestBuyingRoleSetter:
         )
         assert resp.status_code == 400
 
+    def test_set_role_legacy_value_rejected(self, client: TestClient, db_session: Session, test_user: User):
+        """A legacy DB value (buyer_po) is no longer selectable — POST 400s.
+
+        Legacy values still render read-only via the display-label maps, but the setter
+        only accepts the canonical ContactRole vocabulary.
+        """
+        company, site, contact = self._make_company_with_contact(db_session, owner_id=test_user.id)
+        resp = client.post(
+            f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
+            data={"contact_role": "buyer_po"},
+        )
+        assert resp.status_code == 400
+
     def test_set_role_all_canonical_values_accepted(self, client: TestClient, db_session: Session, test_user: User):
         """All canonical buying-role values are accepted."""
-        for role_val in ("specifier", "buyer_po", "ap_payer", "logistics", "exec", "other"):
+        for role_val in ("buyer", "manager", "engineer", "planner", "other"):
             company, site, contact = self._make_company_with_contact(db_session, owner_id=test_user.id)
             resp = client.post(
                 f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
@@ -2210,7 +2223,7 @@ class TestBuyingRoleSetter:
         company, _, _ = self._make_company_with_contact(db_session, owner_id=test_user.id)
         resp = client.post(
             f"/v2/partials/customers/{company.id}/contacts/99999/role",
-            data={"contact_role": "buyer_po"},
+            data={"contact_role": "buyer"},
         )
         assert resp.status_code == 404
 
@@ -2237,12 +2250,12 @@ class TestBuyingRoleSetter:
         company, site, contact = self._make_company_with_contact(db_session, owner_id=test_user.id)
         resp = client.post(
             f"/v2/partials/customers/{company.id}/contacts/{contact.id}/role",
-            data={"contact_role": "specifier"},
+            data={"contact_role": "engineer"},
         )
         assert resp.status_code == 200
         html = resp.text
         # All canonical values must appear as option values
-        for role in ("specifier", "buyer_po", "ap_payer", "logistics", "exec", "other"):
+        for role in ("buyer", "manager", "engineer", "planner", "other"):
             assert f"value='{role}'" in html or f'value="{role}"' in html, (
                 f"Expected role '{role}' as an <option> value in chip editor HTML"
             )
@@ -2294,7 +2307,7 @@ class TestRoleChipLegacy:
         assert "buyer" in resp.text.lower() or "Buyer" in resp.text
 
     def test_canonical_buyer_po_renders_chip(self, client: TestClient, db_session: Session, test_user: User):
-        """New canonical role 'buyer_po' renders a chip in the contact card."""
+        """Legacy role 'buyer_po' still renders a read-only chip in the contact card."""
         company, _, _ = self._make_company_with_contact(db_session, contact_role="buyer_po")
         resp = client.get(f"/v2/partials/customers/{company.id}")
         assert resp.status_code == 200
@@ -2302,7 +2315,7 @@ class TestRoleChipLegacy:
         assert "buyer" in resp.text.lower() or "PO" in resp.text or "Buyer" in resp.text
 
     def test_canonical_specifier_renders_chip(self, client: TestClient, db_session: Session, test_user: User):
-        """New canonical role 'specifier' renders a chip."""
+        """Legacy role 'specifier' still renders a read-only chip."""
         company, _, _ = self._make_company_with_contact(db_session, contact_role="specifier")
         resp = client.get(f"/v2/partials/customers/{company.id}")
         assert resp.status_code == 200
@@ -2502,7 +2515,7 @@ class TestEditContact:
             f"/v2/partials/customers/{company.id}/sites/{site.id}/contacts/{contact.id}/edit",
             data={
                 "full_name": "Alice Smith",
-                "contact_role": "buyer_po",  # canonical value — should persist
+                "contact_role": "buyer",  # canonical value — should persist
                 "title": "Buyer",
                 "email": "alice@editco.com",
                 "phone": "+16175550001",
@@ -2512,7 +2525,7 @@ class TestEditContact:
         db_session.expire_all()
         updated = db_session.query(SiteContact).filter(SiteContact.id == contact.id).first()
         assert updated is not None
-        assert updated.contact_role == "buyer_po"
+        assert updated.contact_role == "buyer"
 
     def test_post_contact_edit_legacy_role_returns_400(self, client: TestClient, db_session: Session, test_user: User):
         """POST contact edit with legacy role 'decision_maker' returns 400."""
@@ -3113,8 +3126,8 @@ class TestContactsTabHome:
         resp = client.get(f"/v2/partials/customers/{company.id}/contacts/add-form")
         assert resp.status_code == 200
         assert "contact_role" in resp.text
-        assert "buyer_po" in resp.text
-        assert "specifier" in resp.text
+        assert "buyer" in resp.text
+        assert "engineer" in resp.text
 
     def test_get_add_form_new_site_option_present(self, client: TestClient, db_session: Session, test_user: User):
         """GET add-form includes a '+ new site' option in the site select."""
@@ -3171,7 +3184,7 @@ class TestContactsTabHome:
                 "full_name": "New Bob",
                 "email": "newbob@tabco.com",
                 "title": "Manager",
-                "contact_role": "buyer_po",
+                "contact_role": "buyer",
             },
         )
         assert resp.status_code == 200
@@ -3291,13 +3304,13 @@ class TestContactsTabHome:
             data={
                 "full_name": "Alice Prime",
                 "email": "alice@tabco.com",
-                "contact_role": "buyer_po",
+                "contact_role": "buyer",
             },
         )
         assert resp.status_code == 200
         db_session.expire_all()
         updated = db_session.get(SiteContact, contact.id)
-        assert updated.contact_role == "buyer_po"
+        assert updated.contact_role == "buyer"
 
     def test_edit_invalid_role_returns_400(self, client: TestClient, db_session: Session, test_user: User):
         """POST edit with legacy 'decision_maker' role returns 400."""
@@ -3419,8 +3432,8 @@ class TestContactsTabHome:
         assert "contacts-tab-list" in html
         # Contact's email must appear (Step 4: form uses first_name/last_name, not full_name input)
         assert test_contact.email in html
-        # Role options must be present
-        assert "buyer_po" in html
+        # Role options must be present (canonical ContactRole vocabulary)
+        assert "engineer" in html
 
     def test_contacts_tab_create_response_contains_roles(
         self,
@@ -3439,7 +3452,7 @@ class TestContactsTabHome:
             headers={"HX-Target": "contacts-tab-list"},
         )
         assert resp.status_code == 200
-        assert "buyer_po" in resp.text
+        assert "engineer" in resp.text
 
     def test_delete_contact_response_contains_roles(
         self,
@@ -3493,7 +3506,7 @@ class TestContactsTabHome:
             headers={"HX-Target": "contacts-tab-list"},
         )
         assert resp.status_code == 200
-        assert "buyer_po" in resp.text
+        assert "engineer" in resp.text
 
     def test_edit_contact_response_contains_roles(
         self,
@@ -3510,11 +3523,11 @@ class TestContactsTabHome:
         db_session.commit()
         resp = client.post(
             f"/v2/partials/customers/{test_company.id}/sites/{test_site.id}/contacts/{test_contact.id}/edit",
-            data={"full_name": test_contact.full_name, "contact_role": "buyer_po"},
+            data={"full_name": test_contact.full_name, "contact_role": "engineer"},
             headers={"HX-Target": "contacts-tab-list"},
         )
         assert resp.status_code == 200
-        assert "buyer_po" in resp.text
+        assert "engineer" in resp.text
 
 
 class TestC3KebabActionsAndCadence:


### PR DESCRIPTION
## CRM customer-tab contact card rework

Four owner-reported items on the contact card (the active `contact_row` macro + its expand drawer):

1. **Role dropdown fixed (root cause)** — the options were the wrong vocabulary (`specifier/buyer_po/…`) so legacy values matched nothing (looked blank) and saves 400'd (looked dead). New `ContactRole` StrEnum = **Buyer/Manager/Engineer/Planner/Other**; both `CANONICAL_ROLES` (htmx_views) and the `roles` Jinja global (template_env) derive from it (DRY). Legacy values kept for read-only display.
2. **Phone + email → click-to-contact** — `tel:` / Outlook-compose links in the row cells + the drawer, DNC-guarded, keeping outreach logging.
3. **Recent notes + notes modal** — latest note shown (batched, no N+1); "See all notes" opens a modal (`GET …/notes-modal`) with the full feed + an add-note form (`POST …/notes`, `can_manage_account`-gated), reusing the existing `ActivityLog` contact-note service.
4. **Horizontal layout** — drawer re-laid as a dense flex-wrap flow instead of a vertical stack. Dead `contact_card` macro deleted.

No migration (`contact_role` is String(50); notes infra existed). 23 new tests + full suite **20,754 green**; new Tailwind chip colors confirmed in the built CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)