### PR TITLE
fix(crm): P2 workflow-breaks

### DIFF
--- a/app/routers/htmx/companies.py
+++ b/app/routers/htmx/companies.py
@@ -4562,6 +4562,7 @@ async def contact_merge(
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
 
+    reassigned = int(result.get("reassigned", 0))
     logger.info(
         "Manual contact merge: kept {} ({}), removed {} by {}",
         contact_id,
@@ -4570,14 +4571,12 @@ async def contact_merge(
         user.email,
     )
 
-    safe_name = html_mod.escape(keep.full_name or "")
-    response = HTMLResponse(
-        f'<p class="text-sm text-emerald-600 py-2">Merged into <strong>{safe_name}</strong>. '
-        f"{int(result.get('reassigned', 0))} record(s) reassigned.</p>",
-        status_code=200,
-    )
+    # Return the refreshed contacts grouped-list (targeted at #contacts-tab-list) so the
+    # merged-away contact disappears immediately; the preview form's after-request closes
+    # the modal. Mirrors the sibling Move-contact flow — no in-modal dead-end.
+    response = _render_contacts_list(request, user, company, db)
     response.headers["HX-Trigger"] = json.dumps(
-        {"showToast": {"message": "Contact merged successfully", "type": "success"}}
+        {"showToast": {"message": f"Contact merged — {reassigned} record(s) reassigned", "type": "success"}}
     )
     return response
 

--- a/app/templates/htmx/partials/customers/_contact_macros.html
+++ b/app/templates/htmx/partials/customers/_contact_macros.html
@@ -368,9 +368,13 @@
                     role='menuitem'
                     class='w-full text-left px-3 py-1.5 text-emerald-700 hover:bg-emerald-50'>Set Primary</button>
             {% endif %}
+            {# Refresh the whole detail (the account-primary shows in the detail header,
+               not the contacts list) via `closest [data-detail-root]` — the same target
+               the Reactivate / Archive account actions use, so it works both inside the
+               CDM workspace right panel and on a deep-linked full-page detail. #}
             <button hx-post='/v2/partials/customers/{{ company.id }}/primary-contact/{{ contact.id }}'
-                    hx-target='#main-content'
-                    hx-swap='innerHTML'
+                    hx-target='closest [data-detail-root]'
+                    hx-swap='outerHTML'
                     @click.stop='km=false'
                     data-loading-disable
                     role='menuitem'

--- a/app/templates/htmx/partials/customers/_contact_merge_preview.html
+++ b/app/templates/htmx/partials/customers/_contact_merge_preview.html
@@ -38,11 +38,13 @@
     </ul>
   </div>
 
-  <div id="contact-merge-result"></div>
-
+  {# On success the handler returns the refreshed contacts grouped-list, which htmx
+     swaps into #contacts-tab-list behind the modal; after-request then closes the
+     modal — mirroring the sibling Move-contact flow (_contact_move_form.html). #}
   <form hx-post="/v2/partials/customers/{{ company.id }}/contacts/{{ keep.id }}/merge"
-        hx-target="#contact-merge-result"
+        hx-target="#contacts-tab-list"
         hx-swap="innerHTML"
+        hx-on::after-request="if(event.detail.successful) $dispatch('close-modal')"
         class="flex items-center gap-3">
     <input type="hidden" name="remove_id" value="{{ remove.id }}">
     <input type="hidden" name="confirmed" value="true">

--- a/tests/test_company_links.py
+++ b/tests/test_company_links.py
@@ -12,6 +12,8 @@ Depends on: tests/conftest.py fixtures (db_session, test_user, admin_user, clien
 
 from __future__ import annotations
 
+import re
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -170,6 +172,30 @@ class TestPrimaryContactEndpoint:
         """contact_b belongs to company_b, not company_a — IDOR guard → 404."""
         resp = owner_client.post(f"/v2/partials/customers/{company_a.id}/primary-contact/{contact_b.id}")
         assert resp.status_code == 404
+
+    def test_kebab_button_targets_detail_root_not_main_content(
+        self, owner_client: TestClient, company_a: Company, contact_a: SiteContact
+    ):
+        """F8: the 'Set account primary' kebab action must refresh the detail via
+        `closest [data-detail-root]` (outerHTML) like the sibling Reactivate/Archive
+        actions — NOT swap the whole #main-content and destroy the CDM split workspace.
+
+        The account-primary shows in the detail header (not the contacts list), so the
+        handler returns the full detail partial; targeting the detail root re-swaps it
+        both inside the CDM workspace and on a deep-linked full-page detail.
+        """
+        resp = owner_client.get(f"/v2/partials/customers/{company_a.id}/tab/contacts")
+        assert resp.status_code == 200
+        m = re.search(
+            r"<button[^>]*primary-contact/" + str(contact_a.id) + r"\b.*?Set account primary</button>",
+            resp.text,
+            re.S,
+        )
+        assert m, "Set account primary button not found in contacts tab"
+        btn = m.group(0)
+        assert "closest [data-detail-root]" in btn
+        assert "outerHTML" in btn
+        assert "#main-content" not in btn
 
 
 class TestParentCompanyEndpoint:

--- a/tests/test_contact_merge_move.py
+++ b/tests/test_contact_merge_move.py
@@ -358,6 +358,47 @@ class TestMergeRoutes:
         db_session.expire_all()
         assert db_session.get(SiteContact, loser_id) is None
 
+    def test_merge_execute_returns_refreshed_contacts_list(
+        self,
+        owner_client_a: TestClient,
+        company_a: Company,
+        keeper: SiteContact,
+        loser: SiteContact,
+    ):
+        """F9: a successful merge returns the refreshed contacts grouped-list (which htmx
+        swaps into #contacts-tab-list behind the modal) — NOT the old dead-end <p> that
+        left the merged-away contact visible until the user manually closed the modal."""
+        resp = owner_client_a.post(
+            f"/v2/partials/customers/{company_a.id}/contacts/{keeper.id}/merge",
+            data={"remove_id": str(loser.id), "confirmed": "true"},
+        )
+        assert resp.status_code == 200
+        # It is the grouped-list partial (has its section marker), not the bare <p>.
+        assert "data-contacts-section" in resp.text
+        assert "Merged into" not in resp.text
+        # Keeper stays; the merged-away loser is gone from the list immediately.
+        assert "Keep Me" in resp.text
+        assert "Lose Me" not in resp.text
+        # Toast confirmation still fires via HX-Trigger.
+        assert "showToast" in resp.headers.get("HX-Trigger", "")
+
+    def test_merge_preview_form_targets_contacts_list_and_closes_modal(
+        self,
+        owner_client_a: TestClient,
+        company_a: Company,
+        keeper: SiteContact,
+        loser: SiteContact,
+    ):
+        """F9: the confirm form swaps into #contacts-tab-list and closes the modal on
+        success — the in-modal #contact-merge-result dead-end target is gone."""
+        resp = owner_client_a.get(
+            f"/v2/partials/customers/{company_a.id}/contacts/{keeper.id}/merge-preview?remove_id={loser.id}"
+        )
+        assert resp.status_code == 200
+        assert 'hx-target="#contacts-tab-list"' in resp.text
+        assert "close-modal" in resp.text
+        assert 'id="contact-merge-result"' not in resp.text
+
     def test_merge_execute_requires_confirmed(
         self,
         owner_client_a: TestClient,


### PR DESCRIPTION
Fixes the CRM cluster of P2 workflow-break findings from `docs/audit/2026-07-02-production-polish-review.md`.

## Findings

**F7 — Create-account / whole-form edit-account flows are orphaned** — `DESIGN_FORK` (not touched)
- Verified still live: `GET /v2/partials/customers/create-form` (companies.py:1088) and `.../{id}/edit-form` (companies.py:3719) have zero template/static references; the CDM filter bar offers only search/filters/Import/Export.
- The fix requires **new UI + a product decision** (add a `+ New account` button to the CDM filter bar → guarded by "never add UI without approval"; and decide whether to wire the whole-form edit-form somewhere or delete it in favor of WS1 inline field editing). Recommendation: add `+ New account` in the list.html action row wired to `create-form`, and delete the orphaned company edit-form in favor of inline editing. Left for product sign-off.

**F8 — 'Set account primary' destroyed the split workspace** — `FIXED`
- The kebab button targeted `#main-content` (innerHTML), so the returned account-detail swap replaced the CDM account list + tab bar.
- Root-cause fix: target `closest [data-detail-root]` with `outerHTML` — the exact pattern used by the sibling Reactivate/Archive account actions (handler already returns the full detail, where the account-primary badge lives). Works both in the CDM workspace and on a deep-linked full-page detail.

**F9 — Contact merge success dead-ended inside the modal** — `FIXED`
- The merge handler returned a bare success `<p>` into `#contact-merge-result` with no list refresh and no modal close, leaving the merged-away contact visible until the user manually closed the modal (button still labeled 'Cancel').
- Root-cause fix: mirror the sibling Move-contact flow — the confirm form now targets `#contacts-tab-list`, closes the modal on success via `hx-on::after-request`, and the handler returns the refreshed contacts grouped-list (`_render_contacts_list`) with the toast preserved.

## Tests
- `tests/test_company_links.py::TestPrimaryContactEndpoint::test_kebab_button_targets_detail_root_not_main_content` (F8)
- `tests/test_contact_merge_move.py::TestMergeRoutes::test_merge_execute_returns_refreshed_contacts_list` + `::test_merge_preview_form_targets_contacts_list_and_closes_modal` (F9)
- Full runs green: the two touched test files (37), `test_static_analysis.py`, `test_crm_macros.py`, `test_crm_views.py`, `test_contacts_ui_compact.py` (370).

🤖 Generated with [Claude Code](https://claude.com/claude-code)