### PR TITLE
fix(resell): P2 workflow-breaks

### DIFF
--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -732,7 +732,10 @@ async def resell_add_line(
     excess_service._resolve_line_material_card(db, item)
     el.total_line_items = (el.total_line_items or 0) + 1
     db.commit()
-    return await resell_lines(request, list_id=list_id, user=user, db=db)
+    # Re-render the WHOLE detail (not just the Lines tab): adding the first line to a
+    # draft is what makes the header Post button appear (line_count > 0), so a Lines-only
+    # swap would leave the header stale and the user with no way to publish (RS-5).
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
 
 
 @router.post("/api/resell/{list_id}/import-preview", response_class=HTMLResponse)
@@ -790,7 +793,10 @@ async def resell_import_confirm(
     except (json.JSONDecodeError, ValueError) as exc:
         raise HTTPException(400, "Invalid import payload") from exc
     excess_service.confirm_import(db, list_id, rows)
-    return await resell_lines(request, list_id=list_id, user=user, db=db)
+    # Re-render the WHOLE detail so the header Post button appears once the draft has
+    # lines — a Lines-only swap leaves the header stale (RS-5).
+    el = excess_service.get_excess_list(db, list_id)
+    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
 
 
 @router.post("/api/resell/{list_id}/publish", response_class=HTMLResponse)
@@ -977,10 +983,20 @@ def _no_contact_buyers(db: Session, el: ExcessList, suggested_ids: set[int]) -> 
 
 
 def _buyer_panel_context(
-    request: Request, db: Session, el: ExcessList, owner: User, line_ids: list[int] | None
+    request: Request,
+    db: Session,
+    el: ExcessList,
+    owner: User,
+    line_ids: list[int] | None,
+    preselect_ids: list[int] | None = None,
 ) -> dict:
     """Context for the offer-to-buyers panel: ranked suggestions + no-contact buyers +
-    scope."""
+    scope.
+
+    ``preselect_ids`` (buyer ``vendor_card_id``s) seed the panel's checked set so a "not
+    yet offered" nudge chip lands with its buyer already selected (RS-8) — one click from
+    action instead of re-finding the buyer in the ranked list.
+    """
     suggestions = _suggestion_rows(db, el, owner, line_ids)
     suggested_ids = {row["buyer"].vendor_card_id for row in suggestions}
     scope_lines = db.query(ExcessLineItem).filter(ExcessLineItem.id.in_(line_ids)).all() if line_ids else None
@@ -993,6 +1009,7 @@ def _buyer_panel_context(
         "channels": [c.value for c in ExcessOutreachChannel],
         "line_ids": line_ids or [],
         "scope_lines": scope_lines,
+        "preselect_ids": preselect_ids or [],
     }
 
 
@@ -1030,6 +1047,7 @@ async def resell_offer_buyers_form(
     request: Request,
     list_id: int,
     line_ids: str = Query(""),
+    preselect_vendor_card_id: str = Query(""),
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
@@ -1037,15 +1055,18 @@ async def resell_offer_buyers_form(
     scope + channel.
 
     ``line_ids`` (comma-separated) scopes the campaign to specific lines; omitted = the
-    whole list. The panel reveals the buyer "who" + scorecard facts, so it is the owner's
-    private view (403 for a non-owner).
+    whole list. ``preselect_vendor_card_id`` seeds the checked set so a "not yet offered"
+    nudge chip opens the panel with that buyer already selected (RS-8). The panel reveals
+    the buyer "who" + scorecard facts, so it is the owner's private view (403 for a
+    non-owner).
     """
     el = excess_service.get_excess_list(db, list_id)
     _require_owner(el, user)
     parsed = [lid for lid in (_to_int(x) for x in line_ids.split(",")) if lid is not None] if line_ids else None
+    preselect = _to_int(preselect_vendor_card_id)
     return template_response(
         "htmx/partials/resell/offer_buyers_modal.html",
-        _buyer_panel_context(request, db, el, user, parsed),
+        _buyer_panel_context(request, db, el, user, parsed, [preselect] if preselect is not None else None),
     )
 
 

--- a/app/templates/htmx/partials/resell/_not_yet_strip.html
+++ b/app/templates/htmx/partials/resell/_not_yet_strip.html
@@ -25,10 +25,11 @@
       <p class="text-xs font-medium text-amber-800">You usually offer this to these buyers — not yet this round</p>
       <div class="mt-1.5 flex flex-wrap gap-1.5">
         {% for b in buyers %}
-        {# Each chip opens the offer panel — no scope means the whole list. #}
+        {# Each chip opens the offer panel with THIS buyer preselected (RS-8) — no scope
+           means the whole list. #}
         <button type="button"
                 @click="$dispatch('open-modal')"
-                hx-get="/v2/partials/resell/{{ el.id }}/offer-buyers-form"
+                hx-get="/v2/partials/resell/{{ el.id }}/offer-buyers-form?preselect_vendor_card_id={{ b.vendor_card_id }}"
                 hx-target="#modal-content"
                 class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-white border border-amber-300 text-amber-700 hover:bg-amber-100 transition-colors">
           {{ b.display_name }}

--- a/app/templates/htmx/partials/resell/add_line_modal.html
+++ b/app/templates/htmx/partials/resell/add_line_modal.html
@@ -1,14 +1,17 @@
 {#
   resell/add_line_modal.html — Add-one-line modal (reuses the excess add-line shape).
-  Posts to /api/resell/{id}/lines which re-renders the Lines tab body.
+  Posts to /api/resell/{id}/lines which re-renders the WHOLE detail panel so the header
+  Post button appears once the draft has lines (RS-5). The form lives in the global modal
+  (outside the detail root), so it targets the detail root by its document-wide marker
+  attribute rather than `closest`.
   Receives: list_id.
   Called by: resell.resell_add_line_form.
 #}
 <div class="p-5">
   <h3 class="text-lg font-semibold text-gray-900 mb-4">Add line</h3>
   <form hx-post="/api/resell/{{ list_id }}/lines"
-        hx-target="#tab-lines-{{ list_id }}"
-        hx-swap="innerHTML"
+        hx-target="[data-resell-detail-root]"
+        hx-swap="outerHTML"
         data-loading-disable
         @htmx:after-request.camel="if(event.detail.successful){ $dispatch('close-modal'); $store.toast.message='Line added'; $store.toast.type='success'; $store.toast.show=true; }"
         class="space-y-4">

--- a/app/templates/htmx/partials/resell/import_preview.html
+++ b/app/templates/htmx/partials/resell/import_preview.html
@@ -1,6 +1,9 @@
 {#
   resell/import_preview.html — Preview of a parsed import (reuses the excess grid).
-  Confirm → /api/resell/{id}/import-confirm (re-renders the Lines tab).
+  Confirm → /api/resell/{id}/import-confirm (re-renders the WHOLE detail so the header
+  Post button appears once the draft has lines — RS-5). A Cancel / "Try another file"
+  affordance ALWAYS renders (even for an all-errors file) so the user is never stranded
+  with no way back to the dropzone (RS-6).
   Receives: list_id, filename, valid_count, error_count, errors, preview_rows,
             all_valid_rows_json.
   Called by: resell.resell_import_preview.
@@ -52,16 +55,24 @@
   {% endif %}
   {% endif %}
 
-  {% if valid_count %}
-  <form hx-post="/api/resell/{{ list_id }}/import-confirm"
-        hx-target="#tab-lines-{{ list_id }}"
-        hx-swap="innerHTML"
-        data-loading-disable
-        @htmx:after-request.camel="$store.toast.message='Imported {{ valid_count }} lines'; $store.toast.type='success'; $store.toast.show=true;">
-    <input type="hidden" name="rows_json" value="{{ all_valid_rows_json }}">
-    <div class="flex gap-2">
+  {# Actions — the Cancel / re-upload affordance ALWAYS renders so an all-errors file
+     never dead-ends inside #import-area (RS-6). Confirm re-renders the whole detail so
+     the header Post button appears (RS-5). #}
+  <div class="flex gap-2">
+    {% if valid_count %}
+    <form hx-post="/api/resell/{{ list_id }}/import-confirm"
+          hx-target="closest [data-resell-detail-root]"
+          hx-swap="outerHTML"
+          data-loading-disable
+          @htmx:after-request.camel="$store.toast.message='Imported {{ valid_count }} lines'; $store.toast.type='success'; $store.toast.show=true;">
+      <input type="hidden" name="rows_json" value="{{ all_valid_rows_json }}">
       <button type="submit" class="btn btn-primary btn-sm">Confirm import ({{ valid_count }})</button>
-    </div>
-  </form>
-  {% endif %}
+    </form>
+    {% endif %}
+    <button type="button"
+            hx-get="/v2/partials/resell/{{ list_id }}/lines"
+            hx-target="#tab-lines-{{ list_id }}"
+            hx-swap="innerHTML"
+            class="btn btn-secondary btn-sm">{{ 'Cancel' if valid_count else 'Try another file' }}</button>
+  </div>
 </div>

--- a/app/templates/htmx/partials/resell/offer_buyers_modal.html
+++ b/app/templates/htmx/partials/resell/offer_buyers_modal.html
@@ -7,19 +7,21 @@
   not to need a JS factory.
 
   Receives: list, suggestions [{buyer: RankedBuyer, overlap}], no_contact_buyers
-            [{card}], channels (list), line_ids (list), scope_lines (or None), user.
-  Called by: resell.resell_offer_buyers_form (via the detail "Offer to buyers" action).
+            [{card}], channels (list), line_ids (list), scope_lines (or None),
+            preselect_ids (buyer vendor_card_ids to pre-check — RS-8), user.
+  Called by: resell.resell_offer_buyers_form (via the detail "Offer to buyers" action
+             and the "not yet offered" nudge chips, which pass a preselect buyer).
   Depends on: the global modal (#modal-content), $store.toast, /api/autocomplete/names.
 
-  Alpine landmines (CLAUDE.md): the |tojson seed is in a SINGLE-quoted x-data attr
-  (tojson emits double quotes); the per-row :checked / @change pass the id as a JS
-  number literal so no quoting hazard.
+  Alpine landmines (CLAUDE.md): the |tojson seeds (selected, scope) are in a SINGLE-quoted
+  x-data attr (tojson emits double quotes); the per-row :checked / @change pass the id as
+  a JS number literal so no quoting hazard.
 #}
 {% set el = list %}
 
 <div class="p-5"
      x-data='{
-       selected: [],
+       selected: {{ preselect_ids|default([])|tojson }},
        scope: {{ "per_line" | tojson if line_ids else "whole_list" | tojson }},
        channel: "email",
        query: "",

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1625,15 +1625,21 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     |        |     price-spread bar, cloned from quote_builder/modal.html, NO auto-select)
     |        +-- GET .../{id}/offer-buyers-form  (owner-only buyer panel: ranked suggestions
     |        |     [buyer_affinity_service.rank_buyers_for] + advisory overlap flag
-    |        |     [overlap_warning] + no-contact history rows + scope + channel)
+    |        |     [overlap_warning] + no-contact history rows + scope + channel;
+    |        |     ?preselect_vendor_card_id= seeds the checked set so a not-yet chip lands
+    |        |     with its buyer already selected — RS-8)
     |        +-- GET .../{id}/outreach           (owner-only Outreach tab: tracker rows +
     |        |     'offered N · M responded · K bid' summary; lazy, explicit hx-target)
     |        +-- GET .../{id}/not-yet-strip      (owner-only nudge: not_yet_offered_strip;
     |              also persists each surfaced buyer as an owner-assigned My-Day follow-up via
     |              task_service.auto_create_resell_followup_task — idempotent per list+buyer+owner)
     +-- POST /api/resell/lists                          (create → excess_service.create_excess_list)
-    +-- POST /api/resell/{id}/lines                     (add line; resolves MaterialCard)
-    +-- POST /api/resell/{id}/import-preview|import-confirm  (reuse excess parsers + preview grid)
+    +-- POST /api/resell/{id}/lines                     (add line; resolves MaterialCard;
+    |     re-renders the WHOLE detail via [data-resell-detail-root], not just Lines, so the
+    |     header Post button appears once a fresh draft has lines — RS-5)
+    +-- POST /api/resell/{id}/import-preview|import-confirm  (reuse excess parsers + preview grid;
+    |     preview ALWAYS renders a re-upload/back affordance even for an all-errors file — RS-6;
+    |     confirm re-renders the whole detail like add-line — RS-5)
     +-- POST /api/resell/{id}/publish                   (excess_mirror.publish_list → Sighting mirror)
     +-- POST /api/resell/{id}/offers                    (excess_service.submit_offer; scope
     |     per_line|take_all; service enforces can_offer + the self-offer guard)

--- a/tests/test_resell_myday_followup.py
+++ b/tests/test_resell_myday_followup.py
@@ -226,3 +226,14 @@ class TestNotYetStripRoute:
         resp = client.get(f"/v2/partials/resell/{owned_list.id}/not-yet-strip")
         assert resp.status_code == 200
         assert _tasks_for(db_session, test_user.id) == []
+
+    def test_chip_carries_preselect_buyer(self, client, db_session, monkeypatch, test_user, owned_list, buyer_card_a):
+        """RS-8: each nudge chip opens the offer panel with its buyer preselected.
+
+        The chip's hx-get must carry preselect_vendor_card_id=<buyer> so the panel lands
+        with that buyer already checked (the one-click promise), not the generic panel.
+        """
+        _stub_strip(monkeypatch, [_ranked(buyer_card_a)])
+        resp = client.get(f"/v2/partials/resell/{owned_list.id}/not-yet-strip")
+        assert resp.status_code == 200
+        assert f"preselect_vendor_card_id={buyer_card_a.id}" in resp.text

--- a/tests/test_resell_routes.py
+++ b/tests/test_resell_routes.py
@@ -371,6 +371,121 @@ def draft_list(db_session: Session, trader_user: User, test_company: Company) ->
     return el
 
 
+@pytest.fixture()
+def empty_draft_list(db_session: Session, trader_user: User, test_company: Company) -> ExcessList:
+    """A freshly-created DRAFT list with ZERO lines (the create-modal starting state).
+
+    RS-5 fixture: adding the FIRST line to this list is what should make the header Post
+    button appear.
+    """
+    el = ExcessList(
+        title="Fresh empty draft",
+        company_id=test_company.id,
+        owner_id=trader_user.id,
+        status="draft",
+        total_line_items=0,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(el)
+    db_session.commit()
+    db_session.refresh(el)
+    return el
+
+
+def test_add_line_returns_full_detail_so_post_appears(client, db_session, trader_user, empty_draft_list):
+    """RS-5: adding the first line to a draft re-renders the WHOLE detail (not just the
+    Lines tab), so the header Post button appears.
+
+    A Lines-only swap (the old behaviour) left the header stale: a freshly-created empty
+    list that just got its first lines showed no way to publish. The response must be the
+    full detail (its root marker is only in detail.html) AND carry the publish action.
+    """
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[require_user] = lambda: trader_user
+    try:
+        resp = client.post(
+            f"/api/resell/{empty_draft_list.id}/lines",
+            data={"part_number": "LM358N", "quantity": "500", "condition": "New"},
+        )
+        assert resp.status_code == 200
+        body = resp.text
+        # Only detail.html renders the root marker — a Lines-only swap would omit it.
+        assert "data-resell-detail-root" in body
+        # The header Post (publish) action now shows because the draft has a line.
+        assert f"/api/resell/{empty_draft_list.id}/publish" in body
+    finally:
+        app.dependency_overrides.pop(require_user, None)
+
+
+def test_import_confirm_returns_full_detail_so_post_appears(client, db_session, trader_user, empty_draft_list):
+    """RS-5: confirming an import re-renders the whole detail so the Post button appears."""
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[require_user] = lambda: trader_user
+    try:
+        resp = client.post(
+            f"/api/resell/{empty_draft_list.id}/import-confirm",
+            data={"rows_json": json.dumps([{"part_number": "LM358N", "quantity": 100, "condition": "New"}])},
+        )
+        assert resp.status_code == 200
+        body = resp.text
+        assert "data-resell-detail-root" in body
+        assert f"/api/resell/{empty_draft_list.id}/publish" in body
+    finally:
+        app.dependency_overrides.pop(require_user, None)
+
+
+def test_import_preview_zero_valid_rows_offers_retry(client, db_session, trader_user, empty_draft_list):
+    """RS-6: an all-errors import preview still renders a re-upload/back affordance.
+
+    The old preview only rendered the Confirm form when valid_count > 0, so an all-errors
+    file left the user stranded inside #import-area (error list only, no re-upload, no
+    cancel). The preview must always render a way back to the dropzone.
+    """
+    from app.dependencies import require_user
+    from app.main import app
+
+    csv_bytes = b"part_number,quantity\n,100\n,50\n"  # both rows blank part_number → all invalid
+    app.dependency_overrides[require_user] = lambda: trader_user
+    try:
+        resp = client.post(
+            f"/api/resell/{empty_draft_list.id}/import-preview",
+            files={"file": ("bad.csv", csv_bytes, "text/csv")},
+        )
+        assert resp.status_code == 200
+        body = resp.text
+        assert "0 valid rows" in body
+        assert "Confirm import" not in body  # nothing to confirm
+        # A re-upload/back affordance is present and returns to the lines dropzone.
+        assert "Try another file" in body
+        assert f"/v2/partials/resell/{empty_draft_list.id}/lines" in body
+    finally:
+        app.dependency_overrides.pop(require_user, None)
+
+
+def test_offer_buyers_form_preselects_buyer(client, db_session, trader_user, posted_list):
+    """RS-8: the offer-to-buyers panel seeds its checked set from preselect_vendor_card_id.
+
+    The "not yet offered" nudge chips promise to pre-fill the buyer; the panel now honours
+    a preselect param so the buyer lands already selected (one click from action) instead
+    of the generic panel with nothing checked.
+    """
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[require_user] = lambda: trader_user
+    try:
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/offer-buyers-form?preselect_vendor_card_id=777")
+        assert resp.status_code == 200
+        # The Alpine state seeds selected with the preselected card id.
+        assert "selected: [777]" in resp.text
+    finally:
+        app.dependency_overrides.pop(require_user, None)
+
+
 def test_non_owner_draft_detail_404(client, draft_list, test_user):
     """Non-owner GET on a DRAFT list → 404 (existence not revealed)."""
     # The default client user (test_user, a buyer) is NOT the owner.


### PR DESCRIPTION
Fixes the resell cluster of P2 workflow-break findings from `docs/audit/2026-07-02-production-polish-review.md`. Each finding was verified against current `main` before fixing.

## RS-5 — Post button never appears after adding the first lines — FIXED
`resell_add_line` and `resell_import_confirm` re-rendered only the Lines tab, so the header **Post** button (guarded on `line_count > 0`) stayed hidden after a fresh empty draft received its first lines — the user had no way to publish and nothing explained why. Both endpoints now re-render the **whole detail** and swap the `[data-resell-detail-root]` marker, matching the existing Post/Close/Award sibling pattern (RS-2). The add-line modal (which lives in the global modal, outside the detail root) targets the marker document-wide; the in-panel import-confirm form uses `closest [data-resell-detail-root]`.

## RS-6 — Zero-valid import preview dead-ends — FIXED
An all-errors file replaced the dropzone with just an error list inside `#import-area`, with no re-upload/cancel/back. `import_preview.html` now **always** renders a Cancel / "Try another file" button that reloads the Lines tab (restoring the dropzone), regardless of `valid_count`.

## RS-7 — Triage cards are no-op filters + double-highlight on load — DESIGN_FORK (not fixed)
Both `Offers to review` and `Take-all` cards carry `stage_key=''`, so they filter nothing (the `stage=` param only maps to `ExcessList.status`) and BOTH show the active ring on first paint (`stage` initializes `''`). The audit's own remedy is a genuine fork — give them real server-side filters (offer-based pseudo-stages like `stage=offers_pending` / `stage=take_all` via an unactioned-offer subquery, keyed off the existing `_stat_strip` counters) **or** make them non-interactive counters — and the ring fix depends on which is chosen. Recommend: real filters (the counters already exist), then only ring cards with a non-empty `stage_key`. Left for a product decision.

## RS-8 — 'Not yet offered' chips don't pre-fill the buyer — FIXED
`resell_offer_buyers_form` now accepts `preselect_vendor_card_id` and seeds the panel's Alpine `selected` set from it (single-quoted x-data, `|tojson`); the `_not_yet_strip.html` chips pass the buyer's `vendor_card_id`. The nudge is now one click from action.

## Tests
Added to `tests/test_resell_routes.py`: full-detail re-render + Post button for add-line and import-confirm (RS-5), zero-valid retry affordance (RS-6), panel preselect seed (RS-8). Added to `tests/test_resell_myday_followup.py`: chip carries the preselect param (RS-8). All pass; `tests/test_static_analysis.py` and neighboring resell suites green; `pre-commit` clean. `docs/APP_MAP_INTERACTIONS.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)