### PR TITLE
fix(approvals): outbox drain ResourceClosedError — per-row commit instead of savepoint

### DIFF
--- a/app/jobs/approval_outbox.py
+++ b/app/jobs/approval_outbox.py
@@ -34,13 +34,14 @@ MAX_OUTBOX_FAIL_COUNT = 5
 def _mark_failed(db: Session, row: ApprovalOutbox, reason: str) -> None:
     """Record a permanent/recoverable failure on a row WITHOUT marking it sent.
 
-    Increments fail_count and stores last_error, then flushes. Once fail_count hits
+    Increments fail_count and stores last_error, then commits so the diagnosis is
+    durable on its own (independent of any other row's outcome). Once fail_count hits
     MAX_OUTBOX_FAIL_COUNT the row is no longer selected by dispatch_pending (dead-
     letter). Never sets sent_at — the row genuinely did not send.
     """
     row.fail_count = (row.fail_count or 0) + 1
     row.last_error = reason
-    db.flush()
+    db.commit()
 
 
 async def dispatch_pending(db: Session) -> int:
@@ -54,11 +55,18 @@ async def dispatch_pending(db: Session) -> int:
         incremented and last_error recorded (NOT marked sent), so the dead-letter cap
         retires the row instead of it retrying forever.
 
-    Each row's work runs inside a SAVEPOINT (db.begin_nested) so a partial failure
-    (e.g. an unflushed in_app Notification) is rolled back to the savepoint and cannot
-    poison the batch; the fail_count/last_error write then happens on the outer
-    transaction and is guaranteed to survive. Identical behavior on PostgreSQL and the
-    SQLite test DB (both support SAVEPOINT).
+    Each row is committed in its OWN transaction: on success
+    ``row.sent_at = now; db.commit()``; on any failure ``db.rollback()`` discards the
+    row's partial state (e.g. a dirty Notification) and ``_mark_failed`` records
+    fail_count/last_error in a fresh transaction that commits independently. This per-row
+    isolation — not a SAVEPOINT — is what keeps a failing row from poisoning the batch.
+
+    A SAVEPOINT (``db.begin_nested``) is deliberately NOT used: the email dispatch path
+    (``send_email`` → ``token_manager.get_valid_token``) commits the session mid-row when
+    it refreshes an expired Graph token, which ends any enclosing savepoint and made the
+    old ``savepoint.commit()`` raise ``ResourceClosedError`` — aborting the whole batch and
+    stranding the email row. A dispatch path that commits internally is fundamentally
+    incompatible with an enclosing savepoint, so each row owns its own commit instead.
 
     Returns the count of rows successfully dispatched.
     """
@@ -94,7 +102,6 @@ async def dispatch_pending(db: Session) -> int:
 
         payload: dict = row.payload or {}
 
-        savepoint = db.begin_nested()
         try:
             if row.channel == "email":
                 subject, html = _ns._build_email_html(payload)
@@ -110,15 +117,14 @@ async def dispatch_pending(db: Session) -> int:
                 raise ValueError(f"unknown channel '{row.channel}'")
 
             row.sent_at = datetime.now(timezone.utc)
-            db.flush()
-            savepoint.commit()
+            db.commit()
             dispatched += 1
 
         except Exception as exc:
-            # Roll back this row's partial state (e.g. a dirty Notification) to the
-            # savepoint so the outer transaction is clean; the fail_count/last_error
-            # write below then cannot re-raise the same error or be lost on rollback.
-            savepoint.rollback()
+            # Discard this row's partial state (e.g. a dirty Notification, or a session
+            # already committed/closed by the dispatch path) and record the failure in a
+            # fresh transaction so it survives independently of the rest of the batch.
+            db.rollback()
             _mark_failed(db, row, str(exc))
             logger.error(
                 "approval_outbox row {} dispatch failed (attempt {}): {}",
@@ -126,9 +132,6 @@ async def dispatch_pending(db: Session) -> int:
                 row.fail_count,
                 exc,
             )
-
-    if rows:
-        db.commit()
 
     return dispatched
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -5069,6 +5069,17 @@ dispatch and the legacy `approve_buy_plan`, so the two paths can never drift.
   `fail_count`/`last_error`; the dead-letter cap (`MAX_OUTBOX_FAIL_COUNT`) retires a broken row.
 - Channel server_default is `in_app` (migration 159) so an outbox row without an explicit
   channel is never silently treated as email.
+- **Transaction model: PER-ROW COMMIT, not SAVEPOINT.** Each row commits in its own
+  transaction (`row.sent_at = now; db.commit()` on success; `db.rollback()` +
+  `_mark_failed` (which itself commits) on failure). This per-row isolation — not a
+  `db.begin_nested()` SAVEPOINT — keeps a failing row from poisoning the batch. A SAVEPOINT
+  is deliberately NOT used because the email path (`send_email` →
+  `token_manager.get_valid_token`) commits the session MID-ROW when it refreshes an expired
+  Graph token, which ends any enclosing savepoint; the old SAVEPOINT design therefore raised
+  `ResourceClosedError` at `savepoint.commit()`, aborted the whole batch, and stranded the
+  email row (sent_at NULL, fail_count 0) while the sibling in_app row had already delivered.
+  A dispatch path that commits internally is fundamentally incompatible with an enclosing
+  savepoint, so each row owns its own commit.
 
 **Buy-plan submission → engine gate (QP Phase C1):** `buyplan_workflow.submit_buy_plan`
 (and `resubmit_buy_plan`), on the non-auto-approve path, call

--- a/tests/test_approval_outbox.py
+++ b/tests/test_approval_outbox.py
@@ -14,6 +14,7 @@ Depends on: conftest (db_session), app.jobs.approval_outbox,
             app.models.approvals, app.models.notification, app.models.auth
 """
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -285,10 +286,10 @@ async def test_unknown_channel_is_failed_not_marked_sent(db_session):
 
 
 @pytest.mark.asyncio
-async def test_in_app_failure_savepoint_does_not_poison_batch(db_session):
-    """If the in_app flush raises, the per-row SAVEPOINT rolls back the dirty
-    Notification and the fail_count/last_error write still survives; a healthy later row
-    in the same batch still dispatches (batch not poisoned)."""
+async def test_in_app_failure_does_not_poison_batch(db_session):
+    """If the in_app write raises, that row is rolled back and failed (fail_count/
+    last_error recorded, no dirty Notification persisted), and a healthy later row in
+    the same batch still dispatches (batch not poisoned by per-row isolation)."""
     from app.jobs import approval_outbox
     from app.jobs.approval_outbox import dispatch_pending
 
@@ -305,7 +306,7 @@ async def test_in_app_failure_savepoint_does_not_poison_batch(db_session):
     def _flaky_write(db, user_id, event_type, title, body=None):
         calls["n"] += 1
         if calls["n"] == 1:
-            db.add(  # dirty object that must be rolled back to the savepoint
+            db.add(  # dirty object that must NOT survive the failed row
                 Notification(user_id=user_id, event_type=event_type, title=title, body=body, is_read=False)
             )
             raise RuntimeError("boom in_app")
@@ -323,4 +324,62 @@ async def test_in_app_failure_savepoint_does_not_poison_batch(db_session):
 
     # Exactly one Notification — the bad row's dirty Notification was rolled back.
     notifs = db_session.execute(select(Notification).where(Notification.user_id == user.id)).scalars().all()
-    assert len(notifs) == 1, "the failed row's Notification must have been rolled back to the savepoint"
+    assert len(notifs) == 1, "the failed row's Notification must have been rolled back"
+
+
+@pytest.mark.asyncio
+async def test_email_dispatch_path_committing_session_does_not_abort_batch(db_session):
+    """Regression for the staging ResourceClosedError.
+
+    The real email path is ``send_email`` → ``token_manager.get_valid_token(user, db)``,
+    which on an expired/near-expiry token refreshes it and calls ``db.commit()`` MID-ROW.
+    A mid-row commit ends any enclosing ``begin_nested()`` SAVEPOINT, so the old drain
+    blew up at ``savepoint.commit()`` with ``sqlalchemy.exc.ResourceClosedError: This
+    transaction is closed`` — and the failing ``except savepoint.rollback()`` propagated,
+    aborting the whole 60s batch and leaving the email row stuck (sent_at NULL,
+    fail_count 0) while the sibling in_app row had already been delivered.
+
+    The drain MUST tolerate a dispatch path that commits/closes the transaction mid-row:
+    no ResourceClosedError, the committing email row is delivered, and a sibling in_app
+    row in the same batch still delivers.
+    """
+    from app.jobs.approval_outbox import dispatch_pending
+
+    sender = _make_user(db_session, "refresher@example.com")
+    other = _make_user(db_session, "inapp-sibling@example.com")
+    req = _make_request(db_session, sender)
+    email_row = _pending_outbox(db_session, req, sender, channel="email")
+    inapp_row = _pending_outbox(db_session, req, other, channel="in_app")
+    db_session.commit()
+
+    # Faithfully simulate get_valid_token's token-refresh write: mutate the user and
+    # commit the SESSION mid-row, exactly as token_manager does, then return a token.
+    async def _refresh_then_token(user, db):
+        user.m365_last_healthy = datetime.now(timezone.utc)
+        db.commit()  # this is what closed the savepoint in production
+        return "tok"
+
+    with (
+        patch(
+            "app.services.approvals.notifications.get_valid_token",
+            side_effect=_refresh_then_token,
+        ),
+        patch("app.services.approvals.notifications.GraphClient") as MockGC,
+    ):
+        gc_instance = MagicMock()
+        gc_instance.post_json = AsyncMock(return_value=None)
+        MockGC.return_value = gc_instance
+
+        # Must NOT raise ResourceClosedError.
+        dispatched = await dispatch_pending(db_session)
+
+    assert dispatched == 2, "both the committing email row and the in_app sibling dispatch"
+
+    db_session.refresh(email_row)
+    db_session.refresh(inapp_row)
+    assert email_row.sent_at is not None, "the committing email row must be marked sent"
+    assert email_row.fail_count == 0
+    assert inapp_row.sent_at is not None, "the sibling in_app row must NOT be aborted"
+
+    notifs = db_session.execute(select(Notification).where(Notification.user_id == other.id)).scalars().all()
+    assert len(notifs) == 1, "the in_app sibling's Notification must be written"


### PR DESCRIPTION
ROOT CAUSE: `token_manager.get_valid_token` commits the session mid-row (token refresh), ending the enclosing SAVEPOINT, so the drain's `savepoint.commit()` threw ResourceClosedError and aborted — leaving approval EMAIL notifications stuck undelivered. FIX: per-row commit (no savepoint). Regression test proven RED→GREEN; 306 tests green. No migration. 🤖 Generated with [Claude Code](https://claude.com/claude-code)