### PR TITLE
fix(reqlist): W1a — quote_status sort, inline-save Quotes cell, loader cartesian

### DIFF
--- a/app/routers/htmx/requisitions.py
+++ b/app/routers/htmx/requisitions.py
@@ -85,9 +85,12 @@ async def requisitions_list_partial(
         .filter(Requisition.is_scratch.is_(False))
         .options(
             joinedload(Requisition.creator),
-            joinedload(Requisition.requirements),
-            joinedload(Requisition.offers),
-            joinedload(Requisition.quotes),
+            # selectinload (not joinedload) for the three collections: stacking
+            # collection joinedloads multiplies the base query's rows per requisition
+            # (requirements × offers × quotes cartesian before entity dedup).
+            selectinload(Requisition.requirements),
+            selectinload(Requisition.offers),
+            selectinload(Requisition.quotes),
         )
     )
 
@@ -156,6 +159,22 @@ async def requisitions_list_partial(
         (Requisition.deadline == "ASAP", "0000-00-00"),
         else_=Requisition.deadline,
     )
+    # Aggregate quote significance (asc = won first), mirroring _best_quote_status; a
+    # requisition with no quotes yields NULL → nullslast puts it at the bottom either way.
+    quote_status_sub = (
+        select(
+            sqlfunc.min(
+                case(
+                    *[(Quote.status == status, prio) for status, prio in _QUOTE_STATUS_PRIORITY.items()],
+                    else_=5,
+                )
+            )
+        )
+        .where(Quote.requisition_id == Requisition.id)
+        .correlate(Requisition)
+        .scalar_subquery()
+        .label("quote_status_sort")
+    )
     sort_col_map = {
         "name": Requisition.name,
         "customer_name": Requisition.customer_name,
@@ -166,6 +185,7 @@ async def requisitions_list_partial(
         "updated_at": Requisition.updated_at,
         "req_count": req_count_sub,
         "offer_count": offer_count_sub,
+        "quote_status": quote_status_sub,
     }
     sort_col = sort_col_map.get(sort)
     if sort_col is None:

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -57,7 +57,7 @@ from ..utils.sql_helpers import escape_like
 from ._lookup_helpers import get_requisition_or_404
 from .auth import _password_login_enabled
 from .htmx._shared import _base_ctx, _safe_int, _vite_assets
-from .htmx.requisitions import requisition_tab, requisitions_list_partial
+from .htmx.requisitions import _best_quote_status, requisition_tab, requisitions_list_partial
 from .htmx.settings import _run_inbox_scan_now
 
 router = APIRouter(tags=["htmx-views"])
@@ -576,19 +576,23 @@ async def requisition_inline_save(
         ctx.update({"req": req, "requirements": requirements, "users": users})
         response = template_response("htmx/partials/requisitions/detail_header.html", ctx)
     else:
-        # Row context — re-fetch ORM object with relationships
+        # Row context — re-fetch ORM object with relationships. Must attach the SAME
+        # computed attrs the list route does (req_count/offer_count/quote_status) or
+        # the swapped-in row degrades those cells.
         req = (
             db.query(Requisition)
             .options(
                 joinedload(Requisition.creator),
                 joinedload(Requisition.requirements),
                 joinedload(Requisition.offers),
+                joinedload(Requisition.quotes),
             )
             .filter(Requisition.id == req_id)
             .first()
         )
         req.req_count = len(req.requirements) if req.requirements else 0
         req.offer_count = len(req.offers) if req.offers else 0
+        req.quote_status = _best_quote_status(req.quotes)
         ctx = _base_ctx(request, user, "requisitions")
         ctx.update({"req": req, "user_role": getattr(user, "role", UserRole.SALES), "user": user})
         response = template_response("htmx/partials/requisitions/req_row.html", ctx)

--- a/tests/test_req_list_quote_column.py
+++ b/tests/test_req_list_quote_column.py
@@ -78,3 +78,78 @@ def test_quoted_req_shows_status_badge(client: TestClient, db_session, test_cust
     row = _list_soup(client).select_one(f'tr[id="req-row-{req.id}"]')
     assert row is not None
     assert "Sent" in row.get_text()  # quote_status_badge label for 'sent'
+
+
+def _make_req_with_quote(db_session, site, user, name, quote_status=None, n_quotes=1):
+    from datetime import datetime, timezone
+
+    from app.models import Quote, Requisition
+
+    req = Requisition(
+        name=name,
+        customer_name=f"{name} Co",
+        status="open",
+        customer_site_id=site.id,
+        created_by=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req)
+    db_session.flush()
+    if quote_status:
+        for i in range(n_quotes):
+            db_session.add(
+                Quote(
+                    requisition_id=req.id,
+                    customer_site_id=site.id,
+                    quote_number=f"Q-{name}-{i}",
+                    status=quote_status,
+                    line_items=[],
+                    created_by_id=user.id,
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+    db_session.commit()
+    return req
+
+
+def test_quote_status_sort_orders_by_significance(client: TestClient, db_session, test_customer_site, test_user):
+    """The Quotes column header renders a sort link, so ?sort=quote_status must actually
+    sort (won > lost > sent > revised, no-quote rows last) instead of silently falling
+    back to created_at (the #623 regression: 'quote_status' was missing from the route's
+    sort whitelist)."""
+    # Created oldest-first so a silent created_at fallback (desc default → newest first,
+    # asc → oldest first) CANNOT accidentally produce the expected significance order.
+    won = _make_req_with_quote(db_session, test_customer_site, test_user, "SORT-NONE-DECOY", None)
+    sent = _make_req_with_quote(db_session, test_customer_site, test_user, "SORT-SENT", "sent")
+    winner = _make_req_with_quote(db_session, test_customer_site, test_user, "SORT-WON", "won")
+
+    resp = client.get("/v2/partials/requisitions?sort=quote_status&dir=asc")
+    assert resp.status_code == 200
+    text = resp.text
+    pos_won, pos_sent, pos_none = (text.find(f"req-row-{r.id}") for r in (winner, sent, won))
+    assert pos_won != -1 and pos_sent != -1 and pos_none != -1
+    assert pos_won < pos_sent < pos_none, "expected won < sent < no-quote row order under quote_status asc"
+
+
+def test_inline_save_rerender_keeps_quote_status(client: TestClient, db_session, test_customer_site, test_user):
+    """Inline-saving any field returns the full row — it must keep the Quotes cell
+    populated (the #623 regression: the row-context re-render never computed
+    req.quote_status, degrading the cell to the dash)."""
+    req = _make_req_with_quote(db_session, test_customer_site, test_user, "INLINE-KEEP", "sent")
+
+    resp = client.patch(
+        f"/v2/partials/requisitions/{req.id}/inline",
+        data={"field": "name", "value": "INLINE-KEEP-RENAMED", "context": "row"},
+    )
+    assert resp.status_code == 200
+    assert "Sent" in resp.text, "row re-render lost the quote_status badge"
+
+
+def test_multi_quote_req_renders_once(client: TestClient, db_session, test_customer_site, test_user):
+    """A requisition with several quotes/requirements/offers must render exactly one row
+    (guards entity dedup across the collection-loader strategy)."""
+    req = _make_req_with_quote(db_session, test_customer_site, test_user, "MULTI-Q", "sent", n_quotes=3)
+
+    soup = _list_soup(client)
+    rows = soup.select(f'tr[id="req-row-{req.id}"]')
+    assert len(rows) == 1


### PR DESCRIPTION
First code slice of remediation Wave 1 — three adversarially-verified regressions from the #620–#623 merge wave:

1. **Dead sort control**: the Quotes column header rendered a sort link but `quote_status` wasn't in the route's sort whitelist — clicks silently sorted by `created_at` with a misleading arrow. Now sorts by a correlated `MIN(CASE)` significance subquery (won > lost > sent > revised, no-quote rows last) mirroring `_best_quote_status`.
2. **Inline-save degraded the Quotes cell**: the row-context re-render never computed `req.quote_status`, so any inline edit blanked the cell to a dash until refresh. The re-render now attaches the same computed attrs as the list route.
3. **Collection-loader cartesian**: three stacked collection `joinedload`s multiplied base-query rows per requisition (requirements × offers × quotes); switched to `selectinload`.

TDD: 3 new tests (sort order constructed so a silent created_at fallback cannot pass; re-render badge; multi-quote dedup guard). Ripple neighborhood: 447 passed.

Findings: WF3 REG-3/F1(models-tests), REG-4/WF1 REQ-08, WF3 F2(models-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF