### PR TITLE
fix(settings): P2 workflow-breaks

### DIFF
--- a/app/routers/admin/spec_codes.py
+++ b/app/routers/admin/spec_codes.py
@@ -34,6 +34,7 @@ from ...models.sourcing import (
 )
 from ...schemas.spec_codes import ApproveActionBody, RejectActionBody
 from ...template_env import template_response
+from ..htmx._shared import full_page_shell
 
 router = APIRouter(tags=["admin"])
 
@@ -66,7 +67,15 @@ async def list_pending(
     user: User = Depends(require_settings_access),
     db: Session = Depends(get_db),
 ):
-    """Render the pending spec-code approval queue (HTMX partial)."""
+    """Render the pending spec-code approval queue (HTMX partial).
+
+    Settings → Data Ops "Open queue" hx-push-urls this url into history, so a full-page
+    reload / bookmark / share arrives WITHOUT the HX-Request header: serve the app shell
+    (which then HTMX-loads this same url) instead of a shell-less fragment.
+    """
+    if request.headers.get("HX-Request") != "true":
+        return full_page_shell(request, user, request.url.path, "settings")
+
     rows = db.query(OemSpecCodePending).order_by(OemSpecCodePending.discovered_at.desc()).all()
     return template_response(
         "htmx/partials/admin/spec_codes_pending.html",

--- a/app/routers/htmx/_shared.py
+++ b/app/routers/htmx/_shared.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from fastapi import Request
 from loguru import logger
 from sqlalchemy.orm import Session
+from starlette.responses import Response
 
 from ...constants import UserRole
 from ...models import User, VerificationGroupMember
@@ -82,6 +83,22 @@ def _base_ctx(request: Request, user: User, current_view: str = "") -> dict:
         "now_utc": datetime.now(timezone.utc),
         "build_commit": os.environ.get("BUILD_COMMIT", "dev"),
     }
+
+
+def full_page_shell(request: Request, user: User, partial_url: str, nav_active: str = "") -> Response:
+    """Serve the base app shell that HTMX-loads ``partial_url`` into #main-content.
+
+    Content-negotiation companion for routes whose OWN url is pushed into history (hx-
+    push-url): a full-page reload / bookmark / share of that url arrives WITHOUT the HX-
+    Request header and must receive the app shell (nav + chrome), not a bare fragment.
+    The shell's loader then re-requests the same url WITH the HX-Request header and the
+    route returns its partial. Mirrors how htmx_views.v2_page builds every /v2/* shell.
+    """
+    from ...template_env import page_response
+
+    ctx = _base_ctx(request, user, nav_active)
+    ctx["partial_url"] = partial_url
+    return page_response(ctx)
 
 
 def _parse_date_safe(val, date_cls):

--- a/app/routers/quality_plans.py
+++ b/app/routers/quality_plans.py
@@ -26,7 +26,7 @@ Depends on: app.services.quality_plan_service (validate_complete, validate_secti
 from datetime import date
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
@@ -50,6 +50,7 @@ from ..services.quality_plan_service import (
 )
 from ..template_env import template_response
 from ..utils.normalization import normalize_mpn_key
+from .htmx._shared import full_page_shell
 
 router = APIRouter(tags=["quality_plans"])
 
@@ -267,7 +268,7 @@ def qp_for_buy_plan(
     bp_id: int,
     db: Session = Depends(get_db),
     user=Depends(require_user),
-) -> HTMLResponse:
+) -> Response:
     """Get-or-create the Quality Plan for a buy plan and render its native detail.
 
     The front door to the QP view: the buy-plan owner clicks "Quality Plan" and lands
@@ -275,7 +276,16 @@ def qp_for_buy_plan(
     later open returns the same one (a buy plan has at most one QP). Ownership is scoped
     through the buy plan's parent requisition via get_buyplan_for_user, so a restricted-
     role non-owner gets a 404 (existence not leaked) before any QP is created.
+
+    This url is pushed into history (the buy-plan "Quality Plan" button hx-push-urls it),
+    so a full-page reload / bookmark / share arrives WITHOUT the HX-Request header: serve
+    the app shell (which then HTMX-loads this same url and get-or-creates the QP) instead
+    of a shell-less fragment. get-or-create runs only on the HTMX pass, keeping the
+    full-page load side-effect-free.
     """
+    if request.headers.get("HX-Request") != "true":
+        return full_page_shell(request, user, request.url.path, "buy-plans")
+
     # Ownership-scoped load (404 for missing buy plan or restricted non-owner).
     bp = get_buyplan_for_user(db, user, bp_id)
 

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2451,6 +2451,16 @@ merges different-`account_owner_id` accounts) are reused AS-IS.
   blank + emitted empty merge ids; dead). Default keep/remove direction follows
   `pair.auto_keep_id`; both buttons POST `/v2/partials/admin/company-merge`. Reached via
   `GET /v2/partials/settings/data-ops` (`require_user` + explicit `is_admin` gate).
+- **OEM Spec-Code Approvals "Open queue" (SET-07):** the Data Ops card links to the pending
+  spec-code approval queue (`GET /admin/spec-codes/pending`, `admin/spec_codes.list_pending`,
+  `require_settings_access`) with `hx-get` + `hx-push-url="true"`. Because that url is pushed
+  into history, a raw browser reload / bookmark arrives WITHOUT the `HX-Request` header — the
+  route content-negotiates (`request.headers.get("HX-Request") != "true"`) and serves the app
+  shell via `full_page_shell(request, user, request.url.path, "settings")` (`routers/htmx/
+  _shared.py`), whose `base_page.html` loader re-fires `hx-get` at this same url WITH the header
+  to paint the queue; HTMX callers still get the bare `spec_codes_pending.html` partial. Coverage:
+  `tests/routers/admin/test_spec_codes_pending.py` (HTMX pass renders the queue, full-page reload
+  serves the shell).
 - **Vendor-Duplicates loop (same template) had the identical flat-field bug** — it read
   `pair.name_a/id_a/sightings_a` while `vendor_utils.find_vendor_dedup_candidates` returns
   NESTED `{vendor_a:{id,name,sightings}, vendor_b:{…}, score}` → vendor rows rendered blank
@@ -5500,9 +5510,14 @@ has at most one QP, so a second open returns the same row (no duplicate). It re-
 with the same eager options `qp_detail` uses and renders via the shared `_qp_detail_response`,
 so the user lands on the native QP detail. The QP detail's header sub-line carries a back-link
 to the buy plan (`hx-get="/v2/partials/buy-plans/{bp.id}"`, `hx-target="#main-content"`) so the
-view is not a dead-end. Coverage: `tests/test_qp_entry.py` (create-on-first-open, idempotent
-second open, restricted-non-owner 404 with no QP created, button renders the for-buy-plan
-hx-get).
+view is not a dead-end. **Full-page reload / bookmark (SET-05):** the button `hx-push-url`s this
+url into history, so a raw browser reload arrives WITHOUT the `HX-Request` header — the route
+content-negotiates (`request.headers.get("HX-Request") != "true"`) and serves the app shell via
+`full_page_shell(request, user, request.url.path, "buy-plans")` (`routers/htmx/_shared.py`), whose
+`base_page.html` loader re-fires `hx-get` at this same url WITH the header to paint the QP; the
+non-HTMX pass is side-effect-free (get-or-create runs only on the HTMX pass). Coverage:
+`tests/test_qp_entry.py` (create-on-first-open, idempotent second open, restricted-non-owner 404
+with no QP created, button renders the for-buy-plan hx-get, full-page reload serves the shell).
 
 **QP section gates — Sales / Purchasing (QP Phase C2a):** the QualityPlan is the engine
 subject (`subject_type='quality_plan'`); the `gate_type` discriminates the section.

--- a/tests/routers/admin/test_spec_codes_pending.py
+++ b/tests/routers/admin/test_spec_codes_pending.py
@@ -79,10 +79,30 @@ def pending_row(db_session: Session) -> OemSpecCodePending:
 # ── Tests ─────────────────────────────────────────────────────────────
 
 
+# HTMX navigations send this header; list_pending content-negotiates on it (bare partial
+# for HTMX callers, full app shell for a raw browser reload/bookmark of the pushed url).
+_HX = {"HX-Request": "true"}
+
+
 def test_list_pending_returns_200(client_with_settings_user, pending_row):
-    resp = client_with_settings_user.get("/admin/spec-codes/pending")
+    resp = client_with_settings_user.get("/admin/spec-codes/pending", headers=_HX)
     assert resp.status_code == 200
     assert b"SPREJ" in resp.content
+
+
+def test_list_pending_full_page_reload_serves_shell(client_with_settings_user, pending_row):
+    """SET-07: Settings → Data Ops 'Open queue' hx-push-urls /admin/spec-codes/pending, so
+    a raw browser reload / bookmark of that url (no HX-Request header) must render the full
+    app shell that HTMX-loads the queue — not a shell-less fragment."""
+    resp = client_with_settings_user.get("/admin/spec-codes/pending")  # no HX-Request
+    assert resp.status_code == 200
+    body = resp.content.decode()
+    # App shell: the #main-content mount + a loader that points back at this same url.
+    assert 'id="main-content"' in body
+    assert 'hx-get="/admin/spec-codes/pending"' in body
+    assert 'hx-trigger="load"' in body
+    # The queue partial itself has NOT been rendered inline (it loads via the HTMX pass).
+    assert "SPREJ" not in body
 
 
 def test_approve_promotes_to_oem_spec_codes(client_with_settings_user, pending_row, db_session, admin_user):
@@ -455,7 +475,7 @@ def test_pending_list_strips_javascript_url_from_citations(client_with_settings_
     )
     db_session.commit()
 
-    resp = client_with_settings_user.get("/admin/spec-codes/pending")
+    resp = client_with_settings_user.get("/admin/spec-codes/pending", headers=_HX)
     assert resp.status_code == 200
     body = resp.content.decode()
 

--- a/tests/test_qp_entry.py
+++ b/tests/test_qp_entry.py
@@ -30,6 +30,10 @@ from app.models.quality_plan import QualityPlan
 from app.models.quotes import Quote
 from app.models.sourcing import Requisition
 
+# HTMX navigations send this header; the for-buy-plan route content-negotiates on it
+# (bare partial for HTMX callers, full app shell for a raw browser reload/bookmark).
+_HX = {"HX-Request": "true"}
+
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
 
@@ -131,7 +135,7 @@ def test_for_buy_plan_creates_qp_on_first_open(client, db_session: Session, test
     bp = _seed_buy_plan(db_session, test_user.id, test_customer_site.id)
     assert _qp_count(db_session, bp.id) == 0
 
-    resp = client.get(f"/v2/qp/for-buy-plan/{bp.id}")
+    resp = client.get(f"/v2/qp/for-buy-plan/{bp.id}", headers=_HX)
     assert resp.status_code == 200
 
     qps = _qps_for(db_session, bp.id)
@@ -147,11 +151,11 @@ def test_for_buy_plan_is_idempotent(client, db_session: Session, test_user, test
     """A second open returns the SAME qp.id and creates no duplicate row."""
     bp = _seed_buy_plan(db_session, test_user.id, test_customer_site.id)
 
-    resp1 = client.get(f"/v2/qp/for-buy-plan/{bp.id}")
+    resp1 = client.get(f"/v2/qp/for-buy-plan/{bp.id}", headers=_HX)
     assert resp1.status_code == 200
     qp_id_1 = _qps_for(db_session, bp.id)[0].id
 
-    resp2 = client.get(f"/v2/qp/for-buy-plan/{bp.id}")
+    resp2 = client.get(f"/v2/qp/for-buy-plan/{bp.id}", headers=_HX)
     assert resp2.status_code == 200
 
     qps = _qps_for(db_session, bp.id)
@@ -162,7 +166,7 @@ def test_for_buy_plan_is_idempotent(client, db_session: Session, test_user, test
 
 def test_for_buy_plan_missing_buy_plan_404(client):
     """A non-existent buy plan returns 404 (no QP to create)."""
-    resp = client.get("/v2/qp/for-buy-plan/999999")
+    resp = client.get("/v2/qp/for-buy-plan/999999", headers=_HX)
     assert resp.status_code == 404
 
 
@@ -176,7 +180,7 @@ def test_for_buy_plan_ownership_404_for_restricted_non_owner(
     """
     bp = _seed_buy_plan(db_session, test_user.id, test_customer_site.id)
 
-    resp = restricted_client.get(f"/v2/qp/for-buy-plan/{bp.id}")
+    resp = restricted_client.get(f"/v2/qp/for-buy-plan/{bp.id}", headers=_HX)
     assert resp.status_code == 404
     # Ownership is enforced before create — no QP row leaks into existence.
     assert _qp_count(db_session, bp.id) == 0
@@ -191,3 +195,27 @@ def test_buy_plan_detail_renders_quality_plan_button(client, db_session: Session
     body = resp.text
     assert "Quality Plan" in body
     assert f"/v2/qp/for-buy-plan/{bp.id}" in body
+
+
+def test_for_buy_plan_full_page_reload_serves_shell(client, db_session: Session, test_user, test_customer_site):
+    """SET-05: the 'Quality Plan' button hx-push-urls /v2/qp/for-buy-plan/{id}, so a raw
+    browser reload / bookmark of that url (no HX-Request header) must render the full app
+    shell that HTMX-loads the QP — not a shell-less fragment.
+
+    The shell pass must also be side-effect-free: get-or-create runs only when the shell's
+    loader re-requests WITH the HX-Request header.
+    """
+    bp = _seed_buy_plan(db_session, test_user.id, test_customer_site.id)
+    assert _qp_count(db_session, bp.id) == 0
+
+    resp = client.get(f"/v2/qp/for-buy-plan/{bp.id}")  # no HX-Request → full page
+    assert resp.status_code == 200
+    body = resp.text
+    # App shell: the #main-content mount + a loader that points back at this same url.
+    assert 'id="main-content"' in body
+    assert f'hx-get="/v2/qp/for-buy-plan/{bp.id}"' in body
+    assert 'hx-trigger="load"' in body
+    # The QP partial has NOT been rendered inline (it loads via the HTMX pass)...
+    assert "Quality Plan #" not in body
+    # ...and no QP row was created by the side-effect-free full-page load.
+    assert _qp_count(db_session, bp.id) == 0


### PR DESCRIPTION
## Settings cluster P2 workflow-breaks (docs/audit/2026-07-02-production-polish-review.md)

Both fixed findings are the same bug class: a **partial-only route whose own url is pushed into history** (`hx-push-url`) returns a shell-less fragment on browser reload / bookmark / share, because the route serves the bare partial unconditionally (no `HX-Request` branch) and no full-page shell handler exists for the pushed url.

**Root-cause fix (no band-aid):** content-negotiate on the `HX-Request` header — the pattern already used by `crm/enrichment.py`. New shared helper `full_page_shell()` (`app/routers/htmx/_shared.py`) serves `base_page.html` (nav + chrome) whose loader re-fires `hx-get` at the same url WITH the header to paint the partial, mirroring how `htmx_views.v2_page` builds every `/v2/*` shell.

### Findings

| ID | Status | Notes |
|----|--------|-------|
| **SET-05** — Quality Plan button pushes `/v2/qp/for-buy-plan/{id}` with no full-page shell | **FIXED_NOW** | `quality_plans.qp_for_buy_plan` now serves the shell on a non-HTMX load; get-or-create runs only on the HTMX pass, so the full-page load is side-effect-free. |
| **SET-06** — "Manage connectors" capability gates almost nothing | **DESIGN_FORK** | `MANAGE_CONNECTORS` is advertised in the Access editor but only gates `POST /api/sources/{id}/test`; the Connectors tab + activate/credentials hard-gate `role==ADMIN`. Fixing = a product/security decision (extend the capability to gate the tab/activate/credentials vs. drop the key from `CAPABILITY_ACCESS_KEYS`). Not guessed. |
| **SET-07** — Data Ops "Open queue" pushes `/admin/spec-codes/pending` (partial-only) | **FIXED_NOW** | `admin/spec_codes.list_pending` now serves the shell on a non-HTMX load; HTMX callers still get the bare queue partial. |

### Tests
- New: full-page-reload-serves-shell tests for both routes (assert `#main-content` mount + loader `hx-get` back at the same url + no inline partial content + no side effects).
- Updated: existing behavioral tests for both routes now send `HX-Request` (they exercise the partial/business path, which is where the logic now lives).
- `tests/test_qp_entry.py` + `tests/routers/admin/test_spec_codes_pending.py` + `tests/test_static_analysis.py`: **48 passed**. QP/authz neighbors green.
- `pre-commit` (ruff, ruff-format, docformatter, mypy) clean.
- `docs/APP_MAP_INTERACTIONS.md` updated for both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)