### PR TITLE
fix(p1): buy-plan PO approval-control bypass — verify_po_sent detection-only + cancel orphaned PO gate on completion

### DIFF
--- a/app/services/buyplan_workflow.py
+++ b/app/services/buyplan_workflow.py
@@ -194,7 +194,7 @@ def _run_reject_side_effects(plan: BuyPlan, user: User, db: Session, *, reason: 
     _log_approval_activity(plan, "reject", user, reason, db)
 
 
-def _cancel_open_engine_requests_for_plan(plan: BuyPlan, user: User, db: Session) -> int:
+def _cancel_open_engine_requests_for_plan(plan: BuyPlan, user: User | None, db: Session) -> int:
     """Cancel every open (REQUESTED) BUY_PLAN ApprovalRequest for *plan* via the engine.
 
     The single point that closes a plan's engine gate when the plan leaves PENDING — called
@@ -787,6 +787,15 @@ def _complete_plan(plan: BuyPlan, db: Session) -> None:
     Shared by check_completion (normal auto-complete) and the stock-sale auto-complete
     job so both completion paths produce a case report.
     """
+    # Close any open engine gate BEFORE completing so no REQUESTED row is orphaned in the
+    # approvals queue/badge. When the line flow runs to terminal before a deal-level
+    # PURCHASE_ORDER approver decides, that gate is still open; leaving it live orphaned a
+    # REQUESTED row (a later decision then hit the plan.status != ACTIVE guard → 400) AND
+    # silently bypassed the SP-3 large-PO sign-off. Mirrors cancel_buy_plan / halt_plan; the
+    # helper is a no-op when nothing is open. Cancels on behalf of each request's own
+    # requester/owner (submitted_by is only a last-resort fallback actor).
+    _cancel_open_engine_requests_for_plan(plan, plan.submitted_by, db)
+
     plan.status = BuyPlanStatus.COMPLETED.value
     plan.completed_at = datetime.now(timezone.utc)
     plan.case_report = generate_case_report(plan, db)
@@ -1315,10 +1324,15 @@ Generated: {now.strftime("%Y-%m-%d %H:%M UTC")}
 
 
 async def verify_po_sent(plan: "BuyPlan", db: "Session") -> list[dict]:
-    """Scan buyer's Outlook sent folder for PO emails matching each line.
+    """Scan buyer's Outlook sent folder for PO emails matching each line (detection
+    only).
 
     For each line with a po_number, searches Graph API for emails containing that PO
-    number. Returns list of verification results per line.
+    number and reports whether one was found. This is a NON-AUTHORITATIVE signal: it does
+    NOT verify the line or complete the plan — verification is gated behind verify_po's
+    ``can_approve_purchase_orders`` right (Phase D). Each result carries
+    ``awaiting_approver_verification`` so callers can flag PENDING_VERIFY lines whose PO
+    email was detected for an approver to sign off.
     """
     from ..utils.graph_client import GraphClient
     from ..utils.token_manager import get_valid_token
@@ -1371,9 +1385,13 @@ async def verify_po_sent(plan: "BuyPlan", db: "Session") -> list[dict]:
             )
 
             found = len(messages) > 0
-            if found and line.status == BuyPlanLineStatus.PENDING_VERIFY.value:
-                line.status = BuyPlanLineStatus.VERIFIED.value
-                line.po_verified_at = datetime.now(timezone.utc)
+            # DETECTION ONLY — finding the PO email in the buyer's sent folder is a signal,
+            # NOT verification. Flipping the line to VERIFIED here bypassed the Phase-D
+            # purchase-order-approver gate (can_approve_purchase_orders) that the interactive
+            # verify_po enforces, and left po_verified_by_id NULL — letting a buyer who merely
+            # emailed a PO complete the deal with no approver signing off. Line verification
+            # must go through verify_po; here we only flag lines awaiting that approval.
+            awaiting = found and line.status == BuyPlanLineStatus.PENDING_VERIFY.value
 
             results.append(
                 {
@@ -1381,15 +1399,15 @@ async def verify_po_sent(plan: "BuyPlan", db: "Session") -> list[dict]:
                     "po_number": line.po_number,
                     "found": found,
                     "message_count": len(messages),
+                    "awaiting_approver_verification": awaiting,
                 }
             )
         except Exception as e:
             logger.error("PO verification failed for line {}: {}", line.id, e)
             results.append({"line_id": line.id, "po_number": line.po_number, "found": False, "error": str(e)})
 
-    # Use centralized completion check (respects SO verification requirement)
-    check_completion(plan.id, db)
-
+    # No completion side-effect: this scan never verifies a line, so it cannot drive
+    # completion. Verified lines complete through verify_po's gated (approver) path.
     # NOTE: flush (not commit) — the caller (PO-verify job) owns the transaction.
     db.flush()
     return results

--- a/tests/test_buyplan_po_verify.py
+++ b/tests/test_buyplan_po_verify.py
@@ -63,8 +63,13 @@ def _make_line(
 
 
 @pytest.mark.asyncio
-async def test_po_found(db_session, test_user, test_quote, test_requisition):
-    """When Graph API finds PO emails, line status changes to verified."""
+async def test_po_found_flags_but_does_not_verify(db_session, test_user, test_quote, test_requisition):
+    """Finding a PO email FLAGS the line but must NOT verify it.
+
+    Regression: auto-verifying here bypassed the Phase-D can_approve_purchase_orders gate
+    (verify_po) and left po_verified_by_id NULL — a buyer emailing a PO could complete the
+    deal with no approver signing off. Detection is a signal, not verification.
+    """
     plan = _make_plan(db_session, test_user, test_quote, test_requisition)
     line = _make_line(db_session, plan, buyer=test_user, po_number="PO-12345")
     db_session.commit()
@@ -83,10 +88,12 @@ async def test_po_found(db_session, test_user, test_quote, test_requisition):
     assert results[0]["found"] is True
     assert results[0]["message_count"] == 1
     assert results[0]["po_number"] == "PO-12345"
-    # Line should now be verified
+    assert results[0]["awaiting_approver_verification"] is True
+    # Line is flagged, NOT verified — no gate bypass, no NULL-approver stamp.
     db_session.refresh(line)
-    assert line.status == BuyPlanLineStatus.VERIFIED.value
-    assert line.po_verified_at is not None
+    assert line.status == BuyPlanLineStatus.PENDING_VERIFY.value
+    assert line.po_verified_at is None
+    assert line.po_verified_by_id is None
 
 
 @pytest.mark.asyncio
@@ -109,6 +116,7 @@ async def test_po_not_found(db_session, test_user, test_quote, test_requisition)
     assert len(results) == 1
     assert results[0]["found"] is False
     assert results[0]["message_count"] == 0
+    assert results[0]["awaiting_approver_verification"] is False
     db_session.refresh(line)
     assert line.status == BuyPlanLineStatus.PENDING_VERIFY.value
 
@@ -137,8 +145,13 @@ async def test_graph_error(db_session, test_user, test_quote, test_requisition):
 
 
 @pytest.mark.asyncio
-async def test_all_verified_auto_completes(db_session, test_user, test_quote, test_requisition):
-    """When all PO lines are verified, plan auto-completes."""
+async def test_detection_does_not_complete_plan(db_session, test_user, test_quote, test_requisition):
+    """Detecting PO emails on every line must NOT auto-complete the plan.
+
+    Completion requires each line to be VERIFIED through the gated verify_po path; a
+    mail scan that merely finds the PO emails leaves the lines PENDING_VERIFY and the
+    plan ACTIVE.
+    """
     plan = _make_plan(db_session, test_user, test_quote, test_requisition)
     line1 = _make_line(db_session, plan, buyer=test_user, po_number="PO-001")
     line2 = _make_line(db_session, plan, buyer=test_user, po_number="PO-002")
@@ -156,9 +169,14 @@ async def test_all_verified_auto_completes(db_session, test_user, test_quote, te
 
     assert len(results) == 2
     assert all(r["found"] for r in results)
+    assert all(r["awaiting_approver_verification"] for r in results)
+    # Lines stay pending; plan stays active — no completion without approver verification.
     db_session.refresh(plan)
-    assert plan.status == BuyPlanStatus.COMPLETED.value
-    assert plan.completed_at is not None
+    assert plan.status == BuyPlanStatus.ACTIVE.value
+    assert plan.completed_at is None
+    for ln in (line1, line2):
+        db_session.refresh(ln)
+        assert ln.status == BuyPlanLineStatus.PENDING_VERIFY.value
 
 
 @pytest.mark.asyncio

--- a/tests/test_buyplan_workflow_bugs.py
+++ b/tests/test_buyplan_workflow_bugs.py
@@ -9,11 +9,14 @@ Depends on: conftest fixtures, app/services/buyplan_workflow.py
 """
 
 from datetime import datetime, timezone
+from decimal import Decimal
 
 import pytest
 from sqlalchemy.orm import Session
 
+from app.constants import ApprovalGateType, ApprovalRequestStatus, ApprovalSubjectType
 from app.models import Company, CustomerSite, Quote, Requirement, Requisition, User
+from app.models.approvals import ApprovalRequest
 from app.models.buy_plan import (
     BuyPlan,
     BuyPlanLine,
@@ -167,6 +170,42 @@ class TestCheckCompletionIdempotency:
 
         assert result.status == BuyPlanStatus.ACTIVE.value
         assert result.completed_at is None
+
+    def test_completion_cancels_open_po_gate(self, db_session):
+        """Auto-completing via the line flow cancels an orphaned open PURCHASE_ORDER
+        gate.
+
+        Regression: the line flow can run to terminal before a deal-level PO approver
+        decides. _complete_plan left that PURCHASE_ORDER ApprovalRequest REQUESTED — a
+        later decision hit the plan.status != ACTIVE guard (400) and the SP-3 large-PO
+        sign-off was silently bypassed. Completion must close the gate (like cancel/halt).
+        """
+        plan, user = _make_plan_with_lines(
+            db_session,
+            status=BuyPlanStatus.ACTIVE.value,
+            so_status=SOVerificationStatus.APPROVED.value,
+            line_statuses=[BuyPlanLineStatus.VERIFIED.value],
+            total_cost=25000.0,
+        )
+        # Deal-level PO gate still open when the line flow reaches terminal.
+        po_req = ApprovalRequest(
+            gate_type=ApprovalGateType.PURCHASE_ORDER,
+            status=ApprovalRequestStatus.REQUESTED,
+            subject_type=ApprovalSubjectType.BUY_PLAN,
+            subject_id=plan.id,
+            amount=Decimal("25000"),
+            requested_by_id=user.id,
+            owner_id=user.id,
+        )
+        db_session.add(po_req)
+        db_session.flush()
+
+        result = check_completion(plan.id, db_session)
+
+        assert result.status == BuyPlanStatus.COMPLETED.value
+        db_session.refresh(po_req)
+        # The orphan is closed, not left REQUESTED in the approvals queue.
+        assert po_req.status == ApprovalRequestStatus.CANCELLED
 
     def test_does_not_complete_without_so_approval(self, db_session):
         """Plan should NOT complete if SO is not yet approved."""


### PR DESCRIPTION
## Phase 2c-A — Buy-plan PO approval-control bypass

Seventh PR in the codebase-audit remediation (Phase 2c cluster, part A). Two SP-3 purchase-order sign-off holes where automated/line-flow paths skipped the manager gate their interactive twins enforce. Root-cause fixes, TDD'd. No schema changes.

### 1. `verify_po_sent` auto-verified PO lines, bypassing the Phase-D approver gate
The scheduled `_job_po_verification → verify_po_sent` scan flipped a `PENDING_VERIFY` line to `VERIFIED` whenever the PO# appeared in the buyer's Outlook sent folder — with **no `can_approve_purchase_orders` check** and `po_verified_by_id` left NULL — then `check_completion` could auto-complete the plan. So a buyer who merely emailed a PO could complete a deal with **no PO approver signing off**, while the interactive `verify_po` (Phase D) requires that manager right and stamps the approver.

**Fix:** `verify_po_sent` is now **detection-only**. It reports `found` + a new `awaiting_approver_verification` flag per line, changes no line status, and drives no completion. Line verification stays gated behind `verify_po`. (The job already ignored the return value, so no caller breaks; the flag is there for a future "PO detected — awaiting sign-off" nudge.)

### 2. `_complete_plan` orphaned the open deal-level PURCHASE_ORDER gate
An over-threshold plan opens a `PURCHASE_ORDER` ApprovalRequest **and** generates line buyer tasks. The line flow can run to terminal (all lines `VERIFIED`/`CANCELLED` + SO approved) **before** any PO approver decides. `_complete_plan` never closed that gate, so a `REQUESTED` row was orphaned in the approvals queue — a later decision hit the `plan.status != ACTIVE` guard (→ 400) and the SP-3 large-PO control was silently bypassed.

**Fix:** `_complete_plan` now cancels any open engine request for the plan (`_cancel_open_engine_requests_for_plan`), mirroring `cancel_buy_plan`/`halt_plan`; it's a no-op when nothing is open. Verified that **every** completion path (`check_completion`, the receiving/re-source re-completion, and the stock-sale job) routes through `_complete_plan`, so none can orphan the gate.

### Tests
`verify_po_sent` flags-but-does-not-verify + detection-does-not-complete; completion cancels the open PO gate (regression). Full buy-plan / PO / job surface (385 tests) green.

### Known follow-up (separate item, not band-aided here)
The audit also notes the *converse* race: if the PO gate is approved **first**, the plan moves ACTIVE→INBOUND and `AWAITING_PO` lines can't `confirm_po` (which requires ACTIVE) — a stall. That's a distinct state-machine question; tracked separately rather than half-fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
