### PR TITLE
perf(proactive): eliminate requirement N+1 + scope do-not-offer query (PERF-2)

### DIFF
--- a/app/services/proactive_service.py
+++ b/app/services/proactive_service.py
@@ -65,15 +65,27 @@ def get_matches_for_user(
         joinedload(ProactiveMatch.offer).joinedload(Offer.entered_by),
         joinedload(ProactiveMatch.requisition),
         joinedload(ProactiveMatch.customer_site).joinedload(CustomerSite.company),
+        # PERF-2: requirement is read (m.requirement.target_qty) inside the per-match
+        # loop below — without this joinedload it was one lazy SELECT per match.
+        joinedload(ProactiveMatch.requirement),
     ).order_by(ProactiveMatch.match_score.desc(), ProactiveMatch.created_at.desc())
     matches = query.all()
 
-    # Build do-not-offer set for filtering
-    dno_rows = db.query(
-        ProactiveDoNotOffer.mpn,
-        ProactiveDoNotOffer.company_id,
-    ).all()
-    dno_set = {(r.mpn, r.company_id) for r in dno_rows}
+    # Build the do-not-offer set for filtering. PERF-2: scope the query to the companies
+    # actually present in this match set — the ProactiveDoNotOffer table only grows and a
+    # company absent from the matches can never suppress one, so loading the whole table
+    # every call was wasted work. (customer_site is joinedload-ed above, so resolving the
+    # company_id here adds no query.)
+    match_company_ids = {(m.company_id or (m.customer_site.company_id if m.customer_site else None)) for m in matches}
+    match_company_ids.discard(None)
+    dno_set: set = set()
+    if match_company_ids:
+        dno_rows = (
+            db.query(ProactiveDoNotOffer.mpn, ProactiveDoNotOffer.company_id)
+            .filter(ProactiveDoNotOffer.company_id.in_(match_company_ids))
+            .all()
+        )
+        dno_set = {(r.mpn, r.company_id) for r in dno_rows}
 
     # Group by customer site
     groups: dict[int, dict] = {}

--- a/tests/test_proactive_perf2.py
+++ b/tests/test_proactive_perf2.py
@@ -1,0 +1,129 @@
+"""PERF-2 — get_matches_for_user must not N+1 on ProactiveMatch.requirement, and the do-
+not-offer suppression must still work after scoping that lookup to the match set.
+
+Regression (2026-07-02 production-polish audit): the per-match loop reads
+m.requirement.target_qty but requirement was not eager-loaded → one lazy SELECT per
+match; and the ProactiveDoNotOffer table (which only grows) was loaded in full every call.
+
+Called by: pytest
+Depends on: app.services.proactive_service.get_matches_for_user.
+"""
+
+from decimal import Decimal
+
+from sqlalchemy import event
+
+from app.models import User
+from app.models.crm import Company, CustomerSite
+from app.models.intelligence import MaterialCard, ProactiveDoNotOffer, ProactiveMatch
+from app.models.offers import Offer
+from app.models.sourcing import Requirement, Requisition
+from app.services.proactive_service import get_matches_for_user
+
+
+def _seed_match(db, owner, company, site, *, mpn: str) -> ProactiveMatch:
+    card = MaterialCard(normalized_mpn=mpn.lower(), display_mpn=mpn)
+    db.add(card)
+    db.flush()
+    req = Requisition(name=f"R-{mpn}", customer_site_id=site.id, status="archived", created_by=owner.id)
+    db.add(req)
+    db.flush()
+    requirement = Requirement(
+        requisition_id=req.id, primary_mpn=mpn, normalized_mpn=mpn.lower(), material_card_id=card.id, target_qty=1000
+    )
+    db.add(requirement)
+    db.flush()
+    offer = Offer(
+        requisition_id=req.id,
+        requirement_id=requirement.id,
+        material_card_id=card.id,
+        vendor_name="Arrow",
+        mpn=mpn,
+        unit_price=Decimal("0.42"),
+        qty_available=5000,
+        status="active",
+    )
+    db.add(offer)
+    db.flush()
+    match = ProactiveMatch(
+        offer_id=offer.id,
+        requirement_id=requirement.id,
+        requisition_id=req.id,
+        customer_site_id=site.id,
+        salesperson_id=owner.id,
+        mpn=mpn,
+        material_card_id=card.id,
+        company_id=company.id,
+        match_score=85,
+        margin_pct=23.0,
+        our_cost=0.42,
+        status="new",
+    )
+    db.add(match)
+    db.commit()
+    return match
+
+
+def _base(db) -> tuple[User, Company, CustomerSite]:
+    owner = User(email="rep@trioscs.com", name="Rep", role="sales")
+    db.add(owner)
+    db.flush()
+    company = Company(name="Acme")
+    db.add(company)
+    db.flush()
+    site = CustomerSite(company_id=company.id, site_name="HQ", is_active=True)
+    db.add(site)
+    db.flush()
+    return owner, company, site
+
+
+class _QueryCounter:
+    def __init__(self, db):
+        self.engine = db.get_bind()
+        self.count = 0
+
+    def _on_exec(self, *a, **k):
+        self.count += 1
+
+    def __enter__(self):
+        event.listen(self.engine, "after_cursor_execute", self._on_exec)
+        return self
+
+    def __exit__(self, *a):
+        event.remove(self.engine, "after_cursor_execute", self._on_exec)
+
+
+def test_matches_query_count_independent_of_match_count(db_session):
+    """Query count must not grow with the number of matches (no requirement N+1)."""
+    owner, company, site = _base(db_session)
+    _seed_match(db_session, owner, company, site, mpn="LM358N")
+
+    with _QueryCounter(db_session) as c1:
+        get_matches_for_user(db_session, owner.id, status="new")
+    one = c1.count
+
+    for mpn in ("SN74LS", "NE555P", "TL072CP"):
+        _seed_match(db_session, owner, company, site, mpn=mpn)
+
+    with _QueryCounter(db_session) as c4:
+        get_matches_for_user(db_session, owner.id, status="new")
+    four = c4.count
+
+    # 4 matches must cost the same number of queries as 1 — a lazy requirement load
+    # would add one SELECT per extra match (would be one+3).
+    assert four == one, f"N+1 on requirement: 1 match={one} queries, 4 matches={four}"
+
+
+def test_do_not_offer_still_suppresses_after_scoping(db_session):
+    """The scoped do-not-offer query must still suppress a matched (mpn, company)."""
+    owner, company, site = _base(db_session)
+    _seed_match(db_session, owner, company, site, mpn="LM358N")
+    _seed_match(db_session, owner, company, site, mpn="NE555P")
+
+    db_session.add(ProactiveDoNotOffer(mpn="LM358N", company_id=company.id, created_by_id=owner.id))
+    db_session.commit()
+
+    result = get_matches_for_user(db_session, owner.id, status="new")
+    shown = {m["mpn"] for g in result["groups"] for m in g["matches"]}
+    assert "LM358N" not in shown, "do-not-offer match was not suppressed"
+    assert "NE555P" in shown


### PR DESCRIPTION
## PERF-2 (production-polish audit, 2026-07-02)

`get_matches_for_user` (rendered on every `/v2/proactive` load) read `m.requirement.target_qty` inside the per-match loop but did **not** eager-load `ProactiveMatch.requirement` → one lazy SELECT **per match**. It also loaded the entire `ProactiveDoNotOffer` table (which only grows) on every call.

**Fixes (both behavior-preserving):**
- `joinedload(ProactiveMatch.requirement)` — folds the requirement into the main query.
- Scope the do-not-offer lookup to the `company_id`s actually present in the match set (a company absent from the matches can never suppress one; `customer_site` is already joinedload-ed so resolving the id adds no query).

The **unbounded match query** (3rd sub-finding) needs pagination UI, so it's left as a follow-up rather than a silent cap.

## Tests (`tests/test_proactive_perf2.py`)
- Query count is **identical for 1 vs 4 matches** (direct N+1 guard — a lazy requirement load would add one SELECT per extra match).
- Do-not-offer still suppresses a matched `(mpn, company)` after scoping.
- Proactive neighbors (prepare/helpers/routers): **63 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)