### PR TITLE
chore(ci/ops): W7a — CI efficiency + ops hardening quick wins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,18 @@ on:
     # schedule instead — see the `migration-full-cycle` job below (HIGH-DEVOPS-7).
     - cron: "0 7 * * *"
 
+# Cancel superseded runs of the same PR/branch; pushes to main and the nightly
+# schedule get a unique group per run (run_id) so they are never cancelled.
+concurrency:
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
+    # The nightly `schedule` trigger exists for migration-full-cycle below. The
+    # full test job already ran for every push/PR (and the host runs the suite
+    # nightly too) — don't burn ~12 runner-minutes re-running it every night.
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     # Suite has grown to ~13.8k tests; locally it runs in ~2.5 min, but the
     # 2-vCPU GitHub runner takes longer. 15-min was being exceeded before the
@@ -197,10 +207,15 @@ jobs:
         env:
           TESTING: "1"
           PYTHONPATH: ${{ github.workspace }}
+        # -q not -v: ~21k tests at -v stream megabytes of log the 2-vCPU runner
+        # has to flush (a measurable slice of the ~9m step); failures still show
+        # full detail via --tb=short. --cov-report=term (not term-missing): the
+        # per-line miss dump belongs in coverage.xml, not thousands of log lines.
+        # fail-under=85: actual coverage sits ~94%; the old 50 could never fire.
         run: |
-          pytest tests/ -v --tb=short \
-            --cov=app --cov-report=term-missing --cov-report=xml:coverage.xml \
-            --cov-fail-under=50 \
+          pytest tests/ -q --tb=short \
+            --cov=app --cov-report=term --cov-report=xml:coverage.xml \
+            --cov-fail-under=85 \
             --junitxml=test-results.xml
 
       - name: Redis integration tests
@@ -221,6 +236,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-results
+          # Debugging artifacts go stale in days; the default 90-day retention
+          # just accumulates storage.
+          retention-days: 14
           path: |
             test-results.xml
             coverage.xml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,11 +37,20 @@ jobs:
           npm ci
 
       - name: Bandit security linter
-        run: bandit -r app/ -c pyproject.toml -f json -o bandit-report.json || true
-
-      - name: Bandit summary
-        if: always()
-        run: bandit -r app/ -c pyproject.toml -ll
+        # Single scan: the JSON artifact and the gating summary come from ONE
+        # bandit run (it used to scan app/ twice back-to-back). -ll gates on
+        # medium+ severity; the JSON report is uploaded below for triage.
+        run: |
+          bandit -r app/ -c pyproject.toml -f json -o bandit-report.json -ll || rc=$?
+          bandit_exit=${rc:-0}
+          python -c "
+          import json
+          d = json.load(open('bandit-report.json'))
+          for r in d.get('results', []):
+              print(f\"{r['issue_severity']}: {r['filename']}:{r['line_number']} {r['test_id']} {r['issue_text']}\")
+          print(f\"{len(d.get('results', []))} finding(s)\")
+          "
+          exit $bandit_exit
 
       - name: pip-audit vulnerability scan
         # --requirement scopes the audit to declared deps (app + dev) and their

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,7 +179,9 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
+      # :ro — the internet-facing container must not be able to rewrite its own
+      # routing/security config if compromised.
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
       - static_files:/srv/static:ro

--- a/scripts/nightly_tests.sh
+++ b/scripts/nightly_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Nightly full test suite + 100% coverage check
-# Runs at 2am via cron — logs to /var/log/avail/nightly_tests/
+# Nightly full test suite + coverage check on the HOST checkout.
+# Called by: root crontab (30 2 * * * — 02:30 UTC) — logs to /var/log/avail/nightly_tests/
+# Note: per-day logs here are pruned by /etc/logrotate.d/avail (host config).
 
 set -euo pipefail
 


### PR DESCRIPTION
Verified findings from the CI-efficiency and server-ops review:

- **CI-2**: concurrency groups — superseded runs on the same PR now cancel instead of running to completion (main pushes and nightly schedule are never cancelled).
- **CI-3**: the nightly `schedule` trigger no longer re-runs the full test job (~12 wasted runner-minutes/night) — it exists for `migration-full-cycle`.
- **CI-6**: pytest runs `-q` with `--cov-report=term` — `-v` over ~21k tests plus the per-line miss dump was megabytes of streamed log on a 2-vCPU runner.
- **CI-8**: `--cov-fail-under` raised 50→85 (actual coverage ~94%; the old gate could never fire).
- **CI-9**: artifact retention 90→14 days.
- **CI-10 (part)**: bandit scans `app/` once instead of twice; single run feeds both the JSON artifact and the medium+ gate.
- **OPS-12**: Caddyfile mounted `:ro` into the internet-facing container (applies at next deploy).
- **Host-side (no repo diff)**: `/etc/logrotate.d/avail` now rotates `/var/log/avail` (nothing did — March-era logs were accumulating) and crontab comments were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF