### PR TITLE
test: root-cause xdist parallel-state flakes + isolation defects (14 findings)

### DIFF
--- a/app/services/ics_worker/search_engine.py
+++ b/app/services/ics_worker/search_engine.py
@@ -18,6 +18,12 @@ from .human_behavior import HumanBehavior
 # ICsource member search URL
 SEARCH_URL = "https://www.icsource.com/members/Search/NewSearch.aspx"
 
+# Page-settle pacing between navigation/submit and reading the DOM. Kept as a module
+# constant (not a literal) so unit tests can zero it out — the ASP.NET WebForms page
+# is fully mocked in tests, so the real 1s waits only add dead wall-clock (~2s/test)
+# and feed the 30s-timeout risk. Production default is unchanged (1.0s).
+_PACE_SECONDS = 1.0
+
 
 async def search_part(page, part_number: str) -> dict:
     """Search for a part on ICsource using form-based search.
@@ -30,7 +36,7 @@ async def search_part(page, part_number: str) -> dict:
 
     logger.info("ICS search: navigating to search for '{}'", part_number)
     await page.goto(SEARCH_URL, wait_until="load", timeout=30000)
-    await asyncio.sleep(1)
+    await asyncio.sleep(_PACE_SECONDS)
 
     # Fill part number field — try multiple selectors in priority order
     pn_input = None
@@ -199,7 +205,7 @@ async def search_part(page, part_number: str) -> dict:
     except Exception:
         logger.warning("ICS search: results selector not found within 20s — page may have changed structure")
 
-    await asyncio.sleep(1)
+    await asyncio.sleep(_PACE_SECONDS)
 
     # Get results HTML
     html = await page.evaluate("""

--- a/app/services/ics_worker/worker.py
+++ b/app/services/ics_worker/worker.py
@@ -28,6 +28,14 @@ except ImportError:  # pragma: no cover
 
 EASTERN = ZoneInfo("America/New_York")
 
+# Private module-level alias for the pacing primitive. The main loop awaits
+# ``_async_sleep`` (never ``asyncio.sleep`` directly) so tests patch
+# ``worker._async_sleep`` in isolation. Patching the shared ``asyncio.sleep`` would
+# intercept sleeps from every other coroutine in the process, skewing circuit-breaker
+# call-count assertions and causing xdist-order flakes. Production behavior is
+# identical: ``_async_sleep is asyncio.sleep``.
+_async_sleep = asyncio.sleep
+
 _shutdown_requested = False
 
 
@@ -185,13 +193,13 @@ async def main():
                 # Check business hours
                 if not scheduler.is_business_hours():
                     logger.debug("ICS worker: outside business hours, sleeping 30 min")
-                    await asyncio.sleep(30 * 60)
+                    await _async_sleep(30 * 60)
                     continue
 
                 # Check daily limit
                 if searches_today >= config.ICS_MAX_DAILY_SEARCHES:
                     logger.info("ICS worker: daily limit reached ({}), sleeping until tomorrow", searches_today)
-                    await asyncio.sleep(60 * 60)
+                    await _async_sleep(60 * 60)
                     continue
 
                 # Check circuit breaker
@@ -205,7 +213,7 @@ async def main():
                             circuit_breaker_reason=info["trip_reason"],
                         )
                     breaker_was_open = True
-                    await asyncio.sleep(60 * 60)
+                    await _async_sleep(60 * 60)
                     continue
 
                 # Breaker healthy: clear a previously-open flag on the open->healthy
@@ -226,7 +234,7 @@ async def main():
                     duration = scheduler.get_break_duration()
                     logger.info("ICS worker: taking a break ({:.0f} min)", duration / 60)
                     scheduler.reset_break_counter()
-                    await asyncio.sleep(duration)
+                    await _async_sleep(duration)
                     continue
 
                 # Run AI gate for any pending items
@@ -246,7 +254,7 @@ async def main():
                     if not item:
                         logger.debug("ICS worker: queue empty, sleeping 60s")
                         db.close()
-                        await asyncio.sleep(60)
+                        await _async_sleep(60)
                         continue
 
                     # Ensure session is valid
@@ -254,7 +262,7 @@ async def main():
                         logger.error("ICS worker: session re-auth failed, sleeping 5 min")
                         mark_status(db, item, "failed", error="Session authentication failed")
                         db.close()
-                        await asyncio.sleep(5 * 60)
+                        await _async_sleep(5 * 60)
                         continue
 
                     # Execute search (already marked 'searching' by the claim).
@@ -347,11 +355,11 @@ async def main():
                 # Delay before next search
                 delay = scheduler.next_delay()
                 logger.debug("ICS worker: sleeping {:.0f}s before next search", delay)
-                await asyncio.sleep(delay)
+                await _async_sleep(delay)
 
             except Exception as e:
                 logger.error("ICS worker: unexpected error in main loop: {}", e)
-                await asyncio.sleep(5 * 60)
+                await _async_sleep(5 * 60)
 
     finally:
         # Shutdown cleanup

--- a/app/services/nc_worker/worker.py
+++ b/app/services/nc_worker/worker.py
@@ -29,6 +29,14 @@ except ImportError:  # pragma: no cover
 
 EASTERN = ZoneInfo("America/New_York")
 
+# Private module-level alias for the pacing primitive. The main loop calls ``_sleep``
+# (never ``time.sleep`` directly) so tests patch ``worker._sleep`` in isolation.
+# Patching the shared ``time`` module's ``sleep`` would intercept sleeps from EVERY
+# other thread in the process (TestClient portals, lingering timers), skewing the
+# circuit-breaker call-count assertions and causing xdist-order flakes. Production
+# behavior is identical: ``_sleep is time.sleep``.
+_sleep = time.sleep
+
 _shutdown_requested = False
 
 
@@ -185,13 +193,13 @@ def main():
                 # Check business hours
                 if not scheduler.is_business_hours():
                     logger.debug("NC worker: outside business hours, sleeping 30 min")
-                    time.sleep(30 * 60)
+                    _sleep(30 * 60)
                     continue
 
                 # Check daily limit
                 if searches_today >= config.NC_MAX_DAILY_SEARCHES:
                     logger.info("NC worker: daily limit reached ({})", searches_today)
-                    time.sleep(60 * 60)
+                    _sleep(60 * 60)
                     continue
 
                 # Check circuit breaker
@@ -205,7 +213,7 @@ def main():
                             circuit_breaker_reason=info["trip_reason"],
                         )
                     breaker_was_open = True
-                    time.sleep(60 * 60)
+                    _sleep(60 * 60)
                     continue
 
                 # Breaker healthy: clear a previously-open flag on the open->healthy
@@ -226,7 +234,7 @@ def main():
                     duration = scheduler.get_break_duration()
                     logger.info("NC worker: taking a break ({:.0f} min)", duration / 60)
                     scheduler.reset_break_counter()
-                    time.sleep(duration)
+                    _sleep(duration)
                     continue
 
                 # Run AI gate for any pending items
@@ -246,7 +254,7 @@ def main():
                     if not item:
                         logger.debug("NC worker: queue empty, sleeping 60s")
                         db.close()
-                        time.sleep(60)
+                        _sleep(60)
                         continue
 
                     # Ensure session is valid
@@ -254,7 +262,7 @@ def main():
                         logger.error("NC worker: session re-auth failed")
                         mark_status(db, item, "failed", error="Session authentication failed")
                         db.close()
-                        time.sleep(5 * 60)
+                        _sleep(5 * 60)
                         continue
 
                     # Execute search (already marked 'searching' by the claim)
@@ -337,11 +345,11 @@ def main():
                 # Delay before next search
                 delay = scheduler.next_delay()
                 logger.debug("NC worker: sleeping {:.0f}s before next search", delay)
-                time.sleep(delay)
+                _sleep(delay)
 
             except Exception as e:
                 logger.error("NC worker: unexpected error: {}", e)
-                time.sleep(5 * 60)
+                _sleep(5 * 60)
 
     finally:
         logger.info(

--- a/app/services/tbf_worker/worker.py
+++ b/app/services/tbf_worker/worker.py
@@ -28,6 +28,14 @@ except ImportError:  # pragma: no cover
 
 EASTERN = ZoneInfo("America/New_York")
 
+# Private module-level alias for the pacing primitive. The main loop awaits
+# ``_async_sleep`` (never ``asyncio.sleep`` directly) so tests patch
+# ``worker._async_sleep`` in isolation. Patching the shared ``asyncio.sleep`` would
+# intercept sleeps from every other coroutine in the process, skewing circuit-breaker
+# call-count assertions and causing xdist-order flakes. Production behavior is
+# identical: ``_async_sleep is asyncio.sleep``.
+_async_sleep = asyncio.sleep
+
 _shutdown_requested = False
 
 
@@ -185,13 +193,13 @@ async def main():
                 # Check business hours
                 if not scheduler.is_business_hours():
                     logger.debug("TBF worker: outside business hours, sleeping 30 min")
-                    await asyncio.sleep(30 * 60)
+                    await _async_sleep(30 * 60)
                     continue
 
                 # Check daily limit
                 if searches_today >= config.TBF_MAX_DAILY_SEARCHES:
                     logger.info("TBF worker: daily limit reached ({}), sleeping until tomorrow", searches_today)
-                    await asyncio.sleep(60 * 60)
+                    await _async_sleep(60 * 60)
                     continue
 
                 # Check circuit breaker
@@ -205,7 +213,7 @@ async def main():
                             circuit_breaker_reason=info["trip_reason"],
                         )
                     breaker_was_open = True
-                    await asyncio.sleep(60 * 60)
+                    await _async_sleep(60 * 60)
                     continue
 
                 # Breaker healthy: clear a previously-open flag on the open->healthy
@@ -226,7 +234,7 @@ async def main():
                     duration = scheduler.get_break_duration()
                     logger.info("TBF worker: taking a break ({:.0f} min)", duration / 60)
                     scheduler.reset_break_counter()
-                    await asyncio.sleep(duration)
+                    await _async_sleep(duration)
                     continue
 
                 # Run AI gate for any pending items
@@ -246,7 +254,7 @@ async def main():
                     if not item:
                         logger.debug("TBF worker: queue empty, sleeping 60s")
                         db.close()
-                        await asyncio.sleep(60)
+                        await _async_sleep(60)
                         continue
 
                     # Ensure session is valid
@@ -254,7 +262,7 @@ async def main():
                         logger.error("TBF worker: session re-auth failed, sleeping 5 min")
                         mark_status(db, item, "failed", error="Session authentication failed")
                         db.close()
-                        await asyncio.sleep(5 * 60)
+                        await _async_sleep(5 * 60)
                         continue
 
                     # Execute search (already marked 'searching' by the claim).
@@ -347,11 +355,11 @@ async def main():
                 # Delay before next search
                 delay = scheduler.next_delay()
                 logger.debug("TBF worker: sleeping {:.0f}s before next search", delay)
-                await asyncio.sleep(delay)
+                await _async_sleep(delay)
 
             except Exception as e:
                 logger.error("TBF worker: unexpected error in main loop: {}", e)
-                await asyncio.sleep(5 * 60)
+                await _async_sleep(5 * 60)
 
     finally:
         # Shutdown cleanup

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,9 @@
 [pytest]
 asyncio_mode = auto
+# pytest-asyncio 1.x manages per-test loops itself (the old conftest `event_loop`
+# fixture was a no-op under 1.4.0 and was removed). Pin the async-fixture loop scope
+# to function so isolation is explicit and the "unset" deprecation warning is silenced.
+asyncio_default_fixture_loop_scope = function
 testpaths = tests
 # E2E tests hit the live Docker app and use Playwright; they pollute the
 # asyncio event loop for subsequent unit tests.  Run them separately via:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,12 +13,20 @@ Called by: all test files via pytest autodiscovery
 Depends on: app.models (Base), app.database (get_db), app.dependencies
 """
 
-import asyncio
 import os
 
 import nest_asyncio
 
-nest_asyncio.apply()  # Allow nested event loops (prevents cross-test contamination)
+# Many synchronous unit tests drive coroutines via
+# ``asyncio.get_event_loop().run_until_complete(...)``. Under pytest-asyncio's auto mode
+# an async test that ran earlier in the same (xdist) worker can leave the policy with no
+# current event loop, so a later SYNC test's ``get_event_loop()`` raises "There is no
+# current event loop" and the whole worker's remaining get_event_loop() tests fail by
+# ordering. ``nest_asyncio.apply()`` keeps a usable loop available process-wide, which
+# neutralizes that ordering hazard. Verified empirically: removing it turns ~60 such
+# tests red under xdist. Kept deliberately (F13 reviewed — remove only after migrating
+# every ``get_event_loop().run_until_complete`` call site to an async test / asyncio.run).
+nest_asyncio.apply()
 
 os.environ["TESTING"] = "1"  # Must be set before importing app modules
 os.environ["RATE_LIMIT_ENABLED"] = "false"  # Disable rate limiting in tests
@@ -31,6 +39,7 @@ from datetime import datetime, timezone
 
 import pytest
 from fastapi.testclient import TestClient
+from loguru import logger
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -50,19 +59,6 @@ from app.models import (
     VendorCard,
     VendorContact,
 )
-
-# ── Event loop isolation ─────────────────────────────────────────────
-# Provide a fresh event loop per test to prevent cross-test pollution
-# (e.g. Playwright e2e tests leaving a running loop).
-
-
-@pytest.fixture()
-def event_loop():
-    """Create a fresh event loop for each test function."""
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
-
 
 # ── In-memory SQLite engine ──────────────────────────────────────────
 # SQLite can't handle PostgreSQL ARRAY columns — remap them to JSON.
@@ -107,8 +103,50 @@ _sqlite_safe = [t for name, t in Base.metadata.tables.items() if name not in _PG
 Base.metadata.create_all(bind=engine, tables=_sqlite_safe)
 
 # Pre-compute delete order (respects FK dependencies via reversed create order).
-_delete_order = list(reversed(Base.metadata.sorted_tables))
-_delete_stmts = [t.delete() for t in _delete_order if t.name not in _PG_ONLY_TABLES]
+#
+# The companies <-> customer_sites <-> site_contacts trio is an FK cycle that
+# ``sorted_tables`` cannot topologically order (it emits SAWarning 'unresolvable
+# cycles' and drops those FK edges from the sort). Delete the cycle explicitly in
+# child -> parent order FIRST, then everything else in reverse-create order. The
+# per-table resilient cleanup below is what actually guarantees isolation, but a
+# correct base order means the happy path never needs the retry.
+_CYCLE_DELETE_FIRST = ("site_contacts", "customer_sites", "companies")
+_tables_by_name = {t.name: t for t in Base.metadata.sorted_tables}
+_delete_order_names = [n for n in _CYCLE_DELETE_FIRST if n in _tables_by_name] + [
+    t.name for t in reversed(Base.metadata.sorted_tables) if t.name not in _CYCLE_DELETE_FIRST
+]
+_delete_stmts = [_tables_by_name[n].delete() for n in _delete_order_names if n not in _PG_ONLY_TABLES]
+
+
+def _cleanup_all_rows() -> None:
+    """Delete every row FK-safely, resilient to a single table's DELETE failing.
+
+    Each DELETE runs inside its own SAVEPOINT so one failure — e.g. a future FK edge
+    into the companies/customer_sites/site_contacts cycle that lacks a cascade — is
+    isolated and rolled back on its own, instead of aborting the whole transaction and
+    leaking EVERY table's rows into the next test (the multi-test cascade signature of
+    the xdist flake clusters). Tables that fail the first pass are retried once after
+    the rest are cleared (their FK parents/children are gone by then). A row that still
+    won't delete is logged loudly rather than silently swallowed.
+    """
+    with engine.begin() as conn:
+        failed = []
+        for stmt in _delete_stmts:
+            sp = conn.begin_nested()
+            try:
+                conn.execute(stmt)
+                sp.commit()
+            except Exception:
+                sp.rollback()
+                failed.append(stmt)
+        for stmt in failed:
+            sp = conn.begin_nested()
+            try:
+                conn.execute(stmt)
+                sp.commit()
+            except Exception:
+                sp.rollback()
+                logger.warning("Test cleanup could not delete {} — rows may leak", stmt.table.name)
 
 
 @pytest.fixture(autouse=True)
@@ -122,6 +160,80 @@ def _clear_8x8_token_cache():
 
 
 @pytest.fixture(autouse=True)
+def _reset_ai_gate_state():
+    """Reset every search-worker AI-gate's cooldown + classification cache per test.
+
+    Each worker gate (nc/ics/tbf) is a thin shim over one shared ``AIGate`` instance
+    that carries a module-level ``_last_api_failure`` cooldown timestamp and an
+    in-memory classification cache. A fail-open test drives the real API-failure path,
+    which sets the cooldown to ``time.monotonic()``; the base gate then silently
+    no-ops ``process_ai_gate`` for 300s. Under xdist that poisons every later gate
+    test in the same worker (items stay 'pending', ``status == 'queued'`` asserts
+    fail) — passes in isolation, flakes in the full suite. Reset both the module-level
+    name and the underlying gate instance, on all three workers, before AND after each
+    test so no test inherits a poisoned cooldown or a stale cache.
+    """
+    from app.services.ics_worker import ai_gate as ics_gate
+    from app.services.nc_worker import ai_gate as nc_gate
+    from app.services.tbf_worker import ai_gate as tbf_gate
+
+    gate_modules = (nc_gate, ics_gate, tbf_gate)
+
+    def _reset() -> None:
+        for mod in gate_modules:
+            mod._last_api_failure = 0.0
+            mod._gate._last_api_failure = 0.0
+            with mod._gate._cache_lock:
+                mod._gate._classification_cache.clear()
+
+    _reset()
+    yield
+    _reset()
+
+
+@pytest.fixture(autouse=True)
+def _clear_known_html_hashes():
+    """Clear the shared HTML-structure-hash registry before and after each test.
+
+    ``search_worker_base.monitoring._known_html_hashes`` is one process-wide dict keyed
+    by component ("NC"/"ICS"/"TBF"). The 'first hash never warns / changed structure
+    warns' tests across three files depend on every consumer clearing it first; a test
+    that seeds hashes without clearing (or asserts warning behavior after another file
+    populated the same component set in the worker) flakes by ordering. Centralize the
+    clear here so no per-file setup_method discipline is load-bearing.
+    """
+    from app.services.search_worker_base.monitoring import _known_html_hashes
+
+    _known_html_hashes.clear()
+    yield
+    _known_html_hashes.clear()
+
+
+@pytest.fixture(autouse=True)
+def _restore_dependency_overrides():
+    """Snapshot and restore ``app.main.app.dependency_overrides`` around every test.
+
+    ``app.main.app`` is a process-wide singleton. Many tests install auth/db overrides
+    inline (``app.dependency_overrides[dep] = ...``) and pop them AFTER their asserts,
+    with no try/finally — so a failing assert (or a 30s timeout) leaks the override onto
+    the shared app for the rest of that xdist worker, and every later test using
+    ``unauthenticated_client`` (expects 401) or a real-authz client then fails for
+    unrelated reasons. This is the amplification mechanism behind the multi-test
+    user_mgmt/vendor/activities flake clusters. Snapshotting before and restoring the
+    exact mapping after each test makes any leak impossible, worker-wide and for future
+    tests, regardless of assertion outcome.
+    """
+    from app.main import app
+
+    snapshot = dict(app.dependency_overrides)
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(snapshot)
+
+
+@pytest.fixture(autouse=True)
 def db_session():
     """Yield a session, then DELETE all rows (fast) instead of drop/create tables."""
     session = TestSessionLocal()
@@ -129,10 +241,9 @@ def db_session():
         yield session
     finally:
         session.rollback()
-        # Delete all rows in FK-safe order — much faster than drop_all/create_all
-        with engine.begin() as conn:
-            for stmt in _delete_stmts:
-                conn.execute(stmt)
+        # Delete all rows in FK-safe order — much faster than drop_all/create_all.
+        # Per-table savepoints keep one failure from cascading (see _cleanup_all_rows).
+        _cleanup_all_rows()
         session.close()
 
 

--- a/tests/test_auto_dedup_service.py
+++ b/tests/test_auto_dedup_service.py
@@ -242,18 +242,38 @@ class TestDedupVendors:
             _dedup_vendors(db_session)
 
     def test_ai_confirm_mid_score_accepted(self, db_session):
-        """Score 92-97 with AI approval should merge."""
-        from app.services.auto_dedup_service import _dedup_vendors
+        """Score 92-97 with AI approval performs a REAL merge (only the AI call mocked).
 
-        _make_vendor(
+        End-to-end: nothing but ``_ai_confirm_vendor_merge`` is stubbed, so the real
+        ``merge_vendor_cards`` runs. Asserts the AI was consulted for the mid-score band,
+        the merge actually happened, the lower-sighting card was deleted, and its
+        sightings were folded into the survivor — a real scoring/merge regression now
+        fails this test instead of passing green.
+        """
+        from app.services.auto_dedup_service import _dedup_vendors
+        from app.vendor_utils import fuzzy_score_vendor
+
+        keep = _make_vendor(
             db_session, "Arrow Electronics Group", normalized_name="arrow electronics group", sighting_count=20
         )
-        _make_vendor(db_session, "Arrow Electronics Grp", normalized_name="arrow electronics grp", sighting_count=5)
+        remove = _make_vendor(
+            db_session, "Arrow Electronics Grp", normalized_name="arrow electronics grp", sighting_count=5
+        )
         db_session.commit()
 
-        with patch("app.services.auto_dedup_service._ai_confirm_vendor_merge", return_value=True):
-            # Whether AI is called depends on the fuzzy score
-            _dedup_vendors(db_session)
+        # Pin the branch under test: this pair must score in the AI-confirm band
+        # (92-97), NOT the >=98 auto-merge band — otherwise the AI is never consulted.
+        assert 92 <= fuzzy_score_vendor("arrow electronics group", "arrow electronics grp") < 98
+
+        with patch("app.services.auto_dedup_service._ai_confirm_vendor_merge", return_value=True) as mock_ai:
+            merged = _dedup_vendors(db_session)
+
+        mock_ai.assert_called_once()  # AI was consulted for the mid-score pair
+        assert merged == 1  # and its approval drove exactly one real merge
+        assert db_session.get(VendorCard, remove.id) is None  # lower-sighting card deleted
+        survivor = db_session.get(VendorCard, keep.id)
+        assert survivor is not None
+        assert survivor.sighting_count == 25  # 20 + 5 folded in
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/test_ics_worker.py
+++ b/tests/test_ics_worker.py
@@ -248,7 +248,7 @@ class TestMainLoop:
                 patch("app.services.ics_worker.circuit_breaker.CircuitBreaker"),
                 patch("app.services.ics_worker.ai_gate.process_ai_gate"),
                 patch("app.services.ics_worker.queue_manager.claim_next_queued_item"),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -298,7 +298,7 @@ class TestMainLoop:
                 patch("app.services.ics_worker.circuit_breaker.CircuitBreaker"),
                 patch("app.services.ics_worker.ai_gate.process_ai_gate"),
                 patch("app.services.ics_worker.queue_manager.claim_next_queued_item"),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -351,7 +351,7 @@ class TestMainLoop:
                 patch("app.services.ics_worker.circuit_breaker.CircuitBreaker", return_value=mock_breaker),
                 patch("app.services.ics_worker.ai_gate.process_ai_gate"),
                 patch("app.services.ics_worker.queue_manager.claim_next_queued_item"),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -404,7 +404,7 @@ class TestMainLoop:
                 patch("app.services.ics_worker.circuit_breaker.CircuitBreaker", return_value=mock_breaker),
                 patch("app.services.ics_worker.ai_gate.process_ai_gate", new_callable=AsyncMock),
                 patch("app.services.ics_worker.queue_manager.claim_next_queued_item", return_value=None),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -485,7 +485,7 @@ class TestMainLoop:
                 ),
                 patch("app.services.ics_worker.result_parser.parse_results_html", return_value=parsed_sightings),
                 patch("app.services.ics_worker.sighting_writer.save_ics_sightings", return_value=1),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -553,7 +553,7 @@ class TestMainLoop:
                 patch("app.services.ics_worker.ai_gate.process_ai_gate", new_callable=AsyncMock),
                 patch("app.services.ics_worker.queue_manager.claim_next_queued_item", side_effect=get_next),
                 patch("app.services.ics_worker.queue_manager.mark_status") as mock_mark,
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -630,7 +630,7 @@ class TestMainLoop:
                     new_callable=AsyncMock,
                     side_effect=asyncio.TimeoutError,
                 ),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -685,7 +685,7 @@ class TestMainLoop:
                 patch("app.services.ics_worker.circuit_breaker.CircuitBreaker", return_value=mock_breaker),
                 patch("app.services.ics_worker.ai_gate.process_ai_gate", new_callable=AsyncMock),
                 patch("app.services.ics_worker.queue_manager.claim_next_queued_item"),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -761,7 +761,7 @@ class TestMainLoop:
                     return_value={"html": "", "duration_ms": 100},
                     create=True,
                 ),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -837,7 +837,7 @@ class TestMainLoop:
                     side_effect=Exception("Network timeout"),
                     create=True,
                 ),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 
@@ -918,7 +918,7 @@ class TestMainLoop:
                 ),
                 patch("app.services.ics_worker.result_parser.parse_results_html", return_value=[]),
                 patch("app.services.ics_worker.sighting_writer.save_ics_sightings", return_value=0),
-                patch("asyncio.sleep", side_effect=mock_sleep),
+                patch("app.services.ics_worker.worker._async_sleep", side_effect=mock_sleep),
             ):
                 from app.services.ics_worker.worker import main
 

--- a/tests/test_ics_worker_full.py
+++ b/tests/test_ics_worker_full.py
@@ -274,6 +274,18 @@ class TestResultParser:
 
 
 class TestSearchEngine:
+    @pytest.fixture(autouse=True)
+    def _no_pace(self, monkeypatch):
+        """Zero the page-settle pacing so search_part tests don't pay ~2s of real sleep.
+
+        The ASP.NET page is fully mocked here, so the production 1s waits are pure dead
+        wall-clock (and feed the 30s-timeout risk). Patching the module constant leaves
+        production pacing untouched and auto-restores after the test.
+        """
+        import app.services.ics_worker.search_engine as se
+
+        monkeypatch.setattr(se, "_PACE_SECONDS", 0)
+
     def test_search_url_constant(self):
         assert "icsource.com" in SEARCH_URL
         assert "NewSearch" in SEARCH_URL
@@ -1290,15 +1302,16 @@ class TestAiGate:
 
 class TestSessionManager:
     @pytest.mark.asyncio
-    async def test_start_no_display(self):
+    async def test_start_no_display(self, monkeypatch):
         from app.services.ics_worker.session_manager import IcsSessionManager
 
         cfg = IcsConfig()
         sm = IcsSessionManager(cfg)
-        with patch.dict(os.environ, {}, clear=True):
-            os.environ.pop("DISPLAY", None)
-            with pytest.raises(RuntimeError, match="DISPLAY"):
-                await sm.start()
+        # Remove ONLY DISPLAY (auto-restored). clear=True would wipe the whole env —
+        # including the TESTING / DATABASE_URL / REDIS_URL guards the app reads.
+        monkeypatch.delenv("DISPLAY", raising=False)
+        with pytest.raises(RuntimeError, match="DISPLAY"):
+            await sm.start()
 
     @pytest.mark.asyncio
     async def test_login_no_credentials(self):
@@ -1561,7 +1574,7 @@ class TestIcsWorkerMainLoop:
     _PARSE = "app.services.ics_worker.result_parser.parse_results_html"
     _SAVE = "app.services.ics_worker.sighting_writer.save_ics_sightings"
     _AI_GATE = "app.services.ics_worker.ai_gate.process_ai_gate"
-    _ASYNC_SLEEP = "app.services.ics_worker.worker.asyncio.sleep"
+    _ASYNC_SLEEP = "app.services.ics_worker.worker._async_sleep"
 
     def _make_mock_db(self, db_session):
         mock_session = MagicMock(wraps=db_session)
@@ -2581,6 +2594,14 @@ class TestSchedulerBranches:
 
 
 class TestSearchEngineFull:
+    @pytest.fixture(autouse=True)
+    def _no_pace(self, monkeypatch):
+        """Zero the page-settle pacing so search_part tests don't pay ~2s of real
+        sleep."""
+        import app.services.ics_worker.search_engine as se
+
+        monkeypatch.setattr(se, "_PACE_SECONDS", 0)
+
     @pytest.mark.asyncio
     async def test_search_part_all_selectors_fail_fallback(self):
         """When all 4 selectors fail, falls back to first text input (lines 52-55)."""

--- a/tests/test_multiplier_score.py
+++ b/tests/test_multiplier_score.py
@@ -689,16 +689,17 @@ class TestMultiplierAPI:
 
         app.dependency_overrides[get_db] = lambda: db_session
         app.dependency_overrides[require_user] = lambda: buyer
-        client = TestClient(app)
+        try:
+            client = TestClient(app)
 
-        resp = client.get("/api/performance/multiplier-scores?role=buyer&month=2026-02")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["role"] == "buyer"
-        assert len(data["entries"]) >= 1
-
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(require_user, None)
+            resp = client.get("/api/performance/multiplier-scores?role=buyer&month=2026-02")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["role"] == "buyer"
+            assert len(data["entries"]) >= 1
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(require_user, None)
 
     def test_get_bonus_winners(self, db_session):
         """GET /api/performance/bonus-winners returns data."""
@@ -713,15 +714,16 @@ class TestMultiplierAPI:
 
         app.dependency_overrides[get_db] = lambda: db_session
         app.dependency_overrides[require_user] = lambda: buyer
-        client = TestClient(app)
+        try:
+            client = TestClient(app)
 
-        resp = client.get("/api/performance/bonus-winners?role=buyer&month=2026-02")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert "winners" in data
-
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(require_user, None)
+            resp = client.get("/api/performance/bonus-winners?role=buyer&month=2026-02")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "winners" in data
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(require_user, None)
 
     def test_invalid_role_rejected(self, db_session):
         """Invalid role returns 422."""
@@ -736,13 +738,14 @@ class TestMultiplierAPI:
 
         app.dependency_overrides[get_db] = lambda: db_session
         app.dependency_overrides[require_user] = lambda: user
-        client = TestClient(app)
+        try:
+            client = TestClient(app)
 
-        resp = client.get("/api/performance/multiplier-scores?role=invalid")
-        assert resp.status_code == 422
-
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(require_user, None)
+            resp = client.get("/api/performance/multiplier-scores?role=invalid")
+            assert resp.status_code == 422
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(require_user, None)
 
     def test_refresh_requires_admin(self, db_session):
         """POST refresh requires admin role."""
@@ -757,13 +760,14 @@ class TestMultiplierAPI:
 
         app.dependency_overrides[get_db] = lambda: db_session
         app.dependency_overrides[require_user] = lambda: buyer
-        client = TestClient(app)
+        try:
+            client = TestClient(app)
 
-        resp = client.post("/api/performance/multiplier-scores/refresh")
-        assert resp.status_code == 403
-
-        app.dependency_overrides.pop(get_db, None)
-        app.dependency_overrides.pop(require_user, None)
+            resp = client.post("/api/performance/multiplier-scores/refresh")
+            assert resp.status_code == 403
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(require_user, None)
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/test_nc_worker_full.py
+++ b/tests/test_nc_worker_full.py
@@ -1502,7 +1502,7 @@ class TestWorkerMainLoop:
     _SEARCH = "app.services.nc_worker.search_engine.search_part"
     _PARSE = "app.services.nc_worker.result_parser.parse_results_html"
     _SAVE = "app.services.nc_worker.sighting_writer.save_nc_sightings"
-    _TIME_SLEEP = "app.services.nc_worker.worker.time.sleep"
+    _TIME_SLEEP = "app.services.nc_worker.worker._sleep"
     _ASYNCIO_RUN = "app.services.nc_worker.worker.asyncio.run"
     _RUN_AI_GATE = "app.services.nc_worker.worker.run_ai_gate"
 
@@ -2573,7 +2573,11 @@ class TestNcSearchEngineFull:
 
         import app.services.nc_worker.search_engine as se
 
-        # Reset the module-level loop so the assertion is deterministic.
+        # Isolate the module-level browser loop. Save the original and force a fresh
+        # one for a deterministic assertion; the finally closes whatever loop THIS test
+        # creates and restores the original, so we never orphan an open loop (leaking
+        # its fds) into later tests in this xdist worker.
+        original_loop = se._browser_loop
         se._browser_loop = None
 
         mock_resp = MagicMock()
@@ -2595,18 +2599,24 @@ class TestNcSearchEngineFull:
                 "status_code": 200,
             }
 
-        with patch("app.services.nc_worker.search_engine._search_browser", side_effect=record_loop):
-            first = search_part(mock_session_mgr, "AAA111")
-            second = search_part(mock_session_mgr, "BBB222")
+        try:
+            with patch("app.services.nc_worker.search_engine._search_browser", side_effect=record_loop):
+                first = search_part(mock_session_mgr, "AAA111")
+                second = search_part(mock_session_mgr, "BBB222")
 
-        assert first["mode"] == "browser"
-        assert second["mode"] == "browser"
-        # Same loop drove BOTH calls (fails on old asyncio.run: two loop ids).
-        assert len(seen_loop_ids) == 2
-        assert seen_loop_ids[0] == seen_loop_ids[1]
-        # And that loop is still alive (old asyncio.run closes it each time).
-        assert se._browser_loop is not None
-        assert not se._browser_loop.is_closed()
+            assert first["mode"] == "browser"
+            assert second["mode"] == "browser"
+            # Same loop drove BOTH calls (fails on old asyncio.run: two loop ids).
+            assert len(seen_loop_ids) == 2
+            assert seen_loop_ids[0] == seen_loop_ids[1]
+            # And that loop is still alive (old asyncio.run closes it each time).
+            assert se._browser_loop is not None
+            assert not se._browser_loop.is_closed()
+        finally:
+            created = se._browser_loop
+            if created is not None and not created.is_closed():
+                created.close()
+            se._browser_loop = original_loop
 
     def test_has_results_empty(self):
         """_has_results returns False for empty string (line 153)."""
@@ -3273,7 +3283,7 @@ class TestNcWorkerGaps:
     _SEARCH = "app.services.nc_worker.search_engine.search_part"
     _PARSE = "app.services.nc_worker.result_parser.parse_results_html"
     _SAVE = "app.services.nc_worker.sighting_writer.save_nc_sightings"
-    _TIME_SLEEP = "app.services.nc_worker.worker.time.sleep"
+    _TIME_SLEEP = "app.services.nc_worker.worker._sleep"
     _ASYNCIO_RUN = "app.services.nc_worker.worker.asyncio.run"
     _RUN_AI_GATE = "app.services.nc_worker.worker.run_ai_gate"
 

--- a/tests/test_nightly_tbf_worker_main.py
+++ b/tests/test_nightly_tbf_worker_main.py
@@ -83,7 +83,7 @@ _SEARCH_PART = "app.services.tbf_worker.search_engine.search_part"
 _PARSE_HTML = "app.services.tbf_worker.result_parser.parse_results_html"
 _SAVE_SIGHTINGS = "app.services.tbf_worker.sighting_writer.save_tbf_sightings"
 _SESSION_LOCAL = "app.database.SessionLocal"
-_SLEEP = "app.services.tbf_worker.worker.asyncio.sleep"
+_SLEEP = "app.services.tbf_worker.worker._async_sleep"
 _UPDATE_STATUS = "app.services.tbf_worker.worker.update_worker_status"
 _DB_SESSION = "app.services.tbf_worker.worker._db_session"
 

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -14,12 +14,18 @@ from app.services.ics_worker.session_manager import IcsSessionManager
 
 
 @pytest.fixture()
-def config():
-    """ICS config with test credentials."""
+def config(tmp_path):
+    """ICS config with test credentials.
+
+    The browser profile dir is a per-test ``tmp_path`` subdir (auto-cleaned, unique per
+    xdist worker) — never a fixed shared path, which would collide across parallel
+    workers / concurrent pytest invocations the moment a real launch_persistent_context
+    path runs.
+    """
     c = IcsConfig()
     c.ICS_USERNAME = "testuser"
     c.ICS_PASSWORD = "testpass"
-    c.ICS_BROWSER_PROFILE_DIR = "/tmp/test_ics_profile"
+    c.ICS_BROWSER_PROFILE_DIR = str(tmp_path / "ics_profile")
     return c
 
 
@@ -79,21 +85,13 @@ class TestInit:
 
 
 class TestStart:
-    def test_start_no_display_raises(self, manager):
+    def test_start_no_display_raises(self, manager, monkeypatch):
         """Start() raises RuntimeError when DISPLAY is not set."""
-        with patch.dict("os.environ", {}, clear=False):
-            # Remove DISPLAY if present
-            with patch.dict("os.environ", {"DISPLAY": ""}, clear=False):
-                # Actually need to remove DISPLAY
-                import os
-
-                old = os.environ.pop("DISPLAY", None)
-                try:
-                    with pytest.raises(RuntimeError, match="DISPLAY environment variable not set"):
-                        asyncio.get_event_loop().run_until_complete(manager.start())
-                finally:
-                    if old is not None:
-                        os.environ["DISPLAY"] = old
+        # Remove ONLY DISPLAY (auto-restored) — never clear the whole environment, which
+        # would also wipe the TESTING / DATABASE_URL / REDIS_URL sandbox guards.
+        monkeypatch.delenv("DISPLAY", raising=False)
+        with pytest.raises(RuntimeError, match="DISPLAY environment variable not set"):
+            asyncio.get_event_loop().run_until_complete(manager.start())
 
     def test_start_success_logged_in(self, manager, mock_playwright, mock_page):
         """Start() launches browser and detects existing login."""

--- a/tests/test_tbf_worker_coverage.py
+++ b/tests/test_tbf_worker_coverage.py
@@ -66,49 +66,41 @@ class TestSearchScheduler:
         with patch.dict(os.environ, {"FORCE_BUSINESS_HOURS": "1"}):
             assert s.is_business_hours() is True
 
-    def test_is_business_hours_saturday(self):
+    def test_is_business_hours_saturday(self, monkeypatch):
         """Saturday is always off."""
         s = self._make()
         # weekday() returns 5 for Saturday
         fake_dt = MagicMock()
         fake_dt.weekday.return_value = 5
         fake_dt.hour = 12
-        with (
-            patch.dict(os.environ, {}, clear=False),
-            patch("app.services.tbf_worker.scheduler.datetime") as mock_dt,
-        ):
-            if "FORCE_BUSINESS_HOURS" in os.environ:
-                del os.environ["FORCE_BUSINESS_HOURS"]
+        monkeypatch.delenv("FORCE_BUSINESS_HOURS", raising=False)
+        with patch("app.services.tbf_worker.scheduler.datetime") as mock_dt:
             mock_dt.now.return_value = fake_dt
             result = s.is_business_hours()
         assert result is False
 
-    def test_is_business_hours_sunday_morning(self):
+    def test_is_business_hours_sunday_morning(self, monkeypatch):
         """Sunday before 6 PM is off."""
         s = self._make()
         fake_dt = MagicMock()
         fake_dt.weekday.return_value = 6
         fake_dt.hour = 10
-        env = {k: v for k, v in os.environ.items() if k != "FORCE_BUSINESS_HOURS"}
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch("app.services.tbf_worker.scheduler.datetime") as mock_dt,
-        ):
+        # Remove ONLY the override var (auto-restored) — never clear the whole env, which
+        # would also wipe the TESTING / DATABASE_URL / REDIS_URL sandbox guards.
+        monkeypatch.delenv("FORCE_BUSINESS_HOURS", raising=False)
+        with patch("app.services.tbf_worker.scheduler.datetime") as mock_dt:
             mock_dt.now.return_value = fake_dt
             result = s.is_business_hours()
         assert result is False
 
-    def test_is_business_hours_sunday_evening(self):
+    def test_is_business_hours_sunday_evening(self, monkeypatch):
         """Sunday at 6 PM+ is on."""
         s = self._make()
         fake_dt = MagicMock()
         fake_dt.weekday.return_value = 6
         fake_dt.hour = 18
-        env = {k: v for k, v in os.environ.items() if k != "FORCE_BUSINESS_HOURS"}
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch("app.services.tbf_worker.scheduler.datetime") as mock_dt,
-        ):
+        monkeypatch.delenv("FORCE_BUSINESS_HOURS", raising=False)
+        with patch("app.services.tbf_worker.scheduler.datetime") as mock_dt:
             mock_dt.now.return_value = fake_dt
             result = s.is_business_hours()
         assert result is True


### PR DESCRIPTION
## Test-suite health — production-polish audit (WF2/WF3)

Root-causes the ~9 known xdist parallel-state flakes and 14 isolation defects. **Full suite: 21589 passed, 0 failed across 2 consecutive clean `-n auto` runs**; the two poisoning findings (F1, F2) were reproduced red-before / green-after via forced-order runs.

### Production code — behavior-preserving only
- **Worker sleep aliases** (`nc_worker`/`ics_worker`/`tbf_worker` `worker.py`): the loops now call module-level `_sleep = time.sleep` / `_async_sleep = asyncio.sleep` so tests patch `worker._sleep` in isolation instead of the **global** `time.sleep`/`asyncio.sleep` (which intercepted sleeps from every other thread/coroutine and skewed circuit-breaker call-count assertions → order-dependent flakes). `_sleep is time.sleep` — production is identical.
- **ICS `_PACE_SECONDS = 1.0`** (`ics_worker/search_engine.py`): the two 1s page-settle waits become a module constant tests can zero (the WebForms page is fully mocked in tests, so the real waits only added ~2s/test dead wall-clock and fed the 30s-timeout risk). **Prod default unchanged (1.0s).**

### Test isolation (conftest autouse fixtures — the central guarantees)
- **F2 dependency_overrides leak** (the amplifier): snapshot/restore of `app.dependency_overrides` around every test — leaks now impossible suite-wide + for future tests.
- **F1 ai-gate cooldown leak**: reset the shared gate's module `_last_api_failure` + per-worker cooldown/cache before & after each test (a fail-open test used to no-op later gate tests for 300s).
- **F8/F14 ICS pacing + profile dir**; **F11** known-html-hashes clear; **F5/F12** `monkeypatch.delenv` instead of `patch.dict(..., clear=True)`; **F7** persistent-loop cleanup; **F6** dead `event_loop` fixture removed + `asyncio_default_fixture_loop_scope=function`; **F9/F10** stronger dedup assertion + resilient cyclic-table cleanup (per-table SAVEPOINTs).
- **F13 nest_asyncio**: reviewed and **KEPT** (documented) — removing it turns ~60 sync `run_until_complete` tests red under xdist; removal is unsafe.

Rebased onto current main; the branch's modified test files pass under `-n auto` post-merge (536 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)