### PR TITLE
fix(resell): Lines tab no longer leaks best competing offer price/count to non-owners (RS-1)

### DIFF
--- a/app/templates/htmx/partials/resell/_lines.html
+++ b/app/templates/htmx/partials/resell/_lines.html
@@ -13,8 +13,11 @@
 {% set is_draft = el.status == 'draft' %}
 
 {# Reusable best-offer / offer-count chip → opens the per-line comparison modal. #}
-{% macro _line_offer_badge(el, item) %}
-  {% if (item.offer_count or 0) > 0 %}
+{# is_owner passed explicitly — Jinja macros don't see the template-level set.
+   A non-owner broker must not see the competing-offer COUNT either (the badge
+   also 403s on click), so it shows a dash for them. #}
+{% macro _line_offer_badge(el, item, is_owner) %}
+  {% if is_owner and (item.offer_count or 0) > 0 %}
   <button hx-get="/v2/partials/resell/{{ el.id }}/lines/{{ item.id }}/offers"
           hx-target="#modal-content"
           @click="$dispatch('open-modal', { wide: true })"
@@ -78,7 +81,7 @@
         {% if desc %}<p class="text-sm text-gray-500 mt-0.5">{{ desc }}</p>{% endif %}
         {% if item.manufacturer %}<p class="text-xs text-gray-400 mt-0.5">{{ item.manufacturer }}</p>{% endif %}
       </div>
-      {{ _line_offer_badge(el, item) }}
+      {{ _line_offer_badge(el, item, is_owner) }}
     </div>
     <div class="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
       <div><span class="block text-xs text-gray-400 uppercase tracking-wide">Qty</span><span class="font-medium tabular-nums">{{ "{:,}".format(item.quantity) }}</span></div>
@@ -86,7 +89,9 @@
       <div><span class="block text-xs text-gray-400 uppercase tracking-wide">Date code</span><span class="font-medium">{{ item.date_code or '—' }}</span></div>
       <div>
         <span class="block text-xs text-gray-400 uppercase tracking-wide">Best offer</span>
-        {% if item.best_offer_unit_price is not none %}
+        {# Owner-only: a non-owner broker must never see the current best COMPETING
+           price (matches the Offers-tab / compare 403 boundary). #}
+        {% if is_owner and item.best_offer_unit_price is not none %}
         <span class="font-semibold text-emerald-600 tabular-nums">${{ "{:,.4f}".format(item.best_offer_unit_price|float) }}</span>
         {% else %}<span class="text-gray-400">—</span>{% endif %}
       </div>
@@ -116,11 +121,12 @@
           <td class="text-right tabular-nums">{{ "{:,}".format(item.quantity) }}</td>
           <td>{{ item.condition or '—' }}</td>
           <td class="text-right tabular-nums">
-            {% if item.best_offer_unit_price is not none %}
+            {# Owner-only best competing price (see single-card note above). #}
+            {% if is_owner and item.best_offer_unit_price is not none %}
             <span class="font-semibold text-emerald-600">${{ "{:,.4f}".format(item.best_offer_unit_price|float) }}</span>
             {% else %}<span class="text-gray-400">—</span>{% endif %}
           </td>
-          <td class="text-center">{{ _line_offer_badge(el, item) }}</td>
+          <td class="text-center">{{ _line_offer_badge(el, item, is_owner) }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/tests/test_resell_draft_offer_privacy.py
+++ b/tests/test_resell_draft_offer_privacy.py
@@ -112,3 +112,51 @@ def test_non_owner_submit_offer_on_posted_200(client, db_session, posted_list, o
     assert resp.status_code == 200
     offers = db_session.query(ExcessOffer).filter_by(excess_list_id=posted_list.id).all()
     assert len(offers) == 1
+
+
+def _posted_list_with_best_offer(db_session, owner, company):
+    """A posted list whose single line carries a best competing offer price + count."""
+    el = _list_with_line(db_session, owner, company, ExcessListStatus.COLLECTING)
+    line = db_session.query(ExcessLineItem).filter_by(excess_list_id=el.id).first()
+    line.best_offer_unit_price = 12.3456
+    line.offer_count = 3
+    db_session.commit()
+    return el
+
+
+def test_non_owner_lines_tab_hides_best_offer_price_and_count(client, db_session, owner_user, test_company, test_user):
+    """RS-1 (data leak): the Lines tab must NOT show a non-owner broker the current best
+    COMPETING offer price or the offer count — that's the same data the Offers tab and
+    compare endpoint 403-guard.
+
+    client (test_user, a buyer) is NOT the owner.
+    """
+    assert test_user.id != owner_user.id
+    el = _posted_list_with_best_offer(db_session, owner_user, test_company)
+
+    resp = client.get(f"/v2/partials/resell/{el.id}/lines")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "12.3456" not in body, "best competing offer price leaked to a non-owner broker"
+    assert "12.35" not in body
+    assert "3 offer" not in body, "competing offer count leaked to a non-owner broker"
+    # The line itself (MPN/qty) is still shown — only the offer data is hidden.
+    assert "XCVU9P-2FLGA2104I" in body
+
+
+def test_owner_lines_tab_shows_best_offer_price_and_count(monkeypatch, client, db_session, owner_user, test_company):
+    """Control: the OWNER does see the best offer price + count (the gate is
+    owner-scoped, not a blanket hide)."""
+    el = _posted_list_with_best_offer(db_session, owner_user, test_company)
+
+    # Authenticate the client as the owner for this request.
+    from app.dependencies import require_user
+
+    client.app.dependency_overrides[require_user] = lambda: owner_user
+    try:
+        resp = client.get(f"/v2/partials/resell/{el.id}/lines")
+    finally:
+        client.app.dependency_overrides.pop(require_user, None)
+    assert resp.status_code == 200
+    assert "12.3456" in resp.text, "owner must still see the best offer price"
+    assert "3 offer" in resp.text, "owner must still see the offer count"


### PR DESCRIPTION
**P1 data leak.** The resell detail spec: a non-owner broker sees only MPN/qty/condition, never the seller or competing-offer data. The Offers tab and compare endpoint 403-guard that data — but `_lines.html` (the **default** detail tab) rendered `best_offer_unit_price` and the '▸ N offers' badge **unconditionally**, so a broker browsing an open list's row saw each line's current best competing price + offer count. Clicking the badge then 403'd into an empty modal — a dead-end confirming the boundary was meant to exist.

Fix: gate the Best-offer price (single-card + table) and the offer-count badge on `is_owner` (dash for non-owners). The compare 403 stays as defense in depth.

TDD: a non-owner GET of the lines partial shows no price/count; the owner still sees both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF