### PR TITLE
feat(quotes): propagate Quote.source through quote revisions (Wave 6)

### DIFF
--- a/app/routers/htmx/quotes.py
+++ b/app/routers/htmx/quotes.py
@@ -442,6 +442,9 @@ async def revise_quote_htmx(
         notes=quote.notes,
         status=QuoteStatus.DRAFT,
         created_by_id=user.id,
+        # Carry revenue attribution forward so a revision of a proactive-sourced
+        # quote stays attributed to proactive selling (Wave 6).
+        source=quote.source,
     )
     db.add(new_quote)
     db.commit()

--- a/app/services/quote_builder_service.py
+++ b/app/services/quote_builder_service.py
@@ -513,6 +513,10 @@ def save_quote_from_builder(
         validity_days=payload.validity_days,
         notes=payload.notes,
         created_by_id=user.id,
+        # A revision inherits revenue attribution from its parent so a
+        # proactive-sourced quote stays attributed through revisions (Wave 6).
+        # A fresh build has no parent → source stays None (set elsewhere on origin).
+        source=old_quote.source if old_quote else None,
     )
     db.add(quote)
     db.flush()

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1253,6 +1253,14 @@ reflects the chosen offer. The choice rides the existing assemble payload
 (`offer_id`) through `save_quote_from_builder` onto `QuoteLine.offer_id`. Vendor
 identity stays internal — the customer doc/export strips it (`quote_export_context`).
 
+**Revision source attribution (Wave 6).** `Quote.source` (e.g. `'proactive'`; migration
+113) is revenue-attribution provenance. Both quote-revision chokepoints inherit it from the
+parent so attribution survives a revision: the htmx "Revise" button
+(`htmx/quotes.py::revise_quote_htmx`, `source=quote.source`) and the builder revise branch
+(`save_quote_from_builder`, `source=old_quote.source if old_quote else None`). A fresh
+(non-revision) build has no parent so `source` stays NULL — it is set only at origin
+(e.g. `proactive_service.py` sets `'proactive'`).
+
 ## 6. Buy Plan Workflow
 
 ```

--- a/tests/test_htmx_views_nightly10.py
+++ b/tests/test_htmx_views_nightly10.py
@@ -525,6 +525,41 @@ class TestReviseQuoteHtmx:
         resp = client.post("/v2/partials/quotes/99999/revise")
         assert resp.status_code == 404
 
+    def test_revise_inherits_proactive_source(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_requisition: Requisition,
+        test_customer_site: CustomerSite,
+        test_user: User,
+    ):
+        """Revising a proactive-sourced quote keeps source='proactive' on the revision
+        (Wave 6 revenue attribution)."""
+        quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, source="proactive")
+        resp = client.post(f"/v2/partials/quotes/{quote.id}/revise")
+        assert resp.status_code == 200
+        revision = (
+            db_session.query(Quote).filter(Quote.requisition_id == test_requisition.id, Quote.id != quote.id).one()
+        )
+        assert revision.source == "proactive"
+
+    def test_revise_preserves_null_source(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_requisition: Requisition,
+        test_customer_site: CustomerSite,
+        test_user: User,
+    ):
+        """A non-proactive quote (source=None) yields a revision with source=None."""
+        quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user)
+        resp = client.post(f"/v2/partials/quotes/{quote.id}/revise")
+        assert resp.status_code == 200
+        revision = (
+            db_session.query(Quote).filter(Quote.requisition_id == test_requisition.id, Quote.id != quote.id).one()
+        )
+        assert revision.source is None
+
 
 class TestApplyMarkupHtmx:
     """Covers POST /v2/partials/quotes/{quote_id}/apply-markup."""

--- a/tests/test_quote_builder.py
+++ b/tests/test_quote_builder.py
@@ -303,6 +303,47 @@ def test_save_quote_revision(db_session, test_user):
     assert old_quote.status == "revised"
 
 
+def test_save_quote_revision_inherits_source(db_session, test_user):
+    """A revision must inherit ``source`` from its parent (Wave 6 revenue attribution).
+
+    A fresh (non-revision) build keeps the default ``source`` of None.
+    """
+    from app.schemas.quote_builder import QuoteBuilderLine, QuoteBuilderSaveRequest
+    from app.services.quote_builder_service import save_quote_from_builder
+
+    req, r1 = _seed_requirement(db_session, test_user)
+
+    def _payload(quote_id=None):
+        return QuoteBuilderSaveRequest(
+            lines=[
+                QuoteBuilderLine(
+                    requirement_id=r1.id,
+                    mpn="LM358DR",
+                    manufacturer="TI",
+                    qty=500,
+                    cost_price=0.24,
+                    sell_price=0.31,
+                    margin_pct=22.6,
+                )
+            ],
+            quote_id=quote_id,
+        )
+
+    # Fresh build → no proactive origin → source stays None.
+    result1 = save_quote_from_builder(db_session, req_id=req.id, payload=_payload(), user=test_user)
+    parent = db_session.get(Quote, result1["quote_id"])
+    assert parent.source is None
+
+    # Mark the parent as proactive-originated, then revise it.
+    parent.source = "proactive"
+    db_session.commit()
+
+    result2 = save_quote_from_builder(db_session, req_id=req.id, payload=_payload(quote_id=parent.id), user=test_user)
+    revision = db_session.get(Quote, result2["quote_id"])
+    assert revision.id != parent.id
+    assert revision.source == "proactive"  # attribution propagates through the revision
+
+
 def test_builder_modal_endpoint_404_bad_req(client):
     resp = client.get("/v2/partials/quote-builder/99999")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
`quotes.source` (migration 113) carries revenue-attribution provenance (e.g. `'proactive'`). When a quote was **revised**, the new revision was created without inheriting `source`, so proactive-originated revenue attribution was silently lost on every revision. This wires source inheritance at both revision chokepoints.

## Chokepoints wired (the single Quote() constructor in each revision flow)
- `app/routers/htmx/quotes.py::revise_quote_htmx` — the "Revise" button (`detail.html`): `source=quote.source`
- `app/services/quote_builder_service.py::save_quote_from_builder` — the builder revise branch (`payload.quote_id` set → `old_quote`): `source=old_quote.source if old_quote else None`

A fresh (non-revision) build has no parent, so `source` stays `NULL` — it is set only at origin (e.g. `proactive_service.py` sets `'proactive'`). `Quote` has no `source_offer_id` column, so only `source` propagates.

## Tests (failing-first, TDD)
- `tests/test_quote_builder.py::test_save_quote_revision_inherits_source` — builder revision inherits `'proactive'`; fresh build keeps `None`.
- `tests/test_htmx_views_nightly10.py::TestReviseQuoteHtmx::test_revise_inherits_proactive_source` + `::test_revise_preserves_null_source` — htmx revise inherits source; null-source control.

Verify: `pytest -k "quote and (source or revis or version or supersede or attribution)"` → 32 passed. Broader quote suites (155 tests) green; `pre-commit run --all-files` clean.

## Docs
`docs/APP_MAP_INTERACTIONS.md` — added a "Revision source attribution (Wave 6)" note to the quote-builder flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)