### PR TITLE
fix(ux): next-step CTAs on empty Build-Quote/Offers states + Reopen for closed quotes

### DIFF
--- a/app/templates/htmx/partials/quotes/detail.html
+++ b/app/templates/htmx/partials/quotes/detail.html
@@ -145,6 +145,21 @@
     </button>
     {% endif %}
 
+    {# Reopen a closed quote back to draft for editing (endpoint accepts sent/won/lost). The
+       'sent' state has its own action set above, so surface Reopen for the won/lost gap. #}
+    {% if quote.status in ('won', 'lost') %}
+    {# .btn btn-lg == px-4 py-2 text-sm — matches the sibling actions while sizing via the
+       canonical .btn family (not inline px-/py-, per the static-analysis ratchet). #}
+    <button hx-post="/v2/partials/quotes/{{ quote.id }}/reopen"
+            hx-target="#main-content"
+            hx-confirm="Reopen this quote back to draft for editing?"
+            data-loading-disable
+            class="btn btn-secondary btn-lg inline-flex items-center gap-1.5">
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+      Reopen
+    </button>
+    {% endif %}
+
     <button hx-post="/v2/partials/quotes/{{ quote.id }}/revise"
             hx-target="#main-content"
             hx-confirm="Create a new revision of this quote?"

--- a/app/templates/htmx/partials/requisitions/tabs/build_quote.html
+++ b/app/templates/htmx/partials/requisitions/tabs/build_quote.html
@@ -13,7 +13,14 @@
 {% if not lines %}
 <div class="mx-auto max-w-xs text-center text-sm text-gray-600 py-10">
   <svg class="mx-auto mb-3 h-10 w-10 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
-  No parts to quote yet.
+  <p>No parts to quote yet.</p>
+  {# Next step: parts are added + sourced on the Parts tab (mirrors the tab-nav switch). #}
+  <button @click="activeTab = 'parts'"
+          hx-get="/v2/partials/requisitions/{{ req.id }}/tab/parts"
+          hx-target="#tab-content" hx-swap="innerHTML"
+          class="btn btn-primary btn-sm mt-3">
+    Add parts &rarr;
+  </button>
 </div>
 
 {% else %}

--- a/app/templates/htmx/partials/requisitions/tabs/offers.html
+++ b/app/templates/htmx/partials/requisitions/tabs/offers.html
@@ -264,7 +264,14 @@
     <p class="text-xs text-gray-400 mt-1">Try selecting a different filter above or clear the filter to see all offers.</p>
     {% else %}
     <p class="text-sm font-medium text-gray-600 mt-3">No offers received yet.</p>
-    <p class="text-xs text-gray-400 mt-1">Offers appear here when vendors respond to RFQs or when leads are promoted.</p>
+    <p class="text-xs text-gray-400 mt-1">Offers appear when vendors respond to RFQs, when leads are promoted, or from searching all supplier sources.</p>
+    {# Next step: the sourcing engine (Search All Sources) lives on the Parts tab. #}
+    <button @click="activeTab = 'parts'"
+            hx-get="/v2/partials/requisitions/{{ req.id }}/tab/parts"
+            hx-target="#tab-content" hx-swap="innerHTML"
+            class="btn btn-primary btn-sm mt-3">
+      Search all sources &rarr;
+    </button>
     {% endif %}
   </div>
   {% endif %}

--- a/tests/test_build_quote_tab.py
+++ b/tests/test_build_quote_tab.py
@@ -106,6 +106,9 @@ class TestBuildQuoteTabRender:
         resp = client.get(f"/v2/partials/requisitions/{req.id}/build-quote")
         assert resp.status_code == 200
         assert "No parts to quote yet" in resp.text
+        # Empty state offers a next step (jump to the Parts tab) rather than dead-ending.
+        assert "Add parts" in resp.text
+        assert f"/v2/partials/requisitions/{req.id}/tab/parts" in resp.text
 
 
 class TestBuildQuoteAssemble:

--- a/tests/test_htmx_views.py
+++ b/tests/test_htmx_views.py
@@ -597,6 +597,17 @@ class TestRequisitionDetail:
         resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/offers")
         assert resp.status_code == 200
 
+    def test_tab_offers_empty_shows_search_cta(self, client: TestClient, db_session: Session, test_user: User):
+        """Empty offers tab points to sourcing (Search all sources → Parts tab) instead
+        of dead-ending with a message the user can't act on."""
+        req = _make_requisition(db_session, test_user)
+        db_session.commit()
+        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/offers")
+        assert resp.status_code == 200
+        assert "No offers received yet" in resp.text
+        assert "Search all sources" in resp.text
+        assert f"/v2/partials/requisitions/{req.id}/tab/parts" in resp.text
+
     @pytest.mark.parametrize(
         "tab, expected_status",
         [

--- a/tests/test_sprint5_quote_workflow.py
+++ b/tests/test_sprint5_quote_workflow.py
@@ -59,6 +59,24 @@ class TestQuotePreview:
         assert resp.status_code == 404
 
 
+# ── Reopen button (clarity: closed quotes were un-reopenable from the detail UI) ──────
+
+
+class TestQuoteReopenButton:
+    def test_lost_quote_detail_shows_reopen(self, client: TestClient, db_session: Session, test_quote: Quote):
+        test_quote.status = "lost"
+        db_session.commit()
+        resp = client.get(f"/v2/partials/quotes/{test_quote.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Reopen" in resp.text
+        assert f"/v2/partials/quotes/{test_quote.id}/reopen" in resp.text
+
+    def test_draft_quote_detail_has_no_reopen(self, client: TestClient, draft_quote: Quote):
+        resp = client.get(f"/v2/partials/quotes/{draft_quote.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Reopen" not in resp.text
+
+
 # ── Delete Quote ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
**PR 2 of 3** from the workflow deep-review — the "what do I do now?" clarity gaps (finding cluster B) where a surface worked but the next step wasn't obvious. Disjoint from PR1 (#619).

- **B1** — Build-Quote empty state ("No parts to quote yet.") now offers an **Add parts** button that switches to the Parts tab (mirrors the tab-nav `hx-get`), instead of dead-ending.
- **B2** — Offers empty state now offers **Search all sources** → the Parts tab (where the sourcing engine lives), so users learn offers also come from proactive sourcing, not only RFQ replies.
- **B3** — won/lost quotes now surface a **Reopen** button. The `POST .../quotes/{id}/reopen` endpoint already existed but was unreachable from the detail UI. Sized via `.btn btn-lg` (== `px-4 py-2`) to satisfy the inline-button static ratchet while matching its sibling actions.

## Tests
- Render assertions: Build-Quote + Offers empty states show their CTA and link to the Parts tab; lost-quote detail shows Reopen, draft does not.
- Full suite green **except** the known xdist-only `nc_worker` circuit-breaker flake (passes in isolation; green on `main`). `pre-commit run --all-files` clean.

## Deferred to the post-#619 work
B4 (SO-signed signal) and B7 (buy-plan line → source-offer link) touch files PR1 (#619) also changes, so they'll land on top of merged PR1 to avoid conflicts. B5/B6 are minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)