### PR TITLE
perf(perf-10): eliminate N+1 (PERF-10)

### DIFF
--- a/app/routers/crm/export.py
+++ b/app/routers/crm/export.py
@@ -11,7 +11,7 @@ Routes:
 
 Called by: app/routers/crm/__init__.py (included into crm_router)
 Depends on: app/services/crm_service (cdm_company_query, customer_contacts_query,
-            cadence_state_of, CONTACT_CADENCE_DOTS),
+            contact_cadence_predicate, CONTACT_CADENCE_DOTS),
             app/dependencies.is_manager_or_admin,
             app/models/crm.py (Company, CustomerSite, SiteContact)
 """
@@ -30,8 +30,8 @@ from app.dependencies import is_manager_or_admin, require_access
 from app.models import User
 from app.services.crm_service import (
     CONTACT_CADENCE_DOTS,
-    cadence_state_of,
     cdm_company_query,
+    contact_cadence_predicate,
     customer_contacts_query,
 )
 
@@ -119,14 +119,15 @@ def _contacts_generator(
     yield buf.getvalue()
 
     # customer_contacts_query is role-scoped (reps see only manageable accounts)
-    # and applies search/company_id/contact_role. cadence_state is derived, so it
-    # is filtered in Python (mirrors customer_contacts_list_ctx).
+    # and applies search/company_id/contact_role. cadence_state is derived, but
+    # contact_cadence_predicate expresses it as a SQL cutoff (mirrors
+    # customer_contacts_list_ctx / cadence_state_of EXACTLY) so the filter runs in the
+    # database and the whole set streams via yield_per instead of materializing. (PERF-10)
     base = customer_contacts_query(db, user, search=search, company_id=company_id, contact_role=contact_role)
     if cadence_state in CONTACT_CADENCE_DOTS:
         now = datetime.now(timezone.utc)
-        rows = [c for c in base.all() if cadence_state_of(c, now) == cadence_state]
-    else:
-        rows = base.yield_per(200)
+        base = base.filter(contact_cadence_predicate(cadence_state, now))
+    rows = base.yield_per(200)
 
     for contact in rows:
         site = contact.customer_site

--- a/app/services/crm_service.py
+++ b/app/services/crm_service.py
@@ -517,18 +517,15 @@ def customer_contacts_list_ctx(
     base = customer_contacts_query(db, user, search=search, company_id=company_id, contact_role=contact_role)
 
     if cadence_state in CONTACT_CADENCE_DOTS:
-        # cadence_state is derived → fetch the filtered set, compute, then slice.
-        rows = base.all()
-        for c in rows:
-            c.cadence_state = cadence_state_of(c, now)
-        rows = [c for c in rows if c.cadence_state == cadence_state]
-        total = len(rows)
-        contacts = rows[offset : offset + limit]
-    else:
-        total = base.count()
-        contacts = base.offset(offset).limit(limit).all()
-        for c in contacts:
-            c.cadence_state = cadence_state_of(c, now)
+        # cadence_state is derived from last_outbound_at, but its integer day-floor
+        # thresholds collapse to exact timestamp cutoffs, so the filter (and therefore
+        # count + paging) runs in SQL rather than loading the whole scoped set into
+        # Python. contact_cadence_predicate mirrors cadence_state_of EXACTLY. (PERF-10)
+        base = base.filter(contact_cadence_predicate(cadence_state, now))
+    total = base.count()
+    contacts = base.offset(offset).limit(limit).all()
+    for c in contacts:
+        c.cadence_state = cadence_state_of(c, now)
 
     # Company filter options: distinct companies within the viewer's scope.
     company_q = (
@@ -556,6 +553,43 @@ def customer_contacts_list_ctx(
 def cadence_state_of(contact: SiteContact, now: datetime) -> str:
     """Contact-level cadence dot — standard 30d outbound clock (tier=None)."""
     return cadence_state(None, contact.last_outbound_at, now)
+
+
+def contact_cadence_predicate(state: str, now: datetime):
+    """SQL predicate selecting SiteContacts whose contact-level cadence_state ==
+    ``state``.
+
+    Mirrors ``cadence_state_of()`` → ``cadence_state(tier=None, last_outbound_at, now)``
+    EXACTLY so the filter (and thus count + LIMIT/OFFSET paging) can run in the database
+    instead of loading the whole scoped contact set into Python (PERF-10). cadence_state
+    derives from the OUTBOUND clock with integer day-floor thresholds:
+
+        new        last_outbound_at IS NULL
+        overdue    floor(days) > CADENCE_RED_DAYS
+        due        target < floor(days) <= CADENCE_RED_DAYS   (empty when target == red)
+        on_target  floor(days) <= target                       (and not NULL)
+
+    where ``days == (now - last_outbound_at).days`` and ``target`` is the "standard" tier
+    target (tier is always None for contacts). The day-FLOOR comparison collapses to an
+    exact timestamp cutoff — ``floor(days) > k  ⇔  (now - ts) >= (k+1) days  ⇔
+    ts <= now - (k+1) days`` — so no SQL date-diff is needed and the comparison is portable
+    across SQLite (tests) and PostgreSQL (prod), matching the existing _needs_call_filter
+    pattern. NULL rows are excluded from the timestamp bands explicitly (they are "new").
+    """
+    col = SiteContact.last_outbound_at
+    if state == "new":
+        return col.is_(None)
+    target = TIER_TARGET_DAYS.get("standard", CADENCE_RED_DAYS)
+    overdue_cutoff = now - timedelta(days=CADENCE_RED_DAYS + 1)  # ts <= this ⇒ overdue
+    due_cutoff = now - timedelta(days=target + 1)  # ts <= this ⇒ due-or-worse
+    if state == "overdue":
+        return and_(col.isnot(None), col <= overdue_cutoff)
+    if state == "due":
+        # Collapses to an empty set when target == CADENCE_RED_DAYS (the current config),
+        # exactly matching cadence_state's unreachable "due" band for tier=None contacts.
+        return and_(col.isnot(None), col <= due_cutoff, col > overdue_cutoff)
+    # on_target — the only remaining CONTACT_CADENCE_DOTS value.
+    return and_(col.isnot(None), col > due_cutoff)
 
 
 def company_contact_rows(

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2564,8 +2564,11 @@ UI for uploading a vendor's stock list. All three are thin routes in
   MANAGER/ADMIN see all (the predicate is skipped for `is_manager_or_admin`).
   `customer_contacts_query` joins `SiteContact → CustomerSite → Company` (all
   `is_active`), filters search (name OR email) / company / role; `cadence_state` is a
-  DERIVED dot (not a column) so it is computed via `cadence_state_of` and filtered in
-  Python by `customer_contacts_list_ctx`. The company-filter dropdown is built from the
+  DERIVED dot (not a column) but its day-floor thresholds collapse to exact timestamp
+  cutoffs, so `customer_contacts_list_ctx` filters it in SQL via
+  `contact_cadence_predicate` (which mirrors `cadence_state_of` EXACTLY) and pages with
+  count()/offset()/limit() — no full-set load before paging (PERF-10). The company-filter
+  dropdown is built from the
   same visibility scope. `require_user`. Reached via the "All contacts" link in
   `customers/list.html`.
 - **`GET /v2/vendor-contacts`** (`vendor_contacts_partial` → `vendors/contacts_list.html`)
@@ -5204,8 +5207,10 @@ minimal and mirrors the accounts pattern; no rearrangement of existing controls.
   visible set (`effective_my_only = my_only OR not is_manager_or_admin`); managers can add
   the My-accounts filter. Unfiltered call = all visible (unchanged default).
 - `GET /v2/customers/contacts/export.csv` now accepts `search/company_id/contact_role/
-  cadence_state` and streams via the role-scoped `customer_contacts_query` (cadence_state is
-  derived → filtered in Python, mirroring `customer_contacts_list_ctx`). Headers unchanged.
+  cadence_state` and streams via the role-scoped `customer_contacts_query`; the derived
+  `cadence_state` facet is applied in SQL via `contact_cadence_predicate` (mirroring
+  `customer_contacts_list_ctx`) so the whole set streams through `yield_per(200)` instead
+  of being materialized (PERF-10). Headers unchanged.
 - Both export links are progressive-enhancement anchors: `@click.prevent` rebuilds the
   download URL from the live filter form (`#cdm-filters` / `#contacts-filters`) via
   `URLSearchParams(new FormData(...))`; the bare `href` is the no-JS fallback (full export).

--- a/tests/test_contacts_cadence_perf.py
+++ b/tests/test_contacts_cadence_perf.py
@@ -1,0 +1,321 @@
+"""PERF-10 — the global customer-contacts list must filter + page the cadence_state
+facet in SQL, not by loading the entire role-scoped contact set into Python.
+
+Two guarantees are locked here:
+
+1. Performance: with a cadence_state filter set, only the requested page (LIMIT rows) is
+   materialized as ORM objects — the cost does NOT grow with the size of the filtered
+   set (the pre-fix code did ``base.all()`` then sliced in Python).
+2. Identical results: ``contact_cadence_predicate`` (the SQL cutoff) classifies rows
+   byte-for-byte identically to the original ``cadence_state_of`` Python classifier,
+   across NULL / boundary-day / future-dated / duplicate edge cases, and the paged ctx
+   output matches the replicated pre-fix algorithm exactly (same ids, order, total).
+
+Called by: pytest
+Depends on: app.services.crm_service.customer_contacts_list_ctx / customer_contacts_query /
+    contact_cadence_predicate / cadence_state_of, app.models.crm (Company/CustomerSite/
+    SiteContact).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+
+from app.models import Company, CustomerSite, SiteContact, User
+from app.services.crm_service import (
+    CADENCE_RED_DAYS,
+    CONTACT_CADENCE_DOTS,
+    TIER_TARGET_DAYS,
+    cadence_state_of,
+    contact_cadence_predicate,
+    customer_contacts_list_ctx,
+    customer_contacts_query,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _company_site(db: Session) -> tuple[Company, CustomerSite]:
+    co = Company(name="Cadence Co", is_active=True)
+    db.add(co)
+    db.flush()
+    site = CustomerSite(company_id=co.id, site_name="HQ", is_active=True)
+    db.add(site)
+    db.flush()
+    return co, site
+
+
+def _contact(db, site_id, *, name, last_outbound=None, last_activity=None) -> SiteContact:
+    c = SiteContact(
+        customer_site_id=site_id,
+        full_name=name,
+        is_active=True,
+        last_outbound_at=last_outbound,
+        last_activity_at=last_activity,
+    )
+    db.add(c)
+    return c
+
+
+class _LoadCounter:
+    """Counts SiteContact rows materialized into ORM objects (identity map must be
+    clear)."""
+
+    def __init__(self, model):
+        self.model = model
+        self.count = 0
+
+    def _on_load(self, *a, **k):
+        self.count += 1
+
+    def __enter__(self):
+        event.listen(self.model, "load", self._on_load)
+        return self
+
+    def __exit__(self, *a):
+        event.remove(self.model, "load", self._on_load)
+
+
+class _QueryCounter:
+    def __init__(self, db):
+        self.engine = db.get_bind()
+        self.count = 0
+
+    def _on_exec(self, *a, **k):
+        self.count += 1
+
+    def __enter__(self):
+        event.listen(self.engine, "after_cursor_execute", self._on_exec)
+        return self
+
+    def __exit__(self, *a):
+        event.remove(self.engine, "after_cursor_execute", self._on_exec)
+
+
+def _old_algorithm(db, user, *, cadence_state, limit, offset, now):
+    """The pre-PERF-10 algorithm: full fetch, classify in Python, filter, slice.
+
+    Reproduced verbatim so the optimized code can be asserted byte-for-byte identical.
+    """
+    base = customer_contacts_query(db, user)
+    rows = base.all()
+    for c in rows:
+        c.cadence_state = cadence_state_of(c, now)
+    rows = [c for c in rows if c.cadence_state == cadence_state]
+    total = len(rows)
+    return rows[offset : offset + limit], total
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Performance guard — cadence filter pages in SQL, cost independent of N
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_cadence_filter_pages_in_sql_cost_independent_of_n(db_session: Session, admin_user: User):
+    """Only the LIMIT-sized page is fetched; doubling the matching set does not change
+    it."""
+    admin_id = admin_user.id
+    _, site = _company_site(db_session)
+    site_id = site.id
+    now = datetime.now(timezone.utc)
+
+    for i in range(25):
+        _contact(
+            db_session,
+            site_id,
+            name=f"Overdue {i}",
+            last_outbound=now - timedelta(days=60),  # unambiguously overdue
+            last_activity=now - timedelta(days=i),  # distinct → stable order
+        )
+    db_session.commit()
+    db_session.expunge_all()  # force real DB loads so the load event fires per fetched row
+
+    admin = db_session.get(User, admin_id)
+    with _QueryCounter(db_session) as qc, _LoadCounter(SiteContact) as lc:
+        ctx = customer_contacts_list_ctx(db_session, admin, cadence_state="overdue", limit=5, offset=0)
+
+    assert ctx["total"] == 25, "count must reflect the full filtered set"
+    assert len(ctx["contacts"]) == 5, "page must honor the limit"
+    # PERF-10 core: only the 5-row page materializes, NOT all 25 filtered rows.
+    assert lc.count == 5, f"expected 5 SiteContact rows loaded (page size), got {lc.count}"
+    queries_at_25 = qc.count
+
+    # Double the matching population; page cost (queries + rows loaded) must stay flat.
+    for i in range(25, 50):
+        _contact(
+            db_session,
+            site_id,
+            name=f"Overdue {i}",
+            last_outbound=now - timedelta(days=60),
+            last_activity=now - timedelta(days=i),
+        )
+    db_session.commit()
+    db_session.expunge_all()
+
+    admin = db_session.get(User, admin_id)
+    with _QueryCounter(db_session) as qc2, _LoadCounter(SiteContact) as lc2:
+        ctx2 = customer_contacts_list_ctx(db_session, admin, cadence_state="overdue", limit=5, offset=0)
+
+    assert ctx2["total"] == 50
+    assert lc2.count == 5, f"page cost scaled with N: {lc2.count} rows loaded for 50 matches"
+    assert qc2.count == queries_at_25, "query count must not scale with the filtered-set size"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Exact equivalence — SQL predicate == Python classifier at a fixed `now`
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_predicate_matches_python_classifier_across_edges(db_session: Session, admin_user: User):
+    """contact_cadence_predicate partitions rows exactly like cadence_state_of,
+    including NULL, future-dated, and every day-boundary around the 30/31-day
+    threshold."""
+    _, site = _company_site(db_session)
+    site_id = site.id
+    now = datetime(2026, 6, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+    edges = {
+        "null": None,
+        "future_2d": now + timedelta(days=2),
+        "d0": now,
+        "d5": now - timedelta(days=5),
+        "d29": now - timedelta(days=29),
+        "d30": now - timedelta(days=30),
+        "d30_12h": now - timedelta(days=30, hours=12),
+        "d31": now - timedelta(days=31),
+        "d31_12h": now - timedelta(days=31, hours=12),
+        "d60": now - timedelta(days=60),
+    }
+    for label, ts in edges.items():
+        _contact(db_session, site_id, name=label, last_outbound=ts)
+    db_session.commit()
+
+    base = customer_contacts_query(db_session, admin_user)
+    all_contacts = base.all()
+
+    seen: set[int] = set()
+    for state in CONTACT_CADENCE_DOTS:
+        sql_ids = {c.id for c in base.filter(contact_cadence_predicate(state, now)).all()}
+        py_ids = {c.id for c in all_contacts if cadence_state_of(c, now) == state}
+        assert sql_ids == py_ids, f"state={state}: SQL {sql_ids} != Python {py_ids}"
+        assert not (seen & sql_ids), f"state={state} overlaps a prior band"
+        seen |= sql_ids
+
+    # Every contact is classified into exactly one band (total partition).
+    assert seen == {c.id for c in all_contacts}
+
+
+def test_due_band_is_empty_for_contacts(db_session: Session, admin_user: User):
+    """With standard target == the red ceiling, the 'due' band is unreachable for
+    contacts (tier=None) — the SQL predicate must agree by returning nothing."""
+    assert TIER_TARGET_DAYS.get("standard") == CADENCE_RED_DAYS  # invariant the empty band relies on
+    _, site = _company_site(db_session)
+    site_id = site.id
+    now = datetime(2026, 6, 17, 12, 0, 0, tzinfo=timezone.utc)
+    for d in (0, 15, 30, 31, 45, 90):
+        _contact(db_session, site_id, name=f"d{d}", last_outbound=now - timedelta(days=d))
+    db_session.commit()
+
+    base = customer_contacts_query(db_session, admin_user)
+    assert base.filter(contact_cadence_predicate("due", now)).all() == []
+    assert not [c for c in base.all() if cadence_state_of(c, now) == "due"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Paged-ctx equivalence — same ids / order / total as the pre-fix algorithm
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_ctx_matches_old_algorithm_including_duplicates_and_nulls(db_session: Session, admin_user: User):
+    """The optimized ctx returns identical ids, order and totals to the full-fetch-then-
+    slice algorithm across pages, duplicate sort keys, and the empty 'due' band."""
+    _, site = _company_site(db_session)
+    site_id = site.id
+    now = datetime.now(timezone.utc)
+    tie = now - timedelta(days=100)  # identical last_activity_at → id.desc() tie-break
+
+    # 6 overdue: 3 with distinct activity times, 3 sharing `tie` (duplicate sort keys).
+    for i in range(3):
+        _contact(
+            db_session,
+            site_id,
+            name=f"OD-distinct-{i}",
+            last_outbound=now - timedelta(days=60),
+            last_activity=now - timedelta(days=10 + i),
+        )
+    for i in range(3):
+        _contact(db_session, site_id, name=f"OD-tie-{i}", last_outbound=now - timedelta(days=60), last_activity=tie)
+    # 3 on_target, 2 new (NULL outbound).
+    for i in range(3):
+        _contact(
+            db_session,
+            site_id,
+            name=f"OT-{i}",
+            last_outbound=now - timedelta(days=5),
+            last_activity=now - timedelta(days=i),
+        )
+    for i in range(2):
+        _contact(db_session, site_id, name=f"NEW-{i}", last_outbound=None, last_activity=now - timedelta(days=i))
+    db_session.commit()
+
+    cases = [
+        ("overdue", 2, 0),
+        ("overdue", 2, 2),
+        ("overdue", 2, 4),
+        ("overdue", 50, 0),
+        ("on_target", 2, 0),
+        ("on_target", 2, 2),
+        ("new", 50, 0),
+        ("due", 50, 0),  # empty band
+    ]
+    for state, limit, offset in cases:
+        old_page, old_total = _old_algorithm(
+            db_session, admin_user, cadence_state=state, limit=limit, offset=offset, now=now
+        )
+        ctx = customer_contacts_list_ctx(db_session, admin_user, cadence_state=state, limit=limit, offset=offset)
+        assert ctx["total"] == old_total, f"{state} l={limit} o={offset}: total mismatch"
+        assert [c.id for c in ctx["contacts"]] == [c.id for c in old_page], (
+            f"{state} l={limit} o={offset}: page ids/order mismatch"
+        )
+        for c in ctx["contacts"]:
+            assert c.cadence_state == state, "returned rows must carry the requested cadence_state"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. CSV export call-site — same filtered rows, now streamed (no full materialize)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _export_names(db, user, *, cadence_state) -> set[str]:
+    import csv as _csv
+    import io as _io
+
+    from app.routers.crm.export import _contacts_generator
+
+    text = "".join(_contacts_generator(db, user, search="", company_id=0, contact_role="", cadence_state=cadence_state))
+    reader = _csv.DictReader(_io.StringIO(text))
+    return {row["full_name"] for row in reader}
+
+
+def test_contacts_csv_export_cadence_filter_matches_python(db_session: Session, admin_user: User):
+    """The export generator's cadence branch yields exactly the rows the old Python
+    filter did."""
+    _, site = _company_site(db_session)
+    site_id = site.id
+    now = datetime.now(timezone.utc)
+    for i in range(4):
+        _contact(db_session, site_id, name=f"OD-{i}", last_outbound=now - timedelta(days=60))
+    for i in range(3):
+        _contact(db_session, site_id, name=f"OT-{i}", last_outbound=now - timedelta(days=5))
+    for i in range(2):
+        _contact(db_session, site_id, name=f"NEW-{i}", last_outbound=None)
+    db_session.commit()
+
+    base = customer_contacts_query(db_session, admin_user)
+    all_contacts = base.all()
+    for state in ("overdue", "on_target", "new"):
+        expected = {c.full_name for c in all_contacts if cadence_state_of(c, now) == state}
+        assert _export_names(db_session, admin_user, cadence_state=state) == expected, f"export {state} mismatch"


### PR DESCRIPTION
## PERF-10 — Contacts cadence facet loaded the entire scoped set before paging

**Finding:** `docs/audit/2026-07-02-production-polish-review.md` (PERF-10).

`customer_contacts_list_ctx` (`/v2/contacts`) and `_contacts_generator`
(`/v2/customers/contacts/export.csv`) did `rows = base.all()` whenever a
`cadence_state` facet was active, computed `cadence_state_of` per row in Python,
then filtered and sliced `rows[offset:offset+limit]`. Pagination was cosmetic —
the DB and app paid for the full role-scoped contact set on every page click, and
the export path also lost the `yield_per(200)` streaming of its non-cadence branch.

## Fix

`cadence_state` is derived purely from `last_outbound_at` vs `now` with integer
day-floor thresholds, and `floor(days) > k  ⇔  ts <= now - (k+1) days`, so the
facet collapses to exact timestamp cutoffs. New `contact_cadence_predicate(state, now)`
expresses it as a SQL predicate that mirrors `cadence_state_of` **exactly**:

- `new` → `last_outbound_at IS NULL`
- `overdue` → `ts <= now - (CADENCE_RED_DAYS+1) days`
- `on_target` → `ts > now - (target+1) days`
- `due` → the `target < floor(days) <= red` band, which stays **empty** for
  tier=None contacts (target == red) — matching the Python classifier's unreachable
  band exactly.

Both call sites now filter in SQL: `list_ctx` pages with `count()/offset()/limit()`;
export streams via `yield_per(200)`. Cutoffs are computed in Python and compared
against the column (no SQL date-diff), so the query is portable across SQLite (tests)
and PostgreSQL — same pattern as the existing `_needs_call_filter`; no
sqlite-masks-postgres risk.

## Identical results — guaranteed

This is a pure optimization; the output is byte-for-byte identical. Locked by
`tests/test_contacts_cadence_perf.py`:

- **Perf guard** — only the LIMIT-sized page materializes (5 rows for 25 and again
  for 50 matches; verified via an ORM instance-load counter after `expunge_all`), and
  the after_cursor_execute query count does not scale with N. *Fails on the pre-fix code.*
- **Exact equivalence** — the SQL predicate partitions rows identically to the Python
  `cadence_state_of` at a fixed `now`, across NULL / future-dated / every 30–31d
  boundary; asserts a total partition and the empty `due` band.
- **Paged-ctx + CSV-export equivalence** — identical ids, order, total, and per-row
  `cadence_state` vs the replicated pre-fix algorithm (duplicate sort keys, nulls,
  empty band, multiple pages).

Docs: `docs/APP_MAP_INTERACTIONS.md` updated for both endpoints.

## Test summary
`tests/test_contacts_cadence_perf.py` (5 tests) pass; neighbors green
(`test_crm_ia`, `test_cadence_state`, `test_crm_service`, `test_crm_views`,
`test_crm_csv_export`, `test_access_control`, `test_crm_p4_power_ux`, contacts UI/fields —
542 tests). pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)