### PR TITLE
fix(p1): authz/scoping cluster — IDOR/PII scoping, SSRF, connector key-leak, +4 more

### DIFF
--- a/app/connectors/element14.py
+++ b/app/connectors/element14.py
@@ -81,6 +81,11 @@ class Element14Connector(BaseConnector):
 
     async def _api_search(self, term: str, part_number: str) -> list[dict]:
         """Run a single search against the element14 API."""
+        # callInfo.apiKey rides in the URL query string. On an unhandled HTTP
+        # status the full URL lands inside the raised httpx.HTTPStatusError's
+        # str(); BaseConnector redacts secret query params via _redact_secrets
+        # BEFORE logging, so the key never reaches the loguru sinks. (Sentry's
+        # before_send only scrubs Sentry events — redaction is at the log sink.)
         params = {
             "term": term,
             "storeInfo.id": "www.newark.com",

--- a/app/connectors/mouser.py
+++ b/app/connectors/mouser.py
@@ -44,8 +44,11 @@ class MouserConnector(BaseConnector):
         }
 
         # Mouser API requires apiKey as URL query param — no header auth option.
-        # Sentry before_send hook scrubs query strings containing "key" (see main.py).
-        # httpx does not log URL params at INFO level, only at DEBUG/TRACE.
+        # On an unhandled HTTP status this URL ends up inside the raised
+        # httpx.HTTPStatusError's str(); BaseConnector redacts secret query
+        # params (apiKey/api_key/key/token) via _redact_secrets BEFORE logging,
+        # so the key never reaches the loguru sinks. (Sentry's before_send only
+        # scrubs Sentry events, not local logs — redaction is at the log sink.)
         r = await http.post(
             self.SEARCH_URL,
             params={"apiKey": self.api_key},

--- a/app/connectors/oemsecrets.py
+++ b/app/connectors/oemsecrets.py
@@ -33,6 +33,11 @@ class OEMSecretsConnector(BaseConnector):
         if not self.api_key:
             return []
 
+        # apiKey rides in the URL query string. On an unhandled HTTP status the
+        # full URL lands inside the raised httpx.HTTPStatusError's str();
+        # BaseConnector redacts secret query params via _redact_secrets BEFORE
+        # logging, so the key never reaches the loguru sinks. (Sentry's
+        # before_send only scrubs Sentry events — redaction is at the log sink.)
         params = {
             "apiKey": self.api_key,
             "searchTerm": part_number,

--- a/app/connectors/sources.py
+++ b/app/connectors/sources.py
@@ -39,6 +39,17 @@ def _redact_secrets(text: str) -> str:
     return _SECRET_QS_RE.sub(r"\1REDACTED", text)
 
 
+def _safe_connector_error(exc: BaseException) -> "ConnectorError":
+    """Wrap a propagating exception so neither its message NOR its traceback can leak a
+    secret URL query param to downstream sinks (the orchestrator's logger.exception, the
+    source-stats row str(e), the SSE error field).
+
+    Raise it ``from None`` so the original
+    secret-bearing exception is dropped from the __context__/__cause__ chain.
+    """
+    return ConnectorError(f"{type(exc).__name__}: {_redact_secrets(str(exc))}")
+
+
 # ── Async-compatible circuit breaker ─────────────────────────────────
 # Opens after `fail_max` consecutive failures, resets after `reset_timeout` seconds.
 
@@ -171,7 +182,7 @@ class BaseConnector(ABC):
                 if status in (401, 403, 422):
                     self._breaker.record_failure()
                     logger.warning(f"{self.__class__.__name__} auth error {status} for {part_number} — not retrying")
-                    raise
+                    raise _safe_connector_error(e) from None  # e's URL holds ?apiKey=SECRET
 
                 self._breaker.record_failure()
                 last_err = e
@@ -187,7 +198,8 @@ class BaseConnector(ABC):
                 else:
                     logger.warning(f"{self.__class__.__name__} failed for {part_number}: {_redact_secrets(str(e))}")
         if last_err is not None:
-            raise last_err  # propagate so caller can track the error
+            # Sanitize: last_err may be an httpx error whose URL holds ?apiKey=SECRET.
+            raise _safe_connector_error(last_err) from None
         raise RuntimeError(
             f"{self.__class__.__name__}: search loop completed without result or error for {part_number}"
         )

--- a/app/connectors/sources.py
+++ b/app/connectors/sources.py
@@ -198,8 +198,12 @@ class BaseConnector(ABC):
                 else:
                     logger.warning(f"{self.__class__.__name__} failed for {part_number}: {_redact_secrets(str(e))}")
         if last_err is not None:
-            # Sanitize: last_err may be an httpx error whose URL holds ?apiKey=SECRET.
-            raise _safe_connector_error(last_err) from None
+            # An exhausted httpx HTTPStatusError embeds the request URL (?apiKey=SECRET)
+            # in its message — sanitize it. Other exception types carry no secret, so
+            # propagate them unchanged (preserves their type for callers / health checks).
+            if isinstance(last_err, httpx.HTTPStatusError):
+                raise _safe_connector_error(last_err) from None
+            raise last_err
         raise RuntimeError(
             f"{self.__class__.__name__}: search loop completed without result or error for {part_number}"
         )

--- a/app/connectors/sources.py
+++ b/app/connectors/sources.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import random
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -13,6 +14,30 @@ from loguru import logger
 from ..utils import safe_float, safe_int
 from ._core_attrs import clean_str
 from .errors import ConnectorAuthError, ConnectorError, ConnectorQuotaError, ConnectorRateLimitError
+
+# ── Secret redaction for logged exception text ───────────────────────
+# Connectors that authenticate with the API key as a URL query param (Mouser,
+# element14, OEMSecrets, Nexar REST) leak that key the moment httpx raises an
+# HTTPStatusError: str(HTTPStatusError) embeds the FULL request URL, including
+# ``?apiKey=SECRET``. BaseConnector logs that string at WARNING, which fans out
+# to every loguru sink (stdout / file / docker logs). Sentry's before_send hook
+# only scrubs events shipped to Sentry — it does NOT touch the local log sinks —
+# so the raw key would otherwise sit in plaintext logs. Redact before logging.
+# The secret keyword may be the whole param name (``apiKey``) or the suffix of a
+# dotted/underscored one (element14's ``callInfo.apiKey``); a preceding separator
+# (start-of-name, ``.``, ``_`` or ``-``) keeps ``monkey``/``donkey`` from matching.
+_SECRET_QS_RE = re.compile(r"(?i)([?&](?:[\w.-]*[._-])?(?:api[_-]?key|apikey|key|token)=)[^&\s'\"]+")
+
+
+def _redact_secrets(text: str) -> str:
+    """Replace secret query-param values (apiKey/api_key/key/apikey/token) with
+    REDACTED.
+
+    Used to sanitize an exception's ``str()`` before it is written to the logs,
+    since httpx error messages embed the full request URL with its query string.
+    """
+    return _SECRET_QS_RE.sub(r"\1REDACTED", text)
+
 
 # ── Async-compatible circuit breaker ─────────────────────────────────
 # Opens after `fail_max` consecutive failures, resets after `reset_timeout` seconds.
@@ -153,14 +178,14 @@ class BaseConnector(ABC):
                 if attempt < self.max_retries:
                     await asyncio.sleep(2**attempt + random.uniform(0, 1))
                 else:
-                    logger.warning(f"{self.__class__.__name__} failed for {part_number}: {e}")
+                    logger.warning(f"{self.__class__.__name__} failed for {part_number}: {_redact_secrets(str(e))}")
             except Exception as e:
                 self._breaker.record_failure()
                 last_err = e
                 if attempt < self.max_retries:
                     await asyncio.sleep(2**attempt + random.uniform(0, 1))
                 else:
-                    logger.warning(f"{self.__class__.__name__} failed for {part_number}: {e}")
+                    logger.warning(f"{self.__class__.__name__} failed for {part_number}: {_redact_secrets(str(e))}")
         if last_err is not None:
             raise last_err  # propagate so caller can track the error
         raise RuntimeError(

--- a/app/routers/crm/quotes.py
+++ b/app/routers/crm/quotes.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from loguru import logger
 from sqlalchemy.orm import Session, joinedload
 
-from ...constants import QuoteStatus, RequisitionStatus, UserRole
+from ...constants import RESTRICTED_ROLES, QuoteStatus, RequisitionStatus
 from ...database import get_db
 from ...dependencies import require_user
 from ...models import ActivityLog, CustomerSite, Offer, Quote, Requisition, User
@@ -578,7 +578,7 @@ async def pricing_history(mpn: str, user: User = Depends(require_user), db: Sess
         .options(joinedload(Quote.customer_site).joinedload(CustomerSite.company))
         .filter(Quote.status.in_(_PRICED_STATUSES))
     )
-    if user.role == UserRole.SALES:
+    if user.role in RESTRICTED_ROLES:
         quotes = quotes.join(Requisition, Quote.requisition_id == Requisition.id).filter(
             Requisition.created_by == user.id
         )

--- a/app/routers/htmx/companies.py
+++ b/app/routers/htmx/companies.py
@@ -2387,6 +2387,8 @@ async def company_detail_partial(
     )
     if not company:
         raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")  # scope detail to match the contacts list
 
     sites = [s for s in (company.sites or []) if s.is_active]
 
@@ -2506,6 +2508,8 @@ async def company_tab(
     company = db.query(Company).filter(Company.id == company_id).first()
     if not company:
         raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")  # scope detail to match the contacts list
 
     valid_tabs = {"sites", "contacts", "requisitions", "activity", "quotes", "buy_plans", "files", "history"}
     if tab not in valid_tabs:

--- a/app/routers/htmx/companies.py
+++ b/app/routers/htmx/companies.py
@@ -3785,6 +3785,12 @@ async def edit_company(
         if new_owner_id != company.account_owner_id:
             if not can_manage_account_team(user, company):
                 raise HTTPException(403, "Only the account owner or a manager can change the primary owner")
+            # The new owner must be a real active user — mirrors create_company and the
+            # bulk assign-owner path, so a deactivated/non-existent id can't silently take
+            # ownership (or raise an unhandled FK IntegrityError on commit).
+            target = db.get(User, new_owner_id)
+            if not target or not target.is_active:
+                raise HTTPException(400, "Owner must be an active user")
             company.account_owner_id = new_owner_id
 
     parent_company_id_raw = form.get("parent_company_id", "").strip()

--- a/app/routers/htmx/companies.py
+++ b/app/routers/htmx/companies.py
@@ -1117,7 +1117,7 @@ async def create_company(
     db.commit()
     logger.info("Company {} created by {}", company.id, user.email)
 
-    return await company_detail_partial(request=request, company_id=company.id, user=user, db=db)
+    return await _render_company_detail(request, company.id, user, db)
 
 
 @router.get("/v2/partials/customers/typeahead", response_class=HTMLResponse)
@@ -2039,7 +2039,7 @@ async def deactivate_company(
     invalidate_prefix("companies_typeahead")
 
     logger.info("Company {} archived (DNC) by {}, reason={!r}", company_id, user.email, disposition_reason)
-    return await company_detail_partial(request=request, company_id=company_id, user=user, db=db)
+    return await _render_company_detail(request, company_id, user, db)
 
 
 @router.post("/v2/partials/customers/{company_id}/reactivate", response_class=HTMLResponse)
@@ -2081,7 +2081,7 @@ async def reactivate_company(
         )
         return template_response("htmx/partials/customers/archived_list.html", ctx)
 
-    return await company_detail_partial(request=request, company_id=company_id, user=user, db=db)
+    return await _render_company_detail(request, company_id, user, db)
 
 
 @router.get("/v2/partials/customers/archived", response_class=HTMLResponse)
@@ -2378,6 +2378,23 @@ async def company_detail_partial(
     ``tab`` deep-links to the specified tab on first load (default: contacts).
     Invalid tab values silently fall back to contacts.
     """
+    company = db.get(Company, company_id)
+    if not company:
+        raise HTTPException(404, "Company not found")
+    if not can_manage_account(user, company, db):
+        raise HTTPException(404, "Company not found")  # scope detail to match the contacts list
+    return await _render_company_detail(request, company_id, user, db, tab=tab)
+
+
+async def _render_company_detail(
+    request: Request, company_id: int, user: User, db: Session, *, tab: str = "contacts"
+) -> HTMLResponse:
+    """Render company detail (NO access gate).
+
+    company_detail_partial gates with can_manage_account then calls this; create_company
+    / edit_company call it directly after authorizing their own mutation (the actor just
+    created/edited the account, so the post-mutation render is trusted).
+    """
     active_tab = tab if tab in _VALID_CUSTOMER_TABS else "contacts"
     company = (
         db.query(Company)
@@ -2387,8 +2404,6 @@ async def company_detail_partial(
     )
     if not company:
         raise HTTPException(404, "Company not found")
-    if not can_manage_account(user, company, db):
-        raise HTTPException(404, "Company not found")  # scope detail to match the contacts list
 
     sites = [s for s in (company.sites or []) if s.is_active]
 
@@ -3513,7 +3528,7 @@ async def set_account_primary_contact(
     db.refresh(company)
     logger.info("Company {} primary contact set to {} by {}", company_id, contact_id, user.email)
 
-    return await company_detail_partial(request=request, company_id=company_id, user=user, db=db)
+    return await _render_company_detail(request, company_id, user, db)
 
 
 @router.post(
@@ -3548,7 +3563,7 @@ async def set_parent_company(
     db.refresh(company)
     logger.info("Company {} parent set to {} by {}", company_id, raw or "None", user.email)
 
-    return await company_detail_partial(request=request, company_id=company_id, user=user, db=db)
+    return await _render_company_detail(request, company_id, user, db)
 
 
 # ── Shared helper — parent-company validation used by set_parent_company + edit_company ──
@@ -3821,7 +3836,7 @@ async def edit_company(
     db.commit()
     logger.info("Company {} edited by {}", company_id, user.email)
 
-    return await company_detail_partial(request=request, company_id=company_id, user=user, db=db)
+    return await _render_company_detail(request, company_id, user, db)
 
 
 # ── Inline Field Edit — Account (WS1) ─────────────────────────────────────

--- a/app/routers/htmx/materials.py
+++ b/app/routers/htmx/materials.py
@@ -29,7 +29,6 @@ from ...dependencies import (
     has_buyer_role,
     require_access,
     require_buyer,
-    require_user,
 )
 from ...models import (
     Offer,
@@ -201,7 +200,7 @@ async def materials_workspace_partial(
     ctx["total_materials"] = total_materials
     ctx["display_names"] = {sub: get_display_name(sub) for sub in all_subs}
     ctx["global_facet_counts"] = get_global_facet_counts(db)
-    # The workspace is require_user, but POST /api/materials/add is require_buyer —
+    # The workspace is MATERIALS-gated, but POST /api/materials/add is require_buyer —
     # hide the "Add part" button from roles whose submit would 403 (dead-end otherwise).
     ctx["can_add_parts"] = has_buyer_role(user)
     return template_response("htmx/partials/materials/workspace.html", ctx)
@@ -211,7 +210,7 @@ async def materials_workspace_partial(
 async def materials_filters_manufacturers_partial(
     request: Request,
     commodity: str = "",
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Render manufacturer filter dropdown."""
@@ -241,7 +240,7 @@ async def materials_filters_global_partial(
     internal: str = "all",
     searched_within: str = "any",
     min_searches: str = "0",
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Render global facets (lifecycle / RoHS / condition / has-datasheet) with live
@@ -279,7 +278,7 @@ async def materials_filters_global_partial(
 async def manufacturer_search(
     request: Request,
     q: str = "",
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Typeahead search for manufacturers by name or alias."""
@@ -314,7 +313,7 @@ async def manufacturer_search(
 async def manufacturer_add(
     request: Request,
     name: str = Form(...),
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Add a new manufacturer on the fly from typeahead."""
@@ -339,7 +338,7 @@ async def manufacturer_add(
 async def materials_filters_tree_partial(
     request: Request,
     commodity: str = "",
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Render the commodity category tree for the faceted sidebar."""
@@ -377,7 +376,7 @@ async def materials_filters_sub_partial(
     internal: str = "all",
     searched_within: str = "any",
     min_searches: str = "0",
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Render sub-filters for a selected commodity with live facet counts.
@@ -435,7 +434,7 @@ async def materials_filters_sub_partial(
 async def materials_ai_interpret_partial(
     request: Request,
     q: str = "",
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Interpret a natural language query using AI and return pre-selection chip."""
@@ -475,7 +474,7 @@ async def materials_faceted_partial(
     internal: str = Query("all"),
     searched_within: str = Query("any"),
     min_searches: str = Query("0"),
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Return faceted-search material list as HTML partial."""
@@ -675,7 +674,7 @@ async def material_add_form_partial(
 async def material_enrich_status_partial(
     request: Request,
     card_id: int,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Render the enrichment-status badge for the card detail header.
@@ -709,7 +708,7 @@ async def material_conflict_accept(
     request: Request,
     card_id: int,
     key: str,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Accept a validation conflict's evidence value — a human decision.
@@ -788,7 +787,7 @@ async def material_conflict_accept(
 async def fru_lookup_partial(
     request: Request,
     q: str = Query("", max_length=100),
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """FRU crosswalk lookup: render whichever view matches the part number.
@@ -818,7 +817,7 @@ async def fru_lookup_partial(
 async def material_detail_partial(
     request: Request,
     card_id: int,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Return material card detail as HTML partial."""
@@ -862,7 +861,7 @@ async def material_tab_partial(
     request: Request,
     card_id: int,
     tab_name: str,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Return a material detail tab partial."""
@@ -916,7 +915,7 @@ async def material_tab_partial(
 async def update_material_card(
     request: Request,
     card_id: int,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Update material card fields.
@@ -1042,7 +1041,7 @@ async def update_material_card(
 async def enrich_material(
     request: Request,
     material_id: int,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Trigger authoritative enrichment for a material card.
@@ -1107,7 +1106,7 @@ async def find_crosses(
     request: Request,
     material_id: int,
     refresh: bool = Form(False),
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """On-demand AI search for crosses & substitutes for a single material card.
@@ -1190,7 +1189,7 @@ async def find_crosses(
 async def material_insights(
     request: Request,
     material_id: int,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
     """Return MPN insights panel for a material card."""

--- a/app/routers/htmx/materials.py
+++ b/app/routers/htmx/materials.py
@@ -175,11 +175,14 @@ def _parse_card_filter_params(
 @router.get("/v2/partials/materials", response_class=HTMLResponse)
 async def materials_list_partial(
     request: Request,
-    user: User = Depends(require_user),
+    user: User = Depends(require_access(AccessKey.MATERIALS)),
     db: Session = Depends(get_db),
 ):
-    """Redirect to faceted workspace — all materials browsing uses the sidebar
-    layout."""
+    """Redirect to faceted workspace — all materials browsing uses the sidebar layout.
+
+    Gated by MATERIALS access (it calls workspace_partial directly, so the inner route's
+    Depends would otherwise never run).
+    """
     return await materials_workspace_partial(request, user, db)
 
 

--- a/app/routers/htmx/requisitions.py
+++ b/app/routers/htmx/requisitions.py
@@ -24,7 +24,7 @@ from sqlalchemy import case, exists, or_, select
 from sqlalchemy import func as sqlfunc
 from sqlalchemy.orm import Session, joinedload, selectinload
 
-from ...constants import QuoteStatus, RequisitionStatus, SourcingStatus, UserRole
+from ...constants import RESTRICTED_ROLES, QuoteStatus, RequisitionStatus, SourcingStatus
 from ...database import get_db
 from ...dependencies import require_requisition_access, require_user
 from ...models import (
@@ -117,8 +117,8 @@ async def requisitions_list_partial(
         except ValueError:
             pass
 
-    # Sales users only see their own
-    if user.role == UserRole.SALES:
+    # Restricted roles (sales/trader) only see their own
+    if user.role in RESTRICTED_ROLES:
         query = query.filter(Requisition.created_by == user.id)
 
     total = query.count()
@@ -198,9 +198,9 @@ async def requisitions_list_partial(
             if reason and reason in match_counts:
                 match_counts[reason] += 1
 
-    # Fetch team users for owner dropdown (non-sales only)
+    # Fetch team users for owner dropdown (unrestricted roles only)
     users = []
-    if user.role != UserRole.SALES:
+    if user.role not in RESTRICTED_ROLES:
         users = db.query(User).order_by(User.name).all()
 
     from ...services.activity_service import get_inbox_sync_status

--- a/app/routers/proactive.py
+++ b/app/routers/proactive.py
@@ -320,6 +320,12 @@ async def get_site_contacts(
     db: Session = Depends(get_db),
 ):
     """Get SiteContacts for a customer site (for the send modal contact picker)."""
+    from ..models import CustomerSite
+
+    site = db.get(CustomerSite, site_id)
+    company = db.get(Company, site.company_id) if site else None
+    if not company or not can_manage_account(user, company, db):
+        raise HTTPException(404, "Site not found")  # scope site-contacts to match the contacts list
     contacts = (
         db.query(SiteContact)
         .filter(

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -657,11 +657,14 @@ async def resell_offer_form(
     db: Session = Depends(get_db),
 ):
     """Render the submit-offer modal (per-line / take-all scope toggle)."""
-    el = excess_service.get_excess_list(db, list_id)
+    # Load-and-authorize: non-owners 404 on a draft (existence not revealed).
+    el, is_owner = _get_list_for_user(db, list_id, user)
     if not excess_service.can_offer(user):
         raise HTTPException(403, "You do not have permission to submit offers")
-    if el.owner_id == user.id:
+    if is_owner:
         raise HTTPException(403, "You cannot offer on your own excess list")
+    if el.status not in {s.value for s in _POSTED_STATUSES}:
+        raise HTTPException(404, "List not found")
     return template_response(
         "htmx/partials/resell/offer_form.html",
         {"request": request, "list": el},
@@ -842,6 +845,12 @@ async def resell_submit_offer(
     the same preview grid (import_preview) and lands here per-row. The service enforces
     can_offer + the self-offer guard.
     """
+    # Load-and-authorize: non-owners 404 on a draft (existence not revealed), and offers
+    # are only accepted on a posted/published list — never on an unpublished draft.
+    el, _ = _get_list_for_user(db, list_id, user)
+    if el.status not in {s.value for s in _POSTED_STATUSES}:
+        raise HTTPException(404, "List not found")
+
     scope = ExcessOfferScope(scope).value if scope in (s.value for s in ExcessOfferScope) else ExcessOfferScope.PER_LINE
 
     lines = None

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -26,7 +26,7 @@ from .connectors.element14 import Element14Connector
 from .connectors.mouser import MouserConnector
 from .connectors.oemsecrets import OEMSecretsConnector
 from .connectors.sourcengine import SourcengineConnector
-from .connectors.sources import BrokerBinConnector, NexarConnector
+from .connectors.sources import BrokerBinConnector, NexarConnector, _redact_secrets
 from .constants import FRU_ALIAS_SOURCE, ActivityType, ApiSourceStatus, SourceRunStatus
 from .database import SessionLocal
 from .models import (
@@ -1453,10 +1453,10 @@ async def _fetch_fresh(pns: list[str], db: Session) -> tuple[list[dict], list[di
         except Exception as e:
             elapsed_ms = int((time.time() - start) * 1000)
             logger.opt(exception=True).error(
-                "Search {} via {} failed ({}ms): {}", pn, conn.__class__.__name__, elapsed_ms, e
+                "Search {} via {} failed ({}ms): {}", pn, conn.__class__.__name__, elapsed_ms, _redact_secrets(str(e))
             )
             if source_name:
-                stats_updates.append((source_name, 0, elapsed_ms, str(e)[:500]))
+                stats_updates.append((source_name, 0, elapsed_ms, _redact_secrets(str(e))[:500]))
             return []
 
     # Fire all connector×PN combos in parallel (with concurrency limit)
@@ -2751,7 +2751,7 @@ async def stream_search_mpn(search_id: str, mpn: str) -> None:
                                 {
                                     "source": source_name,
                                     "status": SourceRunStatus.ERROR.value,
-                                    "error": str(e)[:500],
+                                    "error": _redact_secrets(str(e))[:500],
                                     "results": 0,
                                     "ms": 0,
                                 },

--- a/app/utils/vendor_helpers.py
+++ b/app/utils/vendor_helpers.py
@@ -20,7 +20,7 @@ from sqlalchemy import text as sqltext
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from sqlalchemy.orm import Session
 
-from ..http_client import http_redirect
+from ..http_client import http
 from ..models import VendorCard, VendorReview
 from ..services.credential_service import get_credential_cached
 from ..services.specialty_detector import commodity_slug_to_display
@@ -422,6 +422,38 @@ def is_private_url(url: str) -> bool:
         return True  # Can't resolve = block it
 
 
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+
+
+async def _safe_get(url: str, *, headers: dict, timeout: int, max_redirects: int = 4):
+    """GET ``url`` with a non-redirecting client, re-validating every redirect hop.
+
+    The shared ``http`` client has ``follow_redirects=False``, so each 3xx is returned
+    rather than silently followed. We resolve the ``Location`` target, re-run
+    ``is_private_url`` against it, and only then continue — so a vendor page that 302s to
+    an internal host or cloud metadata (e.g. http://169.254.169.254/...) is never fetched
+    (SSRF). Returns the final non-redirect ``httpx.Response``, or ``None`` if a hop
+    resolves to a private/internal address or the redirect budget is exhausted. Network
+    errors propagate to the caller (handled by ``asyncio.gather(return_exceptions=True)``).
+    """
+    from urllib.parse import urljoin
+
+    loop = asyncio.get_running_loop()
+    current = url
+    for _ in range(max_redirects + 1):
+        if await loop.run_in_executor(None, is_private_url, current):
+            logger.warning(f"SSRF blocked (redirect hop): {current}")
+            return None
+        resp = await http.get(current, headers=headers, timeout=timeout)
+        location = resp.headers.get("location") if resp.status_code in _REDIRECT_STATUSES else None
+        if location:
+            current = urljoin(current, location)
+            continue
+        return resp
+    logger.warning(f"SSRF blocked (too many redirects): {url}")
+    return None
+
+
 async def scrape_website_contacts(url: str) -> dict:
     """Fetch vendor website homepage + /contact page, extract emails and phones.
 
@@ -462,12 +494,13 @@ async def scrape_website_contacts(url: str) -> dict:
         "Accept": "text/html,application/xhtml+xml",
     }
 
-    # Fetch all pages concurrently instead of sequentially
-    tasks = [http_redirect.get(page_url, headers=headers, timeout=10) for page_url in pages_to_try]
+    # Fetch all pages concurrently instead of sequentially. _safe_get re-validates every
+    # redirect hop so a 302 to an internal host / cloud metadata is never followed.
+    tasks = [_safe_get(page_url, headers=headers, timeout=10) for page_url in pages_to_try]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     for resp in results:
-        if isinstance(resp, Exception):
+        if resp is None or isinstance(resp, Exception):
             continue
         if resp.status_code != 200:
             continue

--- a/tests/test_activity_quality.py
+++ b/tests/test_activity_quality.py
@@ -170,7 +170,8 @@ class TestActivityTimelineEnrichment:
         """Customer activity tab shows AI summary when available."""
         from app.models.crm import Company
 
-        company = Company(name="Timeline Test Co", is_active=True)
+        # account_owner_id: company tab now gates on can_manage_account
+        company = Company(name="Timeline Test Co", is_active=True, account_owner_id=test_user.id)
         db_session.add(company)
         db_session.flush()
 

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -823,6 +823,7 @@ async def test_connector_skips_retry_on_401(db_session):
     """401 errors skip retry and fail immediately."""
     import httpx
 
+    from app.connectors.errors import ConnectorError
     from app.connectors.sources import BaseConnector
 
     class MockConnector(BaseConnector):
@@ -831,7 +832,9 @@ async def test_connector_skips_retry_on_401(db_session):
             raise httpx.HTTPStatusError("401 Unauthorized", request=resp.request, response=resp)
 
     conn = MockConnector(max_retries=2)
-    with pytest.raises(httpx.HTTPStatusError):
+    # Fix 6: the 401/403 path now raises a sanitized ConnectorError (from None) so the
+    # secret URL can't leak downstream; it still skips retry and trips the breaker.
+    with pytest.raises(ConnectorError):
         await conn.search("LM317")
 
     # Should only have been called once (no retries)
@@ -843,6 +846,7 @@ async def test_connector_skips_retry_on_403(db_session):
     """403 errors skip retry and fail immediately."""
     import httpx
 
+    from app.connectors.errors import ConnectorError
     from app.connectors.sources import BaseConnector
 
     class MockConnector(BaseConnector):
@@ -854,7 +858,9 @@ async def test_connector_skips_retry_on_403(db_session):
             raise httpx.HTTPStatusError("403 Forbidden", request=resp.request, response=resp)
 
     conn = MockConnector(max_retries=2)
-    with pytest.raises(httpx.HTTPStatusError):
+    # Fix 6: the 401/403 path now raises a sanitized ConnectorError (from None) so the
+    # secret URL can't leak downstream; it still skips retry and trips the breaker.
+    with pytest.raises(ConnectorError):
         await conn.search("LM317")
 
     # Only 1 call, no retries for auth errors

--- a/tests/test_authz_company_detail_scoping.py
+++ b/tests/test_authz_company_detail_scoping.py
@@ -1,0 +1,57 @@
+"""Company detail + site-contacts must match the contacts-list ownership scoping.
+
+The global contacts list scopes non-managers to accounts they can_manage (owner /
+site-owner / collaborator), but company_detail_partial / company_tab / get_site_contacts
+showed full contact PII to any logged-in user by id. Per product decision, scope them to
+match the list: a non-manager who can't manage the account gets 404; managers/admins and
+the account owner get 200.
+
+Called by: pytest
+Depends on: app.routers.htmx.companies, app.routers.proactive,
+            conftest (client, db_session, test_user, admin_user)
+"""
+
+from app.models.crm import Company, CustomerSite
+
+
+def _company(db, owner_id):
+    c = Company(name="ScopeCo", is_active=True, account_owner_id=owner_id)
+    db.add(c)
+    db.commit()
+    db.refresh(c)
+    return c
+
+
+def _site(db, company_id):
+    s = CustomerSite(company_id=company_id, site_name="HQ", is_active=True)
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s
+
+
+def test_company_detail_404_for_non_manager_non_owner(client, db_session, test_user, admin_user):
+    co = _company(db_session, owner_id=admin_user.id)  # owned by someone else
+    assert client.get(f"/v2/partials/customers/{co.id}").status_code == 404
+
+
+def test_company_detail_200_for_account_owner(client, db_session, test_user):
+    co = _company(db_session, owner_id=test_user.id)
+    assert client.get(f"/v2/partials/customers/{co.id}").status_code == 200
+
+
+def test_company_tab_404_for_non_manager_non_owner(client, db_session, test_user, admin_user):
+    co = _company(db_session, owner_id=admin_user.id)
+    assert client.get(f"/v2/partials/customers/{co.id}/tab/contacts").status_code == 404
+
+
+def test_site_contacts_404_for_non_manager_non_owner(client, db_session, test_user, admin_user):
+    co = _company(db_session, owner_id=admin_user.id)
+    site = _site(db_session, co.id)
+    assert client.get(f"/api/proactive/contacts/{site.id}").status_code == 404
+
+
+def test_site_contacts_200_for_account_owner(client, db_session, test_user):
+    co = _company(db_session, owner_id=test_user.id)
+    site = _site(db_session, co.id)
+    assert client.get(f"/api/proactive/contacts/{site.id}").status_code == 200

--- a/tests/test_authz_materials_gate.py
+++ b/tests/test_authz_materials_gate.py
@@ -1,0 +1,23 @@
+"""materials_list_partial must enforce MATERIALS access.
+
+GET /v2/partials/materials was gated only by require_user, then called
+materials_workspace_partial() directly as a function — so the inner route's
+Depends(require_access(MATERIALS)) never ran, leaking the full workspace to a user
+without materials access. The list partial must carry the same gate.
+
+Called by: pytest
+Depends on: app.routers.htmx.materials, conftest (client, db_session, test_user)
+"""
+
+from app.constants import AccessKey
+
+
+def test_materials_list_denied_without_materials_access(client, db_session, test_user):
+    test_user.access_overrides = {AccessKey.MATERIALS.value: False}
+    db_session.commit()
+    assert client.get("/v2/partials/materials").status_code == 403
+
+
+def test_materials_list_allowed_with_access(client, db_session, test_user):
+    # Buyer default grants MATERIALS access.
+    assert client.get("/v2/partials/materials").status_code == 200

--- a/tests/test_authz_requisition_list_scoping.py
+++ b/tests/test_authz_requisition_list_scoping.py
@@ -1,0 +1,40 @@
+"""Requisition list-partial ownership scoping for restricted roles.
+
+RESTRICTED_ROLES = {SALES, TRADER}, but the htmx requisitions_list_partial scoped
+only SALES — a TRADER saw every requisition's name/customer in the list (while the
+now-gated detail/tabs 404 on the same reqs). A restricted role must see only its own;
+buyer/manager/admin remain unrestricted.
+
+Called by: pytest
+Depends on: app.routers.htmx.requisitions, conftest (client, db_session, test_user, admin_user)
+"""
+
+from app.constants import UserRole
+from app.models import Requisition
+
+
+def _req(db, owner_id, name):
+    r = Requisition(name=name, status="open", urgency="normal", customer_name="Cust", created_by=owner_id)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def test_trader_sees_only_own_requisitions_in_list(client, db_session, test_user, admin_user):
+    _req(db_session, test_user.id, "MINE-REQ-T")
+    _req(db_session, admin_user.id, "FOREIGN-REQ-T")
+    test_user.role = UserRole.TRADER
+    db_session.commit()
+    resp = client.get("/v2/partials/requisitions")
+    assert resp.status_code == 200
+    assert "MINE-REQ-T" in resp.text
+    assert "FOREIGN-REQ-T" not in resp.text  # restricted: foreign requisition hidden
+
+
+def test_buyer_sees_all_requisitions_in_list(client, db_session, test_user, admin_user):
+    _req(db_session, test_user.id, "MINE-REQ-B")
+    _req(db_session, admin_user.id, "FOREIGN-REQ-B")
+    assert test_user.role == "buyer"
+    resp = client.get("/v2/partials/requisitions")
+    assert "FOREIGN-REQ-B" in resp.text  # unrestricted: sees all

--- a/tests/test_company_links.py
+++ b/tests/test_company_links.py
@@ -209,9 +209,13 @@ class TestParentCompanyEndpoint:
         db_session: Session,
         company_a: Company,
         company_b: Company,
+        test_user: User,
     ):
         """After setting company_a's parent to company_b, company_b has 1 child."""
         company_a.parent_company_id = company_b.id
+        # company detail now gates on can_manage_account; test_user owns company_a but the
+        # rendered account here is company_b, so make test_user its owner too.
+        company_b.account_owner_id = test_user.id
         db_session.commit()
 
         # Render company_b detail — should mention 1 child account

--- a/tests/test_connector_key_redaction.py
+++ b/tests/test_connector_key_redaction.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 from loguru import logger
 
+from app.connectors.errors import ConnectorError
 from app.connectors.sources import BaseConnector, _redact_secrets
 
 SECRET = "SUPERSECRETKEY1234567890"
@@ -98,7 +99,9 @@ async def test_search_with_retry_does_not_log_api_key():
     captured: list[str] = []
     sink_id = logger.add(captured.append, level="WARNING", format="{message}")
     try:
-        with pytest.raises(httpx.HTTPStatusError):
+        # _search_with_retry now wraps the propagating httpx error in a sanitized
+        # ConnectorError (from None) so the secret can't reach the orchestrator's logs.
+        with pytest.raises(ConnectorError):
             await _LeakyConnector()._search_with_retry("ABC123")
     finally:
         logger.remove(sink_id)

--- a/tests/test_connector_key_redaction.py
+++ b/tests/test_connector_key_redaction.py
@@ -1,0 +1,109 @@
+"""Regression tests: connector API keys must never leak to the logs.
+
+Connectors that authenticate with the API key as a URL query param (Mouser,
+element14, OEMSecrets, Nexar REST) raise httpx.HTTPStatusError on an unhandled
+status, whose str() embeds the FULL request URL including ``?apiKey=SECRET``.
+BaseConnector logs that string at WARNING to every loguru sink. These tests pin
+that the secret is scrubbed (REDACTED) before it reaches the log sink.
+
+Covers: app/connectors/sources.py _redact_secrets helper + the two
+BaseConnector._search_with_retry WARNING log paths.
+
+All external HTTP is faked — no real API requests.
+"""
+
+import httpx
+import pytest
+from loguru import logger
+
+from app.connectors.sources import BaseConnector, _redact_secrets
+
+SECRET = "SUPERSECRETKEY1234567890"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  _redact_secrets — unit
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestRedactSecrets:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            f"https://api.mouser.com/api/v2/search/keyword?apiKey={SECRET}",
+            f"https://api.element14.com/catalog/products?term=ABC&callInfo.apiKey={SECRET}",
+            f"https://oemsecretsapi.com/partsearch?apiKey={SECRET}&searchTerm=ABC",
+            f"https://octopart.com/api/v4/rest/parts/search?q=ABC&apikey={SECRET}&limit=20",
+            f"https://x.test/p?api_key={SECRET}",
+            f"https://x.test/p?key={SECRET}",
+            f"https://x.test/p?token={SECRET}&q=1",
+            f"https://x.test/p?APIKEY={SECRET}",  # case-insensitive
+        ],
+    )
+    def test_secret_value_is_redacted(self, raw):
+        out = _redact_secrets(raw)
+        assert SECRET not in out
+        assert "REDACTED" in out
+
+    def test_non_secret_params_preserved(self):
+        raw = f"https://x.test/p?q=ABC123&apiKey={SECRET}&limit=20"
+        out = _redact_secrets(raw)
+        assert "q=ABC123" in out
+        assert "limit=20" in out
+        assert SECRET not in out
+
+    def test_does_not_overmatch_unrelated_param(self):
+        # A param that merely contains "key" as a substring is not a secret.
+        raw = "https://x.test/p?monkey=banana&donkey=kong"
+        assert _redact_secrets(raw) == raw
+
+    def test_redacts_full_httpx_error_message(self):
+        request = httpx.Request("GET", f"https://api.example.com/s?apiKey={SECRET}&q=ABC")
+        response = httpx.Response(500, request=request)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            msg = str(exc)
+        assert SECRET in msg  # sanity: httpx really does embed the URL
+        out = _redact_secrets(msg)
+        assert SECRET not in out
+        assert "REDACTED" in out
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  BaseConnector log path — integration
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class _LeakyConnector(BaseConnector):
+    """A connector whose _do_search raises an HTTPStatusError for a URL whose query
+    string carries the API key — exactly how a 5xx from Mouser/element14/ OEMSecrets
+    surfaces through BaseConnector."""
+
+    source_name = "leaky"
+
+    def __init__(self):
+        # max_retries=0 → the single attempt fails and logs immediately.
+        super().__init__(max_retries=0)
+
+    async def _do_search(self, part_number: str) -> list[dict]:
+        request = httpx.Request("GET", f"https://api.example.com/search?apiKey={SECRET}&q={part_number}")
+        response = httpx.Response(500, request=request)
+        response.raise_for_status()  # raises httpx.HTTPStatusError with the URL in str()
+        return []
+
+
+@pytest.mark.asyncio
+async def test_search_with_retry_does_not_log_api_key():
+    captured: list[str] = []
+    sink_id = logger.add(captured.append, level="WARNING", format="{message}")
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            await _LeakyConnector()._search_with_retry("ABC123")
+    finally:
+        logger.remove(sink_id)
+
+    blob = "".join(captured)
+    assert blob, "expected a WARNING log line for the exhausted HTTP error"
+    assert SECRET not in blob, f"API key leaked to logs: {blob!r}"
+    assert "REDACTED" in blob

--- a/tests/test_connector_reraise_redaction.py
+++ b/tests/test_connector_reraise_redaction.py
@@ -1,0 +1,54 @@
+"""Regression: the exception PROPAGATED out of BaseConnector._search_with_retry must
+not carry a secret URL query param.
+
+search_service logs str(e) + the traceback, persists str(e) to the source-stats row,
+and streams it in the SSE error field — so redacting only the inner BaseConnector log
+line (the first pass) was insufficient. A 401 (wrong key) or an exhausted 5xx must
+surface a redacted exception.
+
+Called by: pytest
+Depends on: app.connectors.sources
+"""
+
+import httpx
+
+from app.connectors.sources import BaseConnector
+
+_SECRET_URL = "https://api.mouser.com/api/v1/search?apiKey=SUPER_SECRET_KEY_123"
+
+
+class _LeakyConnector(BaseConnector):
+    source_name = "leaky"
+
+    def __init__(self, status: int):
+        super().__init__(max_retries=0)
+        self._status = status
+
+    async def _do_search(self, part_number: str):
+        req = httpx.Request("GET", _SECRET_URL)
+        resp = httpx.Response(self._status, request=req)
+        raise httpx.HTTPStatusError(f"Client error '{self._status}' for url '{req.url}'", request=req, response=resp)
+
+
+async def test_auth_401_reraise_is_redacted():
+    conn = _LeakyConnector(401)
+    raised = None
+    try:
+        await conn._search_with_retry("LM317")
+    except Exception as e:  # noqa: BLE001
+        raised = e
+    assert raised is not None
+    assert "SUPER_SECRET_KEY_123" not in str(raised)
+    assert "REDACTED" in str(raised)
+
+
+async def test_exhausted_5xx_reraise_is_redacted():
+    conn = _LeakyConnector(500)
+    raised = None
+    try:
+        await conn._search_with_retry("LM317")
+    except Exception as e:  # noqa: BLE001
+        raised = e
+    assert raised is not None
+    assert "SUPER_SECRET_KEY_123" not in str(raised)
+    assert "REDACTED" in str(raised)

--- a/tests/test_contact_fields.py
+++ b/tests/test_contact_fields.py
@@ -447,6 +447,21 @@ class TestContactFormOwnerSelect:
 # ── full_name still renders ───────────────────────────────────────────────────
 
 
+@pytest.fixture()
+def _grant_account_management(test_user: User, db_session: Session) -> None:
+    """Promote the buyer ``test_user`` to MANAGER so it can_manage every account.
+
+    The contacts tab is reached via the company detail partial
+    (``GET /v2/partials/customers/{id}``), which now gates on ``can_manage_account``. The
+    class below GETs that endpoint as ``test_user`` on ``test_company`` without assigning
+    ownership, so promote the actor to MANAGER (``can_manage_account`` is True for managers,
+    exactly as for the account owner) to exercise the authorized render path.
+    """
+    test_user.role = "manager"
+    db_session.commit()
+
+
+@pytest.mark.usefixtures("_grant_account_management")
 class TestFullNameStillRenders:
     """full_name is still the display field everywhere."""
 

--- a/tests/test_crm_audit_trail.py
+++ b/tests/test_crm_audit_trail.py
@@ -311,6 +311,8 @@ class TestDetailRendersCreatedBy:
             name="TemplateAuditCo",
             created_by_id=test_user.id,
             modified_by_id=test_user.id,
+            # company detail now gates on can_manage_account
+            account_owner_id=test_user.id,
         )
         db_session.add(co)
         db_session.commit()

--- a/tests/test_crm_disposition.py
+++ b/tests/test_crm_disposition.py
@@ -377,6 +377,22 @@ class TestDispositionRoute:
         assert co.disposition in (None, CompanyDisposition.ACTIVE)
 
 
+@pytest.fixture()
+def _grant_account_management(test_user: User, db_session: Session) -> None:
+    """Promote the buyer ``test_user`` to MANAGER so it can_manage every account.
+
+    The send-to-prospecting route clears the company's ``account_owner_id`` and then
+    re-renders the company detail partial, which now gates on ``can_manage_account``.
+    Once ownership is cleared the buyer would 404 on that re-render, so promote the actor
+    to MANAGER (``can_manage_account`` stays True regardless of ownership) to exercise the
+    authorized render path. The clears-ownership assertion is unaffected — the service
+    still nulls ``account_owner_id``.
+    """
+    test_user.role = "manager"
+    db_session.commit()
+
+
+@pytest.mark.usefixtures("_grant_account_management")
 class TestSendToProspectingRoute:
     def test_route_clears_ownership(self, client, db_session: Session, test_user: User):
         co = _make_company(db_session, name="SendRoute", owner_id=test_user.id, domain="sendroute.com")

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -51,6 +51,21 @@ def test_contact(db_session: Session, test_site):
     return contact
 
 
+@pytest.fixture()
+def _grant_account_management(test_user: User, db_session: Session) -> None:
+    """Promote the buyer ``test_user`` to MANAGER so it can_manage every account.
+
+    Company detail + tab partials (``GET /v2/partials/customers/{id}`` and
+    ``.../tab/{tab}``) now gate on ``can_manage_account``. The classes below GET those
+    endpoints as ``test_user`` on companies they create without assigning ownership, so
+    promote the actor to MANAGER (``can_manage_account`` is True for managers, exactly as
+    for the account owner) to exercise the authorized render path. Applied per-class via
+    ``@pytest.mark.usefixtures`` — scoped narrowly so role-based list tests are untouched.
+    """
+    test_user.role = "manager"
+    db_session.commit()
+
+
 class TestCRMShell:
     """Test CRM shell partial route."""
 
@@ -531,6 +546,7 @@ class TestCustomerStaleness:
         assert pos_new < pos_old < pos_recent
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestContactPanel:
     """Test the contacts panel (default detail tab) with outreach actions."""
 
@@ -741,6 +757,7 @@ class TestContactPanel:
         assert "1 contact" in html, "Site group should show 1 contact, not 2"
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestEmailIntelligenceInActivity:
     """Test email intelligence data shown in activity tabs."""
 
@@ -811,6 +828,7 @@ class TestPerformanceRetired:
         assert resp.status_code == 404
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestContactsTabP33:
     """P3-3 TDD: accordion by site, role chips, per-contact clocks, honest empty states.
 
@@ -1029,6 +1047,7 @@ class TestContactsTabP33:
         assert "No contacts" in resp.text or "no contacts" in resp.text.lower()
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCompanyDetailCadenceCard:
     """Tests for the new account-cadence card + commercial-context strip in the company
     detail partial.
@@ -1222,6 +1241,7 @@ class TestCompanyDetailCadenceCard:
 # ────────────────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestUnifiedActivityTimeline:
     """P3-4 / Step-1 CRM regroup: activity tab shows type-sectioned ActivityLog feed.
 
@@ -1597,6 +1617,7 @@ class TestUnifiedTimelineHelper:
         assert events[-1]["ts"] == old
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestActivityTabTruncation:
     """Test that the activity tab indicates when ActivityLog results are truncated.
 
@@ -1940,6 +1961,7 @@ class TestVendorDetailCadenceHero:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestSegmentTagViews:
     """Tests for segment-tag UI endpoints.
 
@@ -2266,6 +2288,7 @@ class TestBuyingRoleSetter:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestRoleChipLegacy:
     """Tests that role_chip renders both legacy and new canonical values.
 
@@ -2584,6 +2607,7 @@ class TestEditContact:
         assert resp.status_code == 400
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestManualCompanyMerge:
     """Manual merge-duplicate accounts (P2e).
 
@@ -2795,6 +2819,7 @@ class TestManualCompanyMerge:
 # ────────────────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestAccountBuyPlansTab:
     """P3: account detail exposes a Buy Plans tab listing all buy-plans whose
     requisition belongs to the company (via company_id FK or name match).
@@ -2905,6 +2930,7 @@ class TestAccountBuyPlansTab:
         assert "Buy Plans" in resp.text, "Buy Plans tab label must appear in detail"
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCRMMacroDedup:
     """Route-level guards for the CRM template-macro dedup (refactor/crm-template-
     macros).
@@ -3065,6 +3091,7 @@ class TestCRMMacroDedup:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestContactsTabHome:
     """C2 TDD: Unified add/edit form + editable role + tab wrapper.
 
@@ -3530,6 +3557,7 @@ class TestContactsTabHome:
         assert "engineer" in resp.text
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestC3KebabActionsAndCadence:
     """C3 TDD: kebab (Edit/Delete/Set-Primary) on Contacts tab + cadence badge/sort.
 
@@ -3817,6 +3845,7 @@ class TestC3KebabActionsAndCadence:
         assert real_rows[0]["cadence"] == "new"
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestC4SuggestedContactsUI:
     """C4 TDD: Suggested-contacts UI loop.
 
@@ -4077,6 +4106,7 @@ class TestC4SuggestedContactsUI:
         assert sc is not None
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestFullWidthContactsForwardLayout:
     """Pin the full-width, contacts-forward customer + vendor detail reshape.
 
@@ -4548,6 +4578,7 @@ class TestCompanyPhase0FormFields:
         assert co.source == "apollo", f"Expected source 'apollo' preserved, got {co.source!r}"
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCustomerTabDeepLink:
     """Phase-0 Task B: account-detail tabs are deep-linkable via ?tab= param.
 
@@ -4811,6 +4842,7 @@ class TestDispositionFilter:
         assert "checked" in resp.text
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestAccountActivityTab:
     """Tests for the company Activity tab — type-sectioned feed (Step 1 of core-CRM
     plan).
@@ -5018,6 +5050,7 @@ class TestAccountActivityTab:
         assert ">Calls<" not in html
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestKnownFieldGrid:
     """WS2: account detail renders a known-field grid; empty fields show '+ Add <label>'."""
 

--- a/tests/test_edit_company_owner_validation.py
+++ b/tests/test_edit_company_owner_validation.py
@@ -1,0 +1,83 @@
+"""test_edit_company_owner_validation.py — Regression tests for edit_company owner gate.
+
+Verifies that POST /v2/partials/customers/{id}/edit validates a new primary owner the
+same way create_company and the bulk assign-owner path do: the target user must exist
+and be active. Without this guard, ownership can be silently transferred to a
+deactivated user, or a bogus id raises an unhandled FK IntegrityError (500) on commit.
+
+Called by: pytest
+Depends on: conftest.py fixtures (client auths as test_user; db_session, test_company, test_user)
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Company, User
+
+
+def _make_user(db: Session, *, email: str, azure_id: str, is_active: bool) -> User:
+    user = User(email=email, name=email.split("@")[0], role="buyer", azure_id=azure_id)
+    user.is_active = is_active
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+class TestEditCompanyOwnerValidation:
+    def test_edit_rejects_deactivated_new_owner(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
+        """Reassigning ownership to a deactivated user must 400 and leave owner
+        unchanged."""
+        # test_user is the primary owner so it passes can_manage_account_team.
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        deactivated = _make_user(
+            db_session, email="ghost@trioscs.com", azure_id="azure-deactivated-001", is_active=False
+        )
+
+        resp = client.post(
+            f"/v2/partials/customers/{test_company.id}/edit",
+            data={"name": test_company.name, "owner_id": str(deactivated.id)},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 400
+        db_session.refresh(test_company)
+        assert test_company.account_owner_id == test_user.id
+
+    def test_edit_rejects_nonexistent_new_owner(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
+        """A non-existent owner id must 400 (clean), not raise an FK error on commit."""
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{test_company.id}/edit",
+            data={"name": test_company.name, "owner_id": "999999"},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 400
+        db_session.refresh(test_company)
+        assert test_company.account_owner_id == test_user.id
+
+    def test_edit_accepts_active_new_owner(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
+        """Reassigning ownership to a valid active user succeeds."""
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        active = _make_user(db_session, email="newowner@trioscs.com", azure_id="azure-active-001", is_active=True)
+
+        resp = client.post(
+            f"/v2/partials/customers/{test_company.id}/edit",
+            data={"name": test_company.name, "owner_id": str(active.id)},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 200
+        db_session.refresh(test_company)
+        assert test_company.account_owner_id == active.id

--- a/tests/test_htmx_views.py
+++ b/tests/test_htmx_views.py
@@ -1214,6 +1214,22 @@ class TestCustomersList:
         assert resp.status_code == 200
 
 
+@pytest.fixture()
+def _grant_account_management(test_user: User, db_session: Session) -> None:
+    """Promote the buyer ``test_user`` to MANAGER so it can_manage every account.
+
+    Company detail + tab partials (``GET /v2/partials/customers/{id}`` and
+    ``.../tab/{tab}``) now gate on ``can_manage_account``. The class below GETs those
+    endpoints as ``test_user`` on companies it creates without assigning ownership, so
+    promote the actor to MANAGER (``can_manage_account`` is True for managers, exactly as
+    for the account owner) to exercise the authorized render path. Applied per-class via
+    ``@pytest.mark.usefixtures`` — scoped narrowly so role-based list tests are untouched.
+    """
+    test_user.role = "manager"
+    db_session.commit()
+
+
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCustomerDetail:
     """Test customer detail and tabs."""
 

--- a/tests/test_htmx_views_coverage.py
+++ b/tests/test_htmx_views_coverage.py
@@ -218,6 +218,22 @@ class TestVendorDetailMpnFilter:
 # ══════════════════════════════════════════════════════════════════════════
 
 
+@pytest.fixture()
+def _grant_account_management(test_user: User, db_session: Session) -> None:
+    """Promote the buyer ``test_user`` to MANAGER so it can_manage every account.
+
+    Company detail + tab partials (``GET /v2/partials/customers/{id}`` and
+    ``.../tab/{tab}``) now gate on ``can_manage_account``. The classes below GET those
+    endpoints as ``test_user`` on companies they create without assigning ownership, so
+    promote the actor to MANAGER (``can_manage_account`` is True for managers, exactly as
+    for the account owner) to exercise the authorized render path. Applied per-class via
+    ``@pytest.mark.usefixtures`` — scoped narrowly so role-based list tests are untouched.
+    """
+    test_user.role = "manager"
+    db_session.commit()
+
+
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCustomerTabs:
     @pytest.mark.parametrize(
         ("tab", "expected_status"),
@@ -253,6 +269,7 @@ class TestCustomerTabs:
 # ══════════════════════════════════════════════════════════════════════════
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCustomerDetail:
     def test_customer_detail(self, client: TestClient, db_session: Session):
         co = _make_company(db_session)
@@ -270,6 +287,7 @@ class TestCustomerDetail:
 # ══════════════════════════════════════════════════════════════════════════
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCompanyNameCheck:
     def test_company_detail_with_open_req(self, client: TestClient, db_session: Session, test_user: User):
         co = _make_company(db_session, name="OpenReqCo")

--- a/tests/test_htmx_views_deep.py
+++ b/tests/test_htmx_views_deep.py
@@ -903,6 +903,22 @@ class TestVendorDetailRoutes:
 # ══════════════════════════════════════════════════════════════════════════
 
 
+@pytest.fixture()
+def _grant_account_management(test_user: User, db_session: Session) -> None:
+    """Promote the buyer ``test_user`` to MANAGER so it can_manage every account.
+
+    Company detail + tab partials (``GET /v2/partials/customers/{id}`` and
+    ``.../tab/{tab}``) now gate on ``can_manage_account``. The class below GETs those
+    endpoints as ``test_user`` on companies it creates without assigning ownership, so
+    promote the actor to MANAGER (``can_manage_account`` is True for managers, exactly as
+    for the account owner) to exercise the authorized render path. Applied per-class via
+    ``@pytest.mark.usefixtures`` — scoped narrowly so role-based list tests are untouched.
+    """
+    test_user.role = "manager"
+    db_session.commit()
+
+
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCustomerRoutes:
     @pytest.mark.parametrize(
         "path",

--- a/tests/test_htmx_views_nightly18.py
+++ b/tests/test_htmx_views_nightly18.py
@@ -151,6 +151,22 @@ class TestCheckCompanyDuplicate:
 # ── Company Detail ────────────────────────────────────────────────────────
 
 
+@pytest.fixture()
+def _grant_account_management(test_user: User, db_session: Session) -> None:
+    """Promote the buyer ``test_user`` to MANAGER so it can_manage every account.
+
+    Company detail + tab partials (``GET /v2/partials/customers/{id}`` and
+    ``.../tab/{tab}``) now gate on ``can_manage_account``. The classes below GET those
+    endpoints as ``test_user`` on companies they create without assigning ownership, so
+    promote the actor to MANAGER (``can_manage_account`` is True for managers, exactly as
+    for the account owner) to exercise the authorized render path. Applied per-class via
+    ``@pytest.mark.usefixtures`` — scoped narrowly so role-based list tests are untouched.
+    """
+    test_user.role = "manager"
+    db_session.commit()
+
+
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCompanyDetailPartial:
     def test_detail_success(self, client: TestClient, test_company: Company):
         resp = client.get(f"/v2/partials/customers/{test_company.id}")
@@ -164,6 +180,7 @@ class TestCompanyDetailPartial:
 # ── Company Tabs ──────────────────────────────────────────────────────────
 
 
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCompanyTab:
     @pytest.mark.parametrize("tab", ["sites", "contacts", "requisitions", "activity"])
     def test_tab_valid(self, client: TestClient, test_company: Company, tab: str):

--- a/tests/test_htmx_views_nightly4.py
+++ b/tests/test_htmx_views_nightly4.py
@@ -547,6 +547,22 @@ class TestPartHeaderEditCell:
 # ── Tests: Company tab routes ─────────────────────────────────────────
 
 
+@pytest.fixture()
+def _grant_account_management(test_user: User, db_session: Session) -> None:
+    """Promote the buyer ``test_user`` to MANAGER so it can_manage every account.
+
+    Company detail + tab partials (``GET /v2/partials/customers/{id}`` and
+    ``.../tab/{tab}``) now gate on ``can_manage_account``. The classes below GET those
+    endpoints as ``test_user`` on companies they create without assigning ownership, so
+    promote the actor to MANAGER (``can_manage_account`` is True for managers, exactly as
+    for the account owner) to exercise the authorized render path. Applied per-class via
+    ``@pytest.mark.usefixtures`` — scoped narrowly so role-based list tests are untouched.
+    """
+    test_user.role = "manager"
+    db_session.commit()
+
+
+@pytest.mark.usefixtures("_grant_account_management")
 class TestCompanyTabRoutes:
     @pytest.mark.parametrize("tab", ["sites", "contacts", "requisitions", "activity"])
     def test_tab_empty_returns_200(self, client: TestClient, db_session: Session, test_company, tab: str):

--- a/tests/test_phase_integration_fixes.py
+++ b/tests/test_phase_integration_fixes.py
@@ -274,7 +274,8 @@ class TestCompanyActivityTab:
         from app.models import Company
         from app.models.offers import Contact as RfqContact
 
-        company = Company(name="Activity Co", account_type="customer")
+        # account_owner_id: company detail/tab now gates on can_manage_account
+        company = Company(name="Activity Co", account_type="customer", account_owner_id=test_user.id)
         db_session.add(company)
         db_session.flush()
 
@@ -312,7 +313,8 @@ class TestCompanyActivityTab:
         """Empty company activity tab shows placeholder."""
         from app.models import Company
 
-        company = Company(name="Empty Co", account_type="customer")
+        # account_owner_id: company detail/tab now gates on can_manage_account
+        company = Company(name="Empty Co", account_type="customer", account_owner_id=test_user.id)
         db_session.add(company)
         db_session.commit()
 
@@ -329,7 +331,8 @@ class TestCompanyActivityTab:
         from app.models.intelligence import ActivityLog
         from app.models.offers import Contact as RfqContact
 
-        company = Company(name="Mixed Emails Co", account_type="customer")
+        # account_owner_id: company detail/tab now gates on can_manage_account
+        company = Company(name="Mixed Emails Co", account_type="customer", account_owner_id=test_user.id)
         db_session.add(company)
         db_session.flush()
 

--- a/tests/test_quotes_relocation.py
+++ b/tests/test_quotes_relocation.py
@@ -218,6 +218,8 @@ def _company_with_site(db_session, *, name="Acme Corp"):
 
 def test_company_quotes_tab_unions_site_and_requisition(client, db_session, test_user):
     company, site = _company_with_site(db_session)
+    company.account_owner_id = test_user.id  # company detail/tab now gates on can_manage_account
+    db_session.commit()
     reqn, _ = _req_with_part(db_session, test_user, company_id=company.id)
     # Quote linked only via the customer site:
     _quote(db_session, requisition_id=reqn.id, number="Q-SITE-1", site_id=site.id)
@@ -231,6 +233,8 @@ def test_company_quotes_tab_unions_site_and_requisition(client, db_session, test
 
 def test_company_quotes_tab_empty_state(client, db_session, test_user):
     company, _ = _company_with_site(db_session)
+    company.account_owner_id = test_user.id  # company detail/tab now gates on can_manage_account
+    db_session.commit()
     resp = client.get(f"/v2/partials/customers/{company.id}/tab/quotes")
     assert resp.status_code == 200
     assert "No quotes" in resp.text
@@ -243,6 +247,8 @@ def test_company_unknown_tab_still_404(client, db_session, test_user):
 
 def test_company_detail_shows_quotes_tab_button(client, db_session, test_user):
     company, _ = _company_with_site(db_session)
+    company.account_owner_id = test_user.id  # company detail/tab now gates on can_manage_account
+    db_session.commit()
     resp = client.get(f"/v2/partials/customers/{company.id}")
     assert resp.status_code == 200
     assert "tab/quotes" in resp.text

--- a/tests/test_resell_draft_offer_privacy.py
+++ b/tests/test_resell_draft_offer_privacy.py
@@ -1,0 +1,114 @@
+"""test_resell_draft_offer_privacy.py — Draft-privacy regression for the offer funnel.
+
+Guards the resell offer entry points (the submit-offer modal and the offer POST) against
+leaking or accepting offers on an UNPUBLISHED (draft) list. A non-owner with ``can_offer``
+must get a 404 (existence not revealed) on a draft list — only the owner sees a draft, and
+nobody may bid on it until it is posted. A posted (collecting) list still works for the
+same non-owner.
+
+Called by: pytest. Depends on: conftest fixtures (client auths as test_user, a buyer),
+app.routers.resell, app.services.excess_service.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.constants import ExcessListStatus
+from app.models import Company, User
+from app.models.excess import ExcessLineItem, ExcessList, ExcessOffer
+from app.utils.normalization import normalize_mpn_key
+
+
+@pytest.fixture()
+def owner_user(db_session: Session) -> User:
+    """The list owner — a trader (can_post + can_offer), distinct from the buyer
+    client."""
+    user = User(
+        email="owner-trader@trioscs.com",
+        name="Olive Owner",
+        role="trader",
+        azure_id="test-azure-owner-trader",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def _list_with_line(db_session: Session, owner: User, company: Company, status: str) -> ExcessList:
+    el = ExcessList(
+        title=f"List ({status})",
+        company_id=company.id,
+        owner_id=owner.id,
+        status=status,
+        total_line_items=1,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(el)
+    db_session.flush()
+    db_session.add(
+        ExcessLineItem(
+            excess_list_id=el.id,
+            part_number="XCVU9P-2FLGA2104I",
+            normalized_part_number=normalize_mpn_key("XCVU9P-2FLGA2104I"),
+            quantity=50,
+            condition="New",
+        )
+    )
+    db_session.commit()
+    db_session.refresh(el)
+    return el
+
+
+@pytest.fixture()
+def draft_list(db_session: Session, owner_user: User, test_company: Company) -> ExcessList:
+    """A DRAFT (unpublished) list owned by owner_user — invisible to non-owners."""
+    return _list_with_line(db_session, owner_user, test_company, ExcessListStatus.DRAFT)
+
+
+@pytest.fixture()
+def posted_list(db_session: Session, owner_user: User, test_company: Company) -> ExcessList:
+    """A posted (collecting) list owned by owner_user — open for offers."""
+    return _list_with_line(db_session, owner_user, test_company, ExcessListStatus.COLLECTING)
+
+
+def test_non_owner_offer_form_on_draft_404(client, draft_list, owner_user, test_user):
+    """Non-owner GET on a draft list's offer-form modal → 404 (existence not
+    revealed)."""
+    assert test_user.id != owner_user.id
+    resp = client.get(f"/v2/partials/resell/{draft_list.id}/offer-form")
+    assert resp.status_code == 404
+
+
+def test_non_owner_submit_offer_on_draft_404(client, db_session, draft_list, owner_user, test_user):
+    """Non-owner POST of an offer on a draft list → 404 and NO offer persisted."""
+    assert test_user.id != owner_user.id
+    resp = client.post(
+        f"/api/resell/{draft_list.id}/offers",
+        data={"scope": "per_line", "mpn_raw": "XCVU9P-2FLGA2104I", "quantity": "10", "unit_price": "5.00"},
+    )
+    assert resp.status_code == 404
+    offers = db_session.query(ExcessOffer).filter_by(excess_list_id=draft_list.id).all()
+    assert offers == []
+
+
+def test_non_owner_offer_form_on_posted_200(client, posted_list, owner_user, test_user):
+    """The same non-owner CAN open the offer-form on a posted (collecting) list."""
+    resp = client.get(f"/v2/partials/resell/{posted_list.id}/offer-form")
+    assert resp.status_code == 200
+
+
+def test_non_owner_submit_offer_on_posted_200(client, db_session, posted_list, owner_user, test_user):
+    """The same non-owner CAN submit an offer on a posted list (offer persisted)."""
+    resp = client.post(
+        f"/api/resell/{posted_list.id}/offers",
+        data={"scope": "per_line", "mpn_raw": "XCVU9P-2FLGA2104I", "quantity": "10", "unit_price": "5.00"},
+    )
+    assert resp.status_code == 200
+    offers = db_session.query(ExcessOffer).filter_by(excess_list_id=posted_list.id).all()
+    assert len(offers) == 1

--- a/tests/test_routers_proactive.py
+++ b/tests/test_routers_proactive.py
@@ -212,8 +212,14 @@ def test_scorecard_sales_own(mock_fn, sales_client):
 # ── Site Contacts ────────────────────────────────────────────────────
 
 
-def test_contacts_for_site(client, db_session, test_customer_site):
-    """Returns site contacts."""
+def test_contacts_for_site(client, db_session, test_user, test_company, test_customer_site):
+    """Returns site contacts.
+
+    get_site_contacts now scopes to can_manage_account, so test_user must own the site's
+    company to pass the gate.
+    """
+    test_company.account_owner_id = test_user.id
+    db_session.commit()
     contact = SiteContact(
         customer_site_id=test_customer_site.id,
         full_name="Jane Doe",
@@ -231,9 +237,15 @@ def test_contacts_for_site(client, db_session, test_customer_site):
     assert data[0]["is_primary"] is True
 
 
-def test_contacts_site_empty(client):
-    """Invalid/empty site_id -> empty list."""
-    resp = client.get("/api/proactive/contacts/99999")
+def test_contacts_site_empty(client, db_session, test_user, test_company, test_customer_site):
+    """Owned site with no contacts -> empty list.
+
+    get_site_contacts now 404s for an unmanaged/unknown site, so exercise the empty-list
+    path on a real site whose company test_user owns.
+    """
+    test_company.account_owner_id = test_user.id
+    db_session.commit()
+    resp = client.get(f"/api/proactive/contacts/{test_customer_site.id}")
     assert resp.status_code == 200
     assert resp.json() == []
 
@@ -429,8 +441,13 @@ class TestDraftEndpoint:
 
 
 class TestContactsExtended:
-    def test_contacts_multiple_for_site(self, client, db_session, test_customer_site):
-        """Multiple contacts ordered by is_primary desc, then full_name."""
+    def test_contacts_multiple_for_site(self, client, db_session, test_user, test_company, test_customer_site):
+        """Multiple contacts ordered by is_primary desc, then full_name.
+
+        test_user owns the site's company so the can_manage_account gate passes.
+        """
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
         c1 = SiteContact(
             customer_site_id=test_customer_site.id,
             full_name="Alice Smith",

--- a/tests/test_routers_vendors_crud.py
+++ b/tests/test_routers_vendors_crud.py
@@ -543,7 +543,7 @@ async def test_scrape_website_contacts_extracts_data():
     with patch("app.cache.intel_cache.get_cached", return_value=None):
         with patch("app.cache.intel_cache.set_cached"):
             with patch("app.utils.vendor_helpers.is_private_url", return_value=False):
-                with patch("app.utils.vendor_helpers.http_redirect") as mock_http:
+                with patch("app.utils.vendor_helpers.http") as mock_http:
                     mock_http.get = AsyncMock(return_value=mock_resp)
                     result = await scrape_website_contacts("https://vendor.com")
 
@@ -557,7 +557,7 @@ async def test_scrape_website_contacts_handles_errors():
     with patch("app.cache.intel_cache.get_cached", return_value=None):
         with patch("app.cache.intel_cache.set_cached"):
             with patch("app.utils.vendor_helpers.is_private_url", return_value=False):
-                with patch("app.utils.vendor_helpers.http_redirect") as mock_http:
+                with patch("app.utils.vendor_helpers.http") as mock_http:
                     mock_http.get = AsyncMock(side_effect=Exception("Connection failed"))
                     result = await scrape_website_contacts("https://dead-site.com")
 
@@ -575,7 +575,7 @@ async def test_scrape_website_contacts_non_200():
     with patch("app.cache.intel_cache.get_cached", return_value=None):
         with patch("app.cache.intel_cache.set_cached"):
             with patch("app.utils.vendor_helpers.is_private_url", return_value=False):
-                with patch("app.utils.vendor_helpers.http_redirect") as mock_http:
+                with patch("app.utils.vendor_helpers.http") as mock_http:
                     mock_http.get = AsyncMock(return_value=mock_resp)
                     result = await scrape_website_contacts("https://no-contact.com")
 
@@ -593,7 +593,7 @@ async def test_scrape_website_contacts_no_scheme():
     with patch("app.cache.intel_cache.get_cached", return_value=None):
         with patch("app.cache.intel_cache.set_cached"):
             with patch("app.utils.vendor_helpers.is_private_url", return_value=False):
-                with patch("app.utils.vendor_helpers.http_redirect") as mock_http:
+                with patch("app.utils.vendor_helpers.http") as mock_http:
                     mock_http.get = AsyncMock(return_value=mock_resp)
                     result = await scrape_website_contacts("bare.com")
 
@@ -606,7 +606,7 @@ async def test_scrape_website_contacts_domain_index_error():
     with patch("app.cache.intel_cache.get_cached", return_value=None):
         with patch("app.cache.intel_cache.set_cached"):
             with patch("app.utils.vendor_helpers.is_private_url", return_value=False):
-                with patch("app.utils.vendor_helpers.http_redirect") as mock_http:
+                with patch("app.utils.vendor_helpers.http") as mock_http:
                     mock_http.get = AsyncMock(return_value=MagicMock(status_code=404, text=""))
                     result = await scrape_website_contacts("https://")
     # Should still return valid (empty) result

--- a/tests/test_vendor_helpers.py
+++ b/tests/test_vendor_helpers.py
@@ -931,7 +931,7 @@ class TestScrapeWebsiteContacts:
                 patch("app.cache.intel_cache.get_cached", return_value=None),
                 patch("app.cache.intel_cache.set_cached"),
                 patch("app.utils.vendor_helpers.is_private_url", return_value=False),
-                patch("app.utils.vendor_helpers.http_redirect", mock_http),
+                patch("app.utils.vendor_helpers.http", mock_http),
             ):
                 return await scrape_website_contacts("https://vendor.com")
 
@@ -954,7 +954,7 @@ class TestScrapeWebsiteContacts:
                 patch("app.cache.intel_cache.get_cached", return_value=None),
                 patch("app.cache.intel_cache.set_cached"),
                 patch("app.utils.vendor_helpers.is_private_url", return_value=False),
-                patch("app.utils.vendor_helpers.http_redirect", mock_http),
+                patch("app.utils.vendor_helpers.http", mock_http),
             ):
                 return await scrape_website_contacts("https://downsite.com")
 
@@ -988,7 +988,7 @@ class TestScrapeWebsiteContacts:
                 patch("app.cache.intel_cache.get_cached", return_value=None),
                 patch("app.cache.intel_cache.set_cached"),
                 patch("app.utils.vendor_helpers.is_private_url", return_value=False),
-                patch("app.utils.vendor_helpers.http_redirect", mock_http),
+                patch("app.utils.vendor_helpers.http", mock_http),
             ):
                 return await scrape_website_contacts("https://forbidden.com")
 

--- a/tests/test_vendor_helpers_ssrf_redirect.py
+++ b/tests/test_vendor_helpers_ssrf_redirect.py
@@ -1,0 +1,93 @@
+"""Regression tests for SSRF-via-redirect in scrape_website_contacts.
+
+is_private_url only validates the INITIAL url; the fetch must not follow a 3xx to an
+unvalidated host. These tests prove a vendor page that 302s to an internal host / cloud
+metadata (169.254.169.254) is NOT fetched, while a redirect to a public host still works.
+
+Tests: app.utils.vendor_helpers._safe_get / scrape_website_contacts
+"""
+
+import asyncio
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+from app.utils.vendor_helpers import scrape_website_contacts
+
+METADATA_URL = "http://169.254.169.254/latest/meta-data/"
+
+
+class _FakeResp:
+    def __init__(self, status_code, *, headers=None, text=""):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+
+
+def _host_is_private(url: str) -> bool:
+    """Stand-in for is_private_url: only the cloud-metadata IP counts as private."""
+    return (urlparse(url).hostname or "") == "169.254.169.254"
+
+
+def test_redirect_to_internal_host_not_followed():
+    """A 302 to an internal/metadata host is blocked, not followed to the internal
+    service."""
+    fetched: list[str] = []
+
+    async def fake_get(url, headers=None, timeout=None):
+        fetched.append(url)
+        # Vendor page issues a 302 pointing at the cloud-metadata endpoint.
+        return _FakeResp(302, headers={"location": METADATA_URL})
+
+    class _FakeClient:
+        get = staticmethod(fake_get)
+
+    async def _run():
+        with (
+            patch("app.cache.intel_cache.get_cached", return_value=None),
+            patch("app.cache.intel_cache.set_cached"),
+            patch("app.utils.vendor_helpers.is_private_url", side_effect=_host_is_private),
+            patch("app.utils.vendor_helpers.http", _FakeClient),
+        ):
+            return await scrape_website_contacts("https://evil-vendor.com")
+
+    result = asyncio.get_event_loop().run_until_complete(_run())
+
+    # Scraper returns empty — it never reached the internal metadata service.
+    assert result == {"emails": [], "phones": []}
+    # The internal/metadata host must never have been requested.
+    assert all(urlparse(u).hostname != "169.254.169.254" for u in fetched), fetched
+    # The vendor pages themselves were attempted (so this isn't a no-op pass).
+    assert fetched, "expected the public vendor pages to be fetched"
+
+
+def test_redirect_to_public_host_is_followed():
+    """A 302 to another PUBLIC host is followed (no over-blocking) and content
+    extracted."""
+    final_html = '<a href="mailto:sales@vendor.com">Email</a>'
+    fetched: list[str] = []
+
+    async def fake_get(url, headers=None, timeout=None):
+        fetched.append(url)
+        if "vendor.com" in (urlparse(url).hostname or "") and "/landing" not in url:
+            # First hop: redirect to a public landing page on a public host.
+            return _FakeResp(302, headers={"location": "https://www.vendor.com/landing"})
+        return _FakeResp(200, text=final_html)
+
+    class _FakeClient:
+        get = staticmethod(fake_get)
+
+    async def _run():
+        with (
+            patch("app.cache.intel_cache.get_cached", return_value=None),
+            patch("app.cache.intel_cache.set_cached"),
+            # No host here is private.
+            patch("app.utils.vendor_helpers.is_private_url", return_value=False),
+            patch("app.utils.vendor_helpers.http", _FakeClient),
+        ):
+            return await scrape_website_contacts("https://vendor.com")
+
+    result = asyncio.get_event_loop().run_until_complete(_run())
+
+    assert "sales@vendor.com" in result["emails"]
+    # The public landing page was followed.
+    assert any("/landing" in u for u in fetched), fetched


### PR DESCRIPTION
Phase 2a of the audit remediation — the **P1 authz/scoping cluster**. Every fix is real-DB TDD'd and passed an adversarial review pass (which caught a bypassed redaction + an incomplete gate before merge).

## Fixes
1. **Requisition list scoping** — filtered only SALES; now `RESTRICTED_ROLES` (TRADER too), both the record filter and the owner dropdown. Same sweep fixed `quotes.py` pricing-history (TRADER saw every customer's pricing).
2. **materials access gate** — `materials_list_partial` bypassed the inner `require_access`; now the **whole materials partial surface** (`/faceted`, `/{card_id}`, filters, …) requires `MATERIALS` access (review caught that gating only the wrapper left the data endpoints open).
3. **edit_company owner validation** — validate the new owner exists + is active (was a silent transfer to a deactivated user / a 500 on bad id).
4. **resell draft-privacy** — non-owners 404 on draft lists (offer-form + submit), via `_get_list_for_user` + posted-status check.
5. **SSRF via redirect** — the website scraper re-validates **every redirect hop's** resolved IP (was: initial URL only → 302 to `169.254.169.254` followed).
6. **connector API-key log leak** — keys in URL query params leaked via re-raised httpx errors to logs / the source-stats row / the SSE stream. Now sanitized at the re-raise (`ConnectorError(redacted) from None` — clean `str` *and* traceback; only httpx errors are wrapped) + redacted at the orchestrator sinks.
7. **company detail / site-contacts PII scoping** *(product decision: "match the contacts list")* — `company_detail_partial` / `company_tab` / `get_site_contacts` now gate on `can_manage_account` (404), consistent with the already-scoped contacts list. Gate is on the **GET route only**; the 5 internal mutation handlers that re-render the detail use a new ungated `_render_company_detail` helper.

## Tests
- New: `test_authz_requisition_list_scoping`, `test_authz_materials_gate`, `test_authz_company_detail_scoping`, `test_edit_company_owner_validation`, `test_resell_draft_offer_privacy`, `test_vendor_helpers_ssrf_redirect`, `test_connector_key_redaction`, `test_connector_reraise_redaction` — all red→green.
- The detail-scoping is a behavior change (a non-manager can't view non-owned accounts — same as the list already does), so ~124 existing happy-path tests were updated to own/manage the viewed company (no weakened assertions; the 404 path is covered by the new deny-path test).
- Full local suite: 21493 passing after fixes; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)