### PR TITLE
feat(proactive-04): inline add-contact on Prepare so Send never dead-ends

### DIFF
--- a/app/routers/htmx/proactive.py
+++ b/app/routers/htmx/proactive.py
@@ -14,7 +14,7 @@ import asyncio
 import html as html_mod
 import json
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from loguru import logger
 from sqlalchemy import func as sqlfunc
@@ -213,6 +213,117 @@ async def proactive_prepare_page(
         }
     )
     return template_response("htmx/partials/proactive/prepare.html", ctx)
+
+
+def _render_contact_picker(request, db, site_id, added_contact_id=None):
+    """Re-render the Prepare "Send To" contact picker for one site.
+
+    Shared by proactive_add_contact so the swapped-in list mirrors the initial
+    prepare.html render exactly (same fields, same ordering).
+    """
+    contacts = (
+        db.query(SiteContact)
+        .filter(SiteContact.customer_site_id == site_id)
+        .order_by(SiteContact.is_primary.desc(), SiteContact.full_name)
+        .all()
+    )
+    contact_data = [
+        {
+            "id": c.id,
+            "full_name": c.full_name,
+            "email": c.email,
+            "title": c.title,
+            "is_primary": c.is_primary,
+            "has_email": bool(c.email),
+        }
+        for c in contacts
+    ]
+    return template_response(
+        "htmx/partials/proactive/_contact_picker.html",
+        {"request": request, "contacts": contact_data, "added_contact_id": added_contact_id},
+    )
+
+
+@router.post("/v2/partials/proactive/prepare/{site_id}/add-contact", response_class=HTMLResponse)
+async def proactive_add_contact(
+    site_id: int,
+    request: Request,
+    full_name: str = Form(""),
+    email: str = Form(""),
+    title: str = Form(""),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Add a SiteContact from the Prepare page, then re-render the contact picker.
+
+    Fixes PROACTIVE-04: when a site has no emailable contact, Send was disabled with
+    no way forward. This adds one inline. The refreshed picker auto-selects the new
+    contact (client-side) so Send unblocks in a single step.
+
+    Authorization: the caller must be the assigned salesperson on at least one
+    ProactiveMatch at this site — the same relationship that lets them reach Prepare.
+    Validation failures raise 4xx (surfaced by the global htmx toast handler); the
+    form stays open with the entered values on error.
+    """
+    from ...models import ProactiveMatch
+    from ...models.crm import CustomerSite as _CS
+
+    site = db.get(_CS, site_id)
+    if site is None:
+        raise HTTPException(404, "Site not found")
+
+    owns_match = (
+        db.query(ProactiveMatch.id)
+        .filter(
+            ProactiveMatch.customer_site_id == site_id,
+            ProactiveMatch.salesperson_id == user.id,
+        )
+        .first()
+    )
+    if not owns_match:
+        raise HTTPException(403, "Not authorized to add a contact for this site")
+
+    full_name = full_name.strip()
+    email = email.strip().lower()
+    if not full_name:
+        raise HTTPException(400, "Name is required.")
+    if not email:
+        raise HTTPException(400, "Email is required to send an offer.")
+    if "@" not in email:
+        raise HTTPException(400, "Enter a valid email address.")
+
+    # Per-site email dedup (case-insensitive) — mirrors the canonical add path.
+    dup = (
+        db.query(SiteContact)
+        .filter(
+            SiteContact.customer_site_id == site_id,
+            sqlfunc.lower(SiteContact.email) == email,
+        )
+        .first()
+    )
+    if dup:
+        raise HTTPException(409, f"A contact with email {email} already exists at this site.")
+
+    # Split full_name into first/last so the new contact matches the canonical
+    # contacts_tab_create shape (full_name stays the derived source of truth).
+    parts = full_name.split(" ", 1)
+    contact = SiteContact(
+        customer_site_id=site_id,
+        full_name=full_name,
+        first_name=parts[0] or None,
+        last_name=parts[1].strip() if len(parts) > 1 else None,
+        email=email,
+        title=title.strip() or None,
+    )
+    db.add(contact)
+    db.commit()
+    logger.info(
+        "Proactive add-contact: created contact {} at site {} by {}",
+        contact.id,
+        site_id,
+        user.email,
+    )
+    return _render_contact_picker(request, db, site_id, added_contact_id=contact.id)
 
 
 @router.post("/v2/partials/proactive/draft", response_class=HTMLResponse)

--- a/app/static/htmx_app.js
+++ b/app/static/htmx_app.js
@@ -1048,12 +1048,17 @@ htmx.on('htmx:afterSwap', function(evt) {
     // settings-content — the Settings tab body is lazy-swapped here and re-swapped by
     // every settings mutation (e.g. a dedup merge re-renders Data Ops), so its Alpine
     // directives — the Data Ops multi-select bar — must re-init or the checkboxes go
-    // inert and selection state is lost after the first action).
+    // inert and selection state is lost after the first action;
+    // proactive-contact-list — the Prepare page add-contact POST swaps the re-rendered
+    // picker here, whose :checked/@change checkboxes bind to the surrounding prepare
+    // x-data scope and whose new row carries an x-init auto-select; without re-init the
+    // checkboxes go inert and the new contact never selects (Send stays disabled).
     if (t && typeof Alpine !== 'undefined' && typeof Alpine.initTree === 'function') {
         if (
             t.id === 'lead-drawer-content' ||
             t.id === 'rfq-affinity-section' ||
-            t.id === 'settings-content'
+            t.id === 'settings-content' ||
+            t.id === 'proactive-contact-list'
         ) {
             Alpine.initTree(t);
         }

--- a/app/templates/htmx/partials/proactive/_contact_picker.html
+++ b/app/templates/htmx/partials/proactive/_contact_picker.html
@@ -1,0 +1,45 @@
+{#
+  proactive/_contact_picker.html — "Send To" contact rows for the Prepare page.
+
+  Rendered inside #proactive-contact-list, which sits inside the prepare.html root
+  Alpine component that owns selectedContacts / toggleContact. Checkbox bindings
+  resolve those up the scope chain.
+
+  Receives:
+    contacts          — list of dicts (id, full_name, email, title, is_primary, has_email)
+    added_contact_id  — optional int; a freshly-added contact to auto-select (via
+                        x-init → toggleContact) so the Send button unblocks.
+  Called by:
+    prepare.html ({% include %} — initial render, no added_contact_id)
+    proactive_add_contact (POST /v2/partials/proactive/prepare/{site_id}/add-contact)
+  Depends on: HTMX, Alpine.js, Tailwind CSS.
+#}
+{% if contacts %}
+  {% for c in contacts %}
+  <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer {{ 'opacity-50' if not c.has_email }}"
+         {% if not c.has_email %}title="No email address"{% endif %}>
+    {# Checkbox — accent via accent-color + input-focus (not brand-500) #}
+    <input type="checkbox"
+           {% if not c.has_email %}disabled{% endif %}
+           :checked="selectedContacts[{{ c.id }}]"
+           @change="toggleContact({{ c.id }})"
+           {% if added_contact_id is defined and added_contact_id and c.id == added_contact_id %}x-init="if (!selectedContacts[{{ c.id }}]) toggleContact({{ c.id }})"{% endif %}
+           class="rounded border-gray-300 input-focus disabled:opacity-40"
+           style="accent-color:var(--accent)">
+    <div class="flex-1 min-w-0">
+      <p class="text-sm font-medium text-gray-900">{{ c.full_name or '(unnamed)' }}</p>
+      <p class="text-xs text-gray-600">
+        {{ c.email or '(no email)' }}
+        {% if c.title %} &middot; {{ c.title }}{% endif %}
+        {% if c.is_primary %}
+        <span class="badge-mini bg-gray-100 text-gray-600 ml-1">Primary</span>
+        {% endif %}
+      </p>
+    </div>
+  </label>
+  {% endfor %}
+{% else %}
+  <div class="text-center py-6">
+    <p class="text-sm text-gray-600">No contacts on file. Add one below to send this offer.</p>
+  </div>
+{% endif %}

--- a/app/templates/htmx/partials/proactive/prepare.html
+++ b/app/templates/htmx/partials/proactive/prepare.html
@@ -100,40 +100,58 @@
     </div>
   </div>
 
-  {# Send To — Contact Picker #}
-  <div class="bg-white rounded-lg border border-line-base mb-6">
-    <div class="px-4 py-3 bg-gray-50 border-b border-line-base">
+  {# Send To — Contact Picker (+ inline add-contact so Send is never a dead end) #}
+  <div class="bg-white rounded-lg border border-line-base mb-6" x-data="{ showAddContact: false }">
+    <div class="px-4 py-3 bg-gray-50 border-b border-line-base flex items-center justify-between">
       <h2 class="text-sm font-semibold text-gray-900">Send To</h2>
+      {# Toggle the inline add-contact form — .btn-ghost matches page chrome #}
+      <button type="button" @click="showAddContact = !showAddContact"
+              :aria-expanded="showAddContact"
+              class="btn-ghost btn-sm inline-flex items-center gap-1">
+        <svg class="h-3.5 w-3.5 transition-transform" :class="{ 'rotate-45': showAddContact }"
+             fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+        </svg>
+        <span x-text="showAddContact ? 'Cancel' : 'Add contact'">Add contact</span>
+      </button>
     </div>
-    <div class="p-4 space-y-2">
-      {% if contacts %}
-        {% for c in contacts %}
-        <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer {{ 'opacity-50' if not c.has_email }}"
-               {% if not c.has_email %}title="No email address"{% endif %}>
-          {# Checkbox — accent via accent-color + input-focus (not brand-500) #}
-          <input type="checkbox"
-                 {% if not c.has_email %}disabled{% endif %}
-                 :checked="selectedContacts[{{ c.id }}]"
-                 @change="toggleContact({{ c.id }})"
-                 class="rounded border-gray-300 input-focus disabled:opacity-40"
-                 style="accent-color:var(--accent)">
-          <div class="flex-1 min-w-0">
-            <p class="text-sm font-medium text-gray-900">{{ c.full_name or '(unnamed)' }}</p>
-            <p class="text-xs text-gray-600">
-              {{ c.email or '(no email)' }}
-              {% if c.title %} &middot; {{ c.title }}{% endif %}
-              {% if c.is_primary %}
-              <span class="badge-mini bg-gray-100 text-gray-600 ml-1">Primary</span>
-              {% endif %}
-            </p>
+    <div class="p-4 space-y-3">
+      {# Contact rows — refreshed in place by the add-contact endpoint #}
+      <div id="proactive-contact-list" class="space-y-2">
+        {% include "htmx/partials/proactive/_contact_picker.html" %}
+      </div>
+
+      {# Inline add-contact — hx-posts, swaps the refreshed picker back in, and the
+         new contact auto-selects (x-init) so the Send button unblocks. Validation
+         errors return 4xx → global toast (no swap); the form stays open. #}
+      <div x-show="showAddContact" x-cloak x-transition class="pt-3 border-t border-line-base">
+        <form hx-post="/v2/partials/proactive/prepare/{{ site_id }}/add-contact"
+              hx-target="#proactive-contact-list"
+              hx-swap="innerHTML"
+              data-loading-disable
+              @htmx:after-request.camel="if (event.detail.successful) { $el.reset(); showAddContact = false }"
+              class="space-y-2">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <div>
+              <label for="pac-name" class="block text-xs font-medium text-gray-600 mb-1">Name</label>
+              <input type="text" name="full_name" id="pac-name" required
+                     placeholder="Full name" class="input input-sm">
+            </div>
+            <div>
+              <label for="pac-email" class="block text-xs font-medium text-gray-600 mb-1">Email</label>
+              <input type="email" name="email" id="pac-email" required
+                     placeholder="name@company.com" class="input input-sm">
+            </div>
           </div>
-        </label>
-        {% endfor %}
-      {% else %}
-        <div class="text-center py-6">
-          <p class="text-sm text-gray-600">No contacts on file.</p>
-        </div>
-      {% endif %}
+          <div class="flex items-end gap-2">
+            <div class="flex-1">
+              <label for="pac-title" class="block text-xs font-medium text-gray-600 mb-1">Title <span class="text-gray-400 font-normal">(optional)</span></label>
+              <input type="text" name="title" id="pac-title" placeholder="e.g. Buyer" class="input input-sm">
+            </div>
+            <button type="submit" class="btn-primary btn-sm whitespace-nowrap">Add &amp; select</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -273,6 +273,9 @@ URL space and the `htmx-views` tag, and `main.py` mounts each one alongside
   parsers (`_parse_filter_json`/`_pop_manufacturers`/`_parse_card_filter_params`).
 - `app/routers/htmx/proactive.py` — **tail split (proactive slice)**: the proactive part-match
   list, refresh/scan, batch-dismiss, the prepare page + draft + send flow (`/v2/proactive/*`),
+  the inline add-contact affordance on Prepare
+  (`POST /v2/partials/proactive/prepare/{site_id}/add-contact` → re-renders `_contact_picker.html`
+  into `#proactive-contact-list`, auto-selecting the new contact so Send unblocks — PROACTIVE-04),
   the legacy send/convert routes, scorecard, badge, and do-not-offer.
 - `app/routers/htmx/parts.py` — **tail split (parts-workspace body slice)**: the parts list, the
   detail tabs (offers/sourcing/req-details/quotes/activity/comms/notes), the header + inline cell +

--- a/tests/test_proactive_prepare.py
+++ b/tests/test_proactive_prepare.py
@@ -600,3 +600,215 @@ def test_htmx_do_not_offer_match_no_longer_in_list(db_session):
     after = get_matches_for_user(db_session, data["owner"].id, status="new")
     after_mpns = [m["mpn"] for g in after["groups"] for m in g["matches"]]
     assert "LM358N" not in after_mpns, "DNO match must be suppressed from list"
+
+
+# ── PROACTIVE-04: inline add-contact on the Prepare page ─────────────────────
+
+
+def _add_contact_client(db_session, user):
+    """Build a TestClient with get_db + require_user overridden to *user*."""
+    from fastapi.testclient import TestClient
+
+    from app.database import get_db
+    from app.dependencies import require_user
+    from app.main import app
+
+    def _override_db():
+        yield db_session
+
+    def _override_user():
+        return user
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[require_user] = _override_user
+    return TestClient(app), app
+
+
+def _cleanup_overrides(app):
+    from app.database import get_db
+    from app.dependencies import require_user
+
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(require_user, None)
+
+
+def test_add_contact_creates_and_auto_selects(db_session):
+    """POST add-contact creates a SiteContact and returns a picker that auto-selects
+    it."""
+    data = _setup_send_scenario(db_session)
+    site_id = data["site"].id
+    client, app = _add_contact_client(db_session, data["owner"])
+
+    before = db_session.query(SiteContact).filter(SiteContact.customer_site_id == site_id).count()
+
+    try:
+        resp = client.post(
+            f"/v2/partials/proactive/prepare/{site_id}/add-contact",
+            data={"full_name": "Carol Chen", "email": "carol@acme.com", "title": "Buyer"},
+        )
+    finally:
+        _cleanup_overrides(app)
+
+    assert resp.status_code == 200, resp.text
+    created = (
+        db_session.query(SiteContact)
+        .filter(SiteContact.customer_site_id == site_id, SiteContact.email == "carol@acme.com")
+        .first()
+    )
+    assert created is not None, "contact must be persisted"
+    assert created.full_name == "Carol Chen"
+    assert created.first_name == "Carol" and created.last_name == "Chen"
+    assert db_session.query(SiteContact).filter(SiteContact.customer_site_id == site_id).count() == before + 1
+    # Auto-select wiring: ONLY the new contact's row carries an x-init toggle so Send
+    # unblocks in one step without re-selecting the pre-existing contacts.
+    assert f"toggleContact({created.id})" in resp.text
+    assert resp.text.count("x-init") == 1, "only the freshly-added contact may auto-select"
+    assert f'x-init="if (!selectedContacts[{created.id}])' in resp.text
+    assert "carol@acme.com" in resp.text
+
+
+def test_add_contact_first_contact_unblocks_empty_site(db_session):
+    """A site with zero contacts gets one, and the picker no longer shows the empty
+    state."""
+    data = _setup_send_scenario(db_session)
+    # Fresh site with NO contacts but a match owned by the salesperson.
+    empty_site = CustomerSite(company_id=data["company"].id, site_name="Depot", is_active=True)
+    db_session.add(empty_site)
+    db_session.flush()
+    match = ProactiveMatch(
+        offer_id=data["offer"].id,
+        customer_site_id=empty_site.id,
+        salesperson_id=data["owner"].id,
+        mpn="LM358N",
+        company_id=data["company"].id,
+        match_score=50,
+        status="new",
+    )
+    db_session.add(match)
+    db_session.commit()
+
+    client, app = _add_contact_client(db_session, data["owner"])
+    try:
+        resp = client.post(
+            f"/v2/partials/proactive/prepare/{empty_site.id}/add-contact",
+            data={"full_name": "Dana Lee", "email": "dana@acme.com"},
+        )
+    finally:
+        _cleanup_overrides(app)
+
+    assert resp.status_code == 200, resp.text
+    assert "No contacts on file" not in resp.text
+    assert "dana@acme.com" in resp.text
+
+
+def test_add_contact_requires_name_and_email(db_session):
+    """Empty name, empty email, and malformed email each return 4xx and create
+    nothing."""
+    data = _setup_send_scenario(db_session)
+    site_id = data["site"].id
+    client, app = _add_contact_client(db_session, data["owner"])
+    before = db_session.query(SiteContact).filter(SiteContact.customer_site_id == site_id).count()
+
+    try:
+        r_noname = client.post(
+            f"/v2/partials/proactive/prepare/{site_id}/add-contact",
+            data={"full_name": "  ", "email": "x@acme.com"},
+        )
+        r_noemail = client.post(
+            f"/v2/partials/proactive/prepare/{site_id}/add-contact",
+            data={"full_name": "No Email", "email": ""},
+        )
+        r_bademail = client.post(
+            f"/v2/partials/proactive/prepare/{site_id}/add-contact",
+            data={"full_name": "Bad Email", "email": "not-an-email"},
+        )
+    finally:
+        _cleanup_overrides(app)
+
+    assert r_noname.status_code == 400
+    assert r_noemail.status_code == 400
+    assert r_bademail.status_code == 400
+    assert db_session.query(SiteContact).filter(SiteContact.customer_site_id == site_id).count() == before, (
+        "no contact may be created on validation failure"
+    )
+
+
+def test_add_contact_dedup_rejects_existing_email(db_session):
+    """Adding an email that already exists at the site returns 409 and creates
+    nothing."""
+    data = _setup_send_scenario(db_session)
+    site_id = data["site"].id
+    client, app = _add_contact_client(db_session, data["owner"])
+    before = db_session.query(SiteContact).filter(SiteContact.customer_site_id == site_id).count()
+
+    try:
+        # contact1 already has jane@acme.com — case-insensitive dedup.
+        resp = client.post(
+            f"/v2/partials/proactive/prepare/{site_id}/add-contact",
+            data={"full_name": "Jane Dup", "email": "JANE@acme.com"},
+        )
+    finally:
+        _cleanup_overrides(app)
+
+    assert resp.status_code == 409
+    assert db_session.query(SiteContact).filter(SiteContact.customer_site_id == site_id).count() == before
+
+
+def test_add_contact_authz_requires_owned_match(db_session):
+    """A user with no proactive match at the site cannot add a contact (403)."""
+    data = _setup_send_scenario(db_session)
+    site_id = data["site"].id
+    stranger = User(
+        email="stranger@trioscs.com",
+        name="Stranger",
+        role="sales",
+        azure_id="x-999",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(stranger)
+    db_session.commit()
+
+    client, app = _add_contact_client(db_session, stranger)
+    before = db_session.query(SiteContact).filter(SiteContact.customer_site_id == site_id).count()
+    try:
+        resp = client.post(
+            f"/v2/partials/proactive/prepare/{site_id}/add-contact",
+            data={"full_name": "Sneaky", "email": "sneaky@acme.com"},
+        )
+    finally:
+        _cleanup_overrides(app)
+
+    assert resp.status_code == 403
+    assert db_session.query(SiteContact).filter(SiteContact.customer_site_id == site_id).count() == before
+
+
+def test_add_contact_missing_site_404(db_session):
+    """Posting to a nonexistent site returns 404."""
+    data = _setup_send_scenario(db_session)
+    client, app = _add_contact_client(db_session, data["owner"])
+    try:
+        resp = client.post(
+            "/v2/partials/proactive/prepare/999999/add-contact",
+            data={"full_name": "Ghost", "email": "ghost@acme.com"},
+        )
+    finally:
+        _cleanup_overrides(app)
+    assert resp.status_code == 404
+
+
+def test_prepare_page_renders_add_contact_affordance(db_session):
+    """The Prepare page exposes the inline add-contact form + picker container."""
+    data = _setup_send_scenario(db_session)
+    client, app = _add_contact_client(db_session, data["owner"])
+    try:
+        resp = client.post(
+            "/v2/proactive/prepare/{}".format(data["site"].id),
+            data={"match_ids": str(data["match"].id)},
+        )
+    finally:
+        _cleanup_overrides(app)
+
+    assert resp.status_code == 200, resp.text
+    assert 'id="proactive-contact-list"' in resp.text
+    assert f"/v2/partials/proactive/prepare/{data['site'].id}/add-contact" in resp.text
+    assert "showAddContact" in resp.text

--- a/tests/test_proactive_prepare.py
+++ b/tests/test_proactive_prepare.py
@@ -812,3 +812,41 @@ def test_prepare_page_renders_add_contact_affordance(db_session):
     assert 'id="proactive-contact-list"' in resp.text
     assert f"/v2/partials/proactive/prepare/{data['site'].id}/add-contact" in resp.text
     assert "showAddContact" in resp.text
+
+
+def test_afterswap_reinits_alpine_on_proactive_contact_list():
+    """Regression guard for the htmx+Alpine re-init bug.
+
+    The add-contact POST swaps the re-rendered picker into #proactive-contact-list via
+    hx-swap="innerHTML". This codebase only re-runs Alpine.initTree on HTMX-swapped
+    nodes for an explicit allowlist in the htmx:afterSwap handler. If 'proactive-
+    contact-list' is absent, the swapped checkbox rows go inert: the new contact's
+    x-init auto-select never fires (Send stays disabled) and existing checkboxes lose
+    :checked / @change. Assert the swap target id (the one the form's hx-target actually
+    uses) is in that Alpine.initTree allowlist.
+    """
+    import re
+    from pathlib import Path
+
+    js = Path("app/static/htmx_app.js").read_text()
+
+    # Isolate the afterSwap Alpine.initTree gate: the `if (...) { Alpine.initTree(t); }`
+    # block guarded by `typeof Alpine.initTree === 'function'`. Matching just this region
+    # ensures the id is a genuine allowlist entry, not an incidental mention elsewhere.
+    m = re.search(
+        r"typeof Alpine\.initTree === 'function'.*?Alpine\.initTree\(t\)",
+        js,
+        re.DOTALL,
+    )
+    assert m is not None, "afterSwap Alpine.initTree gate not found in htmx_app.js"
+    allowlist = m.group(0)
+
+    # The swap target the add-contact form posts into (hx-target in prepare.html).
+    assert "proactive-contact-list" in allowlist, (
+        "#proactive-contact-list must be in the afterSwap Alpine.initTree allowlist so "
+        "the swapped picker re-inits (x-init auto-select + :checked/@change bindings)"
+    )
+    # Sibling entries must survive alongside it (mirrors rfq-affinity-section exactly).
+    assert "rfq-affinity-section" in allowlist
+    assert "settings-content" in allowlist
+    assert "lead-drawer-content" in allowlist


### PR DESCRIPTION
## PROACTIVE-04

On the Proactive **Prepare** page, **Send** was disabled whenever the customer site had no emailable contact — with no way to add one from the page. This makes the offer flow a dead end for any site missing a contact.

## Fix

Adds an inline **Add contact** affordance to the **Send To** card:

- A toggle button in the card header reveals a compact inline form (Name, Email, optional Title), styled with the page's own design tokens (`.input`, `.btn-primary`, `.btn-ghost`, `--accent`).
- Submitting `hx-post`s to a new partial route, which re-renders the contact picker into `#proactive-contact-list` and **auto-selects the freshly-added contact** (`x-init` → the existing `toggleContact`) so the Alpine-disabled Send button unblocks in a single step.
- On success the form resets and collapses; on any validation failure it stays open with the entered values.

## Implementation

- Extracted the Send To contact rows into `app/templates/htmx/partials/proactive/_contact_picker.html`, shared by the initial `prepare.html` render and the add-contact endpoint (identical fields/ordering).
- New `POST /v2/partials/proactive/prepare/{site_id}/add-contact` in `app/routers/htmx/proactive.py`:
  - **Authorization**: caller must own a `ProactiveMatch` at the site (the same relationship that lets them reach Prepare) → else 403.
  - Per-site **case-insensitive email dedup** (mirrors the canonical `contacts_tab_create`) → 409.
  - Validation (missing name/email, malformed email) raises 4xx, surfaced by the global `htmx:responseError` toast handler; no swap, form stays open.
  - CSRF is handled globally by the `htmx:configRequest` header hook — no hidden token field needed.

## Tests

`tests/test_proactive_prepare.py` — 8 new tests: create + auto-select (only the new row gets `x-init`), first-contact unblocks an empty site, name/email/format validation (400), dedup (409), authz (403), missing site (404), and Prepare renders the affordance. Full file + `tests/test_static_analysis.py` green (47 passed). Pre-commit (ruff/format/docformatter/mypy) clean. APP_MAP_ARCHITECTURE updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF