### PR TITLE
fix(crm): 5 P1 workflow breaks — dead site-edit, merge redirect, archived 404, dead Claim-anyway, dead DNC (F1-F6)

### DIFF
--- a/app/routers/htmx/companies.py
+++ b/app/routers/htmx/companies.py
@@ -4324,14 +4324,18 @@ async def company_merge(
         user.email,
     )
 
-    # Redirect browser to keeper's detail page via HTMX redirect header
+    # Redirect browser to the keeper's FULL-PAGE detail URL via HTMX redirect header.
+    # HX-Redirect triggers a real window.location navigation, so it must point at the
+    # base-page-wrapped route (/v2/customers/{id}) — NOT the bare partial
+    # (/v2/partials/customers/{id}), which would land the user on an unstyled fragment
+    # with no nav shell or CSS entry point.
     safe_name = html_mod.escape(keep.name or "")
     response = HTMLResponse(
         f'<p class="text-sm text-emerald-600 py-2">Merged into <strong>{safe_name}</strong>. '
         f"{int(result.get('sites_moved', 0))} site(s) and {int(result.get('reassigned', 0))} record(s) reassigned.</p>",
         status_code=200,
     )
-    response.headers["HX-Redirect"] = f"/v2/partials/customers/{company_id}"
+    response.headers["HX-Redirect"] = f"/v2/customers/{company_id}"
     return response
 
 

--- a/app/templates/htmx/partials/customers/_account_list.html
+++ b/app/templates/htmx/partials/customers/_account_list.html
@@ -190,7 +190,7 @@
   <p class="px-3 py-1 text-xs font-medium text-gray-400 uppercase tracking-wider">Archived — Do Not Call</p>
   {% for company in archived_search_results %}
   <div class="flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-gray-50"
-       hx-get="/v2/partials/customers/{{ company.id }}/detail"
+       hx-get="/v2/partials/customers/{{ company.id }}"
        hx-target="#cdm-detail"
        hx-swap="innerHTML">
     <div class="min-w-0 flex-1">

--- a/app/templates/htmx/partials/customers/_disposition_control.html
+++ b/app/templates/htmx/partials/customers/_disposition_control.html
@@ -26,10 +26,12 @@
       </select>
     </form>
   </div>
-  {# Send to Prospecting — relinquishes ownership + pools the account. #}
+  {# Send to Prospecting — relinquishes ownership + pools the account.
+     Targets `closest [data-detail-root]` (not #cdm-detail) so it re-swaps the detail
+     partial in both the CDM workspace and the standalone/deep-linked full-page view. #}
   <form hx-post='/v2/partials/customers/{{ company.id }}/send-to-prospecting'
-        hx-target='#cdm-detail'
-        hx-swap='innerHTML'
+        hx-target='closest [data-detail-root]'
+        hx-swap='outerHTML'
         hx-confirm='Send {{ company.name }} back to prospecting? This clears your ownership.'>
     <button type='submit'
             class='inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded border border-gray-200 text-gray-600 hover:bg-brand-50 hover:text-brand-600 hover:border-brand-200 transition-colors focus:outline-none focus:ring-1 focus:ring-brand-400'

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -12,8 +12,12 @@
 
 <title hx-swap-oob="true">{{ company.name }} — Companies — AvailAI</title>
 
-{# Full panel width — no max-w cap; the slim header + multi-column contacts use it all. #}
-<div class="space-y-4 page-fluid">
+{# Full panel width — no max-w cap; the slim header + multi-column contacts use it all.
+   data-detail-root marks this partial's own root so account actions (Reactivate /
+   Archive / Send-to-Prospecting) can target `closest [data-detail-root]` and re-swap
+   themselves whether they render inside the CDM workspace right panel (#cdm-detail) or
+   standalone in #main-content on a deep-linked/reloaded page. #}
+<div data-detail-root class="space-y-4 page-fluid">
 
   {# ── Breadcrumb — "Customers › {Account}" (you-are-here for the right panel).
      Reuses the treatment from the retired site_detail.html. "Customers" is the
@@ -37,8 +41,8 @@
     {% if can_reactivate %}
     <button type="button"
             hx-post="/v2/partials/customers/{{ company.id }}/reactivate"
-            hx-target="#cdm-detail"
-            hx-swap="innerHTML"
+            hx-target="closest [data-detail-root]"
+            hx-swap="outerHTML"
             hx-confirm="Restore this account to active status?"
             class="btn btn-secondary btn-sm flex-shrink-0">
       Reactivate
@@ -215,8 +219,8 @@
               {% if company.is_active %}
             <button type="button"
                     hx-post="/v2/partials/customers/{{ company.id }}/deactivate"
-                    hx-target="#cdm-detail"
-                    hx-swap="innerHTML"
+                    hx-target="closest [data-detail-root]"
+                    hx-swap="outerHTML"
                     hx-confirm="Archive (Do Not Call)? This will unassign the account and hide it from all active lists. Are you sure?"
                     @click.stop="open = false"
                     role="menuitem"

--- a/app/templates/htmx/partials/customers/tabs/site_edit_modal.html
+++ b/app/templates/htmx/partials/customers/tabs/site_edit_modal.html
@@ -1,14 +1,14 @@
 {# site_edit_modal.html — Edit form for a CustomerSite, loaded into #modal-content
    via $dispatch('open-modal', {url: '...'}). The base modal renders ✕/backdrop/Escape.
    Receives: site (CustomerSite), company_id (int), users (list[User]).
-   On success: re-renders #sites-list area and closes the modal.
+   On success: re-renders #company-tab-content (the Sites tab panel) and closes the modal.
    Called by: GET /v2/partials/customers/{company_id}/sites/{site_id}/edit-form
 #}
 <div class='p-5'>
   <h3 id="modal-title" class='text-sm font-semibold text-gray-900 mb-4'>Edit Site</h3>
 
   <form hx-post='/v2/partials/customers/{{ company_id }}/sites/{{ site.id }}/edit'
-        hx-target='#main-content'
+        hx-target='#company-tab-content'
         hx-swap='innerHTML'
         hx-on::after-request='if(event.detail.successful) $dispatch("close-modal")'
         data-loading-disable

--- a/app/templates/htmx/partials/prospecting/list.html
+++ b/app/templates/htmx/partials/prospecting/list.html
@@ -172,7 +172,9 @@
     </button>
     <div x-show="open" x-cloak class="border-t border-amber-200 p-4 space-y-3">
       {% for p in screened_out_prospects %}
-      <div class="flex items-start justify-between gap-3 text-sm">
+      {# id must match the Claim-anyway button's hx-target below — the claim endpoint's
+         _action_oob response swaps this row (outerHTML) with the refreshed card. #}
+      <div id="prospect-{{ p.id }}" class="flex items-start justify-between gap-3 text-sm">
         <div class="min-w-0">
           <span class="font-medium text-gray-800">{{ p.name }}</span>
           {% if p.domain %}<span class="text-gray-400 ml-1">{{ p.domain }}</span>{% endif %}

--- a/tests/test_authz_merge_addsite_idor.py
+++ b/tests/test_authz_merge_addsite_idor.py
@@ -139,6 +139,20 @@ class TestCompanyMergeIDOR:
             cleanup()
         assert resp.status_code == 200
 
+    def test_merge_success_redirects_to_full_page_url(self, client, keep_company, remove_company):
+        """F2: merge success must HX-Redirect to the base-page-wrapped /v2/customers/{id},
+        NOT the bare partial /v2/partials/customers/{id}. HX-Redirect does a real
+        window.location navigation, so the partial URL would land the user on an unstyled,
+        nav-less HTML fragment."""
+        resp = client.post(
+            f"/v2/partials/customers/{keep_company.id}/merge",
+            data={"remove_id": str(remove_company.id), "confirmed": "true"},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Redirect") == f"/v2/customers/{keep_company.id}"
+        assert "/partials/" not in resp.headers.get("HX-Redirect", "")
+
 
 # ── 2. merge preview (GET) ───────────────────────────────────────────────────
 

--- a/tests/test_crm_views.py
+++ b/tests/test_crm_views.py
@@ -164,6 +164,83 @@ class TestCustomerWorkspace:
         assert 'id="cdm-workspace"' not in resp.text
 
 
+class TestArchivedSearchResults:
+    """F3: archived (DNC) rows surfaced in a name search must link to the real detail
+    route (/v2/partials/customers/{id}), not a non-existent /detail suffix that 404s and
+    swaps nothing."""
+
+    def test_archived_row_uses_real_detail_url(self, client: TestClient, db_session: Session, test_user: User):
+        archived = Company(name="ZzArchived DNC Co", is_active=False)
+        db_session.add(archived)
+        db_session.commit()
+
+        resp = client.get("/v2/partials/customers/account-list", params={"search": "ZzArchived"})
+        assert resp.status_code == 200
+        body = resp.text
+        assert "ZzArchived DNC Co" in body
+        # Correct URL present (matches the active-row pattern); broken /detail suffix absent.
+        assert f'hx-get="/v2/partials/customers/{archived.id}"' in body
+        assert f"/v2/partials/customers/{archived.id}/detail" not in body
+
+    def test_detail_suffix_route_does_not_exist(self, client: TestClient, db_session: Session):
+        """The old /detail suffix has no registered route → 404 (the silent failure F3
+        fixed)."""
+        archived = Company(name="ZzArchived404 Co", is_active=False)
+        db_session.add(archived)
+        db_session.commit()
+
+        resp = client.get(f"/v2/partials/customers/{archived.id}/detail", headers={"HX-Request": "true"})
+        assert resp.status_code == 404
+
+
+@pytest.mark.usefixtures("_grant_account_management")
+class TestAccountActionsWorkStandalone:
+    """F6: Reactivate / Archive (DNC) / Send-to-Prospecting must target the detail
+    partial's own root (`closest [data-detail-root]`), not `#cdm-detail`. `#cdm-detail`
+    exists only inside the CDM workspace shell, so on a deep-linked / reloaded full-page
+    company view (detail rendered into #main-content) those actions were dead — htmx fired
+    a targetError and never sent the request."""
+
+    def test_detail_root_carries_data_detail_root_marker(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        c = Company(name="Standalone Marker Co", is_active=True, account_owner_id=test_user.id)
+        db_session.add(c)
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{c.id}")
+        assert resp.status_code == 200
+        assert "data-detail-root" in resp.text
+
+    def test_archive_and_send_to_prospecting_target_detail_root(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        c = Company(name="ActiveActions Co", is_active=True, account_owner_id=test_user.id)
+        db_session.add(c)
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{c.id}")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "/deactivate" in body  # Archive (DNC) kebab action rendered
+        assert "/send-to-prospecting" in body  # disposition control rendered
+        # Both actions resolve to the detail root, and none target the shell-only id.
+        assert body.count("closest [data-detail-root]") >= 2
+        assert 'hx-target="#cdm-detail"' not in body
+        assert "hx-target='#cdm-detail'" not in body
+
+    def test_reactivate_targets_detail_root_on_archived_view(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        c = Company(name="ArchivedActions Co", is_active=False, account_owner_id=None)
+        db_session.add(c)
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{c.id}")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "/reactivate" in body
+        assert "closest [data-detail-root]" in body
+        assert 'hx-target="#cdm-detail"' not in body
+
+
 class TestOverdueChip:
     """Test the overdue 'needs a call' chip on the CDM workspace filter bar.
 

--- a/tests/test_sp3_ui.py
+++ b/tests/test_sp3_ui.py
@@ -259,6 +259,24 @@ class TestListSortAndBucket:
         assert f"/v2/partials/prospecting/{p.id}/claim" in body
         assert "Claim anyway" in body
 
+    def test_screened_out_row_has_claim_target_id(self, client, db_session, monkeypatch):
+        """F4: the screened-out row must carry id='prospect-<id>' so the Claim-anyway
+        button's hx-target='#prospect-<id>' resolves. Screened-out prospects are filtered
+        out of the grid (where _card.html normally provides that id), so without an id on
+        the row htmx aborts the claim with targetError and the button is dead."""
+        monkeypatch.setattr(settings, "ai_screen_enabled", True)
+        p = _make_prospect(
+            db_session,
+            name="LowFitCo",
+            trio_match_score=10,
+            enrichment_data=_ai_screen(verdict="screened_out", match=10),
+        )
+        resp = client.get("/v2/partials/prospecting?sort=ai_match_desc")
+        assert resp.status_code == 200
+        body = resp.text
+        assert f'id="prospect-{p.id}"' in body  # target the claim button swaps
+        assert f'hx-target="#prospect-{p.id}"' in body  # button points at that id
+
     def test_screened_out_bucket_hidden_when_screening_disabled(self, client, db_session, monkeypatch):
         """No screened-out section when ai_screen_enabled=False."""
         monkeypatch.setattr(settings, "ai_screen_enabled", False)

--- a/tests/test_sprint4_company_crud.py
+++ b/tests/test_sprint4_company_crud.py
@@ -131,6 +131,21 @@ class TestEditSite:
         )
         assert resp.status_code == 404
 
+    def test_edit_form_targets_tab_panel_not_shell(
+        self, client: TestClient, test_company: Company, test_customer_site: CustomerSite
+    ):
+        """F1: the site-edit modal must swap the Sites tab panel (#company-tab-content),
+        NOT #main-content. The edit handler returns the sites_tab fragment (same as a
+        Sites-tab click); targeting #main-content replaced the whole page/workspace shell
+        with a bare sites list, wiping the header, tabs, and account list."""
+        resp = client.get(
+            f"/v2/partials/customers/{test_company.id}/sites/{test_customer_site.id}/edit-form",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert "hx-target='#company-tab-content'" in resp.text
+        assert "hx-target='#main-content'" not in resp.text
+
 
 # ── Typeahead ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Five verified P1 CRM/prospecting workflow bugs, each an htmx action targeting an element or URL absent from the served DOM/route (all reproduced + root-caused):

- **F1** site-edit save targeted `#main-content` but the handler returns the sites-tab fragment → wiped the whole page. Now targets `#company-tab-content` (what the working Sites-tab click uses).
- **F2** company-merge `HX-Redirect`'d to a raw partial URL → unstyled fragment page. Now redirects to the base-page-wrapped `/v2/customers/{id}`.
- **F3** archived-company search rows hit `/v2/partials/customers/{id}/detail` — no such route → silent 404. Dropped the `/detail` suffix.
- **F4** 'Claim anyway' in the screened-out bucket targeted `#prospect-{id}` which was filtered out of the DOM → dead. Added the row id so the claim response swaps it.
- **F6** Archive(DNC)/Reactivate/Send-to-Prospecting targeted `#cdm-detail` (workspace-shell-only) → dead on any deep-linked/reloaded company page. Now target `closest [data-detail-root]` (present in both contexts).

Authz preserved throughout (no gate widened). TDD: render/route assertions across 5 test files; touched-file suites 332 passed + 425 regression-sweep passed. Merged current main in cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF