### PR TITLE
fix(p1): correctness cluster — MPN normalization, MOQ/lead-time, avail-score 0-100, substitutes hardening

### DIFF
--- a/app/routers/htmx/offers.py
+++ b/app/routers/htmx/offers.py
@@ -230,6 +230,8 @@ async def save_parsed_offers(
 
     # Match MPNs to requirements
     reqs = db.query(Requirement).filter(Requirement.requisition_id == req_id).all()
+    from app.services.offer_qualification import apply_qualification
+    from app.utils.normalization import normalize_mpn_key
     from app.vendor_utils import normalize_vendor_name
 
     saved_count = 0
@@ -266,6 +268,9 @@ async def save_parsed_offers(
             vendor_name=card.display_name,
             vendor_name_normalized=card.normalized_name,
             mpn=o["mpn"],
+            # Canonical dedup key (dash-stripped) so the part-centric offers query
+            # matches these AI-parsed offers, mirroring add_offer / create_offer.
+            normalized_mpn=normalize_mpn_key(o["mpn"]),
             manufacturer=o.get("manufacturer"),
             qty_available=o.get("qty_available"),
             unit_price=o.get("unit_price"),
@@ -278,6 +283,7 @@ async def save_parsed_offers(
             entered_by_id=user.id,
             status=OfferStatus.ACTIVE,
         )
+        apply_qualification(offer)  # non-raising: composes note + sets qualification_status
         db.add(offer)
         # Offer hook: the user reviewed and saved this parse ACTIVE — user-initiated
         # proof of availability, release the vendor's matching active records.

--- a/app/routers/htmx/vendors.py
+++ b/app/routers/htmx/vendors.py
@@ -609,7 +609,7 @@ async def vendor_tab(
     else:  # offers
         offers = (
             db.query(Offer)
-            .filter(Offer.vendor_name == vendor.display_name)
+            .filter(Offer.vendor_name_normalized == vendor.normalized_name)
             .order_by(Offer.created_at.desc().nullslast())
             .limit(50)
             .all()

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -1332,10 +1332,18 @@ async def add_to_requisition(
     )
 
     if not requirement:
+        # Mirror update_requirement: store the canonical key-form normalized_mpn
+        # (lowercase, separators stripped) so part-history / material-card joins
+        # line up, and resolve the MaterialCard up front.
+        from ..search_service import resolve_material_card
+        from ..utils.normalization import normalize_mpn_key
+
+        card = resolve_material_card(mpn, db)
         requirement = Requirement(
             requisition_id=requisition_id,
             primary_mpn=mpn,
-            normalized_mpn=mpn.strip().upper(),
+            normalized_mpn=normalize_mpn_key(mpn),
+            material_card_id=card.id if card else None,
             target_qty=None,
             sourcing_status=SourcingStatus.OPEN,
         )

--- a/app/routers/requisitions/requirements.py
+++ b/app/routers/requisitions/requirements.py
@@ -94,7 +94,14 @@ def _substitute_keys(requirement: Requirement) -> list[str]:
     """
     keys = []
     for sub in requirement.substitutes or []:
-        sub_str = (sub if isinstance(sub, str) else sub.get("mpn", "")).strip()
+        # Robust to legacy strings, dict form (incl. {"mpn": None}), and malformed
+        # non-str/non-dict entries — mirrors parse_substitute_mpns.
+        if isinstance(sub, str):
+            sub_str = sub.strip()
+        elif isinstance(sub, dict):
+            sub_str = str(sub.get("mpn") or "").strip()
+        else:
+            continue
         if sub_str:
             sub_key = normalize_mpn_key(sub_str)
             if sub_key:

--- a/app/routers/requisitions/requirements.py
+++ b/app/routers/requisitions/requirements.py
@@ -87,11 +87,14 @@ def _dedupe_substitutes(subs: list[str], primary_mpn: str) -> list[dict]:
 
 
 def _substitute_keys(requirement: Requirement) -> list[str]:
-    """Return normalized MPN keys for a requirement's substitutes (string or dict
-    form)."""
+    """Return normalized MPN keys for a requirement's substitutes.
+
+    Handles both the canonical dict form ({"mpn": ..., "manufacturer": ...})
+    and the legacy plain-string form.
+    """
     keys = []
     for sub in requirement.substitutes or []:
-        sub_str = (sub if isinstance(sub, str) else "").strip()
+        sub_str = (sub if isinstance(sub, str) else sub.get("mpn", "")).strip()
         if sub_str:
             sub_key = normalize_mpn_key(sub_str)
             if sub_key:

--- a/app/search_service.py
+++ b/app/search_service.py
@@ -1394,6 +1394,29 @@ def get_market_source_health(db: Session) -> dict:
     }
 
 
+def _any_pn_obsolete(db: Session, pns: list[str]) -> bool:
+    """True if any of ``pns`` maps to a MaterialCard marked obsolete.
+
+    ``pns`` are display-form MPNs (uppercase, dashes preserved) as produced by
+    ``get_all_pns``, but ``MaterialCard.normalized_mpn`` stores the canonical
+    KEY form (``normalize_mpn_key``: lowercase, non-alphanumerics stripped).
+    Query with the key form — a raw display-form ``filter_by`` never matches.
+    All keys are batched into a single indexed ``.in_()`` query to avoid an N+1.
+    """
+    keys = [k for k in (normalize_mpn_key(pn) for pn in pns) if k]
+    if not keys:
+        return False
+    return (
+        db.query(MaterialCard.id)
+        .filter(
+            MaterialCard.normalized_mpn.in_(keys),
+            MaterialCard.lifecycle_status == "obsolete",
+        )
+        .first()
+        is not None
+    )
+
+
 async def _fetch_fresh(pns: list[str], db: Session) -> tuple[list[dict], list[dict]]:
     """Run all enabled connectors against pns and return (results, source_stats).
 
@@ -1566,12 +1589,7 @@ async def _fetch_fresh(pns: list[str], db: Session) -> tuple[list[dict], list[di
         api_result_count = len(out)
         has_price_below_target = any(r.get("unit_price") is not None and r["unit_price"] > 0 for r in out)
         # Check obsolete status from MaterialCard if available
-        is_obsolete = False
-        for pn in pns:
-            card = db.query(MaterialCard).filter_by(normalized_mpn=pn).first()
-            if card and getattr(card, "lifecycle_status", None) == "obsolete":
-                is_obsolete = True
-                break
+        is_obsolete = _any_pn_obsolete(db, pns)
 
         # Months since last sighting for primary PN.
         # NOTE: Sighting has no `mpn` column — the stored fields are

--- a/app/services/avail_score_service.py
+++ b/app/services/avail_score_service.py
@@ -545,8 +545,14 @@ def compute_sales_avail_score(db: Session, user_id: int, month: date) -> dict:
     b5_score = _tier(new_biz, [(8, 10), (6, 8), (4, 6), (2, 4), (1, 2)])
     b5_raw = f"{new_accounts} accts + {new_contacts} contacts + {prospect_companies} prospects"
 
-    # ── B6: Interaction Quality ──
-    # Average quality_score of meaningful activities this month
+    # ── B6: Interaction Quality (displayed diagnostic — NOT scored) ──
+    # Average quality_score of meaningful activities this month. This is a soft,
+    # AI-assessed signal, not real tradable activity, so it is surfaced for context
+    # but deliberately excluded from behavior_total: sales must share the buyers'
+    # documented 0-100 scale (5 behaviors + 5 outcomes). Summing b6 here made sales
+    # 0-110 — easier to clear the absolute QUALIFY gates (60/50/40) that drive real
+    # $500/$250/$100 payouts — and b6 was never persisted, so the breakdown could not
+    # reconcile (b1..b5 ≠ behavior_total).
     avg_quality_raw = (
         db.query(sqlfunc.avg(ActivityLog.quality_score))
         .filter(
@@ -560,7 +566,7 @@ def compute_sales_avail_score(db: Session, user_id: int, month: date) -> dict:
     ) or 0.0
     b6 = _tier(avg_quality_raw, [(80, 10), (60, 8), (40, 6), (20, 4), (1, 2)])
 
-    behavior_total = b1_score + b2_score + b3_score + b4_score + b5_score + b6
+    behavior_total = b1_score + b2_score + b3_score + b4_score + b5_score
 
     # ── O1: Win Rate ──
     won = (

--- a/app/services/avail_score_service.py
+++ b/app/services/avail_score_service.py
@@ -124,7 +124,9 @@ def compute_buyer_avail_score(db: Session, user_id: int, month: date) -> dict:
 
     # Pre-load offer IDs in quotes and buy plans (same pattern as existing leaderboard)
     quoted_offer_ids = set()
-    for (items,) in db.query(Quote.line_items).filter(Quote.status.in_(["sent", "won", "lost"])).limit(10000).all():
+    # No arbitrary row cap: a global .limit() silently dropped offers past the cap and
+    # undercounted O2/O4 (which drive real payouts). Scan all sent/won/lost quotes.
+    for (items,) in db.query(Quote.line_items).filter(Quote.status.in_(["sent", "won", "lost"])).all():
         for item in items or []:
             oid = item.get("offer_id")
             if oid:
@@ -136,7 +138,6 @@ def compute_buyer_avail_score(db: Session, user_id: int, month: date) -> dict:
         db.query(BuyPlan.status, BuyPlanLine.offer_id)
         .join(BuyPlanLine, BuyPlanLine.buy_plan_id == BuyPlan.id)
         .filter(BuyPlanLine.offer_id.isnot(None))
-        .limit(10000)
         .all()
     ):
         bp_offer_ids.add(offer_id)

--- a/app/startup.py
+++ b/app/startup.py
@@ -110,6 +110,7 @@ def run_startup_migrations() -> None:
         _create_default_user_if_env_set()
     _backfill_sighting_offer_normalized_mpn()
     _backfill_sighting_vendor_normalized()
+    _backfill_offer_vendor_normalized()
     _backfill_proactive_offer_qty()
     _backfill_ticket_defaults()
     _backfill_material_cards()
@@ -773,6 +774,57 @@ def _backfill_sighting_vendor_normalized() -> None:
                 break
         if total:
             logger.info("Backfilled vendor_name_normalized on {} sightings", total)
+
+
+def _backfill_offer_vendor_normalized() -> None:
+    """Backfill offers.vendor_name_normalized from vendor_name until none remain.
+
+    The vendor detail offers tab filters Offer.vendor_name_normalized == normalized_name
+    (aligned with sightings/leads). Every offer write-path already populates the column,
+    but a legacy row created before that was universal would be NULL and silently hidden
+    by the tab; this idempotent backfill closes that gap.
+    """
+    from .vendor_utils import normalize_vendor_name
+
+    with engine.connect() as conn:
+        # Check column exists first
+        try:
+            conn.execute(sqltext("SELECT vendor_name_normalized FROM offers LIMIT 0"))
+        except (SQLAlchemyError, DBAPIError):
+            conn.rollback()
+            return  # Column not yet created
+
+        total = 0
+        while True:
+            try:
+                rows = conn.execute(
+                    sqltext(
+                        "SELECT id, vendor_name FROM offers "
+                        "WHERE vendor_name_normalized IS NULL AND vendor_name IS NOT NULL "
+                        "LIMIT :lim"
+                    ),
+                    {"lim": _BACKFILL_BATCH_SIZE},
+                ).fetchall()
+                if not rows:
+                    break
+                batch = []
+                for r in rows:
+                    nv = normalize_vendor_name(r[1])
+                    if nv:
+                        batch.append({"nv": nv, "id": r[0]})
+                if batch:
+                    conn.execute(
+                        sqltext("UPDATE offers SET vendor_name_normalized = :nv WHERE id = :id"),
+                        batch,
+                    )
+                    conn.commit()
+                total += len(batch)
+            except Exception as e:
+                logger.warning("Backfill offers.vendor_name_normalized failed: {}", e)
+                conn.rollback()
+                break
+        if total:
+            logger.info("Backfilled vendor_name_normalized on {} offers", total)
 
 
 # ── Denormalized company count triggers ──────────────────────────────

--- a/app/utils/normalization.py
+++ b/app/utils/normalization.py
@@ -204,7 +204,9 @@ def normalize_lead_time(raw: Any) -> int | None:
         multiplier = 7
     elif any(w in s for w in ("month", "mo")):
         multiplier = 30
-    elif any(w in s for w in ("day", "dy", "d ", "aro", "business")):
+    elif any(w in s for w in ("day", "dy", "d ", "aro", "business")) or re.search(r"\d\s*d\b", s):
+        # Compact day shorthand ("30d", "5d", "14 d") has no trailing space, so
+        # match a digit immediately followed by a standalone "d".
         multiplier = 1
     else:
         # Ambiguous — assume weeks if >0 and <52, days otherwise
@@ -291,8 +293,17 @@ def normalize_moq(raw: Any) -> int | None:
     if raw is None:
         return None
     s = str(raw).strip()
-    # Strip common prefixes
+    # Strip common leading prefixes ("MOQ:", "Minimum", "Min")
     s = re.sub(r"^(?:moq|minimum|min)[:\s]*", "", s, flags=re.IGNORECASE).strip()
+    # Strip trailing qualifier words ("10K minimum", "500 pcs", "250 each") before
+    # quantity parsing — otherwise a trailing "minimum" makes the string end in "m"
+    # and normalize_quantity mistakes it for the 1e6 multiplier suffix → None.
+    s = re.sub(
+        r"[\s:]*(?:minimum|min|pcs|pieces|piece|units|unit|each|ea|qty|quantity)\.?$",
+        "",
+        s,
+        flags=re.IGNORECASE,
+    ).strip()
     return normalize_quantity(s)
 
 

--- a/tests/test_add_to_requisition_normalize.py
+++ b/tests/test_add_to_requisition_normalize.py
@@ -1,0 +1,128 @@
+"""Regression tests for add-to-requisition MPN normalization.
+
+What this does: verifies the /v2/partials/search/add-to-requisition endpoint
+stores the canonical key-form ``normalized_mpn`` (matching ``normalize_mpn_key``)
+and resolves ``material_card_id`` when it auto-creates a Requirement — mirroring
+update_requirement so part-history / material-card joins line up.
+What calls it: pytest.
+Depends on: app.routers.htmx_views.add_to_requisition, conftest fixtures.
+"""
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.constants import RequisitionStatus, SourcingStatus
+from app.models import MaterialCard, Requirement, Requisition, User
+from app.utils.normalization import normalize_mpn_key
+
+
+def _make_requisition(db: Session, user: User) -> Requisition:
+    req = Requisition(
+        name="REQ-NORM",
+        customer_name="Norm Corp",
+        status=RequisitionStatus.OPEN,
+        created_by=user.id,
+        claimed_by_id=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(req)
+    db.flush()
+    return req
+
+
+def test_add_to_requisition_stores_key_form_normalized_mpn(client: TestClient, db_session: Session, test_user: User):
+    """A Requirement auto-created via add-to-requisition must store the key-form
+    normalized_mpn (lowercase, no separators), not the display form."""
+    req = _make_requisition(db_session, test_user)
+    db_session.commit()
+
+    raw_mpn = "LM2596S-5.0"
+    resp = client.post(
+        "/v2/partials/search/add-to-requisition",
+        json={
+            "requisition_id": req.id,
+            "mpn": raw_mpn,
+            "items": [
+                {
+                    "vendor_name": "Arrow",
+                    "mpn_matched": raw_mpn,
+                    "qty_available": 500,
+                    "confidence": 80,
+                    "score": 60,
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200
+
+    requirement = db_session.query(Requirement).filter_by(requisition_id=req.id, primary_mpn=raw_mpn.upper()).one()
+    # Canonical key form: "lm2596s50" — NOT the display/upper form "LM2596S-5.0".
+    assert requirement.normalized_mpn == normalize_mpn_key(raw_mpn)
+    assert requirement.normalized_mpn == "lm2596s50"
+
+
+def test_add_to_requisition_resolves_material_card(client: TestClient, db_session: Session, test_user: User):
+    """When a matching MaterialCard exists, the auto-created Requirement must get its
+    material_card_id populated (resolve_material_card)."""
+    req = _make_requisition(db_session, test_user)
+    raw_mpn = "LM2596S-5.0"
+    card = MaterialCard(
+        normalized_mpn=normalize_mpn_key(raw_mpn),
+        display_mpn="LM2596S-5.0",
+        search_count=0,
+    )
+    db_session.add(card)
+    db_session.commit()
+    card_id = card.id
+
+    resp = client.post(
+        "/v2/partials/search/add-to-requisition",
+        json={
+            "requisition_id": req.id,
+            "mpn": raw_mpn,
+            "items": [
+                {
+                    "vendor_name": "Mouser",
+                    "mpn_matched": raw_mpn,
+                    "qty_available": 100,
+                    "confidence": 70,
+                    "score": 50,
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200
+
+    requirement = db_session.query(Requirement).filter_by(requisition_id=req.id, primary_mpn=raw_mpn.upper()).one()
+    assert requirement.material_card_id == card_id
+
+
+def test_add_to_requisition_existing_requirement_left_untouched(
+    client: TestClient, db_session: Session, test_user: User
+):
+    """If the Requirement already exists, no new one is created and the existing
+    primary_mpn is reused (sanity around the find-or-create branch)."""
+    req = _make_requisition(db_session, test_user)
+    existing = Requirement(
+        requisition_id=req.id,
+        primary_mpn="NE555P",
+        normalized_mpn=normalize_mpn_key("NE555P"),
+        target_qty=10,
+        sourcing_status=SourcingStatus.OPEN,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(existing)
+    db_session.commit()
+
+    resp = client.post(
+        "/v2/partials/search/add-to-requisition",
+        json={
+            "requisition_id": req.id,
+            "mpn": "NE555P",
+            "items": [{"vendor_name": "Mouser", "qty_available": 100, "confidence": 70, "score": 50}],
+        },
+    )
+    assert resp.status_code == 200
+    assert db_session.query(Requirement).filter_by(requisition_id=req.id).count() == 1

--- a/tests/test_avail_score.py
+++ b/tests/test_avail_score.py
@@ -809,6 +809,47 @@ class TestAvailScoreCoverageGaps:
         # Offer should be in quoted + po_confirmed sets
         assert result["total_score"] >= 0
 
+    def test_o2_o4_count_offer_in_quote_and_completed_buyplan(self, db_session):
+        """O2 (offers_in_quotes) + O4 (bp_confirmed) must count a user's offer in a sent
+        quote and a completed buy plan.
+
+        Removing the arbitrary .limit(10000) on those global scans is the fix (the cap
+        silently dropped offers past it, undercounting scores that drive real payouts);
+        a >10000-row truncation can't be unit-tested cheaply, so this guards the
+        underlying O2/O4 computation instead.
+        """
+        from app.models.buy_plan import BuyPlanLine
+
+        buyer = _make_user(db_session, "O2O4 Buyer", "buyer", "o2o4")
+        reqn = _make_req(db_session, buyer.id, created_at=NOW)
+        offer = _make_offer(db_session, reqn.id, buyer.id, created_at=NOW)
+        db_session.flush()
+        quote = Quote(
+            requisition_id=reqn.id,
+            quote_number=f"Q-O2O4-{offer.id}",
+            status="sent",
+            line_items=[{"offer_id": offer.id, "qty": 50}],
+            created_by_id=buyer.id,
+            created_at=NOW,
+        )
+        db_session.add(quote)
+        db_session.flush()
+        bp = BuyPlan(
+            requisition_id=reqn.id,
+            quote_id=quote.id,
+            status="completed",
+            submitted_by_id=buyer.id,
+            created_at=NOW,
+        )
+        db_session.add(bp)
+        db_session.flush()
+        db_session.add(BuyPlanLine(buy_plan_id=bp.id, offer_id=offer.id, quantity=50))
+        db_session.commit()
+
+        result = compute_buyer_avail_score(db_session, buyer.id, MONTH)
+        assert "(1/" in result["o2_raw"]  # offer counted in quotes (O2)
+        assert "(1/" in result["o4_raw"]  # offer counted as PO-confirmed (O4)
+
     def test_req_without_created_at_skipped(self, db_session):
         """Line 385: req with no created_at is skipped in B4 pipeline hygiene."""
         buyer = _make_user(db_session, "NoDt Buyer", "buyer", "nodt")

--- a/tests/test_avail_score.py
+++ b/tests/test_avail_score.py
@@ -369,6 +369,42 @@ class TestSalesAvailScore:
         result = compute_sales_avail_score(db_session, sales.id, MONTH)
         assert result["b1_score"] == 8  # 80% coverage
 
+    def test_b6_interaction_quality_excluded_from_total(self, db_session):
+        """B6 (Interaction Quality) is a displayed diagnostic, NOT scored into the
+        total.
+
+        Regression: sales summed b1..b6 → a 0-110 scale vs buyers' 0-100, and b6 was
+        never persisted so the breakdown could not reconcile. The score must stay 0-100
+        (5 behaviors + 5 outcomes) with behavior_total == b1..b5, while b6 remains visible.
+        """
+        sales = _make_user(db_session, "Quality Sales", "sales", "quality-sales")
+        # High-quality, meaningful, quality-assessed activities make b6 fire (> 0).
+        for _ in range(3):
+            db_session.add(
+                ActivityLog(
+                    user_id=sales.id,
+                    activity_type="email_sent",
+                    channel="email",
+                    created_at=NOW,
+                    is_meaningful=True,
+                    quality_assessed_at=NOW,
+                    quality_score=90.0,
+                )
+            )
+        db_session.commit()
+
+        result = compute_sales_avail_score(db_session, sales.id, MONTH)
+
+        # b6 fired and is still surfaced as a diagnostic …
+        assert result["b6"] > 0
+        assert result["b6_label"] == "Interaction Quality"
+        # … but it is NOT part of behavior_total (only b1..b5 are) …
+        assert result["behavior_total"] == sum(result[f"b{i}_score"] for i in range(1, 6))
+        # … so both the behavior subtotal and the grand total stay on the 0-100 scale.
+        assert result["behavior_total"] <= 50
+        assert result["total_score"] == result["behavior_total"] + result["outcome_total"]
+        assert result["total_score"] <= 100
+
     def test_outreach_consistency(self, db_session):
         """Sales active on 15 days gets 8 on B2."""
         sales = _make_user(db_session, "Consistent Sales", "sales", "consistent")

--- a/tests/test_normalization_moq_leadtime_fix.py
+++ b/tests/test_normalization_moq_leadtime_fix.py
@@ -1,0 +1,53 @@
+"""Regression tests for normalize_moq trailing qualifiers and compact-day lead times.
+
+What it does: pins the two correctness fixes in app/utils/normalization.py —
+(1) normalize_moq must parse MOQ strings whose numeric token is followed by a
+trailing qualifier word ("10K minimum", "500 pcs"); (2) normalize_lead_time must
+read compact day shorthand ("30d", "5d") as days, not weeks.
+Called by: pytest.
+Depends on: app.utils.normalization.
+"""
+
+import pytest
+
+from app.utils.normalization import normalize_lead_time, normalize_moq
+
+
+class TestNormalizeMoqTrailingQualifier:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            # The documented example that previously returned None because
+            # "minimum" ends with "m" and tripped the 1e6 branch.
+            pytest.param("10K minimum", 10000, id="k_trailing_minimum"),
+            pytest.param("500 pcs", 500, id="trailing_pcs"),
+            pytest.param("1000 units", 1000, id="trailing_units"),
+            pytest.param("250 each", 250, id="trailing_each"),
+            pytest.param("2K min", 2000, id="k_trailing_min"),
+            # Existing behaviour must still hold.
+            pytest.param("10K", 10000, id="k_suffix_plain"),
+            pytest.param("MOQ: 500", 500, id="moq_prefix"),
+            pytest.param("Minimum 100", 100, id="min_prefix"),
+            pytest.param(500, 500, id="plain_int"),
+        ],
+    )
+    def test_normalize_moq(self, value, expected):
+        assert normalize_moq(value) == expected
+
+
+class TestNormalizeLeadTimeCompactDays:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param("30d", 30, id="compact_30d"),
+            pytest.param("5d", 5, id="compact_5d"),
+            pytest.param("14 d", 14, id="spaced_d"),
+            # Existing behaviour must still hold.
+            pytest.param("30 days", 30, id="days_word"),
+            pytest.param("6", 42, id="ambiguous_small_weeks"),
+            pytest.param("4-6 weeks", 35, id="weeks_range"),
+            pytest.param("90", 90, id="ambiguous_large_days"),
+        ],
+    )
+    def test_normalize_lead_time(self, value, expected):
+        assert normalize_lead_time(value) == expected

--- a/tests/test_save_parsed_offers_normalize_qual.py
+++ b/tests/test_save_parsed_offers_normalize_qual.py
@@ -1,0 +1,95 @@
+"""test_save_parsed_offers_normalize_qual.py — regression for the AI-parse save path.
+
+Covers the save_parsed_offers HTMX route (POST
+/v2/partials/requisitions/{req_id}/save-parsed-offers): offers saved from a reviewed
+AI parse must store the canonical key-form ``normalized_mpn`` and have a computed
+``qualification_status`` so they are visible in the part-centric Offers panel
+(part_offers_for) and carry qualification state — exactly like add_offer.
+
+Called by: pytest
+Depends on: conftest.py (client, db_session, test_user)
+"""
+
+import os
+
+os.environ["TESTING"] = "1"
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.constants import RequisitionStatus
+from app.models import Offer, Requirement, Requisition, User
+from app.services.part_offers import part_offers_for
+from app.utils.normalization import normalize_mpn_key
+
+
+def _make_requisition(db: Session, user: User, primary_mpn: str) -> Requisition:
+    req = Requisition(
+        name="REQ-PARSE-QUAL-001",
+        customer_name="Test Customer",
+        status=RequisitionStatus.OPEN,
+        created_by=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(req)
+    db.flush()
+    db.add(
+        Requirement(
+            requisition_id=req.id,
+            primary_mpn=primary_mpn,
+            target_qty=100,
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+    db.refresh(req)
+    return req
+
+
+def test_save_parsed_offer_sets_key_form_normalized_mpn_and_qualification(client, db_session, test_user):
+    """A saved AI-parsed offer gets a key-form normalized_mpn and a computed status."""
+    # Dashed/dotted MPN proves we store the KEY form (dashes+dots stripped), not display.
+    mpn = "LM2596S-5.0"
+    req = _make_requisition(db_session, test_user, primary_mpn=mpn)
+
+    resp = client.post(
+        f"/v2/partials/requisitions/{req.id}/save-parsed-offers",
+        data={
+            "vendor_name": "Arrow Electronics",
+            "offers[0].mpn": mpn,
+            "offers[0].qty_available": "500",
+            "offers[0].unit_price": "0.85",
+            "offers[0].condition": "refurb",
+        },
+    )
+    assert resp.status_code == 200
+
+    offer = db_session.query(Offer).filter(Offer.requisition_id == req.id).one()
+    # normalized_mpn must be the canonical dedup key (dash/dot stripped, lowercased).
+    assert offer.normalized_mpn == normalize_mpn_key(mpn) == "lm2596s50"
+    # apply_qualification must have run: status is computed (not NULL) for refurb.
+    assert offer.qualification_status is not None
+    assert offer.qualification_status != "unset"
+
+
+def test_save_parsed_offer_visible_in_part_offers_for(client, db_session, test_user):
+    """The saved offer matches via normalized_mpn so it shows in the part Offers
+    panel."""
+    mpn = "LM317T"
+    req = _make_requisition(db_session, test_user, primary_mpn=mpn)
+
+    resp = client.post(
+        f"/v2/partials/requisitions/{req.id}/save-parsed-offers",
+        data={
+            "vendor_name": "Arrow Electronics",
+            "offers[0].mpn": mpn,
+            "offers[0].qty_available": "250",
+            "offers[0].condition": "new",
+        },
+    )
+    assert resp.status_code == 200
+
+    requirement = db_session.query(Requirement).filter(Requirement.requisition_id == req.id).one()
+    found = part_offers_for(requirement, db_session)
+    assert any(o.mpn == mpn and o.normalized_mpn == normalize_mpn_key(mpn) for o in found)

--- a/tests/test_search_service_obsolete_normalize.py
+++ b/tests/test_search_service_obsolete_normalize.py
@@ -1,0 +1,60 @@
+"""Regression tests for the AI-search obsolescence trigger MPN lookup.
+
+Called by: pytest
+Depends on: app.search_service._any_pn_obsolete, MaterialCard, normalize_mpn_key
+
+The smart-AI trigger checks whether any of a requirement's PNs is an obsolete
+MaterialCard. ``pns`` arrive in DISPLAY form (uppercase, dashes preserved) from
+get_all_pns, while MaterialCard.normalized_mpn stores the canonical KEY form
+(normalize_mpn_key: lowercase, non-alphanumerics stripped). A raw display-form
+``filter_by(normalized_mpn=pn)`` never matches, so is_obsolete was permanently
+False and the trigger never fired. These tests lock in the key-form lookup.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models import MaterialCard
+from app.search_service import _any_pn_obsolete
+from app.utils.normalization import normalize_mpn_key
+
+
+def _mk_card(db: Session, display_mpn: str, lifecycle_status: str) -> MaterialCard:
+    card = MaterialCard(
+        normalized_mpn=normalize_mpn_key(display_mpn),
+        display_mpn=display_mpn,
+        lifecycle_status=lifecycle_status,
+    )
+    db.add(card)
+    db.flush()
+    return card
+
+
+class TestAnyPnObsolete:
+    def test_obsolete_card_found_from_display_form_pn(self, db_session: Session):
+        # Card stored in canonical key form ("xc7a35t-1ftg256c"); the PN that
+        # reaches the trigger is the display form ("XC7A35T-1FTG256C").
+        _mk_card(db_session, "XC7A35T-1FTG256C", "obsolete")
+        db_session.commit()
+
+        assert _any_pn_obsolete(db_session, ["XC7A35T-1FTG256C"]) is True
+
+    def test_active_card_is_not_obsolete(self, db_session: Session):
+        _mk_card(db_session, "STM32F407VGT6", "active")
+        db_session.commit()
+
+        assert _any_pn_obsolete(db_session, ["STM32F407VGT6"]) is False
+
+    def test_mixed_pns_returns_true_if_any_obsolete(self, db_session: Session):
+        _mk_card(db_session, "LM358-DR", "active")
+        _mk_card(db_session, "EP2C5T144C8N", "obsolete")
+        db_session.commit()
+
+        assert _any_pn_obsolete(db_session, ["LM358-DR", "EP2C5T144C8N"]) is True
+
+    def test_no_matching_card_returns_false(self, db_session: Session):
+        assert _any_pn_obsolete(db_session, ["NOSUCHPART-123"]) is False
+
+    def test_empty_or_unkeyable_pns_returns_false(self, db_session: Session):
+        # normalize_mpn_key strips these to empty, so there are no keys to match.
+        assert _any_pn_obsolete(db_session, []) is False
+        assert _any_pn_obsolete(db_session, ["--", "  "]) is False

--- a/tests/test_search_streaming.py
+++ b/tests/test_search_streaming.py
@@ -584,7 +584,9 @@ def test_add_to_requisition_creates_sightings(client, db_session):
 
     requirement = db_session.query(Requirement).filter_by(requisition_id=req.id, primary_mpn="LM317T").first()
     assert requirement is not None
-    assert requirement.normalized_mpn == "LM317T"
+    # Canonical key form (lowercase, separators stripped) — matches update_requirement
+    # so part-history / material-card joins line up. Was the broken .upper() display form.
+    assert requirement.normalized_mpn == "lm317t"
 
     sighting = db_session.query(Sighting).filter_by(requirement_id=requirement.id).first()
     assert sighting is not None

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -710,6 +710,7 @@ class TestRunStartupMigrationsNonTesting:
                 patch("app.startup._backfill_normalized_mpn") as m_bfill,
                 patch("app.startup._backfill_sighting_offer_normalized_mpn") as m_so,
                 patch("app.startup._backfill_sighting_vendor_normalized") as m_sv,
+                patch("app.startup._backfill_offer_vendor_normalized") as m_ov,
                 patch("app.startup._backfill_proactive_offer_qty") as m_pq,
                 patch("app.startup._backfill_ticket_defaults"),
                 patch("app.startup._exec") as m_exec,
@@ -728,6 +729,7 @@ class TestRunStartupMigrationsNonTesting:
                 m_bfill.assert_called_once()
                 m_so.assert_called_once()
                 m_sv.assert_called_once()
+                m_ov.assert_called_once()
                 m_pq.assert_called_once()
                 m_vinod.assert_called_once()
         finally:
@@ -1008,6 +1010,53 @@ class TestBackfillSightingVendorNormalized:
             assert r1[0] == "acme"
             r2 = conn.execute(sqltext("SELECT vendor_name_normalized FROM sightings WHERE id = 2")).fetchone()
             assert r2[0] == "beta corp"
+
+
+class TestBackfillOfferVendorNormalized:
+    """_backfill_offer_vendor_normalized logic (offers tab matches on the normalized
+    name)."""
+
+    _CREATE = "CREATE TABLE offers (id INTEGER PRIMARY KEY, vendor_name TEXT, vendor_name_normalized TEXT)"
+
+    def test_backfill_updates_null_rows(self):
+        """Offers with NULL vendor_name_normalized get populated from vendor_name."""
+        from app.startup import _backfill_offer_vendor_normalized
+
+        eng = _make_sqlite_engine()
+        with eng.connect() as conn:
+            conn.execute(sqltext(self._CREATE))
+            conn.execute(
+                sqltext("INSERT INTO offers (id, vendor_name, vendor_name_normalized) VALUES (1, 'XSS Vend', NULL)")
+            )
+            conn.execute(
+                sqltext("INSERT INTO offers (id, vendor_name, vendor_name_normalized) VALUES (2, 'Arrow', 'arrow')")
+            )
+            conn.commit()
+
+        with (
+            patch("app.startup.engine", eng),
+            patch("app.vendor_utils.normalize_vendor_name", side_effect=lambda n: n.lower().strip()),
+        ):
+            _backfill_offer_vendor_normalized()
+
+        with eng.connect() as conn:
+            r1 = conn.execute(sqltext("SELECT vendor_name_normalized FROM offers WHERE id = 1")).fetchone()
+            assert r1[0] == "xss vend"  # NULL row backfilled
+            r2 = conn.execute(sqltext("SELECT vendor_name_normalized FROM offers WHERE id = 2")).fetchone()
+            assert r2[0] == "arrow"  # already-set row untouched
+
+    def test_column_not_exists_returns_early(self):
+        """If vendor_name_normalized column doesn't exist, function returns without
+        error."""
+        from app.startup import _backfill_offer_vendor_normalized
+
+        eng = _make_sqlite_engine()
+        with eng.connect() as conn:
+            conn.execute(sqltext("CREATE TABLE offers (id INTEGER PRIMARY KEY, vendor_name TEXT)"))
+            conn.commit()
+
+        with patch("app.startup.engine", eng):
+            _backfill_offer_vendor_normalized()  # no raise
 
 
 class TestBackfillMaterialCards:

--- a/tests/test_substitute_keys_dict_form.py
+++ b/tests/test_substitute_keys_dict_form.py
@@ -1,0 +1,47 @@
+"""Regression tests for _substitute_keys handling dict-form substitutes.
+
+Requirement.substitutes is canonically stored as a list of dicts
+({"mpn": ..., "manufacturer": ...}); _substitute_keys must extract the
+normalized MPN key from both that dict form and the legacy string form.
+
+Tests: app/routers/requisitions/requirements.py::_substitute_keys
+"""
+
+from types import SimpleNamespace
+
+from app.routers.requisitions.requirements import _substitute_keys
+from app.utils.normalization import normalize_mpn_key
+
+
+def _req(substitutes):
+    """Minimal stand-in for a Requirement (only .substitutes is read)."""
+    return SimpleNamespace(substitutes=substitutes)
+
+
+def test_substitute_keys_string_form():
+    req = _req(["LM317T", "LM-338T"])
+    assert _substitute_keys(req) == [normalize_mpn_key("LM317T"), normalize_mpn_key("LM-338T")]
+
+
+def test_substitute_keys_dict_form():
+    req = _req(
+        [
+            {"mpn": "LM338T", "manufacturer": "TI"},
+            {"mpn": "SG3525", "manufacturer": "ON Semi"},
+        ]
+    )
+    assert _substitute_keys(req) == [normalize_mpn_key("LM338T"), normalize_mpn_key("SG3525")]
+
+
+def test_substitute_keys_mixed_form():
+    req = _req(["LM317T", {"mpn": "LM338T", "manufacturer": "TI"}])
+    assert _substitute_keys(req) == [normalize_mpn_key("LM317T"), normalize_mpn_key("LM338T")]
+
+
+def test_substitute_keys_skips_empty_dict_mpn():
+    req = _req([{"mpn": "", "manufacturer": "TI"}, {"mpn": "LM338T", "manufacturer": "TI"}])
+    assert _substitute_keys(req) == [normalize_mpn_key("LM338T")]
+
+
+def test_substitute_keys_none():
+    assert _substitute_keys(_req(None)) == []

--- a/tests/test_substitute_keys_dict_form.py
+++ b/tests/test_substitute_keys_dict_form.py
@@ -43,5 +43,19 @@ def test_substitute_keys_skips_empty_dict_mpn():
     assert _substitute_keys(req) == [normalize_mpn_key("LM338T")]
 
 
+def test_substitute_keys_skips_none_dict_mpn():
+    # {"mpn": None} previously crashed: dict.get("mpn", "") returns None (the key
+    # exists), then None.strip() raised AttributeError. Must skip, not crash.
+    req = _req([{"mpn": None, "manufacturer": "TI"}, {"mpn": "LM338T"}])
+    assert _substitute_keys(req) == [normalize_mpn_key("LM338T")]
+
+
+def test_substitute_keys_skips_malformed_entries():
+    # Non-str/non-dict entries (None, ints) in the list previously crashed on
+    # .get()/.strip(); they must be skipped while valid entries still resolve.
+    req = _req([None, 12345, {"mpn": "LM338T"}, "LM317T"])
+    assert _substitute_keys(req) == [normalize_mpn_key("LM338T"), normalize_mpn_key("LM317T")]
+
+
 def test_substitute_keys_none():
     assert _substitute_keys(_req(None)) == []

--- a/tests/test_vendor_offers_tab_normalized_match.py
+++ b/tests/test_vendor_offers_tab_normalized_match.py
@@ -1,0 +1,47 @@
+"""Regression: vendor detail "offers" tab must match offers by normalized vendor
+name, not by exact display-name string.
+
+What it covers: the offers branch of ``vendor_tab``
+(GET /v2/partials/vendors/{id}/tab/offers) historically filtered on
+``Offer.vendor_name == vendor.display_name`` (exact raw string), so an offer
+stored under a slightly different name string (different case / spacing /
+company suffix) was dropped — even though the SAME vendor view matches
+sightings via ``vendor_name_normalized == normalized_name``. The fix aligns the
+offers branch with the normalized-name match used everywhere else on the view.
+
+Called by: pytest. Depends on: conftest fixtures (client, db_session,
+test_vendor_card).
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Offer, VendorCard
+
+
+def test_offers_tab_matches_on_normalized_name_not_display_string(
+    client: TestClient, db_session: Session, test_vendor_card: VendorCard
+):
+    """An offer whose vendor_name differs from the card's display_name in
+    case/spacing/suffix, but whose vendor_name_normalized equals the card's
+    normalized_name, MUST appear in the vendor offers tab."""
+    # test_vendor_card: display_name="Arrow Electronics", normalized_name="arrow electronics"
+    assert test_vendor_card.display_name == "Arrow Electronics"
+    assert test_vendor_card.normalized_name == "arrow electronics"
+
+    # Raw vendor_name intentionally != display_name (uppercased + suffix + comma),
+    # but the normalized form matches the card's normalized_name.
+    offer = Offer(
+        vendor_card_id=test_vendor_card.id,
+        vendor_name="ARROW ELECTRONICS, INC.",
+        vendor_name_normalized="arrow electronics",
+        mpn="XZ-NORMMATCH-9001",
+    )
+    db_session.add(offer)
+    db_session.commit()
+
+    resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/offers")
+    assert resp.status_code == 200
+    # The offer's MPN should be rendered in the offers table.
+    assert "XZ-NORMMATCH-9001" in resp.text
+    assert "No offers from this vendor yet" not in resp.text

--- a/tests/test_xss_html_fragments.py
+++ b/tests/test_xss_html_fragments.py
@@ -56,6 +56,9 @@ def test_vendor_offers_tab_escapes_mpn_and_does_not_500(client, db_session, test
         Offer(
             requisition_id=test_requisition.id,
             vendor_name="XSS Vend",
+            # The offers tab matches on the normalized vendor name (as sightings/leads
+            # do); real write-paths always populate it, so the test must too.
+            vendor_name_normalized="xss vend",
             mpn=_XSS,
             qty_available=10,
             unit_price=1.0,


### PR DESCRIPTION
## Phase 2b — P1 correctness cluster

Sixth PR in the codebase-audit remediation (after #598 data-loss cron, #599 P0 security, #600 P1 authz/scoping). Root-cause fixes only, each TDD'd. No schema changes.

### MPN normalization — display-vs-key mismatches (×5)
A hardened key form (`normalize_mpn_key`) exists, but several read/write paths compared or stored the *display* MPN instead of the key, so matches silently missed and stored data drifted:
- **search_service** — obsolete `MaterialCard` now matched by normalized key, batched (no per-item drift).
- **htmx add-to-requisition** — stores key-form `normalized_mpn` and resolves the correct material card (was `.upper()`).
- **offers `save_parsed_offers`** — sets `normalized_mpn` + qualification on AI-parsed save, consistent with other offer write-paths.
- **vendors offers-tab** — matches on normalized vendor name (was raw `display_name`), aligning with how the same view already matches sightings/leads. Every offer write-path already sets `vendor_name_normalized`; an idempotent `_backfill_offer_vendor_normalized()` (mirroring the existing sightings backfill) closes the legacy-NULL gap so the normalized-match filter can never hide an existing offer.
- **requirements `_substitute_keys`** — extracts the MPN key from dict-form substitutes (was string-only).

### Substitutes hardening
`_substitute_keys` no longer crashes on `{"mpn": None}` (dict key present with `None` value → old `dict.get("mpn","")` returned `None` → `None.strip()` raised) or on malformed non-str/non-dict list entries. Mirrors `parse_substitute_mpns`. Regression tests for both crash cases.

### Normalization edge cases (`normalize_moq`, `normalize_lead_time`)
- `normalize_moq` strips trailing qualifier words ("10K minimum", "500 pcs", "250 each") before quantity parsing — a trailing "minimum" ended the string in "m" and was mistaken for the 1e6 multiplier suffix → `None`.
- `normalize_lead_time` recognizes compact day shorthand ("30d", "5d", "14 d") that has no trailing space.

### Avail-score correctness
- **O2/O4 truncation** — removed the arbitrary `.limit(10000)` global scans over quotes/buy-plan lines; they silently dropped offers past the cap and undercounted the O2/O4 outcome metrics that drive real payouts.
- **b6 Interaction Quality → 0–100 scale** — `compute_sales_avail_score` summed **6** behaviors (b1–b6) into `behavior_total`, so sales ran a 0–110 scale while buyers run the documented 0–100, yet `_rank_and_bonus` applies the same absolute QUALIFY gates (60/50/40) that drive real $500/$250/$100 bonuses — making sales easier to qualify. b6 was also never persisted (`_upsert_snapshot`/`get_avail_scores` only handle b1–b5), so the stored breakdown couldn't reconcile. Per the module's documented "5 behaviors + 5 outcomes = 0–100" contract and to keep the score focused on real tradable activity for both roles, b6 (a soft AI-assessed signal) is **excluded from `behavior_total`** and retained as a displayed diagnostic. Reconciles the breakdown and equalizes the payout gates.

### Tests
Added negative/edge coverage precisely where the audit found none: substitutes crash cases, `normalize_moq`/lead-time edge inputs, add-to-requisition normalization, offers normalized/qualification save, search obsolete-by-key, vendor offers-tab normalized match, avail-score b6-excluded-from-total reconciliation. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
