### PR TITLE
fix: 4 regressions from audit remediation (boot-hang + 3 data-integrity)

### DIFF
--- a/app/routers/htmx/companies.py
+++ b/app/routers/htmx/companies.py
@@ -1133,7 +1133,7 @@ async def create_company(
         hq_city=form.get("hq_city", "").strip() or None,
         hq_state=(normalize_us_state(raw_hq_state) or raw_hq_state) if raw_hq_state else None,
         hq_country=(normalize_country(raw_hq_country) or raw_hq_country) if raw_hq_country else None,
-        phone=normalize_phone_e164(raw_phone) if raw_phone else None,
+        phone=(normalize_phone_e164(raw_phone) or raw_phone) if raw_phone else None,
         credit_terms=form.get("credit_terms", "").strip() or None,
         tax_id=form.get("tax_id", "").strip() or None,
         source=form.get("source", "").strip() or "manual",
@@ -1657,7 +1657,7 @@ def apply_company_field(company: Company, field: str, value: str) -> None:
         raise HTTPException(404, f"Unknown editable field: {field!r}")
     v = value.strip()
     if field == "phone":
-        company.phone = normalize_phone_e164(v) if v else None
+        company.phone = (normalize_phone_e164(v) or v) if v else None
     elif field == "hq_state":
         company.hq_state = (normalize_us_state(v) or v) if v else None
     elif field == "hq_country":

--- a/app/schemas/crm.py
+++ b/app/schemas/crm.py
@@ -126,10 +126,14 @@ class CompanyCreate(BaseModel):
     def normalize_phone(cls, v: str | None) -> str | None:
         if v is None:
             return v
+        # Preserve the raw input when it can't be parsed to E.164 (e.g. a 7-digit local
+        # number) rather than 422-ing the whole company write — mirrors hq_state/hq_country
+        # here and the contact-phone path in routers/htmx/companies.py, which also fall
+        # back to raw. Empty/whitespace collapses to None.
         result = normalize_phone_e164(v)
-        if result is None:
-            raise ValueError(f"Could not parse phone number: {v}")
-        return result
+        if result:
+            return result
+        return v.strip() or None
 
 
 class CompanyUpdate(BaseModel):
@@ -171,10 +175,14 @@ class CompanyUpdate(BaseModel):
     def normalize_phone(cls, v: str | None) -> str | None:
         if v is None:
             return v
+        # Preserve the raw input when it can't be parsed to E.164 (e.g. a 7-digit local
+        # number) rather than 422-ing the whole company write — mirrors hq_state/hq_country
+        # here and the contact-phone path in routers/htmx/companies.py, which also fall
+        # back to raw. Empty/whitespace collapses to None.
         result = normalize_phone_e164(v)
-        if result is None:
-            raise ValueError(f"Could not parse phone number: {v}")
-        return result
+        if result:
+            return result
+        return v.strip() or None
 
 
 # ── Offers ───────────────────────────────────────────────────────────

--- a/app/services/knowledge_service.py
+++ b/app/services/knowledge_service.py
@@ -236,10 +236,11 @@ def capture_quote_fact(db: Session, *, quote, user_id: int) -> KnowledgeEntry | 
     """Auto-capture price facts when a quote is created.
 
     Uses a savepoint so a create failure doesn't corrupt the caller's transaction (the
-    quote it just created), and does NOT commit the caller's in-flight transaction — mirrors
-    capture_offer_fact (the old path called create_entry with the default commit=True and no
-    savepoint, so it both committed the caller's txn early and poisoned it on any failure).
-    Called from: app/routers/crm/quotes.py after quote creation.
+    quote it just created), then commits its own entry. Callers treat this as fire-and-
+    forget and several (create_quote, build_quote) return without a further commit, so
+    the capture MUST persist the entry itself or it rolls back at session close. Mirrors
+    capture_offer_fact. Called from: app/routers/crm/quotes.py and
+    app/services/quote_builder_service.py after quote creation.
     """
     nested = db.begin_nested()
     try:
@@ -278,18 +279,29 @@ def capture_quote_fact(db: Session, *, quote, user_id: int) -> KnowledgeEntry | 
             commit=False,
         )
         nested.commit()
-        return entry
     except Exception as e:
         nested.rollback()
         logger.warning("Failed to capture quote fact: {}", e)
         return None
+    # Persist the released savepoint. Kept OUTSIDE the savepoint block so a commit error
+    # can't roll back an already-released savepoint; the caller's own (already-committed)
+    # work is unaffected either way.
+    try:
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        logger.warning("Failed to persist quote fact: {}", e)
+        return None
+    return entry
 
 
 def capture_offer_fact(db: Session, *, offer, user_id: int | None = None) -> KnowledgeEntry | None:
     """Auto-capture facts when an offer is created (manual or parsed).
 
-    Uses a savepoint so FK failures don't corrupt the caller's transaction.
-    Called from: app/routers/crm/offers.py, app/email_service.py
+    Uses a savepoint so FK failures don't corrupt the caller's transaction, then commits
+    its own entry — callers treat this as fire-and-forget and don't reliably commit
+    afterward, so the capture must persist the entry itself or it rolls back at session
+    close. Called from: app/routers/crm/offers.py, app/email_service.py
     """
     nested = db.begin_nested()
     try:
@@ -330,11 +342,19 @@ def capture_offer_fact(db: Session, *, offer, user_id: int | None = None) -> Kno
             commit=False,
         )
         nested.commit()
-        return entry
     except Exception as e:
         nested.rollback()
         logger.warning("Failed to capture offer fact: {}", e)
         return None
+    # Persist the released savepoint (see capture_quote_fact — kept outside the savepoint
+    # block so a commit error can't roll back an already-released savepoint).
+    try:
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        logger.warning("Failed to persist offer fact: {}", e)
+        return None
+    return entry
 
 
 def capture_rfq_response_fact(

--- a/app/services/search_worker_base/queue_manager.py
+++ b/app/services/search_worker_base/queue_manager.py
@@ -21,6 +21,7 @@ from app.constants import RequisitionStatus
 from app.models import Requirement, Sighting
 from app.models.sourcing import Requisition
 from app.services.vendor_unavailability import apply_to_fresh_sightings
+from app.utils.normalization import normalize_mpn_key
 
 from .mpn_normalizer import strip_packaging_suffixes
 
@@ -154,21 +155,29 @@ class QueueManager:
         if recent:
             # Link existing sightings from the previous search to this requirement's material card
             if req.material_card_id and recent.requirement_id:
-                existing_sightings = (
-                    db.query(Sighting)
+                # Scope to the deduped MPN only. A requirement can have multiple
+                # queue rows (primary + resolved-AVL MPNs), so its sightings span
+                # several normalized MPNs; without scoping we'd clone the source
+                # requirement's OTHER MPNs' sightings onto THIS requirement.
+                # Compare on the canonical MPN KEY (normalize_mpn_key), NOT the raw
+                # column: sightings store strip_packaging_suffixes(the vendor's TYPED
+                # part number), which preserves internal dashes/dots, so a vendor who
+                # listed "ABC-123" for a search of "ABC123" would be dropped by raw
+                # equality. The key form collapses both to "abc123" — cloning
+                # punctuation variants of the SAME part while still excluding the
+                # requirement's other MPNs (whose keys differ). Filtered in Python
+                # because the stored column is the packaging-suffix form, not the key.
+                target_key = normalize_mpn_key(norm_mpn)
+                existing_sightings = [
+                    s
+                    for s in db.query(Sighting)
                     .filter(
                         Sighting.requirement_id == recent.requirement_id,
                         Sighting.source_type == self.source_type,
-                        # Scope to the deduped MPN only. A requirement can have
-                        # multiple queue rows (primary + resolved-AVL MPNs), so
-                        # its sightings span several normalized MPNs. Without
-                        # this filter we'd clone the source requirement's OTHER
-                        # MPNs' sightings onto THIS requirement, attributing
-                        # vendor offers for an MPN it never requested.
-                        Sighting.normalized_mpn == norm_mpn,
                     )
                     .all()
-                )
+                    if normalize_mpn_key(s.normalized_mpn) == target_key
+                ]
                 cloned_rows = []
                 for s in existing_sightings:
                     new_s = self._link_sighting(s, requirement_id, req.material_card_id, self.source_type)

--- a/app/startup.py
+++ b/app/startup.py
@@ -763,18 +763,24 @@ def _backfill_sighting_vendor_normalized() -> None:
             return  # Column not yet created
 
         total = 0
+        last_id = 0
         while True:
             try:
                 rows = conn.execute(
                     sqltext(
                         "SELECT id, vendor_name FROM sightings "
                         "WHERE vendor_name_normalized IS NULL AND vendor_name IS NOT NULL "
-                        "LIMIT :lim"
+                        "AND id > :last_id ORDER BY id LIMIT :lim"
                     ),
-                    {"lim": _BACKFILL_BATCH_SIZE},
+                    {"last_id": last_id, "lim": _BACKFILL_BATCH_SIZE},
                 ).fetchall()
                 if not rows:
                     break
+                # Advance the cursor past every row we examined. Rows whose vendor_name
+                # normalizes to '' (e.g. "LLC", "Inc.") never get an UPDATE, so filtering
+                # only on "IS NULL" would re-select them forever and hang startup; the
+                # id cursor skips them instead of looping on them.
+                last_id = rows[-1][0]
                 batch = []
                 for r in rows:
                     nv = normalize_vendor_name(r[1])
@@ -814,18 +820,24 @@ def _backfill_offer_vendor_normalized() -> None:
             return  # Column not yet created
 
         total = 0
+        last_id = 0
         while True:
             try:
                 rows = conn.execute(
                     sqltext(
                         "SELECT id, vendor_name FROM offers "
                         "WHERE vendor_name_normalized IS NULL AND vendor_name IS NOT NULL "
-                        "LIMIT :lim"
+                        "AND id > :last_id ORDER BY id LIMIT :lim"
                     ),
-                    {"lim": _BACKFILL_BATCH_SIZE},
+                    {"last_id": last_id, "lim": _BACKFILL_BATCH_SIZE},
                 ).fetchall()
                 if not rows:
                     break
+                # Advance the cursor past every row we examined. Rows whose vendor_name
+                # normalizes to '' (e.g. "LLC", "Inc.") never get an UPDATE, so filtering
+                # only on "IS NULL" would re-select them forever and hang startup; the
+                # id cursor skips them instead of looping on them.
+                last_id = rows[-1][0]
                 batch = []
                 for r in rows:
                     nv = normalize_vendor_name(r[1])

--- a/tests/test_knowledge_service_coverage.py
+++ b/tests/test_knowledge_service_coverage.py
@@ -289,6 +289,24 @@ class TestCaptureQuoteFact:
         result = knowledge_service.capture_quote_fact(db_session, quote=mock_quote, user_id=test_user.id)
         assert result is None
 
+    def test_quote_fact_survives_caller_rollback(self, db_session: Session, test_user: User, requisition: Requisition):
+        """Regression: create_quote/build_quote return WITHOUT committing after this call,
+        so the captured fact must be durably committed here — it must survive the caller
+        rolling back its transaction (pre-fix it was only flushed and vanished)."""
+        from app.models.knowledge import KnowledgeEntry
+
+        mock_quote = MagicMock()
+        mock_quote.quote_number = "Q-DURABLE-1"
+        mock_quote.requisition_id = requisition.id
+        mock_quote.line_items = [{"mpn": "LM317T", "unit_sell": 1.50, "qty": 100, "vendor_name": "Arrow"}]
+        entry = knowledge_service.capture_quote_fact(db_session, quote=mock_quote, user_id=test_user.id)
+        assert entry is not None
+
+        db_session.rollback()  # caller discards its own transaction without committing
+
+        surviving = db_session.query(KnowledgeEntry).filter(KnowledgeEntry.content.like("%Q-DURABLE-1%")).all()
+        assert len(surviving) == 1
+
 
 class TestCaptureOfferFact:
     def test_captures_offer(self, db_session: Session, test_user: User, requisition: Requisition):
@@ -316,6 +334,30 @@ class TestCaptureOfferFact:
         mock_offer.requisition_id = None
         result = knowledge_service.capture_offer_fact(db_session, offer=mock_offer)
         assert result is None
+
+    def test_offer_fact_survives_caller_rollback(self, db_session: Session, test_user: User, requisition: Requisition):
+        """Regression: offer callers don't reliably commit after this call, so the fact
+        must be durably committed here — it must survive a caller rollback."""
+        from types import SimpleNamespace
+
+        from app.models.knowledge import KnowledgeEntry
+
+        offer = SimpleNamespace(
+            mpn="LM317T-DURABLE",
+            unit_price=0.75,
+            quantity=500,
+            vendor_name="Arrow",
+            lead_time=None,
+            vendor_card_id=None,
+            requisition_id=requisition.id,
+        )
+        entry = knowledge_service.capture_offer_fact(db_session, offer=offer, user_id=test_user.id)
+        assert entry is not None
+
+        db_session.rollback()
+
+        surviving = db_session.query(KnowledgeEntry).filter(KnowledgeEntry.mpn == "LM317T-DURABLE").all()
+        assert len(surviving) == 1
 
 
 class TestCaptureRfqResponseFact:

--- a/tests/test_queue_manager_dedup_mpn_scope.py
+++ b/tests/test_queue_manager_dedup_mpn_scope.py
@@ -102,3 +102,58 @@ def test_dedup_clones_only_matching_mpn_sightings(db_session, requisition):
     assert len(cloned) == 1
     assert cloned[0].normalized_mpn == _DEDUP_MPN
     assert {s.normalized_mpn for s in cloned} == {_DEDUP_MPN}
+
+
+def test_dedup_clones_punctuation_variant_of_searched_mpn(db_session, requisition):
+    """A vendor who listed the SAME part with internal punctuation ("ABC-123") for a
+    search of "ABC123" must still clone onto the deduped requirement — matched by the
+    canonical MPN key, not raw equality (sightings store the vendor's typed PN, which
+    keeps the dash).
+
+    A genuinely different MPN stays excluded.
+    """
+    search_mpn = "ABC123"
+    variant_mpn = "ABC-123"  # strip_packaging_suffixes preserves the internal dash
+
+    req_a = Requirement(
+        requisition_id=requisition.id,
+        primary_mpn=search_mpn,
+        target_qty=100,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req_a)
+    db_session.flush()
+
+    completed = IcsSearchQueue(
+        requirement_id=req_a.id,
+        requisition_id=requisition.id,
+        mpn=search_mpn,
+        normalized_mpn=search_mpn,
+        status="completed",
+        last_searched_at=datetime.now(timezone.utc),
+    )
+    db_session.add(completed)
+
+    # A's sightings: the same part typed with a dash, plus a genuinely unrelated MPN.
+    db_session.add(_make_sighting(req_a.id, variant_mpn, "VendorVariant"))
+    db_session.add(_make_sighting(req_a.id, _OTHER_MPN, "VendorOther"))
+
+    card = MaterialCard(normalized_mpn=search_mpn.lower(), display_mpn=search_mpn)
+    db_session.add(card)
+    db_session.flush()
+    req_b = Requirement(
+        requisition_id=requisition.id,
+        primary_mpn=search_mpn,
+        material_card_id=card.id,
+        target_qty=50,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req_b)
+    db_session.commit()
+
+    result = enqueue_for_ics_search(req_b.id, db_session)
+    assert result is None  # deduped, no new queue row
+
+    cloned = db_session.query(Sighting).filter(Sighting.requirement_id == req_b.id).all()
+    # The punctuation variant IS the same part → cloned; the unrelated MPN stays out.
+    assert {s.normalized_mpn for s in cloned} == {variant_mpn}

--- a/tests/test_schemas_crm.py
+++ b/tests/test_schemas_crm.py
@@ -170,6 +170,16 @@ class TestCompanyCreatePhone:
         assert c.phone is not None
         assert c.phone.startswith("+")
 
+    def test_phone_local_number_preserved_not_rejected(self) -> None:
+        """Regression: a 7-digit local number can't be parsed to E.164, but the write must
+        NOT 422 — the raw input is preserved (mirrors hq_state/hq_country fallback)."""
+        c = CompanyCreate(name="Acme", phone="555-1234")
+        assert c.phone == "555-1234"
+
+    def test_phone_blank_collapses_to_none(self) -> None:
+        c = CompanyCreate(name="Acme", phone="   ")
+        assert c.phone is None
+
 
 # ── CompanyCreate hq normalization (parity with CompanyUpdate) ──────
 
@@ -217,6 +227,11 @@ class TestCompanyUpdateValidators:
         u = CompanyUpdate(phone="(555) 123-4567")
         assert u.phone is not None
         assert u.phone.startswith("+")
+
+    def test_phone_local_number_preserved_not_rejected(self) -> None:
+        """Regression: an un-parseable local number is preserved, not 422'd."""
+        u = CompanyUpdate(phone="555-1234")
+        assert u.phone == "555-1234"
 
 
 # ── OfferCreate validators ─────────────────────────────────────────

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1011,6 +1011,39 @@ class TestBackfillSightingVendorNormalized:
             r2 = conn.execute(sqltext("SELECT vendor_name_normalized FROM sightings WHERE id = 2")).fetchone()
             assert r2[0] == "beta corp"
 
+    def test_empty_normalizing_row_does_not_hang(self):
+        """Regression: a legacy row whose vendor_name normalizes to '' (e.g. 'LLC') must
+        NOT spin the backfill forever. The id cursor skips it and still processes the
+        rest — no stop-loop exception hack needed (the pre-fix loop re-selected the
+        never-updatable row endlessly and hung startup)."""
+        from app.startup import _backfill_sighting_vendor_normalized
+
+        eng = _make_sqlite_engine()
+        with eng.connect() as conn:
+            conn.execute(sqltext(_CREATE_VENDOR_SIGHTINGS))
+            # id=1 normalizes to '' → never updatable; id=2 is a real vendor at a higher id.
+            conn.execute(
+                sqltext("INSERT INTO sightings (id, vendor_name, vendor_name_normalized) VALUES (1, 'LLC', NULL)")
+            )
+            conn.execute(
+                sqltext("INSERT INTO sightings (id, vendor_name, vendor_name_normalized) VALUES (2, 'Arrow', NULL)")
+            )
+            conn.commit()
+
+        with (
+            patch("app.startup.engine", eng),
+            patch(
+                "app.vendor_utils.normalize_vendor_name", side_effect=lambda n: "" if n == "LLC" else n.lower().strip()
+            ),
+        ):
+            _backfill_sighting_vendor_normalized()  # must TERMINATE (would hang pre-fix)
+
+        with eng.connect() as conn:
+            r1 = conn.execute(sqltext("SELECT vendor_name_normalized FROM sightings WHERE id = 1")).fetchone()
+            assert r1[0] is None  # junk row skipped, stays NULL
+            r2 = conn.execute(sqltext("SELECT vendor_name_normalized FROM sightings WHERE id = 2")).fetchone()
+            assert r2[0] == "arrow"  # loop advanced past the junk and processed the rest
+
 
 class TestBackfillOfferVendorNormalized:
     """_backfill_offer_vendor_normalized logic (offers tab matches on the normalized
@@ -1057,6 +1090,37 @@ class TestBackfillOfferVendorNormalized:
 
         with patch("app.startup.engine", eng):
             _backfill_offer_vendor_normalized()  # no raise
+
+    def test_empty_normalizing_row_does_not_hang(self):
+        """Regression: an offer whose vendor_name normalizes to '' (e.g. 'LLC') must NOT
+        spin the backfill forever. The id cursor skips it and still processes the rest —
+        the pre-fix loop re-selected the never-updatable row endlessly and hung startup."""
+        from app.startup import _backfill_offer_vendor_normalized
+
+        eng = _make_sqlite_engine()
+        with eng.connect() as conn:
+            conn.execute(sqltext(self._CREATE))
+            conn.execute(
+                sqltext("INSERT INTO offers (id, vendor_name, vendor_name_normalized) VALUES (1, 'LLC', NULL)")
+            )
+            conn.execute(
+                sqltext("INSERT INTO offers (id, vendor_name, vendor_name_normalized) VALUES (2, 'Arrow', NULL)")
+            )
+            conn.commit()
+
+        with (
+            patch("app.startup.engine", eng),
+            patch(
+                "app.vendor_utils.normalize_vendor_name", side_effect=lambda n: "" if n == "LLC" else n.lower().strip()
+            ),
+        ):
+            _backfill_offer_vendor_normalized()  # must TERMINATE (would hang pre-fix)
+
+        with eng.connect() as conn:
+            r1 = conn.execute(sqltext("SELECT vendor_name_normalized FROM offers WHERE id = 1")).fetchone()
+            assert r1[0] is None  # junk row skipped, stays NULL
+            r2 = conn.execute(sqltext("SELECT vendor_name_normalized FROM offers WHERE id = 2")).fetchone()
+            assert r2[0] == "arrow"  # loop advanced past the junk and processed the rest
 
 
 class TestBackfillMaterialCards:


### PR DESCRIPTION
## Why

The post-remediation **adversarial regression review** (diff `b21e62d8..main`, 25 agents) surfaced 4 real regressions the audit remediation introduced. Each was re-verified against live code and fixed **root-cause with TDD**. (2 further candidates were adversarially refuted and dropped.)

## Fixes

### 🔴 HIGH — startup boot-hang
`_backfill_sighting_vendor_normalized` **and** `_backfill_offer_vendor_normalized` looped `while True` **forever** whenever any legacy `vendor_name` normalizes to `''` (e.g. `"LLC"`, `"Inc."`, punctuation-only). Such a row never gets an `UPDATE`, so a `WHERE vendor_name_normalized IS NULL` filter re-selects it every iteration and **startup never finishes**. Both run on every non-`TESTING` boot.
- **Fix:** paginate by an `id > :last_id` cursor so examined-but-unupdatable rows are skipped, not re-selected.
- An existing test (`test_normalize_returns_empty_skips_row`) masked this by forcing a `RuntimeError("stop loop")` on the 2nd iteration. Added clean regression tests that **terminate naturally** (they would hang→timeout on the old code).

### 🟠 MED — cross-req dedup dropped same-part vendor offers
Sightings store `strip_packaging_suffixes(the vendor's typed PN)` (preserves internal `-`/`.`), but the clone filter compared that column `== strip(searched MPN)`. A vendor who listed `"ABC-123"` for a search of `"ABC123"` was silently dropped from the deduped clone.
- **Fix:** compare on the canonical `normalize_mpn_key` (`"abc123"`), which matches punctuation variants of the same part while still excluding the requirement's OTHER (resolved-AVL) MPNs.

### 🟠 MED — auto-captured quote price facts silently lost
`capture_quote_fact` flushed the `KnowledgeEntry` into a savepoint but never committed; callers (`create_quote`, `create_quote`/`build_quote`) return without committing, so the entry **rolled back at session close**. (Offer path was fragile for the same reason — only conditional commits after.)
- **Fix:** `capture_quote_fact` and `capture_offer_fact` durably commit their own entry; the savepoint still isolates create failures from the caller's transaction.

### 🟠 MED — 7–9 digit company phones rejected
The canonical `format_phone_e164` correctly returns `None` for sub-10-digit partials — but `CompanyCreate/Update` then raised → **HTTP 422**, and the htmx create/edit paths stored **NULL** (silent data loss).
- **Fix:** preserve the raw input (`normalize_phone_e164(v) or v`), matching the contact-phone path already at `companies.py:1744` and the `hq_state`/`hq_country` fallbacks.

## Tests
- Regression tests added for all 4 (boot-hang termination ×2, punctuation-variant clone, fact-survives-caller-rollback ×2, local-phone-preserved ×2).
- **Full suite: 21,716 passed, 18 skipped.** `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)