### PR TITLE
fix(nightly): W3a — pin nightly suite to clean origin/main worktree + honest crash status

### DIFF
--- a/scripts/nightly_tests.sh
+++ b/scripts/nightly_tests.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
-# Nightly full test suite + coverage check on the HOST checkout.
+# Nightly full test suite + coverage check against a CLEAN origin/main snapshot.
 # Called by: root crontab (30 2 * * * — 02:30 UTC) — logs to /var/log/avail/nightly_tests/
-# Note: per-day logs here are pruned by /etc/logrotate.d/avail (host config).
+#
+# Runs in a dedicated detached worktree (NOT the live checkout): the live
+# /root/availai is routinely mid-branch during active development, so testing it
+# at 02:30 tested an arbitrary snapshot — the 2026-06/07 red streak was partly
+# stale-checkout drift. pytest runs with cwd INSIDE the worktree so template
+# paths resolve against the snapshot, using the main checkout's .venv (deps
+# track the host install either way).
+#
+# Per-day logs here are pruned by /etc/logrotate.d/avail (host config).
 
 set -euo pipefail
 
@@ -11,14 +19,27 @@ mkdir -p "$LOG_DIR"
 DATE=$(date +%Y-%m-%d)
 LOG_FILE="$LOG_DIR/$DATE.log"
 
+REPO=/root/availai
+WT=/root/availai-worktrees/nightly-main
+PYTEST="$REPO/.venv/bin/pytest"
+
 echo "=== Nightly Test Run: $(date) ===" > "$LOG_FILE"
 
-cd /root/availai
+# Refresh the pinned worktree to origin/main (create on first run).
+git -C "$REPO" fetch -q origin main >> "$LOG_FILE" 2>&1
+if [ ! -d "$WT" ]; then
+    git -C "$REPO" worktree add --detach "$WT" origin/main >> "$LOG_FILE" 2>&1
+fi
+git -C "$WT" checkout -q --force --detach origin/main >> "$LOG_FILE" 2>&1
+git -C "$WT" clean -qfd >> "$LOG_FILE" 2>&1
+echo "Testing $(git -C "$WT" rev-parse --short HEAD) (origin/main)" >> "$LOG_FILE"
+
+cd "$WT"
 
 # Run full suite with coverage
 set +e
-TESTING=1 PYTHONPATH=/root/availai pytest tests/ \
-    --cov=app --cov-report=term-missing --tb=short -q \
+TESTING=1 PYTHONPATH="$WT" "$PYTEST" tests/ \
+    --cov=app --cov-report=term --tb=short -q \
     >> "$LOG_FILE" 2>&1
 
 EXIT_CODE=$?
@@ -33,14 +54,23 @@ echo "Exit code: $EXIT_CODE" >> "$LOG_FILE"
 echo "Coverage: ${COVERAGE}%" >> "$LOG_FILE"
 echo "Finished: $(date)" >> "$LOG_FILE"
 
-# Alert if tests failed or coverage dropped below 80%
-if [ "$EXIT_CODE" -ne 0 ] || [ "$COVERAGE" -lt 80 ]; then
-    echo "ALERT: Tests failed or coverage dropped to ${COVERAGE}%" >> "$LOG_FILE"
-    # Write a flag file for easy monitoring
-    echo "${DATE}: FAIL (exit=$EXIT_CODE, coverage=${COVERAGE}%)" > "$LOG_DIR/LAST_STATUS"
+# Classify the outcome honestly: an xdist INTERNALERROR (a worker crashed) is a
+# CRASH — pytest aborts before the coverage table, so coverage reads 0% and the
+# old summary conflated "suite crashed" with "coverage collapsed".
+if grep -q '^INTERNALERROR' "$LOG_FILE"; then
+    STATUS="CRASH (xdist internal error — see log; exit=$EXIT_CODE)"
+elif [ "$EXIT_CODE" -ne 0 ]; then
+    STATUS="FAIL (exit=$EXIT_CODE, coverage=${COVERAGE}%)"
+elif [ "$COVERAGE" -lt 80 ]; then
+    STATUS="FAIL (coverage dropped to ${COVERAGE}%)"
 else
-    echo "${DATE}: PASS (coverage=${COVERAGE}%)" > "$LOG_DIR/LAST_STATUS"
+    STATUS="PASS (coverage=${COVERAGE}%)"
 fi
+echo "${DATE}: ${STATUS}" > "$LOG_DIR/LAST_STATUS"
+case "$STATUS" in
+    PASS*) : ;;
+    *) echo "ALERT: ${STATUS}" >> "$LOG_FILE" ;;
+esac
 
 # Keep only last 30 days of logs
 find "$LOG_DIR" -name "*.log" -mtime +30 -delete 2>/dev/null || true


### PR DESCRIPTION
Root-caused the 4-night red streak (OPS-2/CI-1 from the ops review):

1. **The nightly tested whatever branch the live checkout was on at 02:30** — mid-program that's an arbitrary snapshot (the 2026-07-01 crash was on a template deleted by #622 that the stale checkout still had). It now refreshes a dedicated detached worktree to `origin/main` and runs inside it.
2. **Crash ≠ 0% coverage**: an xdist INTERNALERROR aborts pytest before the coverage table, so the summary said 'coverage=0%'. `LAST_STATUS` now reports `CRASH (xdist internal error)` distinctly.

Verified: syntax check + live smoke (worktree refreshed to `d7e4d4b5`, test file green inside it).

Remaining W3 (proper wave): the xdist worker-crash class itself + real alerting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF