### PR TITLE
fix(workflow): honest follow-up card + materials Enrich stops self-nesting (MAT-2, F2)

### DIFF
--- a/app/routers/htmx/offers.py
+++ b/app/routers/htmx/offers.py
@@ -1388,6 +1388,14 @@ async def send_follow_up_htmx(
     ctx = _base_ctx(request, user, "follow-ups")
     ctx["contact_id"] = contact_id
     ctx["vendor_name"] = contact.vendor_name or "Vendor"
+
+    # Honest result card: only claim "sent" when the email actually went out (or in test
+    # mode). A swallowed Graph failure or a contact with no address leaves email_sent False
+    # — surface that instead of the green success card, which used to lie.
+    if not email_sent and not is_testing:
+        ctx["reason"] = "no_email" if not contact.vendor_contact else "send_failed"
+        return template_response("htmx/partials/follow_ups/send_failed.html", ctx)
+
     return template_response("htmx/partials/follow_ups/sent_success.html", ctx)
 
 

--- a/app/templates/htmx/partials/follow_ups/send_failed.html
+++ b/app/templates/htmx/partials/follow_ups/send_failed.html
@@ -1,0 +1,24 @@
+{#
+  follow_ups/send_failed.html — Replaces a follow-up card when the send did NOT happen.
+  Shown when the Graph send raised (swallowed exception) or the contact has no email
+  address on file, so the card never falsely claims "Follow-up sent".
+  Receives: contact_id (int), vendor_name (str), reason (str: 'no_email' | 'send_failed').
+  Called by: htmx/offers.py send_follow_up_htmx endpoint.
+  Depends on: Tailwind CSS with rose palette.
+#}
+<div id="follow-up-{{ contact_id }}" class="bg-rose-50 rounded-lg border border-rose-200 p-4">
+  <div class="flex items-center gap-2">
+    <div class="flex items-center justify-center w-6 h-6 rounded-full bg-rose-100">
+      <svg class="h-4 w-4 text-rose-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+    </div>
+    <p class="text-sm font-medium text-rose-700">
+      {% if reason == 'no_email' %}
+      No email address on file for <span class="font-semibold">{{ vendor_name }}</span> — follow-up not sent.
+      {% else %}
+      Couldn't send the follow-up to <span class="font-semibold">{{ vendor_name }}</span>. Please try again.
+      {% endif %}
+    </p>
+  </div>
+</div>

--- a/app/templates/htmx/partials/materials/detail.html
+++ b/app/templates/htmx/partials/materials/detail.html
@@ -52,9 +52,12 @@
         {# Enrichment-status badge — polls itself while the card is queued (HTTP 286
            stops the poll once the worker lands a terminal status). #}
         {% include "htmx/partials/materials/enrich_status.html" %}
+        {# Enrich returns the FULL detail partial, so it must replace the whole detail
+           surface (#main-content) like conflict-accept and the edit form — NOT hx-target
+           "this"/outerHTML, which nested a second detail tree inside this button. #}
         <button hx-post="/v2/partials/materials/{{ card.id }}/enrich"
-                hx-target="this"
-                hx-swap="outerHTML"
+                hx-target="#main-content"
+                hx-swap="innerHTML"
                 data-loading-disable
                 class="mt-1 inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-accent-600 bg-accent-50 border border-accent-200 rounded-lg hover:bg-accent-100 transition-colors">
           <svg class="h-3.5 w-3.5 htmx-indicator animate-spin" fill="none" viewBox="0 0 24 24">

--- a/tests/test_workflow_honesty_p1.py
+++ b/tests/test_workflow_honesty_p1.py
@@ -1,0 +1,118 @@
+"""Workflow-honesty P1s — the UI must not claim an action succeeded when it didn't, and
+a self-refreshing action must not nest a second copy of its own surface.
+
+Covers two audit findings (2026-07-02 production-polish review):
+  * MAT-2 — the materials Enrich button returned the FULL detail partial into
+    hx-target="this"/outerHTML, nesting a duplicate detail tree (and duplicate
+    element IDs) inside the button. It must target #main-content like its sibling
+    actions (conflict-accept, edit).
+  * F2 — send_follow_up_htmx returned the green "Follow-up sent" card even when the
+    Graph send raised (swallowed) or the contact had no email address, so email_sent
+    stayed False. It must return an honest failure card in those cases.
+
+Called by: pytest
+Depends on: app.routers.htmx.offers, app.routers.htmx.materials, conftest fixtures
+            (client = buyer test_user → unrestricted requisition access).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.intelligence import MaterialCard
+from app.models.offers import Contact as RfqContact
+from app.models.sourcing import Requisition
+
+# ── MAT-2: Enrich button targets #main-content, never self-nests ─────────────
+
+
+def test_material_enrich_button_targets_main_content(client: TestClient, db_session: Session):
+    """The Enrich button must swap into #main-content (its endpoint returns the whole
+    detail partial), not hx-target='this'/outerHTML which nested a duplicate detail."""
+    card = MaterialCard(normalized_mpn="lm317t", display_mpn="LM317T", manufacturer="TI", search_count=0)
+    db_session.add(card)
+    db_session.commit()
+    db_session.refresh(card)
+
+    html = client.get(f"/v2/partials/materials/{card.id}").text
+
+    # Isolate the Enrich button's own attributes (from its hx-post to the class attr).
+    marker = f'hx-post="/v2/partials/materials/{card.id}/enrich"'
+    assert marker in html, "Enrich button missing from detail render"
+    start = html.index(marker)
+    button = html[start : start + 300]
+    assert 'hx-target="#main-content"' in button, "Enrich must target #main-content"
+    assert 'hx-target="this"' not in button, "Enrich must NOT self-target (nests a duplicate detail)"
+    assert 'hx-swap="outerHTML"' not in button, "Enrich must not outerHTML-swap onto itself"
+
+
+# ── F2: follow-up send tells the truth ───────────────────────────────────────
+
+
+def _seed_contact(db: Session, user, *, vendor_contact: str | None) -> RfqContact:
+    req = Requisition(name="FU-REQ", customer_name="FU Co", status="open")
+    db.add(req)
+    db.flush()
+    contact = RfqContact(
+        requisition_id=req.id,
+        user_id=user.id,
+        contact_type="email",
+        vendor_name="V Co",
+        vendor_contact=vendor_contact,
+        status="sent",
+    )
+    db.add(contact)
+    db.commit()
+    db.refresh(contact)
+    return contact
+
+
+def test_follow_up_no_email_returns_failure_card(client, db_session, test_user, monkeypatch):
+    """A contact with no email address on file: the Graph block is skipped, email_sent
+    stays False — the endpoint must return the honest 'no email' card, not 'sent'."""
+    # is_testing gates the success path open; turn it OFF so the real send/skip logic runs.
+    monkeypatch.setenv("TESTING", "0")
+    contact = _seed_contact(db_session, test_user, vendor_contact=None)
+
+    resp = client.post(f"/v2/partials/follow-ups/{contact.id}/send")
+    assert resp.status_code == 200
+    assert "No email address on file" in resp.text
+    assert "Follow-up sent" not in resp.text
+    # Status must NOT have advanced to a sent-state on a non-send.
+    db_session.refresh(contact)
+    assert contact.status == "sent"  # unchanged from seed; never flipped to SENT by a real send
+
+
+def test_follow_up_send_failure_returns_failure_card(client, db_session, test_user, monkeypatch):
+    """When the Graph send raises (swallowed), email_sent is False — return the honest
+    'couldn't send' card rather than the green success card."""
+    monkeypatch.setenv("TESTING", "0")
+    contact = _seed_contact(db_session, test_user, vendor_contact="v@example.com")
+
+    class _BoomGraph:
+        def __init__(self, *a, **k):
+            pass
+
+        async def post_json(self, *a, **k):
+            raise RuntimeError("graph 500")
+
+    with (
+        patch("app.dependencies.require_fresh_token", new=AsyncMock(return_value="tok")),
+        patch("app.utils.graph_client.GraphClient", _BoomGraph),
+    ):
+        resp = client.post(f"/v2/partials/follow-ups/{contact.id}/send")
+
+    assert resp.status_code == 200
+    assert "Couldn't send" in resp.text
+    assert "Follow-up sent" not in resp.text
+
+
+def test_follow_up_testing_mode_still_reports_sent(client, db_session, test_user):
+    """Regression guard: in TESTING mode (is_testing True) the endpoint still returns the
+    success card — the honesty gate must not swallow the normal test/success path."""
+    contact = _seed_contact(db_session, test_user, vendor_contact="v@example.com")
+
+    resp = client.post(f"/v2/partials/follow-ups/{contact.id}/send")
+    assert resp.status_code == 200
+    assert "Follow-up sent" in resp.text


### PR DESCRIPTION
## Workflow-honesty P1s (production-polish audit, 2026-07-02)

Two findings where the UI claimed an action succeeded when it hadn't, or nested its own surface.

### MAT-2 — Enrich button self-nested the whole detail
The materials detail **Enrich** button used `hx-target="this"` + `hx-swap="outerHTML"`, but the `/enrich` endpoint returns the **entire detail partial**. Clicking it rendered a second detail tree *inside the button* — duplicating `#insights-panel`, `#material-tab-content`, `#crosses-section` IDs and breaking their htmx targeting. Now targets `#main-content` like its sibling actions (conflict-accept, edit PUT).

### F2 — follow-up send lied on failure
`send_follow_up_htmx` always returned the green *"Follow-up sent"* card, even when:
- the Graph send **raised** (exception logged + swallowed → `email_sent=False`), or
- the contact had **no email address** (the send block is skipped entirely).

In both cases nothing was sent and `contact.status` never advanced, yet the user saw success. Added `follow_ups/send_failed.html` and gated the return: an honest failure card ("No email address on file" / "Couldn't send…") when `not email_sent and not is_testing`.

## Tests
`tests/test_workflow_honesty_p1.py` — enrich-target render assertion, no-email failure card, send-exception failure card, and a regression guard that TESTING-mode still reports sent. Ripple run (static-analysis ratchets + follow-up + materials neighbors): **77 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)