### PR TITLE
chore(ui): DS conformance — Requisitions + Parts + Search partials

### DIFF
--- a/app/templates/htmx/partials/parts/header.html
+++ b/app/templates/htmx/partials/parts/header.html
@@ -44,7 +44,7 @@
           {{ requirement.brand or 'No brand' }}
         </span>
       </div>
-      <p class="text-xs text-gray-400 truncate mt-0.5">
+      <p class="text-secondary truncate mt-0.5">
         {{ requirement.requisition.name if requirement.requisition else '—' }}
         {% if requirement.requisition and requirement.requisition.customer_name %}
           · {{ requirement.requisition.customer_name }}
@@ -89,7 +89,7 @@
               title="Click to edit qty">
           {{ '{:,}'.format(requirement.target_qty) if requirement.target_qty else '—' }}
         </span>
-        <span class="text-xs text-gray-400 block">qty</span>
+        <span class="text-secondary block">qty</span>
       </div>
 
       {# Target Price — inline editable #}
@@ -101,7 +101,7 @@
               title="Click to edit target price">
           {{ '${:,.4f}'.format(requirement.target_price) if requirement.target_price else '—' }}
         </span>
-        <span class="text-xs text-gray-400 block">target</span>
+        <span class="text-secondary block">target</span>
       </div>
 
     </div>

--- a/app/templates/htmx/partials/parts/list.html
+++ b/app/templates/htmx/partials/parts/list.html
@@ -253,7 +253,7 @@
   {# ── Undo toast for archive actions ──────────────────────── #}
   <div x-data="undoToast()" @part-archived.window="showUndo($event.detail)"
        x-show="visible" x-cloak
-       class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 bg-gray-800 text-white px-4 py-2 rounded-lg shadow-lg flex items-center gap-3 text-xs">
+       class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 bg-gray-800 text-white px-4 py-2 rounded-lg shadow-float flex items-center gap-3 text-xs">
     <span x-text="message"></span>
     <button @click="undo()" class="font-semibold text-accent-300 hover:text-accent-100 underline">Undo</button>
     <span class="text-gray-400 text-[11px]" x-text="countdown + 's'"></span>

--- a/app/templates/htmx/partials/parts/tabs/comms.html
+++ b/app/templates/htmx/partials/parts/tabs/comms.html
@@ -56,7 +56,7 @@
           {% if task.description %}
             <p class="text-xs text-gray-600 mt-0.5">{{ task.description }}</p>
           {% endif %}
-          <div class="flex items-center gap-3 mt-1.5 text-xs text-gray-400 flex-wrap">
+          <div class="flex items-center gap-3 mt-1.5 text-secondary flex-wrap">
             {% if task.assignee %}
               <span class="inline-flex items-center gap-1">
                 <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>
@@ -107,7 +107,7 @@
         </button>
         <div class="flex-1 min-w-0">
           <p class="text-sm text-gray-600 line-through">{{ task.title }}</p>
-          <div class="flex items-center gap-2 mt-1 text-xs text-gray-400">
+          <div class="flex items-center gap-2 mt-1 text-secondary">
             {% if task.assignee %}<span>{{ task.assignee.name or task.assignee.email }}</span>{% endif %}
             {% if task.completed_at %}<span>Done {{ task.completed_at.strftime('%m/%d/%y') }}</span>{% endif %}
           </div>
@@ -119,7 +119,7 @@
   {% endif %}
 
   {% if not pending_tasks and not done_tasks %}
-  <div class="mx-auto max-w-sm rounded-xl bg-white p-6 sm:p-8 text-center shadow-sm border border-gray-100">
+  <div class="mx-auto max-w-sm rounded-xl bg-white p-6 sm:p-8 text-center shadow-card border border-gray-100">
     <svg class="mx-auto mb-4 h-12 w-12 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round"
             d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>

--- a/app/templates/htmx/partials/parts/tabs/notes.html
+++ b/app/templates/htmx/partials/parts/tabs/notes.html
@@ -7,7 +7,7 @@
   <div class="card">
     <div class="flex items-center justify-between mb-3">
       <h3 class="text-sm font-semibold text-gray-900">Sales Notes</h3>
-      <span class="text-xs text-gray-400">{{ requirement.primary_mpn }}</span>
+      <span class="text-secondary">{{ requirement.primary_mpn }}</span>
     </div>
     <form hx-patch="/v2/partials/parts/{{ requirement.id }}/notes"
           hx-target="#notes-tab-content"

--- a/app/templates/htmx/partials/parts/tabs/quotes.html
+++ b/app/templates/htmx/partials/parts/tabs/quotes.html
@@ -75,7 +75,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
     </svg>
     <p class="text-sm font-medium text-gray-500 mt-3">This part hasn't been on any quotes yet.</p>
-    <p class="text-xs text-gray-400 mt-1">Quotes are created from a requirement's Offers tab.</p>
+    <p class="text-secondary mt-1">Quotes are created from a requirement's Offers tab.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/parts/tabs/req_details.html
+++ b/app/templates/htmx/partials/parts/tabs/req_details.html
@@ -172,7 +172,7 @@
          class="flex items-center gap-3 mb-2 px-3 py-1.5 bg-brand-50 rounded-lg border border-brand-200 text-xs">
       <span class="text-gray-600" x-text="selectedSiblings.length + ' selected'"></span>
       <button type="button"
-              class="px-2 py-0.5 text-xs font-medium rounded-md bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
+              class="px-2 py-0.5 text-xs font-medium rounded-lg bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
               hx-post="/v2/partials/parts/bulk-archive"
               :hx-vals="JSON.stringify({requirement_ids: selectedSiblings})"
               hx-target="#part-detail"
@@ -242,7 +242,7 @@
       </table>
     </div>
     {% else %}
-    <p class="text-xs text-gray-400 italic">No parts on this requisition.</p>
+    <p class="text-secondary italic">No parts on this requisition.</p>
     {% endif %}
   </div>
 </div>

--- a/app/templates/htmx/partials/parts/tabs/sourcing.html
+++ b/app/templates/htmx/partials/parts/tabs/sourcing.html
@@ -23,7 +23,7 @@
               x-data="{ showTip: false }" @mouseenter="showTip = true" @mouseleave="showTip = false">
             Score
             <div x-show="showTip" x-cloak
-                 class="absolute z-50 left-0 top-full mt-1 w-64 p-3 bg-white border border-gray-200 rounded-lg shadow-lg text-xs text-gray-600 font-normal normal-case">
+                 class="absolute z-50 left-0 top-full mt-1 w-64 p-3 bg-white border border-gray-200 rounded-lg shadow-float text-xs text-gray-600 font-normal normal-case">
               <p class="font-semibold text-gray-900 mb-1">Sighting Score (0-100)</p>
               <ul class="space-y-0.5">
                 <li>Trust: 30% — vendor reliability</li>
@@ -38,7 +38,7 @@
               x-data="{ showTip: false }" @mouseenter="showTip = true" @mouseleave="showTip = false">
             Tier
             <div x-show="showTip" x-cloak
-                 class="absolute z-50 left-0 top-full mt-1 w-48 p-3 bg-white border border-gray-200 rounded-lg shadow-lg text-xs text-gray-600 font-normal normal-case">
+                 class="absolute z-50 left-0 top-full mt-1 w-48 p-3 bg-white border border-gray-200 rounded-lg shadow-float text-xs text-gray-600 font-normal normal-case">
               <p class="font-semibold text-gray-900 mb-1">Quality Tiers</p>
               <ul class="space-y-0.5">
                 <li><span class="text-green-600 font-medium">Excellent</span> 70-100</li>
@@ -83,10 +83,10 @@
           <td class="compact-cell whitespace-nowrap relative" x-data="{ showQty: false }">
             <span role="button" tabindex="0" @click="showQty = !showQty" @keydown.enter="showQty = !showQty" @keydown.space.prevent="showQty = !showQty" class="cursor-pointer hover:text-brand-500" aria-label="Show quantity breakdown">
               {{ '{:,}'.format(s.estimated_qty) if s.estimated_qty else '—' }}
-              {% if s.listing_count > 1 %}<span class="text-xs text-gray-400 ml-0.5">({{ s.listing_count }})</span>{% endif %}
+              {% if s.listing_count > 1 %}<span class="text-secondary ml-0.5">({{ s.listing_count }})</span>{% endif %}
             </span>
             <div x-show="showQty" role="tooltip" @click.away="showQty = false" x-cloak
-                 class="absolute z-50 mt-1 w-64 p-3 bg-white border border-gray-200 rounded-lg shadow-lg text-xs">
+                 class="absolute z-50 mt-1 w-64 p-3 bg-white border border-gray-200 rounded-lg shadow-float text-xs">
               <p class="font-semibold text-gray-900 mb-1">Qty Breakdown ({{ s.listing_count }} listing{{ 's' if s.listing_count != 1 else '' }})</p>
               <table class="w-full text-xs">
                 <thead><tr><th class="text-left text-gray-500">Source</th><th class="text-right text-gray-500">Qty</th></tr></thead>
@@ -104,7 +104,7 @@
               {{ '${:,.4f}'.format(s.avg_price) if s.avg_price else '—' }}
             </span>
             <div x-show="showPrice" role="tooltip" @click.away="showPrice = false" x-cloak
-                 class="absolute z-50 mt-1 w-64 p-3 bg-white border border-gray-200 rounded-lg shadow-lg text-xs">
+                 class="absolute z-50 mt-1 w-64 p-3 bg-white border border-gray-200 rounded-lg shadow-float text-xs">
               <p class="font-semibold text-gray-900 mb-1">Price Breakdown</p>
               <p class="text-gray-500 mb-1">Best: {{ '${:,.4f}'.format(s.best_price) if s.best_price else '—' }} | Avg: {{ '${:,.4f}'.format(s.avg_price) if s.avg_price else '—' }}</p>
               <table class="w-full text-xs">

--- a/app/templates/htmx/partials/parts/workspace.html
+++ b/app/templates/htmx/partials/parts/workspace.html
@@ -10,7 +10,7 @@
      split-panel height below subtracts this 26px strip so the layout doesn't overflow. #}
 {% if pipeline %}
 {# border-line-base replaces border-gray-200 (finding 12) #}
-<div class="h-[26px] flex items-center gap-4 px-3 text-xs text-gray-500 bg-gray-50 border-b border-line-base">
+<div class="h-[26px] flex items-center gap-4 px-3 text-secondary bg-gray-50 border-b border-line-base">
   {# Page eyebrow answers "Where am I?" (finding 9) #}
   <span class="font-semibold text-gray-700 mr-1">Sales Hub</span>
   <span class="text-gray-300">·</span>
@@ -136,7 +136,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
         </svg>
         <p class="text-sm font-medium text-gray-600">Select a part</p>
-        <p class="text-xs text-gray-400 mt-1">Click a row to view offers, sourcing & activity</p>
+        <p class="text-secondary mt-1">Click a row to view offers, sourcing & activity</p>
       </div>
       {# Scrollbar + content — always in DOM, shown when part selected #}
       <div x-show="selectedPartId" x-cloak class="flex flex-col flex-1 min-h-0">

--- a/app/templates/htmx/partials/requisitions/edit_offer_form.html
+++ b/app/templates/htmx/partials/requisitions/edit_offer_form.html
@@ -19,22 +19,22 @@
     {# Row 1: Vendor Name, Qty Available, Unit Price, Lead Time #}
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Vendor Name *</label>
+        <label class="block text-secondary mb-1">Vendor Name *</label>
         <input type="text" name="vendor_name" required value="{{ offer.vendor_name or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Qty Available</label>
+        <label class="block text-secondary mb-1">Qty Available</label>
         <input type="number" name="qty_available" min="1" value="{{ offer.qty_available or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Unit Price (USD)</label>
+        <label class="block text-secondary mb-1">Unit Price (USD)</label>
         <input type="number" name="unit_price" step="0.0001" min="0" value="{{ offer.unit_price or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Lead Time</label>
+        <label class="block text-secondary mb-1">Lead Time</label>
         <input type="text" name="lead_time" value="{{ offer.lead_time or '' }}"
                class="input input-sm">
       </div>
@@ -43,17 +43,17 @@
     {# Row 2: Manufacturer, Date Code, Condition, MOQ #}
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Manufacturer</label>
+        <label class="block text-secondary mb-1">Manufacturer</label>
         <input type="text" name="manufacturer" value="{{ offer.manufacturer or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Date Code</label>
+        <label class="block text-secondary mb-1">Date Code</label>
         <input type="text" name="date_code" value="{{ offer.date_code or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Condition</label>
+        <label class="block text-secondary mb-1">Condition</label>
         <select name="condition" class="input input-sm">
           <option value="">--</option>
           <option value="new" {{ 'selected' if offer.condition == 'new' }}>New</option>
@@ -62,7 +62,7 @@
         </select>
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">MOQ</label>
+        <label class="block text-secondary mb-1">MOQ</label>
         <input type="number" name="moq" min="1" value="{{ offer.moq or '' }}"
                class="input input-sm">
       </div>
@@ -71,22 +71,22 @@
     {# Row 3: SPQ, Packaging, Firmware, Hardware Code #}
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
       <div>
-        <label class="block text-xs text-gray-500 mb-1">SPQ</label>
+        <label class="block text-secondary mb-1">SPQ</label>
         <input type="number" name="spq" min="1" value="{{ offer.spq or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Packaging</label>
+        <label class="block text-secondary mb-1">Packaging</label>
         <input type="text" name="packaging" value="{{ offer.packaging or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Firmware</label>
+        <label class="block text-secondary mb-1">Firmware</label>
         <input type="text" name="firmware" value="{{ offer.firmware or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Hardware Code</label>
+        <label class="block text-secondary mb-1">Hardware Code</label>
         <input type="text" name="hardware_code" value="{{ offer.hardware_code or '' }}"
                class="input input-sm">
       </div>
@@ -95,23 +95,23 @@
     {# Row 4: Warranty, Country of Origin, Valid Until, Linked Requirement #}
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Warranty</label>
+        <label class="block text-secondary mb-1">Warranty</label>
         <input type="text" name="warranty" value="{{ offer.warranty or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Country of Origin</label>
+        <label class="block text-secondary mb-1">Country of Origin</label>
         <input type="text" name="country_of_origin" value="{{ offer.country_of_origin or '' }}"
                class="input input-sm">
       </div>
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Valid Until</label>
+        <label class="block text-secondary mb-1">Valid Until</label>
         <input type="date" name="valid_until" value="{{ offer.valid_until.isoformat() if offer.valid_until else '' }}"
                class="input input-sm">
       </div>
       {% if requirements %}
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Linked Requirement</label>
+        <label class="block text-secondary mb-1">Linked Requirement</label>
         <select name="requirement_id" class="input input-sm">
           <option value="">— None —</option>
           {% for r in requirements %}
@@ -124,7 +124,7 @@
 
     {# Notes #}
     <div>
-      <label class="block text-xs text-gray-500 mb-1">Notes</label>
+      <label class="block text-secondary mb-1">Notes</label>
       <textarea name="notes" rows="2"
                 class="input input-sm">{{ offer.notes or '' }}</textarea>
     </div>

--- a/app/templates/htmx/partials/requisitions/list.html
+++ b/app/templates/htmx/partials/requisitions/list.html
@@ -64,7 +64,7 @@
           {# Search scope indicators — show what matched when actively searching #}
           {% if match_counts %}
           <div class="flex items-center gap-1.5 mt-1.5 animate-fade-in">
-            <span class="text-xs text-gray-400 uppercase tracking-wide mr-0.5">Matched:</span>
+            <span class="text-secondary uppercase tracking-wide mr-0.5">Matched:</span>
             {% set scopes = [
               ("name", "Names", "bg-brand-50 text-brand-600 border-brand-200", match_counts.name),
               ("customer", "Customers", "bg-sky-50 text-sky-600 border-sky-200", match_counts.customer),
@@ -196,7 +196,7 @@
         <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
       </button>
       <div x-show="showAssign" role="menu" @click.away="showAssign = false" x-cloak
-           class="absolute left-0 mt-1 w-48 bg-white border border-gray-200 rounded-lg shadow-lg z-10 py-1">
+           class="absolute left-0 mt-1 w-48 bg-white border border-gray-200 rounded-lg shadow-float z-10 py-1">
         {% for u in users %}
         <button hx-post="/v2/partials/requisitions/bulk/assign"
                 hx-target="#main-content"

--- a/app/templates/htmx/partials/requisitions/req_row.html
+++ b/app/templates/htmx/partials/requisitions/req_row.html
@@ -127,7 +127,7 @@
         <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path d="M10 6a2 2 0 110-4 2 2 0 010 4zm0 6a2 2 0 110-4 2 2 0 010 4zm0 6a2 2 0 110-4 2 2 0 010 4z"/></svg>
       </button>
       <div x-show="open" x-cloak x-transition
-           class="absolute right-0 top-full mt-1 w-40 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1">
+           class="absolute right-0 top-full mt-1 w-40 bg-white border border-gray-200 rounded-lg shadow-float z-50 py-1">
         {% if not req.claimed_by_id and user and user.role in ('buyer','trader','manager','admin') %}
         <button hx-post="/v2/partials/requisitions/{{ req.id }}/action/claim"
                 hx-target="#main-content"
@@ -158,7 +158,7 @@
       {# Won/Lost close-reason popover — required textarea + confirm. #}
       <div x-show="outcomePrompt" x-cloak x-transition
            @keydown.escape.stop="outcomePrompt = null"
-           class="absolute right-0 top-full mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-3">
+           class="absolute right-0 top-full mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-float z-50 p-3">
         <p class="text-xs font-semibold text-gray-700 mb-1">
           <span x-text="outcomePrompt === 'won' ? 'Why won?' : 'Why lost?'"></span>
           <span class="text-rose-500">*</span>
@@ -176,7 +176,7 @@
           <button type="button"
                   data-loading-disable
                   :disabled="!outcomeReady"
-                  class="px-2 py-1 text-xs font-medium rounded bg-brand-500 text-white hover:bg-brand-600 disabled:opacity-40 disabled:cursor-not-allowed"
+                  class="btn btn-sm btn-primary"
                   @click="htmx.ajax('POST', '/v2/partials/requisitions/{{ req.id }}/action/' + outcomePrompt, {target: '#main-content', indicator: '#main-content', values: {reason: outcomeReason}}); outcomePrompt = null">Confirm</button>
         </div>
       </div>

--- a/app/templates/htmx/partials/requisitions/rfq_compose.html
+++ b/app/templates/htmx/partials/requisitions/rfq_compose.html
@@ -64,7 +64,7 @@
               </span>
               {% endif %}
               {% if v.domain %}
-              <span class="text-xs text-gray-400">{{ v.domain }}</span>
+              <span class="text-secondary">{{ v.domain }}</span>
               {% endif %}
             </div>
             {% if v.emails %}
@@ -92,7 +92,7 @@
       {% else %}
       <div class="p-6 sm:p-8 text-center">
         <p class="text-sm text-gray-600">No vendors found with sightings for this requisition.</p>
-        <p class="text-xs text-gray-400 mt-1">Search for parts first to find vendors.</p>
+        <p class="text-secondary mt-1">Search for parts first to find vendors.</p>
       </div>
       {% endif %}
     </div>
@@ -168,7 +168,7 @@
               class="btn-primary">
         <span x-text="'Send RFQ to ' + selectedVendors.length + ' vendor(s)'">Send RFQ</span>
       </button>
-      <p class="text-xs text-gray-400" x-show="selectedVendors.length === 0" x-cloak>
+      <p class="text-secondary" x-show="selectedVendors.length === 0" x-cloak>
         Select at least one vendor to send.
       </p>
     </div>

--- a/app/templates/htmx/partials/requisitions/rfq_prepare.html
+++ b/app/templates/htmx/partials/requisitions/rfq_prepare.html
@@ -30,7 +30,7 @@
         <p class="text-xs text-gray-600">{{ v.sighting_count }} sighting{{ "s" if v.sighting_count != 1 }}</p>
       </div>
       {% if v.already_contacted %}
-      <span class="text-xs text-gray-400">Already contacted</span>
+      <span class="text-secondary">Already contacted</span>
       {% else %}
       <span class="text-xs text-emerald-600 font-medium">Available</span>
       {% endif %}

--- a/app/templates/htmx/partials/requisitions/tabs/activity.html
+++ b/app/templates/htmx/partials/requisitions/tabs/activity.html
@@ -130,7 +130,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
       </svg>
       <p class="text-sm font-medium text-gray-600 mt-3">No activity recorded yet.</p>
-      <p class="text-xs text-gray-400 mt-1">Click "+ Log Activity" above to add a note, call, or email.</p>
+      <p class="text-secondary mt-1">Click "+ Log Activity" above to add a note, call, or email.</p>
     </div>
     {% endif %}
   </div>

--- a/app/templates/htmx/partials/requisitions/tabs/build_quote.html
+++ b/app/templates/htmx/partials/requisitions/tabs/build_quote.html
@@ -39,7 +39,7 @@
     {# Markup % — surfaced + adjustable; reseeds unedited lines. #}
     <div class="flex items-end gap-2 flex-shrink-0">
       <div>
-        <label class="block text-xs text-gray-400 uppercase tracking-wide mb-0.5">Markup %</label>
+        <label class="block text-secondary uppercase tracking-wide mb-0.5">Markup %</label>
         <input type="number" step="1" min="0" x-model.number="markupPct"
                class="input w-20 text-right tabular-nums" aria-label="Default markup percent">
       </div>
@@ -88,7 +88,7 @@
             </td>
             <td>
               <span class="font-mono font-medium text-gray-900">{{ l.mpn or '—' }}</span>
-              {% if l.manufacturer %}<span class="block text-xs text-gray-400">{{ l.manufacturer }}</span>{% endif %}
+              {% if l.manufacturer %}<span class="block text-secondary">{{ l.manufacturer }}</span>{% endif %}
               {# Per-line offer picker — internal only (vendor identity never crosses into the
                  customer doc; quote_export_context strips it). Shown only when there is a real
                  choice (2+ active offers); the chosen offer is what gets quoted and becomes the
@@ -104,7 +104,7 @@
                 {% endfor %}
               </select>
               {% elif l.offer_count == 1 %}
-              <span class="block text-xs text-gray-400">{{ l.offers[0].vendor_name }} · ${{ "{:,.4f}".format(l.offers[0].unit_price) }}</span>
+              <span class="block text-secondary">{{ l.offers[0].vendor_name }} · ${{ "{:,.4f}".format(l.offers[0].unit_price) }}</span>
               {% endif %}
             </td>
             <td class="text-right tabular-nums">{{ "{:,}".format(l.qty or 0) }}</td>
@@ -183,7 +183,7 @@
     <div class="flex items-start justify-between gap-3">
       <div>
         <p class="text-base font-semibold text-gray-900">{{ summary.quote_number }}</p>
-        <p class="text-xs text-gray-400 mt-0.5">
+        <p class="text-secondary mt-0.5">
           {{ summary.line_count }} line{{ 's' if summary.line_count != 1 }} · rev {{ summary.revision }} · {{ quote.status }}
         </p>
       </div>
@@ -222,7 +222,7 @@
           <tr>
             <td>
               <span class="font-mono font-medium text-gray-900">{{ li.part_number or '—' }}</span>
-              {% if li.manufacturer %}<span class="block text-xs text-gray-400">{{ li.manufacturer }}</span>{% endif %}
+              {% if li.manufacturer %}<span class="block text-secondary">{{ li.manufacturer }}</span>{% endif %}
             </td>
             <td>{{ li.condition or '—' }}</td>
             <td class="text-right tabular-nums">{{ "{:,}".format(li.quantity) }}</td>

--- a/app/templates/htmx/partials/requisitions/tabs/buy_plans.html
+++ b/app/templates/htmx/partials/requisitions/tabs/buy_plans.html
@@ -60,7 +60,7 @@
             d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
     </svg>
     <p class="text-sm font-medium text-gray-600 mt-3">No buy plans linked.</p>
-    <p class="text-xs text-gray-400 mt-1">Buy plans are created after a quote is won and a sales order is received.</p>
+    <p class="text-secondary mt-1">Buy plans are created after a quote is won and a sales order is received.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/requisitions/tabs/offers.html
+++ b/app/templates/htmx/partials/requisitions/tabs/offers.html
@@ -19,7 +19,7 @@
         <svg class="h-3 w-3 ml-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
       </button>
       <div x-show="addOpen" role="menu" aria-label="Add offer options" @click.outside="addOpen = false" x-cloak x-transition
-           class="absolute left-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-lg z-10 py-1">
+           class="absolute left-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-float z-10 py-1">
         <button hx-get="/v2/partials/requisitions/{{ req.id }}/add-offer-form"
                 hx-target="#parse-area" hx-swap="innerHTML"
                 @click="addOpen = false"
@@ -199,7 +199,7 @@
                    x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
                    x-transition:leave="transition ease-in duration-75"
                    x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95"
-                   class="absolute right-0 top-full mt-1 w-40 bg-white border border-gray-200 rounded-lg shadow-lg z-10 py-1">
+                   class="absolute right-0 top-full mt-1 w-40 bg-white border border-gray-200 rounded-lg shadow-float z-10 py-1">
                 <button hx-get="/v2/partials/requisitions/{{ req.id }}/offers/{{ o.id }}/edit-form"
                         hx-target="#parse-area" hx-swap="innerHTML"
                         @click.stop="open = false"
@@ -264,10 +264,10 @@
     </svg>
     {% if qual %}
     <p class="text-sm font-medium text-gray-600 mt-3">No offers match this filter.</p>
-    <p class="text-xs text-gray-400 mt-1">Try selecting a different filter above or clear the filter to see all offers.</p>
+    <p class="text-secondary mt-1">Try selecting a different filter above or clear the filter to see all offers.</p>
     {% else %}
     <p class="text-sm font-medium text-gray-600 mt-3">No offers received yet.</p>
-    <p class="text-xs text-gray-400 mt-1">Offers appear when vendors respond to RFQs, when leads are promoted, or from searching all supplier sources.</p>
+    <p class="text-secondary mt-1">Offers appear when vendors respond to RFQs, when leads are promoted, or from searching all supplier sources.</p>
     {# Next step: the sourcing engine (Search All Sources) lives on the Parts tab. #}
     <button @click="activeTab = 'parts'"
             hx-get="/v2/partials/requisitions/{{ req.id }}/tab/parts"

--- a/app/templates/htmx/partials/requisitions/tabs/parse_email_form.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parse_email_form.html
@@ -9,7 +9,7 @@
     <button @click="$el.closest('#parse-area').innerHTML = ''"
             class="text-xs text-gray-400 hover:text-gray-600">Close</button>
   </div>
-  <p class="text-xs text-gray-500 mb-3">Paste a vendor email reply below. AI will extract structured offers with confidence scoring.</p>
+  <p class="text-secondary mb-3">Paste a vendor email reply below. AI will extract structured offers with confidence scoring.</p>
 
   <form hx-post="/v2/partials/requisitions/{{ req.id }}/parse-email"
         hx-target="#parse-area"
@@ -20,19 +20,19 @@
 
     <div class="grid grid-cols-2 gap-3 mb-3">
       <div>
-        <label class="text-xs text-gray-500 block mb-1">Subject (optional)</label>
+        <label class="text-secondary block mb-1">Subject (optional)</label>
         <input type="text" name="email_subject" placeholder="RE: RFQ for LM317T"
                class="input">
       </div>
       <div>
-        <label class="text-xs text-gray-500 block mb-1">Vendor Name (optional)</label>
+        <label class="text-secondary block mb-1">Vendor Name (optional)</label>
         <input type="text" name="vendor_name" placeholder="Arrow Electronics"
                class="input">
       </div>
     </div>
 
     <div class="mb-3">
-      <label class="text-xs text-gray-500 block mb-1">Email Body</label>
+      <label class="text-secondary block mb-1">Email Body</label>
       <textarea name="email_body" rows="6" required
                 placeholder="Paste the full vendor email here..."
                 class="input font-mono"></textarea>

--- a/app/templates/htmx/partials/requisitions/tabs/parsed_email_results.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parsed_email_results.html
@@ -139,7 +139,7 @@
   {% else %}
   <div class="p-6 text-center bg-white rounded-lg border border-gray-200">
     <p class="text-sm text-gray-600">No offers could be parsed from this email.</p>
-    <p class="text-xs text-gray-400 mt-1">Try pasting a different email or check the format.</p>
+    <p class="text-secondary mt-1">Try pasting a different email or check the format.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/requisitions/tabs/parsed_offer_results.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parsed_offer_results.html
@@ -108,7 +108,7 @@
   {% else %}
   <div class="p-6 text-center bg-white rounded-lg border border-gray-200">
     <p class="text-sm text-gray-600">No offers could be parsed from the text.</p>
-    <p class="text-xs text-gray-400 mt-1">Try pasting different text or use a more structured format.</p>
+    <p class="text-secondary mt-1">Try pasting different text or use a more structured format.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/requisitions/tabs/parts.html
+++ b/app/templates/htmx/partials/requisitions/tabs/parts.html
@@ -51,12 +51,12 @@
       {# Row 1: MPN, Manufacturer typeahead, Qty, Target Price #}
       <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
         <div>
-          <label class="block text-xs text-gray-500 mb-1">MPN *</label>
+          <label class="block text-secondary mb-1">MPN *</label>
           <input type="text" name="primary_mpn" required placeholder="Part number"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500 font-mono">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Manufacturer *</label>
+          <label class="block text-secondary mb-1">Manufacturer *</label>
           <div class="relative" x-data="{ mfrOpen: false }">
             <input type="text" name="manufacturer" required
                    placeholder="Manufacturer (required)"
@@ -69,17 +69,17 @@
                    hx-vals="js:{q: event.target.value}"
                    hx-swap="innerHTML"
                    class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500 placeholder:text-gray-400">
-            <div class="mfr-dropdown absolute z-50 w-full mt-0.5 bg-white border border-gray-200 rounded shadow-lg max-h-40 overflow-y-auto"
+            <div class="mfr-dropdown absolute z-50 w-full mt-0.5 bg-white border border-gray-200 rounded shadow-float max-h-40 overflow-y-auto"
                  x-show="mfrOpen" x-cloak></div>
           </div>
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Qty</label>
+          <label class="block text-secondary mb-1">Qty</label>
           <input type="number" name="target_qty" min="1" value="1" placeholder="Qty"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Target Price</label>
+          <label class="block text-secondary mb-1">Target Price</label>
           <input type="number" name="target_price" step="0.0001" min="0" placeholder="$0.0000"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
@@ -88,22 +88,22 @@
       {# Row 2: Brand, Customer PN, Need-by Date, Condition, Packaging #}
       <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Brand</label>
+          <label class="block text-secondary mb-1">Brand</label>
           <input type="text" name="brand" placeholder="Brand (optional)"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Customer PN</label>
+          <label class="block text-secondary mb-1">Customer PN</label>
           <input type="text" name="customer_pn" placeholder="Customer's part #"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Need-by Date</label>
+          <label class="block text-secondary mb-1">Need-by Date</label>
           <input type="date" name="need_by_date"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Condition</label>
+          <label class="block text-secondary mb-1">Condition</label>
           <select name="condition" class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
             <option value="">--</option>
             <option value="new">New</option>
@@ -112,7 +112,7 @@
           </select>
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Packaging</label>
+          <label class="block text-secondary mb-1">Packaging</label>
           <input type="text" name="packaging" placeholder="e.g. Tape & Reel"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
@@ -121,17 +121,17 @@
       {# Row 3: Date Codes, Firmware, Hardware Codes #}
       <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Date Codes</label>
+          <label class="block text-secondary mb-1">Date Codes</label>
           <input type="text" name="date_codes" placeholder="2024+"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Firmware</label>
+          <label class="block text-secondary mb-1">Firmware</label>
           <input type="text" name="firmware" placeholder="Rev / version"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Hardware Codes</label>
+          <label class="block text-secondary mb-1">Hardware Codes</label>
           <input type="text" name="hardware_codes" placeholder="HW rev"
                  class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500">
         </div>
@@ -139,7 +139,7 @@
 
       {# Structured substitute rows #}
       <div x-data="{ subs: [] }" @req-form-reset.window="subs = []">
-        <label class="block text-xs text-gray-500 mb-1">Substitutes</label>
+        <label class="block text-secondary mb-1">Substitutes</label>
         <template x-for="(sub, idx) in subs" :key="idx">
           <div class="flex gap-1.5 items-center mb-1.5">
             <input aria-label="Sub MPN" :name="'sub_mpn'" x-model="sub.mpn" placeholder="Sub MPN"
@@ -154,7 +154,7 @@
                      hx-vals="js:{q: event.target.value}"
                      hx-swap="innerHTML"
                      class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-brand-500 focus:border-brand-500 placeholder:text-gray-400">
-              <div class="sub-mfr-dropdown absolute z-50 w-full mt-0.5 bg-white border border-gray-200 rounded shadow-lg max-h-32 overflow-y-auto"
+              <div class="sub-mfr-dropdown absolute z-50 w-full mt-0.5 bg-white border border-gray-200 rounded shadow-float max-h-32 overflow-y-auto"
                    x-show="subMfrOpen" x-cloak></div>
             </div>
             <button type="button" @click="subs.splice(idx, 1)"
@@ -167,7 +167,7 @@
 
       {# Full-width: Notes #}
       <div>
-        <label class="block text-xs text-gray-500 mb-1">Notes</label>
+        <label class="block text-secondary mb-1">Notes</label>
         <textarea name="notes" rows="2" placeholder="Any additional details..."
                   class="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-brand-500 focus:border-brand-500"></textarea>
       </div>
@@ -203,7 +203,7 @@
      placeholder row, matching the vendors/contacts tab pattern. #}
   <div id="parts-table-wrapper">
   {% if requirements %}
-  <p class="text-xs text-gray-400 mb-2">{{ requirements|length }} requirement{{ "s" if requirements|length != 1 }}. Double-click any row to edit inline.</p>
+  <p class="text-secondary mb-2">{{ requirements|length }} requirement{{ "s" if requirements|length != 1 }}. Double-click any row to edit inline.</p>
   {% endif %}
   <div class="overflow-x-auto bg-white rounded-lg border border-brand-200">
     <table class="min-w-full divide-y divide-gray-200">
@@ -244,7 +244,7 @@
                     d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
             </svg>
             <p class="text-sm font-medium text-gray-600 mt-3">No requirements yet.</p>
-            <p class="text-xs text-gray-400 mt-1">Add parts using the form above.</p>
+            <p class="text-secondary mt-1">Add parts using the form above.</p>
           </td>
         </tr>
         {% endif %}

--- a/app/templates/htmx/partials/requisitions/tabs/quotes.html
+++ b/app/templates/htmx/partials/requisitions/tabs/quotes.html
@@ -71,7 +71,7 @@
             d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
     </svg>
     <p class="text-sm font-medium text-gray-600 mt-3">No quotes generated.</p>
-    <p class="text-xs text-gray-400 mt-1">Create a quote from the Offers tab by selecting offers and clicking "Create Quote."</p>
+    <p class="text-secondary mt-1">Create a quote from the Offers tab by selecting offers and clicking "Create Quote."</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/requisitions/tabs/req_row.html
+++ b/app/templates/htmx/partials/requisitions/tabs/req_row.html
@@ -63,7 +63,7 @@
       <span class="text-gray-400 tabular-nums">0</span>
     {% endif %}
     {% if r.last_searched_at %}
-    <div class="text-xs text-gray-400">{{ r.last_searched_at|timeago }}</div>
+    <div class="text-secondary">{{ r.last_searched_at|timeago }}</div>
     {% endif %}
   </td>
   <td class="px-4 py-2.5 text-center" x-show="!editing" x-cloak>
@@ -114,7 +114,7 @@
                  hx-vals="js:{q: event.target.value}"
                  hx-swap="innerHTML"
                  class="w-full px-2 py-1.5 text-sm border border-brand-200 rounded focus:ring-2 focus:ring-brand-500 placeholder:text-gray-400">
-          <div class="mfr-dropdown absolute z-50 w-full mt-0.5 bg-white border border-gray-200 rounded shadow-lg max-h-40 overflow-y-auto"
+          <div class="mfr-dropdown absolute z-50 w-full mt-0.5 bg-white border border-gray-200 rounded shadow-float max-h-40 overflow-y-auto"
                x-show="mfrOpen" x-cloak></div>
         </div>
         <input aria-label="Target Qty" type="number" name="target_qty" value="{{ r.target_qty or 1 }}" min="1"
@@ -176,7 +176,7 @@
                      hx-vals="js:{q: event.target.value}"
                      hx-swap="innerHTML"
                      class="w-full px-2 py-1 text-xs border border-gray-300 rounded focus:ring-1 focus:ring-brand-500 placeholder:text-gray-400">
-              <div class="sub-mfr-dropdown absolute z-50 w-full mt-0.5 bg-white border border-gray-200 rounded shadow-lg max-h-32 overflow-y-auto"
+              <div class="sub-mfr-dropdown absolute z-50 w-full mt-0.5 bg-white border border-gray-200 rounded shadow-float max-h-32 overflow-y-auto"
                    x-show="subMfrOpen" x-cloak></div>
             </div>
             <button type="button" @click="subs.splice(idx, 1)"

--- a/app/templates/htmx/partials/requisitions/tabs/responses.html
+++ b/app/templates/htmx/partials/requisitions/tabs/responses.html
@@ -38,7 +38,7 @@
             d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
     </svg>
     <p class="text-sm text-gray-600 mt-2">No vendor responses yet.</p>
-    <p class="text-xs text-gray-400 mt-1">Click "Poll Inbox" to check for vendor replies, or responses will appear when vendors reply to RFQs.</p>
+    <p class="text-secondary mt-1">Click "Poll Inbox" to check for vendor replies, or responses will appear when vendors reply to RFQs.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/requisitions/tabs/tasks.html
+++ b/app/templates/htmx/partials/requisitions/tabs/tasks.html
@@ -15,7 +15,7 @@
       </button>
       {% endfor %}
     </div>
-    <span class="text-xs text-gray-400">{{ tasks|length }} task{{ "s" if tasks|length != 1 }}</span>
+    <span class="text-secondary">{{ tasks|length }} task{{ "s" if tasks|length != 1 }}</span>
   </div>
 
   {# Inline add task form #}
@@ -168,7 +168,7 @@
                 d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/>
         </svg>
         <p class="text-sm font-medium text-gray-600 mt-3">No tasks yet.</p>
-        <p class="text-xs text-gray-400 mt-1">Add a task to track work on this requisition.</p>
+        <p class="text-secondary mt-1">Add a task to track work on this requisition.</p>
       </div>
     {% endif %}
   </div>

--- a/app/templates/htmx/partials/search/dossier_datasheet_block.html
+++ b/app/templates/htmx/partials/search/dossier_datasheet_block.html
@@ -13,9 +13,9 @@
     Datasheet (saved {{ saved.captured_at.strftime('%b %d, %Y') if saved.captured_at else '' }})
   </a>
   {% elif card.datasheet_searched_at and not card.datasheet_captured_at %}
-  <span class="inline-flex items-center gap-1.5 text-xs text-gray-400">No datasheet found (will retry)</span>
+  <span class="inline-flex items-center gap-1.5 text-secondary">No datasheet found (will retry)</span>
   {% else %}
-  <span class="inline-flex items-center gap-1.5 text-xs text-gray-400"
+  <span class="inline-flex items-center gap-1.5 text-secondary"
         hx-get="/v2/partials/search/dossier/datasheet-status?mpn={{ mpn|urlencode }}"
         hx-trigger="every 15s" hx-target="this" hx-swap="outerHTML">
     <svg class="h-3.5 w-3.5 animate-spin text-brand-400" viewBox="0 0 24 24" fill="none"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>

--- a/app/templates/htmx/partials/search/dossier_hero.html
+++ b/app/templates/htmx/partials/search/dossier_hero.html
@@ -18,7 +18,7 @@
          @dossier-add-to-req.window="addToReq()">
 
   {# ── Identity hero card ── #}
-  <div class="rounded-xl bg-white border border-brand-200 shadow-sm p-5">
+  <div class="rounded-xl bg-white border border-brand-200 shadow-card p-5">
     <div class="flex flex-col lg:flex-row gap-6">
 
       {# Zone A — identity #}
@@ -67,7 +67,7 @@
         {% if known and card.description %}
         <p class="mt-3 text-xs text-gray-600 max-w-xl leading-relaxed">{{ card.description }}</p>
         {% elif not known %}
-        <p class="mt-3 text-xs text-gray-400 max-w-xl leading-relaxed">We don't have history on this part — the live market below will tell us who has it.</p>
+        <p class="mt-3 text-secondary max-w-xl leading-relaxed">We don't have history on this part — the live market below will tell us who has it.</p>
         {% endif %}
       </div>
 
@@ -78,7 +78,7 @@
         <div class="mt-1 flex items-baseline gap-1.5">
           {# figure-accent: tabular-nums + accent color for the decision-driving numeral #}
           <span class="font-mono text-2xl font-bold figure-accent">${{ (pt.last_price if pt.last_price is not none else pt.min_price)|pricefmt }}</span>
-          <span class="text-xs text-gray-400">last</span>
+          <span class="text-secondary">last</span>
         </div>
         <p class="font-mono text-xs text-gray-600 mt-0.5">${{ pt.min_price|pricefmt }} – ${{ pt.max_price|pricefmt }}</p>
         {# Sparkline from min/last/max — a 3-point glanceable trend (no axes). currentColor via text-brand-400 wrapper. #}
@@ -93,11 +93,11 @@
           <polyline fill="none" stroke="currentColor" stroke-width="1.5" points="0,{{ '%.1f'|format(y_lo) }} 60,{{ '%.1f'|format(y_hi) }} 120,{{ '%.1f'|format(y_last) }}"/>
           <circle cx="120" cy="{{ '%.1f'|format(y_last) }}" r="2" fill="currentColor"/>
         </svg>
-        <p class="text-xs text-gray-400 mt-1">{{ pt.currency }} · min–max–last</p>
+        <p class="text-secondary mt-1">{{ pt.currency }} · min–max–last</p>
         {% else %}
         <div class="mt-1 rounded-lg border border-dashed border-brand-200 px-3 py-4 text-center">
           <p class="font-mono text-sm text-gray-300">$ — — —</p>
-          <p class="text-xs text-gray-400 mt-1">No price history yet — run the market</p>
+          <p class="text-secondary mt-1">No price history yet — run the market</p>
         </div>
         {% endif %}
       </div>
@@ -117,7 +117,7 @@
           {% for b in history.buyers[:3] %}
           <span class="h-5 w-5 rounded-full bg-accent-100 text-accent-700 grid place-items-center text-[11px] font-semibold ring-2 ring-white" title="{{ b.name or b.email }}">{{ (b.name or b.email)[:2]|upper }}</span>
           {% endfor %}
-          <span class="text-xs text-gray-400 pl-2.5">{{ history.buyers|length }} buyer{{ '' if history.buyers|length == 1 else 's' }}</span>
+          <span class="text-secondary pl-2.5">{{ history.buyers|length }} buyer{{ '' if history.buyers|length == 1 else 's' }}</span>
         </div>
         {% endif %}
       </div>
@@ -149,7 +149,7 @@
           <svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg>
         </button>
         <div x-show="overflow" x-cloak @click.outside="overflow=false" x-transition
-             class="absolute right-0 mt-1 w-52 rounded-lg bg-white border border-brand-200 shadow-lg z-20 py-1 text-sm">
+             class="absolute right-0 mt-1 w-52 rounded-lg bg-white border border-brand-200 shadow-float z-20 py-1 text-sm">
           <button type="button" @click="refreshMarket();overflow=false" class="w-full text-left px-3 py-2 hover:bg-brand-50 text-gray-700">↻ Refresh market</button>
           <button type="button" @click="copyMpn();overflow=false" class="w-full text-left px-3 py-2 hover:bg-brand-50 text-gray-700">Copy MPN</button>
           {% if known %}

--- a/app/templates/htmx/partials/search/dossier_market.html
+++ b/app/templates/htmx/partials/search/dossier_market.html
@@ -26,7 +26,7 @@
   <button type="button"
           hx-get="/v2/partials/search/dossier/market?mpn={{ mpn|urlencode }}&amp;refresh=1"
           hx-target="#dossier-market" hx-swap="innerHTML"
-          class="ml-auto px-2.5 py-1 rounded-md border border-brand-300 text-brand-600 hover:text-brand-800 hover:bg-brand-50 inline-flex items-center gap-1.5">
+          class="ml-auto px-2.5 py-1 rounded-lg border border-brand-300 text-brand-600 hover:text-brand-800 hover:bg-brand-50 inline-flex items-center gap-1.5">
     <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
     Refresh market
   </button>

--- a/app/templates/htmx/partials/search/dossier_recent.html
+++ b/app/templates/htmx/partials/search/dossier_recent.html
@@ -5,7 +5,7 @@
    Depends on: recent (list[MaterialCard]). #}
 
 {% if recent %}
-<div class="bg-white border border-brand-200 rounded-lg shadow-sm p-3">
+<div class="bg-white border border-brand-200 rounded-lg shadow-card p-3">
   <p class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">Recent searches</p>
   <div class="divide-y divide-brand-100">
     {% for c in recent %}
@@ -15,7 +15,7 @@
        class="flex items-center justify-between gap-3 py-2.5 px-1 hover:bg-brand-50 rounded-md transition-colors">
       <div class="min-w-0">
         <p class="font-mono text-sm font-semibold text-brand-900 truncate">{{ c.display_mpn }}</p>
-        <p class="text-xs text-gray-400 truncate">{{ c.manufacturer or '—' }}{% if c.category %} · {{ c.category }}{% endif %}</p>
+        <p class="text-secondary truncate">{{ c.manufacturer or '—' }}{% if c.category %} · {{ c.category }}{% endif %}</p>
       </div>
       <div class="shrink-0 text-right">
         <p class="text-[11px] text-gray-400">{{ c.last_searched_at|timeago }}</p>
@@ -26,7 +26,7 @@
   </div>
 </div>
 {% else %}
-<div class="bg-white border border-brand-200 rounded-lg shadow-sm p-8 text-center">
+<div class="bg-white border border-brand-200 rounded-lg shadow-card p-8 text-center">
   <p class="text-sm text-gray-400">No recent searches yet — enter a part number above to begin.</p>
 </div>
 {% endif %}

--- a/app/templates/htmx/partials/search/dossier_shell.html
+++ b/app/templates/htmx/partials/search/dossier_shell.html
@@ -22,7 +22,7 @@
       {# input-focus adds accent ring on keyboard focus — a11y fix for the bare bg-transparent bar #}
       <input x-model="q" name="mpn" type="text" aria-label="Part number"
              placeholder="Enter a part number…"
-             class="flex-1 bg-transparent px-1 py-1 text-sm font-mono tracking-tight text-brand-900 placeholder:text-gray-400 input-focus rounded-md">
+             class="flex-1 bg-transparent px-1 py-1 text-sm font-mono tracking-tight text-brand-900 placeholder:text-gray-400 input-focus rounded-lg">
       <span id="ds-bar-spin" class="htmx-indicator"><svg class="inline h-4 w-4 animate-spin text-brand-500" viewBox="0 0 24 24" fill="none"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg></span>
       <button type="submit" class="btn-primary btn-sm">Search</button>
     </form>
@@ -58,7 +58,7 @@
        hx-get="/v2/partials/search/dossier/hero?mpn={{ mpn|urlencode }}"
        hx-trigger="load" hx-target="this" hx-swap="outerHTML">
     {# Skeleton header matches the resolved hero geometry: title + pill row + freshness placeholder #}
-    <section class="rounded-xl bg-white border border-brand-200 shadow-sm p-5 animate-pulse">
+    <section class="rounded-xl bg-white border border-brand-200 shadow-card p-5 animate-pulse">
       <div class="h-7 w-56 bg-brand-100 rounded"></div>
       <div class="mt-2 h-4 w-32 bg-brand-100 rounded"></div>
       <div class="mt-3 h-3 w-72 bg-brand-100 rounded"></div>
@@ -70,7 +70,7 @@
   </div>
 
   {# LIVE MARKET — light brand card (matches the sections below), open by default. #}
-  <section class="rounded-xl bg-white border border-brand-200 shadow-sm overflow-hidden"
+  <section class="rounded-xl bg-white border border-brand-200 shadow-card overflow-hidden"
            x-data="{ open: persistOr(true, 'dossier_market_open') }">
     <header @click="open=!open" class="flex items-center justify-between px-4 py-3 cursor-pointer select-none">
       <h2 class="flex items-center gap-2 text-sm font-semibold text-brand-900">
@@ -103,7 +103,7 @@
   </section>
 
   {# WHAT WE KNOW — reuses the existing /history endpoint + history_panel.html, open by default. #}
-  <section id="know" class="rounded-xl bg-white border border-brand-200 shadow-sm"
+  <section id="know" class="rounded-xl bg-white border border-brand-200 shadow-card"
            x-data="{ open: persistOr(true, 'dossier_know_open') }">
     <header @click="open=!open" class="flex items-center justify-between px-4 py-3 cursor-pointer select-none">
       <h2 class="flex items-center gap-2 text-sm font-semibold text-brand-900">
@@ -115,7 +115,7 @@
       <div id="dossier-history" class="px-4 pb-4"
            hx-get="/v2/partials/search/history?mpn={{ mpn|urlencode }}"
            hx-trigger="load" hx-target="this" hx-swap="innerHTML">
-        <div class="rounded-xl bg-white p-6 border border-line-subtle shadow-sm animate-pulse">
+        <div class="rounded-xl bg-white p-6 border border-line-subtle shadow-card animate-pulse">
           <div class="h-4 w-2/3 bg-gray-100 rounded"></div>
           <div class="mt-3 h-3 w-1/2 bg-gray-100 rounded"></div>
         </div>
@@ -124,7 +124,7 @@
   </section>
 
   {# SPECS & ENRICHMENT — closed by default (reference, not decision-driving). #}
-  <section class="rounded-xl bg-white border border-brand-200 shadow-sm"
+  <section class="rounded-xl bg-white border border-brand-200 shadow-card"
            x-data="{ open: persistOr(false, 'dossier_specs_open') }">
     <header @click="open=!open" class="flex items-center justify-between px-4 py-3 cursor-pointer select-none">
       <h2 class="flex items-center gap-2 text-sm font-semibold text-brand-900">

--- a/app/templates/htmx/partials/search/dossier_specs.html
+++ b/app/templates/htmx/partials/search/dossier_specs.html
@@ -12,7 +12,7 @@
 {% if card is none %}
 <div class="rounded-lg bg-brand-50 border border-brand-100 px-4 py-6 text-center">
   <p class="text-sm font-medium text-gray-600">New to us — no enrichment yet</p>
-  <p class="text-xs text-gray-400 mt-1">The first sourcing action queues this part for enrichment.</p>
+  <p class="text-secondary mt-1">The first sourcing action queues this part for enrichment.</p>
 </div>
 {% else %}
 
@@ -78,7 +78,7 @@
 <div class="rounded-lg bg-brand-50 border border-brand-100 px-4 py-6 text-center">
   {% if unenriched %}
   <p class="text-sm font-medium text-gray-600">Unenriched — enriching…</p>
-  <p class="text-xs text-gray-400 mt-1">We know this part, but its specs haven't been filled in yet.</p>
+  <p class="text-secondary mt-1">We know this part, but its specs haven't been filled in yet.</p>
   {% else %}
   <p class="text-sm font-medium text-gray-600">No specs on record.</p>
   {% endif %}

--- a/app/templates/htmx/partials/search/form.html
+++ b/app/templates/htmx/partials/search/form.html
@@ -7,7 +7,7 @@
 
 <div class="max-w-2xl mx-auto space-y-3">
   {# Search form card — deep-links to the dossier. #}
-  <div class="bg-white border border-brand-200 rounded-lg shadow-sm p-3">
+  <div class="bg-white border border-brand-200 rounded-lg shadow-card p-3">
     <form x-data="{ q: '' }"
           @submit.prevent="const v=q.trim(); if(v){ const u='/v2/partials/search?mpn='+encodeURIComponent(v); htmx.ajax('GET', u, {target:'#main-content', indicator:'#ds-landing-spin'}); history.pushState({},'','/v2/search?mpn='+encodeURIComponent(v)); }">
       <div class="flex gap-2">
@@ -23,7 +23,7 @@
           Search
         </button>
       </div>
-      <p class="mt-1 text-xs text-gray-400">Pulls everything we know about the part + the live market across Nexar, BrokerBin, DigiKey, Mouser, eBay, OEMSecrets, and more.</p>
+      <p class="mt-1 text-secondary">Pulls everything we know about the part + the live market across Nexar, BrokerBin, DigiKey, Mouser, eBay, OEMSecrets, and more.</p>
     </form>
   </div>
 
@@ -31,7 +31,7 @@
   <div id="recent-searches"
        hx-get="/v2/partials/search/recent"
        hx-trigger="load" hx-target="this" hx-swap="innerHTML">
-    <div class="bg-white border border-brand-200 rounded-lg shadow-sm p-6 animate-pulse">
+    <div class="bg-white border border-brand-200 rounded-lg shadow-card p-6 animate-pulse">
       <div class="h-3 w-1/3 bg-gray-100 rounded"></div>
       <div class="mt-3 space-y-2">
         <div class="h-3 w-full bg-gray-100 rounded"></div>

--- a/app/templates/htmx/partials/search/full_results.html
+++ b/app/templates/htmx/partials/search/full_results.html
@@ -49,7 +49,7 @@
 
   {% if results.total_count == 0 %}
   {# ── Empty state ── #}
-  <div class="bg-white border border-brand-200 rounded-xl shadow-sm p-6 sm:p-8 text-center">
+  <div class="bg-white border border-brand-200 rounded-xl shadow-card p-6 sm:p-8 text-center">
     <svg class="mx-auto w-16 h-16 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
       <path stroke-linecap="round" stroke-linejoin="round"
             d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"/>
@@ -160,7 +160,7 @@
     {% if items %}
     <div>
       <h3 class="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-2">{{ group_label }}</h3>
-      <div class="bg-white border border-brand-200 rounded-xl shadow-sm overflow-hidden">
+      <div class="bg-white border border-brand-200 rounded-xl shadow-card overflow-hidden">
         <table class="w-full text-sm">
           <tbody class="divide-y divide-gray-100">
             {% for item in items[:10] %}
@@ -175,7 +175,7 @@
                    class="font-medium text-gray-900 hover:text-brand-600">{{ item.name }}</a>
               </td>
               <td class="px-4 py-2.5 text-gray-600">{{ item.customer_name|default("—") }}</td>
-              <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.status|default("") }}</td>
+              <td class="px-4 py-2.5 text-secondary">{{ item.status|default("") }}</td>
 
               {% elif group_key == "companies" %}
               <td class="px-4 py-2.5">
@@ -186,7 +186,7 @@
                    class="font-medium text-gray-900 hover:text-brand-600">{{ item.name }}</a>
               </td>
               <td class="px-4 py-2.5 text-gray-600">{{ item.domain|default("—") }}</td>
-              <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.account_type|default("") }}</td>
+              <td class="px-4 py-2.5 text-secondary">{{ item.account_type|default("") }}</td>
 
               {% elif group_key == "vendors" %}
               <td class="px-4 py-2.5">
@@ -207,7 +207,7 @@
                    class="font-medium text-gray-900 hover:text-brand-600">{{ item.full_name }}</a>
               </td>
               <td class="px-4 py-2.5 text-gray-600">{{ item.email|default("—") }}</td>
-              <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.title|default("") }}</td>
+              <td class="px-4 py-2.5 text-secondary">{{ item.title|default("") }}</td>
 
               {% elif group_key == "site_contacts" %}
               <td class="px-4 py-2.5 font-medium text-gray-900">{{ item.full_name }}</td>
@@ -245,7 +245,7 @@
                    class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.display_mpn }}</a>
               </td>
               <td class="table-cell text-gray-600">{{ item.manufacturer|default("—") }}</td>
-              <td class="table-cell text-gray-400 text-xs truncate max-w-xs">{{ item.description|default("") }}</td>
+              <td class="table-cell text-secondary truncate max-w-xs">{{ item.description|default("") }}</td>
 
               {% elif group_key == "sightings" %}
               <td class="table-cell">
@@ -276,7 +276,7 @@
   {% set items = results.groups.get(group_key, []) %}
   {% if items %}
   <div x-show="tab === '{{ group_key }}'" x-cloak>
-    <div class="bg-white border border-brand-200 rounded-xl shadow-sm overflow-hidden">
+    <div class="bg-white border border-brand-200 rounded-xl shadow-card overflow-hidden">
       <table class="w-full text-sm">
         <thead class="bg-gray-50 border-b border-gray-200">
           <tr>
@@ -329,7 +329,7 @@
                  class="font-medium text-gray-900 hover:text-brand-600">{{ item.name }}</a>
             </td>
             <td class="px-4 py-2.5 text-gray-600">{{ item.customer_name|default("—") }}</td>
-            <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.status|default("") }}</td>
+            <td class="px-4 py-2.5 text-secondary">{{ item.status|default("") }}</td>
 
             {% elif group_key == "companies" %}
             <td class="px-4 py-2.5">
@@ -340,7 +340,7 @@
                  class="font-medium text-gray-900 hover:text-brand-600">{{ item.name }}</a>
             </td>
             <td class="px-4 py-2.5 text-gray-600">{{ item.domain|default("—") }}</td>
-            <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.account_type|default("") }}</td>
+            <td class="px-4 py-2.5 text-secondary">{{ item.account_type|default("") }}</td>
 
             {% elif group_key == "vendors" %}
             <td class="px-4 py-2.5">
@@ -361,7 +361,7 @@
                  class="font-medium text-gray-900 hover:text-brand-600">{{ item.full_name }}</a>
             </td>
             <td class="px-4 py-2.5 text-gray-600">{{ item.email|default("—") }}</td>
-            <td class="px-4 py-2.5 text-gray-400 text-xs">{{ item.title|default("") }}</td>
+            <td class="px-4 py-2.5 text-secondary">{{ item.title|default("") }}</td>
 
             {% elif group_key == "site_contacts" %}
             <td class="px-4 py-2.5 font-medium text-gray-900">{{ item.full_name }}</td>
@@ -399,7 +399,7 @@
                  class="font-medium font-mono text-gray-900 hover:text-brand-600">{{ item.display_mpn }}</a>
             </td>
             <td class="table-cell text-gray-600">{{ item.manufacturer|default("—") }}</td>
-            <td class="table-cell text-gray-400 text-xs truncate max-w-xs">{{ item.description|default("") }}</td>
+            <td class="table-cell text-secondary truncate max-w-xs">{{ item.description|default("") }}</td>
 
             {% elif group_key == "sightings" %}
             <td class="table-cell">

--- a/app/templates/htmx/partials/search/history_panel.html
+++ b/app/templates/htmx/partials/search/history_panel.html
@@ -14,10 +14,10 @@
   {% if fru_hit %}
   {# A crosswalk-known part isn't "new to us" — only its trading history is empty. #}
   <p class="text-sm font-medium text-gray-600">No trading history yet</p>
-  <p class="text-xs text-gray-400 mt-1">We know this part from the FRU crosswalk below.</p>
+  <p class="text-secondary mt-1">We know this part from the FRU crosswalk below.</p>
   {% else %}
   <p class="text-sm font-medium text-gray-600">No prior history</p>
-  <p class="text-xs text-gray-400 mt-1">This part looks new to us.</p>
+  <p class="text-secondary mt-1">This part looks new to us.</p>
   {% endif %}
 </div>
 {% else %}
@@ -129,7 +129,7 @@
      Full matrix lives on the materials surface — the deep link lands on the
      faceted results, which render the fru_section for the same q. #}
 {% if fru_hit %}
-<div class="mt-3 rounded-xl bg-white border border-line-subtle shadow-sm p-4">
+<div class="mt-3 rounded-xl bg-white border border-line-subtle shadow-card p-4">
   <div class="flex items-center justify-between gap-2">
     <p class="text-sm font-semibold text-gray-900">FRU crosswalk</p>
     <a href="/v2/materials?q={{ fru_query | urlencode }}"

--- a/app/templates/htmx/partials/search/lead_detail.html
+++ b/app/templates/htmx/partials/search/lead_detail.html
@@ -89,7 +89,7 @@
         <dd class="font-medium {{ 'text-emerald-700' if s.unit_price else 'text-gray-400' }}">
           {% if s.unit_price %}
             ${{ "%.4f"|format(s.unit_price) if s.unit_price < 1 else "%.2f"|format(s.unit_price) }}
-            {% if s.currency and s.currency != "USD" %}<span class="text-gray-400 text-xs ml-1">{{ s.currency }}</span>{% endif %}
+            {% if s.currency and s.currency != "USD" %}<span class="text-secondary ml-1">{{ s.currency }}</span>{% endif %}
           {% else %}RFQ{% endif %}
         </dd>
       </div>

--- a/app/templates/htmx/partials/search/results_shell.html
+++ b/app/templates/htmx/partials/search/results_shell.html
@@ -16,7 +16,7 @@
     <button type="button"
             hx-get="/v2/partials/search/dossier/market?mpn={{ mpn|urlencode }}&amp;refresh=1"
             hx-target="#dossier-market" hx-swap="innerHTML"
-            class="ml-auto px-2.5 py-1 rounded-md border border-brand-300 text-brand-600 hover:text-brand-800 hover:bg-brand-50 inline-flex items-center gap-1.5">
+            class="ml-auto px-2.5 py-1 rounded-lg border border-brand-300 text-brand-600 hover:text-brand-800 hover:bg-brand-50 inline-flex items-center gap-1.5">
       <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
       Refresh market
     </button>

--- a/app/templates/htmx/partials/search/vendor_card.html
+++ b/app/templates/htmx/partials/search/vendor_card.html
@@ -50,7 +50,7 @@
     {% if card.unit_price %}
     <span class="font-mono text-base font-semibold text-brand-900">${{ "%.4f"|format(card.unit_price) }}</span>
     {% else %}
-    <span class="text-xs text-gray-400">RFQ</span>
+    <span class="text-secondary">RFQ</span>
     {% endif %}
   </div>
 


### PR DESCRIPTION
## What

A **safe design-system conformance pass** over `app/templates/htmx/partials/{requisitions,parts,search}/` — hand-rolled markup swapped for the app's **existing** canonical classes/tokens so the same visual outcome is produced consistently, plus the documented gray-600 contrast floor. **No new classes, colors, spacing, layout, or behavior.** 37 files, 127/127 pure class swaps.

## Rules applied

- **Rule 1 — contrast floor:** `text-xs text-gray-400/500` caption/label/help copy → `.text-secondary` (documented gray-600 floor, size-preserving). 104 swaps. Interactive controls with a `hover:text-*` two-state transition (Cancel/Close/Dismiss buttons, toggle links) were **left as-is** — they're controls, not caption copy, and their muted→emphasized hover is deliberate.
- **Rule 4 — primary CTA color:** the "Confirm" close-reason CTA in `req_row.html` was rendered in `bg-brand-500` (steel) with a bare `rounded` → `btn btn-sm btn-primary` (rests at accent-500).
- **Rule 5 — shadow tiers:** floating dropdowns/menus/tooltips/toasts `shadow-lg` → `shadow-float` (15); resting card containers `shadow-sm` → `shadow-card` (15). Pills, buttons, inputs, `hover:shadow-sm`, and the sticky dossier bar were skipped.
- **Rule 9 — radius tier:** `rounded-md` on inputs/buttons → `rounded-lg` (4 controls).

## Intentionally skipped

- **`requisitions/unified_modal.html`** — excluded entirely (dark-gradient header held for the user + complex Alpine `:class` bindings).
- **Rule 7 legacy `divide-y` tables** (6) — `.data-table` adoption changes the header background gray-50→white and re-flows per-cell utilities; a visual direction change, not a no-op. Deferred to a dedicated table pass.
- **Non-`text-xs` gray text**, badge/chip `rounded-md` (chip family = `rounded` 4px), and filter-pill/segmented-toggle `bg-brand-500` active states (correct per the `filter_pill` pattern) — out of scope for a size-preserving mechanical swap.

## Verification

- `tests/test_static_analysis.py` + render/route suites for these surfaces: **675+ passing** (`test_htmx_views`, `test_htmx_views_deep`, `test_htmx_views_coverage`, `test_part_dossier_router`, `test_faceted_search`/`_routes`, `test_build_quote_*`, `test_offer_qualification_routes`, `test_search_presentation`, `test_htmx_material_card_auto`, …).
- `pre-commit run --files` clean.
- All classes/tokens used already exist in `app/static/styles.css` / `tailwind.config.js` (`shadow-card`/`shadow-float` are safelisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF