### PR TITLE
feat(approvals): Phase F-1 gap-fills — restore parity before retiring lenses

### DIFF
--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -15,7 +15,7 @@ Depends on: app.models, app.dependencies, app.database, app.services.approvals,
 import json
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from loguru import logger
 from sqlalchemy import select
@@ -166,6 +166,37 @@ async def buy_plans_list_partial(
         }
     )
     return template_response("htmx/partials/buy_plans/hub.html", ctx)
+
+
+@router.get("/v2/partials/approvals/pipeline-archive", response_class=HTMLResponse)
+async def pipeline_archive_partial(
+    request: Request,
+    scope: str = "",
+    offset: int = 0,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Lazy "load older" page of the Pipeline's Done (completed) deals.
+
+    The Pipeline surface renders its Done cards via the shared archive-rows partial; this
+    returns the next page of those cards (newest-completed first) so a "Load older" click
+    appends in place. Scope is role-resolved exactly like the board so no other rep's
+    completed deals leak. MUST be registered BEFORE the one-segment ``{tab}`` catch-all
+    below, or FastAPI routes "pipeline-archive" there as an unknown tab (404). Mirrors
+    ``buy_plans_archive_partial`` (the board's lazy archive page).
+    """
+    from ...services.buyplan_hub import completed_archive
+
+    scope = _resolve_deal_scope(scope, _can_see_all_deals(user, db))
+
+    ctx = _base_ctx(request, user, "buy-plans")
+    ctx.update(
+        {
+            "archive": completed_archive(db, user, scope=scope, offset=offset),
+            "scope": scope,
+        }
+    )
+    return template_response("htmx/partials/approvals/_pipeline_archive_rows.html", ctx)
 
 
 @router.get("/v2/partials/approvals/{tab}", response_class=HTMLResponse)
@@ -417,6 +448,42 @@ async def sales_order_create(
     return resp
 
 
+@router.post("/v2/partials/approvals/prepay-requests/{request_id}/decide", response_class=HTMLResponse)
+async def prepay_request_decide(
+    request: Request,
+    request_id: int,
+    action: str = Form("approve"),
+    comment: str | None = Form(None),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Decide a prepayment ApprovalRequest from the My Queue inline action (HTML re-
+    render).
+
+    The standalone decision route (POST /v2/approvals/requests/{id}/decision) returns JSON;
+    My Queue instead needs the refreshed queue body swapped into ``#bp-hub-body``. This thin
+    sibling resolves the request via the SAME approvals-engine ``decide`` (no duplicated
+    logic), then re-renders the My Queue surface (origin=my_queue parity with the approve /
+    verify-po handlers). Reject requires a non-blank comment (400 otherwise); a caller who
+    holds no PENDING recipient slot is 403 (engine PermissionError); a stale/decided request
+    is 400 (engine ValueError).
+    """
+    from ...services.approvals.service import decide as svc_decide
+
+    if action == "reject" and not (comment or "").strip():
+        raise HTTPException(400, "A reason is required to reject a prepayment.")
+
+    try:
+        svc_decide(db, request_id, user, action, comment=comment or None)
+        db.commit()
+    except PermissionError as e:
+        raise HTTPException(403, str(e))
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+    return _render_my_queue_body(request, user, db)
+
+
 @router.get("/v2/partials/buy-plans/resource", response_class=HTMLResponse)
 async def buy_plans_resource_partial(
     request: Request,
@@ -524,10 +591,10 @@ def _render_my_queue_body(request: Request, user: User, db: Session) -> HTMLResp
     (it gates which kinds it emits by the viewer's rights / role / ownership), so no extra
     gating is needed here — Jinja consumes only the resolved ``QueueRow`` list.
     """
-    from ...services.buyplan_hub import my_queue
+    from ...services.buyplan_hub import my_queue, open_avg_margin
 
     ctx = _base_ctx(request, user, "buy-plans")
-    ctx.update({"queue": my_queue(db, user), "user": user})
+    ctx.update({"queue": my_queue(db, user), "avg_margin": open_avg_margin(db), "user": user})
     return template_response("htmx/partials/approvals/_surface_my_queue.html", ctx)
 
 
@@ -544,7 +611,7 @@ def _render_pipeline_body(request: Request, user: User, db: Session, scope: str 
     All/Mine; sales/traders are locked to ``mine`` so no other rep's deals leak. The Mine/All
     toggle reloads THIS body in place (hx-target #bp-hub-body, hx-push-url="false").
     """
-    from ...services.buyplan_hub import completed_archive, deals_board
+    from ...services.buyplan_hub import completed_archive, deals_board, open_avg_margin
 
     can_all = _can_see_all_deals(user, db)
     board_scope = _resolve_deal_scope(scope, can_all)
@@ -554,6 +621,10 @@ def _render_pipeline_body(request: Request, user: User, db: Session, scope: str 
     purchase = deals_board(
         db, user, scope=board_scope, statuses=[BuyPlanStatus.ACTIVE.value, BuyPlanStatus.INBOUND.value]
     )
+    # HALTED is the off-ramp — buyers regain its visibility via a dedicated Halted column
+    # (rework parity). HALTED maps to the "active" bucket in _STATUS_TO_COLUMN. The column
+    # only renders for can_see_all_deals viewers (see the surface template).
+    halted = deals_board(db, user, scope=board_scope, statuses=[BuyPlanStatus.HALTED.value])
 
     ctx = _base_ctx(request, user, "buy-plans")
     ctx.update(
@@ -561,9 +632,11 @@ def _render_pipeline_body(request: Request, user: User, db: Session, scope: str 
             "build_col": build["draft"],
             "approve_col": approve["pending"],
             "purchase_col": purchase["active"],
+            "halted_col": halted["active"],
             "archive": completed_archive(db, user, scope=board_scope),
             "scope": board_scope,
             "can_see_all_deals": can_all,
+            "avg_margin": open_avg_margin(db),
             "user": user,
         }
     )

--- a/app/services/buyplan_hub.py
+++ b/app/services/buyplan_hub.py
@@ -625,6 +625,25 @@ _OPEN_STATUSES: frozenset[str] = frozenset(
     }
 )
 
+
+def open_avg_margin(db: Session) -> float:
+    """Average ``total_margin_pct`` across all open (non-terminal) plans; ``0.0`` if
+    none.
+
+    The single cheap aggregate behind the "avg margin" figure shown on BOTH the My Queue
+    header and the Pipeline metric strip. Mirrors the avg_margin aggregation in
+    :func:`supervise_overview` (same ``_OPEN_STATUSES`` set; NULL margins excluded by AVG,
+    coalesced to 0) but as a standalone query so the two lighter surfaces don't pay for the
+    full supervise overview build.
+    """
+    avg = (
+        db.query(func.coalesce(func.avg(BuyPlan.total_margin_pct), 0))
+        .filter(BuyPlan.status.in_(_OPEN_STATUSES))
+        .scalar()
+    )
+    return float(avg or 0.0)
+
+
 #: Risk-first priority tier for each *supervise-lens* action-queue row kind
 #: (1 = highest risk, surfaced first). The supervise lens sorts its unified queue by
 #: ``(priority, waiting_since)`` so the riskiest, oldest items lead. Distinct from the
@@ -1044,6 +1063,7 @@ class QueueRow:
 _QUEUE_PRIORITY: dict[str, int] = {
     "halted": 1,
     "plan_returned": 2,
+    "flagged": 2,
     "plan_approve": 3,
     "prepay_approve": 3,
     "po_verify": 4,
@@ -1058,6 +1078,7 @@ _QUEUE_PRIORITY: dict[str, int] = {
 _QUEUE_LABEL: dict[str, str] = {
     "halted": "Halted",
     "plan_returned": "Returned",
+    "flagged": "Flagged",
     "plan_approve": "Approve",
     "prepay_approve": "Prepay",
     "po_verify": "Verify",
@@ -1072,6 +1093,7 @@ _QUEUE_LABEL: dict[str, str] = {
 _QUEUE_ACTION_LABEL: dict[str, str] = {
     "halted": "Open",
     "plan_returned": "Resubmit",
+    "flagged": "Open",
     "plan_approve": "Approve",
     "prepay_approve": "Approve",
     "po_verify": "Verify",
@@ -1192,6 +1214,20 @@ def _make_line_row(line: BuyPlanLine, *, kind: str, since: datetime | None, cuto
     Touches only eager-loaded relationships (buy_plan, offer, buyer, requirement).
     """
     plan = line.buy_plan
+    extra: dict = {
+        "margin_pct": plan.total_margin_pct if plan else None,
+        "vendor_name": line.offer.vendor_name if line.offer else None,
+        "owner_name": _user_name(line.buyer),
+        "owner_role": "Buyer",
+    }
+    # flagged rows carry the buyer's issue reason for at-a-glance triage; cut-PO rows expose
+    # whether they were kicked back (manager/ops rejected the PO) + the rejection note so the
+    # My Queue surface can flag + explain the re-cut, mirroring the buyer Orders lens.
+    if kind == "flagged":
+        extra["issue_reason"] = _issue_reason(line)
+    elif kind in ("cut_po", "cut_po_overdue"):
+        extra["kicked_back"] = line.po_rejection_note is not None
+        extra["po_rejection_note"] = line.po_rejection_note
     return QueueRow(
         kind=kind,
         priority=_QUEUE_PRIORITY[kind],
@@ -1207,12 +1243,7 @@ def _make_line_row(line: BuyPlanLine, *, kind: str, since: datetime | None, cuto
         action_url=_action_url(kind, plan_id=line.buy_plan_id, line_id=line.id, request_id=None),
         action_label=_QUEUE_ACTION_LABEL[kind],
         detail_href=f"/v2/partials/buy-plans/{line.buy_plan_id}",
-        extra={
-            "margin_pct": plan.total_margin_pct if plan else None,
-            "vendor_name": line.offer.vendor_name if line.offer else None,
-            "owner_name": _user_name(line.buyer),
-            "owner_role": "Buyer",
-        },
+        extra=extra,
     )
 
 
@@ -1287,6 +1318,9 @@ def _prepay_rows(db: Session, user: object) -> list[QueueRow]:
                     "vendor_name": (pp.vendor_card.display_name if pp and pp.vendor_card else None),
                     "amount": ar.amount,
                     "owner_role": "Approver",
+                    # The engine request id so the My Queue inline action can build the
+                    # decide URL (the QueueRow.action_url stays the JSON decision route).
+                    "request_id": ar.id,
                 },
             )
         )
@@ -1333,6 +1367,14 @@ def my_queue(db: Session, user: object) -> list[QueueRow]:
         kind = "plan_returned" if _is_returned(plan) else "plan_draft"
         since = plan.approved_at if kind == "plan_returned" else plan.created_at
         rows.append(_make_plan_row(plan, kind=kind, since=since or plan.created_at))
+
+    # flagged (P2): buyer-flagged (ISSUE) lines are a supervisor triage surface — the buyer
+    # who raised them can't self-resolve, so they route to managers/admins/ops only (parity
+    # with the supervise lens). Shares _query_flagged_lines with supervise_overview.
+    if is_supervisor:
+        rows += [
+            _make_line_row(ln, kind="flagged", since=ln.created_at, cutoff=cutoff) for ln in _query_flagged_lines(db)
+        ]
 
     # plan_approve (P3): buy-plan approvers see every pending plan.
     if is_approver:

--- a/app/templates/htmx/partials/approvals/_pipeline_archive_rows.html
+++ b/app/templates/htmx/partials/approvals/_pipeline_archive_rows.html
@@ -1,0 +1,25 @@
+{#
+  approvals/_pipeline_archive_rows.html — one page of the Pipeline's Done (completed) deals
+  as deal_card tiles, plus a self-replacing "Load older" button when more pages remain.
+  Reused by _surface_pipeline.html (the initial Done render) AND
+  htmx/buy_plans.pipeline_archive_partial (the lazy "Load older" append).
+  Receives: archive (dict from buyplan_hub.completed_archive:
+                     deals/total/limit/offset/next_offset),
+            scope (str: 'mine'|'all').
+  Depends on: HTMX, approvals/_pipeline_macros.html (deal_card).
+
+  Append idiom: the "Load older" button targets ITSELF with hx-swap="outerHTML", so the next
+  page's cards replace the button in place (and carry their own button if more remain). The
+  cards are emitted as siblings before it. Mirrors buy_plans/_archive_rows.html.
+#}
+{% from "htmx/partials/approvals/_pipeline_macros.html" import deal_card %}
+{% for card in archive.deals %}{{ deal_card(card) }}{% endfor %}
+{% if archive.next_offset is not none %}
+<button hx-get="/v2/partials/approvals/pipeline-archive?scope={{ scope }}&offset={{ archive.next_offset }}"
+        hx-target="this"
+        hx-swap="outerHTML"
+        hx-push-url="false"
+        class="btn-secondary btn-sm col-span-full text-brand-600">
+  Load older
+</button>
+{% endif %}

--- a/app/templates/htmx/partials/approvals/_pipeline_macros.html
+++ b/app/templates/htmx/partials/approvals/_pipeline_macros.html
@@ -3,17 +3,20 @@
   rework Phase C): the de-noised deal card with the signature 4-pip "who-has-the-ball"
   stepper, and the parameterized open-count/value metric strip.
 
-  deal_card(card) — one calm deal tile, built from a buyplan_hub._deal_card dict. The
-    4-pip stepper (●●○○) replaces the old blocker line + PO progress bar: done pips fill
-    brand-500, the live "ball" (current stage) is the single accent-500 node, upcoming
-    pips are hollow brand-200 outlines. The ball position is the card's status mapped to a
-    4-stage index (DRAFT→Build 0, PENDING→Approve 1, ACTIVE|INBOUND→Purchase 2,
-    COMPLETED→Done 3). Customer is the one bold line; value is tabular; SO · owner is a
-    muted secondary line; ONE margin-health badge; the stock chip is kept. A card that
-    needs the viewer's action (own DRAFT) gains an accent ring (not amber — single-accent
-    rule). The whole tile is a keyboard-navigable link to the plan detail.
+  deal_card(card) — one calm deal tile, built from a buyplan_hub._deal_card dict. Customer is
+    the one bold line; value is tabular; SO · owner is a muted secondary line; ONE
+    margin-health badge; the stock chip is kept. Below the money row sit a light fact line
+    (primary part / our PO numbers), a Returned badge for a rejected-resubmit draft else the
+    blocker text, and a thin verified/total PO-progress bar (Phase F-1 parity additions). The
+    signature 4-pip stepper (●●○○) stays LAST: done pips fill brand-500, the live "ball"
+    (current stage) is the single accent-500 node, upcoming pips are hollow brand-200
+    outlines. The ball position is the card's status mapped to a 4-stage index (DRAFT→Build 0,
+    PENDING→Approve 1, ACTIVE|INBOUND→Purchase 2, COMPLETED→Done 3). A card that needs the
+    viewer's action (own DRAFT) gains an accent ring (not amber — single-accent rule). The
+    whole tile is a keyboard-navigable link to the plan detail.
 
-  metric_strip(open_count, open_value) — the light contextual strip (N open deals · $value).
+  metric_strip(open_count, open_value, avg_margin=none) — the light contextual strip
+    (N open deals · $value · N% avg margin when avg_margin is truthy).
 
   Used by: approvals/_surface_pipeline.html.
   Depends on: HTMX, Alpine.js (card keyboard activation), Tailwind brand/accent/line palette,
@@ -61,7 +64,46 @@
     <span class="{% if m >= 30 %}badge-success{% elif m >= 15 %}badge-warning{% else %}badge-danger{% endif %}">{{ '{:.1f}'.format(m) }}%</span>
   </div>
 
-  {# Signature 4-pip "who-has-the-ball" stepper + stage caption (replaces blocker + bar) #}
+  {# Light fact line: primary part / our PO(s) — at-a-glance scan without opening the deal
+     (mirror _board's fact line; brand-400 to stay quiet under the money row). #}
+  {% if card.primary_mpn or card.po_numbers %}
+  <div class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-brand-400">
+    {% if card.primary_mpn %}
+    <span class="font-mono truncate max-w-[10rem]" title="Primary part {{ card.primary_mpn }}">{{ card.primary_mpn }}</span>
+    {% endif %}
+    {% if card.po_numbers %}
+    {% if card.primary_mpn %}<span class="text-brand-300" aria-hidden="true">·</span>{% endif %}
+    <span title="PO(s): {{ card.po_numbers | join(', ') }}">PO <span class="font-mono">{{ card.po_numbers | join(', ') }}</span></span>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {# Returned / blocker line — a returned (rejected-resubmit) draft gets a loud Returned
+     badge; every other state shows its calm blocker text (rework parity). #}
+  {% if card.blocker %}
+  <div class="mt-1">
+    {% if 'rejected' in card.blocker %}
+    <span class="badge-danger">Returned</span>
+    {% else %}
+    <span class="text-xs text-gray-600">{{ card.blocker }}</span>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {# PO-progress bar (thin/subtle, verified/total) — mirror _board. #}
+  {% if card.po_progress[1] %}
+  <div class="mt-1.5">
+    <div class="flex items-center justify-between text-[11px] text-tertiary mb-0.5">
+      <span>POs</span>
+      <span>{{ card.po_progress[0] }}/{{ card.po_progress[1] }}</span>
+    </div>
+    <div class="h-1 w-full bg-gray-200 rounded-full overflow-hidden">
+      <div class="h-full bg-emerald-500 rounded-full" style="width: {{ (100 * card.po_progress[0] / card.po_progress[1]) | round(0, 'floor') | int }}%"></div>
+    </div>
+  </div>
+  {% endif %}
+
+  {# Signature 4-pip "who-has-the-ball" stepper + stage caption #}
   <div class="mt-1.5 flex items-center gap-2" title="Stage: {{ _STAGE_LABELS[s] }} ({{ s + 1 }} of 4)">
     <div class="flex items-center gap-1" aria-hidden="true">
       {% for i in range(4) %}
@@ -74,9 +116,10 @@
 {% endmacro %}
 
 
-{% macro metric_strip(open_count, open_value) %}
+{% macro metric_strip(open_count, open_value, avg_margin=none) %}
 <div class="flex items-center gap-4 text-xs text-gray-600">
   <span>{{ open_count }} open deal{{ 's' if open_count != 1 }}</span>
   <span>${{ '{:,.0f}'.format(open_value) }} open value</span>
+  {% if avg_margin %}<span>{{ '{:.0f}'.format(avg_margin) }}% avg margin</span>{% endif %}
 </div>
 {% endmacro %}

--- a/app/templates/htmx/partials/approvals/_surface_my_queue.html
+++ b/app/templates/htmx/partials/approvals/_surface_my_queue.html
@@ -27,7 +27,7 @@
    The filter token collapses plan_approve + prepay_approve into one "approve" chip and
    po_verify into "verify" (mirrors the spec's Verify-SO+PO collapse). Rows x-show on it. #}
 {% set band_of = {
-  'halted': 'risk', 'plan_returned': 'risk', 'cut_po_overdue': 'risk',
+  'halted': 'risk', 'plan_returned': 'risk', 'flagged': 'risk', 'cut_po_overdue': 'risk',
   'plan_approve': 'decide', 'prepay_approve': 'decide',
   'po_verify': 'routine', 'claim': 'routine', 'cut_po': 'routine',
   'receive': 'routine', 'plan_draft': 'routine'
@@ -35,7 +35,7 @@
 {% set dot_of = {'risk': 'bg-rose-500', 'decide': 'bg-accent-500', 'routine': 'bg-brand-400'} %}
 {% set label_color_of = {'risk': 'text-rose-600', 'decide': 'text-accent-600', 'routine': 'text-brand-500'} %}
 {% set token_of = {
-  'halted': 'halted', 'plan_returned': 'returned', 'cut_po_overdue': 'overdue',
+  'halted': 'halted', 'plan_returned': 'returned', 'flagged': 'flagged', 'cut_po_overdue': 'overdue',
   'plan_approve': 'approve', 'prepay_approve': 'approve', 'po_verify': 'verify',
   'claim': 'claim', 'cut_po': 'cut_po', 'receive': 'receive', 'plan_draft': 'draft'
 } %}
@@ -44,13 +44,15 @@
 {% macro queue_row(row, band_of, dot_of, label_color_of, token_of) %}
 {% set band = band_of[row.kind] %}
 {% set token = token_of[row.kind] %}
-{% set inline_action = row.kind in ('plan_approve', 'po_verify') %}
+{% set inline_action = row.kind in ('plan_approve', 'po_verify', 'prepay_approve') %}
+{% set kicked = row.extra.get('kicked_back') %}
 {% set m = row.extra.get('margin_pct') | float if row.extra.get('margin_pct') is not none else 0 %}
 {% set detail_url = row.detail_href %}
 {% set push_url = detail_url | replace('/partials', '') if detail_url else '' %}
 {% set ah = row.age_hours %}
 <div x-show="qf === 'all' || qf === '{{ token }}'"
      class="grid grid-cols-[16px_84px_minmax(0,1fr)_auto_auto_auto_auto] items-center gap-3 px-4 py-2.5
+            {% if kicked %}bg-rose-50{% endif %}
             {% if inline_action %}ring-1 ring-inset ring-accent-400{% else %}cursor-pointer hover:bg-brand-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500{% endif %}"
      {% if not inline_action and detail_url %}
      hx-get="{{ detail_url }}"
@@ -87,7 +89,15 @@
         {% if ns.shown %}<span class="text-brand-300" aria-hidden="true"> · </span>{% endif %}{{ row.extra.get('owner_role') }} {{ row.extra.get('owner_name') }}{% set ns.shown = true %}
       {%- endif -%}
       {%- if row.extra.get('amount') is not none -%}
-        {% if ns.shown %}<span class="text-brand-300" aria-hidden="true"> · </span>{% endif %}${{ '{:,.0f}'.format(row.extra.get('amount') | float) }} prepay
+        {% if ns.shown %}<span class="text-brand-300" aria-hidden="true"> · </span>{% endif %}${{ '{:,.0f}'.format(row.extra.get('amount') | float) }} prepay{% set ns.shown = true %}
+      {%- endif -%}
+      {# flagged: the buyer's issue reason in rose (mirror _supervise) #}
+      {%- if row.kind == 'flagged' and row.extra.get('issue_reason') -%}
+        {% if ns.shown %}<span class="text-brand-300" aria-hidden="true"> · </span>{% endif %}<span class="text-rose-600">{{ row.extra.get('issue_reason') }}</span>{% set ns.shown = true %}
+      {%- endif -%}
+      {# kicked-back cut PO: warning glyph + the manager/ops rejection note in rose #}
+      {%- if kicked and row.extra.get('po_rejection_note') -%}
+        {% if ns.shown %}<span class="text-brand-300" aria-hidden="true"> · </span>{% endif %}<span class="text-rose-700">⚠ {{ row.extra.get('po_rejection_note') }}</span>
       {%- endif -%}
     </div>
   </div>
@@ -119,6 +129,28 @@
       <button type="submit" name="action" value="reject" data-loading-disable
               hx-confirm="Send this PO back to the buyer?" class="btn-danger btn-sm">Reject</button>
     </form>
+    {% elif row.kind == 'prepay_approve' %}
+    {# Prepay decide — one-click Approve; Reject reveals a required-comment textarea (the
+       engine refuses a blank reject). Both post the HTML decide sibling that re-renders this
+       body; mirrors the _orders_queue showPo reveal pattern. #}
+    {% set decide_url = '/v2/partials/approvals/prepay-requests/' ~ row.extra.get('request_id') ~ '/decide' %}
+    <div x-data="{ rejectOpen: false }" class="flex flex-col items-end gap-1.5">
+      <div class="flex items-center gap-1.5">
+        <form hx-post="{{ decide_url }}" hx-target="#bp-hub-body" hx-swap="innerHTML" hx-push-url="false">
+          <input type="hidden" name="action" value="approve">
+          <button type="submit" data-loading-disable class="btn-primary btn-sm">Approve</button>
+        </form>
+        <button type="button" @click="rejectOpen = !rejectOpen" class="btn-danger btn-sm">Reject</button>
+      </div>
+      <form x-show="rejectOpen" x-cloak x-collapse
+            hx-post="{{ decide_url }}" hx-target="#bp-hub-body" hx-swap="innerHTML" hx-push-url="false"
+            class="space-y-1.5">
+        <input type="hidden" name="action" value="reject">
+        <textarea name="comment" rows="2" required placeholder="Why reject this prepayment?"
+                  class="input input-sm w-48"></textarea>
+        <button type="submit" data-loading-disable class="btn-danger btn-sm">Confirm reject</button>
+      </form>
+    </div>
     {% else %}
     <span class="text-xs font-medium text-accent-600 whitespace-nowrap">{{ row.action_label }} →</span>
     {% endif %}
@@ -134,11 +166,15 @@
 {% endfor %}
 {# Risk-first chip order; each renders only when present (live counts). #}
 {% set chip_order = [
-  ('halted', 'Halted'), ('returned', 'Returned'), ('overdue', 'Overdue'),
+  ('halted', 'Halted'), ('returned', 'Returned'), ('flagged', 'Flagged'), ('overdue', 'Overdue'),
   ('approve', 'Approve'), ('verify', 'Verify'), ('claim', 'Claim'),
   ('cut_po', 'Cut PO'), ('receive', 'Receive'), ('draft', 'Draft')
 ] %}
 {% set total_value = queue | map(attribute='value') | select | map('float') | sum %}
+{# Kicked-back tally over the queue (cut-PO rows the manager/ops sent back) — surfaced as a
+   rose header cue, mirroring the buyer Orders lens. #}
+{% set kb = namespace(n=0) %}
+{% for r in queue %}{% if r.extra.get('kicked_back') %}{% set kb.n = kb.n + 1 %}{% endif %}{% endfor %}
 
 {# ── Header + hero card share one Alpine root for the client-side filter ── #}
 <div x-data="{ qf: 'all' }">
@@ -149,7 +185,10 @@
       {% if queue %}{{ queue | length }} item{{ 's' if queue | length != 1 }} need{{ '' if queue | length != 1 else 's' }} you{% else %}You're all caught up{% endif %}
     </div>
     {% if queue %}
-    <div class="text-sm text-gray-600">${{ '{:,.0f}'.format(total_value) }} in play</div>
+    <div class="text-sm text-gray-600">${{ '{:,.0f}'.format(total_value) }} in play{% if avg_margin %} · {{ '{:.0f}'.format(avg_margin) }}% avg margin{% endif %}</div>
+    {% if kb.n %}
+    <div class="text-sm text-rose-600 font-medium">{{ kb.n }} kicked back</div>
+    {% endif %}
     <div class="mt-3 flex flex-wrap items-center gap-2">
       <button type="button" @click="qf = 'all'"
               :class="qf === 'all' ? 'bg-accent-600 text-white' : 'bg-brand-100 text-brand-600 hover:bg-brand-200'"

--- a/app/templates/htmx/partials/approvals/_surface_pipeline.html
+++ b/app/templates/htmx/partials/approvals/_surface_pipeline.html
@@ -11,12 +11,15 @@
   "who-has-the-ball" stepper). The scope toggle reloads THIS body in place
   (hx-target #bp-hub-body, hx-push-url="false") so the lens stays Pipeline.
 
-  Receives: build_col / approve_col / purchase_col (list[deal-card dicts]),
+  Receives: build_col / approve_col / purchase_col / halted_col (list[deal-card dicts]),
             archive (dict from completed_archive: deals/total/...), scope ('mine'|'all'),
-            can_see_all_deals (bool).
+            can_see_all_deals (bool), avg_margin (float — open-book avg margin %).
+  The Halted lane + the Mine/All toggle render only for can_see_all_deals viewers (buyers
+  regain HALTED visibility here — rework parity).
   Called by: htmx/buy_plans.py _render_pipeline_body (the pipeline lens dispatch).
   Depends on: HTMX, Alpine.js (Done toggle), Tailwind brand/accent/line palette,
-              approvals/_pipeline_macros.html (deal_card + metric_strip).
+              approvals/_pipeline_macros.html (deal_card + metric_strip),
+              approvals/_pipeline_archive_rows.html (Done cards + lazy paging).
 #}
 {% from "htmx/partials/approvals/_pipeline_macros.html" import deal_card, metric_strip %}
 
@@ -27,7 +30,7 @@
 <div>
   {# ── Header: metric strip + (optional) Mine/All scope toggle ── #}
   <div class="flex items-center gap-4 mb-4">
-    {{ metric_strip(open_cards | length, open_value) }}
+    {{ metric_strip(open_cards | length, open_value, avg_margin) }}
     {% if can_see_all_deals %}
     {# Scope toggle — PO-cutters + ops narrow to their own deals or see every owner's.
        Each pill reloads THIS body in place (so the lens stays Pipeline); push-url off (R6). #}
@@ -46,8 +49,10 @@
     {% endif %}
   </div>
 
-  {# ── Three visible stage columns: Build · Approve · Purchase ── #}
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+  {# ── Stage columns: Build · Approve · Purchase, plus a Halted lane for can-see-all
+       viewers (buyers regain HALTED visibility — rework parity). The grid widens to 4 when
+       the Halted lane shows. ── #}
+  <div class="grid grid-cols-1 sm:grid-cols-2 {% if can_see_all_deals %}lg:grid-cols-4{% else %}lg:grid-cols-3{% endif %} gap-3">
     {% for label, cards in columns %}
     {# needs-my-action cards sort first (matches the de-noised board). #}
     {% set sorted_cards = cards | sort(attribute='needs_my_action', reverse=True) %}
@@ -64,6 +69,23 @@
       </div>
     </div>
     {% endfor %}
+
+    {# Halted lane — the off-ramp, always rendered (empty "—") for can-see-all viewers so
+       managers/buyers never lose sight of halted deals. Rose tint = at-risk health hue. #}
+    {% if can_see_all_deals %}
+    <div class="bg-rose-50/40 rounded-lg border border-rose-200 flex flex-col min-h-[120px]">
+      <div class="px-3 py-2 border-b border-rose-200 flex items-center justify-between">
+        <span class="text-xs font-semibold text-rose-700 uppercase tracking-wider">Halted</span>
+        <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 rounded-full bg-rose-200 text-rose-700 text-xs font-medium">{{ halted_col | length }}</span>
+      </div>
+      <div class="p-2 space-y-1.5 flex-1">
+        {% for card in halted_col %}{{ deal_card(card) }}{% endfor %}
+        {% if not halted_col %}
+        <div class="px-2 py-4 text-center text-xs text-gray-300">—</div>
+        {% endif %}
+      </div>
+    </div>
+    {% endif %}
   </div>
 
   {# ── Collapsed Done summary bar (default closed; expand to the completed cards) ──
@@ -81,7 +103,9 @@
       <span class="tabular-nums">{{ archive.total }}</span>
     </button>
     <div x-show="doneOpen" x-cloak class="mt-3 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-      {% for card in archive.deals %}{{ deal_card(card) }}{% endfor %}
+      {# Done cards + lazy "Load older" paging via the shared archive-rows partial (consumes
+         archive.next_offset) — the Pipeline no longer renders an unbounded completed list. #}
+      {% include "htmx/partials/approvals/_pipeline_archive_rows.html" %}
       {% if not archive.deals %}
       <div class="px-2 py-6 text-center text-xs text-gray-300 sm:col-span-2 lg:col-span-3">No completed deals yet.</div>
       {% endif %}

--- a/app/templates/htmx/partials/buy_plans/_detail_lines.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_lines.html
@@ -103,7 +103,7 @@
                                 class="btn btn-primary btn-sm">
                           Confirm
                         </button>
-                        <button @click="$dispatch('open-modal', { type: 'issue-{{ line.id }}' }); modalType = 'issue-{{ line.id }}'; showModal = true"
+                        <button @click="modalType = 'issue'; modalLineId = {{ line.id }}; showModal = true"
                                 class="btn btn-danger btn-sm">
                           Issue
                         </button>

--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -34,7 +34,7 @@
    (pending/active) plan. Mirrors the service-side _can_halt + HALTABLE_STATUSES guard. #}
 {% set can_halt = bp.status in ('pending', 'active') and (is_ops_member or user.role in ('manager', 'admin')) %}
 
-<div class="page-fluid" x-data="{ showModal: false, modalType: '', showAi: false, showNotes: false, showSo: false }">
+<div class="page-fluid" x-data="{ showModal: false, modalType: '', modalLineId: 0, showAi: false, showNotes: false, showSo: false }">
 
   {# ═══ 1. COMPACT HEADER WITH INLINE STATS ═══ #}
   <div class="mb-4">
@@ -178,6 +178,42 @@
                     @click="showModal = false"
                     class="btn btn-primary">
               Submit
+            </button>
+          </div>
+        </div>
+      </template>
+
+      {# Issue modal — a buyer flags a problem on a line (re-homed from the inline orders
+         affordance so origination/flagging works from the deal detail too). modalLineId is
+         set by the line's Issue button in _detail_lines; the Flag Issue button drives the
+         existing per-line issue route via htmx.ajax — NOT a dynamic :hx-post bind, which
+         would resolve before this x-if template inits and post a stale line id. Field names
+         (issue_type, note) match buy_plan_flag_issue_partial. #}
+      <template x-if="modalType === 'issue'" x-cloak>
+        <div x-data="{ issue_type: 'sold_out', note: '' }">
+          <h3 class="text-lg font-semibold text-gray-900 mb-4">Flag an Issue</h3>
+          <div class="space-y-3">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">What's wrong?</label>
+              <select x-model="issue_type" class="input w-full">
+                <option value="sold_out">Sold out / no stock</option>
+                <option value="price_changed">Price changed</option>
+                <option value="lead_time_changed">Lead time changed</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Note (optional)</label>
+              <textarea x-model="note" rows="3" class="input w-full" placeholder="Add any detail for the team."></textarea>
+            </div>
+          </div>
+          <div class="mt-5 flex justify-end gap-2">
+            {{ modal_cancel_btn() }}
+            <button type="button"
+                    @click.prevent="htmx.ajax('POST', '/v2/partials/buy-plans/{{ bp.id }}/lines/' + modalLineId + '/issue', {target: '#main-content', swap: 'innerHTML', indicator: '#main-content', values: {issue_type: issue_type, note: note}}); showModal = false"
+                    data-loading-disable
+                    class="btn btn-danger">
+              Flag Issue
             </button>
           </div>
         </div>

--- a/app/templates/htmx/partials/buy_plans/hub.html
+++ b/app/templates/htmx/partials/buy_plans/hub.html
@@ -41,6 +41,20 @@
     </button>
     {% endif %}
     {% endfor %}
+
+    {# ── New Buy Plan origination ──
+       Lives in the hub shell (right-aligned via ml-auto) so it persists across every lens
+       switch. Loads the Sales-Order-new requisition picker into the hub body (not a page
+       push) — origination starts a DRAFT buy plan from an open requisition's offers. #}
+    <button hx-get="/v2/partials/approvals/sales-orders/new"
+            hx-target="#bp-hub-body"
+            hx-swap="innerHTML"
+            hx-push-url="false"
+            data-loading-disable
+            class="btn btn-primary btn-sm ml-auto inline-flex items-center gap-1">
+      <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+      New Buy Plan
+    </button>
   </div>
 
   {# ── Lazy body ──

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1566,8 +1566,13 @@ microlabel · customer · muted secondary line · age (>72h amber) · value · m
 posting the existing routes with `hx-push-url="false"` + `hx-target="#bp-hub-body"`; every
 other kind is a **whole-row link** to its detail screen (where its form / multi-step action
 lives), trailing `{action} →`. There is NO colored left rail (the dot + risk-first sort
-already encode risk). `prepay_approve` is a navigation row (its decision endpoint returns
-JSON, not a partial — inline one-click lands in Phase D).
+already encode risk). `prepay_approve` now carries inline **Approve / Reject-with-reason** posting the new
+`POST /v2/partials/approvals/prepay-requests/{id}/decide` (wraps `approvals.service.decide`
+and re-renders the My Queue body; reject requires a comment → 400 otherwise, 403 for a
+non-recipient — authz is enforced inside `decide`). The supervisor-only **`flagged`** kind
+(P2, ISSUE lines via the shared `_query_flagged_lines`) and kicked-back `cut_po` rows surface
+the issue / PO-rejection reason inline (rose); the header adds `· N% avg margin`
+(`open_avg_margin`) and a rose `N kicked back` tally (Phase F-1 parity restoration).
 
 **Pipeline surface (Approvals rework Phase C — the 4-stage deal board).** The `pipeline`
 lens renders `approvals/_surface_pipeline.html` via `_render_pipeline_body` (the
@@ -1581,12 +1586,18 @@ Done is `completed_archive`. Cards render through the shared `deal_card` macro
 (`approvals/_pipeline_macros.html`): the signature **4-pip "who-has-the-ball" stepper**
 (`●●○○` — done pips `bg-brand-500`, the single live ball `bg-accent-500`, upcoming hollow
 `border-brand-200`) computed from the card's `status`→stage index (DRAFT 0 / PENDING 1 /
-ACTIVE|INBOUND 2 / COMPLETED 3) **replaces the old blocker line + PO progress bar**, plus
+ACTIVE|INBOUND 2 / COMPLETED 3) now sits ALONGSIDE the **restored blocker line +
+verified/total PO-progress bar + headline MPN + cut-PO#(s) + a rose `Returned` badge**
+(distinguishing a kicked-back DRAFT from a fresh one — Phase F-1 parity restoration), plus
 Customer + tabular value + a muted `SO · owner` line + ONE margin-health badge + the `stock`
 chip; a card needing the viewer's action (own DRAFT) gains a `ring-accent-400` (not amber).
 Scope is role-resolved exactly like the board (`_resolve_deal_scope` + `_can_see_all_deals`);
 the **Mine/All toggle** reloads this body in place (`hx-target="#bp-hub-body"`,
-`hx-push-url="false"`). A light `metric_strip` macro shows the open count + value.
+`hx-push-url="false"`). A light `metric_strip` macro shows the open count + value + `· N% avg margin`
+(`open_avg_margin`). A rose **Halted column** renders for `can_see_all_deals` viewers (so
+buyers regain halted visibility); the Done section pages via
+`GET /v2/partials/approvals/pipeline-archive` (`_pipeline_archive_rows.html` — a
+self-replacing **Load older** button consuming `archive.next_offset`) (Phase F-1).
 
 **My Queue foundation (Approvals rework Phase A — the service-layer read model).**
 `buyplan_hub.my_queue(db, user) -> list[QueueRow]` is the role-aware "what needs YOU now"

--- a/tests/test_buyplan_approval_review.py
+++ b/tests/test_buyplan_approval_review.py
@@ -284,6 +284,45 @@ def test_pending_badge_renders_on_review(
     assert "badge" in body
 
 
+def test_detail_issue_modal_present_for_awaiting_line(
+    client: TestClient, db_session: Session, test_user, sales_user, test_requisition
+):
+    """An ACTIVE plan with the buyer's AWAITING_PO line renders the Flag-Issue modal (a
+    re-homed origination affordance) and the line Issue button wires modalLineId so the
+    modal posts to that line's issue route via htmx.ajax (Phase F-1 gap-fill)."""
+    q = _make_quote(db_session, test_requisition.id)
+    plan = BuyPlan(
+        quote_id=q.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE.value,
+        so_status=SOVerificationStatus.APPROVED.value,
+        submitted_by_id=sales_user.id,
+    )
+    db_session.add(plan)
+    db_session.flush()
+    line = BuyPlanLine(
+        buy_plan_id=plan.id,
+        quantity=10,
+        unit_cost=100.00,
+        status=BuyPlanLineStatus.AWAITING_PO.value,
+        buyer_id=test_user.id,
+    )
+    db_session.add(line)
+    db_session.flush()
+    db_session.commit()
+
+    body = client.get(f"/v2/partials/buy-plans/{plan.id}").text
+    # Outer modal state carries modalLineId; the line Issue button wires it to this line.
+    assert "modalLineId" in body
+    assert f"modalLineId = {line.id}" in body
+    assert "modalType = 'issue'" in body
+    # The modal posts to the per-line issue route via htmx.ajax (not a stale :hx-post bind).
+    assert "Flag Issue" in body
+    assert f"/v2/partials/buy-plans/{plan.id}/lines/' + modalLineId + '/issue" in body
+    # The dead $dispatch('open-modal') affordance is gone.
+    assert "open-modal" not in body
+
+
 def test_rejected_draft_blocker_distinguishes_from_fresh(db_session: Session, test_user, sales_user, test_requisition):
     """A rejected plan returns to DRAFT but the hub blocker marks it 'rejected —
     resubmit' (via approved_at), distinguishing it from a never-submitted draft."""

--- a/tests/test_buyplan_hub_routes.py
+++ b/tests/test_buyplan_hub_routes.py
@@ -888,6 +888,145 @@ def test_resolve_deal_scope_contract(scope, can_see_all, expected):
     assert _resolve_deal_scope(scope, can_see_all) == expected
 
 
+# ── New Buy Plan origination button (hub shell, Phase F-1) ──────────────────
+
+
+def test_hub_shell_has_new_buy_plan_button(client: TestClient):
+    """The hub shell carries a persistent New Buy Plan origination button targeting the
+    sales-order-new picker into the hub body (so it survives lens switches)."""
+    resp = client.get("/v2/partials/approvals")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "New Buy Plan" in body
+    assert 'hx-get="/v2/partials/approvals/sales-orders/new"' in body
+    assert 'hx-target="#bp-hub-body"' in body
+
+
+# ── Prepay decide (My Queue inline action, Phase F-1) ───────────────────────
+
+
+def _prepay_setup(db_session, recipient, test_requisition, *, amount="1000.00"):
+    """A committed ACTIVE plan + a REQUESTED prepayment routed to ``recipient``."""
+    from tests.test_my_queue import _grant, _make_prepay_request
+
+    q = _make_quote(db_session, test_requisition.id)
+    plan = _make_plan(db_session, quote_id=q.id, req_id=test_requisition.id)
+    _grant(db_session, recipient, can_approve_prepayments=True)
+    ar, _pp = _make_prepay_request(db_session, recipient=recipient, buy_plan_id=plan.id, amount=amount)
+    db_session.commit()
+    return ar
+
+
+def test_prepay_decide_approve_returns_my_queue_html(
+    client: TestClient, db_session: Session, manager_user, test_requisition
+):
+    """Approve via the inline decide route → 200 + the re-rendered My Queue body (HTML,
+    not JSON)."""
+    ar = _prepay_setup(db_session, manager_user, test_requisition)
+    with _acting_as(manager_user):
+        resp = client.post(
+            f"/v2/partials/approvals/prepay-requests/{ar.id}/decide",
+            data={"action": "approve"},
+        )
+    assert resp.status_code == 200
+    body = resp.text
+    # My Queue surface re-rendered (calm-header copy), never the JSON decision payload.
+    assert "in play" in body or "caught up" in body.lower()
+    assert "Line Items" not in body
+    assert '"status"' not in body  # not the JSON decision response
+
+
+def test_prepay_decide_reject_with_comment_ok(client: TestClient, db_session: Session, manager_user, test_requisition):
+    """Reject with a comment → 200 + My Queue body."""
+    ar = _prepay_setup(db_session, manager_user, test_requisition)
+    with _acting_as(manager_user):
+        resp = client.post(
+            f"/v2/partials/approvals/prepay-requests/{ar.id}/decide",
+            data={"action": "reject", "comment": "Too expensive — renegotiate terms."},
+        )
+    assert resp.status_code == 200
+    assert "Line Items" not in resp.text
+
+
+def test_prepay_decide_reject_without_comment_400(
+    client: TestClient, db_session: Session, manager_user, test_requisition
+):
+    """Reject without a comment is refused (400) — a prepayment reject needs a
+    reason."""
+    ar = _prepay_setup(db_session, manager_user, test_requisition)
+    with _acting_as(manager_user):
+        resp = client.post(
+            f"/v2/partials/approvals/prepay-requests/{ar.id}/decide",
+            data={"action": "reject"},
+        )
+    assert resp.status_code == 400
+
+
+def test_prepay_decide_non_recipient_403(
+    client: TestClient, db_session: Session, manager_user, test_user, test_requisition
+):
+    """A user with no PENDING recipient slot on the request gets 403 (engine
+    PermissionError)."""
+    ar = _prepay_setup(db_session, manager_user, test_requisition)
+    # Default client acts as test_user (a buyer), who is NOT a recipient of the request.
+    resp = client.post(
+        f"/v2/partials/approvals/prepay-requests/{ar.id}/decide",
+        data={"action": "approve"},
+    )
+    assert resp.status_code == 403
+
+
+# ── Pipeline archive (lazy Done paging, Phase F-1) ──────────────────────────
+
+
+def test_pipeline_archive_returns_rows(client: TestClient, db_session: Session, test_user, test_requisition):
+    """The Pipeline archive route returns completed deal cards for the requested
+    page."""
+    from datetime import datetime, timezone
+
+    q = _make_quote(db_session, test_requisition.id)
+    plan = _make_plan(
+        db_session,
+        quote_id=q.id,
+        req_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        submitted_by_id=test_user.id,
+        completed_at=datetime.now(timezone.utc),
+    )
+    db_session.commit()
+
+    resp = client.get("/v2/partials/approvals/pipeline-archive?scope=mine&offset=0")
+    assert resp.status_code == 200
+    assert f"/v2/partials/buy-plans/{plan.id}" in resp.text
+
+
+def test_pipeline_archive_next_page_button(client: TestClient, db_session: Session, test_user, test_requisition):
+    """More than one page of completed deals → a Load older button pointing at the next
+    offset on the pipeline-archive route (not the legacy board archive)."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.services.buyplan_hub import ARCHIVE_PAGE_SIZE
+
+    q = _make_quote(db_session, test_requisition.id)
+    now = datetime.now(timezone.utc)
+    for i in range(ARCHIVE_PAGE_SIZE + 1):
+        _make_plan(
+            db_session,
+            quote_id=q.id,
+            req_id=test_requisition.id,
+            status=BuyPlanStatus.COMPLETED,
+            submitted_by_id=test_user.id,
+            completed_at=now - timedelta(hours=i),
+        )
+    db_session.commit()
+
+    resp = client.get("/v2/partials/approvals/pipeline-archive?scope=mine&offset=0")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Load older" in body
+    assert f"/v2/partials/approvals/pipeline-archive?scope=mine&offset={ARCHIVE_PAGE_SIZE}" in body
+
+
 def test_board_buyer_narrows_to_mine_excludes_other_owner(
     client: TestClient, db_session: Session, test_user, manager_user, test_requisition
 ):

--- a/tests/test_my_queue.py
+++ b/tests/test_my_queue.py
@@ -483,6 +483,143 @@ def test_my_queue_sales_sees_only_owned_drafts(db_session, sales_user, test_quot
     assert rows[0].plan_id == own_draft.id
 
 
+# ── flagged (P2) — supervisor-only triage (Phase F-1 gap-fill) ─────────
+
+
+def test_my_queue_flagged_supervisor_only(db_session, test_user, manager_user, test_quote, test_requisition):
+    """An ISSUE (buyer-flagged) line surfaces as a P2 flagged row to a supervisor only.
+
+    The row carries the issue reason in extra, no inline action (action_url None), and
+    links to the plan detail; a non-supervisor never sees the flagged kind.
+    """
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+    )
+    line = _make_line(
+        db_session,
+        buy_plan_id=plan.id,
+        buyer_id=test_user.id,
+        status=BuyPlanLineStatus.ISSUE,
+        issue_type="sold_out",
+    )
+    line.issue_note = "Vendor sold the lot"
+    db_session.flush()
+
+    rows = my_queue(db_session, manager_user)
+    assert "flagged" in _kinds(rows)
+    row = _row(rows, "flagged")
+    assert row.line_id == line.id
+    assert row.priority == 2
+    assert row.action_url is None
+    assert row.detail_href == f"/v2/partials/buy-plans/{plan.id}"
+    assert row.extra["issue_reason"] == "Vendor sold the lot"
+
+    # A plain buyer (non-supervisor) never sees the flagged kind.
+    assert "flagged" not in _kinds(my_queue(db_session, test_user))
+
+
+# ── cut_po kicked-back extra (Phase F-1 gap-fill) ──────────────────────
+
+
+def test_my_queue_cut_po_kicked_back_extra(db_session, test_user, test_quote, test_requisition):
+    """A kicked-back AWAITING_PO line carries kicked_back + po_rejection_note in
+    extra."""
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        approved_at=datetime.now(timezone.utc),
+    )
+    line = _make_line(db_session, buy_plan_id=plan.id, buyer_id=test_user.id, status=BuyPlanLineStatus.AWAITING_PO)
+    line.po_rejection_note = "Wrong vendor — re-cut to Arrow"
+    db_session.flush()
+
+    row = _row(my_queue(db_session, test_user), "cut_po")
+    assert row.extra["kicked_back"] is True
+    assert row.extra["po_rejection_note"] == "Wrong vendor — re-cut to Arrow"
+
+
+def test_my_queue_cut_po_not_kicked_back_extra(db_session, test_user, test_quote, test_requisition):
+    """A normal AWAITING_PO line reports kicked_back=False and a None rejection note."""
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        approved_at=datetime.now(timezone.utc),
+    )
+    _make_line(db_session, buy_plan_id=plan.id, buyer_id=test_user.id, status=BuyPlanLineStatus.AWAITING_PO)
+
+    row = _row(my_queue(db_session, test_user), "cut_po")
+    assert row.extra["kicked_back"] is False
+    assert row.extra["po_rejection_note"] is None
+
+
+# ── prepay row carries request_id (Phase F-1 gap-fill) ─────────────────
+
+
+def test_my_queue_prepay_row_carries_request_id(db_session, manager_user, test_quote, test_requisition):
+    """A prepay_approve row exposes the originating ApprovalRequest id so the inline My
+    Queue action can build the decide URL."""
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        total_cost="5000.00",
+    )
+    _grant(db_session, manager_user, can_approve_prepayments=True)
+    ar, _pp = _make_prepay_request(db_session, recipient=manager_user, buy_plan_id=plan.id, amount="2500.00")
+
+    row = _row(my_queue(db_session, manager_user), "prepay_approve")
+    assert row.extra["request_id"] == ar.id
+
+
+# ── open_avg_margin (My Queue + Pipeline metric parity, Phase F-1) ─────
+
+
+def test_open_avg_margin_zero_when_no_open_plans(db_session):
+    """No open plans → 0.0 (AVG of an empty set, coalesced)."""
+    from app.services.buyplan_hub import open_avg_margin
+
+    assert open_avg_margin(db_session) == 0.0
+
+
+def test_open_avg_margin_averages_open_plans_only(db_session, test_quote, test_requisition):
+    """Averages total_margin_pct across OPEN plans; terminal (COMPLETED) plans
+    excluded."""
+    from app.services.buyplan_hub import open_avg_margin
+
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        total_margin_pct=20,
+    )
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.PENDING,
+        total_margin_pct=40,
+    )
+    # COMPLETED is terminal → excluded from the open-book average.
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.COMPLETED,
+        total_margin_pct=100,
+    )
+
+    assert open_avg_margin(db_session) == 30.0
+
+
 # ── supervise_overview contract unchanged (R4) ────────────────────────
 
 

--- a/tests/test_surface_my_queue.py
+++ b/tests/test_surface_my_queue.py
@@ -19,6 +19,7 @@ Depends on: app/routers/htmx/buy_plans (my-queue lens dispatch),
 from __future__ import annotations
 
 from contextlib import contextmanager
+from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -220,3 +221,116 @@ def test_my_queue_surface_sales_sees_own_draft(
     assert f'hx-get="/v2/partials/buy-plans/{draft.id}"' in body
     # Sales is not a PO-cutter/approver → no inline action forms.
     assert 'name="origin" value="my_queue"' not in body
+
+
+# ── Flagged triage row (supervisor, Phase F-1 gap-fill) ────────────────────
+
+
+def test_my_queue_surface_flagged_row_supervisor(
+    client: TestClient, db_session: Session, manager_user: User, test_user: User, test_quote, test_requisition
+):
+    """A supervisor's My Queue shows a flagged (rose At-risk) row with the issue reason
+    and a Flagged filter chip."""
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+    )
+    line = _make_line(
+        db_session,
+        buy_plan_id=plan.id,
+        buyer_id=test_user.id,
+        status=BuyPlanLineStatus.ISSUE,
+        issue_type="sold_out",
+    )
+    line.issue_note = "Vendor sold the lot"
+    db_session.flush()
+
+    with _acting_as(manager_user):
+        resp = client.get(MY_QUEUE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Flagged (" in body  # the Flagged filter chip with a live count
+    assert "Vendor sold the lot" in body  # the issue reason surfaced (rose)
+    assert "bg-rose-500" in body  # At-risk band dot
+    # A flagged row is a whole-row link to detail (no inline action form).
+    assert f'hx-get="/v2/partials/buy-plans/{plan.id}"' in body
+
+
+# ── Prepay inline action (Phase F-1 gap-fill) ──────────────────────────────
+
+
+def test_my_queue_surface_prepay_inline_action(
+    client: TestClient, db_session: Session, manager_user: User, test_quote, test_requisition
+):
+    """A routed prepay row renders an inline Approve form + a Reject reveal posting the
+    prepay decide route into #bp-hub-body (push-url off)."""
+    from tests.test_my_queue import _grant, _make_prepay_request
+
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        total_cost="5000.00",
+    )
+    _grant(db_session, manager_user, can_approve_prepayments=True)
+    ar, _pp = _make_prepay_request(db_session, recipient=manager_user, buy_plan_id=plan.id, amount="2500.00")
+
+    with _acting_as(manager_user):
+        resp = client.get(MY_QUEUE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    assert f"/v2/partials/approvals/prepay-requests/{ar.id}/decide" in body
+    assert 'hx-target="#bp-hub-body"' in body
+    assert 'hx-push-url="false"' in body
+    assert "rejectOpen" in body  # the reject reveal toggle
+    assert "$2,500 prepay" in body  # the amount surfaced on the muted line
+
+
+# ── Header avg-margin + kicked-back surfacing (Phase F-1 gap-fill) ─────────
+
+
+def test_my_queue_surface_header_shows_avg_margin(
+    client: TestClient, db_session: Session, test_user: User, test_quote, test_requisition
+):
+    """The My Queue header money subline appends the open-book avg margin."""
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        total_cost="5000.00",
+        total_margin_pct=25,
+        approved_at=datetime.now(timezone.utc),
+    )
+    _make_line(db_session, buy_plan_id=plan.id, buyer_id=test_user.id, status=BuyPlanLineStatus.AWAITING_PO)
+
+    resp = client.get(MY_QUEUE_URL)
+    assert resp.status_code == 200
+    assert "avg margin" in resp.text
+
+
+def test_my_queue_surface_kicked_back_surfacing(
+    client: TestClient, db_session: Session, test_user: User, test_quote, test_requisition
+):
+    """A kicked-back cut_po row surfaces a rose 'kicked back' header line, the rejection
+    note, and a rose-tinted row."""
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        approved_at=datetime.now(timezone.utc),
+    )
+    line = _make_line(db_session, buy_plan_id=plan.id, buyer_id=test_user.id, status=BuyPlanLineStatus.AWAITING_PO)
+    line.po_rejection_note = "Wrong vendor — re-cut to Arrow"
+    db_session.flush()
+
+    resp = client.get(MY_QUEUE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "kicked back" in body
+    assert "Wrong vendor — re-cut to Arrow" in body
+    assert "bg-rose-50" in body  # the row gets a rose tint

--- a/tests/test_surface_pipeline.py
+++ b/tests/test_surface_pipeline.py
@@ -22,8 +22,8 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.constants import BuyPlanStatus
-from tests.test_buyplan_hub_board import _make_plan
+from app.constants import BuyPlanLineStatus, BuyPlanStatus, SOVerificationStatus
+from tests.test_buyplan_hub_board import _make_line, _make_plan
 
 PIPELINE_URL = "/v2/partials/approvals/pipeline"
 
@@ -176,3 +176,139 @@ def test_pipeline_sales_locked_to_mine_no_toggle(client: TestClient, sales_user)
     assert resp.status_code == 200
     assert "?scope=all" not in resp.text
     assert "?scope=mine" not in resp.text
+
+
+# ── Halted column (buyer HALTED visibility, Phase F-1) ───────────────────────
+
+
+def test_pipeline_halted_column_for_can_see_all(
+    client: TestClient, db_session: Session, test_user, test_quote, test_requisition
+):
+    """A can-see-all viewer (buyer) gets a 4th Halted column rendering halted plans."""
+    halted = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.HALTED,
+    )
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "lg:grid-cols-4" in body  # the grid widens to 4 columns
+    assert "Halted" in body  # the column header
+    assert f'hx-get="/v2/partials/buy-plans/{halted.id}"' in body  # the halted card links to detail
+
+
+def test_pipeline_halted_column_hidden_for_sales(
+    client: TestClient, sales_user, db_session, test_quote, test_requisition
+):
+    """A sales user (no cross-owner visibility) gets the 3-column grid (no Halted
+    lane)."""
+    from app.dependencies import require_user
+    from app.main import app
+
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.HALTED,
+        submitted_by_id=sales_user.id,
+    )
+    app.dependency_overrides[require_user] = lambda: sales_user
+    try:
+        resp = client.get(PIPELINE_URL)
+    finally:
+        app.dependency_overrides.pop(require_user, None)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "lg:grid-cols-4" not in body
+    assert "lg:grid-cols-3" in body
+
+
+# ── Metric strip avg margin (parity, Phase F-1) ──────────────────────────────
+
+
+def test_pipeline_metric_strip_shows_avg_margin(
+    client: TestClient, db_session: Session, test_user, test_quote, test_requisition
+):
+    """The Pipeline metric strip surfaces the open-book avg margin."""
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        total_margin_pct=22,
+    )
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    assert "avg margin" in resp.text
+
+
+# ── Richer deal card (parity, Phase F-1) ─────────────────────────────────────
+
+
+def test_pipeline_deal_card_returned_badge(
+    client: TestClient, db_session: Session, test_user, test_quote, test_requisition
+):
+    """A returned (rejected-resubmit) DRAFT card shows a Returned badge."""
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.DRAFT,
+        so_status=SOVerificationStatus.REJECTED,
+    )
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Returned" in body
+    assert "badge-danger" in body
+
+
+def test_pipeline_deal_card_po_progress_and_blocker(
+    client: TestClient, db_session: Session, test_user, test_quote, test_requisition
+):
+    """An ACTIVE card shows the PO-progress bar (verified/total) and the blocker
+    text."""
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        requisition_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+    )
+    _make_line(db_session, buy_plan_id=plan.id, status=BuyPlanLineStatus.VERIFIED)
+    _make_line(db_session, buy_plan_id=plan.id, status=BuyPlanLineStatus.AWAITING_PO)
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "bg-emerald-500" in body  # PO-progress fill
+    assert "1/2" in body  # verified/total
+    assert "1 POs to cut" in body  # the blocker text
+
+
+# ── Done section uses the shared archive-rows include (Phase F-1) ────────────
+
+
+def test_pipeline_done_uses_archive_rows_include(
+    client: TestClient, db_session: Session, test_user, test_quote, test_requisition
+):
+    """The Done section renders completed deals via the shared archive-rows partial;
+    with more than one page it offers a Load older button hitting pipeline-archive."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.services.buyplan_hub import ARCHIVE_PAGE_SIZE
+
+    now = datetime.now(timezone.utc)
+    for i in range(ARCHIVE_PAGE_SIZE + 1):
+        _make_plan(
+            db_session,
+            quote_id=test_quote.id,
+            requisition_id=test_requisition.id,
+            status=BuyPlanStatus.COMPLETED,
+            completed_at=now - timedelta(hours=i),
+        )
+    resp = client.get(PIPELINE_URL)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "/v2/partials/approvals/pipeline-archive?scope=" in body
+    assert "Load older" in body


### PR DESCRIPTION
## Phase F-1 — Gap-fills (restore parity before retiring lenses)

Sixth phase of the Approvals rework. Before retiring the old 5 lenses (F-2), an **adversarial parity audit** found capabilities that would otherwise be silently lost. F-1 closes them so retirement loses nothing. Scope = the **5 blockers + true regressions**; the "Team Orders" awareness section and the "Recently resolved" disclosure are intentionally dropped (rework simplification).

### Blockers closed
1. **New Buy Plan origination** — persistent "New Buy Plan" button in the hub tab strip (reaches the existing requisition-picker flow); survives lens switches.
2. **Prepayment approve/reject** — inline Approve + Reject-with-reason on My Queue `prepay_approve` rows → new `POST /v2/partials/approvals/prepay-requests/{id}/decide` (wraps `approvals.service.decide`, re-renders the queue; reject requires a comment → 400; **403 for a non-recipient — authz enforced in `decide`**).
3. **Flag-issue on a line** — issue modal on the detail line (`htmx.ajax` with `indicator`), posting the existing `/lines/{id}/issue`; reachable for `awaiting_po` lines (the buyer's path).
4. **Flagged-line triage** — new supervisor-only `flagged` kind in `my_queue()` (P2, reuses `_query_flagged_lines`) + Flagged chip + issue reason inline.
5. **Completed-archive "Load older"** — new `GET /v2/partials/approvals/pipeline-archive` (registered before the `{tab}` catch-all) + `_pipeline_archive_rows.html` self-replacing pagination consuming `next_offset`.

### True regressions fixed
6. **deal_card** — restored blocker line / verified-total PO-progress bar / headline MPN / cut-PO#(s) + a rose **Returned** badge (distinguishes a kicked-back DRAFT from a fresh one); single-accent rule preserved.
7. **Buyers see HALTED** — dedicated rose **Halted column** on Pipeline for `can_see_all_deals` viewers.
8. **avg-margin** metric on the My Queue header + Pipeline metric strip (`open_avg_margin`).
9. **Kicked-back** — count + rose row tint + inline rejection note on My Queue `cut_po` rows.

### Verification
- **24 new tests** (My Queue flagged/kicked-back/prepay/avg-margin, route tests incl. prepay non-recipient 403 + reject-no-comment 400 + archive paging, surface render tests, detail issue-modal). **379 affected-suite tests pass**; pre-commit clean.
- **Adversarial review fleet: 0 confirmed findings** across correctness, **authz** (prepay-decide IDOR + archive scope-leak), HTMX/Alpine, **parity-closure** (each of the 9 gaps verified actually closed), and test quality.
- No migration (reuses existing columns + routes). APP_MAP updated.

### Next
F-2 retires the old 5 lenses (leaving My Queue + Pipeline), converts `_board.html` → `deal_card`, opportunistic token cleanup — now safe because parity is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
