### PR TITLE
fix(p1): browser-worker reliability ×3 — persistent event loop, circuit-breaker reset, AI-gate poison items

### DIFF
--- a/app/services/ics_worker/ai_gate.py
+++ b/app/services/ics_worker/ai_gate.py
@@ -190,10 +190,13 @@ async def process_ai_gate(db: Session):
 
             for item in batch_items:
                 classification = result_map.get(normalize_mpn_key(item.mpn))
-                if not classification:
-                    # Model genuinely omitted this MPN — fail open like the API-failure
-                    # branch so a poison item can't recycle as 'pending' and starve the gate.
-                    logger.warning("AI gate: no classification returned for {} — failing open to search", item.mpn)
+                if not classification or not all(k in classification for k in ("search_ics", "commodity", "reason")):
+                    # Model omitted this MPN, or returned a malformed classification (missing
+                    # keys). Fail open like the API-failure branch — never leave it pending, and
+                    # never let classification[...] KeyError abort the batch + skip commit.
+                    logger.warning(
+                        "AI gate: missing/malformed classification for {} — failing open to search", item.mpn
+                    )
                     item.commodity_class = "unknown"
                     item.gate_decision = "search"
                     item.gate_reason = "AI gate: no classification returned — defaulting to search"

--- a/app/services/ics_worker/ai_gate.py
+++ b/app/services/ics_worker/ai_gate.py
@@ -16,6 +16,7 @@ from loguru import logger
 from sqlalchemy.orm import Session
 
 from app.models import IcsSearchQueue
+from app.utils.normalization import normalize_mpn_key
 
 # Cooldown after API failure to avoid hammering a broken endpoint
 _GATE_COOLDOWN_SECONDS = 300  # 5 minutes
@@ -185,13 +186,19 @@ async def process_ai_gate(db: Session):
                 break  # Stop processing further batches during this cycle
 
             # Build a lookup by MPN
-            result_map = {r["mpn"]: r for r in results}
+            result_map = {normalize_mpn_key(r["mpn"]): r for r in results}
 
             for item in batch_items:
-                classification = result_map.get(item.mpn)
+                classification = result_map.get(normalize_mpn_key(item.mpn))
                 if not classification:
-                    # Model didn't return this MPN — leave pending
-                    logger.warning("AI gate: no classification returned for {}", item.mpn)
+                    # Model genuinely omitted this MPN — fail open like the API-failure
+                    # branch so a poison item can't recycle as 'pending' and starve the gate.
+                    logger.warning("AI gate: no classification returned for {} — failing open to search", item.mpn)
+                    item.commodity_class = "unknown"
+                    item.gate_decision = "search"
+                    item.gate_reason = "AI gate: no classification returned — defaulting to search"
+                    item.status = "queued"
+                    item.updated_at = datetime.now(timezone.utc)
                     continue
 
                 decision = "search" if classification["search_ics"] else "skip"

--- a/app/services/ics_worker/worker.py
+++ b/app/services/ics_worker/worker.py
@@ -125,6 +125,10 @@ async def main():
         await session.start()
     except Exception as e:
         logger.error("ICS worker: failed to start browser session: {}", e)
+        # start() may have launched Playwright/Chromium before failing, so tear it down or
+        # the browser subprocess leaks — matches the login-failure path below. stop() is
+        # None-safe on partial state.
+        await session.stop()
         with _db_session() as db:
             update_worker_status(db, is_running=False)
         return

--- a/app/services/ics_worker/worker.py
+++ b/app/services/ics_worker/worker.py
@@ -110,6 +110,7 @@ async def main():
     searches_today = 0
     sightings_today = 0
     last_stats_date = None
+    breaker_was_open = False
 
     logger.info("ICS worker starting...")
 
@@ -199,8 +200,22 @@ async def main():
                             circuit_breaker_open=True,
                             circuit_breaker_reason=info["trip_reason"],
                         )
+                    breaker_was_open = True
                     await asyncio.sleep(60 * 60)
                     continue
+
+                # Breaker healthy: clear a previously-open flag on the open->healthy
+                # transition (the breaker auto-resets after cooldown, so without this
+                # the status row would show circuit_breaker_open=True forever).
+                if breaker_was_open:
+                    logger.info("ICS worker: circuit breaker self-healed, resuming searches")
+                    with _db_session() as db:
+                        update_worker_status(
+                            db,
+                            circuit_breaker_open=False,
+                            circuit_breaker_reason=None,
+                        )
+                    breaker_was_open = False
 
                 # Check if time for a break
                 if scheduler.time_for_break():

--- a/app/services/nc_worker/ai_gate.py
+++ b/app/services/nc_worker/ai_gate.py
@@ -190,10 +190,13 @@ async def process_ai_gate(db: Session):
 
             for item in batch_items:
                 classification = result_map.get(normalize_mpn_key(item.mpn))
-                if not classification:
-                    # Model genuinely omitted this MPN — fail open like the API-failure
-                    # branch so a poison item can't recycle as 'pending' and starve the gate.
-                    logger.warning("AI gate: no classification returned for {} — failing open to search", item.mpn)
+                if not classification or not all(k in classification for k in ("search_nc", "commodity", "reason")):
+                    # Model omitted this MPN, or returned a malformed classification (missing
+                    # keys). Fail open like the API-failure branch — never leave it pending, and
+                    # never let classification[...] KeyError abort the batch + skip commit.
+                    logger.warning(
+                        "AI gate: missing/malformed classification for {} — failing open to search", item.mpn
+                    )
                     item.commodity_class = "unknown"
                     item.gate_decision = "search"
                     item.gate_reason = "AI gate: no classification returned — defaulting to search"

--- a/app/services/nc_worker/ai_gate.py
+++ b/app/services/nc_worker/ai_gate.py
@@ -16,6 +16,7 @@ from loguru import logger
 from sqlalchemy.orm import Session
 
 from app.models import NcSearchQueue
+from app.utils.normalization import normalize_mpn_key
 
 # Cooldown after API failure to avoid hammering a broken endpoint
 _GATE_COOLDOWN_SECONDS = 300  # 5 minutes
@@ -185,13 +186,19 @@ async def process_ai_gate(db: Session):
                 break  # Stop processing further batches during this cycle
 
             # Build a lookup by MPN
-            result_map = {r["mpn"]: r for r in results}
+            result_map = {normalize_mpn_key(r["mpn"]): r for r in results}
 
             for item in batch_items:
-                classification = result_map.get(item.mpn)
+                classification = result_map.get(normalize_mpn_key(item.mpn))
                 if not classification:
-                    # Model didn't return this MPN — leave pending
-                    logger.warning("AI gate: no classification returned for {}", item.mpn)
+                    # Model genuinely omitted this MPN — fail open like the API-failure
+                    # branch so a poison item can't recycle as 'pending' and starve the gate.
+                    logger.warning("AI gate: no classification returned for {} — failing open to search", item.mpn)
+                    item.commodity_class = "unknown"
+                    item.gate_decision = "search"
+                    item.gate_reason = "AI gate: no classification returned — defaulting to search"
+                    item.status = "queued"
+                    item.updated_at = datetime.now(timezone.utc)
                     continue
 
                 decision = "search" if classification["search_nc"] else "skip"

--- a/app/services/nc_worker/search_engine.py
+++ b/app/services/nc_worker/search_engine.py
@@ -14,6 +14,24 @@ from urllib.parse import quote
 
 from loguru import logger
 
+# Persistent event loop for the browser fallback path.
+#
+# session_manager caches the Patchright browser/page (start_browser() is a
+# no-op once has_browser is True), so those objects are bound to whatever
+# event loop first drove them. asyncio.run() creates a fresh loop and closes
+# it on every call, which would orphan the cached browser after the first
+# fallback ("Event loop is closed" on the second). Reuse ONE loop across all
+# browser calls in the process so the cached browser stays bound to a live loop.
+_browser_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _get_browser_loop() -> asyncio.AbstractEventLoop:
+    """Return the shared browser event loop, (re)creating it if needed."""
+    global _browser_loop
+    if _browser_loop is None or _browser_loop.is_closed():
+        _browser_loop = asyncio.new_event_loop()
+    return _browser_loop
+
 
 def build_search_url(mpn: str, search_logic: str = "Begins") -> str:
     """Build the full NC search URL with all required parameters.
@@ -48,7 +66,8 @@ def search_part(session_manager, part_number: str) -> dict:
 
     # HTTP didn't return results — try browser fallback
     logger.info("NC search: HTTP returned no results, trying browser fallback for '{}'", part_number)
-    browser_result = asyncio.run(_search_browser(session_manager, part_number))
+    loop = _get_browser_loop()
+    browser_result = loop.run_until_complete(_search_browser(session_manager, part_number))
     if browser_result:
         browser_result["mode"] = "browser"
         return browser_result

--- a/app/services/nc_worker/worker.py
+++ b/app/services/nc_worker/worker.py
@@ -115,6 +115,7 @@ def main():
     searches_today = 0
     sightings_today = 0
     last_stats_date = None
+    breaker_was_open = False
 
     logger.info("NC worker starting...")
 
@@ -203,8 +204,22 @@ def main():
                             circuit_breaker_open=True,
                             circuit_breaker_reason=info["trip_reason"],
                         )
+                    breaker_was_open = True
                     time.sleep(60 * 60)
                     continue
+
+                # Breaker healthy: clear a previously-open flag on the open->healthy
+                # transition (the breaker auto-resets after cooldown, so without this
+                # the status row would show circuit_breaker_open=True forever).
+                if breaker_was_open:
+                    logger.info("NC worker: circuit breaker self-healed, resuming searches")
+                    with _db_session() as db:
+                        update_worker_status(
+                            db,
+                            circuit_breaker_open=False,
+                            circuit_breaker_reason=None,
+                        )
+                    breaker_was_open = False
 
                 # Check if time for a break
                 if scheduler.time_for_break():

--- a/app/services/nc_worker/worker.py
+++ b/app/services/nc_worker/worker.py
@@ -351,7 +351,12 @@ def main():
         )
         session.stop()
         if session.has_browser:
-            asyncio.run(session.stop_browser())
+            # Stop the browser on the SAME persistent loop it was created on (search_part
+            # drives the browser via _get_browser_loop). A fresh asyncio.run() loop here
+            # would fail cross-loop against the persistent-loop-bound Patchright objects.
+            from .search_engine import _get_browser_loop
+
+            _get_browser_loop().run_until_complete(session.stop_browser())
         with _db_session() as db:
             update_worker_status(db, is_running=False)
 

--- a/app/services/search_worker_base/ai_gate.py
+++ b/app/services/search_worker_base/ai_gate.py
@@ -219,10 +219,15 @@ class AIGate:
 
                 for item in batch_items:
                     classification = result_map.get(normalize_mpn_key(item.mpn))
-                    if not classification:
-                        # Model genuinely omitted this MPN — fail open like the API-failure
-                        # branch so a poison item can't recycle as 'pending' and starve the gate.
-                        logger.warning("AI gate: no classification returned for {} — failing open to search", item.mpn)
+                    if not classification or not all(
+                        k in classification for k in (self.search_field, "commodity", "reason")
+                    ):
+                        # Model omitted this MPN, or returned a malformed classification (missing
+                        # keys). Fail open like the API-failure branch — never leave it pending,
+                        # and never let classification[...] KeyError abort the batch + skip commit.
+                        logger.warning(
+                            "AI gate: missing/malformed classification for {} — failing open to search", item.mpn
+                        )
                         item.commodity_class = "unknown"
                         item.gate_decision = "search"
                         item.gate_reason = "AI gate: no classification returned — defaulting to search"

--- a/app/services/search_worker_base/ai_gate.py
+++ b/app/services/search_worker_base/ai_gate.py
@@ -16,6 +16,8 @@ from datetime import datetime, timezone
 from loguru import logger
 from sqlalchemy.orm import Session
 
+from app.utils.normalization import normalize_mpn_key
+
 # Cooldown after API failure to avoid hammering a broken endpoint
 _GATE_COOLDOWN_SECONDS = 300  # 5 minutes
 
@@ -213,13 +215,19 @@ class AIGate:
                     break  # Stop processing further batches during this cycle
 
                 # Build a lookup by MPN
-                result_map = {r["mpn"]: r for r in results}
+                result_map = {normalize_mpn_key(r["mpn"]): r for r in results}
 
                 for item in batch_items:
-                    classification = result_map.get(item.mpn)
+                    classification = result_map.get(normalize_mpn_key(item.mpn))
                     if not classification:
-                        # Model didn't return this MPN — leave pending
-                        logger.warning("AI gate: no classification returned for {}", item.mpn)
+                        # Model genuinely omitted this MPN — fail open like the API-failure
+                        # branch so a poison item can't recycle as 'pending' and starve the gate.
+                        logger.warning("AI gate: no classification returned for {} — failing open to search", item.mpn)
+                        item.commodity_class = "unknown"
+                        item.gate_decision = "search"
+                        item.gate_reason = "AI gate: no classification returned — defaulting to search"
+                        item.status = "queued"
+                        item.updated_at = datetime.now(timezone.utc)
                         continue
 
                     decision = "search" if classification[self.search_field] else "skip"

--- a/app/services/tbf_worker/ai_gate.py
+++ b/app/services/tbf_worker/ai_gate.py
@@ -194,11 +194,13 @@ async def process_ai_gate(db: Session):
 
             for item in batch_items:
                 classification = result_map.get(normalize_mpn_key(item.mpn))
-                if not classification:
-                    # Model genuinely omitted this MPN — fail open exactly like
-                    # the API-failure branch so a poison item can never recycle
-                    # as 'pending' indefinitely and starve the gate.
-                    logger.warning("AI gate: no classification returned for {} — failing open to search", item.mpn)
+                if not classification or not all(k in classification for k in ("search_broker", "commodity", "reason")):
+                    # Model omitted this MPN, or returned a malformed classification (missing
+                    # keys). Fail open like the API-failure branch — never leave it pending, and
+                    # never let classification[...] KeyError abort the batch + skip commit.
+                    logger.warning(
+                        "AI gate: missing/malformed classification for {} — failing open to search", item.mpn
+                    )
                     item.commodity_class = "unknown"
                     item.gate_decision = "search"
                     item.gate_reason = "AI gate: no classification returned — defaulting to search"

--- a/app/services/tbf_worker/ai_gate.py
+++ b/app/services/tbf_worker/ai_gate.py
@@ -17,6 +17,7 @@ from loguru import logger
 from sqlalchemy.orm import Session
 
 from app.models import TbfSearchQueue
+from app.utils.normalization import normalize_mpn_key
 
 # Cooldown after API failure to avoid hammering a broken endpoint
 _GATE_COOLDOWN_SECONDS = 300  # 5 minutes
@@ -185,14 +186,24 @@ async def process_ai_gate(db: Session):
                     item.updated_at = datetime.now(timezone.utc)
                 break  # Stop processing further batches during this cycle
 
-            # Build a lookup by MPN
-            result_map = {r["mpn"]: r for r in results}
+            # Build a lookup keyed on a NORMALIZED mpn so case/whitespace echo
+            # differences from the model still match the DB item. Looking up by
+            # the exact returned string left items 'pending' forever, and the
+            # pending fetch re-selected the same poison rows every cycle.
+            result_map = {normalize_mpn_key(r["mpn"]): r for r in results}
 
             for item in batch_items:
-                classification = result_map.get(item.mpn)
+                classification = result_map.get(normalize_mpn_key(item.mpn))
                 if not classification:
-                    # Model didn't return this MPN — leave pending
-                    logger.warning("AI gate: no classification returned for {}", item.mpn)
+                    # Model genuinely omitted this MPN — fail open exactly like
+                    # the API-failure branch so a poison item can never recycle
+                    # as 'pending' indefinitely and starve the gate.
+                    logger.warning("AI gate: no classification returned for {} — failing open to search", item.mpn)
+                    item.commodity_class = "unknown"
+                    item.gate_decision = "search"
+                    item.gate_reason = "AI gate: no classification returned — defaulting to search"
+                    item.status = "queued"
+                    item.updated_at = datetime.now(timezone.utc)
                     continue
 
                 decision = "search" if classification["search_broker"] else "skip"

--- a/app/services/tbf_worker/worker.py
+++ b/app/services/tbf_worker/worker.py
@@ -125,6 +125,10 @@ async def main():
         await session.start()
     except Exception as e:
         logger.error("TBF worker: failed to start browser session: {}", e)
+        # start() may have launched Playwright/Chromium before failing (e.g. a nav or
+        # health-check raised), so tear it down or the browser subprocess leaks — matches
+        # the login-failure path below. stop() is None-safe on partial state.
+        await session.stop()
         with _db_session() as db:
             update_worker_status(db, is_running=False)
         return

--- a/app/services/tbf_worker/worker.py
+++ b/app/services/tbf_worker/worker.py
@@ -110,6 +110,7 @@ async def main():
     searches_today = 0
     sightings_today = 0
     last_stats_date = None
+    breaker_was_open = False
 
     logger.info("TBF worker starting...")
 
@@ -199,8 +200,22 @@ async def main():
                             circuit_breaker_open=True,
                             circuit_breaker_reason=info["trip_reason"],
                         )
+                    breaker_was_open = True
                     await asyncio.sleep(60 * 60)
                     continue
+
+                # Breaker healthy: clear a previously-open flag on the open->healthy
+                # transition (the breaker auto-resets after cooldown, so without this
+                # the status row would show circuit_breaker_open=True forever).
+                if breaker_was_open:
+                    logger.info("TBF worker: circuit breaker self-healed, resuming searches")
+                    with _db_session() as db:
+                        update_worker_status(
+                            db,
+                            circuit_breaker_open=False,
+                            circuit_breaker_reason=None,
+                        )
+                    breaker_was_open = False
 
                 # Check if time for a break
                 if scheduler.time_for_break():

--- a/tests/test_ai_gate.py
+++ b/tests/test_ai_gate.py
@@ -203,6 +203,46 @@ class TestProcessAIGate:
         assert item.gate_decision == "search"
 
     @pytest.mark.asyncio
+    async def test_case_shifted_mpn_still_classified(self):
+        """Model echoing the MPN in a different case still matches (normalized lookup).
+
+        Regression: keying result_map on the exact returned string left case/whitespace
+        echoes unmatched -> item stayed 'pending' and the pending fetch re-selected it
+        every cycle (poison starvation).
+        """
+        item = self._make_item("STM32F407")
+        model = MagicMock()
+        db_mock = self._db_with_items([item])
+
+        gate = AIGate(model, "ICsource", "search_ics")
+        # Model returns the mpn lower-cased (a common echo drift)
+        classifications = [{"mpn": "stm32f407", "search_ics": True, "commodity": "semiconductor", "reason": "mcu"}]
+        with patch.object(gate, "classify_parts_batch", new_callable=AsyncMock, return_value=classifications):
+            await gate.process_ai_gate(db_mock)
+
+        assert item.status == "queued"  # classified, NOT left pending
+        assert item.gate_decision == "search"
+
+    @pytest.mark.asyncio
+    async def test_omitted_mpn_fails_open_not_pending(self):
+        """An item the model omits is failed-open to search, never left 'pending'."""
+        returned = self._make_item("STM32F407")
+        omitted = self._make_item("LM358")
+        model = MagicMock()
+        db_mock = self._db_with_items([returned, omitted])
+
+        gate = AIGate(model, "ICsource", "search_ics")
+        classifications = [{"mpn": "STM32F407", "search_ics": True, "commodity": "semiconductor", "reason": "mcu"}]
+        with patch.object(gate, "classify_parts_batch", new_callable=AsyncMock, return_value=classifications):
+            await gate.process_ai_gate(db_mock)
+
+        assert returned.gate_decision == "search"
+        # The omitted item must be failed-open, not left to recycle as a poison row.
+        assert omitted.status == "queued"
+        assert omitted.gate_decision == "search"
+        assert "no classification" in omitted.gate_reason
+
+    @pytest.mark.asyncio
     async def test_gated_out_when_skip(self):
         item = self._make_item("RC0402")
 
@@ -219,16 +259,17 @@ class TestProcessAIGate:
         assert item.gate_decision == "skip"
 
     @pytest.mark.asyncio
-    async def test_missing_mpn_in_results_leaves_pending(self):
+    async def test_missing_mpn_in_results_fails_open(self):
         item = self._make_item("UNKNOWNPART")
 
         model = MagicMock()
         db_mock = self._db_with_items([item])
 
         gate = AIGate(model, "ICsource", "search_ics")
-        # Classification doesn't include this MPN
+        # Classification doesn't include this MPN (empty results)
         with patch.object(gate, "classify_parts_batch", new_callable=AsyncMock, return_value=[]):
             await gate.process_ai_gate(db_mock)
 
-        # Status should remain "pending"
-        assert item.status == "pending"
+        # Fail open, not left 'pending' — otherwise the item recycles as a poison row.
+        assert item.status == "queued"
+        assert item.gate_decision == "search"

--- a/tests/test_ai_gate.py
+++ b/tests/test_ai_gate.py
@@ -243,6 +243,32 @@ class TestProcessAIGate:
         assert "no classification" in omitted.gate_reason
 
     @pytest.mark.asyncio
+    async def test_malformed_classification_fails_open_not_keyerror(self):
+        """A classification missing required keys fails open — it must NOT KeyError.
+
+        Regression: classification[self.search_field]/["commodity"]/["reason"] on a malformed
+        model dict raised KeyError, aborting the whole batch loop and skipping the commit
+        (every classification in the batch lost). Malformed => fail open, like omission.
+        """
+        good = self._make_item("STM32F407")
+        malformed = self._make_item("LM358")
+        model = MagicMock()
+        db_mock = self._db_with_items([good, malformed])
+
+        gate = AIGate(model, "ICsource", "search_ics")
+        classifications = [
+            {"mpn": "STM32F407", "search_ics": True, "commodity": "semiconductor", "reason": "mcu"},
+            {"mpn": "LM358"},  # missing search_ics/commodity/reason
+        ]
+        with patch.object(gate, "classify_parts_batch", new_callable=AsyncMock, return_value=classifications):
+            await gate.process_ai_gate(db_mock)  # must not raise
+
+        assert good.gate_decision == "search"
+        assert malformed.status == "queued"  # failed open, batch not aborted
+        assert malformed.gate_decision == "search"
+        db_mock.commit.assert_called_once()  # commit reached (batch not aborted)
+
+    @pytest.mark.asyncio
     async def test_gated_out_when_skip(self):
         item = self._make_item("RC0402")
 

--- a/tests/test_ai_gate_coverage.py
+++ b/tests/test_ai_gate_coverage.py
@@ -238,7 +238,7 @@ class TestProcessAIGate:
         assert item.status == "gated_out"
         assert item.gate_decision == "skip"
 
-    async def test_missing_mpn_in_result_leaves_pending(self, db_session: Session):
+    async def test_missing_mpn_in_result_fails_open(self, db_session: Session):
         MockModel = MagicMock()
 
         item = _make_queue_item("MISSING_MPN")
@@ -252,8 +252,9 @@ class TestProcessAIGate:
         with patch.object(gate, "classify_parts_batch", new=AsyncMock(return_value=classification)):
             await gate.process_ai_gate(db_mock)
 
-        # Status should remain "pending" since no classification returned
-        assert item.status == "pending"
+        # Fail open, not left 'pending' — otherwise the item recycles forever as a poison row.
+        assert item.status == "queued"
+        assert item.gate_decision == "search"
 
     async def test_mixed_cache_and_uncached(self, db_session: Session):
         MockModel = MagicMock()

--- a/tests/test_ics_worker_full.py
+++ b/tests/test_ics_worker_full.py
@@ -2501,8 +2501,8 @@ class TestAiGateFull:
 
     @pytest.mark.asyncio
     async def test_process_ai_gate_missing_classification(self, db_session, test_requisition):
-        """process_ai_gate handles when model doesn't return a classification for an
-        MPN."""
+        """An MPN the model omits is failed-open to search, not left 'pending'
+        (poison)."""
         from app.services.ics_worker.ai_gate import clear_classification_cache, process_ai_gate
 
         clear_classification_cache()
@@ -2524,7 +2524,8 @@ class TestAiGateFull:
             await process_ai_gate(db_session)
 
         db_session.refresh(item)
-        assert item.status == "pending"
+        assert item.status == "queued"  # failed open, not left pending
+        assert item.gate_decision == "search"
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_ics_worker_full.py
+++ b/tests/test_ics_worker_full.py
@@ -1449,7 +1449,12 @@ class TestWorker:
 
     @pytest.mark.asyncio
     async def test_main_browser_start_failure(self, db_session):
-        """Worker exits gracefully when browser fails to start."""
+        """Worker exits gracefully when browser fails to start AND tears down the
+        session.
+
+        start() can launch Playwright/Chromium before raising; the except handler must
+        stop() the session so the browser subprocess isn't leaked.
+        """
         import app.services.ics_worker.worker as worker_mod
 
         ws = IcsWorkerStatus(id=1, is_running=False)
@@ -1467,6 +1472,9 @@ class TestWorker:
                 with patch(self._SESSION, return_value=mock_session):
                     with patch(self._RECOVER):
                         await worker_mod.main()
+
+            # Leak guard: partial browser state is torn down on start failure.
+            mock_session.stop.assert_awaited()
         finally:
             worker_mod._shutdown_requested = original_shutdown
 

--- a/tests/test_nc_worker_full.py
+++ b/tests/test_nc_worker_full.py
@@ -2477,11 +2477,61 @@ class TestNcSearchEngineFull:
             "status_code": 200,
         }
 
-        with patch("app.services.nc_worker.search_engine._search_browser"):
-            with patch("app.services.nc_worker.search_engine.asyncio.run", return_value=browser_result):
-                result = search_part(mock_session_mgr, "XYZ123")
+        async def fake_browser(_sm, _pn):
+            return browser_result
+
+        with patch("app.services.nc_worker.search_engine._search_browser", side_effect=fake_browser):
+            result = search_part(mock_session_mgr, "XYZ123")
 
         assert result["mode"] == "browser"
+
+    def test_search_part_browser_uses_persistent_loop(self):
+        """Repeated browser fallbacks reuse ONE live event loop.
+
+        Regression: search_part used asyncio.run() per call, creating and
+        closing a fresh loop each time. The session_manager caches the browser
+        page bound to the first loop, so the second fallback ran against a
+        closed loop ("Event loop is closed"). All browser coroutines must run
+        on a single persistent loop that stays open across calls.
+        """
+        import asyncio
+
+        import app.services.nc_worker.search_engine as se
+
+        # Reset the module-level loop so the assertion is deterministic.
+        se._browser_loop = None
+
+        mock_resp = MagicMock()
+        mock_resp.text = "<html>No results</html>"  # forces browser fallback
+        mock_resp.status_code = 200
+
+        mock_session_mgr = MagicMock()
+        mock_session_mgr.session.get = MagicMock(return_value=mock_resp)
+        mock_session_mgr.has_browser = True
+
+        seen_loop_ids = []
+
+        async def record_loop(_sm, _pn):
+            seen_loop_ids.append(id(asyncio.get_running_loop()))
+            return {
+                "html": "<div class='searchresultstable'>data</div>",
+                "url": "url",
+                "duration_ms": 1,
+                "status_code": 200,
+            }
+
+        with patch("app.services.nc_worker.search_engine._search_browser", side_effect=record_loop):
+            first = search_part(mock_session_mgr, "AAA111")
+            second = search_part(mock_session_mgr, "BBB222")
+
+        assert first["mode"] == "browser"
+        assert second["mode"] == "browser"
+        # Same loop drove BOTH calls (fails on old asyncio.run: two loop ids).
+        assert len(seen_loop_ids) == 2
+        assert seen_loop_ids[0] == seen_loop_ids[1]
+        # And that loop is still alive (old asyncio.run closes it each time).
+        assert se._browser_loop is not None
+        assert not se._browser_loop.is_closed()
 
     def test_has_results_empty(self):
         """_has_results returns False for empty string (line 153)."""

--- a/tests/test_nc_worker_full.py
+++ b/tests/test_nc_worker_full.py
@@ -1120,8 +1120,11 @@ class TestAiGate:
 
     @pytest.mark.asyncio
     async def test_process_ai_gate_missing_classification(self, db_session, test_requisition):
-        """process_ai_gate handles when model doesn't return a classification for an
-        MPN."""
+        """An MPN the model omits is failed-open to search, not left 'pending'.
+
+        Leaving it pending let the pending fetch re-select the same poison row every
+        cycle, starving the gate. Fail-open unblocks the batch slot.
+        """
         from app.services.nc_worker.ai_gate import clear_classification_cache, process_ai_gate
 
         clear_classification_cache()
@@ -1143,7 +1146,8 @@ class TestAiGate:
             await process_ai_gate(db_session)
 
         db_session.refresh(item)
-        assert item.status == "pending"  # Not classified, left pending
+        assert item.status == "queued"  # failed open, not left pending
+        assert item.gate_decision == "search"
 
     def test_clear_classification_cache(self):
         from app.services.nc_worker.ai_gate import _classification_cache, clear_classification_cache

--- a/tests/test_nc_worker_full.py
+++ b/tests/test_nc_worker_full.py
@@ -3473,7 +3473,8 @@ class TestNcWorkerGaps:
             worker_mod._shutdown_requested = original
 
     def test_main_has_browser_stop(self, db_session):
-        """Main() calls stop_browser when has_browser is True (line 316)."""
+        """Main() stops the browser on the persistent browser loop when has_browser is
+        True."""
         import app.services.nc_worker.worker as worker_mod
 
         ws = NcWorkerStatus(id=1, is_running=False)
@@ -3487,18 +3488,25 @@ class TestNcWorkerGaps:
         mock_session.is_logged_in = True
         mock_session.stop = MagicMock()
         mock_session.has_browser = True
-        mock_session.stop_browser = MagicMock()  # Not AsyncMock — avoids unawaited coroutine
+        mock_session.stop_browser = MagicMock()  # loop.run_until_complete is mocked, so no await
+
+        # The teardown now drives stop_browser on the SAME persistent loop search_part uses
+        # (not a fresh asyncio.run loop), so patch that loop and assert it ran the coroutine.
+        mock_loop = MagicMock()
 
         try:
             worker_mod._shutdown_requested = True
             with patch(self._DB, self._make_mock_db(db_session)):
                 with patch(self._SESSION, return_value=mock_session):
                     with patch(self._QUEUE_RECOVER):
-                        with patch(self._ASYNCIO_RUN) as mock_asyncio_run:
+                        with patch(
+                            "app.services.nc_worker.search_engine._get_browser_loop",
+                            return_value=mock_loop,
+                        ):
                             worker_mod.main()
 
-            # stop_browser called via asyncio.run
-            mock_asyncio_run.assert_called()
+            mock_session.stop_browser.assert_called()
+            mock_loop.run_until_complete.assert_called()
         finally:
             worker_mod._shutdown_requested = original
 

--- a/tests/test_nc_worker_full.py
+++ b/tests/test_nc_worker_full.py
@@ -1690,6 +1690,75 @@ class TestWorkerMainLoop:
         finally:
             worker_mod._shutdown_requested = original_shutdown
 
+    def test_main_circuit_breaker_clears_on_self_heal(self, db_session):
+        """Regression: breaker open->healthy transition resets circuit_breaker_open.
+
+        The breaker auto-resets after its cooldown, so should_stop() flips True (tripped
+        iteration) then False (self-healed iteration). The healthy iteration MUST write
+        circuit_breaker_open=False / circuit_breaker_reason=None back to the status row,
+        otherwise monitoring/UI shows the breaker permanently OPEN after it recovered.
+        """
+        import app.services.nc_worker.worker as worker_mod
+
+        # Seed the singleton row already OPEN so a passing test proves the CLEAR ran
+        # (not merely that the flag was never set).
+        ws = NcWorkerStatus(
+            id=1,
+            is_running=False,
+            circuit_breaker_open=True,
+            circuit_breaker_reason="captcha",
+        )
+        db_session.add(ws)
+        db_session.commit()
+
+        original_shutdown = worker_mod._shutdown_requested
+
+        sleep_calls = {"n": 0}
+
+        def mock_sleep(seconds):
+            # Iter 1 (breaker open) sleeps 1hr; let the loop continue to iter 2.
+            # Iter 2 (healthy) clears the flag then sleeps on the empty queue — stop there.
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] >= 2:
+                worker_mod._shutdown_requested = True
+
+        mock_session = MagicMock()
+        mock_session.start = MagicMock()
+        mock_session.is_logged_in = True
+        mock_session.stop = MagicMock()
+        mock_session.has_browser = False
+
+        mock_scheduler = MagicMock()
+        mock_scheduler.is_business_hours.return_value = True
+        mock_scheduler.time_for_break.return_value = False
+
+        mock_breaker = MagicMock()
+        # Tripped iteration, then self-healed iteration.
+        mock_breaker.should_stop.side_effect = [True, False]
+        mock_breaker.get_trip_info.return_value = {"trip_reason": "captcha"}
+
+        try:
+            worker_mod._shutdown_requested = False
+
+            with patch(self._DB, self._make_mock_db(db_session)):
+                with patch(self._SESSION, return_value=mock_session):
+                    with patch(self._SCHEDULER, return_value=mock_scheduler):
+                        with patch(self._BREAKER, return_value=mock_breaker):
+                            with patch(self._TIME_SLEEP, side_effect=mock_sleep):
+                                with patch(self._QUEUE_RECOVER):
+                                    with patch(self._RUN_AI_GATE):
+                                        with patch(self._QUEUE_NEXT, return_value=None):
+                                            worker_mod.main()
+        finally:
+            worker_mod._shutdown_requested = original_shutdown
+
+        # Both iterations ran: one tripped, one healed.
+        assert mock_breaker.should_stop.call_count == 2
+        # The self-healed iteration cleared the persisted breaker flag.
+        db_session.refresh(ws)
+        assert ws.circuit_breaker_open is False
+        assert ws.circuit_breaker_reason is None
+
     def test_main_break_time(self, db_session):
         """Main() takes a break when scheduler says it's time."""
         import app.services.nc_worker.worker as worker_mod

--- a/tests/test_nightly_tbf_worker_main.py
+++ b/tests/test_nightly_tbf_worker_main.py
@@ -117,6 +117,32 @@ class TestTbfWorkerMain:
         sm.stop.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_browser_start_failure_stops_session(self):
+        """Start() raising tears down the session (leak guard) before exiting.
+
+        start() can launch Playwright/Chromium before failing; without stop() the
+        browser subprocess would leak.
+        """
+        import app.services.tbf_worker.worker as wmod
+
+        sm = _make_sm(start_raises=Exception("No DISPLAY"))
+        ctx = _make_mock_ctx()
+
+        wmod._shutdown_requested = False
+        try:
+            with (
+                patch(_DB_SESSION, return_value=ctx),
+                patch(_UPDATE_STATUS),
+                patch(_QUEUE_RECOVER),
+                patch(_SESSION_MGR, return_value=sm),
+            ):
+                await wmod.main()
+        finally:
+            wmod._shutdown_requested = False
+
+        sm.stop.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_off_hours_sleeps(self):
         """Off-hours path: loop calls asyncio.sleep(30*60)."""
         import app.services.tbf_worker.worker as wmod

--- a/tests/test_tbf_ai_gate.py
+++ b/tests/test_tbf_ai_gate.py
@@ -224,7 +224,10 @@ class TestProcessAiGate:
         clear_classification_cache()
 
     @pytest.mark.asyncio
-    async def test_missing_mpn_in_response_leaves_pending(self):
+    async def test_missing_mpn_in_response_fails_open_to_queued(self):
+        # Regression: a genuinely omitted MPN must NOT be left 'pending' — the
+        # pending fetch would re-select the same poison row every cycle and
+        # starve the gate. Fail open to 'queued' instead.
         from app.services.tbf_worker.ai_gate import clear_classification_cache, process_ai_gate
 
         clear_classification_cache()
@@ -238,7 +241,46 @@ class TestProcessAiGate:
         ):
             await process_ai_gate(db)
 
-        assert item.status == "pending"  # left unchanged
+        assert item.status == "queued"
+        assert item.commodity_class == "unknown"
+        assert item.gate_decision == "search"
+        assert "no classification" in item.gate_reason.lower()
+        clear_classification_cache()
+
+    @pytest.mark.asyncio
+    async def test_case_whitespace_shifted_mpn_still_matches(self):
+        # Regression: the model echoes the MPN with different case/whitespace
+        # (or punctuation). Normalized lookup on BOTH sides must still match so
+        # the item is classified, not left 'pending'.
+        from app.services.tbf_worker.ai_gate import clear_classification_cache, process_ai_gate
+
+        clear_classification_cache()
+        shifted = _make_queue_item("LM317T", "lm317t", "TI")
+        shifted.status = "pending"
+        omitted = _make_queue_item("STM32F407", "stm32f407", "ST")
+        omitted.status = "pending"
+        db = _mock_db([shifted, omitted])
+
+        classifications = [
+            # Model echoes the mpn case/whitespace-shifted for the first item…
+            {"mpn": " lm317t ", "search_broker": True, "commodity": "semiconductor", "reason": "LDO"},
+            # …and OMITS the second item entirely.
+        ]
+        with patch(
+            "app.services.tbf_worker.ai_gate.classify_parts_batch",
+            new=AsyncMock(return_value=classifications),
+        ):
+            await process_ai_gate(db)
+
+        # Shifted item matched via normalization → classified, not pending.
+        assert shifted.status == "queued"
+        assert shifted.gate_decision == "search"
+        assert shifted.commodity_class == "semiconductor"
+        # Omitted item failed open → queued, not pending.
+        assert omitted.status == "queued"
+        assert omitted.gate_decision == "search"
+        assert omitted.commodity_class == "unknown"
+        db.commit.assert_called_once()
         clear_classification_cache()
 
 


### PR DESCRIPTION
## Phase 2c-C — Browser-worker reliability (×3)

Ninth PR in the codebase-audit remediation (final Phase 2c cluster). Three background-worker bugs that silently degrade the supplier-scraping workers over a process's lifetime. Root-cause fixes, each TDD'd (fails against the bug, passes with the fix) and adversarially reviewed. No schema changes.

### 1. Browser fallback worked only once per process — `nc_worker/search_engine.py`
`search_part` called `asyncio.run(_search_browser(...))` on every browser fallback. `asyncio.run` creates a fresh event loop and **closes it** after each call, but `NcSessionManager` caches the Patchright browser/page (`start_browser()` is a no-op once `has_browser` is True). So after the first fallback the cached page stayed bound to a now-closed loop and the second fallback in the same process died with *"Event loop is closed."* **Fix:** a module-level **persistent** event loop (`_get_browser_loop()`, recreated only if closed) drives all browser coroutines via `run_until_complete`, so the cached browser stays bound to a live loop. The shutdown teardown was also updated to stop the browser on that same persistent loop (was a fresh `asyncio.run` → cross-loop failure).

### 2. Circuit-breaker showed permanently OPEN after self-heal — `nc_worker`/`ics_worker`/`tbf_worker/worker.py`
Each worker wrote `circuit_breaker_open=True` when `breaker.should_stop()` tripped, but the breaker **auto-resets** after its cooldown and the worker resumes searching — yet nothing ever wrote the flag back to `False`, so monitoring/UI showed the breaker open forever. **Fix (all three workers, identically):** track the prior breaker state locally and, on the open→healthy transition, write `circuit_breaker_open=False` + `circuit_breaker_reason=None` exactly once (no per-iteration DB write). Mirrors the enrichment-worker healthy-path pattern.

### 3. AI-gate poison items starved the queue — all four workers (`nc_worker`, `ics_worker`, `tbf_worker`, `search_worker_base`)
The classification lookup keyed `result_map` on the exact model-returned `mpn` and looked it up by the exact DB `item.mpn`. A model echo with different case/whitespace — or an omitted item — left the item `status='pending'`, and the `pending … LIMIT 30` fetch re-selected those same poison items every cycle, permanently occupying the batch and starving the gate (and the whole search queue). **Fix:** (a) normalize **both** sides of the lookup (`normalize_mpn_key`) so echo differences still match; (b) any item still unclassified after normalization is **failed-open** to `status='queued'` / `decision='search'` with a clear reason (matching the existing API-failure fail-open) so a poison item can never recycle indefinitely. The identical bug lived in all four `ai_gate.py` copies (nc/ics/tbf/base) — **all four are fixed** for consistency (the near-duplicate files are a flagged simplify/de-dup target for Phase 3).

### Tests
Each fix ships a regression test exercising the real path: two consecutive browser fallbacks reuse the same live loop; a tripped→healthy cycle flips the persisted breaker flag to False; a case-shifted MPN is classified via normalization while an omitted item is failed-open (not left pending). Full browser-worker surface (1162 tests) + `pre-commit --all-files` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
