### PR TITLE
feat(activity): Redis-backed CDM outreach rate limiter (Wave 7)

### DIFF
--- a/app/rate_limit.py
+++ b/app/rate_limit.py
@@ -1,14 +1,23 @@
 """Shared rate limiter with Redis storage and in-memory fallback.
 
-Uses Redis for distributed rate limiting across workers when available. Falls back to
-in-memory storage if Redis is unreachable at startup (limits won't be shared across
-workers in that case).
+Two limiters live here, both Redis-backed with an in-memory fallback so enforcement
+survives a Redis outage (limits just stop being shared across workers in that mode):
+
+- ``limiter`` — the slowapi IP-based HTTP limiter (storage resolved at import time).
+- ``check_rate_limit`` — a per-(user, bucket) fixed-window counter for application-level
+  outreach throttles (CDM click-to-call / click-to-contact / call-outcome). It rides the
+  shared Redis substrate (``app.cache.intel_cache``) via an atomic ``INCR``, so a per-user
+  limit holds across every worker process and across restarts within the window.
 """
+
+import time
+from threading import Lock
 
 from loguru import logger
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
+from .cache.intel_cache import _get_redis
 from .config import settings
 
 
@@ -36,3 +45,75 @@ limiter = Limiter(
     enabled=settings.rate_limit_enabled,
     storage_uri=_resolve_storage(),
 )
+
+
+# ── Per-(user, bucket) outreach rate limiter ───────────────────────────
+# Fixed-window counter shared across processes via the Redis substrate. The window is
+# encoded in the key (``…:{window_index}``) so the counter resets automatically each
+# window without any pruning; the key is also given a TTL as a belt-and-braces cleanup.
+# Degrades to a per-process in-memory counter when Redis is unavailable — same posture
+# as the slowapi ``limiter`` above (enforcement continues, just not shared across
+# workers). Fixed window, not sliding: this is the shape the counter substrate supports
+# atomically (mirrors ``intel_cache.incr_count``).
+
+_OUTREACH_RL_PREFIX = "rl:outreach:"
+
+# In-memory fallback store: ``{user_id}:{bucket}`` -> (window_index, count).
+# Used only when Redis is down; reset by ``reset_rate_limit_state`` (tests).
+_fallback_lock = Lock()
+_fallback_counts: dict[str, tuple[int, int]] = {}
+
+
+def _now() -> float:
+    """Current wall-clock time — a seam so tests can advance the window."""
+    return time.time()
+
+
+def _check_in_memory(key_base: str, window_index: int, limit: int) -> bool:
+    """Per-process fixed-window fallback used when Redis is unavailable."""
+    with _fallback_lock:
+        prev = _fallback_counts.get(key_base)
+        count = prev[1] + 1 if prev is not None and prev[0] == window_index else 1
+        _fallback_counts[key_base] = (window_index, count)
+    return count <= limit
+
+
+def check_rate_limit(user_id: int, bucket: str, limit: int, window_seconds: int = 60) -> bool:
+    """Return True if the caller is within the rate limit, False if it is exceeded.
+
+    Atomic fixed-window counter keyed per ``(user_id, bucket, time-window)``. The counter
+    lives in the shared Redis substrate (``app.cache.intel_cache``), so the per-user limit
+    is enforced across all worker processes and across restarts within the window. When
+    Redis is unavailable the check degrades to a per-process in-memory counter (mirrors the
+    slowapi ``limiter`` fallback): enforcement continues, but the limit stops being shared.
+
+    Semantics: allows up to ``limit`` calls per ``window_seconds`` window, blocks the next.
+    """
+    window_index = int(_now() // window_seconds)
+    key_base = f"{user_id}:{bucket}"
+
+    redis = _get_redis()
+    if redis is not None:
+        redis_key = f"{_OUTREACH_RL_PREFIX}{key_base}:{window_index}"
+        try:
+            count = int(redis.incr(redis_key))
+            # Bound the key's lifetime (2× window so the tail of a window still expires
+            # cleanly). Window correctness comes from the key, not the TTL.
+            redis.expire(redis_key, window_seconds * 2)
+            return count <= limit
+        except Exception as e:
+            logger.warning(
+                "Outreach rate limiter: Redis error ({}) — falling back to in-memory counter",
+                e,
+            )
+
+    return _check_in_memory(key_base, window_index, limit)
+
+
+def reset_rate_limit_state() -> None:
+    """Clear the in-memory fallback counter.
+
+    Test-support hook.
+    """
+    with _fallback_lock:
+        _fallback_counts.clear()

--- a/app/routers/activity.py
+++ b/app/routers/activity.py
@@ -4,7 +4,7 @@ Logs phone_call activity_log entries when a user clicks a tel: link.
 This is a fire-and-forget endpoint — it must never visibly fail.
 
 Business rules:
-- Rate limit: 10 calls per user per minute (in-memory)
+- Rate limit: 10 calls per user per minute (Redis-backed, shared across workers)
 - Invalid entity IDs are warned, not rejected
 - Phone must parse to E.164 or return 400
 - Entire handler wrapped in try/except — returns 201 on any internal error
@@ -13,8 +13,6 @@ Called by: app/static/app.js (logCallInitiated), app/static/crm.js
 Depends on: app/utils/phone_utils.py, app/services/activity_service.py
 """
 
-import time
-from collections import defaultdict
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -33,6 +31,7 @@ from ..constants import (
 from ..database import get_db
 from ..dependencies import can_manage_account, require_user
 from ..models import ActivityLog, Company, CustomerSite, SiteContact, User, VendorCard
+from ..rate_limit import check_rate_limit
 from ..schemas.activity import (
     ActivityTimelineResponse,
     CallInitiatedRequest,
@@ -44,28 +43,16 @@ from ..utils.phone_utils import format_phone_display, format_phone_e164
 
 router = APIRouter(prefix="/api/activity", tags=["activity"])
 
-# ── In-memory rate limiter ─────────────────────────────────────────────
+# ── Rate-limit budgets ─────────────────────────────────────────────────
 # Buckets are keyed per user AND per endpoint family so a rep's heavy phone
 # use never silently blocks their email/Teams outreach logging (and vice
 # versa). Outreach gets a higher budget: the CDM call-list workflow can
-# legitimately produce several logs per contact per minute.
-_call_log: dict[str, list[float]] = defaultdict(list)
+# legitimately produce several logs per contact per minute. The counter
+# itself is the shared Redis-backed limiter in app/rate_limit.py, so these
+# limits hold across worker processes and restarts (in-memory fallback when
+# Redis is down).
 _RATE_LIMIT = 10  # max click-to-call logs per user per minute
 _OUTREACH_RATE_LIMIT = 30  # max outreach logs per user per minute
-
-
-def _check_rate_limit(user_id: int, bucket: str = "call", limit: int = _RATE_LIMIT) -> bool:
-    """Return True if user is within rate limit, False if exceeded."""
-    key = f"{user_id}:{bucket}"
-    now = time.time()
-    window = now - 60
-    timestamps = _call_log[key]
-    # Prune old entries
-    _call_log[key] = [t for t in timestamps if t > window]
-    if len(_call_log[key]) >= limit:
-        return False
-    _call_log[key].append(now)
-    return True
 
 
 def _validated_entity_ids(
@@ -153,7 +140,7 @@ def call_initiated(
             raise HTTPException(400, "Invalid phone number")
 
         # Rate limit
-        if not _check_rate_limit(user.id):
+        if not check_rate_limit(user.id, bucket="call", limit=_RATE_LIMIT):
             raise HTTPException(429, "Too many calls — try again in a minute")
 
         phone_display = format_phone_display(body.phone_number)
@@ -247,7 +234,7 @@ def outreach_initiated(
         elif not contact_value:
             raise HTTPException(400, "Contact value is required")
 
-        if not _check_rate_limit(user.id, bucket="outreach", limit=_OUTREACH_RATE_LIMIT):
+        if not check_rate_limit(user.id, bucket="outreach", limit=_OUTREACH_RATE_LIMIT):
             raise HTTPException(429, "Too many outreach logs — try again in a minute")
 
         company_id, customer_site_id, site_contact_id, dropped = _validated_entity_ids(
@@ -300,7 +287,7 @@ def record_call_outcome(
     not spend outreach tokens).
     """
     try:
-        if not _check_rate_limit(user.id, bucket="call_outcome", limit=_OUTREACH_RATE_LIMIT):
+        if not check_rate_limit(user.id, bucket="call_outcome", limit=_OUTREACH_RATE_LIMIT):
             raise HTTPException(429, "Too many requests — try again in a minute")
 
         record = db.get(ActivityLog, activity_id)

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2106,7 +2106,12 @@ Delegated click listener in app/static/htmx_app.js
 activity.py router -> log_outreach_initiated(db, user_id=..., channel=...,
     |                                          contact_value=..., ...)
     |   - rate limit: per-user "outreach" bucket (30/min), separate from the
-    |     click-to-call bucket (10/min) so channels never starve each other
+    |     click-to-call bucket (10/min) so channels never starve each other.
+    |     Enforced by app.rate_limit.check_rate_limit — an atomic fixed-window
+    |     INCR counter on the shared Redis substrate (app.cache.intel_cache), so
+    |     the limit holds across worker processes/restarts; degrades to a
+    |     per-process in-memory counter when Redis is down (same fallback posture
+    |     as the slowapi limiter). call-outcome stamps use a third bucket.
     |   - nonexistent OR mismatched company/site/contact ids (site not under
     |     the company, contact not under the site) are nulled out with a
     |     warning (stale DOM ids must not FK-crash the insert or bump an

--- a/tests/test_activity_endpoint.py
+++ b/tests/test_activity_endpoint.py
@@ -11,12 +11,12 @@ from app.models import ActivityLog
 
 @pytest.fixture(autouse=True)
 def _clear_rate_limit():
-    """Clear in-memory rate limiter between tests."""
-    from app.routers.activity import _call_log
+    """Reset the shared rate limiter's in-memory fallback between tests."""
+    from app.rate_limit import reset_rate_limit_state
 
-    _call_log.clear()
+    reset_rate_limit_state()
     yield
-    _call_log.clear()
+    reset_rate_limit_state()
 
 
 class TestCallInitiated:

--- a/tests/test_activity_outreach.py
+++ b/tests/test_activity_outreach.py
@@ -14,12 +14,12 @@ from app.models.crm import Company, CustomerSite, SiteContact
 
 @pytest.fixture(autouse=True)
 def _clear_rate_limit():
-    """Clear in-memory rate limiter between tests."""
-    from app.routers.activity import _call_log
+    """Reset the shared rate limiter's in-memory fallback between tests."""
+    from app.rate_limit import reset_rate_limit_state
 
-    _call_log.clear()
+    reset_rate_limit_state()
     yield
-    _call_log.clear()
+    reset_rate_limit_state()
 
 
 @pytest.fixture
@@ -154,16 +154,18 @@ class TestOutreachInitiated:
         assert "Call to +14155551234" in record.subject
 
     def test_rate_limit_returns_429(self, client, cdm_company):
+        from app import rate_limit
         from app.routers import activity as activity_router
 
-        user_buckets = activity_router._call_log
         # Outreach has its own (higher) budget, separate from call-initiated
         for _ in range(activity_router._OUTREACH_RATE_LIMIT):
             resp = self._post(client, cdm_company, "phone", "+14155551234")
             assert resp.status_code == 201
         resp = self._post(client, cdm_company, "phone", "+14155551234")
         assert resp.status_code == 429
-        assert user_buckets  # sanity: limiter actually tracked the user
+        # Sanity: the shared limiter's fallback store actually tracked the user
+        # (Redis is unavailable under TESTING, so the in-memory path is exercised).
+        assert rate_limit._fallback_counts
 
     def test_rate_limit_bucket_separate_from_call_initiated(self, client, cdm_company):
         """Exhausting the click-to-call budget must not block outreach logging."""

--- a/tests/test_call_outcome.py
+++ b/tests/test_call_outcome.py
@@ -21,11 +21,11 @@ from app.models import ActivityLog
 
 @pytest.fixture(autouse=True)
 def _clear_rate_limit():
-    from app.routers.activity import _call_log
+    from app.rate_limit import reset_rate_limit_state
 
-    _call_log.clear()
+    reset_rate_limit_state()
     yield
-    _call_log.clear()
+    reset_rate_limit_state()
 
 
 @pytest.fixture

--- a/tests/test_dnc_flag.py
+++ b/tests/test_dnc_flag.py
@@ -62,12 +62,12 @@ def dnc_company(db_session: Session, test_user):
 
 @pytest.fixture(autouse=True)
 def _clear_rate_limit():
-    """Clear in-memory rate limiter between tests."""
-    from app.routers.activity import _call_log
+    """Reset the shared rate limiter's in-memory fallback between tests."""
+    from app.rate_limit import reset_rate_limit_state
 
-    _call_log.clear()
+    reset_rate_limit_state()
     yield
-    _call_log.clear()
+    reset_rate_limit_state()
 
 
 # ── Toggle DNC ────────────────────────────────────────────────────────

--- a/tests/test_outreach_rate_limiter.py
+++ b/tests/test_outreach_rate_limiter.py
@@ -1,0 +1,201 @@
+"""Tests for the shared per-user outreach rate limiter
+(``app.rate_limit.check_rate_limit``).
+
+The CDM outreach endpoints (click-to-call, click-to-contact, call-outcome) used to share
+a per-process in-memory dict, so the limit was not enforced across worker processes or
+across restarts. The limiter now rides the shared Redis substrate
+(``app.cache.intel_cache``) — an atomic fixed-window counter — and degrades to a
+per-process in-memory counter only when Redis is unavailable.
+
+Covers: under-limit allows, over-limit blocks, state shared via the Redis substrate
+(survives an in-memory reset → proxy for cross-process / restart), graceful in-memory
+fallback when Redis is down or erroring, window rollover, and per-(user, bucket)
+isolation.
+
+Called by: pytest
+Depends on: app.rate_limit
+"""
+
+import pytest
+
+from app import rate_limit
+
+
+class FakeRedis:
+    """Minimal redis stand-in implementing the slice the limiter uses (incr/expire).
+
+    A single instance models one shared Redis server: every ``check_rate_limit`` call
+    that resolves to this instance shares ``store``, which is how the test simulates
+    state being shared across processes.
+    """
+
+    def __init__(self, *, fail: bool = False):
+        self.store: dict[str, int] = {}
+        self.expirations: dict[str, int] = {}
+        self.fail = fail
+
+    def incr(self, key: str) -> int:
+        if self.fail:
+            raise RuntimeError("redis down")
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    def expire(self, key: str, ttl: int) -> bool:
+        if self.fail:
+            raise RuntimeError("redis down")
+        self.expirations[key] = ttl
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter():
+    """Reset the in-memory fallback counter around every test."""
+    rate_limit.reset_rate_limit_state()
+    yield
+    rate_limit.reset_rate_limit_state()
+
+
+# ── Redis-backed (shared) path ─────────────────────────────────────────
+
+
+def test_under_limit_allows(monkeypatch):
+    redis = FakeRedis()
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: redis)
+
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "outreach", limit=5) is True
+
+
+def test_over_limit_blocks(monkeypatch):
+    redis = FakeRedis()
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: redis)
+
+    # Exactly ``limit`` calls are allowed...
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "outreach", limit=5) is True
+    # ...the next one is blocked.
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5) is False
+
+
+def test_redis_key_carries_a_ttl(monkeypatch):
+    """The Redis counter key is given a bounded TTL so windows self-expire."""
+    redis = FakeRedis()
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: redis)
+
+    rate_limit.check_rate_limit(7, "outreach", limit=5, window_seconds=60)
+
+    assert len(redis.store) == 1
+    (key,) = redis.store
+    assert redis.expirations[key] >= 60
+
+
+def test_state_shared_via_redis_substrate(monkeypatch):
+    """The count lives in the Redis substrate, not the per-process store.
+
+    Clearing the in-memory fallback (the proxy for a fresh process / restart) must NOT
+    reset the limit while Redis is up — that is what makes the limit hold across
+    workers.
+    """
+    redis = FakeRedis()
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: redis)
+
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "outreach", limit=5) is True
+
+    # Simulate a different worker / a restart: wipe local state.
+    rate_limit.reset_rate_limit_state()
+
+    # The shared Redis counter still remembers — the next call is blocked.
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5) is False
+    # And the counter genuinely lives in Redis.
+    assert list(redis.store.values()) == [6]
+
+
+# ── In-memory fallback (Redis down) ────────────────────────────────────
+
+
+def test_redis_down_falls_back_to_in_memory(monkeypatch):
+    """Redis unavailable (``_get_redis`` → None): enforcement still happens locally."""
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: None)
+
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "outreach", limit=5) is True
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5) is False
+
+
+def test_redis_error_falls_back_gracefully(monkeypatch):
+    """A Redis client that raises must not surface — fall back to in-memory."""
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: FakeRedis(fail=True))
+
+    # No exception escapes, and the limit is still enforced.
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "outreach", limit=5) is True
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5) is False
+
+
+def test_in_memory_reset_clears_fallback(monkeypatch):
+    """When Redis is down, ``reset_rate_limit_state`` does free the bucket again."""
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: None)
+
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "outreach", limit=5) is True
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5) is False
+
+    rate_limit.reset_rate_limit_state()
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5) is True
+
+
+# ── Window + key isolation ─────────────────────────────────────────────
+
+
+def test_window_rollover_resets_counter(monkeypatch):
+    """Advancing the clock past the window starts a fresh budget (in-memory path)."""
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: None)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(rate_limit, "_now", lambda: clock["t"])
+
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "outreach", limit=5, window_seconds=60) is True
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5, window_seconds=60) is False
+
+    # Jump into the next window.
+    clock["t"] += 61
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5, window_seconds=60) is True
+
+
+def test_window_rollover_resets_counter_redis(monkeypatch):
+    """Same rollover guarantee on the Redis path: the key is window-indexed."""
+    redis = FakeRedis()
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: redis)
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(rate_limit, "_now", lambda: clock["t"])
+
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "outreach", limit=5, window_seconds=60) is True
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5, window_seconds=60) is False
+
+    clock["t"] += 61
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5, window_seconds=60) is True
+
+
+def test_buckets_are_independent(monkeypatch):
+    """Exhausting one bucket must not touch another bucket's budget."""
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: None)
+
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "call", limit=5) is True
+    assert rate_limit.check_rate_limit(1, "call", limit=5) is False
+
+    # Different bucket, same user — fresh budget.
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5) is True
+
+
+def test_users_are_independent(monkeypatch):
+    """Two users do not share a budget."""
+    monkeypatch.setattr(rate_limit, "_get_redis", lambda: None)
+
+    for _ in range(5):
+        assert rate_limit.check_rate_limit(1, "outreach", limit=5) is True
+    assert rate_limit.check_rate_limit(1, "outreach", limit=5) is False
+
+    assert rate_limit.check_rate_limit(2, "outreach", limit=5) is True


### PR DESCRIPTION
## What & why

The per-buyer outreach rate limiter on the CDM activity endpoints
(`POST /api/activity/call-initiated`, `/outreach-initiated`, `/{id}/call-outcome`)
was a **per-process in-memory dict** (`activity._call_log`). With multiple
worker processes (Docker `app` + `enrichment-worker`, gunicorn workers) the
limit was enforced *per process*, so the real ceiling was `limit × N workers`
and it reset on every restart.

This replaces it with a **shared Redis-backed limiter** so the limit holds
across processes and restarts.

## Approach

New `check_rate_limit(user_id, bucket, limit, window_seconds=60)` in
`app/rate_limit.py` (the canonical shared-limiter home, alongside the existing
slowapi `limiter`):

- **Atomic fixed-window counter** on the existing Redis substrate
  (`app.cache.intel_cache._get_redis`) via `INCR` + `EXPIRE`. The window is
  encoded in the key (`rl:outreach:{user}:{bucket}:{window_index}`), so it
  resets each window with no pruning and the counter is shared across every
  worker.
- **In-memory fallback** when Redis is down or erroring (mirrors how the
  slowapi limiter and `intel_cache` degrade): enforcement continues, just not
  shared across workers. No exception ever surfaces to the request.
- **Same limit semantics preserved**: 10/min click-to-call, 30/min outreach,
  30/min call-outcome, 60s window. `activity.py` keeps its per-bucket budget
  constants and just delegates the counting.

Under `TESTING=1`, `_get_redis()` returns `None`, so the suite exercises the
in-memory fallback path (same behavior the old dict had).

## Tests (TDD)

`tests/test_outreach_rate_limiter.py` (11 tests):
- under-limit allows / over-limit blocks
- **state shared via the Redis substrate** — clearing the in-memory store does
  NOT reset the count while Redis is up (proxy for cross-process / restart)
- Redis-key TTL is set
- Redis-down (`None`) and Redis-erroring clients both fall back gracefully
- window rollover resets (both Redis and in-memory paths)
- per-`(user, bucket)` isolation

Existing activity fixtures (`test_activity_outreach`, `test_activity_endpoint`,
`test_call_outcome`, `test_dnc_flag`) now reset the shared limiter's in-memory
fallback via `reset_rate_limit_state()` instead of the removed `_call_log`.

## Verification

- `pre-commit run --files …` (ruff, ruff-format, docformatter, mypy) — all pass
- 82 passed across the limiter + affected activity/rate-limit suites
- No migration added (alembic head stays `170_prospecting_persistence`)
- `docs/APP_MAP_INTERACTIONS.md` updated to describe the shared limiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)