### PR TITLE
fix(connectors): preserve operator is_active toggle across reboots

### DIFF
--- a/app/startup.py
+++ b/app/startup.py
@@ -95,7 +95,7 @@ def run_startup_migrations() -> None:
         _seed_manufacturers(conn)
         _create_count_triggers(conn)
         _backfill_company_counts(conn)
-        _exec(conn, "UPDATE api_sources SET is_active = false WHERE status = 'disabled' AND is_active = true")
+        _reconcile_connector_active(conn)
         # Normalize legacy site_type 'headquarters' → 'hq' (idempotent)
         _exec(conn, "UPDATE customer_sites SET site_type='hq' WHERE site_type='headquarters'")
         _exec(
@@ -282,6 +282,36 @@ def _exec(conn, stmt: str, params: dict | None = None) -> None:  # noqa: S603
     except (SQLAlchemyError, DBAPIError) as e:
         logger.warning("DDL failed: {}", e)
         conn.rollback()
+
+
+def _reconcile_connector_active(conn) -> None:
+    """Boot-time connector reconciliation seam — intentionally leaves ``is_active``
+    alone.
+
+    ``ApiSource.status`` is the auto-managed health state (set by
+    ``app/services/health_monitor.py``; ``'disabled'`` means "no connector
+    available"); ``ApiSource.is_active`` is the *operator* toggle (set by
+    ``PUT /api/sources/{id}/activate`` in ``app/routers/sources.py``). They are
+    orthogonal concerns. A previous version coupled them here —
+    ``UPDATE api_sources SET is_active = false WHERE status = 'disabled'`` — which
+    silently wiped operator intent on every reboot (the boot-reset defect).
+
+    Root cause: a source the operator turned on simply can't run while it has no
+    connector, but its toggle must be *retained* so it resumes automatically once
+    health recovers. So boot reconciliation must change ``is_active`` in neither
+    direction; only an explicit operator action may flip it. The readers downstream
+    (``app/routers/sources.py``, ``app/services/health_monitor.py``) all merely
+    *filter* on ``is_active`` and never assume "disabled ⇒ inactive", so leaving
+    the toggle intact is safe.
+
+    Kept as a named, directly-testable seam (``run_startup_migrations`` short-
+    circuits under ``TESTING``, so the regression test calls this helper directly).
+    Takes ``conn`` for symmetry with its sibling startup steps and so any future
+    reconciliation has the connection already wired.
+
+    Called by: run_startup_migrations (real boots), tests (directly)
+    Depends on: nothing — a no-op by design; the regression test pins the contract.
+    """
 
 
 # ── Full-text search triggers (PostgreSQL-specific) ─────────────────

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -21,7 +21,7 @@ from sqlalchemy import create_engine
 from sqlalchemy import text as sqltext
 from sqlalchemy.pool import StaticPool
 
-from app.startup import _exec, run_startup_migrations
+from app.startup import _exec, _reconcile_connector_active, run_startup_migrations
 
 
 def _make_sqlite_engine():
@@ -1252,3 +1252,43 @@ class TestBackfillSweepCooldown:
 
         db_session.refresh(pa)
         assert pa.reclaim_blocked_until is None
+
+
+def _make_api_sources_engine():
+    """SQLite engine with a minimal ``api_sources`` table for reconciliation tests.
+
+    Mirrors only the two columns ``_reconcile_connector_active`` arbitrates: the
+    auto-managed health ``status`` and the operator ``is_active`` toggle.
+    """
+    eng = _make_sqlite_engine()
+    with eng.connect() as conn:
+        conn.execute(
+            sqltext("CREATE TABLE api_sources (id INTEGER PRIMARY KEY, name TEXT, status TEXT, is_active BOOLEAN)")
+        )
+        # Operator turned this source ON; health later marked it 'disabled' (no connector).
+        conn.execute(
+            sqltext("INSERT INTO api_sources (id, name, status, is_active) VALUES (1, 'brokerbin', 'disabled', 1)")
+        )
+        # Health says 'live' but the operator turned it OFF — reconciliation must not re-enable it.
+        conn.execute(sqltext("INSERT INTO api_sources (id, name, status, is_active) VALUES (2, 'nexar', 'live', 0)"))
+        conn.commit()
+    return eng
+
+
+def test_reconcile_connector_active_preserves_operator_intent():
+    """Boot reconciliation must never clobber the operator's ``is_active`` toggle.
+
+    Regression for the boot-reset defect: startup coupled the auto-managed health
+    ``status`` to the operator ``is_active`` toggle, flipping operator-enabled
+    sources OFF on every reboot. Reconciliation must leave ``is_active`` untouched
+    in BOTH directions — neither disable a health-'disabled' source the operator
+    turned on (so it can run again once health recovers), nor auto-enable a
+    health-'live' source the operator turned off.
+    """
+    eng = _make_api_sources_engine()
+    with eng.connect() as conn:
+        _reconcile_connector_active(conn)
+        rows = dict(conn.execute(sqltext("SELECT name, is_active FROM api_sources")).all())
+
+    assert rows["brokerbin"], "operator-enabled source must stay active despite status='disabled'"
+    assert not rows["nexar"], "reconciliation must not auto-enable an operator-disabled source"


### PR DESCRIPTION
## Phase 0 of the Approvals-rework program — warm-up boot-reset defect

### Problem
`run_startup_migrations()` ran, on **every boot**:
```sql
UPDATE api_sources SET is_active = false WHERE status = 'disabled' AND is_active = true
```
This coupled two orthogonal concerns:
- `ApiSource.status` — auto-managed **health** state (set by `health_monitor.py`; `'disabled'` = no connector available)
- `ApiSource.is_active` — the **operator** toggle (set by `PUT /api/sources/{id}/activate`)

So any connector an operator switched on came back **off** after a reboot — operator intent silently wiped.

### Fix (root cause, not band-aid)
The two fields are independent. A source the operator enabled simply can't run while it has no connector, but its toggle must be **retained** so it resumes automatically once health recovers. Boot reconciliation must therefore change `is_active` in **neither** direction.

- Removed the coupling; routed through a named, no-op `_reconcile_connector_active(conn)` seam. `run_startup_migrations()` short-circuits under `TESTING`, so this seam is what the regression test drives directly (keeps the test non-vacuous).
- Added `test_reconcile_connector_active_preserves_operator_intent`: seeds `(status='disabled', is_active=True)` and `(status='live', is_active=False)`, runs reconciliation, asserts the operator toggle is untouched in **both** directions.

### Reader audit (app-wide, beyond the two files originally scoped)
Every `is_active` reader — `routers/sources.py`, `services/health_monitor.py`, `services/connector_service.py::_display_state`, `routers/htmx_views.py` test-all — only **filters** on the toggle; none assumes "disabled ⇒ inactive". `_display_state` treats `is_active=False` as `"off"` = "operator switched it off", so the fix makes that label *accurate* (an operator-enabled-but-health-disabled source now shows `untested`/`needs_setup`, not a false `off`). The part-search path gates connectors on **env-var API keys**, not this toggle — no search-path risk.

### Tests
`test_startup.py` + all startup/connector/source/health suites green locally (346 passed). Watched the regression test fail against the extracted coupling before fixing (TDD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)