### PR TITLE
refactor(auth): W5c — one canonical ENABLE_PASSWORD_LOGIN parse

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -232,6 +232,18 @@ async def logout(request: Request):
     return RedirectResponse("/v2/requisitions", status_code=302)
 
 
+def password_login_env_enabled() -> bool:
+    """True iff ENABLE_PASSWORD_LOGIN is set truthy in the environment.
+
+    Single canonical parse of this auth-critical flag — startup.py and the auth
+    router all call this instead of re-implementing the ``.lower() == "true"``
+    check (which previously lived, subtly copy-pasted, in three places). Read at
+    call time (not via config.py's import-time Settings) so the flag can be
+    toggled per-process — the behavior the tests and operator rely on.
+    """
+    return os.getenv("ENABLE_PASSWORD_LOGIN", "false").lower() == "true"
+
+
 def _password_login_enabled() -> bool:
     """Return True when local/test password login should be allowed.
 
@@ -239,7 +251,7 @@ def _password_login_enabled() -> bool:
     """
     if os.getenv("TESTING") == "1":
         return True
-    return os.getenv("ENABLE_PASSWORD_LOGIN", "false").lower() == "true"
+    return password_login_env_enabled()
 
 
 def _verify_password(stored: str, password: str) -> bool:

--- a/app/startup.py
+++ b/app/startup.py
@@ -76,7 +76,9 @@ def run_startup_migrations() -> None:
     Safe to call on every app boot.
     """
     # Warn if password login backdoor is active outside test mode
-    if os.getenv("ENABLE_PASSWORD_LOGIN", "false").lower() == "true" and not os.getenv("TESTING"):
+    from .routers.auth import password_login_env_enabled
+
+    if password_login_env_enabled() and not os.getenv("TESTING"):
         logger.critical(
             "ENABLE_PASSWORD_LOGIN is active in non-test mode. "
             "This creates an authentication bypass. Disable before production use."
@@ -107,7 +109,7 @@ def run_startup_migrations() -> None:
 
     _verify_encryption_canary()
     _backfill_normalized_mpn()
-    if os.environ.get("ENABLE_PASSWORD_LOGIN", "false").lower() == "true":
+    if password_login_env_enabled():
         _create_default_user_if_env_set()
     _backfill_sighting_offer_normalized_mpn()
     _backfill_sighting_vendor_normalized()


### PR DESCRIPTION
CFG-7: the auth-critical `ENABLE_PASSWORD_LOGIN` flag was parsed with an identical `os.getenv(...).lower() == 'true'` in three places. Extracted `password_login_env_enabled()` in `auth.py` as the single reader; both `startup.py` sites call it.

Deliberately kept **call-time env reads** rather than a `config.py` Settings field (read once at import): the auth tests and the operator toggle this flag per-process via the environment, which a config field would silently break. So this is a de-duplication, not a semantics change.

94 auth + startup tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF