### PR TITLE
chore(hooks): track the git-add + lockfile guard hooks

### DIFF
--- a/.claude/hooks/git-add-guard.sh
+++ b/.claude/hooks/git-add-guard.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# git-add-guard.sh — PreToolUse(Bash) hook.
+# Blocks `git add -A`, `git add .`, and `git add --all` in this shared checkout, where
+# such a blanket stage would pull in the node_modules symlink and the .superpowers/ scratch
+# tree. Stage explicit paths instead. Reads the tool-call JSON on stdin; exit 2 = block.
+# Called by: /root/availai/.claude/settings.local.json PreToolUse Bash matcher.
+# Depends on: jq, grep.
+cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null)
+if printf '%s' "$cmd" | grep -qE 'git[[:space:]]+add' \
+   && printf '%s' "$cmd" | grep -qE '(^|[[:space:]])(-A|--all|\.)([[:space:]]|$)'; then
+  echo 'BLOCKED: never `git add -A` / `.` / `--all` here (stages the node_modules symlink + .superpowers/ scratch). Stage explicit paths.' >&2
+  exit 2
+fi
+exit 0

--- a/.claude/hooks/requirements-guard.sh
+++ b/.claude/hooks/requirements-guard.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# requirements-guard.sh — PreToolUse(Edit) hook.
+# Blocks edits to requirements.txt / requirements-dev.txt — those are pip-compile-generated
+# lockfiles. Edit the matching requirements*.in source and recompile (pip-compile) instead.
+# Reads the edited paths from $CLAUDE_FILE_PATHS; exit 2 = block.
+# Called by: /root/availai/.claude/settings.local.json PreToolUse Edit matcher.
+for f in $CLAUDE_FILE_PATHS; do
+  if echo "$f" | grep -qE 'requirements(-dev)?\.txt$'; then
+    echo 'BLOCKED: requirements*.txt is a pip-compile lockfile — edit the matching .in source and recompile (pip-compile); never hand-edit the .txt.' >&2
+    exit 2
+  fi
+done
+exit 0


### PR DESCRIPTION
Two PreToolUse guard scripts already referenced in settings.local.json but previously untracked. git-add-guard blocks blanket `git add -A/./--all`; requirements-guard blocks edits to the pip-compile lockfiles. Follow the same conventions as the sibling tracked hooks.