### PR TITLE
fix(sightings/sourcing): 6 P1 workflow breaks — dead batch actions, no-op re-search, filter targets, vendor-key (SIGHT/SOURCING/SEARCH)

### DIFF
--- a/app/routers/htmx/sourcing.py
+++ b/app/routers/htmx/sourcing.py
@@ -11,9 +11,6 @@ Depends on: app.models, app.dependencies, app.database, app.scoring,
     app.search_service, ._shared.
 """
 
-import asyncio
-import json
-import time
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -105,13 +102,18 @@ async def sourcing_search_trigger(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Trigger multi-source search for a requirement.
+    """Re-run the sourcing pipeline for a requirement and PERSIST the results.
 
-    Runs connectors in parallel, publishes SSE events per source completion, syncs leads
-    on completion, returns redirect to sourcing results.
+    Delegates to ``search_requirement()`` — the same orchestrator the sightings refresh
+    button uses. It fans out across the connectors once (the 48h per-MPN cooldown gates
+    the spend), saves the sightings, and write-throughs canonical ``SourcingLead`` rows
+    (``sync_leads_for_sightings``). The old implementation instead called
+    ``quick_search_mpn`` six times (each a full read-only sweep of every connector) and
+    discarded every result, so "Re-search" persisted nothing and redirected to an
+    unchanged list. After persisting, redirect back to the results page, which now reads
+    the freshly-written leads.
     """
-
-    from ...services.sse_broker import broker
+    from ...search_service import search_requirement
 
     req = db.query(Requirement).filter(Requirement.id == requirement_id).first()
     if not req:
@@ -119,47 +121,14 @@ async def sourcing_search_trigger(
     # Search triggers connector SPEND + cross-owner disclosure — scope to the owner.
     require_requisition_access(db, req.requisition_id, user, label="Requirement")
 
-    mpn = req.primary_mpn or ""
-    sources = ["brokerbin", "nexar", "digikey", "mouser", "oemsecrets", "element14"]
-    channel = f"sourcing:{requirement_id}"
-    all_sightings = []
+    try:
+        await search_requirement(req, db)
+    except Exception:
+        logger.warning("Sourcing re-search failed for requirement {}", requirement_id, exc_info=True)
 
-    async def search_source(source_name):
-        start_t = time.time()
-        try:
-            from ...search_service import quick_search_mpn
-
-            raw = await quick_search_mpn(mpn, db)
-            results = raw if isinstance(raw, list) else raw.get("sightings", [])
-            elapsed = int((time.time() - start_t) * 1000)
-            count = len(results) if results else 0
-            await broker.publish(
-                channel,
-                "source-complete",
-                json.dumps({"source": source_name, "count": count, "elapsed_ms": elapsed, "status": "done"}),
-            )
-            return results or []
-        except Exception as exc:
-            elapsed = int((time.time() - start_t) * 1000)
-            logger.error("Sourcing search failed for {} on {}: {}", mpn, source_name, exc)
-            await broker.publish(
-                channel,
-                "source-complete",
-                json.dumps(
-                    {"source": source_name, "count": 0, "elapsed_ms": elapsed, "status": "failed", "error": str(exc)}
-                ),
-            )
-            return []
-
-    results_by_source = await asyncio.gather(*[search_source(s) for s in sources], return_exceptions=True)
-
-    for source_results in results_by_source:
-        if isinstance(source_results, list):
-            all_sightings.extend(source_results)
-
-    await broker.publish(
-        channel, "search-complete", json.dumps({"total": len(all_sightings), "requirement_id": requirement_id})
-    )
+    # search_requirement() commits via a separate write session; expire so the redirect
+    # target re-reads the freshly-persisted leads instead of the caller session's cache.
+    db.expire_all()
 
     return HTMLResponse(status_code=200, headers={"HX-Redirect": f"/v2/sourcing/{requirement_id}"})
 

--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -1145,8 +1145,12 @@ async def search_lead_detail(
         if results:
             from ..vendor_utils import normalize_vendor_name
 
+            # Normalize BOTH sides: the template sends the raw vendor name (url-encoded),
+            # so applying the same normalizer here makes the key survive suffix stripping
+            # (", Inc." / "LLC" / "Corp.") that used to make the row's Details → miss.
+            vendor_key_norm = normalize_vendor_name(vendor_key)
             lead = next(
-                (r for r in results if normalize_vendor_name(r.get("vendor_name", "")) == vendor_key),
+                (r for r in results if normalize_vendor_name(r.get("vendor_name", "")) == vendor_key_norm),
                 None,
             )
             if lead:

--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -341,8 +341,28 @@ async def sightings_list(
     if user.role in RESTRICTED_ROLES:
         query = query.filter(Requisition.created_by == user.id)
 
+    # Thresholds shared by the dashboard-strip quick filters below AND the counter/
+    # heatmap computations further down — compute once so a filtered list matches its
+    # counter exactly. UTC-aware to line up with UTCDateTime columns.
+    stale_threshold = datetime.now(timezone.utc) - timedelta(days=settings.sighting_stale_days)
+    deadline_48h = date.today() + timedelta(days=2)
+
     if filters.status:
         query = query.filter(Requirement.sourcing_status == filters.status)
+    # Urgent quick filter — same predicate as the "urgent" counter (priority >= 70 OR
+    # need_by within 48h).
+    if filters.urgent:
+        query = query.filter((Requirement.priority_score >= 70) | (Requirement.need_by_date <= deadline_48h))
+    # Stale quick filter — active requirements with no ActivityLog inside the stale
+    # window (mirrors the "stale" counter's NOT-IN-recent-activity set).
+    if filters.stale:
+        recent_activity = (
+            db.query(ActivityLog.requirement_id)
+            .filter(ActivityLog.requirement_id.isnot(None))
+            .group_by(ActivityLog.requirement_id)
+            .having(sqlfunc.max(ActivityLog.created_at) >= stale_threshold)
+        )
+        query = query.filter(~Requirement.id.in_(recent_activity.subquery().select()))
     if filters.sales_person:
         safe = escape_like(filters.sales_person)
         query = query.join(User, Requisition.created_by == User.id).filter(User.name.ilike(f"%{safe}%", escape="\\"))
@@ -383,8 +403,6 @@ async def sightings_list(
 
     top_vendors = {}
     coverage_map = {}
-    # Stale threshold is UTC-aware; UTCDateTime columns read back aware too
-    stale_threshold = datetime.now(timezone.utc) - timedelta(days=settings.sighting_stale_days)
     stale_req_ids: set[int] = set()
 
     if requirements:
@@ -433,8 +451,6 @@ async def sightings_list(
         coverage_map = {c.requirement_id: c.total_qty or 0 for c in coverage_rows}
 
     # ── Dashboard Strip Counters (Phase 2) ──────────────────────────
-    deadline_48h = date.today() + timedelta(days=2)
-
     # Active requirement IDs for dashboard (not just current page)
     active_req_select = (
         db.query(Requirement.id)
@@ -924,7 +940,32 @@ async def sightings_batch_refresh(
     level = "warning" if failed else "success"
     if _toast_suppressed_for_sse(source):
         return HTMLResponse("")
-    return _oob_toast(msg, level)
+
+    # Re-render the sightings table for the split-panel caller so refreshed coverage /
+    # status is visible immediately (the old code returned only an OOB toast whose
+    # #toast-trigger anchor does not exist, which both dropped the toast AND emptied the
+    # table). The requisition parts-tab caller posts hx-swap="none" and only needs the
+    # toast, which fires via the HX-Trigger bridge (htmx_app.js) regardless of swap mode.
+    hx_target = request.headers.get("HX-Target", "")
+    if hx_target == "sightings-table":
+
+        def _fs(key: str) -> str:
+            val = form.get(key, "")
+            return val if isinstance(val, str) else ""
+
+        # search_requirement() commits via a separate write session, so drop the caller
+        # session's identity-map cache before re-querying for fresh coverage/status.
+        db.expire_all()
+        filters = SightingsListParams(
+            status=_fs("status"),
+            q=_fs("q"),
+            group_by=_fs("group_by"),
+            manufacturer=_fs("manufacturer"),
+        )
+        resp: HTMLResponse = await sightings_list(request, db=db, user=user, filters=filters)
+    else:
+        resp = HTMLResponse("")
+    return _with_toast(resp, msg, level)
 
 
 @router.post("/v2/partials/sightings/batch-assign", response_class=HTMLResponse)
@@ -994,7 +1035,7 @@ async def sightings_batch_status(
         raise HTTPException(status_code=400, detail=f"Maximum {MAX_BATCH_SIZE} requirements per batch")
 
     if not requirement_ids:
-        return _oob_toast("No requirements selected", "warning")
+        return _with_toast(HTMLResponse(""), "No requirements selected", "warning")
 
     try:
         SourcingStatus(new_status)
@@ -1034,7 +1075,9 @@ async def sightings_batch_status(
     if skipped:
         msg += f" {skipped} skipped (invalid transition)."
     level = "success" if skipped == 0 else "warning"
-    return _oob_toast(msg, level)
+    # Empty body + HX-Trigger:showToast — the working toast bridge (htmx_app.js). The
+    # form posts hx-swap="none", so there is no body to swap and nothing is wiped.
+    return _with_toast(HTMLResponse(""), msg, level)
 
 
 @router.post("/v2/partials/sightings/batch-notes", response_class=HTMLResponse)
@@ -1058,10 +1101,10 @@ async def sightings_batch_notes(
         raise HTTPException(status_code=400, detail=f"Maximum {MAX_BATCH_SIZE} requirements per batch")
 
     if not requirement_ids:
-        return _oob_toast("No requirements selected", "warning")
+        return _with_toast(HTMLResponse(""), "No requirements selected", "warning")
 
     if not notes:
-        return _oob_toast("Note text is required", "warning")
+        return _with_toast(HTMLResponse(""), "Note text is required", "warning")
 
     int_ids = [int(rid) for rid in requirement_ids]
     reqs = db.query(Requirement).filter(Requirement.id.in_(int_ids)).all()
@@ -1083,7 +1126,8 @@ async def sightings_batch_notes(
 
     count = len(reqs)
     msg = f"Added note to {count} requirement{'s' if count != 1 else ''}"
-    return _oob_toast(msg)
+    # Empty body + HX-Trigger:showToast (form posts hx-swap="none").
+    return _with_toast(HTMLResponse(""), msg)
 
 
 @router.get("/v2/partials/sightings/{requirement_id}/unavailable-form", response_class=HTMLResponse)

--- a/app/schemas/sightings.py
+++ b/app/schemas/sightings.py
@@ -20,3 +20,7 @@ class SightingsListParams(BaseModel):
     dir: str = "desc"
     page: int = Field(default=1, ge=1)
     limit: int = Field(default=50, ge=1, le=200)
+    # Dashboard-strip quick filters. These mirror the counter predicates computed in
+    # sightings_list so clicking "N Urgent" / "N Stale" shows exactly those N rows.
+    urgent: bool = False  # priority_score >= 70 OR need_by_date within 48h
+    stale: bool = False  # no ActivityLog within sighting_stale_days

--- a/app/templates/htmx/partials/search/vendor_card.html
+++ b/app/templates/htmx/partials/search/vendor_card.html
@@ -73,8 +73,11 @@
             hx-post="/v2/partials/search/quick-source/offer"
             hx-vals='{"mpn": "{{ card.mpn_matched|e }}", "vendor_name": "{{ card.vendor_name|e }}"}'
             class="p-1.5 rounded text-gray-400 hover:text-brand-700 hover:bg-brand-50"><svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M12 4v16m8-8H4"/></svg></button>
+    {# Pass the RAW vendor name (url-encoded so spaces/& survive); the server matches on
+       normalize_vendor_name() of both sides, so a lower|trim key that keeps the ", Inc."
+       suffix the normalizer strips no longer misses. #}
     <button type="button"
-            hx-get="/v2/partials/search/lead-detail?search_id={{ search_id }}&vendor_key={{ card.vendor_name|lower|trim }}"
+            hx-get="/v2/partials/search/lead-detail?search_id={{ search_id }}&vendor_key={{ card.vendor_name|urlencode }}"
             hx-target="#lead-drawer-content" hx-swap="innerHTML"
             class="px-2 py-1 rounded text-[11px] text-gray-600 hover:text-brand-700 hover:bg-brand-50">Details →</button>
   </div>

--- a/app/templates/htmx/partials/sightings/table.html
+++ b/app/templates/htmx/partials/sightings/table.html
@@ -13,7 +13,7 @@
 {% set dc = dashboard_counters|default({}) %}
 <div class="px-3 pt-3 pb-2 border-b border-gray-100 flex items-center gap-2 flex-wrap">
   {# Urgent counter — Sales Hub btn shape; active count tints the chrome. #}
-  <button hx-get="/v2/partials/sightings?priority_min=70&q={{ q }}&manufacturer={{ manufacturer|default('') }}"
+  <button hx-get="/v2/partials/sightings?urgent=1&q={{ q }}&manufacturer={{ manufacturer|default('') }}"
           hx-target="#sightings-table" hx-swap="innerHTML"
           class="btn btn-sm btn-secondary inline-flex items-center gap-1.5
                  {{ 'border-rose-300 text-rose-700 bg-rose-50' if dc.get('urgent', 0) > 0 else '' }}">
@@ -318,13 +318,23 @@
             class="btn-primary btn-sm">
       Build RFQ (<span x-text="$store.sightingSelection.count"></span> parts)
     </button>
-    <button class="btn-secondary btn-sm"
-            hx-post="/v2/partials/sightings/batch-refresh"
-            hx-vals='js:{requirement_ids: JSON.stringify($store.sightingSelection.array)}'
-            hx-target="#sightings-table"
-            data-loading-disable>
-      Refresh Sightings
-    </button>
+    {# Refresh runs a connector sweep for the selected requirements, then the handler
+       re-renders this table (target #sightings-table) so coverage/status update in place.
+       requirement_ids ride an Alpine :value bind (works in Alpine scope, unlike $store in
+       hx-vals js:); the current filters ride hidden inputs so the refreshed list keeps the
+       active view. #}
+    <form hx-post="/v2/partials/sightings/batch-refresh"
+          hx-target="#sightings-table" hx-swap="innerHTML"
+          data-loading-disable>
+      <input type="hidden" name="requirement_ids" :value="JSON.stringify($store.sightingSelection.array)">
+      <input type="hidden" name="status" value="{{ status }}">
+      <input type="hidden" name="q" value="{{ q }}">
+      <input type="hidden" name="group_by" value="{{ group_by }}">
+      <input type="hidden" name="manufacturer" value="{{ manufacturer|default('') }}">
+      <button type="submit" class="btn-secondary btn-sm">
+        Refresh Sightings
+      </button>
+    </form>
 
 
     {# ── Batch Status Dropdown ─────────────────────────────── #}
@@ -336,7 +346,7 @@
       <div x-show="open" @click.outside="open = false" x-cloak
            class="absolute bottom-full mb-1 left-0 bg-white border border-gray-200 rounded-lg shadow-lg p-3 w-48 z-50">
         <form hx-post="/v2/partials/sightings/batch-status"
-              hx-target="#toast-trigger" hx-swap="outerHTML"
+              hx-swap="none"
               @htmx:after-request="open = false"
               x-data="{ status: '' }">
           <input type="hidden" name="requirement_ids" :value="JSON.stringify($store.sightingSelection.array)">
@@ -369,7 +379,7 @@
       <div x-show="open" @click.outside="open = false" x-cloak
            class="absolute bottom-full mb-1 left-0 bg-white border border-gray-200 rounded-lg shadow-lg p-3 w-64 z-50">
         <form hx-post="/v2/partials/sightings/batch-notes"
-              hx-target="#toast-trigger" hx-swap="outerHTML"
+              hx-swap="none"
               @htmx:after-request="open = false"
               x-data="{ noteText: '' }">
           <input type="hidden" name="requirement_ids" :value="JSON.stringify($store.sightingSelection.array)">

--- a/app/templates/htmx/partials/sourcing/_filter_macros.html
+++ b/app/templates/htmx/partials/sourcing/_filter_macros.html
@@ -5,9 +5,11 @@
    Depends on: nothing (pure markup helpers).
 
    filter_pill_group renders one labelled row of pill links. Every link points at
-   the sourcing partial with the full filter query string, where exactly one
+   the caller-supplied `endpoint` with the full filter query string, where exactly one
    parameter (`param`) is overridden by the option value and the rest stay at their
-   current f_* value. `selected` is the value that paints a pill active.
+   current f_* value, and pushes `push_url` to history. `selected` is the value that
+   paints a pill active. (Results view targets the full-grid partial; the workspace view
+   passes the rows-only '.../workspace-list' endpoint + '#lead-list-content' target.)
 
    The body is emitted at a canonical indentation (the opening <div> at column 0,
    its children two spaces deeper). Each call site positions the first line and pipes
@@ -15,13 +17,14 @@
    rendered bytes match the former inline markup exactly. #}
 
 {% macro filter_pill_group(label, param, options, selected, requirement_id, target,
+                           endpoint, push_url,
                            f_confidence, f_safety, f_freshness, f_source, f_status,
                            f_contactability, f_corroborated, f_sort) -%}
 <div class="flex items-center gap-1.5">
   <span class="text-[11px] text-gray-600 font-medium">{{ label }}:</span>
   {% for val, opt_label in options %}
-  <a hx-get="/v2/partials/sourcing/{{ requirement_id }}?confidence={{ val if param == 'confidence' else f_confidence }}&safety={{ val if param == 'safety' else f_safety }}&freshness={{ val if param == 'freshness' else f_freshness }}&source={{ f_source }}&status={{ val if param == 'status' else f_status }}&contactability={{ val if param == 'contactability' else f_contactability }}&corroborated={{ val if param == 'corroborated' else f_corroborated }}&sort={{ f_sort }}"
-     hx-target="{{ target }}" hx-push-url="true"
+  <a hx-get="{{ endpoint }}?confidence={{ val if param == 'confidence' else f_confidence }}&safety={{ val if param == 'safety' else f_safety }}&freshness={{ val if param == 'freshness' else f_freshness }}&source={{ f_source }}&status={{ val if param == 'status' else f_status }}&contactability={{ val if param == 'contactability' else f_contactability }}&corroborated={{ val if param == 'corroborated' else f_corroborated }}&sort={{ f_sort }}"
+     hx-target="{{ target }}" hx-push-url="{{ push_url }}"
      class="px-2 py-0.5 text-[11px] rounded-full border cursor-pointer
        {{ 'bg-brand-500 text-white border-brand-500' if val == selected else 'bg-white text-gray-600 border-gray-300 hover:border-brand-300' }}">
     {{ opt_label }}

--- a/app/templates/htmx/partials/sourcing/filter_bar.html
+++ b/app/templates/htmx/partials/sourcing/filter_bar.html
@@ -5,12 +5,24 @@
    Context vars: requirement, f_confidence, f_safety, f_freshness, f_source, f_status,
                  f_contactability, f_corroborated, f_sort,
                  filter_target (str, default '#main-content') — HTMX swap target for filter changes
+                 filter_endpoint (str, default '/v2/partials/sourcing/{id}') — hx-get URL each
+                   control hits. Results view uses the full-grid partial; the workspace view
+                   MUST pass the rows-only '.../workspace-list' endpoint so filters swap just
+                   the left list rows into #lead-list-content instead of nesting the whole
+                   card grid inside it.
+                 filter_push_url (str, default '/v2/sourcing/{id}') — real (resolvable) page
+                   URL pushed to history so F5 loads the app shell, not the naked partial
+                   fragment. Must be a registered page route ('/v2/sourcing/...'), not the
+                   pretty '/sourcing/...' alias (which 404s on reload).
                  compact (bool, default false) — show single-row compact mode #}
 {% from "htmx/partials/sourcing/_filter_macros.html" import filter_pill_group -%}
 {% set target = filter_target|default('#main-content') %}
+{% set endpoint = filter_endpoint|default('/v2/partials/sourcing/' ~ requirement.id) %}
+{% set push_url = filter_push_url|default('/v2/sourcing/' ~ requirement.id) %}
 {% set is_compact = compact|default(false) %}
 {# Bind the current filter state once so each pill group only varies by its own param. #}
 {% set _state = {'requirement_id': requirement.id, 'target': target,
+                 'endpoint': endpoint, 'push_url': push_url,
                  'f_confidence': f_confidence, 'f_safety': f_safety,
                  'f_freshness': f_freshness, 'f_source': f_source, 'f_status': f_status,
                  'f_contactability': f_contactability, 'f_corroborated': f_corroborated,
@@ -25,8 +37,8 @@
 
     <div class="flex items-center gap-1.5">
       <span class="text-[11px] text-gray-600 font-medium">Sort:</span>
-      <select hx-get="/v2/partials/sourcing/{{ requirement.id }}"
-              hx-target="{{ target }}" hx-push-url="true"
+      <select hx-get="{{ endpoint }}"
+              hx-target="{{ target }}" hx-push-url="{{ push_url }}"
               hx-include="#sourcing-filters"
               name="sort"
               class="text-[11px] border border-gray-300 rounded px-1.5 py-0.5 focus:ring-brand-500 focus:border-brand-500">
@@ -55,8 +67,8 @@
         <label class="flex items-center gap-0.5 text-[11px] cursor-pointer">
           <input type="checkbox" name="source" value="{{ src }}"
                  {{ 'checked' if src in f_source }}
-                 hx-get="/v2/partials/sourcing/{{ requirement.id }}"
-                 hx-target="{{ target }}" hx-push-url="true"
+                 hx-get="{{ endpoint }}"
+                 hx-target="{{ target }}" hx-push-url="{{ push_url }}"
                  hx-include="#sourcing-filters"
                  class="rounded border-gray-300 text-brand-500 focus:ring-brand-500 w-3 h-3">
           {% with source_type=src %}{% include "htmx/partials/shared/source_badge.html" %}{% endwith %}

--- a/app/templates/htmx/partials/sourcing/results.html
+++ b/app/templates/htmx/partials/sourcing/results.html
@@ -34,8 +34,12 @@
     </div>
   </div>
 
-  {# Filter bar (shared component) #}
-  {% with filter_target='#main-content', compact=false %}
+  {# Filter bar (shared component). Results view swaps the whole grid into #main-content
+     and pushes the real page URL so F5 loads the app shell. #}
+  {% with filter_target='#main-content',
+          filter_endpoint='/v2/partials/sourcing/' ~ requirement.id,
+          filter_push_url='/v2/sourcing/' ~ requirement.id,
+          compact=false %}
     {% include "htmx/partials/sourcing/filter_bar.html" %}
   {% endwith %}
 

--- a/app/templates/htmx/partials/sourcing/workspace.html
+++ b/app/templates/htmx/partials/sourcing/workspace.html
@@ -38,9 +38,15 @@
     </div>
   </div>
 
-  {# Filter bar #}
+  {# Filter bar. Workspace swaps ONLY the left list rows (#lead-list-content) via the
+     rows-only workspace-list endpoint — hitting the full-grid partial here nested the
+     entire card grid inside the list panel. Pushes the real workspace page URL so F5
+     loads the app shell. #}
   <div class="flex-shrink-0 px-3 py-2 bg-gray-50 border-b border-gray-200">
-    {% with filter_target='#lead-list-content', compact=true %}
+    {% with filter_target='#lead-list-content',
+            filter_endpoint='/v2/partials/sourcing/' ~ requirement.id ~ '/workspace-list',
+            filter_push_url='/v2/sourcing/' ~ requirement.id ~ '/workspace',
+            compact=true %}
       {% include "htmx/partials/sourcing/filter_bar.html" %}
     {% endwith %}
   </div>

--- a/tests/test_htmx_views_nightly.py
+++ b/tests/test_htmx_views_nightly.py
@@ -343,6 +343,30 @@ class TestSourcingPartials:
         resp = client.get(f"/v2/partials/sourcing/{item.id}/workspace")
         assert resp.status_code == 200
 
+    def test_sourcing_workspace_filters_target_rows_only_endpoint(self, client, db_session: Session, test_user: User):
+        """SOURCING-WS-FILTER-WRONG-TARGET: in the workspace the filter/sort/source
+        controls must hit the rows-only '/workspace-list' endpoint and swap into
+        #lead-list-content — NOT the full card-grid partial (which nested the whole
+        results page inside the left list panel)."""
+        req = _req(db_session, test_user)
+        item = _requirement(db_session, req)
+        _sourcing_lead(db_session, item)
+        db_session.commit()
+
+        body = client.get(f"/v2/partials/sourcing/{item.id}/workspace").text
+        ws_list = f"/v2/partials/sourcing/{item.id}/workspace-list"
+        # The filter controls (pills, sort select, source checkboxes) target the
+        # rows-only endpoint and the left list container.
+        assert f'hx-get="{ws_list}' in body
+        assert 'hx-target="#lead-list-content"' in body
+        # The full-grid partial URL must NOT be a filter hx-get target inside the
+        # workspace filter bar (that was the nesting bug). It only appears as the
+        # "Grid view" link href.
+        assert f'hx-get="/v2/partials/sourcing/{item.id}?' not in body
+        # push-url points at the real (resolvable) workspace page URL, not the naked
+        # partial fragment (which would 404 on F5).
+        assert f'hx-push-url="/v2/sourcing/{item.id}/workspace"' in body
+
     def test_sourcing_workspace_page(self, client, db_session: Session, test_user: User):
         req = _req(db_session, test_user)
         item = _requirement(db_session, req)
@@ -391,21 +415,20 @@ class TestSourcingPartials:
         assert resp.status_code == 404
 
     def test_sourcing_search_trigger(self, client, db_session: Session, test_user: User):
+        """Re-search delegates to search_requirement() (which persists sightings +
+        leads) and redirects back to the results page."""
         req = _req(db_session, test_user)
         item = _requirement(db_session, req)
         db_session.commit()
 
-        mock_broker = MagicMock()
-        mock_broker.publish = AsyncMock(return_value=None)
-        mock_broker.listen = AsyncMock(return_value=iter([]))
-
-        with (
-            patch("app.services.sse_broker.broker", mock_broker),
-            patch("app.search_service.quick_search_mpn", AsyncMock(return_value=[])),
-        ):
+        mock_search = AsyncMock(return_value={"sightings": [], "source_stats": [], "mpn_results": {}})
+        with patch("app.search_service.search_requirement", mock_search):
             resp = client.post(f"/v2/partials/sourcing/{item.id}/search")
 
         assert resp.status_code in (200, 303)
+        # The persistence path was actually invoked (old code discarded results).
+        mock_search.assert_awaited_once()
+        assert resp.headers.get("HX-Redirect") == f"/v2/sourcing/{item.id}"
 
     def test_lead_detail_page(self, client, db_session: Session, test_user: User):
         req = _req(db_session, test_user)

--- a/tests/test_manual_search.py
+++ b/tests/test_manual_search.py
@@ -147,7 +147,8 @@ class TestBatchEdgeCases:
             data={"requirement_ids": "[]"},
         )
         assert resp.status_code == 200
-        assert "0/0" in resp.text
+        # Toast fires via HX-Trigger:showToast (empty body for the non-table caller).
+        assert "0/0" in resp.headers.get("HX-Trigger", "")
 
     def test_malformed_json_returns_400(self, client, db_session):
         """Invalid JSON in requirement_ids should return 400."""

--- a/tests/test_search_streaming.py
+++ b/tests/test_search_streaming.py
@@ -485,6 +485,56 @@ def test_search_filter_reads_from_cache(client, db_session):
     assert "Arrow" in resp.text
 
 
+def test_lead_detail_matches_vendor_with_suffix(client, db_session):
+    """SEARCH-DETAILS-VENDORKEY: the market-row Details → passes the RAW vendor name
+    (url-encoded). The server normalizes BOTH sides, so a name carrying a corporate
+    suffix the normalizer strips (', Inc.') still matches its cached result instead of
+    falling through to 'Lead not found'."""
+    cached_results = [
+        {
+            "vendor_name": "Mouser Electronics, Inc.",
+            "mpn_matched": "LM317T",
+            "unit_price": 0.45,
+            "confidence_color": "green",
+            "confidence_pct": 85,
+            "lead_quality": "strong",
+            "source_type": "nexar",
+            "sub_offers": [],
+            "sources_found": ["nexar"],
+            "score": 80,
+            "is_authorized": True,
+        },
+    ]
+    with patch(
+        "app.routers.htmx_views._get_cached_search_results",
+        return_value=cached_results,
+    ):
+        resp = client.get(
+            "/v2/partials/search/lead-detail",
+            params={"search_id": "sfx-1", "vendor_key": "Mouser Electronics, Inc."},
+            headers={"HX-Request": "true"},
+        )
+    assert resp.status_code == 200
+    assert "Mouser Electronics" in resp.text
+    assert "Lead not found" not in resp.text
+
+
+def test_lead_detail_unknown_vendor_returns_not_found(client, db_session):
+    """A vendor_key with no cached match still returns the 'Lead not found' message."""
+    cached_results = [{"vendor_name": "Arrow Electronics", "mpn_matched": "LM317T"}]
+    with patch(
+        "app.routers.htmx_views._get_cached_search_results",
+        return_value=cached_results,
+    ):
+        resp = client.get(
+            "/v2/partials/search/lead-detail",
+            params={"search_id": "sfx-2", "vendor_key": "Nobody Corp"},
+            headers={"HX-Request": "true"},
+        )
+    assert resp.status_code == 200
+    assert "Lead not found" in resp.text
+
+
 def test_search_filter_expired_returns_message(client, db_session):
     """GET /v2/partials/search/filter with no cached data returns expiry message."""
     with patch(

--- a/tests/test_sightings_async_coverage.py
+++ b/tests/test_sightings_async_coverage.py
@@ -75,7 +75,7 @@ class TestBatchStatusAsync:
             data={"requirement_ids": "[]", "status": "sourcing"},
         )
         assert resp.status_code == 200
-        assert "No requirements" in resp.text
+        assert "No requirements" in resp.headers.get("HX-Trigger", "")
 
     async def test_batch_status_invalid_status(self, client, db_session, test_user, test_requisition):
         r = _make_requirement(db_session, test_requisition)
@@ -113,7 +113,8 @@ class TestBatchRefreshAsync:
                 data={"requirement_ids": "[]"},
             )
         assert resp.status_code == 200
-        assert "Searched" in resp.text or "0/" in resp.text
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "Searched" in trigger or "0/" in trigger
 
     async def test_batch_refresh_invalid_format(self, client):
         resp = client.post(
@@ -148,8 +149,9 @@ class TestBatchRefreshAsync:
                 data={"requirement_ids": json.dumps([r.id])},
             )
         assert resp.status_code == 200
-        # Failed count should be in message
-        assert "1/" in resp.text or "failed" in resp.text.lower()
+        # Failed count should be in the toast message (HX-Trigger header).
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "1/" in trigger or "failed" in trigger.lower()
 
 
 # ── preview-inquiry ───────────────────────────────────────────────────

--- a/tests/test_sightings_async_direct.py
+++ b/tests/test_sightings_async_direct.py
@@ -89,7 +89,8 @@ async def test_batch_refresh_success(db_session: Session, test_user: User, test_
         )
 
     assert resp.status_code == 200
-    assert "Searched" in resp.body.decode()
+    # Toast fires via HX-Trigger:showToast; body is empty for the non-table caller.
+    assert "Searched" in resp.headers.get("HX-Trigger", "")
 
 
 async def test_batch_refresh_empty_ids(db_session: Session, test_user: User):
@@ -132,7 +133,7 @@ async def test_batch_refresh_id_not_found(db_session: Session, test_user: User):
         )
 
     assert resp.status_code == 200
-    assert "failed" in resp.body.decode().lower()
+    assert "failed" in resp.headers.get("HX-Trigger", "").lower()
 
 
 async def test_batch_refresh_search_raises(db_session: Session, test_user: User, test_requisition: Requisition):
@@ -195,7 +196,8 @@ async def test_batch_refresh_skipped_all_fresh(db_session: Session, test_user: U
         )
 
     assert resp.status_code == 200
-    assert "skipped" in resp.body.decode().lower() or "Searched" in resp.body.decode()
+    trigger = resp.headers.get("HX-Trigger", "")
+    assert "skipped" in trigger.lower() or "Searched" in trigger
 
 
 # ── batch-assign (lines 749-782) ─────────────────────────────────────────────
@@ -318,7 +320,7 @@ async def test_batch_status_update_open_to_sourcing(
     )
 
     assert resp.status_code == 200
-    assert "Updated" in resp.body.decode()
+    assert "Updated" in resp.headers.get("HX-Trigger", "")
 
 
 async def test_batch_status_empty_ids_returns_warning(db_session: Session, test_user: User):
@@ -339,7 +341,7 @@ async def test_batch_status_empty_ids_returns_warning(db_session: Session, test_
     )
 
     assert resp.status_code == 200
-    assert "No requirements" in resp.body.decode()
+    assert "No requirements" in resp.headers.get("HX-Trigger", "")
 
 
 async def test_batch_status_invalid_status_raises_400(
@@ -414,7 +416,7 @@ async def test_batch_notes_success(db_session: Session, test_user: User, test_re
     )
 
     assert resp.status_code == 200
-    assert "Added note" in resp.body.decode()
+    assert "Added note" in resp.headers.get("HX-Trigger", "")
 
 
 async def test_batch_notes_empty_ids(db_session: Session, test_user: User):
@@ -435,7 +437,7 @@ async def test_batch_notes_empty_ids(db_session: Session, test_user: User):
     )
 
     assert resp.status_code == 200
-    assert "No requirements" in resp.body.decode()
+    assert "No requirements" in resp.headers.get("HX-Trigger", "")
 
 
 async def test_batch_notes_empty_notes(db_session: Session, test_user: User, test_requisition: Requisition):
@@ -458,7 +460,7 @@ async def test_batch_notes_empty_notes(db_session: Session, test_user: User, tes
     )
 
     assert resp.status_code == 200
-    assert "Note text is required" in resp.body.decode()
+    assert "Note text is required" in resp.headers.get("HX-Trigger", "")
 
 
 # ── mark-unavailable (lines 887-919) ──────────────────────────────────────────

--- a/tests/test_sightings_batch_ops.py
+++ b/tests/test_sightings_batch_ops.py
@@ -95,7 +95,7 @@ def test_batch_refresh_nonexistent_requirement(client, db_session):
             data={"requirement_ids": "[99999]"},
         )
     assert resp.status_code == 200
-    assert "1" in resp.text  # "1 failed" or similar
+    assert "1" in resp.headers.get("HX-Trigger", "")  # "1 failed" in the showToast message
 
 
 def test_batch_refresh_valid_requirement(client, db_session, test_user):
@@ -159,6 +159,46 @@ def test_batch_refresh_runs_searches_in_parallel(client, db_session, test_user):
     assert peak_inflight == 3, f"batch-refresh still serial: peak {peak_inflight} concurrent search(es), expected 3"
 
 
+def test_batch_refresh_rerenders_table_for_split_panel(client, db_session, test_user):
+    """SIGHT-BATCH-REFRESH-WIPE: the split-panel caller (HX-Target: sightings-table)
+    must get the freshly-rendered table back — NOT an empty body that wipes the list —
+    plus the toast via the HX-Trigger:showToast bridge."""
+    _, requirement = _make_req_and_requirement(db_session, test_user.id, mpn="RERENDER-MPN")
+    db_session.commit()
+
+    with patch("app.search_service.search_requirement", new_callable=AsyncMock, return_value=None):
+        resp = client.post(
+            "/v2/partials/sightings/batch-refresh",
+            data={"requirement_ids": json.dumps([requirement.id])},
+            headers={"HX-Target": "sightings-table"},
+        )
+
+    assert resp.status_code == 200
+    # Re-rendered table body (not empty) — contains the requirement + table chrome.
+    assert "RERENDER-MPN" in resp.text
+    assert "sightingSelection" in resp.text  # the table partial re-rendered
+    # Toast still fires via the header bridge.
+    assert "Searched" in resp.headers.get("HX-Trigger", "")
+
+
+def test_batch_refresh_non_table_caller_gets_empty_body(client, db_session, test_user):
+    """The requisition parts-tab caller posts hx-swap='none' (no HX-Target: sightings-
+    table) and only needs the toast — the body stays empty so nothing is
+    swapped/wiped."""
+    _, requirement = _make_req_and_requirement(db_session, test_user.id)
+    db_session.commit()
+
+    with patch("app.search_service.search_requirement", new_callable=AsyncMock, return_value=None):
+        resp = client.post(
+            "/v2/partials/sightings/batch-refresh",
+            data={"requirement_ids": json.dumps([requirement.id])},
+        )
+
+    assert resp.status_code == 200
+    assert resp.text == ""  # empty body — nothing to swap
+    assert "Searched" in resp.headers.get("HX-Trigger", "")
+
+
 # ── batch-assign ──────────────────────────────────────────────────
 
 
@@ -219,7 +259,9 @@ def test_batch_status_empty_list(client):
         data={"requirement_ids": "[]", "status": "sourcing"},
     )
     assert resp.status_code == 200
-    assert "no requirements" in resp.text.lower() or "warning" in resp.text.lower()
+    # Toast now fires via the HX-Trigger:showToast bridge (empty body, hx-swap="none").
+    trigger = resp.headers.get("HX-Trigger", "").lower()
+    assert "no requirements" in trigger or "warning" in trigger
 
 
 def test_batch_status_invalid_status(client, db_session, test_user):
@@ -283,7 +325,8 @@ def test_batch_notes_empty_list(client):
         data={"requirement_ids": "[]", "notes": "Test note"},
     )
     assert resp.status_code == 200
-    assert "no requirements" in resp.text.lower() or "warning" in resp.text.lower()
+    trigger = resp.headers.get("HX-Trigger", "").lower()
+    assert "no requirements" in trigger or "warning" in trigger
 
 
 def test_batch_notes_empty_notes(client, db_session, test_user):
@@ -296,7 +339,8 @@ def test_batch_notes_empty_notes(client, db_session, test_user):
         data={"requirement_ids": json.dumps([requirement.id]), "notes": ""},
     )
     assert resp.status_code == 200
-    assert "required" in resp.text.lower() or "warning" in resp.text.lower()
+    trigger = resp.headers.get("HX-Trigger", "").lower()
+    assert "required" in trigger or "warning" in trigger
 
 
 def test_batch_notes_creates_activity(client, db_session, test_user):

--- a/tests/test_sightings_batch_ops_coverage.py
+++ b/tests/test_sightings_batch_ops_coverage.py
@@ -148,8 +148,9 @@ def test_batch_refresh_all_skipped_returns_info_level(client, db_session, test_u
         )
 
     assert resp.status_code == 200
-    # All skipped — toast should contain "skipped"
-    assert "skipped" in resp.text.lower() or "already fresh" in resp.text.lower() or resp.text
+    # All skipped — toast (HX-Trigger header) should contain the searched-count message.
+    trigger = resp.headers.get("HX-Trigger", "")
+    assert "skipped" in trigger.lower() or "already fresh" in trigger.lower() or "Searched" in trigger
 
 
 def test_batch_refresh_success_path_level_success(client, db_session, test_user):
@@ -188,8 +189,8 @@ def test_batch_refresh_exception_in_search_counts_as_failed(client, db_session, 
             )
 
     assert resp.status_code == 200
-    # failed path → warning level toast
-    assert "1" in resp.text  # "1 failed" mentioned
+    # failed path → warning level toast (HX-Trigger header)
+    assert "1" in resp.headers.get("HX-Trigger", "")  # "1 failed" mentioned
 
 
 def test_batch_refresh_broker_publish_called(client, db_session, test_user):
@@ -222,7 +223,7 @@ def test_batch_refresh_nonexistent_id_increments_failed(client, db_session):
         )
 
     assert resp.status_code == 200
-    assert "1" in resp.text
+    assert "1" in resp.headers.get("HX-Trigger", "")
 
 
 # ── batch-assign: buyer name lookup (lines 769-782) ──────────────────
@@ -304,8 +305,9 @@ def test_batch_status_skip_invalid_transition(client, db_session, test_user):
     )
 
     assert resp.status_code == 200
-    # At least one skipped — toast at warning level or "skipped" text
-    assert "skipped" in resp.text.lower() or "warning" in resp.text.lower() or resp.text
+    # At least one skipped — toast (HX-Trigger header) at warning level or "skipped" text
+    trigger = resp.headers.get("HX-Trigger", "")
+    assert "skipped" in trigger.lower() or "warning" in trigger.lower() or "Updated" in trigger
 
 
 def test_batch_status_success_creates_activity_log(client, db_session, test_user):
@@ -369,8 +371,8 @@ def test_batch_notes_singular_count_in_message(client, db_session, test_user):
     )
 
     assert resp.status_code == 200
-    # "1 requirement" (singular, not "requirements")
-    assert "requirement" in resp.text.lower()
+    # "1 requirement" (singular, not "requirements") — in the HX-Trigger toast message.
+    assert "requirement" in resp.headers.get("HX-Trigger", "").lower()
 
 
 # ── mark-unavailable: broker.publish and sightings_detail (lines 900-919) ─

--- a/tests/test_sightings_coverage.py
+++ b/tests/test_sightings_coverage.py
@@ -311,8 +311,8 @@ class TestBatchRefreshLogic:
                 data={"requirement_ids": json.dumps([r.id])},
             )
         assert resp.status_code == 200
-        # "Refreshed 1/1" or similar success message
-        assert "1/1" in resp.text or "1" in resp.text
+        # Toast fires via HX-Trigger:showToast (empty body for the non-table caller).
+        assert "1/1" in resp.headers.get("HX-Trigger", "")
 
     def test_batch_refresh_failure_increments_failed(self, client, db_session):
         """Search failure for a requirement shows failed count."""
@@ -326,7 +326,8 @@ class TestBatchRefreshLogic:
                 data={"requirement_ids": json.dumps([r.id])},
             )
         assert resp.status_code == 200
-        assert "failed" in resp.text.lower() or "0/1" in resp.text
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "failed" in trigger.lower() or "0/1" in trigger
 
     def test_batch_refresh_nonexistent_id_counts_as_failed(self, client, db_session):
         """Nonexistent requirement ID results in failed count."""

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -6,7 +6,7 @@ Depends on: conftest.py fixtures, app models, sighting_status service
 
 import json
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from html.parser import HTMLParser
 
 import pytest
@@ -2967,6 +2967,102 @@ class TestDashboardCounters:
             assert label in text, f"Dashboard counter '{label}' missing from response"
 
 
+class TestUrgentStaleQuickFilters:
+    """SIGHT-URGENT-STALE-NOOP: the dashboard 'N Urgent' / 'N Stale' buttons pass
+    ?urgent=1 / ?stale=1; the endpoint must accept + apply them with the SAME predicate
+    as the counters so the filtered list matches the count (previously the params were
+    silently dropped and the full unfiltered list reloaded)."""
+
+    def _two_reqs(self, db_session):
+        """Return (urgent_req, calm_req): one high-priority urgent, one low/idle."""
+        req = Requisition(name="QF RFQ", status="open", customer_name="QF Corp")
+        db_session.add(req)
+        db_session.flush()
+        urgent = Requirement(
+            requisition_id=req.id,
+            primary_mpn="URGENT-MPN",
+            target_qty=10,
+            sourcing_status="open",
+            priority_score=90.0,
+        )
+        calm = Requirement(
+            requisition_id=req.id,
+            primary_mpn="CALM-MPN",
+            target_qty=10,
+            sourcing_status="open",
+            priority_score=10.0,
+        )
+        db_session.add_all([urgent, calm])
+        db_session.commit()
+        return urgent, calm
+
+    def test_urgent_filter_by_priority(self, client, db_session):
+        """?urgent=1 shows only priority>=70 (or near-deadline) requirements."""
+        self._two_reqs(db_session)
+        resp = client.get("/v2/partials/sightings?urgent=1")
+        assert resp.status_code == 200
+        assert "URGENT-MPN" in resp.text
+        assert "CALM-MPN" not in resp.text
+
+    def test_urgent_filter_by_deadline(self, client, db_session):
+        """A low-priority req with need_by within 48h still passes the urgent filter."""
+        req = Requisition(name="DL RFQ", status="open", customer_name="DL Corp")
+        db_session.add(req)
+        db_session.flush()
+        soon = Requirement(
+            requisition_id=req.id,
+            primary_mpn="SOON-MPN",
+            target_qty=10,
+            sourcing_status="open",
+            priority_score=5.0,
+            need_by_date=date.today() + timedelta(days=1),
+        )
+        later = Requirement(
+            requisition_id=req.id,
+            primary_mpn="LATER-MPN",
+            target_qty=10,
+            sourcing_status="open",
+            priority_score=5.0,
+            need_by_date=date.today() + timedelta(days=30),
+        )
+        db_session.add_all([soon, later])
+        db_session.commit()
+        resp = client.get("/v2/partials/sightings?urgent=1")
+        assert resp.status_code == 200
+        assert "SOON-MPN" in resp.text
+        assert "LATER-MPN" not in resp.text
+
+    def test_stale_filter_excludes_recently_active(self, client, db_session):
+        """?stale=1 shows only requirements with no ActivityLog inside the stale
+        window."""
+        urgent, calm = self._two_reqs(db_session)
+        # Give `calm` a fresh activity so it is NOT stale; `urgent` stays stale (no logs).
+        db_session.add(
+            ActivityLog(
+                activity_type="note",
+                channel="manual",
+                requirement_id=calm.id,
+                requisition_id=calm.requisition_id,
+                notes="touched",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        db_session.commit()
+        resp = client.get("/v2/partials/sightings?stale=1")
+        assert resp.status_code == 200
+        assert "URGENT-MPN" in resp.text  # no activity → stale
+        assert "CALM-MPN" not in resp.text  # recent activity → not stale
+
+    def test_no_filter_shows_all(self, client, db_session):
+        """Without the quick-filter params, both requirements appear (regression: the
+        old code dropped the params AND showed everything, masking the bug)."""
+        self._two_reqs(db_session)
+        resp = client.get("/v2/partials/sightings")
+        assert resp.status_code == 200
+        assert "URGENT-MPN" in resp.text
+        assert "CALM-MPN" in resp.text
+
+
 class TestCoverageMap:
     """Phase 2: Fulfillment coverage bar data in sightings_list context."""
 
@@ -3498,7 +3594,8 @@ class TestBatchStatus:
             data={"requirement_ids": json.dumps([r.id]), "status": "sourcing"},
         )
         assert resp.status_code == 200
-        assert "Updated 1 of 1" in resp.text
+        # Toast fires via HX-Trigger:showToast (empty body, form posts hx-swap="none").
+        assert "Updated 1 of 1" in resp.headers.get("HX-Trigger", "")
         db_session.refresh(r)
         assert r.sourcing_status == "sourcing"
 
@@ -3531,7 +3628,7 @@ class TestBatchStatus:
             data={"requirement_ids": json.dumps([r.id]), "status": "sourcing"},
         )
         assert resp.status_code == 200
-        assert "skipped" in resp.text.lower()
+        assert "skipped" in resp.headers.get("HX-Trigger", "").lower()
         db_session.refresh(r)
         assert r.sourcing_status == "won"
 
@@ -3549,8 +3646,9 @@ class TestBatchStatus:
             data={"requirement_ids": json.dumps([r1.id, r2.id]), "status": "sourcing"},
         )
         assert resp.status_code == 200
-        assert "Updated 1 of 2" in resp.text
-        assert "1 skipped" in resp.text
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "Updated 1 of 2" in trigger
+        assert "1 skipped" in trigger
 
     def test_over_limit_returns_400(self, client, db_session):
         ids = list(range(1, 52))
@@ -3579,7 +3677,7 @@ class TestBatchNotes:
             data={"requirement_ids": json.dumps([r.id]), "notes": "Test batch note"},
         )
         assert resp.status_code == 200
-        assert "Added note to 1 requirement" in resp.text
+        assert "Added note to 1 requirement" in resp.headers.get("HX-Trigger", "")
         logs = (
             db_session.query(ActivityLog)
             .filter(
@@ -3604,7 +3702,7 @@ class TestBatchNotes:
             data={"requirement_ids": json.dumps([r1.id, r2.id]), "notes": "Shared note"},
         )
         assert resp.status_code == 200
-        assert "Added note to 2 requirements" in resp.text
+        assert "Added note to 2 requirements" in resp.headers.get("HX-Trigger", "")
         logs = (
             db_session.query(ActivityLog)
             .filter(
@@ -3622,7 +3720,7 @@ class TestBatchNotes:
             data={"requirement_ids": json.dumps([r.id]), "notes": ""},
         )
         assert resp.status_code == 200
-        assert "Note text is required" in resp.text
+        assert "Note text is required" in resp.headers.get("HX-Trigger", "")
 
     def test_over_limit_returns_400(self, client, db_session):
         ids = list(range(1, 52))

--- a/tests/test_sightings_router_comprehensive.py
+++ b/tests/test_sightings_router_comprehensive.py
@@ -377,7 +377,9 @@ class TestSightingsRefreshBranches:
                 data={"requirement_ids": json.dumps([r.id, r2.id])},
             )
             assert resp.status_code == 200
-            assert "1 failed" in resp.text or "failed" in resp.text.lower()
+            # Toast fires via HX-Trigger:showToast (empty body for the non-table caller).
+            trigger = resp.headers.get("HX-Trigger", "")
+            assert "1 failed" in trigger or "failed" in trigger.lower()
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -717,7 +719,7 @@ class TestBatchNotesBranches:
             data={"requirement_ids": "[]", "notes": "note"},
         )
         assert resp.status_code == 200
-        assert "No requirements selected" in resp.text
+        assert "No requirements selected" in resp.headers.get("HX-Trigger", "")
 
     def test_whitespace_only_notes(self, client, db_session):
         _, r, _ = _seed(db_session)
@@ -726,7 +728,7 @@ class TestBatchNotesBranches:
             data={"requirement_ids": json.dumps([r.id]), "notes": "   "},
         )
         assert resp.status_code == 200
-        assert "Note text is required" in resp.text
+        assert "Note text is required" in resp.headers.get("HX-Trigger", "")
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -741,7 +743,7 @@ class TestBatchStatusBranches:
             data={"requirement_ids": "[]", "status": "sourcing"},
         )
         assert resp.status_code == 200
-        assert "No requirements selected" in resp.text
+        assert "No requirements selected" in resp.headers.get("HX-Trigger", "")
 
     def test_all_valid_transitions(self, client, db_session):
         req = Requisition(name="RFQ", status="open", customer_name="Corp")
@@ -756,7 +758,7 @@ class TestBatchStatusBranches:
             data={"requirement_ids": json.dumps([r1.id, r2.id]), "status": "sourcing"},
         )
         assert resp.status_code == 200
-        assert "Updated 2 of 2" in resp.text
+        assert "Updated 2 of 2" in resp.headers.get("HX-Trigger", "")
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_sightings_router_coverage2.py
+++ b/tests/test_sightings_router_coverage2.py
@@ -375,7 +375,7 @@ class TestBatchRefreshAdditional:
                 headers={"HX-Request": "true"},
             )
         assert resp.status_code == 200
-        assert "failed" in resp.text.lower()
+        assert "failed" in resp.headers.get("HX-Trigger", "").lower()
 
     def test_batch_refresh_invalid_json(self, client: TestClient):
         resp = client.post(

--- a/tests/test_sightings_router_coverage3.py
+++ b/tests/test_sightings_router_coverage3.py
@@ -105,7 +105,7 @@ class TestBatchRefreshCoverage:
                 headers={"HX-Request": "true"},
             )
         assert resp.status_code == 200
-        assert "1/1" in resp.text
+        assert "1/1" in resp.headers.get("HX-Trigger", "")
 
     def test_batch_refresh_id_not_found_increments_failed(self, client: TestClient):
         """Lines 657-659: req_obj is None → failed += 1."""
@@ -116,7 +116,7 @@ class TestBatchRefreshCoverage:
                 headers={"HX-Request": "true"},
             )
         assert resp.status_code == 200
-        assert "failed" in resp.text.lower()
+        assert "failed" in resp.headers.get("HX-Trigger", "").lower()
 
     def test_batch_refresh_mixed_failed_and_skipped(self, client: TestClient, two_items, db_session: Session):
         """Lines 683-688: failed > 0 → level='warning', skipped text appended."""
@@ -134,8 +134,9 @@ class TestBatchRefreshCoverage:
                 headers={"HX-Request": "true"},
             )
         assert resp.status_code == 200
-        # Either failed or skipped text must appear
-        assert "failed" in resp.text.lower() or "skipped" in resp.text.lower()
+        # Either failed or skipped text must appear in the HX-Trigger toast message.
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "failed" in trigger.lower() or "skipped" in trigger.lower()
 
     def test_batch_refresh_too_many(self, client: TestClient):
         """Line 642-643: exceeds MAX_BATCH_SIZE."""
@@ -157,7 +158,7 @@ class TestBatchRefreshCoverage:
             )
         # non-list parsed → requirement_ids = [] → 0 searched
         assert resp.status_code == 200
-        assert "0/0" in resp.text
+        assert "0/0" in resp.headers.get("HX-Trigger", "")
 
 
 # ── batch-assign ─────────────────────────────────────────────────────────────
@@ -255,7 +256,7 @@ class TestBatchStatusCoverage:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "No requirements selected" in resp.text
+        assert "No requirements selected" in resp.headers.get("HX-Trigger", "")
 
     def test_batch_status_too_many(self, client: TestClient):
         """Line 747-748: exceeds MAX_BATCH_SIZE."""
@@ -286,7 +287,7 @@ class TestBatchStatusCoverage:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "Updated 1" in resp.text
+        assert "Updated 1" in resp.headers.get("HX-Trigger", "")
 
     def test_batch_status_skipped_invalid_transition(self, client: TestClient, req_item, db_session: Session):
         """Lines 778-787: invalid transition → skipped > 0, level=warning."""
@@ -300,7 +301,7 @@ class TestBatchStatusCoverage:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "skipped" in resp.text.lower()
+        assert "skipped" in resp.headers.get("HX-Trigger", "").lower()
 
     def test_batch_status_two_items_mixed(self, client: TestClient, two_items, db_session: Session):
         """Both items: one valid, one invalid transition → updated=1, skipped=1."""
@@ -313,7 +314,7 @@ class TestBatchStatusCoverage:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "skipped" in resp.text.lower()
+        assert "skipped" in resp.headers.get("HX-Trigger", "").lower()
 
 
 # ── batch-notes ──────────────────────────────────────────────────────────────
@@ -328,7 +329,7 @@ class TestBatchNotesCoverage:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "No requirements selected" in resp.text
+        assert "No requirements selected" in resp.headers.get("HX-Trigger", "")
 
     def test_batch_notes_too_many(self, client: TestClient):
         """Line 804-805: exceeds MAX_BATCH_SIZE."""
@@ -349,7 +350,7 @@ class TestBatchNotesCoverage:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "Note text is required" in resp.text
+        assert "Note text is required" in resp.headers.get("HX-Trigger", "")
 
     def test_batch_notes_success(self, client: TestClient, req_item):
         """Lines 813-831: notes added to all requirements, success toast."""
@@ -360,7 +361,7 @@ class TestBatchNotesCoverage:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "Added note" in resp.text
+        assert "Added note" in resp.headers.get("HX-Trigger", "")
 
     def test_batch_notes_multiple_requirements(self, client: TestClient, two_items):
         """Plural form: 'Added note to 2 requirements'."""
@@ -371,7 +372,7 @@ class TestBatchNotesCoverage:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "2 requirement" in resp.text
+        assert "2 requirement" in resp.headers.get("HX-Trigger", "")
 
 
 # ── mark-unavailable ──────────────────────────────────────────────────────────

--- a/tests/test_sightings_router_extra.py
+++ b/tests/test_sightings_router_extra.py
@@ -75,7 +75,8 @@ class TestBatchRefresh:
                 headers={"HX-Request": "true"},
             )
         assert resp.status_code == 200
-        assert "Searched" in resp.text or "Refreshed" in resp.text
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "Searched" in trigger or "Refreshed" in trigger
 
     def test_batch_refresh_nonexistent_ids(self, client: TestClient):
         with patch("app.search_service.search_requirement", new=AsyncMock()):
@@ -85,7 +86,8 @@ class TestBatchRefresh:
                 headers={"HX-Request": "true"},
             )
         assert resp.status_code == 200
-        assert "failed" in resp.text.lower() or "0/" in resp.text
+        trigger = resp.headers.get("HX-Trigger", "")
+        assert "failed" in trigger.lower() or "0/" in trigger
 
 
 class TestBatchAssign:
@@ -136,7 +138,7 @@ class TestBatchStatus:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "No requirements" in resp.text
+        assert "No requirements" in resp.headers.get("HX-Trigger", "")
 
     def test_batch_status_too_many(self, client: TestClient):
         ids = list(range(51))
@@ -164,7 +166,7 @@ class TestBatchStatus:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "Updated" in resp.text
+        assert "Updated" in resp.headers.get("HX-Trigger", "")
 
 
 class TestBatchNotes:
@@ -175,7 +177,7 @@ class TestBatchNotes:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "No requirements" in resp.text
+        assert "No requirements" in resp.headers.get("HX-Trigger", "")
 
     def test_batch_notes_too_many(self, client: TestClient):
         ids = list(range(51))
@@ -194,7 +196,7 @@ class TestBatchNotes:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "required" in resp.text.lower()
+        assert "required" in resp.headers.get("HX-Trigger", "").lower()
 
     def test_batch_notes_success(self, client: TestClient, req_with_item: tuple):
         _, item = req_with_item
@@ -204,7 +206,7 @@ class TestBatchNotes:
             headers={"HX-Request": "true"},
         )
         assert resp.status_code == 200
-        assert "Added note" in resp.text
+        assert "Added note" in resp.headers.get("HX-Trigger", "")
 
 
 class TestAssignBuyer:

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -61,7 +61,7 @@ def test_htmx_ajax_calls_have_indicator():
     # the allowlist. Drain the list as those sites get fixed.
     allowlist: set[tuple[str, int]] = {
         ("app/templates/htmx/base.html", 57),
-        ("app/templates/htmx/partials/sourcing/workspace.html", 176),
+        ("app/templates/htmx/partials/sourcing/workspace.html", 182),
         ("app/templates/htmx/partials/parts/cell_edit.html", 12),
         ("app/templates/htmx/partials/parts/cell_edit.html", 26),
         ("app/templates/htmx/partials/parts/cell_edit.html", 37),
@@ -165,11 +165,11 @@ def test_hx_vals_js_has_no_alpine_magics():
     Regression (SET-01): the system-settings toggles used `$el.checked`, so every
     toggle no-op'd. Use `event.target` / `this` instead.
 
-    NOTE: `$store` is deliberately excluded here — the one remaining `$store` use
-    (sightings batch actions) is tracked separately as SIGHT-BATCH in the review
-    and fixed in its own wave; add it back to this ratchet once that lands.
+    `$store` is included: the last remaining `$store` use in `hx-vals="js:..."` (the
+    sightings batch-refresh button, SIGHT-BATCH) was converted to a form with an Alpine
+    `:value` bind, so no `hx-vals js:` may reference `$store` (undefined in htmx eval).
     """
-    magic = re.compile(r"\$(el|refs|data|dispatch|nextTick|watch)\b")
+    magic = re.compile(r"\$(el|store|refs|data|dispatch|nextTick|watch)\b")
     offenders: list[str] = []
     for path in sorted(Path("app/templates").rglob("*.html")):
         text = path.read_text()


### PR DESCRIPTION
Six verified P1 workflow breaks in sightings/sourcing/search, all reproduced + root-caused:

- **SIGHT-BATCH-DEAD**: batch Change-Status/Add-Note forms targeted `#toast-trigger` (exists nowhere) → htmx aborted. Now post `hx-swap=none` with the toast via `HX-Trigger:showToast` (the app's real toast bridge).
- **SIGHT-BATCH-REFRESH-WIPE**: Refresh returned only a dead-anchor OOB toast that emptied the table. Now a form carrying `requirement_ids` + filters; handler re-renders the table (split-panel) / empty (parts-tab) with the toast via header. Removed the `$store`-in-`hx-vals js:` that would ReferenceError.
- **SIGHT-URGENT-STALE-NOOP**: Urgent/Stale counter buttons sent params the schema dropped → showed the full list. Added `urgent`/`stale` to the schema + applied the *exact counter predicates* so N Urgent shows those N.
- **SOURCING-RESEARCH-NOOP**: 'Re-search' ran 6 duplicate sweeps, persisted nothing, redirected to the stale list. Now delegates to `search_requirement()` (persists sightings + write-throughs SourcingLead rows).
- **SOURCING-WS-FILTER-WRONG-TARGET**: workspace filters swapped the full grid into the left list panel + pushed a naked partial URL. Parameterized the filter bar → rows-only endpoint into the grid container + a resolvable page push-url.
- **SEARCH-DETAILS-VENDORKEY**: market-row 'Details →' built the vendor key with `|lower|trim` but the server matched `normalize_vendor_name()` → 'Lead not found'. Template passes the raw name; server normalizes both sides.

Authz + SSE-gate + X-Rendered-Req-Id conventions preserved. Closed the `$store`-in-hx-vals ratchet exclusion (last use gone). Full suite 21582 passed; merged current main in cleanly (static-analysis + sightings suites re-verified: 26 + 389 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF