### PR TITLE
style(crm/prospecting): design-system conformance pass on Customers/CRM + Prospecting partials

### DIFF
--- a/app/templates/htmx/partials/customers/_account_list.html
+++ b/app/templates/htmx/partials/customers/_account_list.html
@@ -77,7 +77,7 @@
         Assign owner ▾
       </button>
       <div x-show="open" x-cloak @click.outside="open = false"
-           class="absolute left-0 top-full mt-1 z-20 bg-white border border-line-base rounded-lg shadow-lg p-2 w-48">
+           class="absolute left-0 top-full mt-1 z-20 bg-white border border-line-base rounded-lg shadow-float p-2 w-48">
         <form hx-post="/v2/partials/customers/bulk/assign-owner"
               hx-target="#cdm-list" hx-swap="innerHTML"
               hx-include="#cdm-filters"

--- a/app/templates/htmx/partials/customers/_account_task_form.html
+++ b/app/templates/htmx/partials/customers/_account_task_form.html
@@ -14,9 +14,9 @@
          aria-label="Due date">
   <div class="flex gap-2">
     <button type="submit"
-            class="px-3 py-1 text-xs font-medium bg-brand-600 text-white rounded hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500">Save</button>
+            class="btn-primary btn-sm">Save</button>
     <button type="button"
             onclick="document.getElementById('account-task-form-{{ company_id }}').innerHTML = ''"
-            class="px-3 py-1 text-xs font-medium text-gray-600 rounded border border-gray-200 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500">Cancel</button>
+            class="btn-secondary btn-sm">Cancel</button>
   </div>
 </form>

--- a/app/templates/htmx/partials/customers/_account_tasks.html
+++ b/app/templates/htmx/partials/customers/_account_tasks.html
@@ -3,7 +3,7 @@
    Called by: detail.html (inside acct-settings collapsible)
    Depends on: task_service.get_open_tasks_for_company
 #}
-<div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4" id="account-tasks-{{ company_id }}">
+<div class="bg-white rounded-xl shadow-card border border-brand-200 p-4" id="account-tasks-{{ company_id }}">
   <div class="flex items-center justify-between mb-2">
     <h2 class="text-sm font-semibold text-gray-900">Tasks</h2>
     <button type="button"
@@ -71,6 +71,6 @@
       {% endfor %}
     </ul>
   {% else %}
-    <p class="text-xs text-gray-400 italic">No open tasks.</p>
+    <p class="text-secondary italic">No open tasks.</p>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/customers/_add_note_form.html
+++ b/app/templates/htmx/partials/customers/_add_note_form.html
@@ -4,7 +4,7 @@
    Depends on: POST /v2/partials/customers/{company_id}/activity/add-note
 #}
 <div class="bg-white rounded-lg border border-gray-200 p-4 mt-3" id="add-note-form-{{ company_id }}">
-  <h3 class="text-sm font-semibold text-gray-700 mb-2">Add note</h3>
+  <h3 class="h3 mb-2">Add note</h3>
   <form hx-post="/v2/partials/customers/{{ company_id }}/activity/add-note"
         hx-target="#activity-tab-{{ company_id }}"
         hx-swap="outerHTML"

--- a/app/templates/htmx/partials/customers/_contact_macros.html
+++ b/app/templates/htmx/partials/customers/_contact_macros.html
@@ -339,7 +339,7 @@
           </button>
           <div x-show='km' x-cloak
                role='menu'
-               class='absolute right-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-lg z-20 py-1 text-xs text-left'>
+               class='absolute right-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-float z-20 py-1 text-xs text-left'>
             <button @click.stop="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/contacts/{{ contact.id }}/edit-form'}); km=false"
                     role='menuitem'
                     class='w-full text-left px-3 py-1.5 text-brand-600 hover:bg-brand-50'>Edit</button>

--- a/app/templates/htmx/partials/customers/_contact_merge_form.html
+++ b/app/templates/htmx/partials/customers/_contact_merge_form.html
@@ -34,7 +34,7 @@
              hx-swap="innerHTML"
              hx-include="[name='exclude_id']">
       <div id="contact-merge-results"
-           class="absolute z-30 w-full bg-white border border-gray-200 rounded-md shadow-lg mt-1 hidden">
+           class="absolute z-30 w-full bg-white border border-gray-200 rounded-lg shadow-float mt-1 hidden">
       </div>
     </div>
 

--- a/app/templates/htmx/partials/customers/_contact_merge_preview.html
+++ b/app/templates/htmx/partials/customers/_contact_merge_preview.html
@@ -17,7 +17,7 @@
     <p class="text-sm font-semibold text-rose-800">Will be deleted</p>
     <p class="text-base font-bold text-gray-900">{{ remove.full_name }}</p>
     {% if remove.email %}<p class="text-xs text-gray-600">{{ remove.email }}</p>{% endif %}
-    {% if remove.title %}<p class="text-xs text-gray-500">{{ remove.title }}</p>{% endif %}
+    {% if remove.title %}<p class="text-secondary">{{ remove.title }}</p>{% endif %}
   </div>
 
   <div class="rounded-lg border border-emerald-200 bg-emerald-50 p-4 space-y-2">

--- a/app/templates/htmx/partials/customers/_contact_notes_modal.html
+++ b/app/templates/htmx/partials/customers/_contact_notes_modal.html
@@ -27,7 +27,7 @@
     <label for="note-input-{{ contact.id }}" class="sr-only">Add a note</label>
     <textarea id="note-input-{{ contact.id }}" name="notes" rows="3"
               placeholder="Add a note about this contact…"
-              class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"></textarea>
+              class="input"></textarea>
     {% if error %}
     <p class="mt-1 text-xs text-rose-600">{{ error }}</p>
     {% endif %}
@@ -52,7 +52,7 @@
     </div>
     {% endfor %}
     {% else %}
-    <p class="text-xs text-gray-400">No notes yet.</p>
+    <p class="text-secondary">No notes yet.</p>
     {% endif %}
   </div>
 </div>

--- a/app/templates/htmx/partials/customers/_contact_tags.html
+++ b/app/templates/htmx/partials/customers/_contact_tags.html
@@ -35,7 +35,7 @@
     </button>
 
     <div x-show='open' @click.outside='open = false' x-cloak
-         class='absolute left-0 top-6 z-20 w-48 bg-white rounded-lg shadow-lg border border-gray-200 p-2'>
+         class='absolute left-0 top-6 z-20 w-48 bg-white rounded-lg shadow-float border border-gray-200 p-2'>
 
       {# Pick an existing segment tag (exclude already-assigned ones) #}
       {% set assigned_ids = contact_tags | map(attribute='id') | list %}

--- a/app/templates/htmx/partials/customers/_contact_task_form.html
+++ b/app/templates/htmx/partials/customers/_contact_task_form.html
@@ -14,9 +14,9 @@
          aria-label="Due date">
   <div class="flex gap-2">
     <button type="submit"
-            class="px-3 py-1 text-xs font-medium bg-brand-600 text-white rounded hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500">Save</button>
+            class="btn-primary btn-sm">Save</button>
     <button type="button"
             onclick="document.getElementById('contact-task-form-{{ contact_id }}').innerHTML = ''"
-            class="px-3 py-1 text-xs font-medium text-gray-600 rounded border border-gray-200 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500">Cancel</button>
+            class="btn-secondary btn-sm">Cancel</button>
   </div>
 </form>

--- a/app/templates/htmx/partials/customers/_custom_fields.html
+++ b/app/templates/htmx/partials/customers/_custom_fields.html
@@ -50,7 +50,7 @@
     </button>
 
     <div x-show='open' @click.outside='open = false' x-cloak
-         class='absolute left-0 top-7 z-20 w-64 bg-white rounded-lg shadow-lg border border-gray-200 p-3'>
+         class='absolute left-0 top-7 z-20 w-64 bg-white rounded-lg shadow-float border border-gray-200 p-3'>
       <form hx-post='{{ _post_url }}'
             hx-target='#custom-fields-{{ entity }}-{{ obj.id }}'
             hx-swap='outerHTML'
@@ -63,7 +63,7 @@
                class='w-full px-2 py-1 text-xs border border-gray-200 rounded focus:ring-1 focus:ring-brand-500 focus:border-brand-500'
                required maxlength='500'>
         <button type='submit'
-                class='self-end px-3 py-1 text-xs font-medium bg-brand-500 text-white rounded hover:bg-brand-600'>Add</button>
+                class='btn-primary btn-sm self-end'>Add</button>
       </form>
     </div>
   </div>

--- a/app/templates/htmx/partials/customers/_dup_suggestion.html
+++ b/app/templates/htmx/partials/customers/_dup_suggestion.html
@@ -20,7 +20,7 @@
     </div>
     <button type="button"
             title="Merge {{ match.name }} into {{ company.name }}"
-            class="flex-shrink-0 inline-flex items-center gap-1 rounded-md border border-amber-300
+            class="flex-shrink-0 inline-flex items-center gap-1 rounded-lg border border-amber-300
                    bg-white px-2.5 py-1.5 text-xs font-medium text-amber-800 hover:bg-amber-100
                    focus:outline-none focus:ring-2 focus:ring-amber-500"
             hx-get="/v2/partials/customers/{{ company.id }}/merge-form"

--- a/app/templates/htmx/partials/customers/_field_history_list.html
+++ b/app/templates/htmx/partials/customers/_field_history_list.html
@@ -26,5 +26,5 @@
   {% endfor %}
 </div>
 {% else %}
-<p class="text-xs text-gray-400">No field changes recorded yet.</p>
+<p class="text-secondary">No field changes recorded yet.</p>
 {% endif %}

--- a/app/templates/htmx/partials/customers/_form_fields.html
+++ b/app/templates/htmx/partials/customers/_form_fields.html
@@ -16,7 +16,7 @@
 <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Account Owner</label>
         <select name="owner_id"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                class="input">
           <option value="">— None —</option>
           {% for u in users %}
           <option value="{{ u.id }}"{% if with_selection %} {{ 'selected' if selected_id == u.id else '' }}{% endif %}>{{ u.name }} ({{ u.role }})</option>

--- a/app/templates/htmx/partials/customers/_merge_form.html
+++ b/app/templates/htmx/partials/customers/_merge_form.html
@@ -27,8 +27,7 @@
              id="merge-search"
              placeholder="Type to search accounts…"
              autocomplete="off"
-             class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm
-                    focus:ring-brand-500 focus:border-brand-500"
+             class="input"
              hx-get="/v2/partials/customers/typeahead"
              hx-trigger="input changed delay:250ms"
              hx-target="#merge-typeahead-results"
@@ -40,7 +39,7 @@
     <select id="merge-remove-select"
             name="remove_id"
             size="6"
-            class="mt-2 w-full border border-gray-200 rounded-md text-sm text-gray-700
+            class="mt-2 w-full border border-gray-200 rounded-lg text-sm text-gray-700
                    focus:ring-brand-500 focus:border-brand-500 hidden"
             hx-get="/v2/partials/customers/typeahead"
             hx-trigger="none"
@@ -93,8 +92,7 @@
   <div class="flex justify-end">
     <button type="button"
             @click="$dispatch('close-modal')"
-            class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium
-                   text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500">
+            class="btn-secondary">
       Cancel
     </button>
   </div>

--- a/app/templates/htmx/partials/customers/_merge_preview.html
+++ b/app/templates/htmx/partials/customers/_merge_preview.html
@@ -58,15 +58,13 @@
     <input type="hidden" name="confirmed" value="true">
 
     <button type="submit"
-            class="flex-1 rounded-md bg-rose-600 px-4 py-2 text-sm font-semibold text-white
-                   hover:bg-rose-700 focus:outline-none focus:ring-2 focus:ring-rose-500">
+            class="btn-danger flex-1">
       Merge and delete {{ remove.name }}
     </button>
 
     <button type="button"
             @click="$dispatch('close-modal')"
-            class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium
-                   text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500">
+            class="btn-secondary">
       Cancel
     </button>
   </form>

--- a/app/templates/htmx/partials/customers/_name_suggestion.html
+++ b/app/templates/htmx/partials/customers/_name_suggestion.html
@@ -11,8 +11,7 @@
             px-2.5 py-1 text-xs text-brand-700">
   <span>Suggested name: <span class="font-semibold">{{ suggested }}</span></span>
   <button type="button"
-          class="rounded bg-brand-500 px-2 py-0.5 text-[11px] font-medium text-white
-                 hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          class="btn-primary btn-sm"
           hx-post="/v2/partials/customers/{{ company.id }}/apply-name"
           hx-vals='{"name": {{ suggested|tojson }}}'
           hx-target="closest div"

--- a/app/templates/htmx/partials/customers/_saved_views.html
+++ b/app/templates/htmx/partials/customers/_saved_views.html
@@ -37,7 +37,7 @@
     + Save view
   </button>
   <div x-show="saveOpen" x-cloak
-       class="absolute left-0 top-full mt-1 z-30 bg-white border border-line-base rounded-lg shadow-lg p-2 w-56">
+       class="absolute left-0 top-full mt-1 z-30 bg-white border border-line-base rounded-lg shadow-float p-2 w-56">
     <form hx-post="/v2/partials/customers/saved-views"
           hx-target="#saved-views-{{ list_key }}" hx-swap="innerHTML"
           hx-include="#{{ target_form }}"

--- a/app/templates/htmx/partials/customers/_segment_tags.html
+++ b/app/templates/htmx/partials/customers/_segment_tags.html
@@ -36,7 +36,7 @@
     </button>
 
     <div x-show='open' @click.outside='open = false' x-cloak
-         class='absolute left-0 top-6 z-20 w-48 bg-white rounded-lg shadow-lg border border-gray-200 p-2'>
+         class='absolute left-0 top-6 z-20 w-48 bg-white rounded-lg shadow-float border border-gray-200 p-2'>
 
       {# Pick an existing segment tag (exclude already-assigned ones) #}
       {% set assigned_ids = segment_tags | map(attribute='id') | list %}

--- a/app/templates/htmx/partials/customers/archived_list.html
+++ b/app/templates/htmx/partials/customers/archived_list.html
@@ -5,7 +5,7 @@
 #}
 <div class="space-y-1 p-4">
   <div class="flex items-center justify-between mb-3">
-    <h2 class="text-sm font-semibold text-gray-700">Archived Accounts (Do Not Call)</h2>
+    <h2 class="h3">Archived Accounts (Do Not Call)</h2>
     {# Return to the active account list (same #cdm-list panel). #}
     <a href="#" role="button"
        hx-get="/v2/partials/customers/account-list"

--- a/app/templates/htmx/partials/customers/create_form.html
+++ b/app/templates/htmx/partials/customers/create_form.html
@@ -27,20 +27,20 @@
                hx-get="/v2/partials/customers/check-duplicate"
                hx-trigger="keyup changed delay:500ms"
                hx-target="#dup-warning"
-               class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+               class="input">
         <div id="dup-warning" class="mt-1"></div>
       </div>
 
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Website</label>
         <input type="url" name="website" placeholder="https://..."
-               class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+               class="input">
       </div>
 
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Industry</label>
         <select name="industry"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                class="input">
           <option value="">— Select industry —</option>
           {% for val in crm_industries %}
           <option value="{{ val }}">{{ val }}</option>
@@ -54,13 +54,13 @@
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Legal / Registered Name</label>
           <input type="text" name="legal_name" placeholder="Full legal entity name"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                 class="input">
         </div>
         <div class="grid grid-cols-2 gap-3">
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Employee Size</label>
             <select name="employee_size"
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                    class="input">
               <option value="">— Select —</option>
               <option value="1-10">1–10</option>
               <option value="11-50">11–50</option>
@@ -75,7 +75,7 @@
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Revenue Range</label>
             <select name="revenue_range"
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                    class="input">
               <option value="">— Select —</option>
               <option value="&lt;$1M">&lt;$1M</option>
               <option value="$1M-$10M">$1M–$10M</option>
@@ -94,7 +94,7 @@
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Main Phone</label>
           <input type="tel" name="phone" placeholder="+1 555 000 0000"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                 class="input">
         </div>
       </fieldset>
 
@@ -105,18 +105,18 @@
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">City</label>
             <input type="text" name="hq_city" placeholder="e.g. Austin"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                   class="input">
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">State / Region</label>
             <input type="text" name="hq_state" placeholder="e.g. TX"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                   class="input">
           </div>
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Country</label>
           <input type="text" name="hq_country" placeholder="e.g. United States"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                 class="input">
         </div>
       </fieldset>
 
@@ -127,12 +127,12 @@
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Credit Terms</label>
             <input type="text" name="credit_terms" placeholder="e.g. Net 30"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                   class="input">
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Tax ID (EIN / VAT)</label>
             <input type="text" name="tax_id" placeholder="e.g. 12-3456789"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                   class="input">
           </div>
         </div>
       </fieldset>
@@ -143,7 +143,7 @@
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">How was this account acquired?</label>
           <select name="source"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                  class="input">
             <option value="manual" selected>Manual entry</option>
             <option value="sfdc">Salesforce import</option>
             <option value="referral">Referral</option>
@@ -159,14 +159,14 @@
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Notes</label>
         <textarea name="notes" rows="3"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500"></textarea>
+                  class="input"></textarea>
       </div>
 
       <div class="flex justify-end gap-2 pt-1">
         <button type="button" @click='$dispatch("close-modal")'
                 class="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Cancel</button>
         <button type="submit"
-                class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+                class="btn-primary">
           Create account
         </button>
       </div>

--- a/app/templates/htmx/partials/customers/detail.html
+++ b/app/templates/htmx/partials/customers/detail.html
@@ -207,7 +207,7 @@
           </button>
           <div x-show="open" x-cloak
                role="menu"
-               class="absolute right-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-lg z-20 py-1 text-xs text-left">
+               class="absolute right-0 top-full mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-float z-20 py-1 text-xs text-left">
             {# Edit account — opens the full account edit form as a modal. Most fields are
                also inline-editable in the header/settings grid, so the full form is an
                overflow action alongside Merge/Archive. #}
@@ -293,13 +293,13 @@
       </div>
 
       {# ── Segment Tags — inside account-settings collapsible (less weight on other tabs) #}
-      <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4">
+      <div class="bg-white rounded-xl shadow-card border border-brand-200 p-4">
         <h2 class="text-sm font-semibold text-gray-900 mb-2">Segments</h2>
         {% include "htmx/partials/customers/_segment_tags.html" %}
       </div>
 
       {# ── Additional Details — custom key:value fields (WS3) #}
-      <div class="bg-white rounded-xl shadow-sm border border-brand-200 p-4">
+      <div class="bg-white rounded-xl shadow-card border border-brand-200 p-4">
         <h2 class="text-sm font-semibold text-gray-900 mb-2">Additional details</h2>
         {% with entity='company', obj=company, company_id=company.id %}
           {% include "htmx/partials/customers/_custom_fields.html" %}
@@ -307,7 +307,7 @@
       </div>
 
       {# ── Audit trail — created / modified by ─────────────────────── #}
-      <p class="text-xs text-gray-400 mt-1">
+      <p class="text-secondary mt-1">
         Created by <span class="text-gray-600 font-medium">{{ company.created_by.name if company.created_by else '—' }}</span>
         &middot;
         Updated by <span class="text-gray-600 font-medium">{{ company.modified_by.name if company.modified_by else '—' }}</span>

--- a/app/templates/htmx/partials/customers/edit_form.html
+++ b/app/templates/htmx/partials/customers/edit_form.html
@@ -25,33 +25,33 @@
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Company Name *</label>
         <input type="text" name="name" value="{{ company.name or '' }}" required
-               class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+               class="input">
       </div>
 
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Website</label>
         <input type="url" name="website" value="{{ company.website or '' }}"
-               class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+               class="input">
       </div>
 
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Domain</label>
         <input type="text" name="domain" value="{{ company.domain or '' }}"
                placeholder="e.g. acme.com"
-               class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+               class="input">
       </div>
 
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn URL</label>
         <input type="url" name="linkedin_url" value="{{ company.linkedin_url or '' }}"
                placeholder="https://linkedin.com/company/acme"
-               class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+               class="input">
       </div>
 
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Account Type</label>
         <select name="account_type"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                class="input">
           <option value="">— None —</option>
           {% for val in ["Customer", "Prospect", "Partner", "Competitor"] %}
           <option value="{{ val }}"{% if company.account_type == val %} selected{% endif %}>{{ val }}</option>
@@ -62,7 +62,7 @@
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Industry</label>
         <select name="industry"
-                class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                class="input">
           <option value="">— None —</option>
           {# Preserve a legacy / out-of-list current value so saving doesn't drop it. #}
           {% if company.industry and company.industry not in crm_industries %}
@@ -81,13 +81,13 @@
           <label class="block text-sm font-medium text-gray-700 mb-1">Legal / Registered Name</label>
           <input type="text" name="legal_name" value="{{ company.legal_name or '' }}"
                  placeholder="Full legal entity name"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                 class="input">
         </div>
         <div class="grid grid-cols-2 gap-3">
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Employee Size</label>
             <select name="employee_size"
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                    class="input">
               <option value="">— Select —</option>
               {% for opt in ["1-10", "11-50", "51-200", "201-500", "501-1000", "1001-5000", "5001-10000", "10001+"] %}
               <option value="{{ opt }}"{% if company.employee_size == opt %} selected{% endif %}>{{ opt }}</option>
@@ -97,7 +97,7 @@
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Revenue Range</label>
             <select name="revenue_range"
-                    class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                    class="input">
               <option value="">— Select —</option>
               {% for opt in ["<$1M", "$1M-$10M", "$10M-$50M", "$50M-$200M", "$200M-$1B", ">$1B"] %}
               <option value="{{ opt }}"{% if company.revenue_range == opt %} selected{% endif %}>{{ opt }}</option>
@@ -114,7 +114,7 @@
           <label class="block text-sm font-medium text-gray-700 mb-1">Main Phone</label>
           <input type="tel" name="phone" value="{{ company.phone or '' }}"
                  placeholder="+1 555 000 0000"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                 class="input">
         </div>
       </fieldset>
 
@@ -126,20 +126,20 @@
             <label class="block text-sm font-medium text-gray-700 mb-1">City</label>
             <input type="text" name="hq_city" value="{{ company.hq_city or '' }}"
                    placeholder="e.g. Austin"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                   class="input">
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">State / Region</label>
             <input type="text" name="hq_state" value="{{ company.hq_state or '' }}"
                    placeholder="e.g. TX"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                   class="input">
           </div>
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Country</label>
           <input type="text" name="hq_country" value="{{ company.hq_country or '' }}"
                  placeholder="e.g. United States"
-                 class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                 class="input">
         </div>
       </fieldset>
 
@@ -151,13 +151,13 @@
             <label class="block text-sm font-medium text-gray-700 mb-1">Credit Terms</label>
             <input type="text" name="credit_terms" value="{{ company.credit_terms or '' }}"
                    placeholder="e.g. Net 30"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                   class="input">
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700 mb-1">Tax ID (EIN / VAT)</label>
             <input type="text" name="tax_id" value="{{ company.tax_id or '' }}"
                    placeholder="e.g. 12-3456789"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                   class="input">
           </div>
         </div>
       </fieldset>
@@ -169,7 +169,7 @@
           <label class="block text-sm font-medium text-gray-700 mb-1">How was this account acquired?</label>
           {%- set _source_opts = ["manual", "sfdc", "referral", "inbound", "outbound", "enrichment"] -%}
           <select name="source"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                  class="input">
             <option value=""{% if company.source not in _source_opts %} selected{% endif %}>— Keep current ({{ company.source or 'none' }}) —</option>
             {% for val, label in [("manual", "Manual entry"), ("sfdc", "Salesforce import"), ("referral", "Referral"), ("inbound", "Inbound inquiry"), ("outbound", "Outbound prospecting"), ("enrichment", "Enrichment")] %}
             <option value="{{ val }}"{% if company.source == val %} selected{% endif %}>{{ label }}</option>
@@ -186,27 +186,27 @@
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Parent Company</label>
           <select name="parent_company_id"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">
+                  class="input">
             <option value="">— None (top-level account) —</option>
             {% for co in all_companies %}
             <option value="{{ co.id }}"{% if company.parent_company_id == co.id %} selected{% endif %}>{{ co.name }}</option>
             {% endfor %}
           </select>
-          <p class="text-xs text-gray-500 mt-1">Select a parent company to create a hierarchy. Cannot set this company as its own parent.</p>
+          <p class="text-secondary mt-1">Select a parent company to create a hierarchy. Cannot set this company as its own parent.</p>
         </div>
       </fieldset>
 
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">Notes</label>
         <textarea name="notes" rows="3"
-                  class="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500">{{ company.notes or '' }}</textarea>
+                  class="input">{{ company.notes or '' }}</textarea>
       </div>
 
       <div class="flex justify-end gap-2 pt-1">
         <button type="button" @click='$dispatch("close-modal")'
                 class="px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800">Cancel</button>
         <button type="submit"
-                class="px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600">
+                class="btn-primary">
           Save Changes
         </button>
       </div>

--- a/app/templates/htmx/partials/customers/list.html
+++ b/app/templates/htmx/partials/customers/list.html
@@ -168,7 +168,7 @@
         <div class="modal-body space-y-4">
           <div>
             <p class="text-sm font-medium text-gray-700 mb-1">Import Companies</p>
-            <p class="text-xs text-gray-500 mb-2">CSV columns: <code>name</code> (required), <code>website</code>, <code>account_type</code></p>
+            <p class="text-secondary mb-2">CSV columns: <code>name</code> (required), <code>website</code>, <code>account_type</code></p>
             <form hx-post="/v2/partials/customers/import/preview"
                   hx-target="#import-result"
                   hx-swap="innerHTML"
@@ -184,7 +184,7 @@
           </div>
           <div>
             <p class="text-sm font-medium text-gray-700 mb-1">Import Contacts</p>
-            <p class="text-xs text-gray-500 mb-2">CSV columns: <code>company_name</code>, <code>contact_name</code> (required), <code>email</code>, <code>phone</code>, <code>role</code></p>
+            <p class="text-secondary mb-2">CSV columns: <code>company_name</code>, <code>contact_name</code> (required), <code>email</code>, <code>phone</code>, <code>role</code></p>
             <form hx-post="/v2/partials/customers/import/contacts/preview"
                   hx-target="#import-result"
                   hx-swap="innerHTML"

--- a/app/templates/htmx/partials/customers/tabs/_contact_form.html
+++ b/app/templates/htmx/partials/customers/tabs/_contact_form.html
@@ -43,10 +43,10 @@
     {# ── Site selection (add mode only) ─────────────────────────────────── #}
     {% if mode == 'add' %}
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Site <span class='text-rose-500'>*</span></label>
+      <label class='form-label'>Site <span class='text-rose-500'>*</span></label>
       <select name='site_id'
               @change='newSite = ($el.value === "__new__")'
-              class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+              class='input'>
         {% if sites %}
           {# preselect_site_id (from "+ add here") wins; else first HQ / first site. #}
           {% for s in sites %}
@@ -64,71 +64,71 @@
 
     {# New site name — revealed when '+ new site' selected #}
     <div x-show='newSite' x-cloak>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>New Site Name <span class='text-rose-500'>*</span></label>
+      <label class='form-label'>New Site Name <span class='text-rose-500'>*</span></label>
       <input type='text' name='new_site_name' placeholder='e.g. Shanghai Branch'
              :required='newSite'
-             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+             class='input'>
     </div>
     {% endif %}
 
     {# ── Core contact fields ─────────────────────────────────────────────── #}
     <div class='grid grid-cols-2 gap-2'>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>First Name <span class='text-rose-500'>*</span></label>
+        <label class='form-label'>First Name <span class='text-rose-500'>*</span></label>
         <input type='text' name='first_name'
                value='{{ (contact.first_name if contact else "") | e }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Last Name</label>
+        <label class='form-label'>Last Name</label>
         <input type='text' name='last_name'
                value='{{ (contact.last_name if contact else "") | e }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
     </div>
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Title</label>
+      <label class='form-label'>Title</label>
       <input type='text' name='title'
              value='{{ (contact.title if contact else "") | e }}'
-             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+             class='input'>
     </div>
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Email</label>
+      <label class='form-label'>Email</label>
       <input type='email' name='email'
              value='{{ (contact.email if contact else "") | e }}'
-             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+             class='input'>
     </div>
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Phone</label>
+      <label class='form-label'>Phone</label>
       <input type='tel' name='phone'
              value='{{ (contact.phone if contact else "") | e }}'
-             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+             class='input'>
     </div>
 
     <div class='grid grid-cols-2 gap-2'>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Secondary Email</label>
+        <label class='form-label'>Secondary Email</label>
         <input type='email' name='secondary_email' maxlength='255'
                value='{{ (contact.secondary_email if contact else "") | e }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Secondary Phone</label>
+        <label class='form-label'>Secondary Phone</label>
         <input type='tel' name='secondary_phone' maxlength='100'
                value='{{ (contact.secondary_phone if contact else "") | e }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
     </div>
 
     {# ── Reports to (same-company contacts, self excluded in edit mode) ──── #}
     {% if mode == 'edit' and site %}
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Reports To</label>
+      <label class='form-label'>Reports To</label>
       <select name='reports_to_id'
-              class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+              class='input'>
         <option value=''>— none —</option>
         {% if site_contacts_for_select is defined %}
         {% for sc in site_contacts_for_select %}
@@ -143,15 +143,15 @@
     {% endif %}
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>WeChat ID</label>
+      <label class='form-label'>WeChat ID</label>
       <input type='text' name='wechat_id' maxlength='100'
              value='{{ (contact.wechat_id if contact else "") | e }}'
-             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+             class='input'>
     </div>
 
     {# ── Role select — CANONICAL_ROLES is the single source ──────────────── #}
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Role</label>
+      <label class='form-label'>Role</label>
       {% set role_labels = {
         'specifier':  'Specifier',
         'buyer_po':   'Buyer / PO',
@@ -161,7 +161,7 @@
         'other':      'Other',
       } %}
       <select name='contact_role'
-              class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+              class='input'>
         <option value=''>— clear —</option>
         {% for r in roles %}
         <option value='{{ r }}'
@@ -184,25 +184,25 @@
 
     {# ── LinkedIn URL ─────────────────────────────────────────────────────── #}
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>LinkedIn URL</label>
+      <label class='form-label'>LinkedIn URL</label>
       <input type='url' name='linkedin_url' maxlength='500'
              value='{{ (contact.linkedin_url if contact else "") | e }}'
              placeholder='https://linkedin.com/in/…'
-             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>
+             class='input'>
     </div>
 
     {# ── Notes ────────────────────────────────────────────────────────────── #}
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Notes</label>
+      <label class='form-label'>Notes</label>
       <textarea name='notes' rows='2'
-                class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500'>{{ (contact.notes if contact else "") | e }}</textarea>
+                class='input'>{{ (contact.notes if contact else "") | e }}</textarea>
     </div>
 
     <div class='flex justify-end gap-2 pt-1'>
       <button type='button' @click='$dispatch("close-modal")'
               class='px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800'>Cancel</button>
       <button type='submit'
-              class='px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600'>
+              class='btn-primary'>
         {% if mode == 'add' %}Add Contact{% else %}Save Changes{% endif %}
       </button>
     </div>

--- a/app/templates/htmx/partials/customers/tabs/_contacts_grouped_list.html
+++ b/app/templates/htmx/partials/customers/tabs/_contacts_grouped_list.html
@@ -56,7 +56,7 @@
           {{ site_cadence_dot(grp_site, now_utc) }}
           <span class="text-xs font-semibold text-gray-700 truncate">{{ grp_site.site_name if grp_site else "Unknown site" }}</span>
           {% if grp_site and grp_site.city %}
-          <span class="text-xs text-gray-400 truncate">· {{ grp_site.city }}</span>
+          <span class="text-secondary truncate">· {{ grp_site.city }}</span>
           {% endif %}
           {%- set grp_active_count = grp_rows | rejectattr('contact.is_archived', 'equalto', True) | list | length -%}
           <span class="text-gray-300 text-[11px]">·</span>

--- a/app/templates/htmx/partials/customers/tabs/activity_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/activity_tab.html
@@ -51,7 +51,7 @@
       <path stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'/>
     </svg>
     <p class='text-sm text-gray-600'>No activity recorded for this company yet.</p>
-    <p class='text-xs text-gray-400 mt-1'>Activity will appear here as you log calls, emails, notes, and meetings.</p>
+    <p class='text-secondary mt-1'>Activity will appear here as you log calls, emails, notes, and meetings.</p>
   </div>
   {% endif %}
 
@@ -71,7 +71,7 @@
            @click='hideOther = !hideOther'>
         <div class='flex items-center gap-2'>
           {{ activity_icon(icon_type) }}
-          <h3 class='text-sm font-semibold text-gray-700'>{{ section_label }}</h3>
+          <h3 class='h3'>{{ section_label }}</h3>
           <span class='inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600'>{{ section_items|length }}</span>
         </div>
         <div class='flex items-center gap-2'>
@@ -109,7 +109,7 @@
       {# ── Section header ───────────────────────────────── #}
       <div class='px-4 py-2.5 bg-gray-50 border-b flex items-center gap-2'>
         {{ activity_icon(icon_type) }}
-        <h3 class='text-sm font-semibold text-gray-700'>{{ section_label }}</h3>
+        <h3 class='h3'>{{ section_label }}</h3>
         <span class='inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600'>{{ section_items|length }}</span>
       </div>
       {# ── Section body (date-grouped, mixed for Emails) ── #}
@@ -152,7 +152,7 @@
                     Out
                   </span>
                 </div>
-                {% if c.subject %}<p class='text-xs text-gray-400 truncate mt-0.5'>{{ c.subject }}</p>{% endif %}
+                {% if c.subject %}<p class='text-secondary truncate mt-0.5'>{{ c.subject }}</p>{% endif %}
               </div>
               <div class='text-right flex-shrink-0 flex flex-col items-end gap-1'>
                 {% if rfq_req %}
@@ -180,7 +180,7 @@
     {# ── Truncation footer ─────────────────────────────── #}
     {% if activities_truncated %}
     <div class='px-4 py-2 bg-gray-50 border border-gray-200 rounded-lg mt-3'>
-      <p class='text-xs text-gray-400'>Showing most recent 50 activities — older history may not appear.</p>
+      <p class='text-secondary'>Showing most recent 50 activities — older history may not appear.</p>
     </div>
     {% endif %}
 

--- a/app/templates/htmx/partials/customers/tabs/buy_plans_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/buy_plans_tab.html
@@ -62,7 +62,7 @@
             d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
     </svg>
     <p class="text-sm font-medium text-gray-600 mt-3">No buy plans for this account.</p>
-    <p class="text-xs text-gray-400 mt-1">Buy plans are created after a quote is won and a sales order is received.</p>
+    <p class="text-secondary mt-1">Buy plans are created after a quote is won and a sales order is received.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/customers/tabs/contacts_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/contacts_tab.html
@@ -68,12 +68,12 @@
                 hx-target='#suggested-contacts-panel'
                 hx-swap='innerHTML'
                 hx-indicator='#suggested-contacts-spinner'
-                class='px-3 py-1.5 text-xs font-medium text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500'>
+                class='btn-secondary btn-sm'>
           Find contacts
         </button>
         {% endif %}
         <button @click="$dispatch('open-modal', {url: '/v2/partials/customers/{{ company.id }}/contacts/add-form'})"
-                class="px-3 py-1.5 text-xs font-medium text-white bg-brand-500 rounded-lg hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-500">
+                class="btn-primary btn-sm">
           + Add Contact
         </button>
       </div>
@@ -85,7 +85,7 @@
   </div>
 
   {# ── Suggested contacts panel (hidden until "Find contacts" clicked) ─────── #}
-  <div id="suggested-contacts-spinner" class="htmx-indicator mt-2 text-xs text-gray-400 py-2">Finding contacts…</div>
+  <div id="suggested-contacts-spinner" class="htmx-indicator mt-2 text-secondary py-2">Finding contacts…</div>
   <div id="suggested-contacts-panel" class="mt-2"></div>
 
   {# ── Grouped list wrapped in stable swap target ──────────────────────────── #}

--- a/app/templates/htmx/partials/customers/tabs/history_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/history_tab.html
@@ -13,7 +13,7 @@
       <svg class="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
       </svg>
-      <h3 class="text-sm font-semibold text-gray-700">Field changes</h3>
+      <h3 class="h3">Field changes</h3>
       {% if history %}
       <span class="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600">{{ history|length }}</span>
       {% endif %}

--- a/app/templates/htmx/partials/customers/tabs/quotes_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/quotes_tab.html
@@ -72,7 +72,7 @@
             d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
     </svg>
     <p class="text-sm font-medium text-gray-600 mt-3">No quotes for this account.</p>
-    <p class="text-xs text-gray-400 mt-1">Quotes are created from a requirement's Offers tab.</p>
+    <p class="text-secondary mt-1">Quotes are created from a requirement's Offers tab.</p>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/customers/tabs/site_edit_modal.html
+++ b/app/templates/htmx/partials/customers/tabs/site_edit_modal.html
@@ -15,15 +15,15 @@
         class='space-y-3'>
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Site Name <span class="text-rose-500">*</span></label>
+      <label class='form-label'>Site Name <span class="text-rose-500">*</span></label>
       <input type='text' name='site_name' required value='{{ site.site_name or "" }}'
-             class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+             class='input'>
     </div>
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Site Type</label>
+      <label class='form-label'>Site Type</label>
       <select name='site_type'
-              class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+              class='input'>
         <option value=''>—</option>
         <option value='hq' {% if site.site_type == 'hq' %}selected{% endif %}>HQ</option>
         <option value='branch' {% if site.site_type == 'branch' %}selected{% endif %}>Branch</option>
@@ -35,62 +35,62 @@
 
     <div class='grid grid-cols-2 gap-2'>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Address Line 1</label>
+        <label class='form-label'>Address Line 1</label>
         <input type='text' name='address_line1' value='{{ site.address_line1 or "" }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Address Line 2</label>
+        <label class='form-label'>Address Line 2</label>
         <input type='text' name='address_line2' value='{{ site.address_line2 or "" }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
     </div>
 
     <div class='grid grid-cols-2 gap-2'>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>City</label>
+        <label class='form-label'>City</label>
         <input type='text' name='city' value='{{ site.city or "" }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>State</label>
+        <label class='form-label'>State</label>
         <input type='text' name='state' value='{{ site.state or "" }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
     </div>
 
     <div class='grid grid-cols-2 gap-2'>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>ZIP</label>
+        <label class='form-label'>ZIP</label>
         <input type='text' name='zip' value='{{ site.zip or "" }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Country</label>
+        <label class='form-label'>Country</label>
         <input type='text' name='country' value='{{ site.country or "" }}'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
     </div>
 
     <div class='grid grid-cols-2 gap-2'>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Payment Terms</label>
+        <label class='form-label'>Payment Terms</label>
         <input type='text' name='payment_terms' value='{{ site.payment_terms or "" }}'
                placeholder='e.g. Net30'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
       <div>
-        <label class='block text-xs font-medium text-gray-700 mb-1'>Shipping Terms</label>
+        <label class='form-label'>Shipping Terms</label>
         <input type='text' name='shipping_terms' value='{{ site.shipping_terms or "" }}'
                placeholder='e.g. FCA'
-               class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+               class='input'>
       </div>
     </div>
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Site Owner</label>
+      <label class='form-label'>Site Owner</label>
       <select name='owner_id'
-              class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>
+              class='input'>
         <option value=''>— None —</option>
         {% for u in users %}
         <option value='{{ u.id }}'{% if site.owner_id == u.id %} selected{% endif %}>{{ u.name }} ({{ u.role }})</option>
@@ -99,16 +99,16 @@
     </div>
 
     <div>
-      <label class='block text-xs font-medium text-gray-700 mb-1'>Notes</label>
+      <label class='form-label'>Notes</label>
       <textarea name='notes' rows='2'
-                class='w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 focus:border-brand-500'>{{ site.notes or "" }}</textarea>
+                class='input'>{{ site.notes or "" }}</textarea>
     </div>
 
     <div class='flex justify-end gap-2 pt-1'>
       <button type='button' @click='$dispatch("close-modal")'
               class='px-3 py-1.5 text-sm text-gray-600 hover:text-gray-800'>Cancel</button>
       <button type='submit'
-              class='px-4 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600'>
+              class='btn-primary'>
         Save Changes
       </button>
     </div>

--- a/app/templates/htmx/partials/customers/tabs/sites_tab.html
+++ b/app/templates/htmx/partials/customers/tabs/sites_tab.html
@@ -53,7 +53,7 @@
         {% endfor %}
       </select>
       <button type="submit"
-              class="px-3 py-1.5 text-sm font-medium text-white bg-brand-500 rounded hover:bg-brand-600 col-span-2">
+              class="btn-primary col-span-2">
         Add Site
       </button>
     </form>
@@ -71,7 +71,7 @@
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
       </svg>
       <p class="text-sm text-gray-600 mb-1">No sites yet.</p>
-      <p class="text-xs text-gray-400">Use "+ Add Site" above to add a location for this account.</p>
+      <p class="text-secondary">Use "+ Add Site" above to add a location for this account.</p>
     </div>
     {% endif %}
   </div>

--- a/app/templates/htmx/partials/prospecting/_card.html
+++ b/app/templates/htmx/partials/prospecting/_card.html
@@ -28,7 +28,7 @@
       <div class="min-w-0">
         <h3 class="text-sm font-bold text-gray-900 truncate">{{ prospect.name }}</h3>
         {% if prospect.domain %}
-        <p class="text-xs text-gray-500 truncate">{{ prospect.domain }}</p>
+        <p class="text-secondary truncate">{{ prospect.domain }}</p>
         {% endif %}
       </div>
       <div class="shrink-0 ml-2 flex flex-col items-end gap-1">
@@ -167,7 +167,7 @@
   </div>
   {% elif prospect.status == 'dismissed' %}
   <div class="mt-3 pt-3 border-t border-line-subtle">
-    <span class="text-xs text-gray-400">Dismissed {{ prospect.dismissed_at.strftime('%b %d') if prospect.dismissed_at else '' }}</span>
+    <span class="text-secondary">Dismissed {{ prospect.dismissed_at.strftime('%b %d') if prospect.dismissed_at else '' }}</span>
   </div>
   {% endif %}
 </div>

--- a/app/templates/htmx/partials/prospecting/detail.html
+++ b/app/templates/htmx/partials/prospecting/detail.html
@@ -13,7 +13,7 @@
   <div class="card p-6 mb-6">
     <div class="flex items-start justify-between">
       <div>
-        <h1 class="text-2xl font-bold text-gray-900">{{ prospect.name }}</h1>
+        <h1 class="h1">{{ prospect.name }}</h1>
         {% if prospect.domain %}
         <a href="https://{{ prospect.domain }}" target="_blank" rel="noopener"
            class="text-sm text-brand-500 hover:text-brand-600 hover:underline">{{ prospect.domain }} &nearr;</a>
@@ -177,7 +177,7 @@
         {% endfor %}
       </div>
       {% else %}
-      <p class="mt-3 text-xs text-gray-400">No active buying signals yet.</p>
+      <p class="mt-3 text-secondary">No active buying signals yet.</p>
       {% endif %}
     </div>
   </div>
@@ -189,7 +189,7 @@
   {% set ai_screen = enrichment.get('ai_screen', {}) %}
   {% if ai_screen and ai_screen.get('verdict') %}
   <div class="card p-5 mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+    <h2 class="h2 mb-4 flex items-center gap-2">
       AI Screening
       {% set verdict = ai_screen.get('verdict', '') %}
       <span class="badge
@@ -235,7 +235,7 @@
     {% endif %}
 
     {# Meta: confidence + model + screened_at #}
-    <p class="text-xs text-gray-400">
+    <p class="text-secondary">
       Confidence {{ ai_screen.get('confidence', '?') }}%
       &middot; {{ ai_screen.get('model', '') }}
       {% if ai_screen.get('screened_at') %}&middot; {{ ai_screen.screened_at[:10] }}{% endif %}
@@ -246,7 +246,7 @@
   {# Contacts #}
   {% if contacts %}
   <div class="card p-5 mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-3">
+    <h2 class="h2 mb-3">
       Contacts
       <span class="text-sm font-normal text-gray-400">
         {{ contact_stats.total }} total · {{ contact_stats.verified }} verified · {{ contact_stats.decision_makers }} decision-maker{{ "s" if contact_stats.decision_makers != 1 }}
@@ -258,7 +258,7 @@
         <div class="min-w-0">
           <p class="text-sm font-medium text-gray-900 truncate">{{ c.get('name', 'Unknown') }}</p>
           {% if c.get('title') %}<p class="text-xs text-gray-600 truncate">{{ c.title }}</p>{% endif %}
-          {% if c.get('email') %}<p class="text-xs text-gray-500 truncate">{{ c.email }}</p>{% endif %}
+          {% if c.get('email') %}<p class="text-secondary truncate">{{ c.email }}</p>{% endif %}
         </div>
         <div class="shrink-0 flex items-center gap-1.5">
           {% if c.get('seniority') == 'decision_maker' %}
@@ -282,7 +282,7 @@
   {# Similar customers / prior wins #}
   {% if similar_customers %}
   <div class="card p-5 mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-3">Similar wins</h2>
+    <h2 class="h2 mb-3">Similar wins</h2>
     <div class="flex flex-wrap gap-2">
       {% for s in similar_customers %}
       <span class="chip bg-brand-50 text-brand-600 border-brand-100">
@@ -307,11 +307,11 @@
   {# Enrichment data #}
   {% if enrichment %}
   <div class="card bg-brand-50 p-5 mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Enrichment Data</h2>
+    <h2 class="h2 mb-4">Enrichment Data</h2>
 
     {% if enrichment.get('sam_gov') %}
     <div class="mb-4">
-      <h3 class="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-1.5">
+      <h3 class="h3 mb-2 flex items-center gap-1.5">
         <svg class="w-4 h-4 text-brand-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
         </svg>
@@ -327,7 +327,7 @@
 
     {% if enrichment.get('recent_news') %}
     <div class="mb-4">
-      <h3 class="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-1.5">
+      <h3 class="h3 mb-2 flex items-center gap-1.5">
         <svg class="w-4 h-4 text-brand-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"/>
         </svg>
@@ -352,7 +352,7 @@
     {# Signals #}
     {% if enrichment.get('signals') %}
     <div class="mb-4">
-      <h3 class="text-sm font-semibold text-gray-700 mb-2">Signals</h3>
+      <h3 class="h3 mb-2">Signals</h3>
       <div class="flex flex-wrap gap-2">
         {% for signal in enrichment.signals %}
         <span class="chip bg-amber-50 text-amber-700 border-amber-200">
@@ -369,7 +369,7 @@
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
     </svg>
     <p class="text-sm text-gray-600">No enrichment data yet.</p>
-    <p class="text-xs text-gray-400 mt-1">Click "Enrich" above to gather free data from SAM.gov and news sources.</p>
+    <p class="text-secondary mt-1">Click "Enrich" above to gather free data from SAM.gov and news sources.</p>
   </div>
   {% endif %}
 
@@ -406,7 +406,7 @@
   {# Description / AI writeup #}
   {% if prospect.ai_writeup or prospect.description %}
   <div class="card p-5 mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-2">About</h2>
+    <h2 class="h2 mb-2">About</h2>
     <p class="text-sm text-gray-600 leading-relaxed">{{ prospect.ai_writeup or prospect.description }}</p>
   </div>
   {% endif %}
@@ -414,29 +414,29 @@
   {# Additional details grid #}
   {% if prospect.employee_count_range or prospect.revenue_range or prospect.hq_location or prospect.naics_code %}
   <div class="card p-5 mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-3">Company Details</h2>
+    <h2 class="h2 mb-3">Company Details</h2>
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
       {% if prospect.employee_count_range %}
       <div>
-        <dt class="text-xs text-gray-400 font-medium">Employees</dt>
+        <dt class="text-secondary font-medium">Employees</dt>
         <dd class="text-sm text-gray-900 mt-0.5">{{ prospect.employee_count_range }}</dd>
       </div>
       {% endif %}
       {% if prospect.revenue_range %}
       <div>
-        <dt class="text-xs text-gray-400 font-medium">Revenue</dt>
+        <dt class="text-secondary font-medium">Revenue</dt>
         <dd class="text-sm text-gray-900 mt-0.5">{{ prospect.revenue_range }}</dd>
       </div>
       {% endif %}
       {% if prospect.hq_location %}
       <div>
-        <dt class="text-xs text-gray-400 font-medium">HQ Location</dt>
+        <dt class="text-secondary font-medium">HQ Location</dt>
         <dd class="text-sm text-gray-900 mt-0.5">{{ prospect.hq_location }}</dd>
       </div>
       {% endif %}
       {% if prospect.naics_code %}
       <div>
-        <dt class="text-xs text-gray-400 font-medium">NAICS Code</dt>
+        <dt class="text-secondary font-medium">NAICS Code</dt>
         <dd class="text-sm font-mono text-gray-900 mt-0.5">{{ prospect.naics_code }}</dd>
       </div>
       {% endif %}

--- a/app/templates/htmx/partials/prospecting/list.html
+++ b/app/templates/htmx/partials/prospecting/list.html
@@ -14,7 +14,7 @@
   <div class="flex items-center justify-between mb-3">
     <div>
       <h1 class="text-xl font-bold text-gray-900">Prospecting</h1>
-      <p class="text-xs text-gray-500 mt-0.5">Suggested accounts ranked by fit + buying signals</p>
+      <p class="text-secondary mt-0.5">Suggested accounts ranked by fit + buying signals</p>
     </div>
     {# Add-prospect control #}
     <div x-data="{ open: false }" class="relative">
@@ -24,7 +24,7 @@
         Add prospect
       </button>
       <div x-show="open" x-cloak @click.outside="open = false" x-transition
-           class="absolute right-0 mt-2 w-72 bg-white border border-line-base rounded-lg shadow-lg p-3 z-20">
+           class="absolute right-0 mt-2 w-72 bg-white border border-line-base rounded-lg shadow-float p-3 z-20">
         <form hx-post="/v2/partials/prospecting/add-domain"
               hx-target="#add-prospect-result"
               hx-swap="innerHTML"
@@ -119,9 +119,9 @@
     </svg>
     <p class="mt-2 text-sm text-gray-600">No prospects found</p>
     {% if q or status %}
-    <p class="text-xs text-gray-400 mt-1">Try clearing the filter or searching for something else.</p>
+    <p class="text-secondary mt-1">Try clearing the filter or searching for something else.</p>
     {% else %}
-    <p class="text-xs text-gray-400 mt-1">Add a company domain to start prospecting.</p>
+    <p class="text-secondary mt-1">Add a company domain to start prospecting.</p>
     {% endif %}
   </div>
   {% endif %}
@@ -188,7 +188,7 @@
           hx-target="#prospect-{{ p.id }}"
           hx-swap="outerHTML"
           data-loading-disable
-          class="shrink-0 px-2 py-1 text-xs font-medium text-amber-700 border border-amber-300 rounded hover:bg-amber-100 transition-colors">
+          class="shrink-0 px-2 py-1 text-xs font-medium text-amber-700 border border-amber-300 rounded-lg hover:bg-amber-100 transition-colors">
           Claim anyway
         </button>
       </div>

--- a/app/templates/htmx/partials/prospecting/reassign_modal.html
+++ b/app/templates/htmx/partials/prospecting/reassign_modal.html
@@ -11,7 +11,7 @@
 {% set swap = 'innerHTML' if ctx == 'detail' else 'outerHTML' %}
 <div class="p-4">
   <h3 id="modal-title" class="text-sm font-semibold text-gray-900 mb-1">Reassign account</h3>
-  <p class="text-xs text-gray-500 mb-3">
+  <p class="text-secondary mb-3">
     Hand <strong>{{ prospect.name }}</strong> to another rep. This bypasses the 30-day
     reclaim cooldown and removes the account from the prospecting pool.
   </p>


### PR DESCRIPTION
## What

A **safe, mechanical design-system conformance pass** over the Customers/CRM and Prospecting template surfaces — replacing hand-rolled markup with the app's **existing** canonical classes/macros (`app/static/styles.css`, `htmx/partials/shared/_macros.html`). No redesign, no rearranged features, no new classes/colors/spacing, no behavior change.

Dirs touched (only): `app/templates/htmx/partials/customers/` and `app/templates/htmx/partials/prospecting/` (37 files).

## Conversions applied

- **Inputs (rule 6):** hand-rolled `w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-brand-500 ...` → `.input` (company create/edit forms, contact form, site-edit modal, merge form, notes modal, owner-select macro).
- **Labels (rule 2):** verbatim `block text-xs font-medium text-gray-700 mb-1` → `.form-label`.
- **Headings (rule 3):** section/detail/heading recipes matching `.h1`/`.h2`/`.h3` exactly → the class (prospecting detail section titles, CRM history/activity/note headers).
- **Buttons (rule 4):** primary CTAs rendered in `bg-brand-500/600` (Save / Add / Create / Apply / Add Contact / Add Site / Reclaim / Claim) → `.btn-primary` (+ `.btn-sm`); neutral outline Cancel/Find/Dismiss → `.btn-secondary`; destructive merge → `.btn-danger`; bare `rounded` on buttons → `rounded-lg`.
- **Shadows (rule 5):** resting card `shadow-sm` → `shadow-card`; floating dropdown/popover `shadow-lg` → `shadow-float`.
- **Contrast floor (rule 1):** `text-gray-400/500` on real reader-facing caption/label/empty-state/help copy → `.text-secondary` (gray-600 floor). Icon strokes, disabled states, and inline metadata left untouched.
- **Radius (rule 9):** stray `rounded-md` on controls/dropdowns → `rounded-lg`.

## Intentionally skipped (noted, not guessed)

- **Row-clickable data tables** (quotes / buy-plans / contacts lists, rule 7): a `.data-table` swap would darken their intentional `gray-600` secondary cells (the `.data-table td` color rule overrides the utilities) — that's a visible change, not a no-op, so left as-is.
- Hand-rolled empty states with **custom icons + multi-line copy** (rule 8): converting to the shared `empty_state.html` partial would drop the bespoke icon/second line — a taste change; only the sub-caption contrast was floored.
- Tertiary `text-[11px]` timestamps / brand-outline toggle buttons: converting would shift size or hue.

## Verification

- `tests/test_static_analysis.py`, `test_template_ui_integrity`, `test_template_env`, `test_template_attr_quoting_fixes`, `test_crm_macros` — 85 passed.
- CRM render/route suite (`test_crm_views`, `test_routers_crm`, `test_crm_account_crud_buttons`, `test_contacts_tab_quotes`, `test_contact_outreach_buttons`, `test_account_contact_tasks`, `test_company_merge_service`, `test_contact_merge_move`, `test_crm_p5_trust`, `test_crm_p4_power_ux`, `test_sprint4_company_crud`, `test_edit_company_*`, `test_crm_bulk_import`) — 651 passed.
- Prospecting suite (`test_prospecting`, `test_prospecting_tab`, `test_integration_prospecting`, `test_prospect_claim`, `test_prospecting_reclaim_ui`, `test_prospecting_accounts`, `test_prospect_free_enrichment`, `test_prospect_screening`, `test_prospecting_stats_target_regression`) — 219 passed.
- `pre-commit run --files` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmzDZ9rkaijWeU7yTBNGnF