### PR TITLE
fix(P0): system-settings toggles work (SET-01)

### DIFF
--- a/app/templates/htmx/partials/settings/system.html
+++ b/app/templates/htmx/partials/settings/system.html
@@ -41,7 +41,10 @@
                    class="sr-only peer"
                    hx-put="/api/admin/config/{{ item.key }}"
                    hx-swap="none"
-                   hx-vals='js:{value: $el.checked ? "true" : "false"}'
+                   {# $el is an Alpine magic — undefined in htmx's js: eval, so the
+                      value was never computed and every toggle silently no-op'd.
+                      htmx exposes the change event; event.target is the checkbox. #}
+                   hx-vals='js:{value: event.target.checked ? "true" : "false"}'
                    hx-ext="json-enc"
                    data-loading-disable
                    aria-label="{{ item.label }}">

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -159,6 +159,33 @@ def test_no_tojson_in_double_quoted_alpine_attribute():
 _HX_VALS_JS = re.compile(r"""hx-vals\s*=\s*(['"])js:(.*?)\1""", re.DOTALL)
 
 
+def test_hx_vals_js_has_no_alpine_magics():
+    """`hx-vals="js:..."` runs in htmx's eval context (event + `this` = element), NOT
+    Alpine's — so Alpine magics like `$el`, `$store`, `$refs`, `$data` are UNDEFINED
+    there and throw, silently aborting the request.
+
+    Regression (SET-01): the system-settings toggles used `$el.checked`, so every
+    toggle no-op'd. Use `event.target` / `this` instead.
+
+    NOTE: `$store` is deliberately excluded here — the one remaining `$store` use
+    (sightings batch actions) is tracked separately as SIGHT-BATCH in the review
+    and fixed in its own wave; add it back to this ratchet once that lands.
+    """
+    magic = re.compile(r"\$(el|refs|data|dispatch|nextTick|watch)\b")
+    offenders: list[str] = []
+    for path in sorted(Path("app/templates").rglob("*.html")):
+        text = path.read_text()
+        for m in _HX_VALS_JS.finditer(text):
+            hit = magic.search(m.group(2))
+            if hit:
+                line = text[: m.start()].count("\n") + 1
+                offenders.append(f"{path.relative_to(Path('.'))}:{line}: Alpine {hit.group(0)} in hx-vals js:")
+    assert not offenders, (
+        "hx-vals='js:...' must not reference Alpine magics (undefined in htmx eval → "
+        "request silently aborts). Use event.target / this:\n" + "\n".join(offenders)
+    )
+
+
 def test_hx_vals_js_is_object_literal():
     """`hx-vals="js:..."` MUST be a plain object literal (start with `{`).
 


### PR DESCRIPTION
**P0.** The admin System-settings boolean toggles used `hx-vals='js:{value: $el.checked ...}'`. `$el` is an **Alpine** magic — undefined in htmx's `js:` eval — so the expression threw and every toggle **silently no-op'd** (feature flags never persisted). Fixed to `event.target.checked`.

Added a static-analysis ratchet forbidding Alpine magics in `hx-vals='js:...'`. `$store` excluded for now (sightings-batch SIGHT-BATCH finding, own wave).

Fourth of the WF1 P0 cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF