### PR TITLE
chore(fe): remove dead .opp-* CSS + fix stale coverage_meter comment (FE-3)

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -212,29 +212,10 @@
 .opp-time--72h    { color: var(--opp-urgency-72h-text); }
 .opp-time--normal { color: var(--opp-text-tertiary); }
 
-.opp-mpn {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--opp-text-primary);
-  font-variant-numeric: tabular-nums;
-  display: block;
-}
-.opp-desc { font-size: 11px; font-weight: 400; color: var(--opp-text-tertiary); margin-top: 2px; display: block; }
-.opp-mpn-more { font-size: 10px; color: var(--opp-text-tertiary); margin-left: 6px; }
-
-.opp-qty, .opp-unit-price {
-  font-size: 12px;
-  color: var(--opp-text-secondary);
-  font-variant-numeric: tabular-nums;
-}
-
-.opp-deal { font-size: 13px; font-variant-numeric: tabular-nums; }
-.opp-deal--tier-primary-500 { font-weight: 500; color: var(--opp-text-primary); }
-.opp-deal--tier-primary-400 { font-weight: 400; color: var(--opp-text-primary); }
-.opp-deal--tier-tertiary    { font-weight: 400; color: var(--opp-text-tertiary); }
-.opp-deal--computed         { font-style: italic; }
-
+/* FE-3: .opp-mpn/.opp-desc/.opp-qty/.opp-unit-price/.opp-deal-* removed — they styled the
+   mpn_chips_aggregated + deal_value macros that were deleted with the retired /requisitions2
+   opportunity table. The .opp-time-*, .opp-coverage-*, opp_status_cell tokens stay (live via
+   Sightings + Resell). */
 .opp-coverage { display: inline-flex; gap: 2px; align-items: center; }
 .opp-coverage-seg { width: 6px; height: 14px; background: var(--opp-coverage-empty); border-radius: 1px; }
 .opp-coverage-seg--filled { background: var(--opp-coverage-filled); }

--- a/app/templates/htmx/partials/shared/_macros.html
+++ b/app/templates/htmx/partials/shared/_macros.html
@@ -218,7 +218,8 @@ Usage:
 {#
   Purpose:     6-segment meter showing offers-covered / total requirements.
   Depends on:  styles.css opp-coverage* tokens.
-  Called-by:   requisitions2/_table_rows.html, _single_row.html
+  Called-by:   sightings/table.html, resell/_lists.html (the retired requisitions2
+               opportunity table was its original caller; these reuse the token).
   Business:    coverage_filled = count of requirements with ≥1 offer (not
                sightings — see spec §Coverage semantic). Segments filled =
                round(6·filled/total). total==0 renders an empty meter with


### PR DESCRIPTION
## FE-3 (production-polish audit, 2026-07-02)

The `.opp-mpn`/`.opp-desc`/`.opp-mpn-more`/`.opp-qty`/`.opp-unit-price`/`.opp-deal-*` rules styled the `mpn_chips_aggregated` + `deal_value` macros that were deleted with the retired `/requisitions2` opportunity table — **0 template/JS references**. Removed them.

Kept the still-live `.opp-time-*`, `.opp-coverage-*`, and `opp_status_cell` tokens (used by Sightings + Resell). Also fixed `coverage_meter`'s stale `Called-by: requisitions2/...` comment to point at its real callers.

CSS-only + a comment; braces balance verified, no test references the removed classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)