### PR TITLE
hardening(search): escape LIKE wildcards in user-input ILIKE sites (HIGH-SEC-3)

### DIFF
--- a/CODE_REVIEW_NOTES.md
+++ b/CODE_REVIEW_NOTES.md
@@ -70,7 +70,7 @@ Legend: ✅ FIXED · ◐ PARTIAL · ⚠️ STILL OPEN
 |----|--------|------|
 | HIGH-SEC-1 | ⚠️ STILL OPEN | `{{ title_attr\|safe }}` still at `_macros.html:158`. |
 | HIGH-SEC-2 | ⚠️ STILL OPEN | `thread_viewer.html:59` now uses `\|sanitize_html\|safe`, but `class` is still in the wildcard allowlist (`template_env.py:140`); `nh3` still `>=` pinned. |
-| HIGH-SEC-3 | ⚠️ STILL OPEN | Unescaped ILIKE wildcards still at `htmx_views.py:3330, 6924` (`f"%{q.strip()}%"`). |
+| HIGH-SEC-3 | ✅ RESOLVED | All user-input ILIKE/LIKE search sites now route through `escape_like()` + `.ilike(..., escape="\\")`; shared `SearchBuilder.ilike_filter` carries the escape. Regression test `tests/test_ilike_wildcard_escaping.py`. (Domain-field `%@{domain}` analytics deliberately excluded — structured column, not user search.) |
 | HIGH-SEC-4 | ⚠️ STILL OPEN | Graph webhook validation echo — carried over from 2026-05-04 review, not individually re-verified; conservatively open. |
 | HIGH-BE-1 | ⚠️ STILL OPEN | `htmx_views.py` is 9,918 lines (was 10,024) — not split. |
 | HIGH-BE-2 | ⚠️ STILL OPEN | God files persist (`htmx_views.py` 9918, `search_service.py` 2348, `email_service.py` 1277). |
@@ -146,9 +146,17 @@ The detailed bodies below are retained verbatim from the 2026-05-04 review for e
   `app/templates/htmx/partials/emails/thread_viewer.html:59` (now `|sanitize_html|safe`), allowlist in `app/template_env.py:107–147` — `class` is allowed on every element (`template_env.py:140`); URL schemes need to be re-verified per `nh3` version. Vendor email is fully attacker-controlled.
   *Fix:* remove `class` from the wildcard allowlist; pin `nh3`; consider sandboxed `<iframe srcdoc>` for email bodies.
 
-- **HIGH-SEC-3 — Unescaped wildcards in ILIKE patterns.** ⚠️ STILL OPEN
-  `app/routers/htmx_views.py:3330, 6924` — `term = f"%{q.strip()}%"` for brand/commodity/manufacturer search. Not SQLi (parameterized) but `%`/`_` from the user forces full-table scans.
-  *Fix:* call `escape_like()` and pass `escape='!'` to `ilike()`, or use `SearchBuilder.safe`.
+- **HIGH-SEC-3 — Unescaped wildcards in ILIKE patterns.** ✅ RESOLVED
+  The originally-flagged `htmx_views.py` sites were split into `app/routers/htmx/`
+  modules and services. Every user-controlled ILIKE/LIKE search/filter site now runs
+  its term through `escape_like()` and passes `escape="\\"` so `%`/`_`/`\` match
+  literally (the shared `SearchBuilder.ilike_filter` carries the escape, fixing all its
+  callers). Not SQLi (always parameterized) — the harm was full-table scans / unintended
+  wildcard matches. Regression: `tests/test_ilike_wildcard_escaping.py`.
+  *Deliberately excluded:* `%@{domain}` email-domain analytics
+  (`engagement_scorer`/`response_analytics`/`vendor_scorecard`/`prospect_warm_intros`)
+  read a structured `.domain` column, not a free-text search box; constant LIKE patterns
+  (`"%@availai.local"`, sample-data tags); and the in-flight files under concurrent work.
 
 - **HIGH-SEC-4 — Graph webhook `validationToken` echo is unauthenticated.** ⚠️ STILL OPEN (not individually re-verified)
   `app/routers/v13_features/activity.py:49–51, 88–90` — Required by Graph protocol; mitigate at edge.

--- a/app/routers/ai.py
+++ b/app/routers/ai.py
@@ -99,16 +99,20 @@ def _build_vendor_history(vendor_name: str, db: Session) -> dict:
     total_rfqs = (
         db.query(func.count(Contact.id))
         .filter(
-            Contact.vendor_name.ilike(f"%{safe_vendor}%"),
+            Contact.vendor_name.ilike(f"%{safe_vendor}%", escape="\\"),
             Contact.contact_type == "email",
         )
         .scalar()
     ) or 0
 
-    total_offers = (db.query(func.count(Offer.id)).filter(Offer.vendor_name.ilike(f"%{safe_vendor}%")).scalar()) or 0
+    total_offers = (
+        db.query(func.count(Offer.id)).filter(Offer.vendor_name.ilike(f"%{safe_vendor}%", escape="\\")).scalar()
+    ) or 0
 
     last_contact_date = (
-        db.query(func.max(Contact.created_at)).filter(Contact.vendor_name.ilike(f"%{safe_vendor}%")).scalar()
+        db.query(func.max(Contact.created_at))
+        .filter(Contact.vendor_name.ilike(f"%{safe_vendor}%", escape="\\"))
+        .scalar()
     )
 
     return {

--- a/app/routers/crm/offers.py
+++ b/app/routers/crm/offers.py
@@ -36,6 +36,7 @@ from ...services.status_machine import require_valid_transition
 from ...services.vendor_unavailability import maybe_release_on_offer
 from ...utils.async_helpers import safe_background_task
 from ...utils.normalization import normalize_mpn_key
+from ...utils.sql_helpers import escape_like
 from ...vendor_utils import normalize_vendor_name
 from ._helpers import _preload_last_quoted_prices, record_changes
 
@@ -337,7 +338,12 @@ async def create_offer(
 
         prefix = norm_name.split()[0] if norm_name else ""
         if prefix and len(prefix) >= 2:
-            candidates = db.query(VendorCard).filter(VendorCard.normalized_name.ilike(f"{prefix}%")).limit(20).all()
+            candidates = (
+                db.query(VendorCard)
+                .filter(VendorCard.normalized_name.ilike(f"{escape_like(prefix)}%", escape="\\"))
+                .limit(20)
+                .all()
+            )
             if candidates:
                 matches = fuzzy_match_vendor(
                     payload.vendor_name,

--- a/app/routers/htmx/requisitions.py
+++ b/app/routers/htmx/requisitions.py
@@ -41,6 +41,7 @@ from ...models import (
 from ...services.freeform_parser_service import parse_freeform_rfq
 from ...template_env import template_response
 from ...utils.search_builder import SearchBuilder
+from ...utils.sql_helpers import escape_like
 from .._lookup_helpers import get_requisition_or_404
 from ._shared import _base_ctx, _parse_date_safe
 
@@ -585,7 +586,7 @@ async def customer_quick_create(
     from app.cache.decorators import invalidate_prefix
 
     # Check for duplicates
-    existing = db.query(Company).filter(Company.name.ilike(company_name.strip())).first()
+    existing = db.query(Company).filter(Company.name.ilike(escape_like(company_name.strip()), escape="\\")).first()
     if existing:
         site = existing.sites[0] if existing.sites else None
         site_id = site.id if site else ""

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -52,6 +52,7 @@ from ..services.sighting_ingest import sighting_from_row
 from ..services.vendor_unavailability import apply_to_fresh_sightings
 from ..template_env import page_response, template_response, templates
 from ..utils.search_builder import SearchBuilder
+from ..utils.sql_helpers import escape_like
 from ._lookup_helpers import get_requisition_or_404
 from .auth import _password_login_enabled
 from .htmx._shared import _base_ctx, _safe_int, _vite_assets
@@ -1210,7 +1211,7 @@ async def search_lead_detail(
     if vendor_name:
         lead_row = (
             db.query(SourcingLead)
-            .filter(SourcingLead.vendor_name.ilike(vendor_name))
+            .filter(SourcingLead.vendor_name.ilike(escape_like(vendor_name), escape="\\"))
             .order_by(SourcingLead.created_at.desc())
             .first()
         )

--- a/app/routers/requisitions/core.py
+++ b/app/routers/requisitions/core.py
@@ -338,19 +338,19 @@ def _build_requisition_list(q, status, sort, order, limit, offset, user, db):
         mpn_match = exists(
             select(Requirement.id).where(
                 Requirement.requisition_id == Requisition.id,
-                Requirement.primary_mpn.ilike(f"%{safe_q}%"),
+                Requirement.primary_mpn.ilike(f"%{safe_q}%", escape="\\"),
             )
         )
         subs_match = exists(
             select(Requirement.id).where(
                 Requirement.requisition_id == Requisition.id,
-                Requirement.substitutes_text.ilike(f"%{safe_q}%"),
+                Requirement.substitutes_text.ilike(f"%{safe_q}%", escape="\\"),
             )
         )
         query = query.filter(
             or_(
-                Requisition.name.ilike(f"%{safe_q}%"),
-                Requisition.customer_name.ilike(f"%{safe_q}%"),
+                Requisition.name.ilike(f"%{safe_q}%", escape="\\"),
+                Requisition.customer_name.ilike(f"%{safe_q}%", escape="\\"),
                 mpn_match,
                 subs_match,
             )

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -53,6 +53,7 @@ from ..services import (
     task_service,
 )
 from ..template_env import template_response
+from ..utils.sql_helpers import escape_like
 
 router = APIRouter(tags=["resell"])
 
@@ -313,7 +314,7 @@ async def resell_lists(
     if stage:
         query = query.filter(ExcessList.status == stage)
     if q:
-        query = query.filter(ExcessList.title.ilike(f"%{q}%"))
+        query = query.filter(ExcessList.title.ilike(f"%{escape_like(q)}%", escape="\\"))
 
     lists = query.order_by(ExcessList.updated_at.desc().nullslast(), ExcessList.id.desc()).all()
     cards = [_list_card(db, el, can_see_customer=can_see_customer) for el in lists]

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -314,19 +314,19 @@ async def sightings_list(
         query = query.filter(Requirement.sourcing_status == filters.status)
     if filters.sales_person:
         safe = escape_like(filters.sales_person)
-        query = query.join(User, Requisition.created_by == User.id).filter(User.name.ilike(f"%{safe}%"))
+        query = query.join(User, Requisition.created_by == User.id).filter(User.name.ilike(f"%{safe}%", escape="\\"))
     if filters.assigned == "mine":
         query = query.filter(Requirement.assigned_buyer_id == user.id)
     if filters.q:
         safe_q = escape_like(filters.q)
         query = query.filter(
-            Requirement.primary_mpn.ilike(f"%{safe_q}%")
-            | Requisition.customer_name.ilike(f"%{safe_q}%")
-            | Requirement.substitutes_text.ilike(f"%{safe_q}%")
+            Requirement.primary_mpn.ilike(f"%{safe_q}%", escape="\\")
+            | Requisition.customer_name.ilike(f"%{safe_q}%", escape="\\")
+            | Requirement.substitutes_text.ilike(f"%{safe_q}%", escape="\\")
         )
     if filters.manufacturer:
         safe_mfr = escape_like(filters.manufacturer)
-        query = query.filter(Requirement.manufacturer.ilike(f"%{safe_mfr}%"))
+        query = query.filter(Requirement.manufacturer.ilike(f"%{safe_mfr}%", escape="\\"))
 
     total = query.count()
 

--- a/app/routers/tags.py
+++ b/app/routers/tags.py
@@ -35,7 +35,7 @@ async def list_tags(
     if tag_type:
         query = query.filter(Tag.tag_type == tag_type)
     if q:
-        query = query.filter(Tag.name.ilike(f"%{escape_like(q)}%"))
+        query = query.filter(Tag.name.ilike(f"%{escape_like(q)}%", escape="\\"))
 
     total = query.count()
     tags = query.order_by(Tag.name).offset(offset).limit(limit).all()

--- a/app/routers/vendors_crud.py
+++ b/app/routers/vendors_crud.py
@@ -353,7 +353,7 @@ async def autocomplete_names(
     # Primary: match on normalized_name
     vendors_by_name = (
         db.query(VendorCard)
-        .filter(VendorCard.normalized_name.ilike(f"%{sb.safe}%"))
+        .filter(VendorCard.normalized_name.ilike(f"%{sb.safe}%", escape="\\"))
         .order_by(VendorCard.sighting_count.desc().nullslast(), VendorCard.display_name)
         .limit(limit)
         .all()
@@ -364,7 +364,7 @@ async def autocomplete_names(
     vendors_by_alt = (
         db.query(VendorCard)
         .filter(
-            cast(VendorCard.alternate_names, String).ilike(f"%{sb.safe}%"),
+            cast(VendorCard.alternate_names, String).ilike(f"%{sb.safe}%", escape="\\"),
             VendorCard.id.notin_(seen_ids) if seen_ids else True,
         )
         .order_by(VendorCard.sighting_count.desc().nullslast(), VendorCard.display_name)
@@ -374,7 +374,7 @@ async def autocomplete_names(
 
     companies = (
         db.query(Company.id, Company.name)
-        .filter(Company.is_active, Company.name.ilike(f"%{sb.safe}%"))
+        .filter(Company.is_active, Company.name.ilike(f"%{sb.safe}%", escape="\\"))
         .order_by(Company.name)
         .limit(limit)
         .all()

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -29,6 +29,7 @@ from ..constants import (
 from ..models import Company, User
 from ..models.excess import ExcessLineItem, ExcessList, ExcessOffer, ExcessOfferLine
 from ..utils.normalization import normalize_mpn_key
+from ..utils.sql_helpers import escape_like
 from .buyer_affinity_service import recompute_buyer_score_on_win
 
 # ---------------------------------------------------------------------------
@@ -244,7 +245,7 @@ def list_excess_lists(
     query = db.query(ExcessList)
 
     if q:
-        query = query.filter(ExcessList.title.ilike(f"%{q}%"))
+        query = query.filter(ExcessList.title.ilike(f"%{escape_like(q)}%", escape="\\"))
     if status:
         query = query.filter(ExcessList.status == status)
 

--- a/app/services/faceted_search_service.py
+++ b/app/services/faceted_search_service.py
@@ -432,8 +432,8 @@ def _apply_card_filters(
             query = query.filter(
                 or_(
                     MaterialCard.search_vector.op("@@")(ts_query),
-                    MaterialCard.display_mpn.ilike(f"%{sb.safe}%"),
-                    MaterialCard.normalized_mpn.ilike(f"%{sb.safe}%"),
+                    MaterialCard.display_mpn.ilike(f"%{sb.safe}%", escape="\\"),
+                    MaterialCard.normalized_mpn.ilike(f"%{sb.safe}%", escape="\\"),
                 )
             )
         else:

--- a/app/services/global_search_service.py
+++ b/app/services/global_search_service.py
@@ -600,13 +600,13 @@ def _run_intent_query(search_op: dict, db: Session, user: User | None = None) ->
         if filter_name == "email_domain":
             # Domain filter: ILIKE %@domain
             sb_filter = SearchBuilder(str(filter_value))
-            q = q.filter(col.ilike(f"%@{sb_filter.safe}%"))
+            q = q.filter(col.ilike(f"%@{sb_filter.safe}%", escape="\\"))
         elif filter_name == "is_blacklisted":
             q = q.filter(col == filter_value)
         else:
             # Exact-ish match via ILIKE for text filters
             sb_filter = SearchBuilder(str(filter_value))
-            q = q.filter(col.ilike(f"%{sb_filter.safe}%"))
+            q = q.filter(col.ilike(f"%{sb_filter.safe}%", escape="\\"))
 
     # Dedup parts by normalized_mpn, offers by (mpn, vendor_name), sightings by (mpn, vendor)
     if entity_type == "part":

--- a/app/services/requisition_list_service.py
+++ b/app/services/requisition_list_service.py
@@ -441,19 +441,19 @@ def list_requisitions(
         mpn_match = exists(
             select(Requirement.id).where(
                 Requirement.requisition_id == Requisition.id,
-                Requirement.primary_mpn.ilike(f"%{safe_q}%"),
+                Requirement.primary_mpn.ilike(f"%{safe_q}%", escape="\\"),
             )
         )
         subs_match = exists(
             select(Requirement.id).where(
                 Requirement.requisition_id == Requisition.id,
-                Requirement.substitutes_text.ilike(f"%{safe_q}%"),
+                Requirement.substitutes_text.ilike(f"%{safe_q}%", escape="\\"),
             )
         )
         query = query.filter(
             or_(
-                Requisition.name.ilike(f"%{safe_q}%"),
-                Requisition.customer_name.ilike(f"%{safe_q}%"),
+                Requisition.name.ilike(f"%{safe_q}%", escape="\\"),
+                Requisition.customer_name.ilike(f"%{safe_q}%", escape="\\"),
                 mpn_match,
                 subs_match,
             )

--- a/app/services/strategic_vendor_service.py
+++ b/app/services/strategic_vendor_service.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.models.strategic import StrategicVendor
 from app.models.vendors import VendorCard
+from app.utils.sql_helpers import escape_like
 
 MAX_STRATEGIC_VENDORS = 10
 TTL_DAYS = 39
@@ -281,7 +282,7 @@ def get_open_pool(
     q = db.query(VendorCard).filter(VendorCard.id.notin_(claimed_sub))
 
     if search:
-        q = q.filter(VendorCard.display_name.ilike(f"%{search}%"))
+        q = q.filter(VendorCard.display_name.ilike(f"%{escape_like(search)}%", escape="\\"))
 
     total = q.count()
     vendors = q.order_by(VendorCard.display_name).offset(offset).limit(limit).all()

--- a/app/services/vendor_affinity_service.py
+++ b/app/services/vendor_affinity_service.py
@@ -185,7 +185,7 @@ def find_affinity_vendors_l3(mpn: str, manufacturer: str | None, db: Session) ->
             func.count(func.distinct(Sighting.normalized_mpn)).label("mpn_count"),
         )
         .join(MaterialCard, Sighting.material_card_id == MaterialCard.id)
-        .filter(MaterialCard.category.ilike(f"%{escape_like(category)}%"))
+        .filter(MaterialCard.category.ilike(f"%{escape_like(category)}%", escape="\\"))
         .group_by(Sighting.vendor_name_normalized, Sighting.vendor_name)
         .order_by(func.count(func.distinct(Sighting.normalized_mpn)).desc())
         .limit(20)

--- a/app/services/vendor_email_lookup.py
+++ b/app/services/vendor_email_lookup.py
@@ -23,6 +23,7 @@ from ..models import (
     VendorCard,
     VendorContact,
 )
+from ..utils.sql_helpers import escape_like
 from ..vendor_utils import normalize_vendor_name
 
 
@@ -73,15 +74,16 @@ async def find_vendors_for_parts(
 
 def _query_db_for_part(mpn_upper: str, db: Session) -> list[dict]:
     """Query all internal sources for vendors of a specific MPN."""
-    like_pattern = f"%{mpn_upper}%"
+    safe_mpn = escape_like(mpn_upper)
+    like_pattern = f"%{safe_mpn}%"
     vendors: dict[str, dict] = {}  # normalized_name -> vendor info
 
     # 1. Sightings — vendors who listed this part on APIs
     sightings = (
         db.query(Sighting)
         .filter(
-            sqlfunc.upper(Sighting.normalized_mpn).like(like_pattern)
-            | sqlfunc.upper(sqlfunc.coalesce(Sighting.mpn_matched, "")).like(like_pattern)
+            sqlfunc.upper(Sighting.normalized_mpn).like(like_pattern, escape="\\")
+            | sqlfunc.upper(sqlfunc.coalesce(Sighting.mpn_matched, "")).like(like_pattern, escape="\\")
         )
         .order_by(Sighting.created_at.desc())
         .limit(200)
@@ -132,7 +134,7 @@ def _query_db_for_part(mpn_upper: str, db: Session) -> list[dict]:
         history_rows = (
             db.query(MaterialVendorHistory)
             .join(MaterialCard)
-            .filter(sqlfunc.upper(MaterialCard.mpn).like(like_pattern))
+            .filter(sqlfunc.upper(MaterialCard.mpn).like(like_pattern, escape="\\"))
             .order_by(MaterialVendorHistory.times_seen.desc())
             .limit(50)
             .all()
@@ -167,7 +169,7 @@ def _query_db_for_part(mpn_upper: str, db: Session) -> list[dict]:
             .filter(
                 sqlfunc.cast(
                     EmailIntelligence.parts_detected, db.bind.dialect.name == "postgresql" and "TEXT" or "VARCHAR"
-                ).ilike(f"%{mpn_upper}%")
+                ).ilike(f"%{safe_mpn}%", escape="\\")
             )
             .order_by(EmailIntelligence.received_at.desc())
             .limit(30)
@@ -180,7 +182,7 @@ def _query_db_for_part(mpn_upper: str, db: Session) -> list[dict]:
 
             ei_rows = (
                 db.query(EmailIntelligence)
-                .filter(cast(EmailIntelligence.parts_detected, String).ilike(f"%{mpn_upper}%"))
+                .filter(cast(EmailIntelligence.parts_detected, String).ilike(f"%{safe_mpn}%", escape="\\"))
                 .order_by(EmailIntelligence.received_at.desc())
                 .limit(30)
                 .all()

--- a/app/services/vendor_scorecard.py
+++ b/app/services/vendor_scorecard.py
@@ -357,7 +357,7 @@ def get_vendor_scorecard_list(
     )
 
     if search:
-        q = q.filter(VendorCard.display_name.ilike(f"%{escape_like(search)}%"))
+        q = q.filter(VendorCard.display_name.ilike(f"%{escape_like(search)}%", escape="\\"))
 
     # Count before pagination
     total = q.count()

--- a/app/utils/search_builder.py
+++ b/app/utils/search_builder.py
@@ -43,7 +43,9 @@ class SearchBuilder:
         if not self.q:
             return sa_true()
         pattern = f"{self.safe}%" if prefix else f"%{self.safe}%"
-        return or_(*[col.ilike(pattern) for col in columns])
+        # escape="\\" so escape_like()'s \%, \_, \\ are matched literally
+        # (PostgreSQL defaults LIKE's escape to \, but SQLite/tests do not).
+        return or_(*[col.ilike(pattern, escape="\\") for col in columns])
 
     def fts_or_fallback(self, query, model, fallback_columns, *, min_len=3):
         """Try PostgreSQL full-text search, fall back to ILIKE.

--- a/tests/test_ilike_wildcard_escaping.py
+++ b/tests/test_ilike_wildcard_escaping.py
@@ -1,0 +1,88 @@
+"""test_ilike_wildcard_escaping.py — HIGH-SEC-3 regression tests.
+
+A user-supplied search term that contains the SQL LIKE wildcards ``%`` / ``_``
+(or the escape char ``\\``) must match those characters *literally*, never as
+wildcards. That requires two things working together:
+  1. the term is run through ``escape_like()`` before interpolation, and
+  2. the ``.ilike(...)`` / ``.like(...)`` call passes ``escape="\\"`` so the
+     backslash escaping is actually honoured by the database.
+
+Both halves are exercised here at the DB level (in-memory SQLite, which — unlike
+PostgreSQL — has *no* default LIKE escape char, so the missing ``escape=`` is a
+real, observable bug). A control test pins the unescaped wildcard behaviour so
+the value of the helper is documented.
+
+Called by: pytest
+Depends on: app/utils/sql_helpers.py, app/utils/search_builder.py, app/models/tags.py
+"""
+
+from pathlib import Path
+
+from app.models.tags import Tag
+from app.utils.search_builder import SearchBuilder
+
+
+def _add_tags(db, names, tag_type="brand"):
+    for n in names:
+        db.add(Tag(name=n, tag_type=tag_type))
+    db.commit()
+
+
+def _search(db, term):
+    """Run *term* through the shared SearchBuilder ILIKE path."""
+    sb = SearchBuilder(term)
+    return {t.name for t in db.query(Tag).filter(sb.ilike_filter(Tag.name)).all()}
+
+
+# ── literal matching ────────────────────────────────────────────────────────
+
+
+def test_percent_matches_literally_not_as_wildcard(db_session):
+    # As a wildcard "100%" matches BOTH rows; escaped it matches only "100%".
+    _add_tags(db_session, ["100% Cotton", "1000 Cotton"])
+    assert _search(db_session, "100%") == {"100% Cotton"}
+
+
+def test_underscore_matches_literally_not_as_wildcard(db_session):
+    # "_" is a single-char wildcard; escaped it must match only the literal "_".
+    _add_tags(db_session, ["A_B Widget", "AXB Widget"])
+    assert _search(db_session, "A_B") == {"A_B Widget"}
+
+
+def test_backslash_matches_literally(db_session):
+    _add_tags(db_session, [r"path\to", "pathXto"])
+    assert _search(db_session, r"path\to") == {r"path\to"}
+
+
+# ── normal-term behaviour is unchanged ──────────────────────────────────────
+
+
+def test_normal_term_still_matches(db_session):
+    _add_tags(db_session, ["100% Cotton", "1000 Cotton"])
+    assert _search(db_session, "Cotton") == {"100% Cotton", "1000 Cotton"}
+
+
+def test_normal_term_no_false_positive(db_session):
+    _add_tags(db_session, ["Resistor", "Capacitor"])
+    assert _search(db_session, "Resist") == {"Resistor"}
+
+
+# ── control: documents the unescaped (buggy) wildcard semantics ─────────────
+
+
+def test_raw_unescaped_underscore_acts_as_wildcard(db_session):
+    """Without escaping, ``_`` matches any single char — the bug we fix."""
+    _add_tags(db_session, ["A_B Widget", "AXB Widget"])
+    raw = {t.name for t in db_session.query(Tag).filter(Tag.name.ilike("%A_B%")).all()}
+    assert raw == {"A_B Widget", "AXB Widget"}
+
+
+# ── regression guard for the shared helper ──────────────────────────────────
+
+
+def test_search_builder_passes_escape_char():
+    src = Path("app/utils/search_builder.py").read_text()
+    assert 'escape="\\\\"' in src, (
+        'SearchBuilder.ilike_filter must call .ilike(..., escape="\\\\") so '
+        "escape_like()'s backslash escaping is honoured by the database."
+    )


### PR DESCRIPTION
## HIGH-SEC-3 — Unescaped wildcards in ILIKE patterns

User-supplied search/filter terms were interpolated into `f"%{q}%"` ILIKE/LIKE patterns **without escaping** the SQL wildcards `%` and `_` (and `\`). A user searching a literal `%` or `_` got wildcard matching / full-table scans instead of a literal match. Not SQLi (always parameterized) — the harm is unintended matches and full-table scans.

The originally-flagged `htmx_views.py:3330/6924` sites were since split into `app/routers/htmx/` modules + services. The `escape_like()` helper (`app/utils/sql_helpers.py`) and `SearchBuilder` (`app/utils/search_builder.py`) already existed and were used in many places — **this PR completes the rollout and fixes a latent gap in the shared helper.**

### Key fix — shared `SearchBuilder`
`SearchBuilder.ilike_filter` escaped the term via `escape_like()` but called `.ilike(pattern)` **without** `escape="\\"`. PostgreSQL defaults LIKE's escape char to `\`, so it worked in prod — but SQLite (tests) has **no** default escape, making the helper a silent no-op there. Now passes `escape="\\"`, fixing every caller and making behavior consistent across PG/SQLite.

### Sites fixed
**Raw user-input (added `escape_like()` + `escape="\\"`):**
- `app/routers/resell.py` — excess-list title search
- `app/services/excess_service.py` — excess-list title search
- `app/services/strategic_vendor_service.py` — unclaimed-vendor display_name search
- `app/routers/htmx/requisitions.py` — company-name duplicate check
- `app/routers/crm/offers.py` — vendor normalized_name prefix match (from offer payload)
- `app/services/vendor_email_lookup.py` — MPN part search (Sightings / MaterialCard / EmailIntelligence)
- `app/routers/htmx_views.py` — SourcingLead vendor_name safety lookup

**Already `escape_like()`'d, added missing `escape="\\"`:**
- `app/utils/search_builder.py` (shared `ilike_filter`)
- `app/routers/sightings.py`, `app/routers/vendors_crud.py`, `app/routers/ai.py`, `app/routers/requisitions/core.py`, `app/routers/tags.py`
- `app/services/global_search_service.py`, `app/services/requisition_list_service.py`, `app/services/faceted_search_service.py`, `app/services/vendor_affinity_service.py`, `app/services/vendor_scorecard.py`

### Behavior
Normal (no-wildcard) searches are unchanged. Only a literal `%`/`_`/`\` in the query now matches literally instead of acting as a wildcard.

### Tests
New `tests/test_ilike_wildcard_escaping.py` — DB-level (SQLite) proof that `%`, `_`, `\` match literally via `SearchBuilder`, that normal terms still match, a control documenting raw wildcard semantics, and a guard that the shared helper keeps `escape="\\"`.
- `TESTING=1 pytest -k "search or ilike or escape or filter"` → **1494 passed, 1 skipped**
- `tests/test_ilike_wildcard_escaping.py` + `test_sql_helpers` + `test_search_builder` + `test_static_analysis` → 55 passed
- `pre-commit run` on changed files → all hooks pass (ruff, ruff-format, mypy)

### Deliberately excluded (reviewed, out of scope)
- **`%@{domain}` email-domain analytics** — `engagement_scorer.py`, `response_analytics.py`, `vendor_scorecard.py:107`, `prospect_warm_intros.py`. These read a structured `.domain` column (system-populated from parsed emails), not a free-text search box, and the `%@` prefix is an intentional suffix-match wildcard. No user-search attack surface.
- **Constant LIKE patterns** — `"%@availai.local"`, `"%,%"`, `seed_sample_data` SAMPLE_TAG patterns, `crm_service` `Q-{year}-` prefix.

### Skipped per task — in-flight files (concurrent work)
`app/routers/htmx/buy_plans.py`, `app/routers/htmx/prospecting.py`, `app/services/buyplan_workflow.py`, `app/constants.py`, `app/services/enrichment_worker/*` — grepped, **none contain ILIKE/LIKE sites**, so no follow-up needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)