### PR TITLE
fix(p1): revive dead Alpine handlers + tojson-in-double-quoted-attr breakouts (5 template bugs)

### DIFF
--- a/app/templates/htmx/partials/manufacturers/search_results.html
+++ b/app/templates/htmx/partials/manufacturers/search_results.html
@@ -8,8 +8,12 @@
 {% from "htmx/partials/manufacturers/_picker_macros.html" import mfr_picker_apply -%}
 {% if results is defined and results %}
   {% for mfr in results %}
+  {# tojson emits a leading/trailing " that would close a double-quoted attr, and the
+     onclick body is full of single quotes so it can't be single-quoted — stash the name in
+     a single-quoted data- attr (tojson-safe) and read it via dataset in the handler. #}
   <div class="px-3 py-1.5 text-xs hover:bg-brand-50 cursor-pointer transition-colors"
-       onclick="(function(el, name){ {{ mfr_picker_apply('el', 'name') }} })(this, {{ mfr.canonical_name|tojson }})">
+       data-mfr-name='{{ mfr.canonical_name|tojson }}'
+       onclick="(function(el, name){ {{ mfr_picker_apply('el', 'name') }} })(this, JSON.parse(this.dataset.mfrName))">
     <span class="font-medium">{{ mfr.canonical_name }}</span>
     {% if mfr.aliases %}
     <span class="text-gray-400 ml-1">({{ mfr.aliases|join(', ') }})</span>

--- a/app/templates/htmx/partials/requisitions/tabs/offers.html
+++ b/app/templates/htmx/partials/requisitions/tabs/offers.html
@@ -74,7 +74,7 @@
       {% if draft_quote %}
       <button x-show="selectedOffers.length > 0" x-cloak
               @click="
-                var csrf = document.cookie.match(/csrftoken=([^;]+)/) ? RegExp.$1 : '';
+                let csrf = document.cookie.match(/csrftoken=([^;]+)/) ? RegExp.$1 : '';
                 fetch('/v2/partials/requisitions/{{ req.id }}/add-offers-to-quote', {
                   method: 'POST',
                   headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrf},

--- a/app/templates/htmx/partials/requisitions/tabs/req_row.html
+++ b/app/templates/htmx/partials/requisitions/tabs/req_row.html
@@ -158,7 +158,7 @@
       </div>
       {# Structured substitute rows — initialised from data-subs JSON attribute #}
       <div x-data="{ subs: JSON.parse($el.dataset.subs || '[]') }"
-           data-subs="{{ r.substitutes | tojson if r.substitutes else '[]' }}">
+           data-subs='{{ r.substitutes | tojson if r.substitutes else "[]" }}'>
         <div class="text-xs text-gray-600 mb-1">Substitutes</div>
         <template x-for="(sub, idx) in subs" :key="idx">
           <div class="flex gap-1.5 items-center mb-1">

--- a/app/templates/htmx/partials/sightings/table.html
+++ b/app/templates/htmx/partials/sightings/table.html
@@ -61,7 +61,7 @@
 
 {# ── Filter Bar ──────────────────────────────────────────────── #}
 <div class="px-3 py-2 border-b border-gray-100 flex items-center gap-2 flex-wrap"
-     x-data="{ sStatus: '{{ status }}', sGroupBy: '{{ group_by }}', sQ: '{{ q }}', sManufacturer: '{{ manufacturer|default("") }}' }">
+     x-data='{ sStatus: {{ status|tojson }}, sGroupBy: {{ group_by|tojson }}, sQ: {{ q|tojson }}, sManufacturer: {{ manufacturer|default("")|tojson }} }'>
   <input aria-label="Search sightings" type="text" name="q" value="{{ q }}"
          placeholder="Search MPN or customer..."
          x-model="sQ"
@@ -222,7 +222,7 @@
               <label class="flex items-center gap-1.5 cursor-pointer select-none">
                 <input type="checkbox" class="rounded border-gray-300"
                        @change="
-                         var ids = [{% for r in group_reqs %}{{ r.id }}{% if not loop.last %},{% endif %}{% endfor %}];
+                         let ids = [{% for r in group_reqs %}{{ r.id }}{% if not loop.last %},{% endif %}{% endfor %}];
                          ids.forEach(function(id){ var has = $store.sightingSelection.has(id); if ($event.target.checked && !has) $store.sightingSelection.toggle(id); else if (!$event.target.checked && has) $store.sightingSelection.toggle(id); });
                        ">
                 <span class="text-xs text-gray-600 font-normal">Select all {{ group_reqs|length }}</span>

--- a/tests/test_sightings_batch_ops.py
+++ b/tests/test_sightings_batch_ops.py
@@ -200,15 +200,6 @@ def test_batch_assign_too_many(client):
     assert resp.status_code == 400
 
 
-def test_batch_assign_invalid_json_returns_400(client):
-    """Batch-assign with malformed requirement_ids returns 400, not 500."""
-    resp = client.post(
-        "/v2/partials/sightings/batch-assign",
-        data={"requirement_ids": "not-json", "buyer_id": "1"},
-    )
-    assert resp.status_code == 400
-
-
 # ── batch-status ──────────────────────────────────────────────────
 
 
@@ -260,15 +251,6 @@ def test_batch_status_too_many(client):
     resp = client.post(
         "/v2/partials/sightings/batch-status",
         data={"requirement_ids": json.dumps(list(range(1001))), "status": "sourcing"},
-    )
-    assert resp.status_code == 400
-
-
-def test_batch_status_invalid_json_returns_400(client):
-    """Batch-status with malformed requirement_ids returns 400, not 500."""
-    resp = client.post(
-        "/v2/partials/sightings/batch-status",
-        data={"requirement_ids": "not-json", "status": "sourcing"},
     )
     assert resp.status_code == 400
 
@@ -325,15 +307,6 @@ def test_batch_notes_too_many(client):
     resp = client.post(
         "/v2/partials/sightings/batch-notes",
         data={"requirement_ids": json.dumps(list(range(1001))), "notes": "note"},
-    )
-    assert resp.status_code == 400
-
-
-def test_batch_notes_invalid_json_returns_400(client):
-    """Batch-notes with malformed requirement_ids returns 400, not 500."""
-    resp = client.post(
-        "/v2/partials/sightings/batch-notes",
-        data={"requirement_ids": "not-json", "notes": "note"},
     )
     assert resp.status_code == 400
 

--- a/tests/test_sightings_batch_ops.py
+++ b/tests/test_sightings_batch_ops.py
@@ -200,6 +200,15 @@ def test_batch_assign_too_many(client):
     assert resp.status_code == 400
 
 
+def test_batch_assign_invalid_json_returns_400(client):
+    """Batch-assign with malformed requirement_ids returns 400, not 500."""
+    resp = client.post(
+        "/v2/partials/sightings/batch-assign",
+        data={"requirement_ids": "not-json", "buyer_id": "1"},
+    )
+    assert resp.status_code == 400
+
+
 # ── batch-status ──────────────────────────────────────────────────
 
 
@@ -251,6 +260,15 @@ def test_batch_status_too_many(client):
     resp = client.post(
         "/v2/partials/sightings/batch-status",
         data={"requirement_ids": json.dumps(list(range(1001))), "status": "sourcing"},
+    )
+    assert resp.status_code == 400
+
+
+def test_batch_status_invalid_json_returns_400(client):
+    """Batch-status with malformed requirement_ids returns 400, not 500."""
+    resp = client.post(
+        "/v2/partials/sightings/batch-status",
+        data={"requirement_ids": "not-json", "status": "sourcing"},
     )
     assert resp.status_code == 400
 
@@ -307,6 +325,15 @@ def test_batch_notes_too_many(client):
     resp = client.post(
         "/v2/partials/sightings/batch-notes",
         data={"requirement_ids": json.dumps(list(range(1001))), "notes": "note"},
+    )
+    assert resp.status_code == 400
+
+
+def test_batch_notes_invalid_json_returns_400(client):
+    """Batch-notes with malformed requirement_ids returns 400, not 500."""
+    resp = client.post(
+        "/v2/partials/sightings/batch-notes",
+        data={"requirement_ids": "not-json", "notes": "note"},
     )
     assert resp.status_code == 400
 

--- a/tests/test_template_attr_quoting_fixes.py
+++ b/tests/test_template_attr_quoting_fixes.py
@@ -1,0 +1,66 @@
+"""Regression tests for the Alpine `var`-handler and tojson-in-double-quoted-attr bugs.
+
+These template bugs are silent no-ops at runtime (dead Alpine handlers / attributes that
+close early), so we lock the fixes structurally: render where a quote-containing value can
+break out, and source-assert the corrected leading keyword / attribute quoting.
+
+Tests: app/templates/htmx/partials/{requisitions/tabs/offers.html, requisitions/tabs/
+req_row.html, sightings/table.html, manufacturers/search_results.html}
+Depends on: app/template_env.py (configured Jinja env with custom filters)
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.template_env import templates
+
+_TPL = Path("app/templates")
+
+
+def _src(rel: str) -> str:
+    return (_TPL / rel).read_text()
+
+
+def test_offers_add_to_quote_handler_uses_let_not_var():
+    # A `var`-leading Alpine @click compiles to a SyntaxError and no-ops (offers never POST).
+    src = _src("htmx/partials/requisitions/tabs/offers.html")
+    assert "let csrf = document.cookie" in src
+    assert "var csrf = document.cookie" not in src
+
+
+def test_sightings_select_all_handler_uses_let_not_var():
+    src = _src("htmx/partials/sightings/table.html")
+    assert "let ids = [" in src
+    assert "var ids = [" not in src
+
+
+def test_sightings_filter_xdata_is_single_quoted_tojson():
+    # A user query with an apostrophe must not break the x-data attr — single-quoted + tojson.
+    src = _src("htmx/partials/sightings/table.html")
+    assert "x-data='{ sStatus: {{ status|tojson }}" in src
+
+
+def test_req_row_data_subs_is_single_quoted():
+    # tojson emits `"` — a double-quoted data-subs closes early and JSON.parse throws.
+    src = _src("htmx/partials/requisitions/tabs/req_row.html")
+    assert "data-subs='{{ r.substitutes | tojson" in src
+
+
+def test_manufacturer_picker_name_survives_quotes_in_onclick():
+    """A manufacturer name with ' and " renders a well-formed, non-truncated onclick.
+
+    Old bug: {{ name|tojson }} inside a double-quoted onclick closed the attribute early,
+    so clicking a typeahead result did nothing. The name now rides a single-quoted data-
+    attr read via dataset in the handler.
+    """
+    mfr = SimpleNamespace(canonical_name='O\'Reilly "Semi" Ltd', aliases=[])
+    html = templates.env.get_template("htmx/partials/manufacturers/search_results.html").render(results=[mfr])
+
+    # Value carried on a single-quoted data- attr (tojson escapes ' → legal there).
+    assert "data-mfr-name='" in html
+    # Handler reads it via dataset instead of interpolating tojson into the double-quoted attr.
+    assert "JSON.parse(this.dataset.mfrName)" in html
+    # The raw name's double-quote must appear only inside the single-quoted data- attr as an
+    # escaped JSON unicode, never as a bare " that would close the onclick early.
+    assert 'onclick="(function(el, name){' in html
+    assert "\\u0022" in html or "&#34;" in html  # the " in the name is escaped, not raw


### PR DESCRIPTION
P1-tail template cluster. Five silent-no-op template bugs (documented CLAUDE.md anti-patterns):

**Dead Alpine handlers (`var`-leading):** Alpine only IIFE-wraps `if/let/const`-leading handler bodies; a `var`-leading body compiles to a SyntaxError and no-ops. 'Add to Draft Quote' `@click` (offers.html) and the manufacturer-group 'Select all' `@change` (sightings/table.html) both began `var` — offers were never POSTed, group ids never reached the basket. Changed leading `var` → `let`.

**`|tojson` in double-quoted attributes:** `tojson` escapes `<>&'` but not the double-quote, so it closes a double-quoted attribute early. Single-quoted the sightings filter `x-data` and req_row `data-subs`. The manufacturer-picker `onclick` can't be single-quoted (macro body full of single quotes), so the name now rides a single-quoted `data-` attribute read via `dataset`.

Render + source regression tests (incl. a manufacturer name with both quote kinds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)