### PR TITLE
fix(security): keep requisition import-save under CSRF enforcement

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ setup_logging()  # Must run before any other module logs
 import hmac
 import logging
 import os
+import re
 import uuid
 from contextlib import asynccontextmanager
 
@@ -382,27 +383,37 @@ app.add_middleware(
 # GZip responses ≥ 500 bytes — big wins on JSON-heavy API payloads
 app.add_middleware(GZipMiddleware, minimum_size=500)
 
+# CSRF double-submit-cookie exemptions. Matched with re.Pattern.match against
+# request.url.path (starlette_csrf ``_url_is_exempt``), so anchor the end with ``$``
+# to stop a prefix from over-matching a sibling route. Only genuinely
+# CSRF-incompatible or unauthenticated endpoints belong here; every state-changing
+# authenticated route must stay under x-csrftoken enforcement. Exposed as a
+# module-level constant so the exempt set is unit-testable (see tests).
+CSRF_EXEMPT_URLS = [
+    re.compile(r"/auth/callback$"),
+    re.compile(r"/auth/login$"),
+    re.compile(r"/health$"),
+    re.compile(r"/metrics$"),
+    # Import PREVIEW only: import-parse is a multipart upload (a plain browser form
+    # post can't add the x-csrftoken header) and import-form is a GET. import-save
+    # (POST that CREATES requisition + requirement rows) is deliberately EXCLUDED so
+    # it stays under standard CSRF enforcement like every other state-changing route.
+    re.compile(r"/v2/partials/requisitions/import-(form|parse)$"),
+    re.compile(r"/v2/partials/customers/lookup"),  # AI company lookup (read-only)
+    re.compile(r"/api/webhooks/graph$"),  # Microsoft Graph mail webhook
+    re.compile(r"/api/webhooks/teams$"),  # Microsoft Graph Teams webhook
+    re.compile(r"/api/webhooks/acs$"),  # Azure Communication Services webhook
+]
+
 # CSRF protection (double-submit cookie) — disabled in test mode
 if not os.environ.get("TESTING"):
-    import re
-
     from starlette_csrf import CSRFMiddleware
 
     app.add_middleware(
         CSRFMiddleware,
         secret=settings.secret_key,
         sensitive_cookies={"session"},  # Only enforce CSRF when session cookie is present
-        exempt_urls=[
-            re.compile(r"/auth/callback$"),
-            re.compile(r"/auth/login$"),
-            re.compile(r"/health$"),
-            re.compile(r"/metrics$"),
-            re.compile(r"/v2/partials/requisitions/import-.*"),  # multipart file upload
-            re.compile(r"/v2/partials/customers/lookup"),  # AI company lookup (read-only)
-            re.compile(r"/api/webhooks/graph$"),  # Microsoft Graph mail webhook
-            re.compile(r"/api/webhooks/teams$"),  # Microsoft Graph Teams webhook
-            re.compile(r"/api/webhooks/acs$"),  # Azure Communication Services webhook
-        ],
+        exempt_urls=CSRF_EXEMPT_URLS,
     )
 
 

--- a/docs/APP_MAP_ARCHITECTURE.md
+++ b/docs/APP_MAP_ARCHITECTURE.md
@@ -50,7 +50,14 @@ FastAPI Middleware Stack (in order):
     │       (sets current_user_id contextvar) and ModuleAccessMiddleware (per-user MODULE
     │       access chokepoint on module-exclusive HTMX sub-partials — see INTERACTIONS
     │       "Module SUB-partial chokepoint"; reads scope["session"] so Session must run first).
-    ├── 3. CSRFMiddleware (double-submit cookie on mutations)
+    ├── 3. CSRFMiddleware (double-submit cookie on mutations; exempt set is the
+    │       module-level `CSRF_EXEMPT_URLS` in main.py — anchor patterns with `$` since
+    │       starlette_csrf matches `re.match(url.path)`. Only auth/health/webhook/read
+    │       endpoints and the requisition import PREVIEW are exempt: `import-parse`
+    │       (multipart upload, browser form can't add the x-csrftoken header) + the
+    │       `import-form` GET. `import-save` (the DB write) is NOT exempt — it stays under
+    │       token enforcement like every mutation; htmx supplies the header via the global
+    │       `htmx:configRequest` listener in htmx_app.js)
     ├── 4. PrometheusMiddleware (request count + duration histogram, app/prometheus_metrics.py)
     │       Note: fastapi 0.137 (PR #15745) made `app.routes` a tree — `include_router`'d
     │       routes hide behind opaque `_IncludedRouter` wrappers — so `_handler_for` reads

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -244,6 +244,60 @@ class TestCSRFExemptions:
         assert r"/auth/.*" not in content, "Broad /auth/.* CSRF exemption should be removed"
         assert "/auth/callback" in content
 
+    def test_import_save_not_csrf_exempt(self):
+        """The requisition import-save POST creates Requisition + Requirement rows, so
+        it must stay under CSRF-token enforcement.
+
+        Only the multipart preview (import-parse) and the import-form GET are exempt — a
+        prefix pattern that also covered import-save would let a cross-site POST forge
+        requisitions.
+        """
+        from starlette.datastructures import URL
+        from starlette_csrf import CSRFMiddleware
+
+        from app.main import CSRF_EXEMPT_URLS
+
+        mw = CSRFMiddleware(app=lambda scope, receive, send: None, secret="x", exempt_urls=CSRF_EXEMPT_URLS)
+        assert mw._url_is_exempt(URL(path="/v2/partials/requisitions/import-save")) is False
+        assert mw._url_is_exempt(URL(path="/v2/partials/requisitions/import-parse")) is True
+        assert mw._url_is_exempt(URL(path="/v2/partials/requisitions/import-form")) is True
+
+    def test_import_save_rejected_without_csrf_token(self):
+        """End-to-end: with the real exempt set, an authenticated (session-cookie) POST to
+        import-save carrying no x-csrftoken is rejected 403, while import-parse (multipart
+        preview) still passes through exempt. Fails against the old broad ``import-.*``
+        exemption, which let import-save through unprotected."""
+        from starlette.applications import Starlette
+        from starlette.responses import PlainTextResponse
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+        from starlette_csrf import CSRFMiddleware
+
+        from app.main import CSRF_EXEMPT_URLS
+
+        async def ok(request):
+            return PlainTextResponse("ok")
+
+        app = Starlette(
+            routes=[
+                Route("/v2/partials/requisitions/import-save", ok, methods=["POST"]),
+                Route("/v2/partials/requisitions/import-parse", ok, methods=["POST"]),
+            ]
+        )
+        app.add_middleware(
+            CSRFMiddleware,
+            secret="test-secret",
+            sensitive_cookies={"session"},
+            exempt_urls=CSRF_EXEMPT_URLS,
+        )
+        client = TestClient(app)
+        client.cookies.set("session", "authenticated")
+
+        # No x-csrftoken header → the write path must be rejected.
+        assert client.post("/v2/partials/requisitions/import-save").status_code == 403
+        # The multipart preview stays exempt and passes through.
+        assert client.post("/v2/partials/requisitions/import-parse").status_code == 200
+
 
 # ── Fix 6: Style Attribute XSS ────────────────────────────────────
 


### PR DESCRIPTION
## Security finding
The CSRF `exempt_urls` pattern in `app/main.py` was:
```python
re.compile(r"/v2/partials/requisitions/import-.*"),  # multipart file upload
```
That prefix was intended to exempt only the **multipart preview** (`import-parse`), but `re.Pattern.match` against `request.url.path` with no end anchor also matched **`import-save`** — a `POST` that **creates `Requisition` + `Requirement` rows** from ordinary form fields (`app/routers/htmx/requisitions.py`). A DB-write route was therefore exempt from CSRF-token enforcement.

`same_site=lax` already mitigates in practice, so this is **defense-in-depth**, but the write path should not sit in the exempt set.

## Fix (minimal)
- Narrowed the pattern to `re.compile(r"/v2/partials/requisitions/import-(form|parse)$")` — exempts only the multipart preview (`import-parse`, which a plain browser form post can't add the `x-csrftoken` header to) and the `import-form` GET. `import-save` now stays under standard `x-csrftoken` enforcement like every other mutation.
- Hoisted the exempt list to a module-level `CSRF_EXEMPT_URLS` constant so the exempt set is unit-testable, and moved `import re` to the module import block.

The real save flow is unaffected: `import-save` is submitted via `hx-post`, and the global `htmx:configRequest` listener in `app/static/htmx_app.js` attaches the `x-csrftoken` header to every htmx mutation.

## Tests (fail without the fix)
Added to `tests/test_security_fixes.py::TestCSRFExemptions`, both built against the real `CSRF_EXEMPT_URLS`:
- `test_import_save_not_csrf_exempt` — asserts `import-save` is not exempt while `import-parse`/`import-form` are.
- `test_import_save_rejected_without_csrf_token` — end-to-end through `CSRFMiddleware`: a session-cookie POST to `import-save` with no `x-csrftoken` → **403**; `import-parse` → **200** (still exempt).

Both fail against the old broad `import-.*` pattern (verified by reverting) and pass with the fix. Full run of the touched files (`test_security_fixes`, `test_main`, `test_static_analysis`, `test_req_import`, `test_import_parse_json`, `test_unified_req_form`, `test_htmx_views`, `test_htmx_material_card_auto`, `test_frontend_hardening`): **333 passed**.

## Docs
Updated the CSRFMiddleware entry in `docs/APP_MAP_ARCHITECTURE.md` to document `CSRF_EXEMPT_URLS`, the `$`-anchor requirement (starlette_csrf matches `re.match(url.path)`), and that `import-save` is deliberately not exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF