### PR TITLE
feat(resell): wire buyer-reply tracking into the inbox poll (RS-4)

### DIFF
--- a/app/email_service.py
+++ b/app/email_service.py
@@ -881,15 +881,19 @@ async def poll_inbox(
             # reply rolls back with the rest, never poisons the whole scan). Offer
             # extraction stays MANUAL (the "Convert to offer" quick-add), so has_offer
             # is False here — status advances to responded, not bid.
-            if matched_resell_rows:
+            # An OOO / vacation / bounce auto-reply is NOT genuine engagement: advancing the
+            # outreach to "responded" and logging a "meaningful" inbound reply would stop the
+            # follow-up clock on a buyer who never actually replied. The RFQ path repairs this
+            # after AI parsing, but a purely-resell reply skips AI parsing — so gate it here.
+            # The VendorResponse row above still records the raw inbound message either way.
+            if matched_resell_rows and not _is_auto_reply(subj, vr.body):
                 from .services.resell_outreach_service import _log_inbound_reply_activity, record_response
 
                 updated = record_response(
                     db,
-                    conversation_id=conv_id or None,
+                    conversation_id=conv_id,
                     message_id=msg_id,
-                    has_offer=False,
-                    declined=False,
+                    has_offer=False,  # offer extraction stays manual (Convert-to-offer)
                     commit=False,
                 )
                 for outreach_row in updated:
@@ -966,24 +970,39 @@ async def poll_inbox(
     return results
 
 
+# Out-of-office / vacation / bounce / delivery-failure phrases that mark a message as an
+# automated reply rather than a genuine human response.
+_AUTO_REPLY_SIGNALS = (
+    "out of office",
+    "automatic reply",
+    "autoreply",
+    "i am currently out",
+    "on vacation",
+    "will return",
+    "away from",
+    "undeliverable",
+    "delivery failure",
+)
+
+
+def _is_auto_reply(subject: str, body: str) -> bool:
+    """True if the message looks like an OOO / vacation / bounce auto-reply.
+
+    Shared by the RFQ classifier and the resell reply path so neither treats an
+    automated reply as genuine engagement (advancing status / stopping the follow-up
+    clock).
+    """
+    body_lower = (body or "").lower()[:2000]
+    subject_lower = (subject or "").lower()
+    return any(s in body_lower or s in subject_lower for s in _AUTO_REPLY_SIGNALS)
+
+
 def _classify_response(parsed: dict, body: str, subject: str) -> dict:
     """Classify a vendor response into actionable categories."""
     body_lower = (body or "").lower()[:2000]
-    subject_lower = (subject or "").lower()
 
     # OOO / bounce detection
-    ooo_signals = [
-        "out of office",
-        "automatic reply",
-        "autoreply",
-        "i am currently out",
-        "on vacation",
-        "will return",
-        "away from",
-        "undeliverable",
-        "delivery failure",
-    ]
-    if any(s in body_lower or s in subject_lower for s in ooo_signals):
+    if _is_auto_reply(subject, body):
         return {
             "type": "ooo_bounce",
             "needs_action": False,

--- a/app/email_service.py
+++ b/app/email_service.py
@@ -22,6 +22,7 @@ from .constants import (
 from .models import (
     ActivityLog,
     Contact,
+    ExcessOutreach,
     Offer,
     PendingBatch,
     ProcessedMessage,
@@ -761,6 +762,9 @@ async def poll_inbox(
         # matched contact's status progresses below.
         matched_contacts: list[Contact] = []
         matched_req_id = requisition_id
+        # Resell outreach rows this reply matches (buyer replying to an offer-out). Stays
+        # empty unless the resell tier below fires; only ever set when no Contact matched.
+        matched_resell_rows: list[ExcessOutreach] = []
 
         # Tier 1: ConversationId (exact thread, global) — all of the REPLYING
         # vendor's contacts on the thread (vendor-scoped: a reply from vendor A
@@ -796,13 +800,25 @@ async def poll_inbox(
                     # the first token's requisition
                     matched_req_id = token_req_ids[0]
 
-        # Tier 3: Exact email match (USER-SCOPED, most-recent contact by design)
-        if not matched_contacts and email_addr in email_map:
+        # Tier 2.5: Resell outreach (exact conversation/message id). A buyer replying to
+        # an offered-OUT excess list — the trader→buyer inverse of the RFQ path. Runs only
+        # when no Contact matched (an RFQ reply always wins), and BEFORE the fuzzy
+        # email/domain fallbacks, mirroring the exact-before-fuzzy tier order. Reuses the
+        # already-built + unit-tested resell matcher; a hit routes to record_response below.
+        if not matched_contacts:
+            from .services.resell_outreach_service import _match_outreach
+
+            matched_resell_rows = _match_outreach(db, conversation_id=conv_id, message_id=msg_id)
+
+        # Tier 3: Exact email match (USER-SCOPED, most-recent contact by design). Yields
+        # to the exact resell match above — an exact conv/msg hit must win over this fuzzy
+        # sender-email fallback (a buyer whose address also appears in email_map).
+        if not matched_contacts and not matched_resell_rows and email_addr in email_map:
             matched_contacts = [email_map[email_addr]]
             matched_req_id = matched_contacts[0].requisition_id
 
         # Tier 4: Domain match (USER-SCOPED, most-recent contact by design)
-        if not matched_contacts and "@" in email_addr:
+        if not matched_contacts and not matched_resell_rows and "@" in email_addr:
             sender_domain = email_addr.split("@", 1)[1]
             if sender_domain in domain_map:
                 matched_contacts = [domain_map[sender_domain]]
@@ -824,7 +840,7 @@ async def poll_inbox(
                 graph_conversation_id=conv_id,
                 scanned_by_user_id=scanned_by_user_id,
                 received_at=msg.get("receivedDateTime"),
-                status="matched" if matched_contacts else VendorResponseStatus.NEW,
+                status="matched" if (matched_contacts or matched_resell_rows) else VendorResponseStatus.NEW,
                 created_at=datetime.now(timezone.utc),
             )
             db.add(vr)
@@ -858,6 +874,27 @@ async def poll_inbox(
             for mc in matched_contacts:
                 _progress_contact_status(mc, vr, db)
 
+            # ── Resell outreach progression (Tier 2.5 hit) ──
+            # A buyer replying to an offered-out list: advance the ExcessOutreach
+            # row(s) sent→responded and log the inbound reply on the resell timeline.
+            # commit=False keeps it inside THIS message's savepoint (one bad resell
+            # reply rolls back with the rest, never poisons the whole scan). Offer
+            # extraction stays MANUAL (the "Convert to offer" quick-add), so has_offer
+            # is False here — status advances to responded, not bid.
+            if matched_resell_rows:
+                from .services.resell_outreach_service import _log_inbound_reply_activity, record_response
+
+                updated = record_response(
+                    db,
+                    conversation_id=conv_id or None,
+                    message_id=msg_id,
+                    has_offer=False,
+                    declined=False,
+                    commit=False,
+                )
+                for outreach_row in updated:
+                    _log_inbound_reply_activity(db, outreach=outreach_row, vr=vr)
+
             nested.commit()
 
             # ── Reply classification + AI parsing (batch or inline) ──
@@ -866,7 +903,11 @@ async def poll_inbox(
             # earlier would let a vanished vendor_response_id reach AI parsing
             # (billed) and _auto_create_offers_from_parse, poisoning the final
             # db.commit() and rolling back the entire scan.
-            if get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY"):
+            # A purely-resell reply (matched the outreach tier, no Contact) carries no RFQ
+            # to parse and no contact status to repair, so it never enters AI parsing —
+            # don't bill Claude for it. A reply that also matched a Contact still parses.
+            purely_resell = bool(matched_resell_rows) and not matched_contacts
+            if get_credential_cached("anthropic_ai", "ANTHROPIC_API_KEY") and not purely_resell:
                 pending_parse.append(vr)
 
             results.append(

--- a/app/routers/resell.py
+++ b/app/routers/resell.py
@@ -43,7 +43,7 @@ from ..constants import (
 from ..database import get_db
 from ..dependencies import require_access, require_fresh_token, require_user
 from ..file_utils import parse_tabular_file
-from ..models import Company, User, VendorCard
+from ..models import Company, User, VendorCard, VendorResponse
 from ..models.excess import CustomerBid, ExcessLineItem, ExcessList, ExcessOffer, ExcessOfferLine, ExcessOutreach
 from ..services import (
     bid_back_service,
@@ -1092,6 +1092,43 @@ def _outreach_tracker_context(request: Request, db: Session, el: ExcessList, use
     }
 
 
+def _replies_context(db: Session, el: ExcessList) -> dict[str, dict]:
+    """Map each of the list's outreach conversations to its buyer replies.
+
+    Joins the buyer's inbound emails (``VendorResponse``, one per received message, written
+    by the inbox poll and carrying the reply body) back to the ``ExcessOutreach`` they
+    answered — on the shared ``graph_conversation_id`` the send path stamped. Returns
+    ``{conversation_id: {"outreach": ExcessOutreach, "replies": [VendorResponse, …]}}`` with
+    replies newest-first, so the reply viewer can render one conversation's thread. Only
+    outreach rows with a conversation id participate (an unstamped row has no thread to show).
+    """
+    outreach_rows = (
+        db.query(ExcessOutreach)
+        .filter(
+            ExcessOutreach.excess_list_id == el.id,
+            ExcessOutreach.graph_conversation_id.isnot(None),
+        )
+        .all()
+    )
+    owning: dict[str, ExcessOutreach] = {}
+    for row in outreach_rows:
+        # Per-line campaigns write several rows on one conversation; keep the first as the
+        # display anchor (they share buyer + list, which is all the viewer reads).
+        owning.setdefault(row.graph_conversation_id, row)
+
+    replies: dict[str, list[VendorResponse]] = {}
+    if owning:
+        for vr in (
+            db.query(VendorResponse)
+            .filter(VendorResponse.graph_conversation_id.in_(list(owning.keys())))
+            .order_by(VendorResponse.received_at.desc())
+            .all()
+        ):
+            replies.setdefault(vr.graph_conversation_id, []).append(vr)
+
+    return {conv: {"outreach": owning[conv], "replies": replies.get(conv, [])} for conv in owning}
+
+
 @router.get("/v2/partials/resell/{list_id}/offer-buyers-form", response_class=HTMLResponse)
 async def resell_offer_buyers_form(
     request: Request,
@@ -1240,6 +1277,104 @@ async def resell_submit_outreach(
             line_item_ids=parsed_lines,
             notes=notes or None,
         )
+
+    el = excess_service.get_excess_list(db, list_id)
+    return template_response("htmx/partials/resell/_outreach.html", _outreach_tracker_context(request, db, el, user))
+
+
+def _load_outreach_for_owner(
+    db: Session, list_id: int, outreach_id: int, user: User
+) -> tuple[ExcessList, ExcessOutreach]:
+    """Owner-gated load of one outreach row on a list, requiring an email thread.
+
+    404 (not 403) when the row is missing or belongs to another list — existence is not
+    revealed. 404 when the row has no ``graph_conversation_id`` (a manual-log or degraded
+    send has no thread to view or convert). Shared by the reply-viewer + convert-to-offer
+    routes so both enforce the same guard.
+    """
+    el = excess_service.get_excess_list(db, list_id)
+    _require_owner(el, user)
+    outreach = db.get(ExcessOutreach, outreach_id)
+    if outreach is None or outreach.excess_list_id != el.id:
+        raise HTTPException(404, "Outreach not found")
+    if not outreach.graph_conversation_id:
+        raise HTTPException(404, "No email thread on this outreach")
+    return el, outreach
+
+
+@router.get("/v2/partials/resell/{list_id}/outreach/{outreach_id}/reply", response_class=HTMLResponse)
+async def resell_outreach_reply(
+    request: Request,
+    list_id: int,
+    outreach_id: int,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Reply viewer for one buyer×list outreach (owner-only): the reply thread + a
+    convert-to-offer quick-add.
+
+    Loads the buyer's inbound emails on this outreach's conversation and renders them
+    with a "Convert to offer" form, so the trader can turn a free-text reply into a
+    tracked inbound ExcessOffer. Owner's private view (403 non-owner); 404 when the
+    outreach has no email thread.
+    """
+    el, outreach = _load_outreach_for_owner(db, list_id, outreach_id, user)
+    ctx = _replies_context(db, el).get(outreach.graph_conversation_id, {})
+    return template_response(
+        "htmx/partials/resell/_reply_viewer.html",
+        {
+            "request": request,
+            "user": user,
+            "list": el,
+            "outreach": outreach,
+            "replies": ctx.get("replies", []),
+        },
+    )
+
+
+@router.post("/api/resell/{list_id}/outreach/{outreach_id}/offer", response_class=HTMLResponse)
+async def resell_outreach_convert_offer(
+    request: Request,
+    list_id: int,
+    outreach_id: int,
+    mpn_raw: str = Form(""),
+    quantity: str = Form(""),
+    unit_price: str = Form(""),
+    lead_time_days: str = Form(""),
+    terms_text: str = Form(""),
+    notes: str = Form(""),
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+):
+    """Convert a buyer's reply into a tracked inbound offer (owner-only), then re-render
+    the tracker.
+
+    Human-reviewed offer extraction: the trader reads the reply and types the line. Reuses
+    :func:`resell_outreach_service.record_response` (``has_offer=True``) so the offer is
+    created via the SAME queued-never-dropped line matcher as an emailed bid and the
+    outreach advances sent/responded → ``bid``. Owner-gated; 404 when there is no thread.
+    """
+    el, outreach = _load_outreach_for_owner(db, list_id, outreach_id, user)
+
+    qty = _to_int(quantity)
+    if not mpn_raw.strip() or qty is None:
+        raise HTTPException(400, "A converted offer needs a part number and quantity")
+
+    resell_outreach_service.record_response(
+        db,
+        conversation_id=outreach.graph_conversation_id,
+        has_offer=True,
+        offer_lines=[
+            {
+                "mpn_raw": mpn_raw.strip(),
+                "quantity": qty,
+                "unit_price": _to_decimal(unit_price),
+                "lead_time_days": _to_int(lead_time_days),
+                "terms_text": terms_text or None,
+            }
+        ],
+        offer_notes=notes or None,
+    )
 
     el = excess_service.get_excess_list(db, list_id)
     return template_response("htmx/partials/resell/_outreach.html", _outreach_tracker_context(request, db, el, user))

--- a/app/services/resell_outreach_service.py
+++ b/app/services/resell_outreach_service.py
@@ -51,7 +51,7 @@ from ..constants import (
     ExcessOutreachStatus,
     OfferLineMatchStatus,
 )
-from ..models import ActivityLog, Company, User, VendorCard
+from ..models import ActivityLog, Company, User, VendorCard, VendorResponse
 from ..models.excess import ExcessLineItem, ExcessList, ExcessOffer, ExcessOfferLine, ExcessOutreach
 from ..utils.normalization import normalize_mpn_key
 from ..vendor_utils import normalize_vendor_name
@@ -480,6 +480,7 @@ def record_response(
     declined: bool = False,
     offer_lines: list[dict] | None = None,
     offer_notes: str | None = None,
+    commit: bool = True,
 ) -> list[ExcessOutreach]:
     """Advance the matched ExcessOutreach row(s) on a buyer's reply; link an offer.
 
@@ -495,7 +496,12 @@ def record_response(
     scoped to the canonical buyer (``offerer_vendor_card_id`` from the outreach's
     ``target_vendor_card_id``), with one ExcessOfferLine per row matched to the list's
     lines by part number only (the same matching ``submit_offer`` uses) — unmatched rows
-    are queued, never dropped. Commits. Returns the advanced rows ([] if no match).
+    are queued, never dropped. Returns the advanced rows ([] if no match).
+
+    ``commit`` (default True) commits + refreshes. Pass ``commit=False`` when the caller
+    owns the transaction (the inbox poll runs this inside a per-message savepoint): the
+    status changes + any linked ExcessOffer/Line are still ``flush``ed so they get PKs and
+    are visible in the session, but the enclosing txn stays open for the caller to commit.
 
     Raises ValueError if neither conversation_id nor message_id is supplied.
     """
@@ -523,11 +529,63 @@ def record_response(
     if has_offer:
         _link_inbound_offer(db, rows[0], offer_lines or [], offer_notes)
 
-    db.commit()
-    for row in rows:
-        db.refresh(row)
+    if commit:
+        db.commit()
+        for row in rows:
+            db.refresh(row)
+    else:
+        # Caller owns the txn (inbox-poll savepoint): flush so status changes + the
+        # linked ExcessOffer/Line get PKs and are visible before the caller commits.
+        db.flush()
     logger.info("record_response advanced {} outreach row(s) → {} (offer={})", len(rows), new_status, has_offer)
     return rows
+
+
+def _log_inbound_reply_activity(db: Session, *, outreach: ExcessOutreach, vr: VendorResponse) -> None:
+    """Write one inbound ActivityLog for a buyer's reply on a resell outreach.
+
+    Sibling of :func:`_log_outreach_activity` for the INBOUND leg: the buyer's reply lands
+    on the same immutable timeline + cadence clocks, scoped to the outreach's
+    ``excess_list_id`` and its canonical buyer ``vendor_card_id``. Idempotent per reply —
+    dedups on ``external_id`` (the Graph message id) within the list scope, so a per-line
+    campaign whose rows share one conversation logs the reply ONCE (never once-per-line),
+    and it never collides with the requisition-side ``log_email_activity`` row (that row
+    carries no ``excess_list_id``). Advances the reply clock via ``bump_clocks_from_activity``.
+    """
+    if vr.message_id:
+        existing = (
+            db.query(ActivityLog)
+            .filter(
+                ActivityLog.external_id == vr.message_id,
+                ActivityLog.excess_list_id == outreach.excess_list_id,
+            )
+            .first()
+        )
+        if existing:
+            return
+
+    card = db.get(VendorCard, outreach.target_vendor_card_id) if outreach.target_vendor_card_id else None
+    record = ActivityLog(
+        user_id=outreach.submitted_by,
+        activity_type=ActivityType.EMAIL_RECEIVED,
+        channel=Channel.EMAIL,
+        direction=Direction.INBOUND,
+        event_type=EventType.EMAIL,
+        excess_list_id=outreach.excess_list_id,
+        vendor_card_id=outreach.target_vendor_card_id,
+        contact_name=card.display_name if card else vr.vendor_name,
+        contact_email=vr.vendor_email,
+        subject=vr.subject,
+        external_id=vr.message_id,
+        is_meaningful=True,
+        auto_logged=True,
+    )
+    db.add(record)
+    db.flush()
+
+    from .cadence_service import bump_clocks_from_activity
+
+    bump_clocks_from_activity(db, record)
 
 
 def _match_outreach(

--- a/app/templates/htmx/partials/resell/_outreach.html
+++ b/app/templates/htmx/partials/resell/_outreach.html
@@ -66,14 +66,27 @@
           <td class="text-gray-500">{{ row.submitted_by_user.name if row.submitted_by_user else '—' }}</td>
           <td class="text-gray-500 text-xs">{{ (row.sent_at or row.created_at).strftime('%b %d, %H:%M') if (row.sent_at or row.created_at) else '—' }}</td>
           <td>
-            {{ status_badge(row.status, status_map={
-              'sent': 'bg-sky-50 text-sky-600 border-sky-200',
-              'opened': 'bg-indigo-50 text-indigo-600 border-indigo-200',
-              'responded': 'bg-amber-50 text-amber-600 border-amber-200',
-              'bid': 'bg-emerald-50 text-emerald-700 border-emerald-300',
-              'declined': 'bg-rose-50 text-rose-500 border-rose-200',
-              'no_response': 'bg-gray-50 text-gray-400 border-gray-200'
-            }) }}
+            <div class="flex items-center gap-2">
+              {{ status_badge(row.status, status_map={
+                'sent': 'bg-sky-50 text-sky-600 border-sky-200',
+                'opened': 'bg-indigo-50 text-indigo-600 border-indigo-200',
+                'responded': 'bg-amber-50 text-amber-600 border-amber-200',
+                'bid': 'bg-emerald-50 text-emerald-700 border-emerald-300',
+                'declined': 'bg-rose-50 text-rose-500 border-rose-200',
+                'no_response': 'bg-gray-50 text-gray-400 border-gray-200'
+              }) }}
+              {# View reply — only once a reply landed on the thread (needs a conversation
+                 id + an engaged status). Opens the reply viewer in the global modal, same
+                 dispatch+target pattern as "Offer to buyers" above. #}
+              {% if row.graph_conversation_id and row.status in ('opened', 'responded', 'bid', 'declined') %}
+              <button @click="$dispatch('open-modal')"
+                      hx-get="/v2/partials/resell/{{ el.id }}/outreach/{{ row.id }}/reply"
+                      hx-target="#modal-content"
+                      class="text-xs font-medium text-accent-600 hover:text-accent-700 hover:underline">
+                View reply
+              </button>
+              {% endif %}
+            </div>
           </td>
         </tr>
         {% endfor %}

--- a/app/templates/htmx/partials/resell/_reply_viewer.html
+++ b/app/templates/htmx/partials/resell/_reply_viewer.html
@@ -1,0 +1,114 @@
+{#
+  resell/_reply_viewer.html — Buyer-reply viewer + convert-to-offer (owner-only modal).
+  Renders one outreach conversation's inbound replies (VendorResponse rows the inbox poll
+  captured and matched to this ExcessOutreach) above a "Convert to offer" quick-add that
+  turns a free-text reply into a tracked inbound ExcessOffer. Human-reviewed extraction —
+  the trader reads the reply and types the line; the service reuses the same queued line
+  matcher as an emailed bid and advances the outreach to "bid".
+  Receives: list (ExcessList), outreach (ExcessOutreach), replies (VendorResponse[]), user.
+  Called by: resell.resell_outreach_reply.
+  Depends on: sanitize_html + fmtdate filters; POSTs resell.resell_outreach_convert_offer.
+#}
+{% set el = list %}
+{% set buyer = outreach.target_vendor_card.display_name if outreach.target_vendor_card else 'this buyer' %}
+<div class="p-5" x-data="{ showConvert: {{ 'false' if outreach.status == 'bid' else 'true' }} }">
+
+  {# ── Header ─────────────────────────────────────────────────────── #}
+  <div class="flex items-start justify-between gap-3 mb-4">
+    <div>
+      <h2 class="text-lg font-semibold text-gray-900">Reply from {{ buyer }}</h2>
+      <p class="text-sm text-gray-500">On <span class="font-medium text-gray-700">{{ el.title }}</span></p>
+    </div>
+    <button type="button" @click="$dispatch('close-modal')" aria-label="Close"
+            class="text-gray-400 hover:text-gray-600 -mt-1">
+      <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+    </button>
+  </div>
+
+  {# ── Reply thread ───────────────────────────────────────────────── #}
+  {% if replies %}
+  <div class="rounded-lg border border-brand-200 divide-y divide-gray-100 max-h-72 overflow-y-auto">
+    {% for vr in replies %}
+    <div class="p-4">
+      <div class="flex items-center justify-between mb-1.5">
+        <div class="flex items-center gap-2">
+          <div class="flex items-center justify-center w-7 h-7 rounded-full bg-brand-100 text-brand-600 text-xs font-bold">
+            {{ (vr.vendor_name or vr.vendor_email or 'U')[0]|upper }}
+          </div>
+          <div>
+            <span class="text-sm font-medium text-gray-900">{{ vr.vendor_name or 'Unknown sender' }}</span>
+            {% if vr.vendor_email %}<span class="text-xs text-gray-400 ml-1">&lt;{{ vr.vendor_email }}&gt;</span>{% endif %}
+          </div>
+        </div>
+        <span class="text-xs text-gray-400">{{ vr.received_at | fmtdate }}</span>
+      </div>
+      {% if vr.subject %}<p class="text-xs font-medium text-gray-600 mb-1.5">{{ vr.subject }}</p>{% endif %}
+      <div class="text-sm text-gray-700 prose prose-sm max-w-none">
+        {{ vr.body | sanitize_html | safe }}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  {# The outreach advanced on a reply but no message body was captured (or it was purged).
+     Honest note, not a silent blank — the convert form below still works off the thread. #}
+  <div class="rounded-lg border border-dashed border-brand-200 p-5 text-center text-sm text-gray-500">
+    <p class="font-medium text-gray-600">This buyer replied, but no message body was captured.</p>
+    <p class="text-xs text-gray-400 mt-1">You can still record their offer below.</p>
+  </div>
+  {% endif %}
+
+  {# ── Convert to offer ───────────────────────────────────────────── #}
+  <div class="mt-5 pt-4 border-t border-gray-100">
+    <div class="flex items-center justify-between">
+      <h3 class="text-sm font-semibold text-gray-900">
+        {% if outreach.status == 'bid' %}Add another offer line{% else %}Convert reply to an offer{% endif %}
+      </h3>
+      <button type="button" @click="showConvert = !showConvert"
+              class="text-xs font-medium text-accent-600 hover:text-accent-700"
+              x-text="showConvert ? 'Hide' : 'Add offer'"></button>
+    </div>
+    <p class="text-xs text-gray-400 mt-0.5">Read the reply, then record the buyer's price and quantity as a tracked offer.</p>
+
+    <form x-show="showConvert" x-cloak
+          hx-post="/api/resell/{{ el.id }}/outreach/{{ outreach.id }}/offer"
+          hx-target="#tab-outreach-{{ el.id }}"
+          hx-swap="innerHTML"
+          data-loading-disable
+          @htmx:after-request.camel="if(event.detail.successful){ $dispatch('close-modal'); $store.toast.message='Offer created from reply'; $store.toast.type='success'; $store.toast.show=true; }"
+          class="space-y-3 mt-3">
+      <div>
+        <label class="form-label">Part number <span class="text-rose-500">*</span></label>
+        <input type="text" name="mpn_raw" required class="input" placeholder="e.g. XCVU9P-2FLGA2104I">
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <label class="form-label">Quantity <span class="text-rose-500">*</span></label>
+          <input type="number" name="quantity" min="1" required class="input">
+        </div>
+        <div>
+          <label class="form-label">Unit price</label>
+          <input type="number" name="unit_price" step="0.0001" min="0" class="input" placeholder="optional">
+        </div>
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <label class="form-label">Lead time (days)</label>
+          <input type="number" name="lead_time_days" min="0" class="input" placeholder="optional">
+        </div>
+        <div>
+          <label class="form-label">Terms</label>
+          <input type="text" name="terms_text" class="input" placeholder="packaging / date-code…">
+        </div>
+      </div>
+      <div>
+        <label class="form-label">Notes</label>
+        <textarea name="notes" rows="2" class="input" placeholder="Optional context from the reply…"></textarea>
+      </div>
+      <div class="modal-footer">
+        <button type="button" @click="$dispatch('close-modal')" class="btn btn-secondary">Cancel</button>
+        <button type="submit" class="btn btn-primary">Save offer</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -1118,7 +1118,7 @@ email_service.poll_inbox()
     |       (delta query incremental sync when available; top-50 fallback —
     |        ALL messages fetched, matching happens locally below)
     |
-    +---> 4-tier reply matching (first tier that hits wins):
+    +---> reply matching (first tier that hits wins; exact before fuzzy):
     |       Tier 1: graph_conversation_id (global, exact) — matches ALL
     |               Contacts sharing the thread: a cross-requisition RFQ
     |               writes one Contact per (requisition, vendor) on ONE
@@ -1129,6 +1129,13 @@ email_service.poll_inbox()
     |               pair is resolved via req_email_map (unique keys under the
     |               per-requisition fan-out); tokens with no email match still
     |               assign the first token's requisition
+    |       Tier 2.5 (RS-4): RESELL outreach — a buyer replying to an offered-OUT
+    |               excess list (the trader->buyer inverse of the RFQ). Runs ONLY
+    |               when no Contact matched (Tiers 1-2), and BEFORE the fuzzy
+    |               email/domain tiers (which now also yield to it), reusing the
+    |               already-built resell_outreach_service._match_outreach
+    |               (graph_conversation_id then graph_message_id, both stamped on
+    |               ExcessOutreach at send time via migration 133)
     |       Tier 3: sender email -> most-recent contact (USER-SCOPED,
     |               single-contact fallback BY DESIGN — untokenized replies)
     |       Tier 4: sender domain (USER-SCOPED, same single-contact design)
@@ -1136,11 +1143,21 @@ email_service.poll_inbox()
     +---> DB: INSERT vendor_responses (raw email) — exactly ONE per message
     |     (it is per-message, not per-requisition); contact_id anchors to the
     |     first matched contact; _progress_contact_status then advances EVERY
-    |     matched contact, so all involved requisitions' rows progress
+    |     matched contact, so all involved requisitions' rows progress.
+    |     status='matched' when EITHER a Contact OR a resell row matched.
     |       +---> activity_service.py: log_email_activity() --> DB: INSERT activity_log
-    |             (event_type='email', direction='inbound', activity_type='email_received';
-    |              dedups on external_id=message_id) so inbound vendor replies
-    |              appear on the requisition Activity tab
+    |       |     (event_type='email', direction='inbound', activity_type='email_received';
+    |       |      dedups on external_id=message_id) so inbound vendor replies
+    |       |      appear on the requisition Activity tab
+    |       +---> [RS-4 resell hit] resell_outreach_service.record_response(commit=False)
+    |             INSIDE the per-message savepoint: advances the ExcessOutreach row(s)
+    |             sent->responded (offer extraction stays MANUAL — see the resell
+    |             "Convert to offer" quick-add, so has_offer=False here, never ->bid),
+    |             then _log_inbound_reply_activity writes ONE excess_list_id-scoped
+    |             inbound activity_log (dedup on external_id+excess_list_id, so a
+    |             per-line campaign sharing one conversation logs the reply once and
+    |             never collides with the requisition-side log_email_activity row).
+    |             A PURELY-resell reply (no Contact) skips AI parsing (never billed).
     |
     v
 ai_email_parser.py
@@ -1685,9 +1702,28 @@ GET /v2/partials/resell/workspace?lens=mine|open   (shell: pills + stats + split
     |     (full-history recompute self-heals wins), re-mirrors the lines, and steps the list
     |     back off awarded → bid_out (close_at set) else collecting. Same _award_response OOB)
     +-- POST /api/resell/{id}/outreach                  (owner-only; channel=email →
-          resell_outreach_service.submit_outreach_email [RFQ send engine], else
-          submit_outreach [manual log]; re-renders the Outreach tracker)
+    |     resell_outreach_service.submit_outreach_email [RFQ send engine], else
+    |     submit_outreach [manual log]; re-renders the Outreach tracker)
+    +-- GET  /v2/partials/resell/{id}/outreach/{oid}/reply   (RS-4, owner-only; the tracker's
+    |     "View reply" button opens _reply_viewer.html in #modal-content — the buyer's reply
+    |     thread (_replies_context joins VendorResponse↔ExcessOutreach on graph_conversation_id,
+    |     newest-first) + a "Convert to offer" quick-add. 404 when the outreach has no thread)
+    +-- POST /api/resell/{id}/outreach/{oid}/offer      (RS-4, owner-only; human-reviewed
+          offer extraction — record_response(has_offer=True) creates the inbound ExcessOffer
+          via the SAME queued-never-dropped line matcher as an emailed bid + advances the
+          outreach →bid; re-renders the tracker into #tab-outreach-<id>)
 ```
+
+**RS-4 reply tracking (inbound half).** The send path already stamps
+`ExcessOutreach.graph_conversation_id`/`graph_message_id` (migration 133); RS-4 wires the
+INBOUND half with NO new migration. `email_service.poll_inbox` gained Tier 2.5 (see §4):
+a buyer's reply matches the outreach via `resell_outreach_service._match_outreach` and
+advances it `sent→responded` through `record_response(commit=False)` inside the existing
+per-message savepoint, logging one excess-scoped inbound `activity_log`. The tracker's
+"View reply" button (shown once a reply lands — `graph_conversation_id` + an engaged status)
+opens the reply viewer, which reuses the `VendorResponse` rows the poll already writes (no
+new reply-content table) and offers a manual "Convert to offer" — offer auto-detection from
+the AI parse is a deliberately deferred Phase-2 decision.
 
 Adaptive-detail rule (spec "density scales to line count, placement follows offer scope"):
 `shape='single'` (1 line → one `.card`, no table chrome) vs `'table'` (≥2 → `compact-table`);

--- a/tests/test_resell_outreach_service.py
+++ b/tests/test_resell_outreach_service.py
@@ -13,7 +13,7 @@ Called by: pytest
 Depends on: app.services.resell_outreach_service, tests.conftest
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -513,3 +513,30 @@ class TestRecordResponse:
     def test_requires_a_match_key(self, db_session: Session):
         with pytest.raises(ValueError):
             svc.record_response(db_session, has_offer=False)
+
+    def test_commit_false_flushes_without_committing(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        line_item: ExcessLineItem,
+        buyer_card: VendorCard,
+        trader: User,
+    ):
+        """Commit=False (the inbox-poll savepoint path) must NOT commit, but the linked
+        ExcessOffer is flush-visible in the same session so the caller can finish the
+        txn."""
+        o = self._make_outreach(db_session, excess_list, buyer_card, trader)
+        with patch.object(db_session, "commit", MagicMock()) as mock_commit:
+            updated = svc.record_response(
+                db_session,
+                conversation_id="conv-1",
+                has_offer=True,
+                offer_lines=[{"mpn_raw": "LM358N", "quantity": 500, "unit_price": "1.25"}],
+                commit=False,
+            )
+        mock_commit.assert_not_called()
+        assert updated[0].status == "bid"
+        # Flushed, so the inbound offer is visible in THIS session before any commit.
+        offers = db_session.query(ExcessOffer).filter(ExcessOffer.excess_list_id == excess_list.id).all()
+        assert len(offers) == 1
+        assert offers[0].id is not None

--- a/tests/test_resell_reply_matching.py
+++ b/tests/test_resell_reply_matching.py
@@ -1,0 +1,226 @@
+"""Tests for the resell reply-matching tier wired into email_service.poll_inbox (RS-4).
+
+The send path stamps ``ExcessOutreach.graph_conversation_id`` / ``graph_message_id``; this
+covers the INBOUND half — poll_inbox's new Tier-2.5 matches a buyer's reply to those rows
+(reusing resell_outreach_service._match_outreach), advances the outreach via
+record_response(commit=False) inside the per-message savepoint, and logs the reply on the
+resell timeline. Also covers the tier ordering (a Contact match preempts resell), cross-poll
+idempotency, and the purely-resell AI-parse skip.
+
+Graph is mocked at the source (GraphClient) — no network. Called by: pytest.
+Depends on: app.email_service, app.services.resell_outreach_service, tests.conftest.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.email_service import poll_inbox
+from app.models import ActivityLog, Company, Contact, ExcessList, ExcessOutreach, User, VendorCard, VendorResponse
+from tests.conftest import engine
+
+_ = engine
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def owner(db_session: Session) -> User:
+    u = User(email="rs4-owner@trioscs.com", name="RS4 Owner", role="trader", azure_id="rs4-owner")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def buyer_card(db_session: Session) -> VendorCard:
+    vc = VendorCard(normalized_name="buyer one", display_name="Buyer One", emails=["sales@buyerone.com"])
+    db_session.add(vc)
+    db_session.commit()
+    db_session.refresh(vc)
+    return vc
+
+
+@pytest.fixture()
+def excess_list(db_session: Session, owner: User) -> ExcessList:
+    co = Company(name="Seller Co")
+    db_session.add(co)
+    db_session.flush()
+    el = ExcessList(company_id=co.id, owner_id=owner.id, title="RS4 Excess", status="open")
+    db_session.add(el)
+    db_session.commit()
+    db_session.refresh(el)
+    return el
+
+
+def _outreach(db, el, card, owner, conv="conv-rs4", msg="msg-rs4", status="sent") -> ExcessOutreach:
+    row = ExcessOutreach(
+        excess_list_id=el.id,
+        target_vendor_card_id=card.id,
+        submitted_by=owner.id,
+        channel="email",
+        status=status,
+        graph_conversation_id=conv,
+        graph_message_id=msg,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _inbox_message(msg_id="msg-rs4", conv_id="conv-rs4", sender="sales@buyerone.com"):
+    return {
+        "id": msg_id,
+        "subject": "RE: your excess offer",
+        "from": {"emailAddress": {"address": sender, "name": "Buyer One"}},
+        "bodyPreview": "We'll take 500 at $1.25",
+        "body": {"content": "<p>We'll take 500 at $1.25</p>"},
+        "conversationId": conv_id,
+        "receivedDateTime": None,
+    }
+
+
+async def _run_poll(db, messages, *, credential=None):
+    mock_gc = AsyncMock()
+    mock_gc.get_json.return_value = {"value": messages}
+    with (
+        patch("app.utils.graph_client.GraphClient", return_value=mock_gc),
+        patch("app.email_service.get_credential_cached", return_value=credential),
+        patch("app.email_service._submit_parse_batch", new_callable=AsyncMock) as submit_batch,
+    ):
+        results = await poll_inbox(token="fake-token", db=db)
+    return results, submit_batch
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+class TestResellReplyMatching:
+    @pytest.mark.asyncio
+    async def test_match_by_conversation_id_advances_and_logs(
+        self, db_session: Session, excess_list: ExcessList, buyer_card: VendorCard, owner: User
+    ):
+        row = _outreach(db_session, excess_list, buyer_card, owner)
+
+        await _run_poll(db_session, [_inbox_message()])
+
+        db_session.refresh(row)
+        assert row.status == "responded"
+
+        vr = db_session.query(VendorResponse).filter(VendorResponse.message_id == "msg-rs4").one()
+        assert vr.status == "matched"
+
+        # The inbound reply lands on the resell timeline, scoped to the list + buyer.
+        act = (
+            db_session.query(ActivityLog)
+            .filter(ActivityLog.excess_list_id == excess_list.id, ActivityLog.direction == "inbound")
+            .all()
+        )
+        assert len(act) == 1
+        assert act[0].vendor_card_id == buyer_card.id
+        assert act[0].external_id == "msg-rs4"
+
+    @pytest.mark.asyncio
+    async def test_match_by_message_id_fallback(
+        self, db_session: Session, excess_list: ExcessList, buyer_card: VendorCard, owner: User
+    ):
+        # No conversation id on the row — only the message id was captured at send time.
+        row = _outreach(db_session, excess_list, buyer_card, owner, conv=None, msg="msg-only")
+        # Incoming message carries a conversation id that matches NOTHING → message-id fallback.
+        await _run_poll(db_session, [_inbox_message(msg_id="msg-only", conv_id="unrelated-conv")])
+
+        db_session.refresh(row)
+        assert row.status == "responded"
+
+    @pytest.mark.asyncio
+    async def test_contact_match_preempts_resell(
+        self,
+        db_session: Session,
+        excess_list: ExcessList,
+        buyer_card: VendorCard,
+        owner: User,
+        test_user: User,
+        test_requisition,
+    ):
+        # An RFQ Contact on the SAME conversation (Tier-1 exact) must win; the outreach on
+        # that conversation is never treated as a resell reply.
+        row = _outreach(db_session, excess_list, buyer_card, owner, conv="conv-shared", msg="msg-shared")
+        contact = Contact(
+            requisition_id=test_requisition.id,
+            user_id=test_user.id,
+            contact_type="email",
+            vendor_name="Buyer One",
+            vendor_contact="sales@buyerone.com",
+            graph_conversation_id="conv-shared",
+            created_at=datetime.now(timezone.utc),
+        )
+        db_session.add(contact)
+        db_session.commit()
+
+        await _run_poll(db_session, [_inbox_message(msg_id="msg-shared", conv_id="conv-shared")])
+
+        db_session.refresh(row)
+        assert row.status == "sent"  # untouched — the reply was a Contact (RFQ) match
+
+        vr = db_session.query(VendorResponse).filter(VendorResponse.message_id == "msg-shared").one()
+        assert vr.contact_id == contact.id
+        # No resell-scoped inbound activity was written.
+        assert db_session.query(ActivityLog).filter(ActivityLog.excess_list_id == excess_list.id).count() == 0
+
+    @pytest.mark.asyncio
+    async def test_idempotent_across_two_polls(
+        self, db_session: Session, excess_list: ExcessList, buyer_card: VendorCard, owner: User
+    ):
+        row = _outreach(db_session, excess_list, buyer_card, owner)
+
+        await _run_poll(db_session, [_inbox_message()])
+        await _run_poll(db_session, [_inbox_message()])  # same message again
+
+        db_session.refresh(row)
+        assert row.status == "responded"
+        # The message is de-duped by already_processed on the 2nd poll — no dup VR/activity.
+        assert db_session.query(VendorResponse).filter(VendorResponse.message_id == "msg-rs4").count() == 1
+        assert db_session.query(ActivityLog).filter(ActivityLog.excess_list_id == excess_list.id).count() == 1
+
+    @pytest.mark.asyncio
+    async def test_purely_resell_reply_skips_ai_parse(
+        self, db_session: Session, excess_list: ExcessList, buyer_card: VendorCard, owner: User
+    ):
+        _outreach(db_session, excess_list, buyer_card, owner)
+
+        # Credential PRESENT — the only reason parse is skipped is the purely-resell gate.
+        _results, submit_batch = await _run_poll(db_session, [_inbox_message()], credential="sk-key")
+
+        submit_batch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_per_line_campaign_logs_reply_once(
+        self, db_session: Session, excess_list: ExcessList, buyer_card: VendorCard, owner: User
+    ):
+        # Two outreach rows share one conversation (a per-line campaign). One reply must
+        # advance BOTH but log the inbound activity only ONCE.
+        r1 = _outreach(db_session, excess_list, buyer_card, owner, msg="msg-a")
+        r2 = ExcessOutreach(
+            excess_list_id=excess_list.id,
+            target_vendor_card_id=buyer_card.id,
+            submitted_by=owner.id,
+            channel="email",
+            status="sent",
+            graph_conversation_id="conv-rs4",
+            graph_message_id="msg-b",
+        )
+        db_session.add(r2)
+        db_session.commit()
+
+        await _run_poll(db_session, [_inbox_message()])
+
+        db_session.refresh(r1)
+        db_session.refresh(r2)
+        assert r1.status == "responded"
+        assert r2.status == "responded"
+        assert db_session.query(ActivityLog).filter(ActivityLog.excess_list_id == excess_list.id).count() == 1

--- a/tests/test_resell_reply_matching.py
+++ b/tests/test_resell_reply_matching.py
@@ -126,6 +126,38 @@ class TestResellReplyMatching:
         assert act[0].external_id == "msg-rs4"
 
     @pytest.mark.asyncio
+    async def test_auto_reply_does_not_advance_or_stop_clock(
+        self, db_session: Session, excess_list: ExcessList, buyer_card: VendorCard, owner: User
+    ):
+        """An OOO/bounce auto-reply matches the outreach thread but must NOT advance it
+        to 'responded' or log a meaningful inbound reply — doing so would stop the
+        follow-up clock on a buyer who never actually replied.
+
+        The VendorResponse still records the raw inbound message.
+        """
+        row = _outreach(db_session, excess_list, buyer_card, owner)
+        msg = _inbox_message()
+        msg["subject"] = "Automatic reply: Out of Office"
+        msg["body"] = {"content": "I am currently out of the office and will return Monday."}
+        msg["bodyPreview"] = "I am currently out of the office"
+
+        await _run_poll(db_session, [msg])
+
+        db_session.refresh(row)
+        assert row.status == "sent"  # NOT advanced by an auto-reply
+
+        # The raw inbound message is still recorded (matched)...
+        vr = db_session.query(VendorResponse).filter(VendorResponse.message_id == "msg-rs4").one()
+        assert vr.status == "matched"
+        # ...but no inbound resell activity log fires (which would stop the follow-up clock).
+        act = (
+            db_session.query(ActivityLog)
+            .filter(ActivityLog.excess_list_id == excess_list.id, ActivityLog.direction == "inbound")
+            .count()
+        )
+        assert act == 0
+
+    @pytest.mark.asyncio
     async def test_match_by_message_id_fallback(
         self, db_session: Session, excess_list: ExcessList, buyer_card: VendorCard, owner: User
     ):

--- a/tests/test_resell_reply_routes.py
+++ b/tests/test_resell_reply_routes.py
@@ -1,0 +1,192 @@
+"""test_resell_reply_routes.py — Route/render + helper tests for RS-4 reply tracking.
+
+Covers the new owner-gated reply surface on resell detail:
+  - ``_replies_context`` joins VendorResponse ↔ ExcessOutreach on graph_conversation_id
+    (newest-first, threads without a conversation id excluded);
+  - the reply-viewer route (403 non-owner, 404 when no thread, 200 renders the thread);
+  - the convert-to-offer route (creates a matched inbound ExcessOffer + advances the
+    outreach to ``bid``; owner-gated).
+
+The client fixture authenticates as ``test_user``; the happy-path list is owned by that
+user, and non-owner cases seed the list under a different owner.
+Called by: pytest. Depends on: app.routers.resell, tests.conftest.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import Company, ExcessList, ExcessOutreach, User, VendorCard, VendorResponse
+from app.models.excess import ExcessLineItem, ExcessOffer, ExcessOfferLine
+from app.routers.resell import _replies_context
+from app.utils.normalization import normalize_mpn_key
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def other_owner(db_session: Session) -> User:
+    u = User(email="rs4-other@trioscs.com", name="RS4 Other", role="trader", azure_id="rs4-other")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def buyer_card(db_session: Session) -> VendorCard:
+    vc = VendorCard(normalized_name="buyer two", display_name="Buyer Two", emails=["sales@buyertwo.com"])
+    db_session.add(vc)
+    db_session.commit()
+    db_session.refresh(vc)
+    return vc
+
+
+def _list(db: Session, owner: User) -> ExcessList:
+    co = Company(name="RS4 Seller")
+    db.add(co)
+    db.flush()
+    el = ExcessList(company_id=co.id, owner_id=owner.id, title="RS4 Routes Excess", status="open")
+    db.add(el)
+    db.commit()
+    db.refresh(el)
+    return el
+
+
+def _outreach(db, el, card, owner, *, conv="conv-r", msg="msg-r", status="responded") -> ExcessOutreach:
+    row = ExcessOutreach(
+        excess_list_id=el.id,
+        target_vendor_card_id=card.id,
+        submitted_by=owner.id,
+        channel="email",
+        status=status,
+        graph_conversation_id=conv,
+        graph_message_id=msg,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _reply(db, conv, *, received_at, body="We'll take them.", email="sales@buyertwo.com") -> VendorResponse:
+    vr = VendorResponse(
+        vendor_name="Buyer Two",
+        vendor_email=email,
+        subject="RE: excess",
+        body=body,
+        graph_conversation_id=conv,
+        received_at=received_at,
+        status="matched",
+    )
+    db.add(vr)
+    db.commit()
+    db.refresh(vr)
+    return vr
+
+
+# ── _replies_context (test 7) ────────────────────────────────────────
+
+
+class TestRepliesContext:
+    def test_joins_and_orders_newest_first(self, db_session: Session, test_user: User, buyer_card: VendorCard):
+        el = _list(db_session, test_user)
+        a = _outreach(db_session, el, buyer_card, test_user, conv="cA", msg="mA")
+        _outreach(db_session, el, buyer_card, test_user, conv="cB", msg="mB")
+        # An outreach with NO conversation id must be excluded from the map.
+        _outreach(db_session, el, buyer_card, test_user, conv=None, msg="mC")
+
+        now = datetime.now(timezone.utc)
+        older = _reply(db_session, "cA", received_at=now - timedelta(hours=2), body="first")
+        newer = _reply(db_session, "cA", received_at=now - timedelta(hours=1), body="second")
+        _reply(db_session, "cB", received_at=now, body="onB")
+
+        ctx = _replies_context(db_session, el)
+
+        assert set(ctx.keys()) == {"cA", "cB"}  # conv=None excluded
+        assert ctx["cA"]["outreach"].id == a.id
+        # Newest-first ordering within a conversation.
+        assert [r.id for r in ctx["cA"]["replies"]] == [newer.id, older.id]
+        assert len(ctx["cB"]["replies"]) == 1
+
+
+# ── reply-viewer route (test 8) ──────────────────────────────────────
+
+
+class TestReplyViewerRoute:
+    def test_renders_thread_for_owner(self, client, db_session: Session, test_user: User, buyer_card: VendorCard):
+        el = _list(db_session, test_user)
+        row = _outreach(db_session, el, buyer_card, test_user)
+        _reply(db_session, "conv-r", received_at=datetime.now(timezone.utc), body="Yes please")
+
+        resp = client.get(f"/v2/partials/resell/{el.id}/outreach/{row.id}/reply")
+        assert resp.status_code == 200
+        assert "Yes please" in resp.text
+        assert "Convert reply to an offer" in resp.text
+
+    def test_non_owner_forbidden(self, client, db_session: Session, other_owner: User, buyer_card: VendorCard):
+        el = _list(db_session, other_owner)  # owned by someone else
+        row = _outreach(db_session, el, buyer_card, other_owner)
+        resp = client.get(f"/v2/partials/resell/{el.id}/outreach/{row.id}/reply")
+        assert resp.status_code == 403
+
+    def test_no_thread_not_found(self, client, db_session: Session, test_user: User, buyer_card: VendorCard):
+        el = _list(db_session, test_user)
+        row = _outreach(db_session, el, buyer_card, test_user, conv=None, msg=None)
+        resp = client.get(f"/v2/partials/resell/{el.id}/outreach/{row.id}/reply")
+        assert resp.status_code == 404
+
+
+# ── convert-to-offer route (tests 9-10) ──────────────────────────────
+
+
+class TestConvertToOfferRoute:
+    def test_creates_matched_offer_and_advances_to_bid(
+        self, client, db_session: Session, test_user: User, buyer_card: VendorCard
+    ):
+        el = _list(db_session, test_user)
+        db_session.add(
+            ExcessLineItem(
+                excess_list_id=el.id,
+                part_number="LM358N",
+                normalized_part_number=normalize_mpn_key("LM358N"),
+                quantity=500,
+            )
+        )
+        db_session.commit()
+        row = _outreach(db_session, el, buyer_card, test_user)
+
+        resp = client.post(
+            f"/api/resell/{el.id}/outreach/{row.id}/offer",
+            data={"mpn_raw": "LM358N", "quantity": "500", "unit_price": "1.25"},
+        )
+        assert resp.status_code == 200
+
+        offers = db_session.query(ExcessOffer).filter(ExcessOffer.excess_list_id == el.id).all()
+        assert len(offers) == 1
+        assert offers[0].offerer_vendor_card_id == buyer_card.id
+
+        line = db_session.query(ExcessOfferLine).filter(ExcessOfferLine.offer_id == offers[0].id).one()
+        assert line.match_status == "matched"
+
+        db_session.refresh(row)
+        assert row.status == "bid"
+
+    def test_missing_fields_rejected(self, client, db_session: Session, test_user: User, buyer_card: VendorCard):
+        el = _list(db_session, test_user)
+        row = _outreach(db_session, el, buyer_card, test_user)
+        resp = client.post(
+            f"/api/resell/{el.id}/outreach/{row.id}/offer",
+            data={"mpn_raw": "", "quantity": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_owner_gated(self, client, db_session: Session, other_owner: User, buyer_card: VendorCard):
+        el = _list(db_session, other_owner)  # owned by someone else
+        row = _outreach(db_session, el, buyer_card, other_owner)
+        resp = client.post(
+            f"/api/resell/{el.id}/outreach/{row.id}/offer",
+            data={"mpn_raw": "LM358N", "quantity": "10"},
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
## RS-4 — Resell outreach reply-tracking (wiring, no migration)

The reply-matching machinery already existed and was unit-tested but was **never called**. This wires it into the inbox poll and adds the reply UI, with **NO new migration** (the send path already persists `graph_conversation_id`/`graph_message_id` via migration 133; the optional perf index is deferred to the perf pass).

### What changed
- **`email_service.poll_inbox`** — new exact-match **Tier 2.5** between the RFQ subject-token tier and the fuzzy email/domain tiers. A buyer replying to an offered-out excess list matches the `ExcessOutreach` via the existing `_match_outreach` (conversation id → message id) and advances it `sent→responded` through `record_response(commit=False)` **inside the existing per-message savepoint** (one bad resell message logs+skips, never crashes the scan). The fuzzy contact tiers (3/4) now yield to this exact match; a **purely-resell** reply skips AI parsing (never billed).
- **`resell_outreach_service`** — `record_response` gains `commit=False` (flushes so the linked `ExcessOffer`/lines get PKs; caller owns the txn) + `_log_inbound_reply_activity` writes one `excess_list_id`-scoped inbound `activity_log`, idempotent on `external_id`+`excess_list_id` (a per-line campaign sharing one conversation logs the reply once; no collision with the requisition-side `log_email_activity` row).
- **`routers/resell`** — `_replies_context` joins `VendorResponse`↔`ExcessOutreach` on the shared conversation id (newest-first); new **owner-gated** reply-viewer route (`GET …/outreach/{oid}/reply`, 404 when no thread) + convert-to-offer route (`POST …/outreach/{oid}/offer`, human-reviewed extraction reusing `record_response(has_offer=True)` → the same queued-never-dropped line matcher as an emailed bid → outreach `→bid`).
- **Templates** — `_outreach.html` gains a "View reply" affordance (shown once a reply lands: `graph_conversation_id` + engaged status), opening the new `_reply_viewer.html` modal (reply thread reusing `VendorResponse`, no new reply-content table) with a "Convert to offer" quick-add.
- **`docs/APP_MAP_INTERACTIONS.md`** — poll_inbox tier diagram + resell reply fan-out.

Offer auto-detection from the AI parse is a deliberately deferred Phase-2 decision; extraction stays manual.

### Tests
New `tests/test_resell_reply_matching.py` (conversation match, message-id fallback, Contact-preempts-resell tier order, cross-poll idempotency, purely-resell parse-skip, per-line single-log) + `tests/test_resell_reply_routes.py` (`_replies_context` join+ordering, reply-viewer 200/403/404, convert-to-offer creates matched offer + `→bid` + owner-gating) + extended `test_resell_outreach_service.py` (`commit=False` flushes without committing). Full area suite (email_service + all resell + static analysis) green; `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF