### PR TITLE
Approvals: one manager approval for every buy plan + buy-plan naming (frozen scope)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -248,7 +248,6 @@ class Settings(BaseSettings):
     po_verify_interval_min: int = 30
 
     # --- Buy Plan V3 ---
-    buyplan_auto_approve_threshold: float = 5000
     buyplan_stale_offer_days: int = 5
     sighting_stale_days: int = 3  # Days before a requirement is flagged stale
     buyplan_min_margin_pct: float = 10

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -11324,7 +11324,7 @@ async def sales_order_create(
         resp.headers["HX-Trigger"] = json.dumps(
             {
                 "showToast": {
-                    "message": f"There is already an open Sales Order for this requisition (plan #{existing_id}).",
+                    "message": f"There is already an open buy plan for this requisition (plan #{existing_id}).",
                     "type": "warning",
                 }
             }
@@ -11334,7 +11334,7 @@ async def sales_order_create(
     except ValueError:
         # Any other origination failure (e.g. requisition has no requirements). Return a
         # curated client message rather than echoing the raw builder error.
-        raise HTTPException(400, "Could not originate a Sales Order from the selected offers.")
+        raise HTTPException(400, "Could not build a buy plan from the selected offers.")
 
     resp = await buy_plan_detail_partial(request, plan.id, user, db)
     resp.headers["HX-Push-Url"] = f"/v2/buy-plans/{plan.id}"

--- a/app/services/buyplan_workflow.py
+++ b/app/services/buyplan_workflow.py
@@ -70,19 +70,12 @@ def submit_buy_plan(
 
     plan.is_stock_sale = _is_stock_sale(plan, db)
 
-    # Auto-approve decision
-    if _should_auto_approve(plan):
-        plan.status = BuyPlanStatus.ACTIVE.value
-        plan.auto_approved = True
-        plan.approved_at = datetime.now(timezone.utc)
-        logger.info("Buy plan {} auto-approved (cost={:.2f})", plan_id, float(plan.total_cost or 0))
-        _generate_buyer_tasks(plan, db)
-    else:
-        plan.status = BuyPlanStatus.PENDING.value
-        logger.info("Buy plan {} pending approval (cost={:.2f})", plan_id, float(plan.total_cost or 0))
-        # Open the engine gate: route a BUY_PLAN ApprovalRequest to can_approve_buy_plans
-        # holders (cancels any stale open request first — RISK 2).
-        _open_engine_request_for_plan(plan, user, db)
+    # Every plan goes to the one manager approval — no auto-approve (frozen scope).
+    plan.status = BuyPlanStatus.PENDING.value
+    logger.info("Buy plan {} submitted for approval (cost={:.2f})", plan_id, float(plan.total_cost or 0))
+    # Open the engine gate: route a BUY_PLAN ApprovalRequest to can_approve_buy_plans
+    # holders (cancels any stale open request first — RISK 2).
+    _open_engine_request_for_plan(plan, user, db)
 
     db.flush()
     return plan
@@ -850,16 +843,11 @@ def resubmit_buy_plan(
     plan.submitted_at = datetime.now(timezone.utc)
     plan.salesperson_notes = salesperson_notes
 
-    # Auto-approve decision (same logic as initial submit)
-    if _should_auto_approve(plan):
-        plan.status = BuyPlanStatus.ACTIVE.value
-        plan.auto_approved = True
-        plan.approved_at = datetime.now(timezone.utc)
-    else:
-        plan.status = BuyPlanStatus.PENDING.value
-        # Re-open the engine gate. Cancels the stale request from the prior submission so
-        # exactly ONE REQUESTED request exists for this plan (RISK 2).
-        _open_engine_request_for_plan(plan, user, db)
+    # Every plan goes to the one manager approval — no auto-approve (frozen scope).
+    plan.status = BuyPlanStatus.PENDING.value
+    # Re-open the engine gate. Cancels the stale request from the prior submission so
+    # exactly ONE REQUESTED request exists for this plan (RISK 2).
+    _open_engine_request_for_plan(plan, user, db)
 
     db.flush()
     return plan
@@ -898,23 +886,6 @@ def _generate_buyer_tasks(plan: BuyPlan, db: Session) -> None:
             )
         except Exception:
             logger.warning("Buyer task auto-gen failed for plan {} line {}", plan.id, line.id, exc_info=True)
-
-
-# ── Helpers: Auto-Approval ───────────────────────────────────────────
-
-
-def _should_auto_approve(plan: BuyPlan) -> bool:
-    """Decide whether a buy plan should be auto-approved.
-
-    Auto-approves when total cost < threshold AND no critical AI flags. Used by both
-    submit_buy_plan() and resubmit_buy_plan().
-    """
-    total = float(plan.total_cost or 0)
-    has_critical = any(
-        (f.get("severity") if isinstance(f, dict) else getattr(f, "severity", None)) == "critical"
-        for f in (plan.ai_flags or [])
-    )
-    return total < settings.buyplan_auto_approve_threshold and not has_critical
 
 
 # ── Helpers: Line Edits ──────────────────────────────────────────────

--- a/app/templates/htmx/partials/approvals/_sales_order_new.html
+++ b/app/templates/htmx/partials/approvals/_sales_order_new.html
@@ -17,7 +17,7 @@
 {# ── Mode 1: requisition picker ── #}
 <div>
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-lg font-semibold text-gray-900">New Sales Order</h2>
+    <h2 class="text-lg font-semibold text-gray-900">New Buy Plan</h2>
     <button hx-get="/v2/partials/approvals/sales-orders"
             hx-target="#bp-hub-body"
             hx-swap="innerHTML"
@@ -26,7 +26,7 @@
     </button>
   </div>
   <p class="text-sm text-gray-600 mb-4">
-    Pick a requisition with offers to originate a Sales Order directly from its RFQ offers.
+    Pick a requisition with offers to build a buy plan directly from its RFQ offers.
   </p>
   {% if picker_rows %}
   <div class="divide-y divide-line-base rounded-lg border border-line-base bg-white">
@@ -47,7 +47,7 @@
   </div>
   {% else %}
   <div class="rounded-lg border border-line-base bg-gray-50 px-4 py-8 text-center text-sm text-gray-600">
-    No open requisitions with offers are available to originate a Sales Order.
+    No open requisitions with offers are available to build a buy plan.
   </div>
   {% endif %}
 </div>
@@ -57,7 +57,7 @@
   <div class="flex items-center justify-between mb-4">
     <div class="min-w-0">
       <h2 class="text-lg font-semibold text-gray-900 truncate">
-        New Sales Order — {{ selected_req.name or 'REQ #' ~ selected_req.id }}
+        New Buy Plan — {{ selected_req.name or 'REQ #' ~ selected_req.id }}
       </h2>
       <p class="text-xs text-gray-600">REQ #{{ selected_req.id }}</p>
     </div>
@@ -128,13 +128,13 @@
         Cancel
       </button>
       <button type="submit" data-loading-disable class="btn btn-primary btn-sm">
-        Create Sales Order
+        Build Buy Plan
       </button>
     </div>
   </form>
   {% else %}
   <div class="rounded-lg border border-line-base bg-gray-50 px-4 py-8 text-center text-sm text-gray-600">
-    This requisition has no active offers to build a Sales Order from.
+    This requisition has no active offers to build a buy plan from.
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/approvals/_tab_sales_orders.html
+++ b/app/templates/htmx/partials/approvals/_tab_sales_orders.html
@@ -16,7 +16,7 @@
           hx-swap="innerHTML"
           class="btn btn-primary btn-sm inline-flex items-center gap-1">
     <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-    New Sales Order
+    New Buy Plan
   </button>
 </div>
 {% include "htmx/partials/approvals/_pending_section.html" %}

--- a/tests/test_buy_plan_service.py
+++ b/tests/test_buy_plan_service.py
@@ -660,8 +660,8 @@ def _make_ops_member(db, user):
 
 
 class TestSubmitBuyPlan:
-    def test_auto_approve_low_cost(self, db_session: Session, test_quote: Quote, test_user: User):
-        """Cost below threshold with no critical flags → auto-approve."""
+    def test_low_cost_goes_to_manager(self, db_session: Session, test_quote: Quote, test_user: User):
+        """Frozen scope: every plan goes to the one manager approval — no auto-approve."""
         plan, _, _, _ = _make_draft_plan(db_session, test_quote, test_user, total_cost=500.0)
 
         result = submit_buy_plan(
@@ -670,8 +670,8 @@ class TestSubmitBuyPlan:
             test_user,
             db_session,
         )
-        assert result.status == BuyPlanStatus.ACTIVE.value
-        assert result.auto_approved is True
+        assert result.status == BuyPlanStatus.PENDING.value
+        assert result.auto_approved is not True
         assert result.sales_order_number == "SO-2026-001"
         assert result.submitted_by_id == test_user.id
 
@@ -1287,8 +1287,9 @@ class TestCheckCompletion:
 
 
 class TestResubmitBuyPlan:
-    def test_resubmit_auto_approve(self, db_session: Session, test_quote: Quote, test_user: User):
-        """Resubmit a rejected (draft) plan → auto-approve if under threshold."""
+    def test_resubmit_goes_to_manager(self, db_session: Session, test_quote: Quote, test_user: User):
+        """Resubmit a rejected (draft) plan → back to the one manager approval (no auto-
+        approve)."""
         plan, _, _, _ = _make_draft_plan(db_session, test_quote, test_user, total_cost=500.0)
         # Simulate prior rejection
         plan.approval_notes = "Fix the SO number"
@@ -1301,8 +1302,8 @@ class TestResubmitBuyPlan:
             test_user,
             db_session,
         )
-        assert result.status == BuyPlanStatus.ACTIVE.value
-        assert result.auto_approved is True
+        assert result.status == BuyPlanStatus.PENDING.value
+        assert result.auto_approved is not True
         assert result.sales_order_number == "SO-FIXED"
         # SO verification reset
         assert result.so_status == SOVerificationStatus.PENDING.value

--- a/tests/test_buyplan_workflow.py
+++ b/tests/test_buyplan_workflow.py
@@ -28,7 +28,6 @@ from app.services.buyplan_workflow import (
     _generate_buyer_tasks,
     _is_stock_sale,
     _recalculate_financials,
-    _should_auto_approve,
     approve_buy_plan,
     cancel_buy_plan,
     check_completion,
@@ -108,23 +107,22 @@ def _make_verification_member(db: Session, user: User) -> VerificationGroupMembe
 class TestSubmitBuyPlan:
     """Tests for submit_buy_plan()."""
 
-    def test_submit_auto_approve_low_cost(
+    def test_submit_low_cost_goes_to_manager(
         self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
     ):
-        """Plans under threshold with no critical flags get auto-approved."""
+        """Frozen scope: every plan goes to the one manager approval — no auto-approve,
+        regardless of cost. A low-cost plan that used to auto-approve now lands PENDING."""
         plan = _make_plan(db_session, test_user, test_quote, test_requisition, total_cost=100.00)
         _make_line(db_session, plan)
         db_session.refresh(plan)
 
-        with patch("app.services.buyplan_workflow._generate_buyer_tasks"):
-            result = submit_buy_plan(plan.id, "SO-001", test_user, db_session)
+        result = submit_buy_plan(plan.id, "SO-001", test_user, db_session)
 
-        assert result.status == BuyPlanStatus.ACTIVE.value
-        assert result.auto_approved is True
+        assert result.status == BuyPlanStatus.PENDING.value
+        assert result.auto_approved is not True
         assert result.sales_order_number == "SO-001"
         assert result.submitted_by_id == test_user.id
         assert result.submitted_at is not None
-        assert result.approved_at is not None
 
     def test_submit_pending_approval_high_cost(
         self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
@@ -211,7 +209,7 @@ class TestSubmitBuyPlan:
                 with patch("app.services.buyplan_workflow.score_offer", return_value=85.0):
                     result = submit_buy_plan(plan.id, "SO-005", test_user, db_session, line_edits=edits)
 
-        assert result.status == BuyPlanStatus.ACTIVE.value
+        assert result.status == BuyPlanStatus.PENDING.value
 
 
 # ── Approve Buy Plan ─────────────────────────────────────────────────
@@ -780,7 +778,7 @@ class TestResetAndResubmit:
         with pytest.raises(ValueError, match="Only halted/cancelled"):
             reset_buy_plan_to_draft(plan.id, test_user, db_session)
 
-    def test_resubmit_auto_approve(
+    def test_resubmit_goes_to_manager(
         self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
     ):
         plan = _make_plan(db_session, test_user, test_quote, test_requisition, total_cost=50.00)
@@ -789,8 +787,8 @@ class TestResetAndResubmit:
 
         result = resubmit_buy_plan(plan.id, "SO-RESUB", test_user, db_session, customer_po_number="PO-R1")
 
-        assert result.status == BuyPlanStatus.ACTIVE.value
-        assert result.auto_approved is True
+        assert result.status == BuyPlanStatus.PENDING.value
+        assert result.auto_approved is not True
         assert result.sales_order_number == "SO-RESUB"
         assert result.customer_po_number == "PO-R1"
 
@@ -826,50 +824,6 @@ class TestResetAndResubmit:
 
 class TestHelpers:
     """Tests for private helper functions."""
-
-    def test_should_auto_approve_low_cost_no_flags(
-        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
-    ):
-        plan = _make_plan(db_session, test_user, test_quote, test_requisition, total_cost=100.00, ai_flags=[])
-        assert _should_auto_approve(plan) is True
-
-    def test_should_not_auto_approve_high_cost(
-        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
-    ):
-        plan = _make_plan(db_session, test_user, test_quote, test_requisition, total_cost=10000.00, ai_flags=[])
-        assert _should_auto_approve(plan) is False
-
-    def test_should_not_auto_approve_critical_flags(
-        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
-    ):
-        plan = _make_plan(
-            db_session,
-            test_user,
-            test_quote,
-            test_requisition,
-            total_cost=100.00,
-            ai_flags=[{"severity": "critical", "type": "test"}],
-        )
-        assert _should_auto_approve(plan) is False
-
-    def test_should_auto_approve_warning_flags_ok(
-        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
-    ):
-        plan = _make_plan(
-            db_session,
-            test_user,
-            test_quote,
-            test_requisition,
-            total_cost=100.00,
-            ai_flags=[{"severity": "warning", "type": "test"}],
-        )
-        assert _should_auto_approve(plan) is True
-
-    def test_should_auto_approve_none_cost(
-        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
-    ):
-        plan = _make_plan(db_session, test_user, test_quote, test_requisition, total_cost=None, ai_flags=[])
-        assert _should_auto_approve(plan) is True
 
     def test_recalculate_financials(
         self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition

--- a/tests/test_buyplan_workflow_bugs.py
+++ b/tests/test_buyplan_workflow_bugs.py
@@ -3,7 +3,6 @@
 Covers:
 - check_completion idempotency (no duplicate case reports)
 - approve_buy_plan requires manager/admin role
-- _should_auto_approve consistency between submit and resubmit
 
 Called by: pytest
 Depends on: conftest fixtures, app/services/buyplan_workflow.py
@@ -23,11 +22,8 @@ from app.models.buy_plan import (
     SOVerificationStatus,
 )
 from app.services.buyplan_workflow import (
-    _should_auto_approve,
     approve_buy_plan,
     check_completion,
-    resubmit_buy_plan,
-    submit_buy_plan,
 )
 
 # ── Helpers ────────────────────────────────────────────────────────────
@@ -244,56 +240,3 @@ class TestApproveBuyPlanRoleCheck:
 
         assert result.status == BuyPlanStatus.DRAFT.value
         assert result.approval_notes == "Needs revision"
-
-
-# ── _should_auto_approve consistency ──────────────────────────────────
-
-
-class TestShouldAutoApprove:
-    @pytest.mark.parametrize(
-        ("total_cost", "ai_flags", "expected"),
-        [
-            pytest.param(100.0, [], True, id="low_cost_no_flags_auto_approves"),
-            pytest.param(10000.0, [], False, id="high_cost_does_not_auto_approve"),
-            pytest.param(
-                100.0,
-                [{"type": "stale_offer", "severity": "critical", "message": "test"}],
-                False,
-                id="critical_flags_prevent_auto_approve",
-            ),
-            pytest.param(
-                100.0,
-                [{"type": "low_margin", "severity": "warning", "message": "test"}],
-                True,
-                id="warning_flags_allow_auto_approve",
-            ),
-        ],
-    )
-    def test_auto_approve_decision(self, db_session, total_cost, ai_flags, expected):
-        plan, _ = _make_plan_with_lines(
-            db_session,
-            total_cost=total_cost,
-            ai_flags=ai_flags,
-        )
-        assert _should_auto_approve(plan) is expected
-
-    def test_submit_and_resubmit_use_same_logic(self, db_session):
-        """Verify submit and resubmit produce same auto-approve decision."""
-        plan, user = _make_plan_with_lines(
-            db_session,
-            total_cost=100.0,
-            ai_flags=[],
-        )
-        result1 = submit_buy_plan(plan.id, "SO-001", user, db_session)
-        status_after_submit = result1.status
-        auto_after_submit = result1.auto_approved
-
-        # Reset to draft for resubmit
-        plan.status = BuyPlanStatus.DRAFT.value
-        plan.auto_approved = False
-        plan.approved_at = None
-        db_session.flush()
-
-        result2 = resubmit_buy_plan(plan.id, "SO-002", user, db_session)
-        assert result2.status == status_after_submit
-        assert result2.auto_approved == auto_after_submit

--- a/tests/test_e2e_sourcing_flow.py
+++ b/tests/test_e2e_sourcing_flow.py
@@ -275,13 +275,13 @@ class TestBuyPlanFullLifecycle:
         plan = ctx["plan"]
         line = ctx["line"]
 
-        # Submit
+        # Submit → pending (no auto-approve; every plan goes to the manager)
         plan = submit_buy_plan(plan.id, "SO-001", ctx["sales"], db_session)
-        assert plan.status in (BuyPlanStatus.ACTIVE.value, BuyPlanStatus.PENDING.value)
+        assert plan.status == BuyPlanStatus.PENDING.value
 
-        # Auto-approved since total_cost=100 < threshold
+        # Manager approves → active
+        plan = approve_buy_plan(plan.id, "approve", ctx["manager"], db_session)
         assert plan.status == BuyPlanStatus.ACTIVE.value
-        assert plan.auto_approved is True
 
         # Confirm PO
         line = confirm_po(
@@ -344,6 +344,7 @@ class TestBuyPlanFullLifecycle:
         line = ctx["line"]
 
         plan = submit_buy_plan(plan.id, "SO-004", ctx["sales"], db_session)
+        plan = approve_buy_plan(plan.id, "approve", ctx["manager"], db_session)
         assert plan.status == BuyPlanStatus.ACTIVE.value
 
         # Flag issue on line
@@ -376,6 +377,7 @@ class TestBuyPlanFullLifecycle:
         line = ctx["line"]
 
         plan = submit_buy_plan(plan.id, "SO-006", ctx["sales"], db_session)
+        plan = approve_buy_plan(plan.id, "approve", ctx["manager"], db_session)
         line = confirm_po(
             plan.id, line.id, "PO-BAD", datetime(2026, 4, 1, tzinfo=timezone.utc), ctx["buyer"], db_session
         )

--- a/tests/test_nightly_qp_coverage.py
+++ b/tests/test_nightly_qp_coverage.py
@@ -94,11 +94,11 @@ class TestSectionApproved:
 
     def test_sales_order_not_approved(self):
         qp = self._qp_mock(sales_approved=False)
-        assert _section_approved(qp, "sales_order") is False
+        assert _section_approved(qp, "qp_sales") is False
 
     def test_sales_order_approved(self):
         qp = self._qp_mock(sales_approved=True)
-        assert _section_approved(qp, "sales_order") is True
+        assert _section_approved(qp, "qp_sales") is True
 
     def test_purchase_order_not_approved(self):
         qp = self._qp_mock(purchasing_approved=False)
@@ -119,7 +119,7 @@ def _make_admin_user(db: Session) -> User:
         role="admin",
         azure_id=f"azure-nqp-{uuid.uuid4().hex[:8]}",
         is_active=True,
-        can_approve_sales_orders=True,
+        can_approve_qp_sales=True,
         can_approve_pos=True,
     )
     db.add(u)
@@ -164,7 +164,6 @@ def _make_qp(db: Session, owner: User) -> QualityPlan:
         created_by_id=owner.id,
         order_type="new",
         status="draft",
-        sales_so_number="TSO99999",
         sales_condition="New",
         sales_quantity=5,
         sales_product_commodity="SSD",
@@ -225,8 +224,12 @@ class TestQpRouteErrorPaths:
         """An incomplete QP hits the IncompleteQPError path → 200 (re-render with
         errors)."""
         client, _user, qp = _qp_client
-        # Blank out a required field to make submit() raise IncompleteQPError
-        qp.sales_so_number = None
+        # Blank the canonical Sales Order # (now on the linked BuyPlan) so submit() hits
+        # the IncompleteQPError path → 200 re-render with errors.
+        from app.models.buy_plan import BuyPlan
+
+        bp = db_session.get(BuyPlan, qp.buy_plan_id)
+        bp.sales_order_number = None
         db_session.commit()
         r = client.post(f"/v2/qp/{qp.id}/submit")
         assert r.status_code == 200
@@ -244,10 +247,10 @@ class TestQpRouteErrorPaths:
     def test_patch_sales_when_not_approved_writes_field(self, _qp_client, db_session: Session):
         """PATCH /v2/qp/{id}/sales on an unapproved section updates the field."""
         client, _user, qp = _qp_client
-        r = client.patch(f"/v2/qp/{qp.id}/sales", data={"sales_so_number": "TSO-NEW-99"})
+        r = client.patch(f"/v2/qp/{qp.id}/sales", data={"sales_condition": "Refurbished"})
         assert r.status_code == 200
         db_session.refresh(qp)
-        assert qp.sales_so_number == "TSO-NEW-99"
+        assert qp.sales_condition == "Refurbished"
 
     def test_patch_purchasing_when_not_approved_writes_field(self, _qp_client, db_session: Session):
         """PATCH /v2/qp/{id}/purchasing on an unapproved section updates the field."""
@@ -262,10 +265,10 @@ class TestQpRouteErrorPaths:
         client, _user, qp = _qp_client
         qp.sales_section_approved_at = datetime.now(timezone.utc)
         db_session.commit()
-        r = client.patch(f"/v2/qp/{qp.id}/sales", data={"sales_so_number": "IGNORED"})
+        r = client.patch(f"/v2/qp/{qp.id}/sales", data={"sales_condition": "IGNORED"})
         assert r.status_code == 200
         db_session.refresh(qp)
-        assert qp.sales_so_number == "TSO99999"
+        assert qp.sales_condition == "New"
 
     def test_add_serial_not_found_returns_404(self, _qp_client):
         client, _user, _qp = _qp_client

--- a/tests/test_sales_order_origination.py
+++ b/tests/test_sales_order_origination.py
@@ -201,6 +201,20 @@ def test_new_sales_order_picker_renders_offer_form_for_requisition(nonadmin_clie
     assert str(offer.id) in r.text
 
 
+def test_builder_labels_say_buy_plan_not_sales_order(nonadmin_client: TestClient, so_setup):
+    """Frozen-scope naming: the builder surface says 'buy plan', not 'Sales Order'.
+
+    The buy plan is the object being built; 'Sales Order' was the old misnomer. The
+    Acctivate SO# *field* labels (e.g. 'Sales Order #') are kept separately."""
+    req, _requirement, _offer = so_setup
+    r = nonadmin_client.get(f"/v2/partials/approvals/sales-orders/new?requisition_id={req.id}")
+    assert r.status_code == 200
+    assert "New Buy Plan" in r.text  # builder heading
+    assert "Build Buy Plan" in r.text  # primary action
+    assert "New Sales Order" not in r.text  # old object label gone
+    assert "Create Sales Order" not in r.text
+
+
 def test_create_sales_order_returns_draft_detail(nonadmin_client: TestClient, so_setup):
     """Posting the offer/sell selections creates a DRAFT buy plan and renders its detail
     (with the Submit form)."""


### PR DESCRIPTION
## Approvals tab — frozen-scope minimal flow

AVAIL builds and tracks the **buy plan** (the vehicle); Acctivate creates SOs/POs. The flow: convert RFQ → buy plan (saved on build) → add the Acctivate SO# → **one** manager approval → notify buyers → buyers enter PO#s for tracking.

### Changes (mostly removal)
- **Remove auto-approve** (`_should_auto_approve` + `buyplan_auto_approve_threshold`). `submit_buy_plan` / `resubmit_buy_plan` now **always** open the one `BUY_PLAN` engine gate (`can_approve_buy_plans`). **No plan reaches ACTIVE without a manager approval.** The `auto_approved` column is kept (always `False`) — no migration. Updated/removed the tests that asserted the old threshold behavior.
- **Rename** the builder's user-facing labels "Sales Order" → "buy plan" (heading, "Build Buy Plan" button, empty states, 2 router messages). **Kept** `sales_order_number` / `po_number` columns, the "Sales Order #" / "Acctivate Sales Order #" field labels (that's the real Acctivate SO **number**), and all routes/functions/filenames. The "Sales Orders" hub tab label is unchanged (renaming would duplicate the existing "Buy Plans" tab).

### Deliberately NOT in scope (frozen)
No second/SO approval gate, no SLA/escalation/delegation, no returned-for-correction, no autosave/soft-delete/undo, no migration, no new columns/gate-types/statuses, no SO/PO-creating code path. The existing ops SO-verify (`so_status`) step is left untouched — it's downstream completion confirmation, not a second approval.

### Tests
280 affected tests green (`test_buyplan_workflow`, `_bugs`, `test_buy_plan_service`, `_models`, `test_c1_buyplan_gate`, `test_sales_order_origination`, `test_buyplan_builder_so_origin`); pre-commit clean. Buyer-notify on approve verified (`_run_approve_side_effects` → buyer "cut PO" tasks, covered by `test_c1_buyplan_gate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)