### PR TITLE
fix(settings): user-mgmt validation errors (400) render the inline banner (SET-03)

### DIFF
--- a/app/templates/htmx/partials/settings/users.html
+++ b/app/templates/htmx/partials/settings/users.html
@@ -3,6 +3,11 @@
              no agent), active_admin_count (int), error (str|None inline banner).
    Rendered by: htmx_views.settings_users_tab (GET) and the three
                 admin/users POSTs (which swap #users-content via outerHTML).
+   Error render (SET-03): validation failures re-render THIS partial with `error` set at
+                HTTP 400. htmx won't swap a 4xx by default, so every form carries
+                hx-target-4xx="#users-content" (response-targets ext, loaded in base.html)
+                — without it the inline banner below was unreachable and the user only saw
+                a generic toast.
    CSRF: htmx_app.js injects x-csrftoken on every POST automatically. #}
 <div class="space-y-4" id="users-content">
 
@@ -21,7 +26,7 @@
     </div>
     <form class="px-5 py-4 grid grid-cols-1 sm:grid-cols-4 gap-3 items-end"
           hx-post="/api/admin/users/invite"
-          hx-target="#users-content" hx-swap="outerHTML">
+          hx-target="#users-content" hx-target-4xx="#users-content" hx-swap="outerHTML">
       <div class="sm:col-span-2">
         <label class="form-label" for="invite-email">Email</label>
         <input id="invite-email" name="email" type="email" required
@@ -89,7 +94,7 @@
             <td class="table-cell">
               <select name="role"
                       hx-post="/api/admin/users/{{ row.user.id }}/role"
-                      hx-target="#users-content" hx-swap="outerHTML"
+                      hx-target="#users-content" hx-target-4xx="#users-content" hx-swap="outerHTML"
                       hx-trigger="change"
                       class="input input-sm input-focus w-auto">
                 {% for r in roles %}
@@ -107,7 +112,7 @@
                        class="h-4 w-4 rounded border-gray-300 text-accent-600 focus:ring-accent-500"
                        {{ 'checked' if row.can_approve_buy_plans else '' }}
                        hx-post="/api/admin/users/{{ row.user.id }}/buyplan-approver"
-                       hx-target="#users-content" hx-swap="outerHTML"
+                       hx-target="#users-content" hx-target-4xx="#users-content" hx-swap="outerHTML"
                        hx-trigger="change">
                 <span class="ml-2 text-xs text-gray-600">{{ 'Yes' if row.can_approve_buy_plans else 'No' }}</span>
               </label>
@@ -117,7 +122,7 @@
                  Wrapped in a form so both fields submit together on any change.
                  Hidden 'false' field ensures an unchecked box still submits a revoke. #}
               <form hx-post="/api/admin/users/{{ row.user.id }}/prepayment-approver"
-                    hx-target="#users-content" hx-swap="outerHTML"
+                    hx-target="#users-content" hx-target-4xx="#users-content" hx-swap="outerHTML"
                     hx-trigger="change from:input">
                 <input type="hidden" name="can_approve" value="false">
                 <div class="space-y-1">
@@ -146,7 +151,7 @@
                        class="h-4 w-4 rounded border-gray-300 text-accent-600 focus:ring-accent-500"
                        {{ 'checked' if row.can_approve_qp_sales else '' }}
                        hx-post="/api/admin/users/{{ row.user.id }}/sales-order-approver"
-                       hx-target="#users-content" hx-swap="outerHTML"
+                       hx-target="#users-content" hx-target-4xx="#users-content" hx-swap="outerHTML"
                        hx-trigger="change">
                 <span class="ml-2 text-xs text-gray-600">{{ 'Yes' if row.can_approve_qp_sales else 'No' }}</span>
               </label>
@@ -161,7 +166,7 @@
                        class="h-4 w-4 rounded border-gray-300 text-accent-600 focus:ring-accent-500"
                        {{ 'checked' if row.can_approve_qp_purchasing else '' }}
                        hx-post="/api/admin/users/{{ row.user.id }}/po-approver"
-                       hx-target="#users-content" hx-swap="outerHTML"
+                       hx-target="#users-content" hx-target-4xx="#users-content" hx-swap="outerHTML"
                        hx-trigger="change">
                 <span class="ml-2 text-xs text-gray-600">{{ 'Yes' if row.can_approve_qp_purchasing else 'No' }}</span>
               </label>
@@ -171,7 +176,7 @@
                  prepayment gate). Wrapped in a form so both fields submit together; the
                  hidden 'false' field ensures an unchecked box still submits a revoke. #}
               <form hx-post="/api/admin/users/{{ row.user.id }}/purchase-order-approver"
-                    hx-target="#users-content" hx-swap="outerHTML"
+                    hx-target="#users-content" hx-target-4xx="#users-content" hx-swap="outerHTML"
                     hx-trigger="change from:input">
                 <input type="hidden" name="can_approve" value="false">
                 <div class="space-y-1">
@@ -210,13 +215,13 @@
                 <button class="btn-secondary btn-sm text-rose-600"
                         hx-post="/api/admin/users/{{ row.user.id }}/active"
                         hx-vals='{"is_active": "false"}'
-                        hx-target="#users-content" hx-swap="outerHTML"
+                        hx-target="#users-content" hx-target-4xx="#users-content" hx-swap="outerHTML"
                         hx-confirm="Deactivate {{ row.user.name or row.user.email }}? They won't be able to sign in.">Deactivate</button>
                 {% else %}
                 <button class="btn-secondary btn-sm text-emerald-600"
                         hx-post="/api/admin/users/{{ row.user.id }}/active"
                         hx-vals='{"is_active": "true"}'
-                        hx-target="#users-content" hx-swap="outerHTML"
+                        hx-target="#users-content" hx-target-4xx="#users-content" hx-swap="outerHTML"
                         hx-confirm="Reactivate {{ row.user.name or row.user.email }}?">Activate</button>
                 {% endif %}
               </div>

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -521,3 +521,30 @@ def test_users_audit_template_renders():
     assert "target@trioscs.com" in html
     assert "system" in html  # actor None
     assert "Showing latest 200 of 999" in html
+
+
+# ── SET-03: validation errors (400) are swappable + rendered ──────────────────
+
+
+class TestUsersTabErrorRender:
+    """SET-03 — a 400 validation re-render carries the inline error banner AND the forms
+    carry hx-target-4xx so htmx (which won't swap a 4xx by default) actually shows it
+    instead of falling back to a generic toast."""
+
+    def test_users_tab_forms_carry_4xx_error_target(self, admin_client):
+        """Every user-mgmt form routes 4xx responses back into #users-content so the re-
+        rendered error banner is swapped in rather than dropped."""
+        html = admin_client.get("/v2/partials/settings/users").text
+        assert 'hx-target-4xx="#users-content"' in html
+        # The invite form (always present) must carry it, not just per-row forms.
+        invite_idx = html.index("/api/admin/users/invite")
+        # Look at the invite form's attribute block around its hx-post.
+        assert 'hx-target-4xx="#users-content"' in html[invite_idx - 200 : invite_idx + 200]
+
+    def test_invite_400_body_contains_error_banner(self, admin_client, db_session):
+        """The 400 re-render body carries the inline banner text (the swappable content
+        hx-target-4xx delivers) — not an empty/JSON body."""
+        r = admin_client.post("/api/admin/users/invite", data={"email": "notanemail", "role": "buyer"})
+        assert r.status_code == 400
+        assert "Enter a valid email address." in r.text
+        assert 'id="users-content"' in r.text  # full partial re-rendered, swap-ready


### PR DESCRIPTION
## SET-03 (production-polish audit, 2026-07-02)

`admin/users.py` re-renders `users.html` **with the inline error banner** at HTTP 400 for validation failures — invalid email, "Can't remove the last admin", "You can't deactivate yourself", bad dollar limit, duplicate user. But htmx doesn't swap a 4xx by default, and `htmx_app.js` only whitelists **422→#modal-content**, so these banners were **unreachable**: the user got a generic toast (the 400 HTML body fails `JSON.parse`) with no reason for the failure.

**Fix (root cause, no semantics change):** every user-mgmt form already targets `#users-content` for success. Adding `hx-target-4xx="#users-content"` (the `response-targets` extension, already loaded in `base.html`) routes the 4xx re-render into the same container, so the banner shows. The 400 status is preserved — the existing `== 400` tests stay valid.

## Tests
`TestUsersTabErrorRender` in `tests/test_user_management.py`:
- every form carries `hx-target-4xx="#users-content"` (the invite form specifically);
- the 400 invite response body carries the swappable banner (`Enter a valid email address.` + `id="users-content"`).

Full `test_user_management.py`: **39 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)