### PR TITLE
chore: remove dead fix_queue mount + mkdir (DC-05)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,6 @@ RUN chmod +x docker-entrypoint.sh
 RUN useradd -r -u 1000 -m appuser \
     && chown -R appuser:appuser /app \
     && mkdir -p /var/log/avail && chown appuser:appuser /var/log/avail \
-    && mkdir -p /app/fix_queue && chown appuser:appuser /app/fix_queue \
     && mkdir -p /app/uploads/tickets /app/uploads/avatars && chown -R appuser:appuser /app/uploads
 # NOTE: /app/uploads is a named volume (see docker-compose.yml). Docker seeds a
 # *fresh* volume from this image dir, so creating it appuser-owned here makes new

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,6 @@ services:
       - uploads:/app/uploads
       - static_files:/srv/static
       - applogs:/var/log/avail
-      - ./fix_queue:/app/fix_queue
       - ./scripts:/app/scripts:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]


### PR DESCRIPTION
## DC-05 (production-polish audit, 2026-07-02)

`fix_queue` was self-heal-pipeline v2 infrastructure (Claude-API patches applied by a host watcher). The host watcher no longer exists, and migration 054 retired the `fix_queued`/`fix_proposed`/`fix_in_progress` ticket statuses — but the containers still carried it as dead weight:
- `docker-compose.yml` bind-mounted `./fix_queue:/app/fix_queue`
- `Dockerfile` `mkdir -p /app/fix_queue && chown ...`

Repo-wide grep (incl. dynamic `fix.?queue`/`FIX_QUEUE`) finds **zero** consumers in `app/`, `scripts/`, `deploy/`, `.github/`, crontab, or root scripts. Removed both. The git-ignored host `./fix_queue` dir (stale runtime artifacts) can be deleted separately during server cleanup.

Infra-only; `docker-compose.yml` parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)