### PR TITLE
hardening(encryption): ENCRYPTION_SALT rotation command (PRE_ROLLOUT Gate 4)

### DIFF
--- a/STABLE.md
+++ b/STABLE.md
@@ -11,6 +11,19 @@ Do not refactor these without explicit approval. Changes here can break startup,
 ## Auth & dependencies
 - `app/dependencies.py` — require_user, require_buyer, auth middleware
 
+## Encryption (at-rest secrets)
+
+- `app/utils/encrypted_type.py` — `EncryptedText` SQLAlchemy type + `build_fernet()`
+  key derivation for `users.refresh_token` / `access_token` / `password_hash`.
+- `app/services/credential_service.py` — the **same** `ENCRYPTION_SALT` keys
+  `api_sources.credentials` (supplier API keys; graceful env-var fallback on a decrypt miss).
+- **`SECRET_KEY` + `ENCRYPTION_SALT` are jointly load-bearing.** Both feed the Fernet
+  key (PBKDF2). Changing either orphans every encrypted cell. When `ENCRYPTION_SALT` is
+  unset, the hard-coded legacy salts (`_LEGACY_SALT`, `_LEGACY_CREDENTIAL_SALT`) stand in,
+  so `SECRET_KEY` alone is load-bearing in that mode. Never change these casually.
+- **Rotate the salt** with `python -m app.management.rotate_encryption_salt` (`--dry-run`
+  first; idempotent/resumable). Full procedure: `docs/PRE_ROLLOUT_CHECKLIST.md` Gate 4.
+
 ## Critical routers (thin entry points; logic in services)
 - `app/routers/auth.py`
 - `app/routers/requisitions/` (core, requirements, attachments)

--- a/app/management/rotate_encryption_salt.py
+++ b/app/management/rotate_encryption_salt.py
@@ -1,0 +1,263 @@
+"""rotate_encryption_salt.py — Rotate the Fernet salt for EncryptedText columns.
+
+Re-encrypts the three at-rest ``EncryptedText`` columns on the ``users`` table
+(refresh_token, access_token, password_hash) from an OLD ``ENCRYPTION_SALT`` to a
+NEW one without orphaning existing ciphertext.
+
+Why this exists: ``app/utils/encrypted_type.py`` derives a Fernet key from
+``SECRET_KEY`` + ``ENCRYPTION_SALT``. Changing ``ENCRYPTION_SALT`` makes every
+existing ciphertext undecryptable. This command bridges the gap — it decrypts each
+value with the OLD salt's key and re-encrypts with the NEW salt's key in a single
+transaction (PRE_ROLLOUT Gate 4).
+
+The crypto is keyed off the values passed in (old/new salt + secret key), NOT the
+live settings, so the command is independent of the running app's configuration and
+can be run before OR after ``ENCRYPTION_SALT`` is changed in ``.env``.
+
+Idempotent + resumable: a value already encrypted under the NEW salt is detected (it
+decrypts with the new key, not the old) and left untouched, so re-running after a
+partial/failed run — or running twice — is a safe no-op for already-rotated rows. A
+value that decrypts with *neither* salt is reported and left intact (never discarded),
+so a wrong-OLD-salt run can't destroy data.
+
+NOTE — blast radius: ``ENCRYPTION_SALT`` also keys
+``app/services/credential_service.py`` (supplier API keys in ``api_sources.credentials``).
+That path degrades gracefully (falls back to env vars on a decrypt miss), so it does not
+block rotation, but re-enter any DB-stored supplier credentials afterward. See
+``docs/PRE_ROLLOUT_CHECKLIST.md`` Gate 4.
+
+Usage:
+    # Dry-run from the current (live) salt to a freshly generated one:
+    python -m app.management.rotate_encryption_salt --new-salt "$(openssl rand -base64 32)" --dry-run
+    # Then, with the SAME new salt, rotate for real:
+    python -m app.management.rotate_encryption_salt --new-salt "<same value>"
+
+    # Explicit OLD salt (e.g. .env already edited to the new value):
+    python -m app.management.rotate_encryption_salt --old-salt "<old>" --new-salt "<new>"
+
+    # NEW salt may also come from the NEW_ENCRYPTION_SALT env var.
+
+Called by: operator, manually, during a salt rotation (PRE_ROLLOUT Gate 4).
+Depends on: app.utils.encrypted_type.build_fernet, app.database.SessionLocal,
+            app.config.settings (default OLD salt + secret key).
+"""
+
+import argparse
+import hashlib
+import os
+from dataclasses import dataclass, field
+
+from cryptography.fernet import Fernet, InvalidToken
+from loguru import logger
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from ..utils.encrypted_type import build_fernet
+
+# The EncryptedText columns this command rotates. All live on the ``users`` table.
+TABLE = "users"
+COLUMNS: tuple[str, ...] = ("refresh_token", "access_token", "password_hash")
+
+# rotate_value() status codes.
+ROTATED = "rotated"
+ALREADY = "already"
+UNDECRYPTABLE = "undecryptable"
+
+
+@dataclass
+class RotationStats:
+    """Per-run, per-column tally of the rotation outcome."""
+
+    users_scanned: int = 0
+    rows_updated: int = 0
+    rotated: dict[str, int] = field(default_factory=lambda: {c: 0 for c in COLUMNS})
+    already: dict[str, int] = field(default_factory=lambda: {c: 0 for c in COLUMNS})
+    undecryptable: dict[str, int] = field(default_factory=lambda: {c: 0 for c in COLUMNS})
+
+    @property
+    def total_rotated(self) -> int:
+        return sum(self.rotated.values())
+
+    @property
+    def total_undecryptable(self) -> int:
+        return sum(self.undecryptable.values())
+
+
+def _salt_fingerprint(salt: str | None) -> str:
+    """A short, non-reversible fingerprint of a salt for auditable logging.
+
+    Never logs the salt itself. Empty/None salt is the legacy fallback.
+    """
+    if not salt:
+        return "(legacy fallback salt)"
+    return f"sha256:{hashlib.sha256(salt.encode()).hexdigest()[:12]}"
+
+
+def rotate_value(raw: str | None, old_fernet: Fernet, new_fernet: Fernet) -> tuple[str | None, str | None]:
+    """Rotate one stored ciphertext value from old_fernet to new_fernet.
+
+    Returns ``(new_raw, status)``:
+      - decrypts with OLD  -> re-encrypt with NEW -> ``(new_ciphertext, ROTATED)``
+      - decrypts with NEW  -> already rotated      -> ``(raw,            ALREADY)``
+      - decrypts with neither                      -> ``(raw,            UNDECRYPTABLE)``
+      - raw is None/empty                          -> ``(raw,            None)``
+
+    Never returns plaintext and never discards an undecryptable value, so a
+    wrong-salt run can't destroy data — it just reports and leaves it intact.
+    """
+    if not raw:
+        return raw, None
+    raw_bytes = raw.encode()
+    try:
+        plaintext = old_fernet.decrypt(raw_bytes)
+    except InvalidToken:
+        # Not decryptable with OLD. Already rotated to NEW? Then it's done.
+        try:
+            new_fernet.decrypt(raw_bytes)
+            return raw, ALREADY
+        except InvalidToken:
+            return raw, UNDECRYPTABLE
+    return new_fernet.encrypt(plaintext).decode(), ROTATED
+
+
+def rotate_salt(
+    db: Session,
+    *,
+    old_salt: str | None,
+    new_salt: str | None,
+    secret_key: str,
+    dry_run: bool = False,
+) -> RotationStats:
+    """Re-encrypt all EncryptedText user columns from old_salt to new_salt.
+
+    Builds OLD and NEW Fernet keys from ``(secret_key, salt)`` — independent of the
+    live app settings — and runs in a single transaction: it commits once at the end,
+    or (in dry-run) rolls back so nothing is written.
+
+    Reads/writes the columns as RAW text via Core SQL, deliberately bypassing the
+    ``EncryptedText`` TypeDecorator (which would auto-decrypt/encrypt with the *live*
+    key) so the rotation is driven solely by the supplied OLD/NEW salts.
+
+    Raises ``ValueError`` if OLD and NEW resolve to the same salt (nothing to rotate).
+    """
+    if old_salt == new_salt or (not old_salt and not new_salt):
+        raise ValueError("OLD and NEW salts resolve to the same value — nothing to rotate.")
+
+    old_fernet = build_fernet(secret_key, old_salt)
+    new_fernet = build_fernet(secret_key, new_salt)
+
+    stats = RotationStats()
+    select_cols = ", ".join(COLUMNS)
+    rows = db.execute(text(f"SELECT id, {select_cols} FROM {TABLE}")).mappings().all()
+
+    for row in rows:
+        stats.users_scanned += 1
+        updates: dict[str, str] = {}
+        for col in COLUMNS:
+            new_raw, status = rotate_value(row[col], old_fernet, new_fernet)
+            if status == ROTATED:
+                stats.rotated[col] += 1
+                # ROTATED always yields a non-None ciphertext str (see rotate_value).
+                updates[col] = new_raw
+            elif status == ALREADY:
+                stats.already[col] += 1
+            elif status == UNDECRYPTABLE:
+                stats.undecryptable[col] += 1
+                logger.warning(
+                    "{}.id={} {}: ciphertext decrypts with neither OLD nor NEW salt — left intact",
+                    TABLE,
+                    row["id"],
+                    col,
+                )
+        if updates:
+            stats.rows_updated += 1
+            if not dry_run:
+                set_clause = ", ".join(f"{c} = :{c}" for c in updates)
+                db.execute(
+                    text(f"UPDATE {TABLE} SET {set_clause} WHERE id = :_id"),
+                    {**updates, "_id": row["id"]},
+                )
+
+    if dry_run:
+        db.rollback()
+    else:
+        db.commit()
+    return stats
+
+
+def _log_summary(
+    stats: RotationStats, old_salt: str | None, new_salt: str | None, secret_key: str, dry_run: bool
+) -> None:
+    """Print a clear before/after summary (salts fingerprinted, never logged raw)."""
+    mode = "DRY RUN — no changes written" if dry_run else "LIVE — changes committed"
+    secret_fp = hashlib.sha256(secret_key.encode()).hexdigest()[:12]
+    logger.info("-" * 64)
+    logger.info("ENCRYPTION SALT ROTATION  [{}]", mode)
+    logger.info("  secret_key fingerprint : sha256:{} (unchanged on both sides)", secret_fp)
+    logger.info("  OLD salt               : {}", _salt_fingerprint(old_salt))
+    logger.info("  NEW salt               : {}", _salt_fingerprint(new_salt))
+    logger.info("  users scanned          : {}", stats.users_scanned)
+    logger.info("  rows {:<17}: {}", "to update" if dry_run else "updated", stats.rows_updated)
+    for col in COLUMNS:
+        logger.info(
+            "    {:<14} rotated={} already={} undecryptable={}",
+            col,
+            stats.rotated[col],
+            stats.already[col],
+            stats.undecryptable[col],
+        )
+    if stats.total_undecryptable:
+        logger.warning(
+            "  {} value(s) decrypt with NEITHER salt — verify the OLD salt + SECRET_KEY before proceeding.",
+            stats.total_undecryptable,
+        )
+    logger.info("-" * 64)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Rotate ENCRYPTION_SALT for the at-rest EncryptedText user columns "
+        "(refresh_token, access_token, password_hash)."
+    )
+    parser.add_argument(
+        "--old-salt",
+        default=None,
+        help="Current salt. Defaults to settings.encryption_salt (the live value). "
+        "Empty means the legacy hard-coded salt.",
+    )
+    parser.add_argument(
+        "--new-salt",
+        default=None,
+        help="New salt. Falls back to the NEW_ENCRYPTION_SALT env var. Generate one with: openssl rand -base64 32",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report what would change; write nothing.")
+    args = parser.parse_args()
+
+    from ..config import settings
+    from ..database import SessionLocal
+
+    old_salt = args.old_salt if args.old_salt is not None else settings.encryption_salt
+    new_salt = args.new_salt if args.new_salt is not None else os.environ.get("NEW_ENCRYPTION_SALT")
+
+    if not new_salt:
+        parser.error(
+            "NEW salt is required: pass --new-salt or set NEW_ENCRYPTION_SALT "
+            "(generate one with: openssl rand -base64 32)."
+        )
+
+    db = SessionLocal()
+    try:
+        stats = rotate_salt(
+            db,
+            old_salt=old_salt,
+            new_salt=new_salt,
+            secret_key=settings.secret_key,
+            dry_run=args.dry_run,
+        )
+        _log_summary(stats, old_salt, new_salt, settings.secret_key, args.dry_run)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/management/rotate_encryption_salt.py
+++ b/app/management/rotate_encryption_salt.py
@@ -148,7 +148,9 @@ def rotate_salt(
 
     stats = RotationStats()
     select_cols = ", ".join(COLUMNS)
-    rows = db.execute(text(f"SELECT id, {select_cols} FROM {TABLE}")).mappings().all()
+    # B608: TABLE + COLUMNS are hardcoded module constants (no user input); SQL
+    # identifiers cannot be bind-parameterized.
+    rows = db.execute(text(f"SELECT id, {select_cols} FROM {TABLE}")).mappings().all()  # nosec B608
 
     for row in rows:
         stats.users_scanned += 1
@@ -174,7 +176,8 @@ def rotate_salt(
             if not dry_run:
                 set_clause = ", ".join(f"{c} = :{c}" for c in updates)
                 db.execute(
-                    text(f"UPDATE {TABLE} SET {set_clause} WHERE id = :_id"),
+                    # B608: TABLE constant + set_clause is COLUMNS constants; values are bound params.
+                    text(f"UPDATE {TABLE} SET {set_clause} WHERE id = :_id"),  # nosec B608
                     {**updates, "_id": row["id"]},
                 )
 

--- a/app/utils/encrypted_type.py
+++ b/app/utils/encrypted_type.py
@@ -14,6 +14,26 @@ _fernet_instance = None
 _LEGACY_SALT = b"availai-token-encryption-v1"
 
 
+def build_fernet(secret_key: str, salt: str | None) -> Fernet:
+    """Build a Fernet from an explicit secret key + salt string.
+
+    An empty/None ``salt`` falls back to the legacy static salt (backward
+    compatibility). This is the single key-derivation point: the SQLAlchemy type's
+    normal path reaches it via :func:`_get_fernet`, and the salt-rotation management
+    command (``app.management.rotate_encryption_salt``) calls it directly to build a
+    Fernet for an *arbitrary* OLD/NEW salt, independent of the live settings.
+    """
+    salt_bytes = salt.encode() if salt else _LEGACY_SALT
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt_bytes,
+        iterations=100_000,
+    )
+    key = base64.urlsafe_b64encode(kdf.derive(secret_key.encode()))
+    return Fernet(key)
+
+
 def _get_fernet():
     """Derive a Fernet key from the app secret key (cached after first call).
 
@@ -25,20 +45,9 @@ def _get_fernet():
         return _fernet_instance
     from ..config import settings
 
-    if settings.encryption_salt:
-        salt = settings.encryption_salt.encode()
-    else:
+    if not settings.encryption_salt:
         logger.warning("ENCRYPTION_SALT not set — using legacy static salt. Set ENCRYPTION_SALT for defense-in-depth.")
-        salt = _LEGACY_SALT
-
-    kdf = PBKDF2HMAC(
-        algorithm=hashes.SHA256(),
-        length=32,
-        salt=salt,
-        iterations=100_000,
-    )
-    key = base64.urlsafe_b64encode(kdf.derive(settings.secret_key.encode()))
-    _fernet_instance = Fernet(key)
+    _fernet_instance = build_fernet(settings.secret_key, settings.encryption_salt)
     return _fernet_instance
 
 

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -42,7 +42,10 @@
 | last_login_at | UTCDateTime, nullable | Migration 148. Stamped on every successful OAuth callback. NULL + no azure_id ⇒ an "Invited" (pre-provisioned, never-logged-in) row. |
 | access_overrides | JSON, default `{}` | Migration 148. **Explicit per-user access overrides only**: `{access_key: bool}` keyed by `constants.AccessKey`. An *absent* key means "use the role default" (`constants.ROLE_ACCESS_DEFAULTS`) — the dict never stores the role default, so it stays empty until an admin grants/revokes a specific key. Read by `dependencies.user_has_access` (override wins over role default; admin → all). `ops_verification` is NOT stored here (it lives in `verification_group_members`). |
 | invited_by_id | FK -> users (SET NULL), nullable | Migration 148. The admin who invited this user (set by the Users-tab invite flow); SET NULL so the row survives the inviter's deletion. |
+| password_hash | EncryptedText, nullable | PBKDF2 password hash (`<salt_b64>$<hash_b64>`), encrypted at rest. Only used when password login is enabled. |
 | avatar_path | String 255, nullable | Migration 156. Stored basename of the uploaded profile photo under `avatars.AVATARS_DIR` (`/app/uploads/avatars`, e.g. `user_12_a1b2c3d4.png`); set by `POST /api/user/avatar` (own-profile only, `require_user`), served by `GET /api/user/avatar/{filename}`. NULL ⇒ the shared `user_avatar` macro renders the initials fallback. |
+
+> **`EncryptedText` columns (`refresh_token`, `access_token`, `password_hash`)** are Fernet-encrypted at rest via `app/utils/encrypted_type.py`, keyed by `SECRET_KEY` + `ENCRYPTION_SALT` (legacy static salt when unset). `SECRET_KEY`/`ENCRYPTION_SALT` are jointly load-bearing — see `STABLE.md` → *Encryption*. Rotate the salt without orphaning ciphertext via `python -m app.management.rotate_encryption_salt` (decrypt-old → re-encrypt-new, idempotent, `--dry-run`); full procedure in `docs/PRE_ROLLOUT_CHECKLIST.md` Gate 4.
 
 **`user_admin_audit`** — Append-only trail of admin actions against users (Migration 148)
 | Column | Type | Notes |

--- a/docs/PRE_ROLLOUT_CHECKLIST.md
+++ b/docs/PRE_ROLLOUT_CHECKLIST.md
@@ -154,28 +154,40 @@ If yes, renewal works via TXT records without needing the droplet reachable by h
 
 `users.refresh_token`, `users.access_token`, `users.password_hash` are `EncryptedText` columns whose Fernet key derives from `SECRET_KEY` + `ENCRYPTION_SALT` (falling back to a hard-coded legacy salt when `ENCRYPTION_SALT` is unset).
 
+> **Blast radius — API credentials share the salt.** `ENCRYPTION_SALT` *also* keys `app/services/credential_service.py`, which encrypts `api_sources.credentials` (supplier API keys). That path **degrades gracefully** — on a decrypt miss it falls back to the env-var credential and logs — so it does **not** block a salt rotation, but the DB-stored supplier keys become unreadable until re-entered (admin → Connectors) or supplied via env vars. The three `users` token/password columns do **not** degrade gracefully (orphaned tokens force re-login; an orphaned `password_hash` breaks password login), which is why the rotation command targets them. Re-enter any DB-stored supplier keys after rotating.
+
 ### Gate 4a — Decide the rotation plan NOW, not after the import
 
 Options:
 - **Keep the legacy salt fallback** (`ENCRYPTION_SALT` unset). Simplest, already works. Defense-in-depth is weaker; acceptable for small team / internal tool.
-- **Rotate to a fresh per-deployment salt** BEFORE the import, with a migration that re-encrypts the existing 3 non-null rows. After the import, you can't rotate without re-encrypting the whole `users` table plus any new encrypted columns SFDC adds.
+- **Rotate to a fresh per-deployment salt** BEFORE the import, using the rotation command below to re-encrypt the existing non-null rows. After the import, you can still rotate, but the command must cover the whole `users` table plus any new encrypted columns SFDC adds.
 
 ### Gate 4b — If keeping legacy salt
 
-Document explicitly in `STABLE.md` that `SECRET_KEY` is jointly load-bearing with the hard-coded legacy salt in `app/utils/encrypted_type.py::_LEGACY_SALT`. Changing either invalidates all encrypted rows.
+Document explicitly in `STABLE.md` that `SECRET_KEY` is jointly load-bearing with the hard-coded legacy salts in `app/utils/encrypted_type.py::_LEGACY_SALT` and `app/services/credential_service.py::_LEGACY_CREDENTIAL_SALT`. Changing either `SECRET_KEY` invalidates all encrypted rows. (Already captured in `STABLE.md` → *Encryption*.)
 
 ### Gate 4c — If rotating
 
-1. Generate: `openssl rand -base64 32`
-2. Write migration `scripts/migrate_encryption_salt.py` that:
-   - Loads all `users` rows with non-null encrypted columns.
-   - Decrypts with the legacy salt (in-memory).
-   - Sets `settings.encryption_salt` to the new value + resets `_fernet_instance`.
-   - Re-encrypts and saves.
-   - Commits.
-3. Add `ENCRYPTION_SALT=...` to `.env` **after** the migration runs.
-4. Add the new salt to the `.env` backup (Gate 2) immediately.
-5. Document in `STABLE.md` that `SECRET_KEY` + `ENCRYPTION_SALT` are jointly load-bearing.
+Use the management command **`app/management/rotate_encryption_salt.py`**. It decrypts every `users` EncryptedText cell with the OLD salt's key and re-encrypts with the NEW salt's key in one transaction. The crypto is keyed off the values you pass (**not** the live config), so you can run it before *or* after editing `.env`. It is **idempotent/resumable** (a value already on the NEW salt is detected and skipped) and **never discards** a value it can't decrypt (it reports `undecryptable` and leaves the row intact).
+
+1. **Back up first** — confirm Gate 2 (`.env`) and Gate 9 (DB snapshot). A rotation rewrites encrypted cells.
+2. **Generate the new salt:** `openssl rand -base64 32`
+3. **Dry-run** (reads + reports, writes nothing). With `.env` still on the OLD salt:
+   ```bash
+   docker compose exec -T app python -m app.management.rotate_encryption_salt \
+       --new-salt "<NEW_SALT>" --dry-run
+   ```
+   Confirm **`undecryptable=0`** for every column. If any value is undecryptable, **STOP** — the OLD salt / `SECRET_KEY` assumption is wrong; do not proceed.
+4. **Rotate for real** (same NEW salt):
+   ```bash
+   docker compose exec -T app python -m app.management.rotate_encryption_salt \
+       --new-salt "<NEW_SALT>"
+   ```
+   (The default OLD salt is the live `settings.encryption_salt`. If `.env` has already been changed to the new value, pass the previous salt explicitly with `--old-salt "<OLD_SALT>"`. `--new-salt` may also come from the `NEW_ENCRYPTION_SALT` env var.)
+5. Set **`ENCRYPTION_SALT=<NEW_SALT>`** in `.env`, then recreate the `app` + `enrichment-worker` containers so the live key matches the re-encrypted data.
+6. Add the new salt to the `.env` backup (Gate 2) and the offsite store **immediately**.
+7. **Verify** a user can still authenticate / password-login (the three columns decrypt), then re-enter any DB-stored supplier credentials (blast-radius note above).
+8. Confirm `STABLE.md` → *Encryption* still states that `SECRET_KEY` + `ENCRYPTION_SALT` are jointly load-bearing.
 
 ---
 

--- a/tests/test_rotate_encryption_salt.py
+++ b/tests/test_rotate_encryption_salt.py
@@ -1,0 +1,209 @@
+"""Tests for app/management/rotate_encryption_salt.py and the build_fernet refactor.
+
+Covers: arbitrary-salt Fernet construction, the per-value rotation state machine
+(rotated / already / undecryptable), the full DB rotation (dry-run + live),
+idempotency/resumability, and the encrypt-old -> rotate -> decrypt-new round trip
+through the ORM EncryptedText type.
+
+Called by: pytest
+Depends on: app.utils.encrypted_type, app.management.rotate_encryption_salt,
+            app.models.auth.User, app.config
+"""
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import text
+
+import app.utils.encrypted_type as et_mod
+from app.config import Settings
+from app.management.rotate_encryption_salt import (
+    ALREADY,
+    ROTATED,
+    UNDECRYPTABLE,
+    rotate_salt,
+    rotate_value,
+)
+from app.models.auth import User
+from app.utils.encrypted_type import build_fernet
+
+SECRET = "test-secret-key"
+
+
+@pytest.fixture(autouse=True)
+def _reset_fernet_cache():
+    """Reset the cached Fernet instance before and after each test."""
+    et_mod._fernet_instance = None
+    yield
+    et_mod._fernet_instance = None
+
+
+def _make_settings(**overrides):
+    defaults = dict(secret_key=SECRET, encryption_salt="", database_url="sqlite://")
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+# ── build_fernet refactor ────────────────────────────────────────────
+
+
+class TestBuildFernet:
+    def test_returns_fernet(self):
+        assert isinstance(build_fernet(SECRET, "salt-a"), Fernet)
+
+    def test_same_inputs_same_key(self):
+        a = build_fernet(SECRET, "salt-a")
+        b = build_fernet(SECRET, "salt-a")
+        assert b.decrypt(a.encrypt(b"hi")) == b"hi"
+
+    def test_different_salts_cannot_cross_decrypt(self):
+        a = build_fernet(SECRET, "salt-a")
+        b = build_fernet(SECRET, "salt-b")
+        with pytest.raises(InvalidToken):
+            b.decrypt(a.encrypt(b"secret"))
+
+    def test_empty_salt_is_legacy_fallback(self):
+        """Empty and None salt both resolve to the legacy static salt."""
+        empty = build_fernet(SECRET, "")
+        none_ = build_fernet(SECRET, None)
+        assert none_.decrypt(empty.encrypt(b"x")) == b"x"
+
+    def test_get_fernet_matches_build_fernet(self, monkeypatch):
+        """The SQLAlchemy normal path derives the same key as build_fernet."""
+        monkeypatch.setattr("app.config.settings", _make_settings(encryption_salt="live-salt"))
+        et_mod._fernet_instance = None
+        live = et_mod._get_fernet()
+        manual = build_fernet(SECRET, "live-salt")
+        assert manual.decrypt(live.encrypt(b"payload")) == b"payload"
+
+
+# ── rotate_value state machine ───────────────────────────────────────
+
+
+class TestRotateValue:
+    def setup_method(self):
+        self.old = build_fernet(SECRET, "old-salt")
+        self.new = build_fernet(SECRET, "new-salt")
+
+    def test_none_passthrough(self):
+        assert rotate_value(None, self.old, self.new) == (None, None)
+
+    def test_empty_passthrough(self):
+        assert rotate_value("", self.old, self.new) == ("", None)
+
+    def test_rotates_old_to_new(self):
+        raw = self.old.encrypt(b"my-token").decode()
+        new_raw, status = rotate_value(raw, self.old, self.new)
+        assert status == ROTATED
+        # New ciphertext decrypts with the NEW key to the original plaintext...
+        assert self.new.decrypt(new_raw.encode()) == b"my-token"
+        # ...and the OLD key can no longer decrypt it.
+        with pytest.raises(InvalidToken):
+            self.old.decrypt(new_raw.encode())
+
+    def test_already_rotated_is_noop(self):
+        raw = self.new.encrypt(b"my-token").decode()
+        new_raw, status = rotate_value(raw, self.old, self.new)
+        assert status == ALREADY
+        assert new_raw == raw
+
+    def test_undecryptable_left_intact(self):
+        new_raw, status = rotate_value("not-a-fernet-token", self.old, self.new)
+        assert status == UNDECRYPTABLE
+        assert new_raw == "not-a-fernet-token"
+
+
+# ── full DB rotation ─────────────────────────────────────────────────
+
+
+def _insert_user_under_salt(db, monkeypatch, salt, **enc):
+    """Insert a User whose EncryptedText columns are written under ``salt``.
+
+    Returns the new user id and detaches all ORM objects so later reads reload fresh
+    from the DB under whatever salt the live settings then carry.
+    """
+    monkeypatch.setattr("app.config.settings", _make_settings(encryption_salt=salt))
+    et_mod._fernet_instance = None
+    user = User(email="rot@trioscs.com", **enc)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    uid = user.id
+    db.expunge_all()
+    return uid
+
+
+class TestRotateSaltDB:
+    def test_full_rotation_roundtrip(self, db_session, monkeypatch):
+        uid = _insert_user_under_salt(
+            db_session,
+            monkeypatch,
+            "old-salt",
+            refresh_token="refresh-abc",
+            access_token="access-xyz",
+            password_hash="pw$hash",
+        )
+
+        stats = rotate_salt(db_session, old_salt="old-salt", new_salt="new-salt", secret_key=SECRET)
+        assert stats.users_scanned == 1
+        assert stats.rows_updated == 1
+        assert stats.rotated["refresh_token"] == 1
+        assert stats.rotated["access_token"] == 1
+        assert stats.rotated["password_hash"] == 1
+        assert stats.total_undecryptable == 0
+
+        # Under the NEW salt, the ORM transparently decrypts the rotated values.
+        monkeypatch.setattr("app.config.settings", _make_settings(encryption_salt="new-salt"))
+        et_mod._fernet_instance = None
+        u = db_session.get(User, uid)
+        db_session.expire(u)
+        assert u.refresh_token == "refresh-abc"
+        assert u.access_token == "access-xyz"
+        assert u.password_hash == "pw$hash"
+
+        # Under the OLD salt, the rotated ciphertext no longer decrypts (-> None).
+        monkeypatch.setattr("app.config.settings", _make_settings(encryption_salt="old-salt"))
+        et_mod._fernet_instance = None
+        db_session.expire(u)
+        assert u.refresh_token is None
+
+    def test_idempotent_second_run(self, db_session, monkeypatch):
+        _insert_user_under_salt(db_session, monkeypatch, "old-salt", refresh_token="tok")
+        rotate_salt(db_session, old_salt="old-salt", new_salt="new-salt", secret_key=SECRET)
+
+        # Second run: every value is already on the NEW salt -> detected, skipped.
+        stats = rotate_salt(db_session, old_salt="old-salt", new_salt="new-salt", secret_key=SECRET)
+        assert stats.total_rotated == 0
+        assert stats.already["refresh_token"] == 1
+        assert stats.rows_updated == 0
+
+    def test_dry_run_writes_nothing(self, db_session, monkeypatch):
+        _insert_user_under_salt(db_session, monkeypatch, "old-salt", refresh_token="tok")
+        stats = rotate_salt(db_session, old_salt="old-salt", new_salt="new-salt", secret_key=SECRET, dry_run=True)
+        assert stats.rotated["refresh_token"] == 1
+        assert stats.rows_updated == 1  # would-update count
+
+        # The DB still holds OLD-salt ciphertext: decrypts under OLD, not NEW.
+        raw = db_session.execute(text("SELECT refresh_token FROM users")).scalar_one()
+        assert build_fernet(SECRET, "old-salt").decrypt(raw.encode()) == b"tok"
+        with pytest.raises(InvalidToken):
+            build_fernet(SECRET, "new-salt").decrypt(raw.encode())
+
+    def test_undecryptable_row_left_intact(self, db_session, monkeypatch):
+        # Encrypt under a salt that is neither OLD nor NEW.
+        _insert_user_under_salt(db_session, monkeypatch, "mystery-salt", refresh_token="tok")
+        stats = rotate_salt(db_session, old_salt="old-salt", new_salt="new-salt", secret_key=SECRET)
+        assert stats.undecryptable["refresh_token"] == 1
+        assert stats.total_rotated == 0
+        assert stats.rows_updated == 0
+
+        # Row is untouched: still decrypts under the original mystery salt.
+        raw = db_session.execute(text("SELECT refresh_token FROM users")).scalar_one()
+        assert build_fernet(SECRET, "mystery-salt").decrypt(raw.encode()) == b"tok"
+
+    def test_equal_salts_refused(self, db_session):
+        with pytest.raises(ValueError, match="nothing to rotate"):
+            rotate_salt(db_session, old_salt="same", new_salt="same", secret_key=SECRET)
+
+    def test_both_empty_salts_refused(self, db_session):
+        with pytest.raises(ValueError, match="nothing to rotate"):
+            rotate_salt(db_session, old_salt=None, new_salt="", secret_key=SECRET)


### PR DESCRIPTION
## What & why

`app/utils/encrypted_type.py` derives a Fernet key from `SECRET_KEY` + `ENCRYPTION_SALT` (falling back to a hard-coded legacy salt when unset). There was **no way to rotate the salt** without orphaning the 3 `EncryptedText` columns on `users` — `refresh_token`, `access_token`, `password_hash`. Changing the salt made every existing ciphertext undecryptable (forced re-login; broken password login). This closes **PRE_ROLLOUT Gate 4** by shipping a safe, idempotent rotation command.

The command is the deliverable — actually **running** a rotation is the operator's call.

## Changes

- **`app/utils/encrypted_type.py` (minimal refactor):** extract `build_fernet(secret_key, salt)` as the single key-derivation point. `_get_fernet()` now delegates to it; the SQLAlchemy type's normal path (instance cache, legacy fallback, unset-salt warning) is behaviorally unchanged.
- **`app/management/rotate_encryption_salt.py` (new):**
  - Reads **OLD** salt (default = live `settings.encryption_salt`; override with `--old-salt`) and **NEW** salt (`--new-salt` or `NEW_ENCRYPTION_SALT`).
  - Decrypts every `users` EncryptedText cell with the OLD key and re-encrypts with the NEW key **in one transaction**.
  - Crypto is keyed off the **passed values, not the live config**, so it runs before *or* after `.env` is edited. Reads/writes columns as **raw text via Core SQL**, deliberately bypassing the `EncryptedText` TypeDecorator so the live key can't interfere.
  - **Idempotent / resumable:** a value already on the NEW salt decrypts with NEW (not OLD) and is reported as `already` / skipped. **Never discards** a value it can't decrypt (reports `undecryptable`, leaves the row intact). **Refuses a no-op** (OLD == NEW).
  - `--dry-run` reports without writing; prints a fingerprinted (never raw) before/after summary + per-column `rotated`/`already`/`undecryptable` counts.
- **Docs:** rewrote `PRE_ROLLOUT_CHECKLIST.md` Gate 4c around the real command (dry-run-first procedure) and added the **shared-salt blast radius** note (`ENCRYPTION_SALT` also keys `credential_service.py` → `api_sources.credentials`, which degrades gracefully via env-var fallback). Added an *Encryption* section to `STABLE.md` and documented the EncryptedText columns + rotation in `APP_MAP_DATABASE.md`.

## Scope note

Targets the 3 `users` columns (per task). API-credential ciphertext shares the salt but degrades gracefully (env-var fallback on a decrypt miss), so it does not block rotation — documented in Gate 4 with a re-entry step. No band-aid: the user-token columns are the ones that fail hard, which is exactly what this rotates.

## Tests (TDD)

`tests/test_rotate_encryption_salt.py` (16 tests): `build_fernet` arbitrary-salt key isolation + legacy fallback; the per-value state machine (`rotated`/`already`/`undecryptable`/passthrough); and the full DB rotation — **round trip** (encrypt-old → rotate → decrypt-new works; OLD key no longer decrypts via the ORM), idempotent second run, dry-run-writes-nothing, undecryptable-row-left-intact, and equal/both-empty-salt refusal.

## Constraints honored

- **No migration** — alembic head stays `170_prospecting_persistence`.
- Did not touch any of the concurrent-work files.
- `pre-commit run --all-files` clean (ruff, ruff-format, docformatter, mypy). Existing `test_encrypted_type` / `test_security_fixes` / auth + password-guard suites still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)