### PR TITLE
fix(p1): transaction-safety cluster ×4 — knowledge-regen, company-merge fail-closed, teams watermark, email pending-parse

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -844,10 +844,6 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
                 )
             )
 
-            # ── Reply classification + AI parsing (batch or inline) ──
-            if get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY"):
-                pending_parse.append(vr)
-
             # ── Contact status progression ──
             # Every matched contact progresses: a cross-requisition reply must
             # advance the (requisition, vendor) row on EVERY involved requisition.
@@ -855,6 +851,15 @@ async def poll_inbox(token: str, db: Session, requisition_id: int = None, scanne
                 _progress_contact_status(mc, vr, db)
 
             nested.commit()
+
+            # ── Reply classification + AI parsing (batch or inline) ──
+            # Only enqueue for AI parsing AFTER the savepoint commits. If the
+            # savepoint above had failed, the except rolls back vr; enqueuing
+            # earlier would let a vanished vendor_response_id reach AI parsing
+            # (billed) and _auto_create_offers_from_parse, poisoning the final
+            # db.commit() and rolling back the entire scan.
+            if get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY"):
+                pending_parse.append(vr)
 
             results.append(
                 {

--- a/app/jobs/teams_call_jobs.py
+++ b/app/jobs/teams_call_jobs.py
@@ -55,6 +55,11 @@ async def _job_sync_teams_calls():
         )
 
         total_logged = 0
+        # A single global watermark covers every user's window. If ANY user's fetch fails,
+        # advancing it past the missed window would permanently lose that user's records
+        # (nothing was logged, so dedup can't recover them). Track failures and only advance
+        # when the whole window was fetched cleanly, so a transient error is retried next run.
+        any_fetch_failed = False
         for user in users:
             token = await get_valid_token(user, db)
             if not token:
@@ -74,6 +79,7 @@ async def _job_sync_teams_calls():
                 )
             except Exception as e:
                 logger.warning("Teams call records fetch failed for {}: {}", user.email, e)
+                any_fetch_failed = True
                 continue
 
             for record in records:
@@ -104,12 +110,17 @@ async def _job_sync_teams_calls():
                 if result:
                     total_logged += 1
 
-        # Update watermark in same transaction as activity records
-        now_str = datetime.now(timezone.utc).isoformat()
-        if wm_row:
-            wm_row.value = now_str
+        # Advance the watermark ONLY when every user's window was fetched cleanly.
+        # If any fetch failed we still commit the successfully-logged records, but leave
+        # the watermark untouched so the missed window is re-fetched on the next run.
+        if any_fetch_failed:
+            logger.warning("Teams call sync: a user fetch failed — leaving watermark unadvanced to retry next run")
         else:
-            db.add(SystemConfig(key=wm_key, value=now_str, description="Teams call records last poll"))
+            now_str = datetime.now(timezone.utc).isoformat()
+            if wm_row:
+                wm_row.value = now_str
+            else:
+                db.add(SystemConfig(key=wm_key, value=now_str, description="Teams call records last poll"))
         db.commit()
 
         if total_logged:

--- a/app/services/company_merge_service.py
+++ b/app/services/company_merge_service.py
@@ -164,7 +164,11 @@ def merge_companies(keep_id: int, remove_id: int, db: Session) -> dict:
             )
             reassigned += count
         except Exception as e:
-            logger.warning("Company merge: failed to reassign {}.{}: {}", model.__tablename__, col, e)
+            # Fail CLOSED: a reassignment error re-raises so the caller rolls back the whole
+            # merge rather than proceeding to db.delete(remove) and orphaning / cascade-deleting
+            # the un-reassigned rows (mirrors vendor_merge_service / delete_companies).
+            logger.error("Company merge: FK reassignment failed on {}.{}: {}", model.__tablename__, col, e)
+            raise ValueError(f"Company merge aborted — failed to reassign {model.__tablename__}.{col}: {e}") from e
 
     # 9. Delete removed company
     db.delete(remove)

--- a/app/services/knowledge_service.py
+++ b/app/services/knowledge_service.py
@@ -545,10 +545,10 @@ async def _regenerate_insights(
         logger.debug(no_context_log)
         return []
 
+    # Snapshot (but do NOT yet delete) the cached insights. We only replace them
+    # once fresh insights are in hand — a failed/empty AI call must leave the old
+    # rows intact rather than wiping the cache with nothing to show for it.
     old_insights = db.query(KnowledgeEntry).filter(*delete_filters).all()
-    for old in old_insights:
-        db.delete(old)
-    db.flush()
 
     try:
         result = await claude_structured(
@@ -566,9 +566,14 @@ async def _regenerate_insights(
         logger.warning(failed_log, e)
         return []
 
-    if not result or "insights" not in result:
+    if not result or not result.get("insights"):
         logger.warning(no_results_log)
         return []
+
+    # Fresh insights are available — safe to swap out the old cached rows now.
+    for old in old_insights:
+        db.delete(old)
+    db.flush()
 
     entries = []
     now = datetime.now(timezone.utc)

--- a/tests/test_company_merge_service.py
+++ b/tests/test_company_merge_service.py
@@ -136,6 +136,38 @@ def test_merge_missing_company_raises(db_session):
         merge_companies(co.id, 99999, db_session)
 
 
+def test_merge_reassign_failure_aborts_and_preserves_remove(db_session):
+    """A failed FK-reassignment must fail CLOSED: merge re-raises and does NOT delete
+    the removed company (mirrors vendor_merge_service / delete_companies).
+
+    Regression: previously the loop swallowed the exception and proceeded to
+    db.delete(remove)/flush anyway, orphaning or cascade-deleting the un-reassigned rows.
+    """
+    from app.models import ActivityLog
+
+    keep, remove = _make_pair(db_session, {"name": "F Corp"}, {"name": "F Corporation"})
+    remove_id = remove.id
+    db_session.commit()
+
+    real_query = db_session.query
+
+    def _boom_on_activity_log(model, *args, **kwargs):
+        if model is ActivityLog:
+            raise RuntimeError("simulated bulk UPDATE failure (unique-constraint conflict)")
+        return real_query(model, *args, **kwargs)
+
+    db_session.query = _boom_on_activity_log
+    try:
+        with pytest.raises(ValueError, match="Company merge aborted"):
+            merge_companies(keep.id, remove_id, db_session)
+    finally:
+        db_session.query = real_query
+
+    db_session.rollback()
+    # The removed company must still exist — merge aborted before deleting it.
+    assert db_session.get(Company, remove_id) is not None
+
+
 def test_merge_renames_colliding_sites(db_session):
     """Sites with duplicate names get prefixed with removed company name."""
     keep, remove = _make_pair(db_session, {"name": "E Corp"}, {"name": "E Corporation"})

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -2977,6 +2977,93 @@ class TestScopeThreadContactsToSender:
         assert out == []
 
 
+class TestPollInboxSavepointFailureNotParsed:
+    """Regression: a VendorResponse whose savepoint commit fails must NOT reach
+    AI parsing/billing.
+
+    Bug: ``vr`` was appended to ``pending_parse`` BEFORE ``nested.commit()``. If
+    the savepoint commit failed, the ``except`` rolled the row back but left the
+    rolled-back ``vr`` in ``pending_parse`` — it was then AI-parsed and billed, and
+    could spawn Offers referencing a vanished ``vendor_response_id`` that poisoned
+    the poll's final ``db.commit()`` (rolling back the entire scan). Fix appends to
+    ``pending_parse`` only after ``nested.commit()`` succeeds.
+    """
+
+    def _make_inbox_message(self, msg_id, sender_email):
+        return {
+            "id": msg_id,
+            "subject": "RE: RFQ",
+            "from": {"emailAddress": {"address": sender_email, "name": "Vendor"}},
+            "bodyPreview": "Quote attached",
+            "body": {"content": "<p>Quote attached</p>"},
+            "conversationId": f"conv-{msg_id}",
+            "receivedDateTime": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_rolled_back_response_excluded_from_parse_and_billing(self, db_session, test_user, test_requisition):
+        """First message commits; second message's savepoint commit fails.
+
+        Only the first is parsed/billed/persisted.
+        """
+        mock_gc = AsyncMock()
+        mock_gc.get_json.return_value = {
+            "value": [
+                self._make_inbox_message("msg-good", "good@parts.com"),
+                self._make_inbox_message("msg-bad", "bad@parts.com"),
+            ]
+        }
+
+        # Force ONLY the second message's savepoint commit to fail, exactly as a
+        # Postgres savepoint-release error would (the observable outcome — row not
+        # persisted, not parsed — holds identically on SQLite).
+        real_begin_nested = db_session.begin_nested
+        state = {"n": 0}
+
+        def flaky_begin_nested():
+            state["n"] += 1
+            nested = real_begin_nested()
+            if state["n"] == 2:
+
+                def boom():
+                    raise RuntimeError("savepoint commit failed")
+
+                nested.commit = boom
+            return nested
+
+        db_session.begin_nested = flaky_begin_nested
+
+        captured = {}
+
+        async def fake_submit(pending, db):
+            captured["parsed"] = list(pending)
+
+        billed = MagicMock()
+
+        with (
+            patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+            patch("app.email_service.get_credential_cached", return_value="fake-key"),
+            patch("app.email_service._submit_parse_batch", side_effect=fake_submit),
+            patch("app.email_service._record_email_mining_calls", billed),
+        ):
+            results = await poll_inbox(
+                token="fake-token",
+                db=db_session,
+                requisition_id=test_requisition.id,
+            )
+
+        # Only the good message produced a result and persisted a row.
+        assert [r["message_id"] for r in results] == ["msg-good"]
+        rows = db_session.query(VendorResponse).all()
+        assert [r.message_id for r in rows] == ["msg-good"]
+
+        # The rolled-back response must NOT have been enqueued for AI parsing…
+        assert "parsed" in captured
+        assert [vr.message_id for vr in captured["parsed"]] == ["msg-good"]
+        # …nor billed against the Claude-call budget.
+        billed.assert_called_once_with(1)
+
+
 class TestPollInboxCrossRequisitionFanout:
     """Reply matching against per-(requisition, vendor) Contact rows.
 

--- a/tests/test_knowledge_service_coverage.py
+++ b/tests/test_knowledge_service_coverage.py
@@ -523,6 +523,72 @@ class TestGenerateInsights:
         assert len(all_insights) == 1
         assert all_insights[0].content == "New insight"
 
+    async def test_generate_insights_failure_preserves_cached(
+        self, db_session: Session, test_user: User, requisition: Requisition
+    ):
+        # Regression: a failed AI regen must NOT wipe the previously-cached insights.
+        from app.utils.claude_errors import ClaudeError
+
+        knowledge_service.create_entry(
+            db_session,
+            user_id=test_user.id,
+            entry_type="ai_insight",
+            content="Cached insight worth keeping",
+            requisition_id=requisition.id,
+        )
+        entry = knowledge_service.create_entry(
+            db_session,
+            user_id=test_user.id,
+            entry_type="fact",
+            content="LM317T data",
+            requisition_id=requisition.id,
+        )
+        entry.created_at = datetime.now(timezone.utc)
+        db_session.commit()
+
+        async def _raise(*a, **kw):
+            raise ClaudeError("AI regen blew up")
+
+        with patch("app.utils.claude_client.claude_structured", new=_raise):
+            result = await knowledge_service.generate_insights(db_session, requisition.id)
+        assert result == []
+
+        surviving = knowledge_service.get_cached_insights(db_session, requisition.id)
+        assert len(surviving) == 1
+        assert surviving[0].content == "Cached insight worth keeping"
+
+    async def test_generate_insights_empty_result_preserves_cached(
+        self, db_session: Session, test_user: User, requisition: Requisition
+    ):
+        # Regression: an empty AI result must NOT wipe the previously-cached insights.
+        knowledge_service.create_entry(
+            db_session,
+            user_id=test_user.id,
+            entry_type="ai_insight",
+            content="Cached insight worth keeping",
+            requisition_id=requisition.id,
+        )
+        entry = knowledge_service.create_entry(
+            db_session,
+            user_id=test_user.id,
+            entry_type="fact",
+            content="LM317T data",
+            requisition_id=requisition.id,
+        )
+        entry.created_at = datetime.now(timezone.utc)
+        db_session.commit()
+
+        async def _mock_empty(*a, **kw):
+            return {"insights": []}
+
+        with patch("app.utils.claude_client.claude_structured", new=_mock_empty):
+            result = await knowledge_service.generate_insights(db_session, requisition.id)
+        assert result == []
+
+        surviving = knowledge_service.get_cached_insights(db_session, requisition.id)
+        assert len(surviving) == 1
+        assert surviving[0].content == "Cached insight worth keeping"
+
 
 class TestBuildMpnContext:
     def test_returns_empty_for_unknown_mpn(self, db_session: Session):

--- a/tests/test_nightly_coverage_boost.py
+++ b/tests/test_nightly_coverage_boost.py
@@ -385,14 +385,21 @@ class TestVendorHelpersCommitExceptions:
 
 
 class TestCompanyMergeEdgeCases:
-    def test_reassignment_exception_logged_continues(self, db_session):
-        """Lines 146-147: FK reassignment failing logs warning but merge continues."""
+    def test_reassignment_exception_aborts_merge_fail_closed(self, db_session):
+        """FK reassignment failing aborts the whole merge (fail closed), not swallow-
+        then-delete.
+
+        Regression: the loop used to log-and-continue, then db.delete(remove) anyway — a
+        partial merge that orphans/cascade-deletes the un-reassigned rows on a poisoned PG
+        transaction. It now re-raises (like vendor_merge_service) so the caller rolls back.
+        """
         from app.services.company_merge_service import merge_companies
 
         keep = Company(name="KeepCo", domain="keepco.com")
         remove = Company(name="RemoveCo", domain="removeco.com")
         db_session.add_all([keep, remove])
         db_session.commit()
+        remove_id = remove.id
 
         # Patch one of the update calls to raise
         original_query = db_session.query
@@ -420,10 +427,12 @@ class TestCompanyMergeEdgeCases:
                 return self._inner.first(*args, **kwargs)
 
         with patch.object(db_session, "query", side_effect=PatchedQuery):
-            # Should not raise — warnings are logged, merge continues
-            result = merge_companies(keep.id, remove.id, db_session)
+            with pytest.raises(Exception, match="(?i)abort"):
+                merge_companies(keep.id, remove.id, db_session)
 
-        assert result is not None
+        # Fail closed: the 'remove' company must NOT have been deleted.
+        db_session.rollback()
+        assert db_session.get(Company, remove_id) is not None
 
     def test_cache_invalidation_exception_logged(self, db_session):
         """Lines 158-159: cache invalidation failure is logged, merge still succeeds."""

--- a/tests/test_teams_call_jobs_coverage.py
+++ b/tests/test_teams_call_jobs_coverage.py
@@ -19,9 +19,11 @@ import os
 os.environ["TESTING"] = "1"
 
 import contextlib
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.orm import Session
 
 # ---------------------------------------------------------------------------
 # register_teams_call_jobs
@@ -383,3 +385,105 @@ async def test_job_sync_record_no_datetime_fields():
         await _job_sync_teams_calls()
 
     assert logged_durations == [0]
+
+
+# ---------------------------------------------------------------------------
+# Real-DB watermark regression: a per-user fetch failure must NOT advance the
+# single global watermark (else the failed user's window is lost forever), but a
+# fully-successful run MUST advance it. Uses the in-memory SQLite DB (mocks hid this).
+# ---------------------------------------------------------------------------
+
+_OLD_WM = "2025-01-01T00:00:00+00:00"
+
+
+def _seed_two_buyers_and_watermark(db: Session):
+    """Insert two m365-connected buyers and a stale watermark row; return the users."""
+    from app.models.auth import User
+    from app.models.config import SystemConfig
+
+    users = []
+    for i in (1, 2):
+        u = User(
+            email=f"buyer{i}@trioscs.com",
+            name=f"Buyer {i}",
+            role="buyer",
+            azure_id=f"az-wm-{i}",
+            m365_connected=True,
+            created_at=datetime.now(timezone.utc),
+        )
+        db.add(u)
+        users.append(u)
+    db.add(SystemConfig(key="teams_calls_last_poll", value=_OLD_WM, description="Teams call records last poll"))
+    db.commit()
+    for u in users:
+        db.refresh(u)
+    return users
+
+
+@contextlib.contextmanager
+def _patch_realdb_deps(db_session, *, fetch_by_email):
+    """Run the job against the real test session.
+
+    ``fetch_by_email`` maps a user's email to either a records list or an Exception
+    instance to raise. get_valid_token returns the user's email as the token so the
+    patched GraphClient can dispatch per user.
+    """
+
+    async def _get_token(user, _db):
+        return user.email
+
+    def _graph_ctor(token):
+        gc = AsyncMock()
+        outcome = fetch_by_email[token]
+
+        async def _get_all_pages(*_a, **_kw):
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        gc.get_all_pages.side_effect = _get_all_pages
+        return gc
+
+    with (
+        patch("app.database.SessionLocal", return_value=db_session),
+        patch("app.utils.token_manager.get_valid_token", _get_token),
+        patch("app.utils.graph_client.GraphClient", side_effect=_graph_ctor),
+        # Prevent the job's finally: db.close() from closing our fixture session so we
+        # can re-read the committed watermark afterwards.
+        patch.object(db_session, "close", lambda: None),
+    ):
+        yield
+
+
+def _read_watermark(db: Session) -> str:
+    from app.models.config import SystemConfig
+
+    db.expire_all()
+    row = db.query(SystemConfig).filter(SystemConfig.key == "teams_calls_last_poll").first()
+    return row.value
+
+
+async def test_watermark_not_advanced_when_a_user_fetch_fails(db_session: Session):
+    """One user's Graph fetch raises while another succeeds so watermark stays put."""
+    from app.jobs.teams_call_jobs import _job_sync_teams_calls
+
+    u1, u2 = _seed_two_buyers_and_watermark(db_session)
+    fetch = {u1.email: RuntimeError("Graph timeout"), u2.email: []}
+
+    with _patch_realdb_deps(db_session, fetch_by_email=fetch):
+        await _job_sync_teams_calls()
+
+    assert _read_watermark(db_session) == _OLD_WM, "failed user's window must be retried next run"
+
+
+async def test_watermark_advanced_when_all_fetches_succeed(db_session: Session):
+    """Fully-successful run advances the watermark past the prior value."""
+    from app.jobs.teams_call_jobs import _job_sync_teams_calls
+
+    u1, u2 = _seed_two_buyers_and_watermark(db_session)
+    fetch = {u1.email: [], u2.email: []}
+
+    with _patch_realdb_deps(db_session, fetch_by_email=fetch):
+        await _job_sync_teams_calls()
+
+    assert _read_watermark(db_session) != _OLD_WM, "clean run must advance the watermark"


### PR DESCRIPTION
## Phase 2c-B — Transaction-safety cluster (×4)

Eighth PR in the codebase-audit remediation. Four independent failure-path bugs where a swallowed error or mis-ordered write causes **permanent data loss** or a poisoned transaction. Root-cause fixes, each TDD'd with a real-DB regression test that fails against the bug and passes with the fix; each fix was adversarially reviewed. No schema changes.

### 1. Knowledge insights wiped on AI-regen failure — `knowledge_service._regenerate_insights`
The helper `delete`+`flush`'d the cached `ai_insight` rows **before** calling Claude, so every failure branch (`ClaudeUnavailableError`, `ClaudeError`, empty/None result) returned `[]` with the old insights already gone and no rollback. **Fix:** generate-first / replace-on-success — call the model, return early on any failure/empty branch leaving the old rows intact, and only delete-and-replace once fresh insights are in hand. An empty `{"insights": []}` result is now a no-op instead of clearing the cache. Serves all four scopes (req/mpn/vendor/company).

### 2. Company merge deletes on partial failure — `company_merge_service.merge_companies`
The FK-reassignment loop caught `Exception`, only logged, then proceeded to `db.delete(remove)` anyway — so a failed bulk UPDATE (e.g. a unique-constraint conflict when both companies own an `EnrichmentQueue`/`ProactiveDoNotOffer` row) orphaned or cascade-deleted the un-reassigned rows with the company. **Fix:** re-raise to **fail closed** (matching `vendor_merge_service`/`delete_companies`) so the caller rolls back the whole merge. All three callers already handle the raise (`settings`/`auto_dedup` → `db.rollback()`, `companies` route → 400).

### 3. Teams call sync loses a user's window on fetch failure — `teams_call_jobs._job_sync_teams_calls`
A per-user Graph fetch failure was swallowed with `continue`, but the single global watermark (`teams_calls_last_poll`) was advanced to *now* **unconditionally** — so the next poll started past the failed user's window and those never-logged records were permanently unrecoverable. **Fix:** track an `any_fetch_failed` flag and advance the watermark **only** on a fully clean run; successfully-logged records still commit, and the missed window is retried next run (dedup on `external_id` prevents duplicates). *(Disclosed bounded edge: a persistently-failing user pins the watermark and grows the re-scan window — strictly better than the pre-fix unconditional loss.)*

### 4. Rolled-back vendor response still AI-parsed & billed — `email_service.poll_inbox`
The `VendorResponse` was appended to `pending_parse` **before** its savepoint `nested.commit()` succeeded. A failed savepoint commit rolled the row back but left the dead `vr` queued — later AI-parsed (billed) and `_auto_create_offers_from_parse` could create Offers referencing the vanished `vendor_response_id`, poisoning the poll's final `db.commit()`. **Fix:** append to `pending_parse` only **after** `nested.commit()` returns, so a rolled-back response can never reach parsing.

### Tests
Each fix ships a real-in-memory-SQLite regression test asserting the observable data-safety outcome (cache preserved / merge aborts + `remove` kept / watermark not advanced / response not parsed-or-billed). One existing edge test that encoded the old company-merge swallow-behavior was updated to the fail-closed contract. Integrated branch: 552-test company-merge caller sweep + all four module suites green; `pre-commit --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
