### PR TITLE
feat(sightings): adopt the Sales Hub look (status dots, coverage meters, framed detail header)

### DIFF
--- a/app/templates/htmx/partials/sightings/_vendor_row.html
+++ b/app/templates/htmx/partials/sightings/_vendor_row.html
@@ -51,7 +51,7 @@
 {% set name_color = 'text-gray-400' if is_unavailable else 'text-gray-900' %}
 {% set num_color = 'text-gray-400' if is_unavailable else 'text-gray-600' %}
 {% set score_color = 'text-gray-400' if (is_unavailable or s.score is none)
-   else ('text-emerald-600' if s.score >= 70 else ('text-amber-600' if s.score >= 40 else 'text-gray-500')) %}
+   else ('figure-accent' if s.score >= 70 else ('text-amber-600' if s.score >= 40 else 'text-gray-500')) %}
 {# Blacklisted vendors expose no actions; everyone else gets a kebab. #}
 {% set has_actions = vs != 'blacklisted' %}
 
@@ -215,19 +215,19 @@
           {# ── Unavailability knowledge — first entry, full width ── #}
           {% if unav and is_unavailable %}
           <div class="col-span-2">
-            <span class="text-gray-400">What we learned:</span>
+            <span class="text-secondary">What we learned:</span>
             <span class="text-rose-600 font-medium">{{ unav.reason_label }}</span>
             {% if unav.note %}<span class="italic text-gray-600">— {{ unav.note }}</span>{% endif %}
             <span class="text-gray-400">· {% if unav.marked_by %}{{ unav.marked_by }}, {% endif %}{{ unav.age_days }}d ago</span>
           </div>
           {% elif unav_advisory or unav_restock %}
           <div class="col-span-2">
-            <span class="text-gray-400">History:</span>
+            <span class="text-secondary">History:</span>
             <span class="text-gray-600">Marked unavailable — {{ unav.reason_label|lower }}{% if unav.note %} — <span class="italic">{{ unav.note }}</span>{% endif %} · {% if unav.marked_by %}{{ unav.marked_by }}, {% endif %}{{ unav.age_days }}d ago{% if unav.released_by %} · released by {{ unav.released_by }}{% endif %}</span>
           </div>
           {% if unav_restock %}
           <div class="col-span-2">
-            <span class="text-gray-400">Changed:</span>
+            <span class="text-secondary">Changed:</span>
             <span class="font-mono text-emerald-600">{{ unav.qty_at_mark if unav.qty_at_mark is not none else '?' }} → {{ s.estimated_qty or '—' }}</span>
             {% if intel.get('age_days') is not none %}<span class="text-gray-400">· seen {{ intel.age_days }}d ago</span>{% endif %}
           </div>
@@ -236,14 +236,14 @@
 
           {% if intel.get('listing_count') %}
           <div>
-            <span class="text-gray-400">Sources:</span>
+            <span class="text-secondary">Sources:</span>
             <span class="text-gray-700">Found on {{ intel.listing_count }} source{{ 's' if intel.listing_count != 1 }}</span>
           </div>
           {% endif %}
 
           {% if intel.get('source_types') %}
           <div>
-            <span class="text-gray-400">Via:</span>
+            <span class="text-secondary">Via:</span>
             {% for src in intel.source_types[:3] %}
               {% set source_name = src %}
               {% include "htmx/partials/shared/source_badge.html" %}
@@ -256,49 +256,49 @@
 
           {% if intel.get('tier') %}
           <div>
-            <span class="text-gray-400">Evidence:</span>
+            <span class="text-secondary">Evidence:</span>
             <span class="text-gray-700">{{ intel.tier }}</span>
           </div>
           {% endif %}
 
           {% if s.avg_price and s.best_price %}
           <div>
-            <span class="text-gray-400">Price Range:</span>
+            <span class="text-secondary">Price Range:</span>
             <span class="font-mono text-gray-700">${{ '%.2f'|format(s.best_price) }} — ${{ '%.2f'|format(s.avg_price) }}</span>
           </div>
           {% endif %}
 
           {% if intel.get('response_rate') is not none %}
           <div>
-            <span class="text-gray-400">Response Rate:</span>
+            <span class="text-secondary">Response Rate:</span>
             <span class="text-gray-700">{{ (intel.response_rate * 100)|int }}%</span>
           </div>
           {% endif %}
 
           {% if intel.get('ghost_rate') is not none %}
           <div>
-            <span class="text-gray-400">Ghost Rate:</span>
+            <span class="text-secondary">Ghost Rate:</span>
             <span class="{{ 'text-rose-600' if intel.ghost_rate > 0.3 else 'text-gray-700' }}">{{ (intel.ghost_rate * 100)|int }}%</span>
           </div>
           {% endif %}
 
           {% if intel.get('best_lead_time_days') %}
           <div>
-            <span class="text-gray-400">Lead Time:</span>
+            <span class="text-secondary">Lead Time:</span>
             <span class="text-gray-700">{{ intel.best_lead_time_days }} day{{ 's' if intel.best_lead_time_days != 1 }}</span>
           </div>
           {% endif %}
 
           {% if intel.get('min_moq') %}
           <div>
-            <span class="text-gray-400">MOQ:</span>
+            <span class="text-secondary">MOQ:</span>
             <span class="font-mono text-gray-700">{{ intel.min_moq }}</span>
           </div>
           {% endif %}
 
           {% if vendor_phone %}
           <div>
-            <span class="text-gray-400">Phone:</span>
+            <span class="text-secondary">Phone:</span>
             <a href="tel:{{ vendor_phone }}" @click.stop class="text-accent-600 hover:text-accent-700">{{ vendor_phone }}</a>
           </div>
           {% endif %}

--- a/app/templates/htmx/partials/sightings/activity_section.html
+++ b/app/templates/htmx/partials/sightings/activity_section.html
@@ -2,9 +2,12 @@
    Called by: sightings/detail.html (include), sightings_log_activity (POST response)
    Depends on: HTMX, Alpine.js, Tailwind
    Context vars: activities (list of ActivityLog), requirement
+   Root padding (px-5 py-3) is self-contained: this partial swaps standalone into
+   #sightings-activity-section, whose parent #sightings-detail is flush (no p-3).
 #}
 
-<h4 class="text-xs font-semibold text-gray-600 uppercase tracking-wider mb-2">Activity</h4>
+<div class="px-5 py-3">
+<h4 class="h4 mb-2">Activity</h4>
 
 {# ── Inline Log Note Form ──────────────────────────────────── #}
 <div x-data="{ open: false }" class="mb-3">
@@ -70,3 +73,4 @@
 
 {# ── Timeline ──────────────────────────────────────────────── #}
 {% include "htmx/partials/shared/activity_timeline.html" %}
+</div>

--- a/app/templates/htmx/partials/sightings/detail.html
+++ b/app/templates/htmx/partials/sightings/detail.html
@@ -9,39 +9,44 @@
 {% import "htmx/partials/shared/_macros.html" as m %}
 {% from "htmx/partials/shared/_mpn_chips.html" import mpn_chips %}
 
-{# ── Part Header (always visible above tabs) ─────────────────── #}
-<div class="border-b border-gray-100 pb-3 mb-3 sightings-slide-down">
-  <div class="flex items-start justify-between">
-    <div>
-      {{ mpn_chips(requirement, link_map=link_map) }}
-      {% if requirement.manufacturer %}
-      <p class="text-xs text-gray-600 mt-1">{{ requirement.manufacturer }}</p>
-      {% endif %}
-    </div>
-    <div class="flex items-center gap-2 flex-shrink-0">
-      <button @click="$dispatch('open-modal', {url: '/v2/partials/sightings/vendor-modal?requirement_ids={{ requirement.id }}'})"
-              class="btn-primary btn-sm">Build RFQ</button>
-      {{ m.search_button(requirement, target="#sightings-detail", swap="innerHTML") }}
-    </div>
+{# ── Part Header (always visible above tabs) — Sales Hub look:
+     flush flex header (mirror requisitions2/_detail_panel.html:27) then a
+     dt/dd metadata grid. The inline status <select> hx-patch is Sightings-
+     specific and stays AS-IS. ─────────────────────────────────────────── #}
+<div class="flex items-center gap-3 px-5 py-3 border-b border-gray-200 bg-gray-50 flex-shrink-0 sightings-slide-down">
+  <div class="flex-1 min-w-0">
+    {{ mpn_chips(requirement, link_map=link_map) }}
+    {% if requirement.manufacturer %}
+    <p class="text-xs text-gray-600 mt-1">{{ requirement.manufacturer }}</p>
+    {% endif %}
   </div>
+  <div class="flex items-center gap-2 flex-shrink-0">
+    <button @click="$dispatch('open-modal', {url: '/v2/partials/sightings/vendor-modal?requirement_ids={{ requirement.id }}'})"
+            class="btn btn-sm btn-primary">Build RFQ</button>
+    {{ m.search_button(requirement, target="#sightings-detail", swap="innerHTML") }}
+  </div>
+</div>
 
-  <div class="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+<div class="grid grid-cols-2 gap-x-4 gap-y-2 px-5 py-3 border-b border-gray-200 text-sm flex-shrink-0">
     <div>
-      <span class="text-gray-400">Qty:</span>
-      <span class="font-mono text-sm font-semibold text-gray-800">{{ requirement.target_qty or '—' }}</span>
+      <dt class="text-xs font-medium text-gray-400 uppercase">Qty</dt>
+      <dd class="text-gray-900 mt-0.5 font-mono font-semibold">{{ requirement.target_qty or '—' }}</dd>
     </div>
     <div>
-      <span class="text-gray-400">Target:</span>
-      <span class="figure-accent text-sm font-semibold">{{ '$%.2f'|format(requirement.target_price) if requirement.target_price else '—' }}</span>
+      <dt class="text-xs font-medium text-gray-400 uppercase">Target</dt>
+      <dd class="figure-accent mt-0.5 font-semibold">{{ '$%.2f'|format(requirement.target_price) if requirement.target_price else '—' }}</dd>
     </div>
     <div>
-      <span class="text-gray-400">Customer:</span>
-      <a href="/v2/requisitions/{{ requisition.id }}" class="text-accent-600 hover:underline">
-        {{ requisition.customer_name or '—' }}
-      </a>
+      <dt class="text-xs font-medium text-gray-400 uppercase">Customer</dt>
+      <dd class="mt-0.5">
+        <a href="/v2/requisitions/{{ requisition.id }}" class="text-accent-600 hover:underline">
+          {{ requisition.customer_name or '—' }}
+        </a>
+      </dd>
     </div>
     <div>
-      <span class="text-gray-400">Status:</span>
+      <dt class="text-xs font-medium text-gray-400 uppercase">Status</dt>
+      <dd class="mt-0.5">
       {% set status_styles = {
         'open': 'text-gray-700',
         'sourcing': 'text-blue-700',
@@ -70,20 +75,20 @@
         {{ (requirement.sourcing_status or 'open')|capitalize }}
       </span>
       {% endif %}
+      </dd>
     </div>
-  </div>
 </div>
 
 {# ── Tabbed body: Vendors (default) / Activity ──────────────── #}
 {# Inline rendering: `activities` already loaded by sightings_detail; lazy hx-get would add a round trip with no benefit. #}
 <div x-data="{ activeTab: 'vendors' }">
-  <div class="border-b border-gray-200 mb-3">
-    <nav class="flex gap-6 -mb-px">
+  <div class="border-b border-gray-200 px-5">
+    <nav class="flex gap-0 -mb-px">
       {% for tab_id, tab_label in [('vendors', 'Vendors'), ('offers', 'Offers'), ('activity', 'Activity')] %}
       <button @click="activeTab = '{{ tab_id }}'"
               type="button"
               :class="activeTab === '{{ tab_id }}' ? 'border-accent-600 text-accent-600' : 'border-transparent text-gray-500 hover:text-gray-900 hover:border-gray-200'"
-              class="py-2 px-1 text-xs font-medium border-b-2 transition-colors whitespace-nowrap">
+              class="px-4 py-2 text-sm font-medium border-b-2 transition-colors whitespace-nowrap">
         {{ tab_label }}
       </button>
       {% endfor %}
@@ -91,9 +96,9 @@
   </div>
 
   {# ── Vendors panel (default) ──────────────────────────────── #}
-  <div x-show="activeTab === 'vendors'" x-cloak>
+  <div x-show="activeTab === 'vendors'" x-cloak class="px-5 py-3">
 <div class="mb-4">
-  <h4 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+  <h4 class="h4 mb-2">
     Vendors ({{ summaries|length }})
   </h4>
 

--- a/app/templates/htmx/partials/sightings/list.html
+++ b/app/templates/htmx/partials/sightings/list.html
@@ -136,18 +136,12 @@
     </div>
   </div>
 
-  {# ── Drag Handle (desktop only) ────────────────────────────── #}
-  <div class="hidden lg:block w-[3px] cursor-col-resize bg-gray-200 hover:bg-accent-400 transition-colors flex-shrink-0 relative group"
+  {# ── Drag Handle (desktop only) — slim Sales-Hub treatment ─────── #}
+  <div class="hidden lg:block w-1 cursor-col-resize bg-gray-200 hover:bg-accent-400 transition-colors flex-shrink-0 relative"
        :class="dragging ? 'bg-accent-500' : ''"
        @mousedown="startDrag($event)">
+    {# Invisible widened hit-target keeps the grip easy to grab despite the slim bar. #}
     <div class="absolute inset-y-0 -left-2 -right-2"></div>
-    <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-      <div class="w-1 h-1 rounded-full bg-white"></div>
-      <div class="w-1 h-1 rounded-full bg-white"></div>
-      <div class="w-1 h-1 rounded-full bg-white"></div>
-      <div class="w-1 h-1 rounded-full bg-white"></div>
-      <div class="w-1 h-1 rounded-full bg-white"></div>
-    </div>
   </div>
 
   {# ── Right Panel: Requirement Detail ─────────────────────── #}
@@ -198,8 +192,10 @@
         {% endfor %}
       </div>
     </div>
-    {# Detail content — loaded via HTMX when row selected #}
-    <div x-show="selectedReqId" x-cloak id="sightings-detail" class="sightings-fade p-3"
+    {# Detail content — loaded via HTMX when row selected. No padding here: the
+       detail partials (header/grid/tabs + offers_panel/activity_section) carry
+       their own px-5 py-3 so the Sales-Hub header sits flush to the edge. #}
+    <div x-show="selectedReqId" x-cloak id="sightings-detail" class="sightings-fade"
          hx-indicator="#sightings-detail-skeleton"></div>
   </div>
 </div>

--- a/app/templates/htmx/partials/sightings/offers_panel.html
+++ b/app/templates/htmx/partials/sightings/offers_panel.html
@@ -1,13 +1,16 @@
 {# offers_panel.html — part-centric offers list for the sightings Offers tab.
    Receives: requirement, part_offers (list[Offer]).
    Called by: detail.html include + sightings offer endpoints (swap #sightings-offers-panel).
-   Depends on: _offer_row.html, the global open-modal modal. #}
+   Depends on: _offer_row.html, the global open-modal modal.
+   Root padding (px-5 py-3) is self-contained: this partial swaps standalone into
+   #sightings-offers-panel, whose parent #sightings-detail is flush (no p-3). #}
+<div class="px-5 py-3">
 <div class="mb-3 flex items-center justify-between">
-  <h4 class="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+  <h4 class="h4">
     All offers for {{ requirement.primary_mpn }} · {{ part_offers|length }}
   </h4>
   <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/{{ requirement.id }}/offer-form'})"
-          class="btn-primary btn-sm">
+          class="btn btn-sm btn-primary">
     <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
     Enter Offer
   </button>
@@ -24,3 +27,4 @@
   {% endfor %}
 </div>
 {% endif %}
+</div>

--- a/app/templates/htmx/partials/sightings/table.html
+++ b/app/templates/htmx/partials/sightings/table.html
@@ -12,11 +12,11 @@
 {# ── Smart Priority Dashboard Strip ────────────────────────── #}
 {% set dc = dashboard_counters|default({}) %}
 <div class="px-3 pt-3 pb-2 border-b border-gray-100 flex items-center gap-2 flex-wrap">
-  {# Urgent counter #}
+  {# Urgent counter — Sales Hub btn shape; active count tints the chrome. #}
   <button hx-get="/v2/partials/sightings?priority_min=70&q={{ q }}&manufacturer={{ manufacturer|default('') }}"
           hx-target="#sightings-table" hx-swap="innerHTML"
-          class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors
-                 {{ 'bg-rose-100 text-rose-700' if dc.get('urgent', 0) > 0 else 'bg-gray-100 text-gray-500' }}">
+          class="btn btn-sm btn-secondary inline-flex items-center gap-1.5
+                 {{ 'border-rose-300 text-rose-700 bg-rose-50' if dc.get('urgent', 0) > 0 else '' }}">
     <span class="inline-block w-2 h-2 rounded-full {{ 'bg-rose-500' if dc.get('urgent', 0) > 0 else 'bg-gray-300' }}"></span>
     {{ dc.get('urgent', 0) }} Urgent
   </button>
@@ -24,8 +24,8 @@
   {# Stale counter #}
   <button hx-get="/v2/partials/sightings?stale=1&q={{ q }}&manufacturer={{ manufacturer|default('') }}"
           hx-target="#sightings-table" hx-swap="innerHTML"
-          class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors
-                 {{ 'bg-amber-100 text-amber-700' if dc.get('stale', 0) > 0 else 'bg-gray-100 text-gray-500' }}">
+          class="btn btn-sm btn-secondary inline-flex items-center gap-1.5
+                 {{ 'border-amber-300 text-amber-700 bg-amber-50' if dc.get('stale', 0) > 0 else '' }}">
     <span class="inline-block w-2 h-2 rounded-full {{ 'bg-amber-500' if dc.get('stale', 0) > 0 else 'bg-gray-300' }}"></span>
     {{ dc.get('stale', 0) }} Stale
   </button>
@@ -33,8 +33,8 @@
   {# Pending counter #}
   <button hx-get="/v2/partials/sightings?status=offered&q={{ q }}&manufacturer={{ manufacturer|default('') }}"
           hx-target="#sightings-table" hx-swap="innerHTML"
-          class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium transition-colors
-                 {{ 'bg-blue-100 text-blue-700' if dc.get('pending', 0) > 0 else 'bg-gray-100 text-gray-500' }}">
+          class="btn btn-sm btn-secondary inline-flex items-center gap-1.5
+                 {{ 'border-blue-300 text-blue-700 bg-blue-50' if dc.get('pending', 0) > 0 else '' }}">
     <span class="inline-block w-2 h-2 rounded-full {{ 'bg-blue-500' if dc.get('pending', 0) > 0 else 'bg-gray-300' }}"></span>
     {{ dc.get('pending', 0) }} Pending
   </button>
@@ -83,7 +83,7 @@
           hx-trigger="change"
           hx-target="#sightings-table"
           :hx-vals="JSON.stringify({status: sStatus, q: sQ, manufacturer: sManufacturer})"
-          class="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-600">
+          class="input w-auto">
     <option value="" {{ 'selected' if not group_by }}>Flat</option>
     <option value="brand" {{ 'selected' if group_by == 'brand' }}>By Brand</option>
     <option value="manufacturer" {{ 'selected' if group_by == 'manufacturer' }}>By Manufacturer</option>
@@ -125,14 +125,14 @@
                  @change="document.querySelectorAll('.req-checkbox').forEach(cb => { cb.checked = toggleAll; if (toggleAll) $store.sightingSelection.toggle(parseInt(cb.value)); else $store.sightingSelection.clear(); })"
                  class="rounded border-gray-300">
         </th>
-        <th class="text-left">Part Numbers</th>
-        <th class="text-left hidden sm:table-cell">Description</th>
-        <th class="text-right w-[60px] hidden sm:table-cell">Qty</th>
-        <th class="text-left hidden xl:table-cell">Customer</th>
-        <th class="text-left w-[80px] hidden xl:table-cell">Sales</th>
-        <th class="text-left w-[80px]">Coverage</th>
-        <th class="text-left w-[80px]">Status</th>
-        <th class="text-center w-[60px] hidden xl:table-cell">Priority</th>
+        <th class="opp-col-header text-left">Part Numbers</th>
+        <th class="opp-col-header text-left hidden sm:table-cell">Description</th>
+        <th class="opp-col-header text-right w-[60px] hidden sm:table-cell">Qty</th>
+        <th class="opp-col-header text-left hidden xl:table-cell">Customer</th>
+        <th class="opp-col-header text-left w-[80px] hidden xl:table-cell">Sales</th>
+        <th class="opp-col-header text-left w-[80px]">Coverage</th>
+        <th class="opp-col-header text-left w-[80px]">Status</th>
+        <th class="opp-col-header text-right w-[60px] hidden xl:table-cell">Priority</th>
       </tr>
     </thead>
     <tbody>
@@ -171,10 +171,7 @@
             x-data="{ refreshing: false }"
             :class="refreshing ? 'opacity-60' : ''">
           <div class="relative flex items-center gap-1">
-            <div class="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden" title="{{ cov_pct }}% coverage ({{ cov_qty }} / {{ r.target_qty or '?' }})">
-              <div class="h-full rounded-full transition-all duration-300 {{ 'bg-red-300' if cov_pct < 50 else 'bg-gray-400' }}"
-                   style="width: {{ cov_pct }}%"></div>
-            </div>
+            <span title="{{ cov_pct }}% coverage ({{ cov_qty }} / {{ r.target_qty or '?' }})">{{ m.coverage_meter(cov_qty, r.target_qty) }}</span>
             <span class="text-[10px] text-gray-400 w-7 text-right">{{ cov_pct }}%</span>
             <button class="ml-0.5 text-gray-300 hover:text-amber-500 transition-colors"
                     title="Search this requirement"
@@ -193,7 +190,7 @@
         </td>
         <td>
           <div class="flex items-center gap-1.5">
-            <span class="transition-colors duration-200">{{ m.status_badge(r.sourcing_status) }}</span>
+            <span class="transition-colors duration-200">{{ m.opp_status_cell(r.sourcing_status, none) }}</span>
             {# Hover-revealed quick Build RFQ button — @click.stop so it doesn't
                select the row; mirrors the refresh icon-button pattern above #}
             <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/sightings/vendor-modal?requirement_ids={{ r.id }}'})"
@@ -205,7 +202,7 @@
             </button>
           </div>
         </td>
-        <td class="text-center hidden xl:table-cell">
+        <td class="text-right hidden xl:table-cell">
           {% if r.priority_score %}
             {% set pri = r.priority_score %}
             {% set pri_label = 'High' if pri >= 70 else ('Med' if pri >= 40 else 'Low') %}
@@ -220,7 +217,7 @@
         <tr class="bg-gray-50 border-b border-gray-200">
           <td colspan="9" class="px-3 py-2">
             <div class="flex items-center gap-3">
-              <span class="font-semibold text-sm text-gray-800">{{ group_name }}</span>
+              <span class="h4">{{ group_name }}</span>
               {# "Select all N" checkbox for this group — adds/removes all group ids in the basket #}
               <label class="flex items-center gap-1.5 cursor-pointer select-none">
                 <input type="checkbox" class="rounded border-gray-300"

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -4326,7 +4326,15 @@ BROWSER (HTMX + Alpine.js)
       _mpn_chips.html: equal inline pills for all MPNs (primary + subs)
           with overflow toggle and modal material card click
       status_badge macro (_macros.html): unified badge rendering
-          used across all pages (requisitions, sightings, parts, etc.)
+          used across all pages (requisitions, parts, etc.)
+      Sales-Hub look (requisitions2 opportunity-table tokens): the
+          Sightings list table + detail panel reuse opp_status_cell
+          (status dot+label), coverage_meter (6-seg meter), .opp-col-header
+          (th), .h4 / .figure-accent / .input / .btn btn-sm. Sightings-only
+          treatments are preserved: the red/green _vendor_row row_tint
+          (bg-rose-50/60 unavailable, bg-emerald-50/50 offer-in), the inline
+          status <select> hx-patch advance-status, the per-vendor expandable
+          drawer, the SSE refresh, and the multi-select action bar.
 ```
 
 ---

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -4108,3 +4108,138 @@ class TestRequisitionStatusFilter:
         assert resp.status_code == 200
         for status in ("sourcing", "won", "quoted"):
             assert f"MPN-{status.upper()}" in resp.text
+
+
+class TestSightingsSalesHubLook:
+    """Pins the Sales Hub (requisitions2) visual restyle of the Sightings page: the list
+    table + detail panel adopt the shared opportunity-table tokens (opp-col-header /
+    opp_status_cell / coverage_meter / .h4 / .figure-accent / .input / .btn btn-sm),
+    WITHOUT flattening the Sightings-specific behaviour.
+
+    Companion guards: TestSightingsVendorRowStatusTreatment pins the protected
+    red/green row_tint; TestDashboardCounters/TestBatchStatus/TestBatchNotes pin
+    the counters + action-bar handlers. Here we assert the new class strings AND
+    re-confirm the protected interactions co-exist in the same render.
+    """
+
+    # ── List table tokens ────────────────────────────────────────────
+    def test_table_th_uses_opp_col_header(self, client, db_session):
+        _seed_data(db_session)
+        resp = client.get("/v2/partials/sightings")
+        assert resp.status_code == 200
+        assert "opp-col-header" in resp.text  # Sales Hub column headers
+
+    def test_table_status_cell_is_opp_status_dot(self, client, db_session):
+        """Status column uses the dot+label opp_status_cell, not the old pill badge."""
+        _seed_data(db_session)
+        resp = client.get("/v2/partials/sightings")
+        assert resp.status_code == 200
+        assert "opp-status-dot" in resp.text
+
+    def test_table_coverage_uses_coverage_meter(self, client, db_session):
+        """Coverage column uses the 6-segment opp-coverage meter macro."""
+        _seed_data(db_session)
+        resp = client.get("/v2/partials/sightings")
+        assert resp.status_code == 200
+        assert "opp-coverage" in resp.text
+        assert "opp-coverage-seg" in resp.text
+
+    def test_kpi_counters_use_btn_shape(self, client, db_session):
+        """The Urgent/Stale/Pending counters adopt the .btn btn-sm btn-secondary shape
+        (no longer rounded-full pills)."""
+        _seed_data(db_session)
+        resp = client.get("/v2/partials/sightings")
+        assert resp.status_code == 200
+        assert "btn btn-sm btn-secondary" in resp.text
+
+    def test_group_by_select_uses_input_token(self, client, db_session):
+        _seed_data(db_session)
+        resp = client.get("/v2/partials/sightings")
+        assert resp.status_code == 200
+        assert 'class="input w-auto"' in resp.text
+
+    def test_grouped_label_uses_h4_token(self, client, db_session):
+        """Group-header label renders with the .h4 token when grouped."""
+        _seed_data(db_session)
+        resp = client.get("/v2/partials/sightings?group_by=manufacturer")
+        assert resp.status_code == 200
+        assert '<span class="h4">' in resp.text
+
+    # ── List table — PROTECTED interactions still render ─────────────
+    def test_table_keeps_selection_and_action_bar(self, client, db_session):
+        """The Sales Hub restyle must NOT drop the checkbox selection store nor the
+        multi-select action bar (Build RFQ / Refresh / Change Status / Add Note)."""
+        _seed_data(db_session)
+        resp = client.get("/v2/partials/sightings")
+        body = resp.text
+        assert "sightingSelection" in body  # selection store
+        assert "toggleAll" in body  # select-all checkbox
+        assert "req-checkbox" in body  # per-row checkbox
+        assert "Build RFQ (" in body  # action bar primary
+        assert "Refresh Sightings" in body  # action bar refresh
+        assert "Change Status" in body  # action bar status dropdown
+        assert "Add Note" in body  # action bar notes dropdown
+
+    # ── Detail panel tokens ──────────────────────────────────────────
+    def test_detail_header_is_flush_sales_hub(self, client, db_session):
+        """Part header adopts the flush requisitions2 header shell (px-5 py-3 + bg-
+        gray-50 + border-b) and the .h4 vendors heading."""
+        _, r, _ = _seed_data(db_session)
+        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
+        body = resp.text
+        assert resp.status_code == 200
+        assert "px-5 py-3 border-b border-gray-200 bg-gray-50" in body  # flush header
+        assert 'class="h4 mb-2"' in body  # vendors heading uses .h4
+
+    def test_detail_target_price_uses_figure_accent(self, client, db_session):
+        _, r, _ = _seed_data(db_session)
+        # _seed_data sets target_price via requirement? ensure a price is present
+        r.target_price = 2.5
+        db_session.commit()
+        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
+        assert resp.status_code == 200
+        assert "figure-accent" in resp.text  # target price + high score both use it
+
+    def test_detail_status_select_hx_patch_preserved(self, client, db_session):
+        """The Sightings-specific inline status <select> hx-patch must survive the
+        restyle (it is NOT replaced by the Sales Hub static status pill)."""
+        _, r, _ = _seed_data(db_session)
+        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
+        body = resp.text
+        assert resp.status_code == 200
+        assert "/advance-status" in body  # inline status select endpoint
+        assert 'hx-patch="/v2/partials/sightings/' in body
+
+    def test_detail_high_score_vendor_uses_figure_accent(self, client, db_session):
+        """A vendor scoring >= 70 renders its score with .figure-accent (was text-
+        emerald-600)."""
+        _, r, _ = _seed_data(db_session)  # seed sets score=75.0 (>= 70)
+        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
+        assert resp.status_code == 200
+        assert "figure-accent" in resp.text
+        # the old per-score emerald text token is gone from the score cell
+        assert "Good Vendor" in resp.text
+
+    # ── Offers / Activity panels self-pad (so the now-flush #sightings-detail
+    #    doesn't let their content hit the edge on a standalone innerHTML swap).
+    #    Both panels are included inline by /detail, so we assert their unique
+    #    content sits inside a px-5 py-3 root there. ──────────────────────────
+    def test_offers_panel_self_pads(self, client, db_session):
+        _, r, _ = _seed_data(db_session)
+        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
+        body = resp.text
+        assert resp.status_code == 200
+        # offers_panel root is px-5 py-3 immediately wrapping its "All offers for" heading
+        assert re.search(
+            r'<div class="px-5 py-3">\s*<div class="mb-3 flex items-center justify-between">\s*'
+            r'<h4 class="h4">\s*All offers for',
+            body,
+        )
+
+    def test_activity_panel_self_pads(self, client, db_session):
+        _, r, _ = _seed_data(db_session)
+        resp = client.get(f"/v2/partials/sightings/{r.id}/detail")
+        body = resp.text
+        assert resp.status_code == 200
+        # activity_section root is px-5 py-3 immediately wrapping its Activity heading
+        assert re.search(r'<div class="px-5 py-3">\s*<h4 class="h4 mb-2">Activity</h4>', body)


### PR DESCRIPTION
Restyles Sightings to the requisitions2 (Sales Hub) visual language, reusing its exact macros (opp_status_cell, coverage_meter, opp-col-header, .h4, .figure-accent). RED/GREEN vendor-availability rows + all sightings behavior preserved (test-confirmed). 325 sightings + 5094 broad sweep green. No migration. 🤖 Generated with [Claude Code](https://claude.com/claude-code)