### PR TITLE
fix(prospecting): rewire Explorium discovery off unverified /businesses/search

### DIFF
--- a/app/connectors/explorium.py
+++ b/app/connectors/explorium.py
@@ -54,6 +54,28 @@ async def _post(path: str, api_key: str, body: dict):
     return resp
 
 
+async def discover_businesses(filters: dict, size: int, api_key: str) -> list[dict]:
+    """Discover businesses matching ICP filters via Explorium's documented Fetch
+    Businesses endpoint (``POST /v1/businesses``).
+
+    Uses the same verified machinery as ``enrich_company`` / ``search_contacts``: the
+    ``api_key`` header, a ``{"filters": {...}, "size": N}`` request body, and a ``data``
+    array response. 402/403/429 → ProviderQuotaError (propagated to the caller).
+    Transport/parse errors → ``[]``. No results → ``[]``.
+    """
+    try:
+        resp = await _post(
+            "/businesses",
+            api_key,
+            {"mode": "full", "size": size, "filters": filters},
+        )
+        rows = (resp.json().get("data") if resp else None) or []
+        return rows if isinstance(rows, list) else []
+    except (httpx.HTTPError, KeyError, ValueError) as e:
+        logger.warning("Explorium discover_businesses error: {}", e)
+        return []
+
+
 async def _match_business_id(domain: str, name: str, api_key: str) -> str | None:
     """Call /businesses/match and return the first matched business_id, or None."""
     resp = await _post(

--- a/app/services/prospect_discovery_explorium.py
+++ b/app/services/prospect_discovery_explorium.py
@@ -1,7 +1,13 @@
 """Explorium/Vibe Prospecting discovery service — primary discovery source.
 
-Finds companies matching ICP segments with firmographics + intent/hiring/event signals
-in a single API call. Normalizes results into ProspectAccountCreate schemas.
+Finds companies matching ICP segments (firmographics) and normalizes any
+intent/hiring/event signals present on each record into ProspectAccountCreate schemas.
+
+Discovery routes through the verified connector — ``app.connectors.explorium``
+``discover_businesses()`` calls the documented ``POST /v1/businesses`` Fetch endpoint
+(``api_key`` header, ``{"filters": {...}, "size": N}`` body, ``data`` array response) —
+the same machinery that powers the CRM enrichment path. (The previous bulk
+``/v1/businesses/search`` endpoint was never a real Explorium route.)
 
 For point-enrichment of a known domain (not discovery), use app.connectors.explorium
 directly: explorium.enrich_company(domain, name, api_key) /
@@ -13,14 +19,18 @@ import asyncio
 from loguru import logger
 
 from app.config import settings
-from app.http_client import http
+from app.connectors import explorium
 from app.schemas.prospect_account import ProspectAccountCreate
 from app.services.prospect_scoring import (
     calculate_fit_score,
     calculate_readiness_score,
 )
 
+# Kept for backward-compatible imports (app.services.prospect_signals reads these).
 EXPLORIUM_BASE = getattr(settings, "explorium_api_base_url", "https://api.explorium.ai")
+
+# How many businesses to request per ICP-segment x region Fetch call.
+DISCOVERY_PAGE_SIZE = 50
 
 # ── Segment search definitions ───────────────────────────────────────
 
@@ -86,9 +96,13 @@ def _get_api_key() -> str:
 
 
 async def discover_companies_with_signals(segment_key: str, region_key: str) -> list[dict]:
-    """Call Explorium API to find companies matching an ICP segment + region.
+    """Find companies matching an ICP segment + region via the verified connector.
 
-    Returns raw normalized dicts with company data + signal data combined.
+    Builds an Explorium business-filter envelope and routes through
+    ``app.connectors.explorium.discover_businesses`` (documented ``POST /v1/businesses``
+    Fetch endpoint). Returns normalized dicts (firmographics + any signals present on the
+    record). Returns ``[]`` when the key is missing, the segment is unknown, or the API
+    errors out (including quota / ProviderQuotaError).
     """
     api_key = _get_api_key()
     if not api_key:
@@ -102,44 +116,18 @@ async def discover_companies_with_signals(segment_key: str, region_key: str) -> 
 
     country_codes = REGIONS.get(region_key, ["US"])
 
-    payload = {
-        "linkedin_categories": seg["linkedin_categories"],
-        "naics_codes": seg["naics_codes"],
-        "company_size": SIZE_RANGES,
-        "company_country_code": country_codes,
-        "business_intent_topics": SHARED_INTENT_TOPICS + seg["intent_keywords"],
-        "limit": 50,
+    # Explorium business-filter envelope: each filter is `{"values": [...]}` (the same
+    # request shape the verified /prospects search uses). ICP intent keywords are NOT a
+    # documented business filter — intent is read back off each record in normalization.
+    filters = {
+        "linkedin_category": {"values": seg["linkedin_categories"]},
+        "naics_category": {"values": seg["naics_codes"]},
+        "company_size": {"values": SIZE_RANGES},
+        "country_code": {"values": [c.lower() for c in country_codes]},
     }
 
     try:
-        # Use same header format as app.connectors.explorium (api_key: not Authorization: Bearer)
-        # NOTE: This /v1/businesses/search bulk-discovery endpoint is unverified against the
-        # current Explorium API and should be rewired to the documented /v1/businesses fetch
-        # in a follow-up (out of scope for the current prospecting feature).
-        resp = await http.post(
-            f"{EXPLORIUM_BASE}/v1/businesses/search",
-            json=payload,
-            headers={
-                "Content-Type": "application/json",
-                "api_key": api_key,
-            },
-            timeout=60,
-        )
-
-        if resp.status_code != 200:
-            logger.warning(
-                "Explorium search failed for {}/{}: {} {}",
-                segment_key,
-                region_key,
-                resp.status_code,
-                resp.text[:200],
-            )
-            return []
-
-        data = resp.json()
-        businesses = data.get("businesses", data.get("results", []))
-        if not isinstance(businesses, list):
-            businesses = []
+        businesses = await explorium.discover_businesses(filters, DISCOVERY_PAGE_SIZE, api_key)
 
         logger.info(
             "Explorium {}/{}: {} raw results",
@@ -151,7 +139,7 @@ async def discover_companies_with_signals(segment_key: str, region_key: str) -> 
         return [normalize_explorium_result(b, segment_key) for b in businesses]
 
     except Exception as e:
-        logger.error("Explorium API error for {}/{}: {}", segment_key, region_key, e)
+        logger.error("Explorium discovery error for {}/{}: {}", segment_key, region_key, e)
         return []
 
 
@@ -160,7 +148,11 @@ def normalize_explorium_result(raw: dict, segment_key: str) -> dict:
 
     Extracts firmographics + signals into a unified dict ready for scoring.
     """
-    domain = (raw.get("domain") or raw.get("website_domain") or "").strip().lower()
+    domain = (
+        (raw.get("domain") or raw.get("website_domain") or _domain_from_website(raw.get("website")) or "")
+        .strip()
+        .lower()
+    )
     if domain.startswith("www."):
         domain = domain[4:]
 
@@ -169,10 +161,12 @@ def normalize_explorium_result(raw: dict, segment_key: str) -> dict:
         "name": raw.get("company_name") or raw.get("name") or "",
         "domain": domain,
         "website": raw.get("website") or raw.get("website_url"),
-        "industry": raw.get("industry") or raw.get("linkedin_industry"),
-        "naics_code": raw.get("naics_code") or raw.get("primary_naics_code"),
+        "industry": raw.get("industry") or raw.get("linkedin_industry") or raw.get("linkedin_industry_category"),
+        "naics_code": raw.get("naics_code") or raw.get("primary_naics_code") or raw.get("naics"),
         "employee_count_range": _normalize_size(raw),
-        "revenue_range": raw.get("annual_revenue") or raw.get("revenue_range"),
+        "revenue_range": (
+            raw.get("annual_revenue") or raw.get("revenue_range") or _fmt_band(raw.get("yearly_revenue_range"))
+        ),
         "hq_location": _build_location(raw),
         "region": _detect_region(raw),
         "description": raw.get("description") or raw.get("short_description"),
@@ -260,6 +254,26 @@ def normalize_explorium_result(raw: dict, segment_key: str) -> dict:
     return result
 
 
+def _domain_from_website(website: str | None) -> str:
+    """Derive a bare domain from a website URL (strips scheme + path)."""
+    if not website:
+        return ""
+    return website.replace("https://", "").replace("http://", "").split("/")[0]
+
+
+def _fmt_band(obj) -> str | None:
+    """Format a {min, max} range dict as 'min-max', 'min+', or 'max'."""
+    if isinstance(obj, dict):
+        lo, hi = obj.get("min"), obj.get("max")
+        if lo is not None and hi is not None:
+            return f"{lo}-{hi}"
+        if lo is not None:
+            return f"{lo}+"
+        if hi is not None:
+            return str(hi)
+    return None
+
+
 def _normalize_size(raw: dict) -> str | None:
     """Extract employee count range from various Explorium fields."""
     size = raw.get("company_size") or raw.get("employee_count") or raw.get("estimated_num_employees")
@@ -281,15 +295,16 @@ def _normalize_size(raw: dict) -> str | None:
             return "5001-10000"
         else:
             return "10001+"
-    return None
+    # Real /v1/businesses Fetch records carry a {min, max} range dict.
+    return _fmt_band(raw.get("number_of_employees_range"))
 
 
 def _build_location(raw: dict) -> str | None:
     """Build location string from city/state/country fields."""
     parts = [
-        raw.get("city") or raw.get("hq_city"),
-        raw.get("state") or raw.get("hq_state"),
-        raw.get("country") or raw.get("hq_country") or raw.get("country_code"),
+        raw.get("city") or raw.get("hq_city") or raw.get("city_name"),
+        raw.get("state") or raw.get("hq_state") or raw.get("region_name"),
+        raw.get("country") or raw.get("hq_country") or raw.get("country_code") or raw.get("country_name"),
     ]
     location = ", ".join(filter(None, parts))
     return location or None
@@ -301,7 +316,7 @@ def _detect_region(raw: dict) -> str | None:
     The Explorium connector emits the human-readable ``hq_country`` name (e.g. "Germany"),
     while the discovery search API supplies ``country_code`` — so match on both.
     """
-    cc = (raw.get("country_code") or raw.get("hq_country") or "").upper()
+    cc = (raw.get("country_code") or raw.get("hq_country") or raw.get("country_name") or "").upper()
     if cc in ("US", "USA", "UNITED STATES"):
         return "US"
     _EU = (

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2677,8 +2677,15 @@ scheduler. Contact discovery degrades gracefully: a provider failure renders an 
 
 - `app/connectors/explorium.py` — 2-call pipeline: `/businesses/match` → business_id,
   then `/businesses/firmographics/enrich`; contacts via `/prospects` +
-  `/prospects/contacts_information/enrich`. Auth: `api_key:` header (NOT
+  `/prospects/contacts_information/enrich`. ICP discovery via `discover_businesses()` →
+  `/businesses` Fetch endpoint (`{"filters": {...}, "size": N}` body, `data` array
+  response — same shape as the `/prospects` search). Auth: `api_key:` header (NOT
   `Authorization: Bearer`). 402/403/429 → `ProviderQuotaError`.
+  - `app/services/prospect_discovery_explorium.py` (prospecting discovery) routes through
+    `explorium.discover_businesses()` and normalizes each business into a scoring-ready
+    dict. It previously hit an unverified `/v1/businesses/search` bulk route — now retired.
+    (Note: `app/services/prospect_signals.py` signal-backfill still calls the old
+    `/v1/businesses/search` with a `Bearer` header — a separate follow-up.)
 - `app/connectors/clay_mcp.py` — backend MCP client (JSON-RPC 2.0 over HTTPS to
   `https://api.clay.com/v3/mcp`). Clay speaks **MCP Streamable HTTP**: every
   `tools/call` requires a session, so the connector first runs the handshake

--- a/tests/test_explorium_connector.py
+++ b/tests/test_explorium_connector.py
@@ -325,3 +325,90 @@ async def test_search_contacts_drops_prospect_with_no_name(monkeypatch):
 
     assert len(contacts) == 1
     assert contacts[0]["full_name"] == "Bob Smith"
+
+
+# ── discover_businesses (Fetch Businesses /v1/businesses) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_discover_businesses_posts_filters_and_parses_data(monkeypatch):
+    """Discovery hits the documented POST /v1/businesses Fetch endpoint with the
+    verified `api_key` header + `{filters, size}` body, and parses the `data` array."""
+    from app.connectors import explorium
+
+    calls = []
+
+    async def fake_post(url, **k):
+        calls.append((url, k.get("headers", {}), k.get("json")))
+        return Resp(200, {"total_results": 2, "data": [{"name": "Arrow"}, {"name": "Avnet"}]})
+
+    monkeypatch.setattr(explorium.http, "post", fake_post, raising=False)
+    filters = {"country_code": {"values": ["us"]}}
+    rows = await explorium.discover_businesses(filters, 50, "K")
+
+    url, headers, body = calls[0]
+    assert url.endswith("/businesses")  # NOT /businesses/search
+    assert headers["api_key"] == "K"
+    assert "Authorization" not in headers
+    assert body["filters"] == filters
+    assert body["size"] == 50
+    assert [r["name"] for r in rows] == ["Arrow", "Avnet"]
+
+
+@pytest.mark.asyncio
+async def test_discover_businesses_empty_data(monkeypatch):
+    from app.connectors import explorium
+
+    async def fake_post(url, **k):
+        return Resp(200, {"data": []})
+
+    monkeypatch.setattr(explorium.http, "post", fake_post, raising=False)
+    assert await explorium.discover_businesses({}, 50, "K") == []
+
+
+@pytest.mark.asyncio
+async def test_discover_businesses_data_not_list(monkeypatch):
+    from app.connectors import explorium
+
+    async def fake_post(url, **k):
+        return Resp(200, {"data": "oops"})
+
+    monkeypatch.setattr(explorium.http, "post", fake_post, raising=False)
+    assert await explorium.discover_businesses({}, 50, "K") == []
+
+
+@pytest.mark.asyncio
+async def test_discover_businesses_non_200_returns_empty(monkeypatch):
+    from app.connectors import explorium
+
+    async def fake_post(url, **k):
+        return Resp(500, {})
+
+    monkeypatch.setattr(explorium.http, "post", fake_post, raising=False)
+    assert await explorium.discover_businesses({}, 50, "K") == []
+
+
+@pytest.mark.asyncio
+async def test_discover_businesses_quota_raises(monkeypatch):
+    """402/403/429 propagate as ProviderQuotaError (not swallowed)."""
+    from app.connectors import explorium
+
+    async def fake_post(url, **k):
+        return Resp(429, {})
+
+    monkeypatch.setattr(explorium.http, "post", fake_post, raising=False)
+    with pytest.raises(ProviderQuotaError):
+        await explorium.discover_businesses({}, 50, "K")
+
+
+@pytest.mark.asyncio
+async def test_discover_businesses_transport_error_returns_empty(monkeypatch):
+    import httpx
+
+    from app.connectors import explorium
+
+    async def fake_post(url, **k):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(explorium.http, "post", fake_post, raising=False)
+    assert await explorium.discover_businesses({}, 50, "K") == []

--- a/tests/test_services/test_prospect_discovery.py
+++ b/tests/test_services/test_prospect_discovery.py
@@ -10,7 +10,7 @@ os.environ["TESTING"] = "1"
 os.environ["RATE_LIMIT_ENABLED"] = "false"
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.orm import Session
@@ -55,17 +55,6 @@ EXPLORIUM_NO_DOMAIN = {
     "company_name": "Ghost Corp",
     "industry": "Unknown",
 }
-
-
-def _mock_response(status_code, *, json_body=None, text=None):
-    """Build a MagicMock httpx-style response for Explorium API patches."""
-    mock_resp = MagicMock()
-    mock_resp.status_code = status_code
-    if json_body is not None:
-        mock_resp.json.return_value = json_body
-    if text is not None:
-        mock_resp.text = text
-    return mock_resp
 
 
 # ── Explorium Tests ──────────────────────────────────────────────────
@@ -137,6 +126,33 @@ class TestExploriumNormalization:
         result = normalize_explorium_result(raw, "ems_electronics")
         assert result["employee_count_range"] == "1001-5000"
 
+    def test_real_fetch_businesses_record(self):
+        """Real POST /v1/businesses Fetch record field names map correctly."""
+        from app.services.prospect_discovery_explorium import normalize_explorium_result
+
+        raw = {
+            "business_id": "abc123",
+            "name": "Avnet",
+            "website": "https://www.avnet.com/",
+            "linkedin_industry_category": "Electronics",
+            "naics": "423690",
+            "number_of_employees_range": {"min": 5001, "max": 10000},
+            "yearly_revenue_range": {"min": 1_000_000_000},
+            "city_name": "Phoenix",
+            "region_name": "Arizona",
+            "country_name": "United States",
+        }
+        result = normalize_explorium_result(raw, "ems_electronics")
+
+        assert result["name"] == "Avnet"
+        assert result["domain"] == "avnet.com"  # derived from website, www. stripped
+        assert result["industry"] == "Electronics"
+        assert result["naics_code"] == "423690"
+        assert result["employee_count_range"] == "5001-10000"
+        assert result["revenue_range"] == "1000000000+"
+        assert result["hq_location"] == "Phoenix, Arizona, United States"
+        assert result["region"] == "US"
+
     def test_string_events(self):
         """Events as strings instead of dicts."""
         from app.services.prospect_discovery_explorium import normalize_explorium_result
@@ -185,25 +201,53 @@ class TestExploriumDiscovery:
     async def test_successful_search(self):
         from app.services.prospect_discovery_explorium import discover_companies_with_signals
 
-        mock_resp = _mock_response(200, json_body={"businesses": [EXPLORIUM_RAW_RESULT]})
-
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
-            with patch("app.services.prospect_discovery_explorium.http") as mock_http:
-                mock_http.post = AsyncMock(return_value=mock_resp)
+            with patch(
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[EXPLORIUM_RAW_RESULT],
+            ):
                 results = await discover_companies_with_signals("aerospace_defense", "US")
 
         assert len(results) == 1
         assert results[0]["domain"] == "raytheon-sensors.com"
 
     @pytest.mark.asyncio
+    async def test_routes_through_verified_businesses_fetch(self):
+        """Discovery builds the Explorium business-filter envelope and calls the
+        verified connector (POST /v1/businesses) — NOT the unverified /businesses/search
+        bulk route."""
+        from app.services.prospect_discovery_explorium import (
+            DISCOVERY_PAGE_SIZE,
+            discover_companies_with_signals,
+        )
+
+        mock_discover = AsyncMock(return_value=[])
+        with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
+            with patch(
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                mock_discover,
+            ):
+                await discover_companies_with_signals("aerospace_defense", "EU")
+
+        filters, size, api_key = mock_discover.call_args.args
+        assert api_key == "key"
+        assert size == DISCOVERY_PAGE_SIZE
+        assert "linkedin_category" in filters and "values" in filters["linkedin_category"]
+        assert filters["naics_category"]["values"] == ["336412", "336413"]
+        assert filters["country_code"]["values"] == ["de", "gb", "fr", "nl", "se"]  # lowercased
+
+    @pytest.mark.asyncio
     async def test_api_error_returns_empty(self):
         from app.services.prospect_discovery_explorium import discover_companies_with_signals
 
-        mock_resp = _mock_response(500, text="Internal Server Error")
-
+        # Connector degrades non-200 to [] internally → discovery sees an empty list.
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
-            with patch("app.services.prospect_discovery_explorium.http") as mock_http:
-                mock_http.post = AsyncMock(return_value=mock_resp)
+            with patch(
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[],
+            ):
                 results = await discover_companies_with_signals("aerospace_defense", "US")
 
         assert results == []
@@ -213,8 +257,11 @@ class TestExploriumDiscovery:
         from app.services.prospect_discovery_explorium import discover_companies_with_signals
 
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
-            with patch("app.services.prospect_discovery_explorium.http") as mock_http:
-                mock_http.post = AsyncMock(side_effect=Exception("timeout"))
+            with patch(
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                side_effect=Exception("timeout"),
+            ):
                 results = await discover_companies_with_signals("aerospace_defense", "US")
 
         assert results == []
@@ -228,14 +275,16 @@ class TestExploriumBatch:
     async def test_dedup_existing_domains(self):
         from app.services.prospect_discovery_explorium import run_explorium_discovery_batch
 
-        mock_resp = _mock_response(200, json_body={"businesses": [EXPLORIUM_RAW_RESULT]})
-
         existing = {"raytheon-sensors.com"}  # already in pool
 
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
-            with patch("app.services.prospect_discovery_explorium.http") as mock_http:
-                mock_http.post = AsyncMock(return_value=mock_resp)
-                results = await run_explorium_discovery_batch("test-batch", existing)
+            with patch(
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[EXPLORIUM_RAW_RESULT],
+            ):
+                with patch("asyncio.sleep", new_callable=AsyncMock):
+                    results = await run_explorium_discovery_batch("test-batch", existing)
 
         assert len(results) == 0  # deduped away
 
@@ -252,11 +301,12 @@ class TestExploriumBatch:
     async def test_batch_returns_prospect_creates(self):
         from app.services.prospect_discovery_explorium import run_explorium_discovery_batch
 
-        mock_resp = _mock_response(200, json_body={"businesses": [EXPLORIUM_RAW_RESULT]})
-
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
-            with patch("app.services.prospect_discovery_explorium.http") as mock_http:
-                mock_http.post = AsyncMock(return_value=mock_resp)
+            with patch(
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[EXPLORIUM_RAW_RESULT],
+            ):
                 with patch("asyncio.sleep", new_callable=AsyncMock):
                     results = await run_explorium_discovery_batch("test-batch", set())
 
@@ -466,12 +516,12 @@ class TestDedupLogic:
         """Same domain from multiple segment searches is deduped."""
         from app.services.prospect_discovery_explorium import run_explorium_discovery_batch
 
-        # Same company appears in every search
-        mock_resp = _mock_response(200, json_body={"businesses": [EXPLORIUM_RAW_RESULT]})
-
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
-            with patch("app.services.prospect_discovery_explorium.http") as mock_http:
-                mock_http.post = AsyncMock(return_value=mock_resp)
+            with patch(
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[EXPLORIUM_RAW_RESULT],  # same company in every search
+            ):
                 with patch("asyncio.sleep", new_callable=AsyncMock):
                     results = await run_explorium_discovery_batch("dedup-batch", set())
 
@@ -491,8 +541,11 @@ class TestGracefulDegradation:
         from app.services.prospect_discovery_explorium import run_explorium_discovery_batch
 
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
-            with patch("app.services.prospect_discovery_explorium.http") as mock_http:
-                mock_http.post = AsyncMock(side_effect=Exception("Connection refused"))
+            with patch(
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                side_effect=Exception("Connection refused"),
+            ):
                 with patch("asyncio.sleep", new_callable=AsyncMock):
                     results = await run_explorium_discovery_batch("fail-batch", set())
 
@@ -525,16 +578,17 @@ class TestExploriumCoverageGaps:
             result = _get_api_key()
         assert result == ""
 
-    def test_businesses_not_list(self):
-        """Line 133: businesses is not a list, gets reset to []."""
+    def test_empty_discovery_returns_empty(self):
+        """Connector returns [] (e.g. non-list/empty data) → discovery yields []."""
         from app.services.prospect_discovery_explorium import discover_companies_with_signals
-
-        mock_resp = _mock_response(200, json_body={"businesses": "not-a-list"})
 
         async def run():
             with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
-                with patch("app.services.prospect_discovery_explorium.http") as mock_http:
-                    mock_http.post = AsyncMock(return_value=mock_resp)
+                with patch(
+                    "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                    new_callable=AsyncMock,
+                    return_value=[],
+                ):
                     return await discover_companies_with_signals("aerospace_defense", "US")
 
         results = asyncio.get_event_loop().run_until_complete(run())
@@ -616,11 +670,12 @@ class TestExploriumCoverageGaps:
             "industry": "Unknown",
         }
 
-        mock_resp = _mock_response(200, json_body={"businesses": [no_domain_result]})
-
         with patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"):
-            with patch("app.services.prospect_discovery_explorium.http") as mock_http:
-                mock_http.post = AsyncMock(return_value=mock_resp)
+            with patch(
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[no_domain_result],
+            ):
                 with patch("asyncio.sleep", new_callable=AsyncMock):
                     results = await run_explorium_discovery_batch("test-batch", set())
 

--- a/tests/test_services_coverage_3.py
+++ b/tests/test_services_coverage_3.py
@@ -221,13 +221,13 @@ class TestDiscoverCompaniesWithSignals:
 
     @pytest.mark.asyncio
     async def test_api_error(self):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 500
-        mock_resp.text = "Internal Server Error"
+        # Connector degrades transport/HTTP errors to [] → discovery yields [].
         with (
             patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"),
             patch(
-                "app.services.prospect_discovery_explorium.http.post", new_callable=AsyncMock, return_value=mock_resp
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[],
             ),
         ):
             result = await discover_companies_with_signals("aerospace_defense", "US")
@@ -235,15 +235,12 @@ class TestDiscoverCompaniesWithSignals:
 
     @pytest.mark.asyncio
     async def test_successful_discovery(self):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {
-            "businesses": [{"company_name": "Test Corp", "domain": "test.com", "country_code": "US"}]
-        }
         with (
             patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"),
             patch(
-                "app.services.prospect_discovery_explorium.http.post", new_callable=AsyncMock, return_value=mock_resp
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[{"company_name": "Test Corp", "domain": "test.com", "country_code": "US"}],
             ),
         ):
             result = await discover_companies_with_signals("aerospace_defense", "US")
@@ -255,7 +252,7 @@ class TestDiscoverCompaniesWithSignals:
         with (
             patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"),
             patch(
-                "app.services.prospect_discovery_explorium.http.post",
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
                 new_callable=AsyncMock,
                 side_effect=Exception("timeout"),
             ),
@@ -274,18 +271,15 @@ class TestRunExploriumDiscoveryBatch:
     @pytest.mark.asyncio
     async def test_dedup_known_domains(self):
         """Domains in existing_domains should be skipped."""
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {
-            "businesses": [
-                {"company_name": "Known Co", "domain": "known.com", "country_code": "US"},
-                {"company_name": "New Co", "domain": "new.com", "country_code": "US"},
-            ]
-        }
         with (
             patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"),
             patch(
-                "app.services.prospect_discovery_explorium.http.post", new_callable=AsyncMock, return_value=mock_resp
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"company_name": "Known Co", "domain": "known.com", "country_code": "US"},
+                    {"company_name": "New Co", "domain": "new.com", "country_code": "US"},
+                ],
             ),
             patch("app.services.prospect_discovery_explorium.calculate_fit_score", return_value=(70, "Good fit")),
             patch("app.services.prospect_discovery_explorium.calculate_readiness_score", return_value=(50, {})),
@@ -298,13 +292,12 @@ class TestRunExploriumDiscoveryBatch:
 
     @pytest.mark.asyncio
     async def test_skips_empty_domains(self):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"businesses": [{"company_name": "No Domain", "domain": ""}]}
         with (
             patch("app.services.prospect_discovery_explorium._get_api_key", return_value="key"),
             patch(
-                "app.services.prospect_discovery_explorium.http.post", new_callable=AsyncMock, return_value=mock_resp
+                "app.services.prospect_discovery_explorium.explorium.discover_businesses",
+                new_callable=AsyncMock,
+                return_value=[{"company_name": "No Domain", "domain": ""}],
             ),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):


### PR DESCRIPTION
## What

The prospecting discovery path (`app/services/prospect_discovery_explorium.py`) called an **unverified** `/v1/businesses/search` bulk endpoint with a flat payload and a `businesses`/`results` response shape that was never a real Explorium route — previously only the auth header had been corrected. This rewires it to the **verified** Explorium client pattern.

## Verified pattern it now uses

Added `app.connectors.explorium.discover_businesses()`, which POSTs the documented **`/v1/businesses` Fetch endpoint** using the *same machinery the CRM enrichment path already proves* (`enrich_company` / `search_contacts`):

- `api_key:` header (NOT `Authorization: Bearer`)
- `{"filters": {...}, "size": N}` request body — the exact shape of the verified `/prospects` search
- `data` array response parsing
- `402/403/429 → ProviderQuotaError` (propagated); transport/parse errors → `[]`

`discover_companies_with_signals()` now builds the business-filter envelope (`linkedin_category` / `naics_category` / `company_size` / `country_code`, lowercased) and routes through the connector. `normalize_explorium_result()` gains **additive** fallbacks for the real Fetch field names (`linkedin_industry_category`, `naics`, `number_of_employees_range`, `yearly_revenue_range`, `city_name`/`region_name`/`country_name`, website-derived domain).

## Behavior preserved

Still discovers prospect businesses per ICP segment × region, dedups, scores, and returns `ProspectAccountCreate` rows; empty/error → `[]`. Shared constants (`EXPLORIUM_BASE`, `SHARED_INTENT_TOPICS`) kept for backward-compatible imports.

## Out of scope (follow-up)

`app/services/prospect_signals.py` signal-backfill still calls the same `/v1/businesses/search` route **with a `Bearer` header** (same Wave-5 defect, different file). Flagged in `docs/APP_MAP_INTERACTIONS.md` for a separate PR — the verified `enrich_company` returns firmographics only, so a verified *signals* path needs its own design.

## Tests (TDD)

- **Connector** (`tests/test_explorium_connector.py`): endpoint URL is `/businesses` not `/businesses/search`, `api_key` header, `filters`/`size` body, `data` parsing, empty, non-list data, 500, 429→`ProviderQuotaError`, transport error → `[]`.
- **Service** (`tests/test_services/test_prospect_discovery.py`): routes through verified fetch with lowercased `country_code` filters, real Fetch-record normalization, dedup, graceful degradation. Existing `http`-mock tests updated to mock the verified connector.

No migration (alembic head stays `170_prospecting_persistence`). `pre-commit run --all-files`-scope hooks pass; 285 targeted tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)