### PR TITLE
perf(perf-8): eliminate N+1 (PERF-8)

### DIFF
--- a/app/routers/sightings.py
+++ b/app/routers/sightings.py
@@ -209,10 +209,15 @@ def _annotated_unavailability(
     the rows-win state selection) so the template stays dumb and never re-derives
     policy. Vendors with no matching record are absent.
     """
-    raw = unavailability_for_requirement(db, requirement, vendor_names)
+    # PERF-8: load the requirement's sightings once and share the single scan between the
+    # unavailability lookup and the has_unstamped_row grouping below — both operate on the
+    # identical set (Sighting.requirement_id == requirement.id). Skip the scan entirely
+    # when there are no vendors to annotate (unavailability_for_requirement returns {}
+    # without touching sightings in that case, so the pre-fix query count is unchanged).
+    rows = db.query(Sighting).filter(Sighting.requirement_id == requirement.id).all() if vendor_names else []
+    raw = unavailability_for_requirement(db, requirement, vendor_names, sightings=rows)
     if not raw:
         return {}
-    rows = db.query(Sighting).filter(Sighting.requirement_id == requirement.id).all()
     # Group sightings by vendor norm for condition-scoped has_unstamped_row computation.
     sightings_by_vendor: dict[str, list[Sighting]] = {}
     for s in rows:

--- a/app/services/vendor_unavailability.py
+++ b/app/services/vendor_unavailability.py
@@ -510,6 +510,7 @@ def unavailability_for_requirement(
     db: Session,
     requirement: Requirement,
     vendor_names: Sequence[str],
+    sightings: Sequence[Sighting] | None = None,
 ) -> dict[str, UnavailabilityIntel]:
     """Vendor display name -> annotated most-recent matching record, for rendering.
 
@@ -517,6 +518,11 @@ def unavailability_for_requirement(
     key. One batched query — no N+1. Vendors with no matching record are absent from the
     result. Each entry carries the computed policy state (is_active, age_days) plus the
     record itself so templates render the three row states without re-deriving policy.
+
+    ``sightings`` lets a caller that has already loaded this requirement's sightings pass
+    them through instead of forcing a second identical scan (PERF-8). When None the set is
+    queried here as before. The candidate keys are set-built, so iteration order does not
+    matter; any full ``Sighting.requirement_id == requirement.id`` result is equivalent.
     """
     norm_by_display = {vn: normalize_vendor_name(vn) for vn in vendor_names}
     norms = {n for n in norm_by_display.values() if n}
@@ -525,7 +531,9 @@ def unavailability_for_requirement(
 
     primary_key = normalize_mpn_key(requirement.primary_mpn)
     keys_by_norm: dict[str, set[str]] = {n: ({primary_key} if primary_key else set()) for n in norms}
-    for s in db.query(Sighting).filter(Sighting.requirement_id == requirement.id).all():
+    if sightings is None:
+        sightings = db.query(Sighting).filter(Sighting.requirement_id == requirement.id).all()
+    for s in sightings:
         norm = sighting_vendor_norm(s)
         if norm not in keys_by_norm:
             continue

--- a/tests/test_sightings_router.py
+++ b/tests/test_sightings_router.py
@@ -4522,6 +4522,206 @@ class TestAnnotatedUnavailabilityConditionScoped:
         assert result["Good Vendor"]["has_unstamped_row"] is True
 
 
+class _SightingScanCounter:
+    """Count SELECTs that scan the ``sightings`` table for the enclosing block.
+
+    PERF-8: _annotated_unavailability used to scan the requirement's sightings twice per
+    render (once inside unavailability_for_requirement, once in the wrapper). This asserts
+    the merged single scan and guards against the double-scan regressing.
+    """
+
+    def __init__(self, db):
+        from sqlalchemy import event as _event
+
+        self._event = _event
+        self.engine = db.get_bind()
+        self.count = 0
+
+    def _on_exec(self, conn, cursor, statement, parameters, context, executemany):
+        if "from sightings" in statement.lower():
+            self.count += 1
+
+    def __enter__(self):
+        self._event.listen(self.engine, "after_cursor_execute", self._on_exec)
+        return self
+
+    def __exit__(self, *a):
+        self._event.remove(self.engine, "after_cursor_execute", self._on_exec)
+
+
+class TestAnnotatedUnavailabilitySingleScan:
+    """PERF-8: the requirement's sightings are scanned once, not twice, per render."""
+
+    def _seed_record(self, db_session, r, *, condition=None):
+        db_session.add(
+            VendorPartUnavailability(
+                vendor_name_normalized="good vendor",
+                normalized_mpn="testmpn001",
+                reason="sold_elsewhere",
+                condition=condition,
+                requirement_id=r.id,
+            )
+        )
+        db_session.commit()
+
+    def test_sightings_scanned_once_when_record_present(self, client, db_session):
+        """With a matching unavailability record the wrapper must scan sightings exactly
+        once (was twice: helper scan + wrapper scan)."""
+        from app.routers.sightings import _annotated_unavailability
+
+        _, r, _ = _seed_data(db_session)
+        db_session.add(
+            Sighting(
+                requirement_id=r.id,
+                vendor_name="Good Vendor",
+                mpn_matched="TEST-MPN-001",
+                is_unavailable=True,
+                condition="New",
+            )
+        )
+        db_session.commit()
+        self._seed_record(db_session, r, condition="new")
+
+        with _SightingScanCounter(db_session) as counter:
+            result = _annotated_unavailability(db_session, r, ["Good Vendor"])
+
+        assert "Good Vendor" in result  # record present → wrapper ran its full body
+        assert counter.count == 1, f"expected a single sightings scan, got {counter.count}"
+
+    def test_scan_count_independent_of_sighting_count(self, client, db_session):
+        """The sightings scan count must stay 1 regardless of how many sightings exist —
+        the old double-scan was constant-2 but each scan is unbounded in rows."""
+        from app.routers.sightings import _annotated_unavailability
+
+        _, r, _ = _seed_data(db_session)
+        self._seed_record(db_session, r, condition=None)
+        for i in range(2):
+            db_session.add(
+                Sighting(
+                    requirement_id=r.id,
+                    vendor_name="Good Vendor",
+                    mpn_matched="TEST-MPN-001",
+                    is_unavailable=False,
+                    condition="New",
+                )
+            )
+        db_session.commit()
+        with _SightingScanCounter(db_session) as c_small:
+            _annotated_unavailability(db_session, r, ["Good Vendor"])
+
+        for i in range(25):
+            db_session.add(
+                Sighting(
+                    requirement_id=r.id,
+                    vendor_name="Good Vendor",
+                    mpn_matched="TEST-MPN-001",
+                    is_unavailable=False,
+                    condition="New",
+                )
+            )
+        db_session.commit()
+        with _SightingScanCounter(db_session) as c_big:
+            _annotated_unavailability(db_session, r, ["Good Vendor"])
+
+        assert c_small.count == 1
+        assert c_big.count == c_small.count, "sightings scan count grew with sighting count"
+
+    def test_no_scan_when_no_vendors(self, client, db_session):
+        """Empty vendor list short-circuits before any sightings scan (unchanged from
+        pre-fix: unavailability_for_requirement returns {} without touching sightings)."""
+        from app.routers.sightings import _annotated_unavailability
+
+        _, r, _ = _seed_data(db_session)
+        db_session.add(Sighting(requirement_id=r.id, vendor_name="Good Vendor", mpn_matched="TEST-MPN-001"))
+        db_session.commit()
+        with _SightingScanCounter(db_session) as counter:
+            result = _annotated_unavailability(db_session, r, [])
+        assert result == {}
+        assert counter.count == 0
+
+
+class TestAnnotatedUnavailabilityEquivalence:
+    """PERF-8: sharing the loaded sighting set must produce byte-identical output — same
+    rows, same has_unstamped_row derivation — across duplicate/null/multi-vendor cases."""
+
+    def _rec(self, db_session, r, vendor_norm, mpn_norm, *, condition=None):
+        db_session.add(
+            VendorPartUnavailability(
+                vendor_name_normalized=vendor_norm,
+                normalized_mpn=mpn_norm,
+                reason="sold_elsewhere",
+                condition=condition,
+                requirement_id=r.id,
+            )
+        )
+
+    def test_duplicate_and_null_condition_sightings(self, client, db_session):
+        """Duplicate sightings (same vendor+mpn) and NULL-condition rows must yield the
+        same has_unstamped_row the single merged scan derives: an unstamped row matching
+        the record's condition (or any row for a NULL record) sets it True."""
+        from app.routers.sightings import _annotated_unavailability
+
+        _, r, _ = _seed_data(db_session)
+        # Two identical unstamped NEW sightings for the same vendor (duplicates) ...
+        for _ in range(2):
+            db_session.add(
+                Sighting(
+                    requirement_id=r.id,
+                    vendor_name="Good Vendor",
+                    mpn_matched="TEST-MPN-001",
+                    is_unavailable=False,
+                    condition="New",
+                )
+            )
+        # ... plus a stamped row with NULL condition (should not flip the NEW record).
+        db_session.add(
+            Sighting(
+                requirement_id=r.id,
+                vendor_name="Good Vendor",
+                mpn_matched="TEST-MPN-001",
+                is_unavailable=True,
+                condition=None,
+            )
+        )
+        self._rec(db_session, r, "good vendor", "testmpn001", condition="new")
+        db_session.commit()
+
+        result = _annotated_unavailability(db_session, r, ["Good Vendor"])
+        assert set(result.keys()) == {"Good Vendor"}
+        assert result["Good Vendor"]["condition"] == "new"
+        assert result["Good Vendor"]["has_unstamped_row"] is True
+
+    def test_multi_vendor_only_matched_vendor_present(self, client, db_session):
+        """A vendor with no matching record is absent; the matched vendor is annotated —
+        identical to the pre-fix per-vendor filtering over the shared scan."""
+        from app.routers.sightings import _annotated_unavailability
+
+        _, r, _ = _seed_data(db_session)
+        db_session.add(
+            Sighting(
+                requirement_id=r.id,
+                vendor_name="Good Vendor",
+                mpn_matched="TEST-MPN-001",
+                is_unavailable=True,
+                condition="New",
+            )
+        )
+        db_session.add(
+            Sighting(
+                requirement_id=r.id,
+                vendor_name="Other Vendor",
+                mpn_matched="TEST-MPN-001",
+                is_unavailable=False,
+                condition="New",
+            )
+        )
+        self._rec(db_session, r, "good vendor", "testmpn001", condition="new")
+        db_session.commit()
+
+        result = _annotated_unavailability(db_session, r, ["Good Vendor", "Other Vendor"])
+        assert set(result.keys()) == {"Good Vendor"}
+
+
 class TestUnavailableFormConditionSelector:
     """Task 8: unavailable_form renders condition selector and corrected copy."""
 

--- a/tests/test_vendor_unavailability.py
+++ b/tests/test_vendor_unavailability.py
@@ -723,6 +723,56 @@ class TestUnavailabilityForRequirement:
         requirement = _make_requirement(db_session, primary_mpn="AAA-111")
         assert unavailability_for_requirement(db_session, requirement, []) == {}
 
+    def test_preloaded_sightings_match_queried(self, db_session: Session):
+        """PERF-8: passing a pre-loaded sighting set must produce byte-identical intel to
+        the self-querying path — same keys, same chosen record per vendor. Covers
+        duplicate, cross-vendor and primary-key-only rows so the candidate-key set build
+        is exercised."""
+        requirement = _make_requirement(db_session, primary_mpn="AAA-111")
+        # Duplicate rows for one vendor, a distinct-mpn row for another, and a row whose
+        # mpn matches only the requirement's primary key.
+        _make_sighting(db_session, requirement, "Acme Components", mpn_matched="BBB-222")
+        _make_sighting(db_session, requirement, "Acme Components", mpn_matched="BBB-222")
+        _make_sighting(db_session, requirement, "Acme Components", mpn_matched="AAA-111")
+        _make_sighting(db_session, requirement, "Globex Parts", mpn_matched=None)
+        db_session.add_all(
+            [
+                VendorPartUnavailability(
+                    vendor_name_normalized="acme components",
+                    normalized_mpn=normalize_mpn_key("BBB-222"),
+                    reason=UnavailabilityReason.BROKEN,
+                    created_at=datetime.now(timezone.utc) - timedelta(days=1),
+                ),
+                VendorPartUnavailability(
+                    vendor_name_normalized="acme components",
+                    normalized_mpn=normalize_mpn_key("AAA-111"),
+                    reason=UnavailabilityReason.SOLD_ELSEWHERE,
+                    created_at=datetime.now(timezone.utc),
+                ),
+                VendorPartUnavailability(
+                    vendor_name_normalized="globex parts",
+                    normalized_mpn=normalize_mpn_key("AAA-111"),
+                    reason=UnavailabilityReason.BOUGHT_BY_US,
+                    created_at=datetime.now(timezone.utc),
+                ),
+            ]
+        )
+        db_session.commit()
+
+        vendors = ["Acme Components", "Globex Parts"]
+        queried = unavailability_for_requirement(db_session, requirement, vendors)
+
+        preloaded = list(db_session.query(Sighting).filter(Sighting.requirement_id == requirement.id).all())
+        passed = unavailability_for_requirement(db_session, requirement, vendors, sightings=preloaded)
+
+        assert set(queried) == set(passed)
+        assert {v: i.record.id for v, i in queried.items()} == {v: i.record.id for v, i in passed.items()}
+        # A shuffled / reversed set must not change the outcome (candidate keys are a set).
+        reversed_pass = unavailability_for_requirement(
+            db_session, requirement, vendors, sightings=list(reversed(preloaded))
+        )
+        assert {v: i.record.id for v, i in reversed_pass.items()} == {v: i.record.id for v, i in queried.items()}
+
 
 # ── Temporal policy: model columns, predicate, source classes ─────────────────
 


### PR DESCRIPTION
## PERF-8 — Sightings detail scanned all sightings for a requirement twice per render

`_annotated_unavailability` (app/routers/sightings.py) ran `db.query(Sighting).filter(Sighting.requirement_id == requirement.id).all()` **twice** per sightings-detail render: once inside `unavailability_for_requirement` (the candidate-key build) and again in the wrapper (the `has_unstamped_row` grouping). Both are full, unbounded scans of the identical set, and requirements accumulate sightings across repeated search cascades.

### Fix
Load the set once in the wrapper and pass it through a new optional `sightings` parameter on `unavailability_for_requirement` (`None` → self-query, so the service's other callers/tests are unchanged). The two call sites provably operate on the same query, and the candidate keys are set-built, so iteration order is irrelevant — output is **byte-for-byte identical** to the pre-fix double-scan (same rows, same per-vendor record selection, same `has_unstamped_row`). The empty-vendor short-circuit is preserved so the degenerate path's query count is unchanged.

### Out of scope (intentionally not done)
The audit's second suggestion — cap the parts-sourcing popover to top-10-by-score rows in SQL — **changes rendered output**, so it is a behavior change, not a pure optimization, and is excluded here.

### Tests
- **Query-count guard** (`TestAnnotatedUnavailabilitySingleScan`): sightings scanned exactly once, independent of N (verified: the pre-fix double-scan path measures 3 sightings scans and fails the guard; the fix measures 1). Includes the empty-vendor no-scan path.
- **Behavioral equivalence** (`TestAnnotatedUnavailabilityEquivalence`): duplicate / NULL-condition / multi-vendor sighting sets produce the expected output.
- **Service-level** (`test_preloaded_sightings_match_queried`): the preloaded-set path returns identical keys and per-vendor record ids to the self-querying path, including reversed input order.

All runs on in-memory SQLite (no PG-only SQL introduced). 447 tests pass across `test_sightings_router.py`, `test_vendor_unavailability.py`, `test_static_analysis.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)