### PR TITLE
test: fix tz-naive datetime in sightings cov + de-brittle 3 config-default tests

### DIFF
--- a/tests/test_config_lusha_settings.py
+++ b/tests/test_config_lusha_settings.py
@@ -11,10 +11,26 @@ os.environ["TESTING"] = "1"
 from app.config import settings
 
 
-def test_lusha_settings_defaults():
-    assert settings.lusha_enrichment_enabled is False
-    assert settings.lusha_cooldown_minutes == 15
-    assert settings.prospect_enrich_contacts_per_account == 5
+def test_lusha_settings_defaults(monkeypatch):
+    """Lusha SP1 config CODE defaults, independent of any ambient prod ``.env``.
+
+    A fresh Settings is built with no env file and the relevant vars cleared so the
+    assertions verify the in-code defaults even when pytest runs from a checkout that
+    carries a prod ``.env`` (e.g. ``LUSHA_ENRICHMENT_ENABLED=true``).
+    """
+    from app.config import Settings
+
+    for key in (
+        "LUSHA_ENRICHMENT_ENABLED",
+        "LUSHA_COOLDOWN_MINUTES",
+        "PROSPECT_ENRICH_CONTACTS_PER_ACCOUNT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    s = Settings(_env_file=None)
+    assert s.lusha_enrichment_enabled is False
+    assert s.lusha_cooldown_minutes == 15
+    assert s.prospect_enrich_contacts_per_account == 5
 
 
 def test_no_lusha_api_key_field():

--- a/tests/test_prospect_screening.py
+++ b/tests/test_prospect_screening.py
@@ -36,11 +36,28 @@ def _prospect(db: Session, **kw) -> ProspectAccount:
 # ── Config tests ─────────────────────────────────────────────────────
 
 
-def test_sp3_config_defaults():
-    assert settings.ai_screen_enabled is False
-    assert settings.ai_screen_min_match == 40
-    assert settings.ai_screen_daily_cap == 200
-    assert settings.ai_screen_web_search_enabled is False
+def test_sp3_config_defaults(monkeypatch):
+    """AI-screen config CODE defaults, independent of any ambient prod ``.env``.
+
+    A fresh Settings is built with no env file and the relevant vars cleared so the
+    assertions verify the in-code defaults even when pytest runs from a checkout that
+    carries a prod ``.env`` (e.g. ``AI_SCREEN_ENABLED=true``).
+    """
+    from app.config import Settings
+
+    for key in (
+        "AI_SCREEN_ENABLED",
+        "AI_SCREEN_MIN_MATCH",
+        "AI_SCREEN_DAILY_CAP",
+        "AI_SCREEN_WEB_SEARCH_ENABLED",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    s = Settings(_env_file=None)
+    assert s.ai_screen_enabled is False
+    assert s.ai_screen_min_match == 40
+    assert s.ai_screen_daily_cap == 200
+    assert s.ai_screen_web_search_enabled is False
 
 
 # ── Screen service tests ─────────────────────────────────────────────

--- a/tests/test_sightings_router_coverage3.py
+++ b/tests/test_sightings_router_coverage3.py
@@ -122,7 +122,7 @@ class TestBatchRefreshCoverage:
         """Lines 683-688: failed > 0 → level='warning', skipped text appended."""
         _, items = two_items
         # Rate-limit first item
-        items[0].last_searched_at = datetime.utcnow() - timedelta(seconds=5)
+        items[0].last_searched_at = datetime.now(timezone.utc) - timedelta(seconds=5)
         db_session.commit()
         with patch(
             "app.search_service.search_requirement",

--- a/tests/test_sp4_reclamation.py
+++ b/tests/test_sp4_reclamation.py
@@ -142,11 +142,24 @@ class TestMigration123:
 # ── Config ────────────────────────────────────────────────────────────────────
 
 
-def test_sp4_config_defaults():
-    """SP4 config fields have correct defaults."""
+def test_sp4_config_defaults(monkeypatch):
+    """SP4 config fields have correct CODE defaults.
+
+    Builds a fresh Settings with no env file and the relevant vars cleared, so the
+    assertions verify the in-code defaults regardless of any ambient prod ``.env``
+    (e.g. ``ACCOUNT_SWEEP_INACTIVITY_DAYS=35``) that pytest would otherwise load.
+    """
     from app.config import Settings
 
-    s = Settings()
+    for key in (
+        "ACCOUNT_SWEEP_ENABLED",
+        "ACCOUNT_SWEEP_INACTIVITY_DAYS",
+        "ACCOUNT_SWEEP_MANAGER_EMAIL",
+        "ACCOUNT_REACTIVATION_SWEEP_ENABLED",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    s = Settings(_env_file=None)
     assert s.account_sweep_enabled is False
     assert s.account_sweep_inactivity_days == 90
     assert s.account_sweep_manager_email == ""


### PR DESCRIPTION
## Summary

Two Wave-1 test-hygiene fixes (no app behavior change; tests only).

### (a) `tests/test_sightings_router_coverage3.py` — tz-naive `datetime.utcnow()`
Replaced the deprecated, tz-naive `datetime.utcnow()` (line 125) with `datetime.now(timezone.utc)` (import already present).

**True root cause of `test_batch_refresh_mixed_failed_and_skipped`** (the "reds the nightly" vs "merely warns" disagreement — both were half-right):
- Under the **default** pytest config the deprecated call only emits a `DeprecationWarning`, so the test passes.
- Under a **warnings-as-errors** run (`-W error::DeprecationWarning`, how a strict nightly treats warnings) the `datetime.utcnow()` call raises **before the handler runs**, failing the test. That is the "reds the nightly cron" behavior.
- The tz-aware replacement removes the warning entirely → green under both default and `-W error` runs.

Note: the `last_searched_at` setup on that line is functionally inert today — the batch-refresh handler was refactored to enforce cooldown inside `search_requirement` (per-MPN `MaterialCard.last_searched_at`), so there is no requirement-level "skipped" branch left in the handler. The test still passes via the `failed` branch (mocked `RuntimeError` → `2 failed`, `level="warning"`).

### (b) De-brittle the 3 `*_config_defaults` tests (lusha / sp3 / sp4)
- `tests/test_config_lusha_settings.py::test_lusha_settings_defaults`
- `tests/test_prospect_screening.py::test_sp3_config_defaults`
- `tests/test_sp4_reclamation.py::test_sp4_config_defaults`

They assert in-code `Settings` defaults but read the process-wide `settings` singleton (or a bare `Settings()`), so they go **RED** when pytest runs from a checkout that carries a prod `.env` overriding a default (e.g. `ACCOUNT_SWEEP_INACTIVITY_DAYS` 90→35, `AI_SCREEN_ENABLED` / `LUSHA_ENRICHMENT_ENABLED` true). Each now builds a fresh `Settings(_env_file=None)` with the relevant env vars cleared via `monkeypatch`, asserting the **CODE** default independent of ambient env. **No app defaults changed.**

## Verification
- Sightings test: passes under default config **and** under `-W error::DeprecationWarning`.
- 3 config tests: pass both **without** a prod `.env` (worktree) and **with** a prod-like `.env` present in cwd (the original brittleness scenario).
- All affected files: `77 passed` under the default xdist config.
- `pre-commit run --all-files`: all hooks pass (ruff, ruff-format, docformatter, mypy clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)