### PR TITLE
feat(approvals): SP-4 — receiving-reject falls down into the re-source pool

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -461,17 +461,25 @@ class LineIssueType(StrEnum):
 
 
 class LineResourceReason(StrEnum):
-    """Why a buyer is re-sourcing a line whose PO was cancelled.
+    """Why a buyer is re-sourcing a line whose PO fell down.
 
     This flow is VENDOR-fall-down only (customer cancellations are handled elsewhere and
     never enter here), so every value here counts against the vendor's cancellation
-    performance.
+    performance. Two triggers feed the same re-source pool:
+      - PO-cancel (SP-3 vendor-cancel): the vendor fell down BEFORE delivery; and
+      - receiving-reject (SP-4): the vendor delivered, but the parts were rejected at
+        receiving (defective / wrong / short). Same fall-down, discovered later.
     """
 
+    # ── PO-cancel (vendor fell down before delivery) ──
     SOLD_ELSEWHERE = "sold_elsewhere"  # vendor sold the part to someone else
     CANNOT_DELIVER = "cannot_deliver"  # vendor can't fulfill the PO
     NO_STOCK = "no_stock"  # stock evaporated after the PO was cut
     PRICE_CHANGE = "price_change"  # vendor repriced / reneged
+    # ── Receiving-reject (SP-4: parts arrived but failed receiving) ──
+    DEFECTIVE = "defective"  # parts arrived defective / bad condition
+    WRONG_PART = "wrong_part"  # vendor shipped the wrong part
+    SHORT_SHIP = "short_ship"  # short quantity received
     OTHER = "other"
 
 
@@ -483,6 +491,10 @@ RESOURCE_TO_UNAVAILABILITY_REASON: dict[str, str] = {
     LineResourceReason.CANNOT_DELIVER.value: "not_really_there",
     LineResourceReason.NO_STOCK.value: "not_really_there",
     LineResourceReason.PRICE_CHANGE.value: "sold_elsewhere",
+    # Receiving-reject reasons map to the matching durable unavailability reason.
+    LineResourceReason.DEFECTIVE.value: "broken",
+    LineResourceReason.WRONG_PART.value: "different_part",
+    LineResourceReason.SHORT_SHIP.value: "not_really_there",
     LineResourceReason.OTHER.value: "sold_elsewhere",
 }
 
@@ -499,6 +511,10 @@ class POCancellationReason(StrEnum):
     CANNOT_DELIVER = "cannot_deliver"
     NO_STOCK = "no_stock"
     PRICE_CHANGE = "price_change"
+    # Receiving-reject (SP-4): the vendor delivered but the parts failed receiving.
+    DEFECTIVE = "defective"
+    WRONG_PART = "wrong_part"
+    SHORT_SHIP = "short_ship"
     OTHER = "other"
 
 

--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -837,6 +837,44 @@ async def buy_plan_confirm_po_partial(
     return await buy_plan_detail_partial(request, plan_id, user, db)
 
 
+async def _resource_lines_and_alert(
+    plan_id: int,
+    line_id: int,
+    reason_code: str,
+    reason_note: str | None,
+    also_line_ids: list[int],
+    user: User,
+    db: Session,
+) -> dict:
+    """Shared fall-down → re-source core for BOTH triggers (vendor-cancel + receiving-
+    reject).
+
+    Pools the target line(s) via the single ``resource_line`` engine, commits, and fans out
+    one URGENT backfill alert per pooled line. Both routes funnel here so the receiving-reject
+    path reuses the same pool/alert as the vendor-cancel path (no parallel queue). Returns the
+    service payload; raises HTTP 400 on a service ValueError (with a server-side log first).
+    """
+    from ...services.buyplan_notifications import notify_resource_requested, run_notify_bg
+    from ...services.buyplan_workflow import resource_line
+
+    try:
+        payload = resource_line(plan_id, line_id, reason_code, reason_note, user, db, also_line_ids=also_line_ids)
+        db.commit()
+    except ValueError as e:
+        # Log before re-raising so a real failure (e.g. an un-keyable requirement deep in
+        # the service) leaves a server trace instead of a silent, mislabeled 400.
+        logger.warning("Re-source failed for plan {} line {}: {}", plan_id, line_id, e)
+        raise HTTPException(400, str(e))
+
+    # Broadcast one urgent alert PER pooled line (scope=plan re-sources siblings too, and
+    # each pooled line needs its own claim).
+    for resourced in payload["resourced_lines"]:
+        await run_notify_bg(
+            notify_resource_requested, plan_id, line_id=resourced["line_id"], actor_id=user.id, reason=reason_code
+        )
+    return payload
+
+
 @router.post("/v2/partials/buy-plans/{plan_id}/lines/{line_id}/resource", response_class=HTMLResponse)
 async def buy_plan_resource_line_partial(
     request: Request,
@@ -845,15 +883,12 @@ async def buy_plan_resource_line_partial(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Re-source a line whose vendor PO was cancelled.
+    """Re-source a line whose vendor PO was cancelled (SP-3 vendor-cancel fall-down).
 
     Records the cancellation (vendor performance), marks the offer sold + the vendor
     unavailable, drops the line into the open claim pool, and fires the URGENT backfill
     alert to all other buyers. ``scope=plan`` re-sources the plan's other cut lines too.
     """
-    from ...services.buyplan_notifications import notify_resource_requested, run_notify_bg
-    from ...services.buyplan_workflow import resource_line
-
     # Per-record ownership (non-owner SALES/TRADER → 404) + PO-cutter role gate (403).
     get_buyplan_for_user(db, user, plan_id)
     _require_po_cutter(user)
@@ -868,24 +903,44 @@ async def buy_plan_resource_line_partial(
     if not reason_code:
         raise HTTPException(400, "A re-source reason is required")
 
-    try:
-        payload = resource_line(plan_id, line_id, reason_code, reason_note, user, db, also_line_ids=also_line_ids)
-        db.commit()
-    except ValueError as e:
-        # Log before re-raising so a real failure (e.g. an un-keyable requirement deep in
-        # the service) leaves a server trace instead of a silent, mislabeled 400.
-        logger.warning("Re-source failed for plan {} line {}: {}", plan_id, line_id, e)
-        raise HTTPException(400, str(e))
-
-    # Broadcast one urgent alert PER re-sourced line (scope=plan re-sources siblings too,
-    # and each pooled line needs its own claim).
-    for resourced in payload["resourced_lines"]:
-        await run_notify_bg(
-            notify_resource_requested, plan_id, line_id=resourced["line_id"], actor_id=user.id, reason=reason_code
-        )
+    await _resource_lines_and_alert(plan_id, line_id, reason_code, reason_note, also_line_ids, user, db)
 
     if origin == "resource":
         return await buy_plans_resource_partial(request, user, db)
+    return await buy_plan_detail_partial(request, plan_id, user, db)
+
+
+@router.post("/v2/partials/buy-plans/{plan_id}/lines/{line_id}/reject-received", response_class=HTMLResponse)
+async def buy_plan_reject_received_line_partial(
+    request: Request,
+    plan_id: int,
+    line_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Reject a line at receiving — SP-4 fall-down (wrong / defective / short parts).
+
+    The vendor delivered, but the parts failed receiving. This drops the line into the SAME
+    open re-source pool the vendor-cancel Re-source uses (reusing ``resource_line``), reopens
+    the INBOUND plan to ACTIVE so the line can be re-claimed/re-cut from another vendor, and
+    fires the URGENT backfill alert. Owner- + buyer-gated exactly like the re-source route.
+    ``scope=plan`` rejects the plan's other received lines too.
+    """
+    # Per-record ownership (non-owner SALES/TRADER → 404) + PO-cutter role gate (403).
+    get_buyplan_for_user(db, user, plan_id)
+    _require_po_cutter(user)
+
+    form = await request.form()
+    reason_code = form.get("reason_code", "").strip()
+    reason_note = (form.get("reason_note") or "").strip() or None
+    scope = form.get("scope", "line")
+    also_line_ids = [int(i) for i in form.getlist("also_line_ids")] if scope == "plan" else []
+
+    if not reason_code:
+        raise HTTPException(400, "A rejection reason is required")
+
+    await _resource_lines_and_alert(plan_id, line_id, reason_code, reason_note, also_line_ids, user, db)
+
     return await buy_plan_detail_partial(request, plan_id, user, db)
 
 

--- a/app/services/buyplan_workflow.py
+++ b/app/services/buyplan_workflow.py
@@ -539,15 +539,19 @@ def resource_line(
     db: Session,
     also_line_ids: list[int] | None = None,
 ) -> dict:
-    """Re-source one (default) or several cut-PO lines back into the open claim pool.
+    """Re-source one (default) or several fallen-down lines back into the open claim
+    pool.
 
-    A vendor fell down (sold elsewhere / can't deliver), the buyer cancelled the PO in
-    Acctivate, and now the line must be backfilled. For each target line this:
+    The single fall-down → re-source engine for BOTH triggers (do NOT build a parallel
+    one): the SP-3 vendor-cancel (the buyer cancelled a cut PO before delivery) and the
+    SP-4 receiving-reject (parts arrived but were rejected at receiving — defective /
+    wrong / short). For each target line this:
       1. records an immutable POCancellation (vendor-performance fact),
       2. marks the vendor's offer SOLD + the vendor unavailable for that part,
       3. resets the line into the pool (unassigned, no PO/offer, status RESOURCING),
-    then reopens the plan if it had auto-completed and refreshes the canceled vendors'
-    cancellation metrics. Returns a payload the route hands to the urgent-alert fan-out.
+    then reopens the plan if it had auto-completed (COMPLETED) OR was awaiting receipt
+    (INBOUND) and refreshes the canceled vendors' cancellation metrics. Returns a payload
+    the route hands to the urgent-alert fan-out.
 
     Escalation: ``also_line_ids`` re-sources sibling lines on the SAME plan in one action
     (the hybrid scope — default is just ``line_id``).
@@ -564,12 +568,17 @@ def resource_line(
     if not plan:
         raise ValueError(f"Buy plan {plan_id} not found")
 
-    # Only ACTIVE (live) or COMPLETED (auto-completed, reopened below) plans can be
-    # re-sourced. A VERIFIED line can survive on a CANCELLED/HALTED plan (cancel only
-    # cascades open lines), but re-sourcing it would dead-end — claim → confirm_po needs
-    # an ACTIVE plan, which a cancelled/halted plan can never become here.
-    if plan.status not in (BuyPlanStatus.ACTIVE.value, BuyPlanStatus.COMPLETED.value):
-        raise ValueError(f"Cannot re-source on a {plan.status} plan (must be active or completed)")
+    # Only ACTIVE (live), COMPLETED (auto-completed) or INBOUND (SP-4 receiving-reject) plans
+    # can be re-sourced — COMPLETED/INBOUND are reopened to ACTIVE below. A VERIFIED line can
+    # survive on a CANCELLED/HALTED plan (cancel only cascades open lines), but re-sourcing it
+    # would dead-end — claim → confirm_po needs an ACTIVE plan, which a cancelled/halted plan
+    # can never become here.
+    if plan.status not in (
+        BuyPlanStatus.ACTIVE.value,
+        BuyPlanStatus.COMPLETED.value,
+        BuyPlanStatus.INBOUND.value,
+    ):
+        raise ValueError(f"Cannot re-source on a {plan.status} plan (must be active, inbound, or completed)")
 
     reason_code = LineResourceReason(reason_code).value  # validate the dropdown value
 
@@ -645,9 +654,11 @@ def resource_line(
         line.last_nudge_at = None
         line.status = BuyPlanLineStatus.RESOURCING.value
 
-    # A verified line auto-completes its plan; re-sourcing it must reopen the plan so the
-    # re-claimed line's PO flow (confirm_po requires an ACTIVE plan) works again.
-    if plan.status == BuyPlanStatus.COMPLETED.value:
+    # A COMPLETED (auto-completed) or INBOUND (awaiting receipt, SP-4 reject) plan must reopen
+    # to ACTIVE so the re-claimed line's PO flow (confirm_po requires an ACTIVE plan) works
+    # again. completed_at/case_report are only set on COMPLETED; clearing them is a harmless
+    # no-op for an INBOUND plan.
+    if plan.status in (BuyPlanStatus.COMPLETED.value, BuyPlanStatus.INBOUND.value):
         plan.status = BuyPlanStatus.ACTIVE.value
         plan.completed_at = None
         plan.case_report = None

--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -436,6 +436,49 @@
               </div>
               {% endif %}
 
+              {# ── SP-4: reject at receiving (wrong/defective/short). Falls into the SAME
+                   re-source pool as a vendor-cancel fall-down. Shown only while the deal is
+                   INBOUND (PO approved, goods arriving) on a cut line — the per-line
+                   counterpart to the plan-level "Mark Received" affordance. ── #}
+              {% if can_resource and bp.status == 'inbound' and line.status in ['pending_verify', 'verified'] %}
+              {% set other_recv = lines|selectattr('status', 'in', ['pending_verify', 'verified'])|rejectattr('id', 'eq', line.id)|list %}
+              <div x-data="{ showJ: false, escalate: false }" class="mt-1.5">
+                <a @click="showJ = !showJ" class="text-xs text-rose-500 hover:text-rose-700 font-medium cursor-pointer">Reject &rarr;</a>
+                <div x-show="showJ" x-cloak x-collapse class="mt-2">
+                  <form hx-post="/v2/partials/buy-plans/{{ bp.id }}/lines/{{ line.id }}/reject-received"
+                        hx-target="#main-content" hx-swap="innerHTML"
+                        hx-confirm="Reject this line at receiving? The parts fall back into the re-source pool, mark the vendor's offer Sold + unavailable, and alert ALL buyers to backfill."
+                        class="space-y-1.5">
+                    <input type="hidden" name="scope" :value="escalate ? 'plan' : 'line'">
+                    <select name="reason_code" aria-label="Rejection reason" class="input input-sm w-44">
+                      <option value="defective">Defective / bad parts</option>
+                      <option value="wrong_part">Wrong part shipped</option>
+                      <option value="short_ship">Short shipment</option>
+                      <option value="other">Other</option>
+                    </select>
+                    <textarea name="reason_note" rows="2" placeholder="What was wrong? (optional)"
+                              class="input input-sm w-44"></textarea>
+                    {% if other_recv %}
+                    <label class="flex items-center gap-1.5 text-xs text-gray-600">
+                      <input type="checkbox" x-model="escalate"> Also reject other received lines on this deal
+                    </label>
+                    <div x-show="escalate" x-cloak class="pl-4 space-y-0.5">
+                      {% for o in other_recv %}
+                      <label class="flex items-center gap-1.5 text-xs text-gray-500">
+                        <input type="checkbox" name="also_line_ids" value="{{ o.id }}" checked>
+                        <span class="font-mono">{{ o.requirement.primary_mpn if o.requirement else ('line ' ~ o.id) }}</span>
+                      </label>
+                      {% endfor %}
+                    </div>
+                    {% endif %}
+                    <button type="submit" data-loading-disable class="btn btn-danger btn-sm">
+                      Reject &amp; re-source
+                    </button>
+                  </form>
+                </div>
+              </div>
+              {% endif %}
+
               {# ── Open pool: a re-sourced line awaiting a claim. Any PO-cutter can grab it. ── #}
               {% if line.status == 'resourcing' %}
                 {% if can_resource %}

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1303,15 +1303,29 @@ buyplan_workflow.py (state machine)
             ops (PO unverified >2h) until lines advance; idempotent via buy_plan_lines.last_nudge_at
 ```
 
-### 6e. Re-source (cancelled PO → open claim pool → urgent buyer backfill)
+### 6e. Re-source (fall-down → open claim pool → urgent buyer backfill)
 
-A buyer records a PO on a line to close it out in Acctivate; when a **vendor falls down**
-(sells elsewhere / can't deliver) the buyer cancels that PO in Acctivate and clicks
-**Re-source** on the line (`POST /v2/partials/buy-plans/{plan}/lines/{line}/resource`;
-gated by `get_buyplan_for_user` ownership + `_require_po_cutter` role). The button shows
-on `pending_verify`/`verified` lines even when the plan auto-completed (the late-fall-down
-case). `buyplan_workflow.resource_line` (default one line; `scope=plan` escalates to the
-plan's other cut lines) for each target, in one transaction:
+`buyplan_workflow.resource_line` is the **single** fall-down → re-source engine, fed by
+**two triggers** (never a parallel queue):
+
+- **Vendor-cancel (SP-3):** a buyer records a PO on a line in Acctivate; when a **vendor
+  falls down** (sells elsewhere / can't deliver) the buyer cancels that PO and clicks
+  **Re-source** on the line (`POST /v2/partials/buy-plans/{plan}/lines/{line}/resource`).
+  Shown on `pending_verify`/`verified` lines of an `active`/`completed` plan (the button
+  survives even when the plan auto-completed — the late-fall-down case).
+- **Receiving-reject (SP-4):** the vendor delivered, but the parts were rejected at
+  receiving (**defective / wrong / short**). On an **INBOUND** plan the buyer clicks
+  **Reject** on the line (`POST /v2/partials/buy-plans/{plan}/lines/{line}/reject-received`,
+  the per-line counterpart to the plan-level "Mark Received") instead of completing the
+  deal. The reject reasons (`defective`/`wrong_part`/`short_ship`) are receiving-specific
+  `LineResourceReason`/`POCancellationReason` values (free strings on the `String` reason
+  columns — **no migration**); each maps to a durable vendor-unavailability reason
+  (`broken`/`different_part`/`not_really_there`). The plan reopens **INBOUND → active**.
+
+Both triggers are gated by `get_buyplan_for_user` ownership + `_require_po_cutter` role and
+both funnel through the router helper `_resource_lines_and_alert` (pool + commit + alert
+fan-out). `buyplan_workflow.resource_line` (default one line; `scope=plan` escalates to the
+plan's other cut/received lines) for each target, in one transaction:
 
 1. `po_cancellation_service.record_po_cancellation` — append the immutable `po_cancellations`
    row (vendor-performance fact; `days_to_cancel` from `po_confirmed_at`).
@@ -1319,7 +1333,8 @@ plan's other cut lines) for each target, in one transaction:
 3. `mark_vendor_unavailable` — `record_unavailability(SOLD_ELSEWHERE-mapped)` so the vendor
    shows **unavailable** for that part on the Sightings tab (§2d).
 4. Reset the line into the pool: clear buyer/offer/PO fields, `status = resourcing`; reopen
-   the plan to `active` if it had auto-completed.
+   the plan to `active` if it had auto-completed (`completed`) or was awaiting receipt
+   (`inbound`), so `claim_line` → `confirm_po` (needs an active plan) works again.
 5. `refresh_vendor_cancellation_metrics` — recompute the vendor's `cancellation_rate` /
    `avg_days_to_cancel` / `slow_cancel_count` (a slow cancel, >7d, dampens `vendor_score`
    harder — `vendor_score._cancel_dampener`).
@@ -5295,10 +5310,14 @@ above it a `PURCHASE_ORDER` `ApprovalRequest` opens (amount = plan total), route
 `can_approve_purchase_orders` holders within their `purchase_order_approval_limit` (mirrors the
 prepayment amount-filter). `decide()` discriminates it from the `BUY_PLAN` gate by **gate_type**
 (both carry a BuyPlan subject): on approve it runs `_run_po_approve_side_effects`, moving the
-plan **ACTIVE → INBOUND** (goods inbound). The buyer then completes the deal via
-`receive_buy_plan` (`POST /v2/partials/buy-plans/{id}/receive`, the "Mark Received" banner on an
-INBOUND plan), which moves **INBOUND → COMPLETED** through the shared `_complete_plan` (same case
-report as auto-completion). The deal-level gate surfaces under the **Purchase Orders** stage tab
+plan **ACTIVE → INBOUND** (goods inbound). On an INBOUND plan the buyer either completes the
+deal via `receive_buy_plan` (`POST /v2/partials/buy-plans/{id}/receive`, the "Mark Received"
+banner), which moves **INBOUND → COMPLETED** through the shared `_complete_plan` (same case
+report as auto-completion); **or (SP-4 fall-down)** rejects line(s) at receiving
+(`POST .../lines/{line}/reject-received`, the per-line "Reject" affordance) when the parts
+arrive defective/wrong/short — those lines fall into the **same re-source pool** as a
+vendor-cancel fall-down (§6e: `resource_line` reopens the plan INBOUND → ACTIVE so the line
+can be re-claimed/re-cut). The deal-level gate surfaces under the **Purchase Orders** stage tab
 (`_TAB_APPROVE_ATTR['purchase_orders'] = can_approve_purchase_orders`); the QP Purchasing
 section gate is now QP-view inline only (no tab).
 

--- a/tests/test_approvals_sp4_fall_down.py
+++ b/tests/test_approvals_sp4_fall_down.py
@@ -1,0 +1,327 @@
+"""test_approvals_sp4_fall_down.py — Approvals SP-4: receiving-reject → re-source.
+
+The SP-3 receiving step lets a buyer mark an INBOUND plan received (→ COMPLETED). SP-4
+adds the fall-down path: at receiving the buyer can REJECT line(s) (wrong / defective /
+short parts) instead. A rejected line "falls down" into the SAME open re-source pool the
+vendor-cancel Re-source uses (status RESOURCING) so it can be backfilled from another
+vendor — it REUSES ``resource_line`` (and therefore the POCancellation vendor-performance
+fact + the urgent buyer alert); it does NOT build a parallel queue.
+
+Covers:
+  - rejecting a received line on an INBOUND plan pools it (RESOURCING) and reopens the
+    plan to ACTIVE so the line can be re-claimed/re-cut;
+  - the rejection records a POCancellation with the receiving-specific reason;
+  - a fully-received PO still completes (the happy path is untouched);
+  - the reject route fires one urgent backfill alert per pooled line;
+  - the reject route is owner- + buyer-gated (non-owner sales → 404; owner-but-not-a-
+    PO-cutter → 403).
+
+Called by: pytest
+Depends on: conftest fixtures, app.services.buyplan_workflow, app.routers.htmx.buy_plans.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.constants import (
+    RESOURCE_TO_UNAVAILABILITY_REASON,
+    BuyPlanLineStatus,
+    BuyPlanStatus,
+    LineResourceReason,
+    OfferStatus,
+    SOVerificationStatus,
+    UnavailabilityReason,
+)
+from app.models import Offer, POCancellation, User  # noqa: F401 (User kept for parity/typing)
+from app.models.buy_plan import BuyPlan, BuyPlanLine
+from app.models.sourcing import Requisition
+from app.services.buyplan_workflow import receive_buy_plan, resource_line
+
+# ── Helpers (mirror tests/test_buyplan_resource.py) ──────────────────────
+
+
+def _make_plan(db, quote, requisition, **overrides) -> BuyPlan:
+    defaults = dict(
+        quote_id=quote.id,
+        requisition_id=requisition.id,
+        status=BuyPlanStatus.INBOUND.value,
+        so_status=SOVerificationStatus.APPROVED.value,
+        total_cost=10_000.0,
+        total_revenue=20_000.0,
+        total_margin_pct=50.0,
+        ai_flags=[],
+        created_at=datetime.now(timezone.utc),
+    )
+    defaults.update(overrides)
+    plan = BuyPlan(**defaults)
+    db.add(plan)
+    db.flush()
+    return plan
+
+
+def _make_offer(db, requirement, vendor_card, **overrides) -> Offer:
+    defaults = dict(
+        requirement_id=requirement.id,
+        vendor_card_id=vendor_card.id,
+        vendor_name=vendor_card.display_name or "Arrow Electronics",
+        vendor_name_normalized=vendor_card.normalized_name,
+        mpn=requirement.primary_mpn or "LM317T",
+        normalized_mpn=requirement.primary_mpn or "LM317T",
+        unit_price=1.0,
+        status=OfferStatus.ACTIVE.value,
+    )
+    defaults.update(overrides)
+    offer = Offer(**defaults)
+    db.add(offer)
+    db.flush()
+    return offer
+
+
+def _make_received_line(db, plan, requirement, offer, buyer, **overrides) -> BuyPlanLine:
+    """A VERIFIED line on an INBOUND plan — goods arrived (a live, received PO)."""
+    defaults = dict(
+        buy_plan_id=plan.id,
+        requirement_id=requirement.id,
+        offer_id=offer.id,
+        quantity=100,
+        unit_cost=1.0,
+        unit_sell=2.0,
+        buyer_id=buyer.id,
+        status=BuyPlanLineStatus.VERIFIED.value,
+        po_number="PO-7700",
+        po_confirmed_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    defaults.update(overrides)
+    line = BuyPlanLine(**defaults)
+    db.add(line)
+    db.flush()
+    return line
+
+
+class _FakeForm(dict):
+    """Minimal Starlette FormData stand-in: .get + .getlist."""
+
+    def getlist(self, key):
+        v = self.get(key)
+        if v is None:
+            return []
+        return v if isinstance(v, list) else [v]
+
+
+class _FakeRequest:
+    def __init__(self, form_data):
+        self._form = _FakeForm(form_data)
+
+    async def form(self):
+        return self._form
+
+
+# ── Service: receiving-reject pools the line via the EXISTING re-source ───
+
+
+class TestReceivingRejectService:
+    def test_reject_pools_line_and_reopens_inbound_plan(
+        self, db_session: Session, test_user, test_quote, test_requisition, test_vendor_card
+    ):
+        plan = _make_plan(db_session, test_quote, test_requisition)
+        requirement = test_requisition.requirements[0]
+        offer = _make_offer(db_session, requirement, test_vendor_card)
+        line = _make_received_line(db_session, plan, requirement, offer, test_user)
+
+        payload = resource_line(plan.id, line.id, LineResourceReason.DEFECTIVE.value, "Bad caps", test_user, db_session)
+        db_session.commit()
+        db_session.refresh(line)
+        db_session.refresh(plan)
+
+        # Pooled into the SAME open re-source pool the vendor-cancel flow uses.
+        assert line.status == BuyPlanLineStatus.RESOURCING.value
+        assert line.buyer_id is None
+        assert line.offer_id is None
+        # The INBOUND plan reopens to ACTIVE so the line can be re-claimed/re-cut.
+        assert plan.status == BuyPlanStatus.ACTIVE.value
+        assert len(payload["resourced_lines"]) == 1
+
+    def test_reject_records_cancellation_fact(
+        self, db_session: Session, test_user, test_quote, test_requisition, test_vendor_card
+    ):
+        plan = _make_plan(db_session, test_quote, test_requisition)
+        requirement = test_requisition.requirements[0]
+        offer = _make_offer(db_session, requirement, test_vendor_card)
+        line = _make_received_line(db_session, plan, requirement, offer, test_user)
+
+        resource_line(plan.id, line.id, LineResourceReason.WRONG_PART.value, None, test_user, db_session)
+        db_session.commit()
+
+        cancel = db_session.query(POCancellation).filter_by(buy_plan_line_id=line.id).one()
+        assert cancel.reason_code == LineResourceReason.WRONG_PART.value
+        assert cancel.po_number == "PO-7700"
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            LineResourceReason.DEFECTIVE.value,
+            LineResourceReason.WRONG_PART.value,
+            LineResourceReason.SHORT_SHIP.value,
+        ],
+    )
+    def test_each_receiving_reason_is_valid_and_maps_to_unavailability(
+        self, db_session: Session, test_user, test_quote, test_requisition, test_vendor_card, reason
+    ):
+        plan = _make_plan(db_session, test_quote, test_requisition)
+        requirement = test_requisition.requirements[0]
+        offer = _make_offer(db_session, requirement, test_vendor_card)
+        line = _make_received_line(db_session, plan, requirement, offer, test_user)
+
+        resource_line(plan.id, line.id, reason, None, test_user, db_session)
+        db_session.commit()
+        db_session.refresh(line)
+
+        assert line.status == BuyPlanLineStatus.RESOURCING.value
+        # Every receiving reason maps to a real vendor-unavailability reason.
+        mapped = RESOURCE_TO_UNAVAILABILITY_REASON[reason]
+        assert mapped in {r.value for r in UnavailabilityReason}
+
+
+# ── Service: the happy path (fully received → COMPLETED) is untouched ─────
+
+
+def test_fully_received_plan_still_completes(
+    db_session: Session, test_user, test_quote, test_requisition, test_vendor_card
+):
+    """With no rejected lines, mark-received still drives an INBOUND plan to
+    COMPLETED."""
+    plan = _make_plan(db_session, test_quote, test_requisition)
+    requirement = test_requisition.requirements[0]
+    offer = _make_offer(db_session, requirement, test_vendor_card)
+    _make_received_line(db_session, plan, requirement, offer, test_user)
+
+    received = receive_buy_plan(plan.id, test_user, db_session)
+
+    assert received.status == BuyPlanStatus.COMPLETED.value
+    assert received.completed_at is not None
+    assert received.case_report
+
+
+# ── Route: reject-received pools + alerts, owner/buyer gated ──────────────
+
+
+class TestRejectReceivedRoute:
+    @pytest.mark.asyncio
+    async def test_route_pools_line_and_fires_alert(
+        self, db_session: Session, test_user, test_quote, test_requisition, test_vendor_card
+    ):
+        from app.routers.htmx import buy_plans as htmx_buy_plans
+
+        plan = _make_plan(db_session, test_quote, test_requisition)
+        requirement = test_requisition.requirements[0]
+        offer = _make_offer(db_session, requirement, test_vendor_card)
+        line = _make_received_line(db_session, plan, requirement, offer, test_user)
+        db_session.commit()
+
+        mock_bg = AsyncMock()
+        req = _FakeRequest({"reason_code": "defective", "scope": "line"})
+        with (
+            patch("app.services.buyplan_notifications.run_notify_bg", mock_bg),
+            patch.object(htmx_buy_plans, "buy_plan_detail_partial", new_callable=AsyncMock, return_value="ok"),
+        ):
+            result = await htmx_buy_plans.buy_plan_reject_received_line_partial(
+                req, plan.id, line.id, user=test_user, db=db_session
+            )
+
+        db_session.refresh(line)
+        assert result == "ok"
+        assert line.status == BuyPlanLineStatus.RESOURCING.value
+        fired = [c.args[0].__name__ for c in mock_bg.await_args_list]
+        assert "notify_resource_requested" in fired
+
+    @pytest.mark.asyncio
+    async def test_route_requires_reason(
+        self, db_session: Session, test_user, test_quote, test_requisition, test_vendor_card
+    ):
+        from app.routers.htmx import buy_plans as htmx_buy_plans
+
+        plan = _make_plan(db_session, test_quote, test_requisition)
+        requirement = test_requisition.requirements[0]
+        offer = _make_offer(db_session, requirement, test_vendor_card)
+        line = _make_received_line(db_session, plan, requirement, offer, test_user)
+        db_session.commit()
+
+        req = _FakeRequest({"reason_code": "", "scope": "line"})
+        with pytest.raises(HTTPException) as exc:
+            await htmx_buy_plans.buy_plan_reject_received_line_partial(
+                req, plan.id, line.id, user=test_user, db=db_session
+            )
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_route_buyer_gated_owner_but_not_po_cutter_403(
+        self, db_session: Session, sales_user, test_quote, test_vendor_card
+    ):
+        """A sales owner (not a PO-cutter) is 403'd by the buyer gate."""
+        from app.routers.htmx import buy_plans as htmx_buy_plans
+
+        # Requisition OWNED by the sales user, so get_buyplan_for_user passes ownership and
+        # the _require_po_cutter buyer gate is what fires.
+        req_obj = Requisition(
+            name="REQ-SALES-OWN",
+            customer_name="SalesCo",
+            status="open",
+            created_by=sales_user.id,
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(req_obj)
+        db_session.flush()
+        plan = BuyPlan(
+            requisition_id=req_obj.id,
+            quote_id=test_quote.id,
+            status=BuyPlanStatus.INBOUND.value,
+            so_status=SOVerificationStatus.APPROVED.value,
+            total_cost=10_000.0,
+        )
+        db_session.add(plan)
+        db_session.commit()
+
+        req = _FakeRequest({"reason_code": "defective"})
+        with pytest.raises(HTTPException) as exc:
+            await htmx_buy_plans.buy_plan_reject_received_line_partial(req, plan.id, 1, user=sales_user, db=db_session)
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_route_non_owner_sales_404(
+        self, db_session: Session, test_user, sales_user, test_quote, test_requisition, test_vendor_card
+    ):
+        """A sales user who does not own the plan is 404'd before any mutation."""
+        from app.routers.htmx import buy_plans as htmx_buy_plans
+
+        plan = _make_plan(db_session, test_quote, test_requisition)  # owned by test_user (buyer)
+        db_session.commit()
+
+        req = _FakeRequest({"reason_code": "defective"})
+        with pytest.raises(HTTPException) as exc:
+            await htmx_buy_plans.buy_plan_reject_received_line_partial(req, plan.id, 1, user=sales_user, db=db_session)
+        assert exc.value.status_code == 404
+
+
+# ── Render: the INBOUND detail partial shows the per-line Reject affordance ──
+
+
+def test_inbound_detail_renders_reject_affordance(
+    client, db_session: Session, test_user, test_quote, test_requisition, test_vendor_card
+):
+    """The real detail template renders the SP-4 Reject affordance on an INBOUND plan's
+    cut line (catches Jinja errors + confirms the button posts to /reject-received)."""
+    plan = _make_plan(db_session, test_quote, test_requisition)
+    requirement = test_requisition.requirements[0]
+    offer = _make_offer(db_session, requirement, test_vendor_card)
+    _make_received_line(db_session, plan, requirement, offer, test_user)
+    db_session.commit()
+
+    resp = client.get(f"/v2/partials/buy-plans/{plan.id}")
+
+    assert resp.status_code == 200
+    assert "reject-received" in resp.text
+    assert "Reject &amp; re-source" in resp.text


### PR DESCRIPTION
## Approvals SP-4 — fall-down → re-source (parts rejected in receiving)

Builds on **SP-3** (PO `INBOUND` state + `receive_buy_plan`). At the receiving step the buyer can now **REJECT** line(s) — wrong / defective / short parts — instead of marking the whole PO received. A rejected line **falls down into the SAME open re-source pool** the existing **vendor-cancel Re-source** (#532) uses.

### Re-source mechanism reused (no parallel queue)
- `buyplan_workflow.resource_line` — the single fall-down → re-source engine (pools the line to `RESOURCING`, writes the immutable `POCancellation` vendor-performance fact, marks the offer `SOLD` + the vendor unavailable, reopens the plan, fans out the urgent buyer-backfill alert).
- `claim_line` / `resourcing_pool_queue` / `BuyplanResourcingSource` — the same "Needs Re-sourcing" pool, badge, and claim race.
- `po_cancellation_service` side effects + `notify_resource_requested` broadcast.

### What changed
- **constants** — receiving-specific `LineResourceReason`/`POCancellationReason` values (`defective` / `wrong_part` / `short_ship`); each maps to a durable vendor-unavailability reason (`broken` / `different_part` / `not_really_there`).
- **service** — `resource_line` now accepts an **INBOUND** plan and reopens **INBOUND → ACTIVE** (mirrors the existing COMPLETED → ACTIVE reopen) so the line can be re-claimed/re-cut from another vendor.
- **router** — extracted the shared `_resource_lines_and_alert` core (pool + commit + alert) so vendor-cancel and receiving-reject funnel through one path; added the thin `POST /v2/partials/buy-plans/{id}/lines/{line}/reject-received` route (owner- + buyer-gated, mirroring the re-source route).
- **template** — per-line **Reject** affordance on an INBOUND plan's cut lines, the per-line counterpart to the plan-level "Mark Received" banner (with `scope=plan` escalation, mirroring the re-source form).
- **docs** — `APP_MAP_INTERACTIONS.md` §6e + the SP-3 receiving section updated.

### Migration
**None.** Reuses the existing `RESOURCING` line status; the new reasons are free strings on the existing `String(30/32)` reason columns. Alembic head unchanged at `166_sp3_po_receiving` (single head). `MIGRATION_NUMBERS_IN_FLIGHT.txt` untouched.

### Tests (TDD) — `tests/test_approvals_sp4_fall_down.py`, 11 tests
- rejecting a received line on an INBOUND plan pools it (`RESOURCING`) + reopens the plan to ACTIVE;
- the rejection records a `POCancellation` with the receiving reason; each new reason validates + maps to a real unavailability reason;
- a fully-received PO still completes (happy path untouched);
- the reject route fires one urgent backfill alert per pooled line + requires a reason;
- owner/buyer gating (non-owner sales → 404; owner-but-not-a-PO-cutter → 403);
- real-render check of the INBOUND detail partial's Reject affordance.

Targeted suite `-k "resource or receiv or fall or buyplan or buy_plan or sp4 or sp3"`: **1221 passed, 1 skipped**. `pre-commit run --all-files`-scope hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)