### PR TITLE
test: nightly coverage — bring 4 modules to 85%+

### DIFF
--- a/tests/test_nightly_qp_coverage.py
+++ b/tests/test_nightly_qp_coverage.py
@@ -1,0 +1,307 @@
+"""tests/test_nightly_qp_coverage.py — Nightly coverage boost for app/routers/quality_plans.py.
+
+Targets the uncovered helper functions (_coerce, _parse_date, _section_approved)
+and the error/exception paths in the submit and section-gate route handlers.
+
+Called by: pytest (nightly coverage run)
+Depends on: conftest (db_session, client, test_user), test_c2a_gates helpers
+"""
+
+import os
+import uuid
+from datetime import date, datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+os.environ.setdefault("TESTING", "1")
+
+from app.constants import BuyPlanStatus
+from app.models.auth import User
+from app.models.buy_plan import BuyPlan
+from app.models.quality_plan import QpFruLookup, QualityPlan
+from app.models.quotes import Quote
+from app.models.sourcing import Requisition
+from app.routers.quality_plans import _coerce, _parse_date, _section_approved
+
+# ── Pure-function unit tests ──────────────────────────────────────────────────
+
+
+class TestCoerce:
+    """_coerce: type coercion for HTML form values."""
+
+    def test_none_input_returns_none(self):
+        assert _coerce("text", None) is None
+
+    def test_blank_strip_returns_none(self):
+        assert _coerce("text", "   ") is None
+
+    def test_bool_true_variants(self):
+        for val in ("true", "True", "TRUE", "yes", "1", "on"):
+            assert _coerce("bool", val) is True, f"Expected True for {val!r}"
+
+    def test_bool_false_variants(self):
+        for val in ("false", "False", "FALSE", "no", "0", "off"):
+            assert _coerce("bool", val) is False, f"Expected False for {val!r}"
+
+    def test_bool_junk_returns_none(self):
+        assert _coerce("bool", "maybe") is None
+
+    def test_int_valid(self):
+        assert _coerce("int", "42") == 42
+
+    def test_int_invalid_returns_none(self):
+        assert _coerce("int", "abc") is None
+
+    def test_text_passthrough(self):
+        assert _coerce("text", "  hello  ") == "hello"
+
+
+class TestParseDate:
+    """_parse_date: parse YYYY-MM-DD HTML date inputs."""
+
+    def test_none_returns_none(self):
+        assert _parse_date(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_date("") is None
+
+    def test_whitespace_returns_none(self):
+        assert _parse_date("   ") is None
+
+    def test_valid_date(self):
+        assert _parse_date("2025-03-15") == date(2025, 3, 15)
+
+    def test_invalid_date_returns_none(self):
+        assert _parse_date("not-a-date") is None
+
+    def test_partial_date_returns_none(self):
+        assert _parse_date("2025-13-99") is None
+
+
+class TestSectionApproved:
+    """_section_approved: checks whether a section already carries an approved stamp."""
+
+    def _qp_mock(self, sales_approved=False, purchasing_approved=False):
+        from unittest.mock import MagicMock
+
+        qp = MagicMock(spec=QualityPlan)
+        qp.sales_section_approved_at = datetime.now(timezone.utc) if sales_approved else None
+        qp.purchasing_section_approved_at = datetime.now(timezone.utc) if purchasing_approved else None
+        return qp
+
+    def test_sales_order_not_approved(self):
+        qp = self._qp_mock(sales_approved=False)
+        assert _section_approved(qp, "sales_order") is False
+
+    def test_sales_order_approved(self):
+        qp = self._qp_mock(sales_approved=True)
+        assert _section_approved(qp, "sales_order") is True
+
+    def test_purchase_order_not_approved(self):
+        qp = self._qp_mock(purchasing_approved=False)
+        assert _section_approved(qp, "purchase_order") is False
+
+    def test_purchase_order_approved(self):
+        qp = self._qp_mock(purchasing_approved=True)
+        assert _section_approved(qp, "purchase_order") is True
+
+
+# ── Helpers (mirrors test_c2a_gates._make_qp) ─────────────────────────────────
+
+
+def _make_admin_user(db: Session) -> User:
+    u = User(
+        email=f"nqp-{uuid.uuid4().hex[:8]}@test.com",
+        name="NQP Admin",
+        role="admin",
+        azure_id=f"azure-nqp-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+        can_approve_sales_orders=True,
+        can_approve_pos=True,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_qp(db: Session, owner: User) -> QualityPlan:
+    req = Requisition(
+        name=f"REQ-NQP-{uuid.uuid4().hex[:6]}",
+        customer_name="NQPCo",
+        status="active",
+        created_by=owner.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(req)
+    db.flush()
+
+    quote = Quote(
+        requisition_id=req.id,
+        quote_number=f"QNQP-{uuid.uuid4().hex[:8]}",
+        line_items=[],
+        status="sent",
+        created_by_id=owner.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(quote)
+    db.flush()
+
+    bp = BuyPlan(
+        requisition_id=req.id,
+        quote_id=quote.id,
+        status=BuyPlanStatus.DRAFT.value,
+        so_status="pending",
+        total_cost=500.0,
+    )
+    db.add(bp)
+    db.flush()
+
+    qp = QualityPlan(
+        buy_plan_id=bp.id,
+        created_by_id=owner.id,
+        order_type="new",
+        status="draft",
+        sales_so_number="TSO99999",
+        sales_condition="New",
+        sales_quantity=5,
+        sales_product_commodity="SSD",
+        sales_testing_required=True,
+        purchasing_po_number="PO-NQP-01",
+        purchasing_condition="New",
+        purchasing_product_commodity="SSD",
+        purchasing_testing_required=True,
+    )
+    db.add(qp)
+    db.flush()
+    return qp
+
+
+@pytest.fixture()
+def _qp_client(db_session: Session):
+    """TestClient + (user, qp) for quality-plan route tests."""
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    user = _make_admin_user(db_session)
+    qp = _make_qp(db_session, user)
+    db_session.commit()
+
+    def _db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[require_user] = lambda: user
+    try:
+        yield TestClient(app, raise_server_exceptions=False), user, qp
+    finally:
+        for dep in (get_db, require_user):
+            app.dependency_overrides.pop(dep, None)
+
+
+# ── Route handler error-path tests ────────────────────────────────────────────
+
+
+class TestQpRouteErrorPaths:
+    def test_submit_qp_not_found_returns_404(self, _qp_client):
+        client, _user, _qp = _qp_client
+        r = client.post("/v2/qp/999999/submit")
+        assert r.status_code == 404
+
+    def test_submit_sales_not_found_returns_404(self, _qp_client):
+        client, _user, _qp = _qp_client
+        r = client.post("/v2/qp/999999/submit-sales")
+        assert r.status_code == 404
+
+    def test_submit_purchasing_not_found_returns_404(self, _qp_client):
+        client, _user, _qp = _qp_client
+        r = client.post("/v2/qp/999999/submit-purchasing")
+        assert r.status_code == 404
+
+    def test_submit_qp_incomplete_returns_200_with_errors(self, _qp_client, db_session: Session):
+        """An incomplete QP hits the IncompleteQPError path → 200 (re-render with errors)."""
+        client, _user, qp = _qp_client
+        # Blank out a required field to make submit() raise IncompleteQPError
+        qp.sales_so_number = None
+        db_session.commit()
+        r = client.post(f"/v2/qp/{qp.id}/submit")
+        assert r.status_code == 200
+
+    def test_patch_sales_not_found_returns_404(self, _qp_client):
+        client, _user, _qp = _qp_client
+        r = client.patch("/v2/qp/999999/sales", data={"sales_so_number": "TSO-X"})
+        assert r.status_code == 404
+
+    def test_patch_purchasing_not_found_returns_404(self, _qp_client):
+        client, _user, _qp = _qp_client
+        r = client.patch("/v2/qp/999999/purchasing", data={"purchasing_po_number": "PO-X"})
+        assert r.status_code == 404
+
+    def test_patch_sales_when_not_approved_writes_field(self, _qp_client, db_session: Session):
+        """PATCH /v2/qp/{id}/sales on an unapproved section updates the field."""
+        client, _user, qp = _qp_client
+        r = client.patch(f"/v2/qp/{qp.id}/sales", data={"sales_so_number": "TSO-NEW-99"})
+        assert r.status_code == 200
+        db_session.refresh(qp)
+        assert qp.sales_so_number == "TSO-NEW-99"
+
+    def test_patch_purchasing_when_not_approved_writes_field(self, _qp_client, db_session: Session):
+        """PATCH /v2/qp/{id}/purchasing on an unapproved section updates the field."""
+        client, _user, qp = _qp_client
+        r = client.patch(f"/v2/qp/{qp.id}/purchasing", data={"purchasing_po_number": "PO-NEW-77"})
+        assert r.status_code == 200
+        db_session.refresh(qp)
+        assert qp.purchasing_po_number == "PO-NEW-77"
+
+    def test_patch_sales_when_already_approved_is_noop(self, _qp_client, db_session: Session):
+        """PATCH on an approved section must not overwrite data."""
+        client, _user, qp = _qp_client
+        qp.sales_section_approved_at = datetime.now(timezone.utc)
+        db_session.commit()
+        r = client.patch(f"/v2/qp/{qp.id}/sales", data={"sales_so_number": "IGNORED"})
+        assert r.status_code == 200
+        db_session.refresh(qp)
+        assert qp.sales_so_number == "TSO99999"
+
+    def test_add_serial_not_found_returns_404(self, _qp_client):
+        client, _user, _qp = _qp_client
+        r = client.post("/v2/qp/999999/serial", data={"serial_number": "SN-001"})
+        assert r.status_code == 404
+
+    def test_delete_serial_not_found_returns_404(self, _qp_client):
+        client, _user, _qp = _qp_client
+        r = client.delete("/v2/qp/999999/serial/1")
+        assert r.status_code == 404
+
+    def test_add_fru_not_found_returns_404(self, _qp_client):
+        client, _user, _qp = _qp_client
+        r = client.post("/v2/qp/999999/fru", data={"fru": "LM317T"})
+        assert r.status_code == 404
+
+    def test_delete_fru_not_found_returns_404(self, _qp_client):
+        client, _user, _qp = _qp_client
+        r = client.delete("/v2/qp/999999/fru/1")
+        assert r.status_code == 404
+
+    def test_delete_fru_wrong_qp_returns_404(self, _qp_client, db_session: Session):
+        """Deleting a FRU lookup that belongs to a different QP returns 404."""
+        client, _user, qp = _qp_client
+        # Create a lookup under a different QP id
+        other_user = _make_admin_user(db_session)
+        other_qp = _make_qp(db_session, other_user)
+        db_session.commit()
+
+        fru = QpFruLookup(qp_id=other_qp.id, fru_norm="xc7a35t")
+        db_session.add(fru)
+        db_session.commit()
+
+        r = client.delete(f"/v2/qp/{qp.id}/fru/{fru.id}")
+        assert r.status_code == 404
+
+    def test_load_qp_for_edit_not_found_returns_404(self, _qp_client):
+        """_load_qp_for_edit raises 404 when no row exists."""
+        client, _user, _qp = _qp_client
+        r = client.patch("/v2/qp/888888/sales", data={})
+        assert r.status_code == 404

--- a/tests/test_nightly_qp_coverage.py
+++ b/tests/test_nightly_qp_coverage.py
@@ -1,10 +1,11 @@
-"""tests/test_nightly_qp_coverage.py — Nightly coverage boost for app/routers/quality_plans.py.
+"""tests/test_nightly_qp_coverage.py — Nightly coverage boost for
+app/routers/quality_plans.py.
 
-Targets the uncovered helper functions (_coerce, _parse_date, _section_approved)
-and the error/exception paths in the submit and section-gate route handlers.
+Targets the uncovered helper functions (_coerce, _parse_date, _section_approved) and the
+error/exception paths in the submit and section-gate route handlers.
 
-Called by: pytest (nightly coverage run)
-Depends on: conftest (db_session, client, test_user), test_c2a_gates helpers
+Called by: pytest (nightly coverage run) Depends on: conftest (db_session, client,
+test_user), test_c2a_gates helpers
 """
 
 import os
@@ -221,7 +222,8 @@ class TestQpRouteErrorPaths:
         assert r.status_code == 404
 
     def test_submit_qp_incomplete_returns_200_with_errors(self, _qp_client, db_session: Session):
-        """An incomplete QP hits the IncompleteQPError path → 200 (re-render with errors)."""
+        """An incomplete QP hits the IncompleteQPError path → 200 (re-render with
+        errors)."""
         client, _user, qp = _qp_client
         # Blank out a required field to make submit() raise IncompleteQPError
         qp.sales_so_number = None

--- a/tests/test_nightly_resell_coverage.py
+++ b/tests/test_nightly_resell_coverage.py
@@ -1,10 +1,11 @@
-"""tests/test_nightly_resell_coverage.py — Nightly coverage boost for app/routers/resell.py.
+"""tests/test_nightly_resell_coverage.py — Nightly coverage boost for
+app/routers/resell.py.
 
-Targets uncovered helper functions (_file_extension, _hours_until, _offer_coverage)
-and error paths in route handlers (403/404/409/400 branches).
+Targets uncovered helper functions (_file_extension, _hours_until, _offer_coverage) and
+error paths in route handlers (403/404/409/400 branches).
 
-Called by: pytest (nightly coverage run)
-Depends on: conftest (db_session, client, test_user, test_company)
+Called by: pytest (nightly coverage run) Depends on: conftest (db_session, client,
+test_user, test_company)
 """
 
 import os

--- a/tests/test_nightly_resell_coverage.py
+++ b/tests/test_nightly_resell_coverage.py
@@ -1,0 +1,375 @@
+"""tests/test_nightly_resell_coverage.py — Nightly coverage boost for app/routers/resell.py.
+
+Targets uncovered helper functions (_file_extension, _hours_until, _offer_coverage)
+and error paths in route handlers (403/404/409/400 branches).
+
+Called by: pytest (nightly coverage run)
+Depends on: conftest (db_session, client, test_user, test_company)
+"""
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+os.environ.setdefault("TESTING", "1")
+
+from app.constants import ExcessListStatus
+from app.models import Company, User
+from app.models.excess import ExcessLineItem, ExcessList
+from app.routers.resell import _file_extension, _hours_until, _offer_coverage
+
+# ── Pure-function unit tests ──────────────────────────────────────────────────
+
+
+class TestFileExtension:
+    def test_no_dot_returns_empty(self):
+        assert _file_extension("filename") == ""
+
+    def test_csv_extension(self):
+        assert _file_extension("data.CSV") == ".csv"
+
+    def test_multiple_dots(self):
+        assert _file_extension("my.file.xlsx") == ".xlsx"
+
+    def test_empty_string(self):
+        assert _file_extension("") == ""
+
+
+class TestHoursUntil:
+    def test_none_close_at_returns_none(self):
+        assert _hours_until(None) is None
+
+    def test_future_close_at_positive(self):
+        future = datetime.now(timezone.utc) + timedelta(hours=2)
+        result = _hours_until(future)
+        assert result is not None
+        assert 1.9 < result < 2.1
+
+    def test_past_close_at_negative(self):
+        past = datetime.now(timezone.utc) - timedelta(hours=3)
+        result = _hours_until(past)
+        assert result is not None
+        assert -3.1 < result < -2.9
+
+    def test_naive_datetime_tolerated(self):
+        naive = datetime.utcnow() + timedelta(hours=1)
+        result = _hours_until(naive)
+        assert result is not None
+        assert result > 0
+
+
+class TestOfferCoverage:
+    def test_empty_list_zero_zero(self):
+        assert _offer_coverage([]) == (0, 0)
+
+    def test_all_lines_covered(self):
+        items = [_mock_item(2), _mock_item(3)]
+        assert _offer_coverage(items) == (2, 2)
+
+    def test_no_lines_covered(self):
+        items = [_mock_item(0), _mock_item(0)]
+        assert _offer_coverage(items) == (0, 2)
+
+    def test_partial_coverage(self):
+        items = [_mock_item(1), _mock_item(0), _mock_item(5)]
+        assert _offer_coverage(items) == (2, 3)
+
+
+def _mock_item(offer_count: int):
+    """Create a minimal object with an offer_count attribute."""
+
+    class _Item:
+        pass
+
+    obj = _Item()
+    obj.offer_count = offer_count
+    return obj
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+def _make_trader(db: Session) -> User:
+    u = User(
+        email=f"trader-nr-{uuid.uuid4().hex[:8]}@test.com",
+        name="NR Trader",
+        role="trader",
+        azure_id=f"azure-nr-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_buyer(db: Session) -> User:
+    u = User(
+        email=f"buyer-nr-{uuid.uuid4().hex[:8]}@test.com",
+        name="NR Buyer",
+        role="buyer",
+        azure_id=f"azure-nb-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_sales_user(db: Session) -> User:
+    """A 'sales' user: can post but cannot offer — useful for testing offer 403."""
+    u = User(
+        email=f"sales-nr-{uuid.uuid4().hex[:8]}@test.com",
+        name="NR Sales",
+        role="sales",
+        azure_id=f"azure-ns-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _make_list(db: Session, owner: User, company: Company, status: str = ExcessListStatus.COLLECTING) -> ExcessList:
+    el = ExcessList(
+        title=f"NR-List-{uuid.uuid4().hex[:6]}",
+        company_id=company.id,
+        owner_id=owner.id,
+        status=status,
+        total_line_items=0,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(el)
+    db.flush()
+    return el
+
+
+def _make_draft_list(db: Session, owner: User, company: Company) -> ExcessList:
+    return _make_list(db, owner, company, ExcessListStatus.DRAFT)
+
+
+def _make_line(db: Session, el: ExcessList, mpn: str = "LM317T") -> ExcessLineItem:
+    item = ExcessLineItem(
+        excess_list_id=el.id,
+        part_number=mpn,
+        quantity=10,
+        status="available",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(item)
+    db.flush()
+    return item
+
+
+@pytest.fixture()
+def _trader_client(db_session: Session, test_company: Company):
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    trader = _make_trader(db_session)
+    db_session.commit()
+
+    def _db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[require_user] = lambda: trader
+    try:
+        yield TestClient(app, raise_server_exceptions=False), trader
+    finally:
+        for dep in (get_db, require_user):
+            app.dependency_overrides.pop(dep, None)
+
+
+@pytest.fixture()
+def _buyer_client(db_session: Session, test_company: Company):
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    buyer = _make_buyer(db_session)
+    db_session.commit()
+
+    def _db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[require_user] = lambda: buyer
+    try:
+        yield TestClient(app, raise_server_exceptions=False), buyer
+    finally:
+        for dep in (get_db, require_user):
+            app.dependency_overrides.pop(dep, None)
+
+
+# ── Route error-path tests ─────────────────────────────────────────────────────
+
+
+class TestResellCreateFormErrors:
+    def test_buyer_cannot_access_create_form(self, _buyer_client):
+        """Non-trader users get 403 from the create-form route."""
+        client, _buyer = _buyer_client
+        r = client.get("/v2/partials/resell/create-form")
+        assert r.status_code == 403
+
+
+class TestResellLineOfferCompareErrors:
+    def test_non_owner_gets_403(self, _buyer_client, db_session: Session, test_company: Company):
+        client, buyer = _buyer_client
+        trader = _make_trader(db_session)
+        el = _make_list(db_session, trader, test_company)
+        line = _make_line(db_session, el)
+        db_session.commit()
+        r = client.get(f"/v2/partials/resell/{el.id}/lines/{line.id}/offers")
+        assert r.status_code == 403
+
+    def test_owner_with_missing_line_gets_404(self, _trader_client, db_session: Session, test_company: Company):
+        client, trader = _trader_client
+        el = _make_list(db_session, trader, test_company)
+        db_session.commit()
+        r = client.get(f"/v2/partials/resell/{el.id}/lines/999999/offers")
+        assert r.status_code == 404
+
+    def test_owner_with_line_from_different_list_gets_404(
+        self, _trader_client, db_session: Session, test_company: Company
+    ):
+        client, trader = _trader_client
+        el1 = _make_list(db_session, trader, test_company)
+        el2 = _make_list(db_session, trader, test_company)
+        line_on_el2 = _make_line(db_session, el2)
+        db_session.commit()
+        r = client.get(f"/v2/partials/resell/{el1.id}/lines/{line_on_el2.id}/offers")
+        assert r.status_code == 404
+
+
+class TestResellAddLineFormErrors:
+    def test_posted_list_returns_409(self, _trader_client, db_session: Session, test_company: Company):
+        client, trader = _trader_client
+        el = _make_list(db_session, trader, test_company, ExcessListStatus.COLLECTING)
+        db_session.commit()
+        r = client.get(f"/v2/partials/resell/{el.id}/add-line-form")
+        assert r.status_code == 409
+
+    def test_draft_list_returns_200(self, _trader_client, db_session: Session, test_company: Company):
+        client, trader = _trader_client
+        el = _make_draft_list(db_session, trader, test_company)
+        db_session.commit()
+        r = client.get(f"/v2/partials/resell/{el.id}/add-line-form")
+        assert r.status_code == 200
+
+
+@pytest.fixture()
+def _sales_client(db_session: Session, test_company: Company):
+    """A 'sales' user client: can post but not offer."""
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    sales = _make_sales_user(db_session)
+    db_session.commit()
+
+    def _db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[require_user] = lambda: sales
+    try:
+        yield TestClient(app, raise_server_exceptions=False), sales
+    finally:
+        for dep in (get_db, require_user):
+            app.dependency_overrides.pop(dep, None)
+
+
+class TestResellOfferFormErrors:
+    def test_owner_cannot_offer_on_own_list(self, _trader_client, db_session: Session, test_company: Company):
+        """List owner gets 403 when trying to offer on their own list."""
+        client, trader = _trader_client
+        el = _make_list(db_session, trader, test_company)
+        db_session.commit()
+        r = client.get(f"/v2/partials/resell/{el.id}/offer-form")
+        assert r.status_code == 403
+
+    def test_sales_user_cannot_offer(self, _sales_client, db_session: Session, test_company: Company):
+        """Sales role users cannot submit offers (not in _CAN_OFFER_ROLES)."""
+        client, sales = _sales_client
+        trader = _make_trader(db_session)
+        el = _make_list(db_session, trader, test_company)
+        db_session.commit()
+        r = client.get(f"/v2/partials/resell/{el.id}/offer-form")
+        assert r.status_code == 403
+
+
+class TestResellListFiltering:
+    def test_lists_stage_filter(self, _trader_client, db_session: Session, test_company: Company):
+        """Lists filtered by stage returns 200."""
+        client, trader = _trader_client
+        _make_list(db_session, trader, test_company)
+        db_session.commit()
+        r = client.get("/v2/partials/resell/lists?stage=collecting&lens=mine")
+        assert r.status_code == 200
+
+    def test_lists_q_filter(self, _trader_client, db_session: Session, test_company: Company):
+        """Lists filtered by search query returns 200."""
+        client, trader = _trader_client
+        _make_list(db_session, trader, test_company)
+        db_session.commit()
+        r = client.get("/v2/partials/resell/lists?q=surplus&lens=mine")
+        assert r.status_code == 200
+
+
+class TestResellCreateListErrors:
+    def test_buyer_cannot_create_list(self, _buyer_client, test_company: Company):
+        client, _buyer = _buyer_client
+        r = client.post(
+            "/api/resell/lists",
+            data={"title": "Test List", "company_id": test_company.id, "notes": ""},
+        )
+        assert r.status_code == 403
+
+
+class TestResellAddLineErrors:
+    def test_posted_list_add_line_returns_409(self, _trader_client, db_session: Session, test_company: Company):
+        client, trader = _trader_client
+        el = _make_list(db_session, trader, test_company, ExcessListStatus.COLLECTING)
+        db_session.commit()
+        r = client.post(
+            f"/api/resell/{el.id}/lines",
+            data={"part_number": "LM317T", "quantity": 10},
+        )
+        assert r.status_code == 409
+
+
+class TestResellBidBack:
+    def test_build_bid_invalid_json_returns_400(self, _trader_client, db_session: Session, test_company: Company):
+        client, trader = _trader_client
+        el = _make_list(db_session, trader, test_company)
+        db_session.commit()
+        r = client.post(
+            f"/api/resell/{el.id}/bid",
+            data={"selections_json": "not-json"},
+        )
+        assert r.status_code == 400
+
+    def test_build_bid_empty_list_returns_400(self, _trader_client, db_session: Session, test_company: Company):
+        client, trader = _trader_client
+        el = _make_list(db_session, trader, test_company)
+        db_session.commit()
+        r = client.post(
+            f"/api/resell/{el.id}/bid",
+            data={"selections_json": "[]"},
+        )
+        assert r.status_code == 400
+
+
+class TestResellPublishErrors:
+    def test_non_owner_cannot_publish(self, _buyer_client, db_session: Session, test_company: Company):
+        client, buyer = _buyer_client
+        trader = _make_trader(db_session)
+        el = _make_draft_list(db_session, trader, test_company)
+        db_session.commit()
+        r = client.post(f"/api/resell/{el.id}/publish")
+        assert r.status_code == 403

--- a/tests/test_nightly_seed_resell.py
+++ b/tests/test_nightly_seed_resell.py
@@ -1,0 +1,317 @@
+"""tests/test_nightly_seed_resell.py — Coverage tests for app/management/seed_resell_demo.py.
+
+Tests the idempotent demo-seeder's helper functions and the main seed() / _reset()
+entry points with the test DB, mocking external service calls (excess_service,
+excess_mirror) that would talk to the real supplier APIs.
+
+Called by: pytest (nightly coverage run)
+Depends on: conftest (db_session)
+"""
+
+import os
+from unittest.mock import patch
+
+from sqlalchemy.orm import Session
+
+os.environ.setdefault("TESTING", "1")
+
+from app.constants import ExcessListStatus, UserRole
+from app.management.seed_resell_demo import (
+    _BROKER_EMAIL,
+    _CUSTOMER_NAME,
+    _LIST_AWARDED,
+    _LIST_COLLECTING,
+    _LIST_ONEOFF,
+    _TRADER_EMAIL,
+    _build_awarded,
+    _build_collecting,
+    _build_oneoff,
+    _get_or_create_company,
+    _get_or_create_list,
+    _get_or_create_user,
+    _list_has_offers,
+    _now,
+    _reset,
+    seed,
+)
+from app.models import Company, User
+from app.models.excess import ExcessList
+
+# ── Pure helper tests ─────────────────────────────────────────────────────────
+
+
+def test_now_returns_utc_datetime():
+    ts = _now()
+    assert ts.tzinfo is not None
+    assert ts.year >= 2025
+
+
+class TestGetOrCreateUser:
+    def test_creates_new_user(self, db_session: Session):
+        email = "seed-test-create@example.com"
+        user = _get_or_create_user(db_session, email, "Test User", UserRole.BUYER)
+        db_session.flush()
+        assert user.email == email
+        assert user.role == UserRole.BUYER
+
+    def test_returns_existing_user(self, db_session: Session):
+        email = "seed-test-existing@example.com"
+        u1 = _get_or_create_user(db_session, email, "User One", UserRole.BUYER)
+        db_session.flush()
+        u2 = _get_or_create_user(db_session, email, "User Two", UserRole.TRADER)
+        db_session.flush()
+        assert u1.id == u2.id
+
+
+class TestGetOrCreateCompany:
+    def test_creates_new_company(self, db_session: Session):
+        name = "Seed Test Company Inc."
+        co = _get_or_create_company(db_session, name)
+        db_session.flush()
+        assert co.name == name
+
+    def test_returns_existing_company(self, db_session: Session):
+        name = "Seed Test Company Duplicate"
+        co1 = _get_or_create_company(db_session, name)
+        db_session.flush()
+        co2 = _get_or_create_company(db_session, name)
+        db_session.flush()
+        assert co1.id == co2.id
+
+
+class TestGetOrCreateList:
+    def _make_owner(self, db: Session) -> User:
+        u = User(
+            email="seed-list-owner@example.com",
+            name="List Owner",
+            role=UserRole.TRADER,
+            created_at=_now(),
+        )
+        db.add(u)
+        db.flush()
+        return u
+
+    def _make_company(self, db: Session) -> Company:
+        co = Company(name="List Co", account_type="Customer", is_active=True, created_at=_now())
+        db.add(co)
+        db.flush()
+        return co
+
+    def test_creates_new_list(self, db_session: Session):
+        owner = self._make_owner(db_session)
+        co = self._make_company(db_session)
+        el, created = _get_or_create_list(
+            db_session,
+            title="Seed Test List",
+            company=co,
+            owner=owner,
+            status=ExcessListStatus.COLLECTING,
+            close_in_days=5,
+        )
+        db_session.flush()
+        assert created is True
+        assert el.title == "Seed Test List"
+        assert el.status == ExcessListStatus.COLLECTING
+
+    def test_returns_existing_list(self, db_session: Session):
+        owner = self._make_owner(db_session)
+        co = self._make_company(db_session)
+        el1, c1 = _get_or_create_list(
+            db_session,
+            title="Seed Idempotent List",
+            company=co,
+            owner=owner,
+            status=ExcessListStatus.DRAFT,
+            close_in_days=None,
+        )
+        db_session.flush()
+        el2, c2 = _get_or_create_list(
+            db_session,
+            title="Seed Idempotent List",
+            company=co,
+            owner=owner,
+            status=ExcessListStatus.OPEN,
+            close_in_days=None,
+        )
+        db_session.flush()
+        assert c1 is True
+        assert c2 is False
+        assert el1.id == el2.id
+
+    def test_no_close_at_when_close_in_days_none(self, db_session: Session):
+        owner = self._make_owner(db_session)
+        co = self._make_company(db_session)
+        el, _ = _get_or_create_list(
+            db_session,
+            title="Seed No Close Date",
+            company=co,
+            owner=owner,
+            status=ExcessListStatus.AWARDED,
+            close_in_days=None,
+        )
+        db_session.flush()
+        if hasattr(el, "close_at"):
+            assert el.close_at is None
+
+
+class TestListHasOffers:
+    def test_no_offers_returns_false(self, db_session: Session):
+        owner = User(email="ho-owner@example.com", name="HO", role="trader", created_at=_now())
+        db_session.add(owner)
+        co = Company(name="HO Co", account_type="Customer", is_active=True, created_at=_now())
+        db_session.add(co)
+        db_session.flush()
+        el = ExcessList(
+            title="HO Test",
+            company_id=co.id,
+            owner_id=owner.id,
+            status=ExcessListStatus.COLLECTING,
+            created_at=_now(),
+        )
+        db_session.add(el)
+        db_session.flush()
+        assert _list_has_offers(db_session, el) is False
+
+
+# ── Build helpers (with mocked external calls) ────────────────────────────────
+
+
+def _make_seed_users(db: Session):
+    trader = User(
+        email=_TRADER_EMAIL,
+        name="Demo Trader",
+        role=UserRole.TRADER,
+        created_at=_now(),
+    )
+    db.add(trader)
+    broker = User(
+        email=_BROKER_EMAIL,
+        name="Demo Broker",
+        role=UserRole.BUYER,
+        created_at=_now(),
+    )
+    db.add(broker)
+    company = Company(name=_CUSTOMER_NAME, account_type="Customer", is_active=True, created_at=_now())
+    db.add(company)
+    db.flush()
+    return trader, broker, company
+
+
+class TestBuildAwarded:
+    def test_creates_awarded_list(self, db_session: Session):
+        trader, _broker, company = _make_seed_users(db_session)
+        _build_awarded(db_session, company, trader)
+        db_session.flush()
+        el = db_session.query(ExcessList).filter_by(title=_LIST_AWARDED).one()
+        assert el.status == ExcessListStatus.AWARDED
+
+    def test_idempotent(self, db_session: Session):
+        trader, _broker, company = _make_seed_users(db_session)
+        _build_awarded(db_session, company, trader)
+        db_session.flush()
+        _build_awarded(db_session, company, trader)
+        db_session.flush()
+        count = db_session.query(ExcessList).filter_by(title=_LIST_AWARDED).count()
+        assert count == 1
+
+
+class TestBuildCollecting:
+    def test_creates_collecting_list(self, db_session: Session):
+        trader, broker, company = _make_seed_users(db_session)
+        with (
+            patch("app.management.seed_resell_demo.excess_mirror.sync_list_mirror"),
+            patch("app.management.seed_resell_demo.excess_service.submit_offer"),
+            patch("app.management.seed_resell_demo.excess_service._resolve_line_material_card"),
+        ):
+            _build_collecting(db_session, company, trader, broker)
+            db_session.commit()
+
+        el = db_session.query(ExcessList).filter_by(title=_LIST_COLLECTING).one()
+        assert el.status == ExcessListStatus.COLLECTING
+
+    def test_idempotent_no_duplicate_lists(self, db_session: Session):
+        trader, broker, company = _make_seed_users(db_session)
+        with (
+            patch("app.management.seed_resell_demo.excess_mirror.sync_list_mirror"),
+            patch("app.management.seed_resell_demo.excess_service.submit_offer"),
+            patch("app.management.seed_resell_demo.excess_service._resolve_line_material_card"),
+        ):
+            _build_collecting(db_session, company, trader, broker)
+            db_session.commit()
+            _build_collecting(db_session, company, trader, broker)
+            db_session.commit()
+
+        count = db_session.query(ExcessList).filter_by(title=_LIST_COLLECTING).count()
+        assert count == 1
+
+
+class TestBuildOneoff:
+    def test_creates_oneoff_list(self, db_session: Session):
+        trader, broker, company = _make_seed_users(db_session)
+        with (
+            patch("app.management.seed_resell_demo.excess_mirror.sync_list_mirror"),
+            patch("app.management.seed_resell_demo.excess_service.submit_offer"),
+            patch("app.management.seed_resell_demo.excess_service._resolve_line_material_card"),
+        ):
+            _build_oneoff(db_session, company, trader, broker)
+            db_session.commit()
+
+        el = db_session.query(ExcessList).filter_by(title=_LIST_ONEOFF).one()
+        assert el.status == ExcessListStatus.OPEN
+
+
+class TestSeed:
+    def test_seed_creates_all_three_lists(self, db_session: Session):
+        with (
+            patch("app.management.seed_resell_demo.excess_mirror.sync_list_mirror"),
+            patch("app.management.seed_resell_demo.excess_service.submit_offer"),
+            patch("app.management.seed_resell_demo.excess_service._resolve_line_material_card"),
+        ):
+            seed(db_session)
+            db_session.commit()
+
+        titles = {el.title for el in db_session.query(ExcessList).all()}
+        assert _LIST_COLLECTING in titles
+        assert _LIST_ONEOFF in titles
+        assert _LIST_AWARDED in titles
+
+    def test_seed_idempotent(self, db_session: Session):
+        with (
+            patch("app.management.seed_resell_demo.excess_mirror.sync_list_mirror"),
+            patch("app.management.seed_resell_demo.excess_service.submit_offer"),
+            patch("app.management.seed_resell_demo.excess_service._resolve_line_material_card"),
+        ):
+            seed(db_session)
+            db_session.commit()
+            seed(db_session)
+            db_session.commit()
+
+        count = (
+            db_session.query(ExcessList)
+            .filter(ExcessList.title.in_([_LIST_COLLECTING, _LIST_ONEOFF, _LIST_AWARDED]))
+            .count()
+        )
+        assert count == 3
+
+
+class TestReset:
+    def test_reset_removes_demo_data(self, db_session: Session):
+        with (
+            patch("app.management.seed_resell_demo.excess_mirror.sync_list_mirror"),
+            patch("app.management.seed_resell_demo.excess_service.submit_offer"),
+            patch("app.management.seed_resell_demo.excess_service._resolve_line_material_card"),
+        ):
+            seed(db_session)
+            db_session.commit()
+
+        _reset(db_session)
+        count = (
+            db_session.query(ExcessList)
+            .filter(ExcessList.title.in_([_LIST_COLLECTING, _LIST_ONEOFF, _LIST_AWARDED]))
+            .count()
+        )
+        assert count == 0
+
+    def test_reset_noop_when_no_data(self, db_session: Session):
+        # Should not raise even when there's nothing to delete
+        _reset(db_session)

--- a/tests/test_nightly_seed_resell.py
+++ b/tests/test_nightly_seed_resell.py
@@ -1,11 +1,11 @@
-"""tests/test_nightly_seed_resell.py — Coverage tests for app/management/seed_resell_demo.py.
+"""tests/test_nightly_seed_resell.py — Coverage tests for
+app/management/seed_resell_demo.py.
 
-Tests the idempotent demo-seeder's helper functions and the main seed() / _reset()
-entry points with the test DB, mocking external service calls (excess_service,
-excess_mirror) that would talk to the real supplier APIs.
+Tests the idempotent demo-seeder's helper functions and the main seed() / _reset() entry
+points with the test DB, mocking external service calls (excess_service, excess_mirror)
+that would talk to the real supplier APIs.
 
-Called by: pytest (nightly coverage run)
-Depends on: conftest (db_session)
+Called by: pytest (nightly coverage run) Depends on: conftest (db_session)
 """
 
 import os

--- a/tests/test_nightly_tbf_worker_main.py
+++ b/tests/test_nightly_tbf_worker_main.py
@@ -1,4 +1,5 @@
-"""tests/test_nightly_tbf_worker_main.py — Coverage tests for tbf_worker/worker.py main loop.
+"""tests/test_nightly_tbf_worker_main.py — Coverage tests for tbf_worker/worker.py main
+loop.
 
 Tests the main() coroutine's various execution branches by mocking all browser/DB/API
 dependencies and letting the loop take one tick before receiving a shutdown signal.
@@ -6,8 +7,7 @@ dependencies and letting the loop take one tick before receiving a shutdown sign
 All symbols imported *inside* main() are patched at their source modules, not on the
 worker module (they're not module-level attributes in worker.py).
 
-Called by: pytest (nightly coverage run)
-Depends on: conftest (db_session)
+Called by: pytest (nightly coverage run) Depends on: conftest (db_session)
 """
 
 import asyncio
@@ -542,7 +542,8 @@ class TestTbfWorkerMain:
 
     @pytest.mark.asyncio
     async def test_session_expired_health_requeues_item(self):
-        """SESSION_EXPIRED page health re-queues the item (mark_status with 'queued')."""
+        """SESSION_EXPIRED page health re-queues the item (mark_status with
+        'queued')."""
         import app.services.tbf_worker.worker as wmod
 
         sm = _make_sm(is_logged_in=True)

--- a/tests/test_nightly_tbf_worker_main.py
+++ b/tests/test_nightly_tbf_worker_main.py
@@ -1,0 +1,602 @@
+"""tests/test_nightly_tbf_worker_main.py — Coverage tests for tbf_worker/worker.py main loop.
+
+Tests the main() coroutine's various execution branches by mocking all browser/DB/API
+dependencies and letting the loop take one tick before receiving a shutdown signal.
+
+All symbols imported *inside* main() are patched at their source modules, not on the
+worker module (they're not module-level attributes in worker.py).
+
+Called by: pytest (nightly coverage run)
+Depends on: conftest (db_session)
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("TESTING", "1")
+
+
+def _make_mock_db():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    db.close = MagicMock()
+    db.add = MagicMock()
+    db.commit = MagicMock()
+    return db
+
+
+def _make_mock_ctx(mock_db=None):
+    if mock_db is None:
+        mock_db = _make_mock_db()
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=mock_db)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+def _make_sm(*, is_logged_in=True, start_raises=None, login_result=True):
+    sm = AsyncMock()
+    sm.is_logged_in = is_logged_in
+    sm.page = MagicMock()
+    sm.start = AsyncMock(side_effect=start_raises) if start_raises else AsyncMock()
+    sm.login = AsyncMock(return_value=login_result)
+    sm.stop = AsyncMock()
+    sm.ensure_session = AsyncMock(return_value=True)
+    return sm
+
+
+def _make_normal_scheduler(tick_limit=1, *, on_tick=None):
+    """Scheduler that permits work for `tick_limit` ticks then triggers shutdown."""
+    tick = {"n": 0}
+
+    class _S:
+        def is_business_hours(self_inner):
+            tick["n"] += 1
+            if on_tick:
+                on_tick(tick["n"])
+            return True
+
+        def time_for_break(self_inner):
+            return False
+
+        def next_delay(self_inner):
+            return 0.001
+
+    return _S()
+
+
+# The standard patches used by every test that reaches the main loop body.
+# Symbol → its actual module path (all are imported *inside* main(), not at module level).
+_QUEUE_RECOVER = "app.services.tbf_worker.queue_manager.recover_stale_searches"
+_QUEUE_CLAIM = "app.services.tbf_worker.queue_manager.claim_next_queued_item"
+_QUEUE_COMPLETE = "app.services.tbf_worker.queue_manager.mark_completed"
+_QUEUE_STATUS = "app.services.tbf_worker.queue_manager.mark_status"
+_AI_GATE = "app.services.tbf_worker.ai_gate.process_ai_gate"
+_SESSION_MGR = "app.services.tbf_worker.session_manager.TbfSessionManager"
+_SCHEDULER = "app.services.tbf_worker.scheduler.SearchScheduler"
+_BREAKER = "app.services.tbf_worker.circuit_breaker.CircuitBreaker"
+_CONFIG = "app.services.tbf_worker.config.TbfConfig"
+_SEARCH_PART = "app.services.tbf_worker.search_engine.search_part"
+_PARSE_HTML = "app.services.tbf_worker.result_parser.parse_results_html"
+_SAVE_SIGHTINGS = "app.services.tbf_worker.sighting_writer.save_tbf_sightings"
+_SESSION_LOCAL = "app.database.SessionLocal"
+_SLEEP = "app.services.tbf_worker.worker.asyncio.sleep"
+_UPDATE_STATUS = "app.services.tbf_worker.worker.update_worker_status"
+_DB_SESSION = "app.services.tbf_worker.worker._db_session"
+
+
+class TestTbfWorkerMain:
+    """Exercises the main() loop paths via mocked dependencies."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_on_flag_before_loop(self):
+        """Setting _shutdown_requested before the loop causes immediate clean exit."""
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(is_logged_in=True)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+
+        wmod._shutdown_requested = True
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_make_normal_scheduler()),
+                patch(_BREAKER, return_value=MagicMock(should_stop=lambda: False)),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        sm.stop.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_off_hours_sleeps(self):
+        """Off-hours path: loop calls asyncio.sleep(30*60)."""
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(is_logged_in=True)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+        sleep_mock = AsyncMock()
+        tick = {"n": 0}
+
+        class _OffHoursScheduler:
+            def is_business_hours(self_inner):
+                tick["n"] += 1
+                if tick["n"] >= 1:
+                    wmod._shutdown_requested = True
+                return False
+
+            def time_for_break(self_inner):
+                return False
+
+            def next_delay(self_inner):
+                return 0.001
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_OffHoursScheduler()),
+                patch(_BREAKER, return_value=MagicMock(should_stop=lambda: False)),
+                patch(_SLEEP, sleep_mock),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        sleep_mock.assert_any_await(30 * 60)
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_sleeps(self):
+        """Daily-limit path: loop calls asyncio.sleep(60*60)."""
+        import app.services.tbf_worker.worker as wmod
+        from app.services.tbf_worker.config import TbfConfig
+
+        sm = _make_sm(is_logged_in=True)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+        sleep_mock = AsyncMock()
+        tick = {"n": 0}
+
+        class _LimitScheduler:
+            def is_business_hours(self_inner):
+                tick["n"] += 1
+                if tick["n"] >= 1:
+                    wmod._shutdown_requested = True
+                return True
+
+            def time_for_break(self_inner):
+                return False
+
+            def next_delay(self_inner):
+                return 0.001
+
+        cfg = TbfConfig()
+        patched_cfg = MagicMock()
+        patched_cfg.TBF_MAX_DAILY_SEARCHES = 0  # triggers limit immediately
+        patched_cfg.TBF_BREAKER_COOLDOWN_MINUTES = cfg.TBF_BREAKER_COOLDOWN_MINUTES
+        patched_cfg.TBF_SEARCH_TIMEOUT_SECONDS = 30
+        patched_cfg.TBF_MIN_DELAY_SECONDS = 0.001
+        patched_cfg.TBF_MAX_DELAY_SECONDS = 0.001
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_LimitScheduler()),
+                patch(_BREAKER, return_value=MagicMock(should_stop=lambda: False)),
+                patch(_CONFIG, return_value=patched_cfg),
+                patch(_SLEEP, sleep_mock),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        sleep_mock.assert_any_await(60 * 60)
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_open_sleeps(self):
+        """Open circuit breaker: loop calls asyncio.sleep(60*60)."""
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(is_logged_in=True)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+        sleep_mock = AsyncMock()
+        tick = {"n": 0}
+
+        class _Scheduler:
+            def is_business_hours(self_inner):
+                tick["n"] += 1
+                if tick["n"] >= 1:
+                    wmod._shutdown_requested = True
+                return True
+
+            def time_for_break(self_inner):
+                return False
+
+            def next_delay(self_inner):
+                return 0.001
+
+        breaker = MagicMock()
+        breaker.should_stop.return_value = True
+        breaker.get_trip_info.return_value = {"trip_reason": "test-error"}
+        breaker.trip_reason = "test-error"
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_Scheduler()),
+                patch(_BREAKER, return_value=breaker),
+                patch(_SLEEP, sleep_mock),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        sleep_mock.assert_any_await(60 * 60)
+
+    @pytest.mark.asyncio
+    async def test_break_time_sleeps(self):
+        """Break-time path: loop sleeps for the break duration."""
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(is_logged_in=True)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+        sleep_mock = AsyncMock()
+        tick = {"n": 0}
+
+        class _BreakScheduler:
+            def is_business_hours(self_inner):
+                return True
+
+            def time_for_break(self_inner):
+                tick["n"] += 1
+                if tick["n"] >= 1:
+                    wmod._shutdown_requested = True
+                return True
+
+            def get_break_duration(self_inner):
+                return 7
+
+            def reset_break_counter(self_inner):
+                pass
+
+            def next_delay(self_inner):
+                return 0.001
+
+        breaker = MagicMock()
+        breaker.should_stop.return_value = False
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_BreakScheduler()),
+                patch(_BREAKER, return_value=breaker),
+                patch(_SLEEP, sleep_mock),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        sleep_mock.assert_any_await(7)
+
+    @pytest.mark.asyncio
+    async def test_empty_queue_sleeps(self):
+        """Empty queue: loop sleeps 60s then shuts down."""
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(is_logged_in=True)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+        sleep_mock = AsyncMock()
+        tick = {"n": 0}
+
+        class _Scheduler:
+            def is_business_hours(self_inner):
+                return True
+
+            def time_for_break(self_inner):
+                return False
+
+            def next_delay(self_inner):
+                return 0.001
+
+        breaker = MagicMock()
+        breaker.should_stop.return_value = False
+
+        def _claim(db):
+            tick["n"] += 1
+            if tick["n"] >= 1:
+                wmod._shutdown_requested = True
+            return None
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_AI_GATE, new_callable=AsyncMock),
+                patch(_QUEUE_CLAIM, side_effect=_claim),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_Scheduler()),
+                patch(_BREAKER, return_value=breaker),
+                patch(_SLEEP, sleep_mock),
+                patch(_SESSION_LOCAL, return_value=mock_db),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        sleep_mock.assert_any_await(60)
+
+    @pytest.mark.asyncio
+    async def test_session_auth_failure_sleeps_5min(self):
+        """ensure_session() returning False marks item failed and sleeps 5min."""
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(is_logged_in=True)
+        sm.ensure_session = AsyncMock(return_value=False)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+        sleep_mock = AsyncMock()
+        tick = {"n": 0}
+        statuses = []
+
+        class _Scheduler:
+            def is_business_hours(self_inner):
+                return True
+
+            def time_for_break(self_inner):
+                return False
+
+            def next_delay(self_inner):
+                return 0.001
+
+        breaker = MagicMock()
+        breaker.should_stop.return_value = False
+
+        mock_item = MagicMock()
+        mock_item.mpn = "LM317T"
+        mock_item.id = 42
+
+        def _claim(db):
+            tick["n"] += 1
+            if tick["n"] >= 1:
+                wmod._shutdown_requested = True
+            return mock_item
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_AI_GATE, new_callable=AsyncMock),
+                patch(_QUEUE_CLAIM, side_effect=_claim),
+                patch(_QUEUE_STATUS, side_effect=lambda db, item, s, **kw: statuses.append(s)),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_Scheduler()),
+                patch(_BREAKER, return_value=breaker),
+                patch(_SLEEP, sleep_mock),
+                patch(_SESSION_LOCAL, return_value=mock_db),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        sleep_mock.assert_any_await(5 * 60)
+        assert "failed" in statuses
+
+    @pytest.mark.asyncio
+    async def test_search_timeout_fails_item(self):
+        """Search timeout marks item failed and continues."""
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(is_logged_in=True)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+        sleep_mock = AsyncMock()
+        tick = {"n": 0}
+        statuses = []
+
+        class _Scheduler:
+            def is_business_hours(self_inner):
+                return True
+
+            def time_for_break(self_inner):
+                return False
+
+            def next_delay(self_inner):
+                return 0.001
+
+        breaker = MagicMock()
+        breaker.should_stop.return_value = False
+
+        mock_item = MagicMock()
+        mock_item.mpn = "XC7A35T"
+        mock_item.id = 99
+
+        def _claim(db):
+            tick["n"] += 1
+            if tick["n"] >= 1:
+                wmod._shutdown_requested = True
+            return mock_item
+
+        async def _timed_out(*args, **kwargs):
+            raise asyncio.TimeoutError
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_AI_GATE, new_callable=AsyncMock),
+                patch(_QUEUE_CLAIM, side_effect=_claim),
+                patch(_QUEUE_STATUS, side_effect=lambda db, item, s, **kw: statuses.append(s)),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_Scheduler()),
+                patch(_BREAKER, return_value=breaker),
+                patch(_SLEEP, sleep_mock),
+                patch(_SESSION_LOCAL, return_value=mock_db),
+                patch("asyncio.wait_for", side_effect=_timed_out),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        assert "failed" in statuses
+
+    @pytest.mark.asyncio
+    async def test_successful_search_marks_completed(self):
+        """Happy path: search returns HTML, sightings written, item marked completed."""
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(is_logged_in=True)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+        sleep_mock = AsyncMock()
+        tick = {"n": 0}
+        completed_calls = []
+
+        class _Scheduler:
+            def is_business_hours(self_inner):
+                return True
+
+            def time_for_break(self_inner):
+                return False
+
+            def next_delay(self_inner):
+                return 0.001
+
+        breaker = MagicMock()
+        breaker.should_stop.return_value = False
+        breaker.check_page_health = AsyncMock(return_value="OK")
+        breaker.record_results = MagicMock()
+        breaker.record_empty_results = MagicMock()
+
+        mock_item = MagicMock()
+        mock_item.mpn = "LM317T"
+        mock_item.id = 77
+
+        def _claim(db):
+            tick["n"] += 1
+            if tick["n"] >= 1:
+                wmod._shutdown_requested = True
+            return mock_item
+
+        async def _search(page, mpn):
+            return {"html": "<html>results</html>", "duration_ms": 50}
+
+        sighting = MagicMock()
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_AI_GATE, new_callable=AsyncMock),
+                patch(_QUEUE_CLAIM, side_effect=_claim),
+                patch(_QUEUE_COMPLETE, side_effect=lambda *a, **kw: completed_calls.append(kw)),
+                patch(_QUEUE_STATUS),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_Scheduler()),
+                patch(_BREAKER, return_value=breaker),
+                patch(_SLEEP, sleep_mock),
+                patch(_SESSION_LOCAL, return_value=mock_db),
+                patch(_SEARCH_PART, side_effect=_search),
+                patch(_PARSE_HTML, return_value=[sighting]),
+                patch(_SAVE_SIGHTINGS, return_value=1),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        assert completed_calls, "mark_completed should have been called"
+
+    @pytest.mark.asyncio
+    async def test_session_expired_health_requeues_item(self):
+        """SESSION_EXPIRED page health re-queues the item (mark_status with 'queued')."""
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(is_logged_in=True)
+        mock_db = _make_mock_db()
+        ctx = _make_mock_ctx(mock_db)
+        sleep_mock = AsyncMock()
+        tick = {"n": 0}
+        statuses = []
+
+        class _Scheduler:
+            def is_business_hours(self_inner):
+                return True
+
+            def time_for_break(self_inner):
+                return False
+
+            def next_delay(self_inner):
+                return 0.001
+
+        breaker = MagicMock()
+        breaker.should_stop.return_value = False
+        breaker.check_page_health = AsyncMock(return_value="SESSION_EXPIRED")
+
+        mock_item = MagicMock()
+        mock_item.mpn = "ATmega328P"
+        mock_item.id = 55
+
+        def _claim(db):
+            tick["n"] += 1
+            if tick["n"] >= 1:
+                wmod._shutdown_requested = True
+            return mock_item
+
+        async def _search(page, mpn):
+            return {"html": "<html/>", "duration_ms": 10}
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_AI_GATE, new_callable=AsyncMock),
+                patch(_QUEUE_CLAIM, side_effect=_claim),
+                patch(_QUEUE_STATUS, side_effect=lambda db, item, s, **kw: statuses.append(s)),
+                patch(_SESSION_MGR, return_value=sm),
+                patch(_SCHEDULER, return_value=_Scheduler()),
+                patch(_BREAKER, return_value=breaker),
+                patch(_SLEEP, sleep_mock),
+                patch(_SESSION_LOCAL, return_value=mock_db),
+                patch(_SEARCH_PART, side_effect=_search),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        assert "queued" in statuses


### PR DESCRIPTION
## Summary

- **`app/management/seed_resell_demo.py`**: 0% → 88% — helper functions (`_get_or_create_user/company/list`, `_list_has_offers`, `_now`) + `seed()` / `_reset()` entry points, mocking `excess_service` / `excess_mirror`
- **`app/routers/quality_plans.py`**: 81% → 93% — pure-function coverage for `_coerce` (bool/int/text/None), `_parse_date` (valid/empty/invalid), `_section_approved` (both gate types); route error paths (404 on missing QP, 200 re-render on `IncompleteQPError`, no-op PATCH on approved section, FRU wrong-QP 404)
- **`app/routers/resell.py`**: 81% → 88% — `_file_extension` (no-dot case), `_hours_until` (None, naive datetime, overdue), `_offer_coverage`; route 403/404/409/400 paths (non-owner offer comparison, create-form 403 for buyer, add-line-form 409 on posted list, bid JSON parse errors, non-owner publish 403)
- **`app/services/tbf_worker/worker.py`**: 40% → 90% — full `main()` loop branch coverage: shutdown flag, off-hours sleep, daily-limit sleep, circuit-breaker sleep, break-time sleep, empty-queue sleep, session-auth failure, search timeout, successful search, SESSION_EXPIRED re-queue

Overall total coverage: 94% → **95%**.

## Test plan

- [ ] `TESTING=1 PYTHONPATH=. python3 -m pytest tests/test_nightly_qp_coverage.py tests/test_nightly_resell_coverage.py tests/test_nightly_seed_resell.py tests/test_nightly_tbf_worker_main.py -v` → 88 passed
- [ ] Full suite coverage confirms all 4 modules ≥ 85%

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoS3E4nUAhpoEwptX75rPn)_