### PR TITLE
fix(vendors): P2 workflow-breaks

### DIFF
--- a/app/routers/htmx/vendors.py
+++ b/app/routers/htmx/vendors.py
@@ -812,19 +812,24 @@ async def contact_timeline(
 # ── Vendor Contact CRUD (HTMX, parity P1) ──────────────────────────────────
 
 
-def _render_vendor_contacts(request: Request, vendor, contacts, user):
-    """Re-render vendor contacts tab partial."""
-    return template_response(
-        "htmx/partials/vendors/tabs/contacts.html",
-        {"request": request, "vendor": vendor, "contacts": contacts, "user": user},
-    )
-
-
 def _render_contact_row(request: Request, c, vendor):
     """Re-render a single vendor contact row partial."""
     return template_response(
         "htmx/partials/vendors/tabs/contact_row.html",
         {"request": request, "c": c, "vendor": vendor},
+    )
+
+
+def _render_contact_rows(request: Request, vendor, contacts):
+    """Re-render the contact table rows only (tbody inner content).
+
+    Used when a re-render must target #contacts-table-body with hx-swap="innerHTML"
+    (e.g. set-primary flips the Primary badge across every row). Returning the full
+    contacts.html shell here would nest a <div>/<form>/<table> inside the <tbody>.
+    """
+    return template_response(
+        "htmx/partials/vendors/tabs/contact_rows.html",
+        {"request": request, "vendor": vendor, "contacts": contacts},
     )
 
 
@@ -977,7 +982,8 @@ async def vendor_contact_set_primary(
         .limit(50)
         .all()
     )
-    return _render_vendor_contacts(request, vendor, contacts, user)
+    # Return rows only — the button swaps innerHTML into <tbody id="contacts-table-body">.
+    return _render_contact_rows(request, vendor, contacts)
 
 
 # ── Vendor Ownership UI (surface existing StrategicVendor) ─────────────────

--- a/app/templates/htmx/partials/vendors/find_contacts_tab.html
+++ b/app/templates/htmx/partials/vendors/find_contacts_tab.html
@@ -16,6 +16,7 @@
       <button hx-post="/v2/partials/vendors/{{ vendor.id }}/ai/find-contacts"
               hx-target="#prospect-results"
               hx-swap="innerHTML"
+              hx-include="#find-contacts-form"
               data-loading-disable
               @htmx:before-request="searching = true"
               @htmx:after-request="searching = false"

--- a/app/templates/htmx/partials/vendors/reviews.html
+++ b/app/templates/htmx/partials/vendors/reviews.html
@@ -3,7 +3,7 @@
    Called by: htmx_views.py vendor_reviews / add_vendor_review routes.
    Depends on: HTMX, Tailwind CSS with brand palette.
 #}
-<div class="space-y-4">
+<div id="vendor-reviews" class="space-y-4">
   <div class="flex items-center justify-between">
     <h3 class="text-sm font-semibold text-gray-900">Reviews ({{ reviews|length }})</h3>
   </div>
@@ -11,6 +11,7 @@
   {# Add review form #}
   <form hx-post="/v2/partials/vendors/{{ vendor.id }}/reviews"
         hx-target="#vendor-reviews"
+        hx-swap="outerHTML"
         data-loading-disable
         class="bg-gray-50 rounded-lg border border-gray-200 p-3">
     <div class="flex items-center gap-3 mb-2">
@@ -54,6 +55,7 @@
       {% if r.user_id == user.id %}
       <button hx-delete="/v2/partials/vendors/{{ vendor.id }}/reviews/{{ r.id }}"
               hx-target="#vendor-reviews"
+              hx-swap="outerHTML"
               hx-confirm="Delete this review?"
               data-loading-disable
               class="text-xs text-rose-500 hover:text-rose-700 ml-2">

--- a/app/templates/htmx/partials/vendors/tabs/contact_rows.html
+++ b/app/templates/htmx/partials/vendors/tabs/contact_rows.html
@@ -1,0 +1,25 @@
+{# contact_rows.html — Vendor contact table rows (tbody inner content).
+   Receives: contacts (list[VendorContact]), vendor (VendorCard).
+   Called by: contacts.html (initial render, included into #contacts-table-body)
+              and the set-primary route (re-render after a primary flip).
+   Depends on: contact_row.html partial.
+
+   Kept as the SOLE source of the tbody inner content so a re-render (set-primary)
+   returns exactly the rows — never the full contacts.html shell, which would nest a
+   <div>/<form>/<table> inside the existing <tbody id="contacts-table-body">.
+#}
+{% if contacts %}
+  {% for c in contacts %}
+    {% include "htmx/partials/vendors/tabs/contact_row.html" %}
+  {% endfor %}
+{% else %}
+<tr id="contacts-empty-state">
+  <td colspan="6" class="py-6 sm:py-8 text-center">
+    <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/>
+    </svg>
+    <p class="text-sm font-medium text-gray-600 mt-3">No contacts found for this vendor.</p>
+    <p class="text-xs text-gray-400 mt-1">Click "+ Add Contact" above or use "Find Contacts" to discover contacts via AI.</p>
+  </td>
+</tr>
+{% endif %}

--- a/app/templates/htmx/partials/vendors/tabs/contacts.html
+++ b/app/templates/htmx/partials/vendors/tabs/contacts.html
@@ -55,21 +55,7 @@
         </tr>
       </thead>
       <tbody id="contacts-table-body" class="divide-y divide-gray-200">
-        {% if contacts %}
-          {% for c in contacts %}
-            {% include "htmx/partials/vendors/tabs/contact_row.html" %}
-          {% endfor %}
-        {% else %}
-        <tr id="contacts-empty-state">
-          <td colspan="6" class="py-6 sm:py-8 text-center">
-            <svg class="mx-auto h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/>
-            </svg>
-            <p class="text-sm font-medium text-gray-600 mt-3">No contacts found for this vendor.</p>
-            <p class="text-xs text-gray-400 mt-1">Click "+ Add Contact" above or use "Find Contacts" to discover contacts via AI.</p>
-          </td>
-        </tr>
-        {% endif %}
+        {% include "htmx/partials/vendors/tabs/contact_rows.html" %}
       </tbody>
     </table>
   </div>

--- a/tests/test_vendors_p2_workflow_breaks.py
+++ b/tests/test_vendors_p2_workflow_breaks.py
@@ -1,0 +1,175 @@
+"""test_vendors_p2_workflow_breaks.py — regression tests for the vendors P2 cluster.
+
+Covers three htmx workflow-break fixes:
+  * vendors-reviews-target — add/delete-review target #vendor-reviews, which the
+    reviews partial must actually render (else htmx:targetError aborts the swap).
+  * vendors-setprimary-nesting — set-primary must return contact ROWS ONLY (tbody
+    inner content), never the full contacts.html shell nested inside the <tbody>.
+  * vendors-findcontacts-filter-dead — the Find Contacts button must hx-include the
+    #find-contacts-form so the title-keywords filter is actually sent.
+
+Called by: pytest
+Depends on: conftest fixtures (client, db_session, test_vendor_card, test_vendor_contact)
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import VendorCard, VendorContact
+
+# ── vendors-reviews-target ───────────────────────────────────────────────────
+
+
+class TestVendorReviewsTarget:
+    def test_reviews_tab_renders_the_target_id(self, client: TestClient, test_vendor_card: VendorCard):
+        """The reviews partial must render id="vendor-reviews" — the element the add and
+        delete forms target.
+
+        Without it htmx raises htmx:targetError and aborts.
+        """
+        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/reviews")
+        assert resp.status_code == 200
+        assert 'id="vendor-reviews"' in resp.text
+        # The forms reference that exact target.
+        assert 'hx-target="#vendor-reviews"' in resp.text
+
+    def test_add_review_returns_self_replacing_partial(
+        self, client: TestClient, db_session: Session, test_vendor_card: VendorCard
+    ):
+        """Add-review returns the full reviews.html; the target id must survive the swap
+        and the swap must be outerHTML so the returned root replaces (not nests inside)
+        the existing #vendor-reviews element."""
+        resp = client.post(
+            f"/v2/partials/vendors/{test_vendor_card.id}/reviews",
+            data={"rating": "5", "comment": "Excellent fulfilment"},
+        )
+        assert resp.status_code == 200
+        assert 'id="vendor-reviews"' in resp.text  # target persists across swaps
+        assert 'hx-swap="outerHTML"' in resp.text  # self-replace, no nesting
+        assert "Excellent fulfilment" in resp.text
+
+    def test_delete_review_targets_rendered_id(
+        self, client: TestClient, db_session: Session, test_vendor_card: VendorCard, test_user
+    ):
+        """Deleting an own review returns the refreshed reviews partial with the target
+        id present, so the swap lands instead of aborting."""
+        from app.models import VendorReview
+
+        review = VendorReview(
+            vendor_card_id=test_vendor_card.id,
+            user_id=test_user.id,
+            rating=4,
+            comment="Prompt replies",
+        )
+        db_session.add(review)
+        db_session.commit()
+        db_session.refresh(review)
+
+        resp = client.delete(f"/v2/partials/vendors/{test_vendor_card.id}/reviews/{review.id}")
+        assert resp.status_code == 200
+        assert 'id="vendor-reviews"' in resp.text
+
+
+# ── vendors-setprimary-nesting ───────────────────────────────────────────────
+
+
+class TestVendorSetPrimaryNesting:
+    def test_set_primary_returns_rows_only(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_vendor_card: VendorCard,
+        test_vendor_contact: VendorContact,
+    ):
+        """Set-primary swaps innerHTML into <tbody id="contacts-table-body">, so the
+        response must be table ROWS ONLY — never the full contacts.html shell (a
+        <div>/<form>/<table> nested inside a <tbody> is malformed DOM)."""
+        vc2 = VendorContact(
+            vendor_card_id=test_vendor_card.id,
+            email="second@vendor.com",
+            source="manual",
+            confidence=80,
+            is_primary=True,
+        )
+        db_session.add(vc2)
+        db_session.commit()
+
+        resp = client.post(f"/v2/partials/vendors/{test_vendor_card.id}/contacts/{test_vendor_contact.id}/set-primary")
+        assert resp.status_code == 200
+        # Rows are present…
+        assert "<tr" in resp.text
+        assert test_vendor_contact.email in resp.text
+        assert "second@vendor.com" in resp.text
+        # …but the full-shell markup must NOT be — that was the nesting bug. (Per-row
+        # inline-edit <form>s are expected; the shell's <table>/<tbody>/add-contact
+        # header are the tell-tale nesting markers.)
+        assert 'id="contacts-table-body"' not in resp.text
+        assert "<table" not in resp.text
+        assert "<thead" not in resp.text
+        assert "+ Add Contact" not in resp.text
+
+    def test_contacts_tab_still_renders_rows(
+        self, client: TestClient, test_vendor_card: VendorCard, test_vendor_contact: VendorContact
+    ):
+        """Regression: the shared contact_rows partial still renders inside the full tab
+        shell (tbody + rows both present)."""
+        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/contacts")
+        assert resp.status_code == 200
+        assert 'id="contacts-table-body"' in resp.text
+        assert test_vendor_contact.email in resp.text
+
+    def test_contacts_tab_empty_state_preserved(self, client: TestClient, test_vendor_card: VendorCard):
+        """Regression: the extracted empty state still renders for a zero-contact vendor."""
+        resp = client.get(f"/v2/partials/vendors/{test_vendor_card.id}/tab/contacts")
+        assert resp.status_code == 200
+        assert "No contacts found for this vendor" in resp.text
+        assert 'id="contacts-table-body"' in resp.text
+
+
+# ── vendors-findcontacts-filter-dead ─────────────────────────────────────────
+
+
+@pytest.fixture()
+def vendor_with_domain(db_session: Session) -> VendorCard:
+    card = VendorCard(
+        normalized_name="mouser",
+        display_name="Mouser Electronics",
+        domain="mouser.com",
+        emails=["sales@mouser.com"],
+        sighting_count=50,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(card)
+    db_session.commit()
+    db_session.refresh(card)
+    return card
+
+
+class TestFindContactsFilter:
+    def test_button_includes_filter_form(self, client: TestClient, vendor_with_domain: VendorCard):
+        """The Find Contacts button lives outside the filter <form>, so it must hx-
+        include="#find-contacts-form" or the title-keywords input is never sent."""
+        resp = client.get(f"/v2/partials/vendors/{vendor_with_domain.id}/tab/find_contacts")
+        assert resp.status_code == 200
+        assert 'id="find-contacts-form"' in resp.text
+        assert 'hx-include="#find-contacts-form"' in resp.text
+        # The keyword input lives inside that form.
+        assert 'name="title_keywords"' in resp.text
+
+    @patch("app.services.ai_service.enrich_contacts_websearch", new_callable=AsyncMock)
+    def test_title_keywords_reach_search_service(self, mock_search, client: TestClient, vendor_with_domain: VendorCard):
+        """Server side: once the form is included, its title_keywords value drives the
+        AI search (proving the filter is honoured, not dropped)."""
+        mock_search.return_value = []
+        resp = client.post(
+            f"/v2/partials/vendors/{vendor_with_domain.id}/ai/find-contacts",
+            data={"title_keywords": "procurement, buyer"},
+        )
+        assert resp.status_code == 200
+        # enrich_contacts_websearch(display_name, domain, keywords, limit=...)
+        assert mock_search.await_count == 1
+        assert mock_search.await_args.args[2] == "procurement, buyer"


### PR DESCRIPTION
Fixes the **vendors** cluster of P2 htmx workflow-break findings from `docs/audit/2026-07-02-production-polish-review.md`. All three were verified LIVE on current main.

## Findings

### vendors-reviews-target — FIXED
`reviews.html` add-review form and per-review delete button both target `#vendor-reviews`, but the partial root `<div class="space-y-4">` had no id, so htmx raised `htmx:targetError` and aborted every add/delete swap. Gave the root `id="vendor-reviews"` and set `hx-swap="outerHTML"` on both actions so the returned partial self-replaces cleanly (no nesting).

### vendors-setprimary-nesting — FIXED
The Set Primary button swaps `innerHTML` into `<tbody id="contacts-table-body">`, but the route returned the entire `contacts.html` shell (a `<div>`/`<form>`/`<table>`/nested `<tbody>`) — injecting that subtree inside the existing `<tbody>` produced malformed DOM. Extracted the tbody inner content into a shared `contact_rows.html` partial (used by both the tab's initial render and the re-render) and made set-primary return rows only. Removed the now-dead `_render_vendor_contacts` helper.

### vendors-findcontacts-filter-dead — FIXED
The Find Contacts button sits outside `<form id="find-contacts-form">` and omitted `hx-include`, so the title-keywords filter input was never sent (endpoint always received `""`). Added `hx-include="#find-contacts-form"` to the button.

## Tests
New `tests/test_vendors_p2_workflow_breaks.py` (8 tests) covers all three: reviews target id renders + survives add/delete swaps, set-primary returns rows-only (no shell markers) + tab/empty-state regressions, and the find-contacts button includes the filter form + keywords reach the search service. Ran with `test_vendor_parity_p1`, `test_phase3a_ai_contacts`, `test_routers_vendor_contacts`, and `test_static_analysis` — all green (132 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)