### PR TITLE
fix(config): W5a — credential resolution for Hunter auto-enrich + vendor-affinity L3

### DIFF
--- a/app/routers/crm/companies.py
+++ b/app/routers/crm/companies.py
@@ -438,7 +438,10 @@ async def create_company(
     if domain and (
         get_credential_cached("explorium_enrichment", "EXPLORIUM_API_KEY")
         or get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY")
-        or getattr(settings, "hunter_api_key", "")
+        # Was settings.hunter_api_key — a nonexistent field that getattr defaulted to
+        # "", so a Hunter-only setup never auto-enriched. Resolve it the same way the
+        # enrichment path does (connectors-table credential, env fallback).
+        or get_credential_cached("hunter_enrichment", "HUNTER_API_KEY")
     ):
         from ...enrichment_service import apply_enrichment_to_company, enrich_entity
 

--- a/app/services/vendor_affinity_service.py
+++ b/app/services/vendor_affinity_service.py
@@ -11,7 +11,6 @@ from loguru import logger
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from app.config import settings
 from app.models import (
     EntityTag,
     MaterialCard,
@@ -167,9 +166,14 @@ def find_affinity_vendors_l2(mpn: str, db: Session, exclude_vendors: set[str] | 
 def find_affinity_vendors_l3(mpn: str, manufacturer: str | None, db: Session) -> list[dict]:
     """Use Claude to classify MPN into a category, then find vendors supplying that
     category."""
-    api_key = settings.anthropic_api_key
+    # Resolve via the credential store (connectors table, env fallback) — same as
+    # every other Anthropic caller. Reading settings.anthropic_api_key directly left
+    # L3 silently off whenever the key lives only in the DB, not the environment.
+    from app.services.credential_service import get_credential_cached
+
+    api_key = get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY")
     if not api_key:
-        logger.debug("L3: no anthropic_api_key configured, skipping")
+        logger.debug("L3: no Anthropic credential configured, skipping")
         return []
 
     # Classify the MPN into a sourcing category using Claude Haiku.

--- a/tests/test_vendor_affinity.py
+++ b/tests/test_vendor_affinity.py
@@ -226,9 +226,8 @@ def test_l2_no_tags(db_session: Session):
 
 
 def test_l3_skipped_without_api_key(db_session: Session):
-    """L3 returns empty list when no Anthropic API key is configured."""
-    with patch("app.services.vendor_affinity_service.settings") as mock_settings:
-        mock_settings.anthropic_api_key = ""
+    """L3 returns empty list when no Anthropic credential is configured."""
+    with patch("app.services.credential_service.get_credential_cached", return_value=None):
         results = find_affinity_vendors_l3("LM317T", "Texas Instruments", db_session)
     assert results == []
 
@@ -329,7 +328,8 @@ def test_find_vendor_affinity_deduplicates(db_session: Session):
     db_session.add(et)
     db_session.commit()
 
-    results = find_vendor_affinity("LM317T", db_session)
+    with patch("app.services.credential_service.get_credential_cached", return_value=None):
+        results = find_vendor_affinity("LM317T", db_session)
 
     # Arrow should appear only once
     arrow_results = [r for r in results if r["vendor_name"].lower() == "arrow electronics"]
@@ -359,5 +359,6 @@ def test_find_vendor_affinity_limits_to_10(db_session: Session):
 
     db_session.commit()
 
-    results = find_vendor_affinity("LM317T", db_session)
+    with patch("app.services.credential_service.get_credential_cached", return_value=None):
+        results = find_vendor_affinity("LM317T", db_session)
     assert len(results) <= 10

--- a/tests/test_vendor_affinity_coverage.py
+++ b/tests/test_vendor_affinity_coverage.py
@@ -262,16 +262,14 @@ class TestFindAffinityVendorsL3:
     def test_no_api_key_returns_empty(self, db_session: Session):
         from app.services.vendor_affinity_service import find_affinity_vendors_l3
 
-        with patch("app.services.vendor_affinity_service.settings") as mock_settings:
-            mock_settings.anthropic_api_key = None
+        with patch("app.services.credential_service.get_credential_cached", return_value=None):
             result = find_affinity_vendors_l3("LM317T", "TI", db_session)
         assert result == []
 
     def test_classify_returns_none_returns_empty(self, db_session: Session):
         from app.services.vendor_affinity_service import find_affinity_vendors_l3
 
-        with patch("app.services.vendor_affinity_service.settings") as mock_settings:
-            mock_settings.anthropic_api_key = "sk-fake"
+        with patch("app.services.credential_service.get_credential_cached", return_value="sk-fake"):
             with patch("app.services.vendor_affinity_service._classify_mpn", return_value=None):
                 result = find_affinity_vendors_l3("LM317T", "TI", db_session)
         assert result == []
@@ -294,8 +292,7 @@ class TestFindAffinityVendorsL3:
         db_session.add(s)
         db_session.commit()
 
-        with patch("app.services.vendor_affinity_service.settings") as mock_settings:
-            mock_settings.anthropic_api_key = "sk-fake"
+        with patch("app.services.credential_service.get_credential_cached", return_value="sk-fake"):
             with patch("app.services.vendor_affinity_service._classify_mpn", return_value="Voltage Regulator"):
                 result = find_affinity_vendors_l3("LM317T", "TI", db_session)
 
@@ -394,8 +391,7 @@ class TestFindVendorAffinity:
     def test_empty_db_returns_empty_list(self, db_session: Session):
         from app.services.vendor_affinity_service import find_vendor_affinity
 
-        with patch("app.services.vendor_affinity_service.settings") as mock_settings:
-            mock_settings.anthropic_api_key = None
+        with patch("app.services.credential_service.get_credential_cached", return_value=None):
             result = find_vendor_affinity("UNKNOWN_MPN", db_session)
         assert isinstance(result, list)
         assert len(result) == 0
@@ -405,8 +401,7 @@ class TestFindVendorAffinity:
 
         with patch("app.services.vendor_affinity_service.find_affinity_vendors_l1") as mock_l1:
             with patch("app.services.vendor_affinity_service.find_affinity_vendors_l2") as mock_l2:
-                with patch("app.services.vendor_affinity_service.settings") as mock_settings:
-                    mock_settings.anthropic_api_key = None
+                with patch("app.services.credential_service.get_credential_cached", return_value=None):
                     mock_l1.return_value = [{"vendor_name": "Arrow", "level": 1, "mpn_count": 5, "manufacturer": "TI"}]
                     mock_l2.return_value = [{"vendor_name": "Arrow", "level": 2, "mpn_count": 3, "manufacturer": "TI"}]
                     result = find_vendor_affinity("LM317T", db_session)
@@ -423,8 +418,7 @@ class TestFindVendorAffinity:
         ]
         with patch("app.services.vendor_affinity_service.find_affinity_vendors_l1", return_value=many_vendors):
             with patch("app.services.vendor_affinity_service.find_affinity_vendors_l2", return_value=[]):
-                with patch("app.services.vendor_affinity_service.settings") as mock_settings:
-                    mock_settings.anthropic_api_key = None
+                with patch("app.services.credential_service.get_credential_cached", return_value=None):
                     result = find_vendor_affinity("LM317T", db_session)
 
         assert len(result) <= 10
@@ -435,8 +429,7 @@ class TestFindVendorAffinity:
         with patch("app.services.vendor_affinity_service.find_affinity_vendors_l1", return_value=[]):
             with patch("app.services.vendor_affinity_service.find_affinity_vendors_l2", return_value=[]):
                 with patch("app.services.vendor_affinity_service.find_affinity_vendors_l3", return_value=[]) as mock_l3:
-                    with patch("app.services.vendor_affinity_service.settings") as mock_settings:
-                        mock_settings.anthropic_api_key = "sk-fake"
+                    with patch("app.services.credential_service.get_credential_cached", return_value="sk-fake"):
                         find_vendor_affinity("LM317T", db_session)
 
         mock_l3.assert_called_once()
@@ -448,8 +441,7 @@ class TestFindVendorAffinity:
         with patch("app.services.vendor_affinity_service.find_affinity_vendors_l1", return_value=five_vendors):
             with patch("app.services.vendor_affinity_service.find_affinity_vendors_l2", return_value=[]):
                 with patch("app.services.vendor_affinity_service.find_affinity_vendors_l3") as mock_l3:
-                    with patch("app.services.vendor_affinity_service.settings") as mock_settings:
-                        mock_settings.anthropic_api_key = "sk-fake"
+                    with patch("app.services.credential_service.get_credential_cached", return_value="sk-fake"):
                         find_vendor_affinity("LM317T", db_session)
 
         mock_l3.assert_not_called()


### PR DESCRIPTION
Two features that were silently off whenever their key lived in the connectors DB but not the environment:

- **CFG-1**: companies auto-enrich gated on `settings.hunter_api_key` — a **nonexistent Settings field** that `getattr(..., "")` masked, so a Hunter-only setup never auto-enriched. Now resolves via `get_credential_cached('hunter_enrichment','HUNTER_API_KEY')` like `enrichment_service` and the sources key-test.
- **CFG-5**: `vendor_affinity_service.find_affinity_vendors_l3` read `settings.anthropic_api_key` (env-only) while every other Anthropic caller uses the credential store — a DB-only key left L3 dead. Now uses the credential store too.

Tests repointed to the credential-store contract (the L3-gated `find_vendor_affinity` tests that mocked settings to short-circuit L3 also relied on L3 not opening its own session — fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF