### PR TITLE
docs: quick-win fixes from the polish review

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,12 @@ docker compose logs -f app
 ### Updating the code
 ```bash
 cd /root/availai
-git pull
-docker compose up -d --build
+./deploy.sh
 ```
+`deploy.sh` syncs `main`, rebuilds with a fresh `BUILD_COMMIT` build-arg (so templates
+and static assets are never stale), recreates both the app and enrichment-worker
+containers, waits for the health check, and restarts the host worker units.
+Never use bare `docker compose up -d --build` — it ships stale templates.
 
 ### Stopping everything
 ```bash

--- a/STABLE.md
+++ b/STABLE.md
@@ -27,15 +27,15 @@ Do not refactor these without explicit approval. Changes here can break startup,
 ## Critical routers (thin entry points; logic in services)
 - `app/routers/auth.py`
 - `app/routers/requisitions/` (core, requirements, attachments)
-- `app/routers/task.py`
-- `app/routers/crm/` (companies, offers, quotes, buy_plans, etc.)
-- `app/routers/rfq.py`
+- `app/routers/crm/` (companies, offers, quotes, enrichment, export, clone)
+- `app/routers/htmx/` + `app/routers/htmx_views.py` (HTMX partial surfaces)
 
-## Frontend (single-page app)
-- `app/templates/index.html`
-- `app/static/app.js`
-- `app/static/crm.js`
-- `app/static/styles.css`
+## Frontend (HTMX + Alpine.js + Jinja2)
+- `app/templates/htmx/base.html` — app shell (script/style includes, toast store, CSRF listener)
+- `app/templates/htmx/` — all server-rendered pages and partials
+- `app/static/htmx_app.js` — HTMX/Alpine bootstrap, stores, global listeners
+- `app/static/styles.css` — design tokens + component classes (Tailwind source)
+- `app/static/dist/` — Vite build output (never edit by hand)
 
 When changing any listed file, run tests and do a quick smoke check before committing.
 
@@ -46,20 +46,4 @@ When changing any listed file, run tests and do a quick smoke check before commi
 
 ## Known tech debt
 
-- **`app/static/htmx_app.js` — `htmx:afterSwap` Alpine.initTree gate uses a hardcoded ID allowlist** (`lead-drawer-content`, `rq2-table`). When future HTMX-swapped regions contain Alpine directives (`x-*`), they must be added manually to this list or their directives won't re-bind after swap. Fragile. Future refactor idea: trigger `initTree` whenever the swap target subtree contains any element with an `x-*` attribute, so new regions get covered automatically. Not urgent — Alpine's own MutationObserver handles most cases, and the allowlist is a belt-and-suspenders fallback. Captured 2026-04-21 during the opportunity-table v2 merge.
-
-## Opportunity Table (/requisitions2)
-
-The `/requisitions2` split-workspace left panel renders the v2 opportunity
-table (status dots, urgency accents, deal-value typography, coverage meter,
-aggregated MPN chip row, truncation tooltips, hover action rail). This is the
-sole rendering — the former opportunity-table-v2 feature flag and the legacy
-5-col fallback have been retired.
-
-**Token set:** `app/static/styles.css` `:root { --opp-* }` variables for
-dot colors, urgency border/text, coverage fill, text primary/secondary/
-tertiary, separator. Component classes: `.opp-status-dot`, `.opp-status-label`,
-`.opp-time--{24h,72h,normal}`, `.opp-deal--tier-{primary-500,primary-400,tertiary}`,
-`.opp-deal--computed`, `.opp-deal--partial`, `.opp-coverage-seg`,
-`.opp-row--urgent-{24h,72h}`, `.opp-col-header`, `.opp-chip-row`,
-`.opp-chip-more`, `.opp-name-cell`, `.opp-action-rail*`, `.truncate-tip`.
+- **`app/static/htmx_app.js` — `htmx:afterSwap` Alpine.initTree gate uses a hardcoded ID allowlist** (`lead-drawer-content`, `rq2-table`). When future HTMX-swapped regions contain Alpine directives (`x-*`), they must be added manually to this list or their directives won't re-bind after swap. Fragile. Future refactor idea: trigger `initTree` whenever the swap target subtree contains any element with an `x-*` attribute, so new regions get covered automatically. Not urgent — Alpine's own MutationObserver handles most cases, and the allowlist is a belt-and-suspenders fallback. Captured 2026-04-21 during the opportunity-table v2 merge. (`rq2-table` is dead since `/requisitions2` was retired in #622 — drop it with the dead-code sweep.)

--- a/docs/HTMX_ALPINE_TOOLKIT.md
+++ b/docs/HTMX_ALPINE_TOOLKIT.md
@@ -228,7 +228,10 @@ Emits events when order changes so you can save to server.
 **AvailAI uses:**
 ```html
 <!-- Reorder RFQ line items by priority -->
-<div x-data="{ items: {{ rfq_items|tojson }} }"
+<!-- NOTE: single-quoted x-data is load-bearing — tojson output contains double quotes
+     (and tojson escapes ' itself), so a double-quoted attribute would end at the first
+     JSON key and kill the whole component. See CLAUDE.md anti-patterns. -->
+<div x-data='{ items: {{ rfq_items|tojson }} }'
      x-sort="(item, position) => {
        htmx.ajax('PATCH', '/v2/api/rfq/reorder', {
          values: { item_id: item, position: position }

--- a/docs/audit/2026-05-04-full-code-review-HISTORICAL.md
+++ b/docs/audit/2026-05-04-full-code-review-HISTORICAL.md
@@ -1,3 +1,7 @@
+> **HISTORICAL — retired from repo root 2026-07-02.** This May 2026 whole-codebase review is
+> materially superseded: its open criticals were re-verified fixed or moot on main during the
+> 2026-06-30 full audit (see AUDIT_REPORT_2026-06-30.md and REMEDIATION_2026-07.md). Kept for history.
+
 # AvailAI — Full Code Review Notes (Re-verified)
 
 **Original review:** 2026-05-04 (branch `claude/code-review-notes-f6Cg7`, base commit `fbba111`)


### PR DESCRIPTION
First remediation slice from the Phase-1 review (textual only, zero runtime surface): README banned-deploy-method fix, STABLE.md brought current, toolkit tojson anti-pattern example fixed, May review notes retired to docs/audit/ as historical.

Findings: DOC-1, DOC-2, ORG-3, ORG-4 (all adversarially verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF