### PR TITLE
fix(resell): Post/Close work on a deep-linked detail page (RS-2)

### DIFF
--- a/app/templates/htmx/partials/resell/detail.html
+++ b/app/templates/htmx/partials/resell/detail.html
@@ -11,6 +11,7 @@
 {% set el = list %}
 
 <div class="flex flex-col h-full"
+     data-resell-detail-root
      x-data="{ tab: 'lines' }">
 
   {# ── Slim header ──────────────────────────────────────────────── #}
@@ -59,8 +60,8 @@
       <div class="flex items-center gap-2 flex-shrink-0">
         {% if can_see_customer and el.status == 'draft' and line_count > 0 %}
         <button hx-post="/api/resell/{{ el.id }}/publish"
-                hx-target="#split-right-resell"
-                hx-swap="innerHTML"
+                hx-target="closest [data-resell-detail-root]"
+                hx-swap="outerHTML"
                 hx-confirm="Post this list? Lines lock and become visible to brokers."
                 data-loading-disable
                 class="btn-primary btn-sm">
@@ -81,8 +82,8 @@
         {% endif %}
         {% if can_see_customer and el.status in ['open', 'collecting'] %}
         <button hx-post="/api/resell/{{ el.id }}/close"
-                hx-target="#split-right-resell"
-                hx-swap="innerHTML"
+                hx-target="closest [data-resell-detail-root]"
+                hx-swap="outerHTML"
                 hx-confirm="Close this list? The posting window ends and the bid goes out."
                 data-loading-disable
                 class="btn-secondary btn-sm">

--- a/tests/test_resell_routes.py
+++ b/tests/test_resell_routes.py
@@ -670,3 +670,24 @@ def test_import_confirm_to_posted_list_returns_409(client, db_session, trader_us
         assert resp.status_code == 409
     finally:
         app.dependency_overrides.pop(require_user, None)
+
+
+def test_detail_action_buttons_target_self_not_workspace_shell(client, db_session, trader_user, posted_list):
+    """RS-2: on a deep-linked/reloaded /v2/resell/{id}, the detail loads standalone
+    into #main-content — but Post/Close targeted #split-right-resell, which only exists
+    in the workspace shell, so they fired htmx:targetError and did nothing. They must
+    target the detail's own always-present root instead."""
+    from app.dependencies import require_user
+
+    client.app.dependency_overrides[require_user] = lambda: trader_user
+    try:
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}")
+    finally:
+        client.app.dependency_overrides.pop(require_user, None)
+    assert resp.status_code == 200
+    body = resp.text
+    # The owner sees the Close action (collecting list); it targets the detail root,
+    # and no action targets the workspace-shell-only #split-right-resell.
+    assert "data-resell-detail-root" in body
+    assert "#split-right-resell" not in body
+    assert "closest [data-resell-detail-root]" in body


### PR DESCRIPTION
**RS-2.** The resell Post and Close buttons targeted `#split-right-resell`, which only exists in the workspace split shell. On a reloaded/bookmarked `/v2/resell/{id}` the detail loads standalone into `#main-content`, so the selector resolved to nothing → htmx fired `targetError` and the buttons clicked **silently**. Both handlers return the detail partial, so they now target the detail's own always-present root (`data-resell-detail-root`) with `outerHTML` — working in both the workspace and standalone contexts (mirrors the CRM F6 fix).

TDD: deep-linked detail (as owner) targets the detail root, never `#split-right-resell`. Ripple 46 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF