### PR TITLE
refactor(workers): pure, tested heartbeat-liveness decision

### DIFF
--- a/app/jobs/worker_liveness_jobs.py
+++ b/app/jobs/worker_liveness_jobs.py
@@ -1,17 +1,22 @@
 """Worker liveness watchdog — alerts when a background worker stops heartbeating.
 
-Each worker (ICS, NetComponents, enrichment) writes ``last_heartbeat`` on every loop
-tick. systemd/docker restart a *crashed* worker, but a *hung* one (wedged browser,
-deadlock, network stall) keeps its process alive while doing nothing — nobody notices.
-This job reads the heartbeats every few minutes and alerts (Teams + Sentry, debounced)
-when a worker that should be running has gone silent, or has its circuit breaker open.
+Each worker (ICS, NetComponents, The Broker Forum, enrichment) writes
+``last_heartbeat`` on every loop tick. systemd/docker restart a *crashed* worker,
+but a *hung* one (wedged browser, deadlock, network stall) keeps its process alive
+while doing nothing — nobody notices. This job reads the heartbeats every few
+minutes and alerts (Teams + Sentry + logs, debounced per worker) when a worker that
+should be running has gone silent, or has its circuit breaker open.
+
+The staleness + debounce decision is factored into pure functions
+(``heartbeat_is_stale`` / ``should_alert_stale_heartbeat``) so it is unit-testable
+without the scheduler or a database.
 
 Called by: app/jobs/__init__.py via register_worker_liveness_jobs().
-Depends on: worker_status models, services.teams_notifications, cache.intel_cache (debounce),
-            search_worker_base.monitoring (Sentry).
+Depends on: worker_status models, services.teams_notifications, cache.intel_cache
+            (debounce store — Redis-backed, no schema/column), search_worker_base.monitoring (Sentry).
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from apscheduler.triggers.interval import IntervalTrigger
 from loguru import logger
@@ -35,14 +40,64 @@ def _as_utc(dt):
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
-async def _alert(label: str, message: str, debounce_minutes: int) -> None:
-    """Debounced alert (1× per label per window) to Teams + Sentry + logs."""
-    from ..cache.intel_cache import get_cached, set_cached
+# ── Pure decision logic (no DB / scheduler / IO — unit-testable) ─────────
 
-    key = f"worker_alert:{label}"
-    if get_cached(key) is not None:
-        return  # already alerted within the debounce window
-    set_cached(key, {"alerted": 1}, ttl_days=debounce_minutes / 1440)
+
+def heartbeat_is_stale(
+    is_running: bool,
+    last_heartbeat: datetime | None,
+    now: datetime,
+    stale_after_minutes: int,
+) -> bool:
+    """Return True when a worker that claims to be running has gone silent.
+
+    A NULL/never-seen heartbeat counts as stale. A worker with ``is_running``
+    False is never stale — a clean shutdown sets that flag, so expected silence
+    does not false-alarm. Naive timestamps are coerced to UTC before comparison.
+    """
+    if not is_running:
+        return False
+    if last_heartbeat is None:
+        return True
+    return _as_utc(last_heartbeat) < now - timedelta(minutes=stale_after_minutes)
+
+
+def should_alert_stale_heartbeat(
+    *,
+    is_running: bool,
+    last_heartbeat: datetime | None,
+    now: datetime,
+    stale_after_minutes: int,
+    already_alerted: bool,
+) -> bool:
+    """Pure staleness + debounce gate the watchdog uses to decide whether to emit.
+
+    Emits only when the worker's heartbeat is stale (see ``heartbeat_is_stale``)
+    AND we have not already alerted within the debounce window
+    (``already_alerted`` is False).
+    """
+    return heartbeat_is_stale(is_running, last_heartbeat, now, stale_after_minutes) and not already_alerted
+
+
+# ── Debounce store + alert fan-out ──────────────────────────────────────
+
+
+def _already_alerted(label: str) -> bool:
+    """Debounce read: True while an alert for ``label`` is still within its window.
+
+    State lives in the Redis-backed intel_cache (TTL = debounce window), so no
+    new column/migration is needed and the debounce is shared across processes.
+    """
+    from ..cache.intel_cache import get_cached
+
+    return get_cached(f"worker_alert:{label}") is not None
+
+
+async def _emit_alert(label: str, message: str, debounce_minutes: int) -> None:
+    """Record the debounce marker, then fan the alert out to logs, Sentry, Teams."""
+    from ..cache.intel_cache import set_cached
+
+    set_cached(f"worker_alert:{label}", {"alerted": 1}, ttl_days=debounce_minutes / 1440)
 
     logger.error("WORKER WATCHDOG: {}", message)
     try:
@@ -61,14 +116,12 @@ async def _alert(label: str, message: str, debounce_minutes: int) -> None:
 
 @_traced_job
 async def _job_monitor_worker_heartbeats():
-    from datetime import timedelta
-
     from ..config import settings
     from ..database import SessionLocal
     from ..models import EnrichmentWorkerStatus, IcsWorkerStatus, NcWorkerStatus, TbfWorkerStatus
 
     now = datetime.now(timezone.utc)
-    stale_cutoff = now - timedelta(minutes=settings.worker_heartbeat_stale_minutes)
+    stale_minutes = settings.worker_heartbeat_stale_minutes
     debounce = settings.worker_alert_debounce_minutes
 
     checks = (
@@ -83,24 +136,36 @@ async def _job_monitor_worker_heartbeats():
             row = db.get(model, 1)
             if row is None:
                 continue
-            hb = _as_utc(row.last_heartbeat)
-            # Stale: claims to be running but the heartbeat went silent. (A clean
-            # shutdown sets is_running=False, so this won't false-alarm on a stop.)
-            if row.is_running and (hb is None or hb < stale_cutoff):
-                age = "unknown" if hb is None else f"{int((now - hb).total_seconds() // 60)}m"
-                await _alert(
+            is_running = bool(row.is_running)
+            hb = row.last_heartbeat
+
+            # Stale: claims to be running but the heartbeat went silent (or never landed).
+            if should_alert_stale_heartbeat(
+                is_running=is_running,
+                last_heartbeat=hb,
+                now=now,
+                stale_after_minutes=stale_minutes,
+                already_alerted=_already_alerted(label),
+            ):
+                hb_utc = _as_utc(hb)
+                age = "unknown" if hb_utc is None else f"{int((now - hb_utc).total_seconds() // 60)}m"
+                await _emit_alert(
                     label,
                     f"{label} worker heartbeat is stale (last seen {age} ago). "
-                    f"It may be hung or crashed — check the service.",
+                    "It may be hung or crashed — check the service.",
                     debounce,
                 )
-            # Up but not working: circuit breaker open.
-            elif getattr(row, "circuit_breaker_open", False):
-                reason = getattr(row, "circuit_breaker_reason", None) or "unknown"
-                await _alert(
-                    f"{label}-breaker",
-                    f"{label} worker circuit breaker is OPEN: {reason}",
-                    debounce,
-                )
+            # Up but not working: circuit breaker open. Only when not stale — a silent
+            # worker's headline problem is the silence, so we don't double-alert.
+            elif not heartbeat_is_stale(is_running, hb, now, stale_minutes) and getattr(
+                row, "circuit_breaker_open", False
+            ):
+                if not _already_alerted(f"{label}-breaker"):
+                    reason = getattr(row, "circuit_breaker_reason", None) or "unknown"
+                    await _emit_alert(
+                        f"{label}-breaker",
+                        f"{label} worker circuit breaker is OPEN: {reason}",
+                        debounce,
+                    )
     finally:
         db.close()

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -542,6 +542,21 @@ reflects process liveness independent of work, and stays fresh on idle /
 cap-sleep / breaker-open / off-hours paths (a liveness monitor reading
 `last_heartbeat` won't false-alarm "DOWN" while a worker is merely paused).
 
+**Proactive liveness watchdog.** Beyond the on-demand Connectors-page read, a
+scheduler job (`app/jobs/worker_liveness_jobs.py`, registered by
+`register_worker_liveness_jobs`, runs every `settings.worker_liveness_check_minutes`)
+actively consumes `last_heartbeat` for all four singletons (ics, nc, tbf,
+enrichment). When a worker that claims `is_running` has a heartbeat that is
+NULL/never-seen or older than `settings.worker_heartbeat_stale_minutes`, or its
+circuit breaker is open, it emits a debounced alert (Loguru + Sentry via
+`search_worker_base.monitoring.capture_sentry_message` + Teams). Debounce state is
+held per worker in the Redis-backed `intel_cache` keyed `worker_alert:<label>` with
+TTL = `settings.worker_alert_debounce_minutes` (no schema/column). The
+staleness + debounce decision is factored into pure functions
+(`heartbeat_is_stale` / `should_alert_stale_heartbeat`) so it is unit-testable
+without the scheduler or DB. The job is disabled under `TESTING` with the rest of
+the scheduler. Tests: `tests/test_worker_liveness.py`.
+
 **Worker-aware Connectors-page status.** The Settings → Connectors page must
 NOT render a worker-backed source as "broken"/"no API"/"needs setup" just
 because it has no direct API key. `connector_service.is_worker_backed()` (the

--- a/tests/test_worker_liveness.py
+++ b/tests/test_worker_liveness.py
@@ -8,8 +8,14 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
-from app.jobs.worker_liveness_jobs import _job_monitor_worker_heartbeats
+from app.jobs.worker_liveness_jobs import (
+    _job_monitor_worker_heartbeats,
+    heartbeat_is_stale,
+    should_alert_stale_heartbeat,
+)
 from app.models import IcsWorkerStatus
+
+NOW = datetime(2026, 6, 28, 12, 0, tzinfo=timezone.utc)
 
 
 def _run(db_session):
@@ -81,3 +87,68 @@ def test_debounce_suppresses_repeat(db_session):
     ):
         asyncio.run(_job_monitor_worker_heartbeats())
     teams.assert_not_awaited()
+
+
+def test_null_heartbeat_treated_as_stale(db_session):
+    # A running worker that never wrote a heartbeat (NULL) is stale → alert.
+    _ics(db_session, is_running=True, last_heartbeat=None)
+    teams = _run(db_session)
+    teams.assert_awaited_once()
+    assert "ICS" in teams.await_args.args[0]
+
+
+# ── Pure decision function — no DB / scheduler / IO ──────────────────────
+
+
+class TestHeartbeatIsStale:
+    """heartbeat_is_stale() — pure staleness predicate (the branch selector)."""
+
+    def test_fresh_running_worker_not_stale(self):
+        assert heartbeat_is_stale(True, NOW - timedelta(minutes=2), NOW, 15) is False
+
+    def test_old_running_worker_is_stale(self):
+        assert heartbeat_is_stale(True, NOW - timedelta(minutes=20), NOW, 15) is True
+
+    def test_null_heartbeat_is_stale(self):
+        assert heartbeat_is_stale(True, None, NOW, 15) is True
+
+    def test_stopped_worker_never_stale(self):
+        # Clean shutdown sets is_running=False — silence is expected, not a fault.
+        assert heartbeat_is_stale(False, None, NOW, 15) is False
+        assert heartbeat_is_stale(False, NOW - timedelta(hours=5), NOW, 15) is False
+
+    def test_naive_heartbeat_coerced_to_utc(self):
+        # ICS stores naive timestamps; they must compare correctly against UTC now.
+        naive = (NOW - timedelta(minutes=20)).replace(tzinfo=None)
+        assert heartbeat_is_stale(True, naive, NOW, 15) is True
+
+
+class TestShouldAlertStaleHeartbeat:
+    """should_alert_stale_heartbeat() — pure staleness + debounce emit gate."""
+
+    def _decide(self, **overrides):
+        kwargs = {
+            "is_running": True,
+            "last_heartbeat": NOW - timedelta(minutes=20),
+            "now": NOW,
+            "stale_after_minutes": 15,
+            "already_alerted": False,
+        }
+        kwargs.update(overrides)
+        return should_alert_stale_heartbeat(**kwargs)
+
+    def test_stale_and_not_yet_alerted_emits(self):
+        assert self._decide() is True
+
+    def test_null_heartbeat_emits(self):
+        assert self._decide(last_heartbeat=None) is True
+
+    def test_fresh_does_not_emit(self):
+        assert self._decide(last_heartbeat=NOW - timedelta(minutes=2)) is False
+
+    def test_debounce_suppresses_repeat(self):
+        # Stale, but already alerted within the window → stay quiet.
+        assert self._decide(already_alerted=True) is False
+
+    def test_stopped_worker_does_not_emit(self):
+        assert self._decide(is_running=False) is False


### PR DESCRIPTION
## What & why

Wave-1 item *"Worker heartbeat-liveness job → consume `*WorkerStatus.last_heartbeat`; alert on stale."*

While implementing, I found the watchdog **already shipped** in `3981ceff` (`harden(workers): self-healing + liveness watchdog`): `app/jobs/worker_liveness_jobs.py` already reads `last_heartbeat` for all four worker singletons (ICS / NetComponents / TBF / Enrichment), alerts on stale heartbeats and open breakers, is registered via `register_worker_liveness_jobs`, and runs every `worker_liveness_check_minutes` (disabled under `TESTING` with the rest of the scheduler). So the plan's "NOTHING reads it" is stale.

What was **missing** vs. the task spec: the staleness + debounce decision was inline in the scheduler job — only reachable through a mocked-DB integration test — and there was no NULL-heartbeat coverage. This PR closes that gap with no behavior change.

## Changes

- **Extract two pure, IO-free functions** the job now calls:
  - `heartbeat_is_stale(is_running, last_heartbeat, now, stale_after_minutes)` — a running worker whose heartbeat is `NULL`/never-seen or older than `worker_heartbeat_stale_minutes`. NULL counts as stale; naive timestamps coerced to UTC; a stopped worker (`is_running=False`) is never stale.
  - `should_alert_stale_heartbeat(...)` — staleness **AND** not-already-alerted (debounce gate). This is the real decision the job uses to emit, not a parallel copy.
- **Tests** (`tests/test_worker_liveness.py`): unit tests for both pure functions (stale / fresh / NULL / stopped / naive-ts / debounce) plus a NULL-heartbeat integration case; all 6 pre-existing integration tests retained and green.
- **Docs**: document the proactive watchdog in `APP_MAP_INTERACTIONS.md` (the heartbeat section previously only described the on-demand Connectors-page reader).

## Debounce storage choice (no schema change)

Kept the existing **Redis-backed `intel_cache`** (key `worker_alert:<label>`, TTL = `worker_alert_debounce_minutes`). It satisfies "in-memory/Redis, not a new column/migration" and, being Redis-backed, the debounce is shared across processes. `app/rate_limit.py` does **not** fit — it's a slowapi `Limiter` keyed on remote IP address for HTTP endpoints, not a per-worker-label time-window suppressor.

## Verification

- `TESTING=1 PYTHONPATH=$(pwd) pytest tests/ -k "heartbeat or liveness or worker_status" -q` → **44 passed**
- `tests/test_scheduler.py` → 14 passed (registration intact)
- `pre-commit run --all-files` → all hooks pass, no unrelated drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)