### PR TITLE
feat(approvals): Pipeline surface — 4-stage board (Phase C)

### DIFF
--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -108,7 +108,7 @@ def _require_po_cutter(user: User) -> None:
         raise HTTPException(403, "Only buyers and managers can re-source / claim lines")
 
 
-_APPROVALS_TABS = ("my_queue", "sales_orders", "buy_plans", "purchase_orders", "prepayments", "supervise")
+_APPROVALS_TABS = ("my_queue", "pipeline", "sales_orders", "buy_plans", "purchase_orders", "prepayments", "supervise")
 
 
 _TAB_APPROVE_ATTR = {
@@ -123,12 +123,12 @@ _TAB_APPROVE_ATTR = {
 def _default_lens(user: User, db: Session) -> str:
     """Pick the landing stage tab for the Approvals hub based on the user's role.
 
-    - managers/admins/ops land on Supervise (until the Pipeline surface ships in Phase C),
+    - managers/admins/ops land on Pipeline — the 4-stage deal board (Phase C),
     - everyone else (buyers, sales, traders) lands on My Queue — their personal,
       role-aware "what needs YOU now" surface.
     """
     if _can_supervise(user, db):
-        return "supervise"
+        return "pipeline"
     return "my_queue"
 
 
@@ -196,6 +196,9 @@ async def approvals_tab_partial(
 
     if lens == "my_queue":
         return _render_my_queue_body(request, user, db)
+
+    if lens == "pipeline":
+        return _render_pipeline_body(request, user, db, scope)
 
     ctx = _base_ctx(request, user, "buy-plans")
     if lens in _TAB_APPROVE_ATTR:
@@ -525,6 +528,45 @@ def _render_my_queue_body(request: Request, user: User, db: Session) -> HTMLResp
     ctx = _base_ctx(request, user, "buy-plans")
     ctx.update({"queue": my_queue(db, user), "user": user})
     return template_response("htmx/partials/approvals/_surface_my_queue.html", ctx)
+
+
+def _render_pipeline_body(request: Request, user: User, db: Session, scope: str = "") -> HTMLResponse:
+    """Build + render the Pipeline surface body for ``user`` into ``#bp-hub-body``.
+
+    The Pipeline is the deal flow as cards in the four canonical stages: three visible
+    columns Build (DRAFT) · Approve (PENDING) · Purchase (ACTIVE|INBOUND), plus a collapsed
+    Done (COMPLETED) summary below. Each column is one ``deals_board`` call with an explicit
+    status filter so the read model stays the single source of truth (see Phase B / the
+    rework design's "Two surfaces via lens values"). Done comes from ``completed_archive``.
+
+    Scope is role-resolved exactly like the standalone board: PO-cutters + ops may toggle
+    All/Mine; sales/traders are locked to ``mine`` so no other rep's deals leak. The Mine/All
+    toggle reloads THIS body in place (hx-target #bp-hub-body, hx-push-url="false").
+    """
+    from ...services.buyplan_hub import completed_archive, deals_board
+
+    can_all = _can_see_all_deals(user, db)
+    board_scope = _resolve_deal_scope(scope, can_all)
+
+    build = deals_board(db, user, scope=board_scope, statuses=[BuyPlanStatus.DRAFT.value])
+    approve = deals_board(db, user, scope=board_scope, statuses=[BuyPlanStatus.PENDING.value])
+    purchase = deals_board(
+        db, user, scope=board_scope, statuses=[BuyPlanStatus.ACTIVE.value, BuyPlanStatus.INBOUND.value]
+    )
+
+    ctx = _base_ctx(request, user, "buy-plans")
+    ctx.update(
+        {
+            "build_col": build["draft"],
+            "approve_col": approve["pending"],
+            "purchase_col": purchase["active"],
+            "archive": completed_archive(db, user, scope=board_scope),
+            "scope": board_scope,
+            "can_see_all_deals": can_all,
+            "user": user,
+        }
+    )
+    return template_response("htmx/partials/approvals/_surface_pipeline.html", ctx)
 
 
 def _render_supervise_body(request: Request, user: User, db: Session) -> HTMLResponse:

--- a/app/services/buyplan_hub.py
+++ b/app/services/buyplan_hub.py
@@ -307,6 +307,10 @@ _STATUS_TO_COLUMN: dict[str, str] = {
     BuyPlanStatus.PENDING: "pending",
     BuyPlanStatus.ACTIVE: "active",
     BuyPlanStatus.HALTED: "active",
+    # INBOUND is a sub-status of the Purchase stage (goods inbound, awaiting receipt) —
+    # it buckets with ACTIVE so the Pipeline's Purchase column (statuses=[ACTIVE, INBOUND])
+    # surfaces it. Previously dropped by the safety net, which silently hid inbound deals.
+    BuyPlanStatus.INBOUND: "active",
     # COMPLETED → archive section (see completed_archive), not an active column
     # CANCELLED → omitted (no entry)
 }
@@ -451,6 +455,10 @@ def _deal_card(plan: BuyPlan, user: object) -> dict:
         "primary_mpn": _primary_mpn(plan),
         "value": plan.total_cost,
         "margin_pct": plan.total_margin_pct,
+        # Raw lifecycle status — the Pipeline card maps it to a 4-stage index for the
+        # "who-has-the-ball" pip stepper (DRAFT→Build, PENDING→Approve,
+        # ACTIVE|INBOUND→Purchase, COMPLETED→Done). stage_label keeps the legacy vocabulary.
+        "status": plan.status,
         "stage_label": _STAGE_LABELS.get(plan.status, plan.status),
         "blocker": _compute_blocker(plan),
         "po_progress": (verified_count, len(active_lines)),

--- a/app/templates/htmx/partials/approvals/_pipeline_macros.html
+++ b/app/templates/htmx/partials/approvals/_pipeline_macros.html
@@ -1,0 +1,82 @@
+{#
+  approvals/_pipeline_macros.html — shared macros for the Pipeline surface (Approvals
+  rework Phase C): the de-noised deal card with the signature 4-pip "who-has-the-ball"
+  stepper, and the parameterized open-count/value metric strip.
+
+  deal_card(card) — one calm deal tile, built from a buyplan_hub._deal_card dict. The
+    4-pip stepper (●●○○) replaces the old blocker line + PO progress bar: done pips fill
+    brand-500, the live "ball" (current stage) is the single accent-500 node, upcoming
+    pips are hollow brand-200 outlines. The ball position is the card's status mapped to a
+    4-stage index (DRAFT→Build 0, PENDING→Approve 1, ACTIVE|INBOUND→Purchase 2,
+    COMPLETED→Done 3). Customer is the one bold line; value is tabular; SO · owner is a
+    muted secondary line; ONE margin-health badge; the stock chip is kept. A card that
+    needs the viewer's action (own DRAFT) gains an accent ring (not amber — single-accent
+    rule). The whole tile is a keyboard-navigable link to the plan detail.
+
+  metric_strip(open_count, open_value) — the light contextual strip (N open deals · $value).
+
+  Used by: approvals/_surface_pipeline.html.
+  Depends on: HTMX, Alpine.js (card keyboard activation), Tailwind brand/accent/line palette,
+              .chip + .badge-* + .text-tertiary primitives. Jinja consumes only the card dict.
+#}
+
+{# status → 4-stage index for the pip stepper (the canonical Build/Approve/Purchase/Done
+   mapping). HALTED is an off-ramp that never reaches the Pipeline board; default to 0. #}
+{% set _STAGE_INDEX = {'draft': 0, 'pending': 1, 'active': 2, 'inbound': 2, 'completed': 3, 'halted': 0} %}
+{% set _STAGE_LABELS = ['Build', 'Approve', 'Purchase', 'Done'] %}
+
+
+{% macro deal_card(card) %}
+{% set m = card.margin_pct | float if card.margin_pct is not none else 0 %}
+{% set s = _STAGE_INDEX.get(card.status, 0) %}
+<div hx-get="/v2/partials/buy-plans/{{ card.plan_id }}"
+     hx-target="#main-content"
+     hx-push-url="/v2/buy-plans/{{ card.plan_id }}"
+     preload="mouseover"
+     tabindex="0"
+     role="link"
+     @keydown.enter.prevent="$el.click()"
+     @keydown.space.prevent="$el.click()"
+     class="bg-white rounded-md border border-line-base px-2.5 py-2 cursor-pointer hover:shadow-sm transition-shadow
+            focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:outline-none
+            {% if card.needs_my_action %}ring-2 ring-accent-400{% endif %}">
+
+  {# Customer headline (the one bold line) + stock chip #}
+  <div class="flex items-start justify-between gap-2">
+    <span class="text-sm font-semibold text-gray-900 leading-tight truncate" title="{{ card.customer_name or '—' }}">{{ card.customer_name or '—' }}</span>
+    {% if card.is_stock_sale %}
+    <span class="chip bg-purple-50 text-purple-700 border-purple-200 flex-shrink-0">stock</span>
+    {% endif %}
+  </div>
+
+  {# Muted SO · owner line #}
+  <div class="text-tertiary truncate">
+    SO <span class="font-mono">{{ card.tso or '—' }}</span>
+    {% if card.owner_name %}<span class="text-brand-300" aria-hidden="true"> · </span>{{ card.owner_name }}{% endif %}
+  </div>
+
+  {# Value (tabular) + ONE margin-health badge #}
+  <div class="mt-1 flex items-center justify-between gap-2">
+    <span class="text-sm font-semibold tabular-nums text-gray-900">${{ '{:,.2f}'.format(card.value | float) if card.value else '0.00' }}</span>
+    <span class="{% if m >= 30 %}badge-success{% elif m >= 15 %}badge-warning{% else %}badge-danger{% endif %}">{{ '{:.1f}'.format(m) }}%</span>
+  </div>
+
+  {# Signature 4-pip "who-has-the-ball" stepper + stage caption (replaces blocker + bar) #}
+  <div class="mt-1.5 flex items-center gap-2" title="Stage: {{ _STAGE_LABELS[s] }} ({{ s + 1 }} of 4)">
+    <div class="flex items-center gap-1" aria-hidden="true">
+      {% for i in range(4) %}
+      <span class="h-1.5 w-1.5 rounded-full {% if i < s %}bg-brand-500{% elif i == s %}bg-accent-500{% else %}border border-brand-200{% endif %}"></span>
+      {% endfor %}
+    </div>
+    <span class="text-[11px] font-medium text-tertiary">{{ _STAGE_LABELS[s] }}</span>
+  </div>
+</div>
+{% endmacro %}
+
+
+{% macro metric_strip(open_count, open_value) %}
+<div class="flex items-center gap-4 text-xs text-gray-600">
+  <span>{{ open_count }} open deal{{ 's' if open_count != 1 }}</span>
+  <span>${{ '{:,.0f}'.format(open_value) }} open value</span>
+</div>
+{% endmacro %}

--- a/app/templates/htmx/partials/approvals/_surface_pipeline.html
+++ b/app/templates/htmx/partials/approvals/_surface_pipeline.html
@@ -1,0 +1,90 @@
+{#
+  approvals/_surface_pipeline.html — the "Pipeline" surface body (Approvals rework Phase C).
+  The deal flow as cards in the four canonical stages: three visible columns
+  Build · Approve · Purchase, plus a collapsed Done summary bar below (default closed,
+  expandable via Alpine x-show). A light metric strip (open count + value) and — for users
+  who may see every owner's deals — a Mine/All scope toggle sit above the columns.
+
+  Each column's cards come from one buyplan_hub.deals_board call with an explicit status
+  filter (Build=DRAFT, Approve=PENDING, Purchase=ACTIVE|INBOUND); Done comes from
+  completed_archive. Cards render via the shared deal_card macro (the 4-pip
+  "who-has-the-ball" stepper). The scope toggle reloads THIS body in place
+  (hx-target #bp-hub-body, hx-push-url="false") so the lens stays Pipeline.
+
+  Receives: build_col / approve_col / purchase_col (list[deal-card dicts]),
+            archive (dict from completed_archive: deals/total/...), scope ('mine'|'all'),
+            can_see_all_deals (bool).
+  Called by: htmx/buy_plans.py _render_pipeline_body (the pipeline lens dispatch).
+  Depends on: HTMX, Alpine.js (Done toggle), Tailwind brand/accent/line palette,
+              approvals/_pipeline_macros.html (deal_card + metric_strip).
+#}
+{% from "htmx/partials/approvals/_pipeline_macros.html" import deal_card, metric_strip %}
+
+{% set columns = [('Build', build_col), ('Approve', approve_col), ('Purchase', purchase_col)] %}
+{% set open_cards = build_col + approve_col + purchase_col %}
+{% set open_value = open_cards | map(attribute='value') | select | map('float') | sum %}
+
+<div>
+  {# ── Header: metric strip + (optional) Mine/All scope toggle ── #}
+  <div class="flex items-center gap-4 mb-4">
+    {{ metric_strip(open_cards | length, open_value) }}
+    {% if can_see_all_deals %}
+    {# Scope toggle — PO-cutters + ops narrow to their own deals or see every owner's.
+       Each pill reloads THIS body in place (so the lens stays Pipeline); push-url off (R6). #}
+    <div class="ml-auto inline-flex items-center rounded-full bg-brand-100 p-0.5 text-xs">
+      {% for s, lbl in [('all', 'All deals'), ('mine', 'Mine')] %}
+      <button hx-get="/v2/partials/approvals/pipeline?scope={{ s }}"
+              hx-target="#bp-hub-body"
+              hx-swap="innerHTML"
+              hx-push-url="false"
+              class="px-3 py-0.5 rounded-full font-medium transition-colors
+                     {% if scope == s %}bg-accent-600 text-white shadow-sm{% else %}text-brand-600 hover:bg-brand-200{% endif %}">
+        {{ lbl }}
+      </button>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+
+  {# ── Three visible stage columns: Build · Approve · Purchase ── #}
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+    {% for label, cards in columns %}
+    {# needs-my-action cards sort first (matches the de-noised board). #}
+    {% set sorted_cards = cards | sort(attribute='needs_my_action', reverse=True) %}
+    <div class="bg-gray-50 rounded-lg border border-line-base flex flex-col min-h-[120px]">
+      <div class="px-3 py-2 border-b border-line-base flex items-center justify-between">
+        <span class="text-xs font-semibold text-gray-600 uppercase tracking-wider">{{ label }}</span>
+        <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 rounded-full bg-gray-200 text-gray-600 text-xs font-medium">{{ cards | length }}</span>
+      </div>
+      <div class="p-2 space-y-1.5 flex-1">
+        {% for card in sorted_cards %}{{ deal_card(card) }}{% endfor %}
+        {% if not cards %}
+        <div class="px-2 py-4 text-center text-xs text-gray-300">—</div>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  {# ── Collapsed Done summary bar (default closed; expand to the completed cards) ──
+     Sized via .btn-ghost/.btn-sm (the canonical collapse-bar pattern, mirroring the
+     Completed archive) — never inline px-/py- on the button. #}
+  <div class="mt-4" x-data="{ doneOpen: false }">
+    <button type="button"
+            @click="doneOpen = !doneOpen"
+            :aria-expanded="doneOpen"
+            class="btn-ghost btn-sm w-full justify-start gap-2 border border-line-base bg-gray-50 text-xs text-gray-600 hover:bg-gray-100">
+      <span x-show="!doneOpen" aria-hidden="true">▸</span>
+      <span x-show="doneOpen" aria-hidden="true">▾</span>
+      <span class="font-medium text-gray-700">Done</span>
+      <span class="text-brand-300" aria-hidden="true">·</span>
+      <span class="tabular-nums">{{ archive.total }}</span>
+    </button>
+    <div x-show="doneOpen" x-cloak class="mt-3 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {% for card in archive.deals %}{{ deal_card(card) }}{% endfor %}
+      {% if not archive.deals %}
+      <div class="px-2 py-6 text-center text-xs text-gray-300 sm:col-span-2 lg:col-span-3">No completed deals yet.</div>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/app/templates/htmx/partials/buy_plans/hub.html
+++ b/app/templates/htmx/partials/buy_plans/hub.html
@@ -1,14 +1,16 @@
 {#
   buy_plans/hub.html — Approvals hub shell with a lifecycle stage-tab switcher.
   Tabs: My Queue (the role-aware "what needs YOU now" surface — the default landing for
-  non-supervisors), then the five lifecycle stages Sales Orders, Buy Plans, Purchase
-  Orders, Vendor Prepayments, Supervise. The body lazy-loads the active tab partial into
+  non-supervisors) + Pipeline (the 4-stage deal board — the default landing for
+  supervisors), then the five lifecycle stages Sales Orders, Buy Plans, Purchase Orders,
+  Vendor Prepayments, Supervise. The body lazy-loads the active tab partial into
   #bp-hub-body.
-  Receives: lens (str: 'my_queue'|'sales_orders'|'buy_plans'|'purchase_orders'|
+  Receives: lens (str: 'my_queue'|'pipeline'|'sales_orders'|'buy_plans'|'purchase_orders'|
             'prepayments'|'supervise'), can_supervise (bool), alert_markers (dict).
   Called by: htmx/buy_plans.py buy_plans_list_partial (GET /v2/partials/approvals).
   Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette; the per-tab bodies under
-              approvals/ (lazy-loaded into #bp-hub-body) — my-queue → _surface_my_queue.html.
+              approvals/ (lazy-loaded into #bp-hub-body) — my-queue → _surface_my_queue.html,
+              pipeline → _surface_pipeline.html.
 #}
 <title hx-swap-oob="true">Approvals — AvailAI</title>
 
@@ -19,7 +21,7 @@
      (can_supervise). The work surface + the pinned approval section INSIDE each stage are
      what gate further by role. #}
   <div class="flex flex-wrap items-center gap-2 mb-5">
-    {% for l, label in [('my_queue', 'My Queue'), ('sales_orders', 'Sales Orders'), ('buy_plans', 'Buy Plans'), ('purchase_orders', 'Purchase Orders'), ('prepayments', 'Vendor Prepayments'), ('supervise', 'Supervise')] %}
+    {% for l, label in [('my_queue', 'My Queue'), ('pipeline', 'Pipeline'), ('sales_orders', 'Sales Orders'), ('buy_plans', 'Buy Plans'), ('purchase_orders', 'Purchase Orders'), ('prepayments', 'Vendor Prepayments'), ('supervise', 'Supervise')] %}
     {% if l != 'supervise' or can_supervise %}
     {# Highlight is Alpine-reactive (:class on lens) so the active pill updates the
        instant a tab is clicked — before the server swap returns — and stays correct

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1428,14 +1428,14 @@ flow. See APP_MAP_DATABASE `po_cancellations`.
 
 **Approvals module — lifecycle stage-tab read flow (SP-1).** `/v2/approvals` is its own
 primary-nav tab (legacy `/v2/buy-plans` 302-redirects to it, preserving `?lens=`) rendering
-a stage-tab shell (`partials/buy_plans/hub.html`): a switcher over **My Queue** + the five
-**lifecycle stages** + a lazy `#bp-hub-body` that loads the active tab body. The shell route
-`GET /v2/partials/approvals?lens=` (alias `/v2/partials/buy-plans`) resolves the tab
-(`my_queue`/`sales_orders`/`buy_plans`/`purchase_orders`/`prepayments`/`supervise`), falling
-back to a **role-derived default** (`_default_lens`): managers/admins/ops → Supervise,
-everyone else (buyers/sales/traders) → **My Queue** (the Approvals-rework Phase B role-aware
-"what needs YOU now" surface; Pipeline replaces Supervise as the supervisor default in
-Phase C). Only the **Supervise** tab is gate-rendered
+a stage-tab shell (`partials/buy_plans/hub.html`): a switcher over **My Queue** + **Pipeline**
++ the five **lifecycle stages** + a lazy `#bp-hub-body` that loads the active tab body. The
+shell route `GET /v2/partials/approvals?lens=` (alias `/v2/partials/buy-plans`) resolves the
+tab (`my_queue`/`pipeline`/`sales_orders`/`buy_plans`/`purchase_orders`/`prepayments`/
+`supervise`), falling back to a **role-derived default** (`_default_lens`): managers/admins/ops
+→ **Pipeline** (the Approvals-rework Phase C 4-stage deal board), everyone else
+(buyers/sales/traders) → **My Queue** (the Phase B role-aware "what needs YOU now" surface).
+Only the **Supervise** tab is gate-rendered
 (`_can_supervise` = manager/admin OR ops verification-group member); the other four stage
 tabs are always shown — the *work surface* and the *pinned approval section* inside each
 gate further by role. URL paths are dash-cased (`/v2/partials/approvals/<stage>`); lens keys
@@ -1469,6 +1469,13 @@ the pinned section survives a toggle. The standalone `/board` route keeps the de
 ```
 GET /v2/partials/approvals?lens=          (shell: stage-tab switcher + lazy #bp-hub-body)
     |
+    +-- pipeline        --> GET /partials/approvals/pipeline?scope=  (_render_pipeline_body)
+    |                        buyplan_hub.deals_board called ONCE PER COLUMN with an explicit
+    |                        status filter — Build=[DRAFT], Approve=[PENDING],
+    |                        Purchase=[ACTIVE,INBOUND] — + completed_archive for the collapsed
+    |                        Done column. Same _resolve_deal_scope + All/Mine toggle (reloads
+    |                        #bp-hub-body, hx-push-url=false). Cards via the deal_card macro
+    |                        (4-pip "who-has-the-ball" stepper). See the Pipeline surface note.
     +-- sales_orders    --> GET /partials/approvals/sales-orders?scope=  (SP-2 work surface)
     |                        "New Sales Order" button (-> GET /partials/approvals/sales-orders/
     |                        new requisition picker -> create_sales_order_from_offers) + the
@@ -1549,6 +1556,25 @@ other kind is a **whole-row link** to its detail screen (where its form / multi-
 lives), trailing `{action} →`. There is NO colored left rail (the dot + risk-first sort
 already encode risk). `prepay_approve` is a navigation row (its decision endpoint returns
 JSON, not a partial — inline one-click lands in Phase D).
+
+**Pipeline surface (Approvals rework Phase C — the 4-stage deal board).** The `pipeline`
+lens renders `approvals/_surface_pipeline.html` via `_render_pipeline_body` (the
+`approvals_tab_partial` dispatch branch). It shows the deal flow as cards in the four
+canonical stages **Build → Approve → Purchase → Done** (retiring the Draft/Pending/Active
+vocabulary). Three columns are visible (Build / Approve / Purchase) with a **collapsed Done
+summary bar** below (Alpine `x-show`, default closed). Each column is ONE
+`buyplan_hub.deals_board` call with an explicit status filter (`[DRAFT]`, `[PENDING]`,
+`[ACTIVE, INBOUND]` — `INBOUND` now buckets to the `active` column via `_STATUS_TO_COLUMN`);
+Done is `completed_archive`. Cards render through the shared `deal_card` macro
+(`approvals/_pipeline_macros.html`): the signature **4-pip "who-has-the-ball" stepper**
+(`●●○○` — done pips `bg-brand-500`, the single live ball `bg-accent-500`, upcoming hollow
+`border-brand-200`) computed from the card's `status`→stage index (DRAFT 0 / PENDING 1 /
+ACTIVE|INBOUND 2 / COMPLETED 3) **replaces the old blocker line + PO progress bar**, plus
+Customer + tabular value + a muted `SO · owner` line + ONE margin-health badge + the `stock`
+chip; a card needing the viewer's action (own DRAFT) gains a `ring-accent-400` (not amber).
+Scope is role-resolved exactly like the board (`_resolve_deal_scope` + `_can_see_all_deals`);
+the **Mine/All toggle** reloads this body in place (`hx-target="#bp-hub-body"`,
+`hx-push-url="false"`). A light `metric_strip` macro shows the open count + value.
 
 **My Queue foundation (Approvals rework Phase A — the service-layer read model).**
 `buyplan_hub.my_queue(db, user) -> list[QueueRow]` is the role-aware "what needs YOU now"

--- a/tests/test_approvals_module_shell.py
+++ b/tests/test_approvals_module_shell.py
@@ -116,11 +116,11 @@ def test_default_lens_buyer_is_my_queue(db_session: Session, test_user: User):
     assert _default_lens(test_user, db_session) == "my_queue"
 
 
-def test_default_lens_manager_is_supervise(db_session: Session, manager_user: User):
-    """Managers/ops land on Supervise (until the Pipeline surface ships in Phase C)."""
+def test_default_lens_manager_is_pipeline(db_session: Session, manager_user: User):
+    """Managers/ops land on Pipeline — the 4-stage deal board (Phase C)."""
     from app.routers.htmx.buy_plans import _default_lens
 
-    assert _default_lens(manager_user, db_session) == "supervise"
+    assert _default_lens(manager_user, db_session) == "pipeline"
 
 
 def test_default_lens_sales_is_my_queue(db_session: Session, sales_user: User):

--- a/tests/test_buyplan_hub_routes.py
+++ b/tests/test_buyplan_hub_routes.py
@@ -165,8 +165,8 @@ def test_buy_plans_tab_sales_locked_to_mine_no_toggle(client: TestClient, sales_
     assert "?scope=mine" not in resp.text
 
 
-def test_hub_shell_manager_defaults_to_supervise(client: TestClient, manager_user):
-    """A manager with no lens lands on the Supervise tab body."""
+def test_hub_shell_manager_defaults_to_pipeline(client: TestClient, manager_user):
+    """A manager with no lens lands on the Pipeline tab body (Phase C default)."""
     from app.dependencies import require_user
     from app.main import app
 
@@ -176,7 +176,7 @@ def test_hub_shell_manager_defaults_to_supervise(client: TestClient, manager_use
     finally:
         app.dependency_overrides.pop(require_user, None)
     assert resp.status_code == 200
-    assert "/v2/partials/approvals/supervise" in resp.text
+    assert "/v2/partials/approvals/pipeline" in resp.text
 
 
 def test_hub_supervise_button_hidden_for_sales(client: TestClient, sales_user):

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -545,7 +545,7 @@ def test_inline_button_sizing_does_not_grow():
 
     Macro files are the canonical source and are excluded. Ratchet.
     """
-    BASELINE = 228  # +2 My Queue surface filter-chip pills (same rounded-full lens/scope pill pattern, no .btn-* equivalent; Approvals rework Phase B); was 226 (+2 supervise filter-chips), 224 after the UI program (was 280)
+    BASELINE = 229  # +1 Pipeline surface Mine/All scope-toggle pill (same rounded-full lens/scope pill pattern as _board.html, no .btn-* equivalent; Approvals rework Phase C); was 228 (+2 My Queue filter-chip pills), 226 (+2 supervise filter-chips), 224 after the UI program (was 280)
     count = _tpl_regex_count(r'<button[^>]*class="[^"]*\bp[xy]-[0-9]', exclude={"_macros.html"})
     assert count <= BASELINE, (
         f"inline-sized <button> rose to {count} (baseline {BASELINE}). Use .btn-sm/md/lg or the btn_* macros."

--- a/tests/test_surface_pipeline.py
+++ b/tests/test_surface_pipeline.py
@@ -1,0 +1,178 @@
+"""Route + render tests for the Pipeline surface (Approvals rework Phase C).
+
+Covers GET /v2/partials/approvals/pipeline → _render_pipeline_body → _surface_pipeline.html:
+- 200 for a buyer fixture, with the empty all-columns state;
+- the three visible stage columns (Build / Approve / Purchase) render the right plans by
+  status (DRAFT→Build, PENDING→Approve, ACTIVE→Purchase);
+- the Done summary is collapsed by default (x-show on the cards, default closed);
+- the Mine/All scope toggle fires ?scope=all with hx-target="#bp-hub-body" + push-url off;
+- the signature 4-pip stepper renders the correct "ball" position (the single accent node)
+  for a plan in each of the four stages.
+
+Reuses the buy-plan builders from tests/test_buyplan_hub_board.py and conftest fixtures
+(client, db_session, test_user, test_quote, test_requisition).
+
+Depends on: app/routers/htmx/buy_plans (pipeline lens dispatch),
+            app/templates/htmx/partials/approvals/_surface_pipeline.html + _pipeline_macros.html.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.constants import BuyPlanStatus
+from tests.test_buyplan_hub_board import _make_plan
+
+PIPELINE_URL = "/v2/partials/approvals/pipeline"
+
+
+# ── Empty state ─────────────────────────────────────────────────────────────
+
+
+def test_pipeline_surface_empty_state(client: TestClient):
+    """A buyer with no deals gets 200 + the three stage columns and an empty Done
+    bar."""
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    # Three visible stage columns, canonical labels only (no Draft/Pending/Active vocab).
+    assert "Build" in body
+    assert "Approve" in body
+    assert "Purchase" in body
+    assert "Done" in body
+    # Empty → no card carries a pip ball.
+    assert "bg-accent-500" not in body
+
+
+# ── Column bucketing by status ──────────────────────────────────────────────
+
+
+def test_pipeline_columns_bucket_by_status(
+    client: TestClient, db_session: Session, test_user, test_quote, test_requisition
+):
+    """A DRAFT / PENDING / ACTIVE plan each render under the right column.
+
+    The buyer sees all deals (scope defaults to ``all``); each card links to its detail and
+    carries its stage's pip ball, so the aggregate pip counts pin the bucketing:
+    balls = 3 (one per card), done pips = 0 (Build) + 1 (Approve) + 2 (Purchase) = 3.
+    """
+    kw = dict(quote_id=test_quote.id, requisition_id=test_requisition.id)
+    draft = _make_plan(db_session, status=BuyPlanStatus.DRAFT, **kw)
+    pending = _make_plan(db_session, status=BuyPlanStatus.PENDING, **kw)
+    active = _make_plan(db_session, status=BuyPlanStatus.ACTIVE, **kw)
+
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Column headers present.
+    assert "Build" in body and "Approve" in body and "Purchase" in body
+    # Every plan's card links to its detail.
+    for plan in (draft, pending, active):
+        assert f'hx-get="/v2/partials/buy-plans/{plan.id}"' in body
+    # One ball per card; done-pip total fixes each ball position (0 + 1 + 2 = 3).
+    assert body.count("bg-accent-500") == 3
+    assert body.count("bg-brand-500") == 3
+    # Canonical stage captions appear (one per card).
+    assert ">Build</span>" in body
+    assert ">Approve</span>" in body
+    assert ">Purchase</span>" in body
+
+
+# ── 4-pip stepper: ball position per stage ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "status,expected_ball_index",
+    [
+        (BuyPlanStatus.DRAFT, 0),  # Build
+        (BuyPlanStatus.PENDING, 1),  # Approve
+        (BuyPlanStatus.ACTIVE, 2),  # Purchase
+        (BuyPlanStatus.COMPLETED, 3),  # Done
+    ],
+)
+def test_pipeline_pip_ball_position(
+    client: TestClient,
+    db_session: Session,
+    test_user,
+    test_quote,
+    test_requisition,
+    status,
+    expected_ball_index,
+):
+    """A single plan in each stage renders exactly one accent ball, with the number of
+    filled (done) pips before it equal to the stage index — proving the ball lands on
+    the plan's current stage.
+
+    COMPLETED is server-rendered inside the collapsed Done section.
+    """
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=status,
+    )
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    # Exactly one ball (accent node) for the one card on the page.
+    assert body.count("bg-accent-500") == 1
+    # Filled done pips precede the ball → their count is the ball's stage index.
+    assert body.count("bg-brand-500") == expected_ball_index
+
+
+# ── Done collapsed by default ───────────────────────────────────────────────
+
+
+def test_pipeline_done_collapsed_by_default(
+    client: TestClient, db_session: Session, test_user, test_quote, test_requisition
+):
+    """The Done section is collapsed by default — its cards live under x-show with the
+    toggle starting closed."""
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+    )
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    # The collapsible starts closed and the completed cards are gated on it.
+    assert "doneOpen: false" in body
+    assert 'x-show="doneOpen"' in body
+    # The Done summary bar shows the count.
+    assert ">Done</span>" in body
+
+
+# ── Scope toggle ────────────────────────────────────────────────────────────
+
+
+def test_pipeline_scope_toggle_targets_hub_body(client: TestClient):
+    """A can-see-all viewer (buyer) gets the Mine/All toggle: ?scope=all reloads the
+    body in place (hx-target #bp-hub-body) and never pushes a URL (R6)."""
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "/v2/partials/approvals/pipeline?scope=all" in body
+    assert "/v2/partials/approvals/pipeline?scope=mine" in body
+    assert 'hx-target="#bp-hub-body"' in body
+    assert 'hx-push-url="false"' in body
+
+
+def test_pipeline_sales_locked_to_mine_no_toggle(client: TestClient, sales_user):
+    """A sales user (no cross-owner visibility) gets no scope toggle and scope=all is
+    refused, so no other rep's deals leak — exactly like the standalone board."""
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[require_user] = lambda: sales_user
+    try:
+        resp = client.get(f"{PIPELINE_URL}?scope=all")
+    finally:
+        app.dependency_overrides.pop(require_user, None)
+    assert resp.status_code == 200
+    assert "?scope=all" not in resp.text
+    assert "?scope=mine" not in resp.text


### PR DESCRIPTION
## Phase C — Pipeline surface (Approvals-module rework)

The third phase of the approved Approvals rework. Adds the **Pipeline** surface: the deal flow as cards in the four canonical stages **Build → Approve → Purchase → Done**. Additive — the old 5 lenses stay until Phase F.

### What's in it
- **Route + dispatch** (`buy_plans.py`): `pipeline` added to `_APPROVALS_TABS`; `_render_pipeline_body` dispatched from `approvals_tab_partial` for `GET /v2/partials/approvals/pipeline?scope=mine|all`. Each column is one `deals_board` call with an explicit status filter — Build `[DRAFT]`, Approve `[PENDING]`, Purchase `[ACTIVE, INBOUND]` — and Done is `completed_archive`. `_default_lens` now lands supervisors (managers/admins/ops) on Pipeline.
- **Shell** (`hub.html`): a **Pipeline** tab beside My Queue (same Alpine lens pattern, `hx-push-url` to `/v2/approvals?lens=pipeline`).
- **`_surface_pipeline.html`**: 3 visible columns (Build · Approve · Purchase) + a **collapsed Done summary bar** (`▸ Done · N`, Alpine `x-show`, default closed) + a **Mine/All scope toggle** (reloads `#bp-hub-body`, `hx-push-url="false"`) + a light metric strip.
- **`_pipeline_macros.html`**: `deal_card(card)` — de-noised card with the signature **4-pip "who-has-the-ball" stepper** (`●●○○`: done `bg-brand-500`, ball `bg-accent-500`, upcoming hollow `border-brand-200`) computed from `status`→stage, replacing the blocker line + PO progress bar; needs-my-action ring → `ring-accent-400`. Plus `metric_strip(...)`.
- **`buyplan_hub.py`**: `INBOUND` now buckets to the `active` column (Purchase sub-status — previously silently dropped by the column safety net); the deal-card dict carries the raw `status` for pip computation.

### Status → stage → pip mapping
| status | stage | column | ball pip index |
|---|---|---|---|
| `DRAFT` | Build | Build | 0 |
| `PENDING` | Approve | Approve | 1 |
| `ACTIVE` / `INBOUND` | Purchase | Purchase | 2 |
| `COMPLETED` | Done | Done (collapsed) | 3 |

`HALTED`/`CANCELLED` are off-ramps and never reach the Pipeline board.

### Verification
- **Tests**: `tests/test_surface_pipeline.py` — route 200, column bucketing by status, the 4-pip ball position per stage, Done collapsed by default, scope toggle target/push-url. Two existing default-lens tests updated (supervisor → pipeline). The inline-button ratchet baseline bumped +1 (the scope-toggle pill; same lens/scope-pill pattern as `_board.html`).
- **Full suite**: 21505 passed, 18 skipped, 0 failed (`-n auto`).
- **Tailwind gate**: `npm run build` clean; every new class (`bg-brand-500`, `bg-accent-500`, `border-brand-200`, `ring-accent-400`, pip sizing) present in `app/static/dist/assets/*.css` — no safelist change needed.
- **pre-commit**: clean on all changed files.
- APP_MAP_INTERACTIONS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZy72e78nrSBXgaXxChMBZ
