### PR TITLE
fix(search): register /v2/search/results full-page route (shell-01)

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -136,6 +136,7 @@ _MODULE_ENTRY_URLS: tuple[tuple[AccessKey, str], ...] = (
 @router.get("/v2/requisitions", response_class=HTMLResponse)
 @router.get("/v2/requisitions/{req_id:int}", response_class=HTMLResponse)
 @router.get("/v2/search", response_class=HTMLResponse)
+@router.get("/v2/search/results", response_class=HTMLResponse)
 @router.get("/v2/vendors", response_class=HTMLResponse)
 @router.get("/v2/vendors/{vendor_id:int}", response_class=HTMLResponse)
 @router.get("/v2/customers", response_class=HTMLResponse)
@@ -233,10 +234,17 @@ async def v2_page(request: Request, db: Session = Depends(get_db)):
     elif current_view == "my-day":
         partial_url = "/v2/partials/my-day"
     elif current_view == "search":
-        # Deep-link the Part Dossier: ?mpn= rides along to /v2/partials/search so a
-        # bookmarked /v2/search?mpn=<PN> paints the dossier on first load.
-        mpn_qs = request.query_params.get("mpn", "").strip()
-        partial_url = f"/v2/partials/search?mpn={quote(mpn_qs)}" if mpn_qs else "/v2/partials/search"
+        if path.rstrip("/").endswith("/results"):
+            # Full-page global-search results (F5/bookmark/share of "View all
+            # results"): thread ?q= to the results partial (shell-01). Without this
+            # route the pushed /v2/search/results URL 404'd → bare JSON error page.
+            q_qs = request.query_params.get("q", "").strip()
+            partial_url = f"/v2/partials/search/results?q={quote(q_qs)}"
+        else:
+            # Deep-link the Part Dossier: ?mpn= rides along to /v2/partials/search so a
+            # bookmarked /v2/search?mpn=<PN> paints the dossier on first load.
+            mpn_qs = request.query_params.get("mpn", "").strip()
+            partial_url = f"/v2/partials/search?mpn={quote(mpn_qs)}" if mpn_qs else "/v2/partials/search"
     elif current_view == "settings":
         # Thread ?tab= through so a deep-link / redirect (e.g. the legacy
         # /v2/trouble-tickets → /v2/settings?tab=tickets) paints the right tab on

--- a/tests/test_htmx_views_coverage.py
+++ b/tests/test_htmx_views_coverage.py
@@ -183,6 +183,16 @@ class TestV2PageRouting:
         resp = client.get(url)
         assert resp.status_code == 200
 
+    def test_search_results_full_page_route_exists(self, client: TestClient):
+        """shell-01: 'View all results' pushes /v2/search/results into the URL. A
+        F5/bookmark of that URL must serve the app shell (200), not the 404→bare-JSON
+        page it produced before the route was registered."""
+        resp = client.get("/v2/search/results?q=LM317T")
+        assert resp.status_code == 200
+        # It's the full HTML shell, not a JSON error.
+        assert "application/json" not in resp.headers.get("content-type", "")
+        assert "<!DOCTYPE html>" in resp.text or "<html" in resp.text
+
     def test_v2_buy_plans_detail(self, client: TestClient, db_session: Session, test_user: User):
         req = _make_requisition(db_session, test_user)
         quote = _make_quote(db_session, req, test_user)


### PR DESCRIPTION
**shell-01.** The global-search 'View all results' link pushes `/v2/search/results?q=...` into the URL bar, but only the *partial* `/v2/partials/search/results` was registered — the full-page `v2_page` decorator never matched `/v2/search/results`, so an F5/bookmark/share **404'd** and `main.py` rendered a bare JSON error page. Added the route to `v2_page` and threaded `?q=` to the results partial for a `/results` path (mirrors the existing `?mpn=` dossier threading).

TDD: `GET /v2/search/results?q=...` returns the HTML shell (200), not JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF