### PR TITLE
fix(requisitions): Add-Requirement dead on empty parts + Search-All nested-swap (REQ-02/REQ-05)

### DIFF
--- a/app/templates/htmx/partials/requisitions/tabs/parts.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parts.html
@@ -17,7 +17,7 @@
       {% if requirements %}
       <button type="button"
               hx-post="/v2/partials/requisitions/{{ req.id }}/search-all"
-              hx-target="closest div"
+              hx-target="#tab-content"
               hx-swap="innerHTML"
               data-loading-disable
               class="btn-primary btn-sm">
@@ -187,7 +187,7 @@
   <div class="mb-3 px-3 py-2 bg-brand-50 border border-brand-200 rounded-lg text-sm text-brand-700 flex items-center gap-2"
        hx-get="/v2/partials/requisitions/{{ req.id }}/tab/parts"
        hx-trigger="load delay:8s"
-       hx-target="closest div"
+       hx-target="#tab-content"
        hx-swap="innerHTML">
     <svg class="h-4 w-4 animate-spin flex-none" fill="none" viewBox="0 0 24 24">
       <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3"></circle>
@@ -197,10 +197,14 @@
   </div>
   {% endif %}
 
-  {# Requirements table #}
+  {# Requirements table — always rendered (including #parts-tbody) so the Add
+     Requirement form's hx-target="#parts-tbody" (above) resolves even when the
+     requisition has zero parts; the empty state lives inside the tbody as a
+     placeholder row, matching the vendors/contacts tab pattern. #}
   <div id="parts-table-wrapper">
   {% if requirements %}
   <p class="text-xs text-gray-400 mb-2">{{ requirements|length }} requirement{{ "s" if requirements|length != 1 }}. Double-click any row to edit inline.</p>
+  {% endif %}
   <div class="overflow-x-auto bg-white rounded-lg border border-brand-200">
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50 sticky top-0">
@@ -228,15 +232,24 @@
         </tr>
       </thead>
       <tbody id="parts-tbody" class="divide-y divide-gray-200">
+        {% if requirements %}
         {% for r in requirements %}
           {% include "htmx/partials/requisitions/tabs/req_row.html" %}
         {% endfor %}
+        {% else %}
+        <tr id="parts-empty-state">
+          <td colspan="17" class="py-6 sm:py-8 text-center">
+            <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
+            </svg>
+            <p class="text-sm font-medium text-gray-600 mt-3">No requirements yet.</p>
+            <p class="text-xs text-gray-400 mt-1">Add parts using the form above.</p>
+          </td>
+        </tr>
+        {% endif %}
       </tbody>
     </table>
   </div>
-  {% else %}
-  {% set message = "No requirements yet. Add parts using the form above." %}
-  {% include "htmx/partials/shared/empty_state.html" %}
-  {% endif %}
   </div>{# /parts-table-wrapper #}
 </div>

--- a/tests/test_htmx_views.py
+++ b/tests/test_htmx_views.py
@@ -813,6 +813,47 @@ class TestAddRequirement:
         )
         assert resp.status_code == 404
 
+    def test_zero_parts_tab_renders_stable_tbody_target(self, client: TestClient, db_session: Session, test_user: User):
+        """REQ-02 regression: the Add Requirement form targets hx-target="#parts-tbody"
+        (unchanged). On a zero-parts requisition the tbody must still be present in
+        the served DOM or htmx aborts with targetError and the form is dead — verify
+        the tab always renders a real #parts-tbody, even with no requirements."""
+        req = _make_requisition(db_session, test_user)
+        db_session.commit()
+        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/parts")
+        assert resp.status_code == 200
+        assert 'id="parts-tbody"' in resp.text
+        assert 'hx-target="#parts-tbody"' in resp.text
+
+    def test_zero_parts_tab_add_requirement_end_to_end(self, client: TestClient, db_session: Session, test_user: User):
+        """REQ-02: Add Requirement must actually work starting from a zero-parts
+        requisition (the form's hx-target now resolves, so the POST completes and
+        returns a swappable <tr> fragment for #parts-tbody)."""
+        req = _make_requisition(db_session, test_user)
+        db_session.commit()
+        tab_resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/parts")
+        assert 'id="parts-tbody"' in tab_resp.text
+
+        add_resp = client.post(
+            f"/v2/partials/requisitions/{req.id}/requirements",
+            data={"primary_mpn": "NE555P", "manufacturer": "Texas Instruments", "target_qty": "100"},
+        )
+        assert add_resp.status_code == 200
+        assert "<tr" in add_resp.text
+        assert "NE555P" in add_resp.text
+
+    def test_has_parts_tab_still_renders_tbody(self, client: TestClient, db_session: Session, test_user: User):
+        """Regression: the has-parts case must keep rendering #parts-tbody with its
+        rows (not just the zero-parts placeholder)."""
+        req = _make_requisition(db_session, test_user)
+        _make_requirement(db_session, req, primary_mpn="LM317T")
+        db_session.commit()
+        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/parts")
+        assert resp.status_code == 200
+        assert 'id="parts-tbody"' in resp.text
+        assert "LM317T" in resp.text
+        assert 'id="parts-empty-state"' not in resp.text
+
 
 class TestSearchAll:
     """Test search-all requirements in a requisition."""
@@ -830,6 +871,36 @@ class TestSearchAll:
         resp = client.post(f"/v2/partials/requisitions/{req.id}/search-all")
         assert resp.status_code == 200
         assert "No requirements to search" in resp.text
+
+    def test_search_all_button_targets_tab_content(self, client: TestClient, db_session: Session, test_user: User):
+        """REQ-05 regression: the toolbar 'Search All Sources' button used to target
+        hx-target="closest div" (the toolbar row), so the full-tab response it gets
+        back nested a duplicate table inside the toolbar. It must target the stable
+        #tab-content ancestor, matching detail_header.html's working wiring."""
+        req = _make_requisition(db_session, test_user)
+        _make_requirement(db_session, req)
+        db_session.commit()
+        resp = client.get(f"/v2/partials/requisitions/{req.id}/tab/parts")
+        assert resp.status_code == 200
+        assert 'hx-target="closest div"' not in resp.text
+        assert 'hx-post="/v2/partials/requisitions/{}/search-all"'.format(req.id) in resp.text
+        assert 'hx-target="#tab-content"' in resp.text
+
+    def test_search_all_refresh_banner_targets_tab_content(
+        self, client: TestClient, db_session: Session, test_user: User
+    ):
+        """REQ-05 regression: the 8s auto-refresh banner shown after triggering a
+        search used to target hx-target="closest div" (the banner itself), nesting
+        a duplicate table inside the banner. It must target #tab-content."""
+        req = _make_requisition(db_session, test_user)
+        _make_requirement(db_session, req)
+        db_session.commit()
+        resp = client.post(f"/v2/partials/requisitions/{req.id}/search-all")
+        assert resp.status_code == 200
+        assert "Searching all sources" in resp.text
+        assert 'hx-target="closest div"' not in resp.text
+        # Both the toolbar button and the refresh banner must now target #tab-content.
+        assert resp.text.count('hx-target="#tab-content"') == 2
 
 
 class TestRequisitionImport:


### PR DESCRIPTION
## Summary

Both findings verified live in current code, in `app/templates/htmx/partials/requisitions/tabs/parts.html`, and fixed:

- **REQ-02 — FIXED.** The Add Requirement form targets `hx-target="#parts-tbody"`, but `#parts-tbody` only existed inside the `{% if requirements %}` table branch; the zero-parts else-branch rendered `shared/empty_state.html` (no tbody), so htmx aborted with `targetError` and `add_requirement` (app/routers/htmx/requisitions.py ~804) was never reached. Fix: the table (with `#parts-tbody`) is now always rendered; the empty state is a placeholder `<tr id="parts-empty-state">` inside the tbody instead of a separate card, matching the existing pattern in `vendors/tabs/contacts.html`. Verified the has-parts case still renders rows correctly (no regression).

- **REQ-05 — FIXED.** Both the "Search All Sources" toolbar button and the 8s auto-refresh banner used `hx-target="closest div"`, resolving to their own small wrapper divs. Since `search-all` and `tab/parts` (app/routers/htmx/requisitions.py ~879-936) both return the *entire* `tabs/parts.html` template, this nested a full duplicate toolbar+table inside the toolbar row (and inside the banner), producing duplicate ids. Fix: both now target `hx-target="#tab-content"`, matching the already-correct wiring on `detail_header.html`'s own "Search Sources" button (`#tab-content` is the stable ancestor div wrapping the tab body in `detail.html`).

## Test plan

- [x] Added `TestAddRequirement.test_zero_parts_tab_renders_stable_tbody_target`, `test_zero_parts_tab_add_requirement_end_to_end`, `test_has_parts_tab_still_renders_tbody`
- [x] Added `TestSearchAll.test_search_all_button_targets_tab_content`, `test_search_all_refresh_banner_targets_tab_content`
- [x] `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_htmx_views.py -q --override-ini="addopts=" ` → 225 passed
- [x] `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_htmx_views.py tests/test_htmx_views_deep.py tests/test_htmx_views_nightly8.py -q --override-ini="addopts="` → 476 passed
- [x] `TESTING=1 PYTHONPATH=$(pwd) pytest tests/test_authz_app_routers_htmx_views.py tests/test_authz_app_routers_requisitions_requirements.py tests/test_authz_requisition_read_idor.py tests/test_routers_requisitions.py tests/test_integration_requisitions.py tests/test_requirements.py tests/test_requirement_entry_fixes.py -q --override-ini="addopts="` → 205 passed
- [x] `pre-commit run --files app/templates/htmx/partials/requisitions/tabs/parts.html tests/test_htmx_views.py` → clean (ruff-format reflowed once, re-staged, second run clean)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>