### PR TITLE
chore(config): remove 10 dead Settings fields + coupled validator (CFG-3/DC-09)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -192,15 +192,11 @@ class Settings(BaseSettings):
     # Env: ENRICHMENT_SKIP_WEB_FOR_OEM_MPNS.
     enrichment_skip_web_for_oem_mpns: bool = True
 
-    # --- Tagging ---
-    min_tag_confidence: float = 0.90
-
     # --- AI Features ---
     ai_features_enabled: str = "mike_only"  # "all", "mike_only", "off"
 
     # --- Email Intelligence ---
     email_mining_enabled: bool = False
-    email_mining_lookback_days: int = 180
     # Cap on how many mined domains (top N by inbox volume) get an eager Explorium
     # match per batch. The long tail is created unenriched and enriched on demand later.
     # This is the only metered-spend lever for the email-mining path.
@@ -237,11 +233,7 @@ class Settings(BaseSettings):
     customer_inactivity_days: int = 30
     strategic_inactivity_days: int = 90
     customer_warning_days: int = 23
-    offer_attribution_days: int = 14
     vendor_protection_warn_days: int = 60
-    vendor_protection_drop_days: int = 90
-    routing_window_hours: int = 48
-    collision_lookback_days: int = 7
 
     # --- Proactive offers ---
     proactive_matching_enabled: bool = True
@@ -262,7 +254,6 @@ class Settings(BaseSettings):
     sighting_stale_days: int = 3  # Days before a requirement is flagged stale
     buyplan_min_margin_pct: float = 10
     buyplan_nudge_buyer_hours: int = 4
-    buyplan_escalate_manager_hours: int = 8
     buyplan_nudge_ops_hours: int = 2
     buyplan_favoritism_threshold_pct: float = 60
     buyplan_better_offer_pct: float = 5
@@ -316,7 +307,6 @@ class Settings(BaseSettings):
     # On by default; degrades cleanly when HUNTER_API_KEY is absent (no key → contact
     # fetch returns [] without an outbound call — never raises).
     hunter_enrichment_enabled: bool = True  # feature gate; off → Hunter not triggered
-    hunter_cooldown_minutes: int = 15  # quota/rate-limit (402/429) circuit cooldown
 
     # --- SAM.gov Enrichment ---
     # On by default; free public API. When SAM_GOV_API_KEY is absent the connector uses
@@ -349,9 +339,6 @@ class Settings(BaseSettings):
     # Set MVP_MODE=true in .env only to suppress the Teams integration.
     mvp_mode: bool = False
 
-    # --- On-demand enrichment orchestrator ---
-    on_demand_enrichment_enabled: bool = True
-
     # --- Metrics ---
     metrics_token: str = ""  # Required token for /metrics endpoint (X-Metrics-Token header)
 
@@ -362,7 +349,6 @@ class Settings(BaseSettings):
     prospecting_enabled: bool = True
     prospecting_min_fit_for_contacts: int = 60
     prospecting_expire_days: int = 90
-    prospecting_resurface_days: int = 180
 
     # --- SP4: Account Reclamation ---
     # Nightly sweep: reassigns accounts inactive beyond the threshold from their owner
@@ -403,13 +389,6 @@ class Settings(BaseSettings):
     def validate_sample_rate(cls, v: float) -> float:
         if not 0.0 <= v <= 1.0:
             raise ValueError("Sample rate must be between 0.0 and 1.0")
-        return v
-
-    @field_validator("min_tag_confidence")
-    @classmethod
-    def validate_confidence(cls, v: float) -> float:
-        if not 0.0 <= v <= 1.0:
-            raise ValueError("Confidence/threshold must be between 0.0 and 1.0")
         return v
 
     @model_validator(mode="after")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,19 +106,6 @@ class TestSampleRateValidator:
                 _make()
 
 
-class TestConfidenceValidator:
-    """Confidence thresholds must be 0.0-1.0."""
-
-    def test_valid_confidence(self):
-        s = _settings_with({"MIN_TAG_CONFIDENCE": "0.85"})
-        assert s.min_tag_confidence == 0.85
-
-    def test_confidence_too_high(self):
-        with patch.dict(os.environ, {"MIN_TAG_CONFIDENCE": "1.5"}, clear=True):
-            with pytest.raises(ValidationError, match="Confidence/threshold must be between"):
-                _make()
-
-
 class TestCsvParsing:
     """Comma-separated env vars parse into lists correctly."""
 

--- a/tests/test_provider_quota_coverage.py
+++ b/tests/test_provider_quota_coverage.py
@@ -21,7 +21,6 @@ from app.services.enrichment_credit_guard import ProviderQuotaError
 def test_new_provider_settings_exist():
     for attr in (
         "hunter_enrichment_enabled",
-        "hunter_cooldown_minutes",
         "sam_gov_enrichment_enabled",
     ):
         assert hasattr(settings, attr), f"settings missing attribute: {attr}"


### PR DESCRIPTION
## CFG-3 / DC-09 (production-polish audit, 2026-07-02)

Ten `Settings` fields are referenced **nowhere** in app code (verified zero non-config references): `min_tag_confidence`, `email_mining_lookback_days`, `offer_attribution_days`, `vendor_protection_drop_days`, `routing_window_hours`, `collision_lookback_days`, `buyplan_escalate_manager_hours`, `hunter_cooldown_minutes`, `on_demand_enrichment_enabled`, `prospecting_resurface_days` — dead operator knobs that mislead anyone reading config.

Removed them plus the now-orphaned `@field_validator("min_tag_confidence")`. Settings uses `extra="ignore"`, so any of these still present in a deployed `.env` are harmlessly ignored — **no startup risk**. Kept `octopart_api_key` (a live connector constructor param shares the name).

Updated the two tests that asserted on the dead knobs (`TestConfidenceValidator` in `test_config.py`; the `hunter_cooldown_minutes` `hasattr` check in `test_provider_quota_coverage.py`) — both files green (31 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)