### PR TITLE
hardening(devops): fix alembic downgrade chain + nightly migration CI + backup stdin/SSE hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,12 @@ REDIS_URL=redis://redis:6379/0
 # ── Backups ──
 BACKUP_INTERVAL_HOURS=6          # How often to run pg_dump (hours)
 BACKUP_RETENTION_DAYS=30         # How long to keep local backups (days)
+# Optional gpg symmetric passphrase. When set, local backups are encrypted at
+# rest (AES256; the passphrase is fed via stdin so it never appears in argv/ps)
+# and the plaintext is removed; when unset they are stored unencrypted (with a
+# loud warning). restore.sh needs the SAME value to decrypt. Keep this OUT of the
+# repo — set it only in the deployed .env, stored separately from the backups.
+# BACKUP_GPG_PASSPHRASE=
 
 # ── Off-site Backups (DigitalOcean Spaces — optional but recommended) ──
 # DO_SPACES_KEY=                 # DigitalOcean Spaces access key
@@ -100,6 +106,7 @@ BACKUP_RETENTION_DAYS=30         # How long to keep local backups (days)
 # DO_SPACES_BUCKET=availai-backups
 # DO_SPACES_REGION=nyc3
 # SPACES_RETENTION_DAYS=90       # How long to keep remote backups
+# SPACES_SSE=AES256              # Server-side encryption for uploads (set to "none" to disable)
 
 # ── SP3: AI Account Screening ──
 AI_SCREEN_ENABLED=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   # Run CI for PRs targeting any branch — supports stacked PRs where a feature
   # PR is based on another open feature branch rather than directly on main.
   pull_request:
+  schedule:
+    # Nightly full migration chain-replay (downgrade base → upgrade head). Too
+    # slow/fragile to gate every PR with 160+ migrations, so it runs here on a
+    # schedule instead — see the `migration-full-cycle` job below (HIGH-DEVOPS-7).
+    - cron: "0 7 * * *"
 
 jobs:
   test:
@@ -219,3 +224,66 @@ jobs:
           path: |
             test-results.xml
             coverage.xml
+
+  migration-full-cycle:
+    # HIGH-DEVOPS-7: full chain-replay (downgrade base → re-upgrade head) of all
+    # 160+ migrations. Too slow/fragile to gate every PR, so it runs nightly via
+    # the `schedule` trigger instead. Per-PR CI keeps the cheap, high-value
+    # checks: single-head assertion ("Validate Alembic migrations"), a fresh
+    # `upgrade head` + schema-drift gate ("Alembic upgrade + schema-drift gate"),
+    # and a single-step `downgrade -1` reversibility check on the new migration.
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: availai
+          POSTGRES_PASSWORD: availai
+          POSTGRES_DB: availai
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U availai -d availai"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
+            libffi-dev shared-mime-info
+
+      - name: Install Python dependencies
+        # Prod lock only — alembic env.py imports the app models, which need the
+        # runtime deps; the dev/test toolchain isn't required for a migration replay.
+        run: pip install -r requirements.txt
+
+      - name: Full migration chain-replay (downgrade base → upgrade head)
+        env:
+          DATABASE_URL: postgresql://availai:availai@localhost:5432/availai
+          SECRET_KEY: ci-secret-key
+          SESSION_SECRET: ci-session-secret
+          TESTING: "0"
+          PYTHONPATH: ${{ github.workspace }}
+          # The 001 explicit-DDL baseline + incremental 002+ chain don't share a
+          # clean reverse drop ordering, so unwinding to base needs cascade.
+          # Production never sets this; single-step downgrades there still fail
+          # loudly on FK-dependency errors.
+          ALEMBIC_ALLOW_CASCADE: "1"
+        run: |
+          alembic upgrade head
+          alembic downgrade base
+          alembic upgrade head

--- a/alembic/versions/d2bea118f720_fix_remaining_ondelete_server_default_.py
+++ b/alembic/versions/d2bea118f720_fix_remaining_ondelete_server_default_.py
@@ -2,7 +2,7 @@
 
 Covers model changes not addressed by prior migrations:
 - ondelete clauses on 20+ FK columns across buy_plan, config, enrichment,
-  error_report, intelligence, offers, performance, prospect_account, sourcing
+  intelligence, offers, performance, prospect_account, sourcing
 - server_default=func.now() on timestamp columns in excess, trouble_ticket,
   root_cause_group
 - Missing indexes on enrichment (started_by, reviewed_by, saved_by),
@@ -37,8 +37,21 @@ def _recreate_fk(
     ref_column: str,
     ondelete: str | None,
 ) -> None:
-    """Drop and recreate a FK constraint with the specified ondelete behavior."""
+    """Drop and recreate a FK constraint with the specified ondelete behavior.
+
+    Defensive: on a full ``downgrade base`` chain replay this migration runs
+    while later migrations' table drops are still in effect, so the target
+    table (or column) may not exist. Skip silently in that case instead of
+    raising ``NoSuchTableError`` — there is no FK to fix on a table that isn't
+    present. Combined with no longer hard-coding since-dropped tables (e.g.
+    ``error_reports``, dropped by a3f9c1d82e47), this keeps chain replays green.
+    """
     conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if not inspector.has_table(table):
+        return
+    if column not in {col["name"] for col in inspector.get_columns(table)}:
+        return
     result = conn.execute(
         sa.text(
             """
@@ -105,8 +118,6 @@ def upgrade() -> None:
         ("enrichment_jobs", "started_by_id", "users", "id"),
         ("enrichment_queue", "reviewed_by_id", "users", "id"),
         ("prospect_contacts", "saved_by_id", "users", "id"),
-        # error_report.py
-        ("error_reports", "resolved_by_id", "users", "id"),
         # intelligence.py
         ("proactive_matches", "customer_site_id", "customer_sites", "id"),
         ("proactive_matches", "salesperson_id", "users", "id"),
@@ -139,8 +150,6 @@ def upgrade() -> None:
     CASCADE_FKS = [
         # config.py
         ("graph_subscriptions", "user_id", "users", "id"),
-        # error_report.py
-        ("error_reports", "user_id", "users", "id"),
         # performance.py (StockListHash)
         ("stock_list_hashes", "user_id", "users", "id"),
     ]
@@ -226,7 +235,6 @@ def downgrade() -> None:
     # -----------------------------------------------------------------------
     CASCADE_FKS = [
         ("stock_list_hashes", "user_id", "users", "id"),
-        ("error_reports", "user_id", "users", "id"),
         ("graph_subscriptions", "user_id", "users", "id"),
     ]
 
@@ -253,7 +261,6 @@ def downgrade() -> None:
         ("proactive_offers", "converted_requisition_id", "requisitions", "id"),
         ("proactive_matches", "salesperson_id", "users", "id"),
         ("proactive_matches", "customer_site_id", "customer_sites", "id"),
-        ("error_reports", "resolved_by_id", "users", "id"),
         ("prospect_contacts", "saved_by_id", "users", "id"),
         ("enrichment_queue", "reviewed_by_id", "users", "id"),
         ("enrichment_jobs", "started_by_id", "users", "id"),

--- a/backup.sh
+++ b/backup.sh
@@ -47,14 +47,16 @@ fi
 
 # ── 2b. Optional at-rest encryption (gpg symmetric AES256) ──
 # When BACKUP_GPG_PASSPHRASE is set, encrypt the verified dump and remove the
-# plaintext so nothing readable lands on disk. Decrypt+restore later with:
-#   gpg --batch --decrypt --passphrase "$BACKUP_GPG_PASSPHRASE" FILE.dump.gpg \
-#     | pg_restore -U availai -d availai
+# plaintext so nothing readable lands on disk. The passphrase is fed via stdin
+# (--passphrase-fd 0), never the command line, so it never appears in `ps`/argv.
+# Decrypt+restore later (passphrase via stdin too):
+#   printf '%s' "$BACKUP_GPG_PASSPHRASE" | gpg --batch --pinentry-mode loopback \
+#     --passphrase-fd 0 --decrypt FILE.dump.gpg | pg_restore -U availai -d availai
 if [ -n "${BACKUP_GPG_PASSPHRASE:-}" ]; then
     log "Encrypting backup (gpg symmetric, AES256)..."
-    if gpg --batch --yes --quiet --cipher-algo AES256 \
-           --passphrase "${BACKUP_GPG_PASSPHRASE}" --symmetric \
-           --output "${BACKUP_FILE}.gpg" "$BACKUP_FILE"; then
+    if printf '%s' "${BACKUP_GPG_PASSPHRASE}" | gpg --batch --yes --quiet \
+           --pinentry-mode loopback --passphrase-fd 0 --cipher-algo AES256 \
+           --symmetric --output "${BACKUP_FILE}.gpg" "$BACKUP_FILE"; then
         rm -f "$BACKUP_FILE"
         BACKUP_FILE="${BACKUP_FILE}.gpg"
         SIZE=$(du -h "$BACKUP_FILE" | cut -f1)

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,11 +36,15 @@ if [ "$NO_COMMIT" = false ]; then
     if git diff --quiet && git diff --cached --quiet; then
         echo "No changes to commit — skipping commit step"
     else
-        git add -A
-        # Last line of defence before `git add -A` lands something in history.
-        # .gitignore should already exclude these, but the moment it misses a
-        # new untracked file (a secret, an SSH key, a DB dump) `git add -A`
-        # stages it. Abort the deploy rather than commit it.
+        # Stage only modifications/deletions to already-TRACKED files (`-u`),
+        # never new untracked files. The old `git add -A` swept in everything, so
+        # the moment .gitignore missed a new untracked secret / SSH key / DB dump
+        # it landed in history (CRIT-DEVOPS-2). `-u` removes that entire class at
+        # the source: a brand-new file is committed only if the operator
+        # deliberately `git add`ed it first — already-staged paths are preserved.
+        git add -u
+        # Defence in depth for anything deliberately pre-staged: refuse to commit
+        # files matching known-sensitive patterns even when explicitly added.
         DANGER=$(git diff --cached --name-only | grep -iE \
             '(^|/)\.env($|\.)|\.(pem|key|p12|pfx|sql|sqlite3?|dump)$|(^|/)(credentials|service-account|id_rsa|id_ed25519)[^/]*$' \
             || true)

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -487,6 +487,22 @@ reader (>= 0.85) — see APP_MAP_INTERACTIONS "Worker second-pass ordering":
 | Script | Purpose |
 |--------|---------|
 | `backfill_oem_enrichment.py` | Dry-run-first backfill over `not_found` / `not_catalogued` cards through the OEM tiers. Writes a coverage CSV; rolls back unless `--commit`. Shared `web_meter` budget cap (`--max-web-calls`, default 300) halts mid-run to prevent API overspend. The paced worker drains any remainder. |
+| `backup.sh` / `restore.sh` | `pg_dump` custom-format backups (verify → optional encrypt → checksum → rotate) and their restore. Optional at-rest encryption: when `BACKUP_GPG_PASSPHRASE` is set, the verified `.gz` is gpg-symmetric AES256-encrypted (`.dump.gz.gpg`) and the plaintext removed; unset → plaintext with a loud warning. The passphrase is fed via **stdin** (`--passphrase-fd 0`), never argv, so it never appears in `ps`. `restore.sh` transparently decrypts `.gpg` backups (needs the same passphrase) and encrypts its pre-restore safety dump too. (Repo-root `backup.sh` is the equivalent host-cron variant.) |
+| `backup-to-spaces.sh` | Off-site upload of the latest backup to DigitalOcean Spaces. Requests server-side encryption (`SPACES_SSE`, default `AES256`; set `SPACES_SSE=none` to disable) — defence-in-depth on top of the optional gpg-at-rest encryption. Skips cleanly when `DO_SPACES_*` is unset. |
+
+## CI & DevOps
+
+- **CI (`.github/workflows/ci.yml`)** — per-PR runs the cheap, high-value Alembic
+  checks: single-head assertion, fresh `upgrade head` + schema-drift gate, and a
+  single-step `downgrade -1` reversibility check on the new migration. The
+  expensive full chain-replay (`downgrade base → upgrade head` over all
+  migrations, needs `ALEMBIC_ALLOW_CASCADE`) runs **nightly** via the `schedule`
+  trigger as the `migration-full-cycle` job, not on every PR (HIGH-DEVOPS-7).
+- **Deploy (`deploy.sh`)** — the commit step stages with `git add -u`
+  (tracked-file modifications/deletions only), never untracked files, so a stray
+  secret/key/DB dump can't be swept into a deploy commit (CRIT-DEVOPS-2); brand-new
+  files must be `git add`ed deliberately first. A sensitive-path denylist is the
+  defence-in-depth backstop.
 
 ## Key Numbers
 

--- a/scripts/backup-to-spaces.sh
+++ b/scripts/backup-to-spaces.sh
@@ -19,6 +19,13 @@ set -euo pipefail
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 SPACES_RETENTION_DAYS="${SPACES_RETENTION_DAYS:-90}"
 ENDPOINT="https://${DO_SPACES_REGION:-nyc3}.digitaloceanspaces.com"
+# Server-side encryption for objects at rest in Spaces. Defaults to AES256
+# (SSE-S3 — Spaces-managed keys, no key material to manage, no size change so the
+# upload-size verification below still holds). Set SPACES_SSE=none to disable if a
+# target endpoint doesn't support SSE, so it degrades gracefully. Backups are ALSO
+# gpg-encrypted at rest by backup.sh when BACKUP_GPG_PASSPHRASE is set — this is
+# defence-in-depth on top of that.
+SPACES_SSE="${SPACES_SSE:-AES256}"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [spaces] $1"; }
 die() { log "FATAL: $1"; exit 1; }
@@ -48,17 +55,24 @@ export AWS_SECRET_ACCESS_KEY="$DO_SPACES_SECRET"
 export AWS_DEFAULT_REGION="${DO_SPACES_REGION:-nyc3}"
 
 # ─── Upload ──────────────────────────────────────────────────────────────────
-# --sse AES256 requests server-side encryption (SSE-S3) so the object is
-# encrypted at rest in Spaces even when the local backup is not gpg-encrypted.
-# Defense in depth: combines with backup.sh's optional gpg-at-rest encryption.
-log "Uploading ${FILENAME} to s3://${DO_SPACES_BUCKET}/db-backups/ (SSE AES256)"
+# Build the optional server-side-encryption flag. An empty array expands to
+# nothing under `set -u` (bash 4.4+), so SPACES_SSE=none cleanly disables SSE.
+SSE_ARGS=()
+if [ -n "$SPACES_SSE" ] && [ "$SPACES_SSE" != "none" ]; then
+    SSE_ARGS=(--sse "$SPACES_SSE")
+fi
+
+# Server-side encryption (default SSE-S3 AES256) keeps the object encrypted at
+# rest in Spaces even when the local backup is not gpg-encrypted — defence in
+# depth on top of backup.sh's optional gpg-at-rest encryption.
+log "Uploading ${FILENAME} to s3://${DO_SPACES_BUCKET}/db-backups/ (SSE: ${SPACES_SSE})"
 
 aws s3 cp \
     "$BACKUP_FILE" \
     "s3://${DO_SPACES_BUCKET}/db-backups/${FILENAME}" \
     --endpoint-url "$ENDPOINT" \
-    --sse AES256 \
-    --storage-class STANDARD
+    --storage-class STANDARD \
+    "${SSE_ARGS[@]}"
 
 # Also upload checksum if it exists
 if [ -f "${BACKUP_FILE}.sha256" ]; then
@@ -66,7 +80,7 @@ if [ -f "${BACKUP_FILE}.sha256" ]; then
         "${BACKUP_FILE}.sha256" \
         "s3://${DO_SPACES_BUCKET}/db-backups/${FILENAME}.sha256" \
         --endpoint-url "$ENDPOINT" \
-        --sse AES256
+        "${SSE_ARGS[@]}"
 fi
 
 log "Upload complete"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -126,9 +126,13 @@ fi
 # unset, the backup stays plaintext (restore.sh transparently handles both).
 if [ -n "$GPG_PASSPHRASE" ]; then
     log "Encrypting backup (gpg symmetric, AES256)..."
-    gpg --batch --yes --quiet \
+    # Passphrase via stdin (--passphrase-fd 0), never the command line, so it
+    # never appears in `ps`/argv. --pinentry-mode loopback is required for a
+    # non-interactive fd passphrase under --batch (gpg 2.1+). The plaintext .gz
+    # is read from the file argument, so stdin carries only the passphrase.
+    printf '%s' "$GPG_PASSPHRASE" | gpg --batch --yes --quiet \
+        --pinentry-mode loopback --passphrase-fd 0 \
         --cipher-algo AES256 \
-        --passphrase "$GPG_PASSPHRASE" \
         --symmetric \
         --output "${BACKUP_FILE_GZ}.gpg" \
         "$BACKUP_FILE_GZ" \

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -25,7 +25,11 @@ decompress() {
     if [[ "$f" == *.gpg ]]; then
         [ -n "${BACKUP_GPG_PASSPHRASE:-}" ] \
             || die "Backup '${f}' is gpg-encrypted but BACKUP_GPG_PASSPHRASE is not set"
-        gpg --batch --quiet --decrypt --passphrase "${BACKUP_GPG_PASSPHRASE}" "$f" 2>/dev/null | gunzip -c
+        # Passphrase via stdin (--passphrase-fd 0), never the command line, so it
+        # never appears in `ps`/argv. The ciphertext is read from the file arg.
+        printf '%s' "${BACKUP_GPG_PASSPHRASE}" \
+            | gpg --batch --quiet --pinentry-mode loopback --passphrase-fd 0 --decrypt "$f" 2>/dev/null \
+            | gunzip -c
     else
         gunzip -c "$f"
     fi
@@ -187,11 +191,18 @@ if [ "$SKIP_SAFETY" = false ]; then
 
     # Match backup.sh's at-rest policy: when a passphrase is configured, the
     # pre-restore safety dump is encrypted too (never leave plaintext on disk).
+    # Best-effort — a failure here must NOT abort the restore. Passphrase via
+    # stdin (--passphrase-fd 0), never the command line, so it never hits argv.
     if [ -n "${BACKUP_GPG_PASSPHRASE:-}" ] && [ -s "$SAFETY_FILE" ]; then
-        gpg --batch --yes --quiet --cipher-algo AES256 \
-            --passphrase "${BACKUP_GPG_PASSPHRASE}" --symmetric \
-            --output "${SAFETY_FILE}.gpg" "$SAFETY_FILE" \
-            && rm -f "$SAFETY_FILE" && SAFETY_FILE="${SAFETY_FILE}.gpg"
+        if printf '%s' "${BACKUP_GPG_PASSPHRASE}" \
+            | gpg --batch --yes --quiet --pinentry-mode loopback --passphrase-fd 0 \
+                --cipher-algo AES256 --symmetric \
+                --output "${SAFETY_FILE}.gpg" "$SAFETY_FILE"; then
+            rm -f "$SAFETY_FILE"
+            SAFETY_FILE="${SAFETY_FILE}.gpg"
+        else
+            log "WARNING: failed to encrypt safety backup; leaving plaintext ${SAFETY_FILE}"
+        fi
     fi
 
     SAFETY_SIZE=$(stat -c%s "$SAFETY_FILE" 2>/dev/null || stat -f%z "$SAFETY_FILE" 2>/dev/null || echo "0")

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -11,8 +11,6 @@ import importlib.util
 import inspect
 from pathlib import Path
 
-import pytest
-
 MIGRATION_DIR = Path(__file__).parent.parent / "alembic" / "versions"
 ENV_PY = Path(__file__).parent.parent / "alembic" / "env.py"
 
@@ -170,29 +168,18 @@ def test_no_create_all_in_main():
     assert "create_all" not in content, "Remove Base.metadata.create_all — use Alembic"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Known break (post-PR-108 follow-up): d2bea118f720 _recreate_fk iterates a "
-        "hard-coded FK list that includes the 'error_reports' table, but "
-        "a3f9c1d82e47_drop_dead_tables drops 'error_reports' earlier in the chain. "
-        "On a `downgrade base` chain replay, d2bea118f720 runs before a3f9c1d82e47's "
-        "downgrade restores the table, so reflection inside _recreate_fk raises "
-        "NoSuchTableError: error_reports. Fix is a has_table guard before each "
-        "recreate (or de-hardcoding the FK list). This static-analysis test pins "
-        "the fragile pattern so the next refactor can't silently fix-or-paper-over."
-    ),
-)
 def test_d2bea_recreate_fk_does_not_hardcode_dropped_tables():
-    """Pin the known `error_reports` downgrade-chain break.
+    """Regression: d2bea118f720 must not hard-code a since-dropped table.
 
-    Static check: the d2bea118f720 migration source contains the literal string
-    'error_reports' inside its hard-coded FK lists, AND a3f9c1d82e47 drops that
-    same table. Until the migration is reworked to guard each `_recreate_fk`
-    call with `has_table()` (or stops hard-coding now-dropped tables), this
-    pattern will break `alembic downgrade base` chain replays. xfail(strict)
-    means the day someone fixes the underlying bug, this test must be
-    deleted/updated — silently passing here would defeat the pin.
+    Fixed in the hardening(devops) PR: d2bea118f720 used to iterate a hard-coded
+    FK list that included the 'error_reports' table, but a3f9c1d82e47 drops that
+    table earlier in the chain — so a `downgrade base` chain replay ran
+    d2bea118f720 while 'error_reports' didn't exist and reflection inside
+    `_recreate_fk` raised NoSuchTableError. The fix removed the 'error_reports'
+    entries from d2bea's FK lists AND made `_recreate_fk` guard each call with
+    `inspect(conn).has_table()`. This static check keeps the bad pattern from
+    reappearing: it fails if d2bea ever re-hard-codes a table that a3f9c1d82e47
+    drops.
     """
     versions = MIGRATION_DIR
     d2bea_src = (versions / "d2bea118f720_fix_remaining_ondelete_server_default_.py").read_text()

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -4,11 +4,13 @@
 # Depends on: scripts/backup.sh, scripts/restore.sh, scripts/backup-to-spaces.sh
 
 import os
+import shutil
 import subprocess
 
 import pytest
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(__file__), "..", "scripts")
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
 
 ALL_SCRIPTS = [
     "backup.sh",
@@ -130,6 +132,119 @@ class TestBackupScriptContent:
         )
 
 
+class TestPassphraseNotOnCommandLine:
+    """The gpg passphrase must be fed via stdin (--passphrase-fd 0), never as a CLI arg
+    — a command-line --passphrase leaks the secret into argv/`ps`."""
+
+    def _read_root(self):
+        with open(os.path.join(REPO_ROOT, "backup.sh")) as f:
+            return f.read()
+
+    @pytest.mark.parametrize("name", ["backup.sh", "restore.sh"])
+    def test_scripts_use_passphrase_fd(self, name):
+        content = _read_script(name)
+        assert "--passphrase-fd" in content, f"{name} must feed the gpg passphrase via --passphrase-fd (stdin)"
+        # The command-line form `--passphrase <value>` (trailing space) must be
+        # absent everywhere, including comments, so nothing demonstrates the leak.
+        assert "--passphrase " not in content, f"{name} must NOT pass the passphrase on the gpg command line"
+        assert "--pinentry-mode loopback" in content, (
+            f"{name} needs --pinentry-mode loopback for a non-interactive fd passphrase under --batch"
+        )
+
+    def test_root_backup_uses_passphrase_fd(self):
+        content = self._read_root()
+        assert "--passphrase-fd" in content, "root backup.sh must feed the gpg passphrase via --passphrase-fd (stdin)"
+        assert "--passphrase " not in content, "root backup.sh must NOT pass the passphrase on the gpg command line"
+
+    def test_root_backup_keyed_from_canonical_env(self):
+        """The host-cron variant must use the same BACKUP_GPG_PASSPHRASE knob."""
+        content = self._read_root()
+        assert "BACKUP_GPG_PASSPHRASE" in content, "root backup.sh must read BACKUP_GPG_PASSPHRASE"
+        assert "UNENCRYPTED" in content, "root backup.sh must warn loudly when storing unencrypted"
+
+    @pytest.mark.skipif(shutil.which("gpg") is None, reason="gpg not installed")
+    def test_gpg_symmetric_roundtrip_matches_script_invocation(self, tmp_path):
+        """Functional proof that the exact gpg flags the scripts use encrypt and decrypt
+        a payload correctly (passphrase via stdin fd 0) and reject a wrong key.
+
+        Uses an isolated GNUPGHOME so it never touches a real keyring.
+        """
+        plaintext = tmp_path / "payload.bin"
+        plaintext.write_bytes(b"AVAILAI-BACKUP-SENTINEL-" + os.urandom(64))
+        enc = tmp_path / "payload.bin.gpg"
+        key = "correct horse battery staple"
+        gnupg = tmp_path / "gnupg"
+        gnupg.mkdir(mode=0o700)
+        env = {**os.environ, "GNUPGHOME": str(gnupg)}
+
+        # Encrypt with the exact flags the scripts use (passphrase via stdin fd 0).
+        enc_proc = subprocess.run(
+            [
+                "gpg",
+                "--batch",
+                "--yes",
+                "--quiet",
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase-fd",
+                "0",
+                "--symmetric",
+                "--cipher-algo",
+                "AES256",
+                "--output",
+                str(enc),
+                str(plaintext),
+            ],
+            input=key.encode(),
+            capture_output=True,
+            env=env,
+        )
+        assert enc_proc.returncode == 0, enc_proc.stderr.decode()
+        assert enc.exists()
+        assert enc.read_bytes() != plaintext.read_bytes(), "ciphertext must differ from plaintext"
+
+        # Correct key decrypts back to the original bytes.
+        good = subprocess.run(
+            [
+                "gpg",
+                "--batch",
+                "--yes",
+                "--quiet",
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase-fd",
+                "0",
+                "--decrypt",
+                str(enc),
+            ],
+            input=key.encode(),
+            capture_output=True,
+            env=env,
+        )
+        assert good.returncode == 0, good.stderr.decode()
+        assert good.stdout == plaintext.read_bytes()
+
+        # Wrong key must fail.
+        bad = subprocess.run(
+            [
+                "gpg",
+                "--batch",
+                "--yes",
+                "--quiet",
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase-fd",
+                "0",
+                "--decrypt",
+                str(enc),
+            ],
+            input=b"wrong key",
+            capture_output=True,
+            env=env,
+        )
+        assert bad.returncode != 0, "decryption with the wrong key must fail"
+
+
 class TestRestoreScriptContent:
     """Verify restore.sh has required safety features."""
 
@@ -190,8 +305,15 @@ class TestSpacesScriptContent:
     def test_spaces_uses_server_side_encryption(self):
         """Off-site uploads must request server-side encryption (SSE-S3)."""
         content = _read_script("backup-to-spaces.sh")
-        assert "--sse AES256" in content, (
-            "backup-to-spaces.sh must upload with --sse AES256 (server-side encryption at rest)"
+        assert "--sse" in content, "backup-to-spaces.sh must request server-side encryption (--sse)"
+        assert "AES256" in content, "backup-to-spaces.sh must default to AES256 server-side encryption"
+
+    def test_spaces_sse_is_overridable(self):
+        """SSE must be overridable (e.g. SPACES_SSE=none) so it degrades gracefully."""
+        content = _read_script("backup-to-spaces.sh")
+        assert "SPACES_SSE" in content, "backup-to-spaces.sh must expose SPACES_SSE for graceful override"
+        assert '"none"' in content or "none" in content, (
+            "backup-to-spaces.sh must let SPACES_SSE=none disable server-side encryption"
         )
 
 


### PR DESCRIPTION
## Summary

Four focused devops hardening items.

### 1. Fix broken alembic full-downgrade chain (root cause)
`alembic/versions/d2bea118f720_...` hard-coded `_recreate_fk` calls for the `error_reports` table, but `a3f9c1d82e47_drop_dead_tables` drops that table earlier in the chain. On `alembic downgrade base` chain replay, d2bea ran while `error_reports` no longer existed and reflection raised `NoSuchTableError`.

- Removed the `error_reports` entries from **both** the upgrade and downgrade FK lists (the table is dead — fixing its FK ondelete is pointless).
- Made `_recreate_fk` defensive: guards with `inspect(conn).has_table(table)` and a column-presence check, so a chain replay can never raise on a since-dropped table/column.
- Converted the `@pytest.mark.xfail(strict=True)` pin `test_d2bea_recreate_fk_does_not_hardcode_dropped_tables` into a normal passing regression test (docstring updated to past tense).

### 2. Salvaged unshipped devops work from the `zombie-devops-incomplete` stash
Adapted everything to main's canonical encryption env var **`BACKUP_GPG_PASSPHRASE`** (the stash used the old `BACKUP_ENCRYPTION_KEY`, which is **not** reintroduced). Stash dropped after salvage.

- **Nightly migration full-cycle CI job** — new `migration-full-cycle` job in `.github/workflows/ci.yml`, gated on a `schedule` cron (`0 7 * * *`), that replays `upgrade head → downgrade base → upgrade head` on a real PostgreSQL service (HIGH-DEVOPS-7). Per-PR CI keeps the cheap single-head + schema-drift + single-step-downgrade checks. This job depends on Item 1's fix to pass.
- **`--passphrase-fd 0` stdin hardening** for gpg in `scripts/backup.sh`, `scripts/restore.sh` and repo-root `backup.sh` (+ `--pinentry-mode loopback`), so the passphrase is never on argv/`ps`. Comments showing the old command-line form were updated to the stdin form.
- **`SPACES_SSE` override knob** in `scripts/backup-to-spaces.sh` (default `AES256`, `none` disables), documented in `.env.example` — which also now documents the previously-undocumented `BACKUP_GPG_PASSPHRASE`.
- **Tests** in `tests/test_backup.py`: a gpg-symmetric roundtrip functional test (encrypt/decrypt/wrong-key-fails using the exact script flags) and "no passphrase on command line" assertions for all three scripts; updated the SSE test for the new variable form.

### 3. Narrow `deploy.sh` `git add -A` (CRIT-DEVOPS-2)
Changed the deploy commit step to `git add -u` — stages only modifications/deletions to already-tracked files, never new untracked files, eliminating the entire class of "stray secret/key/DB dump swept into history". Brand-new files must be `git add`ed deliberately first; the sensitive-path denylist remains as defence-in-depth.

### 4. Docs
Updated `docs/APP_MAP_ARCHITECTURE.md` (backup scripts table + a CI & DevOps section describing the nightly chain-replay and the `git add -u` deploy contract).

## Verification
- Full round-trip on a **throwaway** `postgres:16` (not staging): `alembic upgrade head → downgrade base → upgrade head` all exited 0, ending on a single head `171_unavail_condition`. Container torn down.
- `pre-commit` clean on all changed files (ruff, ruff-format, docformatter, mypy, etc.).
- `TESTING=1 PYTHONPATH=/root/availai pytest tests/test_alembic.py tests/test_backup.py -q` → **64 passed** (gpg roundtrip ran, not skipped). `tests/test_static_analysis.py` → 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)