### PR TITLE
chore(dead-code): W2a — dead macros, dead helpers, stale comments, env-example model pin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,10 @@ DEFAULT_USER_ROLE=buyer
 
 # ── AI ──
 ANTHROPIC_API_KEY=
-ANTHROPIC_MODEL=claude-sonnet-4-20250514
+# Optional override — leave unset to use the code default (config.py
+# anthropic_model), which tracks the current recommended model. Pinning an
+# old id here silently downgrades every AI feature.
+# ANTHROPIC_MODEL=
 
 # ── Data Sources ──
 NEXAR_CLIENT_ID=

--- a/app/services/activity_service.py
+++ b/app/services/activity_service.py
@@ -196,11 +196,6 @@ def match_email_to_entity(email_addr: str, db: Session) -> dict | None:
     return None
 
 
-def _phone_digits(phone: str | None) -> str:
-    """Return only the digit characters of a phone string ("" if none)."""
-    return "".join(c for c in (phone or "") if c.isdigit())
-
-
 def _match_vendor_card_by_phone(db: Session, e164: str) -> VendorCard | None:
     """Find one non-blacklisted VendorCard whose normalized_phones contains e164.
 

--- a/app/services/approvals/notifications.py
+++ b/app/services/approvals/notifications.py
@@ -18,14 +18,6 @@ from sqlalchemy.orm import Session
 # used by buyplan_notifications and avoid import-time side effects.
 
 
-# Re-exported here so tests can patch at the source module.
-def _import_graph():
-    from app.utils.graph_client import GraphClient
-    from app.utils.token_manager import get_valid_token
-
-    return GraphClient, get_valid_token
-
-
 # Make them patchable at this module level (mirrors buyplan_notifications pattern).
 try:
     from app.utils.graph_client import GraphClient  # noqa: F401

--- a/app/services/connector_service.py
+++ b/app/services/connector_service.py
@@ -58,11 +58,6 @@ _COMMS_CATEGORIES = {"email", "auth", "platform", "notifications", "voip", "comm
 _PLANNED = {"findchips", "future", "heilind", "lcsc", "rochester", "verical"}
 
 
-def is_planned(source) -> bool:
-    """Return True when the source is a roadmap connector (not yet built)."""
-    return source.name in _PLANNED
-
-
 def control_type(source) -> str:
     name = source.name
     # Planned check first — must take priority over key/keyless logic.

--- a/app/static/htmx_mobile.css
+++ b/app/static/htmx_mobile.css
@@ -1,7 +1,7 @@
 /*
   htmx_mobile.css — Mobile-specific styles for the HTMX + Alpine.js frontend.
   Handles touch-friendly tap targets, mobile bottom nav, and drawer behavior.
-  Called by: base.html (via <link>)
+  Called by: htmx_app.js (import './htmx_mobile.css' — ships inside that Vite bundle)
   Depends on: styles.css (base styles, CSS variables)
 */
 

--- a/app/templates/htmx/partials/customers/_contact_macros.html
+++ b/app/templates/htmx/partials/customers/_contact_macros.html
@@ -105,25 +105,6 @@
 {% endmacro %}
 
 
-{# ── Compact last-touch indicator (always-visible row) ─────────────────────────── #}
-{% macro _last_touch_compact(contact, now_utc, cadence) %}
-{# Shows a cadence dot + compact "Xd" text. NULL → "—". #}
-{% set out_ts = contact.last_outbound_at if contact else none %}
-{% set _dot = {'new': 'bg-gray-300', 'on_target': 'bg-emerald-400', 'due': 'bg-amber-400', 'overdue': 'bg-rose-500'} %}
-{% set _dot_cls = _dot.get(cadence, 'bg-gray-300') %}
-<span class="inline-flex items-center gap-1 text-[11px]"
-      title="{% if out_ts and now_utc %}Last outreach {{ (now_utc - out_ts).days }}d ago{% else %}No logged outreach yet{% endif %}">
-  <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 {{ _dot_cls }}"></span>
-  {% if out_ts and now_utc %}
-    {% set out_days = (now_utc - out_ts).days %}
-    <span class="{% if cadence == 'overdue' %}text-rose-600{% elif cadence == 'due' %}text-amber-600{% else %}text-gray-400{% endif %}">{{ out_days }}d</span>
-  {% else %}
-    <span class="text-gray-400">—<span class="sr-only"> no data</span></span>
-  {% endif %}
-</span>
-{% endmacro %}
-
-
 {# NOTE: the old per-card `contact_card` macro was removed as dead code — the active
    CRM customer-tab surface is the compact-table `contact_row` macro below. #}
 

--- a/app/templates/htmx/partials/shared/_macros.html
+++ b/app/templates/htmx/partials/shared/_macros.html
@@ -214,40 +214,6 @@ Usage:
 {%- endmacro %}
 
 
-{# ── Opportunity Table v2 — Deal Value ────────────────────────────── #}
-{#
-  Purpose:     Dollar amount with typographic-magnitude encoding.
-  Depends on:  styles.css opp-deal-* tokens.
-  Called-by:   requisitions2/_table_rows.html, _single_row.html
-  Business:    Tier by magnitude (>=100k primary-500, 1k–99,999 primary-400,
-               <1k tertiary). source='computed' → italic. source='partial' →
-               italic + leading ~ + floor-estimate tooltip (priced_count /
-               requirement_count interpolated).
-#}
-{% macro deal_value(amount, source='entered', priced_count=0, requirement_count=0) -%}
-{%- if amount is none or amount == 0 -%}
-<span class="opp-deal opp-deal--tier-tertiary">—</span>
-{%- else -%}
-  {%- if amount >= 100000 -%}{%- set tier = 'primary-500' -%}
-  {%- elif amount >= 1000 -%}{%- set tier = 'primary-400' -%}
-  {%- else -%}{%- set tier = 'tertiary' -%}{%- endif -%}
-  {%- set prefix = '~' if source == 'partial' else '' -%}
-  {%- set italic_cls = ' opp-deal--computed' if source in ('computed', 'partial') else '' -%}
-  {%- set partial_cls = ' opp-deal--partial' if source == 'partial' else '' -%}
-  {%- if source == 'partial' -%}
-    {%- set title_text = 'Floor estimate — ' ~ priced_count ~ ' of ' ~ requirement_count ~ ' parts priced' -%}
-  {%- elif source == 'computed' -%}
-    {%- set title_text = 'Computed from target prices (all parts priced)' -%}
-  {%- elif source == 'entered' -%}
-    {%- set title_text = 'Entered by broker' -%}
-  {%- else -%}
-    {%- set title_text = '' -%}
-  {%- endif -%}
-<span class="opp-deal opp-deal--tier-{{ tier }}{{ italic_cls }}{{ partial_cls }}"{% if title_text %} title="{{ title_text }}"{% endif %}>{{ prefix }}${{ '{:,.0f}'.format(amount) }}</span>
-{%- endif -%}
-{%- endmacro %}
-
-
 {# ── Opportunity Table v2 — Coverage Meter ────────────────────────── #}
 {#
   Purpose:     6-segment meter showing offers-covered / total requirements.
@@ -285,14 +251,6 @@ Usage:
   Business:    <24h red, <72h amber, else none. hours may be None (no
                deadline set or unparseable) — treat as not-urgent.
 #}
-{# ── Opportunity Table v2 — Urgency Accent Class ─────────────────── #}
-{% macro urgency_accent_class(hours, urgency) -%}
-{%- if hours is not none and hours <= 24 -%}opp-row--urgent-24h
-{%- elif hours is not none and hours <= 72 -%}opp-row--urgent-72h
-{%- elif urgency == 'critical' -%}opp-row--urgent-24h
-{%- endif -%}
-{%- endmacro %}
-
 {% macro time_text(hours) -%}
 {%- if hours is none -%}{%- elif hours < 0 -%}
 <span class="opp-time opp-time--24h">Overdue</span>

--- a/tests/test_opp_macros.py
+++ b/tests/test_opp_macros.py
@@ -13,8 +13,7 @@ ENV = templates.env
 
 def render_macro(call_expr: str, **ctx) -> str:
     tpl = ENV.from_string(
-        '{% from "htmx/partials/shared/_macros.html" import '
-        "status_dot, deal_value, coverage_meter, urgency_accent_class, time_text %}" + call_expr,
+        '{% from "htmx/partials/shared/_macros.html" import status_dot, coverage_meter, time_text %}' + call_expr,
     )
     return tpl.render(**ctx).strip()
 
@@ -37,55 +36,6 @@ def test_status_dot_buckets(value, bucket, label):
     html = render_macro(f'{{{{ status_dot("{value}") }}}}')
     assert f"opp-status-dot--{bucket}" in html
     assert f">{label}<" in html
-
-
-# ── deal_value ────────────────────────────────────────────────────────
-
-
-@pytest.mark.parametrize(
-    "amount,source,expect_class,expect_text",
-    [
-        (150000, "entered", "opp-deal--tier-primary-500", "$150,000"),
-        (5000, "entered", "opp-deal--tier-primary-400", "$5,000"),
-        (500, "entered", "opp-deal--tier-tertiary", "$500"),
-        (25000, "computed", "opp-deal--computed", "$25,000"),
-        (None, "none", "opp-deal--tier-tertiary", "—"),
-        (0, "none", "opp-deal--tier-tertiary", "—"),
-    ],
-)
-def test_deal_value_tiers(amount, source, expect_class, expect_text):
-    html = render_macro(f"{{{{ deal_value({amount!r}, {source!r}) }}}}")
-    assert expect_class in html
-    assert expect_text in html
-
-
-def test_deal_value_partial_has_tilde_and_italic_and_tooltip():
-    html = render_macro('{{ deal_value(30000, "partial", priced_count=3, requirement_count=5) }}')
-    assert "~$30,000" in html
-    assert "opp-deal--computed" in html
-    assert "opp-deal--partial" in html
-    assert "3 of 5 parts priced" in html
-
-
-def test_deal_value_title_attr_is_escaped_not_safe():
-    """HIGH-SEC-1: the title tooltip must be rendered through Jinja2
-    autoescaping in the attribute context. A value containing HTML/quote
-    metacharacters (priced_count/requirement_count are normally ints, but
-    the macro must not trust them) must come out escaped — never raw.
-    """
-    html = render_macro(
-        '{{ deal_value(30000, "partial", priced_count=\'"><script>x</script>\', requirement_count=5) }}'
-    )
-    # The raw payload must not appear; the escaped form must.
-    assert "<script>x</script>" not in html
-    assert "&lt;script&gt;" in html
-    # The title attribute must still be present and well-formed.
-    assert 'title="Floor estimate' in html
-
-
-def test_deal_value_no_title_attr_for_unknown_source():
-    html = render_macro('{{ deal_value(500, "mystery") }}')
-    assert "title=" not in html
 
 
 # ── coverage_meter ────────────────────────────────────────────────────
@@ -111,25 +61,6 @@ def test_coverage_meter_full():
 def test_coverage_meter_aria_label():
     html = render_macro("{{ coverage_meter(2, 5) }}")
     assert 'aria-label="Coverage: 2 of 5 parts sourced"' in html
-
-
-# ── urgency_accent_class ──────────────────────────────────────────────
-
-
-@pytest.mark.parametrize(
-    "hours,urgency,expected",
-    [
-        (6, "normal", "opp-row--urgent-24h"),
-        (48, "normal", "opp-row--urgent-72h"),
-        (120, "normal", ""),
-        (None, "normal", ""),
-        (None, "critical", "opp-row--urgent-24h"),
-        (120, "critical", "opp-row--urgent-24h"),
-    ],
-)
-def test_urgency_accent_class(hours, urgency, expected):
-    html = render_macro(f"{{{{ urgency_accent_class({hours!r}, {urgency!r}) }}}}")
-    assert html == expected
 
 
 # ── time_text ─────────────────────────────────────────────────────────


### PR DESCRIPTION
First dead-code slice (each item adversarially verified + independently grep-confirmed before deletion):

- `deal_value` + `urgency_accent_class` macros — orphaned by the #622 /requisitions2 retirement; dedicated tests pruned (the file's other macros are live and keep theirs).
- `_last_touch_compact` (contact macros), `activity_service._phone_digits`, `approvals/notifications._import_graph`, `connector_service.is_planned` — zero call sites.
- `htmx_mobile.css` header comment corrected (Vite import, not a `<link>`).
- `.env.example` no longer pins an old `ANTHROPIC_MODEL` — copying the example was silently downgrading every AI feature [CFG-9].

Deliberately NOT here: the `mpn_chips_aggregated` → `_build_row_mpn_chips` → `requisition_list_service` cascade — that's W2b as one coherent PR (service deletion + authz-test re-pointing).

Tests: 744 green across the touched surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF