### PR TITLE
docs(env): document all Settings fields in .env.example + completeness guard (CFG-6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,3 +128,170 @@ ACCOUNT_SWEEP_ENABLED=false
 ACCOUNT_SWEEP_INACTIVITY_DAYS=90
 ACCOUNT_SWEEP_MANAGER_EMAIL=
 ACCOUNT_REACTIVATION_SWEEP_ENABLED=true
+
+# ══════════════════════════════════════════════════════════════════
+# Additional settings — feature flags, tunables & integrations.
+# All optional: each falls back to the code default in app/config.py when unset.
+# Shown with their default values (secrets/IDs left blank to fill in).
+# ══════════════════════════════════════════════════════════════════
+
+# ── Core ──
+SECRET_KEY=change-me-in-production
+
+# ── Sentry ──
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1
+SENTRY_PROFILES_SAMPLE_RATE=0.1
+
+# ── Rate limiting ──
+RATE_LIMIT_DEFAULT=120/minute
+RATE_LIMIT_ENABLED=true
+
+# ── Cross-app alerts ──
+ALERT_RECENCY_DAYS=30
+ALERTS_EPOCH=
+
+# ── Redis ──
+CACHE_BACKEND=redis
+
+# ── Microsoft Azure OAuth ──
+DATASHEET_LIBRARY_DRIVE_ID=
+DATASHEET_LIBRARY_SUBPATH=Datasheets
+
+# ── Nexar (Octopart) ──
+OCTOPART_API_KEY=
+
+# ── OEM Spec Code Resolver ──
+SPEC_RESOLVER_ENABLED=false
+SPEC_RESOLVER_MIN_CONFIDENCE=0.3
+SPEC_RESOLVER_MODEL_TIER=opus
+
+# ── Agent service-to-service auth ──
+AGENT_API_KEY=
+
+# ── Explorium / Vibe Prospecting ──
+EXPLORIUM_API_BASE_URL=https://api.explorium.ai
+EXPLORIUM_ENRICHMENT_ENABLED=false
+EXPLORIUM_COOLDOWN_MINUTES=15
+
+# ── Customer enrichment ──
+CUSTOMER_ENRICHMENT_ENABLED=true
+CUSTOMER_ENRICHMENT_COOLDOWN_DAYS=90
+CUSTOMER_ENRICHMENT_CONTACTS_PER_ACCOUNT=5
+
+# ── Material card AI enrichment ──
+MPN_DECODE_ENABLED=true
+DESC_PARSE_ENABLED=true
+PARTSURFER_DESC_ENABLED=true
+CONNECTOR_DESC_HARVEST_ENABLED=true
+EBAY_TITLE_MINING_ENABLED=true
+PARTSURFER_FETCH_PER_BATCH=5
+FRU_CROSSWALK_ENRICH_ENABLED=true
+FRU_CROSSWALK_DRIVE_PN_DECODE_ENABLED=true
+OEM_CROSSWALK_ENRICH_ENABLED=true
+ENRICHMENT_LANE_SPLIT_ENABLED=true
+ENRICHMENT_SKIP_WEB_FOR_OEM_MPNS=true
+
+# ── AI Features ──
+AI_FEATURES_ENABLED=mike_only
+
+# ── Email Intelligence ──
+EMAIL_MINING_ENRICH_CAP=25
+EMAIL_MINING_BATCH_DAILY_CAP=1000
+
+# ── M365 Integration v2 ──
+INBOX_SCAN_INTERVAL_MIN=30
+DIGEST_COOLDOWN_SECONDS=120
+INBOX_BACKFILL_DAYS=180
+CONTACTS_SYNC_ENABLED=true
+
+# ── Admin (CSV env var, parsed to list[str] by model_validator) ──
+ENABLE_USER_ALLOWLIST=true
+
+# ── RFQ ──
+FOLLOW_UP_DAYS=3
+
+# ── Activity tracking & customer ownership ──
+ACTIVITY_TRACKING_ENABLED=true
+OWNERSHIP_SWEEP_ENABLED=false
+CUSTOMER_INACTIVITY_DAYS=30
+STRATEGIC_INACTIVITY_DAYS=90
+CUSTOMER_WARNING_DAYS=23
+VENDOR_PROTECTION_WARN_DAYS=60
+
+# ── Proactive offers ──
+PROACTIVE_MATCHING_ENABLED=true
+PROACTIVE_THROTTLE_DAYS=21
+PROACTIVE_SCAN_INTERVAL_HOURS=4
+PROACTIVE_MIN_MARGIN_PCT=10.0
+PROACTIVE_MATCH_EXPIRY_DAYS=30
+
+# ── Buy plan (CSV env vars, parsed to list[str] by model_validator) ──
+STOCK_SALE_VENDOR_NAMES=trio,trio supply chain,stock,internal
+STOCK_SALE_NOTIFY_EMAILS=logistics@trioscs.com,accounting@trioscs.com
+BUYPLAN_AUTO_COMPLETE_HOUR=18
+BUYPLAN_AUTO_COMPLETE_TZ=America/New_York
+PO_VERIFY_INTERVAL_MIN=30
+
+# ── Buy Plan V3 ──
+BUYPLAN_STALE_OFFER_DAYS=5
+SIGHTING_STALE_DAYS=3
+BUYPLAN_MIN_MARGIN_PCT=10
+BUYPLAN_NUDGE_BUYER_HOURS=4
+BUYPLAN_NUDGE_OPS_HOURS=2
+BUYPLAN_FAVORITISM_THRESHOLD_PCT=60
+BUYPLAN_BETTER_OFFER_PCT=5
+PO_AUTO_APPROVE_THRESHOLD=5000
+
+# ── Vendor-part unavailability ("Two Windows, Real Proof" temporal policy) ──
+UNAVAILABILITY_SUPPRESS_DAYS=30
+UNAVAILABILITY_LISTING_SUPPRESS_DAYS=180
+UNAVAILABILITY_QTY_JUMP_FACTOR=2.0
+
+# ── Search ──
+SEARCH_CONCURRENCY_LIMIT=10
+SEARCH_TOTAL_TIMEOUT_S=12.0
+
+# ── Contact intelligence ──
+CONTACT_SCORING_ENABLED=true
+CONTACT_NUDGE_DORMANT_DAYS=30
+CONTACT_NUDGE_COOLING_DAYS=14
+
+# ── Own company domains (CSV env var, parsed to frozenset[str] by model_validator) ──
+OWN_DOMAINS=trioscs.com
+
+# ── Lusha Enrichment (key via get_credential_cached, NOT a Settings field) ──
+LUSHA_ENRICHMENT_ENABLED=false
+LUSHA_COOLDOWN_MINUTES=15
+PROSPECT_ENRICH_CONTACTS_PER_ACCOUNT=5
+
+# ── Hunter.io Enrichment ──
+HUNTER_ENRICHMENT_ENABLED=true
+
+# ── SAM.gov Enrichment ──
+SAM_GOV_ENRICHMENT_ENABLED=true
+
+# ── Worker liveness watchdog (scheduler job in the supervised app) ──
+WORKER_LIVENESS_CHECK_MINUTES=5
+WORKER_HEARTBEAT_STALE_MINUTES=15
+WORKER_ALERT_DEBOUNCE_MINUTES=60
+
+# ── Clay Enrichment (MCP connector; CLAY_API_KEY via credential store) ──
+CLAY_ENRICHMENT_ENABLED=false
+CLAY_COOLDOWN_MINUTES=15
+
+# ── Azure Communication Services ──
+ACS_CONNECTION_STRING=
+ACS_FROM_PHONE=
+ACS_CALLBACK_URL=
+
+# ── MVP Mode ──
+MVP_MODE=false
+
+# ── Backup monitoring ──
+BACKUP_MAX_AGE_HOURS=26
+
+# ── Prospecting ──
+PROSPECTING_ENABLED=true
+PROSPECTING_MIN_FIT_FOR_CONTACTS=60
+PROSPECTING_EXPIRE_DAYS=90

--- a/tests/test_env_example_complete.py
+++ b/tests/test_env_example_complete.py
@@ -1,0 +1,50 @@
+"""CFG-6 — .env.example must document every Settings field (no silent drift).
+
+The audit found .env.example documented ~40 of ~143 settings, so operators had no
+reference for the majority of feature flags and tunables. This guard fails the moment a
+new Settings field is added without a matching .env.example entry, keeping the reference
+complete going forward.
+
+Called by: pytest
+Depends on: app.config.Settings, .env.example (repo root).
+"""
+
+import re
+from pathlib import Path
+
+from app.config import Settings
+
+# Fields that PR #670 removes from Settings — intentionally NOT documented. Once #670
+# merges these no longer exist on Settings, so this set becomes a harmless no-op; drop it.
+_PENDING_REMOVAL = {
+    "min_tag_confidence",
+    "email_mining_lookback_days",
+    "offer_attribution_days",
+    "vendor_protection_drop_days",
+    "routing_window_hours",
+    "collision_lookback_days",
+    "buyplan_escalate_manager_hours",
+    "hunter_cooldown_minutes",
+    "on_demand_enrichment_enabled",
+    "prospecting_resurface_days",
+}
+
+
+def _documented_keys() -> set[str]:
+    env_example = Path(__file__).resolve().parent.parent / ".env.example"
+    keys = set()
+    for line in env_example.read_text().splitlines():
+        m = re.match(r"^\s*#?\s*([A-Z][A-Z0-9_]+)\s*=", line)
+        if m:
+            keys.add(m.group(1).lower())
+    return keys
+
+
+def test_env_example_documents_every_settings_field():
+    fields = set(Settings.model_fields)
+    documented = _documented_keys()
+    missing = sorted(f for f in fields if f not in documented and f not in _PENDING_REMOVAL)
+    assert not missing, (
+        "These app/config.py Settings fields are undocumented in .env.example: "
+        f"{missing}. Add each as `UPPERCASE_NAME=<default>` under the matching section."
+    )


### PR DESCRIPTION
## CFG-6 (production-polish audit, 2026-07-02)

`.env.example` documented only **40 of 143** `Settings` fields — operators had no reference for the majority of feature flags and tunables at go-live.

- Added the **~93 missing vars**, grouped by `app/config.py`'s own sections, each with its code default (secrets/IDs left blank to fill in). Excludes the 10 dead fields PR #670 removes.
- Added `tests/test_env_example_complete.py` — **fails if any `Settings` field lacks a `.env.example` entry**, so the reference can't silently drift again (the root cause). The `_PENDING_REMOVAL` allowlist covers the 10 fields #670 deletes and becomes a no-op once that merges.

Docs + one guard test; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)