### PR TITLE
fix(approvals): ownership-scope list/detail endpoints for RESTRICTED_ROLES

### DIFF
--- a/app/routers/approvals.py
+++ b/app/routers/approvals.py
@@ -23,12 +23,13 @@ Depends on: app.services.approvals.service, app.services.approvals.events,
 
 from fastapi import APIRouter, Depends, Form, HTTPException
 from fastapi.responses import JSONResponse, RedirectResponse
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
+from ..constants import RESTRICTED_ROLES, ApprovalRecipientStatus
 from ..database import get_db
 from ..dependencies import require_approval_gatekeeper, require_user
-from ..models.approvals import ApprovalRequest
+from ..models.approvals import ApprovalRequest, ApprovalStep, ApprovalStepRecipient
 from ..models.auth import User
 from ..services.approvals.events import cancel as svc_cancel
 from ..services.approvals.events import reassign as svc_reassign
@@ -59,6 +60,59 @@ def _serialize_request(r: ApprovalRequest) -> dict:
         "resolution_note": r.resolution_note,
         "created_at": r.created_at.isoformat() if r.created_at else None,
     }
+
+
+def _pending_recipient_exists(user: User):
+    """Correlated EXISTS: *user* holds a PENDING recipient row on the outer request.
+
+    Shared by the list scope and the detail guard so both mirror the exact set
+    require_approval_gatekeeper acts on.
+    """
+    return (
+        select(ApprovalStepRecipient.id)
+        .join(ApprovalStep, ApprovalStepRecipient.step_id == ApprovalStep.id)
+        .where(
+            ApprovalStep.request_id == ApprovalRequest.id,
+            ApprovalStepRecipient.user_id == user.id,
+            ApprovalStepRecipient.status == ApprovalRecipientStatus.PENDING,
+        )
+        .exists()
+    )
+
+
+def _restricted_visibility_clause(user: User):
+    """WHERE clause limiting ApprovalRequest rows a RESTRICTED_ROLES user may see.
+
+    Mirrors how the app scopes requisition-derived data (require_requisition_access /
+    RESTRICTED_ROLES): SALES/TRADER see only requests they submitted (requested_by_id),
+    own (owner_id), or must personally decide (a PENDING recipient row). Unrestricted
+    roles (buyer/manager/admin) are never passed here and keep full visibility.
+    """
+    return or_(
+        ApprovalRequest.requested_by_id == user.id,
+        ApprovalRequest.owner_id == user.id,
+        _pending_recipient_exists(user),
+    )
+
+
+def _can_view_request(db: Session, request: ApprovalRequest, user: User) -> bool:
+    """True if *user* may view *request* — full for unrestricted roles, scoped for
+    RESTRICTED_ROLES to their own/owned/pending-recipient requests (mirrors
+    _restricted_visibility_clause)."""
+    if getattr(user, "role", None) not in RESTRICTED_ROLES:
+        return True
+    if user.id in (request.requested_by_id, request.owner_id):
+        return True
+    recipient = db.execute(
+        select(ApprovalStepRecipient.id)
+        .join(ApprovalStep, ApprovalStepRecipient.step_id == ApprovalStep.id)
+        .where(
+            ApprovalStep.request_id == request.id,
+            ApprovalStepRecipient.user_id == user.id,
+            ApprovalStepRecipient.status == ApprovalRecipientStatus.PENDING,
+        )
+    ).first()
+    return recipient is not None
 
 
 @router.post("/v2/approvals/requests/{id}/decision")
@@ -150,6 +204,10 @@ def list_requests(
     (gate_type=buy_plan, subject_type=buy_plan), so the old read-only buy-plan bridge is
     gone — filter on gate_type='buy_plan' to get exactly the buy-plan requests.
 
+    Ownership scope: RESTRICTED_ROLES (SALES/TRADER) see only requests they submitted,
+    own, or must personally decide (see _restricted_visibility_clause); unrestricted
+    roles (buyer/manager/admin) see all — mirrors requisition-derived data scoping.
+
     Returns: {"items": [...], "total": N}.
     """
     q = select(ApprovalRequest)
@@ -157,6 +215,8 @@ def list_requests(
         q = q.where(ApprovalRequest.gate_type == gate_type)
     if status:
         q = q.where(ApprovalRequest.status == status)
+    if getattr(current_user, "role", None) in RESTRICTED_ROLES:
+        q = q.where(_restricted_visibility_clause(current_user))
 
     rows = db.execute(q).scalars().all()
     items = [_serialize_request(r) for r in rows]
@@ -183,11 +243,16 @@ def get_request(
 ):
     """Get a single ApprovalRequest by id.
 
+    Ownership scope: RESTRICTED_ROLES (SALES/TRADER) may only read a request they
+    submitted, own, or must personally decide (see _can_view_request); otherwise 404
+    (existence not leaked, mirroring require_requisition_access). Unrestricted roles
+    (buyer/manager/admin) may read any request.
+
     Returns: the request object as a dict.
-    Raises: 404 if not found.
+    Raises: 404 if not found or not visible to the current user.
     """
     request = db.get(ApprovalRequest, id)
-    if request is None:
+    if request is None or not _can_view_request(db, request, current_user):
         return JSONResponse(status_code=404, content={"error": f"ApprovalRequest {id} not found"})
 
     return _serialize_request(request)

--- a/docs/APP_MAP_INTERACTIONS.md
+++ b/docs/APP_MAP_INTERACTIONS.md
@@ -5782,8 +5782,14 @@ four-sub-tab `approvals/_queue.html` lens was already retired before that).
 per-gate projection) but is no longer wired to a human surface; the only human-facing approvals
 queue is now the engine API (`GET /v2/approvals/requests` + the standalone Approvals page).
 Subjects resolve by `subject_type` (buy_plan→plan detail, quality_plan→`/v2/qp/{id}`,
-prepayment→vendor + payment method). Visibility is **org-wide** (every request of that gate),
-but approve/reject act only for an eligible PENDING recipient (`decide()`). The legacy
+prepayment→vendor + payment method). **Visibility is ownership-scoped** (parity with
+requisition-derived data): unrestricted roles (buyer/manager/admin) see every request, but
+`RESTRICTED_ROLES` (SALES/TRADER) see only requests they submitted (`requested_by_id`), own
+(`owner_id`), or must personally decide (a PENDING `ApprovalStepRecipient` row) — enforced on
+BOTH `list_requests` (`_restricted_visibility_clause`) and `get_request`
+(`_can_view_request`; 404-not-403 so existence isn't leaked, mirroring
+`require_requisition_access`). approve/reject still act only for an eligible PENDING recipient
+(`decide()`). The legacy
 `GET /v2/approvals/queue` still **302-redirects** to `/v2/buy-plans?lens=approvals` (which 302s
 on to the hub, where the unknown lens falls back to the role default).
 `ApprovalRequestActionSource` (`AlertKind.APPROVAL_ACTION`) is registered under the

--- a/tests/test_approvals_routes.py
+++ b/tests/test_approvals_routes.py
@@ -59,6 +59,21 @@ def _make_outsider(db: Session) -> User:
     return u
 
 
+def _make_restricted(db: Session, role: str = "sales") -> User:
+    """A RESTRICTED_ROLES user (sales/trader) — ownership-scoped visibility."""
+    u = User(
+        email=f"restricted-{uuid.uuid4().hex[:6]}@test.com",
+        name="Restricted",
+        role=role,
+        azure_id=f"azure-restricted-{uuid.uuid4().hex[:8]}",
+        can_approve_buy_plans=False,
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
 def _make_buy_plan(db: Session, user: User) -> BuyPlan:
     req = Requisition(
         name=f"REQ-TEST-{uuid.uuid4().hex[:6]}",
@@ -302,3 +317,91 @@ class TestPostCancel:
         assert resp.json() == {"cancelled": True}
         db_session.expire(ar)
         assert ar.status == "cancelled"
+
+
+class TestOwnershipScoping:
+    """RESTRICTED_ROLES (SALES/TRADER) may only see requests they submitted, own, or
+    must personally decide — list + detail. Unrestricted roles keep full visibility.
+
+    Security: without scoping, a restricted user could enumerate every company-wide
+    approval's dollar amount / owner via the list and detail endpoints.
+    """
+
+    def _seed_request(self, db_session: Session, owner: User) -> ApprovalRequest:
+        bp = _make_buy_plan(db_session, owner)
+        qp = _make_quality_plan(db_session, bp, owner)
+        ar, _, _ = _make_approval_chain(db_session, qp, owner)
+        return ar
+
+    def test_restricted_user_does_not_see_others_request_in_list(self, db_session: Session) -> None:
+        """A sales user must NOT see another user's request in the list."""
+        owner = _make_approver(db_session)  # admin, owns the request
+        ar = self._seed_request(db_session, owner)
+        stranger = _make_restricted(db_session)  # sales, unrelated
+
+        for client in _build_client(db_session, stranger, override_gatekeeper=False):
+            resp = client.get("/v2/approvals/requests")
+
+        assert resp.status_code == 200
+        ids = [item["id"] for item in resp.json()["items"]]
+        assert ar.id not in ids, "restricted user leaked another user's approval request"
+
+    def test_restricted_user_gets_404_on_others_detail(self, db_session: Session) -> None:
+        """A sales user must get 404 on another user's request detail (existence
+        hidden)."""
+        owner = _make_approver(db_session)  # admin, owns the request
+        ar = self._seed_request(db_session, owner)
+        stranger = _make_restricted(db_session)  # sales, unrelated
+
+        for client in _build_client(db_session, stranger, override_gatekeeper=False):
+            resp = client.get(f"/v2/approvals/requests/{ar.id}")
+
+        assert resp.status_code == 404
+        assert "error" in resp.json()
+
+    def test_restricted_user_sees_own_request(self, db_session: Session) -> None:
+        """A sales user sees the request they submitted/own — list + detail (200)."""
+        me = _make_restricted(db_session)  # sales, owner + requester
+        ar = self._seed_request(db_session, me)
+
+        for client in _build_client(db_session, me, override_gatekeeper=False):
+            list_resp = client.get("/v2/approvals/requests")
+            detail_resp = client.get(f"/v2/approvals/requests/{ar.id}")
+
+        assert list_resp.status_code == 200
+        assert ar.id in [item["id"] for item in list_resp.json()["items"]]
+        assert detail_resp.status_code == 200
+        assert detail_resp.json()["id"] == ar.id
+
+    def test_restricted_recipient_sees_request(self, db_session: Session) -> None:
+        """A sales user who is a PENDING recipient (not owner/requester) sees it."""
+        owner = _make_approver(db_session)  # admin, owns the request
+        ar = self._seed_request(db_session, owner)
+        # Route a fresh pending recipient step to a restricted user (not owner/requester).
+        recip_user = _make_restricted(db_session, role="trader")
+        step = ApprovalStep(request_id=ar.id, seq=2, rule="any", status="pending")
+        db_session.add(step)
+        db_session.flush()
+        db_session.add(ApprovalStepRecipient(step_id=step.id, user_id=recip_user.id, status="pending"))
+        db_session.commit()
+
+        for client in _build_client(db_session, recip_user, override_gatekeeper=False):
+            list_resp = client.get("/v2/approvals/requests")
+            detail_resp = client.get(f"/v2/approvals/requests/{ar.id}")
+
+        assert ar.id in [item["id"] for item in list_resp.json()["items"]]
+        assert detail_resp.status_code == 200
+
+    def test_admin_sees_all_requests(self, db_session: Session) -> None:
+        """An admin (unrestricted) still sees another user's request — list + detail."""
+        owner = _make_outsider(db_session)  # buyer, owns the request
+        ar = self._seed_request(db_session, owner)
+        admin = _make_approver(db_session)  # admin, unrelated
+
+        for client in _build_client(db_session, admin, override_gatekeeper=False):
+            list_resp = client.get("/v2/approvals/requests")
+            detail_resp = client.get(f"/v2/approvals/requests/{ar.id}")
+
+        assert ar.id in [item["id"] for item in list_resp.json()["items"]]
+        assert detail_resp.status_code == 200
+        assert detail_resp.json()["id"] == ar.id


### PR DESCRIPTION
## Security fix (production-readiness audit)

`GET /v2/approvals/requests` (`list_requests`) and `GET /v2/approvals/requests/{id}` (`get_request`) in `app/routers/approvals.py` only `Depends(require_user)` and returned **every** `ApprovalRequest` company-wide — `amount`, `currency`, `requested_by_id`, `owner_id`, `resolution_note`, `subject_id`. A restricted **SALES/TRADER** could enumerate every buy-plan / PO / prepayment approval and its dollar amount, defeating the ownership model the rest of the app enforces (`require_requisition_access`, `RESTRICTED_ROLES`).

## Fix

Scope both endpoints exactly the way requisition-derived data is scoped elsewhere:

- **Unrestricted roles** (buyer / manager / admin) keep full visibility — no behavior change.
- **`RESTRICTED_ROLES`** (SALES / TRADER) see only requests where they are `requested_by_id`, `owner_id`, or hold a **PENDING `ApprovalStepRecipient`** row (the exact set `require_approval_gatekeeper` / `decide()` act on).
- List filters via `_restricted_visibility_clause` (correlated `EXISTS`); detail guards via `_can_view_request` and returns **404-not-403** so existence isn't leaked (mirrors `require_requisition_access`).

approve / reject / cancel authz is unchanged.

## Tests (`tests/test_approvals_routes.py::TestOwnershipScoping`)

- restricted user does **not** see another user's request in the list — **FAILS without the fix**
- restricted user gets **404** on another user's detail — **FAILS without the fix**
- restricted user sees their **OWN** request (list + detail)
- restricted user who is a PENDING recipient sees the request
- **admin still sees all** (list + detail)

Verified the two leak tests fail on `origin/main`'s behavior and pass with the fix. Full `tests/test_approvals_routes.py`, `tests/test_static_analysis.py`, `tests/test_approvals_bridge.py`, `tests/test_approvals_coverage_nightly.py`, `tests/test_c2b_sections.py`, `tests/test_my_queue.py` green. `pre-commit` clean. `docs/APP_MAP_INTERACTIONS.md` updated (visibility is now ownership-scoped, not org-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF