### PR TITLE
fix(search-sourcing): P2 workflow-breaks

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -1326,7 +1326,11 @@ async def add_to_requisition(
     mpn = body.get("mpn", "").strip()
     items = body.get("items", [])
 
-    if not requisition_id or not mpn or not items:
+    # The MPN + requisition are the only required inputs: from the part dossier the
+    # meaningful action is "add THIS part to a requisition", which creates the
+    # Requirement row. Shortlisted market rows (items) are optional supporting
+    # sightings, so an empty shortlist must still succeed (it added the part).
+    if not requisition_id or not mpn:
         return HTMLResponse(
             '<div class="text-red-600 text-sm p-2">Missing required fields.</div>',
             status_code=400,
@@ -1384,10 +1388,13 @@ async def add_to_requisition(
     db.commit()
 
     count = len(items)
+    req_label = html_mod.escape(req.name or "")
+    if count:
+        what = f"{count} result{'s' if count != 1 else ''}"
+    else:
+        what = html_mod.escape(mpn)
     return HTMLResponse(
-        f'<div class="text-sm text-emerald-600 p-2">'
-        f"Added {count} result{'s' if count != 1 else ''} to requisition &ldquo;{html_mod.escape(req.name or '')}&rdquo;"
-        f"</div>"
+        f'<div class="text-sm text-emerald-600 p-2">Added {what} to requisition &ldquo;{req_label}&rdquo;</div>'
     )
 
 

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -672,6 +672,70 @@ Alpine.data('splitPanel', (panelId, defaultPct) => ({
 }));
 
 /**
+ * sourcingWorkspace — keyboard navigation for the split-panel sourcing workspace.
+ * Arrow keys walk the selection through leadIds and lazy-load each lead's detail
+ * into #split-right-sourcing; Escape restores the empty-state placeholder.
+ *
+ * Registered statically here (NOT via an in-partial `alpine:init` listener) because
+ * the workspace partial arrives via HTMX long after Alpine.start() has already fired,
+ * so a partial-scoped alpine:init would never run and `x-data="sourcingWorkspace()"`
+ * would throw. Mirrors splitPanel: the initial selection and lead-id list are passed
+ * in from the template's x-data call.
+ *
+ * Called by: app/templates/htmx/partials/sourcing/workspace.html
+ *            (x-data="sourcingWorkspace(<selected_lead_id>, [<lead ids>])").
+ * Depends on: Alpine.js, htmx.
+ */
+Alpine.data('sourcingWorkspace', (selectedLeadId, leadIds) => ({
+    selectedLead: selectedLeadId || 0,
+    leadIds: leadIds || [],
+
+    selectNext() {
+        const idx = this.leadIds.indexOf(this.selectedLead);
+        if (idx < this.leadIds.length - 1) {
+            this.selectedLead = this.leadIds[idx + 1];
+            this._loadLead(this.selectedLead);
+        }
+    },
+
+    selectPrev() {
+        const idx = this.leadIds.indexOf(this.selectedLead);
+        if (idx > 0) {
+            this.selectedLead = this.leadIds[idx - 1];
+            this._loadLead(this.selectedLead);
+        }
+    },
+
+    clearSelection() {
+        this.selectedLead = 0;
+        const target = document.getElementById('split-right-sourcing');
+        if (target) {
+            target.textContent = '';
+            const wrapper = document.createElement('div');
+            wrapper.className = 'flex items-center justify-center h-full text-gray-400';
+            const inner = document.createElement('div');
+            inner.className = 'text-center';
+            const p = document.createElement('p');
+            p.className = 'text-sm';
+            p.textContent = 'Select a lead to view details';
+            inner.appendChild(p);
+            wrapper.appendChild(inner);
+            target.appendChild(wrapper);
+        }
+    },
+
+    _loadLead(leadId) {
+        htmx.ajax('GET', '/v2/partials/sourcing/leads/' + leadId + '/panel', {
+            target: '#split-right-sourcing',
+            swap: 'innerHTML',
+            indicator: '#split-right-sourcing',
+        });
+        const row = document.getElementById('lead-row-' + leadId);
+        if (row) row.scrollIntoView({ block: 'nearest' });
+    },
+}));
+
+/**
  * resizableModal — global modal wrapper behavior: open/close state plus, on
  * desktop, drag-to-move and drag-to-resize (4 edges + 4 corners) with the
  * chosen size/position remembered per size-bucket.

--- a/app/templates/htmx/partials/materials/detail.html
+++ b/app/templates/htmx/partials/materials/detail.html
@@ -231,7 +231,7 @@
               class="px-4 py-2.5 text-sm font-medium transition-colors -mb-px"
               hx-get="/v2/partials/materials/{{ card.id }}/tab/{{ tab_id }}"
               hx-target="#material-tab-content"
-              hx-trigger="{{ 'load, click once' if tab_id == 'vendors' else 'click once' }}">
+              hx-trigger="{{ 'load, click' if tab_id == 'vendors' else 'click' }}">
         {{ tab_label }}
       </button>
       {% endfor %}

--- a/app/templates/htmx/partials/sourcing/lead_card.html
+++ b/app/templates/htmx/partials/sourcing/lead_card.html
@@ -12,7 +12,7 @@
             {% if lead.buyer_status == 'contacted' or lead.buyer_status == 'has_stock' %}border-l-4 border-l-teal-500 border-brand-200{% else %}border-brand-200{% endif %}
             hover:border-brand-400"
      hx-get="/v2/partials/sourcing/leads/{{ lead.id }}"
-     hx-target="#main-content" hx-push-url="/sourcing/leads/{{ lead.id }}">
+     hx-target="#main-content" hx-push-url="/v2/sourcing/leads/{{ lead.id }}">
 
   <div class="p-4 space-y-3">
     {# Row 1: Vendor name + safety badge #}

--- a/app/templates/htmx/partials/sourcing/lead_panel.html
+++ b/app/templates/htmx/partials/sourcing/lead_panel.html
@@ -331,9 +331,9 @@
 
   {# Link to full detail page #}
   <div class="text-center">
-    <a href="/sourcing/leads/{{ lead.id }}"
+    <a href="/v2/sourcing/leads/{{ lead.id }}"
        hx-get="/v2/partials/sourcing/leads/{{ lead.id }}"
-       hx-target="#main-content" hx-push-url="/sourcing/leads/{{ lead.id }}"
+       hx-target="#main-content" hx-push-url="/v2/sourcing/leads/{{ lead.id }}"
        class="text-[11px] text-brand-500 hover:text-brand-600">
       Open full detail →
     </a>

--- a/app/templates/htmx/partials/sourcing/results.html
+++ b/app/templates/htmx/partials/sourcing/results.html
@@ -18,9 +18,9 @@
       </p>
     </div>
     <div class="flex items-center gap-2">
-      <a href="/sourcing/{{ requirement.id }}/workspace"
+      <a href="/v2/sourcing/{{ requirement.id }}/workspace"
          hx-get="/v2/partials/sourcing/{{ requirement.id }}/workspace"
-         hx-target="#main-content" hx-push-url="/sourcing/{{ requirement.id }}/workspace"
+         hx-target="#main-content" hx-push-url="/v2/sourcing/{{ requirement.id }}/workspace"
          class="px-3 py-2 text-sm text-gray-600 border border-gray-300 rounded-lg
                 hover:bg-gray-50">
         Workspace view

--- a/app/templates/htmx/partials/sourcing/workspace.html
+++ b/app/templates/htmx/partials/sourcing/workspace.html
@@ -8,7 +8,7 @@
                  per_page, f_confidence, f_safety, f_freshness, f_source, f_status,
                  f_contactability, f_corroborated, f_sort, selected_lead_id #}
 
-<div class="flex flex-col h-[calc(100vh-7.5rem)]" x-data="sourcingWorkspace()"
+<div class="flex flex-col h-[calc(100vh-7.5rem)]" x-data="sourcingWorkspace({{ selected_lead_id|default(0)|int }}, [{% for lead in leads %}{{ lead.id }}{% if not loop.last %}, {% endif %}{% endfor %}])"
      @keydown.arrow-down.prevent="selectNext()"
      @keydown.arrow-up.prevent="selectPrev()"
      @keydown.escape="clearSelection()"
@@ -24,9 +24,9 @@
       </span>
     </div>
     <div class="flex items-center gap-2">
-      <a href="/sourcing/{{ requirement.id }}"
+      <a href="/v2/sourcing/{{ requirement.id }}"
          hx-get="/v2/partials/sourcing/{{ requirement.id }}"
-         hx-target="#main-content" hx-push-url="/sourcing/{{ requirement.id }}"
+         hx-target="#main-content" hx-push-url="/v2/sourcing/{{ requirement.id }}"
          class="text-xs text-gray-600 hover:text-brand-500"
          title="Switch to card grid view">Grid view</a>
       <button hx-post="/v2/partials/sourcing/{{ requirement.id }}/search"
@@ -136,56 +136,3 @@
     </div>
   </div>
 </div>
-
-<script>
-  document.addEventListener('alpine:init', () => {
-    if (!Alpine._sourcingWorkspaceRegistered) {
-      Alpine.data('sourcingWorkspace', () => ({
-        selectedLead: {{ selected_lead_id|default(0) }},
-        leadIds: [{% for lead in leads %}{{ lead.id }}{% if not loop.last %}, {% endif %}{% endfor %}],
-
-        selectNext() {
-          const idx = this.leadIds.indexOf(this.selectedLead);
-          if (idx < this.leadIds.length - 1) {
-            this.selectedLead = this.leadIds[idx + 1];
-            this._loadLead(this.selectedLead);
-          }
-        },
-
-        selectPrev() {
-          const idx = this.leadIds.indexOf(this.selectedLead);
-          if (idx > 0) {
-            this.selectedLead = this.leadIds[idx - 1];
-            this._loadLead(this.selectedLead);
-          }
-        },
-
-        clearSelection() {
-          this.selectedLead = 0;
-          const target = document.getElementById('split-right-sourcing');
-          if (target) {
-            target.textContent = '';
-            const wrapper = document.createElement('div');
-            wrapper.className = 'flex items-center justify-center h-full text-gray-400';
-            const inner = document.createElement('div');
-            inner.className = 'text-center';
-            const p = document.createElement('p');
-            p.className = 'text-sm';
-            p.textContent = 'Select a lead to view details';
-            inner.appendChild(p);
-            wrapper.appendChild(inner);
-            target.appendChild(wrapper);
-          }
-        },
-
-        _loadLead(leadId) {
-          htmx.ajax('GET', '/v2/partials/sourcing/leads/' + leadId + '/panel',
-            { target: '#split-right-sourcing', swap: 'innerHTML' });
-          const row = document.getElementById('lead-row-' + leadId);
-          if (row) row.scrollIntoView({ block: 'nearest' });
-        }
-      }));
-      Alpine._sourcingWorkspaceRegistered = true;
-    }
-  });
-</script>

--- a/tests/test_htmx_views_nightly5.py
+++ b/tests/test_htmx_views_nightly5.py
@@ -211,18 +211,24 @@ class TestAddToRequisition:
         assert resp.status_code == 400
         assert "Missing required fields" in resp.text
 
-    def test_missing_items_returns_400(
+    def test_no_items_still_adds_mpn(
         self,
         client: TestClient,
         test_requisition: Requisition,
     ):
-        """Present requisition_id + mpn but no items → 400."""
+        """requisition_id + mpn with an empty shortlist adds the MPN itself (200).
+
+        DOSSIER-ADDREQ-EMPTY-400 fix: shortlisted market rows (items) are optional
+        supporting evidence, so an empty shortlist must no longer dead-end on 400 —
+        it adds the dossier's MPN as a new requirement.
+        """
         resp = client.post(
             "/v2/partials/search/add-to-requisition",
             content=json.dumps({"requisition_id": test_requisition.id, "mpn": "LM317T", "items": []}),
             headers={"Content-Type": "application/json"},
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 200
+        assert "Added" in resp.text
 
     def test_requisition_not_found_returns_404(self, client: TestClient):
         """Unknown requisition_id → 404 HTML response."""

--- a/tests/test_search_sourcing_p2_fixes.py
+++ b/tests/test_search_sourcing_p2_fixes.py
@@ -1,0 +1,158 @@
+"""Regression tests for the search-sourcing P2 workflow-break cluster (2026-07-02
+production-polish audit).
+
+Covers:
+  - MAT-TABS-CLICK-ONCE     — material detail tabs must re-fetch on every click
+                              (no `hx-trigger="click once"`), so re-visiting a tab
+                              reloads its content instead of showing the last tab.
+  - SOURCING-WS-ALPINE-INIT — the `sourcingWorkspace` Alpine component must be
+                              registered statically in htmx_app.js (an in-partial
+                              `alpine:init` listener never re-fires after Alpine.start,
+                              so x-data would throw and keyboard nav would be dead).
+  - SOURCING-LEGACY-HREF-404 — grid/workspace/lead toggle links must push the
+                              registered `/v2/sourcing/...` full-page routes, not the
+                              never-registered legacy `/sourcing/...` paths (F5 / new-tab
+                              404).
+  - DOSSIER-ADDREQ-EMPTY-400 — "Add to Requisition" with nothing shortlisted must add
+                              the PART (create the Requirement) rather than dead-ending
+                              on a 400.
+
+What calls it: pytest.
+Depends on: app.routers.htmx.sourcing (results/workspace partials),
+            app.routers.htmx.materials (detail partial),
+            app.routers.htmx_views.add_to_requisition, conftest fixtures.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.constants import RequisitionStatus, SourcingStatus
+from app.models import MaterialCard, Requirement, Requisition, User
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+def _requisition(db: Session, user: User) -> Requisition:
+    req = Requisition(
+        name="SS-P2-REQ",
+        customer_name="Acme",
+        status=RequisitionStatus.OPEN,
+        created_by=user.id,
+        claimed_by_id=user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(req)
+    db.flush()
+    return req
+
+
+def _requirement(db: Session, req: Requisition, mpn: str = "LM317T") -> Requirement:
+    r = Requirement(
+        requisition_id=req.id,
+        primary_mpn=mpn,
+        normalized_mpn=mpn.lower(),
+        target_qty=100,
+        sourcing_status=SourcingStatus.OPEN,
+    )
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _card(db: Session, mpn: str = "LM317T") -> MaterialCard:
+    card = MaterialCard(normalized_mpn=mpn.lower(), display_mpn=mpn, manufacturer="TI", search_count=0)
+    db.add(card)
+    db.commit()
+    db.refresh(card)
+    return card
+
+
+# ── MAT-TABS-CLICK-ONCE ─────────────────────────────────────────────────────
+def test_material_tabs_refetch_on_every_click(client: TestClient, db_session: Session):
+    """Detail tabs must use plain `click` (re-fetch each click), never `click once`
+    (which strands the shared container on the last-loaded tab)."""
+    card = _card(db_session)
+    resp = client.get(f"/v2/partials/materials/{card.id}")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "click once" not in html, "material detail tabs still use hx-trigger='click once'"
+    # Vendors tab auto-loads then re-fetches on click; others fetch on click.
+    assert 'hx-trigger="load, click"' in html
+    assert 'hx-trigger="click"' in html
+
+
+# ── SOURCING-WS-ALPINE-INIT ─────────────────────────────────────────────────
+def test_sourcing_workspace_alpine_registered_statically(client: TestClient, db_session: Session, test_user: User):
+    """The workspace partial must invoke sourcingWorkspace(...) with args and carry no
+    in-partial `alpine:init` registration; the component lives in htmx_app.js."""
+    req = _requisition(db_session, test_user)
+    item = _requirement(db_session, req)
+    resp = client.get(f"/v2/partials/sourcing/{item.id}/workspace")
+    assert resp.status_code == 200
+    html = resp.text
+    # x-data now passes the initial selection + lead ids as args (static factory pattern).
+    assert "sourcingWorkspace(" in html
+    # The stranded pattern is gone: no partial-scoped alpine:init registration.
+    assert "alpine:init" not in html
+
+    # The component is registered statically (like splitPanel) so it exists before
+    # Alpine processes the HTMX-swapped x-data.
+    js = Path("app/static/htmx_app.js").read_text()
+    assert "Alpine.data('sourcingWorkspace'" in js
+
+
+# ── SOURCING-LEGACY-HREF-404 ────────────────────────────────────────────────
+def test_sourcing_workspace_grid_link_uses_v2(client: TestClient, db_session: Session, test_user: User):
+    """The workspace's Grid-view toggle must push the registered /v2/sourcing/{id}."""
+    req = _requisition(db_session, test_user)
+    item = _requirement(db_session, req)
+    html = client.get(f"/v2/partials/sourcing/{item.id}/workspace").text
+    assert f'hx-push-url="/v2/sourcing/{item.id}"' in html
+    assert f'href="/v2/sourcing/{item.id}"' in html
+    # No legacy, unregistered /sourcing/{id} (404 on reload/new-tab).
+    assert 'hx-push-url="/sourcing/' not in html
+    assert 'href="/sourcing/' not in html
+
+
+def test_sourcing_results_workspace_link_uses_v2(client: TestClient, db_session: Session, test_user: User):
+    """The results view's Workspace-view toggle must push
+    /v2/sourcing/{id}/workspace."""
+    req = _requisition(db_session, test_user)
+    item = _requirement(db_session, req)
+    html = client.get(f"/v2/partials/sourcing/{item.id}").text
+    assert f'hx-push-url="/v2/sourcing/{item.id}/workspace"' in html
+    assert 'hx-push-url="/sourcing/' not in html
+    assert 'href="/sourcing/' not in html
+
+
+# ── DOSSIER-ADDREQ-EMPTY-400 ────────────────────────────────────────────────
+def test_add_to_requisition_empty_items_adds_part(client: TestClient, db_session: Session, test_user: User):
+    """From the dossier with nothing shortlisted, Add-to-Requisition must add the PART
+    (create the Requirement) and return 200 — not dead-end on 'Missing required
+    fields'."""
+    req = _requisition(db_session, test_user)
+    db_session.commit()
+
+    resp = client.post(
+        "/v2/partials/search/add-to-requisition",
+        json={"requisition_id": req.id, "mpn": "NE555P", "items": []},
+    )
+    assert resp.status_code == 200
+    assert "NE555P" in resp.text
+    requirement = db_session.query(Requirement).filter_by(requisition_id=req.id, primary_mpn="NE555P").one()
+    assert requirement.sourcing_status == SourcingStatus.OPEN
+
+
+def test_add_to_requisition_still_requires_mpn(client: TestClient, db_session: Session, test_user: User):
+    """The MPN remains required — a blank MPN is still a 400 (the guard only dropped the
+    non-empty-items condition, not the MPN key)."""
+    req = _requisition(db_session, test_user)
+    db_session.commit()
+    resp = client.post(
+        "/v2/partials/search/add-to-requisition",
+        json={"requisition_id": req.id, "mpn": "", "items": []},
+    )
+    assert resp.status_code == 400

--- a/tests/test_static_analysis.py
+++ b/tests/test_static_analysis.py
@@ -61,7 +61,6 @@ def test_htmx_ajax_calls_have_indicator():
     # the allowlist. Drain the list as those sites get fixed.
     allowlist: set[tuple[str, int]] = {
         ("app/templates/htmx/base.html", 57),
-        ("app/templates/htmx/partials/sourcing/workspace.html", 182),
         ("app/templates/htmx/partials/parts/cell_edit.html", 12),
         ("app/templates/htmx/partials/parts/cell_edit.html", 26),
         ("app/templates/htmx/partials/parts/cell_edit.html", 37),


### PR DESCRIPTION
Fixes the search-sourcing cluster of P2 workflow-break findings from the 2026-07-02 production-polish audit (`docs/audit/2026-07-02-production-polish-review.md`). Each finding was verified against current `origin/main` first — ~40% of the audit was already fixed.

## Findings

| ID | Status | Fix |
|----|--------|-----|
| **MAT-TABS-CLICK-ONCE** | FIXED_NOW | Material detail tabs used `hx-trigger="click once"`, stranding the shared `#material-tab-content` on the last tab when re-visiting one. Switched to plain `click` (the sibling tab pattern in requisitions/vendors detail) so every click re-fetches. |
| **SOURCING-WS-ALPINE-INIT** | FIXED_NOW | `sourcingWorkspace` was registered inside an in-partial `addEventListener('alpine:init', …)`; that event fires at `Alpine.start()`, long before this HTMX-loaded partial arrives, so `x-data="sourcingWorkspace()"` always threw and keyboard nav was dead. Registered the component statically in `htmx_app.js` (mirrors `splitPanel`), passing the initial selection + lead ids via `x-data` args. The moved `htmx.ajax` call now passes an `indicator:`; drained its static-analysis allowlist entry. |
| **SOURCING-LEGACY-HREF-404** | FIXED_NOW | Grid/Workspace/lead toggle links pushed the never-registered legacy `/sourcing/…` paths (F5 / new-tab → 404). Pointed `href` + `hx-push-url` at the registered `/v2/sourcing/…` full-page routes in `workspace.html`, `results.html`, `lead_card.html`, `lead_panel.html`. |
| **DOSSIER-ADDREQ-EMPTY-400** | FIXED_NOW | "Add to Requisition" from the part dossier with nothing shortlisted dead-ended on a 400. The MPN + requisition are the only required inputs (shortlisted market rows are optional supporting sightings), so an empty shortlist now adds the part (creates the Requirement) and returns 200. |
| **SEARCH-AI-UNWIRED** | DESIGN_FORK | `POST /v2/partials/search/ai` (ai_search) and `GET /v2/partials/search/filter` are genuinely caller-less, but wiring them requires building brand-new UI (an Enter-key AI-search trigger + UX) or deciding to delete the capability. Recommendation: product decision — either wire an explicit "AI search" affordance on the topbar/dossier or remove both dead endpoints + `ai_search`. |
| **SHORTLIST-CREATE-RFQ-FAKE** | DESIGN_FORK | The shortlist "Create RFQ" button opens the identical Add-to-Requisition picker; `action=rfq` is accepted but never used, so no RFQ is created. Fixing requires a product decision (build real RFQ creation from a shortlist vs. relabel/remove the button). Recommendation: decide send-vs-relabel before implementing. |

## Tests
`tests/test_search_sourcing_p2_fixes.py` (6 tests) covers all four FIXED_NOW findings: tab re-fetch trigger, static Alpine registration + no in-partial `alpine:init`, `/v2/sourcing/…` push-urls on both workspace and results views, and empty-items add-to-requisition (plus the MPN-still-required guard). Also drained the `workspace.html:182` allowlist entry in `tests/test_static_analysis.py`.

Ran: new file + `test_add_to_requisition_normalize` + `test_static_analysis` + materials/sourcing neighbors — all green. `pre-commit run --files …` clean; ESLint 0 errors on `htmx_app.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)