### PR TITLE
fix(ux): make the Phase-D SO-sign-off fold visible on the buy-plan

### DIFF
--- a/app/templates/htmx/partials/buy_plans/_detail_action_banner.html
+++ b/app/templates/htmx/partials/buy_plans/_detail_action_banner.html
@@ -44,7 +44,7 @@
   <div class="mb-4 bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex items-center justify-between gap-3">
     <div class="flex items-center gap-3">
       <span class="flex-shrink-0 w-6 h-6 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center">!</span>
-      <span class="text-sm text-blue-800">This plan needs your approval. ${{ '{:,.2f}'.format(total_cost) }} total.</span>
+      <span class="text-sm text-blue-800">This plan needs your approval. ${{ '{:,.2f}'.format(total_cost) }} total. <span class="text-blue-600">Approving also signs off the sales order.</span></span>
     </div>
     <div class="flex gap-2 flex-shrink-0">
       <button @click="modalType = 'approve'; showModal = true"

--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -49,6 +49,15 @@
           Stock Sale
         </span>
         {% endif %}
+        {# Phase-D fold made explicit: the single plan approval IS the SO sign-off (previously
+           silent). Surface who signed so the fold isn't invisible. #}
+        {% if bp.so_status == 'approved' and bp.approved_by %}
+        <span class="chip bg-emerald-50 text-emerald-700 border-emerald-200 inline-flex items-center gap-1"
+              title="Approving this buy plan also signed off the sales order — one approval covers both.">
+          <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+          SO signed · {{ bp.approved_by.name or bp.approved_by.email }}
+        </span>
+        {% endif %}
       </div>
       {# Finding #6: total value → .figure-accent; margin keeps its semantic colour;
          lines/vendors demoted to lighter weight so the money figure wins hierarchy #}

--- a/tests/test_buyplan_hub_routes.py
+++ b/tests/test_buyplan_hub_routes.py
@@ -455,3 +455,35 @@ def test_resolve_issue_route_non_supervisor_403(
     assert resp.status_code == 403
     db_session.refresh(line)
     assert line.status == BuyPlanLineStatus.ISSUE.value
+
+
+def test_detail_shows_so_signed_chip(
+    client: TestClient, db_session: Session, manager_user, test_quote, test_requisition
+):
+    """An approved (active) plan surfaces a 'SO signed · <approver>' chip so the Phase-D
+    fold (one approval also signs the sales order) is no longer invisible."""
+    plan = _make_plan(
+        db_session,
+        quote_id=test_quote.id,
+        req_id=test_requisition.id,
+        status=BuyPlanStatus.ACTIVE,
+        so_status=SOVerificationStatus.APPROVED,
+        approved_by_id=manager_user.id,
+    )
+    resp = client.get(f"/v2/partials/buy-plans/{plan.id}")
+    assert resp.status_code == 200
+    assert "SO signed" in resp.text
+
+
+def test_approval_banner_notes_so_fold(
+    client: TestClient, db_session: Session, manager_user, test_quote, test_requisition
+):
+    """The approval banner tells the approver that approving also signs off the sales
+    order."""
+    manager_user.can_approve_buy_plans = True
+    plan = _make_plan(db_session, quote_id=test_quote.id, req_id=test_requisition.id, status=BuyPlanStatus.PENDING)
+    db_session.commit()
+    with _acting_as(manager_user):
+        resp = client.get(f"/v2/partials/buy-plans/{plan.id}")
+    assert resp.status_code == 200
+    assert "signs off the sales order" in resp.text


### PR DESCRIPTION
Clarity fix **B4** from the workflow review (finding cluster B, on top of #619/#620).

Approving a buy plan also signs off the sales order (the Phase-D fold — one approval covers both), but that was **invisible**: the approval carried no signal and the header never showed the SO was signed.

- **Plan header** — an emerald **"SO signed · &lt;approver&gt;"** chip on approved plans, with a tooltip explaining the fold.
- **Approval banner** — "Approving also signs off the sales order." so the approver knows *before* clicking.

### Scope notes on the rest of cluster B (verification-driven)
- **B5** (closed-req → buy-plans link) — redundant: the Buy Plans tab already exists on the requisition detail.
- **B7** (buy-plan line → source offer) — already satisfied: `_detail_lines` shows the offer's vendor.
- **B6** (aggregate quote status on the list) — **deferred**: the `quote_status` aggregate is already computed in `list_requisitions`, but surfacing it needs a new table column (header/cell/visibility) — the lowest-value item.

### Tests
SO-signed chip renders on an approved plan; approval banner shows the fold note. 60 buyplan-route + static-analysis tests pass; `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)