### PR TITLE
fix(resell): wire recompute_buyer_score_on_win into the award path

### DIFF
--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -865,6 +865,26 @@ async def resell_submit_offer(
     return await resell_offers(request, list_id=el.id, user=user, db=db)
 
 
+@router.post("/api/resell/{list_id}/offers/{offer_id}/award", response_class=HTMLResponse)
+async def resell_award_offer(
+    request: Request,
+    list_id: int,
+    offer_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Award an inbound offer (owner-only): flip it to ``won`` and recompute the winning
+    buyer's scorecard, then re-render the detail panel.
+
+    The award is the single path that marks an ExcessOffer ``won``; the service owns the
+    transaction and fires the buyer-score recompute hook before committing. Owner-gated +
+    404 on a missing offer are enforced in ``excess_service.award_offer``.
+    """
+    offer = excess_service.award_offer(db, offer_id, user)
+    el = excess_service.get_excess_list(db, offer.excess_list_id)
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
+
+
 # ── Outreach: offer-to-buyers panel + tracker + don't-forget strip ───
 #
 # The trader→buyer half of Resell (the inverse of sourcing's RFQ). Offering excess OUT

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -29,6 +29,7 @@ from ..constants import (
 from ..models import Company, User
 from ..models.excess import ExcessLineItem, ExcessList, ExcessOffer, ExcessOfferLine
 from ..utils.normalization import normalize_mpn_key
+from .buyer_affinity_service import recompute_buyer_score_on_win
 
 # ---------------------------------------------------------------------------
 # Resell capabilities — role-derived powers (spec §"Roles & capabilities")
@@ -591,6 +592,49 @@ def withdraw_offer(db: Session, offer_id: int) -> ExcessOffer:
     _safe_commit(db, entity="excess offer withdrawal")
     db.refresh(offer)
     logger.info("Withdrew ExcessOffer id={} ({} lines recomputed)", offer_id, len(affected))
+    return offer
+
+
+def award_offer(db: Session, offer_id: int, owner: User) -> ExcessOffer:
+    """Award an inbound offer — the single chokepoint where an ExcessOffer becomes
+    ``won``.
+
+    Owner-only (the list owner is the only one who may pick a winner): raises 404 if the
+    offer does not exist, 403 if *owner* does not own the offer's list. Flips the offer
+    to ``won``, marks each matched line item ``awarded``, recomputes the best-price
+    rollup of every line the offer touched, then recomputes the winning buyer's
+    ``BuyerScore`` via ``recompute_buyer_score_on_win`` BEFORE the commit (this path owns
+    the transaction; the hook no-ops for an offer with no canonical buyer card). Commits,
+    refreshes, returns the offer. Mirrors ``withdraw_offer`` (the inverse terminal flip).
+    """
+    offer = db.get(ExcessOffer, offer_id)
+    if not offer:
+        raise HTTPException(404, f"ExcessOffer {offer_id} not found")
+
+    excess_list = get_excess_list(db, offer.excess_list_id)
+    if excess_list.owner_id != owner.id:
+        raise HTTPException(403, "Only the list owner can award an offer")
+
+    affected = {line.excess_line_item_id for line in offer.lines if line.excess_line_item_id is not None}
+    offer.status = ExcessOfferStatus.WON
+    for line_item_id in affected:
+        line_item = db.get(ExcessLineItem, line_item_id)
+        if line_item is not None:
+            line_item.status = ExcessLineItemStatus.AWARDED
+    db.flush()
+
+    for line_item_id in affected:
+        recompute_line_rollup(db, line_item_id)
+
+    # Recompute the winning buyer's scorecard before the commit — this path owns the
+    # transaction (the hook returns None / no-ops for an offer with no canonical buyer).
+    recompute_buyer_score_on_win(db, offer)
+
+    _safe_commit(db, entity="excess offer award")
+    db.refresh(offer)
+    logger.info(
+        "Awarded ExcessOffer id={} (status=won, {} lines awarded) by owner={}", offer_id, len(affected), owner.id
+    )
     return offer
 
 

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -808,6 +808,10 @@ Model: `VendorContactAttachment` (`app/models/vendors.py`).
 > `can_post`/`can_offer` (role-derived capabilities), `submit_offer` (per_line/take_all;
 > part-number-only matching via `normalize_mpn_key`; unmatched/ambiguous rows queued),
 > `recompute_line_rollup`/`withdraw_offer` (min priced active offer -> best_offer_*),
+> `award_offer` (the single chokepoint that flips an offer -> `won`: owner-gated, marks
+> matched lines `awarded`, recomputes rollups, then fires the buyer-score win-hook
+> `buyer_affinity_service.recompute_buyer_score_on_win` BEFORE the commit — no-ops for an
+> offer with no canonical buyer; routed as `POST /api/resell/{id}/offers/{offer_id}/award`),
 > `close_list`, `get_excess_stats` (offer counts), list/line CRUD + import, and
 > `material_card_id` resolution on the import path. The thin router is `app/routers/resell.py`
 > (templates under `app/templates/htmx/partials/resell/*`).

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1451,6 +1451,9 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     +-- POST /api/resell/{id}/publish                   (excess_mirror.publish_list → Sighting mirror)
     +-- POST /api/resell/{id}/offers                    (excess_service.submit_offer; scope
     |     per_line|take_all; service enforces can_offer + the self-offer guard)
+    +-- POST /api/resell/{id}/offers/{offer_id}/award   (owner-only; excess_service.award_offer:
+    |     the single offer→won chokepoint; marks matched lines awarded, recomputes rollups,
+    |     then fires buyer_affinity_service.recompute_buyer_score_on_win before commit)
     +-- POST /api/resell/{id}/outreach                  (owner-only; channel=email →
           resell_outreach_service.submit_outreach_email [RFQ send engine], else
           submit_outreach [manual log]; re-renders the Outreach tracker)

--- a/tests/test_resell_award.py
+++ b/tests/test_resell_award.py
@@ -1,0 +1,290 @@
+"""test_resell_award.py — the Resell award path (offer → won) + the buyer-score hook.
+
+Awarding an inbound ExcessOffer is the SINGLE chokepoint where an offer flips to
+``won``. The award MUST recompute the winning buyer's scorecard (the
+``recompute_buyer_score_on_win`` hook) inside the same transaction, so a won offer is
+always reflected in that buyer's BuyerScore rollup. These tests cover:
+
+  - ``excess_service.award_offer`` — flips the offer to ``won``, marks its matched
+    lines ``awarded``, recomputes the line rollups, and upserts the buyer's BuyerScore
+    (the orphaned win-hook, now wired). Owner-gated (403) and 404 on a missing offer.
+  - the None-safe case: an offer with NO canonical buyer card still wins, no BuyerScore.
+  - the POST award endpoint end-to-end: owner awards → 200 + offer won + score; a
+    non-owner is forbidden (403).
+
+Called by: pytest
+Depends on: app.services.excess_service, app.routers.resell, tests.conftest
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.constants import ExcessLineItemStatus, ExcessOfferStatus, OfferLineMatchStatus
+from app.models import Company, User, VendorCard
+from app.models.excess import (
+    BuyerScore,
+    ExcessLineItem,
+    ExcessList,
+    ExcessOffer,
+    ExcessOfferLine,
+)
+from app.models.intelligence import MaterialCard
+from app.services import excess_service
+from tests.conftest import engine
+
+_ = engine
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def owner(db_session: Session) -> User:
+    """The list owner — the trader who awards offers on their own list."""
+    u = User(email="award-owner@trioscs.com", name="Award Owner", role="trader", azure_id="award-owner-001")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def broker(db_session: Session) -> User:
+    """The offerer — a buyer who submitted the inbound offer (submitted_by)."""
+    u = User(email="award-broker@trioscs.com", name="Award Broker", role="buyer", azure_id="award-broker-001")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def outsider(db_session: Session) -> User:
+    """A teammate who does NOT own the list — must not be able to award its offers."""
+    u = User(email="award-outsider@trioscs.com", name="Award Outsider", role="trader", azure_id="award-outsider-001")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def seller_company(db_session: Session) -> Company:
+    co = Company(name="Award Seller Co")
+    db_session.add(co)
+    db_session.commit()
+    db_session.refresh(co)
+    return co
+
+
+@pytest.fixture()
+def excess_list(db_session: Session, seller_company: Company, owner: User) -> ExcessList:
+    el = ExcessList(company_id=seller_company.id, owner_id=owner.id, title="Award Excess")
+    db_session.add(el)
+    db_session.commit()
+    db_session.refresh(el)
+    return el
+
+
+@pytest.fixture()
+def cap_line(db_session: Session, excess_list: ExcessList) -> ExcessLineItem:
+    mc = MaterialCard(normalized_mpn="grm188r", display_mpn="GRM188R", category="capacitors")
+    db_session.add(mc)
+    db_session.flush()
+    li = ExcessLineItem(
+        excess_list_id=excess_list.id,
+        part_number="GRM188R",
+        quantity=1000,
+        material_card_id=mc.id,
+        asking_price=Decimal("1.00"),
+    )
+    db_session.add(li)
+    db_session.commit()
+    db_session.refresh(li)
+    return li
+
+
+def _buyer_card(db: Session, name: str) -> VendorCard:
+    vc = VendorCard(normalized_name=name.lower(), display_name=name)
+    db.add(vc)
+    db.flush()
+    return vc
+
+
+def _open_offer(
+    db: Session,
+    *,
+    excess_list: ExcessList,
+    submitter: User,
+    line: ExcessLineItem,
+    buyer: VendorCard | None,
+    unit_price: Decimal,
+) -> ExcessOffer:
+    """An OPEN per-line ExcessOffer carrying one matched line — ready to be awarded."""
+    offer = ExcessOffer(
+        excess_list_id=excess_list.id,
+        submitted_by=submitter.id,
+        offerer_vendor_card_id=buyer.id if buyer else None,
+        scope="per_line",
+        status=ExcessOfferStatus.OPEN,
+    )
+    db.add(offer)
+    db.flush()
+    db.add(
+        ExcessOfferLine(
+            offer_id=offer.id,
+            excess_line_item_id=line.id,
+            mpn_raw=line.part_number,
+            quantity=line.quantity,
+            unit_price=unit_price,
+            match_status=OfferLineMatchStatus.MATCHED,
+        )
+    )
+    db.flush()
+    return offer
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  award_offer (service)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestAwardOfferService:
+    def test_award_flips_won_and_recomputes_buyer_score(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """The centerpiece: awarding an offer flips it to won, awards its line, and
+        upserts the winning buyer's BuyerScore (the orphaned win-hook is now wired)."""
+        buyer = _buyer_card(db_session, "Award Buyer")
+        offer = _open_offer(
+            db_session,
+            excess_list=excess_list,
+            submitter=broker,
+            line=cap_line,
+            buyer=buyer,
+            unit_price=Decimal("0.80"),
+        )
+        db_session.commit()
+        # Precondition: no scorecard yet, offer is still open.
+        assert db_session.query(BuyerScore).filter_by(vendor_card_id=buyer.id).count() == 0
+
+        result = excess_service.award_offer(db_session, offer.id, owner)
+
+        assert result.status == ExcessOfferStatus.WON
+        db_session.refresh(cap_line)
+        assert cap_line.status == ExcessLineItemStatus.AWARDED
+        # The win-hook fired: a BuyerScore row exists and counts the win.
+        score = db_session.query(BuyerScore).filter_by(vendor_card_id=buyer.id).one()
+        assert score.offers_received == 1
+        assert score.wins == 1
+
+    def test_award_with_no_canonical_buyer_wins_without_score(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """An offer with no canonical buyer card still wins; the hook no-ops (no
+        BuyerScore, no crash)."""
+        offer = _open_offer(
+            db_session,
+            excess_list=excess_list,
+            submitter=broker,
+            line=cap_line,
+            buyer=None,
+            unit_price=Decimal("0.50"),
+        )
+        db_session.commit()
+
+        result = excess_service.award_offer(db_session, offer.id, owner)
+
+        assert result.status == ExcessOfferStatus.WON
+        assert db_session.query(BuyerScore).count() == 0
+
+    def test_award_by_non_owner_forbidden(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        cap_line: ExcessLineItem,
+        owner: User,
+        broker: User,
+        outsider: User,
+    ):
+        buyer = _buyer_card(db_session, "Guard Buyer")
+        offer = _open_offer(
+            db_session,
+            excess_list=excess_list,
+            submitter=broker,
+            line=cap_line,
+            buyer=buyer,
+            unit_price=Decimal("0.80"),
+        )
+        db_session.commit()
+        with pytest.raises(HTTPException) as exc:
+            excess_service.award_offer(db_session, offer.id, outsider)
+        assert exc.value.status_code == 403
+        db_session.refresh(offer)
+        assert offer.status == ExcessOfferStatus.OPEN  # unchanged
+
+    def test_award_missing_offer_404(self, db_session: Session, owner: User):
+        with pytest.raises(HTTPException) as exc:
+            excess_service.award_offer(db_session, 999_999, owner)
+        assert exc.value.status_code == 404
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  POST award endpoint
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestAwardRoute:
+    def test_award_route_marks_won_and_recomputes_score(
+        self, client, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        from app.dependencies import require_user
+        from app.main import app
+
+        buyer = _buyer_card(db_session, "Route Buyer")
+        offer = _open_offer(
+            db_session,
+            excess_list=excess_list,
+            submitter=broker,
+            line=cap_line,
+            buyer=buyer,
+            unit_price=Decimal("0.80"),
+        )
+        db_session.commit()
+
+        app.dependency_overrides[require_user] = lambda: owner
+        try:
+            resp = client.post(f"/api/resell/{excess_list.id}/offers/{offer.id}/award")
+        finally:
+            app.dependency_overrides.pop(require_user, None)
+
+        assert resp.status_code == 200
+        db_session.refresh(offer)
+        assert offer.status == ExcessOfferStatus.WON
+        assert db_session.query(BuyerScore).filter_by(vendor_card_id=buyer.id).count() == 1
+
+    def test_award_route_non_owner_forbidden(
+        self, client, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, broker: User
+    ):
+        """The default client user is not the list owner → 403 (the award stays
+        open)."""
+        buyer = _buyer_card(db_session, "Route Guard Buyer")
+        offer = _open_offer(
+            db_session,
+            excess_list=excess_list,
+            submitter=broker,
+            line=cap_line,
+            buyer=buyer,
+            unit_price=Decimal("0.80"),
+        )
+        db_session.commit()
+
+        resp = client.post(f"/api/resell/{excess_list.id}/offers/{offer.id}/award")
+        assert resp.status_code == 403
+        db_session.refresh(offer)
+        assert offer.status == ExcessOfferStatus.OPEN


### PR DESCRIPTION
## What & why

`buyer_affinity_service.recompute_buyer_score_on_win` (the offer-win scorecard hook) was **orphaned with zero callers** — because there was **no award path at all**: nothing in the codebase flipped an `ExcessOffer` to `won` (only the seed demo did). The plan's pointers (resell.py ~151/928) are a stat counter and a query filter, not writes. So this PR builds the missing chokepoint and wires the hook into it. (Wave 1 — correctness foundation.)

## Changes
- **`excess_service.award_offer(db, offer_id, owner)`** — the single `offer → won` chokepoint. Owner-gated (403), 404 on a missing offer. Flips the offer to `won`, marks its matched line items `awarded`, recomputes the best-price line rollups, then calls **`recompute_buyer_score_on_win(db, offer)` BEFORE the commit** (this path owns the transaction; the hook no-ops for an offer with no canonical buyer). Mirrors the existing `withdraw_offer` terminal-flip pattern.
- **`POST /api/resell/{list_id}/offers/{offer_id}/award`** — thin owner-gated endpoint that invokes the service and re-renders the detail panel.
- **APP_MAP_DATABASE.md + APP_MAP_INTERACTIONS.md** updated with the award path + win-hook.

## Tests (TDD — red first, then green)
`tests/test_resell_award.py`:
- win recompute (centerpiece): award flips `won`, line `awarded`, `BuyerScore` upserted (wins=1)
- None-safe: offer with no canonical buyer still wins, no `BuyerScore`, no crash
- owner-gate 403 + 404 on missing offer (offer stays `open`)
- endpoint end-to-end: owner → 200 + `won` + score; non-owner → 403

`TESTING=1 pytest tests/ -k "resell or buyer_score or affinity or award"` → **332 passed**. `pre-commit run --all-files` clean.

## Deliberately out of scope
- **No migration** (no schema change).
- **No visible "Award" button.** Adding UI elements needs UX/product sign-off (UI guardrail); the offer-compare modal explicitly defers winner-selection UX ("NO auto-select"). The endpoint is the tested seam that affordance will hook into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)