### PR TITLE
fix(crm): contact-dedup cron repoints child rows instead of cascade-deleting them (P0 data loss)

### DIFF
--- a/app/jobs/maintenance_jobs.py
+++ b/app/jobs/maintenance_jobs.py
@@ -145,6 +145,8 @@ async def _job_contact_dedup():
     try:
         from sqlalchemy import func
 
+        from ..services.contact_merge_service import merge_contacts
+
         dupes = (
             db.query(
                 SiteContact.customer_site_id,
@@ -173,11 +175,16 @@ async def _job_contact_dedup():
             for other in contacts:
                 if other.id == best.id:
                     continue
-                for col in _CONTACT_MERGE_FIELDS:
-                    if getattr(best, col, None) is None and getattr(other, col, None) is not None:
-                        setattr(best, col, getattr(other, col))
-                db.delete(other)
-                merged += 1
+                # Route through the canonical merge so child rows (attachments,
+                # tasks, activities, primary-contact link) are REPOINTED to the
+                # keeper, not cascade-deleted. Per-pair savepoint isolates a bad
+                # pair so it can't abort the whole nightly run.
+                try:
+                    with db.begin_nested():
+                        merge_contacts(best.id, other.id, db)
+                    merged += 1
+                except Exception:
+                    logger.exception("Contact dedup: merge of {} into {} failed; skipping", other.id, best.id)
         db.commit()
         if merged:
             logger.info(f"Contact dedup: merged {merged} duplicate contacts")

--- a/tests/test_jobs_coverage.py
+++ b/tests/test_jobs_coverage.py
@@ -918,77 +918,11 @@ class TestJobContactDedup:
         mock_db.commit.assert_called_once()
         mock_db.close.assert_called_once()
 
-    def test_merges_duplicate_contacts(self):
-        """Duplicate contacts are merged — best kept, others deleted."""
-        mock_db = MagicMock()
-
-        # Simulate 1 duplicate group found
-        dupe = SimpleNamespace(customer_site_id=1, em="john@test.com", cnt=2)
-        dupe_query = MagicMock()
-        dupe_query.filter.return_value.group_by.return_value.having.return_value.all.return_value = [dupe]
-
-        # Create mock contacts for the duplicate group
-        contact1 = MagicMock(id=1, full_name=None, title=None, phone=None, notes=None, linkedin_url=None)
-        contact2 = MagicMock(
-            id=2, full_name="John Doe", title="Buyer", phone="555-1234", notes="Primary", linkedin_url=None
-        )
-
-        contacts_query = MagicMock()
-        contacts_query.filter.return_value.order_by.return_value.all.return_value = [contact1, contact2]
-
-        call_count = [0]
-
-        def side_effect_query(model, *args):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return dupe_query
-            return contacts_query
-
-        mock_db.query.side_effect = side_effect_query
-
-        with patch("app.database.SessionLocal", return_value=mock_db):
-            from app.jobs.maintenance_jobs import _job_contact_dedup
-
-            asyncio.run(_job_contact_dedup())
-
-        # contact1 (fewer fields) should be deleted
-        mock_db.delete.assert_called_once_with(contact1)
-        mock_db.commit.assert_called_once()
-        mock_db.close.assert_called_once()
-
-    def test_merges_fields_from_deleted_into_best(self):
-        """Best contact gets missing fields from duplicate before deletion."""
-        mock_db = MagicMock()
-
-        dupe = SimpleNamespace(customer_site_id=1, em="jane@test.com", cnt=2)
-        dupe_query = MagicMock()
-        dupe_query.filter.return_value.group_by.return_value.having.return_value.all.return_value = [dupe]
-
-        # contact1 has phone only, contact2 has name+title (more fields = best)
-        contact1 = MagicMock(id=1, full_name=None, title=None, phone="555-9999", notes=None, linkedin_url=None)
-        contact2 = MagicMock(id=2, full_name="Jane Smith", title="Manager", phone=None, notes=None, linkedin_url=None)
-
-        contacts_query = MagicMock()
-        contacts_query.filter.return_value.order_by.return_value.all.return_value = [contact1, contact2]
-
-        call_count = [0]
-
-        def side_effect_query(model, *args):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return dupe_query
-            return contacts_query
-
-        mock_db.query.side_effect = side_effect_query
-
-        with patch("app.database.SessionLocal", return_value=mock_db):
-            from app.jobs.maintenance_jobs import _job_contact_dedup
-
-            asyncio.run(_job_contact_dedup())
-
-        # contact1 deleted, contact2 (best) should absorb phone from contact1
-        mock_db.delete.assert_called_once_with(contact1)
-        mock_db.commit.assert_called_once()
+    # Merge behaviour (keeper selection, loser deletion, scalar backfill, and the
+    # critical child-row reassignment so attachments/tasks are NOT cascade-deleted)
+    # is covered against the real DB in tests/test_maintenance_jobs_dedup_cascade.py.
+    # A mock session can't exercise the real ORM cascade the old delete-based code
+    # data-lost on, so those assertions live there, not here.
 
     def test_error_rollback_and_reraise(self):
         """DB error triggers rollback and re-raises."""

--- a/tests/test_maintenance_jobs.py
+++ b/tests/test_maintenance_jobs.py
@@ -1,6 +1,12 @@
-"""Tests for app/jobs/maintenance_jobs.py — _job_contact_dedup function.
+"""Tests for app/jobs/maintenance_jobs.py — _job_contact_dedup control flow.
 
-Covers: duplicate merging, no-dupes path, error rollback.
+Covers the mock-level control flow (no-dupes path, error rollback). The actual
+merge behaviour — keeper selection, loser deletion, scalar backfill, and the
+CRITICAL child-row reassignment (attachments/tasks must not cascade-delete) — is
+covered against the real DB in test_maintenance_jobs_dedup_cascade.py (a mock
+session can't exercise the real ORM cascade, which is how the cascade data-loss
+bug originally slipped through).
+
 Called by: pytest
 Depends on: app.jobs.maintenance_jobs
 """
@@ -17,36 +23,11 @@ def _run(coro):
     return loop.run_until_complete(coro)
 
 
-class _FakeContact:
-    """Minimal stand-in for SiteContact with attribute tracking."""
-
-    def __init__(
-        self, id, customer_site_id, email, full_name=None, title=None, phone=None, notes=None, linkedin_url=None
-    ):
-        self.id = id
-        self.customer_site_id = customer_site_id
-        self.email = email
-        self.full_name = full_name
-        self.title = title
-        self.phone = phone
-        self.notes = notes
-        self.linkedin_url = linkedin_url
-
-
-class _FakeDupeRow:
-    """Mimics a SQLAlchemy keyed-tuple result from the group-by query."""
-
-    def __init__(self, customer_site_id, em, cnt):
-        self.customer_site_id = customer_site_id
-        self.em = em
-        self.cnt = cnt
-
-
 def _build_mock_db(dupe_rows, contacts_by_group):
     """Build a mock DB session with controlled query chains.
 
-    dupe_rows: list of _FakeDupeRow for the group-by query
-    contacts_by_group: list of list[_FakeContact] — one per dupe_row
+    dupe_rows: list of group-by result rows
+    contacts_by_group: list of list — one contact list per dupe_row
     """
     db = MagicMock()
 
@@ -72,76 +53,7 @@ def _build_mock_db(dupe_rows, contacts_by_group):
 
 
 class TestJobContactDedup:
-    """Tests for the _job_contact_dedup scheduler job."""
-
-    @patch("app.database.SessionLocal")
-    def test_dedup_merges_and_deletes(self, mock_session_local):
-        """Two contacts with same site+email: best keeps fields, loser deleted."""
-        contact_a = _FakeContact(
-            id=1,
-            customer_site_id=10,
-            email="alice@example.com",
-            full_name="Alice Smith",
-            phone="+15551234567",
-        )
-        contact_b = _FakeContact(
-            id=2,
-            customer_site_id=10,
-            email="Alice@example.com",
-            title="VP Sales",
-            notes="Met at trade show",
-        )
-        dupe_row = _FakeDupeRow(customer_site_id=10, em="alice@example.com", cnt=2)
-
-        db = _build_mock_db([dupe_row], [[contact_a, contact_b]])
-        mock_session_local.return_value = db
-
-        from app.jobs.maintenance_jobs import _job_contact_dedup
-
-        _run(_job_contact_dedup())
-
-        db.delete.assert_called_once()
-        db.commit.assert_called_once()
-        db.close.assert_called_once()
-
-        # Verify the winner got the loser's fields merged
-        deleted_contact = db.delete.call_args[0][0]
-        if deleted_contact is contact_b:
-            assert contact_a.title == "VP Sales"
-            assert contact_a.notes == "Met at trade show"
-        else:
-            assert contact_b.full_name == "Alice Smith"
-            assert contact_b.phone == "+15551234567"
-
-    @patch("app.database.SessionLocal")
-    def test_dedup_best_has_most_fields(self, mock_session_local):
-        """Contact with more filled fields is kept as the winner."""
-        winner = _FakeContact(
-            id=1,
-            customer_site_id=10,
-            email="bob@example.com",
-            full_name="Bob",
-            title="CTO",
-            phone="+15559999999",
-            notes="Important",
-            linkedin_url="https://linkedin.com/in/bob",
-        )
-        loser = _FakeContact(
-            id=2,
-            customer_site_id=10,
-            email="bob@example.com",
-            full_name="Robert",
-        )
-        dupe_row = _FakeDupeRow(customer_site_id=10, em="bob@example.com", cnt=2)
-        db = _build_mock_db([dupe_row], [[winner, loser]])
-        mock_session_local.return_value = db
-
-        from app.jobs.maintenance_jobs import _job_contact_dedup
-
-        _run(_job_contact_dedup())
-
-        db.delete.assert_called_once_with(loser)
-        db.commit.assert_called_once()
+    """Control-flow tests for the _job_contact_dedup scheduler job."""
 
     @patch("app.database.SessionLocal")
     def test_no_dupes_no_changes(self, mock_session_local):

--- a/tests/test_maintenance_jobs_dedup_cascade.py
+++ b/tests/test_maintenance_jobs_dedup_cascade.py
@@ -1,0 +1,131 @@
+"""tests/test_maintenance_jobs_dedup_cascade.py — real-DB regression for the contact-
+dedup cron's cascade data loss.
+
+The existing tests/test_maintenance_jobs.py exercise _job_contact_dedup with a
+mocked session + a fake SiteContact stand-in, so they never run the real ORM
+cascade and missed that db.delete(loser) destroys the loser's attachments
+(cascade='all, delete-orphan') and open tasks (FK ondelete=CASCADE). These tests
+run against the real conftest SQLite engine (FK pragma ON) so the cascade fires.
+
+Called by: pytest
+Depends on: app.jobs.maintenance_jobs, app.services.contact_merge_service,
+            app.models.crm/task, conftest.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+import app.database as appdb
+from app.models.crm import Company, CustomerSite, SiteContact, SiteContactAttachment
+from app.models.task import RequisitionTask
+
+_run = asyncio.run
+
+
+@pytest.fixture()
+def _bind_job_session(db_session: Session, monkeypatch):
+    """Point the job's SessionLocal() at the same test engine db_session uses, so the
+    job's own session shares the StaticPool connection (and its commits are visible to
+    the assertions)."""
+    job_sessionmaker = sessionmaker(bind=db_session.get_bind(), autoflush=False)
+    monkeypatch.setattr(appdb, "SessionLocal", job_sessionmaker)
+    return job_sessionmaker
+
+
+def _dupe_pair(db_session: Session) -> tuple[SiteContact, SiteContact]:
+    """A keeper (more complete) + loser sharing one site and email — the exact shape
+    _job_contact_dedup groups on."""
+    co = Company(name="Dedup Cascade Co", is_active=True)
+    db_session.add(co)
+    db_session.commit()
+    site = CustomerSite(company_id=co.id, site_name="HQ", is_active=True)
+    db_session.add(site)
+    db_session.commit()
+
+    # The (customer_site_id, email) unique constraint is exact-case; the cron dedups
+    # on lower(email), so real dupes differ only by email case.
+    keeper = SiteContact(
+        customer_site_id=site.id, full_name="Keep Me", email="dup@example.com", title="Director", phone="+15550000001"
+    )
+    loser = SiteContact(customer_site_id=site.id, full_name="Lose Me", email="DUP@example.com")
+    db_session.add_all([keeper, loser])
+    db_session.commit()
+    db_session.refresh(keeper)
+    db_session.refresh(loser)
+    return keeper, loser
+
+
+def test_dedup_preserves_loser_attachment_reassigned_to_keeper(db_session: Session, _bind_job_session):
+    """The loser's attachment must survive dedup and be reassigned to the keeper, not
+    cascade-deleted."""
+    keeper, loser = _dupe_pair(db_session)
+    att = SiteContactAttachment(
+        site_contact_id=loser.id, file_name="invoice.pdf", created_at=datetime.now(timezone.utc)
+    )
+    db_session.add(att)
+    db_session.commit()
+    att_id, keeper_id, loser_id = att.id, keeper.id, loser.id
+
+    from app.jobs.maintenance_jobs import _job_contact_dedup
+
+    _run(_job_contact_dedup())
+
+    db_session.expire_all()
+    assert db_session.get(SiteContact, loser_id) is None, "loser should be merged away"
+    assert db_session.get(SiteContact, keeper_id) is not None, "keeper must survive"
+    surviving = db_session.get(SiteContactAttachment, att_id)
+    assert surviving is not None, "attachment must NOT be cascade-deleted"
+    assert surviving.site_contact_id == keeper_id, "attachment must be reassigned to the keeper"
+
+
+def test_dedup_preserves_loser_task_reassigned_to_keeper(db_session: Session, _bind_job_session):
+    """The loser's open task must survive dedup and be reassigned to the keeper, not
+    cascade-deleted."""
+    keeper, loser = _dupe_pair(db_session)
+    task = RequisitionTask(
+        site_contact_id=loser.id,
+        title="Follow up call",
+        task_type="general",
+        status="todo",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(task)
+    db_session.commit()
+    task_id, keeper_id = task.id, keeper.id
+
+    from app.jobs.maintenance_jobs import _job_contact_dedup
+
+    _run(_job_contact_dedup())
+
+    db_session.expire_all()
+    surviving = db_session.get(RequisitionTask, task_id)
+    assert surviving is not None, "task must NOT be cascade-deleted"
+    assert surviving.site_contact_id == keeper_id, "task must be reassigned to the keeper"
+
+
+def test_dedup_keeps_most_complete_deletes_loser_and_backfills(db_session: Session, _bind_job_session):
+    """The more-complete contact is kept, the loser deleted, and the loser's non-null
+    fields backfill gaps on the keeper.
+
+    (Real-DB replacement for the old mock-based test_dedup_merges_and_deletes /
+    _best_has_most_fields.)
+    """
+    keeper, loser = _dupe_pair(db_session)  # keeper has 3 merge-fields, loser has 1
+    loser.linkedin_url = "https://linkedin.com/in/lose-me"  # a gap the keeper lacks
+    db_session.commit()
+    keeper_id, loser_id = keeper.id, loser.id
+
+    from app.jobs.maintenance_jobs import _job_contact_dedup
+
+    _run(_job_contact_dedup())
+
+    db_session.expire_all()
+    assert db_session.get(SiteContact, loser_id) is None, "loser deleted"
+    survivor = db_session.get(SiteContact, keeper_id)
+    assert survivor is not None, "most-complete contact kept"
+    assert survivor.linkedin_url == "https://linkedin.com/in/lose-me", "loser's field backfilled onto keeper"


### PR DESCRIPTION
## Problem (P0 — active nightly data loss)
`_job_contact_dedup` (daily 03:30 maintenance cron) merged duplicate site-contacts by copying 5 scalar fields onto the keeper, then `db.delete(loser)` **with no FK repoint**. Because:
- `SiteContact.attachments` is `cascade="all, delete-orphan"` → the loser's **attachments were deleted**
- `requisition_tasks.site_contact_id` is `ondelete=CASCADE` → the loser's **open tasks were deleted**
- `activity_log.site_contact_id` / `companies.primary_contact_id` → **nulled**

…so two contacts sharing an email (case-insensitively) silently destroyed the lower-completeness one's CRM attachments + open tasks **every night, no backup, no guard**. Surfaced by the codebase audit.

## Fix (root cause, reuse-not-duplicate)
Route the merge through the existing canonical **`contact_merge_service.merge_contacts()`**, which already:
- reassigns `ActivityLog` / `SiteContactAttachment` / `RequisitionTask` from loser → keeper
- `db.expire(loser, ["attachments"])` to defeat the ORM delete-orphan cascade
- clears a stale `Company.primary_contact_id`, backfills scalar gaps, merges notes

Each pair runs in a `db.begin_nested()` savepoint so one bad pair can't abort the whole nightly run.

## Tests
- **New real-DB regression** `tests/test_maintenance_jobs_dedup_cascade.py`: proves the loser's attachment + task **survive and are reassigned to the keeper** (FK pragma on, real cascade fires). Also covers keeper-selection + scalar backfill.
- The pre-existing dedup tests were **mock-based** (fake session/contacts) — exactly why the real cascade slipped through. The redundant old-contract mocks in `test_maintenance_jobs.py` + `test_jobs_coverage.py` are removed in favor of the real-DB coverage. Net −16 lines.
- `pre-commit run --files` clean (ruff/format/docformatter/mypy); affected suite green under xdist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)