### PR TITLE
fix(p1): CRM/offers ×3 — vendor-response status vocab, CompanyCreate hq normalization, phone-match perf

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -273,6 +273,7 @@ class VendorResponseStatus(StrEnum):
     PARSED = "parsed"
     REVIEWED = "reviewed"
     REJECTED = "rejected"
+    FLAGGED = "flagged"
 
 
 class UserRole(StrEnum):

--- a/app/routers/htmx/offers.py
+++ b/app/routers/htmx/offers.py
@@ -1814,10 +1814,21 @@ async def update_response_status(
         raise HTTPException(404, "Response not found")
 
     form = await request.form()
-    new_status = form.get("status", "").strip()
-    valid = {"reviewed", "rejected", "flagged", "new"}
-    if new_status not in valid:
-        raise HTTPException(400, f"Invalid status. Must be one of: {', '.join(valid)}")
+    action = form.get("status", "").strip()
+    # Map accepted action strings to in-vocabulary VendorResponseStatus members so
+    # the persisted status always matches enum-based filters/reports.
+    status_by_action = {
+        VendorResponseStatus.NEW.value: VendorResponseStatus.NEW,
+        VendorResponseStatus.REVIEWED.value: VendorResponseStatus.REVIEWED,
+        VendorResponseStatus.REJECTED.value: VendorResponseStatus.REJECTED,
+        VendorResponseStatus.FLAGGED.value: VendorResponseStatus.FLAGGED,
+    }
+    new_status = status_by_action.get(action)
+    if new_status is None:
+        raise HTTPException(
+            400,
+            f"Invalid status. Must be one of: {', '.join(status_by_action)}",
+        )
 
     vr.status = new_status
     db.commit()

--- a/app/schemas/crm.py
+++ b/app/schemas/crm.py
@@ -52,6 +52,28 @@ def normalize_website(v: str | None) -> str | None:
     return v
 
 
+def normalize_hq_country_value(v: str | None) -> str | None:
+    """Normalize a company HQ country to an ISO code (shared by CompanyCreate and
+    CompanyUpdate so create/edit stay in parity).
+
+    None passes through; an unmappable value is kept verbatim.
+    """
+    if v is None:
+        return v
+    return normalize_country(v) or v
+
+
+def normalize_hq_state_value(v: str | None) -> str | None:
+    """Normalize a company HQ state to a US abbreviation (shared by CompanyCreate and
+    CompanyUpdate so create/edit stay in parity).
+
+    None passes through; an unmappable value is kept verbatim.
+    """
+    if v is None:
+        return v
+    return normalize_us_state(v) or v
+
+
 # ── Companies ────────────────────────────────────────────────────────
 
 
@@ -88,6 +110,16 @@ class CompanyCreate(BaseModel):
     @classmethod
     def validate_website(cls, v: str | None) -> str | None:
         return normalize_website(v)
+
+    @field_validator("hq_country")
+    @classmethod
+    def normalize_hq_country(cls, v: str | None) -> str | None:
+        return normalize_hq_country_value(v)
+
+    @field_validator("hq_state")
+    @classmethod
+    def normalize_hq_state(cls, v: str | None) -> str | None:
+        return normalize_hq_state_value(v)
 
     @field_validator("phone")
     @classmethod
@@ -127,16 +159,12 @@ class CompanyUpdate(BaseModel):
     @field_validator("hq_country")
     @classmethod
     def normalize_hq_country(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        return normalize_country(v) or v
+        return normalize_hq_country_value(v)
 
     @field_validator("hq_state")
     @classmethod
     def normalize_hq_state(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        return normalize_us_state(v) or v
+        return normalize_hq_state_value(v)
 
     @field_validator("phone")
     @classmethod

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 
 from loguru import logger
 from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session, selectinload
 
 from app.config import settings
@@ -200,6 +201,24 @@ def _phone_digits(phone: str | None) -> str:
     return "".join(c for c in (phone or "") if c.isdigit())
 
 
+def _match_vendor_card_by_phone(db: Session, e164: str) -> VendorCard | None:
+    """Find one non-blacklisted VendorCard whose normalized_phones contains e164.
+
+    Pushes the membership test into the database instead of materializing every
+    non-blacklisted vendor card into Python.
+
+    Postgres: uses JSONB containment (``@>``). ``normalized_phones`` is a plain
+    ``JSON`` column (no ``@>``), so it is cast to ``JSONB`` at query time. SQLite
+    (the test DB) has neither ``JSONB`` nor ``@>``, so it falls back to a Python
+    membership test over the (blacklist-filtered) rows — the observable result is
+    identical; only Postgres gets the indexed/in-DB path.
+    """
+    base = db.query(VendorCard).filter(VendorCard.is_blacklisted.is_(False))
+    if bool(db.bind) and db.bind.dialect.name == "postgresql":
+        return base.filter(VendorCard.normalized_phones.cast(JSONB).contains([e164])).first()
+    return next((c for c in base.all() if e164 in (c.normalized_phones or [])), None)
+
+
 def match_phone_to_entity(phone: str, db: Session) -> dict | None:
     """Unified E.164 phone matcher — queries normalized columns in priority order.
 
@@ -212,7 +231,8 @@ def match_phone_to_entity(phone: str, db: Session) -> dict | None:
       2. Company.normalized_phone
       3. CustomerSite.normalized_phone / normalized_phone_2
       4. VendorContact.normalized_phone
-      5. VendorCard.normalized_phones (JSON list, Python filter)
+      5. VendorCard.normalized_phones (JSON containment, fallback only —
+         skipped entirely when priorities 1-4 already matched)
 
     Returns None if the number is unparseable or no match found.
     """
@@ -323,28 +343,31 @@ def match_phone_to_entity(phone: str, db: Session) -> dict | None:
                 }
             )
 
-    # ── Priority 5: VendorCard phones JSON ──────────────────────────────
-    vendor_cards = db.query(VendorCard).filter(VendorCard.is_blacklisted.is_(False)).all()
-    for card in vendor_cards:
-        key = ("vendor", card.id)
-        if key in seen:
-            continue
-        if e164 in (card.normalized_phones or []):
-            seen.add(key)
-            candidates.append(
-                {
-                    "type": "vendor",
-                    "id": card.id,
-                    "name": card.display_name,
-                    "source": "vendor_card",
-                    "company_id": None,
-                    "vendor_card_id": card.id,
-                    "_site_id": None,
-                    "_site_contact_id": None,
-                    "_contact_name": None,
-                    "_vendor_contact_id": None,
-                }
-            )
+    # ── Priority 5: VendorCard normalized_phones (fallback) ──────────────
+    # Only runs when priorities 1-4 produced no match. This is the last-resort
+    # JSON-containment lookup — it must never execute on the hot inbound/outbound
+    # call-logging path when a higher-priority normalized-column match already
+    # exists, and it must NOT materialize every non-blacklisted vendor card.
+    if not candidates:
+        card = _match_vendor_card_by_phone(db, e164)
+        if card is not None:
+            key = ("vendor", card.id)
+            if key not in seen:
+                seen.add(key)
+                candidates.append(
+                    {
+                        "type": "vendor",
+                        "id": card.id,
+                        "name": card.display_name,
+                        "source": "vendor_card",
+                        "company_id": None,
+                        "vendor_card_id": card.id,
+                        "_site_id": None,
+                        "_site_contact_id": None,
+                        "_contact_name": None,
+                        "_vendor_contact_id": None,
+                    }
+                )
 
     if not candidates:
         return None

--- a/tests/test_htmx_views_nightly9.py
+++ b/tests/test_htmx_views_nightly9.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 os.environ["TESTING"] = "1"
 
+from app.constants import VendorResponseStatus  # noqa: E402
 from app.models import (  # noqa: E402
     Company,
     CustomerSite,
@@ -758,32 +759,33 @@ class TestUpdateResponseStatus:
     """Covers update_response_status (lines 5515-5550)."""
 
     @pytest.mark.parametrize(
-        ("status", "verify_stored"),
+        "status",
         [
-            ("reviewed", True),
-            ("rejected", True),
-            ("flagged", False),
+            VendorResponseStatus.REVIEWED,
+            VendorResponseStatus.REJECTED,
+            VendorResponseStatus.FLAGGED,
+            VendorResponseStatus.NEW,
         ],
-        ids=["reviewed", "rejected", "flagged"],
+        ids=["reviewed", "rejected", "flagged", "new"],
     )
     def test_update_status_valid(
         self,
         client: TestClient,
         db_session: Session,
         test_user: User,
-        status: str,
-        verify_stored: bool,
+        status: VendorResponseStatus,
     ):
         req = _req(db_session, test_user)
         vr = _vendor_response(db_session, req)
         resp = client.patch(
             f"/v2/partials/requisitions/{req.id}/responses/{vr.id}/status",
-            data={"status": status},
+            data={"status": status.value},
         )
         assert resp.status_code == 200
-        if verify_stored:
-            db_session.refresh(vr)
-            assert vr.status == status
+        db_session.refresh(vr)
+        # Stored value must be in-vocabulary: constructing the enum from it must
+        # not raise (the pre-fix bug stored 'flagged' as an out-of-vocab string).
+        assert VendorResponseStatus(vr.status) == status
 
     def test_update_status_invalid_raises_400(
         self,

--- a/tests/test_schemas_crm.py
+++ b/tests/test_schemas_crm.py
@@ -171,6 +171,30 @@ class TestCompanyCreatePhone:
         assert c.phone.startswith("+")
 
 
+# ── CompanyCreate hq normalization (parity with CompanyUpdate) ──────
+
+
+class TestCompanyCreateHqNormalization:
+    @pytest.mark.parametrize(
+        "field,value,expected",
+        [
+            pytest.param("hq_country", None, None, id="hq_country_none"),
+            pytest.param("hq_country", "United States", "US", id="hq_country_value"),
+            pytest.param("hq_state", None, None, id="hq_state_none"),
+            pytest.param("hq_state", "California", "CA", id="hq_state_value"),
+        ],
+    )
+    def test_normalize(self, field, value, expected) -> None:
+        c = CompanyCreate(name="Acme", **{field: value})
+        assert getattr(c, field) == expected
+
+    def test_create_update_parity(self) -> None:
+        created = CompanyCreate(name="Acme", hq_country="United States", hq_state="California")
+        updated = CompanyUpdate(hq_country="United States", hq_state="California")
+        assert created.hq_country == updated.hq_country == "US"
+        assert created.hq_state == updated.hq_state == "CA"
+
+
 # ── CompanyUpdate validators ────────────────────────────────────────
 
 

--- a/tests/test_unified_phone_matcher.py
+++ b/tests/test_unified_phone_matcher.py
@@ -124,6 +124,76 @@ class TestUnifiedMatcherVendorCard:
         assert result["type"] == "vendor"
         assert result["vendor_card_id"] == card.id
 
+    def test_priority5_skipped_when_higher_priority_matches(self, db_session, monkeypatch):
+        """Priority-5 vendor-card scan must NOT run when a priority 1-4 match exists.
+
+        A company (priority 2) and a vendor card (priority 5) share the same phone. The
+        company must win AND the expensive vendor-card fallback must be short-circuited
+        (never invoked), so the result is unambiguous.
+        """
+        from app.models import Company
+        from app.models.vendors import VendorCard
+        from app.services import activity_service
+
+        co = Company(name="Shared Phone Co", phone="9165550700", is_active=True)
+        db_session.add(co)
+        card = VendorCard(
+            normalized_name="shared-vendor",
+            display_name="Shared Vendor",
+            source="test",
+            phones=["9165550700"],
+            is_blacklisted=False,
+        )
+        db_session.add(card)
+        db_session.flush()
+
+        # Spy on the fallback helper: it must never be called on a 1-4 hit.
+        calls = {"n": 0}
+        real = activity_service._match_vendor_card_by_phone
+
+        def _spy(db, e164):
+            calls["n"] += 1
+            return real(db, e164)
+
+        monkeypatch.setattr(activity_service, "_match_vendor_card_by_phone", _spy)
+
+        result = match_phone_to_entity("916-555-0700", db_session)
+
+        assert result is not None
+        assert result["type"] == "company"
+        assert result["company_id"] == co.id
+        assert result["ambiguous"] is False
+        assert calls["n"] == 0, "priority-5 fallback ran despite a higher-priority match"
+
+    def test_priority5_matches_via_db_containment(self, db_session):
+        """Priority-5 links a phone to a vendor card when 1-4 do not match."""
+        from app.models.vendors import VendorCard
+        from app.services import activity_service
+
+        card = VendorCard(
+            normalized_name="containment-vendor",
+            display_name="Containment Vendor",
+            source="test",
+            phones=["(800) 344-4539"],
+            is_blacklisted=False,
+        )
+        db_session.add(card)
+        db_session.flush()
+
+        # e164 must live in the normalized_phones JSON list for the match.
+        assert "+18003444539" in (card.normalized_phones or [])
+
+        # The helper itself resolves the card via the in-DB membership test.
+        # NOTE: on Postgres this compiles to a JSONB `@>` containment query;
+        # SQLite (this test DB) has no JSONB/@>, so the helper degrades to a
+        # Python membership test — the observable match result is identical.
+        assert activity_service._match_vendor_card_by_phone(db_session, "+18003444539") is card
+
+        result = match_phone_to_entity("8003444539", db_session)
+        assert result is not None
+        assert result["type"] == "vendor"
+        assert result["vendor_card_id"] == card.id
+
     def test_blacklisted_vendor_not_returned(self, db_session):
         from app.models.vendors import VendorCard
 


### PR DESCRIPTION
P1-tail CRM/offers cluster. Three fixes, each TDD'd + adversarially reviewed.

**1. Out-of-vocabulary vendor-response status** — `update_response_status` assigned `vr.status = 'flagged'` as a raw string, but `VendorResponseStatus` (StrEnum) only defined new/parsed/reviewed/rejected — so a flagged row held a value outside the vocabulary and never matched any status-based filter/report. Added a `FLAGGED` member and assign from validated enum constants (no migration — `status` is a plain String column).

**2. CompanyCreate skipped hq normalization** — `CompanyUpdate` normalizes `hq_country`/`hq_state` ('United States'→'US', 'California'→'CA') but `CompanyCreate` didn't, so a created company stored verbatim values that broke country/state equality filters and grouping. Added the same field_validators (shared, not duplicated) for create/edit parity.

**3. Phone-match full-table scan on every call** — `match_phone_to_entity` priority-5 ran `db.query(VendorCard).filter(is_blacklisted==False).all()` + a Python membership loop on the hot call-logging path, even when priorities 1-4 already matched. Now short-circuits when a higher-priority match exists, and pushes the phone-membership test into the DB. Cross-dialect: Postgres casts the `JSON` column to `JSONB` for `@>` containment; SQLite (test DB) falls back to a Python scan.

Full CRM/offers ripple sweep (812 tests) green; `pre-commit --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)