### PR TITLE
fix(p2): correctness cluster ×7 — encryption canary, OEMSecrets trust, email direction, worker kwargs, frozen result, knowledge IDOR+savepoint, unified status machine

### DIFF
--- a/app/connectors/oemsecrets.py
+++ b/app/connectors/oemsecrets.py
@@ -134,10 +134,12 @@ class OEMSecretsConnector(BaseConnector):
                 continue
             seen.add(key)
 
-            # Authorization status
+            # Authorization status. OEMSecrets is a 140+-distributor gray-market
+            # meta-aggregator, so an unknown/absent signal must NOT be treated as
+            # authorized — default False and flip to True only on a positive signal.
             auth_status = item.get("distributor_authorisation_status", "")
             is_auth = (
-                auth_status == "authorised" if auth_status else item.get("authorized", item.get("is_authorized", True))
+                auth_status == "authorised" if auth_status else item.get("authorized", item.get("is_authorized", False))
             )
 
             # Core attributes (optional — None when absent)

--- a/app/models/enrichment_worker_status.py
+++ b/app/models/enrichment_worker_status.py
@@ -17,6 +17,7 @@ Depends on: nothing (standalone table)
 
 from datetime import datetime, timezone
 
+from loguru import logger
 from sqlalchemy import JSON, Boolean, CheckConstraint, Column, Date, Integer, Text
 
 from ..database import UTCDateTime
@@ -59,11 +60,24 @@ def update_enrichment_worker_status(db, **kwargs) -> None:
     Pass any column as a kwarg: is_running=True, enriched_today=5, etc.
     Silently returns if the row does not yet exist (e.g. pre-migration).
     """
+    # Reject unknown kwargs LOUDLY. The old `if hasattr(status, key)` guard silently
+    # dropped any typo'd/non-column kwarg (e.g. a misspelled `enriched_todays=5`), so the
+    # heartbeat committed while the intended write was a no-op — a bug that hides
+    # indefinitely. Validate against the real columns and fail fast.
+    valid_columns = set(EnrichmentWorkerStatus.__table__.columns.keys())
+    unknown = set(kwargs) - valid_columns
+    if unknown:
+        logger.error(
+            "update_enrichment_worker_status: unknown column kwarg(s) {} (valid: {})",
+            sorted(unknown),
+            sorted(valid_columns),
+        )
+        raise AttributeError(f"Unknown EnrichmentWorkerStatus column(s): {sorted(unknown)}")
+
     status = db.get(EnrichmentWorkerStatus, 1)
     if not status:
         return
     for key, value in kwargs.items():
-        if hasattr(status, key):
-            setattr(status, key, value)
+        setattr(status, key, value)
     status.updated_at = datetime.now(timezone.utc)
     db.commit()

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -458,7 +458,7 @@ def _match_entity_links(match: dict | None) -> dict:
 
 def log_email_activity(
     user_id: int | None,
-    direction: str,  # "sent" or "received"
+    direction: str,  # sent/received/inbound/outbound (normalized via _normalize_direction)
     email_addr: str,
     subject: str | None,
     external_id: str | None,
@@ -483,9 +483,20 @@ def log_email_activity(
         if existing:
             return None
 
+    # Normalize direction the same way log_call_activity does so 'outbound'/'inbound'/
+    # 'sent'/'received' all classify correctly. Email rows must carry a definite direction
+    # (EMAIL_SENT vs EMAIL_RECEIVED), so an unrecognized value is rejected explicitly
+    # rather than silently mis-bucketed as INBOUND / EMAIL_RECEIVED.
+    normalized_direction = _normalize_direction(direction)
+    if normalized_direction is None:
+        raise ValueError(
+            f"log_email_activity: unrecognized direction {direction!r}; expected one of sent/received/inbound/outbound"
+        )
+    is_outbound = normalized_direction == Direction.OUTBOUND
+
     match = match_email_to_entity(email_addr, db)
 
-    activity_type = ActivityType.EMAIL_SENT if direction == "sent" else ActivityType.EMAIL_RECEIVED
+    activity_type = ActivityType.EMAIL_SENT if is_outbound else ActivityType.EMAIL_RECEIVED
 
     record = ActivityLog(
         user_id=user_id,
@@ -496,9 +507,9 @@ def log_email_activity(
         contact_name=contact_name,
         subject=subject,
         external_id=external_id,
-        direction=Direction.OUTBOUND if direction == "sent" else Direction.INBOUND,
+        direction=normalized_direction,
         event_type=EventType.EMAIL,
-        summary=f"Email {'to' if direction == 'sent' else 'from'} {contact_name or email_addr}",
+        summary=f"Email {'to' if is_outbound else 'from'} {contact_name or email_addr}",
         requisition_id=requisition_id,
         requirement_id=requirement_id,
         occurred_at=occurred_at,

--- a/app/services/enrichment_worker/web_extractor.py
+++ b/app/services/enrichment_worker/web_extractor.py
@@ -36,9 +36,14 @@ _PROMPT = (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class WebExtractResult:
-    """Result of a web-search enrichment attempt."""
+    """Result of a web-search enrichment attempt.
+
+    Frozen: producers build the full object in one ``return`` and consumers only read, so
+    immutability is safe and lets the ``_FAILED`` module singleton be shared without an
+    aliasing footgun (mutating a field on the singleton would corrupt every future failure).
+    """
 
     status: str  # "web_sourced" | "failed"
     description: str | None = None

--- a/app/services/knowledge_service.py
+++ b/app/services/knowledge_service.py
@@ -123,11 +123,15 @@ def get_entry(db: Session, entry_id: int) -> KnowledgeEntry | None:
 def update_entry(db: Session, entry_id: int, user_id: int, **kwargs) -> KnowledgeEntry | None:
     """Update an entry.
 
-    Only the creator can update.
+    Only the creator may update — enforced (the docstring claimed it but the check was
+    never wired, a latent IDOR if exposed via a router). A non-creator (or a user acting
+    on a system entry whose created_by is None) raises PermissionError.
     """
     entry = db.get(KnowledgeEntry, entry_id)
     if not entry:
         return None
+    if entry.created_by != user_id:
+        raise PermissionError(f"User {user_id} may not update knowledge entry {entry_id} (creator: {entry.created_by})")
     for key, value in kwargs.items():
         if value is not None and hasattr(entry, key):
             setattr(entry, key, value)
@@ -139,11 +143,14 @@ def update_entry(db: Session, entry_id: int, user_id: int, **kwargs) -> Knowledg
 def delete_entry(db: Session, entry_id: int, user_id: int) -> bool:
     """Delete an entry.
 
-    Returns True if deleted.
+    Only the creator may delete (enforced — latent IDOR otherwise). Returns True if
+    deleted; raises PermissionError for a non-creator.
     """
     entry = db.get(KnowledgeEntry, entry_id)
     if not entry:
         return False
+    if entry.created_by != user_id:
+        raise PermissionError(f"User {user_id} may not delete knowledge entry {entry_id} (creator: {entry.created_by})")
     db.delete(entry)
     db.commit()
     logger.info("Knowledge entry deleted: id={} by user={}", entry_id, user_id)
@@ -228,11 +235,17 @@ def post_answer(
 def capture_quote_fact(db: Session, *, quote, user_id: int) -> KnowledgeEntry | None:
     """Auto-capture price facts when a quote is created.
 
+    Uses a savepoint so a create failure doesn't corrupt the caller's transaction (the
+    quote it just created), and does NOT commit the caller's in-flight transaction — mirrors
+    capture_offer_fact (the old path called create_entry with the default commit=True and no
+    savepoint, so it both committed the caller's txn early and poisoned it on any failure).
     Called from: app/routers/crm/quotes.py after quote creation.
     """
+    nested = db.begin_nested()
     try:
         line_items = quote.line_items or []
         if not line_items:
+            nested.rollback()
             return None
 
         facts = []
@@ -249,10 +262,11 @@ def capture_quote_fact(db: Session, *, quote, user_id: int) -> KnowledgeEntry | 
                 )
 
         if not facts:
+            nested.rollback()
             return None
 
         content = "Quote #{} — {}".format(quote.quote_number, "; ".join(facts))
-        return create_entry(
+        entry = create_entry(
             db,
             user_id=user_id,
             entry_type="fact",
@@ -261,8 +275,12 @@ def capture_quote_fact(db: Session, *, quote, user_id: int) -> KnowledgeEntry | 
             confidence=1.0,
             expires_at=datetime.now(timezone.utc) + timedelta(days=EXPIRY_PRICE_FACT),
             requisition_id=quote.requisition_id,
+            commit=False,
         )
+        nested.commit()
+        return entry
     except Exception as e:
+        nested.rollback()
         logger.warning("Failed to capture quote fact: {}", e)
         return None
 

--- a/app/services/requirement_status.py
+++ b/app/services/requirement_status.py
@@ -19,17 +19,14 @@ from ..constants import ActivityType
 from ..constants import SourcingStatus as RequirementSourcingStatus
 from ..models import ActivityLog, Requirement, Requisition, User
 from .activity_service import log_activity
+from .status_machine import SOURCING_TRANSITIONS
 
-# Valid per-part status transitions
-ALLOWED_TRANSITIONS: dict[str, set[str]] = {
-    "open": {"sourcing", "offered", "quoted", "won", "lost", "archived"},
-    "sourcing": {"offered", "quoted", "won", "lost", "open", "archived"},
-    "offered": {"quoted", "won", "lost", "sourcing", "archived"},
-    "quoted": {"won", "lost", "offered", "archived"},
-    "won": {"lost", "archived"},
-    "lost": {"open", "sourcing", "archived"},
-    "archived": {"open"},
-}
+# Per-part status transitions. The single source of truth is
+# status_machine.SOURCING_TRANSITIONS — validate_transition("requirement", …)
+# and transition_requirement (below) MUST agree, so both reference the same
+# table. `ALLOWED_TRANSITIONS` is kept as an alias for backwards compatibility
+# with existing importers; it is the same object, not a copy.
+ALLOWED_TRANSITIONS: dict[str, set[str]] = SOURCING_TRANSITIONS
 
 
 def transition_requirement(

--- a/app/services/status_machine.py
+++ b/app/services/status_machine.py
@@ -102,14 +102,54 @@ REQUISITION_TRANSITIONS: dict[str, set[str]] = {
 }
 
 # ── Sourcing Status Transitions (Requirement-level) ────────────────────
+# SINGLE SOURCE OF TRUTH for per-part sourcing transition legality. Both
+# validators route through this table: validate_transition("requirement", …)
+# (below) and requirement_status.transition_requirement (which imports this as
+# ALLOWED_TRANSITIONS). Do not fork it — keep the two in sync by reference.
+#
+# Reconciliation (2026-07): this table previously diverged from
+# requirement_status.ALLOWED_TRANSITIONS. The permissive (superset) definition
+# won because the authoritative event handlers require skip-ahead legality:
+# on_offer_created advances open/sourcing → offered and on_quote_built advances
+# open/sourcing/offered → quoted (offers/quotes can arrive on a part that never
+# had an RFQ sent — e.g. inbound email mining). Under the old restrictive table
+# those transitions were rejected and silently skipped, leaving a part that is
+# on a confirmed offer or customer quote still displayed as "open" — a data
+# integrity bug. Un-archive (archived → open) is likewise legal because a
+# requirement is re-openable (unlike a terminal offer).
 SOURCING_TRANSITIONS: dict[str, set[str]] = {
-    SourcingStatus.OPEN: {SourcingStatus.SOURCING, SourcingStatus.ARCHIVED},
-    SourcingStatus.SOURCING: {SourcingStatus.OFFERED, SourcingStatus.OPEN, SourcingStatus.ARCHIVED},
-    SourcingStatus.OFFERED: {SourcingStatus.QUOTED, SourcingStatus.SOURCING, SourcingStatus.ARCHIVED},
-    SourcingStatus.QUOTED: {SourcingStatus.WON, SourcingStatus.LOST, SourcingStatus.OFFERED, SourcingStatus.ARCHIVED},
-    SourcingStatus.WON: {SourcingStatus.ARCHIVED},
-    SourcingStatus.LOST: {SourcingStatus.OPEN, SourcingStatus.ARCHIVED},
-    SourcingStatus.ARCHIVED: set(),  # terminal
+    SourcingStatus.OPEN: {
+        SourcingStatus.SOURCING,
+        SourcingStatus.OFFERED,
+        SourcingStatus.QUOTED,
+        SourcingStatus.WON,
+        SourcingStatus.LOST,
+        SourcingStatus.ARCHIVED,
+    },
+    SourcingStatus.SOURCING: {
+        SourcingStatus.OFFERED,
+        SourcingStatus.QUOTED,
+        SourcingStatus.WON,
+        SourcingStatus.LOST,
+        SourcingStatus.OPEN,
+        SourcingStatus.ARCHIVED,
+    },
+    SourcingStatus.OFFERED: {
+        SourcingStatus.QUOTED,
+        SourcingStatus.WON,
+        SourcingStatus.LOST,
+        SourcingStatus.SOURCING,
+        SourcingStatus.ARCHIVED,
+    },
+    SourcingStatus.QUOTED: {
+        SourcingStatus.WON,
+        SourcingStatus.LOST,
+        SourcingStatus.OFFERED,
+        SourcingStatus.ARCHIVED,
+    },
+    SourcingStatus.WON: {SourcingStatus.LOST, SourcingStatus.ARCHIVED},
+    SourcingStatus.LOST: {SourcingStatus.OPEN, SourcingStatus.SOURCING, SourcingStatus.ARCHIVED},
+    SourcingStatus.ARCHIVED: {SourcingStatus.OPEN},  # re-openable (un-archive)
 }
 
 

--- a/app/startup.py
+++ b/app/startup.py
@@ -105,6 +105,7 @@ def run_startup_migrations() -> None:
         )
         _analyze_hot_tables(conn)
 
+    _verify_encryption_canary()
     _backfill_normalized_mpn()
     if os.environ.get("ENABLE_PASSWORD_LOGIN", "false").lower() == "true":
         _create_default_user_if_env_set()
@@ -571,6 +572,24 @@ def _seed_site_contacts(conn) -> None:
 
 
 _BACKFILL_BATCH_SIZE = 500
+
+
+def _verify_encryption_canary() -> None:
+    """Fail loudly at boot if the live ENCRYPTION_SALT/SECRET_KEY can't decrypt stored
+    data.
+
+    A wrong salt would otherwise silently empty every encrypted credential app-wide. See
+    app/utils/encrypted_type.py::verify_encryption_canary.
+    """
+    from app.database import SessionLocal
+
+    from .utils.encrypted_type import verify_encryption_canary
+
+    db = SessionLocal()
+    try:
+        verify_encryption_canary(db)
+    finally:
+        db.close()
 
 
 def _backfill_normalized_mpn() -> None:

--- a/app/utils/encrypted_type.py
+++ b/app/utils/encrypted_type.py
@@ -51,6 +51,55 @@ def _get_fernet():
     return _fernet_instance
 
 
+_CANARY_KEY = "encryption_canary"
+_CANARY_SENTINEL = "AVAIL-ENC-CANARY-v1"
+
+
+def verify_encryption_canary(db) -> None:
+    """Boot-time self-test: prove the live key can decrypt data encrypted under itself.
+
+    A wrong ENCRYPTION_SALT/SECRET_KEY derives a valid-but-DIFFERENT Fernet key, so every
+    EncryptedText column silently decrypts to None (InvalidToken) — the app's stored
+    credentials (M365 tokens, API keys, password hashes) all read as empty with only a
+    per-field warning, indistinguishable from genuinely-empty data. The per-field decrypt
+    cannot tell "wrong key" from "legit pre-migration plaintext", so detection must live
+    here, once, at startup. First boot under a given key bootstraps the canary; later boots
+    verify it and FAIL LOUD (raise) on mismatch instead of silently emptying every secret.
+
+    Called from app/startup.py after the system_config table exists. No-op-safe if the
+    table is missing (pre-migration) — it just skips.
+    """
+    from sqlalchemy.exc import DatabaseError, SQLAlchemyError
+
+    from ..models.config import SystemConfig
+
+    f = _get_fernet()
+    try:
+        row = db.query(SystemConfig).filter(SystemConfig.key == _CANARY_KEY).first()
+    except (SQLAlchemyError, DatabaseError):
+        db.rollback()
+        return  # table not yet created — nothing to verify against
+    if row is None:
+        token = f.encrypt(_CANARY_SENTINEL.encode()).decode()
+        db.add(SystemConfig(key=_CANARY_KEY, value=token, description="Encryption self-test canary"))
+        db.commit()
+        logger.info("Encryption canary bootstrapped under the current key.")
+        return
+    try:
+        decrypted = f.decrypt(row.value.encode()).decode()
+    except InvalidToken as e:
+        raise RuntimeError(
+            "ENCRYPTION MISCONFIG: the encryption canary failed to decrypt — the live "
+            "ENCRYPTION_SALT/SECRET_KEY does not match the key that encrypted stored data. "
+            "Refusing to boot silently, since every encrypted credential (M365 tokens, API "
+            "keys, password hashes) would otherwise read as empty. Restore the correct "
+            "ENCRYPTION_SALT or run the salt-rotation migration."
+        ) from e
+    if decrypted != _CANARY_SENTINEL:
+        raise RuntimeError(f"ENCRYPTION MISCONFIG: canary decrypted to an unexpected value ({decrypted!r}).")
+    logger.debug("Encryption canary verified.")
+
+
 class EncryptedText(TypeDecorator):
     """Transparently encrypts/decrypts text values stored in the database."""
 

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -927,6 +927,42 @@ class TestOEMSecretsConnector:
         results = c._parse(data, "ABC")
         assert results[0]["is_authorized"] is False
 
+    def test_parse_no_auth_signal_defaults_unauthorized(self):
+        """No authorization signal at all → is_authorized must default to False.
+
+        OEMSecrets aggregates 140+ gray-market distributors; an absent signal must not
+        overstate trust by defaulting to authorized.
+        """
+        c = self._make_connector()
+        data = {
+            "stock": [
+                {
+                    "distributor": {"distributor_name": "Some Broker"},
+                    "source_part_number": "ABC",
+                    "quantity_in_stock": 100,
+                    "prices": {"USD": [{"unit_break": 1, "unit_price": "1.50"}]},
+                }
+            ]
+        }
+        results = c._parse(data, "ABC")
+        assert results[0]["is_authorized"] is False
+
+    def test_parse_authorized_signal_sets_true(self):
+        """A positive authorized signal → is_authorized True."""
+        c = self._make_connector()
+        data = {
+            "stock": [
+                {
+                    "distributor": {"distributor_name": "Arrow"},
+                    "source_part_number": "ABC",
+                    "quantity_in_stock": 100,
+                    "distributor_authorisation_status": "authorised",
+                }
+            ]
+        }
+        results = c._parse(data, "ABC")
+        assert results[0]["is_authorized"] is True
+
     def test_parse_v3_no_usd_prices(self):
         """Falls back to first available currency if USD not in prices."""
         c = self._make_connector()

--- a/tests/test_encrypted_type.py
+++ b/tests/test_encrypted_type.py
@@ -242,3 +242,26 @@ class TestCredentialServiceSalt:
         encrypted = cs_mod.encrypt_value("super-secret-api-key")
         assert encrypted != "super-secret-api-key"
         assert cs_mod.decrypt_value(encrypted) == "super-secret-api-key"
+
+
+def test_encryption_canary_bootstrap_verify_and_wrong_key(db_session):
+    """The boot canary bootstraps on first run, verifies under the same key, and FAILS
+    LOUD when the key changes (wrong ENCRYPTION_SALT) — instead of silently emptying
+    every encrypted credential app-wide."""
+    import app.utils.encrypted_type as et
+    from app.models.config import SystemConfig
+    from app.utils.encrypted_type import _CANARY_KEY, build_fernet, verify_encryption_canary
+
+    # First boot under key A: no canary row yet → bootstrap (no raise).
+    et._fernet_instance = build_fernet("secret", "saltA")
+    verify_encryption_canary(db_session)
+    row = db_session.query(SystemConfig).filter(SystemConfig.key == _CANARY_KEY).first()
+    assert row is not None and row.value  # stored ciphertext
+
+    # Later boot, SAME key: verifies cleanly.
+    verify_encryption_canary(db_session)  # no raise
+
+    # Boot with a WRONG salt (different-but-valid key): must fail loudly, not silently None.
+    et._fernet_instance = build_fernet("secret", "saltB")
+    with pytest.raises(RuntimeError, match="ENCRYPTION MISCONFIG"):
+        verify_encryption_canary(db_session)

--- a/tests/test_enrichment_worker.py
+++ b/tests/test_enrichment_worker.py
@@ -60,6 +60,18 @@ def test_update_helper_noop_when_no_row(db_session):
     update_enrichment_worker_status(db_session, is_running=True, enriched_today=5)
 
 
+def test_update_helper_rejects_unknown_kwarg(db_session):
+    """A typo'd/non-column kwarg raises loudly instead of being silently dropped.
+
+    The old hasattr-guard skipped unknown keys (e.g. a misspelled counter), so the write
+    was a silent no-op while the heartbeat still committed — the bug now fails fast.
+    """
+    from app.models.enrichment_worker_status import update_enrichment_worker_status
+
+    with pytest.raises(AttributeError, match="enriched_todays"):
+        update_enrichment_worker_status(db_session, enriched_todays=5)
+
+
 def test_update_helper_sets_fields(db_session):
     """update_enrichment_worker_status sets columns on the singleton row."""
 

--- a/tests/test_knowledge_service_coverage.py
+++ b/tests/test_knowledge_service_coverage.py
@@ -837,3 +837,50 @@ class TestGeneratePipelineInsights:
         with patch("app.utils.claude_client.claude_structured", new=_mock):
             result = await knowledge_service.generate_pipeline_insights(db_session)
         assert len(result) == 1
+
+
+class TestKnowledgeEntryAuthzAndSavepoint:
+    """Update/delete enforce creator-only; capture_quote_fact is savepoint-isolated."""
+
+    def test_update_entry_non_creator_raises(self, db_session, test_user):
+        import pytest
+
+        from app.services import knowledge_service
+
+        entry = knowledge_service.create_entry(db_session, user_id=test_user.id, entry_type="note", content="mine")
+        with pytest.raises(PermissionError):
+            knowledge_service.update_entry(db_session, entry.id, user_id=test_user.id + 999, content="hacked")
+        # creator can still update
+        updated = knowledge_service.update_entry(db_session, entry.id, user_id=test_user.id, content="ok")
+        assert updated is not None and updated.content == "ok"
+
+    def test_delete_entry_non_creator_raises(self, db_session, test_user):
+        import pytest
+
+        from app.services import knowledge_service
+
+        entry = knowledge_service.create_entry(db_session, user_id=test_user.id, entry_type="note", content="mine")
+        with pytest.raises(PermissionError):
+            knowledge_service.delete_entry(db_session, entry.id, user_id=test_user.id + 999)
+        assert knowledge_service.delete_entry(db_session, entry.id, user_id=test_user.id) is True
+
+    def test_capture_quote_fact_failure_is_savepoint_isolated(self, db_session, test_user):
+        """A create failure inside capture_quote_fact rolls back only its savepoint and
+        does NOT poison the caller's transaction (the just-created quote survives)."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from sqlalchemy import text
+
+        from app.services import knowledge_service
+
+        quote = SimpleNamespace(
+            line_items=[{"mpn": "LM317T", "unit_sell": 1.5, "qty": 10, "vendor_name": "Arrow"}],
+            quote_number="Q-KS-1",
+            requisition_id=None,
+        )
+        with patch.object(knowledge_service, "create_entry", side_effect=RuntimeError("boom")):
+            result = knowledge_service.capture_quote_fact(db_session, quote=quote, user_id=test_user.id)
+        assert result is None
+        # The outer transaction is intact (not aborted) — a follow-up query works.
+        assert db_session.execute(text("SELECT 1")).scalar() == 1

--- a/tests/test_nightly_coverage_boost.py
+++ b/tests/test_nightly_coverage_boost.py
@@ -209,8 +209,9 @@ class TestActivityDigestEdgeCases:
 
 
 class TestSourcingAutoProgressEdgeCases:
-    def test_invalid_transition_blocked_returns_false(self, db_session):
-        """Lines 51-56: validate_transition returns False for non-allowed forward skip."""
+    def test_no_progress_when_already_ahead(self, db_session):
+        """auto_progress is forward-only: a backward target returns False and leaves
+        status unchanged (the _STATUS_ORDER guard, independent of the transition table)."""
         from app.constants import SourcingStatus
         from app.models.sourcing import Requirement as Req2
         from app.models.sourcing import Requisition as Req
@@ -223,16 +224,39 @@ class TestSourcingAutoProgressEdgeCases:
         r = Req2(
             requisition_id=req.id,
             primary_mpn="TEST123",
+            sourcing_status=SourcingStatus.QUOTED,
+        )
+        db_session.add(r)
+        db_session.commit()
+
+        # QUOTED → OFFERED is backwards in _STATUS_ORDER → no progress.
+        result = auto_progress_status(r, SourcingStatus.OFFERED, db_session)
+        assert result is False
+        assert r.sourcing_status == SourcingStatus.QUOTED
+
+    def test_skip_ahead_progresses(self, db_session):
+        """Reconciled contract: OPEN → OFFERED is a legal skip-ahead, so auto_progress
+        advances (offers can arrive on a part with no prior sourcing step)."""
+        from app.constants import SourcingStatus
+        from app.models.sourcing import Requirement as Req2
+        from app.models.sourcing import Requisition as Req
+        from app.services.sourcing_auto_progress import auto_progress_status
+
+        req = Req(name="REQ-SKIP2", status="active")
+        db_session.add(req)
+        db_session.flush()
+
+        r = Req2(
+            requisition_id=req.id,
+            primary_mpn="TEST456",
             sourcing_status=SourcingStatus.OPEN,
         )
         db_session.add(r)
         db_session.commit()
 
-        # OPEN → OFFERED: forward in order but OFFERED not in OPEN's allowed transitions
         result = auto_progress_status(r, SourcingStatus.OFFERED, db_session)
-        assert result is False
-        # Sourcing status must remain OPEN
-        assert r.sourcing_status == SourcingStatus.OPEN
+        assert result is True
+        assert r.sourcing_status == SourcingStatus.OFFERED
 
 
 # ── ai_email_parser ────────────────────────────────────────────────────

--- a/tests/test_requirement_status.py
+++ b/tests/test_requirement_status.py
@@ -213,3 +213,47 @@ class TestUnclaimRequisition:
 
         changed = unclaim_requisition(test_requisition, db_session, actor=test_user)
         assert changed is False
+
+
+class TestValidatorParity:
+    """Both per-part sourcing validators must agree for every transition.
+
+    ``transition_requirement`` (requirement_status.py) and
+    ``validate_transition("requirement", …)`` (status_machine.py) previously used
+    two divergent tables, so a transition's legality depended on which validator a
+    caller happened to hit. They now share ``status_machine.SOURCING_TRANSITIONS``
+    as the single source of truth; this parametrized matrix guards re-divergence.
+    """
+
+    def test_tables_are_the_same_object(self):
+        from app.services.status_machine import SOURCING_TRANSITIONS
+
+        assert ALLOWED_TRANSITIONS is SOURCING_TRANSITIONS
+
+    @pytest.mark.parametrize("to_status", list(RequirementSourcingStatus))
+    @pytest.mark.parametrize("from_status", list(RequirementSourcingStatus))
+    def test_both_validators_agree(self, db_session, test_requisition, test_user, from_status, to_status):
+        from app.services.status_machine import validate_transition
+
+        if from_status == to_status:
+            # No-op: status_machine treats it as valid, transition_requirement as
+            # a no-change (False). Neither rejects — they agree.
+            assert validate_transition("requirement", from_status.value, to_status.value) is True
+            req_item = _first_requirement(test_requisition, db_session, from_status.value)
+            assert transition_requirement(req_item, to_status.value, db_session, actor=test_user) is False
+            return
+
+        expected_legal = to_status.value in ALLOWED_TRANSITIONS.get(from_status.value, set())
+
+        # status_machine validator
+        sm_legal = validate_transition("requirement", from_status.value, to_status.value, raise_on_invalid=False)
+        assert sm_legal is expected_legal
+
+        # requirement_status validator (raises ValueError on an illegal transition)
+        req_item = _first_requirement(test_requisition, db_session, from_status.value)
+        if expected_legal:
+            assert transition_requirement(req_item, to_status.value, db_session, actor=test_user) is True
+            assert req_item.sourcing_status == to_status.value
+        else:
+            with pytest.raises(ValueError):
+                transition_requirement(req_item, to_status.value, db_session, actor=test_user)

--- a/tests/test_services_activity.py
+++ b/tests/test_services_activity.py
@@ -260,6 +260,73 @@ class TestLogEmailActivity:
         assert record.company_id is None
         assert record.vendor_card_id is None
 
+    def test_outbound_synonym_classifies_outbound(self, db_session, test_user):
+        """'outbound' must classify OUTBOUND / email_sent, not be silently mis-bucketed
+        as INBOUND / email_received (regression: direction was matched only against the
+        literal 'sent')."""
+        co = _make_company(db_session)
+        _make_site(db_session, co.id, email="contact@acme.com")
+        db_session.commit()
+
+        record = log_email_activity(
+            test_user.id,
+            "outbound",
+            "contact@acme.com",
+            "RFQ",
+            "msg-out-1",
+            "J",
+            db_session,
+        )
+        assert record is not None
+        assert record.activity_type == "email_sent"
+        assert record.direction == "outbound"
+
+    def test_inbound_synonym_classifies_inbound(self, db_session, test_user):
+        co = _make_company(db_session)
+        _make_site(db_session, co.id, email="vendor@acme.com")
+        db_session.commit()
+
+        record = log_email_activity(
+            test_user.id,
+            "inbound",
+            "vendor@acme.com",
+            "RE: RFQ",
+            "msg-in-1",
+            "V",
+            db_session,
+        )
+        assert record is not None
+        assert record.activity_type == "email_received"
+        assert record.direction == "inbound"
+
+    def test_sent_and_received_still_classify(self, db_session, test_user):
+        co = _make_company(db_session)
+        _make_site(db_session, co.id, email="contact@acme.com")
+        db_session.commit()
+
+        sent = log_email_activity(test_user.id, "sent", "contact@acme.com", "S", "msg-s", "J", db_session)
+        received = log_email_activity(test_user.id, "received", "contact@acme.com", "R", "msg-r", "J", db_session)
+        assert sent is not None and sent.activity_type == "email_sent"
+        assert sent.direction == "outbound"
+        assert received is not None and received.activity_type == "email_received"
+        assert received.direction == "inbound"
+
+    def test_unknown_direction_rejected(self, db_session, test_user):
+        """An unrecognized direction is rejected explicitly, never silently stored as an
+        inbound/received row."""
+        import pytest
+
+        with pytest.raises(ValueError):
+            log_email_activity(
+                test_user.id,
+                "gibberish",
+                "contact@acme.com",
+                "S",
+                "msg-bad",
+                "J",
+                db_session,
+            )
+
 
 # ── Call activity logging ───────────────────────────────────────────
 

--- a/tests/test_sightings_advance_status.py
+++ b/tests/test_sightings_advance_status.py
@@ -57,22 +57,46 @@ class TestAdvanceStatusValid:
         db_session.refresh(requirement_open)
         assert requirement_open.sourcing_status == SourcingStatus.OFFERED
 
-
-class TestAdvanceStatusInvalid:
-    """Invalid transitions return 409."""
-
-    def test_open_to_won_rejected(self, client: TestClient, db_session: Session, requirement_open: Requirement):
+    def test_open_to_won_skip_ahead(self, client: TestClient, db_session: Session, requirement_open: Requirement):
+        """Skip-ahead is legal (single source of truth): open → won succeeds."""
         resp = advance_status(client, requirement_open.id, SourcingStatus.WON)
-        assert resp.status_code == 409
-        # Status should remain unchanged
+        assert resp.status_code == 200
         db_session.refresh(requirement_open)
-        assert requirement_open.sourcing_status == SourcingStatus.OPEN
+        assert requirement_open.sourcing_status == SourcingStatus.WON
 
-    def test_archived_is_terminal(self, client: TestClient, db_session: Session, requirement_open: Requirement):
+    def test_archived_reopens_to_open(self, client: TestClient, db_session: Session, requirement_open: Requirement):
+        """A requirement is re-openable: archived → open (un-archive) succeeds."""
         requirement_open.sourcing_status = SourcingStatus.ARCHIVED
         db_session.commit()
 
         resp = advance_status(client, requirement_open.id, SourcingStatus.OPEN)
+        assert resp.status_code == 200
+        db_session.refresh(requirement_open)
+        assert requirement_open.sourcing_status == SourcingStatus.OPEN
+
+
+class TestAdvanceStatusInvalid:
+    """Invalid transitions return 409."""
+
+    def test_won_to_sourcing_rejected(self, client: TestClient, db_session: Session, requirement_open: Requirement):
+        """Won only transitions to lost/archived — won → sourcing is illegal."""
+        requirement_open.sourcing_status = SourcingStatus.WON
+        db_session.commit()
+
+        resp = advance_status(client, requirement_open.id, SourcingStatus.SOURCING)
+        assert resp.status_code == 409
+        # Status should remain unchanged
+        db_session.refresh(requirement_open)
+        assert requirement_open.sourcing_status == SourcingStatus.WON
+
+    def test_archived_only_reopens_to_open(
+        self, client: TestClient, db_session: Session, requirement_open: Requirement
+    ):
+        """Archived only transitions to open — archived → sourcing is illegal."""
+        requirement_open.sourcing_status = SourcingStatus.ARCHIVED
+        db_session.commit()
+
+        resp = advance_status(client, requirement_open.id, SourcingStatus.SOURCING)
         assert resp.status_code == 409
 
 
@@ -98,7 +122,11 @@ class TestAdvanceStatusActivityLog:
     def test_no_activity_log_on_invalid_transition(
         self, client: TestClient, db_session: Session, requirement_open: Requirement
     ):
-        advance_status(client, requirement_open.id, SourcingStatus.WON)
+        # won → sourcing is illegal, so no status-change activity is logged.
+        requirement_open.sourcing_status = SourcingStatus.WON
+        db_session.commit()
+
+        advance_status(client, requirement_open.id, SourcingStatus.SOURCING)
 
         log_count = (
             db_session.query(ActivityLog)

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -3523,15 +3523,17 @@ class TestBatchStatus:
 
     def test_skips_invalid_transitions(self, client, db_session):
         _, r, _ = _seed_data(db_session)
-        # open -> won is NOT valid (must go open -> sourcing -> offered -> quoted -> won)
+        # won -> sourcing is NOT valid (won only transitions to lost/archived).
+        r.sourcing_status = "won"
+        db_session.commit()
         resp = client.post(
             "/v2/partials/sightings/batch-status",
-            data={"requirement_ids": json.dumps([r.id]), "status": "won"},
+            data={"requirement_ids": json.dumps([r.id]), "status": "sourcing"},
         )
         assert resp.status_code == 200
         assert "skipped" in resp.text.lower()
         db_session.refresh(r)
-        assert r.sourcing_status == "open"
+        assert r.sourcing_status == "won"
 
     def test_mixed_valid_and_invalid(self, client, db_session):
         req = Requisition(name="Mix RFQ", status="open", customer_name="Mix Corp")

--- a/tests/test_sightings_router_comprehensive.py
+++ b/tests/test_sightings_router_comprehensive.py
@@ -412,10 +412,11 @@ class TestAdvanceStatus:
         assert resp.status_code == 400
 
     def test_advance_invalid_transition_returns_409(self, client, db_session):
-        _, r, _ = _seed(db_session, sourcing_status="open")
+        # won only transitions to lost/archived — won → sourcing is illegal.
+        _, r, _ = _seed(db_session, sourcing_status="won")
         resp = client.patch(
             f"/v2/partials/sightings/{r.id}/advance-status",
-            data={"status": "won"},
+            data={"status": "sourcing"},
         )
         assert resp.status_code == 409
 

--- a/tests/test_web_extractor.py
+++ b/tests/test_web_extractor.py
@@ -12,6 +12,7 @@ Gates under test (enforced in Python, NOT trusted from LLM output):
   Plus: description/manufacturer quality check.
 """
 
+import dataclasses
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -78,6 +79,32 @@ async def test_claude_backend_error_propagates(mock_cj):
     mock_cj.side_effect = ClaudeRateLimitError("429")
     with pytest.raises(ClaudeError):
         await extract_part_from_web("LM317T", "lm317t")
+
+
+def test_web_extract_result_is_frozen():
+    """WebExtractResult must be frozen so the shared ``_FAILED`` singleton can't be
+    mutated in place — an aliasing footgun that would corrupt every future failure."""
+    from app.services.enrichment_worker.web_extractor import WebExtractResult
+
+    result = WebExtractResult(status="web_sourced", source_urls=["https://x.com"])
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        result.source_urls = ["https://evil.com"]  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        result.status = "failed"  # type: ignore[misc]
+
+
+def test_failed_singleton_cannot_be_mutated():
+    """The module-level ``_FAILED`` singleton is shared across all failure returns;
+    mutating any field on it must raise, not silently poison later results."""
+    from app.services.enrichment_worker.web_extractor import _FAILED
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _FAILED.status = "web_sourced"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _FAILED.confidence = 0.99  # type: ignore[misc]
+    # dataclasses.replace produces a new object, never touching the singleton.
+    assert dataclasses.replace(_FAILED, status="web_sourced") is not _FAILED
+    assert _FAILED.status == "failed"
 
 
 def test_prompt_constrains_category_to_canonical_vocabulary():

--- a/tests/test_workflow_state_clarity.py
+++ b/tests/test_workflow_state_clarity.py
@@ -223,13 +223,14 @@ class TestSourcingStatusTransitions:
     def test_offered_to_quoted_valid(self):
         assert validate_transition("requirement", "offered", "quoted") is True
 
-    def test_open_to_won_invalid(self):
-        """Skipping states should be rejected."""
-        assert validate_transition("requirement", "open", "won", raise_on_invalid=False) is False
+    def test_open_to_won_valid(self):
+        """Skip-ahead is legal: offers/quotes can arrive on a part with no prior
+        sourcing step, so open → won is a valid transition."""
+        assert validate_transition("requirement", "open", "won", raise_on_invalid=False) is True
 
-    def test_archived_is_terminal(self):
-        """No transitions from archived."""
-        assert validate_transition("requirement", "archived", "open", raise_on_invalid=False) is False
+    def test_archived_can_reopen(self):
+        """A requirement is re-openable: archived → open (un-archive) is valid."""
+        assert validate_transition("requirement", "archived", "open", raise_on_invalid=False) is True
 
     def test_noop_same_status_valid(self):
         assert validate_transition("requirement", "open", "open") is True


### PR DESCRIPTION
Phase 3 Batch A — 7 P2 correctness fixes. Each TDD'd + adversarially reviewed; the encryption, worker-kwargs, and knowledge fixes were **reworked after review** (the first attempts were band-aids or misdiagnoses — quality-gated).

- **Encryption bad-salt masking** — a wrong ENCRYPTION_SALT derives a valid-but-different Fernet key, so every EncryptedText field silently decrypted to None (all credentials read empty). The per-field decrypt can't distinguish wrong-key from legit plaintext, so added a boot-time **decrypt canary** in system_config that fails LOUD on mismatch.
- **OEMSecrets** `is_authorized` now defaults **False** on no signal (was True — overstated trust for a gray-market aggregator).
- **log_email_activity** routes `direction` through the shared `_normalize_direction` (was an open-string check silently bucketing 'outbound' as INBOUND).
- **update_enrichment_worker_status** rejects unknown column kwargs loudly (was a silent hasattr-drop no-op).
- **WebExtractResult** frozen to protect the shared `_FAILED` singleton (siblings were frozen; it wasn't).
- **Knowledge entries** — enforce creator-only update/delete (latent IDOR) + savepoint-isolate `capture_quote_fact` (was committing the caller's txn + poisoning it on failure).
- **Per-part sourcing state machine** — single source of truth (two divergent transition tables reconciled).

Full P2 ripple sweep (520 tests) + `pre-commit --all-files` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)