### PR TITLE
feat(qp): front door — 'Quality Plan' button on a buy plan creates + opens the native QP

### DIFF
--- a/app/routers/quality_plans.py
+++ b/app/routers/quality_plans.py
@@ -1,7 +1,8 @@
 """routers/quality_plans.py — HTMX router for Quality Plan views.
 
-Purpose: Exposes GET /v2/qp/{id} (QP detail partial),
-         POST /v2/qp/{id}/submit (submit-for-review action), the QP Phase C2a
+Purpose: Exposes GET /v2/qp/for-buy-plan/{bp_id} (the front door — get-or-create the QP
+         for a buy plan and render its native detail), GET /v2/qp/{id} (QP detail
+         partial), POST /v2/qp/{id}/submit (submit-for-review action), the QP Phase C2a
          section gates POST /v2/qp/{id}/submit-sales + /submit-purchasing (open the
          SALES_ORDER / PURCHASE_ORDER approval gate), and the QP Phase C2b native-section
          editors: PATCH /v2/qp/{id}/sales + /purchasing (inline field edit → refreshed
@@ -31,7 +32,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from ..constants import ApprovalGateType, ApprovalSubjectType
 from ..database import get_db
-from ..dependencies import require_requisition_access, require_user
+from ..dependencies import get_buyplan_for_user, require_requisition_access, require_user
 from ..models.approvals import ApprovalRequest
 from ..models.buy_plan import BuyPlan, BuyPlanLine
 from ..models.crm import CustomerSite
@@ -41,6 +42,7 @@ from ..models.quotes import Quote
 from ..services.quality_plan_service import (
     IncompleteQPError,
     NoSectionApproverError,
+    create_qp,
     submit,
     submit_section,
     validate_complete,
@@ -232,6 +234,46 @@ def _require_qp_access(db: Session, user, qp: QualityPlan) -> None:
         owner_id=qp.created_by_id,
         label="Quality plan",
     )
+
+
+@router.get("/v2/qp/for-buy-plan/{bp_id}", response_class=HTMLResponse)
+def qp_for_buy_plan(
+    request: Request,
+    bp_id: int,
+    db: Session = Depends(get_db),
+    user=Depends(require_user),
+) -> HTMLResponse:
+    """Get-or-create the Quality Plan for a buy plan and render its native detail.
+
+    The front door to the QP view: the buy-plan owner clicks "Quality Plan" and lands
+    here. Idempotent — the first open creates the (DRAFT) QP for this buy plan, every
+    later open returns the same one (a buy plan has at most one QP). Ownership is scoped
+    through the buy plan's parent requisition via get_buyplan_for_user, so a restricted-
+    role non-owner gets a 404 (existence not leaked) before any QP is created.
+    """
+    # Ownership-scoped load (404 for missing buy plan or restricted non-owner).
+    bp = get_buyplan_for_user(db, user, bp_id)
+
+    qp = db.execute(select(QualityPlan).where(QualityPlan.buy_plan_id == bp.id)).scalar_one_or_none()
+    if qp is None:
+        qp = create_qp(db, owner_id=user.id, buy_plan_id=bp.id)
+        db.commit()
+
+    # Re-load with the same eager options qp_detail uses so the detail partial renders
+    # the owner / serial / FRU sections without lazy-load surprises.
+    qp = db.get(
+        QualityPlan,
+        qp.id,
+        options=[
+            joinedload(QualityPlan.created_by),
+            joinedload(QualityPlan.approved_by),
+            joinedload(QualityPlan.buy_plan),
+            joinedload(QualityPlan.serial_entries).joinedload(QpSerialEntry.buyer),
+            joinedload(QualityPlan.serial_entries).joinedload(QpSerialEntry.submitted_by),
+            joinedload(QualityPlan.fru_lookups),
+        ],
+    )
+    return _qp_detail_response(request, user, db, qp)
 
 
 @router.get("/v2/qp/{qp_id}", response_class=HTMLResponse)

--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -51,6 +51,17 @@
         </span>
         <span class="text-xs text-gray-400">{{ lines|length }} line{{ 's' if lines|length != 1 }}</span>
         <span class="text-xs text-gray-400">{{ unique_vendors|length }} vendor{{ 's' if unique_vendors|length != 1 }}</span>
+        {# Quality Plan front door — get-or-create this buy plan's QP and open its native
+           view. Always shown (independent of the action banner) so the owner can always
+           reach the QP. #}
+        <button hx-get="/v2/qp/for-buy-plan/{{ bp.id }}"
+                hx-target="#main-content"
+                hx-push-url="true"
+                data-loading-disable
+                class="btn btn-secondary btn-sm inline-flex items-center gap-1">
+          <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+          Quality Plan
+        </button>
         {# Cancel/Reset only shown here when NOT in action banner #}
         {% if not has_action_banner %}
           {% if bp.status in ('halted', 'cancelled') %}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -5057,6 +5057,23 @@ open request exists — a plan that went `PENDING` before C1 deployed — it fal
 legacy `approve_buy_plan` and logs a WARNING (RISK 3, transition window, removed in a
 follow-up).
 
+**QP front door — open-or-create from a buy plan (`GET /v2/qp/for-buy-plan/{bp_id}`):**
+the only entry point to the native QP view. The buy-plan detail (`buy_plans/detail.html`)
+renders a secondary "Quality Plan" button (`hx-get="/v2/qp/for-buy-plan/{bp.id}"`,
+`hx-target="#main-content"`, `hx-push-url="true"`) in the header actions row, always shown
+(independent of the role-aware action banner). The route (`quality_plans.qp_for_buy_plan`)
+ownership-scopes via `get_buyplan_for_user(db, user, bp_id)` (404 for a missing plan OR a
+`RESTRICTED_ROLES` non-owner — existence not leaked, enforced BEFORE any create), then
+get-or-creates: `db.query(QualityPlan).filter_by(buy_plan_id=bp.id).first()`, else
+`create_qp(db, owner_id=user.id, buy_plan_id=bp.id)` + commit. It is idempotent — a buy plan
+has at most one QP, so a second open returns the same row (no duplicate). It re-loads the QP
+with the same eager options `qp_detail` uses and renders via the shared `_qp_detail_response`,
+so the user lands on the native QP detail. The QP detail's header sub-line carries a back-link
+to the buy plan (`hx-get="/v2/partials/buy-plans/{bp.id}"`, `hx-target="#main-content"`) so the
+view is not a dead-end. Coverage: `tests/test_qp_entry.py` (create-on-first-open, idempotent
+second open, restricted-non-owner 404 with no QP created, button renders the for-buy-plan
+hx-get).
+
 **QP section gates — Sales / Purchasing (QP Phase C2a):** the QualityPlan is the engine
 subject (`subject_type='quality_plan'`); the `gate_type` discriminates the section.
 `routing.route_request` gains `SALES_ORDER` → every active `can_approve_sales_orders` holder

--- a/tests/test_qp_entry.py
+++ b/tests/test_qp_entry.py
@@ -1,0 +1,193 @@
+"""test_qp_entry.py — TDD tests for the QP front door.
+
+Covers GET /v2/qp/for-buy-plan/{bp_id} (get-or-create the buy plan's Quality Plan and
+render the native QP detail) plus the "Quality Plan" entry button on the buy-plan detail.
+
+Tests:
+  1. First open with no existing QP creates one (DRAFT, buy_plan_id set) and renders the
+     QP detail (200).
+  2. Idempotent — a second open returns the SAME qp.id and does not create a duplicate.
+  3. Ownership — a restricted-role (sales) user who does not own the buy plan's
+     requisition gets a 404 and NO QP is created.
+  4. The buy-plan detail renders the "Quality Plan" button wired to the for-buy-plan
+     get-or-open route.
+
+Called by: pytest (TESTING=1 PYTHONPATH=. pytest tests/test_qp_entry.py -v)
+Depends on: app.routers.quality_plans, app.routers.htmx_views (buy-plan detail partial),
+            conftest (client, db_session, test_user, sales_user, test_customer_site).
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.models.auth import User
+from app.models.buy_plan import BuyPlan
+from app.models.quality_plan import QualityPlan
+from app.models.quotes import Quote
+from app.models.sourcing import Requisition
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _make_requisition(db: Session, owner_id: int) -> Requisition:
+    req = Requisition(
+        name="QP-ENTRY-001",
+        status="active",
+        customer_name="Acme Electronics",
+        created_by=owner_id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(req)
+    db.flush()
+    return req
+
+
+def _make_quote(db: Session, requisition_id: int, site_id: int | None = None) -> Quote:
+    q = Quote(
+        requisition_id=requisition_id,
+        customer_site_id=site_id,
+        quote_number="QT-QPE-001",
+        status="sent",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(q)
+    db.flush()
+    return q
+
+
+def _make_buy_plan(db: Session, requisition_id: int, quote_id: int, owner_id: int) -> BuyPlan:
+    bp = BuyPlan(
+        requisition_id=requisition_id,
+        quote_id=quote_id,
+        status="draft",
+        so_status="pending",
+        sales_order_number="SO-QPE-1",
+        submitted_by_id=owner_id,
+    )
+    db.add(bp)
+    db.flush()
+    return bp
+
+
+def _seed_buy_plan(db: Session, owner_id: int, site_id: int) -> BuyPlan:
+    """Create a requisition → quote → buy plan chain owned by owner_id."""
+    req = _make_requisition(db, owner_id)
+    q = _make_quote(db, req.id, site_id)
+    bp = _make_buy_plan(db, req.id, q.id, owner_id)
+    db.commit()
+    return bp
+
+
+def _qp_count(db: Session, bp_id: int) -> int:
+    """Number of QualityPlan rows linked to the given buy plan."""
+    return db.execute(
+        select(func.count()).select_from(QualityPlan).where(QualityPlan.buy_plan_id == bp_id)
+    ).scalar_one()
+
+
+def _qps_for(db: Session, bp_id: int) -> list[QualityPlan]:
+    """All QualityPlan rows linked to the given buy plan."""
+    return list(db.execute(select(QualityPlan).where(QualityPlan.buy_plan_id == bp_id)).scalars().all())
+
+
+def _restricted_client(db_session: Session, sales_user: User) -> TestClient:
+    """A TestClient authenticated as a restricted-role (sales) user.
+
+    Mirrors the conftest `client` fixture override pattern but returns sales_user from
+    require_user so role-scoped ownership (RESTRICTED_ROLES) is exercised.
+    """
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[require_user] = lambda: sales_user
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(require_user, None)
+
+
+@pytest.fixture()
+def restricted_client(db_session: Session, sales_user: User):
+    yield from _restricted_client(db_session, sales_user)
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+
+def test_for_buy_plan_creates_qp_on_first_open(client, db_session: Session, test_user, test_customer_site):
+    """First open with no existing QP creates one (DRAFT, buy_plan_id set) and
+    renders."""
+    bp = _seed_buy_plan(db_session, test_user.id, test_customer_site.id)
+    assert _qp_count(db_session, bp.id) == 0
+
+    resp = client.get(f"/v2/qp/for-buy-plan/{bp.id}")
+    assert resp.status_code == 200
+
+    qps = _qps_for(db_session, bp.id)
+    assert len(qps) == 1
+    qp = qps[0]
+    assert qp.status == "draft"
+    assert qp.created_by_id == test_user.id
+    # Lands on the native QP detail view.
+    assert f"Quality Plan #{qp.id}" in resp.text
+
+
+def test_for_buy_plan_is_idempotent(client, db_session: Session, test_user, test_customer_site):
+    """A second open returns the SAME qp.id and creates no duplicate row."""
+    bp = _seed_buy_plan(db_session, test_user.id, test_customer_site.id)
+
+    resp1 = client.get(f"/v2/qp/for-buy-plan/{bp.id}")
+    assert resp1.status_code == 200
+    qp_id_1 = _qps_for(db_session, bp.id)[0].id
+
+    resp2 = client.get(f"/v2/qp/for-buy-plan/{bp.id}")
+    assert resp2.status_code == 200
+
+    qps = _qps_for(db_session, bp.id)
+    assert len(qps) == 1, "second open must not create a duplicate QP"
+    assert qps[0].id == qp_id_1
+    assert f"Quality Plan #{qp_id_1}" in resp2.text
+
+
+def test_for_buy_plan_missing_buy_plan_404(client):
+    """A non-existent buy plan returns 404 (no QP to create)."""
+    resp = client.get("/v2/qp/for-buy-plan/999999")
+    assert resp.status_code == 404
+
+
+def test_for_buy_plan_ownership_404_for_restricted_non_owner(
+    restricted_client, db_session: Session, test_user, test_customer_site
+):
+    """A restricted-role user who does not own the buy plan's requisition gets 404.
+
+    The buy plan is owned by test_user (a buyer); the acting user is sales_user
+    (RESTRICTED_ROLES), who owns nothing here. The route must 404 and create NO QP.
+    """
+    bp = _seed_buy_plan(db_session, test_user.id, test_customer_site.id)
+
+    resp = restricted_client.get(f"/v2/qp/for-buy-plan/{bp.id}")
+    assert resp.status_code == 404
+    # Ownership is enforced before create — no QP row leaks into existence.
+    assert _qp_count(db_session, bp.id) == 0
+
+
+def test_buy_plan_detail_renders_quality_plan_button(client, db_session: Session, test_user, test_customer_site):
+    """The buy-plan detail renders the 'Quality Plan' button wired to for-buy-plan."""
+    bp = _seed_buy_plan(db_session, test_user.id, test_customer_site.id)
+
+    resp = client.get(f"/v2/partials/buy-plans/{bp.id}")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Quality Plan" in body
+    assert f"/v2/qp/for-buy-plan/{bp.id}" in body


### PR DESCRIPTION
The QP engine + gates + native sections were all built but **unreachable** — no way to create or open a QP from the UI. This wires the front door: a 'Quality Plan' button on the buy-plan detail → `GET /v2/qp/for-buy-plan/{bp_id}` get-or-creates the QP (via `create_qp`) and opens the native QP view. Idempotent (one QP per buy plan), ownership-scoped (404 for non-owners), back-link to the buy plan. No migration. 5 tests + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)