### PR TITLE
feat(resell): auto-create owner My-Day follow-up tasks from not-yet strip

### DIFF
--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -44,7 +44,14 @@ from ..dependencies import require_access, require_fresh_token, require_user
 from ..file_utils import parse_tabular_file
 from ..models import Company, User, VendorCard
 from ..models.excess import CustomerBid, ExcessLineItem, ExcessList, ExcessOffer, ExcessOfferLine, ExcessOutreach
-from ..services import bid_back_service, buyer_affinity_service, excess_mirror, excess_service, resell_outreach_service
+from ..services import (
+    bid_back_service,
+    buyer_affinity_service,
+    excess_mirror,
+    excess_service,
+    resell_outreach_service,
+    task_service,
+)
 from ..template_env import template_response
 
 router = APIRouter(tags=["resell"])
@@ -1039,12 +1046,28 @@ async def resell_not_yet_strip(
 ):
     """The "usually offered, not yet this round" nudge strip (owner-only).
 
-    Wired into the EXISTING detail nudge surface (NOT a new My-Day). Surfaces buyers
-    historically active in this list's commodities with no outreach on THIS list yet.
+    Wired into the EXISTING detail nudge surface AND, per CRM Phase 2, also persists
+    each surfaced buyer as a durable My-Day follow-up task for the list owner so the
+    nudge survives a page close. The in-page strip and the task share the same buyer
+    set; task creation is idempotent per (list, buyer, owner) via the Task service, so
+    reloading the strip never duplicates a buyer's task.
     """
     el = excess_service.get_excess_list(db, list_id)
     _require_owner(el, user)
     buyers = buyer_affinity_service.not_yet_offered_strip(db, excess_list_id=el.id)
+    # Persist the nudge as owner-assigned My-Day follow-up tasks (idempotent). Due today
+    # so it lands under the Tasks page "Due soon" bucket.
+    due = datetime.now(timezone.utc)
+    for b in buyers:
+        task_service.auto_create_resell_followup_task(
+            db,
+            excess_list_id=el.id,
+            vendor_card_id=b.vendor_card_id,
+            owner_id=el.owner_id,
+            buyer_name=b.display_name,
+            list_title=el.title,
+            due_at=due,
+        )
     return template_response(
         "htmx/partials/resell/_not_yet_strip.html",
         {"request": request, "user": user, "list": el, "buyers": buyers},

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -603,6 +603,63 @@ def on_bid_due_soon(db: Session, requisition_id: int, deadline: str, req_name: s
     )
 
 
+def auto_create_resell_followup_task(
+    db: Session,
+    *,
+    excess_list_id: int,
+    vendor_card_id: int,
+    owner_id: int,
+    buyer_name: str,
+    list_title: str | None = None,
+    due_at: datetime | None = None,
+) -> RequisitionTask:
+    """Idempotently create the list owner's My-Day follow-up for a buyer the resell
+    "usually offered, not yet this round" nudge surfaces.
+
+    Scoped to the buyer's vendor card (the buyer-side "who"), assigned to the list
+    owner, so the nudge survives a page close as a durable task. Keyed by (excess list,
+    buyer card, owner) via source_ref + assignee REGARDLESS of status: reloading the
+    strip never duplicates a buyer's task, and a follow-up the owner has already
+    completed is not re-created. Returns the task that now represents the nudge
+    (existing or freshly created).
+    """
+    source_ref = f"resell_notyet:{excess_list_id}:{vendor_card_id}"
+    existing = (
+        db.query(RequisitionTask)
+        .filter(
+            RequisitionTask.source_ref == source_ref,
+            RequisitionTask.assigned_to_id == owner_id,
+        )
+        .first()
+    )
+    if existing:
+        return existing
+    suffix = f" on {list_title}" if list_title else ""
+    title = f"Follow up: offer {buyer_name}{suffix} this round"[:255]
+    task = RequisitionTask(
+        vendor_card_id=vendor_card_id,
+        title=title,
+        task_type="sales",
+        priority=2,
+        assigned_to_id=owner_id,
+        created_by=owner_id,
+        source="system",
+        source_ref=source_ref,
+        due_at=due_at,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    logger.info(
+        "Resell follow-up task created: {} (list={}, buyer_card={}, owner={})",
+        task.id,
+        excess_list_id,
+        vendor_card_id,
+        owner_id,
+    )
+    return task
+
+
 # ---------------------------------------------------------------------------
 # Task-to-response helper
 # ---------------------------------------------------------------------------

--- a/app/templates/htmx/partials/resell/_not_yet_strip.html
+++ b/app/templates/htmx/partials/resell/_not_yet_strip.html
@@ -9,12 +9,11 @@
   Depends on: the global modal (offer-buyers panel).
 
   ── My-Day seam (DO NOT build a new My-Day here) ──────────────────────────────────
-  The generalized follow-up Task hook lands in CRM Phase 2. When that ships, a buyer
-  surfaced here should also create a My-Day follow-up Task for the owner so the nudge
-  survives a page close. The router endpoint resell_not_yet_strip is the place to call
-  the Task service; this template only renders the in-page strip today.
-  # TODO(crm-phase2): create My-Day follow-up Task here (in resell_not_yet_strip) for
-  #                   each surfaced buyer, via the generalized Task service.
+  CRM-Phase-2 hook is now live: the router (resell.resell_not_yet_strip) persists each
+  surfaced buyer as an owner-assigned My-Day follow-up task via
+  task_service.auto_create_resell_followup_task (idempotent per list+buyer+owner), so
+  the nudge survives a page close. This template only renders the in-page strip — task
+  creation stays in the router, never in markup.
 #}
 {% set el = list %}
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1444,7 +1444,8 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     |        +-- GET .../{id}/outreach           (owner-only Outreach tab: tracker rows +
     |        |     'offered N · M responded · K bid' summary; lazy, explicit hx-target)
     |        +-- GET .../{id}/not-yet-strip      (owner-only nudge: not_yet_offered_strip;
-    |              # TODO(crm-phase2) My-Day Task seam lives in resell_not_yet_strip)
+    |              also persists each surfaced buyer as an owner-assigned My-Day follow-up via
+    |              task_service.auto_create_resell_followup_task — idempotent per list+buyer+owner)
     +-- POST /api/resell/lists                          (create → excess_service.create_excess_list)
     +-- POST /api/resell/{id}/lines                     (add line; resolves MaterialCard)
     +-- POST /api/resell/{id}/import-preview|import-confirm  (reuse excess parsers + preview grid)

--- a/tests/test_resell_myday_followup.py
+++ b/tests/test_resell_myday_followup.py
@@ -1,0 +1,228 @@
+"""test_resell_myday_followup.py — Resell "not yet this round" My-Day follow-up tasks.
+
+Covers the CRM-Phase-2 seam wired into the resell not-yet strip: each buyer the
+"usually offered, not yet this round" nudge surfaces also lands as a durable My-Day
+follow-up RequisitionTask assigned to the LIST OWNER, so the nudge survives a page
+close. Creation is idempotent per (excess list, buyer card, owner) — reloading the
+strip never duplicates a buyer's task.
+
+Two layers:
+- service: task_service.auto_create_resell_followup_task (creation + idempotency,
+  including across done tasks, separate buyers, and separate owners).
+- route: GET /v2/partials/resell/{id}/not-yet-strip creates one task per surfaced
+  buyer for the owner and is idempotent on reload (the strip ranking itself is
+  stubbed — it has its own coverage in test_buyer_affinity_service.py).
+
+Called by: pytest
+Depends on: conftest.py (db_session, test_user, test_company, client),
+            services.task_service, services.buyer_affinity_service.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+os.environ["TESTING"] = "1"
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.constants import ExcessListStatus, TaskStatus
+from app.models import Company, User, VendorCard
+from app.models.excess import ExcessLineItem, ExcessList
+from app.models.task import RequisitionTask
+from app.services import task_service
+from app.services.buyer_affinity_service import RankedBuyer
+from app.utils.normalization import normalize_mpn_key
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_card(db: Session, name: str) -> VendorCard:
+    card = VendorCard(
+        normalized_name=name.lower(),
+        display_name=name,
+        emails=[f"sales@{name.lower().replace(' ', '')}.com"],
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(card)
+    db.commit()
+    db.refresh(card)
+    return card
+
+
+@pytest.fixture()
+def buyer_card_a(db_session: Session) -> VendorCard:
+    return _make_card(db_session, "Buyer Alpha")
+
+
+@pytest.fixture()
+def buyer_card_b(db_session: Session) -> VendorCard:
+    return _make_card(db_session, "Buyer Beta")
+
+
+@pytest.fixture()
+def owned_list(db_session: Session, test_user: User, test_company: Company) -> ExcessList:
+    """A collecting list owned by test_user (the client fixture's auth user)."""
+    el = ExcessList(
+        title="Acme surplus",
+        company_id=test_company.id,
+        owner_id=test_user.id,
+        status=ExcessListStatus.COLLECTING,
+        total_line_items=1,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(el)
+    db_session.flush()
+    db_session.add(
+        ExcessLineItem(
+            excess_list_id=el.id,
+            part_number="XCVU9P-2FLGA2104I",
+            normalized_part_number=normalize_mpn_key("XCVU9P-2FLGA2104I"),
+            quantity=50,
+            condition="New",
+        )
+    )
+    db_session.commit()
+    db_session.refresh(el)
+    return el
+
+
+def _tasks_for(db: Session, owner_id: int) -> list[RequisitionTask]:
+    return db.query(RequisitionTask).filter(RequisitionTask.assigned_to_id == owner_id).all()
+
+
+# ---------------------------------------------------------------------------
+# Service layer — auto_create_resell_followup_task
+# ---------------------------------------------------------------------------
+
+
+class TestFollowupTaskService:
+    def test_creates_followup_task_for_buyer(self, db_session, test_user, owned_list, buyer_card_a):
+        task = task_service.auto_create_resell_followup_task(
+            db_session,
+            excess_list_id=owned_list.id,
+            vendor_card_id=buyer_card_a.id,
+            owner_id=test_user.id,
+            buyer_name=buyer_card_a.display_name,
+            list_title=owned_list.title,
+        )
+        assert task is not None
+        assert task.assigned_to_id == test_user.id
+        assert task.vendor_card_id == buyer_card_a.id
+        assert task.source == "system"
+        assert task.source_ref == f"resell_notyet:{owned_list.id}:{buyer_card_a.id}"
+        assert buyer_card_a.display_name in task.title
+        assert len(_tasks_for(db_session, test_user.id)) == 1
+
+    def test_idempotent_same_buyer_list_owner(self, db_session, test_user, owned_list, buyer_card_a):
+        for _ in range(3):
+            task_service.auto_create_resell_followup_task(
+                db_session,
+                excess_list_id=owned_list.id,
+                vendor_card_id=buyer_card_a.id,
+                owner_id=test_user.id,
+                buyer_name=buyer_card_a.display_name,
+                list_title=owned_list.title,
+            )
+        assert len(_tasks_for(db_session, test_user.id)) == 1
+
+    def test_idempotent_even_after_done(self, db_session, test_user, owned_list, buyer_card_a):
+        """A completed follow-up is not recreated on reload (don't re-nag a dismissed
+        nudge)."""
+        task = task_service.auto_create_resell_followup_task(
+            db_session,
+            excess_list_id=owned_list.id,
+            vendor_card_id=buyer_card_a.id,
+            owner_id=test_user.id,
+            buyer_name=buyer_card_a.display_name,
+        )
+        task.status = TaskStatus.DONE.value
+        task.completed_at = datetime.now(timezone.utc)
+        db_session.commit()
+        task_service.auto_create_resell_followup_task(
+            db_session,
+            excess_list_id=owned_list.id,
+            vendor_card_id=buyer_card_a.id,
+            owner_id=test_user.id,
+            buyer_name=buyer_card_a.display_name,
+        )
+        assert len(_tasks_for(db_session, test_user.id)) == 1
+
+    def test_separate_buyers_get_separate_tasks(self, db_session, test_user, owned_list, buyer_card_a, buyer_card_b):
+        for card in (buyer_card_a, buyer_card_b):
+            task_service.auto_create_resell_followup_task(
+                db_session,
+                excess_list_id=owned_list.id,
+                vendor_card_id=card.id,
+                owner_id=test_user.id,
+                buyer_name=card.display_name,
+            )
+        assert len(_tasks_for(db_session, test_user.id)) == 2
+
+    def test_separate_owners_get_separate_tasks(self, db_session, test_user, manager_user, owned_list, buyer_card_a):
+        for owner in (test_user, manager_user):
+            task_service.auto_create_resell_followup_task(
+                db_session,
+                excess_list_id=owned_list.id,
+                vendor_card_id=buyer_card_a.id,
+                owner_id=owner.id,
+                buyer_name=buyer_card_a.display_name,
+            )
+        assert len(_tasks_for(db_session, test_user.id)) == 1
+        assert len(_tasks_for(db_session, manager_user.id)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Route layer — GET /v2/partials/resell/{id}/not-yet-strip
+# ---------------------------------------------------------------------------
+
+
+def _stub_strip(monkeypatch, ranked: list[RankedBuyer]) -> None:
+    """Pin the strip ranking to a fixed buyer set (ranking has its own coverage)."""
+    monkeypatch.setattr(
+        "app.services.buyer_affinity_service.not_yet_offered_strip",
+        lambda db, *, excess_list_id, **kw: ranked,
+    )
+
+
+def _ranked(card: VendorCard) -> RankedBuyer:
+    return RankedBuyer(
+        vendor_card_id=card.id,
+        display_name=card.display_name,
+        last_bid=None,
+        win_rate=None,
+        last_offered_at=None,
+        rank_reason="buys_this_commodity",
+    )
+
+
+class TestNotYetStripRoute:
+    def test_route_creates_one_task_per_buyer(
+        self, client, db_session, monkeypatch, test_user, owned_list, buyer_card_a, buyer_card_b
+    ):
+        _stub_strip(monkeypatch, [_ranked(buyer_card_a), _ranked(buyer_card_b)])
+        resp = client.get(f"/v2/partials/resell/{owned_list.id}/not-yet-strip")
+        assert resp.status_code == 200
+        tasks = _tasks_for(db_session, test_user.id)
+        assert len(tasks) == 2
+        scoped = {t.vendor_card_id for t in tasks}
+        assert scoped == {buyer_card_a.id, buyer_card_b.id}
+        assert all(t.assigned_to_id == test_user.id for t in tasks)
+
+    def test_route_idempotent_on_reload(
+        self, client, db_session, monkeypatch, test_user, owned_list, buyer_card_a, buyer_card_b
+    ):
+        _stub_strip(monkeypatch, [_ranked(buyer_card_a), _ranked(buyer_card_b)])
+        client.get(f"/v2/partials/resell/{owned_list.id}/not-yet-strip")
+        client.get(f"/v2/partials/resell/{owned_list.id}/not-yet-strip")
+        assert len(_tasks_for(db_session, test_user.id)) == 2
+
+    def test_route_no_buyers_creates_no_tasks(self, client, db_session, monkeypatch, test_user, owned_list):
+        _stub_strip(monkeypatch, [])
+        resp = client.get(f"/v2/partials/resell/{owned_list.id}/not-yet-strip")
+        assert resp.status_code == 200
+        assert _tasks_for(db_session, test_user.id) == []


### PR DESCRIPTION
## What

Implements the deferred `TODO(crm-phase2)` in the resell "usually offered, not yet this round" nudge strip. Each buyer the strip surfaces is now also persisted as a durable **My-Day follow-up `RequisitionTask` assigned to the list owner**, scoped to the buyer's vendor card, so the nudge survives a page close (the in-page chip strip alone vanished on reload).

## How

- **Task service (business logic):** new `task_service.auto_create_resell_followup_task(...)` reuses the existing generalized `RequisitionTask` / My-Day system (no new model). It creates a `source="system"` task scoped to the buyer's `vendor_card_id`, assigned to + created by the list owner, due today (lands in the Tasks page "Due soon" bucket).
- **Idempotency guard:** keyed on `source_ref = resell_notyet:{list_id}:{vendor_card_id}` **+** assignee, matched **regardless of status**. Reloading the strip never duplicates a buyer's task, and a follow-up the owner already completed is not re-created (no re-nag). Different buyers and different owners each get their own task.
- **Router stays thin:** `resell_not_yet_strip` loops the surfaced buyers and delegates to the service; template only renders.
- **Docs:** updated the resell route map in `APP_MAP_INTERACTIONS.md` and cleared the `TODO(crm-phase2)` comment in `_not_yet_strip.html`.

## Tests (TDD — written failing first)

`tests/test_resell_myday_followup.py`, two layers:
- **Service:** creation; idempotency (repeat calls, and across a completed task); per-buyer separation; per-owner separation.
- **Route:** one task per surfaced buyer for the owner; idempotent on reload; empty strip creates nothing (strip ranking stubbed — it has its own coverage in `test_buyer_affinity_service.py`).

Targeted suite green: `TESTING=1 pytest tests/ -k "resell or not_yet or my_day or task"` → **569 passed**. `pre-commit run --all-files`-equivalent on changed files passes (ruff, ruff-format, docformatter, mypy).

## Migration

None — reuses the existing `RequisitionTask` model and its `vendor_card_id` / `source_ref` columns. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)