### PR TITLE
fix(config): W5b — unify follow-up staleness threshold on settings.follow_up_days

### DIFF
--- a/app/routers/htmx/offers.py
+++ b/app/routers/htmx/offers.py
@@ -1226,11 +1226,10 @@ async def follow_ups_list_partial(
     db: Session = Depends(get_db),
 ):
     """Cross-requisition follow-up queue as HTML partial."""
-    from ...config import settings as cfg
+    from ...config import settings
     from ...models.offers import Contact as RfqContact
 
-    threshold_days = getattr(cfg, "follow_up_days", 2)
-    threshold = datetime.now() - __import__("datetime").timedelta(days=threshold_days)
+    threshold = datetime.now(timezone.utc) - timedelta(days=settings.follow_up_days)
 
     stale_q = db.query(RfqContact).filter(
         RfqContact.contact_type == "email",
@@ -1745,11 +1744,12 @@ async def send_batch_follow_up(
     db: Session = Depends(get_db),
 ):
     """Send follow-ups to all stale contacts at once."""
+    from ...config import settings
     from ...models.offers import Contact as RfqContact
 
-    cfg = getattr(request.app, "state", None)
-    threshold_days = getattr(cfg, "follow_up_days", 2) if cfg else 2
-    threshold = datetime.now(timezone.utc) - timedelta(days=threshold_days)
+    # Was request.app.state.follow_up_days — a value nothing ever set, so this
+    # silently used the getattr default (2) and diverged from the queue/badge.
+    threshold = datetime.now(timezone.utc) - timedelta(days=settings.follow_up_days)
 
     q = db.query(RfqContact).filter(
         RfqContact.contact_type == "email",
@@ -1784,9 +1784,10 @@ async def follow_up_badge(
     db: Session = Depends(get_db),
 ):
     """Return follow-up count badge for nav sidebar."""
+    from ...config import settings
     from ...models.offers import Contact as RfqContact
 
-    threshold = datetime.now(timezone.utc) - timedelta(days=2)
+    threshold = datetime.now(timezone.utc) - timedelta(days=settings.follow_up_days)
     q = db.query(sqlfunc.count(RfqContact.id)).filter(
         RfqContact.contact_type == "email",
         RfqContact.status.in_(["sent", "opened"]),

--- a/tests/test_follow_up_threshold.py
+++ b/tests/test_follow_up_threshold.py
@@ -1,0 +1,75 @@
+"""W5b: the follow-up queue, batch-send, and nav badge must use ONE threshold.
+
+Regression: batch-send read request.app.state.follow_up_days (never set → getattr
+default 2) and the badge hardcoded 2, while the queue read settings.follow_up_days
+(3) — so the badge/batch counted a different staleness cutoff than the queue, and
+FOLLOW_UP_DAYS was silently ignored. All three now read settings.follow_up_days.
+
+Called by: pytest
+Depends on: app.routers.htmx.offers, conftest fixtures
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.models.offers import Contact as RfqContact
+from app.models.sourcing import Requisition
+
+
+def _contact_aged_days(db, user, days: int) -> None:
+    req = Requisition(name="FU-REQ", customer_name="FU Co", status="open")
+    db.add(req)
+    db.flush()
+    db.add(
+        RfqContact(
+            requisition_id=req.id,
+            user_id=user.id,
+            contact_type="email",
+            vendor_name="V Co",
+            vendor_contact="v@example.com",
+            status="sent",
+            created_at=datetime.now(timezone.utc) - timedelta(days=days),
+        )
+    )
+    db.commit()
+
+
+def test_badge_counts_contacts_older_than_configured_days(client: TestClient, db_session, test_user):
+    """A contact aged just past settings.follow_up_days (default 3) is counted; the
+    badge must NOT use the old hardcoded 2 (which would count a 2.5-day-old contact the
+    queue does not)."""
+    from app.config import settings
+
+    # Aged between 2 and 3 days: stale under the OLD 2-day badge, fresh under the
+    # real 3-day config — proves the badge now honors the config, not the literal 2.
+    _contact_aged_days(db_session, test_user, days=2)  # 2 full days < 3 → must NOT count
+
+    assert settings.follow_up_days == 3
+    resp = client.get("/v2/partials/follow-ups/badge")
+    assert resp.status_code == 200
+    # 2-day-old contact is fresh under the 3-day threshold → empty badge.
+    assert resp.text.strip() == ""
+
+
+def test_badge_counts_stale_contact(client: TestClient, db_session, test_user):
+    _contact_aged_days(db_session, test_user, days=5)  # older than 3 → counted
+    resp = client.get("/v2/partials/follow-ups/badge")
+    assert resp.status_code == 200
+    assert "1" in resp.text
+
+
+def test_all_three_surfaces_share_the_config_threshold(monkeypatch, client: TestClient, db_session, test_user):
+    """Badge, queue, and batch-send resolve the same settings.follow_up_days — bump it
+    and a contact between the old and new cutoff flips consistently everywhere."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "follow_up_days", 10)
+    _contact_aged_days(db_session, test_user, days=5)  # fresh under 10-day threshold
+
+    badge = client.get("/v2/partials/follow-ups/badge")
+    assert badge.text.strip() == "", "badge should honor the raised threshold"
+    queue = client.get("/v2/partials/follow-ups")
+    assert queue.status_code == 200
+    # The 5-day contact must not appear as stale in the queue under a 10-day cutoff.
+    assert "V Co" not in queue.text


### PR DESCRIPTION
CFG-2: the RFQ follow-up feature used three different staleness cutoffs:
- **queue** (`GET /v2/partials/follow-ups`): `settings.follow_up_days` = 3 ✓
- **batch-send**: `request.app.state.follow_up_days` — a value nothing ever sets, so `getattr(..., 2)` silently used **2**
- **nav badge**: hardcoded **2**

So badge and batch counted a 2-day cutoff while the queue used 3, and `FOLLOW_UP_DAYS` was ignored by two of three. All three now read `settings.follow_up_days`.

TDD'd (new file): the badge honors the config rather than the old literal 2, and badge+queue move together when the threshold changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF