### PR TITLE
perf(search): run blocking vendor-affinity L3 off the event loop (PERF-1)

### DIFF
--- a/app/search_service.py
+++ b/app/search_service.py
@@ -366,6 +366,26 @@ def _affinity_match_to_result(match: dict, mpn: str) -> dict:
     }
 
 
+def _find_affinity_in_thread(mpn: str) -> list[dict]:
+    """Run the SYNC find_vendor_affinity on a worker thread with its OWN session.
+
+    find_vendor_affinity falls through to an L3 fallback that makes a BLOCKING
+    anthropic.Anthropic().messages.create(timeout=30) call, so running it directly on
+    the event loop froze every concurrent request for up to 30s (PERF-1). We dispatch it
+    via asyncio.to_thread; SQLAlchemy sessions are not thread-safe, so the request session
+    never crosses the boundary — each call opens and closes a fresh SessionLocal (the
+    established pattern, mirroring routers/sightings.py._find_affinity_in_thread).
+
+    NB: find_vendor_affinity is referenced as the module-level name (NOT re-imported
+    lazily) so tests patching app.search_service.find_vendor_affinity still take effect.
+    """
+    thread_db = SessionLocal()
+    try:
+        return find_vendor_affinity(mpn, thread_db)
+    finally:
+        thread_db.close()
+
+
 async def search_requirement(req: Requirement, db: Session) -> dict:
     """Search APIs for stale MPNs only; surface cached sightings for fresh ones.
 
@@ -408,12 +428,13 @@ async def search_requirement(req: Requirement, db: Session) -> dict:
         key = normalize_mpn_key(pn)
         mpn_results[pn] = "searched" if key in searched_keys else "cached"
 
-    # Vendor affinity is a pure-DB lookup (no connector quota) keyed on the
-    # requirement's primary MPN, so we compute it on every path — including
-    # the cached-only short-circuit below.
+    # Vendor affinity is keyed on the requirement's primary MPN (no connector quota), so
+    # we compute it on every path — including the cached-only short-circuit below. It is
+    # NOT a pure-DB lookup: its L3 fallback makes a blocking 30s Anthropic call, so it runs
+    # on a worker thread (asyncio.to_thread) to keep the event loop free (PERF-1).
     primary_mpn = pns[0]
     try:
-        affinity_matches = find_vendor_affinity(primary_mpn, db)
+        affinity_matches = await asyncio.to_thread(_find_affinity_in_thread, primary_mpn)
     except Exception as e:
         logger.warning("Vendor affinity lookup failed for {}: {}", primary_mpn, e)
         affinity_matches = []

--- a/tests/test_search_affinity.py
+++ b/tests/test_search_affinity.py
@@ -214,3 +214,33 @@ class TestAffinityDedupWithLiveResults:
         arrow_results = [s for s in sightings if s.get("vendor_name", "").lower() == "arrow"]
         assert len(arrow_results) == 1
         assert arrow_results[0].get("source_type") == "nexar"
+
+
+class TestAffinityRunsOffEventLoop:
+    """PERF-1 — find_vendor_affinity has a blocking 30s Anthropic L3 fallback, so it
+    must run OFF the event-loop thread (via asyncio.to_thread) or it freezes every
+    concurrent request.
+
+    This guards against a regression back to a direct on-loop call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_affinity_dispatched_to_worker_thread(self, db_session, requirement):
+        import threading
+
+        main_thread = threading.get_ident()
+        seen: dict = {}
+
+        def _spy(mpn, db):
+            seen["thread"] = threading.get_ident()
+            return list(MOCK_AFFINITY)
+
+        with (
+            patch("app.search_service._fetch_fresh", new_callable=AsyncMock) as mock_fetch,
+            patch("app.search_service.find_vendor_affinity", side_effect=_spy),
+        ):
+            mock_fetch.return_value = (list(MOCK_FRESH), list(MOCK_STATS))
+            await search_requirement(requirement, db_session)
+
+        assert "thread" in seen, "find_vendor_affinity was never called"
+        assert seen["thread"] != main_thread, "affinity ran on the event-loop thread (PERF-1 regression)"


### PR DESCRIPTION
## PERF-1 (production-polish audit, 2026-07-02)

`search_requirement` (async) called `find_vendor_affinity(primary_mpn, db)` **directly on the event loop**. That function falls through to an L3 fallback that makes a **synchronous** `anthropic.Anthropic().messages.create(timeout=30)` network call — so a single cold-cache affinity lookup froze **every concurrent request** for up to 30s. The comment above the call even mislabeled it a "pure-DB lookup."

**Fix:** dispatch it via `asyncio.to_thread` with a fresh thread-local `SessionLocal` (SQLAlchemy sessions aren't thread-safe), mirroring the existing `routers/sightings.py._find_affinity_in_thread` wrapper. The helper references the **module-level** `find_vendor_affinity` name (not a lazy re-import) so the existing `patch("app.search_service.find_vendor_affinity")` test mocks still apply. Corrected the misleading comment.

## Tests
- `test_affinity_dispatched_to_worker_thread` — asserts the affinity call runs on a **non-main** thread (direct PERF-1 regression guard).
- Full affinity/search suites (`test_search_affinity`, `test_search_service_cooldown`, `test_search_service_nightly`, `test_vendor_affinity`): **46 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)