### PR TITLE
fix(startup): W1c — admin seed is env-driven, no hard-coded default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ AZURE_CLIENT_SECRET=
 AZURE_TENANT_ID=
 APP_URL=https://app.availai.net
 
+# ── Bootstrap admin (fresh installs) ──
+# Seeded once at startup if no user with this email exists. REQUIRED on a fresh
+# database or nobody can log in with admin rights; unset = no admin is seeded.
+SEED_ADMIN_EMAIL=
+SEED_ADMIN_NAME=
+
 # ── Local Password Login (development / non-Azure environments) ──
 # Enables the /auth/login password form as an alternative to Azure SSO.
 # SECURITY: relative to SSO this is an authentication bypass. Keep it

--- a/app/startup.py
+++ b/app/startup.py
@@ -212,8 +212,13 @@ def _seed_admin_user_if_env_set(db=None) -> None:
     Called by: run_startup_migrations
     Depends on: User model, SessionLocal
     """
-    email = os.environ.get("SEED_ADMIN_EMAIL", "vinod@trioscs.com")
-    name = os.environ.get("SEED_ADMIN_NAME", "Vinod")
+    email = os.environ.get("SEED_ADMIN_EMAIL")
+    if not email:
+        # No hard-coded default: seeding an admin into every fresh install without
+        # the operator asking for it is an access-control decision the env must make.
+        logger.debug("SEED_ADMIN_EMAIL not set — skipping admin seed")
+        return
+    name = os.environ.get("SEED_ADMIN_NAME", email.split("@")[0])
 
     from .models.auth import User
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -201,51 +201,71 @@ class TestCreateDefaultUser:
                 _create_default_user_if_env_set()
 
 
-class TestSeedVinodUser:
-    """Lines 102, 112-114, 117: _seed_admin_user_if_env_set logic."""
+class TestSeedAdminUser:
+    """_seed_admin_user_if_env_set logic — env-driven, no hard-coded default admin."""
+
+    _ENV = {"SEED_ADMIN_EMAIL": "ops@example.com", "SEED_ADMIN_NAME": "Ops"}
 
     @patch("app.startup.SessionLocal")
-    def test_creates_vinod_user(self, mock_sl, db_session):
-        """Creates Vinod admin user when not present."""
+    def test_creates_admin_user_from_env(self, mock_sl, db_session):
+        """Creates the env-named admin user when not present."""
         from app.startup import _seed_admin_user_if_env_set
 
         mock_sl.return_value = db_session
-        _seed_admin_user_if_env_set()
+        with patch.dict("os.environ", self._ENV):
+            _seed_admin_user_if_env_set()
 
         from app.models.auth import User
 
-        u = db_session.query(User).filter_by(email="vinod@trioscs.com").first()
+        u = db_session.query(User).filter_by(email="ops@example.com").first()
         assert u is not None
         assert u.role == "admin"
 
     @patch("app.startup.SessionLocal")
-    def test_skips_existing_vinod(self, mock_sl, db_session):
-        """Does not duplicate Vinod user."""
+    def test_skips_existing_admin(self, mock_sl, db_session):
+        """Does not duplicate the admin user."""
         from app.models.auth import User
         from app.startup import _seed_admin_user_if_env_set
 
         mock_sl.return_value = db_session
-        existing = User(email="vinod@trioscs.com", name="Vinod", role="admin")
+        existing = User(email="ops@example.com", name="Ops", role="admin")
         db_session.add(existing)
         db_session.commit()
 
-        _seed_admin_user_if_env_set()
-        count = db_session.query(User).filter_by(email="vinod@trioscs.com").count()
+        with patch.dict("os.environ", self._ENV):
+            _seed_admin_user_if_env_set()
+        count = db_session.query(User).filter_by(email="ops@example.com").count()
         assert count == 1
 
-    def test_seed_vinod_with_passed_db(self, db_session):
+    def test_seed_with_passed_db(self, db_session):
         """When db is passed directly, does not create/close own session."""
         from app.startup import _seed_admin_user_if_env_set
 
-        _seed_admin_user_if_env_set(db=db_session)
+        with patch.dict("os.environ", self._ENV):
+            _seed_admin_user_if_env_set(db=db_session)
 
         from app.models.auth import User
 
-        u = db_session.query(User).filter_by(email="vinod@trioscs.com").first()
+        u = db_session.query(User).filter_by(email="ops@example.com").first()
         assert u is not None
 
     @patch("app.startup.SessionLocal")
-    def test_seed_vinod_handles_error(self, mock_sl):
+    def test_env_unset_seeds_nothing_and_opens_no_session(self, mock_sl):
+        """No SEED_ADMIN_EMAIL means no seed and no DB session (CFG-8).
+
+        The old hard-coded default seeded an admin into every fresh install.
+        """
+        import os
+
+        from app.startup import _seed_admin_user_if_env_set
+
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("SEED_ADMIN_EMAIL", None)
+            _seed_admin_user_if_env_set()
+        mock_sl.assert_not_called()
+
+    @patch("app.startup.SessionLocal")
+    def test_seed_handles_error(self, mock_sl):
         """DB error is rolled back and re-raised."""
         from app.startup import _seed_admin_user_if_env_set
 
@@ -256,7 +276,7 @@ class TestSeedVinodUser:
         mock_db.close = MagicMock()
         mock_sl.return_value = mock_db
 
-        with pytest.raises(RuntimeError, match="DB error"):
+        with patch.dict("os.environ", self._ENV), pytest.raises(RuntimeError, match="DB error"):
             _seed_admin_user_if_env_set()
         mock_db.rollback.assert_called_once()
         mock_db.close.assert_called_once()

--- a/tests/test_vinod_seed.py
+++ b/tests/test_vinod_seed.py
@@ -1,27 +1,56 @@
 """Tests for _seed_admin_user_if_env_set() in startup.py.
 
-Verifies idempotent creation of the admin user.
+Verifies the seed is env-driven (no hard-coded default admin) and idempotent.
 """
+
+from unittest.mock import patch
 
 from app.models.auth import User
 from app.startup import _seed_admin_user_if_env_set
 
 
-def test_seed_vinod_creates_user(db_session):
-    """_seed_admin_user_if_env_set creates an admin user with the correct fields."""
-    _seed_admin_user_if_env_set(db=db_session)
+def test_env_unset_seeds_nothing(db_session):
+    """Without SEED_ADMIN_EMAIL, nothing is seeded (CFG-8).
 
-    user = db_session.query(User).filter_by(email="vinod@trioscs.com").first()
+    The old hard-coded default silently created an admin on every fresh install.
+    """
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+
+        os.environ.pop("SEED_ADMIN_EMAIL", None)
+        _seed_admin_user_if_env_set(db=db_session)
+
+    assert db_session.query(User).filter_by(role="admin").count() == 0
+
+
+def test_seed_creates_user_from_env(db_session):
+    """_seed_admin_user_if_env_set creates an admin user from the env vars."""
+    with patch.dict("os.environ", {"SEED_ADMIN_EMAIL": "ops@example.com", "SEED_ADMIN_NAME": "Ops"}):
+        _seed_admin_user_if_env_set(db=db_session)
+
+    user = db_session.query(User).filter_by(email="ops@example.com").first()
     assert user is not None
-    assert user.name == "Vinod"
+    assert user.name == "Ops"
     assert user.role == "admin"
     assert user.password_hash is None
 
 
-def test_seed_vinod_idempotent(db_session):
-    """Calling _seed_admin_user_if_env_set twice creates only one user."""
-    _seed_admin_user_if_env_set(db=db_session)
-    _seed_admin_user_if_env_set(db=db_session)
+def test_seed_name_defaults_to_email_local_part(db_session):
+    with patch.dict("os.environ", {"SEED_ADMIN_EMAIL": "vinod@trioscs.com"}):
+        import os
 
-    count = db_session.query(User).filter_by(email="vinod@trioscs.com").count()
-    assert count == 1
+        os.environ.pop("SEED_ADMIN_NAME", None)
+        _seed_admin_user_if_env_set(db=db_session)
+
+    user = db_session.query(User).filter_by(email="vinod@trioscs.com").first()
+    assert user is not None
+    assert user.name == "vinod"
+
+
+def test_seed_idempotent(db_session):
+    """Calling _seed_admin_user_if_env_set twice creates only one user."""
+    with patch.dict("os.environ", {"SEED_ADMIN_EMAIL": "ops@example.com", "SEED_ADMIN_NAME": "Ops"}):
+        _seed_admin_user_if_env_set(db=db_session)
+        _seed_admin_user_if_env_set(db=db_session)
+
+    assert db_session.query(User).filter_by(email="ops@example.com").count() == 1


### PR DESCRIPTION
CFG-8 from the config-hygiene review: `_seed_admin_user_if_env_set` defaulted `SEED_ADMIN_EMAIL` to a hard-coded personal address, silently seeding that admin into every fresh install despite the function's name. Unset env now means no seed and no DB session. Documented in `.env.example`; the staging host got the explicit env vars (its DB already holds the admin row — verified live, zero access impact).

Tests rewritten to the env-driven contract, including the env-unset case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF