### PR TITLE
fix(misc-critic): P2 workflow-breaks

### DIFF
--- a/app/routers/htmx/offers.py
+++ b/app/routers/htmx/offers.py
@@ -12,6 +12,7 @@ Depends on: app.models, app.dependencies, app.database, app.services, ._shared
     re-renders the requisition offers tab).
 """
 
+import json
 import os
 from datetime import datetime, timedelta, timezone
 
@@ -1240,13 +1241,14 @@ async def rfq_send(
     return template_response("htmx/partials/requisitions/rfq_results.html", ctx)
 
 
-@router.get("/v2/partials/follow-ups", response_class=HTMLResponse)
-async def follow_ups_list_partial(
-    request: Request,
-    user: User = Depends(require_user),
-    db: Session = Depends(get_db),
-):
-    """Cross-requisition follow-up queue as HTML partial."""
+def _build_follow_ups_ctx(request: Request, user: User, db: Session) -> dict:
+    """Build the cross-requisition follow-up queue template context.
+
+    Shared by the list partial and the batch-send re-render so both surfaces render the
+    SAME queue (same threshold, same per-owner scope). Extracted so send-batch can
+    return the refreshed list instead of a bare success div that replaced the whole
+    page.
+    """
     from ...config import settings
     from ...models.offers import Contact as RfqContact
 
@@ -1268,9 +1270,7 @@ async def follow_ups_list_partial(
         for r in db.query(Requisition.id, Requisition.name).filter(Requisition.id.in_(req_ids)).all():
             req_names[r.id] = r.name
 
-    from datetime import timezone as tz
-
-    now = datetime.now(tz.utc)
+    now = datetime.now(timezone.utc)
     follow_ups = []
     for c in stale:
         ca = c.created_at if c.created_at else now
@@ -1290,6 +1290,17 @@ async def follow_ups_list_partial(
 
     ctx = _base_ctx(request, user, "follow-ups")
     ctx.update({"follow_ups": follow_ups, "total": len(follow_ups)})
+    return ctx
+
+
+@router.get("/v2/partials/follow-ups", response_class=HTMLResponse)
+async def follow_ups_list_partial(
+    request: Request,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Cross-requisition follow-up queue as HTML partial."""
+    ctx = _build_follow_ups_ctx(request, user, db)
     return template_response("htmx/partials/follow_ups/list.html", ctx)
 
 
@@ -1800,10 +1811,15 @@ async def send_batch_follow_up(
     db.commit()
     logger.info("Batch follow-up: {} contacts marked by {}", sent_count, user.email)
 
+    # Re-render the (now shorter / empty) queue so the surrounding page survives —
+    # the button targets #main-content, and returning a bare success div here used
+    # to wipe the whole list, stranding the user on a one-line message. The success
+    # count is surfaced via an HX-Trigger toast instead (base.html showToast bridge).
     msg = f"{sent_count} contact{'s' if sent_count != 1 else ''} marked as responded."
-    return HTMLResponse(
-        f'<div class="text-sm text-green-700 bg-green-50 border border-green-200 rounded-lg px-3 py-2">{msg}</div>'
-    )
+    ctx = _build_follow_ups_ctx(request, user, db)
+    resp = template_response("htmx/partials/follow_ups/list.html", ctx)
+    resp.headers["HX-Trigger"] = json.dumps({"showToast": {"message": msg, "type": "success"}})
+    return resp
 
 
 @router.get("/v2/partials/follow-ups/badge", response_class=HTMLResponse)

--- a/app/templates/htmx/partials/shared/topbar.html
+++ b/app/templates/htmx/partials/shared/topbar.html
@@ -30,6 +30,7 @@
              hx-target="#global-search-results"
              @focus="searchOpen = true"
              @blur="setTimeout(() => searchOpen = false, 200)"
+             @keydown.enter.prevent="searchOpen = true; htmx.ajax('POST', '/v2/partials/search/ai', {target: '#global-search-results', indicator: '#global-search-results', values: {q: $el.value}, source: $el})"
              @keydown.escape="$el.blur(); searchOpen = false">
     </div>
     <div id="global-search-results"

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2326,7 +2326,10 @@ REUSING the helpers above (no new ad-hoc checks):
 - `htmx_views`: `sourcing_search_trigger` (connector spend) + `ai_rephrase_email` gated on
   `require_requisition_access`; `send_batch_follow_up` and `follow_up_badge` scope the stale-
   `RfqContact` query for `RESTRICTED_ROLES` (join `Requisition`, filter `created_by == user.id`)
-  so the badge matches what the batch acts on.
+  so the badge matches what the batch acts on. `send_batch_follow_up` re-renders the shared
+  `follow_ups/list.html` (via `_build_follow_ups_ctx`, the same builder the list partial uses)
+  so the "Send All" swap into `#main-content` leaves the refreshed queue intact instead of a
+  bare success div, and surfaces the count through an `HX-Trigger: showToast`.
 - `crm.quotes.create_quote` (`POST /api/requisitions/{req_id}/quote`) — `offer_ids` filtered to
   `Offer.requisition_id == req_id` (400 on any mismatch) and the `on_quote_built` requirement-
   advance query filtered the same way, so foreign offers can't enter the quote or advance another

--- a/tests/test_follow_up_batch_render.py
+++ b/tests/test_follow_up_batch_render.py
@@ -1,0 +1,90 @@
+"""F5 regression: 'Send All' must NOT wipe the follow-up queue.
+
+The batch button targets #main-content. It used to return a bare
+'<div>N marked as responded</div>' success fragment, which replaced the entire
+main-content region — leaving the user on a one-line message with no list, no
+heading, and no next action. The handler now re-renders the (now shorter/empty)
+follow_ups/list.html so the surrounding page survives, and surfaces the count via
+an HX-Trigger showToast the base layout renders.
+
+Called by: pytest
+Depends on: app.routers.htmx.offers, conftest fixtures
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.models.offers import Contact as RfqContact
+from app.models.sourcing import Requisition
+
+
+def _stale_contact(db, user, name: str, days: int = 5) -> None:
+    req = Requisition(name=f"FU-{name}", customer_name="FU Co", status="open")
+    db.add(req)
+    db.flush()
+    db.add(
+        RfqContact(
+            requisition_id=req.id,
+            user_id=user.id,
+            contact_type="email",
+            vendor_name=name,
+            vendor_contact=f"{name.lower()}@example.com",
+            status="sent",
+            created_at=datetime.now(timezone.utc) - timedelta(days=days),
+        )
+    )
+    db.commit()
+
+
+def test_send_batch_rerenders_list_not_bare_div(client: TestClient, db_session, test_user):
+    """Batch send returns the re-rendered queue (page survives), not a bare success
+    div."""
+    _stale_contact(db_session, test_user, "AlphaVendor")
+    _stale_contact(db_session, test_user, "BetaVendor")
+
+    resp = client.post("/v2/partials/follow-ups/send-batch")
+    assert resp.status_code == 200
+
+    # The queue shell is re-rendered — after marking all stale contacts responded the
+    # queue is empty, so the empty-state (still part of the list partial) shows. The key
+    # regression assertion: the whole list template came back, not a lone success line.
+    assert "No follow-ups needed!" in resp.text
+    assert "needing follow-up" in resp.text
+    # The count message moved OUT of the swapped body and into the toast trigger.
+    assert "marked as responded" not in resp.text
+
+
+def test_send_batch_emits_showtoast_trigger(client: TestClient, db_session, test_user):
+    """The success count is surfaced via an HX-Trigger showToast, not the swapped
+    body."""
+    _stale_contact(db_session, test_user, "GammaVendor")
+    _stale_contact(db_session, test_user, "DeltaVendor")
+
+    resp = client.post("/v2/partials/follow-ups/send-batch")
+    assert resp.status_code == 200
+
+    trigger = json.loads(resp.headers["HX-Trigger"])
+    assert "showToast" in trigger
+    assert "marked as responded" in trigger["showToast"]["message"]
+    assert trigger["showToast"]["type"] == "success"
+
+
+def test_send_batch_actually_marks_contacts(client: TestClient, db_session, test_user):
+    """Sanity: the batch still marks stale contacts responded (queue empties afterward)."""
+    _stale_contact(db_session, test_user, "EpsilonVendor")
+    _stale_contact(db_session, test_user, "ZetaVendor")
+
+    # Before: queue lists both vendors.
+    before = client.get("/v2/partials/follow-ups")
+    assert "EpsilonVendor" in before.text
+    assert "ZetaVendor" in before.text
+
+    client.post("/v2/partials/follow-ups/send-batch")
+
+    # After: queue is empty (both marked responded).
+    after = client.get("/v2/partials/follow-ups")
+    assert "EpsilonVendor" not in after.text
+    assert "ZetaVendor" not in after.text
+    assert "No follow-ups needed!" in after.text

--- a/tests/test_topbar_ai_search_enter.py
+++ b/tests/test_topbar_ai_search_enter.py
@@ -1,0 +1,51 @@
+"""shell-03 regression: the global-search 'Press Enter for AI-powered search' hint
+must actually be wired.
+
+The no-results state (search_results.html) tells the user to press Enter for AI
+search, and POST /v2/partials/search/ai is fully built — but the topbar input had
+no Enter handler, so the endpoint was reachable only from tests and the hint was
+dead. The topbar input now wires @keydown.enter to an htmx.ajax POST against the AI
+endpoint, targeting the same #global-search-results dropdown as type-ahead.
+
+Called by: pytest
+Depends on: app.template_env.templates, app.routers.htmx_views.ai_search_endpoint
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from app.template_env import templates
+
+
+def _render_topbar() -> str:
+    return templates.get_template("htmx/partials/shared/topbar.html").render(user_name="Tester")
+
+
+def test_topbar_wires_enter_to_ai_search():
+    """The search input fires the AI endpoint on Enter (fulfilling the hint)."""
+    html = _render_topbar()
+    assert "@keydown.enter" in html
+    assert "/v2/partials/search/ai" in html
+
+
+def test_topbar_ai_search_targets_results_dropdown():
+    """Enter posts into the same dropdown type-ahead uses, and sends the query."""
+    html = _render_topbar()
+    # The Enter handler must target the global-search results container and pass the
+    # current input value as q so the endpoint (q: str = Form("")) receives it.
+    assert "target: '#global-search-results'" in html
+    assert "q: $el.value" in html
+
+
+def test_ai_search_endpoint_still_serves(client, db_session):
+    """The endpoint the hint now reaches responds 200 (safe Claude-unavailable path)."""
+    with (
+        patch(
+            "app.services.global_search_service.claude_structured",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch("app.services.global_search_service._get_ai_cache", return_value=None),
+        patch("app.services.global_search_service._set_ai_cache"),
+    ):
+        resp = client.post("/v2/partials/search/ai", data={"q": "LM358"})
+    assert resp.status_code == 200


### PR DESCRIPTION
Fixes the **misc-critic** cluster of P2 workflow-break findings from `docs/audit/2026-07-02-production-polish-review.md`. Each finding was verified against current `main` before touching anything (the audit is an older snapshot).

## Findings

### F5 — 'Send All' swaps into #main-content and wipes the follow-ups list — **FIXED**
`send_batch_follow_up` returned a bare `<div>N marked as responded</div>` into `#main-content`, replacing the entire main region — after the action the page showed one floating success line with no list, heading, or next action. Now re-renders the shared `follow_ups/list.html` (the now-shorter/empty queue) so the surrounding page survives, and surfaces the count via `HX-Trigger: showToast`. Extracted `_build_follow_ups_ctx` so the list partial and the batch re-render share one builder (same threshold + per-owner scope).
Test: `tests/test_follow_up_batch_render.py`.

### shell-03 — Global search's "Press Enter for AI-powered search" hint is dead — **FIXED**
The no-results hint promised AI search on Enter and `POST /v2/partials/search/ai` was fully built (Claude Haiku intent parse, safe fallback to `fast_search`), but nothing handled Enter — the endpoint was reachable only from tests. Wired the topbar input's `@keydown.enter` to `htmx.ajax` the AI endpoint into `#global-search-results`. This matches the flow `docs/APP_MAP_INTERACTIONS.md` already documented ("Pressing Enter posts `/v2/partials/search/ai`").
Test: `tests/test_topbar_ai_search_enter.py`.

### QP-3 — Inline Reject with a cancelled/blank prompt silently does nothing — **ALREADY FIXED**
The reject `POST` returns a 400 JSON `{"error": ...}` (`approvals.py` post_decision) and the global `htmx:responseError` handler (`htmx_app.js:507-522`) parses `body.error` and shows an error toast on any 4xx. A blank/cancelled reject prompt now surfaces "reject requires a non-blank comment" as a toast — no longer a silent, inert button. No change needed.

### PROACTIVE-04 — Prepare page silently blocks Send when no emailable contact exists — **DESIGN FORK**
Confirmed live (`prepare.html:203` `:disabled="contactCount === 0"`; email-less contacts render disabled). The complete fix (a recovery path — inline add-contact form vs. link to a canonical customer-contacts surface, and whether/how to preserve the in-progress offer prep) requires a product decision; a bare explanatory hint with no recovery would be a band-aid. **Recommendation:** add an explanatory hint next to the disabled Send plus a deep-link to the customer's contacts surface (customer detail Contacts tab) that returns to Prepare, or gate entry to Prepare when the site has no emailable contact.

## Tests
`test_follow_up_batch_render.py` (3) + `test_topbar_ai_search_enter.py` (3) pass; neighbors green (`test_follow_up_threshold`, `test_ai_search`, `test_qp_view`, `test_approvals_routes`) and `test_static_analysis.py` (htmx-ajax indicator ratchet) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)