### PR TITLE
fix(settings): non-admin lands on Profile not 403 Connectors; scope approver-form trigger (SET-02/04)

### DIFF
--- a/app/routers/htmx/settings.py
+++ b/app/routers/htmx/settings.py
@@ -147,9 +147,15 @@ async def settings_partial(
     db: Session = Depends(get_db),
 ):
     """Settings page — renders index with active tab."""
+    is_admin = user.role == UserRole.ADMIN
+    # Connectors is admin-only (403 for others). A non-admin hitting Settings with
+    # the default 'connectors' tab landed on an empty 403 page — send them to Profile
+    # (available to everyone) instead (SET-04).
+    if tab == "connectors" and not is_admin:
+        tab = "profile"
     ctx = _base_ctx(request, user, "settings")
     ctx["active_tab"] = tab
-    ctx["is_admin"] = user.role == UserRole.ADMIN
+    ctx["is_admin"] = is_admin
     # Supervisor-tier flag — gates the Activity Scorecard tab (manager + admin).
     ctx["is_manager"] = is_manager_or_admin(user)
     return template_response("htmx/partials/settings/index.html", ctx)

--- a/app/templates/htmx/partials/settings/index.html
+++ b/app/templates/htmx/partials/settings/index.html
@@ -19,9 +19,11 @@
 <div class="page-fluid" x-data="{ tab: '{{ active_tab }}' }">
   {# Tab buttons — scroll horizontally on narrow screens instead of overflowing the page #}
   <div class="flex gap-1 mb-6 border-b border-line-base overflow-x-auto">
+    {% if is_admin %}
+    {# Connectors tab is admin-only (the endpoint 403s otherwise) — the button
+       must not render for non-admins, who would land on an empty 403 (SET-04). #}
     {{ tab_button('connectors', '/v2/partials/settings/connectors', 'Connectors', ['M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4']) }}
 
-    {% if is_admin %}
     {{ tab_button('system', '/v2/partials/settings/system', 'System', ['M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z', 'M15 12a3 3 0 11-6 0 3 3 0 016 0z'], extra_attrs='
             hx-indicator="#settings-load-spinner"
             data-loading-disable') }}

--- a/app/templates/htmx/partials/settings/users.html
+++ b/app/templates/htmx/partials/settings/users.html
@@ -118,7 +118,7 @@
                  Hidden 'false' field ensures an unchecked box still submits a revoke. #}
               <form hx-post="/api/admin/users/{{ row.user.id }}/prepayment-approver"
                     hx-target="#users-content" hx-swap="outerHTML"
-                    hx-trigger="change from:input">
+                    hx-trigger="change">
                 <input type="hidden" name="can_approve" value="false">
                 <div class="space-y-1">
                   <label class="inline-flex items-center cursor-pointer">
@@ -172,7 +172,7 @@
                  hidden 'false' field ensures an unchecked box still submits a revoke. #}
               <form hx-post="/api/admin/users/{{ row.user.id }}/purchase-order-approver"
                     hx-target="#users-content" hx-swap="outerHTML"
-                    hx-trigger="change from:input">
+                    hx-trigger="change">
                 <input type="hidden" name="can_approve" value="false">
                 <div class="space-y-1">
                   <label class="inline-flex items-center cursor-pointer">

--- a/tests/test_htmx_views_nightly11.py
+++ b/tests/test_htmx_views_nightly11.py
@@ -288,6 +288,33 @@ class TestSettingsPartials:
         resp = client.get("/v2/partials/settings/connectors")
         assert resp.status_code == 403
 
+    def test_non_admin_settings_index_lands_on_profile_not_403_connectors(self, client: TestClient):
+        """SET-04: the default settings tab is 'connectors' (admin-only, 403). A
+        non-admin (buyer client) must be redirected to the Profile tab, not served an
+        empty 403 page, and the Connectors tab button must not render for them."""
+        resp = client.get("/v2/partials/settings")
+        assert resp.status_code == 200
+        body = resp.text
+        # Profile content is shown; the admin-only Connectors tab button is absent.
+        assert "/v2/partials/settings/connectors" not in body, "Connectors tab button leaked to a non-admin"
+
+    def test_prepayment_approver_form_change_trigger_is_scoped(self, client: TestClient):
+        """SET-02: the per-user approver forms must trigger on their OWN change
+        (bubbling to the form), not 'change from:input' which htmx resolves to EVERY
+        input on the page."""
+        # Admin sees the Users tab; assert no over-broad 'from:input' trigger remains.
+        from app.constants import UserRole
+        from app.dependencies import require_user
+
+        admin = type("A", (), {"id": 1, "role": UserRole.ADMIN, "name": "A", "email": "a@x.com"})()
+        client.app.dependency_overrides[require_user] = lambda: admin
+        try:
+            resp = client.get("/v2/partials/settings/users")
+        finally:
+            client.app.dependency_overrides.pop(require_user, None)
+        if resp.status_code == 200:
+            assert "change from:input" not in resp.text
+
     def test_settings_system_tab_non_admin_returns_403(self, client: TestClient, db_session: Session, test_user: User):
         """Buyer user should get 403 from system tab (admin-only)."""
         resp = client.get("/v2/partials/settings/system")

--- a/tests/test_tickets_wiring.py
+++ b/tests/test_tickets_wiring.py
@@ -135,11 +135,29 @@ class TestSettingsTicketsTab:
         assert 'hx-get="/v2/partials/trouble-tickets/workspace"' in html
         assert "/v2/partials/settings/tickets" not in html
 
-    def test_settings_partial_default_tab_unchanged(self, client):
-        """The default (Connectors) tab still first-paints its own content URL."""
+    def test_settings_partial_default_tab_by_role(self, client, db_session):
+        """Default tab is role-aware (SET-04): an admin first-paints Connectors (the
+        admin-only tab); a non-admin gets Profile instead of an empty 403 Connectors
+        page.
+
+        The `client` fixture is a buyer → Profile.
+        """
         html = client.get("/v2/partials/settings").text
-        assert "{ tab: 'connectors' }" in html
-        assert 'hx-get="/v2/partials/settings/connectors"' in html
+        assert "{ tab: 'profile' }" in html
+        assert 'hx-get="/v2/partials/settings/profile"' in html
+
+        # An admin still defaults to Connectors.
+        from app.constants import UserRole
+        from app.dependencies import require_user
+
+        admin = type("A", (), {"id": 99, "role": UserRole.ADMIN, "name": "Ad", "email": "ad@x.com"})()
+        client.app.dependency_overrides[require_user] = lambda: admin
+        try:
+            admin_html = client.get("/v2/partials/settings").text
+        finally:
+            client.app.dependency_overrides.pop(require_user, None)
+        assert "{ tab: 'connectors' }" in admin_html
+        assert 'hx-get="/v2/partials/settings/connectors"' in admin_html
 
 
 # ── Fix 4: honest status toast (gate on r.ok) ────────────────────────


### PR DESCRIPTION
Two settings P1s:

- **SET-04**: the settings default tab is `connectors`, which 403s for non-admins, and its tab button rendered *outside* the `is_admin` block — so a non-admin opening Settings got an empty **403 page**. Non-admins now default to the Profile tab (available to all) and the Connectors button is gated behind `is_admin`.
- **SET-02**: the per-user prepayment/PO approver forms used `hx-trigger='change from:input'`, which htmx resolves against the root node → **every input on the page**, so each of the 2N forms fired on any input's change anywhere. The trigger is on the `<form>`; plain `change` bubbles to it correctly.

TDD: non-admin settings index is 200 with no Connectors button; no `change from:input` remains. Ripple 133 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF