### PR TITLE
fix(frontend): W6b — missing Vite manifest fails loud instead of silently blank

### DIFF
--- a/app/routers/htmx/_shared.py
+++ b/app/routers/htmx/_shared.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import Request
+from loguru import logger
 from sqlalchemy.orm import Session
 
 from ...constants import UserRole
@@ -25,6 +26,15 @@ _MANIFEST_PATH = Path("app/static/dist/.vite/manifest.json")
 _vite_manifest: dict = {}
 if _MANIFEST_PATH.exists():
     _vite_manifest = json.loads(_MANIFEST_PATH.read_text())
+else:
+    logger.critical(
+        "Vite manifest missing ({}) — the frontend will render UNSTYLED with dead JS "
+        "(the un-hashed fallback path never exists in dist/). Run `npm run build`, or "
+        "deploy via ./deploy.sh which builds it.",
+        _MANIFEST_PATH,
+    )
+
+_warned_missing_entry = False
 
 
 def _vite_assets() -> dict:
@@ -33,6 +43,17 @@ def _vite_assets() -> dict:
     Keys: js_file, css_files.
     """
     entry = _vite_manifest.get("htmx_app.js", {})
+    if not entry:
+        # Fail LOUDLY (but keep serving so dev-without-build still shows raw HTML):
+        # the fallback path below points at an asset Vite never emits, so every page
+        # would otherwise be silently blank/unstyled with a 404'd bundle.
+        global _warned_missing_entry
+        if not _warned_missing_entry:
+            _warned_missing_entry = True
+            logger.critical(
+                "Vite manifest has no 'htmx_app.js' entry — pages will be unstyled with "
+                "dead JS until `npm run build` produces app/static/dist/.vite/manifest.json"
+            )
     js_file = entry.get("file", "assets/htmx_app.js")
     css_files = entry.get("css", [])
     # Also add standalone styles entry if not already in css list

--- a/tests/test_htmx_views_nightly28.py
+++ b/tests/test_htmx_views_nightly28.py
@@ -171,3 +171,50 @@ class TestV2PageRequisitionsPath:
         db_session.commit()
         db_session.refresh(req)
         assert self._get(client, f"/v2/requisitions/{req.id}", test_user) == 200
+
+
+class TestViteManifestLoudness:
+    """FE-9 (production-polish): a missing manifest entry must be LOUD, not a silently
+    blank/unstyled app (the un-hashed fallback never exists in dist/)."""
+
+    def test_missing_entry_logs_critical_once(self):
+        from unittest.mock import patch
+
+        from app.routers.htmx import _shared
+
+        records = []
+        handler_id = None
+        from loguru import logger as _loguru
+
+        handler_id = _loguru.add(lambda m: records.append(m), level="CRITICAL")
+        try:
+            with (
+                patch.object(_shared, "_vite_manifest", {}),
+                patch.object(_shared, "_warned_missing_entry", False),
+            ):
+                out1 = _shared._vite_assets()
+                out2 = _shared._vite_assets()
+        finally:
+            _loguru.remove(handler_id)
+
+        assert out1["js_file"] == "assets/htmx_app.js"  # fallback still served
+        crits = [r for r in records if "htmx_app.js" in str(r)]
+        assert len(crits) == 1, "critical must fire exactly once, not per-request"
+
+    def test_present_entry_logs_nothing(self):
+        from unittest.mock import patch
+
+        from app.routers.htmx import _shared
+
+        records = []
+        from loguru import logger as _loguru
+
+        handler_id = _loguru.add(lambda m: records.append(m), level="CRITICAL")
+        try:
+            with patch.object(_shared, "_vite_manifest", {"htmx_app.js": {"file": "assets/htmx_app-abc.js"}}):
+                out = _shared._vite_assets()
+        finally:
+            _loguru.remove(handler_id)
+
+        assert out["js_file"] == "assets/htmx_app-abc.js"
+        assert not records


### PR DESCRIPTION
FE-9 from the frontend-assets review: a missing/entry-less Vite manifest fell back to an un-hashed asset path that never exists in `dist/` — the whole app rendered blank/unstyled with a 404'd bundle and no log signal. Now CRITICAL-logs (once, not per-request) while still serving raw HTML for dev-without-build.

TDD'd: fires exactly once; silent when the manifest is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF