### PR TITLE
fix(reqlist): P1 quick-wins — Claim/Unclaim renders + real 'won' status pill (REQ-07, REQ-03)

### DIFF
--- a/app/routers/htmx/requisitions.py
+++ b/app/routers/htmx/requisitions.py
@@ -259,6 +259,7 @@ async def requisitions_list_partial(
             "limit": limit,
             "offset": offset,
             "users": users,
+            "user": user,  # req_row kebab gates Claim/Unclaim on `user` — omitting it hid them
             "user_role": user.role,
             "inbox_status": get_inbox_sync_status(db, user),
         }

--- a/app/templates/htmx/partials/requisitions/list.html
+++ b/app/templates/htmx/partials/requisitions/list.html
@@ -125,7 +125,8 @@
 
       {# Status pills #}
       <div class="flex flex-wrap gap-2">
-        {% for s_val, s_label in [('', 'All'), ('open', 'Open'), ('awarded', 'Awarded')] %}
+        {# 'won' is the real RequisitionStatus; the old 'awarded' value doesn't exist and always returned empty. #}
+        {% for s_val, s_label in [('', 'All'), ('open', 'Open'), ('won', 'Won')] %}
         <button type="button"
                 @click="rStatus = '{{ s_val }}'"
                 hx-get="/v2/partials/requisitions"

--- a/tests/test_req_list_quote_column.py
+++ b/tests/test_req_list_quote_column.py
@@ -177,3 +177,40 @@ def test_mark_lost_confirm_posts_dynamically_not_static_won(client: TestClient, 
     # so 'Mark Lost' actually hits /action/lost.
     assert "htmx.ajax('POST', '/v2/partials/requisitions/" in html
     assert "/action/' + outcomePrompt" in html
+
+
+def test_claim_button_renders_for_buyer_on_unclaimed_req(client: TestClient, db_session, test_customer_site, test_user):
+    """REQ-07: the req_row kebab gates Claim/Unclaim on `user`, which the list route
+    omitted from its context — so the buttons never rendered. With `user` present, a
+    buyer sees Claim on an unclaimed requisition."""
+    from datetime import datetime, timezone
+
+    from app.models import Requisition
+
+    req = Requisition(
+        name="CLAIMABLE",
+        customer_name="Claim Co",
+        status="open",
+        customer_site_id=test_customer_site.id,
+        created_by=test_user.id,
+        claimed_by_id=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(req)
+    db_session.commit()
+
+    soup = _list_soup(client)
+    row = soup.select_one(f'tr[id="req-row-{req.id}"]')
+    assert row is not None
+    assert "Claim" in row.get_text(), "Claim kebab item must render (user now in context)"
+
+
+def test_status_pill_uses_real_won_status_not_phantom_awarded(client: TestClient, test_requisition):
+    """REQ-03: the status filter pill filtered on 'awarded', which is not a
+    RequisitionStatus, so it always returned an empty list. It now uses 'won'."""
+    resp = client.get("/v2/partials/requisitions")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "'awarded'" not in html and '"awarded"' not in html, "phantom 'awarded' status still referenced"
+    # The Won pill posts the real status value.
+    assert "status: 'won'" in html or '"status": "won"' in html or "{status: 'won'" in html


### PR DESCRIPTION
Two clearly-scoped requisitions-list P1s from the workflow review:

- **REQ-07**: the list route's template context had `user_role` but not `user`. `req_row.html` gates the Claim/Unclaim kebab items on `user` (and `req.claimed_by_id == user.id`), so they never rendered from the list — a buyer could never claim a requisition from the Sales Hub. Added `user` to the context.
- **REQ-03**: the status filter pill offered 'Awarded', filtering on `status == 'awarded'` — not a `RequisitionStatus` value, so it always returned an empty list. Now 'Won' → `status == 'won'`.

TDD'd both. The subtler requisitions P1s (dead multi-Build-Quote, Search-All-Sources mis-targeting, list push-url) follow in a considered wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF