### PR TITLE
fix(p1): sourcing correctness ×4 — dedup MPN scope, buyer-confidence preservation, Anthropic timeout, batch-JSON 400

### DIFF
--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -925,7 +925,12 @@ async def sightings_batch_assign(
     """Batch-assign a buyer to multiple requirements."""
     form = await request.form()
     req_ids_raw = form.get("requirement_ids", "[]")
-    requirement_ids = json.loads(req_ids_raw) if isinstance(req_ids_raw, str) else []
+    try:
+        requirement_ids = json.loads(req_ids_raw) if isinstance(req_ids_raw, str) else []
+        if not isinstance(requirement_ids, list):
+            requirement_ids = []
+    except (json.JSONDecodeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid requirement_ids format")
     buyer_id_str = form.get("buyer_id", "")
     buyer_id = int(buyer_id_str) if buyer_id_str else None
 
@@ -966,7 +971,12 @@ async def sightings_batch_status(
 
     form = await request.form()
     req_ids_raw = form.get("requirement_ids", "[]")
-    requirement_ids = json.loads(req_ids_raw) if isinstance(req_ids_raw, str) else []
+    try:
+        requirement_ids = json.loads(req_ids_raw) if isinstance(req_ids_raw, str) else []
+        if not isinstance(requirement_ids, list):
+            requirement_ids = []
+    except (json.JSONDecodeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid requirement_ids format")
     new_status = form.get("status", "")
 
     if len(requirement_ids) > MAX_BATCH_SIZE:
@@ -1025,7 +1035,12 @@ async def sightings_batch_notes(
     """Add a note to multiple requirements."""
     form = await request.form()
     req_ids_raw = form.get("requirement_ids", "[]")
-    requirement_ids = json.loads(req_ids_raw) if isinstance(req_ids_raw, str) else []
+    try:
+        requirement_ids = json.loads(req_ids_raw) if isinstance(req_ids_raw, str) else []
+        if not isinstance(requirement_ids, list):
+            requirement_ids = []
+    except (json.JSONDecodeError, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid requirement_ids format")
     notes = form.get("notes", "").strip()
 
     if len(requirement_ids) > MAX_BATCH_SIZE:

--- a/app/services/search_worker_base/queue_manager.py
+++ b/app/services/search_worker_base/queue_manager.py
@@ -159,6 +159,13 @@ class QueueManager:
                     .filter(
                         Sighting.requirement_id == recent.requirement_id,
                         Sighting.source_type == self.source_type,
+                        # Scope to the deduped MPN only. A requirement can have
+                        # multiple queue rows (primary + resolved-AVL MPNs), so
+                        # its sightings span several normalized MPNs. Without
+                        # this filter we'd clone the source requirement's OTHER
+                        # MPNs' sightings onto THIS requirement, attributing
+                        # vendor offers for an MPN it never requested.
+                        Sighting.normalized_mpn == norm_mpn,
                     )
                     .all()
                 )

--- a/app/services/sighting_aggregation.py
+++ b/app/services/sighting_aggregation.py
@@ -66,6 +66,10 @@ def _estimate_qty_with_ai(qty_values: list[int | None]) -> dict:
             model=MODELS["fast"],
             max_tokens=20,
             messages=[{"role": "user", "content": prompt}],
+            # Bound the request so a hung API can't block this synchronous
+            # rebuild (runs in the post-search thread-pool worker) for the SDK
+            # ~600s default. Matches the shared claude_client's ~30s timeout.
+            timeout=30,
         )
         text = resp.content[0].text.strip()
         return {"qty": int(text), "approximate": False}

--- a/app/services/sourcing_leads.py
+++ b/app/services/sourcing_leads.py
@@ -421,7 +421,6 @@ def upsert_lead_from_sighting(db: Session, requirement: Requirement, sighting: S
     contactability = _contactability_score(sighting, vendor_card)
     historical = _historical_success_score(vendor_card)
     confidence_score = _compute_confidence(sighting, source_reliability, freshness, contactability, historical)
-    confidence_band = _confidence_band(confidence_score)
     safety_score, safety_flags, safety_summary = _compute_vendor_safety(vendor_card, contactability)
 
     lead = (
@@ -473,8 +472,15 @@ def upsert_lead_from_sighting(db: Session, requirement: Requirement, sighting: S
     lead.source_reliability_score = source_reliability
     lead.contactability_score = contactability
     lead.historical_success_score = historical
-    lead.confidence_score = confidence_score
-    lead.confidence_band = confidence_band
+    # Once a buyer has acted on a lead, their outcome feedback (applied by
+    # update_lead_status — e.g. no_stock -14, bad_lead -18) OWNS confidence_score.
+    # Overwriting it with the freshly source-computed value on every re-sight would
+    # restore a high band and surface a 'no_stock' lead as high-confidence. Preserve
+    # the stored score for buyer-touched leads; only (re)compute for untouched ones.
+    if (lead.buyer_status or "new") == "new" or lead.confidence_score is None:
+        lead.confidence_score = confidence_score
+    effective_confidence = float(lead.confidence_score or 0.0)
+    lead.confidence_band = _confidence_band(effective_confidence)
     lead.vendor_safety_score = safety_score
     lead.vendor_safety_band = _safety_band(safety_score, has_vendor_data=vendor_card is not None)
     lead.vendor_safety_summary = safety_summary
@@ -491,8 +497,8 @@ def upsert_lead_from_sighting(db: Session, requirement: Requirement, sighting: S
         evidence_tier=sighting.evidence_tier,
         source_type=sighting.source_type,
     )
-    lead.suggested_next_action = _suggested_next_action(confidence_score, safety_score, contactability)
-    lead.risk_flags = _build_lead_risk_flags(confidence_score, source_reliability, freshness, contactability)
+    lead.suggested_next_action = _suggested_next_action(effective_confidence, safety_score, contactability)
+    lead.risk_flags = _build_lead_risk_flags(effective_confidence, source_reliability, freshness, contactability)
     lead.updated_at = _now_utc()
     return lead
 

--- a/app/services/sourcing_leads.py
+++ b/app/services/sourcing_leads.py
@@ -719,7 +719,11 @@ def _refresh_lead_evidence_rollups(db: Session, lead: SourcingLead) -> None:
     categories = {_source_category(row.source_type) for row in evidence_rows}
     lead.evidence_count = evidence_count
     lead.corroborated = len(categories) >= 2
-    if lead.corroborated and lead.confidence_score is not None:
+    # The +5 corroboration bump must NOT touch a buyer-owned score. Once buyer_status
+    # leaves 'new', buyer feedback owns confidence_score (see upsert_lead_from_sighting);
+    # bumping it here on every re-sync would both restore a buyer-lowered 'no_stock' lead to
+    # a high band AND — now that upsert preserves the score — accumulate unbounded to 100.
+    if lead.corroborated and lead.confidence_score is not None and (lead.buyer_status or "new") == "new":
         lead.confidence_score = _clamp(float(lead.confidence_score) + 5.0)
         lead.confidence_band = _confidence_band(float(lead.confidence_score))
         # Promote raw evidence to inferred when corroborated by multiple source categories

--- a/app/services/vendor_affinity_service.py
+++ b/app/services/vendor_affinity_service.py
@@ -222,6 +222,10 @@ def _classify_mpn(mpn: str, manufacturer: str | None, api_key: str) -> str | Non
                     ),
                 }
             ],
+            # Bound the request so a hung API can't block the synchronous search
+            # fan-out for the SDK ~600s default. Matches the shared
+            # claude_client's ~30s timeout.
+            timeout=30,
         )
         category = message.content[0].text.strip()
         logger.info("L3: classified MPN={} as category={}", mpn, category)

--- a/tests/test_claude_sdk_timeout.py
+++ b/tests/test_claude_sdk_timeout.py
@@ -1,0 +1,72 @@
+"""Regression tests: synchronous Anthropic SDK calls must pass a bounded timeout.
+
+Covers the two sync ``anthropic.Anthropic().messages.create(...)`` call sites that
+run inside the post-search thread-pool worker:
+  - app/services/sighting_aggregation.py :: _estimate_qty_with_ai
+  - app/services/vendor_affinity_service.py :: _classify_mpn
+
+Without an explicit ``timeout=``, a hung API response would block the worker for the
+SDK's ~600s default. These tests assert every call passes a bounded (~30s) timeout so
+that can't happen.
+
+Depends on: unittest.mock (patches the ``anthropic`` module + settings).
+"""
+
+from unittest.mock import MagicMock, patch
+
+# Ceiling for what counts as "bounded" — the shared claude_client uses ~30s.
+BOUNDED_TIMEOUT_MAX = 60
+
+
+def _make_mock_anthropic(text: str):
+    """Return (anthropic_module_mock, client_mock) whose create() yields ``text``."""
+    mock_content = MagicMock()
+    mock_content.text = text
+    mock_resp = MagicMock()
+    mock_resp.content = [mock_content]
+    client = MagicMock()
+    client.messages.create.return_value = mock_resp
+    module = MagicMock()
+    module.Anthropic.return_value = client
+    return module, client
+
+
+def test_estimate_qty_passes_bounded_timeout():
+    from app.services.sighting_aggregation import _estimate_qty_with_ai
+
+    module, client = _make_mock_anthropic("350")
+    mock_settings = MagicMock()
+    mock_settings.ANTHROPIC_API_KEY = "sk-test-key"
+    mock_claude_client = MagicMock()
+    mock_claude_client.MODELS = {"fast": "claude-haiku-3"}
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "anthropic": module,
+            "app.config": MagicMock(settings=mock_settings),
+            "app.utils.claude_client": mock_claude_client,
+        },
+    ):
+        result = _estimate_qty_with_ai([100, 200, 300])
+
+    assert result == {"qty": 350, "approximate": False}
+    client.messages.create.assert_called_once()
+    kwargs = client.messages.create.call_args.kwargs
+    assert "timeout" in kwargs, "messages.create must pass an explicit timeout"
+    assert 0 < kwargs["timeout"] <= BOUNDED_TIMEOUT_MAX
+
+
+def test_classify_mpn_passes_bounded_timeout():
+    from app.services.vendor_affinity_service import _classify_mpn
+
+    module, client = _make_mock_anthropic("Resistor")
+
+    with patch.dict("sys.modules", {"anthropic": module}):
+        result = _classify_mpn("RC0402", None, "sk-fake")
+
+    assert result == "Resistor"
+    client.messages.create.assert_called_once()
+    kwargs = client.messages.create.call_args.kwargs
+    assert "timeout" in kwargs, "messages.create must pass an explicit timeout"
+    assert 0 < kwargs["timeout"] <= BOUNDED_TIMEOUT_MAX

--- a/tests/test_queue_manager_dedup_mpn_scope.py
+++ b/tests/test_queue_manager_dedup_mpn_scope.py
@@ -1,0 +1,104 @@
+"""Regression test: cross-requirement dedup must clone only the deduped MPN's sightings.
+
+A requirement can own multiple queue rows (primary + resolved-AVL MPNs), so its
+sightings span several normalized MPNs. When requirement B dedups against a recent
+completed search of requirement A for MPN X, only A's X-MPN sightings may be cloned
+onto B — never A's other MPNs' sightings (which B never requested).
+
+Called by: pytest auto-discovery.
+Depends on: app/services/search_worker_base/queue_manager.py (QueueManager dedup).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models import IcsSearchQueue, Requirement, Sighting
+from app.models.intelligence import MaterialCard
+from app.models.sourcing import Requisition
+from app.services.ics_worker.queue_manager import enqueue_for_ics_search
+
+_DEDUP_MPN = "SPREJ"
+_OTHER_MPN = "OTHERMPN"
+_SOURCE_TYPE = "icsource"
+
+
+@pytest.fixture
+def requisition(db_session, test_user):
+    rset = Requisition(
+        name="dedup-req",
+        customer_name="Acme",
+        status="open",
+        created_by=test_user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(rset)
+    db_session.flush()
+    return rset
+
+
+def _make_sighting(requirement_id: int, normalized_mpn: str, vendor: str) -> Sighting:
+    return Sighting(
+        requirement_id=requirement_id,
+        vendor_name=vendor,
+        mpn_matched=normalized_mpn,
+        normalized_mpn=normalized_mpn,
+        source_type=_SOURCE_TYPE,
+        qty_available=10,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_dedup_clones_only_matching_mpn_sightings(db_session, requisition):
+    """Source requirement A has sightings for TWO MPNs; deduping requirement B against
+    A's completed X-MPN search must clone only the X-MPN sightings."""
+    # Source requirement A — searched for two MPNs, holds sightings for both.
+    req_a = Requirement(
+        requisition_id=requisition.id,
+        primary_mpn=_DEDUP_MPN,
+        target_qty=100,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req_a)
+    db_session.flush()
+
+    # A completed ICS search of the deduped MPN, inside the dedup window.
+    completed = IcsSearchQueue(
+        requirement_id=req_a.id,
+        requisition_id=requisition.id,
+        mpn=_DEDUP_MPN,
+        normalized_mpn=_DEDUP_MPN,
+        status="completed",
+        last_searched_at=datetime.now(timezone.utc),
+    )
+    db_session.add(completed)
+
+    # A's sightings span BOTH MPNs.
+    db_session.add(_make_sighting(req_a.id, _DEDUP_MPN, "VendorMatch"))
+    db_session.add(_make_sighting(req_a.id, _OTHER_MPN, "VendorOther"))
+
+    # Target requirement B with a material card so dedup will clone.
+    card = MaterialCard(normalized_mpn=_DEDUP_MPN.lower(), display_mpn=_DEDUP_MPN)
+    db_session.add(card)
+    db_session.flush()
+    req_b = Requirement(
+        requisition_id=requisition.id,
+        primary_mpn=_DEDUP_MPN,
+        material_card_id=card.id,
+        target_qty=50,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req_b)
+    db_session.commit()
+
+    # Enqueue B for the same MPN → dedups against A's completed search.
+    result = enqueue_for_ics_search(req_b.id, db_session)
+    assert result is None  # deduped, no new queue row
+
+    cloned = db_session.query(Sighting).filter(Sighting.requirement_id == req_b.id).all()
+    # Only the deduped-MPN sighting is cloned; the OTHER-MPN one must NOT leak.
+    assert len(cloned) == 1
+    assert cloned[0].normalized_mpn == _DEDUP_MPN
+    assert {s.normalized_mpn for s in cloned} == {_DEDUP_MPN}

--- a/tests/test_sightings_batch_ops.py
+++ b/tests/test_sightings_batch_ops.py
@@ -200,6 +200,15 @@ def test_batch_assign_too_many(client):
     assert resp.status_code == 400
 
 
+def test_batch_assign_invalid_json_returns_400(client):
+    """Batch-assign with malformed requirement_ids returns 400, not 500."""
+    resp = client.post(
+        "/v2/partials/sightings/batch-assign",
+        data={"requirement_ids": "not-json", "buyer_id": "1"},
+    )
+    assert resp.status_code == 400
+
+
 # ── batch-status ──────────────────────────────────────────────────
 
 
@@ -251,6 +260,15 @@ def test_batch_status_too_many(client):
     resp = client.post(
         "/v2/partials/sightings/batch-status",
         data={"requirement_ids": json.dumps(list(range(1001))), "status": "sourcing"},
+    )
+    assert resp.status_code == 400
+
+
+def test_batch_status_invalid_json_returns_400(client):
+    """Batch-status with malformed requirement_ids returns 400, not 500."""
+    resp = client.post(
+        "/v2/partials/sightings/batch-status",
+        data={"requirement_ids": "not-json", "status": "sourcing"},
     )
     assert resp.status_code == 400
 
@@ -307,6 +325,15 @@ def test_batch_notes_too_many(client):
     resp = client.post(
         "/v2/partials/sightings/batch-notes",
         data={"requirement_ids": json.dumps(list(range(1001))), "notes": "note"},
+    )
+    assert resp.status_code == 400
+
+
+def test_batch_notes_invalid_json_returns_400(client):
+    """Batch-notes with malformed requirement_ids returns 400, not 500."""
+    resp = client.post(
+        "/v2/partials/sightings/batch-notes",
+        data={"requirement_ids": "not-json", "notes": "note"},
     )
     assert resp.status_code == 400
 

--- a/tests/test_sourcing_leads_service.py
+++ b/tests/test_sourcing_leads_service.py
@@ -453,6 +453,73 @@ class TestUpdateLeadStatus:
         assert resynced.confidence_score == lowered
         assert resynced.confidence_band == _confidence_band(lowered)
 
+    def test_corroboration_bump_skips_buyer_touched_lead(self, db_session: Session):
+        """The +5 corroboration bump (production _refresh_lead_evidence_rollups) must
+        not touch a buyer-owned score — else a 'no_stock' lead climbs back to a high
+        band and, since upsert now preserves the score, accumulates unbounded on every
+        re-sync."""
+        from app.models.sourcing_lead import LeadEvidence
+        from app.services.sourcing_leads import _refresh_lead_evidence_rollups
+
+        req = _make_requisition(db_session)
+        requirement = _make_requirement(db_session, req.id)
+        _make_vendor_card(db_session)
+        sighting = _make_sighting(db_session, req.id, requirement.id)
+        lead = upsert_lead_from_sighting(db_session, requirement, sighting)
+        db_session.flush()
+        db_session.commit()
+
+        lead = update_lead_status(db_session, lead.id, "no_stock")
+        lowered = lead.confidence_score
+
+        # Two evidence rows in DISTINCT source categories (api + marketplace) → corroborated.
+        for i, st in enumerate(("nexar", "brokerbin")):
+            db_session.add(
+                LeadEvidence(
+                    evidence_id=f"ev_test_{i}",
+                    lead_id=lead.id,
+                    signal_type="stock_listing",
+                    source_type=st,
+                    source_name=st,
+                )
+            )
+        db_session.flush()
+
+        _refresh_lead_evidence_rollups(db_session, lead)
+
+        assert lead.corroborated is True  # corroboration fired …
+        assert lead.confidence_score == lowered  # … but the buyer-owned score was NOT bumped
+
+    def test_corroboration_bump_still_applies_to_untouched_lead(self, db_session: Session):
+        """A 'new' (untouched) corroborated lead still gets the +5 — the guard is buyer-
+        only."""
+        from app.models.sourcing_lead import LeadEvidence
+        from app.services.sourcing_leads import _refresh_lead_evidence_rollups
+
+        req = _make_requisition(db_session)
+        requirement = _make_requirement(db_session, req.id)
+        _make_vendor_card(db_session)
+        sighting = _make_sighting(db_session, req.id, requirement.id)
+        lead = upsert_lead_from_sighting(db_session, requirement, sighting)
+        db_session.flush()
+        before = float(lead.confidence_score)
+
+        for i, st in enumerate(("nexar", "brokerbin")):
+            db_session.add(
+                LeadEvidence(
+                    evidence_id=f"ev_new_{i}",
+                    lead_id=lead.id,
+                    signal_type="stock_listing",
+                    source_type=st,
+                    source_name=st,
+                )
+            )
+        db_session.flush()
+
+        _refresh_lead_evidence_rollups(db_session, lead)
+        assert lead.corroborated is True
+        assert float(lead.confidence_score) == min(before + 5.0, 100.0)  # +5 applied for 'new'
+
     def test_resync_untouched_lead_still_recomputes_confidence(self, db_session: Session):
         """A lead the buyer has NOT acted on (buyer_status == 'new') must still pick up
         a freshly source-computed confidence on re-sync — preservation is buyer-only."""

--- a/tests/test_sourcing_leads_service.py
+++ b/tests/test_sourcing_leads_service.py
@@ -428,6 +428,53 @@ class TestUpdateLeadStatus:
         assert events[0].status == "contacted"
         assert events[0].note == "test note"
 
+    def test_resync_preserves_buyer_lowered_confidence(self, db_session: Session):
+        """Regression: a buyer 'no_stock' outcome lowers confidence_score; re-syncing the
+        same sighting must NOT restore the source-computed band and mask the outcome."""
+        req = _make_requisition(db_session)
+        requirement = _make_requirement(db_session, req.id)
+        _make_vendor_card(db_session)
+        sighting = _make_sighting(db_session, req.id, requirement.id)
+
+        lead = upsert_lead_from_sighting(db_session, requirement, sighting)
+        db_session.flush()
+        db_session.commit()
+        source_computed = lead.confidence_score
+
+        # Buyer marks the lead 'no_stock' — update_lead_status applies a -14 delta.
+        lead = update_lead_status(db_session, lead.id, "no_stock")
+        lowered = lead.confidence_score
+        assert lowered < source_computed  # buyer feedback dropped confidence
+
+        # Re-sight the same vendor/part — confidence must stay lowered, not be restored.
+        resynced = upsert_lead_from_sighting(db_session, requirement, sighting)
+        db_session.flush()
+        assert resynced.buyer_status == "no_stock"
+        assert resynced.confidence_score == lowered
+        assert resynced.confidence_band == _confidence_band(lowered)
+
+    def test_resync_untouched_lead_still_recomputes_confidence(self, db_session: Session):
+        """A lead the buyer has NOT acted on (buyer_status == 'new') must still pick up
+        a freshly source-computed confidence on re-sync — preservation is buyer-only."""
+        req = _make_requisition(db_session)
+        requirement = _make_requirement(db_session, req.id)
+        _make_vendor_card(db_session)
+        # Stale sighting → lower freshness contribution.
+        stale = _make_sighting(db_session, req.id, requirement.id)
+        stale.created_at = datetime.now(timezone.utc) - timedelta(days=20)
+        db_session.flush()
+        lead = upsert_lead_from_sighting(db_session, requirement, stale)
+        db_session.flush()
+        stale_score = lead.confidence_score
+
+        # Fresh re-sight of the same vendor/part while still 'new' → recompute upward.
+        fresh = _make_sighting(db_session, req.id, requirement.id)
+        resynced = upsert_lead_from_sighting(db_session, requirement, fresh)
+        db_session.flush()
+        assert resynced.id == lead.id
+        assert resynced.buyer_status == "new"
+        assert resynced.confidence_score >= stale_score
+
 
 class TestAppendLeadFeedback:
     def test_append_feedback(self, db_session: Session):

--- a/tests/test_vendor_unavailability.py
+++ b/tests/test_vendor_unavailability.py
@@ -1939,10 +1939,11 @@ class TestQueueDedupReapplication:
     def test_dedup_cloned_sightings_stamped(self, db_session: Session):
         from app.models import IcsSearchQueue
         from app.models.intelligence import MaterialCard
+        from app.services.search_worker_base.mpn_normalizer import strip_packaging_suffixes
         from app.services.search_worker_base.queue_manager import QueueManager
 
         req_old = _make_requirement(db_session, primary_mpn="LM317T")
-        _make_sighting(
+        src = _make_sighting(
             db_session,
             req_old,
             "Arrow Electronics",
@@ -1950,6 +1951,10 @@ class TestQueueDedupReapplication:
             qty_available=100,
             source_type="icsource",
         )
+        # Production sightings carry normalized_mpn (strip_packaging_suffixes); the dedup
+        # clone now scopes on it, so the source sighting must have it set like production.
+        src.normalized_mpn = strip_packaging_suffixes("LM317T")
+        db_session.flush()
 
         card = MaterialCard(normalized_mpn="lm317t", display_mpn="LM317T")
         db_session.add(card)


### PR DESCRIPTION
P1-tail sourcing cluster. Four correctness bugs in the sourcing engine. Root-cause fixes, each TDD'd; the buyer-confidence and dedup fixes were adversarially reviewed (the confidence fix was reworked after review caught the original missed the production path).

**1. Cross-req dedup cloned the wrong MPN's sightings** — `queue_manager.enqueue_search` dedup cloned a source requirement's sightings filtered only by `(requirement_id, source_type)`. Since a requirement can hold multiple MPNs (primary + AVL override), requirement B deduping against A inherited A's *other*-MPN sightings — attributing vendor offers for parts B never requested onto B's material card. Now scoped with `Sighting.normalized_mpn == norm_mpn`.

**2. Buyer-lowered lead confidence restored on re-sync** — a buyer 'no_stock' outcome lowers `confidence_score`, but `upsert_lead_from_sighting` overwrote it with the source-computed value on every re-sight *and* `_refresh_lead_evidence_rollups` applied an unconditional +5 corroboration bump — so a 'no_stock' lead climbed back to a high band (and accumulated unbounded to 100). Buyer feedback now **owns** `confidence_score` once `buyer_status != 'new'`: no recompute, no +5. (Tested through the real `_refresh_lead_evidence_rollups` path.)

**3. Sync Anthropic calls could block ~600s** — `sighting_aggregation._estimate_qty_with_ai` and `vendor_affinity_service._classify_mpn` called the SDK with no timeout (SDK default ~600s), blocking the synchronous post-search thread-pool worker. Bounded both.

**4. Malformed `requirement_ids` → 500** — the sightings batch assign/status/notes handlers `json.loads`'d the field with no guard. Wrapped in try/except → 400 (mirroring the already-guarded `batch_refresh`).

Full sourcing ripple sweep green; `pre-commit --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)