### PR TITLE
fix(P0): revive the five dead buy-plan modals + template-x-if audit (BP-1)

### DIFF
--- a/app/templates/htmx/partials/buy_plans/detail.html
+++ b/app/templates/htmx/partials/buy_plans/detail.html
@@ -180,11 +180,13 @@
           </div>
           <div class="mt-5 flex justify-end gap-2">
             {{ modal_cancel_btn() }}
-            <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/submit"
-                    hx-target="#main-content"
-                    :hx-vals="JSON.stringify({sales_order_number: so, customer_po_number: cpo, salesperson_notes: notes})"
+            {# Confirm fires imperatively via htmx.ajax so it works INSIDE this
+               <template x-if> clone (htmx never processes template-fragment content, so a
+               static hx-post here would be dead — see the Issue modal for the same pattern).
+               CSRF is injected by the global htmx:configRequest listener. SO# is required. #}
+            <button type="button"
+                    @click.prevent="so.trim() && (htmx.ajax('POST', '/v2/partials/buy-plans/{{ bp.id }}/submit', {target: '#main-content', swap: 'innerHTML', indicator: '#main-content', values: {sales_order_number: so, customer_po_number: cpo, salesperson_notes: notes}}), showModal = false)"
                     data-loading-disable
-                    @click="showModal = false"
                     class="btn btn-primary">
               Submit
             </button>
@@ -242,12 +244,11 @@
           </div>
           <div class="mt-5 flex justify-end gap-2">
             {{ modal_cancel_btn() }}
-            {# Finding #4: raw bg-emerald-600 → .btn btn-primary #}
-            <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/approve"
-                    hx-target="#main-content"
-                    :hx-vals="JSON.stringify({action: 'approve', notes: notes})"
+            {# Finding #4: raw bg-emerald-600 → .btn btn-primary. Imperative htmx.ajax so the
+               confirm works inside this <template x-if> clone (a static hx-post would be dead). #}
+            <button type="button"
+                    @click.prevent="htmx.ajax('POST', '/v2/partials/buy-plans/{{ bp.id }}/approve', {target: '#main-content', swap: 'innerHTML', indicator: '#main-content', values: {action: 'approve', notes: notes}}); showModal = false"
                     data-loading-disable
-                    @click="showModal = false"
                     class="btn btn-primary">
               Approve
             </button>
@@ -267,12 +268,12 @@
           </div>
           <div class="mt-5 flex justify-end gap-2">
             {{ modal_cancel_btn() }}
-            {# Finding #4: raw bg-rose-600 → .btn btn-danger #}
-            <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/approve"
-                    hx-target="#main-content"
-                    :hx-vals="JSON.stringify({action: 'reject', notes: notes})"
+            {# Finding #4: raw bg-rose-600 → .btn btn-danger. Imperative htmx.ajax so the
+               confirm works inside this <template x-if> clone (a static hx-post would be dead).
+               Reason is required: the short-circuit guard keeps the modal open on empty input. #}
+            <button type="button"
+                    @click.prevent="notes.trim() && (htmx.ajax('POST', '/v2/partials/buy-plans/{{ bp.id }}/approve', {target: '#main-content', swap: 'innerHTML', indicator: '#main-content', values: {action: 'reject', notes: notes}}), showModal = false)"
                     data-loading-disable
-                    @click="showModal = false"
                     class="btn btn-danger">
               Reject
             </button>
@@ -297,11 +298,11 @@
           </div>
           <div class="mt-5 flex justify-end gap-2">
             {{ modal_cancel_btn() }}
-            <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/halt"
-                    hx-target="#main-content"
-                    :hx-vals="JSON.stringify({reason: reason})"
+            {# Imperative htmx.ajax so the confirm works inside this <template x-if> clone
+               (a static hx-post would be dead). Reason is optional (service default). #}
+            <button type="button"
+                    @click.prevent="htmx.ajax('POST', '/v2/partials/buy-plans/{{ bp.id }}/halt', {target: '#main-content', swap: 'innerHTML', indicator: '#main-content', values: {reason: reason}}); showModal = false"
                     data-loading-disable
-                    @click="showModal = false"
                     class="btn btn-danger">
               Halt Plan
             </button>
@@ -322,11 +323,11 @@
           </div>
           <div class="mt-5 flex justify-end gap-2">
             {{ modal_cancel_btn() }}
-            <button hx-post="/v2/partials/buy-plans/{{ bp.id }}/cancel"
-                    hx-target="#main-content"
-                    :hx-vals="JSON.stringify({reason: reason})"
+            {# Imperative htmx.ajax so the confirm works inside this <template x-if> clone
+               (a static hx-post would be dead). Reason is optional (service default). #}
+            <button type="button"
+                    @click.prevent="htmx.ajax('POST', '/v2/partials/buy-plans/{{ bp.id }}/cancel', {target: '#main-content', swap: 'innerHTML', indicator: '#main-content', values: {reason: reason}}); showModal = false"
                     data-loading-disable
-                    @click="showModal = false"
                     class="btn btn-danger">
               Cancel Plan
             </button>

--- a/app/templates/htmx/partials/quotes/line_row.html
+++ b/app/templates/htmx/partials/quotes/line_row.html
@@ -9,14 +9,15 @@
     @dblclick="editing = true">
   {# MPN cell — in edit mode, expands to show full inline form #}
   <td class="px-4 py-3 text-sm font-mono font-medium text-gray-900" :colspan="editing ? 8 : 1">
-    <template x-if="!editing" x-cloak>
-      <span>{{ line.mpn }}</span>
-    </template>
-    <template x-if="editing" x-cloak>
-      <form hx-put="/v2/partials/quotes/{{ line.quote_id }}/lines/{{ line.id }}"
-            hx-target="#line-{{ line.id }}" hx-swap="outerHTML"
-            data-loading-disable
-            class="flex flex-wrap gap-2 items-end">
+    {# x-show (not <template x-if>) keeps the edit form in the server-rendered DOM so htmx
+       processes its hx-put at swap time; a form inside a <template x-if> clone is never
+       handed to htmx.process, so Save would be dead. Matches this row's x-show convention. #}
+    <span x-show="!editing" x-cloak>{{ line.mpn }}</span>
+    <form x-show="editing" x-cloak
+          hx-put="/v2/partials/quotes/{{ line.quote_id }}/lines/{{ line.id }}"
+          hx-target="#line-{{ line.id }}" hx-swap="outerHTML"
+          data-loading-disable
+          class="flex flex-wrap gap-2 items-end">
         <div>
           <label class="block text-xs text-gray-400 mb-0.5">MPN</label>
           <input type="text" name="mpn" value="{{ line.mpn }}"
@@ -49,7 +50,6 @@
           <button type="button" @click="editing = false" class="px-3 py-1 text-xs text-gray-600 border border-gray-300 rounded-md hover:bg-gray-100 transition-colors">Cancel</button>
         </div>
       </form>
-    </template>
   </td>
   {% set desc = line|part_description %}
   <td class="px-4 py-3 text-sm text-gray-600 truncate max-w-[200px]" x-show="!editing" x-cloak title="{{ desc }}">{{ desc or '-' }}</td>

--- a/app/templates/htmx/partials/requisitions/unified_modal.html
+++ b/app/templates/htmx/partials/requisitions/unified_modal.html
@@ -345,8 +345,12 @@
           </div>
 
           {# ── Substitute detail rows ── #}
-          <template x-if="part.showSubs">
-            <div class="border-t border-gray-200">
+          {# x-show (not <template x-if>) keeps these rows in the DOM alongside the main
+             part row so the sub-manufacturer hx-get autocomplete shares the main row's
+             clone/processing timing; content inside a <template x-if> is never handed to
+             htmx.process. Submission reads the Alpine `part.substitutes` model (hidden
+             inputs below), not these visible rows, so gating on display-only is safe. #}
+          <div x-show="part.showSubs" x-cloak class="border-t border-gray-200">
               <template x-for="(sub, si) in part.substitutes" :key="si">
                 <div class="flex items-center bg-amber-50/60 border-b border-amber-200/50 border-l-[3px] border-l-amber-400">
                   <div class="flex-none w-[40px] px-2 py-1.5 text-center">
@@ -387,8 +391,7 @@
                   </div>
                 </div>
               </template>
-            </div>
-          </template>
+          </div>
         </div>
       </template>
       </div>{# /min-w-max #}

--- a/tests/test_buyplan_approval_review.py
+++ b/tests/test_buyplan_approval_review.py
@@ -338,3 +338,91 @@ def test_rejected_draft_blocker_distinguishes_from_fresh(db_session: Session, te
 
     assert _compute_blocker(fresh) == "ready to submit"
     assert _compute_blocker(rejected) == "rejected — resubmit"
+
+
+# ── BP-1: modal confirm buttons fire via htmx.ajax (not dead static hx-post) ──
+#
+# The five buy-plan action modals (submit / approve / reject / halt / cancel) each render
+# their confirm button INSIDE an Alpine `<template x-if="modalType === '...'">`. htmx never
+# processes template-fragment content (and Alpine's x-if clone is never handed to
+# htmx.process), so a static `hx-post` on those buttons fires ZERO requests — a DRAFT could
+# never be Submitted and a pending plan never Approved/Rejected. The fix issues the request
+# imperatively via `htmx.ajax(...)` in @click (evaluated at click time), mirroring the
+# proven-live Issue modal. These tests pin that the imperative pattern renders with the
+# EXACT endpoint + posted fields for each modal, and that the dead static form is gone.
+
+
+def _promote(db: Session, user: User, role: str) -> None:
+    user.role = role
+    db.add(user)
+    db.flush()
+
+
+def test_submit_modal_confirm_uses_htmx_ajax(
+    client: TestClient, db_session: Session, test_user, sales_user, test_requisition
+):
+    """Submit modal (always rendered): imperative POST to /submit carrying all three
+    fields + the required #main-content indicator; no dead static hx-post."""
+    plan = _make_pending_plan(db_session, test_requisition.id, sales_user, status=BuyPlanStatus.DRAFT.value)
+    db_session.commit()
+
+    body = client.get(f"/v2/partials/buy-plans/{plan.id}").text
+    assert f"htmx.ajax('POST', '/v2/partials/buy-plans/{plan.id}/submit'" in body
+    assert "sales_order_number: so" in body
+    assert "customer_po_number: cpo" in body
+    assert "salesperson_notes: notes" in body
+    assert "indicator: '#main-content'" in body
+    # The dead static form the fix replaced must be gone.
+    assert f'hx-post="/v2/partials/buy-plans/{plan.id}/submit"' not in body
+
+
+def test_cancel_modal_confirm_uses_htmx_ajax(
+    client: TestClient, db_session: Session, test_user, sales_user, test_requisition
+):
+    """Cancel modal (rendered for non-terminal plans): imperative POST to /cancel with
+    the reason field; no dead static hx-post."""
+    plan = _make_pending_plan(db_session, test_requisition.id, sales_user, status=BuyPlanStatus.DRAFT.value)
+    db_session.commit()
+
+    body = client.get(f"/v2/partials/buy-plans/{plan.id}").text
+    assert f"htmx.ajax('POST', '/v2/partials/buy-plans/{plan.id}/cancel'" in body
+    assert "values: {reason: reason}" in body
+    assert f'hx-post="/v2/partials/buy-plans/{plan.id}/cancel"' not in body
+
+
+def test_approve_reject_modals_confirm_use_htmx_ajax(
+    client: TestClient, db_session: Session, test_user, sales_user, test_requisition
+):
+    """Approve + Reject modals (gated to approvers): both fire imperative POSTs to
+    /approve with the correct action discriminator; Reject is the ONLY reject path in
+    the app, so a dead button here would strand every pending plan.
+
+    No static hx-post remains.
+    """
+    plan = _make_pending_plan(db_session, test_requisition.id, sales_user)
+    _grant(db_session, test_user)
+    db_session.commit()
+
+    body = client.get(f"/v2/partials/buy-plans/{plan.id}").text
+    assert f"htmx.ajax('POST', '/v2/partials/buy-plans/{plan.id}/approve'" in body
+    assert "action: 'approve', notes: notes" in body
+    assert "action: 'reject', notes: notes" in body
+    assert "indicator: '#main-content'" in body
+    # No static hx-post to the approve endpoint anywhere (only the imperative call string).
+    assert f'hx-post="/v2/partials/buy-plans/{plan.id}/approve"' not in body
+
+
+def test_halt_modal_confirm_uses_htmx_ajax(
+    client: TestClient, db_session: Session, test_user, sales_user, test_requisition
+):
+    """Halt modal (gated to supervisor/manager/admin on an in-flight plan): imperative
+    POST to /halt with the reason field; no dead static hx-post."""
+    plan = _make_pending_plan(db_session, test_requisition.id, sales_user)
+    _promote(db_session, test_user, "manager")  # can_halt = pending + manager
+    db_session.commit()
+
+    body = client.get(f"/v2/partials/buy-plans/{plan.id}").text
+    assert "Halt Buy Plan" in body  # modal actually rendered
+    assert f"htmx.ajax('POST', '/v2/partials/buy-plans/{plan.id}/halt'" in body
+    assert "values: {reason: reason}" in body
+    assert f'hx-post="/v2/partials/buy-plans/{plan.id}/halt"' not in body

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -184,6 +184,71 @@ def test_hx_vals_js_is_object_literal():
     )
 
 
+_HX_VERB_ATTR = re.compile(r"\bhx-(?:post|get|put|delete)\s*=", re.IGNORECASE)
+_TEMPLATE_TAG = re.compile(r"<template\b([^>]*)>|</template>", re.IGNORECASE)
+
+
+def _blank_template_comments(text: str) -> str:
+    """Blank Jinja {# #} and HTML <!-- --> comment bodies (newlines preserved) so prose
+    that MENTIONS `<template x-if>` or an hx-verb — e.g. the explanatory comments the
+    BP-1 fix itself adds — is not parsed as live markup."""
+
+    def repl(m: "re.Match[str]") -> str:
+        return re.sub(r"[^\n]", " ", m.group(0))
+
+    text = re.sub(r"\{#.*?#\}", repl, text, flags=re.DOTALL)
+    return re.sub(r"<!--.*?-->", repl, text, flags=re.DOTALL)
+
+
+def _hx_verb_in_xif_offenders(raw: str) -> list[int]:
+    """Return the line numbers of every hx-(post|get|put|delete) attribute that sits
+    INSIDE a ``<template x-if=...>...</template>`` block (nesting-aware)."""
+    text = _blank_template_comments(raw)
+    # Build the character spans covered by an x-if <template> (including nested templates).
+    stack: list[tuple[int, bool]] = []
+    xif_spans: list[tuple[int, int]] = []
+    for m in _TEMPLATE_TAG.finditer(text):
+        if m.group(0).lower().startswith("</template"):
+            if stack:
+                open_end, is_xif = stack.pop()
+                if is_xif:
+                    xif_spans.append((open_end, m.start()))
+        else:
+            is_xif = bool(re.search(r"\bx-if\b", m.group(1)))
+            stack.append((m.end(), is_xif))
+    offenders: list[int] = []
+    for hm in _HX_VERB_ATTR.finditer(text):
+        pos = hm.start()
+        if any(start <= pos < end for start, end in xif_spans):
+            offenders.append(text[:pos].count("\n") + 1)
+    return offenders
+
+
+def test_no_hx_verb_inside_template_x_if():
+    """BP-1 defect class: an ``hx-post/hx-get/hx-put/hx-delete`` on an element INSIDE a
+    ``<template x-if=...>...</template>`` block is DEAD.
+
+    htmx 2.x processes nodes only at load / after-swap; a ``<template>``'s content is an
+    inert DocumentFragment, and Alpine's x-if clone is inserted WITHOUT being handed to
+    ``htmx.process`` — so the hx-* attribute is never wired and the element fires zero
+    requests (a buy-plan confirm button that silently did nothing; an inline-edit form whose
+    Save was dead). The fix is either an imperative ``htmx.ajax(...)`` in ``@click`` (read at
+    click time) or switching ``<template x-if>`` to a plain ``<div x-show>`` (which keeps the
+    element in the server-rendered DOM so htmx processes it at swap time).
+
+    Allowlist NOTHING — a hit is a genuinely dead control. Convert the call site.
+    """
+    offenders: list[str] = []
+    for path in sorted(Path("app/templates").rglob("*.html")):
+        for line in _hx_verb_in_xif_offenders(path.read_text()):
+            offenders.append(f"{path.relative_to(Path('.'))}:{line}")
+    assert not offenders, (
+        "hx-post/get/put/delete found on an element INSIDE a <template x-if> (htmx never "
+        "processes template-fragment content, so the control is DEAD). Use an imperative "
+        "htmx.ajax(...) @click, or switch the wrapper to <div x-show>:\n" + "\n".join(offenders)
+    )
+
+
 def test_dockerfile_cache_bust_precedes_source_copies():
     """deploy.sh dropped --no-cache (PR #211); template freshness now relies entirely on
     a per-deploy BUILD_COMMIT cache-bust placed BEFORE the source COPYs in each


### PR DESCRIPTION
**P0.** All five buy-plan detail modals (Submit, Approve, Reject, Halt, Cancel) had their confirm-button `hx-post` INSIDE an Alpine `<template x-if>`. htmx never processes template-fragment content and Alpine's x-if clone is never handed to htmx.process, so every confirm button fired **zero requests** — a draft could never be submitted, a pending plan never approved/**rejected** (Reject had no other UI path), Halt/Cancel silently no-op'd.

Fix: each confirm button now issues the request imperatively via `htmx.ajax(...)` in `@click` (the proven-live pattern already used by the Issue-line modal in the same file) — exact endpoint, method, target, indicator, and every posted field preserved; required-field guards (SO# on submit, reason on reject) kept.

**Audited all 13 `<template x-if>` + hx-* templates** (nesting-aware, comment-stripped): 3 genuinely broken and fixed (buy-plan modals; `quotes/line_row` inline-edit; `unified_modal` sub-mfr autocomplete → `x-show`); 10 correctly left (their hx-* is on siblings/outer elements, x-if only wraps display content) — each documented.

New static-analysis ratchet `test_no_hx_verb_inside_template_x_if` locks the defect class out of CI. Extended buy-plan render tests. Merged current main (P0 fixes) in cleanly; both new ratchets + buy-plan suite green.

Fifth and final P0 of the WF1 cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF