### PR TITLE
fix(ai): W1b — ai_gate malformed-element guard + revive dead sighting-aggregation AI branch

### DIFF
--- a/app/services/search_worker_base/ai_gate.py
+++ b/app/services/search_worker_base/ai_gate.py
@@ -222,8 +222,10 @@ class AIGate:
                         item.updated_at = datetime.now(timezone.utc)
                     break  # Stop processing further batches during this cycle
 
-                # Build a lookup by MPN
-                result_map = {normalize_mpn_key(r["mpn"]): r for r in results}
+                # Build a lookup by MPN. Skip elements with no usable 'mpn' — indexing
+                # r["mpn"] here would KeyError BEFORE the per-item malformed guard
+                # below, aborting the batch and skipping the commit (poison recycle).
+                result_map = {normalize_mpn_key(r["mpn"]): r for r in results if isinstance(r, dict) and r.get("mpn")}
 
                 for item in batch_items:
                     classification = result_map.get(normalize_mpn_key(item.mpn))

--- a/app/services/sighting_aggregation.py
+++ b/app/services/sighting_aggregation.py
@@ -46,16 +46,22 @@ def _estimate_qty_with_ai(qty_values: list[int | None]) -> dict:
     if len(non_null) <= 2:
         return {"qty": sum(non_null), "approximate": False}
 
+    # Resolve the key OUTSIDE the try: a config/credential problem must surface as
+    # the no-key fallback, not be swallowed as "AI failed". (This branch was dead
+    # since it shipped — it read settings.ANTHROPIC_API_KEY, which doesn't exist
+    # [the field is lowercase], and the AttributeError was eaten by the except.)
+    from app.services.credential_service import get_credential_cached
+
+    api_key = get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY")
+    if not api_key:
+        return {"qty": max(non_null), "approximate": True}
+
     try:
         import anthropic
 
-        from app.config import settings
         from app.utils.claude_client import MODELS
 
-        if not settings.ANTHROPIC_API_KEY:
-            return {"qty": max(non_null), "approximate": True}
-
-        client = anthropic.Anthropic(api_key=settings.ANTHROPIC_API_KEY)
+        client = anthropic.Anthropic(api_key=api_key)
         prompt = (
             f"Given these quantity listings from the same vendor for the same part: {non_null}. "
             f"Some may be duplicate stock listed on different platforms. "

--- a/tests/test_ai_gate.py
+++ b/tests/test_ai_gate.py
@@ -299,3 +299,33 @@ class TestProcessAIGate:
         # Fail open, not left 'pending' — otherwise the item recycles as a poison row.
         assert item.status == "queued"
         assert item.gate_decision == "search"
+
+    @pytest.mark.asyncio
+    async def test_result_element_without_mpn_key_does_not_abort_batch(self):
+        """A results ELEMENT with no 'mpn' key must not KeyError inside the result_map
+        comprehension (which runs BEFORE the per-item malformed guard) — that aborts the
+        whole batch and skips the commit, recycling every item as poison.
+
+        The mpn-less element is discarded; the item it would have described fails open
+        like any omitted item, and valid sibling elements still classify normally.
+        """
+        classified = self._make_item("STM32F407")
+        orphaned = self._make_item("LM358")
+        model = MagicMock()
+        db_mock = self._db_with_items([classified, orphaned])
+
+        gate = AIGate(model, "ICsource", "search_ics")
+        classifications = [
+            {"mpn": "STM32F407", "search_ics": True, "commodity": "semiconductor", "reason": "mcu"},
+            # Malformed element: model dropped the 'mpn' key entirely.
+            {"search_ics": True, "commodity": "semiconductor", "reason": "op-amp"},
+        ]
+        with patch.object(gate, "classify_parts_batch", new_callable=AsyncMock, return_value=classifications):
+            await gate.process_ai_gate(db_mock)
+
+        assert classified.status == "queued"
+        assert classified.gate_decision == "search"
+        # The orphaned item fails open instead of recycling as a poison row.
+        assert orphaned.status == "queued"
+        assert orphaned.gate_decision == "search"
+        assert "no classification" in orphaned.gate_reason

--- a/tests/test_claude_sdk_timeout.py
+++ b/tests/test_claude_sdk_timeout.py
@@ -34,19 +34,11 @@ def _make_mock_anthropic(text: str):
 def test_estimate_qty_passes_bounded_timeout():
     from app.services.sighting_aggregation import _estimate_qty_with_ai
 
-    module, client = _make_mock_anthropic("350")
-    mock_settings = MagicMock()
-    mock_settings.ANTHROPIC_API_KEY = "sk-test-key"
-    mock_claude_client = MagicMock()
-    mock_claude_client.MODELS = {"fast": "claude-haiku-3"}
+    _module, client = _make_mock_anthropic("350")
 
-    with patch.dict(
-        "sys.modules",
-        {
-            "anthropic": module,
-            "app.config": MagicMock(settings=mock_settings),
-            "app.utils.claude_client": mock_claude_client,
-        },
+    with (
+        patch("app.services.credential_service.get_credential_cached", return_value="sk-test-key"),
+        patch("anthropic.Anthropic", return_value=client),
     ):
         result = _estimate_qty_with_ai([100, 200, 300])
 

--- a/tests/test_data_integrity_h8_h10_h11_h12.py
+++ b/tests/test_data_integrity_h8_h10_h11_h12.py
@@ -152,36 +152,29 @@ class TestH11QtyEstimation:
         assert _estimate_qty_with_ai(qtys) == expected
 
     def test_three_values_no_api_key_returns_max_approximate(self):
-        """Without ANTHROPIC_API_KEY, fallback uses max and marks approximate."""
+        """Without an Anthropic credential, fallback uses max and marks approximate."""
         from app.services.sighting_aggregation import _estimate_qty_with_ai
 
-        with patch("app.config.settings") as mock_settings:
-            mock_settings.ANTHROPIC_API_KEY = ""
+        with patch("app.services.credential_service.get_credential_cached", return_value=None):
             result = _estimate_qty_with_ai([100, 200, 300])
 
         assert result == {"qty": 300, "approximate": True}
 
     def test_ai_exception_returns_max_approximate(self):
         """When Claude API call fails, returns max with approximate=True."""
-        from unittest.mock import patch as _patch
-
         from app.services.sighting_aggregation import _estimate_qty_with_ai
 
-        mock_anthropic_mod = MagicMock()
-        mock_anthropic_mod.Anthropic.side_effect = RuntimeError("API error")
-
-        with _patch.dict("sys.modules", {"anthropic": mock_anthropic_mod}):
-            with _patch("app.config.settings") as mock_settings:
-                mock_settings.ANTHROPIC_API_KEY = "sk-test"
-                result = _estimate_qty_with_ai([50, 100, 150])
+        with (
+            patch("app.services.credential_service.get_credential_cached", return_value="sk-test"),
+            patch("anthropic.Anthropic", side_effect=RuntimeError("API error")),
+        ):
+            result = _estimate_qty_with_ai([50, 100, 150])
 
         assert result["qty"] == 150  # max, not sum (350)
         assert result["approximate"] is True
 
     def test_ai_success_returns_exact(self):
         """When Claude responds with a number, returns exact result."""
-        from unittest.mock import patch as _patch
-
         from app.services.sighting_aggregation import _estimate_qty_with_ai
 
         mock_resp = MagicMock()
@@ -190,15 +183,10 @@ class TestH11QtyEstimation:
         mock_client = MagicMock()
         mock_client.messages.create.return_value = mock_resp
 
-        mock_anthropic_mod = MagicMock()
-        mock_anthropic_mod.Anthropic.return_value = mock_client
-
         with (
-            _patch.dict("sys.modules", {"anthropic": mock_anthropic_mod}),
-            _patch("app.config.settings") as mock_settings,
-            _patch("app.utils.claude_client.MODELS", {"fast": "claude-3-haiku"}),
+            patch("app.services.credential_service.get_credential_cached", return_value="sk-test"),
+            patch("anthropic.Anthropic", return_value=mock_client),
         ):
-            mock_settings.ANTHROPIC_API_KEY = "sk-test"
             result = _estimate_qty_with_ai([100, 200, 300])
 
         assert result == {"qty": 250, "approximate": False}

--- a/tests/test_sighting_aggregation.py
+++ b/tests/test_sighting_aggregation.py
@@ -553,18 +553,21 @@ class TestEstimateQtyWithAI:
         result = _estimate_qty_with_ai([None, 100])
         assert result == {"qty": 100, "approximate": False}
 
+    # Regression note (2026-07-02): these three tests previously replaced the whole
+    # app.config module with a MagicMock, on which ANY attribute exists — which is
+    # exactly how the production bug (settings.ANTHROPIC_API_KEY, a nonexistent
+    # uppercase field, swallowed by the broad except) shipped green while the AI
+    # branch was dead. They now patch the REAL seams: the credential store the
+    # function actually reads, and anthropic.Anthropic at its source module.
+
     def test_three_values_no_api_key_returns_max(self):
-        # > 2 non-null values but no API key → max fallback
-        # settings is imported lazily inside the function; mock app.config.settings
-        mock_settings = MagicMock()
-        mock_settings.ANTHROPIC_API_KEY = None
-        with patch.dict("sys.modules", {"app.config": MagicMock(settings=mock_settings)}):
+        # > 2 non-null values but no credential → max fallback, flagged approximate
+        with patch("app.services.credential_service.get_credential_cached", return_value=None):
             result = _estimate_qty_with_ai([100, 200, 300])
-        # Falls into the "no API key" branch → max fallback
         assert result == {"qty": 300, "approximate": True}
 
     def test_three_values_ai_success(self):
-        # > 2 values with API key → Claude returns a number
+        # > 2 values with a credential → Claude's estimate is used
         mock_content = MagicMock()
         mock_content.text = "350"
         mock_resp = MagicMock()
@@ -572,42 +575,20 @@ class TestEstimateQtyWithAI:
         mock_client = MagicMock()
         mock_client.messages.create.return_value = mock_resp
 
-        mock_settings = MagicMock()
-        mock_settings.ANTHROPIC_API_KEY = "sk-test-key"
-        mock_anthropic_module = MagicMock()
-        mock_anthropic_module.Anthropic.return_value = mock_client
-        mock_claude_client = MagicMock()
-        mock_claude_client.MODELS = {"fast": "claude-haiku-3"}
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "anthropic": mock_anthropic_module,
-                "app.config": MagicMock(settings=mock_settings),
-                "app.utils.claude_client": mock_claude_client,
-            },
+        with (
+            patch("app.services.credential_service.get_credential_cached", return_value="sk-test-key"),
+            patch("anthropic.Anthropic", return_value=mock_client) as anthropic_cls,
         ):
             result = _estimate_qty_with_ai([100, 200, 300])
 
         assert result == {"qty": 350, "approximate": False}
+        anthropic_cls.assert_called_once_with(api_key="sk-test-key")
 
     def test_three_values_ai_exception_returns_max(self):
-        # AI call throws → max fallback (exception caught)
-        # Any exception inside the try block → fallback to max
-        mock_settings = MagicMock()
-        mock_settings.ANTHROPIC_API_KEY = "sk-test-key"
-        mock_anthropic_module = MagicMock()
-        mock_anthropic_module.Anthropic.side_effect = Exception("API error")
-        mock_claude_client = MagicMock()
-        mock_claude_client.MODELS = {"fast": "claude-haiku-3"}
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "anthropic": mock_anthropic_module,
-                "app.config": MagicMock(settings=mock_settings),
-                "app.utils.claude_client": mock_claude_client,
-            },
+        # AI call throws → max fallback (exception caught inside the try)
+        with (
+            patch("app.services.credential_service.get_credential_cached", return_value="sk-test-key"),
+            patch("anthropic.Anthropic", side_effect=Exception("API error")),
         ):
             result = _estimate_qty_with_ai([100, 200, 300])
 


### PR DESCRIPTION
Second Wave-1 slice — two verified findings from the code-health review:

1. **ai_gate batch abort** (WF3 F6, manually re-verified): the `result_map` comprehension indexed `r['mpn']` before the per-item malformed guard could run — one model element without an `mpn` key aborted the whole batch and skipped the commit, recycling every item as poison. Elements without a usable mpn are now discarded and their items fail open (the #610 hardening was one key short).
2. **Dead AI branch since it shipped** (WF2 DC-01): `_estimate_qty_with_ai` read `settings.ANTHROPIC_API_KEY` (the field is lowercase) and the AttributeError was swallowed as 'AI failed' — the Claude qty de-dup estimation never executed once. Key now resolves via `get_credential_cached` (the canonical path every other caller uses) outside the try.
3. **Mock-fragility cleanup**: the three tests covering that branch replaced the whole `app.config` module with a MagicMock — any attribute exists on a mock, which is exactly how the dead branch shipped green. Rewritten against real seams.

Tests: 50 + 23 + 7 ripple, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF