### PR TITLE
refactor: sweep raw status-string literals to StrEnum constants

### DIFF
--- a/app/routers/admin/system.py
+++ b/app/routers/admin/system.py
@@ -21,6 +21,7 @@ from loguru import logger
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from ...constants import ApiSourceStatus
 from ...database import get_db
 from ...dependencies import require_admin, require_settings_access
 from ...models import ApiSource, User
@@ -181,11 +182,11 @@ def api_connector_health(
         total_results = src.total_results or 0
         errors_24h = src.error_count_24h or 0
         # Auto-flag degraded: >50% failure rate over last 24h (min 4 searches)
-        status = src.status or "pending"
+        status = src.status or ApiSourceStatus.PENDING
         if errors_24h >= 4 and total > 0:
             recent_success = max(0, total - errors_24h)
             if errors_24h > recent_success:
-                status = "degraded"
+                status = ApiSourceStatus.DEGRADED
         result.append(
             {
                 "id": src.id,
@@ -364,10 +365,10 @@ def api_delete_credential(
     src.credentials = creds
     # Recheck status -- if credentials are now incomplete, downgrade to pending
     env_vars = src.env_vars or []
-    if env_vars and src.status == "live":
+    if env_vars and src.status == ApiSourceStatus.LIVE:
         all_set = all(credential_is_set(db, src.name, v) for v in env_vars)
         if not all_set:
-            src.status = "pending"
+            src.status = ApiSourceStatus.PENDING
     db.commit()
     logger.info(f"Credential {var_name} removed from {src.name} by {user.email}")
     return {"status": "removed" if removed else "not_found"}

--- a/app/routers/crm/offers.py
+++ b/app/routers/crm/offers.py
@@ -9,6 +9,7 @@ from ...constants import (
     AccessKey,
     ActivityType,
     OfferStatus,
+    QuoteStatus,
     RequisitionStatus,
     UserRole,
 )
@@ -114,7 +115,7 @@ async def list_offers(req_id: int, user: User = Depends(require_user), db: Sessi
     query = db.query(Offer).filter(Offer.requisition_id == req_id)
     # Hide draft/pending_review offers from buyers — only sales/admin/manager see them
     if user.role == UserRole.BUYER:
-        query = query.filter(Offer.status != "pending_review")
+        query = query.filter(Offer.status != OfferStatus.PENDING_REVIEW)
     offers = (
         query.options(
             joinedload(Offer.entered_by),
@@ -134,7 +135,7 @@ async def list_offers(req_id: int, user: User = Depends(require_user), db: Sessi
         db.query(Quote)
         .filter(
             Quote.requisition_id == req_id,
-            Quote.status.in_(["draft", "sent", "won"]),
+            Quote.status.in_([QuoteStatus.DRAFT, QuoteStatus.SENT, QuoteStatus.WON]),
         )
         .all()
     )
@@ -249,7 +250,7 @@ async def list_offers(req_id: int, user: User = Depends(require_user), db: Sessi
             .filter(
                 Offer.requisition_id != req_id,
                 Offer.material_card_id.in_(all_card_ids),
-                Offer.status.in_(["active", "won"]),
+                Offer.status.in_([OfferStatus.ACTIVE, OfferStatus.WON]),
             )
             .options(joinedload(Offer.entered_by))
             .order_by(Offer.created_at.desc())
@@ -654,7 +655,7 @@ async def approve_offer(
     if not offer:
         raise HTTPException(404, "Offer not found")
     require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
-    if offer.status != "pending_review":
+    if offer.status != OfferStatus.PENDING_REVIEW:
         raise HTTPException(400, "Only pending_review offers can be approved")
     old_status = offer.status
     require_valid_transition("offer", offer.status, OfferStatus.ACTIVE)
@@ -684,7 +685,7 @@ async def reject_offer(
     if not offer:
         raise HTTPException(404, "Offer not found")
     require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
-    if offer.status != "pending_review":
+    if offer.status != OfferStatus.PENDING_REVIEW:
         raise HTTPException(400, "Only pending_review offers can be rejected")
     old_status = offer.status
     require_valid_transition("offer", offer.status, OfferStatus.REJECTED)
@@ -915,7 +916,7 @@ async def list_review_queue(
         db.query(Offer)
         .filter(
             Offer.evidence_tier == "T4",
-            Offer.status == "pending_review",
+            Offer.status == OfferStatus.PENDING_REVIEW,
         )
         .order_by(Offer.created_at.desc())
         .limit(100)
@@ -987,7 +988,7 @@ async def reject_offer_t4_review(
     if not offer:
         raise HTTPException(404, "Offer not found")
     require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
-    if offer.status != "pending_review":
+    if offer.status != OfferStatus.PENDING_REVIEW:
         raise HTTPException(400, "Only pending_review offers can be rejected")
 
     require_valid_transition("offer", offer.status, OfferStatus.REJECTED)

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -29,6 +29,7 @@ from ..constants import (
     RESTRICTED_ROLES,
     AccessKey,
     ActivityType,
+    ApiSourceStatus,
     AttributionStatus,
     BuyPlanStatus,
     ContactRole,
@@ -43,6 +44,7 @@ from ..constants import (
     TicketSource,
     TicketStatus,
     UserRole,
+    VendorResponseStatus,
 )
 from ..database import get_db
 from ..dependencies import (
@@ -2723,7 +2725,7 @@ async def promote_offer_htmx(
     if not offer:
         raise HTTPException(404, "Offer not found")
     require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
-    if offer.status != "pending_review":
+    if offer.status != OfferStatus.PENDING_REVIEW:
         raise HTTPException(400, "Only pending_review offers can be promoted")
 
     old_status = offer.status
@@ -2770,7 +2772,7 @@ async def reject_offer_htmx(
     if not offer:
         raise HTTPException(404, "Offer not found")
     require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
-    if offer.status != "pending_review":
+    if offer.status != OfferStatus.PENDING_REVIEW:
         raise HTTPException(400, "Only pending_review offers can be rejected")
 
     old_status = offer.status
@@ -3506,7 +3508,7 @@ async def send_reply_htmx(
             logger.warning("Vendor reply send failed for response {}: {}", response_id, exc)
 
     if email_sent or is_testing:
-        vr.status = "reviewed"
+        vr.status = VendorResponseStatus.REVIEWED
         db.commit()
 
     logger.info(
@@ -3817,7 +3819,7 @@ def _get_enabled_sources(db: Session) -> list[dict]:
     """
     from ..models import ApiSource
 
-    sources = db.query(ApiSource).filter(ApiSource.status != "disabled").all()
+    sources = db.query(ApiSource).filter(ApiSource.status != ApiSourceStatus.DISABLED).all()
     return [{"name": s.name, "status": s.status} for s in sources]
 
 
@@ -10312,7 +10314,7 @@ async def delete_quote_htmx(
 ):
     """Delete a draft quote and redirect to the requisitions page."""
     quote = get_quote_for_user(db, user, quote_id)
-    if quote.status != "draft":
+    if quote.status != QuoteStatus.DRAFT:
         raise HTTPException(400, "Only draft quotes can be deleted")
 
     db.delete(quote)
@@ -10331,7 +10333,7 @@ async def reopen_quote(
 ):
     """Reopen a sent/closed quote back to draft."""
     quote = get_quote_for_user(db, user, quote_id)
-    if quote.status not in ("sent", "won", "lost"):
+    if quote.status not in (QuoteStatus.SENT, QuoteStatus.WON, QuoteStatus.LOST):
         raise HTTPException(400, "Only sent/won/lost quotes can be reopened")
 
     require_valid_transition("quote", quote.status, QuoteStatus.DRAFT)
@@ -13954,7 +13956,7 @@ async def add_offers_to_draft_quote(
     quote = get_quote_for_user(db, user, quote_id)
     if quote.requisition_id != req_id:
         raise HTTPException(404, "Quote not found")
-    if quote.status != "draft":
+    if quote.status != QuoteStatus.DRAFT:
         raise HTTPException(400, "Can only add to draft quotes")
 
     offers = db.query(Offer).filter(Offer.id.in_(offer_ids), Offer.requisition_id == req_id).all()
@@ -14004,7 +14006,7 @@ async def build_buy_plan_htmx(
     from ..services.buyplan_builder import build_buy_plan
 
     quote = get_quote_for_user(db, user, quote_id)
-    if quote.status != "won":
+    if quote.status != QuoteStatus.WON:
         raise HTTPException(400, "Quote must be won to build a buy plan")
 
     try:

--- a/app/routers/proactive.py
+++ b/app/routers/proactive.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session, joinedload
 
 from ..cache.decorators import cached_endpoint
+from ..constants import ProactiveMatchStatus
 from ..database import get_db
 from ..dependencies import can_manage_account, require_user
 from ..models import Company, ProactiveDoNotOffer, ProactiveMatch, SiteContact, User
@@ -80,9 +81,9 @@ async def dismiss_matches(
         .filter(
             ProactiveMatch.id.in_(match_ids),
             ProactiveMatch.salesperson_id == user.id,
-            ProactiveMatch.status == "new",
+            ProactiveMatch.status == ProactiveMatchStatus.NEW,
         )
-        .update({"status": "dismissed"}, synchronize_session=False)
+        .update({"status": ProactiveMatchStatus.DISMISSED}, synchronize_session=False)
     )
     db.commit()
     return {"dismissed": updated}
@@ -136,9 +137,9 @@ async def add_do_not_offer(
             ProactiveMatch.mpn == mpn,
             ProactiveMatch.company_id == item.company_id,
             ProactiveMatch.salesperson_id == user.id,
-            ProactiveMatch.status == "new",
+            ProactiveMatch.status == ProactiveMatchStatus.NEW,
         ).update(
-            {"status": "dismissed", "dismiss_reason": "do_not_offer"},
+            {"status": ProactiveMatchStatus.DISMISSED, "dismiss_reason": "do_not_offer"},
             synchronize_session=False,
         )
 

--- a/app/routers/requisitions/core.py
+++ b/app/routers/requisitions/core.py
@@ -20,7 +20,15 @@ from sqlalchemy import and_, case, exists, literal, or_, select
 from sqlalchemy import func as sqlfunc
 from sqlalchemy.orm import Session, joinedload
 
-from ...constants import RESTRICTED_ROLES, ActivityType, RequisitionStatus, UserRole
+from ...constants import (
+    RESTRICTED_ROLES,
+    ActivityType,
+    ContactStatus,
+    ProactiveMatchStatus,
+    QuoteStatus,
+    RequisitionStatus,
+    UserRole,
+)
 from ...database import get_db
 from ...dependencies import get_req_for_user, require_admin, require_user
 from ...models import (
@@ -119,7 +127,7 @@ def _build_requisition_list(q, status, sort, order, limit, offset, user, db):
         select(sqlfunc.count(Contact.id))
         .where(
             Contact.requisition_id == Requisition.id,
-            Contact.status == "sent",
+            Contact.status == ContactStatus.SENT,
         )
         .correlate(Requisition)
         .scalar_subquery()
@@ -141,7 +149,7 @@ def _build_requisition_list(q, status, sort, order, limit, offset, user, db):
     )
     latest_rfq_sent_sq = (
         select(sqlfunc.max(Contact.created_at))
-        .where(Contact.requisition_id == Requisition.id, Contact.status == "sent")
+        .where(Contact.requisition_id == Requisition.id, Contact.status == ContactStatus.SENT)
         .correlate(Requisition)
         .scalar_subquery()
         .label("latest_rfq_sent_at")
@@ -199,10 +207,10 @@ def _build_requisition_list(q, status, sort, order, limit, offset, user, db):
         .label("total_target_value")
     )
     _quote_priority = case(
-        (Quote.status == "won", literal(1)),
-        (Quote.status == "lost", literal(2)),
-        (Quote.status == "sent", literal(3)),
-        (Quote.status == "revised", literal(4)),
+        (Quote.status == QuoteStatus.WON, literal(1)),
+        (Quote.status == QuoteStatus.LOST, literal(2)),
+        (Quote.status == QuoteStatus.SENT, literal(3)),
+        (Quote.status == QuoteStatus.REVISED, literal(4)),
         else_=literal(5),
     )
     quote_status_sq = (
@@ -232,7 +240,7 @@ def _build_requisition_list(q, status, sort, order, limit, offset, user, db):
     )
     quote_won_value_sq = (
         select(sqlfunc.max(Quote.won_revenue))
-        .where(Quote.requisition_id == Requisition.id, Quote.status == "won")
+        .where(Quote.requisition_id == Requisition.id, Quote.status == QuoteStatus.WON)
         .correlate(Requisition)
         .scalar_subquery()
         .label("quote_won_value")
@@ -258,7 +266,7 @@ def _build_requisition_list(q, status, sort, order, limit, offset, user, db):
         select(sqlfunc.count(Contact.id))
         .where(
             Contact.requisition_id == Requisition.id,
-            Contact.status.in_(["sent", "opened"]),
+            Contact.status.in_([ContactStatus.SENT, ContactStatus.OPENED]),
         )
         .correlate(Requisition)
         .scalar_subquery()
@@ -268,7 +276,7 @@ def _build_requisition_list(q, status, sort, order, limit, offset, user, db):
         select(sqlfunc.count(ProactiveMatch.id))
         .where(
             ProactiveMatch.requisition_id == Requisition.id,
-            ProactiveMatch.status != "dismissed",
+            ProactiveMatch.status != ProactiveMatchStatus.DISMISSED,
         )
         .correlate(Requisition)
         .scalar_subquery()

--- a/app/routers/requisitions/requirements.py
+++ b/app/routers/requisitions/requirements.py
@@ -120,7 +120,7 @@ def _annotate_buyer_outcomes(req: Requisition, results: dict, db: Session) -> No
         )
         .filter(
             Offer.requirement_id.in_(req_ids),
-            Offer.status != "rejected",
+            Offer.status != OfferStatus.REJECTED,
         )
         .all()
     )
@@ -307,7 +307,7 @@ async def list_requirements(req_id: int, user: User = Depends(require_user), db:
             .filter(
                 RequisitionTask.requisition_id == req_id,
                 RequisitionTask.source_ref.in_(part_refs),
-                RequisitionTask.status != "done",
+                RequisitionTask.status != TaskStatus.DONE,
             )
             .group_by(RequisitionTask.source_ref)
             .all()
@@ -795,7 +795,7 @@ async def get_saved_sightings(
             .filter(
                 Offer.requisition_id != req_id,
                 Offer.material_card_id.in_(all_card_ids),
-                Offer.status.in_(["active", "won"]),
+                Offer.status.in_([OfferStatus.ACTIVE, OfferStatus.WON]),
             )
             .options(joinedload(Offer.entered_by))
             .order_by(Offer.created_at.desc())
@@ -1237,7 +1237,7 @@ async def list_requirement_offers(
     current = (
         db.query(Offer)
         .options(joinedload(Offer.entered_by))
-        .filter(Offer.requirement_id == requirement_id, Offer.status.in_(["active", "won"]))
+        .filter(Offer.requirement_id == requirement_id, Offer.status.in_([OfferStatus.ACTIVE, OfferStatus.WON]))
         .order_by(Offer.created_at.desc())
         .all()
     )
@@ -1260,7 +1260,7 @@ async def list_requirement_offers(
             .filter(
                 Offer.requisition_id != req_item.requisition_id,
                 Offer.material_card_id.in_(card_ids),
-                Offer.status.in_(["active", "won"]),
+                Offer.status.in_([OfferStatus.ACTIVE, OfferStatus.WON]),
             )
             .order_by(Offer.created_at.desc())
             .limit(50)
@@ -1559,7 +1559,7 @@ async def list_requirement_history(
         .filter(
             RequisitionTask.requisition_id == req_item.requisition_id,
             RequisitionTask.source_ref.in_(all_refs),
-            RequisitionTask.status == "done",
+            RequisitionTask.status == TaskStatus.DONE,
         )
         .all()
     )

--- a/app/routers/sources.py
+++ b/app/routers/sources.py
@@ -24,7 +24,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from ..config import settings
-from ..constants import AccessKey
+from ..constants import AccessKey, ApiSourceStatus
 from ..database import get_db
 from ..dependencies import (
     require_access,
@@ -447,8 +447,8 @@ async def list_api_sources(user: User = Depends(require_user), db: Session = Dep
             any_set = any(credential_is_set(db, src.name, v) for v in env_vars)
             # Only downgrade to pending if ALL credentials are missing
             # Never auto-upgrade to "live" — that's the health checker's job
-            if not any_set and src.status not in ("disabled", "error"):
-                src.status = "pending"
+            if not any_set and src.status not in (ApiSourceStatus.DISABLED, ApiSourceStatus.ERROR):
+                src.status = ApiSourceStatus.PENDING
     db.commit()
 
     result = []
@@ -515,7 +515,7 @@ async def run_source_test(src: ApiSource, db: Session) -> dict:
         elapsed_ms = int((time.time() - start) * 1000)
 
         if has_env_vars:
-            src.status = "live"
+            src.status = ApiSourceStatus.LIVE
             src.last_success = datetime.now(timezone.utc)
             src.last_error = None
             src.avg_response_ms = elapsed_ms
@@ -524,7 +524,7 @@ async def run_source_test(src: ApiSource, db: Session) -> dict:
         error = str(e)[:500]
         # Only mark as error if source is configurable (has env_vars)
         if has_env_vars:
-            src.status = "error"
+            src.status = ApiSourceStatus.ERROR
             src.last_error = error
 
     db.commit()
@@ -578,12 +578,12 @@ async def toggle_api_source(
         raise HTTPException(404, "API source not found")
     new_status = payload.status
     # When enabling, auto-detect correct status based on credentials
-    if new_status != "disabled":
+    if new_status != ApiSourceStatus.DISABLED:
         env_vars = src.env_vars or []
         if env_vars and all(credential_is_set(db, src.name, v) for v in env_vars):
-            new_status = "live"
+            new_status = ApiSourceStatus.LIVE
         else:
-            new_status = "pending"
+            new_status = ApiSourceStatus.PENDING
     src.status = new_status
     db.commit()
     return {"ok": True, "status": src.status}
@@ -620,7 +620,7 @@ async def health_summary(
         db.query(ApiSource)
         .filter(
             ApiSource.is_active == True,  # noqa: E712
-            ApiSource.status.in_(["error", "degraded"]),
+            ApiSource.status.in_([ApiSourceStatus.ERROR, ApiSourceStatus.DEGRADED]),
         )
         .all()
     )
@@ -652,7 +652,7 @@ async def system_alerts(
         db.query(ApiSource)
         .filter(
             ApiSource.is_active == True,  # noqa: E712
-            ApiSource.status.in_(["error", "degraded"]),
+            ApiSource.status.in_([ApiSourceStatus.ERROR, ApiSourceStatus.DEGRADED]),
         )
         .order_by(ApiSource.display_name)
         .all()
@@ -774,7 +774,7 @@ async def scan_inbox_for_vendors(request: Request, user: User = Depends(require_
         em_src.last_success = datetime.now(timezone.utc)
         em_src.total_searches = (em_src.total_searches or 0) + 1
         em_src.total_results = (em_src.total_results or 0) + results.get("vendors_found", 0)
-        em_src.status = "live"
+        em_src.status = ApiSourceStatus.LIVE
         db.commit()
 
     return {


### PR DESCRIPTION
## What

Pure readability refactor (Wave 2 of the phased plan): replace stringly-typed status literals with the canonical `StrEnum` constants from `app/constants.py` across 7 routers. `StrEnum` members compare/serialize equal to their string values, so **behavior is unchanged** — no new behavior added, existing tests stay green.

## Why

Per `CLAUDE.md` CODE RULES: *"Status values: always use StrEnum constants from app/constants.py, never raw strings."* This sweep brings the named sites (plus coherent in-file stragglers for the same models) into compliance.

## Scope (per file, by model)

- `routers/sources.py` — `ApiSourceStatus` (assignments, `!=`, `not in`, `.in_`)
- `routers/admin/system.py` — `ApiSourceStatus`
- `routers/htmx_views.py` — `OfferStatus`, `VendorResponseStatus`, `ApiSourceStatus`, `QuoteStatus`
- `routers/crm/offers.py` — `OfferStatus`, `QuoteStatus`
- `routers/requisitions/core.py` — `ContactStatus`, `QuoteStatus` (case-expr), `ProactiveMatchStatus`
- `routers/requisitions/requirements.py` — `OfferStatus`, `TaskStatus`
- `routers/proactive.py` — `ProactiveMatchStatus`

Every enum/member was confirmed to exist in `app/constants.py` before substitution.

## Intentionally NOT changed (reported, no skips for missing enums in named sites)

- `requisitions/core.py:244` — `Offer.status.notin_(["rejected", "deleted", "expired"])` left whole: `Offer` is not a named-site model for this file, and `"deleted"` has **no `OfferStatus` member**, so a partial conversion would create an ugly mixed enum/string list (band-aid). Left untouched.
- HTTP response payload dicts, changelog/`record_changes` value dicts, query-param defaults, and non-model local response-status vars — out of scope (not model `.status` reads/writes), left as-is to avoid drift.

## Verification

- `TESTING=1 pytest tests/ -k "source or offer or quote or requisition or proactive or contact or task" -q` → **5151 passed, 3 skipped**.
- `pre-commit run --all-files` → all hooks pass; **mypy clean** (504 source files, 0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)