### PR TITLE
feat(enrichment): activate Lenovo OEM resolver in worker Pass A (Wave 6)

### DIFF
--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -225,9 +225,12 @@ async def _oem_resolution_pass(
 ) -> int:
     """Pass A — paced OEM spare→canonical resolution over this batch (network).
 
-    Candidates are batch cards classified ``hpe`` (Phase A) with no fresh
-    ``oem_crosswalk`` row (resolved rows are permanent; no_match rows block for 90
-    days). At most ``config.oem_resolve_per_batch`` resolves per batch, each gated on
+    Candidates are batch cards classified ``hpe`` or ``lenovo`` — the vendors with a
+    grounded crosswalk source (``SOURCE_BY_VENDOR``) — with no fresh ``oem_crosswalk``
+    row (resolved rows are permanent; no_match rows block for 90 days). Both vendors run
+    the same Claude-grounded resolver, negative cache and crosswalk writer; only the
+    per-spare vendor label differs (it steers PartSurfer vs PSREF and tags the row).
+    At most ``config.oem_resolve_per_batch`` resolves per batch, each gated on
     BOTH daily caps — the web cap (every resolve is a billable web call, counted
     INSIDE ``web_daily_cap``) and the OEM sub-cap (``oem_resolve_daily_cap``, tallied
     at ``enrichment_worker:oem_resolves:{date}`` with the same max-of-cache-and-
@@ -252,21 +255,40 @@ async def _oem_resolution_pass(
     """
     from app.services.enrichment_worker.oem_classifier import classify_oem_vendor
     from app.services.enrichment_worker.oem_crosswalk_resolver import resolve_oem_spare
-    from app.services.oem_crosswalk_enrich import apply_resolution, pending_resolution
+    from app.services.oem_crosswalk_enrich import (
+        SOURCE_BY_VENDOR,
+        apply_resolution,
+        pending_resolution,
+    )
     from app.utils.normalization import normalize_mpn_key
 
-    # Phase A: HP/HPE only. Dedupe by spare norm (one resolve covers every card
-    # sharing it, forever).
+    # HP/HPE + Lenovo — the vendors with a grounded crosswalk source (SOURCE_BY_VENDOR:
+    # hpe->partsurfer, lenovo->psref). Both resolve through the same Claude web_search
+    # grounding (no direct OEM HTTP), the same negative cache and the same crosswalk
+    # writer — only the vendor label differs (it steers the resolver's lookup hint and
+    # tags the row). Dedupe by spare norm (one resolve covers every card sharing it,
+    # forever) and remember each norm's classified vendor — the negative-cache selector,
+    # the grounded resolver and apply_resolution are all vendor-scoped.
     candidates: dict[str, str] = {}
+    candidate_vendors: dict[str, str] = {}
     for card in batch:
-        if classify_oem_vendor(card.display_mpn) == "hpe":
+        vendor = classify_oem_vendor(card.display_mpn)
+        if vendor in SOURCE_BY_VENDOR:
             norm = normalize_mpn_key(card.display_mpn)
             if norm and norm not in candidates:
                 candidates[norm] = card.display_mpn
+                candidate_vendors[norm] = vendor
     if not candidates:
         return web_calls_today
 
-    pending = pending_resolution(db, candidates.keys(), "hpe")
+    # pending_resolution is vendor-scoped (it queries oem_crosswalk WHERE vendor=...), so
+    # select per vendor and merge. A norm classifies to exactly one vendor, so the merged
+    # map has no cross-vendor key collisions.
+    pending: dict = {}
+    for vendor in SOURCE_BY_VENDOR:
+        vendor_norms = [n for n, v in candidate_vendors.items() if v == vendor]
+        if vendor_norms:
+            pending.update(pending_resolution(db, vendor_norms, vendor))
     if not pending:
         return web_calls_today
 
@@ -295,6 +317,7 @@ async def _oem_resolution_pass(
             break
         taken += 1
         display_mpn = candidates[norm]
+        vendor = candidate_vendors[norm]
         # Bill BEFORE the await (the WebMeter reserve discipline, made durable):
         # incr_count advances the shared date counters atomically (no lost updates
         # against the drain CLI) and web_state mirrors them up front, so a call that
@@ -304,7 +327,7 @@ async def _oem_resolution_pass(
         web_state["web_calls"] = web_calls_today
         web_state["oem_resolves"] = oem_resolves_today
         try:
-            result = await resolve_oem_spare(display_mpn, norm, "hpe")
+            result = await resolve_oem_spare(display_mpn, norm, vendor)
         except ClaudeError as e:
             # Transient backend failure (incl. an unparseable response): feed the
             # breaker, write NO row — the spare is retried next batch for free.
@@ -320,7 +343,7 @@ async def _oem_resolution_pass(
         # batch session. The batch-final commit owns durability.
         try:
             with db.begin_nested():
-                row = apply_resolution(stale_row, result, display_mpn=display_mpn, spare_norm=norm, vendor="hpe")
+                row = apply_resolution(stale_row, result, display_mpn=display_mpn, spare_norm=norm, vendor=vendor)
                 if stale_row is None:
                     db.add(row)
                 # Flush so Pass B (same batch, same session) sees the row even on
@@ -595,9 +618,9 @@ async def run_one_batch(
     # per the crosswalk-pass pattern (worker-level queries between awaits are fine;
     # enrich_card's per-card no-query-after-await invariant is untouched).
     #
-    # Pass A — paced resolution (network): resolve uncached HP/HPE spare PNs in this
-    # batch via Claude-grounded PartSurfer lookup and upsert oem_crosswalk rows
-    # (incl. 90-day-negative no_match rows). Bounded by oem_resolve_per_batch and
+    # Pass A — paced resolution (network): resolve uncached HP/HPE + Lenovo spare PNs in
+    # this batch via Claude-grounded PartSurfer/PSREF lookup and upsert oem_crosswalk
+    # rows (incl. 90-day-negative no_match rows). Bounded by oem_resolve_per_batch and
     # BOTH daily caps; every call bills the web counter (counted INSIDE web_daily_cap).
     #
     # Pass B — deterministic writer (zero network): cards whose display_mpn norm has a

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2962,10 +2962,16 @@ crosswalk-pass pattern; both passes gated by settings.oem_crosswalk_enrich_enabl
 migration 100, spec: SPEC_OEM_WEB_RESOLUTION):
 
     Pass A — paced resolution (network). Batch cards whose display_mpn classifies
-    "hpe" (Phase A — HP/HPE via PartSurfer at https://partsurfer.hp.com; the
-    classifier gained the `\d{6}-B\d{2}` option-kit and `L\d{5}-\d{3}` L-series
-    shapes) and have NO fresh oem_crosswalk row are resolved via
-    enrichment_worker/oem_crosswalk_resolver.resolve_oem_spare — Claude web_search
+    to a vendor in SOURCE_BY_VENDOR — "hpe" (HP/HPE via PartSurfer at
+    https://partsurfer.hp.com; the classifier gained the `\d{6}-B\d{2}` option-kit
+    and `L\d{5}-\d{3}` L-series shapes) or "lenovo" (Wave 6 — Lenovo via PSREF at
+    https://psref.lenovo.com; the classic/modern FRU shapes already in the
+    classifier) — and have NO fresh oem_crosswalk row are resolved via
+    enrichment_worker/oem_crosswalk_resolver.resolve_oem_spare. Both vendors run the
+    SAME grounded resolver, negative cache and crosswalk writer; only the per-spare
+    vendor label differs (it steers the lookup hint PartSurfer-vs-PSREF and tags the
+    row). pending_resolution is selected per vendor (it is vendor-scoped) and merged —
+    Claude web_search
     grounded extraction (claude_json + five Python trust gates, HARDER than the
     ephemeral oem_extractor contract because the outcome is permanent with no
     distributor re-verification: (1) the SINGLE source_url the quote was taken from

--- a/tests/test_oem_crosswalk_worker.py
+++ b/tests/test_oem_crosswalk_worker.py
@@ -29,6 +29,18 @@ RESOLVED = OemResolveResult(
     confidence=0.95,
     payload={"canonical_mpn": "ST4000NM0035"},
 )
+# Lenovo resolves through the SAME grounded resolver, just steered at PSREF and minted
+# with vendor='lenovo' (Pass B then sources it from psref — see SOURCE_BY_VENDOR).
+LENOVO_RESOLVED = OemResolveResult(
+    status="resolved",
+    canonical_mpn="ST4000NM0035",
+    manufacturer="Seagate",
+    title="ThinkSystem 4TB 7.2K SAS 12Gb Hot Swap 512n HDD",
+    source_url="https://psref.lenovo.com/Detail/01HW917",
+    source_domain="psref.lenovo.com",
+    confidence=0.95,
+    payload={"canonical_mpn": "ST4000NM0035"},
+)
 NO_MATCH = OemResolveResult(status="no_match", payload={"canonical_mpn": None})
 
 
@@ -44,11 +56,11 @@ def _seed_card(db, mpn: str, status: str = MaterialEnrichmentStatus.UNENRICHED) 
     return card
 
 
-def _seed_no_match_row(db, mpn: str, age_days: int) -> OemCrosswalk:
+def _seed_no_match_row(db, mpn: str, age_days: int, vendor: str = "hpe") -> OemCrosswalk:
     row = OemCrosswalk(
         spare_raw=mpn,
         spare_norm=normalize_mpn_key(mpn),
-        vendor="hpe",
+        vendor=vendor,
         status=OemCrosswalkStatus.NO_MATCH,
         looked_up_at=datetime.now(timezone.utc) - timedelta(days=age_days),
     )
@@ -184,15 +196,121 @@ def test_pass_a_resolved_row_fields(db_session):
     assert web_state["oem_resolves"] == 1
 
 
-def test_pass_a_skips_non_hpe_cards(db_session):
-    # Phase A is HPE-only: Lenovo FRUs and generic MPNs never reach the resolver.
-    _seed_card(db_session, "01HW917")  # lenovo
-    _seed_card(db_session, "LM2596S-5.0")  # generic
+def test_pass_a_skips_unsupported_vendor_cards(db_session):
+    # Pass A only resolves vendors with a grounded crosswalk source (SOURCE_BY_VENDOR =
+    # hpe, lenovo). A generic MPN (classifies to None) and a Dell spare (classifies to
+    # 'dell' — has NO grounded resolver) never reach the resolver.
+    _seed_card(db_session, "HV52W")  # dell — classified but not in SOURCE_BY_VENDOR
+    _seed_card(db_session, "LM2596S-5.0")  # generic — classifies to None
     resolve_mock = AsyncMock(return_value=RESOLVED)
 
     _run(db_session, resolve_mock)
 
     resolve_mock.assert_not_awaited()
+    assert db_session.query(OemCrosswalk).count() == 0
+
+
+def test_pass_a_resolves_lenovo_spare(db_session):
+    # Wave 6: a Lenovo FRU now enters Pass A, resolves through the SAME grounded
+    # resolver steered at PSREF, and is minted as an oem_crosswalk row with
+    # vendor='lenovo'. Mirrors test_pass_a_resolved_row_fields for HP/HPE.
+    _seed_card(db_session, "01HW917")  # lenovo classic FRU
+    resolve_mock = AsyncMock(return_value=LENOVO_RESOLVED)
+
+    _, web_state, _ = _run(db_session, resolve_mock)
+
+    # The grounded resolver was called with the lenovo vendor label (it steers the
+    # PSREF lookup hint and the domain gate).
+    assert resolve_mock.await_count == 1
+    assert resolve_mock.await_args.args == ("01HW917", "01hw917", "lenovo")
+    row = db_session.query(OemCrosswalk).one()
+    assert row.spare_raw == "01HW917"
+    assert row.spare_norm == "01hw917"
+    assert row.vendor == "lenovo"
+    assert row.status == OemCrosswalkStatus.RESOLVED
+    assert row.canonical_mpn_raw == "ST4000NM0035"
+    assert row.source_domain == "psref.lenovo.com"
+    # Same billing as HP/HPE: one resolve = one web call + one oem-resolve sub-cap tick.
+    assert web_state["web_calls"] == 1
+    assert web_state["oem_resolves"] == 1
+
+
+def test_pass_a_resolves_hpe_and_lenovo_in_one_batch(db_session):
+    # Both vendors are candidates in the same batch; each is resolved under its own
+    # vendor label and minted as its own row.
+    _seed_card(db_session, "695510-001")  # hpe
+    _seed_card(db_session, "01HW917")  # lenovo
+    resolve_mock = AsyncMock(side_effect=[RESOLVED, LENOVO_RESOLVED])
+
+    _run(db_session, resolve_mock, cfg=EnrichmentWorkerConfig(batch_size=5, oem_resolve_per_batch=2))
+
+    assert resolve_mock.await_count == 2
+    vendors_called = {call.args[2] for call in resolve_mock.await_args_list}
+    assert vendors_called == {"hpe", "lenovo"}
+    rows = db_session.query(OemCrosswalk).all()
+    assert {r.vendor for r in rows} == {"hpe", "lenovo"}
+    assert all(r.status == OemCrosswalkStatus.RESOLVED for r in rows)
+
+
+def test_pass_a_lenovo_fresh_no_match_blocks_resolution(db_session):
+    # The 90-day negative cache is vendor-scoped: a fresh lenovo no_match row blocks the
+    # lenovo spare exactly as the hpe path is blocked.
+    _seed_card(db_session, "01HW917")
+    _seed_no_match_row(db_session, "01HW917", age_days=10, vendor="lenovo")
+    resolve_mock = AsyncMock(return_value=LENOVO_RESOLVED)
+
+    _run(db_session, resolve_mock)
+
+    resolve_mock.assert_not_awaited()
+
+
+def test_pass_a_lenovo_stale_no_match_retried_in_place(db_session):
+    # A 91-day-old lenovo no_match row is stale: the spare re-resolves and the SAME row
+    # is updated in place (upsert on the unique key — no second row). Mirrors hpe.
+    _seed_card(db_session, "01HW917")
+    stale = _seed_no_match_row(db_session, "01HW917", age_days=91, vendor="lenovo")
+    resolve_mock = AsyncMock(return_value=LENOVO_RESOLVED)
+
+    _run(db_session, resolve_mock)
+
+    assert resolve_mock.await_count == 1
+    rows = db_session.query(OemCrosswalk).all()
+    assert len(rows) == 1
+    assert rows[0].id == stale.id
+    assert rows[0].status == OemCrosswalkStatus.RESOLVED
+    assert rows[0].vendor == "lenovo"
+
+
+def test_pass_b_lenovo_upgrade_sources_from_psref(db_session):
+    # End-to-end PSREF path: a seeded resolved lenovo row lets Pass B upgrade the spare
+    # card to oem_sourced and stamp enrichment_source='psref' (SOURCE_BY_VENDOR[lenovo]).
+    from app.services.commodity_registry import seed_commodity_schemas
+
+    seed_commodity_schemas(db_session)
+    card = _seed_card(db_session, "01HW917")
+    row = OemCrosswalk(
+        spare_raw="01HW917",
+        spare_norm="01hw917",
+        vendor="lenovo",
+        status=OemCrosswalkStatus.RESOLVED,
+        canonical_mpn_raw="ST4000NM0035",
+        canonical_mpn_norm="st4000nm0035",
+        canonical_manufacturer="Seagate",
+        confidence=0.95,
+        looked_up_at=datetime.now(timezone.utc),
+    )
+    db_session.add(row)
+    db_session.flush()
+    resolve_mock = AsyncMock(return_value=LENOVO_RESOLVED)
+
+    counts, web_state, _ = _run(db_session, resolve_mock)
+
+    resolve_mock.assert_not_awaited()  # resolved row is fresh — Pass A no-ops
+    assert card.enrichment_status == MaterialEnrichmentStatus.OEM_SOURCED
+    assert card.enrichment_source == "psref"
+    assert card.category == "hdd"
+    assert counts == {MaterialEnrichmentStatus.OEM_SOURCED: 1}
+    assert web_state["web_calls"] == 0  # the early-return saved the card's web calls
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Activates the **Lenovo** OEM spare→canonical resolver (Wave 6). The resolver stack was already Lenovo-capable end to end — the only gap was that the enrichment worker's **Pass A** (`_oem_resolution_pass` in `app/services/enrichment_worker/worker.py`) only classified and resolved `hpe`, so Lenovo-classified spares never entered resolution.

Resolution uses **Claude `web_search` grounding** (no direct `support.lenovo.com` / PSREF HTTP), so OEM egress is **not** a blocker.

## What I mirrored from the hpe path

Pass A now handles `hpe` **and** `lenovo`, gated on the vendors present in `oem_crosswalk_enrich.SOURCE_BY_VENDOR` (`hpe`→`partsurfer`, `lenovo`→`psref`) — the single source of truth, so a future vendor auto-enables once it has a crosswalk source + classifier shape. Each spare carries its **classified vendor** through:

- **Candidate classification** — `classify_oem_vendor(...) in SOURCE_BY_VENDOR` instead of `== "hpe"`; the per-norm vendor is remembered.
- **Negative-cache selector** — `pending_resolution` is vendor-scoped, so it is selected **per vendor and merged** (a norm classifies to exactly one vendor → no key collisions). Same 90-day `no_match` window, same fresh-blocks / stale-retries-in-place behavior.
- **Grounded resolver** — `resolve_oem_spare(display_mpn, norm, vendor)` (steers the PartSurfer-vs-PSREF lookup hint; the domain gate already allowlists `*.lenovo.com`).
- **Crosswalk writer** — `apply_resolution(..., vendor=vendor)` tags the `oem_crosswalk` row with the right vendor; **Pass B** (`oem_crosswalk_and_record_specs`) was already vendor-agnostic and sources the upgrade from `psref` for lenovo.

Everything else is unchanged and shared: same `oem_crosswalk_enrich_enabled` flag, same `oem_resolve_per_batch` / `oem_resolve_daily_cap` / `web_daily_cap` caps and billing, same `record_claude_error`/`record_claude_success` breaker, same per-row SAVEPOINT isolation against the drain-CLI race.

**Out of scope (deliberately untouched):** the HP-only `_partsurfer_desc_pass`, which does direct HTTP to `partsurfer.hpe.com` — that is the description-enrichment pass, not the grounded crosswalk resolver.

## Tests (TDD)

New/updated coverage in `tests/test_oem_crosswalk_worker.py`, mirroring the hpe Pass A tests (grounding mocked):
- `test_pass_a_resolves_lenovo_spare` — lenovo spare resolves via the grounded path, resolver called with `vendor="lenovo"`, writes a `vendor='lenovo'` crosswalk row.
- `test_pass_a_resolves_hpe_and_lenovo_in_one_batch` — both vendors resolve under their own labels in one batch.
- `test_pass_a_lenovo_fresh_no_match_blocks_resolution` / `test_pass_a_lenovo_stale_no_match_retried_in_place` — vendor-scoped 90-day negative cache.
- `test_pass_b_lenovo_upgrade_sources_from_psref` — Pass B upgrades the card to `oem_sourced` with `enrichment_source='psref'`.
- `test_pass_a_skips_non_hpe_cards` → `test_pass_a_skips_unsupported_vendor_cards` (generic + dell, which has no grounded resolver).

`docs/APP_MAP_INTERACTIONS.md` Pass A section updated to describe the hpe+lenovo classification + per-vendor `pending_resolution`.

## Verification

- 239 enrichment-worker-related tests pass (incl. all OEM crosswalk worker/writer/resolver/backfill/classifier + partsurfer).
- `pre-commit run` (ruff, ruff-format, mypy, docformatter) green.
- No migration (alembic head stays `170_prospecting_persistence`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)