### PR TITLE
test(buy-plans): lock deals role-scope contract (predicate + resolver + buyer narrow-to-mine) — Wave 5

### DIFF
--- a/tests/test_buyplan_hub_routes.py
+++ b/tests/test_buyplan_hub_routes.py
@@ -21,12 +21,14 @@ from __future__ import annotations
 import uuid
 from contextlib import contextmanager
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.constants import BuyPlanLineStatus, BuyPlanStatus, SOVerificationStatus
 from app.models.buy_plan import BuyPlan, BuyPlanLine
 from app.models.quotes import Quote
+from app.routers.htmx.buy_plans import _can_see_all_deals, _resolve_deal_scope
 
 
 @contextmanager
@@ -774,3 +776,70 @@ def test_approve_default_origin_returns_detail(
         app.dependency_overrides.pop(require_buyplan_approver, None)
     assert resp.status_code == 200
     assert "Line Items" in resp.text
+
+
+# ── Role-scope predicate + resolver (lock the deal-scope contract directly) ──
+#
+# The board/archive/tab routes are exercised above. These unit-level tests pin the
+# two helpers those routes lean on — `_can_see_all_deals` (who may see every owner's
+# deals) and `_resolve_deal_scope` (how a requested scope is normalized) — so the
+# role contract is locked independently of any template/route plumbing.
+
+
+@pytest.mark.parametrize("fixture_name", ["test_user", "manager_user", "admin_user"])
+def test_can_see_all_deals_true_for_po_cutters(request, db_session: Session, fixture_name):
+    """PO-cutters (buyer/manager/admin) may view every owner's deals."""
+    user = request.getfixturevalue(fixture_name)
+    assert _can_see_all_deals(user, db_session) is True
+
+
+@pytest.mark.parametrize("fixture_name", ["sales_user", "trader_user"])
+def test_can_see_all_deals_false_for_restricted_roles(request, db_session: Session, fixture_name):
+    """Sales/traders are scoped to their own deals — no cross-owner visibility."""
+    user = request.getfixturevalue(fixture_name)
+    assert _can_see_all_deals(user, db_session) is False
+
+
+def test_can_see_all_deals_ops_membership_elevates_restricted_role(db_session: Session, sales_user):
+    """The ops arm: a sales user gains all-deals visibility once in the ops group."""
+    assert _can_see_all_deals(sales_user, db_session) is False
+    _add_ops(db_session, sales_user)
+    db_session.flush()
+    assert _can_see_all_deals(sales_user, db_session) is True
+
+
+@pytest.mark.parametrize(
+    "scope,can_see_all,expected",
+    [
+        # can_see_all=True (PO-cutter / ops): default → all, explicit honored both ways.
+        ("", True, "all"),  # role default
+        ("garbage", True, "all"),  # unknown → role default
+        ("all", True, "all"),
+        ("mine", True, "mine"),  # narrow-to-mine via the toggle
+        # can_see_all=False (sales/trader): default → mine, all coerced to mine (no leak).
+        ("", False, "mine"),  # role default
+        ("garbage", False, "mine"),  # unknown → role default
+        ("all", False, "mine"),  # forced to mine — no cross-owner leak
+        ("mine", False, "mine"),
+    ],
+)
+def test_resolve_deal_scope_contract(scope, can_see_all, expected):
+    """Normalize a requested scope against the viewer's visibility, per role."""
+    assert _resolve_deal_scope(scope, can_see_all) == expected
+
+
+def test_board_buyer_narrows_to_mine_excludes_other_owner(
+    client: TestClient, db_session: Session, test_user, manager_user, test_requisition
+):
+    """A buyer (can_see_all) narrowing via the Mine toggle (?scope=mine) sees only their
+    own deals — another owner's plan is excluded.
+
+    The default client acts as the buyer, so this proves the toggle actually narrows for
+    a privileged user (not just defaults).
+    """
+    mine = _make_owned_plan(db_session, test_user, test_requisition)
+    other = _make_owned_plan(db_session, manager_user, test_requisition)
+    resp = client.get("/v2/partials/buy-plans/board?scope=mine")
+    assert resp.status_code == 200
+    assert f"/v2/partials/buy-plans/{mine.id}" in resp.text
+    assert f"/v2/partials/buy-plans/{other.id}" not in resp.text


### PR DESCRIPTION
## Summary

The Deals **See mine** / **See all** role-scope filter on the Approvals / Buy-Plans **Deals/Orders lens** is **already fully implemented** — by **#534** (role-scoped the My Deals board: buyers see all, sales see own) plus the SP-1 Approvals-tab integration. The inventory's "hardcoded `scope=mine`" note is stale. Verified present:

- **Predicate** `_can_see_all_deals(user, db)` (`app/routers/htmx/buy_plans.py`) — PO-cutters (buyer/manager/admin, via `_can_resource`) **or** an ops verification-group member → see every owner's deals; sales/traders (`RESTRICTED_ROLES`) are scoped to their own.
- **Resolver** `_resolve_deal_scope(scope, can_see_all)` — empty/unknown → role default (`all` for privileged, else `mine`); `all` requested by a non-privileged user is coerced to `mine` (no cross-owner leak).
- **Toggle UI** — the **All deals / Mine** pill toggle in `templates/htmx/partials/buy_plans/_board.html`, rendered only for `can_see_all_deals` users; sales/traders get no toggle.
- **Plumbing** — `?scope=` threads via HTMX through the standalone board, archive, and the Buy Plans / Sales Orders stage tabs (`scope_toggle_url`), with `deals_board` / `completed_archive` applying the owner filter.

Because the feature is complete, **no production code was added** (that would be redundant). This PR adds the **missing test coverage** that locks the role-scope behavior, which existing tests only exercised indirectly.

## What #534 / SP-1 already covered vs. what this PR adds

**Already covered** (unchanged): predicate, resolver, toggle UI, scope plumbing, service-layer scope filtering, and route tests for buyer/manager default-all, sales/trader default-mine, `scope=all` forced-to-mine for restricted roles, toggle shown-for-buyer / hidden-for-sales, ops-member elevation, and the tab-level toggle URLs.

**Added here** (`tests/test_buyplan_hub_routes.py`, +69 lines):
- `_can_see_all_deals` **direct unit tests per role** — buyer/manager/admin → `True`; sales/trader → `False`; a sales user elevated via ops verification-group membership → `True`.
- `_resolve_deal_scope` **normalization table** — privileged: default/unknown → `all`, `mine` honored; restricted: default/unknown/`all` → `mine` (leak-proof).
- **Route-level buyer narrow-to-mine** — a buyer (privileged) requesting `?scope=mine` sees only their own deals and **excludes** another owner's plan. This is the narrow direction the existing buyer route tests left unasserted (they only covered default-all / `scope=all`).

## Testing

- `TESTING=1 PYTHONPATH=$(pwd) pytest tests/ -k "deal or scope or buyplan or buy_plan or my_deals or lens" -q` → **987 passed** (includes the 15 new tests).
- `pre-commit run --all-files` → all hooks **Passed** (docformatter reflowed one docstring; re-ran clean).

`docs/APP_MAP_INTERACTIONS.md` already documents this behavior (deal-board visibility section, ~L1414-1463); no doc change needed since no behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)