### PR TITLE
fix(buyplan): resolve ISSUE-line dead-end + surface silent no-approver stalls

### DIFF
--- a/app/routers/htmx/buy_plans.py
+++ b/app/routers/htmx/buy_plans.py
@@ -476,6 +476,8 @@ async def buy_plan_detail_partial(
         ],
     )
 
+    from ...services.buyplan_workflow import plan_needs_approver_reason
+
     ctx = _base_ctx(request, user, "buy-plans")
     ctx.update(
         {
@@ -483,9 +485,13 @@ async def buy_plan_detail_partial(
             "lines": bp.lines or [],
             "is_ops_member": _is_ops_member(user, db),
             "can_resource": _can_resource(user),
+            # Supervisors/ops resolve flagged-issue lines (the buyer who raised them can't).
+            "can_supervise": _can_supervise(user, db),
             "user": user,
             # Most-urgent flag reason so the indicator states the issue at first glance.
             "top_flag": summarize_top_flag(bp.ai_flags),
+            # Why the plan is silently stalled for lack of a configured approver (or None).
+            "no_approver_reason": plan_needs_approver_reason(bp, db),
         }
     )
     return template_response("htmx/partials/buy_plans/detail.html", ctx)
@@ -904,6 +910,34 @@ async def buy_plan_flag_issue_partial(
     try:
         flag_line_issue(plan_id, line_id, issue_type, user, db, note=note)
         db.commit()
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+    return await buy_plan_detail_partial(request, plan_id, user, db)
+
+
+@router.post("/v2/partials/buy-plans/{plan_id}/lines/{line_id}/resolve-issue", response_class=HTMLResponse)
+async def buy_plan_resolve_issue_partial(
+    request: Request,
+    plan_id: int,
+    line_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Supervisor clears a flagged issue → line back to awaiting_po.
+
+    Returns refreshed detail.
+    """
+    from ...services.buyplan_workflow import resolve_line_issue
+
+    # Per-record ownership: non-owner SALES/TRADER → 404 before any mutation.
+    get_buyplan_for_user(db, user, plan_id)
+
+    try:
+        resolve_line_issue(plan_id, line_id, user, db)
+        db.commit()
+    except PermissionError as e:
+        raise HTTPException(403, str(e))
     except ValueError as e:
         raise HTTPException(400, str(e))
 

--- a/app/services/approvals/routing.py
+++ b/app/services/approvals/routing.py
@@ -35,6 +35,51 @@ class NoEligibleApproverError(Exception):
     """Raised when no active, amount-eligible approver exists for the gate."""
 
 
+def _eligible_approvers(db: Session, gate: str, amount) -> list[User]:
+    """Active users eligible to approve *gate* for *amount* (per-gate per-user toggles).
+
+    The single source of truth for approver eligibility, shared by ``route_request`` (which
+    creates the recipients) and ``has_eligible_approver`` (which only asks whether any exist).
+    Amount-limited gates (prepayment, purchase_order) filter their NULL-means-unlimited limit
+    in Python.
+    """
+    if gate == ApprovalGateType.BUY_PLAN:
+        return db.query(User).filter(User.is_active.is_(True), User.can_approve_buy_plans.is_(True)).all()
+    if gate == ApprovalGateType.PREPAYMENT:
+        candidates = db.query(User).filter(User.is_active.is_(True), User.can_approve_prepayments.is_(True)).all()
+        return [
+            u
+            for u in candidates
+            if u.prepayment_approval_limit is None or (amount is not None and amount <= u.prepayment_approval_limit)
+        ]
+    if gate == ApprovalGateType.QP_SALES:
+        return db.query(User).filter(User.is_active.is_(True), User.can_approve_qp_sales.is_(True)).all()
+    if gate == ApprovalGateType.QP_PURCHASING:
+        return db.query(User).filter(User.is_active.is_(True), User.can_approve_qp_purchasing.is_(True)).all()
+    if gate == ApprovalGateType.PURCHASE_ORDER:
+        candidates = db.query(User).filter(User.is_active.is_(True), User.can_approve_purchase_orders.is_(True)).all()
+        return [
+            u
+            for u in candidates
+            if u.purchase_order_approval_limit is None
+            or (amount is not None and amount <= u.purchase_order_approval_limit)
+        ]
+    raise NoEligibleApproverError(f"No routing rule defined for gate={gate!r}")
+
+
+def has_eligible_approver(db: Session, gate: ApprovalGateType, amount=None) -> bool:
+    """True if at least one active user can approve *gate* for *amount*.
+
+    Read-only counterpart to ``route_request``'s eligibility. Used to detect (and surface in
+    the UI) a plan that will silently stall because no approver is configured for its open
+    gate — otherwise ``NoEligibleApproverError`` is only logged and the plan sits invisibly.
+    """
+    try:
+        return bool(_eligible_approvers(db, gate, amount))
+    except NoEligibleApproverError:
+        return False
+
+
 def route_request(db: Session, request: ApprovalRequest) -> ApprovalStep:
     """Create one ApprovalStep + one ApprovalStepRecipient per eligible approver.
 
@@ -55,82 +100,7 @@ def route_request(db: Session, request: ApprovalRequest) -> ApprovalStep:
         NoEligibleApproverError: If zero eligible users exist for the gate.
     """
     gate = request.gate_type
-
-    if gate == ApprovalGateType.BUY_PLAN:
-        candidates = (
-            db.query(User)
-            .filter(
-                User.is_active.is_(True),
-                User.can_approve_buy_plans.is_(True),
-            )
-            .all()
-        )
-        # No amount check for buy_plan gate
-        eligible = candidates
-
-    elif gate == ApprovalGateType.PREPAYMENT:
-        candidates = (
-            db.query(User)
-            .filter(
-                User.is_active.is_(True),
-                User.can_approve_prepayments.is_(True),
-            )
-            .all()
-        )
-        # Filter in Python to handle NULL limit (unlimited) vs capped limit
-        amount = request.amount
-        eligible = [
-            u
-            for u in candidates
-            if u.prepayment_approval_limit is None or (amount is not None and amount <= u.prepayment_approval_limit)
-        ]
-
-    elif gate == ApprovalGateType.QP_SALES:
-        # QP Sales section: route to every active user holding can_approve_qp_sales.
-        # No amount check (the section gate approves the section, not a spend).
-        eligible = (
-            db.query(User)
-            .filter(
-                User.is_active.is_(True),
-                User.can_approve_qp_sales.is_(True),
-            )
-            .all()
-        )
-
-    elif gate == ApprovalGateType.QP_PURCHASING:
-        # QP Purchasing section: route to every active user holding can_approve_qp_purchasing.
-        # No amount check (the section gate approves the section, not a spend).
-        eligible = (
-            db.query(User)
-            .filter(
-                User.is_active.is_(True),
-                User.can_approve_qp_purchasing.is_(True),
-            )
-            .all()
-        )
-
-    elif gate == ApprovalGateType.PURCHASE_ORDER:
-        # Deal-level PO gate: route to active can_approve_purchase_orders holders, filtered
-        # by their optional dollar limit (mirrors the prepayment amount-filter exactly).
-        candidates = (
-            db.query(User)
-            .filter(
-                User.is_active.is_(True),
-                User.can_approve_purchase_orders.is_(True),
-            )
-            .all()
-        )
-        amount = request.amount
-        eligible = [
-            u
-            for u in candidates
-            if u.purchase_order_approval_limit is None
-            or (amount is not None and amount <= u.purchase_order_approval_limit)
-        ]
-
-    else:
-        raise NoEligibleApproverError(f"No routing rule defined for gate={gate!r}")
-
+    eligible = _eligible_approvers(db, gate, request.amount)
     if not eligible:
         raise NoEligibleApproverError(f"No eligible approver for gate={gate!r} amount={request.amount}")
 

--- a/app/services/buyplan_hub.py
+++ b/app/services/buyplan_hub.py
@@ -1062,6 +1062,7 @@ class QueueRow:
 #: queue sorts by ``(priority, -age_hours)`` — risk-first, oldest-first within each tier.
 _QUEUE_PRIORITY: dict[str, int] = {
     "halted": 1,
+    "no_approver": 2,
     "plan_returned": 2,
     "flagged": 2,
     "plan_approve": 3,
@@ -1077,6 +1078,7 @@ _QUEUE_PRIORITY: dict[str, int] = {
 #: Short uppercase microlabel shown in the row's KIND column.
 _QUEUE_LABEL: dict[str, str] = {
     "halted": "Halted",
+    "no_approver": "No approver",
     "plan_returned": "Returned",
     "flagged": "Flagged",
     "plan_approve": "Approve",
@@ -1092,6 +1094,7 @@ _QUEUE_LABEL: dict[str, str] = {
 #: Primary action-button verb per kind (the right-rail CTA).
 _QUEUE_ACTION_LABEL: dict[str, str] = {
     "halted": "Open",
+    "no_approver": "Open",
     "plan_returned": "Resubmit",
     "flagged": "Open",
     "plan_approve": "Approve",
@@ -1327,6 +1330,46 @@ def _prepay_rows(db: Session, user: object) -> list[QueueRow]:
     return rows
 
 
+def _query_stuck_no_approver_plans(db: Session, *, owner_id: int | None = None) -> list[BuyPlan]:
+    """Plans silently stalled because no approver is configured for their open gate.
+
+    Emitted only in the rare, config-level case that no active user holds the approving
+    right (otherwise the plan is merely awaiting a real approver). ``owner_id`` scopes to a
+    single AM (my_queue); ``None`` returns every stuck plan (admins, so they can fix the
+    config). BUY_PLAN eligibility is global — one check gates every PENDING plan — while
+    PURCHASE_ORDER is amount-sensitive, so each over-threshold ACTIVE plan is checked against
+    its own total.
+    """
+    from ..config import settings
+    from ..constants import ApprovalGateType
+    from .approvals.routing import has_eligible_approver
+
+    loads = (
+        *_PLAN_CUSTOMER_LOADS,
+        joinedload(BuyPlan.submitted_by),
+        selectinload(BuyPlan.lines).selectinload(BuyPlanLine.requirement),
+    )
+    out: list[BuyPlan] = []
+
+    if not has_eligible_approver(db, ApprovalGateType.BUY_PLAN):
+        q = db.query(BuyPlan).filter(BuyPlan.status == BuyPlanStatus.PENDING)
+        if owner_id is not None:
+            q = q.filter(BuyPlan.submitted_by_id == owner_id)
+        out += q.options(*loads).order_by(BuyPlan.created_at.asc()).all()
+
+    q = db.query(BuyPlan).filter(
+        BuyPlan.status == BuyPlanStatus.ACTIVE,
+        BuyPlan.total_cost >= settings.po_auto_approve_threshold,
+    )
+    if owner_id is not None:
+        q = q.filter(BuyPlan.submitted_by_id == owner_id)
+    for plan in q.options(*loads).order_by(BuyPlan.created_at.asc()).all():
+        if not has_eligible_approver(db, ApprovalGateType.PURCHASE_ORDER, plan.total_cost):
+            out.append(plan)
+
+    return out
+
+
 def my_queue(db: Session, user: object) -> list[QueueRow]:
     """Return the role-aware "what needs YOU now" queue for *user*, risk-first.
 
@@ -1361,6 +1404,16 @@ def my_queue(db: Session, user: object) -> list[QueueRow]:
     # halted (P1): own plans always; supervisors see the whole risk surface.
     halted = _query_halted_plans(db) if is_supervisor else _query_halted_plans(db, owner_id=user.id)
     rows += [_make_plan_row(p, kind="halted", since=p.halted_at or p.created_at) for p in halted]
+
+    # no_approver (P2): plans stalled because no approver is configured for the open gate.
+    # Owner-scoped — a submitted plan leaves the AM's draft queue and no approver exists to
+    # see it, so without this the owner has NO signal at all; admins see every stuck plan so
+    # they can fix the config (grant someone the approving right).
+    stuck_owner = None if user.role == UserRole.ADMIN else user.id
+    rows += [
+        _make_plan_row(p, kind="no_approver", since=p.submitted_at or p.created_at)
+        for p in _query_stuck_no_approver_plans(db, owner_id=stuck_owner)
+    ]
 
     # plan_returned (P2) + plan_draft (P9): the user's own DRAFT plans.
     for plan in _query_owner_draft_plans(db, owner_id=user.id):

--- a/app/services/buyplan_workflow.py
+++ b/app/services/buyplan_workflow.py
@@ -782,6 +782,70 @@ def flag_line_issue(
     return line
 
 
+def resolve_line_issue(plan_id: int, line_id: int, user: User, db: Session) -> BuyPlanLine:
+    """Clear a flagged issue on a line, returning it to awaiting_po so the buyer can re-
+    cut.
+
+    The counterpart to :func:`flag_line_issue`. Without it an ISSUE line was a dead-end — the
+    UI showed only a badge and re-source rejects the ISSUE status, so the only escape was
+    halting the whole plan. Flagged lines route to supervisors on the My Queue (the buyer who
+    raised the issue can't self-resolve), so this action carries the same supervisor/ops
+    authority as :func:`halt_plan`. The PO-confirmation fields are cleared alongside the issue
+    so ``awaiting_po`` means what it always means (no confirmed PO); the buyer re-confirms.
+    """
+    plan = db.get(BuyPlan, plan_id)
+    if not plan:
+        raise ValueError(f"Buy plan {plan_id} not found")
+    if plan.status != BuyPlanStatus.ACTIVE.value:
+        raise ValueError(f"Plan must be active (current: {plan.status})")
+
+    if not _can_halt(user, db):
+        raise PermissionError("Only a supervisor or ops member can resolve a flagged issue")
+
+    line = db.get(BuyPlanLine, line_id)
+    if not line or line.buy_plan_id != plan_id:
+        raise ValueError(f"Line {line_id} not found in plan {plan_id}")
+    if line.status != BuyPlanLineStatus.ISSUE.value:
+        raise ValueError(f"Line has no issue to resolve (current: {line.status})")
+
+    line.status = BuyPlanLineStatus.AWAITING_PO.value
+    line.issue_type = None
+    line.issue_note = None
+    line.po_number = None
+    line.estimated_ship_date = None
+    line.po_confirmed_at = None
+    line.last_nudge_at = None
+    logger.info("Issue resolved on line {} (plan {}) by {}", line_id, plan_id, user.email)
+
+    db.flush()
+    return line
+
+
+def plan_needs_approver_reason(plan: BuyPlan, db: Session) -> str | None:
+    """Why *plan* is stalled for lack of a configured approver, else ``None``.
+
+    A submitted plan stalls silently when no active user holds the approving right for its
+    open gate: ``create_request`` raises ``NoEligibleApproverError``, which is only logged,
+    and the plan sits invisibly (the owner no longer sees a PENDING plan and no approver
+    exists to see it). This read-only check lets the UI surface it instead. Returns
+    ``"buy_plan"`` (PENDING, no buy-plan approver) or ``"purchase_order"`` (ACTIVE over the
+    PO threshold, no approver within the required limit), else ``None``.
+    """
+    from ..constants import ApprovalGateType
+    from .approvals.routing import has_eligible_approver
+
+    if plan.status == BuyPlanStatus.PENDING.value:
+        if not has_eligible_approver(db, ApprovalGateType.BUY_PLAN):
+            return "buy_plan"
+    elif plan.status == BuyPlanStatus.ACTIVE.value:
+        total = float(plan.total_cost or 0)
+        if total >= settings.po_auto_approve_threshold and not has_eligible_approver(
+            db, ApprovalGateType.PURCHASE_ORDER, plan.total_cost
+        ):
+            return "purchase_order"
+    return None
+
+
 # ── Workflow: Completion ─────────────────────────────────────────────
 
 

--- a/app/templates/htmx/partials/approvals/_surface_my_queue.html
+++ b/app/templates/htmx/partials/approvals/_surface_my_queue.html
@@ -28,6 +28,7 @@
    po_verify into "verify" (mirrors the spec's Verify-SO+PO collapse). Rows x-show on it. #}
 {% set band_of = {
   'halted': 'risk', 'plan_returned': 'risk', 'flagged': 'risk', 'cut_po_overdue': 'risk',
+  'no_approver': 'risk',
   'plan_approve': 'decide', 'prepay_approve': 'decide',
   'po_verify': 'routine', 'claim': 'routine', 'cut_po': 'routine',
   'receive': 'routine', 'plan_draft': 'routine'
@@ -36,6 +37,7 @@
 {% set label_color_of = {'risk': 'text-rose-600', 'decide': 'text-accent-600', 'routine': 'text-brand-500'} %}
 {% set token_of = {
   'halted': 'halted', 'plan_returned': 'returned', 'flagged': 'flagged', 'cut_po_overdue': 'overdue',
+  'no_approver': 'halted',
   'plan_approve': 'approve', 'prepay_approve': 'approve', 'po_verify': 'verify',
   'claim': 'claim', 'cut_po': 'cut_po', 'receive': 'receive', 'plan_draft': 'draft'
 } %}

--- a/app/templates/htmx/partials/buy_plans/_detail_action_banner.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_action_banner.html
@@ -8,6 +8,25 @@
 #}
   {# ═══ 3. ROLE-AWARE ACTION BANNER ═══ #}
 
+  {# Stalled: no approver is configured for the open gate. Without this the plan sits
+     invisibly (the owner no longer sees a PENDING plan and no approver exists to see it).
+     Informational only — deliberately NOT part of has_action_banner, so the owner can
+     still Cancel/Reset a stuck plan. #}
+  {% if no_approver_reason %}
+  <div class="mb-4 bg-amber-50 border border-amber-300 rounded-lg px-4 py-3 flex items-center gap-3">
+    <svg class="flex-shrink-0 w-5 h-5 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+    </svg>
+    <span class="text-sm text-amber-800">
+      {% if no_approver_reason == 'purchase_order' %}
+      This deal is over the PO-approval threshold but <strong>no purchase-order approver is configured</strong> (or none can approve this amount), so it can't advance. Ask an admin to grant purchase-order approval rights.
+      {% else %}
+      This plan is awaiting approval but <strong>no buy-plan approver is configured</strong>, so it can't advance. Ask an admin to grant buy-plan approval rights.
+      {% endif %}
+    </span>
+  </div>
+  {% endif %}
+
   {# Buyer: lines awaiting PO assigned to them #}
   {% if show_buyer_banner %}
   <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center gap-3">

--- a/app/templates/htmx/partials/buy_plans/_detail_lines.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_lines.html
@@ -135,6 +135,17 @@
                   </span>
                 {% elif line.status == 'issue' %}
                   <span class="text-xs text-rose-600 font-medium">{{ line.issue_type|replace('_', ' ')|capitalize if line.issue_type else 'Issue' }}</span>
+                  {# Supervisors/ops clear a flagged issue → line back to awaiting_po (the buyer
+                     who raised it can't self-resolve; otherwise ISSUE is a dead-end). #}
+                  {% if can_supervise %}
+                  <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/lines/{{ line.id }}/resolve-issue"
+                          hx-target="#main-content" hx-swap="innerHTML"
+                          hx-confirm="Clear this issue and return the line to awaiting PO?"
+                          data-loading-disable
+                          class="btn btn-primary btn-sm ml-2">
+                    Resolve
+                  </button>
+                  {% endif %}
                 {% endif %}
               {% endif %}
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1361,6 +1361,11 @@ buyplan_workflow.py (state machine)
     |
     |  Per-line (active):  awaiting_po --confirm_po--> pending_verify --verify_po(PO approver)--> verified
     |  Re-source (§6e):    pending_verify|verified --resource_line--> resourcing --claim_line--> awaiting_po
+    |  Flag/Resolve issue: flag_line_issue: awaiting_po|pending_verify --> issue (buyer). resolve_line_issue:
+    |                      issue --> awaiting_po (clears issue + PO-confirm fields), POST .../lines/{id}/resolve-issue,
+    |                      _can_halt-gated (supervisor/ops) — the buyer who raised it can't self-resolve, so
+    |                      flagged lines route to the supervisor My Queue "flagged" kind. Without resolve, ISSUE
+    |                      was a dead-end (badge only; resource_line rejects it).
     |  SO fold (Phase D):  the single manager approval IS the SO sign-off — _run_approve_side_effects
     |                      stamps so_status=approved + so_verified_by/at at approval time; there is no
     |                      separate verify-SO step (route/modal/queue-kind retired). sales_order_number
@@ -1374,6 +1379,10 @@ buyplan_workflow.py (state machine)
     |                      can_approve_purchase_orders right — the POST route depends on
     |                      require_buyplan_po_approver (403 otherwise), verify_po re-checks the predicate,
     |                      and detail hides the controls via the can_approve_purchase_orders Jinja global.
+    |  No-approver stall:  a plan whose open gate has NO configured approver (routing.has_eligible_approver
+    |                      False — otherwise NoEligibleApproverError is only logged) is surfaced, not left
+    |                      invisible: buyplan_workflow.plan_needs_approver_reason drives an amber detail banner,
+    |                      and my_queue emits a "no_approver" kind to the owner (+ admins) so the stall is seen.
     |  Ops group:          VerificationGroupMember (Settings > Ops Group; seeded from ADMIN_EMAILS) now
     |                      authorizes Halt + was the grandfather basis for can_approve_purchase_orders
     |                      (migration 173). admin/buy_plan_ops.toggle_ops_member guards the toggle: it

--- a/tests/test_approval_routing.py
+++ b/tests/test_approval_routing.py
@@ -16,7 +16,7 @@ import pytest
 from app.constants import ApprovalGateType, ApprovalRecipientStatus, ApprovalStepRule
 from app.models.approvals import ApprovalRequest, ApprovalStep
 from app.models.auth import User
-from app.services.approvals.routing import NoEligibleApproverError, route_request
+from app.services.approvals.routing import NoEligibleApproverError, has_eligible_approver, route_request
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -184,3 +184,38 @@ def test_step_linked_to_request(db_session, prepayment_approvers):
 
     assert step.request_id == req.id
     assert isinstance(step, ApprovalStep)
+
+
+class TestHasEligibleApprover:
+    """has_eligible_approver mirrors route_request's eligibility without creating a step
+    — used to detect (and surface) a plan that would silently stall for lack of an
+    approver."""
+
+    def test_true_when_active_buy_plan_approver_exists(self, db_session):
+        db_session.add(User(email="a@trioscs.com", name="A", is_active=True, can_approve_buy_plans=True))
+        db_session.flush()
+        assert has_eligible_approver(db_session, ApprovalGateType.BUY_PLAN) is True
+
+    def test_false_when_no_buy_plan_approver(self, db_session):
+        db_session.add(User(email="b@trioscs.com", name="B", is_active=True, can_approve_buy_plans=False))
+        db_session.flush()
+        assert has_eligible_approver(db_session, ApprovalGateType.BUY_PLAN) is False
+
+    def test_inactive_approver_excluded(self, db_session):
+        db_session.add(User(email="c@trioscs.com", name="C", is_active=False, can_approve_buy_plans=True))
+        db_session.flush()
+        assert has_eligible_approver(db_session, ApprovalGateType.BUY_PLAN) is False
+
+    def test_po_gate_respects_dollar_limit(self, db_session):
+        db_session.add(
+            User(
+                email="d@trioscs.com",
+                name="D",
+                is_active=True,
+                can_approve_purchase_orders=True,
+                purchase_order_approval_limit=Decimal("1000"),
+            )
+        )
+        db_session.flush()
+        assert has_eligible_approver(db_session, ApprovalGateType.PURCHASE_ORDER, Decimal("500")) is True
+        assert has_eligible_approver(db_session, ApprovalGateType.PURCHASE_ORDER, Decimal("5000")) is False

--- a/tests/test_buyplan_hub_routes.py
+++ b/tests/test_buyplan_hub_routes.py
@@ -399,3 +399,59 @@ def test_pipeline_archive_next_page_button(client: TestClient, db_session: Sessi
     body = resp.text
     assert "Load older" in body
     assert f"/v2/partials/approvals/pipeline-archive?scope=mine&offset={ARCHIVE_PAGE_SIZE}" in body
+
+
+def test_my_queue_renders_no_approver_row(client: TestClient, db_session, test_user, test_quote, test_requisition):
+    """A stuck PENDING plan (no approver configured) renders as a No-approver row for
+    its owner — verifies the new kind's display maps resolve (no Jinja error)."""
+    _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        req_id=test_requisition.id,
+        status=BuyPlanStatus.PENDING,
+        submitted_by_id=test_user.id,
+    )
+    resp = client.get("/v2/partials/approvals/my-queue")
+    assert resp.status_code == 200
+    assert "No approver" in resp.text
+
+
+def test_detail_renders_no_approver_banner(client: TestClient, db_session, test_user, test_quote, test_requisition):
+    """The plan detail surfaces the no-approver banner when the plan is stalled without
+    an approver — the owner otherwise had no signal."""
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        req_id=test_requisition.id,
+        status=BuyPlanStatus.PENDING,
+        submitted_by_id=test_user.id,
+    )
+    resp = client.get(f"/v2/partials/buy-plans/{plan.id}")
+    assert resp.status_code == 200
+    assert "no buy-plan approver" in resp.text
+
+
+def test_resolve_issue_route_supervisor_ok(
+    client: TestClient, db_session: Session, manager_user, test_quote, test_requisition
+):
+    """A supervisor POSTs resolve-issue → 200 and the line returns to awaiting_po."""
+    plan = _make_plan(db_session, quote_id=test_quote.id, req_id=test_requisition.id, status=BuyPlanStatus.ACTIVE)
+    line = _make_line(db_session, plan_id=plan.id, status=BuyPlanLineStatus.ISSUE, issue_type="price_changed")
+    with _acting_as(manager_user):
+        resp = client.post(f"/v2/partials/buy-plans/{plan.id}/lines/{line.id}/resolve-issue")
+    assert resp.status_code == 200
+    db_session.refresh(line)
+    assert line.status == BuyPlanLineStatus.AWAITING_PO.value
+
+
+def test_resolve_issue_route_non_supervisor_403(
+    client: TestClient, db_session: Session, test_user, test_quote, test_requisition
+):
+    """A plain buyer (the client default) can't resolve a flagged issue → 403; the line
+    is left untouched."""
+    plan = _make_plan(db_session, quote_id=test_quote.id, req_id=test_requisition.id, status=BuyPlanStatus.ACTIVE)
+    line = _make_line(db_session, plan_id=plan.id, status=BuyPlanLineStatus.ISSUE, issue_type="sold_out")
+    resp = client.post(f"/v2/partials/buy-plans/{plan.id}/lines/{line.id}/resolve-issue")
+    assert resp.status_code == 403
+    db_session.refresh(line)
+    assert line.status == BuyPlanLineStatus.ISSUE.value

--- a/tests/test_buyplan_workflow.py
+++ b/tests/test_buyplan_workflow.py
@@ -36,7 +36,9 @@ from app.services.buyplan_workflow import (
     flag_line_issue,
     generate_case_report,
     halt_plan,
+    plan_needs_approver_reason,
     reset_buy_plan_to_draft,
+    resolve_line_issue,
     resubmit_buy_plan,
     submit_buy_plan,
     verify_po,
@@ -1418,3 +1420,104 @@ class TestVerifyPoRejectClearsNudge:
         db_session.refresh(line)
         assert line.status == BuyPlanLineStatus.AWAITING_PO.value
         assert line.last_nudge_at is None
+
+
+class TestResolveLineIssue:
+    """resolve_line_issue() — clears a flagged issue back to awaiting_po (supervisor-
+    gated)."""
+
+    def test_supervisor_resolves_issue_to_awaiting_po(
+        self, db_session: Session, manager_user: User, test_user: User, test_quote: Quote, test_requisition: Requisition
+    ):
+        plan = _make_plan(db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.ACTIVE.value)
+        line = _make_line(
+            db_session, plan, status=BuyPlanLineStatus.ISSUE.value, issue_type="price_changed", issue_note="up 20%"
+        )
+
+        result = resolve_line_issue(plan.id, line.id, manager_user, db_session)
+
+        assert result.status == BuyPlanLineStatus.AWAITING_PO.value
+        assert result.issue_type is None
+        assert result.issue_note is None
+
+    def test_resolve_clears_stale_po_fields(
+        self, db_session: Session, manager_user: User, test_user: User, test_quote: Quote, test_requisition: Requisition
+    ):
+        """A PENDING_VERIFY line flagged then resolved must land in a clean awaiting_po
+        (no confirmed PO), so the buyer re-confirms rather than inheriting a stale
+        PO#."""
+        plan = _make_plan(db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.ACTIVE.value)
+        line = _make_line(
+            db_session,
+            plan,
+            status=BuyPlanLineStatus.ISSUE.value,
+            issue_type="sold_out",
+            po_number="PO-STALE",
+            po_confirmed_at=datetime.now(timezone.utc),
+        )
+
+        result = resolve_line_issue(plan.id, line.id, manager_user, db_session)
+
+        assert result.status == BuyPlanLineStatus.AWAITING_PO.value
+        assert result.po_number is None
+        assert result.po_confirmed_at is None
+
+    def test_non_supervisor_cannot_resolve(
+        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
+    ):
+        """The buyer who raised the issue can't self-resolve (matches the
+        flagged→supervisor My Queue routing) — a plain buyer is refused."""
+        plan = _make_plan(db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.ACTIVE.value)
+        line = _make_line(db_session, plan, status=BuyPlanLineStatus.ISSUE.value, issue_type="other")
+
+        with pytest.raises(PermissionError):
+            resolve_line_issue(plan.id, line.id, test_user, db_session)
+
+    def test_resolve_non_issue_line_rejected(
+        self, db_session: Session, manager_user: User, test_user: User, test_quote: Quote, test_requisition: Requisition
+    ):
+        plan = _make_plan(db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.ACTIVE.value)
+        line = _make_line(db_session, plan, status=BuyPlanLineStatus.AWAITING_PO.value)
+
+        with pytest.raises(ValueError, match="no issue to resolve"):
+            resolve_line_issue(plan.id, line.id, manager_user, db_session)
+
+
+class TestPlanNeedsApproverReason:
+    """plan_needs_approver_reason() — detects a plan silently stalled for lack of an
+    approver."""
+
+    def test_pending_no_buy_plan_approver(
+        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
+    ):
+        plan = _make_plan(db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.PENDING.value)
+        assert plan_needs_approver_reason(plan, db_session) == "buy_plan"
+
+    def test_pending_with_approver_returns_none(
+        self, db_session: Session, manager_user: User, test_user: User, test_quote: Quote, test_requisition: Requisition
+    ):
+        _grant_approver(db_session, manager_user)
+        plan = _make_plan(db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.PENDING.value)
+        assert plan_needs_approver_reason(plan, db_session) is None
+
+    def test_active_over_threshold_no_po_approver(
+        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
+    ):
+        plan = _make_plan(
+            db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.ACTIVE.value, total_cost=10000.00
+        )
+        assert plan_needs_approver_reason(plan, db_session) == "purchase_order"
+
+    def test_active_under_threshold_returns_none(
+        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
+    ):
+        plan = _make_plan(
+            db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.ACTIVE.value, total_cost=100.00
+        )
+        assert plan_needs_approver_reason(plan, db_session) is None
+
+    def test_draft_returns_none(
+        self, db_session: Session, test_user: User, test_quote: Quote, test_requisition: Requisition
+    ):
+        plan = _make_plan(db_session, test_user, test_quote, test_requisition, status=BuyPlanStatus.DRAFT.value)
+        assert plan_needs_approver_reason(plan, db_session) is None

--- a/tests/test_my_queue.py
+++ b/tests/test_my_queue.py
@@ -447,13 +447,16 @@ def test_my_queue_oldest_first_within_tier(db_session, test_user, test_quote, te
 # ── Role gating summary (sales sees only owner-scoped work) ────────────
 
 
-def test_my_queue_sales_sees_only_owned_drafts(db_session, sales_user, test_quote, test_requisition):
+def test_my_queue_sales_sees_only_owned_drafts(db_session, sales_user, manager_user, test_quote, test_requisition):
     """A sales user is not a PO-cutter/approver: they only see their own
     draft/returned/halted.
 
     A PENDING plan they own routes to approvers, not to them; a RESOURCING pool line is
     invisible to non-cutters.
     """
+    # A real buy-plan approver exists, so the owned PENDING plan is normally-pending (routed
+    # to the manager) rather than config-stuck — it must NOT surface to sales as no_approver.
+    _grant(db_session, manager_user, can_approve_buy_plans=True)
     own_draft = _make_plan(
         db_session,
         quote_id=test_quote.id,
@@ -640,3 +643,43 @@ def test_supervise_overview_contract_unchanged(db_session):
         "flagged_count",
     }
     assert result["queue"] == []
+
+
+class TestNoApproverKind:
+    """no_approver — a plan silently stalled because no approver is configured surfaces
+    to its owner (who otherwise has no signal) and to admins (who can fix the
+    config)."""
+
+    def test_surfaces_stuck_pending_plan_to_owner(self, db_session, test_user, test_quote, test_requisition):
+        _make_plan(
+            db_session,
+            quote_id=test_quote.id,
+            requisition_id=test_requisition.id,
+            status=BuyPlanStatus.PENDING,
+            submitted_by_id=test_user.id,
+        )
+        assert "no_approver" in _kinds(my_queue(db_session, test_user))
+
+    def test_absent_when_buy_plan_approver_configured(
+        self, db_session, test_user, manager_user, test_quote, test_requisition
+    ):
+        _grant(db_session, manager_user, can_approve_buy_plans=True)
+        _make_plan(
+            db_session,
+            quote_id=test_quote.id,
+            requisition_id=test_requisition.id,
+            status=BuyPlanStatus.PENDING,
+            submitted_by_id=test_user.id,
+        )
+        assert "no_approver" not in _kinds(my_queue(db_session, test_user))
+
+    def test_over_threshold_active_without_po_approver(self, db_session, test_user, test_quote, test_requisition):
+        _make_plan(
+            db_session,
+            quote_id=test_quote.id,
+            requisition_id=test_requisition.id,
+            status=BuyPlanStatus.ACTIVE,
+            submitted_by_id=test_user.id,
+            total_cost=Decimal("10000"),
+        )
+        assert "no_approver" in _kinds(my_queue(db_session, test_user))


### PR DESCRIPTION
**PR 1 of 3** from the workflow deep-review. Closes the two *functional* deal-completion gaps (finding cluster A) — where a live deal could get stuck or hit a dead-end.

## A1 — the ISSUE line was a dead-end
`flag_line_issue` set `status=issue`, but the detail UI showed only a badge and `resource_line` rejects the `issue` status — so a flagged line's only escape was **halting the whole plan**.
- `resolve_line_issue` (issue → awaiting_po, clears the issue + stale PO-confirm fields) + `POST .../lines/{id}/resolve-issue` + a **Resolve** button.
- Supervisor/ops-gated (`_can_halt`) to match the existing flagged→supervisor **My Queue** routing — the buyer who raised the issue can't self-resolve.

## A3 — a no-approver stall was silent
If no active user held the approving right, `NoEligibleApproverError` was only logged and the plan sat invisibly (the owner no longer sees a PENDING plan; no approver exists to see it).
- `routing.has_eligible_approver` — **refactored `route_request` to share one `_eligible_approvers` source of truth** (no logic drift).
- `buyplan_workflow.plan_needs_approver_reason` drives an amber **detail banner** and a new **`no_approver` My Queue kind** shown to the owner (+ admins, who can fix the config).

## Scope corrections vs the approved plan (verification-driven)
- **A2 (Cancel-on-INBOUND) dropped** — false positive: the Cancel button is already suppressed on INBOUND by the enclosing `has_action_banner` guard (`detail.html:82`).
- **A4 (line un-verify) deferred** — re-source already provides an escape for a mis-verified line.

## Tests
- Service: `resolve_line_issue` (supervisor / non-supervisor 403 / wrong-status / field hygiene), `plan_needs_approver_reason` (pending/active/threshold/draft), `has_eligible_approver` (active/inactive/PO dollar-limit).
- Route + render: resolve-issue 200/403, `no_approver` row renders, detail banner renders.
- 1 ripple found + fixed (`test_my_queue_sales_sees_only_owned_drafts` now configures an approver so its owned PENDING plan is normally-pending, not config-stuck).
- **Full suite 21,739 passed**, `pre-commit run --all-files` clean, APP_MAP updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)