### PR TITLE
hardening(graph-webhook): bound + nosniff the unauthenticated Graph validation echo (HIGH-SEC-4)

### DIFF
--- a/app/routers/v13_features/activity.py
+++ b/app/routers/v13_features/activity.py
@@ -36,6 +36,29 @@ router = APIRouter(tags=["v13"])
 # ═══════════════════════════════════════════════════════════════════════
 
 
+def _validation_echo_response(validation_token: str) -> PlainTextResponse:
+    """Echo Graph's subscription-validation token under strict bounds.
+
+    Graph REQUIRES the raw ``validationToken`` returned with HTTP 200 as
+    text/plain on subscription creation, so we must mirror it. To keep this
+    unauthenticated echo from reflecting oversized or HTML/script payloads we
+    (1) bound length + charset via ``is_safe_validation_token`` (reject with
+    400 otherwise) and (2) pin an explicit ``text/plain; charset=utf-8`` body
+    with ``X-Content-Type-Options: nosniff`` so no browser will content-sniff
+    it into HTML.
+    """
+    from app.services.webhook_service import is_safe_validation_token
+
+    if not is_safe_validation_token(validation_token):
+        raise HTTPException(400, "Invalid validation token")
+    return PlainTextResponse(
+        content=validation_token,
+        status_code=200,
+        media_type="text/plain; charset=utf-8",
+        headers={"X-Content-Type-Options": "nosniff"},
+    )
+
+
 @router.post("/api/webhooks/graph")
 @limiter.limit("60/minute")
 async def graph_webhook(
@@ -48,7 +71,7 @@ async def graph_webhook(
     """
     validation_token = request.query_params.get("validationToken")
     if validation_token:
-        return PlainTextResponse(content=validation_token, status_code=200)
+        return _validation_echo_response(validation_token)
 
     try:
         raw = await request.json()
@@ -87,7 +110,7 @@ async def teams_webhook(
 
     validation_token = request.query_params.get("validationToken")
     if validation_token:
-        return PlainTextResponse(content=validation_token, status_code=200)
+        return _validation_echo_response(validation_token)
 
     try:
         raw = await request.json()

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -43,6 +43,31 @@ _M365_SUB_ERROR_MSG = "Email tracking degraded — Graph subscription renewal fa
 REPLAY_WINDOW_SECONDS = 300  # 5 minutes
 _seen_notifications: dict[str, float] = {}  # key -> timestamp
 
+# Validation-echo bounds. Microsoft Graph requires the raw ``validationToken``
+# query param to be echoed back as text/plain on subscription creation. Graph's
+# token is a short, randomly generated, URL-safe string, so we bound its length
+# and restrict its charset before reflecting it — this keeps the unauthenticated
+# echo endpoint from being coerced into mirroring oversized or HTML/script
+# payloads (defense in depth alongside the text/plain + nosniff response).
+MAX_VALIDATION_TOKEN_LEN = 2048
+# Angle brackets can never appear in a genuine Graph validation token; rejecting
+# them makes "the echo cannot reflect HTML" true at the input boundary, not just
+# via the response content-type.
+_DISALLOWED_TOKEN_CHARS = frozenset("<>")
+
+
+def is_safe_validation_token(token: str) -> bool:
+    """Return ``True`` if *token* is a plausible Graph validation token.
+
+    Graph sends a short, randomly generated string. We accept only non-empty, length-
+    bounded, printable-ASCII tokens with no angle brackets so the unauthenticated
+    validation-echo endpoint cannot reflect oversized or non-text (HTML/script/binary)
+    payloads.
+    """
+    if not token or len(token) > MAX_VALIDATION_TOKEN_LEN:
+        return False
+    return all(0x20 <= ord(ch) <= 0x7E and ch not in _DISALLOWED_TOKEN_CHARS for ch in token)
+
 
 # ═══════════════════════════════════════════════════════════════════════
 #  SUBSCRIPTION MANAGEMENT

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1135,6 +1135,32 @@ ai_offer_service.py (if confidence >= 0.8)
     +---> sse_broker.py --> SSE push ("new offer parsed")
 ```
 
+### 4a. Graph webhook endpoint (push) + validation-echo hardening
+
+Real-time complement to the polling job above. `webhook_service.create_mail_subscription`
+(and `create_teams_subscription`) register a Graph subscription whose `notificationUrl`
+is `POST /api/webhooks/graph` (`/api/webhooks/teams` for Teams), storing a random
+per-subscription `clientState` (`secrets.token_hex(16)`) on `graph_subscriptions`.
+
+`graph_webhook` (`app/routers/v13_features/activity.py`) handles two request shapes:
+
+- **Subscription-validation handshake** — Graph creates the subscription by calling the
+  endpoint with a `?validationToken=` query param and REQUIRES the raw token echoed back
+  with HTTP 200 as `text/plain`. The echo is unauthenticated (Graph has no token yet), so
+  it is hardened by `_validation_echo_response` → `webhook_service.is_safe_validation_token`:
+  length-bounded (`MAX_VALIDATION_TOKEN_LEN = 2048`) + printable-ASCII-only + no angle
+  brackets (reject → 400), and the 200 response pins `text/plain; charset=utf-8` with
+  `X-Content-Type-Options: nosniff` so the endpoint can't be coerced into reflecting
+  oversized or HTML/script payloads.
+- **Change notifications** — validated by `validate_notifications`: unknown
+  `subscriptionId` rejected, `clientState` checked against the stored secret with a
+  timing-safe `hmac.compare_digest` (wrong/missing/empty → rejected), plus a 5-min
+  replay window keyed on `subscriptionId:resource`. An all-invalid batch → 403; valid
+  `created` notifications fetch the message and feed the same activity-log + inbox-poll
+  path as section 4. The Teams endpoint shares this contract but is gated off in
+  `MVP_MODE` (returns 404); the mail/graph endpoint runs in MVP mode (mail subscriptions
+  are created regardless of `MVP_MODE`).
+
 ## 5. Quote Building
 
 **Where quotes are surfaced.** The standalone Quotes nav tab was retired

--- a/tests/test_webhook_security_integration.py
+++ b/tests/test_webhook_security_integration.py
@@ -265,3 +265,80 @@ def test_admin_health_rate_limited_endpoint(admin_client):
 def test_admin_config_rate_limited_endpoint(admin_client):
     r = admin_client.get("/api/admin/config")
     assert r.status_code == 200
+
+
+# ── Validation-echo hardening (HIGH-SEC-4) ───────────────────────────
+
+
+def test_validation_handshake_is_text_plain_and_nosniff(admin_client):
+    """A genuine handshake echoes the raw token as bounded text/plain + nosniff."""
+    r = admin_client.post("/api/webhooks/graph?validationToken=hello-graph-123")
+    assert r.status_code == 200
+    assert r.text == "hello-graph-123"
+    assert r.headers["content-type"] == "text/plain; charset=utf-8"
+    assert r.headers["x-content-type-options"] == "nosniff"
+
+
+def test_oversized_validation_token_rejected(admin_client):
+    """A validationToken longer than the bound is rejected (no oversized echo)."""
+    huge = "a" * 5000
+    r = admin_client.post("/api/webhooks/graph", params={"validationToken": huge})
+    assert r.status_code == 400
+    assert huge not in r.text
+
+
+def test_html_validation_token_rejected(admin_client):
+    """A validationToken carrying HTML/script is rejected, not reflected."""
+    payload = "<script>alert(document.cookie)</script>"
+    r = admin_client.post("/api/webhooks/graph", params={"validationToken": payload})
+    assert r.status_code == 400
+    assert "<script>" not in r.text
+
+
+def test_control_char_validation_token_rejected(admin_client):
+    """A validationToken with non-printable/control characters is rejected."""
+    r = admin_client.post("/api/webhooks/graph", params={"validationToken": "abc\ndef\x00"})
+    assert r.status_code == 400
+
+
+def test_teams_validation_handshake_is_bounded(admin_client):
+    """Teams shares the same bounded echo; HTML is rejected there too."""
+    with patch("app.routers.v13_features.activity.settings") as mock_settings:
+        mock_settings.mvp_mode = False
+        good = admin_client.post("/api/webhooks/teams?validationToken=teams-ok-123")
+        bad = admin_client.post("/api/webhooks/teams", params={"validationToken": "<img src=x onerror=alert(1)>"})
+    assert good.status_code == 200
+    assert good.text == "teams-ok-123"
+    assert good.headers["x-content-type-options"] == "nosniff"
+    assert bad.status_code == 400
+
+
+def test_missing_client_state_rejected(admin_client, sub1):
+    """A change notification omitting clientState (real sub has one) is rejected."""
+    notification = {
+        "subscriptionId": "sub-sec-001",
+        "changeType": "created",
+        "resource": "Users('a')/Messages('m-missing-state')",
+    }  # no clientState key at all
+    r = webhook_post(admin_client, {"value": [notification]})
+    assert r.status_code == 403
+
+
+def test_empty_client_state_rejected(admin_client, sub1):
+    """An empty clientState against a secret-bearing subscription is rejected."""
+    r = webhook_post(admin_client, {"value": [notif("sub-sec-001", "")]})
+    assert r.status_code == 403
+
+
+def test_is_safe_validation_token_bounds():
+    """Unit-level charset/length bounds for the validation-echo guard."""
+    from app.services.webhook_service import MAX_VALIDATION_TOKEN_LEN, is_safe_validation_token
+
+    assert is_safe_validation_token("hello-graph-123") is True
+    assert is_safe_validation_token("a" * MAX_VALIDATION_TOKEN_LEN) is True
+    assert is_safe_validation_token("a" * (MAX_VALIDATION_TOKEN_LEN + 1)) is False
+    assert is_safe_validation_token("") is False
+    assert is_safe_validation_token("<b>") is False
+    assert is_safe_validation_token("line\nbreak") is False
+    assert is_safe_validation_token("nul\x00byte") is False
+    assert is_safe_validation_token("héllo") is False  # non-ASCII


### PR DESCRIPTION
## HIGH-SEC-4 — Graph webhook validation-echo hardening

The Microsoft Graph webhook endpoints (`POST /api/webhooks/graph`, `/api/webhooks/teams`) must echo the raw `?validationToken=` query param back as `text/plain` + 200 when Graph creates/validates a subscription. They reflected it **unbounded and unauthenticated** with no explicit content-type guard — a reflection/abuse surface (oversized + HTML/script reflection).

### What changed (Graph handshake preserved)
- **(b) Bound the echo.** New `webhook_service.is_safe_validation_token()` accepts only a non-empty, `<= 2048`-char, printable-ASCII token with no angle brackets; anything else → `400`. `_validation_echo_response()` pins `Content-Type: text/plain; charset=utf-8` and `X-Content-Type-Options: nosniff` so the response can never be content-sniffed into HTML. Graph's real validationToken is a short random URL-safe string, so the genuine handshake is unaffected. Applied to **both** the graph and teams endpoints.
- **(a) clientState assertion.** The per-subscription secret is set at creation time (`secrets.token_hex(16)`, stored on `graph_subscriptions.client_state`) and asserted on inbound change notifications via a timing-safe `hmac.compare_digest` in `validate_notifications()` (already present). Added tests locking in that **wrong / missing / empty** `clientState` against a secret-bearing subscription is rejected (`403`).
- **(c) Feature gate respected.** The Teams endpoint stays `404` under `MVP_MODE`; the mail/graph endpoint runs in MVP mode (mail subscriptions are created regardless of `MVP_MODE`), so it is intentionally left ungated — gating it would silently break email tracking.

### Tests (`tests/test_webhook_security_integration.py`)
- Valid handshake echoes the raw token with `text/plain; charset=utf-8` + `nosniff` (graph + teams).
- Oversized (5000 chars), HTML (`<script>`), control-char, and non-ASCII tokens → `400` (no reflection).
- Missing / empty `clientState` against a real subscription → `403`.
- Unit bounds for `is_safe_validation_token` (length boundary, charset).

### Scope / safety
- Files: `app/services/webhook_service.py`, `app/routers/v13_features/activity.py`, `tests/test_webhook_security_integration.py`, `docs/APP_MAP_INTERACTIONS.md` (new §4a). No migration. None of the in-flight locked files touched.
- 245 webhook/activity/teams tests green; `pre-commit run --all-files`-scope hooks pass (ruff, ruff-format, docformatter, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)