### PR TITLE
fix(enrichment): keep worker heartbeat fresh during cap/breaker sleeps

### DIFF
--- a/app/services/enrichment_worker/worker.py
+++ b/app/services/enrichment_worker/worker.py
@@ -86,6 +86,50 @@ def _record_heartbeat(db: Session, breaker: "EnrichmentCircuitBreaker") -> bool:
     return breaker_open
 
 
+def _heartbeat_sleep_chunk_seconds() -> int:
+    """Max seconds to sleep between heartbeat refreshes during a long cap/breaker sleep.
+
+    A third of the liveness watchdog's stale window (floored at 60s), so the heartbeat is
+    refreshed several times over before it could ever be judged stale. Derived from
+    ``settings.worker_heartbeat_stale_minutes`` — the SAME threshold the watchdog uses — so
+    lowering that threshold automatically tightens the chunk instead of silently
+    re-introducing the false alarm.
+    """
+    from app.config import settings
+
+    return max(60, (settings.worker_heartbeat_stale_minutes * 60) // 3)
+
+
+async def _sleep_with_heartbeat(total_seconds: int, breaker: "EnrichmentCircuitBreaker") -> None:
+    """Sleep ``total_seconds`` in heartbeat-sized chunks, refreshing the heartbeat
+    between.
+
+    The daily-cap and circuit-breaker branches idle ~1h. A single ``asyncio.sleep(3600)``
+    lets ``last_heartbeat`` go stale mid-sleep, so the liveness watchdog false-alarms
+    "heartbeat stale" on a perfectly healthy, legitimately-capped/paused worker. Chunking
+    the sleep and calling ``_record_heartbeat`` after each chunk keeps the heartbeat fresh.
+
+    Real-hang detection is NOT weakened: the heartbeat is only refreshed AFTER a chunk the
+    worker actually finished sleeping through, so a wedged event loop / stuck heartbeat
+    write still lets the heartbeat go stale and the watchdog fires. Also honors
+    ``_shutdown_requested`` so a SIGTERM during the sleep exits within one chunk instead of
+    blocking the full hour.
+    """
+    from app.database import SessionLocal
+
+    chunk = _heartbeat_sleep_chunk_seconds()
+    slept = 0
+    while slept < total_seconds and not _shutdown_requested:
+        this_chunk = min(chunk, total_seconds - slept)
+        await asyncio.sleep(this_chunk)
+        slept += this_chunk
+        db = SessionLocal()
+        try:
+            _record_heartbeat(db, breaker)
+        finally:
+            db.close()
+
+
 def _load_today_counters(db: Session, today_date: date) -> dict:
     """Hydrate the worker's in-memory daily counters from the persisted status row.
 
@@ -990,25 +1034,29 @@ async def main() -> None:
                     web_state["web_calls"] = 0
                     web_state["oem_resolves"] = 0
 
-                # Daily cap check — long sleep when exhausted
+                # Daily cap check — long sleep when exhausted. Chunked so the heartbeat
+                # keeps refreshing through the hour (a LEGITIMATE cap sleep must not look
+                # like a hang to the liveness watchdog); a genuine hang mid-sleep still
+                # goes silent and is caught.
                 if enriched_today >= config.daily_cap:
                     logger.info(
                         "ENRICH_WORKER: daily cap reached ({}/{}), sleeping 1h",
                         enriched_today,
                         config.daily_cap,
                     )
-                    await asyncio.sleep(3600)
+                    await _sleep_with_heartbeat(3600, breaker)
                     continue
 
                 # Circuit breaker check — long sleep when open. Reuses the breaker_open
                 # value already persisted by _record_heartbeat at the top of this tick, so
-                # the status write is not duplicated here.
+                # the status write is not duplicated here. Chunked (same reason as the cap
+                # sleep) so a paused-on-breaker worker keeps heartbeating.
                 if breaker_open:
                     logger.error(
                         "ENRICH_WORKER: circuit breaker open ({}), sleeping 1h",
                         breaker.get_trip_info()["trip_reason"],
                     )
-                    await asyncio.sleep(3600)
+                    await _sleep_with_heartbeat(3600, breaker)
                     continue
 
                 # Run one batch. The session is closed exactly once (in finally) so the

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -541,6 +541,14 @@ tick via `_record_heartbeat()` at the top of the loop — so the heartbeat
 reflects process liveness independent of work, and stays fresh on idle /
 cap-sleep / breaker-open / off-hours paths (a liveness monitor reading
 `last_heartbeat` won't false-alarm "DOWN" while a worker is merely paused).
+The enrichment worker's LONG (~1h) daily-cap and circuit-breaker sleeps would
+otherwise let the heartbeat lapse mid-sleep and false-alarm the watchdog, so
+those two sleeps run through `_sleep_with_heartbeat()` — it splits the hour into
+chunks (a third of `settings.worker_heartbeat_stale_minutes`, floored at 60s)
+and re-touches the heartbeat after each chunk. Real-hang detection is preserved:
+the refresh only follows a chunk the worker actually finished sleeping through,
+so a wedged loop still goes silent and is caught (the chunk loop also honors the
+shutdown flag so SIGTERM exits within one chunk).
 
 **Proactive liveness watchdog.** Beyond the on-demand Connectors-page read, a
 scheduler job (`app/jobs/worker_liveness_jobs.py`, registered by

--- a/tests/test_enrichment_worker_coverage.py
+++ b/tests/test_enrichment_worker_coverage.py
@@ -17,6 +17,8 @@ import sys
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 os.environ["TESTING"] = "1"
 
 
@@ -216,17 +218,23 @@ async def test_main_empty_batch_uses_idle_sleep():
 # ---------------------------------------------------------------------------
 
 
-async def test_main_daily_cap_sleeps_one_hour():
-    """When daily_cap is reached, main() sleeps 1h before the next batch."""
+async def test_main_daily_cap_sleeps_in_heartbeat_chunks():
+    """When daily_cap is reached, main() sleeps 1h in watchdog-safe chunks (never a
+    single silent 3600s sleep) so the liveness watchdog does not false-alarm on a capped
+    worker."""
     import app.services.enrichment_worker.worker as w
+    from app.config import settings
 
     original = w._shutdown_requested
     w._shutdown_requested = False
     sleep_calls = []
+    chunk = w._heartbeat_sleep_chunk_seconds()
 
     async def fake_sleep(secs):
         sleep_calls.append(secs)
-        if secs == 3600:
+        # The first cap-sleep chunk is enough to prove the behavior — shut down so the
+        # (otherwise forever-capped) loop terminates.
+        if secs == chunk:
             w._shutdown_requested = True
 
     async def fake_batch(*args, **kwargs):
@@ -243,7 +251,10 @@ async def test_main_daily_cap_sleeps_one_hour():
     finally:
         w._shutdown_requested = original
 
-    assert 3600 in sleep_calls
+    stale_seconds = settings.worker_heartbeat_stale_minutes * 60
+    assert chunk in sleep_calls  # cap path slept in chunks
+    assert 3600 not in sleep_calls  # never one silent hour-long sleep
+    assert all(s <= stale_seconds for s in sleep_calls)  # every chunk stays within the window
 
 
 # ---------------------------------------------------------------------------
@@ -251,8 +262,9 @@ async def test_main_daily_cap_sleeps_one_hour():
 # ---------------------------------------------------------------------------
 
 
-async def test_main_circuit_breaker_open_sleeps_one_hour():
-    """When circuit breaker is open, main() sleeps 1h and updates CB status."""
+async def test_main_circuit_breaker_open_sleeps_in_heartbeat_chunks():
+    """When the circuit breaker is open, main() sleeps 1h in watchdog-safe chunks (never
+    a single silent 3600s sleep) so a paused-on-breaker worker keeps heartbeating."""
     import app.services.enrichment_worker.worker as w
     from app.services.enrichment_worker.circuit_breaker import EnrichmentCircuitBreaker
     from app.services.enrichment_worker.config import EnrichmentWorkerConfig
@@ -260,10 +272,11 @@ async def test_main_circuit_breaker_open_sleeps_one_hour():
     original = w._shutdown_requested
     w._shutdown_requested = False
     sleep_calls = []
+    chunk = w._heartbeat_sleep_chunk_seconds()
 
     async def fake_sleep(secs):
         sleep_calls.append(secs)
-        if secs == 3600:
+        if secs == chunk:
             w._shutdown_requested = True
 
     cfg = EnrichmentWorkerConfig(circuit_breaker_errors=1)
@@ -285,7 +298,121 @@ async def test_main_circuit_breaker_open_sleeps_one_hour():
     finally:
         w._shutdown_requested = original
 
-    assert 3600 in sleep_calls
+    assert chunk in sleep_calls  # breaker path slept in chunks
+    assert 3600 not in sleep_calls  # never one silent hour-long sleep
+
+
+# ---------------------------------------------------------------------------
+# _sleep_with_heartbeat — chunked cap/breaker sleep that keeps the heartbeat fresh
+# (liveness-watchdog false-alarm fix) WITHOUT weakening real-hang detection
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_sleep_chunk_stays_within_stale_window():
+    """The chunk is derived from the SAME stale threshold the watchdog uses and stays
+    comfortably inside it, so the coupling can't silently regress."""
+    from app.config import settings
+    from app.services.enrichment_worker.worker import _heartbeat_sleep_chunk_seconds
+
+    chunk = _heartbeat_sleep_chunk_seconds()
+    stale_seconds = settings.worker_heartbeat_stale_minutes * 60
+    assert 0 < chunk < stale_seconds
+
+
+async def test_sleep_with_heartbeat_refreshes_each_chunk():
+    """A capped worker keeps its heartbeat FRESH: the 1h sleep is split into chunks that
+    stay within the watchdog's stale window, and the heartbeat is refreshed after each."""
+    import app.services.enrichment_worker.worker as w
+    from app.config import settings
+
+    sleeps = []
+    hb_calls = []
+
+    async def fake_sleep(secs):
+        sleeps.append(secs)
+
+    def fake_hb(db, breaker):
+        hb_calls.append(True)
+        return False
+
+    original = w._shutdown_requested
+    w._shutdown_requested = False
+    try:
+        with (
+            patch("asyncio.sleep", side_effect=fake_sleep),
+            patch("app.database.SessionLocal", return_value=_mock_db()),
+            patch.object(w, "_record_heartbeat", side_effect=fake_hb),
+        ):
+            await w._sleep_with_heartbeat(3600, breaker=MagicMock())
+    finally:
+        w._shutdown_requested = original
+
+    stale_seconds = settings.worker_heartbeat_stale_minutes * 60
+    assert sum(sleeps) == 3600  # sleeps the full hour, in pieces
+    assert max(sleeps) < stale_seconds  # every gap stays inside the stale window
+    assert len(hb_calls) == len(sleeps)  # heartbeat refreshed after every chunk
+    assert len(hb_calls) >= 3  # several refreshes across the hour
+
+
+async def test_sleep_with_heartbeat_no_refresh_on_wedged_chunk():
+    """Real-hang detection is PRESERVED: if a sleep chunk never completes (wedged event
+    loop), the heartbeat is NOT refreshed for that chunk — it goes stale and the watchdog
+    fires. Refreshes only ever follow chunks the worker actually slept through."""
+    import app.services.enrichment_worker.worker as w
+
+    hb_calls = []
+    sleep_n = [0]
+
+    async def wedge_on_third(secs):
+        sleep_n[0] += 1
+        if sleep_n[0] == 3:
+            raise RuntimeError("event loop wedged")
+
+    def fake_hb(db, breaker):
+        hb_calls.append(True)
+        return False
+
+    original = w._shutdown_requested
+    w._shutdown_requested = False
+    try:
+        with (
+            patch("asyncio.sleep", side_effect=wedge_on_third),
+            patch("app.database.SessionLocal", return_value=_mock_db()),
+            patch.object(w, "_record_heartbeat", side_effect=fake_hb),
+        ):
+            with pytest.raises(RuntimeError):
+                await w._sleep_with_heartbeat(3600, breaker=MagicMock())
+    finally:
+        w._shutdown_requested = original
+
+    # Only the 2 completed chunks refreshed; the wedged 3rd chunk did NOT.
+    assert len(hb_calls) == 2
+
+
+async def test_sleep_with_heartbeat_exits_on_shutdown():
+    """A SIGTERM during the long sleep exits within one chunk instead of blocking the
+    whole hour — the shutdown flag is honored between chunks."""
+    import app.services.enrichment_worker.worker as w
+
+    sleeps = []
+
+    async def fake_sleep(secs):
+        sleeps.append(secs)
+        w._shutdown_requested = True  # SIGTERM arrives during the first chunk
+
+    original = w._shutdown_requested
+    w._shutdown_requested = False
+    try:
+        with (
+            patch("asyncio.sleep", side_effect=fake_sleep),
+            patch("app.database.SessionLocal", return_value=_mock_db()),
+            patch.object(w, "_record_heartbeat", return_value=False),
+        ):
+            await w._sleep_with_heartbeat(3600, breaker=MagicMock())
+    finally:
+        w._shutdown_requested = original
+
+    assert len(sleeps) == 1  # stopped after the first chunk, not all 12
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The liveness watchdog (`app/jobs/worker_liveness_jobs.py`, `WORKER_HEARTBEAT_STALE_MINUTES=15`) false-alarmed **"heartbeat is stale"** whenever the enrichment worker was in its LEGITIMATE ~1h daily-cap sleep (it logs `daily cap reached, sleeping 1h`). The circuit-breaker-open path had the identical bug.

**Root cause:** the worker refreshes `last_heartbeat` once at the top of each loop tick, then `await asyncio.sleep(3600)`. During that hour the heartbeat lapses far past the 15-min stale window, so the watchdog fires a bogus Teams + Sentry alert on a perfectly healthy, merely-paused worker.

## Fix

Both long (~1h) sleeps — daily-cap and circuit-breaker — now run through `_sleep_with_heartbeat()`, which splits the hour into chunks (a third of `settings.worker_heartbeat_stale_minutes`, floored at 60s — derived from the **same** threshold the watchdog reads) and re-touches the heartbeat via `_record_heartbeat()` after each chunk.

**Real-hang detection is NOT weakened:** the refresh only follows a chunk the worker actually finished sleeping through, so a wedged event loop / stuck heartbeat write still goes silent and the watchdog catches it. The chunk loop also honors `_shutdown_requested`, so SIGTERM now exits within one chunk instead of blocking the full hour.

## Tests

- `test_sleep_with_heartbeat_refreshes_each_chunk` — a capped worker keeps its heartbeat fresh: sleeps the full hour in pieces that stay within the stale window, refreshed after each chunk.
- `test_sleep_with_heartbeat_no_refresh_on_wedged_chunk` — a hang mid-sleep yields no further refresh (hang detection preserved).
- `test_sleep_with_heartbeat_exits_on_shutdown` — SIGTERM exits within one chunk.
- `test_heartbeat_sleep_chunk_stays_within_stale_window` — the derivation stays inside the watchdog window.
- Updated the two `main()` cap/breaker tests to assert chunked (not single-3600s) sleeps.

Updated `docs/APP_MAP_INTERACTIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF