### PR TITLE
feat(resell): award-winner picker + unaward reversal (RS-3)

### DIFF
--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -904,7 +904,8 @@ async def resell_submit_offer(
 
 def _toast(resp: Response, message: str) -> Response:
     """Attach the ``showToast`` HX-Trigger so an award/unaward confirms even though the
-    triggering button was swapped out of the DOM (mirrors sightings._toast)."""
+    triggering button was swapped out of the DOM (same pattern as
+    sightings._with_toast)."""
     resp.headers["HX-Trigger"] = json.dumps({"showToast": {"message": message, "type": "success"}})
     return resp
 

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -33,6 +33,7 @@ from sqlalchemy.orm import Session
 
 from ..constants import (
     AccessKey,
+    ExcessLineItemStatus,
     ExcessListStatus,
     ExcessOfferScope,
     ExcessOfferStatus,
@@ -240,6 +241,7 @@ def _detail_context(request: Request, db: Session, el: ExcessList, user: User) -
         "list": el,
         "line_items": items,
         "line_count": len(items),
+        "awarded_line_count": sum(1 for it in items if it.status == ExcessLineItemStatus.AWARDED),
         "offer_count": offer_count,
         "take_all_count": take_all_count,
         "can_see_customer": can_see_customer,
@@ -378,40 +380,36 @@ async def resell_lines(
     return template_response("htmx/partials/resell/_lines.html", _detail_context(request, db, el, user))
 
 
-@router.get("/v2/partials/resell/{list_id}/offers", response_class=HTMLResponse)
-async def resell_offers(
-    request: Request,
-    list_id: int,
-    user: User = Depends(require_user),
-    db: Session = Depends(get_db),
-):
-    """Lazy Offers tab body — per-line offer stacks + pinned take-all banner.
+def _offers_context(request: Request, db: Session, el: ExcessList, user: User) -> dict:
+    """Build the Offers tab context — per-line offer stacks + pinned take-all banners.
 
-    Offers are the owner's private view — non-owners must not see other brokers' quotes.
-    If the requester is not the owner, render the "offers are private" state without
-    querying or passing any offer data.
+    Offers are the owner's private view: a non-owner gets an empty stack (the template
+    renders the "offers are private" state instead). ``take_all_blocked`` is True once any
+    line is already awarded, which disables a whole-list take-all award (it would collide
+    with the per-line winner). Caller must have already authorized access to *el*.
     """
-    el, can_see_customer = _get_list_for_user(db, list_id, user)
     is_owner = el.owner_id == user.id
     items = db.query(ExcessLineItem).filter_by(excess_list_id=el.id).order_by(ExcessLineItem.id).all()
+    take_all_blocked = any(it.status == ExcessLineItemStatus.AWARDED for it in items)
+    base = {
+        "request": request,
+        "user": user,
+        "list": el,
+        "line_items": items,
+        "shape": "single" if len(items) == 1 else "table",
+        "take_all_blocked": take_all_blocked,
+    }
 
     if not is_owner:
         # Non-owner: render an empty offers view — no offer data in the response.
-        return template_response(
-            "htmx/partials/resell/_offers.html",
-            {
-                "request": request,
-                "user": user,
-                "list": el,
-                "line_items": items,
-                "by_line": {it.id: [] for it in items},
-                "unmatched": [],
-                "take_all_offers": [],
-                "can_see_customer": False,
-                "is_owner": False,
-                "shape": "single" if len(items) == 1 else "table",
-            },
-        )
+        return {
+            **base,
+            "by_line": {it.id: [] for it in items},
+            "unmatched": [],
+            "take_all_offers": [],
+            "can_see_customer": False,
+            "is_owner": False,
+        }
 
     take_all_offers = (
         db.query(ExcessOffer)
@@ -443,21 +441,37 @@ async def resell_offers(
             else:
                 unmatched.append(entry)
 
-    return template_response(
-        "htmx/partials/resell/_offers.html",
-        {
-            "request": request,
-            "user": user,
-            "list": el,
-            "line_items": items,
-            "by_line": by_line,
-            "unmatched": unmatched,
-            "take_all_offers": take_all_offers,
-            "can_see_customer": can_see_customer,
-            "is_owner": True,
-            "shape": "single" if len(items) == 1 else "table",
-        },
-    )
+    return {
+        **base,
+        "by_line": by_line,
+        "unmatched": unmatched,
+        "take_all_offers": take_all_offers,
+        "can_see_customer": True,
+        "is_owner": True,
+    }
+
+
+def _award_response_context(request: Request, db: Session, el: ExcessList, user: User) -> dict:
+    """Combined context for the award/unaward OOB response.
+
+    ``_award_response.html`` swaps the Offers tab (its primary target) and, out-of-band,
+    the Lines tab (awarded/withdrawn pills) and the header chips (the awarded-count chip +
+    list-status badge) — so awarding never resets the Alpine ``tab`` state. Merging the
+    two contexts is safe: the shared keys (request/user/list/line_items/shape) are equal.
+    """
+    return {**_detail_context(request, db, el, user), **_offers_context(request, db, el, user)}
+
+
+@router.get("/v2/partials/resell/{list_id}/offers", response_class=HTMLResponse)
+async def resell_offers(
+    request: Request,
+    list_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Lazy Offers tab body — per-line offer stacks + pinned take-all banner."""
+    el, _ = _get_list_for_user(db, list_id, user)
+    return template_response("htmx/partials/resell/_offers.html", _offers_context(request, db, el, user))
 
 
 @router.get("/v2/partials/resell/{list_id}/lines/{line_id}/offers", response_class=HTMLResponse)
@@ -888,6 +902,13 @@ async def resell_submit_offer(
     return await resell_offers(request, list_id=el.id, user=user, db=db)
 
 
+def _toast(resp: Response, message: str) -> Response:
+    """Attach the ``showToast`` HX-Trigger so an award/unaward confirms even though the
+    triggering button was swapped out of the DOM (mirrors sightings._toast)."""
+    resp.headers["HX-Trigger"] = json.dumps({"showToast": {"message": message, "type": "success"}})
+    return resp
+
+
 @router.post("/api/resell/{list_id}/offers/{offer_id}/award", response_class=HTMLResponse)
 async def resell_award_offer(
     request: Request,
@@ -896,16 +917,44 @@ async def resell_award_offer(
     user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    """Award an inbound offer (owner-only): flip it to ``won`` and recompute the winning
-    buyer's scorecard, then re-render the detail panel.
+    """Award an inbound offer (owner-only): flip it to ``won``, mark its lines sold,
+    recompute the winning buyer's scorecard, and re-render the Offers tab + OOB
+    lines/chips.
 
-    The award is the single path that marks an ExcessOffer ``won``; the service owns the
-    transaction and fires the buyer-score recompute hook before committing. Owner-gated +
-    404 on a missing offer are enforced in ``excess_service.award_offer``.
+    The service owns the transaction (buyer-score hook, mirror-retire, list-status
+    derivation) and enforces owner-gating, 404 on a missing offer, and 409 when a line is
+    already awarded to a different offer. The response is an OOB compose so awarding from a
+    tab never resets the Alpine ``tab`` state; the toast fires via HX-Trigger.
     """
     offer = excess_service.award_offer(db, offer_id, user)
     el = excess_service.get_excess_list(db, offer.excess_list_id)
-    return template_response("htmx/partials/resell/detail.html", _detail_context(request, db, el, user))
+    resp = template_response(
+        "htmx/partials/resell/_award_response.html", _award_response_context(request, db, el, user)
+    )
+    return _toast(resp, "Offer awarded")
+
+
+@router.post("/api/resell/{list_id}/offers/{offer_id}/unaward", response_class=HTMLResponse)
+async def resell_unaward_offer(
+    request: Request,
+    list_id: int,
+    offer_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Reverse an award (owner-only): flip the offer back to ``open``, return its lines
+    to the pool, and re-render the Offers tab + OOB lines/chips.
+
+    The explicit inverse of award — never a silent auto-swap to a different winner. The
+    service enforces owner-gating, 404 on a missing offer, and 409 when the offer is not
+    awarded (nothing to reverse).
+    """
+    offer = excess_service.unaward_offer(db, offer_id, user)
+    el = excess_service.get_excess_list(db, offer.excess_list_id)
+    resp = template_response(
+        "htmx/partials/resell/_award_response.html", _award_response_context(request, db, el, user)
+    )
+    return _toast(resp, "Award reversed")
 
 
 # ── Outreach: offer-to-buyers panel + tracker + don't-forget strip ───

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -596,17 +596,55 @@ def withdraw_offer(db: Session, offer_id: int) -> ExcessOffer:
     return offer
 
 
+# Line statuses that are decided (no longer collecting offers) for list-status derivation.
+_DECIDED_LINE_STATUSES = (ExcessLineItemStatus.AWARDED, ExcessLineItemStatus.WITHDRAWN)
+
+
+def _award_scope_items(db: Session, offer: ExcessOffer, excess_list: ExcessList) -> list[ExcessLineItem]:
+    """The line items an award/unaward of *offer* acts on.
+
+    A ``take_all`` offer carries NO ``ExcessOfferLine`` rows — it binds the whole list, so
+    its scope is every non-withdrawn line (FIX: take_all used to award zero lines because
+    it derived the scope from the empty ``offer.lines``). A ``per_line`` offer's scope is
+    the distinct matched line items its lines point at.
+    """
+    if offer.scope == ExcessOfferScope.TAKE_ALL:
+        return [li for li in excess_list.line_items if li.status != ExcessLineItemStatus.WITHDRAWN]
+    ids = {line.excess_line_item_id for line in offer.lines if line.excess_line_item_id is not None}
+    items = (db.get(ExcessLineItem, i) for i in ids)
+    return [it for it in items if it is not None]
+
+
+def _apply_award_list_status(excess_list: ExcessList) -> None:
+    """Derive the list's own status once its lines are all decided (FIX #1).
+
+    Nothing else flips an ExcessList to ``awarded``, so the workspace "Awarded" glance
+    stayed empty. When every line is decided (awarded or withdrawn) AND at least one was
+    awarded, the list itself is awarded. A partial award (some lines still open) does NOT
+    flip it — offers are still being collected on the rest.
+    """
+    items = excess_list.line_items
+    if (
+        items
+        and all(it.status in _DECIDED_LINE_STATUSES for it in items)
+        and any(it.status == ExcessLineItemStatus.AWARDED for it in items)
+    ):
+        excess_list.status = ExcessListStatus.AWARDED
+
+
 def award_offer(db: Session, offer_id: int, owner: User) -> ExcessOffer:
     """Award an inbound offer — the single chokepoint where an ExcessOffer becomes
     ``won``.
 
     Owner-only (the list owner is the only one who may pick a winner): raises 404 if the
-    offer does not exist, 403 if *owner* does not own the offer's list. Flips the offer
-    to ``won``, marks each matched line item ``awarded``, recomputes the best-price
-    rollup of every line the offer touched, then recomputes the winning buyer's
-    ``BuyerScore`` via ``recompute_buyer_score_on_win`` BEFORE the commit (this path owns
-    the transaction; the hook no-ops for an offer with no canonical buyer card). Commits,
-    refreshes, returns the offer. Mirrors ``withdraw_offer`` (the inverse terminal flip).
+    offer does not exist, 403 if *owner* does not own the offer's list. Idempotent — an
+    already-won offer is returned unchanged. Otherwise: guards that none of the awarded
+    lines are already sold to a different offer (409, ``unaward first``), flips the offer
+    to ``won`` and its lines to ``awarded``, recomputes each touched line's best-price
+    rollup, recomputes the winning buyer's ``BuyerScore`` (``recompute_buyer_score_on_win``),
+    retires the sold lines from the Sighting mirror (``sync_list_mirror`` — a sold line
+    must stop advertising as live supply), and derives the list's own ``awarded`` status
+    when every line is decided. All in one transaction, committed here.
     """
     offer = db.get(ExcessOffer, offer_id)
     if not offer:
@@ -616,25 +654,84 @@ def award_offer(db: Session, offer_id: int, owner: User) -> ExcessOffer:
     if excess_list.owner_id != owner.id:
         raise HTTPException(403, "Only the list owner can award an offer")
 
-    affected = {line.excess_line_item_id for line in offer.lines if line.excess_line_item_id is not None}
+    if offer.status == ExcessOfferStatus.WON:
+        return offer  # idempotent — a double-award is a no-op, not a second flip
+
+    affected = _award_scope_items(db, offer, excess_list)
+    already = next((it for it in affected if it.status == ExcessLineItemStatus.AWARDED), None)
+    if already is not None:
+        raise HTTPException(409, f"Line '{already.part_number}' is already awarded — unaward the winner first")
+
     offer.status = ExcessOfferStatus.WON
-    for line_item_id in affected:
-        line_item = db.get(ExcessLineItem, line_item_id)
-        if line_item is not None:
-            line_item.status = ExcessLineItemStatus.AWARDED
+    for it in affected:
+        it.status = ExcessLineItemStatus.AWARDED
     db.flush()
 
-    for line_item_id in affected:
-        recompute_line_rollup(db, line_item_id)
+    for it in affected:
+        recompute_line_rollup(db, it.id)
 
     # Recompute the winning buyer's scorecard before the commit — this path owns the
     # transaction (the hook returns None / no-ops for an offer with no canonical buyer).
     recompute_buyer_score_on_win(db, offer)
 
+    # Retire the sold lines from the Sighting live-mirror — a lazy import breaks the
+    # excess_mirror ↔ excess_service cycle (excess_mirror imports get_excess_list).
+    from . import excess_mirror
+
+    excess_mirror.sync_list_mirror(db, excess_list)
+    _apply_award_list_status(excess_list)
+
     _safe_commit(db, entity="excess offer award")
     db.refresh(offer)
     logger.info(
         "Awarded ExcessOffer id={} (status=won, {} lines awarded) by owner={}", offer_id, len(affected), owner.id
+    )
+    return offer
+
+
+def unaward_offer(db: Session, offer_id: int, owner: User) -> ExcessOffer:
+    """Reverse an award — the explicit inverse of :func:`award_offer`.
+
+    Owner-only (404 missing, 403 non-owner, same order as award). Raises 409 if the offer
+    is not ``won`` (there is nothing to reverse — we never silently re-pick a different
+    winner). Flips the offer back to ``open`` and its awarded lines back to ``available``,
+    recomputes each line's rollup, recomputes the buyer's ``BuyerScore`` (a full-history
+    recompute self-heals the win count back down), re-mirrors the now-live lines
+    (``sync_list_mirror``), and steps the list's own status back off ``awarded`` — to
+    ``bid_out`` when the posting window has closed, else ``collecting``. One transaction.
+    """
+    offer = db.get(ExcessOffer, offer_id)
+    if not offer:
+        raise HTTPException(404, f"ExcessOffer {offer_id} not found")
+
+    excess_list = get_excess_list(db, offer.excess_list_id)
+    if excess_list.owner_id != owner.id:
+        raise HTTPException(403, "Only the list owner can reverse an award")
+
+    if offer.status != ExcessOfferStatus.WON:
+        raise HTTPException(409, "This offer is not awarded — nothing to reverse")
+
+    affected = [it for it in _award_scope_items(db, offer, excess_list) if it.status == ExcessLineItemStatus.AWARDED]
+    offer.status = ExcessOfferStatus.OPEN
+    for it in affected:
+        it.status = ExcessLineItemStatus.AVAILABLE
+    db.flush()
+
+    for it in affected:
+        recompute_line_rollup(db, it.id)
+
+    recompute_buyer_score_on_win(db, offer)
+
+    from . import excess_mirror
+
+    excess_mirror.sync_list_mirror(db, excess_list)
+    if excess_list.status == ExcessListStatus.AWARDED:
+        excess_list.status = ExcessListStatus.BID_OUT if excess_list.close_at else ExcessListStatus.COLLECTING
+
+    _safe_commit(db, entity="excess offer unaward")
+    db.refresh(offer)
+    logger.info(
+        "Unawarded ExcessOffer id={} (status=open, {} lines reverted) by owner={}", offer_id, len(affected), owner.id
     )
     return offer
 

--- a/app/services/excess_service.py
+++ b/app/services/excess_service.py
@@ -610,9 +610,9 @@ def _award_scope_items(db: Session, offer: ExcessOffer, excess_list: ExcessList)
     """
     if offer.scope == ExcessOfferScope.TAKE_ALL:
         return [li for li in excess_list.line_items if li.status != ExcessLineItemStatus.WITHDRAWN]
-    ids = {line.excess_line_item_id for line in offer.lines if line.excess_line_item_id is not None}
-    items = (db.get(ExcessLineItem, i) for i in ids)
-    return [it for it in items if it is not None]
+    # per_line: the distinct matched line items its lines point at (via the loaded
+    # relationship — no need to re-fetch each id).
+    return list({line.excess_line_item for line in offer.lines if line.excess_line_item is not None})
 
 
 def _apply_award_list_status(excess_list: ExcessList) -> None:
@@ -658,6 +658,11 @@ def award_offer(db: Session, offer_id: int, owner: User) -> ExcessOffer:
         return offer  # idempotent — a double-award is a no-op, not a second flip
 
     affected = _award_scope_items(db, offer, excess_list)
+    if not affected:
+        # No live lines to award (a take_all on an all-withdrawn/empty list, or a per_line
+        # offer whose lines matched nothing). Flipping the offer to WON here would be a
+        # fake success — the "Offer awarded" toast with zero lines actually awarded.
+        raise HTTPException(409, "This offer has no live lines to award.")
     already = next((it for it in affected if it.status == ExcessLineItemStatus.AWARDED), None)
     if already is not None:
         raise HTTPException(409, f"Line '{already.part_number}' is already awarded — unaward the winner first")

--- a/app/templates/htmx/partials/resell/_award_response.html
+++ b/app/templates/htmx/partials/resell/_award_response.html
@@ -1,0 +1,18 @@
+{#
+  resell/_award_response.html — response for an award / unaward action.
+  OOB compose (like prospecting/_action_oob.html): the PRIMARY body is the Offers tab
+  (the action button's hx-target is #tab-offers-<id>), so awarding never resets the
+  Alpine `tab` state. Out-of-band it also refreshes the Lines tab (awarded/withdrawn
+  pills) and the header chips (the N/M-awarded chip + the list-status badge that flips
+  to `awarded` when the last line is decided).
+  Receives: the merged _detail_context + _offers_context (see resell._award_response_context).
+  Called by: resell.resell_award_offer, resell.resell_unaward_offer.
+#}
+{% set el = list %}
+{% include "htmx/partials/resell/_offers.html" %}
+<div id="tab-lines-{{ el.id }}" hx-swap-oob="innerHTML">
+  {% include "htmx/partials/resell/_lines.html" %}
+</div>
+<div id="resell-chips-{{ el.id }}" hx-swap-oob="innerHTML">
+  {% include "htmx/partials/resell/_header_chips.html" %}
+</div>

--- a/app/templates/htmx/partials/resell/_header_chips.html
+++ b/app/templates/htmx/partials/resell/_header_chips.html
@@ -1,0 +1,46 @@
+{#
+  resell/_header_chips.html — the metadata-chip row inside the detail header.
+  Factored out of detail.html so the award/unaward OOB response can refresh it in
+  place (the list-status badge + the N/M awarded chip both change on award). Renders
+  the chip CONTENT only — the id'd flex container lives in detail.html (primary render)
+  and in _award_response.html (the hx-swap-oob wrapper), mirroring prospecting/
+  _action_oob.html's #prospect-stats pattern (no duplicate id, idempotent re-swap).
+  Receives: list, can_see_customer, line_count, offer_count, awarded_line_count,
+            hours_until.
+  Called by: detail.html, _award_response.html.
+#}
+{% from "htmx/partials/shared/_macros.html" import status_badge, time_text %}
+{% set el = list %}
+{# Customer is OWNER-ONLY (customer-hiding hook). #}
+{% if can_see_customer and el.company %}
+<span class="inline-flex items-center gap-1">
+  <svg class="h-3.5 w-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5"/></svg>
+  {{ el.company.name }}
+</span>
+{% endif %}
+{{ status_badge(el.status, status_map={
+  'draft': 'bg-slate-50 text-slate-500 border-slate-200',
+  'open': 'bg-sky-50 text-sky-600 border-sky-200',
+  'collecting': 'bg-amber-50 text-amber-600 border-amber-200',
+  'bid_out': 'bg-violet-50 text-violet-600 border-violet-200',
+  'awarded': 'bg-emerald-50 text-emerald-700 border-emerald-300',
+  'closed': 'bg-gray-50 text-gray-400 border-gray-200',
+  'expired': 'bg-gray-50 text-gray-400 border-gray-200'
+}) }}
+<span>{{ line_count }} line{{ 's' if line_count != 1 }}</span>
+<span>{{ offer_count }} offer{{ 's' if offer_count != 1 }}</span>
+{# Awarded coverage — emerald once every line is decided, amber while partial. Visible to
+   non-owners too (like the line/offer counts): "this deal is done" is not private. #}
+{% if awarded_line_count %}
+<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full font-medium border
+    {{ 'bg-emerald-50 text-emerald-700 border-emerald-200' if awarded_line_count == line_count
+       else 'bg-amber-50 text-amber-700 border-amber-200' }}">
+  {{ awarded_line_count }}/{{ line_count }} awarded
+</span>
+{% endif %}
+{% if hours_until is not none %}
+<span class="inline-flex items-center gap-1">closes {{ time_text(hours_until) }}</span>
+{% endif %}
+{% if can_see_customer and el.owner %}
+<span class="text-gray-400">· {{ el.owner.name }}</span>
+{% endif %}

--- a/app/templates/htmx/partials/resell/_lines.html
+++ b/app/templates/htmx/partials/resell/_lines.html
@@ -29,6 +29,17 @@
   {% endif %}
 {% endmacro %}
 
+{# Awarded / Withdrawn state pill — surfaces a line's terminal status next to its offer
+   badge so the sold/pulled lines read at a glance (RS-3). Shown to everyone: "this line
+   is sold" is a fact, not the owner's private planning data. #}
+{% macro _status_pill(item) %}
+  {%- if item.status == 'awarded' -%}
+  <span class="inline-flex items-center px-1.5 py-0.5 text-xs font-semibold rounded-full bg-emerald-100 text-emerald-700 whitespace-nowrap">Awarded</span>
+  {%- elif item.status == 'withdrawn' -%}
+  <span class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-500 whitespace-nowrap">Withdrawn</span>
+  {%- endif -%}
+{% endmacro %}
+
 <div class="space-y-4">
 
   {# ── Easy entry (owner, draft only — lines lock on post) ──────── #}
@@ -81,7 +92,10 @@
         {% if desc %}<p class="text-sm text-gray-500 mt-0.5">{{ desc }}</p>{% endif %}
         {% if item.manufacturer %}<p class="text-xs text-gray-400 mt-0.5">{{ item.manufacturer }}</p>{% endif %}
       </div>
-      {{ _line_offer_badge(el, item, is_owner) }}
+      <div class="inline-flex items-center gap-1.5 flex-shrink-0">
+        {{ _status_pill(item) }}
+        {{ _line_offer_badge(el, item, is_owner) }}
+      </div>
     </div>
     <div class="mt-3 grid grid-cols-2 sm:grid-cols-4 gap-3 text-sm">
       <div><span class="block text-xs text-gray-400 uppercase tracking-wide">Qty</span><span class="font-medium tabular-nums">{{ "{:,}".format(item.quantity) }}</span></div>
@@ -126,7 +140,12 @@
             <span class="font-semibold text-emerald-600">${{ "{:,.4f}".format(item.best_offer_unit_price|float) }}</span>
             {% else %}<span class="text-gray-400">—</span>{% endif %}
           </td>
-          <td class="text-center">{{ _line_offer_badge(el, item, is_owner) }}</td>
+          <td class="text-center">
+            <div class="inline-flex items-center gap-1.5">
+              {{ _status_pill(item) }}
+              {{ _line_offer_badge(el, item, is_owner) }}
+            </div>
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/app/templates/htmx/partials/resell/_offers.html
+++ b/app/templates/htmx/partials/resell/_offers.html
@@ -17,6 +17,36 @@
   {%- else -%}Broker #{{ offer.id }}{%- endif -%}
 {% endmacro %}
 
+{#
+  Per-line award action — the single 3-way cell (spec §RS-3): the offer that won this
+  line shows Awarded ✓ + Unaward (the explicit inverse); a line awarded to a DIFFERENT
+  offer shows "Not selected" (a pure render decision — award never auto-marks losers
+  ``lost``); an open/late offer on an un-awarded line shows Award. Every button targets
+  #tab-offers (its own tab) so the OOB response never resets the Alpine tab state.
+#}
+{% macro _offer_action(el, item, offer, is_owner) %}
+  {%- if offer.status == 'won' -%}
+  <div class="inline-flex items-center gap-1.5 whitespace-nowrap">
+    <span class="text-xs font-semibold text-emerald-700">Awarded ✓</span>
+    <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/unaward"
+            hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
+            hx-confirm="Reverse this award? The line returns to the pool for offers."
+            data-loading-disable
+            class="btn-ghost btn-sm text-rose-600 hover:text-rose-700">Unaward</button>
+  </div>
+  {%- elif item.status == 'awarded' -%}
+  <span class="text-xs text-gray-400 whitespace-nowrap">Not selected</span>
+  {%- elif offer.status in ['open', 'late'] -%}
+  <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/award"
+          hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
+          hx-confirm="Award {{ _broker_label(offer, is_owner) }} for {{ item.part_number }}? This marks the line sold."
+          data-loading-disable
+          class="btn-primary btn-sm">Award</button>
+  {%- else -%}
+  <span class="text-xs text-gray-400">—</span>
+  {%- endif -%}
+{% endmacro %}
+
 {% if not is_owner %}
 {# Offerer-facing: a non-owner never sees the collected offer stack. #}
 <div class="mx-auto max-w-sm text-center py-10">
@@ -31,8 +61,10 @@
 <div class="space-y-5">
 
   {# ── Pinned take-all banner(s) ──────────────────────────────── #}
+  {% set active_line_count = line_items|rejectattr('status', 'equalto', 'withdrawn')|list|length %}
   {% for offer in take_all_offers %}
-  <div class="rounded-lg border-2 border-violet-200 bg-violet-50 p-4">
+  {% set won = offer.status == 'won' %}
+  <div class="rounded-lg border-2 p-4 {{ 'border-emerald-300 bg-emerald-50' if won else 'border-violet-200 bg-violet-50' }}">
     <div class="flex items-start justify-between gap-3">
       <div>
         <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded-full bg-violet-100 text-violet-700">
@@ -48,6 +80,27 @@
         <span class="text-lg font-bold text-violet-700 tabular-nums">${{ "{:,.2f}".format(offer.take_all_total_price|float) }}</span>
         {% else %}<span class="text-sm text-gray-400 italic">Price TBD</span>{% endif %}
       </div>
+    </div>
+    {# ── 3-way award action: Awarded✓+Unaward / disabled(blocked) / Award all N ── #}
+    <div class="mt-3 pt-3 border-t flex items-center justify-end gap-2 {{ 'border-emerald-200' if won else 'border-violet-200' }}">
+      {% if won %}
+      <span class="text-xs font-semibold text-emerald-700">Awarded ✓ — the whole list</span>
+      <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/unaward"
+              hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
+              hx-confirm="Reverse this take-all award? Every line returns to the pool."
+              data-loading-disable
+              class="btn-ghost btn-sm text-rose-600 hover:text-rose-700">Unaward</button>
+      {% elif take_all_blocked %}
+      <span class="text-xs text-gray-500">Some lines already awarded — unaward them first</span>
+      {% elif offer.status in ['open', 'late'] %}
+      <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/award"
+              hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
+              hx-confirm="Award the whole list to {{ _broker_label(offer, is_owner) }}? All {{ active_line_count }} line{{ 's' if active_line_count != 1 }} are marked sold."
+              data-loading-disable
+              class="btn-primary btn-sm">Award all {{ active_line_count }}</button>
+      {% else %}
+      <span class="text-xs text-gray-400">—</span>
+      {% endif %}
     </div>
   </div>
   {% endfor %}
@@ -75,12 +128,15 @@
             <th class="text-right">Qty</th>
             <th class="text-center">Lead</th>
             <th class="text-left">Terms</th>
+            <th class="text-center">Action</th>
           </tr>
         </thead>
         <tbody>
           {% for e in entries %}
           {% set best = item.best_offer_id is not none and e.offer.id == item.best_offer_id and e.line.unit_price is not none %}
-          <tr class="{{ 'bg-emerald-50/60' if best }}">
+          {% set won = e.offer.status == 'won' %}
+          {% set not_selected = item.status == 'awarded' and not won %}
+          <tr class="{{ 'bg-emerald-50' if won else 'opacity-60' if not_selected else 'bg-emerald-50/60' if best else '' }}">
             <td>{{ _broker_label(e.offer, is_owner) }}{% if best %}<span class="ml-1 text-xs font-semibold text-emerald-600">best</span>{% endif %}</td>
             <td class="text-right tabular-nums {{ 'font-semibold text-emerald-600' if best }}">
               {% if e.line.unit_price is not none %}${{ "{:,.4f}".format(e.line.unit_price|float) }}{% else %}<span class="text-gray-400">TBD</span>{% endif %}
@@ -88,6 +144,7 @@
             <td class="text-right tabular-nums">{{ "{:,}".format(e.line.quantity) }}</td>
             <td class="text-center">{{ (e.line.lead_time_days|string ~ 'd') if e.line.lead_time_days is not none else '—' }}</td>
             <td class="text-gray-500">{{ e.line.terms_text or '—' }}</td>
+            <td class="text-center">{{ _offer_action(el, item, e.offer, is_owner) }}</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/htmx/partials/resell/detail.html
+++ b/app/templates/htmx/partials/resell/detail.html
@@ -7,7 +7,6 @@
   Called by: resell.resell_detail (+ publish re-render).
   Depends on: shared/_macros.html, partials/resell/_lines.html, _offers.html.
 #}
-{% from "htmx/partials/shared/_macros.html" import status_badge, time_text %}
 {% set el = list %}
 
 <div class="flex flex-col h-full"
@@ -28,31 +27,10 @@
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">
         <h1 class="text-xl font-bold text-gray-900 truncate">{{ el.title }}</h1>
-        {# Metadata chips — customer is OWNER-ONLY (customer-hiding hook). #}
-        <div class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
-          {% if can_see_customer and el.company %}
-          <span class="inline-flex items-center gap-1">
-            <svg class="h-3.5 w-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5"/></svg>
-            {{ el.company.name }}
-          </span>
-          {% endif %}
-          {{ status_badge(el.status, status_map={
-            'draft': 'bg-slate-50 text-slate-500 border-slate-200',
-            'open': 'bg-sky-50 text-sky-600 border-sky-200',
-            'collecting': 'bg-amber-50 text-amber-600 border-amber-200',
-            'bid_out': 'bg-violet-50 text-violet-600 border-violet-200',
-            'awarded': 'bg-emerald-50 text-emerald-700 border-emerald-300',
-            'closed': 'bg-gray-50 text-gray-400 border-gray-200',
-            'expired': 'bg-gray-50 text-gray-400 border-gray-200'
-          }) }}
-          <span>{{ line_count }} line{{ 's' if line_count != 1 }}</span>
-          <span>{{ offer_count }} offer{{ 's' if offer_count != 1 }}</span>
-          {% if hours_until is not none %}
-          <span class="inline-flex items-center gap-1">closes {{ time_text(hours_until) }}</span>
-          {% endif %}
-          {% if can_see_customer and el.owner %}
-          <span class="text-gray-400">· {{ el.owner.name }}</span>
-          {% endif %}
+        {# Metadata chips — refreshed in place by the award/unaward OOB response, so the
+           id'd flex container is the swap target (chip content lives in _header_chips). #}
+        <div id="resell-chips-{{ el.id }}" class="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
+          {% include "htmx/partials/resell/_header_chips.html" %}
         </div>
       </div>
 

--- a/app/templates/htmx/partials/resell/offer_compare.html
+++ b/app/templates/htmx/partials/resell/offer_compare.html
@@ -14,6 +14,38 @@
   {%- else -%}Broker #{{ offer.id }}{%- endif -%}
 {% endmacro %}
 
+{#
+  Award action for a compare row (owner-only modal). Same 3-way as the Offers tab, but
+  every button ALSO closes this modal on success — the underlying Offers/Lines tabs and
+  header chips are refreshed out-of-band by the response, so once the pick lands the modal
+  has served its purpose. Targets #tab-offers-<id> (which lives outside the modal, so the
+  @htmx:after-request handler on the button survives the swap and fires reliably).
+#}
+{% macro _compare_action(el, item, offer) %}
+  {%- if offer.status == 'won' -%}
+  <div class="inline-flex items-center gap-1.5 whitespace-nowrap">
+    <span class="text-xs font-semibold text-emerald-700">Awarded ✓</span>
+    <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/unaward"
+            hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
+            hx-confirm="Reverse this award? The line returns to the pool for offers."
+            @htmx:after-request.camel="if(event.detail.successful) $dispatch('close-modal')"
+            data-loading-disable
+            class="btn-ghost btn-sm text-rose-600 hover:text-rose-700">Unaward</button>
+  </div>
+  {%- elif item.status == 'awarded' -%}
+  <span class="text-xs text-gray-400 whitespace-nowrap">Not selected</span>
+  {%- elif offer.status in ['open', 'late'] -%}
+  <button hx-post="/api/resell/{{ el.id }}/offers/{{ offer.id }}/award"
+          hx-target="#tab-offers-{{ el.id }}" hx-swap="innerHTML"
+          hx-confirm="Award {{ _broker_label(offer) }} for {{ item.part_number }}? This marks the line sold."
+          @htmx:after-request.camel="if(event.detail.successful) $dispatch('close-modal')"
+          data-loading-disable
+          class="btn-primary btn-sm">Award</button>
+  {%- else -%}
+  <span class="text-xs text-gray-400">—</span>
+  {%- endif -%}
+{% endmacro %}
+
 <div class="p-5 max-w-3xl">
   <div class="flex items-center justify-between mb-4">
     <div>
@@ -35,12 +67,15 @@
           <th class="px-3 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Qty</th>
           <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Lead</th>
           <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Terms</th>
+          <th class="px-3 py-2 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-gray-200">
         {% for r in rows %}
         {% set is_best = item.best_offer_id is not none and r.offer.id == item.best_offer_id and r.line.unit_price is not none %}
-        <tr class="{{ 'bg-emerald-50/60' if is_best else 'hover:bg-gray-50' }}">
+        {% set won = r.offer.status == 'won' %}
+        {% set not_selected = item.status == 'awarded' and not won %}
+        <tr class="{{ 'bg-emerald-50' if won else 'opacity-60' if not_selected else 'bg-emerald-50/60' if is_best else 'hover:bg-gray-50' }}">
           <td class="px-3 py-2 text-sm font-medium text-gray-900">
             {{ _broker_label(r.offer) }}
             {% if is_best %}<span class="ml-1.5 inline-flex px-1.5 py-0.5 text-xs font-semibold rounded-full bg-emerald-100 text-emerald-700">Best</span>{% endif %}
@@ -51,6 +86,7 @@
           <td class="px-3 py-2 text-sm text-right tabular-nums">{{ "{:,}".format(r.line.quantity) }}</td>
           <td class="px-3 py-2 text-sm text-gray-600">{{ (r.line.lead_time_days|string ~ 'd') if r.line.lead_time_days is not none else '—' }}</td>
           <td class="px-3 py-2 text-sm text-gray-600">{{ r.line.terms_text or '—' }}</td>
+          <td class="px-3 py-2 text-center">{{ _compare_action(el, item, r.offer) }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/docs/APP_MAP_DATABASE.md
+++ b/docs/APP_MAP_DATABASE.md
@@ -836,11 +836,22 @@ Model: `VendorContactAttachment` (`app/models/vendors.py`).
 > `can_post`/`can_offer` (role-derived capabilities), `submit_offer` (per_line/take_all;
 > part-number-only matching via `normalize_mpn_key`; unmatched/ambiguous rows queued),
 > `recompute_line_rollup`/`withdraw_offer` (min priced active offer -> best_offer_*),
-> `award_offer` (the single chokepoint that flips an offer -> `won`: owner-gated, marks
-> matched lines `awarded`, recomputes rollups, then fires the buyer-score win-hook
-> `buyer_affinity_service.recompute_buyer_score_on_win` BEFORE the commit — no-ops for an
-> offer with no canonical buyer; routed as `POST /api/resell/{id}/offers/{offer_id}/award`),
-> `close_list`, `get_excess_stats` (offer counts), list/line CRUD + import, and
+> `award_offer` (the single chokepoint that flips an offer -> `won`: owner-gated; a
+> `take_all` offer awards EVERY non-withdrawn line (it carries no offer lines), a
+> `per_line` offer awards its matched lines; idempotent for an already-won offer; 409 if a
+> line is already awarded to a different offer; marks lines `awarded`, recomputes rollups,
+> fires the buyer-score win-hook `buyer_affinity_service.recompute_buyer_score_on_win`
+> BEFORE the commit — no-ops for an offer with no canonical buyer; RETIRES the sold lines
+> from the Sighting mirror via `excess_mirror.sync_list_mirror`; and DERIVES the list's own
+> `awarded` status once every line is decided (awarded/withdrawn) with ≥1 awarded — nothing
+> else flips `excess_lists.status`->`awarded`. Routed as `POST /api/resell/{id}/offers/{offer_id}/award`),
+> `unaward_offer` (the explicit inverse — never a silent auto-swap to a new winner: 409 if
+> not won, reverts offer->`open` + lines->`available`, recomputes rollups + buyer score
+> (full-history recompute self-heals `wins` back down), re-mirrors the lines, and steps the
+> list off `awarded` -> `bid_out` (close_at set) else `collecting`; `POST /api/resell/{id}/offers/{offer_id}/unaward`).
+> Award never auto-marks the losing offers `lost` (`ExcessOfferStatus.LOST` stays
+> defined-but-unassigned) — "not selected" is a pure render decision (line awarded + this
+> row's offer != won). `close_list`, `get_excess_stats` (offer counts), list/line CRUD + import, and
 > `material_card_id` resolution on the import path. The thin router is `app/routers/resell.py`
 > (templates under `app/templates/htmx/partials/resell/*`).
 >

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1652,8 +1652,19 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     +-- POST /api/resell/{id}/offers                    (excess_service.submit_offer; scope
     |     per_line|take_all; service enforces can_offer + the self-offer guard)
     +-- POST /api/resell/{id}/offers/{offer_id}/award   (owner-only; excess_service.award_offer:
-    |     the single offer→won chokepoint; marks matched lines awarded, recomputes rollups,
-    |     then fires buyer_affinity_service.recompute_buyer_score_on_win before commit)
+    |     the single offer→won chokepoint; take_all awards ALL non-withdrawn lines, per_line
+    |     awards its matched lines; 409 if a line is already awarded to another offer;
+    |     idempotent for an already-won offer; recomputes rollups + buyer-score win-hook;
+    |     retires the sold lines from the Sighting mirror (sync_list_mirror); derives the
+    |     list→awarded status once every line is decided. RESPONSE is an OOB compose
+    |     (_award_response.html): PRIMARY = Offers tab (hx-target #tab-offers-<id>), OOB =
+    |     #tab-lines-<id> (Awarded/Withdrawn pills) + #resell-chips-<id> (N/M-awarded chip +
+    |     status badge), so awarding never resets the Alpine tab state; HX-Trigger showToast)
+    +-- POST /api/resell/{id}/offers/{offer_id}/unaward (owner-only; excess_service.unaward_offer:
+    |     the EXPLICIT inverse — never a silent auto-swap to a new winner. 409 if the offer
+    |     is not won; reverts offer→open + lines→available, recomputes rollups + buyer score
+    |     (full-history recompute self-heals wins), re-mirrors the lines, and steps the list
+    |     back off awarded → bid_out (close_at set) else collecting. Same _award_response OOB)
     +-- POST /api/resell/{id}/outreach                  (owner-only; channel=email →
           resell_outreach_service.submit_outreach_email [RFQ send engine], else
           submit_outreach [manual log]; re-renders the Outreach tracker)

--- a/tests/test_resell_award.py
+++ b/tests/test_resell_award.py
@@ -312,6 +312,22 @@ class TestAwardOfferService:
         assert a.status == ExcessLineItemStatus.AWARDED
         assert b.status == ExcessLineItemStatus.AWARDED
 
+    def test_award_with_no_live_lines_rejected_not_fake_won(
+        self, db_session: Session, excess_list: ExcessList, owner: User, broker: User
+    ):
+        """A take_all offer whose only line is withdrawn has NO live lines to award — it
+        must 409 and stay OPEN, not flip to won with zero lines (fake success)."""
+        li = _line(db_session, excess_list, "WITHDRAWN-ONLY")
+        li.status = ExcessLineItemStatus.WITHDRAWN
+        offer = _take_all_offer(db_session, excess_list=excess_list, submitter=broker, buyer=None)
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            excess_service.award_offer(db_session, offer.id, owner)
+        assert exc.value.status_code == 409
+        db_session.refresh(offer)
+        assert offer.status == ExcessOfferStatus.OPEN
+
     def test_award_flips_list_when_all_decided(
         self, db_session: Session, excess_list: ExcessList, owner: User, broker: User
     ):

--- a/tests/test_resell_award.py
+++ b/tests/test_resell_award.py
@@ -24,7 +24,7 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from app.constants import ExcessLineItemStatus, ExcessOfferStatus, OfferLineMatchStatus
+from app.constants import ExcessLineItemStatus, ExcessListStatus, ExcessOfferStatus, OfferLineMatchStatus
 from app.models import Company, User, VendorCard
 from app.models.excess import (
     BuyerScore,
@@ -34,7 +34,9 @@ from app.models.excess import (
     ExcessOfferLine,
 )
 from app.models.intelligence import MaterialCard
+from app.models.sourcing import Sighting
 from app.services import excess_service
+from app.services.excess_mirror import publish_list
 from tests.conftest import engine
 
 _ = engine
@@ -149,6 +151,64 @@ def _open_offer(
     return offer
 
 
+def _take_all_offer(
+    db: Session,
+    *,
+    excess_list: ExcessList,
+    submitter: User,
+    buyer: VendorCard | None = None,
+    total_price: Decimal | None = Decimal("500.00"),
+) -> ExcessOffer:
+    """An OPEN take_all ExcessOffer — binds the whole list, carries NO offer lines."""
+    offer = ExcessOffer(
+        excess_list_id=excess_list.id,
+        submitted_by=submitter.id,
+        offerer_vendor_card_id=buyer.id if buyer else None,
+        scope="take_all",
+        status=ExcessOfferStatus.OPEN,
+        take_all_total_price=total_price,
+    )
+    db.add(offer)
+    db.flush()
+    return offer
+
+
+def _line(
+    db: Session,
+    excess_list: ExcessList,
+    part_number: str,
+    *,
+    with_card: bool = True,
+    qty: int = 100,
+) -> ExcessLineItem:
+    """Add one AVAILABLE ExcessLineItem (optionally card-linked for mirror tests)."""
+    card_id = None
+    if with_card:
+        mc = MaterialCard(normalized_mpn=part_number.lower(), display_mpn=part_number, category="capacitors")
+        db.add(mc)
+        db.flush()
+        card_id = mc.id
+    li = ExcessLineItem(
+        excess_list_id=excess_list.id,
+        part_number=part_number,
+        quantity=qty,
+        material_card_id=card_id,
+        asking_price=Decimal("1.00"),
+    )
+    db.add(li)
+    db.flush()
+    return li
+
+
+def _customer_excess_sightings(db: Session, company_id: int) -> list[Sighting]:
+    """The list's live Sighting mirror rows (source_type='customer_excess')."""
+    return (
+        db.query(Sighting)
+        .filter(Sighting.source_type == "customer_excess", Sighting.source_company_id == company_id)
+        .all()
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════
 #  award_offer (service)
 # ═══════════════════════════════════════════════════════════════════════
@@ -233,6 +293,229 @@ class TestAwardOfferService:
             excess_service.award_offer(db_session, 999_999, owner)
         assert exc.value.status_code == 404
 
+    def test_award_take_all_marks_all_lines(
+        self, db_session: Session, excess_list: ExcessList, owner: User, broker: User
+    ):
+        """FIX #2: a take_all offer carries NO offer lines — awarding it must still flip
+        EVERY (non-withdrawn) line to awarded, not zero."""
+        a = _line(db_session, excess_list, "TAKEALL-A")
+        b = _line(db_session, excess_list, "TAKEALL-B")
+        buyer = _buyer_card(db_session, "Take All Buyer")
+        offer = _take_all_offer(db_session, excess_list=excess_list, submitter=broker, buyer=buyer)
+        db_session.commit()
+
+        result = excess_service.award_offer(db_session, offer.id, owner)
+
+        assert result.status == ExcessOfferStatus.WON
+        db_session.refresh(a)
+        db_session.refresh(b)
+        assert a.status == ExcessLineItemStatus.AWARDED
+        assert b.status == ExcessLineItemStatus.AWARDED
+
+    def test_award_flips_list_when_all_decided(
+        self, db_session: Session, excess_list: ExcessList, owner: User, broker: User
+    ):
+        """FIX #1: once every line is decided (awarded), the LIST itself flips to
+        awarded so the workspace "Awarded" glance is no longer always-empty."""
+        excess_list.status = ExcessListStatus.COLLECTING
+        _line(db_session, excess_list, "LISTFLIP-A")
+        _line(db_session, excess_list, "LISTFLIP-B")
+        offer = _take_all_offer(db_session, excess_list=excess_list, submitter=broker, buyer=None)
+        db_session.commit()
+
+        excess_service.award_offer(db_session, offer.id, owner)
+
+        db_session.refresh(excess_list)
+        assert excess_list.status == ExcessListStatus.AWARDED
+
+    def test_award_partial_does_not_flip_list(
+        self, db_session: Session, excess_list: ExcessList, owner: User, broker: User
+    ):
+        """A per_line award of ONLY some lines must NOT flip the list — offers are still
+        being collected on the rest."""
+        excess_list.status = ExcessListStatus.COLLECTING
+        a = _line(db_session, excess_list, "PARTIAL-A")
+        _line(db_session, excess_list, "PARTIAL-B")  # left open
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=a, buyer=None, unit_price=Decimal("0.50")
+        )
+        db_session.commit()
+
+        excess_service.award_offer(db_session, offer.id, owner)
+
+        db_session.refresh(excess_list)
+        assert excess_list.status == ExcessListStatus.COLLECTING
+
+    def test_award_idempotent_double_award(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """Awarding the same offer twice is a no-op the second time — the buyer's win
+        count stays 1, never doubling."""
+        buyer = _buyer_card(db_session, "Idempotent Buyer")
+        offer = _open_offer(
+            db_session,
+            excess_list=excess_list,
+            submitter=broker,
+            line=cap_line,
+            buyer=buyer,
+            unit_price=Decimal("0.80"),
+        )
+        db_session.commit()
+
+        excess_service.award_offer(db_session, offer.id, owner)
+        again = excess_service.award_offer(db_session, offer.id, owner)
+
+        assert again.status == ExcessOfferStatus.WON
+        score = db_session.query(BuyerScore).filter_by(vendor_card_id=buyer.id).one()
+        assert score.wins == 1
+
+    def test_award_conflict_409_line_already_awarded(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """Two competing offers on the same line: awarding the second must 409 (the line
+        is already sold) — never silently steal it."""
+        first = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        second = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.70")
+        )
+        db_session.commit()
+        excess_service.award_offer(db_session, first.id, owner)
+
+        with pytest.raises(HTTPException) as exc:
+            excess_service.award_offer(db_session, second.id, owner)
+        assert exc.value.status_code == 409
+        assert "already awarded" in exc.value.detail
+        db_session.refresh(second)
+        assert second.status == ExcessOfferStatus.OPEN
+
+    def test_award_retires_sighting_mirror(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """FIX #3: a sold line must stop advertising as live supply — awarding retires
+        its Sighting mirror row."""
+        publish_list(db_session, excess_list.id, owner)
+        assert len(_customer_excess_sightings(db_session, excess_list.company_id)) == 1
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        db_session.commit()
+
+        excess_service.award_offer(db_session, offer.id, owner)
+
+        assert _customer_excess_sightings(db_session, excess_list.company_id) == []
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  unaward_offer (service) — the explicit inverse
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestUnawardOfferService:
+    def test_unaward_reverts_offer_line_and_score(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """Unaward flips the offer back to open, its line back to available, and drops
+        the buyer's win count back to 0 (a full-history recompute self-heals)."""
+        buyer = _buyer_card(db_session, "Reverse Buyer")
+        offer = _open_offer(
+            db_session,
+            excess_list=excess_list,
+            submitter=broker,
+            line=cap_line,
+            buyer=buyer,
+            unit_price=Decimal("0.80"),
+        )
+        db_session.commit()
+        excess_service.award_offer(db_session, offer.id, owner)
+
+        result = excess_service.unaward_offer(db_session, offer.id, owner)
+
+        assert result.status == ExcessOfferStatus.OPEN
+        db_session.refresh(cap_line)
+        assert cap_line.status == ExcessLineItemStatus.AVAILABLE
+        score = db_session.query(BuyerScore).filter_by(vendor_card_id=buyer.id).one()
+        assert score.wins == 0
+
+    def test_unaward_reverts_list_status_to_bid_out(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """A closed (close_at stamped) list that was awarded steps back to bid_out on
+        unaward, not to the pre-close collecting."""
+        from datetime import datetime, timezone
+
+        excess_list.status = ExcessListStatus.BID_OUT
+        excess_list.close_at = datetime.now(timezone.utc)
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        db_session.commit()
+        excess_service.award_offer(db_session, offer.id, owner)
+        db_session.refresh(excess_list)
+        assert excess_list.status == ExcessListStatus.AWARDED  # precondition
+
+        excess_service.unaward_offer(db_session, offer.id, owner)
+
+        db_session.refresh(excess_list)
+        assert excess_list.status == ExcessListStatus.BID_OUT
+
+    def test_unaward_re_mirrors_line(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """Reversing an award re-mirrors the line so it advertises as live supply
+        again."""
+        publish_list(db_session, excess_list.id, owner)
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        db_session.commit()
+        excess_service.award_offer(db_session, offer.id, owner)
+        assert _customer_excess_sightings(db_session, excess_list.company_id) == []  # retired
+
+        excess_service.unaward_offer(db_session, offer.id, owner)
+
+        assert len(_customer_excess_sightings(db_session, excess_list.company_id)) == 1
+
+    def test_unaward_by_non_owner_forbidden(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        cap_line: ExcessLineItem,
+        owner: User,
+        broker: User,
+        outsider: User,
+    ):
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        db_session.commit()
+        excess_service.award_offer(db_session, offer.id, owner)
+
+        with pytest.raises(HTTPException) as exc:
+            excess_service.unaward_offer(db_session, offer.id, outsider)
+        assert exc.value.status_code == 403
+        db_session.refresh(offer)
+        assert offer.status == ExcessOfferStatus.WON  # unchanged
+
+    def test_unaward_not_awarded_409(
+        self, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """Unawarding an offer that never won is a 409 — there is nothing to reverse."""
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            excess_service.unaward_offer(db_session, offer.id, owner)
+        assert exc.value.status_code == 409
+
+    def test_unaward_missing_offer_404(self, db_session: Session, owner: User):
+        with pytest.raises(HTTPException) as exc:
+            excess_service.unaward_offer(db_session, 999_999, owner)
+        assert exc.value.status_code == 404
+
 
 # ═══════════════════════════════════════════════════════════════════════
 #  POST award endpoint
@@ -288,3 +571,92 @@ class TestAwardRoute:
         assert resp.status_code == 403
         db_session.refresh(offer)
         assert offer.status == ExcessOfferStatus.OPEN
+
+    def test_award_route_shows_unaward_and_hides_award(
+        self, client, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """Awarding via the route returns the refreshed Offers tab: the won row now offers
+        Unaward, and no Award button for that offer remains."""
+        from app.dependencies import require_user
+        from app.main import app
+
+        excess_list.status = ExcessListStatus.COLLECTING
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        db_session.commit()
+
+        app.dependency_overrides[require_user] = lambda: owner
+        try:
+            resp = client.post(f"/api/resell/{excess_list.id}/offers/{offer.id}/award")
+        finally:
+            app.dependency_overrides.pop(require_user, None)
+
+        assert resp.status_code == 200
+        assert "Awarded" in resp.text
+        assert f"/offers/{offer.id}/unaward" in resp.text
+        assert f"/offers/{offer.id}/award" not in resp.text
+
+    def test_award_route_conflict_409_json_error_shape(
+        self, client, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """A conflicting award returns a 409 with the ``{"error": ...}`` shape the
+        global htmx error toast reads."""
+        from app.dependencies import require_user
+        from app.main import app
+
+        first = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        second = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.70")
+        )
+        db_session.commit()
+        excess_service.award_offer(db_session, first.id, owner)
+
+        app.dependency_overrides[require_user] = lambda: owner
+        try:
+            resp = client.post(f"/api/resell/{excess_list.id}/offers/{second.id}/award")
+        finally:
+            app.dependency_overrides.pop(require_user, None)
+
+        assert resp.status_code == 409
+        assert "already awarded" in resp.json()["error"]
+
+    def test_unaward_route_reverts_200(
+        self, client, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        from app.dependencies import require_user
+        from app.main import app
+
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        db_session.commit()
+        excess_service.award_offer(db_session, offer.id, owner)
+
+        app.dependency_overrides[require_user] = lambda: owner
+        try:
+            resp = client.post(f"/api/resell/{excess_list.id}/offers/{offer.id}/unaward")
+        finally:
+            app.dependency_overrides.pop(require_user, None)
+
+        assert resp.status_code == 200
+        db_session.refresh(offer)
+        assert offer.status == ExcessOfferStatus.OPEN
+
+    def test_unaward_route_non_owner_forbidden(
+        self, client, db_session: Session, excess_list: ExcessList, cap_line: ExcessLineItem, owner: User, broker: User
+    ):
+        """The default client user is not the owner → unaward is 403 (the award
+        stands)."""
+        offer = _open_offer(
+            db_session, excess_list=excess_list, submitter=broker, line=cap_line, buyer=None, unit_price=Decimal("0.80")
+        )
+        db_session.commit()
+        excess_service.award_offer(db_session, offer.id, owner)
+
+        resp = client.post(f"/api/resell/{excess_list.id}/offers/{offer.id}/unaward")
+        assert resp.status_code == 403
+        db_session.refresh(offer)
+        assert offer.status == ExcessOfferStatus.WON

--- a/tests/test_resell_award_ui.py
+++ b/tests/test_resell_award_ui.py
@@ -1,0 +1,199 @@
+"""test_resell_award_ui.py — rendered-HTML checks for the RS-3 award picker.
+
+Complements the behavioural award/unaward tests (test_resell_award.py) by asserting the
+wiring is actually visible in the served partials: the Award button on the Offers tab and
+the per-line Compare modal, the Awarded pill on the Lines tab, the N/M-awarded header
+chip, and — the privacy boundary — that a non-owner never sees any award affordance.
+
+Called by: pytest
+Depends on: app.routers.resell, app.services.excess_service, tests.conftest
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.constants import ExcessLineItemStatus, ExcessListStatus, ExcessOfferStatus, OfferLineMatchStatus
+from app.models import Company, User, VendorCard
+from app.models.excess import ExcessLineItem, ExcessList, ExcessOffer, ExcessOfferLine
+from app.models.intelligence import MaterialCard
+from tests.conftest import engine
+
+_ = engine
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def owner(db_session: Session) -> User:
+    u = User(email="ui-owner@trioscs.com", name="UI Owner", role="trader", azure_id="ui-owner-1")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def non_owner(db_session: Session) -> User:
+    u = User(email="ui-broker@trioscs.com", name="UI Broker", role="buyer", azure_id="ui-broker-1")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def posted_list(db_session: Session, owner: User) -> ExcessList:
+    co = Company(name="UI Seller Co")
+    db_session.add(co)
+    db_session.flush()
+    el = ExcessList(company_id=co.id, owner_id=owner.id, title="UI Award List", status=ExcessListStatus.COLLECTING)
+    db_session.add(el)
+    db_session.commit()
+    db_session.refresh(el)
+    return el
+
+
+def _line(db: Session, el: ExcessList, pn: str) -> ExcessLineItem:
+    mc = MaterialCard(normalized_mpn=pn.lower(), display_mpn=pn, category="capacitors")
+    db.add(mc)
+    db.flush()
+    li = ExcessLineItem(
+        excess_list_id=el.id, part_number=pn, quantity=100, material_card_id=mc.id, asking_price=Decimal("1.00")
+    )
+    db.add(li)
+    db.flush()
+    return li
+
+
+def _open_offer(db: Session, el: ExcessList, submitter: User, line: ExcessLineItem) -> ExcessOffer:
+    vc = VendorCard(normalized_name=f"buyer-{line.id}", display_name=f"Buyer {line.id}")
+    db.add(vc)
+    db.flush()
+    offer = ExcessOffer(
+        excess_list_id=el.id,
+        submitted_by=submitter.id,
+        offerer_vendor_card_id=vc.id,
+        scope="per_line",
+        status=ExcessOfferStatus.OPEN,
+    )
+    db.add(offer)
+    db.flush()
+    db.add(
+        ExcessOfferLine(
+            offer_id=offer.id,
+            excess_line_item_id=line.id,
+            mpn_raw=line.part_number,
+            quantity=line.quantity,
+            unit_price=Decimal("0.80"),
+            match_status=OfferLineMatchStatus.MATCHED,
+        )
+    )
+    db.commit()
+    return offer
+
+
+def _as(user: User):
+    """Override require_user for the duration of one request."""
+    from app.dependencies import require_user
+    from app.main import app
+
+    app.dependency_overrides[require_user] = lambda: user
+    return require_user
+
+
+def _unset(dep):
+    from app.main import app
+
+    app.dependency_overrides.pop(dep, None)
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+def test_offers_tab_shows_award_button_for_open_offer(
+    client, db_session: Session, posted_list: ExcessList, owner: User, non_owner: User
+):
+    line = _line(db_session, posted_list, "OFFERTAB-A")
+    offer = _open_offer(db_session, posted_list, non_owner, line)
+
+    dep = _as(owner)
+    try:
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/offers")
+    finally:
+        _unset(dep)
+
+    assert resp.status_code == 200
+    assert f"/offers/{offer.id}/award" in resp.text
+    assert ">Award</button>" in resp.text
+
+
+def test_offer_compare_shows_award_button(
+    client, db_session: Session, posted_list: ExcessList, owner: User, non_owner: User
+):
+    line = _line(db_session, posted_list, "COMPARE-A")
+    offer = _open_offer(db_session, posted_list, non_owner, line)
+
+    dep = _as(owner)
+    try:
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/lines/{line.id}/offers")
+    finally:
+        _unset(dep)
+
+    assert resp.status_code == 200
+    assert f"/offers/{offer.id}/award" in resp.text
+    assert "Action" in resp.text
+
+
+def test_lines_tab_shows_awarded_pill(client, db_session: Session, posted_list: ExcessList, owner: User):
+    line = _line(db_session, posted_list, "PILL-A")
+    line.status = ExcessLineItemStatus.AWARDED
+    db_session.commit()
+
+    dep = _as(owner)
+    try:
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/lines")
+    finally:
+        _unset(dep)
+
+    assert resp.status_code == 200
+    assert "Awarded" in resp.text
+
+
+def test_header_shows_awarded_chip(client, db_session: Session, posted_list: ExcessList, owner: User):
+    a = _line(db_session, posted_list, "CHIP-A")
+    _line(db_session, posted_list, "CHIP-B")
+    a.status = ExcessLineItemStatus.AWARDED
+    db_session.commit()
+
+    dep = _as(owner)
+    try:
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}")
+    finally:
+        _unset(dep)
+
+    assert resp.status_code == 200
+    assert "1/2 awarded" in resp.text
+
+
+def test_non_owner_never_sees_award_affordance(
+    client, db_session: Session, posted_list: ExcessList, owner: User, non_owner: User
+):
+    """A non-owner's Offers tab is the private state — no award/unaward wiring at
+    all."""
+    line = _line(db_session, posted_list, "PRIVACY-A")
+    _open_offer(db_session, posted_list, non_owner, line)
+
+    dep = _as(non_owner)
+    try:
+        resp = client.get(f"/v2/partials/resell/{posted_list.id}/offers")
+    finally:
+        _unset(dep)
+
+    assert resp.status_code == 200
+    assert "/award" not in resp.text
+    assert "/unaward" not in resp.text


### PR DESCRIPTION
## RS-3 — Resell award-winner picker + unaward reversal

Wires the previously-built-but-unwired `award_offer` chokepoint to **Award** buttons on the resell Offers tab and the per-line compare modal, fixes its 3 real bugs, and adds the explicit inverse (`unaward`). **No migration** (all status enums already exist).

### Service (`excess_service`)
- **Fix #1 — list never reached `awarded`:** derive `excess_lists.status` → `awarded` once every line is decided (awarded/withdrawn) with ≥1 awarded. Nothing else flipped it, so the workspace "Awarded" glance was always empty.
- **Fix #2 — take_all awarded zero lines:** a `take_all` offer carries no offer lines, so award now acts on every non-withdrawn line (not the empty `offer.lines`).
- **Fix #3 — dead mirror retirement:** award now retires the sold lines from the Sighting live-mirror (`sync_list_mirror`) so a sold line stops advertising as live supply.
- Idempotent for an already-won offer; **409** when a line is already awarded to a different offer (never silently steal it).
- **`unaward_offer`** — the explicit inverse (409 if not won), reverts offer→open + lines→available, self-heals the buyer win count (full-history recompute), re-mirrors, and steps the list off `awarded` → `bid_out` (close_at set) else `collecting`. Never a silent auto-swap; `ExcessOfferStatus.LOST` stays defined-but-unassigned — "not selected" is a pure render decision.

### Router / templates
- **OOB compose** (`_award_response.html`): primary body = Offers tab (`hx-target #tab-offers-<id>`), out-of-band = `#tab-lines-<id>` (Awarded/Withdrawn pills) + `#resell-chips-<id>` (N/M-awarded chip + status badge). Awarding from a tab never resets Alpine `tab` state. Toast via `HX-Trigger showToast`; failures (403/404/409) flow to the global `htmx:responseError` toast with the `{"error": ...}` shape.
- 3-way action on `_offers.html` + `offer_compare.html` (**Award** / **Awarded ✓ + Unaward** / **Not selected**), take-all banner **Award all N** / disabled-when-blocked, and the **Awarded/Withdrawn** pill on `_lines.html`.
- `_header_chips.html` factored out of `detail.html` so the chip row refreshes in place — the id lives on the container (the `prospecting/_action_oob.html` sibling pattern), avoiding duplicate-id nesting on re-swap.

### Tests
- Extended `tests/test_resell_award.py`: take_all-marks-all, list-flip, partial-no-flip, idempotent-double, 409 conflict, mirror-retire; full `unaward` service suite (revert+score, →bid_out, re-mirror, 403/409/404); + award/unaward route tests (unaward-hides-award content, 409 JSON error shape, revert 200, non-owner 403).
- New `tests/test_resell_award_ui.py`: rendered-HTML wiring (Award button on Offers tab + compare, Awarded pill, N/M chip) + non-owner privacy boundary.

### Verification
- `tests/test_resell_award.py` + `tests/test_resell_award_ui.py` + `tests/test_static_analysis.py`: **53 passed**.
- Full resell/excess/mirror/buyer scope under xdist: **345 passed**.
- `pre-commit run --files` (ruff, ruff-format, docformatter, mypy): clean.
- End-to-end render check confirmed: 200 + HX-Trigger toast + both OOB targets + `1/1 awarded` chip + no duplicate-id nesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF