### PR TITLE
chore(config): turn MVP mode off (default mvp_mode=False, full surface)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -326,9 +326,14 @@ class Settings(BaseSettings):
     acs_callback_url: str = ""
 
     # --- MVP Mode ---
-    # When True, disables: Dashboard/Analytics, Enrichment, Teams, Task Manager
-    # Set MVP_MODE=false in .env to re-enable all features
-    mvp_mode: bool = True
+    # Now gates ONLY the Teams chat integration: the POST /api/webhooks/teams endpoint
+    # (returns 404 when True) and Graph Teams-chat subscription creation in
+    # ensure_all_users_subscribed. Dashboard/Analytics, Enrichment, and Task Manager were
+    # un-gated by the module consolidation and are always-on regardless of this flag.
+    # Default is False ("no MVP" — full surface incl. Teams; Teams subscription creation
+    # degrades gracefully if the public webhook callback isn't configured yet).
+    # Set MVP_MODE=true in .env only to suppress the Teams integration.
+    mvp_mode: bool = False
 
     # --- On-demand enrichment orchestrator ---
     on_demand_enrichment_enabled: bool = True


### PR DESCRIPTION
Per user directive ('mvp mode off' / no-MVP). 

**What this actually does:** `mvp_mode` now gates ONLY the Teams chat integration (the `POST /api/webhooks/teams` endpoint, which returns 404 when True, and Graph Teams-chat subscription creation in `ensure_all_users_subscribed`). Dashboard/Analytics, Enrichment, and Task Manager were un-gated by the module-consolidation work and are already always-on regardless of this flag — the old comment claiming otherwise was stale and is corrected.

**Safety:** `create_teams_subscription` already wraps the Graph POST in try/except (logs + returns None), so enabling Teams before the public webhook callback / Graph Teams permissions are in place is harmless — no 500, mail subscriptions unaffected. Teams becomes functional once that infra lands.

**Verification:** full suite 21,242 passed / 0 failed; the 4 mvp_mode-gated test files (136 tests) pass — they set `mvp_mode` explicitly per-case so they're unaffected by the default flip.

**⚠️ Deployment note:** if the prod/staging `.env` pins `MVP_MODE=true`, that env value overrides this default — remove/flip that line for the change to take effect in prod (I can't edit `.env`).