### PR TITLE
feat(approvals): four-tab queue folded into the Buy Plans hub

### DIFF
--- a/app/routers/approvals.py
+++ b/app/routers/approvals.py
@@ -5,10 +5,14 @@ Purpose: HTTP surface for approval workflows. Returns JSON; HTMX partials can
            - app.services.approvals.service (decide)
            - app.services.approvals.events (reassign, cancel)
 
-         QP Phase C1: the engine OWNS the buy-plan gate, so list_requests and the
-         /v2/approvals/queue view are engine-only — a buy-plan submission surfaces here
-         as a native ApprovalRequest (gate_type=buy_plan, subject_type=buy_plan). The old
-         read-only buy-plan bridge has been retired.
+         QP Phase C1: the engine OWNS the buy-plan gate, so list_requests is engine-only —
+         a buy-plan submission surfaces as a native ApprovalRequest (gate_type=buy_plan,
+         subject_type=buy_plan). The old read-only buy-plan bridge has been retired.
+
+         The human-facing queue is now FOUR tabs (Buy Plans / Sales Orders / Purchase
+         Orders / Vendor Prepayments) folded into the Buy-Plans hub as its "approvals"
+         lens — rendered by routers/htmx_views.py via services/approvals/queue. The legacy
+         GET /v2/approvals/queue 302-redirects there.
 
 Called by: app.main (router registration).
 Depends on: app.services.approvals.service, app.services.approvals.events,
@@ -17,8 +21,8 @@ Depends on: app.services.approvals.service, app.services.approvals.events,
             app.constants, app.template_env.
 """
 
-from fastapi import APIRouter, Depends, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi import APIRouter, Depends, Form, HTTPException
+from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -29,7 +33,6 @@ from ..models.auth import User
 from ..services.approvals.events import cancel as svc_cancel
 from ..services.approvals.events import reassign as svc_reassign
 from ..services.approvals.service import decide as svc_decide
-from ..template_env import template_response
 
 router = APIRouter(tags=["approvals"])
 
@@ -160,27 +163,16 @@ def list_requests(
     return {"items": items, "total": len(items)}
 
 
-@router.get("/v2/approvals/queue", response_class=HTMLResponse)
-def get_queue(
-    request: Request,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(require_user),
-):
-    """Render the engine approvals queue as an HTMX partial.
+@router.get("/v2/approvals/queue")
+def get_queue(current_user: User = Depends(require_user)) -> RedirectResponse:
+    """Retired standalone queue — folded into the Buy Plans hub 'approvals' lens.
 
-    QP Phase C1: engine-only. Every pending approval — buy plans included — is an
-    ApprovalRequest, so the queue renders one table of engine rows. A buy_plan-subject row
-    links to its plan detail partial and offers inline approve/reject posting to the
-    engine's decision endpoint.
+    The four-tab approvals queue now renders as a Buy-Plans hub lens body (GET
+    /v2/partials/buy-plans/approvals). This route 302-redirects any deep link or old
+    bookmark to that lens so nothing 404s. The render + tab logic live in
+    services/approvals/queue.build_queue_view.
     """
-    engine_rows = db.execute(select(ApprovalRequest)).scalars().all()
-
-    ctx = {
-        "request": request,
-        "current_user": current_user,
-        "engine_requests": engine_rows,
-    }
-    return template_response("htmx/partials/approvals/_queue.html", ctx)
+    return RedirectResponse(url="/v2/buy-plans?lens=approvals", status_code=302)
 
 
 @router.get("/v2/approvals/requests/{id}")

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -461,6 +461,17 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
         # first full-page load instead of defaulting to Connectors.
         tab_qs = request.query_params.get("tab", "").strip()
         partial_url = f"/v2/partials/settings?tab={quote(tab_qs)}" if tab_qs else "/v2/partials/settings"
+    elif current_view == "buy-plans":
+        # Thread ?lens= through so a deep-link / redirect (the legacy /v2/approvals/queue
+        # → /v2/buy-plans?lens=approvals) and a reload/bookmark of a pushed lens URL paint
+        # the right lens on first full-page load instead of falling to _default_lens. A
+        # detail URL (/buy-plans/{id}) is overridden by the _DETAIL_VIEWS block below.
+        lens_qs = request.query_params.get("lens", "").strip()
+        partial_url = (
+            f"/v2/partials/buy-plans?lens={quote(lens_qs)}"
+            if lens_qs in ("orders", "deals", "supervise", "resource", "approvals")
+            else "/v2/partials/buy-plans"
+        )
     else:
         partial_url = f"/v2/partials/{current_view}"
     # Detail views: a trailing numeric id (/{view}/{id}) overrides the list partial with

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -10979,6 +10979,17 @@ def _can_resource(user: User) -> bool:
     return user.role in _PO_CUTTER_ROLES
 
 
+def _can_approve_any(user: User) -> bool:
+    """True when the user can approve at least one gate (sees the hub "Approvals"
+    lens)."""
+    return bool(
+        getattr(user, "can_approve_buy_plans", False)
+        or getattr(user, "can_approve_prepayments", False)
+        or getattr(user, "can_approve_sales_orders", False)
+        or getattr(user, "can_approve_pos", False)
+    )
+
+
 def _require_po_cutter(user: User) -> None:
     """403 unless the user is an active PO-cutter (buyer/manager/admin)."""
     if not _can_resource(user) or not getattr(user, "is_active", True):
@@ -11011,7 +11022,7 @@ async def buy_plans_list_partial(
     The shell renders only the lens switcher + a lazy body that loads the active
     lens partial into ``#bp-hub-body``. Row data is fetched by the body, not here.
     """
-    active_lens = lens if lens in ("orders", "deals", "supervise", "resource") else _default_lens(user, db)
+    active_lens = lens if lens in ("orders", "deals", "supervise", "resource", "approvals") else _default_lens(user, db)
 
     # Spotlight markers: plan rows that carry an open step needing this user's action.
     # Buy Plans is its own primary nav tab, so the source is registered under "buy-plans".
@@ -11026,9 +11037,33 @@ async def buy_plans_list_partial(
             "alert_markers": alert_markers,
             "can_supervise": _can_supervise(user, db),
             "can_resource": _can_resource(user),
+            "can_approve_any": _can_approve_any(user),
         }
     )
     return template_response("htmx/partials/buy_plans/hub.html", ctx)
+
+
+@router.get("/v2/partials/buy-plans/approvals", response_class=HTMLResponse)
+async def buy_plans_approvals_partial(
+    request: Request,
+    tab: str | None = None,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Approvals lens body — the four-tab engine approvals queue.
+
+    Buy Plans / Sales Orders / Purchase Orders / Vendor Prepayments, segmented by
+    gate_type. Approver-gated (any can_approve_* toggle). Renders into #bp-hub-body; its
+    sub-tabs swap back into the same container. ``tab`` absent → smart-default tab.
+    """
+    if not _can_approve_any(user):
+        raise HTTPException(403, "Approvals require an approver role")
+    from ..services.approvals.queue import build_queue_view
+
+    ctx = _base_ctx(request, user, "buy-plans")
+    ctx["view"] = build_queue_view(db, user, tab)
+    ctx["current_user"] = user
+    return template_response("htmx/partials/approvals/_queue.html", ctx)
 
 
 @router.get("/v2/partials/buy-plans/resource", response_class=HTMLResponse)

--- a/app/services/alerts/sources/__init__.py
+++ b/app/services/alerts/sources/__init__.py
@@ -18,7 +18,9 @@ register("buy-plans", BuyplanActionSource())  # Buy Plans is its own primary nav
 register("buy-plans", BuyplanResourcingSource())  # open re-sourcing pool (adds to the tab badge)
 register("crm", InboundCustomerSource())  # CRM — inbound from a customer
 register("my-day", TasksActionSource())  # My Day — open tasks assigned to me
-register("approvals", ApprovalRequestActionSource())  # Approvals — engine requests I must decide
+register(
+    "buy-plans", ApprovalRequestActionSource()
+)  # Approvals folded into the Buy Plans hub — count merges onto its badge
 
 __all__ = [
     "OfferConfirmedSource",

--- a/app/services/approvals/queue.py
+++ b/app/services/approvals/queue.py
@@ -1,0 +1,364 @@
+"""queue.py — read-side view-model builder for the four-tab approvals queue.
+
+Purpose: build_queue_view assembles everything the approvals lens body renders, with a
+         constant number of queries (no N+1 regardless of row count):
+           - four tabs segmented by ApprovalRequest.gate_type
+             (buy_plans / sales_orders / purchase_orders / prepayments);
+           - a Pending section (REQUESTED, org-wide) + a Recently-resolved section
+             (terminal statuses, capped, coalesce-ordered so cancelled rows with a NULL
+             resolved_at still sort sanely);
+           - per-tab pill counts that are ORG-WIDE pending totals;
+           - a smart-default tab (the gate with the most items awaiting THIS user; tie or
+             zero → Buy Plans) used only when no explicit tab is requested;
+           - per-row can_act (True only when the user is an eligible PENDING recipient —
+             mirrors the engine's decide() gate), plus the routed-to approver names so an
+             org-wide viewer sees who owns a request they cannot action.
+
+Called by: routers/approvals.py (get_queue) and the Buy-Plans hub "approvals" lens body
+           (routers/htmx_views.py).
+Depends on: models.approvals (ApprovalRequest/Step/StepRecipient), models.auth (User),
+            models.buy_plan (BuyPlan), models.quality_plan (QualityPlan, Prepayment),
+            models.sourcing (Requisition, via BuyPlan), app.constants enums. Reuses the
+            exact awaiting-me join from services/alerts/sources/approvals.py.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, joinedload
+
+from ...constants import (
+    ApprovalGateType,
+    ApprovalRecipientStatus,
+    ApprovalRequestStatus,
+    ApprovalSubjectType,
+)
+from ...models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
+from ...models.auth import User
+from ...models.buy_plan import BuyPlan
+from ...models.quality_plan import Prepayment, QualityPlan
+
+# tab key → gate_type. Order is the on-screen left-to-right order and the smart-default
+# tie-break order (leftmost wins).
+TAB_ORDER = ["buy_plans", "sales_orders", "purchase_orders", "prepayments"]
+TAB_GATE = {
+    "buy_plans": ApprovalGateType.BUY_PLAN,
+    "sales_orders": ApprovalGateType.SALES_ORDER,
+    "purchase_orders": ApprovalGateType.PURCHASE_ORDER,
+    "prepayments": ApprovalGateType.PREPAYMENT,
+}
+TAB_LABEL = {
+    "buy_plans": "Buy Plans",
+    "sales_orders": "Sales Orders",
+    "purchase_orders": "Purchase Orders",
+    "prepayments": "Vendor Prepayments",
+}
+DEFAULT_TAB = "buy_plans"
+
+RESOLVED_STATUSES = (
+    ApprovalRequestStatus.APPROVED,
+    ApprovalRequestStatus.REJECTED,
+    ApprovalRequestStatus.CANCELLED,
+    ApprovalRequestStatus.EXPIRED,
+)
+RESOLVED_LIMIT = 10
+# Defensive ceiling on the org-wide pending list (it is naturally self-clearing, but
+# never let a runaway backlog render an unbounded table). Oldest-first, so the work most
+# in need of a decision is never the part that gets hidden.
+PENDING_CAP = 200
+
+
+@dataclass
+class RowVM:
+    """One approval row, fully resolved for the template (no ORM access in Jinja)."""
+
+    id: int
+    gate_type: str
+    status: str
+    amount: Decimal | None
+    currency: str
+    created_at: datetime | None
+    resolved_at: datetime | None
+    resolution_note: str | None
+    subject_label: str
+    subject_href: str | None
+    requester_name: str
+    approver_names: str
+    parent_label: str | None
+    payment_method: str | None
+    can_act: bool
+
+
+@dataclass
+class QueueView:
+    """Everything the approvals lens body needs."""
+
+    active_tab: str
+    active_label: str = ""
+    tabs: list[dict] = field(default_factory=list)
+    pending_rows: list[RowVM] = field(default_factory=list)
+    resolved_rows: list[RowVM] = field(default_factory=list)
+
+
+def build_queue_view(db: Session, user: User, tab: str | None) -> QueueView:
+    """Assemble the QueueView for *user* on *tab* (smart-default when tab is absent)."""
+    active_tab = tab if tab in TAB_GATE else _smart_default_tab(db, user)
+    gate = TAB_GATE[active_tab]
+
+    pill_by_gate = _pending_counts_by_gate(db)
+    pending = _pending_rows(db, gate)
+    resolved = _resolved_rows(db, gate)
+
+    actionable = _actionable_request_ids(db, user)
+    pending_ids = [ar.id for ar in pending]
+    approver_names = _approver_names_by_request(db, pending_ids)
+    requester_names = _requester_names(db, pending + resolved)
+    subjects = _load_subjects(db, pending + resolved)
+
+    pending_vms = [
+        _row_vm(
+            ar,
+            pending=True,
+            actionable=actionable,
+            approver_names=approver_names,
+            requester_names=requester_names,
+            subjects=subjects,
+        )
+        for ar in pending
+    ]
+    resolved_vms = [
+        _row_vm(
+            ar,
+            pending=False,
+            actionable=actionable,
+            approver_names=approver_names,
+            requester_names=requester_names,
+            subjects=subjects,
+        )
+        for ar in resolved
+    ]
+
+    tabs = [{"key": k, "label": TAB_LABEL[k], "count": pill_by_gate.get(TAB_GATE[k], 0)} for k in TAB_ORDER]
+    return QueueView(
+        active_tab=active_tab,
+        active_label=TAB_LABEL[active_tab],
+        tabs=tabs,
+        pending_rows=pending_vms,
+        resolved_rows=resolved_vms,
+    )
+
+
+# ── Queries ──────────────────────────────────────────────────────────────
+
+
+def _pending_counts_by_gate(db: Session) -> dict[str, int]:
+    """Org-wide REQUESTED count per gate_type (drives the tab pills)."""
+    rows = db.execute(
+        select(ApprovalRequest.gate_type, func.count(ApprovalRequest.id))
+        .where(ApprovalRequest.status == ApprovalRequestStatus.REQUESTED)
+        .group_by(ApprovalRequest.gate_type)
+    ).all()
+    return {gate: count for gate, count in rows}
+
+
+def _awaiting_me_counts(db: Session, user: User) -> dict[str, int]:
+    """REQUESTED requests where *user* holds a PENDING recipient row, grouped by
+    gate."""
+    rows = db.execute(
+        select(ApprovalRequest.gate_type, func.count(func.distinct(ApprovalRequest.id)))
+        .join(ApprovalStep, ApprovalStep.request_id == ApprovalRequest.id)
+        .join(ApprovalStepRecipient, ApprovalStepRecipient.step_id == ApprovalStep.id)
+        .where(
+            ApprovalRequest.status == ApprovalRequestStatus.REQUESTED,
+            ApprovalStepRecipient.user_id == user.id,
+            ApprovalStepRecipient.status == ApprovalRecipientStatus.PENDING,
+        )
+        .group_by(ApprovalRequest.gate_type)
+    ).all()
+    return {gate: count for gate, count in rows}
+
+
+def _smart_default_tab(db: Session, user: User) -> str:
+    """Tab with the most items awaiting *user*; tie or zero → leftmost (Buy Plans)."""
+    counts = _awaiting_me_counts(db, user)
+    best_tab, best_count = DEFAULT_TAB, -1
+    for tab_key in TAB_ORDER:
+        c = counts.get(TAB_GATE[tab_key], 0)
+        if c > best_count:  # strict → leftmost wins on ties
+            best_tab, best_count = tab_key, c
+    return best_tab
+
+
+def _pending_rows(db: Session, gate) -> list[ApprovalRequest]:
+    return list(
+        db.execute(
+            select(ApprovalRequest)
+            .where(ApprovalRequest.status == ApprovalRequestStatus.REQUESTED, ApprovalRequest.gate_type == gate)
+            .order_by(ApprovalRequest.created_at.asc(), ApprovalRequest.id.asc())
+            .limit(PENDING_CAP)
+        ).scalars()
+    )
+
+
+def _resolved_rows(db: Session, gate) -> list[ApprovalRequest]:
+    # coalesce(resolved_at, updated_at, created_at): cancelled rows never set resolved_at,
+    # so a bare resolved_at order would scatter them — portable across PG and SQLite.
+    order_key = func.coalesce(ApprovalRequest.resolved_at, ApprovalRequest.updated_at, ApprovalRequest.created_at)
+    return list(
+        db.execute(
+            select(ApprovalRequest)
+            .where(ApprovalRequest.status.in_(RESOLVED_STATUSES), ApprovalRequest.gate_type == gate)
+            .order_by(order_key.desc(), ApprovalRequest.id.desc())
+            .limit(RESOLVED_LIMIT)
+        ).scalars()
+    )
+
+
+def _actionable_request_ids(db: Session, user: User) -> set[int]:
+    """Request ids *user* may decide (REQUESTED + a PENDING recipient row) — mirrors
+    decide()."""
+    return set(
+        db.execute(
+            select(ApprovalRequest.id)
+            .join(ApprovalStep, ApprovalStep.request_id == ApprovalRequest.id)
+            .join(ApprovalStepRecipient, ApprovalStepRecipient.step_id == ApprovalStep.id)
+            .where(
+                ApprovalRequest.status == ApprovalRequestStatus.REQUESTED,
+                ApprovalStepRecipient.user_id == user.id,
+                ApprovalStepRecipient.status == ApprovalRecipientStatus.PENDING,
+            )
+            .distinct()
+        ).scalars()
+    )
+
+
+def _approver_names_by_request(db: Session, request_ids: list[int]) -> dict[int, list[str]]:
+    """For each request id, the names of its PENDING recipients (the routed-to
+    approvers)."""
+    if not request_ids:
+        return {}
+    rows = db.execute(
+        select(ApprovalStep.request_id, User.name)
+        .join(ApprovalStepRecipient, ApprovalStepRecipient.step_id == ApprovalStep.id)
+        .join(User, User.id == ApprovalStepRecipient.user_id)
+        .where(
+            ApprovalStep.request_id.in_(request_ids),
+            ApprovalStepRecipient.status == ApprovalRecipientStatus.PENDING,
+        )
+    ).all()
+    out: dict[int, list[str]] = defaultdict(list)
+    for req_id, name in rows:
+        out[req_id].append(name or "—")
+    return out
+
+
+def _requester_names(db: Session, rows: list[ApprovalRequest]) -> dict[int, str]:
+    ids = {ar.requested_by_id for ar in rows if ar.requested_by_id}
+    if not ids:
+        return {}
+    return {uid: (name or "—") for uid, name in db.execute(select(User.id, User.name).where(User.id.in_(ids))).all()}
+
+
+def _load_subjects(db: Session, rows: list[ApprovalRequest]) -> dict[tuple[str, int], object]:
+    """Batch-load subject objects keyed by (subject_type, subject_id).
+
+    One query per type.
+    """
+    by_type: dict[str, set[int]] = defaultdict(set)
+    for ar in rows:
+        if ar.subject_type and ar.subject_id:
+            by_type[ar.subject_type].add(ar.subject_id)
+
+    subjects: dict[tuple[str, int], object] = {}
+
+    bp_ids = by_type.get(ApprovalSubjectType.BUY_PLAN)
+    if bp_ids:
+        for bp in db.execute(select(BuyPlan).where(BuyPlan.id.in_(bp_ids))).scalars():
+            subjects[(ApprovalSubjectType.BUY_PLAN, bp.id)] = bp
+
+    qp_ids = by_type.get(ApprovalSubjectType.QUALITY_PLAN)
+    if qp_ids:
+        qps = (
+            db.execute(
+                select(QualityPlan)
+                .options(joinedload(QualityPlan.buy_plan).joinedload(BuyPlan.requisition))
+                .where(QualityPlan.id.in_(qp_ids))
+            )
+            .unique()
+            .scalars()
+        )
+        for qp in qps:
+            subjects[(ApprovalSubjectType.QUALITY_PLAN, qp.id)] = qp
+
+    pp_ids = by_type.get(ApprovalSubjectType.PREPAYMENT)
+    if pp_ids:
+        pps = (
+            db.execute(select(Prepayment).options(joinedload(Prepayment.vendor_card)).where(Prepayment.id.in_(pp_ids)))
+            .unique()
+            .scalars()
+        )
+        for pp in pps:
+            subjects[(ApprovalSubjectType.PREPAYMENT, pp.id)] = pp
+
+    return subjects
+
+
+# ── Assembly ─────────────────────────────────────────────────────────────
+
+
+def _resolve_subject(ar: ApprovalRequest, subjects: dict) -> tuple[str, str | None, str | None, str | None]:
+    """Return (subject_label, subject_href, parent_label, payment_method) for a row."""
+    obj = subjects.get((ar.subject_type, ar.subject_id)) if ar.subject_id else None
+
+    if obj is not None and ar.subject_type == ApprovalSubjectType.BUY_PLAN:
+        return f"Plan #{ar.subject_id}", f"/v2/partials/buy-plans/{ar.subject_id}", None, None
+
+    if obj is not None and ar.subject_type == ApprovalSubjectType.QUALITY_PLAN:
+        parent = None
+        bp = getattr(obj, "buy_plan", None)
+        req = getattr(bp, "requisition", None) if bp is not None else None
+        if req is not None:
+            parent = req.customer_name or req.name
+        return f"QP #{ar.subject_id}", f"/v2/qp/{ar.subject_id}", parent, None
+
+    if obj is not None and ar.subject_type == ApprovalSubjectType.PREPAYMENT:
+        vendor = obj.vendor_card.display_name if obj.vendor_card else f"Prepayment #{ar.subject_id}"
+        href = f"/v2/partials/buy-plans/{obj.buy_plan_id}" if obj.buy_plan_id else None
+        return vendor, href, None, obj.payment_method
+
+    # Deleted/missing subject → audit-safe fallback, no link.
+    return f"Request #{ar.id}", None, None, None
+
+
+def _row_vm(
+    ar: ApprovalRequest,
+    *,
+    pending: bool,
+    actionable: set[int],
+    approver_names: dict[int, list[str]],
+    requester_names: dict[int, str],
+    subjects: dict,
+) -> RowVM:
+    subject_label, subject_href, parent_label, payment_method = _resolve_subject(ar, subjects)
+    return RowVM(
+        id=ar.id,
+        gate_type=ar.gate_type,
+        status=ar.status,
+        amount=ar.amount,
+        currency=ar.currency or "USD",
+        created_at=ar.created_at,
+        resolved_at=ar.resolved_at,
+        resolution_note=ar.resolution_note,
+        subject_label=subject_label,
+        subject_href=subject_href,
+        requester_name=requester_names.get(ar.requested_by_id, "—") if ar.requested_by_id else "—",
+        approver_names=(", ".join(approver_names.get(ar.id, [])) or "—") if pending else "—",
+        parent_label=parent_label,
+        payment_method=payment_method,
+        can_act=pending and ar.id in actionable,
+    )

--- a/app/templates/htmx/partials/approvals/_macros.html
+++ b/app/templates/htmx/partials/approvals/_macros.html
@@ -1,0 +1,92 @@
+{#
+  approvals/_macros.html — row + empty-state macros for the four-tab approvals queue.
+
+  Purpose: render one ApprovalRequest row (RowVM) for the Pending or Recently-resolved
+           table, and the per-tab empty state. Pending rows show inline approve/reject
+           ONLY when row.can_act (the user is an eligible PENDING recipient — mirrors the
+           engine's decide() gate); otherwise they show the routed-to approver names.
+
+  Used by: approvals/_queue.html.
+  Depends on: shared/_macros.html (btn_primary/btn_danger — canonical .btn-sm sizing),
+              .compact-table from styles.css, the accent palette.
+
+  Note: approve/reject POST to the engine decision endpoint, then re-fetch the active tab
+  back into #bp-hub-body (the hub lens body) so the user stays on the same sub-tab.
+#}
+{% from "htmx/partials/shared/_macros.html" import btn_primary, btn_danger %}
+
+
+{% macro _status_pill(status) -%}
+<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+  {% if status == 'approved' %}bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200
+  {% elif status == 'rejected' %}bg-red-50 text-red-700 ring-1 ring-inset ring-red-200
+  {% elif status == 'cancelled' %}bg-gray-100 text-gray-600 ring-1 ring-inset ring-gray-200
+  {% elif status == 'expired' %}bg-gray-100 text-gray-500 ring-1 ring-inset ring-gray-200
+  {% else %}bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200{% endif %}">
+  {{ status | title }}
+</span>
+{%- endmacro %}
+
+
+{% macro _subject_cell(row) -%}
+{% if row.subject_href %}
+{# Subject link navigates to the subject's detail (replaces the page) — explicit
+   hx-target so it never inherits #main-content's hx-target="this" ambiguously. #}
+<a href="{{ row.subject_href }}"
+   hx-get="{{ row.subject_href }}"
+   hx-target="#main-content"
+   hx-push-url="false"
+   class="font-medium text-brand-600 hover:text-brand-800">{{ row.subject_label }}</a>
+{% else %}
+<span class="text-gray-700">{{ row.subject_label }}</span>
+{% endif %}
+{% if row.parent_label %}<div class="text-[11px] text-gray-400">{{ row.parent_label }}</div>{% endif %}
+{% if row.payment_method %}<div class="text-[11px] text-gray-400">{{ row.payment_method | title }}</div>{% endif %}
+{%- endmacro %}
+
+
+{% macro approval_row(row, pending, active_tab) -%}
+{% set refetch = "if(event.detail.successful) htmx.ajax('GET','/v2/partials/buy-plans/approvals?tab=" ~ active_tab ~ "',{target:'#bp-hub-body',indicator:'#approvals-queue'})" %}
+<tr>
+  <td class="td-label">{{ _subject_cell(row) }}</td>
+  <td>{% if row.amount is not none %}${{ "{:,.2f}".format(row.amount) }}{% else %}—{% endif %}</td>
+  <td class="td-label text-gray-600">{{ row.requester_name }}</td>
+  {% if pending %}
+  <td class="td-label text-right">
+    {% if row.can_act %}
+    <div class="inline-flex items-center gap-1.5">
+      {{ btn_primary('Approve', {
+        'hx-post': '/v2/approvals/requests/' ~ row.id ~ '/decision',
+        'hx-vals': "js:{action: 'approve'}",
+        'hx-swap': 'none',
+        'hx-on::after-request': refetch
+      }) }}
+      {{ btn_danger('Reject', {
+        'hx-post': '/v2/approvals/requests/' ~ row.id ~ '/decision',
+        'hx-vals': "js:{action: 'reject', comment: prompt('Reason for rejection?') || ''}",
+        'hx-swap': 'none',
+        'hx-on::after-request': refetch
+      }) }}
+    </div>
+    {% else %}
+    <span class="text-xs text-gray-400">Routed to {{ row.approver_names }}</span>
+    {% endif %}
+  </td>
+  {% else %}
+  <td>{{ _status_pill(row.status) }}</td>
+  <td class="text-gray-500 text-xs">
+    {{ row.resolved_at.strftime('%Y-%m-%d') if row.resolved_at else (row.created_at.strftime('%Y-%m-%d') if row.created_at else '—') }}
+  </td>
+  {% endif %}
+</tr>
+{%- endmacro %}
+
+
+{% macro empty_state(label) -%}
+<div class="rounded-lg border border-gray-200 bg-white px-6 py-10 text-center">
+  <svg class="mx-auto h-10 w-10 text-emerald-300 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+  </svg>
+  <p class="text-sm text-gray-600">No {{ label | lower }} awaiting approval.</p>
+</div>
+{%- endmacro %}

--- a/app/templates/htmx/partials/approvals/_queue.html
+++ b/app/templates/htmx/partials/approvals/_queue.html
@@ -1,115 +1,95 @@
 {#
-  approvals/_queue.html — Engine approvals queue: every pending approval is an ApprovalRequest.
+  approvals/_queue.html — Four-tab approvals queue (the Buy-Plans hub "approvals" lens body).
 
-  Purpose: Single view for approvers to see all pending approval items. Every row is an
-           engine ApprovalRequest (prepayments, buy plans, …) actioned inline against the
-           engine's decision endpoint. QP Phase C1 retired the read-only buy-plan bridge:
-           a buy-plan submission now surfaces here as a native buy_plan-subject request,
-           and its Subject cell links to the plan detail partial.
+  Purpose: segment every engine ApprovalRequest into four tabs by gate_type — Buy Plans /
+           Sales Orders / Purchase Orders / Vendor Prepayments. Each tab shows a Pending
+           section (inline approve/reject for eligible recipients) and a Recently-resolved
+           read-only section. Per-tab pills are ORG-WIDE pending counts. The view opens on
+           the smart-default tab (most awaiting the current user) when no tab is requested.
 
   Receives:
-    engine_requests (list[ApprovalRequest]) — engine approval requests (any status).
-    current_user    (User)                  — authenticated user.
-    request         (Request)               — FastAPI request (required by template_response).
+    view         (services.approvals.queue.QueueView) — active_tab/active_label/tabs/
+                 pending_rows/resolved_rows, all pre-resolved (no ORM access here).
+    current_user (User)    — authenticated user.
+    request      (Request) — required by template_response.
 
-  Called by: routers/approvals.py → GET /v2/approvals/queue.
-  Depends on: Tailwind CSS, HTMX, app accent palette, .compact-table from styles.css,
-              shared/_macros.html (btn_primary/btn_danger — canonical .btn-sm sizing).
+  Rendered into #bp-hub-body by routers/htmx_views.py → GET /v2/partials/buy-plans/approvals.
+  LANDMINE: the sub-tabs swap into #bp-hub-body (NOT #main-content) — an explicit hx-target
+  is mandatory inside the hub or the swap inherits #main-content's hx-target="this" and
+  wipes the page (see buy_plans/hub.html).
+  Depends on: approvals/_macros.html, Tailwind + accent palette, .compact-table, HTMX.
 #}
-{% from "htmx/partials/shared/_macros.html" import btn_primary, btn_danger %}
+{% from "htmx/partials/approvals/_macros.html" import approval_row, empty_state %}
 
-{# Count only OPEN (requested) rows for the "pending" header — resolved rows still render
-   below (with a View link) but are not "pending". #}
-{% set pending_count = engine_requests | selectattr('status', 'equalto', 'requested') | list | length %}
-<div id="approvals-queue" class="page-fluid">
-  <div class="flex items-center justify-between mb-5">
-    <div>
-      <h2 class="text-lg font-semibold text-gray-900">Approvals Queue</h2>
-      <p class="text-sm text-gray-600 mt-0.5">
-        {{ pending_count }} item{{ 's' if pending_count != 1 }} pending
-      </p>
-    </div>
+<div id="approvals-queue">
+
+  {# ── Tab strip (segment by gate_type) — sub-tabs swap into the hub lens body ── #}
+  <div class="flex flex-wrap gap-2 mb-4" role="tablist">
+    {% for t in view.tabs %}
+    <a hx-get="/v2/partials/buy-plans/approvals?tab={{ t.key }}"
+       hx-target="#bp-hub-body"
+       hx-swap="innerHTML"
+       hx-push-url="false"
+       role="tab"
+       aria-selected="{{ 'true' if view.active_tab == t.key else 'false' }}"
+       class="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-colors focus:outline-none focus:ring-2"
+       style="{% if view.active_tab == t.key %}background-color:var(--accent);color:var(--accent-contrast);--tw-ring-color:var(--accent-ring);{% else %}background-color:#f3f4f6;color:#374151;border:1px solid #d1d5db;--tw-ring-color:var(--accent-ring);{% endif %}">
+      {{ t.label }}
+      {% if t.count > 0 %}
+      <span class="badge-warning ml-1 text-[11px] font-bold px-1.5 py-0.5">{{ t.count }}</span>
+      {% endif %}
+    </a>
+    {% endfor %}
   </div>
 
-  {% if engine_requests|length == 0 %}
-  <div class="rounded-lg border border-gray-200 bg-white px-6 py-10 text-center">
-    <p class="text-sm text-gray-600">No pending approvals.</p>
-  </div>
+  {% if not view.pending_rows and not view.resolved_rows %}
+  {{ empty_state(view.active_label) }}
   {% else %}
-  <div class="rounded-lg border border-gray-200 bg-white overflow-hidden">
+
+  {# ── Pending ── #}
+  {% if view.pending_rows %}
+  <h3 class="text-sm font-semibold text-gray-900 mb-2">
+    Pending <span class="text-gray-400 font-normal">({{ view.pending_rows | length }})</span>
+  </h3>
+  <div class="rounded-lg border border-gray-200 bg-white overflow-hidden mb-6">
     <table class="compact-table">
       <thead>
         <tr>
-          <th class="text-left">Type</th>
           <th class="text-left">Subject</th>
           <th class="text-left">Amount</th>
-          <th class="text-left">Status</th>
-          <th class="text-left">Created</th>
+          <th class="text-left">Requested by</th>
           <th></th>
         </tr>
       </thead>
       <tbody>
-
-        {# ── Engine ApprovalRequest rows ── #}
-        {% for ar in engine_requests %}
-        <tr>
-          <td class="td-label">
-            <span class="inline-flex items-center rounded-full bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700 ring-1 ring-inset ring-brand-200">
-              {{ ar.gate_type | replace('_', ' ') | title }}
-            </span>
-          </td>
-          <td class="td-label text-gray-700">
-            {% if ar.subject_type == 'buy_plan' and ar.subject_id %}
-            {# Buy-plan subject: link to the plan detail partial (read-context for the approver). #}
-            <a href="/v2/partials/buy-plans/{{ ar.subject_id }}"
-               hx-get="/v2/partials/buy-plans/{{ ar.subject_id }}"
-               hx-target="#main-content"
-               hx-push-url="false"
-               class="font-medium text-brand-600 hover:text-brand-800">Plan #{{ ar.subject_id }}</a>
-            {% else %}
-            Request #{{ ar.id }}
-            {% endif %}
-          </td>
-          <td>{% if ar.amount %}${{ "{:,.2f}".format(ar.amount) }}{% else %}—{% endif %}</td>
-          <td class="td-label">
-            <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
-              {% if ar.status == 'approved' %}bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200
-              {% elif ar.status == 'rejected' %}bg-red-50 text-red-700 ring-1 ring-inset ring-red-200
-              {% else %}bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200{% endif %}">
-              {{ ar.status | title }}
-            </span>
-          </td>
-          <td>{{ ar.created_at.strftime('%Y-%m-%d') if ar.created_at else '—' }}</td>
-          <td class="td-label text-right">
-            {% if ar.status == 'requested' %}
-            {# Inline approve/reject against the engine decision endpoint (returns JSON), then
-               re-fetch the whole queue into #main-content on success. The refresh htmx.ajax
-               carries an indicator: (HTMX 2.x doesn't auto-read hx-indicator for imperative
-               calls). A 403 (not a pending recipient) is fail-quiet: the queue is unchanged. #}
-            <div class="inline-flex items-center gap-1.5">
-              {{ btn_primary('Approve', {
-                'hx-post': '/v2/approvals/requests/' ~ ar.id ~ '/decision',
-                'hx-vals': "js:{action: 'approve'}",
-                'hx-swap': 'none',
-                'hx-on::after-request': "if(event.detail.successful) htmx.ajax('GET','/v2/approvals/queue',{target:'#main-content',indicator:'#approvals-queue'})"
-              }) }}
-              {{ btn_danger('Reject', {
-                'hx-post': '/v2/approvals/requests/' ~ ar.id ~ '/decision',
-                'hx-vals': "js:{action: 'reject', comment: prompt('Reason for rejection?') || ''}",
-                'hx-swap': 'none',
-                'hx-on::after-request': "if(event.detail.successful) htmx.ajax('GET','/v2/approvals/queue',{target:'#main-content',indicator:'#approvals-queue'})"
-              }) }}
-            </div>
-            {% else %}
-            <a href="/v2/approvals/requests/{{ ar.id }}"
-               class="text-xs font-medium text-brand-600 hover:text-brand-800">View</a>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-
+        {% for row in view.pending_rows %}{{ approval_row(row, True, view.active_tab) }}{% endfor %}
       </tbody>
     </table>
   </div>
+  {% else %}
+  <p class="text-sm text-gray-500 mb-6">Nothing pending right now.</p>
+  {% endif %}
+
+  {# ── Recently resolved (read-only history) ── #}
+  {% if view.resolved_rows %}
+  <h3 class="text-sm font-semibold text-gray-900 mb-2">Recently resolved</h3>
+  <div class="rounded-lg border border-gray-200 bg-white overflow-hidden">
+    <table class="compact-table">
+      <thead>
+        <tr>
+          <th class="text-left">Subject</th>
+          <th class="text-left">Amount</th>
+          <th class="text-left">Requested by</th>
+          <th class="text-left">Status</th>
+          <th class="text-left">Resolved</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in view.resolved_rows %}{{ approval_row(row, False, view.active_tab) }}{% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/buy_plans/hub.html
+++ b/app/templates/htmx/partials/buy_plans/hub.html
@@ -14,8 +14,8 @@
   {# ── Lens switcher ──
      Supervise is gated: only managers/admins/ops (can_supervise) see the button. #}
   <div class="flex items-center gap-2 mb-5">
-    {% for l, label in [('deals', 'My Deals'), ('orders', 'My Orders'), ('resource', 'Needs Re-sourcing'), ('supervise', 'Supervise')] %}
-    {% if (l != 'supervise' or can_supervise) and (l != 'resource' or can_resource) %}
+    {% for l, label in [('deals', 'My Deals'), ('orders', 'My Orders'), ('resource', 'Needs Re-sourcing'), ('approvals', 'Approvals'), ('supervise', 'Supervise')] %}
+    {% if (l != 'supervise' or can_supervise) and (l != 'resource' or can_resource) and (l != 'approvals' or can_approve_any) %}
     {# Highlight is Alpine-reactive (:class on lens) so the active pill updates the
        instant a lens is clicked — before the server swap returns — and stays correct
        after the re-rendered hub re-inits x-data with the server lens. Mirrors the
@@ -44,6 +44,7 @@
        hx-get="{{ '/v2/partials/buy-plans/orders' if lens == 'orders'
                  else '/v2/partials/buy-plans/supervise' if lens == 'supervise'
                  else '/v2/partials/buy-plans/resource' if lens == 'resource'
+                 else '/v2/partials/buy-plans/approvals' if lens == 'approvals'
                  else '/v2/partials/buy-plans/board?scope=mine' }}"
        hx-trigger="load"
        hx-target="#bp-hub-body"

--- a/app/templates/htmx/partials/shared/mobile_nav.html
+++ b/app/templates/htmx/partials/shared/mobile_nav.html
@@ -11,7 +11,7 @@
        moreOpen: false,
        activeNav: '{{ current_view }}',
        urlToNav(url) {
-         const map = {'/v2/requisitions':'requisitions','/v2/sightings':'sightings','/v2/materials':'materials','/v2/search':'search','/v2/buy-plans':'buy-plans','/v2/resell':'resell','/v2/crm':'crm','/v2/customers':'crm','/v2/contacts':'crm','/v2/vendor-contacts':'crm','/v2/vendors':'crm','/v2/proactive':'proactive','/v2/prospecting':'prospecting','/v2/my-day':'my-day','/v2/approvals':'approvals','/v2/settings':'settings'};
+         const map = {'/v2/requisitions':'requisitions','/v2/sightings':'sightings','/v2/materials':'materials','/v2/search':'search','/v2/buy-plans':'buy-plans','/v2/resell':'resell','/v2/crm':'crm','/v2/customers':'crm','/v2/contacts':'crm','/v2/vendor-contacts':'crm','/v2/vendors':'crm','/v2/proactive':'proactive','/v2/prospecting':'prospecting','/v2/my-day':'my-day','/v2/approvals':'buy-plans','/v2/settings':'settings'};
          for (const [prefix, id] of Object.entries(map)) { if (url.startsWith(prefix)) return id; }
          return this.activeNav;
        }
@@ -41,10 +41,11 @@
       ('prospecting', 'Prospect', '/v2/prospecting', '/v2/partials/prospecting',
        'M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7'),
       ('my-day', 'Tasks', '/v2/my-day', '/v2/partials/my-day',
-       'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z'),
-      ('approvals', 'Approvals', '/v2/approvals/queue', '/v2/approvals/queue',
-       'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z')
+       'M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z')
     ] %}
+    {# 'Approvals' is no longer a top-level nav item — it is folded into the Buy Plans hub
+       as the "Approvals" lens, and its alert count is merged onto the Buy Plans badge
+       (ApprovalRequestActionSource re-registered under the "buy-plans" tab). #}
     {% for id, label, href, partial, icon_path in nav_items %}
     {# Per-user nav gate: hide a section the user lacks access to. `access` is a
        {nav-id: bool} map from _base_ctx; default-show if it's somehow absent. #}
@@ -73,7 +74,7 @@
               hx-swap="innerHTML"
               hx-push-url="false"
               class="absolute -top-1.5 -right-2 flex items-center justify-center min-w-[14px] h-[14px]"></span>
-        {% elif id in ('requisitions', 'buy-plans', 'crm', 'my-day', 'approvals') %}
+        {% elif id in ('requisitions', 'buy-plans', 'crm', 'my-day') %}
         {# Cross-app alert badge — same emerald pill as proactive, fed by the AlertSource registry #}
         <span id="{{ id }}-nav-badge"
               hx-get="/v2/partials/alerts/{{ id }}/badge"

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1326,11 +1326,13 @@ flow. See APP_MAP_DATABASE `po_cancellations`.
 **Buy Plan Deal Hub — role-lens read flow.** `/v2/buy-plans` is its own primary-nav
 tab rendering a lens shell (`partials/buy_plans/hub.html`): a lens switcher + a lazy
 `#bp-hub-body` that loads the active lens body. The shell route
-`GET /v2/partials/buy-plans?lens=` resolves the lens (`deals`/`orders`/`supervise`),
-falling back to a **role-derived default** (`_default_lens`): managers/admins/ops →
-Supervise, buyers → My Orders, everyone else → My Deals. The Supervise button + lens
-are gated by `_can_supervise` (manager/admin OR ops verification-group member); a
-non-supervisor who requests it is served the mine-scope board (defense in depth).
+`GET /v2/partials/buy-plans?lens=` resolves the lens
+(`deals`/`orders`/`resource`/`approvals`/`supervise`), falling back to a **role-derived
+default** (`_default_lens`): managers/admins/ops → Supervise, buyers → My Orders, everyone
+else → My Deals. The Supervise button + lens are gated by `_can_supervise` (manager/admin
+OR ops verification-group member); Needs Re-sourcing by `_can_resource` (PO-cutter); and
+**Approvals** by `_can_approve_any` (any `can_approve_*` toggle). A user who requests a
+lens they lack is served a safe fallback / 403 (defense in depth).
 
 ```
 GET /v2/partials/buy-plans?lens=          (shell: switcher + lazy #bp-hub-body)
@@ -1350,6 +1352,11 @@ GET /v2/partials/buy-plans?lens=          (shell: switcher + lazy #bp-hub-body)
     |                        + buyplan_hub.team_line_queue (read-only "Team Orders"
     |                        awareness section: other buyers' open AWAITING_PO/
     |                        PENDING_VERIFY lines; no action affordances)
+    +-- lens=approvals --> GET /partials/buy-plans/approvals?tab=
+    |                        services/approvals/queue.build_queue_view (four sub-tabs by
+    |                        gate_type: buy_plans/sales_orders/purchase_orders/prepayments;
+    |                        Pending + Recently-resolved; smart-default tab; sub-tabs swap
+    |                        back into #bp-hub-body). Approver-gated (_can_approve_any).
     +-- lens=supervise --> GET /partials/buy-plans/supervise
                              services/buyplan_hub.supervise_overview (triage strip:
                              approvals / SO+PO verify / overdue / flagged / halted)
@@ -5218,14 +5225,28 @@ ONLY pending plans with **no open `BUY_PLAN` `ApprovalRequest`**, so a post-C1 p
 on the **Approvals** badge alone (no double-count) while a pre-C1 transition-window plan (no
 engine request) still surfaces on the buy-plans badge and never goes invisible.
 
-The **read-only buy-plan bridge is RETIRED** (C1). `list_requests`/`get_queue`
-(`routers/approvals.py`) are engine-only: a buy plan surfaces as a native `ApprovalRequest`
-(`gate_type=buy_plan`, `subject_type=buy_plan`). `_serialize_request(r)` is the single
-11-field engine-item projection shared by `list_requests` + `get_request` (now carrying
-`subject_type`/`subject_id` so a `buy_plan` request links back to its plan detail partial).
-The `/v2/approvals/queue` partial renders one engine table with inline approve/reject for
-`requested` rows posting to the decision endpoint; a `buy_plan`-subject row links to
-`/v2/partials/buy-plans/{subject_id}`. An **Approvals** primary-nav item
-(`mobile_nav.html` → `/v2/approvals/queue`) surfaces the queue, with an emerald badge fed by
-`ApprovalRequestActionSource` (tab `approvals`, `AlertKind.APPROVAL_ACTION`) counting open
-requests where the user is a PENDING recipient.
+The **read-only buy-plan bridge is RETIRED** (C1). `list_requests` (`routers/approvals.py`)
+is engine-only: a buy plan surfaces as a native `ApprovalRequest` (`gate_type=buy_plan`,
+`subject_type=buy_plan`). `_serialize_request(r)` is the single 11-field engine-item
+projection shared by `list_requests` + `get_request` (carrying `subject_type`/`subject_id`).
+
+**Approvals = four tabs, folded into the Buy Plans hub.** The human-facing queue is no
+longer a standalone nav item. It is the **"Approvals" lens** of the Buy-Plans Deal Hub
+(`partials/buy_plans/hub.html`), gated to approvers (`_can_approve_any` — any
+`can_approve_*` toggle). The lens body route `GET /v2/partials/buy-plans/approvals?tab=`
+(`routers/htmx_views.py`) calls `services/approvals/queue.build_queue_view(db, user, tab)`
+and renders `partials/approvals/_queue.html` into `#bp-hub-body`. The view segments every
+`ApprovalRequest` by `gate_type` into four sub-tabs — **Buy Plans / Sales Orders / Purchase
+Orders / Vendor Prepayments** — each a **Pending** section (inline approve/reject) over a
+**Recently-resolved** section (terminal statuses, capped at 10, ordered by
+`coalesce(resolved_at, updated_at, created_at) desc` so a cancelled row with a NULL
+`resolved_at` still sorts sanely). Subjects resolve by `subject_type` (buy_plan→`Plan #` /
+plan detail, quality_plan→`QP #` / `/v2/qp/{id}` with the parent deal as a sub-label,
+prepayment→vendor + payment method, linking the parent buy plan). Visibility is **org-wide**
+(every request of that type), but approve/reject render only when the user is an eligible
+PENDING recipient (`can_act`, mirroring `decide()`); otherwise the routed-to approver names
+show. Per-tab pills are org-wide REQUESTED counts; with no `?tab=`, the server opens the
+**smart-default** tab (most awaiting the user; tie/zero → Buy Plans). The legacy
+`GET /v2/approvals/queue` now **302-redirects** to `/v2/buy-plans?lens=approvals`.
+`ApprovalRequestActionSource` (`AlertKind.APPROVAL_ACTION`) is registered under the
+**`buy-plans`** tab, so its "awaiting me" count merges onto the Buy Plans nav badge.

--- a/tests/test_approvals_bridge.py
+++ b/tests/test_approvals_bridge.py
@@ -11,8 +11,9 @@ Covers:
   - Filtering gate_type=buy_plan returns exactly the buy-plan requests.
   - A pending BuyPlan with NO ApprovalRequest (pre-C1 / unrouted) does NOT appear — the
     queue is engine-only.
-  - GET /v2/approvals/queue renders HTML; a buy_plan-subject row links to the plan detail
-    partial (/v2/partials/buy-plans/{id}) and the queue still renders for prepayment rows.
+  - The four-tab approvals queue (Buy-Plans hub "approvals" lens body,
+    /v2/partials/buy-plans/approvals) renders HTML; a buy_plan-subject row links to the
+    plan detail partial, Pending/Recently-resolved split, and prepayment rows render.
 
 Called by: pytest
 Depends on: conftest (db_session), app.routers.approvals, app.models.approvals,
@@ -224,8 +225,8 @@ class TestEngineNativeQueue:
         ids = {i["id"] for i in body["items"]}
         assert {bp_ar.id, pp_ar.id} <= ids
 
-    def test_queue_html_links_buy_plan_subject_to_detail(self, db_session: Session) -> None:
-        """GET /v2/approvals/queue renders HTML; a buy_plan-subject row links to the
+    def test_lens_links_buy_plan_subject_to_detail(self, db_session: Session) -> None:
+        """The Buy Plans approvals tab renders HTML; a buy_plan-subject row links to the
         plan detail partial."""
         user = _make_user(db_session)
         bp = _make_buy_plan(db_session, user, status="pending")
@@ -233,36 +234,39 @@ class TestEngineNativeQueue:
         db_session.commit()
 
         for client in _build_client(db_session, user):
-            resp = client.get("/v2/approvals/queue")
+            resp = client.get("/v2/partials/buy-plans/approvals?tab=buy_plans")
 
         assert resp.status_code == 200
         assert "text/html" in resp.headers.get("content-type", "")
         assert f"/v2/partials/buy-plans/{bp.id}" in resp.text
 
-    def test_queue_header_counts_only_open_requests(self, db_session: Session) -> None:
-        """The 'N items pending' header counts only REQUESTED rows — a resolved request
-        renders (with a View link) but must not inflate the pending count."""
+    def test_lens_splits_pending_and_resolved(self, db_session: Session) -> None:
+        """A REQUESTED row lands in Pending; a resolved row lands in Recently resolved —
+        the two sections are distinct (a resolved row never inflates Pending)."""
         user = _make_user(db_session)
         bp = _make_buy_plan(db_session, user, status="pending")
         _make_buy_plan_request(db_session, bp, user)  # one open
-        resolved = _make_prepayment_request(db_session, user)
-        resolved.status = "approved"  # a historical, non-pending row
+        bp2 = _make_buy_plan(db_session, user, status="pending")
+        resolved = _make_buy_plan_request(db_session, bp2, user)
+        resolved.status = "approved"  # a historical, non-pending row of the SAME gate
+        resolved.resolved_at = datetime.now(timezone.utc)
         db_session.commit()
 
         for client in _build_client(db_session, user):
-            resp = client.get("/v2/approvals/queue")
+            resp = client.get("/v2/partials/buy-plans/approvals?tab=buy_plans")
 
         assert resp.status_code == 200
-        assert "1 item pending" in resp.text, resp.text[:400]
+        assert "Pending" in resp.text
+        assert "Recently resolved" in resp.text
 
-    def test_queue_html_renders_prepayment_row(self, db_session: Session) -> None:
-        """The engine-only queue still renders non-buy-plan rows (prepayment)."""
+    def test_prepayments_tab_renders_row(self, db_session: Session) -> None:
+        """The Vendor Prepayments tab renders a prepayment-gate row."""
         user = _make_user(db_session)
         ar = _make_prepayment_request(db_session, user)
         db_session.commit()
 
         for client in _build_client(db_session, user):
-            resp = client.get("/v2/approvals/queue")
+            resp = client.get("/v2/partials/buy-plans/approvals?tab=prepayments")
 
         assert resp.status_code == 200
-        assert f"/v2/approvals/requests/{ar.id}" in resp.text
+        assert f"Request #{ar.id}" in resp.text  # no subject set → audit-safe fallback label

--- a/tests/test_approvals_coverage_nightly.py
+++ b/tests/test_approvals_coverage_nightly.py
@@ -17,7 +17,6 @@ import uuid
 from datetime import datetime, timezone
 from unittest.mock import patch
 
-from fastapi.responses import HTMLResponse
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -155,19 +154,19 @@ class TestApprovalsRouterCoverage:
         assert resp.status_code == 404
         assert "error" in resp.json()
 
-    def test_get_queue_renders(self, db_session: Session):
-        """GET /v2/approvals/queue renders without error."""
+    def test_get_queue_redirects_to_hub_lens(self, db_session: Session):
+        """GET /v2/approvals/queue 302-redirects to the Buy Plans hub 'approvals' lens.
+
+        The standalone queue was retired — the four-tab queue now renders as a Buy-Plans
+        hub lens body. The old URL stays a valid deep link via the redirect.
+        """
         user = _make_user(db_session)
         db_session.commit()
 
         client = _get_client(db_session, user)
-        with patch("app.routers.approvals.template_response") as mock_tpl:
-            mock_tpl.return_value = HTMLResponse("<html></html>")
-            resp = client.get("/v2/approvals/queue")
-        # The queue view does real ORM work; without full fixtures it may 500 before
-        # template_response is reached. We only assert the route is reachable and the
-        # app doesn't raise at the framework layer (status is a valid HTTP response).
-        assert resp.status_code in (200, 500)
+        resp = client.get("/v2/approvals/queue", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/v2/buy-plans?lens=approvals"
 
     def test_serialize_request_all_fields(self, db_session: Session):
         """_serialize_request projects all 11 fields."""

--- a/tests/test_approvals_queue.py
+++ b/tests/test_approvals_queue.py
@@ -479,6 +479,68 @@ def test_amount_source_per_gate(db_session: Session) -> None:
     assert build_queue_view(db_session, me, "prepayments").pending_rows[0].amount == Decimal("2500.00")
 
 
+def test_invalid_tab_falls_back_to_smart_default(db_session: Session) -> None:
+    """An explicit-but-unknown tab (e.g. a stale deep-link) degrades to the smart
+    default, never a KeyError/500.
+
+    The router passes ``tab`` through unvalidated.
+    """
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    qp = _qp(db_session, bp, me)
+    _seed(
+        db_session,
+        ApprovalGateType.PURCHASE_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(me,),
+    )
+
+    view = build_queue_view(db_session, me, "garbage")
+
+    assert view.active_tab in ("buy_plans", "sales_orders", "purchase_orders", "prepayments")
+    assert view.active_tab == "purchase_orders"  # equals the smart default (most awaiting me)
+
+
+def test_pending_capped_oldest_first(db_session, monkeypatch) -> None:
+    """PENDING_CAP bounds the pending list, oldest-first so the work most in need of a
+    decision is never the part that gets hidden."""
+    from app.services.approvals import queue as queue_mod
+
+    monkeypatch.setattr(queue_mod, "PENDING_CAP", 2)
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    oldest = _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        pending_recipients=(me,),
+        created_at=base,
+    )
+    second = _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        pending_recipients=(me,),
+        created_at=base + timedelta(days=1),
+    )
+    _seed(  # newest — must be the one dropped by the cap
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        pending_recipients=(me,),
+        created_at=base + timedelta(days=2),
+    )
+
+    view = build_queue_view(db_session, me, "buy_plans")
+
+    assert [r.id for r in view.pending_rows] == [oldest.id, second.id]
+
+
 def test_routed_request_via_service_is_actionable(db_session: Session) -> None:
     """Integration: a request created through the real create_request/route path is can_act for its approver."""
     from app.services.approvals.service import create_request

--- a/tests/test_approvals_queue.py
+++ b/tests/test_approvals_queue.py
@@ -1,0 +1,497 @@
+"""test_approvals_queue.py — Tests for app/services/approvals/queue.py.
+
+Covers build_queue_view: four-tab segmentation by gate_type, smart-default tab
+(most awaiting-me, tie/zero → buy_plans), Pending vs Recently-resolved split
+(resolved capped + coalesce-ordered), org-wide pill counts, per-row can_act
+(eligible PENDING recipient only), org-wide visibility, and per-gate subject
+label/href/amount resolution.
+
+Called by: pytest
+Depends on: conftest (db_session), app.services.approvals.queue,
+            app.services.approvals.service, app.models.{approvals,auth,buy_plan,
+            quality_plan,quotes,sourcing,vendors}, app.constants.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from app.constants import (
+    ApprovalGateType,
+    ApprovalRecipientStatus,
+    ApprovalRequestStatus,
+    ApprovalSubjectType,
+    PaymentMethod,
+)
+from app.models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
+from app.models.auth import User
+from app.models.buy_plan import BuyPlan
+from app.models.quality_plan import Prepayment, QualityPlan
+from app.models.quotes import Quote
+from app.models.sourcing import Requisition
+from app.models.vendors import VendorCard
+from app.services.approvals.queue import build_queue_view
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _user(db: Session, *, name: str = "Approver", **toggles) -> User:
+    u = User(
+        email=f"u-{uuid.uuid4().hex[:6]}@test.com",
+        name=name,
+        role="admin",
+        azure_id=f"az-{uuid.uuid4().hex[:8]}",
+        created_at=datetime.now(timezone.utc),
+        **toggles,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _bp(db: Session, user: User, *, customer: str = "TestCo") -> BuyPlan:
+    req = Requisition(
+        name=f"REQ-{uuid.uuid4().hex[:6]}",
+        customer_name=customer,
+        status="active",
+        created_by=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(req)
+    db.flush()
+    quote = Quote(
+        requisition_id=req.id,
+        quote_number=f"Q-{uuid.uuid4().hex[:8]}",
+        line_items=[],
+        status="sent",
+        created_by_id=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(quote)
+    db.flush()
+    bp = BuyPlan(
+        requisition_id=req.id,
+        quote_id=quote.id,
+        status="draft",
+        so_status="pending",
+        total_cost=Decimal("1000.00"),
+    )
+    db.add(bp)
+    db.flush()
+    return bp
+
+
+def _qp(db: Session, bp: BuyPlan, user: User) -> QualityPlan:
+    qp = QualityPlan(buy_plan_id=bp.id, created_by_id=user.id, status="in_review")
+    db.add(qp)
+    db.flush()
+    return qp
+
+
+def _prepay(db: Session, bp: BuyPlan, user: User, *, method=PaymentMethod.WIRE, vendor="Acme Components") -> Prepayment:
+    vc = VendorCard(normalized_name=f"vc-{uuid.uuid4().hex[:8]}", display_name=vendor)
+    db.add(vc)
+    db.flush()
+    pp = Prepayment(
+        buy_plan_id=bp.id,
+        vendor_card_id=vc.id,
+        total_incl_fees=Decimal("2500.00"),
+        currency="USD",
+        payment_method=method,
+        created_by_id=user.id,
+    )
+    db.add(pp)
+    db.flush()
+    return pp
+
+
+def _seed(
+    db: Session,
+    gate,
+    *,
+    subject_type,
+    subject_id: int,
+    status=ApprovalRequestStatus.REQUESTED,
+    pending_recipients=(),
+    requester: User | None = None,
+    owner: User | None = None,
+    amount: Decimal | None = None,
+    resolved_at: datetime | None = None,
+    created_at: datetime | None = None,
+) -> ApprovalRequest:
+    """Seed one ApprovalRequest (+ a step + PENDING recipients) directly for full
+    control."""
+    ar = ApprovalRequest(
+        gate_type=gate,
+        status=status,
+        subject_type=subject_type,
+        subject_id=subject_id,
+        amount=amount,
+        currency="USD",
+        requested_by_id=requester.id if requester else None,
+        owner_id=owner.id if owner else None,
+        resolved_at=resolved_at,
+    )
+    if created_at is not None:
+        ar.created_at = created_at
+    db.add(ar)
+    db.flush()
+    if pending_recipients:
+        step = ApprovalStep(request_id=ar.id, seq=1, rule="any", status="pending")
+        db.add(step)
+        db.flush()
+        for u in pending_recipients:
+            db.add(ApprovalStepRecipient(step_id=step.id, user_id=u.id, status=ApprovalRecipientStatus.PENDING))
+        db.flush()
+    return ar
+
+
+# ── Tests ────────────────────────────────────────────────────────────────
+
+
+def test_tab_filter_returns_only_that_gate_type(db_session: Session) -> None:
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    qp = _qp(db_session, bp, me)
+    pp = _prepay(db_session, bp, me)
+    _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        pending_recipients=(me,),
+    )
+    so = _seed(
+        db_session,
+        ApprovalGateType.SALES_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(me,),
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.PREPAYMENT,
+        subject_type=ApprovalSubjectType.PREPAYMENT,
+        subject_id=pp.id,
+        pending_recipients=(me,),
+    )
+
+    view = build_queue_view(db_session, me, "sales_orders")
+
+    assert view.active_tab == "sales_orders"
+    assert [r.id for r in view.pending_rows] == [so.id]
+    assert all(r.gate_type == "sales_order" for r in view.pending_rows)
+
+
+def test_smart_default_picks_gate_with_most_awaiting_me(db_session: Session) -> None:
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    qp = _qp(db_session, bp, me)
+    _seed(
+        db_session,
+        ApprovalGateType.PURCHASE_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(me,),
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.PURCHASE_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(me,),
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        pending_recipients=(me,),
+    )
+
+    view = build_queue_view(db_session, me, None)
+
+    assert view.active_tab == "purchase_orders"
+
+
+def test_smart_default_zero_falls_back_to_buy_plans(db_session: Session) -> None:
+    me = _user(db_session)
+    other = _user(db_session)
+    bp = _bp(db_session, other)
+    qp = _qp(db_session, bp, other)
+    # Pending work exists, but routed to someone else — me is awaiting nothing.
+    _seed(
+        db_session,
+        ApprovalGateType.SALES_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(other,),
+    )
+
+    view = build_queue_view(db_session, me, None)
+
+    assert view.active_tab == "buy_plans"
+
+
+def test_explicit_tab_overrides_smart_default(db_session: Session) -> None:
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    qp = _qp(db_session, bp, me)
+    _seed(
+        db_session,
+        ApprovalGateType.PURCHASE_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(me,),
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.PURCHASE_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(me,),
+    )
+
+    view = build_queue_view(db_session, me, "prepayments")
+
+    assert view.active_tab == "prepayments"
+
+
+def test_pending_vs_resolved_split(db_session: Session) -> None:
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    now = datetime.now(timezone.utc)
+    pending = _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        pending_recipients=(me,),
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        status=ApprovalRequestStatus.APPROVED,
+        resolved_at=now,
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        status=ApprovalRequestStatus.REJECTED,
+        resolved_at=now,
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        status=ApprovalRequestStatus.CANCELLED,
+    )  # resolved_at None
+
+    view = build_queue_view(db_session, me, "buy_plans")
+
+    assert [r.id for r in view.pending_rows] == [pending.id]
+    assert len(view.resolved_rows) == 3
+
+
+def test_resolved_capped_at_10_and_coalesce_ordered(db_session: Session) -> None:
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    approved_ids = []
+    for i in range(12):
+        ar = _seed(
+            db_session,
+            ApprovalGateType.BUY_PLAN,
+            subject_type=ApprovalSubjectType.BUY_PLAN,
+            subject_id=bp.id,
+            status=ApprovalRequestStatus.APPROVED,
+            resolved_at=base + timedelta(days=i),
+        )
+        approved_ids.append((i, ar.id))
+    # Cancelled row has resolved_at=None but a much-later created_at → coalesce ranks it newest.
+    cancelled = _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        status=ApprovalRequestStatus.CANCELLED,
+        resolved_at=None,
+        created_at=base + timedelta(days=100),
+    )
+
+    view = build_queue_view(db_session, me, "buy_plans")
+
+    assert len(view.resolved_rows) == 10
+    assert view.resolved_rows[0].id == cancelled.id  # coalesce(resolved_at, updated_at, created_at) newest
+    # The 3 oldest approved (days 0,1,2) fall off the cap of 10.
+    oldest_three = {ar_id for day, ar_id in approved_ids if day < 3}
+    assert oldest_three.isdisjoint({r.id for r in view.resolved_rows})
+
+
+def test_pill_counts_are_org_wide(db_session: Session) -> None:
+    me = _user(db_session)
+    other = _user(db_session)
+    bp = _bp(db_session, other)
+    qp = _qp(db_session, bp, other)
+    for _ in range(3):
+        _seed(
+            db_session,
+            ApprovalGateType.SALES_ORDER,
+            subject_type=ApprovalSubjectType.QUALITY_PLAN,
+            subject_id=qp.id,
+            pending_recipients=(other,),
+        )
+
+    view = build_queue_view(db_session, me, "sales_orders")
+
+    so_tab = next(t for t in view.tabs if t["key"] == "sales_orders")
+    assert so_tab["count"] == 3  # org-wide REQUESTED, even though me is awaiting none
+
+
+def test_can_act_only_for_eligible_pending_recipient(db_session: Session) -> None:
+    me = _user(db_session)
+    other = _user(db_session)
+    bp = _bp(db_session, me)
+    qp = _qp(db_session, bp, me)
+    a = _seed(
+        db_session,
+        ApprovalGateType.PURCHASE_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(me,),
+    )
+    b = _seed(
+        db_session,
+        ApprovalGateType.PURCHASE_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(other,),
+    )
+
+    view = build_queue_view(db_session, me, "purchase_orders")
+
+    by_id = {r.id: r for r in view.pending_rows}
+    assert by_id[a.id].can_act is True
+    assert by_id[b.id].can_act is False
+
+
+def test_org_wide_shows_unactionable_row_with_approver_names(db_session: Session) -> None:
+    me = _user(db_session)
+    other = _user(db_session, name="Bob Approver")
+    bp = _bp(db_session, me)
+    qp = _qp(db_session, bp, me)
+    b = _seed(
+        db_session,
+        ApprovalGateType.PURCHASE_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(other,),
+    )
+
+    view = build_queue_view(db_session, me, "purchase_orders")
+
+    row = next(r for r in view.pending_rows if r.id == b.id)
+    assert row.can_act is False
+    assert "Bob Approver" in row.approver_names
+
+
+def test_subject_label_and_href_per_gate(db_session: Session) -> None:
+    me = _user(db_session)
+    bp = _bp(db_session, me, customer="ACME Corp")
+    qp = _qp(db_session, bp, me)
+    pp = _prepay(db_session, bp, me, method=PaymentMethod.WIRE, vendor="Acme Components")
+    _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        pending_recipients=(me,),
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.SALES_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        pending_recipients=(me,),
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.PREPAYMENT,
+        subject_type=ApprovalSubjectType.PREPAYMENT,
+        subject_id=pp.id,
+        pending_recipients=(me,),
+    )
+
+    bp_row = build_queue_view(db_session, me, "buy_plans").pending_rows[0]
+    assert bp_row.subject_label == f"Plan #{bp.id}"
+    assert bp_row.subject_href == f"/v2/partials/buy-plans/{bp.id}"
+
+    so_row = build_queue_view(db_session, me, "sales_orders").pending_rows[0]
+    assert so_row.subject_label == f"QP #{qp.id}"
+    assert so_row.subject_href == f"/v2/qp/{qp.id}"
+    assert so_row.parent_label and "ACME Corp" in so_row.parent_label
+
+    pp_row = build_queue_view(db_session, me, "prepayments").pending_rows[0]
+    assert "Acme Components" in pp_row.subject_label
+    assert pp_row.payment_method == "wire"
+    assert pp_row.subject_href == f"/v2/partials/buy-plans/{bp.id}"
+
+
+def test_amount_source_per_gate(db_session: Session) -> None:
+    me = _user(db_session)
+    bp = _bp(db_session, me)
+    qp = _qp(db_session, bp, me)
+    pp = _prepay(db_session, bp, me)
+    _seed(
+        db_session,
+        ApprovalGateType.BUY_PLAN,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=bp.id,
+        amount=Decimal("4200.00"),
+        pending_recipients=(me,),
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.SALES_ORDER,
+        subject_type=ApprovalSubjectType.QUALITY_PLAN,
+        subject_id=qp.id,
+        amount=None,
+        pending_recipients=(me,),
+    )
+    _seed(
+        db_session,
+        ApprovalGateType.PREPAYMENT,
+        subject_type=ApprovalSubjectType.PREPAYMENT,
+        subject_id=pp.id,
+        amount=Decimal("2500.00"),
+        pending_recipients=(me,),
+    )
+
+    assert build_queue_view(db_session, me, "buy_plans").pending_rows[0].amount == Decimal("4200.00")
+    assert build_queue_view(db_session, me, "sales_orders").pending_rows[0].amount is None
+    assert build_queue_view(db_session, me, "prepayments").pending_rows[0].amount == Decimal("2500.00")
+
+
+def test_routed_request_via_service_is_actionable(db_session: Session) -> None:
+    """Integration: a request created through the real create_request/route path is can_act for its approver."""
+    from app.services.approvals.service import create_request
+
+    me = _user(db_session, can_approve_sales_orders=True)
+    bp = _bp(db_session, me)
+    qp = _qp(db_session, bp, me)
+    create_request(
+        db_session, gate_type=ApprovalGateType.SALES_ORDER, amount=None, subject=qp, requested_by=me, owner=me
+    )
+    db_session.flush()
+
+    view = build_queue_view(db_session, me, "sales_orders")
+
+    assert len(view.pending_rows) == 1
+    assert view.pending_rows[0].can_act is True

--- a/tests/test_buyplan_approvals_lens.py
+++ b/tests/test_buyplan_approvals_lens.py
@@ -71,6 +71,24 @@ class TestApprovalsLensGating:
             assert label in resp.text
         assert 'hx-target="#bp-hub-body"' in resp.text
 
+    def test_full_page_threads_lens_to_lazy_partial(self, nonadmin_client):
+        """A full-page load of /v2/buy-plans?lens=approvals threads ?lens= into the lazy
+        partial URL, so a deep link / reload / the /v2/approvals/queue redirect lands on
+        the requested lens instead of the role default.
+
+        (v2_page authenticates via the session cookie, so this needs nonadmin_client,
+        not the require_user-only client.)
+        """
+        resp = nonadmin_client.get("/v2/buy-plans?lens=approvals")
+        assert resp.status_code == 200
+        assert "/v2/partials/buy-plans?lens=approvals" in resp.text
+
+    def test_full_page_ignores_unknown_lens(self, nonadmin_client):
+        """An unknown ?lens= value is dropped (no query string), not echoed verbatim."""
+        resp = nonadmin_client.get("/v2/buy-plans?lens=bogus")
+        assert resp.status_code == 200
+        assert "lens=bogus" not in resp.text
+
 
 class TestBadgeMerge:
     def test_approval_action_registered_under_buy_plans(self):

--- a/tests/test_buyplan_approvals_lens.py
+++ b/tests/test_buyplan_approvals_lens.py
@@ -1,0 +1,91 @@
+"""test_buyplan_approvals_lens.py — Approvals folded into the Buy Plans hub.
+
+Covers:
+  - the hub renders the "Approvals" lens pill ONLY for approvers (can_approve_any);
+  - the lens-body route /v2/partials/buy-plans/approvals is approver-gated (403 otherwise)
+    and renders the four-tab queue into #bp-hub-body;
+  - the approvals alert count merges onto the Buy Plans nav badge (the source is
+    re-registered under the "buy-plans" tab).
+
+Called by: pytest
+Depends on: conftest (client, test_user, db_session), app.routers.htmx_views,
+            app.services.alerts, app.models.approvals.
+"""
+
+from app.constants import (
+    AlertKind,
+    ApprovalGateType,
+    ApprovalRecipientStatus,
+    ApprovalRequestStatus,
+    ApprovalSubjectType,
+)
+from app.models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
+
+
+def _seed_pending_buy_plan_approval(db, user):
+    ar = ApprovalRequest(
+        gate_type=ApprovalGateType.BUY_PLAN,
+        status=ApprovalRequestStatus.REQUESTED,
+        subject_type=ApprovalSubjectType.BUY_PLAN,
+        subject_id=1,
+        requested_by_id=user.id,
+        owner_id=user.id,
+    )
+    db.add(ar)
+    db.flush()
+    step = ApprovalStep(request_id=ar.id, seq=1, rule="any", status="pending")
+    db.add(step)
+    db.flush()
+    db.add(ApprovalStepRecipient(step_id=step.id, user_id=user.id, status=ApprovalRecipientStatus.PENDING))
+    db.flush()
+    return ar
+
+
+class TestApprovalsLensGating:
+    def test_pill_hidden_for_non_approver(self, client, test_user, db_session):
+        """A user with no approver toggle does not see the Approvals lens pill."""
+        resp = client.get("/v2/partials/buy-plans")
+        assert resp.status_code == 200
+        assert "lens=approvals" not in resp.text
+
+    def test_pill_shown_for_approver(self, client, test_user, db_session):
+        """An approver sees the Approvals lens pill in the hub switcher."""
+        test_user.can_approve_buy_plans = True
+        db_session.flush()
+        resp = client.get("/v2/partials/buy-plans")
+        assert resp.status_code == 200
+        assert "lens=approvals" in resp.text
+
+    def test_lens_body_403_for_non_approver(self, client, test_user, db_session):
+        """The lens body is approver-gated."""
+        resp = client.get("/v2/partials/buy-plans/approvals")
+        assert resp.status_code == 403
+
+    def test_lens_body_renders_four_tabs_into_hub_body(self, client, test_user, db_session):
+        """An approver gets all four tab labels and sub-tabs targeting #bp-hub-body."""
+        test_user.can_approve_sales_orders = True
+        db_session.flush()
+        resp = client.get("/v2/partials/buy-plans/approvals?tab=buy_plans")
+        assert resp.status_code == 200
+        for label in ("Buy Plans", "Sales Orders", "Purchase Orders", "Vendor Prepayments"):
+            assert label in resp.text
+        assert 'hx-target="#bp-hub-body"' in resp.text
+
+
+class TestBadgeMerge:
+    def test_approval_action_registered_under_buy_plans(self):
+        """The approvals alert source now lives on the buy-plans tab (folded nav)."""
+        import app.services.alerts.sources  # noqa: F401  — import triggers registration
+        from app.services.alerts import tab_for_kind
+
+        assert tab_for_kind(AlertKind.APPROVAL_ACTION) == "buy-plans"
+
+    def test_count_for_buy_plans_includes_awaiting_approvals(self, db_session, test_user):
+        """count_for_tab('buy-plans') sums the approval-action count (badge merge)."""
+        import app.services.alerts.sources  # noqa: F401
+        from app.services.alerts import count_for_tab
+
+        before = count_for_tab(db_session, test_user, "buy-plans")
+        _seed_pending_buy_plan_approval(db_session, test_user)
+        after = count_for_tab(db_session, test_user, "buy-plans")
+        assert after == before + 1

--- a/tests/test_buyplan_nav.py
+++ b/tests/test_buyplan_nav.py
@@ -35,12 +35,13 @@ class TestMobileNavTemplate:
         src = _TEMPLATE.read_text()
         assert "('reporting'," not in src, "'reporting' nav item still present in nav_items"
 
-    def test_nav_items_has_approvals_entry(self):
-        """nav_items tuple contains the C1 'approvals' entry → /v2/approvals/queue."""
+    def test_nav_items_has_no_approvals_entry(self):
+        """Approvals is folded into the Buy Plans hub lens — no standalone nav item."""
         src = _TEMPLATE.read_text()
-        assert "('approvals'," in src, "'approvals' nav item missing from nav_items"
-        assert "'/v2/approvals/queue'" in src, "Approvals nav must point at the engine queue"
-        assert "'/v2/approvals':'approvals'" in src, "urlToNav must map /v2/approvals to 'approvals'"
+        assert "('approvals'," not in src, "'approvals' nav item must be removed (folded into Buy Plans hub)"
+        assert "'/v2/approvals/queue'" not in src, "the standalone Approvals nav link must be gone"
+        # Deep links to /v2/approvals highlight the Buy Plans tab (it 302s to the hub lens).
+        assert "'/v2/approvals':'buy-plans'" in src, "urlToNav must alias /v2/approvals to 'buy-plans'"
 
     def test_url_to_nav_maps_buy_plans_to_itself(self):
         """UrlToNav maps /v2/buy-plans to 'buy-plans'."""
@@ -59,7 +60,7 @@ class TestMobileNavTemplate:
         verifies the badge wiring, not an incidental 'buy-plans' string elsewhere.
         """
         src = _TEMPLATE.read_text()
-        assert "{% elif id in ('requisitions', 'buy-plans', 'crm', 'my-day', 'approvals') %}" in src
+        assert "{% elif id in ('requisitions', 'buy-plans', 'crm', 'my-day') %}" in src
 
 
 class TestNavIdAlias:


### PR DESCRIPTION
## Approvals → four tabs, folded into the Buy Plans hub

Reorganizes the flat, org-wide approvals queue into **four tabs by `gate_type`** — Buy Plans · Sales Orders · Purchase Orders · Vendor Prepayments — and folds it into the **Buy-Plans Deal Hub** as a new **"Approvals" lens** (gated to approvers), retiring the standalone Approvals bottom-nav item. No schema change.

### Behaviour (locked with the user)
- **Four tabs** by gate_type. Each tab = a **Pending** section (inline approve/reject) over a **Recently-resolved** read-only section (cap 10, ordered by `coalesce(resolved_at, updated_at, created_at) desc` so cancelled rows with a NULL `resolved_at` still sort sanely).
- **Smart-default tab**: with no `?tab=`, the server opens the tab with the most items *awaiting you* (tie/zero → Buy Plans). Per-tab pills are **org-wide** REQUESTED counts.
- **Org-wide visibility**: every request of a type shows; approve/reject render only when you're an eligible PENDING recipient (`can_act`, mirrors the engine `decide()` gate). Otherwise the routed-to approver names show.
- **Folded nav**: the standalone Approvals item is gone; `GET /v2/approvals/queue` **302-redirects** to `/v2/buy-plans?lens=approvals`; `ApprovalRequestActionSource` re-registered under the `buy-plans` tab so its awaiting-me count **merges onto the Buy Plans nav badge**.

### Shape
- **New** `app/services/approvals/queue.py` — `build_queue_view` (constant query count, no N+1): GROUP-BY pill counts, awaiting-me smart default, pending/resolved row sets, one actionable-id set, grouped approver names, subjects batch-loaded by `subject_type`.
- **New** lens-body route `GET /v2/partials/buy-plans/approvals?tab=` (`htmx_views.py`, approver-gated) → renders into `#bp-hub-body`; sub-tabs swap back into the same container.
- `_queue.html` rewritten + new `_macros.html`; `hub.html` gains the lens; `mobile_nav.html` drops the item.

### Verification
- **Full suite green: 20,926 passed**, 19 skipped, 1 xfailed (local, mirrors CI).
- New `tests/test_approvals_queue.py` (13 service tests) + `tests/test_buyplan_approvals_lens.py` (gating + badge merge); updated bridge/nav/coverage tests for the folded behaviour.
- `ruff` clean; `pre-commit run --all-files` all-pass (mypy clean on 504 files).
- APP_MAP_INTERACTIONS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
