### PR TITLE
fix(authz): enforce ownership on offers.py requisition GET partials (IDOR)

### DIFF
--- a/app/routers/htmx/offers.py
+++ b/app/routers/htmx/offers.py
@@ -70,6 +70,7 @@ async def parse_email_form(
 ):
     """Return the parse-email paste form."""
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
     ctx = _base_ctx(request, user, "requisitions")
     ctx["req"] = req
     return template_response("htmx/partials/requisitions/tabs/parse_email_form.html", ctx)
@@ -84,6 +85,7 @@ async def paste_offer_form(
 ):
     """Return the paste-offer freeform form."""
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
     ctx = _base_ctx(request, user, "requisitions")
     ctx["req"] = req
     return template_response("htmx/partials/requisitions/tabs/paste_offer_form.html", ctx)
@@ -468,6 +470,7 @@ async def add_offer_form(
 ):
     """Return the manual offer entry form."""
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
     requirements = db.query(Requirement).filter(Requirement.requisition_id == req_id).all()
     ctx = _base_ctx(request, user, "requisitions")
     ctx["req"] = req
@@ -983,6 +986,7 @@ async def rfq_compose(
     from ...models.offers import Contact as RfqContact
 
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
 
     parts = db.query(Requirement).filter(Requirement.requisition_id == req_id).all()
 
@@ -1684,6 +1688,7 @@ async def rfq_prepare_panel(
     from ...models.offers import Contact as RfqContact
 
     req = get_requisition_or_404(db, req_id)
+    require_requisition_access(db, req_id, user)
 
     # Get requirements for this req
     requirements = db.query(Requirement).filter(Requirement.requisition_id == req_id).all()

--- a/app/routers/htmx/offers.py
+++ b/app/routers/htmx/offers.py
@@ -610,6 +610,7 @@ async def edit_offer_form(
     db: Session = Depends(get_db),
 ):
     """Return inline edit form for an existing offer."""
+    require_requisition_access(db, req_id, user)
     offer = db.query(Offer).filter(Offer.id == offer_id, Offer.requisition_id == req_id).first()
     if not offer:
         raise HTTPException(404, "Offer not found")
@@ -925,6 +926,7 @@ async def offer_changelog(
     offer = db.get(Offer, offer_id)
     if not offer:
         raise HTTPException(404, "Offer not found")
+    require_requisition_access(db, offer.requisition_id, user, owner_id=offer.entered_by_id, label="Offer")
     rows = (
         db.query(ChangeLog)
         .filter(ChangeLog.entity_type == "offer", ChangeLog.entity_id == offer_id)

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -2470,6 +2470,16 @@ REUSING the helpers above (no new ad-hoc checks):
 Regression coverage: `tests/test_authz_hardening.py` (cross-account 403/404 + legitimate owner/
 manager/admin allowed + per-owner data-isolation asserts for proactive / follow-ups / quote).
 
+**Read-IDOR closure — offers.py GET partials.** Five requisition-scoped GET partial handlers in
+`app/routers/htmx/offers.py` (`parse_email_form`, `paste_offer_form`, `add_offer_form`,
+`rfq_compose`, `rfq_prepare_panel` — the parse-email/paste-offer/add-offer forms and the
+rfq-compose/rfq-prepare panels) resolved the requisition via `get_requisition_or_404` but skipped
+`require_requisition_access`, so a `RESTRICTED_ROLES` (SALES/TRADER) non-owner could read another
+rep's requisition name/customer/MPNs/vendor contacts by crafting a direct GET. Each now calls
+`require_requisition_access(db, req_id, user)` right after the 404 check (404-not-403 so existence
+isn't leaked), matching their mutating siblings in the same file. Regression coverage:
+`tests/test_authz_offers_partials_idor.py`.
+
 **Disposition (Increment 1, migration 118).** Salespeople dispose of accounts +
 contacts via setter routes in `htmx_views.py` (all owner-or-admin where they touch
 ownership/disposition; `is_admin = user.role == UserRole.ADMIN`, mirroring

--- a/tests/test_authz_offers_partials_idor.py
+++ b/tests/test_authz_offers_partials_idor.py
@@ -1,0 +1,64 @@
+"""Read-IDOR regression for offers.py requisition-scoped GET partials.
+
+Five GET partial handlers in app.routers.htmx.offers loaded the requisition by
+id (get_requisition_or_404) but skipped require_requisition_access — so a
+restricted (SALES/TRADER) non-owner could read another rep's requisition name,
+customer, MPNs, and vendor contacts by crafting a direct GET. Their mutating
+siblings in the same file all call require_requisition_access. A restricted
+non-owner must now get 404 (existence not leaked); owners and unrestricted
+buyers must still get 200.
+
+Called by: pytest
+Depends on: app.routers.htmx.offers, conftest fixtures
+            (client, db_session, test_requisition, test_user, admin_user)
+"""
+
+import pytest
+
+from app.constants import UserRole
+
+# GET partials that must enforce require_requisition_access.
+PARTIAL_PATHS = [
+    "parse-email-form",
+    "paste-offer-form",
+    "add-offer-form",
+    "rfq-compose",
+    "rfq-prepare",
+]
+
+
+def _make_foreign(db_session, test_requisition, test_user, admin_user, role=UserRole.SALES):
+    """Restrict test_user and hand requisition ownership to someone else."""
+    test_user.role = role
+    test_requisition.created_by = admin_user.id
+    db_session.commit()
+
+
+@pytest.mark.parametrize("suffix", PARTIAL_PATHS)
+def test_partial_blocks_non_owner_sales(suffix, client, db_session, test_requisition, test_user, admin_user):
+    _make_foreign(db_session, test_requisition, test_user, admin_user)
+    resp = client.get(f"/v2/partials/requisitions/{test_requisition.id}/{suffix}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize("suffix", PARTIAL_PATHS)
+def test_partial_blocks_non_owner_trader(suffix, client, db_session, test_requisition, test_user, admin_user):
+    _make_foreign(db_session, test_requisition, test_user, admin_user, role=UserRole.TRADER)
+    resp = client.get(f"/v2/partials/requisitions/{test_requisition.id}/{suffix}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize("suffix", PARTIAL_PATHS)
+def test_partial_allows_owning_sales(suffix, client, db_session, test_requisition, test_user):
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id
+    db_session.commit()
+    resp = client.get(f"/v2/partials/requisitions/{test_requisition.id}/{suffix}")
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize("suffix", PARTIAL_PATHS)
+def test_partial_allows_buyer(suffix, client, db_session, test_requisition, test_user):
+    assert test_user.role == "buyer"
+    resp = client.get(f"/v2/partials/requisitions/{test_requisition.id}/{suffix}")
+    assert resp.status_code == 200

--- a/tests/test_authz_offers_partials_idor.py
+++ b/tests/test_authz_offers_partials_idor.py
@@ -62,3 +62,34 @@ def test_partial_allows_buyer(suffix, client, db_session, test_requisition, test
     assert test_user.role == "buyer"
     resp = client.get(f"/v2/partials/requisitions/{test_requisition.id}/{suffix}")
     assert resp.status_code == 200
+
+
+# Two more offer-scoped GET partials in the same file had the identical read-IDOR
+# (they render an offer's vendor + unit price / full change history). They take an
+# offer_id, so they aren't in the req-suffix parametrization above.
+
+
+def test_edit_offer_form_blocks_non_owner(client, db_session, test_requisition, test_offer, test_user, admin_user):
+    """GET .../offers/{id}/edit-form must enforce requisition ownership (was IDOR)."""
+    _make_foreign(db_session, test_requisition, test_user, admin_user)
+    resp = client.get(f"/v2/partials/requisitions/{test_requisition.id}/offers/{test_offer.id}/edit-form")
+    assert resp.status_code == 404
+
+
+def test_offer_changelog_blocks_non_owner(client, db_session, test_requisition, test_offer, test_user, admin_user):
+    """GET /v2/partials/offers/{id}/changelog must enforce offer/requisition
+    ownership."""
+    _make_foreign(db_session, test_requisition, test_user, admin_user)
+    test_offer.entered_by_id = admin_user.id  # the offer belongs to the other rep too
+    db_session.commit()
+    resp = client.get(f"/v2/partials/offers/{test_offer.id}/changelog")
+    assert resp.status_code in (403, 404)
+
+
+def test_edit_offer_form_allows_owner(client, db_session, test_requisition, test_offer, test_user):
+    """The owning SALES rep still gets the edit form."""
+    test_user.role = UserRole.SALES
+    test_requisition.created_by = test_user.id
+    db_session.commit()
+    resp = client.get(f"/v2/partials/requisitions/{test_requisition.id}/offers/{test_offer.id}/edit-form")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Security fix — read-IDOR on offers.py requisition GET partials

Five requisition-scoped **GET partial** handlers in `app/routers/htmx/offers.py` resolved the requisition via `get_requisition_or_404(db, req_id)` but **skipped** `require_requisition_access(db, req_id, user)`. As a result a `RESTRICTED_ROLES` (SALES/TRADER) non-owner could read another rep's requisition name, customer, MPNs, and vendor contacts by crafting a direct GET — an object-level authorization (IDOR) hole.

The **mutating siblings** in the same file (`parse_email_action`, `save_parsed_offers`, `add_offer`, `rfq_send`, `log_activity`, etc.) and `requisition_tab` all already call `require_requisition_access`. This aligns the read partials with them.

### Handlers fixed
- `parse_email_form` — `GET /v2/partials/requisitions/{req_id}/parse-email-form`
- `paste_offer_form` — `GET /v2/partials/requisitions/{req_id}/paste-offer-form`
- `add_offer_form` — `GET /v2/partials/requisitions/{req_id}/add-offer-form`
- `rfq_compose` — `GET /v2/partials/requisitions/{req_id}/rfq-compose`
- `rfq_prepare_panel` — `GET /v2/partials/requisitions/{req_id}/rfq-prepare`

Each now calls `require_requisition_access(db, req_id, user)` immediately after the 404 existence check (404-not-403 so existence isn't leaked), reusing the exact helper the siblings use — no new ad-hoc checks.

### Tests
- New `tests/test_authz_offers_partials_idor.py`: for all 5 partials, a restricted SALES/TRADER non-owner gets **404**, while the owning SALES user and an unrestricted buyer get **200**. Verified the blocking assertions **fail without the fix** (10 failures) and pass with it.
- Ran the full offers/htmx test surface (`test_htmx_views`, `test_htmx_views_coverage`, `test_offers_overhaul`, `test_sprint2_offer_mgmt`, `test_phase3b_email_parsing`, `test_authz_offers_mark_sold`, `test_authz_requisition_read_idor`) + `test_static_analysis` — **428 passed**, no pre-existing test assumed the old behavior.

### Docs
Documented the closure in `docs/APP_MAP_INTERACTIONS.md` (authz-hardening section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF