### PR TITLE
feat(crm): surface create/edit-account forms as modal buttons (F7)

### DIFF
--- a/app/routers/htmx/companies.py
+++ b/app/routers/htmx/companies.py
@@ -3761,6 +3761,15 @@ async def edit_company(
     form = await request.form()
     name = form.get("name", "").strip()
     if name:
+        # Duplicate-name guard — mirror create_company. Company.name is nullable=False
+        # and NOT unique, so nothing else stops a rename colliding with another account.
+        # Exclude self (Company.id != company_id) so a no-op or case-only save on the
+        # same row doesn't false-positive.
+        existing = (
+            db.query(Company).filter(sqlfunc.lower(Company.name) == name.lower(), Company.id != company_id).first()
+        )
+        if existing:
+            raise HTTPException(409, f"Company '{existing.name}' already exists (ID {existing.id})")
         company.name = name
     notes = form.get("notes", "").strip()
     company.notes = notes or company.notes

--- a/app/routers/htmx/companies.py
+++ b/app/routers/htmx/companies.py
@@ -1165,7 +1165,12 @@ async def create_company(
     db.commit()
     logger.info("Company {} created by {}", company.id, user.email)
 
-    return await _render_company_detail(request, company.id, user, db)
+    # Load the new account's detail into the CDM right panel (form hx-target=#cdm-detail);
+    # the HX-Trigger tells the workspace's hidden listener to refresh the left account list
+    # so the freshly created row appears. On deep-link contexts (no listener) it no-ops.
+    resp = await _render_company_detail(request, company.id, user, db)
+    resp.headers["HX-Trigger"] = "cdmListRefresh"
+    return resp
 
 
 @router.get("/v2/partials/customers/typeahead", response_class=HTMLResponse)
@@ -3805,7 +3810,12 @@ async def edit_company(
     db.commit()
     logger.info("Company {} edited by {}", company_id, user.email)
 
-    return await _render_company_detail(request, company_id, user, db)
+    # Refreshed detail replaces the detail root in place (form hx-target=#company-detail-<id>,
+    # outerHTML) so it works in both the workspace and a deep-linked full page. The HX-Trigger
+    # refreshes the left account list too (name/owner/type edits change the row) when present.
+    resp = await _render_company_detail(request, company_id, user, db)
+    resp.headers["HX-Trigger"] = "cdmListRefresh"
+    return resp
 
 
 # ── Inline Field Edit — Account (WS1) ─────────────────────────────────────

--- a/app/templates/htmx/partials/customers/_form_fields.html
+++ b/app/templates/htmx/partials/customers/_form_fields.html
@@ -1,7 +1,6 @@
 {# _form_fields.html — Shared field macros for the company create/edit forms.
    Extracted from create_form.html and edit_form.html to remove copy-paste of the
-   account-owner <select> and the submit/cancel button row. Each macro emits markup
-   byte-identical to the inline version it replaced.
+   account-owner <select>.
 
    Call convention: the macro body's first line carries no leading indentation, so
    the call site supplies the opening indent, e.g. `      {{ owner_select(users) }}`.
@@ -23,22 +22,5 @@
           <option value="{{ u.id }}"{% if with_selection %} {{ 'selected' if selected_id == u.id else '' }}{% endif %}>{{ u.name }} ({{ u.role }})</option>
           {% endfor %}
         </select>
-      </div>
-{%- endmacro -%}
-
-{# Submit + Cancel row. `submit_label` is the primary button text; `cancel_url`
-   is the hx-get the Cancel button navigates back to (swapped into #main-content). #}
-{%- macro submit_cancel(submit_label, cancel_url) -%}
-<div class="flex items-center gap-3 pt-2">
-        <button type="submit"
-                class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-md hover:bg-brand-600">
-          {{ submit_label }}
-        </button>
-        <button type="button"
-                hx-get="{{ cancel_url }}"
-                hx-target="#main-content"
-                class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200">
-          Cancel
-        </button>
       </div>
 {%- endmacro -%}

--- a/app/templates/htmx/partials/customers/create_form.html
+++ b/app/templates/htmx/partials/customers/create_form.html
@@ -1,15 +1,22 @@
-{# create_form.html — Create new company form.
-   Receives: users (list[User]).
-   Called by: htmx_views.py company_create_form route.
-   Depends on: HTMX, Tailwind CSS with brand palette, _form_fields.html macros.
+{# create_form.html — Create new company form, loaded into #modal-content via
+   $dispatch('open-modal', {url: '/v2/partials/customers/create-form'}). The base modal
+   renders its own ✕ / backdrop / Escape (base.html).
+   Receives: users (list[User]); crm_industries (Jinja global).
+   Called by: GET /v2/partials/customers/create-form (companies.py), surfaced by the
+     "+ New account" button on the CDM account list (list.html).
+   Success: the new account's detail swaps into #cdm-detail, the modal closes, and the
+     handler's HX-Trigger=cdmListRefresh refreshes the left account list. Errors surface
+     via the global htmx:responseError toast (htmx_app.js) with the modal kept open.
+   Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette, _form_fields.html macros.
 #}
-{% from "htmx/partials/customers/_form_fields.html" import owner_select, submit_cancel -%}
-<div class="max-w-2xl mx-auto">
-  <div class="bg-white rounded-lg shadow border border-gray-200 p-6">
-    <h2 class="text-lg font-bold text-gray-900 mb-4">Create Company</h2>
+{% from "htmx/partials/customers/_form_fields.html" import owner_select -%}
+<div class="p-5">
+    <h3 id="modal-title" class="text-lg font-bold text-gray-900 mb-4">Create Company</h3>
 
     <form hx-post="/v2/partials/customers/create"
-          hx-target="#main-content"
+          hx-target="#cdm-detail"
+          hx-swap="innerHTML"
+          hx-on::after-request='if(event.detail.successful) $dispatch("close-modal")'
           data-loading-disable
           class="space-y-4">
 
@@ -155,7 +162,13 @@
                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500"></textarea>
       </div>
 
-      {{ submit_cancel("Create Company", "/v2/partials/customers") }}
+      <div class="flex justify-end gap-2 pt-1">
+        <button type="button" @click='$dispatch("close-modal")'
+                class="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Cancel</button>
+        <button type="submit"
+                class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+          Create account
+        </button>
+      </div>
     </form>
-  </div>
 </div>

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -16,8 +16,10 @@
    data-detail-root marks this partial's own root so account actions (Reactivate /
    Archive / Send-to-Prospecting) can target `closest [data-detail-root]` and re-swap
    themselves whether they render inside the CDM workspace right panel (#cdm-detail) or
-   standalone in #main-content on a deep-linked/reloaded page. #}
-<div data-detail-root class="space-y-4 page-fluid">
+   standalone in #main-content on a deep-linked/reloaded page. The stable id lets the
+   Edit-account modal (which lives OUTSIDE this root, in #modal-content, so `closest`
+   can't reach it) re-swap this detail in place via outerHTML in either context. #}
+<div id="company-detail-{{ company.id }}" data-detail-root class="space-y-4 page-fluid">
 
   {# ── Breadcrumb — "Customers › {Account}" (you-are-here for the right panel).
      Reuses the treatment from the retired site_detail.html. "Customers" is the
@@ -206,6 +208,16 @@
           <div x-show="open" x-cloak
                role="menu"
                class="absolute right-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-lg z-20 py-1 text-xs text-left">
+            {# Edit account — opens the full account edit form as a modal. Most fields are
+               also inline-editable in the header/settings grid, so the full form is an
+               overflow action alongside Merge/Archive. #}
+            <button type="button"
+                    hx-get="/v2/partials/customers/{{ company.id }}/edit-form"
+                    hx-target="#modal-content"
+                    hx-swap="innerHTML"
+                    @click.stop="$dispatch('open-modal'); open = false"
+                    role="menuitem"
+                    class="w-full text-left px-3 py-1.5 text-gray-700 hover:bg-gray-50">Edit account</button>
             {# Merge duplicate — opens modal with search + confirm flow #}
             <button type="button"
                     hx-get="/v2/partials/customers/{{ company.id }}/merge-form"

--- a/app/templates/htmx/partials/customers/edit_form.html
+++ b/app/templates/htmx/partials/customers/edit_form.html
@@ -1,15 +1,24 @@
-{# edit_form.html — Inline edit form for company fields.
-   Receives: company (Company), users (list[User]).
-   Called by: htmx_views.py company_edit_form route.
-   Depends on: HTMX, Tailwind CSS with brand palette, _form_fields.html macros.
+{# edit_form.html — Edit form for company fields, loaded into #modal-content via
+   $dispatch('open-modal', {url: '/v2/partials/customers/{id}/edit-form'}). The base modal
+   renders its own ✕ / backdrop / Escape (base.html).
+   Receives: company (Company), users (list[User]), all_companies (list[Company]);
+     crm_industries (Jinja global).
+   Called by: GET /v2/partials/customers/{id}/edit-form (companies.py), surfaced by the
+     "Edit account" item in the company-detail kebab menu (detail.html).
+   Success: the refreshed detail replaces #company-detail-{id} (outerHTML — works in the
+     workspace right panel AND a deep-linked full page), the modal closes, and the handler's
+     HX-Trigger=cdmListRefresh refreshes the left account list. Errors surface via the
+     global htmx:responseError toast (htmx_app.js) with the modal kept open.
+   Depends on: HTMX, Alpine.js, Tailwind CSS with brand palette, _form_fields.html macros.
 #}
-{% from "htmx/partials/customers/_form_fields.html" import owner_select, submit_cancel -%}
-<div class="max-w-2xl mx-auto">
-  <div class="bg-white rounded-lg shadow border border-gray-200 p-6">
-    <h2 class="text-lg font-bold text-gray-900 mb-4">Edit Company</h2>
+{% from "htmx/partials/customers/_form_fields.html" import owner_select -%}
+<div class="p-5">
+    <h3 id="modal-title" class="text-lg font-bold text-gray-900 mb-4">Edit Company</h3>
 
     <form hx-post="/v2/partials/customers/{{ company.id }}/edit"
-          hx-target="#main-content"
+          hx-target="#company-detail-{{ company.id }}"
+          hx-swap="outerHTML"
+          hx-on::after-request='if(event.detail.successful) $dispatch("close-modal")'
           data-loading-disable
           class="space-y-4">
 
@@ -193,7 +202,13 @@
                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">{{ company.notes or '' }}</textarea>
       </div>
 
-      {{ submit_cancel("Save Changes", "/v2/partials/customers/" ~ company.id) }}
+      <div class="flex justify-end gap-2 pt-1">
+        <button type="button" @click='$dispatch("close-modal")'
+                class="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Cancel</button>
+        <button type="submit"
+                class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+          Save Changes
+        </button>
+      </div>
     </form>
-  </div>
 </div>

--- a/app/templates/htmx/partials/customers/edit_form.html
+++ b/app/templates/htmx/partials/customers/edit_form.html
@@ -23,8 +23,8 @@
           class="space-y-4">
 
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">Company Name</label>
-        <input type="text" name="name" value="{{ company.name or '' }}"
+        <label class="block text-sm font-medium text-gray-700 mb-1">Company Name *</label>
+        <input type="text" name="name" value="{{ company.name or '' }}" required
                class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
       </div>
 

--- a/app/templates/htmx/partials/customers/list.html
+++ b/app/templates/htmx/partials/customers/list.html
@@ -15,6 +15,18 @@
      x-data="{ selectedId: null, autoSelectFirst() { if (this.selectedId !== null) return; const detail = this.$el.querySelector('#cdm-detail'); if (!detail || !detail.querySelector('[data-cdm-empty]')) return; const first = this.$el.querySelector('#cdm-list [role=\'button\'][hx-get]'); if (first) first.click() } }"
      x-init="$nextTick(() => autoSelectFirst())">
 
+  {# List-refresh hook — the create/edit-account modals fire HX-Trigger=cdmListRefresh on
+     success; this hidden element reloads the left account list (honoring the live filters)
+     so a new or renamed account shows immediately. It lives inside the workspace, so a
+     deep-linked full-page edit (no workspace present) simply has no listener and the
+     trigger harmlessly no-ops. #}
+  <div hx-get="/v2/partials/customers/account-list"
+       hx-trigger="cdmListRefresh from:body"
+       hx-target="#cdm-list"
+       hx-swap="innerHTML"
+       hx-include="#cdm-filters"
+       class="hidden"></div>
+
   {# ── Filter / sort bar ─────────────────────────────────────── #}
   {# All filter controls use .input / .input-sm (accent ring, line border) per PR0. #}
   <form id="cdm-filters" class="flex items-center gap-1.5 flex-wrap pb-1 flex-shrink-0"
@@ -113,9 +125,24 @@
     {% include "htmx/partials/customers/_saved_views.html" %}
   </div>
 
-  {# Export + cross-company contacts links + Import — below the filter bar, above the split workspace #}
+  {# New account (primary CTA) + Export/contacts/Import utilities — below the filter bar,
+     above the split workspace. Until now accounts arrived only via CSV import (F7); the
+     "+ New account" button surfaces the existing create-account form as a modal. #}
   {# Import modal uses the shared modal-* primitives to match vendors import and the rest of the app. #}
-  <div class="flex justify-end gap-3 text-xs text-gray-600 mb-0.5" x-data="{ importOpen: false }">
+  <div class="flex items-center justify-between gap-3 mb-0.5" x-data="{ importOpen: false }">
+    {# + New account — loads the create-account form into #modal-content and opens the
+       global modal (base.html). On success the new account's detail fills #cdm-detail and
+       the list refreshes via HX-Trigger=cdmListRefresh. #}
+    <button type="button"
+            @click="$dispatch('open-modal')"
+            hx-get="/v2/partials/customers/create-form"
+            hx-target="#modal-content"
+            hx-swap="innerHTML"
+            data-loading-disable
+            class="btn btn-primary btn-sm whitespace-nowrap">
+      + New account
+    </button>
+    <div class="flex items-center gap-3 text-xs text-gray-600">
     <a hx-get="/v2/partials/contacts" hx-target="#main-content" hx-push-url="/v2/contacts"
        class="hover:text-accent-600 hover:underline cursor-pointer">All contacts</a>
     {# Export honors the CURRENT filtered view: @click.prevent rebuilds the download URL
@@ -126,6 +153,7 @@
     <a href="/v2/customers/contacts/export.csv" class="hover:text-accent-600 hover:underline">Export contacts</a>
     <button type="button" @click="importOpen = true"
             class="hover:text-accent-600 hover:underline cursor-pointer">Import CSV</button>
+    </div>
 
     {# Import modal — built on shared modal-* primitives to match vendors import modal. #}
     <div x-show="importOpen" x-cloak

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2383,6 +2383,22 @@ CDM left list (`_account_list.html`), regardless of `site_count`, hx-gets the SA
   GET → 405).
 - **Breadcrumb** `Customers › {Account}` (`<nav aria-label="Breadcrumb">`) sits at
   the top of `detail.html` (reused from the retired `site_detail.html`).
+- **Create / edit account (F7 — modal buttons).** The create/edit-account forms are
+  surfaced as modals (they previously had NO UI entry — accounts arrived only via CSV
+  import). The `+ New account` primary button (`list.html`, above the split workspace)
+  `$dispatch('open-modal')` + hx-gets `GET .../create-form` into `#modal-content`;
+  `create_form.html` posts to `POST .../create` targeting `#cdm-detail` (the new account's
+  detail fills the right panel). The `Edit account` kebab item (`detail.html`) hx-gets
+  `GET .../{id}/edit-form`; `edit_form.html` posts to `POST .../{id}/edit` targeting
+  `#company-detail-{id}` with `outerHTML` (the `data-detail-root` div now carries that
+  stable id, so the modal — which lives outside the root and can't use `closest` — re-swaps
+  the detail in place in BOTH the workspace and a deep-linked full page). Both handlers set
+  `HX-Trigger=cdmListRefresh`; a hidden listener in `list.html` reloads `#cdm-list` (honoring
+  live `#cdm-filters`) so a new/renamed account shows immediately (no-ops on deep-link, where
+  no listener exists). Both forms close the modal on success via `hx-on::after-request`; 4xx
+  (missing name 400, duplicate 409, cross-owner 403) surfaces through the global
+  `htmx:responseError` toast with the modal kept open. The shared `submit_cancel` macro
+  (which navigated `#main-content`) was removed; `owner_select` remains.
 - **Contacts is the default + primary right-panel surface.** `contacts_tab.html`
   (the ONLY contact-management surface, full feature set) wraps the
   `contactsView` Alpine.data component (`htmx_app.js`): a people-search + a site

--- a/tests/test_crm_account_crud_buttons.py
+++ b/tests/test_crm_account_crud_buttons.py
@@ -1,0 +1,121 @@
+"""test_crm_account_crud_buttons.py — F7: surface the create/edit-account forms as
+modals.
+
+Verifies the buttons that wire the previously-orphaned create-account and edit-account
+forms into the CRM: the "+ New account" button on the account list, the "Edit account"
+kebab item on company detail, that both forms are modal-shaped (refresh the list/detail
+via the correct hx-target, never a #main-content wipe), and that a successful create/edit
+fires HX-Trigger=cdmListRefresh so the left account list refreshes.
+
+Called by: pytest
+Depends on: conftest.py fixtures (client, db_session, test_company, test_user),
+            app.routers.htmx.companies
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Company, User
+
+_HX = {"HX-Request": "true"}
+
+
+# ── Account list: "+ New account" button + refresh listener ──────────────────
+
+
+class TestNewAccountButton:
+    def test_list_has_new_account_button(self, client: TestClient, test_company: Company):
+        resp = client.get("/v2/partials/customers", headers=_HX)
+        assert resp.status_code == 200
+        # Button opens the create-account form as a modal (loads into #modal-content).
+        assert "/v2/partials/customers/create-form" in resp.text
+        assert "+ New account" in resp.text
+        assert 'hx-target="#modal-content"' in resp.text
+
+    def test_list_has_refresh_listener(self, client: TestClient, test_company: Company):
+        """The workspace carries the hidden listener that reloads #cdm-list when a
+        create/edit modal fires cdmListRefresh."""
+        resp = client.get("/v2/partials/customers", headers=_HX)
+        assert resp.status_code == 200
+        assert "cdmListRefresh from:body" in resp.text
+        assert 'hx-target="#cdm-list"' in resp.text
+
+
+# ── Company detail: "Edit account" affordance + stable root id ───────────────
+
+
+class TestEditAffordance:
+    def test_detail_has_edit_affordance(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{test_company.id}", headers=_HX)
+        assert resp.status_code == 200
+        assert f"/v2/partials/customers/{test_company.id}/edit-form" in resp.text
+        assert 'hx-target="#modal-content"' in resp.text
+
+    def test_detail_root_has_stable_id(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
+        """The edit modal (outside the detail root) re-swaps the detail via this id."""
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{test_company.id}", headers=_HX)
+        assert resp.status_code == 200
+        assert f'id="company-detail-{test_company.id}"' in resp.text
+
+
+# ── Forms are modal-shaped (refresh detail/list, never wipe #main-content) ───
+
+
+class TestFormsAreModalShaped:
+    def test_create_form_targets_detail_not_shell(self, client: TestClient):
+        resp = client.get("/v2/partials/customers/create-form", headers=_HX)
+        assert resp.status_code == 200
+        assert 'hx-target="#cdm-detail"' in resp.text
+        assert 'hx-target="#main-content"' not in resp.text
+        # Closes the modal on a successful submit.
+        assert "close-modal" in resp.text
+
+    def test_edit_form_targets_detail_root_not_shell(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        resp = client.get(f"/v2/partials/customers/{test_company.id}/edit-form", headers=_HX)
+        assert resp.status_code == 200
+        assert f'hx-target="#company-detail-{test_company.id}"' in resp.text
+        assert 'hx-swap="outerHTML"' in resp.text
+        assert 'hx-target="#main-content"' not in resp.text
+        assert "close-modal" in resp.text
+
+
+# ── Successful create/edit fires the list-refresh trigger ────────────────────
+
+
+class TestListRefreshTrigger:
+    def test_create_fires_list_refresh(self, client: TestClient, db_session: Session):
+        resp = client.post(
+            "/v2/partials/customers/create",
+            data={"name": "Refresh Trigger Co"},
+            headers=_HX,
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Trigger") == "cdmListRefresh"
+        assert db_session.query(Company).filter(Company.name == "Refresh Trigger Co").first() is not None
+
+    def test_edit_fires_list_refresh(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+        resp = client.post(
+            f"/v2/partials/customers/{test_company.id}/edit",
+            data={"name": "Renamed Account Co"},
+            headers=_HX,
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Trigger") == "cdmListRefresh"
+        db_session.refresh(test_company)
+        assert test_company.name == "Renamed Account Co"

--- a/tests/test_edit_company_name_validation.py
+++ b/tests/test_edit_company_name_validation.py
@@ -1,0 +1,78 @@
+"""test_edit_company_name_validation.py — Regression tests closing two fake-success gaps
+in the edit-account flow now that its form is user-reachable.
+
+1. The edit form's Company Name input must carry the ``required`` attribute the create
+   form has, so the browser can't silently submit a blank name.
+2. POST /v2/partials/customers/{id}/edit must reject renaming an account onto another
+   existing account's name with the same 409 the create path uses (Company.name is
+   nullable=False and NOT unique, so nothing else stops a colliding rename).
+
+Called by: pytest
+Depends on: conftest.py fixtures (client auths as test_user; db_session, test_company, test_user)
+"""
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import Company, User
+
+
+class TestEditCompanyNameRequiredAttr:
+    def test_edit_form_name_input_has_required(self, client: TestClient, test_company: Company):
+        """The rendered edit form's name input must include ``required`` so a blank name
+        can't be silently submitted (parity with the create form)."""
+        resp = client.get(
+            f"/v2/partials/customers/{test_company.id}/edit-form",
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        html = resp.text
+        # Locate the name input and assert it carries the required attribute.
+        idx = html.find('name="name"')
+        assert idx != -1, "edit form is missing the company name input"
+        # The tag runs from the opening '<input' up to its closing '>'.
+        tag_start = html.rfind("<input", 0, idx)
+        tag_end = html.find(">", idx)
+        name_tag = html[tag_start:tag_end]
+        assert "required" in name_tag, f"name input is missing 'required': {name_tag!r}"
+
+
+class TestEditCompanyDuplicateName:
+    def test_edit_rejects_rename_onto_existing_name(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
+        """Renaming an account onto another account's existing name must 409 and leave
+        the name unchanged (mirrors create_company's duplicate guard)."""
+        # test_user owns test_company so can_manage_account passes.
+        test_company.account_owner_id = test_user.id
+        other = Company(name="Globex Corporation", is_active=True)
+        db_session.add(other)
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{test_company.id}/edit",
+            data={"name": "globex corporation"},  # case-insensitive collision
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 409
+        db_session.refresh(test_company)
+        assert test_company.name == "Acme Electronics"
+
+    def test_edit_allows_saving_same_name(
+        self, client: TestClient, test_company: Company, test_user: User, db_session: Session
+    ):
+        """A no-op save (name unchanged) must NOT be blocked by the self row — the
+        duplicate guard excludes the company being edited."""
+        test_company.account_owner_id = test_user.id
+        db_session.commit()
+
+        resp = client.post(
+            f"/v2/partials/customers/{test_company.id}/edit",
+            data={"name": test_company.name},
+            headers={"HX-Request": "true"},
+        )
+
+        assert resp.status_code == 200
+        db_session.refresh(test_company)
+        assert test_company.name == "Acme Electronics"


### PR DESCRIPTION
## What & why

F7: accounts previously arrived **only via CSV import** — the create-account and edit-account forms existed in the codebase but had **no UI entry point** (orphaned routes). This wires them into the CRM as modals.

## Changes

- **`+ New account`** primary button on the CDM account list (`list.html`) — `$dispatch('open-modal')` + hx-gets `GET .../create-form` into `#modal-content`. On success the new account's detail fills `#cdm-detail`.
- **`Edit account`** kebab item on company detail (`detail.html`) — opens `GET .../{id}/edit-form` as a modal. On success the refreshed detail replaces `#company-detail-{id}` via `outerHTML`, so it works in **both** the workspace right panel and a deep-linked full page. The `data-detail-root` div now carries that stable id (the modal lives outside the root, so `closest` can't reach it — an explicit id is required).
- Both `create`/`edit` handlers emit `HX-Trigger=cdmListRefresh`; a hidden listener in the workspace reloads the left account list so a new/renamed account shows immediately (no-ops on deep-link, where no listener exists).
- Forms reshaped for the modal shell (**no `#main-content` wipe**): they close the modal on success via `hx-on::after-request`. Errors (missing name 400, duplicate 409, cross-owner 403) surface through the global `htmx:responseError` toast with the modal kept open. The dead `submit_cancel` macro (which navigated `#main-content`) was removed; `owner_select` remains.

Mirrors the canonical modal-create pattern (requisitions `create-form` / `reqListRefresh`, contacts `_contact_form.html` `hx-on::after-request` close-modal).

## Tests

`tests/test_crm_account_crud_buttons.py` (8 tests): list button + refresh listener present, edit affordance + stable detail-root id, both forms modal-shaped (correct hx-target, never `#main-content`), and create/edit fire `HX-Trigger=cdmListRefresh`. Full CRM regression sweep green (575 + existing `test_sprint4_company_crud.py` + `test_static_analysis.py`).

APP_MAP_INTERACTIONS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF