### PR TITLE
hardening(devops): encrypt backups, drop CI downgrade-base, cap defusedxml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           assert len(heads) <= 1, f'Multiple migration heads detected: {heads}'
           "
 
-      - name: Alembic upgrade/downgrade smoke test
+      - name: Alembic upgrade + schema-drift gate (fresh DB)
         env:
           DATABASE_URL: postgresql://availai:availai@localhost:5432/availai
           SECRET_KEY: ci-secret-key
@@ -154,17 +154,17 @@ jobs:
           # root must be importable (python runs the script with sys.path[0]=scripts/, not
           # the cwd). Without this the schema-drift gate dies on ModuleNotFoundError.
           PYTHONPATH: ${{ github.workspace }}
-          # Allow chain-replay downgrade-base to cascade-drop tables. The 001
-          # explicit-DDL baseline + incremental 002+ chain don't share a clean
-          # reverse drop ordering, so unwinding to base needs cascade. Production
-          # never sets this; single-step downgrades there still fail loudly on
-          # FK-dependency errors.
-          ALEMBIC_ALLOW_CASCADE: "1"
         run: |
+          # Apply the full migration chain forward onto a fresh DB, then assert the
+          # resulting schema matches the ORM models (the schema-drift gate). We do NOT
+          # replay `alembic downgrade base` here every PR: single-head-ness is already
+          # asserted in "Validate Alembic migrations" above, and per-migration
+          # reversibility is covered by the single-step downgrade smoke test below.
+          # Unwinding the whole 001-baseline + 002+ chain to base needed an
+          # ALEMBIC_ALLOW_CASCADE hack (the chain has no clean reverse drop ordering)
+          # and was slow/fragile without adding coverage those two checks don't give.
           alembic upgrade head
           python scripts/check_schema_matches_models.py
-          alembic downgrade base
-          alembic upgrade head
 
       - name: Alembic single-step downgrade smoke test (no cascade)
         env:

--- a/backup.sh
+++ b/backup.sh
@@ -45,6 +45,29 @@ else
     exit 1
 fi
 
+# ── 2b. Optional at-rest encryption (gpg symmetric AES256) ──
+# When BACKUP_GPG_PASSPHRASE is set, encrypt the verified dump and remove the
+# plaintext so nothing readable lands on disk. Decrypt+restore later with:
+#   gpg --batch --decrypt --passphrase "$BACKUP_GPG_PASSPHRASE" FILE.dump.gpg \
+#     | pg_restore -U availai -d availai
+if [ -n "${BACKUP_GPG_PASSPHRASE:-}" ]; then
+    log "Encrypting backup (gpg symmetric, AES256)..."
+    if gpg --batch --yes --quiet --cipher-algo AES256 \
+           --passphrase "${BACKUP_GPG_PASSPHRASE}" --symmetric \
+           --output "${BACKUP_FILE}.gpg" "$BACKUP_FILE"; then
+        rm -f "$BACKUP_FILE"
+        BACKUP_FILE="${BACKUP_FILE}.gpg"
+        SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+        log "Encrypted → $BACKUP_FILE ($SIZE)"
+    else
+        log_err "gpg encryption failed: $BACKUP_FILE"
+        rm -f "$BACKUP_FILE" "${BACKUP_FILE}.gpg"
+        exit 1
+    fi
+else
+    log "BACKUP_GPG_PASSPHRASE not set — backup stored UNENCRYPTED (set it to enable AES256 at-rest encryption)"
+fi
+
 # ── 3. Write timestamp into app container for /health freshness check ──
 # The uploads volume is shared between host and container at /app/uploads
 docker compose -f "$COMPOSE_DIR/docker-compose.yml" exec -T app \
@@ -53,7 +76,7 @@ docker compose -f "$COMPOSE_DIR/docker-compose.yml" exec -T app \
     || log "Warning: could not write timestamp (app container may be down)"
 
 # ── 4. Rotate old backups ──
-PRUNED=$(find "$BACKUP_DIR" -name "availai-*.dump" -mtime +$KEEP_DAYS -print -delete | wc -l)
+PRUNED=$(find "$BACKUP_DIR" \( -name "availai-*.dump" -o -name "availai-*.dump.gpg" \) -mtime +$KEEP_DAYS -print -delete | wc -l)
 # Also clean up any legacy .sql.gz backups from old format
 PRUNED_LEGACY=$(find "$BACKUP_DIR" -name "availai-*.sql.gz" -mtime +$KEEP_DAYS -print -delete | wc -l)
 if [ "$PRUNED" -gt 0 ] || [ "$PRUNED_LEGACY" -gt 0 ]; then

--- a/requirements.in
+++ b/requirements.in
@@ -56,7 +56,7 @@ anthropic>=0.111.0,<1.0
 # HTML sanitization for untrusted email content (XSS prevention)
 nh3==0.3.6
 # Safe XML parsing (XXE prevention)
-defusedxml>=0.7.1
+defusedxml>=0.7.1,<1.0
 # Azure Communication Services (click-to-call)
 azure-communication-callautomation>=1.5.0,<2.0
 azure-communication-identity>=1.5.0,<2.0

--- a/scripts/backup-to-spaces.sh
+++ b/scripts/backup-to-spaces.sh
@@ -48,12 +48,16 @@ export AWS_SECRET_ACCESS_KEY="$DO_SPACES_SECRET"
 export AWS_DEFAULT_REGION="${DO_SPACES_REGION:-nyc3}"
 
 # ─── Upload ──────────────────────────────────────────────────────────────────
-log "Uploading ${FILENAME} to s3://${DO_SPACES_BUCKET}/db-backups/"
+# --sse AES256 requests server-side encryption (SSE-S3) so the object is
+# encrypted at rest in Spaces even when the local backup is not gpg-encrypted.
+# Defense in depth: combines with backup.sh's optional gpg-at-rest encryption.
+log "Uploading ${FILENAME} to s3://${DO_SPACES_BUCKET}/db-backups/ (SSE AES256)"
 
 aws s3 cp \
     "$BACKUP_FILE" \
     "s3://${DO_SPACES_BUCKET}/db-backups/${FILENAME}" \
     --endpoint-url "$ENDPOINT" \
+    --sse AES256 \
     --storage-class STANDARD
 
 # Also upload checksum if it exists
@@ -61,7 +65,8 @@ if [ -f "${BACKUP_FILE}.sha256" ]; then
     aws s3 cp \
         "${BACKUP_FILE}.sha256" \
         "s3://${DO_SPACES_BUCKET}/db-backups/${FILENAME}.sha256" \
-        --endpoint-url "$ENDPOINT"
+        --endpoint-url "$ENDPOINT" \
+        --sse AES256
 fi
 
 log "Upload complete"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -19,6 +19,12 @@ BACKUP_FILE_GZ="${BACKUP_FILE}.gz"
 CHECKSUM_FILE="${BACKUP_FILE_GZ}.sha256"
 LOG_FILE="${BACKUP_DIR}/backup.log"
 
+# Optional at-rest encryption. When BACKUP_GPG_PASSPHRASE is set, the compressed
+# dump is encrypted with gpg symmetric AES256 before the checksum/rotation steps,
+# so backups on disk (and any off-site copy made from them) are never plaintext.
+# Unset → plaintext output (local/dev convenience). Restore handles both.
+GPG_PASSPHRASE="${BACKUP_GPG_PASSPHRASE:-}"
+
 # ─── Functions ───────────────────────────────────────────────────────────────
 log() {
     local msg="[$(date '+%Y-%m-%d %H:%M:%S')] $1"
@@ -102,16 +108,11 @@ if [ ! -f "$BACKUP_FILE_GZ" ]; then
     die "Compression failed — gzip output missing"
 fi
 
-GZ_SIZE=$(stat -c%s "$BACKUP_FILE_GZ" 2>/dev/null || stat -f%z "$BACKUP_FILE_GZ")
-
 # ─── Verification ────────────────────────────────────────────────────────────
+# Verify the dump can be listed (proves format is valid). This MUST run on the
+# plaintext .gz, before any encryption — pg_restore can't read a .gpg blob.
 log "Verifying backup integrity..."
 
-# 1. SHA-256 checksum
-sha256sum "$BACKUP_FILE_GZ" > "$CHECKSUM_FILE"
-log "Checksum: $(cat "$CHECKSUM_FILE")"
-
-# 2. Verify the dump can be listed (proves format is valid)
 RESTORE_TABLE_COUNT=$(gunzip -c "$BACKUP_FILE_GZ" | pg_restore --list 2>/dev/null | grep "TABLE " | wc -l || true)
 log "Verified: backup contains ${RESTORE_TABLE_COUNT} TABLE entries"
 
@@ -119,17 +120,44 @@ if [ "$RESTORE_TABLE_COUNT" -lt 5 ]; then
     die "Backup verification failed — only ${RESTORE_TABLE_COUNT} tables found (expected many more)"
 fi
 
+# ─── At-rest encryption (gpg symmetric AES256, opt-in) ───────────────────────
+# Guarded on BACKUP_GPG_PASSPHRASE: when set, the verified .gz is encrypted and
+# the plaintext removed, so nothing readable lands on disk or off-site. When
+# unset, the backup stays plaintext (restore.sh transparently handles both).
+if [ -n "$GPG_PASSPHRASE" ]; then
+    log "Encrypting backup (gpg symmetric, AES256)..."
+    gpg --batch --yes --quiet \
+        --cipher-algo AES256 \
+        --passphrase "$GPG_PASSPHRASE" \
+        --symmetric \
+        --output "${BACKUP_FILE_GZ}.gpg" \
+        "$BACKUP_FILE_GZ" \
+        || die "gpg encryption failed"
+    rm -f "$BACKUP_FILE_GZ"
+    BACKUP_FILE_GZ="${BACKUP_FILE_GZ}.gpg"
+    CHECKSUM_FILE="${BACKUP_FILE_GZ}.sha256"
+    log "Encrypted → ${BACKUP_FILE_GZ}"
+else
+    log "BACKUP_GPG_PASSPHRASE not set — backup stored UNENCRYPTED (set it to enable AES256 at-rest encryption)"
+fi
+
+GZ_SIZE=$(stat -c%s "$BACKUP_FILE_GZ" 2>/dev/null || stat -f%z "$BACKUP_FILE_GZ")
+
+# ─── Checksum (over the final on-disk artifact) ──────────────────────────────
+sha256sum "$BACKUP_FILE_GZ" > "$CHECKSUM_FILE"
+log "Checksum: $(cat "$CHECKSUM_FILE")"
+
 # ─── Rotation ────────────────────────────────────────────────────────────────
 DELETED_COUNT=0
 if [ "$RETENTION_DAYS" -gt 0 ]; then
     while IFS= read -r old_file; do
         rm -f "$old_file" "${old_file}.sha256"
         DELETED_COUNT=$((DELETED_COUNT + 1))
-    done < <(find "$BACKUP_DIR" -name "${DB_NAME}_*.dump.gz" -mtime +"$RETENTION_DAYS" -type f 2>/dev/null)
+    done < <(find "$BACKUP_DIR" \( -name "${DB_NAME}_*.dump.gz" -o -name "${DB_NAME}_*.dump.gz.gpg" \) -mtime +"$RETENTION_DAYS" -type f 2>/dev/null)
 fi
 
-# Count remaining backups
-BACKUP_COUNT=$(find "$BACKUP_DIR" -name "${DB_NAME}_*.dump.gz" -type f 2>/dev/null | wc -l)
+# Count remaining backups (plaintext + encrypted)
+BACKUP_COUNT=$(find "$BACKUP_DIR" \( -name "${DB_NAME}_*.dump.gz" -o -name "${DB_NAME}_*.dump.gz.gpg" \) -type f 2>/dev/null | wc -l)
 
 # ─── Summary ─────────────────────────────────────────────────────────────────
 log "╔══════════════════════════════════════════════════════════════╗"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -17,6 +17,20 @@ DB_USER="${POSTGRES_USER:-availai}"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"; }
 die() { log "FATAL: $1"; exit 1; }
 
+# Emit the decompressed (and gpg-decrypted, if the file ends in .gpg) backup
+# stream to stdout, so the rest of the script is agnostic to whether a backup
+# was encrypted at rest by backup.sh. Encrypted backups need BACKUP_GPG_PASSPHRASE.
+decompress() {
+    local f="$1"
+    if [[ "$f" == *.gpg ]]; then
+        [ -n "${BACKUP_GPG_PASSPHRASE:-}" ] \
+            || die "Backup '${f}' is gpg-encrypted but BACKUP_GPG_PASSPHRASE is not set"
+        gpg --batch --quiet --decrypt --passphrase "${BACKUP_GPG_PASSPHRASE}" "$f" 2>/dev/null | gunzip -c
+    else
+        gunzip -c "$f"
+    fi
+}
+
 usage() {
     echo "Usage: $0 [backup_file.dump.gz]"
     echo ""
@@ -54,7 +68,7 @@ list_backups() {
             fi
             echo "  ${f}  (${size_human}, ${date_str}, ${checksum_status})"
             count=$((count + 1))
-        done < <(find "$BACKUP_DIR" -name "${DB_NAME}_*.dump.gz" -type f | sort -r)
+        done < <(find "$BACKUP_DIR" \( -name "${DB_NAME}_*.dump.gz" -o -name "${DB_NAME}_*.dump.gz.gpg" \) -type f | sort -r)
         echo ""
         echo "Total: ${count} backups"
     else
@@ -84,7 +98,7 @@ verify_backup() {
 
     # List contents
     local table_count
-    table_count=$(gunzip -c "$file" | pg_restore --list 2>/dev/null | grep "TABLE " | wc -l || true)
+    table_count=$(decompress "$file" | pg_restore --list 2>/dev/null | grep "TABLE " | wc -l || true)
     log "Tables in backup: ${table_count}"
 
     if [ "$table_count" -lt 5 ]; then
@@ -117,7 +131,7 @@ if [ -z "$BACKUP_FILE" ]; then
     if [ -f "${BACKUP_DIR}/LATEST" ]; then
         BACKUP_FILE=$(cat "${BACKUP_DIR}/LATEST")
     else
-        BACKUP_FILE=$(find "$BACKUP_DIR" -name "${DB_NAME}_*.dump.gz" -type f | sort -r | head -1)
+        BACKUP_FILE=$(find "$BACKUP_DIR" \( -name "${DB_NAME}_*.dump.gz" -o -name "${DB_NAME}_*.dump.gz.gpg" \) -type f | sort -r | head -1)
     fi
 fi
 
@@ -146,7 +160,7 @@ if [ -f "${BACKUP_FILE}.sha256" ]; then
     fi
 fi
 
-TABLE_COUNT=$(gunzip -c "$BACKUP_FILE" | pg_restore --list 2>/dev/null | grep "TABLE " | wc -l || true)
+TABLE_COUNT=$(decompress "$BACKUP_FILE" | pg_restore --list 2>/dev/null | grep "TABLE " | wc -l || true)
 if [ "$TABLE_COUNT" -lt 5 ]; then
     die "Backup appears corrupt — only ${TABLE_COUNT} tables. Aborting."
 fi
@@ -171,6 +185,15 @@ if [ "$SKIP_SAFETY" = false ]; then
         --format=custom --no-owner --no-acl --compress=0 \
         2>/dev/null | gzip -9 > "$SAFETY_FILE" || true
 
+    # Match backup.sh's at-rest policy: when a passphrase is configured, the
+    # pre-restore safety dump is encrypted too (never leave plaintext on disk).
+    if [ -n "${BACKUP_GPG_PASSPHRASE:-}" ] && [ -s "$SAFETY_FILE" ]; then
+        gpg --batch --yes --quiet --cipher-algo AES256 \
+            --passphrase "${BACKUP_GPG_PASSPHRASE}" --symmetric \
+            --output "${SAFETY_FILE}.gpg" "$SAFETY_FILE" \
+            && rm -f "$SAFETY_FILE" && SAFETY_FILE="${SAFETY_FILE}.gpg"
+    fi
+
     SAFETY_SIZE=$(stat -c%s "$SAFETY_FILE" 2>/dev/null || stat -f%z "$SAFETY_FILE" 2>/dev/null || echo "0")
     if [ "$SAFETY_SIZE" -gt 1024 ]; then
         log "Safety backup created: ${SAFETY_FILE} ($(numfmt --to=iec-i --suffix=B "$SAFETY_SIZE" 2>/dev/null || echo "${SAFETY_SIZE} bytes"))"
@@ -194,7 +217,7 @@ psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d postgres -c \
     2>/dev/null
 
 log "Restoring from ${BACKUP_FILE}..."
-gunzip -c "$BACKUP_FILE" | pg_restore \
+decompress "$BACKUP_FILE" | pg_restore \
     -h "$DB_HOST" \
     -p "$DB_PORT" \
     -U "$DB_USER" \

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -107,6 +107,28 @@ class TestBackupScriptContent:
         content = _read_script("backup.sh")
         assert "LATEST" in content, "backup.sh must write a LATEST marker file"
 
+    def test_backup_supports_at_rest_encryption(self):
+        """Optional gpg-symmetric AES-256 at-rest encryption, keyed from env."""
+        content = _read_script("backup.sh")
+        assert "BACKUP_GPG_PASSPHRASE" in content, "backup.sh must read the encryption key from BACKUP_GPG_PASSPHRASE"
+        assert "--symmetric" in content and "AES256" in content, "backup.sh encryption must use gpg symmetric AES-256"
+
+    def test_backup_encryption_is_opt_in(self):
+        """Encryption must be guarded so an unset key still yields a usable backup."""
+        content = _read_script("backup.sh")
+        assert 'if [ -n "$GPG_PASSPHRASE" ]' in content, (
+            "backup.sh must guard encryption on the passphrase being set (plaintext otherwise)"
+        )
+
+    def test_backup_verifies_before_encrypting(self):
+        """pg_restore --list must run on the plaintext dump, before encryption."""
+        content = _read_script("backup.sh")
+        verify_idx = content.index("pg_restore --list")
+        encrypt_idx = content.index("--symmetric")
+        assert verify_idx < encrypt_idx, (
+            "backup.sh must verify the dump before encrypting it (pg_restore can't read a .gpg blob)"
+        )
+
 
 class TestRestoreScriptContent:
     """Verify restore.sh has required safety features."""
@@ -139,6 +161,14 @@ class TestRestoreScriptContent:
         content = _read_script("restore.sh")
         assert "RESTORE COMPLETE" in content, "restore.sh must verify and report after restore"
 
+    def test_restore_decrypts_encrypted_backups(self):
+        """restore.sh must transparently decrypt gpg-encrypted (.gpg) backups."""
+        content = _read_script("restore.sh")
+        assert "--decrypt" in content and "BACKUP_GPG_PASSPHRASE" in content, (
+            "restore.sh must gpg --decrypt .gpg backups using BACKUP_GPG_PASSPHRASE"
+        )
+        assert ".gpg" in content, "restore.sh must recognise the .gpg encrypted-backup suffix"
+
 
 class TestSpacesScriptContent:
     """Verify backup-to-spaces.sh handles missing config gracefully."""
@@ -156,6 +186,13 @@ class TestSpacesScriptContent:
     def test_spaces_has_remote_rotation(self):
         content = _read_script("backup-to-spaces.sh")
         assert "SPACES_RETENTION_DAYS" in content, "backup-to-spaces.sh must support remote rotation"
+
+    def test_spaces_uses_server_side_encryption(self):
+        """Off-site uploads must request server-side encryption (SSE-S3)."""
+        content = _read_script("backup-to-spaces.sh")
+        assert "--sse AES256" in content, (
+            "backup-to-spaces.sh must upload with --sse AES256 (server-side encryption at rest)"
+        )
 
 
 class TestDockerComposeBackup:


### PR DESCRIPTION
High-tier `CODE_REVIEW_NOTES.md` DevOps findings. Each was re-verified against current `main`; several were already fixed (noted below). This PR closes the genuinely-open ones. **Do not merge/deploy** without review.

## Fixed here

### HIGH-DEVOPS-1 — unencrypted backups
- `scripts/backup.sh` + root `backup.sh`: optional **gpg-symmetric AES256** at-rest encryption, **guarded on `BACKUP_GPG_PASSPHRASE`** (plaintext when unset, so local/dev is unaffected). Integrity verification (`pg_restore --list`) runs on the plaintext `.gz` **before** encryption; checksum / rotation / `LATEST` all track the `.gpg` artifact.
- `scripts/restore.sh`: transparent `decompress()` that gpg-decrypts `.gpg` backups using the same passphrase; the pre-restore safety dump is encrypted too so no plaintext lingers on disk.
- `scripts/backup-to-spaces.sh`: `aws s3 cp` now uploads with **`--sse AES256`** (server-side encryption at rest in Spaces) — defense in depth with the gpg layer.
- `tests/test_backup.py`: **+5 tests** — encryption opt-in + guard + verify-before-encrypt ordering, restore decrypt support, Spaces SSE.

### HIGH-DEVOPS-7 — `alembic downgrade base` every PR
- `.github/workflows/ci.yml`: the upgrade/downgrade smoke step no longer replays `alembic downgrade base` (which required the `ALEMBIC_ALLOW_CASCADE` hack because the 001-baseline + 002+ chain has no clean reverse drop ordering). It now does **`upgrade head` on a fresh DB + the schema-drift gate** (`check_schema_matches_models.py`). Coverage preserved: single-head-ness is still asserted in the "Validate Alembic migrations" step, and per-migration reversibility is still covered by the existing single-step `downgrade -1` smoke test.

### HIGH-DEVOPS-5 — loose lower-bound pins
- `requirements.in`: `defusedxml` gains a conservative `<1.0` cap — the **only** remaining uncapped prod dep (rapidfuzz / orjson / anthropic / starlette / prometheus_client / sse-starlette / azure-* are already capped on `main`). Resolved version stays `0.7.1`, so the cap doesn't bind and `requirements.txt` is **byte-identical** (no lock change; CI sync gate stays green on Python 3.13).

## Already fixed on `main` (verified, no change needed)
- **HIGH-DEVOPS-2**: `Dockerfile` `FROM` lines are already `@sha256`-pinned (`node:26-alpine`, `python:3.14-slim`).
- **HIGH-DEVOPS-4**: `apscheduler` is already `>=3.11.2,<4.0` (valid) — not the invalid `==3.11.2,<4.0` from the review.
- **HIGH-DEVOPS-6**: `.github/dependabot.yml` already declares both `npm` and `docker` ecosystems.

## Verification
- `pre-commit run --all-files` → all hooks pass, 519 source files, zero unrelated drift.
- `pytest tests/test_backup.py` → **49 passed** (44 prior + 5 new).
- `bash -n` clean on all 5 backup scripts.
- Time-boxed `pip-compile` (pip-tools 7.5.3, matching the pinned CI version) confirms the `defusedxml` cap produces no `requirements.txt` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)