### PR TITLE
fix(P0): quote-from-offers isn't emailed empty (OQ-01)

### DIFF
--- a/app/routers/htmx/offers.py
+++ b/app/routers/htmx/offers.py
@@ -341,6 +341,7 @@ async def create_quote_from_offers(
 
     subtotal = 0.0
     total_cost = 0.0
+    line_items = []  # canonical JSON the email/PDF render from (quote_send.py:220)
     for o in offers:
         sell_price = float(o.unit_price or 0)
         cost_price = sell_price  # Default cost = sell, buyer adjusts
@@ -358,9 +359,29 @@ async def create_quote_from_offers(
             margin_pct=margin_pct,
         )
         db.add(line)
+        # Mirror each line into quote.line_items in the shape quote_builder_service
+        # emits — otherwise the sent email / PDF render an EMPTY line-item table
+        # (they read quote.line_items, not the QuoteLine rows).
+        line_items.append(
+            {
+                "mpn": o.mpn or "",
+                "manufacturer": o.manufacturer or "",
+                "qty": qty,
+                "cost_price": cost_price,
+                "sell_price": sell_price,
+                "margin_pct": margin_pct,
+                "lead_time": o.lead_time,
+                "date_code": o.date_code,
+                "condition": o.condition,
+                "packaging": o.packaging,
+                "moq": o.moq,
+                "offer_id": o.id,
+            }
+        )
         subtotal += sell_price * qty
         total_cost += cost_price * qty
 
+    quote.line_items = line_items
     quote.subtotal = subtotal
     quote.total_cost = total_cost
     quote.total_margin_pct = ((subtotal - total_cost) / subtotal * 100) if subtotal else 0

--- a/tests/test_integration_quote_workflow.py
+++ b/tests/test_integration_quote_workflow.py
@@ -1,69 +1,36 @@
-"""test_integration_quote_workflow.py — Integration tests for the full quote lifecycle.
-
-Tests the complete workflow: create requisition → link to customer site → add
-requirements → log offers → build quote → update quote lines → mark result.
+"""test_integration_quote_workflow.py — Integration tests for the quote lifecycle.
 
 Called by: pytest
-Depends on: conftest.py (client, db_session, test_user, test_company fixtures)
+Depends on: conftest.py (client, db_session, test_requisition, test_offer fixtures)
 """
 
-import pytest
-
-pytestmark = pytest.mark.slow
-
-# ── Helpers ──────────────────────────────────────────────────────────────
+# ── Tests ────────────────────────────────────────────────────────────────
 
 
-def _setup_req_with_offers(client):
-    """Create a requisition linked to a customer site with offers.
+def test_create_quote_from_offers_populates_line_items_json(client, db_session, test_requisition, test_offer):
+    """P0 regression (OQ-01): creating a quote from selected offers must populate
+    quote.line_items (the JSON the emailed quote + PDF render from) — not only the
+    QuoteLine ORM rows the detail UI reads.
 
-    Returns (req_id, offer_ids).
+    Otherwise the customer receives an empty line-item table.
     """
-    # Create company + site
-    co = client.post("/api/companies", json={"name": "QuoteTest Corp"}).json()
-    site = client.post(
-        f"/api/companies/{co['id']}/sites",
-        json={"site_name": "HQ", "contact_name": "Jane", "contact_email": "jane@test.com"},
-    ).json()
+    from app.models import Quote
 
-    # Create requisition and link to site
-    req = client.post(
-        "/api/requisitions",
-        json={
-            "name": "Quote Workflow Test",
-            "customer_site_id": site["id"],
-        },
-    ).json()
-    req_id = req["id"]
+    resp = client.post(
+        f"/v2/partials/requisitions/{test_requisition.id}/create-quote",
+        data={"offer_ids": str(test_offer.id)},
+    )
+    assert resp.status_code == 200
 
-    items = client.post(
-        f"/api/requisitions/{req_id}/requirements",
-        json=[
-            {"primary_mpn": "LM317T", "manufacturer": "TI", "target_qty": 500, "target_price": 0.50},
-            {"primary_mpn": "NE555P", "manufacturer": "TI", "target_qty": 200, "target_price": 0.30},
-        ],
-    ).json()["created"]
-
-    offer1 = client.post(
-        f"/api/requisitions/{req_id}/offers",
-        json={
-            "mpn": "LM317T",
-            "vendor_name": "Arrow Electronics",
-            "unit_price": 0.45,
-            "qty_available": 1000,
-            "requirement_id": items[0]["id"],
-        },
-    ).json()
-
-    offer2 = client.post(
-        f"/api/requisitions/{req_id}/offers",
-        json={
-            "mpn": "NE555P",
-            "vendor_name": "Mouser",
-            "unit_price": 0.25,
-            "qty_available": 500,
-            "requirement_id": items[1]["id"],
-        },
-    ).json()
-
-    return req_id, [offer1["id"], offer2["id"]]
+    quote = (
+        db_session.query(Quote).filter(Quote.requisition_id == test_requisition.id).order_by(Quote.id.desc()).first()
+    )
+    assert quote is not None
+    assert quote.line_items, "quote.line_items must be populated (email/PDF render from it)"
+    assert len(quote.line_items) == 1
+    li = quote.line_items[0]
+    assert li["mpn"] == "LM317T"
+    assert li["sell_price"] == 0.50
+    assert li["qty"] == 1000
+    assert li["offer_id"] == test_offer.id
+    assert "manufacturer" in li


### PR DESCRIPTION
**P0.** `POST .../create-quote` (the Offers-tab 'Create Quote from Selected' action) built `QuoteLine` ORM rows — which the detail UI reads — but never set `quote.line_items`, the JSON column the **sent email** (`quote_send.py:220`) and the **PDF** render from. So a quote created off the Offers tab, when sent, delivered the customer an **empty line-item table**.

Fix: mirror each line into `quote.line_items` in the same shape `quote_builder_service` emits.

TDD: integration test asserts `line_items` is populated + coherent after create-quote. Also removed the file's stale, never-run `_setup_req_with_offers` helper (used dead API routes).

Second of the WF1 P0 cluster. Report: docs/audit/2026-07-02-production-polish-review.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF