### PR TITLE
feat(email-mining): daily budget cap on the inbox-parse batch path (Wave 6)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -205,6 +205,16 @@ class Settings(BaseSettings):
     # match per batch. The long tail is created unenriched and enriched on demand later.
     # This is the only metered-spend lever for the email-mining path.
     email_mining_enrich_cap: int = 25
+    # Daily ceiling on the number of Claude requests the email-mining inbox-parse BATCH
+    # path (email_service._submit_parse_batch / its sequential fallback) may dispatch per
+    # UTC day. Every pending vendor reply = one fast-tier Claude call billed to
+    # cost_bucket="email_mining"; without a cap a large first-time inbox backfill could
+    # submit thousands of requests unbounded. When the day's metered+submitted call count
+    # reaches this cap the batch stops enqueuing and logs (raw rows stay re-parsable next
+    # day). Reuses the claude_usage:email_mining metering counters as today's spend and
+    # mirrors the enrichment-worker daily_cap / ai_screen_daily_cap count-cap pattern.
+    # 0 (or negative) disables the cap -> pre-cap unbounded behavior (graceful default).
+    email_mining_batch_daily_cap: int = 1000
 
     # --- M365 Integration v2 ---
     inbox_scan_interval_min: int = 30

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -880,12 +880,20 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
             continue
 
     # ── Submit AI batch or fall back to sequential parsing ──
+    # Gate on the daily email-mining budget cap BEFORE either path spends Claude credits.
+    # Trimming here (rather than inside _submit_parse_batch) keeps the batch and its
+    # sequential fallback under the same ceiling — the fallback can't bypass the cap.
     if pending_parse:
-        try:
-            await _submit_parse_batch(pending_parse, db)
-        except Exception as e:
-            logger.warning(f"Batch submit failed, falling back to sequential: {e}")
-            await _parse_sequential_fallback(pending_parse, db)
+        to_parse = _enforce_email_mining_cap(pending_parse)
+        if to_parse:
+            try:
+                await _submit_parse_batch(to_parse, db)
+            except Exception as e:
+                logger.warning(f"Batch submit failed, falling back to sequential: {e}")
+                await _parse_sequential_fallback(to_parse, db)
+            # Bill the day's counter for the calls just dispatched (batch or fallback),
+            # so successive scans within the same UTC day respect the cap.
+            _record_email_mining_calls(len(to_parse))
 
     # ── Post-parse: update contact status for OOO/bounce classifications ──
     # Only the sequential fallback sets vr.classification synchronously; batch
@@ -1144,6 +1152,91 @@ async def parse_response_ai(body: str, subject: str) -> dict | None:
 
 
 # ── Batch AI Processing ─────────────────────────────────────────────────
+
+
+def _mining_submit_key() -> str:
+    """Redis key for today's count of dispatched email-mining Claude requests (UTC
+    date)."""
+    return "email_mining:batch:submitted:" + datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _email_mining_calls_today() -> int:
+    """Today's email-mining Claude request count for the daily budget gate.
+
+    Returns ``max(metered, submitted)`` so the cap holds even before a batch's own usage
+    is metered:
+      * ``metered`` sums the ``claude_usage:email_mining:{tier}:calls:{date}`` counters
+        that ``claude_client._meter_usage`` writes on batch-results poll (lags submit);
+      * ``submitted`` is the ``email_mining:batch:submitted:{date}`` counter this path
+        bumps at dispatch time (covers the metering lag).
+    Mirrors the enrichment worker's ``max(intel_cache.get_count(...), in_process_floor)``
+    reconciliation. Best-effort: any cache error degrades to 0 (no cap) — never raises.
+    """
+    from app.cache import intel_cache
+
+    try:
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        metered = sum(
+            intel_cache.get_count(f"claude_usage:email_mining:{tier}:calls:{today}")
+            for tier in ("fast", "smart", "opus")
+        )
+        submitted = intel_cache.get_count(_mining_submit_key())
+        return max(metered, submitted)
+    except Exception as e:  # cap accounting must never break the inbox poll
+        logger.debug("email-mining spend read skipped: {}", e)
+        return 0
+
+
+def _enforce_email_mining_cap(pending: list[VendorResponse]) -> list[VendorResponse]:
+    """Trim today's email-mining batch to the remaining daily Claude-call budget.
+
+    Returns the slice of *pending* that may be AI-parsed today (the highest-volume order
+    is preserved). A non-positive ``email_mining_batch_daily_cap`` disables the cap →
+    pre-cap unbounded behavior. Logs (Loguru) when the cap trims or fully blocks the
+    batch; trimmed-off responses stay raw (status 'new'/'matched') and remain re-parsable
+    later (manual ai.py reparse), so no data is lost — only Claude spend is bounded.
+    """
+    from app.config import settings
+
+    cap = settings.email_mining_batch_daily_cap
+    if cap <= 0:
+        return pending
+
+    already = _email_mining_calls_today()
+    remaining = cap - already
+    if remaining <= 0:
+        logger.warning(
+            "Email-mining daily budget cap reached ({}/{}) — skipping AI parse of {} "
+            "vendor response(s) this cycle (raw rows kept; re-parsable after UTC rollover)",
+            already,
+            cap,
+            len(pending),
+        )
+        return []
+    if len(pending) > remaining:
+        logger.warning(
+            "Email-mining daily budget cap: trimming batch {}->{} request(s) (today {}/{}); "
+            "{} response(s) stay raw this cycle",
+            len(pending),
+            remaining,
+            already,
+            cap,
+            len(pending) - remaining,
+        )
+        return pending[:remaining]
+    return pending
+
+
+def _record_email_mining_calls(count: int) -> None:
+    """Bump today's email-mining submitted-call counter by *count* (best-effort)."""
+    if count <= 0:
+        return
+    from app.cache import intel_cache
+
+    try:
+        intel_cache.incr_count(_mining_submit_key(), amount=count, ttl_days=1.0)
+    except Exception as e:  # metering is best-effort; never break the inbox poll
+        logger.debug("email-mining submit-count bump skipped: {}", e)
 
 
 async def _submit_parse_batch(

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1135,6 +1135,25 @@ ai_offer_service.py (if confidence >= 0.8)
     +---> sse_broker.py --> SSE push ("new offer parsed")
 ```
 
+**Email-mining daily budget cap (Wave 6).** The inbox-parse path turns every pending
+vendor reply into one fast-tier Claude request — `_submit_parse_batch` submits them to the
+Anthropic Batch API with `cost_bucket="email_mining"` (or, if submit raises,
+`_parse_sequential_fallback` calls `parse_response_ai` per reply). Spend was *metered*
+(`claude_usage:email_mining:{tier}:{metric}:{date}` via `_meter_usage` on results poll —
+readout `python -m app.management.enrichment_spend --bucket email_mining`) but nothing
+*gated* it, so a large first-time inbox backfill could dispatch thousands of requests
+unbounded. `poll_inbox` now trims the day's batch via `_enforce_email_mining_cap(pending)`
+**before** either path spends credits (so the sequential fallback can't bypass the cap):
+`settings.email_mining_batch_daily_cap` (env `EMAIL_MINING_BATCH_DAILY_CAP`, default 1000
+calls/UTC-day; `<= 0` disables → pre-cap behavior) minus today's spend
+`_email_mining_calls_today()` = `max(`metered `claude_usage:email_mining:*:calls:{date}`,
+the submit-time `email_mining:batch:submitted:{date}` counter `_record_email_mining_calls`
+bumps after each dispatch`)`. At/over cap → the batch stops enqueuing and logs (Loguru);
+trimmed-off replies stay raw (`status='new'/'matched'`, re-parsable via the ai.py reparse
+endpoint after the UTC rollover — no data lost, only Claude spend bounded). Mirrors the
+enrichment-worker `daily_cap` / `ai_screen_daily_cap` count-cap pattern; reuses the
+`intel_cache` Redis/PG counter substrate (no migration).
+
 ### 4a. Graph webhook endpoint (push) + validation-echo hardening
 
 Real-time complement to the polling job above. `webhook_service.create_mail_subscription`

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -32,10 +32,13 @@ from app.email_service import (
     _apply_parsed_result,
     _build_html_body,
     _classify_response,
+    _email_mining_calls_today,
+    _enforce_email_mining_cap,
     _find_sent_message,
     _is_noise_email,
     _parse_sequential_fallback,
     _progress_contact_status,
+    _record_email_mining_calls,
     _scope_thread_contacts_to_sender,
     _submit_parse_batch,
     log_phone_contact,
@@ -1772,6 +1775,177 @@ class TestSubmitParseBatch:
             pytest.raises(RuntimeError, match="no batch_id"),
         ):
             await _submit_parse_batch([vr], db_session)
+
+
+# ── Email-mining daily budget cap (Wave 6) ───────────────────────────
+
+
+class TestEmailMiningBudgetCap:
+    """The daily Claude-spend cap on the email-mining inbox-parse batch path."""
+
+    def test_cap_disabled_returns_all(self, monkeypatch):
+        """Cap <= 0 disables the cap (graceful default = pre-cap unbounded behavior)."""
+        from app.config import settings
+
+        pending = [MagicMock() for _ in range(5)]
+        for disabled in (0, -1):
+            monkeypatch.setattr(settings, "email_mining_batch_daily_cap", disabled)
+            # _email_mining_calls_today must NOT even be consulted when the cap is off.
+            with patch("app.email_service._email_mining_calls_today", side_effect=AssertionError):
+                assert _enforce_email_mining_cap(pending) == pending
+
+    def test_under_cap_returns_all(self, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "email_mining_batch_daily_cap", 10)
+        pending = [MagicMock() for _ in range(3)]
+        with patch("app.email_service._email_mining_calls_today", return_value=0):
+            assert _enforce_email_mining_cap(pending) == pending
+
+    def test_at_cap_returns_empty_and_logs(self, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "email_mining_batch_daily_cap", 5)
+        pending = [MagicMock() for _ in range(4)]
+        with (
+            patch("app.email_service._email_mining_calls_today", return_value=5),
+            patch("app.email_service.logger.warning") as mock_warn,
+        ):
+            assert _enforce_email_mining_cap(pending) == []
+        mock_warn.assert_called_once()
+        assert "cap reached" in mock_warn.call_args[0][0]
+
+    def test_over_cap_returns_empty(self, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "email_mining_batch_daily_cap", 5)
+        pending = [MagicMock() for _ in range(4)]
+        with patch("app.email_service._email_mining_calls_today", return_value=99):
+            assert _enforce_email_mining_cap(pending) == []
+
+    def test_trims_to_remaining_budget(self, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "email_mining_batch_daily_cap", 10)
+        pending = [MagicMock() for _ in range(5)]
+        with (
+            patch("app.email_service._email_mining_calls_today", return_value=8),
+            patch("app.email_service.logger.warning") as mock_warn,
+        ):
+            result = _enforce_email_mining_cap(pending)
+        # remaining = 10 - 8 = 2; highest-volume order preserved
+        assert result == pending[:2]
+        mock_warn.assert_called_once()
+
+    def test_calls_today_is_max_of_metered_and_submitted(self):
+        """Today's count reconciles the metered claude_usage calls with the submit
+        counter."""
+
+        def fake_count(key):
+            return {
+                "claude_usage:email_mining:fast:calls:": 3,  # metered (fast tier)
+                "email_mining:batch:submitted:": 7,  # submit-time counter
+            }.get(
+                next(
+                    (
+                        p
+                        for p in (
+                            "claude_usage:email_mining:fast:calls:",
+                            "email_mining:batch:submitted:",
+                        )
+                        if key.startswith(p)
+                    ),
+                    "",
+                ),
+                0,
+            )
+
+        with patch("app.cache.intel_cache.get_count", side_effect=fake_count):
+            # metered total = 3 (fast) + 0 (smart) + 0 (opus) = 3; submitted = 7 -> max 7
+            assert _email_mining_calls_today() == 7
+
+    def test_calls_today_swallows_cache_errors(self):
+        with patch("app.cache.intel_cache.get_count", side_effect=RuntimeError("redis down")):
+            assert _email_mining_calls_today() == 0
+
+    def test_record_calls_increments_counter(self):
+        with patch("app.cache.intel_cache.incr_count") as mock_incr:
+            _record_email_mining_calls(4)
+        mock_incr.assert_called_once()
+        assert mock_incr.call_args.kwargs.get("amount") == 4
+
+    def test_record_calls_noop_on_zero(self):
+        with patch("app.cache.intel_cache.incr_count") as mock_incr:
+            _record_email_mining_calls(0)
+        mock_incr.assert_not_called()
+
+
+class TestPollInboxBudgetCap:
+    """poll_inbox enforces the cap before BOTH the batch and its sequential fallback."""
+
+    def _make_inbox_message(self):
+        return {
+            "id": "cap-msg-1",
+            "subject": "RE: RFQ",
+            "from": {"emailAddress": {"address": "vendor@parts.com", "name": "Vendor"}},
+            "bodyPreview": "Quote attached",
+            "body": {"content": "<p>Quote attached</p>"},
+            "conversationId": "cap-conv-1",
+            "receivedDateTime": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_under_cap_submits_batch(self, db_session, test_user, test_requisition, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "email_mining_batch_daily_cap", 1000)
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {"value": [self._make_inbox_message()]}
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value="fake-key"),
+            patch("app.email_service._email_mining_calls_today", return_value=0),
+            patch("app.cache.intel_cache.incr_count") as mock_incr,
+            patch(
+                "app.utils.claude_client.claude_batch_submit",
+                new_callable=AsyncMock,
+                return_value="batch-cap-1",
+            ) as mock_submit,
+            patch("app.services.response_parser.clean_email_body", return_value="cleaned"),
+            patch("app.services.response_parser.RESPONSE_PARSE_SCHEMA", {"type": "object"}),
+            patch("app.services.response_parser.SYSTEM_PROMPT", "System prompt"),
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session, requisition_id=test_requisition.id)
+
+        assert len(results) == 1
+        mock_submit.assert_called_once()  # under cap -> batch dispatched
+        mock_incr.assert_called_once()  # today's submit counter billed
+
+    @pytest.mark.asyncio
+    async def test_over_cap_skips_batch_and_fallback(self, db_session, test_user, test_requisition, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "email_mining_batch_daily_cap", 5)
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {"value": [self._make_inbox_message()]}
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value="fake-key"),
+            patch("app.email_service._email_mining_calls_today", return_value=5),
+            patch(
+                "app.utils.claude_client.claude_batch_submit",
+                new_callable=AsyncMock,
+            ) as mock_submit,
+            patch("app.email_service._parse_sequential_fallback", new_callable=AsyncMock) as mock_seq,
+        ):
+            results = await poll_inbox(token="fake-token", db=db_session, requisition_id=test_requisition.id)
+
+        # Raw response row is still saved (data not lost), but NO Claude spend occurs.
+        assert len(results) == 1
+        mock_submit.assert_not_called()
+        mock_seq.assert_not_called()
 
 
 # ── _parse_sequential_fallback ───────────────────────────────────────


### PR DESCRIPTION
## Problem

Email-mining inbox parsing turns **every pending vendor reply into one fast-tier Claude request** — `email_service._submit_parse_batch` submits them to the Anthropic Batch API with `cost_bucket="email_mining"` (or `_parse_sequential_fallback` calls `parse_response_ai` per reply if submit raises). Spend was **metered** (`claude_usage:email_mining:{tier}:{metric}:{date}` via `_meter_usage`; readout `python -m app.management.enrichment_spend --bucket email_mining`) but **nothing gated it** — a large first-time inbox backfill could dispatch thousands of requests unbounded.

## Change

`poll_inbox` now trims the day's batch via `_enforce_email_mining_cap(pending)` **before** either path spends credits (so the sequential fallback can't bypass the cap):

- **Config:** `settings.email_mining_batch_daily_cap` — env **`EMAIL_MINING_BATCH_DAILY_CAP`**, default **1000** Claude calls/UTC-day. `<= 0` disables the cap → graceful pre-cap behavior.
- **Today's spend:** `_email_mining_calls_today()` = `max(` metered `claude_usage:email_mining:*:calls:{date}` counters, the submit-time `email_mining:batch:submitted:{date}` counter `_record_email_mining_calls` bumps after each dispatch `)`. The `max` covers the metering lag (usage is only recorded on batch-results poll) — mirrors the enrichment worker's `max(get_count(...), in_process_floor)` reconciliation.
- **At/over cap:** the batch stops enqueuing and logs (Loguru). Trimmed-off replies stay **raw** (`status='new'/'matched'`, re-parsable via the ai.py reparse endpoint after the UTC rollover) — **no data lost, only Claude spend bounded.**

Mirrors the enrichment-worker `daily_cap` / `ai_screen_daily_cap` count-cap pattern. Cap reads + counter bumps are best-effort (degrade to `0`/no-op, never raise).

## No migration

Reuses the existing `claude_usage:email_mining` metering plus the `intel_cache` Redis/PG counter substrate. **No schema change** — `alembic heads` unchanged at `169_crm_field_history`.

## Tests (TDD)

- `TestEmailMiningBudgetCap` — helper units: cap disabled (0/-1), under-cap passes all, **at**-cap and **over**-cap return empty + log, trim-to-remaining (order preserved), `max(metered, submitted)` reconciliation, cache-error swallow, submit-counter bump (and zero no-op).
- `TestPollInboxBudgetCap` — under-cap **submits** + bills the counter; over-cap **skips both** the batch and the sequential fallback while the raw response row is still saved.

`TESTING=1 ... pytest tests/ -k "mining or proactive or budget or cap or spend or metering"` → **805 passed**; full `tests/test_email_service.py` → **173 passed**; `pre-commit run --all-files`-equivalent on changed files green.

Docs: `docs/APP_MAP_INTERACTIONS.md` §4 updated with the cap flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)