### PR TITLE
fix(buyplan): confirm_po allowed in INBOUND — resolve the deal-PO-first stall

### DIFF
--- a/app/services/buyplan_workflow.py
+++ b/app/services/buyplan_workflow.py
@@ -461,8 +461,12 @@ def confirm_po(
     plan = db.get(BuyPlan, plan_id)
     if not plan:
         raise ValueError(f"Buy plan {plan_id} not found")
-    if plan.status != BuyPlanStatus.ACTIVE.value:
-        raise ValueError(f"Plan must be active (current: {plan.status})")
+    # ACTIVE or INBOUND: over-threshold plans move ACTIVE→INBOUND when the deal-level PO
+    # gate is approved, but their lines can still be AWAITING_PO — the buyer must be able to
+    # record the individual line PO# in either state (else the deal-PO approval strands the
+    # AWAITING_PO lines with no way to confirm their POs).
+    if plan.status not in (BuyPlanStatus.ACTIVE.value, BuyPlanStatus.INBOUND.value):
+        raise ValueError(f"Plan must be active or inbound (current: {plan.status})")
 
     line = db.get(BuyPlanLine, line_id)
     if not line or line.buy_plan_id != plan_id:

--- a/tests/test_buyplan_workflow_bugs.py
+++ b/tests/test_buyplan_workflow_bugs.py
@@ -207,6 +207,26 @@ class TestCheckCompletionIdempotency:
         # The orphan is closed, not left REQUESTED in the approvals queue.
         assert po_req.status == ApprovalRequestStatus.CANCELLED
 
+    def test_confirm_po_allowed_when_plan_inbound(self, db_session):
+        """After the deal-level PO gate is approved (ACTIVE→INBOUND), an AWAITING_PO
+        line can still record its PO — else the deal-PO approval strands those lines."""
+        from datetime import datetime, timezone
+
+        from app.services.buyplan_workflow import confirm_po
+
+        plan, user = _make_plan_with_lines(
+            db_session,
+            status=BuyPlanStatus.INBOUND.value,
+            so_status=SOVerificationStatus.APPROVED.value,
+            line_statuses=[BuyPlanLineStatus.AWAITING_PO.value],
+        )
+        line = plan.lines[0]
+
+        result = confirm_po(plan.id, line.id, "PO-INB-1", datetime.now(timezone.utc), user, db_session)
+
+        assert result.status == BuyPlanLineStatus.PENDING_VERIFY.value
+        assert result.po_number == "PO-INB-1"
+
     def test_does_not_complete_without_so_approval(self, db_session):
         """Plan should NOT complete if SO is not yet approved."""
         plan, _ = _make_plan_with_lines(


### PR DESCRIPTION
Tracked follow-up to #602 (PO-approval reconciliation). When an over-threshold plan's deal-level PURCHASE_ORDER gate is approved, the plan moves ACTIVE→INBOUND — but `confirm_po` required ACTIVE, stranding any still-AWAITING_PO lines with no way to record their PO#s. Now `confirm_po` accepts ACTIVE **or** INBOUND. `verify_po` has no plan-status guard (unaffected); INBOUND completion still flows through `receive_buy_plan`. TDD'd; buy-plan workflow suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)