### PR TITLE
feat(quotes): Delete-draft button on quote detail

### DIFF
--- a/app/templates/htmx/partials/quotes/detail.html
+++ b/app/templates/htmx/partials/quotes/detail.html
@@ -198,6 +198,24 @@
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
       Download PDF
     </a>
+
+    {# Delete draft — destructive, so it sits last (flex-wraps away from the primary Send
+       action). Only draft quotes are deletable; the endpoint 400s otherwise, so the button
+       is draft-gated. On success the DELETE returns an empty body with HX-Redirect →
+       full navigation to /v2/requisitions (redirect wins, so hx-target is moot). A 400/404
+       surfaces via the global htmx:responseError toast (htmx_app.js reads body.error) — no
+       silent failure. hx-target="#main-content" exists in both the deep-link page and the
+       Build-Quote workspace. Matches the vendors/detail.html delete sibling. #}
+    {% if quote.status == 'draft' %}
+    <button hx-delete="/v2/partials/quotes/{{ quote.id }}"
+            hx-target="#main-content"
+            hx-confirm="Delete this draft quote? This cannot be undone."
+            data-loading-disable
+            class="btn btn-danger btn-lg inline-flex items-center gap-1.5">
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+      Delete draft
+    </button>
+    {% endif %}
   </div>
 
   {# Global markup input #}

--- a/tests/test_sprint5_quote_workflow.py
+++ b/tests/test_sprint5_quote_workflow.py
@@ -106,6 +106,37 @@ class TestDeleteQuote:
         assert resp.status_code == 404
 
 
+# ── Delete-draft button (detail UI wiring for the DELETE endpoint) ────
+
+
+class TestDeleteDraftButton:
+    def test_draft_detail_shows_delete_button(self, client: TestClient, draft_quote: Quote):
+        """Draft detail renders a Delete-draft button wired to the DELETE endpoint."""
+        resp = client.get(f"/v2/partials/quotes/{draft_quote.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Delete draft" in resp.text
+        assert f'hx-delete="/v2/partials/quotes/{draft_quote.id}"' in resp.text
+        # Confirmation dialog guards the destructive action.
+        assert "hx-confirm=" in resp.text
+
+    def test_non_draft_detail_has_no_delete_button(self, client: TestClient, db_session: Session, test_quote: Quote):
+        """Sent/won/lost quotes must NOT expose the Delete-draft button (endpoint
+        400s)."""
+        test_quote.status = "sent"
+        db_session.commit()
+        resp = client.get(f"/v2/partials/quotes/{test_quote.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert "Delete draft" not in resp.text
+        assert f'hx-delete="/v2/partials/quotes/{test_quote.id}"' not in resp.text
+
+    def test_delete_success_redirects_to_requisitions(self, client: TestClient, draft_quote: Quote):
+        """The button relies on HX-Redirect → /v2/requisitions on a successful
+        delete."""
+        resp = client.delete(f"/v2/partials/quotes/{draft_quote.id}", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Redirect") == "/v2/requisitions"
+
+
 # ── Reopen Quote ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Surfaces the **existing** \`DELETE /v2/partials/quotes/{id}\` endpoint (\`delete_quote_htmx\`) as a **Delete draft** button in the quote detail actions bar (\`app/templates/htmx/partials/quotes/detail.html\`).

## Behavior

- Button is **draft-gated** (\`{% if quote.status == 'draft' %}\`) — the endpoint 400s for non-draft quotes, so it is only offered when deletion is valid.
- \`hx-confirm\` guards the destructive action.
- On success the endpoint returns an empty body with \`HX-Redirect: /v2/requisitions\`, so htmx does a full navigation (the \`hx-target="#main-content"\` is moot on success but exists in both the deep-link page and the Build-Quote workspace).
- On a 400/404 the global \`htmx:responseError\` handler (\`htmx_app.js\`) reads \`body.error\` and shows an error toast — **no silent failure**.
- Placed last in the actions bar (flex-wraps away from the primary Send action) and styled \`btn btn-danger btn-lg\` to signal a destructive action, matching the sizing of sibling actions.

Declarative \`hx-delete\` + \`hx-confirm\` + \`hx-target="#main-content"\` matches the existing \`vendors/detail.html\` delete sibling and the sourcing HX-Redirect pattern.

## Tests

\`tests/test_sprint5_quote_workflow.py::TestDeleteDraftButton\`:
- Draft detail renders the button wired to the DELETE endpoint with \`hx-confirm\`.
- Sent/won/lost detail does **not** expose the button.
- Successful delete responds with \`HX-Redirect: /v2/requisitions\`.

All 48 tests in the file pass, plus \`tests/test_static_analysis.py\`. \`pre-commit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF