### PR TITLE
Vendors surface: design-system conformance pass

### DIFF
--- a/app/templates/htmx/partials/vendors/_custom_fields.html
+++ b/app/templates/htmx/partials/vendors/_custom_fields.html
@@ -44,7 +44,7 @@
     </button>
 
     <div x-show='open' @click.outside='open = false' x-cloak
-         class='absolute left-0 top-7 z-20 w-64 bg-white rounded-lg shadow-lg border border-gray-200 p-3'>
+         class='absolute left-0 top-7 z-20 w-64 bg-white rounded-lg shadow-float border border-gray-200 p-3'>
       <form hx-post='{{ _post_url }}'
             hx-target='#vendor-custom-fields-{{ vendor.id }}'
             hx-swap='outerHTML'
@@ -57,7 +57,7 @@
                class='w-full px-2 py-1 text-xs border border-gray-200 rounded focus:ring-2 focus:ring-brand-500 focus:border-brand-500'
                required maxlength='500'>
         <button type='submit'
-                class='self-end px-3 py-1 text-xs font-medium bg-brand-500 text-white rounded hover:bg-brand-600'>Add</button>
+                class='self-end btn btn-primary btn-sm'>Add</button>
       </form>
     </div>
   </div>

--- a/app/templates/htmx/partials/vendors/create_form.html
+++ b/app/templates/htmx/partials/vendors/create_form.html
@@ -25,7 +25,7 @@
                hx-trigger="keyup changed delay:500ms"
                hx-target="#dup-warning"
                hx-include="[name=display_name]"
-               class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+               class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                placeholder="e.g. Arrow Electronics">
         <div id="dup-warning" class="mt-1 text-xs text-amber-600"></div>
       </div>
@@ -34,13 +34,13 @@
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Website</label>
           <input type="url" name="website"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                 class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                  placeholder="https://example.com">
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Industry</label>
           <input type="text" name="industry"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                 class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                  placeholder="e.g. Electronic Components">
         </div>
       </div>
@@ -49,13 +49,13 @@
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Emails (comma-separated)</label>
           <input type="text" name="emails"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                 class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                  placeholder="sales@vendor.com, info@vendor.com">
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Phones (comma-separated)</label>
           <input type="text" name="phones"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                 class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                  placeholder="+1-555-0100">
         </div>
       </div>
@@ -66,20 +66,20 @@
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">City</label>
             <input type="text" name="hq_city"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                   class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                    placeholder="e.g. Chicago">
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Country</label>
             <input type="text" name="hq_country"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                   class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                    placeholder="e.g. US">
           </div>
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Employee Size</label>
           <select name="employee_size"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
+                  class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500">
             <option value="">— Select —</option>
             <option value="1-10">1–10</option>
             <option value="11-50">11–50</option>

--- a/app/templates/htmx/partials/vendors/detail.html
+++ b/app/templates/htmx/partials/vendors/detail.html
@@ -180,7 +180,7 @@
 
         {# Contact info card #}
         {% if vendor.emails or vendor.phones or vendor.website %}
-        <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-5">
+        <div class="bg-white rounded-xl shadow-card border border-brand-200 p-5">
           <h2 class="text-sm font-semibold text-gray-900 mb-3">Contact Information</h2>
           <div class="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
             {% if vendor.website %}
@@ -226,7 +226,7 @@
 
         {# Contacts table (overview summary) #}
         {% if contacts %}
-        <div class="bg-white rounded-xl shadow-sm border border-brand-200 overflow-hidden">
+        <div class="bg-white rounded-xl shadow-card border border-brand-200 overflow-hidden">
           <div class="px-5 py-3 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
             <h2 class="text-sm font-semibold text-gray-900">Contacts ({{ contacts|length }})</h2>
             <button @click="activeTab = 'contacts'"
@@ -288,7 +288,7 @@
 
         {# Recent sightings #}
         {% if recent_sightings %}
-        <div class="bg-white rounded-xl shadow-sm border border-brand-200 overflow-hidden">
+        <div class="bg-white rounded-xl shadow-card border border-brand-200 overflow-hidden">
           <div class="px-5 py-3 bg-gray-50 border-b border-gray-200">
             <h2 class="text-sm font-semibold text-gray-900">
               {% if mpn_filter %}

--- a/app/templates/htmx/partials/vendors/edit_vendor_form.html
+++ b/app/templates/htmx/partials/vendors/edit_vendor_form.html
@@ -43,7 +43,7 @@
       </div>
     </div>
     <button type="submit"
-            class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+            class="btn btn-primary btn-md">
       Save Changes
     </button>
   </form>

--- a/app/templates/htmx/partials/vendors/emails_tab.html
+++ b/app/templates/htmx/partials/vendors/emails_tab.html
@@ -141,7 +141,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
     </svg>
     <p class="text-sm text-gray-600 mb-1">No email history with this vendor.</p>
-    <p class="text-xs text-gray-400">Email history appears when RFQs are sent or responses are received.</p>
+    <p class="text-secondary">Email history appears when RFQs are sent or responses are received.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/vendors/find_contacts_results.html
+++ b/app/templates/htmx/partials/vendors/find_contacts_results.html
@@ -21,6 +21,6 @@
     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"/>
   </svg>
   <p class="text-sm text-gray-600">No contacts found for this vendor.</p>
-  <p class="text-xs text-gray-400 mt-1">Try broadening the job title keywords.</p>
+  <p class="text-secondary mt-1">Try broadening the job title keywords.</p>
 </div>
 {% endif %}

--- a/app/templates/htmx/partials/vendors/find_contacts_tab.html
+++ b/app/templates/htmx/partials/vendors/find_contacts_tab.html
@@ -21,7 +21,7 @@
               @htmx:before-request="searching = true"
               @htmx:after-request="searching = false"
               :disabled="searching"
-              class="px-4 py-2 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-2">
+              class="btn btn-primary btn-md">
         <svg x-show="!searching" x-cloak class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
         </svg>
@@ -50,7 +50,7 @@
     <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
       <div class="px-4 py-3 bg-gray-50 border-b border-gray-200 flex items-center justify-between">
         <h3 class="text-sm font-semibold text-gray-900">Found Contacts ({{ prospects|length }})</h3>
-        <span class="text-xs text-gray-400">Previously discovered via AI</span>
+        <span class="text-secondary">Previously discovered via AI</span>
       </div>
       <div class="divide-y divide-gray-200" id="prospect-list">
         {% for p in prospects %}
@@ -64,7 +64,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/>
       </svg>
       <p class="text-sm text-gray-600 mb-1">No AI-discovered contacts yet.</p>
-      <p class="text-xs text-gray-400">Click "Find Contacts" above to search with AI.</p>
+      <p class="text-secondary">Click "Find Contacts" above to search with AI.</p>
     </div>
     {% endif %}
 

--- a/app/templates/htmx/partials/vendors/list.html
+++ b/app/templates/htmx/partials/vendors/list.html
@@ -13,7 +13,7 @@
   <div class="flex items-center justify-between mb-4">
     <div>
       <h2 class="text-base font-semibold text-gray-900">Vendors</h2>
-      <p class="text-xs text-gray-500 mt-0.5">{{ total }} vendor{{ "s" if total != 1 }}</p>
+      <p class="text-secondary mt-0.5">{{ total }} vendor{{ "s" if total != 1 }}</p>
     </div>
     <div class="flex items-center gap-2">
       <a hx-get="/v2/partials/vendor-contacts"

--- a/app/templates/htmx/partials/vendors/overview_tab.html
+++ b/app/templates/htmx/partials/vendors/overview_tab.html
@@ -63,7 +63,7 @@
 
   {# Contacts table #}
   {% if contacts %}
-  <div class="bg-white rounded-xl shadow-sm border border-brand-200 overflow-hidden">
+  <div class="bg-white rounded-xl shadow-card border border-brand-200 overflow-hidden">
     <div class="px-5 py-3 bg-gray-50 border-b border-gray-200">
       <h2 class="text-sm font-semibold text-gray-900">Contacts ({{ contacts|length }})</h2>
     </div>
@@ -115,7 +115,7 @@
 
   {# Recent sightings #}
   {% if recent_sightings %}
-  <div class="bg-white rounded-xl shadow-sm border border-brand-200 overflow-hidden">
+  <div class="bg-white rounded-xl shadow-card border border-brand-200 overflow-hidden">
     <div class="px-5 py-3 bg-gray-50 border-b border-gray-200">
       <h2 class="text-sm font-semibold text-gray-900">
         {% if mpn_filter %}

--- a/app/templates/htmx/partials/vendors/reviews.html
+++ b/app/templates/htmx/partials/vendors/reviews.html
@@ -28,7 +28,7 @@
       <input aria-label="Review comment" type="text" name="comment" placeholder="Add a comment (optional)"
              class="flex-1 px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
       <button type="submit"
-              class="px-3 py-1.5 text-xs font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+              class="btn btn-primary btn-sm">
         Add Review
       </button>
     </div>

--- a/app/templates/htmx/partials/vendors/tabs/_vendor_tasks.html
+++ b/app/templates/htmx/partials/vendors/tabs/_vendor_tasks.html
@@ -4,7 +4,7 @@
               complete_task_endpoint, delete_task_endpoint (vendor branch)
    Depends on: task_service.get_open_tasks_for_vendor_card
 #}
-<div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4" id="vendor-tasks-{{ vendor_id }}">
+<div class="bg-white rounded-xl shadow-card border border-brand-200 p-4" id="vendor-tasks-{{ vendor_id }}">
   <div class="flex items-center justify-between mb-2">
     <h2 class="text-sm font-semibold text-gray-900">Tasks</h2>
     <button type="button"
@@ -71,6 +71,6 @@
       {% endfor %}
     </ul>
   {% else %}
-    <p class="text-xs text-gray-400 italic">No open tasks.</p>
+    <p class="text-secondary italic">No open tasks.</p>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/vendors/tabs/activity_tab.html
+++ b/app/templates/htmx/partials/vendors/tabs/activity_tab.html
@@ -43,7 +43,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0116 0z"/>
     </svg>
     <p class="text-sm text-gray-600">No activity recorded for this vendor yet.</p>
-    <p class="text-xs text-gray-400 mt-1">Activity will appear here as you log calls, emails, notes, and meetings.</p>
+    <p class="text-secondary mt-1">Activity will appear here as you log calls, emails, notes, and meetings.</p>
   </div>
   {% endif %}
 
@@ -131,7 +131,7 @@
     {# ── Truncation footer ─────────────────────────────── #}
     {% if activities_truncated %}
     <div class="px-4 py-2 bg-gray-50 border border-gray-200 rounded-lg mt-3">
-      <p class="text-xs text-gray-400">Showing most recent 50 activities — older history may not appear.</p>
+      <p class="text-secondary">Showing most recent 50 activities — older history may not appear.</p>
     </div>
     {% endif %}
 

--- a/app/templates/htmx/partials/vendors/tabs/contact_row.html
+++ b/app/templates/htmx/partials/vendors/tabs/contact_row.html
@@ -79,8 +79,8 @@
       <input aria-label="Phone" type="text" name="phone" value="{{ c.phone or '' }}"
              class="w-32 px-2 py-1 text-sm border border-brand-200 rounded focus:ring-2 focus:ring-brand-500"
              placeholder="Phone">
-      <button type="submit" class="px-3 py-1 text-xs font-medium bg-brand-500 text-white rounded hover:bg-brand-600">Save</button>
-      <button type="button" @click="editing = false" class="px-3 py-1 text-xs font-medium text-gray-600 border border-gray-300 rounded hover:bg-gray-100">Cancel</button>
+      <button type="submit" class="btn btn-primary btn-sm">Save</button>
+      <button type="button" @click="editing = false" class="btn btn-secondary btn-sm">Cancel</button>
     </form>
   </td>
 </tr>

--- a/app/templates/htmx/partials/vendors/tabs/contact_rows.html
+++ b/app/templates/htmx/partials/vendors/tabs/contact_rows.html
@@ -19,7 +19,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/>
     </svg>
     <p class="text-sm font-medium text-gray-600 mt-3">No contacts found for this vendor.</p>
-    <p class="text-xs text-gray-400 mt-1">Click "+ Add Contact" above or use "Find Contacts" to discover contacts via AI.</p>
+    <p class="text-secondary mt-1">Click "+ Add Contact" above or use "Find Contacts" to discover contacts via AI.</p>
   </td>
 </tr>
 {% endif %}

--- a/app/templates/htmx/partials/vendors/tabs/contacts.html
+++ b/app/templates/htmx/partials/vendors/tabs/contacts.html
@@ -35,7 +35,7 @@
       <input aria-label="Phone" type="text" name="phone" placeholder="Phone"
              class="px-2 py-1.5 text-sm border border-brand-200 rounded-lg focus:ring-2 focus:ring-brand-500">
       <button type="submit"
-              class="px-3 py-1.5 text-sm font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 transition-colors">
+              class="btn btn-primary btn-md">
         Add
       </button>
     </form>

--- a/app/templates/htmx/partials/vendors/vendor_card.html
+++ b/app/templates/htmx/partials/vendors/vendor_card.html
@@ -16,7 +16,7 @@
     <div class="min-w-0">
       <h3 class="font-semibold text-gray-900 truncate">{{ v.display_name }}</h3>
       {% if v.domain %}
-      <p class="text-xs text-gray-400 truncate">{{ v.domain }}</p>
+      <p class="text-secondary truncate">{{ v.domain }}</p>
       {% endif %}
     </div>
     {% set claim = claim_map.get(v.id) if claim_map else None %}
@@ -57,7 +57,7 @@
     </div>
   </div>
   {% else %}
-  <p class="text-xs text-gray-400 italic">New — no score yet</p>
+  <p class="text-secondary italic">New — no score yet</p>
   {% endif %}
 
   {# Row 3: Brand + commodity tags #}
@@ -101,7 +101,7 @@
 
   {# Row 6: Location + industry #}
   {% if v.hq_country or v.industry %}
-  <div class="text-xs text-gray-400 truncate">
+  <div class="text-secondary truncate">
     {{ v.hq_country or '' }}{% if v.hq_country and v.industry %} · {% endif %}{{ v.industry or '' }}
   </div>
   {% endif %}


### PR DESCRIPTION
Mechanical design-system conformance pass over `app/templates/htmx/partials/vendors/` — hand-rolled markup swapped for the app's existing canonical classes/macros so the same visual outcome is produced consistently, plus the documented gray-600 contrast floor. No layout, behavior, or structural changes (no `hx-*`, `@click`, `x-data`, id, or name touched). All changes are presentation classes only.

## Changes

**Buttons (rule 4 — primary CTAs must be `.btn-primary`, not the wrong gray `bg-brand-500`)**
- `edit_vendor_form.html` Save Changes, `_custom_fields.html` Add, `find_contacts_tab.html` Find Contacts, `reviews.html` Add Review, `tabs/contact_row.html` Save (+ its paired Cancel → `.btn-secondary`), `tabs/contacts.html` Add → `.btn-primary` (`btn-sm`/`btn-md` matched to the original size so text size is preserved).

**Shadows (rule 5)**
- `shadow-sm` on resting card containers → `shadow-card` (`detail.html` ×3, `overview_tab.html` ×2, `tabs/_vendor_tasks.html`).
- Floating `_custom_fields.html` add-field dropdown `shadow-lg` → `shadow-float`.

**Contrast floor (rule 1 — faint reader-facing caption/empty-state/help copy)**
- `text-xs text-gray-400/500` → `.text-secondary` (gray-600, size-preserving) in `list.html`, `find_contacts_tab.html` ×2, `find_contacts_results.html`, `emails_tab.html`, `tabs/activity_tab.html` ×2, `tabs/contact_rows.html`, `tabs/_vendor_tasks.html`, `vendor_card.html` ×3.

**Input radius (rule 9)**
- `create_form.html` inputs/select `rounded-md` (undocumented 6px) → `rounded-lg` (documented tier). The fieldset container radius is left untouched.

## Deliberately skipped (non-mechanical / would change visual outcome — noted, not guessed)
- Legacy `min-w-full divide-y divide-gray-200` + `thead bg-gray-50` tables (detail, overview, contacts_list, tabs/contacts): converting to `.data-table`/`.compact-table` flattens per-cell color emphasis (emerald price, gray-600 cells) and swaps the header background — not a same-visual swap.
- Hand-rolled empty states (list, contacts_list, emails, find_contacts): the shared `empty_state.html` partial only supports a single message line and different card chrome; these carry a second help line / deliberate `.card` chrome.
- `emails_tab.html` RFQ-status pill → `quote_status_badge`: routing only the status pill through the macro adds a border and diverges from the adjacent (macro-less) classification pill, creating intra-tab inconsistency.
- `text-sm` gray-400 empty states (contact_timeline, reviews) and `create_form` `text-sm` labels: converting to `.text-secondary`/`.form-label` would resize the text.

## Tests
- `TESTING=1 pytest tests/test_static_analysis.py` + vendor render/route + template-integrity suites: 1044 passed (static analysis, template UI integrity, vendor CRUD/contacts/tasks/activity/stock/scorecard, htmx_views deep + nightly).
- `pre-commit run --files <changed>`: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF