### PR TITLE
fix(offers-quotes): P2 workflow-breaks

### DIFF
--- a/app/routers/htmx/quotes.py
+++ b/app/routers/htmx/quotes.py
@@ -11,6 +11,7 @@ Depends on: app.models, app.dependencies, app.database, app.services, ._shared
 """
 
 import html as html_mod
+import json
 import os
 from datetime import datetime, timezone
 
@@ -46,6 +47,24 @@ from ...template_env import template_response
 from ._shared import _base_ctx, _is_ops_member
 
 router = APIRouter(tags=["htmx-views"])
+
+
+def _recalc_quote_totals(db: Session, quote: Quote) -> None:
+    """Recompute quote header totals (subtotal/cost/margin) from its QuoteLine rows.
+
+    The detail header (quotes/detail.html) and the sent-email/PDF total (quote_send.py)
+    all read quote.subtotal / total_cost / total_margin_pct, so every line mutation (add
+    / edit / delete / add-offer / apply-markup) must refresh them or the stored totals
+    drift from the visible lines and the customer is emailed a stale subtotal (OQ-12).
+    Single arbitration point — every mutation handler calls this before commit.
+    """
+    db.flush()
+    lines = db.query(QuoteLine).filter(QuoteLine.quote_id == quote.id).all()
+    subtotal = sum(float(ln.sell_price or 0) * (ln.qty or 1) for ln in lines)
+    total_cost = sum(float(ln.cost_price or 0) * (ln.qty or 1) for ln in lines)
+    quote.subtotal = subtotal
+    quote.total_cost = total_cost
+    quote.total_margin_pct = ((subtotal - total_cost) / subtotal * 100) if subtotal else 0
 
 
 # ── Sprint 5: Quote Workflow Completion ────────────────────────────────
@@ -237,7 +256,7 @@ async def update_quote_line(
     if not line or line.quote_id != quote_id:
         raise HTTPException(404, "Line not found")
     # Scope the parent quote through ownership (raises 404 for SALES accessing other users' quotes).
-    get_quote_for_user(db, user, line.quote_id)
+    quote = get_quote_for_user(db, user, line.quote_id)
     form = await request.form()
     if "mpn" in form:
         line.mpn = form["mpn"]
@@ -260,6 +279,7 @@ async def update_quote_line(
             raise HTTPException(400, "sell_price must be a number")
     if line.sell_price and float(line.sell_price) > 0 and line.cost_price is not None:
         line.margin_pct = round((float(line.sell_price) - float(line.cost_price)) / float(line.sell_price) * 100, 2)
+    _recalc_quote_totals(db, quote)
     db.commit()
     ctx = _base_ctx(request, user, "quotes")
     ctx["line"] = line
@@ -279,8 +299,9 @@ async def delete_quote_line(
     if not line or line.quote_id != quote_id:
         raise HTTPException(404, "Line not found")
     # Scope the parent quote through ownership (raises 404 for SALES accessing other users' quotes).
-    get_quote_for_user(db, user, line.quote_id)
+    quote = get_quote_for_user(db, user, line.quote_id)
     db.delete(line)
+    _recalc_quote_totals(db, quote)
     db.commit()
     return HTMLResponse("")
 
@@ -299,7 +320,7 @@ async def add_quote_line(
 ):
     """Add a new line item to a quote, return the new row HTML."""
     # Ownership/existence check (raises 404 if the quote isn't visible to the user).
-    get_quote_for_user(db, user, quote_id)
+    quote = get_quote_for_user(db, user, quote_id)
     margin_pct = 0.0
     if sell_price > 0:
         margin_pct = round((sell_price - cost_price) / sell_price * 100, 2)
@@ -313,6 +334,7 @@ async def add_quote_line(
         margin_pct=margin_pct,
     )
     db.add(line)
+    _recalc_quote_totals(db, quote)
     db.commit()
     db.refresh(line)
     ctx = _base_ctx(request, user, "quotes")
@@ -349,6 +371,7 @@ async def add_offer_to_quote(
         margin_pct=0,
     )
     db.add(line)
+    _recalc_quote_totals(db, quote)
     db.commit()
     db.refresh(line)
     ctx = _base_ctx(request, user, "quotes")
@@ -381,16 +404,28 @@ async def send_quote_htmx(
     try:
         await send_quote_email(db, quote, user, token=token, testing=testing)
     except QuoteSendDNCBlocked:
-        return HTMLResponse(
-            '<div class="rounded bg-rose-50 border border-rose-200 text-rose-700 text-xs px-2 py-1.5">'
-            "This recipient is do-not-contact — quote not sent.</div>"
-        )
+        # Surface the failure as a toast WITHOUT swapping — the Send button targets
+        # #main-content, so swapping any error body would replace the whole quote
+        # detail / Build-Quote workspace (OQ-07). HX-Reswap=none keeps the workspace
+        # intact; the showToast HX-Trigger bridges to $store.toast (htmx_app.js).
+        return _send_error_toast("This recipient is do-not-contact — quote not sent.")
     except QuoteSendError as exc:
-        return HTMLResponse(
-            '<div class="rounded bg-rose-50 border border-rose-200 text-rose-700 text-xs px-2 py-1.5">'
-            f"{html_mod.escape(exc.detail)}</div>"
-        )
+        return _send_error_toast(exc.detail)
     return await quote_detail_partial(request, quote_id, user, db)
+
+
+def _send_error_toast(message: str) -> HTMLResponse:
+    """Return a no-swap response that surfaces a send failure as a toast.
+
+    The quote Send buttons (quotes/detail.html, requisitions/tabs/build_quote.html)
+    target #main-content, so any swapped error body wipes the whole workspace (OQ-07).
+    HX-Reswap=none suppresses the swap; the showToast HX-Trigger (htmx_app.js) shows the
+    error and the user stays where they are to retry.
+    """
+    resp = HTMLResponse("")
+    resp.headers["HX-Reswap"] = "none"
+    resp.headers["HX-Trigger"] = json.dumps({"showToast": {"message": message, "type": "error"}})
+    return resp
 
 
 @router.post("/v2/partials/quotes/{quote_id}/result", response_class=HTMLResponse)
@@ -485,13 +520,14 @@ async def apply_markup_htmx(
 ):
     """Apply a markup percentage to all lines in the quote."""
     # Scope ownership check before mutating any lines (raises 404 for SALES on other users' quotes).
-    get_quote_for_user(db, user, quote_id)
+    quote = get_quote_for_user(db, user, quote_id)
     lines = db.query(QuoteLine).filter(QuoteLine.quote_id == quote_id).all()
     for line in lines:
         if line.cost_price and float(line.cost_price) > 0:
             multiplier = 1 + (markup_pct / 100)
             line.sell_price = round(float(line.cost_price) * multiplier, 4)
             line.margin_pct = round(markup_pct / multiplier, 2)
+    _recalc_quote_totals(db, quote)
     db.commit()
     return await quote_detail_partial(request, quote_id, user, db)
 
@@ -549,14 +585,7 @@ async def add_offers_to_draft_quote(
         )
         db.add(line)
 
-    # Recalculate totals
-    db.flush()
-    all_lines = db.query(QuoteLine).filter(QuoteLine.quote_id == quote.id).all()
-    subtotal = sum(float(ln.sell_price or 0) * (ln.qty or 1) for ln in all_lines)
-    total_cost = sum(float(ln.cost_price or 0) * (ln.qty or 1) for ln in all_lines)
-    quote.subtotal = subtotal
-    quote.total_cost = total_cost
-    quote.total_margin_pct = ((subtotal - total_cost) / subtotal * 100) if subtotal else 0
+    _recalc_quote_totals(db, quote)
     db.commit()
 
     logger.info("Added {} offers to quote {} by {}", len(offers), quote.quote_number, user.email)

--- a/app/routers/htmx/quotes.py
+++ b/app/routers/htmx/quotes.py
@@ -59,12 +59,39 @@ def _recalc_quote_totals(db: Session, quote: Quote) -> None:
     Single arbitration point — every mutation handler calls this before commit.
     """
     db.flush()
-    lines = db.query(QuoteLine).filter(QuoteLine.quote_id == quote.id).all()
+    lines = db.query(QuoteLine).filter(QuoteLine.quote_id == quote.id).order_by(QuoteLine.id).all()
     subtotal = sum(float(ln.sell_price or 0) * (ln.qty or 1) for ln in lines)
     total_cost = sum(float(ln.cost_price or 0) * (ln.qty or 1) for ln in lines)
     quote.subtotal = subtotal
     quote.total_cost = total_cost
     quote.total_margin_pct = ((subtotal - total_cost) / subtotal * 100) if subtotal else 0
+
+    # Rebuild quote.line_items (the JSON the sent email + PDF render their ROWS from —
+    # quote_send.py:220, quote_builder_service) from the QuoteLine rows, so an edited /
+    # added / deleted line stays consistent with the recomputed total. Without this the
+    # OQ-12 fix only corrected the header total: the email rows still showed stale prices
+    # and no longer summed to the stated total (edit-then-send self-contradiction). The
+    # display-only fields (condition/date_code/…) live on the linked Offer, not QuoteLine.
+    new_line_items = []
+    for ln in lines:
+        offer = db.get(Offer, ln.offer_id) if ln.offer_id else None
+        new_line_items.append(
+            {
+                "mpn": ln.mpn or "",
+                "manufacturer": ln.manufacturer or "",
+                "qty": ln.qty or 1,
+                "cost_price": float(ln.cost_price or 0),
+                "sell_price": float(ln.sell_price or 0),
+                "margin_pct": float(ln.margin_pct or 0),
+                "lead_time": offer.lead_time if offer else None,
+                "date_code": offer.date_code if offer else None,
+                "condition": offer.condition if offer else None,
+                "packaging": offer.packaging if offer else None,
+                "moq": offer.moq if offer else None,
+                "offer_id": ln.offer_id,
+            }
+        )
+    quote.line_items = new_line_items
 
 
 # ── Sprint 5: Quote Workflow Completion ────────────────────────────────

--- a/app/templates/htmx/partials/requisitions/tabs/offers.html
+++ b/app/templates/htmx/partials/requisitions/tabs/offers.html
@@ -120,7 +120,7 @@
         <tr>
           <th class="px-3 py-2.5 text-center w-8">
             <input aria-label="Select all offers" type="checkbox"
-                   @change="selectedOffers = $el.checked ? [{% for o in offers %}{{ o.id }}{{ ',' if not loop.last }}{% endfor %}] : []"
+                   @change="document.querySelectorAll('#offers-form input[name=offer_ids]').forEach(c => c.checked = $el.checked); selectedOffers = $el.checked ? [{% for o in offers %}{{ o.id }}{{ ',' if not loop.last }}{% endfor %}] : []"
                    class="rounded border-gray-300 text-brand-500 focus:ring-brand-500">
           </th>
           <th data-col-key="vendor" class="px-4 py-2.5 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Vendor</th>

--- a/tests/test_oq_offers_quotes_workflow.py
+++ b/tests/test_oq_offers_quotes_workflow.py
@@ -122,6 +122,27 @@ class TestLineMutationsRecalcTotals:
         assert draft_quote.subtotal == pytest.approx(30.0)  # 10 * 3.00
         assert draft_quote.total_cost == pytest.approx(10.0)
 
+    def test_update_line_rebuilds_line_items_so_email_rows_match_total(
+        self, client: TestClient, db_session: Session, draft_quote: Quote
+    ):
+        """OQ-12 (full): editing a line must rebuild quote.line_items (the JSON the sent
+        email/PDF render ROWS from) — not just the header subtotal — so the emailed rows
+        sum to the stated total instead of showing stale prices."""
+        line = _add_line(db_session, draft_quote, qty=5, cost_price=1.0, sell_price=2.0)
+        client.put(
+            f"/v2/partials/quotes/{draft_quote.id}/lines/{line.id}",
+            data={"qty": "10", "cost_price": "1.00", "sell_price": "3.00"},
+            headers={"HX-Request": "true"},
+        )
+        db_session.refresh(draft_quote)
+        items = draft_quote.line_items or []
+        assert len(items) == 1
+        assert items[0]["sell_price"] == pytest.approx(3.00)
+        assert items[0]["qty"] == 10
+        # The email renders rows from line_items and the total from subtotal — they must agree.
+        rows_total = sum((it.get("sell_price") or 0) * (it.get("qty") or 0) for it in items)
+        assert rows_total == pytest.approx(float(draft_quote.subtotal))
+
     def test_delete_line_recalcs(self, client: TestClient, db_session: Session, draft_quote: Quote):
         keep = _add_line(db_session, draft_quote, mpn="KEEP", qty=5, cost_price=1.0, sell_price=2.0)
         drop = _add_line(db_session, draft_quote, mpn="DROP", qty=2, cost_price=1.0, sell_price=4.0)

--- a/tests/test_oq_offers_quotes_workflow.py
+++ b/tests/test_oq_offers_quotes_workflow.py
@@ -1,0 +1,162 @@
+"""test_oq_offers_quotes_workflow.py — P2 offers/quotes workflow-break fixes.
+
+Covers the production-polish audit findings:
+  - OQ-06: the offers-tab select-all now checks/unchecks the row offer_ids checkboxes
+    that "Create Quote from Selected" reads via hx-include (else it 400s).
+  - OQ-12: every quote-line mutation (add / edit / delete / add-offer / apply-markup)
+    recomputes the quote header totals so quote.subtotal (emailed by quote_send) no
+    longer drifts from the visible lines.
+
+Called by: pytest
+Depends on: tests/conftest.py fixtures (client, db_session, test_requisition,
+test_customer_site, test_user, test_offer), app.routers.htmx.quotes / .offers.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Offer, Quote, QuoteLine, Requisition, User
+
+
+@pytest.fixture()
+def draft_quote(
+    db_session: Session,
+    test_requisition: Requisition,
+    test_customer_site,
+    test_user: User,
+) -> Quote:
+    """A fresh draft quote (no totals yet) for line-mutation tests."""
+    q = Quote(
+        requisition_id=test_requisition.id,
+        customer_site_id=test_customer_site.id,
+        quote_number="TEST-Q-OQ12-001",
+        status="draft",
+        line_items=[],
+        created_by_id=test_user.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(q)
+    db_session.commit()
+    db_session.refresh(q)
+    return q
+
+
+def _add_line(db: Session, quote: Quote, **kw) -> QuoteLine:
+    line = QuoteLine(
+        quote_id=quote.id,
+        mpn=kw.get("mpn", "LM317T"),
+        qty=kw.get("qty", 1),
+        cost_price=kw.get("cost_price", 0.0),
+        sell_price=kw.get("sell_price", 0.0),
+        margin_pct=kw.get("margin_pct", 0.0),
+    )
+    db.add(line)
+    db.commit()
+    db.refresh(line)
+    return line
+
+
+# ── OQ-06: select-all drives the offer_ids checkboxes hx-include reads ──────────
+
+
+class TestSelectAllChecksRowCheckboxes:
+    def test_select_all_toggles_offer_id_checkboxes(self, client: TestClient, test_offer: Offer):
+        """The header select-all @change must set .checked on the row offer_ids inputs
+        so hx-include="[name='offer_ids']" actually sends them (OQ-06)."""
+        resp = client.get(
+            f"/v2/partials/requisitions/{test_offer.requisition_id}/tab/offers",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # The select-all handler now scopes to the offers form and mirrors $el.checked.
+        assert "input[name=offer_ids]" in resp.text
+        assert "c.checked = $el.checked" in resp.text
+
+    def test_create_quote_succeeds_with_offer_ids(self, client: TestClient, db_session: Session, test_offer: Offer):
+        """With offer_ids posted (what a fixed select-all produces) create-quote builds
+        a draft quote rather than 400ing."""
+        resp = client.post(
+            f"/v2/partials/requisitions/{test_offer.requisition_id}/create-quote",
+            data={"offer_ids": str(test_offer.id)},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        quote = (
+            db_session.query(Quote)
+            .filter(Quote.requisition_id == test_offer.requisition_id)
+            .order_by(Quote.id.desc())
+            .first()
+        )
+        assert quote is not None
+        assert quote.status == "draft"
+
+
+# ── OQ-12: line mutations keep the header totals in sync ────────────────────────
+
+
+class TestLineMutationsRecalcTotals:
+    def test_add_line_recalcs(self, client: TestClient, db_session: Session, draft_quote: Quote):
+        resp = client.post(
+            f"/v2/partials/quotes/{draft_quote.id}/lines",
+            data={"mpn": "LM317T", "qty": "10", "cost_price": "1.00", "sell_price": "2.00"},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(draft_quote)
+        assert draft_quote.subtotal == pytest.approx(20.0)  # 10 * 2.00
+        assert draft_quote.total_cost == pytest.approx(10.0)  # 10 * 1.00
+        assert draft_quote.total_margin_pct == pytest.approx(50.0)
+
+    def test_update_line_recalcs(self, client: TestClient, db_session: Session, draft_quote: Quote):
+        line = _add_line(db_session, draft_quote, qty=5, cost_price=1.0, sell_price=2.0)
+        resp = client.put(
+            f"/v2/partials/quotes/{draft_quote.id}/lines/{line.id}",
+            data={"qty": "10", "cost_price": "1.00", "sell_price": "3.00"},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(draft_quote)
+        assert draft_quote.subtotal == pytest.approx(30.0)  # 10 * 3.00
+        assert draft_quote.total_cost == pytest.approx(10.0)
+
+    def test_delete_line_recalcs(self, client: TestClient, db_session: Session, draft_quote: Quote):
+        keep = _add_line(db_session, draft_quote, mpn="KEEP", qty=5, cost_price=1.0, sell_price=2.0)
+        drop = _add_line(db_session, draft_quote, mpn="DROP", qty=2, cost_price=1.0, sell_price=4.0)
+        # Seed a stale header to prove the delete refreshes it.
+        draft_quote.subtotal = 999.0
+        db_session.commit()
+        resp = client.delete(
+            f"/v2/partials/quotes/{draft_quote.id}/lines/{drop.id}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(draft_quote)
+        assert draft_quote.subtotal == pytest.approx(10.0)  # only KEEP: 5 * 2.00
+        assert db_session.get(QuoteLine, drop.id) is None
+        assert db_session.get(QuoteLine, keep.id) is not None
+
+    def test_apply_markup_recalcs(self, client: TestClient, db_session: Session, draft_quote: Quote):
+        _add_line(db_session, draft_quote, qty=10, cost_price=1.0, sell_price=1.0)
+        resp = client.post(
+            f"/v2/partials/quotes/{draft_quote.id}/apply-markup",
+            data={"markup_pct": "25"},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(draft_quote)
+        # sell = cost * 1.25 = 1.25 per unit, qty 10 => subtotal 12.5
+        assert draft_quote.subtotal == pytest.approx(12.5)
+        assert draft_quote.total_cost == pytest.approx(10.0)
+
+    def test_add_offer_recalcs(self, client: TestClient, db_session: Session, draft_quote: Quote, test_offer: Offer):
+        resp = client.post(
+            f"/v2/partials/quotes/{draft_quote.id}/add-offer/{test_offer.id}",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        db_session.refresh(draft_quote)
+        # add-offer seeds sell_price=0 (buyer prices later); cost = 0.50 * 1000 = 500.
+        assert draft_quote.total_cost == pytest.approx(500.0)

--- a/tests/test_quote_send.py
+++ b/tests/test_quote_send.py
@@ -12,6 +12,7 @@ Depends on: tests/conftest.py fixtures (client, db_session, test_user, test_comp
 test_requisition, test_customer_site), SQLite test engine.
 """
 
+import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
 
@@ -95,14 +96,23 @@ def test_htmx_send_marks_sent_via_real_service(client, db_session, test_requisit
 
 
 def test_htmx_send_blocked_when_site_dnc(client, db_session, test_requisition, test_customer_site, test_user):
-    """Site-level do_not_contact blocks the send: status unchanged, rose partial back."""
+    """Site-level do_not_contact blocks the send: status unchanged, no-swap toast back.
+
+    OQ-07: the Send button targets #main-content, so the failure must NOT swap a body
+    (it would wipe the workspace). The route replies HX-Reswap=none + a showToast
+    HX-Trigger carrying the DNC message.
+    """
     test_customer_site.do_not_contact = True
     db_session.commit()
     quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-DNCS")
 
     resp = client.post(f"/v2/partials/quotes/{quote.id}/send")
     assert resp.status_code == 200
-    assert "do-not-contact" in resp.text
+    assert resp.headers.get("HX-Reswap") == "none"
+    assert resp.text == ""
+    trigger = json.loads(resp.headers["HX-Trigger"])
+    assert "do-not-contact" in trigger["showToast"]["message"]
+    assert trigger["showToast"]["type"] == "error"
     db_session.refresh(quote)
     assert quote.status == "draft"
 
@@ -123,7 +133,37 @@ def test_htmx_send_blocked_when_contact_dnc(client, db_session, test_requisition
 
     resp = client.post(f"/v2/partials/quotes/{quote.id}/send")
     assert resp.status_code == 200
-    assert "do-not-contact" in resp.text
+    assert resp.headers.get("HX-Reswap") == "none"
+    trigger = json.loads(resp.headers["HX-Trigger"])
+    assert "do-not-contact" in trigger["showToast"]["message"]
+    db_session.refresh(quote)
+    assert quote.status == "draft"
+
+
+def test_htmx_send_graph_error_is_no_swap_toast(client, db_session, test_requisition, test_customer_site, test_user):
+    """OQ-07: a Graph send failure must NOT swap a body into #main-content (which would
+    wipe the quote detail / Build-Quote workspace).
+
+    The route replies HX-Reswap=none + a showToast HX-Trigger carrying the error detail,
+    so the user stays on the page to retry.
+    """
+    from app.routers.htmx import quotes
+    from app.services.quote_send import QuoteSendError
+
+    quote = _draft_quote(db_session, test_requisition, test_customer_site, test_user, number="Q-2026-GERR")
+
+    async def _boom(db, q, user, **kwargs):
+        raise QuoteSendError("Graph send failed: mailbox unavailable")
+
+    with patch.object(quotes, "send_quote_email", new=AsyncMock(side_effect=_boom)):
+        resp = client.post(f"/v2/partials/quotes/{quote.id}/send")
+
+    assert resp.status_code == 200
+    assert resp.headers.get("HX-Reswap") == "none"
+    assert resp.text == ""
+    trigger = json.loads(resp.headers["HX-Trigger"])
+    assert "mailbox unavailable" in trigger["showToast"]["message"]
+    assert trigger["showToast"]["type"] == "error"
     db_session.refresh(quote)
     assert quote.status == "draft"
 


### PR DESCRIPTION
Fixes the offers/quotes cluster of P2 workflow-break findings from `docs/audit/2026-07-02-production-polish-review.md`. Each finding was re-verified against current `main` before acting (~40% of the audit is stale).

## OQ-06 — Select-all + "Create Quote from Selected" 400 — FIXED
The header select-all `@change` only updated the Alpine `selectedOffers` array, never the row `offer_ids` checkboxes that `hx-include="[name='offer_ids']"` reads. Select-all → Create Quote sent nothing → `400 No offers selected`. The `@change` now mirrors `$el.checked` onto the row checkboxes (scoped to `#offers-form`), matching the requisitions-list select-all pattern.

## OQ-07 — Send failure wipes the workspace — FIXED
On DNC block / Graph error `send_quote_htmx` returned a tiny error `<div>` with 200 status; because the Send buttons target `#main-content`, htmx swapped it in and destroyed the quote-detail / Build-Quote workspace. Error paths now return `HX-Reswap: none` + a `showToast` `HX-Trigger`, so the user stays put and can retry. Extracted `_send_error_toast()`.

## OQ-08 — Quote metadata edit / recent-terms have no UI callers — DESIGN_FORK
`POST /quotes/{id}/edit` and `GET /quotes/recent-terms` are genuinely orphaned. The fix is either building a brand-new terms/notes editor on quote detail or deleting the endpoints — a product/UI decision (UI Guardrails require explicit approval to add UI). Recommendation: add a terms/notes editor to `quotes/detail.html` wired to `/edit` with the `recent-terms` datalists, OR delete both endpoints if editing is intentionally builder-only.

## OQ-10 — preview_quote / delete_quote_htmx have no UI triggers — DESIGN_FORK
Both endpoints are orphaned; wiring them means adding new Preview / Delete-draft buttons (new UI), and `preview.html` renders from `quote.quote_lines` while the real email renders from `line_items` JSON (would preview the wrong content). Recommendation: add Preview + Delete-draft actions to `quotes/detail.html` and make preview render from the same source as `quote_send`, OR remove the dead endpoints.

## OQ-12 — Quote header totals drift from lines — FIXED
`add_quote_line`, `update_quote_line`, `delete_quote_line`, `add_offer_to_quote`, and `apply_markup_htmx` all mutated `QuoteLine` without refreshing `quote.subtotal / total_cost / total_margin_pct`; only `add_offers_to_draft_quote` recalced. The header and the emailed total (`quote_send.py`) drifted from the visible lines. Added one `_recalc_quote_totals()` helper (the logic already inlined in `add_offers_to_draft_quote`, now reused there too) and call it from every line-mutation handler before commit.

## Tests
- `tests/test_oq_offers_quotes_workflow.py` — select-all render assertion + create-quote regression; recalc verified on all five mutation paths.
- `tests/test_quote_send.py` — updated the two DNC cases and added a Graph-error case to the no-swap `HX-Reswap`/`showToast` contract.

`TESTING=1 pytest` on the new + neighbor suites (test_oq_offers_quotes_workflow, test_quote_send, test_sprint5_quote_workflow, test_integration_quote_workflow, test_static_analysis, test_offers_overhaul, test_phase_integration_fixes, test_quote_preflight, test_build_quote_tab, authz offers/quotes) all green. `pre-commit` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)