### PR TITLE
perf(requisitions): selectinload row-render collections to kill the reqs×offers×quotes cartesian

### DIFF
--- a/app/routers/htmx_views.py
+++ b/app/routers/htmx_views.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from loguru import logger
 from sqlalchemy import func as sqlfunc
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..constants import (
     AccessKey,
@@ -574,8 +574,8 @@ async def requisition_inline_save(
             db.query(Requisition)
             .options(
                 joinedload(Requisition.creator),
-                joinedload(Requisition.requirements),
-                joinedload(Requisition.offers),
+                selectinload(Requisition.requirements),
+                selectinload(Requisition.offers),
             )
             .filter(Requisition.id == req_id)
             .first()
@@ -594,9 +594,9 @@ async def requisition_inline_save(
             db.query(Requisition)
             .options(
                 joinedload(Requisition.creator),
-                joinedload(Requisition.requirements),
-                joinedload(Requisition.offers),
-                joinedload(Requisition.quotes),
+                selectinload(Requisition.requirements),
+                selectinload(Requisition.offers),
+                selectinload(Requisition.quotes),
             )
             .filter(Requisition.id == req_id)
             .first()


### PR DESCRIPTION
## Confirmed regression from the whole-program review

The final adversarial regression review flagged this (verified with a compiled-query repro): `requisition_inline_save` (context='row') stacked `joinedload` on **three** one-to-many collections — `requirements` + `offers` + `quotes` — so re-rendering a single row LEFT-OUTER-JOINed all three and hydrated `|requirements|×|offers|×|quotes|` rows for one requisition (e.g. **25×80×3 = 6000 rows** to render one row).

PR #627 fixed this exact pattern on the sibling **list** route (→ `selectinload`) but missed this **row** path. Switched all three collection loads here (both row-render blocks) to `selectinload`; `creator` stays `joinedload` (many-to-one).

Behavior is identical — verified by **302 passing** requisition render/edit tests + the review's compiled-query repro (post-fix: zero collection joins in the driving statement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)